### PR TITLE
fix(archive): derive wall_clock_seconds on every run and unify ISO parsing

### DIFF
--- a/daydream/archive/manifest.py
+++ b/daydream/archive/manifest.py
@@ -63,7 +63,8 @@ class Manifest:
         total_prompt_tokens: Non-cached prompt tokens.
         total_completion_tokens: Completion tokens.
         total_cached_tokens: Cached tokens.
-        wall_clock_seconds: Wall-clock duration (from eval, if available).
+        wall_clock_seconds: Wall-clock duration derived from step timestamps
+            on every run; refined by eval's fork-inclusive value when available.
         total_findings: Number of findings (from eval, if available).
         grounding_rate: Grounding rate (from eval, if available).
         coverage_ratio: File coverage ratio (from eval, if available).
@@ -113,7 +114,8 @@ class Manifest:
     total_completion_tokens: int | None = None
     total_cached_tokens: int | None = None
 
-    # Evaluation metrics (populated only with --eval)
+    # wall_clock_seconds is derived from step timestamps on every run; the
+    # remaining metrics below are populated only with --eval.
     wall_clock_seconds: float | None = None
     total_findings: int | None = None
     grounding_rate: float | None = None
@@ -243,9 +245,16 @@ def build_manifest(
         archive_path=str(archive_path),
     )
 
+    # Wall-clock is derivable from step timestamps alone, so populate it for
+    # every run — not just --eval runs. When --eval ran, its fork-inclusive
+    # disk-based value (see eval.analyzer.analyze_timing) takes precedence.
+    m.wall_clock_seconds = recorder.compute_wall_clock_seconds()
+
     if evaluation:
         timing = evaluation.get("timing", {})
-        m.wall_clock_seconds = timing.get("total_wall_clock_seconds")
+        eval_wall_clock = timing.get("total_wall_clock_seconds")
+        if eval_wall_clock is not None:
+            m.wall_clock_seconds = eval_wall_clock
 
         findings = evaluation.get("findings", {})
         m.total_findings = findings.get("total")

--- a/daydream/eval/analyzer.py
+++ b/daydream/eval/analyzer.py
@@ -17,6 +17,8 @@ from collections import Counter
 from datetime import datetime
 from pathlib import Path
 
+from daydream.timeutil import parse_iso_timestamp
+
 # ---------------------------------------------------------------------------
 # Trajectory loading
 # ---------------------------------------------------------------------------
@@ -97,7 +99,7 @@ def load_trajectories(daydream_dir: Path, session_id: str | None = None) -> dict
 # ---------------------------------------------------------------------------
 
 def _parse_iso_ts(ts: str) -> datetime:
-    return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    return parse_iso_timestamp(ts)
 
 
 def _agent_label(filename: str) -> str:

--- a/daydream/pr_comment_renderer.py
+++ b/daydream/pr_comment_renderer.py
@@ -36,6 +36,7 @@ from pathlib import Path
 import daydream
 from daydream.atif import Step, Trajectory
 from daydream.pricing import compute_cost
+from daydream.timeutil import parse_iso_timestamp
 
 # Display labels for each phase key used in Step.extra['daydream_phase'].
 # Keys are the string values of daydream.trajectory.DaydreamPhase. Defined
@@ -66,7 +67,7 @@ _GENERIC_MODEL_LABELS: frozenset[str] = frozenset({"claude", "codex", ""})
 
 def _parse_ts(ts: str) -> datetime:
     """Parse an ATIF ISO 8601 timestamp (Z-suffix) to a timezone-aware datetime."""
-    return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    return parse_iso_timestamp(ts)
 
 
 def _format_duration(seconds: float | None) -> str:

