### PR TITLE
refactor(trajectory): read version from __version__ instead of importlib.metadata

### DIFF
--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -28,10 +28,10 @@ from contextvars import ContextVar
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
-from importlib import metadata
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
+import daydream
 from daydream.atif import (
     Agent,
     FinalMetrics,
@@ -864,10 +864,7 @@ class TrajectoryRecorder:
     def build_trajectory(self, steps: list[Step] | None = None) -> Trajectory:
         if steps is None:
             steps = self.steps
-        try:
-            version = metadata.version("daydream")
-        except metadata.PackageNotFoundError:
-            version = "0.0.0"
+        version = daydream.__version__
 
         final_metrics = FinalMetrics(
             total_prompt_tokens=self._final_totals["prompt"] or None,


### PR DESCRIPTION
## Summary

The ATIF trajectory recorder was the only site in daydream still reading the version through `importlib.metadata.version("daydream")` with a silent `"0.0.0"` fallback on `PackageNotFoundError`. Every other version-stamping surface (`pr_comment_renderer`, `pr_review`, `phases` trailer construction) already reads `daydream.__version__` directly. This brings the trajectory recorder in line.

## Concrete improvements

1. **No silent fallback.** A broken/partial install used to record `"0.0.0"` into the trajectory's `agent.version` field. With `daydream.__version__` it would surface an `AttributeError` at the point of failure — much louder, easier to debug.
2. **No editable-install lag.** `importlib.metadata` reads from the installed package record, which only refreshes on `uv sync` / rebuild. After bumping `__version__`, trajectories used to stamp the *old* version until the next sync. Reading the module attribute is always current.

Also drops the now-unused `from importlib import metadata` import.

## Diff

- `daydream/trajectory.py:31` — drop `from importlib import metadata`
- `daydream/trajectory.py:34` — add `import daydream` in the first-party import group (matches the convention in `pr_comment_renderer.py`, `pr_review.py`, `phases.py`)
- `daydream/trajectory.py:867–870` — replace the `try / except PackageNotFoundError` block with `version = daydream.__version__`

## Test plan

- [x] `make lint` — clean
- [x] `make typecheck` — clean (52 files, no issues)
- [x] `uv run pytest tests/test_trajectory.py -v` — 45/45 pass
- [x] Full suite — 809/809 pass
- [x] Grep for `PackageNotFoundError` / `metadata.version` / `"0.0.0"` outside `tests/fixtures/atif_golden/_invalid/` — none found

---

Generated with [Claude Code](https://claude.com/claude-code)