### PR TITLE
fix(git_ops): diff against remote default branch instead of local

### DIFF
--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -452,15 +452,7 @@ def _resolve_upstream_if_remote_ahead(repo: Path, branch: str) -> str | None:
 
 
 def _prefer_remote_base(repo: Path, base: str) -> str:
-    """Return ``origin/<base>`` when it exists, otherwise *base* unchanged.
-
-    For diff operations the remote tracking branch is the correct comparison
-    target — it reflects what the default branch looks like on the remote,
-    not the (potentially stale or identical-to-HEAD) local copy.  This is
-    especially important when the user is working directly on ``main``:
-    ``git diff main...HEAD`` is always empty, but
-    ``git diff origin/main...HEAD`` shows the unpushed changes.
-    """
+    """Return ``origin/<base>`` when it exists, otherwise *base* unchanged."""
     remote_ref = f"origin/{base}"
     check = _run_git(repo, ["rev-parse", "--verify", f"refs/remotes/{remote_ref}"], timeout=5)
     if check.returncode == 0:

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -451,11 +451,31 @@ def _resolve_upstream_if_remote_ahead(repo: Path, branch: str) -> str | None:
     return upstream if right > 0 else None
 
 
+def _prefer_remote_base(repo: Path, base: str) -> str:
+    """Return ``origin/<base>`` when it exists, otherwise *base* unchanged.
+
+    For diff operations the remote tracking branch is the correct comparison
+    target — it reflects what the default branch looks like on the remote,
+    not the (potentially stale or identical-to-HEAD) local copy.  This is
+    especially important when the user is working directly on ``main``:
+    ``git diff main...HEAD`` is always empty, but
+    ``git diff origin/main...HEAD`` shows the unpushed changes.
+    """
+    remote_ref = f"origin/{base}"
+    check = _run_git(repo, ["rev-parse", "--verify", f"refs/remotes/{remote_ref}"], timeout=5)
+    if check.returncode == 0:
+        return remote_ref
+    return base
+
+
 def diff(repo: Path, base: str, head: str = "HEAD", *, exclude: list[str] | None = None) -> str:
     """Return the unified diff between *base* and *head*.
 
     Uses three-dot syntax (``base...head``) so the diff reflects changes on
-    *head* since it diverged from *base*.
+    *head* since it diverged from *base*.  When ``origin/<base>`` exists the
+    function prefers it via :func:`_prefer_remote_base` so the diff is
+    computed against the remote default branch — not a potentially stale
+    (or identical-to-HEAD) local copy.
 
     Args:
         repo: Repository working directory.
@@ -469,7 +489,8 @@ def diff(repo: Path, base: str, head: str = "HEAD", *, exclude: list[str] | None
     Raises:
         GitError: If ``git diff`` fails.
     """
-    args = ["diff", f"{base}...{head}"]
+    preferred_base = _prefer_remote_base(repo, base)
+    args = ["diff", f"{preferred_base}...{head}"]
     if exclude:
         args.append("--")
         args.append(".")

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -275,6 +275,25 @@ def test_diff_excludes_paths(tmp_path: Path) -> None:
     assert "drop.txt" not in out
 
 
+def test_diff_prefers_origin_when_on_default_branch(tmp_path: Path) -> None:
+    """When HEAD is on main, diff against origin/main shows unpushed commits."""
+    remote_dir = tmp_path / "remote.git"
+    remote_dir.mkdir()
+    _git(remote_dir, "init", "--bare", "-b", "main")
+
+    repo = _make_repo_with_main(tmp_path)
+    _git(repo, "remote", "add", "origin", str(remote_dir))
+    _git(repo, "push", "-u", "origin", "main")
+
+    # Local commit on main — not pushed.
+    (repo / "local.txt").write_text("local change\n")
+    _git(repo, "add", "local.txt")
+    _commit(repo, "local only")
+
+    out = git_ops.diff(repo, "main")
+    assert "local.txt" in out, "diff should show unpushed changes vs origin/main"
+
+
 # --- diff_name_only ---------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

When a user runs daydream while on the default branch (`main`) with unpushed commits, `git diff main...HEAD` produces an empty diff because `main` and `HEAD` point to the same ref. This causes daydream to report "no diff found" and exit without reviewing anything.

## Changes

### Fixed
- `git_ops.diff()` now prefers `origin/<base>` over the local branch name when the remote tracking ref exists, so `git diff origin/main...HEAD` correctly shows unpushed changes
- Added `_prefer_remote_base()` helper that checks for `refs/remotes/origin/<base>` existence

### Added
- `test_diff_prefers_origin_when_on_default_branch` — sets up a repo with an origin, makes an unpushed commit on main, and verifies the diff includes it

## Motivation

Users working directly on `main` (common in smaller repos or quick fixes) were getting false "no diff" results. All three diff call sites (deep orchestrator, comment/review mode, shallow loop) go through `git_ops.diff()`, so the fix applies everywhere.

## Testing

- [x] Unit tests added
- [x] Full test suite passes (1028 tests)
- [x] Linting passes
- [x] Type checking passes

---

Generated with [Claude Code](https://claude.com/claude-code)