--- a/daydream/timeutil.py
+++ b/daydream/timeutil.py
@@ -1,0 +1,30 @@
+"""Low-level time parsing helpers shared across daydream.
+
+Provide a single canonical parser for the ISO 8601 timestamps (with optional
+``Z`` UTC suffix) emitted in ATIF trajectories and read back by the eval,
+archive, and PR-comment layers. This module depends only on the standard
+library so any daydream module may import it without risk of a cycle.
+
+Exports:
+    parse_iso_timestamp: Parse an ISO 8601 timestamp string to a datetime.
+"""
+
+from datetime import datetime
+
+
+def parse_iso_timestamp(value: str) -> datetime:
+    """Parse an ISO 8601 timestamp into a datetime.
+
+    Accepts a trailing ``Z`` UTC designator by normalizing it to ``+00:00``
+    before delegating to :func:`datetime.fromisoformat`.
+
+    Args:
+        value: An ISO 8601 timestamp string, optionally ``Z``-suffixed.
+
+    Returns:
+        The parsed datetime; timezone-aware when the input carries an offset.
+
+    Raises:
+        ValueError: If ``value`` is not a valid ISO 8601 timestamp.
+    """
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -43,6 +43,7 @@ from daydream.atif import (
     ToolCall,
     Trajectory,
 )
+from daydream.timeutil import parse_iso_timestamp
 from daydream.ui import create_console, print_error, print_warning
 
 # Run-directory layout (single source of truth)
@@ -873,13 +874,13 @@ class TrajectoryRecorder:
         dispatched and merged within it.
 
         Returns:
-            Rounded duration in seconds, or ``None`` when unmeasurable.
+            Rounded duration in seconds, or ``None`` when unmeasurable —
+            fewer than two timestamped steps, or an unparseable timestamp.
         """
-        timestamps = [
-            datetime.fromisoformat(s.timestamp.replace("Z", "+00:00"))
-            for s in self.steps
-            if s.timestamp
-        ]
+        try:
+            timestamps = [parse_iso_timestamp(s.timestamp) for s in self.steps if s.timestamp]
+        except ValueError:
+            return None
         if len(timestamps) < 2:
             return None
         return round((max(timestamps) - min(timestamps)).total_seconds(), 1)

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -858,6 +858,32 @@ class TrajectoryRecorder:
             self._final_totals["cost"] += cost_usd
             self._final_totals["any_cost_seen"] = True
 
+    def compute_wall_clock_seconds(self) -> float | None:
+        """Total wall-clock seconds spanned by recorded step timestamps.
+
+        Derived from the earliest and latest ``Step.timestamp`` across the
+        recorder's steps. Returns ``None`` when fewer than two timestamped
+        steps exist (no measurable span).
+
+        Independent of ``--eval``: this mirrors the timestamp-span derivation
+        in :func:`daydream.eval.analyzer.analyze_timing`, but reads in-memory
+        steps so every archived run captures duration without the deterministic
+        evaluation pass. Fork-only steps live in sibling recorders and are not
+        included here; the main flow's span bounds them because forks are
+        dispatched and merged within it.
+
+        Returns:
+            Rounded duration in seconds, or ``None`` when unmeasurable.
+        """
+        timestamps = [
+            datetime.fromisoformat(s.timestamp.replace("Z", "+00:00"))
+            for s in self.steps
+            if s.timestamp
+        ]
+        if len(timestamps) < 2:
+            return None
+        return round((max(timestamps) - min(timestamps)).total_seconds(), 1)
+
     def _sibling_path_for(self, descriptor: str) -> Path:
         """Return the sibling trajectory file path for *descriptor*.
 

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -296,7 +296,6 @@ def test_build_manifest_without_evaluation(tmp_path: Path):
         archive_path=tmp_path,
     )
 
-    assert m.wall_clock_seconds is None
     assert m.total_findings is None
     assert m.grounding_rate is None
     assert m.coverage_ratio is None

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -41,6 +41,7 @@ class _MockRecorder:
     explicit_path: bool = False
     pr_number: int | None = None
     pr_repo: str | None = None
+    _wall_clock_seconds: float | None = None
     _final_totals: dict = field(
         default_factory=lambda: {
             "prompt": 100,
@@ -50,6 +51,9 @@ class _MockRecorder:
             "any_cost_seen": True,
         },
     )
