### PR TITLE
fix(training): correct run-level label attribution (footer-not-bot + archive-time PR linkage)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ lint:
 	uv run ruff check daydream tests
 
 typecheck:
-	uv run mypy daydream
+	uv run mypy daydream tests
 
 test:
 	uv run pytest -v

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ install:
 	uv sync
 
 lint:
-	uv run ruff check daydream
+	uv run ruff check daydream tests
 
 typecheck:
 	uv run mypy daydream

--- a/daydream/archive/_schema.py
+++ b/daydream/archive/_schema.py
@@ -1,0 +1,233 @@
+"""SQLite schema definitions and migration helpers for the daydream archive index.
+
+Centralises all DDL constants (CREATE TABLE, CREATE INDEX, UPSERT) and the
+idempotent migration helpers that bring a live database up to the current
+schema version. Imported exclusively by ``daydream.archive.index``; callers
+outside that module should not depend on anything in this file directly.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import warnings
+
+SCHEMA_VERSION = 5
+
+_PRECEDENCE_ORDER = "CASE WHEN source = 'human' THEN 1 ELSE 0 END DESC, observed_at DESC"
+"""SQL ORDER BY expression that ranks label_observations by human-first precedence then recency.
+
+Used identically across append_label_observation, latest_label_observation,
+bulk_latest_label_observations, and label_count_summary — centralised here so
+all callers stay in sync if the precedence rule ever changes.
+"""
+
+_REVIEWER_PENALTY_MAP: dict[str, float] = {
+    "accepted": 0.0,
+    "contested": 0.5,
+    "rejected": 1.0,
+}
+"""Maintainer outcome label → false-positive penalty, mirroring
+``daydream.training.reward._FP_PENALTY_MAP``.  Defined here so the archive
+layer does not depend on the training layer."""
+
+_CREATE_TABLE = """
+CREATE TABLE IF NOT EXISTS runs (
+    session_id TEXT PRIMARY KEY,
+    archived_at TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'complete',
+    run_flow TEXT NOT NULL,
+    skill TEXT,
+    model TEXT,
+    backend TEXT NOT NULL DEFAULT 'claude',
+    review_backend TEXT,
+    fix_backend TEXT,
+    test_backend TEXT,
+    review_only INTEGER NOT NULL DEFAULT 0,
+    deep INTEGER NOT NULL DEFAULT 0,
+    loop INTEGER NOT NULL DEFAULT 0,
+    remote_url TEXT,
+    repo_slug TEXT,
+    source_path TEXT,
+    branch TEXT,
+    base_branch TEXT,
+    head_sha TEXT,
+    base_sha TEXT,
+    changed_files TEXT,
+    pr_number INTEGER,
+    pr_repo TEXT,
+    total_cost_usd REAL,
+    total_findings INTEGER,
+    grounding_rate REAL,
+    coverage_ratio REAL,
+    cost_per_finding_usd REAL,
+    wall_clock_seconds REAL,
+    total_prompt_tokens INTEGER,
+    total_completion_tokens INTEGER,
+    total_cached_tokens INTEGER,
+    outcome_labels TEXT NOT NULL DEFAULT '[]',
+    labeled_at TEXT,
+    rubric_json TEXT,
+    composite_reward REAL,
+    has_posterior INTEGER NOT NULL DEFAULT 0,
+    archive_path TEXT NOT NULL,
+    schema_version INTEGER NOT NULL DEFAULT 1
+)
+"""
+
+# Append-only bitemporal annotation history. ``observed_at`` is transaction
+# time (when the annotation was recorded); ``valid_at`` is valid time (when the
+# outcome the annotation describes became true, e.g. a PR merge timestamp). The
+# reward columns (``reward_version``, ``reward_json``, ``composite_reward``)
+# carry the full ``RewardBreakdown`` plus its cached composite scalar so a
+# corpus re-projection has every axis and each annotation generation is
+# self-describing (the ``runs.composite_reward`` mirror remains the SQL-threshold
+# cache). ``reviewer_logins`` is a JSON array of the human GitHub accounts whose
+# review/reply outcomes seeded the posterior axis (empty/``None`` for non-PR
+# runs); ``has_posterior`` is the population discriminator (1 when the row
+# carries a ``PosteriorBreakdown``, mirrored onto ``runs`` so SQL consumers can
+# split labeled/unlabeled populations without parsing ``reward_json``). See spec
+# ``corpus-pipeline-architecture`` (silver layer) and ``reward-posterior-corrections`` (C3).
+# ``source`` is the precedence marker (``'auto'`` for automated rubric labels,
+# ``'human'`` for maintainer overrides) — human-sourced rows win in the "latest
+# label" projections regardless of recency. Pre-existing rows default to ``'auto'``
+# via the additive ``_migrate_label_observations_schema`` ALTER-ADD migration.
+_CREATE_LABEL_OBSERVATIONS_TABLE = """
+CREATE TABLE IF NOT EXISTS label_observations (
+    session_id       TEXT NOT NULL,
+    observed_at      TEXT NOT NULL,
+    labels           TEXT NOT NULL,
+    pr_state         TEXT,
+    labeler_version  TEXT NOT NULL,
+    evidence_sha     TEXT,
+    rubric_json      TEXT,
+    valid_at         TEXT,
+    reward_version   TEXT,
+    reward_json      TEXT,
+    composite_reward REAL,
+    reviewer_logins  TEXT,
+    has_posterior    INTEGER NOT NULL DEFAULT 0,
+    source           TEXT NOT NULL DEFAULT 'auto',
+    PRIMARY KEY (session_id, observed_at)
+)
+"""
+
+_CREATE_INDEXES = [
+    "CREATE INDEX IF NOT EXISTS idx_runs_repo_slug ON runs(repo_slug)",
+    "CREATE INDEX IF NOT EXISTS idx_runs_archived_at ON runs(archived_at)",
+    "CREATE INDEX IF NOT EXISTS idx_runs_outcome ON runs(outcome_labels)",
+    "CREATE INDEX IF NOT EXISTS idx_label_obs_observed_at ON label_observations(observed_at)",
+    "CREATE INDEX IF NOT EXISTS idx_label_obs_session ON label_observations(session_id)",
+]
+
+_UPSERT_SQL = """
+INSERT OR REPLACE INTO runs (
+    session_id, archived_at, status, run_flow, skill, model, backend,
+    review_backend, fix_backend, test_backend,
+    review_only, deep, loop, remote_url, repo_slug, source_path, branch, base_branch,
+    head_sha, base_sha, changed_files, pr_number, pr_repo, total_cost_usd, total_findings,
+    grounding_rate, coverage_ratio, cost_per_finding_usd, wall_clock_seconds,
+    total_prompt_tokens, total_completion_tokens, total_cached_tokens,
+    outcome_labels, labeled_at, composite_reward, archive_path, schema_version
+) VALUES (
+    :session_id, :archived_at, :status, :run_flow, :skill, :model, :backend,
+    :review_backend, :fix_backend, :test_backend,
+    :review_only, :deep, :loop, :remote_url, :repo_slug, :source_path, :branch, :base_branch,
+    :head_sha, :base_sha, :changed_files, :pr_number, :pr_repo, :total_cost_usd, :total_findings,
+    :grounding_rate, :coverage_ratio, :cost_per_finding_usd, :wall_clock_seconds,
+    :total_prompt_tokens, :total_completion_tokens, :total_cached_tokens,
+    :outcome_labels, :labeled_at, :composite_reward, :archive_path, :schema_version
+)
+"""
+
+
+def _alter_add_missing(
+    conn: sqlite3.Connection,
+    table: str,
+    migrations: list[tuple[str, str]],
+) -> None:
+    """ALTER TABLE *table* to add any columns in *migrations* that are absent.
+
+    Each entry in *migrations* is a ``(column_name, column_type)`` pair.
+    Missing columns are added idempotently; a ``duplicate column name`` error
+    (raised by a race between concurrent openers) is silently swallowed, which
+    preserves the warn-and-continue semantics of the callers it replaces.
+
+    Args:
+        conn: An open SQLite connection.
+        table: Name of the table to inspect and alter.
+        migrations: Ordered list of ``(col, col_type)`` pairs to apply.
+    """
+    existing = {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}  # noqa: S608 - table is a module-local constant at every call site
+    for col, col_type in migrations:
+        if col not in existing:
+            try:
+                conn.execute(f"ALTER TABLE {table} ADD COLUMN {col} {col_type}")  # noqa: S608 - col/col_type are module-local constants
+            except sqlite3.OperationalError as exc:
+                if "duplicate column name" not in str(exc).lower():
+                    raise
+
+
+def _migrate_schema(conn: sqlite3.Connection) -> None:
+    """Add columns that exist in _CREATE_TABLE but are missing from the live DB."""
+    _alter_add_missing(
+        conn,
+        "runs",
+        [
+            ("review_backend", "TEXT"),
+            ("fix_backend", "TEXT"),
+            ("test_backend", "TEXT"),
+            ("rubric_json", "TEXT"),
+            ("base_sha", "TEXT"),
+            ("changed_files", "TEXT"),
+            ("composite_reward", "REAL"),
+            ("source_path", "TEXT"),
+            ("has_posterior", "INTEGER NOT NULL DEFAULT 0"),
+        ],
+    )
+
+
+def _recreate_label_observations_if_stale(conn: sqlite3.Connection) -> None:
+    """Drop and recreate ``label_observations`` if it predates the bitemporal/posterior columns.
+
+    The bitemporal/reward/posterior columns are part of the table's primary
+    structure, so rather than `ALTER TABLE ADD COLUMN` (which cannot retrofit
+    them cleanly for the spec's clean-recreate guarantee), a stale table is
+    dropped and rebuilt. A table missing either ``valid_at`` (pre-bitemporal) or
+    ``has_posterior`` (pre-reward-posterior-corrections) is considered stale. Dev
+    label rows are discarded (spec-sanctioned — repopulate via ``harvest``). The
+    ``runs`` table is never touched. Idempotent: after a recreate both columns
+    exist, so subsequent calls are a no-op.
+
+    Args:
+        conn: An open connection whose ``label_observations`` table exists.
+    """
+    existing = {row[1] for row in conn.execute("PRAGMA table_info(label_observations)").fetchall()}
+    if existing and ("valid_at" not in existing or "has_posterior" not in existing):
+        warnings.warn(
+            "label_observations table predates bitemporal/posterior columns and will be dropped "
+            "and recreated. Existing label rows will be lost — repopulate via `harvest`.",
+            stacklevel=2,
+        )
+        conn.execute("DROP TABLE label_observations")
+        conn.execute(_CREATE_LABEL_OBSERVATIONS_TABLE)
+
+
+def _migrate_label_observations_schema(conn: sqlite3.Connection) -> None:
+    """Additively ALTER-ADD columns missing from a live ``label_observations`` table.
+
+    Unlike ``_recreate_label_observations_if_stale`` (which drop-recreates for
+    structural bitemporal/posterior columns), this is non-destructive: the
+    ``source`` precedence marker is additive, so pre-existing rows are preserved
+    and default to ``'auto'``. Delegates to ``_alter_add_missing`` (the shared
+    helper that also backs ``_migrate_schema`` for the runs table).
+
+    Args:
+        conn: An open connection whose ``label_observations`` table exists.
+    """
+    _alter_add_missing(
+        conn,
+        "label_observations",
+        [
+            ("source", "TEXT NOT NULL DEFAULT 'auto'"),
+        ],
+    )

--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -848,6 +848,36 @@ def update_labels(archive_dir: Path, session_id: str, labels: list[str]) -> bool
     return True
 
 
+def set_run_pr_link(archive_dir: Path, session_id: str, pr_number: int, pr_repo: str) -> None:
+    """Backfill the PR linkage columns on a run row.
+
+    Used by harvest to durably record a PR resolved for an orphan run (a run
+    launched before its PR existed, so ``pr_number`` was frozen as ``None``).
+    Persisting the linkage keeps subsequent harvest passes from re-querying
+    GitHub for the same row and makes the resolution auditable.
+
+    This is a pure linkage backfill: it touches only the ``pr_number`` and
+    ``pr_repo`` columns on the ``runs`` table and never writes to
+    ``label_observations`` or any cache column. A zero-row match (no such
+    ``session_id``) is a silent no-op; the caller guarantees the row exists.
+
+    Args:
+        archive_dir: Path to the archive root.
+        session_id: Full session ID of the run to link.
+        pr_number: Resolved PR number to record.
+        pr_repo: Resolved PR repository slug (``owner/name``) to record.
+    """
+    conn = _get_connection(archive_dir)
+    try:
+        conn.execute(
+            "UPDATE runs SET pr_number = ?, pr_repo = ? WHERE session_id = ?",
+            (pr_number, pr_repo, session_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
 def query_runs(archive_dir: Path, where: str = "", params: tuple = ()) -> list[dict]:
     """Query the runs index with an optional WHERE clause.
 

--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -39,228 +39,37 @@ import warnings
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+from daydream.archive._schema import (
+    _CREATE_INDEXES,
+    _CREATE_LABEL_OBSERVATIONS_TABLE,
+    _CREATE_TABLE,
+    _PRECEDENCE_ORDER,
+    _REVIEWER_PENALTY_MAP,
+    _UPSERT_SQL,
+    SCHEMA_VERSION,
+    _migrate_label_observations_schema,
+    _migrate_schema,
+    _recreate_label_observations_if_stale,
+)
 from daydream.archive.manifest import Manifest
 
-SCHEMA_VERSION = 5
-
-_PRECEDENCE_ORDER = "CASE WHEN source = 'human' THEN 1 ELSE 0 END DESC, observed_at DESC"
-"""SQL ORDER BY expression that ranks label_observations by human-first precedence then recency.
-
-Used identically across append_label_observation, latest_label_observation,
-bulk_latest_label_observations, and label_count_summary — centralised here so
-all callers stay in sync if the precedence rule ever changes.
-"""
-
-_REVIEWER_PENALTY_MAP: dict[str, float] = {
-    "accepted": 0.0,
-    "contested": 0.5,
-    "rejected": 1.0,
-}
-"""Maintainer outcome label → false-positive penalty, mirroring
-``daydream.training.reward._FP_PENALTY_MAP``.  Defined here so the archive
-layer does not depend on the training layer."""
-
-_CREATE_TABLE = """
-CREATE TABLE IF NOT EXISTS runs (
-    session_id TEXT PRIMARY KEY,
-    archived_at TEXT NOT NULL,
-    status TEXT NOT NULL DEFAULT 'complete',
-    run_flow TEXT NOT NULL,
-    skill TEXT,
-    model TEXT,
-    backend TEXT NOT NULL DEFAULT 'claude',
-    review_backend TEXT,
-    fix_backend TEXT,
-    test_backend TEXT,
-    review_only INTEGER NOT NULL DEFAULT 0,
-    deep INTEGER NOT NULL DEFAULT 0,
-    loop INTEGER NOT NULL DEFAULT 0,
-    remote_url TEXT,
-    repo_slug TEXT,
-    source_path TEXT,
-    branch TEXT,
-    base_branch TEXT,
-    head_sha TEXT,
-    base_sha TEXT,
-    changed_files TEXT,
-    pr_number INTEGER,
-    pr_repo TEXT,
-    total_cost_usd REAL,
-    total_findings INTEGER,
-    grounding_rate REAL,
-    coverage_ratio REAL,
-    cost_per_finding_usd REAL,
-    wall_clock_seconds REAL,
-    total_prompt_tokens INTEGER,
-    total_completion_tokens INTEGER,
-    total_cached_tokens INTEGER,
-    outcome_labels TEXT NOT NULL DEFAULT '[]',
-    labeled_at TEXT,
-    rubric_json TEXT,
-    composite_reward REAL,
-    has_posterior INTEGER NOT NULL DEFAULT 0,
-    archive_path TEXT NOT NULL,
-    schema_version INTEGER NOT NULL DEFAULT 1
-)
-"""
-
-# Append-only bitemporal annotation history. ``observed_at`` is transaction
-# time (when the annotation was recorded); ``valid_at`` is valid time (when the
-# outcome the annotation describes became true, e.g. a PR merge timestamp). The
-# reward columns (``reward_version``, ``reward_json``, ``composite_reward``)
-# carry the full ``RewardBreakdown`` plus its cached composite scalar so a
-# corpus re-projection has every axis and each annotation generation is
-# self-describing (the ``runs.composite_reward`` mirror remains the SQL-threshold
-# cache). ``reviewer_logins`` is a JSON array of the human GitHub accounts whose
-# review/reply outcomes seeded the posterior axis (empty/``None`` for non-PR
-# runs); ``has_posterior`` is the population discriminator (1 when the row
-# carries a ``PosteriorBreakdown``, mirrored onto ``runs`` so SQL consumers can
-# split labeled/unlabeled populations without parsing ``reward_json``). See spec
-# ``corpus-pipeline-architecture`` (silver layer) and ``reward-posterior-corrections`` (C3).
-# ``source`` is the precedence marker (``'auto'`` for automated rubric labels,
-# ``'human'`` for maintainer overrides) — human-sourced rows win in the "latest
-# label" projections regardless of recency. Pre-existing rows default to ``'auto'``
-# via the additive ``_migrate_label_observations_schema`` ALTER-ADD migration.
-_CREATE_LABEL_OBSERVATIONS_TABLE = """
-CREATE TABLE IF NOT EXISTS label_observations (
-    session_id       TEXT NOT NULL,
-    observed_at      TEXT NOT NULL,
-    labels           TEXT NOT NULL,
-    pr_state         TEXT,
-    labeler_version  TEXT NOT NULL,
-    evidence_sha     TEXT,
-    rubric_json      TEXT,
-    valid_at         TEXT,
-    reward_version   TEXT,
-    reward_json      TEXT,
-    composite_reward REAL,
-    reviewer_logins  TEXT,
-    has_posterior    INTEGER NOT NULL DEFAULT 0,
-    source           TEXT NOT NULL DEFAULT 'auto',
-    PRIMARY KEY (session_id, observed_at)
-)
-"""
-
-_CREATE_INDEXES = [
-    "CREATE INDEX IF NOT EXISTS idx_runs_repo_slug ON runs(repo_slug)",
-    "CREATE INDEX IF NOT EXISTS idx_runs_archived_at ON runs(archived_at)",
-    "CREATE INDEX IF NOT EXISTS idx_runs_outcome ON runs(outcome_labels)",
-    "CREATE INDEX IF NOT EXISTS idx_label_obs_observed_at ON label_observations(observed_at)",
-    "CREATE INDEX IF NOT EXISTS idx_label_obs_session ON label_observations(session_id)",
+# Re-export for callers (including tests) that import these names from this module.
+__all__ = [
+    "SCHEMA_VERSION",
+    "_CREATE_TABLE",
+    "upsert_run",
+    "update_labels",
+    "query_runs",
+    "count_runs",
+    "append_label_observation",
+    "latest_label_observation",
+    "bulk_latest_label_observations",
+    "reviewer_set_penalty_prior",
+    "label_observation_history",
+    "label_count_summary",
+    "pr_attached_label_coverage",
+    "set_run_pr_link",
 ]
-
-_UPSERT_SQL = """
-INSERT OR REPLACE INTO runs (
-    session_id, archived_at, status, run_flow, skill, model, backend,
-    review_backend, fix_backend, test_backend,
-    review_only, deep, loop, remote_url, repo_slug, source_path, branch, base_branch,
-    head_sha, base_sha, changed_files, pr_number, pr_repo, total_cost_usd, total_findings,
-    grounding_rate, coverage_ratio, cost_per_finding_usd, wall_clock_seconds,
-    total_prompt_tokens, total_completion_tokens, total_cached_tokens,
-    outcome_labels, labeled_at, composite_reward, archive_path, schema_version
-) VALUES (
-    :session_id, :archived_at, :status, :run_flow, :skill, :model, :backend,
-    :review_backend, :fix_backend, :test_backend,
-    :review_only, :deep, :loop, :remote_url, :repo_slug, :source_path, :branch, :base_branch,
-    :head_sha, :base_sha, :changed_files, :pr_number, :pr_repo, :total_cost_usd, :total_findings,
-    :grounding_rate, :coverage_ratio, :cost_per_finding_usd, :wall_clock_seconds,
-    :total_prompt_tokens, :total_completion_tokens, :total_cached_tokens,
-    :outcome_labels, :labeled_at, :composite_reward, :archive_path, :schema_version
-)
-"""
-
-
-def _alter_add_missing(
-    conn: sqlite3.Connection,
-    table: str,
-    migrations: list[tuple[str, str]],
-) -> None:
-    """ALTER TABLE *table* to add any columns in *migrations* that are absent.
-
-    Each entry in *migrations* is a ``(column_name, column_type)`` pair.
-    Missing columns are added idempotently; a ``duplicate column name`` error
-    (raised by a race between concurrent openers) is silently swallowed, which
-    preserves the warn-and-continue semantics of the callers it replaces.
-
-    Args:
-        conn: An open SQLite connection.
-        table: Name of the table to inspect and alter.
-        migrations: Ordered list of ``(col, col_type)`` pairs to apply.
-    """
-    existing = {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}  # noqa: S608 - table is a module-local constant at every call site
-    for col, col_type in migrations:
-        if col not in existing:
-            try:
-                conn.execute(f"ALTER TABLE {table} ADD COLUMN {col} {col_type}")  # noqa: S608 - col/col_type are module-local constants
-            except sqlite3.OperationalError as exc:
-                if "duplicate column name" not in str(exc).lower():
-                    raise
-
-
-def _migrate_schema(conn: sqlite3.Connection) -> None:
-    """Add columns that exist in _CREATE_TABLE but are missing from the live DB."""
-    _alter_add_missing(
-        conn,
-        "runs",
-        [
-            ("review_backend", "TEXT"),
-            ("fix_backend", "TEXT"),
-            ("test_backend", "TEXT"),
-            ("rubric_json", "TEXT"),
-            ("base_sha", "TEXT"),
-            ("changed_files", "TEXT"),
-            ("composite_reward", "REAL"),
-            ("source_path", "TEXT"),
-            ("has_posterior", "INTEGER NOT NULL DEFAULT 0"),
-        ],
-    )
-
-
-def _recreate_label_observations_if_stale(conn: sqlite3.Connection) -> None:
-    """Drop and recreate ``label_observations`` if it predates the bitemporal/posterior columns.
-
-    The bitemporal/reward/posterior columns are part of the table's primary
-    structure, so rather than `ALTER TABLE ADD COLUMN` (which cannot retrofit
-    them cleanly for the spec's clean-recreate guarantee), a stale table is
-    dropped and rebuilt. A table missing either ``valid_at`` (pre-bitemporal) or
-    ``has_posterior`` (pre-reward-posterior-corrections) is considered stale. Dev
-    label rows are discarded (spec-sanctioned — repopulate via ``harvest``). The
-    ``runs`` table is never touched. Idempotent: after a recreate both columns
-    exist, so subsequent calls are a no-op.
-
-    Args:
-        conn: An open connection whose ``label_observations`` table exists.
-    """
-    existing = {row[1] for row in conn.execute("PRAGMA table_info(label_observations)").fetchall()}
-    if existing and ("valid_at" not in existing or "has_posterior" not in existing):
-        warnings.warn(
-            "label_observations table predates bitemporal/posterior columns and will be dropped "
-            "and recreated. Existing label rows will be lost — repopulate via `harvest`.",
-            stacklevel=2,
-        )
-        conn.execute("DROP TABLE label_observations")
-        conn.execute(_CREATE_LABEL_OBSERVATIONS_TABLE)
-
-
-def _migrate_label_observations_schema(conn: sqlite3.Connection) -> None:
-    """Additively ALTER-ADD columns missing from a live ``label_observations`` table.
-
-    Unlike ``_recreate_label_observations_if_stale`` (which drop-recreates for
-    structural bitemporal/posterior columns), this is non-destructive: the
-    ``source`` precedence marker is additive, so pre-existing rows are preserved
-    and default to ``'auto'``. Delegates to ``_alter_add_missing`` (the shared
-    helper that also backs ``_migrate_schema`` for the runs table).
-
-    Args:
-        conn: An open connection whose ``label_observations`` table exists.
-    """
-    _alter_add_missing(
-        conn,
-        "label_observations",
-        [
-            ("source", "TEXT NOT NULL DEFAULT 'auto'"),
-        ],
-    )
 
 
 def _get_connection(archive_dir: Path) -> sqlite3.Connection:

--- a/daydream/training/harvest.py
+++ b/daydream/training/harvest.py
@@ -87,7 +87,12 @@ import anyio
 from rich.console import Console
 
 from daydream import git_ops
-from daydream.archive.index import append_label_observation, query_runs, reviewer_set_penalty_prior
+from daydream.archive.index import (
+    append_label_observation,
+    query_runs,
+    reviewer_set_penalty_prior,
+    set_run_pr_link,
+)
 from daydream.git_ops import GitError, RateLimitError
 from daydream.training import reward
 from daydream.training.backfill_cache import BackfillCache
@@ -100,6 +105,7 @@ from daydream.training.labeler_signals import (
     comment_resolution_signal,
     fix_applied_signal,
     local_commit_applied_signal,
+    pr_link_signal,
     pr_merge_signal,
     reviewer_logins_signal,
 )
@@ -733,7 +739,12 @@ async def run_harvest(config: HarvestConfig) -> dict[str, int]:
     """Walk the archive and append one fresh annotation per indexed run.
 
     The single deferred annotate pass: for every indexed run, materialize the
-    capture-time ``base_sha`` (when missing), build the bitemporal annotation
+    capture-time ``base_sha`` (when missing), re-link orphan runs to their PR
+    (a run launched before its PR existed has ``pr_number=None`` but carries
+    ``repo_slug`` + ``head_sha``; :func:`pr_link_signal` resolves the PR by
+    head sha and the linkage is persisted via
+    :func:`daydream.archive.index.set_run_pr_link` so it becomes labelable),
+    build the bitemporal annotation
     (label + intrinsic reward + posterior sibling axis + captured reviewer set +
     ``valid_at``) via :func:`build_annotation`, and append it through
     :func:`daydream.archive.index.append_label_observation` (which persists
@@ -810,6 +821,19 @@ async def run_harvest(config: HarvestConfig) -> dict[str, int]:
                 row, clone_cache=clone_cache, fetched_repos=fetched_repos, console=console
             )
             _materialize_base_sha_if_missing(row, run_dir, repo_clone=row_repo_clone, console=console)
+            # Re-link orphan runs: the default deep loop archives before the PR
+            # exists, freezing ``pr_number=None``. Resolve the now-existing PR by
+            # ``head_sha`` so the run becomes labelable through the PR path. Stays
+            # inside the per-row ``try`` so a lookup error isolates to this row
+            # (and ``RateLimitError`` propagates to the abort handler unchanged).
+            if not _row_is_pr(row):
+                link = pr_link_signal(row, gh_api=gh_api_callable)
+                if link is not None:
+                    number, slug = link
+                    row["pr_number"] = number
+                    row["pr_repo"] = slug
+                    if not config.dry_run:
+                        set_run_pr_link(config.archive_dir, row["session_id"], number, slug)
             payload = build_annotation(
                 row,
                 run_dir=run_dir,

--- a/daydream/training/labeler_signals.py
+++ b/daydream/training/labeler_signals.py
@@ -28,6 +28,24 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Literal
 
+from daydream.pr_review import DAYDREAM_FOOTER
+
+
+def _is_daydream_comment(comment: dict[str, Any]) -> bool:
+    """Return True when ``comment`` was authored by daydream.
+
+    Daydream posts review comments as a normal authenticated user, so
+    authorship is identified by the :data:`DAYDREAM_FOOTER` badge in the
+    comment body rather than a ``*[bot]`` login.
+
+    Args:
+        comment: A parsed PR review comment dict (``body`` field read).
+
+    Returns:
+        True iff the comment body contains the daydream footer badge.
+    """
+    return DAYDREAM_FOOTER in (comment.get("body") or "")
+
 # ---------------------------------------------------------------------------
 # Result dataclasses
 # ---------------------------------------------------------------------------
@@ -305,9 +323,10 @@ def comment_resolution_signal(
 ) -> CommentResolutionSignal:
     """Return a proxy for "review comments addressed".
 
-    Top-level review comments authored by bot users (login matching
-    ``*[bot]``) are treated as issues; any reply (regardless of author
-    or body) marks the issue resolved.
+    Top-level review comments authored by daydream (identified by the
+    :data:`DAYDREAM_FOOTER` badge in the comment body) are treated as
+    issues; any reply (regardless of author or body) marks the issue
+    resolved.
 
     Args:
         row: Manifest row carrying ``pr_repo`` and ``pr_number``.
@@ -323,21 +342,19 @@ def comment_resolution_signal(
         return CommentResolutionSignal(total=0, replied=0, unresolved=0)
 
     comments = gh_api(repo, f"repos/{repo}/pulls/{number}/comments")
-    top_level_bot_ids: list[int] = []
+    top_level_daydream_ids: list[int] = []
     replies_by_parent: dict[int, int] = {}
 
     for comment in comments:
         in_reply_to = comment.get("in_reply_to_id")
         if in_reply_to is None:
-            user = comment.get("user") or {}
-            login = user.get("login", "")
-            if login.endswith("[bot]"):
-                top_level_bot_ids.append(comment["id"])
+            if _is_daydream_comment(comment):
+                top_level_daydream_ids.append(comment["id"])
         else:
             replies_by_parent[in_reply_to] = replies_by_parent.get(in_reply_to, 0) + 1
 
-    total = len(top_level_bot_ids)
-    replied = sum(1 for cid in top_level_bot_ids if replies_by_parent.get(cid, 0) >= 1)
+    total = len(top_level_daydream_ids)
+    replied = sum(1 for cid in top_level_daydream_ids if replies_by_parent.get(cid, 0) >= 1)
     return CommentResolutionSignal(total=total, replied=replied, unresolved=total - replied)
 
 
@@ -425,8 +442,6 @@ def reviewer_logins_signal(
         Exception: Any exception raised by ``gh_api`` is propagated
             unchanged; failures are never swallowed into ``[]``.
     """
-    from daydream.pr_review import DAYDREAM_FOOTER
-
     repo = row.get("pr_repo")
     number = row.get("pr_number")
     if repo is None or number is None:
@@ -452,7 +467,7 @@ def reviewer_logins_signal(
         user = comment.get("user") or {}
         login = user.get("login", "")
         if in_reply_to is None:
-            if DAYDREAM_FOOTER in (comment.get("body") or ""):
+            if _is_daydream_comment(comment):
                 daydream_comment_ids.add(comment["id"])
                 if login:
                     excluded.add(login)

--- a/daydream/training/labeler_signals.py
+++ b/daydream/training/labeler_signals.py
@@ -341,7 +341,7 @@ def comment_resolution_signal(
     if repo is None or number is None:
         return CommentResolutionSignal(total=0, replied=0, unresolved=0)
 
-    comments = gh_api(repo, f"repos/{repo}/pulls/{number}/comments")
+    comments = gh_api(repo, f"repos/{repo}/pulls/{number}/comments", paginate=True)
     top_level_daydream_ids: list[int] = []
     replies_by_parent: dict[int, int] = {}
 
@@ -384,7 +384,7 @@ def pr_link_signal(
     if not repo_slug or not head_sha:
         return None
 
-    pulls = gh_api(repo_slug, f"repos/{repo_slug}/commits/{head_sha}/pulls")
+    pulls = gh_api(repo_slug, f"repos/{repo_slug}/commits/{head_sha}/pulls", paginate=True)
     for pr in pulls:
         if pr.get("head", {}).get("sha") == head_sha:
             return int(pr["number"]), repo_slug
@@ -484,7 +484,7 @@ def reviewer_logins_signal(
     excluded: set[str] = set()
 
     # (a) Authors of PR reviews.
-    reviews = gh_api(repo, f"repos/{repo}/pulls/{number}/reviews")
+    reviews = gh_api(repo, f"repos/{repo}/pulls/{number}/reviews", paginate=True)
     for review in reviews:
         user = review.get("user") or {}
         login = user.get("login", "")
@@ -492,7 +492,7 @@ def reviewer_logins_signal(
             logins.add(login)
 
     # (b) Authors of replies to daydream's footer-marked top-level comments.
-    comments = gh_api(repo, f"repos/{repo}/pulls/{number}/comments")
+    comments = gh_api(repo, f"repos/{repo}/pulls/{number}/comments", paginate=True)
     daydream_comment_ids: set[int] = set()
     replies_by_parent: dict[int, list[str]] = {}
     for comment in comments:

--- a/daydream/training/labeler_signals.py
+++ b/daydream/training/labeler_signals.py
@@ -358,6 +358,39 @@ def comment_resolution_signal(
     return CommentResolutionSignal(total=total, replied=replied, unresolved=total - replied)
 
 
+def pr_link_signal(
+    row: dict[str, Any],
+    *,
+    gh_api: Callable[..., Any],
+) -> tuple[int, str] | None:
+    """Resolve an orphan run's PR by its ``head_sha`` (SHA-native lookup).
+
+    A run launched before its PR existed has ``pr_number=None`` but carries
+    ``repo_slug`` + ``head_sha``. This looks up the PR(s) whose head commit
+    is ``head_sha`` via ``repos/{slug}/commits/{sha}/pulls`` and returns the
+    one whose head matches exactly, disambiguating reused branch names.
+
+    Args:
+        row: Manifest row carrying ``repo_slug`` and ``head_sha``.
+        gh_api: Callable returning the parsed pull list for the commit.
+
+    Returns:
+        ``(pr_number, repo_slug)`` for the first pull whose head matches
+        ``head_sha``; ``None`` when required fields are missing or no pull
+        matches. Exceptions from ``gh_api`` propagate to the caller.
+    """
+    repo_slug = row.get("repo_slug")
+    head_sha = row.get("head_sha")
+    if not repo_slug or not head_sha:
+        return None
+
+    pulls = gh_api(repo_slug, f"repos/{repo_slug}/commits/{head_sha}/pulls")
+    for pr in pulls:
+        if pr.get("head", {}).get("sha") == head_sha:
+            return int(pr["number"]), repo_slug
+    return None
+
+
 def local_commit_applied_signal(
     row: dict[str, Any],
     *,

--- a/daydream/training/labeler_signals.py
+++ b/daydream/training/labeler_signals.py
@@ -28,7 +28,13 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Literal
 
-from daydream.pr_review import DAYDREAM_FOOTER
+# Version-stable prefix shared across all daydream releases.  Matching only
+# this prefix means comments posted by older or newer versions of daydream are
+# still recognised even when their embedded version string differs from the
+# currently-installed package.  (The full DAYDREAM_FOOTER constant from
+# daydream.pr_review embeds the current version number and therefore fails to
+# match historical comments posted by a different release.)
+_DAYDREAM_FOOTER_PREFIX = "<sub>🧙 Posted by [daydream v"
 
 
 def _is_daydream_comment(comment: dict[str, Any]) -> bool:
@@ -38,13 +44,20 @@ def _is_daydream_comment(comment: dict[str, Any]) -> bool:
     authorship is identified by the :data:`DAYDREAM_FOOTER` badge in the
     comment body rather than a ``*[bot]`` login.
 
+    The match is made against the version-stable prefix of the footer
+    (``_DAYDREAM_FOOTER_PREFIX``) rather than the full version-pinned
+    :data:`DAYDREAM_FOOTER` constant, so that comments posted by any release
+    of daydream are correctly identified even when their embedded version
+    string differs from the currently-installed package.
+
     Args:
         comment: A parsed PR review comment dict (``body`` field read).
 
     Returns:
         True iff the comment body contains the daydream footer badge.
     """
-    return DAYDREAM_FOOTER in (comment.get("body") or "")
+    return _DAYDREAM_FOOTER_PREFIX in (comment.get("body") or "")
+
 
 # ---------------------------------------------------------------------------
 # Result dataclasses
@@ -387,7 +400,11 @@ def pr_link_signal(
     pulls = gh_api(repo_slug, f"repos/{repo_slug}/commits/{head_sha}/pulls", paginate=True)
     for pr in pulls:
         if pr.get("head", {}).get("sha") == head_sha:
-            return int(pr["number"]), repo_slug
+            pr_number = pr.get("number")
+            if pr_number is None:
+                continue
+            pr_repo = pr.get("head", {}).get("repo", {}).get("full_name") or repo_slug
+            return int(pr_number), pr_repo
     return None
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ build-backend = "hatchling.build"
 [tool.mypy]
 python_version = "3.12"
 ignore_missing_imports = true
+namespace_packages = true
+explicit_package_bases = true
+mypy_path = "."
 
 [tool.ruff]
 target-version = "py312"

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -8,7 +8,7 @@ set -euo pipefail
 echo "Running pre-push checks..."
 
 echo "→ Linting with ruff..."
-uv run ruff check daydream
+uv run ruff check daydream tests
 
 echo "→ Type checking with mypy..."
 uv run mypy daydream

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -11,7 +11,7 @@ echo "→ Linting with ruff..."
 uv run ruff check daydream tests
 
 echo "→ Type checking with mypy..."
-uv run mypy daydream
+uv run mypy daydream tests
 
 echo "→ Running tests..."
 uv run pytest -v

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 
 import os
 import subprocess
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from pathlib import Path
 
 import pytest
@@ -290,7 +290,7 @@ def _reset_trajectory_recorder():
 
 
 @pytest.fixture(autouse=True)
-def archive_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+def archive_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
     """Isolate DAYDREAM_ARCHIVE_DIR to a per-test tmpdir so tests never touch ~/.daydream/archive/."""
     path = tmp_path / "archive"
     path.mkdir(parents=True, exist_ok=True)

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -23,6 +23,7 @@ from daydream.archive.index import (
     latest_label_observation,
     query_runs,
     reviewer_set_penalty_prior,
+    set_run_pr_link,
     update_labels,
     upsert_run,
 )
@@ -413,6 +414,13 @@ def test_update_labels_ambiguous_prefix(tmp_path: Path):
 
     with pytest.raises(ValueError, match="matches 2 sessions"):
         update_labels(tmp_path, "abc", ["x"])
+
+
+def test_set_run_pr_link_backfills_pr_columns(tmp_path: Path):
+    upsert_run(tmp_path, _make_manifest(session_id="s-orphan", pr_number=None, pr_repo=None))
+    set_run_pr_link(tmp_path, "s-orphan", 7, "org/repo")
+    row = query_runs(tmp_path, where="session_id = ?", params=("s-orphan",))[0]
+    assert (row["pr_number"], row["pr_repo"]) == (7, "org/repo")
 
 
 def test_query_runs_with_where(tmp_path: Path):

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -9,6 +9,7 @@ import sqlite3
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -29,6 +30,8 @@ from daydream.archive.index import (
 )
 from daydream.archive.manifest import Manifest, build_manifest
 from daydream.config_file import DaydreamFileConfig
+from daydream.runner import RunConfig
+from daydream.trajectory import TrajectoryRecorder
 
 # ---------------------------------------------------------------------------
 # Mock helpers
@@ -176,8 +179,8 @@ def test_build_manifest_basic(tmp_path: Path):
     )
 
     m = build_manifest(
-        recorder=recorder,
-        config=config,
+        recorder=cast(TrajectoryRecorder, recorder),
+        config=cast(RunConfig, config),
         git_ctx=git_ctx,
         status="complete",
         archive_path=tmp_path,
@@ -204,8 +207,8 @@ def test_manifest_to_dict_structure(tmp_path: Path):
     git_ctx = GitContext()
 
     m = build_manifest(
-        recorder=recorder,
-        config=config,
+        recorder=cast(TrajectoryRecorder, recorder),
+        config=cast(RunConfig, config),
         git_ctx=git_ctx,
         status="complete",
         archive_path=tmp_path,
@@ -241,8 +244,8 @@ def test_manifest_to_dict_code_context_carries_git_ctx_fields(tmp_path: Path):
     )
 
     m = build_manifest(
-        recorder=recorder,
-        config=config,
+        recorder=cast(TrajectoryRecorder, recorder),
+        config=cast(RunConfig, config),
         git_ctx=git_ctx,
         status="complete",
         archive_path=tmp_path,
@@ -271,8 +274,8 @@ def test_build_manifest_with_evaluation(tmp_path: Path):
     }
 
     m = build_manifest(
-        recorder=recorder,
-        config=config,
+        recorder=cast(TrajectoryRecorder, recorder),
+        config=cast(RunConfig, config),
         git_ctx=git_ctx,
         status="complete",
         archive_path=tmp_path,
@@ -292,8 +295,8 @@ def test_build_manifest_without_evaluation(tmp_path: Path):
     git_ctx = GitContext()
 
     m = build_manifest(
-        recorder=recorder,
-        config=config,
+        recorder=cast(TrajectoryRecorder, recorder),
+        config=cast(RunConfig, config),
         git_ctx=git_ctx,
         status="complete",
         archive_path=tmp_path,
@@ -312,8 +315,8 @@ def test_build_manifest_wall_clock_without_evaluation(tmp_path: Path):
     git_ctx = GitContext()
 
     m = build_manifest(
-        recorder=recorder,
-        config=config,
+        recorder=cast(TrajectoryRecorder, recorder),
+        config=cast(RunConfig, config),
         git_ctx=git_ctx,
         status="complete",
         archive_path=tmp_path,
@@ -332,8 +335,8 @@ def test_build_manifest_eval_wall_clock_overrides_recorder(tmp_path: Path):
     evaluation = {"timing": {"total_wall_clock_seconds": 42.5}}
 
     m = build_manifest(
-        recorder=recorder,
-        config=config,
+        recorder=cast(TrajectoryRecorder, recorder),
+        config=cast(RunConfig, config),
         git_ctx=git_ctx,
         status="complete",
         archive_path=tmp_path,
@@ -348,8 +351,8 @@ def test_build_manifest_eval_wall_clock_overrides_recorder(tmp_path: Path):
 # ---------------------------------------------------------------------------
 
 
-def _make_manifest(session_id: str = "sess-0001", **overrides) -> Manifest:
-    defaults = {
+def _make_manifest(session_id: str = "sess-0001", **overrides: Any) -> Manifest:
+    defaults: dict[str, Any] = {
         "session_id": session_id,
         "archived_at": "2026-04-29T00:00:00+00:00",
         "status": "complete",
@@ -625,7 +628,12 @@ def test_archive_run_round_trip(tmp_path: Path, archive_dir: Path):
     target, _, _ = _setup_bundle(tmp_path, session_id)
     recorder = _MockRecorder(session_id=session_id)
 
-    archive_run(recorder=recorder, target_dir=target, config=config, status="complete")
+    archive_run(
+        recorder=cast(TrajectoryRecorder, recorder),
+        target_dir=target,
+        config=cast(RunConfig, config),
+        status="complete",
+    )
 
     run_dir = archive_dir / "runs" / session_id
     assert run_dir.is_dir()
@@ -740,7 +748,9 @@ def test_human_label_wins_over_newer_auto_in_projection(tmp_path: Path):
     # A NEWER auto observation must NOT dethrone the human label:
     append_label_observation(tmp_path, "s-prec", labels=["rejected"], pr_state="closed",
                              labeler_version="auto-v2", evidence_sha="sha2", source="auto")
-    assert latest_label_observation(tmp_path, "s-prec")["labels"] == '["accepted"]'
+    prec_obs = latest_label_observation(tmp_path, "s-prec")
+    assert prec_obs is not None
+    assert prec_obs["labels"] == '["accepted"]'
     assert bulk_latest_label_observations(tmp_path, ["s-prec"])["s-prec"]["labels"] == '["accepted"]'
     assert label_count_summary(tmp_path) == {"accepted": 1}
 
@@ -792,6 +802,7 @@ def test_append_observation_persists_valid_at_and_reward(tmp_path: Path):
         reward_version="r1", reward_json='{"composite":0.5}', composite_reward=0.5,
     )
     obs = latest_label_observation(tmp_path, "s1")
+    assert obs is not None
     assert obs["valid_at"] == "2026-01-02T00:00:00+00:00"
     assert obs["reward_version"] == "r1"
     assert query_runs(tmp_path, "session_id = ?", ("s1",))[0]["composite_reward"] == 0.5
@@ -802,6 +813,7 @@ def test_append_observation_defaults_valid_at_to_observed_at(tmp_path: Path):
     append_label_observation(tmp_path, "s2", labels=[], pr_state=None,
                              labeler_version="v1", evidence_sha=None, valid_at=None)
     obs = latest_label_observation(tmp_path, "s2")
+    assert obs is not None
     assert obs["valid_at"] == obs["observed_at"]   # Q2 collapse for local runs
 
 

--- a/tests/test_cli_label.py
+++ b/tests/test_cli_label.py
@@ -6,6 +6,8 @@ cache value, the human-sourced observation in history, and the prior label
 echoed to stdout — not mere dispatch.
 """
 
+from typing import Any
+
 from daydream import cli
 from daydream.archive.index import (
     append_label_observation,
@@ -16,8 +18,8 @@ from daydream.archive.index import (
 from daydream.archive.manifest import Manifest
 
 
-def _make_manifest(session_id: str = "sess-0001", **overrides) -> Manifest:
-    defaults = {
+def _make_manifest(session_id: str = "sess-0001", **overrides: Any) -> Manifest:
+    defaults: dict[str, Any] = {
         "session_id": session_id,
         "archived_at": "2026-04-29T00:00:00+00:00",
         "status": "complete",

--- a/tests/test_deep_fanout.py
+++ b/tests/test_deep_fanout.py
@@ -12,6 +12,8 @@ from daydream.phases import phase_per_stack_reviews
 class _RecordingBackend:
     """Records every execute call; verifies no `agents` kwarg was passed."""
 
+    model = "mock-model"  # satisfies the Backend protocol's `model: str` member
+
     def __init__(self) -> None:
         self.prompts: list[str] = []
         self.agents_seen: list[Any] = []

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -1,5 +1,6 @@
 """Deep-mode prompt builder tests (D-09, D-10, D-19, D-20)."""
 from pathlib import Path
+from typing import TypedDict
 
 from daydream.deep.prompts import (
     DOC_REVIEW_NOTICE,
@@ -9,7 +10,21 @@ from daydream.deep.prompts import (
 )
 
 
-def _paths(tmp_path: Path) -> dict[str, Path]:
+class _PromptPaths(TypedDict):
+    """The four on-disk path kwargs shared by the per-stack and fallback builders.
+
+    Declaring each key's type explicitly lets mypy reconcile ``**p`` unpacking
+    with the builders' per-parameter signatures; a plain ``dict[str, Path]`` would
+    spill ``Path`` onto unrelated kwargs like ``prior_commits``/``is_docs_only``.
+    """
+
+    diff_path: Path
+    intent_path: Path
+    alternatives_path: Path
+    output_path: Path
+
+
+def _paths(tmp_path: Path) -> _PromptPaths:
     return {
         "diff_path": tmp_path / ".daydream" / "diff.patch",
         "intent_path": tmp_path / ".daydream" / "deep" / "intent.md",

--- a/tests/test_multi_turn_tokens.py
+++ b/tests/test_multi_turn_tokens.py
@@ -16,7 +16,7 @@ import json
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, TypedDict
 
 import pytest
 
@@ -35,11 +35,19 @@ from daydream.trajectory import (
     TrajectoryRecorder,
 )
 
+
 # -- Token value constants for the 3-turn sequence --------------------------
-TURN_1 = {"prompt_tokens": 100, "completion_tokens": 20, "cached_tokens": 5, "cost_usd": 0.001}
-TURN_2 = {"prompt_tokens": 150, "completion_tokens": 30, "cached_tokens": 10, "cost_usd": 0.002}
-TURN_3 = {"prompt_tokens": 200, "completion_tokens": 40, "cached_tokens": 15, "cost_usd": 0.003}
-TURNS = [TURN_1, TURN_2, TURN_3]
+class _TurnTokens(TypedDict):
+    prompt_tokens: int
+    completion_tokens: int
+    cached_tokens: int
+    cost_usd: float
+
+
+TURN_1: _TurnTokens = {"prompt_tokens": 100, "completion_tokens": 20, "cached_tokens": 5, "cost_usd": 0.001}
+TURN_2: _TurnTokens = {"prompt_tokens": 150, "completion_tokens": 30, "cached_tokens": 10, "cost_usd": 0.002}
+TURN_3: _TurnTokens = {"prompt_tokens": 200, "completion_tokens": 40, "cached_tokens": 15, "cost_usd": 0.003}
+TURNS: list[_TurnTokens] = [TURN_1, TURN_2, TURN_3]
 PHASES = [DaydreamPhase.REVIEW, DaydreamPhase.FIX, DaydreamPhase.TEST]
 
 

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -468,11 +468,15 @@ def test_redactor_scrubs_text_content_parts() -> None:
     assert len(out.message) == 3
     # First text part: secret redacted
     assert out.message[0].type == "text"
-    assert "sk-test-secret123abc" not in out.message[0].text
-    assert "[REDACTED_API_KEY]" in out.message[0].text
+    first_text = out.message[0].text
+    assert first_text is not None  # type='text' guarantees text is populated
+    assert "sk-test-secret123abc" not in first_text
+    assert "[REDACTED_API_KEY]" in first_text
     # Image part: unchanged
     assert out.message[1].type == "image"
-    assert out.message[1].source.path == "screenshot.png"
+    image_source = out.message[1].source
+    assert image_source is not None  # type='image' guarantees source is populated
+    assert image_source.path == "screenshot.png"
     # Second text part: clean, no redaction tokens injected
     assert out.message[2].type == "text"
     assert out.message[2].text == "clean text"

--- a/tests/test_training_base_sha.py
+++ b/tests/test_training_base_sha.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -84,10 +85,12 @@ def test_materialize_is_noop_when_base_sha_already_set(
         )
     )
     called: list[bool] = []
-    monkeypatch.setattr(
-        "daydream.git_ops.merge_base",
-        lambda *a, **k: called.append(True) or "should-not-be-used",
-    )
+
+    def _record_merge_base(*a: Any, **k: Any) -> str:
+        called.append(True)
+        return "should-not-be-used"
+
+    monkeypatch.setattr("daydream.git_ops.merge_base", _record_merge_base)
     result = materialize_base_sha(manifest_path, repo_clone=tmp_path / "fake-clone")
     assert result == "existing-sha"
     assert called == []

--- a/tests/test_training_harvest.py
+++ b/tests/test_training_harvest.py
@@ -15,10 +15,12 @@ from daydream.archive.index import (
     label_observation_history,
     latest_label_observation,
     pr_attached_label_coverage,
+    query_runs,
     upsert_run,
 )
 from daydream.archive.manifest import Manifest
 from daydream.git_ops import GitError
+from daydream.pr_review import DAYDREAM_FOOTER
 from daydream.training import harvest
 from daydream.training.backfill_cache import BackfillCache
 from daydream.training.harvest import (
@@ -102,6 +104,33 @@ def _fake_gh_not_merged_with_reviewer(login: str = "alice"):
         if endpoint.endswith("/comments"):
             return []
         return {"merged": False, "merged_at": None}
+
+    return responder
+
+
+def _fake_gh_merged_unresolved_daydream(merged_at: str):
+    """Return a ``gh_api`` responder: a merged PR whose only top-level comment
+    is daydream's footer-marked comment with NO reply.
+
+    Mirrors :func:`_fake_gh_merged` but the ``comments`` endpoint returns a
+    single unresolved daydream finding (identified by ``DAYDREAM_FOOTER``,
+    authored as a normal human user — not a ``[bot]``). The rubric must read
+    this as one unresolved daydream issue → ``contested``, not ``accepted``.
+    """
+
+    def responder(repo: str, endpoint: str, **kwargs: Any) -> Any:
+        if endpoint.endswith("/comments"):
+            return [
+                {
+                    "id": 1,
+                    "in_reply_to_id": None,
+                    "user": {"login": "kevin"},
+                    "body": f"finding\n\n{DAYDREAM_FOOTER}",
+                }
+            ]
+        if endpoint.endswith("/reviews"):
+            return []
+        return {"merged": True, "merged_at": merged_at}
 
     return responder
 
@@ -396,6 +425,25 @@ async def test_harvest_writes_one_annotation(tmp_path, archive_dir, monkeypatch)
     obs = latest_label_observation(archive_dir, "s1")
     assert summary["annotated"] == 1
     assert obs["valid_at"] == "2026-02-01T00:00:00+00:00" and obs["composite_reward"] is not None
+
+
+async def test_harvest_labels_unresolved_daydream_comment_contested(tmp_path, archive_dir, monkeypatch):
+    """Real-path: a merged PR whose daydream comment is unresolved → ``contested``.
+
+    Bug 1 regression guard. daydream posts review comments as a normal
+    authenticated (non-``[bot]``) user, so the old ``[bot]`` author check made
+    its findings invisible → every merged PR was mislabeled ``accepted``. This
+    drives ``run_harvest`` end-to-end and asserts the persisted run label is
+    ``contested``, the rubric's correct verdict for an unresolved finding.
+    """
+    _seed_archived_deep_run(archive_dir, "s-contest", merged_at="2026-02-01T00:00:00+00:00")
+    monkeypatch.setattr(
+        "daydream.training.harvest._gh_api",
+        _fake_gh_merged_unresolved_daydream("2026-02-01T00:00:00+00:00"),
+    )
+    await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
+    row = query_runs(archive_dir, "session_id = ?", ("s-contest",))[0]
+    assert json.loads(row["outcome_labels"]) == ["contested"]
 
 
 async def test_re_harvest_is_idempotent(tmp_path, archive_dir, monkeypatch):

--- a/tests/test_training_harvest.py
+++ b/tests/test_training_harvest.py
@@ -108,6 +108,34 @@ def _fake_gh_not_merged_with_reviewer(login: str = "alice"):
     return responder
 
 
+def _fake_gh_orphan_relink(merged_at: str):
+    """Return a ``gh_api`` responder that re-links an orphan run to PR 7.
+
+    The ``commits/{sha}/pulls`` probe resolves the row's ``head_sha`` to PR 7
+    (head sha ``orphsha``); PR 7 is then a merged PR whose only top-level
+    comment is daydream's footer-marked, unresolved finding — so once the run
+    is re-linked the rubric must label it ``contested``.
+    """
+
+    def responder(repo: str, endpoint: str, **kwargs: Any) -> Any:
+        if endpoint.endswith("/pulls") and "/commits/" in endpoint:
+            return [{"number": 7, "head": {"sha": "orphsha"}}]
+        if endpoint.endswith("/comments"):
+            return [
+                {
+                    "id": 1,
+                    "in_reply_to_id": None,
+                    "user": {"login": "kevin"},
+                    "body": f"finding\n\n{DAYDREAM_FOOTER}",
+                }
+            ]
+        if endpoint.endswith("/reviews"):
+            return []
+        return {"merged": True, "merged_at": merged_at}
+
+    return responder
+
+
 def _fake_gh_merged_unresolved_daydream(merged_at: str):
     """Return a ``gh_api`` responder: a merged PR whose only top-level comment
     is daydream's footer-marked comment with NO reply.
@@ -444,6 +472,83 @@ async def test_harvest_labels_unresolved_daydream_comment_contested(tmp_path, ar
     await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
     row = query_runs(archive_dir, "session_id = ?", ("s-contest",))[0]
     assert json.loads(row["outcome_labels"]) == ["contested"]
+
+
+async def test_harvest_relinks_orphan_run_and_labels_it(tmp_path, archive_dir, monkeypatch):
+    """Real-path: an orphan run (PR opened after launch) is re-linked at harvest.
+
+    Bug 2. The default deep loop archives before the PR exists, freezing
+    ``pr_number=None``. Harvest must re-link the orphan row by its ``head_sha``
+    (via ``commits/{sha}/pulls``), persist the linkage, and then label the run
+    through the PR path. Drives ``run_harvest`` end-to-end and asserts both the
+    persisted linkage and the resulting ``contested`` label.
+    """
+    run_dir = _seed_deep_bronze(tmp_path, verdict="consistent", grounding=1.0)
+    upsert_run(
+        archive_dir,
+        Manifest(
+            session_id="s-orph",
+            archived_at="2026-01-01T00:00:00Z",
+            run_flow="normal",
+            backend="claude",
+            repo_slug="org/repo",
+            branch="feat/x",
+            head_sha="orphsha",
+            base_branch="main",
+            pr_number=None,
+            pr_repo=None,
+            grounding_rate=1.0,
+            changed_files=["app.py"],
+            archive_path=str(run_dir),
+        ),
+    )
+    monkeypatch.setattr(
+        "daydream.training.harvest._gh_api",
+        _fake_gh_orphan_relink("2026-02-01T00:00:00+00:00"),
+    )
+    await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
+    row = query_runs(archive_dir, "session_id = ?", ("s-orph",))[0]
+    assert row["pr_number"] == 7 and row["pr_repo"] == "org/repo"  # linkage persisted
+    assert json.loads(row["outcome_labels"]) == ["contested"]  # now labelable (was orphan)
+
+
+async def test_harvest_leaves_true_local_run_unlinked(tmp_path, archive_dir, monkeypatch):
+    """Real-path: a local-only run (no PR ever opened) flows the local path.
+
+    Bug 2 guard. The ``commits/{sha}/pulls`` probe returns no PR, so the row
+    stays unlinked and must not be force-linked or errored — it flows the
+    existing local-branch posterior path unchanged.
+    """
+    run_dir = _seed_deep_bronze(tmp_path, verdict="consistent", grounding=1.0)
+    upsert_run(
+        archive_dir,
+        Manifest(
+            session_id="s-local",
+            archived_at="2026-01-01T00:00:00Z",
+            run_flow="normal",
+            backend="claude",
+            repo_slug="org/repo",
+            branch="feat/x",
+            head_sha="localsha",
+            base_branch="main",
+            pr_number=None,
+            pr_repo=None,
+            grounding_rate=1.0,
+            changed_files=["app.py"],
+            archive_path=str(run_dir),
+        ),
+    )
+
+    def _gh_no_pr(repo: str, endpoint: str, **kwargs: Any) -> Any:
+        if endpoint.endswith("/pulls") and "/commits/" in endpoint:
+            return []  # no PR ever opened
+        raise AssertionError(f"PR endpoints must not be hit for an unlinked local run ({endpoint})")
+
+    monkeypatch.setattr("daydream.training.harvest._gh_api", _gh_no_pr)
+    summary = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
+    row = query_runs(archive_dir, "session_id = ?", ("s-local",))[0]
+    assert row["pr_number"] is None
+    assert summary["errors"] == 0
 
 
 async def test_re_harvest_is_idempotent(tmp_path, archive_dir, monkeypatch):

--- a/tests/test_training_harvest.py
+++ b/tests/test_training_harvest.py
@@ -512,6 +512,63 @@ async def test_harvest_relinks_orphan_run_and_labels_it(tmp_path, archive_dir, m
     assert json.loads(row["outcome_labels"]) == ["contested"]  # now labelable (was orphan)
 
 
+async def test_harvest_dry_run_mutates_row_in_memory_but_suppresses_set_run_pr_link(
+    tmp_path, archive_dir, monkeypatch
+):
+    """dry_run=True: in-memory linkage preview is applied but not persisted.
+
+    The contract (harvest.py lines 832-836): when an orphan run re-links to a
+    PR, ``row['pr_number']`` and ``row['pr_repo']`` are mutated unconditionally
+    so ``build_annotation`` sees the linked PR and produces a PR-path annotation.
+    The ``set_run_pr_link`` DB write is guarded by ``if not config.dry_run`` and
+    must not fire.
+
+    This test exercises the real ``set_run_pr_link`` code path (no spy/patch):
+    if the guard is broken the function will actually write to the DB and the
+    DB-state assertions below will catch it.
+    """
+    run_dir = _seed_deep_bronze(tmp_path, verdict="consistent", grounding=1.0)
+    upsert_run(
+        archive_dir,
+        Manifest(
+            session_id="s-orph-dry",
+            archived_at="2026-01-01T00:00:00Z",
+            run_flow="normal",
+            backend="claude",
+            repo_slug="org/repo",
+            branch="feat/x",
+            head_sha="orphsha",
+            base_branch="main",
+            pr_number=None,
+            pr_repo=None,
+            grounding_rate=1.0,
+            changed_files=["app.py"],
+            archive_path=str(run_dir),
+        ),
+    )
+
+    monkeypatch.setattr(
+        "daydream.training.harvest._gh_api",
+        _fake_gh_orphan_relink("2026-02-01T00:00:00+00:00"),
+    )
+
+    summary = await run_harvest(
+        HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c", dry_run=True)
+    )
+
+    # In-memory linkage drove build_annotation through the PR path:
+    assert summary["would_annotate"] == 1
+    assert summary["annotated"] == 0
+
+    # DB row stays unlinked (real set_run_pr_link was not called):
+    row = query_runs(archive_dir, "session_id = ?", ("s-orph-dry",))[0]
+    assert row["pr_number"] is None
+    assert row["pr_repo"] is None
+
+    # No label observation written:
+    assert latest_label_observation(archive_dir, "s-orph-dry") is None
+
+
 async def test_harvest_leaves_true_local_run_unlinked(tmp_path, archive_dir, monkeypatch):
     """Real-path: a local-only run (no PR ever opened) flows the local path.
 

--- a/tests/test_training_labeler_signals.py
+++ b/tests/test_training_labeler_signals.py
@@ -18,6 +18,7 @@ from daydream.training.labeler_signals import (
     comment_resolution_signal,
     fix_applied_signal,
     local_commit_applied_signal,
+    pr_link_signal,
     pr_merge_signal,
     reviewer_logins_signal,
 )
@@ -273,3 +274,37 @@ def test_local_commit_applied_signal_no_local_commits_returns_rejected(tmp_path:
         file_at_fetcher=lambda repo, path, sha: "",
     )
     assert sig == LocalCommitAppliedSignal(verdict="rejected")
+
+
+def _fake_commits_pulls(pulls):
+    # pulls: list returned by repos/{slug}/commits/{sha}/pulls
+    def responder(repo, endpoint, **kwargs):
+        assert endpoint == "repos/org/repo/commits/abc123/pulls"
+        return pulls
+
+    return responder
+
+
+def test_pr_link_signal_matches_pr_by_head_sha() -> None:
+    row = {"repo_slug": "org/repo", "branch": "feat/x", "head_sha": "abc123", "pr_number": None}
+    gh = _fake_commits_pulls([{"number": 7, "head": {"sha": "abc123"}}])
+    assert pr_link_signal(row, gh_api=gh) == (7, "org/repo")
+
+
+def test_pr_link_signal_disambiguates_multiple_pulls_by_head_sha() -> None:
+    row = {"repo_slug": "org/repo", "branch": "feat/x", "head_sha": "abc123", "pr_number": None}
+    gh = _fake_commits_pulls(
+        [{"number": 5, "head": {"sha": "other"}}, {"number": 7, "head": {"sha": "abc123"}}]
+    )
+    assert pr_link_signal(row, gh_api=gh) == (7, "org/repo")
+
+
+def test_pr_link_signal_returns_none_when_no_head_sha_match() -> None:
+    row = {"repo_slug": "org/repo", "branch": "feat/x", "head_sha": "abc123", "pr_number": None}
+    gh = _fake_commits_pulls([{"number": 5, "head": {"sha": "forcepushed"}}])
+    assert pr_link_signal(row, gh_api=gh) is None
+
+
+def test_pr_link_signal_returns_none_without_required_fields() -> None:
+    gh = _fake_commits_pulls([])  # must NOT be called (missing head_sha short-circuits)
+    assert pr_link_signal({"repo_slug": "org/repo"}, gh_api=gh) is None

--- a/tests/test_training_labeler_signals.py
+++ b/tests/test_training_labeler_signals.py
@@ -157,12 +157,46 @@ def test_comment_resolution_signal_all_resolved() -> None:
     gh = _fake_gh_responder(
         {
             ("org/repo", "repos/org/repo/pulls/42/comments"): [
-                {"id": 1, "in_reply_to_id": None, "user": {"login": "coderabbitai[bot]"}},
+                {
+                    "id": 1,
+                    "in_reply_to_id": None,
+                    "user": {"login": "daydream-runner"},
+                    "body": f"finding\n\n{DAYDREAM_FOOTER}",
+                },
                 {"id": 2, "in_reply_to_id": 1, "user": {"login": "human"}, "body": "ack"},
             ],
         }
     )
     assert comment_resolution_signal(row, gh_api=gh) == CommentResolutionSignal(total=1, replied=1, unresolved=0)
+
+
+def test_comment_resolution_counts_footer_comment_from_human_author() -> None:
+    row = {"pr_repo": "org/repo", "pr_number": 42}
+    gh = _fake_gh_responder(
+        {
+            ("org/repo", "repos/org/repo/pulls/42/comments"): [
+                {
+                    "id": 1,
+                    "in_reply_to_id": None,
+                    "user": {"login": "kevin"},
+                    "body": f"finding\n\n{DAYDREAM_FOOTER}",
+                },
+            ],
+        }
+    )
+    assert comment_resolution_signal(row, gh_api=gh) == CommentResolutionSignal(total=1, replied=0, unresolved=1)
+
+
+def test_comment_resolution_ignores_non_daydream_bot_comment() -> None:
+    row = {"pr_repo": "org/repo", "pr_number": 42}
+    gh = _fake_gh_responder(
+        {
+            ("org/repo", "repos/org/repo/pulls/42/comments"): [
+                {"id": 1, "in_reply_to_id": None, "user": {"login": "coderabbitai[bot]"}, "body": "nit"},
+            ],
+        }
+    )
+    assert comment_resolution_signal(row, gh_api=gh) == CommentResolutionSignal(total=0, replied=0, unresolved=0)
 
 
 def test_local_commit_applied_signal_positive(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fixes two BLOCKER bugs from #122 that corrupt the forward data-collection path for auto-labeling (regressions in #89): daydream's own PR comments were invisible to the labeler (so every merged PR was labeled `accepted`), and default deep-loop runs became orphan/unlabelable because `pr_number` was only captured at CLI launch.

Closes #122.

## Changes

### Fixed
- **Footer-based comment attribution.** `comment_resolution_signal` and `reviewer_logins_signal` now identify daydream-authored comments by the `DAYDREAM_FOOTER` badge rather than a `[bot]` author suffix. `--comment`/deep flows post via `gh api` as the authenticated human user, so the `[bot]` check silently counted zero daydream comments → `unresolved=0` → uniformly-positive `accepted` corpus.
- **Version-stable footer match.** `_is_daydream_comment` matches a version-stable footer prefix (`_DAYDREAM_FOOTER_PREFIX`) instead of the full version-pinned `DAYDREAM_FOOTER`, so comments from any daydream release are recognized.
- **Archive-time PR re-linkage.** Orphan runs (fixes applied locally before a PR exists → `pr_number=None`) are re-linked to their PR at harvest time via a new SHA-native `pr_link_signal`, making the default-flow runs labelable.
- **Pagination.** All four list-endpoint `gh_api` calls in `labeler_signals` (`comments`, `commits/{sha}/pulls`, `reviews`, `comments`) now pass `paginate=True`; GitHub's default 30-item cap was silently truncating results on busy PRs.
- `pr_link_signal` extracts `pr_repo` from the PR payload's `head.repo.full_name` rather than always falling back to `repo_slug`, and guards against a missing `pr_number`.

### Added
- `set_run_pr_link` in `daydream/archive/index.py` to backfill PR linkage on an existing run row.
- `daydream/archive/_schema.py` — extracted SQL schema constants, migration helpers, and DDL strings out of `index.py` (which now re-exports for backward compatibility).

## Motivation

Per #122: the buggy attribution was worse than missing data — it produced a uniformly-positive corpus that teaches the model its noise is good. Both bugs defeat the auto-labeling shipped in #89.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed

- Real-path harvest test asserting a merged PR with an unresolved daydream comment takes the contested/rejected branch of `derive_outcome_label` (not `accepted`).
- Real-path test driving the archive path with PR linkage resolved post-run (orphan run becomes labelable).
- Test covering `dry_run=True` orphan re-link: verifies the in-memory linkage preview fires `build_annotation` but suppresses the DB write.

Verified locally: `make lint` (clean), `make typecheck` (no issues, 74 files), and `pytest tests/test_training_labeler_signals.py tests/test_training_harvest.py tests/test_archive.py` → 100 passed.

## Related Issues

- Closes #122
- Parent: #86 — Open-Weight Code-Review Model (Milestone 1)
- Regression in: #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)