### PR TITLE
test(backends/codex): ATIF trajectory parity — golden round-trip + D-04 fallback (#155)

### DIFF
--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -539,6 +539,19 @@ class Invocation:
         elif isinstance(event, MetricsEvent):
             # EVNT-02 attribute names verbatim (D-15: cached_tokens is a
             # SUBSET of prompt_tokens, not added).
+            #
+            # D-04 correlation fallback (Codex): Codex emits no per-message
+            # id, so MetricsEvent.message_id is always '' on the Codex path.
+            # In the common Codex case a TurnEndEvent closes the content Step
+            # before turn.completed fires, so this MetricsEvent arrives with
+            # no open Step and the ``target is None`` branch below opens a
+            # fresh Step to hold the metrics. Correlation is therefore
+            # TURN-granular for Codex — one MetricsEvent per turn.completed →
+            # one metrics-bearing Step per turn — which is coarser than
+            # Claude's per-message correlation via message_id. This is the
+            # documented, tested fallback for the missing id surface (see
+            # tests/contract/test_backend_codex_trajectory.py); it is not a
+            # silent coarsening.
             target = self._open_step_dict
             if target is None:
                 self._ensure_open_step()

--- a/tests/contract/test_backend_codex_trajectory.py
+++ b/tests/contract/test_backend_codex_trajectory.py
@@ -1,0 +1,179 @@
+"""ATIF trajectory parity for CodexBackend — golden round-trip + D-04 fallback (#155).
+
+Two contract tests over a real-shape multi-turn Codex JSONL fixture:
+
+1. **Correlation (D-04 fallback):** a multi-turn Codex fixture produces exactly
+   one ``MetricsEvent`` per ``turn.completed`` (turn-granular correlation),
+   each with ``message_id=''`` (Codex emits no per-message id). This is the
+   documented, tested limitation — no silent coarsening.
+
+2. **Golden round-trip:** the recorded trajectory validates cleanly against
+   the ATIF v1.6 schema, survives a load → re-validate cycle, and captures
+   REASON spans (ThinkingEvent), ACT/tool spans (ToolStart/ToolResult paired
+   via the item ``id``), ``Step.metrics`` with prompt/completion tokens, and
+   ``cached_tokens`` surfaced from ``usage.cached_input_tokens``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from daydream.atif.validator import TrajectoryValidator
+from daydream.backends import MetricsEvent
+from daydream.backends.codex import CodexBackend
+from daydream.trajectory import DaydreamPhase, DaydreamRunFlow, TrajectoryRecorder
+from tests.harness.codex_replay import make_mock_process_from_fixture
+
+FIXTURE = "multi_turn_with_metrics.jsonl"
+
+
+async def _drive_codex_through_recorder(
+    tmp_path: Path, *, fixture: str = FIXTURE
+) -> tuple[list[Any], TrajectoryRecorder]:
+    """Drive ``CodexBackend.execute`` through *fixture* while recording.
+
+    Mirrors the recorder + invocation pattern in
+    ``tests/contract/test_backend_step_parity.py`` /
+    ``_run_backend_against_canonical``: one ``TrajectoryRecorder``, one
+    ``Invocation`` scope, and the backend's ``AgentEvent`` stream fed to
+    ``inv.observe``. Returns the raw event list (for stream assertions) and
+    the recorder (for step assertions).
+    """
+    recorder = TrajectoryRecorder(
+        path=tmp_path / "trajectory.json",
+        run_flow=DaydreamRunFlow.NORMAL,
+        target_dir=tmp_path,
+        agent_model_name="codex-test-model",
+        session_id="00000000-0000-0000-0000-000000000155",
+    )
+    backend = CodexBackend(model="codex-test-model")
+    events: list[Any] = []
+    async with recorder:
+        async with recorder.invocation(phase=DaydreamPhase.REVIEW) as inv:
+            mock_proc = make_mock_process_from_fixture(fixture)
+            with patch(
+                "daydream.backends.codex.asyncio.create_subprocess_exec",
+                return_value=mock_proc,
+            ):
+                async for event in backend.execute(tmp_path, "review"):
+                    inv.observe(event)
+                    events.append(event)
+    return events, recorder
+
+
+@pytest.mark.asyncio
+async def test_codex_emits_one_turn_granular_metrics_event_per_turn(
+    tmp_path: Path,
+) -> None:
+    """D-04 fallback: one MetricsEvent per turn.completed, message_id always ''.
+
+    Codex has no per-message id surface (spike: agent_message items carry
+    ``id`` but no ``message_id``; ``turn.completed`` carries only ``usage``),
+    so correlation is turn-granular — coarser than Claude's per-message
+    correlation. The limitation is named here in code, not silently applied.
+    """
+    events, _ = await _drive_codex_through_recorder(tmp_path)
+
+    metrics_events = [e for e in events if isinstance(e, MetricsEvent)]
+    assert len(metrics_events) == 2, (
+        f"expected one MetricsEvent per turn (2 turns), got {len(metrics_events)}"
+    )
+    for idx, mev in enumerate(metrics_events, start=1):
+        assert mev.message_id == "", (
+            f"turn {idx}: Codex MetricsEvent.message_id must be '' (D-04), "
+            f"got {mev.message_id!r}"
+        )
+        assert mev.prompt_tokens > 0, (
+            f"turn {idx}: prompt_tokens non-positive ({mev.prompt_tokens})"
+        )
+        assert mev.completion_tokens > 0, (
+            f"turn {idx}: completion_tokens non-positive ({mev.completion_tokens})"
+        )
+    # Distinct token counts prove the two MetricsEvents originate from the two
+    # separate turn.completed events rather than a duplicated emission.
+    assert metrics_events[0].prompt_tokens != metrics_events[1].prompt_tokens
+
+
+@pytest.mark.asyncio
+async def test_codex_trajectory_golden_round_trip(tmp_path: Path) -> None:
+    """Recorded trajectory validates, round-trips, and spans REASON + ACT.
+
+    The fixture carries reasoning items (→ ThinkingEvent → reasoning_content =
+    REASON span), ``command_execution`` items with ``id`` fields (→ paired
+    ToolStart/ToolResult = ACT/tool span), and ``usage.cached_input_tokens``
+    (→ ``Step.metrics.cached_tokens`` non-None).
+    """
+    _, recorder = await _drive_codex_through_recorder(tmp_path)
+
+    traj_path = tmp_path / "trajectory.json"
+    assert traj_path.exists(), "recorder.__aexit__ must write trajectory.json"
+
+    # First validation pass on the freshly-written file.
+    validator = TrajectoryValidator()
+    first_ok = validator.validate(traj_path)
+    assert first_ok, validator.get_errors() or "first validation failed"
+
+    # Round-trip: re-load the written JSON, re-validate from dict form
+    # (validate_images=False — no filesystem anchor for in-memory dict).
+    raw = json.loads(traj_path.read_text())
+    rt_validator = TrajectoryValidator()
+    rt_ok = rt_validator.validate(raw, validate_images=False)
+    assert rt_ok, rt_validator.get_errors() or "round-trip validation failed"
+
+    agent_steps = [s for s in recorder.steps if s.source == "agent"]
+    assert agent_steps, "no agent steps recorded"
+
+    # REASON span: at least one step carries reasoning_content.
+    reason_steps = [s for s in agent_steps if s.reasoning_content]
+    assert reason_steps, "no REASON span (reasoning_content) captured"
+
+    # ACT/tool span: at least one step carries paired tool_calls + observation.
+    act_steps = [
+        s
+        for s in agent_steps
+        if s.tool_calls and s.observation and s.observation.results
+    ]
+    assert act_steps, "no ACT/tool span (tool_calls + observation) captured"
+    # ToolStart/ToolResult paired via the item 'id' field: each observation
+    # result's source_call_id must match a tool_call's tool_call_id on the
+    # same step (CORE-06).
+    for act_step in act_steps:
+        observation = act_step.observation
+        assert observation is not None and observation.results, (
+            f"ACT span on step {act_step.step_id}: observation/results missing"
+        )
+        call_ids = {tc.tool_call_id for tc in (act_step.tool_calls or [])}
+        result_ids = {r.source_call_id for r in observation.results}
+        assert result_ids & call_ids, (
+            f"ACT span on step {act_step.step_id}: tool result id {result_ids} "
+            f"not paired with tool call id {call_ids}"
+        )
+
+    # Step.metrics present with prompt/completion tokens (turn-granular, D-04).
+    metric_steps = [s for s in agent_steps if s.metrics is not None]
+    assert metric_steps, "no step carries metrics"
+    for ms in metric_steps:
+        metrics = ms.metrics
+        assert metrics is not None, f"step {ms.step_id}: metrics is None"
+        assert metrics.prompt_tokens is not None, (
+            f"step {ms.step_id}: metrics.prompt_tokens is None"
+        )
+        assert metrics.completion_tokens is not None, (
+            f"step {ms.step_id}: metrics.completion_tokens is None"
+        )
+
+    # cached_tokens surfaced from usage.cached_input_tokens (non-None).
+    cached_steps = [s for s in metric_steps if s.metrics is not None and s.metrics.cached_tokens is not None]
+    assert cached_steps, "no step carries non-None cached_tokens"
+    for cs in cached_steps:
+        metrics = cs.metrics
+        assert metrics is not None, f"step {cs.step_id}: metrics is None"
+        assert metrics.cached_tokens and metrics.cached_tokens > 0, (
+            f"step {cs.step_id}: cached_tokens not positive "
+            f"({metrics.cached_tokens})"
+        )

--- a/tests/contract/test_backend_codex_trajectory.py
+++ b/tests/contract/test_backend_codex_trajectory.py
@@ -149,9 +149,13 @@ async def test_codex_trajectory_golden_round_trip(tmp_path: Path) -> None:
         )
         call_ids = {tc.tool_call_id for tc in (act_step.tool_calls or [])}
         result_ids = {r.source_call_id for r in observation.results}
-        assert result_ids & call_ids, (
-            f"ACT span on step {act_step.step_id}: tool result id {result_ids} "
-            f"not paired with tool call id {call_ids}"
+        # issubset, not intersection: intersection (&) would only prove at
+        # least one match, letting a step with mixed matched/unmatched results
+        # pass false-green. Every result id must correspond to a call id.
+        assert result_ids.issubset(call_ids), (
+            f"ACT span on step {act_step.step_id}: unpaired tool result ids "
+            f"{sorted(str(r) for r in (result_ids - call_ids))} "
+            f"not present in tool call ids {sorted(str(c) for c in call_ids)}"
         )
 
     # Step.metrics present with prompt/completion tokens (turn-granular, D-04).

--- a/tests/fixtures/codex_jsonl/multi_turn_with_metrics.jsonl
+++ b/tests/fixtures/codex_jsonl/multi_turn_with_metrics.jsonl
@@ -1,0 +1,15 @@
+{"type":"thread.started","thread_id":"019eebb8-aaaa-aaaa-aaaa-000000000001"}
+{"type":"turn.started"}
+{"type":"item.started","item":{"id":"item_0","type":"reasoning","text":"","aggregated_output":"","status":"in_progress"}}
+{"type":"item.completed","item":{"id":"item_0","type":"reasoning","text":"Planning the review: inspect the diff, then run the tests."}}
+{"type":"item.started","item":{"id":"item_1","type":"command_execution","command":"/bin/zsh -lc 'git diff main...HEAD'","aggregated_output":"","exit_code":null,"status":"in_progress"}}
+{"type":"item.completed","item":{"id":"item_1","type":"command_execution","command":"/bin/zsh -lc 'git diff main...HEAD'","aggregated_output":"diff --git a/app.py b/app.py\n+def foo(): pass","exit_code":0,"status":"completed"}}
+{"type":"item.completed","item":{"id":"item_2","type":"agent_message","text":"Turn 1 complete: reviewed the diff and found one issue."}}
+{"type":"turn.completed","usage":{"input_tokens":34594,"cached_input_tokens":9984,"output_tokens":168,"reasoning_output_tokens":88}}
+{"type":"turn.started"}
+{"type":"item.started","item":{"id":"item_3","type":"reasoning","text":"","aggregated_output":"","status":"in_progress"}}
+{"type":"item.completed","item":{"id":"item_3","type":"reasoning","text":"Re-evaluating after the fix; the test suite should pass now."}}
+{"type":"item.started","item":{"id":"item_4","type":"command_execution","command":"/bin/zsh -lc 'pytest -q'","aggregated_output":"","exit_code":null,"status":"in_progress"}}
+{"type":"item.completed","item":{"id":"item_4","type":"command_execution","command":"/bin/zsh -lc 'pytest -q'","aggregated_output":"1 passed in 0.5s","exit_code":0,"status":"completed"}}
+{"type":"item.completed","item":{"id":"item_5","type":"agent_message","text":"Turn 2 complete: tests pass, issue resolved."}}
+{"type":"turn.completed","usage":{"input_tokens":36000,"cached_input_tokens":12000,"output_tokens":200,"reasoning_output_tokens":100}}


### PR DESCRIPTION
## Summary

Resolves #155 (Codex parity G5). Parent epic: #157.

Brings Codex ATIF trajectory parity up to Claude's standard on two axes.

**Part A — correlation (D-04 documented fallback):** A real-CLI spike on Codex 0.139.0 (codex exec --experimental-json) confirms there is **no per-message id surface** on Codex: agent_message items carry an id but no message_id, and turn.completed carries only usage. Decision D-04 therefore stands — MetricsEvent.message_id stays empty and correlation is **turn-granular** (one metrics-bearing Step per turn.completed), coarser than Claude's per-message correlation.

Rather than force a key that doesn't exist, the limitation is now **named in code** at the MetricsEvent observation site (daydream/trajectory.py:539) and **tested** — no silent coarsening.

**Part B — golden round-trip:** A new contract test drives CodexBackend.execute through a real-shape multi-turn fixture, records with TrajectoryRecorder, and validates the trajectory:
- validates cleanly against the ATIF v1.6 schema (TrajectoryValidator)
- round-trips: reloaded JSON re-validates
- REASON span captured (ThinkingEvent → reasoning_content)
- ACT/tool span captured (ToolStart/ToolResult paired via the item id field)
- Step.metrics present with prompt/completion tokens
- cached_tokens surfaced from usage.cached_input_tokens (non-None, positive)

The fixture (multi_turn_with_metrics.jsonl) matches the real Codex 0.139.0 JSONL shape captured in the spike: items with id fields, reasoning items, command_execution start/completed pairs, agent_message with top-level text, two turns each ending in turn.completed with distinct token counts.

## Spike finding (real Codex 0.139.0 JSONL)

Captured on gpt-5.5 against a tiny fixture repo. The event stream shape:

    thread.started -> turn.started -> item.started(id,type,command) ->
    item.completed(id,type,...) -> item.completed(id,agent_message,text) ->
    turn.completed(usage:{input_tokens, cached_input_tokens, output_tokens, reasoning_output_tokens})

Conclusions: items DO carry id (tool pairing works); no message_id/turn_id surface exists -> D-04 stands.

## Test plan

- [x] uv run ruff check daydream tests — clean
- [x] uv run mypy daydream tests — clean
- [x] uv run pytest tests/contract/ tests/test_backend_codex.py — 33 passed
- [x] uv run pytest -q — 1609 passed, 1 skipped (baseline for this branch off origin/main; no regressions)
- [x] Pre-push hook gate (lint + typecheck daydream+tests + non-integration suite) — passed

Build order: follows #153 (PR #187). Precedes #154 (real-CLI golden, which builds on this trajectory fixture).
