### PR TITLE
feat(cli)!: per-phase model overrides with per-backend default table

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ daydream --trajectory /tmp/run.json /path/to/project
 | `--parse-model` | Override model for the PARSE phase (default: per-backend table; see README). | Per-backend table (see below) |
 | `--fix-model` | Override model for the FIX phase (default: per-backend table; see README). | Per-backend table (see below) |
 | `--test-model` | Override model for the TEST phase (default: per-backend table; see README). | Per-backend table (see below) |
-| `--exploration-model` | Model for exploration subagents (default: claude-sonnet-4-6). Use a smaller model to save cost. | Per-backend table (see below) |
+| `--exploration-model` | Model for exploration subagents. Use a smaller model to save cost. | Per-backend table (see below) |
 | `--comment` | Review and post inline PR comments, then exit | |
 | `--review` | Review and write a report to terminal/markdown, then exit | |
 | `--shallow` | Single-stack review (skip multi-stack auto-detection) | |

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ daydream --start-at per-stack /path/to/project
 # Mix backends per phase
 daydream --backend codex --fix-backend claude /path/to/project
 
-# Select model explicitly
-daydream --model sonnet /path/to/project
+# Override models per phase (defaults come from the per-backend table)
+daydream --review-model claude-opus-4-6 --parse-model claude-haiku-4-5 /path/to/project
 
 # Force ephemeral worktree even without --branch
 daydream --worktree /path/to/project
@@ -129,7 +129,11 @@ daydream --trajectory /tmp/run.json /path/to/project
 | `--review-backend` | Override backend for the review phase | `--backend` value |
 | `--fix-backend` | Override backend for the fix phase | `--backend` value |
 | `--test-backend` | Override backend for the test phase | `--backend` value |
-| `--model` | Model name (`opus` for Claude, `gpt-5.3-codex` for Codex) | Backend-specific |
+| `--review-model` | Override model for the REVIEW phase (default: per-backend table; see README). | Per-backend table (see below) |
+| `--parse-model` | Override model for the PARSE phase (default: per-backend table; see README). | Per-backend table (see below) |
+| `--fix-model` | Override model for the FIX phase (default: per-backend table; see README). | Per-backend table (see below) |
+| `--test-model` | Override model for the TEST phase (default: per-backend table; see README). | Per-backend table (see below) |
+| `--exploration-model` | Model for exploration subagents (default: claude-sonnet-4-6). Use a smaller model to save cost. | Per-backend table (see below) |
 | `--comment` | Review and post inline PR comments, then exit | |
 | `--review` | Review and write a report to terminal/markdown, then exit | |
 | `--shallow` | Single-stack review (skip multi-stack auto-detection) | |
@@ -150,6 +154,42 @@ daydream --trajectory /tmp/run.json /path/to/project
 
 \* `parse` and `test` are valid only with `--shallow`.
 † `ttt`, `per-stack`, `merge` are valid only in deep (default) mode.
+
+### Per-phase model defaults
+
+Each phase resolves its model in this order: explicit per-phase flag → per-backend phase default (below) → backend default. Phases without an override flag (WONDER, ENVISION, MERGE, INTENT, PR_FEEDBACK) still resolve through the per-backend table — they get phase-appropriate models without a knob.
+
+**Claude backend:**
+
+| Phase | Default model |
+|-------|---------------|
+| `parse` | `claude-haiku-4-5` |
+| `fix` | `claude-sonnet-4-6` |
+| `test` | `claude-sonnet-4-6` |
+| `exploration` | `claude-sonnet-4-6` |
+| `review` | `claude-opus-4-6` |
+| `wonder` | `claude-opus-4-6` |
+| `envision` | `claude-opus-4-6` |
+| `merge` | `claude-opus-4-6` |
+| `intent` | `claude-opus-4-6` |
+| `pr_feedback` | `claude-opus-4-6` |
+
+**Codex backend:**
+
+| Phase | Default model |
+|-------|---------------|
+| `parse` | `gpt-5.5` |
+| `fix` | `gpt-5.5` |
+| `test` | `gpt-5.5` |
+| `exploration` | `gpt-5.5` |
+| `review` | `gpt-5.5` |
+| `wonder` | `gpt-5.5` |
+| `envision` | `gpt-5.5` |
+| `merge` | `gpt-5.5` |
+| `intent` | `gpt-5.5` |
+| `pr_feedback` | `gpt-5.5` |
+
+The codex table uses `gpt-5.5` for every phase in v1; per-phase tiering for codex is deferred to a future release once concrete model picks across the codex lineup are settled.
 
 ### Subcommands
 

--- a/daydream/archive/manifest.py
+++ b/daydream/archive/manifest.py
@@ -195,7 +195,7 @@ def build_manifest(
         status=status,
         run_flow=recorder.run_flow.value,
         skill=config.skill,
-        model=config.model,
+        model=None,
         backend=config.backend,
         review_backend=config.review_backend,
         fix_backend=config.fix_backend,

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -163,6 +163,38 @@ def _add_shared_arguments(parser: argparse.ArgumentParser) -> None:
             "Use a smaller model to save cost."
         ),
     )
+    parser.add_argument(
+        "--review-model",
+        default=None,
+        type=str,
+        dest="review_model",
+        metavar="MODEL",
+        help="Override model for the REVIEW phase (default: per-backend table; see README).",
+    )
+    parser.add_argument(
+        "--parse-model",
+        default=None,
+        type=str,
+        dest="parse_model",
+        metavar="MODEL",
+        help="Override model for the PARSE phase (default: per-backend table; see README).",
+    )
+    parser.add_argument(
+        "--fix-model",
+        default=None,
+        type=str,
+        dest="fix_model",
+        metavar="MODEL",
+        help="Override model for the FIX phase (default: per-backend table; see README).",
+    )
+    parser.add_argument(
+        "--test-model",
+        default=None,
+        type=str,
+        dest="test_model",
+        metavar="MODEL",
+        help="Override model for the TEST phase (default: per-backend table; see README).",
+    )
 
 
 def _build_summarize_parser() -> argparse.ArgumentParser:
@@ -456,6 +488,10 @@ def _parse_args(argv: list[str] | None = None) -> RunConfig:
         skill=args.skill,
         model=args.model,
         exploration_model=args.exploration_model,
+        review_model=args.review_model,
+        parse_model=args.parse_model,
+        fix_model=args.fix_model,
+        test_model=args.test_model,
         cleanup=args.cleanup,
         quiet=True,
         start_at=args.start_at,
@@ -501,6 +537,10 @@ def _build_feedback_config(args: argparse.Namespace) -> RunConfig:
         skill=None,
         model=args.model,
         exploration_model=None,
+        review_model=args.review_model,
+        parse_model=args.parse_model,
+        fix_model=args.fix_model,
+        test_model=args.test_model,
         cleanup=None,
         quiet=True,
         start_at="review",

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -94,11 +94,33 @@ def _detect_repo_slug() -> str | None:
     return f"{owner}/{name}"
 
 
