### PR TITLE
refactor(cli)!: verb-first redesign with config-file phase control

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ daydream corpus label <session_id> --outcome accepted
 
 # Per-phase model/backend overrides are config-file-only (no CLI flags):
 #   set [tool.daydream] / [tool.daydream.phases.<phase>] in pyproject.toml or .daydream.toml.
-#   Precedence: CLI (--model/--backend, DAYDREAM_MODEL/DAYDREAM_BACKEND) > config file > built-in default.
+#   Precedence: CLI (--model/--backend) > config file > built-in default.
 
 # Development
 make lint       # Run ruff linter

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,14 +19,27 @@ daydream [TARGET] [OPTIONS]
 # Run as module
 python -m daydream
 
-# Examples
-daydream /path/to/project                          # Default: deep multi-stack loop
+# Golden paths (near-zero-flag; `daydream /path` == `daydream review /path`)
+daydream /path/to/project                          # review → fix → test (deep multi-stack)
+daydream --comment /path/to/project                # review → post inline PR comments, then exit
+
+# Other verbs / flags
 daydream --shallow -s python /path/to/project      # Shallow Python review-fix-test loop
 daydream --review /path/to/project                 # Review only, skip fixes
-daydream --comment --branch feat/x /path/to/project  # Post inline PR comments
+daydream --yes /path/to/project                    # Auto-apply fixes without prompting
+daydream --loop 3 /path/to/project                 # Repeat review-fix-test up to 3 rounds
 daydream feedback 42 --bot "<bot-login>[bot]" /path/to/project  # Bot PR comments
-daydream --trajectory /tmp/out.json /path/to/project  # Custom trajectory path
 daydream --non-interactive /path/to/project        # Unattended/harness run: take safe defaults, no prompts
+daydream --help-all                                # Full advanced flag surface (--start-at, --trajectory, ...)
+
+# Data pipeline moved under the `corpus` namespace
+daydream corpus harvest                            # Annotate archived runs
+daydream corpus build --out out.jsonl              # Project to JSONL training corpus
+daydream corpus label <session_id> --outcome accepted
+
+# Per-phase model/backend overrides are config-file-only (no CLI flags):
+#   set [tool.daydream] / [tool.daydream.phases.<phase>] in pyproject.toml or .daydream.toml.
+#   Precedence: CLI (--model/--backend, DAYDREAM_MODEL/DAYDREAM_BACKEND) > config file > built-in default.
 
 # Development
 make lint       # Run ruff linter

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Every run produces an [ATIF v1.6](https://www.harborframework.com/docs/agents/tr
 
 The training data pipeline converts archived trajectories into fine-tuning datasets through three stages:
 
-**Harvest** (`daydream harvest`): Walks the archive index, assembles bronze signals (verifier verdicts, finding records, grounding rate, review length), scores an intrinsic reward, derives the outcome label, and appends a bitemporal annotation. Re-running appends a new generation rather than overwriting, so older `as_of` pins still resolve their original scores.
+**Harvest** (`daydream corpus harvest`): Walks the archive index, assembles bronze signals (verifier verdicts, finding records, grounding rate, review length), scores an intrinsic reward, derives the outcome label, and appends a bitemporal annotation. Re-running appends a new generation rather than overwriting, so older `as_of` pins still resolve their original scores.
 
 **Reward scoring** (`daydream/training/reward.py`): a pure composite over capture-time signals:
 
@@ -44,7 +44,7 @@ The training data pipeline converts archived trajectories into fine-tuning datas
 
 Composite = `round(clip(credit − w_len·len_norm, 0, 1), 4)`. Missing signals are `None`, never imputed as 0. When a maintainer accept/reject label is supplied, scoring also returns a posterior false-positive cost as a sibling field — it never alters the composite. See `reward.py` for the posterior breakdown and weight details.
 
-**Build corpus** (`daydream build-corpus`): Projects `as_of`-pinned silver annotations into JSONL training records, filtered by outcome label, reward threshold, stack, exclusion list, and license. Writes a `lineage.json` manifest (content-addressed `trajectory_set_hash`, labeler/reward versions, `as_of` pin) for byte-for-byte reproducibility, with a temporal-leakage guard that drops annotations newer than the pin.
+**Build corpus** (`daydream corpus build`): Projects `as_of`-pinned silver annotations into JSONL training records, filtered by outcome label, reward threshold, stack, exclusion list, and license. Writes a `lineage.json` manifest (content-addressed `trajectory_set_hash`, labeler/reward versions, `as_of` pin) for byte-for-byte reproducibility, with a temporal-leakage guard that drops annotations newer than the pin.
 
 ### Archive
 
@@ -92,15 +92,28 @@ claude plugin install beagle
 
 Optional: [GitHub CLI](https://cli.github.com/) (`gh`) for PR feedback and `--comment` mode. [Codex CLI](https://openai.com/codex) for `--backend codex`.
 
-Run a review:
+### Golden paths
+
+Two near-zero-flag entry points cover the common cases:
 
 ```bash
-daydream /path/to/project                     # deep multi-stack review-fix-test
-daydream --shallow /path/to/project           # single-stack loop
-daydream --review /path/to/project            # report only, no fixes
-daydream --comment --branch feat/x /path/to/project  # post inline PR comments
+daydream /path/to/project            # review → fix → test (deep multi-stack)
+daydream --comment /path/to/project  # review → post inline PR comments, then exit
+```
+
+`daydream /path` is the default verb; `daydream review /path` is identical. The
+remaining surface is opt-in:
+
+```bash
+daydream --review /path/to/project            # write a report to terminal/markdown, no fixes
+daydream --shallow /path/to/project           # single-stack review → parse → fix → test loop
+daydream --yes /path/to/project               # auto-apply fixes without prompting
+daydream --loop /path/to/project              # repeat review-fix-test until clean (or 5 rounds)
 daydream feedback 42 --bot "<bot-login>[bot]" /path/to/project  # fix bot PR comments
 ```
+
+Run `daydream --help` for the common flags and `daydream --help-all` for the full
+advanced surface (`--start-at`, `--ignore-path`, `--worktree`, `--trajectory`, …).
 
 To update: `git pull && uv sync`
 
@@ -118,32 +131,79 @@ To update: `git pull && uv sync`
 
 ### Corpus Commands
 
+The data-pipeline verbs live under the `corpus` namespace:
+
 ```bash
-daydream harvest                              # annotate all archived runs (reward + label)
-daydream harvest --dry-run
-daydream build-corpus --out /path/to/out.jsonl  # project labeled runs to JSONL
-daydream build-corpus --out out.jsonl --min-reward 0.5 --label accepted --label mixed
-daydream build-corpus --out out.jsonl --as-of 2026-05-01T00:00:00Z  # pinned snapshot
-daydream label <session_id> --accepted        # manual outcome label override
+daydream corpus harvest                              # annotate all archived runs (reward + label)
+daydream corpus harvest --dry-run
+daydream corpus build --out /path/to/out.jsonl       # project labeled runs to JSONL
+daydream corpus build --out out.jsonl --min-reward 0.5 --include-all-labels
+daydream corpus build --out out.jsonl --as-of 2026-05-01T00:00:00Z  # pinned snapshot
+daydream corpus label <session_id> --outcome accepted  # manual outcome label override
 ```
 
 ### Common Options
 
 ```bash
 daydream -s python /path/to/project           # force a specific Beagle skill
-daydream --backend codex /path/to/project
-daydream --review-model claude-opus-4-6 /path/to/project
+daydream --backend codex /path/to/project     # or env DAYDREAM_BACKEND
+daydream --model claude-opus-4-8 /path/to/project  # global model; or env DAYDREAM_MODEL
+daydream --loop 3 /path/to/project            # repeat up to 3 review-fix-test rounds
+daydream --yes /path/to/project               # auto-apply fixes without prompting
+```
+
+Advanced flags (hidden from `--help`, shown by `--help-all`, all still parse):
+
+```bash
 daydream --start-at fix /path/to/project      # resume from a specific phase
-daydream --loop --max-iterations 3 /path/to/project
 daydream --trajectory /tmp/run.json /path/to/project
 daydream --ignore-path vendor /path/to/project
 daydream --worktree /path/to/project          # force ephemeral worktree
 daydream --non-interactive /path/to/project   # run unattended; take every prompt's safe default
 ```
 
-`--non-interactive` takes each prompt's safe default: on test failure it writes a `handoff.md` and exits non-zero instead of looping, otherwise it auto-commits and exits 0.
+`--non-interactive` takes each prompt's safe default: on test failure it writes a `handoff.md` and exits non-zero instead of looping, otherwise it declines fixes and exits 0. It is orthogonal to `--yes`: `--non-interactive` controls *whether* daydream may block on stdin, while `--yes` pre-decides every yes/no gate as "yes". A non-TTY or CI environment (`CI` set) auto-enables non-interactive mode without the flag.
 
-Per-phase backend and model overrides: `--review-backend`, `--fix-backend`, `--test-backend`, `--review-model`, `--parse-model`, `--fix-model`, `--test-model`, `--exploration-model`. Run `daydream --help` for the full option list and per-backend model defaults.
+Per-phase model and backend overrides are no longer CLI flags — set them in the config file (see [Configuration](#configuration)).
+
+## Configuration
+
+Per-phase model/backend selection and global defaults live in a config file, read from the **target repo root** at two sources, merged per-key (the dotfile wins on scalar conflicts):
+
+- `pyproject.toml` under `[tool.daydream]` (lower precedence)
+- `.daydream.toml` at the repo root, using bare top-level keys (higher precedence)
+
+```toml
+# pyproject.toml  →  [tool.daydream]
+[tool.daydream]
+model = "claude-opus-4-8"     # global default across phases
+backend = "claude"            # global default backend
+
+[tool.daydream.phases.fix]    # per-phase override
+backend = "codex"
+model = "gpt-5.5"
+
+[tool.daydream.phases.review]
+model = "claude-opus-4-8"
+```
+
+```toml
+# .daydream.toml  (top-level keys; no [tool.daydream] prefix)
+model = "claude-opus-4-8"
+
+[phases.fix]
+backend = "codex"
+```
+
+Phase names: `exploration`, `review`, `parse`, `fix`, `test`, `merge` (plus
+`intent`, `pr_feedback`). Resolution precedence, highest first:
+
+**CLI > env > config file > built-in per-backend default.**
+
+So `--model` (or `DAYDREAM_MODEL`) beats a `[tool.daydream.phases.*]` override,
+which beats the per-backend table in `daydream/config.py`. The same order applies
+to backend selection via `--backend` / `DAYDREAM_BACKEND` / config / the `claude`
+fallback.
 
 ## Output Files
 

--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ daydream corpus label <session_id> --outcome accepted  # manual outcome label ov
 
 ```bash
 daydream -s python /path/to/project           # force a specific Beagle skill
-daydream --backend codex /path/to/project     # or env DAYDREAM_BACKEND
-daydream --model claude-opus-4-8 /path/to/project  # overrides ALL phases (env DAYDREAM_MODEL is lower-precedence)
+daydream --backend codex /path/to/project     # override backend for this run
+daydream --model claude-opus-4-8 /path/to/project  # overrides ALL phases (beats config-file overrides)
 daydream --loop 3 /path/to/project            # repeat up to 3 review-fix-test rounds
 daydream --yes /path/to/project               # auto-apply fixes without prompting
 ```
@@ -198,12 +198,12 @@ backend = "codex"
 Phase names: `exploration`, `review`, `parse`, `fix`, `test`, `verify`, `merge` (plus
 `intent`, `wonder`, `envision`, `pr_feedback`). Resolution precedence, highest first:
 
-**CLI > env > config file > built-in per-backend default.**
+**CLI > config file (phase, then global) > built-in per-backend default.**
 
-So `--model` (or `DAYDREAM_MODEL`) beats a `[tool.daydream.phases.*]` override,
-which beats the per-backend table in `daydream/config.py`. The same order applies
-to backend selection via `--backend` / `DAYDREAM_BACKEND` / config / the `claude`
-fallback.
+So `--model` beats a `[tool.daydream.phases.*]` override, which beats the
+per-backend table in `daydream/config.py`. The same order applies to backend
+selection via `--backend` / config / the `claude` fallback. (There is no
+environment-variable tier — `DAYDREAM_MODEL`/`DAYDREAM_BACKEND` are not read.)
 
 ## Output Files
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ daydream corpus label <session_id> --outcome accepted  # manual outcome label ov
 ```bash
 daydream -s python /path/to/project           # force a specific Beagle skill
 daydream --backend codex /path/to/project     # override backend for this run
-daydream --model claude-opus-4-8 /path/to/project  # overrides ALL phases (beats config-file overrides)
+daydream --model claude-haiku-4-5 /path/to/project  # overrides ALL phases (beats config-file overrides)
 daydream --loop 3 /path/to/project            # repeat up to 3 review-fix-test rounds
 daydream --yes /path/to/project               # auto-apply fixes without prompting
 ```

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ daydream corpus label <session_id> --outcome accepted  # manual outcome label ov
 ```bash
 daydream -s python /path/to/project           # force a specific Beagle skill
 daydream --backend codex /path/to/project     # or env DAYDREAM_BACKEND
-daydream --model claude-opus-4-8 /path/to/project  # global model; or env DAYDREAM_MODEL
+daydream --model claude-opus-4-8 /path/to/project  # overrides ALL phases (env DAYDREAM_MODEL is lower-precedence)
 daydream --loop 3 /path/to/project            # repeat up to 3 review-fix-test rounds
 daydream --yes /path/to/project               # auto-apply fixes without prompting
 ```
@@ -195,8 +195,8 @@ model = "claude-opus-4-8"
 backend = "codex"
 ```
 
-Phase names: `exploration`, `review`, `parse`, `fix`, `test`, `merge` (plus
-`intent`, `pr_feedback`). Resolution precedence, highest first:
+Phase names: `exploration`, `review`, `parse`, `fix`, `test`, `verify`, `merge` (plus
+`intent`, `wonder`, `envision`, `pr_feedback`). Resolution precedence, highest first:
 
 **CLI > env > config file > built-in per-backend default.**
 

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -56,6 +56,10 @@ class AgentState:
     Attributes:
         quiet_mode: True to hide tool calls and results, False to show them.
         non_interactive: True to take each prompt's safe default without reading stdin.
+        assume: A forced yes/no answer for interactive gates — ``"yes"`` (``--yes``),
+            ``"no"`` (a future ``--no``), or ``None`` (no assumption). Orthogonal to
+            ``non_interactive``: ``non_interactive`` controls *whether* we may block on
+            stdin; ``assume`` supplies a *pre-decided answer* regardless of TTY.
         shutdown_requested: True if shutdown has been requested.
         current_backends: List of active backend instances.
 
@@ -63,6 +67,7 @@ class AgentState:
 
     quiet_mode: bool = False
     non_interactive: bool = False
+    assume: str | None = None
     shutdown_requested: bool = False
     current_backends: list[Backend] = field(default_factory=list)
 
@@ -146,6 +151,56 @@ def get_non_interactive() -> bool:
 
     """
     return _state.non_interactive
+
+
+def set_assume(value: str | None) -> None:
+    """Set the forced yes/no answer for interactive gates.
+
+    Args:
+        value: ``"yes"`` to auto-approve gates (``--yes``), ``"no"`` to auto-decline,
+            or ``None`` for no assumption (gates fall back to prompting or their
+            unattended safe default).
+
+    Returns:
+        None
+
+    """
+    _state.assume = value
+
+
+def get_assume() -> str | None:
+    """Get the forced yes/no answer for interactive gates.
+
+    Returns:
+        ``"yes"``, ``"no"``, or ``None`` when no assumption is set.
+
+    """
+    return _state.assume
+
+
+def resolve_gate(*, assume: str | None, interactive: bool, safe_default: bool) -> bool | None:
+    """Resolve a yes/no interaction gate across the two orthogonal axes.
+
+    Collapses *assume* (a forced answer) and *interactivity* (may we block on
+    stdin?) into a single decision. Pure — performs no I/O.
+
+    Args:
+        assume: A forced answer: ``"yes"`` → True, ``"no"`` → False, ``None`` →
+            no assumption (defer to interactivity).
+        interactive: True when prompts may read stdin.
+        safe_default: The answer to use when unattended and no assumption is set
+            (e.g. ``False`` to decline a fix-apply, ``True`` to auto-commit).
+
+    Returns:
+        ``True``/``False`` to use the resolved answer directly, or ``None`` when
+        the caller should fall back to an interactive prompt.
+
+    """
+    if assume is not None:
+        return assume == "yes"
+    if not interactive:
+        return safe_default
+    return None
 
 
 def set_shutdown_requested(requested: bool) -> None:

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -236,7 +236,7 @@ def resolve_or_prompt(
     decision = resolve_gate(assume=assume, interactive=interactive, safe_default=safe_default)
     if decision is None:
         response = prompt_user(console, question, default)
-        decision = response.lower() in ("y", "yes")
+        decision = response.strip().lower() in ("y", "yes")
     return decision
 
 

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -33,6 +33,7 @@ from daydream.ui import (
     print_cost,
     print_error,
     print_thinking,
+    prompt_user,
 )
 
 
@@ -201,6 +202,42 @@ def resolve_gate(*, assume: str | None, interactive: bool, safe_default: bool) -
     if not interactive:
         return safe_default
     return None
+
+
+def resolve_or_prompt(
+    *,
+    assume: str | None,
+    interactive: bool,
+    safe_default: bool,
+    question: str,
+    default: str,
+) -> bool:
+    """Resolve a yes/no gate, falling back to an interactive prompt when needed.
+
+    Wraps :func:`resolve_gate` with the canonical prompt-and-coerce step so
+    callers don't each re-implement the ``decision is None → prompt_user →
+    lower() in ("y", "yes")`` idiom.
+
+    Args:
+        assume: Forwarded to :func:`resolve_gate` — ``"yes"`` → ``True``,
+            ``"no"`` → ``False``, ``None`` → defer to interactivity.
+        interactive: Forwarded to :func:`resolve_gate` — True when stdin may
+            be read.
+        safe_default: Forwarded to :func:`resolve_gate` — the answer used when
+            unattended and no assumption is set.
+        question: The prompt string shown to the user when interactive (e.g.
+            ``"Apply fixes now? [y/N]"``).
+        default: The default hint shown alongside the question (e.g. ``"n"``).
+
+    Returns:
+        ``True`` if the gate is approved, ``False`` if declined.
+
+    """
+    decision = resolve_gate(assume=assume, interactive=interactive, safe_default=safe_default)
+    if decision is None:
+        response = prompt_user(console, question, default)
+        decision = response.lower() in ("y", "yes")
+    return decision
 
 
 def set_shutdown_requested(requested: bool) -> None:

--- a/daydream/archive/manifest.py
+++ b/daydream/archive/manifest.py
@@ -18,7 +18,6 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 from daydream.archive.git_context import GitContext
-from daydream.runner import _resolved_backend_name
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -215,10 +214,15 @@ def build_manifest(
     """
     totals = recorder._final_totals  # noqa: SLF001 - intentional access to recorder internals
 
+    # Deferred import to avoid a module-level cycle: archive.manifest →
+    # runner → (lazy) archive.  Importing here keeps the call-site semantics
+    # identical while breaking the top-level cycle.
+    from daydream.runner import _resolved_backend_name  # noqa: PLC0415
+
     # Resolve the effective backend through the full precedence chain
-    # (per-phase flag → config.backend → env → file-config → "claude") so the
-    # manifest records the backend that was *actually* used rather than the raw
-    # config value (which is None when the backend came from env or file-config).
+    # (per-phase flag → config.backend → file-config phase → file-config global → "claude")
+    # so the manifest records the backend that was *actually* used rather than the raw
+    # config value (which is None when the backend came from file-config).
     # "review" is used as the representative phase — consistent with how the
     # orchestrator prints the default backend.
     backend_used = _resolved_backend_name(config, "review")

--- a/daydream/archive/manifest.py
+++ b/daydream/archive/manifest.py
@@ -217,7 +217,7 @@ def build_manifest(
     # Deferred import to avoid a module-level cycle: archive.manifest →
     # runner → (lazy) archive.  Importing here keeps the call-site semantics
     # identical while breaking the top-level cycle.
-    from daydream.runner import _resolved_backend_name  # noqa: PLC0415
+    from daydream.runner import _resolved_backend_name  # noqa: PLC0415 - deferred import avoids cycle
 
     # Resolve the effective backend through the full precedence chain
     # (per-phase flag → config.backend → file-config phase → file-config global → "claude")

--- a/daydream/archive/manifest.py
+++ b/daydream/archive/manifest.py
@@ -18,6 +18,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 from daydream.archive.git_context import GitContext
+from daydream.runner import _resolved_backend_name
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -214,10 +215,13 @@ def build_manifest(
     """
     totals = recorder._final_totals  # noqa: SLF001 - intentional access to recorder internals
 
-    # ``config.backend`` is now None by default (env/config-file may supply it
-    # at resolution time). The manifest records the global backend selection,
-    # falling back to ``"claude"`` so the field is never None.
-    backend_used = config.backend or "claude"
+    # Resolve the effective backend through the full precedence chain
+    # (per-phase flag → config.backend → env → file-config → "claude") so the
+    # manifest records the backend that was *actually* used rather than the raw
+    # config value (which is None when the backend came from env or file-config).
+    # "review" is used as the representative phase — consistent with how the
+    # orchestrator prints the default backend.
+    backend_used = _resolved_backend_name(config, "review")
 
     m = Manifest(
         session_id=recorder.session_id,
@@ -227,9 +231,9 @@ def build_manifest(
         skill=config.skill,
         model=None,
         backend=backend_used,
-        review_backend=config.review_backend,
-        fix_backend=config.fix_backend,
-        test_backend=config.test_backend,
+        review_backend=_resolved_backend_name(config, "review"),
+        fix_backend=_resolved_backend_name(config, "fix"),
+        test_backend=_resolved_backend_name(config, "test"),
         review_only=config.output_mode == "review",
         deep=not config.shallow,
         loop=config.loop,

--- a/daydream/archive/manifest.py
+++ b/daydream/archive/manifest.py
@@ -214,6 +214,11 @@ def build_manifest(
     """
     totals = recorder._final_totals  # noqa: SLF001 - intentional access to recorder internals
 
+    # ``config.backend`` is now None by default (env/config-file may supply it
+    # at resolution time). The manifest records the global backend selection,
+    # falling back to ``"claude"`` so the field is never None.
+    backend_used = config.backend or "claude"
+
     m = Manifest(
         session_id=recorder.session_id,
         archived_at=datetime.now(timezone.utc).isoformat(),
@@ -221,7 +226,7 @@ def build_manifest(
         run_flow=recorder.run_flow.value,
         skill=config.skill,
         model=None,
-        backend=config.backend,
+        backend=backend_used,
         review_backend=config.review_backend,
         fix_backend=config.fix_backend,
         test_backend=config.test_backend,

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -165,7 +165,7 @@ def _add_shared_arguments(parser: argparse.ArgumentParser, *, full_help: bool = 
     like ``--backend``, ``--model``, ``--trajectory`` work in both places. The
     global ``--model``/``--backend`` here feed the source-tiered precedence in
     :func:`daydream.runner._resolved_model` / ``_resolve_backend``
-    (CLI > env > config-file > per-backend table).
+    (CLI > config-file phase override > config-file global > per-backend default).
 
     Per-phase model/backend overrides are no longer CLI flags — they live in
     ``[tool.daydream.phases.<phase>]`` of the config file (``pyproject.toml`` /
@@ -1187,11 +1187,18 @@ _CORPUS_SUBVERBS: dict[str, Callable[[list[str]], int]] = {
 }
 
 
-def _print_corpus_help() -> None:
-    """Print usage for the ``corpus`` namespace via the daydream.ui console."""
-    from daydream.ui import create_console
+def _print_corpus_help(*, error: bool = False) -> None:
+    """Print usage for the ``corpus`` namespace.
 
-    console = create_console()
+    Args:
+        error: When ``True`` write to stderr (unknown sub-verb error path);
+            when ``False`` (default) write to stdout (bare invocation / help
+            request path).
+    """
+    from rich.console import Console
+    from daydream.ui import NEON_THEME
+
+    console = Console(stderr=error, theme=NEON_THEME)
     console.print(
         "usage: daydream corpus {harvest,build,label} ...\n"
         "\n"
@@ -1207,18 +1214,22 @@ def _handle_corpus_command(argv: list[str]) -> int:
 
     ``corpus harvest|build|label`` routes to the existing data-pipeline
     handlers (``build`` → the build-corpus projection). A bare ``daydream
-    corpus`` (no sub-verb) prints help and exits 2. Exit codes propagate
+    corpus`` (no sub-verb) prints help to stdout and exits 2. An unknown
+    sub-verb prints help to stderr and exits 2. Exit codes propagate
     unchanged from the handlers.
 
     Args:
         argv: The argument vector after the ``corpus`` verb.
 
     Returns:
-        int: The sub-handler's exit code, or ``2`` for a missing/unknown
-        sub-verb.
+        int: The sub-handler's exit code; ``2`` for a bare (no-arg)
+        invocation or an unknown sub-verb.
     """
-    if not argv or argv[0] not in _CORPUS_SUBVERBS:
-        _print_corpus_help()
+    if not argv:
+        _print_corpus_help(error=False)
+        return 2
+    if argv[0] not in _CORPUS_SUBVERBS:
+        _print_corpus_help(error=True)
         return 2
     handler = _CORPUS_SUBVERBS[argv[0]]
     return int(handler(argv[1:]))

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -31,6 +31,7 @@ from daydream.agent import (
     set_shutdown_requested,
 )
 from daydream.benchmark.cli import _handle_bench_command
+from daydream.config_file import load_file_config
 from daydream.runner import RunConfig, run, run_feedback
 from daydream.trajectory import get_signal_recorder
 from daydream.ui import (
@@ -123,33 +124,14 @@ def _detect_repo_slug(repo: Path) -> str | None:
     return f"{owner}/{name}"
 
 
-_REMOVED_MODEL_FLAG_MESSAGE = (
-    "--model has been removed. Use per-phase flags: "
-    "--review-model, --parse-model, --fix-model, --test-model, --exploration-model. "
-    "See README for the per-backend default table."
-)
-
-
-def _reject_removed_model_flag(parser: argparse.ArgumentParser, argv: list[str]) -> None:
-    """Surface a curated error before argparse runs when ``--model`` is passed.
-
-    Argparse would otherwise reject ``--model`` with a generic "unrecognized
-    arguments" message that gives users no path forward. Catching both
-    ``--model X`` and ``--model=X`` shapes here points users at the new
-    per-phase flags before any parsing happens.
-    """
-    for token in argv:
-        if token == "--model" or token.startswith("--model="):
-            parser.error(_REMOVED_MODEL_FLAG_MESSAGE)
-
-
 def _add_shared_arguments(parser: argparse.ArgumentParser) -> None:
     """Add the shared (non-output-mode) arguments to a parser or subparser.
 
     Used by both the top-level parser and the ``feedback`` subparser so flags
-    like ``--backend``, ``--trajectory`` work in both places. ``--model`` is
-    intentionally absent — see :func:`_reject_removed_model_flag` for the
-    curated error surfaced when a user passes the removed flag.
+    like ``--backend``, ``--model``, ``--trajectory`` work in both places. The
+    global ``--model``/``--backend`` here feed the source-tiered precedence in
+    :func:`daydream.runner._resolved_model` / ``_resolve_backend``
+    (CLI > env > config-file > per-backend table).
     """
     parser.add_argument(
         "--trajectory",
@@ -179,8 +161,19 @@ def _add_shared_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--backend", "-b",
         choices=["claude", "codex"],
-        default="claude",
-        help="Agent backend: claude (default) or codex",
+        default=None,
+        help="Agent backend: claude or codex "
+             "(default: env DAYDREAM_BACKEND, config file, then claude)",
+    )
+    parser.add_argument(
+        "--model", "-m",
+        default=None,
+        type=str,
+        dest="model",
+        metavar="MODEL",
+        help="Global default model across phases "
+             "(default: env DAYDREAM_MODEL, config file, then the per-backend table). "
+             "A per-phase config override is beaten by this global --model.",
     )
     parser.add_argument(
         "--review-backend",
@@ -681,7 +674,6 @@ def _parse_args(argv: list[str] | None = None) -> RunConfig:
     # front ourselves and route to a dedicated parser.
     if raw_argv and raw_argv[0] == "feedback":
         feedback_parser = _build_feedback_parser()
-        _reject_removed_model_flag(feedback_parser, raw_argv[1:])
         feedback_args = feedback_parser.parse_intermixed_args(raw_argv[1:])
         return _build_feedback_config(feedback_args)
 
@@ -690,7 +682,6 @@ def _parse_args(argv: list[str] | None = None) -> RunConfig:
     # a guard for callers that hand crafted-argv to _parse_args directly.
 
     parser = _build_main_parser()
-    _reject_removed_model_flag(parser, raw_argv)
     args = parser.parse_args(raw_argv)
 
     # ----- Reject purely numeric TARGET (likely meant `daydream feedback N`) -----
@@ -737,9 +728,15 @@ def _parse_args(argv: list[str] | None = None) -> RunConfig:
     pr_repo = _detect_repo_slug(target_repo)
     pr_number = _auto_detect_pr_number(target_repo)
 
+    # Low-precedence model/backend source: [tool.daydream] / .daydream.toml at
+    # the target repo root, consulted by ``_resolve_backend`` below CLI and env.
+    file_config = load_file_config(target_repo)
+
     return RunConfig(
         target=args.target,
         skill=args.skill,
+        model=args.model,
+        file_config=file_config,
         exploration_model=args.exploration_model,
         review_model=args.review_model,
         parse_model=args.parse_model,
@@ -784,11 +781,15 @@ def _build_feedback_config(args: argparse.Namespace) -> RunConfig:
         # argparse already enforces type=int, but guard against negatives.
         raise SystemExit(f"feedback subcommand: PR number must be positive (got {pr_number})")
 
-    pr_repo = _detect_repo_slug(Path(args.target) if args.target else Path.cwd())
+    target_repo = Path(args.target) if args.target else Path.cwd()
+    pr_repo = _detect_repo_slug(target_repo)
+    file_config = load_file_config(target_repo)
 
     return RunConfig(
         target=args.target,
         skill=None,
+        model=args.model,
+        file_config=file_config,
         exploration_model=None,
         review_model=args.review_model,
         parse_model=args.parse_model,

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -25,6 +25,7 @@ import argparse
 import inspect
 import signal
 import sys
+from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -222,7 +223,7 @@ def _add_shared_arguments(parser: argparse.ArgumentParser, *, full_help: bool = 
         metavar="MODEL",
         help="Global default model across phases "
              "(default: env DAYDREAM_MODEL, config file, then the per-backend table). "
-             "A per-phase config override is beaten by this global --model.",
+             "A per-phase config-file override takes precedence over this global --model.",
     )
     parser.add_argument(
         "--non-interactive",
@@ -703,11 +704,25 @@ def _normalize_loop_argv(raw_argv: list[str]) -> list[str]:
     Returns:
         A new argv list with bare ``--loop`` rewritten to ``--loop=5``.
     """
+    def _looks_like_int(s: str) -> bool:
+        # Use int() — the same parser argparse applies via type=int — so the
+        # pre-scan and the argument parser agree on what counts as an integer.
+        try:
+            int(s)
+            return True
+        except ValueError:
+            return False
+
     normalized: list[str] = []
     for i, token in enumerate(raw_argv):
         if token == "--loop":
             nxt = raw_argv[i + 1] if i + 1 < len(raw_argv) else None
-            if nxt is None or not nxt.isdigit():
+            # Accept both positive bare digits ("5") and negative/signed
+            # integers ("-3", "+2") so argparse receives the literal value
+            # and can apply type=int validation (including our post-parse
+            # positive-count check).  Only pin the default when the next
+            # token is absent, a flag, or a clearly non-numeric string.
+            if nxt is None or not _looks_like_int(nxt):
                 # Bare --loop (end, before a flag, or before a non-int target):
                 # pin the default count so the next token stays a positional.
                 normalized.append("--loop=5")
@@ -835,7 +850,10 @@ def _parse_args(argv: list[str] | None = None) -> RunConfig:
     # ``--loop`` takes an optional count (``--loop`` ⇒ 5, ``--loop N`` ⇒ N).
     # ``args.loop`` is None when the flag is absent.
     loop = args.loop is not None
-    max_iterations = args.loop or 5
+    max_iterations = args.loop if args.loop is not None else 5
+
+    if loop and max_iterations < 1:
+        parser.error("--loop count must be positive")
 
     # Validate --loop incompatibilities
     if loop and output_mode != "loop":
@@ -1160,27 +1178,27 @@ def _handle_label_command(argv: list[str]) -> int:
     return 0
 
 
-# Sub-verbs of the ``corpus`` namespace, mapped to the handler attribute name
-# on this module. ``build`` is the public name for the build-corpus projection.
-# Handlers are resolved by name at call time (via ``getattr``) so test
-# monkeypatches on the module attribute take effect.
-_CORPUS_SUBVERBS = {
-    "harvest": "_handle_harvest_command",
-    "build": "_handle_build_corpus_command",
-    "label": "_handle_label_command",
+# Sub-verbs of the ``corpus`` namespace mapped to their handler callables.
+# ``build`` is the public name for the build-corpus projection.
+_CORPUS_SUBVERBS: dict[str, Callable[[list[str]], int]] = {
+    "harvest": _handle_harvest_command,
+    "build": _handle_build_corpus_command,
+    "label": _handle_label_command,
 }
 
 
 def _print_corpus_help() -> None:
-    """Print usage for the ``corpus`` namespace to stderr."""
-    print(
+    """Print usage for the ``corpus`` namespace via the daydream.ui console."""
+    from daydream.ui import create_console
+
+    console = create_console()
+    console.print(
         "usage: daydream corpus {harvest,build,label} ...\n"
         "\n"
         "Data-pipeline sub-verbs:\n"
         "  harvest   walk the archive and append one bitemporal annotation per indexed run\n"
         "  build     project the as-of-pinned annotations into a JSONL training corpus\n"
-        "  label     record an authoritative human outcome label that overrides automated ones\n",
-        file=sys.stderr,
+        "  label     record an authoritative human outcome label that overrides automated ones"
     )
 
 
@@ -1202,7 +1220,7 @@ def _handle_corpus_command(argv: list[str]) -> int:
     if not argv or argv[0] not in _CORPUS_SUBVERBS:
         _print_corpus_help()
         return 2
-    handler = getattr(sys.modules[__name__], _CORPUS_SUBVERBS[argv[0]])
+    handler = _CORPUS_SUBVERBS[argv[0]]
     return int(handler(argv[1:]))
 
 

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -1196,6 +1196,7 @@ def _print_corpus_help(*, error: bool = False) -> None:
             request path).
     """
     from rich.console import Console
+
     from daydream.ui import NEON_THEME
 
     console = Console(stderr=error, theme=NEON_THEME)

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -161,7 +161,7 @@ def _detect_repo_slug(repo: Path) -> str | None:
     return f"{owner}/{name}"
 
 
-def _add_shared_arguments(parser: argparse.ArgumentParser) -> None:
+def _add_shared_arguments(parser: argparse.ArgumentParser, *, full_help: bool = True) -> None:
     """Add the shared (non-output-mode) arguments to a parser or subparser.
 
     Used by both the top-level parser and the ``feedback`` subparser so flags
@@ -169,6 +169,14 @@ def _add_shared_arguments(parser: argparse.ArgumentParser) -> None:
     global ``--model``/``--backend`` here feed the source-tiered precedence in
     :func:`daydream.runner._resolved_model` / ``_resolve_backend``
     (CLI > env > config-file > per-backend table).
+
+    Args:
+        parser: The parser (or subparser) to add the shared arguments to.
+        full_help: When False, advanced flags (``--trajectory``, ``--no-archive``,
+            ``--eval``, ``--non-interactive``) are added with their help text
+            suppressed so the default ``--help`` stays focused on common flags.
+            They still parse and populate ``RunConfig`` unchanged; ``--help-all``
+            re-builds the parser with ``full_help=True`` to surface them.
     """
     parser.add_argument(
         "--trajectory",
@@ -179,21 +187,22 @@ def _add_shared_arguments(parser: argparse.ArgumentParser) -> None:
         help=(
             "Write ATIF v1.6 trajectory JSON to this path "
             "(default: <target>/.daydream/runs/<session_id>/trajectory.json)"
-        ),
+        ) if full_help else argparse.SUPPRESS,
     )
     parser.add_argument(
         "--no-archive",
         action="store_true",
         default=False,
         dest="no_archive",
-        help="Disable automatic archival to ~/.daydream/archive/",
+        help="Disable automatic archival to ~/.daydream/archive/" if full_help else argparse.SUPPRESS,
     )
     parser.add_argument(
         "--eval",
         action="store_true",
         default=False,
         dest="run_eval",
-        help="Run deterministic evaluation analysis and store evaluation.json in archive",
+        help="Run deterministic evaluation analysis and store evaluation.json in archive"
+        if full_help else argparse.SUPPRESS,
     )
     parser.add_argument(
         "--backend", "-b",
@@ -276,7 +285,8 @@ def _add_shared_arguments(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         dest="non_interactive",
         help="Run without prompting; take each prompt's safe default "
-             "(confirm intent, decline fixes, exit the test/heal loop).",
+             "(confirm intent, decline fixes, exit the test/heal loop)."
+        if full_help else argparse.SUPPRESS,
     )
     parser.add_argument(
         "--yes",
@@ -554,12 +564,49 @@ def _build_feedback_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _build_main_parser() -> argparse.ArgumentParser:
-    """Build the main argparse parser for the consolidated CLI surface."""
+class _HelpAllAction(argparse.Action):
+    """Print the full help (advanced flags included) and exit.
+
+    The default ``--help`` is built with ``full_help=False`` so advanced flags
+    are suppressed. ``--help-all`` re-builds the parser with ``full_help=True``
+    and renders that help instead, surfacing every flag without changing how
+    any of them parse.
+    """
+
+    def __init__(self, option_strings, dest=argparse.SUPPRESS, default=argparse.SUPPRESS, help=None):  # noqa: A002
+        super().__init__(
+            option_strings=option_strings,
+            dest=dest,
+            default=default,
+            nargs=0,
+            help=help,
+        )
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        _build_main_parser(full_help=True).print_help()
+        parser.exit()
+
+
+def _build_main_parser(*, full_help: bool = False) -> argparse.ArgumentParser:
+    """Build the main argparse parser for the consolidated CLI surface.
+
+    Args:
+        full_help: When True, advanced flags carry their help text so they show
+            up under ``--help-all``. When False (the default for ``--help``),
+            advanced flags are added with ``argparse.SUPPRESS`` help so the
+            default help stays focused on common flags. Either way the flags
+            parse identically and populate ``RunConfig`` unchanged.
+    """
     parser = argparse.ArgumentParser(
         prog="daydream",
         description="Automated code review and fix loop. "
                     "Use `daydream feedback <pr#>` to process PR bot comments.",
+    )
+
+    parser.add_argument(
+        "--help-all",
+        action=_HelpAllAction,
+        help="Show all flags, including advanced ones, then exit.",
     )
 
     parser.add_argument(
@@ -608,7 +655,7 @@ def _build_main_parser() -> argparse.ArgumentParser:
         action="store_true",
         default=False,
         dest="force_worktree",
-        help="Force ephemeral worktree even when --branch is omitted.",
+        help="Force ephemeral worktree even when --branch is omitted." if full_help else argparse.SUPPRESS,
     )
     parser.add_argument(
         "--shallow",
@@ -624,14 +671,15 @@ def _build_main_parser() -> argparse.ArgumentParser:
         metavar="PATH",
         dest="extra_copy",
         type=Path,
-        help="Extra path to copy into ephemeral worktree (repeatable).",
+        help="Extra path to copy into ephemeral worktree (repeatable)." if full_help else argparse.SUPPRESS,
     )
     parser.add_argument(
         "--plan",
         action="store_true",
         default=False,
         dest="plan",
-        help="Generate an implementation plan and embed it in PR comments (use with --comment).",
+        help="Generate an implementation plan and embed it in PR comments (use with --comment)."
+        if full_help else argparse.SUPPRESS,
     )
 
     # ---- Skill selection (overrides auto-detect) ----
@@ -649,13 +697,13 @@ def _build_main_parser() -> argparse.ArgumentParser:
         action="store_true",
         default=None,
         dest="cleanup",
-        help="Cleanup review output after completion",
+        help="Cleanup review output after completion" if full_help else argparse.SUPPRESS,
     )
     cleanup_group.add_argument(
         "--no-cleanup",
         action="store_false",
         dest="cleanup",
-        help="Keep review output after completion",
+        help="Keep review output after completion" if full_help else argparse.SUPPRESS,
     )
     parser.add_argument(
         "--start-at",
@@ -666,7 +714,7 @@ def _build_main_parser() -> argparse.ArgumentParser:
             "Start at a specific phase (default: review). "
             "Choices: review | parse | fix | test | ttt | per-stack | merge. "
             "ttt, per-stack, and merge are valid only in deep (non-shallow) mode."
-        ),
+        ) if full_help else argparse.SUPPRESS,
     )
 
     parser.add_argument(
@@ -675,7 +723,8 @@ def _build_main_parser() -> argparse.ArgumentParser:
         default=[],
         metavar="PATH",
         dest="ignore_paths",
-        help="Exclude path from diff (repeatable, e.g. --ignore-path .planning --ignore-path vendor)",
+        help="Exclude path from diff (repeatable, e.g. --ignore-path .planning --ignore-path vendor)"
+        if full_help else argparse.SUPPRESS,
     )
 
     parser.add_argument(
@@ -688,7 +737,7 @@ def _build_main_parser() -> argparse.ArgumentParser:
         help="Repeat the review-fix-test cycle until zero issues or N iterations (default N: 5)",
     )
 
