### PR TITLE
chore(release): 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.14.0] - 2026-04-28
+## [0.14.0] - 2026-04-29
 
 ### Breaking
 

--- a/daydream/__init__.py
+++ b/daydream/__init__.py
@@ -17,4 +17,4 @@ Submodules:
     ui: User interface utilities for terminal output.
 """
 
-__version__ = "0.13.1"
+__version__ = "0.14.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "daydream"
-version = "0.13.1"
+version = "0.14.0"
 description = "Automated code review and fix loop using Claude"
 requires-python = ">=3.12"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -192,7 +192,7 @@ wheels = [
 
 [[package]]
 name = "daydream"
-version = "0.13.1"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

- Bump version to 0.14.0
- Update CHANGELOG.md with changes since v0.13.1

The 0.14.0 release replaces daydream's prefix-tagged debug logging with [ATIF v1.6](https://www.harborframework.com/docs/agents/trajectory-format) trajectory recording and adds run archive + evaluation tooling. Includes one breaking change: `--debug` is removed in favor of `--trajectory <path>`.

## Post-merge steps

After merging, run:
```
/release-tag 0.14.0
```

---

Generated with [Claude Code](https://claude.com/claude-code)