+_REMOVED_MODEL_FLAG_MESSAGE = (
+    "--model has been removed. Use per-phase flags: "
+    "--review-model, --parse-model, --fix-model, --test-model, --exploration-model. "
+    "See README for the per-backend default table."
+)
+
+
+def _reject_removed_model_flag(parser: argparse.ArgumentParser, argv: list[str]) -> None:
+    """Surface a curated error before argparse runs when ``--model`` is passed.
+
+    Argparse would otherwise reject ``--model`` with a generic "unrecognized
+    arguments" message that gives users no path forward. Catching both
+    ``--model X`` and ``--model=X`` shapes here points users at the new
+    per-phase flags before any parsing happens.
+    """
+    for token in argv:
+        if token == "--model" or token.startswith("--model="):
+            parser.error(_REMOVED_MODEL_FLAG_MESSAGE)
+
+
 def _add_shared_arguments(parser: argparse.ArgumentParser) -> None:
     """Add the shared (non-output-mode) arguments to a parser or subparser.
 
     Used by both the top-level parser and the ``feedback`` subparser so flags
-    like ``--backend``, ``--model``, ``--trajectory`` work in both places.
+    like ``--backend``, ``--trajectory`` work in both places. ``--model`` is
+    intentionally absent — see :func:`_reject_removed_model_flag` for the
+    curated error surfaced when a user passes the removed flag.
     """
     parser.add_argument(
         "--trajectory",
@@ -148,11 +170,6 @@ def _add_shared_arguments(parser: argparse.ArgumentParser) -> None:
         choices=["claude", "codex"],
         default=None,
         help="Override backend for test phase",
-    )
-    parser.add_argument(
-        "--model",
-        default=None,
-        help="Model to use (default: backend-specific). Examples: opus, sonnet, haiku, gpt-5.3-codex",
     )
     parser.add_argument(
         "--exploration-model",
@@ -431,6 +448,7 @@ def _parse_args(argv: list[str] | None = None) -> RunConfig:
     # front ourselves and route to a dedicated parser.
     if raw_argv and raw_argv[0] == "feedback":
         feedback_parser = _build_feedback_parser()
+        _reject_removed_model_flag(feedback_parser, raw_argv[1:])
         feedback_args = feedback_parser.parse_args(raw_argv[1:])
         return _build_feedback_config(feedback_args)
 
@@ -439,6 +457,7 @@ def _parse_args(argv: list[str] | None = None) -> RunConfig:
     # a guard for callers that hand crafted-argv to _parse_args directly.
 
     parser = _build_main_parser()
+    _reject_removed_model_flag(parser, raw_argv)
     args = parser.parse_args(raw_argv)
 
     # ----- Reject purely numeric TARGET (likely meant `daydream feedback N`) -----
@@ -486,7 +505,6 @@ def _parse_args(argv: list[str] | None = None) -> RunConfig:
     return RunConfig(
         target=args.target,
         skill=args.skill,
-        model=args.model,
         exploration_model=args.exploration_model,
         review_model=args.review_model,
         parse_model=args.parse_model,
@@ -535,7 +553,6 @@ def _build_feedback_config(args: argparse.Namespace) -> RunConfig:
     return RunConfig(
         target=args.target,
         skill=None,
-        model=args.model,
         exploration_model=None,
         review_model=args.review_model,
         parse_model=args.parse_model,

--- a/daydream/config.py
+++ b/daydream/config.py
@@ -11,6 +11,11 @@ Exports:
     UNKNOWN_SKILL_PATTERN: str - Regex pattern for detecting unknown skill errors.
     DEFAULT_CLAUDE_MODEL: str - Default Claude model id when no override is given.
     DEFAULT_CODEX_MODEL: str - Default Codex model id when no override is given.
+    DEFAULT_EXPLORATION_MODEL: str - Default model for the EXPLORE phase.
+    PHASE_DEFAULT_MODELS: dict[str, dict[str, str]] - Per-backend per-phase default
+        model mapping. Outer key is backend name ("claude" or "codex"), inner key is
+        the phase name (lowercase, e.g. "review", "parse", "fix"), value is the
+        concrete model id.
 """
 
 from enum import Enum
@@ -21,6 +26,49 @@ from enum import Enum
 DEFAULT_CLAUDE_MODEL = "claude-opus-4-6"
 DEFAULT_CODEX_MODEL = "gpt-5.3-codex"
 DEFAULT_EXPLORATION_MODEL = "claude-sonnet-4-6"
+
+# Per-backend per-phase default model table. The phase resolver in
+# ``daydream.runner._resolve_backend`` looks up
+# ``PHASE_DEFAULT_MODELS[backend_name][phase_name]`` when no explicit per-phase
+# flag is supplied. Phase names are lowercase and match the strings passed by
+# every call site (``"review"``, ``"parse"``, ``"fix"``, ``"test"``,
+# ``"exploration"``, ``"intent"``, ``"wonder"``, ``"envision"``, ``"merge"``,
+# ``"pr_feedback"``).
+#
+# Claude tiering:
+#   - cheap (haiku):   PARSE
+#   - mid   (sonnet):  FIX, TEST, EXPLORATION
+#   - heavy (opus):    REVIEW, WONDER, ENVISION, MERGE, INTENT, PR_FEEDBACK
+#
+# Codex side defaults to ``gpt-5.5`` across the board in v1; per-phase tiering
+# for codex is deferred until concrete model picks across the codex lineup are
+# settled.
+PHASE_DEFAULT_MODELS: dict[str, dict[str, str]] = {
+    "claude": {
+        "parse": "claude-haiku-4-5",
+        "fix": "claude-sonnet-4-6",
+        "test": "claude-sonnet-4-6",
+        "exploration": "claude-sonnet-4-6",
+        "review": "claude-opus-4-6",
+        "wonder": "claude-opus-4-6",
+        "envision": "claude-opus-4-6",
+        "merge": "claude-opus-4-6",
+        "intent": "claude-opus-4-6",
+        "pr_feedback": "claude-opus-4-6",
+    },
+    "codex": {
+        "parse": "gpt-5.5",
+        "fix": "gpt-5.5",
+        "test": "gpt-5.5",
+        "exploration": "gpt-5.5",
+        "review": "gpt-5.5",
+        "wonder": "gpt-5.5",
+        "envision": "gpt-5.5",
+        "merge": "gpt-5.5",
+        "intent": "gpt-5.5",
+        "pr_feedback": "gpt-5.5",
+    },
+}
 
 
 class ReviewSkillChoice(Enum):

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -254,12 +254,17 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
     """
     # Late imports to avoid circular dependency with runner.
     from daydream import git_ops
+    from daydream.backends import Backend
     from daydream.git_ops import GitError
     from daydream.phases import _git_branch, _git_log
     from daydream.runner import _compute_diff_ref, _make_archive_callback, _resolve_backend
     from daydream.ui import phase_subtitle, print_dim, print_phase_hero
 
-    backend = _resolve_backend(config, "review")
+    # Per-phase backends are resolved on demand via `_resolve_backend(config,
+    # phase, backend_cache)`. The cache reuses one Backend instance per
+    # (backend_name, resolved_model) tuple so identical phases share an
+    # instance while phases that resolve to different models stay isolated.
+    backend_cache: dict[tuple[str, str | None], Backend] = {}
 
     target_dir = work.repo
 
@@ -290,7 +295,7 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
         path=trajectory_path,
         run_flow=DaydreamRunFlow.DEEP,
         target_dir=target_dir,
-        agent_model_name=config.model or "",
+        agent_model_name="",
         session_id=session_id,
         explicit_path=config.trajectory_path is not None,
         pr_number=config.pr_number,
@@ -300,7 +305,7 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
         console.print()
         print_info(console, f"Target directory: {target_dir}")
         print_info(console, f"Branch: {branch}")
-        print_info(console, f"Model: {backend.model}")
+        print_info(console, f"Default backend: {config.backend}")
         console.print()
 
         # ------ Resume gate (D-34, D-36, D-37) ------
@@ -322,12 +327,16 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
 
         # ------ Pre-flight notice (D-30, D-31) ------
         stack_lines = [_stack_preflight_line(s) for s in stacks]
+        # Review-centric preflight: the cost_usd=None caveat fires when the
+        # review-phase backend is Codex. Other per-phase backends may differ
+        # but the notice is anchored on the review stage.
+        review_backend_for_preflight = _resolve_backend(config, "review", backend_cache)
         print_preflight_notice(
             console,
             stages=_PIPELINE_STAGE_NAMES,
             stack_lines=stack_lines,
             agent_count=total_agent_count(len(stacks)),
-            codex_in_use=isinstance(backend, CodexBackend),
+            codex_in_use=isinstance(review_backend_for_preflight, CodexBackend),
             exploration_available=EXPLORATION_AVAILABLE,
         )
 
@@ -370,7 +379,7 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
             if config.start_at not in ("per-stack", "merge", "fix"):
                 print_stage_progress(console, 1, 5, _PIPELINE_STAGE_NAMES[0])
                 intent_summary = await phase_understand_intent(
-                    backend,
+                    _resolve_backend(config, "intent", backend_cache),
                     work,
                     diff_path,
                     log,
@@ -380,7 +389,7 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
 
                 print_stage_progress(console, 2, 5, _PIPELINE_STAGE_NAMES[1])
                 alt_issues = await phase_alternative_review(
-                    backend,
+                    _resolve_backend(config, "wonder", backend_cache),
                     work,
                     diff_path,
                     intent_summary,
@@ -396,7 +405,7 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
             if config.start_at not in ("merge", "fix"):
                 print_stage_progress(console, 3, 5, _PIPELINE_STAGE_NAMES[2])
                 per_stack_outputs, failed_stacks = await phase_per_stack_reviews(
-                    backend,
+                    _resolve_backend(config, "review", backend_cache),
                     work,
                     stacks,
                     diff_path=diff_path,
@@ -476,7 +485,9 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
                     # global issue numbering reproducible across runs.
                     for stack_name, output_path in sorted(per_stack_outputs.items()):
                         records = await phase_parse_feedback(
-                            backend, work, input_path=output_path
+                            _resolve_backend(config, "parse", backend_cache),
+                            work,
+                            input_path=output_path,
                         )
                         records_path = per_stack_records_path(dd, stack_name)
                         records_path.write_text(json.dumps(records, indent=2))
@@ -503,7 +514,7 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
 
                 # Cross-stack merge (D-23..D-26).
                 await phase_cross_stack_merge(
-                    backend,
+                    _resolve_backend(config, "merge", backend_cache),
                     work,
                     per_stack_records_paths=per_stack_records_paths,
                     intent_path=intent_p,
@@ -551,20 +562,34 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
                 print_success(console, f"Report written to {merged_report}. Exiting.")
                 return 0
 
-            items = await phase_parse_feedback(backend, work)
+            items = await phase_parse_feedback(
+                _resolve_backend(config, "parse", backend_cache), work
+            )
             if not items:
                 print_success(console, "No actionable items after parse -- done.")
                 return 0
 
             for idx, item in enumerate(items, start=1):
-                await phase_fix(backend, work, item, idx, len(items))
+                await phase_fix(
+                    _resolve_backend(config, "fix", backend_cache),
+                    work,
+                    item,
+                    idx,
+                    len(items),
+                )
 
-            passed, _retries = await phase_test_and_heal(backend, work)
+            passed, _retries = await phase_test_and_heal(
+                _resolve_backend(config, "test", backend_cache), work
+            )
             if not passed:
                 print_warning(console, "Tests failed after fix attempt.")
                 return 1
 
-            await phase_commit_push(backend, work)
+            # phase_commit_push runs as part of the fix/commit cycle — reuse
+            # the fix backend (no separate "commit" phase identifier).
+            await phase_commit_push(
+                _resolve_backend(config, "fix", backend_cache), work
+            )
             return 0
 
         finally:

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -24,8 +24,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from daydream.agent import console
-from daydream.backends import create_backend
-from daydream.config import DEFAULT_EXPLORATION_MODEL, REVIEW_OUTPUT_FILE, SKILL_MAP
+from daydream.config import REVIEW_OUTPUT_FILE, SKILL_MAP
 from daydream.deep.artifacts import (
     alternatives_path as _alternatives_path,
 )
@@ -355,8 +354,7 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
                 config.exploration_context = ExplorationContext()
             else:
                 print_phase_hero(console, "EXPLORE", phase_subtitle("EXPLORE"))
-                explore_model = config.exploration_model or DEFAULT_EXPLORATION_MODEL
-                explore_backend = create_backend(config.backend, model=explore_model)
+                explore_backend = _resolve_backend(config, "exploration", backend_cache)
                 print_dim(console, f"Exploration model: {explore_backend.model}")
                 config.exploration_context = await safe_explore(
                     pre_scan,

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -1158,6 +1158,7 @@ async def phase_review(
 
     """
     print_phase_hero(console, "BREATHE", "\"Be guided by beauty\" —Jim Simons")
+    print_dim(console, f"Model: {backend.model}")
 
     # Use absolute path to prevent model hallucination of paths from training data
     review_output_path = work.repo / REVIEW_OUTPUT_FILE
@@ -1232,6 +1233,7 @@ async def phase_parse_feedback(
 
     """
     print_phase_hero(console, "REFLECT", phase_subtitle("REFLECT"))
+    print_dim(console, f"Model: {backend.model}")
 
     # Use absolute path to prevent model hallucination of paths from training data
     review_output_path = input_path if input_path is not None else work.repo / REVIEW_OUTPUT_FILE
@@ -1322,6 +1324,7 @@ async def phase_test_and_heal(
 
     """
     print_phase_hero(console, "AWAKEN", phase_subtitle("AWAKEN"))
+    print_dim(console, f"Model: {backend.model}")
 
     retries_used = 0
     continuation: ContinuationToken | None = None
@@ -1625,6 +1628,7 @@ async def phase_fetch_pr_feedback(
 
     """
     print_phase_hero(console, "LISTEN", phase_subtitle("LISTEN"))
+    print_dim(console, f"Model: {backend.model}")
 
     skill_invocation = backend.format_skill_invocation(
         "beagle-core:fetch-pr-feedback", f"--pr {pr_number} --bot {bot}"
@@ -1820,6 +1824,7 @@ async def phase_understand_intent(
 
     """
     print_phase_hero(console, "LISTEN", phase_subtitle("LISTEN"))
+    print_dim(console, f"Model: {backend.model}")
 
     prompt = build_intent_prompt(
         diff_path=str(diff_path),
@@ -1887,6 +1892,7 @@ async def phase_alternative_review(
 
     """
     print_phase_hero(console, "WONDER", phase_subtitle("WONDER"))
+    print_dim(console, f"Model: {backend.model}")
 
     prompt = build_alternative_review_prompt(
         intent_summary=intent_summary,
@@ -2005,6 +2011,7 @@ async def phase_generate_plan(
 
     """
     print_phase_hero(console, "ENVISION", phase_subtitle("ENVISION"))
+    print_dim(console, f"Model: {backend.model}")
 
     if auto_select_all:
         selected_ids: list[int] = [i["id"] for i in issues]
@@ -2233,6 +2240,7 @@ async def phase_cross_stack_merge(
         failed_stacks=failed_stacks,
     )
     print_phase_hero(console, "MERGE", phase_subtitle("MERGE"))
+    print_dim(console, f"Model: {backend.model}")
     await run_agent(backend, work.repo, prompt, phase=DaydreamPhase.DEEP)
 
     # Copy from deep artifact dir to canonical location. The agent writes

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -854,6 +854,7 @@ async def _run_loop_shallow(work: WorkContext, config: RunConfig) -> int:
 
             # Phase 3: Fix
             print_phase_hero(console, "HEAL", phase_subtitle("HEAL"))
+            print_dim(console, f"Model: {fix_backend.model}")
             fixes_count = 0
             for i, item in enumerate(items, 1):
                 await phase_fix(fix_backend, work, item, i, len(items))
@@ -975,6 +976,7 @@ async def _run_loop_shallow(work: WorkContext, config: RunConfig) -> int:
             if config.start_at in ("review", "parse", "fix"):
                 if feedback_items:
                     print_phase_hero(console, "HEAL", phase_subtitle("HEAL"))
+                    print_dim(console, f"Model: {fix_backend.model}")
                     for i, item in enumerate(feedback_items, 1):
                         await phase_fix(fix_backend, work, item, i, len(feedback_items))
                         fixes_applied += 1

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -32,7 +32,6 @@ from daydream.agent import (
 )
 from daydream.backends import Backend, create_backend
 from daydream.config import (
-    DEFAULT_EXPLORATION_MODEL,
     PHASE_DEFAULT_MODELS,
     REVIEW_OUTPUT_FILE,
     REVIEW_SKILLS,
@@ -458,6 +457,7 @@ async def _run_pr_feedback(work: WorkContext, config: RunConfig) -> int:
 
     backend_cache: dict[tuple[str, str | None], Backend] = {}
     review_backend = _resolve_backend(config, "review", backend_cache)
+    parse_backend = _resolve_backend(config, "parse", backend_cache)
     fix_backend = _resolve_backend(config, "fix", backend_cache)
 
     session_id = str(uuid.uuid4())
@@ -485,7 +485,7 @@ async def _run_pr_feedback(work: WorkContext, config: RunConfig) -> int:
 
         # Phase 2: Parse feedback (reused from normal flow)
         try:
-            feedback_items = await phase_parse_feedback(review_backend, work)
+            feedback_items = await phase_parse_feedback(parse_backend, work)
         except ValueError:
             print_error(console, "Parse Failed", "Failed to parse PR feedback. Exiting.")
             return 1
@@ -588,7 +588,8 @@ async def _run_review_or_comment(
     two modes is whether the alternative-review issues are posted to the PR
     via :func:`daydream.pr_review.post_review_to_pr_from_alt_issues`.
     """
-    backend = _resolve_backend(config, "review")
+    backend_cache: dict[tuple[str, str | None], Backend] = {}
+    backend = _resolve_backend(config, "review", backend_cache)
     target_dir = work.repo
 
     # Gather git context using the resolved base branch from work (no
@@ -642,8 +643,7 @@ async def _run_review_or_comment(
                 config.exploration_context = ExplorationContext()
             else:
                 print_phase_hero(console, "EXPLORE", phase_subtitle("EXPLORE"))
-                explore_model = config.exploration_model or DEFAULT_EXPLORATION_MODEL
-                explore_backend = create_backend(config.backend, model=explore_model)
+                explore_backend = _resolve_backend(config, "exploration", backend_cache)
                 print_dim(console, f"Exploration model: {explore_backend.model}")
                 config.exploration_context = await safe_explore(
                     pre_scan,
@@ -768,6 +768,7 @@ async def _run_loop_shallow(work: WorkContext, config: RunConfig) -> int:
     # Backends (per-phase overrides).
     backend_cache: dict[tuple[str, str | None], Backend] = {}
     review_backend = _resolve_backend(config, "review", backend_cache)
+    parse_backend = _resolve_backend(config, "parse", backend_cache)
     fix_backend = _resolve_backend(config, "fix", backend_cache)
     test_backend = _resolve_backend(config, "test", backend_cache)
 
@@ -804,8 +805,7 @@ async def _run_loop_shallow(work: WorkContext, config: RunConfig) -> int:
                 config.exploration_context = ExplorationContext()
             else:
                 print_phase_hero(console, "EXPLORE", phase_subtitle("EXPLORE"))
-                explore_model = config.exploration_model or DEFAULT_EXPLORATION_MODEL
-                explore_backend = create_backend(config.backend, model=explore_model)
+                explore_backend = _resolve_backend(config, "exploration", backend_cache)
                 print_dim(console, f"Exploration model: {explore_backend.model}")
                 config.exploration_context = await safe_explore(
                     pre_scan,
@@ -846,7 +846,7 @@ async def _run_loop_shallow(work: WorkContext, config: RunConfig) -> int:
             )
 
             # Phase 2: Parse feedback
-            items = await phase_parse_feedback(review_backend, work)
+            items = await phase_parse_feedback(parse_backend, work)
 
             if not items:
                 print_info(console, f"Clean review on iteration {iteration}")
@@ -966,7 +966,7 @@ async def _run_loop_shallow(work: WorkContext, config: RunConfig) -> int:
             # Phase 2: Parse feedback
             if config.start_at in ("review", "parse", "fix"):
                 try:
-                    feedback_items = await phase_parse_feedback(review_backend, work)
+                    feedback_items = await phase_parse_feedback(parse_backend, work)
                 except ValueError as exc:
                     print_error(console, "Phase 2 Error", str(exc))
                     print_error(console, "Parse Failed", "Failed to parse feedback. Exiting.")

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -31,7 +31,14 @@ from daydream.agent import (
     set_quiet_mode,
 )
 from daydream.backends import Backend, create_backend
-from daydream.config import DEFAULT_EXPLORATION_MODEL, REVIEW_OUTPUT_FILE, REVIEW_SKILLS, SKILL_MAP, ReviewSkillChoice
+from daydream.config import (
+    DEFAULT_EXPLORATION_MODEL,
+    PHASE_DEFAULT_MODELS,
+    REVIEW_OUTPUT_FILE,
+    REVIEW_SKILLS,
+    SKILL_MAP,
+    ReviewSkillChoice,
+)
 from daydream.exploration import ExplorationContext, safe_explore
 from daydream.exploration_runner import count_changed_files, pre_scan, select_tier
 from daydream.git_ops import GitError
@@ -100,6 +107,15 @@ class RunConfig:
         review_backend: Override backend for the review phase. If None, uses backend.
         fix_backend: Override backend for the fix phase. If None, uses backend.
         test_backend: Override backend for the test phase. If None, uses backend.
+        review_model: Model override for the review phase. When None, the
+            resolver falls back to ``PHASE_DEFAULT_MODELS[backend_name]["review"]``
+            and then to the backend's own default.
+        parse_model: Model override for the parse phase. When None, resolves via
+            ``PHASE_DEFAULT_MODELS[backend_name]["parse"]`` then backend default.
+        fix_model: Model override for the fix phase. When None, resolves via
+            ``PHASE_DEFAULT_MODELS[backend_name]["fix"]`` then backend default.
+        test_model: Model override for the test phase. When None, resolves via
+            ``PHASE_DEFAULT_MODELS[backend_name]["test"]`` then backend default.
         loop: Enable continuous review/fix/test iterations. Default is False.
         max_iterations: Maximum number of loop iterations before exiting. Default is 5.
         exploration_model: Model override for exploration subagents. When set, a separate
@@ -137,6 +153,10 @@ class RunConfig:
     review_backend: str | None = None
     fix_backend: str | None = None
     test_backend: str | None = None
+    review_model: str | None = None
+    parse_model: str | None = None
+    fix_model: str | None = None
+    test_model: str | None = None
     loop: bool = False
     max_iterations: int = 5
     exploration_context: ExplorationContext | None = None
@@ -202,29 +222,50 @@ def _make_archive_callback(
 
 
 def _resolve_backend(
-    config: RunConfig, phase: str, cache: dict[str, Backend] | None = None
+    config: RunConfig,
+    phase: str,
+    cache: dict[tuple[str, str | None], Backend] | None = None,
 ) -> Backend:
     """Get or create the backend for a given phase, respecting per-phase overrides.
 
+    Resolution order for the model:
+        1. ``getattr(config, f"{phase}_model", None)`` — explicit per-phase flag.
+        2. ``PHASE_DEFAULT_MODELS[backend_name].get(phase)`` — per-backend phase
+           default table.
+        3. ``None`` — let :func:`create_backend` apply its own backend default.
+
+    The backend kind is resolved first via
+    ``getattr(config, f"{phase}_backend", None) or config.backend``; the model
+    lookup then keys into that backend name's table.
+
     Args:
-        config: Run configuration with backend settings.
-        phase: Phase name ("review", "fix", or "test").
-        cache: Optional dict to cache backends by name. When provided, backends
-               are reused if the same backend name is requested multiple times.
+        config: Run configuration with backend and per-phase model settings.
+        phase: Phase name (e.g. ``"review"``, ``"parse"``, ``"fix"``, ``"test"``,
+            ``"intent"``, ``"wonder"``, ``"envision"``, ``"merge"``,
+            ``"exploration"``, ``"pr_feedback"``).
+        cache: Optional dict to cache backends by ``(backend_name, model)``.
+            When provided, backends are reused only when both the backend kind
+            and the resolved model match — so the same backend kind with two
+            different models yields two distinct instances.
 
     Returns:
         Backend instance for the phase.
 
     """
-    override = getattr(config, f"{phase}_backend", None)
-    backend_name = override or config.backend
+    backend_override = getattr(config, f"{phase}_backend", None)
+    backend_name = backend_override or config.backend
 
+    phase_flag = getattr(config, f"{phase}_model", None)
+    table_default = PHASE_DEFAULT_MODELS.get(backend_name, {}).get(phase)
+    resolved_model = phase_flag or table_default  # ``None`` falls through to backend default
+
+    cache_key = (backend_name, resolved_model)
     if cache is not None:
-        if backend_name not in cache:
-            cache[backend_name] = create_backend(backend_name, model=config.model)
-        return cache[backend_name]
+        if cache_key not in cache:
+            cache[cache_key] = create_backend(backend_name, model=resolved_model)
+        return cache[cache_key]
 
-    return create_backend(backend_name, model=config.model)
+    return create_backend(backend_name, model=resolved_model)
 
 
 def _compute_diff_ref(cwd: Path) -> str:
@@ -418,7 +459,7 @@ async def _run_pr_feedback(work: WorkContext, config: RunConfig) -> int:
     bot = config.bot
     target_dir = work.repo
 
-    backend_cache: dict[str, Backend] = {}
+    backend_cache: dict[tuple[str, str | None], Backend] = {}
     review_backend = _resolve_backend(config, "review", backend_cache)
     fix_backend = _resolve_backend(config, "fix", backend_cache)
 
@@ -728,7 +769,7 @@ async def _run_loop_shallow(work: WorkContext, config: RunConfig) -> int:
         cleanup_enabled = cleanup_response.lower() in ("y", "yes")
 
     # Backends (per-phase overrides).
-    backend_cache: dict[str, Backend] = {}
+    backend_cache: dict[tuple[str, str | None], Backend] = {}
     review_backend = _resolve_backend(config, "review", backend_cache)
     fix_backend = _resolve_backend(config, "fix", backend_cache)
     test_backend = _resolve_backend(config, "test", backend_cache)

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -95,8 +95,6 @@ class RunConfig:
         target: Target directory path for the review. If None, prompts user.
         skill: Review skill to use ("python", "react", "elixir", "go", "rust",
             or "ios"). If None and shallow, prompts user.
-        model: CLI override for the model id. ``None`` means "use the
-            per-backend default from :mod:`daydream.config`".
         cleanup: Remove review output file after completion. If None, prompts user.
         quiet: Suppress verbose output from the agent.
         start_at: Phase to start at ("review", "parse", "fix", "test", "ttt",
@@ -143,7 +141,6 @@ class RunConfig:
 
     target: str | None = None
     skill: str | None = None  # "python", "react", "elixir", "go", "rust", "ios"
-    model: str | None = None
     cleanup: bool | None = None
     quiet: bool = True
     start_at: str = "review"
@@ -469,7 +466,7 @@ async def _run_pr_feedback(work: WorkContext, config: RunConfig) -> int:
         path=trajectory_path,
         run_flow=DaydreamRunFlow.PR,
         target_dir=target_dir,
-        agent_model_name=config.model or "",
+        agent_model_name="",
         session_id=session_id,
         explicit_path=config.trajectory_path is not None,
         pr_number=config.pr_number,
@@ -623,7 +620,7 @@ async def _run_review_or_comment(
         path=trajectory_path,
         run_flow=flow,
         target_dir=target_dir,
-        agent_model_name=config.model or "",
+        agent_model_name="",
         session_id=session_id,
         explicit_path=config.trajectory_path is not None,
         pr_number=config.pr_number,
@@ -780,7 +777,7 @@ async def _run_loop_shallow(work: WorkContext, config: RunConfig) -> int:
         path=trajectory_path,
         run_flow=DaydreamRunFlow.NORMAL,
         target_dir=target_dir,
-        agent_model_name=config.model or "",
+        agent_model_name="",
         session_id=session_id,
         explicit_path=config.trajectory_path is not None,
         pr_number=config.pr_number,

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -44,7 +44,6 @@ class _MockRecorder:
 @dataclass
 class _MockConfig:
     skill: str | None = "python"
-    model: str | None = "opus"
     backend: str = "claude"
     review_backend: str | None = None
     fix_backend: str | None = None
@@ -134,7 +133,9 @@ def test_build_manifest_basic(tmp_path: Path):
     assert m.session_id == recorder.session_id
     assert m.run_flow == "normal"
     assert m.skill == "python"
-    assert m.model == "opus"
+    # Manifest.model is no longer populated from config (per-phase models replaced
+    # the single config.model field); build_manifest stamps it as None.
+    assert m.model is None
     assert m.backend == "claude"
     assert m.total_cost_usd == 0.05
     assert m.total_prompt_tokens == 100

--- a/tests/test_archive_integration.py
+++ b/tests/test_archive_integration.py
@@ -118,7 +118,6 @@ async def test_full_archive_round_trip(tmp_path: Path, monkeypatch: pytest.Monke
     config = RunConfig(
         target=str(target_dir),
         skill="python",
-        model="opus",
         backend="claude",
         archive=True,
         run_eval=False,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ import pytest
 
 from daydream.cli import _parse_args
 from daydream.config import SKILL_MAP
+from daydream.runner import RunConfig
 
 
 def test_default_backend_is_claude(monkeypatch):
@@ -26,18 +27,6 @@ def test_backend_short_flag(monkeypatch):
     monkeypatch.setattr(sys, "argv", ["daydream", "/tmp/project", "-b", "codex"])
     config = _parse_args()
     assert config.backend == "codex"
-
-
-def test_model_default_is_none(monkeypatch):
-    monkeypatch.setattr(sys, "argv", ["daydream", "/tmp/project"])
-    config = _parse_args()
-    assert config.model is None
-
-
-def test_model_explicit(monkeypatch):
-    monkeypatch.setattr(sys, "argv", ["daydream", "/tmp/project", "--model", "sonnet"])
-    config = _parse_args()
-    assert config.model == "sonnet"
 
 
 def test_invalid_backend_rejected(monkeypatch):
@@ -328,3 +317,28 @@ def test_no_per_phase_model_flag_leaves_field_none(tmp_path):
 def test_existing_exploration_model_flag_unchanged(tmp_path):
     config = _parse_args(["--exploration-model", "claude-haiku-4-5", str(tmp_path)])
     assert config.exploration_model == "claude-haiku-4-5"
+
+
+# ---------------------------------------------------------------------------
+# Removed --model flag (Task 5 of per-phase-model-overrides — breaking change)
+# ---------------------------------------------------------------------------
+
+
+def test_removed_model_flag_emits_curated_error(capsys, tmp_path):
+    with pytest.raises(SystemExit) as exc_info:
+        _parse_args(["--model", "claude-opus-4-6", str(tmp_path)])
+    assert exc_info.value.code != 0
+    err = capsys.readouterr().err
+    assert "--model has been removed" in err
+    assert "--review-model" in err
+    assert "--parse-model" in err
+    assert "--fix-model" in err
+    assert "--test-model" in err
+    assert "--exploration-model" in err
+
+
+def test_runconfig_has_no_model_field():
+    config = RunConfig(backend="claude")
+    assert not hasattr(config, "model"), (
+        "RunConfig.model was supposed to be removed in favor of per-phase fields"
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -296,3 +296,35 @@ def test_print_issues_table_renders():
     output = test_console.file.getvalue()
     assert "Bad pattern" in output
     assert "Missing test" in output
+
+
+# ---------------------------------------------------------------------------
+# Per-phase model override flags (Task 3 of per-phase-model-overrides)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "flag,attr,value",
+    [
+        ("--review-model", "review_model", "claude-haiku-4-5"),
+        ("--parse-model", "parse_model", "claude-haiku-4-5"),
+        ("--fix-model", "fix_model", "claude-opus-4-6"),
+        ("--test-model", "test_model", "gpt-5.5"),
+    ],
+)
+def test_per_phase_model_flags_set_runconfig_field(flag, attr, value, tmp_path):
+    config = _parse_args([flag, value, str(tmp_path)])
+    assert getattr(config, attr) == value
+
+
+def test_no_per_phase_model_flag_leaves_field_none(tmp_path):
+    config = _parse_args([str(tmp_path)])
+    assert config.review_model is None
+    assert config.parse_model is None
+    assert config.fix_model is None
+    assert config.test_model is None
+
+
+def test_existing_exploration_model_flag_unchanged(tmp_path):
+    config = _parse_args(["--exploration-model", "claude-haiku-4-5", str(tmp_path)])
+    assert config.exploration_model == "claude-haiku-4-5"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,56 @@
+"""Tests for daydream.config module."""
+
+from daydream.config import (
+    DEFAULT_CLAUDE_MODEL,
+    DEFAULT_CODEX_MODEL,
+    DEFAULT_EXPLORATION_MODEL,
+    PHASE_DEFAULT_MODELS,
+)
+
+PHASE_NAMES = {
+    "review", "parse", "fix", "test", "exploration",
+    "intent", "wonder", "envision", "merge", "pr_feedback",
+}
+
+
+def test_phase_default_models_covers_both_backends():
+    assert set(PHASE_DEFAULT_MODELS.keys()) == {"claude", "codex"}
+
+
+def test_phase_default_models_covers_every_phase_for_each_backend():
+    for backend_name in ("claude", "codex"):
+        assert set(PHASE_DEFAULT_MODELS[backend_name].keys()) == PHASE_NAMES, (
+            f"{backend_name} default table missing phase entries"
+        )
+
+
+def test_phase_default_models_claude_tier_assignments():
+    claude = PHASE_DEFAULT_MODELS["claude"]
+    # PARSE is the cheap tier
+    assert claude["parse"] == "claude-haiku-4-5"
+    # Expensive tier: REVIEW, WONDER, ENVISION, MERGE, INTENT, PR_FEEDBACK
+    for phase in ("review", "wonder", "envision", "merge", "intent", "pr_feedback"):
+        assert claude[phase] == "claude-opus-4-6"
+    # Mid tier: FIX, TEST, EXPLORATION
+    for phase in ("fix", "test", "exploration"):
+        assert claude[phase] == "claude-sonnet-4-6"
+
+
+def test_phase_default_models_codex_uses_gpt_5_5_for_every_phase():
+    codex = PHASE_DEFAULT_MODELS["codex"]
+    for phase in PHASE_NAMES:
+        assert codex[phase] == "gpt-5.5", (
+            f"codex phase {phase} should default to gpt-5.5 in v1"
+        )
+
+
+def test_default_exploration_model_matches_claude_phase_default():
+    # EXPLORE precedent: DEFAULT_EXPLORATION_MODEL is the fallback when no flag
+    # is set and table lookup misses; keep it consistent with the table for Claude.
+    assert DEFAULT_EXPLORATION_MODEL == PHASE_DEFAULT_MODELS["claude"]["exploration"]
+
+
+def test_default_constants_still_exported():
+    # Sanity: existing default constants remain importable for backend creation fallbacks.
+    assert isinstance(DEFAULT_CLAUDE_MODEL, str)
+    assert isinstance(DEFAULT_CODEX_MODEL, str)

--- a/tests/test_deep_merge.py
+++ b/tests/test_deep_merge.py
@@ -78,6 +78,8 @@ def test_merge_prompt_mentions_dedup_candidates(tmp_path: Path) -> None:
 class _RecordingBackend:
     """Records every execute call; verifies no `agents` kwarg was passed."""
 
+    model = "test-model"
+
     def __init__(self) -> None:
         self.agents_seen: list[Any] = []
         self.prompts: list[str] = []

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -956,3 +956,68 @@ async def test_resume_fix_skips_pr_post(
     assert post_calls == [], (
         f"post_review_to_pr_from_report should be skipped on --start-at fix, got {len(post_calls)} call(s)"
     )
+
+
+async def test_resolve_backend_called_with_each_phase_in_deep_flow(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The deep orchestrator must call _resolve_backend with each spec phase,
+    not just 'review'. This is a wiring test, not a model-value test.
+
+    Drives a full deep flow (TTT -> per-stack -> parse -> merge -> fix gate
+    accepted -> fix-loop -> test -> commit) with the stub backend, and asserts
+    every expected phase string appears in the captured call list.
+    """
+    from daydream import runner as _runner
+
+    seen_phases: list[str] = []
+    original = _runner._resolve_backend
+
+    def spy(config, phase, cache=None):
+        seen_phases.append(phase)
+        return original(config, phase, cache)
+
+    # The deep orchestrator does `from daydream.runner import _resolve_backend`
+    # inside run_deep, so patching daydream.runner._resolve_backend intercepts
+    # every call site once the orchestrator is wired to per-phase resolution.
+    monkeypatch.setattr("daydream.runner._resolve_backend", spy)
+
+    # Silence interactive UI but accept the fix gate so fix/test/commit run.
+    monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.deep.orchestrator.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
+
+    _install_stub_backend(monkeypatch, multi_stack_target)
+
+    # Suppress the PR post side effect.
+    async def _no_post(target_dir: Path, report_path: Path, *, console: Any) -> None:
+        return None
+
+    monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _no_post)
+
+    # Stub the fix, test_and_heal, and commit_push phases so they don't try to
+    # mutate the workspace / run tests, but still trigger their resolver call.
+    async def _stub_fix(backend, work, item, idx, total):  # noqa: ARG001
+        return None
+
+    async def _stub_test(backend, work):  # noqa: ARG001
+        return (True, 0)
+
+    async def _stub_commit(backend, work):  # noqa: ARG001
+        return None
+
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_fix", _stub_fix)
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_test_and_heal", _stub_test)
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _stub_commit)
+
+    exit_code = await _run_deep(multi_stack_target)
+    assert exit_code == 0
+
+    expected_phases = {"intent", "wonder", "review", "parse", "merge", "fix", "test"}
+    captured = set(seen_phases)
+    missing = expected_phases - captured
+    assert not missing, (
+        f"Deep orchestrator missing per-phase resolver calls for {missing}; "
+        f"got {sorted(captured)}"
+    )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -827,6 +827,8 @@ async def test_exploration_enriched_output_both_flows(tmp_path, make_work):
     }
 
     class _MB:
+        model = "test-model"
+
         def __init__(self, payload):
             self.payload = payload
 

--- a/tests/test_phase_parse_input_path.py
+++ b/tests/test_phase_parse_input_path.py
@@ -10,6 +10,8 @@ from daydream.phases import phase_parse_feedback
 
 
 class _SpyBackend:
+    model = "test-model"
+
     def __init__(self) -> None:
         self.last_prompt: str = ""
 

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -33,6 +33,8 @@ async def test_phase_test_and_heal_fix_uses_fresh_context(tmp_path, monkeypatch,
     captured_continuations: list[ContinuationToken | None] = []
 
     class FreshContextBackend:
+        model = "test-model"
+
         async def execute(self, cwd, prompt, output_schema=None, continuation=None, agents=None, max_turns=None):
             nonlocal call_count
             call_count += 1
@@ -103,6 +105,8 @@ async def test_phase_parse_feedback_empty_response_returns_empty_list(tmp_path, 
     class EmptyResponseBackend:
         """Simulates a schema miss: no structured output, no text."""
 
+        model = "test-model"
+
         async def execute(self, cwd, prompt, output_schema=None, continuation=None, agents=None, max_turns=None):
             # Only yield a result with no structured output (schema miss)
             yield ResultEvent(structured_output=None, continuation=None)
@@ -131,6 +135,8 @@ async def test_phase_parse_feedback_json_fallback(tmp_path, monkeypatch, make_wo
 
     class JsonTextBackend:
         """Simulates a schema miss where the model outputs JSON as plain text."""
+
+        model = "test-model"
 
         async def execute(self, cwd, prompt, output_schema=None, continuation=None, agents=None, max_turns=None):
             yield TextEvent(text='{"issues": [{"id": 1, "description": "Bug", "file": "foo.py", "line": 10}]}')
@@ -352,6 +358,8 @@ async def test_phase_understand_intent_confirmed_first_try(tmp_path, monkeypatch
     monkeypatch.setattr("daydream.phases.console", type("C", (), {"print": lambda *a, **kw: None})())
 
     class IntentBackend:
+        model = "test-model"
+
         async def execute(self, cwd, prompt, output_schema=None, continuation=None, agents=None, max_turns=None):
             yield TextEvent(text="This PR adds a login page with email/password authentication.")
             yield ResultEvent(structured_output=None, continuation=None)
@@ -390,6 +398,8 @@ async def test_phase_understand_intent_correction_then_confirm(tmp_path, monkeyp
     call_count = 0
 
     class IntentBackend:
+        model = "test-model"
+
         async def execute(self, cwd, prompt, output_schema=None, continuation=None, agents=None, max_turns=None):
             nonlocal call_count
             call_count += 1
@@ -494,6 +504,8 @@ async def test_phase_alternative_review_returns_issues(tmp_path, monkeypatch, ma
     }
 
     class ReviewBackend:
+        model = "test-model"
+
         async def execute(self, cwd, prompt, output_schema=None, continuation=None, agents=None, max_turns=None):
             yield TextEvent(text="Found 2 issues.")
             yield ResultEvent(structured_output=structured_issues, continuation=None)
@@ -529,6 +541,8 @@ async def test_phase_alternative_review_no_issues(tmp_path, monkeypatch, make_wo
     monkeypatch.setattr("daydream.phases.console", type("C", (), {"print": lambda *a, **kw: None})())
 
     class NoIssuesBackend:
+        model = "test-model"
+
         async def execute(self, cwd, prompt, output_schema=None, continuation=None, agents=None, max_turns=None):
             yield TextEvent(text="Implementation looks good.")
             yield ResultEvent(structured_output={"issues": []}, continuation=None)
@@ -577,6 +591,8 @@ async def test_phase_generate_plan_writes_markdown(tmp_path, monkeypatch, make_w
     }
 
     class PlanBackend:
+        model = "test-model"
+
         async def execute(self, cwd, prompt, output_schema=None, continuation=None, agents=None, max_turns=None):
             yield TextEvent(text="Here's the plan.")
             yield ResultEvent(structured_output=structured_plan, continuation=None)
@@ -628,6 +644,8 @@ async def test_phase_generate_plan_skip_on_none(tmp_path, monkeypatch, make_work
     monkeypatch.setattr("daydream.phases.console", type("C", (), {"print": lambda *a, **kw: None})())
 
     class NeverCalledBackend:
+        model = "test-model"
+
         async def execute(self, cwd, prompt, output_schema=None, continuation=None, agents=None, max_turns=None):
             raise AssertionError("Should not be called when user selects 'none'")
             yield  # make it an async generator
@@ -866,6 +884,11 @@ def _silence_phase_io(monkeypatch) -> None:
 
 class _ScriptedBackend:
     """Base mock backend with shared init, cancel, and format_skill_invocation."""
+
+    # Surface a model so phases can render ``Model: <name>`` dim lines after
+    # their heros (Task 6). Tests don't assert this value — they just need the
+    # attribute to exist on the duck-typed Backend.
+    model = "test-model"
 
     def __init__(self, script: list) -> None:
         self.script = list(script)
@@ -1818,3 +1841,331 @@ async def test_option4_calls_write_partial_before_summarizer(
     # write_partial must be called exactly once on the abort path so the
     # trajectory data is on disk while the handoff is being displayed.
     assert fake.partial_writes == 1
+
+
+# ============================================================================
+# Task 6: every phase hero is followed by a dim ``Model: <name>`` line.
+# ============================================================================
+#
+# Each test installs spies on ``print_phase_hero`` and ``print_dim`` so call
+# order can be asserted without parsing styled Rich output. The phase functions
+# stub or reuse the same ``Backend`` test doubles as the surrounding tests in
+# this module — no new fixtures are introduced.
+
+
+def _install_hero_dim_spies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[list[tuple[str, str]], list[str]]:
+    """Capture every ``print_phase_hero`` and ``print_dim`` call.
+
+    Returns (heroes, dim_messages) where ``heroes`` is a list of
+    ``(title, description)`` tuples and ``dim_messages`` is a list of dim
+    message strings, both ordered by call order.
+    """
+    heroes: list[tuple[str, str]] = []
+    dim_messages: list[str] = []
+
+    def _hero_spy(_console, title, description):
+        heroes.append((title, description))
+
+    def _dim_spy(_console, message):
+        dim_messages.append(message)
+
+    monkeypatch.setattr("daydream.phases.print_phase_hero", _hero_spy)
+    monkeypatch.setattr("daydream.phases.print_dim", _dim_spy)
+    return heroes, dim_messages
+
+
+@pytest.mark.asyncio
+async def test_phase_review_prints_model_line_after_hero(
+    tmp_path, monkeypatch, make_work
+):
+    from daydream.phases import phase_review
+
+    monkeypatch.setattr("daydream.phases.print_info", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.phases.console", type("C", (), {"print": lambda *a, **kw: None})())
+    heroes, dim_messages = _install_hero_dim_spies(monkeypatch)
+
+    class _Backend:
+        model = "claude-opus-4-6"
+
+        async def execute(self, cwd, prompt, output_schema=None, continuation=None, agents=None, max_turns=None):
+            yield ResultEvent(structured_output=None, continuation=None)
+
+        async def cancel(self):
+            pass
+
+        def format_skill_invocation(self, skill_key, args=""):
+            return f"/{skill_key}"
+
+    await phase_review(_Backend(), make_work(tmp_path), skill="beagle-python:review-python")
+
+    assert any(title == "BREATHE" for title, _ in heroes)
+    assert "Model: claude-opus-4-6" in dim_messages
+
+
+@pytest.mark.asyncio
+async def test_phase_parse_feedback_prints_model_line_after_hero(
+    tmp_path, monkeypatch, make_work
+):
+    from daydream.phases import phase_parse_feedback
+
+    monkeypatch.setattr("daydream.phases.print_info", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.phases.print_warning", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.phases.console", type("C", (), {"print": lambda *a, **kw: None})())
+    heroes, dim_messages = _install_hero_dim_spies(monkeypatch)
+
+    (tmp_path / REVIEW_OUTPUT_FILE).write_text("## Verdict\n\nReady: Yes\n")
+
+    class _Backend:
+        model = "claude-haiku-4-5"
+
+        async def execute(self, cwd, prompt, output_schema=None, continuation=None, agents=None, max_turns=None):
+            yield ResultEvent(structured_output={"issues": []}, continuation=None)
+
+        async def cancel(self):
+            pass
+
+        def format_skill_invocation(self, skill_key, args=""):
+            return f"/{skill_key}"
+
+    await phase_parse_feedback(_Backend(), make_work(tmp_path))
+
+    assert any(title == "REFLECT" for title, _ in heroes)
+    assert "Model: claude-haiku-4-5" in dim_messages
+
+
+@pytest.mark.asyncio
+async def test_phase_test_and_heal_prints_model_line_after_hero(
+    tmp_path, monkeypatch, make_work
+):
+    from daydream.phases import phase_test_and_heal
+
+    monkeypatch.setattr("daydream.phases.print_info", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.phases.print_success", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.phases.print_warning", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.phases.print_menu", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.phases.print_error", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.phases.console", type("C", (), {"print": lambda *a, **kw: None})())
+    heroes, dim_messages = _install_hero_dim_spies(monkeypatch)
+
+    class _Backend:
+        model = "claude-sonnet-4-6"
+
+        async def execute(self, cwd, prompt, output_schema=None, continuation=None, agents=None, max_turns=None):
+            yield TextEvent(text="All tests passed")
+            yield ResultEvent(structured_output=None, continuation=None)
+
+        async def cancel(self):
+            pass
+
+        def format_skill_invocation(self, skill_key, args=""):
+            return f"/{skill_key}"
+
+    await phase_test_and_heal(_Backend(), make_work(tmp_path))
+
+    assert any(title == "AWAKEN" for title, _ in heroes)
+    assert "Model: claude-sonnet-4-6" in dim_messages
+
+
+@pytest.mark.asyncio
+async def test_phase_fetch_pr_feedback_prints_model_line_after_hero(
+    tmp_path, monkeypatch, make_work
+):
+    from daydream.phases import phase_fetch_pr_feedback
+
+    monkeypatch.setattr("daydream.phases.print_info", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.phases.print_success", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.phases.print_warning", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.phases.console", type("C", (), {"print": lambda *a, **kw: None})())
+    heroes, dim_messages = _install_hero_dim_spies(monkeypatch)
+
+    class _Backend:
+        model = "claude-opus-4-6"
+
+        async def execute(self, cwd, prompt, output_schema=None, continuation=None, agents=None, max_turns=None):
+            yield ResultEvent(structured_output=None, continuation=None)
+
+        async def cancel(self):
+            pass
+
+        def format_skill_invocation(self, skill_key, args=""):
+            return f"/{skill_key}"
+
+    await phase_fetch_pr_feedback(_Backend(), make_work(tmp_path), pr_number=42, bot="botname")
+
+    assert any(title == "LISTEN" for title, _ in heroes)
+    assert "Model: claude-opus-4-6" in dim_messages
+
+
+@pytest.mark.asyncio
+async def test_phase_understand_intent_prints_model_line_after_hero(
+    tmp_path, monkeypatch, make_work
+):
+    from daydream.phases import phase_understand_intent
+
+    monkeypatch.setattr("daydream.phases.print_info", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.phases.console", type("C", (), {"print": lambda *a, **kw: None})())
+    heroes, dim_messages = _install_hero_dim_spies(monkeypatch)
+
+    class _Backend:
+        model = "claude-opus-4-6"
+
+        async def execute(self, cwd, prompt, output_schema=None, continuation=None, agents=None, max_turns=None):
+            yield TextEvent(text="This PR adds a login page.")
+            yield ResultEvent(structured_output=None, continuation=None)
+
+        async def cancel(self):
+            pass
+
+        def format_skill_invocation(self, skill_key, args=""):
+            return f"/{skill_key}"
+
+    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
+
+    diff_file = tmp_path / "diff.patch"
+    diff_file.write_text("diff --git ...")
+
+    await phase_understand_intent(
+        _Backend(), make_work(tmp_path),
+        diff_path=diff_file,
+        log="abc1234 add login",
+        branch="feat/login",
+    )
+
+    assert any(title == "LISTEN" for title, _ in heroes)
+    assert "Model: claude-opus-4-6" in dim_messages
+
+
+@pytest.mark.asyncio
+async def test_phase_alternative_review_prints_model_line_after_hero(
+    tmp_path, monkeypatch, make_work
+):
+    from daydream.phases import phase_alternative_review
+
+    monkeypatch.setattr("daydream.phases.print_info", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.phases.print_issues_table", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.phases.console", type("C", (), {"print": lambda *a, **kw: None})())
+    heroes, dim_messages = _install_hero_dim_spies(monkeypatch)
+
+    class _Backend:
+        model = "claude-opus-4-6"
+
+        async def execute(self, cwd, prompt, output_schema=None, continuation=None, agents=None, max_turns=None):
+            yield ResultEvent(structured_output={"issues": []}, continuation=None)
+
+        async def cancel(self):
+            pass
+
+        def format_skill_invocation(self, skill_key, args=""):
+            return f"/{skill_key}"
+
+    diff_file = tmp_path / "diff.patch"
+    diff_file.write_text("diff ...")
+
+    await phase_alternative_review(
+        _Backend(), make_work(tmp_path),
+        diff_path=diff_file,
+        intent_summary="Adds a login page.",
+    )
+
+    assert any(title == "WONDER" for title, _ in heroes)
+    assert "Model: claude-opus-4-6" in dim_messages
+
+
+@pytest.mark.asyncio
+async def test_phase_generate_plan_prints_model_line_after_hero(
+    tmp_path, monkeypatch, make_work
+):
+    from daydream.phases import phase_generate_plan
+
+    monkeypatch.setattr("daydream.phases.print_info", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.phases.print_success", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.phases.console", type("C", (), {"print": lambda *a, **kw: None})())
+    heroes, dim_messages = _install_hero_dim_spies(monkeypatch)
+
+    structured_plan = {
+        "plan": {
+            "summary": "Refactor auth",
+            "issues": [
+                {
+                    "id": 1,
+                    "title": "Use DI",
+                    "changes": [
+                        {"file": "src/service.py", "description": "Extract iface", "action": "modify"},
+                    ],
+                },
+            ],
+        }
+    }
+
+    class _Backend:
+        model = "claude-opus-4-6"
+
+        async def execute(self, cwd, prompt, output_schema=None, continuation=None, agents=None, max_turns=None):
+            yield ResultEvent(structured_output=structured_plan, continuation=None)
+
+        async def cancel(self):
+            pass
+
+        def format_skill_invocation(self, skill_key, args=""):
+            return f"/{skill_key}"
+
+    issues = [
+        {"id": 1, "title": "Use DI", "description": "Hard-coded deps",
+         "recommendation": "Inject", "severity": "high", "files": ["src/service.py"]},
+    ]
+
+    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "1")
+
+    diff_file = tmp_path / "diff.patch"
+    diff_file.write_text("diff ...")
+
+    await phase_generate_plan(
+        _Backend(), make_work(tmp_path),
+        diff_path=diff_file,
+        intent_summary="Adds auth",
+        issues=issues,
+    )
+
+    assert any(title == "ENVISION" for title, _ in heroes)
+    assert "Model: claude-opus-4-6" in dim_messages
+
+
+@pytest.mark.asyncio
+async def test_phase_cross_stack_merge_prints_model_line_after_hero(
+    tmp_path, monkeypatch, make_work
+):
+    from daydream.phases import phase_cross_stack_merge
+
+    monkeypatch.setattr("daydream.phases.print_info", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.phases.console", type("C", (), {"print": lambda *a, **kw: None})())
+    heroes, dim_messages = _install_hero_dim_spies(monkeypatch)
+
+    class _Backend:
+        model = "claude-opus-4-6"
+
+        async def execute(self, cwd, prompt, output_schema=None, continuation=None, agents=None, max_turns=None):
+            # phase_cross_stack_merge expects the merge agent to have written
+            # the deep artifact before the copy step runs.
+            deep_out = cwd / ".daydream" / "deep" / "review-output.md"
+            deep_out.parent.mkdir(parents=True, exist_ok=True)
+            deep_out.write_text("merged")
+            yield ResultEvent(structured_output=None, continuation=None)
+
+        async def cancel(self):
+            pass
+
+        def format_skill_invocation(self, skill_key, args=""):
+            return f"/{skill_key}"
+
+    await phase_cross_stack_merge(
+        _Backend(), make_work(tmp_path),
+        per_stack_records_paths=[tmp_path / "r.json"],
+        intent_path=tmp_path / "i.md",
+        alternatives_path=tmp_path / "a.json",
+        dedup_candidates_path=tmp_path / "d.json",
+    )
+
+    assert any(title == "MERGE" for title, _ in heroes)
+    assert "Model: claude-opus-4-6" in dim_messages

--- a/tests/test_pr_comment_integration.py
+++ b/tests/test_pr_comment_integration.py
@@ -168,14 +168,15 @@ def patch_sdk(monkeypatch: pytest.MonkeyPatch):
 
 
 def _make_recorder(tmp_path: Path) -> TrajectoryRecorder:
-    """Mirror runner.py: ``agent_model_name`` defaults to the BACKEND alias."""
+    """Mirror runner.py: ``agent_model_name`` is stamped per-step, not at recorder init."""
     return TrajectoryRecorder(
         path=tmp_path / ".daydream" / "trajectory.json",
         run_flow=DaydreamRunFlow.TTT,
         target_dir=tmp_path,
-        # Production runner does ``config.model or config.backend or "claude"``.
-        # When --model isn't set, the recorder gets the backend NAME — which
-        # is exactly the value Bug A leaves in every Step.model_name.
+        # Production runner now passes ``agent_model_name=""`` — the single
+        # config.model field was removed in favor of per-phase model fields.
+        # The recorder gets the backend alias only as a fallback for legacy
+        # callers; daydream stamps the resolved model on each Step explicitly.
         agent_model_name="claude",
         session_id="test",
     )

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -366,6 +366,7 @@ async def test_run_loop_shallow_heal_hero_followed_by_model_line(
 
     backends_by_phase = {
         "review": _StubBackend("review-model-xyz"),
+        "parse": _StubBackend("parse-model-xyz"),
         "fix": _StubBackend("fix-model-xyz"),
         "test": _StubBackend("test-model-xyz"),
     }

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -287,3 +287,52 @@ async def test_pr_feedback_banner_echoes_resolved_backend_model(
     assert f"Model: {chosen_model}" in captured, (
         f"Banner did not echo backend.model; got {captured!r}"
     )
+
+
+# --- Per-phase model resolution tests (Task 2) -----------------------------
+
+
+class TestResolveBackendPhaseModel:
+    def test_explicit_phase_flag_wins_over_table(self):
+        config = RunConfig(backend="claude", review_model="claude-haiku-4-5")
+        backend = runner._resolve_backend(config, "review")
+        assert backend.model == "claude-haiku-4-5"
+
+    def test_table_default_used_when_no_flag(self):
+        config = RunConfig(backend="claude")  # no review_model override
+        backend = runner._resolve_backend(config, "review")
+        assert backend.model == "claude-opus-4-6"  # claude REVIEW default
+
+    def test_table_default_for_phase_without_flag(self):
+        # WONDER has no override flag but should still get the table default.
+        config = RunConfig(backend="claude")
+        backend = runner._resolve_backend(config, "wonder")
+        assert backend.model == "claude-opus-4-6"
+
+    def test_codex_table_default(self):
+        config = RunConfig(backend="codex")
+        backend = runner._resolve_backend(config, "parse")
+        assert backend.model == "gpt-5.5"
+
+    def test_backend_override_uses_overridden_backends_table(self):
+        # --review-backend codex while default is claude: resolver should look up
+        # the codex table for review, not the claude one.
+        config = RunConfig(backend="claude", review_backend="codex")
+        backend = runner._resolve_backend(config, "review")
+        assert backend.model == "gpt-5.5"  # codex REVIEW default (v1)
+
+    def test_cache_returns_same_instance_for_same_phase_and_backend(self):
+        cache: dict = {}
+        config = RunConfig(backend="claude")
+        b1 = runner._resolve_backend(config, "review", cache)
+        b2 = runner._resolve_backend(config, "review", cache)
+        assert b1 is b2
+
+    def test_cache_returns_distinct_instances_for_different_phases(self):
+        # Different models -> different backends, even on the same backend kind.
+        cache: dict = {}
+        config = RunConfig(backend="claude")
+        review_backend = runner._resolve_backend(config, "review", cache)
+        parse_backend = runner._resolve_backend(config, "parse", cache)
+        assert review_backend is not parse_backend
+        assert review_backend.model != parse_backend.model

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -335,3 +335,105 @@ class TestResolveBackendPhaseModel:
         parse_backend = runner._resolve_backend(config, "parse", cache)
         assert review_backend is not parse_backend
         assert review_backend.model != parse_backend.model
+
+
+# --- Task 6: HEAL hero is followed by Model: dim line ----------------------
+
+
+@pytest.mark.asyncio
+async def test_run_loop_shallow_heal_hero_followed_by_model_line(
+    monkeypatch, tmp_path
+):
+    """The HEAL phase hero in ``_run_loop_shallow`` must be followed by a dim
+    ``Model: <name>`` line scoped to the fix backend.
+
+    Drives single-pass shallow loop with ``start_at="fix"`` to skip review,
+    exploration, and skill resolution. Only the fix and test phases run, and
+    HEAL renders before phase_fix. Asserts hero + dim call ordering.
+    """
+    from daydream.config import REVIEW_OUTPUT_FILE
+
+    # Pre-create the review file so the check_review_file_exists guard passes.
+    (tmp_path / REVIEW_OUTPUT_FILE).write_text("## Issues\n\n1. foo.py:1 - Bug\n")
+
+    work = _fake_work(tmp_path)
+
+    # Stub backends to carry distinct phase-specific models so the dim line's
+    # source is unambiguous.
+    class _StubBackend:
+        def __init__(self, model: str):
+            self.model = model
+
+    backends_by_phase = {
+        "review": _StubBackend("review-model-xyz"),
+        "fix": _StubBackend("fix-model-xyz"),
+        "test": _StubBackend("test-model-xyz"),
+    }
+
+    monkeypatch.setattr(
+        "daydream.runner._resolve_backend",
+        lambda _config, phase, _cache=None: backends_by_phase[phase],
+    )
+
+    async def _stub_phase_parse_feedback(_backend, _work):
+        return [{"id": 1, "description": "Bug", "file": "foo.py", "line": 1}]
+
+    async def _stub_phase_fix(*_args, **_kwargs):
+        return None
+
+    async def _stub_phase_test_and_heal(*_args, **_kwargs):
+        return (True, 0)
+
+    async def _stub_phase_commit_push(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr("daydream.runner.phase_parse_feedback", _stub_phase_parse_feedback)
+    monkeypatch.setattr("daydream.runner.phase_fix", _stub_phase_fix)
+    monkeypatch.setattr("daydream.runner.phase_test_and_heal", _stub_phase_test_and_heal)
+    monkeypatch.setattr("daydream.runner.phase_commit_push", _stub_phase_commit_push)
+
+    # Capture hero + dim calls in order.
+    calls: list[tuple[str, str]] = []  # (kind, payload)
+
+    def _hero_spy(_console, title, _description):
+        calls.append(("hero", title))
+
+    def _dim_spy(_console, message):
+        calls.append(("dim", message))
+
+    monkeypatch.setattr("daydream.runner.print_phase_hero", _hero_spy)
+    monkeypatch.setattr("daydream.runner.print_dim", _dim_spy)
+
+    # Silence misc UI noise.
+    monkeypatch.setattr("daydream.runner.print_info", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.runner.print_warning", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.runner.print_error", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.runner.print_summary", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.runner.print_skipped_phases", lambda *a, **kw: None)
+
+    config = RunConfig(
+        target=str(tmp_path),
+        start_at="fix",
+        cleanup=False,
+        loop=False,
+        shallow=True,
+    )
+
+    exit_code = await runner._run_loop_shallow(work, config)
+    assert exit_code == 0
+
+    # Find the HEAL hero in call order.
+    heal_idx = next(
+        (i for i, (kind, payload) in enumerate(calls) if kind == "hero" and payload == "HEAL"),
+        None,
+    )
+    assert heal_idx is not None, f"HEAL hero never rendered; calls={calls!r}"
+    # The very next call must be a dim Model: line carrying the fix backend's id.
+    assert heal_idx + 1 < len(calls), "HEAL hero has no following call"
+    next_kind, next_payload = calls[heal_idx + 1]
+    assert next_kind == "dim", (
+        f"Call after HEAL hero was not a dim line; got {(next_kind, next_payload)!r}"
+    )
+    assert next_payload == "Model: fix-model-xyz", (
+        f"Dim line after HEAL hero did not echo the fix backend's model; got {next_payload!r}"
+    )

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -279,7 +279,6 @@ async def test_pr_feedback_banner_echoes_resolved_backend_model(
         target=str(tmp_path),
         pr_number=42,
         bot="botname",
-        model=None,
     )
 
     exit_code = await runner._run_pr_feedback(work, config)


### PR DESCRIPTION
## Summary

Replaces the single `--model` flag with per-phase model overrides (`--review-model`, `--parse-model`, `--fix-model`, `--test-model`, plus the existing `--exploration-model`). Each phase resolves its model in this order: explicit per-phase flag → per-backend phase default → backend default, so phases without an override knob (WONDER, ENVISION, MERGE, INTENT, PR_FEEDBACK) still get phase-appropriate models out of the box.

## Changes

### Added
- `PHASE_DEFAULT_MODELS` table in `daydream/config.py` mapping backend → phase → model id
- `--review-model`, `--parse-model`, `--fix-model`, `--test-model` CLI flags
- `_resolve_backend(config, phase)` now consults the per-phase table when no explicit flag is set
- Deep orchestrator resolves per-phase backends for intent / wonder / review / parse / merge / fix / test
- UI prints a dim `Model: <name>` line after every phase hero
- README section documenting the per-backend default table and resolution order
- Tests across `test_cli.py`, `test_config.py`, `test_phases.py`, `test_runner.py`, `test_deep_orchestrator.py` covering the new flags and resolution path

### Removed
- `--model` CLI flag (see Breaking Changes)

## Motivation

Different phases benefit from different model tiers — PARSE is mechanical and runs fine on haiku, FIX/TEST/EXPLORATION want sonnet, and REVIEW/WONDER/ENVISION/MERGE/INTENT/PR_FEEDBACK want opus. A single `--model` knob forced the whole pipeline onto one tier; the new per-phase resolver lets callers tune cost vs. quality per phase without inventing a knob for every phase.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests updated
- [x] Pre-push lint + typecheck + full suite

## Breaking Changes

`--model` is removed. Users who passed `--model <name>` should switch to the per-phase flag they actually wanted — `--review-model`, `--parse-model`, `--fix-model`, `--test-model`, or `--exploration-model`. A curated CLI error directs users at the new flags if they pass `--model` (both `--model X` and `--model=X` shapes are caught before argparse runs).

Per-backend defaults are documented in the README's *Per-phase model defaults* section.

---

Generated with [Claude Code](https://claude.com/claude-code)