### PR TITLE
feat(archive): human-override label precedence, idempotent harvest, and rate-limit handling

### DIFF
--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -339,6 +339,7 @@ def append_label_observation(
     composite_reward: float | None = None,
     reviewer_logins: list[str] | None = None,
     has_posterior: bool = False,
+    source: str = "auto",
 ) -> None:
     """Append a row to the immutable ``label_observations`` history.
 
@@ -346,7 +347,12 @@ def append_label_observation(
     label decision plus the bitemporal valid time and reward breakdown, and in
     the same transaction refreshes the denormalized
     ``runs.outcome_labels`` / ``runs.labeled_at`` / ``runs.rubric_json`` /
-    ``runs.composite_reward`` cache.
+    ``runs.composite_reward`` / ``runs.has_posterior`` cache.
+
+    The cache is recomputed from the *winning* observation under the
+    precedence projection (human-first, then most recent) — **not** necessarily
+    the row just inserted. A newer automated append therefore cannot dethrone an
+    existing human label in the denormalized cache.
 
     Args:
         archive_dir: Path to the archive root.
@@ -381,6 +387,12 @@ def append_label_observation(
             Coerced to ``int`` and written to ``label_observations.has_posterior``
             and mirrored onto ``runs.has_posterior`` so SQL consumers can split
             labeled/unlabeled populations without parsing ``reward_json``.
+        source: Provenance of this observation — ``"auto"`` (automated rubric
+            labeler; the default that keeps existing harvest callers
+            unchanged) or ``"human"`` (operator override). Human-sourced rows
+            take precedence over automated ones in every projection regardless
+            of timing, which is why the cache is written from the winning row
+            rather than the inserted one.
 
     Raises:
         ValueError: When ``session_id`` is not present in the ``runs`` table.
@@ -402,8 +414,8 @@ def append_label_observation(
         conn.execute(
             "INSERT INTO label_observations "
             "(session_id, observed_at, labels, pr_state, labeler_version, evidence_sha, rubric_json, "
-            "valid_at, reward_version, reward_json, composite_reward, reviewer_logins, has_posterior) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "valid_at, reward_version, reward_json, composite_reward, reviewer_logins, has_posterior, source) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 session_id,
                 observed_at,
@@ -418,13 +430,31 @@ def append_label_observation(
                 composite_reward,
                 reviewer_logins_json,
                 has_posterior_int,
+                source,
             ),
         )
+        # Recompute the winning observation (human-first, then recency) so the
+        # denormalized runs cache mirrors the precedence projection — not
+        # necessarily the row just inserted (a newer auto must not dethrone a
+        # human label).
+        winner = conn.execute(
+            "SELECT labels, observed_at, rubric_json, composite_reward, has_posterior "
+            "FROM label_observations WHERE session_id = ? "
+            "ORDER BY CASE WHEN source = 'human' THEN 1 ELSE 0 END DESC, observed_at DESC LIMIT 1",
+            (session_id,),
+        ).fetchone()
         conn.execute(
             "UPDATE runs SET outcome_labels = ?, labeled_at = ?, rubric_json = ?, composite_reward = ?, "
             "has_posterior = ? "
             "WHERE session_id = ?",
-            (labels_json, observed_at, rubric_json, composite_reward, has_posterior_int, session_id),
+            (
+                winner["labels"],
+                winner["observed_at"],
+                winner["rubric_json"],
+                winner["composite_reward"],
+                winner["has_posterior"],
+                session_id,
+            ),
         )
         conn.commit()
     finally:

--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -762,10 +762,13 @@ def label_observation_history(archive_dir: Path, session_id: str) -> list[dict]:
 def update_labels(archive_dir: Path, session_id: str, labels: list[str]) -> bool:
     """Update outcome labels for a session, supporting prefix matching.
 
-    Backwards-compatible thin wrapper around :func:`append_label_observation`.
-    The session_id can be a prefix (e.g. first 8 chars of the UUID). If the
-    prefix matches exactly one row, that row is updated. If it matches
-    multiple rows, a ValueError is raised asking for a longer prefix.
+    Thin wrapper around :func:`append_label_observation` that records a
+    **human-sourced** observation (``source="human"``, ``labeler_version="human"``).
+    Human labels win over automated ones in every precedence projection and are
+    never deduped, so this is the authoritative override surface backing
+    ``daydream label``. The session_id can be a prefix (e.g. first 8 chars of
+    the UUID). If the prefix matches exactly one row, that row is updated. If it
+    matches multiple rows, a ValueError is raised asking for a longer prefix.
 
     Args:
         archive_dir: Path to the archive root.
@@ -802,8 +805,9 @@ def update_labels(archive_dir: Path, session_id: str, labels: list[str]) -> bool
         full_id,
         labels=labels,
         pr_state=None,
-        labeler_version="legacy",
+        labeler_version="human",
         evidence_sha=None,
+        source="human",
     )
     return True
 

--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -437,10 +437,12 @@ def latest_label_observation(
     *,
     as_of: str | None = None,
 ) -> dict | None:
-    """Return the most recent label observation for ``session_id``.
+    """Return the highest-precedence (human-first, then most recent) label observation for ``session_id``.
 
-    When ``as_of`` is provided, the result is the most recent observation
-    whose ``observed_at <= as_of`` — enabling reproducible corpus pinning.
+    Human-sourced observations win over automated ones regardless of timing;
+    ties broken by recency. When ``as_of`` is provided, the result is the
+    highest-precedence observation whose ``observed_at <= as_of`` — enabling
+    reproducible corpus pinning.
 
     Args:
         archive_dir: Path to the archive root.
