### PR TITLE
feat(archive): capture source_path in manifest and add harvest clone cache

### DIFF
--- a/daydream/archive/__init__.py
+++ b/daydream/archive/__init__.py
@@ -138,6 +138,7 @@ def _archive_run_inner(
         evaluation = _run_eval(target_dir, recorder.session_id, run_dir)
 
     # 4. Build and write manifest
+    source_path = str(work.source) if work is not None else str(target_dir)
     manifest = build_manifest(
         recorder=recorder,
         config=config,
@@ -145,6 +146,7 @@ def _archive_run_inner(
         status=status,
         archive_path=run_dir,
         evaluation=evaluation,
+        source_path=source_path,
     )
     manifest_path = run_dir / "manifest.json"
     manifest_path.write_text(json.dumps(manifest.to_dict(), indent=2), encoding="utf-8")

--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -54,6 +54,7 @@ CREATE TABLE IF NOT EXISTS runs (
     loop INTEGER NOT NULL DEFAULT 0,
     remote_url TEXT,
     repo_slug TEXT,
+    source_path TEXT,
     branch TEXT,
     base_branch TEXT,
     head_sha TEXT,
@@ -116,7 +117,7 @@ _UPSERT_SQL = """
 INSERT OR REPLACE INTO runs (
     session_id, archived_at, status, run_flow, skill, model, backend,
     review_backend, fix_backend, test_backend,
-    review_only, deep, loop, remote_url, repo_slug, branch, base_branch,
+    review_only, deep, loop, remote_url, repo_slug, source_path, branch, base_branch,
     head_sha, base_sha, changed_files, pr_number, pr_repo, total_cost_usd, total_findings,
     grounding_rate, coverage_ratio, cost_per_finding_usd, wall_clock_seconds,
     total_prompt_tokens, total_completion_tokens, total_cached_tokens,
@@ -124,7 +125,7 @@ INSERT OR REPLACE INTO runs (
 ) VALUES (
     :session_id, :archived_at, :status, :run_flow, :skill, :model, :backend,
     :review_backend, :fix_backend, :test_backend,
-    :review_only, :deep, :loop, :remote_url, :repo_slug, :branch, :base_branch,
+    :review_only, :deep, :loop, :remote_url, :repo_slug, :source_path, :branch, :base_branch,
     :head_sha, :base_sha, :changed_files, :pr_number, :pr_repo, :total_cost_usd, :total_findings,
     :grounding_rate, :coverage_ratio, :cost_per_finding_usd, :wall_clock_seconds,
     :total_prompt_tokens, :total_completion_tokens, :total_cached_tokens,
@@ -144,6 +145,7 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
         ("base_sha", "TEXT"),
         ("changed_files", "TEXT"),
         ("composite_reward", "REAL"),
+        ("source_path", "TEXT"),
     ]
     for col, col_type in migrations:
         if col not in existing:
@@ -237,6 +239,7 @@ def upsert_run(archive_dir: Path, manifest: Manifest) -> None:
                 "loop": int(manifest.loop),
                 "remote_url": manifest.remote_url,
                 "repo_slug": manifest.repo_slug,
+                "source_path": manifest.source_path,
                 "branch": manifest.branch,
                 "base_branch": manifest.base_branch,
                 "head_sha": manifest.head_sha,

--- a/daydream/archive/manifest.py
+++ b/daydream/archive/manifest.py
@@ -47,6 +47,7 @@ class Manifest:
         review_only: Whether the run was review-only.
         deep: Whether deep review mode was used.
         loop: Whether loop mode was enabled.
+        source_path: Absolute path to the source repository at archive time.
         remote_url: Git remote origin URL.
         repo_slug: ``owner/repo`` extracted from remote URL.
         branch: Git branch name at run time.
@@ -93,6 +94,7 @@ class Manifest:
     loop: bool = False
 
     # Git context
+    source_path: str | None = None
     remote_url: str | None = None
     repo_slug: str | None = None
     branch: str | None = None
@@ -146,6 +148,7 @@ class Manifest:
                 "loop": self.loop,
             },
             "git": {
+                "source_path": self.source_path,
                 "remote_url": self.remote_url,
                 "repo_slug": self.repo_slug,
                 "branch": self.branch,
@@ -191,6 +194,7 @@ def build_manifest(
     status: str,
     archive_path: Path,
     evaluation: dict[str, Any] | None = None,
+    source_path: str | None = None,
 ) -> Manifest:
     """Construct a Manifest from run context.
 
@@ -201,6 +205,7 @@ def build_manifest(
         status: Run status (``complete``, ``partial``, ``failed``).
         archive_path: Absolute path to the archive directory for this run.
         evaluation: Optional ``analyze_session()`` result dict.
+        source_path: Absolute path to the source repository at archive time.
 
     Returns:
         A fully populated Manifest.
@@ -221,6 +226,7 @@ def build_manifest(
         review_only=config.output_mode == "review",
         deep=not config.shallow,
         loop=config.loop,
+        source_path=source_path,
         remote_url=git_ctx.remote_url,
         repo_slug=git_ctx.repo_slug,
         branch=git_ctx.branch,

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -835,6 +835,14 @@ def _build_harvest_parser() -> argparse.ArgumentParser:
         help="Override the archive root (default: daydream.archive.get_archive_dir()).",
     )
     parser.add_argument(
+        "--repo-clone-root",
+        type=Path,
+        default=None,
+        dest="repo_clone_root",
+        metavar="PATH",
+        help="Directory for cached repo clones (default: <cache-dir>/repos/).",
+    )
+    parser.add_argument(
         "--fix-applied-window-days",
         type=int,
         default=30,
@@ -888,10 +896,13 @@ def _handle_harvest_command(argv: list[str]) -> int:
     archive_dir = args.archive_dir if args.archive_dir is not None else _archive.get_archive_dir()
     cache_dir = args.cache_dir.expanduser() if args.cache_dir is not None else None
 
+    repo_clone_root = args.repo_clone_root.expanduser() if args.repo_clone_root is not None else None
+
     config = _harvest.HarvestConfig(
         archive_dir=archive_dir,
         dry_run=args.dry_run,
         cache_dir=cache_dir,
+        repo_clone_root=repo_clone_root,
         session_filter=args.session,
         fix_applied_window_days=args.fix_applied_window_days,
         gh_request_spacing_sec=args.gh_spacing_sec,

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -831,6 +831,26 @@ def fetch(repo: Path, remote: str = "origin") -> None:
         raise GitError(f"git fetch {remote} failed in {repo}: {proc.stderr.strip()}")
 
 
+def clone(remote_url: str, target: Path) -> None:
+    """Run ``git clone <remote_url> <target>`` (full clone, no ``--depth``).
+
+    Args:
+        remote_url: Remote URL or local path to clone from.
+        target: Destination directory for the new working tree.
+
+    Raises:
+        GitError: If the clone fails.
+    """
+    proc = subprocess.run(  # noqa: S603 - arguments are not user-controlled
+        ["git", "clone", remote_url, str(target)],  # noqa: S607 - git is a trusted command
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if proc.returncode != 0:
+        raise GitError(f"git clone {remote_url} failed: {proc.stderr.strip()}")
+
+
 def checkout_paths(repo: Path, paths: list[Path]) -> None:
     """Run ``git checkout -- <paths>`` to discard local changes for *paths*.
 

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -831,22 +831,33 @@ def fetch(repo: Path, remote: str = "origin") -> None:
         raise GitError(f"git fetch {remote} failed in {repo}: {proc.stderr.strip()}")
 
 
-def clone(remote_url: str, target: Path) -> None:
-    """Run ``git clone <remote_url> <target>`` (full clone, no ``--depth``).
+def clone(remote_url: str, target: Path, *, blobless: bool = False) -> None:
+    """Run ``git clone <remote_url> <target>``.
 
     Args:
         remote_url: Remote URL or local path to clone from.
         target: Destination directory for the new working tree.
+        blobless: When ``True``, pass ``--filter=blob:none`` to perform a
+            partial clone that omits blobs until they are accessed.  Reduces
+            initial transfer and storage at the cost of lazy blob fetches on
+            first access.  Requires server-side partial-clone support.
 
     Raises:
         GitError: If the clone fails.
     """
-    proc = subprocess.run(  # noqa: S603 - arguments are not user-controlled
-        ["git", "clone", remote_url, str(target)],  # noqa: S607 - git is a trusted command
-        capture_output=True,
-        text=True,
-        timeout=60,
-    )
+    cmd = ["git", "clone"]
+    if blobless:
+        cmd.append("--filter=blob:none")
+    cmd += [remote_url, str(target)]
+    try:
+        proc = subprocess.run(  # noqa: S603 - arguments are not user-controlled
+            cmd,  # noqa: S607 - git is a trusted command
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        raise GitError(f"git clone {remote_url} failed: {type(exc).__name__}: {exc}") from exc
     if proc.returncode != 0:
         raise GitError(f"git clone {remote_url} failed: {proc.stderr.strip()}")
 

--- a/daydream/training/harvest.py
+++ b/daydream/training/harvest.py
@@ -72,6 +72,7 @@ from pathlib import Path
 from typing import Any
 
 import anyio
+from rich.console import Console
 
 from daydream import git_ops
 from daydream.archive.index import append_label_observation, query_runs
@@ -91,7 +92,6 @@ from daydream.training.labeler_signals import (
 from daydream.training.reward import ScoringInputs, score_trajectory
 from daydream.training.rubric import Rubric, derive_outcome_label
 from daydream.ui import create_console, print_warning
-from rich.console import Console
 
 _VERDICTS_FILE = "recommendation-verdicts.json"
 """Bronze artifact (under ``deep/``) carrying the ``verdicts`` list."""
@@ -607,7 +607,9 @@ def _resolve_repo_for_row(
     return cached_repo
 
 
-def _materialize_base_sha_if_missing(row: dict[str, Any], run_dir: Path, repo_clone: Path | None, *, console: Console | None = None) -> None:
+def _materialize_base_sha_if_missing(
+    row: dict[str, Any], run_dir: Path, repo_clone: Path | None, *, console: Console | None = None
+) -> None:
     """Opportunistically backfill ``code_context.base_sha`` into the manifest.
 
     Only acts when ``manifest.json`` exists AND ``repo_clone`` is available.
@@ -741,7 +743,9 @@ async def run_harvest(config: HarvestConfig) -> dict[str, int]:
     for row in queue:
         try:
             run_dir = Path(row["archive_path"])
-            row_repo_clone = _resolve_repo_for_row(row, clone_cache=clone_cache, fetched_repos=fetched_repos, console=console)
+            row_repo_clone = _resolve_repo_for_row(
+                row, clone_cache=clone_cache, fetched_repos=fetched_repos, console=console
+            )
             _materialize_base_sha_if_missing(row, run_dir, repo_clone=row_repo_clone, console=console)
             payload = build_annotation(
                 row,

--- a/daydream/training/harvest.py
+++ b/daydream/training/harvest.py
@@ -546,69 +546,70 @@ def build_annotation(
 
 
 # ---------------------------------------------------------------------------
-# base_sha materialization — relocated from the exporter (plan Assumption 6).
-#
-# The only fallible git I/O that produces an immutable capture-time fact lives
-# in harvest, not build-corpus (which must be pure). build-corpus only *reads*
-# ``base_sha`` from the manifest. The exporter still calls ``materialize_base_sha``
-# until plan Task 7 retires that path, so this is a COPY of the call, not a move.
+# Repo resolution — three-tier priority: source_path → clone cache → None
 # ---------------------------------------------------------------------------
 
 
-def _resolve_repo_clone(repo_slug: str | None) -> Path | None:
-    """Best-effort discovery of a local clone for ``repo_slug``.
+def _resolve_repo_for_row(row: dict[str, Any], clone_cache: Path | None) -> Path | None:
+    """Resolve a local repo working tree for a manifest row.
 
-    ``repo_slug`` must be a full ``owner/repo`` string; slugs that do not
-    split cleanly into two non-empty parts return ``None`` to avoid
-    materializing a ``base_sha`` from an ambiguous clone. Probes the standard
-    developer layouts in order (bare-name first, owner-qualified as fallback);
-    the first path whose ``.git`` directory exists wins.
+    Priority:
+        1. ``row["source_path"]`` when it exists on disk with a ``.git`` dir.
+        2. Clone cache: ``clone_cache/<owner>/<repo>/`` — fetch if present, clone if not.
+        3. ``None`` when no source is available.
+
+    Clone/fetch failures are caught and logged; they never block harvest.
 
     Args:
-        repo_slug: ``owner/repo`` string from the manifest row, or ``None``.
+        row: An indexed manifest row (supplies ``source_path``, ``remote_url``, ``repo_slug``).
+        clone_cache: Root directory for cached clones, or ``None`` to skip cloning.
 
     Returns:
-        Path to a working tree containing ``.git``, or ``None`` when
-        ``repo_slug`` is missing/malformed or no candidate is on disk.
+        Path to a usable working tree, or ``None``.
     """
-    if not isinstance(repo_slug, str) or not repo_slug:
+    source_path = row.get("source_path")
+    if source_path and (Path(source_path) / ".git").exists():
+        return Path(source_path)
+
+    remote_url = row.get("remote_url")
+    repo_slug = row.get("repo_slug")
+    if not remote_url or not repo_slug or clone_cache is None:
         return None
+
     parts = repo_slug.split("/", 1)
-    if len(parts) != 2:
+    if len(parts) != 2 or not parts[0] or not parts[1]:
         return None
-    owner, repo_name = parts
-    if not owner or not repo_name:
-        return None
-    home = Path.home()
-    candidates = (
-        home / repo_name,
-        home / "github" / repo_name,
-        home / "code" / repo_name,
-        home / "github" / owner / repo_name,
-        home / "code" / owner / repo_name,
-    )
-    for candidate in candidates:
-        if (candidate / ".git").exists():
-            return candidate
-    return None
+
+    cached_repo = clone_cache / parts[0] / parts[1]
+    try:
+        if (cached_repo / ".git").exists():
+            git_ops.fetch(cached_repo)
+        else:
+            git_ops.clone(remote_url, cached_repo)
+    except (GitError, OSError) as exc:
+        print_warning(
+            create_console(),
+            f"harvest: repo resolution failed for {repo_slug}: {type(exc).__name__}: {exc}",
+        )
+        if not (cached_repo / ".git").exists():
+            return None
+    return cached_repo
 
 
-def _materialize_base_sha_if_missing(row: dict[str, Any], run_dir: Path) -> None:
+def _materialize_base_sha_if_missing(row: dict[str, Any], run_dir: Path, repo_clone: Path | None) -> None:
     """Opportunistically backfill ``code_context.base_sha`` into the manifest.
 
-    Mirrors the relocated exporter block: only when ``manifest.json`` exists
-    AND a clone of the row's ``repo_slug`` is discoverable on disk. Any failure
-    is swallowed (opportunistic), leaving ``base_sha`` as ``None``; it never
-    raises and never blocks the harvest of the row.
+    Only acts when ``manifest.json`` exists AND ``repo_clone`` is available.
+    Any failure is swallowed (opportunistic), leaving ``base_sha`` as ``None``.
 
     Args:
-        row: The indexed manifest row (supplies ``repo_slug``).
+        row: The indexed manifest row.
         run_dir: The archived run directory (holds ``manifest.json``).
+        repo_clone: Resolved repo working tree, or ``None``.
     """
     manifest_path = run_dir / "manifest.json"
     if not manifest_path.exists():
         return
-    repo_clone = _resolve_repo_clone(row.get("repo_slug"))
     if repo_clone is None:
         return
     try:
@@ -712,7 +713,7 @@ async def run_harvest(config: HarvestConfig) -> dict[str, int]:
         done = cache.completed_sessions()
         queue = [row for row in queue if row["session_id"] not in done]
 
-    repo_clone_fallback = config.repo_clone_root or config.archive_dir
+    clone_cache = config.repo_clone_root or (config.cache_dir / "repos" if config.cache_dir else None)
 
     summary = {
         "considered": len(queue),
@@ -727,13 +728,13 @@ async def run_harvest(config: HarvestConfig) -> dict[str, int]:
     for row in queue:
         try:
             run_dir = Path(row["archive_path"])
-            _materialize_base_sha_if_missing(row, run_dir)
-            row_repo_clone = _resolve_repo_clone(row.get("repo_slug")) or repo_clone_fallback
+            row_repo_clone = _resolve_repo_for_row(row, clone_cache=clone_cache)
+            _materialize_base_sha_if_missing(row, run_dir, repo_clone=row_repo_clone)
             payload = build_annotation(
                 row,
                 run_dir=run_dir,
                 gh_api=gh_api_callable,
-                repo_clone=row_repo_clone,
+                repo_clone=row_repo_clone or config.archive_dir,
                 window_days=config.fix_applied_window_days,
             )
             if config.dry_run:

--- a/daydream/training/harvest.py
+++ b/daydream/training/harvest.py
@@ -91,6 +91,7 @@ from daydream.training.labeler_signals import (
 from daydream.training.reward import ScoringInputs, score_trajectory
 from daydream.training.rubric import Rubric, derive_outcome_label
 from daydream.ui import create_console, print_warning
+from rich.console import Console
 
 _VERDICTS_FILE = "recommendation-verdicts.json"
 """Bronze artifact (under ``deep/``) carrying the ``verdicts`` list."""
@@ -550,7 +551,13 @@ def build_annotation(
 # ---------------------------------------------------------------------------
 
 
-def _resolve_repo_for_row(row: dict[str, Any], clone_cache: Path | None) -> Path | None:
+def _resolve_repo_for_row(
+    row: dict[str, Any],
+    clone_cache: Path | None,
+    *,
+    fetched_repos: set[Path] | None = None,
+    console: Console | None = None,
+) -> Path | None:
     """Resolve a local repo working tree for a manifest row.
 
     Priority:
@@ -583,12 +590,16 @@ def _resolve_repo_for_row(row: dict[str, Any], clone_cache: Path | None) -> Path
     cached_repo = clone_cache / parts[0] / parts[1]
     try:
         if (cached_repo / ".git").exists():
-            git_ops.fetch(cached_repo)
+            if fetched_repos is None or cached_repo not in fetched_repos:
+                git_ops.fetch(cached_repo)
+                if fetched_repos is not None:
+                    fetched_repos.add(cached_repo)
         else:
-            git_ops.clone(remote_url, cached_repo)
+            cached_repo.parent.mkdir(parents=True, exist_ok=True)
+            git_ops.clone(remote_url, cached_repo, blobless=True)
     except (GitError, OSError) as exc:
         print_warning(
-            create_console(),
+            console or create_console(),
             f"harvest: repo resolution failed for {repo_slug}: {type(exc).__name__}: {exc}",
         )
         if not (cached_repo / ".git").exists():
@@ -596,7 +607,7 @@ def _resolve_repo_for_row(row: dict[str, Any], clone_cache: Path | None) -> Path
     return cached_repo
 
 
-def _materialize_base_sha_if_missing(row: dict[str, Any], run_dir: Path, repo_clone: Path | None) -> None:
+def _materialize_base_sha_if_missing(row: dict[str, Any], run_dir: Path, repo_clone: Path | None, *, console: Console | None = None) -> None:
     """Opportunistically backfill ``code_context.base_sha`` into the manifest.
 
     Only acts when ``manifest.json`` exists AND ``repo_clone`` is available.
@@ -616,7 +627,7 @@ def _materialize_base_sha_if_missing(row: dict[str, Any], run_dir: Path, repo_cl
         materialize_base_sha(manifest_path, repo_clone=repo_clone)
     except (OSError, json.JSONDecodeError, GitError) as exc:
         print_warning(
-            create_console(),
+            console or create_console(),
             f"harvest: base_sha backfill failed for {manifest_path}: {type(exc).__name__}: {exc}",
         )
 
@@ -640,8 +651,9 @@ class HarvestConfig:
             :class:`~daydream.training.backfill_cache.BackfillCache`. When
             ``None``, ``gh_api`` calls hit the network on every row.
         repo_clone_root: Optional root under which per-repo clones live (used
-            by the fix-applied / local-commit cascades). Falls back to the
-            archive root when unset.
+            by the fix-applied / local-commit cascades). Falls back to
+            ``cache_dir / 'repos'`` when unset (or ``None`` if ``cache_dir``
+            is also unset).
         session_filter: Optional ``session_id`` prefix to restrict the queue.
         fix_applied_window_days: Lookback window for upstream commits
             considered by the fix-applied cascade.
@@ -714,6 +726,7 @@ async def run_harvest(config: HarvestConfig) -> dict[str, int]:
         queue = [row for row in queue if row["session_id"] not in done]
 
     clone_cache = config.repo_clone_root or (config.cache_dir / "repos" if config.cache_dir else None)
+    fetched_repos: set[Path] = set()
 
     summary = {
         "considered": len(queue),
@@ -728,8 +741,8 @@ async def run_harvest(config: HarvestConfig) -> dict[str, int]:
     for row in queue:
         try:
             run_dir = Path(row["archive_path"])
-            row_repo_clone = _resolve_repo_for_row(row, clone_cache=clone_cache)
-            _materialize_base_sha_if_missing(row, run_dir, repo_clone=row_repo_clone)
+            row_repo_clone = _resolve_repo_for_row(row, clone_cache=clone_cache, fetched_repos=fetched_repos, console=console)
+            _materialize_base_sha_if_missing(row, run_dir, repo_clone=row_repo_clone, console=console)
             payload = build_annotation(
                 row,
                 run_dir=run_dir,

--- a/scripts/zip-review.sh
+++ b/scripts/zip-review.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Zips the most recent daydream review run (trajectory + review-output.md) for sharing on Slack.
+#
+# Usage:
+#   zip-review.sh <daydream-dir> [branch-name]
+#
+# Examples:
+#   zip-review.sh /Users/ka/ro/mono-daydream-review/.daydream gsadalgekar/fix-cancel-future-shipments-crm
+#   zip-review.sh /Users/ka/.daydream/archive
+#   zip-review.sh .daydream  # relative path works too
+
+DAYDREAM_DIR="${1:?Usage: zip-review.sh <daydream-dir> [branch-name]}"
+BRANCH_NAME="${2:-}"
+
+# Resolve to absolute path
+DAYDREAM_DIR="$(cd "$DAYDREAM_DIR" && pwd)"
+
+# Find the runs directory
+RUNS_DIR=""
+for candidate in "$DAYDREAM_DIR/runs" "$DAYDREAM_DIR"; do
+  if [ -d "$candidate" ] && ls "$candidate"/*/trajectory.json &>/dev/null; then
+    RUNS_DIR="$candidate"
+    break
+  fi
+done
+
+if [ -z "$RUNS_DIR" ]; then
+  echo "Error: no runs with trajectory.json found under $DAYDREAM_DIR" >&2
+  exit 1
+fi
+
+# Get most recent run (by modification time)
+LATEST_RUN="$(ls -dt "$RUNS_DIR"/*/ | head -1)"
+LATEST_RUN="${LATEST_RUN%/}"
+RUN_ID="$(basename "$LATEST_RUN")"
+
+echo "Latest run: $RUN_ID ($(stat -f '%Sm' -t '%Y-%m-%d %H:%M' "$LATEST_RUN"))"
+
+# Derive a zip filename from branch name or run ID
+if [ -z "$BRANCH_NAME" ]; then
+  # Try to get branch from manifest.json
+  if [ -f "$LATEST_RUN/manifest.json" ]; then
+    BRANCH_NAME="$(python3 -c "import json; print(json.load(open('$LATEST_RUN/manifest.json'))['git']['branch'])" 2>/dev/null || true)"
+  fi
+  # Try git in the target dir
+  if [ -z "$BRANCH_NAME" ]; then
+    TARGET_DIR="$(python3 -c "
+import json, sys
+for f in ['$LATEST_RUN/trajectory.json', '$LATEST_RUN/manifest.json']:
+    try:
+        d = json.load(open(f))
+        td = d.get('extra', {}).get('target_dir') or d.get('git', {}).get('branch')
+        if td: print(td); sys.exit()
+    except: pass
+" 2>/dev/null || true)"
+    if [ -n "$TARGET_DIR" ] && [ -d "$TARGET_DIR" ]; then
+      BRANCH_NAME="$(git -C "$TARGET_DIR" branch --show-current 2>/dev/null || true)"
+    fi
+  fi
+fi
+
+if [ -n "$BRANCH_NAME" ]; then
+  # Sanitize branch name for filename: take last segment after /, replace non-alnum with -
+  ZIP_STEM="$(echo "$BRANCH_NAME" | sed 's|.*/||' | sed 's/[^a-zA-Z0-9._-]/-/g')"
+else
+  ZIP_STEM="$RUN_ID"
+fi
+
+ZIP_FILE="${ZIP_STEM}.zip"
+echo "Output: $ZIP_FILE"
+
+# Collect files to zip
+FILES_TO_ZIP=()
+
+# Always include the run directory (trajectory + sub-trajectories)
+FILES_TO_ZIP+=("$LATEST_RUN")
+
+# Find review-output.md — check run dir first, then deep/ at daydream level
+REVIEW_OUTPUT=""
+for candidate in \
+  "$LATEST_RUN/review-output.md" \
+  "$LATEST_RUN/deep/review-output.md" \
+  "$DAYDREAM_DIR/deep/review-output.md"; do
+  if [ -f "$candidate" ]; then
+    REVIEW_OUTPUT="$candidate"
+    break
+  fi
+done
+
+if [ -n "$REVIEW_OUTPUT" ]; then
+  # Only add if it's not already inside the run dir
+  case "$REVIEW_OUTPUT" in
+    "$LATEST_RUN"/*) ;;  # already included
+    *) FILES_TO_ZIP+=("$REVIEW_OUTPUT") ;;
+  esac
+  echo "Included review-output.md: $REVIEW_OUTPUT"
+else
+  echo "Warning: no review-output.md found" >&2
+fi
+
+# Create zip
+zip -r "$ZIP_FILE" "${FILES_TO_ZIP[@]}"
+echo ""
+echo "Done: $(du -h "$ZIP_FILE" | cut -f1) $ZIP_FILE"

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -733,6 +733,42 @@ def test_latest_label_observation_filtered_by_as_of(tmp_path: Path) -> None:
     assert json.loads(pinned["labels"]) == ["unknown"]
 
 
+def test_manifest_includes_source_path():
+    """source_path appears in manifest dict under git section."""
+    m = Manifest(
+        session_id="test-session",
+        source_path="/home/user/code/myrepo",
+        remote_url="git@github.com:org/repo.git",
+        repo_slug="org/repo",
+    )
+    d = m.to_dict()
+    assert d["git"]["source_path"] == "/home/user/code/myrepo"
+
+
+def test_source_path_indexed_in_sqlite(tmp_path: Path):
+    """source_path round-trips through upsert_run → query_runs."""
+    idx_dir = tmp_path / "idx"
+    idx_dir.mkdir()
+    m = Manifest(
+        session_id="sp-test",
+        archived_at="2026-01-01T00:00:00Z",
+        run_flow="normal",
+        backend="claude",
+        source_path="/original/repo/path",
+        archive_path=str(tmp_path),
+    )
+    upsert_run(idx_dir, m)
+    rows = query_runs(idx_dir)
+    assert rows[0]["source_path"] == "/original/repo/path"
+
+
+def test_source_path_defaults_to_none():
+    """Old manifests without source_path still work."""
+    m = Manifest(session_id="old")
+    assert m.source_path is None
+    assert m.to_dict()["git"]["source_path"] is None
+
+
 def test_update_labels_is_backward_compat_thin_wrapper(tmp_path: Path) -> None:
     """The legacy update_labels() now writes through append_label_observation
     so existing callers continue to work without source changes."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -387,6 +387,24 @@ def test_harvest_and_build_corpus_dispatch(monkeypatch, tmp_path):
     assert "harvest" in called
 
 
+def test_harvest_parser_accepts_repo_clone_root():
+    """--repo-clone-root is parsed and forwarded to HarvestConfig."""
+    from daydream.cli import _build_harvest_parser
+
+    parser = _build_harvest_parser()
+    args = parser.parse_args(["--repo-clone-root", "/tmp/clones"])
+    assert args.repo_clone_root == Path("/tmp/clones")
+
+
+def test_harvest_parser_repo_clone_root_defaults_to_none():
+    """--repo-clone-root defaults to None (derived from cache_dir at runtime)."""
+    from daydream.cli import _build_harvest_parser
+
+    parser = _build_harvest_parser()
+    args = parser.parse_args([])
+    assert args.repo_clone_root is None
+
+
 def test_removed_verbs_no_longer_dispatch():
     from daydream import cli
     # label / export-jsonl / snapshot handlers are gone

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -731,3 +731,30 @@ def test_gh_pr_view_includes_pr_arg_when_given(
     assert result == {"number": 42}
     cmd = captured["cmd"]
     assert cmd[:4] == ["gh", "pr", "view", "42"]
+
+
+# --- clone -------------------------------------------------------------------
+
+
+def _make_bare_remote(tmp_path: Path) -> Path:
+    """Create a bare remote repo with one committed file."""
+    repo = _make_repo_with_main(tmp_path / "src")
+    bare = tmp_path / "bare.git"
+    subprocess.run(["git", "clone", "--bare", str(repo), str(bare)], check=True, capture_output=True)  # noqa: S603, S607 - arguments are not user-controlled
+    return bare
+
+
+def test_clone_creates_working_tree(tmp_path: Path) -> None:
+    """clone() creates a functional git working tree from a bare remote."""
+    bare = _make_bare_remote(tmp_path)
+    target = tmp_path / "cloned"
+    git_ops.clone(str(bare), target)
+    assert (target / ".git").is_dir()
+    assert (target / "base.txt").read_text() == "base\n"
+
+
+def test_clone_raises_on_invalid_remote(tmp_path: Path) -> None:
+    """clone() raises GitError when the remote URL is invalid."""
+    target = tmp_path / "nope"
+    with pytest.raises(git_ops.GitError, match="git clone .* failed"):
+        git_ops.clone("file:///nonexistent/repo.git", target)

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -758,3 +758,31 @@ def test_clone_raises_on_invalid_remote(tmp_path: Path) -> None:
     target = tmp_path / "nope"
     with pytest.raises(git_ops.GitError, match="git clone .* failed"):
         git_ops.clone("file:///nonexistent/repo.git", target)
+
+
+def test_clone_blobless_passes_filter_flag(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """clone(blobless=True) includes --filter=blob:none in the git invocation."""
+    captured: dict[str, list[str]] = {}
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("daydream.git_ops.subprocess.run", fake_run)
+
+    git_ops.clone("https://example.com/repo.git", tmp_path / "out", blobless=True)
+    assert "--filter=blob:none" in captured["cmd"]
+
+
+def test_clone_default_no_filter_flag(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """clone() without blobless does not pass --filter."""
+    captured: dict[str, list[str]] = {}
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("daydream.git_ops.subprocess.run", fake_run)
+
+    git_ops.clone("https://example.com/repo.git", tmp_path / "out")
+    assert "--filter=blob:none" not in captured["cmd"]

--- a/tests/test_training_harvest.py
+++ b/tests/test_training_harvest.py
@@ -10,6 +10,7 @@ import pytest
 
 from daydream.archive.index import label_observation_history, latest_label_observation, upsert_run
 from daydream.archive.manifest import Manifest
+from daydream.git_ops import GitError
 from daydream.training.harvest import (
     HarvestConfig,
     _resolve_repo_for_row,
@@ -180,7 +181,7 @@ def test_resolve_repo_for_row_clones_when_source_path_missing(tmp_path: Path, mo
     """Falls through to clone when source_path is absent."""
     cache = tmp_path / "cache"
 
-    def fake_clone(url: str, target: Path) -> None:
+    def fake_clone(url: str, target: Path, **kwargs: object) -> None:
         target.mkdir(parents=True, exist_ok=True)
         (target / ".git").mkdir()
 
@@ -211,3 +212,32 @@ def test_resolve_repo_for_row_returns_none_when_no_remote(tmp_path: Path):
     row = {"source_path": None, "remote_url": None, "repo_slug": None}
     result = _resolve_repo_for_row(row, clone_cache=tmp_path / "cache")
     assert result is None
+
+
+def test_resolve_repo_for_row_clone_failure_returns_none(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Clone failure is swallowed and None is returned (no .git left on disk)."""
+    cache = tmp_path / "cache"
+
+    monkeypatch.setattr(
+        "daydream.training.harvest.git_ops.clone",
+        lambda url, target, **kwargs: (_ for _ in ()).throw(GitError("network error")),
+    )
+    row = {"source_path": None, "remote_url": "https://github.com/org/repo.git", "repo_slug": "org/repo"}
+    result = _resolve_repo_for_row(row, clone_cache=cache)
+    assert result is None
+
+
+def test_resolve_repo_for_row_fetch_failure_returns_cached_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Fetch failure is swallowed and the existing cached repo path is returned."""
+    cache = tmp_path / "cache"
+    cached_repo = cache / "org" / "repo"
+    cached_repo.mkdir(parents=True)
+    (cached_repo / ".git").mkdir()
+
+    monkeypatch.setattr(
+        "daydream.training.harvest.git_ops.fetch",
+        lambda repo, remote="origin": (_ for _ in ()).throw(GitError("fetch failed")),
+    )
+    row = {"source_path": None, "remote_url": "https://github.com/org/repo.git", "repo_slug": "org/repo"}
+    result = _resolve_repo_for_row(row, clone_cache=cache)
+    assert result == cached_repo

--- a/tests/test_training_harvest.py
+++ b/tests/test_training_harvest.py
@@ -6,10 +6,13 @@ import json
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from daydream.archive.index import label_observation_history, latest_label_observation, upsert_run
 from daydream.archive.manifest import Manifest
 from daydream.training.harvest import (
     HarvestConfig,
+    _resolve_repo_for_row,
     assemble_scoring_inputs,
     build_annotation,
     run_harvest,
@@ -156,3 +159,55 @@ async def test_re_harvest_appends_new_generation(tmp_path, archive_dir, monkeypa
     await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c1"))
     await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c2"))
     assert len(label_observation_history(archive_dir, "s1")) == 2  # append-only, re-runnable
+
+
+# ---------------------------------------------------------------------------
+# _resolve_repo_for_row
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_repo_for_row_prefers_source_path(tmp_path: Path):
+    """source_path is preferred when it exists and contains .git."""
+    source = tmp_path / "source_repo"
+    source.mkdir()
+    (source / ".git").mkdir()
+    row = {"source_path": str(source), "remote_url": "https://github.com/org/repo.git", "repo_slug": "org/repo"}
+    result = _resolve_repo_for_row(row, clone_cache=tmp_path / "cache")
+    assert result == source
+
+
+def test_resolve_repo_for_row_clones_when_source_path_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Falls through to clone when source_path is absent."""
+    cache = tmp_path / "cache"
+
+    def fake_clone(url: str, target: Path) -> None:
+        target.mkdir(parents=True, exist_ok=True)
+        (target / ".git").mkdir()
+
+    monkeypatch.setattr("daydream.training.harvest.git_ops.clone", fake_clone)
+    row = {"source_path": None, "remote_url": "https://github.com/org/repo.git", "repo_slug": "org/repo"}
+    result = _resolve_repo_for_row(row, clone_cache=cache)
+    assert result == cache / "org" / "repo"
+
+
+def test_resolve_repo_for_row_fetches_existing_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """When the cache clone already exists, fetch instead of clone."""
+    cache = tmp_path / "cache"
+    cached_repo = cache / "org" / "repo"
+    cached_repo.mkdir(parents=True)
+    (cached_repo / ".git").mkdir()
+
+    fetched = []
+    monkeypatch.setattr("daydream.training.harvest.git_ops.fetch", lambda repo, remote="origin": fetched.append(repo))
+    monkeypatch.setattr("daydream.training.harvest.git_ops.clone", lambda *a, **k: pytest.fail("should not clone"))
+    row = {"source_path": None, "remote_url": "https://github.com/org/repo.git", "repo_slug": "org/repo"}
+    result = _resolve_repo_for_row(row, clone_cache=cache)
+    assert result == cached_repo
+    assert fetched == [cached_repo]
+
+
+def test_resolve_repo_for_row_returns_none_when_no_remote(tmp_path: Path):
+    """Returns None when neither source_path nor remote_url is available."""
+    row = {"source_path": None, "remote_url": None, "repo_slug": None}
+    result = _resolve_repo_for_row(row, clone_cache=tmp_path / "cache")
+    assert result is None


### PR DESCRIPTION
## Summary

Record the original source repository path (`source_path`) in archive manifests and the SQLite index so harvest can resolve repo context without probing developer home directories. Replace the hardcoded `~/github` / `~/code` probe cascade with a three-tier resolution: `source_path` on disk → clone cache → `None`. Add `git clone()` to `git_ops` with optional blobless partial-clone support.

## Changes

### Added
- `source_path` field on `Manifest` dataclass, serialized under `git` section and indexed in SQLite
- `git_ops.clone()` function with `blobless: bool` flag for `--filter=blob:none` partial clones
- `--repo-clone-root` CLI flag for harvest to control where cached clones live
- `_resolve_repo_for_row()` in harvest — three-tier repo resolution (source_path → clone cache → None)
- `scripts/zip-review.sh` utility for packaging review runs into a zip for sharing
- Tests for all new code paths (archive, cli, git_ops, harvest)

### Changed
- `_materialize_base_sha_if_missing()` now accepts an explicit `repo_clone` arg instead of probing internally
- Harvest clone cache default changed from `archive_dir` to `cache_dir/repos/` (or `None` if no cache_dir)
- `_resolve_repo_clone()` removed — replaced by `_resolve_repo_for_row()` which is deterministic (no home dir probing)

### Removed
- Hardcoded `~/github`, `~/code`, `~/github/owner/repo` probe cascade in `_resolve_repo_clone()`

## Motivation

The old `_resolve_repo_clone()` probed `~/github/<repo>`, `~/code/<repo>`, etc. — a heuristic that breaks on CI, containers, and machines with non-standard layouts. Recording `source_path` at archive time gives harvest an authoritative pointer to the original repo, and the clone cache provides a deterministic fallback for machines that never had the repo checked out locally.

## Testing

- [x] Unit tests added for `source_path` in manifest, SQLite round-trip, and default `None`
- [x] Unit tests added for `git_ops.clone()` (real clone, invalid remote, blobless flag, default no-filter)
- [x] Unit tests added for `_resolve_repo_for_row()` (source_path preferred, clone fallback, fetch existing, no remote, clone failure, fetch failure)
- [x] Unit tests added for `--repo-clone-root` CLI parsing

## Related Issues

- Closes #105

---

Generated with [Claude Code](https://claude.com/claude-code)