### PR TITLE
fix(backends/codex): resolve CodeRabbit review on #154 golden capture/smoke (#189 follow-up)

### DIFF
--- a/scripts/capture-codex-golden.sh
+++ b/scripts/capture-codex-golden.sh
@@ -36,8 +36,10 @@ echo "→ golden output: $GOLDEN_OUT"
 echo "→ prompt: read README.md then hello.py, then describe both"
 
 # Read prompt from stdin, run read-only so nothing mutates the sample repo.
+# --cd pins the codex working directory to SAMPLE_REPO so the golden is always
+# captured against the in-repo sample repo, never the caller's cwd.
 echo "Read README.md, then read hello.py, then describe both files in one sentence each." \
-  | codex exec --experimental-json --sandbox read-only > "$GOLDEN_OUT"
+  | codex exec --experimental-json --sandbox read-only --cd "$SAMPLE_REPO" > "$GOLDEN_OUT"
 
 LINES=$(wc -l < "$GOLDEN_OUT" | tr -d ' ')
 echo "✓ captured $LINES JSONL lines"

--- a/tests/fixtures/codex_jsonl/real/README.md
+++ b/tests/fixtures/codex_jsonl/real/README.md
@@ -36,7 +36,7 @@ file (mention the codex CLI version in the commit message).
 drives `CodexBackend.execute` through this golden and asserts **structural**
 coverage (not byte-exact text, so a model swap that rewords the agent message
 still passes): a text span, two paired tool calls with **zero orphans** (the
-#153 deterministic-correlation contract re-asserted on real data), a
+`#153` deterministic-correlation contract re-asserted on real data), a
 `MetricsEvent` with prompt/completion tokens and `cached_tokens` surfaced from
 `cached_input_tokens`, and a `ResultEvent`. If the parser or the CLI shape
 drifts, this test fails.

--- a/tests/test_codex_real_cli_contract.py
+++ b/tests/test_codex_real_cli_contract.py
@@ -134,6 +134,8 @@ async def test_codex_live_smoke() -> None:
         "--experimental-json",
         "--sandbox",
         "read-only",
+        "--cd",
+        str(sample_repo),
         stdin=asyncio.subprocess.PIPE,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
@@ -156,7 +158,11 @@ async def test_codex_live_smoke() -> None:
         "item.completed",
         "error",
     }
+    # Failure event types that indicate a broken live run; their presence must
+    # fail the test rather than pass false-green on a non-empty-but-failed stream.
+    failure_types = {"turn.failed", "error"}
     lines: list[str] = []
+    failures: list[str] = []
     assert proc.stdout is not None
     while True:
         raw = await proc.stdout.readline()
@@ -173,10 +179,14 @@ async def test_codex_live_smoke() -> None:
         etype = evt.get("type", "")
         if etype not in known_types:
             _logger.warning("codex live smoke: unrecognized event type %r", etype)
+        if etype in failure_types:
+            failures.append(etype)
         lines.append(text)
-    await proc.wait()
+    rc = await proc.wait()
 
     assert lines, "codex live smoke produced no JSONL output"
+    assert rc == 0, f"codex live smoke exited non-zero: rc={rc}"
+    assert not failures, f"codex live smoke reported failure events: {failures}"
 
     # Feed the live lines through the parser and assert a non-empty stream.
     backend = CodexBackend(model="live-smoke-model")


### PR DESCRIPTION
## Summary

Follow-up to #189 (merged), resolving the 4 CodeRabbit findings whose review (`CHANGES_REQUESTED`, r3449007206 / r3449007210 / r3449007211 / r3449007213) was merged past. This PR addresses all four:

1. **`scripts/capture-codex-golden.sh`** — `SAMPLE_REPO` was defined but never passed to `codex exec`, so the golden could be captured against the caller's cwd instead of the in-repo sample repo. Added `--cd "$SAMPLE_REPO"`.

2. **`tests/fixtures/codex_jsonl/real/README.md`** — a line began with `#153`, which markdown parses as an ATX heading (markdownlint MD018). Escaped as `` `#153` ``.

3. **`tests/test_codex_real_cli_contract.py` (live smoke)** — `sample_repo` was computed but never passed to the codex subprocess, so the smoke test could validate the wrong working tree. Added `--cd str(sample_repo)`.

4. **Same test** — only asserted non-empty output, so a non-zero exit or failure events (`turn.failed`/`error`) would pass false-green. Now asserts `rc == 0` and that no failure event types appear in the stream.

## Context

The original #189 was merged despite CodeRabbit's `CHANGES_REQUESTED` review. This was a beagle-workflow ordering bug (feedback ran post-merge instead of pre-merge), which has been fixed in the beagle-workflow + beagle-queue skills (Phase 7 feedback now runs before the Phase 8 merge gate, which independently gh-api-verifies no blocking reviews). This PR resolves the skipped review comments themselves.

## Test plan

- [x] `uv run ruff check daydream tests` — clean
- [x] `uv run mypy daydream tests` — clean (209 files)
- [x] `uv run pytest tests/test_codex_real_cli_contract.py -v` — 2 passed (golden + live smoke; live smoke now asserts rc==0 and no failure events)
- [x] Pre-push hook gate — passed
