### PR TITLE
feat(pr-comment): add per-phase wall-clock latency to metrics

### DIFF
--- a/daydream/pr_comment_renderer.py
+++ b/daydream/pr_comment_renderer.py
@@ -100,6 +100,15 @@ class _PhaseAgg:
     then renders ``—`` per M6.
 
     Attributes:
+        phase_key: Identifier for the phase these totals belong to.
+        steps: Number of steps recorded in this phase.
+        tool_calls: Number of tool calls made during this phase.
+        input_tokens: Total input tokens consumed by this phase.
+        cached_tokens: Total cached input tokens consumed by this phase.
+        output_tokens: Total output tokens produced by this phase.
+        cost_usd: Accumulated cost in USD for this phase.
+        cost_unknown: True if any step ran on a model that cannot be priced.
+        models: Set of model names that ran steps in this phase.
         first_timestamp: ISO-8601 timestamp of the earliest step in this phase.
         last_timestamp: ISO-8601 timestamp of the latest step in this phase.
     """

--- a/daydream/pr_comment_renderer.py
+++ b/daydream/pr_comment_renderer.py
@@ -245,9 +245,9 @@ def _aggregate(trajectories: list[Trajectory]) -> _RunAgg:
             phase = _ensure_phase(agg, phase_key)
             # Track timestamps from ALL sources (user + agent) for latency.
             if step.timestamp:
-                if phase.first_timestamp is None or step.timestamp < phase.first_timestamp:
+                if phase.first_timestamp is None or _parse_ts(step.timestamp) < _parse_ts(phase.first_timestamp):
                     phase.first_timestamp = step.timestamp
-                if phase.last_timestamp is None or step.timestamp > phase.last_timestamp:
+                if phase.last_timestamp is None or _parse_ts(step.timestamp) > _parse_ts(phase.last_timestamp):
                     phase.last_timestamp = step.timestamp
             if step.source != "agent":
                 continue

--- a/daydream/pr_comment_renderer.py
+++ b/daydream/pr_comment_renderer.py
@@ -98,6 +98,10 @@ class _PhaseAgg:
     true if any step in this phase ran on a model we cannot price (no
     ``cost_usd`` from the backend AND not in MODEL_PRICES); the table cell
     then renders ``—`` per M6.
+
+    Attributes:
+        first_timestamp: ISO-8601 timestamp of the earliest step in this phase.
+        last_timestamp: ISO-8601 timestamp of the latest step in this phase.
     """
 
     phase_key: str

--- a/daydream/pr_comment_renderer.py
+++ b/daydream/pr_comment_renderer.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
+from datetime import datetime
 from pathlib import Path
 
 import daydream
@@ -63,6 +64,31 @@ FALLBACK_NOTE = "*run details unavailable*"
 _GENERIC_MODEL_LABELS: frozenset[str] = frozenset({"claude", "codex", ""})
 
 