+
+    def compute_wall_clock_seconds(self) -> float | None:
+        return self._wall_clock_seconds
 
 
 @dataclass
@@ -297,6 +301,44 @@ def test_build_manifest_without_evaluation(tmp_path: Path):
     assert m.grounding_rate is None
     assert m.coverage_ratio is None
     assert m.cost_per_finding_usd is None
+
+
+def test_build_manifest_wall_clock_without_evaluation(tmp_path: Path):
+    """Wall-clock is derived from step timestamps even when --eval did not run."""
+    recorder = _MockRecorder(_wall_clock_seconds=12.3)
+    config = _MockConfig()
+    git_ctx = GitContext()
+
+    m = build_manifest(
+        recorder=recorder,
+        config=config,
+        git_ctx=git_ctx,
+        status="complete",
+        archive_path=tmp_path,
+    )
+
+    # Populated from the recorder despite no evaluation; eval-only metrics stay None.
+    assert m.wall_clock_seconds == 12.3
+    assert m.total_findings is None
+
+
+def test_build_manifest_eval_wall_clock_overrides_recorder(tmp_path: Path):
+    """When --eval runs, its fork-inclusive timing takes precedence over the recorder span."""
+    recorder = _MockRecorder(_wall_clock_seconds=12.3)
+    config = _MockConfig()
+    git_ctx = GitContext()
+    evaluation = {"timing": {"total_wall_clock_seconds": 42.5}}
+
+    m = build_manifest(
+        recorder=recorder,
+        config=config,
+        git_ctx=git_ctx,
+        status="complete",
+        archive_path=tmp_path,
+        evaluation=evaluation,
+    )
+
+    assert m.wall_clock_seconds == 42.5
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_archive_integration.py
+++ b/tests/test_archive_integration.py
@@ -167,6 +167,55 @@ async def test_full_archive_round_trip(tmp_path: Path, archive_dir: Path) -> Non
         conn.close()
 
 
+async def test_archive_populates_wall_clock_without_eval(tmp_path: Path, archive_dir: Path) -> None:
+    """Real-path: manifest.json carries wall_clock_seconds even when --eval did not run."""
+    from daydream.runner import RunConfig, _make_archive_callback
+
+    target_dir = tmp_path / "project"
+    target_dir.mkdir()
+    (target_dir / ".daydream").mkdir()
+    (target_dir / ".review-output.md").write_text("# Review\nLooks good.\n")
+
+    config = RunConfig(
+        target=str(target_dir),
+        skill="python",
+        backend="claude",
+        archive=True,
+        run_eval=False,  # the path that was previously leaving wall_clock null
+    )
+    callback = _make_archive_callback(config, target_dir)
+    assert callback is not None
+
+    recorder = TrajectoryRecorder(
+        path=target_dir / ".daydream" / "trajectory.json",
+        run_flow=DaydreamRunFlow.NORMAL,
+        target_dir=target_dir,
+        agent_model_name="opus",
+        session_id="test",
+        on_write=callback,
+    )
+
+    async with recorder:
+        # Two steps spaced 8.5s apart so the derived span is deterministic.
+        for ts in ("2026-05-31T10:00:00.000000Z", "2026-05-31T10:00:08.500000Z"):
+            recorder.steps.append(
+                Step(
+                    step_id=recorder._next_step_id(),
+                    timestamp=ts,
+                    source="agent",
+                    message="step",
+                    extra={
+                        "daydream_phase": DaydreamPhase.REVIEW.value,
+                        "daydream_run_flow": DaydreamRunFlow.NORMAL.value,
+                    },
+                )
+            )
+
+    manifest_path = archive_dir / "runs" / recorder.session_id / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["metrics"]["wall_clock_seconds"] == 8.5
+
+
 # ---------------------------------------------------------------------------
 # 4. on_write failure does not raise
 # ---------------------------------------------------------------------------

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -483,6 +483,50 @@ def test_no_recorder_no_op_get_current_returns_none() -> None:
     assert get_current_recorder() is None
 
 
