### PR TITLE
fix(tests): isolate DAYDREAM_ARCHIVE_DIR to stop polluting ~/.daydream/archive

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -249,3 +249,11 @@ def _reset_trajectory_recorder():
     _reset_recorder_for_tests()
     yield
     _reset_recorder_for_tests()
+
+
+@pytest.fixture(autouse=True)
+def archive_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Isolate DAYDREAM_ARCHIVE_DIR to a per-test tmpdir so tests never touch ~/.daydream/archive/."""
+    path = tmp_path / "archive"
+    monkeypatch.setenv("DAYDREAM_ARCHIVE_DIR", str(path))
+    yield path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -252,8 +252,9 @@ def _reset_trajectory_recorder():
 
 
 @pytest.fixture(autouse=True)
-def archive_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+def archive_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Isolate DAYDREAM_ARCHIVE_DIR to a per-test tmpdir so tests never touch ~/.daydream/archive/."""
     path = tmp_path / "archive"
+    path.mkdir(parents=True, exist_ok=True)
     monkeypatch.setenv("DAYDREAM_ARCHIVE_DIR", str(path))
     yield path

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -409,7 +409,6 @@ def test_archive_dir_fixture_isolates_env(archive_dir: Path, tmp_path: Path):
     """Verify the autouse archive_dir fixture's contract: env points at tmp_path/archive."""
     assert os.environ.get("DAYDREAM_ARCHIVE_DIR") == str(archive_dir)
     assert archive_dir == tmp_path / "archive"
-    assert str(archive_dir).startswith(str(tmp_path))
 
 
 # ---------------------------------------------------------------------------
@@ -566,8 +565,6 @@ def test_copy_bundle_skips_missing(tmp_path: Path):
 
 
 def test_archive_run_round_trip(tmp_path: Path, archive_dir: Path):
-    archive_root = archive_dir
-
     session_id = "abcd1234-0000-0000-0000-000000000000"
     config = _MockConfig()
 
@@ -576,7 +573,7 @@ def test_archive_run_round_trip(tmp_path: Path, archive_dir: Path):
 
     archive_run(recorder=recorder, target_dir=target, config=config, status="complete")
 
-    run_dir = archive_root / "runs" / session_id
+    run_dir = archive_dir / "runs" / session_id
     assert run_dir.is_dir()
     assert (run_dir / "manifest.json").is_file()
     assert (run_dir / "trajectory.json").is_file()
@@ -586,7 +583,7 @@ def test_archive_run_round_trip(tmp_path: Path, archive_dir: Path):
     assert manifest_data["run"]["flow"] == "normal"
     assert manifest_data["run"]["skill"] == "python"
 
-    rows = query_runs(archive_root)
+    rows = query_runs(archive_dir)
     assert len(rows) == 1
     assert rows[0]["session_id"] == session_id
 

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -407,7 +407,7 @@ def test_get_archive_dir_default(monkeypatch, tmp_path: Path):
 
 def test_archive_dir_fixture_isolates_env(archive_dir: Path, tmp_path: Path):
     """Verify the autouse archive_dir fixture's contract: env points at tmp_path/archive."""
-    assert os.environ.get("DAYDREAM_ARCHIVE_DIR") == str(archive_dir)
+    assert get_archive_dir() == archive_dir
     assert archive_dir == tmp_path / "archive"
 
 

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -5,6 +5,7 @@ Covers git_context, manifest, index, and the top-level archive_run flow.
 """
 
 import json
+import os
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -404,6 +405,13 @@ def test_get_archive_dir_default(monkeypatch, tmp_path: Path):
     assert expected.is_dir()
 
 
+def test_archive_dir_fixture_isolates_env(archive_dir: Path, tmp_path: Path):
+    """Verify the autouse archive_dir fixture's contract: env points at tmp_path/archive."""
+    assert os.environ.get("DAYDREAM_ARCHIVE_DIR") == str(archive_dir)
+    assert archive_dir == tmp_path / "archive"
+    assert str(archive_dir).startswith(str(tmp_path))
+
+
 # ---------------------------------------------------------------------------
 # __init__: _copy_bundle
 # ---------------------------------------------------------------------------
@@ -557,9 +565,8 @@ def test_copy_bundle_skips_missing(tmp_path: Path):
 # ---------------------------------------------------------------------------
 
 