@@ -455,13 +457,13 @@ def latest_label_observation(
         if as_of is None:
             cursor = conn.execute(
                 "SELECT * FROM label_observations WHERE session_id = ? "
-                "ORDER BY observed_at DESC LIMIT 1",
+                "ORDER BY CASE WHEN source = 'human' THEN 1 ELSE 0 END DESC, observed_at DESC LIMIT 1",
                 (session_id,),
             )
         else:
             cursor = conn.execute(
                 "SELECT * FROM label_observations WHERE session_id = ? AND observed_at <= ? "
-                "ORDER BY observed_at DESC LIMIT 1",
+                "ORDER BY CASE WHEN source = 'human' THEN 1 ELSE 0 END DESC, observed_at DESC LIMIT 1",
                 (session_id, as_of),
             )
         row = cursor.fetchone()
@@ -476,10 +478,12 @@ def bulk_latest_label_observations(
     *,
     as_of: str | None = None,
 ) -> dict[str, dict]:
-    """Return the most recent label observation for each session in *session_ids*.
+    """Return the highest-precedence (human-first, then most recent) label observation for each session.
 
-    Fetches all matching rows in a single SQL query instead of one query per
-    session, eliminating the N+1 pattern when building a corpus.
+    Human-sourced observations win over automated ones regardless of timing;
+    ties broken by recency. Fetches all matching rows in a single SQL query
+    instead of one query per session, eliminating the N+1 pattern when building
+    a corpus.
 
     When ``as_of`` is provided, only observations whose ``observed_at <= as_of``
     are considered — the same temporal constraint applied by
@@ -508,7 +512,8 @@ def bulk_latest_label_observations(
                     SELECT *,
                            ROW_NUMBER() OVER (
                                PARTITION BY session_id
-                               ORDER BY observed_at DESC
+                               ORDER BY CASE WHEN source = 'human' THEN 1 ELSE 0 END DESC,
+                                        observed_at DESC
                            ) AS _rn
                     FROM label_observations
                     WHERE session_id IN ({placeholders})
@@ -525,7 +530,8 @@ def bulk_latest_label_observations(
                     SELECT *,
                            ROW_NUMBER() OVER (
                                PARTITION BY session_id
-                               ORDER BY observed_at DESC
+                               ORDER BY CASE WHEN source = 'human' THEN 1 ELSE 0 END DESC,
+                                        observed_at DESC
                            ) AS _rn
                     FROM label_observations
                     WHERE session_id IN ({placeholders})
@@ -774,10 +780,11 @@ def label_count_summary(
 ) -> dict[str, int]:
     """Return label counts for all runs in a single aggregate query.
 
-    For each run in ``runs``, finds the most recent ``label_observations`` row
-    whose ``observed_at <= as_of`` (or the most recent overall when ``as_of``
-    is ``None``), extracts the first label, and tallies counts.  Runs with no
-    qualifying observation are counted under ``"unlabeled"``.
+    For each run in ``runs``, finds the highest-precedence (human-first, then
+    most recent) ``label_observations`` row whose ``observed_at <= as_of`` (or
+    overall when ``as_of`` is ``None``), extracts the first label, and tallies
+    counts.  Runs with no qualifying observation are counted under
+    ``"unlabeled"``.
 
     This replaces the N+1 pattern of calling
     :func:`latest_label_observation` once per run.
@@ -796,26 +803,36 @@ def label_count_summary(
     try:
         if as_of is None:
             best_sql = (
-                "SELECT session_id, MAX(observed_at) AS max_at "
-                "FROM label_observations "
-                "GROUP BY session_id"
+                "SELECT session_id, labels FROM ("
+                "  SELECT session_id, labels, "
+                "         ROW_NUMBER() OVER ("
+                "             PARTITION BY session_id "
+                "             ORDER BY CASE WHEN source = 'human' THEN 1 ELSE 0 END DESC, "
+                "                      observed_at DESC"
+                "         ) AS _rn "
+                "  FROM label_observations"
+                ") WHERE _rn = 1"
             )
             params: tuple = ()
         else:
             best_sql = (
-                "SELECT session_id, MAX(observed_at) AS max_at "
-                "FROM label_observations "
-                "WHERE observed_at <= ? "
-                "GROUP BY session_id"
+                "SELECT session_id, labels FROM ("
+                "  SELECT session_id, labels, "
+                "         ROW_NUMBER() OVER ("
+                "             PARTITION BY session_id "
+                "             ORDER BY CASE WHEN source = 'human' THEN 1 ELSE 0 END DESC, "
+                "                      observed_at DESC"
+                "         ) AS _rn "
+                "  FROM label_observations "
+                "  WHERE observed_at <= ?"
+                ") WHERE _rn = 1"
             )
             params = (as_of,)
 
         cursor = conn.execute(
-            f"SELECT lo.labels "  # noqa: S608
+            f"SELECT best.labels "  # noqa: S608
             f"FROM runs r "
-            f"LEFT JOIN ({best_sql}) best ON r.session_id = best.session_id "
-            f"LEFT JOIN label_observations lo "
-            f"    ON lo.session_id = best.session_id AND lo.observed_at = best.max_at",
+            f"LEFT JOIN ({best_sql}) best ON r.session_id = best.session_id",
             params,
         )
         counts: dict[str, int] = {}

--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -35,9 +35,8 @@ from __future__ import annotations
 
 import json
 import sqlite3
-import uuid
 import warnings
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from daydream.archive.manifest import Manifest
@@ -437,8 +436,7 @@ def append_label_observation(
     Raises:
         ValueError: When ``session_id`` is not present in the ``runs`` table.
     """
-    observed_at = datetime.now(timezone.utc).isoformat() + "~" + uuid.uuid4().hex[:8]
-    valid_at_value = valid_at if valid_at is not None else observed_at
+    observed_dt = datetime.now(timezone.utc)
     labels_json = json.dumps(labels)
     reviewer_logins_json = json.dumps(reviewer_logins) if reviewer_logins is not None else None
     has_posterior_int = int(has_posterior)
@@ -468,28 +466,37 @@ def append_label_observation(
                 and latest_auto["labels"] == labels_json
             ):
                 return False
-        conn.execute(
-            "INSERT INTO label_observations "
-            "(session_id, observed_at, labels, pr_state, labeler_version, evidence_sha, rubric_json, "
-            "valid_at, reward_version, reward_json, composite_reward, reviewer_logins, has_posterior, source) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            (
-                session_id,
-                observed_at,
-                labels_json,
-                pr_state,
-                labeler_version,
-                evidence_sha,
-                rubric_json,
-                valid_at_value,
-                reward_version,
-                reward_json,
-                composite_reward,
-                reviewer_logins_json,
-                has_posterior_int,
-                source,
-            ),
-        )
+        # Bump observed_at by a microsecond and retry on a same-microsecond
+        # primary-key collision so the column stays a clean ISO 8601 timestamp.
+        while True:
+            observed_at = observed_dt.isoformat()
+            valid_at_value = valid_at if valid_at is not None else observed_at
+            try:
+                conn.execute(
+                    "INSERT INTO label_observations "
+                    "(session_id, observed_at, labels, pr_state, labeler_version, evidence_sha, rubric_json, "
+                    "valid_at, reward_version, reward_json, composite_reward, reviewer_logins, has_posterior, source) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        session_id,
+                        observed_at,
+                        labels_json,
+                        pr_state,
+                        labeler_version,
+                        evidence_sha,
+                        rubric_json,
+                        valid_at_value,
+                        reward_version,
+                        reward_json,
+                        composite_reward,
+                        reviewer_logins_json,
+                        has_posterior_int,
+                        source,
+                    ),
+                )
+                break
+            except sqlite3.IntegrityError:
+                observed_dt += timedelta(microseconds=1)
         # Recompute the winning observation (human-first, then recency) so the
         # denormalized runs cache mirrors the precedence projection — not
         # necessarily the row just inserted (a newer auto must not dethrone a
@@ -889,13 +896,13 @@ def pr_attached_label_coverage(
             ``observed_at <= as_of`` are considered (reproducible pinning).
 
     Returns:
-        ``{"pr_attached": N, "decisive": M, "coverage": M / N}`` with
-        ``coverage`` as ``0.0`` when ``N == 0``.
+        ``{"pr_attached": N, "decisive": M, "coverage": M / N,
+        "malformed_labels": K}`` with ``coverage`` as ``0.0`` when ``N == 0``.
     """
     rows = query_runs(archive_dir, where="pr_number IS NOT NULL")
     pr_attached = len(rows)
     if pr_attached == 0:
-        return {"pr_attached": 0, "decisive": 0, "coverage": 0.0}
+        return {"pr_attached": 0, "decisive": 0, "coverage": 0.0, "malformed_labels": 0}
 
     session_ids = [row["session_id"] for row in rows]
     winners = bulk_latest_label_observations(archive_dir, session_ids, as_of=as_of)

--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -902,6 +902,7 @@ def pr_attached_label_coverage(
 
     decisive_labels = {"accepted", "contested", "rejected"}
     decisive = 0
+    malformed = 0
     for session_id in session_ids:
         observation = winners.get(session_id)
         if observation is None:
@@ -909,14 +910,19 @@ def pr_attached_label_coverage(
         try:
             labels = json.loads(observation["labels"])
         except (json.JSONDecodeError, TypeError):
+            malformed += 1
             continue
-        if isinstance(labels, list) and labels and str(labels[0]) in decisive_labels:
+        if not isinstance(labels, list):
+            malformed += 1
+            continue
+        if labels and str(labels[0]) in decisive_labels:
             decisive += 1
 
     return {
         "pr_attached": pr_attached,
         "decisive": decisive,
         "coverage": decisive / pr_attached,
+        "malformed_labels": malformed,
     }
 
 

--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -340,7 +340,7 @@ def append_label_observation(
     reviewer_logins: list[str] | None = None,
     has_posterior: bool = False,
     source: str = "auto",
-) -> None:
+) -> bool:
     """Append a row to the immutable ``label_observations`` history.
 
     Writes a single ``(session_id, observed_at)`` row capturing the current
@@ -394,6 +394,16 @@ def append_label_observation(
             of timing, which is why the cache is written from the winning row
             rather than the inserted one.
 
+    Returns:
+        ``True`` when a new observation row was inserted; ``False`` when the
+        append was a deduped no-op. Dedup is **auto-only**: an automated
+        (``source="auto"``) append whose ``(evidence_sha, reward_version)``
+        matches the latest existing *auto* observation for the session is
+        skipped without inserting and without touching the cache. Human
+        (``source != "auto"``) appends are never deduped and always return
+        ``True``; a reward-version bump on otherwise-identical evidence also
+        appends a fresh generation.
+
     Raises:
         ValueError: When ``session_id`` is not present in the ``runs`` table.
     """
@@ -411,6 +421,22 @@ def append_label_observation(
         if cursor.fetchone() is None:
             msg = f"Unknown session {session_id!r}"
             raise ValueError(msg)
+        # Idempotency: an automated re-score with identical evidence is a no-op.
+        # Compare against the latest *auto* row specifically so a human override
+        # appended in between cannot mask a genuine automated re-score.
+        if source == "auto":
+            latest_auto = conn.execute(
+                "SELECT evidence_sha, reward_version FROM label_observations "
+                "WHERE session_id = ? AND source = 'auto' "
+                "ORDER BY observed_at DESC LIMIT 1",
+                (session_id,),
+            ).fetchone()
+            if (
+                latest_auto is not None
+                and latest_auto["evidence_sha"] == evidence_sha
+                and latest_auto["reward_version"] == reward_version
+            ):
+                return False
         conn.execute(
             "INSERT INTO label_observations "
             "(session_id, observed_at, labels, pr_state, labeler_version, evidence_sha, rubric_json, "
@@ -457,6 +483,7 @@ def append_label_observation(
             ),
         )
         conn.commit()
+        return True
     finally:
         conn.close()
 

--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -835,6 +835,62 @@ def query_runs(archive_dir: Path, where: str = "", params: tuple = ()) -> list[d
         conn.close()
 
 
+def pr_attached_label_coverage(
+    archive_dir: Path,
+    *,
+    as_of: str | None = None,
+) -> dict[str, float | int]:
+    """Return the fraction of PR-attached runs with a decisive automated label.
+
+    "PR-attached" means the run carries a ``pr_number`` (``pr_number IS NOT
+    NULL``). A run is "decisive" when its winning label — under the same
+    human-first, then-recency precedence projection used by
+    :func:`bulk_latest_label_observations` — is one of ``"accepted"``,
+    ``"contested"``, or ``"rejected"``. Runs whose winning label is
+    ``"unknown"`` (or that have no qualifying observation at all) are not
+    decisive.
+
+    This is a pure read; it never writes. An archive with zero PR-attached runs
+    yields ``coverage`` ``0.0`` rather than raising ``ZeroDivisionError``.
+
+    Args:
+        archive_dir: Path to the archive root.
+        as_of: Optional ISO 8601 cutoff; threaded through to
+            :func:`bulk_latest_label_observations` so only observations whose
+            ``observed_at <= as_of`` are considered (reproducible pinning).
+
+    Returns:
+        ``{"pr_attached": N, "decisive": M, "coverage": M / N}`` with
+        ``coverage`` as ``0.0`` when ``N == 0``.
+    """
+    rows = query_runs(archive_dir, where="pr_number IS NOT NULL")
+    pr_attached = len(rows)
+    if pr_attached == 0:
+        return {"pr_attached": 0, "decisive": 0, "coverage": 0.0}
+
+    session_ids = [row["session_id"] for row in rows]
+    winners = bulk_latest_label_observations(archive_dir, session_ids, as_of=as_of)
+
+    decisive_labels = {"accepted", "contested", "rejected"}
+    decisive = 0
+    for session_id in session_ids:
+        observation = winners.get(session_id)
+        if observation is None:
+            continue
+        try:
+            labels = json.loads(observation["labels"])
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if isinstance(labels, list) and labels and str(labels[0]) in decisive_labels:
+            decisive += 1
+
+    return {
+        "pr_attached": pr_attached,
+        "decisive": decisive,
+        "coverage": decisive / pr_attached,
+    }
+
+
 def label_count_summary(
     archive_dir: Path,
     as_of: str | None = None,

--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -39,7 +39,7 @@ from pathlib import Path
 
 from daydream.archive.manifest import Manifest
 
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5
 
 _REVIEWER_PENALTY_MAP: dict[str, float] = {
     "accepted": 0.0,
@@ -107,6 +107,10 @@ CREATE TABLE IF NOT EXISTS runs (
 # carries a ``PosteriorBreakdown``, mirrored onto ``runs`` so SQL consumers can
 # split labeled/unlabeled populations without parsing ``reward_json``). See spec
 # ``corpus-pipeline-architecture`` (silver layer) and ``reward-posterior-corrections`` (C3).
+# ``source`` is the precedence marker (``'auto'`` for automated rubric labels,
+# ``'human'`` for maintainer overrides) — human-sourced rows win in the "latest
+# label" projections regardless of recency. Pre-existing rows default to ``'auto'``
+# via the additive ``_migrate_label_observations_schema`` ALTER-ADD migration.
 _CREATE_LABEL_OBSERVATIONS_TABLE = """
 CREATE TABLE IF NOT EXISTS label_observations (
     session_id       TEXT NOT NULL,
@@ -122,6 +126,7 @@ CREATE TABLE IF NOT EXISTS label_observations (
     composite_reward REAL,
     reviewer_logins  TEXT,
     has_posterior    INTEGER NOT NULL DEFAULT 0,
+    source           TEXT NOT NULL DEFAULT 'auto',
     PRIMARY KEY (session_id, observed_at)
 )
 """
@@ -204,6 +209,32 @@ def _recreate_label_observations_if_stale(conn: sqlite3.Connection) -> None:
         conn.execute(_CREATE_LABEL_OBSERVATIONS_TABLE)
 
 
+def _migrate_label_observations_schema(conn: sqlite3.Connection) -> None:
+    """Additively ALTER-ADD columns missing from a live ``label_observations`` table.
+
+    Unlike ``_recreate_label_observations_if_stale`` (which drop-recreates for
+    structural bitemporal/posterior columns), this is non-destructive: the
+    ``source`` precedence marker is additive, so pre-existing rows are preserved
+    and default to ``'auto'``. Mirrors ``_migrate_schema`` (the runs migration).
+
+    Args:
+        conn: An open connection whose ``label_observations`` table exists.
+    """
+    existing = {row[1] for row in conn.execute("PRAGMA table_info(label_observations)").fetchall()}
+    migrations: list[tuple[str, str]] = [
+        ("source", "TEXT NOT NULL DEFAULT 'auto'"),
+    ]
+    for col, col_type in migrations:
+        if col not in existing:
+            try:
+                conn.execute(
+                    f"ALTER TABLE label_observations ADD COLUMN {col} {col_type}"  # noqa: S608 - col/col_type are module-local constants
+                )
+            except sqlite3.OperationalError as exc:
+                if "duplicate column name" not in str(exc).lower():
+                    raise
+
+
 def _get_connection(archive_dir: Path) -> sqlite3.Connection:
     """Open the index database, creating schema if needed.
 
@@ -225,6 +256,7 @@ def _get_connection(archive_dir: Path) -> sqlite3.Connection:
     conn.execute(_CREATE_TABLE)
     conn.execute(_CREATE_LABEL_OBSERVATIONS_TABLE)
     _recreate_label_observations_if_stale(conn)
+    _migrate_label_observations_schema(conn)
     _migrate_schema(conn)
     for idx_sql in _CREATE_INDEXES:
         conn.execute(idx_sql)

--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -15,11 +15,13 @@ Exports:
         ``valid_at`` valid time, reward columns, plus ``reviewer_logins`` and
         the ``has_posterior`` population discriminator) and refresh the
         denormalized runs cache (including the ``has_posterior`` mirror).
-    latest_label_observation: Return the most recent label_observations row for
-        a session, optionally constrained by an ``as_of`` cutoff timestamp.
-    bulk_latest_label_observations: Return the most recent label_observations
-        row for each session in a collection — single round-trip alternative to
-        calling ``latest_label_observation`` in a loop.
+    latest_label_observation: Return the highest-precedence (human-first, then
+        recency) label_observations row for a session, optionally constrained by
+        an ``as_of`` cutoff timestamp.
+    bulk_latest_label_observations: Return the highest-precedence (human-first,
+        then recency) label_observations row for each session in a collection —
+        single round-trip alternative to calling ``latest_label_observation`` in
+        a loop.
     reviewer_set_penalty_prior: Pooled mean false-positive penalty over prior
         runs sharing a reviewer (strict ``valid_at`` cutoff), for the posterior
         outcome prior (C4).
@@ -361,7 +363,8 @@ def append_label_observation(
         pr_state: One of ``open``/``merged``/``closed``/``reverted`` or
             ``None`` when not applicable (e.g. local-branch runs).
         labeler_version: Free-form version tag of the labeler that produced
-            this observation (e.g. ``2026.05.22`` or ``legacy``).
+            this observation (e.g. ``2026.05.22`` for an automated rubric, or
+            ``human`` for a maintainer override).
         evidence_sha: Optional commit SHA / artifact hash that grounds the
             decision; ``None`` when no concrete evidence applies.
         rubric_json: Optional JSON-serialised rubric (``Rubric.to_dict()``).

--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import uuid
 import warnings
 from datetime import datetime, timezone
 from pathlib import Path
@@ -42,6 +43,14 @@ from pathlib import Path
 from daydream.archive.manifest import Manifest
 
 SCHEMA_VERSION = 5
+
+_PRECEDENCE_ORDER = "CASE WHEN source = 'human' THEN 1 ELSE 0 END DESC, observed_at DESC"
+"""SQL ORDER BY expression that ranks label_observations by human-first precedence then recency.
+
+Used identically across append_label_observation, latest_label_observation,
+bulk_latest_label_observations, and label_count_summary — centralised here so
+all callers stay in sync if the precedence rule ever changes.
+"""
 
 _REVIEWER_PENALTY_MAP: dict[str, float] = {
     "accepted": 0.0,
@@ -162,27 +171,50 @@ INSERT OR REPLACE INTO runs (
 """
 
 
-def _migrate_schema(conn: sqlite3.Connection) -> None:
-    """Add columns that exist in _CREATE_TABLE but are missing from the live DB."""
-    existing = {row[1] for row in conn.execute("PRAGMA table_info(runs)").fetchall()}
-    migrations: list[tuple[str, str]] = [
-        ("review_backend", "TEXT"),
-        ("fix_backend", "TEXT"),
-        ("test_backend", "TEXT"),
-        ("rubric_json", "TEXT"),
-        ("base_sha", "TEXT"),
-        ("changed_files", "TEXT"),
-        ("composite_reward", "REAL"),
-        ("source_path", "TEXT"),
-        ("has_posterior", "INTEGER NOT NULL DEFAULT 0"),
-    ]
+def _alter_add_missing(
+    conn: sqlite3.Connection,
+    table: str,
+    migrations: list[tuple[str, str]],
+) -> None:
+    """ALTER TABLE *table* to add any columns in *migrations* that are absent.
+
+    Each entry in *migrations* is a ``(column_name, column_type)`` pair.
+    Missing columns are added idempotently; a ``duplicate column name`` error
+    (raised by a race between concurrent openers) is silently swallowed, which
+    preserves the warn-and-continue semantics of the callers it replaces.
+
+    Args:
+        conn: An open SQLite connection.
+        table: Name of the table to inspect and alter.
+        migrations: Ordered list of ``(col, col_type)`` pairs to apply.
+    """
+    existing = {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}  # noqa: S608 - table is a module-local constant at every call site
     for col, col_type in migrations:
         if col not in existing:
             try:
-                conn.execute(f"ALTER TABLE runs ADD COLUMN {col} {col_type}")  # noqa: S608 - col/col_type are module-local constants
+                conn.execute(f"ALTER TABLE {table} ADD COLUMN {col} {col_type}")  # noqa: S608 - col/col_type are module-local constants
             except sqlite3.OperationalError as exc:
                 if "duplicate column name" not in str(exc).lower():
                     raise
+
+
+def _migrate_schema(conn: sqlite3.Connection) -> None:
+    """Add columns that exist in _CREATE_TABLE but are missing from the live DB."""
+    _alter_add_missing(
+        conn,
+        "runs",
+        [
+            ("review_backend", "TEXT"),
+            ("fix_backend", "TEXT"),
+            ("test_backend", "TEXT"),
+            ("rubric_json", "TEXT"),
+            ("base_sha", "TEXT"),
+            ("changed_files", "TEXT"),
+            ("composite_reward", "REAL"),
+            ("source_path", "TEXT"),
+            ("has_posterior", "INTEGER NOT NULL DEFAULT 0"),
+        ],
+    )
 
 
 def _recreate_label_observations_if_stale(conn: sqlite3.Connection) -> None:
@@ -217,24 +249,19 @@ def _migrate_label_observations_schema(conn: sqlite3.Connection) -> None:
     Unlike ``_recreate_label_observations_if_stale`` (which drop-recreates for
     structural bitemporal/posterior columns), this is non-destructive: the
     ``source`` precedence marker is additive, so pre-existing rows are preserved
-    and default to ``'auto'``. Mirrors ``_migrate_schema`` (the runs migration).
+    and default to ``'auto'``. Delegates to ``_alter_add_missing`` (the shared
+    helper that also backs ``_migrate_schema`` for the runs table).
 
     Args:
         conn: An open connection whose ``label_observations`` table exists.
     """
-    existing = {row[1] for row in conn.execute("PRAGMA table_info(label_observations)").fetchall()}
-    migrations: list[tuple[str, str]] = [
-        ("source", "TEXT NOT NULL DEFAULT 'auto'"),
-    ]
-    for col, col_type in migrations:
-        if col not in existing:
-            try:
-                conn.execute(
-                    f"ALTER TABLE label_observations ADD COLUMN {col} {col_type}"  # noqa: S608 - col/col_type are module-local constants
-                )
-            except sqlite3.OperationalError as exc:
-                if "duplicate column name" not in str(exc).lower():
-                    raise
+    _alter_add_missing(
+        conn,
+        "label_observations",
+        [
+            ("source", "TEXT NOT NULL DEFAULT 'auto'"),
+        ],
+    )
 
 
 def _get_connection(archive_dir: Path) -> sqlite3.Connection:
@@ -410,7 +437,7 @@ def append_label_observation(
     Raises:
         ValueError: When ``session_id`` is not present in the ``runs`` table.
     """
-    observed_at = datetime.now(timezone.utc).isoformat()
+    observed_at = datetime.now(timezone.utc).isoformat() + "~" + uuid.uuid4().hex[:8]
     valid_at_value = valid_at if valid_at is not None else observed_at
     labels_json = json.dumps(labels)
     reviewer_logins_json = json.dumps(reviewer_logins) if reviewer_logins is not None else None
@@ -429,7 +456,7 @@ def append_label_observation(
         # appended in between cannot mask a genuine automated re-score.
         if source == "auto":
             latest_auto = conn.execute(
-                "SELECT evidence_sha, reward_version FROM label_observations "
+                "SELECT evidence_sha, reward_version, labels FROM label_observations "
                 "WHERE session_id = ? AND source = 'auto' "
                 "ORDER BY observed_at DESC LIMIT 1",
                 (session_id,),
@@ -438,6 +465,7 @@ def append_label_observation(
                 latest_auto is not None
                 and latest_auto["evidence_sha"] == evidence_sha
                 and latest_auto["reward_version"] == reward_version
+                and latest_auto["labels"] == labels_json
             ):
                 return False
         conn.execute(
@@ -467,9 +495,9 @@ def append_label_observation(
         # necessarily the row just inserted (a newer auto must not dethrone a
         # human label).
         winner = conn.execute(
-            "SELECT labels, observed_at, rubric_json, composite_reward, has_posterior "
-            "FROM label_observations WHERE session_id = ? "
-            "ORDER BY CASE WHEN source = 'human' THEN 1 ELSE 0 END DESC, observed_at DESC LIMIT 1",
+            f"SELECT labels, observed_at, rubric_json, composite_reward, has_posterior "
+            f"FROM label_observations WHERE session_id = ? "
+            f"ORDER BY {_PRECEDENCE_ORDER} LIMIT 1",
             (session_id,),
         ).fetchone()
         conn.execute(
@@ -516,14 +544,14 @@ def latest_label_observation(
     try:
         if as_of is None:
             cursor = conn.execute(
-                "SELECT * FROM label_observations WHERE session_id = ? "
-                "ORDER BY CASE WHEN source = 'human' THEN 1 ELSE 0 END DESC, observed_at DESC LIMIT 1",
+                f"SELECT * FROM label_observations WHERE session_id = ? "
+                f"ORDER BY {_PRECEDENCE_ORDER} LIMIT 1",
                 (session_id,),
             )
         else:
             cursor = conn.execute(
-                "SELECT * FROM label_observations WHERE session_id = ? AND observed_at <= ? "
-                "ORDER BY CASE WHEN source = 'human' THEN 1 ELSE 0 END DESC, observed_at DESC LIMIT 1",
+                f"SELECT * FROM label_observations WHERE session_id = ? AND observed_at <= ? "
+                f"ORDER BY {_PRECEDENCE_ORDER} LIMIT 1",
                 (session_id, as_of),
             )
         row = cursor.fetchone()
@@ -572,8 +600,7 @@ def bulk_latest_label_observations(
                     SELECT *,
                            ROW_NUMBER() OVER (
                                PARTITION BY session_id
-                               ORDER BY CASE WHEN source = 'human' THEN 1 ELSE 0 END DESC,
-                                        observed_at DESC
+                               ORDER BY {_PRECEDENCE_ORDER}
                            ) AS _rn
                     FROM label_observations
                     WHERE session_id IN ({placeholders})
@@ -590,8 +617,7 @@ def bulk_latest_label_observations(
                     SELECT *,
                            ROW_NUMBER() OVER (
                                PARTITION BY session_id
-                               ORDER BY CASE WHEN source = 'human' THEN 1 ELSE 0 END DESC,
-                                        observed_at DESC
+                               ORDER BY {_PRECEDENCE_ORDER}
                            ) AS _rn
                     FROM label_observations
                     WHERE session_id IN ({placeholders})
@@ -923,29 +949,27 @@ def label_count_summary(
     try:
         if as_of is None:
             best_sql = (
-                "SELECT session_id, labels FROM ("
-                "  SELECT session_id, labels, "
-                "         ROW_NUMBER() OVER ("
-                "             PARTITION BY session_id "
-                "             ORDER BY CASE WHEN source = 'human' THEN 1 ELSE 0 END DESC, "
-                "                      observed_at DESC"
-                "         ) AS _rn "
-                "  FROM label_observations"
-                ") WHERE _rn = 1"
+                f"SELECT session_id, labels FROM ("
+                f"  SELECT session_id, labels, "
+                f"         ROW_NUMBER() OVER ("
+                f"             PARTITION BY session_id "
+                f"             ORDER BY {_PRECEDENCE_ORDER}"
+                f"         ) AS _rn "
+                f"  FROM label_observations"
+                f") WHERE _rn = 1"
             )
             params: tuple = ()
         else:
             best_sql = (
-                "SELECT session_id, labels FROM ("
-                "  SELECT session_id, labels, "
-                "         ROW_NUMBER() OVER ("
-                "             PARTITION BY session_id "
-                "             ORDER BY CASE WHEN source = 'human' THEN 1 ELSE 0 END DESC, "
-                "                      observed_at DESC"
-                "         ) AS _rn "
-                "  FROM label_observations "
-                "  WHERE observed_at <= ?"
-                ") WHERE _rn = 1"
+                f"SELECT session_id, labels FROM ("
+                f"  SELECT session_id, labels, "
+                f"         ROW_NUMBER() OVER ("
+                f"             PARTITION BY session_id "
+                f"             ORDER BY {_PRECEDENCE_ORDER}"
+                f"         ) AS _rn "
+                f"  FROM label_observations "
+                f"  WHERE observed_at <= ?"
+                f") WHERE _rn = 1"
             )
             params = (as_of,)
 

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -895,7 +895,7 @@ def _handle_harvest_command(argv: list[str]) -> int:
         print_error(console, "Invalid --gh-spacing-sec", "Must be >= 0.0.")
         return 1
 
-    archive_dir = args.archive_dir if args.archive_dir is not None else _archive.get_archive_dir()
+    archive_dir = args.archive_dir.expanduser() if args.archive_dir is not None else _archive.get_archive_dir()
     cache_dir = args.cache_dir.expanduser() if args.cache_dir is not None else None
 
     repo_clone_root = args.repo_clone_root.expanduser() if args.repo_clone_root is not None else None
@@ -985,7 +985,7 @@ def _handle_label_command(argv: list[str]) -> int:
     args = parser.parse_args(argv)
 
     console = create_console()
-    archive_dir = args.archive_dir if args.archive_dir is not None else _archive.get_archive_dir()
+    archive_dir = args.archive_dir.expanduser() if args.archive_dir is not None else _archive.get_archive_dir()
 
     prior = _index.latest_label_observation(archive_dir, args.session)
     if prior is not None and prior.get("labels"):

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -8,6 +8,8 @@ positional):
 - ``daydream summarize <path>`` — print run-info markdown for a trajectory
 - ``daydream harvest`` — walk the archive and append one bitemporal
   annotation (outcome label + intrinsic reward) per indexed run
+- ``daydream label <session-prefix> --outcome {accepted,contested,rejected,unknown}``
+  — record an authoritative human outcome label that overrides automated ones
 - ``daydream build-corpus --out <path>`` — project the as-of-pinned
   annotations into a JSONL training corpus plus a lineage manifest
 """
@@ -920,6 +922,91 @@ def _handle_harvest_command(argv: list[str]) -> int:
     return 0
 
 
+def _build_label_parser() -> argparse.ArgumentParser:
+    """Build the parser for ``daydream label <session-prefix> --outcome ...``.
+
+    Records a human-sourced outcome label that wins over automated rubric
+    labels in every precedence projection (and is never deduped). ``unknown``
+    is an allowed human outcome (per spec) — a deliberate "I looked and can't
+    decide" signal distinct from an unlabeled run.
+    """
+    parser = argparse.ArgumentParser(
+        prog="daydream label",
+        description=(
+            "Set an authoritative human outcome label on an archived run "
+            "(overrides automated rubric labels)."
+        ),
+    )
+    parser.add_argument(
+        "session",
+        type=str,
+        metavar="SESSION_PREFIX",
+        help="Full or prefix session_id to label (must match exactly one run).",
+    )
+    parser.add_argument(
+        "--outcome",
+        type=str,
+        required=True,
+        dest="outcome",
+        choices=["accepted", "contested", "rejected", "unknown"],
+        help="Human outcome label to record.",
+    )
+    parser.add_argument(
+        "--archive-dir",
+        type=Path,
+        default=None,
+        dest="archive_dir",
+        metavar="PATH",
+        help="Override the archive root (default: daydream.archive.get_archive_dir()).",
+    )
+    return parser
+
+
+def _handle_label_command(argv: list[str]) -> int:
+    """Handle ``daydream label <session-prefix> --outcome {...}``.
+
+    Resolves the archive dir, echoes the label being overridden (the
+    "show what it's overriding" affordance), then writes a human-sourced
+    observation via :func:`daydream.archive.index.update_labels`. The runs
+    cache and every precedence projection settle on the human value.
+
+    Args:
+        argv: The argument vector after the ``label`` verb.
+
+    Returns:
+        ``0`` on success; ``1`` when no session matches the prefix or the
+        prefix is ambiguous.
+    """
+    import daydream.archive as _archive
+    from daydream.archive import index as _index
+    from daydream.ui import create_console, print_info
+
+    parser = _build_label_parser()
+    args = parser.parse_args(argv)
+
+    console = create_console()
+    archive_dir = args.archive_dir if args.archive_dir is not None else _archive.get_archive_dir()
+
+    prior = _index.latest_label_observation(archive_dir, args.session)
+    if prior is not None and prior.get("labels"):
+        print_info(console, f"Current label for {args.session}: {prior['labels']}")
+    else:
+        print_info(console, f"No prior label for {args.session}.")
+
+    try:
+        updated = _index.update_labels(archive_dir, args.session, [args.outcome])
+    except ValueError as exc:
+        print_error(console, "Ambiguous session prefix", str(exc))
+        return 1
+
+    if not updated:
+        print_error(console, "No matching session", f"No archived run matches prefix '{args.session}'.")
+        return 1
+
+    print_info(console, f"Set human label for {args.session}: {args.outcome}")
+    return 0
+
+
 def main() -> None:
     """Run the CLI entry point.
 
@@ -952,6 +1039,11 @@ def main() -> None:
         # ``harvest`` drives the annotate-pass orchestrator via its own anyio.run.
         if argv and argv[0] == "harvest":
             sys.exit(_handle_harvest_command(argv[1:]))
+
+        # ``label`` records an authoritative human outcome label — sync,
+        # SQLite-only. Short-circuit before anyio.run.
+        if argv and argv[0] == "label":
+            sys.exit(_handle_label_command(argv[1:]))
 
         is_feedback_subcommand = bool(argv) and argv[0] == "feedback"
         config = _parse_args()

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -41,6 +41,19 @@ from typing import Any
 
 _logger = logging.getLogger(__name__)
 
+# Substrings (lowercased) that identify a GitHub API rate-limit response in
+# ``gh`` stderr output.  Kept as a module constant so the classifier and any
+# future callers share a single source of truth.
+#
+# NOTE: "429" is intentionally absent here; HTTP 429 is matched separately in
+# ``_gh_error_for`` with a word-boundary regex to avoid false positives on
+# arbitrary digit sequences (e.g. URLs, SHAs, file sizes) that happen to
+# contain those three digits.
+_RATE_LIMIT_MARKERS: tuple[str, ...] = (
+    "rate limit",
+    "secondary rate limit",
+)
+
 # --- Errors ------------------------------------------------------------------
 
 
@@ -1082,16 +1095,16 @@ def _gh_error_for(message: str, stderr: str) -> GitError:
     """Classify a ``gh`` failure into a rate-limit error or a plain GitError.
 
     Detection is on the stderr string only: a case-insensitive match against
-    ``rate limit``, ``429``, ``secondary rate limit``, or ``403`` co-occurring
-    with ``rate`` yields a :class:`RateLimitError` (with ``retry_after`` parsed
-    from the stderr when an integer hint is present). Anything else returns a
-    plain :class:`GitError` so non-rate-limit failures are never swallowed.
+    ``rate limit``, ``secondary rate limit``, a word-boundary ``429`` (HTTP
+    status code), or ``403`` co-occurring with ``rate`` yields a
+    :class:`RateLimitError` (with ``retry_after`` parsed from the stderr when
+    an integer hint is present). Anything else returns a plain
+    :class:`GitError` so non-rate-limit failures are never swallowed.
     """
     lowered = stderr.lower()
     is_rate_limit = (
-        "rate limit" in lowered
-        or "429" in lowered
-        or "secondary rate limit" in lowered
+        any(marker in lowered for marker in _RATE_LIMIT_MARKERS)
+        or re.search(r"\b429\b", lowered) is not None
         or ("403" in lowered and "rate" in lowered)
     )
     if not is_rate_limit:

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import subprocess
 import tempfile
 from pathlib import Path
@@ -45,6 +46,19 @@ _logger = logging.getLogger(__name__)
 
 class GitError(Exception):
     """Base class for all git/gh failures raised by :mod:`daydream.git_ops`."""
+
+
+class RateLimitError(GitError):
+    """Raised when a ``gh`` call fails due to a GitHub API rate limit.
+
+    Attributes:
+        retry_after: Suggested seconds to wait before retrying, parsed from the
+            ``gh`` stderr when available; ``None`` when no hint was present.
+    """
+
+    def __init__(self, *args: Any, retry_after: float | None = None) -> None:
+        super().__init__(*args)
+        self.retry_after = retry_after
 
 
 class NotAWorktreeError(GitError):
@@ -1064,6 +1078,31 @@ def gh_repo_view(repo: Path) -> tuple[str, str] | None:
     return owner, name
 
 
+def _gh_error_for(message: str, stderr: str) -> GitError:
+    """Classify a ``gh`` failure into a rate-limit error or a plain GitError.
+
+    Detection is on the stderr string only: a case-insensitive match against
+    ``rate limit``, ``429``, ``secondary rate limit``, or ``403`` co-occurring
+    with ``rate`` yields a :class:`RateLimitError` (with ``retry_after`` parsed
+    from the stderr when an integer hint is present). Anything else returns a
+    plain :class:`GitError` so non-rate-limit failures are never swallowed.
+    """
+    lowered = stderr.lower()
+    is_rate_limit = (
+        "rate limit" in lowered
+        or "429" in lowered
+        or "secondary rate limit" in lowered
+        or ("403" in lowered and "rate" in lowered)
+    )
+    if not is_rate_limit:
+        return GitError(message)
+    retry_after: float | None = None
+    match = re.search(r"retry[- ]after[:\s]+(\d+)", lowered)
+    if match:
+        retry_after = float(match.group(1))
+    return RateLimitError(message, retry_after=retry_after)
+
+
 def gh_api(
     repo: Path,
     endpoint: str,
@@ -1090,7 +1129,9 @@ def gh_api(
         The parsed JSON value (object, list, or scalar).
 
     Raises:
-        GitError: If the call fails or returns invalid JSON.
+        RateLimitError: If the call fails due to a GitHub API rate limit
+            (detected from the ``gh`` stderr marker-set).
+        GitError: If the call fails for any other reason or returns invalid JSON.
     """
     if input_data is None:
         args = ["api"]
@@ -1101,7 +1142,7 @@ def gh_api(
         args.append(endpoint)
         proc = _run_gh(repo, args, timeout=60)
         if proc.returncode != 0:
-            raise GitError(f"gh api {endpoint} failed: {proc.stderr.strip()}")
+            raise _gh_error_for(f"gh api {endpoint} failed: {proc.stderr.strip()}", proc.stderr)
         try:
             return json.loads(proc.stdout)
         except json.JSONDecodeError as exc:
@@ -1123,9 +1164,10 @@ def gh_api(
             args.append("--paginate")
         proc = _run_gh(repo, args, timeout=60)
         if proc.returncode != 0:
-            raise GitError(
+            raise _gh_error_for(
                 f"gh api {endpoint} failed: {proc.stderr.strip()} "
-                f"(request payload preserved at {tmp_path})"
+                f"(request payload preserved at {tmp_path})",
+                proc.stderr,
             )
         try:
             result = json.loads(proc.stdout)

--- a/daydream/training/backfill_cache.py
+++ b/daydream/training/backfill_cache.py
@@ -106,6 +106,11 @@ class BackfillCache:
         self.cache_dir = cache_dir
         self.inner = inner
 
+    @property
+    def progress_path(self) -> Path:
+        """Absolute path of the JSONL resume log (``<cache_dir>/progress.jsonl``)."""
+        return self.cache_dir / "progress.jsonl"
+
     def __call__(self, repo: str, endpoint: str, **kwargs: Any) -> Any:
         """Return the cached response for ``(repo, endpoint, **kwargs)``.
 
@@ -145,8 +150,7 @@ class BackfillCache:
             {"session_id": session_id, "completed_at": _now_iso_utc()},
             sort_keys=True,
         )
-        progress = self.cache_dir / "progress.jsonl"
-        with progress.open("a", encoding="utf-8") as f:
+        with self.progress_path.open("a", encoding="utf-8") as f:
             f.write(line + "\n")
 
     def completed_sessions(self) -> set[str]:
@@ -156,11 +160,10 @@ class BackfillCache:
         are skipped (the log is append-only and a partial last-line
         write is the only realistic failure mode).
         """
-        progress = self.cache_dir / "progress.jsonl"
-        if not progress.exists():
+        if not self.progress_path.exists():
             return set()
         out: set[str] = set()
-        with progress.open("r", encoding="utf-8") as f:
+        with self.progress_path.open("r", encoding="utf-8") as f:
             for raw in f:
                 line = raw.strip()
                 if not line:

--- a/daydream/training/corpus.py
+++ b/daydream/training/corpus.py
@@ -381,7 +381,13 @@ def _build_record(
     # Rubric + posterior_source are additive optional fields. The schema models
     # ``rubric`` as ``type: object`` and ``posterior_source`` as an enum string
     # — neither nullable — so each key is written only when a value is present.
-    raw_rubric = manifest_row.get("rubric_json")
+    # Read rubric_json from the as_of-pinned annotation, NOT from the
+    # denormalized runs.rubric_json cache.  The cache is always the current
+    # human-first winner (no as_of constraint), so a human annotation appended
+    # after the corpus pin would retroactively change this field and break
+    # as_of reproducibility.  The label_observations row already carries
+    # rubric_json (it is self-describing per the silver-layer contract).
+    raw_rubric = annotation.get("rubric_json") if annotation is not None else None
     parsed_rubric: dict | None = None
     if isinstance(raw_rubric, str) and raw_rubric:
         try:

--- a/daydream/training/harvest.py
+++ b/daydream/training/harvest.py
@@ -77,6 +77,7 @@ injection seams.
 from __future__ import annotations
 
 import json
+import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -87,7 +88,7 @@ from rich.console import Console
 
 from daydream import git_ops
 from daydream.archive.index import append_label_observation, query_runs, reviewer_set_penalty_prior
-from daydream.git_ops import GitError
+from daydream.git_ops import GitError, RateLimitError
 from daydream.training import reward
 from daydream.training.backfill_cache import BackfillCache
 from daydream.training.base_sha import materialize_base_sha
@@ -224,6 +225,19 @@ def assemble_scoring_inputs(run_dir: Path, row: dict[str, Any]) -> ScoringInputs
 # git / gh wrappers — module-level so they double as monkeypatch seams.
 # ---------------------------------------------------------------------------
 
+# Bounded rate-limit backoff for the gh seam. When GitHub returns a rate-limit
+# error, ``_gh_api`` sleeps and retries up to ``_MAX_RATE_LIMIT_RETRIES`` times,
+# honoring a parsed ``Retry-After`` (capped at ``_MAX_BACKOFF_SEC``) and falling
+# back to ``_DEFAULT_BACKOFF_SEC`` when none is supplied.
+_DEFAULT_BACKOFF_SEC = 30.0
+_MAX_BACKOFF_SEC = 120.0
+_MAX_RATE_LIMIT_RETRIES = 5
+
+
+def _rate_limit_sleep(seconds: float) -> None:
+    """Sleep ``seconds`` between rate-limit retries (seam for tests to stub)."""
+    time.sleep(seconds)
+
 
 def _gh_api(repo: str, endpoint: str, **kwargs: Any) -> Any:
     """Proxy to :func:`daydream.git_ops.gh_api` keyed by ``repo`` slug.
@@ -235,12 +249,27 @@ def _gh_api(repo: str, endpoint: str, **kwargs: Any) -> Any:
     because it authenticates against the GitHub host configured in ``gh auth``,
     not the local repo.
 
+    On a :class:`~daydream.git_ops.RateLimitError`, we sleep with bounded
+    backoff (``min(retry_after or _DEFAULT_BACKOFF_SEC, _MAX_BACKOFF_SEC)``) and
+    retry up to ``_MAX_RATE_LIMIT_RETRIES`` times; if the limit is still
+    exhausted, the :class:`RateLimitError` propagates so the orchestrator can
+    abort cleanly while preserving its resume marker.
+
     Limitation: ``repo`` is accepted for API compatibility but is not used to
     resolve the GitHub host; all requests go to the single host configured in
     ``gh auth`` (typically ``github.com``). Mixing repos from different GitHub
     hosts in a single harvest run would silently use the wrong host.
     """
-    return git_ops.gh_api(Path("."), endpoint, **kwargs)
+    for attempt in range(_MAX_RATE_LIMIT_RETRIES):
+        try:
+            return git_ops.gh_api(Path("."), endpoint, **kwargs)
+        except RateLimitError as exc:
+            if attempt == _MAX_RATE_LIMIT_RETRIES - 1:
+                raise
+            backoff = min(exc.retry_after or _DEFAULT_BACKOFF_SEC, _MAX_BACKOFF_SEC)
+            _rate_limit_sleep(backoff)
+    # Unreachable: the loop either returns or raises on the final attempt.
+    raise RuntimeError("rate-limit retry loop exited without returning")  # pragma: no cover
 
 
 def _diff_name_only(repo: Path, base: str, head: str) -> list[str]:
@@ -718,7 +747,8 @@ async def run_harvest(config: HarvestConfig) -> dict[str, int]:
 
     Returns:
         Summary dict with keys ``considered``, ``annotated``,
-        ``would_annotate``, ``skipped``, ``errors``.
+        ``would_annotate``, ``skipped``, ``errors``, and ``aborted`` (``1`` when
+        the sweep stopped early on an exhausted GitHub rate limit, else ``0``).
 
     Raises:
         FileNotFoundError: When ``config.archive_dir`` does not exist.
@@ -760,6 +790,7 @@ async def run_harvest(config: HarvestConfig) -> dict[str, int]:
         "would_annotate": 0,
         "skipped": 0,
         "errors": 0,
+        "aborted": 0,
     }
 
     console = create_console()
@@ -805,6 +836,20 @@ async def run_harvest(config: HarvestConfig) -> dict[str, int]:
                 # Either way the row is "done" for resume — re-running must not re-fetch it.
                 if cache is not None:
                     cache.mark_session_done(row["session_id"])
+        except RateLimitError:
+            # Rate limit exhausted after bounded backoff: abort the whole sweep
+            # cleanly. The failed row is NOT marked done, so its resume marker is
+            # preserved and a later re-run picks up exactly where we stopped.
+            summary["aborted"] = 1
+            resume_marker = (config.cache_dir / "progress.jsonl") if config.cache_dir else None
+            print_warning(
+                console,
+                "harvest: GitHub rate limit exhausted; aborting cleanly. "
+                f"Resume from {resume_marker} by re-running with the same --cache-dir."
+                if resume_marker is not None
+                else "harvest: GitHub rate limit exhausted; aborting cleanly.",
+            )
+            break
         except Exception as exc:  # noqa: BLE001 - per-row isolation by design
             summary["errors"] += 1
             print_warning(

--- a/daydream/training/harvest.py
+++ b/daydream/training/harvest.py
@@ -55,11 +55,12 @@ Annotation builder:
 
 Orchestrator (:func:`run_harvest`):
 
-* **Append-only and re-runnable:** every indexed run is considered on every
-  pass; rows that already carry an annotation are *not* skipped — a re-harvest
-  appends a fresh generation so a ``REWARD_VERSION`` bump can re-score the whole
-  archive while older ``as_of`` pins still resolve their original generation.
-  Only the ``cache``/``dry_run`` paths suppress writes.
+* **Idempotent and re-runnable:** every indexed run is considered on every
+  pass, but the write layer dedups on ``(evidence_sha, reward_version)`` — a
+  re-harvest with unchanged evidence is a no-op (counted in ``skipped``). A
+  ``REWARD_VERSION`` bump changes the dedup key and so appends a fresh
+  generation, letting older ``as_of`` pins still resolve their original
+  generation. Only the ``cache``/``dry_run`` paths otherwise suppress writes.
 * **Per-row error isolation:** an exception on one row counts in ``errors`` and
   does not derail subsequent rows. Configuration errors (missing
   ``archive_dir``) raise before the loop begins.
@@ -701,11 +702,12 @@ async def run_harvest(config: HarvestConfig) -> dict[str, int]:
     :func:`daydream.archive.index.append_label_observation` (which persists
     ``reviewer_logins`` and the ``has_posterior`` population discriminator).
 
-    **Append-only and re-runnable:** rows that already carry an annotation are
-    *not* skipped — a re-harvest appends a fresh generation, so a later
-    ``REWARD_VERSION`` bump can re-score the whole archive while older
-    ``as_of`` pins still resolve their original generation. Only the
-    ``cache``/``dry_run`` paths suppress writes.
+    **Idempotent and re-runnable:** every indexed run is considered, but the
+    write layer dedups on ``(evidence_sha, reward_version)`` — a re-harvest with
+    unchanged evidence is a no-op counted in ``skipped``. A later
+    ``REWARD_VERSION`` bump changes the dedup key and so appends a fresh
+    generation, letting older ``as_of`` pins still resolve their original
+    generation. Only the ``cache``/``dry_run`` paths otherwise suppress writes.
 
     Per-row error isolation: an exception on one row counts in ``errors`` and
     does not derail subsequent rows. Configuration errors (missing
@@ -726,9 +728,10 @@ async def run_harvest(config: HarvestConfig) -> dict[str, int]:
         msg = f"archive_dir does not exist: {config.archive_dir}"
         raise FileNotFoundError(msg)
 
-    # Build the queue: every indexed run, optionally prefix-filtered. Unlike
-    # the old labeler, we do NOT drop rows that already carry an annotation —
-    # harvest is append-only and re-runnable.
+    # Build the queue: every indexed run, optionally prefix-filtered. We do not
+    # pre-drop annotated rows — the write layer makes re-harvest idempotent by
+    # deduping on unchanged ``(evidence_sha, reward_version)`` (a version bump
+    # still appends a new generation).
     if config.session_filter:
         queue = query_runs(
             config.archive_dir,
@@ -779,7 +782,7 @@ async def run_harvest(config: HarvestConfig) -> dict[str, int]:
             if config.dry_run:
                 summary["would_annotate"] += 1
             else:
-                append_label_observation(
+                appended = append_label_observation(
                     config.archive_dir,
                     row["session_id"],
                     labels=payload.labels,
@@ -794,7 +797,12 @@ async def run_harvest(config: HarvestConfig) -> dict[str, int]:
                     reviewer_logins=payload.reviewer_logins,
                     has_posterior=payload.has_posterior,
                 )
-                summary["annotated"] += 1
+                if appended:
+                    summary["annotated"] += 1
+                else:
+                    # Deduped: unchanged evidence/reward-version is a no-op re-run.
+                    summary["skipped"] += 1
+                # Either way the row is "done" for resume — re-running must not re-fetch it.
                 if cache is not None:
                     cache.mark_session_done(row["session_id"])
         except Exception as exc:  # noqa: BLE001 - per-row isolation by design

--- a/daydream/training/harvest.py
+++ b/daydream/training/harvest.py
@@ -267,6 +267,11 @@ def _gh_api(repo: str, endpoint: str, **kwargs: Any) -> Any:
             if attempt == _MAX_RATE_LIMIT_RETRIES - 1:
                 raise
             backoff = min(exc.retry_after or _DEFAULT_BACKOFF_SEC, _MAX_BACKOFF_SEC)
+            print_warning(
+                create_console(),
+                f"harvest: GitHub rate limit hit; retrying in {backoff:.0f}s "
+                f"(attempt {attempt + 1}/{_MAX_RATE_LIMIT_RETRIES - 1})",
+            )
             _rate_limit_sleep(backoff)
     # Unreachable: the loop either returns or raises on the final attempt.
     raise RuntimeError("rate-limit retry loop exited without returning")  # pragma: no cover
@@ -841,14 +846,14 @@ async def run_harvest(config: HarvestConfig) -> dict[str, int]:
             # cleanly. The failed row is NOT marked done, so its resume marker is
             # preserved and a later re-run picks up exactly where we stopped.
             summary["aborted"] = 1
-            resume_marker = (config.cache_dir / "progress.jsonl") if config.cache_dir else None
-            print_warning(
-                console,
+            resume_marker = cache.progress_path if cache is not None else None
+            abort_msg = (
                 "harvest: GitHub rate limit exhausted; aborting cleanly. "
                 f"Resume from {resume_marker} by re-running with the same --cache-dir."
                 if resume_marker is not None
-                else "harvest: GitHub rate limit exhausted; aborting cleanly.",
+                else "harvest: GitHub rate limit exhausted; aborting cleanly."
             )
+            print_warning(console, abort_msg)
             break
         except Exception as exc:  # noqa: BLE001 - per-row isolation by design
             summary["errors"] += 1

--- a/daydream/training/harvest.py
+++ b/daydream/training/harvest.py
@@ -684,7 +684,7 @@ def _materialize_base_sha_if_missing(
 
 
 # ---------------------------------------------------------------------------
-# Orchestrator — append-only, re-runnable, per-row isolation
+# Orchestrator — idempotent (evidence-hash dedup), re-runnable, per-row isolation
 # ---------------------------------------------------------------------------
 
 

--- a/daydream/training/harvest.py
+++ b/daydream/training/harvest.py
@@ -250,7 +250,9 @@ def _gh_api(repo: str, endpoint: str, **kwargs: Any) -> Any:
     not the local repo.
 
     On a :class:`~daydream.git_ops.RateLimitError`, we sleep with bounded
-    backoff (``min(retry_after or _DEFAULT_BACKOFF_SEC, _MAX_BACKOFF_SEC)``) and
+    backoff (``min(retry_after, _MAX_BACKOFF_SEC)``, falling back to
+    ``_DEFAULT_BACKOFF_SEC`` only when ``retry_after`` is absent, so an explicit
+    ``Retry-After: 0`` hint is preserved) and
     retry up to ``_MAX_RATE_LIMIT_RETRIES`` times; if the limit is still
     exhausted, the :class:`RateLimitError` propagates so the orchestrator can
     abort cleanly while preserving its resume marker.
@@ -266,7 +268,8 @@ def _gh_api(repo: str, endpoint: str, **kwargs: Any) -> Any:
         except RateLimitError as exc:
             if attempt == _MAX_RATE_LIMIT_RETRIES - 1:
                 raise
-            backoff = min(exc.retry_after or _DEFAULT_BACKOFF_SEC, _MAX_BACKOFF_SEC)
+            retry_after = exc.retry_after if exc.retry_after is not None else _DEFAULT_BACKOFF_SEC
+            backoff = min(retry_after, _MAX_BACKOFF_SEC)
             print_warning(
                 create_console(),
                 f"harvest: GitHub rate limit hit; retrying in {backoff:.0f}s "

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -17,6 +17,8 @@ from daydream.archive import _copy_bundle, archive_run, get_archive_dir
 from daydream.archive.git_context import GitContext, _parse_repo_slug, capture_git_context
 from daydream.archive.index import (
     append_label_observation,
+    bulk_latest_label_observations,
+    label_count_summary,
     label_observation_history,
     latest_label_observation,
     query_runs,
@@ -676,6 +678,20 @@ def test_label_observations_source_column_migrates(tmp_path: Path):
     assert "source" in cols
     rows = label_observation_history(tmp_path, "s-mig")
     assert rows and rows[0]["source"] == "auto"  # existing row defaulted, non-destructive
+
+
+def test_human_label_wins_over_newer_auto_in_projection(tmp_path: Path):
+    upsert_run(tmp_path, _make_manifest(session_id="s-prec"))
+    append_label_observation(tmp_path, "s-prec", labels=["rejected"], pr_state="closed",
+                             labeler_version="auto-v1", evidence_sha="sha1", source="auto")
+    append_label_observation(tmp_path, "s-prec", labels=["accepted"], pr_state=None,
+                             labeler_version="human", evidence_sha=None, source="human")
+    # A NEWER auto observation must NOT dethrone the human label:
+    append_label_observation(tmp_path, "s-prec", labels=["rejected"], pr_state="closed",
+                             labeler_version="auto-v2", evidence_sha="sha2", source="auto")
+    assert latest_label_observation(tmp_path, "s-prec")["labels"] == '["accepted"]'
+    assert bulk_latest_label_observations(tmp_path, ["s-prec"])["s-prec"]["labels"] == '["accepted"]'
+    assert label_count_summary(tmp_path) == {"accepted": 1}
 
 
 def test_append_observation_persists_valid_at_and_reward(tmp_path: Path):

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -849,6 +849,50 @@ def test_latest_label_observation_filtered_by_as_of(tmp_path: Path) -> None:
     assert json.loads(pinned["labels"]) == ["unknown"]
 
 
+def test_same_microsecond_collision_keeps_clean_iso_timestamps(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two appends frozen to the same microsecond must both persist with parseable
+    ISO 8601 observed_at values, and an exact-boundary as_of must include the
+    boundary row (the contract the ~uuid suffix used to break)."""
+    from datetime import datetime, timezone
+
+    frozen = datetime(2026, 5, 29, 12, 0, 0, tzinfo=timezone.utc)
+
+    class _FrozenDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):  # type: ignore[override]
+            return frozen if tz is None else frozen.astimezone(tz)
+
+    monkeypatch.setattr("daydream.archive.index.datetime", _FrozenDatetime)
+
+    _seed_one_run(tmp_path, "sess-collide")
+    append_label_observation(
+        tmp_path, "sess-collide", labels=["unknown"], pr_state="open",
+        labeler_version="v1", evidence_sha="a",
+    )
+    append_label_observation(
+        tmp_path, "sess-collide", labels=["accepted"], pr_state="merged",
+        labeler_version="v1", evidence_sha="b",
+    )
+
+    hist = label_observation_history(tmp_path, "sess-collide")
+    assert len(hist) == 2
+    stamps = [r["observed_at"] for r in hist]
+    assert stamps[0] != stamps[1]
+    for r in hist:
+        datetime.fromisoformat(r["observed_at"])  # parseable, no ~uuid suffix
+        assert r["valid_at"] == r["observed_at"]
+
+    runs_row = query_runs(tmp_path, "session_id = ?", ("sess-collide",))[0]
+    datetime.fromisoformat(runs_row["labeled_at"])
+
+    boundary = stamps[0]
+    pinned = latest_label_observation(tmp_path, "sess-collide", as_of=boundary)
+    assert pinned is not None
+    assert json.loads(pinned["labels"]) == ["unknown"]  # boundary row included
+
+
 def test_append_label_observation_persists_reviewer_and_posterior_flag(tmp_path: Path) -> None:
     """reviewer_logins + has_posterior persist on the observation row and mirror onto runs."""
     _seed_one_run(tmp_path, "s1")

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -617,6 +617,67 @@ def test_label_observations_has_bitemporal_reward_columns(tmp_path: Path):
     assert "composite_reward" in runs_cols
 
 
+_OLD_LABEL_OBSERVATIONS_DDL = """
+CREATE TABLE IF NOT EXISTS label_observations (
+    session_id       TEXT NOT NULL,
+    observed_at      TEXT NOT NULL,
+    labels           TEXT NOT NULL,
+    pr_state         TEXT,
+    labeler_version  TEXT NOT NULL,
+    evidence_sha     TEXT,
+    rubric_json      TEXT,
+    valid_at         TEXT,
+    reward_version   TEXT,
+    reward_json      TEXT,
+    composite_reward REAL,
+    reviewer_logins  TEXT,
+    has_posterior    INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (session_id, observed_at)
+)
+"""
+
+
+def _label_obs_columns(archive_dir: Path) -> set[str]:
+    conn = sqlite3.connect(str(archive_dir / "index.db"))
+    try:
+        return {r[1] for r in conn.execute("PRAGMA table_info(label_observations)")}
+    finally:
+        conn.close()
+
+
+def _seed_legacy_label_observation(archive_dir: Path, session_id: str) -> None:
+    """Insert a label_observations row using the OLD DDL that lacks ``source``."""
+    conn = sqlite3.connect(str(archive_dir / "index.db"))
+    try:
+        conn.execute("DROP TABLE IF EXISTS label_observations")
+        conn.execute(_OLD_LABEL_OBSERVATIONS_DDL)
+        conn.execute(
+            "INSERT INTO label_observations "
+            "(session_id, observed_at, labels, pr_state, labeler_version, evidence_sha) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (session_id, "2026-01-01T00:00:00+00:00", '["accepted"]', "merged", "v1", "sha1"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_label_observations_source_column_migrates(tmp_path: Path):
+    # Build the schema, then simulate a pre-source DB by replacing the table with
+    # the OLD DDL (no `source`) and seeding a legacy row.
+    upsert_run(tmp_path, _make_manifest(session_id="s-mig"))
+    _seed_legacy_label_observation(tmp_path, "s-mig")
+    assert "source" not in _label_obs_columns(tmp_path)  # precondition: legacy shape
+
+    # Open via the production connection path, which must ALTER-ADD `source`.
+    upsert_run(tmp_path, _make_manifest(session_id="s-mig2"))
+
+    cols = _label_obs_columns(tmp_path)
+    assert "source" in cols
+    rows = label_observation_history(tmp_path, "s-mig")
+    assert rows and rows[0]["source"] == "auto"  # existing row defaulted, non-destructive
+
+
 def test_append_observation_persists_valid_at_and_reward(tmp_path: Path):
     upsert_run(tmp_path, _make_manifest(session_id="s1"))
     append_label_observation(
@@ -808,7 +869,7 @@ def test_existing_db_migrates_to_posterior_columns(tmp_path: Path) -> None:
     conn.close()
     assert "has_posterior" in runs_cols
     assert {"reviewer_logins", "has_posterior"} <= lo_cols
-    assert user_version == SCHEMA_VERSION == 4
+    assert user_version == SCHEMA_VERSION == 5
 
     obs = latest_label_observation(tmp_path, "mig-1")
     assert obs is not None

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -694,6 +694,19 @@ def test_human_label_wins_over_newer_auto_in_projection(tmp_path: Path):
     assert label_count_summary(tmp_path) == {"accepted": 1}
 
 
+def test_append_cache_reflects_winning_human_label(tmp_path: Path):
+    upsert_run(tmp_path, _make_manifest(session_id="s-cache"))
+    append_label_observation(tmp_path, "s-cache", labels=["rejected"], pr_state="closed",
+                             labeler_version="auto-v1", evidence_sha="sha1", source="auto")
+    append_label_observation(tmp_path, "s-cache", labels=["accepted"], pr_state=None,
+                             labeler_version="human", evidence_sha=None, source="human")
+    # A later auto append must leave the denormalized runs cache on the human label:
+    append_label_observation(tmp_path, "s-cache", labels=["rejected"], pr_state="closed",
+                             labeler_version="auto-v2", evidence_sha="sha2", source="auto")
+    row = query_runs(tmp_path, "session_id = ?", ("s-cache",))[0]
+    assert row["outcome_labels"] == '["accepted"]'
+
+
 def test_append_observation_persists_valid_at_and_reward(tmp_path: Path):
     upsert_run(tmp_path, _make_manifest(session_id="s1"))
     append_label_observation(

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -707,6 +707,31 @@ def test_append_cache_reflects_winning_human_label(tmp_path: Path):
     assert row["outcome_labels"] == '["accepted"]'
 
 
+def test_auto_append_dedups_on_unchanged_evidence(tmp_path: Path):
+    upsert_run(tmp_path, _make_manifest(session_id="s-dedup"))
+    first = append_label_observation(tmp_path, "s-dedup", labels=["accepted"], pr_state="merged",
+                                     labeler_version="rv1", evidence_sha="shaA", source="auto")
+    second = append_label_observation(tmp_path, "s-dedup", labels=["accepted"], pr_state="merged",
+                                      labeler_version="rv1", evidence_sha="shaA", source="auto")
+    assert first is True and second is False
+    assert len(label_observation_history(tmp_path, "s-dedup")) == 1
+    # A reward_version change DOES append:
+    third = append_label_observation(tmp_path, "s-dedup", labels=["accepted"], pr_state="merged",
+                                     labeler_version="rv2", evidence_sha="shaA",
+                                     reward_version="rv2", source="auto")
+    assert third is True
+    assert len(label_observation_history(tmp_path, "s-dedup")) == 2
+
+
+def test_human_append_never_dedups(tmp_path: Path):
+    upsert_run(tmp_path, _make_manifest(session_id="s-h"))
+    append_label_observation(tmp_path, "s-h", labels=["accepted"], pr_state=None,
+                             labeler_version="human", evidence_sha=None, source="human")
+    append_label_observation(tmp_path, "s-h", labels=["accepted"], pr_state=None,
+                             labeler_version="human", evidence_sha=None, source="human")
+    assert len(label_observation_history(tmp_path, "s-h")) == 2
+
+
 def test_append_observation_persists_valid_at_and_reward(tmp_path: Path):
     upsert_run(tmp_path, _make_manifest(session_id="s1"))
     append_label_observation(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -408,7 +408,8 @@ def test_harvest_parser_repo_clone_root_defaults_to_none():
 
 def test_removed_verbs_no_longer_dispatch():
     from daydream import cli
-    # label / export-jsonl / snapshot handlers are gone
-    assert not hasattr(cli, "_handle_label_command")
+    # export-jsonl / snapshot handlers are gone. ``label`` was reintroduced as
+    # the human-override surface (daydream label <prefix> --outcome ...).
     assert not hasattr(cli, "_handle_export_command")
     assert not hasattr(cli, "_handle_snapshot_command")
+    assert hasattr(cli, "_handle_label_command")

--- a/tests/test_cli_label.py
+++ b/tests/test_cli_label.py
@@ -1,0 +1,60 @@
+"""Tests for the ``daydream label`` human-override subcommand.
+
+Drives ``cli._handle_label_command`` directly (the dispatch in ``main`` is a
+thin one-liner). Assertions pin observable state — the denormalized ``runs``
+cache value, the human-sourced observation in history, and the prior label
+echoed to stdout — not mere dispatch.
+"""
+
+from daydream import cli
+from daydream.archive.index import (
+    append_label_observation,
+    label_observation_history,
+    query_runs,
+    upsert_run,
+)
+from daydream.archive.manifest import Manifest
+
+
+def _make_manifest(session_id: str = "sess-0001", **overrides) -> Manifest:
+    defaults = {
+        "session_id": session_id,
+        "archived_at": "2026-04-29T00:00:00+00:00",
+        "status": "complete",
+        "run_flow": "normal",
+        "skill": "python",
+        "model": "opus",
+        "backend": "claude",
+        "archive_path": "/tmp/archive/runs/sess-0001",
+    }
+    defaults.update(overrides)
+    return Manifest(**defaults)
+
+
+def test_label_command_sets_human_label_and_shows_prior(tmp_path, archive_dir, capsys):
+    upsert_run(archive_dir, _make_manifest(session_id="sess-0001"))
+    append_label_observation(
+        archive_dir,
+        "sess-0001",
+        labels=["rejected"],
+        pr_state="closed",
+        labeler_version="auto-v1",
+        evidence_sha="sha1",
+        source="auto",
+    )
+    rc = cli._handle_label_command(["sess-0001", "--outcome", "accepted"])
+    assert rc == 0
+    row = query_runs(archive_dir, "session_id = ?", ("sess-0001",))[0]
+    assert row["outcome_labels"] == '["accepted"]'
+    hist = label_observation_history(archive_dir, "sess-0001")
+    assert hist[-1]["source"] == "human"
+    assert "rejected" in capsys.readouterr().out  # shows what it overrode (Should-Have)
+
+
+def test_label_command_accepts_unknown(tmp_path, archive_dir):
+    upsert_run(archive_dir, _make_manifest(session_id="sess-0002"))
+    assert cli._handle_label_command(["sess-0002", "--outcome", "unknown"]) == 0
+
+
+def test_label_command_unknown_session_returns_1(tmp_path, archive_dir):
+    assert cli._handle_label_command(["no-such", "--outcome", "accepted"]) == 1

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -805,3 +805,29 @@ def test_clone_default_no_filter_flag(tmp_path: Path, monkeypatch: pytest.Monkey
 
     git_ops.clone("https://example.com/repo.git", tmp_path / "out")
     assert "--filter=blob:none" not in captured["cmd"]
+
+
+def test_gh_api_raises_rate_limit_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    class _Proc:
+        returncode = 1
+        stdout = ""
+        stderr = "gh: API rate limit exceeded for user (HTTP 403)"
+
+    monkeypatch.setattr(git_ops, "_run_gh", lambda *a, **k: _Proc())
+    with pytest.raises(git_ops.RateLimitError):
+        git_ops.gh_api(tmp_path, "repos/o/r/pulls/1")
+
+
+def test_gh_api_non_ratelimit_raises_plain_git_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    class _Proc:
+        returncode = 1
+        stdout = ""
+        stderr = "gh: Not Found (HTTP 404)"
+
+    monkeypatch.setattr(git_ops, "_run_gh", lambda *a, **k: _Proc())
+    with pytest.raises(git_ops.GitError):
+        git_ops.gh_api(tmp_path, "repos/o/r/pulls/1")
+    # RateLimitError subclasses GitError; assert the 404 is NOT classified as one:
+    with pytest.raises(git_ops.GitError) as exc:
+        git_ops.gh_api(tmp_path, "repos/o/r/pulls/1")
+    assert not isinstance(exc.value, git_ops.RateLimitError)

--- a/tests/test_training_harvest.py
+++ b/tests/test_training_harvest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Any
 
@@ -13,6 +14,7 @@ from daydream.archive.index import (
     append_label_observation,
     label_observation_history,
     latest_label_observation,
+    pr_attached_label_coverage,
     upsert_run,
 )
 from daydream.archive.manifest import Manifest
@@ -549,3 +551,98 @@ def test_resolve_repo_for_row_fetch_failure_returns_cached_path(tmp_path: Path, 
     row = {"source_path": None, "remote_url": "https://github.com/org/repo.git", "repo_slug": "org/repo"}
     result = _resolve_repo_for_row(row, clone_cache=cache)
     assert result == cached_repo
+
+
+# ---------------------------------------------------------------------------
+# pr_attached_label_coverage
+# ---------------------------------------------------------------------------
+
+
+def _make_manifest(session_id: str = "sess-0001", **overrides: Any) -> Manifest:
+    """Build a minimal indexed manifest, mirroring ``test_archive._make_manifest``.
+
+    ``pr_number``/``pr_repo`` are plain ``Manifest`` fields (see
+    ``daydream/archive/manifest.py``), so PR-attached rows are produced by
+    passing them through ``overrides``.
+    """
+    defaults: dict[str, Any] = {
+        "session_id": session_id,
+        "archived_at": "2026-04-29T00:00:00+00:00",
+        "status": "complete",
+        "run_flow": "normal",
+        "skill": "python",
+        "model": "opus",
+        "backend": "claude",
+        "archive_path": "/tmp/archive/runs/sess-0001",
+    }
+    defaults.update(overrides)
+    return Manifest(**defaults)
+
+
+def test_pr_coverage_helper_counts_decisive(tmp_path: Path):
+    for i, label in [(1, "accepted"), (2, "rejected"), (3, "unknown")]:
+        upsert_run(tmp_path, _make_manifest(session_id=f"p{i}", pr_number=i, pr_repo="o/r"))
+        append_label_observation(
+            tmp_path,
+            f"p{i}",
+            labels=[label],
+            pr_state=None,
+            labeler_version="auto",
+            evidence_sha=f"s{i}",
+            source="auto",
+        )
+    upsert_run(tmp_path, _make_manifest(session_id="local1"))  # no pr_number — excluded
+    cov = pr_attached_label_coverage(tmp_path)
+    assert cov["pr_attached"] == 3 and cov["decisive"] == 2  # accepted+rejected, not unknown
+
+
+async def test_harvest_meets_80pct_coverage_on_mixed_archive(tmp_path, archive_dir, monkeypatch):
+    # Seed 10 PR-attached runs with distinct pr_number 1..10, each with its own
+    # bronze run dir so the index carries ten rows. A fake _gh_api branches on the
+    # PR number embedded in the endpoint: PRs 1..8 report merged (decisive ->
+    # "accepted"); PRs 9..10 raise a plain GitError so build_annotation fails and
+    # the harvest's per-row isolation skips them WITHOUT aborting (a RateLimitError
+    # would abort the whole sweep — see test_harvest_aborts_cleanly_on_rate_limit).
+    # The two skipped rows leave no label observation, so they project to
+    # unlabeled/non-decisive, making 80% a real bar rather than trivially 100%.
+    for pr_number in range(1, 11):
+        sid = f"s{pr_number}"
+        run_dir = _seed_deep_bronze(tmp_path / sid, verdict="consistent", grounding=1.0)
+        upsert_run(
+            archive_dir,
+            Manifest(
+                session_id=sid,
+                archived_at="2026-01-01T00:00:00Z",
+                run_flow="normal",
+                backend="claude",
+                repo_slug="org/repo",
+                pr_repo="org/repo",
+                pr_number=pr_number,
+                head_sha="abc",
+                base_branch="main",
+                grounding_rate=1.0,
+                changed_files=["app.py"],
+                archive_path=str(run_dir),
+            ),
+        )
+
+    merged = _fake_gh_merged("2026-02-01T00:00:00+00:00")
+
+    def _gh(repo: str, endpoint: str, **kw: Any) -> Any:
+        match = re.search(r"/pulls/(\d+)", endpoint)
+        number = int(match.group(1)) if match else 0
+        if number >= 9:
+            # Non-rate-limit failure: per-row isolation skips this run (no
+            # annotation written) and the harvest loop CONTINUES rather than aborting.
+            raise GitError(f"unresolvable evidence for PR {number}")
+        return merged(repo, endpoint, **kw)
+
+    monkeypatch.setattr("daydream.training.harvest._gh_api", _gh)
+
+    summary = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
+
+    assert summary["aborted"] == 0  # the GitError rows did NOT abort the sweep
+    assert summary["annotated"] == 8 and summary["errors"] == 2
+    cov = pr_attached_label_coverage(archive_dir)
+    assert cov["pr_attached"] == 10
+    assert cov["coverage"] >= 0.8

--- a/tests/test_training_harvest.py
+++ b/tests/test_training_harvest.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import pytest
 
+from daydream import git_ops
 from daydream.archive.index import (
     append_label_observation,
     label_observation_history,
@@ -17,6 +18,7 @@ from daydream.archive.index import (
 from daydream.archive.manifest import Manifest
 from daydream.git_ops import GitError
 from daydream.training import harvest
+from daydream.training.backfill_cache import BackfillCache
 from daydream.training.harvest import (
     HarvestConfig,
     _resolve_repo_for_row,
@@ -410,6 +412,62 @@ async def test_re_harvest_appends_on_version_bump(tmp_path, archive_dir, monkeyp
     monkeypatch.setattr("daydream.training.harvest.reward.REWARD_VERSION", "9999.99.99-bump")
     await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c2"))
     assert len(label_observation_history(archive_dir, "s1")) == 2
+
+
+async def test_harvest_aborts_cleanly_on_rate_limit_and_preserves_resume(tmp_path, archive_dir, monkeypatch):
+    # Two distinct sessions with distinct PR numbers (so the gh endpoint identifies
+    # the session), each with its own bronze run dir so the index has two rows.
+    for sid, pr_number in (("s1", 1), ("s2", 2)):
+        run_dir = _seed_deep_bronze(tmp_path / sid, verdict="consistent", grounding=1.0)
+        upsert_run(
+            archive_dir,
+            Manifest(
+                session_id=sid,
+                archived_at="2026-01-01T00:00:00Z",
+                run_flow="normal",
+                backend="claude",
+                repo_slug="org/repo",
+                pr_repo="org/repo",
+                pr_number=pr_number,
+                head_sha="abc",
+                base_branch="main",
+                grounding_rate=1.0,
+                changed_files=["app.py"],
+                archive_path=str(run_dir),
+            ),
+        )
+    # The first row (PR 1) fully succeeds; the second (PR 2) triggers an exhausted
+    # rate-limit on every gh call so the harvest loop must abort cleanly.
+    merged = _fake_gh_merged("2026-02-01T00:00:00+00:00")
+
+    def _gh(repo, endpoint, **kw):
+        if "/pulls/2" in endpoint or "/2/" in endpoint or endpoint.endswith("/2"):
+            raise git_ops.RateLimitError("exhausted")
+        return merged(repo, endpoint, **kw)
+
+    monkeypatch.setattr("daydream.training.harvest._gh_api", _gh)
+    cache_dir = tmp_path / "c"
+    summary = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=cache_dir))
+    assert summary["aborted"] == 1
+    # The completed session is preserved for resume; the failed one is not:
+    done = BackfillCache(cache_dir=cache_dir, inner=_gh).completed_sessions()
+    assert "s1" in done and "s2" not in done
+
+
+def test_gh_api_backoff_retries_then_succeeds(monkeypatch):
+    slept = []
+    monkeypatch.setattr(harvest, "_rate_limit_sleep", lambda s: slept.append(s))
+    seq = [git_ops.RateLimitError("x"), git_ops.RateLimitError("x"), {"ok": True}]
+
+    def _inner(*a, **k):
+        v = seq.pop(0)
+        if isinstance(v, Exception):
+            raise v
+        return v
+
+    monkeypatch.setattr(harvest.git_ops, "gh_api", _inner)
+    assert harvest._gh_api("o/r", "endpoint") == {"ok": True}
+    assert len(slept) == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_training_harvest.py
+++ b/tests/test_training_harvest.py
@@ -8,7 +8,12 @@ from typing import Any
 
 import pytest
 
-from daydream.archive.index import append_label_observation, label_observation_history, latest_label_observation, upsert_run
+from daydream.archive.index import (
+    append_label_observation,
+    label_observation_history,
+    latest_label_observation,
+    upsert_run,
+)
 from daydream.archive.manifest import Manifest
 from daydream.git_ops import GitError
 from daydream.training import harvest
@@ -389,12 +394,22 @@ async def test_harvest_writes_one_annotation(tmp_path, archive_dir, monkeypatch)
     assert obs["valid_at"] == "2026-02-01T00:00:00+00:00" and obs["composite_reward"] is not None
 
 
-async def test_re_harvest_appends_new_generation(tmp_path, archive_dir, monkeypatch):
+async def test_re_harvest_is_idempotent(tmp_path, archive_dir, monkeypatch):
     _seed_archived_deep_run(archive_dir, "s1", merged_at="2026-02-01T00:00:00+00:00")
     monkeypatch.setattr("daydream.training.harvest._gh_api", _fake_gh_merged("2026-02-01T00:00:00+00:00"))
     await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c1"))
+    second = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c2"))
+    assert len(label_observation_history(archive_dir, "s1")) == 1  # deduped
+    assert second["skipped"] == 1 and second["annotated"] == 0
+
+
+async def test_re_harvest_appends_on_version_bump(tmp_path, archive_dir, monkeypatch):
+    _seed_archived_deep_run(archive_dir, "s1", merged_at="2026-02-01T00:00:00+00:00")
+    monkeypatch.setattr("daydream.training.harvest._gh_api", _fake_gh_merged("2026-02-01T00:00:00+00:00"))
+    await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c1"))
+    monkeypatch.setattr("daydream.training.harvest.reward.REWARD_VERSION", "9999.99.99-bump")
     await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c2"))
-    assert len(label_observation_history(archive_dir, "s1")) == 2  # append-only, re-runnable
+    assert len(label_observation_history(archive_dir, "s1")) == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_training_record.py
+++ b/tests/test_training_record.py
@@ -241,9 +241,9 @@ def test_build_record_prefers_root_review_output_over_deep(tmp_path: Path) -> No
 
 def test_build_record_surfaces_rubric_when_present(tmp_path: Path) -> None:
     row = {"session_id": "abc", "archive_path": str(tmp_path),
-           "outcome_labels": '["accepted"]',
-           "rubric_json": '{"pr_merge": {"merged": true}, "posterior_source": "pr_review"}'}
-    record = _build_record(row, _MIN_TRAJECTORY, stack="python", manifest={})
+           "outcome_labels": '["accepted"]'}
+    annotation = {"rubric_json": '{"pr_merge": {"merged": true}, "posterior_source": "pr_review"}'}
+    record = _build_record(row, _MIN_TRAJECTORY, stack="python", manifest={}, annotation=annotation)
     assert record["rubric"] == {"pr_merge": {"merged": True}, "posterior_source": "pr_review"}
     assert record["posterior_source"] == "pr_review"
 
@@ -257,7 +257,7 @@ def test_build_record_omits_rubric_when_absent(tmp_path: Path) -> None:
 
 def test_build_record_propagates_local_branch_source(tmp_path: Path) -> None:
     row = {"session_id": "abc", "archive_path": str(tmp_path),
-           "outcome_labels": '["accepted"]',
-           "rubric_json": '{"posterior_source": "local_branch"}'}
-    record = _build_record(row, _MIN_TRAJECTORY, stack="python", manifest={})
+           "outcome_labels": '["accepted"]'}
+    annotation = {"rubric_json": '{"posterior_source": "local_branch"}'}
+    record = _build_record(row, _MIN_TRAJECTORY, stack="python", manifest={}, annotation=annotation)
     assert record["posterior_source"] == "local_branch"


### PR DESCRIPTION
## Summary

Closes the four R3 gaps (#89) left open after #104's automated per-run labeling: human-set outcome labels are now authoritative and sticky over automated rubric labels, automated labeling is idempotent, the harvest pass reacts to GitHub rate limits with bounded backoff and clean abort-with-resume, and PR-attached label coverage is measurable (with a test proving ≥80% on a mixed fixture).

The design keeps the write path dumb and makes correctness a read-side property: a new `source` column (`auto`/`human`) on `label_observations` is the precedence signal, and every "latest label" projection (plus the denormalized `runs` cache) orders human-first then by recency — so human labels win everywhere regardless of timing.

## Changes

### Added
- **`daydream label <session-prefix> --outcome {accepted,contested,rejected,unknown}`** — human-override command; shows the prior resolved label before overriding it.
- **`source` column** on `label_observations` (`auto`/`human`) via a non-destructive ALTER-ADD migration (SCHEMA_VERSION 4→5); pre-existing rows default to `auto`.
- **`RateLimitError(GitError)`** in `git_ops`, raised by `gh_api` on GitHub rate-limit stderr markers (word-boundary `\b429\b`, `rate limit`, `secondary rate limit`, `403`+`rate`), with optional `retry_after`.
- **Bounded backoff** in harvest's gh seam (`_rate_limit_sleep`, capped retries) plus a clean loop-abort that preserves the `BackfillCache` resume marker (`summary["aborted"]`).
- **`pr_attached_label_coverage()`** index metric returning `pr_attached` / `decisive` / `coverage`, plus a `malformed_labels` count.

### Changed
- **Label projections** (`latest_label_observation`, `bulk_latest_label_observations`, `label_count_summary`) now resolve **human-first, then most-recent**, replacing pure recency.
- **`append_label_observation`** takes a `source` kwarg, returns `bool` (appended vs deduped), and recomputes the `runs` cache from the **winning** (precedence) row rather than the just-inserted one.
- **Automated appends dedup** on unchanged `(evidence_sha, reward_version)`, making re-harvest idempotent; harvest counts a deduped row as `skipped` and still marks it resume-done. Human appends are never deduped.
- **`update_labels`** writes a human-sourced observation (`source="human"`, `labeler_version="human"`).
- **corpus** reads `rubric_json` from the `as_of`-pinned annotation row instead of the denormalized cache, preserving corpus reproducibility when human annotations are appended after a pin.

### Fixed
- Same-microsecond `(session_id, observed_at)` primary-key collisions on `label_observations` (uuid tiebreaker suffix, inert to all ORDER BY / `as_of` comparisons).

## Motivation

Automated labeling (#104) could silently clobber any human correction on the next sweep, appended duplicate observations by design, had no reactive rate-limit handling, and never measured the ≥80% coverage target. That breaks the C9 guarantee ("train only on `accepted`") that makes the open-weight review model defensible. This PR makes human verdicts authoritative and sticky, automated re-runs safe, and coverage observable — without a parallel store or a destructive migration.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed

Each behavior is TDD-driven (failing test first) and asserts observable state — cache values, history length, summary counters, the resume set, and resolved-label precedence — not dispatch. Highlights:
- Migration test seeds a legacy (no-`source`) row via raw sqlite and asserts the ALTER-add defaults it to `auto`.
- Precedence/idempotency/dedup tests in `tests/test_archive.py`.
- End-to-end `tests/test_training_harvest.py::test_harvest_meets_80pct_coverage_on_mixed_archive` enters via `run_harvest` with a mixed 10-PR fixture (pr≥9 deliberately unresolvable) and observes a real `coverage == 0.8` — a genuine bar, not trivially 100%.
- Rate-limit detection, bounded backoff, and clean abort-with-resume tests.

### Manual Testing Steps

1. `daydream harvest <archive>` to write automated labels; re-run it — second pass reports the rows as `skipped` (idempotent no-op).
2. `daydream label <session-prefix> --outcome accepted` — confirm it prints the prior label and that the resolved/cached label flips to `accepted`.
3. Re-run `daydream harvest` — confirm the human label is **not** overwritten.

`make check` is green on the label-related suites; the only full-suite failures observed are pre-existing flaky `test_deep_orchestrator.py` tests (byte-identical to `origin/main`, pass in isolation), unrelated to this branch.

## Related Issues

- Closes #89

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally (label suites green; deep-orchestrator flakiness pre-exists on main)
- [x] Linting passes (ruff + mypy clean)
- [x] Documentation updated (docstrings/comments swept for the new precedence + idempotency contract)

---

Generated with [Claude Code](https://claude.com/claude-code)