### PR TITLE
feat(phases): tag commits with daydream trailers and suppress re-litigation

### DIFF
--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -71,6 +71,7 @@ def build_per_stack_prompt(
     alternatives_path: Path,
     output_path: Path,
     exploration_dir: Path | None = None,
+    prior_commits: str | None = None,
 ) -> str:
     """Assemble the per-stack review prompt.
 
@@ -83,6 +84,7 @@ def build_per_stack_prompt(
         alternatives_path: Path to TTT alternatives.json.
         output_path: Where the agent must write its review.
         exploration_dir: Pre-scan exploration directory (if available).
+        prior_commits: Oneline log of prior daydream commits on this branch.
 
     Returns:
         Assembled prompt string.
@@ -91,6 +93,12 @@ def build_per_stack_prompt(
     pointer = _exploration_pointer(exploration_dir)
     if pointer:
         parts.append(pointer)
+    if prior_commits:
+        parts.append(
+            "Prior automated-review commits on this branch — treat as settled "
+            "decisions unless they introduce bugs or security issues:\n"
+            f"{prior_commits}"
+        )
     parts.append(_context_pointers(intent_path=intent_path, alternatives_path=alternatives_path))
     parts.append(_confidence_and_convention_instructions())
     parts.append(_dependency_impact_instructions())
@@ -231,6 +239,7 @@ def build_generic_fallback_prompt(
     output_path: Path,
     exploration_dir: Path | None = None,
     is_docs_only: bool = False,
+    prior_commits: str | None = None,
 ) -> str:
     """Assemble the generic-fallback review prompt (no skill invocation).
 