-    _add_shared_arguments(parser)
+    _add_shared_arguments(parser, full_help=full_help)
 
     return parser
 

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -518,7 +518,7 @@ class _HelpAllAction(argparse.Action):
     any of them parse.
     """
 
-    def __init__(self, option_strings, dest=argparse.SUPPRESS, default=argparse.SUPPRESS, help=None):  # noqa: A002
+    def __init__(self, option_strings, dest=argparse.SUPPRESS, default=argparse.SUPPRESS, help=None):  # noqa: A002 - `help` is argparse.Action's API parameter name
         super().__init__(
             option_strings=option_strings,
             dest=dest,

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -213,7 +213,7 @@ def _add_shared_arguments(parser: argparse.ArgumentParser, *, full_help: bool = 
         choices=["claude", "codex"],
         default=None,
         help="Agent backend: claude or codex "
-             "(default: env DAYDREAM_BACKEND, config file, then claude)",
+             "(default: config file, then claude)",
     )
     parser.add_argument(
         "--model", "-m",
@@ -222,8 +222,8 @@ def _add_shared_arguments(parser: argparse.ArgumentParser, *, full_help: bool = 
         dest="model",
         metavar="MODEL",
         help="Global default model across phases "
-             "(default: env DAYDREAM_MODEL, config file, then the per-backend table). "
-             "A per-phase config-file override takes precedence over this global --model.",
+             "(default: config file, then the per-backend table). "
+             "This global --model takes precedence over any per-phase config-file override.",
     )
     parser.add_argument(
         "--non-interactive",

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -12,12 +12,13 @@ top-level ``TARGET`` positional):
 - ``daydream feedback <pr#>`` — apply bot PR-review comments
 - ``daydream summarize <path>`` — print run-info markdown for a trajectory
 - ``daydream bench`` — score deep-review findings against the offline benchmark
-- ``daydream harvest`` — walk the archive and append one bitemporal
-  annotation (outcome label + intrinsic reward) per indexed run
-- ``daydream label <session-prefix> --outcome {accepted,contested,rejected,unknown}``
-  — record an authoritative human outcome label that overrides automated ones
-- ``daydream build-corpus --out <path>`` — project the as-of-pinned
-  annotations into a JSONL training corpus plus a lineage manifest
+- ``daydream corpus <sub-verb>`` — the data-pipeline namespace:
+    - ``corpus harvest`` — walk the archive and append one bitemporal
+      annotation (outcome label + intrinsic reward) per indexed run
+    - ``corpus build --out <path>`` — project the as-of-pinned annotations
+      into a JSONL training corpus plus a lineage manifest
+    - ``corpus label <session-prefix> --outcome {accepted,contested,rejected,unknown}``
+      — record an authoritative human outcome label that overrides automated ones
 """
 
 import argparse
