### PR TITLE
fix(runner): dispatch on bot instead of pr_number to prevent false feedback routing

### DIFF
--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -2,10 +2,10 @@
 
 The runner is unified around a single :func:`run` entry point. ``run`` opens
 the workspace via :func:`daydream.workspace.open_workspace` and then dispatches
-to a private helper based on ``config.pr_number`` / ``config.output_mode`` /
+to a private helper based on ``config.bot`` / ``config.output_mode`` /
 ``config.shallow``::
 
-    pr_number set            -> _run_pr_feedback (PR feedback flow)
+    bot set (feedback mode)  -> _run_pr_feedback (PR feedback flow)
     output_mode == "comment" -> _run_comment    (review + post inline PR comments)
     output_mode == "review"  -> _run_review     (review report only, no posting)
     output_mode == "loop":
@@ -297,7 +297,7 @@ async def run(config: RunConfig | None = None) -> int:
     """Execute a daydream run end-to-end.
 
     Opens the workspace via :func:`open_workspace` and dispatches to the
-    appropriate flow helper based on ``config.pr_number`` / ``config.output_mode``
+    appropriate flow helper based on ``config.bot`` / ``config.output_mode``
     / ``config.shallow``. Centralising workspace lifecycle means every flow gets
     a real :class:`WorkContext` (in-place or ephemeral) with consistent
     base/branch resolution.
@@ -393,12 +393,15 @@ async def run_feedback(config: RunConfig, pr: int) -> int:
 async def _dispatch(work: WorkContext, config: RunConfig) -> int:
     """Pick the flow helper for the resolved workspace + config.
 
-    Order matters: ``pr_number`` overrides everything (set by the
+    Order matters: ``bot`` signals PR feedback mode (set only by the
     ``daydream feedback <pr#>`` subcommand). Then output_mode picks comment vs
     review vs loop. Inside loop, ``config.shallow`` selects the single-stack
     pipeline; otherwise the deep multi-stack pipeline runs (default).
+
+    Note: ``config.pr_number`` can be auto-detected from the current branch
+    for metadata (trajectory/archive) without implying feedback mode.
     """
-    if config.pr_number is not None:
+    if config.bot is not None:
         return await _run_pr_feedback(work, config)
 
     if config.output_mode == "comment":

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -91,27 +91,22 @@ async def test_run_dispatches_to_pr_feedback_when_pr_number_set(
 
 
 @pytest.mark.asyncio
-async def test_run_does_not_dispatch_to_pr_feedback_when_only_pr_number_set(
+async def test_auto_detected_pr_number_dispatches_to_deep_loop(
     monkeypatch, patch_workspace, silence_runner_ui, tmp_path
 ):
-    """Auto-detected pr_number (no bot) must NOT route to _run_pr_feedback."""
-    pr_feedback_called = False
+    """Auto-detected pr_number (no bot) routes to the deep loop, not PR feedback."""
+    called: dict[str, Any] = {}
 
-    async def pr_stub(work, config):
-        nonlocal pr_feedback_called
-        pr_feedback_called = True
+    async def stub(work, config):
+        called["pr_number"] = config.pr_number
         return 0
 
-    async def deep_stub(work, config):
-        return 0
-
-    monkeypatch.setattr("daydream.runner._run_pr_feedback", pr_stub)
-    monkeypatch.setattr("daydream.runner._run_loop_deep", deep_stub)
+    monkeypatch.setattr("daydream.runner._run_loop_deep", stub)
     config = RunConfig(target=str(tmp_path), pr_number=42, bot=None)
 
     exit_code = await runner.run(config)
     assert exit_code == 0
-    assert not pr_feedback_called
+    assert called["pr_number"] == 42
 
 
 @pytest.mark.asyncio

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -91,6 +91,30 @@ async def test_run_dispatches_to_pr_feedback_when_pr_number_set(
 
 
 @pytest.mark.asyncio
+async def test_run_does_not_dispatch_to_pr_feedback_when_only_pr_number_set(
+    monkeypatch, patch_workspace, silence_runner_ui, tmp_path
+):
+    """Auto-detected pr_number (no bot) must NOT route to _run_pr_feedback."""
+    pr_feedback_called = False
+
+    async def pr_stub(work, config):
+        nonlocal pr_feedback_called
+        pr_feedback_called = True
+        return 0
+
+    async def deep_stub(work, config):
+        return 0
+
+    monkeypatch.setattr("daydream.runner._run_pr_feedback", pr_stub)
+    monkeypatch.setattr("daydream.runner._run_loop_deep", deep_stub)
+    config = RunConfig(target=str(tmp_path), pr_number=42, bot=None)
+
+    exit_code = await runner.run(config)
+    assert exit_code == 0
+    assert not pr_feedback_called
+
+
+@pytest.mark.asyncio
 async def test_run_dispatches_to_comment_mode(
     monkeypatch, patch_workspace, silence_runner_ui, tmp_path
 ):


### PR DESCRIPTION
## Summary

`_auto_detect_pr_number()` populates `config.pr_number` from the current branch's open PR for trajectory/archive metadata. `_dispatch()` used `config.pr_number is not None` as the routing condition for feedback mode, so any `daydream` invocation from a branch with an open PR was incorrectly routed to `_run_pr_feedback`, which then failed with "Invalid PR config" because `bot` was `None`.

## Changes

### Fixed
- Changed `_dispatch()` routing guard from `config.pr_number is not None` to `config.bot is not None` — `bot` is only set by the `feedback` subcommand and is the true feedback-mode indicator
- Updated docstrings in `runner.py` module header, `run()`, and `_dispatch()` to reflect the corrected routing logic

### Added
- Regression test `test_run_does_not_dispatch_to_pr_feedback_when_only_pr_number_set` proving auto-detected `pr_number` without `bot` routes to deep loop, not feedback mode

## Motivation

Running `daydream . --cleanup` (or any normal invocation) from a branch with an open PR triggered `_run_pr_feedback` and errored with "Invalid PR config — PR number and --bot are required". The `pr_number` field was dual-purpose (routing flag + metadata) and auto-detection made the routing condition always true on PR branches.

## Testing

- [x] Unit tests added
- [x] All 20 `test_runner.py` tests pass
- [x] Existing dispatch tests (`test_run_dispatches_to_pr_feedback_when_pr_number_set`) still pass — they already set `bot="botname"`

---

Generated with [Claude Code](https://claude.com/claude-code)