### PR TITLE
perf(agent): cap runaway run_agent turns with wall-clock and tool-call budgets

### DIFF
--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -28,7 +28,7 @@ from daydream.backends import (
     ToolResultEvent,
     ToolStartEvent,
 )
-from daydream.config import DEFAULT_WALL_BUDGET_S, UNKNOWN_SKILL_PATTERN
+from daydream.config import UNKNOWN_SKILL_PATTERN
 from daydream.trajectory import DaydreamPhase, get_current_recorder
 from daydream.ui import (
     AgentTextRenderer,
@@ -368,10 +368,8 @@ def is_environmental_failure(test_output: str) -> bool:
         "connection refused",
         "localhost:5432",
         ":6379",
-        "could not connect",
         "container is not running",
         "make db-up",
-        "is the server running",
         "econnrefused",
     ]
     return any(signature in output_lower for signature in infra_signatures)
@@ -389,9 +387,9 @@ async def run_agent(
     agents: dict[str, AgentDefinition] | None = None,
     max_turns: int | None = None,
     read_only: bool = False,
-    wall_budget_s: float | None = DEFAULT_WALL_BUDGET_S,
+    wall_budget_s: float | None = None,
     tool_call_budget: int | None = None,
-) -> tuple[str | Any, ContinuationToken | None]:
+) -> tuple[str | Any, ContinuationToken | None, str | None]:
     """Run agent with the given prompt and return output plus continuation token.
 
     Streams verbose output to stdout as it's received. When progress_callback
@@ -420,16 +418,20 @@ async def run_agent(
             at the tool layer (Claude PreToolUse guard hook; Codex
             ``--sandbox read-only``). Wired True only for the read-only
             failure-summarizer call; all other call sites keep the default.
-        wall_budget_s: Per-invocation wall-clock budget. When exceeded the loop
-            is cancelled, ``backend.cancel()`` is awaited, the ATIF turn is
-            marked aborted, and the partial output is returned — no exception
-            reaches the caller. ``None`` disables the wall budget.
+        wall_budget_s: Opt-in per-invocation wall-clock budget. When exceeded
+            the loop is cancelled, ``backend.cancel()`` is awaited, the ATIF
+            turn is marked aborted, and the partial output is returned — no
+            exception reaches the caller. ``None`` (the default) disables the
+            wall budget.
         tool_call_budget: Opt-in ceiling on ToolStartEvents in this turn. When
             exceeded the loop breaks with the same abort/partial-return path.
             ``None`` (the default) means no tool-call ceiling.
 
     Returns:
-        Tuple of (output, continuation_token). Output is text or structured data.
+        Tuple of (output, continuation_token, budget_reason). Output is text
+        or structured data. ``budget_reason`` is ``None`` on a normal
+        completion, or a string such as ``"wall_budget_exceeded"`` /
+        ``"tool_call_budget_exceeded"`` when the turn was cut short.
 
     Raises:
         MissingSkillError: If a required skill is not available.
@@ -440,6 +442,7 @@ async def run_agent(
     output_parts: list[str] = []
     structured_result: Any = None
     result_continuation: ContinuationToken | None = None
+    aborted_reason: str | None = None
     use_callback = progress_callback is not None
 
     _state.current_backends.append(backend)
@@ -605,6 +608,7 @@ async def run_agent(
             wall_cancelled = bool(getattr(wall_scope, "cancelled_caught", False))
             if budget_reason is None and wall_cancelled:
                 budget_reason = "wall_budget_exceeded"
+            aborted_reason = budget_reason  # propagate to function scope for caller visibility
             if budget_reason is not None:
                 try:
                     await event_iter.aclose()
@@ -635,14 +639,14 @@ async def run_agent(
         _state.current_backends.remove(backend)
 
     if output_schema is not None and structured_result is not None:
-        return structured_result, result_continuation
+        return structured_result, result_continuation, aborted_reason
     if output_schema is not None:
         raw = "".join(output_parts)
         # Fallback: JSON-parse the raw text when structured output failed.
         if raw.strip():
             try:
                 parsed = json.loads(raw)
-                return parsed, result_continuation
+                return parsed, result_continuation, aborted_reason
             except (json.JSONDecodeError, ValueError):
                 pass
-    return "".join(output_parts), result_continuation
+    return "".join(output_parts), result_continuation, aborted_reason

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -608,7 +608,7 @@ async def run_agent(
             wall_cancelled = bool(getattr(wall_scope, "cancelled_caught", False))
             if budget_reason is None and wall_cancelled:
                 budget_reason = "wall_budget_exceeded"
-            aborted_reason = budget_reason  # propagate to function scope for caller visibility
+            aborted_reason = budget_reason
             if budget_reason is not None:
                 try:
                     await event_iter.aclose()

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import anyio
+
 if TYPE_CHECKING:
     from claude_agent_sdk.types import AgentDefinition
     from rich.text import Text
@@ -26,7 +28,7 @@ from daydream.backends import (
     ToolResultEvent,
     ToolStartEvent,
 )
-from daydream.config import UNKNOWN_SKILL_PATTERN
+from daydream.config import DEFAULT_WALL_BUDGET_S, UNKNOWN_SKILL_PATTERN
 from daydream.trajectory import DaydreamPhase, get_current_recorder
 from daydream.ui import (
     AgentTextRenderer,
@@ -37,6 +39,7 @@ from daydream.ui import (
     print_cost,
     print_error,
     print_thinking,
+    print_warning,
     prompt_user,
 )
 
@@ -341,6 +344,39 @@ def detect_test_success(output: str) -> bool:
     return False
 
 
+def is_environmental_failure(test_output: str) -> bool:
+    """Detect whether a test failure stems from missing infrastructure, not the code.
+
+    Conservative, case-insensitive match on infra signatures (database/cache not
+    reachable). Used to short-circuit the heal loop: re-running an agent fix turn
+    cannot bring up a Postgres/Redis container, so an environmental failure must
+    abort rather than burn turns on a non-code problem.
+
+    Args:
+        test_output: Test/agent output to inspect.
+
+    Returns:
+        True if the output carries an infrastructure-unavailable signature.
+
+    """
+    if not test_output:
+        return False
+
+    output_lower = test_output.lower()
+
+    infra_signatures = [
+        "connection refused",
+        "localhost:5432",
+        ":6379",
+        "could not connect",
+        "container is not running",
+        "make db-up",
+        "is the server running",
+        "econnrefused",
+    ]
+    return any(signature in output_lower for signature in infra_signatures)
+
+
 async def run_agent(
     backend: Backend,
     cwd: Path,
@@ -353,6 +389,8 @@ async def run_agent(
     agents: dict[str, AgentDefinition] | None = None,
     max_turns: int | None = None,
     read_only: bool = False,
+    wall_budget_s: float | None = DEFAULT_WALL_BUDGET_S,
+    tool_call_budget: int | None = None,
 ) -> tuple[str | Any, ContinuationToken | None]:
     """Run agent with the given prompt and return output plus continuation token.
 