@@ -51,11 +52,6 @@ from daydream.ui import (
 # falls through to the ``review`` golden path via the default-verb shim.
 KNOWN_VERBS = {"review", "feedback", "summarize", "corpus", "bench"}
 
-# Data-pipeline verbs still routed at the top level. These are slated to move
-# under the ``corpus`` namespace; until then they remain explicit verbs so the
-# shim does not misroute them to ``review``.
-_LEGACY_DATA_VERBS = {"harvest", "build-corpus", "label"}
-
 
 def _first_verb(argv: list[str]) -> str:
     """Classify the leading argv token into a verb.
@@ -70,11 +66,11 @@ def _first_verb(argv: list[str]) -> str:
         argv: The raw argument list (``sys.argv[1:]``).
 
     Returns:
-        str: The dispatched verb name (a member of :data:`KNOWN_VERBS`, one of
-        the legacy data verbs, or ``"review"``).
+        str: The dispatched verb name (a member of :data:`KNOWN_VERBS` or
+        ``"review"``).
 
     """
-    if argv and (argv[0] in KNOWN_VERBS or argv[0] in _LEGACY_DATA_VERBS):
+    if argv and argv[0] in KNOWN_VERBS:
         return argv[0]
     return "review"
 
@@ -282,14 +278,14 @@ def _run_summarize(args: argparse.Namespace) -> int:
 
 
 def _build_build_corpus_parser() -> argparse.ArgumentParser:
-    """Build the parser for ``daydream build-corpus --out <path> [...]``.
+    """Build the parser for ``daydream corpus build --out <path> [...]``.
 
-    Like ``summarize`` and ``feedback``, ``build-corpus`` is dispatched manually
-    from ``main()`` before the main parser runs so its options don't collide
-    with the top-level ``TARGET`` positional.
+    The ``corpus build`` sub-verb is dispatched manually from ``main()`` (via
+    :func:`_handle_corpus_command`) before the main parser runs so its options
+    don't collide with the top-level ``TARGET`` positional.
     """
     parser = argparse.ArgumentParser(
-        prog="daydream build-corpus",
+        prog="daydream corpus build",
         description="Project as-of-pinned annotations into JSONL training records (one object per run).",
     )
 
@@ -404,16 +400,16 @@ def _build_build_corpus_parser() -> argparse.ArgumentParser:
 
 
 def _handle_build_corpus_command(argv: list[str]) -> int:
-    """Handle ``daydream build-corpus --out <path> [...]``.
+    """Handle ``daydream corpus build --out <path> [...]``.
 
     Drives :func:`daydream.training.corpus.run_build_corpus` synchronously
-    (``build-corpus`` does no agent work — just SQLite reads and a JSONL +
+    (``corpus build`` does no agent work — just SQLite reads and a JSONL +
     lineage-manifest write). Returns an exit code rather than calling
     :func:`sys.exit`; ``main()`` is responsible for translating the code into a
     process exit. This keeps the handler easy to drive from tests.
 
     Args:
-        argv: The argument vector after the ``build-corpus`` verb.
+        argv: The argument vector after the ``corpus build`` sub-verb.
 
     Returns:
         ``0`` on success; ``1`` on a validation error.
@@ -948,7 +944,7 @@ def _build_feedback_config(args: argparse.Namespace) -> RunConfig:
 
 
 def _build_harvest_parser() -> argparse.ArgumentParser:
-    """Build the parser for ``daydream harvest [...]``.
+    """Build the parser for ``daydream corpus harvest [...]``.
 
     Drives the single deferred annotate pass from
     :mod:`daydream.training.harvest`. Every indexed run gets one fresh
@@ -956,7 +952,7 @@ def _build_harvest_parser() -> argparse.ArgumentParser:
     re-running appends a new generation rather than skipping annotated rows.
     """
     parser = argparse.ArgumentParser(
-        prog="daydream harvest",
+        prog="daydream corpus harvest",
         description=(
             "Walk the archive and append one bitemporal annotation "
             "(outcome label + intrinsic reward) for every indexed run "
@@ -1021,7 +1017,7 @@ def _build_harvest_parser() -> argparse.ArgumentParser:
 
 
 def _handle_harvest_command(argv: list[str]) -> int:
-    """Handle ``daydream harvest [...]``.
+    """Handle ``daydream corpus harvest [...]``.
 
     Drives :func:`daydream.training.harvest.run_harvest` (looked up via the
     module attribute so test monkeypatches take effect). ``run_harvest`` is a
@@ -1032,7 +1028,7 @@ def _handle_harvest_command(argv: list[str]) -> int:
     ``errors`` counter surfaces them.
 
     Args:
-        argv: The argument vector after the ``harvest`` verb.
+        argv: The argument vector after the ``corpus harvest`` sub-verb.
 
     Returns:
         ``0`` on success; ``1`` on a validation error.
@@ -1080,7 +1076,7 @@ def _handle_harvest_command(argv: list[str]) -> int:
 
 
 def _build_label_parser() -> argparse.ArgumentParser:
-    """Build the parser for ``daydream label <session-prefix> --outcome ...``.
+    """Build the parser for ``daydream corpus label <session-prefix> --outcome ...``.
 
     Records a human-sourced outcome label that wins over automated rubric
     labels in every precedence projection (and is never deduped). ``unknown``
@@ -1088,7 +1084,7 @@ def _build_label_parser() -> argparse.ArgumentParser:
     decide" signal distinct from an unlabeled run.
     """
     parser = argparse.ArgumentParser(
-        prog="daydream label",
+        prog="daydream corpus label",
         description=(
             "Set an authoritative human outcome label on an archived run "
             "(overrides automated rubric labels)."
@@ -1120,7 +1116,7 @@ def _build_label_parser() -> argparse.ArgumentParser:
 
 
 def _handle_label_command(argv: list[str]) -> int:
-    """Handle ``daydream label <session-prefix> --outcome {...}``.
+    """Handle ``daydream corpus label <session-prefix> --outcome {...}``.
 
     Resolves the archive dir, echoes the label being overridden (the
     "show what it's overriding" affordance), then writes a human-sourced
@@ -1128,7 +1124,7 @@ def _handle_label_command(argv: list[str]) -> int:
     cache and every precedence projection settle on the human value.
 
     Args:
-        argv: The argument vector after the ``label`` verb.
+        argv: The argument vector after the ``corpus label`` sub-verb.
 
     Returns:
         ``0`` on success; ``1`` when no session matches the prefix or the
@@ -1164,6 +1160,52 @@ def _handle_label_command(argv: list[str]) -> int:
     return 0
 
 
+# Sub-verbs of the ``corpus`` namespace, mapped to the handler attribute name
+# on this module. ``build`` is the public name for the build-corpus projection.
+# Handlers are resolved by name at call time (via ``getattr``) so test
+# monkeypatches on the module attribute take effect.
+_CORPUS_SUBVERBS = {
+    "harvest": "_handle_harvest_command",
+    "build": "_handle_build_corpus_command",
+    "label": "_handle_label_command",
+}
+
+
+def _print_corpus_help() -> None:
+    """Print usage for the ``corpus`` namespace to stderr."""
+    print(
+        "usage: daydream corpus {harvest,build,label} ...\n"
+        "\n"
+        "Data-pipeline sub-verbs:\n"
+        "  harvest   walk the archive and append one bitemporal annotation per indexed run\n"
+        "  build     project the as-of-pinned annotations into a JSONL training corpus\n"
+        "  label     record an authoritative human outcome label that overrides automated ones\n",
+        file=sys.stderr,
+    )
+
+
+def _handle_corpus_command(argv: list[str]) -> int:
+    """Dispatch a ``corpus`` sub-verb to its handler.
+
+    ``corpus harvest|build|label`` routes to the existing data-pipeline
+    handlers (``build`` → the build-corpus projection). A bare ``daydream
+    corpus`` (no sub-verb) prints help and exits 2. Exit codes propagate
+    unchanged from the handlers.
+
+    Args:
+        argv: The argument vector after the ``corpus`` verb.
+
+    Returns:
+        int: The sub-handler's exit code, or ``2`` for a missing/unknown
+        sub-verb.
+    """
+    if not argv or argv[0] not in _CORPUS_SUBVERBS:
+        _print_corpus_help()
+        return 2
+    handler = getattr(sys.modules[__name__], _CORPUS_SUBVERBS[argv[0]])
+    return int(handler(argv[1:]))
+
+
 def main() -> None:
     """Run the CLI entry point.
 
@@ -1178,7 +1220,7 @@ def main() -> None:
         - ``feedback`` — apply bot PR-review comments
         - ``summarize`` — print run-info markdown for a trajectory
         - ``bench`` — score deep-review findings against the offline benchmark
-        - ``harvest`` / ``build-corpus`` / ``label`` — data-pipeline verbs
+        - ``corpus`` — data-pipeline namespace (``harvest`` / ``build`` / ``label``)
 
     Returns:
         None: This function does not return; it exits via sys.exit().
@@ -1205,24 +1247,17 @@ def main() -> None:
             summarize_args = summarize_parser.parse_args(argv[1:])
             sys.exit(_run_summarize(summarize_args))
 
-        # ``build-corpus`` is sync — no agent invocations, just SQLite +
-        # filesystem. Short-circuit before anyio.run.
-        if verb == "build-corpus":
-            sys.exit(_handle_build_corpus_command(argv[1:]))
-
-        # ``harvest`` drives the annotate-pass orchestrator via its own anyio.run.
-        if verb == "harvest":
-            sys.exit(_handle_harvest_command(argv[1:]))
+        # ``corpus`` namespaces the data-pipeline sub-verbs
+        # (``harvest`` / ``build`` / ``label``). Each handler owns its own
+        # parser and exit code; a bare ``daydream corpus`` prints help and
+        # exits 2. All three are sync (SQLite + filesystem, no agent work).
+        if verb == "corpus":
+            sys.exit(_handle_corpus_command(argv[1:]))
 
         # ``bench`` scores deep-review findings against the offline benchmark.
         # ``run_bench`` is sync — short-circuit before anyio.run.
         if verb == "bench":
             sys.exit(_handle_bench_command(argv[1:]))
-
-        # ``label`` records an authoritative human outcome label — sync,
-        # SQLite-only. Short-circuit before anyio.run.
-        if verb == "label":
-            sys.exit(_handle_label_command(argv[1:]))
 
         config = _parse_args()
         if verb == "feedback":

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -278,6 +278,16 @@ def _add_shared_arguments(parser: argparse.ArgumentParser) -> None:
         help="Run without prompting; take each prompt's safe default "
              "(confirm intent, decline fixes, exit the test/heal loop).",
     )
+    parser.add_argument(
+        "--yes",
+        action="store_const",
+        const="yes",
+        default=None,
+        dest="assume",
+        help="Auto-answer every yes/no gate with yes (apply fixes, commit). "
+             "Orthogonal to --non-interactive: --yes pre-decides the answer, "
+             "--non-interactive controls whether we may block on stdin.",
+    )
 
 
 def _build_summarize_parser() -> argparse.ArgumentParser:
@@ -768,6 +778,12 @@ def _parse_args(argv: list[str] | None = None) -> RunConfig:
     elif args.review:
         output_mode = "review"
 
+    # ``--yes`` auto-answers the fix/commit gates; ``--review``/``--comment`` run
+    # no fix phase, so the flag has nothing to answer there. Reject it rather than
+    # silently ignore it.
+    if args.assume == "yes" and output_mode != "loop":
+        parser.error("--yes has no effect with --review/--comment (no fix phase to auto-apply)")
+
     # ttt/per-stack/merge are deep-pipeline resume stages; they don't apply
     # to shallow runs.
     if args.shallow and args.start_at in ("ttt", "per-stack", "merge"):
@@ -837,6 +853,7 @@ def _parse_args(argv: list[str] | None = None) -> RunConfig:
         extra_copy=list(args.extra_copy),
         plan=args.plan,
         non_interactive=args.non_interactive,
+        assume=args.assume,
     )
 
 
@@ -884,6 +901,7 @@ def _build_feedback_config(args: argparse.Namespace) -> RunConfig:
         run_eval=args.run_eval,
         output_mode="loop",
         non_interactive=args.non_interactive,
+        assume=args.assume,
     )
 
 

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -170,6 +170,13 @@ def _add_shared_arguments(parser: argparse.ArgumentParser, *, full_help: bool = 
     :func:`daydream.runner._resolved_model` / ``_resolve_backend``
     (CLI > env > config-file > per-backend table).
 
+    Per-phase model/backend overrides are no longer CLI flags — they live in
+    ``[tool.daydream.phases.<phase>]`` of the config file (``pyproject.toml`` /
+    ``.daydream.toml``). The removed flags are rejected with a curated pointer
+    by :func:`_reject_removed_phase_flags`; the underlying ``RunConfig`` fields
+    (``review_model``, ``fix_backend``, …) remain and are still populated from
+    the config file and read by ``_resolve_backend``.
+
     Args:
         parser: The parser (or subparser) to add the shared arguments to.
         full_help: When False, advanced flags (``--trajectory``, ``--no-archive``,
@@ -220,65 +227,6 @@ def _add_shared_arguments(parser: argparse.ArgumentParser, *, full_help: bool = 
         help="Global default model across phases "
              "(default: env DAYDREAM_MODEL, config file, then the per-backend table). "
              "A per-phase config override is beaten by this global --model.",
-    )
-    parser.add_argument(
-        "--review-backend",
-        choices=["claude", "codex"],
-        default=None,
-        help="Override backend for review phase",
-    )
-    parser.add_argument(
-        "--fix-backend",
-        choices=["claude", "codex"],
-        default=None,
-        help="Override backend for fix phase",
-    )
-    parser.add_argument(
-        "--test-backend",
-        choices=["claude", "codex"],
-        default=None,
-        help="Override backend for test phase",
-    )
-    parser.add_argument(
-        "--exploration-model",
-        default=None,
-        dest="exploration_model",
-        help=(
-            "Model for exploration subagents (default: claude-sonnet-4-6). "
-            "Use a smaller model to save cost."
-        ),
-    )
-    parser.add_argument(
-        "--review-model",
-        default=None,
-        type=str,
-        dest="review_model",
-        metavar="MODEL",
-        help="Override model for the REVIEW phase (default: per-backend table; see README).",
-    )
-    parser.add_argument(
-        "--parse-model",
-        default=None,
-        type=str,
-        dest="parse_model",
-        metavar="MODEL",
-        help="Override model for the PARSE phase (default: per-backend table; see README).",
-    )
-    parser.add_argument(
-        "--fix-model",
-        default=None,
-        type=str,
-        dest="fix_model",
-        metavar="MODEL",
-        help="Override model for the FIX phase (default: per-backend table; see README).",
-    )
-    parser.add_argument(
-        "--test-model",
-        default=None,
-        type=str,
-        dest="test_model",
-        metavar="MODEL",
-        help="Override model for the TEST phase (default: per-backend table; see README).",
     )
     parser.add_argument(
         "--non-interactive",
@@ -772,6 +720,46 @@ def _normalize_loop_argv(raw_argv: list[str]) -> list[str]:
     return normalized
 
 
+# Removed per-phase model/backend flags → their config-file replacement. The
+# per-phase overrides moved out of the CLI surface into
+# ``[tool.daydream.phases.<phase>]`` (pyproject.toml / .daydream.toml). The
+# ``RunConfig`` fields they used to set (``review_model``, ``fix_backend``, …)
+# remain — still read by ``_resolve_backend`` and settable via the config file —
+# they are simply no longer CLI-settable.
+_REMOVED_PHASE_FLAGS: dict[str, str] = {
+    "--review-backend": "[tool.daydream.phases.review] backend = \"...\"",
+    "--fix-backend": "[tool.daydream.phases.fix] backend = \"...\"",
+    "--test-backend": "[tool.daydream.phases.test] backend = \"...\"",
+    "--exploration-model": "[tool.daydream.phases.exploration] model = \"...\"",
+    "--review-model": "[tool.daydream.phases.review] model = \"...\"",
+    "--parse-model": "[tool.daydream.phases.parse] model = \"...\"",
+    "--fix-model": "[tool.daydream.phases.fix] model = \"...\"",
+    "--test-model": "[tool.daydream.phases.test] model = \"...\"",
+}
+
+
+def _reject_removed_phase_flags(parser: argparse.ArgumentParser, argv: list[str]) -> None:
+    """Reject any removed per-phase model/backend flag with a config pointer.
+
+    Pre-parse scan (P-reject pattern): if any token in ``argv`` is a removed
+    per-phase flag — either the bare ``--flag`` form (``--fix-model value``) or
+    the joined ``--flag=value`` form — call ``parser.error`` with a curated
+    message naming the ``[tool.daydream.phases.<phase>]`` config replacement.
+
+    Args:
+        parser: The parser whose ``error`` is used to exit with the message.
+        argv: The argument list (after verb-shim stripping).
+    """
+    for token in argv:
+        flag = token.split("=", 1)[0]
+        replacement = _REMOVED_PHASE_FLAGS.get(flag)
+        if replacement is not None:
+            parser.error(
+                f"{flag} was removed; set it in the config file instead: "
+                f"{replacement} (pyproject.toml or .daydream.toml)."
+            )
+
+
 def _parse_args(argv: list[str] | None = None) -> RunConfig:
     """Parse command line arguments and return a RunConfig.
 
@@ -801,6 +789,7 @@ def _parse_args(argv: list[str] | None = None) -> RunConfig:
     # front ourselves and route to a dedicated parser.
     if raw_argv and raw_argv[0] == "feedback":
         feedback_parser = _build_feedback_parser()
+        _reject_removed_phase_flags(feedback_parser, raw_argv[1:])
         feedback_args = feedback_parser.parse_intermixed_args(raw_argv[1:])
         return _build_feedback_config(feedback_args)
 
@@ -811,6 +800,7 @@ def _parse_args(argv: list[str] | None = None) -> RunConfig:
     raw_argv = _normalize_loop_argv(raw_argv)
 
     parser = _build_main_parser()
+    _reject_removed_phase_flags(parser, raw_argv)
     args = parser.parse_args(raw_argv)
 
     # ----- Reject purely numeric TARGET (likely meant `daydream feedback N`) -----
@@ -873,20 +863,22 @@ def _parse_args(argv: list[str] | None = None) -> RunConfig:
         skill=args.skill,
         model=args.model,
         file_config=file_config,
-        exploration_model=args.exploration_model,
-        review_model=args.review_model,
-        parse_model=args.parse_model,
-        fix_model=args.fix_model,
-        test_model=args.test_model,
+        # Per-phase model/backend overrides are config-file-only (no CLI flags).
+        # Left None here so the config file is the sole low-precedence source.
+        exploration_model=None,
+        review_model=None,
+        parse_model=None,
+        fix_model=None,
+        test_model=None,
         cleanup=args.cleanup,
         quiet=True,
         start_at=args.start_at,
         pr_number=pr_number,
         bot=None,
         backend=args.backend,
-        review_backend=args.review_backend,
-        fix_backend=args.fix_backend,
-        test_backend=args.test_backend,
+        review_backend=None,
+        fix_backend=None,
+        test_backend=None,
         ignore_paths=args.ignore_paths,
         loop=loop,
         max_iterations=max_iterations,
@@ -927,20 +919,21 @@ def _build_feedback_config(args: argparse.Namespace) -> RunConfig:
         skill=None,
         model=args.model,
         file_config=file_config,
+        # Per-phase model/backend overrides are config-file-only (no CLI flags).
         exploration_model=None,
-        review_model=args.review_model,
-        parse_model=args.parse_model,
-        fix_model=args.fix_model,
-        test_model=args.test_model,
+        review_model=None,
+        parse_model=None,
+        fix_model=None,
+        test_model=None,
         cleanup=None,
         quiet=True,
         start_at="review",
         pr_number=pr_number,
         bot=args.bot,
         backend=args.backend,
-        review_backend=args.review_backend,
-        fix_backend=args.fix_backend,
-        test_backend=args.test_backend,
+        review_backend=None,
+        fix_backend=None,
+        test_backend=None,
         ignore_paths=[],
         loop=False,
         max_iterations=5,

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -1,11 +1,17 @@
 """CLI entry point for daydream.
 
-Subcommands dispatched manually from :func:`main` before the main argparse
-parser runs (so their flags don't collide with the top-level ``TARGET``
-positional):
+Dispatch is verb-first. :func:`_first_verb` classifies the leading argv token
+against :data:`KNOWN_VERBS`; anything that is not an explicit verb — a bare
+target path, a leading flag, or empty argv — falls through to the default
+``review`` shim, so ``daydream /path`` and ``daydream review /path`` are
+equivalent. Each non-``review`` verb is dispatched manually from :func:`main`
+before the main argparse parser runs (so its flags don't collide with the
+top-level ``TARGET`` positional):
 
+- ``daydream [review] <target>`` — the review/fix loop (default verb)
 - ``daydream feedback <pr#>`` — apply bot PR-review comments
 - ``daydream summarize <path>`` — print run-info markdown for a trajectory
+- ``daydream bench`` — score deep-review findings against the offline benchmark
 - ``daydream harvest`` — walk the archive and append one bitemporal
   annotation (outcome label + intrinsic reward) per indexed run
 - ``daydream label <session-prefix> --outcome {accepted,contested,rejected,unknown}``
@@ -40,6 +46,38 @@ from daydream.ui import (
     print_error,
     set_shutdown_panel,
 )
+
+# Verb-first dispatch table. ``_first_verb`` classifies the leading argv token;
+# anything that isn't an explicit verb (bare path, leading flag, empty argv)
+# falls through to the ``review`` golden path via the default-verb shim.
+KNOWN_VERBS = {"review", "feedback", "summarize", "corpus", "bench"}
+
+# Data-pipeline verbs still routed at the top level. These are slated to move
+# under the ``corpus`` namespace; until then they remain explicit verbs so the
+# shim does not misroute them to ``review``.
+_LEGACY_DATA_VERBS = {"harvest", "build-corpus", "label"}
+
+
+def _first_verb(argv: list[str]) -> str:
+    """Classify the leading argv token into a verb.
+
+    Returns the leading token when it is a recognized verb; otherwise returns
+    ``"review"``. The fallthrough covers the three default-verb cases — empty
+    argv, a leading flag, and a bare target path — so a plain
+    ``daydream /path`` routes through the same parser as ``daydream review
+    /path``.
+
+    Args:
+        argv: The raw argument list (``sys.argv[1:]``).
+
+    Returns:
+        str: The dispatched verb name (a member of :data:`KNOWN_VERBS`, one of
+        the legacy data verbs, or ``"review"``).
+
+    """
+    if argv and (argv[0] in KNOWN_VERBS or argv[0] in _LEGACY_DATA_VERBS):
+        return argv[0]
+    return "review"
 
 
 def _signal_handler(signum: int, frame: object) -> None:
@@ -669,6 +707,12 @@ def _parse_args(argv: list[str] | None = None) -> RunConfig:
     """
     raw_argv = sys.argv[1:] if argv is None else list(argv)
 
+    # Default-verb shim: an explicit leading ``review`` token is equivalent to
+    # the bare ``daydream <target>`` form. Strip it so both parse identically
+    # against the main review parser (positional TARGET unchanged).
+    if raw_argv and raw_argv[0] == "review":
+        raw_argv = raw_argv[1:]
+
     # Manual subcommand dispatch: argparse subparsers eat the first positional
     # which conflicts with our positional TARGET. So we pop "feedback" off the
     # front ourselves and route to a dedicated parser.
@@ -1036,6 +1080,19 @@ def _handle_label_command(argv: list[str]) -> int:
 def main() -> None:
     """Run the CLI entry point.
 
+    Dispatch is verb-first (see :func:`_first_verb` and :data:`KNOWN_VERBS`):
+    the leading token selects a verb, and anything that is not an explicit
+    verb — a bare target path, a leading flag, or empty argv — routes through
+    the default ``review`` shim. Each non-``review`` verb owns its own parser
+    and exit code; ``review`` flows into :func:`_parse_args`.
+
+    Verbs:
+        - ``review`` (default) — the review/fix loop (bare ``daydream <target>``)
+        - ``feedback`` — apply bot PR-review comments
+        - ``summarize`` — print run-info markdown for a trajectory
+        - ``bench`` — score deep-review findings against the offline benchmark
+        - ``harvest`` / ``build-corpus`` / ``label`` — data-pipeline verbs
+
     Returns:
         None: This function does not return; it exits via sys.exit().
 
@@ -1046,39 +1103,42 @@ def main() -> None:
     """
     _install_signal_handlers()
 
-    # Route subcommands before main arg parse. Each handler returns an exit
-    # code; we translate via sys.exit. Supported subcommands: feedback,
-    # summarize, harvest, build-corpus, label, bench.
+    # Verb-first dispatch. ``_first_verb`` classifies the leading token; bare
+    # paths, leading flags, and empty argv all fall through to ``review``.
+    # The non-``review`` verbs are short-circuited here (their handlers own
+    # their own parsers and exit codes); ``review`` flows into ``_parse_args``
+    # which applies the default-verb shim (an explicit leading ``review`` is
+    # equivalent to a bare target).
     argv = sys.argv[1:]
+    verb = _first_verb(argv)
     try:
         # ``summarize`` is sync — short-circuit before anyio.run kicks in.
-        if argv and argv[0] == "summarize":
+        if verb == "summarize":
             summarize_parser = _build_summarize_parser()
             summarize_args = summarize_parser.parse_args(argv[1:])
             sys.exit(_run_summarize(summarize_args))
 
         # ``build-corpus`` is sync — no agent invocations, just SQLite +
         # filesystem. Short-circuit before anyio.run.
-        if argv and argv[0] == "build-corpus":
+        if verb == "build-corpus":
             sys.exit(_handle_build_corpus_command(argv[1:]))
 
         # ``harvest`` drives the annotate-pass orchestrator via its own anyio.run.
-        if argv and argv[0] == "harvest":
+        if verb == "harvest":
             sys.exit(_handle_harvest_command(argv[1:]))
 
         # ``bench`` scores deep-review findings against the offline benchmark.
         # ``run_bench`` is sync — short-circuit before anyio.run.
-        if argv and argv[0] == "bench":
+        if verb == "bench":
             sys.exit(_handle_bench_command(argv[1:]))
 
         # ``label`` records an authoritative human outcome label — sync,
         # SQLite-only. Short-circuit before anyio.run.
-        if argv and argv[0] == "label":
+        if verb == "label":
             sys.exit(_handle_label_command(argv[1:]))
 
-        is_feedback_subcommand = bool(argv) and argv[0] == "feedback"
         config = _parse_args()
-        if is_feedback_subcommand:
+        if verb == "feedback":
             assert config.pr_number is not None  # _build_feedback_config guarantees
             exit_code = anyio.run(run_feedback, config, config.pr_number)
         else:

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -24,7 +24,6 @@ import argparse
 import inspect
 import signal
 import sys
-import warnings
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -671,22 +670,47 @@ def _build_main_parser() -> argparse.ArgumentParser:
 
     parser.add_argument(
         "--loop",
-        action="store_true",
-        default=False,
-        help="Repeat review-fix-test cycle until zero issues or max iterations",
-    )
-    parser.add_argument(
-        "--max-iterations",
+        nargs="?",
+        const=5,
+        default=None,
         type=int,
-        default=5,
         metavar="N",
-        dest="max_iterations",
-        help="Maximum loop iterations (default: 5, only meaningful with --loop)",
+        help="Repeat the review-fix-test cycle until zero issues or N iterations (default N: 5)",
     )
 
     _add_shared_arguments(parser)
 
     return parser
+
+
+def _normalize_loop_argv(raw_argv: list[str]) -> list[str]:
+    """Disambiguate ``--loop``'s optional count from a following positional.
+
+    ``--loop`` carries an optional integer count (``nargs="?"``), which makes
+    argparse greedily try to consume the next token as that count. For the
+    golden path ``daydream --loop /some/path`` argparse would then fail trying
+    to parse the path as an int. This pre-scan pins the count explicitly when
+    ``--loop`` is bare (last token, or followed by a flag or a non-integer
+    token), turning it into ``--loop=5`` so the positional is preserved. An
+    explicit ``--loop N`` is left untouched.
+
+    Args:
+        raw_argv: The argument list after verb-shim stripping.
+
+    Returns:
+        A new argv list with bare ``--loop`` rewritten to ``--loop=5``.
+    """
+    normalized: list[str] = []
+    for i, token in enumerate(raw_argv):
+        if token == "--loop":
+            nxt = raw_argv[i + 1] if i + 1 < len(raw_argv) else None
+            if nxt is None or not nxt.isdigit():
+                # Bare --loop (end, before a flag, or before a non-int target):
+                # pin the default count so the next token stays a positional.
+                normalized.append("--loop=5")
+                continue
+        normalized.append(token)
+    return normalized
 
 
 def _parse_args(argv: list[str] | None = None) -> RunConfig:
@@ -725,6 +749,8 @@ def _parse_args(argv: list[str] | None = None) -> RunConfig:
     # we never reach this branch from the summarize path. Kept here only as
     # a guard for callers that hand crafted-argv to _parse_args directly.
 
+    raw_argv = _normalize_loop_argv(raw_argv)
+
     parser = _build_main_parser()
     args = parser.parse_args(raw_argv)
 
@@ -755,15 +781,16 @@ def _parse_args(argv: list[str] | None = None) -> RunConfig:
             "(use --shallow, or --start-at fix to resume after the merged report)"
         )
 
-    # Validate --loop incompatibilities
-    if args.loop and output_mode != "loop":
-        parser.error("--loop cannot be combined with --review/--comment")
-    if args.loop and args.start_at != "review":
-        parser.error("--loop requires starting at review phase (incompatible with --start-at)")
+    # ``--loop`` takes an optional count (``--loop`` ⇒ 5, ``--loop N`` ⇒ N).
+    # ``args.loop`` is None when the flag is absent.
+    loop = args.loop is not None
+    max_iterations = args.loop or 5
 
-    # Warn if --max-iterations without --loop
-    if args.max_iterations != 5 and not args.loop:
-        warnings.warn("--max-iterations has no effect without --loop", stacklevel=2)
+    # Validate --loop incompatibilities
+    if loop and output_mode != "loop":
+        parser.error("--loop cannot be combined with --review/--comment")
+    if loop and args.start_at != "review":
+        parser.error("--loop requires starting at review phase (incompatible with --start-at)")
 
     # Detect repo slug and PR number for trajectory/archive metadata.
     # Attribute provenance to the target checkout, not the invoking cwd —
@@ -796,8 +823,8 @@ def _parse_args(argv: list[str] | None = None) -> RunConfig:
         fix_backend=args.fix_backend,
         test_backend=args.test_backend,
         ignore_paths=args.ignore_paths,
-        loop=args.loop,
-        max_iterations=args.max_iterations,
+        loop=loop,
+        max_iterations=max_iterations,
         trajectory_path=args.trajectory_path,
         pr_repo=pr_repo,
         archive=not args.no_archive,

--- a/daydream/config_file.py
+++ b/daydream/config_file.py
@@ -16,10 +16,13 @@ Exports:
 
 from __future__ import annotations
 
+import logging
 import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -98,6 +101,12 @@ def _coerce_phases(raw: Any) -> dict[str, dict[str, str]]:
     for phase_name, table in raw.items():
         if isinstance(table, dict):
             result[str(phase_name)] = {str(k): str(v) for k, v in table.items()}
+        else:
+            logger.warning(
+                "daydream config: ignoring phase %r — expected a table, got %s",
+                phase_name,
+                type(table).__name__,
+            )
     return result
 
 

--- a/daydream/config_file.py
+++ b/daydream/config_file.py
@@ -1,0 +1,137 @@
+"""Config-file loader for daydream.
+
+Loads daydream settings from two on-disk sources, merged per-key:
+
+1. ``pyproject.toml`` under the ``[tool.daydream]`` table (low precedence).
+2. ``.daydream.toml`` at the repo root (root keys; high precedence).
+
+The dotfile's keys override pyproject's, merged **per-key** so a
+``[phases.fix]`` table in the dotfile does not wipe a ``[phases.review]``
+table declared in pyproject.
+
+Exports:
+    DaydreamFileConfig: frozen config snapshot with phase accessors.
+    load_file_config: read + merge both sources from a repo root.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class DaydreamFileConfig:
+    """Immutable snapshot of file-sourced daydream configuration.
+
+    Attributes:
+        model: Global default model, or None if unset.
+        backend: Global default backend name, or None if unset.
+        phases: Per-phase sub-tables mapping phase name to a dict of keys
+            (e.g. ``{"fix": {"backend": "codex", "model": "..."}}``).
+    """
+
+    model: str | None = None
+    backend: str | None = None
+    phases: dict[str, dict[str, str]] = field(default_factory=dict)
+
+    def phase_model(self, phase: str) -> str | None:
+        """Return the configured model for ``phase``, or None if unset."""
+        return self.phases.get(phase, {}).get("model")
+
+    def phase_backend(self, phase: str) -> str | None:
+        """Return the configured backend for ``phase``, or None if unset."""
+        return self.phases.get(phase, {}).get("backend")
+
+
+def _load_toml(path: Path) -> dict[str, Any]:
+    """Parse a TOML file into a dict.
+
+    Args:
+        path: Path to the TOML file.
+
+    Returns:
+        The parsed table, or an empty dict if the file is absent.
+
+    Raises:
+        ValueError: If the file exists but is malformed; the message names
+            the offending file.
+    """
+    if not path.is_file():
+        return {}
+    try:
+        with path.open("rb") as handle:
+            return tomllib.load(handle)
+    except tomllib.TOMLDecodeError as exc:
+        raise ValueError(f"Malformed TOML in {path.name}: {exc}") from exc
+
+
+def _merge_section(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    """Merge two daydream config sections, override winning per-key.
+
+    Scalar keys (``model``, ``backend``) from ``override`` replace ``base``.
+    The ``phases`` sub-table is merged per-phase so an override phase table
+    does not discard phases declared only in ``base``.
+    """
+    merged: dict[str, Any] = dict(base)
+    for key, value in override.items():
+        if key == "phases" and isinstance(value, dict) and isinstance(merged.get("phases"), dict):
+            phases: dict[str, Any] = dict(merged["phases"])
+            for phase_name, phase_table in value.items():
+                if isinstance(phase_table, dict) and isinstance(phases.get(phase_name), dict):
+                    phases[phase_name] = {**phases[phase_name], **phase_table}
+                else:
+                    phases[phase_name] = phase_table
+            merged["phases"] = phases
+        else:
+            merged[key] = value
+    return merged
+
+
+def _coerce_phases(raw: Any) -> dict[str, dict[str, str]]:
+    """Normalize a raw ``phases`` value into ``dict[str, dict[str, str]]``."""
+    if not isinstance(raw, dict):
+        return {}
+    result: dict[str, dict[str, str]] = {}
+    for phase_name, table in raw.items():
+        if isinstance(table, dict):
+            result[str(phase_name)] = {str(k): str(v) for k, v in table.items()}
+    return result
+
+
+def load_file_config(root: Path) -> DaydreamFileConfig:
+    """Load and merge daydream file configuration from a repo root.
+
+    Reads ``root/pyproject.toml`` ``[tool.daydream]`` (low precedence) and
+    ``root/.daydream.toml`` (high precedence), merging the two per-key. The
+    dotfile wins on conflicting scalar keys; phase sub-tables merge so each
+    source contributes its own phases.
+
+    Args:
+        root: Repository root directory to search for config files.
+
+    Returns:
+        A ``DaydreamFileConfig``. Absent files yield an empty config.
+
+    Raises:
+        ValueError: If a present config file is malformed TOML; the message
+            names the offending file.
+    """
+    pyproject = _load_toml(root / "pyproject.toml")
+    tool_section = pyproject.get("tool", {})
+    base = tool_section.get("daydream", {}) if isinstance(tool_section, dict) else {}
+    base = base if isinstance(base, dict) else {}
+
+    dotfile = _load_toml(root / ".daydream.toml")
+
+    merged = _merge_section(base, dotfile)
+
+    model = merged.get("model")
+    backend = merged.get("backend")
+    return DaydreamFileConfig(
+        model=str(model) if model is not None else None,
+        backend=str(backend) if backend is not None else None,
+        phases=_coerce_phases(merged.get("phases")),
+    )

--- a/daydream/config_file.py
+++ b/daydream/config_file.py
@@ -41,11 +41,25 @@ class DaydreamFileConfig:
     phases: dict[str, dict[str, str]] = field(default_factory=dict)
 
     def phase_model(self, phase: str) -> str | None:
-        """Return the configured model for ``phase``, or None if unset."""
+        """Return the configured model for a phase.
+
+        Args:
+            phase: Phase name to look up (e.g. ``"fix"``).
+
+        Returns:
+            The configured model, or None if the phase has no ``model`` key.
+        """
         return self.phases.get(phase, {}).get("model")
 
     def phase_backend(self, phase: str) -> str | None:
-        """Return the configured backend for ``phase``, or None if unset."""
+        """Return the configured backend for a phase.
+
+        Args:
+            phase: Phase name to look up (e.g. ``"fix"``).
+
+        Returns:
+            The configured backend, or None if the phase has no ``backend`` key.
+        """
         return self.phases.get(phase, {}).get("backend")
 
 

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -23,7 +23,7 @@ from dataclasses import asdict, is_dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from daydream.agent import console, get_assume, get_non_interactive, resolve_gate
+from daydream.agent import console, get_assume, get_non_interactive, resolve_or_prompt
 from daydream.config import REVIEW_OUTPUT_FILE, SKILL_MAP, STRUCTURE_STACK_NAME
 from daydream.deep.artifacts import (
     alternatives_path as _alternatives_path,
@@ -662,14 +662,13 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
             # Fix-apply gate across the two interaction axes. ``--yes`` auto-applies;
             # an unattended run with no assumption declines (safe_default=False) so a
             # piped/CI run never mutates without intent; otherwise prompt.
-            decision = resolve_gate(
+            decision = resolve_or_prompt(
                 assume=get_assume(),
                 interactive=not get_non_interactive(),
                 safe_default=False,
+                question="Apply fixes now? [y/N]",
+                default="n",
             )
-            if decision is None:
-                answer = prompt_user(console, "Apply fixes now? [y/N]", "n")
-                decision = answer.strip().lower() in ("y", "yes")
             if not decision:
                 print_success(console, f"Report written to {merged_report}. Exiting.")
                 return 0

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -304,7 +304,12 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
     from daydream.backends import Backend
     from daydream.git_ops import GitError
     from daydream.phases import _git_branch, _git_log
-    from daydream.runner import _compute_diff_ref, _make_archive_callback, _resolve_backend
+    from daydream.runner import (
+        _compute_diff_ref,
+        _make_archive_callback,
+        _resolve_backend,
+        _resolved_backend_name,
+    )
     from daydream.ui import phase_subtitle, print_dim, print_phase_hero
 
     # Per-phase backends are resolved on demand via `_resolve_backend(config,
@@ -352,7 +357,7 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
         console.print()
         print_info(console, f"Target directory: {target_dir}")
         print_info(console, f"Branch: {branch}")
-        print_info(console, f"Default backend: {config.backend}")
+        print_info(console, f"Default backend: {_resolved_backend_name(config, 'review')}")
         console.print()
 
         # ------ Resume gate (D-34, D-36, D-37) ------

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -23,7 +23,7 @@ from dataclasses import asdict, is_dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from daydream.agent import console
+from daydream.agent import console, get_assume, get_non_interactive, resolve_gate
 from daydream.config import REVIEW_OUTPUT_FILE, SKILL_MAP, STRUCTURE_STACK_NAME
 from daydream.deep.artifacts import (
     alternatives_path as _alternatives_path,
@@ -659,8 +659,18 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
                     target_dir, merged_items_path(dd), console=console
                 )
 
-            answer = prompt_user(console, "Apply fixes now? [y/N]", "n")
-            if answer.strip().lower() not in ("y", "yes"):
+            # Fix-apply gate across the two interaction axes. ``--yes`` auto-applies;
+            # an unattended run with no assumption declines (safe_default=False) so a
+            # piped/CI run never mutates without intent; otherwise prompt.
+            decision = resolve_gate(
+                assume=get_assume(),
+                interactive=not get_non_interactive(),
+                safe_default=False,
+            )
+            if decision is None:
+                answer = prompt_user(console, "Apply fixes now? [y/N]", "n")
+                decision = answer.strip().lower() in ("y", "yes")
+            if not decision:
                 print_success(console, f"Report written to {merged_report}. Exiting.")
                 return 0
 

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -62,7 +62,6 @@ from daydream.ui import (
     print_success,
     print_verification_summary,
     print_warning,
-    prompt_user,
 )
 from daydream.workspace import WorkContext
 

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -2158,7 +2158,9 @@ async def phase_understand_intent(
             interactive=not get_non_interactive(),
             safe_default=True,
         )
-        if gate is not None:
+        if gate is True:
+            return intent_text
+        if gate is False and get_non_interactive():
             return intent_text
 
         response = prompt_user(

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -13,8 +13,10 @@ from daydream import git_ops
 from daydream.agent import (
     console,
     detect_test_success,
+    get_assume,
     get_non_interactive,
     get_quiet_mode,
+    resolve_gate,
     run_agent,
 )
 from daydream.backends import Backend, ContinuationToken
@@ -1753,17 +1755,34 @@ async def phase_test_and_heal(
 
         print_warning(console, "Tests may have failed or result is unclear.")
 
-        # In non-interactive mode the menu's default "2" (fix-and-retry) would
-        # launch an unbounded, mutating fix loop with no human to stop it.
-        # Take choice-"4" semantics instead: terminate the heal loop and
-        # surface the failure honestly with no mutation. Skip the menu and the
-        # stdin read entirely.
-        if get_non_interactive():
+        # Test-heal retry gate across the two interaction axes. With no human at
+        # the keyboard, the menu's default "2" (fix-and-retry) would launch an
+        # unbounded, mutating fix loop with nothing to stop it -- so the
+        # unattended safe default is to abort (choice-"4" semantics: surface the
+        # failure honestly with no mutation). ``--yes`` opts into a SINGLE bounded
+        # auto fix-and-retry (choice "2"); after that one attempt it falls through
+        # to abort so the loop still terminates. Only an interactive run with no
+        # assumption shows the menu.
+        decision = resolve_gate(
+            assume=get_assume(),
+            interactive=not get_non_interactive(),
+            safe_default=False,
+        )
+        if decision is False or (decision is True and retries_used > 0):
             print_error(
-                console, "Tests failed", "Non-interactive mode: aborting heal loop",
+                console, "Tests failed", "Aborting heal loop (no further auto-retries)",
             )
             await _emit_failure_handoff(backend, work, output, offer_clipboard=False)
             return False, retries_used
+        if decision is True:
+            # Bounded auto fix-and-retry: launch one fix attempt, then loop.
+            console.print()
+            print_info(console, "Launching agent to fix test failures (auto)...")
+            fix_prompt = _build_fix_prompt(output, feedback_items)
+            _, _ = await run_agent(backend, work.repo, fix_prompt, phase=DaydreamPhase.FIX)
+            retries_used += 1
+            continuation = None
+            continue
 
         print_menu(console, "What would you like to do?", [
             ("1", "Retry tests (run again without fixes)"),
@@ -1859,8 +1878,20 @@ async def _do_commit(
 
     """
     if interactive:
-        response = prompt_user(console, "Commit and push changes? [y/N]", "n")
-        if response.lower() not in ("y", "yes"):
+        # Commit/push gate across the two interaction axes. ``--yes`` commits
+        # without prompting; an unattended run with no assumption declines
+        # (safe_default=False — the interactive default is decline); otherwise
+        # prompt. Routed here (not at the caller) so every interactive commit
+        # path honours both axes.
+        decision = resolve_gate(
+            assume=get_assume(),
+            interactive=not get_non_interactive(),
+            safe_default=False,
+        )
+        if decision is None:
+            response = prompt_user(console, "Commit and push changes? [y/N]", "n")
+            decision = response.lower() in ("y", "yes")
+        if not decision:
             print_dim(console, "Skipping commit and push")
             return False
 
@@ -2106,6 +2137,18 @@ async def phase_understand_intent(
         intent_text = output if isinstance(output, str) else str(output)
 
         console.print()
+        # Confirm-or-correct gate. ``--yes`` and unattended runs accept the
+        # understanding as-is and proceed (this read step is non-mutating, so the
+        # safe unattended outcome is to continue, not to block); only an
+        # interactive run with no assumption may offer a correction. A forced
+        # "no" has no correction to supply, so it also proceeds.
+        if resolve_gate(
+            assume=get_assume(),
+            interactive=not get_non_interactive(),
+            safe_default=True,
+        ) is not None:
+            return intent_text
+
         response = prompt_user(
             console,
             "Is this understanding correct? [y/provide correction]",

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -17,6 +17,7 @@ from daydream.agent import (
     get_non_interactive,
     get_quiet_mode,
     resolve_gate,
+    resolve_or_prompt,
     run_agent,
 )
 from daydream.backends import Backend, ContinuationToken
@@ -1671,8 +1672,13 @@ async def _emit_failure_handoff(
 
     if offer_clipboard:
         if clipboard_available():
-            response = prompt_user(console, "Copy handoff to clipboard?", "y")
-            if response.lower() in ("y", "yes"):
+            if resolve_or_prompt(
+                assume=get_assume(),
+                interactive=not get_non_interactive(),
+                safe_default=False,
+                question="Copy handoff to clipboard?",
+                default="y",
+            ):
                 if copy_to_clipboard(body):
                     print_success(console, "Handoff copied to clipboard")
                 else:
@@ -1818,10 +1824,13 @@ async def phase_test_and_heal(
                     print_info(
                         console, f"Suggested command: {sanitized_preview}",
                     )
-                    response = prompt_user(
-                        console, "Use suggested command instead?", "n",
-                    )
-                    if response.lower() in ("y", "yes"):
+                    if resolve_or_prompt(
+                        assume=get_assume(),
+                        interactive=not get_non_interactive(),
+                        safe_default=False,
+                        question="Use suggested command instead?",
+                        default="n",
+                    ):
                         test_command_override = sanitized_preview
 
             retries_used += 1
@@ -1883,14 +1892,13 @@ async def _do_commit(
         # (safe_default=False — the interactive default is decline); otherwise
         # prompt. Routed here (not at the caller) so every interactive commit
         # path honours both axes.
-        decision = resolve_gate(
+        decision = resolve_or_prompt(
             assume=get_assume(),
             interactive=not get_non_interactive(),
             safe_default=False,
+            question="Commit and push changes? [y/N]",
+            default="n",
         )
-        if decision is None:
-            response = prompt_user(console, "Commit and push changes? [y/N]", "n")
-            decision = response.lower() in ("y", "yes")
         if not decision:
             print_dim(console, "Skipping commit and push")
             return False
@@ -2141,12 +2149,16 @@ async def phase_understand_intent(
         # understanding as-is and proceed (this read step is non-mutating, so the
         # safe unattended outcome is to continue, not to block); only an
         # interactive run with no assumption may offer a correction. A forced
-        # "no" has no correction to supply, so it also proceeds.
-        if resolve_gate(
+        # "no" declines the current understanding and falls through so the user
+        # can supply a correction interactively — but only when interactive;
+        # a forced "no" in a non-interactive run also proceeds rather than
+        # blocking on stdin.
+        gate = resolve_gate(
             assume=get_assume(),
             interactive=not get_non_interactive(),
             safe_default=True,
-        ) is not None:
+        )
+        if gate is True or (gate is False and get_non_interactive()):
             return intent_text
 
         response = prompt_user(

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -2158,7 +2158,7 @@ async def phase_understand_intent(
             interactive=not get_non_interactive(),
             safe_default=True,
         )
-        if gate is True or (gate is False and get_non_interactive()):
+        if gate is not None:
             return intent_text
 
         response = prompt_user(

--- a/daydream/pr_review.py
+++ b/daydream/pr_review.py
@@ -26,10 +26,11 @@ from typing import TYPE_CHECKING, Any
 
 import daydream
 from daydream import git_ops
+from daydream.agent import get_assume, get_non_interactive, resolve_or_prompt
 from daydream.git_ops import GitError
 from daydream.pr_comment_renderer import render_run_info_block
 from daydream.trajectory import TrajectoryRecorder, get_current_recorder
-from daydream.ui import print_info, print_success, print_warning, prompt_user
+from daydream.ui import print_info, print_success, print_warning
 
 if TYPE_CHECKING:
     from rich.console import Console
@@ -889,8 +890,13 @@ async def _post(
     )
     print_info(console, f"PR #{pr.number}: {summary}")
 
-    answer = prompt_user(console, "Post these as a PR review? [y/N]", "n")
-    if answer.strip().lower() not in ("y", "yes"):
+    if not resolve_or_prompt(
+        assume=get_assume(),
+        interactive=not get_non_interactive(),
+        safe_default=False,
+        question="Post these as a PR review? [y/N]",
+        default="n",
+    ):
         print_info(console, "Skipped posting to PR.")
         return
 

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -359,6 +359,53 @@ def _resolve_backend(
     return create_backend(backend_name, model=resolved_model)
 
 
+def _truthy(value: str | None) -> bool:
+    """Interpret an environment-variable string as a boolean.
+
+    Args:
+        value: The raw environment value, or None when unset.
+
+    Returns:
+        False for None and for ``""``/``"0"``/``"false"`` (case-insensitive);
+        True for any other non-empty value.
+    """
+    if value is None:
+        return False
+    return value.strip().lower() not in ("", "0", "false")
+
+
+def _stdin_isatty() -> bool:
+    """Report whether stdin is an interactive TTY.
+
+    Returns:
+        True if stdin is attached to a terminal. A detached or closed stdin
+        (raising ``AttributeError``/``ValueError``) is treated as not a TTY.
+    """
+    import sys
+
+    try:
+        return sys.stdin.isatty()
+    except (AttributeError, ValueError):
+        return False
+
+
+def _resolve_interactive(config: "RunConfig") -> bool:
+    """Resolve whether this run may prompt the user, from three sources.
+
+    Precedence: an explicit ``--non-interactive`` flag forces False; otherwise
+    the run is interactive only when stdin is a TTY and ``CI`` is not truthy.
+
+    Args:
+        config: The run configuration carrying the explicit flag.
+
+    Returns:
+        True if prompts may read stdin; False for unattended/harness runs.
+    """
+    if config.non_interactive:
+        return False
+    return _stdin_isatty() and not _truthy(os.environ.get("CI"))
+
+
 def _compute_diff_ref(cwd: Path) -> str:
     """Compute the diff ref to hand to exploration specialists.
 
@@ -422,9 +469,12 @@ async def run(config: RunConfig | None = None) -> int:
         if codex_in_use:
             quiet = False
     set_quiet_mode(quiet)
-    # Take each prompt's safe default without reading stdin when requested.
-    # Set before any phase that can prompt runs.
-    set_non_interactive(config.non_interactive)
+    # Resolve the interactivity axis from three sources, in precedence order:
+    #   1. explicit ``--non-interactive`` flag (config.non_interactive) wins,
+    #   2. else a non-TTY stdin (piped/detached) implies unattended,
+    #   3. else a truthy ``CI`` env var implies unattended.
+    # The result feeds set_non_interactive before any phase that can prompt runs.
+    set_non_interactive(not _resolve_interactive(config))
 
     # Resolve target directory (from config or prompt). Done outside the
     # workspace context manager so that path-validation errors short-circuit

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -17,6 +17,7 @@ subcommand and is a thin wrapper that sets ``pr_number`` and re-enters
 :func:`run`.
 """
 
+import os
 import shutil
 import uuid
 from collections.abc import Callable
@@ -40,6 +41,7 @@ from daydream.config import (
     SKILL_MAP,
     ReviewSkillChoice,
 )
+from daydream.config_file import DaydreamFileConfig
 from daydream.exploration import ExplorationContext, safe_explore
 from daydream.exploration_runner import count_changed_files, pre_scan, select_tier
 from daydream.git_ops import GitError
@@ -131,7 +133,14 @@ class RunConfig:
             "per-stack", or "merge").
         pr_number: GitHub PR number for PR feedback mode. If None, normal mode.
         bot: Bot username whose comments to fetch (e.g. "coderabbitai[bot]").
-        backend: Default backend to use ("claude" or "codex"). Default is "claude".
+        backend: Default backend to use ("claude" or "codex"). Default is None;
+            ``_resolve_backend`` falls back through env/config-file to ``"claude"``.
+        model: Global default model applied across phases when no explicit
+            per-phase model is set. Resolved by ``_resolved_model`` below the
+            per-phase field but above env/config/table sources. Default None.
+        file_config: File-sourced configuration (``[tool.daydream]`` /
+            ``.daydream.toml``) feeding ``_resolved_model`` / ``_resolve_backend``
+            as a low-precedence source. None is treated as an empty config.
         review_backend: Override backend for the review phase. If None, uses backend.
         fix_backend: Override backend for the fix phase. If None, uses backend.
         test_backend: Override backend for the test phase. If None, uses backend.
@@ -178,7 +187,9 @@ class RunConfig:
     start_at: str = "review"
     pr_number: int | None = None
     bot: str | None = None
-    backend: str = "claude"
+    backend: str | None = None
+    model: str | None = None
+    file_config: DaydreamFileConfig | None = None
     review_backend: str | None = None
     fix_backend: str | None = None
     test_backend: str | None = None
@@ -252,25 +263,78 @@ def _make_archive_callback(
     return _cb
 
 
+def _file_config_or_empty(config: RunConfig) -> DaydreamFileConfig:
+    """Return ``config.file_config``, or an empty config when it is None.
+
+    A single accessor so resolution call sites never branch on ``None`` —
+    an absent file config behaves identically to one with no keys set.
+    """
+    return config.file_config if config.file_config is not None else DaydreamFileConfig()
+
+
+def _resolved_backend_name(config: RunConfig, phase: str) -> str:
+    """Resolve the backend kind for ``phase`` across all precedence tiers.
+
+    Order (highest first): explicit per-phase ``--{phase}-backend``, global
+    ``config.backend``, ``DAYDREAM_BACKEND`` env, file-config phase override,
+    file-config global, then the terminal ``"claude"`` fallback.
+    """
+    file_config = _file_config_or_empty(config)
+    return (
+        getattr(config, f"{phase}_backend", None)
+        or config.backend
+        or os.environ.get("DAYDREAM_BACKEND")
+        or file_config.phase_backend(phase)
+        or file_config.backend
+        or "claude"
+    )
+
+
+def _resolved_model(config: RunConfig, phase: str) -> str | None:
+    """Resolve the model for ``phase`` across all precedence tiers.
+
+    Order (highest first): explicit per-phase ``{phase}_model``, global
+    ``config.model``, ``DAYDREAM_MODEL`` env, file-config phase override,
+    file-config global, then ``PHASE_DEFAULT_MODELS[backend][phase]``. Returns
+    ``None`` only when no source supplies a model (the backend then applies its
+    own default).
+
+    The per-backend table lookup keys off the backend kind resolved by
+    :func:`_resolved_backend_name`, so a config-selected backend still gets its
+    own phase tier defaults.
+    """
+    file_config = _file_config_or_empty(config)
+    backend_name = _resolved_backend_name(config, phase)
+    return (
+        getattr(config, f"{phase}_model", None)
+        or config.model
+        or os.environ.get("DAYDREAM_MODEL")
+        or file_config.phase_model(phase)
+        or file_config.model
+        or PHASE_DEFAULT_MODELS.get(backend_name, {}).get(phase)
+    )
+
+
 def _resolve_backend(
     config: RunConfig,
     phase: str,
     cache: dict[tuple[str, str | None], Backend] | None = None,
 ) -> Backend:
-    """Get or create the backend for a given phase, respecting per-phase overrides.
+    """Get or create the backend for a given phase, respecting all precedence tiers.
 
-    Resolution order for the model:
-        1. ``getattr(config, f"{phase}_model", None)`` — explicit per-phase flag.
-        2. ``PHASE_DEFAULT_MODELS[backend_name].get(phase)`` — per-backend phase
-           default table.
-        3. ``None`` — let :func:`create_backend` apply its own backend default.
+    Both the backend kind and the model are resolved through the source-tiered
+    precedence ``CLI > env > config-file > default``:
 
-    The backend kind is resolved first via
-    ``getattr(config, f"{phase}_backend", None) or config.backend``; the model
-    lookup then keys into that backend name's table.
+    - Backend kind via :func:`_resolved_backend_name`
+      (per-phase flag → ``config.backend`` → ``DAYDREAM_BACKEND`` →
+      file-config phase → file-config global → ``"claude"``).
+    - Model via :func:`_resolved_model`
+      (per-phase field → ``config.model`` → ``DAYDREAM_MODEL`` →
+      file-config phase → file-config global → ``PHASE_DEFAULT_MODELS`` →
+      ``None``, where ``None`` falls through to the backend's own default).
 
     Args:
-        config: Run configuration with backend and per-phase model settings.
+        config: Run configuration with backend/model and file-config sources.
         phase: Phase name (e.g. ``"review"``, ``"parse"``, ``"fix"``, ``"test"``,
             ``"intent"``, ``"wonder"``, ``"envision"``, ``"merge"``,
             ``"exploration"``, ``"pr_feedback"``).
@@ -283,12 +347,8 @@ def _resolve_backend(
         Backend instance for the phase.
 
     """
-    backend_override = getattr(config, f"{phase}_backend", None)
-    backend_name = backend_override or config.backend
-
-    phase_flag = getattr(config, f"{phase}_model", None)
-    table_default = PHASE_DEFAULT_MODELS.get(backend_name, {}).get(phase)
-    resolved_model = phase_flag or table_default  # ``None`` falls through to backend default
+    backend_name = _resolved_backend_name(config, phase)
+    resolved_model = _resolved_model(config, phase)
 
     cache_key = (backend_name, resolved_model)
     if cache is not None:
@@ -350,13 +410,14 @@ async def run(config: RunConfig | None = None) -> int:
 
     # Quiet mode tweak: Codex backends need their shell output visible because
     # those commands ARE the user-facing signal. Done before any backend is
-    # constructed so per-phase backends inherit the right setting.
+    # constructed so per-phase backends inherit the right setting. Resolve each
+    # phase's backend through the full precedence chain (CLI/env/config-file)
+    # so a codex backend selected via env or config still disables quiet mode.
     quiet = config.quiet
     if quiet:
-        codex_in_use = config.backend == "codex" or any(
-            b == "codex"
-            for b in (config.review_backend, config.fix_backend, config.test_backend)
-            if b is not None
+        codex_in_use = any(
+            _resolved_backend_name(config, phase) == "codex"
+            for phase in ("review", "fix", "test")
         )
         if codex_in_use:
             quiet = False

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -30,6 +30,8 @@ from daydream.agent import (
     MissingSkillError,
     console,
     get_non_interactive,
+    resolve_gate,
+    set_assume,
     set_non_interactive,
     set_quiet_mode,
 )
@@ -177,6 +179,9 @@ class RunConfig:
         plan: Generate an implementation plan and embed it in PR comments.
         non_interactive: Run without prompting; take each prompt's safe default
             without reading stdin.
+        assume: Forced yes/no answer for interactive gates — ``"yes"`` (``--yes``),
+            ``"no"``, or ``None``. Orthogonal to ``non_interactive``: it supplies a
+            pre-decided answer rather than controlling stdin access.
 
     """
 
@@ -216,6 +221,7 @@ class RunConfig:
     extra_copy: list[Path] = field(default_factory=list)
     plan: bool = False
     non_interactive: bool = False
+    assume: str | None = None  # forced gate answer: "yes" (--yes), "no", or None
 
 
 def _print_missing_skill_error(skill_name: str) -> None:
@@ -475,6 +481,10 @@ async def run(config: RunConfig | None = None) -> int:
     #   3. else a truthy ``CI`` env var implies unattended.
     # The result feeds set_non_interactive before any phase that can prompt runs.
     set_non_interactive(not _resolve_interactive(config))
+    # Interaction has a second, orthogonal axis: ``assume`` (``--yes``) supplies a
+    # forced gate answer regardless of TTY. The two feed ``resolve_gate`` at each
+    # yes/no gate. Set alongside non_interactive so every gate sees both axes.
+    set_assume(config.assume)
 
     # Resolve target directory (from config or prompt). Done outside the
     # workspace context manager so that path-validation errors short-circuit
@@ -918,12 +928,24 @@ async def _run_loop_shallow(work: WorkContext, config: RunConfig) -> int:
             print_error(console, "Missing Review File", str(e))
             return 1
 
-    # Cleanup setting (from config or prompt).
+    # Cleanup setting. An explicit ``--cleanup/--no-cleanup`` (config.cleanup)
+    # wins outright. Otherwise route the yes/no gate through resolve_gate:
+    # ``--yes`` enables cleanup; an unattended run keeps the review output
+    # (safe_default=False); an interactive run prompts.
     if config.cleanup is not None:
         cleanup_enabled = config.cleanup
     else:
-        cleanup_response = prompt_user(console, "Cleanup review output after completion? [y/N]", "n")
-        cleanup_enabled = cleanup_response.lower() in ("y", "yes")
+        cleanup_decision = resolve_gate(
+            assume=config.assume,
+            interactive=not get_non_interactive(),
+            safe_default=False,
+        )
+        if cleanup_decision is None:
+            cleanup_response = prompt_user(
+                console, "Cleanup review output after completion? [y/N]", "n",
+            )
+            cleanup_decision = cleanup_response.lower() in ("y", "yes")
+        cleanup_enabled = cleanup_decision
 
     # Backends (per-phase overrides).
     backend_cache: dict[tuple[str, str | None], Backend] = {}
@@ -1169,21 +1191,28 @@ async def _run_loop_shallow(work: WorkContext, config: RunConfig) -> int:
             ),
         )
 
-        # non_interactive routes to phase_commit_push_auto below because the
-        # interactive prompt's safe default is "decline" (y/N), which would
-        # silently skip the commit when stdin is not a TTY.
-
         # Clean up exploration files before exit
         exploration_cleanup = target_dir / ".daydream" / "exploration"
         if exploration_cleanup.is_dir():
             shutil.rmtree(exploration_cleanup)
 
-        # Commit if tests passed
+        # Commit if tests passed. Commit/push gate across the two interaction
+        # axes. The unattended safe default is to auto-commit (safe_default=True):
+        # the interactive prompt's own default is "decline", which would silently
+        # drop a green run's commit when stdin is not a TTY. ``--yes`` also
+        # auto-commits; a forced ``--no`` skips the commit; an interactive run
+        # with no assumption gets the y/N prompt.
         if tests_passed:
-            if config.non_interactive:
+            commit_decision = resolve_gate(
+                assume=config.assume,
+                interactive=not get_non_interactive(),
+                safe_default=True,
+            )
+            if commit_decision is True:
                 await phase_commit_push_auto(review_backend, work)
-            else:
+            elif commit_decision is None:
                 await phase_commit_push(review_backend, work)
+            # commit_decision is False -> forced decline, skip commit.
 
             if cleanup_enabled:
                 review_output_path = target_dir / REVIEW_OUTPUT_FILE

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -29,8 +29,10 @@ from daydream import git_ops
 from daydream.agent import (
     MissingSkillError,
     console,
+    get_assume,
     get_non_interactive,
     resolve_gate,
+    resolve_or_prompt,
     set_assume,
     set_non_interactive,
     set_quiet_mode,
@@ -139,7 +141,8 @@ class RunConfig:
             ``_resolve_backend`` falls back through env/config-file to ``"claude"``.
         model: Global default model applied across phases when no explicit
             per-phase model is set. Resolved by ``_resolved_model`` below the
-            per-phase field but above env/config/table sources. Default None.
+            per-phase field and below per-phase config-file overrides, but above
+            the env var, config-file global, and table sources. Default None.
         file_config: File-sourced configuration (``[tool.daydream]`` /
             ``.daydream.toml``) feeding ``_resolved_model`` / ``_resolve_backend``
             as a low-precedence source. None is treated as an empty config.
@@ -282,15 +285,15 @@ def _resolved_backend_name(config: RunConfig, phase: str) -> str:
     """Resolve the backend kind for ``phase`` across all precedence tiers.
 
     Order (highest first): explicit per-phase ``--{phase}-backend``, global
-    ``config.backend``, ``DAYDREAM_BACKEND`` env, file-config phase override,
+    ``config.backend``, file-config phase override, ``DAYDREAM_BACKEND`` env,
     file-config global, then the terminal ``"claude"`` fallback.
     """
     file_config = _file_config_or_empty(config)
     return (
         getattr(config, f"{phase}_backend", None)
         or config.backend
-        or os.environ.get("DAYDREAM_BACKEND")
         or file_config.phase_backend(phase)
+        or os.environ.get("DAYDREAM_BACKEND")
         or file_config.backend
         or "claude"
     )
@@ -300,10 +303,10 @@ def _resolved_model(config: RunConfig, phase: str) -> str | None:
     """Resolve the model for ``phase`` across all precedence tiers.
 
     Order (highest first): explicit per-phase ``{phase}_model``, global
-    ``config.model``, ``DAYDREAM_MODEL`` env, file-config phase override,
-    file-config global, then ``PHASE_DEFAULT_MODELS[backend][phase]``. Returns
-    ``None`` only when no source supplies a model (the backend then applies its
-    own default).
+    ``config.model`` (``--model``), ``DAYDREAM_MODEL`` env, file-config phase
+    override, file-config global, then ``PHASE_DEFAULT_MODELS[backend][phase]``.
+    Returns ``None`` only when no source supplies a model (the backend then
+    applies its own default).
 
     The per-backend table lookup keys off the backend kind resolved by
     :func:`_resolved_backend_name`, so a config-selected backend still gets its
@@ -332,11 +335,11 @@ def _resolve_backend(
     precedence ``CLI > env > config-file > default``:
 
     - Backend kind via :func:`_resolved_backend_name`
-      (per-phase flag → ``config.backend`` → ``DAYDREAM_BACKEND`` →
-      file-config phase → file-config global → ``"claude"``).
+      (per-phase flag → ``config.backend`` → file-config phase →
+      ``DAYDREAM_BACKEND`` → file-config global → ``"claude"``).
     - Model via :func:`_resolved_model`
-      (per-phase field → ``config.model`` → ``DAYDREAM_MODEL`` →
-      file-config phase → file-config global → ``PHASE_DEFAULT_MODELS`` →
+      (per-phase field → file-config phase → ``config.model`` → ``DAYDREAM_MODEL`` →
+      file-config global → ``PHASE_DEFAULT_MODELS`` →
       ``None``, where ``None`` falls through to the backend's own default).
 
     Args:
@@ -935,17 +938,13 @@ async def _run_loop_shallow(work: WorkContext, config: RunConfig) -> int:
     if config.cleanup is not None:
         cleanup_enabled = config.cleanup
     else:
-        cleanup_decision = resolve_gate(
-            assume=config.assume,
+        cleanup_enabled = resolve_or_prompt(
+            assume=get_assume(),
             interactive=not get_non_interactive(),
             safe_default=False,
+            question="Cleanup review output after completion? [y/N]",
+            default="n",
         )
-        if cleanup_decision is None:
-            cleanup_response = prompt_user(
-                console, "Cleanup review output after completion? [y/N]", "n",
-            )
-            cleanup_decision = cleanup_response.lower() in ("y", "yes")
-        cleanup_enabled = cleanup_decision
 
     # Backends (per-phase overrides).
     backend_cache: dict[tuple[str, str | None], Backend] = {}
@@ -1204,7 +1203,7 @@ async def _run_loop_shallow(work: WorkContext, config: RunConfig) -> int:
         # with no assumption gets the y/N prompt.
         if tests_passed:
             commit_decision = resolve_gate(
-                assume=config.assume,
+                assume=get_assume(),
                 interactive=not get_non_interactive(),
                 safe_default=True,
             )

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -138,11 +138,11 @@ class RunConfig:
         pr_number: GitHub PR number for PR feedback mode. If None, normal mode.
         bot: Bot username whose comments to fetch (e.g. "coderabbitai[bot]").
         backend: Default backend to use ("claude" or "codex"). Default is None;
-            ``_resolve_backend`` falls back through env/config-file to ``"claude"``.
+            ``_resolve_backend`` falls back through the config file to ``"claude"``.
         model: Global default model applied across phases when no explicit
             per-phase model is set. Resolved by ``_resolved_model`` below the
-            per-phase field and below per-phase config-file overrides, but above
-            the env var, config-file global, and table sources. Default None.
+            per-phase field but above the config-file (phase then global) and
+            table sources. Default None.
         file_config: File-sourced configuration (``[tool.daydream]`` /
             ``.daydream.toml``) feeding ``_resolved_model`` / ``_resolve_backend``
             as a low-precedence source. None is treated as an empty config.
@@ -284,16 +284,15 @@ def _file_config_or_empty(config: RunConfig) -> DaydreamFileConfig:
 def _resolved_backend_name(config: RunConfig, phase: str) -> str:
     """Resolve the backend kind for ``phase`` across all precedence tiers.
 
-    Order (highest first): explicit per-phase ``--{phase}-backend``, global
-    ``config.backend``, file-config phase override, ``DAYDREAM_BACKEND`` env,
-    file-config global, then the terminal ``"claude"`` fallback.
+    Order (highest first): explicit per-phase ``{phase}_backend``, global
+    ``config.backend`` (``--backend``), file-config phase override, file-config
+    global, then the terminal ``"claude"`` fallback.
     """
     file_config = _file_config_or_empty(config)
     return (
         getattr(config, f"{phase}_backend", None)
         or config.backend
         or file_config.phase_backend(phase)
-        or os.environ.get("DAYDREAM_BACKEND")
         or file_config.backend
         or "claude"
     )
@@ -303,10 +302,10 @@ def _resolved_model(config: RunConfig, phase: str) -> str | None:
     """Resolve the model for ``phase`` across all precedence tiers.
 
     Order (highest first): explicit per-phase ``{phase}_model``, global
-    ``config.model`` (``--model``), ``DAYDREAM_MODEL`` env, file-config phase
-    override, file-config global, then ``PHASE_DEFAULT_MODELS[backend][phase]``.
-    Returns ``None`` only when no source supplies a model (the backend then
-    applies its own default).
+    ``config.model`` (``--model``), file-config phase override, file-config
+    global, then ``PHASE_DEFAULT_MODELS[backend][phase]``. Returns ``None``
+    only when no source supplies a model (the backend then applies its own
+    default).
 
     The per-backend table lookup keys off the backend kind resolved by
     :func:`_resolved_backend_name`, so a config-selected backend still gets its
@@ -317,7 +316,6 @@ def _resolved_model(config: RunConfig, phase: str) -> str | None:
     return (
         getattr(config, f"{phase}_model", None)
         or config.model
-        or os.environ.get("DAYDREAM_MODEL")
         or file_config.phase_model(phase)
         or file_config.model
         or PHASE_DEFAULT_MODELS.get(backend_name, {}).get(phase)
@@ -332,13 +330,13 @@ def _resolve_backend(
     """Get or create the backend for a given phase, respecting all precedence tiers.
 
     Both the backend kind and the model are resolved through the source-tiered
-    precedence ``CLI > env > config-file > default``:
+    precedence ``CLI > config-file > default``:
 
     - Backend kind via :func:`_resolved_backend_name`
       (per-phase flag → ``config.backend`` → file-config phase →
-      ``DAYDREAM_BACKEND`` → file-config global → ``"claude"``).
+      file-config global → ``"claude"``).
     - Model via :func:`_resolved_model`
-      (per-phase field → file-config phase → ``config.model`` → ``DAYDREAM_MODEL`` →
+      (per-phase field → ``config.model`` → file-config phase →
       file-config global → ``PHASE_DEFAULT_MODELS`` →
       ``None``, where ``None`` falls through to the backend's own default).
 
@@ -467,8 +465,8 @@ async def run(config: RunConfig | None = None) -> int:
     # Quiet mode tweak: Codex backends need their shell output visible because
     # those commands ARE the user-facing signal. Done before any backend is
     # constructed so per-phase backends inherit the right setting. Resolve each
-    # phase's backend through the full precedence chain (CLI/env/config-file)
-    # so a codex backend selected via env or config still disables quiet mode.
+    # phase's backend through the full precedence chain (CLI/config-file)
+    # so a codex backend selected via config still disables quiet mode.
     quiet = config.quiet
     if quiet:
         codex_in_use = any(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -253,6 +253,24 @@ def make_work() -> Callable[..., WorkContext]:
 
 
 @pytest.fixture(autouse=True)
+def _reset_agent_state():
+    """Reset the ``AgentState`` singleton before AND after every test.
+
+    The interaction axes (``non_interactive``, ``assume``) and ``quiet_mode``
+    live on a module-level ``AgentState`` singleton in ``daydream.agent``. A test
+    that drives ``run()`` calls ``set_non_interactive``/``set_assume``, leaving
+    the singleton dirty for the next test — which silently changes the resolved
+    answer at every ``resolve_gate`` call site. Reset on both edges so each test
+    starts from defaults regardless of order.
+    """
+    from daydream.agent import reset_state
+
+    reset_state()
+    yield
+    reset_state()
+
+
+@pytest.fixture(autouse=True)
 def _reset_trajectory_recorder():
     """Clear the trajectory ContextVar before AND after every test.
 

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -27,6 +27,7 @@ from daydream.archive.index import (
     upsert_run,
 )
 from daydream.archive.manifest import Manifest, build_manifest
+from daydream.config_file import DaydreamFileConfig
 
 # ---------------------------------------------------------------------------
 # Mock helpers
@@ -68,6 +69,7 @@ class _MockConfig:
     loop: bool = False
     archive: bool = True
     run_eval: bool = False
+    file_config: DaydreamFileConfig | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -394,7 +394,7 @@ def test_runconfig_has_model_field():
 
 
 # ---------------------------------------------------------------------------
-# build-corpus exit-code regression guard (Task 11 / corpus-pipeline-architecture)
+# corpus build exit-code regression guard (Task 11 / corpus-pipeline-architecture)
 # ---------------------------------------------------------------------------
 # Tier-3 subprocess test: drives the real CLI entry point through `uv run`
 # against an empty archive directory and asserts a clean exit 0. This catches
@@ -408,7 +408,7 @@ def test_build_corpus_exits_0_on_dry_run(tmp_path: Path) -> None:
     out = tmp_path / "out.jsonl"
     result = subprocess.run(  # noqa: S603 - args are not user-controlled
         [  # noqa: S607 - hardcoded uv/daydream entrypoint
-            "uv", "run", "daydream", "build-corpus",
+            "uv", "run", "daydream", "corpus", "build",
             "--out", str(out), "--include-all-labels", "--dry-run",
         ],
         capture_output=True,
@@ -421,7 +421,7 @@ def test_build_corpus_exits_0_on_dry_run(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# harvest / build-corpus subcommand wiring (Task 11 / corpus-pipeline-architecture)
+# corpus harvest / build subcommand wiring (Task 11 / corpus-pipeline-architecture)
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -82,6 +82,38 @@ def test_loop_optional_count(monkeypatch):
     assert _cfg(monkeypatch, ["/tmp/project"]).loop is False
 
 
+def test_yes_with_review_errors(monkeypatch, capsys):
+    """--yes has no effect with --review (no fix phase) and must be rejected."""
+    monkeypatch.setattr(sys, "argv", ["daydream", "--yes", "--review", "/tmp/project"])
+    with pytest.raises(SystemExit):
+        _parse_args()
+    assert "--yes" in capsys.readouterr().err
+
+
+def test_yes_with_comment_errors(monkeypatch, capsys):
+    """--yes has no effect with --comment (no fix phase) and must be rejected."""
+    monkeypatch.setattr(sys, "argv", ["daydream", "--yes", "--comment", "/tmp/project"])
+    with pytest.raises(SystemExit):
+        _parse_args()
+    assert "--yes" in capsys.readouterr().err
+
+
+def test_loop_zero_count_errors(monkeypatch, capsys):
+    """--loop 0 is rejected because the count must be positive."""
+    monkeypatch.setattr(sys, "argv", ["daydream", "--loop", "0", "/tmp/project"])
+    with pytest.raises(SystemExit):
+        _parse_args()
+    assert "positive" in capsys.readouterr().err
+
+
+def test_loop_negative_count_errors(monkeypatch, capsys):
+    """--loop -1 is rejected because the count must be positive."""
+    monkeypatch.setattr(sys, "argv", ["daydream", "--loop", "-1", "/tmp/project"])
+    with pytest.raises(SystemExit):
+        _parse_args()
+    assert "positive" in capsys.readouterr().err
+
+
 def test_loop_with_comment_errors(monkeypatch):
     """--loop is incompatible with --comment (review-only output mode)."""
     monkeypatch.setattr(sys, "argv", ["daydream", "--loop", "--comment", "/tmp/project"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,9 +15,8 @@ from daydream.runner import RunConfig, _resolved_backend_name, _resolved_model
 
 
 def test_default_backend_is_none_and_resolves_to_claude(monkeypatch):
-    # --backend default is now None so env/config-file can supply it; the
+    # --backend default is now None so the config file can supply it; the
     # terminal fallback in _resolved_backend_name is "claude".
-    monkeypatch.delenv("DAYDREAM_BACKEND", raising=False)
     monkeypatch.setattr(sys, "argv", ["daydream", "/tmp/project"])
     config = _parse_args()
     assert config.backend is None
@@ -42,25 +41,22 @@ def test_invalid_backend_rejected(monkeypatch):
         _parse_args()
 
 
-def test_review_backend_override_via_config_file(monkeypatch):
+def test_review_backend_override_via_config_file():
     # Per-phase backend overrides moved from CLI flags to the config file
     # (cli-verb-redesign Task 8). The resolver still honours a phase override.
-    monkeypatch.delenv("DAYDREAM_BACKEND", raising=False)
     fc = DaydreamFileConfig(backend="claude", phases={"review": {"backend": "codex"}})
     config = RunConfig(target="/tmp/project", backend=None, file_config=fc)
     assert _resolved_backend_name(config, "review") == "codex"
     assert _resolved_backend_name(config, "fix") == "claude"
 
 
-def test_fix_backend_override_via_config_file(monkeypatch):
-    monkeypatch.delenv("DAYDREAM_BACKEND", raising=False)
+def test_fix_backend_override_via_config_file():
     fc = DaydreamFileConfig(phases={"fix": {"backend": "codex"}})
     config = RunConfig(target="/tmp/project", backend=None, file_config=fc)
     assert _resolved_backend_name(config, "fix") == "codex"
 
 
-def test_test_backend_override_via_config_file(monkeypatch):
-    monkeypatch.delenv("DAYDREAM_BACKEND", raising=False)
+def test_test_backend_override_via_config_file():
     fc = DaydreamFileConfig(phases={"test": {"backend": "codex"}})
     config = RunConfig(target="/tmp/project", backend=None, file_config=fc)
     assert _resolved_backend_name(config, "test") == "codex"
@@ -314,10 +310,9 @@ def test_print_issues_table_renders():
         ("test", "gpt-5.5"),
     ],
 )
-def test_per_phase_model_set_via_config_file(phase, value, monkeypatch):
+def test_per_phase_model_set_via_config_file(phase, value):
     # Per-phase model overrides moved from CLI flags to the config file; the
     # resolver still honours a phase override read from the file.
-    monkeypatch.delenv("DAYDREAM_MODEL", raising=False)
     fc = DaydreamFileConfig(phases={phase: {"model": value}})
     config = RunConfig(target="/tmp/project", backend=None, model=None, file_config=fc)
     assert _resolved_model(config, phase) == value

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -67,25 +67,31 @@ def test_test_backend_override(monkeypatch):
     assert config.test_backend == "codex"
 
 
+def _cfg(monkeypatch, args: list[str]) -> RunConfig:
+    """Parse ``daydream <args>`` into a RunConfig via the real CLI parser."""
+    monkeypatch.setattr(sys, "argv", ["daydream", *args])
+    return _parse_args()
+
+
 def test_loop_flag_default_off(monkeypatch):
-    monkeypatch.setattr(sys, "argv", ["daydream", "/tmp/project"])
-    config = _parse_args()
+    config = _cfg(monkeypatch, ["/tmp/project"])
     assert config.loop is False
     assert config.max_iterations == 5
 
 
-def test_loop_flag_enabled(monkeypatch):
-    monkeypatch.setattr(sys, "argv", ["daydream", "/tmp/project", "--loop"])
-    config = _parse_args()
-    assert config.loop is True
+def test_loop_optional_count(monkeypatch):
+    """--loop with no count enables looping at the default of 5; --loop N sets N."""
+    bare = _cfg(monkeypatch, ["--loop", "/tmp/project"])
+    assert (bare.loop, bare.max_iterations) == (True, 5)
+    assert _cfg(monkeypatch, ["--loop", "3", "/tmp/project"]).max_iterations == 3
+    assert _cfg(monkeypatch, ["/tmp/project"]).loop is False
 
 
-def test_max_iterations_flag(monkeypatch):
-    monkeypatch.setattr(sys, "argv", [
-        "daydream", "/tmp/project", "--loop", "--max-iterations", "10",
-    ])
-    config = _parse_args()
-    assert config.max_iterations == 10
+def test_loop_with_comment_errors(monkeypatch):
+    """--loop is incompatible with --comment (review-only output mode)."""
+    monkeypatch.setattr(sys, "argv", ["daydream", "--loop", "--comment", "/tmp/project"])
+    with pytest.raises(SystemExit):
+        _parse_args()
 
 
 def test_loop_start_at_conflict(monkeypatch):
@@ -94,17 +100,6 @@ def test_loop_start_at_conflict(monkeypatch):
     ])
     with pytest.raises(SystemExit):
         _parse_args()
-
-
-def test_max_iterations_without_loop_accepted(monkeypatch):
-    """--max-iterations without --loop is accepted but prints a warning."""
-    monkeypatch.setattr(sys, "argv", [
-        "daydream", "/tmp/project", "--max-iterations", "3",
-    ])
-    with pytest.warns(UserWarning, match="no effect without --loop"):
-        config = _parse_args()
-    assert config.max_iterations == 3
-    assert config.loop is False
 
 
 def test_skill_map_includes_go():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,13 +10,17 @@ import pytest
 
 from daydream.cli import _parse_args
 from daydream.config import SKILL_MAP
-from daydream.runner import RunConfig
+from daydream.runner import RunConfig, _resolved_backend_name
 
 
-def test_default_backend_is_claude(monkeypatch):
+def test_default_backend_is_none_and_resolves_to_claude(monkeypatch):
+    # --backend default is now None so env/config-file can supply it; the
+    # terminal fallback in _resolved_backend_name is "claude".
+    monkeypatch.delenv("DAYDREAM_BACKEND", raising=False)
     monkeypatch.setattr(sys, "argv", ["daydream", "/tmp/project"])
     config = _parse_args()
-    assert config.backend == "claude"
+    assert config.backend is None
+    assert _resolved_backend_name(config, "review") == "claude"
 
 
 def test_backend_flag_codex(monkeypatch):
@@ -335,28 +339,19 @@ def test_existing_exploration_model_flag_unchanged(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Removed --model flag (Task 5 of per-phase-model-overrides — breaking change)
+# Global --model flag (cli-verb-redesign Task 2 — re-added as a global override)
 # ---------------------------------------------------------------------------
 
 
-def test_removed_model_flag_emits_curated_error(capsys, tmp_path):
-    with pytest.raises(SystemExit) as exc_info:
-        _parse_args(["--model", "claude-opus-4-6", str(tmp_path)])
-    assert exc_info.value.code != 0
-    err = capsys.readouterr().err
-    assert "--model has been removed" in err
-    assert "--review-model" in err
-    assert "--parse-model" in err
-    assert "--fix-model" in err
-    assert "--test-model" in err
-    assert "--exploration-model" in err
+def test_global_model_flag_populates_runconfig(tmp_path):
+    config = _parse_args(["--model", "claude-opus-4-8", str(tmp_path)])
+    assert config.model == "claude-opus-4-8"
 
 
-def test_runconfig_has_no_model_field():
+def test_runconfig_has_model_field():
     config = RunConfig(backend="claude")
-    assert not hasattr(config, "model"), (
-        "RunConfig.model was supposed to be removed in favor of per-phase fields"
-    )
+    assert hasattr(config, "model"), "RunConfig.model is the global model override source"
+    assert config.model is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,7 +10,8 @@ import pytest
 
 from daydream.cli import _parse_args
 from daydream.config import SKILL_MAP
-from daydream.runner import RunConfig, _resolved_backend_name
+from daydream.config_file import DaydreamFileConfig
+from daydream.runner import RunConfig, _resolved_backend_name, _resolved_model
 
 
 def test_default_backend_is_none_and_resolves_to_claude(monkeypatch):
@@ -41,30 +42,28 @@ def test_invalid_backend_rejected(monkeypatch):
         _parse_args()
 
 
-def test_review_backend_override(monkeypatch):
-    monkeypatch.setattr(sys, "argv", [
-        "daydream", "/tmp/project",
-        "--backend", "claude", "--review-backend", "codex",
-    ])
-    config = _parse_args()
-    assert config.backend == "claude"
-    assert config.review_backend == "codex"
+def test_review_backend_override_via_config_file(monkeypatch):
+    # Per-phase backend overrides moved from CLI flags to the config file
+    # (cli-verb-redesign Task 8). The resolver still honours a phase override.
+    monkeypatch.delenv("DAYDREAM_BACKEND", raising=False)
+    fc = DaydreamFileConfig(backend="claude", phases={"review": {"backend": "codex"}})
+    config = RunConfig(target="/tmp/project", backend=None, file_config=fc)
+    assert _resolved_backend_name(config, "review") == "codex"
+    assert _resolved_backend_name(config, "fix") == "claude"
 
 
-def test_fix_backend_override(monkeypatch):
-    monkeypatch.setattr(sys, "argv", [
-        "daydream", "/tmp/project", "--fix-backend", "codex",
-    ])
-    config = _parse_args()
-    assert config.fix_backend == "codex"
+def test_fix_backend_override_via_config_file(monkeypatch):
+    monkeypatch.delenv("DAYDREAM_BACKEND", raising=False)
+    fc = DaydreamFileConfig(phases={"fix": {"backend": "codex"}})
+    config = RunConfig(target="/tmp/project", backend=None, file_config=fc)
+    assert _resolved_backend_name(config, "fix") == "codex"
 
 
-def test_test_backend_override(monkeypatch):
-    monkeypatch.setattr(sys, "argv", [
-        "daydream", "/tmp/project", "--test-backend", "codex",
-    ])
-    config = _parse_args()
-    assert config.test_backend == "codex"
+def test_test_backend_override_via_config_file(monkeypatch):
+    monkeypatch.delenv("DAYDREAM_BACKEND", raising=False)
+    fc = DaydreamFileConfig(phases={"test": {"backend": "codex"}})
+    config = RunConfig(target="/tmp/project", backend=None, file_config=fc)
+    assert _resolved_backend_name(config, "test") == "codex"
 
 
 def _cfg(monkeypatch, args: list[str]) -> RunConfig:
@@ -302,22 +301,26 @@ def test_print_issues_table_renders():
 
 
 # ---------------------------------------------------------------------------
-# Per-phase model override flags (Task 3 of per-phase-model-overrides)
+# Per-phase model overrides — config-file path (cli-verb-redesign Task 8)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
-    "flag,attr,value",
+    "phase,value",
     [
-        ("--review-model", "review_model", "claude-haiku-4-5"),
-        ("--parse-model", "parse_model", "claude-haiku-4-5"),
-        ("--fix-model", "fix_model", "claude-opus-4-6"),
-        ("--test-model", "test_model", "gpt-5.5"),
+        ("review", "claude-haiku-4-5"),
+        ("parse", "claude-haiku-4-5"),
+        ("fix", "claude-opus-4-6"),
+        ("test", "gpt-5.5"),
     ],
 )
-def test_per_phase_model_flags_set_runconfig_field(flag, attr, value, tmp_path):
-    config = _parse_args([flag, value, str(tmp_path)])
-    assert getattr(config, attr) == value
+def test_per_phase_model_set_via_config_file(phase, value, monkeypatch):
+    # Per-phase model overrides moved from CLI flags to the config file; the
+    # resolver still honours a phase override read from the file.
+    monkeypatch.delenv("DAYDREAM_MODEL", raising=False)
+    fc = DaydreamFileConfig(phases={phase: {"model": value}})
+    config = RunConfig(target="/tmp/project", backend=None, model=None, file_config=fc)
+    assert _resolved_model(config, phase) == value
 
 
 def test_no_per_phase_model_flag_leaves_field_none(tmp_path):
@@ -326,11 +329,52 @@ def test_no_per_phase_model_flag_leaves_field_none(tmp_path):
     assert config.parse_model is None
     assert config.fix_model is None
     assert config.test_model is None
+    assert config.exploration_model is None
 
 
-def test_existing_exploration_model_flag_unchanged(tmp_path):
-    config = _parse_args(["--exploration-model", "claude-haiku-4-5", str(tmp_path)])
-    assert config.exploration_model == "claude-haiku-4-5"
+# ---------------------------------------------------------------------------
+# Per-phase model/backend flags removed (cli-verb-redesign Task 8 — config-only)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "flag,phase",
+    [
+        ("--review-backend", "review"),
+        ("--fix-backend", "fix"),
+        ("--test-backend", "test"),
+        ("--exploration-model", "exploration"),
+        ("--review-model", "review"),
+        ("--parse-model", "parse"),
+        ("--fix-model", "fix"),
+        ("--test-model", "test"),
+    ],
+)
+def test_per_phase_flag_rejected_with_config_pointer(flag, phase, tmp_path, capsys):
+    with pytest.raises(SystemExit):
+        _parse_args([flag, "claude-opus-4-8", str(tmp_path)])
+    err = capsys.readouterr().err
+    assert flag in err
+    assert f"[tool.daydream.phases.{phase}]" in err
+
+
+@pytest.mark.parametrize(
+    "flag,phase",
+    [
+        ("--fix-model", "fix"),
+        ("--review-backend", "review"),
+    ],
+)
+def test_per_phase_flag_rejected_equals_form(flag, phase, tmp_path, capsys):
+    with pytest.raises(SystemExit):
+        _parse_args([f"{flag}=claude-opus-4-8", str(tmp_path)])
+    err = capsys.readouterr().err
+    assert flag in err
+    assert f"[tool.daydream.phases.{phase}]" in err
+
+
+def test_global_model_still_works(tmp_path):
+    assert _parse_args(["--model", "claude-opus-4-8", str(tmp_path)]).model == "claude-opus-4-8"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_config_precedence.py
+++ b/tests/test_cli_config_precedence.py
@@ -1,0 +1,32 @@
+"""Phase-model resolution precedence: CLI > env > config-file > table default.
+
+Drives the ``_resolved_model`` helper split out of ``_resolve_backend`` so the
+model decision is unit-testable without constructing a Backend. The source
+tiers are (highest first): explicit per-phase field, global ``--model``,
+``DAYDREAM_MODEL`` env, file-config phase override, file-config global, then the
+``PHASE_DEFAULT_MODELS`` table default.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from daydream.config_file import DaydreamFileConfig
+from daydream.runner import RunConfig, _resolved_model
+
+
+def test_precedence_cli_over_env_over_file_over_table(monkeypatch, tmp_path: Path) -> None:
+    fc = DaydreamFileConfig(model="file-model", backend=None, phases={"fix": {"model": "file-fix"}})
+    cfg = RunConfig(target=str(tmp_path), backend=None, model=None, file_config=fc)
+    assert _resolved_model(cfg, "fix") == "file-fix"        # file phase override, nothing higher
+    cfg.model = "cli-global"
+    assert _resolved_model(cfg, "fix") == "cli-global"      # global --model beats file phase override
+    cfg.fix_model = "cli-fix"
+    assert _resolved_model(cfg, "fix") == "cli-fix"         # explicit per-phase beats global --model
+    cfg.model = None
+    cfg.fix_model = None
+    monkeypatch.setenv("DAYDREAM_MODEL", "env-model")
+    assert _resolved_model(cfg, "review") == "env-model"    # env beats file
+    monkeypatch.delenv("DAYDREAM_MODEL")
+    cfg2 = RunConfig(target=str(tmp_path), backend=None, model=None, file_config=DaydreamFileConfig())
+    assert _resolved_model(cfg2, "parse") == "claude-haiku-4-5"   # falls through to table default

--- a/tests/test_cli_config_precedence.py
+++ b/tests/test_cli_config_precedence.py
@@ -1,10 +1,11 @@
-"""Phase-model resolution precedence: CLI > env > config-file > table default.
+"""Phase model/backend resolution precedence: CLI > config-file > default.
 
-Drives the ``_resolved_model`` helper split out of ``_resolve_backend`` so the
-model decision is unit-testable without constructing a Backend. The source
-tiers are (highest first): explicit per-phase field, global ``--model``,
-``DAYDREAM_MODEL`` env, file-config phase override, file-config global, then the
-``PHASE_DEFAULT_MODELS`` table default.
+Drives the ``_resolved_model`` / ``_resolved_backend_name`` helpers split out of
+``_resolve_backend`` so the decision is unit-testable without constructing a
+Backend. The source tiers are (highest first): explicit per-phase field, global
+``--model``/``--backend``, file-config phase override, file-config global, then
+the terminal default (``PHASE_DEFAULT_MODELS`` table / ``"claude"``). There is no
+environment-variable tier — ``DAYDREAM_MODEL``/``DAYDREAM_BACKEND`` are not read.
 """
 
 from __future__ import annotations
@@ -12,10 +13,10 @@ from __future__ import annotations
 from pathlib import Path
 
 from daydream.config_file import DaydreamFileConfig
-from daydream.runner import RunConfig, _resolved_model
+from daydream.runner import RunConfig, _resolved_backend_name, _resolved_model
 
 
-def test_precedence_cli_over_env_over_file_over_table(monkeypatch, tmp_path: Path) -> None:
+def test_model_precedence_cli_over_file_over_table(monkeypatch, tmp_path: Path) -> None:
     fc = DaydreamFileConfig(model="file-model", backend=None, phases={"fix": {"model": "file-fix"}})
     cfg = RunConfig(target=str(tmp_path), backend=None, model=None, file_config=fc)
     assert _resolved_model(cfg, "fix") == "file-fix"        # file phase override, nothing higher
@@ -25,8 +26,40 @@ def test_precedence_cli_over_env_over_file_over_table(monkeypatch, tmp_path: Pat
     assert _resolved_model(cfg, "fix") == "cli-fix"         # explicit per-phase beats global --model
     cfg.model = None
     cfg.fix_model = None
-    monkeypatch.setenv("DAYDREAM_MODEL", "env-model")
-    assert _resolved_model(cfg, "review") == "env-model"    # env beats file
-    monkeypatch.delenv("DAYDREAM_MODEL")
+    assert _resolved_model(cfg, "review") == "file-model"   # no phase override -> file global
     cfg2 = RunConfig(target=str(tmp_path), backend=None, model=None, file_config=DaydreamFileConfig())
     assert _resolved_model(cfg2, "parse") == "claude-haiku-4-5"   # falls through to table default
+
+
+def test_backend_precedence_mirrors_model(tmp_path: Path) -> None:
+    """Backend resolves through the same tiers as model, so the two stay symmetric."""
+    fc = DaydreamFileConfig(model=None, backend="file-global", phases={"fix": {"backend": "file-fix"}})
+    cfg = RunConfig(target=str(tmp_path), backend=None, model=None, file_config=fc)
+    assert _resolved_backend_name(cfg, "fix") == "file-fix"        # file phase override, nothing higher
+    cfg.backend = "cli-global"
+    assert _resolved_backend_name(cfg, "fix") == "cli-global"      # global --backend beats file phase override
+    cfg.fix_backend = "cli-fix"
+    assert _resolved_backend_name(cfg, "fix") == "cli-fix"         # explicit per-phase beats global --backend
+    cfg.backend = None
+    cfg.fix_backend = None
+    assert _resolved_backend_name(cfg, "review") == "file-global"  # no phase override -> file global
+    cfg2 = RunConfig(target=str(tmp_path), backend=None, model=None, file_config=DaydreamFileConfig())
+    assert _resolved_backend_name(cfg2, "parse") == "claude"       # terminal fallback
+
+
+def test_env_vars_are_not_a_precedence_tier(monkeypatch, tmp_path: Path) -> None:
+    """Regression guard: ``DAYDREAM_MODEL``/``DAYDREAM_BACKEND`` must be ignored.
+
+    The env tier was removed to collapse precedence to ``CLI > config > default``.
+    A config-file value must win over an ambient env var, not the reverse.
+    """
+    monkeypatch.setenv("DAYDREAM_MODEL", "env-model")
+    monkeypatch.setenv("DAYDREAM_BACKEND", "env-backend")
+    fc = DaydreamFileConfig(model="file-model", backend="file-backend", phases={})
+    cfg = RunConfig(target=str(tmp_path), backend=None, model=None, file_config=fc)
+    assert _resolved_model(cfg, "review") == "file-model"      # config beats env (env not read)
+    assert _resolved_backend_name(cfg, "review") == "file-backend"
+    # With no config either, falls straight through to the built-in defaults.
+    cfg2 = RunConfig(target=str(tmp_path), backend=None, model=None, file_config=DaydreamFileConfig())
+    assert _resolved_model(cfg2, "parse") == "claude-haiku-4-5"
+    assert _resolved_backend_name(cfg2, "parse") == "claude"

--- a/tests/test_cli_corpus_namespace.py
+++ b/tests/test_cli_corpus_namespace.py
@@ -34,10 +34,12 @@ def _run_main(argv: list[str]) -> int:
 
 def test_corpus_harvest_routes(monkeypatch: pytest.MonkeyPatch) -> None:
     called = {}
-    monkeypatch.setattr(
-        "daydream.training.harvest.run_harvest",
-        lambda c: called.setdefault("hit", True) or {"errors": 0, "annotated": 0, "skipped": 0, "total": 0},
-    )
+
+    def _fake_run_harvest(_config):
+        called["hit"] = True
+        return {"errors": 0, "annotated": 0, "skipped": 0, "total": 0}
+
+    monkeypatch.setattr("daydream.training.harvest.run_harvest", _fake_run_harvest)
     assert _run_main(["corpus", "harvest", "--dry-run"]) == 0
     assert called["hit"]
 

--- a/tests/test_cli_corpus_namespace.py
+++ b/tests/test_cli_corpus_namespace.py
@@ -52,7 +52,11 @@ def test_corpus_build_and_label_route(monkeypatch: pytest.MonkeyPatch, tmp_path)
         label_called["argv"] = argv
         return 0
 
-    monkeypatch.setattr(cli, "_handle_label_command", _fake_label)
+    # Patch the dict entry directly: _handle_corpus_command dispatches from
+    # _CORPUS_SUBVERBS, which captured the original function reference at import
+    # time. Patching cli._handle_label_command replaces the module attribute but
+    # leaves the dict value unchanged, so the real handler still runs.
+    monkeypatch.setitem(cli._CORPUS_SUBVERBS, "label", _fake_label)
     assert _run_main(["corpus", "label", "sess-0001", "--outcome", "accepted"]) == 0
     assert label_called["argv"] == ["sess-0001", "--outcome", "accepted"]
 

--- a/tests/test_cli_corpus_namespace.py
+++ b/tests/test_cli_corpus_namespace.py
@@ -1,0 +1,67 @@
+"""Tests for the ``corpus`` namespace dispatch.
+
+The data-pipeline verbs (``harvest``, ``build``/``build-corpus``, ``label``)
+live under a ``corpus`` parent verb. ``main()`` recognizes ``corpus`` and
+dispatches the sub-verb to the existing handlers; a bare ``daydream corpus``
+prints help and exits 2. The old top-level forms are removed — ``daydream
+harvest`` is no longer a verb, so it falls through to the ``review`` shim and
+is rejected as an invalid target.
+
+These tests drive ``cli.main`` through ``sys.argv`` (the production
+entrypoint), mocking only the handler/backend seam, and assert on the exit
+code and on whether the handler was actually invoked — not on mere dispatch.
+"""
+
+import pytest
+
+from daydream import cli
+
+
+def _run_main(argv: list[str]) -> int:
+    """Drive ``cli.main`` with ``argv`` and return its exit code."""
+    import sys
+
+    saved = sys.argv
+    sys.argv = ["daydream", *argv]
+    try:
+        cli.main()
+    except SystemExit as exc:  # main() always exits via sys.exit
+        return int(exc.code or 0)
+    finally:
+        sys.argv = saved
+    return 0
+
+
+def test_corpus_harvest_routes(monkeypatch: pytest.MonkeyPatch) -> None:
+    called = {}
+    monkeypatch.setattr(
+        "daydream.training.harvest.run_harvest",
+        lambda c: called.setdefault("hit", True) or {"errors": 0, "annotated": 0, "skipped": 0, "total": 0},
+    )
+    assert _run_main(["corpus", "harvest", "--dry-run"]) == 0
+    assert called["hit"]
+
+
+def test_corpus_build_and_label_route(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    out = tmp_path / "x.jsonl"
+    assert _run_main(["corpus", "build", "--out", str(out), "--dry-run"]) == 0
+
+    label_called = {}
+
+    def _fake_label(argv: list[str]) -> int:
+        label_called["argv"] = argv
+        return 0
+
+    monkeypatch.setattr(cli, "_handle_label_command", _fake_label)
+    assert _run_main(["corpus", "label", "sess-0001", "--outcome", "accepted"]) == 0
+    assert label_called["argv"] == ["sess-0001", "--outcome", "accepted"]
+
+
+def test_bare_corpus_prints_help_exits_2() -> None:
+    assert _run_main(["corpus"]) == 2
+
+
+def test_bare_harvest_is_unknown_verb_treated_as_review_target() -> None:
+    # 'harvest' is no longer a verb; _first_verb falls through to review,
+    # which then rejects the unknown '--dry-run' flag (argparse error → exit 2).
+    assert _run_main(["harvest", "--dry-run"]) != 0

--- a/tests/test_cli_help_tiers.py
+++ b/tests/test_cli_help_tiers.py
@@ -1,0 +1,34 @@
+# tests/test_cli_help_tiers.py
+"""Tests for the two-tier help surface (``--help`` vs ``--help-all``)."""
+
+import pytest
+
+from daydream.cli import _parse_args
+from daydream.runner import RunConfig
+
+
+def _parse_argv_for_test(argv: list[str]) -> RunConfig:
+    """Drive the real CLI parser with an explicit argv (no sys.argv mutation)."""
+    return _parse_args(argv)
+
+
+def _cfg(argv: list[str]) -> RunConfig:
+    """Parse ``daydream <argv>`` into a RunConfig via the real CLI parser."""
+    return _parse_args(argv)
+
+
+def test_default_help_hides_advanced(capsys):
+    with pytest.raises(SystemExit):
+        _parse_argv_for_test(["--help"])
+    out = capsys.readouterr().out
+    assert "--comment" in out and "--start-at" not in out and "--ignore-path" not in out
+
+
+def test_help_all_shows_advanced(capsys):
+    with pytest.raises(SystemExit):
+        _parse_argv_for_test(["--help-all"])
+    assert "--start-at" in capsys.readouterr().out
+
+
+def test_advanced_flags_still_parse():
+    assert _cfg(["--start-at", "fix", "/t"]).start_at == "fix"

--- a/tests/test_cli_main_integration.py
+++ b/tests/test_cli_main_integration.py
@@ -91,6 +91,29 @@ def test_cli_main_clean_deep_run_exits_0(
     assert exc.value.code == 0
 
 
+def test_cli_main_explicit_review_verb_exits_0(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``daydream review <target>`` is identical to the bare-target run.
+
+    The default-verb shim must make the explicit ``review`` verb behave
+    exactly like a bare ``daydream <target>``. This drives the SAME production
+    path (cli.main -> verb dispatch -> _parse_args -> anyio.run(run) ->
+    sys.exit) with an explicit leading ``review`` token and asserts the same
+    clean exit 0 as ``test_cli_main_clean_deep_run_exits_0``.
+    """
+    _silence(monkeypatch)
+    _silence_cli_and_runner(monkeypatch)
+    _install_stub_backend(monkeypatch, multi_stack_target)
+
+    monkeypatch.setattr(sys, "argv", ["daydream", "review", str(multi_stack_target)])
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    assert exc.value.code == 0
+
+
 def test_cli_main_trajectory_pr_repo_is_target_not_cwd(
     multi_stack_target: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_cli_main_integration.py
+++ b/tests/test_cli_main_integration.py
@@ -175,3 +175,31 @@ def test_cli_main_wrong_branch_exits_1(
         cli.main()
 
     assert exc.value.code == 1
+
+
+def test_non_tty_auto_enables_non_interactive(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A piped (non-TTY) stdin auto-enables non-interactive with no flag.
+
+    This drives the production entrypoint (``cli.main`` -> ``runner.run``) with a
+    bare target and a non-TTY stdin. The interactivity axis must resolve from the
+    environment (non-TTY) rather than requiring an explicit ``--non-interactive``
+    flag, so the captured ``set_non_interactive`` value is ``True``.
+    """
+    _silence(monkeypatch)
+    _silence_cli_and_runner(monkeypatch)
+    _install_stub_backend(monkeypatch, multi_stack_target)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)  # piped stdin
+    monkeypatch.delenv("CI", raising=False)
+    captured: dict[str, bool] = {}
+    monkeypatch.setattr(
+        "daydream.runner.set_non_interactive",
+        lambda v: captured.__setitem__("v", v),
+    )
+    monkeypatch.setattr(sys, "argv", ["daydream", str(multi_stack_target)])
+
+    with pytest.raises(SystemExit):
+        cli.main()
+
+    assert captured["v"] is True  # auto-enabled with no flag

--- a/tests/test_cli_verbs.py
+++ b/tests/test_cli_verbs.py
@@ -1,0 +1,32 @@
+# tests/test_cli_verbs.py
+"""Tests for verb-first dispatch and the default-``review`` shim.
+
+``_first_verb`` is the pure routing primitive: it inspects the leading token
+and decides which verb owns the rest of argv. A bare path, a leading flag, or
+empty argv all fall through to the ``review`` golden path. ``_parse_argv_for_test``
+drives the real ``_parse_args`` (the production RunConfig builder) so that the
+bare-target and explicit-``review`` forms are proven to parse identically.
+"""
+
+import pytest
+
+from daydream.cli import _first_verb, _parse_args
+from daydream.runner import RunConfig
+
+
+def _parse_argv_for_test(argv: list[str]) -> RunConfig:
+    """Build a RunConfig from argv through the production parser."""
+    return _parse_args(argv)
+
+
+def test_first_verb_routing() -> None:
+    assert _first_verb(["feedback", "42", "--bot", "x"]) == "feedback"
+    assert _first_verb(["/some/path"]) == "review"  # bare path → review shim
+    assert _first_verb(["--comment", "/p"]) == "review"  # leading flag → review
+    assert _first_verb([]) == "review"  # empty → review (interactive target prompt)
+
+
+@pytest.mark.parametrize("argv", [["/t"], ["review", "/t"]])
+def test_bare_and_review_verb_parse_identically(argv: list[str]) -> None:
+    cfg = _parse_argv_for_test(argv)
+    assert cfg.target == "/t" and cfg.output_mode == "loop"

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -1,0 +1,45 @@
+"""Tests for daydream.config_file module (config-file loader)."""
+
+from pathlib import Path
+
+import pytest
+
+from daydream.config_file import DaydreamFileConfig, load_file_config
+
+
+def test_dotfile_wins_over_pyproject(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text('[tool.daydream]\nmodel = "from-pyproject"\n')
+    (tmp_path / ".daydream.toml").write_text('model = "from-dotfile"\n[phases.fix]\nbackend = "codex"\n')
+    cfg = load_file_config(tmp_path)
+    assert cfg.model == "from-dotfile"  # .daydream.toml overrides pyproject, per-key
+    assert cfg.phase_backend("fix") == "codex"
+    assert cfg.phase_model("review") is None
+
+
+def test_absent_config_is_empty(tmp_path: Path) -> None:
+    cfg = load_file_config(tmp_path)
+    assert cfg.model is None and cfg.backend is None and cfg.phase_model("fix") is None
+
+
+def test_malformed_toml_raises_valueerror(tmp_path: Path) -> None:
+    (tmp_path / ".daydream.toml").write_text("model = =bad")
+    with pytest.raises(ValueError, match=r"\.daydream\.toml"):
+        load_file_config(tmp_path)
+
+
+def test_per_key_merge_preserves_pyproject_phase(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.daydream]\nbackend = "claude"\n[tool.daydream.phases.review]\nmodel = "pyproject-review"\n'
+    )
+    (tmp_path / ".daydream.toml").write_text('[phases.fix]\nbackend = "codex"\n')
+    cfg = load_file_config(tmp_path)
+    # dotfile's [phases.fix] must not wipe pyproject's [phases.review]
+    assert cfg.phase_model("review") == "pyproject-review"
+    assert cfg.phase_backend("fix") == "codex"
+    assert cfg.backend == "claude"
+
+
+def test_empty_config_helper() -> None:
+    cfg = DaydreamFileConfig()
+    assert cfg.model is None and cfg.backend is None
+    assert cfg.phase_model("fix") is None and cfg.phase_backend("review") is None

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -249,6 +249,19 @@ def _silence(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
 
 
+def _force_interactive(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the run's interactivity axis to interactive for prompt-path tests.
+
+    ``runner.run`` now auto-resolves non-interactive from a non-TTY stdin or a
+    truthy ``CI`` env var (Task 4). Under pytest, stdin is not a TTY (and ``CI``
+    is set in CI), so a test that drives the REAL interactive prompt path must
+    explicitly establish a TTY stdin and unset ``CI`` -- otherwise the gate
+    short-circuits to its safe default and the interactive branch never runs.
+    """
+    monkeypatch.setattr("daydream.runner._stdin_isatty", lambda: True)
+    monkeypatch.delenv("CI", raising=False)
+
+
 def _install_stub_backend(
     monkeypatch: pytest.MonkeyPatch,
     target: Path,
@@ -1491,6 +1504,9 @@ async def test_heal_loop_receives_feedback_items_in_fix_prompt(
     monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_verification_summary", lambda *a, **kw: None)
+    # This test drives the REAL interactive heal menu; pin interactivity on so
+    # the auto non-interactive resolution (non-TTY pytest stdin) does not bypass it.
+    _force_interactive(monkeypatch)
     # Apply-fixes gate (orchestrator) -> "y".
     monkeypatch.setattr("daydream.deep.orchestrator.prompt_user", lambda *a, **kw: "y")
 
@@ -1829,6 +1845,11 @@ async def test_apply_fixes_gate_eof_declines_cleanly_no_crash(
         raise EOFError("simulated closed stdin")
 
     monkeypatch.setattr("builtins.input", _eof_input)
+
+    # Pin interactivity ON so this genuinely exercises the interactive EOF branch
+    # (input() -> EOFError), not the auto non-interactive short-circuit that the
+    # non-TTY pytest stdin would otherwise trigger.
+    _force_interactive(monkeypatch)
 
     # Sanity: this exercises the interactive branch, NOT the flag short-circuit.
     reset_state()

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -257,6 +257,9 @@ def _silence(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("daydream.deep.orchestrator.prompt_user", lambda *a, **kw: "n")
     # phase_understand_intent calls prompt_user("Is this understanding correct?", "y")
     monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
+    # resolve_or_prompt in agent.py calls prompt_user from its own namespace;
+    # patch it there too so gates that go through resolve_or_prompt don't block on stdin.
+    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "n")
 
 
 def _force_interactive(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -534,6 +537,9 @@ async def test_fix_gate_prompt(multi_stack_target: Path, monkeypatch: pytest.Mon
     monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.prompt_user", _record_prompt)
+    # resolve_or_prompt in agent.py calls prompt_user from its own namespace; patch it
+    # there too so the interactive gate is captured and returns "n".
+    monkeypatch.setattr("daydream.agent.prompt_user", _record_prompt)
     # phase_understand_intent also calls prompt_user; always confirm.
     monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
 
@@ -1378,6 +1384,7 @@ async def test_resolve_backend_called_with_each_phase_in_deep_flow(
     monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
     monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
 
     _install_stub_backend(monkeypatch, multi_stack_target)
@@ -1437,6 +1444,7 @@ async def test_verifier_runs_after_merge_before_fix(
     monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_verification_summary", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
     monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
 
     stub = _install_stub_backend(monkeypatch, multi_stack_target)
@@ -1513,6 +1521,7 @@ async def test_verifier_contradicts_propagates_to_fix_prompt(
     monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_verification_summary", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
     monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
 
     stub = _install_stub_backend(monkeypatch, multi_stack_target)
@@ -1579,6 +1588,9 @@ async def test_heal_loop_receives_feedback_items_in_fix_prompt(
     _force_interactive(monkeypatch)
     # Apply-fixes gate (orchestrator) -> "y".
     monkeypatch.setattr("daydream.deep.orchestrator.prompt_user", lambda *a, **kw: "y")
+    # resolve_or_prompt in agent.py calls prompt_user from its own namespace; patch
+    # it there too so the apply-fixes gate honours "y" when going through that path.
+    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
 
     # phases.prompt_user is shared: intent-confirmation needs "y"; the
     # test-and-heal menu ("Choice") needs "2" (fix-and-retry). Dispatch on the
@@ -1644,6 +1656,7 @@ async def test_structural_finding_reaches_fix_loop(
     monkeypatch.setattr("daydream.deep.orchestrator.print_verification_summary", lambda *a, **kw: None)
     # Accept the apply-fixes gate so the fix loop runs.
     monkeypatch.setattr("daydream.deep.orchestrator.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
     monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
 
     stub = _install_stub_backend(monkeypatch, multi_stack_target)
@@ -1728,6 +1741,7 @@ async def test_start_at_fix_recovers_merged_items(
     monkeypatch.setattr("daydream.deep.orchestrator.print_verification_summary", lambda *a, **kw: None)
     # Accept the apply-fixes gate so the fix loop runs.
     monkeypatch.setattr("daydream.deep.orchestrator.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
     monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
 
     _install_stub_backend(monkeypatch, multi_stack_target)

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -254,7 +254,6 @@ def _silence(monkeypatch: pytest.MonkeyPatch) -> None:
     """Silence interactive UI helpers in deep orchestrator + phases."""
     monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
-    monkeypatch.setattr("daydream.deep.orchestrator.prompt_user", lambda *a, **kw: "n")
     # phase_understand_intent calls prompt_user("Is this understanding correct?", "y")
     monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
     # resolve_or_prompt in agent.py calls prompt_user from its own namespace;
@@ -536,7 +535,6 @@ async def test_fix_gate_prompt(multi_stack_target: Path, monkeypatch: pytest.Mon
 
     monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
-    monkeypatch.setattr("daydream.deep.orchestrator.prompt_user", _record_prompt)
     # resolve_or_prompt in agent.py calls prompt_user from its own namespace; patch it
     # there too so the interactive gate is captured and returns "n".
     monkeypatch.setattr("daydream.agent.prompt_user", _record_prompt)
@@ -572,7 +570,6 @@ async def test_yes_auto_applies_fix(multi_stack_target: Path, monkeypatch: pytes
 
     monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
-    monkeypatch.setattr("daydream.deep.orchestrator.prompt_user", _record_prompt)
     # phase_understand_intent also calls prompt_user; assume="yes" should also
     # suppress that gate, so patch it to fail loudly if it is ever reached.
     monkeypatch.setattr(
@@ -614,7 +611,7 @@ async def test_preflight_notice(multi_stack_target: Path, monkeypatch: pytest.Mo
 
     monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", _capture)
-    monkeypatch.setattr("daydream.deep.orchestrator.prompt_user", lambda *a, **kw: "n")
+    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "n")
     monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
     _install_stub_backend(monkeypatch, multi_stack_target)
 
@@ -643,7 +640,7 @@ async def test_codex_cost_caveat(multi_stack_target: Path, monkeypatch: pytest.M
 
     monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", _capture)
-    monkeypatch.setattr("daydream.deep.orchestrator.prompt_user", lambda *a, **kw: "n")
+    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "n")
     monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
     _install_stub_backend(monkeypatch, multi_stack_target, is_codex=True)
 
@@ -753,7 +750,7 @@ async def test_stage_ui_surfacing(multi_stack_target: Path, monkeypatch: pytest.
 
     monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", _capture)
     monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
-    monkeypatch.setattr("daydream.deep.orchestrator.prompt_user", lambda *a, **kw: "n")
+    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "n")
     monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
     _install_stub_backend(monkeypatch, multi_stack_target)
 
@@ -1383,7 +1380,6 @@ async def test_resolve_backend_called_with_each_phase_in_deep_flow(
     _force_interactive(monkeypatch)
     monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
-    monkeypatch.setattr("daydream.deep.orchestrator.prompt_user", lambda *a, **kw: "y")
     monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
     monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
 
@@ -1443,7 +1439,6 @@ async def test_verifier_runs_after_merge_before_fix(
     monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_verification_summary", lambda *a, **kw: None)
-    monkeypatch.setattr("daydream.deep.orchestrator.prompt_user", lambda *a, **kw: "y")
     monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
     monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
 
@@ -1520,7 +1515,6 @@ async def test_verifier_contradicts_propagates_to_fix_prompt(
     monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_verification_summary", lambda *a, **kw: None)
-    monkeypatch.setattr("daydream.deep.orchestrator.prompt_user", lambda *a, **kw: "y")
     monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
     monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
 
@@ -1586,10 +1580,7 @@ async def test_heal_loop_receives_feedback_items_in_fix_prompt(
     # This test drives the REAL interactive heal menu; pin interactivity on so
     # the auto non-interactive resolution (non-TTY pytest stdin) does not bypass it.
     _force_interactive(monkeypatch)
-    # Apply-fixes gate (orchestrator) -> "y".
-    monkeypatch.setattr("daydream.deep.orchestrator.prompt_user", lambda *a, **kw: "y")
-    # resolve_or_prompt in agent.py calls prompt_user from its own namespace; patch
-    # it there too so the apply-fixes gate honours "y" when going through that path.
+    # Apply-fixes gate routes through resolve_or_prompt → agent.prompt_user.
     monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
 
     # phases.prompt_user is shared: intent-confirmation needs "y"; the
@@ -1655,7 +1646,6 @@ async def test_structural_finding_reaches_fix_loop(
     monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_verification_summary", lambda *a, **kw: None)
     # Accept the apply-fixes gate so the fix loop runs.
-    monkeypatch.setattr("daydream.deep.orchestrator.prompt_user", lambda *a, **kw: "y")
     monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
     monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
 
@@ -1740,7 +1730,6 @@ async def test_start_at_fix_recovers_merged_items(
     monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_verification_summary", lambda *a, **kw: None)
     # Accept the apply-fixes gate so the fix loop runs.
-    monkeypatch.setattr("daydream.deep.orchestrator.prompt_user", lambda *a, **kw: "y")
     monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
     monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
 

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -191,6 +191,16 @@ class _StubBackend:
             )
             return
 
+        # phase_fix -> apply the fix. The stub "applies" the edit by writing a
+        # sentinel file in the repo, an observable consequence the real-path
+        # --yes test asserts on (proving the fix gate auto-approved, not merely
+        # that resolve_gate was called). Keyed on the phase_fix prompt opener.
+        if pl.startswith("fix this issue"):
+            (cwd / ".daydream-fix-applied").write_text("applied\n")
+            yield TextEvent(text="Applied the fix.")
+            yield ResultEvent(structured_output=None, continuation=None)
+            return
+
         # Recommendation verifier (issue #83). Discriminator: build_verification_prompt
         # always embeds the schema constant name "RECOMMENDATION_VERDICTS_SCHEMA" in
         # the prompt text (via json.dumps). This is structural — tied to the schema
@@ -509,6 +519,10 @@ async def test_cross_stack_prefix(multi_stack_target: Path, monkeypatch: pytest.
 async def test_fix_gate_prompt(multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """D-28: Y/n prompt after merge decides whether to apply fixes."""
     _install_stub_backend(monkeypatch, multi_stack_target)
+    # The fix gate now routes through resolve_gate; under a non-TTY/CI run it
+    # short-circuits to its safe default (decline) WITHOUT prompting. This test
+    # asserts the interactive prompt path, so pin interactivity on.
+    _force_interactive(monkeypatch)
 
     asked: list[str] = []
 
@@ -527,6 +541,54 @@ async def test_fix_gate_prompt(multi_stack_target: Path, monkeypatch: pytest.Mon
     assert exit_code == 0
     # At least one prompt message must mention the fix gate.
     assert any("fix" in msg.lower() or "apply" in msg.lower() for msg in asked)
+
+
+async def test_yes_auto_applies_fix(multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Task 6 real-path: ``--yes`` (assume="yes") auto-applies fixes without prompting.
+
+    Drives ``runner.run`` through the deep orchestrator's fix gate with
+    ``assume="yes"``. The gate must NOT call ``prompt_user`` and MUST proceed to
+    ``phase_fix`` — the observable consequence is the sentinel file the stub
+    writes when it receives a fix prompt.
+    """
+    from daydream.runner import RunConfig, run
+
+    _install_stub_backend(monkeypatch, multi_stack_target)
+
+    fix_marker = multi_stack_target / ".daydream-fix-applied"
+    assert not fix_marker.exists()
+
+    prompt_calls: list[tuple[Any, ...]] = []
+
+    def _record_prompt(console, message, default=""):
+        prompt_calls.append((message, default))
+        return default
+
+    monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.deep.orchestrator.prompt_user", _record_prompt)
+    # phase_understand_intent also calls prompt_user; assume="yes" should also
+    # suppress that gate, so patch it to fail loudly if it is ever reached.
+    monkeypatch.setattr(
+        "daydream.phases.prompt_user",
+        lambda *a, **kw: (_ for _ in ()).throw(AssertionError("phases.prompt_user called under --yes")),
+    )
+
+    config = RunConfig(
+        target=str(multi_stack_target),
+        assume="yes",
+        output_mode="loop",
+        cleanup=False,
+    )
+    exit_code = await run(config)
+
+    assert exit_code == 0
+    # The fix gate never prompted.
+    assert not any(
+        "apply" in msg.lower() or "fix" in msg.lower() for msg, _ in prompt_calls
+    ), f"fix gate prompted under --yes: {prompt_calls}"
+    # Observable consequence: the fix landed.
+    assert fix_marker.exists(), "phase_fix never ran -> --yes did not auto-apply"
 
 
 async def test_preflight_notice(multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1309,6 +1371,10 @@ async def test_resolve_backend_called_with_each_phase_in_deep_flow(
     monkeypatch.setattr("daydream.runner._resolve_backend", spy)
 
     # Silence interactive UI but accept the fix gate so fix/test/commit run.
+    # The fix gate routes through resolve_gate; pin interactivity so the "y"
+    # prompt stub is honoured instead of short-circuiting to the unattended
+    # decline default.
+    _force_interactive(monkeypatch)
     monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.prompt_user", lambda *a, **kw: "y")
@@ -1365,6 +1431,8 @@ async def test_verifier_runs_after_merge_before_fix(
     from daydream.deep.artifacts import verdicts_path
 
     # Silence interactive UI but accept the fix gate so the fix loop runs.
+    # Pin interactivity so the resolve_gate fix gate honours the "y" stub.
+    _force_interactive(monkeypatch)
     monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_verification_summary", lambda *a, **kw: None)
@@ -1439,6 +1507,8 @@ async def test_verifier_contradicts_propagates_to_fix_prompt(
     feedback item, the orchestrator attaches the verdict and phase_fix inlines
     `Verifier verdict: contradicts` into the fix-agent prompt.
     """
+    # Pin interactivity so the resolve_gate fix gate honours the "y" stub.
+    _force_interactive(monkeypatch)
     monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_verification_summary", lambda *a, **kw: None)
@@ -1567,6 +1637,8 @@ async def test_structural_finding_reaches_fix_loop(
     markdown re-parse), and items MUST arrive severity-ordered (high before low,
     stable within a tier).
     """
+    # Pin interactivity so the resolve_gate fix gate honours the "y" stub.
+    _force_interactive(monkeypatch)
     monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_verification_summary", lambda *a, **kw: None)
@@ -1649,6 +1721,8 @@ async def test_start_at_fix_recovers_merged_items(
     """
     from daydream.config import REVIEW_OUTPUT_FILE
 
+    # Pin interactivity so the resolve_gate fix gate honours the "y" stub.
+    _force_interactive(monkeypatch)
     monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_verification_summary", lambda *a, **kw: None)

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -570,6 +570,9 @@ async def test_yes_auto_applies_fix(multi_stack_target: Path, monkeypatch: pytes
 
     monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
+    # The fix gate routes through resolve_or_prompt -> daydream.agent.prompt_user,
+    # so observe that namespace; under --yes it must never be reached.
+    monkeypatch.setattr("daydream.agent.prompt_user", _record_prompt)
     # phase_understand_intent also calls prompt_user; assume="yes" should also
     # suppress that gate, so patch it to fail loudly if it is ever reached.
     monkeypatch.setattr(

--- a/tests/test_deep_pr_comment_integration.py
+++ b/tests/test_deep_pr_comment_integration.py
@@ -551,12 +551,24 @@ def _silence_ui(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def _answer_prompts(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Phase prompts: y for intent confirmation; n for fix gate + PR post.
+    """Phase prompts: y for intent confirmation + PR post; n for fix gate.
 
-    The PR-post prompt lives in ``daydream.pr_review.prompt_user`` and asks
-    "Post these as a PR review? [y/N]" — we MUST answer ``y`` or the test
-    never reaches ``_submit_review``.
+    In pytest stdin is not a TTY, so ``runner._resolve_interactive`` returns
+    False and ``set_non_interactive(True)`` is called. Every gate that uses
+    ``resolve_or_prompt(safe_default=False)`` then auto-declines without
+    prompting -- including the PR-post gate. We must force interactive mode
+    the same way ``_force_interactive`` does (in test_deep_orchestrator.py).
+
+    Both the orchestrator fix gate ("Apply fixes now?") and the PR-post gate
+    ("Post these as a PR review?") route through resolve_or_prompt in agent.py,
+    which calls prompt_user from its own (agent) namespace. We dispatch on the
+    question text so the fix gate gets "n" (skip fixes) and PR-post gets "y".
     """
+    # Force interactive mode so resolve_gate defers to prompt_user instead of
+    # short-circuiting to the safe_default=False decline.
+    monkeypatch.setattr("daydream.runner._stdin_isatty", lambda: True)
+    monkeypatch.delenv("CI", raising=False)
+
     monkeypatch.setattr(
         "daydream.phases.prompt_user", lambda *a, **kw: "y", raising=False,
     )
@@ -572,6 +584,20 @@ def _answer_prompts(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     monkeypatch.setattr(
         "daydream.runner.prompt_user", lambda *a, **kw: "n", raising=False,
+    )
+
+    def _agent_prompt(console, message: str, default: str = "") -> str:  # noqa: ARG001
+        # Fix gate: decline so the flow proceeds to PR post without applying fixes.
+        if "apply fixes" in message.lower() or "apply fix" in message.lower():
+            return "n"
+        # PR post gate: approve so _submit_review is reached.
+        if "post these" in message.lower() or "pr review" in message.lower():
+            return "y"
+        # All other gates (phase understand intent, intent confirmation, etc.)
+        return "y"
+
+    monkeypatch.setattr(
+        "daydream.agent.prompt_user", _agent_prompt, raising=False,
     )
 
 

--- a/tests/test_interaction_gate.py
+++ b/tests/test_interaction_gate.py
@@ -1,0 +1,36 @@
+"""Pure resolution truth table for the orthogonal interaction gate.
+
+``resolve_gate`` collapses two orthogonal axes — *assume* (a forced
+yes/no answer, e.g. ``--yes``) and *interactivity* (may we block on
+stdin?) — into a single decision: ``True``/``False`` to use directly, or
+``None`` to fall back to an interactive prompt. This is a fast pure unit
+test that *supplements* the real-path fix-gate test in
+``test_deep_orchestrator.py`` (it never replaces it).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from daydream.agent import resolve_gate
+
+
+@pytest.mark.parametrize(
+    "assume,interactive,expected",
+    [
+        (None, True, None),  # interactive, no assumption -> prompt
+        (None, False, False),  # unattended, no assumption -> safe default (decline)
+        ("yes", True, True),  # explicit yes wins even on a TTY
+        ("yes", False, True),  # CI --yes -> unattended auto-apply
+        ("no", False, False),  # explicit no
+        ("no", True, False),  # explicit no wins even on a TTY
+    ],
+)
+def test_resolve_gate(assume: str | None, interactive: bool, expected: bool | None) -> None:
+    assert resolve_gate(assume=assume, interactive=interactive, safe_default=False) is expected
+
+
+def test_resolve_gate_safe_default_true_when_unattended() -> None:
+    # A gate whose unattended safe default is "yes" (e.g. auto-commit) returns
+    # True when there's no assumption and we cannot prompt.
+    assert resolve_gate(assume=None, interactive=False, safe_default=True) is True

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -1265,6 +1265,10 @@ class _SummarizerBackend(_ScriptedBackend):
         if entry == "fail":
             yield TextEvent(text="1 failed, 0 passed")
             yield ResultEvent(structured_output=None, continuation=None)
+        elif entry == "fix":
+            # Simulate a fix-agent response (output discarded by caller).
+            yield TextEvent(text="Applied fix attempt")
+            yield ResultEvent(structured_output=None, continuation=None)
         elif isinstance(entry, tuple) and entry[0] == "handoff":
             yield ResultEvent(
                 structured_output={"handoff_prompt": entry[1]}, continuation=None,
@@ -1939,6 +1943,115 @@ async def test_phase_test_and_heal_non_interactive_fallback_has_facts_hypotheses
         assert "unknown" in body.lower()
         # The summarizer still ran read-only even on the abort branch.
         assert backend.read_only_calls == [False, True]
+        prompt_sentinel.assert_not_called()
+    finally:
+        reset_state()
+
+
+# ---------------------------------------------------------------------------
+# phase_test_and_heal — --yes bounded auto fix-and-retry (Task assume="yes")
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_phase_test_and_heal_yes_bounded_loop_exactly_one_auto_attempt(
+    tmp_path, monkeypatch, make_work,
+):
+    """``--yes`` (assume="yes") triggers exactly ONE auto fix attempt then aborts.
+
+    Observable contract:
+    - Tests fail → fix agent runs once (retries_used becomes 1).
+    - Tests fail again → ``retries_used > 0`` guard fires → loop terminates.
+    - ``prompt_user`` is never called (no interactive menu).
+    - Total backend calls: 1 (test) + 1 (fix) + 1 (test) + 1 (summarizer) = 4.
+    - Return value is ``(False, 1)``.
+
+    This exercises the real code path at lines 1777-1791 of phases.py that
+    implements the bounded-loop invariant: ``decision is True and retries_used > 0``
+    → abort, preventing an unbounded mutating fix loop under ``--yes``.
+    """
+    from daydream.agent import reset_state, set_assume
+    from daydream.phases import phase_test_and_heal
+
+    reset_state()
+    set_assume("yes")
+    try:
+        _silence_phase_io(monkeypatch)
+        _install_recorder(monkeypatch, tmp_path)
+
+        # Sentinel: the menu must never be shown in auto mode.
+        from unittest.mock import Mock
+
+        prompt_sentinel = Mock(
+            side_effect=AssertionError("prompt_user must not be called under --yes"),
+        )
+        monkeypatch.setattr("daydream.phases.prompt_user", prompt_sentinel)
+
+        # Script: fail → fix (no-op) → fail → handoff (summarizer).
+        # Four calls total; any extra call raises AssertionError via the backend.
+        call_log: list[str] = []
+
+        class _BoundedLoopBackend:
+            model = "test-model"
+            read_only_calls: list[bool] = []
+
+            async def execute(
+                self,
+                cwd,
+                prompt,
+                output_schema=None,
+                continuation=None,
+                agents=None,
+                max_turns=None,
+                read_only=False,
+            ):
+                call_log.append(prompt)
+                self.read_only_calls.append(read_only)
+                n = len(call_log)
+                if n == 1:
+                    # Initial test run → fail.
+                    yield TextEvent(text="1 failed, 0 passed")
+                    yield ResultEvent(structured_output=None, continuation=None)
+                elif n == 2:
+                    # Auto fix agent — returns without passing tests.
+                    yield TextEvent(text="Applied fix attempt")
+                    yield ResultEvent(structured_output=None, continuation=None)
+                elif n == 3:
+                    # Second test run → still fails.
+                    yield TextEvent(text="1 failed, 0 passed")
+                    yield ResultEvent(structured_output=None, continuation=None)
+                elif n == 4:
+                    # Read-only failure summarizer (abort path).
+                    yield ResultEvent(
+                        structured_output={"handoff_prompt": "# Handoff\nauto-mode failure"},
+                        continuation=None,
+                    )
+                else:
+                    raise AssertionError(f"backend called more than 4 times (call #{n})")
+
+            async def cancel(self):
+                pass
+
+            def format_skill_invocation(self, skill_key, args=""):
+                return f"/{skill_key}"
+
+        backend = _BoundedLoopBackend()
+        success, retries = await phase_test_and_heal(backend, make_work(tmp_path))
+
+        # Loop terminated after exactly one auto fix attempt.
+        assert success is False
+        assert retries == 1
+
+        # Exactly 4 backend calls: test → fix → test → summarizer.
+        assert len(call_log) == 4, f"Expected 4 backend calls, got {len(call_log)}: {call_log!r}"
+
+        # The fix prompt (call 2) contains the repair instruction.
+        assert "Analyze the failures and fix them" in call_log[1], call_log[1]
+
+        # The summarizer (call 4) ran read-only; the test runs did not.
+        assert backend.read_only_calls == [False, False, False, True], backend.read_only_calls
+
+        # The interactive menu was never consulted.
         prompt_sentinel.assert_not_called()
     finally:
         reset_state()

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -491,6 +491,70 @@ async def test_phase_understand_intent_correction_then_confirm(tmp_path, monkeyp
     assert "login" in result.lower()
 
 
+async def test_phase_understand_intent_forced_no_interactive_falls_through(tmp_path, monkeypatch, make_work):
+    """A forced ``no`` (assume="no") in interactive mode must enter the correction flow.
+
+    Regression: ``resolve_gate`` returns False for assume="no", and the gate
+    previously short-circuited on ``gate is not None`` — accepting the
+    understanding without ever offering a correction. The fix falls through to
+    the prompt when interactive, so the user is consulted. Observable: the
+    correction prompt is reached (prompt_user is called), not bypassed.
+    """
+    from daydream.agent import reset_state, set_assume
+    from daydream.phases import phase_understand_intent
+
+    monkeypatch.setattr("daydream.phases.print_phase_hero", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.phases.print_info", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.phases.console", type("C", (), {"print": lambda *a, **kw: None})())
+
+    reset_state()
+    set_assume("no")
+    try:
+        call_count = 0
+
+        class IntentBackend:
+            model = "test-model"
+
+            async def execute(
+                self, cwd, prompt, output_schema=None, continuation=None, agents=None,
+                max_turns=None, read_only=False,
+            ):
+                nonlocal call_count
+                call_count += 1
+                yield TextEvent(text="This PR adds a signup page.")
+                yield ResultEvent(structured_output=None, continuation=None)
+
+            async def cancel(self):
+                pass
+
+            def format_skill_invocation(self, skill_key, args=""):
+                return f"/{skill_key}"
+
+        prompt_calls: list[str] = []
+
+        def _record(console, message, default=""):
+            prompt_calls.append(message)
+            return "y"
+
+        monkeypatch.setattr("daydream.phases.prompt_user", _record)
+
+        diff_file = tmp_path / "diff.patch"
+        diff_file.write_text("diff --git ...")
+
+        result = await phase_understand_intent(
+            IntentBackend(), make_work(tmp_path),
+            diff_path=diff_file,
+            log="abc1234 add signup",
+            branch="feat/signup",
+        )
+
+        # The forced "no" did not bypass the gate: the correction prompt was reached.
+        assert prompt_calls, "forced 'no' short-circuited without offering a correction"
+        assert "signup" in result.lower()
+    finally:
+        reset_state()
+
+
 def test_parse_issue_selection_all():
     from daydream.phases import _parse_issue_selection
     issues = [{"id": 1}, {"id": 2}, {"id": 3}]
@@ -1861,6 +1925,7 @@ async def test_phase_test_and_heal_non_interactive_writes_handoff_without_menu(
             side_effect=AssertionError("prompt_user must not be called in non-interactive mode"),
         )
         monkeypatch.setattr("daydream.phases.prompt_user", prompt_sentinel)
+        monkeypatch.setattr("daydream.agent.prompt_user", prompt_sentinel)
 
         # First call: failing test run (menu would otherwise appear). Second
         # call: the read-only failure-summarizer producing the handoff body —
@@ -1928,6 +1993,7 @@ async def test_phase_test_and_heal_non_interactive_fallback_has_facts_hypotheses
             side_effect=AssertionError("prompt_user must not be called in non-interactive mode"),
         )
         monkeypatch.setattr("daydream.phases.prompt_user", prompt_sentinel)
+        monkeypatch.setattr("daydream.agent.prompt_user", prompt_sentinel)
 
         backend = _SummarizerBackend(["fail", ("raise", RuntimeError)])
 
@@ -1986,6 +2052,7 @@ async def test_phase_test_and_heal_yes_bounded_loop_exactly_one_auto_attempt(
             side_effect=AssertionError("prompt_user must not be called under --yes"),
         )
         monkeypatch.setattr("daydream.phases.prompt_user", prompt_sentinel)
+        monkeypatch.setattr("daydream.agent.prompt_user", prompt_sentinel)
 
         # Script: fail → fix (no-op) → fail → handoff (summarizer).
         # Four calls total; any extra call raises AssertionError via the backend.

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -879,6 +879,8 @@ async def test_phase_commit_push_includes_daydream_trailers(tmp_path, monkeypatc
     monkeypatch.setattr("daydream.phases.print_success", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.phases.console", type("C", (), {"print": lambda *a, **kw: None})())
     monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
+    # _do_commit uses resolve_or_prompt which calls prompt_user from agent's namespace.
+    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
 
     captured: dict[str, str] = {}
 
@@ -1068,11 +1070,11 @@ async def test_phase_test_and_heal_option1_verdict_replace_user_confirms(
         "pass",
     ])
 
-    # First prompt_user call: "Choice" -> "1". Second: confirm "y".
-    answers = iter(["1", "y"])
-    monkeypatch.setattr(
-        "daydream.phases.prompt_user", lambda *a, **kw: next(answers, "3"),
-    )
+    # First prompt_user call: "Choice" -> "1" (goes through phases.prompt_user).
+    # Second: "Use suggested command?" -> "y" goes through resolve_or_prompt
+    # which calls agent.prompt_user, not phases.prompt_user.
+    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "1")
+    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
 
     success, retries = await phase_test_and_heal(backend, make_work(tmp_path))
 
@@ -1104,10 +1106,10 @@ async def test_phase_test_and_heal_option1_verdict_replace_user_declines(
         "pass",
     ])
 
-    answers = iter(["1", "n"])
-    monkeypatch.setattr(
-        "daydream.phases.prompt_user", lambda *a, **kw: next(answers, "3"),
-    )
+    # "Choice" -> "1" via phases.prompt_user; "Use suggested command?" -> "n"
+    # via agent.prompt_user (resolve_or_prompt routes through agent's namespace).
+    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "1")
+    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "n")
 
     success, retries = await phase_test_and_heal(backend, make_work(tmp_path))
 
@@ -1360,11 +1362,10 @@ async def test_phase_test_and_heal_option4_clipboard_offer_fires_on_confirm(
         ("handoff", "BODY"),
     ])
 
-    # Choice "4" then clipboard "y"
-    answers = iter(["4", "y"])
-    monkeypatch.setattr(
-        "daydream.phases.prompt_user", lambda *a, **kw: next(answers, "n"),
-    )
+    # "Choice" -> "4" via phases.prompt_user (direct call).
+    # Clipboard confirm -> "y" via agent.prompt_user (resolve_or_prompt path).
+    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "4")
+    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
 
     success, _ = await phase_test_and_heal(backend, make_work(tmp_path))
 
@@ -1995,10 +1996,9 @@ async def test_phase_test_and_heal_option1_strips_backticks_from_retry_prompt(
         "pass",
     ])
 
-    answers = iter(["1", "y"])
-    monkeypatch.setattr(
-        "daydream.phases.prompt_user", lambda *a, **kw: next(answers, "3"),
-    )
+    # "Choice" -> "1" via phases.prompt_user; confirm "y" via agent.prompt_user.
+    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "1")
+    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
 
     success, retries = await phase_test_and_heal(backend, make_work(tmp_path))
 
@@ -2042,6 +2042,7 @@ async def test_phase_test_and_heal_option1_shows_suggested_command_before_confir
 
     # Capture the order: info messages relative to the y/n prompt.
     prompt_called_at: list[int] = []
+    prompt_called_at_choice: list[bool] = []
 
     def _prompt(*_args, **_kw):
         prompt_called_at.append(len(infos))
@@ -2051,8 +2052,12 @@ async def test_phase_test_and_heal_option1_shows_suggested_command_before_confir
             return "1"  # menu Choice
         return "n"
 
-    prompt_called_at_choice: list[bool] = []
+    # Menu choice ("Choice") goes through phases.prompt_user (direct call).
     monkeypatch.setattr("daydream.phases.prompt_user", _prompt)
+    # Confirm gate ("Use suggested command?") goes through agent.prompt_user
+    # (via resolve_or_prompt). Route it through the same _prompt so
+    # prompt_called_at tracks both calls and the ordering assertion holds.
+    monkeypatch.setattr("daydream.agent.prompt_user", _prompt)
 
     backend = _InvestigatorBackend([
         "fail",

--- a/tests/test_pr_review.py
+++ b/tests/test_pr_review.py
@@ -398,7 +398,7 @@ async def test_post_succeeds_and_prints_url(
             body_only=[],
         ),
     )
-    monkeypatch.setattr(pr_review, "prompt_user", lambda *_a, **_k: "y")
+    monkeypatch.setattr(pr_review, "resolve_or_prompt", lambda **_k: True)
 
     captured: dict[str, Any] = {}
 
@@ -442,7 +442,7 @@ async def test_post_warns_with_preserved_payload_path_on_failure(
             body_only=[],
         ),
     )
-    monkeypatch.setattr(pr_review, "prompt_user", lambda *_a, **_k: "y")
+    monkeypatch.setattr(pr_review, "resolve_or_prompt", lambda **_k: True)
     err = "gh api /repos/acme/widgets/pulls/42/reviews failed: HTTP 422 (payload preserved at /tmp/x.json)"
     monkeypatch.setattr(
         pr_review, "_submit_review", lambda *_a, **_k: (None, err)
@@ -479,7 +479,7 @@ async def test_post_skipped_when_user_declines(
             body_only=[],
         ),
     )
-    monkeypatch.setattr(pr_review, "prompt_user", lambda *_a, **_k: "n")
+    monkeypatch.setattr(pr_review, "resolve_or_prompt", lambda **_k: False)
     submit_called = False
 
     def fake_submit(*_a: Any, **_k: Any) -> tuple[str | None, str | None]:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -671,9 +671,17 @@ async def test_non_interactive_shallow_failing_tests_write_handoff_no_fix(monkey
     -- whose ``_build_fix_prompt`` text ("Analyze the failures and fix them",
     asserted absent) -- and ``prompt_user`` would read stdin (rigged to fail).
     """
+    import importlib
+    import sys
+    from pathlib import Path as _Path
+
+    _tests_dir = str(_Path(__file__).parent)
+    if _tests_dir not in sys.path:
+        sys.path.insert(0, _tests_dir)
+    _SummarizerBackend = importlib.import_module("test_phases")._SummarizerBackend
+
     from daydream.agent import reset_state, set_non_interactive
     from daydream.config import REVIEW_OUTPUT_FILE
-    from tests.test_phases import _SummarizerBackend
 
     (tmp_path / REVIEW_OUTPUT_FILE).write_text("## Issues\n\n1. foo.py:1 - X\n")
 
@@ -762,3 +770,122 @@ async def test_non_interactive_shallow_failing_tests_write_handoff_no_fix(monkey
     assert all(
         "Analyze the failures and fix them" not in p for p in test_backend.captured_prompts
     ), test_backend.captured_prompts
+
+
+@pytest.mark.asyncio
+async def test_yes_shallow_failing_tests_bounded_fix_and_abort(monkeypatch, tmp_path):
+    """Real-path: a --yes shallow run whose tests FAIL runs ONE fix attempt then aborts.
+
+    Drives ``_run_loop_shallow`` with the REAL ``phase_test_and_heal`` (not stubbed)
+    against a scripted backend: fail → fix → fail → handoff (summarizer).
+
+    With ``assume="yes"`` the bounded-loop guard at phases.py line 1777
+    (``decision is True and retries_used > 0``) must fire after the first auto
+    fix attempt, writing ``handoff.md`` and returning exit code 1. If the guard
+    were absent, the fix agent would loop forever (the backend raises on call 5).
+    The fix prompt text ("Analyze the failures and fix them") must appear in
+    exactly one call (the fix agent), proving the fix ran once and only once.
+    stdin must never be touched.
+    """
+    import importlib
+    import sys
+    from pathlib import Path as _Path
+
+    _tests_dir = str(_Path(__file__).parent)
+    if _tests_dir not in sys.path:
+        sys.path.insert(0, _tests_dir)
+    _SummarizerBackend = importlib.import_module("test_phases")._SummarizerBackend
+
+    from daydream.agent import reset_state, set_assume
+    from daydream.config import REVIEW_OUTPUT_FILE
+
+    (tmp_path / REVIEW_OUTPUT_FILE).write_text("## Issues\n\n1. foo.py:1 - X\n")
+
+    work = _fake_work(tmp_path)
+
+    # Script: fail → fix (one bounded attempt) → fail → handoff (summarizer).
+    # Any 5th call raises via _SummarizerBackend's guard, proving the loop ends.
+    test_backend = _SummarizerBackend([
+        "fail",
+        "fix",
+        "fail",
+        ("handoff", "# Handoff\n\n--yes bounded fix failure"),
+    ])
+
+    class _StubBackend:
+        model = "stub-model"
+
+    def _resolve(_config, phase, _cache=None):
+        return test_backend if phase == "test" else _StubBackend()
+
+    monkeypatch.setattr("daydream.runner._resolve_backend", _resolve)
+
+    async def _stub_phase_parse_feedback(_backend, _work):
+        return [{"id": 1, "description": "X", "file": "foo.py", "line": 1}]
+
+    async def _stub_phase_fix(*_args, **_kwargs):
+        return None
+
+    commit_calls: list[bool] = []
+
+    async def _spy_phase_commit_push_auto(*_args, **_kwargs):
+        commit_calls.append(True)
+
+    async def _spy_phase_commit_push(*_args, **_kwargs):
+        commit_calls.append(True)
+
+    monkeypatch.setattr("daydream.runner.phase_parse_feedback", _stub_phase_parse_feedback)
+    monkeypatch.setattr("daydream.runner.phase_fix", _stub_phase_fix)
+    monkeypatch.setattr("daydream.runner.phase_commit_push_auto", _spy_phase_commit_push_auto)
+    monkeypatch.setattr("daydream.runner.phase_commit_push", _spy_phase_commit_push)
+
+    def _forbidden_input(*_a: Any, **_kw: Any) -> str:
+        raise AssertionError("input() must not be called under --yes")
+
+    monkeypatch.setattr("builtins.input", _forbidden_input)
+
+    monkeypatch.setattr("daydream.runner.print_phase_hero", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.runner.print_dim", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.runner.print_info", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.runner.print_warning", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.runner.print_error", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.runner.print_summary", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.runner.print_skipped_phases", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        "daydream.phases.console",
+        type("C", (), {"print": lambda *a, **kw: None})(),
+    )
+
+    config = RunConfig(
+        target=str(tmp_path),
+        start_at="fix",
+        cleanup=False,
+        loop=False,
+        shallow=True,
+        assume="yes",
+    )
+
+    reset_state()
+    set_assume("yes")
+    try:
+        exit_code = await runner._run_loop_shallow(work, config)
+    finally:
+        reset_state()
+
+    assert exit_code == 1
+
+    handoffs = list(tmp_path.glob(".daydream/runs/*/handoff.md"))
+    assert len(handoffs) == 1, f"expected exactly one handoff.md, got {handoffs!r}"
+    assert handoffs[0].read_text(encoding="utf-8") == "# Handoff\n\n--yes bounded fix failure"
+
+    assert commit_calls == [], "a commit ran despite tests failing"
+
+    # Exactly four test-backend calls: fail → fix → fail → summarizer.
+    # The fix prompt (call 2) carries the repair instruction; the summarizer
+    # (call 4) ran read-only. No 5th call (bounded-loop guard fired).
+    assert len(test_backend.captured_prompts) == 4, test_backend.captured_prompts
+    assert "Analyze the failures and fix them" in test_backend.captured_prompts[1]
+    assert "read-only failure-summarizer" in test_backend.captured_prompts[3]
+    assert test_backend.read_only_calls == [False, False, False, True], (
+        test_backend.read_only_calls
+    )

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -585,7 +585,13 @@ async def test_non_interactive_shallow_calls_phase_commit_push_auto(monkeypatch,
     on which commit function was actually invoked (observable side effect),
     rather than asserting on dispatch bookkeeping.
     """
+    from daydream.agent import set_non_interactive
     from daydream.config import REVIEW_OUTPUT_FILE
+
+    # The commit gate reads the agent singleton (set by run() from config), not
+    # config.non_interactive directly. This test enters at _run_loop_shallow,
+    # below run()'s set_non_interactive call, so establish the global here.
+    set_non_interactive(True)
 
     (tmp_path / REVIEW_OUTPUT_FILE).write_text("## Issues\n\n1. foo.py:1 - X\n")
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -333,8 +333,8 @@ class TestResolveBackendPhaseModel:
         assert backend.model == "gpt-5.5"
 
     def test_backend_override_uses_overridden_backends_table(self):
-        # --review-backend codex while default is claude: resolver should look up
-        # the codex table for review, not the claude one.
+        # review_backend=codex (config/programmatic) while default is claude:
+        # resolver should look up the codex table for review, not the claude one.
         config = RunConfig(backend="claude", review_backend="codex")
         backend = runner._resolve_backend(config, "review")
         assert backend.model == "gpt-5.5"  # codex REVIEW default (v1)


### PR DESCRIPTION
## Summary

Redesigns the daydream CLI from a flat ~29-flag surface into a **verb-first** interface with a two-tier help system, moving per-phase tuning into a config file and the RL/corpus pipeline into its own `corpus` namespace. The two golden paths become trivial (CI review: 6 flags → 1; local deep: `daydream /path`) while power/maintainer surface is tucked behind `--help-all` and verb namespaces. Closes the verb-first epic (#140).

## Changes

### Added
- **Verb-first dispatch** (`daydream review|feedback|corpus|...`) with a default-verb shim so `daydream /path` and `daydream --comment ...` keep working by injecting `review`.
- **Config-file loader** (`daydream/config_file.py`): `.daydream.toml` or `[tool.daydream]` in `pyproject.toml`, with `[tool.daydream.phases.<phase>]` tables for per-phase model/backend control.
- **Global `--model` / `--backend`** flags restored as the single common knob.
- **Two-tier help**: common flags in `--help`, advanced surface (`--start-at`, `--trajectory`, `--ignore-path`, `--copy`, `--worktree`, `--plan`, `--cleanup`, `--no-archive`, `--eval`, `--non-interactive`) behind `--help-all`.
- **`--yes`** flag (orthogonal to `--non-interactive`) to auto-apply fixes, with a bounded auto-fix loop.
- **`corpus` namespace** for the data pipeline (`harvest`, `build`, `label`).
- `resolve_or_prompt()` / `resolve_gate` in `agent.py` centralising all interactive-gate logic into one tested path.

### Changed
- Phase model/backend resolution precedence: **CLI (`--model`/`--backend`) > config file (phase > global) > built-in default**.
- `--loop [N]` now folds in the old `--max-iterations` (single knob for repeat rounds).
- Non-interactive mode auto-detected from non-TTY / `CI` env.
- README + CLAUDE.md rewritten around verb-first golden paths and the config file.

### Removed (breaking)
- **8 per-phase backend/model CLI flags** (`--review-backend`, `--fix-backend`, `--test-backend`, `--exploration-model`, `--review-model`, `--parse-model`, `--fix-model`, `--test-model`) → moved to the config file.
- **Top-level data-pipeline verbs** (`harvest`, `build-corpus`, `label`) → moved under `corpus`.
- **`DAYDREAM_MODEL` / `DAYDREAM_BACKEND` env tier**: a redundant global-only middle tier strictly less capable than the config file and the sole source of a precedence bug. Collapsing to `CLI > config file > default` removes the asymmetry entirely. (This deviates from #140's proposed `CLI > env > config` precedence — see Motivation.)

### Fixed
- `gate is not None` guard so intent is returned on both accepted and rejected interactive responses.
- Manifest→runner→archive circular import broken via call-site import in `build_manifest`.
- Bare `corpus` → stdout (exit 2); unknown sub-verb → stderr (exit 2); error path no longer imports `daydream.ui`.
- `_normalize_loop_argv` uses `int()` (not `.isdigit()`) so signed counts like `--loop -3` are rejected; `--loop 0` no longer silently coerced to the default.
- `phase_understand_intent` forced-no returns early instead of falling through to a stdin read (prevents CI hangs).

## Motivation

`daydream --help` is the first impression for an OSS tool, and it buried the ~5 flags a newcomer needs under internal RL/corpus machinery and per-phase tuning. The redesign separates the three audiences (newcomer / power user / maintainer) into distinct namespaces and help tiers (#140).

The env-tier removal goes beyond the issue's plan: the issue specified `CLI > DAYDREAM_* env > config file`, but the env vars were strictly less capable than the config file (no per-phase granularity), added a precedence question with no clear use case for a local-dev CLI, and were the sole source of a bug where backend and model disagreed on whether env outranked a per-phase config override. Dropping the tier dissolves the asymmetry rather than re-litigating the ordering.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed

New/updated real-path coverage drives the production entrypoints (`runner.run` / CLI) through the changed decision points:
- `tests/test_cli_verbs.py`, `tests/test_cli_corpus_namespace.py`, `tests/test_cli_help_tiers.py`, `tests/test_cli_main_integration.py` — verb dispatch, corpus namespace, help tiers, `main()` integration.
- `tests/test_cli_config_precedence.py`, `tests/test_config_file.py` — config-file loading and CLI > config > default precedence, including a regression guard asserting `DAYDREAM_*` env is now ignored.
- `tests/test_interaction_gate.py` + gate updates across `test_phases.py`, `test_deep_orchestrator.py`, `test_pr_review.py`, `test_deep_pr_comment_integration.py` — `resolve_or_prompt` path.
- `tests/test_runner.py` real-path `--yes` shallow run; `tests/test_phases.py` bounded `--yes` loop (exactly one auto fix attempt before abort).

lint + typecheck + full test suite run via the pre-push hook on every push to this branch.

## Breaking Changes

User-facing CLI changes requiring migration:
- Per-phase model/backend flags removed → set `[tool.daydream.phases.<phase>]` in `.daydream.toml` or `pyproject.toml`.
- `harvest` / `build-corpus` / `label` → `daydream corpus harvest|build|label`.
- `DAYDREAM_MODEL` / `DAYDREAM_BACKEND` env vars no longer honored → use `--model`/`--backend` or the config file.
- `--max-iterations` folded into `--loop [N]`.

Golden-path invocations (`daydream /path`, `daydream --comment ...`) are preserved via the default-verb shim.

## Related Issues

- Closes #140

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally
- [x] Linting passes
- [x] Documentation updated (README + CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)