### PR TITLE
fix(cli): detect repo slug + PR number from target checkout, not cwd

### DIFF
--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -77,15 +77,20 @@ def _install_signal_handlers() -> None:
     signal.signal(signal.SIGTERM, _signal_handler)
 
 
-def _auto_detect_pr_number() -> int | None:
-    """Auto-detect PR number from the current branch via gh CLI.
+def _auto_detect_pr_number(repo: Path) -> int | None:
+    """Auto-detect PR number from the target checkout's branch via gh CLI.
+
+    Args:
+        repo: Repository working directory to inspect — the target checkout
+            being reviewed, not necessarily the cwd where ``daydream`` was
+            launched.
 
     Returns:
         The PR number if found, or None if detection fails.
 
     """
     try:
-        data = git_ops.gh_pr_view(Path.cwd(), None)
+        data = git_ops.gh_pr_view(repo, None)
     except git_ops.GitError:
         return None
     if not data:
@@ -94,14 +99,21 @@ def _auto_detect_pr_number() -> int | None:
     return int(number) if isinstance(number, int) else None
 
 
-def _detect_repo_slug() -> str | None:
-    """Detect the GitHub owner/repo slug for the current repository via gh CLI.
+def _detect_repo_slug(repo: Path) -> str | None:
+    """Detect the GitHub owner/repo slug for a repository via gh CLI.
+
+    Args:
+        repo: Repository working directory to inspect — the target checkout
+            being reviewed, not necessarily the cwd where ``daydream`` was
+            launched. Attributing the slug to the target keeps trajectory and
+            archive provenance correct when daydream is run from one repo
+            against a checkout of another (the benchmark-harness pattern).
 
     Returns:
         String like ``"owner/repo"``, or None if detection fails.
     """
     try:
-        slug = git_ops.gh_repo_view(Path.cwd())
+        slug = git_ops.gh_repo_view(repo)
     except git_ops.GitError:
         return None
     if slug is None:
@@ -717,9 +729,12 @@ def _parse_args(argv: list[str] | None = None) -> RunConfig:
     if args.max_iterations != 5 and not args.loop:
         warnings.warn("--max-iterations has no effect without --loop", stacklevel=2)
 
