### PR TITLE
feat(backends/codex): event-layer cost synthesis for provider parity (#194)

### DIFF
--- a/daydream/backends/__init__.py
+++ b/daydream/backends/__init__.py
@@ -100,8 +100,9 @@ class CostEvent:
     """Cost and usage information (end-of-call signal feeding FinalMetrics).
 
     Attributes:
-        cost_usd: Total cost in USD; None when unavailable (Codex always
-            None per D-16).
+        cost_usd: Total cost in USD; None when unavailable. Codex synthesizes
+            via the #61 price table (#194 reverses D-16); None only when the
+            model is unknown to the table.
         input_tokens: Prompt tokens (None when unavailable).
         output_tokens: Completion tokens (None when unavailable).
         cached_tokens: Cached portion of input_tokens (subset, NOT added
@@ -156,11 +157,11 @@ class MetricsEvent:
             (Claude ``usage["output_tokens"]``, Codex
             ``usage["output_tokens"]``) and rename at the boundary.
         cached_tokens: Subset of ``prompt_tokens`` served from cache
-            (None when unavailable; Codex always None per D-16). NOT
-            additive to ``prompt_tokens`` (D-15).
-        cost_usd: Per-turn cost in USD (None when unavailable; Codex
-            always None per D-16 — DO NOT synthesize from a token-price
-            table).
+            (None when unavailable). NOT additive to ``prompt_tokens``
+            (D-15).
+        cost_usd: Per-turn cost in USD (None when unavailable). Codex
+            synthesizes via the #61 price table (#194 reverses D-16); None
+            only when the model is unknown to the table.
         reasoning_tokens: Reasoning portion of ``completion_tokens``
             (subset, NOT additive — Codex's ``accounting.rs`` already
             counts these inside ``output_tokens``). Surfaces Codex's

--- a/daydream/backends/codex.py
+++ b/daydream/backends/codex.py
@@ -29,6 +29,7 @@ from daydream.backends import (
     ToolStartEvent,
     TurnEndEvent,
 )
+from daydream.pricing import compute_cost, load_user_prices, resolve_prices
 
 _SHELL_WRAPPER_RE = re.compile(r"/bin/(?:zsh|bash|sh)\s+-lc\s+(.+)$", re.DOTALL)
 _CD_PREFIX_RE = re.compile(r"^cd\s+\S+\s*&&\s*")
@@ -351,10 +352,13 @@ class CodexBackend:
                 elif event_type == "turn.completed":
                     usage = event.get("usage", {})
                     # EVNT-07: MetricsEvent per turn (empty message_id — Codex has no
-                    # per-message id). cost_usd stays None — DO NOT synthesize from a
-                    # token-price table (D-16). cached_input_tokens IS surfaced (#65, K4).
-                    # Rename input/output_tokens → prompt/completion; skip if either
-                    # missing (EVNT-02 requires both). CostEvent below carries partials.
+                    # per-message id). #194 reverses D-16: the CLI emits no cost field,
+                    # so we now synthesize from tokens via the #61 user-overridable price
+                    # table (Claude/Pi parity). None when the model is unknown to the
+                    # table (preserves the #156 observable-marker). cached_input_tokens
+                    # IS surfaced (#65, K4). Rename input/output_tokens → prompt/completion;
+                    # skip if either missing (EVNT-02 requires both). CostEvent below
+                    # carries partials.
                     #
                     # #192: reasoning_output_tokens is the reasoning portion of
                     # output_tokens — a SUBSET, NOT additive (codex's own
@@ -364,20 +368,34 @@ class CodexBackend:
                     # COUNT only — no reasoning content (openai/codex#26428).
                     cached_tokens = usage.get("cached_input_tokens")
                     reasoning_tokens = usage.get("reasoning_output_tokens")
-                    if usage.get("input_tokens") is not None and usage.get("output_tokens") is not None:
+                    in_tok = usage.get("input_tokens")
+                    out_tok = usage.get("output_tokens")
+                    # cached_input_tokens is a SUBSET of input_tokens (D-15);
+                    # compute_cost expects uncached input. Clamp at 0 (mirror
+                    # pr_comment_renderer:346).
+                    cached = cached_tokens or 0
+                    uncached_input = max((in_tok or 0) - cached, 0)
+                    synth_cost = compute_cost(
+                        model=self.model,
+                        input_tokens=uncached_input,
+                        cached_input_tokens=cached,
+                        output_tokens=out_tok or 0,
+                        prices=resolve_prices(load_user_prices()),
+                    )
+                    if in_tok is not None and out_tok is not None:
                         yield MetricsEvent(
                             message_id="",
-                            prompt_tokens=usage["input_tokens"],
-                            completion_tokens=usage["output_tokens"],
+                            prompt_tokens=in_tok,
+                            completion_tokens=out_tok,
                             cached_tokens=cached_tokens,
-                            cost_usd=None,
+                            cost_usd=synth_cost,
                             reasoning_tokens=reasoning_tokens,
                             model_name=self.model,
                         )
                     yield CostEvent(
-                        cost_usd=None,
-                        input_tokens=usage.get("input_tokens"),
-                        output_tokens=usage.get("output_tokens"),
+                        cost_usd=synth_cost,
+                        input_tokens=in_tok,
+                        output_tokens=out_tok,
                         cached_tokens=cached_tokens,
                         reasoning_tokens=reasoning_tokens,
                         model_name=self.model,

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -87,10 +87,6 @@ try:
 except ImportError:  # pragma: no cover -- only hit when Phases 1-4 absent
     EXPLORATION_AVAILABLE = False
 
-# Codex backend class used for isinstance() in the pre-flight notice
-# (D-31 cost_usd=None caveat). Imported here so tests can monkeypatch it.
-from daydream.backends.codex import CodexBackend  # noqa: E402
-
 # Per-file block splitter (splits the unified diff at each `diff --git` header).
 _DIFF_BLOCK_SPLIT = re.compile(r"^(?=diff --git )", re.MULTILINE)
 # `+++ ` and `--- ` file headers inside a single block.
@@ -499,18 +495,13 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
         skill_availability = installed if installed is not None else set(SKILL_MAP.keys())
         stacks = detect_stacks(changed_files, skill_availability=skill_availability)
 
-        # Pre-flight notice (D-30, D-31).
+        # Pre-flight notice (D-30).
         stack_lines = [_stack_preflight_line(s) for s in stacks]
-        # Review-centric preflight: the cost_usd=None caveat fires when the
-        # review-phase backend is Codex. Other per-phase backends may differ
-        # but the notice is anchored on the review stage.
-        review_backend_for_preflight = _resolve_backend(config, "review", backend_cache)
         print_preflight_notice(
             console,
             stages=_PIPELINE_STAGE_NAMES,
             stack_lines=stack_lines,
             agent_count=total_agent_count(len(stacks)),
-            codex_in_use=isinstance(review_backend_for_preflight, CodexBackend),
             exploration_available=EXPLORATION_AVAILABLE,
         )
 

--- a/daydream/ui/summary.py
+++ b/daydream/ui/summary.py
@@ -431,21 +431,21 @@ def print_preflight_notice(
     stages: list[str],
     stack_lines: list[str],
     agent_count: int,
-    codex_in_use: bool,
     exploration_available: bool,
 ) -> None:
-    """Print the deep-mode pre-flight notice (D-30, D-31).
+    """Print the deep-mode pre-flight notice (D-30).
 
     Lists the stages, detected stacks, skill per stack, and total agent
-    count. Surfaces the ``cost_usd=None`` caveat when the Codex backend
-    is in use, because the Codex CLI does not report per-stage cost.
+    count. The D-31 ``cost_usd=None`` caveat was removed when #194 reversed
+    D-16 (Codex now synthesizes cost at the backend layer); per-model
+    unpriceable cases surface via the renderer's "cost unavailable" marker
+    (#156) at render time instead.
 
     Args:
         console: Rich Console instance for output.
         stages: Ordered list of stage display names.
         stack_lines: Per-stack human-readable summary lines.
         agent_count: Total agent invocation count (D-30 formula).
-        codex_in_use: True when any active backend is Codex (D-31).
         exploration_available: True when the exploration infrastructure
             (Phases 1-4) is installed and the pre-scan is wired in.
     """
@@ -464,8 +464,3 @@ def print_preflight_notice(
     for line in stack_lines:
         console.print(f"    - {line}")
     console.print(f"[neon.fg]  Total agents: {agent_count}[/]")
-    if codex_in_use:
-        console.print(
-            "[neon.yellow]  ⚠ Codex backend: per-stage cost_usd=None "
-            "(cost not reported by codex CLI)[/]"
-        )

--- a/tests/test_backend_codex.py
+++ b/tests/test_backend_codex.py
@@ -25,7 +25,8 @@ from daydream.backends.codex import (
     CodexError,
     _unwrap_shell_command,
 )
-from tests.harness.codex_replay import make_mock_process_from_fixture
+from daydream.pricing import compute_cost, load_user_prices, resolve_prices
+from tests.harness.codex_replay import make_mock_process, make_mock_process_from_fixture
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures" / "codex_jsonl"
 
@@ -47,7 +48,17 @@ async def test_simple_text_events():
     assert len(text_events) == 1
     assert text_events[0].text == "Hello from Codex"
     assert len(cost_events) == 1
-    assert cost_events[0].cost_usd is None
+    # #194: gpt-5.3-codex is in MODEL_PRICES → cost is now synthesized at the
+    # backend layer (D-16 reversed), matching compute_cost for these tokens.
+    expected_cost = compute_cost(
+        model="gpt-5.3-codex",
+        input_tokens=100,
+        cached_input_tokens=0,
+        output_tokens=50,
+        prices=resolve_prices(load_user_prices()),
+    )
+    assert cost_events[0].cost_usd is not None
+    assert cost_events[0].cost_usd == pytest.approx(expected_cost)
     assert cost_events[0].input_tokens == 100
     assert cost_events[0].output_tokens == 50
     assert len(result_events) == 1
@@ -327,12 +338,96 @@ async def test_turn_completed_cached_input_tokens():
     assert metrics_events[0].prompt_tokens == 300
     assert metrics_events[0].completion_tokens == 150
     assert metrics_events[0].cached_tokens == 200
+    # fixture-model is unknown to the price table → cost_usd stays None (#156
+    # observable-marker preserved after #194 reversed D-16).
     assert metrics_events[0].cost_usd is None
 
     assert len(cost_events) == 1
     assert cost_events[0].input_tokens == 300
     assert cost_events[0].output_tokens == 150
     assert cost_events[0].cached_tokens == 200
+
+
+@pytest.mark.asyncio
+async def test_codex_synthesizes_cost_for_known_model() -> None:
+    """#194: a known-priced model synthesizes cost at the backend layer.
+
+    Drives a turn.completed with gpt-5.5 (in MODEL_PRICES) and known token
+    counts. Both MetricsEvent and CostEvent must carry a non-None cost_usd
+    matching compute_cost for the uncached-input/cached/output split. Mirrors
+    how Claude (SDK total_cost_usd) and Pi (usage.cost.total) populate cost
+    at the event layer. Reverses D-16.
+    """
+    backend = CodexBackend(model="gpt-5.5")
+    # input_tokens is the TOTAL (cached is a subset per D-15); 15000 total
+    # with 5000 cached → 10000 uncached. output 2000.
+    lines = [
+        '{"type":"thread.started","thread_id":"th_synth"}',
+        '{"type":"item.completed","item":{"type":"agent_message","text":"ok"}}',
+        '{"type":"turn.completed","usage":{"input_tokens":15000,'
+        '"cached_input_tokens":5000,"output_tokens":2000}}',
+    ]
+
+    mock_proc = make_mock_process(lines)
+    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
+        events = []
+        async for event in backend.execute(Path("/tmp"), "Synth"):
+            events.append(event)
+
+    expected = compute_cost(
+        model="gpt-5.5",
+        input_tokens=10_000,  # uncached = 15000 - 5000
+        cached_input_tokens=5_000,
+        output_tokens=2_000,
+        prices=resolve_prices(load_user_prices()),
+    )
+    assert expected is not None
+
+    metrics_events = [e for e in events if isinstance(e, MetricsEvent)]
+    cost_events = [e for e in events if isinstance(e, CostEvent)]
+    assert len(metrics_events) == 1
+    assert len(cost_events) == 1
+    mev = metrics_events[0]
+    cev = cost_events[0]
+    assert mev.cost_usd is not None and mev.cost_usd > 0
+    assert cev.cost_usd is not None and cev.cost_usd > 0
+    assert mev.cost_usd == pytest.approx(expected)
+    assert cev.cost_usd == pytest.approx(expected)
+    # Token wiring unchanged: cached surfaced, input/output renamed.
+    assert mev.prompt_tokens == 15_000
+    assert mev.completion_tokens == 2_000
+    assert mev.cached_tokens == 5_000
+
+
+@pytest.mark.asyncio
+async def test_codex_cost_none_for_unknown_model() -> None:
+    """#156 preserved after #194: a model unknown to the price table yields cost_usd=None.
+
+    Drives a turn.completed with ``definitely-not-a-real-model`` (absent from
+    MODEL_PRICES and any user override). compute_cost returns None, so both
+    MetricsEvent and CostEvent keep cost_usd=None — the observable marker that
+    downstream renderers use to show "cost unavailable".
+    """
+    backend = CodexBackend(model="definitely-not-a-real-model")
+    lines = [
+        '{"type":"thread.started","thread_id":"th_unknown"}',
+        '{"type":"item.completed","item":{"type":"agent_message","text":"ok"}}',
+        '{"type":"turn.completed","usage":{"input_tokens":1000,'
+        '"cached_input_tokens":200,"output_tokens":50}}',
+    ]
+
+    mock_proc = make_mock_process(lines)
+    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
+        events = []
+        async for event in backend.execute(Path("/tmp"), "Unknown"):
+            events.append(event)
+
+    metrics_events = [e for e in events if isinstance(e, MetricsEvent)]
+    cost_events = [e for e in events if isinstance(e, CostEvent)]
+    assert len(metrics_events) == 1
+    assert len(cost_events) == 1
+    assert metrics_events[0].cost_usd is None
+    assert cost_events[0].cost_usd is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_backend_codex_metrics.py
+++ b/tests/test_backend_codex_metrics.py
@@ -1,14 +1,15 @@
-"""Tests for Codex backend MetricsEvent emission (EVNT-07, D-16).
+"""Tests for Codex backend MetricsEvent emission (EVNT-07).
 
 Verifies that the Codex backend emits a MetricsEvent at every
-``turn.completed`` event with the documented parity gap:
+``turn.completed`` event with the documented shape:
 
-- ``cost_usd`` is ALWAYS None (Codex CLI does not report USD cost; D-16
-  decision: do NOT synthesize from a token-price table — Pitfall 6).
-- ``cached_tokens`` is ALWAYS None (Codex ``turn.completed.usage`` has
-  no cached-token field).
-- ``message_id`` is the empty string "" (Codex has no per-message id
-  surface; D-16).
+- ``cost_usd`` is synthesized from tokens via the #61 price table for known
+  models (#194 reverses D-16 — Codex now matches Claude/Pi by populating
+  cost at the backend layer). It stays None for models unknown to the table
+  (#156 observable marker).
+- ``cached_tokens`` mirrors ``cached_input_tokens`` from usage (None when the
+  CLI omits the field).
+- ``message_id`` is the empty string "" (Codex has no per-message id; D-04).
 
 The legacy CostEvent emission is preserved so FinalMetrics aggregation
 still works for Codex runs.
@@ -26,6 +27,7 @@ from daydream.backends import (
     MetricsEvent,
 )
 from daydream.backends.codex import CodexBackend
+from daydream.pricing import compute_cost, load_user_prices, resolve_prices
 
 # Reuse the shared JSONL-stream mock helper from tests/harness — single
 # source of truth for the mock-process shape (Pitfall: do NOT re-implement
@@ -35,7 +37,11 @@ from tests.harness.codex_replay import make_mock_process_from_fixture as _make_m
 
 @pytest.mark.asyncio
 async def test_metrics_event_emitted_at_turn_completed():
-    """turn.completed with full usage produces MetricsEvent with EVNT-02 field names (EVNT-07)."""
+    """turn.completed with full usage produces MetricsEvent with EVNT-02 field names (EVNT-07).
+
+    Model gpt-5.3-codex is in MODEL_PRICES, so #194 synthesizes cost at the
+    backend layer; the value must match compute_cost for these tokens.
+    """
     backend = CodexBackend(model="gpt-5.3-codex")
     mock_proc = _make_mock_process("turn_completed_with_usage.jsonl")
     with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
@@ -45,16 +51,30 @@ async def test_metrics_event_emitted_at_turn_completed():
     metrics = [e for e in events if isinstance(e, MetricsEvent)]
     assert len(metrics) == 1
     m = metrics[0]
-    assert m.message_id == ""              # D-16: Codex parity gap — no per-message id
+    assert m.message_id == ""              # D-04: Codex has no per-message id
     assert m.prompt_tokens == 200          # EVNT-02 verbatim (NOT input_tokens)
     assert m.completion_tokens == 100      # EVNT-02 verbatim (NOT output_tokens)
-    assert m.cached_tokens is None         # D-16: Codex parity gap
-    assert m.cost_usd is None              # D-16: Codex parity gap
+    assert m.cached_tokens is None         # fixture carries no cached_input_tokens
+    expected = compute_cost(
+        model="gpt-5.3-codex",
+        input_tokens=200,
+        cached_input_tokens=0,
+        output_tokens=100,
+        prices=resolve_prices(load_user_prices()),
+    )
+    assert expected is not None
+    assert m.cost_usd is not None          # #194: synthesized at the backend layer
+    assert m.cost_usd == pytest.approx(expected)
 
 
 @pytest.mark.asyncio
 async def test_cost_event_still_emitted():
-    """The legacy CostEvent emission is preserved (so FinalMetrics aggregation works for Codex too)."""
+    """The legacy CostEvent emission is preserved (so FinalMetrics aggregation works for Codex too).
+
+    Model ``fixture-model`` is unknown to the price table, so cost_usd stays
+    None here (#156); a known model would synthesize (see test_metrics_event
+    above and test_backend_codex.py::test_codex_synthesizes_cost_for_known_model).
+    """
     backend = CodexBackend(model="fixture-model")
     mock_proc = _make_mock_process("turn_completed_with_usage.jsonl")
     with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
@@ -66,7 +86,7 @@ async def test_cost_event_still_emitted():
     assert cost[0].input_tokens == 200     # CostEvent keeps SDK boundary names
     assert cost[0].output_tokens == 100
     assert cost[0].cached_tokens is None
-    assert cost[0].cost_usd is None
+    assert cost[0].cost_usd is None        # fixture-model unknown → #156 marker
 
 
 @pytest.mark.asyncio
@@ -84,18 +104,3 @@ async def test_partial_usage_skips_metrics_event():
     cost = [e for e in events if isinstance(e, CostEvent)][0]
     assert cost.input_tokens == 200
     assert cost.output_tokens is None
-
-
-@pytest.mark.asyncio
-async def test_codex_parity_gap_d16():
-    """D-16: cost_usd and cached_tokens are ALWAYS None for Codex; no token-price-table synthesis."""
-    backend = CodexBackend(model="fixture-model")
-    mock_proc = _make_mock_process("turn_completed_with_usage.jsonl")
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
-        events = []
-        async for event in backend.execute(Path("/tmp"), "test"):
-            events.append(event)
-    for e in events:
-        if isinstance(e, (MetricsEvent, CostEvent)):
-            assert e.cost_usd is None
-            assert e.cached_tokens is None

--- a/tests/test_backend_conformance.py
+++ b/tests/test_backend_conformance.py
@@ -52,9 +52,11 @@ CANONICAL_SCRIPT: dict[str, Any] = json.loads(
 # - Codex MetricsEvent.message_id == "": Codex has no per-message id; the
 #   backend emits MetricsEvent with message_id="" once per turn.completed
 #   (daydream/backends/codex.py:333).
-# - Codex CostEvent.cost_usd is None: Codex's turn.completed.usage carries no
-#   cost; the backend always yields CostEvent(cost_usd=None)
-#   (daydream/backends/codex.py:341).
+# - Codex CostEvent.cost_usd is None: the conformance loader drives a sentinel
+#   model (``codex-test-model``) that is absent from the price table, so #194's
+#   backend-layer synthesis yields None (#156). A production priced model
+#   (e.g. gpt-5.5) would synthesize a non-None cost; that path is covered by
+#   tests/test_backend_codex.py and tests/test_codex_real_cli_contract.py.
 KNOWN_DELTAS: dict[str, dict[str, Any]] = {
     "codex": {
         "metrics_message_id": "",
@@ -101,7 +103,8 @@ async def test_backend_conformance(loader: Loader) -> None:
     metrics = [e for e in events if isinstance(e, MetricsEvent)]
     costs = [e for e in events if isinstance(e, CostEvent)]
     if driver == "codex":
-        # Codex carries no per-message id and no cost.
+        # Codex carries no per-message id; cost is None only because the
+        # conformance loader's sentinel model is unpriced (see KNOWN_DELTAS).
         assert all(m.message_id == deltas["metrics_message_id"] for m in metrics)
         assert all(c.cost_usd is deltas["cost_usd"] for c in costs)
     else:

--- a/tests/test_codex_real_cli_contract.py
+++ b/tests/test_codex_real_cli_contract.py
@@ -67,7 +67,7 @@ async def test_real_golden_parses_to_expected_events() -> None:
         f"real golden missing at {FIXTURES_DIR / REAL_GOLDEN}"
     )
 
-    backend = CodexBackend(model="real-golden-model")
+    backend = CodexBackend(model="gpt-5.5")
     mock_proc = make_mock_process_from_fixture(REAL_GOLDEN)
 
     with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
@@ -112,6 +112,12 @@ async def test_real_golden_parses_to_expected_events() -> None:
     # completion_tokens, NOT additive.
     assert mev.reasoning_tokens is not None and mev.reasoning_tokens > 0, (
         f"real reasoning_output_tokens not surfaced: {mev.reasoning_tokens}"
+    )
+    # #194: gpt-5.5 is in MODEL_PRICES → cost is synthesized at the backend
+    # layer (D-16 reversed). The golden's tokens are non-trivial, so the
+    # synthesized cost must be non-None and strictly positive.
+    assert mev.cost_usd is not None and mev.cost_usd > 0, (
+        f"real golden cost not synthesized for gpt-5.5: {mev.cost_usd}"
     )
 
     # Result event present (turn.completed → ResultEvent with continuation).

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -36,12 +36,10 @@ class _StubBackend:
         target: Path,
         *,
         model: str = "mock-model",
-        is_codex: bool = False,
         shared_calls: list[dict[str, Any]] | None = None,
     ) -> None:
         self.model = model
         self._target = target
-        self._is_codex = is_codex
         # When set, every execute() call is also appended (model-tagged) to this
         # shared list so a per-(name, model) factory can capture which model ran
         # each phase even though backends are cached by (name, model) (#168).
@@ -438,7 +436,6 @@ def _install_stub_backend(
     monkeypatch: pytest.MonkeyPatch,
     target: Path,
     *,
-    is_codex: bool = False,
     pin_skill_availability: bool = True,
     enable_exploration: bool = False,
 ) -> _StubBackend:
@@ -457,12 +454,8 @@ def _install_stub_backend(
             specialist prompts. Default False preserves the existing behavior
             (exploration disabled) that the rest of the suite relies on.
     """
-    stub = _StubBackend(target, is_codex=is_codex)
+    stub = _StubBackend(target)
     monkeypatch.setattr("daydream.runner.create_backend", lambda name, model=None: stub)
-    # Patch CodexBackend to the stub's class so the orchestrator's isinstance check
-    # fires without a real Codex dependency.
-    if is_codex:
-        monkeypatch.setattr("daydream.deep.orchestrator.CodexBackend", _StubBackend, raising=False)
     if pin_skill_availability:
         # None -> orchestrator falls back to set(SKILL_MAP.keys()).
         monkeypatch.setattr("daydream.deep.orchestrator.get_installed_skills", lambda: None)
@@ -1155,13 +1148,12 @@ async def test_preflight_notice(multi_stack_target: Path, monkeypatch: pytest.Mo
     """D-30: pre-flight notice lists stages, stacks, skill per stack, total agent count."""
     captured: list[dict[str, Any]] = []
 
-    def _capture(console, *, stages, stack_lines, agent_count, codex_in_use, exploration_available) -> None:
+    def _capture(console, *, stages, stack_lines, agent_count, exploration_available) -> None:
         captured.append(
             {
                 "stages": stages,
                 "stack_lines": stack_lines,
                 "agent_count": agent_count,
-                "codex_in_use": codex_in_use,
                 "exploration_available": exploration_available,
             }
         )
@@ -1181,26 +1173,6 @@ async def test_preflight_notice(multi_stack_target: Path, monkeypatch: pytest.Mo
     # fixture yields N=4 (python + react + generic + structure), so 2 + 2*4 + 1 + 1 = 12.
     assert notice["agent_count"] == 12
     assert len(notice["stack_lines"]) >= 1
-    # No Codex caveat on Claude backend.
-    assert notice["codex_in_use"] is False
-
-
-async def test_codex_cost_caveat(multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """D-31: Codex backend triggers the cost_usd=None caveat in the notice."""
-    captured: list[dict[str, Any]] = []
-
-    def _capture(console, *, stages, stack_lines, agent_count, codex_in_use, exploration_available) -> None:
-        captured.append({"codex_in_use": codex_in_use})
-
-    monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
-    monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", _capture)
-    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "n")
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
-    _install_stub_backend(monkeypatch, multi_stack_target, is_codex=True)
-
-    exit_code = await _run_deep(multi_stack_target)
-    assert exit_code == 0
-    assert captured[0]["codex_in_use"] is True
 
 
 async def test_resume_per_stack_reruns_all(multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1948,7 +1920,7 @@ async def test_resolve_backend_called_with_each_phase_in_deep_flow(
     exit_code = await _run_deep(multi_stack_target)
     assert exit_code == 0
 
-    expected_phases = {"intent", "wonder", "review", "parse", "merge", "fix", "test", "verify"}
+    expected_phases = {"intent", "wonder", "per_stack_review", "parse", "merge", "fix", "test", "verify"}
     captured = set(seen_phases)
     missing = expected_phases - captured
     assert not missing, (


### PR DESCRIPTION
## Summary

Resolves #194. Codex now synthesizes cost at the **backend layer** — matching how Claude (SDK `total_cost_usd`) and Pi (`usage.cost.total`) populate `cost_usd` on events. The synthesized value flows to every consumer (live UI, manifest, eval, trajectory, PR comment) via the existing `CostEvent`/`MetricsEvent` path.

**The gap this closes:** cost synthesis existed only at PR-comment render time (`pr_comment_renderer._accumulate_metrics`), downstream of events. Every other consumer read `cost_usd` directly from the events — which was `None` for Codex. Result: the live terminal UI showed "⚠ Codex backend: per-stage cost_usd=None", archived manifests showed `total_cost_usd: 0.0`, and eval saw `cost_usd: 0.0`. Now the backend synthesizes via the #61 price table and populates the events, so all consumers see the real synthesized cost.

**Reverses D-16** ("DO NOT synthesize cost from a token-price table"). D-16 was correct when made (no price table existed); now #61 shipped the user-overridable table, so the rationale no longer holds.

## What changed (9 files)

- **`daydream/backends/codex.py`** — in the `turn.completed` block, calls `compute_cost(model, uncached_input, cached, output, prices=resolve_prices(load_user_prices()))` and puts the result into both `MetricsEvent.cost_usd` and `CostEvent.cost_usd`. Module-level import of `daydream.pricing`. Cached-input subset clamp mirrors the renderer (`uncached = max(input - cached, 0)`). Unknown model → `None` (preserves #156).
- **`daydream/backends/__init__.py`** — `MetricsEvent.cost_usd` and `CostEvent.cost_usd` docstrings revised: removed "Codex always None per D-16 — DO NOT synthesize"; now documents the #194 reversal.
- **`daydream/ui/summary.py`** — removed the "⚠ Codex backend: per-stage cost_usd=None" pre-flight warning (D-16 artifact; no longer accurate). Removed the `codex_in_use` param.
- **`daydream/deep/orchestrator.py`** — removed the preflight `_resolve_backend(config, "review", ...)` call that existed only for the D-31 cost-caveat check, plus the `CodexBackend` isinstance import.
- **Renderer** — NO change. Its `if metrics.cost_usd is not None: use verbatim` branch now fires for Codex (skipping the `else synthesize` fallback). M5/M6 tests confirm no regression.
- **Tests** — new `test_codex_synthesizes_cost_for_known_model` (gpt-5.5, known tokens → non-None cost matching `compute_cost`) + `test_codex_cost_none_for_unknown_model` (unknown model → None, #156 preserved). Real-CLI golden test asserts `mev.cost_usd > 0` (gpt-5.5 is in MODEL_PRICES). Removed the D-16 ghost tests (asserted `cost_usd always None` — exactly the behavior reversed). Fixed `test_resolve_backend_called_with_each_phase_in_deep_flow` to assert `"per_stack_review"` (the real phase) instead of `"review"` (a preflight side-effect).

## Architectural parity (the pattern followed)

```
Claude: SDK provides total_cost_usd  → CostEvent(cost_usd=…)  [event layer]
Pi:     stream provides cost.total   → MetricsEvent + CostEvent(cost_usd=…)  [event layer]
Codex:  CLI provides NO cost         → NOW synthesizes via #61 table → MetricsEvent + CostEvent(cost_usd=…)  [event layer]
```

## Test plan

- [x] `uv run ruff check daydream tests` — clean
- [x] `uv run mypy daydream tests` — clean (210 files)
- [x] `uv run pytest` targeted (codex + pricing + renderer + contract + real-golden) — 100 passed, 1 skipped
- [x] M5 (Claude $5.50 verbatim) + M6 (unknown-model dash) — both pass (no regression)
- [x] `uv run pytest -q -m "not live_codex"` — 1621 passed, 1 skipped, 1 deselected
- [x] Pre-push hook gate — passed
