### PR TITLE
test(pricing): pin user-override cost synthesis for unknown Codex models (#156)

### DIFF
--- a/tests/test_pr_comment_renderer.py
+++ b/tests/test_pr_comment_renderer.py
@@ -12,6 +12,8 @@ import re
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from daydream.pr_comment_renderer import _PHASE_LABELS, _format_duration, render_run_info_block
 from daydream.trajectory import DaydreamPhase
 
@@ -197,6 +199,55 @@ def test_m6_unknown_model_renders_dash_and_footnote(tmp_path: Path) -> None:
     assert "| —" in out
     assert "mystery-model" in out
     assert "not in the price table" in out
+
+
+# M6b — user price override synthesizes cost for an otherwise-unknown model (#156)
+def test_m6b_user_override_synthesizes_cost_for_unknown_model(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A user-supplied price (via DAYDREAM_PRICES_FILE) for an unknown Codex
+    model produces a SYNTHESIZED cost — not a dash and not the unavailable
+    footnote.
+
+    Extends M6: without the override the model renders '—' (cost unavailable).
+    With the override the renderer's resolve_prices(load_user_prices()) merges
+    it in and compute_cost synthesizes a dollar figure. This is the #156/#61
+    acceptance criterion #1 (Codex cost synthesis reads the overridable table).
+    """
+    prices_file = tmp_path / "prices.toml"
+    prices_file.write_text(
+        '[prices."custom-codex-op"]\ninput = 2.0\ncached_input = 0.5\noutput = 8.0\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DAYDREAM_PRICES_FILE", str(prices_file))
+
+    p = _write_trajectory(
+        tmp_path,
+        model="custom-codex-op",
+        steps=[
+            {
+                "step_id": 1,
+                "timestamp": "2026-05-02T00:00:00.000000Z",
+                "source": "user",
+                "message": "go",
+                "extra": {"daydream_phase": "review", "daydream_run_flow": "ttt"},
+            },
+            _agent_step(
+                step_id=2,
+                phase="review",
+                model="custom-codex-op",
+                prompt=1_000_000,
+                completion=0,
+                cached=0,
+                cost_usd=None,
+            ),
+        ],
+    )
+    out = render_run_info_block([p])
+    # 1M uncached input * $2.00/1M = $2.00 synthesized (no cost_usd from backend).
+    assert "- **Cost:** $2.00" in out
+    # The unavailable footnote must NOT appear — the model IS priced via override.
+    assert "not in the price table" not in out
 
 
 # M7 — mixed-model label

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -290,3 +290,30 @@ def test_compute_cost_uses_override_prices() -> None:
         output_tokens=0,
     )
     assert builtin == pytest.approx(5.0)
+
+
+def test_resolve_prices_adds_unknown_model_then_compute_cost_succeeds() -> None:
+    """Chaining resolve → compute for a genuinely-unknown model (#156 #1).
+
+    An override for a model NOT in MODEL_PRICES must land in the merged table
+    and make compute_cost return a non-None synthesized value. The individual
+    building blocks (load, resolve-per-model, compute-with-prices) are tested
+    above; this asserts the full chain that the Codex cost-synthesis renderer
+    relies on (resolve_prices(load_user_prices()) → compute_cost).
+    """
+    overrides = {"private-finetune": ModelPrice(input=3.0, cached_input=1.0, output=12.0)}
+    merged = resolve_prices(overrides)
+    # The unknown model is now present; built-ins are preserved unchanged.
+    assert "private-finetune" in merged
+    assert "gpt-5.5" in merged
+    assert merged["gpt-5.5"] == MODEL_PRICES["gpt-5.5"]
+    cost = compute_cost(
+        model="private-finetune",
+        input_tokens=500_000,
+        cached_input_tokens=100_000,
+        output_tokens=1_000,
+        prices=merged,
+    )
+    assert cost is not None
+    # 500K*3/1M + 100K*1/1M + 1K*12/1M = 1.5 + 0.1 + 0.012 = 1.612
+    assert cost == pytest.approx(1.612)


### PR DESCRIPTION
## Summary

Resolves #156 (Codex parity G6). Parent epic: #157. Related: #61 (closed).

Most of the cost-synthesis infrastructure shipped with #61: `resolve_prices(load_user_prices())` is wired into the renderer (`pr_comment_renderer.py:215`), the explicit "Cost unavailable: model not in the price table" marker already renders (`_render_unknown_models_note`), and M5/M6 already cover Claude no-regression and the unavailable-marker path.

This closes the **one remaining gap**: criterion #1 had no end-to-end test proving a user-supplied price for an **unknown** Codex model synthesizes a cost (the wiring existed but was untested at the renderer level).

## What's added

- `tests/test_pr_comment_renderer.py::test_m6b_user_override_synthesizes_cost_for_unknown_model` — writes a `prices.toml` override (via `DAYDREAM_PRICES_FILE`) for a model absent from `MODEL_PRICES`, renders a trajectory on that model, and asserts a synthesized dollar figure (not a dash) **and** that the unavailable footnote does NOT appear. This is the renderer-level end-to-end assertion of the #156/#61 acceptance criterion #1.

- `tests/test_pricing.py::test_resolve_prices_adds_unknown_model_then_compute_cost_succeeds` — chains `resolve_prices` → `compute_cost` for a genuinely-unknown model at the pricing layer (the building blocks were individually tested; this asserts the full chain the renderer relies on).

## All three acceptance criteria now have tests

1. **user-supplied price → synthesized cost** — NEW (M6b + pricing chain test)
2. **no price → explicit unavailable marker** — EXISTING (M6: `"not in the price table" in out`)
3. **no Claude regression** — EXISTING (M5: Claude `cost_usd` used verbatim, $5.50 total)

## Test plan

- [x] `uv run ruff check daydream tests` — clean
- [x] `uv run mypy daydream tests` — clean (207 files)
- [x] `uv run pytest` for the 4 related tests (M5, M6, M6b, pricing chain) — 4 passed
- [x] `uv run pytest -q` — 1608 passed, 1 skipped, zero failures
- [x] Pre-push hook gate (ruff + mypy daydream+tests + non-integration suite) — passed

Build order: last of the parity epic (#153 → #155 → #154 → #156).
