### PR TITLE
perf(deep): make verify conditional, demote intent to Sonnet, gate alternatives by diff size (#171)

### DIFF
--- a/daydream/config.py
+++ b/daydream/config.py
@@ -49,8 +49,8 @@ DEFAULT_TOOL_CALL_BUDGET = 50
 #
 # Claude tiering:
 #   - cheap (haiku):   PARSE
-#   - mid   (sonnet):  FIX, TEST, EXPLORATION, PER_STACK_REVIEW
-#   - heavy (opus):    REVIEW, WONDER, ENVISION, MERGE, INTENT, PR_FEEDBACK, ARBITER
+#   - mid   (sonnet):  FIX, TEST, EXPLORATION, PER_STACK_REVIEW, INTENT
+#   - heavy (opus):    REVIEW, WONDER, ENVISION, MERGE, PR_FEEDBACK, ARBITER
 #
 # ``per_stack_review`` and ``arbiter`` split the deep per-stack fan-out off the
 # heavy ``review`` tier (issue #168): the N per-stack reviewers run on Sonnet
@@ -78,7 +78,7 @@ PHASE_DEFAULT_MODELS: dict[str, dict[str, str]] = {
         "wonder": "claude-opus-4-8",
         "envision": "claude-opus-4-8",
         "merge": "claude-opus-4-8",
-        "intent": "claude-opus-4-8",
+        "intent": "claude-sonnet-4-6",
         "pr_feedback": "claude-opus-4-8",
     },
     "codex": {

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -575,13 +575,17 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
                 )
 
                 print_stage_progress(console, 2, 5, _PIPELINE_STAGE_NAMES[1])
-                alt_issues = await phase_alternative_review(
-                    _resolve_backend(config, "wonder", backend_cache),
-                    work,
-                    diff_path,
-                    intent_summary,
-                    exploration_dir=exploration_dir,
-                )
+                if select_tier(count_changed_files(diff)) == "skip":
+                    alt_issues: list[dict[str, Any]] = []
+                    print_dim(console, "Skipping alternatives -- trivial diff")
+                else:
+                    alt_issues = await phase_alternative_review(
+                        _resolve_backend(config, "wonder", backend_cache),
+                        work,
+                        diff_path,
+                        intent_summary,
+                        exploration_dir=exploration_dir,
+                    )
 
                 intent_p, alts_p = _write_ttt_artifacts(
                     dd, intent_summary=intent_summary, alt_issues=alt_issues
@@ -789,17 +793,6 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
                 if deep_copy.exists():
                     merged_report.write_text(deep_copy.read_text())
 
-            # Recommendation verification (issue #83). Runs unconditionally so a
-            # --start-at fix resume still produces verdicts; read-only and idempotent.
-            # Must precede both PR posting and the y/N gate regardless of resume entry.
-            verdicts_file, verdicts_payload = await phase_verify_recommendations(
-                _resolve_backend(config, "verify", backend_cache),
-                work,
-                merged_items_path=merged_items_path(dd),
-                deep_dir=dd,
-            )
-            print_verification_summary(console, verdicts_file)
-
             # Offer to post findings as inline PR review comments.
             # `post_review_to_pr_from_report` is a non-idempotent GitHub write, so
             # `--start-at fix` (resume after the merged report) must skip it to
@@ -837,8 +830,20 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
             # tier so equal-severity items keep their canonical merge order.
             items = severity_sorted(items)
 
+            # Recommendation verification (#83). Runs ONLY after the apply-fixes
+            # gate accepts, so a declined run (non-interactive / EOF / explicit "N")
+            # skips both the verify pass and the recommendation-verdicts.json
+            # artifact. A --start-at fix resume still produces verdicts whenever
+            # fixes are applied (the gate still runs on resume; accept => verify runs).
+            verdicts_file, verdicts_payload = await phase_verify_recommendations(
+                _resolve_backend(config, "verify", backend_cache),
+                work,
+                merged_items_path=merged_items_path(dd),
+                deep_dir=dd,
+            )
+            print_verification_summary(console, verdicts_file)
+
             # Attach verifier verdicts to items by `id` (advisory; phase_fix reads them).
-            verdicts_payload = verdicts_payload if isinstance(verdicts_payload, dict) else {"verdicts": []}
             items = _attach_verdicts(items, verdicts_payload)
             matched_ids = [i["id"] for i in items if i.get("verifier_verdict") is not None]
             unmatched_ids = [

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -455,6 +455,9 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
     daydream_dir.mkdir(exist_ok=True)
     diff_path = daydream_dir / "diff.patch"
     diff_path.write_text(diff)
+    # Diff is immutable from here on; compute the tiering verdict once and reuse
+    # it at both the exploration gate and the alternatives gate below.
+    tier = select_tier(count_changed_files(diff))
     dd = deep_dir(target_dir)
 
     session_id = str(uuid.uuid4())
@@ -514,7 +517,6 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
                 "without pre-scan grounding",
             )
         elif config.exploration_context is None:
-            tier = select_tier(count_changed_files(diff))
             if tier == "skip":
                 print_dim(console, "Skipping exploration -- trivial diff")
                 config.exploration_context = ExplorationContext()
@@ -575,7 +577,7 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
                 )
 
                 print_stage_progress(console, 2, 5, _PIPELINE_STAGE_NAMES[1])
-                if select_tier(count_changed_files(diff)) == "skip":
+                if tier == "skip":
                     alt_issues: list[dict[str, Any]] = []
                     print_dim(console, "Skipping alternatives -- trivial diff")
                 else:

--- a/daydream/training/harvest.py
+++ b/daydream/training/harvest.py
@@ -28,11 +28,9 @@ Signal sources (all under the archived run directory):
 
 Failure-propagation rules:
 
-* Absent verdicts ⇒ ``verifier_verdicts=None`` with the format gate intact —
-  expected for two run shapes keyed off the manifest's ``deep`` flag
-  (``row["deep"]``), not file presence: a shallow run (``deep`` false) never
-  produces verdicts, and a declined deep run (``deep`` true) skips
-  recommendation verification at the apply-fixes gate.
+* Absent verdicts ⇒ ``verifier_verdicts=None`` with the format gate intact.
+  Expected for a shallow run and, after the verify relocation, a declined
+  deep run that skipped recommendation verification at the apply-fixes gate.
 * A *present* verdicts/records file that is malformed JSON ⇒ caught as
   :class:`json.JSONDecodeError` and surfaced as ``format_valid=False``;
   assembly never crashes on bad data.
@@ -183,19 +181,15 @@ def assemble_scoring_inputs(run_dir: Path, row: dict[str, Any]) -> ScoringInputs
     review-output length proxy, combining them with the indexed
     ``grounding_rate`` into the capture-time signals the reward reducer
     consumes. Absent verdicts yield ``verifier_verdicts=None`` and leave the
-    format gate intact; this is expected for *two* run shapes, keyed off the
-    manifest's ``deep`` flag (``row["deep"]``, emitted by
-    ``archive/manifest.py``) rather than the verdicts file's presence: a
-    genuine shallow run (``deep`` false) and a declined deep run (``deep``
-    true) whose recommendation-verification was skipped at the apply-fixes
-    gate. A present-but-malformed structured artifact sets
-    ``format_valid=False`` without raising.
+    format gate intact — expected for a shallow run and, after the verify
+    relocation, a declined deep run whose recommendation verification was
+    skipped at the apply-fixes gate. A present-but-malformed structured
+    artifact sets ``format_valid=False`` without raising.
 
     Args:
         run_dir: The archived run directory (bronze bundle root).
         row: The indexed manifest row; ``row["grounding_rate"]`` supplies the
