### PR TITLE
feat(deep): add language-agnostic structural review meta-stack (#98)

### DIFF
--- a/daydream/config.py
+++ b/daydream/config.py
@@ -16,6 +16,11 @@ Exports:
         model mapping. Outer key is backend name ("claude" or "codex"), inner key is
         the phase name (lowercase, e.g. "review", "parse", "fix"), value is the
         concrete model id.
+    STRUCTURE_SKILL: str - Beagle skill name for the structural-maintainability
+        meta-stack reviewer. Invoked internally by deep mode; not user-selectable
+        (intentionally absent from REVIEW_SKILLS, SKILL_MAP, and ReviewSkillChoice).
+    STRUCTURE_STACK_NAME: str - Stack identifier emitted by detect_stacks for the
+        structural meta-stack assignment.
 """
 
 from enum import Enum
@@ -102,3 +107,12 @@ REVIEW_OUTPUT_FILE = ".review-output.md"
 
 # Pattern to detect unknown skill errors
 UNKNOWN_SKILL_PATTERN = r"Unknown skill: ([\w:-]+)"
+
+# Structural-maintainability meta-stack. Deep mode appends a synthetic
+# ``StackAssignment`` with ``stack_name=STRUCTURE_STACK_NAME`` and
+# ``skill_invocation=STRUCTURE_SKILL`` so the structural reviewer always runs
+# alongside per-language reviewers. Intentionally NOT added to ``REVIEW_SKILLS``,
+# ``SKILL_MAP``, or ``ReviewSkillChoice`` — this skill is a meta-stack invoked by
+# the orchestrator, never selected from the CLI.
+STRUCTURE_SKILL: str = "beagle-quality:review-structure"
+STRUCTURE_STACK_NAME: str = "structure"

--- a/daydream/config.py
+++ b/daydream/config.py
@@ -114,5 +114,5 @@ UNKNOWN_SKILL_PATTERN = r"Unknown skill: ([\w:-]+)"
 # alongside per-language reviewers. Intentionally NOT added to ``REVIEW_SKILLS``,
 # ``SKILL_MAP``, or ``ReviewSkillChoice`` — this skill is a meta-stack invoked by
 # the orchestrator, never selected from the CLI.
-STRUCTURE_SKILL: str = "beagle-quality:review-structure"
+STRUCTURE_SKILL: str = "beagle-core:review-structure"
 STRUCTURE_STACK_NAME: str = "structure"

--- a/daydream/deep/detection.py
+++ b/daydream/deep/detection.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import PurePosixPath
 
-from daydream.config import SKILL_MAP
+from daydream.config import SKILL_MAP, STRUCTURE_SKILL, STRUCTURE_STACK_NAME
 
 # Extension -> stack-key (lowercase, matches SKILL_MAP keys). Keep in sync with
 # SKILL_MAP; this table is about review-skill routing, not syntactic parsing
@@ -138,8 +138,14 @@ def detect_stacks(
             MissingSkillError would be handled separately).
 
     Returns:
-        One StackAssignment per distinct stack that received at least one file.
-        Ordering: non-generic stacks alphabetical, then generic last.
+        One StackAssignment per distinct stack that received at least one file,
+        plus a synthetic ``structure`` meta-stack appended last whenever the diff
+        contains at least one file and is not docs-only. The structure stack
+        carries the full set of changed files (union across languages) and
+        invokes ``STRUCTURE_SKILL`` for repo-wide structural-maintainability
+        review. Ordering: non-generic language stacks alphabetical, then generic,
+        then structure last. Ordering is informational only — the orchestrator
+        iterates the full list in parallel.
     """
     if skill_availability is None:
         skill_availability = set(SKILL_MAP.keys())
@@ -233,6 +239,19 @@ def detect_stacks(
                 skill_invocation=None,
                 files=files,
                 is_docs_only=diff_is_docs_only,
+            )
+        )
+
+    # Structural meta-stack: appended unconditionally for any non-docs-only diff
+    # with at least one changed file. Carries the union of all changed files so
+    # the structural reviewer judges the whole change across language boundaries.
+    if changed_files and not diff_is_docs_only:
+        results.append(
+            StackAssignment(
+                stack_name=STRUCTURE_STACK_NAME,
+                skill_invocation=STRUCTURE_SKILL,
+                files=sorted(changed_files),
+                is_docs_only=False,
             )
         )
     return results

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from daydream.agent import console
-from daydream.config import REVIEW_OUTPUT_FILE, SKILL_MAP
+from daydream.config import REVIEW_OUTPUT_FILE, SKILL_MAP, STRUCTURE_STACK_NAME
 from daydream.deep.artifacts import (
     alternatives_path as _alternatives_path,
 )
@@ -495,6 +495,33 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
                         all_records.extend(records)
                         record_sources.extend(stack_name for _ in records)
 
+                # Partition out the structural meta-stack records BEFORE dedup.
+                # The structural lens carries different convictions than the
+                # language stacks (file-size budgets, layering, canonical-helper
+                # gaps); collapsing it into the language-stack dedup pool would
+                # silently demote those findings into the global ## Issues list.
+                # Resume populates record_sources with the records filename
+                # (e.g. "stack-structure-records.json"); fresh-run populates it
+                # with the stack_name ("structure"). Filter both forms together
+                # to preserve the record_sources[i] / all_records[i] index
+                # invariant.
+                structural_path_candidate = per_stack_records_path(dd, STRUCTURE_STACK_NAME)
+                if structural_path_candidate in per_stack_records_paths:
+                    structural_records_path: Path | None = structural_path_candidate
+                    structural_filename = structural_path_candidate.name
+                    per_stack_records_paths = [
+                        p for p in per_stack_records_paths if p != structural_path_candidate
+                    ]
+                    kept_pairs = [
+                        (rec, src)
+                        for rec, src in zip(all_records, record_sources, strict=True)
+                        if src != STRUCTURE_STACK_NAME and src != structural_filename
+                    ]
+                    all_records = [rec for rec, _ in kept_pairs]
+                    record_sources = [src for _, src in kept_pairs]
+                else:
+                    structural_records_path = None
+
                 # Dedup pre-filter (D-27).
                 alt_issues_for_dedup: list[dict[str, Any]] = (
                     json.loads(alts_p.read_text()) if alts_p.exists() else []
@@ -522,6 +549,7 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
                     dedup_candidates_path=dedup_p,
                     exploration_dir=exploration_dir,
                     failed_stacks=failed_stacks or None,
+                    structural_records_path=structural_records_path,
                 )
 
             # ------ Stage 5: optional fix gate (D-28, D-29) ------

