### PR TITLE
fix(deep): write merge report to .daydream/deep/ to avoid sandbox restrictions

### DIFF
--- a/daydream/deep/artifacts.py
+++ b/daydream/deep/artifacts.py
@@ -71,6 +71,16 @@ def dedup_candidates_path(deep_dir_path: Path) -> Path:
     return deep_dir_path / "dedup-candidates.json"
 
 
+def merged_report_path(deep_dir_path: Path) -> Path:
+    """Merged review report inside the deep artifact directory.
+
+    The merge agent writes here first (same directory as per-stack artifacts,
+    which avoids sandbox write restrictions). The orchestrator then copies the
+    result to ``target / REVIEW_OUTPUT_FILE`` for downstream consumers.
+    """
+    return deep_dir_path / "review-output.md"
+
+
 def per_stack_failures_path(deep_dir_path: Path) -> Path:
     """Per-stack agent failure summary ({stack_name: reason} JSON).
 
@@ -112,12 +122,16 @@ def check_deep_artifacts(stage: str, deep_dir_path: Path) -> None:
         if not records:
             missing.append(deep_dir_path / "stack-*-records.json")
 
-    # Fix stage needs the merged report in target_dir (parent of .daydream, not deep_dir).
+    # Fix stage needs the merged report. Check both the canonical location
+    # (target_dir / .review-output.md) and the deep artifact copy
+    # (deep_dir / review-output.md) so resume works even when the agent
+    # could only write to the deep directory.
     if stage == "fix":
         target_dir = deep_dir_path.parent.parent
-        merged = target_dir / REVIEW_OUTPUT_FILE
-        if not merged.is_file():
-            missing.append(merged)
+        canonical = target_dir / REVIEW_OUTPUT_FILE
+        deep_copy = merged_report_path(deep_dir_path)
+        if not canonical.is_file() and not deep_copy.is_file():
+            missing.append(canonical)
 
     if missing:
         expected_block = "\n".join(f"  - {p}" for p in missing)

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -476,6 +476,17 @@ async def run_deep(config: RunConfig, target_dir: Path) -> int:
         # ------ Stage 5: optional fix gate (D-28, D-29) ------
         print_stage_progress(console, 5, 5, _PIPELINE_STAGE_NAMES[4])
         merged_report = target_dir / REVIEW_OUTPUT_FILE
+
+        # Recover from deep-dir artifact when the canonical file is absent
+        # (e.g. agent wrote to .daydream/deep/ but Python copy didn't run
+        # during a --start-at fix resume).
+        if not merged_report.exists():
+            from daydream.deep.artifacts import merged_report_path
+
+            deep_copy = merged_report_path(dd)
+            if deep_copy.exists():
+                merged_report.write_text(deep_copy.read_text())
+
         if not merged_report.exists():
             print_error(
                 console,

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -1516,6 +1516,12 @@ async def phase_cross_stack_merge(
 
     canonical_path = cwd / REVIEW_OUTPUT_FILE
     agent_output_path = merged_report_path(deep_dir(cwd))
+
+    # Clear stale outputs so a failed merge agent can't leave behind
+    # outdated content that downstream stages would silently consume.
+    canonical_path.unlink(missing_ok=True)
+    agent_output_path.unlink(missing_ok=True)
+
     prompt = build_merge_prompt(
         per_stack_records_paths=per_stack_records_paths,
         intent_path=intent_path,
@@ -1531,6 +1537,7 @@ async def phase_cross_stack_merge(
     # Copy from deep artifact dir to canonical location. The agent writes
     # inside .daydream/deep/ where sandbox restrictions don't apply; Python
     # handles the copy to cwd/.review-output.md.
-    if agent_output_path.exists():
-        canonical_path.write_text(agent_output_path.read_text())
+    if not agent_output_path.is_file():
+        raise FileNotFoundError(f"Expected merged report at {agent_output_path}")
+    canonical_path.write_text(agent_output_path.read_text())
     return canonical_path

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -1488,7 +1488,11 @@ async def phase_cross_stack_merge(
 ) -> Path:
     """Run the cross-stack merge agent and return the output-report path (D-23..D-27).
 
