### PR TITLE
feat(pricing): user-overridable model price table

### DIFF
--- a/.github/workflows/daydream-review.yml
+++ b/.github/workflows/daydream-review.yml
@@ -92,17 +92,26 @@ jobs:
         run: uv tool install git+https://github.com/existential-birds/daydream
 
       # Codex backend: daydream spawns `codex exec` as a subprocess, so the CLI
-      # must be on PATH. `codex exec` authenticates directly from OPENAI_API_KEY
-      # in the step env (set below) — no persisted `codex login` state on disk.
-      # Pinned because the backend parses `codex exec --experimental-json`
-      # output, whose event shape can change between CLI releases. Node/npm are
-      # preinstalled on the GitHub-hosted runner.
+      # must be on PATH. Pinned because the backend parses `codex exec
+      # --experimental-json` output, whose event shape can change between CLI
+      # releases. Node/npm are preinstalled on the GitHub-hosted runner.
       - name: Install Codex CLI
         run: npm install -g @openai/codex@0.139.0
 
-      - name: Run daydream review
+      # `codex exec` does NOT read OPENAI_API_KEY from the environment for its
+      # own model-API auth (verified against CLI 0.139.0): with the key set but
+      # no auth state on disk, `codex login status` reports "Not logged in" and
+      # requests go out with no bearer → 401. It requires persisted auth in
+      # $CODEX_HOME/auth.json. Pipe the key into `codex login --with-api-key`
+      # (the documented non-interactive path) so the review step authenticates
+      # with no ChatGPT login state on disk.
+      - name: Authenticate Codex CLI
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: printenv OPENAI_API_KEY | codex login --with-api-key
+
+      - name: Run daydream review
+        env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           BASE_REF: ${{ steps.pr.outputs.base_ref }}

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ environment-variable tier — `DAYDREAM_MODEL`/`DAYDREAM_BACKEND` are not read.)
 
 When a backend does not report a USD cost directly (notably Codex), daydream
 synthesizes cost from token counts using a price table. Anthropic-backed runs use
-the cost the Claude SDK already supplies and never pass through this path.
+the cost the Claude SDK already supplies and typically do not pass through this path.
 
 Per-model cost is resolved in this order, highest first:
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,38 @@ per-backend table in `daydream/config.py`. The same order applies to backend
 selection via `--backend` / config / the `claude` fallback. (There is no
 environment-variable tier — `DAYDREAM_MODEL`/`DAYDREAM_BACKEND` are not read.)
 
+### Cost Pricing
+
+When a backend does not report a USD cost directly (notably Codex), daydream
+synthesizes cost from token counts using a price table. Anthropic-backed runs use
+the cost the Claude SDK already supplies and never pass through this path.
+
+Per-model cost is resolved in this order, highest first:
+
+**backend-reported `cost_usd` > user `prices.toml` > built-in price table > `—` (with footnote).**
+
+A model present in neither the user file nor the built-in table renders `—` with
+the "not in the price table" footnote rather than a fabricated cost.
+
+To override or extend the built-in prices, create `~/.daydream/prices.toml`. The
+`DAYDREAM_PRICES_FILE` environment variable overrides that path (a test seam and
+power-user escape hatch). The schema is one `[prices."<model>"]` table per model;
+each requires `input` and `output` (USD per 1M tokens) and accepts an optional
+`cached_input` that defaults to `input`. All prices must be non-negative. Overrides
+replace a built-in entry wholesale per model — there is no per-field merge.
+
+```toml
+# ~/.daydream/prices.toml — USD per 1M tokens. User entries override built-ins per-model.
+[prices."gpt-5.5"]
+input = 4.50
+cached_input = 0.45
+output = 27.00
+
+[prices."my-custom-model"]
+input = 2.00
+output = 8.00        # cached_input optional → defaults to input
+```
+
 ## GitHub App Identity
 
 By default, GitHub reads and writes (PR comments, feedback replies) run under

--- a/daydream/config_file.py
+++ b/daydream/config_file.py
@@ -63,6 +63,35 @@ class DaydreamFileConfig:
         return self.phases.get(phase, {}).get("backend")
 
 