+# ---------------------------------------------------------------------------
+# compute_wall_clock_seconds: derived from step timestamps, no --eval needed
+# ---------------------------------------------------------------------------
+
+
+def _append_step_at(recorder: TrajectoryRecorder, ts: str) -> None:
+    """Append a minimal agent step with an explicit ISO-8601 timestamp."""
+    from daydream.atif import Step as AtifStep
+
+    recorder.steps.append(
+        AtifStep(
+            step_id=recorder._next_step_id(),
+            timestamp=ts,
+            source="agent",
+            message="x",
+        )
+    )
+
+
+def test_compute_wall_clock_seconds_spans_first_to_last(tmp_path: Path) -> None:
+    """Span is max(timestamp) - min(timestamp), in seconds, regardless of insertion order."""
+    recorder = _make_recorder(tmp_path)
+    _append_step_at(recorder, "2026-05-31T10:00:00.000000Z")
+    _append_step_at(recorder, "2026-05-31T10:00:07.500000Z")
+    _append_step_at(recorder, "2026-05-31T10:00:03.000000Z")
+
+    assert recorder.compute_wall_clock_seconds() == 7.5
+
+
+def test_compute_wall_clock_seconds_single_step_is_none(tmp_path: Path) -> None:
+    """Fewer than two timestamped steps means no measurable span."""
+    recorder = _make_recorder(tmp_path)
+    _append_step_at(recorder, "2026-05-31T10:00:00.000000Z")
+
+    assert recorder.compute_wall_clock_seconds() is None
+
+
+def test_compute_wall_clock_seconds_no_steps_is_none(tmp_path: Path) -> None:
+    """An empty recorder yields None rather than raising."""
+    recorder = _make_recorder(tmp_path)
+
+    assert recorder.compute_wall_clock_seconds() is None
+
+
 # ===========================================================================
 # Fork / Sibling / Continuation tests (Phase 3, SUBA-01..09)
 # ===========================================================================


### PR DESCRIPTION
## Summary

Archive manifests previously left `wall_clock_seconds` null unless a run was invoked with `--eval`, even though duration is fully derivable from the step timestamps that every run already records. This PR derives wall-clock duration on every archived run and consolidates ISO 8601 timestamp parsing behind a single hardened helper.

## Changes

### Added
- `daydream/timeutil.py`: `parse_iso_timestamp()` — a single stdlib-only canonical parser for the `Z`-suffixed ISO 8601 timestamps emitted in ATIF trajectories. Importable from any layer without cycle risk.
- `TrajectoryRecorder.compute_wall_clock_seconds()` — derives total wall-clock span from in-memory `Step.timestamp` values (max − min), returning `None` when fewer than two timestamped steps exist or a timestamp is unparseable.

### Changed
- `build_manifest()` now populates `wall_clock_seconds` on every run from the recorder's step-timestamp span. When `--eval` ran, its fork-inclusive disk-based value still takes precedence.
- `eval/analyzer.py` and `pr_comment_renderer.py` now delegate their local ISO parsers to `parse_iso_timestamp`, replacing duplicated `datetime.fromisoformat(ts.replace("Z", "+00:00"))` calls.

### Fixed
- `wall_clock_seconds` is no longer null on non-`--eval` runs.
- Unparseable timestamps are now guarded: `compute_wall_clock_seconds()` returns `None` instead of raising.

## Motivation

Wall-clock duration is observable run metadata that every archived run should carry. Gating it behind `--eval` meant the common path silently dropped a metric it had all the data to compute. Unifying the timestamp parser removes three drifting copies of the same `Z`-normalization logic.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed

- `tests/test_trajectory.py`: span-from-first-to-last (order-independent), single-step → `None`, empty recorder → `None`.
- `tests/test_archive.py`: manifest carries the recorder span without evaluation; eval timing overrides the recorder span when present.
- `tests/test_archive_integration.py`: real-path test driving a `TrajectoryRecorder` with `run_eval=False` through the production archive callback, asserting `manifest.json` `metrics.wall_clock_seconds == 8.5`.

Run locally with `make check` (lint + typecheck + full suite).