### PR TITLE
chore(release): 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-04-17
+
+### Added
+
+- **cli:** Add repeatable `--ignore-path PATH` flag to exclude directories from review ([#42](https://github.com/existential-birds/daydream/pull/42))
+
+  Injects git `:(exclude)` pathspecs into diff collection and instructs review-phase agents to apply the same filter. Useful for excluding `.planning/`, `vendor/`, or generated directories in monorepos so diff noise doesn't drown out real review signal.
+
+### Fixed
+
+- **exploration:** Stop embedding full diff text in specialist subagent prompts ([#42](https://github.com/existential-birds/daydream/pull/42))
+
+  Pattern-scanner, dependency-tracer, and test-mapper subagents now receive affected file paths plus a diff ref and fetch per-file diffs on demand via their existing tools. Fixes "Prompt is too long" failures on monorepo-sized diffs (15k+ lines) by dropping token cost from O(total_diff) to O(per-file lookups).
+- **agent:** Correct `detect_test_success()` false negatives on clean-pass outputs ([#42](https://github.com/existential-birds/daydream/pull/42))
+
+  The matcher now extracts structured counts first and falls through to sentinel phrases, handling cases the previous regex missed: "N tests passed" / "0 tests failed" on separate lines, the word "tests" appearing between the count and "failed", and Cargo's native `test result: ok. N passed; 0 failed;` summary. Stops the heal loop from retrying already-passing test runs.
+
+### Security
+
+- **deps:** Bump pyjwt 2.11.0 → 2.12.1 for CVE fix (accepts unknown `crit` header extensions — high) ([#42](https://github.com/existential-birds/daydream/pull/42))
+- **deps:** Bump python-multipart 0.0.22 → 0.0.26 for DoS-via-large-preamble CVE fix ([#41](https://github.com/existential-birds/daydream/pull/41), [#42](https://github.com/existential-birds/daydream/pull/42))
+- **deps:** Bump pygments 2.19.2 → 2.20.0 for ReDoS CVE in GUID regex ([#42](https://github.com/existential-birds/daydream/pull/42))
+
 ## [0.11.1] - 2026-04-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,7 +274,8 @@ Initial release of Daydream - an automated code review and fix loop using the Cl
 - `rich` - Terminal UI components
 - `pyfiglet` - ASCII art header generation
 
-[unreleased]: https://github.com/existential-birds/daydream/compare/v0.11.1...HEAD
+[unreleased]: https://github.com/existential-birds/daydream/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/existential-birds/daydream/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/existential-birds/daydream/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/existential-birds/daydream/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/existential-birds/daydream/compare/v0.9.0...v0.10.0

--- a/daydream/__init__.py
+++ b/daydream/__init__.py
@@ -17,4 +17,4 @@ Submodules:
     ui: User interface utilities for terminal output.
 """
 
-__version__ = "0.11.1"
+__version__ = "0.12.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "daydream"
-version = "0.11.1"
+version = "0.12.0"
 description = "Automated code review and fix loop using Claude"
 requires-python = ">=3.12"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -192,7 +192,7 @@ wheels = [
 
 [[package]]
 name = "daydream"
-version = "0.11.1"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

- Bump version to 0.12.0
- Update CHANGELOG.md with changes since v0.11.1

## Highlights

- **Added:** `--ignore-path` CLI flag (repeatable) for excluding directories from review (#42)
- **Fixed:** Exploration subagents no longer hit context limits on monorepo-sized diffs (#42)
- **Fixed:** `detect_test_success()` false negatives on clean-pass outputs (#42)
- **Security:** Transitive CVE bumps for pyjwt, python-multipart, pygments (#41, #42)

## Post-merge steps

After merging, run:
```
/release-tag 0.12.0
```

---

Generated with [Claude Code](https://claude.com/claude-code)