-    Writes the merged markdown report to ``cwd / REVIEW_OUTPUT_FILE`` (D-24/D-42).
+    The agent writes the report to ``.daydream/deep/review-output.md`` (same
+    directory as per-stack artifacts, which avoids sandbox write restrictions
+    that block dotfiles at the repo root). This function then copies the result
+    to ``cwd / REVIEW_OUTPUT_FILE`` for downstream consumers.
+
     Per D-38, never passes the ``agents`` kwarg (Codex parity).
 
     Args:
@@ -1507,18 +1511,26 @@ async def phase_cross_stack_merge(
         Path to the merged report at ``cwd / REVIEW_OUTPUT_FILE``.
 
     """
+    from daydream.deep.artifacts import deep_dir, merged_report_path
     from daydream.deep.prompts import build_merge_prompt
 
-    output_path = cwd / REVIEW_OUTPUT_FILE
+    canonical_path = cwd / REVIEW_OUTPUT_FILE
+    agent_output_path = merged_report_path(deep_dir(cwd))
     prompt = build_merge_prompt(
         per_stack_records_paths=per_stack_records_paths,
         intent_path=intent_path,
         alternatives_path=alternatives_path,
         dedup_candidates_path=dedup_candidates_path,
-        output_path=output_path,
+        output_path=agent_output_path,
         exploration_dir=exploration_dir,
         failed_stacks=failed_stacks,
     )
     print_phase_hero(console, "MERGE", phase_subtitle("MERGE"))
     await run_agent(backend, cwd, prompt)
-    return output_path
+
+    # Copy from deep artifact dir to canonical location. The agent writes
+    # inside .daydream/deep/ where sandbox restrictions don't apply; Python
+    # handles the copy to cwd/.review-output.md.
+    if agent_output_path.exists():
+        canonical_path.write_text(agent_output_path.read_text())
+    return canonical_path

--- a/scripts/redrive_post.py
+++ b/scripts/redrive_post.py
@@ -30,23 +30,29 @@ def _load_artifacts(deep_dir: Path) -> tuple[list[dict], list[dict], list[dict]]
     return alts, records, dedup
 
 
+def _record_key(record: dict) -> tuple[str, int]:
+    """Composite key for a per-stack record (file + id)."""
+    return str(record["file"]), int(record["id"])
+
+
 def _find_overlaps(
     alts: list[dict], records: list[dict]
-) -> tuple[dict[int, list[dict]], set[int]]:
+) -> tuple[dict[int, list[dict]], set[tuple[str, int]]]:
     """Match alternatives to generic records by shared file paths."""
     by_file: dict[str, list[dict]] = {}
     for r in records:
         by_file.setdefault(r["file"], []).append(r)
 
     alt_matches: dict[int, list[dict]] = {}
-    consumed: set[int] = set()
+    consumed: set[tuple[str, int]] = set()
     for alt in alts:
         matches: list[dict] = []
         for f in alt.get("files", []):
             for r in by_file.get(f, []):
-                if r["id"] not in consumed:
+                key = _record_key(r)
+                if key not in consumed:
                     matches.append(r)
-                    consumed.add(r["id"])
+                    consumed.add(key)
         if matches:
             alt_matches[alt["id"]] = matches
 
@@ -119,7 +125,7 @@ def build_report(
             lines.append(f"{num}. [{loc}] {title}\n{body}\n")
 
     for r in records:
-        if r["id"] in consumed_ids:
+        if _record_key(r) in consumed_ids:
             continue
         num += 1
         loc = f"{r['file']}:{r['line']}" if r.get("line") else r["file"]

--- a/scripts/redrive_post.py
+++ b/scripts/redrive_post.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Re-drive PR comment posting from existing deep review artifacts.
+
+Usage:
+    uv run python scripts/redrive_post.py /path/to/target/repo --pr 58
+
+Reads .daydream/deep/{alternatives.json, stack-*-records.json, dedup-candidates.json}
+and synthesizes .review-output.md, then calls the standard PR posting flow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def _load_artifacts(deep_dir: Path) -> tuple[list[dict], list[dict], list[dict]]:
+    """Load alternatives, per-stack records, and dedup candidates."""
+    alts = json.loads((deep_dir / "alternatives.json").read_text())
+    dedup = json.loads((deep_dir / "dedup-candidates.json").read_text())
+
+    records: list[dict] = []
+    for p in sorted(deep_dir.glob("stack-*-records.json")):
+        records.extend(json.loads(p.read_text()))
+
+    return alts, records, dedup
+
+
+def _find_overlaps(
+    alts: list[dict], records: list[dict]
+) -> tuple[dict[int, list[dict]], set[int]]:
+    """Match alternatives to generic records by shared file paths."""
+    by_file: dict[str, list[dict]] = {}
+    for r in records:
+        by_file.setdefault(r["file"], []).append(r)
+
+    alt_matches: dict[int, list[dict]] = {}
+    consumed: set[int] = set()
+    for alt in alts:
+        matches: list[dict] = []
+        for f in alt.get("files", []):
+            for r in by_file.get(f, []):
+                if r["id"] not in consumed:
+                    matches.append(r)
+                    consumed.add(r["id"])
+        if matches:
+            alt_matches[alt["id"]] = matches
+
+    return alt_matches, consumed
+
+
+def _fmt_body(
+    *,
+    severity: str = "",
+    confidence: str = "",
+    description: str = "",
+    rationale: str = "",
+    recommendation: str = "",
+    extra: str = "",
+) -> str:
+    parts: list[str] = []
+    if severity:
+        parts.append(f"   **Severity:** {severity}")
+    if confidence:
+        parts.append(f"   **Confidence:** {confidence}")
+    if description:
+        parts.append(f"   {description}")
+    if rationale:
+        parts.append(f"   **Rationale:** {rationale}")
+    if recommendation:
+        parts.append(f"   **Recommendation:** {recommendation}")
+    if extra:
+        parts.append(f"   {extra}")
+    return "\n\n".join(parts)
+
+
+def build_report(
+    alts: list[dict], records: list[dict], dedup: list[dict]
+) -> str:
+    """Merge alternatives + per-stack records into .review-output.md."""
+    alt_matches, consumed_ids = _find_overlaps(alts, records)
+
+    lines: list[str] = ["# Review\n"]
+    lines.append("## Issues\n")
+
+    num = 0
+
+    for alt in alts:
+        files = alt.get("files", [])
+        title = alt.get("title", alt.get("description", ""))
+        matches = alt_matches.get(alt["id"], [])
+
+        file_lines: dict[str, int | None] = {f: None for f in files}
+        for m in matches:
+            if m["file"] in file_lines and m.get("line"):
+                file_lines[m["file"]] = m["line"]
+
+        extra = ""
+        if matches:
+            evidence = "; ".join(m["description"] for m in matches)
+            extra = f"**Per-stack evidence:** {evidence}"
+
+        for f in files:
+            num += 1
+            line = file_lines.get(f)
+            loc = f"{f}:{line}" if line else f
+            body = _fmt_body(
+                severity=alt.get("severity", ""),
+                confidence=alt.get("confidence", ""),
+                description=alt.get("description", ""),
+                rationale=alt.get("rationale", ""),
+                recommendation=alt.get("recommendation", ""),
+                extra=extra,
+            )
+            lines.append(f"{num}. [{loc}] {title}\n{body}\n")
+
+    for r in records:
+        if r["id"] in consumed_ids:
+            continue
+        num += 1
+        loc = f"{r['file']}:{r['line']}" if r.get("line") else r["file"]
+        body = _fmt_body(
+            confidence=r.get("confidence", ""),
+            description=r["description"],
+            rationale=r.get("rationale", ""),
+        )
+        lines.append(f"{num}. [{loc}] {r['description']}\n{body}\n")
+
+    return "\n".join(lines)
+
+
+def _lookup_pr(target_dir: Path, pr_number: int) -> dict | None:
+    """Fetch PR details via gh CLI."""
+    try:
+        r = subprocess.run(  # noqa: S603, S607 -- args are hardcoded
+            [
+                "gh", "pr", "view", str(pr_number),
+                "--json", "number,headRefOid,baseRefOid,baseRefName,url",
+            ],
+            cwd=target_dir,
+            capture_output=True,
+            text=True,
+            timeout=15,
+            shell=False,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    if r.returncode != 0:
+        return None
+    try:
+        return json.loads(r.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def _repo_owner_name(target_dir: Path) -> tuple[str | None, str | None]:
+    try:
+        r = subprocess.run(  # noqa: S603, S607
+            ["gh", "repo", "view", "--json", "owner,name"],
+            cwd=target_dir,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            shell=False,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None, None
+    if r.returncode != 0:
+        return None, None
+    try:
+        data = json.loads(r.stdout)
+    except json.JSONDecodeError:
+        return None, None
+    return data.get("owner", {}).get("login"), data.get("name")
+
+
+async def _run(target_dir: Path, pr_number: int, auto_yes: bool = False) -> None:
+    from rich.console import Console
+
+    from daydream.pr_review import (
+        PRInfo,
+        build_payload,
+        classify,
+        parse_report,
+    )
+    from daydream.ui import print_info, print_success, print_warning
+
+    console = Console()
+
+    # --- Build report from artifacts ---
+    deep_dir = target_dir / ".daydream" / "deep"
+    if not deep_dir.is_dir():
+        print(f"No .daydream/deep/ directory found at {target_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    alts, records, dedup = _load_artifacts(deep_dir)
+    report = build_report(alts, records, dedup)
+
+    output_path = target_dir / ".review-output.md"
+    output_path.write_text(report)
+    print(f"Wrote merged report ({len(report)} bytes) to {output_path}")
+
+    # --- Parse the report ---
+    issues = parse_report(report)
+    if not issues:
+        print("No parseable issues in report", file=sys.stderr)
+        sys.exit(1)
+    print(f"Parsed {len(issues)} issues from report")
+
+    # --- Resolve PR info ---
+    pr_data = _lookup_pr(target_dir, pr_number)
+    if pr_data is None:
+        print(f"Could not find PR #{pr_number}", file=sys.stderr)
+        sys.exit(1)
+
+    owner, repo = _repo_owner_name(target_dir)
+    if owner is None or repo is None:
+        print("Could not determine repo owner/name", file=sys.stderr)
+        sys.exit(1)
+
+    pr = PRInfo(
+        number=pr_data["number"],
+        head_sha=pr_data["headRefOid"],
+        base_sha=pr_data["baseRefOid"],
+        base_ref=pr_data.get("baseRefName", ""),
+        owner=owner,
+        repo=repo,
+        url=pr_data.get("url", ""),
+    )
+    print(f"PR #{pr.number} ({pr.url})")
+    print(f"  head: {pr.head_sha[:12]}  base: {pr.base_sha[:12]}")
+
+    # --- Classify issues (inline vs body-only) ---
+    classified = classify(target_dir, pr, issues)
+    inline_files = sorted({c["path"] for c in classified.inline})
+    print(
+        f"\n{len(classified.inline)} inline on "
+        f"{', '.join(inline_files) if inline_files else '(none)'}, "
+        f"{len(classified.body_only)} folded into body"
+    )
+
+    if not classified.inline and not classified.body_only:
+        print("No postable issues after classification")
+        return
+
+    # --- Confirm and post ---
+    if not auto_yes:
+        answer = input("\nPost these as a PR review? [y/N] ").strip().lower()
+        if answer not in ("y", "yes"):
+            print("Skipped.")
+            return
+
+    payload = build_payload(pr, "deep review", classified)
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        prefix=f"pr-{pr.number}-review-",
+        suffix=".json",
+        delete=False,
+        encoding="utf-8",
+    ) as tf:
+        tf.write(json.dumps(payload, indent=2))
+        payload_path = Path(tf.name)
+
+    print(f"Payload written to {payload_path}")
+
+    try:
+        r = subprocess.run(  # noqa: S603, S607
+            [
+                "gh", "api",
+                "--method", "POST",
+                f"/repos/{pr.owner}/{pr.repo}/pulls/{pr.number}/reviews",
+                "--input", str(payload_path),
+            ],
+            cwd=target_dir,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            shell=False,
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        print(f"Failed to post: {exc}", file=sys.stderr)
+        print(f"Payload kept at {payload_path}")
+        sys.exit(1)
+
+    if r.returncode != 0:
+        print(f"gh api failed (rc={r.returncode}): {r.stderr}", file=sys.stderr)
+        print(f"Payload kept at {payload_path}")
+        sys.exit(1)
+
+    try:
+        data = json.loads(r.stdout)
+        url = data.get("html_url", "(no URL returned)")
+    except json.JSONDecodeError:
+        url = "(response not JSON)"
+
+    payload_path.unlink(missing_ok=True)
+    print(f"\nPosted review: {url}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Re-drive deep review PR posting")
+    parser.add_argument("target_dir", type=Path, help="Path to the target repo")
+    parser.add_argument("--pr", type=int, required=True, help="PR number to post to")
+    parser.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompt")
+    args = parser.parse_args()
+
+    target_dir = args.target_dir.resolve()
+    if not target_dir.is_dir():
+        print(f"Not a directory: {target_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    import anyio
+
+    anyio.run(_run, target_dir, args.pr, args.yes)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_deep_integration.py
+++ b/tests/test_deep_integration.py
@@ -84,7 +84,11 @@ class _DeepMockBackend:
         # Cross-stack merge prompt contains "cross-stack merge agent".
         if "cross-stack merge agent" in pl:
             self.calls.append("merge")
-            (self.target_dir / REVIEW_OUTPUT_FILE).write_text(
+            # Write to the deep artifact path (matching real agent behavior);
+            # the caller (phase_cross_stack_merge) copies to canonical.
+            deep = self.target_dir / ".daydream" / "deep" / "review-output.md"
+            deep.parent.mkdir(parents=True, exist_ok=True)
+            deep.write_text(
                 "# Review\n\n## Issues\n\n## Cross-Stack Issues\n"
             )
             yield TextEvent(text="")

--- a/tests/test_deep_merge.py
+++ b/tests/test_deep_merge.py
@@ -93,6 +93,10 @@ class _RecordingBackend:
     ):
         self.prompts.append(prompt)
         self.agents_seen.append(agents)
+        # Write the deep artifact so phase_cross_stack_merge can copy it.
+        deep_out = cwd / ".daydream" / "deep" / "review-output.md"
+        deep_out.parent.mkdir(parents=True, exist_ok=True)
+        deep_out.write_text("merged")
         yield TextEvent(text="merged")
         yield ResultEvent(structured_output=None, continuation=None)
 


### PR DESCRIPTION
## Summary
- The deep review merge agent writes `.review-output.md` to the target repo root, but the SDK sandbox can block dotfile writes there — per-stack agents writing to `.daydream/deep/` succeed because that directory is already within the agent's working tree
- Redirects the merge agent's write target to `.daydream/deep/review-output.md`, then copies to the canonical location from Python (bypassing the sandbox)
- Adds recovery in the orchestrator fix gate and `check_deep_artifacts` for `--start-at fix` resume
- Includes `scripts/redrive_post.py` for re-driving PR comment posts from existing artifacts when the original run fails

## Test plan
- [ ] Existing test suite passes (358 passed, 4 pre-existing failures unchanged)
- [ ] `make lint` and `make typecheck` clean
- [ ] Run `daydream --deep` against a repo with an open PR — verify `.daydream/deep/review-output.md` is created and copied to `.review-output.md`
- [ ] Run `daydream --deep --start-at fix` with only the deep-dir copy present — verify recovery works
- [ ] Run `scripts/redrive_post.py /path/to/repo --pr N` against existing artifacts — verify PR comments post

🤖 Generated with [Claude Code](https://claude.com/claude-code)