### PR TITLE
fix: revert default Claude model to opus-4-6 and consolidate model defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **agent:** Revert default Claude model from `claude-opus-4-7` to `claude-opus-4-6` ([#67](https://github.com/existential-birds/daydream/issues/67))
+
+  4.7 escalates the SDK's default malware-analysis `<system-reminder>` (injected on every `Read` tool result) into hard refusals on benign user code, citing the reminder verbatim and declining requested edits — a regression vs. 4.6 / 4.5, which treat it as a soft nudge. Trajectory data across three recent deep runs showed 15 reminder-tied refusals out of 135 reads (~11%) and ~2,537 wasted output tokens on "this is benign code, proceeding…" preambles. Reverting to 4.6 until the underlying behavior is addressed.
+
+- **agent:** Make `model` a required `str` end-to-end; default lives only in `daydream.config.DEFAULT_CLAUDE_MODEL` / `DEFAULT_CODEX_MODEL`, resolved exactly once in `create_backend`. Removed five duplicated literal fallbacks (`ClaudeBackend.__init__`, `CodexBackend.__init__`, `AgentState.model`, `runner.set_model(... or "...")`, banner display) so a future model bump is one constant change, not a five-file shotgun edit. `set_model` / `get_model` deleted (`AgentState.model` was unused).
+
 ## [0.14.0] - 2026-04-29
 
 ### Breaking

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -55,14 +55,12 @@ class AgentState:
 
     Attributes:
         quiet_mode: True to hide tool calls and results, False to show them.
-        model: Model name to use for agent interactions.
         shutdown_requested: True if shutdown has been requested.
         current_backends: List of active backend instances.
 
     """
 
     quiet_mode: bool = False
-    model: str = "claude-opus-4-7"
     shutdown_requested: bool = False
     current_backends: list[Backend] = field(default_factory=list)
 
@@ -124,28 +122,6 @@ def get_quiet_mode() -> bool:
     """
     return _state.quiet_mode
 
-
-def set_model(model: str) -> None:
-    """Set the model to use for agent interactions.
-
-    Args:
-        model: Model name ("opus", "sonnet", or "haiku").
-
-    Returns:
-        None
-
-    """
-    _state.model = model
-
-
-def get_model() -> str:
-    """Get the current model setting.
-
-    Returns:
-        The current model name.
-
-    """
-    return _state.model
 
 
 def set_shutdown_requested(requested: bool) -> None:

--- a/daydream/backends/__init__.py
+++ b/daydream/backends/__init__.py
@@ -195,6 +195,8 @@ class Backend(Protocol):
     Each backend yields a stream of AgentEvent instances from execute().
     """
 
+    model: str
+
     def execute(
         self,
         cwd: Path,
@@ -215,21 +217,26 @@ def create_backend(name: str, model: str | None = None) -> Backend:
 
     Args:
         name: Backend name ("claude" or "codex").
-        model: Optional model override. Each backend has its own default.
+        model: Optional CLI override. When ``None``, the per-backend default
+            from :mod:`daydream.config` is used. This is the *only* place
+            those defaults are read; downstream layers take ``model: str``
+            as required.
 
     Returns:
-        A Backend instance.
+        A Backend instance whose ``.model`` attribute is a non-empty string.
 
     Raises:
         ValueError: If the backend name is unknown.
 
     """
+    from daydream.config import DEFAULT_CLAUDE_MODEL, DEFAULT_CODEX_MODEL
+
     if name == "claude":
         from daydream.backends.claude import ClaudeBackend
-        return ClaudeBackend(model=model or "claude-opus-4-7")
+        return ClaudeBackend(model=model or DEFAULT_CLAUDE_MODEL)
     if name == "codex":
         from daydream.backends.codex import CodexBackend
-        return CodexBackend(model=model or "gpt-5.3-codex")
+        return CodexBackend(model=model or DEFAULT_CODEX_MODEL)
     raise ValueError(f"Unknown backend: {name!r}. Expected 'claude' or 'codex'.")
 
 

--- a/daydream/backends/claude.py
+++ b/daydream/backends/claude.py
@@ -38,7 +38,7 @@ class ClaudeBackend:
     Translates Claude SDK message types into the unified AgentEvent stream.
     """
 
-    def __init__(self, model: str = "claude-opus-4-7"):
+    def __init__(self, model: str):
         self.model = model
         self._client: ClaudeSDKClient | None = None
 

--- a/daydream/backends/codex.py
+++ b/daydream/backends/codex.py
@@ -67,7 +67,7 @@ class CodexBackend:
     Translates Codex JSONL events into the unified AgentEvent stream.
     """
 
-    def __init__(self, model: str = "gpt-5.3-codex"):
+    def __init__(self, model: str):
         self.model = model
         self._process: asyncio.subprocess.Process | None = None
 

--- a/daydream/config.py
+++ b/daydream/config.py
@@ -9,9 +9,17 @@ Exports:
     REVIEW_SKILLS: dict[ReviewSkillChoice, str] - Mapping of review type identifiers to skill names.
     REVIEW_OUTPUT_FILE: str - Default filename for storing review results.
     UNKNOWN_SKILL_PATTERN: str - Regex pattern for detecting unknown skill errors.
+    DEFAULT_CLAUDE_MODEL: str - Default Claude model id when no override is given.
+    DEFAULT_CODEX_MODEL: str - Default Codex model id when no override is given.
 """
 
 from enum import Enum
+
+# Default model ids — single source of truth. Resolved by ``create_backend`` only
+# when no explicit override is supplied. Every other layer takes ``model: str``
+# as required and does no fallback of its own.
+DEFAULT_CLAUDE_MODEL = "claude-opus-4-6"
+DEFAULT_CODEX_MODEL = "gpt-5.3-codex"
 
 
 class ReviewSkillChoice(Enum):

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -296,7 +296,7 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
         console.print()
         print_info(console, f"Target directory: {target_dir}")
         print_info(console, f"Branch: {branch}")
-        print_info(console, f"Model: {config.model or '<backend-default>'}")
+        print_info(console, f"Model: {backend.model}")
         console.print()
 
         # ------ Resume gate (D-34, D-36, D-37) ------

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -29,7 +29,6 @@ from daydream import git_ops
 from daydream.agent import (
     MissingSkillError,
     console,
-    set_model,
     set_quiet_mode,
 )
 from daydream.backends import Backend, create_backend
@@ -89,7 +88,8 @@ class RunConfig:
     Attributes:
         target: Target directory path for the review. If None, prompts user.
         skill: Review skill to use ("python", "react", or "elixir"). If None, prompts user.
-        model: Claude model to use ("opus", "sonnet", or "haiku", or a dated id). Default is "claude-opus-4-7".
+        model: CLI override for the model id. ``None`` means "use the
+            per-backend default from :mod:`daydream.config`".
         cleanup: Remove review output file after completion. If None, prompts user.
         quiet: Suppress verbose output from the agent.
         review_only: Run review phase only without applying fixes.
@@ -304,7 +304,6 @@ async def run(config: RunConfig | None = None) -> int:
         if codex_in_use:
             quiet = False
     set_quiet_mode(quiet)
-    set_model(config.model or "claude-opus-4-7")
 
     # ``--comment`` and ``--review`` skip the test phase, so they also skip
     # the .env copy mechanism in ephemeral mode (workspace.copy_files_into_ephemeral).
@@ -437,7 +436,7 @@ async def _run_pr_feedback(work: WorkContext, config: RunConfig) -> int:
         print_info(console, f"PR feedback mode: PR #{pr_number}")
         print_info(console, f"Bot: {bot}")
         print_info(console, f"Target directory: {target_dir}")
-        print_info(console, f"Model: {config.model or 'claude-opus-4-7'}")
+        print_info(console, f"Model: {review_backend.model}")
         console.print()
 
         # Phase 1: Fetch PR feedback
@@ -588,7 +587,7 @@ async def _run_review_or_comment(
         console.print()
         print_info(console, f"Target directory: {target_dir}")
         print_info(console, f"Branch: {branch}")
-        print_info(console, f"Model: {config.model or '<backend-default>'}")
+        print_info(console, f"Model: {backend.model}")
         console.print()
 
         # Pre-scan exploration: populate config.exploration_context before phase 1.
@@ -734,7 +733,7 @@ async def _run_loop_shallow(work: WorkContext, config: RunConfig) -> int:
     ):
         console.print()
         print_info(console, f"Target directory: {target_dir}")
-        print_info(console, f"Model: {config.model or '<backend-default>'}")
+        print_info(console, f"Model: {review_backend.model}")
         if skill:
             print_info(console, f"Review skill: {skill}")
         if config.review_only:

--- a/tests/test_agent_recorder_integration.py
+++ b/tests/test_agent_recorder_integration.py
@@ -68,6 +68,7 @@ class MockBackend:
     deterministic.
     """
 
+    model = "mock-model"
     events: list[AgentEvent]
 
     def execute(

--- a/tests/test_backend_claude.py
+++ b/tests/test_backend_claude.py
@@ -214,13 +214,13 @@ async def test_execute_structured_output(patch_sdk):
 
 
 def test_format_skill_invocation_full_key():
-    backend = ClaudeBackend()
+    backend = ClaudeBackend(model="fixture-model")
     result = backend.format_skill_invocation("beagle-python:review-python")
     assert result == "/beagle-python:review-python"
 
 
 def test_format_skill_invocation_with_args():
-    backend = ClaudeBackend()
+    backend = ClaudeBackend(model="fixture-model")
     result = backend.format_skill_invocation("beagle-core:fetch-pr-feedback", "--pr 42 --bot mybot")
     assert result == "/beagle-core:fetch-pr-feedback --pr 42 --bot mybot"
 

--- a/tests/test_backend_codex.py
+++ b/tests/test_backend_codex.py
@@ -76,7 +76,7 @@ async def test_simple_text_events():
 
 @pytest.mark.asyncio
 async def test_tool_use_events():
-    backend = CodexBackend()
+    backend = CodexBackend(model="fixture-model")
     mock_proc = _make_mock_process("tool_use.jsonl")
 
     with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
@@ -107,7 +107,7 @@ async def test_tool_use_events():
 
 @pytest.mark.asyncio
 async def test_structured_output():
-    backend = CodexBackend()
+    backend = CodexBackend(model="fixture-model")
     mock_proc = _make_mock_process("structured_output.jsonl")
     schema = {"type": "object", "properties": {"issues": {"type": "array"}}}
 
@@ -125,7 +125,7 @@ async def test_structured_output():
 
 @pytest.mark.asyncio
 async def test_turn_failed_raises():
-    backend = CodexBackend()
+    backend = CodexBackend(model="fixture-model")
     mock_proc = _make_mock_process("turn_failed.jsonl")
 
     with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
@@ -139,7 +139,7 @@ async def test_continuation_token_resumes():
     """Test that continuation token is passed as 'resume' argument."""
     from daydream.backends import ContinuationToken
 
-    backend = CodexBackend()
+    backend = CodexBackend(model="fixture-model")
     mock_proc = _make_mock_process("simple_text.jsonl")
     token = ContinuationToken(backend="codex", data={"thread_id": "th_prev"})
 
@@ -158,7 +158,7 @@ async def test_continuation_token_resumes():
 @pytest.mark.asyncio
 async def test_streamed_structured_output_via_item_updated():
     """Text delivered via item.updated deltas (item.completed has empty content)."""
-    backend = CodexBackend()
+    backend = CodexBackend(model="fixture-model")
     mock_proc = _make_mock_process("streamed_structured_output.jsonl")
     schema = {"type": "object", "properties": {"issues": {"type": "array"}}}
 
@@ -181,7 +181,7 @@ async def test_streamed_structured_output_via_item_updated():
 @pytest.mark.asyncio
 async def test_output_text_content_blocks():
     """agent_message with output_text content blocks (schema-constrained)."""
-    backend = CodexBackend()
+    backend = CodexBackend(model="fixture-model")
     mock_proc = _make_mock_process("output_text_blocks.jsonl")
     schema = {"type": "object", "properties": {"issues": {"type": "array"}}}
 
@@ -200,7 +200,7 @@ async def test_output_text_content_blocks():
 @pytest.mark.asyncio
 async def test_toplevel_text_field():
     """Real Codex format: text directly on item, not in content blocks."""
-    backend = CodexBackend()
+    backend = CodexBackend(model="fixture-model")
     mock_proc = _make_mock_process("toplevel_text.jsonl")
     schema = {"type": "object", "properties": {"issues": {"type": "array"}}}
 
@@ -236,7 +236,7 @@ async def test_toplevel_text_field():
 @pytest.mark.asyncio
 async def test_turn_completed_result_field():
     """Structured output returned in turn.completed result field."""
-    backend = CodexBackend()
+    backend = CodexBackend(model="fixture-model")
     mock_proc = _make_mock_process("turn_completed_result.jsonl")
     schema = {"type": "object", "properties": {"issues": {"type": "array"}}}
 
@@ -257,7 +257,7 @@ async def test_turn_completed_cached_input_tokens():
     """Codex emits cached_input_tokens on turn.completed.usage; surface it on
     MetricsEvent and CostEvent so cache-hit ratios work for the Codex backend
     (refs #65, K4 — fix for the historical hardcoded cached_tokens=None)."""
-    backend = CodexBackend()
+    backend = CodexBackend(model="fixture-model")
     mock_proc = _make_mock_process("turn_completed_cached_tokens.jsonl")
 
     with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
@@ -281,20 +281,20 @@ async def test_turn_completed_cached_input_tokens():
 
 
 def test_format_skill_invocation():
-    backend = CodexBackend()
+    backend = CodexBackend(model="fixture-model")
     # Should strip namespace prefix and use $ syntax
     result = backend.format_skill_invocation("beagle-python:review-python")
     assert result == "$review-python"
 
 
 def test_format_skill_invocation_with_args():
-    backend = CodexBackend()
+    backend = CodexBackend(model="fixture-model")
     result = backend.format_skill_invocation("beagle-core:fetch-pr-feedback", "--pr 42 --bot mybot")
     assert result == "$fetch-pr-feedback --pr 42 --bot mybot"
 
 
 def test_format_skill_invocation_no_namespace():
-    backend = CodexBackend()
+    backend = CodexBackend(model="fixture-model")
     result = backend.format_skill_invocation("commit-push")
     assert result == "$commit-push"
 
@@ -346,7 +346,7 @@ class TestUnwrapShellCommand:
 @pytest.mark.asyncio
 async def test_execute_raises_on_agents():
     """CodexBackend refuses agents= with NotImplementedError (Plan 02-04)."""
-    backend = CodexBackend()
+    backend = CodexBackend(model="fixture-model")
     mock_agent = {"description": "test", "prompt": "test"}
 
     with pytest.raises(NotImplementedError, match="Codex backend does not support exploration"):

--- a/tests/test_backend_codex_metrics.py
+++ b/tests/test_backend_codex_metrics.py
@@ -56,7 +56,7 @@ async def test_metrics_event_emitted_at_turn_completed():
 @pytest.mark.asyncio
 async def test_cost_event_still_emitted():
     """The legacy CostEvent emission is preserved (so FinalMetrics aggregation works for Codex too)."""
-    backend = CodexBackend()
+    backend = CodexBackend(model="fixture-model")
     mock_proc = _make_mock_process("turn_completed_with_usage.jsonl")
     with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
         events = []
@@ -73,7 +73,7 @@ async def test_cost_event_still_emitted():
 @pytest.mark.asyncio
 async def test_partial_usage_skips_metrics_event():
     """usage missing output_tokens => no MetricsEvent emitted (EVNT-02 requires both as int)."""
-    backend = CodexBackend()
+    backend = CodexBackend(model="fixture-model")
     mock_proc = _make_mock_process("turn_completed_partial_usage.jsonl")
     with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
         events = []
@@ -90,7 +90,7 @@ async def test_partial_usage_skips_metrics_event():
 @pytest.mark.asyncio
 async def test_codex_parity_gap_d16():
     """D-16: cost_usd and cached_tokens are ALWAYS None for Codex; no token-price-table synthesis."""
-    backend = CodexBackend()
+    backend = CodexBackend(model="fixture-model")
     mock_proc = _make_mock_process("turn_completed_with_usage.jsonl")
     with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
         events = []

--- a/tests/test_backends_init.py
+++ b/tests/test_backends_init.py
@@ -74,10 +74,11 @@ def test_result_event_nullable():
     assert event.continuation is None
 
 
-def test_create_backend_claude_default():
+def test_create_backend_claude_default_uses_config_constant():
+    from daydream.config import DEFAULT_CLAUDE_MODEL
     backend = create_backend("claude")
     assert isinstance(backend, ClaudeBackend)
-    assert backend.model == "claude-opus-4-7"
+    assert backend.model == DEFAULT_CLAUDE_MODEL
 
 
 def test_create_backend_claude_custom_model():
@@ -86,12 +87,12 @@ def test_create_backend_claude_custom_model():
     assert backend.model == "sonnet"
 
 
-def test_create_backend_codex_default():
-    backend = create_backend("codex")
-    # Import here to avoid circular — just check it's not ClaudeBackend
+def test_create_backend_codex_default_uses_config_constant():
     from daydream.backends.codex import CodexBackend
+    from daydream.config import DEFAULT_CODEX_MODEL
+    backend = create_backend("codex")
     assert isinstance(backend, CodexBackend)
-    assert backend.model == "gpt-5.3-codex"
+    assert backend.model == DEFAULT_CODEX_MODEL
 
 
 def test_create_backend_codex_custom_model():

--- a/tests/test_deep_integration.py
+++ b/tests/test_deep_integration.py
@@ -13,6 +13,7 @@ from daydream.config import REVIEW_OUTPUT_FILE
 class _DeepMockBackend:
     """Prompt-dispatching mock backend. Subclasses tune cost + agents behavior."""
 
+    model = "mock-model"
     cost_usd: float | None = 0.01
     raise_on_agents: bool = False
 

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -26,6 +26,8 @@ class _StubBackend:
     tests can assert ordering, agents-kwarg absence, and per-stack isolation.
     """
 
+    model = "mock-model"
+
     def __init__(self, target: Path, *, is_codex: bool = False) -> None:
         self._target = target
         self._is_codex = is_codex

--- a/tests/test_deep_pr_comment_integration.py
+++ b/tests/test_deep_pr_comment_integration.py
@@ -27,7 +27,7 @@ from typing import Any
 
 import pytest
 
-REAL_MODEL_ID = "claude-opus-4-7-20251101"
+FIXTURE_MODEL_ID = "fixture-model-id"
 
 
 # ---------------------------------------------------------------------------
@@ -181,7 +181,7 @@ class _FakeSDKClient:
         ``ClaudeBackend.execute`` records a non-zero ``tool_calls`` count
         AND surfaces real cost + usage on the trailing CostEvent. The
         CostEvent is what carries ``model_name`` to the recorder, so the
-        fork's child trajectory should pick up REAL_MODEL_ID.
+        fork's child trajectory should pick up FIXTURE_MODEL_ID.
         """
         tool_id = f"toolu_{tool_name.lower()}_01"
         return [
@@ -189,7 +189,7 @@ class _FakeSDKClient:
                 content=[
                     FakeToolUseBlock(id=tool_id, name=tool_name, input=tool_input),
                 ],
-                model=REAL_MODEL_ID,
+                model=FIXTURE_MODEL_ID,
             ),
             FakeUserMessage(
                 content=[
@@ -202,7 +202,7 @@ class _FakeSDKClient:
             ),
             FakeAssistantMessage(
                 content=[FakeTextBlock(text="exploration complete")],
-                model=REAL_MODEL_ID,
+                model=FIXTURE_MODEL_ID,
             ),
             FakeResultMessage(
                 structured_output=structured,
@@ -259,7 +259,7 @@ class _FakeSDKClient:
             return [
                 FakeAssistantMessage(
                     content=[FakeTextBlock(text="evaluating alternatives")],
-                    model=REAL_MODEL_ID,
+                    model=FIXTURE_MODEL_ID,
                 ),
                 FakeResultMessage(
                     structured_output={"issues": []},
@@ -278,7 +278,7 @@ class _FakeSDKClient:
             return [
                 FakeAssistantMessage(
                     content=[FakeTextBlock(text="parsing")],
-                    model=REAL_MODEL_ID,
+                    model=FIXTURE_MODEL_ID,
                 ),
                 FakeResultMessage(
                     structured_output={"issues": []},
@@ -296,7 +296,7 @@ class _FakeSDKClient:
             return [
                 FakeAssistantMessage(
                     content=[FakeTextBlock(text="The PR refactors foo() for clarity.")],
-                    model=REAL_MODEL_ID,
+                    model=FIXTURE_MODEL_ID,
                 ),
                 FakeResultMessage(
                     total_cost_usd=0.08,
@@ -313,7 +313,7 @@ class _FakeSDKClient:
         return [
             FakeAssistantMessage(
                 content=[FakeTextBlock(text="ok, wrote the review")],
-                model=REAL_MODEL_ID,
+                model=FIXTURE_MODEL_ID,
             ),
             FakeResultMessage(
                 total_cost_usd=0.20,
@@ -636,9 +636,9 @@ async def test_deep_run_produces_pr_comment_with_real_model_and_metrics(
 
     # --- Model line: real SDK id, not 'unknown' / backend alias ---------
     model_line = _line_starting(body, "- **Model:**")
-    assert REAL_MODEL_ID in model_line, (
+    assert FIXTURE_MODEL_ID in model_line, (
         f"BUG: rollup Model line is missing the real SDK model id "
-        f"({REAL_MODEL_ID!r}).\n  got: {model_line!r}\n\n"
+        f"({FIXTURE_MODEL_ID!r}).\n  got: {model_line!r}\n\n"
         f"full body:\n{body}"
     )
     assert "unknown" not in model_line, (
@@ -678,9 +678,9 @@ async def test_deep_run_produces_pr_comment_with_real_model_and_metrics(
             f"(SDK model id never propagated to the per-phase rollup).\n"
             f"  row: {row!r}"
         )
-        assert REAL_MODEL_ID in model_cell, (
+        assert FIXTURE_MODEL_ID in model_cell, (
             f"BUG: row {phase_name!r} Model cell missing real SDK id "
-            f"{REAL_MODEL_ID!r}.\n  row: {row!r}"
+            f"{FIXTURE_MODEL_ID!r}.\n  row: {row!r}"
         )
         # Steps cell is a stringified int. A row with 0 steps would not
         # have rendered, but be defensive.
@@ -811,9 +811,9 @@ async def test_deep_run_exploration_row_has_real_model_and_metrics(
         f"BUG: Exploration row Model='unknown' (matches production bug).\n"
         f"  row: {exploration_row!r}\n\nfull body:\n{body}"
     )
-    assert REAL_MODEL_ID in model_cell, (
+    assert FIXTURE_MODEL_ID in model_cell, (
         f"BUG: Exploration row Model cell is missing real SDK id "
-        f"{REAL_MODEL_ID!r}.\n  got Model cell: {model_cell!r}\n"
+        f"{FIXTURE_MODEL_ID!r}.\n  got Model cell: {model_cell!r}\n"
         f"  row: {exploration_row!r}"
     )
 

--- a/tests/test_exploration_runner.py
+++ b/tests/test_exploration_runner.py
@@ -111,6 +111,8 @@ _VALID_ENVELOPE: dict[str, Any] = {
 class _SpecialistMockBackend:
     """Mock backend that returns specialist results based on output_schema."""
 
+    model = "mock-model"
+
     def __init__(self, results: dict[str, dict] | None = None) -> None:
         self.execute_calls: list[dict[str, Any]] = []
         self._results = results or _VALID_ENVELOPE

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -15,15 +15,6 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-
-from daydream import git_ops
-from daydream.git_ops import (
-    BranchNotFoundError,
-    GitError,
-    NotAWorktreeError,
-    WrongBranchError,
-)
-
 from conftest import (
     _bare_remote,
     _commit,
@@ -31,6 +22,14 @@ from conftest import (
     _git,
     _init_repo,
     _make_repo_with_main,
+)
+
+from daydream import git_ops
+from daydream.git_ops import (
+    BranchNotFoundError,
+    GitError,
+    NotAWorktreeError,
+    WrongBranchError,
 )
 
 # --- assert_is_worktree / is_inside_worktree --------------------------------

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -37,6 +37,8 @@ def strip_ansi(text: str) -> str:
 class MockBackend:
     """Mock backend that yields events based on prompt content."""
 
+    model = "mock-model"
+
     def __init__(self, events: list | None = None):
         self._events = events
         self._prompt: str = ""
@@ -87,6 +89,8 @@ class MockBackend:
 
 class MockBackendWithEvents:
     """Mock backend with pre-configured events for tool panel testing."""
+
+    model = "mock-model"
 
     def __init__(self, events: list):
         self._events = events
@@ -588,6 +592,8 @@ async def test_run_trust_full_flow(tmp_path, monkeypatch):
     call_count = 0
 
     class TrustMockBackend:
+        model = "mock-model"
+
         async def execute(self, cwd, prompt, output_schema=None, continuation=None, agents=None, max_turns=None):
             nonlocal call_count
             call_count += 1
@@ -689,6 +695,8 @@ async def test_run_trust_does_not_prompt_for_skill(tmp_path, monkeypatch):
     subprocess.run(["git", "commit", "-m", "change"], cwd=tmp_path, capture_output=True, env=env)
 
     class MinimalBackend:
+        model = "mock-model"
+
         async def execute(self, cwd, prompt, output_schema=None, continuation=None, agents=None, max_turns=None):
             yield TextEvent(text="Intent: changes f.txt.")
             yield ResultEvent(structured_output={"issues": []}, continuation=None)
@@ -783,7 +791,7 @@ async def test_codex_backend_raises_on_agents(tmp_path: Path):
     """CodexBackend.execute() refuses agents= with NotImplementedError."""
     from daydream.backends.codex import CodexBackend
 
-    backend = CodexBackend()
+    backend = CodexBackend(model="fixture-model")
     with pytest.raises(NotImplementedError, match="Codex backend does not support exploration"):
         async for _ in backend.execute(tmp_path, "prompt", agents={"x": object()}):
             pass

--- a/tests/test_integration_workspace.py
+++ b/tests/test_integration_workspace.py
@@ -36,7 +36,6 @@ from daydream.backends import (
 )
 from daydream.runner import RunConfig
 
-
 # --- Helpers ---------------------------------------------------------------
 
 
@@ -82,6 +81,8 @@ class MockBackend:
     cleanup, exit codes, captured errors) rather than on what the backend
     happened to be asked to do.
     """
+
+    model = "mock-model"
 
     def __init__(self, events: list[AgentEvent] | None = None) -> None:
         default: list[AgentEvent] = [

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -65,6 +65,8 @@ class LoopMockBackend(Backend):
     on each iteration (list of issue lists, one per iteration).
     """
 
+    model = "mock-model"
+
     def __init__(self, review_results: list[list[dict[str, Any]]], tests_pass: bool = True):
         self._review_results = review_results
         self._tests_pass = tests_pass

--- a/tests/test_multi_turn_tokens.py
+++ b/tests/test_multi_turn_tokens.py
@@ -24,7 +24,6 @@ from daydream.agent import run_agent
 from daydream.atif import validate as atif_validate
 from daydream.backends import (
     AgentEvent,
-    Backend,
     ContinuationToken,
     MetricsEvent,
     ResultEvent,
@@ -48,6 +47,7 @@ PHASES = [DaydreamPhase.REVIEW, DaydreamPhase.FIX, DaydreamPhase.TEST]
 class MockBackend:
     """Minimal Backend replaying a canned event list."""
 
+    model = "mock-model"
     events: list[AgentEvent]
 
     def execute(

--- a/tests/test_phase_2_integration.py
+++ b/tests/test_phase_2_integration.py
@@ -82,6 +82,7 @@ class MockBackend:
     on internal helpers from another test module.
     """
 
+    model = "mock-model"
     events: list[AgentEvent]
 
     def execute(

--- a/tests/test_pr_comment_integration.py
+++ b/tests/test_pr_comment_integration.py
@@ -214,7 +214,7 @@ def _phase_row(markdown: str, label: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-REAL_MODEL_ID = "claude-opus-4-5-20250901"
+FIXTURE_MODEL_ID = "fixture-sdk-model-id"
 
 
 async def test_render_uses_real_sdk_model_id_not_backend_alias(
@@ -232,7 +232,7 @@ async def test_render_uses_real_sdk_model_id_not_backend_alias(
     patch_sdk([
         FakeAssistantMessage(
             content=[FakeTextBlock(text="reviewing the code")],
-            model=REAL_MODEL_ID,
+            model=FIXTURE_MODEL_ID,
         ),
         FakeResultMessage(
             total_cost_usd=0.42,
@@ -254,8 +254,8 @@ async def test_render_uses_real_sdk_model_id_not_backend_alias(
     markdown = render_run_info_block([target_path], "trust-the-technology")
 
     model_line = _model_line(markdown)
-    assert REAL_MODEL_ID in model_line, (
-        f"Bug A: expected real SDK model id {REAL_MODEL_ID!r} in Model line, "
+    assert FIXTURE_MODEL_ID in model_line, (
+        f"Bug A: expected real SDK model id {FIXTURE_MODEL_ID!r} in Model line, "
         f"got: {model_line!r}\n\nFull markdown:\n{markdown}"
     )
     # Sanity: the renderer should NOT be showing the backend alias verbatim
@@ -279,7 +279,7 @@ async def test_render_shows_real_cost_and_tokens_from_sdk_usage(
     review_messages = [
         FakeAssistantMessage(
             content=[FakeTextBlock(text="reviewing")],
-            model=REAL_MODEL_ID,
+            model=FIXTURE_MODEL_ID,
         ),
         FakeResultMessage(
             total_cost_usd=0.30,
@@ -293,7 +293,7 @@ async def test_render_shows_real_cost_and_tokens_from_sdk_usage(
     fix_messages = [
         FakeAssistantMessage(
             content=[FakeTextBlock(text="fixing")],
-            model=REAL_MODEL_ID,
+            model=FIXTURE_MODEL_ID,
         ),
         FakeResultMessage(
             total_cost_usd=0.15,
@@ -398,7 +398,7 @@ async def test_per_phase_rollup_distinguishes_phases(
     review_messages = [
         FakeAssistantMessage(
             content=[FakeTextBlock(text="reviewing")],
-            model=REAL_MODEL_ID,
+            model=FIXTURE_MODEL_ID,
         ),
         FakeResultMessage(
             total_cost_usd=0.20,
@@ -412,7 +412,7 @@ async def test_per_phase_rollup_distinguishes_phases(
     parse_messages = [
         FakeAssistantMessage(
             content=[FakeTextBlock(text="parsed")],
-            model=REAL_MODEL_ID,
+            model=FIXTURE_MODEL_ID,
         ),
         FakeResultMessage(
             total_cost_usd=0.05,

--- a/tests/test_pr_review.py
+++ b/tests/test_pr_review.py
@@ -125,7 +125,8 @@ BOLD_HEAD_REPORT = """\
    Parser must accept `__...__` the same as `**...**`.
 
 ## Cross-Stack Issues
-3. **[cross-stack] [admin-dashboard/lib/auth.ts:1, book-service/admin_auth.go:41, backend/deps.py:48] Inconsistent auth source**
+3. **[cross-stack] [admin-dashboard/lib/auth.ts:1, book-service/admin_auth.go:41, backend/deps.py:48]
+    Inconsistent auth source**
    Frontend reads the JWT claim, backends query the database.
    **Confidence:** HIGH
 """

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -261,28 +261,26 @@ async def test_legacy_trust_the_technology_maps_to_comment(
 
 
 @pytest.mark.asyncio
-async def test_pr_feedback_banner_uses_canonical_default_model(
+async def test_pr_feedback_banner_echoes_resolved_backend_model(
     monkeypatch, tmp_path
 ):
-    """When ``config.model`` is None the PR-feedback banner must reflect the
-    actual runtime default (``claude-opus-4-7``) — not the stale ``opus``
-    fallback that drifted out of sync with ``set_model()`` in :func:`run`.
-    Regression for CodeRabbit finding #5 on PR #66.
+    """The PR-feedback banner reports the model id that the resolved backend
+    actually carries — not a parallel literal hardcoded in the runner. Tests
+    propagation, not a specific id.
     """
     work = _fake_work(tmp_path)
 
-    # Stub backend resolution so we don't try to instantiate a real Claude
-    # SDK client during the banner check.
-    class _DummyBackend:
-        pass
+    class _StubBackend:
+        def __init__(self, model: str):
+            self.model = model
+
+    chosen_model = "fixture-model-xyz"
 
     monkeypatch.setattr(
         "daydream.runner._resolve_backend",
-        lambda _config, _phase, _cache=None: _DummyBackend(),
+        lambda _config, _phase, _cache=None: _StubBackend(chosen_model),
     )
 
-    # Stub the first two phases so the flow exits cleanly via the
-    # "No actionable feedback" early return — we only need the banner.
     async def _no_op_fetch(*_args, **_kwargs):
         return None
 
@@ -292,14 +290,11 @@ async def test_pr_feedback_banner_uses_canonical_default_model(
     monkeypatch.setattr("daydream.runner.phase_fetch_pr_feedback", _no_op_fetch)
     monkeypatch.setattr("daydream.runner.phase_parse_feedback", _empty_parse)
 
-    # Capture print_info calls. ``print_info`` is the seam — every banner
-    # line in ``_run_pr_feedback`` goes through it.
     captured: list[str] = []
-
-    def _capture(_console, message):
-        captured.append(message)
-
-    monkeypatch.setattr("daydream.runner.print_info", _capture)
+    monkeypatch.setattr(
+        "daydream.runner.print_info",
+        lambda _console, message: captured.append(message),
+    )
 
     config = RunConfig(
         target=str(tmp_path),
@@ -310,13 +305,6 @@ async def test_pr_feedback_banner_uses_canonical_default_model(
 
     exit_code = await runner._run_pr_feedback(work, config)
     assert exit_code == 0
-
-    assert "Model: claude-opus-4-7" in captured, (
-        f"Expected canonical default in banner; got {captured!r}"
-    )
-    # Guard against the old stale literal sneaking back in. The banner line
-    # is exactly ``Model: <id>``; assert the bare ``Model: opus`` form is
-    # absent.
-    assert "Model: opus" not in captured, (
-        f"Stale 'Model: opus' banner regressed; got {captured!r}"
+    assert f"Model: {chosen_model}" in captured, (
+        f"Banner did not echo backend.model; got {captured!r}"
     )

--- a/tests/test_subagent_shapes.py
+++ b/tests/test_subagent_shapes.py
@@ -37,6 +37,7 @@ from daydream.trajectory import (
 class MockBackend:
     """Minimal Backend replaying a canned event list."""
 
+    model = "mock-model"
     events: list[AgentEvent]
 
     def execute(


### PR DESCRIPTION
Closes #67.

## Summary

- Reverts the default Claude model from `claude-opus-4-7` to `claude-opus-4-6`. 4.7 escalates the SDK's malware-analysis system-reminder (appended to every `Read` tool result) into hard refusals on benign user code; trajectory data shows 15 refusals / 135 reads (~11%) across three recent deep runs plus a ~2,537-token preamble tax.
- Consolidates all model defaults to a single constant in `daydream.config` (`DEFAULT_CLAUDE_MODEL`, `DEFAULT_CODEX_MODEL`), resolved exactly once in `create_backend`. Model is now a required `str` through every layer.
- Removes five duplicated literal fallbacks (`ClaudeBackend.__init__`, `CodexBackend.__init__`, `AgentState.model`, `runner.set_model(... or "...")`, banner display). A future model bump is now a one-line constant change instead of a five-file shotgun edit.
- Deletes `set_model` / `get_model` and the `AgentState.model` field (all unused after the consolidation). Banner now reads from `backend.model` directly.
- Rewrites two brittle `assert backend.model == "literal-id"` tests to assert the propagation contract instead. Mock backends carry a generic `model = "mock-model"` attribute; no test asserts a specific Claude/Codex id string.

## Test plan

- [x] `make lint` (ruff) — clean
- [x] `make typecheck` (mypy) — clean
- [x] `make test` (pytest) — 776 passed
- [ ] Smoke run on real repo to confirm the SDK accepts `claude-opus-4-6`