### PR TITLE
feat(deep): multi-stack deep review mode with inline PR comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ cd daydream
 uv sync
 ```
 
+## Updating
+
+```bash
+cd daydream
+git pull
+uv sync
+```
+
 ## Usage
 
 ```bash

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -69,8 +69,11 @@ def _auto_detect_pr_number() -> int | None:
     return None
 
 
-def _parse_args() -> RunConfig:
+def _parse_args(argv: list[str] | None = None) -> RunConfig:
     """Parse command line arguments and return a RunConfig.
+
+    Args:
+        argv: Optional list of arguments. Defaults to ``sys.argv[1:]`` when None.
 
     Returns:
         RunConfig: Configuration object populated from command line arguments.
@@ -170,10 +173,14 @@ def _parse_args() -> RunConfig:
 
     parser.add_argument(
         "--start-at",
-        choices=["review", "parse", "fix", "test"],
+        choices=["review", "parse", "fix", "test", "ttt", "per-stack", "merge"],
         default="review",
         dest="start_at",
-        help="Start at a specific phase (default: review)",
+        help=(
+            "Start at a specific phase (default: review). "
+            "Choices: review | parse | fix | test | ttt (deep-only) | "
+            "per-stack (deep-only) | merge (deep-only). Deep-only stages require --deep."
+        ),
     )
 
     parser.add_argument(
@@ -257,7 +264,15 @@ def _parse_args() -> RunConfig:
         help="Technology-agnostic review: understand intent, evaluate alternatives, generate plan",
     )
 
-    args = parser.parse_args()
+    parser.add_argument(
+        "--deep",
+        action="store_true",
+        default=False,
+        dest="deep",
+        help="Deep review pipeline: TTT + parallel per-stack + cross-stack merge",
+    )
+
+    args = parser.parse_args(argv)
 
     # Validate --trust-the-technology mutual exclusions
     if args.trust_the_technology:
@@ -269,6 +284,30 @@ def _parse_args() -> RunConfig:
             parser.error("--trust-the-technology and --loop are mutually exclusive")
         if args.pr is not None:
             parser.error("--trust-the-technology and --pr are mutually exclusive")
+
+    # Validate --deep mutual exclusions (D-06) and --start-at parse rejection (D-04)
+    if args.deep:
+        if args.pr is not None:
+            parser.error("--deep and --pr are mutually exclusive")
+        if args.loop:
+            parser.error("--deep and --loop are mutually exclusive")
+        if args.trust_the_technology:
+            parser.error(
+                "--deep and --trust-the-technology are mutually exclusive "
+                "(deep runs TTT internally)"
+            )
+        if args.review_only:
+            parser.error("--deep and --review-only are mutually exclusive")
+        if args.start_at == "parse":
+            parser.error(
+                "--start-at parse is ambiguous under --deep "
+                "(two parse points in the deep pipeline); "
+                "use --start-at fix to resume after the merged report"
+            )
+
+    # D-05: deep-only stages require --deep
+    if args.start_at in ("ttt", "per-stack", "merge") and not args.deep:
+        parser.error(f"--start-at {args.start_at} requires --deep")
 
     # Validate mutual exclusion: --start-at and --review-only
     if args.start_at != "review" and args.review_only:
@@ -328,6 +367,7 @@ def _parse_args() -> RunConfig:
         loop=args.loop,
         max_iterations=args.max_iterations,
         trust_the_technology=args.trust_the_technology,
+        deep=args.deep,
     )
 
 

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -298,10 +298,21 @@ def _parse_args(argv: list[str] | None = None) -> RunConfig:
             )
         if args.review_only:
             parser.error("--deep and --review-only are mutually exclusive")
+        if args.skill:
+            parser.error(
+                "--deep and skill flags are mutually exclusive "
+                "(deep mode detects stacks and invokes per-stack skills internally)"
+            )
         if args.start_at == "parse":
             parser.error(
                 "--start-at parse is ambiguous under --deep "
                 "(two parse points in the deep pipeline); "
+                "use --start-at fix to resume after the merged report"
+            )
+        if args.start_at == "test":
+            parser.error(
+                "--start-at test is not supported under --deep "
+                "(deep resume stages are ttt|per-stack|merge|fix); "
                 "use --start-at fix to resume after the merged report"
             )
 

--- a/daydream/deep/__init__.py
+++ b/daydream/deep/__init__.py
@@ -17,6 +17,7 @@ from daydream.deep.detection import StackAssignment, detect_stacks
 from daydream.deep.prompts import (
     DOC_REVIEW_NOTICE,
     build_generic_fallback_prompt,
+    build_merge_prompt,
     build_per_stack_prompt,
 )
 
@@ -27,6 +28,7 @@ __all__ = [
     "alternatives_path",
     "build_dedup_candidates",
     "build_generic_fallback_prompt",
+    "build_merge_prompt",
     "build_per_stack_prompt",
     "check_deep_artifacts",
     "dedup_candidates_path",

--- a/daydream/deep/__init__.py
+++ b/daydream/deep/__init__.py
@@ -3,6 +3,25 @@
 Exports run_deep once the orchestrator exists (plan 05-09).
 """
 
+from daydream.deep.artifacts import (
+    alternatives_path,
+    check_deep_artifacts,
+    dedup_candidates_path,
+    deep_dir,
+    intent_path,
+    per_stack_records_path,
+    per_stack_review_path,
+)
 from daydream.deep.detection import StackAssignment, detect_stacks
 
-__all__ = ["StackAssignment", "detect_stacks"]
+__all__ = [
+    "StackAssignment",
+    "alternatives_path",
+    "check_deep_artifacts",
+    "dedup_candidates_path",
+    "deep_dir",
+    "detect_stacks",
+    "intent_path",
+    "per_stack_records_path",
+    "per_stack_review_path",
+]

--- a/daydream/deep/__init__.py
+++ b/daydream/deep/__init__.py
@@ -14,6 +14,7 @@ from daydream.deep.artifacts import (
 )
 from daydream.deep.dedup import CandidatePair, build_dedup_candidates
 from daydream.deep.detection import StackAssignment, detect_stacks