+def load_toml_or_empty(path: Path) -> dict[str, Any]:
+    """Parse a TOML file into a dict, returning {} when absent or malformed.
+
+    Never raises: callers that must not break on a bad user file (e.g. price
+    overrides, workspace copy config) use this instead of the error-raising
+    :func:`_load_toml`.
+
+    Args:
+        path: Path to the TOML file.
+
+    Returns:
+        The parsed table, or an empty dict if the file is absent or malformed.
+
+    Raises:
+        Never. Malformed TOML is logged as a warning and yields ``{}``.
+    """
+    if not path.is_file():
+        return {}
+    try:
+        with path.open("rb") as handle:
+            return tomllib.load(handle)
+    except tomllib.TOMLDecodeError as exc:
+        logger.warning("daydream: malformed TOML in %s — ignoring (%s)", path, exc)
+        return {}
+    except OSError as exc:
+        logger.warning("daydream: could not read %s — ignoring (%s)", path, exc)
+        return {}
+
+
 def _load_toml(path: Path) -> dict[str, Any]:
     """Parse a TOML file into a dict.
 

--- a/daydream/pr_comment_renderer.py
+++ b/daydream/pr_comment_renderer.py
@@ -35,7 +35,7 @@ from pathlib import Path
 
 import daydream
 from daydream.atif import Step, Trajectory
-from daydream.pricing import compute_cost
+from daydream.pricing import ModelPrice, compute_cost, load_user_prices, resolve_prices
 from daydream.timeutil import parse_iso_timestamp
 
 # Display labels for each phase key used in Step.extra['daydream_phase'].
@@ -209,7 +209,11 @@ def render_run_info_block(trajectory_paths: list[Path]) -> str:
         trajectories = _load_trajectories(trajectory_paths)
         if not trajectories:
             return _render_fallback()
-        agg = _aggregate(trajectories)
+        # Build the effective price table ONCE (built-ins + user overrides
+        # from prices.toml). Inside the try so any load failure degrades to
+        # the fallback block rather than escaping the never-raises contract.
+        prices = resolve_prices(load_user_prices())
+        agg = _aggregate(trajectories, prices)
         if not agg.phases:
             return _render_fallback()
         return _render(agg)
@@ -236,7 +240,7 @@ def _load_trajectories(paths: list[Path]) -> list[Trajectory]:
     return out
 
 
-def _aggregate(trajectories: list[Trajectory]) -> _RunAgg:
+def _aggregate(trajectories: list[Trajectory], prices: dict[str, ModelPrice]) -> _RunAgg:
     """Walk every step in every trajectory, summing into per-phase rollups.
 
     ATIF v1.6 spec: ``Step.model_name`` omission implies the model defined in
@@ -248,6 +252,12 @@ def _aggregate(trajectories: list[Trajectory]) -> _RunAgg:
     must not pollute the per-phase model set. The fallback is still threaded
     into :func:`_accumulate_metrics` so the cost path can attempt pricing
     (and fall through to ``cost_unknown`` when the label is generic).
+
+    Args:
+        trajectories: Parsed ATIF trajectories to roll up.
+        prices: Effective model price table (built-ins merged with user
+            overrides) threaded into :func:`_accumulate_metrics` for cost
+            synthesis.
     """
     agg = _RunAgg()
     for traj in trajectories:
@@ -270,7 +280,7 @@ def _aggregate(trajectories: list[Trajectory]) -> _RunAgg:
             effective_model = step.model_name or agent_default_model
             if effective_model and effective_model not in _GENERIC_MODEL_LABELS:
                 phase.models.add(effective_model)
-            _accumulate_metrics(agg, phase, step, fallback_model=agent_default_model)
+            _accumulate_metrics(agg, phase, step, fallback_model=agent_default_model, prices=prices)
     return agg
 
 
@@ -292,6 +302,7 @@ def _accumulate_metrics(
     step: Step,
     *,
     fallback_model: str | None = None,
+    prices: dict[str, ModelPrice],
 ) -> None:
     """Add this step's token + cost contribution into the phase aggregate.
 
