### PR TITLE
chore(release): 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-04-12
+
+### Added
+
+- **exploration:** Add pre-scan codebase exploration for grounded reviews ([#36](https://github.com/existential-birds/daydream/pull/36))
+
+  Before invoking the review skill, daydream now runs a tiered exploration phase that analyzes the diff, traces dependencies, scans for project conventions, and maps test coverage. The exploration context is injected into the review prompt so findings are grounded in actual codebase structure rather than the diff alone. Trivial diffs skip exploration automatically; multi-file diffs fan out to parallel specialist subagents.
+
+### Security
+
+- **deps:** Update cryptography from 46.0.5 to 46.0.7 ([#34](https://github.com/existential-birds/daydream/pull/34), [#35](https://github.com/existential-birds/daydream/pull/35))
+
 ## [0.10.0] - 2026-03-14
 
 ### Added
@@ -231,7 +243,8 @@ Initial release of Daydream - an automated code review and fix loop using the Cl
 - `rich` - Terminal UI components
 - `pyfiglet` - ASCII art header generation
 
-[unreleased]: https://github.com/existential-birds/daydream/compare/v0.10.0...HEAD
+[unreleased]: https://github.com/existential-birds/daydream/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/existential-birds/daydream/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/existential-birds/daydream/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/existential-birds/daydream/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/existential-birds/daydream/compare/v0.7.0...v0.8.0

--- a/daydream/__init__.py
+++ b/daydream/__init__.py
@@ -17,4 +17,4 @@ Submodules:
     ui: User interface utilities for terminal output.
 """
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "daydream"
-version = "0.10.0"
+version = "0.11.0"
 description = "Automated code review and fix loop using Claude"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary

- Bump version to 0.11.0
- Update CHANGELOG.md with changes since v0.10.0

## Post-merge steps

After merging, run:
```
/release-tag 0.11.0
```

---

Generated with [Claude Code](https://claude.com/claude-code)