-def test_archive_run_round_trip(monkeypatch, tmp_path: Path):
-    archive_root = tmp_path / "archive"
-    monkeypatch.setenv("DAYDREAM_ARCHIVE_DIR", str(archive_root))
+def test_archive_run_round_trip(tmp_path: Path, archive_dir: Path):
+    archive_root = archive_dir
 
     session_id = "abcd1234-0000-0000-0000-000000000000"
     config = _MockConfig()

--- a/tests/test_archive_integration.py
+++ b/tests/test_archive_integration.py
@@ -101,12 +101,9 @@ async def test_on_write_does_not_fire_on_empty_trajectory(tmp_path: Path) -> Non
 # ---------------------------------------------------------------------------
 
 
-async def test_full_archive_round_trip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_full_archive_round_trip(tmp_path: Path, archive_dir: Path) -> None:
     """_make_archive_callback wires archive_run through on_write, producing manifest + SQLite row."""
     from daydream.runner import RunConfig, _make_archive_callback
-
-    archive_dir = tmp_path / "archive"
-    monkeypatch.setenv("DAYDREAM_ARCHIVE_DIR", str(archive_dir))
 
     # Set up a minimal .daydream/ structure the archive copier expects
     target_dir = tmp_path / "project"

--- a/tests/test_training_export.py
+++ b/tests/test_training_export.py
@@ -135,12 +135,11 @@ def test_export_emit_schema_only_writes_schema_no_records(tmp_path: Path) -> Non
 # ---------------------------------------------------------------------------
 
 
-def test_cli_export_jsonl_end_to_end(tmp_path: Path, monkeypatch: Any) -> None:
+def test_cli_export_jsonl_end_to_end(tmp_path: Path, archive_dir: Path) -> None:
     """Handler exits 0, writes JSONL + schema.json, every line parses."""
     from daydream.cli import _handle_export_command
 
-    build_fixture_archive(tmp_path)
-    monkeypatch.setenv("DAYDREAM_ARCHIVE_DIR", str(tmp_path))
+    build_fixture_archive(archive_dir)
 
     out_path = tmp_path / "out.jsonl"
     rc = _handle_export_command(["--out", str(out_path)])
@@ -154,12 +153,11 @@ def test_cli_export_jsonl_end_to_end(tmp_path: Path, monkeypatch: Any) -> None:
         json.loads(line)  # raises on malformed JSON
 
 
-def test_cli_export_jsonl_dry_run_via_handler(tmp_path: Path, monkeypatch: Any) -> None:
+def test_cli_export_jsonl_dry_run_via_handler(tmp_path: Path, archive_dir: Path) -> None:
     """``--dry-run`` returns 0 but writes no JSONL file."""
     from daydream.cli import _handle_export_command
 
-    build_fixture_archive(tmp_path)
-    monkeypatch.setenv("DAYDREAM_ARCHIVE_DIR", str(tmp_path))
+    build_fixture_archive(archive_dir)
 
     out_path = tmp_path / "out.jsonl"
     rc = _handle_export_command(["--out", str(out_path), "--dry-run"])

--- a/tests/test_training_labeler.py
+++ b/tests/test_training_labeler.py
@@ -18,9 +18,7 @@ from daydream.archive.manifest import Manifest
 from daydream.training.labeler import LabelerConfig, run_label
 
 
