### PR TITLE
fix(git_ops): retry transient git timeouts; distinguish from genuine errors (#120)

### DIFF
--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -301,7 +301,7 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
     # Late imports to avoid circular dependency with runner.
     from daydream import git_ops
     from daydream.backends import Backend
-    from daydream.git_ops import GitError
+    from daydream.git_ops import GitError, GitTimeoutError
     from daydream.phases import _git_branch, _git_log
     from daydream.runner import (
         _compute_diff_ref,
@@ -322,6 +322,12 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
     # ------ Preamble (mirrors run_trust) ------
     try:
         diff = git_ops.diff(work.repo, work.base_branch, exclude=config.ignore_paths)
+    except GitTimeoutError as exc:
+        # Transient host-load timeout that survived git_ops' bounded retries.
+        # Report it accurately instead of the misleading "Unable to determine
+        # base branch" message a genuine ref error would produce (issue #120).
+        print_error(console, "Git Timeout", f"git timed out under load: {exc}")
+        return 1
     except GitError:
         diff = None
     log = _git_log(target_dir)

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -12,7 +12,10 @@ Conventions:
       ``gh`` operations at 60 seconds.
     * ``git`` timeouts are retried a bounded number of times before raising
       :class:`GitTimeoutError` — a trivial command exceeding its timeout means
-      the host is overloaded, not that the command hung.
+      the host is overloaded, not that the command hung. Only read-only queries
+      are retried; mutating operations (fetch/checkout/clean/worktree/amend)
+      pass ``retries=0`` because re-running a non-idempotent command after a
+      timeout could happen on top of partial repo changes.
 
 Error-handling patterns:
     Functions in this module follow one of two documented patterns:
@@ -135,6 +138,9 @@ def _run_git(
         retries: How many additional attempts to make after a
             :class:`subprocess.TimeoutExpired` (total attempts = ``retries + 1``).
             Only timeouts are retried; other failures raise immediately.
+            Mutating wrappers pass ``retries=0`` because re-running a
+            non-idempotent git command after a timeout is unsafe; only
+            read-only queries inherit the retrying default.
 
     Returns:
         The completed process. ``returncode`` is left to the caller to inspect.
@@ -354,7 +360,7 @@ def amend_trailers(repo: Path, trailers: dict[str, str], *, message: str | None 
 
     amended_msg = interp.stdout
     amend_proc = _run_git(
-        repo, ["commit", "--amend", "-m", amended_msg.strip()], timeout=30,
+        repo, ["commit", "--amend", "-m", amended_msg.strip()], timeout=30, retries=0,
     )
     if amend_proc.returncode != 0:
         raise GitError(f"git commit --amend failed: {amend_proc.stderr.strip()}")
@@ -950,7 +956,7 @@ def fetch(repo: Path, remote: str = "origin") -> None:
     Raises:
         GitError: If the fetch fails.
     """
-    proc = _run_git(repo, ["fetch", remote], timeout=30)
+    proc = _run_git(repo, ["fetch", remote], timeout=30, retries=0)
     if proc.returncode != 0:
         raise GitError(f"git fetch {remote} failed in {repo}: {proc.stderr.strip()}")
 
@@ -971,7 +977,7 @@ def fetch_ref(repo: Path, refspec: str, remote: str = "origin", *, timeout: int 
     Raises:
         GitError: If the fetch fails for any reason.
     """
-    proc = _run_git(repo, ["fetch", remote, refspec], timeout=timeout)
+    proc = _run_git(repo, ["fetch", remote, refspec], timeout=timeout, retries=0)
     if proc.returncode != 0:
         raise GitError(f"git fetch {remote} {refspec} failed in {repo}: {proc.stderr.strip()}")
 
@@ -989,7 +995,7 @@ def checkout_detach(repo: Path, sha: str, *, timeout: int = 300) -> None:
     Raises:
         GitError: If the checkout fails.
     """
-    proc = _run_git(repo, ["checkout", "--detach", sha], timeout=timeout)
+    proc = _run_git(repo, ["checkout", "--detach", sha], timeout=timeout, retries=0)
     if proc.returncode != 0:
         raise GitError(f"git checkout --detach {sha} failed in {repo}: {proc.stderr.strip()}")
 
@@ -1041,7 +1047,7 @@ def checkout_paths(repo: Path, paths: list[Path]) -> None:
     if not paths:
         return
     args = ["checkout", "--", *(str(p) for p in paths)]
-    proc = _run_git(repo, args, timeout=30)
+    proc = _run_git(repo, args, timeout=30, retries=0)
     if proc.returncode != 0:
         raise GitError(f"git checkout -- {paths} failed in {repo}: {proc.stderr.strip()}")
 
@@ -1055,7 +1061,7 @@ def clean_untracked(repo: Path) -> None:
     Raises:
         GitError: If the clean fails.
     """
-    proc = _run_git(repo, ["clean", "-fd"], timeout=30)
+    proc = _run_git(repo, ["clean", "-fd"], timeout=30, retries=0)
     if proc.returncode != 0:
         raise GitError(f"git clean -fd failed in {repo}: {proc.stderr.strip()}")
 
@@ -1076,7 +1082,7 @@ def worktree_add(repo: Path, path: Path, ref: str, *, detach: bool = True) -> No
     if detach:
         args.append("--detach")
     args.extend([str(path), ref])
-    proc = _run_git(repo, args, timeout=30)
+    proc = _run_git(repo, args, timeout=30, retries=0)
     if proc.returncode != 0:
         raise GitError(f"git worktree add {path} {ref} failed: {proc.stderr.strip()}")
 
@@ -1096,7 +1102,7 @@ def worktree_remove(repo: Path, path: Path, *, force: bool = True) -> None:
     if force:
         args.append("--force")
     args.append(str(path))
-    proc = _run_git(repo, args, timeout=30)
+    proc = _run_git(repo, args, timeout=30, retries=0)
     if proc.returncode != 0:
         raise GitError(f"git worktree remove {path} failed: {proc.stderr.strip()}")
 

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -10,6 +10,9 @@ Conventions:
     * Every command receives ``cwd=repo`` (no ``git -C`` shenanigans).
     * Read-only queries time out at 5 seconds, IO-bound at 30 seconds, and
       ``gh`` operations at 60 seconds.
+    * ``git`` timeouts are retried a bounded number of times before raising
+      :class:`GitTimeoutError` — a trivial command exceeding its timeout means
+      the host is overloaded, not that the command hung.
 
 Error-handling patterns:
     Functions in this module follow one of two documented patterns:
@@ -61,6 +64,18 @@ class GitError(Exception):
     """Base class for all git/gh failures raised by :mod:`daydream.git_ops`."""
 
 
+class GitTimeoutError(GitError):
+    """Raised when a ``git``/``gh`` subprocess exceeds its timeout.
+
+    Distinct from the generic :class:`GitError` so callers can tell a
+    *transient* host-load timeout (a trivial command starved of CPU) apart
+    from a genuine git failure (bad ref, missing object, not a worktree). A
+    timeout signals the machine is overloaded, not that the command is wrong,
+    so it is retried a bounded number of times in :func:`_run_git` before it
+    surfaces as this exception.
+    """
+
+
 class RateLimitError(GitError):
     """Raised when a ``gh`` call fails due to a GitHub API rate limit.
 
@@ -93,12 +108,22 @@ class WrongBranchError(GitError):
 # --- Internal subprocess helpers --------------------------------------------
 
 
+# A trivial git command exceeding its timeout means the host was momentarily
+# starved of CPU (heavy concurrent load), not that the command hung — so a
+# timeout is retried a bounded number of times before it surfaces as a
+# GitTimeoutError. This is what kept the deep-orchestrator full-suite tests
+# flaky: under load a 5s `git rev-parse`/`diff` would time out, collapse to a
+# generic GitError, and the run would exit 1 (see issue #120).
+_GIT_TIMEOUT_RETRIES = 2
+
+
 def _run_git(
     repo: Path,
     args: list[str],
     *,
     timeout: int = 5,
     capture_bytes: bool = False,
+    retries: int = _GIT_TIMEOUT_RETRIES,
 ) -> subprocess.CompletedProcess[Any]:
     """Run ``git`` in *repo* with hardened defaults.
 
@@ -107,26 +132,48 @@ def _run_git(
         args: Arguments after ``git``.
         timeout: Subprocess timeout in seconds.
         capture_bytes: When True, capture stdout/stderr as bytes (no decoding).
+        retries: How many additional attempts to make after a
+            :class:`subprocess.TimeoutExpired` (total attempts = ``retries + 1``).
+            Only timeouts are retried; other failures raise immediately.
 
     Returns:
         The completed process. ``returncode`` is left to the caller to inspect.
 
     Raises:
-        GitError: If the underlying subprocess machinery itself fails (for
-            example timeout, missing binary, OS-level error).
+        GitTimeoutError: If every attempt times out. Subclass of
+            :class:`GitError`, so existing ``except GitError`` handlers still
+            catch it.
+        GitError: If the underlying subprocess machinery fails for any other
+            reason (missing binary, OS-level error).
     """
-    try:
-        return subprocess.run(  # noqa: S603 - arguments are not user-controlled
-            ["git", *args],  # noqa: S607 - git is a trusted command
-            cwd=repo,
-            capture_output=True,
-            text=not capture_bytes,
-            timeout=timeout,
-            shell=False,
-            check=False,
-        )
-    except (subprocess.SubprocessError, OSError) as exc:
-        raise GitError(f"git {' '.join(args)} failed: {type(exc).__name__}: {exc}") from exc
+    last_timeout: subprocess.TimeoutExpired | None = None
+    for attempt in range(retries + 1):
+        try:
+            return subprocess.run(  # noqa: S603 - arguments are not user-controlled
+                ["git", *args],  # noqa: S607 - git is a trusted command
+                cwd=repo,
+                capture_output=True,
+                text=not capture_bytes,
+                timeout=timeout,
+                shell=False,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            last_timeout = exc
+            if attempt < retries:
+                _logger.warning(
+                    "git %s timed out after %ss (attempt %d/%d); retrying",
+                    " ".join(args),
+                    timeout,
+                    attempt + 1,
+                    retries + 1,
+                )
+        except (subprocess.SubprocessError, OSError) as exc:
+            raise GitError(f"git {' '.join(args)} failed: {type(exc).__name__}: {exc}") from exc
+
+    raise GitTimeoutError(
+        f"git {' '.join(args)} timed out after {timeout}s ({retries + 1} attempts)",
+    ) from last_timeout
 
 
 def _run_gh(
@@ -146,8 +193,9 @@ def _run_gh(
         The completed process with text-decoded stdout/stderr.
 
     Raises:
-        GitError: If the subprocess machinery fails (timeout, missing ``gh``,
-            OS-level error).
+        GitTimeoutError: If the call times out. Subclass of :class:`GitError`.
+        GitError: If the subprocess machinery fails for any other reason
+            (missing ``gh``, OS-level error).
     """
     try:
         return subprocess.run(  # noqa: S603 - arguments are not user-controlled
@@ -159,6 +207,8 @@ def _run_gh(
             shell=False,
             check=False,
         )
+    except subprocess.TimeoutExpired as exc:
+        raise GitTimeoutError(f"gh {' '.join(args)} timed out after {timeout}s") from exc
     except (subprocess.SubprocessError, OSError) as exc:
         raise GitError(f"gh {' '.join(args)} failed: {type(exc).__name__}: {exc}") from exc
 

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import re
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -1948,4 +1949,91 @@ async def test_apply_fixes_gate_eof_declines_cleanly_no_crash(
     # Observable outcome 3: the merged report was written before the exit.
     assert (multi_stack_target / REVIEW_OUTPUT_FILE).is_file(), (
         "merged report missing -- the apply-fixes gate's success/exit path did not run"
+    )
+
+
+# --- Git timeout under load (issue #120) ------------------------------------
+
+
+async def test_deep_run_recovers_from_transient_git_timeout(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression for #120: a transient git timeout no longer fails the run.
+
+    Under heavy host load a trivial git command in the deep preamble would
+    exceed its 5s timeout, collapse to a generic ``GitError``, and the run
+    would exit 1 -- making every ``assert exit_code == 0`` deep test flaky.
+    With the bounded retry in ``git_ops._run_git`` the timeout is retried and
+    the run completes normally.
+
+    Drives the real production path: ``runner.run`` -> deep orchestrator ->
+    ``git_ops.diff`` -> ``_run_git`` -> ``subprocess.run`` (only the backend is
+    stubbed). The first git subprocess call raises ``TimeoutExpired``; every
+    later call delegates to the real ``subprocess.run``.
+    """
+    _silence(monkeypatch)
+    _install_stub_backend(monkeypatch, multi_stack_target)
+
+    real_run = subprocess.run
+    state = {"timed_out_once": False}
+
+    def flaky_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
+        cmd = args[0] if args else kwargs.get("args", [])
+        # Only trip on a real `git` invocation (these go through the retry
+        # path); leave any `gh` call untouched so the test is deterministic.
+        is_git = isinstance(cmd, (list, tuple)) and len(cmd) and cmd[0] == "git"
+        if is_git and not state["timed_out_once"]:
+            state["timed_out_once"] = True
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=5)
+        return real_run(*args, **kwargs)
+
+    monkeypatch.setattr("daydream.git_ops.subprocess.run", flaky_run)
+
+    exit_code = await _run_deep(multi_stack_target)
+
+    from daydream.config import REVIEW_OUTPUT_FILE
+
+    assert state["timed_out_once"], "the injected git timeout never fired"
+    # Observable outcome: the run survived the timeout and exited cleanly...
+    assert exit_code == 0
+    # ...and progressed past the diff preamble to write the merged report.
+    assert (multi_stack_target / REVIEW_OUTPUT_FILE).is_file()
+
+
+async def test_deep_run_reports_persistent_git_timeout_distinctly(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A timeout that survives retries is surfaced as a distinct 'Git Timeout'.
+
+    A genuine bad-ref ``GitError`` reports 'Unable to determine base branch for
+    diff'. A timeout is a different failure mode (transient host load) and must
+    not be misreported as that deterministic-sounding ref error (#120). Drives
+    ``runner.run`` to the real orchestrator branch and captures the rendered
+    error title.
+    """
+    _silence(monkeypatch)
+    _install_stub_backend(monkeypatch, multi_stack_target)
+
+    from daydream.git_ops import GitTimeoutError
+
+    def always_timeout(*args: Any, **kwargs: Any) -> str:
+        raise GitTimeoutError("git diff main...HEAD timed out after 30s (3 attempts)")
+
+    monkeypatch.setattr("daydream.git_ops.diff", always_timeout)
+
+    errors: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "daydream.deep.orchestrator.print_error",
+        lambda console, title, msg, *a, **kw: errors.append((title, msg)),
+    )
+
+    exit_code = await _run_deep(multi_stack_target)
+
+    # Observable outcome: the run aborts...
+    assert exit_code == 1
+    # ...with the timeout-specific title, NOT the misleading base-branch error.
+    titles = [t for t, _ in errors]
+    assert "Git Timeout" in titles, f"expected a distinct Git Timeout error, got {errors!r}"
+    assert "Git Error" not in titles, (
+        f"a timeout was misreported as the generic base-branch error: {errors!r}"
     )

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -536,18 +536,20 @@ def test_error_hierarchy_is_consistent() -> None:
 # --- _run_git timeout retry (issue #120) ------------------------------------
 
 
-def test_run_git_retries_transient_timeout_then_succeeds(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    """A timeout on the first attempt is retried; a later success is returned.
+def test_run_git_timeout_retry_behavior(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """`_run_git` retries transient timeouts but not other failures (#120).
 
-    This is the core fix for the flaky deep-orchestrator suite (#120): under
-    host load a trivial git command times out, but a retry succeeds, so the
-    run no longer collapses to a spurious failure.
+    One test, three cases:
+      * a timeout on the first attempt is retried and the later success returns;
+      * timeouts that exhaust every attempt raise the distinct GitTimeoutError;
+      * a non-timeout subprocess error raises a plain GitError immediately, with
+        no wasted retries.
     """
     repo = _make_repo_with_main(tmp_path)
-    calls = {"n": 0}
     ok = subprocess.CompletedProcess(args=["git"], returncode=0, stdout="true\n", stderr="")
+
+    # Case 1: transient timeout (1st attempt) then success on the retry.
+    calls = {"n": 0}
 
     def flaky_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
         calls["n"] += 1
@@ -556,52 +558,31 @@ def test_run_git_retries_transient_timeout_then_succeeds(
         return ok
 
     monkeypatch.setattr("daydream.git_ops.subprocess.run", flaky_run)
+    assert git_ops._run_git(repo, ["rev-parse", "HEAD"]).returncode == 0
+    assert calls["n"] == 2  # timed out once, then succeeded
 
-    proc = git_ops._run_git(repo, ["rev-parse", "--is-inside-work-tree"])
-
-    assert proc.returncode == 0
-    assert calls["n"] == 2  # first attempt timed out, second succeeded
-
-
-def test_run_git_raises_git_timeout_error_when_all_attempts_time_out(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    """Every attempt timing out surfaces a GitTimeoutError, not a bare GitError."""
-    repo = _make_repo_with_main(tmp_path)
-    calls = {"n": 0}
+    # Case 2: every attempt times out -> GitTimeoutError after retries+1 tries.
+    calls["n"] = 0
 
     def always_timeout(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
         calls["n"] += 1
         raise subprocess.TimeoutExpired(cmd=["git"], timeout=5)
 
     monkeypatch.setattr("daydream.git_ops.subprocess.run", always_timeout)
-
     with pytest.raises(git_ops.GitTimeoutError):
         git_ops._run_git(repo, ["rev-parse", "HEAD"], retries=2)
-
     assert calls["n"] == 3  # 1 initial + 2 retries
 
-
-def test_run_git_does_not_retry_non_timeout_errors(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    """A non-timeout subprocess failure raises immediately as a plain GitError.
-
-    Retrying a missing binary / OS error would just waste time — only the
-    transient timeout is worth a second attempt.
-    """
-    repo = _make_repo_with_main(tmp_path)
-    calls = {"n": 0}
+    # Case 3: non-timeout failure raises plain GitError immediately (no retry).
+    calls["n"] = 0
 
     def os_error(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
         calls["n"] += 1
         raise OSError("git binary missing")
 
     monkeypatch.setattr("daydream.git_ops.subprocess.run", os_error)
-
     with pytest.raises(GitError) as exc:
         git_ops._run_git(repo, ["rev-parse", "HEAD"], retries=2)
-
     assert not isinstance(exc.value, git_ops.GitTimeoutError)
     assert calls["n"] == 1  # no retries for non-timeout failures
 

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -587,6 +587,28 @@ def test_run_git_timeout_retry_behavior(monkeypatch: pytest.MonkeyPatch, tmp_pat
     assert calls["n"] == 1  # no retries for non-timeout failures
 
 
+def test_mutating_wrapper_does_not_retry_on_timeout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Mutating wrappers pass `retries=0`, so a timeout is not re-run (#120).
+
+    Re-running a non-idempotent git command after a timeout could land on top of
+    partial repo changes. `fetch` drives the production path through `_run_git`
+    and must raise GitTimeoutError after exactly one attempt.
+    """
+    repo = _make_repo_with_main(tmp_path)
+    calls = {"n": 0}
+
+    def always_timeout(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
+        calls["n"] += 1
+        raise subprocess.TimeoutExpired(cmd=["git"], timeout=30)
+
+    monkeypatch.setattr("daydream.git_ops.subprocess.run", always_timeout)
+    with pytest.raises(git_ops.GitTimeoutError):
+        git_ops.fetch(repo)
+    assert calls["n"] == 1  # no retries for mutating operations
+
+
 def test_wrong_branch_error_is_raisable() -> None:
     with pytest.raises(WrongBranchError):
         raise WrongBranchError("expected feat, got main")

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -530,6 +530,80 @@ def test_error_hierarchy_is_consistent() -> None:
     assert issubclass(NotAWorktreeError, GitError)
     assert issubclass(BranchNotFoundError, GitError)
     assert issubclass(WrongBranchError, GitError)
+    assert issubclass(git_ops.GitTimeoutError, GitError)
+
+
+# --- _run_git timeout retry (issue #120) ------------------------------------
+
+
+def test_run_git_retries_transient_timeout_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A timeout on the first attempt is retried; a later success is returned.
+
+    This is the core fix for the flaky deep-orchestrator suite (#120): under
+    host load a trivial git command times out, but a retry succeeds, so the
+    run no longer collapses to a spurious failure.
+    """
+    repo = _make_repo_with_main(tmp_path)
+    calls = {"n": 0}
+    ok = subprocess.CompletedProcess(args=["git"], returncode=0, stdout="true\n", stderr="")
+
+    def flaky_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise subprocess.TimeoutExpired(cmd=["git"], timeout=5)
+        return ok
+
+    monkeypatch.setattr("daydream.git_ops.subprocess.run", flaky_run)
+
+    proc = git_ops._run_git(repo, ["rev-parse", "--is-inside-work-tree"])
+
+    assert proc.returncode == 0
+    assert calls["n"] == 2  # first attempt timed out, second succeeded
+
+
+def test_run_git_raises_git_timeout_error_when_all_attempts_time_out(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Every attempt timing out surfaces a GitTimeoutError, not a bare GitError."""
+    repo = _make_repo_with_main(tmp_path)
+    calls = {"n": 0}
+
+    def always_timeout(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
+        calls["n"] += 1
+        raise subprocess.TimeoutExpired(cmd=["git"], timeout=5)
+
+    monkeypatch.setattr("daydream.git_ops.subprocess.run", always_timeout)
+
+    with pytest.raises(git_ops.GitTimeoutError):
+        git_ops._run_git(repo, ["rev-parse", "HEAD"], retries=2)
+
+    assert calls["n"] == 3  # 1 initial + 2 retries
+
+
+def test_run_git_does_not_retry_non_timeout_errors(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A non-timeout subprocess failure raises immediately as a plain GitError.
+
+    Retrying a missing binary / OS error would just waste time — only the
+    transient timeout is worth a second attempt.
+    """
+    repo = _make_repo_with_main(tmp_path)
+    calls = {"n": 0}
+
+    def os_error(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
+        calls["n"] += 1
+        raise OSError("git binary missing")
+
+    monkeypatch.setattr("daydream.git_ops.subprocess.run", os_error)
+
+    with pytest.raises(GitError) as exc:
+        git_ops._run_git(repo, ["rev-parse", "HEAD"], retries=2)
+
+    assert not isinstance(exc.value, git_ops.GitTimeoutError)
+    assert calls["n"] == 1  # no retries for non-timeout failures
 
 
 def test_wrong_branch_error_is_raisable() -> None:


### PR DESCRIPTION
## Summary

Fixes the flaky `test_deep_orchestrator.py` failures tracked in #120.

Under heavy host load (e.g. `make check` overlapping multi-subagent activity), a trivial git command in the deep-orchestrator preamble — `git rev-parse`, `git diff` — would exceed its hardcoded **5s timeout**, get collapsed into a generic `GitError`, and the orchestrator would `return 1`. Every deep test asserts `exit_code == 0` first, so they failed together with the misleading `AssertionError: assert 1 == 0` / "Unable to determine base branch for diff". This was confirmed deterministically in the issue thread.

**Root cause:** a timeout on a *trivial* git command signals transient CPU starvation, not a hung command — but `_run_git` treated it like any other subprocess failure and surfaced it as a deterministic-sounding ref error.

## Changes

- **`GitTimeoutError(GitError)`** — a distinct exception so callers can tell a transient host-load timeout apart from a genuine git failure. Backward-compatible: it subclasses `GitError`, so existing `except GitError` handlers still catch it.
- **`_run_git` retries on `subprocess.TimeoutExpired`** (bounded, 2 retries → 3 attempts total) before raising `GitTimeoutError`. Non-timeout errors (missing binary, OS error) raise immediately — no point retrying those.
- **`_run_gh`** raises the distinct `GitTimeoutError` on timeout (no retry).
- **Deep orchestrator** catches `GitTimeoutError` and prints an accurate `Git Timeout` error instead of the misleading "Unable to determine base branch for diff".

## Tests

All five new tests fail on `main` and pass with this fix (verified by stashing the production change):

- `_run_git` retries a transient timeout then returns the later success.
- `_run_git` raises `GitTimeoutError` after exhausting retries.
- `_run_git` does **not** retry non-timeout errors (raises plain `GitError`).
- **Real-path** (`runner.run` → deep orchestrator → `git_ops.diff` → `_run_git` → `subprocess.run`, only the backend stubbed): a transient git timeout is retried and the run still exits 0 with the merged report written.
- **Real-path**: a persistent timeout surfaces the distinct `Git Timeout` error, not the generic base-branch error.

## Verification

- `make lint` ✅ · `make typecheck` ✅ (no issues, 73 files)
- Full suite: `1277 passed, 1 skipped` locally **and** via the pre-push hook.

## Acceptance criteria (#120)

- [x] Failing condition captured & reproduced deterministically (timeout injection).
- [x] Root cause fixed at its source (`git_ops._run_git`), not papered over.
- [x] Suite green across repeated runs; the deep tests no longer depend on host git timing.

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)