@@ -244,6 +253,7 @@ def build_generic_fallback_prompt(
         output_path: Where the agent must write its review.
         exploration_dir: Pre-scan exploration directory (if available).
         is_docs_only: Whether the whole diff is docs-only (D-20).
+        prior_commits: Oneline log of prior daydream commits on this branch.
 
     Returns:
         Assembled prompt string.
@@ -254,6 +264,12 @@ def build_generic_fallback_prompt(
     pointer = _exploration_pointer(exploration_dir)
     if pointer:
         parts.append(pointer)
+    if prior_commits:
+        parts.append(
+            "Prior automated-review commits on this branch — treat as settled "
+            "decisions unless they introduce bugs or security issues:\n"
+            f"{prior_commits}"
+        )
     parts.append(_context_pointers(intent_path=intent_path, alternatives_path=alternatives_path))
     parts.append(_confidence_and_convention_instructions())
     parts.append(_dependency_impact_instructions())

--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -13,6 +13,7 @@ from daydream.phases import (
     _confidence_and_convention_instructions,
     _dependency_impact_instructions,
     _exploration_pointer,
+    _settled_decisions_block,
 )
 
 DOC_REVIEW_NOTICE = (
@@ -93,12 +94,9 @@ def build_per_stack_prompt(
     pointer = _exploration_pointer(exploration_dir)
     if pointer:
         parts.append(pointer)
-    if prior_commits:
-        parts.append(
-            "Prior automated-review commits on this branch — treat as settled "
-            "decisions unless they introduce bugs or security issues:\n"
-            f"{prior_commits}"
-        )
+    settled = _settled_decisions_block(prior_commits)
+    if settled:
+        parts.append(settled)
     parts.append(_context_pointers(intent_path=intent_path, alternatives_path=alternatives_path))
     parts.append(_confidence_and_convention_instructions())
     parts.append(_dependency_impact_instructions())
@@ -264,12 +262,9 @@ def build_generic_fallback_prompt(
     pointer = _exploration_pointer(exploration_dir)
     if pointer:
         parts.append(pointer)
-    if prior_commits:
-        parts.append(
-            "Prior automated-review commits on this branch — treat as settled "
-            "decisions unless they introduce bugs or security issues:\n"
-            f"{prior_commits}"
-        )
+    settled = _settled_decisions_block(prior_commits)
+    if settled:
+        parts.append(settled)
     parts.append(_context_pointers(intent_path=intent_path, alternatives_path=alternatives_path))
     parts.append(_confidence_and_convention_instructions())
     parts.append(_dependency_impact_instructions())

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -462,6 +462,28 @@ def log(repo: Path, base: str, head: str = "HEAD") -> str:
     return proc.stdout.strip()
 
 
+def daydream_commits(repo: Path, base: str, head: str = "HEAD") -> str | None:
+    """Return oneline log of prior daydream commits in ``base..head``.
+
+    Args:
+        repo: Repository working directory.
+        base: Base ref (e.g. ``"main"``).
+        head: Comparison ref. Defaults to ``"HEAD"``.
+
+    Returns:
+        Stripped log output, or ``None`` if no daydream commits found.
+    """
+    proc = _run_git(
+        repo,
+        ["log", f"{base}..{head}", "--oneline", "--grep=Daydream-Run:"],
+        timeout=30,
+    )
+    if proc.returncode != 0:
+        return None
+    output = proc.stdout.strip()
+    return output or None
+
+
 def show(repo: Path, ref: str, path: str) -> bytes:
     """Return the raw bytes of *path* at *ref* via ``git show``.
 

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -32,10 +32,13 @@ The module is intentionally dependency-free: stdlib only.
 from __future__ import annotations
 
 import json
+import logging
 import subprocess
 import tempfile
 from pathlib import Path
 from typing import Any
+
+_logger = logging.getLogger(__name__)
 
 # --- Errors ------------------------------------------------------------------
 
@@ -200,6 +203,77 @@ def head_sha(repo: Path) -> str:
     if proc.returncode != 0:
         raise GitError(f"cannot resolve HEAD in {repo}: {proc.stderr.strip()}")
     return proc.stdout.strip()
+
+
+def head_commit_message(repo: Path) -> str:
+    """Return the full commit message of ``HEAD``.
+
+    Args:
+        repo: Repository working directory.
+
+    Returns:
+        The commit message body of the current ``HEAD`` commit.
+
+    Raises:
+        GitError: If ``git log`` fails (e.g. empty repository).
+    """
+    proc = _run_git(repo, ["log", "-1", "--format=%B", "HEAD"], timeout=5)
+    if proc.returncode != 0:
+        raise GitError(f"cannot read HEAD message in {repo}: {proc.stderr.strip()}")
+    return proc.stdout.strip()
+
+
+def amend_trailers(repo: Path, trailers: dict[str, str]) -> None:
+    """Amend ``HEAD`` to append missing git trailers.
+
+    Uses ``git interpret-trailers`` to inject trailers, then amends the
+    commit with the updated message.  This is a no-op if *trailers* is empty.
+
+    Args:
+        repo: Repository working directory.
+        trailers: Mapping of trailer keys to values (e.g.
+            ``{"Daydream-Run": "abc123"}``).
+
+    Raises:
+        GitError: If the amend fails.
+    """
+    if not trailers:
+        return
+
+    # Build the amended message via git interpret-trailers.
+    trailer_args: list[str] = []
+    for key, value in trailers.items():
+        trailer_args += ["--trailer", f"{key}: {value}"]
+
+    msg_proc = _run_git(repo, ["log", "-1", "--format=%B", "HEAD"], timeout=5)
+    if msg_proc.returncode != 0:
+        raise GitError(f"cannot read HEAD message: {msg_proc.stderr.strip()}")
+
+    # Pipe message through interpret-trailers (run directly, not via _run_git
+    # because we need stdin).
+    try:
+        interp = subprocess.run(  # noqa: S603, S607
+            ["git", "interpret-trailers", *trailer_args],
+            input=msg_proc.stdout,
+            capture_output=True,
+            text=True,
+            cwd=repo,
+            timeout=5,
+            shell=False,
+            check=False,
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        raise GitError(f"git interpret-trailers failed: {exc}") from exc
+
+    if interp.returncode != 0:
+        raise GitError(f"git interpret-trailers failed: {interp.stderr.strip()}")
+
+    amended_msg = interp.stdout
+    amend_proc = _run_git(
+        repo, ["commit", "--amend", "--no-edit", "-m", amended_msg.strip()], timeout=30,
+    )
+    if amend_proc.returncode != 0:
+        raise GitError(f"git commit --amend failed: {amend_proc.stderr.strip()}")
 
 
 def remote_url(repo: Path, remote: str = "origin") -> str | None:
@@ -479,6 +553,13 @@ def daydream_commits(repo: Path, base: str, head: str = "HEAD") -> str | None:
         timeout=30,
     )
     if proc.returncode != 0:
+        _logger.warning(
+            "git log %s..%s --grep=Daydream-Run: failed (rc=%d): %s",
+            base,
+            head,
+            proc.returncode,
+            (proc.stderr or "").strip(),
+        )
         return None
     output = proc.stdout.strip()
     return output or None

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -252,8 +252,8 @@ def amend_trailers(repo: Path, trailers: dict[str, str]) -> None:
     # Pipe message through interpret-trailers (run directly, not via _run_git
     # because we need stdin).
     try:
-        interp = subprocess.run(  # noqa: S603, S607
-            ["git", "interpret-trailers", *trailer_args],
+        interp = subprocess.run(  # noqa: S603 - arguments are not user-controlled
+            ["git", "interpret-trailers", *trailer_args],  # noqa: S607 - git is a trusted command
             input=msg_proc.stdout,
             capture_output=True,
             text=True,

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -1,12 +1,12 @@
 """Phase functions for the review and fix loop."""
 
-import shlex
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import anyio
 
+import daydream
 from daydream import git_ops
 from daydream.agent import (
     console,
@@ -17,7 +17,7 @@ from daydream.agent import (
 from daydream.backends import Backend, ContinuationToken
 from daydream.git_ops import BranchNotFoundError, GitError
 from daydream.trajectory import DaydreamPhase, get_current_recorder, maybe_fork
-from daydream.workspace import WorkContext, write_intent_json
+from daydream.workspace import WorkContext
 
 if TYPE_CHECKING:
     from daydream.deep.detection import StackAssignment
@@ -345,6 +345,7 @@ def build_review_prompt(
     diff_instruction: str = "",
     review_output_path: str = "",
     exploration_dir: Path | None = None,
+    prior_commits: str | None = None,
 ) -> str:
     """Assemble the prompt for `phase_review`.
 
@@ -353,6 +354,8 @@ def build_review_prompt(
         diff_instruction: Diff scope instruction text.
         review_output_path: Absolute path the agent should write its review to.
         exploration_dir: Optional path to exploration output directory.
+        prior_commits: Oneline log of prior daydream commits on this branch.
+            When present, injected as settled-decisions context.
 
     Returns:
         Fully assembled prompt string.
@@ -362,6 +365,12 @@ def build_review_prompt(
     pointer = _exploration_pointer(exploration_dir)
     if pointer:
         parts.append(pointer)
+    if prior_commits:
+        parts.append(
+            "Prior automated-review commits on this branch — treat as settled "
+            "decisions unless they introduce bugs or security issues:\n"
+            f"{prior_commits}"
+        )
     parts.append(_confidence_and_convention_instructions())
     parts.append(_dependency_impact_instructions())
     body = (
@@ -485,6 +494,11 @@ def revert_uncommitted_changes(cwd: Path) -> bool:
             print_warning(console, f"Revert failed: {type(e).__name__}: {e}")
         return False
     return True
+
+
+def _prior_daydream_commits(work: WorkContext) -> str | None:
+    """Return oneline log of prior daydream commits on this branch."""
+    return git_ops.daydream_commits(work.repo, work.base_branch)
 
 
 def _detect_default_branch(cwd: Path) -> str | None:
@@ -632,11 +646,13 @@ async def phase_review(
             f"Use git pathspec magic, e.g. `git diff {ref} -- . {pathspec_args}`.\n"
         )
 
+    prior_commits = _prior_daydream_commits(work)
     prompt = build_review_prompt(
         skill_invocation=skill_invocation,
         diff_instruction=diff_instruction,
         review_output_path=str(review_output_path),
         exploration_dir=exploration_dir,
+        prior_commits=prior_commits,
     )
 
     await run_agent(backend, work.repo, prompt, phase=DaydreamPhase.REVIEW)
@@ -823,15 +839,40 @@ async def phase_test_and_heal(
             return False, retries_used
 
 
-def _commit_push_args(work: WorkContext, intent_path: Path) -> str:
-    """Format the refs-not-diffs arg string for commit-push skills."""
-    # Use relative path to avoid exposing filesystem structure if logged
-    relative_intent = intent_path.relative_to(work.repo)
-    return (
-        f"--repo {shlex.quote(str(work.repo))} "
-        f"--base {shlex.quote(work.base_sha)} "
-        f"--intent {shlex.quote(str(relative_intent))}"
+async def _do_commit(
+    backend: Backend,
+    work: WorkContext,
+    *,
+    push: bool = False,
+    interactive: bool = False,
+    iteration: int | None = None,
+) -> None:
+    """Stage, commit, and optionally push with daydream trailers."""
+    if interactive:
+        response = prompt_user(console, "Commit and push changes? [y/N]", "n")
+        if response.lower() not in ("y", "yes"):
+            print_dim(console, "Skipping commit and push")
+            return
+
+    iteration_line = f"End the body with: Iteration: {iteration}\n\n" if iteration is not None else ""
+    push_line = "Then push to the remote." if push else "Do NOT push. Only commit."
+
+    prompt = (
+        "Stage all changes and commit using a conventional commit message. "
+        "Review the diff to write a meaningful summary of what was fixed or changed. "
+        "Use the format: <type>: <concise summary of changes>\n\n"
+        "Pick the most appropriate type from: fix, refactor, style, perf. "
+        "If multiple categories of changes exist, pick the dominant one. "
+        "Keep the subject line under 72 characters. "
+        "Add a body with bullet points if there are multiple distinct changes. "
+        f"{iteration_line}"
+        "Add these EXACT git trailers as the last lines of the commit message "
+        "(after a blank line following the body):\n\n"
+        f"Daydream-Run: {work.run_id}\n"
+        f"Daydream-Version: {daydream.__version__}\n\n"
+        f"{push_line}"
     )
+    await run_agent(backend, work.repo, prompt, phase=DaydreamPhase.FIX)
 
 
 async def phase_commit_push(backend: Backend, work: WorkContext) -> None:
@@ -839,35 +880,11 @@ async def phase_commit_push(backend: Backend, work: WorkContext) -> None:
 
     Args:
         backend: The Backend to execute against.
-        work: Workspace context for the commit; passed through as
-            ``--repo`` / ``--base`` / ``--intent`` refs to the skill so the
-            agent fetches the diff itself instead of receiving it inline.
-
-    Returns:
-        None
+        work: Workspace context for the commit.
 
     """
-    response = prompt_user(console, "Commit and push changes? [y/N]", "n")
-
-    if response.lower() in ("y", "yes"):
-        console.print()
-        print_info(console, "Running commit-push skill...")
-        intent_path = write_intent_json(
-            work,
-            {
-                "phase": "commit_push",
-                "head_sha": work.head_sha,
-                "base_branch": work.base_branch,
-                "base_sha": work.base_sha,
-            },
-        )
-        skill_invocation = backend.format_skill_invocation(
-            "beagle-core:commit-push", _commit_push_args(work, intent_path),
-        )
-        await run_agent(backend, work.repo, skill_invocation, phase=DaydreamPhase.FIX)
-        print_success(console, "Commit and push complete")
-    else:
-        print_dim(console, "Skipping commit and push")
+    console.print()
+    await _do_commit(backend, work, push=True, interactive=True)
 
 
 async def phase_fetch_pr_feedback(
@@ -999,19 +1016,8 @@ async def phase_commit_iteration(backend: Backend, work: WorkContext, iteration:
         iteration: Current iteration number (used in commit message)
 
     """
-    prompt = (
-        "Stage all changes and commit using a conventional commit message. "
-        "Review the diff to write a meaningful summary of what was fixed or changed. "
-        "Use the format: <type>: <concise summary of changes>\n\n"
-        "Pick the most appropriate type from: fix, refactor, style, perf. "
-        "If multiple categories of changes exist, pick the dominant one. "
-        "Keep the subject line under 72 characters. "
-        "Add a body with bullet points if there are multiple distinct changes. "
-        f"End the body with: Iteration: {iteration}\n\n"
-        "Do NOT push. Only commit."
-    )
     print_info(console, f"Committing iteration {iteration} changes...")
-    await run_agent(backend, work.repo, prompt, phase=DaydreamPhase.FIX)
+    await _do_commit(backend, work, iteration=iteration)
     print_success(console, f"Iteration {iteration} changes committed")
 
 
@@ -1022,31 +1028,13 @@ async def phase_commit_push_auto(
 
     Args:
         backend: The Backend to execute against.
-        work: Workspace context for the commit; refs are forwarded to the
-            commit-push skill so it can fetch the diff itself.
-        items: Optional fix items applied this run; embedded into the intent
-            JSON so the receiving skill can craft a more informed commit.
-
-    Returns:
-        None
+        work: Workspace context for the commit.
+        items: Optional fix items applied this run (kept for API compat).
 
     """
     console.print()
-    print_info(console, "Running commit-push skill...")
-    intent_path = write_intent_json(
-        work,
-        {
-            "phase": "commit_push_auto",
-            "head_sha": work.head_sha,
-            "base_branch": work.base_branch,
-            "base_sha": work.base_sha,
-            "items": items or [],
-        },
-    )
-    skill_invocation = backend.format_skill_invocation(
-        "beagle-core:commit-push", _commit_push_args(work, intent_path),
-    )
-    await run_agent(backend, work.repo, skill_invocation, phase=DaydreamPhase.FIX)
+    print_info(console, "Committing and pushing changes...")
+    await _do_commit(backend, work, push=True)
     print_success(console, "Commit and push complete")
 
 
@@ -1411,6 +1399,7 @@ async def phase_per_stack_reviews(
     results: dict[str, Path] = {}
     failures: dict[str, str] = {}
     limiter = anyio.CapacityLimiter(4)
+    prior_commits = _prior_daydream_commits(work)
 
     async with anyio.create_task_group() as tg:
         for stack in stacks:
@@ -1424,6 +1413,7 @@ async def phase_per_stack_reviews(
                     output_path=output_path,
                     exploration_dir=exploration_dir,
                     is_docs_only=stack.is_docs_only,
+                    prior_commits=prior_commits,
                 )
             else:
                 prompt = build_per_stack_prompt(
@@ -1435,6 +1425,7 @@ async def phase_per_stack_reviews(
                     alternatives_path=alternatives_path,
                     output_path=output_path,
                     exploration_dir=exploration_dir,
+                    prior_commits=prior_commits,
                 )
 
             # Default-arg capture -- prevents late-binding closure bug (Pitfall 2).

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -339,6 +339,26 @@ def _exploration_pointer(exploration_dir: Path | None) -> str:
     )
 
 
+def _settled_decisions_block(prior_commits: str | None) -> str:
+    """Return prompt block marking prior daydream commits as settled, or empty string.
+
+    Args:
+        prior_commits: Oneline log of prior daydream commits on this branch.
+            When None or empty, returns empty string.
+
+    Returns:
+        Prompt block instructing the agent to treat prior commits as settled decisions.
+
+    """
+    if not prior_commits:
+        return ""
+    return (
+        "Prior automated-review commits on this branch — treat as settled "
+        "decisions unless they introduce bugs or security issues:\n"
+        f"{prior_commits}"
+    )
+
+
 def build_review_prompt(
     *,
     skill_invocation: str = "",
@@ -365,12 +385,9 @@ def build_review_prompt(
     pointer = _exploration_pointer(exploration_dir)
     if pointer:
         parts.append(pointer)
-    if prior_commits:
-        parts.append(
-            "Prior automated-review commits on this branch — treat as settled "
-            "decisions unless they introduce bugs or security issues:\n"
-            f"{prior_commits}"
-        )
+    settled = _settled_decisions_block(prior_commits)
+    if settled:
+        parts.append(settled)
     parts.append(_confidence_and_convention_instructions())
     parts.append(_dependency_impact_instructions())
     body = (
@@ -846,8 +863,23 @@ async def _do_commit(
     push: bool = False,
     interactive: bool = False,
     iteration: int | None = None,
+    items: list[dict[str, Any]] | None = None,
 ) -> None:
-    """Stage, commit, and optionally push with daydream trailers."""
+    """Stage, commit, and optionally push with daydream trailers.
+
+    Args:
+        backend: LLM backend used to run the commit agent.
+        work: Current workspace context (repo path, run ID, etc.).
+        push: If True, push to the remote after committing.
+        interactive: If True, prompt the user for confirmation before
+            committing.
+        iteration: When set, append an ``Iteration: <n>`` trailer to the
+            commit message body.
+        items: Optional list of fix dicts (with ``file`` and ``description``
+            keys) summarising changes applied in this run; included in the
+            agent prompt so the commit message is accurate.
+
+    """
     if interactive:
         response = prompt_user(console, "Commit and push changes? [y/N]", "n")
         if response.lower() not in ("y", "yes"):
@@ -857,10 +889,23 @@ async def _do_commit(
     iteration_line = f"End the body with: Iteration: {iteration}\n\n" if iteration is not None else ""
     push_line = "Then push to the remote." if push else "Do NOT push. Only commit."
 
+    if items:
+        summaries = "\n".join(
+            f"- {it.get('file', 'unknown')}: {it.get('description', 'no description')}"
+            for it in items
+        )
+        items_context = (
+            "The following fixes were applied in this run — use them to write "
+            f"an accurate commit message:\n{summaries}\n\n"
+        )
+    else:
+        items_context = ""
+
     prompt = (
         "Stage all changes and commit using a conventional commit message. "
         "Review the diff to write a meaningful summary of what was fixed or changed. "
         "Use the format: <type>: <concise summary of changes>\n\n"
+        f"{items_context}"
         "Pick the most appropriate type from: fix, refactor, style, perf. "
         "If multiple categories of changes exist, pick the dominant one. "
         "Keep the subject line under 72 characters. "
@@ -874,6 +919,30 @@ async def _do_commit(
     )
     await run_agent(backend, work.repo, prompt, phase=DaydreamPhase.FIX)
 
+    # --- Post-commit trailer verification ---
+    # The agent may omit trailers despite being asked.  Verify and amend if
+    # missing so that daydream_commits() can always find them.
+    expected_trailers = {
+        "Daydream-Run": work.run_id,
+        "Daydream-Version": daydream.__version__,
+    }
+    try:
+        msg = git_ops.head_commit_message(work.repo)
+    except GitError:
+        # No commit to verify (e.g. agent failed to commit) — leave as-is.
+        return
+
+    missing = {k: v for k, v in expected_trailers.items() if f"{k}: {v}" not in msg}
+    if missing:
+        print_warning(
+            console,
+            f"Commit missing daydream trailer(s): {', '.join(missing)}; amending",
+        )
+        try:
+            git_ops.amend_trailers(work.repo, missing)
+        except GitError as exc:
+            print_warning(console, f"Failed to amend trailers: {exc}")
+
 
 async def phase_commit_push(backend: Backend, work: WorkContext) -> None:
     """Prompt user to commit and push changes.
@@ -884,7 +953,9 @@ async def phase_commit_push(backend: Backend, work: WorkContext) -> None:
 
     """
     console.print()
+    print_info(console, "Committing and pushing changes...")
     await _do_commit(backend, work, push=True, interactive=True)
+    print_success(console, "Commit and push complete")
 
 
 async def phase_fetch_pr_feedback(
@@ -1029,12 +1100,13 @@ async def phase_commit_push_auto(
     Args:
         backend: The Backend to execute against.
         work: Workspace context for the commit.
-        items: Optional fix items applied this run (kept for API compat).
+        items: Optional fix items applied this run; forwarded to the commit
+            agent so it can craft an accurate commit message.
 
     """
     console.print()
     print_info(console, "Committing and pushing changes...")
-    await _do_commit(backend, work, push=True)
+    await _do_commit(backend, work, push=True, items=items)
     print_success(console, "Commit and push complete")
 
 

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -154,6 +154,83 @@ def _merge_paths(tmp_path: Path) -> dict[str, Path | list[Path] | None]:
     }
 
 
+def test_per_stack_prompt_includes_prior_commits(tmp_path: Path) -> None:
+    """prior_commits block appears in per-stack prompt when provided."""
+    p = _paths(tmp_path)
+    commits = "abc1234 fix: handle edge case\ndef5678 feat: add retry logic"
+    out = build_per_stack_prompt(
+        skill_invocation="/beagle-python:review-python",
+        stack_name="python",
+        files=["api.py"],
+        prior_commits=commits,
+        **p,
+    )
+    assert "Prior automated-review commits on this branch" in out
+    assert "abc1234 fix: handle edge case" in out
+    assert "def5678 feat: add retry logic" in out
+
+
+def test_per_stack_prompt_omits_prior_commits_when_none(tmp_path: Path) -> None:
+    """prior_commits block absent when prior_commits is None."""
+    p = _paths(tmp_path)
+    out = build_per_stack_prompt(
+        skill_invocation="/beagle-python:review-python",
+        stack_name="python",
+        files=["api.py"],
+        prior_commits=None,
+        **p,
+    )
+    assert "Prior automated-review commits" not in out
+
+
+def test_per_stack_prompt_omits_prior_commits_when_empty(tmp_path: Path) -> None:
+    """prior_commits block absent when prior_commits is empty string."""
+    p = _paths(tmp_path)
+    out = build_per_stack_prompt(
+        skill_invocation="/beagle-python:review-python",
+        stack_name="python",
+        files=["api.py"],
+        prior_commits="",
+        **p,
+    )
+    assert "Prior automated-review commits" not in out
+
+
+def test_generic_fallback_prompt_includes_prior_commits(tmp_path: Path) -> None:
+    """prior_commits block appears in generic-fallback prompt when provided."""
+    p = _paths(tmp_path)
+    commits = "abc1234 fix: handle edge case"
+    out = build_generic_fallback_prompt(
+        files=["config.yaml"],
+        prior_commits=commits,
+        **p,
+    )
+    assert "Prior automated-review commits on this branch" in out
+    assert "abc1234 fix: handle edge case" in out
+
+
+def test_generic_fallback_prompt_omits_prior_commits_when_none(tmp_path: Path) -> None:
+    """prior_commits block absent from generic-fallback when prior_commits is None."""
+    p = _paths(tmp_path)
+    out = build_generic_fallback_prompt(
+        files=["config.yaml"],
+        prior_commits=None,
+        **p,
+    )
+    assert "Prior automated-review commits" not in out
+
+
+def test_generic_fallback_prompt_omits_prior_commits_when_empty(tmp_path: Path) -> None:
+    """prior_commits block absent from generic-fallback when prior_commits is empty."""
+    p = _paths(tmp_path)
+    out = build_generic_fallback_prompt(
+        files=["config.yaml"],
+        prior_commits="",
+        **p,
+    )
+    assert "Prior automated-review commits" not in out
+
+
 def test_merge_prompt_forbids_bold_wrapper_on_numbered_head(tmp_path: Path) -> None:
     """The prompt must tell the merge agent not to bold-wrap `N. [FILE] TITLE`.
 

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -639,6 +639,37 @@ def test_gh_pr_view_omits_pr_arg_when_none(
     assert all(not part.isdigit() for part in cmd)
 
 
+# --- daydream_commits ---------------------------------------------------------
+
+
+def test_daydream_commits_returns_tagged_commits(tmp_path: Path) -> None:
+    repo = _make_repo_with_main(tmp_path)
+    _git(repo, "checkout", "-b", "feat/x")
+    (repo / "a.py").write_text("a\n")
+    _git(repo, "add", "a.py")
+    _git(repo, "commit", "-m", "fix: something\n\nDaydream-Run: test-123\nDaydream-Version: 0.14.0")
+    result = git_ops.daydream_commits(repo, "main")
+    assert result is not None
+    assert "fix: something" in result
+
+
+def test_daydream_commits_excludes_untagged(tmp_path: Path) -> None:
+    repo = _make_repo_with_main(tmp_path)
+    _git(repo, "checkout", "-b", "feat/x")
+    (repo / "b.py").write_text("b\n")
+    _git(repo, "add", "b.py")
+    _commit(repo, "chore: unrelated change")
+    result = git_ops.daydream_commits(repo, "main")
+    assert result is None
+
+
+def test_daydream_commits_none_when_no_commits(tmp_path: Path) -> None:
+    repo = _make_repo_with_main(tmp_path)
+    _git(repo, "checkout", "-b", "feat/x")
+    result = git_ops.daydream_commits(repo, "main")
+    assert result is None
+
+
 def test_gh_pr_view_includes_pr_arg_when_given(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -1,7 +1,6 @@
 # tests/test_phases.py
 """Tests for phase functions with backend abstraction."""
 
-import json
 import subprocess
 
 import pytest
@@ -767,52 +766,79 @@ def test_intent_builder_omits_issue_instructions(tmp_path):
     assert "issue" not in prompt.lower()
 
 
-@pytest.mark.asyncio
-async def test_phase_commit_push_passes_refs_not_diffs(tmp_path, monkeypatch, make_work):
-    """commit-push must be invoked with --repo / --base / --intent (refs-not-diffs).
+def test_build_review_prompt_with_prior_commits():
+    from daydream.phases import build_review_prompt
 
-    Stage 3 contract: phases pass references (paths, base SHA, intent JSON)
-    rather than embedding diffs in the prompt. The receiving skill fetches
-    the diff itself via Read/Grep/Bash. This guards against regressions where
-    a phase might silently drop the new args and revert to the bare skill
-    invocation.
-    """
+    prompt = build_review_prompt(prior_commits="abc1234 fix: something")
+    assert "settled decisions" in prompt
+    assert "abc1234 fix: something" in prompt
+
+
+def test_build_review_prompt_without_prior_commits():
+    from daydream.phases import build_review_prompt
+
+    prompt = build_review_prompt(prior_commits=None)
+    assert "settled decisions" not in prompt
+
+
+@pytest.mark.asyncio
+async def test_phase_commit_push_includes_daydream_trailers(tmp_path, monkeypatch, make_work):
+    """commit-push must include Daydream-Run and Daydream-Version trailers."""
     from daydream.phases import phase_commit_push
 
+    monkeypatch.setattr("daydream.phases.print_dim", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.phases.print_info", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.phases.print_success", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.phases.console", type("C", (), {"print": lambda *a, **kw: None})())
     monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
 
-    captured: dict[str, object] = {}
+    captured: dict[str, str] = {}
 
     class CapturingBackend:
         async def execute(self, cwd, prompt, output_schema=None, continuation=None, agents=None, max_turns=None):
+            captured["prompt"] = prompt
             yield ResultEvent(structured_output=None, continuation=None)
 
         async def cancel(self):
             pass
 
         def format_skill_invocation(self, skill_key, args=""):
-            captured["skill_key"] = skill_key
-            captured["args"] = args
             return f"/{skill_key} {args}"
 
     work = make_work(tmp_path, base_sha="ABC123", head_sha="DEF456")
     await phase_commit_push(CapturingBackend(), work)
 
-    assert captured["skill_key"] == "beagle-core:commit-push"
-    args = captured["args"]
-    assert isinstance(args, str)
-    assert f"--repo {work.repo}" in args
-    assert f"--base {work.base_sha}" in args
-    assert "--intent" in args
+    assert "Daydream-Run:" in captured["prompt"]
+    assert "Daydream-Version:" in captured["prompt"]
+    assert work.run_id in captured["prompt"]
 
-    # Intent file should land under .daydream/intents/<run_id>.json and be JSON.
-    intent_dir = work.repo / ".daydream" / "intents"
-    intents = list(intent_dir.glob("*.json"))
-    assert len(intents) == 1
-    payload = json.loads(intents[0].read_text())
-    assert payload["phase"] == "commit_push"
-    assert payload["head_sha"] == "DEF456"
-    assert payload["base_sha"] == "ABC123"
+
+@pytest.mark.asyncio
+async def test_phase_commit_iteration_includes_daydream_trailers(tmp_path, monkeypatch, make_work):
+    """phase_commit_iteration must include Daydream-Run and Daydream-Version trailers."""
+    from daydream.phases import phase_commit_iteration
+
+    monkeypatch.setattr("daydream.phases.print_info", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.phases.print_success", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.phases.console", type("C", (), {"print": lambda *a, **kw: None})())
+
+    captured: dict[str, str] = {}
+
+    class CapturingBackend:
+        async def execute(self, cwd, prompt, output_schema=None, continuation=None, agents=None, max_turns=None):
+            captured["prompt"] = prompt
+            yield ResultEvent(structured_output=None, continuation=None)
+
+        async def cancel(self):
+            pass
+
+        def format_skill_invocation(self, skill_key, args=""):
+            return f"/{skill_key} {args}"
+
+    work = make_work(tmp_path)
+    await phase_commit_iteration(CapturingBackend(), work, 2)
+
+    assert "Daydream-Run:" in captured["prompt"]
+    assert "Daydream-Version:" in captured["prompt"]
+    assert "Iteration: 2" in captured["prompt"]
+    assert "Do NOT push" in captured["prompt"]


### PR DESCRIPTION
## Summary

All daydream commits now include `Daydream-Run:` and `Daydream-Version:` git trailers. Review prompts inject prior daydream commit history as settled-decisions context, preventing the review agent from re-litigating style/structural choices made in earlier runs.

## Changes

### Added
- `daydream_commits()` in `git_ops.py` — queries commit log filtered by `Daydream-Run:` trailer
- `prior_commits` parameter on `build_review_prompt`, `build_per_stack_prompt`, and `build_generic_fallback_prompt`
- Settled-decisions context block injected into review prompts when prior daydream commits exist
- Tests for `daydream_commits()` (tagged, untagged, empty cases)
- Tests for trailer presence in commit-push and commit-iteration phases

### Changed
- Unified commit logic into `_do_commit()` with trailer injection — replaces the `beagle-core:commit-push` skill invocation with direct agent prompting
- `phase_commit_push`, `phase_commit_iteration`, and `phase_commit_push_auto` all delegate to `_do_commit()`
- Removed `_commit_push_args()` helper and `write_intent_json` import (no longer needed)

### Removed
- Intent JSON file creation for commit-push (refs-not-diffs pattern replaced by inline prompt)
- `beagle-core:commit-push` skill dependency for committing

## Motivation

When daydream runs multiple times on the same branch, the review agent would re-litigate style and structural decisions from earlier runs — burning tokens and producing noise. By tagging commits with trailers and feeding that history back as "settled decisions," subsequent runs focus on new issues only.

Closes #25

## Testing

- [x] Unit tests for `daydream_commits()` — tagged, untagged, and empty commit ranges
- [x] Unit tests for trailer injection in `phase_commit_push` and `phase_commit_iteration`
- [x] Unit tests for `build_review_prompt` with and without prior commits
- [x] Existing test suite passes

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally
- [x] Linting passes

---

Generated with [Claude Code](https://claude.com/claude-code)