### PR TITLE
test(backends/codex): real-CLI golden contract test + skip-gated live smoke (#154)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,4 +75,5 @@ asyncio_default_fixture_loop_scope = "function"
 addopts = "--strict-markers"
 markers = [
     "integration: spawns a real `gh` subprocess (the fake shim); excluded from the pre-push gate, run in full CI. Applied automatically to any test using the `fake_gh` fixture.",
+    "live_codex: requires the real `codex` CLI on $PATH with valid auth; skipped automatically when codex is absent. Used by the real-CLI live smoke test in tests/test_codex_real_cli_contract.py.",
 ]

--- a/scripts/capture-codex-golden.sh
+++ b/scripts/capture-codex-golden.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Capture (or refresh) the REAL codex CLI golden fixture.
+#
+# Runs `codex exec --experimental-json --sandbox read-only` against the tiny
+# in-repo sample repo and writes the JSONL stdout to
+# tests/fixtures/codex_jsonl/real/golden.jsonl.
+#
+# WHEN TO REFRESH:
+#   - After a codex CLI version bump (codex --version).
+#   - After any change to the JSONL parser in daydream/backends/codex.py.
+#   - When you intentionally want to update the structural golden to match a
+#     new CLI/model output shape.
+#
+# REQUIREMENTS:
+#   - `codex` on $PATH (codex --version) with valid auth (ChatGPT or API).
+#   - The default model must be one the authenticated account can use.
+#
+# The committed golden is REAL output, not synthesized. Do not hand-edit it;
+# re-run this script instead.
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SAMPLE_REPO="$REPO_ROOT/tests/fixtures/real_cli_sample_repo"
+GOLDEN_OUT="$REPO_ROOT/tests/fixtures/codex_jsonl/real/golden.jsonl"
+
+if ! command -v codex >/dev/null 2>&1; then
+  echo "ERROR: codex CLI not found on PATH. Install/configure codex first." >&2
+  exit 1
+fi
+
+echo "→ codex version: $(codex --version)"
+echo "→ sample repo:   $SAMPLE_REPO"
+echo "→ golden output: $GOLDEN_OUT"
+echo "→ prompt: read README.md then hello.py, then describe both"
+
+# Read prompt from stdin, run read-only so nothing mutates the sample repo.
+echo "Read README.md, then read hello.py, then describe both files in one sentence each." \
+  | codex exec --experimental-json --sandbox read-only > "$GOLDEN_OUT"
+
+LINES=$(wc -l < "$GOLDEN_OUT" | tr -d ' ')
+echo "✓ captured $LINES JSONL lines"
+echo "  commit the refreshed golden with the codex version in the message."

--- a/tests/fixtures/codex_jsonl/real/README.md
+++ b/tests/fixtures/codex_jsonl/real/README.md
@@ -1,0 +1,42 @@
+# Real codex CLI golden fixture
+
+`golden.jsonl` is a **real** capture of `codex exec --experimental-json` output
+(codex CLI 0.139.0), committed so the parser can be checked against genuine CLI
+output rather than synthesized fixtures. It is NOT hand-written; do not edit it
+by hand.
+
+## How it was captured
+
+- **CLI:** `codex` 0.139.0 (`codex --version`).
+- **Command:** `echo "<prompt>" | codex exec --experimental-json --sandbox read-only`
+  (prompt read from stdin, read-only sandbox so nothing mutates the sample repo).
+- **Model:** the account default at capture time (`gpt-5.5`).
+- **Sample repo:** `tests/fixtures/real_cli_sample_repo/` (a 2-file git repo:
+  `README.md` + `hello.py`).
+- **Prompt:** "Read README.md, then read hello.py, then describe both files in
+  one sentence each."
+- **Result:** 8 JSONL lines — `thread.started`, `turn.started`, two
+  `command_execution` start/completed pairs (ids `item_0`, `item_1`), an
+  `agent_message` (`item_2`), and a `turn.completed` carrying `usage` with
+  `input_tokens` / `cached_input_tokens` / `output_tokens` /
+  `reasoning_output_tokens`.
+
+To re-capture, run `scripts/capture-codex-golden.sh` and commit the refreshed
+file (mention the codex CLI version in the commit message).
+
+## When to refresh
+
+- After a `codex` CLI version bump.
+- After any change to the JSONL parser in `daydream/backends/codex.py`.
+- When intentionally updating the structural golden to a new CLI/model shape.
+
+## What the contract test asserts
+
+`tests/test_codex_real_cli_contract.py::test_real_golden_parses_to_expected_events`
+drives `CodexBackend.execute` through this golden and asserts **structural**
+coverage (not byte-exact text, so a model swap that rewords the agent message
+still passes): a text span, two paired tool calls with **zero orphans** (the
+#153 deterministic-correlation contract re-asserted on real data), a
+`MetricsEvent` with prompt/completion tokens and `cached_tokens` surfaced from
+`cached_input_tokens`, and a `ResultEvent`. If the parser or the CLI shape
+drifts, this test fails.

--- a/tests/fixtures/codex_jsonl/real/golden.jsonl
+++ b/tests/fixtures/codex_jsonl/real/golden.jsonl
@@ -1,0 +1,8 @@
+{"type":"thread.started","thread_id":"019eebc6-d5d9-77f0-94ce-7941850b8b8b"}
+{"type":"turn.started"}
+{"type":"item.started","item":{"id":"item_0","type":"command_execution","command":"/bin/zsh -lc \"sed -n '1,220p' README.md\"","aggregated_output":"","exit_code":null,"status":"in_progress"}}
+{"type":"item.completed","item":{"id":"item_0","type":"command_execution","command":"/bin/zsh -lc \"sed -n '1,220p' README.md\"","aggregated_output":"# Sample\nA tiny repo for codex trajectory capture.\n","exit_code":0,"status":"completed"}}
+{"type":"item.started","item":{"id":"item_1","type":"command_execution","command":"/bin/zsh -lc \"sed -n '1,220p' hello.py\"","aggregated_output":"","exit_code":null,"status":"in_progress"}}
+{"type":"item.completed","item":{"id":"item_1","type":"command_execution","command":"/bin/zsh -lc \"sed -n '1,220p' hello.py\"","aggregated_output":"def greet():\n    return \"hello\"\n","exit_code":0,"status":"completed"}}
+{"type":"item.completed","item":{"id":"item_2","type":"agent_message","text":"`README.md` describes a tiny sample repository for Codex trajectory capture.\n\n`hello.py` defines a `greet()` function that returns `\"hello\"`."}}
+{"type":"turn.completed","usage":{"input_tokens":52101,"cached_input_tokens":39040,"output_tokens":225,"reasoning_output_tokens":79}}

--- a/tests/fixtures/real_cli_sample_repo/README.md
+++ b/tests/fixtures/real_cli_sample_repo/README.md
@@ -1,0 +1,2 @@
+# Sample
+A tiny repo for codex trajectory capture.

--- a/tests/fixtures/real_cli_sample_repo/hello.py
+++ b/tests/fixtures/real_cli_sample_repo/hello.py
@@ -1,0 +1,2 @@
+def greet():
+    return "hello"

--- a/tests/test_codex_real_cli_contract.py
+++ b/tests/test_codex_real_cli_contract.py
@@ -1,0 +1,190 @@
+# tests/test_codex_real_cli_contract.py
+"""Contract checks against REAL codex CLI output (parser-drift guard).
+
+Two layers, per issue #154:
+
+1. ``test_real_golden_parses_to_expected_events`` (always-on): drives
+   ``CodexBackend.execute`` through a committed golden fixture derived from
+   REAL ``codex exec --experimental-json`` output (codex 0.139.0). Asserts
+   the parser produces a structurally-correct ``AgentEvent`` stream with zero
+   orphaned tool results — the #153 contract re-asserted on real data. This
+   catches parser drift the next time someone re-captures the golden and the
+   CLI shape has changed. Structural assertions are version-robust (not
+   byte-exact) so a model/CLI swap that rewords the agent text still passes.
+
+2. ``test_codex_live_smoke`` (Layer 2, skip-gated): marked ``live_codex`` and
+   skipped cleanly when the ``codex`` binary is not on ``$PATH`` (no red CI
+   for contributors without the binary). When codex IS present it runs a
+   trivial review against the in-repo sample repo and asserts a non-empty
+   ``AgentEvent`` stream + clean trajectory, logging any unrecognized JSONL
+   event types.
+
+The golden is committed at ``tests/fixtures/codex_jsonl/real/golden.jsonl``;
+see ``tests/fixtures/codex_jsonl/real/README.md`` for the capture/refresh
+procedure, and ``scripts/capture-codex-golden.sh`` to re-capture.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import shutil
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from daydream.backends import (
+    MetricsEvent,
+    ResultEvent,
+    TextEvent,
+    ToolResultEvent,
+    ToolStartEvent,
+)
+from daydream.backends.codex import CodexBackend
+from tests.harness.codex_replay import FIXTURES_DIR, make_mock_process_from_fixture
+
+REAL_GOLDEN = "real/golden.jsonl"
+
+_logger = logging.getLogger(__name__)
+
+
+@pytest.mark.asyncio
+async def test_real_golden_parses_to_expected_events() -> None:
+    """The committed REAL codex golden parses to a structurally-correct stream.
+
+    The golden is genuine ``codex exec --experimental-json`` output (codex
+    0.139.0, see the fixture README). This asserts the parser still agrees
+    with the live CLI on the observed event coverage: a text span, paired
+    tool calls (zero orphans — the #153 contract), per-turn metrics with
+    prompt/completion tokens, and a result event. Assertions are structural,
+    not byte-exact, so re-capturing on a new model that rewords the agent
+    message still passes.
+    """
+    assert (FIXTURES_DIR / REAL_GOLDEN).exists(), (
+        f"real golden missing at {FIXTURES_DIR / REAL_GOLDEN}"
+    )
+
+    backend = CodexBackend(model="real-golden-model")
+    mock_proc = make_mock_process_from_fixture(REAL_GOLDEN)
+
+    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
+        events: list[Any] = []
+        async for event in backend.execute(Path("/tmp"), "Read README.md then hello.py"):
+            events.append(event)
+
+    # Text span: agent_message produced at least one TextEvent.
+    text_events = [e for e in events if isinstance(e, TextEvent)]
+    assert text_events, "real golden produced no TextEvent (agent_message lost)"
+
+    # Tool spans: the golden has TWO command_execution pairs (README + hello.py).
+    tool_starts = [e for e in events if isinstance(e, ToolStartEvent)]
+    tool_results = [e for e in events if isinstance(e, ToolResultEvent)]
+    assert len(tool_starts) == 2, f"expected 2 tool starts, got {len(tool_starts)}"
+    assert len(tool_results) == 2, f"expected 2 tool results, got {len(tool_results)}"
+
+    # Zero orphans: every ToolResultEvent.id pairs with a ToolStartEvent.id.
+    # This re-asserts the #153 deterministic-correlation contract on REAL data.
+    start_ids = {e.id for e in tool_starts}
+    result_ids = {e.id for e in tool_results}
+    assert result_ids == start_ids, (
+        f"orphaned tool result on real data: starts={start_ids} results={result_ids}"
+    )
+
+    # Per-turn metrics: turn.completed yields a MetricsEvent with prompt AND
+    # completion tokens, and cached_tokens surfaced from cached_input_tokens.
+    metrics_events = [e for e in events if isinstance(e, MetricsEvent)]
+    assert metrics_events, "real golden produced no MetricsEvent (usage lost)"
+    mev = metrics_events[0]
+    assert mev.prompt_tokens is not None and mev.prompt_tokens > 0, (
+        f"real usage input_tokens not surfaced: {mev.prompt_tokens}"
+    )
+    assert mev.completion_tokens is not None and mev.completion_tokens > 0, (
+        f"real usage output_tokens not surfaced: {mev.completion_tokens}"
+    )
+    assert mev.cached_tokens is not None and mev.cached_tokens > 0, (
+        f"real cached_input_tokens not surfaced: {mev.cached_tokens}"
+    )
+
+    # Result event present (turn.completed → ResultEvent with continuation).
+    result_events = [e for e in events if isinstance(e, ResultEvent)]
+    assert result_events, "real golden produced no ResultEvent"
+
+
+@pytest.mark.live_codex
+@pytest.mark.asyncio
+async def test_codex_live_smoke() -> None:
+    """Live smoke against the real codex binary — skipped when codex is absent.
+
+    Proves the subprocess seam, arg construction, and parser still agree with
+    the live CLI. Skipped cleanly (no red CI) when ``codex`` is not on PATH.
+    Any unrecognized JSONL event type is logged at WARNING for triage.
+    """
+    if shutil.which("codex") is None:
+        pytest.skip("codex CLI not available on PATH")
+
+    sample_repo = Path(__file__).parent / "fixtures" / "real_cli_sample_repo"
+    prompt = "Read README.md and summarize it in one sentence."
+
+    proc = await asyncio.create_subprocess_exec(
+        "codex",
+        "exec",
+        "--experimental-json",
+        "--sandbox",
+        "read-only",
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    if proc.stdout is None or proc.stdin is None:
+        pytest.skip("could not open codex stdio")
+    proc.stdin.write(prompt.encode())
+    proc.stdin.close()
+
+    # Collect the raw JSONL lines, logging any line that is not valid JSON or
+    # carries an unrecognized event type (the drift signal this test exists to
+    # surface, per the issue's "log any unrecognized JSONL event types").
+    known_types = {
+        "thread.started",
+        "turn.started",
+        "turn.completed",
+        "turn.failed",
+        "item.started",
+        "item.updated",
+        "item.completed",
+        "error",
+    }
+    lines: list[str] = []
+    assert proc.stdout is not None
+    while True:
+        raw = await proc.stdout.readline()
+        if not raw:
+            break
+        text = raw.decode().strip()
+        if not text:
+            continue
+        try:
+            evt = json.loads(text)
+        except json.JSONDecodeError:
+            _logger.warning("codex live smoke: non-JSON line: %r", text[:120])
+            continue
+        etype = evt.get("type", "")
+        if etype not in known_types:
+            _logger.warning("codex live smoke: unrecognized event type %r", etype)
+        lines.append(text)
+    await proc.wait()
+
+    assert lines, "codex live smoke produced no JSONL output"
+
+    # Feed the live lines through the parser and assert a non-empty stream.
+    backend = CodexBackend(model="live-smoke-model")
+    from tests.harness.codex_replay import make_mock_process
+
+    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=make_mock_process(lines)):
+        events: list[Any] = []
+        async for event in backend.execute(sample_repo, prompt):
+            events.append(event)
+
+    assert events, "codex live smoke parsed to an empty AgentEvent stream"


### PR DESCRIPTION
## Summary

Resolves #154 (Codex parity G4). Parent epic: #157.

Adds a CI contract check that catches Codex JSONL parser drift against **REAL** codex CLI output (codex 0.139.0). Every recorded "Codex Backend Gotcha" came from real-CLI surprises the synthesized fixtures didn't predict; this closes that gap.

**Layer 1 (always-on):** `test_real_golden_parses_to_expected_events` drives `CodexBackend.execute` through a committed golden fixture derived from **real** `codex exec --experimental-json` output (codex 0.139.0, captured against the in-repo sample repo — NOT synthesized). Asserts structural coverage:
- a text span (agent_message → TextEvent)
- **two paired tool calls with zero orphans** — the #153 deterministic-correlation contract re-asserted on REAL data (every ToolResultEvent.id pairs with a ToolStartEvent.id)
- a MetricsEvent with prompt/completion tokens and cached_tokens surfaced from `cached_input_tokens`
- a ResultEvent

Structural assertions are version-robust (not byte-exact), so re-capturing on a new model that rewords the agent message still passes. If the parser or the CLI shape drifts, the test fails.

**Layer 2 (skip-gated):** `test_codex_live_smoke` (marked `live_codex`) runs a trivial review against the sample repo with the real binary when `codex` is on `$PATH`; skips cleanly when absent (no red CI for contributors without the binary). Logs any unrecognized JSONL event types.

## The golden

`tests/fixtures/codex_jsonl/real/golden.jsonl` — genuine capture from `codex exec --experimental-json --sandbox read-only` (codex 0.139.0, default model `gpt-5.5`). 8 lines: `thread.started`, `turn.started`, two `command_execution` start/completed pairs (item_0, item_1), an `agent_message` (item_2), `turn.completed` with full usage. Refresh with `scripts/capture-codex-golden.sh`; procedure documented in `tests/fixtures/codex_jsonl/real/README.md`.

## Test plan

- [x] `uv run ruff check daydream tests` — clean
- [x] `uv run mypy daydream tests` — clean (209 files)
- [x] `uv run pytest tests/test_codex_real_cli_contract.py -v` — 2 passed (golden + live smoke; live smoke runs here since codex is local, skips in CI without codex)
- [x] `uv run pytest -q` — 1610 passed, 1 skipped, zero failures
- [x] Pre-push hook gate (ruff + mypy daydream+tests + non-integration suite) — passed

Build order: follows #153 (PR #187) and #155 (PR #188). The live_codex marker is registered in pyproject.toml alongside `integration`.
