### PR TITLE
ci(daydream-review): switch dogfood review job to Codex backend

### DIFF
--- a/.github/workflows/daydream-review.yml
+++ b/.github/workflows/daydream-review.yml
@@ -2,7 +2,7 @@
 #
 # Runs the daydream reviewer over the checked-out PR head and uploads a
 # findings artifact. This job touches untrusted PR code, so it holds NO App
-# credentials — `ANTHROPIC_API_KEY` is the only secret in this file, and the
+# credentials — `OPENAI_API_KEY` is the only secret in this file, and the
 # GITHUB_TOKEN is read-only (`contents: read`). Posting happens in the
 # separate privileged `daydream-post.yml` (workflow_run), per the locked
 # privilege split: no single job ever holds both PR code and the App key.
@@ -91,15 +91,22 @@ jobs:
       - name: Install daydream
         run: uv tool install git+https://github.com/existential-birds/daydream
 
+      # Codex backend: daydream spawns `codex exec` as a subprocess, so the
+      # CLI must be on PATH and authenticated. Node/npm are preinstalled on the
+      # GitHub-hosted runner.
+      - name: Install Codex CLI
+        run: npm install -g @openai/codex
+
       - name: Run daydream review
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           BASE_REF: ${{ steps.pr.outputs.base_ref }}
         run: |
+          printenv OPENAI_API_KEY | codex login --with-api-key
           mkdir -p findings
-          daydream --review --non-interactive --pr-number "$PR_NUMBER" \
+          daydream --review --backend codex --non-interactive --pr-number "$PR_NUMBER" \
             --findings-out findings/findings.json --base "origin/$BASE_REF" .
 
       - name: Upload findings artifact

--- a/.github/workflows/daydream-review.yml
+++ b/.github/workflows/daydream-review.yml
@@ -91,11 +91,14 @@ jobs:
       - name: Install daydream
         run: uv tool install git+https://github.com/existential-birds/daydream
 
-      # Codex backend: daydream spawns `codex exec` as a subprocess, so the
-      # CLI must be on PATH and authenticated. Node/npm are preinstalled on the
-      # GitHub-hosted runner.
+      # Codex backend: daydream spawns `codex exec` as a subprocess, so the CLI
+      # must be on PATH. `codex exec` authenticates directly from OPENAI_API_KEY
+      # in the step env (set below) — no persisted `codex login` state on disk.
+      # Pinned because the backend parses `codex exec --experimental-json`
+      # output, whose event shape can change between CLI releases. Node/npm are
+      # preinstalled on the GitHub-hosted runner.
       - name: Install Codex CLI
-        run: npm install -g @openai/codex
+        run: npm install -g @openai/codex@0.139.0
 
       - name: Run daydream review
         env:
@@ -104,7 +107,6 @@ jobs:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           BASE_REF: ${{ steps.pr.outputs.base_ref }}
         run: |
-          printenv OPENAI_API_KEY | codex login --with-api-key
           mkdir -p findings
           daydream --review --backend codex --non-interactive --pr-number "$PR_NUMBER" \
             --findings-out findings/findings.json --base "origin/$BASE_REF" .

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -30,6 +30,7 @@ import pytest
 import yaml
 
 TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "daydream" / "templates" / "workflows"
+REPO_WORKFLOWS_DIR = Path(__file__).resolve().parents[1] / ".github" / "workflows"
 
 _SECRET_REF_RE = re.compile(r"secrets\.([A-Za-z0-9_]+)")
 
@@ -349,3 +350,50 @@ def test_daydream_install_is_pinned_to_current_release_tag(name: str) -> None:
             f"daydream whose CLI has drifted from this workflow. Bump the template pin in "
             f"lockstep with the package version on every release."
         )
+
+
+# ---------------------------------------------------------------------------
+# .github/workflows/daydream-review.yml (live repo dogfood workflow — Codex)
+#
+# The repo's own review CI has intentionally diverged from the shipped template:
+# operators get the Anthropic-backed template, but daydream dogfoods itself on the
+# Codex backend (Anthropic disallows subscription auth for automations). The
+# template tests above never load this file, so its Codex contract is asserted
+# here directly.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def repo_review_wf() -> dict[str, Any]:
+    return load_workflow(REPO_WORKFLOWS_DIR / "daydream-review.yml")
+
+
+@pytest.fixture(scope="module")
+def repo_review_text() -> str:
+    return (REPO_WORKFLOWS_DIR / "daydream-review.yml").read_text(encoding="utf-8")
+
+
+def test_repo_review_only_secret_is_openai_api_key(repo_review_text: str) -> None:
+    assert set(_SECRET_REF_RE.findall(repo_review_text)) == {"OPENAI_API_KEY"}
+
+
+def test_repo_review_installs_codex_cli(repo_review_wf: dict[str, Any]) -> None:
+    codex_installs = [
+        s
+        for s in job_steps(repo_review_wf, "analyze")
+        if "Codex" in s.get("name", "") and "npm install -g @openai/codex" in s.get("run", "")
+    ]
+    assert len(codex_installs) == 1
+    # The backend parses `codex exec --experimental-json` output, whose event
+    # shape can drift between CLI releases, so the install must be version-pinned.
+    assert "npm install -g @openai/codex@" in codex_installs[0]["run"]
+
+
+def test_repo_review_runs_codex_backend_non_interactive(repo_review_wf: dict[str, Any]) -> None:
+    daydream_runs = [
+        s for s in job_steps(repo_review_wf, "analyze") if "daydream --review" in s.get("run", "")
+    ]
+    assert len(daydream_runs) == 1
+    run = daydream_runs[0]["run"]
+    assert "--backend codex" in run
+    assert "--non-interactive" in run


### PR DESCRIPTION
## Why

The dogfood self-review job (`.github/workflows/daydream-review.yml`) fails with `Invalid API key`: Anthropic no longer permits using Claude **subscriptions** for automations, so the `ANTHROPIC_API_KEY` secret backing it is no longer valid.

This change re-lands the Codex switch that was made on the `feat/148-setup-distribution` branch but never reached `main` (that PR was squash-merged before this commit landed on it).

## What

In the `analyze` job:
- install the Codex CLI (`npm install -g @openai/codex`) so daydream can spawn `codex exec`
- authenticate via `printenv OPENAI_API_KEY | codex login --with-api-key`
- pass `--backend codex` — every phase (review / parse / exploration) resolves to `gpt-5.5` via `PHASE_DEFAULT_MODELS["codex"]`
- swap the only secret from `ANTHROPIC_API_KEY` → `OPENAI_API_KEY` (added at org level)

## Scope

Dogfood only. The distributed templates under `daydream/templates/workflows/` intentionally stay on `ANTHROPIC_API_KEY` — operators pick their own driver.

## Verified

- `actionlint` clean on the edited workflow
- pre-push gate green (lint + typecheck + full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)