### PR TITLE
fix(backends/codex): deterministic tool-id pairing + observable parse failures (#153)

### DIFF
--- a/daydream/backends/codex.py
+++ b/daydream/backends/codex.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import re
 import tempfile
 import uuid
@@ -32,6 +33,8 @@ from daydream.backends import (
 _SHELL_WRAPPER_RE = re.compile(r"/bin/(?:zsh|bash|sh)\s+-lc\s+(.+)$", re.DOTALL)
 _CD_PREFIX_RE = re.compile(r"^cd\s+\S+\s*&&\s*")
 _CODEX_STDOUT_LIMIT_BYTES = 10 * 1024 * 1024
+
+_logger = logging.getLogger(__name__)
 
 
 def _unwrap_shell_command(command: str) -> str:
@@ -138,12 +141,45 @@ class CodexBackend:
         structured_result: Any = None
 
         # Event correlation state. Codex events arrive item.started → updated* →
-        # completed. (1) Some item.started lack an `id`, so we synthesize a UUID
-        # keyed by type+content and pop it on completion to pair start/result.
+        # completed. (1) Some item.started lack an `id`; we pair start/result via
+        # a deterministic FIFO per item_type (order-preserving, content-
+        # independent) with the legacy content-key as a secondary fallback. When
+        # both miss, the completion is an orphan — we emit an OBSERVABLE warning
+        # and assign a deterministic sequence id so the trajectory recorder can
+        # still bucket it via unmatched_tool_results without a silent drop.
         # (2) agent_message/reasoning text may stream as item.updated deltas with
         # an empty item.completed, so we accumulate deltas by id and join them.
-        pending_item_ids: dict[str, str] = {}  # "type:content" → generated UUID
+        pending_fifo: dict[str, list[str]] = {}  # item_type → [ids] in start order
+        pending_item_ids: dict[str, str] = {}  # "type:content" → generated id (legacy)
         updated_text: dict[str, list[str]] = {}  # item_id → [text deltas]
+        parse_warnings: list[str] = []  # observable parse-failure surface
+        unmatched_seq = 0  # monotonic source for orphaned tool-result ids
+
+        def _warn(msg: str, **detail: Any) -> None:
+            """Log a parser warning and record it for later trajectory surfacing."""
+            parse_warnings.append(msg)
+            _logger.warning("codex: %s %s", msg, detail)
+
+        def _claim_tool_id(item_type: str, content_key: str, content_value: Any) -> str:
+            """Pop the next correlated id for a no-id item.completed.
+
+            Prefers the FIFO (content-independent order correlation), falls back
+            to the legacy content-key, and finally — if both miss — emits an
+            OBSERVABLE warning and returns a deterministic orphan id. The orphan
+            still lands in ``trajectory.extra.unmatched_tool_results`` because
+            the validator hard-fails on a dangling ``source_call_id``; the
+            warning ensures the miss is no longer silent.
+            """
+            nonlocal unmatched_seq
+            fifo = pending_fifo.get(item_type, [])
+            item_id = fifo.pop(0) if fifo else None
+            if item_id is None:
+                item_id = pending_item_ids.pop(content_key, None)
+            if item_id is None:
+                _warn("unmatched tool result", item_type=item_type, key=content_key, value=content_value)
+                item_id = f"codex-unmatched-{unmatched_seq}"
+                unmatched_seq += 1
+            return item_id
 
         proc: asyncio.subprocess.Process | None = None
 
@@ -173,6 +209,9 @@ class CodexBackend:
                 try:
                     event = json.loads(raw_line)
                 except json.JSONDecodeError:
+                    # Codex occasionally emits non-JSON status lines on stdout;
+                    # skip them but leave a debug breadcrumb for triage.
+                    _logger.debug("codex: non-JSON line skipped: %r", raw_line[:80])
                     continue
 
                 event_type = event.get("type", "")
@@ -188,6 +227,9 @@ class CodexBackend:
                         item_id = item.get("id")
                         if not item_id:
                             item_id = str(uuid.uuid4())
+                            # FIFO is the primary correlation path (order-
+                            # preserving); content-key stays as legacy fallback.
+                            pending_fifo.setdefault("command_execution", []).append(item_id)
                             pending_item_ids[f"command_execution:{item.get('command', '')}"] = item_id
                         raw_cmd = item.get("command", "")
                         yield ToolStartEvent(
@@ -199,6 +241,9 @@ class CodexBackend:
                         item_id = item.get("id")
                         if not item_id:
                             item_id = str(uuid.uuid4())
+                            # FIFO is the primary correlation path (order-
+                            # preserving); content-key stays as legacy fallback.
+                            pending_fifo.setdefault("mcp_tool_call", []).append(item_id)
                             pending_item_ids[f"mcp_tool_call:{item.get('tool', '')}"] = item_id
                         yield ToolStartEvent(
                             id=item_id,
@@ -247,10 +292,11 @@ class CodexBackend:
                     elif item_type == "command_execution":
                         item_id = item.get("id")
                         if not item_id:
-                            lookup_key = f"command_execution:{item.get('command', '')}"
-                            item_id = pending_item_ids.pop(lookup_key, None)
-                            if item_id is None:
-                                item_id = str(uuid.uuid4())
+                            item_id = _claim_tool_id(
+                                "command_execution",
+                                f"command_execution:{item.get('command', '')}",
+                                item.get("command", ""),
+                            )
                         exit_code = item.get("exit_code", -1)
                         output = item.get("aggregated_output", "")
                         status = item.get("status", "")
@@ -287,10 +333,11 @@ class CodexBackend:
                     elif item_type == "mcp_tool_call":
                         item_id = item.get("id")
                         if not item_id:
-                            lookup_key = f"mcp_tool_call:{item.get('tool', '')}"
-                            item_id = pending_item_ids.pop(lookup_key, None)
-                            if item_id is None:
-                                item_id = str(uuid.uuid4())
+                            item_id = _claim_tool_id(
+                                "mcp_tool_call",
+                                f"mcp_tool_call:{item.get('tool', '')}",
+                                item.get("tool", ""),
+                            )
                         result_content = ""
                         if "result" in item:
                             result_content = str(item["result"].get("content", ""))
@@ -330,7 +377,13 @@ class CodexBackend:
                         try:
                             structured_result = json.loads(last_agent_text)
                         except json.JSONDecodeError:
-                            pass
+                            # Observable failure path — surface the bad payload
+                            # instead of silently degrading to None.
+                            _warn(
+                                "structured output parse failed",
+                                source="agent_text",
+                                raw=last_agent_text[:200],
+                            )
 
                     # Fallback: result/output field directly on turn.completed.
                     if output_schema and structured_result is None:
@@ -343,7 +396,11 @@ class CodexBackend:
                                     try:
                                         structured_result = json.loads(raw)
                                     except json.JSONDecodeError:
-                                        pass
+                                        _warn(
+                                            "structured output parse failed",
+                                            source=f"turn.completed.{key}",
+                                            raw=raw[:200],
+                                        )
                                 if structured_result is not None:
                                     break
 

--- a/tests/fixtures/codex_jsonl/item_started_no_id.jsonl
+++ b/tests/fixtures/codex_jsonl/item_started_no_id.jsonl
@@ -1,0 +1,9 @@
+{"type":"thread.started","thread_id":"th_noid"}
+{"type":"item.started","item":{"type":"command_execution","command":"echo one"}}
+{"type":"item.completed","item":{"type":"command_execution","command":"echo one","status":"completed","exit_code":0,"aggregated_output":"one"}}
+{"type":"item.started","item":{"type":"command_execution","command":"echo two"}}
+{"type":"item.completed","item":{"type":"command_execution","command":"echo two","status":"completed","exit_code":0,"aggregated_output":"two"}}
+{"type":"item.started","item":{"type":"mcp_tool_call","tool":"search","arguments":{"q":"foo"}}}
+{"type":"item.completed","item":{"type":"mcp_tool_call","tool":"search","arguments":{"q":"foo"},"result":{"content":"found"}}}
+{"type":"item.completed","item":{"type":"agent_message","text":"Done."}}
+{"type":"turn.completed","usage":{"input_tokens":10,"output_tokens":5}}

--- a/tests/fixtures/codex_jsonl/malformed_structured_output.jsonl
+++ b/tests/fixtures/codex_jsonl/malformed_structured_output.jsonl
@@ -1,0 +1,4 @@
+{"type":"thread.started","thread_id":"th_badjson"}
+{"type":"item.started","item":{"type":"agent_message","id":"msg_1","content":[]}}
+{"type":"item.completed","item":{"type":"agent_message","id":"msg_1","text":"this is not valid JSON"}}
+{"type":"turn.completed","usage":{"input_tokens":5,"output_tokens":3}}

--- a/tests/fixtures/codex_jsonl/orphaned_tool_result.jsonl
+++ b/tests/fixtures/codex_jsonl/orphaned_tool_result.jsonl
@@ -1,0 +1,3 @@
+{"type":"thread.started","thread_id":"th_orphan"}
+{"type":"item.completed","item":{"type":"command_execution","command":"orphan-cmd","status":"completed","exit_code":0,"aggregated_output":"ghost"}}
+{"type":"turn.completed","usage":{"input_tokens":5,"output_tokens":3}}

--- a/tests/test_backend_codex.py
+++ b/tests/test_backend_codex.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import json
+import logging
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -503,3 +504,153 @@ async def test_execute_raises_on_agents():
     with pytest.raises(NotImplementedError, match="Codex backend does not support exploration"):
         async for _ in backend.execute(Path("/tmp"), "Test", agents={"explorer": mock_agent}):
             pass
+
+
+# ---------------------------------------------------------------------------
+# Parser hardening (#153): deterministic tool-id correlation + observable
+# parse-failure paths. See .beagle/concepts/codex-parser-hardening/plan.md.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_well_formed_multi_tool_no_orphans(caplog: pytest.LogCaptureFixture) -> None:
+    """No-id item.started/completed pairs correlate via FIFO with zero orphans.
+
+    Drives ``item_started_no_id.jsonl``: two ``command_execution`` items and one
+    ``mcp_tool_call`` item, all lacking ``id`` and arriving in start order.
+    Every ToolResultEvent must pair with a ToolStartEvent (id-set equality) and
+    no parser warning may fire.
+    """
+    backend = CodexBackend(model="fixture-model")
+    mock_proc = make_mock_process_from_fixture("item_started_no_id.jsonl")
+
+    with (
+        patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc),
+        caplog.at_level(logging.WARNING, logger="daydream.backends.codex"),
+    ):
+        events = []
+        async for event in backend.execute(Path("/tmp"), "Run tools"):
+            events.append(event)
+
+    tool_starts = [e for e in events if isinstance(e, ToolStartEvent)]
+    tool_results = [e for e in events if isinstance(e, ToolResultEvent)]
+    assert len(tool_starts) == 3
+    assert len(tool_results) == 3
+    start_ids = {e.id for e in tool_starts}
+    result_ids = {e.id for e in tool_results}
+    assert start_ids == result_ids, (
+        f"every tool result must pair with a tool start; starts={start_ids} results={result_ids}"
+    )
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert not warnings, [r.getMessage() for r in warnings]
+
+
+@pytest.mark.asyncio
+async def test_orphaned_tool_result_is_observable(caplog: pytest.LogCaptureFixture) -> None:
+    """Orphaned tool result (no matching item.started) emits an OBSERVABLE warning.
+
+    Drives ``orphaned_tool_result.jsonl``: a ``command_execution`` item.completed
+    with no preceding item.started. Pre-fix this silently bucketed the result
+    into ``unmatched_tool_results`` via a fresh random UUID. Post-fix the parser
+    must (a) log a WARNING identifiable from caplog and (b) emit the
+    ToolResultEvent with a deterministic ``codex-unmatched-<seq>`` id so the
+    trajectory recorder still buckets it without a silent drop.
+    """
+    backend = CodexBackend(model="fixture-model")
+    mock_proc = make_mock_process_from_fixture("orphaned_tool_result.jsonl")
+
+    with (
+        patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc),
+        caplog.at_level(logging.WARNING, logger="daydream.backends.codex"),
+    ):
+        events = []
+        async for event in backend.execute(Path("/tmp"), "Orphan"):
+            events.append(event)
+
+    tool_results = [e for e in events if isinstance(e, ToolResultEvent)]
+    assert len(tool_results) == 1
+    assert tool_results[0].id == "codex-unmatched-0", (
+        f"orphan should receive a deterministic sequence id; got {tool_results[0].id!r}"
+    )
+
+    warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("unmatched tool result" in w for w in warnings), (
+        f"expected an 'unmatched tool result' WARNING; got {warnings}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_malformed_structured_output_warns(caplog: pytest.LogCaptureFixture) -> None:
+    """Malformed structured-output agent_text emits an OBSERVABLE warning.
+
+    Drives ``malformed_structured_output.jsonl``: agent_text is the literal
+    string "this is not valid JSON" while ``output_schema`` is set. Pre-fix the
+    ``except json.JSONDecodeError: pass`` swallowed this and silently degraded
+    to ``structured_result=None``. Post-fix the parser must log a WARNING
+    identifiable from caplog; the ResultEvent continues to carry
+    ``structured_output=None`` (the schema parse genuinely failed).
+    """
+    backend = CodexBackend(model="fixture-model")
+    mock_proc = make_mock_process_from_fixture("malformed_structured_output.jsonl")
+    schema = {"type": "object", "properties": {"issues": {"type": "array"}}}
+
+    with (
+        patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc),
+        caplog.at_level(logging.WARNING, logger="daydream.backends.codex"),
+    ):
+        events = []
+        async for event in backend.execute(Path("/tmp"), "Parse", output_schema=schema):
+            events.append(event)
+
+    result_events = [e for e in events if isinstance(e, ResultEvent)]
+    assert len(result_events) == 1
+    assert result_events[0].structured_output is None
+
+    warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("structured output parse failed" in w for w in warnings), (
+        f"expected a 'structured output parse failed' WARNING; got {warnings}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("fixture", "expected_substring"),
+    [
+        # Top-level ``text`` wins (real Codex CLI format).
+        ("toplevel_text.jsonl", "Missing yield"),
+        # ``content[].type == "text"`` block extraction.
+        ("simple_text.jsonl", "Hello from Codex"),
+        # ``content[].type == "output_text"`` block extraction.
+        ("output_text_blocks.jsonl", "Bad import"),
+    ],
+)
+def test_text_extraction_precedence(fixture: str, expected_substring: str) -> None:
+    """Per-shape text extraction across the three Codex item shapes.
+
+    Each fixture exercises exactly one shape; ``_extract_text`` must return the
+    expected substring. The dedicated ``test_text_extraction_top_level_wins``
+    below pins the precedence between top-level ``text`` and ``content[]`` blocks
+    when both are present.
+    """
+    fixture_path = FIXTURES_DIR / fixture
+    lines = fixture_path.read_text().strip().split("\n")
+    items = [json.loads(line) for line in lines if "item.completed" in line]
+    candidates = [i["item"] for i in items if i["item"].get("type") == "agent_message"]
+    assert candidates, f"no agent_message item.completed in {fixture}"
+    extracted = CodexBackend._extract_text(candidates[0])
+    assert expected_substring in extracted, (
+        f"fixture={fixture} extracted={extracted!r} expected substring={expected_substring!r}"
+    )
+
+
+def test_text_extraction_top_level_wins_over_content_blocks() -> None:
+    """When BOTH top-level text and content[] blocks are set, top-level wins.
+
+    Pinning the precedence: the per-shape fixtures above each carry only one
+    shape, so this test fixes the relative ordering between the two paths.
+    """
+    item = {
+        "text": "TOP-LEVEL",
+        "content": [{"type": "text", "text": "BLOCK"}, {"type": "output_text", "text": "OUTPUT"}],
+    }
+    assert CodexBackend._extract_text(item) == "TOP-LEVEL"


### PR DESCRIPTION
## Summary

Resolves #153 (Codex parity G3). Parent epic: #157.

Hardens the three documented fragility points in the hand-rolled Codex JSONL parser:

1. **Tool-ID correlation** — the content-hash UUID fallback (`codex.py:189-202, 248-253, 287-293`) orphaned a `ToolResultEvent` whenever `item.started` content differed from `item.completed` content. Replaced with a **deterministic FIFO per `item_type`** (order-preserving, content-independent) as the primary path, with the legacy content-key as a secondary fallback. When both miss, the orphan is now **OBSERVABLE**: `logger.warning(...)` fires and the result gets a deterministic `codex-unmatched-<seq>` id so the trajectory recorder still buckets it via `unmatched_tool_results` (validator hard-fails on a dangling `source_call_id`) without a silent drop.

2. **Silent `JSONDecodeError` on structured-output parse** (`codex.py:332-333, 344-346`) — bare `pass` swallowed malformed payloads and silently degraded to `structured_result=None`. Replaced with `logger.warning(...)` carrying the raw payload; `structured_result` stays `None` (the parse genuinely failed) but the failure is now assertable via `caplog`. Raw-line `JSONDecodeError` (`codex.py:175`) keeps `continue` (Codex emits non-JSON status lines) but gains a debug log.

3. **Triple text-extraction precedence** (`codex.py:422-439`) — existing precedence is now pinned by per-shape parametrized tests over `toplevel_text.jsonl`, `simple_text.jsonl`, `output_text_blocks.jsonl`, plus an explicit test that top-level text wins over `content[]` blocks when both are present.

## Test plan

- [x] `uv run ruff check daydream` — clean
- [x] `uv run mypy daydream` — clean
- [x] `uv run pytest tests/test_backend_codex.py -v` — 36 passed (+7 new)
- [x] `uv run pytest tests/contract/ -v` — 2 passed (step-parity intact)
- [x] `uv run pytest -q` — 1613 passed, 1 skipped (was 1606; zero regressions)

New fixtures: `item_started_no_id.jsonl`, `orphaned_tool_result.jsonl`, `malformed_structured_output.jsonl`.

Build order: this is the foundation for #155 (trajectory assertions) and #154 (real-CLI golden), per epic #157.