-            grounding axis (``None`` when unavailable) and ``row["deep"]``
-            classifies the verdicts-absent case (shallow vs. declined deep).
+            grounding axis (``None`` when unavailable).
 
     Returns:
         A :class:`ScoringInputs` with the verdicts list (or ``None``), the
@@ -214,13 +208,9 @@ def assemble_scoring_inputs(run_dir: Path, row: dict[str, Any]) -> ScoringInputs
         if isinstance(verdicts, list):
             verifier_verdicts = verdicts
     except FileNotFoundError:
-        # No structured verdicts; nothing failed to parse. Expected for two run
-        # shapes, distinguished by the manifest's ``deep`` flag (row["deep"]) —
-        # not by this file's presence: a shallow run (deep false) never produces
-        # verdicts, and after the verify relocation a declined deep run (deep
-        # true) skips recommendation verification at the apply-fixes gate, so it
-        # writes the deep bundle without a verdicts file. Both yield
-        # ``verifier_verdicts=None`` with the format gate intact.
+        # No structured verdicts; nothing failed to parse. Expected for a
+        # shallow run and, after the verify relocation, a declined deep run
+        # that skipped recommendation verification at the apply-fixes gate.
         pass
     except json.JSONDecodeError:
         # Present but malformed ⇒ format gate floors.

--- a/daydream/training/harvest.py
+++ b/daydream/training/harvest.py
@@ -28,8 +28,11 @@ Signal sources (all under the archived run directory):
 
 Failure-propagation rules:
 
-* Absent structured artifacts ⇒ ``verifier_verdicts=None`` (the shallow-run
-  path); ``format_valid`` stays ``True`` because nothing failed to parse.
+* Absent verdicts ⇒ ``verifier_verdicts=None`` with the format gate intact —
+  expected for two run shapes keyed off the manifest's ``deep`` flag
+  (``row["deep"]``), not file presence: a shallow run (``deep`` false) never
+  produces verdicts, and a declined deep run (``deep`` true) skips
+  recommendation verification at the apply-fixes gate.
 * A *present* verdicts/records file that is malformed JSON ⇒ caught as
   :class:`json.JSONDecodeError` and surfaced as ``format_valid=False``;
   assembly never crashes on bad data.
@@ -179,14 +182,20 @@ def assemble_scoring_inputs(run_dir: Path, row: dict[str, Any]) -> ScoringInputs
     Reads the structured bronze artifacts under ``run_dir/deep`` and the
     review-output length proxy, combining them with the indexed
     ``grounding_rate`` into the capture-time signals the reward reducer
