### PR TITLE
fix(ui): render Task-family tools with resolved labels in both render paths

### DIFF
--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -486,9 +486,9 @@ async def run_agent(
                         # later TaskOutput/TaskStop resolves its originating label.
                         tool_registry.observe_result(event.id, event.output)
                     else:
+                        tool_registry.observe_result(event.id, event.output)
                         panel = tool_registry.get(event.id)
                         if panel:
-                            tool_registry.observe_result(event.id, event.output)
                             panel.set_result(event.output, event.is_error)
                             panel.finish()
                             tool_registry.remove(event.id)

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -30,6 +30,7 @@ from daydream.ui import (
     AgentTextRenderer,
     LiveToolPanelRegistry,
     create_console,
+    format_callback_progress,
     print_cost,
     print_error,
     print_thinking,
@@ -402,9 +403,13 @@ async def run_agent(
 
     _state.current_backends.append(backend)
     try:
+        # The registry owns the task_id→label correlation used by both render
+        # modes; it is created unconditionally. In callback mode only its
+        # label-correlation methods (note_call/observe_result/resolve_call_label)
+        # are used — no panels or Live display are created.
+        tool_registry = LiveToolPanelRegistry(console, _state.quiet_mode)
         if not use_callback:
             agent_renderer = AgentTextRenderer(console)
-            tool_registry = LiveToolPanelRegistry(console, _state.quiet_mode)
 
         try:
             event_iter = backend.execute(
@@ -461,8 +466,12 @@ async def run_agent(
 
                 elif isinstance(event, ToolStartEvent):
                     if progress_callback is not None:
-                        first_arg = next(iter(event.input.values()), "") if event.input else ""
-                        progress_callback(f"{event.name} {first_arg}"[:80])
+                        # Record the originating call so a backgrounded launch's
+                        # result can later resolve a Task-family label, then emit a
+                        # plumbing-free, label-aware progress line.
+                        tool_registry.note_call(event.id, event.name, event.input)
+                        label = tool_registry.resolve_call_label(event.name, event.input)
+                        progress_callback(format_callback_progress(event.name, event.input, label))
                     else:
                         if agent_renderer.has_content:
                             agent_renderer.finish()
@@ -472,7 +481,11 @@ async def run_agent(
                         inv.observe(event)
 
                 elif isinstance(event, ToolResultEvent):
-                    if not use_callback:
+                    if use_callback:
+                        # Populate the task_id→label map in callback mode too, so a
+                        # later TaskOutput/TaskStop resolves its originating label.
+                        tool_registry.observe_result(event.id, event.output)
+                    else:
                         panel = tool_registry.get(event.id)
                         if panel:
                             tool_registry.observe_result(event.id, event.output)

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -475,6 +475,7 @@ async def run_agent(
                     if not use_callback:
                         panel = tool_registry.get(event.id)
                         if panel:
+                            tool_registry.observe_result(event.id, event.output)
                             panel.set_result(event.output, event.is_error)
                             panel.finish()
                             tool_registry.remove(event.id)

--- a/daydream/ui.py
+++ b/daydream/ui.py
@@ -2842,9 +2842,63 @@ class LiveToolPanelRegistry:
         self._static_ids: set[str] = set()
         self._live: Live | None = None
         self._group = _ActivePanelsGroup(self)
+        self._task_labels: dict[str, str] = {}
 
     # Tool names whose panels should scroll inline rather than pin via Live.
     _STATIC_TOOL_NAMES: frozenset[str] = frozenset({"Task"})
+
+    # Tool names whose result strings assign an id we can label.
+    _LABEL_SOURCE_TOOL_NAMES: frozenset[str] = frozenset({"Bash", "Agent", "Task", "TaskCreate"})
+
+    def observe_result(self, tool_use_id: str, output: str) -> None:
+        """Harvest a ``task_id → label`` mapping from an originating tool's result.
+
+        When a backgrounded launch tool (``Bash``/``Agent``/``Task``) or a
+        ``TaskCreate`` call returns, its result string assigns an id. This
+        records that id mapped to a human-readable label derived from the
+        originating call's input args.
+
+        Args:
+            tool_use_id: The id of the originating tool call.
+            output: The originating tool's result string.
+
+        """
+        panel = self._panels.get(tool_use_id)
+        if panel is None or panel._name not in self._LABEL_SOURCE_TOOL_NAMES:
+            return
+        task_id = _parse_assigned_task_id(panel._name, output)
+        if task_id is None:
+            return
+        self._task_labels[task_id] = self._derive_label(panel._args, task_id)
+
+    @staticmethod
+    def _derive_label(args: dict[str, object], task_id: str) -> str:
+        """Derive a human label from an originating call's input args.
+
+        Prefers ``description``, then ``subagent_type``, then the first line of
+        ``command``/``prompt``, falling back to the bare id.
+        """
+        for key in ("description", "subagent_type"):
+            value = args.get(key)
+            if isinstance(value, str) and value.strip():
+                return value
+        for key in ("command", "prompt"):
+            value = args.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.splitlines()[0]
+        return task_id
+
+    def resolve_label(self, task_id: str) -> str | None:
+        """Return the harvested label for a task id, or None if unknown.
+
+        Args:
+            task_id: The assigned task id to look up.
+
+        Returns:
+            The mapped label, or None if no mapping was recorded.
+
+        """
+        return self._task_labels.get(task_id)
 
     def create(
         self,

--- a/daydream/ui.py
+++ b/daydream/ui.py
@@ -520,6 +520,70 @@ def _parse_assigned_task_id(name: str, output: str) -> str | None:
     return None
 
 
+def _derive_task_label(args: dict[str, object], task_id: str) -> str:
+    """Derive a human label from an originating Task-family call's input args.
+
+    Prefers ``subject`` (todo-list ``TaskCreate``), then ``description``,
+    then ``subagent_type``, then the first line of ``command``/``prompt``,
+    falling back to the bare id.
+
+    Args:
+        args: The originating tool call's input args.
+        task_id: The assigned id, used as the fallback when no label key is set.
+
+    Returns:
+        The derived label, or ``task_id`` if no meaningful key is present.
+
+    """
+    for key in ("subject", "description", "subagent_type"):
+        value = args.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    for key in ("command", "prompt"):
+        value = args.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.splitlines()[0]
+    return task_id
+
+
+def format_callback_progress(
+    name: str,
+    args: dict[str, object],
+    label: str | None,
+    max_len: int = 80,
+) -> str:
+    """Build a one-line, plumbing-free progress string for the callback render path.
+
+    The callback (parallel-fix/quiet) render path streams a single status line
+    per tool call instead of a Rich panel. Task-family tools must never surface
+    the opaque ``name + task_id`` dump or mechanical ``block``/``timeout`` args
+    here; they lead with the resolved label (when known) and otherwise fall back
+    to a non-opaque derivation (``subject``/``description``/first command line),
+    demoting the bare id to a parenthesized suffix.
+
+    Args:
+        name: The tool's name.
+        args: The tool's input args.
+        label: The resolved label for the call's id, or None when unknown.
+        max_len: Maximum length of the returned string.
+
+    Returns:
+        A truncated progress line.
+
+    """
+    if name in _BACKGROUND_TASK_TOOLS or name in _TODO_TASK_TOOLS:
+        id_key = "task_id" if name in _BACKGROUND_TASK_TOOLS else "taskId"
+        task_id = str(args.get(id_key, "")).strip()
+        lead = label or _derive_task_label(args, task_id)
+        line = f"{name} {lead}"
+        if task_id and task_id != lead:
+            line += f" ({task_id})"
+        return line[:max_len]
+
+    first_arg = next(iter(args.values()), "") if args else ""
+    return f"{name} {first_arg}"[:max_len]
+
+
 def _colorize_tool_args(args: dict[str, object]) -> Text:
     """Apply neon syntax highlighting to tool call arguments.
 
@@ -2893,6 +2957,10 @@ class LiveToolPanelRegistry:
         self._live: Live | None = None
         self._group = _ActivePanelsGroup(self)
         self._task_labels: dict[str, str] = {}
+        # Originating-call args by tool_use_id, populated on every ToolStartEvent
+        # (both render modes) so result→label correlation does not depend on a
+        # panel having been created (the callback render path creates no panels).
+        self._call_args: dict[str, tuple[str, dict[str, object]]] = {}
 
     # Tool names whose panels should scroll inline rather than pin via Live.
     _STATIC_TOOL_NAMES: frozenset[str] = frozenset({"Task"})
@@ -2900,44 +2968,44 @@ class LiveToolPanelRegistry:
     # Tool names whose result strings assign an id we can label.
     _LABEL_SOURCE_TOOL_NAMES: frozenset[str] = frozenset({"Bash", "Agent", "Task", "TaskCreate"})
 
+    def note_call(self, tool_use_id: str, name: str, args: dict[str, object]) -> None:
+        """Record an originating call's name + args for later label correlation.
+
+        Called on **every** ``ToolStartEvent`` (both the Live-panel and the
+        callback render paths) so that ``observe_result`` can resolve a
+        background ``task_id``'s label without a panel having been created.
+
+        Args:
+            tool_use_id: The id of the tool call.
+            name: The tool's name.
+            args: The tool's input args.
+
+        """
+        self._call_args[tool_use_id] = (name, args)
+
     def observe_result(self, tool_use_id: str, output: str) -> None:
         """Harvest a ``task_id → label`` mapping from an originating tool's result.
 
         When a backgrounded launch tool (``Bash``/``Agent``/``Task``) or a
         ``TaskCreate`` call returns, its result string assigns an id. This
         records that id mapped to a human-readable label derived from the
-        originating call's input args.
+        originating call's input args. Reads the originating call from the
+        ``note_call`` store, so it works in both render modes (panel creation
+        is not a prerequisite).
 
         Args:
             tool_use_id: The id of the originating tool call.
             output: The originating tool's result string.
 
         """
-        panel = self._panels.get(tool_use_id)
-        if panel is None or panel._name not in self._LABEL_SOURCE_TOOL_NAMES:
+        call = self._call_args.get(tool_use_id)
+        if call is None or call[0] not in self._LABEL_SOURCE_TOOL_NAMES:
             return
-        task_id = _parse_assigned_task_id(panel._name, output)
+        name, args = call
+        task_id = _parse_assigned_task_id(name, output)
         if task_id is None:
             return
-        self._task_labels[task_id] = self._derive_label(panel._args, task_id)
-
-    @staticmethod
-    def _derive_label(args: dict[str, object], task_id: str) -> str:
-        """Derive a human label from an originating call's input args.
-
-        Prefers ``subject`` (todo-list ``TaskCreate``), then ``description``,
-        then ``subagent_type``, then the first line of ``command``/``prompt``,
-        falling back to the bare id.
-        """
-        for key in ("subject", "description", "subagent_type"):
-            value = args.get(key)
-            if isinstance(value, str) and value.strip():
-                return value
-        for key in ("command", "prompt"):
-            value = args.get(key)
-            if isinstance(value, str) and value.strip():
-                return value.splitlines()[0]
-        return task_id
+        self._task_labels[task_id] = _derive_task_label(args, task_id)
 
     def resolve_label(self, task_id: str) -> str | None:
         """Return the harvested label for a task id, or None if unknown.
@@ -2950,6 +3018,29 @@ class LiveToolPanelRegistry:
 
         """
         return self._task_labels.get(task_id)
+
+    def resolve_call_label(self, name: str, args: dict[str, object]) -> str | None:
+        """Resolve a Task-family call's human label from its args.
+
+        Background-task tools (``TaskOutput``/``TaskStop``) key off ``task_id``;
+        todo-list tools (``TaskGet``/``TaskUpdate``/…) key off ``taskId``. Returns
+        the harvested label for that id, or None when no mapping was recorded (the
+        caller falls back to a non-opaque rendering).
+
+        Args:
+            name: The tool's name.
+            args: The tool's input args.
+
+        Returns:
+            The resolved label, or None if the tool is not Task-family or the id
+            is unknown.
+
+        """
+        if name in _BACKGROUND_TASK_TOOLS:
+            return self.resolve_label(str(args.get("task_id", "")))
+        if name in _TODO_TASK_TOOLS:
+            return self.resolve_label(str(args.get("taskId", "")))
+        return None
 
     def create(
         self,
@@ -2976,14 +3067,12 @@ class LiveToolPanelRegistry:
         if tool_use_id in self._panels:
             self._finalize_panel(tool_use_id)
 
+        # Store the originating call's args for later result→label correlation.
+        self.note_call(tool_use_id, name, args)
+
         # Resolve a human label so the panel header leads with it instead of the
-        # opaque/numeric id. Background-task tools key off ``task_id``; todo-list
-        # tools (TaskGet/TaskUpdate) key off ``taskId``.
-        label: str | None = None
-        if name in _BACKGROUND_TASK_TOOLS:
-            label = self.resolve_label(str(args.get("task_id", "")))
-        elif name in _TODO_TASK_TOOLS:
-            label = self.resolve_label(str(args.get("taskId", "")))
+        # opaque/numeric id.
+        label = self.resolve_call_label(name, args)
 
         panel = LiveToolPanel(
             console=self._console,

--- a/daydream/ui.py
+++ b/daydream/ui.py
@@ -94,6 +94,14 @@ STYLE_AGENT_BG = Style(bgcolor="#051208")
 # Dim style
 STYLE_DIM = Style(dim=True)
 
+# Truncation limits shared across the tool renderers. Named so the scattered
+# magic line-counts/char-caps have one source of meaning instead of bare literals.
+_TASK_PROMPT_MAX_LINES = 10
+_RESULT_MAX_LINES = 20
+_EDIT_PREVIEW_MAX_LINES = 30
+_GLOB_MAX_LINES = 15
+_WRITE_PREVIEW_CHARS = 200
+
 # Mechanical/plumbing tool args dropped from the generic key=value fallback so the
 # line leads with meaningful keys instead of noise.
 _MECHANICAL_TOOL_ARGS = frozenset({"block", "timeout"})
@@ -849,9 +857,9 @@ def _build_tool_header(
         content.append("BLOCKED", style=Style(color=NEON_COLORS["red"], bold=True))
         content.append("\n")
         if old_string:
-            lines = old_string.split("\n")[:30]  # Up to 30 lines
+            lines = old_string.split("\n")[:_EDIT_PREVIEW_MAX_LINES]
             preview = "\n".join(lines)
-            if len(old_string.split("\n")) > 30:
+            if len(old_string.split("\n")) > _EDIT_PREVIEW_MAX_LINES:
                 preview += "\n..."
             preview_len = max(len(preview) - 1, 1)
             # Show with gradient from red to orange
@@ -869,9 +877,9 @@ def _build_tool_header(
         content.append("FLOWING", style=Style(color=NEON_COLORS["green"], bold=True))
         content.append("\n")
         if new_string:
-            lines = new_string.split("\n")[:30]  # Up to 30 lines
+            lines = new_string.split("\n")[:_EDIT_PREVIEW_MAX_LINES]
             preview = "\n".join(lines)
-            if len(new_string.split("\n")) > 30:
+            if len(new_string.split("\n")) > _EDIT_PREVIEW_MAX_LINES:
                 preview += "\n..."
             preview_len = max(len(preview) - 1, 1)
             # Show with gradient from cyan to green
@@ -933,7 +941,7 @@ def _build_tool_body_extras(name: str, args: dict[str, object]) -> list:
         extras.append(Markdown(f"**{description}**"))
     if prompt:
         prompt_lines = prompt.split("\n")
-        max_prompt_lines = 10
+        max_prompt_lines = _TASK_PROMPT_MAX_LINES
         if len(prompt_lines) > max_prompt_lines:
             remaining = len(prompt_lines) - max_prompt_lines
             truncated_prompt = "\n".join(prompt_lines[:max_prompt_lines])
@@ -947,7 +955,7 @@ def _build_tool_body_extras(name: str, args: dict[str, object]) -> list:
 def _build_result_content(
     content: str,
     is_error: bool = False,
-    max_lines: int = 20,
+    max_lines: int = _RESULT_MAX_LINES,
 ) -> tuple[Text | Syntax | Group, bool]:
     """Build styled result content with syntax highlighting.
 
@@ -1051,7 +1059,11 @@ def print_tool_call(
         elif content_str:
             # Show truncated content preview for non-markdown files
             content.append("\n")
-            preview = content_str[:200] + "..." if len(content_str) > 200 else content_str
+            preview = (
+                content_str[:_WRITE_PREVIEW_CHARS] + "..."
+                if len(content_str) > _WRITE_PREVIEW_CHARS
+                else content_str
+            )
             content.append(preview, style=Style(color=NEON_COLORS["foreground"], dim=True))
     elif name == "Task":
         extras = _build_tool_body_extras(name, args)
@@ -1311,7 +1323,7 @@ def print_tool_result(
     console: Console,
     content: str,
     is_error: bool = False,
-    max_lines: int = 20,
+    max_lines: int = _RESULT_MAX_LINES,
 ) -> None:
     """Print a tool result with neon syntax highlighting.
 
@@ -2561,7 +2573,7 @@ class LiveToolPanel:
         """
         return _build_tool_header(self._name, self._args, self._quiet_mode, label=self._label)
 
-    def _build_result_content_internal(self, max_lines: int = 20) -> Text | Syntax | Group:
+    def _build_result_content_internal(self, max_lines: int = _RESULT_MAX_LINES) -> Text | Syntax | Group:
         """Build the result content with syntax highlighting.
 
         Delegates to shared _build_result_content() helper for consistent styling.
@@ -2602,7 +2614,7 @@ class LiveToolPanel:
         result, _ = _build_result_content(self._result, self._is_error, max_lines)
         return result
 
-    def _build_glob_result(self, max_lines: int = 15) -> Text:
+    def _build_glob_result(self, max_lines: int = _GLOB_MAX_LINES) -> Text:
         """Build formatted Glob result showing file count and paths.
 
         Args:
@@ -2651,7 +2663,7 @@ class LiveToolPanel:
 
         return result
 
-    def _build_grep_result(self, max_lines: int = 20) -> Text | Syntax | Group:
+    def _build_grep_result(self, max_lines: int = _RESULT_MAX_LINES) -> Text | Syntax | Group:
         """Build formatted Grep result showing match count.
 
         Args:

--- a/daydream/ui.py
+++ b/daydream/ui.py
@@ -580,8 +580,10 @@ def _append_label_and_id(header_line: Text, label: str | None, task_id: str, *, 
     """Append the shared ``→ "label" (id)`` suffix to a task-tool header line.
 
     Used by both the background-task (``TaskOutput``/``TaskStop``) and todo-list
-    (``TaskGet``/``TaskUpdate``) header branches so the label/id formatting lives
-    in one place (R13). When ``label`` is ``None`` only the dimmed id is shown.
+    (``TaskGet``/``TaskUpdate``/``TaskList``) header branches so the label/id
+    formatting lives in one place (R13). When ``label`` is ``None`` only the
+    dimmed id is shown; when ``task_id`` is empty (e.g. id-less ``TaskList``)
+    no id suffix is appended at all.
 
     Args:
         header_line: The header Text to append to (mutated in place).
@@ -594,7 +596,8 @@ def _append_label_and_id(header_line: Text, label: str | None, task_id: str, *, 
         header_line.append(' → "')
         header_line.append(label, style=STYLE_CYAN)
         header_line.append('"')
-    header_line.append(f" ({id_prefix}{task_id})", style=STYLE_DIM)
+    if task_id.strip():
+        header_line.append(f" ({id_prefix}{task_id})", style=STYLE_DIM)
 
 
 def _build_tool_header(

--- a/daydream/ui.py
+++ b/daydream/ui.py
@@ -492,7 +492,7 @@ def pill(text: str, bg_color: str, fg_color: str) -> Text:
 # =============================================================================
 
 # Patterns for harvesting the assigned task id out of an originating tool's result string.
-_LAUNCH_TASK_ID_PATTERN = re.compile(r"\bID:\s*([A-Za-z0-9]+)\b")
+_LAUNCH_TASK_ID_PATTERN = re.compile(r"\bCommand running in background with ID:\s*([A-Za-z0-9]+)\b")
 _TASKCREATE_ID_PATTERN = re.compile(r"Task #(\d+)")
 _LAUNCH_TASK_TOOLS = frozenset({"Bash", "Agent", "Task"})
 
@@ -520,6 +520,27 @@ def _parse_assigned_task_id(name: str, output: str) -> str | None:
     return None
 
 
+def _task_label_ns_key(name: str, task_id: str) -> str:
+    """Return a namespaced ``_task_labels`` dict key for *task_id*.
+
+    Background launch tools (Bash/Agent/Task) use opaque alphanumeric ids;
+    TaskCreate uses small integer ids.  Storing both in one flat dict risks
+    collision (e.g. a background id of ``'1'`` colliding with TaskCreate id
+    ``1``).  This function prefixes each id with a short namespace tag so the
+    two id spaces never share keys.
+
+    Args:
+        name: The originating tool's name.
+        task_id: The raw assigned id string.
+
+    Returns:
+        ``"bg:<task_id>"`` for launch tools, ``"tc:<task_id>"`` for TaskCreate.
+    """
+    if name in _LAUNCH_TASK_TOOLS:
+        return f"bg:{task_id}"
+    return f"tc:{task_id}"
+
+
 def _derive_task_label(args: dict[str, object], task_id: str) -> str:
     """Derive a human label from an originating Task-family call's input args.
 
@@ -538,12 +559,24 @@ def _derive_task_label(args: dict[str, object], task_id: str) -> str:
     for key in ("subject", "description", "subagent_type"):
         value = args.get(key)
         if isinstance(value, str) and value.strip():
-            return value
+            return value[:80]
     for key in ("command", "prompt"):
         value = args.get(key)
         if isinstance(value, str) and value.strip():
-            return value.splitlines()[0]
+            return value.splitlines()[0][:80]
     return task_id
+
+
+def _task_id_key(name: str) -> str:
+    """Return the arg key that carries a task id for a Task-family tool.
+
+    Background-task tools (``TaskOutput``/``TaskStop``) use ``"task_id"``;
+    todo-list tools (``TaskGet``/``TaskUpdate``/…) use ``"taskId"``.  Keeping
+    this mapping in one place eliminates the three-way duplication that existed
+    across ``resolve_call_label``, ``format_callback_progress``, and
+    ``_build_tool_header``.
+    """
+    return "task_id" if name in _BACKGROUND_TASK_TOOLS else "taskId"
 
 
 def format_callback_progress(
@@ -572,13 +605,10 @@ def format_callback_progress(
 
     """
     if name in _BACKGROUND_TASK_TOOLS or name in _TODO_TASK_TOOLS:
-        id_key = "task_id" if name in _BACKGROUND_TASK_TOOLS else "taskId"
-        task_id = str(args.get(id_key, "")).strip()
+        task_id = str(args.get(_task_id_key(name), "")).strip()
         lead = label or _derive_task_label(args, task_id)
-        line = f"{name} {lead}"
-        if task_id and task_id != lead:
-            line += f" ({task_id})"
-        return line[:max_len]
+        suffix = _format_label_and_id_str(lead, task_id if task_id != lead else "")
+        return f"{name} {suffix}"[:max_len]
 
     first_arg = next(iter(args.values()), "") if args else ""
     return f"{name} {first_arg}"[:max_len]
@@ -640,6 +670,31 @@ def _colorize_tool_args(args: dict[str, object]) -> Text:
 # =============================================================================
 
 
+def _format_label_and_id_str(label: str | None, task_id: str, *, id_prefix: str = "") -> str:
+    """Return the plain-string ``lead (id)`` suffix shared by all task-tool paths.
+
+    This is the single source of truth for the lead-label / id-suffix pattern
+    (R13). Both the Rich panel path (``_append_label_and_id``) and the plain
+    callback/quiet path (``format_callback_progress``) delegate here so the
+    logic is never duplicated.
+
+    Args:
+        label: Resolved human-readable label, or None when unresolved.
+        task_id: The opaque/numeric id to demote to a parenthesized suffix.
+        id_prefix: Optional prefix for the id (e.g. ``"#"`` for todo ids).
+
+    Returns:
+        A plain string such as ``'some label (42)'`` or ``'(42)'``.
+
+    """
+    parts: list[str] = []
+    if label is not None:
+        parts.append(label)
+    if task_id.strip():
+        parts.append(f"({id_prefix}{task_id})")
+    return " ".join(parts)
+
+
 def _append_label_and_id(header_line: Text, label: str | None, task_id: str, *, id_prefix: str = "") -> None:
     """Append the shared ``→ "label" (id)`` suffix to a task-tool header line.
 
@@ -696,7 +751,7 @@ def _build_tool_header(
         header_line = Text()
         header_line.append("\U0001f3a0 ", style=STYLE_ORANGE)  # 🎠
         header_line.append(name, style=STYLE_BOLD_PINK)
-        task_id = str(args.get("task_id", ""))
+        task_id = str(args.get(_task_id_key(name), ""))
         _append_label_and_id(header_line, label, task_id)
         content.append_text(header_line)
         return content
@@ -715,7 +770,7 @@ def _build_tool_header(
                 header_line.append("  ")
                 header_line.append(subject, style=STYLE_CYAN)
         else:
-            task_id = str(args.get("taskId", ""))
+            task_id = str(args.get(_task_id_key(name), ""))
             _append_label_and_id(header_line, label, task_id, id_prefix="#")
             if name == "TaskUpdate":
                 status = str(args.get("status", "")).strip()
@@ -2621,7 +2676,7 @@ class LiveToolPanel:
 
         # Special handling for TaskOutput - surface the <output> snippet, stripping
         # the XML-ish tag plumbing (retrieval_status, task_id, status, ...).
-        if self._name == "TaskOutput":
+        if self._name == "TaskOutput" and not self._is_error:
             match = re.search(r"<output>(.*?)</output>", self._result, re.DOTALL)
             snippet = match.group(1).strip() if match else self._result
             result, _ = _build_result_content(snippet, self._is_error, max_lines)
@@ -2956,7 +3011,7 @@ class LiveToolPanelRegistry:
         self._static_ids: set[str] = set()
         self._live: Live | None = None
         self._group = _ActivePanelsGroup(self)
-        self._task_labels: dict[str, str] = {}
+        self._task_labels: dict[str, str] = {}  # keyed by _task_label_ns_key(name, id)
         # Originating-call args by tool_use_id, populated on every ToolStartEvent
         # (both render modes) so result→label correlation does not depend on a
         # panel having been created (the callback render path creates no panels).
@@ -2966,7 +3021,7 @@ class LiveToolPanelRegistry:
     _STATIC_TOOL_NAMES: frozenset[str] = frozenset({"Task"})
 
     # Tool names whose result strings assign an id we can label.
-    _LABEL_SOURCE_TOOL_NAMES: frozenset[str] = frozenset({"Bash", "Agent", "Task", "TaskCreate"})
+    _LABEL_SOURCE_TOOL_NAMES: frozenset[str] = _LAUNCH_TASK_TOOLS | frozenset({"TaskCreate"})
 
     def note_call(self, tool_use_id: str, name: str, args: dict[str, object]) -> None:
         """Record an originating call's name + args for later label correlation.
@@ -2998,26 +3053,28 @@ class LiveToolPanelRegistry:
             output: The originating tool's result string.
 
         """
-        call = self._call_args.get(tool_use_id)
+        call = self._call_args.pop(tool_use_id, None)
         if call is None or call[0] not in self._LABEL_SOURCE_TOOL_NAMES:
             return
         name, args = call
         task_id = _parse_assigned_task_id(name, output)
         if task_id is None:
             return
-        self._task_labels[task_id] = _derive_task_label(args, task_id)
+        self._task_labels[_task_label_ns_key(name, task_id)] = _derive_task_label(args, task_id)
 
-    def resolve_label(self, task_id: str) -> str | None:
+    def resolve_label(self, name: str, task_id: str) -> str | None:
         """Return the harvested label for a task id, or None if unknown.
 
         Args:
+            name: The originating tool's name (used to select the correct
+                namespace prefix — launch tools vs. TaskCreate).
             task_id: The assigned task id to look up.
 
         Returns:
             The mapped label, or None if no mapping was recorded.
 
         """
-        return self._task_labels.get(task_id)
+        return self._task_labels.get(_task_label_ns_key(name, task_id))
 
     def resolve_call_label(self, name: str, args: dict[str, object]) -> str | None:
         """Resolve a Task-family call's human label from its args.
@@ -3036,10 +3093,12 @@ class LiveToolPanelRegistry:
             is unknown.
 
         """
-        if name in _BACKGROUND_TASK_TOOLS:
-            return self.resolve_label(str(args.get("task_id", "")))
-        if name in _TODO_TASK_TOOLS:
-            return self.resolve_label(str(args.get("taskId", "")))
+        if name in _BACKGROUND_TASK_TOOLS or name in _TODO_TASK_TOOLS:
+            task_id = str(args.get(_task_id_key(name), ""))
+            # Background tools look up ids stored by launch tools ("bg:" prefix);
+            # todo-list tools look up ids stored by TaskCreate ("tc:" prefix).
+            origin_name = "Bash" if name in _BACKGROUND_TASK_TOOLS else "TaskCreate"
+            return self.resolve_label(origin_name, task_id)
         return None
 
     def create(
@@ -3159,6 +3218,8 @@ class LiveToolPanelRegistry:
                 self._console.print(panel._render_panel())
         self._active_order.clear()
         self._panels.clear()
+        self._call_args.clear()
+        self._task_labels.clear()
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -3186,6 +3247,10 @@ class LiveToolPanelRegistry:
 
     def _finalize_panel(self, tool_use_id: str) -> None:
         """Remove a panel from the active set and print its final state."""
+        # Prune the originating-call record; by finalization time observe_result
+        # has already harvested any task_id → label mapping from it.
+        self._call_args.pop(tool_use_id, None)
+
         if tool_use_id in self._static_ids:
             self._static_ids.discard(tool_use_id)
             panel = self._panels.pop(tool_use_id, None)

--- a/daydream/ui.py
+++ b/daydream/ui.py
@@ -98,6 +98,10 @@ STYLE_DIM = Style(dim=True)
 # line leads with meaningful keys instead of noise.
 _MECHANICAL_TOOL_ARGS = frozenset({"block", "timeout"})
 
+# Background-task tools that reference an opaque background ``task_id``; rendered
+# with the resolved label leading and the id demoted to a dim suffix.
+_BACKGROUND_TASK_TOOLS = frozenset({"TaskOutput", "TaskStop"})
+
 # Mystical action terms for tool displays
 MYSTICAL_TERMS = {
     "Glob": ["scrying", "divining", "seeking", "wandering"],
@@ -564,6 +568,8 @@ def _build_tool_header(
     name: str,
     args: dict[str, object],
     quiet_mode: bool = False,
+    *,
+    label: str | None = None,
 ) -> Text:
     """Build styled tool header content.
 
@@ -573,12 +579,31 @@ def _build_tool_header(
         name: Name of the tool being called.
         args: Dictionary of arguments passed to the tool.
         quiet_mode: If True, hide command details for Bash tools.
+        label: Resolved human-readable label for background-task tools
+            (``TaskOutput``/``TaskStop``); when provided it leads the header
+            and the opaque ``task_id`` is demoted to a dim suffix.
 
     Returns:
         Rich Text containing the styled tool header.
 
     """
     content = Text()
+
+    # Background-task tools reference an opaque task_id; lead with the resolved
+    # label (when known) and demote the id to a dim suffix. Never surface the
+    # mechanical block/timeout plumbing.
+    if name in _BACKGROUND_TASK_TOOLS:
+        header_line = Text()
+        header_line.append("\U0001f3a0 ", style=STYLE_ORANGE)  # 🎠
+        header_line.append(name, style=STYLE_BOLD_PINK)
+        task_id = str(args.get("task_id", ""))
+        if label is not None:
+            header_line.append(' → "')
+            header_line.append(label, style=STYLE_CYAN)
+            header_line.append('"')
+        header_line.append(f" ({task_id})", style=STYLE_DIM)
+        content.append_text(header_line)
+        return content
 
     # Special handling for Skill tool calls - Gradient Whisper style
     if name == "Skill":
@@ -2445,6 +2470,7 @@ class LiveToolPanel:
         name: str,
         args: dict[str, object],
         quiet_mode: bool = False,
+        label: str | None = None,
     ) -> None:
         """Initialize the LiveToolPanel.
 
@@ -2454,12 +2480,15 @@ class LiveToolPanel:
             name: Name of the tool being called.
             args: Dictionary of arguments passed to the tool.
             quiet_mode: If True, use static display instead of Live updates.
+            label: Resolved human label for background-task tools, threaded
+                through to the header by the registry.
 
         """
         self._console = console
         self._tool_use_id = tool_use_id
         self._name = name
         self._args = args
+        self._label = label
         self._result: str | None = None
         self._is_error: bool = False
         self._live: Live | None = None
@@ -2481,7 +2510,7 @@ class LiveToolPanel:
             Rich Text containing the styled tool header.
 
         """
-        return _build_tool_header(self._name, self._args, self._quiet_mode)
+        return _build_tool_header(self._name, self._args, self._quiet_mode, label=self._label)
 
     def _build_result_content_internal(self, max_lines: int = 20) -> Text | Syntax | Group:
         """Build the result content with syntax highlighting.
@@ -2925,12 +2954,19 @@ class LiveToolPanelRegistry:
         if tool_use_id in self._panels:
             self._finalize_panel(tool_use_id)
 
+        # Resolve a human label for background-task tools so the panel header
+        # leads with it instead of the opaque task_id.
+        label: str | None = None
+        if name in _BACKGROUND_TASK_TOOLS:
+            label = self.resolve_label(str(args.get("task_id", "")))
+
         panel = LiveToolPanel(
             console=self._console,
             tool_use_id=tool_use_id,
             name=name,
             args=args,
             quiet_mode=self._quiet_mode,
+            label=label,
         )
         self._panels[tool_use_id] = panel
 

--- a/daydream/ui.py
+++ b/daydream/ui.py
@@ -102,6 +102,10 @@ _MECHANICAL_TOOL_ARGS = frozenset({"block", "timeout"})
 # with the resolved label leading and the id demoted to a dim suffix.
 _BACKGROUND_TASK_TOOLS = frozenset({"TaskOutput", "TaskStop"})
 
+# Todo-list tools that reference a small-integer ``taskId``; the human label is
+# the todo's ``subject`` (in ``TaskCreate``'s input; later tools resolve by id).
+_TODO_TASK_TOOLS = frozenset({"TaskCreate", "TaskGet", "TaskUpdate", "TaskList"})
+
 # Mystical action terms for tool displays
 MYSTICAL_TERMS = {
     "Glob": ["scrying", "divining", "seeking", "wandering"],
@@ -564,6 +568,27 @@ def _colorize_tool_args(args: dict[str, object]) -> Text:
 # =============================================================================
 
 
+def _append_label_and_id(header_line: Text, label: str | None, task_id: str, *, id_prefix: str = "") -> None:
+    """Append the shared ``→ "label" (id)`` suffix to a task-tool header line.
+
+    Used by both the background-task (``TaskOutput``/``TaskStop``) and todo-list
+    (``TaskGet``/``TaskUpdate``) header branches so the label/id formatting lives
+    in one place (R13). When ``label`` is ``None`` only the dimmed id is shown.
+
+    Args:
+        header_line: The header Text to append to (mutated in place).
+        label: Resolved human-readable label, or None when unresolved.
+        task_id: The opaque/numeric id to demote to a dim suffix.
+        id_prefix: Optional prefix for the id (e.g. ``"#"`` for todo ids).
+
+    """
+    if label is not None:
+        header_line.append(' → "')
+        header_line.append(label, style=STYLE_CYAN)
+        header_line.append('"')
+    header_line.append(f" ({id_prefix}{task_id})", style=STYLE_DIM)
+
+
 def _build_tool_header(
     name: str,
     args: dict[str, object],
@@ -597,11 +622,31 @@ def _build_tool_header(
         header_line.append("\U0001f3a0 ", style=STYLE_ORANGE)  # 🎠
         header_line.append(name, style=STYLE_BOLD_PINK)
         task_id = str(args.get("task_id", ""))
-        if label is not None:
-            header_line.append(' → "')
-            header_line.append(label, style=STYLE_CYAN)
-            header_line.append('"')
-        header_line.append(f" ({task_id})", style=STYLE_DIM)
+        _append_label_and_id(header_line, label, task_id)
+        content.append_text(header_line)
+        return content
+
+    # Todo-list tools. TaskCreate leads with its own ``subject`` (description
+    # renders below as a Markdown body via _build_tool_body_extras). TaskGet /
+    # TaskUpdate lead with the resolved subject and demote the numeric id;
+    # TaskUpdate appends the meaningful status change. Never surface plumbing.
+    if name in _TODO_TASK_TOOLS:
+        header_line = Text()
+        header_line.append("\U0001f3a0 ", style=STYLE_ORANGE)  # 🎠
+        header_line.append(name, style=STYLE_BOLD_PINK)
+        if name == "TaskCreate":
+            subject = str(args.get("subject", "")).strip()
+            if subject:
+                header_line.append("  ")
+                header_line.append(subject, style=STYLE_CYAN)
+        else:
+            task_id = str(args.get("taskId", ""))
+            _append_label_and_id(header_line, label, task_id, id_prefix="#")
+            if name == "TaskUpdate":
+                status = str(args.get("status", "")).strip()
+                if status:
+                    header_line.append(" → ")
+                    header_line.append(status, style=STYLE_CYAN)
         content.append_text(header_line)
         return content
 
@@ -871,10 +916,14 @@ def _build_tool_header(
 def _build_tool_body_extras(name: str, args: dict[str, object]) -> list:
     """Return extra renderables to display between header and result.
 
-    Currently used for the Task tool, whose `description` and `prompt`
-    arguments are rendered as Markdown so bold/italic/code/lists display
+    Used for the Task tool, whose `description` and `prompt` arguments are
+    rendered as Markdown, and for TaskCreate, whose `description` renders as the
+    Markdown body below its `subject` header — so bold/italic/code/lists display
     properly instead of as a flat key=value dump.
     """
+    if name == "TaskCreate":
+        description = str(args.get("description", "")).strip()
+        return [Markdown(description)] if description else []
     if name != "Task":
         return []
     extras: list = []
@@ -2904,10 +2953,11 @@ class LiveToolPanelRegistry:
     def _derive_label(args: dict[str, object], task_id: str) -> str:
         """Derive a human label from an originating call's input args.
 
-        Prefers ``description``, then ``subagent_type``, then the first line of
-        ``command``/``prompt``, falling back to the bare id.
+        Prefers ``subject`` (todo-list ``TaskCreate``), then ``description``,
+        then ``subagent_type``, then the first line of ``command``/``prompt``,
+        falling back to the bare id.
         """
-        for key in ("description", "subagent_type"):
+        for key in ("subject", "description", "subagent_type"):
             value = args.get(key)
             if isinstance(value, str) and value.strip():
                 return value
@@ -2954,11 +3004,14 @@ class LiveToolPanelRegistry:
         if tool_use_id in self._panels:
             self._finalize_panel(tool_use_id)
 
-        # Resolve a human label for background-task tools so the panel header
-        # leads with it instead of the opaque task_id.
+        # Resolve a human label so the panel header leads with it instead of the
+        # opaque/numeric id. Background-task tools key off ``task_id``; todo-list
+        # tools (TaskGet/TaskUpdate) key off ``taskId``.
         label: str | None = None
         if name in _BACKGROUND_TASK_TOOLS:
             label = self.resolve_label(str(args.get("task_id", "")))
+        elif name in _TODO_TASK_TOOLS:
+            label = self.resolve_label(str(args.get("taskId", "")))
 
         panel = LiveToolPanel(
             console=self._console,

--- a/daydream/ui.py
+++ b/daydream/ui.py
@@ -94,6 +94,10 @@ STYLE_AGENT_BG = Style(bgcolor="#051208")
 # Dim style
 STYLE_DIM = Style(dim=True)
 
+# Mechanical/plumbing tool args dropped from the generic key=value fallback so the
+# line leads with meaningful keys instead of noise.
+_MECHANICAL_TOOL_ARGS = frozenset({"block", "timeout"})
+
 # Mystical action terms for tool displays
 MYSTICAL_TERMS = {
     "Glob": ["scrying", "divining", "seeking", "wandering"],
@@ -471,9 +475,6 @@ def pill(text: str, bg_color: str, fg_color: str) -> Text:
 # Tool Call Component
 # =============================================================================
 
-# Pattern for tool argument colorization
-_TOOL_ARG_PATTERN = re.compile(r"(\w+)=((?:'[^']*'|\"[^\"]*\"|[^,\s]+))")
-
 # Patterns for harvesting the assigned task id out of an originating tool's result string.
 _LAUNCH_TASK_ID_PATTERN = re.compile(r"\bID:\s*([A-Za-z0-9]+)\b")
 _TASKCREATE_ID_PATTERN = re.compile(r"Task #(\d+)")
@@ -521,7 +522,10 @@ def _colorize_tool_args(args: dict[str, object]) -> Text:
     """
     result = Text()
 
-    for i, (key, value) in enumerate(args.items()):
+    # Drop mechanical/plumbing keys entirely so the line leads with meaningful args.
+    items = [(key, value) for key, value in args.items() if key not in _MECHANICAL_TOOL_ARGS]
+
+    for i, (key, value) in enumerate(items):
         if i > 0:
             result.append(", ", style=STYLE_FG)
 

--- a/daydream/ui.py
+++ b/daydream/ui.py
@@ -2591,6 +2591,14 @@ class LiveToolPanel:
         if self._name == "Edit" and not self._is_error:
             return self._build_edit_result()
 
+        # Special handling for TaskOutput - surface the <output> snippet, stripping
+        # the XML-ish tag plumbing (retrieval_status, task_id, status, ...).
+        if self._name == "TaskOutput":
+            match = re.search(r"<output>(.*?)</output>", self._result, re.DOTALL)
+            snippet = match.group(1).strip() if match else self._result
+            result, _ = _build_result_content(snippet, self._is_error, max_lines)
+            return result
+
         result, _ = _build_result_content(self._result, self._is_error, max_lines)
         return result
 

--- a/daydream/ui.py
+++ b/daydream/ui.py
@@ -1369,57 +1369,6 @@ def print_tool_result(
 
 
 # =============================================================================
-# Code Result Component
-# =============================================================================
-
-
-def print_code_result(
-    console: Console,
-    content: str,
-    filename: str = "",
-    max_lines: int = 30,
-) -> None:
-    """Print code content with syntax highlighting.
-
-    Uses Rich's Syntax component for proper highlighting and
-    automatic line wrapping that respects terminal width.
-
-    Args:
-        console: Rich Console instance for output.
-        content: The code content to display.
-        filename: Optional filename to detect language (e.g., "test.py").
-        max_lines: Maximum number of lines to display.
-
-    """
-    lines = content.split("\n")
-    truncated = len(lines) > max_lines
-    display_content = "\n".join(lines[:max_lines]) if truncated else content
-
-    # Detect language from filename extension
-    if "." in filename:
-        lang = filename.rsplit(".", 1)[-1]
-        # Map common extensions
-        lang_map = {"py": "python", "js": "javascript", "ts": "typescript", "md": "markdown"}
-        lang = lang_map.get(lang, lang)
-    else:
-        lang = "text"
-
-    syntax = Syntax(
-        display_content,
-        lang,
-        theme="dracula",
-        line_numbers=True,
-        word_wrap=True,
-    )
-    console.print(syntax)
-
-    if truncated:
-        console.print(
-            f"[neon.dim]... ({len(lines) - max_lines} more lines)[/]"
-        )
-
-
-# =============================================================================
 # Thinking Component
 # =============================================================================
 

--- a/daydream/ui.py
+++ b/daydream/ui.py
@@ -474,6 +474,34 @@ def pill(text: str, bg_color: str, fg_color: str) -> Text:
 # Pattern for tool argument colorization
 _TOOL_ARG_PATTERN = re.compile(r"(\w+)=((?:'[^']*'|\"[^\"]*\"|[^,\s]+))")
 
+# Patterns for harvesting the assigned task id out of an originating tool's result string.
+_LAUNCH_TASK_ID_PATTERN = re.compile(r"\bID:\s*([A-Za-z0-9]+)\b")
+_TASKCREATE_ID_PATTERN = re.compile(r"Task #(\d+)")
+_LAUNCH_TASK_TOOLS = frozenset({"Bash", "Agent", "Task"})
+
+
+def _parse_assigned_task_id(name: str, output: str) -> str | None:
+    """Extract the assigned task id from an originating tool's result string.
+
+    Backgrounded launch tools (Bash/Agent/Task) report their id in a
+    ``Command running in background with ID: <id>. …`` prose string; TaskCreate
+    reports it as ``Task #<N> created successfully: …``.
+
+    Args:
+        name: The originating tool's name.
+        output: The tool's result string.
+
+    Returns:
+        The captured id, or None if the input does not match the expected shape.
+    """
+    if name in _LAUNCH_TASK_TOOLS:
+        match = _LAUNCH_TASK_ID_PATTERN.search(output)
+        return match.group(1) if match else None
+    if name == "TaskCreate":
+        match = _TASKCREATE_ID_PATTERN.search(output)
+        return match.group(1) if match else None
+    return None
+
 
 def _colorize_tool_args(args: dict[str, object]) -> Text:
     """Apply neon syntax highlighting to tool call arguments.

--- a/tests/fixtures/task_tools/bash_bg_launch.txt
+++ b/tests/fixtures/task_tools/bash_bg_launch.txt
@@ -1,0 +1,1 @@
+Command running in background with ID: b0nsmwb99. Output is being written to: /tmp/x/b0nsmwb99.output

--- a/tests/fixtures/task_tools/taskcreate_result.txt
+++ b/tests/fixtures/task_tools/taskcreate_result.txt
@@ -1,0 +1,1 @@
+Task #1 created successfully: Find tool-call render code

--- a/tests/fixtures/task_tools/taskoutput_result.txt
+++ b/tests/fixtures/task_tools/taskoutput_result.txt
@@ -1,0 +1,9 @@
+<retrieval_status>success</retrieval_status>
+<task_id>b0nsmwb99</task_id>
+<task_type>local_bash</task_type>
+<status>completed</status>
+<exit_code>0</exit_code>
+<output>
+spike: backgrounded command output shape
+done-with-bg-work
+</output>

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -215,3 +215,32 @@ def test_taskoutput_header_unknown_id_falls_back_to_bare_id():
     reg.create("c2", "TaskOutput", {"task_id": "zzz999", "block": True, "timeout": 1})
     out = _render_panel_text(reg, "c2")
     assert "zzz999" in out and "block" not in out
+
+
+def test_taskcreate_header_shows_subject_and_body():
+    from rich.console import Console
+
+    from daydream.ui import _build_tool_body_extras, _build_tool_header
+
+    c = Console(record=True)
+    args = {"subject": "Fix auth bug", "description": "details here"}
+    c.print(_build_tool_header("TaskCreate", args))
+    for e in _build_tool_body_extras("TaskCreate", args):
+        c.print(e)
+    out = c.export_text()
+    assert "Fix auth bug" in out and "details here" in out
+
+
+def test_taskupdate_resolves_subject_and_shows_status():
+    from rich.console import Console
+
+    from daydream.ui import LiveToolPanelRegistry
+
+    reg = LiveToolPanelRegistry(Console(record=True), quiet_mode=True)
+    reg.create("c1", "TaskCreate", {"subject": "Fix auth bug", "description": "d"})
+    reg.observe_result("c1", "Task #1 created successfully: Fix auth bug")
+    reg.create("c2", "TaskUpdate", {"taskId": "1", "status": "completed"})
+    c = Console(record=True)
+    c.print(reg.get("c2")._render_panel())
+    out = c.export_text()
+    assert "Fix auth bug" in out and "completed" in out

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -170,3 +170,15 @@ def test_colorize_tool_args_drops_mechanical_keys():
     out = console.export_text()
     assert "command" in out and "pytest" in out
     assert "block" not in out and "timeout" not in out
+
+
+def test_registry_harvests_task_label_from_originating_result():
+    from rich.console import Console
+
+    from daydream.ui import LiveToolPanelRegistry
+
+    reg = LiveToolPanelRegistry(Console(record=True), quiet_mode=True)
+    reg.create("c1", "Bash", {"command": "pytest", "run_in_background": True, "description": "Run tests"})
+    reg.observe_result("c1", "Command running in background with ID: a066168. Output ...")
+    assert reg.resolve_label("a066168") == "Run tests"
+    assert reg.resolve_label("unknown") is None

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -262,3 +262,16 @@ def test_taskoutput_result_shows_output_snippet():
     out = c.export_text()
     assert "done-with-bg-work" in out  # the <output> snippet surfaces
     assert "<retrieval_status>" not in out  # tag plumbing is stripped
+
+
+def test_task_prompt_truncation_uses_named_limit():
+    from rich.console import Console
+
+    from daydream.ui import _TASK_PROMPT_MAX_LINES, _build_tool_body_extras
+
+    args = {"description": "d", "prompt": "\n".join(f"l{i}" for i in range(40))}
+    extras = _build_tool_body_extras("Task", args)
+    c = Console(record=True)
+    for e in extras:
+        c.print(e)
+    assert f"({40 - _TASK_PROMPT_MAX_LINES} more lines)" in c.export_text()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -158,3 +158,15 @@ def test_parse_background_task_id_from_launch_string():
     create = (Path(__file__).parent / "fixtures/task_tools/taskcreate_result.txt").read_text()
     assert _parse_assigned_task_id("TaskCreate", create) == "1"
     assert _parse_assigned_task_id("Bash", "no id here") is None
+
+
+def test_colorize_tool_args_drops_mechanical_keys():
+    from rich.console import Console
+
+    from daydream.ui import _colorize_tool_args
+
+    console = Console(record=True)
+    console.print(_colorize_tool_args({"command": "pytest", "block": True, "timeout": 120000}))
+    out = console.export_text()
+    assert "command" in out and "pytest" in out
+    assert "block" not in out and "timeout" not in out

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -275,3 +275,38 @@ def test_task_prompt_truncation_uses_named_limit():
     for e in extras:
         c.print(e)
     assert f"({40 - _TASK_PROMPT_MAX_LINES} more lines)" in c.export_text()
+
+
+async def test_run_agent_renders_taskoutput_with_label(tmp_path, monkeypatch):
+    from rich.console import Console
+
+    import daydream.agent as agent_mod
+    from daydream.agent import run_agent
+    from daydream.backends import ResultEvent, ToolResultEvent, ToolStartEvent
+    from daydream.trajectory import DaydreamPhase
+    from tests.test_agent_recorder_integration import MockBackend  # existing event-replay mock
+
+    rec = Console(record=True, width=120)
+    monkeypatch.setattr(agent_mod, "console", rec)
+    backend = MockBackend(
+        [
+            ToolStartEvent(
+                id="c1",
+                name="Bash",
+                input={"command": "pytest", "run_in_background": True, "description": "Run tests"},
+            ),
+            ToolResultEvent(id="c1", output="Command running in background with ID: a066168. ...", is_error=False),
+            ToolStartEvent(id="c2", name="TaskOutput", input={"task_id": "a066168", "block": True, "timeout": 120000}),
+            ToolResultEvent(
+                id="c2",
+                output="<task_id>a066168</task_id>\n<output>\ndone-with-bg-work\n</output>",
+                is_error=False,
+            ),
+            ResultEvent(structured_output=None, continuation=None),
+        ]
+    )
+    await run_agent(backend, tmp_path, "go", phase=DaydreamPhase.REVIEW)
+    out = rec.export_text()
+    assert "Run tests" in out and "a066168" in out
+    assert "done-with-bg-work" in out
+    assert "block=True" not in out and "timeout=120000" not in out

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 
@@ -146,3 +148,13 @@ def test_prompt_user_destructive_defaults_decline_on_eof(monkeypatch, message):
     reset_state()
     monkeypatch.setattr("builtins.input", Mock(side_effect=EOFError("EOF when reading a line")))
     assert prompt_user(Console(record=True), message, default="n") == "n"
+
+
+def test_parse_background_task_id_from_launch_string():
+    from daydream.ui import _parse_assigned_task_id
+
+    launch = (Path(__file__).parent / "fixtures/task_tools/bash_bg_launch.txt").read_text()
+    assert _parse_assigned_task_id("Bash", launch) == "b0nsmwb99"
+    create = (Path(__file__).parent / "fixtures/task_tools/taskcreate_result.txt").read_text()
+    assert _parse_assigned_task_id("TaskCreate", create) == "1"
+    assert _parse_assigned_task_id("Bash", "no id here") is None

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -246,6 +246,18 @@ def test_taskupdate_resolves_subject_and_shows_status():
     assert "Fix auth bug" in out and "completed" in out
 
 
+def test_tasklist_header_omits_empty_id_suffix():
+    from rich.console import Console
+
+    from daydream.ui import LiveToolPanelRegistry
+
+    reg = LiveToolPanelRegistry(Console(record=True), quiet_mode=True)
+    reg.create("c1", "TaskList", {})
+    out = _render_panel_text(reg, "c1")
+    assert "TaskList" in out
+    assert "(#)" not in out and "()" not in out
+
+
 def test_taskoutput_result_shows_output_snippet():
     from rich.console import Console
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -182,3 +182,36 @@ def test_registry_harvests_task_label_from_originating_result():
     reg.observe_result("c1", "Command running in background with ID: a066168. Output ...")
     assert reg.resolve_label("a066168") == "Run tests"
     assert reg.resolve_label("unknown") is None
+
+
+def _render_panel_text(reg, tool_use_id):
+    from rich.console import Console
+
+    c = Console(record=True)
+    c.print(reg.get(tool_use_id)._render_panel())
+    return c.export_text()
+
+
+def test_taskoutput_header_leads_with_label_demotes_id():
+    from rich.console import Console
+
+    from daydream.ui import LiveToolPanelRegistry
+
+    reg = LiveToolPanelRegistry(Console(record=True), quiet_mode=True)
+    reg.create("c1", "Bash", {"command": "x", "run_in_background": True, "description": "Run tests"})
+    reg.observe_result("c1", "Command running in background with ID: a066168. ...")
+    reg.create("c2", "TaskOutput", {"task_id": "a066168", "block": True, "timeout": 120000})
+    out = _render_panel_text(reg, "c2")
+    assert "Run tests" in out and "a066168" in out
+    assert "block" not in out and "timeout" not in out
+
+
+def test_taskoutput_header_unknown_id_falls_back_to_bare_id():
+    from rich.console import Console
+
+    from daydream.ui import LiveToolPanelRegistry
+
+    reg = LiveToolPanelRegistry(Console(record=True), quiet_mode=True)
+    reg.create("c2", "TaskOutput", {"task_id": "zzz999", "block": True, "timeout": 1})
+    out = _render_panel_text(reg, "c2")
+    assert "zzz999" in out and "block" not in out

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -180,8 +180,8 @@ def test_registry_harvests_task_label_from_originating_result():
     reg = LiveToolPanelRegistry(Console(record=True), quiet_mode=True)
     reg.create("c1", "Bash", {"command": "pytest", "run_in_background": True, "description": "Run tests"})
     reg.observe_result("c1", "Command running in background with ID: a066168. Output ...")
-    assert reg.resolve_label("a066168") == "Run tests"
-    assert reg.resolve_label("unknown") is None
+    assert reg.resolve_label("Bash", "a066168") == "Run tests"
+    assert reg.resolve_label("Bash", "unknown") is None
 
 
 def _render_panel_text(reg, tool_use_id):

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -244,3 +244,21 @@ def test_taskupdate_resolves_subject_and_shows_status():
     c.print(reg.get("c2")._render_panel())
     out = c.export_text()
     assert "Fix auth bug" in out and "completed" in out
+
+
+def test_taskoutput_result_shows_output_snippet():
+    from rich.console import Console
+
+    from daydream.ui import LiveToolPanelRegistry
+
+    # quiet_mode=False so the result body renders (quiet mode suppresses result
+    # output entirely); R8 is about the rendered TaskOutput result snippet.
+    reg = LiveToolPanelRegistry(Console(record=True), quiet_mode=False)
+    reg.create("c2", "TaskOutput", {"task_id": "a066168", "block": True, "timeout": 1})
+    result = (Path(__file__).parent / "fixtures/task_tools/taskoutput_result.txt").read_text()
+    reg.get("c2").set_result(result, is_error=False)
+    c = Console(record=True)
+    c.print(reg.get("c2")._render_panel())
+    out = c.export_text()
+    assert "done-with-bg-work" in out  # the <output> snippet surfaces
+    assert "<retrieval_status>" not in out  # tag plumbing is stripped

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -322,3 +322,40 @@ async def test_run_agent_renders_taskoutput_with_label(tmp_path, monkeypatch):
     assert "Run tests" in out and "a066168" in out
     assert "done-with-bg-work" in out
     assert "block=True" not in out and "timeout=120000" not in out
+
+
+async def test_run_agent_callback_path_labels_taskoutput(tmp_path):
+    from daydream.agent import run_agent
+    from daydream.backends import ResultEvent, ToolResultEvent, ToolStartEvent
+    from daydream.trajectory import DaydreamPhase
+    from tests.test_agent_recorder_integration import MockBackend  # existing event-replay mock
+
+    backend = MockBackend(
+        [
+            ToolStartEvent(
+                id="c1",
+                name="Bash",
+                input={"command": "pytest", "run_in_background": True, "description": "Run tests"},
+            ),
+            ToolResultEvent(id="c1", output="Command running in background with ID: a066168. ...", is_error=False),
+            ToolStartEvent(id="c2", name="TaskOutput", input={"task_id": "a066168", "block": True, "timeout": 120000}),
+            ToolResultEvent(
+                id="c2",
+                output="<task_id>a066168</task_id>\n<output>\ndone-with-bg-work\n</output>",
+                is_error=False,
+            ),
+            ResultEvent(structured_output=None, continuation=None),
+        ]
+    )
+    lines: list[str] = []
+    await run_agent(
+        backend,
+        tmp_path,
+        "go",
+        phase=DaydreamPhase.REVIEW,
+        progress_callback=lines.append,
+    )
+    joined = "\n".join(lines)
+    assert "Run tests" in joined  # resolved label surfaces in callback mode
+    assert "block" not in joined and "timeout" not in joined
+    assert "TaskOutput a066168" not in joined  # opaque bare-id dump form is gone


### PR DESCRIPTION
## Summary

Daydream's terminal UI was dumping opaque `TaskOutput a066168` lines and mechanical `block`/`timeout` plumbing for Task-family tool calls instead of a human-readable label. This PR makes both render paths (the Rich `Live` panel path and the callback/quiet progress path) label-aware: a backgrounded launch (`Bash`/`Agent`/`Task`) or `TaskCreate` call harvests a `task_id → label` mapping from its result, and the later `TaskOutput`/`TaskStop`/todo-list tool leads with that label and demotes the id to a dim suffix.

## Changes

### Added
- `task_id → label` correlation in `LiveToolPanelRegistry`, decoupled from panel creation: `note_call()` (on every `ToolStartEvent`), `observe_result()` (harvests the id from the originating result), `resolve_label()` / `resolve_call_label()` (look up the label).
- `format_callback_progress()` — plumbing-free, label-leading progress line for the callback/quiet render path.
- Helpers centralizing the formatting logic: `_parse_assigned_task_id()`, `_derive_task_label()`, `_task_id_key()`, `_task_label_ns_key()`, `_format_label_and_id_str()`, `_append_label_and_id()`.
- Named constants for the previously scattered truncation limits (`_RESULT_MAX_LINES`, `_EDIT_PREVIEW_MAX_LINES`, `_GLOB_MAX_LINES`, `_TASK_PROMPT_MAX_LINES`, `_WRITE_PREVIEW_CHARS`).
- Test fixtures pinning captured Task-family result shapes; real-path `run_agent` tests driving the Bash-bg → TaskOutput sequence through both the panel and callback paths.

### Changed
- `_build_tool_header()` renders `TaskOutput`/`TaskStop` and the todo-list tools (`TaskCreate`/`TaskGet`/`TaskUpdate`/`TaskList`) with subject/label + status, dropping mechanical args.
- `TaskOutput` results now surface the `<output>` snippet instead of the XML-ish tag plumbing (guarded behind `is_error=False`).
- `agent.py` creates the registry unconditionally and wires `note_call` + `resolve_call_label` + `observe_result` into both render paths.
- The generic key=value formatter drops mechanical `block`/`timeout` keys.

### Fixed
- The callback render path no longer emits the opaque `TaskOutput <id>` dump — label correlation was previously coupled to panel creation, which the callback path never does.
- Namespaced `_task_labels` keys (`bg:`/`tc:`) prevent collisions between background ids and `TaskCreate` integer ids.
- `_LAUNCH_TASK_ID_PATTERN` tightened to the full sentinel string to avoid false positives.
- Id-less todo tools (`TaskList`) no longer render an empty `()` id suffix.
- `observe_result()` / `_finalize_panel()` pop `call_args` and `teardown()` clears both maps to prevent unbounded memory growth.

### Removed
- Dead `print_code_result` helper and an unused tool-arg regex pattern.

## Motivation

The Task-family rendering feature set out to kill the opaque id dump, but the defect survived in the second (callback) render path because label correlation was coupled to panel creation. Decoupling correlation from panels fixes both paths from one source of truth.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed

Local checks (this session): `make lint` clean, `make typecheck` clean, `make test` → 1300 passed, 1 skipped. New real-path tests drive `run_agent` through the Bash-bg → TaskOutput sequence with a `progress_callback` collector, asserting the rendered label/snippet (not just that a call was made).

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)