### PR TITLE
fix(explore): remove .coderabbit.yaml from pattern-scanner prompts

### DIFF
--- a/daydream/prompts/exploration_subagents.py
+++ b/daydream/prompts/exploration_subagents.py
@@ -3,7 +3,7 @@
 Three specialist subagents power pre-scan exploration:
 
 - **pattern-scanner**: detects codebase conventions and reads guideline files
-  (CLAUDE.md, .coderabbit.yaml, ruff.toml, etc.) -- satisfies EXPL-04.
+  (CLAUDE.md, ruff.toml, etc.) -- satisfies EXPL-04.
 - **dependency-tracer**: extends the static-resolved import graph by grepping
   call sites and emits Dependency edges.
 - **test-mapper**: locates test files for each modified source file via
@@ -130,7 +130,6 @@ recommend changes that contradict existing patterns.
 
 Instructions:
 - Read CLAUDE.md at the repo root if it exists.
-- Read .coderabbit.yaml at the repo root if it exists.
 - Read any other house-style config files you find (ruff.toml, .editorconfig, tsconfig.json, go.mod, Cargo.toml).
 - Infer conventions from the code itself where config files are silent.
 
@@ -186,7 +185,6 @@ and read guideline files relevant to the changes below.
 
 Instructions:
 - Read CLAUDE.md at the repo root if it exists.
-- Read .coderabbit.yaml at the repo root if it exists.
 - Read any other house-style config files you find (ruff.toml, .editorconfig, tsconfig.json, go.mod, Cargo.toml).
 - Infer conventions from the code itself where config files are silent.
 
@@ -278,7 +276,7 @@ work file-by-file so your context stays small.
 
 EXPLORATION_AGENTS: dict[str, AgentDefinition] = {
     "pattern-scanner": AgentDefinition(
-        description="Detects codebase conventions and reads guideline files (CLAUDE.md, .coderabbit.yaml, etc).",
+        description="Detects codebase conventions and reads guideline files (CLAUDE.md, ruff.toml, etc).",
         prompt=PATTERN_SCANNER_SYSTEM_PROMPT,
         tools=["Bash", "Read", "Glob", "Grep"],
         model="inherit",

--- a/tests/test_exploration_runner.py
+++ b/tests/test_exploration_runner.py
@@ -37,11 +37,9 @@ FIXTURES = Path(__file__).parent / "fixtures" / "diffs"
 
 def test_pattern_scanner_prompt_includes_guideline_files():
     assert "CLAUDE.md" in PATTERN_SCANNER_SYSTEM_PROMPT
-    assert ".coderabbit.yaml" in PATTERN_SCANNER_SYSTEM_PROMPT
 
     dynamic = build_pattern_scanner_prompt(["daydream/foo.py"], "main...HEAD")
     assert "CLAUDE.md" in dynamic
-    assert ".coderabbit.yaml" in dynamic
     assert "main...HEAD" in dynamic
     assert "daydream/foo.py" in dynamic
     # Regression guard: raw diff text must never be embedded.


### PR DESCRIPTION
## Summary
- The explore phase pattern-scanner was hardcoded to look for `.coderabbit.yaml` in every repo it scanned, causing unnecessary file reads for a CodeRabbit-specific config that has nothing to do with daydream's convention detection.
- Removed all `.coderabbit.yaml` references from the system prompt, dynamic prompt builder, agent definition description, and module docstring in `daydream/prompts/exploration_subagents.py`.
- Updated test assertions in `tests/test_exploration_runner.py` that were checking for the removed references.

## Test plan
- [x] `make lint` passes
- [x] `make typecheck` passes
- [x] All 12 `test_exploration_runner.py` tests pass
- [x] 1 pre-existing test failure (`test_parse_args_feedback_subcommand_with_target`) unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)