-    consumes. Absent artifacts yield the shallow-run path
-    (``verifier_verdicts=None``); a present-but-malformed structured
-    artifact sets ``format_valid=False`` without raising.
+    consumes. Absent verdicts yield ``verifier_verdicts=None`` and leave the
+    format gate intact; this is expected for *two* run shapes, keyed off the
+    manifest's ``deep`` flag (``row["deep"]``, emitted by
+    ``archive/manifest.py``) rather than the verdicts file's presence: a
+    genuine shallow run (``deep`` false) and a declined deep run (``deep``
+    true) whose recommendation-verification was skipped at the apply-fixes
+    gate. A present-but-malformed structured artifact sets
+    ``format_valid=False`` without raising.
 
     Args:
         run_dir: The archived run directory (bronze bundle root).
         row: The indexed manifest row; ``row["grounding_rate"]`` supplies the
-            grounding axis (``None`` when unavailable).
+            grounding axis (``None`` when unavailable) and ``row["deep"]``
+            classifies the verdicts-absent case (shallow vs. declined deep).
 
     Returns:
         A :class:`ScoringInputs` with the verdicts list (or ``None``), the
@@ -205,7 +214,13 @@ def assemble_scoring_inputs(run_dir: Path, row: dict[str, Any]) -> ScoringInputs
         if isinstance(verdicts, list):
             verifier_verdicts = verdicts
     except FileNotFoundError:
-        # Shallow run — no structured verdicts; nothing failed to parse.
+        # No structured verdicts; nothing failed to parse. Expected for two run
+        # shapes, distinguished by the manifest's ``deep`` flag (row["deep"]) —
+        # not by this file's presence: a shallow run (deep false) never produces
+        # verdicts, and after the verify relocation a declined deep run (deep
+        # true) skips recommendation verification at the apply-fixes gate, so it
+        # writes the deep bundle without a verdicts file. Both yield
+        # ``verifier_verdicts=None`` with the format gate intact.
         pass
     except json.JSONDecodeError:
         # Present but malformed ⇒ format gate floors.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,11 +27,11 @@ def test_phase_default_models_claude_tier_assignments():
     claude = PHASE_DEFAULT_MODELS["claude"]
     # PARSE is the cheap tier
     assert claude["parse"] == "claude-haiku-4-5"
-    # Expensive tier: REVIEW, WONDER, ENVISION, MERGE, INTENT, PR_FEEDBACK
-    for phase in ("review", "wonder", "envision", "merge", "intent", "pr_feedback"):
+    # Expensive tier: REVIEW, WONDER, ENVISION, MERGE, PR_FEEDBACK
+    for phase in ("review", "wonder", "envision", "merge", "pr_feedback"):
         assert claude[phase] == "claude-opus-4-8"
-    # Mid tier: FIX, TEST, EXPLORATION, PER_STACK_REVIEW
-    for phase in ("fix", "test", "exploration", "per_stack_review"):
+    # Mid tier: FIX, TEST, EXPLORATION, PER_STACK_REVIEW, INTENT
+    for phase in ("fix", "test", "exploration", "per_stack_review", "intent"):
         assert claude[phase] == "claude-sonnet-4-6"
 
 

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -3035,6 +3035,42 @@ def _git_single_file_target(tmp_path: Path) -> Path:
     return target
 
 