--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -3,6 +3,13 @@
 Pure keyword-only functions that assemble prompt strings from context pointers.
 All context passes via filesystem paths (D-09) -- no full file contents embedded in
 prompts. Per-stack agents only see their own stack's files + TTT context (D-10).
+
+Public builders:
+    - build_per_stack_prompt: per-language stack scoped review.
+    - build_structural_prompt: repo-wide structural-maintainability meta-stack.
+    - build_merge_prompt: cross-stack merge into a unified report.
+    - build_verification_prompt: recommendation-verifier agent prompt.
+    - build_generic_fallback_prompt: fallback for files without a dedicated stack.
 """
 
 from __future__ import annotations
@@ -10,6 +17,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from daydream.config import STRUCTURE_SKILL
 from daydream.phases import (
     RECOMMENDATION_VERDICTS_SCHEMA,
     _confidence_and_convention_instructions,
@@ -105,6 +113,64 @@ def build_per_stack_prompt(
     parts.append(_stack_scope_instruction(stack_name, files))
     parts.append(_diff_instruction(diff_path, files))
     parts.append(skill_invocation)
+    parts.append(f"Write your full review to {output_path}.")
+    return "\n\n".join(parts)
+
+
+def build_structural_prompt(
+    *,
+    files: list[str],
+    diff_path: Path,
+    intent_path: Path,
+    alternatives_path: Path,
+    output_path: Path,
+    exploration_dir: Path | None = None,
+    prior_commits: str | None = None,
+) -> str:
+    """Assemble the structural-maintainability meta-stack prompt.
+
+    Mirrors ``build_per_stack_prompt`` but covers the full PR rather than a
+    single language's files. The structural rubric judges repo-wide concerns
+    (canonical helpers, file-size budgets, layering, branching shape), so the
+    reviewer must be free to read any file in the codebase via Read/Grep/Bash
+    instead of being scoped to a stack subset.
+
+    Args:
+        files: Full union of changed files across every stack. Used to anchor
+            the scope statement; the reviewer is still free to read beyond.
+        diff_path: Path to the full diff on disk.
+        intent_path: Path to TTT intent.md.
+        alternatives_path: Path to TTT alternatives.json.
+        output_path: Where the agent must write its review.
+        exploration_dir: Accepted for signature symmetry with
+            ``build_per_stack_prompt``; intentionally ignored in the prompt
+            body because the structural reviewer discovers context via tool
+            calls, not pre-injected pointers.
+        prior_commits: Oneline log of prior daydream commits on this branch.
+
+    Returns:
+        Assembled prompt string.
+    """
+    del exploration_dir  # accepted for signature symmetry; intentionally unused.
+    joined = ", ".join(files)
+    parts: list[str] = []
+    settled = _settled_decisions_block(prior_commits)
+    if settled:
+        parts.append(settled)
+    parts.append(_context_pointers(intent_path=intent_path, alternatives_path=alternatives_path))
+    parts.append(
+        f"You are the structural reviewer. The full change spans: {joined}. "
+        f"The structural rubric applies repo-wide -- read any file in the "
+        f"codebase as needed (Read/Grep/Bash) to judge whether canonical "
+        f"helpers exist, file-size budgets are honored, and the change makes "
+        f"the codebase easier or harder to live with."
+    )
+    parts.append(
+        f"The full PR diff (base..HEAD) is at {diff_path}. Read it directly; "
+        f"do NOT run `git diff` without a base ref -- on a clean branch that "
+        f"returns empty and hides committed changes."
+    )
+    parts.append(f"/{STRUCTURE_SKILL}")
     parts.append(f"Write your full review to {output_path}.")
     return "\n\n".join(parts)
 

--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -184,6 +184,7 @@ def build_merge_prompt(
     output_path: Path,
     exploration_dir: Path | None = None,
     failed_stacks: dict[str, str] | None = None,
+    structural_records_path: Path | None = None,
 ) -> str:
     """Assemble the cross-stack merge prompt (D-23..D-27).
 