+from daydream.deep.orchestrator import run_deep, total_agent_count
 from daydream.deep.prompts import (
     DOC_REVIEW_NOTICE,
     build_generic_fallback_prompt,
@@ -37,4 +38,6 @@ __all__ = [
     "intent_path",
     "per_stack_records_path",
     "per_stack_review_path",
+    "run_deep",
+    "total_agent_count",
 ]

--- a/daydream/deep/__init__.py
+++ b/daydream/deep/__init__.py
@@ -12,6 +12,7 @@ from daydream.deep.artifacts import (
     per_stack_records_path,
     per_stack_review_path,
 )
+from daydream.deep.dedup import CandidatePair, build_dedup_candidates
 from daydream.deep.detection import StackAssignment, detect_stacks
 from daydream.deep.prompts import (
     DOC_REVIEW_NOTICE,
@@ -21,8 +22,10 @@ from daydream.deep.prompts import (
 
 __all__ = [
     "DOC_REVIEW_NOTICE",
+    "CandidatePair",
     "StackAssignment",
     "alternatives_path",
+    "build_dedup_candidates",
     "build_generic_fallback_prompt",
     "build_per_stack_prompt",
     "check_deep_artifacts",

--- a/daydream/deep/__init__.py
+++ b/daydream/deep/__init__.py
@@ -13,10 +13,18 @@ from daydream.deep.artifacts import (
     per_stack_review_path,
 )
 from daydream.deep.detection import StackAssignment, detect_stacks
+from daydream.deep.prompts import (
+    DOC_REVIEW_NOTICE,
+    build_generic_fallback_prompt,
+    build_per_stack_prompt,
+)
 
 __all__ = [
+    "DOC_REVIEW_NOTICE",
     "StackAssignment",
     "alternatives_path",
+    "build_generic_fallback_prompt",
+    "build_per_stack_prompt",
     "check_deep_artifacts",
     "dedup_candidates_path",
     "deep_dir",

--- a/daydream/deep/__init__.py
+++ b/daydream/deep/__init__.py
@@ -1,0 +1,8 @@
+"""Deep-review mode package.
+
+Exports run_deep once the orchestrator exists (plan 05-09).
+"""
+
+from daydream.deep.detection import StackAssignment, detect_stacks
+
+__all__ = ["StackAssignment", "detect_stacks"]

--- a/daydream/deep/artifacts.py
+++ b/daydream/deep/artifacts.py
@@ -1,0 +1,119 @@
+"""Deep-review artifact path helpers + predecessor-check guard.
+
+All deep-mode artifacts live under `target / ".daydream" / "deep"` per D-41.
+The final merged report writes to `target / REVIEW_OUTPUT_FILE` per D-24/D-42.
+
+The check_deep_artifacts() helper mirrors check_review_file_exists()
+(daydream/phases.py:611-629) -- same exception type, same actionable message format.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from daydream.config import REVIEW_OUTPUT_FILE
+
+# Stage prerequisites -- single source of truth.
+# Value is a list of file names (relative to deep_dir) that must exist before the
+# given stage can run. Special handling for "merge" (needs at least one glob match)
+# and "fix" (checks REVIEW_OUTPUT_FILE in target_dir, not deep_dir).
+_DEEP_STAGE_PREREQS: dict[str, list[str]] = {
+    "ttt": [],
+    "per-stack": ["intent.md", "alternatives.json"],
+    "merge": ["intent.md", "alternatives.json"],  # + at least one stack-*-records.json
+    "fix": [],  # special-cased: needs REVIEW_OUTPUT_FILE in target_dir
+}
+
+# Which --start-at to suggest when a stage's prerequisites are missing.
+_EARLIER_STAGE: dict[str, str] = {
+    "per-stack": "ttt",
+    "merge": "per-stack",
+    "fix": "merge",
+}
+
+
+def deep_dir(target: Path) -> Path:
+    """Return the `.daydream/deep/` directory for `target`, creating it if absent.
+
+    Args:
+        target: Resolved target directory path.
+
+    Returns:
+        Path to `target / ".daydream" / "deep"`.
+    """
+    d = target / ".daydream" / "deep"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def intent_path(deep_dir_path: Path) -> Path:
+    """Path to the TTT intent summary artifact (D-19 context bus)."""
+    return deep_dir_path / "intent.md"
+
+
+def alternatives_path(deep_dir_path: Path) -> Path:
+    """Path to the TTT alternative-review findings artifact (D-19 context bus)."""
+    return deep_dir_path / "alternatives.json"
+
+
+def per_stack_review_path(deep_dir_path: Path, stack_name: str) -> Path:
+    """Per-stack review markdown output (D-18 deterministic, unique per stack)."""
+    return deep_dir_path / f"stack-{stack_name}-review.md"
+
+
+def per_stack_records_path(deep_dir_path: Path, stack_name: str) -> Path:
+    """Per-stack parsed-records JSON (output of pre-merge parse stage, D-21/D-22)."""
+    return deep_dir_path / f"stack-{stack_name}-records.json"
+
+
+def dedup_candidates_path(deep_dir_path: Path) -> Path:
+    """Dedup pre-filter candidate-pairs output (D-27)."""
+    return deep_dir_path / "dedup-candidates.json"
+
+
+def check_deep_artifacts(stage: str, deep_dir_path: Path) -> None:
+    """Validate predecessor artifacts exist for the given resume stage.
+
+    Args:
+        stage: One of "ttt", "per-stack", "merge", "fix".
+        deep_dir_path: Path to the `.daydream/deep/` directory.
+
+    Raises:
+        ValueError: If stage is not a known deep-mode stage.
+        FileNotFoundError: With an actionable multi-line message naming missing
+            files and the --start-at value that would produce them.
+    """
+    if stage not in _DEEP_STAGE_PREREQS:
+        raise ValueError(f"Unknown deep stage: {stage!r}")
+
+    missing: list[Path] = []
+
+    # Regular file prerequisites.
+    for name in _DEEP_STAGE_PREREQS[stage]:
+        p = deep_dir_path / name
+        if not p.exists():
+            missing.append(p)
+
+    # Merge stage additionally needs at least one stack-*-records.json.
+    if stage == "merge":
+        records = list(deep_dir_path.glob("stack-*-records.json"))
+        if not records:
+            missing.append(deep_dir_path / "stack-*-records.json")
+
+    # Fix stage needs the merged report in target_dir (parent of .daydream, not deep_dir).
+    if stage == "fix":
+        target_dir = deep_dir_path.parent.parent
+        merged = target_dir / REVIEW_OUTPUT_FILE
+        if not merged.exists():
+            missing.append(merged)
+
+    if missing:
+        expected_block = "\n".join(f"  - {p}" for p in missing)
+        earlier = _EARLIER_STAGE.get(stage, "ttt")
+        msg = (
+            f"Cannot resume at stage '{stage}' -- missing artifacts:\n\n"
+            f"{expected_block}\n\n"
+            f"Re-run from an earlier stage:\n"
+            f"  daydream --deep --start-at {earlier}"
+        )
+        raise FileNotFoundError(msg)

--- a/daydream/deep/artifacts.py
+++ b/daydream/deep/artifacts.py
@@ -71,6 +71,16 @@ def dedup_candidates_path(deep_dir_path: Path) -> Path:
     return deep_dir_path / "dedup-candidates.json"
 
 
+def per_stack_failures_path(deep_dir_path: Path) -> Path:
+    """Per-stack agent failure summary ({stack_name: reason} JSON).
+
+    Persisted so a resume at `merge` can still surface uncovered stacks in the
+    final report -- otherwise the failure info lives only in-memory inside the
+    per-stack fan-out call.
+    """
+    return deep_dir_path / "per-stack-failures.json"
+
+
 def check_deep_artifacts(stage: str, deep_dir_path: Path) -> None:
     """Validate predecessor artifacts exist for the given resume stage.
 
@@ -89,14 +99,16 @@ def check_deep_artifacts(stage: str, deep_dir_path: Path) -> None:
     missing: list[Path] = []
 
     # Regular file prerequisites.
+    # Use is_file() (not exists()) so a directory sharing the prereq name doesn't
+    # pass the gate and fail later in less actionable places.
     for name in _DEEP_STAGE_PREREQS[stage]:
         p = deep_dir_path / name
-        if not p.exists():
+        if not p.is_file():
             missing.append(p)
 
     # Merge stage additionally needs at least one stack-*-records.json.
     if stage == "merge":
-        records = list(deep_dir_path.glob("stack-*-records.json"))
+        records = [p for p in deep_dir_path.glob("stack-*-records.json") if p.is_file()]
         if not records:
             missing.append(deep_dir_path / "stack-*-records.json")
 
@@ -104,7 +116,7 @@ def check_deep_artifacts(stage: str, deep_dir_path: Path) -> None:
     if stage == "fix":
         target_dir = deep_dir_path.parent.parent
         merged = target_dir / REVIEW_OUTPUT_FILE
-        if not merged.exists():
+        if not merged.is_file():
             missing.append(merged)
 
     if missing:

--- a/daydream/deep/dedup.py
+++ b/daydream/deep/dedup.py
@@ -1,0 +1,134 @@
+"""Structured dedup pre-filter for deep-review mode (D-27).
+
+Pure function. Takes parsed per-stack records + TTT alternative-review issues and
+emits ``CandidatePair`` entries where each pair shares at least one file AND has
+a normalized-title bigram Jaccard similarity >= 0.5.
+
+The merge agent (plan 05-08) adjudicates candidate pairs. This pre-filter exists
+to keep the merger's prompt small and keep quadratic-pair enumeration out of the
+LLM.
+
+Thresholds (per RESEARCH.md Open Question 3):
+
+- Bigram Jaccard similarity >= 0.5 on normalized titles
+- AND at least one shared file path
+
+Both gates must hold — a loose pre-filter is safer than a tight one because the
+merge agent still adjudicates.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+
+_STOP_WORDS = frozenset(
+    {"the", "a", "an", "is", "on", "in", "of", "to", "for", "and", "or", "with", "by"}
+)
+_PUNCT_RE = re.compile(r"[^a-z0-9\s]+")
+_SIM_THRESHOLD = 0.5
+
+
+@dataclass(frozen=True)
+class CandidatePair:
+    """A same-concern candidate between a per-stack record and a TTT alt-review issue.
+
+    Attributes:
+        record_id: The parsed record's id (from FEEDBACK_SCHEMA).
+        record_file: The record's file field.
+        record_description: The record's description (kept verbatim).
+        alt_title: The TTT alternative-review issue's title.
+        alt_files: The TTT issue's files tuple.
+        similarity: Jaccard bigram similarity between normalized titles.
+    """
+
+    record_id: str
+    record_file: str
+    record_description: str
+    alt_title: str
+    alt_files: tuple[str, ...]
+    similarity: float
+
+
+def _normalize_title(text: str) -> str:
+    """Lowercase, strip punctuation, drop stop words, return whitespace-joined string."""
+    cleaned = _PUNCT_RE.sub(" ", text.lower())
+    tokens = [tok for tok in cleaned.split() if tok and tok not in _STOP_WORDS]
+    return " ".join(tokens)
+
+
+def _bigrams(normalized: str) -> set[str]:
+    """Return the set of 2-character bigrams from a normalized title string.
+
+    Character-level bigrams are used because they are robust to token
+    reordering (per RESEARCH.md Open Question 3 recommendation). Titles
+    shorter than 2 characters return a sentinel single-element set so
+    very short titles remain comparable under Jaccard.
+    """
+    if len(normalized) < 2:
+        return {normalized} if normalized else set()
+    return {normalized[i : i + 2] for i in range(len(normalized) - 1)}
+
+
+def _jaccard(a: set[str], b: set[str]) -> float:
+    """Return Jaccard similarity, or 0.0 when both sets are empty."""
+    if not a and not b:
+        return 0.0
+    union = a | b
+    if not union:
+        return 0.0
+    return len(a & b) / len(union)
+
+
+def _files_overlap(record_file: str, alt_files: Iterable[str]) -> bool:
+    """Return True when the record's file appears in the alt-issue files."""
+    return bool(record_file) and record_file in set(alt_files)
+
+
+def build_dedup_candidates(
+    records: list[dict[str, Any]],
+    alt_issues: list[dict[str, Any]],
+) -> list[CandidatePair]:
+    """Return same-concern candidate pairs per D-27 thresholds.
+
+    Args:
+        records: Parsed per-stack records matching FEEDBACK_SCHEMA
+            (``id``, ``file``, ``line``, ``description`` keys).
+        alt_issues: TTT alternative-review issues matching ALTERNATIVE_REVIEW_SCHEMA
+            (``title``, ``files`` keys).
+
+    Returns:
+        Deterministically-ordered list of ``CandidatePair`` instances for every
+        record/alt-issue combination that shares a file path AND has normalized
+        title bigram Jaccard similarity >= 0.5. Order is ``(record_id, alt_title)``.
+    """
+    pairs: list[CandidatePair] = []
+    for r in records:
+        r_file = str(r.get("file", ""))
+        r_desc = str(r.get("description", ""))
+        r_bigrams = _bigrams(_normalize_title(r_desc))
+        if not r_file or not r_bigrams:
+            continue
+        for a in alt_issues:
+            a_files = tuple(a.get("files") or [])
+            a_title = str(a.get("title", ""))
+            if not a_files or not a_title:
+                continue
+            if not _files_overlap(r_file, a_files):
+                continue
+            sim = _jaccard(r_bigrams, _bigrams(_normalize_title(a_title)))
+            if sim >= _SIM_THRESHOLD:
+                pairs.append(
+                    CandidatePair(
+                        record_id=str(r.get("id", "")),
+                        record_file=r_file,
+                        record_description=r_desc,
+                        alt_title=a_title,
+                        alt_files=a_files,
+                        similarity=sim,
+                    )
+                )
+    pairs.sort(key=lambda p: (p.record_id, p.alt_title))
+    return pairs

--- a/daydream/deep/detection.py
+++ b/daydream/deep/detection.py
@@ -1,0 +1,238 @@
+"""Stack detection and file routing for deep-review mode.
+
+Pure-logic classifier that maps a list of changed files to StackAssignment records
+per D-11..D-16 (see .planning/phases/05-deep-review-mode/05-CONTEXT.md).
+
+The routing order is significant (Pitfall 6 in 05-RESEARCH.md):
+    1. .md pinning (D-14)         -> generic unconditionally
+    2. Extension lookup (D-11)    -> stack by _EXT_TO_STACK
+    3. Config promotion (D-13)    -> promote only on co-change
+    4. Ambiguous nearest-ancestor (D-12)
+    5. Equal-depth fallthrough (D-12c) -> generic
+    6. Missing-skill fallthrough (D-16) -> generic
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import PurePosixPath
+
+from daydream.config import SKILL_MAP
+
+# Extension -> stack-key (lowercase, matches SKILL_MAP keys). Keep in sync with
+# SKILL_MAP; this table is about review-skill routing, not syntactic parsing
+# (tree_sitter_index.LANGUAGES serves a different purpose).
+_EXT_TO_STACK: dict[str, str] = {
+    ".py": "python",
+    ".pyi": "python",
+    ".ts": "react",
+    ".tsx": "react",
+    ".js": "react",
+    ".jsx": "react",
+    ".ex": "elixir",
+    ".exs": "elixir",
+    ".go": "go",
+    ".rs": "rust",
+    ".swift": "ios",
+}
+
+# Config files promoted only when a co-changed stack file signals ownership.
+# filename -> stack-key
+_CONFIG_OWNERSHIP_SIGNALS: dict[str, str] = {
+    "pyproject.toml": "python",
+    "setup.py": "python",
+    "setup.cfg": "python",
+    "package.json": "react",
+    "tsconfig.json": "react",
+    "mix.exs": "elixir",
+    "go.mod": "go",
+    "go.sum": "go",
+    "Cargo.toml": "rust",
+    "Cargo.lock": "rust",
+    "Package.swift": "ios",
+}
+
+# Generic-fallback stack key. Not present in SKILL_MAP by design — it's a synthetic
+# bucket signalling "run the generic review agent".
+GENERIC_STACK = "generic"
+
+
+@dataclass
+class StackAssignment:
+    """Routing result for one detected stack.
+
+    Attributes:
+        stack_name: Lower-case stack key, e.g. "python" or "generic".
+        skill_invocation: Beagle skill key from SKILL_MAP (e.g. "beagle-python:review-python"),
+            or None for the generic fallback.
+        files: Files routed to this stack. Never empty for entries in the returned list.
+        is_docs_only: True when this assignment represents a docs-only diff (triggers D-20
+            notice). Only set on the ``generic`` bucket, and only when no non-generic stacks
+            were detected in the whole diff. Non-generic buckets never have a docs-only mix.
+    """
+
+    stack_name: str
+    skill_invocation: str | None
+    files: list[str] = field(default_factory=list)
+    is_docs_only: bool = False
+
+
+def _ext(path: str) -> str:
+    """Return lowercase suffix of ``path`` (empty string if none)."""
+    return PurePosixPath(path).suffix.lower()
+
+
+def _basename(path: str) -> str:
+    """Return the final path component of ``path``."""
+    return PurePosixPath(path).name
+
+
+def _is_config_generic_default(path: str) -> bool:
+    """Config / infra files that route to generic unless promoted (D-13)."""
+    suffix = _ext(path)
+    if suffix in {".yaml", ".yml", ".toml"}:
+        return True
+    base = _basename(path)
+    if base == "Dockerfile":
+        return True
+    if path.startswith(".github/workflows/") and suffix in {".yml", ".yaml"}:
+        return True
+    return False
+
+
+def _nearest_ancestor_stack(path: str, assigned: dict[str, str]) -> str | None:
+    """Walk up ``path``'s ancestors; return the non-generic stack of the deepest ancestor
+    that contains an already-assigned unambiguous sibling (D-12).
+
+    Returns None on equal-depth ambiguity (D-12c) or when no ancestor match exists.
+    """
+    p = PurePosixPath(path)
+    # Walk deepest-first so "nearest" = first match.
+    for parent in p.parents:
+        ancestor = str(parent)
+        prefix = ancestor + "/" if ancestor and ancestor != "." else ""
+        stacks_here = {
+            stack
+            for file_path, stack in assigned.items()
+            if file_path != path
+            and stack != GENERIC_STACK
+            and file_path.startswith(prefix)
+        }
+        if len(stacks_here) == 1:
+            return next(iter(stacks_here))
+        if len(stacks_here) > 1:
+            return None  # equal-depth ambiguity -> fallthrough (D-12c)
+    return None
+
+
+def detect_stacks(
+    changed_files: list[str],
+    skill_availability: set[str] | None = None,
+) -> list[StackAssignment]:
+    """Route changed files to stacks per D-11..D-16.
+
+    Args:
+        changed_files: Paths (POSIX-style, repo-relative) of files that changed in the diff.
+        skill_availability: Lower-case stack keys for which a Beagle skill is installed.
+            Defaults to all keys in SKILL_MAP (optimistic availability — runtime
+            MissingSkillError would be handled separately).
+
+    Returns:
+        One StackAssignment per distinct stack that received at least one file.
+        Ordering: non-generic stacks alphabetical, then generic last.
+    """
+    if skill_availability is None:
+        skill_availability = set(SKILL_MAP.keys())
+
+    assigned: dict[str, str] = {}  # path -> stack_name
+    ambiguous: list[str] = []
+
+    # Pass 1: unambiguous routing (extension + .md pinning + config default).
+    for path in changed_files:
+        base = _basename(path)
+        suffix = _ext(path)
+
+        # D-14: .md pinned unconditionally.
+        if suffix == ".md":
+            assigned[path] = GENERIC_STACK
+            continue
+
+        # D-11: extension lookup.
+        if suffix in _EXT_TO_STACK:
+            assigned[path] = _EXT_TO_STACK[suffix]
+            continue
+
+        # D-13: config/infra default-generic (may be promoted in pass 2).
+        if _is_config_generic_default(path) or base in _CONFIG_OWNERSHIP_SIGNALS:
+            assigned[path] = GENERIC_STACK
+            continue
+
+        # Otherwise ambiguous — resolved in pass 3.
+        ambiguous.append(path)
+
+    # Pass 2: promote config files whose owner stack is present in the diff (D-13).
+    present_stacks = {s for s in assigned.values() if s != GENERIC_STACK}
+    for path in list(assigned.keys()):
+        base = _basename(path)
+        owner = _CONFIG_OWNERSHIP_SIGNALS.get(base)
+        if owner and owner in present_stacks:
+            assigned[path] = owner
+
+    # Refresh present stacks after promotion.
+    present_stacks = {s for s in assigned.values() if s != GENERIC_STACK}
+
+    # Pass 3: ambiguous files (D-12).
+    for path in ambiguous:
+        if len(present_stacks) == 1:
+            # D-12 single-stack shortcut: unconditional join.
+            assigned[path] = next(iter(present_stacks))
+            continue
+        if len(present_stacks) == 0:
+            assigned[path] = GENERIC_STACK
+            continue
+        nearest = _nearest_ancestor_stack(path, assigned)
+        assigned[path] = nearest if nearest is not None else GENERIC_STACK
+
+    # Pass 4: missing-skill fallthrough (D-16) — move files of any stack without an
+    # installed skill into generic.
+    for path, stack in list(assigned.items()):
+        if stack != GENERIC_STACK and stack not in skill_availability:
+            assigned[path] = GENERIC_STACK
+
+    # Group -> StackAssignment.
+    groups: dict[str, list[str]] = {}
+    for path, stack in assigned.items():
+        groups.setdefault(stack, []).append(path)
+
+    # is_docs_only means "this whole diff is docs-only" (triggers D-20 notice). A mixed
+    # diff (docs + code) must not flag the generic bucket as docs-only even though that
+    # bucket only contains .md files.
+    non_generic_stacks = [k for k in groups if k != GENERIC_STACK]
+    diff_is_docs_only = (
+        not non_generic_stacks
+        and GENERIC_STACK in groups
+        and all(_ext(f) == ".md" for f in groups[GENERIC_STACK])
+    )
+
+    results: list[StackAssignment] = []
+    for stack_name in sorted(non_generic_stacks):
+        files = sorted(groups[stack_name])
+        results.append(
+            StackAssignment(
+                stack_name=stack_name,
+                skill_invocation=SKILL_MAP.get(stack_name),
+                files=files,
+                is_docs_only=all(_ext(f) == ".md" for f in files),
+            )
+        )
+    if GENERIC_STACK in groups:
+        files = sorted(groups[GENERIC_STACK])
+        results.append(
+            StackAssignment(
+                stack_name=GENERIC_STACK,
+                skill_invocation=None,
+                files=files,
+                is_docs_only=diff_is_docs_only,
+            )
+        )
+    return results

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -1,0 +1,389 @@
+"""Deep-review mode orchestrator (``run_deep``).
+
+Composes existing phase primitives plus deep-mode-specific phases into the
+pipeline described by D-07:
+
+    exploration pre-scan -> TTT intent -> TTT alternative-review ->
+    per-stack reviews -> per-stack parse + dedup -> cross-stack merge ->
+    optional fix gate.
+
+All per-plan logic lives in plans 05-01..05-08; this module is the wiring
+layer that stitches them together. No signature changes to any existing
+phase primitive (D-39).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from daydream.agent import console
+from daydream.config import REVIEW_OUTPUT_FILE, SKILL_MAP
+from daydream.deep.artifacts import (
+    alternatives_path as _alternatives_path,
+)
+from daydream.deep.artifacts import (
+    check_deep_artifacts,
+    dedup_candidates_path,
+    deep_dir,
+    per_stack_records_path,
+)
+from daydream.deep.artifacts import (
+    intent_path as _intent_path,
+)
+from daydream.deep.dedup import build_dedup_candidates
+from daydream.deep.detection import StackAssignment, detect_stacks
+from daydream.phases import (
+    phase_alternative_review,
+    phase_commit_push,
+    phase_cross_stack_merge,
+    phase_fix,
+    phase_parse_feedback,
+    phase_per_stack_reviews,
+    phase_test_and_heal,
+    phase_understand_intent,
+)
+from daydream.ui import (
+    print_error,
+    print_info,
+    print_preflight_notice,
+    print_stage_progress,
+    print_success,
+    print_warning,
+    prompt_user,
+)
+
+if TYPE_CHECKING:
+    from daydream.runner import RunConfig
+
+# Exploration infrastructure import guard. When Phases 1-4 are not yet
+# installed, deep mode still runs -- just without grounding context.
+try:
+    from daydream.exploration import ExplorationContext, safe_explore
+    from daydream.exploration_runner import count_changed_files, pre_scan, select_tier
+
+    EXPLORATION_AVAILABLE = True
+except ImportError:  # pragma: no cover -- only hit when Phases 1-4 absent
+    EXPLORATION_AVAILABLE = False
+
+# Codex backend class used for isinstance() in the pre-flight notice
+# (D-31 cost_usd=None caveat). Imported here so tests can monkeypatch it.
+from daydream.backends.codex import CodexBackend  # noqa: E402
+
+# Match git diff file headers to extract the list of changed files.
+_DIFF_FILE_HEADER = re.compile(r"^(?:diff --git a/(\S+)|\+\+\+ b/(\S+))", re.MULTILINE)
+
+# User-visible pipeline stages (exploration is a pre-stage banner, not counted).
+_PIPELINE_STAGE_NAMES: list[str] = [
+    "TTT intent",
+    "TTT alternative-review",
+    "per-stack reviews",
+    "cross-stack merge",
+    "optional fix gate",
+]
+
+
+def total_agent_count(stack_count: int) -> int:
+    """Return the D-30 agent count formula.
+
+    Formula: 2 (TTT intent + alternative-review) + N per-stack reviews
+    + N per-stack parse passes + 1 cross-stack merge. The fix-gate agents
+    are user-gated and excluded from the pre-flight estimate.
+
+    Args:
+        stack_count: Number of detected stack assignments (including the
+            generic-fallback bucket when present).
+
+    Returns:
+        Total agent invocation count surfaced in the pre-flight notice.
+    """
+    return 2 + stack_count + stack_count + 1
+
+
+def _diff_changed_files(diff: str) -> list[str]:
+    """Extract changed files from a unified diff.
+
+    Prefers ``+++ b/<path>`` lines over ``diff --git a/<path>`` because
+    the former survives renames where the a-side path no longer exists.
+
+    Args:
+        diff: Unified diff text.
+
+    Returns:
+        Unique, insertion-ordered list of changed file paths (excluding
+        ``/dev/null`` sentinels).
+    """
+    files: list[str] = []
+    for match in _DIFF_FILE_HEADER.finditer(diff):
+        path = match.group(1) or match.group(2)
+        if path and path != "/dev/null" and path not in files:
+            files.append(path)
+    return files
+
+
+def _stack_preflight_line(stack: StackAssignment) -> str:
+    """Format one detected-stack line for the pre-flight notice."""
+    skill = stack.skill_invocation or "generic fallback"
+    docs_suffix = " (docs-only)" if stack.is_docs_only else ""
+    return f"{stack.stack_name}: {skill} -- {len(stack.files)} file(s){docs_suffix}"
+
+
+def _write_ttt_artifacts(
+    deep_dir_path: Path, *, intent_summary: str, alt_issues: list[dict[str, Any]]
+) -> tuple[Path, Path]:
+    """Persist TTT intent + alternatives to the deep artifact directory.
+
+    Args:
+        deep_dir_path: Path to ``.daydream/deep/``.
+        intent_summary: Confirmed intent summary from phase_understand_intent.
+        alt_issues: Issues returned by phase_alternative_review.
+
+    Returns:
+        Tuple of (intent_path, alternatives_path).
+    """
+    intent_p = _intent_path(deep_dir_path)
+    alts_p = _alternatives_path(deep_dir_path)
+    intent_p.write_text(intent_summary)
+    alts_p.write_text(json.dumps(alt_issues, indent=2))
+    return intent_p, alts_p
+
+
+def _candidate_pair_to_json(pair: Any) -> dict[str, Any]:
+    """Serialize a CandidatePair dataclass into a JSON-compatible dict."""
+    if is_dataclass(pair) and not isinstance(pair, type):
+        data = asdict(pair)
+    else:
+        data = dict(pair)
+    # alt_files is a tuple -> convert to list for stable JSON.
+    if isinstance(data.get("alt_files"), tuple):
+        data["alt_files"] = list(data["alt_files"])
+    return data
+
+
+async def run_deep(config: RunConfig, target_dir: Path) -> int:
+    """Execute the deep-review pipeline (D-07).
+
+    Composes exploration pre-scan, TTT, per-stack fan-out, per-stack parse,
+    dedup pre-filter, cross-stack merge, and the optional fix gate into a
+    single async flow. Supports stage-granular resume via
+    ``config.start_at in ("ttt", "per-stack", "merge", "fix")``.
+
+    Args:
+        config: Run configuration. ``config.deep`` must be True;
+            ``config.start_at`` drives resume behavior.
+        target_dir: Resolved target directory path (repo root).
+
+    Returns:
+        Exit code (0 on success, 1 on failure).
+    """
+    # Late imports to avoid circular dependency with runner.
+    from daydream.phases import _git_branch, _git_diff, _git_log
+    from daydream.runner import _compute_diff_ref, _resolve_backend
+    from daydream.ui import phase_subtitle, print_dim, print_phase_hero
+
+    backend = _resolve_backend(config, "review")
+
+    # ------ Preamble (mirrors run_trust) ------
+    diff = _git_diff(target_dir, exclude=config.ignore_paths)
+    log = _git_log(target_dir)
+    branch = _git_branch(target_dir)
+
+    if diff is None:
+        print_error(console, "Git Error", "Unable to determine base branch for diff")
+        return 1
+    if not diff.strip():
+        print_warning(console, "No diff found -- nothing to review")
+        return 0
+
+    daydream_dir = target_dir / ".daydream"
+    daydream_dir.mkdir(exist_ok=True)
+    diff_path = daydream_dir / "diff.patch"
+    diff_path.write_text(diff)
+    dd = deep_dir(target_dir)
+
+    console.print()
+    print_info(console, f"Target directory: {target_dir}")
+    print_info(console, f"Branch: {branch}")
+    print_info(console, f"Model: {config.model or '<backend-default>'}")
+    console.print()
+
+    # ------ Resume gate (D-34, D-36, D-37) ------
+    if config.start_at in ("per-stack", "merge", "fix"):
+        try:
+            check_deep_artifacts(config.start_at, dd)
+        except FileNotFoundError as exc:
+            print_error(console, "Missing Deep Artifact", str(exc))
+            return 1
+
+    # ------ Stack detection (from diff file list) ------
+    changed_files = _diff_changed_files(diff)
+    stacks = detect_stacks(changed_files, skill_availability=set(SKILL_MAP.keys()))
+
+    # ------ Pre-flight notice (D-30, D-31) ------
+    stack_lines = [_stack_preflight_line(s) for s in stacks]
+    print_preflight_notice(
+        console,
+        stages=_PIPELINE_STAGE_NAMES,
+        stack_lines=stack_lines,
+        agent_count=total_agent_count(len(stacks)),
+        codex_in_use=isinstance(backend, CodexBackend),
+        exploration_available=EXPLORATION_AVAILABLE,
+    )
+
+    # ------ Exploration pre-scan (D-43) ------
+    exploration_dir: Path | None = None
+    if not EXPLORATION_AVAILABLE:
+        print_warning(
+            console,
+            "Exploration infrastructure not installed; running deep pipeline "
+            "without pre-scan grounding",
+        )
+    elif config.exploration_context is None:
+        tier = select_tier(count_changed_files(diff))
+        if tier == "skip":
+            print_dim(console, "Skipping exploration -- trivial diff")
+            config.exploration_context = ExplorationContext()
+        else:
+            print_phase_hero(console, "EXPLORE", phase_subtitle("EXPLORE"))
+            config.exploration_context = await safe_explore(
+                pre_scan,
+                backend,
+                target_dir,
+                diff,
+                config.exploration_depth,
+                diff_ref=_compute_diff_ref(target_dir),
+            )
+    if EXPLORATION_AVAILABLE and config.exploration_context is not None:
+        exploration_dir = config.exploration_context.write_to_dir(
+            daydream_dir / "exploration"
+        )
+
+    try:
+        intent_p = _intent_path(dd)
+        alts_p = _alternatives_path(dd)
+
+        # ------ Stage 1 + 2: TTT ------
+        if config.start_at not in ("per-stack", "merge", "fix"):
+            print_stage_progress(console, 1, 5, _PIPELINE_STAGE_NAMES[0])
+            intent_summary = await phase_understand_intent(
+                backend,
+                target_dir,
+                diff_path,
+                log,
+                branch,
+                exploration_dir=exploration_dir,
+            )
+
+            print_stage_progress(console, 2, 5, _PIPELINE_STAGE_NAMES[1])
+            alt_issues = await phase_alternative_review(
+                backend,
+                target_dir,
+                diff_path,
+                intent_summary,
+                exploration_dir=exploration_dir,
+            )
+
+            intent_p, alts_p = _write_ttt_artifacts(
+                dd, intent_summary=intent_summary, alt_issues=alt_issues
+            )
+
+        # ------ Stage 3: per-stack fan-out ------
+        if config.start_at not in ("merge", "fix"):
+            print_stage_progress(console, 3, 5, _PIPELINE_STAGE_NAMES[2])
+            per_stack_outputs = await phase_per_stack_reviews(
+                backend,
+                target_dir,
+                stacks,
+                diff_path=diff_path,
+                intent_path=intent_p,
+                alternatives_path=alts_p,
+                exploration_dir=exploration_dir,
+            )
+        else:
+            # Resume: reconstruct the expected per-stack output paths on disk.
+            from daydream.deep.artifacts import per_stack_review_path
+
+            per_stack_outputs = {
+                stack.stack_name: per_stack_review_path(dd, stack.stack_name)
+                for stack in stacks
+            }
+
+        # ------ Stage 4: pre-merge parse + dedup + cross-stack merge ------
+        if config.start_at != "fix":
+            print_stage_progress(console, 4, 5, _PIPELINE_STAGE_NAMES[3])
+
+            # Pre-merge parse pass (D-21).
+            per_stack_records_paths: list[Path] = []
+            all_records: list[dict[str, Any]] = []
+            for stack_name, output_path in per_stack_outputs.items():
+                records = await phase_parse_feedback(
+                    backend, target_dir, input_path=output_path
+                )
+                records_path = per_stack_records_path(dd, stack_name)
+                records_path.write_text(json.dumps(records, indent=2))
+                per_stack_records_paths.append(records_path)
+                all_records.extend(records)
+
+            # Dedup pre-filter (D-27).
+            alt_issues_for_dedup: list[dict[str, Any]] = (
+                json.loads(alts_p.read_text()) if alts_p.exists() else []
+            )
+            pairs = build_dedup_candidates(all_records, alt_issues_for_dedup)
+            dedup_p = dedup_candidates_path(dd)
+            dedup_p.write_text(
+                json.dumps([_candidate_pair_to_json(p) for p in pairs], indent=2)
+            )
+
+            # Cross-stack merge (D-23..D-26).
+            await phase_cross_stack_merge(
+                backend,
+                target_dir,
+                per_stack_records_paths=per_stack_records_paths,
+                intent_path=intent_p,
+                alternatives_path=alts_p,
+                dedup_candidates_path=dedup_p,
+                exploration_dir=exploration_dir,
+            )
+
+        # ------ Stage 5: optional fix gate (D-28, D-29) ------
+        print_stage_progress(console, 5, 5, _PIPELINE_STAGE_NAMES[4])
+        merged_report = target_dir / REVIEW_OUTPUT_FILE
+        if not merged_report.exists():
+            print_error(
+                console,
+                "Missing Merged Report",
+                f"Expected merged report at {merged_report}",
+            )
+            return 1
+
+        answer = prompt_user(console, "Apply fixes now? [y/N]", "n")
+        if answer.strip().lower() not in ("y", "yes"):
+            print_success(console, f"Report written to {merged_report}. Exiting.")
+            return 0
+
+        items = await phase_parse_feedback(backend, target_dir)
+        if not items:
+            print_success(console, "No actionable items after parse -- done.")
+            return 0
+
+        for idx, item in enumerate(items, start=1):
+            await phase_fix(backend, target_dir, item, idx, len(items))
+
+        passed, _retries = await phase_test_and_heal(backend, target_dir)
+        if not passed:
+            print_warning(console, "Tests failed after fix attempt.")
+            return 1
+
+        await phase_commit_push(backend, target_dir)
+        return 0
+
+    finally:
+        exploration_cleanup = target_dir / ".daydream" / "exploration"
+        if exploration_cleanup.is_dir():
+            shutil.rmtree(exploration_cleanup)
+        # .daydream/deep/ is preserved per RESEARCH.md Open Question 1 so
+        # subsequent --start-at resumes can find the artifacts they need.

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -490,6 +490,16 @@ async def run_deep(config: RunConfig, target_dir: Path) -> int:
     finally:
         exploration_cleanup = target_dir / ".daydream" / "exploration"
         if exploration_cleanup.is_dir():
-            shutil.rmtree(exploration_cleanup)
+            # Best-effort cleanup: an rmtree failure here would otherwise
+            # escape the finally and replace the run's real exit code with a
+            # cleanup exception, hiding the actual outcome from the caller.
+            try:
+                shutil.rmtree(exploration_cleanup)
+            except OSError as exc:
+                print_warning(
+                    console,
+                    f"Failed to clean up exploration artifacts at "
+                    f"{exploration_cleanup}: {exc}",
+                )
         # .daydream/deep/ is preserved per RESEARCH.md Open Question 1 so
         # subsequent --start-at resumes can find the artifacts they need.

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -360,6 +360,13 @@ async def run_deep(config: RunConfig, target_dir: Path) -> int:
             )
             return 1
 
+        # Offer to post findings as inline PR review comments.
+        from daydream.pr_review import post_review_to_pr_from_report
+
+        await post_review_to_pr_from_report(
+            target_dir, merged_report, console=console
+        )
+
         answer = prompt_user(console, "Apply fixes now? [y/N]", "n")
         if answer.strip().lower() not in ("y", "yes"):
             print_success(console, f"Report written to {merged_report}. Exiting.")

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -133,8 +133,16 @@ def get_installed_skills() -> set[str] | None:
         data = json.loads(registry.read_text())
     except (OSError, json.JSONDecodeError):
         return None
+    # Structurally invalid payloads (non-dict root, non-dict `plugins`) also
+    # signal "unknown" so callers fall back to optimistic availability
+    # instead of aborting deep mode on an AttributeError / TypeError.
+    if not isinstance(data, dict):
+        return None
+    plugins = data.get("plugins")
+    if not isinstance(plugins, dict):
+        return None
     # Keys in the registry look like "<plugin-name>@<marketplace>".
-    installed_plugins = {key.split("@", 1)[0] for key in data.get("plugins", {})}
+    installed_plugins = {key.split("@", 1)[0] for key in plugins}
     installed: set[str] = set()
     for stack_key, skill_invocation in SKILL_MAP.items():
         # SKILL_MAP values are "<plugin-name>:<skill-name>".
@@ -403,11 +411,28 @@ async def run_deep(config: RunConfig, target_dir: Path) -> int:
             per_stack_records_paths: list[Path] = []
             all_records: list[dict[str, Any]] = []
             if config.start_at == "merge":
-                # Resume: the stack-*-records.json files are the validated
-                # prerequisite (see check_deep_artifacts). Load them directly
-                # so resume works even after per-stack review.md files have
-                # been cleaned up.
-                for records_path in sorted(dd.glob("stack-*-records.json")):
+                # Resume: validate a records file exists for every detected
+                # stack (except ones explicitly in `failed_stacks`). A bare
+                # `dd.glob` could silently drop a current stack whose prior
+                # records file is absent, producing an authoritative-looking
+                # merged report that is missing an entire language bucket.
+                expected_paths: list[Path] = []
+                missing_stacks: list[str] = []
+                for stack in stacks:
+                    records_path = per_stack_records_path(dd, stack.stack_name)
+                    if records_path.is_file():
+                        expected_paths.append(records_path)
+                    elif stack.stack_name not in failed_stacks:
+                        missing_stacks.append(stack.stack_name)
+                if missing_stacks:
+                    print_error(
+                        console,
+                        "Missing Per-Stack Records",
+                        "Missing parsed records for: "
+                        + ", ".join(sorted(missing_stacks)),
+                    )
+                    return 1
+                for records_path in sorted(expected_paths):
                     records = json.loads(records_path.read_text())
                     per_stack_records_paths.append(records_path)
                     all_records.extend(records)
@@ -460,11 +485,15 @@ async def run_deep(config: RunConfig, target_dir: Path) -> int:
             return 1
 
         # Offer to post findings as inline PR review comments.
-        from daydream.pr_review import post_review_to_pr_from_report
+        # `post_review_to_pr_from_report` is a non-idempotent GitHub write, so
+        # `--start-at fix` (resume after the merged report) must skip it to
+        # avoid duplicate inline reviews on reruns.
+        if config.start_at != "fix":
+            from daydream.pr_review import post_review_to_pr_from_report
 
-        await post_review_to_pr_from_report(
-            target_dir, merged_report, console=console
-        )
+            await post_review_to_pr_from_report(
+                target_dir, merged_report, console=console
+            )
 
         answer = prompt_user(console, "Apply fixes now? [y/N]", "n")
         if answer.strip().lower() not in ("y", "yes"):

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -31,6 +31,7 @@ from daydream.deep.artifacts import (
     check_deep_artifacts,
     dedup_candidates_path,
     deep_dir,
+    per_stack_failures_path,
     per_stack_records_path,
 )
 from daydream.deep.artifacts import (
@@ -356,9 +357,10 @@ async def run_deep(config: RunConfig, target_dir: Path) -> int:
             )
 
         # ------ Stage 3: per-stack fan-out ------
+        failed_stacks: dict[str, str] = {}
         if config.start_at not in ("merge", "fix"):
             print_stage_progress(console, 3, 5, _PIPELINE_STAGE_NAMES[2])
-            per_stack_outputs = await phase_per_stack_reviews(
+            per_stack_outputs, failed_stacks = await phase_per_stack_reviews(
                 backend,
                 target_dir,
                 stacks,
@@ -367,6 +369,14 @@ async def run_deep(config: RunConfig, target_dir: Path) -> int:
                 alternatives_path=alts_p,
                 exploration_dir=exploration_dir,
             )
+            # Persist so a later `--start-at merge` resume can still surface
+            # uncovered stacks (the in-memory failure map otherwise dies here).
+            failures_p = per_stack_failures_path(dd)
+            if failed_stacks:
+                failures_p.write_text(json.dumps(failed_stacks, indent=2, sort_keys=True))
+            elif failures_p.exists():
+                # Fresh successful run supersedes any stale failures record.
+                failures_p.unlink()
         else:
             # Resume: reconstruct the expected per-stack output paths on disk.
             from daydream.deep.artifacts import per_stack_review_path
@@ -375,6 +385,16 @@ async def run_deep(config: RunConfig, target_dir: Path) -> int:
                 stack.stack_name: per_stack_review_path(dd, stack.stack_name)
                 for stack in stacks
             }
+            # Resume also resurrects any prior failure summary so the merge
+            # prompt can still note uncovered stacks.
+            failures_p = per_stack_failures_path(dd)
+            if failures_p.is_file():
+                try:
+                    loaded = json.loads(failures_p.read_text())
+                    if isinstance(loaded, dict):
+                        failed_stacks = {str(k): str(v) for k, v in loaded.items()}
+                except json.JSONDecodeError:
+                    failed_stacks = {}
 
         # ------ Stage 4: pre-merge parse + dedup + cross-stack merge ------
         if config.start_at != "fix":
@@ -393,7 +413,11 @@ async def run_deep(config: RunConfig, target_dir: Path) -> int:
                     all_records.extend(records)
             else:
                 # Pre-merge parse pass (D-21).
-                for stack_name, output_path in per_stack_outputs.items():
+                # Sort by stack_name so merge input order doesn't depend on the
+                # completion order of the parallel per-stack tasks that
+                # populated `per_stack_outputs` -- keeps the merge prompt and
+                # global issue numbering reproducible across runs.
+                for stack_name, output_path in sorted(per_stack_outputs.items()):
                     records = await phase_parse_feedback(
                         backend, target_dir, input_path=output_path
                     )
@@ -421,6 +445,7 @@ async def run_deep(config: RunConfig, target_dir: Path) -> int:
                 alternatives_path=alts_p,
                 dedup_candidates_path=dedup_p,
                 exploration_dir=exploration_dir,
+                failed_stacks=failed_stacks or None,
             )
 
         # ------ Stage 5: optional fix gate (D-28, D-29) ------

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -15,6 +15,7 @@ phase primitive (D-39).
 from __future__ import annotations
 
 import json
+import os
 import re
 import shutil
 from dataclasses import asdict, is_dataclass
@@ -74,8 +75,13 @@ except ImportError:  # pragma: no cover -- only hit when Phases 1-4 absent
 # (D-31 cost_usd=None caveat). Imported here so tests can monkeypatch it.
 from daydream.backends.codex import CodexBackend  # noqa: E402
 
-# Match git diff file headers to extract the list of changed files.
-_DIFF_FILE_HEADER = re.compile(r"^(?:diff --git a/(\S+)|\+\+\+ b/(\S+))", re.MULTILINE)
+# Per-file block splitter (splits the unified diff at each `diff --git` header).
+_DIFF_BLOCK_SPLIT = re.compile(r"^(?=diff --git )", re.MULTILINE)
+# `+++ ` and `--- ` file headers inside a single block.
+_DIFF_PLUS_HEADER = re.compile(r"^\+\+\+ (\S+)", re.MULTILINE)
+_DIFF_MINUS_HEADER = re.compile(r"^--- (\S+)", re.MULTILINE)
+# Fallback header for binary / mode-only diffs that lack `--- / +++`.
+_DIFF_GIT_HEADER = re.compile(r"^diff --git a/(\S+) b/(\S+)")
 
 # User-visible pipeline stages (exploration is a pre-stage banner, not counted).
 _PIPELINE_STAGE_NAMES: list[str] = [
@@ -104,11 +110,47 @@ def total_agent_count(stack_count: int) -> int:
     return 2 + stack_count + stack_count + 1
 
 
+def get_installed_skills() -> set[str] | None:
+    """Detect which Beagle review-skill plugins are installed.
+
+    Reads the Claude Code plugin registry at
+    ``$CLAUDE_CONFIG_DIR/plugins/installed_plugins.json`` (default
+    ``~/.claude``) and maps installed plugin names back to ``SKILL_MAP``
+    stack keys. Each stack's Beagle skill lives in a plugin named
+    ``beagle-<stack>``; a stack is considered "installed" iff that plugin
+    is present.
+
+    Returns:
+        Set of installed stack keys (subset of ``SKILL_MAP.keys()``), or
+        ``None`` if the registry cannot be read (missing file, bad JSON).
+        ``None`` signals "unknown" so callers can fall back to optimistic
+        availability without forcing every stack through generic.
+    """
+    config_dir = Path(os.environ.get("CLAUDE_CONFIG_DIR") or (Path.home() / ".claude"))
+    registry = config_dir / "plugins" / "installed_plugins.json"
+    try:
+        data = json.loads(registry.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    # Keys in the registry look like "<plugin-name>@<marketplace>".
+    installed_plugins = {key.split("@", 1)[0] for key in data.get("plugins", {})}
+    installed: set[str] = set()
+    for stack_key, skill_invocation in SKILL_MAP.items():
+        # SKILL_MAP values are "<plugin-name>:<skill-name>".
+        plugin_prefix = skill_invocation.split(":", 1)[0]
+        if plugin_prefix in installed_plugins:
+            installed.add(stack_key)
+    return installed
+
+
 def _diff_changed_files(diff: str) -> list[str]:
     """Extract changed files from a unified diff.
 
-    Prefers ``+++ b/<path>`` lines over ``diff --git a/<path>`` because
-    the former survives renames where the a-side path no longer exists.
+    Parses one file per ``diff --git`` block and contributes a single path
+    for each. Prefers the post-state path (``+++ b/<path>``) so renames
+    produce only the destination. Falls back to the pre-state path for
+    deletions (``+++ /dev/null``) and to the ``diff --git`` header for
+    binary / mode-only diffs that lack ``---``/``+++`` lines.
 
     Args:
         diff: Unified diff text.
@@ -117,10 +159,27 @@ def _diff_changed_files(diff: str) -> list[str]:
         Unique, insertion-ordered list of changed file paths (excluding
         ``/dev/null`` sentinels).
     """
+
+    def _strip_prefix(path: str, prefix: str) -> str:
+        return path[len(prefix) :] if path.startswith(prefix) else path
+
     files: list[str] = []
-    for match in _DIFF_FILE_HEADER.finditer(diff):
-        path = match.group(1) or match.group(2)
-        if path and path != "/dev/null" and path not in files:
+    for block in _DIFF_BLOCK_SPLIT.split(diff):
+        if not block.startswith("diff --git "):
+            continue
+        path: str | None = None
+        plus = _DIFF_PLUS_HEADER.search(block)
+        if plus and plus.group(1) != "/dev/null":
+            path = _strip_prefix(plus.group(1), "b/")
+        if path is None:
+            minus = _DIFF_MINUS_HEADER.search(block)
+            if minus and minus.group(1) != "/dev/null":
+                path = _strip_prefix(minus.group(1), "a/")
+        if path is None:
+            git = _DIFF_GIT_HEADER.match(block)
+            if git:
+                path = git.group(2)
+        if path and path not in files:
             files.append(path)
     return files
 
@@ -221,7 +280,12 @@ async def run_deep(config: RunConfig, target_dir: Path) -> int:
 
     # ------ Stack detection (from diff file list) ------
     changed_files = _diff_changed_files(diff)
-    stacks = detect_stacks(changed_files, skill_availability=set(SKILL_MAP.keys()))
+    installed = get_installed_skills()
+    # Optimistic fallback when detection fails: SDK-level MissingSkillError is
+    # still caught downstream in phase_per_stack_reviews, so preserving the
+    # pre-D-16 behavior is safer than routing everything to generic.
+    skill_availability = installed if installed is not None else set(SKILL_MAP.keys())
+    stacks = detect_stacks(changed_files, skill_availability=skill_availability)
 
     # ------ Pre-flight notice (D-30, D-31) ------
     stack_lines = [_stack_preflight_line(s) for s in stacks]
@@ -316,17 +380,27 @@ async def run_deep(config: RunConfig, target_dir: Path) -> int:
         if config.start_at != "fix":
             print_stage_progress(console, 4, 5, _PIPELINE_STAGE_NAMES[3])
 
-            # Pre-merge parse pass (D-21).
             per_stack_records_paths: list[Path] = []
             all_records: list[dict[str, Any]] = []
-            for stack_name, output_path in per_stack_outputs.items():
-                records = await phase_parse_feedback(
-                    backend, target_dir, input_path=output_path
-                )
-                records_path = per_stack_records_path(dd, stack_name)
-                records_path.write_text(json.dumps(records, indent=2))
-                per_stack_records_paths.append(records_path)
-                all_records.extend(records)
+            if config.start_at == "merge":
+                # Resume: the stack-*-records.json files are the validated
+                # prerequisite (see check_deep_artifacts). Load them directly
+                # so resume works even after per-stack review.md files have
+                # been cleaned up.
+                for records_path in sorted(dd.glob("stack-*-records.json")):
+                    records = json.loads(records_path.read_text())
+                    per_stack_records_paths.append(records_path)
+                    all_records.extend(records)
+            else:
+                # Pre-merge parse pass (D-21).
+                for stack_name, output_path in per_stack_outputs.items():
+                    records = await phase_parse_feedback(
+                        backend, target_dir, input_path=output_path
+                    )
+                    records_path = per_stack_records_path(dd, stack_name)
+                    records_path.write_text(json.dumps(records, indent=2))
+                    per_stack_records_paths.append(records_path)
+                    all_records.extend(records)
 
             # Dedup pre-filter (D-27).
             alt_issues_for_dedup: list[dict[str, Any]] = (

--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -48,12 +48,16 @@ def _stack_scope_instruction(stack_name: str, files: list[str]) -> str:
 
 
 def _diff_instruction(diff_path: Path, files: list[str]) -> str:
-    joined = " ".join(files)
+    joined = ", ".join(files)
+    # Point agents at diff_path directly. A bare `git diff -- <files>` command
+    # only surfaces uncommitted workspace changes; on a clean PR branch it
+    # would return empty and hide every committed change. diff_path already
+    # contains the full base..HEAD diff.
     return (
-        f"The full diff is at {diff_path}. Focus on changes in your stack's files "
-        f"using:\n"
-        f"  git diff --no-color -- {joined}\n"
-        f"from within the repository root."
+        f"The full PR diff (base..HEAD) is at {diff_path}. Read it directly; "
+        f"do NOT run `git diff` without a base ref -- on a clean branch that "
+        f"returns empty and hides committed changes.\n"
+        f"Focus on hunks that touch your stack's files: {joined}."
     )
 
 
@@ -105,6 +109,7 @@ def build_merge_prompt(
     dedup_candidates_path: Path,
     output_path: Path,
     exploration_dir: Path | None = None,
+    failed_stacks: dict[str, str] | None = None,
 ) -> str:
     """Assemble the cross-stack merge prompt (D-23..D-27).
 
@@ -122,6 +127,10 @@ def build_merge_prompt(
         dedup_candidates_path: Path to dedup-candidates.json (D-27 pre-filter output).
         output_path: Where the merge agent must write the unified report (D-24).
         exploration_dir: Pre-scan exploration directory (if available).
+        failed_stacks: Optional stack_name -> failure reason for stacks whose
+            per-stack agent raised. The merge prompt includes an explicit
+            "Uncovered stacks" block so the merge report can call out missing
+            coverage instead of silently pretending the run was complete.
 
     Returns:
         Assembled prompt string.
@@ -137,6 +146,17 @@ def build_merge_prompt(
         f"Dedup pre-filter candidate pairs: {dedup_candidates_path}\n"
         f"Per-stack parsed records:\n{records_block}"
     )
+    if failed_stacks:
+        failed_block = "\n".join(
+            f"  - {name}: {reason}" for name, reason in sorted(failed_stacks.items())
+        )
+        parts.append(
+            "Uncovered stacks (per-stack agent raised; no records available):\n"
+            f"{failed_block}\n"
+            "In the merged report add a '## Uncovered Stacks' section listing each "
+            "stack above. Do NOT silently omit them -- downstream readers must be "
+            "able to tell 'no findings' apart from 'this stack never ran'."
+        )
     parts.append(
         "You are the cross-stack merge agent. Read every artifact above by path -- "
         "do NOT re-run any reviews. Your only output is the merged markdown report."

--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -1,0 +1,142 @@
+"""Prompt builders for deep-review mode.
+
+Pure keyword-only functions that assemble prompt strings from context pointers.
+All context passes via filesystem paths (D-09) -- no full file contents embedded in
+prompts. Per-stack agents only see their own stack's files + TTT context (D-10).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from daydream.phases import (
+    _confidence_and_convention_instructions,
+    _dependency_impact_instructions,
+    _exploration_pointer,
+)
+
+DOC_REVIEW_NOTICE = (
+    "[Notice] Dedicated documentation review (beagle-docs) is planned but not yet "
+    "implemented.\nThese documentation files are currently being reviewed by the "
+    "generic-fallback agent (D-20)."
+)
+
+
+def _context_pointers(
+    *,
+    intent_path: Path,
+    alternatives_path: Path,
+) -> str:
+    """Reference pointers for TTT stage outputs (D-09/D-19 context bus)."""
+    return (
+        f"TTT intent summary is at {intent_path}. Read it before starting your review "
+        f"so your findings align with the author's stated intent.\n"
+        f"TTT alternative-review findings are at {alternatives_path}. Use them as a "
+        f"starting point -- you may deepen, confirm, or dismiss each finding with "
+        f"language-specific evidence."
+    )
+
+
+def _stack_scope_instruction(stack_name: str, files: list[str]) -> str:
+    joined = ", ".join(files)
+    return (
+        f"You are reviewing the {stack_name} stack. Focus ONLY on these files:\n"
+        f"  {joined}\n"
+        f"Do NOT review files from other stacks -- their reviews are running in "
+        f"parallel and will be merged afterwards."
+    )
+
+
+def _diff_instruction(diff_path: Path, files: list[str]) -> str:
+    joined = " ".join(files)
+    return (
+        f"The full diff is at {diff_path}. Focus on changes in your stack's files "
+        f"using:\n"
+        f"  git diff --no-color -- {joined}\n"
+        f"from within the repository root."
+    )
+
+
+def build_per_stack_prompt(
+    *,
+    skill_invocation: str,
+    stack_name: str,
+    files: list[str],
+    diff_path: Path,
+    intent_path: Path,
+    alternatives_path: Path,
+    output_path: Path,
+    exploration_dir: Path | None = None,
+) -> str:
+    """Assemble the per-stack review prompt.
+
+    Args:
+        skill_invocation: Beagle skill invocation, e.g. "/beagle-python:review-python".
+        stack_name: Lower-case stack key for scope messaging.
+        files: Files this stack owns.
+        diff_path: Path to the full diff on disk.
+        intent_path: Path to TTT intent.md.
+        alternatives_path: Path to TTT alternatives.json.
+        output_path: Where the agent must write its review.
+        exploration_dir: Pre-scan exploration directory (if available).
+
+    Returns:
+        Assembled prompt string.
+    """
+    parts: list[str] = []
+    pointer = _exploration_pointer(exploration_dir)
+    if pointer:
+        parts.append(pointer)
+    parts.append(_context_pointers(intent_path=intent_path, alternatives_path=alternatives_path))
+    parts.append(_confidence_and_convention_instructions())
+    parts.append(_dependency_impact_instructions())
+    parts.append(_stack_scope_instruction(stack_name, files))
+    parts.append(_diff_instruction(diff_path, files))
+    parts.append(skill_invocation)
+    parts.append(f"Write your full review to {output_path}.")
+    return "\n\n".join(parts)
+
+
+def build_generic_fallback_prompt(
+    *,
+    files: list[str],
+    diff_path: Path,
+    intent_path: Path,
+    alternatives_path: Path,
+    output_path: Path,
+    exploration_dir: Path | None = None,
+    is_docs_only: bool = False,
+) -> str:
+    """Assemble the generic-fallback review prompt (no skill invocation).
+
+    When is_docs_only=True, prepends the D-20 documentation-review notice.
+
+    Args:
+        files: Files this bucket owns.
+        diff_path: Path to the full diff on disk.
+        intent_path: Path to TTT intent.md.
+        alternatives_path: Path to TTT alternatives.json.
+        output_path: Where the agent must write its review.
+        exploration_dir: Pre-scan exploration directory (if available).
+        is_docs_only: Whether the whole diff is docs-only (D-20).
+
+    Returns:
+        Assembled prompt string.
+    """
+    parts: list[str] = []
+    if is_docs_only:
+        parts.append(DOC_REVIEW_NOTICE)
+    pointer = _exploration_pointer(exploration_dir)
+    if pointer:
+        parts.append(pointer)
+    parts.append(_context_pointers(intent_path=intent_path, alternatives_path=alternatives_path))
+    parts.append(_confidence_and_convention_instructions())
+    parts.append(_dependency_impact_instructions())
+    parts.append(_stack_scope_instruction("generic-fallback", files))
+    parts.append(_diff_instruction(diff_path, files))
+    parts.append(
+        "Review these files for correctness, clarity, and consistency with the "
+        "author's intent. Apply language-agnostic review practices."
+    )
+    parts.append(f"Write your full review to {output_path}.")
+    return "\n\n".join(parts)

--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -97,6 +97,84 @@ def build_per_stack_prompt(
     return "\n\n".join(parts)
 
 
+def build_merge_prompt(
+    *,
+    per_stack_records_paths: list[Path],
+    intent_path: Path,
+    alternatives_path: Path,
+    dedup_candidates_path: Path,
+    output_path: Path,
+    exploration_dir: Path | None = None,
+) -> str:
+    """Assemble the cross-stack merge prompt (D-23..D-27).
+
+    The merged report MUST:
+      - live at output_path (single-file contract, D-24/D-42)
+      - carry a flat globally-numbered ## Issues list (D-25)
+      - have a ## Cross-Stack Issues subsection that CONTINUES the numbering (D-25)
+      - prefix every cross-stack title with the literal "[cross-stack]" (D-26, normative)
+      - collapse duplicates per dedup candidate adjudication (D-27)
+
+    Args:
+        per_stack_records_paths: Parsed per-stack record JSON paths (D-22 inputs).
+        intent_path: Path to TTT intent.md.
+        alternatives_path: Path to TTT alternatives.json.
+        dedup_candidates_path: Path to dedup-candidates.json (D-27 pre-filter output).
+        output_path: Where the merge agent must write the unified report (D-24).
+        exploration_dir: Pre-scan exploration directory (if available).
+
+    Returns:
+        Assembled prompt string.
+    """
+    records_block = "\n".join(f"  - {p}" for p in per_stack_records_paths)
+    parts: list[str] = []
+    pointer = _exploration_pointer(exploration_dir)
+    if pointer:
+        parts.append(pointer)
+    parts.append(
+        f"TTT intent summary: {intent_path}\n"
+        f"TTT alternative-review findings: {alternatives_path}\n"
+        f"Dedup pre-filter candidate pairs: {dedup_candidates_path}\n"
+        f"Per-stack parsed records:\n{records_block}"
+    )
+    parts.append(
+        "You are the cross-stack merge agent. Read every artifact above by path -- "
+        "do NOT re-run any reviews. Your only output is the merged markdown report."
+    )
+    parts.append(
+        "Dedup adjudication:\n"
+        "  - For each candidate pair in dedup-candidates.json, decide whether the two\n"
+        "    findings describe the same concern. If yes, emit ONE entry citing both\n"
+        "    sources as combined evidence. If no, emit both entries independently.\n"
+        "  - Concerns that span multiple stacks (contract drift, shared-type "
+        "mismatches, API-contract misalignment) go in ## Cross-Stack Issues."
+    )
+    parts.append(
+        "Report format (MANDATORY):\n\n"
+        "# Review\n\n"
+        "## Per-Stack Context\n"
+        "(optional human-readable per-stack summaries; phase_parse_feedback ignores "
+        "this section)\n\n"
+        "## Issues\n"
+        "1. [FILE:LINE] TITLE\n"
+        "   rationale / recommendation\n"
+        "2. [FILE:LINE] TITLE\n"
+        "   ...\n\n"
+        "## Cross-Stack Issues\n"
+        "<continues the SAME numbering -- do NOT reset to 1>\n"
+        "N. [cross-stack] [FILE:LINE] TITLE\n"
+        "   rationale citing each per-stack source that contributed\n\n"
+        "Rules:\n"
+        "  - Every cross-stack title MUST begin with the literal prefix [cross-stack].\n"
+        "  - Numbering is flat and global; cross-stack continues per-stack numbering.\n"
+        "  - Per-stack human-readable context may appear above ## Issues under "
+        "## Per-Stack Context, but all actionable issues live in the two lists above.\n"
+        "  - Do not invent issues not supported by the source records."
+    )
+    parts.append(f"Write the complete report to {output_path}.")
+    return "\n\n".join(parts)
+
+
 def build_generic_fallback_prompt(
     *,
     files: list[str],

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -1460,3 +1460,47 @@ async def phase_per_stack_reviews(
             tg.start_soon(_task)
 
     return results
+
+
+async def phase_cross_stack_merge(
+    backend: Backend,
+    cwd: Path,
+    *,
+    per_stack_records_paths: list[Path],
+    intent_path: Path,
+    alternatives_path: Path,
+    dedup_candidates_path: Path,
+    exploration_dir: Path | None = None,
+) -> Path:
+    """Run the cross-stack merge agent and return the output-report path (D-23..D-27).
+
+    Writes the merged markdown report to ``cwd / REVIEW_OUTPUT_FILE`` (D-24/D-42).
+    Per D-38, never passes the ``agents`` kwarg (Codex parity).
+
+    Args:
+        backend: The Backend to execute against.
+        cwd: Target directory (repo root). The report is written here.
+        per_stack_records_paths: Parsed per-stack record JSON paths (D-22 inputs).
+        intent_path: Path to TTT intent.md.
+        alternatives_path: Path to TTT alternatives.json.
+        dedup_candidates_path: Path to dedup-candidates.json (D-27 pre-filter output).
+        exploration_dir: Optional pre-scan exploration directory.
+
+    Returns:
+        Path to the merged report at ``cwd / REVIEW_OUTPUT_FILE``.
+
+    """
+    from daydream.deep.prompts import build_merge_prompt
+
+    output_path = cwd / REVIEW_OUTPUT_FILE
+    prompt = build_merge_prompt(
+        per_stack_records_paths=per_stack_records_paths,
+        intent_path=intent_path,
+        alternatives_path=alternatives_path,
+        dedup_candidates_path=dedup_candidates_path,
+        output_path=output_path,
+        exploration_dir=exploration_dir,
+    )
+    print_phase_hero(console, "MERGE", phase_subtitle("MERGE"))
+    await run_agent(backend, cwd, prompt)
+    return output_path

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -3,7 +3,7 @@
 import subprocess
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import anyio
 
@@ -11,9 +11,13 @@ from daydream.agent import (
     _log_debug,
     console,
     detect_test_success,
+    get_debug_log,
     run_agent,
 )
 from daydream.backends import Backend, ContinuationToken
+
+if TYPE_CHECKING:
+    from daydream.deep.detection import StackAssignment
 from daydream.config import REVIEW_OUTPUT_FILE
 from daydream.ui import (
     ParallelFixPanel,
@@ -1360,3 +1364,99 @@ async def phase_generate_plan(
 
     print_success(console, f"Plan written to {plan_path}")
     return plan_path
+
+
+# -------------------------
+# Deep-mode: per-stack fan-out
+# -------------------------
+
+
+async def phase_per_stack_reviews(
+    backend: Backend,
+    cwd: Path,
+    stacks: list["StackAssignment"],
+    *,
+    diff_path: Path,
+    intent_path: Path,
+    alternatives_path: Path,
+    exploration_dir: Path | None = None,
+) -> dict[str, Path]:
+    """Run one review agent per detected stack concurrently (D-17).
+
+    Mirrors phase_fix_parallel's capacity-limiter + task-group + default-arg closure
+    capture pattern. Per D-38, uses orchestrator-level parallelism -- never passes
+    the ``agents`` kwarg (Codex does not support SDK-level sub-agent spawning).
+
+    Args:
+        backend: The Backend to execute against.
+        cwd: Target directory (repo root).
+        stacks: Routed stack assignments (see daydream.deep.detection.detect_stacks).
+        diff_path: Path to the full diff on disk.
+        intent_path: Path to TTT intent.md.
+        alternatives_path: Path to TTT alternatives.json.
+        exploration_dir: Optional pre-scan exploration directory.
+
+    Returns:
+        Mapping of stack_name -> per-stack review output Path for stacks that
+        completed successfully. A stack with an agent failure is omitted from the
+        returned dict (its exception is logged via get_debug_log).
+
+    """
+    from daydream.deep.artifacts import deep_dir as _deep_dir
+    from daydream.deep.artifacts import per_stack_review_path
+    from daydream.deep.prompts import (
+        build_generic_fallback_prompt,
+        build_per_stack_prompt,
+    )
+
+    deep_dir_path = _deep_dir(cwd)
+    results: dict[str, Path] = {}
+    limiter = anyio.CapacityLimiter(4)
+
+    async with anyio.create_task_group() as tg:
+        for stack in stacks:
+            output_path = per_stack_review_path(deep_dir_path, stack.stack_name)
+            if stack.skill_invocation is None:
+                prompt = build_generic_fallback_prompt(
+                    files=stack.files,
+                    diff_path=diff_path,
+                    intent_path=intent_path,
+                    alternatives_path=alternatives_path,
+                    output_path=output_path,
+                    exploration_dir=exploration_dir,
+                    is_docs_only=stack.is_docs_only,
+                )
+            else:
+                prompt = build_per_stack_prompt(
+                    skill_invocation=stack.skill_invocation,
+                    stack_name=stack.stack_name,
+                    files=stack.files,
+                    diff_path=diff_path,
+                    intent_path=intent_path,
+                    alternatives_path=alternatives_path,
+                    output_path=output_path,
+                    exploration_dir=exploration_dir,
+                )
+
+            # Default-arg capture -- prevents late-binding closure bug (Pitfall 2).
+            async def _task(
+                stack_name: str = stack.stack_name,
+                task_prompt: str = prompt,
+                task_output: Path = output_path,
+            ) -> None:
+                try:
+                    async with limiter:
+                        await run_agent(backend, cwd, task_prompt)
+                    results[stack_name] = task_output
+                except Exception as e:  # noqa: BLE001 -- intentionally broad for parallel isolation
+                    debug = get_debug_log()
+                    if debug is not None:
+                        debug.write(
+                            f"[STAGE] per-stack {stack_name} failed: "
+                            f"{type(e).__name__}: {e}\n"
+                        )
+                        debug.flush()
+
+            tg.start_soon(_task)
+
+    return results

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -1380,7 +1380,7 @@ async def phase_per_stack_reviews(
     intent_path: Path,
     alternatives_path: Path,
     exploration_dir: Path | None = None,
-) -> dict[str, Path]:
+) -> tuple[dict[str, Path], dict[str, str]]:
     """Run one review agent per detected stack concurrently (D-17).
 
     Mirrors phase_fix_parallel's capacity-limiter + task-group + default-arg closure
@@ -1397,9 +1397,13 @@ async def phase_per_stack_reviews(
         exploration_dir: Optional pre-scan exploration directory.
 
     Returns:
-        Mapping of stack_name -> per-stack review output Path for stacks that
-        completed successfully. A stack with an agent failure is omitted from the
-        returned dict (its exception is logged via get_debug_log).
+        Tuple of ``(successes, failures)``:
+          - ``successes``: stack_name -> per-stack review output Path for stacks
+            that produced a review.
+          - ``failures``: stack_name -> "<ExceptionType>: <message>" for stacks
+            whose agent raised. Callers MUST surface this to the user and to the
+            merge agent so that missing coverage is visible instead of silently
+            dropped.
 
     """
     from daydream.deep.artifacts import deep_dir as _deep_dir
@@ -1411,6 +1415,7 @@ async def phase_per_stack_reviews(
 
     deep_dir_path = _deep_dir(cwd)
     results: dict[str, Path] = {}
+    failures: dict[str, str] = {}
     limiter = anyio.CapacityLimiter(4)
 
     async with anyio.create_task_group() as tg:
@@ -1449,17 +1454,25 @@ async def phase_per_stack_reviews(
                         await run_agent(backend, cwd, task_prompt)
                     results[stack_name] = task_output
                 except Exception as e:  # noqa: BLE001 -- intentionally broad for parallel isolation
+                    reason = f"{type(e).__name__}: {e}"
+                    failures[stack_name] = reason
                     debug = get_debug_log()
                     if debug is not None:
                         debug.write(
-                            f"[STAGE] per-stack {stack_name} failed: "
-                            f"{type(e).__name__}: {e}\n"
+                            f"[STAGE] per-stack {stack_name} failed: {reason}\n"
                         )
                         debug.flush()
+                    # Surface to the user so a dropped stack isn't invisible
+                    # outside the debug log.
+                    print_warning(
+                        console,
+                        f"Per-stack review for '{stack_name}' failed ({reason}); "
+                        "merge report will note this stack as uncovered.",
+                    )
 
             tg.start_soon(_task)
 
-    return results
+    return results, failures
 
 
 async def phase_cross_stack_merge(
@@ -1471,6 +1484,7 @@ async def phase_cross_stack_merge(
     alternatives_path: Path,
     dedup_candidates_path: Path,
     exploration_dir: Path | None = None,
+    failed_stacks: dict[str, str] | None = None,
 ) -> Path:
     """Run the cross-stack merge agent and return the output-report path (D-23..D-27).
 
@@ -1485,6 +1499,9 @@ async def phase_cross_stack_merge(
         alternatives_path: Path to TTT alternatives.json.
         dedup_candidates_path: Path to dedup-candidates.json (D-27 pre-filter output).
         exploration_dir: Optional pre-scan exploration directory.
+        failed_stacks: Optional stack_name -> reason dict for per-stack agents
+            that failed. Passed through to the merge prompt so the merged
+            report can call out uncovered stacks explicitly.
 
     Returns:
         Path to the merged report at ``cwd / REVIEW_OUTPUT_FILE``.
@@ -1500,6 +1517,7 @@ async def phase_cross_stack_merge(
         dedup_candidates_path=dedup_candidates_path,
         output_path=output_path,
         exploration_dir=exploration_dir,
+        failed_stacks=failed_stacks,
     )
     print_phase_hero(console, "MERGE", phase_subtitle("MERGE"))
     await run_agent(backend, cwd, prompt)

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -713,12 +713,24 @@ async def phase_review(
         print_warning(console, "Review output file was not created")
 
 
-async def phase_parse_feedback(backend: Backend, cwd: Path) -> list[dict[str, Any]]:
+async def phase_parse_feedback(
+    backend: Backend,
+    cwd: Path,
+    *,
+    input_path: Path | None = None,
+) -> list[dict[str, Any]]:
     """Phase 2: Parse feedback from review output and return validated items.
 
     Args:
         backend: The Backend to execute against.
-        cwd: Working directory containing the review output
+        cwd: Working directory containing the review output (also used as the
+            agent's cwd).
+        input_path: Optional explicit path to the review markdown to parse.
+            When None (default), reads ``cwd / REVIEW_OUTPUT_FILE``, preserving
+            behavior for single-skill, PR feedback, and TTT flows. When
+            provided, reads that path instead — used by deep-mode's pre-merge
+            parse stage to iterate per-stack outputs without overwriting each
+            other at the shared REVIEW_OUTPUT_FILE location.
 
     Returns:
         List of validated feedback items with id, description, file, line
@@ -730,7 +742,7 @@ async def phase_parse_feedback(backend: Backend, cwd: Path) -> list[dict[str, An
     print_phase_hero(console, "REFLECT", phase_subtitle("REFLECT"))
 
     # Use absolute path to prevent model hallucination of paths from training data
-    review_output_path = cwd / REVIEW_OUTPUT_FILE
+    review_output_path = input_path if input_path is not None else cwd / REVIEW_OUTPUT_FILE
     prompt = f"""Read the review output file at {review_output_path}.
 
 Extract ONLY actionable issues that need fixing. Skip these sections entirely:

--- a/daydream/pr_review.py
+++ b/daydream/pr_review.py
@@ -405,16 +405,37 @@ def resolve_line(
 
 
 _HUNK_HEADER = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@", re.MULTILINE)
+# Splits a unified diff on each `diff --git` header so we can pick out the
+# block for a single file from a full-PR diff.
+_DIFF_BLOCK_SPLIT = re.compile(r"(?m)^(?=diff --git )")
 
 
 def file_hunks(
-    target_dir: Path, base_sha: str, head_sha: str, path: str
+    target_dir: Path,
+    base_sha: str,
+    head_sha: str,
+    path: str,
+    *,
+    pr_number: int | None = None,
 ) -> list[tuple[int, int]]:
     """Return (start, end) inclusive line ranges on the head side for `path`.
 
-    Falls back to `gh pr diff` if `git diff` can't resolve `base_sha`
-    (common when the base has been rewritten upstream).
+    Primary path: ``git diff <base_sha>..<head_sha> -- <path>``.
+
+    Fallback path: when the git invocation fails (returncode != 0 or raises --
+    common when ``base_sha`` has been rewritten out of the local history) and a
+    ``pr_number`` is available, re-derive the hunks from ``gh pr diff <num>``.
+    The gh diff is a full PR diff, so we slice out the block for ``path``
+    before parsing hunks to avoid attributing other files' hunks to this one.
+
+    Args:
+        target_dir: Repo root.
+        base_sha: Base commit SHA (may be unreachable locally after a rebase).
+        head_sha: Head commit SHA.
+        path: Repo-relative file path.
+        pr_number: Optional PR number; enables the ``gh pr diff`` fallback.
     """
+    git_failed = False
     try:
         r = _run(
             [
@@ -428,10 +449,44 @@ def file_hunks(
             target_dir,
             timeout=20,
         )
-        diff_text = r.stdout.decode(errors="replace") if r.returncode == 0 else ""
+        if r.returncode == 0:
+            diff_text = r.stdout.decode(errors="replace")
+        else:
+            git_failed = True
+            diff_text = ""
     except (subprocess.SubprocessError, OSError):
+        git_failed = True
         diff_text = ""
+
+    if git_failed and pr_number is not None:
+        diff_text = _gh_pr_diff_for_path(target_dir, pr_number, path)
+
     return _parse_hunks(diff_text)
+
+
+def _gh_pr_diff_for_path(target_dir: Path, pr_number: int, path: str) -> str:
+    """Fetch the PR's full diff via `gh pr diff` and return just the block for `path`."""
+    try:
+        r = _run(
+            ["gh", "pr", "diff", str(pr_number)],
+            target_dir,
+            timeout=30,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return ""
+    if r.returncode != 0:
+        return ""
+    full_diff = r.stdout.decode(errors="replace")
+    # Pick the `diff --git a/<path> b/<path>` block.
+    needle_a = f"a/{path} "
+    needle_b = f"b/{path}\n"
+    for block in _DIFF_BLOCK_SPLIT.split(full_diff):
+        if not block.startswith("diff --git "):
+            continue
+        header_line = block.split("\n", 1)[0]
+        if needle_a in header_line or header_line.endswith(f"b/{path}") or needle_b in header_line:
+            return block
+    return ""
 
 
 def _parse_hunks(diff_text: str) -> list[tuple[int, int]]:
@@ -468,7 +523,11 @@ def classify(
             continue
         if issue.path not in hunks_cache:
             hunks_cache[issue.path] = file_hunks(
-                target_dir, pr.base_sha, pr.head_sha, issue.path
+                target_dir,
+                pr.base_sha,
+                pr.head_sha,
+                issue.path,
+                pr_number=pr.number,
             )
         if not within_hunk(line, hunks_cache[issue.path]):
             out.body_only.append(issue)

--- a/daydream/pr_review.py
+++ b/daydream/pr_review.py
@@ -43,6 +43,8 @@ class ParsedIssue:
         title: Short issue title (first line of the body).
         body: Full issue body (rationale + recommendation).
         is_cross_stack: True when the issue spans multiple stacks.
+        confidence: Normalised HIGH / MEDIUM / LOW, if known.
+        severity: Normalised high / medium / low, if known.
     """
 
     path: str
@@ -50,6 +52,8 @@ class ParsedIssue:
     title: str
     body: str
     is_cross_stack: bool = False
+    confidence: str | None = None
+    severity: str | None = None
 
 
 @dataclass
@@ -69,6 +73,9 @@ class PRInfo:
 class _ClassifiedIssues:
     inline: list[dict[str, Any]] = field(default_factory=list)
     body_only: list[ParsedIssue] = field(default_factory=list)
+    # Parallel list to `inline`: the original ParsedIssue for each inline
+    # comment. Used to roll severity/confidence into the summary body.
+    inline_issues: list[ParsedIssue] = field(default_factory=list)
 
 
 # --- Public entry points ----------------------------------------------------
@@ -79,7 +86,7 @@ async def post_review_to_pr_from_report(
     report_path: Path,
     *,
     console: Console,
-    summary_prefix: str = "",
+    mode_label: str = "deep review",
 ) -> None:
     """Parse a deep-mode `.review-output.md` and offer to post to the PR.
 
@@ -87,7 +94,7 @@ async def post_review_to_pr_from_report(
         target_dir: Repo root.
         report_path: Path to the merged review report.
         console: Rich console for user-facing output.
-        summary_prefix: Optional text prepended to the review body.
+        mode_label: Short label for the review mode (used in body template).
     """
     if not report_path.exists():
         return
@@ -96,12 +103,7 @@ async def post_review_to_pr_from_report(
     if not issues:
         print_info(console, "No parseable issues in review output; skipping PR post.")
         return
-    await _post(
-        target_dir,
-        issues,
-        console=console,
-        summary_prefix=summary_prefix or "Daydream deep review findings.",
-    )
+    await _post(target_dir, issues, console=console, mode_label=mode_label)
 
 
 async def post_review_to_pr_from_alt_issues(
@@ -109,7 +111,7 @@ async def post_review_to_pr_from_alt_issues(
     alt_issues: list[dict[str, Any]],
     *,
     console: Console,
-    summary_prefix: str = "",
+    mode_label: str = "trust-the-technology",
 ) -> None:
     """Convert alt-review issues (from `--ttt`) and offer to post to the PR.
 
@@ -117,17 +119,12 @@ async def post_review_to_pr_from_alt_issues(
         target_dir: Repo root.
         alt_issues: Issue dicts from `phase_alternative_review`.
         console: Rich console for user-facing output.
-        summary_prefix: Optional text prepended to the review body.
+        mode_label: Short label for the review mode (used in body template).
     """
     issues = alt_issues_to_parsed(alt_issues)
     if not issues:
         return
-    await _post(
-        target_dir,
-        issues,
-        console=console,
-        summary_prefix=summary_prefix or "Daydream trust-the-technology findings.",
-    )
+    await _post(target_dir, issues, console=console, mode_label=mode_label)
 
 
 # --- Parsers ---------------------------------------------------------------
@@ -135,6 +132,17 @@ async def post_review_to_pr_from_alt_issues(
 
 _ISSUES_HEADER = re.compile(r"^## (?:Cross-Stack Issues|Issues)\s*$", re.MULTILINE)
 _XSTACK_HEADER = re.compile(r"^## Cross-Stack Issues\s*$", re.MULTILINE)
+# Tolerates bold markers in either position: "**Confidence:** HIGH",
+# "**Confidence**: HIGH", or bare "Confidence: HIGH".
+_CONFIDENCE_LINE = re.compile(
+    r"[Cc]onfidence[:*\s]+(HIGH|MEDIUM|LOW|High|Medium|Low|high|medium|low)"
+)
+_SEVERITY_LINE = re.compile(
+    r"[Ss]everity[:*\s]+(high|medium|low|HIGH|MEDIUM|LOW|High|Medium|Low)"
+)
+
+DAYDREAM_REPO_URL = "https://github.com/existential-birds/daydream"
+DAYDREAM_FOOTER = f"<sub>🧙 Posted by [daydream]({DAYDREAM_REPO_URL})</sub>"
 _NEXT_SECTION = re.compile(r"^## ", re.MULTILINE)
 # Matches "N. [path:line] Title" or "N. [path] Title" with optional
 # leading `[cross-stack]` marker.
@@ -181,10 +189,22 @@ def parse_report(text: str) -> list[ParsedIssue]:
                     title=title,
                     body=body,
                     is_cross_stack=section_is_xstack or title.lower().startswith("[cross-stack]"),
+                    confidence=_extract_confidence(body),
+                    severity=_extract_severity(body),
                 )
             )
 
     return issues
+
+
+def _extract_confidence(text: str) -> str | None:
+    m = _CONFIDENCE_LINE.search(text)
+    return m.group(1).upper() if m else None
+
+
+def _extract_severity(text: str) -> str | None:
+    m = _SEVERITY_LINE.search(text)
+    return m.group(1).lower() if m else None
 
 
 def alt_issues_to_parsed(alt_issues: list[dict[str, Any]]) -> list[ParsedIssue]:
@@ -202,17 +222,29 @@ def alt_issues_to_parsed(alt_issues: list[dict[str, Any]]) -> list[ParsedIssue]:
         title = str(raw.get("title", "")).strip()
         description = str(raw.get("description", "")).strip()
         recommendation = str(raw.get("recommendation", "")).strip()
-        severity = str(raw.get("severity", "")).strip()
+        severity = str(raw.get("severity", "")).strip().lower() or None
+        confidence = str(raw.get("confidence", "")).strip().upper() or None
         body_parts = []
         if severity:
             body_parts.append(f"**Severity:** {severity}")
+        if confidence:
+            body_parts.append(f"**Confidence:** {confidence}")
         if description:
             body_parts.append(description)
         if recommendation:
             body_parts.append(f"**Recommendation:** {recommendation}")
         body = "\n\n".join(body_parts)
         for path in files:
-            out.append(ParsedIssue(path=str(path), line=None, title=title, body=body))
+            out.append(
+                ParsedIssue(
+                    path=str(path),
+                    line=None,
+                    title=title,
+                    body=body,
+                    confidence=confidence,
+                    severity=severity,
+                )
+            )
     return out
 
 
@@ -449,12 +481,25 @@ def classify(
                 "body": _format_inline_body(issue),
             }
         )
+        out.inline_issues.append(issue)
     return out
 
 
 def _format_inline_body(issue: ParsedIssue) -> str:
     header = f"**{issue.title}**" if issue.title else ""
-    return f"{header}\n\n{issue.body}".strip()
+    tags = _format_tag_line(issue)
+    parts = [p for p in (header, tags, issue.body) if p]
+    return "\n\n".join(parts + [DAYDREAM_FOOTER]).strip()
+
+
+def _format_tag_line(issue: ParsedIssue) -> str:
+    """Render severity/confidence badges for a single issue, if set."""
+    bits: list[str] = []
+    if issue.severity:
+        bits.append(f"severity: `{issue.severity}`")
+    if issue.confidence:
+        bits.append(f"confidence: `{issue.confidence}`")
+    return " · ".join(bits)
 
 
 def _format_body_section(body_only: list[ParsedIssue]) -> str:
@@ -464,25 +509,75 @@ def _format_body_section(body_only: list[ParsedIssue]) -> str:
     for issue in body_only:
         prefix = "[cross-stack] " if issue.is_cross_stack else ""
         loc = f"`{issue.path}`" + (f":{issue.line}" if issue.line else "")
-        lines.append(f"### {prefix}{issue.title} ({loc})\n\n{issue.body}\n")
+        tags = _format_tag_line(issue)
+        tag_block = f"\n{tags}\n" if tags else ""
+        lines.append(f"### {prefix}{issue.title} ({loc})\n{tag_block}\n{issue.body}\n")
     return "\n".join(lines)
 
 
+def _count_labels(
+    issues: list[ParsedIssue], attr: str, order: tuple[str, ...]
+) -> list[str]:
+    """Return ordered `N LABEL` strings for non-empty counts."""
+    counts: dict[str, int] = {}
+    for issue in issues:
+        val = getattr(issue, attr)
+        if val:
+            counts[val] = counts.get(val, 0) + 1
+    out: list[str] = []
+    for key in order:
+        n = counts.get(key, 0)
+        if n:
+            out.append(f"{n} {key}")
+    return out
+
+
 def build_payload(
-    pr: PRInfo, summary_prefix: str, classified: _ClassifiedIssues
+    pr: PRInfo, mode_label: str, classified: _ClassifiedIssues
 ) -> dict[str, Any]:
-    """Assemble the review payload for `POST /repos/.../pulls/<n>/reviews`."""
-    body_chunks = []
-    if summary_prefix:
-        body_chunks.append(summary_prefix.strip())
+    """Assemble the review payload for `POST /repos/.../pulls/<n>/reviews`.
+
+    The review body follows a fixed template so every run looks the same:
+        🧙 Daydream <mode_label> review
+        N inline, M non-inline
+        Severity / Confidence breakdowns (when known)
+        Non-inline findings (when any)
+        Repo link footer
+    """
+    all_issues_with_inline_meta = [*classified.body_only]
+    # Inline comments live as dicts in classified.inline; we still want
+    # their confidence/severity in the summary counts, so peek at the
+    # original ParsedIssue list by cross-referencing path+line is brittle.
+    # Instead, carry counts we already have from body_only plus inline
+    # metadata we stamp at classify time via the ParsedIssue objects.
+    # (See classify: we store the original issue on _ClassifiedIssues.)
+    all_issues_with_inline_meta.extend(classified.inline_issues)
+
     inline_count = len(classified.inline)
     body_count = len(classified.body_only)
-    body_chunks.append(
-        f"{inline_count} inline comment(s), {body_count} non-inline finding(s)."
+
+    body_chunks: list[str] = []
+    body_chunks.append(f"🧙 [Daydream]({DAYDREAM_REPO_URL}) {mode_label} review")
+    body_chunks.append(f"{inline_count} inline comment(s), {body_count} non-inline finding(s).")
+
+    severity_parts = _count_labels(
+        all_issues_with_inline_meta, "severity", ("high", "medium", "low")
     )
+    if severity_parts:
+        body_chunks.append("**Severity:** " + ", ".join(severity_parts))
+
+    confidence_parts = _count_labels(
+        all_issues_with_inline_meta, "confidence", ("HIGH", "MEDIUM", "LOW")
+    )
+    if confidence_parts:
+        body_chunks.append("**Confidence:** " + ", ".join(confidence_parts))
+
     body_section = _format_body_section(classified.body_only)
     if body_section:
         body_chunks.append(body_section)
+
+    body_chunks.append(DAYDREAM_FOOTER)
+
     payload: dict[str, Any] = {
         "commit_id": pr.head_sha,
         "event": "COMMENT",
@@ -500,7 +595,7 @@ async def _post(
     issues: list[ParsedIssue],
     *,
     console: Console,
-    summary_prefix: str,
+    mode_label: str,
 ) -> None:
     pr = find_open_pr(target_dir)
     if pr is None:
@@ -528,7 +623,7 @@ async def _post(
         print_info(console, "Skipped posting to PR.")
         return
 
-    payload = build_payload(pr, summary_prefix, classified)
+    payload = build_payload(pr, mode_label, classified)
     with tempfile.NamedTemporaryFile(
         mode="w",
         prefix=f"pr-{pr.number}-review-",

--- a/daydream/pr_review.py
+++ b/daydream/pr_review.py
@@ -1,0 +1,582 @@
+"""Post daydream review findings as inline comments on the current branch's PR.
+
+Shared by deep-review mode (parses `.review-output.md`) and
+trust-the-technology mode (consumes alt-review issues directly).
+
+Flow:
+    1. Locate the open PR for the current branch via `gh pr list`.
+    2. Parse issues (from report markdown or alt-issue dicts).
+    3. Resolve each issue to a real head-SHA line via anchor grep.
+    4. Classify into inline (line within a diff hunk) vs body-only.
+    5. Build a single review payload, show a summary, ask y/n.
+    6. On yes, POST to `/repos/<owner>/<repo>/pulls/<num>/reviews`.
+
+Everything is best-effort: failures warn and return, never raise.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from daydream.ui import print_info, print_success, print_warning, prompt_user
+
+if TYPE_CHECKING:
+    from rich.console import Console
+
+
+# --- Data shapes ------------------------------------------------------------
+
+
+@dataclass
+class ParsedIssue:
+    """One issue to evaluate for PR posting.
+
+    Attributes:
+        path: File path relative to repo root.
+        line: Line hint from the source, if any. May be stale.
+        title: Short issue title (first line of the body).
+        body: Full issue body (rationale + recommendation).
+        is_cross_stack: True when the issue spans multiple stacks.
+    """
+
+    path: str
+    line: int | None
+    title: str
+    body: str
+    is_cross_stack: bool = False
+
+
+@dataclass
+class PRInfo:
+    """Details about the open PR for the current branch."""
+
+    number: int
+    head_sha: str
+    base_sha: str
+    base_ref: str
+    owner: str
+    repo: str
+    url: str
+
+
+@dataclass
+class _ClassifiedIssues:
+    inline: list[dict[str, Any]] = field(default_factory=list)
+    body_only: list[ParsedIssue] = field(default_factory=list)
+
+
+# --- Public entry points ----------------------------------------------------
+
+
+async def post_review_to_pr_from_report(
+    target_dir: Path,
+    report_path: Path,
+    *,
+    console: Console,
+    summary_prefix: str = "",
+) -> None:
+    """Parse a deep-mode `.review-output.md` and offer to post to the PR.
+
+    Args:
+        target_dir: Repo root.
+        report_path: Path to the merged review report.
+        console: Rich console for user-facing output.
+        summary_prefix: Optional text prepended to the review body.
+    """
+    if not report_path.exists():
+        return
+    text = report_path.read_text()
+    issues = parse_report(text)
+    if not issues:
+        print_info(console, "No parseable issues in review output; skipping PR post.")
+        return
+    await _post(
+        target_dir,
+        issues,
+        console=console,
+        summary_prefix=summary_prefix or "Daydream deep review findings.",
+    )
+
+
+async def post_review_to_pr_from_alt_issues(
+    target_dir: Path,
+    alt_issues: list[dict[str, Any]],
+    *,
+    console: Console,
+    summary_prefix: str = "",
+) -> None:
+    """Convert alt-review issues (from `--ttt`) and offer to post to the PR.
+
+    Args:
+        target_dir: Repo root.
+        alt_issues: Issue dicts from `phase_alternative_review`.
+        console: Rich console for user-facing output.
+        summary_prefix: Optional text prepended to the review body.
+    """
+    issues = alt_issues_to_parsed(alt_issues)
+    if not issues:
+        return
+    await _post(
+        target_dir,
+        issues,
+        console=console,
+        summary_prefix=summary_prefix or "Daydream trust-the-technology findings.",
+    )
+
+
+# --- Parsers ---------------------------------------------------------------
+
+
+_ISSUES_HEADER = re.compile(r"^## (?:Cross-Stack Issues|Issues)\s*$", re.MULTILINE)
+_XSTACK_HEADER = re.compile(r"^## Cross-Stack Issues\s*$", re.MULTILINE)
+_NEXT_SECTION = re.compile(r"^## ", re.MULTILINE)
+# Matches "N. [path:line] Title" or "N. [path] Title" with optional
+# leading `[cross-stack]` marker.
+_ISSUE_HEAD = re.compile(
+    r"^(?P<num>\d+)\.\s+"
+    r"(?:\[cross-stack\]\s+)?"
+    r"\[(?P<path>[^\]:]+)(?::(?P<line>\d+))?\]\s+"
+    r"(?P<title>.+?)\s*$",
+    re.MULTILINE,
+)
+
+
+def parse_report(text: str) -> list[ParsedIssue]:
+    """Extract issues from a deep-mode merged review report.
+
+    Recognises the `## Issues` and `## Cross-Stack Issues` sections and
+    reads each numbered entry. Cross-stack entries (or entries whose
+    title starts with `[cross-stack]`) are tagged accordingly.
+    """
+    issues: list[ParsedIssue] = []
+    xstack_match = _XSTACK_HEADER.search(text)
+    xstack_start = xstack_match.start() if xstack_match else -1
+
+    for header_match in _ISSUES_HEADER.finditer(text):
+        section_start = header_match.end()
+        # Find where this section ends (next "## " or EOF).
+        rest = text[section_start:]
+        next_section = _NEXT_SECTION.search(rest)
+        section_end = section_start + next_section.start() if next_section else len(text)
+        section_text = text[section_start:section_end]
+        section_is_xstack = header_match.start() == xstack_start
+
+        matches = list(_ISSUE_HEAD.finditer(section_text))
+        for i, m in enumerate(matches):
+            body_start = m.end()
+            body_end = matches[i + 1].start() if i + 1 < len(matches) else len(section_text)
+            body = section_text[body_start:body_end].strip()
+            title = m.group("title").strip()
+            line_str = m.group("line")
+            issues.append(
+                ParsedIssue(
+                    path=m.group("path").strip(),
+                    line=int(line_str) if line_str else None,
+                    title=title,
+                    body=body,
+                    is_cross_stack=section_is_xstack or title.lower().startswith("[cross-stack]"),
+                )
+            )
+
+    return issues
+
+
+def alt_issues_to_parsed(alt_issues: list[dict[str, Any]]) -> list[ParsedIssue]:
+    """Convert `phase_alternative_review` dicts into ParsedIssue objects.
+
+    Alt issues have a `files: list[str]` field and no line hint. When
+    multiple files are listed we emit one issue per file (classifier will
+    fold file-level issues into the review body).
+    """
+    out: list[ParsedIssue] = []
+    for raw in alt_issues:
+        files = raw.get("files") or []
+        if not files:
+            continue
+        title = str(raw.get("title", "")).strip()
+        description = str(raw.get("description", "")).strip()
+        recommendation = str(raw.get("recommendation", "")).strip()
+        severity = str(raw.get("severity", "")).strip()
+        body_parts = []
+        if severity:
+            body_parts.append(f"**Severity:** {severity}")
+        if description:
+            body_parts.append(description)
+        if recommendation:
+            body_parts.append(f"**Recommendation:** {recommendation}")
+        body = "\n\n".join(body_parts)
+        for path in files:
+            out.append(ParsedIssue(path=str(path), line=None, title=title, body=body))
+    return out
+
+
+# --- Git / gh helpers ------------------------------------------------------
+
+
+def _run(
+    cmd: list[str], cwd: Path, *, timeout: int = 15, input_bytes: bytes | None = None
+) -> subprocess.CompletedProcess[bytes]:
+    """Run a subprocess with bytes IO; all args hardcoded or derived from JSON."""
+    return subprocess.run(  # noqa: S603 - args are hardcoded or from parsed gh/git output
+        cmd,
+        cwd=cwd,
+        capture_output=True,
+        input=input_bytes,
+        timeout=timeout,
+        shell=False,
+    )
+
+
+def _current_branch(target_dir: Path) -> str | None:
+    try:
+        r = _run(["git", "branch", "--show-current"], target_dir, timeout=5)
+        return r.stdout.decode().strip() or None
+    except (subprocess.SubprocessError, OSError):
+        return None
+
+
+def find_open_pr(target_dir: Path) -> PRInfo | None:
+    """Locate the open PR for the current branch. Returns None if not found."""
+    branch = _current_branch(target_dir)
+    if not branch:
+        return None
+    try:
+        r = _run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--head",
+                branch,
+                "--state",
+                "open",
+                "--json",
+                "number,headRefOid,baseRefOid,baseRefName,url,headRepository,headRepositoryOwner",
+            ],
+            target_dir,
+            timeout=15,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    if r.returncode != 0:
+        return None
+    try:
+        rows = json.loads(r.stdout.decode() or "[]")
+    except json.JSONDecodeError:
+        return None
+    if not rows:
+        return None
+    row = rows[0]
+    # Owner/repo lookup via `gh repo view` (handles fork cases cleanly).
+    owner, repo = _repo_owner_name(target_dir)
+    if owner is None or repo is None:
+        return None
+    return PRInfo(
+        number=int(row["number"]),
+        head_sha=row["headRefOid"],
+        base_sha=row["baseRefOid"],
+        base_ref=row.get("baseRefName", ""),
+        owner=owner,
+        repo=repo,
+        url=row.get("url", ""),
+    )
+
+
+def _repo_owner_name(target_dir: Path) -> tuple[str | None, str | None]:
+    try:
+        r = _run(
+            ["gh", "repo", "view", "--json", "owner,name"],
+            target_dir,
+            timeout=10,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None, None
+    if r.returncode != 0:
+        return None, None
+    try:
+        data = json.loads(r.stdout.decode())
+    except json.JSONDecodeError:
+        return None, None
+    owner = data.get("owner", {}).get("login")
+    name = data.get("name")
+    return owner, name
+
+
+# --- Line resolution + hunk classification --------------------------------
+
+
+_ANCHOR_TOKEN = re.compile(r"`([^`\n]{3,80})`|\b([A-Za-z_][A-Za-z0-9_]{4,})\b")
+
+
+def extract_anchors(issue: ParsedIssue) -> list[str]:
+    """Pull candidate anchor tokens from an issue body (longest first).
+
+    Prefers backtick-quoted identifiers (e.g. `foo_bar`) since those are
+    the most specific signals of code the reviewer cited. Falls back to
+    any alphanumeric word of length >=5.
+    """
+    seen: list[str] = []
+    for m in _ANCHOR_TOKEN.finditer(f"{issue.title}\n{issue.body}"):
+        token = m.group(1) or m.group(2)
+        if token and token not in seen:
+            seen.append(token)
+    # Longest-first improves hit quality (generic words lose to identifiers).
+    seen.sort(key=len, reverse=True)
+    return seen[:8]
+
+
+def resolve_line(
+    target_dir: Path, head_sha: str, issue: ParsedIssue
+) -> int | None:
+    """Resolve the true line in the head commit for an issue.
+
+    Tries (in order):
+      1. If the issue has a line hint, verify the anchor appears within
+         +/-5 lines; trust it on match.
+      2. Otherwise search the whole file at head for the first anchor hit.
+    Returns None if the file doesn't exist at head or no anchor matches.
+    """
+    try:
+        r = _run(["git", "show", f"{head_sha}:{issue.path}"], target_dir, timeout=10)
+    except (subprocess.SubprocessError, OSError):
+        return None
+    if r.returncode != 0:
+        return None
+    lines = r.stdout.decode(errors="replace").splitlines()
+    if not lines:
+        return None
+
+    anchors = extract_anchors(issue)
+
+    # Step 1: verify hint.
+    if issue.line is not None and 1 <= issue.line <= len(lines):
+        for anchor in anchors:
+            lo = max(1, issue.line - 5)
+            hi = min(len(lines), issue.line + 5)
+            if any(anchor in lines[i - 1] for i in range(lo, hi + 1)):
+                return issue.line
+        # Hint didn't verify; fall through to full-file search.
+
+    # Step 2: full-file search.
+    for anchor in anchors:
+        for i, line in enumerate(lines, start=1):
+            if anchor in line:
+                return i
+
+    return None
+
+
+_HUNK_HEADER = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@", re.MULTILINE)
+
+
+def file_hunks(
+    target_dir: Path, base_sha: str, head_sha: str, path: str
+) -> list[tuple[int, int]]:
+    """Return (start, end) inclusive line ranges on the head side for `path`.
+
+    Falls back to `gh pr diff` if `git diff` can't resolve `base_sha`
+    (common when the base has been rewritten upstream).
+    """
+    try:
+        r = _run(
+            [
+                "git",
+                "diff",
+                "--unified=3",
+                f"{base_sha}..{head_sha}",
+                "--",
+                path,
+            ],
+            target_dir,
+            timeout=20,
+        )
+        diff_text = r.stdout.decode(errors="replace") if r.returncode == 0 else ""
+    except (subprocess.SubprocessError, OSError):
+        diff_text = ""
+    return _parse_hunks(diff_text)
+
+
+def _parse_hunks(diff_text: str) -> list[tuple[int, int]]:
+    hunks: list[tuple[int, int]] = []
+    for m in _HUNK_HEADER.finditer(diff_text):
+        start = int(m.group(1))
+        count = int(m.group(2)) if m.group(2) else 1
+        if count == 0:
+            continue
+        hunks.append((start, start + count - 1))
+    return hunks
+
+
+def within_hunk(line: int, hunks: list[tuple[int, int]], tolerance: int = 3) -> bool:
+    return any(start - tolerance <= line <= end + tolerance for start, end in hunks)
+
+
+# --- Classification + payload build ---------------------------------------
+
+
+def classify(
+    target_dir: Path, pr: PRInfo, issues: list[ParsedIssue]
+) -> _ClassifiedIssues:
+    """Split issues into inline vs body-only based on diff hunks."""
+    out = _ClassifiedIssues()
+    hunks_cache: dict[str, list[tuple[int, int]]] = {}
+    for issue in issues:
+        if issue.is_cross_stack:
+            out.body_only.append(issue)
+            continue
+        line = resolve_line(target_dir, pr.head_sha, issue)
+        if line is None:
+            out.body_only.append(issue)
+            continue
+        if issue.path not in hunks_cache:
+            hunks_cache[issue.path] = file_hunks(
+                target_dir, pr.base_sha, pr.head_sha, issue.path
+            )
+        if not within_hunk(line, hunks_cache[issue.path]):
+            out.body_only.append(issue)
+            continue
+        out.inline.append(
+            {
+                "path": issue.path,
+                "line": line,
+                "side": "RIGHT",
+                "body": _format_inline_body(issue),
+            }
+        )
+    return out
+
+
+def _format_inline_body(issue: ParsedIssue) -> str:
+    header = f"**{issue.title}**" if issue.title else ""
+    return f"{header}\n\n{issue.body}".strip()
+
+
+def _format_body_section(body_only: list[ParsedIssue]) -> str:
+    if not body_only:
+        return ""
+    lines = ["## Non-inline findings\n"]
+    for issue in body_only:
+        prefix = "[cross-stack] " if issue.is_cross_stack else ""
+        loc = f"`{issue.path}`" + (f":{issue.line}" if issue.line else "")
+        lines.append(f"### {prefix}{issue.title} ({loc})\n\n{issue.body}\n")
+    return "\n".join(lines)
+
+
+def build_payload(
+    pr: PRInfo, summary_prefix: str, classified: _ClassifiedIssues
+) -> dict[str, Any]:
+    """Assemble the review payload for `POST /repos/.../pulls/<n>/reviews`."""
+    body_chunks = []
+    if summary_prefix:
+        body_chunks.append(summary_prefix.strip())
+    inline_count = len(classified.inline)
+    body_count = len(classified.body_only)
+    body_chunks.append(
+        f"{inline_count} inline comment(s), {body_count} non-inline finding(s)."
+    )
+    body_section = _format_body_section(classified.body_only)
+    if body_section:
+        body_chunks.append(body_section)
+    payload: dict[str, Any] = {
+        "commit_id": pr.head_sha,
+        "event": "COMMENT",
+        "body": "\n\n".join(body_chunks),
+        "comments": classified.inline,
+    }
+    return payload
+
+
+# --- Core orchestration ---------------------------------------------------
+
+
+async def _post(
+    target_dir: Path,
+    issues: list[ParsedIssue],
+    *,
+    console: Console,
+    summary_prefix: str,
+) -> None:
+    pr = find_open_pr(target_dir)
+    if pr is None:
+        print_warning(
+            console,
+            "No open PR found for the current branch; skipping PR post.",
+        )
+        return
+
+    classified = classify(target_dir, pr, issues)
+    if not classified.inline and not classified.body_only:
+        print_info(console, "No postable issues after classification; skipping PR post.")
+        return
+
+    inline_files = sorted({c["path"] for c in classified.inline})
+    summary = (
+        f"{len(classified.inline)} inline on "
+        f"{', '.join(inline_files) if inline_files else '(none)'}, "
+        f"{len(classified.body_only)} folded into body"
+    )
+    print_info(console, f"PR #{pr.number}: {summary}")
+
+    answer = prompt_user(console, "Post these as a PR review? [y/N]", "n")
+    if answer.strip().lower() not in ("y", "yes"):
+        print_info(console, "Skipped posting to PR.")
+        return
+
+    payload = build_payload(pr, summary_prefix, classified)
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        prefix=f"pr-{pr.number}-review-",
+        suffix=".json",
+        delete=False,
+        encoding="utf-8",
+    ) as tf:
+        tf.write(json.dumps(payload, indent=2))
+        payload_path = Path(tf.name)
+
+    review_url = _submit_review(target_dir, pr, payload_path)
+    if review_url is None:
+        print_warning(
+            console,
+            f"Failed to post PR review; no comments were posted. Payload kept at {payload_path}",
+        )
+        return
+
+    # Success: clean up the tmp payload (gate 3).
+    payload_path.unlink(missing_ok=True)
+    print_success(console, f"Posted review: {review_url}")
+
+
+def _submit_review(
+    target_dir: Path, pr: PRInfo, payload_path: Path
+) -> str | None:
+    """POST the review payload via `gh api`. Returns html_url or None on failure."""
+    try:
+        r = _run(
+            [
+                "gh",
+                "api",
+                "--method",
+                "POST",
+                f"/repos/{pr.owner}/{pr.repo}/pulls/{pr.number}/reviews",
+                "--input",
+                str(payload_path),
+            ],
+            target_dir,
+            timeout=30,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    if r.returncode != 0:
+        return None
+    try:
+        data = json.loads(r.stdout.decode())
+    except json.JSONDecodeError:
+        return None
+    url = data.get("html_url")
+    return str(url) if url else None

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -372,6 +372,13 @@ async def run_trust(config: RunConfig, target_dir: Path) -> int:
         if exploration_cleanup.is_dir():
             shutil.rmtree(exploration_cleanup)
 
+    # Offer to post findings as inline PR review comments.
+    from daydream.pr_review import post_review_to_pr_from_alt_issues
+
+    await post_review_to_pr_from_alt_issues(
+        target_dir, issues, console=console
+    )
+
     return 0
 
 

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -402,9 +402,9 @@ async def run(config: RunConfig | None = None) -> int:
         return 1
 
     # Get review skill (from config or prompt) - not required when starting at "test"
-    # or when using trust-the-technology mode (which has its own flow)
+    # or when using trust-the-technology / deep modes (which have their own flows)
     skill: str | None = None
-    if config.start_at != "test" and not config.trust_the_technology:
+    if config.start_at != "test" and not config.trust_the_technology and not config.deep:
         if config.skill is not None:
             # Map skill name to full skill path
             if config.skill in SKILL_MAP:
@@ -437,8 +437,13 @@ async def run(config: RunConfig | None = None) -> int:
             skill = REVIEW_SKILLS[skill_enum]
 
     # Early validation: check review file exists when starting at parse or fix
-    # (not needed for trust-the-technology mode which has its own flow)
-    if config.start_at in ("parse", "fix") and not config.trust_the_technology:
+    # (not needed for trust-the-technology or deep modes -- both have their
+    # own resume-gate validation).
+    if (
+        config.start_at in ("parse", "fix")
+        and not config.trust_the_technology
+        and not config.deep
+    ):
         try:
             check_review_file_exists(target_dir)
         except FileNotFoundError as e:
@@ -496,6 +501,11 @@ async def run(config: RunConfig | None = None) -> int:
         # Trust-the-technology mode: separate flow
         if config.trust_the_technology:
             return await run_trust(config, target_dir)
+
+        # Deep-review mode: separate flow (D-01, D-07).
+        if config.deep:
+            from daydream.deep.orchestrator import run_deep
+            return await run_deep(config, target_dir)
 
         console.print()
         print_info(console, f"Target directory: {target_dir}")

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -79,6 +79,7 @@ class RunConfig:
         test_backend: Override backend for the test phase. If None, uses backend.
         loop: Enable continuous review/fix/test iterations. Default is False.
         max_iterations: Maximum number of loop iterations before exiting. Default is 5.
+        deep: Run the deep-review pipeline (TTT + per-stack + cross-stack merge). D-01.
         ignore_paths: Paths to exclude from diffs (passed to `git :(exclude)` pathspecs
             and surfaced in review prompts). Default is an empty list.
 
@@ -101,6 +102,7 @@ class RunConfig:
     loop: bool = False
     max_iterations: int = 5
     trust_the_technology: bool = False
+    deep: bool = False
     exploration_context: ExplorationContext | None = None
     exploration_depth: int = 1
     ignore_paths: list[str] = field(default_factory=list)

--- a/daydream/ui.py
+++ b/daydream/ui.py
@@ -3405,3 +3405,66 @@ def render_ttt_plan(console: Console, plan: dict) -> None:
                 console.print(Text.assemble(("    → ", STYLE_DIM), (f"{ref_file}::{ref_symbol}", STYLE_DIM)))
         else:
             console.print(Text.assemble((line, STYLE_DIM), (" (ungrounded)", "yellow")))
+
+
+# =============================================================================
+# Deep-review Mode UI (D-30, D-31, D-44)
+# =============================================================================
+
+
+def print_stage_progress(console: Console, current: int, total: int, name: str) -> None:
+    """Print a ``[stage N/M: name]`` banner at deep-mode stage boundaries (D-44).
+
+    Args:
+        console: Rich Console instance for output.
+        current: Current stage number (1-indexed).
+        total: Total number of stages.
+        name: Human-readable stage name.
+    """
+    console.print(f"[neon.cyan]\u25b6[/] [neon.fg][stage {current}/{total}: {name}][/]")
+
+
+def print_preflight_notice(
+    console: Console,
+    *,
+    stages: list[str],
+    stack_lines: list[str],
+    agent_count: int,
+    codex_in_use: bool,
+    exploration_available: bool,
+) -> None:
+    """Print the deep-mode pre-flight notice (D-30, D-31).
+
+    Lists the stages, detected stacks, skill per stack, and total agent
+    count. Surfaces the ``cost_usd=None`` caveat when the Codex backend
+    is in use, because the Codex CLI does not report per-stage cost.
+
+    Args:
+        console: Rich Console instance for output.
+        stages: Ordered list of stage display names.
+        stack_lines: Per-stack human-readable summary lines.
+        agent_count: Total agent invocation count (D-30 formula).
+        codex_in_use: True when any active backend is Codex (D-31).
+        exploration_available: True when the exploration infrastructure
+            (Phases 1-4) is installed and the pre-scan is wired in.
+    """
+    console.print("[neon.cyan]\u25b6[/] [neon.fg]Deep-review pipeline pre-flight[/]")
+    if exploration_available:
+        console.print("Exploration pre-scan: enabled (runs before stage 1)", style="dim")
+    else:
+        console.print(
+            "Exploration pre-scan: unavailable (deep pipeline runs without grounding)",
+            style="dim yellow",
+        )
+    console.print("[neon.fg]  Stages:[/]")
+    for idx, stage in enumerate(stages, start=1):
+        console.print(f"    {idx}. {stage}")
+    console.print("[neon.fg]  Detected stacks:[/]")
+    for line in stack_lines:
+        console.print(f"    - {line}")
+    console.print(f"[neon.fg]  Total agents: {agent_count}[/]")
+    if codex_in_use:
+        console.print(
+            "[neon.yellow]  \u26a0 Codex backend: per-stage cost_usd=None "
+            "(cost not reported by codex CLI)[/]"
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Shared pytest fixtures for the daydream test suite."""
 
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -51,3 +52,71 @@ def exploration_dir_fixture(tmp_path: Path, exploration_context_fixture: Explora
     exploration_dir = tmp_path / "exploration"
     exploration_context_fixture.write_to_dir(exploration_dir)
     return exploration_dir
+
+
+@pytest.fixture
+def multi_stack_target(tmp_path: Path) -> Path:
+    """Git repo with a Python + React + Markdown diff on a feature branch.
+
+    Used by deep-mode orchestrator and integration tests (plan 05-09 / 05-10)
+    to exercise the multi-stack routing path. The repo has an ``init`` commit
+    on ``main`` and a ``change`` commit on a ``feature`` branch that modifies
+    one file per stack (``api.py``, ``App.tsx``, ``README.md``).
+    """
+    project = tmp_path / "multi_stack"
+    project.mkdir()
+    (project / "api.py").write_text("def hello():\n    return 'world'\n")
+    (project / "App.tsx").write_text("export const App = () => <div>hello</div>;\n")
+    (project / "README.md").write_text("# Project\n")
+    subprocess.run(  # noqa: S603
+        ["git", "init", "-b", "main"],  # noqa: S607
+        cwd=project,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(  # noqa: S603
+        ["git", "config", "user.email", "test@test.com"],  # noqa: S607
+        cwd=project,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(  # noqa: S603
+        ["git", "config", "user.name", "Test"],  # noqa: S607
+        cwd=project,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(  # noqa: S603
+        ["git", "add", "."],  # noqa: S607
+        cwd=project,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(  # noqa: S603
+        ["git", "commit", "-m", "init"],  # noqa: S607
+        cwd=project,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(  # noqa: S603
+        ["git", "checkout", "-b", "feature"],  # noqa: S607
+        cwd=project,
+        capture_output=True,
+        check=True,
+    )
+    (project / "api.py").write_text("def hello():\n    return 'universe'\n")
+    (project / "App.tsx").write_text("export const App = () => <div>universe</div>;\n")
+    (project / "README.md").write_text("# Project\n\nUpdated.\n")
+    subprocess.run(  # noqa: S603
+        ["git", "add", "."],  # noqa: S607
+        cwd=project,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(  # noqa: S603
+        ["git", "commit", "-m", "change"],  # noqa: S607
+        cwd=project,
+        capture_output=True,
+        check=True,
+    )
+    return project

--- a/tests/fixtures/deep/README.md
+++ b/tests/fixtures/deep/README.md
@@ -1,0 +1,5 @@
+# Deep-mode test fixtures
+
+Sample diffs for multi-stack, single-stack, docs-only, and config-only PRs.
+Populated by plan 05-09 (orchestrator integration tests); Wave 0 just creates
+the directory marker.

--- a/tests/test_deep_artifacts.py
+++ b/tests/test_deep_artifacts.py
@@ -50,3 +50,45 @@ def test_check_deep_artifacts_passes_when_present(tmp_path: Path) -> None:
     (deep_dir / "intent.md").write_text("x")
     (deep_dir / "alternatives.json").write_text("[]")
     check_deep_artifacts("per-stack", deep_dir)  # must not raise
+
+
+def test_check_deep_artifacts_rejects_directory_shadowing_prereq(tmp_path: Path) -> None:
+    """A directory named like a prereq must not satisfy the gate."""
+    from daydream.deep.artifacts import check_deep_artifacts
+
+    deep_dir = tmp_path / ".daydream" / "deep"
+    deep_dir.mkdir(parents=True)
+    # intent.md exists as a directory, not a file.
+    (deep_dir / "intent.md").mkdir()
+    (deep_dir / "alternatives.json").write_text("[]")
+    with pytest.raises(FileNotFoundError) as excinfo:
+        check_deep_artifacts("per-stack", deep_dir)
+    assert "intent.md" in str(excinfo.value)
+
+
+def test_check_deep_artifacts_merge_ignores_directory_records(tmp_path: Path) -> None:
+    """A directory matching stack-*-records.json must not satisfy the merge gate."""
+    from daydream.deep.artifacts import check_deep_artifacts
+
+    deep_dir = tmp_path / ".daydream" / "deep"
+    deep_dir.mkdir(parents=True)
+    (deep_dir / "intent.md").write_text("x")
+    (deep_dir / "alternatives.json").write_text("[]")
+    (deep_dir / "stack-bogus-records.json").mkdir()  # directory, not a file
+    with pytest.raises(FileNotFoundError) as excinfo:
+        check_deep_artifacts("merge", deep_dir)
+    assert "stack-*-records.json" in str(excinfo.value)
+
+
+def test_check_deep_artifacts_fix_rejects_directory_merged_report(tmp_path: Path) -> None:
+    """A directory named like REVIEW_OUTPUT_FILE must not satisfy the fix gate."""
+    from daydream.config import REVIEW_OUTPUT_FILE
+    from daydream.deep.artifacts import check_deep_artifacts
+
+    target = tmp_path
+    deep_dir = target / ".daydream" / "deep"
+    deep_dir.mkdir(parents=True)
+    (target / REVIEW_OUTPUT_FILE).mkdir()  # directory, not a file
+    with pytest.raises(FileNotFoundError) as excinfo:
+        check_deep_artifacts("fix", deep_dir)
+    assert REVIEW_OUTPUT_FILE in str(excinfo.value)

--- a/tests/test_deep_artifacts.py
+++ b/tests/test_deep_artifacts.py
@@ -1,15 +1,10 @@
-"""Deep-mode artifact path + check_deep_artifacts tests (D-18, D-36, D-37).
-
-Every test is xfail(strict=True) until Wave 2 plan 05-03 implements the
-``daydream.deep.artifacts`` module.
-"""
+"""Deep-mode artifact path + check_deep_artifacts tests (D-18, D-36, D-37)."""
 
 from pathlib import Path
 
 import pytest
 
 
-@pytest.mark.xfail(reason="Wave 2 plan 05-03 not yet implemented", strict=True)
 def test_per_stack_path_scheme(tmp_path: Path) -> None:
     """D-18: per-stack output path is deterministic + unique."""
     from daydream.deep.artifacts import per_stack_review_path
@@ -21,7 +16,6 @@ def test_per_stack_path_scheme(tmp_path: Path) -> None:
     assert p2.name == "stack-react-review.md"
 
 
-@pytest.mark.xfail(reason="Wave 2 plan 05-03 not yet implemented", strict=True)
 def test_check_deep_artifacts_missing(tmp_path: Path) -> None:
     """D-36: check_deep_artifacts raises FileNotFoundError when predecessor missing."""
     from daydream.deep.artifacts import check_deep_artifacts
@@ -34,7 +28,6 @@ def test_check_deep_artifacts_missing(tmp_path: Path) -> None:
     assert "--start-at" in str(excinfo.value)
 
 
-@pytest.mark.xfail(reason="Wave 2 plan 05-03 not yet implemented", strict=True)
 def test_check_deep_artifacts_merge_requires_records(tmp_path: Path) -> None:
     """D-37: --start-at merge needs per-stack records on disk."""
     from daydream.deep.artifacts import check_deep_artifacts
@@ -48,7 +41,6 @@ def test_check_deep_artifacts_merge_requires_records(tmp_path: Path) -> None:
     assert "stack-*-records.json" in str(excinfo.value)
 
 
-@pytest.mark.xfail(reason="Wave 2 plan 05-03 not yet implemented", strict=True)
 def test_check_deep_artifacts_passes_when_present(tmp_path: Path) -> None:
     """D-36: check passes silently when all predecessors exist."""
     from daydream.deep.artifacts import check_deep_artifacts

--- a/tests/test_deep_artifacts.py
+++ b/tests/test_deep_artifacts.py
@@ -1,0 +1,60 @@
+"""Deep-mode artifact path + check_deep_artifacts tests (D-18, D-36, D-37).
+
+Every test is xfail(strict=True) until Wave 2 plan 05-03 implements the
+``daydream.deep.artifacts`` module.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.xfail(reason="Wave 2 plan 05-03 not yet implemented", strict=True)
+def test_per_stack_path_scheme(tmp_path: Path) -> None:
+    """D-18: per-stack output path is deterministic + unique."""
+    from daydream.deep.artifacts import per_stack_review_path
+
+    p1 = per_stack_review_path(tmp_path, "python")
+    p2 = per_stack_review_path(tmp_path, "react")
+    assert p1 != p2
+    assert p1.name == "stack-python-review.md"
+    assert p2.name == "stack-react-review.md"
+
+
+@pytest.mark.xfail(reason="Wave 2 plan 05-03 not yet implemented", strict=True)
+def test_check_deep_artifacts_missing(tmp_path: Path) -> None:
+    """D-36: check_deep_artifacts raises FileNotFoundError when predecessor missing."""
+    from daydream.deep.artifacts import check_deep_artifacts
+
+    deep_dir = tmp_path / ".daydream" / "deep"
+    deep_dir.mkdir(parents=True)
+    with pytest.raises(FileNotFoundError) as excinfo:
+        check_deep_artifacts("per-stack", deep_dir)
+    assert "intent.md" in str(excinfo.value)
+    assert "--start-at" in str(excinfo.value)
+
+
+@pytest.mark.xfail(reason="Wave 2 plan 05-03 not yet implemented", strict=True)
+def test_check_deep_artifacts_merge_requires_records(tmp_path: Path) -> None:
+    """D-37: --start-at merge needs per-stack records on disk."""
+    from daydream.deep.artifacts import check_deep_artifacts
+
+    deep_dir = tmp_path / ".daydream" / "deep"
+    deep_dir.mkdir(parents=True)
+    (deep_dir / "intent.md").write_text("x")
+    (deep_dir / "alternatives.json").write_text("[]")
+    with pytest.raises(FileNotFoundError) as excinfo:
+        check_deep_artifacts("merge", deep_dir)
+    assert "stack-*-records.json" in str(excinfo.value)
+
+
+@pytest.mark.xfail(reason="Wave 2 plan 05-03 not yet implemented", strict=True)
+def test_check_deep_artifacts_passes_when_present(tmp_path: Path) -> None:
+    """D-36: check passes silently when all predecessors exist."""
+    from daydream.deep.artifacts import check_deep_artifacts
+
+    deep_dir = tmp_path / ".daydream" / "deep"
+    deep_dir.mkdir(parents=True)
+    (deep_dir / "intent.md").write_text("x")
+    (deep_dir / "alternatives.json").write_text("[]")
+    check_deep_artifacts("per-stack", deep_dir)  # must not raise

--- a/tests/test_deep_cli.py
+++ b/tests/test_deep_cli.py
@@ -1,0 +1,54 @@
+"""Deep-mode CLI parsing tests (D-01..D-06).
+
+Every test is xfail(strict=True) until Wave 1 plan 05-02 implements the
+``--deep`` flag and ``--start-at`` deep stages in ``daydream.cli``.
+"""
+
+import pytest
+
+from daydream.cli import _parse_args
+
+
+@pytest.mark.xfail(reason="Wave 1 plan 05-02 not yet implemented", strict=True)
+def test_deep_flag_parsed() -> None:
+    """D-01: --deep sets config.deep=True."""
+    args = _parse_args(["target", "--deep"])
+    assert args.deep is True
+
+
+@pytest.mark.xfail(reason="Wave 1 plan 05-02 not yet implemented", strict=True)
+def test_no_stack_declaration_flags() -> None:
+    """D-02: no --stack / --also-review / --skip-stack flags."""
+    with pytest.raises(SystemExit):
+        _parse_args(["target", "--deep", "--stack", "python"])
+
+
+@pytest.mark.xfail(reason="Wave 1 plan 05-02 not yet implemented", strict=True)
+@pytest.mark.parametrize("stage", ["ttt", "per-stack", "merge"])
+def test_start_at_deep_stages_accepted(stage: str) -> None:
+    """D-03: --start-at ttt|per-stack|merge accepted under --deep."""
+    args = _parse_args(["target", "--deep", "--start-at", stage])
+    assert args.start_at == stage
+
+
+@pytest.mark.xfail(reason="Wave 1 plan 05-02 not yet implemented", strict=True)
+def test_deep_rejects_start_at_parse() -> None:
+    """D-04: --start-at parse rejected under --deep."""
+    with pytest.raises(SystemExit):
+        _parse_args(["target", "--deep", "--start-at", "parse"])
+
+
+@pytest.mark.xfail(reason="Wave 1 plan 05-02 not yet implemented", strict=True)
+@pytest.mark.parametrize("stage", ["ttt", "per-stack", "merge"])
+def test_deep_stages_require_deep_flag(stage: str) -> None:
+    """D-05: deep-only stages only legal with --deep."""
+    with pytest.raises(SystemExit):
+        _parse_args(["target", "--start-at", stage])
+
+
+@pytest.mark.xfail(reason="Wave 1 plan 05-02 not yet implemented", strict=True)
+@pytest.mark.parametrize("other_flag", [["--pr", "123"], ["--loop"], ["--ttt"], ["--review-only"]])
+def test_deep_mutex(other_flag: list[str]) -> None:
+    """D-06: --deep is mutually exclusive with --pr, --loop, --ttt, --review-only."""
+    with pytest.raises(SystemExit):
+        _parse_args(["target", "--deep", *other_flag])

--- a/tests/test_deep_cli.py
+++ b/tests/test_deep_cli.py
@@ -42,3 +42,16 @@ def test_deep_mutex(other_flag: list[str]) -> None:
     """D-06: --deep is mutually exclusive with --pr, --loop, --ttt, --review-only."""
     with pytest.raises(SystemExit):
         _parse_args(["target", "--deep", *other_flag])
+
+
+def test_deep_rejects_start_at_test() -> None:
+    """--start-at test is not a valid deep resume stage; reject at CLI boundary."""
+    with pytest.raises(SystemExit):
+        _parse_args(["target", "--deep", "--start-at", "test"])
+
+
+@pytest.mark.parametrize("skill_flag", ["--python", "--typescript", "--elixir", "--go", "--rust"])
+def test_deep_rejects_skill_flag(skill_flag: str) -> None:
+    """Skill flags are ignored under --deep; reject at CLI boundary instead."""
+    with pytest.raises(SystemExit):
+        _parse_args(["target", "--deep", skill_flag])

--- a/tests/test_deep_cli.py
+++ b/tests/test_deep_cli.py
@@ -1,29 +1,22 @@
-"""Deep-mode CLI parsing tests (D-01..D-06).
-
-Every test is xfail(strict=True) until Wave 1 plan 05-02 implements the
-``--deep`` flag and ``--start-at`` deep stages in ``daydream.cli``.
-"""
+"""Deep-mode CLI parsing tests (D-01..D-06)."""
 
 import pytest
 
 from daydream.cli import _parse_args
 
 
-@pytest.mark.xfail(reason="Wave 1 plan 05-02 not yet implemented", strict=True)
 def test_deep_flag_parsed() -> None:
     """D-01: --deep sets config.deep=True."""
     args = _parse_args(["target", "--deep"])
     assert args.deep is True
 
 
-@pytest.mark.xfail(reason="Wave 1 plan 05-02 not yet implemented", strict=True)
 def test_no_stack_declaration_flags() -> None:
     """D-02: no --stack / --also-review / --skip-stack flags."""
     with pytest.raises(SystemExit):
         _parse_args(["target", "--deep", "--stack", "python"])
 
 
-@pytest.mark.xfail(reason="Wave 1 plan 05-02 not yet implemented", strict=True)
 @pytest.mark.parametrize("stage", ["ttt", "per-stack", "merge"])
 def test_start_at_deep_stages_accepted(stage: str) -> None:
     """D-03: --start-at ttt|per-stack|merge accepted under --deep."""
@@ -31,14 +24,12 @@ def test_start_at_deep_stages_accepted(stage: str) -> None:
     assert args.start_at == stage
 
 
-@pytest.mark.xfail(reason="Wave 1 plan 05-02 not yet implemented", strict=True)
 def test_deep_rejects_start_at_parse() -> None:
     """D-04: --start-at parse rejected under --deep."""
     with pytest.raises(SystemExit):
         _parse_args(["target", "--deep", "--start-at", "parse"])
 
 
-@pytest.mark.xfail(reason="Wave 1 plan 05-02 not yet implemented", strict=True)
 @pytest.mark.parametrize("stage", ["ttt", "per-stack", "merge"])
 def test_deep_stages_require_deep_flag(stage: str) -> None:
     """D-05: deep-only stages only legal with --deep."""
@@ -46,7 +37,6 @@ def test_deep_stages_require_deep_flag(stage: str) -> None:
         _parse_args(["target", "--start-at", stage])
 
 
-@pytest.mark.xfail(reason="Wave 1 plan 05-02 not yet implemented", strict=True)
 @pytest.mark.parametrize("other_flag", [["--pr", "123"], ["--loop"], ["--ttt"], ["--review-only"]])
 def test_deep_mutex(other_flag: list[str]) -> None:
     """D-06: --deep is mutually exclusive with --pr, --loop, --ttt, --review-only."""

--- a/tests/test_deep_dedup.py
+++ b/tests/test_deep_dedup.py
@@ -1,34 +1,30 @@
 """Dedup pre-filter tests (D-27).
 
-Every test is xfail(strict=True) until Wave 3 plan 05-07 implements the
-``daydream.deep.dedup`` module with ``build_dedup_candidates(...)``.
+Covers ``daydream.deep.dedup.build_dedup_candidates`` which emits
+``CandidatePair`` entries where a per-stack record and a TTT alternative
+finding share at least one file AND have normalized-title bigram Jaccard
+similarity >= 0.5.
 """
 
-import pytest
+from daydream.deep.dedup import build_dedup_candidates
 
 
-@pytest.mark.xfail(reason="Wave 3 plan 05-07 not yet implemented", strict=True)
-def test_candidate_pairs_file_overlap_only() -> None:
-    """D-27: file-overlap heuristic emits a candidate pair.
+def test_file_overlap_without_title_similarity_produces_no_pair() -> None:
+    """D-27: file overlap alone is insufficient — both gates must hold.
 
-    When a per-stack record and a TTT alternative share a file path, the
-    dedup pre-filter must surface them as a candidate pair for the merge
-    agent to make the final same-concern judgment.
+    Matching file paths with disjoint titles must NOT surface a candidate
+    pair; D-27 requires BOTH file overlap AND title similarity >= 0.5.
     """
-    from daydream.deep.dedup import build_dedup_candidates
-
-    per_stack = [{"id": "1", "file": "api.py", "title": "Missing return type"}]
-    ttt_alts = [{"files": ["api.py"], "title": "Type hint coverage"}]
+    per_stack = [
+        {"id": "1", "file": "api.py", "line": 1, "description": "Missing return type"},
+    ]
+    ttt_alts = [{"files": ["api.py"], "title": "Frontend styling drift"}]
     pairs = build_dedup_candidates(per_stack, ttt_alts)
-    assert len(pairs) >= 1
-    assert any(p.record_file == "api.py" and "api.py" in p.alt_files for p in pairs)
+    assert pairs == []
 
 
-@pytest.mark.xfail(reason="Wave 3 plan 05-07 not yet implemented", strict=True)
 def test_candidate_pairs_file_and_title() -> None:
     """D-27: file overlap + similar title -> pair."""
-    from daydream.deep.dedup import build_dedup_candidates
-
     records = [
         {"id": "1", "file": "api.py", "line": 42, "description": "Missing input validation on login"},
     ]
@@ -39,12 +35,40 @@ def test_candidate_pairs_file_and_title() -> None:
     assert len(pairs) >= 1
 
 
-@pytest.mark.xfail(reason="Wave 3 plan 05-07 not yet implemented", strict=True)
 def test_candidate_pairs_disjoint() -> None:
     """D-27: no file overlap AND no title overlap -> no pair."""
-    from daydream.deep.dedup import build_dedup_candidates
-
     records = [{"id": "1", "file": "api.py", "line": 1, "description": "SQL injection"}]
     alt_issues = [{"title": "Frontend styling drift", "files": ["App.tsx"]}]
     pairs = build_dedup_candidates(records, alt_issues=alt_issues)
+    assert pairs == []
+
+
+def test_jaccard_similarity_threshold_met() -> None:
+    """D-27: records with high-similarity titles + shared file -> pair."""
+    records = [
+        {
+            "id": "r1",
+            "file": "api.py",
+            "line": 10,
+            "description": "Missing input validation on login endpoint",
+        }
+    ]
+    alt_issues = [
+        {
+            "title": "Input validation missing on login endpoint",
+            "files": ["api.py"],
+        }
+    ]
+    pairs = build_dedup_candidates(records, alt_issues)
+    assert len(pairs) == 1
+    assert pairs[0].similarity >= 0.5
+    assert pairs[0].record_id == "r1"
+    assert "api.py" in pairs[0].alt_files
+
+
+def test_file_overlap_alone_insufficient() -> None:
+    """D-27: file overlap without title similarity -> no pair."""
+    records = [{"id": "r1", "file": "api.py", "line": 1, "description": "SQL injection"}]
+    alt_issues = [{"title": "Logging verbosity too high", "files": ["api.py"]}]
+    pairs = build_dedup_candidates(records, alt_issues)
     assert pairs == []

--- a/tests/test_deep_dedup.py
+++ b/tests/test_deep_dedup.py
@@ -1,0 +1,50 @@
+"""Dedup pre-filter tests (D-27).
+
+Every test is xfail(strict=True) until Wave 3 plan 05-07 implements the
+``daydream.deep.dedup`` module with ``build_dedup_candidates(...)``.
+"""
+
+import pytest
+
+
+@pytest.mark.xfail(reason="Wave 3 plan 05-07 not yet implemented", strict=True)
+def test_candidate_pairs_file_overlap_only() -> None:
+    """D-27: file-overlap heuristic emits a candidate pair.
+
+    When a per-stack record and a TTT alternative share a file path, the
+    dedup pre-filter must surface them as a candidate pair for the merge
+    agent to make the final same-concern judgment.
+    """
+    from daydream.deep.dedup import build_dedup_candidates
+
+    per_stack = [{"id": "1", "file": "api.py", "title": "Missing return type"}]
+    ttt_alts = [{"files": ["api.py"], "title": "Type hint coverage"}]
+    pairs = build_dedup_candidates(per_stack, ttt_alts)
+    assert len(pairs) >= 1
+    assert any(p.record_file == "api.py" and "api.py" in p.alt_files for p in pairs)
+
+
+@pytest.mark.xfail(reason="Wave 3 plan 05-07 not yet implemented", strict=True)
+def test_candidate_pairs_file_and_title() -> None:
+    """D-27: file overlap + similar title -> pair."""
+    from daydream.deep.dedup import build_dedup_candidates
+
+    records = [
+        {"id": "1", "file": "api.py", "line": 42, "description": "Missing input validation on login"},
+    ]
+    alt_issues = [
+        {"title": "Input validation missing on login endpoint", "files": ["api.py"]},
+    ]
+    pairs = build_dedup_candidates(records, alt_issues=alt_issues)
+    assert len(pairs) >= 1
+
+
+@pytest.mark.xfail(reason="Wave 3 plan 05-07 not yet implemented", strict=True)
+def test_candidate_pairs_disjoint() -> None:
+    """D-27: no file overlap AND no title overlap -> no pair."""
+    from daydream.deep.dedup import build_dedup_candidates
+
+    records = [{"id": "1", "file": "api.py", "line": 1, "description": "SQL injection"}]
+    alt_issues = [{"title": "Frontend styling drift", "files": ["App.tsx"]}]
+    pairs = build_dedup_candidates(records, alt_issues=alt_issues)
+    assert pairs == []

--- a/tests/test_deep_detection.py
+++ b/tests/test_deep_detection.py
@@ -1,13 +1,9 @@
 """Stack detection routing tests (D-11..D-16).
 
-Every test is xfail(strict=True) until Wave 1 plan 05-01 implements the
-``daydream.deep.detection`` module with ``detect_stacks(...)``.
+Covers ``daydream.deep.detection.detect_stacks`` implemented in plan 05-01.
 """
 
-import pytest
 
-
-@pytest.mark.xfail(reason="Wave 1 plan 05-01 not yet implemented", strict=True)
 def test_extension_routing_python() -> None:
     """D-11: .py files route to python stack."""
     from daydream.deep.detection import detect_stacks
@@ -17,7 +13,6 @@ def test_extension_routing_python() -> None:
     assert "python" in names
 
 
-@pytest.mark.xfail(reason="Wave 1 plan 05-01 not yet implemented", strict=True)
 def test_extension_routing_react() -> None:
     """D-11: .tsx files route to react stack."""
     from daydream.deep.detection import detect_stacks
@@ -26,7 +21,6 @@ def test_extension_routing_react() -> None:
     assert "react" in {a.stack_name for a in result}
 
 
-@pytest.mark.xfail(reason="Wave 1 plan 05-01 not yet implemented", strict=True)
 def test_ambiguous_single_stack_shortcut() -> None:
     """D-12: single stack in diff -> ambiguous files unconditionally join it."""
     from daydream.deep.detection import detect_stacks
@@ -36,7 +30,6 @@ def test_ambiguous_single_stack_shortcut() -> None:
     assert "migrations/001.sql" in python.files
 
 
-@pytest.mark.xfail(reason="Wave 1 plan 05-01 not yet implemented", strict=True)
 def test_ambiguous_nearest_ancestor() -> None:
     """D-12: ambiguous file routes to nearest-ancestor unambiguous stack."""
     from daydream.deep.detection import detect_stacks
@@ -49,7 +42,6 @@ def test_ambiguous_nearest_ancestor() -> None:
     assert "backend/api/queries.sql" in python.files
 
 
-@pytest.mark.xfail(reason="Wave 1 plan 05-01 not yet implemented", strict=True)
 def test_equal_depth_fallthrough() -> None:
     """D-12c: equal-depth ambiguity falls through to generic."""
     from daydream.deep.detection import detect_stacks
@@ -62,7 +54,6 @@ def test_equal_depth_fallthrough() -> None:
     assert "shared.sql" in generic.files
 
 
-@pytest.mark.xfail(reason="Wave 1 plan 05-01 not yet implemented", strict=True)
 def test_config_default_generic() -> None:
     """D-13a: .yaml / .toml route to generic by default."""
     from daydream.deep.detection import detect_stacks
@@ -71,7 +62,6 @@ def test_config_default_generic() -> None:
     assert {a.stack_name for a in result} == {"generic"}
 
 
-@pytest.mark.xfail(reason="Wave 1 plan 05-01 not yet implemented", strict=True)
 def test_config_promotion_pyproject() -> None:
     """D-13b: pyproject.toml + .py co-change -> python."""
     from daydream.deep.detection import detect_stacks
@@ -81,7 +71,6 @@ def test_config_promotion_pyproject() -> None:
     assert "pyproject.toml" in python.files
 
 
-@pytest.mark.xfail(reason="Wave 1 plan 05-01 not yet implemented", strict=True)
 def test_no_static_promotion_without_cochange() -> None:
     """D-13c: static paths alone do not promote config to a stack."""
     from daydream.deep.detection import detect_stacks
@@ -91,7 +80,6 @@ def test_no_static_promotion_without_cochange() -> None:
     assert {a.stack_name for a in result} == {"generic"}
 
 
-@pytest.mark.xfail(reason="Wave 1 plan 05-01 not yet implemented", strict=True)
 def test_md_pinned_to_generic() -> None:
     """D-14: .md files pinned to generic even when co-changed with code."""
     from daydream.deep.detection import detect_stacks
@@ -102,7 +90,6 @@ def test_md_pinned_to_generic() -> None:
     assert generic.is_docs_only is False  # mixed with py stack, but docs go here
 
 
-@pytest.mark.xfail(reason="Wave 1 plan 05-01 not yet implemented", strict=True)
 def test_no_files_dropped() -> None:
     """D-15: every file is routed somewhere."""
     from daydream.deep.detection import detect_stacks
@@ -113,7 +100,6 @@ def test_no_files_dropped() -> None:
     assert routed == set(files)
 
 
-@pytest.mark.xfail(reason="Wave 1 plan 05-01 not yet implemented", strict=True)
 def test_missing_skill_routes_to_generic() -> None:
     """D-16: detected stack with no installed skill -> generic."""
     from daydream.deep.detection import detect_stacks

--- a/tests/test_deep_detection.py
+++ b/tests/test_deep_detection.py
@@ -1,0 +1,122 @@
+"""Stack detection routing tests (D-11..D-16).
+
+Every test is xfail(strict=True) until Wave 1 plan 05-01 implements the
+``daydream.deep.detection`` module with ``detect_stacks(...)``.
+"""
+
+import pytest
+
+
+@pytest.mark.xfail(reason="Wave 1 plan 05-01 not yet implemented", strict=True)
+def test_extension_routing_python() -> None:
+    """D-11: .py files route to python stack."""
+    from daydream.deep.detection import detect_stacks
+
+    result = detect_stacks(["src/main.py"], skill_availability={"python"})
+    names = {a.stack_name for a in result}
+    assert "python" in names
+
+
+@pytest.mark.xfail(reason="Wave 1 plan 05-01 not yet implemented", strict=True)
+def test_extension_routing_react() -> None:
+    """D-11: .tsx files route to react stack."""
+    from daydream.deep.detection import detect_stacks
+
+    result = detect_stacks(["src/App.tsx"], skill_availability={"react"})
+    assert "react" in {a.stack_name for a in result}
+
+
+@pytest.mark.xfail(reason="Wave 1 plan 05-01 not yet implemented", strict=True)
+def test_ambiguous_single_stack_shortcut() -> None:
+    """D-12: single stack in diff -> ambiguous files unconditionally join it."""
+    from daydream.deep.detection import detect_stacks
+
+    result = detect_stacks(["src/app.py", "migrations/001.sql"], skill_availability={"python"})
+    python = next(a for a in result if a.stack_name == "python")
+    assert "migrations/001.sql" in python.files
+
+
+@pytest.mark.xfail(reason="Wave 1 plan 05-01 not yet implemented", strict=True)
+def test_ambiguous_nearest_ancestor() -> None:
+    """D-12: ambiguous file routes to nearest-ancestor unambiguous stack."""
+    from daydream.deep.detection import detect_stacks
+
+    result = detect_stacks(
+        ["backend/api/main.py", "backend/api/queries.sql", "frontend/App.tsx"],
+        skill_availability={"python", "react"},
+    )
+    python = next(a for a in result if a.stack_name == "python")
+    assert "backend/api/queries.sql" in python.files
+
+
+@pytest.mark.xfail(reason="Wave 1 plan 05-01 not yet implemented", strict=True)
+def test_equal_depth_fallthrough() -> None:
+    """D-12c: equal-depth ambiguity falls through to generic."""
+    from daydream.deep.detection import detect_stacks
+
+    result = detect_stacks(
+        ["main.py", "App.tsx", "shared.sql"],  # .sql has no unambiguous ancestor
+        skill_availability={"python", "react"},
+    )
+    generic = next(a for a in result if a.stack_name == "generic")
+    assert "shared.sql" in generic.files
+
+
+@pytest.mark.xfail(reason="Wave 1 plan 05-01 not yet implemented", strict=True)
+def test_config_default_generic() -> None:
+    """D-13a: .yaml / .toml route to generic by default."""
+    from daydream.deep.detection import detect_stacks
+
+    result = detect_stacks(["config.yaml"], skill_availability=set())
+    assert {a.stack_name for a in result} == {"generic"}
+
+
+@pytest.mark.xfail(reason="Wave 1 plan 05-01 not yet implemented", strict=True)
+def test_config_promotion_pyproject() -> None:
+    """D-13b: pyproject.toml + .py co-change -> python."""
+    from daydream.deep.detection import detect_stacks
+
+    result = detect_stacks(["pyproject.toml", "src/main.py"], skill_availability={"python"})
+    python = next(a for a in result if a.stack_name == "python")
+    assert "pyproject.toml" in python.files
+
+
+@pytest.mark.xfail(reason="Wave 1 plan 05-01 not yet implemented", strict=True)
+def test_no_static_promotion_without_cochange() -> None:
+    """D-13c: static paths alone do not promote config to a stack."""
+    from daydream.deep.detection import detect_stacks
+
+    # pyproject.toml alone (no .py in diff) stays generic
+    result = detect_stacks(["pyproject.toml"], skill_availability={"python"})
+    assert {a.stack_name for a in result} == {"generic"}
+
+
+@pytest.mark.xfail(reason="Wave 1 plan 05-01 not yet implemented", strict=True)
+def test_md_pinned_to_generic() -> None:
+    """D-14: .md files pinned to generic even when co-changed with code."""
+    from daydream.deep.detection import detect_stacks
+
+    result = detect_stacks(["src/main.py", "README.md"], skill_availability={"python"})
+    generic = next(a for a in result if a.stack_name == "generic")
+    assert "README.md" in generic.files
+    assert generic.is_docs_only is False  # mixed with py stack, but docs go here
+
+
+@pytest.mark.xfail(reason="Wave 1 plan 05-01 not yet implemented", strict=True)
+def test_no_files_dropped() -> None:
+    """D-15: every file is routed somewhere."""
+    from daydream.deep.detection import detect_stacks
+
+    files = ["src/main.py", "README.md", "config.yaml", "Dockerfile", "src/App.tsx"]
+    result = detect_stacks(files, skill_availability={"python", "react"})
+    routed = {f for a in result for f in a.files}
+    assert routed == set(files)
+
+
+@pytest.mark.xfail(reason="Wave 1 plan 05-01 not yet implemented", strict=True)
+def test_missing_skill_routes_to_generic() -> None:
+    """D-16: detected stack with no installed skill -> generic."""
+    from daydream.deep.detection import detect_stacks
+
+    result = detect_stacks(["src/lib.rs"], skill_availability=set())  # rust not installed
+    assert {a.stack_name for a in result} == {"generic"}

--- a/tests/test_deep_fanout.py
+++ b/tests/test_deep_fanout.py
@@ -1,0 +1,181 @@
+"""phase_per_stack_reviews concurrency + correctness tests (D-17, D-18, D-38)."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from daydream.backends import ResultEvent, TextEvent
+from daydream.deep.detection import StackAssignment
+from daydream.phases import phase_per_stack_reviews
+
+
+class _RecordingBackend:
+    """Records every execute call; verifies no `agents` kwarg was passed."""
+
+    def __init__(self) -> None:
+        self.prompts: list[str] = []
+        self.agents_seen: list[Any] = []
+
+    async def execute(
+        self,
+        cwd: Path,
+        prompt: str,
+        output_schema: Any = None,
+        continuation: Any = None,
+        agents: Any = None,
+    ):
+        self.prompts.append(prompt)
+        self.agents_seen.append(agents)
+        # Emit minimal events to satisfy run_agent.
+        yield TextEvent(text="done")
+        yield ResultEvent(structured_output=None, continuation=None)
+
+    async def cancel(self) -> None:
+        pass
+
+    def format_skill_invocation(self, skill_key: str, args: str = "") -> str:
+        return f"/{skill_key}"
+
+
+def _mk_stacks() -> list[StackAssignment]:
+    return [
+        StackAssignment(
+            stack_name="python",
+            skill_invocation="/beagle-python:review-python",
+            files=["api.py"],
+            is_docs_only=False,
+        ),
+        StackAssignment(
+            stack_name="react",
+            skill_invocation="/beagle-react:review-frontend",
+            files=["App.tsx"],
+            is_docs_only=False,
+        ),
+        StackAssignment(
+            stack_name="generic",
+            skill_invocation=None,
+            files=["README.md"],
+            is_docs_only=True,
+        ),
+    ]
+
+
+def _mk_context_files(tmp_path: Path) -> tuple[Path, Path, Path]:
+    diff = tmp_path / "diff.patch"
+    diff.write_text("")
+    intent = tmp_path / "intent.md"
+    intent.write_text("x")
+    alts = tmp_path / "alts.json"
+    alts.write_text("[]")
+    return diff, intent, alts
+
+
+async def test_fan_out_invokes_each_stack(tmp_path: Path) -> None:
+    """D-17: each stack gets exactly one backend.execute call."""
+    backend = _RecordingBackend()
+    diff, intent, alts = _mk_context_files(tmp_path)
+
+    results = await phase_per_stack_reviews(
+        backend,
+        tmp_path,
+        _mk_stacks(),
+        diff_path=diff,
+        intent_path=intent,
+        alternatives_path=alts,
+    )
+
+    assert set(results.keys()) == {"python", "react", "generic"}
+    assert len(backend.prompts) == 3
+
+
+async def test_fan_out_never_passes_agents_kwarg(tmp_path: Path) -> None:
+    """D-38 (Codex parity): the `agents` kwarg to backend.execute must be None."""
+    backend = _RecordingBackend()
+    diff, intent, alts = _mk_context_files(tmp_path)
+
+    await phase_per_stack_reviews(
+        backend,
+        tmp_path,
+        _mk_stacks(),
+        diff_path=diff,
+        intent_path=intent,
+        alternatives_path=alts,
+    )
+
+    assert all(a is None for a in backend.agents_seen)
+
+
+async def test_fan_out_unique_output_paths(tmp_path: Path) -> None:
+    """D-18: per-stack output paths are unique and deterministic."""
+    backend = _RecordingBackend()
+    diff, intent, alts = _mk_context_files(tmp_path)
+
+    results = await phase_per_stack_reviews(
+        backend,
+        tmp_path,
+        _mk_stacks(),
+        diff_path=diff,
+        intent_path=intent,
+        alternatives_path=alts,
+    )
+
+    paths = set(results.values())
+    assert len(paths) == 3
+    for p in paths:
+        assert p.name.startswith("stack-") and p.name.endswith("-review.md")
+
+
+async def test_fan_out_closure_capture(tmp_path: Path) -> None:
+    """Pitfall 2: no late-binding bug -- each task gets its own prompt."""
+    backend = _RecordingBackend()
+    diff, intent, alts = _mk_context_files(tmp_path)
+
+    await phase_per_stack_reviews(
+        backend,
+        tmp_path,
+        _mk_stacks(),
+        diff_path=diff,
+        intent_path=intent,
+        alternatives_path=alts,
+    )
+
+    prompts = backend.prompts
+    assert any("python" in p for p in prompts)
+    assert any("react" in p for p in prompts)
+    assert any("generic-fallback" in p for p in prompts)
+
+
+async def test_fan_out_continues_after_one_failure(tmp_path: Path) -> None:
+    """A single stack failure does not abort the whole fan-out."""
+
+    class _FlakyBackend(_RecordingBackend):
+        async def execute(
+            self,
+            cwd: Path,
+            prompt: str,
+            output_schema: Any = None,
+            continuation: Any = None,
+            agents: Any = None,
+        ):
+            self.prompts.append(prompt)
+            self.agents_seen.append(agents)
+            if "react" in prompt.lower():
+                raise RuntimeError("simulated react failure")
+            yield TextEvent(text="ok")
+            yield ResultEvent(structured_output=None, continuation=None)
+
+    backend = _FlakyBackend()
+    diff, intent, alts = _mk_context_files(tmp_path)
+
+    results = await phase_per_stack_reviews(
+        backend,
+        tmp_path,
+        _mk_stacks(),
+        diff_path=diff,
+        intent_path=intent,
+        alternatives_path=alts,
+    )
+
+    assert "python" in results
+    assert "generic" in results
+    assert "react" not in results

--- a/tests/test_deep_fanout.py
+++ b/tests/test_deep_fanout.py
@@ -75,7 +75,7 @@ async def test_fan_out_invokes_each_stack(tmp_path: Path) -> None:
     backend = _RecordingBackend()
     diff, intent, alts = _mk_context_files(tmp_path)
 
-    results = await phase_per_stack_reviews(
+    results, failures = await phase_per_stack_reviews(
         backend,
         tmp_path,
         _mk_stacks(),
@@ -85,6 +85,7 @@ async def test_fan_out_invokes_each_stack(tmp_path: Path) -> None:
     )
 
     assert set(results.keys()) == {"python", "react", "generic"}
+    assert failures == {}
     assert len(backend.prompts) == 3
 
 
@@ -110,7 +111,7 @@ async def test_fan_out_unique_output_paths(tmp_path: Path) -> None:
     backend = _RecordingBackend()
     diff, intent, alts = _mk_context_files(tmp_path)
 
-    results = await phase_per_stack_reviews(
+    results, _ = await phase_per_stack_reviews(
         backend,
         tmp_path,
         _mk_stacks(),
@@ -146,7 +147,7 @@ async def test_fan_out_closure_capture(tmp_path: Path) -> None:
 
 
 async def test_fan_out_continues_after_one_failure(tmp_path: Path) -> None:
-    """A single stack failure does not abort the whole fan-out."""
+    """A single stack failure does not abort the whole fan-out, and is reported."""
 
     class _FlakyBackend(_RecordingBackend):
         async def execute(
@@ -167,7 +168,7 @@ async def test_fan_out_continues_after_one_failure(tmp_path: Path) -> None:
     backend = _FlakyBackend()
     diff, intent, alts = _mk_context_files(tmp_path)
 
-    results = await phase_per_stack_reviews(
+    results, failures = await phase_per_stack_reviews(
         backend,
         tmp_path,
         _mk_stacks(),
@@ -179,3 +180,6 @@ async def test_fan_out_continues_after_one_failure(tmp_path: Path) -> None:
     assert "python" in results
     assert "generic" in results
     assert "react" not in results
+    # Failure surfaces in the returned failures dict with the exception reason.
+    assert "react" in failures
+    assert "simulated react failure" in failures["react"]

--- a/tests/test_deep_integration.py
+++ b/tests/test_deep_integration.py
@@ -1,37 +1,286 @@
-"""Deep-mode backend parity integration tests (D-38..D-40).
+"""Deep-mode backend parity + primitive-preservation tests (D-38, D-39, D-40)."""
 
-Most tests are xfail(strict=True) until plan 05-10 wires the orchestrator
-against both Claude- and Codex-shaped mock backends.
-``test_existing_tests_still_collect`` is NOT xfail — it is a live
-regression guard that enforces D-40: the 50+ existing tests must keep
-importing cleanly while Phase 5 lands.
-"""
+from __future__ import annotations
 
+import inspect
+import re
 from pathlib import Path
 
-import pytest
+from daydream.backends import CostEvent, ResultEvent, TextEvent
+from daydream.config import REVIEW_OUTPUT_FILE
 
 
-@pytest.mark.xfail(reason="Wave 5 plan 05-10 not yet implemented", strict=True)
-def test_claude_shape_backend(multi_stack_target: Path) -> None:
-    """D-38: run_deep works with Claude-shaped MockBackend."""
-    raise NotImplementedError
+class _DeepMockBackend:
+    """Prompt-dispatching mock backend. Subclasses tune cost + agents behavior."""
+
+    cost_usd: float | None = 0.01
+    raise_on_agents: bool = False
+
+    def __init__(self, target_dir: Path) -> None:
+        self.target_dir = target_dir
+        self.calls: list[str] = []
+        self.agents_kwargs_seen: list[object] = []
+
+    async def execute(
+        self,
+        cwd,
+        prompt,
+        output_schema=None,
+        continuation=None,
+        *,
+        agents=None,
+    ):
+        # Record parity evidence -- D-38: no stage may pass `agents=`.
+        self.agents_kwargs_seen.append(agents)
+        if agents and self.raise_on_agents:
+            raise NotImplementedError("Mock Codex: agents kwarg not supported")
+
+        yield CostEvent(
+            cost_usd=self.cost_usd, input_tokens=None, output_tokens=None
+        )
+
+        pl = prompt.lower()
+
+        # Intent prompt contains "intent of these changes" + "understand".
+        # Must be checked BEFORE the alternative branch because the alt-review
+        # prompt also contains "intent".
+        if "understand" in pl and "intent" in pl:
+            self.calls.append("intent")
+            yield TextEvent(text="Intent summary stub.")
+            yield ResultEvent(structured_output=None, continuation=None)
+            return
+
+        # Alternative-review prompt contains "architectural alternatives".
+        if "architectural alternatives" in pl or (
+            "alternative" in pl and "given this intent" in pl
+        ):
+            self.calls.append("alternatives")
+            yield TextEvent(text="")
+            yield ResultEvent(structured_output={"issues": []}, continuation=None)
+            return
+
+        # Per-stack review prompt contains "You are reviewing the ... stack".
+        if "you are reviewing the" in pl and "stack" in pl:
+            self.calls.append("per-stack")
+            # Write the per-stack review file to the path embedded in the prompt.
+            m = re.search(r"stack-(\S+?)-review\.md", prompt)
+            if m:
+                name = m.group(1)
+                out = self.target_dir / ".daydream" / "deep" / f"stack-{name}-review.md"
+                out.parent.mkdir(parents=True, exist_ok=True)
+                out.write_text(f"# Review ({name})\n\n## Issues\n1. [a.py:1] stub\n")
+            yield TextEvent(text="")
+            yield ResultEvent(structured_output=None, continuation=None)
+            return
+
+        # Parse-feedback prompt contains "Read the review output file at".
+        if "read the review output file" in pl or "extract only actionable issues" in pl:
+            self.calls.append("parse")
+            yield TextEvent(text="")
+            yield ResultEvent(structured_output={"issues": []}, continuation=None)
+            return
+
+        # Cross-stack merge prompt contains "cross-stack merge agent".
+        if "cross-stack merge agent" in pl:
+            self.calls.append("merge")
+            (self.target_dir / REVIEW_OUTPUT_FILE).write_text(
+                "# Review\n\n## Issues\n\n## Cross-Stack Issues\n"
+            )
+            yield TextEvent(text="")
+            yield ResultEvent(structured_output=None, continuation=None)
+            return
+
+        # Fallback -- unexpected prompt, but keep the pipeline alive.
+        self.calls.append("other")
+        yield TextEvent(text="")
+        yield ResultEvent(structured_output=None, continuation=None)
+
+    async def cancel(self) -> None:
+        pass
+
+    def format_skill_invocation(self, skill_key: str, args: str = "") -> str:
+        return f"/{skill_key}"
 
 
-@pytest.mark.xfail(reason="Wave 5 plan 05-10 not yet implemented", strict=True)
-def test_codex_shape_backend(multi_stack_target: Path) -> None:
-    """D-38: run_deep works with Codex-shaped MockBackend (no agents kwarg support)."""
-    raise NotImplementedError
+class _ClaudeShape(_DeepMockBackend):
+    cost_usd = 0.0123
+    raise_on_agents = False  # Claude accepts agents kwarg silently
 
 
-@pytest.mark.xfail(reason="Wave 5 plan 05-10 not yet implemented", strict=True)
+class _CodexShape(_DeepMockBackend):
+    cost_usd = None          # Codex does not report cost
+    raise_on_agents = True   # Codex rejects agents kwarg (parity contract)
+
+
+def _silence_ui(monkeypatch) -> None:
+    """Silence noisy UI helpers across orchestrator, phases, and runner."""
+    noop = lambda *a, **kw: None  # noqa: E731 -- terse silencer
+    for module in (
+        "daydream.deep.orchestrator",
+        "daydream.phases",
+        "daydream.runner",
+    ):
+        for name in (
+            "print_stage_progress",
+            "print_preflight_notice",
+            "print_phase_hero",
+            "print_info",
+            "print_success",
+            "print_warning",
+            "print_error",
+            "print_dim",
+            "print_issues_table",
+        ):
+            monkeypatch.setattr(f"{module}.{name}", noop, raising=False)
+
+
+def _wire_mocks(monkeypatch, backend: _DeepMockBackend) -> None:
+    """Install the mock backend + silence prompts and UI.
+
+    ``phase_understand_intent`` loops on ``prompt_user`` until the user confirms
+    with ``y`` -- so ``daydream.phases.prompt_user`` must return ``y``.
+    The orchestrator's fix gate must return ``n`` so we skip the fix pass.
+    """
+    monkeypatch.setattr(
+        "daydream.runner.create_backend",
+        lambda name, model=None: backend,
+    )
+    # Orchestrator fix gate: decline to apply fixes.
+    monkeypatch.setattr(
+        "daydream.deep.orchestrator.prompt_user",
+        lambda *a, **kw: "n",
+        raising=False,
+    )
+    # Intent confirmation loop: accept the first answer.
+    monkeypatch.setattr(
+        "daydream.phases.prompt_user",
+        lambda *a, **kw: "y",
+        raising=False,
+    )
+    # Runner-level prompts (target dir, cleanup): never reached when `target`
+    # and `cleanup` are explicit on RunConfig, but be defensive.
+    monkeypatch.setattr(
+        "daydream.runner.prompt_user",
+        lambda *a, **kw: "n",
+        raising=False,
+    )
+    _silence_ui(monkeypatch)
+
+
+async def _run_deep(target: Path, backend: _DeepMockBackend, monkeypatch) -> int:
+    """Common driver: wire mocks and execute the full deep pipeline."""
+    from daydream.exploration import ExplorationContext
+    from daydream.runner import RunConfig, run
+
+    _wire_mocks(monkeypatch, backend)
+
+    # Pre-populate exploration context to skip the safe_explore backend call.
+    # The orchestrator only runs pre-scan when `exploration_context is None`.
+    config = RunConfig(
+        target=str(target),
+        deep=True,
+        cleanup=False,
+        exploration_context=ExplorationContext(),
+    )
+    return await run(config)
+
+
+async def test_claude_shape_backend(multi_stack_target: Path, monkeypatch) -> None:
+    """D-38: run_deep completes end-to-end on a Claude-shaped backend (cost_usd populated)."""
+    backend = _ClaudeShape(multi_stack_target)
+    exit_code = await _run_deep(multi_stack_target, backend, monkeypatch)
+
+    assert exit_code == 0, f"run_deep returned {exit_code} (expected 0)"
+    assert (multi_stack_target / REVIEW_OUTPUT_FILE).exists(), (
+        "merged report missing after Claude-shape run"
+    )
+    # Stages fired: intent, alternatives, at least one per-stack, parse, merge.
+    required = {"intent", "alternatives", "per-stack", "parse", "merge"}
+    assert required.issubset(set(backend.calls)), (
+        f"missing stages; saw only: {sorted(set(backend.calls))}"
+    )
+
+
+async def test_codex_shape_backend(multi_stack_target: Path, monkeypatch) -> None:
+    """D-38: run_deep completes on Codex-shape (cost_usd=None, no agents= ever passed)."""
+    backend = _CodexShape(multi_stack_target)
+    exit_code = await _run_deep(multi_stack_target, backend, monkeypatch)
+
+    assert exit_code == 0, f"run_deep returned {exit_code} (expected 0)"
+    assert (multi_stack_target / REVIEW_OUTPUT_FILE).exists(), (
+        "merged report missing after Codex-shape run"
+    )
+    # Parity guarantee: if any stage had passed agents=, the mock would have
+    # raised NotImplementedError and run_deep would NOT have reached exit 0.
+    # Extra belt-and-braces assertion:
+    assert all(a in (None, False, [], {}, 0, "") for a in backend.agents_kwargs_seen), (
+        f"agents kwarg was passed somewhere: {backend.agents_kwargs_seen}"
+    )
+
+
 def test_phase_primitives_unmodified() -> None:
-    """D-39: phase_understand_intent, phase_alternative_review, phase_parse_feedback invoked unchanged."""
-    raise NotImplementedError
+    """D-39: existing phase primitives imported unchanged by run_deep."""
+    from daydream.phases import (
+        phase_alternative_review,
+        phase_commit_push,
+        phase_fix,
+        phase_parse_feedback,
+        phase_test_and_heal,
+        phase_understand_intent,
+    )
+
+    # phase_parse_feedback gained an OPTIONAL keyword-only kwarg per plan 05-06.
+    # Positional callers (runner.py:231, 580, 704) still work because
+    # `input_path` is keyword-only with default None.
+    sig = inspect.signature(phase_parse_feedback)
+    params = list(sig.parameters.values())
+    assert params[0].name == "backend", (
+        f"phase_parse_feedback first param: {params[0].name}"
+    )
+    assert params[1].name == "cwd", (
+        f"phase_parse_feedback second param: {params[1].name}"
+    )
+    input_path = sig.parameters.get("input_path")
+    assert input_path is not None, "phase_parse_feedback missing input_path kwarg"
+    assert input_path.kind == inspect.Parameter.KEYWORD_ONLY, (
+        f"input_path kind: {input_path.kind}"
+    )
+    assert input_path.default is None, (
+        f"input_path default: {input_path.default!r}"
+    )
+
+    # Other primitives: first two params are (backend, cwd).
+    # Don't over-specify beyond that -- the tail may grow with kwargs in future
+    # phases without violating the D-39 contract.
+    for fn in (
+        phase_understand_intent,
+        phase_alternative_review,
+        phase_fix,
+        phase_test_and_heal,
+        phase_commit_push,
+    ):
+        params = list(inspect.signature(fn).parameters.values())
+        assert params[0].name == "backend", (
+            f"{fn.__name__} first param: {params[0].name}"
+        )
+        assert params[1].name in ("cwd", "target_dir"), (
+            f"{fn.__name__} second param: {params[1].name}"
+        )
+
+    # D-39 negative guard: no "v2" or "_deep_" wrappers crept in.
+    import daydream.phases as phases_mod
+
+    leaked = [
+        name
+        for name in dir(phases_mod)
+        if ("v2" in name.lower() or "_deep_" in name.lower())
+        and name.startswith("phase_")
+    ]
+    assert not leaked, f"forbidden phase wrappers present: {leaked}"
 
 
 def test_existing_tests_still_collect() -> None:
-    """D-40: smoke check that existing tests still import."""
+    """D-40: existing tests still import and collect."""
     import tests.test_cli  # noqa: F401
     import tests.test_integration  # noqa: F401
     import tests.test_loop  # noqa: F401

--- a/tests/test_deep_integration.py
+++ b/tests/test_deep_integration.py
@@ -1,0 +1,38 @@
+"""Deep-mode backend parity integration tests (D-38..D-40).
+
+Most tests are xfail(strict=True) until plan 05-10 wires the orchestrator
+against both Claude- and Codex-shaped mock backends.
+``test_existing_tests_still_collect`` is NOT xfail — it is a live
+regression guard that enforces D-40: the 50+ existing tests must keep
+importing cleanly while Phase 5 lands.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.xfail(reason="Wave 5 plan 05-10 not yet implemented", strict=True)
+def test_claude_shape_backend(multi_stack_target: Path) -> None:
+    """D-38: run_deep works with Claude-shaped MockBackend."""
+    raise NotImplementedError
+
+
+@pytest.mark.xfail(reason="Wave 5 plan 05-10 not yet implemented", strict=True)
+def test_codex_shape_backend(multi_stack_target: Path) -> None:
+    """D-38: run_deep works with Codex-shaped MockBackend (no agents kwarg support)."""
+    raise NotImplementedError
+
+
+@pytest.mark.xfail(reason="Wave 5 plan 05-10 not yet implemented", strict=True)
+def test_phase_primitives_unmodified() -> None:
+    """D-39: phase_understand_intent, phase_alternative_review, phase_parse_feedback invoked unchanged."""
+    raise NotImplementedError
+
+
+def test_existing_tests_still_collect() -> None:
+    """D-40: smoke check that existing tests still import."""
+    import tests.test_cli  # noqa: F401
+    import tests.test_integration  # noqa: F401
+    import tests.test_loop  # noqa: F401
+    import tests.test_phases  # noqa: F401

--- a/tests/test_deep_integration.py
+++ b/tests/test_deep_integration.py
@@ -280,8 +280,20 @@ def test_phase_primitives_unmodified() -> None:
 
 
 def test_existing_tests_still_collect() -> None:
-    """D-40: existing tests still import and collect."""
-    import tests.test_cli  # noqa: F401
-    import tests.test_integration  # noqa: F401
-    import tests.test_loop  # noqa: F401
-    import tests.test_phases  # noqa: F401
+    """D-40: existing tests still import and collect.
+
+    Loads the target test modules by absolute file path via ``importlib``
+    so the check doesn't depend on ``tests`` being resolvable as a package
+    on ``sys.path`` — a sibling repository can shadow that name when
+    multiple projects share a ``PYTHONPATH`` root.
+    """
+    import importlib.util
+
+    tests_dir = Path(__file__).parent
+    for name in ("test_cli", "test_integration", "test_loop", "test_phases"):
+        spec = importlib.util.spec_from_file_location(
+            f"_d40_probe_{name}", tests_dir / f"{name}.py"
+        )
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)

--- a/tests/test_deep_merge.py
+++ b/tests/test_deep_merge.py
@@ -1,0 +1,132 @@
+"""Cross-stack merge prompt + invocation tests (D-23..D-27, D-38)."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from daydream.backends import ResultEvent, TextEvent
+from daydream.deep.prompts import build_merge_prompt
+from daydream.phases import phase_cross_stack_merge
+
+
+def test_merge_prompt_specifies_report_format(tmp_path: Path) -> None:
+    """D-25: the flat numbered ## Issues + ## Cross-Stack Issues structure is specified."""
+    intent = tmp_path / "intent.md"
+    alts = tmp_path / "alts.json"
+    dedup = tmp_path / "dedup.json"
+    out = tmp_path / ".review-output.md"
+    records = [tmp_path / "r1.json", tmp_path / "r2.json"]
+    prompt = build_merge_prompt(
+        per_stack_records_paths=records,
+        intent_path=intent,
+        alternatives_path=alts,
+        dedup_candidates_path=dedup,
+        output_path=out,
+    )
+    assert "## Issues" in prompt
+    assert "## Cross-Stack Issues" in prompt
+    assert "continues the SAME numbering" in prompt
+
+
+def test_merge_prompt_mandates_cross_stack_prefix(tmp_path: Path) -> None:
+    """D-26: every cross-stack title must begin with [cross-stack]."""
+    prompt = build_merge_prompt(
+        per_stack_records_paths=[tmp_path / "r.json"],
+        intent_path=tmp_path / "i.md",
+        alternatives_path=tmp_path / "a.json",
+        dedup_candidates_path=tmp_path / "d.json",
+        output_path=tmp_path / ".review-output.md",
+    )
+    assert "[cross-stack]" in prompt
+    assert "MUST begin with the literal prefix [cross-stack]" in prompt
+
+
+def test_merge_prompt_references_records_by_path(tmp_path: Path) -> None:
+    """D-22: prompt references records by path, not embedded content."""
+    records = [
+        tmp_path / "deep" / "stack-python-records.json",
+        tmp_path / "deep" / "stack-react-records.json",
+    ]
+    prompt = build_merge_prompt(
+        per_stack_records_paths=records,
+        intent_path=tmp_path / "i.md",
+        alternatives_path=tmp_path / "a.json",
+        dedup_candidates_path=tmp_path / "d.json",
+        output_path=tmp_path / ".review-output.md",
+    )
+    for r in records:
+        assert str(r) in prompt
+
+
+def test_merge_prompt_mentions_dedup_candidates(tmp_path: Path) -> None:
+    """D-27: merger is told to read dedup-candidates and adjudicate."""
+    prompt = build_merge_prompt(
+        per_stack_records_paths=[tmp_path / "r.json"],
+        intent_path=tmp_path / "i.md",
+        alternatives_path=tmp_path / "a.json",
+        dedup_candidates_path=tmp_path / "dedup-candidates.json",
+        output_path=tmp_path / ".review-output.md",
+    )
+    assert "dedup-candidates.json" in prompt or "candidate pair" in prompt
+    assert (
+        "adjudication" in prompt.lower()
+        or "adjudicate" in prompt.lower()
+        or "decide" in prompt.lower()
+    )
+
+
+class _RecordingBackend:
+    """Records every execute call; verifies no `agents` kwarg was passed."""
+
+    def __init__(self) -> None:
+        self.agents_seen: list[Any] = []
+        self.prompts: list[str] = []
+
+    async def execute(
+        self,
+        cwd: Path,
+        prompt: str,
+        output_schema: Any = None,
+        continuation: Any = None,
+        agents: Any = None,
+    ):
+        self.prompts.append(prompt)
+        self.agents_seen.append(agents)
+        yield TextEvent(text="merged")
+        yield ResultEvent(structured_output=None, continuation=None)
+
+    async def cancel(self) -> None:
+        pass
+
+    def format_skill_invocation(self, skill_key: str, args: str = "") -> str:
+        return f"/{skill_key}"
+
+
+async def test_phase_cross_stack_merge_returns_output_path(tmp_path: Path) -> None:
+    """D-24: merged report path is cwd / REVIEW_OUTPUT_FILE."""
+    from daydream.config import REVIEW_OUTPUT_FILE
+
+    backend = _RecordingBackend()
+    result = await phase_cross_stack_merge(
+        backend,
+        tmp_path,
+        per_stack_records_paths=[tmp_path / "r.json"],
+        intent_path=tmp_path / "i.md",
+        alternatives_path=tmp_path / "a.json",
+        dedup_candidates_path=tmp_path / "d.json",
+    )
+    assert result == tmp_path / REVIEW_OUTPUT_FILE
+
+
+async def test_phase_cross_stack_merge_no_agents_kwarg(tmp_path: Path) -> None:
+    """D-38: no agents= kwarg (Codex compatibility)."""
+    backend = _RecordingBackend()
+    await phase_cross_stack_merge(
+        backend,
+        tmp_path,
+        per_stack_records_paths=[tmp_path / "r.json"],
+        intent_path=tmp_path / "i.md",
+        alternatives_path=tmp_path / "a.json",
+        dedup_candidates_path=tmp_path / "d.json",
+    )
+    assert all(a is None for a in backend.agents_seen)

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -491,6 +491,47 @@ async def test_resume_overwrites(multi_stack_target: Path, monkeypatch: pytest.M
     assert "STALE CONTENT" not in old.read_text()
 
 
+async def test_resume_merge_consumes_saved_records(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--start-at merge loads stack-*-records.json and does NOT re-parse reviews.
+
+    Regression: previously the merge branch always re-ran phase_parse_feedback
+    against reconstructed stack-*-review.md paths, so resume failed when those
+    markdown files were absent even though the validated records.json existed.
+    """
+    import json
+
+    _silence(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+
+    deep = multi_stack_target / ".daydream" / "deep"
+    deep.mkdir(parents=True, exist_ok=True)
+    (deep / "intent.md").write_text("primed intent")
+    (deep / "alternatives.json").write_text("[]")
+    # Prime saved records but intentionally NOT the review.md files -- the
+    # resume path must consume records.json directly.
+    (deep / "stack-python-records.json").write_text(
+        json.dumps([{"id": 1, "description": "py issue", "file": "api.py", "line": 1}])
+    )
+    (deep / "stack-react-records.json").write_text(
+        json.dumps([{"id": 1, "description": "tsx issue", "file": "App.tsx", "line": 1}])
+    )
+
+    exit_code = await _run_deep(multi_stack_target, start_at="merge")
+    assert exit_code == 0
+
+    # Parse phase must NOT have been invoked (records already on disk).
+    parse_calls = [c for c in stub.calls if "extract only actionable issues" in c["prompt"].lower()]
+    assert parse_calls == [], f"unexpected parse invocations on merge resume: {len(parse_calls)}"
+
+    # Merge agent must have run and produced the merged report.
+    merge_calls = [c for c in stub.calls if "cross-stack merge agent" in c["prompt"].lower()]
+    assert len(merge_calls) == 1
+    from daydream.config import REVIEW_OUTPUT_FILE
+    assert (multi_stack_target / REVIEW_OUTPUT_FILE).exists()
+
+
 async def test_stage_ui_surfacing(multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """D-44: UI prints [stage N/5: ...] at each stage boundary."""
     progress_calls: list[tuple[int, int, str]] = []
@@ -511,3 +552,152 @@ async def test_stage_ui_surfacing(multi_stack_target: Path, monkeypatch: pytest.
     assert stage_numbers == {1, 2, 3, 4, 5}
     # Total is always 5.
     assert all(c[1] == 5 for c in progress_calls)
+
+
+def _write_plugin_registry(config_dir: Path, plugin_names: list[str]) -> None:
+    registry = config_dir / "plugins" / "installed_plugins.json"
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    registry.write_text(
+        '{"version": 2, "plugins": {'
+        + ", ".join(f'"{name}@marketplace": []' for name in plugin_names)
+        + "}}"
+    )
+
+
+def test_get_installed_skills_full(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """All per-stack beagle plugins present -> full SKILL_MAP coverage."""
+    from daydream.config import SKILL_MAP
+    from daydream.deep.orchestrator import get_installed_skills
+
+    plugin_names = [skill.split(":", 1)[0] for skill in SKILL_MAP.values()]
+    _write_plugin_registry(tmp_path, plugin_names)
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+
+    assert get_installed_skills() == set(SKILL_MAP.keys())
+
+
+def test_get_installed_skills_partial(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Missing beagle-go plugin -> go is excluded from availability."""
+    from daydream.deep.orchestrator import get_installed_skills
+
+    _write_plugin_registry(tmp_path, ["beagle-python", "beagle-react"])
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+
+    result = get_installed_skills()
+    assert result == {"python", "react"}
+
+
+def test_get_installed_skills_missing_registry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Missing registry file -> None (signals 'unknown' to the caller)."""
+    from daydream.deep.orchestrator import get_installed_skills
+
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    assert get_installed_skills() is None
+
+
+def test_get_installed_skills_malformed_registry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unparseable registry -> None (fall back to optimistic availability)."""
+    from daydream.deep.orchestrator import get_installed_skills
+
+    registry = tmp_path / "plugins" / "installed_plugins.json"
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    registry.write_text("not json {{{")
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+
+    assert get_installed_skills() is None
+
+
+def test_run_deep_routes_missing_skill_to_generic(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When beagle-react is absent, React files route to the generic bucket.
+
+    Regression: previously orchestrator passed ``set(SKILL_MAP.keys())`` as
+    availability, so detect_stacks kept React as its own stack, the per-stack
+    agent raised MissingSkillError, and phase_per_stack_reviews silently
+    dropped the React findings.
+    """
+    import anyio
+
+    from daydream.deep import detection as _detection
+
+    _silence(monkeypatch)
+    _install_stub_backend(monkeypatch, multi_stack_target)
+    # Registry with only python installed -- react and markdown should route to generic.
+    _write_plugin_registry(tmp_path, ["beagle-python"])
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+
+    captured: dict[str, list[_detection.StackAssignment]] = {}
+    real_detect = _detection.detect_stacks
+
+    def _spy(files: list[str], **kwargs: Any) -> list[_detection.StackAssignment]:
+        result = real_detect(files, **kwargs)
+        captured["stacks"] = result
+        return result
+
+    monkeypatch.setattr("daydream.deep.orchestrator.detect_stacks", _spy)
+
+    exit_code = anyio.run(_run_deep, multi_stack_target)
+    assert exit_code == 0
+
+    stacks = {s.stack_name for s in captured["stacks"]}
+    # Python remains, but React (no skill installed) must have fallen through to generic.
+    assert "python" in stacks
+    assert "react" not in stacks
+    assert "generic" in stacks
+
+
+def test_diff_changed_files_rename_single_entry() -> None:
+    """Rename diff contributes only the destination path, not both sides."""
+    from daydream.deep.orchestrator import _diff_changed_files
+
+    rename_diff = (
+        "diff --git a/foo.py b/foo.ts\n"
+        "similarity index 85%\n"
+        "rename from foo.py\n"
+        "rename to foo.ts\n"
+        "--- a/foo.py\n"
+        "+++ b/foo.ts\n"
+        "@@ -1 +1 @@\n"
+        "-x = 1\n"
+        "+const x = 1;\n"
+    )
+    assert _diff_changed_files(rename_diff) == ["foo.ts"]
+
+
+def test_diff_changed_files_handles_modify_add_delete_binary() -> None:
+    """Non-rename diff shapes emit exactly one path each."""
+    from daydream.deep.orchestrator import _diff_changed_files
+
+    mixed = (
+        "diff --git a/keep.py b/keep.py\n"
+        "--- a/keep.py\n"
+        "+++ b/keep.py\n"
+        "@@ -1 +1 @@\n"
+        "-x = 1\n"
+        "+x = 2\n"
+        "diff --git a/new.py b/new.py\n"
+        "new file mode 100644\n"
+        "--- /dev/null\n"
+        "+++ b/new.py\n"
+        "@@ -0,0 +1 @@\n"
+        "+x = 1\n"
+        "diff --git a/old.py b/old.py\n"
+        "deleted file mode 100644\n"
+        "--- a/old.py\n"
+        "+++ /dev/null\n"
+        "@@ -1 +0,0 @@\n"
+        "-x = 1\n"
+        "diff --git a/logo.png b/logo.png\n"
+        "index 1234..5678 100644\n"
+        "Binary files a/logo.png and b/logo.png differ\n"
+    )
+    assert _diff_changed_files(mixed) == ["keep.py", "new.py", "old.py", "logo.png"]

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -1,114 +1,505 @@
-"""Deep-mode orchestrator integration tests (xfail until plan 05-09).
+"""Deep-mode orchestrator integration tests (plan 05-09).
 
 Covers D-07..D-10, D-17, D-19..D-22, D-24..D-26, D-28, D-30, D-31,
-D-34, D-35, D-44. Test bodies are intentionally stubbed with
-``raise NotImplementedError`` so the xfail(strict=True) contract holds
-until plan 05-09 fills them in.
+D-34, D-35, D-44.
+
+The tests share a ``_StubBackend`` that dispatches on prompt content to
+simulate the full review pipeline without talking to a real SDK.
 """
 
+from __future__ import annotations
+
+import io
+import json
+import re
+import subprocess
 from pathlib import Path
+from typing import Any
 
 import pytest
 
-
-@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
-def test_pipeline_order(multi_stack_target: Path) -> None:
-    """D-07: Stage order = TTT -> per-stack -> parse -> merge."""
-    # Fill in plan 05-09 when orchestrator exists.
-    raise NotImplementedError
+from daydream.backends import ResultEvent, TextEvent
 
 
-@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
-def test_fresh_context_per_stage(multi_stack_target: Path) -> None:
-    """D-08: Each stage = distinct Backend.execute call."""
-    raise NotImplementedError
+class _StubBackend:
+    """MockBackend that dispatches on prompt content.
+
+    Writes realistic per-stack review outputs and a merged report so the
+    orchestrator can progress through every stage. Records every call so
+    tests can assert ordering, agents-kwarg absence, and per-stack isolation.
+    """
+
+    def __init__(self, target: Path, *, is_codex: bool = False) -> None:
+        self._target = target
+        self._is_codex = is_codex
+        self.calls: list[dict[str, Any]] = []
+
+    async def execute(
+        self,
+        cwd: Path,
+        prompt: str,
+        output_schema: Any = None,
+        continuation: Any = None,
+        agents: Any = None,
+    ):
+        self.calls.append(
+            {
+                "cwd": cwd,
+                "prompt": prompt,
+                "output_schema": output_schema,
+                "agents": agents,
+            }
+        )
+        pl = prompt.lower()
+
+        # TTT intent phase -> returns plain text.
+        if "describe what these changes are trying to achieve" in pl or "confirm your understanding" in pl:
+            yield TextEvent(text="The PR updates greetings across stacks.")
+            yield ResultEvent(structured_output=None, continuation=None)
+            return
+
+        # TTT alternative-review phase -> structured output.
+        if "alternative" in pl and "evaluate" in pl:
+            yield TextEvent(text="")
+            yield ResultEvent(
+                structured_output={
+                    "issues": [
+                        {
+                            "id": 1,
+                            "title": "Inconsistent greeting wording",
+                            "description": "'universe' diverges from 'world' in docs",
+                            "recommendation": "align copy",
+                            "severity": "low",
+                            "files": ["api.py", "README.md"],
+                        }
+                    ]
+                },
+                continuation=None,
+            )
+            return
+
+        # Per-stack review -> write a markdown file + emit done.
+        m = re.search(r"you are reviewing the (\S+) stack", pl)
+        if m is None:
+            m = re.search(r"you are reviewing the (generic-fallback) stack", pl)
+        if m is not None:
+            # Extract the output path the prompt asks the agent to write.
+            out_match = re.search(r"write your full review to (\S+)", prompt, flags=re.IGNORECASE)
+            if out_match is not None:
+                out_path = Path(out_match.group(1))
+                out_path.parent.mkdir(parents=True, exist_ok=True)
+                stack = m.group(1)
+                out_path.write_text(
+                    f"# Review ({stack})\n\n## Issues\n\n1. [api.py:1] Sample issue for {stack}\n"
+                )
+            yield TextEvent(text="")
+            yield ResultEvent(structured_output=None, continuation=None)
+            return
+
+        # phase_parse_feedback -> structured output.
+        if "extract only actionable issues" in pl:
+            yield TextEvent(text="")
+            yield ResultEvent(
+                structured_output={
+                    "issues": [
+                        {"id": 1, "description": "Sample issue", "file": "api.py", "line": 1}
+                    ]
+                },
+                continuation=None,
+            )
+            return
+
+        # Cross-stack merge -> write the report to REVIEW_OUTPUT_FILE.
+        if "cross-stack merge agent" in pl:
+            out_match = re.search(r"write the complete report to (\S+)", prompt, flags=re.IGNORECASE)
+            if out_match is not None:
+                out_path = Path(out_match.group(1))
+                out_path.parent.mkdir(parents=True, exist_ok=True)
+                out_path.write_text(
+                    "# Review\n\n"
+                    "## Issues\n\n"
+                    "1. [api.py:1] Python issue\n"
+                    "   rationale\n"
+                    "2. [App.tsx:1] React issue\n"
+                    "   rationale\n\n"
+                    "## Cross-Stack Issues\n\n"
+                    "3. [cross-stack] [api.py:1] Contract drift between Python handler and React caller\n"
+                    "   rationale\n"
+                )
+            yield TextEvent(text="")
+            yield ResultEvent(structured_output=None, continuation=None)
+            return
+
+        # Default: empty text + no structured output.
+        yield TextEvent(text="")
+        yield ResultEvent(structured_output=None, continuation=None)
+
+    async def cancel(self) -> None:
+        pass
+
+    def format_skill_invocation(self, skill_key: str, args: str = "") -> str:
+        return f"/{skill_key}"
 
 
-@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
-def test_artifacts_on_disk(multi_stack_target: Path) -> None:
-    """D-09: intent.md, alternatives.json, stack-*-review.md, stack-*-records.json written under .daydream/deep/."""
-    raise NotImplementedError
+def _silence(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Silence interactive UI helpers in deep orchestrator + phases."""
+    monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.deep.orchestrator.prompt_user", lambda *a, **kw: "n")
+    # phase_understand_intent calls prompt_user("Is this understanding correct?", "y")
+    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
 
 
-@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
-def test_per_stack_context_isolation(multi_stack_target: Path) -> None:
-    """D-10: per-stack agents never see each other's outputs."""
-    raise NotImplementedError
+def _install_stub_backend(
+    monkeypatch: pytest.MonkeyPatch, target: Path, *, is_codex: bool = False
+) -> _StubBackend:
+    """Patch create_backend to return a single stub backend instance."""
+    stub = _StubBackend(target, is_codex=is_codex)
+    monkeypatch.setattr("daydream.runner.create_backend", lambda name, model=None: stub)
+    # When is_codex=True, the orchestrator's isinstance(backend, CodexBackend)
+    # check needs to succeed. Patch CodexBackend to our stub's class so the
+    # isinstance check fires without needing a real Codex dependency.
+    if is_codex:
+        monkeypatch.setattr("daydream.deep.orchestrator.CodexBackend", _StubBackend, raising=False)
+    return stub
 
 
-@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
-def test_parallel_fan_out(multi_stack_target: Path) -> None:
-    """D-17: per-stack fan-out uses anyio task group + CapacityLimiter."""
-    raise NotImplementedError
+async def _run_deep(target: Path, *, start_at: str = "review") -> int:
+    from daydream.runner import RunConfig, run
+
+    config = RunConfig(target=str(target), deep=True, start_at=start_at)
+    return await run(config)
 
 
-@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
-def test_per_stack_prompt_context(multi_stack_target: Path) -> None:
-    """D-19: per-stack prompt references intent + alternatives paths."""
-    raise NotImplementedError
+async def test_pipeline_order(multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """D-07: Stage order = TTT intent -> alternatives -> per-stack -> parse -> merge."""
+    _silence(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+
+    exit_code = await _run_deep(multi_stack_target)
+    assert exit_code == 0
+
+    # Classify each call by inspecting prompt content.
+    order: list[str] = []
+    for call in stub.calls:
+        pl = call["prompt"].lower()
+        if "describe what these changes are trying to achieve" in pl:
+            order.append("intent")
+        elif "alternative" in pl and "evaluate" in pl:
+            order.append("alternatives")
+        elif "you are reviewing the" in pl and "stack" in pl:
+            order.append("per-stack")
+        elif "extract only actionable issues" in pl:
+            order.append("parse")
+        elif "cross-stack merge agent" in pl:
+            order.append("merge")
+
+    first = {name: order.index(name) for name in set(order)}
+    assert first["intent"] < first["alternatives"]
+    assert first["alternatives"] < first["per-stack"]
+    assert first["per-stack"] < first["parse"]
+    assert first["parse"] < first["merge"]
 
 
-@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
-def test_doc_review_notice(multi_stack_target: Path) -> None:
-    """D-20: .md routed to generic fallback surfaces doc-review notice."""
-    raise NotImplementedError
+async def test_fresh_context_per_stage(multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """D-08: Each stage = a distinct Backend.execute call (no continuation reuse)."""
+    _silence(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+
+    exit_code = await _run_deep(multi_stack_target)
+    assert exit_code == 0
+    # At minimum: intent + alternatives + 3 per-stack + 3 parse + 1 merge = 9 distinct calls.
+    assert len(stub.calls) >= 8
+    # Distinct by prompt (no test here about continuation, just that each stage fires a separate execute).
+    prompts = [c["prompt"] for c in stub.calls]
+    assert len(set(prompts)) == len(prompts) or len(prompts) >= 8
 
 
-@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
-def test_pre_merge_parse_per_stack(multi_stack_target: Path) -> None:
-    """D-21, D-22: phase_parse_feedback invoked per per-stack output, merger consumes records."""
-    raise NotImplementedError
+async def test_artifacts_on_disk(multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """D-09: intent.md, alternatives.json, stack-*-review.md, stack-*-records.json exist."""
+    _silence(monkeypatch)
+    _install_stub_backend(monkeypatch, multi_stack_target)
+
+    exit_code = await _run_deep(multi_stack_target)
+    assert exit_code == 0
+
+    deep = multi_stack_target / ".daydream" / "deep"
+    assert (deep / "intent.md").exists()
+    assert (deep / "alternatives.json").exists()
+    # At least one per-stack review and one per-stack records JSON.
+    review_files = list(deep.glob("stack-*-review.md"))
+    records_files = list(deep.glob("stack-*-records.json"))
+    assert review_files, "expected at least one stack-*-review.md"
+    assert records_files, "expected at least one stack-*-records.json"
+    # Dedup candidates.
+    assert (deep / "dedup-candidates.json").exists()
 
 
-@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
-def test_merged_report_path(multi_stack_target: Path) -> None:
-    """D-24: final report at REVIEW_OUTPUT_FILE path."""
-    raise NotImplementedError
+async def test_per_stack_context_isolation(multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """D-10: per-stack prompts don't embed other stacks' file lists."""
+    _silence(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+
+    exit_code = await _run_deep(multi_stack_target)
+    assert exit_code == 0
+
+    # Find per-stack prompts.
+    per_stack_prompts = [
+        c["prompt"] for c in stub.calls if "you are reviewing the" in c["prompt"].lower()
+    ]
+    assert per_stack_prompts, "expected per-stack prompts"
+    # Each per-stack prompt should mention its own stack's file but NOT foreign files.
+    python_prompt = next((p for p in per_stack_prompts if "api.py" in p and "the python stack" in p.lower()), None)
+    react_prompt = next((p for p in per_stack_prompts if "app.tsx" in p.lower() and "the react stack" in p.lower()), None)
+    assert python_prompt is not None
+    assert react_prompt is not None
+    # Python prompt should not embed React files in its scope instruction.
+    python_scope_line = next(
+        line for line in python_prompt.splitlines() if "focus only on these files" in line.lower()
+    )
+    # next line holds the actual file list (per build_per_stack_prompt).
+    assert "App.tsx" not in python_prompt.split("Focus ONLY on these files:")[1].split("\n", 2)[1]
 
 
-@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
-def test_report_format_flat_numbered(multi_stack_target: Path) -> None:
-    """D-25: flat globally-numbered ## Issues + ## Cross-Stack Issues subsection continuing numbering."""
-    raise NotImplementedError
+async def test_parallel_fan_out(multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """D-17: per-stack fan-out uses anyio task group. No ``agents`` kwarg passed to execute."""
+    _silence(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+
+    exit_code = await _run_deep(multi_stack_target)
+    assert exit_code == 0
+    # Every execute call must have agents=None per D-38.
+    assert all(c["agents"] is None for c in stub.calls)
 
 
-@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
-def test_cross_stack_prefix(multi_stack_target: Path) -> None:
+async def test_per_stack_prompt_context(multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """D-19: per-stack prompts reference intent and alternatives paths."""
+    _silence(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+
+    exit_code = await _run_deep(multi_stack_target)
+    assert exit_code == 0
+
+    per_stack_prompts = [
+        c["prompt"] for c in stub.calls if "you are reviewing the" in c["prompt"].lower()
+    ]
+    assert per_stack_prompts
+    for p in per_stack_prompts:
+        assert "intent.md" in p
+        assert "alternatives.json" in p
+
+
+async def test_doc_review_notice(multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """D-20: generic fallback gets build_generic_fallback_prompt (may include doc notice when docs-only)."""
+    _silence(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+
+    exit_code = await _run_deep(multi_stack_target)
+    assert exit_code == 0
+
+    # In the multi-stack fixture the diff is mixed (python + react + md), so the
+    # generic bucket is NOT docs-only and the notice is NOT expected. The contract
+    # is: a generic-fallback prompt is emitted for README.md and it mentions the
+    # file.
+    fallback_prompts = [
+        c["prompt"] for c in stub.calls if "you are reviewing the generic-fallback stack" in c["prompt"].lower()
+    ]
+    assert fallback_prompts
+    assert any("README.md" in p for p in fallback_prompts)
+
+
+async def test_pre_merge_parse_per_stack(multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """D-21, D-22: phase_parse_feedback invoked once per per-stack output; records written."""
+    _silence(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+
+    exit_code = await _run_deep(multi_stack_target)
+    assert exit_code == 0
+
+    parse_calls = [
+        c for c in stub.calls if "extract only actionable issues" in c["prompt"].lower()
+    ]
+    # At least as many parse calls as per-stack outputs.
+    per_stack_outputs = list((multi_stack_target / ".daydream" / "deep").glob("stack-*-review.md"))
+    assert len(parse_calls) >= len(per_stack_outputs)
+    records = list((multi_stack_target / ".daydream" / "deep").glob("stack-*-records.json"))
+    assert len(records) == len(per_stack_outputs)
+
+
+async def test_merged_report_path(multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """D-24: final report written at REVIEW_OUTPUT_FILE path."""
+    _silence(monkeypatch)
+    _install_stub_backend(monkeypatch, multi_stack_target)
+
+    exit_code = await _run_deep(multi_stack_target)
+    assert exit_code == 0
+    from daydream.config import REVIEW_OUTPUT_FILE
+
+    assert (multi_stack_target / REVIEW_OUTPUT_FILE).exists()
+
+
+async def test_report_format_flat_numbered(multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """D-25: flat globally-numbered ## Issues + continuing ## Cross-Stack Issues subsection."""
+    _silence(monkeypatch)
+    _install_stub_backend(monkeypatch, multi_stack_target)
+
+    exit_code = await _run_deep(multi_stack_target)
+    assert exit_code == 0
+    from daydream.config import REVIEW_OUTPUT_FILE
+
+    text = (multi_stack_target / REVIEW_OUTPUT_FILE).read_text()
+    assert "## Issues" in text
+    assert "## Cross-Stack Issues" in text
+    # Numbering continues: stub writes 1., 2. in ## Issues then 3. in ## Cross-Stack Issues.
+    assert "3." in text.split("## Cross-Stack Issues", 1)[1]
+
+
+async def test_cross_stack_prefix(multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """D-26: every cross-stack title starts with [cross-stack]."""
-    raise NotImplementedError
+    _silence(monkeypatch)
+    _install_stub_backend(monkeypatch, multi_stack_target)
+
+    exit_code = await _run_deep(multi_stack_target)
+    assert exit_code == 0
+    from daydream.config import REVIEW_OUTPUT_FILE
+
+    text = (multi_stack_target / REVIEW_OUTPUT_FILE).read_text()
+    cross_section = text.split("## Cross-Stack Issues", 1)[1]
+    assert "[cross-stack]" in cross_section
 
 
-@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
-def test_fix_gate_prompt(multi_stack_target: Path) -> None:
-    """D-28: Y/n prompt after merge."""
-    raise NotImplementedError
+async def test_fix_gate_prompt(multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """D-28: Y/n prompt after merge decides whether to apply fixes."""
+    _install_stub_backend(monkeypatch, multi_stack_target)
+
+    asked: list[str] = []
+
+    def _record_prompt(console, message, default=""):
+        asked.append(message)
+        # Decline the fix gate.
+        return "n"
+
+    monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.deep.orchestrator.prompt_user", _record_prompt)
+    # phase_understand_intent also calls prompt_user; always confirm.
+    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
+
+    exit_code = await _run_deep(multi_stack_target)
+    assert exit_code == 0
+    # At least one prompt message must mention the fix gate.
+    assert any("fix" in msg.lower() or "apply" in msg.lower() for msg in asked)
 
 
-@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
-def test_preflight_notice(multi_stack_target: Path) -> None:
+async def test_preflight_notice(multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """D-30: pre-flight notice lists stages, stacks, skill per stack, total agent count."""
-    raise NotImplementedError
+    captured: list[dict[str, Any]] = []
+
+    def _capture(console, *, stages, stack_lines, agent_count, codex_in_use, exploration_available) -> None:
+        captured.append(
+            {
+                "stages": stages,
+                "stack_lines": stack_lines,
+                "agent_count": agent_count,
+                "codex_in_use": codex_in_use,
+                "exploration_available": exploration_available,
+            }
+        )
+
+    monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", _capture)
+    monkeypatch.setattr("daydream.deep.orchestrator.prompt_user", lambda *a, **kw: "n")
+    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
+    _install_stub_backend(monkeypatch, multi_stack_target)
+
+    exit_code = await _run_deep(multi_stack_target)
+    assert exit_code == 0
+    assert len(captured) == 1, "pre-flight notice must fire exactly once"
+    notice = captured[0]
+    # Exactly 5 stages.
+    assert len(notice["stages"]) == 5
+    # Agent count: 2 TTT + N per-stack + N parse + 1 merge with N=3 -> 9.
+    assert notice["agent_count"] == 9
+    # Stacks surfaced.
+    assert len(notice["stack_lines"]) >= 1
+    # No Codex caveat on Claude backend.
+    assert notice["codex_in_use"] is False
 
 
-@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
-def test_codex_cost_caveat(multi_stack_target: Path) -> None:
-    """D-31: Codex backend pre-flight mentions cost_usd=None."""
-    raise NotImplementedError
+async def test_codex_cost_caveat(multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """D-31: Codex backend triggers the cost_usd=None caveat in the notice."""
+    captured: list[dict[str, Any]] = []
+
+    def _capture(console, *, stages, stack_lines, agent_count, codex_in_use, exploration_available) -> None:
+        captured.append({"codex_in_use": codex_in_use})
+
+    monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", _capture)
+    monkeypatch.setattr("daydream.deep.orchestrator.prompt_user", lambda *a, **kw: "n")
+    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
+    _install_stub_backend(monkeypatch, multi_stack_target, is_codex=True)
+
+    exit_code = await _run_deep(multi_stack_target)
+    assert exit_code == 0
+    assert captured[0]["codex_in_use"] is True
 
 
-@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
-def test_resume_per_stack_reruns_all(multi_stack_target: Path) -> None:
-    """D-34: --start-at per-stack re-runs ALL per-stack reviews."""
-    raise NotImplementedError
+async def test_resume_per_stack_reruns_all(multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """D-34: --start-at per-stack re-runs ALL per-stack reviews (after priming TTT artifacts)."""
+    _silence(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+
+    # Prime required TTT artifacts for the resume gate.
+    deep = multi_stack_target / ".daydream" / "deep"
+    deep.mkdir(parents=True, exist_ok=True)
+    (deep / "intent.md").write_text("primed intent")
+    (deep / "alternatives.json").write_text("[]")
+
+    exit_code = await _run_deep(multi_stack_target, start_at="per-stack")
+    assert exit_code == 0
+
+    per_stack_calls = [c for c in stub.calls if "you are reviewing the" in c["prompt"].lower()]
+    # detect_stacks on the fixture yields at least 2 non-generic buckets + 1 generic = 3.
+    assert len(per_stack_calls) >= 2
 
 
-@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
-def test_resume_overwrites(multi_stack_target: Path) -> None:
-    """D-35: resume overwrites stage artifacts."""
-    raise NotImplementedError
+async def test_resume_overwrites(multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """D-35: resume overwrites stage artifacts (new stack-*-review.md replaces old)."""
+    _silence(monkeypatch)
+    _install_stub_backend(monkeypatch, multi_stack_target)
+
+    # Prime TTT artifacts and an OLD per-stack review that must be overwritten.
+    deep = multi_stack_target / ".daydream" / "deep"
+    deep.mkdir(parents=True, exist_ok=True)
+    (deep / "intent.md").write_text("primed intent")
+    (deep / "alternatives.json").write_text("[]")
+    old = deep / "stack-python-review.md"
+    old.write_text("STALE CONTENT")
+
+    exit_code = await _run_deep(multi_stack_target, start_at="per-stack")
+    assert exit_code == 0
+
+    # The stub writes a new review -- STALE CONTENT must be gone.
+    assert "STALE CONTENT" not in old.read_text()
 
 
-@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
-def test_stage_ui_surfacing(multi_stack_target: Path) -> None:
+async def test_stage_ui_surfacing(multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """D-44: UI prints [stage N/5: ...] at each stage boundary."""
-    raise NotImplementedError
+    progress_calls: list[tuple[int, int, str]] = []
+
+    def _capture(console, current, total, name) -> None:
+        progress_calls.append((current, total, name))
+
+    monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", _capture)
+    monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.deep.orchestrator.prompt_user", lambda *a, **kw: "n")
+    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
+    _install_stub_backend(monkeypatch, multi_stack_target)
+
+    exit_code = await _run_deep(multi_stack_target)
+    assert exit_code == 0
+    # At least 5 distinct stage boundaries announced.
+    stage_numbers = {c[0] for c in progress_calls}
+    assert stage_numbers == {1, 2, 3, 4, 5}
+    # Total is always 5.
+    assert all(c[1] == 5 for c in progress_calls)

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -1,0 +1,114 @@
+"""Deep-mode orchestrator integration tests (xfail until plan 05-09).
+
+Covers D-07..D-10, D-17, D-19..D-22, D-24..D-26, D-28, D-30, D-31,
+D-34, D-35, D-44. Test bodies are intentionally stubbed with
+``raise NotImplementedError`` so the xfail(strict=True) contract holds
+until plan 05-09 fills them in.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
+def test_pipeline_order(multi_stack_target: Path) -> None:
+    """D-07: Stage order = TTT -> per-stack -> parse -> merge."""
+    # Fill in plan 05-09 when orchestrator exists.
+    raise NotImplementedError
+
+
+@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
+def test_fresh_context_per_stage(multi_stack_target: Path) -> None:
+    """D-08: Each stage = distinct Backend.execute call."""
+    raise NotImplementedError
+
+
+@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
+def test_artifacts_on_disk(multi_stack_target: Path) -> None:
+    """D-09: intent.md, alternatives.json, stack-*-review.md, stack-*-records.json written under .daydream/deep/."""
+    raise NotImplementedError
+
+
+@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
+def test_per_stack_context_isolation(multi_stack_target: Path) -> None:
+    """D-10: per-stack agents never see each other's outputs."""
+    raise NotImplementedError
+
+
+@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
+def test_parallel_fan_out(multi_stack_target: Path) -> None:
+    """D-17: per-stack fan-out uses anyio task group + CapacityLimiter."""
+    raise NotImplementedError
+
+
+@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
+def test_per_stack_prompt_context(multi_stack_target: Path) -> None:
+    """D-19: per-stack prompt references intent + alternatives paths."""
+    raise NotImplementedError
+
+
+@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
+def test_doc_review_notice(multi_stack_target: Path) -> None:
+    """D-20: .md routed to generic fallback surfaces doc-review notice."""
+    raise NotImplementedError
+
+
+@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
+def test_pre_merge_parse_per_stack(multi_stack_target: Path) -> None:
+    """D-21, D-22: phase_parse_feedback invoked per per-stack output, merger consumes records."""
+    raise NotImplementedError
+
+
+@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
+def test_merged_report_path(multi_stack_target: Path) -> None:
+    """D-24: final report at REVIEW_OUTPUT_FILE path."""
+    raise NotImplementedError
+
+
+@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
+def test_report_format_flat_numbered(multi_stack_target: Path) -> None:
+    """D-25: flat globally-numbered ## Issues + ## Cross-Stack Issues subsection continuing numbering."""
+    raise NotImplementedError
+
+
+@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
+def test_cross_stack_prefix(multi_stack_target: Path) -> None:
+    """D-26: every cross-stack title starts with [cross-stack]."""
+    raise NotImplementedError
+
+
+@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
+def test_fix_gate_prompt(multi_stack_target: Path) -> None:
+    """D-28: Y/n prompt after merge."""
+    raise NotImplementedError
+
+
+@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
+def test_preflight_notice(multi_stack_target: Path) -> None:
+    """D-30: pre-flight notice lists stages, stacks, skill per stack, total agent count."""
+    raise NotImplementedError
+
+
+@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
+def test_codex_cost_caveat(multi_stack_target: Path) -> None:
+    """D-31: Codex backend pre-flight mentions cost_usd=None."""
+    raise NotImplementedError
+
+
+@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
+def test_resume_per_stack_reruns_all(multi_stack_target: Path) -> None:
+    """D-34: --start-at per-stack re-runs ALL per-stack reviews."""
+    raise NotImplementedError
+
+
+@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
+def test_resume_overwrites(multi_stack_target: Path) -> None:
+    """D-35: resume overwrites stage artifacts."""
+    raise NotImplementedError
+
+
+@pytest.mark.xfail(reason="Wave 5 plan 05-09 not yet implemented", strict=True)
+def test_stage_ui_surfacing(multi_stack_target: Path) -> None:
+    """D-44: UI prints [stage N/5: ...] at each stage boundary."""
+    raise NotImplementedError

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -213,10 +213,10 @@ async def test_fresh_context_per_stage(multi_stack_target: Path, monkeypatch: py
     exit_code = await _run_deep(multi_stack_target)
     assert exit_code == 0
     # At minimum: intent + alternatives + 3 per-stack + 3 parse + 1 merge = 9 distinct calls.
-    assert len(stub.calls) >= 8
-    # Distinct by prompt (no test here about continuation, just that each stage fires a separate execute).
+    assert len(stub.calls) >= 9
+    # Each stage fires a distinct Backend.execute call -- prompts must be unique.
     prompts = [c["prompt"] for c in stub.calls]
-    assert len(set(prompts)) == len(prompts) or len(prompts) >= 8
+    assert len(set(prompts)) == len(prompts)
 
 
 async def test_artifacts_on_disk(multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -701,3 +701,87 @@ def test_diff_changed_files_handles_modify_add_delete_binary() -> None:
         "Binary files a/logo.png and b/logo.png differ\n"
     )
     assert _diff_changed_files(mixed) == ["keep.py", "new.py", "old.py", "logo.png"]
+
+
+async def test_merge_prompt_lists_records_in_sorted_order(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pre-merge parse iterates sorted(per_stack_outputs.items()) so the merge
+    prompt's records list is stable across runs regardless of which per-stack
+    task completed first."""
+    _silence(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+
+    exit_code = await _run_deep(multi_stack_target)
+    assert exit_code == 0
+
+    merge_prompts = [c["prompt"] for c in stub.calls if "cross-stack merge agent" in c["prompt"].lower()]
+    assert merge_prompts, "merge agent was not invoked"
+    prompt = merge_prompts[0]
+
+    # build_merge_prompt writes records under "Per-stack parsed records:" as
+    # "  - <path>" lines.
+    lines = prompt.splitlines()
+    start = next((i for i, line in enumerate(lines) if "per-stack parsed records:" in line.lower()), None)
+    assert start is not None, "merge prompt missing per-stack records block"
+
+    record_paths: list[str] = []
+    for line in lines[start + 1:]:
+        if line.startswith("  - "):
+            record_paths.append(line[4:].strip())
+        elif line.strip() == "":
+            break
+        else:
+            break
+
+    assert record_paths, "no record paths found in merge prompt"
+    assert record_paths == sorted(record_paths), (
+        f"records not in sorted order: {record_paths}"
+    )
+
+
+async def test_failed_per_stack_surfaces_to_merge_prompt_and_persists(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A per-stack agent failure must:
+      1) persist to per-stack-failures.json under .daydream/deep/,
+      2) appear in the merge prompt under an 'Uncovered stacks' block,
+    so the merge agent can call it out instead of silently ignoring the gap.
+    """
+    import json as _json
+
+    _silence(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+
+    # Wrap the stub's execute so the REACT per-stack prompt raises. Everything
+    # else (TTT, parse, merge, other stacks) keeps the stub's normal behavior.
+    original_execute = stub.execute
+
+    def _maybe_fail(cwd, prompt, output_schema=None, continuation=None, agents=None):
+        pl = prompt.lower()
+        if "you are reviewing the react stack" in pl:
+            async def _fail():
+                raise RuntimeError("simulated react failure")
+                yield  # pragma: no cover -- unreachable; satisfies async-gen typing
+            return _fail()
+        return original_execute(cwd, prompt, output_schema, continuation, agents)
+
+    stub.execute = _maybe_fail  # type: ignore[method-assign]
+
+    exit_code = await _run_deep(multi_stack_target)
+    assert exit_code == 0
+
+    failures_p = multi_stack_target / ".daydream" / "deep" / "per-stack-failures.json"
+    assert failures_p.is_file(), "failures file should be persisted for merge-resume"
+    failures_payload = _json.loads(failures_p.read_text())
+    assert "react" in failures_payload
+    assert "simulated react failure" in failures_payload["react"]
+
+    merge_prompts = [
+        c["prompt"] for c in stub.calls if "cross-stack merge agent" in c["prompt"].lower()
+    ]
+    assert merge_prompts, "merge agent was not invoked"
+    prompt = merge_prompts[0]
+    assert "Uncovered stacks" in prompt
+    assert "react" in prompt
+    assert "simulated react failure" in prompt

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -9,10 +9,7 @@ simulate the full review pipeline without talking to a real SDK.
 
 from __future__ import annotations
 
-import io
-import json
 import re
-import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -52,14 +49,10 @@ class _StubBackend:
         )
         pl = prompt.lower()
 
-        # TTT intent phase -> returns plain text.
-        if "describe what these changes are trying to achieve" in pl or "confirm your understanding" in pl:
-            yield TextEvent(text="The PR updates greetings across stacks.")
-            yield ResultEvent(structured_output=None, continuation=None)
-            return
-
         # TTT alternative-review phase -> structured output.
-        if "alternative" in pl and "evaluate" in pl:
+        # (Checked BEFORE intent because the alt prompt embeds the intent summary
+        # which contains the word "intent", defeating a naive substring check.)
+        if "would you have done this differently" in pl or "evaluate the implementation" in pl:
             yield TextEvent(text="")
             yield ResultEvent(
                 structured_output={
@@ -78,6 +71,13 @@ class _StubBackend:
             )
             return
 
+        # TTT intent phase -> plain text. Discriminator: "understand the intent"
+        # + "commit log:" are both unique to build_intent_prompt.
+        if "understand the intent of these changes" in pl:
+            yield TextEvent(text="The PR updates greetings across stacks.")
+            yield ResultEvent(structured_output=None, continuation=None)
+            return
+
         # Per-stack review -> write a markdown file + emit done.
         m = re.search(r"you are reviewing the (\S+) stack", pl)
         if m is None:
@@ -86,7 +86,8 @@ class _StubBackend:
             # Extract the output path the prompt asks the agent to write.
             out_match = re.search(r"write your full review to (\S+)", prompt, flags=re.IGNORECASE)
             if out_match is not None:
-                out_path = Path(out_match.group(1))
+                raw = out_match.group(1).rstrip(".")
+                out_path = Path(raw)
                 out_path.parent.mkdir(parents=True, exist_ok=True)
                 stack = m.group(1)
                 out_path.write_text(
@@ -113,7 +114,8 @@ class _StubBackend:
         if "cross-stack merge agent" in pl:
             out_match = re.search(r"write the complete report to (\S+)", prompt, flags=re.IGNORECASE)
             if out_match is not None:
-                out_path = Path(out_match.group(1))
+                raw = out_match.group(1).rstrip(".")
+                out_path = Path(raw)
                 out_path.parent.mkdir(parents=True, exist_ok=True)
                 out_path.write_text(
                     "# Review\n\n"
@@ -167,7 +169,8 @@ def _install_stub_backend(
 async def _run_deep(target: Path, *, start_at: str = "review") -> int:
     from daydream.runner import RunConfig, run
 
-    config = RunConfig(target=str(target), deep=True, start_at=start_at)
+    # cleanup=False suppresses the interactive cleanup prompt in runner.run().
+    config = RunConfig(target=str(target), deep=True, start_at=start_at, cleanup=False)
     return await run(config)
 
 
@@ -179,14 +182,15 @@ async def test_pipeline_order(multi_stack_target: Path, monkeypatch: pytest.Monk
     exit_code = await _run_deep(multi_stack_target)
     assert exit_code == 0
 
-    # Classify each call by inspecting prompt content.
+    # Classify each call by inspecting prompt content. Alt is checked before
+    # intent because the alt prompt embeds the intent summary text.
     order: list[str] = []
     for call in stub.calls:
         pl = call["prompt"].lower()
-        if "describe what these changes are trying to achieve" in pl:
-            order.append("intent")
-        elif "alternative" in pl and "evaluate" in pl:
+        if "would you have done this differently" in pl or "evaluate the implementation" in pl:
             order.append("alternatives")
+        elif "understand the intent of these changes" in pl:
+            order.append("intent")
         elif "you are reviewing the" in pl and "stack" in pl:
             order.append("per-stack")
         elif "extract only actionable issues" in pl:
@@ -249,16 +253,20 @@ async def test_per_stack_context_isolation(multi_stack_target: Path, monkeypatch
     ]
     assert per_stack_prompts, "expected per-stack prompts"
     # Each per-stack prompt should mention its own stack's file but NOT foreign files.
-    python_prompt = next((p for p in per_stack_prompts if "api.py" in p and "the python stack" in p.lower()), None)
-    react_prompt = next((p for p in per_stack_prompts if "app.tsx" in p.lower() and "the react stack" in p.lower()), None)
+    python_prompt = next(
+        (p for p in per_stack_prompts if "api.py" in p and "the python stack" in p.lower()),
+        None,
+    )
+    react_prompt = next(
+        (p for p in per_stack_prompts if "app.tsx" in p.lower() and "the react stack" in p.lower()),
+        None,
+    )
     assert python_prompt is not None
     assert react_prompt is not None
-    # Python prompt should not embed React files in its scope instruction.
-    python_scope_line = next(
-        line for line in python_prompt.splitlines() if "focus only on these files" in line.lower()
-    )
-    # next line holds the actual file list (per build_per_stack_prompt).
-    assert "App.tsx" not in python_prompt.split("Focus ONLY on these files:")[1].split("\n", 2)[1]
+    # The scope instruction's file-list line (right after the "Focus ONLY on these files:" header)
+    # must not embed React files in the Python stack prompt.
+    python_scope_files_line = python_prompt.split("Focus ONLY on these files:")[1].split("\n", 2)[1]
+    assert "App.tsx" not in python_scope_files_line
 
 
 async def test_parallel_fan_out(multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -517,6 +517,12 @@ async def test_resume_merge_consumes_saved_records(
     (deep / "stack-react-records.json").write_text(
         json.dumps([{"id": 1, "description": "tsx issue", "file": "App.tsx", "line": 1}])
     )
+    # Markdown routes to the generic bucket; prime its records too so the
+    # merge-resume validation (every detected stack must have records or be
+    # in failed_stacks) passes.
+    (deep / "stack-generic-records.json").write_text(
+        json.dumps([{"id": 1, "description": "docs issue", "file": "README.md", "line": 1}])
+    )
 
     exit_code = await _run_deep(multi_stack_target, start_at="merge")
     assert exit_code == 0
@@ -785,3 +791,145 @@ async def test_failed_per_stack_surfaces_to_merge_prompt_and_persists(
     assert "Uncovered stacks" in prompt
     assert "react" in prompt
     assert "simulated react failure" in prompt
+
+
+def test_get_installed_skills_non_dict_payload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Non-dict root JSON -> None (fall back to optimistic availability).
+
+    Regression: previously `data.get("plugins", {})` raised AttributeError
+    when the registry parsed to a non-dict, aborting deep mode instead of
+    returning None.
+    """
+    from daydream.deep.orchestrator import get_installed_skills
+
+    registry = tmp_path / "plugins" / "installed_plugins.json"
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    registry.write_text("[]")
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+
+    assert get_installed_skills() is None
+
+
+def test_get_installed_skills_non_dict_plugins_field(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`plugins` field is not a mapping -> None.
+
+    Regression: previously iterating ``data.get("plugins", {})`` raised
+    TypeError when the `plugins` field was e.g. a list, aborting deep
+    mode instead of returning None.
+    """
+    from daydream.deep.orchestrator import get_installed_skills
+
+    registry = tmp_path / "plugins" / "installed_plugins.json"
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    registry.write_text('{"version": 2, "plugins": ["beagle-python@marketplace"]}')
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+
+    assert get_installed_skills() is None
+
+
+async def test_resume_merge_errors_on_missing_stack_records(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--start-at merge must fail loudly when a detected stack has no records.
+
+    Regression: previously the merge branch globbed whatever ``stack-*-records.json``
+    files happened to exist on disk, so a detected stack with no prior records
+    would silently disappear from the merged report.
+    """
+    import json
+
+    _silence(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+
+    deep = multi_stack_target / ".daydream" / "deep"
+    deep.mkdir(parents=True, exist_ok=True)
+    (deep / "intent.md").write_text("primed intent")
+    (deep / "alternatives.json").write_text("[]")
+    # Prime records for python only; react and generic are missing.
+    (deep / "stack-python-records.json").write_text(
+        json.dumps([{"id": 1, "description": "py issue", "file": "api.py", "line": 1}])
+    )
+
+    exit_code = await _run_deep(multi_stack_target, start_at="merge")
+    assert exit_code == 1
+
+    # Merge agent must NOT have run -- the orchestrator bailed before it.
+    merge_calls = [c for c in stub.calls if "cross-stack merge agent" in c["prompt"].lower()]
+    assert merge_calls == []
+
+
+async def test_resume_merge_allows_missing_records_for_failed_stacks(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stack listed in per-stack-failures.json is allowed to be missing.
+
+    The merge agent still runs and the missing bucket is surfaced as an
+    uncovered stack rather than being flagged as a records-file gap.
+    """
+    import json
+
+    _silence(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+
+    deep = multi_stack_target / ".daydream" / "deep"
+    deep.mkdir(parents=True, exist_ok=True)
+    (deep / "intent.md").write_text("primed intent")
+    (deep / "alternatives.json").write_text("[]")
+    (deep / "stack-python-records.json").write_text(
+        json.dumps([{"id": 1, "description": "py issue", "file": "api.py", "line": 1}])
+    )
+    (deep / "stack-react-records.json").write_text(
+        json.dumps([{"id": 1, "description": "tsx issue", "file": "App.tsx", "line": 1}])
+    )
+    # No records for the generic bucket, but it's listed as a prior failure.
+    (deep / "per-stack-failures.json").write_text(
+        json.dumps({"generic": "simulated generic failure"})
+    )
+
+    exit_code = await _run_deep(multi_stack_target, start_at="merge")
+    assert exit_code == 0
+
+    merge_calls = [c for c in stub.calls if "cross-stack merge agent" in c["prompt"].lower()]
+    assert len(merge_calls) == 1
+
+
+async def test_resume_fix_skips_pr_post(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--start-at fix must not call post_review_to_pr_from_report.
+
+    Regression: posting is a non-idempotent GitHub write. Calling it on every
+    fix resume would produce duplicate inline reviews on the same PR.
+    """
+    from daydream.config import REVIEW_OUTPUT_FILE
+
+    _silence(monkeypatch)
+    _install_stub_backend(monkeypatch, multi_stack_target)
+
+    post_calls: list[dict[str, Any]] = []
+
+    async def _spy(
+        target_dir: Path, report_path: Path, *, console: Any, mode_label: str = "deep review"
+    ) -> None:
+        post_calls.append({"target_dir": target_dir, "report_path": report_path})
+
+    monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _spy)
+
+    # Prime every artifact the fix-resume gate needs.
+    deep = multi_stack_target / ".daydream" / "deep"
+    deep.mkdir(parents=True, exist_ok=True)
+    (deep / "intent.md").write_text("primed intent")
+    (deep / "alternatives.json").write_text("[]")
+    (multi_stack_target / REVIEW_OUTPUT_FILE).write_text(
+        "# Review\n\n## Issues\n\n1. [api.py:1] primed issue\n   rationale\n"
+    )
+
+    exit_code = await _run_deep(multi_stack_target, start_at="fix")
+    assert exit_code == 0
+    assert post_calls == [], (
+        f"post_review_to_pr_from_report should be skipped on --start-at fix, got {len(post_calls)} call(s)"
+    )

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -100,3 +100,42 @@ def test_prompts_embed_no_full_file_contents(tmp_path: Path) -> None:
     )
     # Heuristic: no line longer than 400 chars (an embedded diff would blow this up)
     assert all(len(line) < 400 for line in out.splitlines())
+
+
+def test_per_stack_prompt_points_at_diff_path(tmp_path: Path) -> None:
+    """Prompt references diff_path for agents to read directly."""
+    p = _paths(tmp_path)
+    out = build_per_stack_prompt(
+        skill_invocation="/beagle-python:review-python",
+        stack_name="python",
+        files=["api.py"],
+        **p,
+    )
+    assert str(p["diff_path"]) in out
+
+
+def test_per_stack_prompt_omits_bare_git_diff_command(tmp_path: Path) -> None:
+    """Prompt must NOT suggest `git diff -- <files>` without a base ref.
+
+    Without a base ref that command only shows uncommitted workspace changes;
+    on a clean PR branch it returns empty and hides every committed change.
+    """
+    p = _paths(tmp_path)
+    out = build_per_stack_prompt(
+        skill_invocation="/beagle-python:review-python",
+        stack_name="python",
+        files=["api.py"],
+        **p,
+    )
+    assert "git diff --no-color -- api.py" not in out
+    assert "git diff -- api.py" not in out
+
+
+def test_generic_fallback_prompt_omits_bare_git_diff_command(tmp_path: Path) -> None:
+    """Generic fallback must not embed the broken git-diff command either."""
+    p = _paths(tmp_path)
+    out = build_generic_fallback_prompt(files=["config.yaml"], **p)
+    assert "git diff --no-color -- config.yaml" not in out
+    assert "git diff -- config.yaml" not in out
+    # diff_path must still be referenced.
+    assert str(p["diff_path"]) in out

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -1,0 +1,102 @@
+"""Deep-mode prompt builder tests (D-09, D-10, D-19, D-20)."""
+from pathlib import Path
+
+from daydream.deep.prompts import (
+    DOC_REVIEW_NOTICE,
+    build_generic_fallback_prompt,
+    build_per_stack_prompt,
+)
+
+
+def _paths(tmp_path: Path) -> dict[str, Path]:
+    return {
+        "diff_path": tmp_path / ".daydream" / "diff.patch",
+        "intent_path": tmp_path / ".daydream" / "deep" / "intent.md",
+        "alternatives_path": tmp_path / ".daydream" / "deep" / "alternatives.json",
+        "output_path": tmp_path / ".daydream" / "deep" / "stack-python-review.md",
+    }
+
+
+def test_per_stack_prompt_has_intent_pointer(tmp_path: Path) -> None:
+    """D-19: prompt references the intent path."""
+    p = _paths(tmp_path)
+    out = build_per_stack_prompt(
+        skill_invocation="/beagle-python:review-python",
+        stack_name="python",
+        files=["api.py"],
+        **p,
+    )
+    assert str(p["intent_path"]) in out
+
+
+def test_per_stack_prompt_has_alternatives_pointer(tmp_path: Path) -> None:
+    """D-19: prompt references the alternatives path."""
+    p = _paths(tmp_path)
+    out = build_per_stack_prompt(
+        skill_invocation="/beagle-python:review-python",
+        stack_name="python",
+        files=["api.py"],
+        **p,
+    )
+    assert str(p["alternatives_path"]) in out
+
+
+def test_per_stack_prompt_includes_skill_invocation(tmp_path: Path) -> None:
+    """D-19: prompt includes the Beagle skill invocation."""
+    p = _paths(tmp_path)
+    out = build_per_stack_prompt(
+        skill_invocation="/beagle-python:review-python",
+        stack_name="python",
+        files=["api.py"],
+        **p,
+    )
+    assert "/beagle-python:review-python" in out
+
+
+def test_per_stack_prompt_scope_lists_only_stack_files(tmp_path: Path) -> None:
+    """D-10: stack scope instruction lists only this stack's files."""
+    p = _paths(tmp_path)
+    out = build_per_stack_prompt(
+        skill_invocation="/beagle-python:review-python",
+        stack_name="python",
+        files=["api.py", "lib/util.py"],
+        **p,
+    )
+    assert "api.py" in out and "lib/util.py" in out
+    assert "Do NOT review files from other stacks" in out
+
+
+def test_generic_fallback_prompt_has_no_skill(tmp_path: Path) -> None:
+    """Generic fallback omits any /beagle-* invocation."""
+    p = _paths(tmp_path)
+    out = build_generic_fallback_prompt(files=["config.yaml"], **p)
+    assert "/beagle-" not in out
+
+
+def test_generic_fallback_docs_notice(tmp_path: Path) -> None:
+    """D-20: is_docs_only=True prepends the doc-review notice."""
+    p = _paths(tmp_path)
+    out = build_generic_fallback_prompt(files=["README.md"], is_docs_only=True, **p)
+    assert DOC_REVIEW_NOTICE in out
+    # Notice must appear before other content
+    assert out.index(DOC_REVIEW_NOTICE) < out.index("Review these files")
+
+
+def test_generic_fallback_no_docs_notice_by_default(tmp_path: Path) -> None:
+    """Docs notice suppressed when is_docs_only=False."""
+    p = _paths(tmp_path)
+    out = build_generic_fallback_prompt(files=["config.yaml"], **p)
+    assert DOC_REVIEW_NOTICE not in out
+
+
+def test_prompts_embed_no_full_file_contents(tmp_path: Path) -> None:
+    """D-09: prompts reference paths, never embed diffs or file bodies."""
+    p = _paths(tmp_path)
+    out = build_per_stack_prompt(
+        skill_invocation="/beagle-python:review-python",
+        stack_name="python",
+        files=["api.py"],
+        **p,
+    )
+    # Heuristic: no line longer than 400 chars (an embedded diff would blow this up)
+    assert all(len(line) < 400 for line in out.splitlines())

--- a/tests/test_phase_parse_input_path.py
+++ b/tests/test_phase_parse_input_path.py
@@ -1,0 +1,67 @@
+"""Regression + behavior tests for phase_parse_feedback input_path kwarg (D-21, D-40)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from daydream.config import REVIEW_OUTPUT_FILE
+from daydream.phases import phase_parse_feedback
+
+
+class _SpyBackend:
+    def __init__(self) -> None:
+        self.last_prompt: str = ""
+
+    async def execute(self, cwd, prompt, output_schema=None, continuation=None, agents=None):
+        from daydream.backends import ResultEvent, TextEvent
+        self.last_prompt = prompt
+        yield TextEvent(text="parsing")
+        yield ResultEvent(
+            structured_output={"issues": []},
+            continuation=None,
+        )
+
+    async def cancel(self) -> None:
+        pass
+
+    def format_skill_invocation(self, skill_key: str, args: str = "") -> str:
+        return f"/{skill_key}"
+
+
+@pytest.fixture(autouse=True)
+def _silence_ui(monkeypatch):
+    monkeypatch.setattr("daydream.phases.print_phase_hero", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.phases.print_info", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.phases.print_warning", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        "daydream.phases.console",
+        type("C", (), {"print": lambda *a, **kw: None})(),
+    )
+
+
+async def test_input_path_default_uses_review_output_file(tmp_path: Path) -> None:
+    """D-40 regression: default call (no kwarg) reads cwd / REVIEW_OUTPUT_FILE."""
+    backend = _SpyBackend()
+    (tmp_path / REVIEW_OUTPUT_FILE).write_text("# Issues\n1. [a.py:1] x\n")
+    await phase_parse_feedback(backend, tmp_path)
+    assert str(tmp_path / REVIEW_OUTPUT_FILE) in backend.last_prompt
+
+
+async def test_input_path_override_used_when_provided(tmp_path: Path) -> None:
+    """D-21: input_path overrides the default, enabling per-stack iteration."""
+    backend = _SpyBackend()
+    custom = tmp_path / ".daydream" / "deep" / "stack-python-review.md"
+    custom.parent.mkdir(parents=True, exist_ok=True)
+    custom.write_text("# Issues\n1. [api.py:1] x\n")
+    await phase_parse_feedback(backend, tmp_path, input_path=custom)
+    assert str(custom) in backend.last_prompt
+    # Default path is NOT in the prompt when override is used
+    assert str(tmp_path / REVIEW_OUTPUT_FILE) not in backend.last_prompt
+
+
+async def test_input_path_is_keyword_only(tmp_path: Path) -> None:
+    """input_path cannot be passed positionally (signature guard)."""
+    backend = _SpyBackend()
+    with pytest.raises(TypeError):
+        await phase_parse_feedback(backend, tmp_path, tmp_path / "other.md")  # type: ignore[misc]

--- a/tests/test_pr_review.py
+++ b/tests/test_pr_review.py
@@ -177,7 +177,14 @@ def test_classify_splits_inline_vs_body(monkeypatch: pytest.MonkeyPatch, pr: PRI
     def fake_resolve(_td: Path, _sha: str, issue: ParsedIssue) -> int | None:
         return issue.line
 
-    def fake_hunks(_td: Path, _base: str, _head: str, path: str) -> list[tuple[int, int]]:
+    def fake_hunks(
+        _td: Path,
+        _base: str,
+        _head: str,
+        path: str,
+        *,
+        pr_number: int | None = None,
+    ) -> list[tuple[int, int]]:
         if path == "a.py":
             return [(8, 12)]  # 10 is inside
         if path == "b.py":
@@ -461,3 +468,110 @@ def test_resolve_line_none_when_missing_file(
     monkeypatch.setattr(pr_review.subprocess, "run", fake_run)
     issue = ParsedIssue(path="gone.py", line=1, title="t", body="b")
     assert pr_review.resolve_line(tmp_path, "head", issue) is None
+
+
+# --- file_hunks git-diff + gh-pr-diff fallback ----------------------------
+
+
+_GH_PR_DIFF = (
+    "diff --git a/x.py b/x.py\n"
+    "--- a/x.py\n"
+    "+++ b/x.py\n"
+    "@@ -1,3 +10,5 @@\n"
+    " old\n"
+    "+new1\n"
+    "+new2\n"
+    "diff --git a/other.py b/other.py\n"
+    "--- a/other.py\n"
+    "+++ b/other.py\n"
+    "@@ -1 +1,2 @@\n"
+    "+noise\n"
+)
+
+
+def test_file_hunks_uses_git_diff_when_it_succeeds(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Happy path: git diff returns a valid diff; gh is not consulted."""
+    gh_called = False
+
+    def fake_run(cmd: list[str], *_a: Any, **_k: Any) -> subprocess.CompletedProcess[bytes]:
+        nonlocal gh_called
+        if cmd[:2] == ["git", "diff"]:
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                (
+                    b"diff --git a/x.py b/x.py\n"
+                    b"--- a/x.py\n"
+                    b"+++ b/x.py\n"
+                    b"@@ -1,3 +20,2 @@\n"
+                    b"+a\n"
+                ),
+                b"",
+            )
+        if cmd[:3] == ["gh", "pr", "diff"]:
+            gh_called = True
+        return subprocess.CompletedProcess(cmd, 1, b"", b"")
+
+    monkeypatch.setattr(pr_review.subprocess, "run", fake_run)
+    hunks = pr_review.file_hunks(tmp_path, "base", "head", "x.py", pr_number=42)
+    assert hunks == [(20, 21)]
+    assert gh_called is False
+
+
+def test_file_hunks_falls_back_to_gh_when_base_unreachable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When git diff fails (base_sha unreachable), gh pr diff rescues the hunks."""
+
+    def fake_run(cmd: list[str], *_a: Any, **_k: Any) -> subprocess.CompletedProcess[bytes]:
+        if cmd[:2] == ["git", "diff"]:
+            # Simulate "fatal: bad revision 'base..head'" -> non-zero exit.
+            return subprocess.CompletedProcess(cmd, 128, b"", b"fatal: bad revision")
+        if cmd[:3] == ["gh", "pr", "diff"]:
+            return subprocess.CompletedProcess(cmd, 0, _GH_PR_DIFF.encode(), b"")
+        return subprocess.CompletedProcess(cmd, 1, b"", b"")
+
+    monkeypatch.setattr(pr_review.subprocess, "run", fake_run)
+    hunks = pr_review.file_hunks(tmp_path, "rewritten_base", "head", "x.py", pr_number=42)
+    # Must come from the x.py block only -- the other.py hunk starts at line 1 and
+    # must NOT leak into x.py's result.
+    assert hunks == [(10, 14)]
+
+
+def test_file_hunks_no_fallback_without_pr_number(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Without a pr_number, file_hunks returns empty instead of calling gh."""
+    gh_called = False
+
+    def fake_run(cmd: list[str], *_a: Any, **_k: Any) -> subprocess.CompletedProcess[bytes]:
+        nonlocal gh_called
+        if cmd[:2] == ["git", "diff"]:
+            return subprocess.CompletedProcess(cmd, 128, b"", b"fatal")
+        if cmd[:3] == ["gh", "pr", "diff"]:
+            gh_called = True
+        return subprocess.CompletedProcess(cmd, 1, b"", b"")
+
+    monkeypatch.setattr(pr_review.subprocess, "run", fake_run)
+    hunks = pr_review.file_hunks(tmp_path, "base", "head", "x.py")
+    assert hunks == []
+    assert gh_called is False
+
+
+def test_file_hunks_gh_fallback_handles_subprocess_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """If gh itself errors out, file_hunks returns empty without raising."""
+
+    def fake_run(cmd: list[str], *_a: Any, **_k: Any) -> subprocess.CompletedProcess[bytes]:
+        if cmd[:2] == ["git", "diff"]:
+            return subprocess.CompletedProcess(cmd, 128, b"", b"fatal")
+        if cmd[:3] == ["gh", "pr", "diff"]:
+            raise subprocess.SubprocessError("gh not found")
+        return subprocess.CompletedProcess(cmd, 1, b"", b"")
+
+    monkeypatch.setattr(pr_review.subprocess, "run", fake_run)
+    hunks = pr_review.file_hunks(tmp_path, "base", "head", "x.py", pr_number=42)
+    assert hunks == []

--- a/tests/test_pr_review.py
+++ b/tests/test_pr_review.py
@@ -32,8 +32,12 @@ Some prose.
 ## Issues
 1. [src/foo.py:42] **Null check missing**
    The function `compute_total` dereferences `items` without a guard.
+   **Severity:** high
+   **Confidence:** HIGH
 2. [src/bar.ts:10] **Type mismatch**
    Variable `count` is typed `string` but assigned a number.
+   Severity: medium
+   Confidence: MEDIUM
 3. [docs/README.md] File-level note
    No line hint; general doc feedback.
 
@@ -50,14 +54,38 @@ def test_parse_report_extracts_all_sections() -> None:
     assert issues[0].line == 42
     assert issues[0].title == "**Null check missing**"
     assert not issues[0].is_cross_stack
+    assert issues[0].severity == "high"
+    assert issues[0].confidence == "HIGH"
+
+    # Parsing also picks up un-bolded `Severity: medium` form.
+    assert issues[1].severity == "medium"
+    assert issues[1].confidence == "MEDIUM"
 
     assert issues[2].path == "docs/README.md"
     assert issues[2].line is None
-    assert not issues[2].is_cross_stack
+    assert issues[2].severity is None
+    assert issues[2].confidence is None
 
     assert issues[3].is_cross_stack
     assert issues[3].path == "src/api.py"
     assert issues[3].line == 5
+
+
+def test_inline_body_has_footer_and_tags() -> None:
+    issue = ParsedIssue(
+        path="a.py",
+        line=10,
+        title="Null deref",
+        body="rationale here",
+        confidence="HIGH",
+        severity="high",
+    )
+    body = pr_review._format_inline_body(issue)
+    assert "**Null deref**" in body
+    assert "severity: `high`" in body
+    assert "confidence: `HIGH`" in body
+    assert body.rstrip().endswith("</sub>")
+    assert pr_review.DAYDREAM_REPO_URL in body
 
 
 def test_parse_report_handles_no_issues_section() -> None:
@@ -82,6 +110,8 @@ def test_alt_issues_to_parsed_produces_one_per_file() -> None:
     assert all(i.line is None for i in issues)
     assert "Recommendation" in issues[0].body
     assert "Severity" in issues[0].body
+    assert issues[0].severity == "low"
+    assert issues[0].confidence == "HIGH"
 
 
 def test_alt_issues_to_parsed_skips_no_files() -> None:
@@ -162,6 +192,8 @@ def test_classify_splits_inline_vs_body(monkeypatch: pytest.MonkeyPatch, pr: PRI
     assert result.inline[0]["path"] == "a.py"
     assert result.inline[0]["line"] == 10
     assert result.inline[0]["side"] == "RIGHT"
+    assert len(result.inline_issues) == 1
+    assert result.inline_issues[0].path == "a.py"
     body_paths = [i.path for i in result.body_only]
     assert set(body_paths) == {"b.py", "c.py"}
 
@@ -170,16 +202,43 @@ def test_build_payload_shape(pr: PRInfo) -> None:
     classified = pr_review._ClassifiedIssues(
         inline=[{"path": "a.py", "line": 10, "side": "RIGHT", "body": "x"}],
         body_only=[
-            ParsedIssue(path="b.py", line=None, title="File note", body="desc")
+            ParsedIssue(
+                path="b.py",
+                line=None,
+                title="File note",
+                body="desc",
+                confidence="MEDIUM",
+                severity="low",
+            )
+        ],
+        inline_issues=[
+            ParsedIssue(
+                path="a.py",
+                line=10,
+                title="t",
+                body="b",
+                confidence="HIGH",
+                severity="high",
+            )
         ],
     )
-    payload = build_payload(pr, "Test summary.", classified)
+    payload = build_payload(pr, "deep review", classified)
     assert payload["commit_id"] == "head123"
     assert payload["event"] == "COMMENT"
     assert payload["comments"] == classified.inline
-    assert "Test summary." in payload["body"]
-    assert "Non-inline findings" in payload["body"]
-    assert "1 inline comment(s), 1 non-inline finding(s)" in payload["body"]
+
+    body = payload["body"]
+    # Template header with wizard emoji + daydream repo link.
+    assert "🧙" in body
+    assert pr_review.DAYDREAM_REPO_URL in body
+    assert "deep review" in body
+    # Counts and breakdowns.
+    assert "1 inline comment(s), 1 non-inline finding(s)" in body
+    assert "**Severity:**" in body and "1 high" in body and "1 low" in body
+    assert "**Confidence:**" in body and "1 HIGH" in body and "1 MEDIUM" in body
+    # Non-inline section + footer.
+    assert "Non-inline findings" in body
+    assert body.rstrip().endswith("</sub>")
 
 
 def test_find_open_pr_returns_none_on_empty_list(
@@ -247,7 +306,7 @@ async def test_post_skips_when_no_pr(
         tmp_path,
         [ParsedIssue(path="x.py", line=1, title="t", body="b")],
         console=_FakeConsole(),  # type: ignore[arg-type]
-        summary_prefix="s",
+        mode_label="deep review",
     )
     assert warnings and "No open PR" in warnings[0]
 
@@ -287,7 +346,7 @@ async def test_post_cleans_tmp_file_on_success(
         tmp_path,
         [ParsedIssue(path="a.py", line=1, title="t", body="b")],
         console=_FakeConsole(),  # type: ignore[arg-type]
-        summary_prefix="s",
+        mode_label="deep review",
     )
     # Tmp file was deleted after success.
     assert not captured["path"].exists()
@@ -321,7 +380,7 @@ async def test_post_warns_and_keeps_file_on_failure(
         tmp_path,
         [ParsedIssue(path="a.py", line=1, title="t", body="b")],
         console=_FakeConsole(),  # type: ignore[arg-type]
-        summary_prefix="s",
+        mode_label="deep review",
     )
     assert warnings
     assert "no comments were posted" in warnings[0].lower()
@@ -362,7 +421,7 @@ async def test_post_skipped_when_user_declines(
         tmp_path,
         [ParsedIssue(path="a.py", line=1, title="t", body="b")],
         console=_FakeConsole(),  # type: ignore[arg-type]
-        summary_prefix="s",
+        mode_label="deep review",
     )
     assert not submit_called
 

--- a/tests/test_pr_review.py
+++ b/tests/test_pr_review.py
@@ -1,0 +1,404 @@
+"""Unit tests for daydream.pr_review."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from daydream import pr_review
+from daydream.pr_review import (
+    ParsedIssue,
+    PRInfo,
+    _parse_hunks,
+    alt_issues_to_parsed,
+    build_payload,
+    classify,
+    extract_anchors,
+    parse_report,
+    within_hunk,
+)
+
+REPORT_FIXTURE = """\
+# Review
+
+## Per-Stack Context
+
+Some prose.
+
+## Issues
+1. [src/foo.py:42] **Null check missing**
+   The function `compute_total` dereferences `items` without a guard.
+2. [src/bar.ts:10] **Type mismatch**
+   Variable `count` is typed `string` but assigned a number.
+3. [docs/README.md] File-level note
+   No line hint; general doc feedback.
+
+## Cross-Stack Issues
+4. [cross-stack] [src/api.py:5] **Contract drift**
+   Python payload shape diverges from TS `ApiResponse` definition.
+"""
+
+
+def test_parse_report_extracts_all_sections() -> None:
+    issues = parse_report(REPORT_FIXTURE)
+    assert len(issues) == 4
+    assert issues[0].path == "src/foo.py"
+    assert issues[0].line == 42
+    assert issues[0].title == "**Null check missing**"
+    assert not issues[0].is_cross_stack
+
+    assert issues[2].path == "docs/README.md"
+    assert issues[2].line is None
+    assert not issues[2].is_cross_stack
+
+    assert issues[3].is_cross_stack
+    assert issues[3].path == "src/api.py"
+    assert issues[3].line == 5
+
+
+def test_parse_report_handles_no_issues_section() -> None:
+    assert parse_report("# Nothing here") == []
+
+
+def test_alt_issues_to_parsed_produces_one_per_file() -> None:
+    alt = [
+        {
+            "id": 1,
+            "title": "Extract helper",
+            "description": "Duplicated logic",
+            "recommendation": "Move to util",
+            "severity": "low",
+            "files": ["a.py", "b.py"],
+            "confidence": "HIGH",
+            "rationale": "r",
+        }
+    ]
+    issues = alt_issues_to_parsed(alt)
+    assert [i.path for i in issues] == ["a.py", "b.py"]
+    assert all(i.line is None for i in issues)
+    assert "Recommendation" in issues[0].body
+    assert "Severity" in issues[0].body
+
+
+def test_alt_issues_to_parsed_skips_no_files() -> None:
+    assert alt_issues_to_parsed([{"title": "t", "files": []}]) == []
+
+
+def test_extract_anchors_prefers_long_tokens() -> None:
+    issue = ParsedIssue(
+        path="x.py",
+        line=None,
+        title="Null check",
+        body="The function `compute_total` dereferences `items` in handleRequest",
+    )
+    anchors = extract_anchors(issue)
+    # Backtick tokens should appear; longest first.
+    assert "compute_total" in anchors
+    assert "handleRequest" in anchors
+    assert anchors == sorted(anchors, key=len, reverse=True)
+
+
+def test_parse_hunks() -> None:
+    diff = (
+        "diff --git a/x.py b/x.py\n"
+        "--- a/x.py\n"
+        "+++ b/x.py\n"
+        "@@ -1,3 +10,5 @@\n"
+        " old\n"
+        "+new1\n"
+        "+new2\n"
+        "@@ -20 +30,2 @@\n"
+        "+new3\n"
+    )
+    assert _parse_hunks(diff) == [(10, 14), (30, 31)]
+
+
+def test_within_hunk_tolerance() -> None:
+    hunks = [(10, 14)]
+    assert within_hunk(13, hunks)
+    assert within_hunk(16, hunks, tolerance=3)  # 14 + 2
+    assert not within_hunk(20, hunks, tolerance=3)
+
+
+@pytest.fixture
+def pr() -> PRInfo:
+    return PRInfo(
+        number=42,
+        head_sha="head123",
+        base_sha="base456",
+        base_ref="main",
+        owner="acme",
+        repo="widgets",
+        url="https://github.com/acme/widgets/pull/42",
+    )
+
+
+def test_classify_splits_inline_vs_body(monkeypatch: pytest.MonkeyPatch, pr: PRInfo) -> None:
+    issues = [
+        ParsedIssue(path="a.py", line=10, title="t1", body="anchor_one"),
+        ParsedIssue(path="b.py", line=99, title="t2", body="anchor_two"),
+        ParsedIssue(path="c.py", line=None, title="t3", body="xstack", is_cross_stack=True),
+    ]
+
+    def fake_resolve(_td: Path, _sha: str, issue: ParsedIssue) -> int | None:
+        return issue.line
+
+    def fake_hunks(_td: Path, _base: str, _head: str, path: str) -> list[tuple[int, int]]:
+        if path == "a.py":
+            return [(8, 12)]  # 10 is inside
+        if path == "b.py":
+            return [(1, 5)]  # 99 is outside
+        return []
+
+    monkeypatch.setattr(pr_review, "resolve_line", fake_resolve)
+    monkeypatch.setattr(pr_review, "file_hunks", fake_hunks)
+
+    result = classify(Path("."), pr, issues)
+    assert len(result.inline) == 1
+    assert result.inline[0]["path"] == "a.py"
+    assert result.inline[0]["line"] == 10
+    assert result.inline[0]["side"] == "RIGHT"
+    body_paths = [i.path for i in result.body_only]
+    assert set(body_paths) == {"b.py", "c.py"}
+
+
+def test_build_payload_shape(pr: PRInfo) -> None:
+    classified = pr_review._ClassifiedIssues(
+        inline=[{"path": "a.py", "line": 10, "side": "RIGHT", "body": "x"}],
+        body_only=[
+            ParsedIssue(path="b.py", line=None, title="File note", body="desc")
+        ],
+    )
+    payload = build_payload(pr, "Test summary.", classified)
+    assert payload["commit_id"] == "head123"
+    assert payload["event"] == "COMMENT"
+    assert payload["comments"] == classified.inline
+    assert "Test summary." in payload["body"]
+    assert "Non-inline findings" in payload["body"]
+    assert "1 inline comment(s), 1 non-inline finding(s)" in payload["body"]
+
+
+def test_find_open_pr_returns_none_on_empty_list(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def fake_run(cmd: list[str], *_a: Any, **_k: Any) -> subprocess.CompletedProcess[bytes]:
+        if cmd[:3] == ["git", "branch", "--show-current"]:
+            return subprocess.CompletedProcess(cmd, 0, b"feat/x\n", b"")
+        if cmd[:3] == ["gh", "pr", "list"]:
+            return subprocess.CompletedProcess(cmd, 0, b"[]", b"")
+        raise AssertionError(f"unexpected {cmd}")
+
+    monkeypatch.setattr(pr_review.subprocess, "run", fake_run)
+    assert pr_review.find_open_pr(tmp_path) is None
+
+
+def test_find_open_pr_returns_pr_info(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    rows = [
+        {
+            "number": 7,
+            "headRefOid": "h",
+            "baseRefOid": "b",
+            "baseRefName": "main",
+            "url": "u",
+        }
+    ]
+    repo = {"owner": {"login": "o"}, "name": "r"}
+
+    def fake_run(cmd: list[str], *_a: Any, **_k: Any) -> subprocess.CompletedProcess[bytes]:
+        if cmd[:3] == ["git", "branch", "--show-current"]:
+            return subprocess.CompletedProcess(cmd, 0, b"f\n", b"")
+        if cmd[:3] == ["gh", "pr", "list"]:
+            return subprocess.CompletedProcess(cmd, 0, json.dumps(rows).encode(), b"")
+        if cmd[:3] == ["gh", "repo", "view"]:
+            return subprocess.CompletedProcess(cmd, 0, json.dumps(repo).encode(), b"")
+        raise AssertionError(f"unexpected {cmd}")
+
+    monkeypatch.setattr(pr_review.subprocess, "run", fake_run)
+    info = pr_review.find_open_pr(tmp_path)
+    assert info is not None
+    assert info.number == 7
+    assert info.owner == "o"
+    assert info.repo == "r"
+
+
+class _FakeConsole:
+    def print(self, *_a: Any, **_k: Any) -> None:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_post_skips_when_no_pr(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(pr_review, "find_open_pr", lambda _td: None)
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        pr_review,
+        "print_warning",
+        lambda _c, msg: warnings.append(msg),
+    )
+    await pr_review._post(
+        tmp_path,
+        [ParsedIssue(path="x.py", line=1, title="t", body="b")],
+        console=_FakeConsole(),  # type: ignore[arg-type]
+        summary_prefix="s",
+    )
+    assert warnings and "No open PR" in warnings[0]
+
+
+@pytest.mark.asyncio
+async def test_post_cleans_tmp_file_on_success(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, pr: PRInfo
+) -> None:
+    monkeypatch.setattr(pr_review, "find_open_pr", lambda _td: pr)
+    monkeypatch.setattr(
+        pr_review,
+        "classify",
+        lambda *_a, **_k: pr_review._ClassifiedIssues(
+            inline=[{"path": "a.py", "line": 1, "side": "RIGHT", "body": "x"}],
+            body_only=[],
+        ),
+    )
+    monkeypatch.setattr(pr_review, "prompt_user", lambda *_a, **_k: "y")
+
+    captured: dict[str, Path] = {}
+
+    def fake_submit(_td: Path, _pr: PRInfo, payload_path: Path) -> str | None:
+        captured["path"] = payload_path
+        assert payload_path.exists()
+        return "https://github.com/acme/widgets/pull/42#pullrequestreview-1"
+
+    monkeypatch.setattr(pr_review, "_submit_review", fake_submit)
+    successes: list[str] = []
+    monkeypatch.setattr(
+        pr_review,
+        "print_success",
+        lambda _c, msg: successes.append(msg),
+    )
+    monkeypatch.setattr(pr_review, "print_info", lambda *_a, **_k: None)
+
+    await pr_review._post(
+        tmp_path,
+        [ParsedIssue(path="a.py", line=1, title="t", body="b")],
+        console=_FakeConsole(),  # type: ignore[arg-type]
+        summary_prefix="s",
+    )
+    # Tmp file was deleted after success.
+    assert not captured["path"].exists()
+    assert successes and "pullrequestreview" in successes[0]
+
+
+@pytest.mark.asyncio
+async def test_post_warns_and_keeps_file_on_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, pr: PRInfo
+) -> None:
+    monkeypatch.setattr(pr_review, "find_open_pr", lambda _td: pr)
+    monkeypatch.setattr(
+        pr_review,
+        "classify",
+        lambda *_a, **_k: pr_review._ClassifiedIssues(
+            inline=[{"path": "a.py", "line": 1, "side": "RIGHT", "body": "x"}],
+            body_only=[],
+        ),
+    )
+    monkeypatch.setattr(pr_review, "prompt_user", lambda *_a, **_k: "y")
+    monkeypatch.setattr(pr_review, "_submit_review", lambda *_a, **_k: None)
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        pr_review,
+        "print_warning",
+        lambda _c, msg: warnings.append(msg),
+    )
+    monkeypatch.setattr(pr_review, "print_info", lambda *_a, **_k: None)
+
+    await pr_review._post(
+        tmp_path,
+        [ParsedIssue(path="a.py", line=1, title="t", body="b")],
+        console=_FakeConsole(),  # type: ignore[arg-type]
+        summary_prefix="s",
+    )
+    assert warnings
+    assert "no comments were posted" in warnings[0].lower()
+    # Tmp path mentioned in warning still exists.
+    # Extract path from warning message.
+    import re as _re
+
+    match = _re.search(r"(/\S+\.json)", warnings[0])
+    assert match
+    assert Path(match.group(1)).exists()
+
+
+@pytest.mark.asyncio
+async def test_post_skipped_when_user_declines(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, pr: PRInfo
+) -> None:
+    monkeypatch.setattr(pr_review, "find_open_pr", lambda _td: pr)
+    monkeypatch.setattr(
+        pr_review,
+        "classify",
+        lambda *_a, **_k: pr_review._ClassifiedIssues(
+            inline=[{"path": "a.py", "line": 1, "side": "RIGHT", "body": "x"}],
+            body_only=[],
+        ),
+    )
+    monkeypatch.setattr(pr_review, "prompt_user", lambda *_a, **_k: "n")
+    submit_called = False
+
+    def fake_submit(*_a: Any, **_k: Any) -> str | None:
+        nonlocal submit_called
+        submit_called = True
+        return "x"
+
+    monkeypatch.setattr(pr_review, "_submit_review", fake_submit)
+    monkeypatch.setattr(pr_review, "print_info", lambda *_a, **_k: None)
+
+    await pr_review._post(
+        tmp_path,
+        [ParsedIssue(path="a.py", line=1, title="t", body="b")],
+        console=_FakeConsole(),  # type: ignore[arg-type]
+        summary_prefix="s",
+    )
+    assert not submit_called
+
+
+def test_resolve_line_verifies_hint(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    file_text = "\n".join(f"line_{i} extra" for i in range(1, 21)).encode()
+
+    def fake_run(cmd: list[str], *_a: Any, **_k: Any) -> subprocess.CompletedProcess[bytes]:
+        assert cmd[:2] == ["git", "show"]
+        return subprocess.CompletedProcess(cmd, 0, file_text, b"")
+
+    monkeypatch.setattr(pr_review.subprocess, "run", fake_run)
+    issue = ParsedIssue(path="x.py", line=10, title="t", body="`line_10`")
+    assert pr_review.resolve_line(tmp_path, "head", issue) == 10
+
+
+def test_resolve_line_full_search_when_hint_bad(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    file_text = "\n".join(f"row_{i}" for i in range(1, 21)).encode()
+
+    def fake_run(cmd: list[str], *_a: Any, **_k: Any) -> subprocess.CompletedProcess[bytes]:
+        return subprocess.CompletedProcess(cmd, 0, file_text, b"")
+
+    monkeypatch.setattr(pr_review.subprocess, "run", fake_run)
+    # Hint at line 2, but anchor is at line 15.
+    issue = ParsedIssue(path="x.py", line=2, title="t", body="`row_15`")
+    assert pr_review.resolve_line(tmp_path, "head", issue) == 15
+
+
+def test_resolve_line_none_when_missing_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def fake_run(cmd: list[str], *_a: Any, **_k: Any) -> subprocess.CompletedProcess[bytes]:
+        return subprocess.CompletedProcess(cmd, 128, b"", b"fatal")
+
+    monkeypatch.setattr(pr_review.subprocess, "run", fake_run)
+    issue = ParsedIssue(path="gone.py", line=1, title="t", body="b")
+    assert pr_review.resolve_line(tmp_path, "head", issue) is None


### PR DESCRIPTION
## Summary

Adds a new `--deep` mode that runs a 5-stage multi-stack review pipeline (exploration → TTT intent → TTT alternatives → per-stack fan-out → cross-stack merge → optional fix gate) and posts the findings as a single atomic inline GitHub PR review. Builds on the existing Backend protocol and never passes `agents=` to `backend.execute`, so Claude and Codex backends produce identical pipeline shape.

## Changes

### Added

- **`daydream/deep/` package** — `detection`, `artifacts`, `prompts`, `dedup`, `orchestrator` (`run_deep`, `total_agent_count`).
  - `detect_stacks`: routes changed files via `.md` pinning → extension lookup → config co-change promotion → ambiguous nearest-ancestor → equal-depth / missing-skill fallthrough to generic (D-11..D-16).
  - `check_deep_artifacts` stage guard with actionable `FileNotFoundError` naming missing files and the `--start-at` value that produces them.
  - `build_per_stack_prompt` / `build_generic_fallback_prompt` / `build_merge_prompt` — path-only context (no diffs / file contents embedded in prompts).
  - `build_dedup_candidates`: character-bigram Jaccard ≥ 0.5 + file overlap AND-gate (D-27).
  - `run_deep` orchestrator with stage-granular resume (`--start-at ttt|per-stack|merge|fix`), preserves `.daydream/deep/` across runs, cleans up exploration dir on exit.
- **`--deep` CLI flag** with new `--start-at` stages and a mutex cluster against `--pr`/`--loop`/`--ttt`/`--review-only`.
- **`daydream/pr_review.py`** — shared post-review step wired into both `run_deep` and `run_trust`. Locates the open PR via `gh pr list`, anchor-greps each finding to a real head-SHA line, classifies against diff hunks, posts a single atomic review via `POST /repos/.../pulls/<n>/reviews`. Cross-stack and off-hunk findings fold into the review body. y/n gated; non-fatal on failure; payload preserved for retry.
- **Templated review body** — wizard-emoji header, inline/non-inline counts, severity (high/medium/low) and confidence (HIGH/MEDIUM/LOW) breakdowns when present, non-inline findings section, and daydream footer. Severity/confidence flow end-to-end: `ttt` lifts from the alt-review schema; `deep` parses `.review-output.md` via lenient regex.
- **`phase_per_stack_reviews`** — task-group + `CapacityLimiter(4)` fan-out mirroring `phase_fix_parallel`. Failures isolated per stack (logged, don't abort the rest).
- **`phase_cross_stack_merge`** — single-output-file contract at `REVIEW_OUTPUT_FILE`, flat globally-numbered `## Issues` with `## Cross-Stack Issues` subsection using `[cross-stack]` prefixes.
- **`print_stage_progress` + `print_preflight_notice` UI helpers** — `[stage N/5: ...]` banners and the pre-flight panel listing stages, detected stacks + skills, agent count (`2 + 2N + 1`), and the Codex `cost_usd=None` caveat.

### Changed

- **`phase_parse_feedback`** — new keyword-only `input_path: Path | None = None`. Default `None` preserves cwd/`REVIEW_OUTPUT_FILE` behavior for all three existing callers; explicit path enables per-stack parse in parallel without colliding.
- **`runner.py`** — dispatches to `run_deep` when `config.deep` is True; skill-prompt / review-file-exists gates skip in deep mode.
- **`_ClassifiedIssues`** — carries `inline_issues` alongside `inline` dicts so the PR-review summary rolls up metadata from every comment, not just non-inline ones.

### Fixed

- **Merge resume** now consumes saved `stack-*-records.json` via `dd.glob(...)` instead of re-running `phase_parse_feedback` against `stack-*-review.md` paths that may not exist.
- **Skill availability** derived at runtime from the Claude Code plugin registry (`get_installed_skills()` reads `$CLAUDE_CONFIG_DIR/plugins/installed_plugins.json`). When a `beagle-<stack>` plugin is absent, D-16 generic fallthrough fires instead of routing to a skill that would surface as a silently-swallowed `MissingSkillError`.
- **`_diff_changed_files`** now parses one path per `diff --git` block, preferring `+++ b/<path>` and falling back to `--- a/<path>` for deletes and the git header for binary / mode-only diffs. Renames contribute only the destination.
- **`test_existing_tests_still_collect`** uses `importlib.util.spec_from_file_location` with absolute paths so the probe survives a sibling `tests` package on `PYTHONPATH`.

## Motivation

Existing review modes (`--python`, `--typescript`, `--ttt`) don't handle PRs that cross stacks cleanly — a mixed Python+React PR either gets one stack's review or a stack-agnostic TTT pass that can't invoke skill-specific checks. Deep mode fans out per-stack reviews in parallel, merges them with dedup, and posts a single coherent review. The inline-PR-comment plumbing was extracted so `--ttt` benefits from it too.

## Testing

- [x] Unit tests added across new modules: detection (11), artifacts (4), prompts, dedup (D-27 AND-gate), CLI flag (13), fan-out, merge, orchestrator (17 previously-xfail tests now pass against a prompt-dispatching `_StubBackend`).
- [x] Integration tests (`tests/test_deep_integration.py`) run `run_deep` end-to-end against two `MockBackend` shapes — Claude-shape (cost_usd populated, accepts agents kwarg silently) and Codex-shape (cost_usd=None, raises `NotImplementedError` if `agents=` passed). The Codex-shape test is the D-38 parity guarantee.
- [x] Signature-stability guard for `phase_understand_intent`, `phase_alternative_review`, `phase_parse_feedback`, `phase_fix`, `phase_test_and_heal`, `phase_commit_push` (D-39).
- [x] Negative guard: no `v2_*`/`_deep_*` phase wrappers leaked into `daydream.phases`.
- [x] Full suite: **302 passed**. `make lint` + `make typecheck` clean.

### Manual Testing Steps

```bash
# On a feature branch with mixed stacks (e.g. Python + React)
daydream --deep /path/to/repo

# Resume a later stage
daydream --deep /path/to/repo --start-at merge

# Verify the inline PR comments land and the body template renders
gh pr view --web
```

## Breaking Changes

None. `--deep` is opt-in; all existing flows (`--python`, `--typescript`, `--ttt`, `--pr`, `--loop`, `--review-only`) are unchanged. `phase_parse_feedback`'s new `input_path` is keyword-only with a `None` default.

---

Generated with [Claude Code](https://claude.com/claude-code)