-    # Detect repo slug and PR number for trajectory/archive metadata
-    pr_repo = _detect_repo_slug()
-    pr_number = _auto_detect_pr_number()
+    # Detect repo slug and PR number for trajectory/archive metadata.
+    # Attribute provenance to the target checkout, not the invoking cwd —
+    # daydream may run from one repo against a checkout of another.
+    target_repo = Path(args.target) if args.target else Path.cwd()
+    pr_repo = _detect_repo_slug(target_repo)
+    pr_number = _auto_detect_pr_number(target_repo)
 
     return RunConfig(
         target=args.target,
@@ -768,7 +783,7 @@ def _build_feedback_config(args: argparse.Namespace) -> RunConfig:
         # argparse already enforces type=int, but guard against negatives.
         raise SystemExit(f"feedback subcommand: PR number must be positive (got {pr_number})")
 
-    pr_repo = _detect_repo_slug()
+    pr_repo = _detect_repo_slug(Path(args.target) if args.target else Path.cwd())
 
     return RunConfig(
         target=args.target,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -425,3 +425,70 @@ def test_removed_verbs_no_longer_dispatch():
     assert not hasattr(cli, "_handle_export_command")
     assert not hasattr(cli, "_handle_snapshot_command")
     assert hasattr(cli, "_handle_label_command")
+
+
+def test_pr_repo_detected_from_target_not_cwd(monkeypatch, tmp_path):
+    """pr_repo records the target checkout's slug, not the invoking cwd (#128).
+
+    Drives the production ``_parse_args`` path with a target distinct from cwd
+    and a stubbed ``gh repo view`` seam that returns a different slug per path.
+    Asserts the resulting ``RunConfig.pr_repo`` (which flows verbatim into the
+    trajectory's ``extra.pr_repo``) reflects the target — the benchmark-harness
+    pattern of running daydream from one repo against a checkout of another.
+    """
+    target = tmp_path / "target-checkout"
+    target.mkdir()
+
+    def fake_gh_repo_view(repo):
+        # Slug keyed on the inspected path so the assertion proves which dir
+        # was passed: the target, not Path.cwd().
+        if Path(repo) == target:
+            return ("grafana", "grafana")
+        return ("existential-birds", "daydream")
+
+    monkeypatch.setattr("daydream.git_ops.gh_repo_view", fake_gh_repo_view)
+    monkeypatch.setattr("daydream.git_ops.gh_pr_view", lambda repo, _branch: None)
+    monkeypatch.setattr(sys, "argv", ["daydream", str(target)])
+
+    config = _parse_args()
+
+    assert config.pr_repo == "grafana/grafana"
+
+
+def test_pr_repo_falls_back_to_cwd_without_target(monkeypatch, tmp_path):
+    """With no target positional, slug detection falls back to the cwd (#128)."""
+    invoking_repo = tmp_path / "invoking-repo"
+    invoking_repo.mkdir()
+    monkeypatch.chdir(invoking_repo)
+
+    def fake_gh_repo_view(repo):
+        assert Path(repo) == invoking_repo
+        return ("existential-birds", "daydream")
+
+    monkeypatch.setattr("daydream.git_ops.gh_repo_view", fake_gh_repo_view)
+    monkeypatch.setattr("daydream.git_ops.gh_pr_view", lambda repo, _branch: None)
+    monkeypatch.setattr(sys, "argv", ["daydream"])
+
+    config = _parse_args()
+
+    assert config.target is None
+    assert config.pr_repo == "existential-birds/daydream"
+
+
+def test_feedback_pr_repo_detected_from_target_not_cwd(monkeypatch, tmp_path):
+    """The feedback subcommand also attributes pr_repo to the target (#128)."""
+    target = tmp_path / "target-checkout"
+    target.mkdir()
+
+    def fake_gh_repo_view(repo):
+        if Path(repo) == target:
+            return ("grafana", "grafana")
+        return ("existential-birds", "daydream")
+
+    monkeypatch.setattr("daydream.git_ops.gh_repo_view", fake_gh_repo_view)
+    monkeypatch.setattr(sys, "argv", ["daydream", "feedback", "42", "--bot", "x[bot]", str(target)])
+
+    config = _parse_args()
+
+    assert config.pr_number == 42
+    assert config.pr_repo == "grafana/grafana"

--- a/tests/test_cli_main_integration.py
+++ b/tests/test_cli_main_integration.py
@@ -46,17 +46,23 @@ from tests.test_deep_orchestrator import (
 def _silence_cli_and_runner(monkeypatch: pytest.MonkeyPatch) -> None:
     """Mock only the external seams cli.main touches before/around the loop.
 
-    - gh-detection helpers (`_auto_detect_pr_number`/`_detect_repo_slug`) shell
-      out to ``gh`` against ``Path.cwd()``; pin them to ``None`` for
-      determinism (no network, no dependency on the host's git checkout).
+    - The provenance detectors (`_auto_detect_pr_number`/`_detect_repo_slug`)
+      shell out to ``gh``. We mock one layer deeper — the ``git_ops`` ``gh``
+      seam — rather than stubbing the detectors themselves, so the REAL
+      cwd-vs-target path-threading logic runs (the thing #128 fixed). The
+      ``gh_repo_view`` stub returns a slug keyed on the inspected path's
+      basename (``acme/<dir name>``), making provenance deterministic and
+      letting a test prove which directory was used. ``gh_pr_view`` -> None.
     - ``runner.print_phase_hero`` renders the DAYDREAM banner on the real run
       path; silence it so the test output stays clean. (It does not block, but
       patching keeps the captured output focused.)
     - signal-handler install is a no-op concern here; leave it real — it is a
       cheap, side-effect-free part of the production entrypoint we want covered.
     """
-    monkeypatch.setattr("daydream.cli._auto_detect_pr_number", lambda: None)
-    monkeypatch.setattr("daydream.cli._detect_repo_slug", lambda: None)
+    monkeypatch.setattr(
+        "daydream.git_ops.gh_repo_view", lambda repo: ("acme", Path(repo).name)
+    )
+    monkeypatch.setattr("daydream.git_ops.gh_pr_view", lambda repo, _branch: None)
     monkeypatch.setattr("daydream.runner.print_phase_hero", lambda *a, **kw: None)
 
 
@@ -83,6 +89,43 @@ def test_cli_main_clean_deep_run_exits_0(
     # SystemExit.code is the int returned by runner.run, propagated through
     # anyio.run -> sys.exit. Not a hardcoded 0 (see TDD proof in the PR).
     assert exc.value.code == 0
+
+
+def test_cli_main_trajectory_pr_repo_is_target_not_cwd(
+    multi_stack_target: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end provenance: the written trajectory's extra.pr_repo is the
+    target checkout's slug, not the invoking cwd (#128).
+
+    This drives the full production entrypoint — ``cli.main`` -> ``anyio.run``
+    -> ``run_deep`` -> ``TrajectoryRecorder._write`` — and asserts the OBSERVABLE
+    on-disk artifact: the ATIF trajectory JSON. The ``gh`` seam returns
+    ``acme/<dir basename>``, so the target yields ``acme/multi_stack`` while the
+    cwd (the daydream repo) would yield a different basename. Asserting
+    ``acme/multi_stack`` proves provenance is attributed to the target — the
+    benchmark-harness pattern that regressed before the fix.
+    """
+    import json
+
+    _silence(monkeypatch)
+    _silence_cli_and_runner(monkeypatch)
+    _install_stub_backend(monkeypatch, multi_stack_target)
+
+    trajectory_path = tmp_path / "trajectory.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["daydream", "--trajectory", str(trajectory_path), str(multi_stack_target)],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert exc.value.code == 0
+
+    assert trajectory_path.exists(), "deep run must write the trajectory to disk"
+    data = json.loads(trajectory_path.read_text(encoding="utf-8"))
+    assert data["extra"]["pr_repo"] == f"acme/{multi_stack_target.name}"
+    assert data["extra"]["pr_repo"] != f"acme/{Path.cwd().name}"
 
 
 def test_cli_main_wrong_branch_exits_1(


### PR DESCRIPTION
## Summary

`_detect_repo_slug()` and `_auto_detect_pr_number()` shelled out to `gh` against `Path.cwd()`, so trajectory/archive provenance recorded the *invoking* repo instead of the *target* checkout being reviewed. Both helpers now take the repo path explicitly, and the call sites pass the resolved target.

## Changes

### Fixed
- `_detect_repo_slug(repo)` and `_auto_detect_pr_number(repo)` now accept the repository path explicitly instead of reading `Path.cwd()`.
- `_parse_args()` resolves `target_repo = Path(args.target) if args.target else Path.cwd()` and threads it into both detectors.
- `_build_feedback_config()` passes the same resolved target into `_detect_repo_slug()`.
- Docstrings updated to document that provenance is attributed to the target checkout, not the launch directory.

## Motivation

Running daydream from one repo against a checkout of another — the benchmark-harness pattern — corrupted provenance: `extra.pr_repo` (and the auto-detected `pr_number`) recorded e.g. `existential-birds/daydream` instead of `grafana/grafana`. `pr_number` had the identical cwd-vs-target defect on the adjacent line and is fixed alongside.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed

- **End-to-end** (`test_cli_main_integration`): drives the full `cli.main` → `anyio.run` → `run_deep` → `TrajectoryRecorder._write` path and asserts the on-disk `extra.pr_repo` is the target's slug, not cwd's. The shared seam helper now stubs `git_ops.gh_repo_view` (one layer deeper) instead of replacing the detectors, so the real path-threading logic runs.
- **Parse-path** (`test_cli`): `_parse_args` default + feedback flows with a target distinct from cwd and a per-path `gh` stub.
- Both new tests were verified to fail on the pre-fix (cwd-based) code path.

## Related Issues

- Closes #128

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally
- [x] Linting passes