### PR TITLE
chore(release): 0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-06-18
+
+### Added
+
+- **github_app:** Run under operator GitHub App identity with scoped token injection ([#159](https://github.com/existential-birds/daydream/pull/159))
+
+  Daydream can now act as a self-hosted review bot using the operator's own GitHub App. Reviews are authored under the App's identity with a short-lived, repo-scoped installation token injected at runtime, so the maintainer never exposes a personal access token.
+
+- **bot:** Actions trigger surface — @-mention / auto-on-PR review via privilege split ([#160](https://github.com/existential-birds/daydream/pull/160))
+
+  Adds GitHub Actions trigger wiring so a review runs either when the bot is @-mentioned on a PR or automatically on PR open/update. A privilege split keeps the untrusted PR-triggered job read-only while a separate trusted job posts results.
+
+- **bot_setup:** One-command self-hosted review-bot setup and distribution ([#161](https://github.com/existential-birds/daydream/pull/161))
+
+  Bundles the workflow templates and a guided setup flow so an operator can stand up a white-label PR review bot in their own repository with a single command.
+
+- **pricing:** User-overridable model price table ([#165](https://github.com/existential-birds/daydream/pull/165))
+
+  Per-model token prices can now be overridden via config so cost metrics stay accurate as provider pricing changes, without waiting for a daydream release.
+
+### Changed
+
+- **cli:** Verb-first redesign with config-file phase control ([#141](https://github.com/existential-birds/daydream/pull/141))
+
+  **Breaking.** The CLI is now verb-first (`daydream review`, `daydream corpus …`), with a default review shim so `daydream /path` still works. Per-phase `--model`/`--backend` flags are removed in favor of `[tool.daydream]` / `[tool.daydream.phases.<phase>]` config in `pyproject.toml` or `.daydream.toml` (precedence: CLI global `--model`/`--backend` > config file > built-in default). The data pipeline verbs are namespaced under `corpus` (`daydream corpus harvest`/`build`/`label`), `--max-iterations` folds into `--loop [N]`, advanced flags hide behind `--help-all`, and non-interactive mode auto-detects from a non-TTY/CI environment.
+
+- **deep:** Sonnet-first per-stack review with a scoped Opus arbiter ([#175](https://github.com/existential-birds/daydream/pull/175))
+
+  Per-stack reviews now run on Sonnet by default with a scoped Opus arbiter pass, cutting review cost and latency while preserving finding quality.
+
+### Fixed
+
+- **git_ops:** Retry transient git timeouts and distinguish them from genuine errors ([#142](https://github.com/existential-birds/daydream/pull/142))
+
+- **training:** Correct run-level label attribution — footer-not-bot and archive-time PR linkage ([#149](https://github.com/existential-birds/daydream/pull/149))
+
+- **ui:** Render Task-family tools with resolved labels in both render paths ([#150](https://github.com/existential-birds/daydream/pull/150))
+
+- **codex:** Real-path harness infrastructure and Codex backend fixes ([#158](https://github.com/existential-birds/daydream/pull/158))
+
+- **training:** Harden harvest PR-signal labeling; de-cruft and parallelize the test suite ([#174](https://github.com/existential-birds/daydream/pull/174))
+
+### Security
+
+- **deps:** Bump `cryptography`, `python-multipart`, and `starlette` in the uv group ([#162](https://github.com/existential-birds/daydream/pull/162))
+
 ## [0.19.0] - 2026-06-04
 
 ### Added
@@ -555,7 +601,8 @@ Initial release of Daydream - an automated code review and fix loop using the Cl
 - `rich` - Terminal UI components
 - `pyfiglet` - ASCII art header generation
 
-[unreleased]: https://github.com/existential-birds/daydream/compare/v0.19.0...HEAD
+[unreleased]: https://github.com/existential-birds/daydream/compare/v0.20.0...HEAD
+[0.20.0]: https://github.com/existential-birds/daydream/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/existential-birds/daydream/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/existential-birds/daydream/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/existential-birds/daydream/compare/v0.16.0...v0.17.0

--- a/daydream/__init__.py
+++ b/daydream/__init__.py
@@ -17,4 +17,4 @@ Submodules:
     ui: User interface utilities for terminal output.
 """
 
-__version__ = "0.19.0"
+__version__ = "0.20.0"

--- a/daydream/templates/workflows/daydream-post.yml
+++ b/daydream/templates/workflows/daydream-post.yml
@@ -51,7 +51,7 @@ jobs:
         # Pinned to a release tag (not `main`) so the bot runs a known daydream
         # version: reproducible and immune to main-drift / uv-cache staleness.
         # Bump in lockstep with the package version on release (a test enforces this).
-        run: uv tool install git+https://github.com/existential-birds/daydream@v0.19.0
+        run: uv tool install git+https://github.com/existential-birds/daydream@v0.20.0
 
       - name: Mint posting token
         id: token

--- a/daydream/templates/workflows/daydream-review.yml
+++ b/daydream/templates/workflows/daydream-review.yml
@@ -92,7 +92,7 @@ jobs:
         # Pinned to a release tag (not `main`) so the bot runs a known daydream
         # version: reproducible and immune to main-drift / uv-cache staleness.
         # Bump in lockstep with the package version on release (a test enforces this).
-        run: uv tool install git+https://github.com/existential-birds/daydream@v0.19.0
+        run: uv tool install git+https://github.com/existential-birds/daydream@v0.20.0
 
       - name: Run daydream review
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "daydream"
-version = "0.19.0"
+version = "0.20.0"
 description = "Automated code review and fix loop using Claude"
 requires-python = ">=3.12.13"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -193,7 +193,7 @@ wheels = [
 
 [[package]]
 name = "daydream"
-version = "0.19.0"
+version = "0.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

- Bump version to 0.20.0
- Update CHANGELOG.md with changes since v0.19.0

### Highlights

- **Added** — self-hosted review-bot: operator GitHub App identity with scoped token injection (#159), Actions @-mention / auto-on-PR trigger surface (#160), one-command bot setup + distribution (#161); user-overridable model price table (#165)
- **Changed (breaking)** — verb-first CLI redesign with config-file phase control (#141); Sonnet-first per-stack review with a scoped Opus arbiter (#175)
- **Fixed** — git timeout retries (#142), training label attribution (#149, #174), Task-tool label rendering (#150), Codex real-path harness (#158)
- **Security** — bump `cryptography`, `python-multipart`, `starlette` (#162)

## Post-merge steps

After merging, run:
\`\`\`
/release-tag 0.20.0
\`\`\`

---

Generated with [Claude Code](https://claude.com/claude-code)