+def _install_accept_gate_pipeline(
+    monkeypatch: pytest.MonkeyPatch, target: Path
+) -> _StubBackend:
+    """Patch the deep pipeline for a fix-gate-ACCEPT run.
+
+    Bundles the per-test setup the two alternatives diff-tier tests share:
+    pin the interactive stdin/CI axis so a forced accept is honoured, silence
+    the deep UI noise (including the recommendation verification summary),
+    force every ``prompt_user`` seam to ``"y"`` (belt-and-suspenders alongside
+    ``assume="yes"``, which short-circuits the gate before any prompt runs),
+    and stub the non-idempotent PR-post / test / commit steps. Returns the
+    stub backend.
+    """
+    _force_interactive(monkeypatch)
+    monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.deep.orchestrator.print_verification_summary", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
+
+    async def _no_post(target_dir: Path, report_path: Path, *, console: Any) -> None:  # noqa: ARG001
+        return None
+
+    async def _stub_test(backend, work, feedback_items=None):  # noqa: ARG001
+        return (True, 0)
+
+    async def _stub_commit(backend, work):  # noqa: ARG001
+        return None
+
+    monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _no_post)
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_test_and_heal", _stub_test)
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _stub_commit)
+
+    return _install_stub_backend(monkeypatch, target)
+
+
 async def test_alternatives_skipped_for_trivial_diff(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -3050,29 +3086,10 @@ async def test_alternatives_skipped_for_trivial_diff(
 
     target = _git_single_file_target(tmp_path)
 
-    # Accept the fix gate so the full pipeline runs; pin interactivity so the
-    # "y" stub is honoured.
-    _force_interactive(monkeypatch)
-    monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
-    monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
-    monkeypatch.setattr("daydream.deep.orchestrator.print_verification_summary", lambda *a, **kw: None)
-    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
-
-    stub = _install_stub_backend(monkeypatch, target)
-
-    async def _no_post(target_dir: Path, report_path: Path, *, console: Any) -> None:  # noqa: ARG001
-        return None
-
-    async def _stub_test(backend, work, feedback_items=None):  # noqa: ARG001
-        return (True, 0)
-
-    async def _stub_commit(backend, work):  # noqa: ARG001
-        return None
-
-    monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _no_post)
-    monkeypatch.setattr("daydream.deep.orchestrator.phase_test_and_heal", _stub_test)
-    monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _stub_commit)
+    # Accept the fix gate so the full pipeline runs; the shared helper pins
+    # interactivity, silences deep UI noise, and stubs the non-idempotent
+    # PR-post / test / commit steps.
+    stub = _install_accept_gate_pipeline(monkeypatch, target)
 
     traj = tmp_path / "trajectory.json"
     exit_code = await run(
@@ -3118,28 +3135,9 @@ async def test_alternatives_runs_for_multi_file_diff(
     """
     from daydream.runner import RunConfig, run
 
-    # Accept the fix gate; pin interactivity so the "y" stub is honoured.
-    _force_interactive(monkeypatch)
-    monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
-    monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
-    monkeypatch.setattr("daydream.deep.orchestrator.print_verification_summary", lambda *a, **kw: None)
-    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
-
-    stub = _install_stub_backend(monkeypatch, multi_stack_target)
-
-    async def _no_post(target_dir: Path, report_path: Path, *, console: Any) -> None:  # noqa: ARG001
-        return None
-
-    async def _stub_test(backend, work, feedback_items=None):  # noqa: ARG001
-        return (True, 0)
-
-    async def _stub_commit(backend, work):  # noqa: ARG001
-        return None
-
-    monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _no_post)
-    monkeypatch.setattr("daydream.deep.orchestrator.phase_test_and_heal", _stub_test)
-    monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _stub_commit)
+    # Accept the fix gate; the shared helper pins interactivity, silences deep
+    # UI noise, and stubs the non-idempotent PR-post / test / commit steps.
+    stub = _install_accept_gate_pipeline(monkeypatch, multi_stack_target)
 
     traj = tmp_path / "trajectory.json"
     exit_code = await run(

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -1966,6 +1966,42 @@ def test_intent_phase_resolves_to_sonnet_default(
     )
 
 
+async def test_intent_phase_runs_on_sonnet_through_runner_run(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#171 real-path: the intent phase Sonnet downgrade must be observable
+    through the runner.run production entrypoint, not only at the unit seam.
+
+    The unit-level assertion (test_intent_phase_resolves_to_sonnet_default) pins
+    ``_resolve_backend(RunConfig(), "intent", {})`` directly. This is its
+    real-path counterpart: it drives runner.run via _run_deep (which calls
+    ``await run(config)``), captures the model on the backend that actually
+    executes the intent prompt via _install_model_capturing_stubs, and asserts
+    it is claude-sonnet-4-6 (mid tier). Mirrors the exact pattern of
+    test_per_stack_sonnet_merge_opus_and_arbiter_on_high_severity. Regression: a
+    revert of the intent default to Opus fails this assertion.
+    """
+    _silence(monkeypatch)
+    calls = _install_model_capturing_stubs(
+        monkeypatch, multi_stack_target, parse_severity="high", merge_echo_records=True
+    )
+
+    exit_code = await _run_deep(multi_stack_target)
+    assert exit_code == 0
+
+    # "understand the intent of these changes" is unique to build_intent_prompt
+    # (phases.py) -- the established intent-phase prompt discriminator.
+    intent_models = [
+        c["model"]
+        for c in calls
+        if "understand the intent of these changes" in c["prompt"].lower()
+    ]
+    assert intent_models, "intent phase did not execute through runner.run"
+    assert set(intent_models) == {"claude-sonnet-4-6"}, (
+        f"intent phase should run on claude-sonnet-4-6 (mid tier), got {sorted(intent_models)!r}"
+    )
+
+
 async def test_verifier_runs_after_merge_before_fix(
     multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -2997,44 +2997,6 @@ async def test_environmental_failure_aborts_heal_loop(
     assert saw_test_step, "no TEST-phase trajectory step recorded -- heal phase not reached"
 
 
-def _git_single_file_target(tmp_path: Path) -> Path:
-    """Build a 1-changed-file feature-branch repo for AC4's trivial-diff case.
-
-    Mirrors the ``multi_stack_target`` fixture shape (init on ``main``, change on
-    ``feature``) but with a single file (``api.py``) so
-    ``select_tier(count_changed_files(diff)) == "skip"``.
-    """
-    target = tmp_path / "single_file"
-    target.mkdir()
-    (target / "api.py").write_text("def hello():\n    return 'world'\n")
-    subprocess.run(  # noqa: S603, S607 - arguments are not user-controlled
-        ["git", "init", "-b", "main"], cwd=target, capture_output=True, check=True
-    )
-    subprocess.run(  # noqa: S603, S607 - arguments are not user-controlled
-        ["git", "config", "user.email", "test@test.com"], cwd=target, capture_output=True, check=True
-    )
-    subprocess.run(  # noqa: S603, S607 - arguments are not user-controlled
-        ["git", "config", "user.name", "Test"], cwd=target, capture_output=True, check=True
-    )
-    subprocess.run(  # noqa: S603, S607 - arguments are not user-controlled
-        ["git", "add", "."], cwd=target, capture_output=True, check=True
-    )
-    subprocess.run(  # noqa: S603, S607 - arguments are not user-controlled
-        ["git", "commit", "-m", "init"], cwd=target, capture_output=True, check=True
-    )
-    subprocess.run(  # noqa: S603, S607 - arguments are not user-controlled
-        ["git", "checkout", "-b", "feature"], cwd=target, capture_output=True, check=True
-    )
-    (target / "api.py").write_text("def hello():\n    return 'universe'\n")
-    subprocess.run(  # noqa: S603, S607 - arguments are not user-controlled
-        ["git", "add", "."], cwd=target, capture_output=True, check=True
-    )
-    subprocess.run(  # noqa: S603, S607 - arguments are not user-controlled
-        ["git", "commit", "-m", "change"], cwd=target, capture_output=True, check=True
-    )
-    return target
-
-
 def _install_accept_gate_pipeline(
     monkeypatch: pytest.MonkeyPatch, target: Path
 ) -> _StubBackend:
@@ -3072,7 +3034,7 @@ def _install_accept_gate_pipeline(
 
 
 async def test_alternatives_skipped_for_trivial_diff(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    feature_branch_repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """AC4 real-path (negative): a 1-file diff skips the alternatives (wonder) phase.
 
@@ -3084,7 +3046,7 @@ async def test_alternatives_skipped_for_trivial_diff(
     """
     from daydream.runner import RunConfig, run
 
-    target = _git_single_file_target(tmp_path)
+    target = feature_branch_repo
 
     # Accept the fix gate so the full pipeline runs; the shared helper pins
     # interactivity, silences deep UI noise, and stubs the non-idempotent

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -1929,6 +1929,43 @@ async def test_resolve_backend_called_with_each_phase_in_deep_flow(
     )
 
 
+def test_intent_phase_resolves_to_sonnet_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC3: the ``intent`` phase resolves to ``claude-sonnet-4-6`` by default.
+
+    Intent summarization is a single mid-complexity turn that does not need Opus;
+    Sonnet matches the FIX/TEST/EXPLORATION/PER_STACK_REVIEW tier. Captures the
+    ``model=`` passed to ``create_backend`` and asserts the default, then that an
+    explicit ``RunConfig(model=...)`` override still wins.
+    """
+    from daydream.runner import RunConfig, _resolve_backend
+
+    captured: dict[str, Any] = {}
+
+    class _B:
+        def __init__(self, model: str | None) -> None:
+            self.model = model
+
+    def fake_create(name: str, model: str | None = None) -> _B:  # noqa: ARG001
+        captured["model"] = model
+        return _B(model)
+
+    monkeypatch.setattr("daydream.runner.create_backend", fake_create)
+
+    # Default: intent lands on Sonnet (mid tier), not Opus.
+    backend = _resolve_backend(RunConfig(), "intent", {})
+    assert backend.model == "claude-sonnet-4-6", (
+        f"intent phase default should be claude-sonnet-4-6, got {backend.model!r}"
+    )
+
+    # An explicit global model override still wins over the phase default.
+    backend_override = _resolve_backend(RunConfig(model="claude-opus-4-8"), "intent", {})
+    assert backend_override.model == "claude-opus-4-8", (
+        f"RunConfig(model=...) override should win for intent, got {backend_override.model!r}"
+    )
+
+
 async def test_verifier_runs_after_merge_before_fix(
     multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -2065,6 +2102,11 @@ async def test_verifier_contradicts_propagates_to_fix_prompt(
     ), (
         "unverified_assumptions did not propagate into the fix prompt; "
         f"fix prompts seen: {fix_prompts!r}"
+    )
+    # AC2 regression guard: when the gate accepts, verify runs and the verdicts
+    # artifact lands on disk (same path asserted by the ordering test).
+    assert (multi_stack_target / ".daydream" / "deep" / "recommendation-verdicts.json").is_file(), (
+        "verdicts file missing -- verify did not run when the gate accepted"
     )
 
 
@@ -2290,6 +2332,12 @@ async def test_start_at_fix_recovers_merged_items(
         "phase_fix received an item that did not originate from the deep-dir "
         f"merged-items.json; got {fixed!r}"
     )
+    # AC5 regression guard: a --start-at fix resume that applies fixes (gate
+    # accepted) still produces verdicts -- verify runs post-gate-accept on resume.
+    assert (multi_stack_target / ".daydream" / "deep" / "recommendation-verdicts.json").is_file(), (
+        "verdicts file missing on --start-at fix resume -- verify must run when "
+        "the gate accepts and fixes are applied"
+    )
 
 
 # Real-path integration: non-interactive / EOF-safe apply-fixes gate.
@@ -2313,7 +2361,7 @@ def _silence_gate_noise(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 async def test_apply_fixes_gate_non_interactive_takes_safe_default(
-    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+    multi_stack_target: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Real-path: non-interactive deep run declines fixes and exits 0 without
     reading stdin.
@@ -2323,6 +2371,11 @@ async def test_apply_fixes_gate_non_interactive_takes_safe_default(
     ``config.non_interactive=True`` propagated by ``run``, the gate must
     short-circuit to its "n" default -- never touching stdin -- so the run
     declines fixes and returns 0.
+
+    AC1: because the gate declines, the recommendation verifier must NOT run --
+    no ``verify`` value among the run's trajectory ``daydream_phase`` steps and
+    no ``recommendation-verdicts.json`` on disk. Verify lives inside the
+    fix-accept branch; a declined run skips it (and its cost).
     """
     from daydream.agent import get_non_interactive, reset_state
     from daydream.config import REVIEW_OUTPUT_FILE
@@ -2352,11 +2405,17 @@ async def test_apply_fixes_gate_non_interactive_takes_safe_default(
 
     monkeypatch.setattr("builtins.input", _forbidden_input)
 
+    traj = tmp_path / "trajectory.json"
     reset_state()
     exit_code = -1
     try:
         assert get_non_interactive() is False
-        config = RunConfig(target=str(multi_stack_target), cleanup=False, non_interactive=True)
+        config = RunConfig(
+            target=str(multi_stack_target),
+            cleanup=False,
+            non_interactive=True,
+            trajectory_path=traj,
+        )
         exit_code = await run(config)
         assert get_non_interactive() is True
     finally:
@@ -2367,6 +2426,19 @@ async def test_apply_fixes_gate_non_interactive_takes_safe_default(
     # The gate's "report written ... exiting" path ran (report on disk before return 0).
     assert (multi_stack_target / REVIEW_OUTPUT_FILE).is_file(), (
         "merged report missing -- the apply-fixes gate's success/exit path did not run"
+    )
+
+    # AC1: the verifier never ran because the gate declined. No verify phase in
+    # the trajectory, and no recommendation-verdicts.json artifact on disk.
+    run_root = multi_stack_target / ".daydream"
+    phases = _scan_trajectory_extra(run_root, traj, "daydream_phase")
+    assert "verify" not in phases, (
+        f"verify phase ran despite the gate declining; phases: {phases!r}"
+    )
+    verdicts_file = multi_stack_target / ".daydream" / "deep" / "recommendation-verdicts.json"
+    assert not verdicts_file.exists(), (
+        f"recommendation-verdicts.json exists despite declined gate -- verify must "
+        f"not run when fixes are not applied; found {verdicts_file}"
     )
 
 
@@ -2887,3 +2959,172 @@ async def test_environmental_failure_aborts_heal_loop(
     run_root = multi_stack_target / ".daydream"
     saw_test_step = "test" in _scan_trajectory_extra(run_root, traj, "daydream_phase")
     assert saw_test_step, "no TEST-phase trajectory step recorded -- heal phase not reached"
+
+
+def _git_single_file_target(tmp_path: Path) -> Path:
+    """Build a 1-changed-file feature-branch repo for AC4's trivial-diff case.
+
+    Mirrors the ``multi_stack_target`` fixture shape (init on ``main``, change on
+    ``feature``) but with a single file (``api.py``) so
+    ``select_tier(count_changed_files(diff)) == "skip"``.
+    """
+    target = tmp_path / "single_file"
+    target.mkdir()
+    (target / "api.py").write_text("def hello():\n    return 'world'\n")
+    subprocess.run(  # noqa: S603, S607 - arguments are not user-controlled
+        ["git", "init", "-b", "main"], cwd=target, capture_output=True, check=True
+    )
+    subprocess.run(  # noqa: S603, S607 - arguments are not user-controlled
+        ["git", "config", "user.email", "test@test.com"], cwd=target, capture_output=True, check=True
+    )
+    subprocess.run(  # noqa: S603, S607 - arguments are not user-controlled
+        ["git", "config", "user.name", "Test"], cwd=target, capture_output=True, check=True
+    )
+    subprocess.run(  # noqa: S603, S607 - arguments are not user-controlled
+        ["git", "add", "."], cwd=target, capture_output=True, check=True
+    )
+    subprocess.run(  # noqa: S603, S607 - arguments are not user-controlled
+        ["git", "commit", "-m", "init"], cwd=target, capture_output=True, check=True
+    )
+    subprocess.run(  # noqa: S603, S607 - arguments are not user-controlled
+        ["git", "checkout", "-b", "feature"], cwd=target, capture_output=True, check=True
+    )
+    (target / "api.py").write_text("def hello():\n    return 'universe'\n")
+    subprocess.run(  # noqa: S603, S607 - arguments are not user-controlled
+        ["git", "add", "."], cwd=target, capture_output=True, check=True
+    )
+    subprocess.run(  # noqa: S603, S607 - arguments are not user-controlled
+        ["git", "commit", "-m", "change"], cwd=target, capture_output=True, check=True
+    )
+    return target
+
+
+async def test_alternatives_skipped_for_trivial_diff(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC4 real-path (negative): a 1-file diff skips the alternatives (wonder) phase.
+
+    ``select_tier(count_changed_files(diff)) == "skip"`` for <=1 changed file, so
+    the alternatives phase must NOT run: no ``alternatives`` value among the run's
+    trajectory ``daydream_phase`` steps, no ``wonder`` prompt dispatched through
+    the stub, and ``alternatives.json`` written as ``[]`` (downstream per-stack
+    and merge consumers still find the file). Intent still runs unconditionally.
+    """
+    from daydream.runner import RunConfig, run
+
+    target = _git_single_file_target(tmp_path)
+
+    # Accept the fix gate so the full pipeline runs; pin interactivity so the
+    # "y" stub is honoured.
+    _force_interactive(monkeypatch)
+    monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.deep.orchestrator.print_verification_summary", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
+
+    stub = _install_stub_backend(monkeypatch, target)
+
+    async def _no_post(target_dir: Path, report_path: Path, *, console: Any) -> None:  # noqa: ARG001
+        return None
+
+    async def _stub_test(backend, work, feedback_items=None):  # noqa: ARG001
+        return (True, 0)
+
+    async def _stub_commit(backend, work):  # noqa: ARG001
+        return None
+
+    monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _no_post)
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_test_and_heal", _stub_test)
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _stub_commit)
+
+    traj = tmp_path / "trajectory.json"
+    exit_code = await run(
+        RunConfig(target=str(target), trajectory_path=traj, assume="yes", output_mode="loop", cleanup=False)
+    )
+    assert exit_code == 0
+
+    run_root = target / ".daydream"
+    phases = _scan_trajectory_extra(run_root, traj, "daydream_phase")
+
+    # alternatives phase never ran.
+    assert "alternatives" not in phases, (
+        f"alternatives phase ran for a trivial (1-file) diff; phases: {phases!r}"
+    )
+    # No wonder/alternatives prompt was dispatched (discriminator per _StubBackend.execute).
+    alt_calls = [
+        c
+        for c in stub.calls
+        if "would you have done this differently" in c["prompt"].lower()
+        or "evaluate the implementation" in c["prompt"].lower()
+    ]
+    assert not alt_calls, (
+        f"alternatives wonder prompt dispatched for a trivial diff: {len(alt_calls)} call(s)"
+    )
+    # alternatives.json still written as [] so downstream consumers find the file.
+    alts_json = json.loads((target / ".daydream" / "deep" / "alternatives.json").read_text())
+    assert alts_json == [], f"expected empty alternatives.json on skip, got {alts_json!r}"
+    # intent still ran -- it is never gated by tier.
+    assert "intent" in phases, (
+        f"intent phase did not run; it must not be gated by diff tier; phases: {phases!r}"
+    )
+
+
+async def test_alternatives_runs_for_multi_file_diff(
+    multi_stack_target: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC4 real-path (positive): a >=2-file diff runs the alternatives phase.
+
+    ``multi_stack_target`` carries a 3-file diff (api.py, App.tsx, README.md),
+    so ``select_tier(count_changed_files(diff)) == "single"`` (not ``"skip"``).
+    The alternatives phase MUST run: an ``alternatives`` value among the run's
+    trajectory ``daydream_phase`` steps and a ``wonder`` prompt dispatched.
+    """
+    from daydream.runner import RunConfig, run
+
+    # Accept the fix gate; pin interactivity so the "y" stub is honoured.
+    _force_interactive(monkeypatch)
+    monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.deep.orchestrator.print_verification_summary", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
+
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+
+    async def _no_post(target_dir: Path, report_path: Path, *, console: Any) -> None:  # noqa: ARG001
+        return None
+
+    async def _stub_test(backend, work, feedback_items=None):  # noqa: ARG001
+        return (True, 0)
+
+    async def _stub_commit(backend, work):  # noqa: ARG001
+        return None
+
+    monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _no_post)
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_test_and_heal", _stub_test)
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _stub_commit)
+
+    traj = tmp_path / "trajectory.json"
+    exit_code = await run(
+        RunConfig(
+            target=str(multi_stack_target), trajectory_path=traj, assume="yes", output_mode="loop", cleanup=False
+        )
+    )
+    assert exit_code == 0
+
+    run_root = multi_stack_target / ".daydream"
+    phases = _scan_trajectory_extra(run_root, traj, "daydream_phase")
+
+    # alternatives phase ran.
+    assert "alternatives" in phases, (
+        f"alternatives phase did not run for a 3-file diff; phases: {phases!r}"
+    )
+    # A wonder/alternatives prompt was dispatched.
+    alt_calls = [
+        c
+        for c in stub.calls
+        if "would you have done this differently" in c["prompt"].lower()
+        or "evaluate the implementation" in c["prompt"].lower()
+    ]
+    assert alt_calls, "alternatives wonder prompt was not dispatched for a 3-file diff"

--- a/tests/test_training_harvest.py
+++ b/tests/test_training_harvest.py
@@ -409,7 +409,7 @@ def test_assemble_declined_deep_run_null_verdicts_keeps_format_valid(tmp_path: P
     (run_dir / "deep" / "stack-python-records.json").write_text(
         json.dumps({"records": [{"id": "i1"}]})
     )
-    inputs = assemble_scoring_inputs(run_dir, {"grounding_rate": 0.5, "deep": 1})
+    inputs = assemble_scoring_inputs(run_dir, {"grounding_rate": 0.5})
     assert inputs.verifier_verdicts is None          # declined ⇒ no verdicts
     assert inputs.format_valid is True                # absence is expected, not malformed
 

--- a/tests/test_training_harvest.py
+++ b/tests/test_training_harvest.py
@@ -397,6 +397,24 @@ def test_assemble_shallow_run_has_null_verdicts(tmp_path: Path):
     assert inputs.verifier_verdicts is None
 
 
+def test_assemble_declined_deep_run_null_verdicts_keeps_format_valid(tmp_path: Path):
+    # Verify relocation: a declined deep run writes the deep bundle (records,
+    # merged report) but skips recommendation verification, so no
+    # recommendation-verdicts.json exists. Harvest must treat the absent
+    # verdicts as expected (verifier_verdicts=None, format gate intact) — NOT
+    # floor format_valid — and the run is distinguished from a shallow run by
+    # the manifest's deep flag (row["deep"]), not by file presence.
+    run_dir = tmp_path / "run"
+    (run_dir / "deep").mkdir(parents=True)
+    # stack records are present and valid (as on a real declined deep run)
+    (run_dir / "deep" / "stack-python-records.json").write_text(
+        json.dumps({"records": [{"id": "i1"}]})
+    )
+    inputs = assemble_scoring_inputs(run_dir, {"grounding_rate": 0.5, "deep": 1})
+    assert inputs.verifier_verdicts is None          # declined ⇒ no verdicts
+    assert inputs.format_valid is True                # absence is expected, not malformed
+
+
 def test_assemble_malformed_verdicts_flags_format_invalid(tmp_path: Path):
     run_dir = tmp_path / "run"
     (run_dir / "deep").mkdir(parents=True)

--- a/tests/test_training_harvest.py
+++ b/tests/test_training_harvest.py
@@ -401,9 +401,8 @@ def test_assemble_declined_deep_run_null_verdicts_keeps_format_valid(tmp_path: P
     # Verify relocation: a declined deep run writes the deep bundle (records,
     # merged report) but skips recommendation verification, so no
     # recommendation-verdicts.json exists. Harvest must treat the absent
-    # verdicts as expected (verifier_verdicts=None, format gate intact) — NOT
-    # floor format_valid — and the run is distinguished from a shallow run by
-    # the manifest's deep flag (row["deep"]), not by file presence.
+    # verdicts as expected (verifier_verdicts=None, format gate intact), not
+    # floor format_valid.
     run_dir = tmp_path / "run"
     (run_dir / "deep").mkdir(parents=True)
     # stack records are present and valid (as on a real declined deep run)


### PR DESCRIPTION
## Summary

- **`verify` now runs only when fixes are applied** (after the apply-fixes gate accepts), not unconditionally — eliminates wasted work on the ~66% of deep runs that decline fixes (~7–12% wall-clock reduction on those runs)
- **`intent` demoted from Opus to Sonnet** — mid-tier model for a single summarization turn that seeds downstream reviews (~4–5% cost reduction)
- **`alternatives` (wonder) gated by diff size** — skipped for ≤1-file diffs via `select_tier`, avoiding a heavyweight red-team pass on trivial changes

## Motivation

Closes #171.

Of 213 archived deep runs that ran `verify`, 140 (66%) never ran a `fix` step — verify's verdicts were computed and discarded. The verify pass is already on Sonnet (cost-neutral), so making it conditional is primarily a **latency win**. The `intent` → Sonnet demotion and `alternatives` diff-size gate are smaller, additive cost reductions.

## Changes

### Changed
- `phase_verify_recommendations` moved from before the fix gate (`orchestrator.py:792`) to after gate-accept (`:833`, between `severity_sorted` and `_attach_verdicts`) — declined runs skip both the verify pass and `recommendation-verdicts.json`
- `intent` phase default model: `claude-opus-4-8` → `claude-sonnet-4-6` (`config.py:81`)
- `alternatives` phase gated by `select_tier(count_changed_files(diff)) == "skip"` — tier computed once and reused at both exploration and alternatives gates
- `harvest.py` docstrings updated: absent verdicts are now expected for two run shapes (shallow + declined deep), not just shallow
- Stale comment at `orchestrator.py:792-794` rewritten to document the new ordering

### Added
- AC1 real-path: gate declines (`non_interactive`) → no `verify` in trajectory, no `recommendation-verdicts.json`
- AC2 regression guard: gate accepts → verdicts file on disk, `contradicts` verdict propagates to fix prompt
- AC3 unit + real-path: `_resolve_backend(config, "intent", {})` → `claude-sonnet-4-6`; override still wins
- AC4 real-path pair: 1-file diff skips alternatives (empty `alternatives.json`, no wonder prompt); 3-file diff runs it
- AC5 regression guard: `--start-at fix` resume with fixes still produces verdicts
- Declined-deep-run harvest test: absent verdicts keep `format_valid=True`
- Shared `_install_accept_gate_pipeline` helper deduplicating ~25 lines of alternatives-test setup

## Test Plan

- [x] `make check` — 1681 passed, 3 skipped
- [x] `uv run ruff check daydream tests` — clean
- [x] `uv run mypy daydream tests` — clean (215 files)
- [x] Each AC test confirmed RED before production change, GREEN after
- [x] Daydream pre-PR review (pi/GLM-5.2): 5 findings addressed (tier-reuse, harvest downstream, test dedup)

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check`)
- [x] Type checking passes (`uv run mypy daydream tests`)
- [x] Documentation updated (tiering comments, harvest docstrings)