@@ -193,6 +194,11 @@ def build_merge_prompt(
       - have a ## Cross-Stack Issues subsection that CONTINUES the numbering (D-25)
       - prefix every cross-stack title with the literal "[cross-stack]" (D-26, normative)
       - collapse duplicates per dedup candidate adjudication (D-27)
+      - when ``structural_records_path`` is provided, carry a ``## Structural
+        Review`` section between ``## Per-Stack Context`` and ``## Issues``
+        with independent (1..N) numbering, NOT merged into the global
+        ``## Issues`` list and NOT deduplicated against per-stack or
+        alternative-review findings
 
     Args:
         per_stack_records_paths: Parsed per-stack record JSON paths (D-22 inputs).
@@ -205,6 +211,13 @@ def build_merge_prompt(
             per-stack agent raised. The merge prompt includes an explicit
             "Uncovered stacks" block so the merge report can call out missing
             coverage instead of silently pretending the run was complete.
+        structural_records_path: Optional path to the parsed structural-stack
+            records JSON. When provided, the merge prompt instructs the agent
+            to render a dedicated ``## Structural Review`` section above
+            ``## Issues`` with independent numbering and NO deduplication
+            against the other record sources. When ``None`` (docs-only diff,
+            empty diff, or no structure stack emitted) the merge prompt body
+            is unchanged and never mentions the structural lens.
 
     Returns:
         Assembled prompt string.
@@ -214,12 +227,31 @@ def build_merge_prompt(
     pointer = _exploration_pointer(exploration_dir)
     if pointer:
         parts.append(pointer)
-    parts.append(
-        f"TTT intent summary: {intent_path}\n"
-        f"TTT alternative-review findings: {alternatives_path}\n"
-        f"Dedup pre-filter candidate pairs: {dedup_candidates_path}\n"
-        f"Per-stack parsed records:\n{records_block}"
-    )
+    context_lines = [
+        f"TTT intent summary: {intent_path}",
+        f"TTT alternative-review findings: {alternatives_path}",
+        f"Dedup pre-filter candidate pairs: {dedup_candidates_path}",
+    ]
+    if structural_records_path is not None:
+        context_lines.append(
+            f"Structural-stack parsed records: {structural_records_path}"
+        )
+    context_lines.append(f"Per-stack parsed records:\n{records_block}")
+    parts.append("\n".join(context_lines))
+    if structural_records_path is not None:
+        parts.append(
+            "Structural-stack handling:\n"
+            f"  - Read the records file at {structural_records_path} and render its "
+            "findings under a dedicated `## Structural Review` section in the "
+            "report (placement pinned below).\n"
+            "  - The `## Structural Review` section has independent numbering "
+            "(1..N) and lists findings parsed from the structural records. Do "
+            "NOT renumber these into the global `## Issues` list, and do NOT "
+            "deduplicate structural findings against per-stack or "
+            "alternative-review findings -- the structural lens carries "
+            "different convictions and merging them silently demotes that "
+            "prioritization."
+        )
     if failed_stacks:
         failed_block = "\n".join(
             f"  - {name}: {reason}" for name, reason in sorted(failed_stacks.items())
@@ -251,12 +283,23 @@ def build_merge_prompt(
         "  - Concerns that span multiple stacks (contract drift, shared-type "
         "mismatches, API-contract misalignment) go in ## Cross-Stack Issues."
     )
+    structural_section_template = (
+        "## Structural Review\n"
+        "<independent numbering 1..N -- do NOT merge into ## Issues>\n"
+        "1. [FILE:LINE] TITLE\n"
+        "   rationale / recommendation parsed from the structural records\n"
+        "2. [FILE:LINE] TITLE\n"
+        "   ...\n\n"
+        if structural_records_path is not None
+        else ""
+    )
     parts.append(
         "Report format (MANDATORY):\n\n"
         "# Review\n\n"
         "## Per-Stack Context\n"
         "(optional human-readable per-stack summaries; phase_parse_feedback ignores "
         "this section)\n\n"
+        f"{structural_section_template}"
         "## Issues\n"
         "1. [FILE:LINE] TITLE\n"
         "   rationale / recommendation\n"

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -2339,6 +2339,7 @@ async def phase_cross_stack_merge(
     dedup_candidates_path: Path,
     exploration_dir: Path | None = None,
     failed_stacks: dict[str, str] | None = None,
+    structural_records_path: Path | None = None,
 ) -> Path:
     """Run the cross-stack merge agent and return the output-report path (D-23..D-27).
 
@@ -2353,6 +2354,8 @@ async def phase_cross_stack_merge(
         backend: The Backend to execute against.
         work: Workspace context; report is written under ``work.repo``.
         per_stack_records_paths: Parsed per-stack record JSON paths (D-22 inputs).
+            Must NOT include the structural meta-stack records file -- callers
+            partition that out and pass it via ``structural_records_path``.
         intent_path: Path to TTT intent.md.
         alternatives_path: Path to TTT alternatives.json.
         dedup_candidates_path: Path to dedup-candidates.json (D-27 pre-filter output).
@@ -2360,6 +2363,12 @@ async def phase_cross_stack_merge(
         failed_stacks: Optional stack_name -> reason dict for per-stack agents
             that failed. Passed through to the merge prompt so the merged
             report can call out uncovered stacks explicitly.
+        structural_records_path: Optional path to the parsed structural
+            meta-stack records JSON. When provided, the merge prompt renders a
+            dedicated ``## Structural Review`` section above ``## Issues`` with
+            independent numbering and is excluded from dedup against the
+            language-stack records. ``None`` when the structural reviewer did
+            not run (docs-only diff, empty diff).
 
     Returns:
         Path to the merged report at ``work.repo / REVIEW_OUTPUT_FILE``.
@@ -2384,6 +2393,7 @@ async def phase_cross_stack_merge(
         output_path=agent_output_path,
         exploration_dir=exploration_dir,
         failed_stacks=failed_stacks,
+        structural_records_path=structural_records_path,
     )
     print_phase_hero(console, "MERGE", phase_subtitle("MERGE"))
     print_dim(console, f"Model: {backend.model}")

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -2252,12 +2252,10 @@ async def phase_per_stack_reviews(
             dropped.
 
     """
+    from daydream.config import STRUCTURE_STACK_NAME
+    from daydream.deep import prompts as _prompts
     from daydream.deep.artifacts import deep_dir as _deep_dir
     from daydream.deep.artifacts import per_stack_review_path
-    from daydream.deep.prompts import (
-        build_generic_fallback_prompt,
-        build_per_stack_prompt,
-    )
 
     deep_dir_path = _deep_dir(work.repo)
     recorder = get_current_recorder()
@@ -2269,8 +2267,18 @@ async def phase_per_stack_reviews(
     async with anyio.create_task_group() as tg:
         for stack in stacks:
             output_path = per_stack_review_path(deep_dir_path, stack.stack_name)
-            if stack.skill_invocation is None:
-                prompt = build_generic_fallback_prompt(
+            if stack.stack_name == STRUCTURE_STACK_NAME:
+                prompt = _prompts.build_structural_prompt(
+                    files=stack.files,
+                    diff_path=diff_path,
+                    intent_path=intent_path,
+                    alternatives_path=alternatives_path,
+                    output_path=output_path,
+                    exploration_dir=exploration_dir,
+                    prior_commits=prior_commits,
+                )
+            elif stack.skill_invocation is None:
+                prompt = _prompts.build_generic_fallback_prompt(
                     files=stack.files,
                     diff_path=diff_path,
                     intent_path=intent_path,
@@ -2281,7 +2289,7 @@ async def phase_per_stack_reviews(
                     prior_commits=prior_commits,
                 )
             else:
-                prompt = build_per_stack_prompt(
+                prompt = _prompts.build_per_stack_prompt(
                     skill_invocation=stack.skill_invocation,
                     stack_name=stack.stack_name,
                     files=stack.files,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -66,7 +66,7 @@ def test_structure_skill_constant_not_user_selectable() -> None:
         ReviewSkillChoice,
     )
 
-    assert STRUCTURE_SKILL == "beagle-quality:review-structure"
+    assert STRUCTURE_SKILL == "beagle-core:review-structure"
     assert STRUCTURE_STACK_NAME == "structure"
     assert STRUCTURE_SKILL not in SKILL_MAP.values()
     assert STRUCTURE_STACK_NAME not in SKILL_MAP

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -54,3 +54,21 @@ def test_default_constants_still_exported():
     # Sanity: existing default constants remain importable for backend creation fallbacks.
     assert isinstance(DEFAULT_CLAUDE_MODEL, str)
     assert isinstance(DEFAULT_CODEX_MODEL, str)
+
+
+def test_structure_skill_constant_not_user_selectable() -> None:
+    """The structural reviewer is a meta-stack: invokable internally, never via CLI."""
+    from daydream.config import (
+        REVIEW_SKILLS,
+        SKILL_MAP,
+        STRUCTURE_SKILL,
+        STRUCTURE_STACK_NAME,
+        ReviewSkillChoice,
+    )
+
+    assert STRUCTURE_SKILL == "beagle-quality:review-structure"
+    assert STRUCTURE_STACK_NAME == "structure"
+    assert STRUCTURE_SKILL not in SKILL_MAP.values()
+    assert STRUCTURE_STACK_NAME not in SKILL_MAP
+    assert STRUCTURE_SKILL not in REVIEW_SKILLS.values()
+    assert all(choice.name != "STRUCTURE" for choice in ReviewSkillChoice)

--- a/tests/test_deep_detection.py
+++ b/tests/test_deep_detection.py
@@ -59,7 +59,8 @@ def test_config_default_generic() -> None:
     from daydream.deep.detection import detect_stacks
 
     result = detect_stacks(["config.yaml"], skill_availability=set())
-    assert {a.stack_name for a in result} == {"generic"}
+    language_names = {a.stack_name for a in result if a.stack_name != "structure"}
+    assert language_names == {"generic"}
 
 
 def test_config_promotion_pyproject() -> None:
@@ -77,7 +78,8 @@ def test_no_static_promotion_without_cochange() -> None:
 
     # pyproject.toml alone (no .py in diff) stays generic
     result = detect_stacks(["pyproject.toml"], skill_availability={"python"})
-    assert {a.stack_name for a in result} == {"generic"}
+    language_names = {a.stack_name for a in result if a.stack_name != "structure"}
+    assert language_names == {"generic"}
 
 
 def test_md_pinned_to_generic() -> None:
@@ -105,4 +107,45 @@ def test_missing_skill_routes_to_generic() -> None:
     from daydream.deep.detection import detect_stacks
 
     result = detect_stacks(["src/lib.rs"], skill_availability=set())  # rust not installed
-    assert {a.stack_name for a in result} == {"generic"}
+    language_names = {a.stack_name for a in result if a.stack_name != "structure"}
+    assert language_names == {"generic"}
+
+
+def test_structure_stack_emitted_for_code_diff() -> None:
+    """Structure stack is unconditionally present on any non-docs-only code diff."""
+    from daydream.config import STRUCTURE_SKILL, STRUCTURE_STACK_NAME
+    from daydream.deep.detection import detect_stacks
+
+    result = detect_stacks(["src/main.py", "src/util.py"], skill_availability={"python"})
+    structure = next((a for a in result if a.stack_name == STRUCTURE_STACK_NAME), None)
+    assert structure is not None
+    assert structure.skill_invocation == STRUCTURE_SKILL
+    assert structure.files == ["src/main.py", "src/util.py"]
+    assert structure.is_docs_only is False
+
+
+def test_structure_stack_files_are_union_across_languages() -> None:
+    """Structure stack sees every changed file regardless of language."""
+    from daydream.config import STRUCTURE_STACK_NAME
+    from daydream.deep.detection import detect_stacks
+
+    files = ["api/main.py", "ui/App.tsx", "infra/Dockerfile"]
+    result = detect_stacks(files, skill_availability={"python", "react"})
+    structure = next(a for a in result if a.stack_name == STRUCTURE_STACK_NAME)
+    assert sorted(structure.files) == sorted(files)
+
+
+def test_structure_stack_skipped_for_docs_only_diff() -> None:
+    """Structural rubric does not apply when the entire diff is docs."""
+    from daydream.config import STRUCTURE_STACK_NAME
+    from daydream.deep.detection import detect_stacks
+
+    result = detect_stacks(["README.md", "CHANGELOG.md"], skill_availability=set())
+    assert all(a.stack_name != STRUCTURE_STACK_NAME for a in result)
+
+
+def test_structure_stack_skipped_for_empty_diff() -> None:
+    """Empty changed_files yields no stacks at all, including structure."""
+    from daydream.deep.detection import detect_stacks
+
+    assert detect_stacks([], skill_availability=set()) == []

--- a/tests/test_deep_fanout.py
+++ b/tests/test_deep_fanout.py
@@ -147,6 +147,65 @@ async def test_fan_out_closure_capture(tmp_path: Path, make_work) -> None:
     assert any("generic-fallback" in p for p in prompts)
 
 
+async def test_phase_per_stack_reviews_uses_structural_prompt_for_structure_stack(
+    tmp_path: Path, make_work, monkeypatch
+) -> None:
+    """Structural stack flows through build_structural_prompt; language stacks do not."""
+    from daydream.config import STRUCTURE_SKILL, STRUCTURE_STACK_NAME
+    from daydream.deep import prompts as _prompts
+    from daydream.phases import phase_per_stack_reviews as _phase
+
+    structural_calls: list[dict[str, Any]] = []
+    per_stack_calls: list[dict[str, Any]] = []
+
+    def _capture_structural(**kwargs: Any) -> str:
+        structural_calls.append(kwargs)
+        return "STRUCTURAL_PROMPT"
+
+    def _capture_per_stack(**kwargs: Any) -> str:
+        per_stack_calls.append(kwargs)
+        return "PER_STACK_PROMPT"
+
+    # phase_per_stack_reviews late-imports these symbols from daydream.deep.prompts;
+    # patch on the module so the late-import re-binding picks up the stubs.
+    monkeypatch.setattr(_prompts, "build_structural_prompt", _capture_structural)
+    monkeypatch.setattr(_prompts, "build_per_stack_prompt", _capture_per_stack)
+
+    backend = _RecordingBackend()
+    diff, intent, alts = _mk_context_files(tmp_path)
+
+    stacks = [
+        StackAssignment(
+            stack_name="python",
+            skill_invocation="/beagle-python:review-python",
+            files=["a.py"],
+            is_docs_only=False,
+        ),
+        StackAssignment(
+            stack_name=STRUCTURE_STACK_NAME,
+            skill_invocation=STRUCTURE_SKILL,
+            files=["a.py"],
+            is_docs_only=False,
+        ),
+    ]
+
+    await _phase(
+        backend,
+        make_work(tmp_path),
+        stacks,
+        diff_path=diff,
+        intent_path=intent,
+        alternatives_path=alts,
+    )
+
+    assert len(structural_calls) == 1
+    assert len(per_stack_calls) == 1
+    assert structural_calls[0]["files"] == ["a.py"]
+    assert "skill_invocation" not in structural_calls[0]
+    assert "stack_name" not in structural_calls[0]
+    assert per_stack_calls[0]["stack_name"] == "python"
+
+
 async def test_fan_out_continues_after_one_failure(tmp_path: Path, make_work) -> None:
     """A single stack failure does not abort the whole fan-out, and is reported."""
 

--- a/tests/test_deep_integration.py
+++ b/tests/test_deep_integration.py
@@ -61,6 +61,26 @@ class _DeepMockBackend:
             yield ResultEvent(structured_output={"issues": []}, continuation=None)
             return
 
+        # Structural meta-stack prompt contains "you are the structural reviewer".
+        # Must be checked BEFORE the per-stack branch: the structural prompt does
+        # NOT contain "you are reviewing the ... stack" but DOES embed the
+        # `stack-structure-review.md` output path, so it would otherwise fall
+        # through to the "other" fallback and never produce a review artifact.
+        if "structural reviewer" in pl:
+            self.calls.append("structure")
+            m = re.search(r"stack-(\S+?)-review\.md", prompt)
+            if m:
+                name = m.group(1)
+                out = self.target_dir / ".daydream" / "deep" / f"stack-{name}-review.md"
+                out.parent.mkdir(parents=True, exist_ok=True)
+                out.write_text(
+                    f"# Structural Review ({name})\n\n## Issues\n"
+                    "1. [api.py:1] hello() leaks a god-object boundary\n"
+                )
+            yield TextEvent(text="")
+            yield ResultEvent(structured_output=None, continuation=None)
+            return
+
         # Per-stack review prompt contains "You are reviewing the ... stack".
         if "you are reviewing the" in pl and "stack" in pl:
             self.calls.append("per-stack")
@@ -89,8 +109,19 @@ class _DeepMockBackend:
             # the caller (phase_cross_stack_merge) copies to canonical.
             deep = self.target_dir / ".daydream" / "deep" / "review-output.md"
             deep.parent.mkdir(parents=True, exist_ok=True)
+            # Mirror the real merge agent's compliance with the prompt: when the
+            # prompt carries the structural-records pointer, render a dedicated
+            # `## Structural Review` section above `## Issues`. When it does not
+            # (docs-only / empty diff), omit the section entirely.
+            structural = (
+                "## Structural Review\n"
+                "1. [api.py:1] hello() leaks a god-object boundary\n\n"
+                if "structural-stack parsed records" in pl
+                else ""
+            )
             deep.write_text(
-                "# Review\n\n## Issues\n\n## Cross-Stack Issues\n"
+                f"# Review\n\n## Per-Stack Context\n\n{structural}"
+                "## Issues\n\n## Cross-Stack Issues\n"
             )
             yield TextEvent(text="")
             yield ResultEvent(structured_output=None, continuation=None)
@@ -304,3 +335,90 @@ def test_existing_tests_still_collect() -> None:
         assert spec is not None and spec.loader is not None
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
+
+
+async def test_structural_meta_stack_flows_end_to_end(
+    multi_stack_target: Path, monkeypatch
+) -> None:
+    """End-to-end smoke for the structural meta-stack pipeline (Tasks 2-7 composed).
+
+    Drives the deep orchestrator on a real multi-language diff (Python + TSX +
+    Markdown — a code diff, so NOT docs-only) and asserts the four observable
+    states the structural pipeline must produce:
+
+      1. ``detect_stacks`` returned ``structure`` as one of the stacks.
+      2. ``phase_per_stack_reviews`` produced a ``stack-structure-review.md``
+         artifact on disk.
+      3. The merge prompt received the ``stack-structure-records.json`` path
+         via ``structural_records_path``.
+      4. The final merged report on disk carries a ``## Structural Review``
+         header.
+
+    These are real observable side effects (files on disk, the path threaded
+    into the merge call, the rendered report header) — not dispatch bookkeeping.
+    If any wire in Tasks 2-7 were broken (structure stack not emitted, prompt
+    not routed, records not partitioned out and forwarded, section not
+    rendered) the corresponding assertion below fails.
+    """
+    from daydream.config import STRUCTURE_STACK_NAME
+    from daydream.deep import detection as _detection
+    from daydream.deep import prompts as _prompts
+    from daydream.deep.detection import StackAssignment
+
+    detected_stacks: list[StackAssignment] = []
+    real_detect = _detection.detect_stacks
+
+    def _spy_detect(changed_files, *, skill_availability):
+        result = real_detect(changed_files, skill_availability=skill_availability)
+        detected_stacks.extend(result)
+        return result
+
+    merge_kwargs: dict = {}
+    real_build_merge = _prompts.build_merge_prompt
+
+    def _spy_merge(**kwargs):
+        merge_kwargs.update(kwargs)
+        return real_build_merge(**kwargs)
+
+    # ``detect_stacks`` is imported into the orchestrator namespace; patch there.
+    monkeypatch.setattr("daydream.deep.orchestrator.detect_stacks", _spy_detect)
+    # ``build_merge_prompt`` is imported lazily inside phase_cross_stack_merge;
+    # patch the source module so the late import resolves to the spy.
+    monkeypatch.setattr("daydream.deep.prompts.build_merge_prompt", _spy_merge)
+
+    backend = _ClaudeShape(multi_stack_target)
+    exit_code = await _run_deep(multi_stack_target, backend, monkeypatch)
+    assert exit_code == 0, f"run_deep returned {exit_code} (expected 0)"
+
+    # (1) detect_stacks emitted the structure meta-stack for this code diff.
+    structure = next(
+        (a for a in detected_stacks if a.stack_name == STRUCTURE_STACK_NAME), None
+    )
+    assert structure is not None, (
+        f"structure stack not emitted; saw: {[a.stack_name for a in detected_stacks]}"
+    )
+
+    deep_dir = multi_stack_target / ".daydream" / "deep"
+
+    # (2) phase_per_stack_reviews produced the structural review artifact.
+    structural_review = deep_dir / "stack-structure-review.md"
+    assert structural_review.is_file(), (
+        "stack-structure-review.md missing -- structure stack was not routed "
+        "through build_structural_prompt or its agent never wrote the artifact"
+    )
+
+    # (3) The merge prompt received the structural records path.
+    structural_records_path = merge_kwargs.get("structural_records_path")
+    assert structural_records_path is not None, (
+        "merge prompt did not receive structural_records_path -- orchestrator "
+        "failed to partition + forward the structural records"
+    )
+    assert structural_records_path.name == "stack-structure-records.json", (
+        f"unexpected structural records filename: {structural_records_path.name}"
+    )
+
+    # (4) The merged report on disk carries the dedicated structural section.
+    merged_report = (multi_stack_target / REVIEW_OUTPUT_FILE).read_text()
+    assert "## Structural Review" in merged_report, (
+        "merged report is missing the ## Structural Review header"
+    )

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -91,6 +91,14 @@ class _StubBackend:
         m = re.search(r"you are reviewing the (\S+) stack", pl)
         if m is None:
             m = re.search(r"you are reviewing the (generic-fallback) stack", pl)
+        if m is None and "you are the structural reviewer" in pl:
+            # Structural meta-stack: same review-file contract, no language label.
+            class _M:
+                @staticmethod
+                def group(_: int) -> str:
+                    return "structure"
+
+            m = _M()  # type: ignore[assignment]
         if m is not None:
             # Extract the output path the prompt asks the agent to write.
             out_match = re.search(r"write your full review to (\S+)", prompt, flags=re.IGNORECASE)
@@ -479,8 +487,10 @@ async def test_preflight_notice(multi_stack_target: Path, monkeypatch: pytest.Mo
     notice = captured[0]
     # Exactly 5 stages.
     assert len(notice["stages"]) == 5
-    # Agent count: 2 TTT + N per-stack + N parse + 1 merge with N=3 -> 9.
-    assert notice["agent_count"] == 9
+    # Agent count: 2 TTT + N per-stack + N parse + 1 merge. The multi-stack
+    # fixture's diff yields N=4 (python + react + generic + structure
+    # meta-stack), so the formula 2 + 2*4 + 1 = 11.
+    assert notice["agent_count"] == 11
     # Stacks surfaced.
     assert len(notice["stack_lines"]) >= 1
     # No Codex caveat on Claude backend.
@@ -575,6 +585,12 @@ async def test_resume_merge_consumes_saved_records(
     # in failed_stacks) passes.
     (deep / "stack-generic-records.json").write_text(
         json.dumps([{"id": 1, "description": "docs issue", "file": "README.md", "line": 1}])
+    )
+    # Structure meta-stack also runs in production -- prime its records.
+    (deep / "stack-structure-records.json").write_text(
+        json.dumps(
+            [{"id": 1, "description": "structural issue", "file": "api.py", "line": 1}]
+        )
     )
 
     exit_code = await _run_deep(multi_stack_target, start_at="merge")
@@ -938,6 +954,12 @@ async def test_resume_merge_allows_missing_records_for_failed_stacks(
     (deep / "stack-react-records.json").write_text(
         json.dumps([{"id": 1, "description": "tsx issue", "file": "App.tsx", "line": 1}])
     )
+    # Structure meta-stack also runs in production -- prime its records.
+    (deep / "stack-structure-records.json").write_text(
+        json.dumps(
+            [{"id": 1, "description": "structural issue", "file": "api.py", "line": 1}]
+        )
+    )
     # No records for the generic bucket, but it's listed as a prior failure.
     (deep / "per-stack-failures.json").write_text(
         json.dumps({"generic": "simulated generic failure"})
@@ -948,6 +970,185 @@ async def test_resume_merge_allows_missing_records_for_failed_stacks(
 
     merge_calls = [c for c in stub.calls if "cross-stack merge agent" in c["prompt"].lower()]
     assert len(merge_calls) == 1
+
+
+async def test_orchestrator_threads_structural_records_to_merge(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Structural records ride the merge prompt as a separate input and are
+    excluded from the dedup pre-filter so they don't get silently collapsed
+    against language-stack findings.
+
+    Drives the merge resume path (start_at="merge") with pre-written records
+    JSONs including a structure record carrying a sentinel description, then
+    asserts (a) the merge prompt receives structural_records_path pointing at
+    the structure records file, (b) the dedup input lists do NOT contain the
+    sentinel structural record.
+    """
+    import json as _json
+
+    from daydream.deep import dedup as _dedup
+    from daydream.deep import prompts as _prompts
+
+    _real_build_merge = _prompts.build_merge_prompt
+
+    captured_merge: dict = {}
+    captured_dedup_records: dict = {}
+    captured_record_dedup: dict = {}
+
+    real_build_dedup = _dedup.build_dedup_candidates
+    real_build_record_dedup = _dedup.build_record_dedup_candidates
+
+    def _capture_merge(**kwargs):
+        captured_merge.update(kwargs)
+        # Delegate to real builder so the merge agent still gets a usable prompt.
+        return _real_build_merge(**kwargs)
+
+    def _capture_dedup(records, alt_issues):
+        captured_dedup_records["records"] = list(records)
+        return real_build_dedup(records, alt_issues)
+
+    def _capture_record_dedup(records, sources):
+        captured_record_dedup["records"] = list(records)
+        captured_record_dedup["sources"] = list(sources)
+        return real_build_record_dedup(records, sources=sources)
+
+    monkeypatch.setattr("daydream.deep.prompts.build_merge_prompt", _capture_merge)
+    monkeypatch.setattr(
+        "daydream.deep.orchestrator.build_dedup_candidates", _capture_dedup
+    )
+    monkeypatch.setattr(
+        "daydream.deep.orchestrator.build_record_dedup_candidates",
+        _capture_record_dedup,
+    )
+
+    _silence(monkeypatch)
+    _install_stub_backend(monkeypatch, multi_stack_target)
+
+    deep = multi_stack_target / ".daydream" / "deep"
+    deep.mkdir(parents=True, exist_ok=True)
+    (deep / "intent.md").write_text("primed intent")
+    (deep / "alternatives.json").write_text("[]")
+    (deep / "stack-python-records.json").write_text(
+        _json.dumps(
+            [{"id": "py-1", "description": "py issue", "file": "api.py", "line": 1}]
+        )
+    )
+    (deep / "stack-react-records.json").write_text(
+        _json.dumps(
+            [{"id": "react-1", "description": "tsx issue", "file": "App.tsx", "line": 1}]
+        )
+    )
+    (deep / "stack-generic-records.json").write_text(
+        _json.dumps(
+            [{"id": "generic-1", "description": "docs issue", "file": "README.md", "line": 1}]
+        )
+    )
+    # Structural record carries a sentinel id so we can verify it never lands
+    # in the dedup input lists.
+    (deep / "stack-structure-records.json").write_text(
+        _json.dumps(
+            [
+                {
+                    "id": "structure-1",
+                    "description": "1000-line file budget violated",
+                    "file": "api.py",
+                    "line": 1,
+                }
+            ]
+        )
+    )
+
+    exit_code = await _run_deep(multi_stack_target, start_at="merge")
+    assert exit_code == 0
+
+    # (1) Merge prompt received structural_records_path pointing at the
+    #     structural records file inside the deep artifact dir.
+    assert captured_merge.get("structural_records_path") is not None
+    assert captured_merge["structural_records_path"].name == "stack-structure-records.json"
+    # And the per_stack_records_paths kwarg must NOT include the structural file
+    # (it rides as its own argument now).
+    per_stack_paths = captured_merge["per_stack_records_paths"]
+    assert all(
+        p.name != "stack-structure-records.json" for p in per_stack_paths
+    ), f"structural records must be partitioned out: {per_stack_paths}"
+
+    # (2) The structural sentinel record must NOT appear in either dedup input.
+    def _has_structure(records: list) -> bool:
+        return any(str(r.get("id", "")).startswith("structure") for r in records)
+
+    assert not _has_structure(captured_dedup_records["records"]), (
+        f"structural records leaked into build_dedup_candidates: "
+        f"{captured_dedup_records['records']}"
+    )
+    assert not _has_structure(captured_record_dedup["records"]), (
+        f"structural records leaked into build_record_dedup_candidates: "
+        f"{captured_record_dedup['records']}"
+    )
+    # And the sources list must stay parallel to the filtered records list.
+    assert len(captured_record_dedup["sources"]) == len(captured_record_dedup["records"])
+
+
+async def test_orchestrator_threads_structural_records_to_merge_fresh_run(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fresh-run path (no start_at) applies the same structural partition.
+
+    Mirrors ``test_orchestrator_threads_structural_records_to_merge`` but lets
+    the pipeline execute the pre-merge parse loop instead of the resume loop,
+    so a divergence between the two code paths would surface here.
+    """
+    from daydream.deep import dedup as _dedup
+    from daydream.deep import prompts as _prompts
+
+    _real_build_merge = _prompts.build_merge_prompt
+
+    captured_merge: dict = {}
+    captured_record_dedup: dict = {}
+
+    real_build_dedup = _dedup.build_dedup_candidates
+    real_build_record_dedup = _dedup.build_record_dedup_candidates
+
+    def _capture_merge(**kwargs):
+        captured_merge.update(kwargs)
+        return _real_build_merge(**kwargs)
+
+    def _capture_dedup(records, alt_issues):
+        return real_build_dedup(records, alt_issues)
+
+    def _capture_record_dedup(records, sources):
+        captured_record_dedup["records"] = list(records)
+        captured_record_dedup["sources"] = list(sources)
+        return real_build_record_dedup(records, sources=sources)
+
+    monkeypatch.setattr("daydream.deep.prompts.build_merge_prompt", _capture_merge)
+    monkeypatch.setattr(
+        "daydream.deep.orchestrator.build_dedup_candidates", _capture_dedup
+    )
+    monkeypatch.setattr(
+        "daydream.deep.orchestrator.build_record_dedup_candidates",
+        _capture_record_dedup,
+    )
+
+    _silence(monkeypatch)
+    _install_stub_backend(monkeypatch, multi_stack_target)
+
+    exit_code = await _run_deep(multi_stack_target)
+    assert exit_code == 0
+
+    # Structural records file lives under the deep artifact dir.
+    assert captured_merge.get("structural_records_path") is not None
+    assert captured_merge["structural_records_path"].name == "stack-structure-records.json"
+    per_stack_paths = captured_merge["per_stack_records_paths"]
+    assert all(
+        p.name != "stack-structure-records.json" for p in per_stack_paths
+    ), f"structural records must be partitioned out (fresh run): {per_stack_paths}"
+
+    # The fresh-run path populates record_sources with the stack_name string,
+    # so the partition removes every entry whose source == 'structure'.
+    assert "structure" not in captured_record_dedup["sources"]
+    # Sources stay parallel to records after filtering.
+    assert len(captured_record_dedup["sources"]) == len(captured_record_dedup["records"])
 
 
 async def test_resume_fix_skips_pr_post(

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -318,4 +318,5 @@ def test_merge_prompt_omits_structural_section_when_path_is_none(tmp_path: Path)
         structural_records_path=None,
     )
     assert "## Structural Review" not in prompt
-    assert "structural" not in prompt.lower()
+    assert "Structural-stack parsed records:" not in prompt
+    assert "Structural-stack handling:" not in prompt

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -248,3 +248,36 @@ def test_merge_prompt_requires_one_path_per_bracket(tmp_path: Path) -> None:
     out = build_merge_prompt(**_merge_paths(tmp_path))  # type: ignore[arg-type]
     assert "EXACTLY ONE file path" in out
     assert "separate numbered entry per file" in out
+
+
+def test_build_structural_prompt_has_no_stack_scope_restriction(tmp_path: Path) -> None:
+    """Structural reviewer sees the whole change — no 'Focus ONLY on these files' clause."""
+    from daydream.config import STRUCTURE_SKILL
+    from daydream.deep.prompts import build_structural_prompt
+
+    prompt = build_structural_prompt(
+        files=["api/main.py", "ui/App.tsx"],
+        diff_path=tmp_path / "diff.patch",
+        intent_path=tmp_path / "intent.md",
+        alternatives_path=tmp_path / "alternatives.json",
+        output_path=tmp_path / "out.md",
+    )
+    assert "Focus ONLY on these files" not in prompt
+    assert "Do NOT review files from other stacks" not in prompt
+    assert STRUCTURE_SKILL in prompt or "/" + STRUCTURE_SKILL in prompt
+    assert str(tmp_path / "out.md") in prompt
+
+
+def test_build_structural_prompt_omits_exploration_pointer(tmp_path: Path) -> None:
+    """Per spec: structural reviewer discovers via tool calls, not pre-injected context."""
+    from daydream.deep.prompts import build_structural_prompt
+
+    prompt = build_structural_prompt(
+        files=["main.py"],
+        diff_path=tmp_path / "diff.patch",
+        intent_path=tmp_path / "intent.md",
+        alternatives_path=tmp_path / "alternatives.json",
+        output_path=tmp_path / "out.md",
+        exploration_dir=tmp_path / "exploration",
+    )
+    assert "exploration" not in prompt.lower()

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -281,3 +281,41 @@ def test_build_structural_prompt_omits_exploration_pointer(tmp_path: Path) -> No
         exploration_dir=tmp_path / "exploration",
     )
     assert "exploration" not in prompt.lower()
+
+
+def test_merge_prompt_emits_structural_section_above_issues(tmp_path: Path) -> None:
+    """When a structural-records path is given, the merge prompt instructs the agent
+    to render `## Structural Review` above `## Issues`."""
+    from daydream.deep.prompts import build_merge_prompt
+
+    structural_path = tmp_path / "stack-structure-records.json"
+    prompt = build_merge_prompt(
+        per_stack_records_paths=[tmp_path / "stack-python-records.json"],
+        intent_path=tmp_path / "intent.md",
+        alternatives_path=tmp_path / "alts.json",
+        dedup_candidates_path=tmp_path / "dedup.json",
+        output_path=tmp_path / "report.md",
+        structural_records_path=structural_path,
+    )
+    assert str(structural_path) in prompt
+    assert "## Structural Review" in prompt
+    structural_idx = prompt.index("## Structural Review")
+    issues_idx = prompt.index("## Issues")
+    assert structural_idx < issues_idx, "Structural Review section must appear above ## Issues"
+    assert "not deduplicat" in prompt.lower() or "do not dedup" in prompt.lower()
+
+
+def test_merge_prompt_omits_structural_section_when_path_is_none(tmp_path: Path) -> None:
+    """No structural section when the meta-stack did not run (docs-only, empty diff)."""
+    from daydream.deep.prompts import build_merge_prompt
+
+    prompt = build_merge_prompt(
+        per_stack_records_paths=[tmp_path / "stack-python-records.json"],
+        intent_path=tmp_path / "intent.md",
+        alternatives_path=tmp_path / "alts.json",
+        dedup_candidates_path=tmp_path / "dedup.json",
+        output_path=tmp_path / "report.md",
+        structural_records_path=None,
+    )
+    assert "## Structural Review" not in prompt
+    assert "structural" not in prompt.lower()


### PR DESCRIPTION
## Summary

Adds an always-on `structure` meta-stack to daydream's deep-mode review pipeline. It runs a language-agnostic structural-maintainability reviewer in parallel with the per-stack language reviews, and its findings flow through the existing parse → merge → fix pipeline, surfacing in a dedicated `## Structural Review` section at the top of the merged report.

> **Cross-repo dependency:** the reviewer invokes the Beagle skill `beagle-core:review-structure`, which ships in the `beagle-core` plugin (handled in a separate Beagle change). That skill must be installed for the structural stack to run against a live backend; this PR's tests stub the backend and do not require it.

## Changes

### Added
- `STRUCTURE_SKILL` (`beagle-core:review-structure`) and `STRUCTURE_STACK_NAME` constants in `daydream/config.py` (meta-stack; intentionally NOT added to `REVIEW_SKILLS` / `SKILL_MAP` / `ReviewSkillChoice`, so the CLI surface is unchanged and `--shallow -s structure` is not selectable).
- `build_structural_prompt` in `daydream/deep/prompts.py` — repo-wide reviewer prompt with no per-stack scope restriction and no pre-injected exploration context (reviewer discovers canonical helpers via Read/Grep/Bash).
- Integration smoke test driving the deep orchestrator end-to-end through the structural stack.

### Changed
- `detect_stacks` now unconditionally emits a `structure` `StackAssignment` (files = union of all changed files), guarded to skip empty and docs-only diffs.
- `phase_per_stack_reviews` routes the `structure` stack to `build_structural_prompt`.
- `build_merge_prompt` gains a keyword-only `structural_records_path` param and instructs the merge agent to render `## Structural Review` above `## Issues` with independent numbering, explicitly NOT deduplicated against language/alternative findings.
- The orchestrator partitions structural records out of the dedup inputs and threads `structural_records_path` to the merge call (both fresh-run and `start_at="merge"` resume paths).

## Motivation

Language review skills (`review-python`, `review-react`, etc.) are calibrated for stack-specific idioms, security, and correctness — none owns structural questions a senior reviewer asks (file-size budgets, ad-hoc branching, canonical-layer leakage, magic abstractions, code-judo restructurings). Those concerns previously went uncaught or surfaced inconsistently as low-conviction side-notes. This wires in a proven structural rubric as a first-class, always-on lens in deep mode. See #98.

## Testing

- [x] Unit tests added/updated (config, detection, prompts, fanout, orchestrator)
- [x] Integration test added (`tests/test_deep_integration.py` — structural meta-stack pipeline smoke)
- [x] Manual testing performed — N/A (no new CLI surface; backend stubbed in tests)

Each task was built test-first (failing test → implement → green). Full suite green via `make check` and the pre-push hook: **985 passed**, ruff + mypy clean.

## Related Issues

- Closes #98

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally
- [x] Linting passes
- [x] Documentation updated (if needed) — N/A

---

Generated with [Claude Code](https://claude.com/claude-code)