+def _parse_ts(ts: str) -> datetime:
+    """Parse an ATIF ISO 8601 timestamp (Z-suffix) to a timezone-aware datetime."""
+    return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+
+def _format_duration(seconds: float | None) -> str:
+    """Format a duration for display in the PR comment.
+
+    Returns '—' when timing data is unavailable.
+    """
+    if seconds is None:
+        return "—"
+    if seconds < 1:
+        return "<1s"
+    total = int(seconds)
+    if total < 60:
+        return f"{total}s"
+    if total < 3600:
+        m, s = divmod(total, 60)
+        return f"{m}m {s}s" if s else f"{m}m"
+    h, remainder = divmod(total, 3600)
+    m = remainder // 60
+    return f"{h}h {m}m" if m else f"{h}h"
+
+
 @dataclass
 class _PhaseAgg:
     """Per-phase running totals.
@@ -83,6 +109,14 @@ class _PhaseAgg:
     cost_usd: float = 0.0
     cost_unknown: bool = False
     models: set[str] = field(default_factory=set)
+    first_timestamp: str | None = None
+    last_timestamp: str | None = None
+
+    @property
+    def duration_s(self) -> float | None:
+        if self.first_timestamp is None or self.last_timestamp is None:
+            return None
+        return (_parse_ts(self.last_timestamp) - _parse_ts(self.first_timestamp)).total_seconds()
 
 
 @dataclass
@@ -126,6 +160,14 @@ class _RunAgg:
         for p in self.phases.values():
             all_m.update(p.models)
         return all_m
+
+    @property
+    def total_duration_s(self) -> float | None:
+        firsts = [p.first_timestamp for p in self.phases.values() if p.first_timestamp]
+        lasts = [p.last_timestamp for p in self.phases.values() if p.last_timestamp]
+        if not firsts or not lasts:
+            return None
+        return (_parse_ts(max(lasts)) - _parse_ts(min(firsts))).total_seconds()
 
 
 def render_run_info_block(trajectory_paths: list[Path]) -> str:
@@ -197,12 +239,18 @@ def _aggregate(trajectories: list[Trajectory]) -> _RunAgg:
     for traj in trajectories:
         agent_default_model = traj.agent.model_name
         for step in traj.steps:
-            if step.source != "agent":
-                continue
             phase_key = _phase_key_of(step)
             if phase_key is None:
                 continue
             phase = _ensure_phase(agg, phase_key)
+            # Track timestamps from ALL sources (user + agent) for latency.
+            if step.timestamp:
+                if phase.first_timestamp is None or step.timestamp < phase.first_timestamp:
+                    phase.first_timestamp = step.timestamp
+                if phase.last_timestamp is None or step.timestamp > phase.last_timestamp:
+                    phase.last_timestamp = step.timestamp
+            if step.source != "agent":
+                continue
             phase.steps += 1
             phase.tool_calls += len(step.tool_calls or [])
             effective_model = step.model_name or agent_default_model
@@ -309,6 +357,7 @@ def _render_rollup(agg: _RunAgg) -> list[str]:
         f"- **Cost:** {_rollup_cost(agg)}",
         f"- **Tokens:** {_rollup_tokens(agg)}",
         f"- **Steps / tool calls:** {_format_int(agg.total_steps)} / {_format_int(agg.total_tools)}",
+        f"- **Duration:** {_format_duration(agg.total_duration_s)}",
     ]
 
 
@@ -362,8 +411,8 @@ def _render_phase_table(agg: _RunAgg) -> list[str]:
     rows: list[str] = [
         "<details><summary>Per-phase breakdown</summary>",
         "",
-        "| Phase | Model | Tools | Input (cached) | Output | Cost |",
-        "|---|---|---|---|---|---|",
+        "| Phase | Model | Tools | Input (cached) | Output | Cost | Latency |",
+        "|---|---|---|---|---|---|---|",
     ]
     # Preserve dict insertion order: _ensure_phase inserts each phase on
     # first encounter, so dict order already matches traversal order. Per-
@@ -392,10 +441,11 @@ def _render_phase_row(phase: _PhaseAgg) -> str:
         input_cell = f"{_format_int(phase.input_tokens)} ({pct})"
     else:
         input_cell = _format_int(phase.input_tokens)
+    latency_cell = _format_duration(phase.duration_s)
     return (
         f"| {label} | {model_cell} | {_format_int(phase.tool_calls)} | "
         f"{input_cell} | {_format_int(phase.output_tokens)} | "
-        f"{cost_cell} |"
+        f"{cost_cell} | {latency_cell} |"
     )
 
 

--- a/tests/test_pr_comment_renderer.py
+++ b/tests/test_pr_comment_renderer.py
@@ -12,7 +12,7 @@ import re
 from pathlib import Path
 from typing import Any
 
-from daydream.pr_comment_renderer import _PHASE_LABELS, render_run_info_block
+from daydream.pr_comment_renderer import _PHASE_LABELS, _format_duration, render_run_info_block
 from daydream.trajectory import DaydreamPhase
 
 # Fixture trajectory files committed under tests/fixtures/trajectories/.
@@ -577,7 +577,9 @@ def test_e2e_unknown_model_emits_named_footnote() -> None:
     rows = [line for line in out.splitlines() if line.startswith("| ") and "|" in line[2:]]
     phase_rows = [r for r in rows if not r.startswith("| Phase |") and not r.startswith("|---")]
     for row in phase_rows:
-        assert row.rstrip().endswith("| — |")
+        cells = [c.strip() for c in row.strip("|").split("|")]
+        # Columns: Phase, Model, Tools, Input (cached), Output, Cost, Latency
+        assert cells[5] == "—", f"Cost cell should be '—' for unknown model: {row!r}"
     # Footnote names the unknown model with backticks.
     assert "<sub>Cost unavailable: model `gpt-6.0-experimental` is not in the price table.</sub>" in out
 
@@ -779,6 +781,105 @@ def test_step_model_falls_back_to_root_agent_model(tmp_path: Path) -> None:
     assert cells[2] == "gpt-5.5"
     # No 'unknown model' footnote, since the fallback resolved to a priced model.
     assert "not in the price table" not in out
+
+
+# ---------------------------------------------------------------------------
+# Duration formatting
+# ---------------------------------------------------------------------------
+def test_format_duration_none_renders_dash() -> None:
+    assert _format_duration(None) == "—"
+
+
+def test_format_duration_sub_second() -> None:
+    assert _format_duration(0.0) == "<1s"
+    assert _format_duration(0.5) == "<1s"
+    assert _format_duration(0.999) == "<1s"
+
+
+def test_format_duration_seconds() -> None:
+    assert _format_duration(1.0) == "1s"
+    assert _format_duration(30.0) == "30s"
+    assert _format_duration(59.9) == "59s"
+
+
+def test_format_duration_minutes() -> None:
+    assert _format_duration(60.0) == "1m"
+    assert _format_duration(61.0) == "1m 1s"
+    assert _format_duration(150.0) == "2m 30s"
+    assert _format_duration(3599.0) == "59m 59s"
+
+
+def test_format_duration_hours() -> None:
+    assert _format_duration(3600.0) == "1h"
+    assert _format_duration(3660.0) == "1h 1m"
+    assert _format_duration(7200.0) == "2h"
+    assert _format_duration(7380.0) == "2h 3m"
+
+
+# ---------------------------------------------------------------------------
+# Duration in rollup and phase table
+# ---------------------------------------------------------------------------
+def test_duration_in_rollup() -> None:
+    """Rollup must include a Duration line derived from step timestamps."""
+    out = render_run_info_block([_SINGLE_PHASE])
+    assert "- **Duration:** 1s" in out
+
+
+def test_latency_column_in_phase_table() -> None:
+    """Per-phase breakdown must include a Latency column with per-phase durations."""
+    out = render_run_info_block([_MULTI_PHASE_CLAUDE])
+    assert "| Latency |" in out
+    # Each phase spans exactly 1 second in the fixture.
+    review_row = next(line for line in out.splitlines() if line.startswith("| Review |"))
+    assert review_row.rstrip().endswith("| 1s |")
+    fix_row = next(line for line in out.splitlines() if line.startswith("| Fix |"))
+    assert fix_row.rstrip().endswith("| 1s |")
+    # Total duration across all 4 phases: 00:00:00 to 00:00:07 = 7s.
+    assert "- **Duration:** 7s" in out
+
+
+def test_duration_degrades_gracefully(tmp_path: Path) -> None:
+    """Duration renders '—' when step timestamps are absent."""
+    p = _write_trajectory(
+        tmp_path,
+        steps=[
+            {
+                "step_id": 1,
+                "timestamp": None,
+                "source": "user",
+                "message": "go",
+                "extra": {"daydream_phase": "review", "daydream_run_flow": "ttt"},
+            },
+            {
+                "step_id": 2,
+                "timestamp": None,
+                "source": "agent",
+                "message": "ok",
+                "model_name": "gpt-5.5",
+                "extra": {"daydream_phase": "review", "daydream_run_flow": "ttt"},
+                "metrics": {
+                    "prompt_tokens": 100,
+                    "completion_tokens": 10,
+                    "cached_tokens": 0,
+                    "cost_usd": 0.01,
+                },
+            },
+        ],
+    )
+    out = render_run_info_block([p])
+    assert "- **Duration:** —" in out
+    review_row = next(line for line in out.splitlines() if line.startswith("| Review |"))
+    assert review_row.rstrip().endswith("| — |")
+
+
+def test_deep_mode_latency_aggregates_across_forks() -> None:
+    """Fix phase latency spans across fork trajectory files."""
+    out = render_run_info_block([_DEEP_PARENT, _DEEP_FORK_A, _DEEP_FORK_B])
+    # Fix phase: fork A starts at 01:00, fork B ends at 02:01 -> 61s.
+    fix_row = next(line for line in out.splitlines() if line.startswith("| Fix |"))
+    assert fix_row.rstrip().endswith("| 1m 1s |")
+    # Total run: 00:00:00 to 02:00:01 -> 121s.
+    assert "- **Duration:** 2m 1s" in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pr_comment_renderer.py
+++ b/tests/test_pr_comment_renderer.py
@@ -684,7 +684,7 @@ def test_metrics_clamped_when_cached_exceeds_prompt(tmp_path: Path) -> None:
     # Per-phase row: Input (cached) cell reads "10 (100%)" — clamped.
     review_row = next(line for line in out.splitlines() if line.startswith("| Review |"))
     cells = [c.strip() for c in review_row.split("|")]
-    # Columns: ['', 'Review', model, tools, input(cached), output, cost, '']
+    # Columns: ['', 'Review', model, tools, input(cached), output, cost, latency, '']
     assert cells[4] == "10 (100%)"
 
 
@@ -777,7 +777,7 @@ def test_step_model_falls_back_to_root_agent_model(tmp_path: Path) -> None:
     # Per-phase Model cell also shows the fallback model.
     review_row = next(line for line in out.splitlines() if line.startswith("| Review |"))
     cells = [c.strip() for c in review_row.split("|")]
-    # Columns: ['', 'Review', model, tools, input(cached), output, cost, '']
+    # Columns: ['', 'Review', model, tools, input(cached), output, cost, latency, '']
     assert cells[2] == "gpt-5.5"
     # No 'unknown model' footnote, since the fallback resolved to a priced model.
     assert "not in the price table" not in out

--- a/uv.lock
+++ b/uv.lock
@@ -193,7 +193,7 @@ wheels = [
 
 [[package]]
 name = "daydream"
-version = "0.17.0"
+version = "0.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

Derives per-phase wall-clock latency from existing ATIF `Step.timestamp` fields grouped by `daydream_phase`. Adds a **Latency** column to the per-phase breakdown table and a **Duration** line to the rollup summary. No schema changes — timestamps were already captured on every step.

## Changes

### Added
- `_parse_ts()` and `_format_duration()` helpers in `pr_comment_renderer.py`
- `first_timestamp` / `last_timestamp` tracking on `_PhaseAgg`
- `duration_s` property on `_PhaseAgg`, `total_duration_s` property on `_RunAgg`
- Latency column in per-phase breakdown table
- Duration line in rollup summary
- 9 new tests: duration formatting, rollup display, phase table latency, graceful degradation (missing timestamps), deep-mode cross-fork aggregation

### Fixed
- Timestamp comparison uses parsed `datetime` objects instead of raw string comparison (ISO-8601 strings don't always sort lexicographically as expected)
- `test_e2e_unknown_model_emits_named_footnote` assertion updated from `endswith` to cell-index check to accommodate new column

## Testing

- [x] Unit tests added (9 new tests)
- [x] Existing tests updated for new column
- [x] `make check` passes

## Related Issues

- Closes #58

---

Generated with [Claude Code](https://claude.com/claude-code)