-async def test_labeler_writes_accepted_for_merged_pr_clean_comments(tmp_path: Path, monkeypatch) -> None:
-    archive_dir = tmp_path / "archive"
-    archive_dir.mkdir(exist_ok=True)
+async def test_labeler_writes_accepted_for_merged_pr_clean_comments(tmp_path: Path, monkeypatch, archive_dir: Path) -> None:
     upsert_run(archive_dir, Manifest(
         session_id="00000000-0000-0000-0000-000000000099",
         archived_at="2026-01-01T00:00:00Z", run_flow="normal", backend="claude",
@@ -52,10 +50,8 @@ async def test_labeler_writes_accepted_for_merged_pr_clean_comments(tmp_path: Pa
     assert summary["labeled"] == 1
 
 
-async def test_labeler_uses_local_branch_signal_for_no_pr_run(tmp_path: Path, monkeypatch) -> None:
+async def test_labeler_uses_local_branch_signal_for_no_pr_run(tmp_path: Path, monkeypatch, archive_dir: Path) -> None:
     """No pr_repo/pr_number → labeler uses local_commit_applied_signal."""
-    archive_dir = tmp_path / "archive"
-    archive_dir.mkdir(exist_ok=True)
     archive_path = tmp_path / "run-no-pr"
     archive_path.mkdir()
     (archive_path / "diff.patch").write_text("+ new_line\n")  # minimal valid patch
@@ -82,9 +78,7 @@ async def test_labeler_uses_local_branch_signal_for_no_pr_run(tmp_path: Path, mo
     assert rub["posterior_source"] == "local_branch"
 
 
-async def test_labeler_dry_run_does_not_write(tmp_path: Path, monkeypatch) -> None:
-    archive_dir = tmp_path / "archive"
-    archive_dir.mkdir(exist_ok=True)
+async def test_labeler_dry_run_does_not_write(tmp_path: Path, monkeypatch, archive_dir: Path) -> None:
     upsert_run(archive_dir, Manifest(
         session_id="00000000-0000-0000-0000-000000000098",
         archived_at="2026-01-01T00:00:00Z", run_flow="normal", backend="claude",
@@ -108,10 +102,8 @@ async def test_labeler_dry_run_does_not_write(tmp_path: Path, monkeypatch) -> No
     assert summary["labeled"] == 0
 
 
-async def test_labeler_per_row_exception_does_not_derail_run(tmp_path: Path, monkeypatch) -> None:
+async def test_labeler_per_row_exception_does_not_derail_run(tmp_path: Path, monkeypatch, archive_dir: Path) -> None:
     """One bad row counts in errors; subsequent rows still process."""
-    archive_dir = tmp_path / "archive"
-    archive_dir.mkdir(exist_ok=True)
     for i, sess in enumerate(["s-bad", "s-good"]):
         upsert_run(archive_dir, Manifest(
             session_id=sess, archived_at="2026-01-01T00:00:00Z",

--- a/tests/test_training_labeler.py
+++ b/tests/test_training_labeler.py
@@ -20,7 +20,7 @@ from daydream.training.labeler import LabelerConfig, run_label
 
 async def test_labeler_writes_accepted_for_merged_pr_clean_comments(tmp_path: Path, monkeypatch) -> None:
     archive_dir = tmp_path / "archive"
-    archive_dir.mkdir()
+    archive_dir.mkdir(exist_ok=True)
     upsert_run(archive_dir, Manifest(
         session_id="00000000-0000-0000-0000-000000000099",
         archived_at="2026-01-01T00:00:00Z", run_flow="normal", backend="claude",
@@ -55,7 +55,7 @@ async def test_labeler_writes_accepted_for_merged_pr_clean_comments(tmp_path: Pa
 async def test_labeler_uses_local_branch_signal_for_no_pr_run(tmp_path: Path, monkeypatch) -> None:
     """No pr_repo/pr_number → labeler uses local_commit_applied_signal."""
     archive_dir = tmp_path / "archive"
-    archive_dir.mkdir()
+    archive_dir.mkdir(exist_ok=True)
     archive_path = tmp_path / "run-no-pr"
     archive_path.mkdir()
     (archive_path / "diff.patch").write_text("+ new_line\n")  # minimal valid patch
@@ -84,7 +84,7 @@ async def test_labeler_uses_local_branch_signal_for_no_pr_run(tmp_path: Path, mo
 
 async def test_labeler_dry_run_does_not_write(tmp_path: Path, monkeypatch) -> None:
     archive_dir = tmp_path / "archive"
-    archive_dir.mkdir()
+    archive_dir.mkdir(exist_ok=True)
     upsert_run(archive_dir, Manifest(
         session_id="00000000-0000-0000-0000-000000000098",
         archived_at="2026-01-01T00:00:00Z", run_flow="normal", backend="claude",
@@ -111,7 +111,7 @@ async def test_labeler_dry_run_does_not_write(tmp_path: Path, monkeypatch) -> No
 async def test_labeler_per_row_exception_does_not_derail_run(tmp_path: Path, monkeypatch) -> None:
     """One bad row counts in errors; subsequent rows still process."""
     archive_dir = tmp_path / "archive"
-    archive_dir.mkdir()
+    archive_dir.mkdir(exist_ok=True)
     for i, sess in enumerate(["s-bad", "s-good"]):
         upsert_run(archive_dir, Manifest(
             session_id=sess, archived_at="2026-01-01T00:00:00Z",

--- a/tests/test_training_snapshot.py
+++ b/tests/test_training_snapshot.py
@@ -12,7 +12,7 @@ from daydream.training.snapshot import SnapshotConfig, run_snapshot
 
 def test_snapshot_writes_corpus_snapshot_json(tmp_path: Path) -> None:
     archive_dir = tmp_path / "archive"
-    archive_dir.mkdir()
+    archive_dir.mkdir(exist_ok=True)
     upsert_run(
         archive_dir,
         Manifest(
@@ -47,7 +47,7 @@ def test_snapshot_writes_corpus_snapshot_json(tmp_path: Path) -> None:
 
 def test_snapshot_label_counts_aggregate_by_class(tmp_path: Path) -> None:
     archive_dir = tmp_path / "archive"
-    archive_dir.mkdir()
+    archive_dir.mkdir(exist_ok=True)
     for idx, label in enumerate(["accepted", "accepted", "rejected", "contested", None]):
         sess = f"s-{idx}"
         upsert_run(

--- a/tests/test_training_snapshot.py
+++ b/tests/test_training_snapshot.py
@@ -10,9 +10,7 @@ from daydream.archive.manifest import Manifest
 from daydream.training.snapshot import SnapshotConfig, run_snapshot
 
 
-def test_snapshot_writes_corpus_snapshot_json(tmp_path: Path) -> None:
-    archive_dir = tmp_path / "archive"
-    archive_dir.mkdir(exist_ok=True)
+def test_snapshot_writes_corpus_snapshot_json(tmp_path: Path, archive_dir: Path) -> None:
     upsert_run(
         archive_dir,
         Manifest(
@@ -45,9 +43,7 @@ def test_snapshot_writes_corpus_snapshot_json(tmp_path: Path) -> None:
     assert summary["total_runs"] == 1
 
 
-def test_snapshot_label_counts_aggregate_by_class(tmp_path: Path) -> None:
-    archive_dir = tmp_path / "archive"
-    archive_dir.mkdir(exist_ok=True)
+def test_snapshot_label_counts_aggregate_by_class(tmp_path: Path, archive_dir: Path) -> None:
     for idx, label in enumerate(["accepted", "accepted", "rejected", "contested", None]):
         sess = f"s-{idx}"
         upsert_run(


### PR DESCRIPTION
## Summary

Adds an autouse `archive_dir` fixture in `tests/conftest.py` that redirects `DAYDREAM_ARCHIVE_DIR` to a per-test tmpdir, so the test suite no longer writes synthetic runs into the developer's real `~/.daydream/archive/`. Existing tests that previously declared the same isolation locally are migrated to consume the fixture.

## Changes

### Added
- `tests/conftest.py::archive_dir` — autouse fixture that pre-creates `tmp_path/archive` and points `DAYDREAM_ARCHIVE_DIR` at it for every test
- `test_archive_dir_fixture_isolates_env` — contract check asserting `get_archive_dir()` matches the fixture path

### Changed
- `test_archive_run_round_trip`, `test_full_archive_round_trip`, `test_cli_export_jsonl_*`, `test_snapshot_*`, `test_labeler_*` — drop redundant `monkeypatch.setenv("DAYDREAM_ARCHIVE_DIR", ...)` + manual `archive_dir.mkdir()` boilerplate in favor of the fixture
- Manual `archive_dir.mkdir()` calls switched to `exist_ok=True` to coexist with the autouse pre-creation

## Motivation

Per #99: with `RunConfig.archive` defaulting to `True` and `get_archive_dir()` falling back to `~/.daydream/archive`, every integration test that went through `run(config)` without explicit opt-out wrote a real run directory and indexed a synthetic row into the developer's production SQLite archive (~8,794 polluted runs / ~652MB observed locally). One source of truth for the per-test archive path eliminates the foot-gun for every current and future test.

## Testing

- [x] Full suite passes locally (`uv run pytest -v`)
- [x] Pre-push hook (lint + typecheck + tests) green on each commit
- [x] Contract test verifies the fixture's effect on `get_archive_dir()`

## Related Issues

- Closes #99

---

Generated with [Claude Code](https://claude.com/claude-code)