@@ -382,6 +420,13 @@ async def run_agent(
             at the tool layer (Claude PreToolUse guard hook; Codex
             ``--sandbox read-only``). Wired True only for the read-only
             failure-summarizer call; all other call sites keep the default.
+        wall_budget_s: Per-invocation wall-clock budget. When exceeded the loop
+            is cancelled, ``backend.cancel()`` is awaited, the ATIF turn is
+            marked aborted, and the partial output is returned — no exception
+            reaches the caller. ``None`` disables the wall budget.
+        tool_call_budget: Opt-in ceiling on ToolStartEvents in this turn. When
+            exceeded the loop breaks with the same abort/partial-return path.
+            ``None`` (the default) means no tool-call ceiling.
 
     Returns:
         Tuple of (output, continuation_token). Output is text or structured data.
@@ -426,110 +471,150 @@ async def run_agent(
             if inv is not None:
                 inv.observe_user_step(prompt=prompt)
 
-            async for event in event_iter:
-                if isinstance(event, TextEvent):
-                    output_parts.append(event.text)
+            # Per-invocation budgets live here so both backends are covered
+            # without a backend-signature change. The wall budget cancels the
+            # async-for via move_on_after; the tool-call ceiling breaks in-loop.
+            tool_calls = 0
+            budget_reason: str | None = None
+            wall_scope: Any = (
+                anyio.move_on_after(wall_budget_s) if wall_budget_s is not None else nullcontext()
+            )
 
-                    skill_match = re.search(UNKNOWN_SKILL_PATTERN, event.text)
-                    if skill_match:
-                        if not use_callback:
-                            agent_renderer.finish()
-                            tool_registry.finish_all()
-                        raise MissingSkillError(skill_match.group(1))
+            with wall_scope:
+                async for event in event_iter:
+                    if isinstance(event, TextEvent):
+                        output_parts.append(event.text)
 
-                    if use_callback and progress_callback is not None:
-                        last_line = event.text.strip().split("\n")[-1]
-                        if last_line:
-                            result = progress_callback(format_callback_text(last_line))
-                            if inspect.isawaitable(result):
-                                await result
-                    elif output_schema is None:
-                        # Structured-output text is the JSON payload, redundant with
-                        # the returned structured result — don't echo it to the terminal.
-                        agent_renderer.append(event.text)
+                        skill_match = re.search(UNKNOWN_SKILL_PATTERN, event.text)
+                        if skill_match:
+                            if not use_callback:
+                                agent_renderer.finish()
+                                tool_registry.finish_all()
+                            raise MissingSkillError(skill_match.group(1))
 
-                    if inv is not None:
-                        inv.observe(event)
+                        if use_callback and progress_callback is not None:
+                            last_line = event.text.strip().split("\n")[-1]
+                            if last_line:
+                                result = progress_callback(format_callback_text(last_line))
+                                if inspect.isawaitable(result):
+                                    await result
+                        elif output_schema is None:
+                            # Structured-output text is the JSON payload, redundant with
+                            # the returned structured result — don't echo it to the terminal.
+                            agent_renderer.append(event.text)
 
-                elif isinstance(event, ThinkingEvent):
-                    if not use_callback:
-                        if agent_renderer.has_content:
-                            agent_renderer.finish()
-                        print_thinking(console, event.text)
+                        if inv is not None:
+                            inv.observe(event)
 
-                    if inv is not None:
-                        inv.observe(event)
-
-                elif isinstance(event, ToolStartEvent):
-                    if progress_callback is not None:
-                        # Record the originating call so a backgrounded launch's result
-                        # can later resolve a Task-family label for the progress line.
-                        tool_registry.note_call(event.id, event.name, event.input)
-                        label = tool_registry.resolve_call_label(event.name, event.input)
-                        result = progress_callback(format_callback_progress(event.name, event.input, label))
-                        if inspect.isawaitable(result):
-                            await result
-                    else:
-                        if agent_renderer.has_content:
-                            agent_renderer.finish()
-                        tool_registry.create(event.id, event.name, event.input)
-
-                    if inv is not None:
-                        inv.observe(event)
-
-                elif isinstance(event, ToolResultEvent):
-                    # Populate the task_id→label map in both modes, so a later
-                    # TaskOutput/TaskStop resolves its originating label.
-                    tool_registry.observe_result(event.id, event.output)
-                    if not use_callback:
-                        panel = tool_registry.get(event.id)
-                        if panel:
-                            panel.set_result(event.output, event.is_error)
-                            panel.finish()
-                            tool_registry.remove(event.id)
-
-                    if inv is not None:
-                        inv.observe(event)
-
-                elif isinstance(event, MetricsEvent):
-                    # EVNT-02 / MAP-06: recorder-only, no UI. Must precede the
-                    # CostEvent branch so isinstance order is correct.
-                    if inv is not None:
-                        inv.observe(event)
-
-                elif isinstance(event, CostEvent):
-                    if event.cost_usd:
+                    elif isinstance(event, ThinkingEvent):
                         if not use_callback:
                             if agent_renderer.has_content:
                                 agent_renderer.finish()
-                            console.print()
-                            print_cost(console, event.cost_usd)
+                            print_thinking(console, event.text)
 
-                    if inv is not None:
-                        inv.observe(event)
+                        if inv is not None:
+                            inv.observe(event)
 
-                elif isinstance(event, ResultEvent):
-                    if event.structured_output is not None:
-                        structured_result = event.structured_output
+                    elif isinstance(event, ToolStartEvent):
+                        if progress_callback is not None:
+                            # Record the originating call so a backgrounded launch's result
+                            # can later resolve a Task-family label for the progress line.
+                            tool_registry.note_call(event.id, event.name, event.input)
+                            label = tool_registry.resolve_call_label(event.name, event.input)
+                            result = progress_callback(format_callback_progress(event.name, event.input, label))
+                            if inspect.isawaitable(result):
+                                await result
+                        else:
+                            if agent_renderer.has_content:
+                                agent_renderer.finish()
+                            tool_registry.create(event.id, event.name, event.input)
+
+                        if inv is not None:
+                            inv.observe(event)
+
+                        tool_calls += 1
+                        if tool_call_budget is not None and tool_calls > tool_call_budget:
+                            budget_reason = "tool_call_budget_exceeded"
+                            break
+
+                    elif isinstance(event, ToolResultEvent):
+                        # Populate the task_id→label map in both modes, so a later
+                        # TaskOutput/TaskStop resolves its originating label.
+                        tool_registry.observe_result(event.id, event.output)
                         if not use_callback:
-                            issues = structured_result.get("issues", []) if isinstance(structured_result, dict) else []
-                            if issues:
-                                formatted = []
-                                for i in issues:
-                                    if "file" in i and "line" in i:
-                                        desc = i.get("description", "")
-                                        issue_id = i.get("id", "?")
-                                        formatted.append(
-                                            f"[{issue_id}] {i['file']}:{i['line']} - {desc}"
-                                        )
-                                    else:
-                                        label = i.get("title", i.get("description", ""))
-                                        formatted.append(f"[{i.get('id', '?')}] {label}")
-                                agent_renderer.append("\n".join(formatted))
-                    result_continuation = event.continuation
+                            panel = tool_registry.get(event.id)
+                            if panel:
+                                panel.set_result(event.output, event.is_error)
+                                panel.finish()
+                                tool_registry.remove(event.id)
 
-                    if inv is not None:
-                        inv.observe(event)
+                        if inv is not None:
+                            inv.observe(event)
+
+                    elif isinstance(event, MetricsEvent):
+                        # EVNT-02 / MAP-06: recorder-only, no UI. Must precede the
+                        # CostEvent branch so isinstance order is correct.
+                        if inv is not None:
+                            inv.observe(event)
+
+                    elif isinstance(event, CostEvent):
+                        if event.cost_usd:
+                            if not use_callback:
+                                if agent_renderer.has_content:
+                                    agent_renderer.finish()
+                                console.print()
+                                print_cost(console, event.cost_usd)
+
+                        if inv is not None:
+                            inv.observe(event)
+
+                    elif isinstance(event, ResultEvent):
+                        if event.structured_output is not None:
+                            structured_result = event.structured_output
+                            if not use_callback:
+                                issues = (
+                                    structured_result.get("issues", [])
+                                    if isinstance(structured_result, dict)
+                                    else []
+                                )
+                                if issues:
+                                    formatted = []
+                                    for i in issues:
+                                        if "file" in i and "line" in i:
+                                            desc = i.get("description", "")
+                                            issue_id = i.get("id", "?")
+                                            formatted.append(
+                                                f"[{issue_id}] {i['file']}:{i['line']} - {desc}"
+                                            )
+                                        else:
+                                            label = i.get("title", i.get("description", ""))
+                                            formatted.append(f"[{i.get('id', '?')}] {label}")
+                                    agent_renderer.append("\n".join(formatted))
+                        result_continuation = event.continuation
+
+                        if inv is not None:
+                            inv.observe(event)
+
+            # Budget abort: the wall scope cancelled the loop, or the tool-call
+            # ceiling broke out. Cancel the backend (swallow any error — an abort
+            # must NEVER raise into the CLI), mark the ATIF turn aborted, surface
+            # a marker, then fall through to the partial-output return.
+            wall_cancelled = bool(getattr(wall_scope, "cancelled_caught", False))
+            if budget_reason is None and wall_cancelled:
+                budget_reason = "wall_budget_exceeded"
+            if budget_reason is not None:
+                try:
+                    await backend.cancel()
+                except Exception:  # noqa: BLE001 - abort must not raise into the CLI
+                    pass
+                if inv is not None:
+                    inv.mark_aborted(budget_reason)
+                if use_callback and progress_callback is not None:
+                    result = progress_callback(format_callback_text(f"[budget] aborted: {budget_reason}"))
+                    if inspect.isawaitable(result):
+                        await result
+                elif not use_callback:
+                    print_warning(console, f"Turn aborted: {budget_reason}")
 
             if not use_callback:
                 if agent_renderer.has_content:

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import inspect
 import json
 import re
-from collections.abc import Callable
+from collections.abc import AsyncGenerator, Callable
 from contextlib import nullcontext
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import anyio
 
@@ -451,9 +451,12 @@ async def run_agent(
             agent_renderer = AgentTextRenderer(console)
 
         try:
-            event_iter = backend.execute(
-                cwd, prompt, output_schema, continuation,
-                agents=agents, max_turns=max_turns, read_only=read_only,
+            event_iter = cast(
+                AsyncGenerator[Any, None],
+                backend.execute(
+                    cwd, prompt, output_schema, continuation,
+                    agents=agents, max_turns=max_turns, read_only=read_only,
+                ),
             )
         except Exception as exc:
             print_error(console, "Backend Init Error", f"{type(exc).__name__}: {exc}")
@@ -603,6 +606,10 @@ async def run_agent(
             if budget_reason is None and wall_cancelled:
                 budget_reason = "wall_budget_exceeded"
             if budget_reason is not None:
+                try:
+                    await event_iter.aclose()
+                except Exception:  # noqa: BLE001 - abort must not raise into the CLI
+                    pass
                 try:
                     await backend.cancel()
                 except Exception:  # noqa: BLE001 - abort must not raise into the CLI

--- a/daydream/backends/claude.py
+++ b/daydream/backends/claude.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import re
 import shlex
 from collections.abc import AsyncIterator
 from pathlib import Path
@@ -12,6 +13,7 @@ from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient, HookJSONOutput
 from claude_agent_sdk.types import (
     AgentDefinition,
     AssistantMessage,
+    HookCallback,
     ResultMessage,
     TextBlock,
     ThinkingBlock,
@@ -57,6 +59,15 @@ _DANGEROUS_TOKENS: frozenset[str] = frozenset({"|", ";", "&", "`", "$"})
 # ``.*`` fires the guard for EVERY tool call so it can fail-closed (allow only
 # the safe set); a deny-list of mutating tools was fail-open.
 _READ_ONLY_HOOK_MATCHER = ".*"
+
+# Catastrophic Bash commands denied in ALL phases (always-on guard, #177). These
+# are the runaway-turn pathologies: full-filesystem-root scans that take hours,
+# plus an unrecoverable wipe. Matched on the raw command via regex.
+_DANGEROUS_COMMAND_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"^\s*find\s+/(\s|$)"),       # find / ...  (root-anchored scan)
+    re.compile(r"^\s*grep\b.*\s/(\s|$)"),    # grep ... /  (root-anchored recursive)
+    re.compile(r"^\s*rm\s+-rf?\s+/(\s|$)"),  # rm -rf /    (catastrophic wipe)
+)
 
 # Tools unconditionally permitted under the read-only profile (Bash handled
 # separately via the command allowlist).
@@ -148,6 +159,36 @@ async def _read_only_guard(input_data: Any, tool_use_id: Any, context: Any) -> H
     )
 
 
+def _is_dangerous_command(cmd: str) -> bool:
+    """Return True if *cmd* is a catastrophic Bash command (always-on deny-list).
+
+    Matches full-filesystem-root scans (``find /``, ``grep ... /``) and ``rm -rf /``
+    — the runaway-turn pathologies. Conservative: a scoped path (``find core/...``)
+    or a non-matching command (``ls``, ``rg foo src/``) returns False.
+    """
+    return any(pattern.search(cmd) for pattern in _DANGEROUS_COMMAND_PATTERNS)
+
+
+async def _dangerous_command_guard(input_data: Any, tool_use_id: Any, context: Any) -> HookJSONOutput:
+    """PreToolUse hook denying catastrophic Bash commands in ALL phases (#177).
+
+    Registered unconditionally. Allows everything except a small deny-list of
+    root-anchored scans and wipes (see ``_is_dangerous_command``). Codex has no
+    equivalent PreToolUse seam (out of scope; its enforcement is ``--sandbox``).
+    """
+    tool_name = input_data.get("tool_name") if isinstance(input_data, dict) else None
+    if tool_name != "Bash":
+        return {}
+    tool_input = input_data.get("tool_input") if isinstance(input_data, dict) else None
+    command = ""
+    if isinstance(tool_input, dict):
+        raw = tool_input.get("command")
+        command = raw if isinstance(raw, str) else ""
+    if _is_dangerous_command(command):
+        return _read_only_deny(f"dangerous command blocked (always-on guard): {command!r}")
+    return {}
+
+
 class ClaudeBackend:
     """Backend that wraps the Claude Agent SDK.
 
@@ -198,8 +239,13 @@ class ClaudeBackend:
             else None
         )
 
-        # Read-only profile: the PreToolUse hook — NOT allowed_tools — is the
-        # enforcement, since bypassPermissions leaves the tool list unrestricted.
+        # PreToolUse hooks — NOT allowed_tools — are the enforcement, since
+        # bypassPermissions leaves the tool list unrestricted. The dangerous-command
+        # guard is always-on (all phases, #177); the read-only guard composes on top
+        # when read_only=True.
+        pre_tool_use_hooks: list[HookCallback] = [_dangerous_command_guard]
+        if read_only:
+            pre_tool_use_hooks.append(_read_only_guard)
         options = ClaudeAgentOptions(
             cwd=str(cwd),
             permission_mode="bypassPermissions",
@@ -209,11 +255,9 @@ class ClaudeBackend:
             output_format=output_format,
             max_buffer_size=10 * 1024 * 1024,  # 10MB — handles large git diffs
             max_turns=max_turns,
-            hooks=(
-                {"PreToolUse": [HookMatcher(matcher=_READ_ONLY_HOOK_MATCHER, hooks=[_read_only_guard])]}
-                if read_only
-                else None
-            ),
+            hooks={
+                "PreToolUse": [HookMatcher(matcher=_READ_ONLY_HOOK_MATCHER, hooks=pre_tool_use_hooks)]
+            },
         )
 
         if agents:

--- a/daydream/backends/claude.py
+++ b/daydream/backends/claude.py
@@ -66,10 +66,13 @@ _READ_ONLY_HOOK_MATCHER = ".*"
 _DANGEROUS_COMMAND_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"^\s*find\s+/(\s|$)"),       # find / ...  (root-anchored scan)
     re.compile(r"^\s*grep\b.*\s/\s*$"),      # grep ... /  (root is the sole trailing path)
-    # rm wiping filesystem root or its glob, with a recursive flag in any order
-    # (-rf, -fr, -R, --recursive). A subpath like ``/home`` is left alone — this
-    # is a runaway/wipe backstop, not a security boundary (the read-only sandbox is).
-    re.compile(r"^\s*rm\s+(?:-\w*[rR]\w*|--recursive)\b.*?\s/\*?(?:\s|$)"),
+    # rm wiping filesystem root or its glob, with a recursive flag anywhere in
+    # the option list (-rf, -fr, -R, --recursive) regardless of token order, so
+    # ``rm --force --recursive /`` and ``rm -f -r /`` are caught too. Two
+    # lookaheads: one for a recursive flag, one for ``/`` (or ``/*``) as a
+    # standalone target. A subpath like ``/home`` is left alone — this is a
+    # runaway/wipe backstop, not a security boundary (the read-only sandbox is).
+    re.compile(r"^\s*rm\b(?=.*(?:^|\s)(?:-\w*[rR]\w*|--recursive)\b)(?=.*(?:^|\s)/\*?(?:\s|$)).*$"),
 )
 
 # Tools unconditionally permitted under the read-only profile (Bash handled

--- a/daydream/backends/claude.py
+++ b/daydream/backends/claude.py
@@ -65,8 +65,11 @@ _READ_ONLY_HOOK_MATCHER = ".*"
 # plus an unrecoverable wipe. Matched on the raw command via regex.
 _DANGEROUS_COMMAND_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"^\s*find\s+/(\s|$)"),       # find / ...  (root-anchored scan)
-    re.compile(r"^\s*grep\b.*\s/(\s|$)"),    # grep ... /  (root-anchored recursive)
-    re.compile(r"^\s*rm\s+-rf?\s+/(\s|$)"),  # rm -rf /    (catastrophic wipe)
+    re.compile(r"^\s*grep\b.*\s/\s*$"),      # grep ... /  (root is the sole trailing path)
+    # rm wiping filesystem root or its glob, with a recursive flag in any order
+    # (-rf, -fr, -R, --recursive). A subpath like ``/home`` is left alone — this
+    # is a runaway/wipe backstop, not a security boundary (the read-only sandbox is).
+    re.compile(r"^\s*rm\s+(?:-\w*[rR]\w*|--recursive)\b.*?\s/\*?(?:\s|$)"),
 )
 
 # Tools unconditionally permitted under the read-only profile (Bash handled

--- a/daydream/config.py
+++ b/daydream/config.py
@@ -32,6 +32,10 @@ DEFAULT_CLAUDE_MODEL = "claude-opus-4-8"
 DEFAULT_CODEX_MODEL = "gpt-5.3-codex"
 DEFAULT_EXPLORATION_MODEL = "claude-sonnet-4-6"
 
+# Caps the 1.5–5h time tail from a single unbounded run_agent turn (issue #169).
+DEFAULT_WALL_BUDGET_S = 1800.0
+DEFAULT_TOOL_CALL_BUDGET = 50
+
 # Per-backend per-phase default model table. The phase resolver in
 # ``daydream.runner._resolve_backend`` looks up
 # ``PHASE_DEFAULT_MODELS[backend_name][phase_name]`` when no explicit per-phase

--- a/daydream/exploration_runner.py
+++ b/daydream/exploration_runner.py
@@ -246,7 +246,7 @@ async def pre_scan(
     async def _run_specialist(name: str, prompt: str, schema: dict) -> None:
         async with maybe_fork(recorder, f"explore-{name}"):
             try:
-                structured, _ = await run_agent(
+                structured, _, _ = await run_agent(
                     backend, repo_root, prompt, output_schema=schema, max_turns=specialist_max_turns,
                     phase=DaydreamPhase.EXPLORATION,
                 )

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -1364,7 +1364,7 @@ def gh_pr_view(repo: Path, pr: int | None = None) -> dict | None:
     try:
         proc = _run_gh(repo, args, retries=_gh_retries())
     except GitError as exc:
-        _logger.warning("gh pr view failed (returning None): %s", exc)
+        _logger.warning("gh pr view failed (%s, returning None): %s", type(exc).__name__, exc)
         return None
     if proc.returncode != 0:
         return None

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -37,7 +37,7 @@ from daydream.workspace import WorkContext
 
 if TYPE_CHECKING:
     from daydream.deep.detection import StackAssignment
-from daydream.config import DEFAULT_TOOL_CALL_BUDGET, REVIEW_OUTPUT_FILE
+from daydream.config import DEFAULT_TOOL_CALL_BUDGET, DEFAULT_WALL_BUDGET_S, REVIEW_OUTPUT_FILE
 from daydream.ui import (
     phase_subtitle,
     print_dim,
@@ -1657,6 +1657,7 @@ async def phase_verify_recommendations(
         output_schema=RECOMMENDATION_VERDICTS_SCHEMA,
         max_turns=25,
         tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
+        wall_budget_s=DEFAULT_WALL_BUDGET_S,
         phase=DaydreamPhase.VERIFY,
     )
 
@@ -1797,6 +1798,7 @@ here.
             backend, work.repo, prompt,
             phase=DaydreamPhase.FIX, max_turns=FIX_MAX_TURNS,
             tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
+            wall_budget_s=DEFAULT_WALL_BUDGET_S,
             progress_callback=_cb,
         )
     else:
@@ -1804,6 +1806,7 @@ here.
             backend, work.repo, prompt,
             phase=DaydreamPhase.FIX, max_turns=FIX_MAX_TURNS,
             tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
+            wall_budget_s=DEFAULT_WALL_BUDGET_S,
         )
     async with (console_lock if console_lock is not None else anyio.Lock()):
         print_fix_complete(console, item_num, total)
@@ -2062,6 +2065,7 @@ async def phase_test_and_heal(
             _, _, _ = await run_agent(
                 backend, work.repo, fix_prompt, phase=DaydreamPhase.FIX, max_turns=FIX_MAX_TURNS,
                 tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
+                wall_budget_s=DEFAULT_WALL_BUDGET_S,
             )
             retries_used += 1
             continuation = None
@@ -2116,6 +2120,7 @@ async def phase_test_and_heal(
             _, _, _ = await run_agent(
                 backend, work.repo, fix_prompt, phase=DaydreamPhase.FIX, max_turns=FIX_MAX_TURNS,
                 tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
+                wall_budget_s=DEFAULT_WALL_BUDGET_S,
             )
             retries_used += 1
             continuation = None
@@ -2427,6 +2432,7 @@ async def phase_understand_intent(
         output, _, _ = await run_agent(
             backend, work.repo, prompt, phase=DaydreamPhase.INTENT,
             tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
+            wall_budget_s=DEFAULT_WALL_BUDGET_S,
         )
         intent_text = output if isinstance(output, str) else str(output)
 

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -18,6 +18,7 @@ from daydream.agent import (
     get_assume,
     get_non_interactive,
     get_quiet_mode,
+    is_environmental_failure,
     resolve_gate,
     resolve_or_prompt,
     run_agent,
@@ -36,7 +37,7 @@ from daydream.workspace import WorkContext
 
 if TYPE_CHECKING:
     from daydream.deep.detection import StackAssignment
-from daydream.config import REVIEW_OUTPUT_FILE
+from daydream.config import DEFAULT_TOOL_CALL_BUDGET, REVIEW_OUTPUT_FILE
 from daydream.ui import (
     phase_subtitle,
     print_dim,
@@ -1651,6 +1652,7 @@ async def phase_verify_recommendations(
         prompt,
         output_schema=RECOMMENDATION_VERDICTS_SCHEMA,
         max_turns=25,
+        tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
         phase=DaydreamPhase.VERIFY,
     )
 
@@ -1789,10 +1791,15 @@ findings with extra skepticism here.
         await run_agent(
             backend, work.repo, prompt,
             phase=DaydreamPhase.FIX, max_turns=FIX_MAX_TURNS,
+            tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
             progress_callback=_cb,
         )
     else:
-        await run_agent(backend, work.repo, prompt, phase=DaydreamPhase.FIX, max_turns=FIX_MAX_TURNS)
+        await run_agent(
+            backend, work.repo, prompt,
+            phase=DaydreamPhase.FIX, max_turns=FIX_MAX_TURNS,
+            tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
+        )
     async with (console_lock if console_lock is not None else anyio.Lock()):
         print_fix_complete(console, item_num, total)
 
@@ -2013,6 +2020,16 @@ async def phase_test_and_heal(
 
         print_warning(console, "Tests may have failed or result is unclear.")
 
+        # An infrastructure failure (DB/cache unreachable) cannot be healed by an
+        # agent fix turn, so abort before the heal gate instead of burning a retry.
+        if is_environmental_failure(output):
+            print_warning(
+                console,
+                "Test failure looks environmental (infrastructure unavailable); "
+                "skipping heal loop.",
+            )
+            return False, retries_used
+
         # Test-heal retry gate across the two interaction axes. With no human at
         # the keyboard, the menu's default "2" (fix-and-retry) would launch an
         # unbounded, mutating fix loop with nothing to stop it -- so the
@@ -2039,6 +2056,7 @@ async def phase_test_and_heal(
             fix_prompt = _build_fix_prompt(output, feedback_items, repo=work.repo)
             _, _ = await run_agent(
                 backend, work.repo, fix_prompt, phase=DaydreamPhase.FIX, max_turns=FIX_MAX_TURNS,
+                tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
             )
             retries_used += 1
             continuation = None
@@ -2092,6 +2110,7 @@ async def phase_test_and_heal(
             fix_prompt = _build_fix_prompt(output, feedback_items, repo=work.repo)
             _, _ = await run_agent(
                 backend, work.repo, fix_prompt, phase=DaydreamPhase.FIX, max_turns=FIX_MAX_TURNS,
+                tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
             )
             retries_used += 1
             continuation = None
@@ -2400,7 +2419,10 @@ async def phase_understand_intent(
         console.print()
         print_info(console, "Agent is analyzing the changes...")
 
-        output, _ = await run_agent(backend, work.repo, prompt, phase=DaydreamPhase.INTENT)
+        output, _ = await run_agent(
+            backend, work.repo, prompt, phase=DaydreamPhase.INTENT,
+            tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
+        )
         intent_text = output if isinstance(output, str) else str(output)
 
         console.print()

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -215,7 +215,7 @@ async def _run_setup_investigator(
 
     async def _invoke() -> dict[str, Any] | None:
         try:
-            result, _ = await run_agent(
+            result, _, _ = await run_agent(
                 backend,
                 work.repo,
                 prompt,
@@ -656,7 +656,7 @@ async def _run_failure_summarizer(
 
     async def _invoke() -> str | None:
         try:
-            result, _ = await run_agent(
+            result, _, _ = await run_agent(
                 backend,
                 work.repo,
                 prompt,
@@ -1193,6 +1193,10 @@ def build_intent_prompt(
         body_text = pr_description.strip()
         if len(body_text) > _PR_BODY_MAX_CHARS:
             body_text = body_text[:_PR_BODY_MAX_CHARS] + "\n[PR description truncated]"
+        # Neutralize the delimiter so a body containing it can't break containment.
+        safe_body = body_text.replace("<pr_description>", "&lt;pr_description>").replace(
+            "</pr_description>", "&lt;/pr_description>"
+        )
         parts.append(
             "The author supplied the following pull-request description. Treat this "
             "author-stated intent as AUTHORITATIVE: where the description and the "
@@ -1204,7 +1208,7 @@ def build_intent_prompt(
             "'complete'.\n\n"
             "Pull request description:\n"
             "<pr_description>\n"
-            f"{body_text.replace('</pr_description>', '<\\/pr_description>')}\n"
+            f"{safe_body}\n"
             "</pr_description>\n"
         )
     body = (
@@ -1540,7 +1544,7 @@ For each issue found, return a JSON object with this structure:
 If there are no actionable issues, return: {{"issues": []}}
 """
 
-    result, _ = await run_agent(backend, work.repo, prompt, output_schema=schema, phase=DaydreamPhase.PARSE)
+    result, _, _ = await run_agent(backend, work.repo, prompt, output_schema=schema, phase=DaydreamPhase.PARSE)
 
     if not isinstance(result, dict) or "issues" not in result:
         # When structured output and JSON fallback both fail (e.g. empty
@@ -1646,7 +1650,7 @@ async def phase_verify_recommendations(
         output_path=output_path,
     )
 
-    result, _ = await run_agent(
+    result, _, _ = await run_agent(
         backend,
         work.repo,
         prompt,
@@ -1730,10 +1734,11 @@ justify each out-of-scope edit in your commit message rather than expanding
 silently. If the change balloons far beyond the named site, stop and report.
 
 If this finding conflicts with an explicit in-code contract — a JSON schema, a
-type signature, or a comment documenting intent — the contract wins. Do not
-override documented intent to satisfy the finding; note the conflict in your
-commit message (or report inability to fix). Treat low/medium-confidence
-findings with extra skepticism here.
+type signature, or a comment documenting intent — the contract wins (unless
+confirmed author intent below overrides it). Do not override documented intent
+to satisfy the finding; note the conflict in your commit message (or report
+inability to fix). Treat low/medium-confidence findings with extra skepticism
+here.
 """
 
     # Best-effort: inject the confirmed author intent so the fixer won't undo a
@@ -2008,7 +2013,7 @@ async def phase_test_and_heal(
         # may re-assign test_command_override (choice "1" → setup investigator).
         test_command_override = None
 
-        output, continuation = await run_agent(
+        output, continuation, _ = await run_agent(
             backend, work.repo, prompt, continuation=continuation, phase=DaydreamPhase.TEST,
         )
 
@@ -2054,7 +2059,7 @@ async def phase_test_and_heal(
             console.print()
             print_info(console, "Launching agent to fix test failures (auto)...")
             fix_prompt = _build_fix_prompt(output, feedback_items, repo=work.repo)
-            _, _ = await run_agent(
+            _, _, _ = await run_agent(
                 backend, work.repo, fix_prompt, phase=DaydreamPhase.FIX, max_turns=FIX_MAX_TURNS,
                 tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
             )
@@ -2108,7 +2113,7 @@ async def phase_test_and_heal(
             console.print()
             print_info(console, "Launching agent to fix test failures...")
             fix_prompt = _build_fix_prompt(output, feedback_items, repo=work.repo)
-            _, _ = await run_agent(
+            _, _, _ = await run_agent(
                 backend, work.repo, fix_prompt, phase=DaydreamPhase.FIX, max_turns=FIX_MAX_TURNS,
                 tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
             )
@@ -2419,7 +2424,7 @@ async def phase_understand_intent(
         console.print()
         print_info(console, "Agent is analyzing the changes...")
 
-        output, _ = await run_agent(
+        output, _, _ = await run_agent(
             backend, work.repo, prompt, phase=DaydreamPhase.INTENT,
             tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
         )
@@ -2506,7 +2511,7 @@ async def phase_alternative_review(
     console.print()
     print_info(console, "Agent is evaluating the implementation...")
 
-    result, _ = await run_agent(
+    result, _, _ = await run_agent(
         backend, work.repo, prompt, output_schema=ALTERNATIVE_REVIEW_SCHEMA, phase=DaydreamPhase.ALTERNATIVES,
     )
 
@@ -2652,7 +2657,7 @@ async def phase_generate_plan(
     console.print()
     print_info(console, f"Generating plan for {len(selected_issues)} issue(s)...")
 
-    result, _ = await run_agent(backend, work.repo, prompt, output_schema=PLAN_SCHEMA, phase=DaydreamPhase.PLAN)
+    result, _, _ = await run_agent(backend, work.repo, prompt, output_schema=PLAN_SCHEMA, phase=DaydreamPhase.PLAN)
 
     if not isinstance(result, dict):
         if not get_quiet_mode():
@@ -2888,7 +2893,7 @@ async def phase_arbiter_review(
         alternatives_path=alternatives_path,
         exploration_dir=exploration_dir,
     )
-    result, _ = await run_agent(backend, work.repo, prompt, output_schema=ARBITER_SCHEMA, phase=DaydreamPhase.DEEP)
+    result, _, _ = await run_agent(backend, work.repo, prompt, output_schema=ARBITER_SCHEMA, phase=DaydreamPhase.DEEP)
 
     if not isinstance(result, dict) or not isinstance(result.get("findings"), list):
         raise ValueError(f"Arbiter returned no findings list (got {type(result).__name__})")
@@ -2985,7 +2990,7 @@ async def phase_cross_stack_merge(
     )
     print_phase_hero(console, "MERGE", phase_subtitle("MERGE"))
     print_dim(console, f"Model: {backend.model}")
-    result, _ = await run_agent(
+    result, _, _ = await run_agent(
         backend, work.repo, prompt, output_schema=MERGED_ITEMS_SCHEMA, phase=DaydreamPhase.DEEP
     )
 

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -423,6 +423,7 @@ class Invocation:
     steps: list[Step] = field(default_factory=list)
     _open_step_dict: dict[str, Any] | None = None
     _in_flight_tools: dict[str, dict[str, Any]] = field(default_factory=dict)
+    _stop_reason: str | None = None
 
     def observe_user_step(self, prompt: str) -> None:
         """Append a user Step at invocation start (MAP-01, Pitfall 4).
@@ -447,6 +448,16 @@ class Invocation:
             self.steps.append(self.recorder.redactor.redact_step(user_step))
         except Exception as exc:  # noqa: BLE001 - recording must never crash a run (Architecture Q7)
             print_warning(_console, f"Trajectory recording: {type(exc).__name__}: {exc}")
+
+    def mark_aborted(self, reason: str) -> None:
+        """Record that this invocation was aborted (e.g. budget exceeded).
+
+        The reason is stamped onto the closing Step's ``extra["stop_reason"]``
+        when the open step is finalized (mirrors the ``extra["partial_step"]``
+        mechanism). ATIF's Step model has no dedicated status field, so the
+        ``extra`` dict is the established extension point.
+        """
+        self._stop_reason = reason
 
     def observe(self, event: "AgentEvent") -> None:
         """Dispatch an AgentEvent into the active Step buffer.
@@ -629,6 +640,8 @@ class Invocation:
         }
         if d["_unmatched_tool_results"]:
             extra["unmatched_tool_results"] = list(d["_unmatched_tool_results"])
+        if self._stop_reason is not None:
+            extra["stop_reason"] = self._stop_reason
 
         agent_step = Step(
             step_id=self.recorder._next_step_id(),

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -456,8 +456,13 @@ class Invocation:
         when the open step is finalized (mirrors the ``extra["partial_step"]``
         mechanism). ATIF's Step model has no dedicated status field, so the
         ``extra`` dict is the established extension point.
+
+        If the budget fires before any event is received, no step is open yet,
+        so we open one here to ensure ``_close_open_step`` (called from
+        ``finish()``) has a Step to stamp the reason onto.
         """
         self._stop_reason = reason
+        self._ensure_open_step()
 
     def observe(self, event: "AgentEvent") -> None:
         """Dispatch an AgentEvent into the active Step buffer.

--- a/tests/harness/test_phase_replay.py
+++ b/tests/harness/test_phase_replay.py
@@ -58,7 +58,7 @@ async def test_side_effect_serves_per_phase(tmp_path, recorder):
             await run_agent(
                 CodexBackend("m"), tmp_path, "go", phase=DaydreamPhase.REVIEW
             )
-            par, _ = await run_agent(
+            par, _, _ = await run_agent(
                 CodexBackend("m"),
                 tmp_path,
                 "go",

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2,6 +2,7 @@
 
 from daydream.agent import (
     get_non_interactive,
+    is_environmental_failure,
     reset_state,
     set_non_interactive,
 )
@@ -24,3 +25,22 @@ def test_reset_state_clears_non_interactive():
     set_non_interactive(True)
     reset_state()
     assert get_non_interactive() is False
+
+
+def test_is_environmental_failure_both_directions():
+    environmental = [
+        "The dev Postgres container is not running",
+        "could not connect to server: Connection refused",
+        "localhost:5432",
+        "ECONNREFUSED",
+    ]
+    for output in environmental:
+        assert is_environmental_failure(output) is True, output
+
+    ordinary = [
+        "AssertionError: assert 1 == 2",
+        "1 failed, 3 passed",
+        "ValueError: bad input",
+    ]
+    for output in ordinary:
+        assert is_environmental_failure(output) is False, output

--- a/tests/test_agent_budget.py
+++ b/tests/test_agent_budget.py
@@ -104,7 +104,62 @@ async def test_run_agent_tool_call_ceiling(tmp_path: Path) -> None:
 
     with anyio.fail_after(5):
         async with recorder:
-            result, _ = await run_agent(
+            result, _, _ = await run_agent(
+                backend,
+                tmp_path,
+                "go",
+                phase=DaydreamPhase.FIX,
+                tool_call_budget=5,
+                wall_budget_s=None,
+            )
+
+    assert isinstance(result, str)
+    assert backend.cancel_calls == 1
+    traj = json.loads(recorder.path.read_text(encoding="utf-8"))
+    step = _agent_step_with_stop_reason(traj)
+    assert step["extra"]["stop_reason"] == "tool_call_budget_exceeded"
+
+
+async def test_run_agent_cancel_error_swallowed(tmp_path: Path) -> None:
+    """cancel() raising must not propagate — abort path must never raise into the CLI."""
+
+    @dataclass
+    class _RaisingCancelBackend:
+        """Backend whose cancel() raises; verifies the swallow contract in run_agent."""
+
+        model = "mock-model"
+        cancel_calls: int = 0
+
+        def execute(
+            self,
+            cwd: Path,
+            prompt: str,
+            output_schema: dict[str, Any] | None = None,
+            continuation: ContinuationToken | None = None,
+            agents: dict[str, Any] | None = None,
+            max_turns: int | None = None,
+            read_only: bool = False,
+        ) -> Any:
+            async def _gen() -> AsyncIterator[AgentEvent]:
+                for i in range(200):
+                    yield ToolStartEvent(id=f"tool-{i}", name="Bash", input={"command": "ls"})
+
+            return _gen()
+
+        async def cancel(self) -> None:
+            self.cancel_calls += 1
+            raise RuntimeError("cancel exploded")
+
+        def format_skill_invocation(self, skill_key: str, args: str = "") -> str:
+            return f"/{skill_key}"
+
+    backend = _RaisingCancelBackend()
+    recorder = _make_recorder(tmp_path)
+
+    # Must complete without raising — error-swallow contract
+    with anyio.fail_after(5):
+        async with recorder:
+            result, _, _ = await run_agent(
                 backend,
                 tmp_path,
                 "go",
@@ -127,7 +182,7 @@ async def test_run_agent_wall_budget(tmp_path: Path) -> None:
 
     with anyio.fail_after(5):
         async with recorder:
-            result, _ = await run_agent(
+            result, _, _ = await run_agent(
                 backend,
                 tmp_path,
                 "go",

--- a/tests/test_agent_budget.py
+++ b/tests/test_agent_budget.py
@@ -1,0 +1,143 @@
+"""Tests for run_agent wall-clock + tool-call budgets (Task 3).
+
+Both budgets live inside run_agent: the loop is wrapped in
+``anyio.move_on_after(wall_budget_s)`` and a ToolStartEvent counter trips the
+tool-call ceiling. On abort, ``backend.cancel()`` is awaited (errors swallowed),
+the recorder Invocation is marked aborted via ``inv.mark_aborted(reason)``, and
+the partial output is returned — no exception reaches the caller.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import anyio
+import pytest
+
+from daydream.agent import run_agent
+from daydream.backends import (
+    AgentEvent,
+    ContinuationToken,
+    ToolStartEvent,
+)
+from daydream.trajectory import (
+    DaydreamPhase,
+    DaydreamRunFlow,
+    TrajectoryRecorder,
+    _reset_recorder_for_tests,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_recorder() -> Any:
+    _reset_recorder_for_tests()
+    yield
+    _reset_recorder_for_tests()
+
+
+@dataclass
+class _BurstBackend:
+    """Backend that yields many ToolStartEvents and never a ResultEvent.
+
+    Optionally sleeps between events so a wall-clock budget can trip.
+    """
+
+    model = "mock-model"
+    count: int = 200
+    sleep_s: float = 0.0
+    cancel_calls: int = 0
+
+    def execute(
+        self,
+        cwd: Path,
+        prompt: str,
+        output_schema: dict[str, Any] | None = None,
+        continuation: ContinuationToken | None = None,
+        agents: dict[str, Any] | None = None,
+        max_turns: int | None = None,
+        read_only: bool = False,
+    ) -> AsyncIterator[AgentEvent]:
+        count = self.count
+        sleep_s = self.sleep_s
+
+        async def _gen() -> AsyncIterator[AgentEvent]:
+            for i in range(count):
+                if sleep_s:
+                    await anyio.sleep(sleep_s)
+                yield ToolStartEvent(id=f"tool-{i}", name="Bash", input={"command": "ls"})
+
+        return _gen()
+
+    async def cancel(self) -> None:
+        self.cancel_calls += 1
+
+    def format_skill_invocation(self, skill_key: str, args: str = "") -> str:
+        return f"/{skill_key}"
+
+
+def _make_recorder(tmp_path: Path) -> TrajectoryRecorder:
+    return TrajectoryRecorder(
+        path=tmp_path / ".daydream" / "trajectory.json",
+        run_flow=DaydreamRunFlow.NORMAL,
+        target_dir=tmp_path,
+        agent_model_name="opus",
+        session_id="test",
+    )
+
+
+def _agent_step_with_stop_reason(traj: dict[str, Any]) -> dict[str, Any]:
+    agent_steps = [s for s in traj["steps"] if s["source"] == "agent"]
+    for step in agent_steps:
+        if step.get("extra", {}).get("stop_reason"):
+            return step
+    raise AssertionError(f"no agent step carried extra['stop_reason']: {agent_steps}")
+
+
+async def test_run_agent_tool_call_ceiling(tmp_path: Path) -> None:
+    """A 200-event burst with tool_call_budget=5 returns under budget, marked aborted."""
+    backend = _BurstBackend(count=200, sleep_s=0.0)
+    recorder = _make_recorder(tmp_path)
+
+    with anyio.fail_after(5):
+        async with recorder:
+            result, _ = await run_agent(
+                backend,
+                tmp_path,
+                "go",
+                phase=DaydreamPhase.FIX,
+                tool_call_budget=5,
+                wall_budget_s=None,
+            )
+
+    assert isinstance(result, str)
+    assert backend.cancel_calls == 1
+    traj = json.loads(recorder.path.read_text(encoding="utf-8"))
+    step = _agent_step_with_stop_reason(traj)
+    assert step["extra"]["stop_reason"] == "tool_call_budget_exceeded"
+
+
+async def test_run_agent_wall_budget(tmp_path: Path) -> None:
+    """A slow stream with wall_budget_s=0.2 returns, step marked wall_budget_exceeded."""
+    backend = _BurstBackend(count=200, sleep_s=0.05)
+    recorder = _make_recorder(tmp_path)
+
+    with anyio.fail_after(5):
+        async with recorder:
+            result, _ = await run_agent(
+                backend,
+                tmp_path,
+                "go",
+                phase=DaydreamPhase.FIX,
+                wall_budget_s=0.2,
+                tool_call_budget=None,
+            )
+
+    assert isinstance(result, str)
+    assert backend.cancel_calls == 1
+    traj = json.loads(recorder.path.read_text(encoding="utf-8"))
+    step = _agent_step_with_stop_reason(traj)
+    assert step["extra"]["stop_reason"] == "wall_budget_exceeded"

--- a/tests/test_agent_budget.py
+++ b/tests/test_agent_budget.py
@@ -123,35 +123,12 @@ async def test_run_agent_tool_call_ceiling(tmp_path: Path) -> None:
 async def test_run_agent_cancel_error_swallowed(tmp_path: Path) -> None:
     """cancel() raising must not propagate — abort path must never raise into the CLI."""
 
-    @dataclass
-    class _RaisingCancelBackend:
-        """Backend whose cancel() raises; verifies the swallow contract in run_agent."""
-
-        model = "mock-model"
-        cancel_calls: int = 0
-
-        def execute(
-            self,
-            cwd: Path,
-            prompt: str,
-            output_schema: dict[str, Any] | None = None,
-            continuation: ContinuationToken | None = None,
-            agents: dict[str, Any] | None = None,
-            max_turns: int | None = None,
-            read_only: bool = False,
-        ) -> Any:
-            async def _gen() -> AsyncIterator[AgentEvent]:
-                for i in range(200):
-                    yield ToolStartEvent(id=f"tool-{i}", name="Bash", input={"command": "ls"})
-
-            return _gen()
+    class _RaisingCancelBackend(_BurstBackend):
+        """_BurstBackend whose cancel() raises; verifies the swallow contract in run_agent."""
 
         async def cancel(self) -> None:
             self.cancel_calls += 1
             raise RuntimeError("cancel exploded")
-
-        def format_skill_invocation(self, skill_key: str, args: str = "") -> str:
-            return f"/{skill_key}"
 
     backend = _RaisingCancelBackend()
     recorder = _make_recorder(tmp_path)

--- a/tests/test_agent_recorder_integration.py
+++ b/tests/test_agent_recorder_integration.py
@@ -119,7 +119,7 @@ async def _run_with_recorder(
     phase: DaydreamPhase = DaydreamPhase.REVIEW,
     run_flow: DaydreamRunFlow = DaydreamRunFlow.NORMAL,
     prompt: str = "hello",
-) -> tuple[dict[str, Any] | None, tuple[Any, Any]]:
+) -> tuple[dict[str, Any] | None, tuple[Any, Any, Any]]:
     """Drive run_agent inside a TrajectoryRecorder. Return (trajectory_dict, return_value)."""
     recorder = _make_recorder(tmp_path, run_flow=run_flow)
     target_path = recorder.path
@@ -265,7 +265,7 @@ async def test_no_recorder_is_clean_no_op(tmp_path: Path) -> None:
         ResultEvent(structured_output=None, continuation=None),
     ])
     # NO TrajectoryRecorder context — recorder is None.
-    out, cont = await run_agent(backend, tmp_path, "hi", phase=DaydreamPhase.REVIEW)
+    out, cont, _ = await run_agent(backend, tmp_path, "hi", phase=DaydreamPhase.REVIEW)
     assert isinstance(out, str)
     assert "ok" in out
     assert cont is None

--- a/tests/test_agent_structured_render.py
+++ b/tests/test_agent_structured_render.py
@@ -31,7 +31,7 @@ async def test_structured_output_text_is_not_rendered(monkeypatch, tmp_path):
     rec = Console(record=True, force_terminal=True, width=100)
     monkeypatch.setattr("daydream.agent.console", rec)
     backend = MockBackend([TextEvent(text=RAW), ResultEvent(structured_output=PAYLOAD, continuation=None)])
-    result, _ = await run_agent(
+    result, _, _ = await run_agent(
         backend, tmp_path, "scan", phase=DaydreamPhase.REVIEW, output_schema={"type": "object"}
     )
     out = rec.export_text()
@@ -46,5 +46,5 @@ async def test_plain_text_still_renders(monkeypatch, tmp_path):
     backend = MockBackend(
         [TextEvent(text="narration here"), ResultEvent(structured_output=None, continuation=None)]
     )
-    result, _ = await run_agent(backend, tmp_path, "go", phase=DaydreamPhase.REVIEW)  # no output_schema
+    result, _, _ = await run_agent(backend, tmp_path, "go", phase=DaydreamPhase.REVIEW)  # no output_schema
     assert "narration here" in rec.export_text()

--- a/tests/test_backend_claude.py
+++ b/tests/test_backend_claude.py
@@ -316,6 +316,11 @@ def test_read_only_bash_guard_decision(cmd, allowed):
     ("rm --recursive --force /", True),       # long-form flags
     ("rm -Rf /", True),                       # capital-R recursive
     ("rm -rf foo /", True),                   # trailing root arg
+    # Recursive flag NOT first: a non-recursive option token preceding it must
+    # not let the wipe slip past the guard (CodeRabbit #185).
+    ("rm --force --recursive /", True),       # long-form, recursive second
+    ("rm -f -r /", True),                     # short-form, recursive second
+    ("rm -i -r /*", True),                    # recursive second, root glob
     ("rm -rf /home/user/tmp", False),         # subpath under / is left alone
     ("rm -rf build", False),                  # relative path
     # F12: `/` as the grep pattern (not a root path) is no longer a false positive.

--- a/tests/test_backend_claude.py
+++ b/tests/test_backend_claude.py
@@ -310,6 +310,16 @@ def test_read_only_bash_guard_decision(cmd, allowed):
     ("find / -name y", True),
     ("grep -r pattern /", True),
     ("rm -rf /", True),
+    # F2: catastrophic wipe shapes the old `-rf?` literal missed.
+    ("rm -fr /", True),                       # reversed flags
+    ("rm -rf /*", True),                      # root glob
+    ("rm --recursive --force /", True),       # long-form flags
+    ("rm -Rf /", True),                       # capital-R recursive
+    ("rm -rf foo /", True),                   # trailing root arg
+    ("rm -rf /home/user/tmp", False),         # subpath under / is left alone
+    ("rm -rf build", False),                  # relative path
+    # F12: `/` as the grep pattern (not a root path) is no longer a false positive.
+    ("grep / file.txt", False),               # searching for a literal slash
     ("find core/osprey-tui -name agent.rs", False),
     ("ls", False),
     ("rg foo src/", False),

--- a/tests/test_backend_claude.py
+++ b/tests/test_backend_claude.py
@@ -305,6 +305,22 @@ def test_read_only_bash_guard_decision(cmd, allowed):
     assert _is_read_only_command(cmd) is allowed
 
 
+@pytest.mark.parametrize("cmd, dangerous", [
+    ("find / -path '*x*'", True),
+    ("find / -name y", True),
+    ("grep -r pattern /", True),
+    ("rm -rf /", True),
+    ("find core/osprey-tui -name agent.rs", False),
+    ("ls", False),
+    ("rg foo src/", False),
+])
+def test_is_dangerous_command(cmd, dangerous):
+    """The always-on dangerous-command predicate flags root-scans and catastrophic deletes."""
+    from daydream.backends.claude import _is_dangerous_command
+
+    assert _is_dangerous_command(cmd) is dangerous
+
+
 @pytest.mark.asyncio
 async def test_read_only_execute_registers_pretooluse_guard(patch_sdk):
     """read_only=True wires a fail-closed PreToolUse guard onto the SDK options.
@@ -330,43 +346,77 @@ async def test_read_only_execute_registers_pretooluse_guard(patch_sdk):
     matchers = hooks["PreToolUse"]
     assert len(matchers) == 1
     matcher = matchers[0]
-    assert matcher.hooks  # at least one callback registered
-    guard = matcher.hooks[0]
+    assert matcher.hooks  # callbacks registered
 
-    deny_write = await guard(
-        {"tool_name": "Write", "tool_input": {"file_path": "x", "content": "y"}}, None, {}
+    async def decide(payload):
+        # Mirror the SDK: run every registered hook; first deny wins.
+        for hook in matcher.hooks:
+            out = await hook(payload, None, {})
+            if out.get("hookSpecificOutput", {}).get("permissionDecision") == "deny":
+                return out
+        return {}
+
+    deny_write = await decide(
+        {"tool_name": "Write", "tool_input": {"file_path": "x", "content": "y"}}
     )
     assert deny_write["hookSpecificOutput"]["permissionDecision"] == "deny"
 
-    deny_bash = await guard(
-        {"tool_name": "Bash", "tool_input": {"command": "git commit -m x"}}, None, {}
+    deny_bash = await decide(
+        {"tool_name": "Bash", "tool_input": {"command": "git commit -m x"}}
     )
     assert deny_bash["hookSpecificOutput"]["permissionDecision"] == "deny"
 
-    allow_bash = await guard(
-        {"tool_name": "Bash", "tool_input": {"command": "git log -n 5"}}, None, {}
+    allow_bash = await decide(
+        {"tool_name": "Bash", "tool_input": {"command": "git log -n 5"}}
     )
     assert "hookSpecificOutput" not in allow_bash
-    allow_read = await guard({"tool_name": "Read", "tool_input": {"file_path": "x"}}, None, {})
+    allow_read = await decide({"tool_name": "Read", "tool_input": {"file_path": "x"}})
     assert "hookSpecificOutput" not in allow_read
 
     # Fail-closed: a narrow deny-list matcher would never present an unknown tool to the guard.
-    deny_unknown = await guard({"tool_name": "FutureMutator", "tool_input": {}}, None, {})
+    deny_unknown = await decide({"tool_name": "FutureMutator", "tool_input": {}})
     assert deny_unknown["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    # read_only=True also composes the always-on dangerous-command guard: a root scan denies.
+    deny_find_root = await decide(
+        {"tool_name": "Bash", "tool_input": {"command": "find / -name x"}}
+    )
+    assert deny_find_root["hookSpecificOutput"]["permissionDecision"] == "deny"
 
 
 @pytest.mark.asyncio
-async def test_non_read_only_execute_registers_no_hook(patch_sdk):
-    """read_only=False (default) leaves the normal fix/test profile untouched — no hook."""
+async def test_non_read_only_execute_registers_dangerous_command_hook(patch_sdk):
+    """read_only=False (default) still wires the always-on dangerous-command guard.
+
+    The guard is registered unconditionally (all phases). Drive the callback that
+    was actually built onto the production options: a ``find /`` root scan denies,
+    a scoped ``find core/...`` allows.
+    """
     patch_sdk(MockClaudeSDKClientCapture)
     backend = ClaudeBackend(model="opus")
 
-    async for _ in backend.execute(Path("/tmp"), "Go"):
+    async for _ in backend.execute(Path("/tmp"), "Go", read_only=False):
         pass
 
     opts = MockClaudeSDKClientCapture.captured_options
     assert opts is not None
-    assert getattr(opts, "hooks", None) is None
+    hooks = opts.hooks
+    assert hooks is not None and "PreToolUse" in hooks
+    matchers = hooks["PreToolUse"]
+    assert len(matchers) == 1
+    guard = matchers[0].hooks[0]
+
+    deny_find_root = await guard(
+        {"tool_name": "Bash", "tool_input": {"command": "find / -name x"}}, None, {}
+    )
+    assert deny_find_root["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    allow_find_scoped = await guard(
+        {"tool_name": "Bash", "tool_input": {"command": "find core/osprey-tui -name agent.rs"}},
+        None,
+        {},
+    )
+    assert "hookSpecificOutput" not in allow_find_scoped
 
 
 @pytest.mark.asyncio

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -18,7 +18,7 @@ from typing import Any
 import anyio
 import pytest
 
-from daydream.backends import ResultEvent, TextEvent
+from daydream.backends import ResultEvent, TextEvent, ToolStartEvent
 
 
 class _StubBackend:
@@ -75,6 +75,17 @@ class _StubBackend:
         # When set, the fix branch raises for the matching file, isolating one
         # file-group's failure so a test can assert the others still applied.
         self.fix_fail_file: str | None = None
+        # When True, the fix branch yields a long burst of ToolStartEvents and
+        # NEVER emits a ResultEvent -- simulating a runaway turn. Without the
+        # in-loop tool-call budget in run_agent this stream never completes and
+        # the run hangs; with it, the loop aborts after tool_call_budget calls.
+        self.runaway_fix: bool = False
+        # When True, the test-suite branch emits a Postgres-unreachable signature
+        # (infra down, not a code bug) so phase_test_and_heal's
+        # is_environmental_failure() short-circuit fires. The heal-fix branch then
+        # writes ``.daydream-heal-fix-applied`` -- a sentinel that MUST be absent
+        # when the short-circuit aborts before re-entering a fix turn (AC#6b).
+        self.environmental_test_failure: bool = False
 
     async def execute(
         self,
@@ -305,6 +316,14 @@ class _StubBackend:
         # phase_fix -> "apply" the edit by writing a sentinel file, the observable
         # consequence the --yes real-path test asserts the fix gate auto-approved.
         if pl.startswith("fix this issue"):
+            if self.runaway_fix:
+                # Emit a long burst of tool calls and NEVER a ResultEvent. A
+                # generator that never returns models the 1.5-5h time-tail the
+                # tool-call budget exists to cut; the budget breaks the loop.
+                for n in range(500):
+                    yield ToolStartEvent(id=f"tc-{n}", name="Bash", input={"command": "find /"})
+                    await anyio.sleep(0)
+                return
             m = re.search(r"^File: (.+)$", prompt, re.M)
             fixed_file = m.group(1).strip() if m else "unknown"
             # phase_fix emits an absolute path when the file exists on disk; the stub keys fixes by basename.
@@ -343,12 +362,34 @@ class _StubBackend:
             )
             return
 
+        # Heal-loop fix turn (prompt starts with "The tests failed."). Writes a
+        # distinct sentinel so a test can assert the heal loop DID re-enter a fix
+        # turn -- and, by its ABSENCE, that the environmental short-circuit aborted
+        # before any fix turn ran (AC#6b).
+        if pl.startswith("the tests failed"):
+            (cwd / ".daydream-heal-fix-applied").write_text("healed\n")
+            yield TextEvent(text="Attempted to fix the test failures.")
+            yield ResultEvent(structured_output=None, continuation=None)
+            return
+
         # Test-and-heal run. The prompt is constant, so a call counter drives the
         # result: with fail_first_test_run set, the FIRST run fails (heal loop
-        # reaches choice "2") and subsequent runs pass.
+        # reaches choice "2") and subsequent runs pass. With
+        # environmental_test_failure set, every run emits a Postgres-unreachable
+        # signature -- detect_test_success() is False AND is_environmental_failure()
+        # is True, so the heal loop must abort before a fix turn.
         if "run the project's test suite" in pl:
             self.test_suite_calls += 1
-            if self.fail_first_test_run and self.test_suite_calls == 1:
+            if self.environmental_test_failure:
+                yield TextEvent(
+                    text=(
+                        "could not connect to server: Connection refused\n"
+                        "\tIs the server running on host localhost (127.0.0.1) "
+                        "and accepting TCP/IP connections on port 5432?\n"
+                        "The dev Postgres container is not running."
+                    )
+                )
+            elif self.fail_first_test_run and self.test_suite_calls == 1:
                 yield TextEvent(text="1 failed, 0 passed")
             else:
                 yield TextEvent(text="2 passed, 0 failed")
@@ -2669,3 +2710,149 @@ async def test_merge_resume_skips_arbiter_when_marker_present(
 
     arbiter_calls = [c for c in calls if "you are the arbiter" in c["prompt"].lower()]
     assert arbiter_calls == [], "arbiter must not re-run when the completion marker is present"
+
+
+async def test_run_terminates_under_tool_call_budget(
+    multi_stack_target: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC#6a real-path: a runaway fix turn is capped by the tool-call budget.
+
+    The stub's fix branch yields an unbounded burst of ToolStartEvents and never
+    a ResultEvent (the 1.5-5h time-tail #169 targets). Driven through the real
+    ``runner.run`` -> deep orchestrator -> ``phase_fix_parallel`` -> ``run_agent``
+    path with a small ``tool_call_budget``, the loop must break, ``run`` must
+    return an int exit code (no hang/exception), and the aborted turn's ATIF step
+    must carry ``extra["stop_reason"]``.
+
+    Discriminating: without the in-loop tool-call budget in ``run_agent`` the
+    stub stream never completes, so ``run`` never returns -- the ``fail_after``
+    timeout turns that regression into a failure instead of an infinite hang.
+    """
+    from daydream.runner import RunConfig, run
+
+    _silence(monkeypatch)
+    # Patch the binding actually read at the fix call site (Task 5 imported the
+    # constant INTO daydream.phases); patching only daydream.config would not take
+    # effect because phases already resolved the name at import time.
+    monkeypatch.setattr("daydream.phases.DEFAULT_TOOL_CALL_BUDGET", 3)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    stub.runaway_fix = True
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_test_and_heal", lambda *a, **k: _ok())
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _noop_commit)
+
+    traj = tmp_path / "trajectory.json"
+    with anyio.fail_after(30):
+        exit_code = await run(
+            RunConfig(
+                target=str(multi_stack_target),
+                trajectory_path=traj,
+                assume="yes",
+                output_mode="loop",
+                cleanup=False,
+            )
+        )
+
+    assert isinstance(exit_code, int)
+
+    # The aborted fix turn runs inside a sibling (forked) trajectory under the
+    # per-run dir, so scan every trajectory JSON written for this run for a step
+    # whose extra carries a stop_reason -- the observable proof the turn aborted.
+    run_root = multi_stack_target / ".daydream"
+    stop_reasons: list[str] = []
+    for tf in list(run_root.rglob("*.json")) + ([traj] if traj.exists() else []):
+        try:
+            payload = json.loads(tf.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        for step in payload.get("steps", []):
+            reason = (step.get("extra") or {}).get("stop_reason")
+            if reason:
+                stop_reasons.append(reason)
+
+    assert stop_reasons, "no trajectory step recorded extra['stop_reason']; budget did not trip"
+    assert "tool_call_budget_exceeded" in stop_reasons
+
+
+async def test_environmental_failure_aborts_heal_loop(
+    multi_stack_target: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC#6b real-path: an environmental test failure aborts heal without a fix turn.
+
+    Drives the REAL ``phase_test_and_heal`` through ``runner.run`` -> deep
+    orchestrator. The stub's test-suite branch emits a Postgres-unreachable
+    signature, so ``detect_test_success`` is False AND ``is_environmental_failure``
+    is True. The orchestrator's short-circuit (Task 6) must return failure BEFORE
+    re-entering a fix turn -- so the heal-fix sentinel
+    ``.daydream-heal-fix-applied`` must NEVER be written.
+
+    ``assume="yes"`` opts into a SINGLE bounded auto fix-and-retry, so this test
+    is DISCRIMINATING without hanging: remove the environmental short-circuit and
+    the heal loop runs exactly one fix turn (then aborts), writing the sentinel.
+    With the short-circuit in place the sentinel is absent, the run returns an int
+    failure exit code, and a TEST-phase trajectory step is recorded with no fix.
+    """
+    monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.deep.orchestrator.print_verification_summary", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
+
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    stub.environmental_test_failure = True  # every test run reports infra-down
+
+    async def _no_post(target_dir: Path, report_path: Path, *, console: Any) -> None:
+        return None
+
+    async def _stub_commit(backend, work):  # noqa: ARG001
+        return None
+
+    monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _no_post)
+    # phase_test_and_heal stays REAL so the environmental short-circuit runs.
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _stub_commit)
+
+    from daydream.runner import RunConfig, run
+
+    traj = tmp_path / "trajectory.json"
+    config = RunConfig(
+        target=str(multi_stack_target),
+        trajectory_path=traj,
+        assume="yes",
+        output_mode="loop",
+        cleanup=False,
+    )
+    exit_code = await run(config)
+
+    # Environmental failure is not healable -> run reports failure, not success.
+    assert isinstance(exit_code, int)
+    assert exit_code != 0, "environmental failure must surface as a non-zero exit, not be healed"
+
+    # The observable proof: the heal loop NEVER re-entered a fix turn, so the
+    # heal-fix sentinel was never written. (Discriminating: without the
+    # short-circuit, choice "2" would write this file.)
+    heal_sentinel = multi_stack_target / ".daydream-heal-fix-applied"
+    assert not heal_sentinel.exists(), (
+        "heal-fix sentinel exists -- the environmental short-circuit did not "
+        "abort before re-entering a fix turn"
+    )
+    # And no heal-fix prompt was ever dispatched to the backend.
+    heal_prompts = [c for c in stub.calls if c["prompt"].lower().startswith("the tests failed")]
+    assert not heal_prompts, "a heal fix prompt was dispatched despite environmental abort"
+
+    # The environmental outcome is observable: the test phase ran (the suite was
+    # invoked) and a TEST-phase trajectory step was recorded for this run.
+    assert stub.test_suite_calls >= 1, "test suite never ran -- heal phase not reached"
+    run_root = multi_stack_target / ".daydream"
+    saw_test_step = False
+    for tf in list(run_root.rglob("*.json")) + ([traj] if traj.exists() else []):
+        try:
+            payload = json.loads(tf.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        for step in payload.get("steps", []):
+            if (step.get("extra") or {}).get("daydream_phase") == "test":
+                saw_test_step = True
+    assert saw_test_step, "no TEST-phase trajectory step recorded -- heal phase not reached"

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -80,6 +80,10 @@ class _StubBackend:
         # in-loop tool-call budget in run_agent this stream never completes and
         # the run hangs; with it, the loop aborts after tool_call_budget calls.
         self.runaway_fix: bool = False
+        # Real per-event sleep for the runaway burst (default 0.0 == anyio.sleep(0),
+        # an interleave point with no wall time). A small positive value lets the
+        # wall-clock budget trip before the tool-call budget in the wall real-path test.
+        self.runaway_fix_sleep_s: float = 0.0
         # When True, the test-suite branch emits a Postgres-unreachable signature
         # (infra down, not a code bug) so phase_test_and_heal's
         # is_environmental_failure() short-circuit fires. The heal-fix branch then
@@ -322,7 +326,7 @@ class _StubBackend:
                 # tool-call budget exists to cut; the budget breaks the loop.
                 for n in range(500):
                     yield ToolStartEvent(id=f"tc-{n}", name="Bash", input={"command": "find /"})
-                    await anyio.sleep(0)
+                    await anyio.sleep(self.runaway_fix_sleep_s)
                 return
             m = re.search(r"^File: (.+)$", prompt, re.M)
             fixed_file = m.group(1).strip() if m else "unknown"
@@ -2714,6 +2718,28 @@ async def test_merge_resume_skips_arbiter_when_marker_present(
     assert arbiter_calls == [], "arbiter must not re-run when the completion marker is present"
 
 
+def _scan_trajectory_extra(run_root: Path, traj: Path, key: str) -> list[str]:
+    """Collect ``step["extra"][key]`` across every trajectory JSON written for a run.
+
+    An aborted/forked turn writes sibling trajectory files under the per-run dir, so
+    scan all ``*.json`` beneath ``run_root`` plus the top-level ``traj`` path. Non-dict
+    or unparseable files are skipped. Returns only truthy values, in discovery order.
+    """
+    values: list[str] = []
+    for tf in list(run_root.rglob("*.json")) + ([traj] if traj.exists() else []):
+        try:
+            payload = json.loads(tf.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        for step in payload.get("steps", []):
+            value = (step.get("extra") or {}).get(key)
+            if value:
+                values.append(value)
+    return values
+
+
 async def test_run_terminates_under_tool_call_budget(
     multi_stack_target: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -2760,21 +2786,62 @@ async def test_run_terminates_under_tool_call_budget(
     # per-run dir, so scan every trajectory JSON written for this run for a step
     # whose extra carries a stop_reason -- the observable proof the turn aborted.
     run_root = multi_stack_target / ".daydream"
-    stop_reasons: list[str] = []
-    for tf in list(run_root.rglob("*.json")) + ([traj] if traj.exists() else []):
-        try:
-            payload = json.loads(tf.read_text())
-        except (json.JSONDecodeError, OSError):
-            continue
-        if not isinstance(payload, dict):
-            continue
-        for step in payload.get("steps", []):
-            reason = (step.get("extra") or {}).get("stop_reason")
-            if reason:
-                stop_reasons.append(reason)
+    stop_reasons = _scan_trajectory_extra(run_root, traj, "stop_reason")
 
     assert stop_reasons, "no trajectory step recorded extra['stop_reason']; budget did not trip"
     assert "tool_call_budget_exceeded" in stop_reasons
+
+
+async def test_run_terminates_under_wall_budget(
+    multi_stack_target: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#169 real-path: a runaway fix turn is capped by the wall-clock budget.
+
+    The stub's fix branch yields a slow, unbounded burst of ToolStartEvents (a real
+    per-event sleep, never a ResultEvent) -- the 1.5-5h time-tail #169 targets.
+    Driven through the real ``runner.run`` -> deep orchestrator -> ``phase_fix_parallel``
+    -> ``run_agent`` path with a tiny ``DEFAULT_WALL_BUDGET_S``, the wall scope must
+    cancel the turn, ``run`` must return an int exit code, and the aborted turn's ATIF
+    step must carry ``extra["stop_reason"] == "wall_budget_exceeded"``.
+
+    Discriminating: the wall budget only engages because ``phase_fix_parallel`` now
+    passes ``wall_budget_s=DEFAULT_WALL_BUDGET_S`` at the fix call site. Unwire that
+    (the pre-fix state, where the constant was defined but never passed) and the wall
+    scope is ``nullcontext()`` in production -- the tool-call budget trips instead, so
+    ``stop_reason`` is ``tool_call_budget_exceeded`` and this assertion fails.
+    """
+    from daydream.runner import RunConfig, run
+
+    _silence(monkeypatch)
+    # Patch the binding read at the fix call site (phases imported the constant by
+    # name at import time, so patching daydream.config alone would not take effect).
+    # 0.3s wall trips after ~6 slow events, well before the 50-call tool-call budget.
+    monkeypatch.setattr("daydream.phases.DEFAULT_WALL_BUDGET_S", 0.3)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    stub.runaway_fix = True
+    stub.runaway_fix_sleep_s = 0.05
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_test_and_heal", lambda *a, **k: _ok())
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _noop_commit)
+
+    traj = tmp_path / "trajectory.json"
+    with anyio.fail_after(30):
+        exit_code = await run(
+            RunConfig(
+                target=str(multi_stack_target),
+                trajectory_path=traj,
+                assume="yes",
+                output_mode="loop",
+                cleanup=False,
+            )
+        )
+
+    assert isinstance(exit_code, int)
+
+    run_root = multi_stack_target / ".daydream"
+    stop_reasons = _scan_trajectory_extra(run_root, traj, "stop_reason")
+
+    assert stop_reasons, "no trajectory step recorded extra['stop_reason']; budget did not trip"
+    assert "wall_budget_exceeded" in stop_reasons
 
 
 async def test_environmental_failure_aborts_heal_loop(
@@ -2846,15 +2913,5 @@ async def test_environmental_failure_aborts_heal_loop(
     # invoked) and a TEST-phase trajectory step was recorded for this run.
     assert stub.test_suite_calls >= 1, "test suite never ran -- heal phase not reached"
     run_root = multi_stack_target / ".daydream"
-    saw_test_step = False
-    for tf in list(run_root.rglob("*.json")) + ([traj] if traj.exists() else []):
-        try:
-            payload = json.loads(tf.read_text())
-        except (json.JSONDecodeError, OSError):
-            continue
-        if not isinstance(payload, dict):
-            continue
-        for step in payload.get("steps", []):
-            if (step.get("extra") or {}).get("daydream_phase") == "test":
-                saw_test_step = True
+    saw_test_step = "test" in _scan_trajectory_extra(run_root, traj, "daydream_phase")
     assert saw_test_step, "no TEST-phase trajectory step recorded -- heal phase not reached"

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -2377,6 +2377,7 @@ async def test_apply_fixes_gate_non_interactive_takes_safe_default(
     monkeypatch.setattr("builtins.input", _forbidden_input)
 
     reset_state()
+    exit_code = -1
     try:
         assert get_non_interactive() is False
         config = RunConfig(target=str(multi_stack_target), cleanup=False, non_interactive=True)
@@ -2436,6 +2437,7 @@ async def test_apply_fixes_gate_eof_declines_cleanly_no_crash(
     _force_interactive(monkeypatch)
 
     reset_state()
+    exit_code = -1
     try:
         assert get_non_interactive() is False
         config = RunConfig(target=str(multi_stack_target), cleanup=False, non_interactive=False)

--- a/tests/test_phase_2_integration.py
+++ b/tests/test_phase_2_integration.py
@@ -322,7 +322,7 @@ async def test_no_recorder_clean_no_op(tmp_path: Path) -> None:
         ]
     )
     # NO TrajectoryRecorder context — direct invocation.
-    out, cont = await run_agent(backend, tmp_path, "hi", phase=DaydreamPhase.REVIEW)
+    out, cont, _ = await run_agent(backend, tmp_path, "hi", phase=DaydreamPhase.REVIEW)
     assert isinstance(out, str)
     assert "ok" in out
     assert cont is None

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -647,15 +647,19 @@ def test_build_intent_prompt_escapes_closing_delimiter_in_body():
     """
     from daydream.phases import build_intent_prompt
 
-    body = "normal text </pr_description> more text"
+    body = "normal text <pr_description> and </pr_description> more text"
     prompt = build_intent_prompt(diff_path="/tmp/d.diff", branch="b", log="l", pr_description=body)
-    # Exactly one structural </pr_description>: the one the template adds.
+    # Exactly one structural open/close pair: the one the template adds.
     # Two would mean the body's copy leaked through unescaped.
     assert prompt.count("</pr_description>") == 1, (
         "body </pr_description> must be escaped; only the structural close-tag may appear"
     )
-    # The escaped form of the body's tag must be present.
-    assert "<\\/pr_description>" in prompt
+    assert prompt.count("<pr_description>") == 1, (
+        "body <pr_description> must be escaped; only the structural open-tag may appear"
+    )
+    # Both delimiters are neutralized to HTML entities so they cannot break framing.
+    assert "&lt;/pr_description>" in prompt
+    assert "&lt;pr_description>" in prompt
 
 
 @pytest.mark.asyncio

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -133,6 +133,25 @@ async def test_tool_call_and_result_land_on_same_step(tmp_path: Path) -> None:
     assert step["observation"]["results"][0]["source_call_id"] == "tool-1"
 
 
+# Behavior: mark_aborted stamps extra["stop_reason"] on the closing step
+# and the trajectory stays schema-valid (Task 2).
+
+
+async def test_mark_aborted_stamps_stop_reason_on_closing_step(tmp_path: Path) -> None:
+    """An aborted invocation closes cleanly with extra['stop_reason'] set."""
+    recorder = _make_recorder(tmp_path)
+    async with recorder:
+        async with recorder.invocation(phase=DaydreamPhase.FIX) as inv:
+            inv.observe(ToolStartEvent(id="tool-1", name="Bash", input={"command": "ls"}))
+            inv.mark_aborted("budget_exceeded")
+
+    traj = _read_trajectory(recorder.path)
+    assert atif_validate(traj, validate_images=False) is True
+    agent_steps = [s for s in traj["steps"] if s["source"] == "agent"]
+    assert len(agent_steps) == 1
+    assert agent_steps[0]["extra"]["stop_reason"] == "budget_exceeded"
+
+
 # Behavior 4: User step has source="user" and NO agent-only fields
 # (Pitfall 4)
 


### PR DESCRIPTION
## Summary

A single unbounded `run_agent` turn could run 1.5–5h: an SDK turn is not one tool call, so `max_turns` was the wrong instrument for capping the time tail. This PR enforces budgets *inside* `run_agent`'s loop — a per-invocation wall-clock budget and an opt-in tool-call ceiling — so both backends are bounded with no change to the `Backend` signature. It also adds an always-on guard against catastrophic Bash commands and short-circuits the heal loop on unhealable environmental test failures.

## Changes

### Added
- Per-invocation wall-clock budget in `run_agent` (`anyio.move_on_after`, default 1800s) and an opt-in `ToolStartEvent` ceiling (default 50), wired at the fix/intent/verify call sites.
- `Invocation.mark_aborted` stamps `extra["stop_reason"]` on the ATIF turn when a budget aborts the run; partial output is returned.
- Always-on `PreToolUse` guard denying catastrophic Bash commands (`find /`, `grep ... /`, `rm -rf /`) across all phases.
- `is_environmental_failure` short-circuits the heal loop when a test failure (DB/cache unreachable) can't be fixed by a fix turn.
- Real-path tests driving both budget aborts through `runner.run` with a real worktree (mocking only `Backend`), plus dangerous-command guard cases.

### Changed
- `run_agent` returns a 3-tuple (adds `budget_reason`); all call sites and unpack points updated, including the production `exploration_runner.py` path.
- `build_intent_prompt` escapes both `<pr_description>` delimiters as HTML entities.

### Fixed
- On budget abort, `aclose()` the `event_iter` async generator *before* `backend.cancel()` so generator cleanup (finally blocks, `GeneratorExit`) completes before the backend receives the cancel signal. `backend.execute(...)` is cast to `AsyncGenerator` (both implementations are generator functions).
- `backend.cancel()` errors are swallowed — a budget abort never raises into the CLI.
- `claude.py` dangerous-command guard: `grep` no longer false-positives when `/` is the search pattern; `rm` now catches `-fr`, `--recursive --force`, and the `/` / `/*` root-glob wipe shapes.

## Motivation

`max_turns` bounds turn count, not wall-clock time, and an SDK turn can fan out into many tool calls. The runaway-time tail (#169) needed budgets enforced at the loop level, where both backends are covered without a protocol change. The dangerous-command guard (#177) is a runaway/wipe backstop, not a sandbox — Codex has no equivalent `PreToolUse` seam (its enforcement is `--sandbox`).

## Testing

- [x] Unit tests added/updated (`tests/test_agent_budget.py`, `test_is_dangerous_command` cases, `tests/test_agent.py`)
- [x] Integration tests added/updated (real-path aborts via `runner.run` in `tests/test_deep_orchestrator.py`)
- [x] Manual testing performed (full `make check` — lint, typecheck, test suite)

Real-path tests assert observable outcomes: exit code, trajectory `extra["stop_reason"]`, and absence of the heal-fix sentinel.

## Related Issues

- Closes #169
- Closes #177

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally
- [x] Linting passes
- [x] Documentation updated (if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)