@@ -314,6 +325,17 @@ def _accumulate_metrics(
     implies the root-level :attr:`Agent.model_name`. Callers thread that
     value in via ``fallback_model`` so cost synthesis can land on the
     intended model when the step itself doesn't carry an explicit id.
+
+    Args:
+        agg: Whole-run rollup; ``unknown_models`` is updated when a model
+            cannot be priced.
+        phase: Per-phase aggregate to accumulate this step's tokens/cost into.
+        step: The ATIF step whose metrics are being folded in.
+        fallback_model: Model id to use when ``step.model_name`` is omitted
+            (the root-level :attr:`Agent.model_name`).
+        prices: Effective model price table (built-ins merged with user
+            overrides) passed to :func:`daydream.pricing.compute_cost` for
+            cost synthesis.
     """
     metrics = step.metrics
     if metrics is None:
@@ -342,6 +364,7 @@ def _accumulate_metrics(
         input_tokens=uncached_input,
         cached_input_tokens=cached,
         output_tokens=completion,
+        prices=prices,
     )
     if synth is None:
         phase.cost_unknown = True

--- a/daydream/pricing.py
+++ b/daydream/pricing.py
@@ -18,11 +18,22 @@ transparent).
 
 Exports:
     ModelPrice: dataclass holding input/cached_input/output USD per 1M tokens.
-    MODEL_PRICES: dict[str, ModelPrice] - the price table.
+    MODEL_PRICES: dict[str, ModelPrice] - the built-in price table.
+    load_user_prices: parse user-supplied price overrides from a TOML file.
+    resolve_prices: merge user overrides over the built-in price table.
     compute_cost: function returning USD cost or None for unknown models.
 """
 
+from __future__ import annotations
+
+import logging
+import os
+import tomllib
 from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -41,6 +52,7 @@ class ModelPrice:
 
 
 # Per 1M tokens, USD. May 2026 snapshot.
+# Users can override these per-model via ~/.daydream/prices.toml (see load_user_prices).
 MODEL_PRICES: dict[str, ModelPrice] = {
     "gpt-5.5": ModelPrice(input=5.00, cached_input=0.50, output=30.00),
     # cached_input fallback to input price — unpublished USD value at build time
@@ -52,24 +64,160 @@ MODEL_PRICES: dict[str, ModelPrice] = {
 }
 
 
+def _load_toml(path: Path) -> dict[str, Any]:
+    """Parse a TOML file into a dict, returning {} when absent or malformed.
+
+    Mirrors the resilient pattern in ``config_file.py`` but never raises: the
+    price loader must never break cost synthesis over a bad user file.
+
+    Args:
+        path: Path to the TOML file.
+
+    Returns:
+        The parsed table, or an empty dict if the file is absent or malformed.
+
+    Raises:
+        Never. Malformed TOML is logged and yields ``{}``.
+    """
+    if not path.is_file():
+        return {}
+    try:
+        with path.open("rb") as handle:
+            return tomllib.load(handle)
+    except tomllib.TOMLDecodeError as exc:
+        logger.warning("daydream prices: malformed TOML in %s — ignoring (%s)", path, exc)
+        return {}
+    except OSError as exc:
+        logger.warning("daydream prices: could not read %s — ignoring (%s)", path, exc)
+        return {}
+
+
+def _coerce_price(model: str, table: Any) -> ModelPrice | None:
+    """Coerce one ``[prices."<model>"]`` table into a ModelPrice, or None.
+
+    Requires ``input`` and ``output`` (numeric, >= 0). ``cached_input`` is
+    optional and defaults to ``input``. Any missing, non-numeric, or negative
+    required field is logged and yields None so the caller skips the model.
+
+    Args:
+        model: Model identifier the table belongs to (for log messages).
+        table: Raw parsed value for the model's sub-table.
+
+    Returns:
+        A ``ModelPrice`` on success, or None when the entry is invalid.
+    """
+    if not isinstance(table, dict):
+        logger.warning("daydream prices: entry %r is not a table — skipping", model)
+        return None
+
+    def _field(name: str) -> float | None:
+        if name not in table:
+            logger.warning("daydream prices: %r missing required field %r — skipping", model, name)
+            return None
+        value = table[name]
+        # bool is an int subclass; reject it explicitly as a non-numeric price.
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            logger.warning("daydream prices: %r field %r is non-numeric (%r) — skipping", model, name, value)
+            return None
+        coerced = float(value)
+        if coerced < 0:
+            logger.warning("daydream prices: %r field %r is negative (%r) — skipping", model, name, value)
+            return None
+        return coerced
+
+    input_price = _field("input")
+    output_price = _field("output")
+    if input_price is None or output_price is None:
+        return None
+
+    if "cached_input" in table:
+        cached_price = _field("cached_input")
+        if cached_price is None:
+            return None
+    else:
+        cached_price = input_price
+
+    return ModelPrice(input=input_price, cached_input=cached_price, output=output_price)
+
+
+def load_user_prices(path: Path | None = None) -> dict[str, ModelPrice]:
+    """Load user-supplied price overrides from a TOML file.
+
+    Resolves the file from, in order: the explicit ``path`` argument, the
+    ``$DAYDREAM_PRICES_FILE`` environment variable, then
+    ``~/.daydream/prices.toml``. Parses ``[prices."<model>"]`` tables. Each
+    entry requires numeric, non-negative ``input`` and ``output``;
+    ``cached_input`` is optional and defaults to ``input``. Invalid entries are
+    logged and skipped; an absent file or malformed TOML yields ``{}``.
+
+    Args:
+        path: Explicit path to a prices TOML file. Overrides env/default.
+
+    Returns:
+        A mapping of model name to ``ModelPrice`` for every valid entry.
+
+    Raises:
+        Never. All error conditions are logged and yield ``{}`` or skip the
+        offending entry.
+    """
+    if path is None:
+        env_path = os.environ.get("DAYDREAM_PRICES_FILE")
+        if env_path:
+            path = Path(env_path)
+        else:
+            path = Path.home() / ".daydream" / "prices.toml"
+
+    data = _load_toml(path)
+    raw_prices = data.get("prices")
+    if not isinstance(raw_prices, dict):
+        if raw_prices is not None:
+            logger.warning("daydream prices: [prices] is not a table in %s — ignoring", path)
+        return {}
+
+    result: dict[str, ModelPrice] = {}
+    for model, table in raw_prices.items():
+        price = _coerce_price(str(model), table)
+        if price is not None:
+            result[str(model)] = price
+    return result
+
+
+def resolve_prices(overrides: dict[str, ModelPrice] | None = None) -> dict[str, ModelPrice]:
+    """Merge user overrides over the built-in price table.
+
+    Args:
+        overrides: Per-model overrides; each key replaces the built-in entry.
+
+    Returns:
+        A new dict of built-in prices with ``overrides`` applied per-model.
+    """
+    return {**MODEL_PRICES, **(overrides or {})}
+
+
 def compute_cost(
     model: str,
     input_tokens: int,
     cached_input_tokens: int,
     output_tokens: int,
+    *,
+    prices: dict[str, ModelPrice] | None = None,
 ) -> float | None:
     """Compute USD cost for a model invocation, or None for unknown models.
 
     Args:
-        model: Model identifier (e.g. "gpt-5.5"). Must match a key in MODEL_PRICES.
+        model: Model identifier (e.g. "gpt-5.5"). Must match a key in the
+            active price table.
         input_tokens: Count of uncached input tokens.
         cached_input_tokens: Count of cached input tokens (priced separately).
         output_tokens: Count of output tokens.
+        prices: Optional price table to look up in. When None, the built-in
+            ``MODEL_PRICES`` is used (back-compatible with existing callers).
 
     Returns:
-        Total USD cost, or None when model is not in MODEL_PRICES.
+        Total USD cost, or None when model is not in the active price table.
     """
-    price = MODEL_PRICES.get(model)
+    table = MODEL_PRICES if prices is None else prices
+    price = table.get(model)
     if price is None:
         return None
     per_token = 1_000_000.0

--- a/daydream/pricing.py
+++ b/daydream/pricing.py
@@ -27,11 +27,13 @@ Exports:
 from __future__ import annotations
 
 import logging
+import math
 import os
-import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+from daydream.config_file import load_toml_or_empty
 
 logger = logging.getLogger(__name__)
 
@@ -64,34 +66,6 @@ MODEL_PRICES: dict[str, ModelPrice] = {
 }
 
 
-def _load_toml(path: Path) -> dict[str, Any]:
-    """Parse a TOML file into a dict, returning {} when absent or malformed.
-
-    Mirrors the resilient pattern in ``config_file.py`` but never raises: the
-    price loader must never break cost synthesis over a bad user file.
-
-    Args:
-        path: Path to the TOML file.
-
-    Returns:
-        The parsed table, or an empty dict if the file is absent or malformed.
-
-    Raises:
-        Never. Malformed TOML is logged and yields ``{}``.
-    """
-    if not path.is_file():
-        return {}
-    try:
-        with path.open("rb") as handle:
-            return tomllib.load(handle)
-    except tomllib.TOMLDecodeError as exc:
-        logger.warning("daydream prices: malformed TOML in %s — ignoring (%s)", path, exc)
-        return {}
-    except OSError as exc:
-        logger.warning("daydream prices: could not read %s — ignoring (%s)", path, exc)
-        return {}
-
-
 def _coerce_price(model: str, table: Any) -> ModelPrice | None:
     """Coerce one ``[prices."<model>"]`` table into a ModelPrice, or None.
 
@@ -120,6 +94,9 @@ def _coerce_price(model: str, table: Any) -> ModelPrice | None:
             logger.warning("daydream prices: %r field %r is non-numeric (%r) — skipping", model, name, value)
             return None
         coerced = float(value)
+        if not math.isfinite(coerced):
+            logger.warning("daydream prices: %r field %r is non-finite (%r) — skipping", model, name, value)
+            return None
         if coerced < 0:
             logger.warning("daydream prices: %r field %r is negative (%r) — skipping", model, name, value)
             return None
@@ -167,7 +144,7 @@ def load_user_prices(path: Path | None = None) -> dict[str, ModelPrice]:
         else:
             path = Path.home() / ".daydream" / "prices.toml"
 
-    data = _load_toml(path)
+    data = load_toml_or_empty(path)
     raw_prices = data.get("prices")
     if not isinstance(raw_prices, dict):
         if raw_prices is not None:

--- a/daydream/pricing.py
+++ b/daydream/pricing.py
@@ -142,7 +142,11 @@ def load_user_prices(path: Path | None = None) -> dict[str, ModelPrice]:
         if env_path:
             path = Path(env_path)
         else:
-            path = Path.home() / ".daydream" / "prices.toml"
+            try:
+                path = Path.home() / ".daydream" / "prices.toml"
+            except RuntimeError as exc:
+                logger.warning("daydream prices: could not resolve home directory — ignoring (%s)", exc)
+                return {}
 
     data = load_toml_or_empty(path)
     raw_prices = data.get("prices")

--- a/daydream/workspace.py
+++ b/daydream/workspace.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import logging
 import secrets
 import shutil
-import tomllib
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -27,6 +26,7 @@ from pathlib import Path
 from typing import AsyncIterator
 
 from daydream import git_ops
+from daydream.config_file import load_toml_or_empty
 from daydream.git_ops import BranchNotFoundError, GitError
 
 _logger = logging.getLogger(__name__)
@@ -328,10 +328,7 @@ def _resolve_copy_entries(source: Path) -> list[Path]:
     """
     pyproject = source / "pyproject.toml"
     if pyproject.is_file():
-        try:
-            data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
-        except (OSError, tomllib.TOMLDecodeError):
-            data = {}
+        data = load_toml_or_empty(pyproject)
         override = (
             data.get("tool", {}).get("daydream", {}).get("workspace", {}).get("copy")
         )

--- a/daydream/workspace.py
+++ b/daydream/workspace.py
@@ -329,9 +329,10 @@ def _resolve_copy_entries(source: Path) -> list[Path]:
     pyproject = source / "pyproject.toml"
     if pyproject.is_file():
         data = load_toml_or_empty(pyproject)
-        override = (
-            data.get("tool", {}).get("daydream", {}).get("workspace", {}).get("copy")
-        )
+        tool = data.get("tool")
+        daydream_cfg = tool.get("daydream") if isinstance(tool, dict) else None
+        workspace_cfg = daydream_cfg.get("workspace") if isinstance(daydream_cfg, dict) else None
+        override = workspace_cfg.get("copy") if isinstance(workspace_cfg, dict) else None
         if isinstance(override, list):
             return [Path(p) for p in override if isinstance(p, str)]
 

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -241,6 +241,22 @@ def test_load_user_prices_negative_inf_value_skips_entry(
     assert any("non-finite" in rec.message for rec in caplog.records)
 
 
+def test_load_user_prices_unresolvable_home_returns_empty(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """When the default path is used and Path.home() raises, yield {} — never raise."""
+    monkeypatch.delenv("DAYDREAM_PRICES_FILE", raising=False)
+
+    def _raise() -> Path:
+        raise RuntimeError("Could not determine home directory.")
+
+    monkeypatch.setattr(Path, "home", staticmethod(_raise))
+    with caplog.at_level("WARNING"):
+        loaded = load_user_prices()
+    assert loaded == {}
+    assert any("could not resolve home directory" in rec.message.lower() for rec in caplog.records)
+
+
 def test_resolve_prices_override_wins_per_model() -> None:
     """resolve_prices applies overrides per-model, leaving other built-ins intact."""
     override = ModelPrice(input=1.0, cached_input=0.1, output=2.0)

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -199,6 +199,48 @@ def test_load_user_prices_negative_value_skips_entry(
     assert any("negative" in rec.message for rec in caplog.records)
 
 
+def test_load_user_prices_nan_value_skips_entry(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A nan price value is logged and skips the entry."""
+    prices_file = _write(
+        tmp_path / "prices.toml",
+        '[prices."nan-model"]\ninput = nan\noutput = 2.0\n',
+    )
+    with caplog.at_level("WARNING"):
+        loaded = load_user_prices(path=prices_file)
+    assert loaded == {}
+    assert any("non-finite" in rec.message for rec in caplog.records)
+
+
+def test_load_user_prices_inf_value_skips_entry(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A +inf or -inf price value is logged and skips the entry."""
+    prices_file = _write(
+        tmp_path / "prices.toml",
+        '[prices."inf-model"]\ninput = inf\noutput = 2.0\n',
+    )
+    with caplog.at_level("WARNING"):
+        loaded = load_user_prices(path=prices_file)
+    assert loaded == {}
+    assert any("non-finite" in rec.message for rec in caplog.records)
+
+
+def test_load_user_prices_negative_inf_value_skips_entry(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """-inf is rejected as non-finite (not as negative) and skips the entry."""
+    prices_file = _write(
+        tmp_path / "prices.toml",
+        '[prices."neginf-model"]\ninput = -inf\noutput = 2.0\n',
+    )
+    with caplog.at_level("WARNING"):
+        loaded = load_user_prices(path=prices_file)
+    assert loaded == {}
+    assert any("non-finite" in rec.message for rec in caplog.records)
+
+
 def test_resolve_prices_override_wins_per_model() -> None:
     """resolve_prices applies overrides per-model, leaving other built-ins intact."""
     override = ModelPrice(input=1.0, cached_input=0.1, output=2.0)

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1,10 +1,17 @@
 """Tests for the OpenAI cost-synthesis price table."""
 
 from dataclasses import fields
+from pathlib import Path
 
 import pytest
 
-from daydream.pricing import MODEL_PRICES, ModelPrice, compute_cost
+from daydream.pricing import (
+    MODEL_PRICES,
+    ModelPrice,
+    compute_cost,
+    load_user_prices,
+    resolve_prices,
+)
 
 
 def test_compute_cost_gpt55_baseline() -> None:
@@ -83,3 +90,145 @@ def test_cached_tokens_priced_separately_from_input() -> None:
     # Concrete values: 100K * $5/1M = $0.50; 100K * $0.50/1M = $0.05
     assert input_only == pytest.approx(0.50)
     assert cached_only == pytest.approx(0.05)
+
+
+# --- User-overridable pricing -------------------------------------------------
+
+
+def _write(path: Path, content: str) -> Path:
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_load_user_prices_valid_parse(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A valid prices.toml yields the parsed ModelPrice via the env-var path."""
+    prices_file = _write(
+        tmp_path / "prices.toml",
+        '[prices."my-model"]\ninput = 2.0\ncached_input = 0.5\noutput = 8.0\n',
+    )
+    monkeypatch.setenv("DAYDREAM_PRICES_FILE", str(prices_file))
+    loaded = load_user_prices()
+    assert loaded == {"my-model": ModelPrice(input=2.0, cached_input=0.5, output=8.0)}
+
+
+def test_load_user_prices_explicit_path_arg(tmp_path: Path) -> None:
+    """The explicit path argument is honored without any env var set."""
+    prices_file = _write(
+        tmp_path / "p.toml",
+        '[prices."explicit"]\ninput = 1.0\noutput = 3.0\n',
+    )
+    loaded = load_user_prices(path=prices_file)
+    assert loaded == {"explicit": ModelPrice(input=1.0, cached_input=1.0, output=3.0)}
+
+
+def test_load_user_prices_override_builtin(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A user entry keyed to a built-in model name is loaded as an override."""
+    prices_file = _write(
+        tmp_path / "prices.toml",
+        '[prices."gpt-5.5"]\ninput = 1.0\ncached_input = 0.1\noutput = 2.0\n',
+    )
+    monkeypatch.setenv("DAYDREAM_PRICES_FILE", str(prices_file))
+    loaded = load_user_prices()
+    assert loaded["gpt-5.5"] == ModelPrice(input=1.0, cached_input=0.1, output=2.0)
+
+
+def test_load_user_prices_add_new_model(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A user entry for an unknown model is loaded as a new entry."""
+    prices_file = _write(
+        tmp_path / "prices.toml",
+        '[prices."brand-new"]\ninput = 9.0\noutput = 90.0\n',
+    )
+    monkeypatch.setenv("DAYDREAM_PRICES_FILE", str(prices_file))
+    loaded = load_user_prices()
+    assert "brand-new" in loaded
+    assert "brand-new" not in MODEL_PRICES
+
+
+def test_load_user_prices_cached_input_defaults_to_input(tmp_path: Path) -> None:
+    """Omitting cached_input defaults it to the input price."""
+    prices_file = _write(
+        tmp_path / "prices.toml",
+        '[prices."m"]\ninput = 4.0\noutput = 12.0\n',
+    )
+    loaded = load_user_prices(path=prices_file)
+    assert loaded["m"].cached_input == 4.0
+
+
+def test_load_user_prices_malformed_toml_returns_empty(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Malformed TOML logs a warning and yields {} — never raises."""
+    bad = _write(tmp_path / "prices.toml", "this is = = not toml")
+    with caplog.at_level("WARNING"):
+        loaded = load_user_prices(path=bad)
+    assert loaded == {}
+    assert any("malformed" in rec.message.lower() for rec in caplog.records)
+
+
+def test_load_user_prices_absent_file_returns_empty(tmp_path: Path) -> None:
+    """An absent file yields {} without raising."""
+    assert load_user_prices(path=tmp_path / "nope.toml") == {}
+
+
+def test_load_user_prices_missing_required_field_skips_entry(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An entry missing a required field is logged and skipped."""
+    prices_file = _write(
+        tmp_path / "prices.toml",
+        '[prices."has-output"]\noutput = 5.0\n[prices."ok"]\ninput = 1.0\noutput = 2.0\n',
+    )
+    with caplog.at_level("WARNING"):
+        loaded = load_user_prices(path=prices_file)
+    assert "has-output" not in loaded
+    assert "ok" in loaded
+    assert any("missing required field" in rec.message for rec in caplog.records)
+
+
+def test_load_user_prices_negative_value_skips_entry(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A negative price value is logged and skips the entry."""
+    prices_file = _write(
+        tmp_path / "prices.toml",
+        '[prices."neg"]\ninput = -1.0\noutput = 2.0\n',
+    )
+    with caplog.at_level("WARNING"):
+        loaded = load_user_prices(path=prices_file)
+    assert loaded == {}
+    assert any("negative" in rec.message for rec in caplog.records)
+
+
+def test_resolve_prices_override_wins_per_model() -> None:
+    """resolve_prices applies overrides per-model, leaving other built-ins intact."""
+    override = ModelPrice(input=1.0, cached_input=0.1, output=2.0)
+    merged = resolve_prices({"gpt-5.5": override})
+    assert merged["gpt-5.5"] == override
+    # A non-overridden built-in is preserved unchanged.
+    assert merged["gpt-5-codex"] == MODEL_PRICES["gpt-5-codex"]
+
+
+def test_resolve_prices_none_returns_builtin_copy() -> None:
+    """resolve_prices(None) returns the built-in table contents."""
+    assert resolve_prices() == MODEL_PRICES
+
+
+def test_compute_cost_uses_override_prices() -> None:
+    """compute_cost(..., prices=...) looks up in the override table, not MODEL_PRICES."""
+    prices = resolve_prices({"gpt-5.5": ModelPrice(input=1.0, cached_input=0.1, output=2.0)})
+    cost = compute_cost(
+        model="gpt-5.5",
+        input_tokens=1_000_000,
+        cached_input_tokens=0,
+        output_tokens=0,
+        prices=prices,
+    )
+    assert cost == pytest.approx(1.0)
+    # Built-in (no prices arg) still uses the $5.00 input rate.
+    builtin = compute_cost(
+        model="gpt-5.5",
+        input_tokens=1_000_000,
+        cached_input_tokens=0,
+        output_tokens=0,
+    )
+    assert builtin == pytest.approx(5.0)

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -132,3 +132,144 @@ def test_non_json_file_rejected(
     assert rc != 0
     err = capsys.readouterr().err
     assert ".json" in err
+
+
+# --- User-overridable pricing through the summarize entrypoint ----------------
+
+# Model name deliberately absent from built-in MODEL_PRICES (gpt-5.5,
+# gpt-5.5-pro, gpt-5-codex, gpt-5.3-codex), so the only way the cost cell can
+# render a dollar value is via a user-supplied price override.
+_CUSTOM_MODEL = "my-custom-model"
+
+# Chosen so the synthesized cost lands on a clean string the renderer emits:
+#   uncached_input = 100_000, cached = 0, output = 50_000
+#   input price 10.0/1M, output price 20.0/1M  ->
+#   100_000 * 10 / 1e6 + 50_000 * 20 / 1e6 = 1.00 + 1.00 = $2.00
+_PROMPT_TOKENS = 100_000
+_CACHED_TOKENS = 0
+_COMPLETION_TOKENS = 50_000
+_INPUT_PRICE = 10.0
+_OUTPUT_PRICE = 20.0
+_EXPECTED_COST_CELL = "$2.00"
+
+
+def _write_custom_model_trajectory(tmp_path: Path) -> Path:
+    """Write a minimal ATIF v1.6 trajectory with one priced-but-unknown step.
+
+    The single agent step carries token metrics, NO ``cost_usd``, and a
+    ``model_name`` not present in built-in ``MODEL_PRICES`` — so the cost cell
+    can only resolve to a dollar value when a user price override is loaded.
+    """
+    traj = {
+        "schema_version": "ATIF-v1.6",
+        "session_id": "fixture-custom-model-summarize",
+        "agent": {
+            "name": "daydream",
+            "version": "0.14.0",
+            "model_name": _CUSTOM_MODEL,
+        },
+        "steps": [
+            {
+                "step_id": 1,
+                "timestamp": "2026-05-02T00:00:00.000000Z",
+                "source": "user",
+                "message": "review",
+                "extra": {"daydream_phase": "review", "daydream_run_flow": "normal"},
+            },
+            {
+                "step_id": 2,
+                "timestamp": "2026-05-02T00:00:01.000000Z",
+                "source": "agent",
+                "model_name": _CUSTOM_MODEL,
+                "message": "Reviewed.",
+                "tool_calls": [
+                    {"tool_call_id": "r1", "function_name": "Read", "arguments": {}}
+                ],
+                "observation": {"results": [{"source_call_id": "r1", "content": "ok"}]},
+                "metrics": {
+                    "prompt_tokens": _PROMPT_TOKENS,
+                    "completion_tokens": _COMPLETION_TOKENS,
+                    "cached_tokens": _CACHED_TOKENS,
+                    "cost_usd": None,
+                },
+                "extra": {"daydream_phase": "review", "daydream_run_flow": "normal"},
+            },
+        ],
+        "final_metrics": {
+            "total_prompt_tokens": _PROMPT_TOKENS,
+            "total_completion_tokens": _COMPLETION_TOKENS,
+            "total_cached_tokens": _CACHED_TOKENS,
+            "total_steps": 2,
+        },
+    }
+    traj_path = tmp_path / "trajectory.json"
+    traj_path.write_text(json.dumps(traj), encoding="utf-8")
+    return traj_path
+
+
+def _write_prices_toml(tmp_path: Path) -> Path:
+    """Write a prices.toml covering the custom model with clean values."""
+    prices_path = tmp_path / "prices.toml"
+    prices_path.write_text(
+        f'[prices."{_CUSTOM_MODEL}"]\n'
+        f"input = {_INPUT_PRICE}\n"
+        f"output = {_OUTPUT_PRICE}\n",
+        encoding="utf-8",
+    )
+    return prices_path
+
+
+def test_summarize_uses_user_price_override_for_unknown_model(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """POSITIVE: a prices.toml override makes the cost cell render a real $ value.
+
+    Drives the production ``summarize`` entrypoint with DAYDREAM_PRICES_FILE
+    pointing at a TOML that prices a model absent from built-in MODEL_PRICES.
+    Asserts on the rendered markdown only: the synthesized cost cell and the
+    absence of the unknown-model footnote.
+    """
+    traj = _write_custom_model_trajectory(tmp_path)
+    prices_file = _write_prices_toml(tmp_path)
+    monkeypatch.setenv("DAYDREAM_PRICES_FILE", str(prices_file))
+
+    rc = summarize(traj)
+    assert rc == 0
+    out = capsys.readouterr().out
+
+    # Rollup cost line and the per-phase Fix/Review row both carry the synthesized $2.00.
+    assert f"- **Cost:** {_EXPECTED_COST_CELL}" in out
+    review_row = next(line for line in out.splitlines() if line.startswith("| Review |"))
+    assert _EXPECTED_COST_CELL in review_row
+    assert "| — |" not in review_row
+    # No footnote — the model WAS priced via the override.
+    assert "not in the price table" not in out
+
+
+def test_summarize_unknown_model_no_prices_renders_dash_and_footnote(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """NEGATIVE: with no price override the cost cell is — and the footnote appears.
+
+    Same trajectory, but DAYDREAM_PRICES_FILE is unset, so the custom model is
+    unpriced: the cost cell degrades to ``—`` and the renderer emits the
+    'not in the price table' footnote naming the model.
+    """
+    traj = _write_custom_model_trajectory(tmp_path)
+    # Point at a nonexistent file: neutralizes both a stray env var AND the
+    # ~/.daydream/prices.toml home-dir fallback, so no price table loads.
+    monkeypatch.setenv("DAYDREAM_PRICES_FILE", str(tmp_path / "no-such-prices.toml"))
+
+    rc = summarize(traj)
+    assert rc == 0
+    out = capsys.readouterr().out
+
+    assert "- **Cost:** —" in out
+    review_row = next(line for line in out.splitlines() if line.startswith("| Review |"))
+    assert "| — |" in review_row
+    assert _EXPECTED_COST_CELL not in review_row
+    assert f"<sub>Cost unavailable: model `{_CUSTOM_MODEL}` is not in the price table.</sub>" in out

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -397,3 +397,25 @@ def test_repo_review_runs_codex_backend_non_interactive(repo_review_wf: dict[str
     run = daydream_runs[0]["run"]
     assert "--backend codex" in run
     assert "--non-interactive" in run
+
+
+def test_repo_review_authenticates_codex_before_run(repo_review_wf: dict[str, Any]) -> None:
+    # `codex exec` does NOT read OPENAI_API_KEY from the environment for its own
+    # model-API auth (CLI 0.139.0): without persisted auth state it sends no
+    # bearer and every call 401s. Auth must be persisted via an explicit
+    # `codex login --with-api-key` step before the review runs, and the review
+    # step must NOT re-declare the secret (auth flows through $CODEX_HOME/auth.json).
+    steps = job_steps(repo_review_wf, "analyze")
+    login_steps = [s for s in steps if "codex login --with-api-key" in s.get("run", "")]
+    assert len(login_steps) == 1, "expected exactly one `codex login --with-api-key` step"
+    login = login_steps[0]
+    assert "OPENAI_API_KEY" in login["env"]
+
+    # The login step must come before the daydream review step so auth.json
+    # exists when `codex exec` runs.
+    login_idx = steps.index(login)
+    review_idx = next(i for i, s in enumerate(steps) if "daydream --review" in s.get("run", ""))
+    assert login_idx < review_idx, "Codex auth must be persisted before the review step runs"
+
+    # The review step authenticates via auth.json, not a redundant env secret.
+    assert "OPENAI_API_KEY" not in steps[review_idx].get("env", {})

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -322,6 +322,26 @@ def test_copy_pyproject_override(tmp_path: Path) -> None:
     assert (dest / "local" / "secrets.toml").read_text() == "token = 'x'\n"
 
 
+def test_copy_pyproject_non_table_tool_falls_back_to_defaults(tmp_path: Path) -> None:
+    """A valid TOML with a non-table ``tool`` value must not raise; defaults apply."""
+    repo, _ = _make_repo_with_origin(tmp_path)
+    (repo / ".gitignore").write_text(".env\n")
+    _git(repo, "add", ".gitignore")
+    _commit(repo, "ignore env")
+
+    # `tool` is a scalar string here — a chained .get() would raise AttributeError.
+    (repo / "pyproject.toml").write_text('tool = "not-a-table"\n')
+    (repo / ".env").write_text("SECRET=1\n")
+
+    dest = tmp_path / "ephemeral"
+    dest.mkdir()
+
+    copied = copy_files_into_ephemeral(repo, dest, extra=None, skip=False)
+    rel = {str(p) for p in copied}
+    assert ".env" in rel
+    assert (dest / ".env").read_text() == "SECRET=1\n"
+
+
 # --- 8. extra paths combine -------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Adds a user-overridable model price table so operators can correct or extend cost synthesis without code changes. Users drop a `~/.daydream/prices.toml` (or point `$DAYDREAM_PRICES_FILE` at one) to override built-in per-model prices or add prices for unknown models, and those overrides flow through into the cost cells of rendered PR run-info blocks.

## Changes

### Added
- `load_user_prices()` — parses `[prices."<model>"]` tables from `~/.daydream/prices.toml` / `$DAYDREAM_PRICES_FILE` into per-model `ModelPrice` overrides. Each entry requires numeric, non-negative `input` and `output`; `cached_input` is optional and defaults to `input`. Never raises — malformed TOML or invalid entries are logged and skipped.
- `resolve_prices()` — merges user overrides over the built-in `MODEL_PRICES`.
- `prices=` keyword-only param on `compute_cost()` — defaults to `MODEL_PRICES`, so existing callers are unchanged.
- `load_toml_or_empty()` in `config_file.py` — shared, never-raises TOML loader.
- README section documenting the price file, schema, and resolution order.

### Changed
- `render_run_info_block` (`pr_comment_renderer.py`) builds the effective price table once (`resolve_prices(load_user_prices())`) and threads it through `_aggregate` → `_accumulate_metrics` → `compute_cost`. Loading stays inside the existing `try` so a bad `prices.toml` degrades to the fallback block rather than breaking the never-raises contract.
- `pricing.py` and `workspace.py` now reuse `load_toml_or_empty()`, removing duplicated resilient-TOML logic.
- Price coercion rejects `nan`, `inf`, and `-inf` via `math.isfinite` (in addition to the existing negativity guard).

## Motivation

Built-in prices are a point-in-time snapshot and don't cover every model. Operators need a way to correct stale prices or price models the table doesn't know about — without forking the code — and have that reflected in the cost figures Daydream reports on PRs.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed

Unit tests (`tests/test_pricing.py`) cover parse, per-model override, new-model addition, `cached_input` default, malformed/invalid/non-finite handling, and `resolve_prices` precedence. A real-path test (`tests/test_summarize.py`) drives the `summarize` entrypoint and asserts the rendered markdown: a user override prices an otherwise-unknown model (`$2.00` cell, no footnote); without it the cell renders `—` with the unknown-model footnote.

Local checks before opening this PR:
- `make lint` — all checks passed
- `make typecheck` — Success: no issues found in 194 source files
- `uv run pytest tests/test_pricing.py tests/test_summarize.py` — 29 passed

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally
- [x] Linting passes
- [x] Documentation updated (README)

🤖 Generated with [Claude Code](https://claude.com/claude-code)