### PR TITLE
docs: remove product names from README and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ daydream /path/to/project                          # Default: deep multi-stack l
 daydream --shallow -s python /path/to/project      # Shallow Python review-fix-test loop
 daydream --review /path/to/project                 # Review only, skip fixes
 daydream --comment --branch feat/x /path/to/project  # Post inline PR comments
-daydream feedback 42 --bot "coderabbitai[bot]" /path/to/project  # Bot PR comments
+daydream feedback 42 --bot "<bot-login>[bot]" /path/to/project  # Bot PR comments
 daydream --trajectory /tmp/out.json /path/to/project  # Custom trajectory path
 
 # Development

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Daydream is a code-review agent that produces structured training data from its own runs. It reviews diffs using stack-specific [Beagle](https://github.com/existential-birds/beagle) skills, applies fixes, validates via test suite, and records every agent interaction as an [ATIF v1.6](https://www.harborframework.com/docs/agents/trajectory-format) trajectory. A bitemporal corpus pipeline then scores, labels, and projects those trajectories into JSONL datasets for SFT and RL fine-tuning.
 
-The goal is an open-weight code-review model (Qwen2.5-Coder-7B, QLoRA) trained on daydream's own trajectory archive, independently benchmarked against CodeRabbit and Greptile on a held-out PR replay corpus. See [Milestone 1](https://github.com/existential-birds/daydream/issues/86) for the current training roadmap.
+The goal is an open-weight code-review model (Qwen2.5-Coder-7B, QLoRA) trained on daydream's own trajectory archive, independently benchmarked against leading commercial code-review bots on a held-out PR replay corpus. See [Milestone 1](https://github.com/existential-birds/daydream/issues/86) for the current training roadmap.
 
 ![demo](https://github.com/user-attachments/assets/60a80645-36de-410e-afa7-7a96efef3f57)
 
@@ -96,7 +96,7 @@ daydream /path/to/project                     # deep multi-stack review-fix-test
 daydream --shallow /path/to/project           # single-stack loop
 daydream --review /path/to/project            # report only, no fixes
 daydream --comment --branch feat/x /path/to/project  # post inline PR comments
-daydream feedback 42 --bot "coderabbitai[bot]" /path/to/project  # fix bot PR comments
+daydream feedback 42 --bot "<bot-login>[bot]" /path/to/project  # fix bot PR comments
 ```
 
 To update: `git pull && uv sync`


### PR DESCRIPTION
## Summary

Removes named references to specific commercial code-review products from the user-facing docs.

- **README.md**
  - Benchmark positioning claim now reads "independently benchmarked against **leading commercial code-review bots**" instead of naming specific products.
  - `daydream feedback` example uses a `--bot "<bot-login>[bot]"` placeholder rather than a hardcoded third-party bot login.
- **CLAUDE.md**
  - Same `--bot "<bot-login>[bot]"` placeholder in the Commands example.

## Left unchanged (intentional)

- **`CHANGELOG.md`** — historical entries describing past PRs; rewriting them would falsify the record.
- **`tests/*`** — real bot-login strings are functional fixtures / regression-thread labels.
- **`daydream/cli.py` and `daydream/runner.py`** — `--bot` help text and a docstring still show a real bot login as an example. Out of scope for this PR; flagged for a follow-up decision.

## Verification

Pre-push hook ran lint (ruff), typecheck (mypy), and the full suite: **1025 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)