### PR TITLE
fix(ui): stop dumping structured-output JSON to the terminal

### DIFF
--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -441,7 +441,9 @@ async def run_agent(
                             result = progress_callback(last_line)
                             if inspect.isawaitable(result):
                                 await result
-                    else:
+                    elif output_schema is None:
+                        # Structured-output text is the JSON payload, redundant with
+                        # the returned structured result — don't echo it to the terminal.
                         agent_renderer.append(event.text)
 
                     if inv is not None:

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -62,6 +62,7 @@ from daydream.phases import (
 )
 from daydream.trajectory import DaydreamRunFlow, TrajectoryRecorder, default_trajectory_path
 from daydream.ui import (
+    format_verdict_join,
     print_error,
     print_info,
     print_preflight_notice,
@@ -846,18 +847,15 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
                 and i.get("lens") != "structural"
                 and not isinstance(i.get("id"), int)
             ]
-            eligible = len(matched_ids) + len(unmatched_ids)
-            summary = (
-                f"Verdict join: {len(matched_ids)}/{eligible} verdict-eligible items "
-                f"matched a verifier verdict; {len(structural_ids)} structural "
-                f"verdict-exempt; {len(items)} total to fix "
-                f"(matched={matched_ids}, unmatched={unmatched_ids}, "
-                f"structural={structural_ids}"
+            console.print(
+                format_verdict_join(
+                    matched=matched_ids,
+                    unmatched=unmatched_ids,
+                    structural=structural_ids,
+                    other=other_ids,
+                    total=len(items),
+                )
             )
-            if other_ids:
-                summary += f", other={other_ids}"
-            summary += ")"
-            print_info(console, summary)
 
             fix_failures = await phase_fix_parallel(
                 _resolve_backend(config, "fix", backend_cache), work, items

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -69,6 +69,7 @@ from daydream.ui import (
     print_success,
     print_verification_summary,
     print_warning,
+    render_exploration_summary,
 )
 from daydream.workspace import WorkContext
 
@@ -537,6 +538,7 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
                     config.exploration_depth,
                     diff_ref=_compute_diff_ref(target_dir),
                 )
+                render_exploration_summary(console, config.exploration_context)
         if EXPLORATION_AVAILABLE and config.exploration_context is not None:
             exploration_dir = config.exploration_context.write_to_dir(
                 daydream_dir / "exploration"

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -539,7 +539,7 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
                     config.exploration_depth,
                     diff_ref=_compute_diff_ref(target_dir),
                 )
-                render_exploration_summary(console, config.exploration_context)
+                console.print(render_exploration_summary(config.exploration_context))
         if EXPLORATION_AVAILABLE and config.exploration_context is not None:
             exploration_dir = config.exploration_context.write_to_dir(
                 daydream_dir / "exploration"

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -1519,7 +1519,8 @@ If there are no actionable issues, return: {{"issues": []}}
         raise ValueError(f"Expected dict with 'issues' key, got {type(result)}")
 
     feedback_items = result["issues"]
-    print_info(console, f"Found {len(feedback_items)} actionable issues")
+    issue_count = len(feedback_items)
+    print_info(console, f"Found {issue_count} actionable {'issue' if issue_count == 1 else 'issues'}")
     if feedback_items:
         print_feedback_table(console, feedback_items)
     return feedback_items
@@ -2689,7 +2690,7 @@ async def phase_per_stack_reviews(
         print_warning(
             console,
             f"Per-stack reviews failed for {len(failures)} stack(s); "
-            "the merge report will note them as uncovered.\n" + lines,
+            "failures will be passed to the merge step.\n" + lines,
         )
 
     if recorder is not None:

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -2680,15 +2680,17 @@ async def phase_per_stack_reviews(
                             await run_agent(backend, work.repo, task_prompt, phase=DaydreamPhase.DEEP)
                         results[stack_name] = task_output
                     except Exception as e:  # noqa: BLE001 -- intentionally broad for parallel isolation
-                        reason = f"{type(e).__name__}: {e}"
-                        failures[stack_name] = reason
-                        print_warning(
-                            console,
-                            f"Per-stack review for '{stack_name}' failed ({reason}); "
-                            "merge report will note this stack as uncovered.",
-                        )
+                        failures[stack_name] = f"{type(e).__name__}: {e}"
 
             tg.start_soon(_task)
+
+    if failures:
+        lines = "\n".join(f"  - {name}: {reason}" for name, reason in sorted(failures.items()))
+        print_warning(
+            console,
+            f"Per-stack reviews failed for {len(failures)} stack(s); "
+            "the merge report will note them as uncovered.\n" + lines,
+        )
 
     if recorder is not None:
         recorder.create_dispatch_step(phase=DaydreamPhase.DEEP)

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -40,6 +40,7 @@ from daydream.ui import (
     phase_subtitle,
     print_dim,
     print_error,
+    print_feedback_table,
     print_fix_complete,
     print_fix_progress,
     print_info,
@@ -1519,6 +1520,8 @@ If there are no actionable issues, return: {{"issues": []}}
 
     feedback_items = result["issues"]
     print_info(console, f"Found {len(feedback_items)} actionable issues")
+    if feedback_items:
+        print_feedback_table(console, feedback_items)
     return feedback_items
 
 
@@ -2797,6 +2800,8 @@ async def phase_arbiter_review(
         arb_id = finding.get("arb_id")
         if isinstance(arb_id, int):
             verdicts[arb_id] = finding
+    kept = sum(1 for v in verdicts.values() if v.get("keep"))
+    print_info(console, f"Arbiter: kept {kept}, dropped {len(verdicts) - kept}")
     return verdicts
 
 
@@ -2917,6 +2922,7 @@ async def phase_cross_stack_merge(
 
     items = normalize_items(agent_items + structural_items)
     items_path.write_text(json.dumps({"items": items}, indent=2))
+    print_info(console, f"Merged into {len(items)} items")
 
     # Render the human report FROM the canonical items, then copy from the deep
     # artifact dir to the canonical location (the deep dir avoids sandbox write

--- a/daydream/ui.py
+++ b/daydream/ui.py
@@ -2321,10 +2321,10 @@ def print_issues_table(console: Console, issues: list[dict]) -> None:
 
 def format_verdict_join(
     *,
-    matched: list,
-    unmatched: list,
-    structural: list,
-    other: list,
+    matched: list[int | None],
+    unmatched: list[int | None],
+    structural: list[int | None],
+    other: list[int | None],
     total: int,
 ) -> Table:
     """Build a table summarizing how merged items joined to verifier verdicts.
@@ -2356,15 +2356,22 @@ def format_verdict_join(
     table.add_column("Count", style=STYLE_FG)
     table.add_column("IDs", style=STYLE_DIM)
 
-    def _ids(values: list) -> str:
+    def _ids(values: list[int | None]) -> str:
         return ", ".join(str(v) for v in values)
 
-    table.add_row("Matched", str(len(matched)), _ids(matched))
-    table.add_row("Unmatched", str(len(unmatched)), _ids(unmatched))
-    table.add_row("Structural", str(len(structural)), _ids(structural))
+    n_matched = len(matched)
+    n_unmatched = len(unmatched)
+    n_structural = len(structural)
+    n_other = len(other)
+    computed_total = n_matched + n_unmatched + n_structural + n_other
+
+    table.add_row("Matched", str(n_matched), _ids(matched))
+    table.add_row("Unmatched", str(n_unmatched), _ids(unmatched))
+    table.add_row("Structural", str(n_structural), _ids(structural))
     if other:
-        table.add_row("Other", str(len(other)), _ids(other))
-    table.add_row("Total", str(total), "")
+        table.add_row("Other", str(n_other), _ids(other))
+    mismatch = f"  [expected {total}]" if computed_total != total else ""
+    table.add_row("Total", str(computed_total) + mismatch, "")
 
     return table
 
@@ -2374,21 +2381,23 @@ def format_verdict_join(
 _EXPLORATION_LIST_CAP = 8
 
 
-def render_exploration_summary(console: Console, ctx: "ExplorationContext") -> None:
-    """Render the pre-scan exploration context as a readable summary.
+def render_exploration_summary(ctx: "ExplorationContext") -> "Group | Text":
+    """Build a renderable summarising the pre-scan exploration context.
 
     Replaces the raw structured-output JSON dump with a counts header plus
     compact lists of conventions, dependencies, and affected files. Mirrors
     the field shapes and label wording of ExplorationContext.to_prompt_section.
 
     Args:
-        console: Rich Console instance for output.
         ctx: Aggregated exploration results (read-only).
+
+    Returns:
+        A rich renderable (Table wrapped in a Group, or a plain Text for the
+        empty case) ready to pass to console.print.
 
     """
     if not (ctx.affected_files or ctx.conventions or ctx.dependencies or ctx.guidelines):
-        print_dim(console, "Exploration: no codebase context gathered")
-        return
+        return Text("Exploration: no codebase context gathered", style=STYLE_DIM)
 
     def _count(n: int, singular: str, plural: str) -> str:
         return f"{n} {singular}" if n == 1 else f"{n} {plural}"
@@ -2446,8 +2455,7 @@ def render_exploration_summary(console: Console, ctx: "ExplorationContext") -> N
     if ctx.guidelines:
         _add_items("Project Guidelines", list(ctx.guidelines))
 
-    console.print()
-    console.print(table)
+    return Group(Text(""), table)
 
 
 # Menu Component

--- a/daydream/ui.py
+++ b/daydream/ui.py
@@ -11,6 +11,7 @@ import time
 from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pyfiglet
 from rich import box
@@ -25,6 +26,9 @@ from rich.syntax import Syntax
 from rich.table import Table
 from rich.text import Text
 from rich.theme import Theme
+
+if TYPE_CHECKING:
+    from daydream.exploration import ExplorationContext
 
 # Color Theme (Dracula-based)
 
@@ -2310,6 +2314,87 @@ def print_issues_table(console: Console, issues: list[dict]) -> None:
         if "files" in issue and issue["files"]:
             files_str = ", ".join(issue["files"])
             console.print(Text(f"  Files: {files_str}", style=STYLE_DIM))
+
+
+# Exploration Summary Component
+
+_EXPLORATION_LIST_CAP = 8
+
+
+def render_exploration_summary(console: Console, ctx: "ExplorationContext") -> None:
+    """Render the pre-scan exploration context as a readable summary.
+
+    Replaces the raw structured-output JSON dump with a counts header plus
+    compact lists of conventions, dependencies, and affected files. Mirrors
+    the field shapes and label wording of ExplorationContext.to_prompt_section.
+
+    Args:
+        console: Rich Console instance for output.
+        ctx: Aggregated exploration results (read-only).
+
+    """
+    if not (ctx.affected_files or ctx.conventions or ctx.dependencies or ctx.guidelines):
+        print_dim(console, "Exploration: no codebase context gathered")
+        return
+
+    def _count(n: int, singular: str, plural: str) -> str:
+        return f"{n} {singular}" if n == 1 else f"{n} {plural}"
+
+    parts: list[str] = []
+    if ctx.affected_files:
+        parts.append(_count(len(ctx.affected_files), "file", "files"))
+    if ctx.conventions:
+        parts.append(_count(len(ctx.conventions), "convention", "conventions"))
+    if ctx.dependencies:
+        parts.append(_count(len(ctx.dependencies), "dependency", "dependencies"))
+    if ctx.guidelines:
+        parts.append(_count(len(ctx.guidelines), "guideline", "guidelines"))
+
+    table = Table(
+        title="🔍 Exploration",
+        title_style=STYLE_BOLD_CYAN,
+        box=box.ROUNDED,
+        border_style=STYLE_PURPLE,
+        show_header=False,
+        padding=(0, 1),
+    )
+    table.add_column("Section", style=STYLE_CYAN, no_wrap=True)
+    table.add_column("Detail", style=STYLE_FG)
+
+    table.add_row("", pill(f" {' · '.join(parts)} ", NEON_COLORS["purple"], NEON_COLORS["background"]))
+
+    def _add_items(label: str, items: list[str]) -> None:
+        shown = items[:_EXPLORATION_LIST_CAP]
+        body = Text()
+        for i, line in enumerate(shown):
+            if i:
+                body.append("\n")
+            body.append(line, style=STYLE_FG)
+        extra = len(items) - len(shown)
+        if extra > 0:
+            body.append(f"\n+{extra} more", style=STYLE_DIM)
+        table.add_row(Text(label, style=STYLE_BOLD_PINK), body)
+
+    if ctx.conventions:
+        _add_items(
+            "Conventions",
+            [f"{c.name} — {c.description}" + (f" ({c.source})" if c.source else "") for c in ctx.conventions],
+        )
+    if ctx.dependencies:
+        _add_items(
+            "Dependencies",
+            [f"{d.source} {d.relationship} {d.target}" for d in ctx.dependencies],
+        )
+    if ctx.affected_files:
+        _add_items(
+            "Affected Files",
+            [f"{f.path} ({f.role})" for f in ctx.affected_files],
+        )
+    if ctx.guidelines:
+        _add_items("Project Guidelines", list(ctx.guidelines))
+
+    console.print()
+    console.print(table)
 
 
 # Menu Component

--- a/daydream/ui.py
+++ b/daydream/ui.py
@@ -2316,6 +2316,59 @@ def print_issues_table(console: Console, issues: list[dict]) -> None:
             console.print(Text(f"  Files: {files_str}", style=STYLE_DIM))
 
 
+# Verdict-Join Summary Component
+
+
+def format_verdict_join(
+    *,
+    matched: list,
+    unmatched: list,
+    structural: list,
+    other: list,
+    total: int,
+) -> Table:
+    """Build a table summarizing how merged items joined to verifier verdicts.
+
+    One row per category (Matched / Unmatched / Structural / Other) showing the
+    count and, dimly, the ids; a final Total row. The Other row is omitted when
+    empty. Mirrors the print_summary table style.
+
+    Args:
+        matched: Ids of items that matched a verifier verdict.
+        unmatched: Ids of verdict-eligible items with no verifier verdict.
+        structural: Ids of structural (verdict-exempt) items.
+        other: Leftover ids that fit no other bucket.
+        total: Total number of items to fix (len(items)).
+
+    Returns:
+        A rich Table ready to pass to console.print.
+
+    """
+    table = Table(
+        title="Verdict Join",
+        title_style=STYLE_BOLD_GREEN,
+        box=box.ROUNDED,
+        border_style=STYLE_PURPLE,
+        show_header=False,
+        padding=(0, 1),
+    )
+    table.add_column("Category", style=STYLE_CYAN)
+    table.add_column("Count", style=STYLE_FG)
+    table.add_column("IDs", style=STYLE_DIM)
+
+    def _ids(values: list) -> str:
+        return ", ".join(str(v) for v in values)
+
+    table.add_row("Matched", str(len(matched)), _ids(matched))
+    table.add_row("Unmatched", str(len(unmatched)), _ids(unmatched))
+    table.add_row("Structural", str(len(structural)), _ids(structural))
+    if other:
+        table.add_row("Other", str(len(other)), _ids(other))
+    table.add_row("Total", str(total), "")
+
+    return table
+
+
 # Exploration Summary Component
 
 _EXPLORATION_LIST_CAP = 8

--- a/tests/test_agent_structured_render.py
+++ b/tests/test_agent_structured_render.py
@@ -7,62 +7,24 @@ Verified terminal-render harness (from Task 0):
     rec.export_text()  # captures the rendered agent text
 
 run_agent requires the keyword-only `phase=` argument (DaydreamPhase),
-imported from daydream.trajectory. MockBackend mirrors the dataclass at
-tests/test_agent_recorder_integration.py:61-96.
+imported from daydream.trajectory. MockBackend is imported from
+tests.test_agent_recorder_integration (the single canonical definition).
 """
 
 from __future__ import annotations
-
-from collections.abc import AsyncIterator
-from dataclasses import dataclass
-from pathlib import Path
-from typing import Any
 
 from rich.console import Console
 
 from daydream.agent import run_agent
 from daydream.backends import (
-    AgentEvent,
-    ContinuationToken,
     ResultEvent,
     TextEvent,
 )
 from daydream.trajectory import DaydreamPhase
+from tests.test_agent_recorder_integration import MockBackend
 
 RAW = '{"conventions": [{"name": "OpenAPI First", "description": "x", "source": "CLAUDE.md"}]}'
 PAYLOAD = {"conventions": [{"name": "OpenAPI First", "description": "x", "source": "CLAUDE.md"}]}
-
-
-@dataclass
-class MockBackend:
-    """Minimal Backend that replays a canned event list (mirrors the protocol)."""
-
-    model = "mock-model"
-    events: list[AgentEvent]
-
-    def execute(
-        self,
-        cwd: Path,
-        prompt: str,
-        output_schema: dict[str, Any] | None = None,
-        continuation: ContinuationToken | None = None,
-        agents: dict[str, Any] | None = None,
-        max_turns: int | None = None,
-        read_only: bool = False,
-    ) -> AsyncIterator[AgentEvent]:
-        events = self.events
-
-        async def _gen() -> AsyncIterator[AgentEvent]:
-            for event in events:
-                yield event
-
-        return _gen()
-
-    async def cancel(self) -> None:
-        return None
-
-    def format_skill_invocation(self, skill_key: str, args: str = "") -> str:
-        return f"/{skill_key}"
 
 
 async def test_structured_output_text_is_not_rendered(monkeypatch, tmp_path):

--- a/tests/test_agent_structured_render.py
+++ b/tests/test_agent_structured_render.py
@@ -1,0 +1,88 @@
+"""Task 1 real-path tests: run_agent must not echo structured-output JSON.
+
+Verified terminal-render harness (from Task 0):
+    rec = Console(record=True, force_terminal=True, width=100)
+    monkeypatch.setattr("daydream.agent.console", rec)
+    ... drive run_agent ...
+    rec.export_text()  # captures the rendered agent text
+
+run_agent requires the keyword-only `phase=` argument (DaydreamPhase),
+imported from daydream.trajectory. MockBackend mirrors the dataclass at
+tests/test_agent_recorder_integration.py:61-96.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from rich.console import Console
+
+from daydream.agent import run_agent
+from daydream.backends import (
+    AgentEvent,
+    ContinuationToken,
+    ResultEvent,
+    TextEvent,
+)
+from daydream.trajectory import DaydreamPhase
+
+RAW = '{"conventions": [{"name": "OpenAPI First", "description": "x", "source": "CLAUDE.md"}]}'
+PAYLOAD = {"conventions": [{"name": "OpenAPI First", "description": "x", "source": "CLAUDE.md"}]}
+
+
+@dataclass
+class MockBackend:
+    """Minimal Backend that replays a canned event list (mirrors the protocol)."""
+
+    model = "mock-model"
+    events: list[AgentEvent]
+
+    def execute(
+        self,
+        cwd: Path,
+        prompt: str,
+        output_schema: dict[str, Any] | None = None,
+        continuation: ContinuationToken | None = None,
+        agents: dict[str, Any] | None = None,
+        max_turns: int | None = None,
+        read_only: bool = False,
+    ) -> AsyncIterator[AgentEvent]:
+        events = self.events
+
+        async def _gen() -> AsyncIterator[AgentEvent]:
+            for event in events:
+                yield event
+
+        return _gen()
+
+    async def cancel(self) -> None:
+        return None
+
+    def format_skill_invocation(self, skill_key: str, args: str = "") -> str:
+        return f"/{skill_key}"
+
+
+async def test_structured_output_text_is_not_rendered(monkeypatch, tmp_path):
+    rec = Console(record=True, force_terminal=True, width=100)
+    monkeypatch.setattr("daydream.agent.console", rec)
+    backend = MockBackend([TextEvent(text=RAW), ResultEvent(structured_output=PAYLOAD, continuation=None)])
+    result, _ = await run_agent(
+        backend, tmp_path, "scan", phase=DaydreamPhase.REVIEW, output_schema={"type": "object"}
+    )
+    out = rec.export_text()
+    assert result == PAYLOAD  # canonical structured result still returned
+    assert "OpenAPI First" not in out  # raw JSON content NOT on the terminal
+    assert "{" not in out
+
+
+async def test_plain_text_still_renders(monkeypatch, tmp_path):
+    rec = Console(record=True, force_terminal=True, width=100)
+    monkeypatch.setattr("daydream.agent.console", rec)
+    backend = MockBackend(
+        [TextEvent(text="narration here"), ResultEvent(structured_output=None, continuation=None)]
+    )
+    result, _ = await run_agent(backend, tmp_path, "go", phase=DaydreamPhase.REVIEW)  # no output_schema
+    assert "narration here" in rec.export_text()

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -499,8 +499,8 @@ async def test_run_deep_renders_prescan_summary_not_json(
     # Add a 4th changed file so select_tier() -> "parallel" (the pattern-scanner
     # runs and its conventions reach the rendered summary).
     (multi_stack_target / "extra.py").write_text("VALUE = 2\n")
-    subprocess.run(["git", "add", "."], cwd=multi_stack_target, capture_output=True, check=True)  # noqa: S603, S607
-    subprocess.run(  # noqa: S603, S607
+    subprocess.run(["git", "add", "."], cwd=multi_stack_target, capture_output=True, check=True)  # noqa: S603, S607 - arguments are not user-controlled
+    subprocess.run(  # noqa: S603, S607 - arguments are not user-controlled
         ["git", "commit", "-m", "add extra"], cwd=multi_stack_target, capture_output=True, check=True
     )
 

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -119,6 +119,39 @@ class _StubBackend:
             )
             return
 
+        # Exploration specialists. Each returns its envelope sub-dict as
+        # structured_output (keyed into results[name] by _run_specialist) plus a
+        # TextEvent of raw JSON the production gate must suppress from the terminal.
+        if "you are the **pattern-scanner** specialist" in pl:
+            payload = {
+                "conventions": [
+                    {
+                        "name": "OpenAPI First",
+                        "description": "openapi.yaml is the HTTP contract",
+                        "source": "CLAUDE.md",
+                    }
+                ],
+                "guidelines": [],
+            }
+            yield TextEvent(text=json.dumps({"conventions": payload["conventions"], "guidelines": []}))
+            yield ResultEvent(structured_output=payload, continuation=None)
+            return
+        if "you are the **dependency-tracer** specialist" in pl:
+            payload = {
+                "affected_files": [],
+                "dependencies": [
+                    {"source": "App.tsx", "target": "api.py", "relationship": "calls"}
+                ],
+            }
+            yield TextEvent(text=json.dumps(payload))
+            yield ResultEvent(structured_output=payload, continuation=None)
+            return
+        if "you are the **test-mapper** specialist" in pl:
+            payload = {"affected_files": []}
+            yield TextEvent(text=json.dumps(payload))
+            yield ResultEvent(structured_output=payload, continuation=None)
+            return
+
         # TTT intent phase -> plain text. Discriminator unique to build_intent_prompt.
         if "understand the intent of these changes" in pl:
             yield TextEvent(text="The PR updates greetings across stacks.")
@@ -352,6 +385,7 @@ def _install_stub_backend(
     *,
     is_codex: bool = False,
     pin_skill_availability: bool = True,
+    enable_exploration: bool = False,
 ) -> _StubBackend:
     """Patch create_backend to return a single stub backend instance.
 
@@ -363,6 +397,10 @@ def _install_stub_backend(
             plugin registry and prevents exploration from adding unexpected
             backend calls. Pass False when a test explicitly controls skill
             availability (e.g. via ``CLAUDE_CONFIG_DIR``).
+        enable_exploration: When True, leaves ``EXPLORATION_AVAILABLE`` True so
+            the real ``pre_scan`` branch runs and the stub answers the
+            specialist prompts. Default False preserves the existing behavior
+            (exploration disabled) that the rest of the suite relies on.
     """
     stub = _StubBackend(target, is_codex=is_codex)
     monkeypatch.setattr("daydream.runner.create_backend", lambda name, model=None: stub)
@@ -373,8 +411,9 @@ def _install_stub_backend(
     if pin_skill_availability:
         # None -> orchestrator falls back to set(SKILL_MAP.keys()).
         monkeypatch.setattr("daydream.deep.orchestrator.get_installed_skills", lambda: None)
-        # Disable exploration pre-scan so it doesn't add extra backend calls.
-        monkeypatch.setattr("daydream.deep.orchestrator.EXPLORATION_AVAILABLE", False)
+        if not enable_exploration:
+            # Disable exploration pre-scan so it doesn't add extra backend calls.
+            monkeypatch.setattr("daydream.deep.orchestrator.EXPLORATION_AVAILABLE", False)
     return stub
 
 
@@ -441,6 +480,44 @@ async def _ok(*_a: Any, **_k: Any) -> tuple[bool, int]:
 async def _noop_commit(*_a: Any, **_k: Any) -> None:
     """Async no-op stand-in for phase_commit_push."""
     return None
+
+
+async def test_run_deep_renders_prescan_summary_not_json(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Real-path: the pre-scan summary renders as a readable panel, not raw JSON.
+
+    Drives ``run`` through ``run_deep`` with EXPLORATION_AVAILABLE left True so
+    the real ``pre_scan`` branch executes and the stub answers the specialist
+    prompts. Asserts the convention surfaces in the rendered summary and that
+    no raw structured-output JSON envelope leaks to the terminal.
+    """
+    from rich.console import Console
+
+    from daydream.runner import RunConfig, run
+
+    # Add a 4th changed file so select_tier() -> "parallel" (the pattern-scanner
+    # runs and its conventions reach the rendered summary).
+    (multi_stack_target / "extra.py").write_text("VALUE = 2\n")
+    subprocess.run(["git", "add", "."], cwd=multi_stack_target, capture_output=True, check=True)  # noqa: S603, S607
+    subprocess.run(  # noqa: S603, S607
+        ["git", "commit", "-m", "add extra"], cwd=multi_stack_target, capture_output=True, check=True
+    )
+
+    _silence(monkeypatch)
+    rec = Console(record=True, force_terminal=True, width=120)
+    monkeypatch.setattr("daydream.deep.orchestrator.console", rec)
+    _install_stub_backend(monkeypatch, multi_stack_target, enable_exploration=True)
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_test_and_heal", lambda *a, **k: _ok())
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _noop_commit)
+
+    exit_code = await run(
+        RunConfig(target=str(multi_stack_target), assume="yes", output_mode="loop", cleanup=False)
+    )
+    assert exit_code == 0
+    out = rec.export_text()
+    assert "OpenAPI First" in out  # convention surfaced by the summary
+    assert '{"conventions"' not in out and "pattern-scanner" not in out  # no raw JSON envelope
 
 
 async def test_parallel_fix_applies_all_disjoint_files(

--- a/tests/test_phases_render.py
+++ b/tests/test_phases_render.py
@@ -25,10 +25,12 @@ from typing import Any
 from rich.console import Console
 
 from daydream.backends import AgentEvent, ContinuationToken, ResultEvent
+from daydream.deep.detection import StackAssignment
 from daydream.phases import (
     phase_arbiter_review,
     phase_cross_stack_merge,
     phase_parse_feedback,
+    phase_per_stack_reviews,
 )
 from daydream.workspace import WorkContext
 
@@ -193,3 +195,79 @@ async def test_arbiter_prints_kept_dropped(monkeypatch, tmp_path):
     assert "kept" in out.lower()
     assert "2" in out
     assert "1" in out
+
+
+@dataclass
+class _PerStackBackend:
+    """Backend that raises for stacks whose name appears in ``fail_for``.
+
+    ``phase_per_stack_reviews`` passes each stack's output path (which embeds the
+    stack name, e.g. ``stack-stack-a-review.md``) into the per-stack prompt, so the
+    stub keys its raise/succeed decision off the prompt text. Mirrors the
+    three-method Backend protocol (test_agent_recorder_integration:61-96).
+    """
+
+    model = "mock-model"
+    fail_for: set[str]
+
+    def execute(
+        self,
+        cwd: Path,
+        prompt: str,
+        output_schema: dict[str, Any] | None = None,
+        continuation: ContinuationToken | None = None,
+        agents: dict[str, Any] | None = None,
+        max_turns: int | None = None,
+        read_only: bool = False,
+    ) -> AsyncIterator[AgentEvent]:
+        should_fail = any(f"stack-{name}-review.md" in prompt for name in self.fail_for)
+
+        async def _gen() -> AsyncIterator[AgentEvent]:
+            if should_fail:
+                raise RuntimeError("agent boom")
+            yield ResultEvent(structured_output=None, continuation=None)
+
+        return _gen()
+
+    async def cancel(self) -> None:
+        return None
+
+    def format_skill_invocation(self, skill_key: str, args: str = "") -> str:
+        return f"/{skill_key}"
+
+
+async def test_per_stack_failures_summarized_once(monkeypatch, tmp_path):
+    rec = _rec(monkeypatch)
+    work = _work(tmp_path)
+    (tmp_path / ".daydream" / "deep").mkdir(parents=True, exist_ok=True)
+    diff = tmp_path / ".daydream" / "deep" / "diff.patch"
+    diff.write_text("diff")
+    intent = tmp_path / ".daydream" / "deep" / "intent.md"
+    intent.write_text("intent")
+    alts = tmp_path / ".daydream" / "deep" / "alternatives.json"
+    alts.write_text("[]")
+
+    stacks = [
+        StackAssignment(stack_name="stack-a", skill_invocation=None, files=["a.py"]),
+        StackAssignment(stack_name="stack-b", skill_invocation=None, files=["b.py"]),
+        StackAssignment(stack_name="stack-c", skill_invocation=None, files=["c.py"]),
+    ]
+    backend = _PerStackBackend(fail_for={"stack-a", "stack-b"})
+
+    successes, failures = await phase_per_stack_reviews(
+        backend,
+        work,
+        stacks,
+        diff_path=diff,
+        intent_path=intent,
+        alternatives_path=alts,
+    )
+
+    out = rec.export_text()
+    assert set(failures) == {"stack-a", "stack-b"}
+    assert set(successes) == {"stack-c"}
+    # ONE consolidated end-of-phase summary names BOTH failed stacks -- not two
+    # scattered inline warnings. The summary header is emitted exactly once.
+    assert "stack-a" in out and "stack-b" in out
+    assert out.count("uncovered") >= 1
+    assert out.count("Per-stack reviews failed") == 1

--- a/tests/test_phases_render.py
+++ b/tests/test_phases_render.py
@@ -1,0 +1,195 @@
+"""Phase-seam render tests for the de-silenced structured phases (Task 3).
+
+After Task 1 suppressed raw structured-output JSON in ``run_agent``, the
+structured phases (parse-feedback, cross-stack merge, arbiter) produced no
+visible terminal output. These tests drive the real phase entrypoints with a
+``MockBackend`` whose ``ResultEvent.structured_output`` matches each phase's
+schema and assert the restored summaries render observable content (counts,
+a table) without dumping raw JSON.
+
+Verified harness (from Task 0): record console is
+``Console(record=True, force_terminal=True, width=100)``; tests patch the
+importing module's binding via ``monkeypatch.setattr("daydream.phases.console", rec)``.
+``MockBackend`` mirrors tests/test_agent_recorder_integration.py:61-96 and
+accounts for ``run_agent``'s keyword-only ``phase`` argument (passed by the
+phases themselves, not the backend).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from rich.console import Console
+
+from daydream.backends import AgentEvent, ContinuationToken, ResultEvent
+from daydream.phases import (
+    phase_arbiter_review,
+    phase_cross_stack_merge,
+    phase_parse_feedback,
+)
+from daydream.workspace import WorkContext
+
+
+@dataclass
+class MockBackend:
+    """Replays a canned event list (mirrors test_agent_recorder_integration:61-96)."""
+
+    model = "mock-model"
+    events: list[AgentEvent]
+
+    def execute(
+        self,
+        cwd: Path,
+        prompt: str,
+        output_schema: dict[str, Any] | None = None,
+        continuation: ContinuationToken | None = None,
+        agents: dict[str, Any] | None = None,
+        max_turns: int | None = None,
+        read_only: bool = False,
+    ) -> AsyncIterator[AgentEvent]:
+        events = self.events
+
+        async def _gen() -> AsyncIterator[AgentEvent]:
+            for event in events:
+                yield event
+
+        return _gen()
+
+    async def cancel(self) -> None:
+        return None
+
+    def format_skill_invocation(self, skill_key: str, args: str = "") -> str:
+        return f"/{skill_key}"
+
+
+def _rec(monkeypatch: Any) -> Console:
+    rec = Console(record=True, force_terminal=True, width=100)
+    monkeypatch.setattr("daydream.phases.console", rec)
+    return rec
+
+
+def _work(tmp_path: Path) -> WorkContext:
+    return WorkContext(
+        repo=tmp_path,
+        source=tmp_path,
+        base_branch="main",
+        base_sha="DEADBEEF",
+        head_branch="feat/x",
+        head_sha="CAFEBABE",
+        is_ephemeral=False,
+        run_id="20260101000000-deadbeef",
+    )
+
+
+async def test_parse_feedback_renders_issue_table(monkeypatch, tmp_path):
+    rec = _rec(monkeypatch)
+    payload = {
+        "issues": [
+            {
+                "id": 1,
+                "description": "Missing null check",
+                "file": "f.py",
+                "line": 3,
+                "confidence": "HIGH",
+                "rationale": "crashes on None",
+            }
+        ]
+    }
+    backend = MockBackend([ResultEvent(structured_output=payload, continuation=None)])
+
+    items = await phase_parse_feedback(backend, _work(tmp_path))
+
+    out = rec.export_text()
+    assert items == payload["issues"]
+    assert "Found 1 actionable issues" in out
+    assert "f.py" in out
+    assert "Missing null check" in out
+    assert "{" not in out
+
+
+async def test_merge_prints_item_count(monkeypatch, tmp_path):
+    rec = _rec(monkeypatch)
+    items = [
+        {
+            "id": i,
+            "description": f"issue {i}",
+            "file": f"f{i}.py",
+            "line": i,
+            "confidence": "HIGH",
+            "rationale": "r",
+            "lens": "per-stack",
+            "severity": "high",
+        }
+        for i in range(1, 4)
+    ]
+    backend = MockBackend([ResultEvent(structured_output={"items": items}, continuation=None)])
+
+    dd = tmp_path / ".daydream" / "deep"
+    dd.mkdir(parents=True, exist_ok=True)
+    intent = dd / "intent.md"
+    intent.write_text("intent")
+    alts = dd / "alternatives.json"
+    alts.write_text("[]")
+    dedup = dd / "dedup-candidates.json"
+    dedup.write_text("[]")
+
+    await phase_cross_stack_merge(
+        backend,
+        _work(tmp_path),
+        per_stack_records_paths=[],
+        intent_path=intent,
+        alternatives_path=alts,
+        dedup_candidates_path=dedup,
+    )
+
+    out = rec.export_text()
+    assert "3" in out
+    assert "{" not in out
+
+
+async def test_arbiter_prints_kept_dropped(monkeypatch, tmp_path):
+    rec = _rec(monkeypatch)
+    selected = [
+        {
+            "file": f"f{i}.py",
+            "line": i,
+            "severity": "high",
+            "confidence": "HIGH",
+            "description": f"d{i}",
+            "rationale": "r",
+        }
+        for i in range(1, 4)
+    ]
+    findings = [
+        {"arb_id": 1, "keep": True, "severity": "high", "confidence": "HIGH", "description": "d1", "rationale": "r"},
+        {"arb_id": 2, "keep": True, "severity": "high", "confidence": "HIGH", "description": "d2", "rationale": "r"},
+        {"arb_id": 3, "keep": False, "severity": "low", "confidence": "LOW", "description": "d3", "rationale": "r"},
+    ]
+    backend = MockBackend([ResultEvent(structured_output={"findings": findings}, continuation=None)])
+
+    dd = tmp_path / ".daydream" / "deep"
+    dd.mkdir(parents=True, exist_ok=True)
+    diff = dd / "diff.patch"
+    diff.write_text("diff")
+    intent = dd / "intent.md"
+    intent.write_text("intent")
+    alts = dd / "alternatives.json"
+    alts.write_text("[]")
+
+    verdicts = await phase_arbiter_review(
+        backend,
+        _work(tmp_path),
+        selected_records=selected,
+        diff_path=diff,
+        intent_path=intent,
+        alternatives_path=alts,
+    )
+
+    out = rec.export_text()
+    assert len(verdicts) == 3
+    assert "kept" in out.lower()
+    assert "2" in out
+    assert "1" in out

--- a/tests/test_phases_render.py
+++ b/tests/test_phases_render.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Any
 
 from rich.console import Console
+from test_agent_recorder_integration import MockBackend
 
 from daydream.backends import AgentEvent, ContinuationToken, ResultEvent
 from daydream.deep.detection import StackAssignment
@@ -32,39 +33,6 @@ from daydream.phases import (
     phase_parse_feedback,
     phase_per_stack_reviews,
 )
-from daydream.workspace import WorkContext
-
-
-@dataclass
-class MockBackend:
-    """Replays a canned event list (mirrors test_agent_recorder_integration:61-96)."""
-
-    model = "mock-model"
-    events: list[AgentEvent]
-
-    def execute(
-        self,
-        cwd: Path,
-        prompt: str,
-        output_schema: dict[str, Any] | None = None,
-        continuation: ContinuationToken | None = None,
-        agents: dict[str, Any] | None = None,
-        max_turns: int | None = None,
-        read_only: bool = False,
-    ) -> AsyncIterator[AgentEvent]:
-        events = self.events
-
-        async def _gen() -> AsyncIterator[AgentEvent]:
-            for event in events:
-                yield event
-
-        return _gen()
-
-    async def cancel(self) -> None:
-        return None
-
-    def format_skill_invocation(self, skill_key: str, args: str = "") -> str:
-        return f"/{skill_key}"
 
 
 def _rec(monkeypatch: Any) -> Console:
@@ -73,20 +41,7 @@ def _rec(monkeypatch: Any) -> Console:
     return rec
 
 
-def _work(tmp_path: Path) -> WorkContext:
-    return WorkContext(
-        repo=tmp_path,
-        source=tmp_path,
-        base_branch="main",
-        base_sha="DEADBEEF",
-        head_branch="feat/x",
-        head_sha="CAFEBABE",
-        is_ephemeral=False,
-        run_id="20260101000000-deadbeef",
-    )
-
-
-async def test_parse_feedback_renders_issue_table(monkeypatch, tmp_path):
+async def test_parse_feedback_renders_issue_table(monkeypatch, tmp_path, make_work):
     rec = _rec(monkeypatch)
     payload = {
         "issues": [
@@ -102,17 +57,17 @@ async def test_parse_feedback_renders_issue_table(monkeypatch, tmp_path):
     }
     backend = MockBackend([ResultEvent(structured_output=payload, continuation=None)])
 
-    items = await phase_parse_feedback(backend, _work(tmp_path))
+    items = await phase_parse_feedback(backend, make_work(tmp_path))
 
     out = rec.export_text()
     assert items == payload["issues"]
-    assert "Found 1 actionable issues" in out
+    assert "Found 1 actionable issue" in out
     assert "f.py" in out
     assert "Missing null check" in out
     assert "{" not in out
 
 
-async def test_merge_prints_item_count(monkeypatch, tmp_path):
+async def test_merge_prints_item_count(monkeypatch, tmp_path, make_work):
     rec = _rec(monkeypatch)
     items = [
         {
@@ -140,7 +95,7 @@ async def test_merge_prints_item_count(monkeypatch, tmp_path):
 
     await phase_cross_stack_merge(
         backend,
-        _work(tmp_path),
+        make_work(tmp_path),
         per_stack_records_paths=[],
         intent_path=intent,
         alternatives_path=alts,
@@ -148,11 +103,11 @@ async def test_merge_prints_item_count(monkeypatch, tmp_path):
     )
 
     out = rec.export_text()
-    assert "3" in out
+    assert "Merged into 3 items" in out
     assert "{" not in out
 
 
-async def test_arbiter_prints_kept_dropped(monkeypatch, tmp_path):
+async def test_arbiter_prints_kept_dropped(monkeypatch, tmp_path, make_work):
     rec = _rec(monkeypatch)
     selected = [
         {
@@ -183,7 +138,7 @@ async def test_arbiter_prints_kept_dropped(monkeypatch, tmp_path):
 
     verdicts = await phase_arbiter_review(
         backend,
-        _work(tmp_path),
+        make_work(tmp_path),
         selected_records=selected,
         diff_path=diff,
         intent_path=intent,
@@ -236,9 +191,9 @@ class _PerStackBackend:
         return f"/{skill_key}"
 
 
-async def test_per_stack_failures_summarized_once(monkeypatch, tmp_path):
+async def test_per_stack_failures_summarized_once(monkeypatch, tmp_path, make_work):
     rec = _rec(monkeypatch)
-    work = _work(tmp_path)
+    work = make_work(tmp_path)
     (tmp_path / ".daydream" / "deep").mkdir(parents=True, exist_ok=True)
     diff = tmp_path / ".daydream" / "deep" / "diff.patch"
     diff.write_text("diff")
@@ -269,5 +224,5 @@ async def test_per_stack_failures_summarized_once(monkeypatch, tmp_path):
     # ONE consolidated end-of-phase summary names BOTH failed stacks -- not two
     # scattered inline warnings. The summary header is emitted exactly once.
     assert "stack-a" in out and "stack-b" in out
-    assert out.count("uncovered") >= 1
+    assert out.count("failures will be passed to the merge step") >= 1
     assert out.count("Per-stack reviews failed") == 1

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -33,6 +33,20 @@ def test_plan_renderer_dims_ungrounded_steps():
     assert "(ungrounded)" in output
 
 
+def test_format_verdict_join_renders_table_counts():
+    from rich.console import Console
+
+    from daydream.ui import format_verdict_join  # type: ignore[attr-defined]
+
+    table = format_verdict_join(matched=[1, 2], unmatched=[3], structural=[4, 5], other=[], total=5)
+    console = Console(record=True, force_terminal=True, width=100)
+    console.print(table)
+    out = console.export_text()
+    assert "2" in out and "matched" in out.lower()
+    assert "structural" in out.lower()
+    assert "{" not in out
+
+
 def _run_renderer_and_count_panels(width: int, height: int, text_lines: list[str]) -> tuple[int, object]:
     from rich.console import Console
     from rich.panel import Panel

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -81,6 +81,39 @@ def test_agent_text_renderer_small_content_single_panel():
     assert renderer._buffer == []  # type: ignore[attr-defined]
 
 
+def test_render_exploration_summary_shows_content_not_json():
+    from rich.console import Console
+
+    from daydream.exploration import Convention, Dependency, ExplorationContext, FileInfo
+    from daydream.ui import render_exploration_summary  # type: ignore[attr-defined]
+
+    ctx = ExplorationContext(
+        affected_files=[FileInfo(path="services/library/openapi.yaml", role="modified")],
+        conventions=[
+            Convention(name="OpenAPI First", description="openapi.yaml is the HTTP contract", source="CLAUDE.md")
+        ],
+        dependencies=[Dependency(source="router.go", target="gen/server.go", relationship="imports")],
+    )
+    console = Console(record=True, force_terminal=True, width=100)
+    render_exploration_summary(console, ctx)
+    out = console.export_text()
+    assert "OpenAPI First" in out
+    assert "1 convention" in out  # count line
+    assert "{" not in out  # no raw JSON
+
+
+def test_render_exploration_summary_empty_is_quiet():
+    from rich.console import Console
+
+    from daydream.exploration import ExplorationContext
+    from daydream.ui import render_exploration_summary  # type: ignore[attr-defined]
+
+    console = Console(record=True, force_terminal=True, width=100)
+    render_exploration_summary(console, ExplorationContext())
+    out = console.export_text()
+    assert "{" not in out and "[" not in out  # never dumps a structure; one dim line at most
+
+
 def test_prompt_user_returns_default_on_eof(monkeypatch):
     from unittest.mock import Mock
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -109,7 +109,7 @@ def test_render_exploration_summary_shows_content_not_json():
         dependencies=[Dependency(source="router.go", target="gen/server.go", relationship="imports")],
     )
     console = Console(record=True, force_terminal=True, width=100)
-    render_exploration_summary(console, ctx)
+    console.print(render_exploration_summary(ctx))
     out = console.export_text()
     assert "OpenAPI First" in out
     assert "1 convention" in out  # count line
@@ -123,7 +123,7 @@ def test_render_exploration_summary_empty_is_quiet():
     from daydream.ui import render_exploration_summary  # type: ignore[attr-defined]
 
     console = Console(record=True, force_terminal=True, width=100)
-    render_exploration_summary(console, ExplorationContext())
+    console.print(render_exploration_summary(ExplorationContext()))
     out = console.export_text()
     assert "{" not in out and "[" not in out  # never dumps a structure; one dim line at most
 


### PR DESCRIPTION
## Summary

Structured-output phases were echoing their raw JSON payload to the terminal — redundant with the parsed result and noisy. This stops the raw dump at the source and replaces each phase's JSON spew with a compact, themed summary (table or pill header).

## Changes

### Fixed
- `run_agent` no longer appends agent text to the terminal renderer when an `output_schema` is set — the structured-output JSON is the return value, not something to echo.

### Added
- `format_verdict_join()` (ui.py): renders the verdict-join summary as a table (Matched / Unmatched / Structural / Other + Total), self-computing the total and noting any mismatch with the caller's count.
- `render_exploration_summary()` (ui.py): replaces the raw pre-scan JSON with a counts pill plus capped lists of conventions, dependencies, affected files, and guidelines.
- Concise per-phase summaries: arbiter ("kept N, dropped M"), cross-stack merge ("Merged into N items"), and a feedback table for parsed issues.

### Changed
- Per-stack review failures are collected silently and summarized once after the task group, instead of one warning per failing stack.
- `phase_parse_feedback` pluralizes "issue/issues" correctly for count == 1.
- `render_exploration_summary` returns a renderable (caller does `console.print`) rather than printing directly, keeping render helpers decoupled from the console.

### Removed
- Duplicate `MockBackend` dataclass in `test_agent_structured_render` and `test_phases_render`; both now import the shared one from `test_agent_recorder_integration`.

## Motivation

Schema-constrained agent turns return their result as structured data, but the streamed assistant text (the same JSON) was still being rendered, dumping large JSON blobs into the terminal. The fix is at the root in `run_agent`; the per-phase summaries restore useful, readable signal in its place.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed

New/updated tests: `tests/test_agent_structured_render.py`, `tests/test_phases_render.py`, `tests/test_ui.py`, `tests/test_deep_orchestrator.py`.

```
make lint        # All checks passed
make typecheck   # Success: no issues found in 198 source files
uv run pytest tests/test_agent_structured_render.py tests/test_phases_render.py \
              tests/test_ui.py tests/test_deep_orchestrator.py -q   # 86 passed
```

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally
- [x] Linting passes