### PR TITLE
fix(exploration,claude): prevent stuck subagents and unmatched tool results

### DIFF
--- a/daydream/backends/claude.py
+++ b/daydream/backends/claude.py
@@ -93,6 +93,12 @@ class ClaudeBackend:
         # the trailing CostEvent. The trajectory recorder uses this to
         # upgrade the generic ``"claude"`` backend label to the actual id.
         last_assistant_model: str | None = None
+        # StructuredOutput ToolUseBlocks are intentionally skipped (the
+        # structured result is captured via ResultMessage.structured_output
+        # instead).  Track their IDs so the corresponding ToolResultBlocks
+        # in the subsequent UserMessage are also skipped — otherwise the
+        # trajectory recorder logs them as unmatched_tool_results.
+        skipped_tool_ids: set[str] = set()
 
         async with ClaudeSDKClient(options=options) as client:
             self._client = client
@@ -112,6 +118,7 @@ class ClaudeBackend:
                                 yield ThinkingEvent(text=block.thinking)
                             elif isinstance(block, ToolUseBlock):
                                 if block.name == "StructuredOutput":
+                                    skipped_tool_ids.add(block.id)
                                     continue
                                 yield ToolStartEvent(
                                     id=block.id,
@@ -150,6 +157,9 @@ class ClaudeBackend:
                     elif isinstance(msg, UserMessage):
                         for user_block in msg.content:
                             if isinstance(user_block, ToolResultBlock):
+                                if user_block.tool_use_id in skipped_tool_ids:
+                                    skipped_tool_ids.discard(user_block.tool_use_id)
+                                    continue
                                 content_str = str(user_block.content) if user_block.content else ""
                                 yield ToolResultEvent(
                                     id=user_block.tool_use_id,

--- a/daydream/exploration_runner.py
+++ b/daydream/exploration_runner.py
@@ -254,25 +254,39 @@ async def pre_scan(
             except Exception:  # noqa: BLE001 - best-effort path; exploration degrades silently per D-08
                 pass
 
-    file_paths = [f.path for f in static_files]
+    # Only pass actually-changed file paths to the test-mapper and
+    # pattern-scanner.  The full import-expanded list (static_files) is
+    # correct for the dependency-tracer (it needs the import graph), but
+    # the other two specialists interpret the list as "files to process"
+    # and will attempt per-file tool calls for every entry.  On large
+    # monorepos the import-expanded list can be 10K+ files, causing the
+    # test-mapper to run for 50+ minutes instead of 2.
+    changed_paths = sorted({m.group(1) for m in _DIFF_HEADER_RE.finditer(diff_text)})
 
-    async with anyio.create_task_group() as tg:
-        if tier == "single":
-            dep_prompt = build_dependency_tracer_prompt(static_files, diff_ref)
-            tg.start_soon(_run_specialist, "dependency_tracer", dep_prompt, DEPENDENCY_TRACER_SCHEMA)
-        else:  # parallel
-            tg.start_soon(
-                _run_specialist, "pattern_scanner",
-                build_pattern_scanner_prompt(file_paths, diff_ref), PATTERN_SCANNER_SCHEMA,
-            )
-            tg.start_soon(
-                _run_specialist, "dependency_tracer",
-                build_dependency_tracer_prompt(static_files, diff_ref), DEPENDENCY_TRACER_SCHEMA,
-            )
-            tg.start_soon(
-                _run_specialist, "test_mapper",
-                build_test_mapper_prompt(file_paths, diff_ref), TEST_MAPPER_SCHEMA,
-            )
+    # Wall-clock timeout for the entire exploration task group.  Individual
+    # specialists are already best-effort (except Exception: pass), so if
+    # one hangs past this deadline anyio cancels it and we proceed with
+    # whatever partial results we have.
+    _SPECIALIST_TIMEOUT_SECONDS = 300  # 5 minutes
+
+    with anyio.move_on_after(_SPECIALIST_TIMEOUT_SECONDS):
+        async with anyio.create_task_group() as tg:
+            if tier == "single":
+                dep_prompt = build_dependency_tracer_prompt(static_files, diff_ref)
+                tg.start_soon(_run_specialist, "dependency_tracer", dep_prompt, DEPENDENCY_TRACER_SCHEMA)
+            else:  # parallel
+                tg.start_soon(
+                    _run_specialist, "pattern_scanner",
+                    build_pattern_scanner_prompt(changed_paths, diff_ref), PATTERN_SCANNER_SCHEMA,
+                )
+                tg.start_soon(
+                    _run_specialist, "dependency_tracer",
+                    build_dependency_tracer_prompt(static_files, diff_ref), DEPENDENCY_TRACER_SCHEMA,
+                )
+                tg.start_soon(
+                    _run_specialist, "test_mapper",
+                    build_test_mapper_prompt(changed_paths, diff_ref), TEST_MAPPER_SCHEMA,
+                )
 
     if recorder is not None:
         recorder.create_dispatch_step(phase=DaydreamPhase.EXPLORATION)

--- a/daydream/exploration_runner.py
+++ b/daydream/exploration_runner.py
@@ -46,6 +46,8 @@ Tier: TypeAlias = Literal["skip", "single", "parallel"]
 # regex is the right tool here per D-04 (no tree-sitter for non-source text).
 _DIFF_HEADER_RE = re.compile(r"^diff --git a/(.+) b/", re.MULTILINE)
 
+_SPECIALIST_TIMEOUT_SECONDS = 300  # 5 minutes
+
 
 EXPLORATION_ENVELOPE_SCHEMA: dict[str, Any] = {
     "type": "object",
@@ -262,12 +264,6 @@ async def pre_scan(
     # monorepos the import-expanded list can be 10K+ files, causing the
     # test-mapper to run for 50+ minutes instead of 2.
     changed_paths = sorted({m.group(1) for m in _DIFF_HEADER_RE.finditer(diff_text)})
-
-    # Wall-clock timeout for the entire exploration task group.  Individual
-    # specialists are already best-effort (except Exception: pass), so if
-    # one hangs past this deadline anyio cancels it and we proceed with
-    # whatever partial results we have.
-    _SPECIALIST_TIMEOUT_SECONDS = 300  # 5 minutes
 
     with anyio.move_on_after(_SPECIALIST_TIMEOUT_SECONDS):
         async with anyio.create_task_group() as tg:

--- a/tests/test_backend_claude.py
+++ b/tests/test_backend_claude.py
@@ -364,6 +364,41 @@ async def _drive_claude_backend_to_list(
 
 
 @pytest.mark.asyncio
+async def test_structured_output_tool_result_is_suppressed(patch_sdk) -> None:
+    """StructuredOutput ToolUseBlocks are skipped, and the corresponding
+    ToolResultBlock in the next UserMessage must also be skipped — otherwise
+    the trajectory recorder logs it as an unmatched_tool_result."""
+    events = await _drive_claude_backend_to_list(
+        messages=[
+            MockAssistantMessage(content=[
+                MockToolUseBlock(id="tool-real", name="Read", input={"file": "a.py"}),
+                MockToolUseBlock(id="tool-so", name="StructuredOutput", input={"result": "{}"}),
+            ]),
+            MockUserMessage(content=[
+                MockToolResultBlock(tool_use_id="tool-real", content="file contents"),
+                MockToolResultBlock(tool_use_id="tool-so", content='{"data": 1}'),
+            ]),
+            MockResultMessage(total_cost_usd=0.01, structured_output={"data": 1}),
+        ],
+        patch_sdk_fn=patch_sdk,
+    )
+
+    tool_starts = [e for e in events if isinstance(e, ToolStartEvent)]
+    tool_results = [e for e in events if isinstance(e, ToolResultEvent)]
+
+    assert len(tool_starts) == 1
+    assert tool_starts[0].name == "Read"
+    assert tool_starts[0].id == "tool-real"
+
+    assert len(tool_results) == 1
+    assert tool_results[0].id == "tool-real"
+    assert tool_results[0].output == "file contents"
+
+    result_events = [e for e in events if isinstance(e, ResultEvent)]
+    assert result_events[0].structured_output == {"data": 1}
+
+
+@pytest.mark.asyncio
 async def test_claude_backend_emits_turn_end_per_assistant_message(patch_sdk) -> None:
     """One TurnEndEvent per AssistantMessage, after that message's events."""
     from daydream.backends import TurnEndEvent

--- a/tests/test_exploration_runner.py
+++ b/tests/test_exploration_runner.py
@@ -225,6 +225,38 @@ def test_parallel_tier_launches_three_agents(tmp_path):
     assert "use type hints" in ctx.guidelines
 
 
+def test_parallel_tier_routes_correct_file_lists(tmp_path):
+    py = (FIXTURES / "python_multifile.diff").read_text()
+    ts = (FIXTURES / "typescript_multifile.diff").read_text()
+    diff_text = py + ts
+
+    backend = _SpecialistMockBackend()
+    anyio.run(pre_scan, backend, tmp_path, diff_text)
+
+    diff_changed = {"daydream_demo/api.py", "daydream_demo/models.py", "src/api.ts", "src/models.ts"}
+
+    calls_by_schema = {}
+    for call in backend.execute_calls:
+        if call["schema"] == PATTERN_SCANNER_SCHEMA:
+            calls_by_schema["pattern_scanner"] = call
+        elif call["schema"] == DEPENDENCY_TRACER_SCHEMA:
+            calls_by_schema["dependency_tracer"] = call
+        elif call["schema"] == TEST_MAPPER_SCHEMA:
+            calls_by_schema["test_mapper"] = call
+
+    assert set(calls_by_schema.keys()) == {"pattern_scanner", "dependency_tracer", "test_mapper"}
+
+    for name in ("pattern_scanner", "test_mapper"):
+        prompt = calls_by_schema[name]["prompt"]
+        for path in diff_changed:
+            assert f"- {path}" in prompt
+        assert "(modified)" not in prompt
+
+    dep_prompt = calls_by_schema["dependency_tracer"]["prompt"]
+    for path in diff_changed:
+        assert f"- {path} (modified)" in dep_prompt
+
+
 def test_parse_envelope_handles_missing_keys(tmp_path):
     diff_text = (FIXTURES / "python_multifile.diff").read_text()
     envelope = {


### PR DESCRIPTION
## Summary

Fixes two bugs discovered during a live run on a large monorepo (69-file diff expanding to 14K files via tree-sitter import resolution): the test-mapper exploration subagent hanging for 50+ minutes, and `StructuredOutput` tool results being logged as `unmatched_tool_results` in trajectories.

## Changes

### Fixed
- **Exploration file list explosion**: test-mapper and pattern-scanner now receive only the diff-changed file paths instead of the full import-expanded list. The dependency-tracer still gets the full list since it needs the import graph. On large monorepos the import-expanded list can be 10K+ files, causing the test-mapper to make per-file tool calls for every entry.
- **Wall-clock timeout**: the exploration task group is now wrapped in `anyio.move_on_after(300)` (5 minutes) so a stuck specialist degrades gracefully instead of blocking the entire run indefinitely.
- **StructuredOutput tool result leak**: `StructuredOutput` `ToolUseBlock`s were already skipped (no `ToolStartEvent`), but the corresponding `ToolResultBlock` in the subsequent `UserMessage` was not — producing orphan `ToolResultEvent`s logged as `unmatched_tool_results`. Now skipped tool IDs are tracked and their results filtered.

## Motivation

During a production run, the test-mapper subagent ran for 52+ minutes while the other two exploration subagents completed in ~2 minutes each. The run was completely blocked in the exploration phase. Root cause: `pre_scan()` passed the full tree-sitter import-expanded file list (14,016 files) to all three subagent prompts, but only the dependency-tracer needs the full graph.

The `unmatched_tool_results` bug was discovered in the pattern-scanner trajectory from the same run — tool call ID `toolu_01TKzYCboVTcGnShG6e7nXcA` appeared as unmatched because its `StructuredOutput` `ToolUseBlock` was skipped but the result was not.

## Testing

- [x] Unit tests added/updated
- [x] Linting passes (`make lint`)
- [x] Type checking passes (`make typecheck`)
- [x] All 1027 tests pass (`make test`)

### Test coverage
- `test_structured_output_tool_result_is_suppressed`: verifies that when a `StructuredOutput` ToolUseBlock is present alongside a real tool call, only the real tool's start/result events are emitted — the StructuredOutput result is filtered.

---

Generated with [Claude Code](https://claude.com/claude-code)