### PR TITLE
perf(deep): short-circuit tiny-diff fan-out + inline diff hunks in per-stack prompts

### DIFF
--- a/daydream/config_file.py
+++ b/daydream/config_file.py
@@ -34,11 +34,16 @@ class DaydreamFileConfig:
         backend: Global default backend name, or None if unset.
         phases: Per-phase sub-tables mapping phase name to a dict of keys
             (e.g. ``{"fix": {"backend": "codex", "model": "..."}}``).
+        shallow_fanout_threshold: Max changed-file count that triggers the
+            tiny-diff short-circuit in deep mode (issue #172). ``None`` falls
+            through to the RunConfig field / orchestrator default. ``0``
+            explicitly disables the short-circuit.
     """
 
     model: str | None = None
     backend: str | None = None
     phases: dict[str, dict[str, str]] = field(default_factory=dict)
+    shallow_fanout_threshold: int | None = None
 
     def phase_model(self, phase: str) -> str | None:
         """Return the configured model for a phase.
@@ -182,8 +187,21 @@ def load_file_config(root: Path) -> DaydreamFileConfig:
 
     model = merged.get("model")
     backend = merged.get("backend")
+    # shallow_fanout_threshold: tolerate non-int (stray string, list, etc.) by
+    # degrading to None rather than crashing the loader. ``0`` is a meaningful
+    # value (disable the short-circuit) so it must round-trip unchanged.
+    raw_threshold = merged.get("shallow_fanout_threshold")
+    threshold: int | None
+    if isinstance(raw_threshold, bool):
+        # bool is a subclass of int but never a meaningful threshold value.
+        threshold = None
+    elif isinstance(raw_threshold, int):
+        threshold = raw_threshold
+    else:
+        threshold = None
     return DaydreamFileConfig(
         model=str(model) if model is not None else None,
         backend=str(backend) if backend is not None else None,
         phases=_coerce_phases(merged.get("phases")),
+        shallow_fanout_threshold=threshold,
     )

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -48,6 +48,7 @@ from daydream.deep.detection import StackAssignment, detect_stacks
 from daydream.phases import (
     FEEDBACK_SCHEMA,
     PER_STACK_RECORD_SCHEMA,
+    normalize_items,
     phase_alternative_review,
     phase_arbiter_review,
     phase_commit_push,
@@ -95,6 +96,14 @@ _DIFF_MINUS_HEADER = re.compile(r"^--- (\S+)", re.MULTILINE)
 # Fallback header for binary / mode-only diffs that lack `--- / +++`.
 _DIFF_GIT_HEADER = re.compile(r"^diff --git a/(\S+) b/(\S+)")
 
+
+# Issue #172 — Read-once diff hunks (Fix B). Upper byte bound for the inlined
+# diff section in per-stack / generic prompts. Above this bound the helper
+# returns ``None`` and the prompt falls back to the diff_path pointer so the
+# prompt size stays bounded. ~12 KiB comfortably fits a few hundred lines of
+# unified diff without bloating the per-stack review prompts.
+INLINE_DIFF_BUDGET_BYTES = 12_288
+
 # User-visible pipeline stages (exploration is a pre-stage banner, not counted).
 _PIPELINE_STAGE_NAMES: list[str] = [
     "TTT intent",
@@ -123,6 +132,206 @@ def total_agent_count(stack_count: int) -> int:
         Total agent invocation count surfaced in the pre-flight notice.
     """
     return 2 + stack_count + stack_count + 1 + 1
+
+
+# Issue #172 — tiny-diff short-circuit. A diff with at most this many changed
+# files collapses the per-language fan-out to a single combined assignment and
+# skips the merge agent + arbiter (a tiny diff has nothing to cross-stack-merge
+# and nothing contested to arbitrate). Both levers are required for AC1 because
+# a 1-file single-language diff is already only 2 stacks (lang + structure);
+# the count reduction for that case comes entirely from skipping merge+arbiter.
+DEFAULT_SHALLOW_FANOUT_THRESHOLD = 2
+
+
+def _single_stack_agent_count(stack_count: int) -> int:
+    """Return the agent count for a tiny-diff single-stack run (issue #172).
+
+    Single-stack mode runs 2 TTT + N per-stack reviews + N parse passes but
+    skips the merge agent and the arbiter (lever 2). The surviving stack list
+    after collapse is at most ``[combined-or-single, structure]`` (≤2).
+
+    Args:
+        stack_count: Number of stack assignments AFTER the tiny-diff collapse.
+
+    Returns:
+        Total agent invocation count for the single-stack-mode run.
+    """
+    return 2 + stack_count + stack_count
+
+
+def _shallow_fanout_threshold(config: RunConfig) -> int:
+    """Resolve the tiny-diff short-circuit threshold (issue #172, AC7).
+
+    Precedence (highest first), mirroring ``_resolve_backend`` /
+    ``_resolved_model`` at ``runner.py:295-326``:
+
+      1. ``RunConfig.shallow_fanout_threshold`` (CLI tier).
+      2. ``DaydreamFileConfig.shallow_fanout_threshold`` (file-config scalar).
+      3. ``DEFAULT_SHALLOW_FANOUT_THRESHOLD`` (built-in default).
+
+    Uses ``is not None`` checks rather than truthiness so a configured value
+    of ``0`` (explicitly disable the short-circuit) is honored.
+
+    Args:
+        config: Run configuration carrying the CLI/file-config sources.
+
+    Returns:
+        The resolved integer threshold. ``0`` disables the short-circuit.
+    """
+    if config.shallow_fanout_threshold is not None:
+        return config.shallow_fanout_threshold
+    file_config = config.file_config
+    if file_config is not None and file_config.shallow_fanout_threshold is not None:
+        return file_config.shallow_fanout_threshold
+    return DEFAULT_SHALLOW_FANOUT_THRESHOLD
+
+
+def _collapse_stacks_for_tiny_diff(
+    stacks: list[StackAssignment],
+    changed_files: list[str],
+    *,
+    threshold: int,
+) -> tuple[list[StackAssignment], bool]:
+    """Collapse the per-language fan-out for a tiny diff (issue #172, Fix A lever 1).
+
+    When ``0 < len(changed_files) <= threshold``:
+
+      - If ≥2 distinct *non-structural* stacks exist, merge them into a single
+        combined ``generic`` assignment (a single agent cannot invoke two
+        per-language Beagle skills, so the combined review uses the generic
+        fallback skill).
+      - The ``STRUCTURE_STACK_NAME`` meta-stack stays as its own assignment so
+        structural findings remain correctly tagged ``lens="structural"``
+        downstream (AC6).
+      - If only one non-structural stack exists (the common 1-file case), it is
+        preserved unchanged — the per-language skill survives.
+
+    Returns ``(stacks, single_stack_mode)`` where ``single_stack_mode`` reports
+    whether the tiny-diff gate is active (caller uses it to skip merge+arbiter).
+    When the gate is inactive, ``stacks`` is returned unchanged.
+
+    Args:
+        stacks: Stack assignments returned by ``detect_stacks``.
+        changed_files: Changed file list used to compute the gate.
+        threshold: Resolved threshold from ``_shallow_fanout_threshold``. ``0``
+            disables the short-circuit (returns inputs unchanged).
+
+    Returns:
+        Tuple of ``(possibly_collapsed_stacks, single_stack_mode)``.
+    """
+    if threshold <= 0 or not (0 < len(changed_files) <= threshold):
+        return stacks, False
+
+    non_structural = [s for s in stacks if s.stack_name != STRUCTURE_STACK_NAME]
+    structural = [s for s in stacks if s.stack_name == STRUCTURE_STACK_NAME]
+
+    # When ≥2 distinct non-structural stacks exist, merge them into one combined
+    # generic-fallback assignment (preserve the per-language skill for the
+    # common 1-language tiny-diff case).
+    if len(non_structural) >= 2:
+        combined_files = sorted({f for s in non_structural for f in s.files})
+        # A combined review cannot invoke two per-language Beagle skills, so the
+        # combined assignment uses the generic-fallback skill (skill_invocation=None).
+        # is_docs_only is False by construction: ≥2 non-structural stacks means at
+        # least one is a real language stack (docs-only diff → single generic stack).
+        combined = StackAssignment(
+            stack_name="generic",
+            skill_invocation=None,
+            files=combined_files,
+            is_docs_only=False,
+        )
+        return [*structural, combined], True
+
+    # 0 or 1 non-structural stacks: nothing to collapse (lever 1 is a no-op), but
+    # the gate is still active so the caller applies lever 2 (skip merge+arbiter).
+    return stacks, True
+
+
+def _write_single_stack_merged_items(
+    repo: Path,
+    deep_dir_path: Path,
+    all_records: list[dict[str, Any]],
+    structural_records_path: Path | None,
+) -> None:
+    """Write the canonical ``merged-items.json`` for a tiny-diff run (issue #172).
+
+    Replaces ``phase_cross_stack_merge`` for single-stack-mode runs: there is
+    nothing to cross-stack-merge and nothing contested to arbitrate, so the
+    host writes the canonical item list directly. Reuses ``normalize_items``
+    and the **exact** structural-tagging logic from
+    ``phase_cross_stack_merge`` so downstream consumers (fix gate, verifier,
+    PR posting) consume items unchanged (AC6).
+
+    Mirrors ``phase_cross_stack_merge``'s write contract:
+      - clears stale ``merged-items.json`` / ``review-output.md`` /
+        canonical ``REVIEW_OUTPUT_FILE`` so a failed prior run can't leave
+        behind outdated content;
+      - tags per-stack records with ``lens="per-stack"`` (the merge agent
+        normally does this; in single-stack mode the host does it);
+      - appends structural records tagged ``lens="structural"`` with the same
+        HIGH/high confidence/severity defaults;
+      - renders ``review-output.md`` from the canonical items and copies it
+        to ``repo / REVIEW_OUTPUT_FILE``.
+
+    Args:
+        repo: Repository root (``work.repo``); the canonical report is written
+            alongside the deep artifact directory.
+        deep_dir_path: Deep artifact directory (``target / .daydream / deep``).
+        all_records: Non-structural parsed per-stack records (already
+            partitioned by the caller). Carries ``severity`` / ``confidence``
+            / ``rationale`` from ``PER_STACK_RECORD_SCHEMA`` but no ``lens``.
+        structural_records_path: Optional path to the parsed structural
+            meta-stack records JSON. ``None`` when no structural review ran.
+
+    """
+    from daydream.deep.artifacts import merged_items_path, merged_report_path
+    from daydream.deep.render import render_report
+
+    canonical_path = repo / REVIEW_OUTPUT_FILE
+    report_path = merged_report_path(deep_dir_path)
+    items_path = merged_items_path(deep_dir_path)
+
+    # Clear stale outputs (mirrors phase_cross_stack_merge).
+    canonical_path.unlink(missing_ok=True)
+    report_path.unlink(missing_ok=True)
+    items_path.unlink(missing_ok=True)
+
+    # Tag per-stack records (the merge agent normally sets lens; here the host
+    # does it). ``severity`` is already present from PER_STACK_RECORD_SCHEMA.
+    per_stack_items: list[dict[str, Any]] = [
+        {**rec, "lens": "per-stack"} for rec in all_records
+    ]
+
+    # Append structural findings in Python, tagged lens="structural". Copy
+    # verbatim from phase_cross_stack_merge:3019-3036 so the lens taxonomy and
+    # downstream verifier accounting (orchestrator.py:849/854) stay identical.
+    structural_items: list[dict[str, Any]] = []
+    if structural_records_path is not None and structural_records_path.is_file():
+        try:
+            structural_records = json.loads(structural_records_path.read_text())
+        except (json.JSONDecodeError, OSError) as exc:
+            print_warning(
+                console, f"Skipping malformed structural records: {type(exc).__name__}: {exc}"
+            )
+            structural_records = []
+        for rec in structural_records:
+            structural_items.append(
+                {
+                    **rec,
+                    "lens": "structural",
+                    "confidence": rec.get("confidence", "HIGH"),
+                    "severity": rec.get("severity", "high"),
+                }
+            )
+
+    items = normalize_items(per_stack_items + structural_items)
+    items_path.write_text(json.dumps({"items": items}, indent=2))
+    print_info(console, f"Merged into {len(items)} items")
+
+    # Render + copy (mirrors phase_cross_stack_merge:3045-3046) so the canonical
+    # ``REVIEW_OUTPUT_FILE`` exists for the exit message and resume recovery.
+    report_path.write_text(render_report(items))
+    canonical_path.write_text(report_path.read_text())
 
 
 def get_installed_skills() -> set[str] | None:
@@ -205,6 +414,62 @@ def _diff_changed_files(diff: str) -> list[str]:
         if path and path not in files:
             files.append(path)
     return files
+
+
+def _diff_blocks_for_files(diff: str, files: list[str]) -> str | None:
+    """Return the concatenated diff blocks for ``files`` (issue #172, Fix B).
+
+    Reuses the existing per-file block splitter (``_DIFF_BLOCK_SPLIT`` regex at
+    :91) plus the post-state header regexes (``_DIFF_PLUS_HEADER`` /
+    ``_DIFF_MINUS_HEADER`` / ``_DIFF_GIT_HEADER``) to select the ``diff --git``
+    blocks whose post-state path matches a file in ``files``. The blocks are
+    concatenated as-is (unified-diff text, including headers / hunks).
+
+    Byte-bounded: when the concatenated result would exceed
+    ``INLINE_DIFF_BUDGET_BYTES`` the helper returns ``None`` so the caller
+    falls back to the diff_path pointer (keeps prompt size bounded). Also
+    returns ``None`` when no blocks match (e.g. files absent from the diff).
+
+    Args:
+        diff: Full unified diff text.
+        files: Repo-relative paths to select blocks for.
+
+    Returns:
+        The concatenated diff blocks (with a trailing newline), or ``None``
+        when the result would exceed the byte budget or no blocks match.
+    """
+    wanted = set(files)
+    if not wanted:
+        return None
+
+    def _strip_prefix(path: str, prefix: str) -> str:
+        return path[len(prefix) :] if path.startswith(prefix) else path
+
+    selected: list[str] = []
+    for block in _DIFF_BLOCK_SPLIT.split(diff):
+        if not block.startswith("diff --git "):
+            continue
+        path: str | None = None
+        plus = _DIFF_PLUS_HEADER.search(block)
+        if plus and plus.group(1) != "/dev/null":
+            path = _strip_prefix(plus.group(1), "b/")
+        if path is None:
+            minus = _DIFF_MINUS_HEADER.search(block)
+            if minus and minus.group(1) != "/dev/null":
+                path = _strip_prefix(minus.group(1), "a/")
+        if path is None:
+            git = _DIFF_GIT_HEADER.match(block)
+            if git:
+                path = git.group(2)
+        if path in wanted:
+            selected.append(block if block.endswith("\n") else block + "\n")
+
+    if not selected:
+        return None
+    result = "".join(selected)
+    if len(result.encode("utf-8")) > INLINE_DIFF_BUDGET_BYTES:
+        return None
+    return result
 
 
 def _stack_preflight_line(stack: StackAssignment) -> str:
@@ -497,14 +762,35 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
         # pre-D-16 behavior is safer than routing everything to generic.
         skill_availability = installed if installed is not None else set(SKILL_MAP.keys())
         stacks = detect_stacks(changed_files, skill_availability=skill_availability)
+        # Issue #172 — tiny-diff short-circuit. When the diff is small enough
+        # (≤ SHALLOW_FANOUT_THRESHOLD files), collapse the per-language fan-out
+        # to a single combined assignment and skip merge+arbiter downstream.
+        # ``single_stack_mode`` is recomputed here (top of run_deep) so a
+        # ``--start-at merge``/``--start-at fix`` resume on a tiny diff re-enters
+        # the same bypass branch rather than routing to the absent merge agent.
+        threshold = _shallow_fanout_threshold(config)
+        if threshold > 0 and 0 < len(changed_files) <= threshold:
+            stacks, _ = _collapse_stacks_for_tiny_diff(
+                stacks, changed_files, threshold=threshold
+            )
+            single_stack_mode = True
+        else:
+            single_stack_mode = False
 
-        # Pre-flight notice (D-30).
+        # Pre-flight notice (D-30). Agent count reflects the tiny-diff collapse
+        # when single_stack_mode is active (issue #172): merge+arbiter are
+        # skipped, so the estimate uses ``_single_stack_agent_count``.
         stack_lines = [_stack_preflight_line(s) for s in stacks]
+        notice_agent_count = (
+            _single_stack_agent_count(len(stacks))
+            if single_stack_mode
+            else total_agent_count(len(stacks))
+        )
         print_preflight_notice(
             console,
             stages=_PIPELINE_STAGE_NAMES,
             stack_lines=stack_lines,
-            agent_count=total_agent_count(len(stacks)),
+            agent_count=notice_agent_count,
             exploration_available=EXPLORATION_AVAILABLE,
         )
 
@@ -604,6 +890,7 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
                     intent_path=intent_p,
                     alternatives_path=alts_p,
                     exploration_dir=exploration_dir,
+                    diff_text=diff,
                 )
                 # Persist so a later `--start-at merge` resume can still surface
                 # uncovered stacks (the in-memory failure map otherwise dies here).
@@ -711,64 +998,76 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
                 else:
                     structural_records_path = None
 
-                # Scoped Opus arbiter (#168). Sonnet ran the per-stack reviews;
-                # a single heavyweight arbiter now re-reviews ONLY the
-                # high-severity / contested findings and writes its verdicts back
-                # into the per-stack records before merge. A `--start-at merge`
-                # resume re-runs arbitration from the on-disk records UNLESS the
-                # completion marker proves a prior run already finalised them
-                # (#175): a crash between the parse write and the rewrite would
-                # otherwise let unarbitrated high-severity findings reach merge.
-                arbiter_marker = arbiter_complete_path(dd)
-                if config.start_at != "merge" or not arbiter_marker.is_file():
-                    arbiter_targets = select_arbiter_targets(all_records, record_sources)
-                    if arbiter_targets:
-                        verdicts = await phase_arbiter_review(
-                            _resolve_backend(config, "arbiter", backend_cache),
-                            work,
-                            selected_records=[all_records[i] for i in arbiter_targets],
-                            diff_path=diff_path,
-                            intent_path=intent_p,
-                            alternatives_path=alts_p,
-                            exploration_dir=exploration_dir,
-                        )
-                        all_records, record_sources = _apply_arbiter_verdicts(
-                            all_records, record_sources, arbiter_targets, verdicts
-                        )
-                        _rewrite_stack_records(
-                            dd, per_stack_records_paths, all_records, record_sources
-                        )
-                    arbiter_marker.write_text("")
+                if not single_stack_mode:
+                    # Scoped Opus arbiter (#168). Sonnet ran the per-stack reviews;
+                    # a single heavyweight arbiter now re-reviews ONLY the
+                    # high-severity / contested findings and writes its verdicts back
+                    # into the per-stack records before merge. A `--start-at merge`
+                    # resume re-runs arbitration from the on-disk records UNLESS the
+                    # completion marker proves a prior run already finalised them
+                    # (#175): a crash between the parse write and the rewrite would
+                    # otherwise let unarbitrated high-severity findings reach merge.
+                    arbiter_marker = arbiter_complete_path(dd)
+                    if config.start_at != "merge" or not arbiter_marker.is_file():
+                        arbiter_targets = select_arbiter_targets(all_records, record_sources)
+                        if arbiter_targets:
+                            verdicts = await phase_arbiter_review(
+                                _resolve_backend(config, "arbiter", backend_cache),
+                                work,
+                                selected_records=[all_records[i] for i in arbiter_targets],
+                                diff_path=diff_path,
+                                intent_path=intent_p,
+                                alternatives_path=alts_p,
+                                exploration_dir=exploration_dir,
+                            )
+                            all_records, record_sources = _apply_arbiter_verdicts(
+                                all_records, record_sources, arbiter_targets, verdicts
+                            )
+                            _rewrite_stack_records(
+                                dd, per_stack_records_paths, all_records, record_sources
+                            )
+                        arbiter_marker.write_text("")
 
-                # Dedup pre-filter (D-27).
-                alt_issues_for_dedup: list[dict[str, Any]] = (
-                    json.loads(alts_p.read_text()) if alts_p.exists() else []
-                )
-                pairs = build_dedup_candidates(all_records, alt_issues_for_dedup)
-                record_pairs = build_record_dedup_candidates(all_records, sources=record_sources)
-                dedup_p = dedup_candidates_path(dd)
-                dedup_p.write_text(
-                    json.dumps(
-                        {
-                            "record_alt_pairs": [_candidate_pair_to_json(p) for p in pairs],
-                            "record_duplicate_pairs": [_candidate_pair_to_json(p) for p in record_pairs],
-                        },
-                        indent=2,
+                    # Dedup pre-filter (D-27).
+                    alt_issues_for_dedup: list[dict[str, Any]] = (
+                        json.loads(alts_p.read_text()) if alts_p.exists() else []
                     )
-                )
+                    pairs = build_dedup_candidates(all_records, alt_issues_for_dedup)
+                    record_pairs = build_record_dedup_candidates(all_records, sources=record_sources)
+                    dedup_p = dedup_candidates_path(dd)
+                    dedup_p.write_text(
+                        json.dumps(
+                            {
+                                "record_alt_pairs": [_candidate_pair_to_json(p) for p in pairs],
+                                "record_duplicate_pairs": [_candidate_pair_to_json(p) for p in record_pairs],
+                            },
+                            indent=2,
+                        )
+                    )
 
-                # Cross-stack merge (D-23..D-26).
-                await phase_cross_stack_merge(
-                    _resolve_backend(config, "merge", backend_cache),
-                    work,
-                    per_stack_records_paths=per_stack_records_paths,
-                    intent_path=intent_p,
-                    alternatives_path=alts_p,
-                    dedup_candidates_path=dedup_p,
-                    exploration_dir=exploration_dir,
-                    failed_stacks=failed_stacks or None,
-                    structural_records_path=structural_records_path,
-                )
+                    # Cross-stack merge (D-23..D-26).
+                    await phase_cross_stack_merge(
+                        _resolve_backend(config, "merge", backend_cache),
+                        work,
+                        per_stack_records_paths=per_stack_records_paths,
+                        intent_path=intent_p,
+                        alternatives_path=alts_p,
+                        dedup_candidates_path=dedup_p,
+                        exploration_dir=exploration_dir,
+                        failed_stacks=failed_stacks or None,
+                        structural_records_path=structural_records_path,
+                    )
+                else:
+                    # Issue #172 — tiny-diff single-stack bypass. A ≤2-file diff
+                    # has nothing to cross-stack-merge and nothing contested to
+                    # arbitrate, so the host writes ``merged-items.json`` directly
+                    # via ``normalize_items`` + the exact structural-tagging logic
+                    # from ``phase_cross_stack_merge``. No arbiter, no dedup, no
+                    # merge agent. Downstream consumers (fix gate, verifier, PR
+                    # posting) read the canonical JSON unchanged (AC6).
+                    _write_single_stack_merged_items(
+                        work.repo, dd, all_records, structural_records_path
+                    )
 
             print_stage_progress(console, 5, 5, _PIPELINE_STAGE_NAMES[4])
             merged_report = target_dir / REVIEW_OUTPUT_FILE

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import shutil
 import uuid
 from dataclasses import asdict, is_dataclass
@@ -44,11 +43,11 @@ from daydream.deep.artifacts import (
     intent_path as _intent_path,
 )
 from daydream.deep.dedup import build_dedup_candidates, build_record_dedup_candidates
-from daydream.deep.detection import StackAssignment, detect_stacks
+from daydream.deep.detection import GENERIC_STACK, StackAssignment, detect_stacks
 from daydream.phases import (
     FEEDBACK_SCHEMA,
     PER_STACK_RECORD_SCHEMA,
-    normalize_items,
+    _write_single_stack_merged_items,
     phase_alternative_review,
     phase_arbiter_review,
     phase_commit_push,
@@ -88,21 +87,14 @@ try:
 except ImportError:  # pragma: no cover -- only hit when Phases 1-4 absent
     EXPLORATION_AVAILABLE = False
 
-# Per-file block splitter (splits the unified diff at each `diff --git` header).
-_DIFF_BLOCK_SPLIT = re.compile(r"^(?=diff --git )", re.MULTILINE)
-# `+++ ` and `--- ` file headers inside a single block.
-_DIFF_PLUS_HEADER = re.compile(r"^\+\+\+ (\S+)", re.MULTILINE)
-_DIFF_MINUS_HEADER = re.compile(r"^--- (\S+)", re.MULTILINE)
-# Fallback header for binary / mode-only diffs that lack `--- / +++`.
-_DIFF_GIT_HEADER = re.compile(r"^diff --git a/(\S+) b/(\S+)")
-
-
-# Issue #172 — Read-once diff hunks (Fix B). Upper byte bound for the inlined
-# diff section in per-stack / generic prompts. Above this bound the helper
-# returns ``None`` and the prompt falls back to the diff_path pointer so the
-# prompt size stays bounded. ~12 KiB comfortably fits a few hundred lines of
-# unified diff without bloating the per-stack review prompts.
-INLINE_DIFF_BUDGET_BYTES = 12_288
+# Per-file diff block splitter + the shared per-block path resolver live in
+# ``daydream.deep.prompts`` (canonical home of the diff-text -> prompt
+# primitives). Imported here because ``_diff_changed_files`` shares them with
+# ``prompts._diff_blocks_for_files`` (issue #172 Fix B).
+from daydream.deep.prompts import (
+    _DIFF_BLOCK_SPLIT,
+    _diff_block_path,
+)
 
 # User-visible pipeline stages (exploration is a pre-stage banner, not counted).
 _PIPELINE_STAGE_NAMES: list[str] = [
@@ -137,9 +129,10 @@ def total_agent_count(stack_count: int) -> int:
 # Issue #172 — tiny-diff short-circuit. A diff with at most this many changed
 # files collapses the per-language fan-out to a single combined assignment and
 # skips the merge agent + arbiter (a tiny diff has nothing to cross-stack-merge
-# and nothing contested to arbitrate). Both levers are required for AC1 because
-# a 1-file single-language diff is already only 2 stacks (lang + structure);
-# the count reduction for that case comes entirely from skipping merge+arbiter.
+# and nothing contested to arbitrate). A 1-file single-language diff is already
+# only 2 stacks (lang + structure), so the collapse is a no-op there and the
+# count reduction for that case comes entirely from skipping merge+arbiter
+# (lever 2); see ``_single_stack_agent_count``.
 DEFAULT_SHALLOW_FANOUT_THRESHOLD = 2
 
 
@@ -196,10 +189,12 @@ def _collapse_stacks_for_tiny_diff(
 
     When ``0 < len(changed_files) <= threshold``:
 
-      - If ≥2 distinct *non-structural* stacks exist, merge them into a single
-        combined ``generic`` assignment (a single agent cannot invoke two
-        per-language Beagle skills, so the combined review uses the generic
-        fallback skill).
+      - If ≥2 distinct *non-structural* stacks exist, merge them into one
+        combined assignment. A code+docs/config diff (exactly one *real*
+        language stack plus the ``generic`` bucket) absorbs the generic files
+        into the language stack so its per-language Beagle skill survives; only
+        ≥2 *real* language stacks fall back to ``generic`` (a single agent
+        cannot invoke two per-language Beagle skills).
       - The ``STRUCTURE_STACK_NAME`` meta-stack stays as its own assignment so
         structural findings remain correctly tagged ``lens="structural"``
         downstream (AC6).
@@ -226,16 +221,38 @@ def _collapse_stacks_for_tiny_diff(
     structural = [s for s in stacks if s.stack_name == STRUCTURE_STACK_NAME]
 
     # When ≥2 distinct non-structural stacks exist, merge them into one combined
-    # generic-fallback assignment (preserve the per-language skill for the
-    # common 1-language tiny-diff case).
+    # assignment. The combined skill depends on how many *real* language stacks
+    # are present:
+    #   - exactly one real language stack + the generic bucket (a code+docs/config
+    #     tiny diff, e.g. api.py + README.md): absorb the generic files into the
+    #     language stack so its per-language Beagle skill survives (the
+    #     skill-preservation goal stated in this docstring).
+    #   - ≥2 real language stacks (e.g. python + react): a single agent cannot
+    #     invoke two per-language Beagle skills, so fall back to generic.
     if len(non_structural) >= 2:
         combined_files = sorted({f for s in non_structural for f in s.files})
-        # A combined review cannot invoke two per-language Beagle skills, so the
-        # combined assignment uses the generic-fallback skill (skill_invocation=None).
-        # is_docs_only is False by construction: ≥2 non-structural stacks means at
-        # least one is a real language stack (docs-only diff → single generic stack).
+        real_language = [s for s in non_structural if s.stack_name != GENERIC_STACK]
+        if len(real_language) == 1:
+            lang = real_language[0]
+            return (
+                [
+                    *structural,
+                    StackAssignment(
+                        stack_name=lang.stack_name,
+                        skill_invocation=lang.skill_invocation,
+                        files=combined_files,
+                        is_docs_only=False,
+                    ),
+                ],
+                True,
+            )
+        # ≥2 real-language stacks: one agent cannot invoke two per-language
+        # Beagle skills, so the combined assignment uses the generic-fallback
+        # skill (skill_invocation=None). is_docs_only is False by construction:
+        # ≥2 non-structural stacks means at least one is a real language stack
+        # (docs-only diff → single generic stack).
         combined = StackAssignment(
-            stack_name="generic",
+            stack_name=GENERIC_STACK,
             skill_invocation=None,
             files=combined_files,
             is_docs_only=False,
@@ -245,93 +262,6 @@ def _collapse_stacks_for_tiny_diff(
     # 0 or 1 non-structural stacks: nothing to collapse (lever 1 is a no-op), but
     # the gate is still active so the caller applies lever 2 (skip merge+arbiter).
     return stacks, True
-
-
-def _write_single_stack_merged_items(
-    repo: Path,
-    deep_dir_path: Path,
-    all_records: list[dict[str, Any]],
-    structural_records_path: Path | None,
-) -> None:
-    """Write the canonical ``merged-items.json`` for a tiny-diff run (issue #172).
-
-    Replaces ``phase_cross_stack_merge`` for single-stack-mode runs: there is
-    nothing to cross-stack-merge and nothing contested to arbitrate, so the
-    host writes the canonical item list directly. Reuses ``normalize_items``
-    and the **exact** structural-tagging logic from
-    ``phase_cross_stack_merge`` so downstream consumers (fix gate, verifier,
-    PR posting) consume items unchanged (AC6).
-
-    Mirrors ``phase_cross_stack_merge``'s write contract:
-      - clears stale ``merged-items.json`` / ``review-output.md`` /
-        canonical ``REVIEW_OUTPUT_FILE`` so a failed prior run can't leave
-        behind outdated content;
-      - tags per-stack records with ``lens="per-stack"`` (the merge agent
-        normally does this; in single-stack mode the host does it);
-      - appends structural records tagged ``lens="structural"`` with the same
-        HIGH/high confidence/severity defaults;
-      - renders ``review-output.md`` from the canonical items and copies it
-        to ``repo / REVIEW_OUTPUT_FILE``.
-
-    Args:
-        repo: Repository root (``work.repo``); the canonical report is written
-            alongside the deep artifact directory.
-        deep_dir_path: Deep artifact directory (``target / .daydream / deep``).
-        all_records: Non-structural parsed per-stack records (already
-            partitioned by the caller). Carries ``severity`` / ``confidence``
-            / ``rationale`` from ``PER_STACK_RECORD_SCHEMA`` but no ``lens``.
-        structural_records_path: Optional path to the parsed structural
-            meta-stack records JSON. ``None`` when no structural review ran.
-
-    """
-    from daydream.deep.artifacts import merged_items_path, merged_report_path
-    from daydream.deep.render import render_report
-
-    canonical_path = repo / REVIEW_OUTPUT_FILE
-    report_path = merged_report_path(deep_dir_path)
-    items_path = merged_items_path(deep_dir_path)
-
-    # Clear stale outputs (mirrors phase_cross_stack_merge).
-    canonical_path.unlink(missing_ok=True)
-    report_path.unlink(missing_ok=True)
-    items_path.unlink(missing_ok=True)
-
-    # Tag per-stack records (the merge agent normally sets lens; here the host
-    # does it). ``severity`` is already present from PER_STACK_RECORD_SCHEMA.
-    per_stack_items: list[dict[str, Any]] = [
-        {**rec, "lens": "per-stack"} for rec in all_records
-    ]
-
-    # Append structural findings in Python, tagged lens="structural". Copy
-    # verbatim from phase_cross_stack_merge:3019-3036 so the lens taxonomy and
-    # downstream verifier accounting (orchestrator.py:849/854) stay identical.
-    structural_items: list[dict[str, Any]] = []
-    if structural_records_path is not None and structural_records_path.is_file():
-        try:
-            structural_records = json.loads(structural_records_path.read_text())
-        except (json.JSONDecodeError, OSError) as exc:
-            print_warning(
-                console, f"Skipping malformed structural records: {type(exc).__name__}: {exc}"
-            )
-            structural_records = []
-        for rec in structural_records:
-            structural_items.append(
-                {
-                    **rec,
-                    "lens": "structural",
-                    "confidence": rec.get("confidence", "HIGH"),
-                    "severity": rec.get("severity", "high"),
-                }
-            )
-
-    items = normalize_items(per_stack_items + structural_items)
-    items_path.write_text(json.dumps({"items": items}, indent=2))
-    print_info(console, f"Merged into {len(items)} items")
-
-    # Render + copy (mirrors phase_cross_stack_merge:3045-3046) so the canonical
-    # ``REVIEW_OUTPUT_FILE`` exists for the exit message and resume recovery.
-    report_path.write_text(render_report(items))
-    canonical_path.write_text(report_path.read_text())
 
 
 def get_installed_skills() -> set[str] | None:
@@ -384,6 +314,10 @@ def _diff_changed_files(diff: str) -> list[str]:
     deletions (``+++ /dev/null``) and to the ``diff --git`` header for
     binary / mode-only diffs that lack ``---``/``+++`` lines.
 
+    The per-block path resolution is delegated to ``_diff_block_path`` so the
+    unified-diff parsing contract is shared with ``_diff_blocks_for_files``
+    rather than duplicated here.
+
     Args:
         diff: Unified diff text.
 
@@ -391,85 +325,12 @@ def _diff_changed_files(diff: str) -> list[str]:
         Unique, insertion-ordered list of changed file paths (excluding
         ``/dev/null`` sentinels).
     """
-
-    def _strip_prefix(path: str, prefix: str) -> str:
-        return path[len(prefix) :] if path.startswith(prefix) else path
-
     files: list[str] = []
     for block in _DIFF_BLOCK_SPLIT.split(diff):
-        if not block.startswith("diff --git "):
-            continue
-        path: str | None = None
-        plus = _DIFF_PLUS_HEADER.search(block)
-        if plus and plus.group(1) != "/dev/null":
-            path = _strip_prefix(plus.group(1), "b/")
-        if path is None:
-            minus = _DIFF_MINUS_HEADER.search(block)
-            if minus and minus.group(1) != "/dev/null":
-                path = _strip_prefix(minus.group(1), "a/")
-        if path is None:
-            git = _DIFF_GIT_HEADER.match(block)
-            if git:
-                path = git.group(2)
+        path = _diff_block_path(block)
         if path and path not in files:
             files.append(path)
     return files
-
-
-def _diff_blocks_for_files(diff: str, files: list[str]) -> str | None:
-    """Return the concatenated diff blocks for ``files`` (issue #172, Fix B).
-
-    Reuses the existing per-file block splitter (``_DIFF_BLOCK_SPLIT`` regex at
-    :91) plus the post-state header regexes (``_DIFF_PLUS_HEADER`` /
-    ``_DIFF_MINUS_HEADER`` / ``_DIFF_GIT_HEADER``) to select the ``diff --git``
-    blocks whose post-state path matches a file in ``files``. The blocks are
-    concatenated as-is (unified-diff text, including headers / hunks).
-
-    Byte-bounded: when the concatenated result would exceed
-    ``INLINE_DIFF_BUDGET_BYTES`` the helper returns ``None`` so the caller
-    falls back to the diff_path pointer (keeps prompt size bounded). Also
-    returns ``None`` when no blocks match (e.g. files absent from the diff).
-
-    Args:
-        diff: Full unified diff text.
-        files: Repo-relative paths to select blocks for.
-
-    Returns:
-        The concatenated diff blocks (with a trailing newline), or ``None``
-        when the result would exceed the byte budget or no blocks match.
-    """
-    wanted = set(files)
-    if not wanted:
-        return None
-
-    def _strip_prefix(path: str, prefix: str) -> str:
-        return path[len(prefix) :] if path.startswith(prefix) else path
-
-    selected: list[str] = []
-    for block in _DIFF_BLOCK_SPLIT.split(diff):
-        if not block.startswith("diff --git "):
-            continue
-        path: str | None = None
-        plus = _DIFF_PLUS_HEADER.search(block)
-        if plus and plus.group(1) != "/dev/null":
-            path = _strip_prefix(plus.group(1), "b/")
-        if path is None:
-            minus = _DIFF_MINUS_HEADER.search(block)
-            if minus and minus.group(1) != "/dev/null":
-                path = _strip_prefix(minus.group(1), "a/")
-        if path is None:
-            git = _DIFF_GIT_HEADER.match(block)
-            if git:
-                path = git.group(2)
-        if path in wanted:
-            selected.append(block if block.endswith("\n") else block + "\n")
-
-    if not selected:
-        return None
-    result = "".join(selected)
-    if len(result.encode("utf-8")) > INLINE_DIFF_BUDGET_BYTES:
-        return None
-    return result
 
 
 def _stack_preflight_line(stack: StackAssignment) -> str:

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -927,7 +927,8 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
                     # merge agent. Downstream consumers (fix gate, verifier, PR
                     # posting) read the canonical JSON unchanged (AC6).
                     _write_single_stack_merged_items(
-                        work.repo, dd, all_records, structural_records_path
+                        work.repo, dd, all_records, structural_records_path,
+                        failed_stacks=failed_stacks or None,
                     )
 
             print_stage_progress(console, 5, 5, _PIPELINE_STAGE_NAMES[4])

--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -16,6 +16,7 @@ Public builders:
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Any
 
@@ -58,6 +59,95 @@ def _stack_scope_instruction(stack_name: str, files: list[str]) -> str:
         f"Do NOT review files from other stacks -- their reviews are running in "
         f"parallel and will be merged afterwards."
     )
+
+
+# Issue #172 — Read-once diff hunks (Fix B). Upper byte bound for the inlined
+# diff section in per-stack / generic prompts. Above this bound the helper
+# returns ``None`` and the prompt falls back to the diff_path pointer so the
+# prompt size stays bounded. ~12 KiB comfortably fits a few hundred lines of
+# unified diff without bloating the per-stack review prompts.
+INLINE_DIFF_BUDGET_BYTES = 12_288
+
+# Per-file block splitter (splits the unified diff at each `diff --git` header).
+_DIFF_BLOCK_SPLIT = re.compile(r"^(?=diff --git )", re.MULTILINE)
+# `+++ ` and `--- ` file headers inside a single block.
+_DIFF_PLUS_HEADER = re.compile(r"^\+\+\+ (\S+)", re.MULTILINE)
+_DIFF_MINUS_HEADER = re.compile(r"^--- (\S+)", re.MULTILINE)
+# Fallback header for binary / mode-only diffs that lack `--- / +++`.
+_DIFF_GIT_HEADER = re.compile(r"^diff --git a/(\S+) b/(\S+)")
+
+
+def _diff_block_path(block: str) -> str | None:
+    """Resolve the single changed path for one ``diff --git`` block.
+
+    Shared unified-diff block-parsing contract used by both
+    ``_diff_blocks_for_files`` (here) and ``orchestrator._diff_changed_files``
+    so the post-state / pre-state / header fallback order and ``/dev/null``
+    handling live in exactly one place.
+
+    Prefers the post-state path (``+++ b/<path>``) so renames produce only the
+    destination. Falls back to the pre-state path for deletions
+    (``+++ /dev/null``) and to the ``diff --git`` header for binary / mode-only
+    diffs that lack ``---``/``+++`` lines. ``/dev/null`` sentinels are skipped
+    at every layer. Returns ``None`` for blocks that are not ``diff --git``
+    headers or where no path can be resolved.
+    """
+
+    def _strip_prefix(path: str, prefix: str) -> str:
+        return path[len(prefix) :] if path.startswith(prefix) else path
+
+    if not block.startswith("diff --git "):
+        return None
+    plus = _DIFF_PLUS_HEADER.search(block)
+    if plus and plus.group(1) != "/dev/null":
+        return _strip_prefix(plus.group(1), "b/")
+    minus = _DIFF_MINUS_HEADER.search(block)
+    if minus and minus.group(1) != "/dev/null":
+        return _strip_prefix(minus.group(1), "a/")
+    git = _DIFF_GIT_HEADER.match(block)
+    if git:
+        return git.group(2)
+    return None
+
+
+def _diff_blocks_for_files(diff: str, files: list[str]) -> str | None:
+    """Return the concatenated diff blocks for ``files`` (issue #172, Fix B).
+
+    Reuses the existing per-file block splitter (``_DIFF_BLOCK_SPLIT`` regex)
+    plus ``_diff_block_path`` (which applies the post-state header regexes
+    ``_DIFF_PLUS_HEADER`` / ``_DIFF_MINUS_HEADER`` / ``_DIFF_GIT_HEADER``) to
+    select the ``diff --git`` blocks whose post-state path matches a file in
+    ``files``. The blocks are concatenated as-is (unified-diff text, including
+    headers / hunks).
+
+    Byte-bounded: when the concatenated result would exceed
+    ``INLINE_DIFF_BUDGET_BYTES`` the helper returns ``None`` so the caller
+    falls back to the diff_path pointer (keeps prompt size bounded). Also
+    returns ``None`` when no blocks match (e.g. files absent from the diff).
+
+    Args:
+        diff: Full unified diff text.
+        files: Repo-relative paths to select blocks for.
+
+    Returns:
+        The concatenated diff blocks (with a trailing newline), or ``None``
+        when the result would exceed the byte budget or no blocks match.
+    """
+    wanted = set(files)
+    if not wanted:
+        return None
+
+    selected: list[str] = []
+    for block in _DIFF_BLOCK_SPLIT.split(diff):
+        if _diff_block_path(block) in wanted:
+            selected.append(block if block.endswith("\n") else block + "\n")
+
+    if not selected:
+        return None
+    result = "".join(selected)
+    if len(result.encode("utf-8")) > INLINE_DIFF_BUDGET_BYTES:
+        return None
+    return result
 
 
 def _diff_instruction(

--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -60,7 +60,41 @@ def _stack_scope_instruction(stack_name: str, files: list[str]) -> str:
     )
 
 
-def _diff_instruction(diff_path: Path, files: list[str]) -> str:
+def _diff_instruction(
+    diff_path: Path,
+    files: list[str],
+    *,
+    inline_diff: str | None = None,
+) -> str:
+    """Diff context for a per-stack / generic-fallback reviewer.
+
+    Issue #172 Fix B (read-once):
+      - When ``inline_diff`` is supplied (the relevant hunks already extracted
+        by ``_diff_blocks_for_files`` and under the byte bound), the hunks are
+        inlined and the ``Read it directly`` instruction is DROPPED. The agent
+        has what it needs without a tool-call round-trip for the static
+        ``diff.patch`` file.
+      - When ``inline_diff`` is ``None`` (byte budget exceeded / no matching
+        blocks / caller had no diff text), today's path-pointer text is used
+        unchanged so the agent can still locate the full diff for whole-file
+        context. ``diff_path`` stays a required param either way.
+
+    Args:
+        diff_path: Path to the full diff on disk.
+        files: Files this stack owns (used in the fallback path-pointer text).
+        inline_diff: Pre-extracted hunks to inline, or ``None`` for the fallback.
+
+    Returns:
+        The diff-context section for the prompt.
+    """
+    if inline_diff:
+        return (
+            "Relevant diff hunks for your stack (inlined; do NOT re-Read "
+            "diff.patch for these — the hunks are already here):\n\n"
+            f"{inline_diff.rstrip()}\n\n"
+            "Focus on hunks that touch your stack's files. For whole-file "
+            "context beyond these hunks you MAY Read the source files directly."
+        )
     joined = ", ".join(files)
     # Point agents at diff_path directly. A bare `git diff -- <files>` command
     # only surfaces uncommitted workspace changes; on a clean PR branch it
@@ -85,6 +119,7 @@ def build_per_stack_prompt(
     output_path: Path,
     exploration_dir: Path | None = None,
     prior_commits: str | None = None,
+    inline_diff: str | None = None,
 ) -> str:
     """Assemble the per-stack review prompt.
 
@@ -98,6 +133,9 @@ def build_per_stack_prompt(
         output_path: Where the agent must write its review.
         exploration_dir: Pre-scan exploration directory (if available).
         prior_commits: Oneline log of prior daydream commits on this branch.
+        inline_diff: Issue #172 Fix B. Pre-extracted diff hunks for ``files``
+            to inline (skips the ``Read it directly`` instruction). ``None``
+            falls back to the diff_path pointer.
 
     Returns:
         Assembled prompt string.
@@ -113,7 +151,7 @@ def build_per_stack_prompt(
     parts.append(_confidence_and_convention_instructions())
     parts.append(_dependency_impact_instructions())
     parts.append(_stack_scope_instruction(stack_name, files))
-    parts.append(_diff_instruction(diff_path, files))
+    parts.append(_diff_instruction(diff_path, files, inline_diff=inline_diff))
     parts.append(skill_invocation)
     parts.append(f"Write your full review to {output_path}.")
     return "\n\n".join(parts)
@@ -468,6 +506,7 @@ def build_generic_fallback_prompt(
     exploration_dir: Path | None = None,
     is_docs_only: bool = False,
     prior_commits: str | None = None,
+    inline_diff: str | None = None,
 ) -> str:
     """Assemble the generic-fallback review prompt (no skill invocation).
 
@@ -482,6 +521,9 @@ def build_generic_fallback_prompt(
         exploration_dir: Pre-scan exploration directory (if available).
         is_docs_only: Whether the whole diff is docs-only (D-20).
         prior_commits: Oneline log of prior daydream commits on this branch.
+        inline_diff: Issue #172 Fix B. Pre-extracted diff hunks for ``files``
+            to inline (skips the ``Read it directly`` instruction). ``None``
+            falls back to the diff_path pointer.
 
     Returns:
         Assembled prompt string.
@@ -499,7 +541,7 @@ def build_generic_fallback_prompt(
     parts.append(_confidence_and_convention_instructions())
     parts.append(_dependency_impact_instructions())
     parts.append(_stack_scope_instruction("generic-fallback", files))
-    parts.append(_diff_instruction(diff_path, files))
+    parts.append(_diff_instruction(diff_path, files, inline_diff=inline_diff))
     parts.append(
         "Review these files for correctness, clarity, and consistency with the "
         "author's intent. Apply language-agnostic review practices."

--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -71,8 +71,8 @@ INLINE_DIFF_BUDGET_BYTES = 12_288
 # Per-file block splitter (splits the unified diff at each `diff --git` header).
 _DIFF_BLOCK_SPLIT = re.compile(r"^(?=diff --git )", re.MULTILINE)
 # `+++ ` and `--- ` file headers inside a single block.
-_DIFF_PLUS_HEADER = re.compile(r"^\+\+\+ (\S+)", re.MULTILINE)
-_DIFF_MINUS_HEADER = re.compile(r"^--- (\S+)", re.MULTILINE)
+_DIFF_PLUS_HEADER = re.compile(r"^\+\+\+ (.+)$", re.MULTILINE)
+_DIFF_MINUS_HEADER = re.compile(r"^--- (.+)$", re.MULTILINE)
 # Fallback header for binary / mode-only diffs that lack `--- / +++`.
 _DIFF_GIT_HEADER = re.compile(r"^diff --git a/(\S+) b/(\S+)")
 

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -3001,7 +3001,12 @@ def _append_structural_and_write_merged(
             # malformed output; degrade to none rather than crash the merge.
             print_warning(console, f"Skipping malformed structural records: {type(exc).__name__}: {exc}")
             structural_records = []
+        if not isinstance(structural_records, list):
+            print_warning(console, "Skipping non-list structural records; expected a list")
+            structural_records = []
         for rec in structural_records:
+            if not isinstance(rec, dict):
+                continue
             structural_items.append(
                 {
                     **rec,
@@ -3027,6 +3032,8 @@ def _write_single_stack_merged_items(
     deep_dir_path: Path,
     all_records: list[dict[str, Any]],
     structural_records_path: Path | None,
+    *,
+    failed_stacks: dict[str, str] | None = None,
 ) -> None:
     """Write the canonical ``merged-items.json`` for a tiny-diff run (issue #172).
 
@@ -3063,6 +3070,16 @@ def _write_single_stack_merged_items(
     canonical_path = repo / REVIEW_OUTPUT_FILE
     report_path = merged_report_path(deep_dir_path)
     items_path = merged_items_path(deep_dir_path)
+
+    # Surface failed stacks (CodeRabbit: single-stack bypass must not silently
+    # succeed when a reviewer crashed). The full merge path passes these into
+    # the merge prompt; here we warn so the failure is visible in the report.
+    if failed_stacks:
+        print_warning(
+            console,
+            f"Single-stack run completed with {len(failed_stacks)} failed stack(s): "
+            + ", ".join(sorted(failed_stacks)),
+        )
 
     # Clear stale outputs (mirrors phase_cross_stack_merge).
     canonical_path.unlink(missing_ok=True)

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -2706,6 +2706,7 @@ async def phase_per_stack_reviews(
     intent_path: Path,
     alternatives_path: Path,
     exploration_dir: Path | None = None,
+    diff_text: str | None = None,
 ) -> tuple[dict[str, Path], dict[str, str]]:
     """Run one review agent per detected stack concurrently (D-17).
 
@@ -2721,6 +2722,12 @@ async def phase_per_stack_reviews(
         intent_path: Path to TTT intent.md.
         alternatives_path: Path to TTT alternatives.json.
         exploration_dir: Optional pre-scan exploration directory.
+        diff_text: Issue #172 Fix B. The raw unified diff text. When supplied,
+            the per-stack / generic-fallback prompts inline the relevant hunks
+            for each stack (via ``_diff_blocks_for_files``) and drop the
+            ``Read it directly`` instruction. ``None`` falls back to the
+            diff_path pointer. The structural prompt is never inlined
+            (it roams repo-wide by design).
 
     Returns:
         Tuple of ``(successes, failures)``:
@@ -2736,6 +2743,7 @@ async def phase_per_stack_reviews(
     from daydream.deep import prompts as _prompts
     from daydream.deep.artifacts import deep_dir as _deep_dir
     from daydream.deep.artifacts import per_stack_review_path
+    from daydream.deep.orchestrator import _diff_blocks_for_files
 
     deep_dir_path = _deep_dir(work.repo)
     recorder = get_current_recorder()
@@ -2748,6 +2756,9 @@ async def phase_per_stack_reviews(
         for stack in stacks:
             output_path = per_stack_review_path(deep_dir_path, stack.stack_name)
             if stack.stack_name == STRUCTURE_STACK_NAME:
+                # Structural prompt is NOT inlined — its lens legitimately roams
+                # beyond the diff, so it keeps its diff_path pointer and its
+                # repo-wide Read/Grep/Bash freedom.
                 prompt = _prompts.build_structural_prompt(
                     files=stack.files,
                     diff_path=diff_path,
@@ -2757,29 +2768,40 @@ async def phase_per_stack_reviews(
                     exploration_dir=exploration_dir,
                     prior_commits=prior_commits,
                 )
-            elif stack.skill_invocation is None:
-                prompt = _prompts.build_generic_fallback_prompt(
-                    files=stack.files,
-                    diff_path=diff_path,
-                    intent_path=intent_path,
-                    alternatives_path=alternatives_path,
-                    output_path=output_path,
-                    exploration_dir=exploration_dir,
-                    is_docs_only=stack.is_docs_only,
-                    prior_commits=prior_commits,
-                )
             else:
-                prompt = _prompts.build_per_stack_prompt(
-                    skill_invocation=stack.skill_invocation,
-                    stack_name=stack.stack_name,
-                    files=stack.files,
-                    diff_path=diff_path,
-                    intent_path=intent_path,
-                    alternatives_path=alternatives_path,
-                    output_path=output_path,
-                    exploration_dir=exploration_dir,
-                    prior_commits=prior_commits,
+                # Issue #172 Fix B: inline the relevant diff hunks for this
+                # stack when diff_text is supplied AND the blocks fit the byte
+                # budget. ``None`` falls back to the diff_path pointer.
+                inline_diff = (
+                    _diff_blocks_for_files(diff_text, stack.files)
+                    if diff_text is not None
+                    else None
                 )
+                if stack.skill_invocation is None:
+                    prompt = _prompts.build_generic_fallback_prompt(
+                        files=stack.files,
+                        diff_path=diff_path,
+                        intent_path=intent_path,
+                        alternatives_path=alternatives_path,
+                        output_path=output_path,
+                        exploration_dir=exploration_dir,
+                        is_docs_only=stack.is_docs_only,
+                        prior_commits=prior_commits,
+                        inline_diff=inline_diff,
+                    )
+                else:
+                    prompt = _prompts.build_per_stack_prompt(
+                        skill_invocation=stack.skill_invocation,
+                        stack_name=stack.stack_name,
+                        files=stack.files,
+                        diff_path=diff_path,
+                        intent_path=intent_path,
+                        alternatives_path=alternatives_path,
+                        output_path=output_path,
+                        exploration_dir=exploration_dir,
+                        prior_commits=prior_commits,
+                        inline_diff=inline_diff,
+                    )
 
             # Default-arg capture -- prevents late-binding closure bug (Pitfall 2).
             async def _task(

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -2743,7 +2743,7 @@ async def phase_per_stack_reviews(
     from daydream.deep import prompts as _prompts
     from daydream.deep.artifacts import deep_dir as _deep_dir
     from daydream.deep.artifacts import per_stack_review_path
-    from daydream.deep.orchestrator import _diff_blocks_for_files
+    from daydream.deep.prompts import _diff_blocks_for_files
 
     deep_dir_path = _deep_dir(work.repo)
     recorder = get_current_recorder()
@@ -2942,6 +2942,147 @@ async def phase_arbiter_review(
     return verdicts
 
 
+def _append_structural_and_write_merged(
+    base_items: list[dict[str, Any]],
+    structural_records_path: Path | None,
+    items_path: Path,
+    report_path: Path,
+    canonical_path: Path,
+) -> None:
+    """Append structural records to ``base_items`` and write the merged artifacts.
+
+    Single source of truth for the structural-tagging + write epilogue shared
+    by ``phase_cross_stack_merge`` (multi-stack) and
+    ``_write_single_stack_merged_items`` (tiny-diff bypass, issue #172), so the
+    merge-write contract lives in exactly one place instead of being copied.
+
+    Performs the shared sequence:
+      - parse ``structural_records_path`` with graceful degradation to ``[]``
+        on malformed/missing output (a prior agent run may have emitted bad
+        JSON -- degrade rather than crash);
+      - append structural findings tagged ``lens="structural"`` with HIGH/high
+        confidence/severity defaults -- the structural lens is high-conviction
+        by construction and must not be demoted at sort time;
+      - normalize the combined list (fresh unique ids) and write the canonical
+        ``merged-items.json``;
+      - render ``review-output.md`` from the canonical items and copy it to
+        ``canonical_path`` (the deep artifact dir avoids sandbox write
+        restrictions on repo-root dotfiles).
+
+    Callers own the clear-stale step: each clears ``items_path`` /
+    ``report_path`` / ``canonical_path`` at a point appropriate to its own
+    failure semantics (``phase_cross_stack_merge`` clears *before* the merge
+    agent runs so a crash leaves no stale output; the single-stack bypass has
+    no agent, so it clears immediately before this call). Keeping clear-stale
+    out of this helper preserves both error-handling contracts.
+
+    Args:
+        base_items: Non-structural records (merge-agent items or per-stack
+            records already tagged ``lens="per-stack"``).
+        structural_records_path: Optional path to the parsed structural
+            meta-stack records JSON. ``None`` when no structural review ran.
+        items_path: Canonical ``merged-items.json`` path.
+        report_path: Rendered report path inside the deep artifact dir.
+        canonical_path: Repo-root canonical report (``REVIEW_OUTPUT_FILE``).
+
+    """
+    from daydream.deep.render import render_report
+
+    # Append structural findings in Python, tagged lens="structural". They are
+    # parsed FEEDBACK_SCHEMA records ({id, description, file, line}) and carry no
+    # confidence/severity, so default both to HIGH/high -- the structural lens is
+    # high-conviction by construction and must not be demoted at sort time.
+    structural_items: list[dict[str, Any]] = []
+    if structural_records_path is not None and structural_records_path.is_file():
+        try:
+            structural_records = json.loads(structural_records_path.read_text())
+        except (json.JSONDecodeError, OSError) as exc:
+            # Structural records come from a prior agent run that may have emitted
+            # malformed output; degrade to none rather than crash the merge.
+            print_warning(console, f"Skipping malformed structural records: {type(exc).__name__}: {exc}")
+            structural_records = []
+        for rec in structural_records:
+            structural_items.append(
+                {
+                    **rec,
+                    "lens": "structural",
+                    "confidence": rec.get("confidence", "HIGH"),
+                    "severity": rec.get("severity", "high"),
+                }
+            )
+
+    items = normalize_items(base_items + structural_items)
+    items_path.write_text(json.dumps({"items": items}, indent=2))
+    print_info(console, f"Merged into {len(items)} items")
+
+    # Render the human report FROM the canonical items, then copy from the deep
+    # artifact dir to the canonical location (the deep dir avoids sandbox write
+    # restrictions on repo-root dotfiles).
+    report_path.write_text(render_report(items))
+    canonical_path.write_text(report_path.read_text())
+
+
+def _write_single_stack_merged_items(
+    repo: Path,
+    deep_dir_path: Path,
+    all_records: list[dict[str, Any]],
+    structural_records_path: Path | None,
+) -> None:
+    """Write the canonical ``merged-items.json`` for a tiny-diff run (issue #172).
+
+    Replaces ``phase_cross_stack_merge`` for single-stack-mode runs: there is
+    nothing to cross-stack-merge and nothing contested to arbitrate, so the
+    host writes the canonical item list directly. The structural-tagging +
+    write epilogue is shared with ``phase_cross_stack_merge`` via
+    ``_append_structural_and_write_merged`` so downstream consumers (fix gate,
+    verifier, PR posting) consume items unchanged (AC6).
+
+    Owns only the single-stack-specific steps ``phase_cross_stack_merge``
+    delegates to its merge agent:
+      - clears stale ``merged-items.json`` / ``review-output.md`` /
+        canonical ``REVIEW_OUTPUT_FILE`` so a failed prior run can't leave
+        behind outdated content;
+      - tags per-stack records with ``lens="per-stack"`` (the merge agent
+        normally does this; in single-stack mode the host does it);
+      - delegates the structural append + normalize + render + copy to
+        ``_append_structural_and_write_merged``.
+
+    Args:
+        repo: Repository root (``work.repo``); the canonical report is written
+            alongside the deep artifact directory.
+        deep_dir_path: Deep artifact directory (``target / .daydream / deep``).
+        all_records: Non-structural parsed per-stack records (already
+            partitioned by the caller). Carries ``severity`` / ``confidence``
+            / ``rationale`` from ``PER_STACK_RECORD_SCHEMA`` but no ``lens``.
+        structural_records_path: Optional path to the parsed structural
+            meta-stack records JSON. ``None`` when no structural review ran.
+
+    """
+    from daydream.deep.artifacts import merged_items_path, merged_report_path
+
+    canonical_path = repo / REVIEW_OUTPUT_FILE
+    report_path = merged_report_path(deep_dir_path)
+    items_path = merged_items_path(deep_dir_path)
+
+    # Clear stale outputs (mirrors phase_cross_stack_merge).
+    canonical_path.unlink(missing_ok=True)
+    report_path.unlink(missing_ok=True)
+    items_path.unlink(missing_ok=True)
+
+    # Tag per-stack records (the merge agent normally sets lens; here the host
+    # does it). ``severity`` is already present from PER_STACK_RECORD_SCHEMA.
+    per_stack_items: list[dict[str, Any]] = [
+        {**rec, "lens": "per-stack"} for rec in all_records
+    ]
+
+    # Structural append + normalize + render + copy is shared with
+    # phase_cross_stack_merge (via _append_structural_and_write_merged) so the
+    # lens taxonomy and downstream verifier accounting stay identical (AC6).
+    _append_structural_and_write_merged(
+        per_stack_items, structural_records_path, items_path, report_path, canonical_path
+    )
+
+
 async def phase_cross_stack_merge(
     backend: Backend,
     work: WorkContext,
@@ -2999,7 +3140,6 @@ async def phase_cross_stack_merge(
     """
     from daydream.deep.artifacts import deep_dir, merged_items_path, merged_report_path
     from daydream.deep.prompts import build_merge_prompt
-    from daydream.deep.render import render_report
 
     dd = deep_dir(work.repo)
     canonical_path = work.repo / REVIEW_OUTPUT_FILE
@@ -3034,36 +3174,12 @@ async def phase_cross_stack_merge(
         raise ValueError(f"Cross-stack merge returned no item list (got {type(result).__name__})")
     agent_items: list[dict[str, Any]] = result["items"]
 
-    # Append structural findings in Python, tagged lens="structural". They are
-    # parsed FEEDBACK_SCHEMA records ({id, description, file, line}) and carry no
-    # confidence/severity, so default both to HIGH/high -- the structural lens is
-    # high-conviction by construction and must not be demoted at sort time.
-    structural_items: list[dict[str, Any]] = []
-    if structural_records_path is not None and structural_records_path.is_file():
-        try:
-            structural_records = json.loads(structural_records_path.read_text())
-        except (json.JSONDecodeError, OSError) as exc:
-            # Structural records come from a prior agent run that may have emitted
-            # malformed output; degrade to none rather than crash the merge.
-            print_warning(console, f"Skipping malformed structural records: {type(exc).__name__}: {exc}")
-            structural_records = []
-        for rec in structural_records:
-            structural_items.append(
-                {
-                    **rec,
-                    "lens": "structural",
-                    "confidence": rec.get("confidence", "HIGH"),
-                    "severity": rec.get("severity", "high"),
-                }
-            )
-
-    items = normalize_items(agent_items + structural_items)
-    items_path.write_text(json.dumps({"items": items}, indent=2))
-    print_info(console, f"Merged into {len(items)} items")
-
-    # Render the human report FROM the canonical items, then copy from the deep
-    # artifact dir to the canonical location (the deep dir avoids sandbox write
-    # restrictions on repo-root dotfiles).
-    report_path.write_text(render_report(items))
-    canonical_path.write_text(report_path.read_text())
+    # Structural append + normalize + render + copy is shared with
+    # _write_single_stack_merged_items via _append_structural_and_write_merged
+    # so the lens taxonomy and downstream verifier accounting stay identical
+    # (AC6). The structural-tagging + graceful-malformed-degradation rationale
+    # is documented there.
+    _append_structural_and_write_merged(
+        agent_items, structural_records_path, items_path, report_path, canonical_path
+    )
     return canonical_path

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -187,6 +187,11 @@ class RunConfig:
         assume: Forced yes/no answer for interactive gates — ``"yes"`` (``--yes``),
             ``"no"``, or ``None``. Orthogonal to ``non_interactive``: it supplies a
             pre-decided answer rather than controlling stdin access.
+        shallow_fanout_threshold: Max changed-file count that triggers the
+            tiny-diff short-circuit in deep mode (issue #172). ``None`` falls
+            through to ``file_config.shallow_fanout_threshold`` then
+            ``DEFAULT_SHALLOW_FANOUT_THRESHOLD`` (precedence CLI > file > default,
+            mirroring ``_resolve_backend``). ``0`` disables the short-circuit.
 
     """
 
@@ -229,6 +234,10 @@ class RunConfig:
     non_interactive: bool = False
     assume: str | None = None  # forced gate answer: "yes" (--yes), "no", or None
     identity: str = "unknown"  # resolved GitHub identity; set once by run()
+    # Issue #172: tiny-diff short-circuit gate (max changed files). CLI-tier
+    # override; falls through to file-config scalar then the orchestrator
+    # default (DEFAULT_SHALLOW_FANOUT_THRESHOLD). ``0`` disables the gate.
+    shallow_fanout_threshold: int | None = None
 
 
 def _print_missing_skill_error(skill_name: str) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -246,6 +246,72 @@ def multi_stack_target(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
+def tiny_diff_target(tmp_path: Path) -> Path:
+    """Git repo with a 2-file two-language diff on a feature branch (issue #172).
+
+    Mirrors ``multi_stack_target`` but with only two changed files (``api.py`` +
+    ``App.tsx``) so the deep pipeline's tiny-diff short-circuit fires: the two
+    language stacks collapse into one combined generic-fallback assignment and
+    the merge agent + arbiter are skipped. Used by AC2 / AC5 real-path tests.
+    """
+    project = tmp_path / "tiny_diff"
+    project.mkdir()
+    (project / "api.py").write_text("def hello():\n    return 'world'\n")
+    (project / "App.tsx").write_text("export const App = () => <div>hello</div>;\n")
+    subprocess.run(  # noqa: S603
+        ["git", "init", "-b", "main"],  # noqa: S607
+        cwd=project,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(  # noqa: S603
+        ["git", "config", "user.email", "test@test.com"],  # noqa: S607
+        cwd=project,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(  # noqa: S603
+        ["git", "config", "user.name", "Test"],  # noqa: S607
+        cwd=project,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(  # noqa: S603
+        ["git", "add", "."],  # noqa: S607
+        cwd=project,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(  # noqa: S603
+        ["git", "commit", "-m", "init"],  # noqa: S607
+        cwd=project,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(  # noqa: S603
+        ["git", "checkout", "-b", "feature"],  # noqa: S607
+        cwd=project,
+        capture_output=True,
+        check=True,
+    )
+    (project / "api.py").write_text("def hello():\n    return 'universe'\n")
+    (project / "App.tsx").write_text("export const App = () => <div>universe</div>;\n")
+    subprocess.run(  # noqa: S603
+        ["git", "add", "."],  # noqa: S607
+        cwd=project,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(  # noqa: S603
+        ["git", "commit", "-m", "change"],  # noqa: S607
+        cwd=project,
+        capture_output=True,
+        check=True,
+    )
+    return project
+
+
+@pytest.fixture
 def make_work() -> Callable[..., WorkContext]:
     """Builder for synthetic ``WorkContext`` instances.
 

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -3124,3 +3124,378 @@ async def test_alternatives_runs_for_multi_file_diff(
         or "evaluate the implementation" in c["prompt"].lower()
     ]
     assert alt_calls, "alternatives wonder prompt was not dispatched for a 3-file diff"
+
+# =============================================================================
+# Issue #172 — Perf: tiny-diff short-circuit + read-once diff hunks
+# =============================================================================
+
+
+def test_shallow_fanout_threshold_precedence() -> None:
+    """AC7: SHALLOW_FANOUT_THRESHOLD honors CLI (RunConfig) > config file > default.
+
+    Mirrors the `_resolve_backend` precedence pattern; uses `is not None` so a
+    config value of ``0`` (disable the short-circuit entirely) is honored
+    rather than treated as falsy.
+    """
+    from daydream.config_file import DaydreamFileConfig
+    from daydream.deep.orchestrator import (
+        DEFAULT_SHALLOW_FANOUT_THRESHOLD,
+        _shallow_fanout_threshold,
+    )
+    from daydream.runner import RunConfig
+
+    # Default: no CLI field, no file_config.
+    assert _shallow_fanout_threshold(RunConfig()) == DEFAULT_SHALLOW_FANOUT_THRESHOLD
+    # Explicit 0 on RunConfig disables the short-circuit (must NOT be ignored as falsy).
+    assert _shallow_fanout_threshold(RunConfig(shallow_fanout_threshold=0)) == 0
+    # CLI value wins.
+    assert _shallow_fanout_threshold(RunConfig(shallow_fanout_threshold=5)) == 5
+    # File-config value beats default.
+    fc = DaydreamFileConfig(shallow_fanout_threshold=3)
+    assert _shallow_fanout_threshold(RunConfig(file_config=fc)) == 3
+    # File-config value of 0 (disable) is honored, not treated as falsy.
+    fc_zero = DaydreamFileConfig(shallow_fanout_threshold=0)
+    assert _shallow_fanout_threshold(RunConfig(file_config=fc_zero)) == 0
+    # CLI > file.
+    assert (
+        _shallow_fanout_threshold(
+            RunConfig(file_config=fc, shallow_fanout_threshold=5)
+        )
+        == 5
+    )
+
+
+def test_collapse_stacks_for_tiny_diff_single_language() -> None:
+    """AC1 (unit): 1-file single-language diff collapses to a strictly smaller agent count.
+
+    Today `detect_stacks(["api.py"])` yields 2 stacks (python + structure) →
+    `total_agent_count(2) == 8`. After collapse:
+      - lever 1 (collapse language fan-out) is a no-op (only one language stack)
+      - lever 2 (skip merge+arbiter) drops the count to ``_single_stack_agent_count``
+        which must be strictly less than 8.
+    """
+    from daydream.deep.detection import detect_stacks
+    from daydream.deep.orchestrator import (
+        _collapse_stacks_for_tiny_diff,
+        _single_stack_agent_count,
+        total_agent_count,
+    )
+
+    stacks = detect_stacks(["api.py"])
+    assert len(stacks) == 2  # python + structure (baseline sanity check)
+    baseline_count = total_agent_count(len(stacks))  # 8
+
+    collapsed, single_stack_mode = _collapse_stacks_for_tiny_diff(
+        stacks, ["api.py"], threshold=2
+    )
+    assert single_stack_mode is True
+    # Structure stack stays as its own assignment (AC6 lens taxonomy preserved).
+    stack_names = [s.stack_name for s in collapsed]
+    assert "structure" in stack_names
+    # The collapsed run uses the single-stack agent count, which MUST be strictly
+    # less than the baseline 8 (lever 2: skip merge+arbiter).
+    assert _single_stack_agent_count(len(collapsed)) < baseline_count
+
+
+def test_collapse_stacks_for_tiny_diff_two_languages() -> None:
+    """AC1 (unit): 2-file two-language diff collapses the language fan-out.
+
+    Today `detect_stacks(["api.py", "App.tsx"])` yields 3 stacks (python + react
+    + structure) → ``total_agent_count(3) == 12``. After collapse the two
+    language stacks merge into one combined (generic-fallback) stack, so the
+    surviving stack list is `[combined, structure]` (≤2). The single-stack agent
+    count for ≤2 stacks is strictly less than 12.
+    """
+    from daydream.deep.detection import detect_stacks
+    from daydream.deep.orchestrator import (
+        _collapse_stacks_for_tiny_diff,
+        _single_stack_agent_count,
+        total_agent_count,
+    )
+
+    stacks = detect_stacks(["api.py", "App.tsx"])
+    assert len(stacks) == 3  # python + react + structure (baseline)
+    baseline_count = total_agent_count(len(stacks))  # 12
+
+    collapsed, single_stack_mode = _collapse_stacks_for_tiny_diff(
+        stacks, ["api.py", "App.tsx"], threshold=2
+    )
+    assert single_stack_mode is True
+    # Collapse merged the two language stacks into one combined assignment.
+    non_structural = [s for s in collapsed if s.stack_name != "structure"]
+    assert len(non_structural) == 1
+    combined = non_structural[0]
+    # Combined assignment carries both files and uses the generic-fallback skill
+    # (a single agent cannot invoke two per-language Beagle skills).
+    assert set(combined.files) == {"api.py", "App.tsx"}
+    assert combined.skill_invocation is None
+    # Single-stack agent count is strictly less than 12.
+    assert _single_stack_agent_count(len(collapsed)) < baseline_count
+
+
+def test_collapse_stacks_for_tiny_diff_disabled_at_threshold_zero() -> None:
+    """AC7 edge: threshold=0 disables the short-circuit (no collapse happens)."""
+    from daydream.deep.detection import detect_stacks
+    from daydream.deep.orchestrator import _collapse_stacks_for_tiny_diff
+
+    stacks = detect_stacks(["api.py", "App.tsx"])
+    collapsed, single_stack_mode = _collapse_stacks_for_tiny_diff(
+        stacks, ["api.py", "App.tsx"], threshold=0
+    )
+    assert single_stack_mode is False
+    assert collapsed == stacks  # unchanged
+
+
+def _count_review_prompts(calls: list[dict[str, Any]]) -> int:
+    """Count per-stack + structural review prompts in a captured call list.
+
+    Discriminators mirror the production prompt builders:
+      - per-stack / generic-fallback: ``"you are reviewing the <X> stack"``
+      - structural: ``"you are the structural reviewer"``
+    """
+    n = 0
+    for c in calls:
+        pl = c["prompt"].lower()
+        if "you are reviewing the" in pl and "stack" in pl:
+            n += 1
+        elif "you are the structural reviewer" in pl:
+            n += 1
+    return n
+
+
+def _count_merge_prompts(calls: list[dict[str, Any]]) -> int:
+    """Count cross-stack merge-agent prompts (discriminator: 'cross-stack merge agent')."""
+    return sum(1 for c in calls if "cross-stack merge agent" in c["prompt"].lower())
+
+
+async def test_ac2_tiny_diff_collapses_fanout_and_skips_merge(
+    tiny_diff_target: Path, multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC2 (real-path): a ≤2-file two-language diff collapses the fan-out.
+
+    Drives ``runner.run`` through the full deep pipeline on a 2-file repo
+    (``api.py`` + ``App.tsx``). The tiny-diff short-circuit MUST:
+      - collapse the two language stacks (python + react) into one combined
+        generic-fallback review (≤2 review agents total, vs 4 for multi_stack);
+      - skip the merge agent + arbiter;
+      - still write the canonical ``merged-items.json`` (AC6 unchanged schema).
+
+    The proof is directional: the same harness run against ``multi_stack_target``
+    yields strictly more review prompts and a recorded merge-agent prompt, while
+    the tiny-diff run yields strictly fewer and no merge prompt.
+    """
+    from daydream.runner import RunConfig, run
+
+    # Run BOTH repos through the identical harness so the count comparison is a
+    # paired observation, not an absolute threshold.
+    async def _drive(target: Path) -> list[dict[str, Any]]:
+        # Fresh shared-call list per run (the factory binds it via closure).
+        _silence(monkeypatch)
+        shared_calls = _install_model_capturing_stubs(monkeypatch, target)
+        # Stub the post-merge side effects so the run terminates cleanly.
+        monkeypatch.setattr("daydream.deep.orchestrator.phase_test_and_heal", lambda *a, **k: _ok())
+        monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _noop_commit)
+        async def _no_post(target_dir: Path, report_path: Path, *, console: Any) -> None:
+            return None
+        monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _no_post)
+        rc = await run(RunConfig(target=str(target), start_at="review", cleanup=False))
+        assert rc == 0, f"deep run on {target.name} exited {rc}"
+        return list(shared_calls)
+
+    tiny_calls = await _drive(tiny_diff_target)
+    multi_calls = await _drive(multi_stack_target)
+
+    # (b) Canonical merged-items.json written for the tiny diff.
+    items_file = tiny_diff_target / ".daydream" / "deep" / "merged-items.json"
+    assert items_file.is_file(), f"merged-items.json missing at {items_file}"
+    items_payload = json.loads(items_file.read_text())
+    assert isinstance(items_payload.get("items"), list)
+
+    # (c) Review-prompt count for tiny diff is STRICTLY LESS than multi_stack.
+    tiny_reviews = _count_review_prompts(tiny_calls)
+    multi_reviews = _count_review_prompts(multi_calls)
+    assert tiny_reviews < multi_reviews, (
+        f"tiny-diff review fan-out did not collapse: tiny={tiny_reviews}, multi={multi_reviews}"
+    )
+    # Tiny diff: 2 review agents (combined lang + structure). Multi: 4.
+    assert tiny_reviews == 2, f"expected 2 review agents for tiny diff, got {tiny_reviews}"
+    assert multi_reviews == 4, f"expected 4 review agents for multi_stack, got {multi_reviews}"
+
+    # The merge agent MUST be skipped on the tiny diff (lever 2).
+    assert _count_merge_prompts(tiny_calls) == 0, "merge agent ran on tiny diff"
+    # And the multi_stack run still invokes it (regression-guard for AC3).
+    assert _count_merge_prompts(multi_calls) == 1, "merge agent missing on multi_stack"
+
+
+async def test_ac3_multi_stack_fanout_unchanged_by_short_circuit(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC3 (regression guard): the ≥3-file fan-out is byte-for-byte unchanged.
+
+    The tiny-diff short-circuit is scoped to ≤threshold files. The 3-file
+    ``multi_stack_target`` (python + react + generic + structure = 4 stacks)
+    MUST still perform the full fan-out AND invoke the merge agent. This test
+    pairs with AC2 to prove the gate is scoped correctly.
+
+    This also documents that ``test_preflight_notice`` (which asserts
+    ``agent_count == 12`` for this fixture) stays green: 4 stacks → 12 agents,
+    unchanged because no collapse fires above the threshold.
+    """
+    from daydream.runner import RunConfig, run
+
+    _silence(monkeypatch)
+    shared_calls = _install_model_capturing_stubs(monkeypatch, multi_stack_target)
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_test_and_heal", lambda *a, **k: _ok())
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _noop_commit)
+    async def _no_post(target_dir: Path, report_path: Path, *, console: Any) -> None:
+        return None
+    monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _no_post)
+
+    rc = await run(RunConfig(target=str(multi_stack_target), start_at="review", cleanup=False))
+    assert rc == 0
+
+    # 4 stacks → 4 review prompts (python + react + generic + structure).
+    assert _count_review_prompts(shared_calls) == 4
+    # Merge agent still runs (NOT collapsed).
+    assert _count_merge_prompts(shared_calls) == 1
+
+
+async def test_ac5_per_stack_prompt_inlines_diff_hunks(
+    tiny_diff_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC5 (real-path): per-stack review prompts contain inlined diff hunks and
+    NO ``Read it directly`` / diff_path instruction.
+
+    Drives ``runner.run`` through the deep pipeline on a 2-file fixture and
+    inspects the recorded prompts on the stub's shared call list. The per-stack
+    review prompt MUST inline the relevant hunks and MUST NOT instruct the agent
+    to ``Read it directly`` — proving ``diff.patch`` is read 0 times
+    (transitively: no Read instruction + hunks present inline).
+
+    Grounding note: ``_StubBackend`` does not model tool-call execution (its
+    review branch writes the review file directly without emitting Read events),
+    so "diff.patch is Read 0 times" is proven by the absence of the Read
+    instruction in the recorded prompt, not by counting Read events.
+    """
+    from daydream.runner import RunConfig, run
+
+    _silence(monkeypatch)
+    shared_calls = _install_model_capturing_stubs(monkeypatch, tiny_diff_target)
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_test_and_heal", lambda *a, **k: _ok())
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _noop_commit)
+
+    async def _no_post(target_dir: Path, report_path: Path, *, console: Any) -> None:
+        return None
+
+    monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _no_post)
+
+    rc = await run(RunConfig(target=str(tiny_diff_target), start_at="review", cleanup=False))
+    assert rc == 0
+
+    # The per-stack review prompt is the one carrying the scope discriminator.
+    # (The structural prompt is intentionally NOT inlined — Fix B excludes it.)
+    per_stack_review_prompts = [
+        c["prompt"]
+        for c in shared_calls
+        if "you are reviewing the" in c["prompt"].lower() and "stack" in c["prompt"].lower()
+    ]
+    assert per_stack_review_prompts, "expected at least one per-stack review prompt"
+    prompt = per_stack_review_prompts[0]
+
+    # Hunks are inlined: the actual changed content reaches the prompt.
+    assert "return 'universe'" in prompt, "expected inlined hunk content in per-stack prompt"
+    # The Read instruction is absent (the agent is never told to Read diff.patch).
+    assert "Read it directly" not in prompt
+    # And diff_path is not embedded as an instruction (it remains a required
+    # param of the builder but is not surfaced when hunks are inlined).
+    diff_path_str = str(tiny_diff_target / ".daydream" / "diff.patch")
+    assert diff_path_str not in prompt
+
+    # Discriminating check: the STRUCTURAL prompt still carries the pointer
+    # (Fix B does NOT inline the structural / arbiter prompts).
+    structural_prompts = [
+        c["prompt"] for c in shared_calls if "you are the structural reviewer" in c["prompt"].lower()
+    ]
+    assert structural_prompts, "expected a structural review prompt"
+    assert "Read it directly" in structural_prompts[0]
+    assert diff_path_str in structural_prompts[0]
+
+
+async def test_ac6_single_stack_merged_items_carry_structural_lens(
+    tiny_diff_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC6: tiny-diff single-stack writer tags structural items ``lens="structural"``.
+
+    The single-stack host writer (``_write_single_stack_merged_items``) must
+    replicate ``phase_cross_stack_merge``'s structural tagging exactly so the
+    verifier's matched/unmatched accounting (orchestrator.py:968/973) does not
+    drift. Real-path: drive the tiny-diff flow, parse merged-items.json, and
+    assert at least one item carries ``lens="structural"``.
+    """
+    from daydream.runner import RunConfig, run
+
+    _silence(monkeypatch)
+    _install_model_capturing_stubs(monkeypatch, tiny_diff_target)
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_test_and_heal", lambda *a, **k: _ok())
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _noop_commit)
+
+    async def _no_post(target_dir: Path, report_path: Path, *, console: Any) -> None:
+        return None
+
+    monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _no_post)
+
+    rc = await run(RunConfig(target=str(tiny_diff_target), start_at="review", cleanup=False))
+    assert rc == 0
+
+    items_file = tiny_diff_target / ".daydream" / "deep" / "merged-items.json"
+    assert items_file.is_file()
+    items = json.loads(items_file.read_text())["items"]
+    lenses = {i.get("lens") for i in items}
+    # Structural findings reach the canonical item list tagged correctly.
+    assert "structural" in lenses, f"no structural-lens items in {lenses}"
+    # And every item carries a fresh contiguous integer id (normalize_items).
+    assert all(isinstance(i.get("id"), int) for i in items), "non-integer id in merged items"
+    assert [i["id"] for i in items] == list(range(1, len(items) + 1)), "ids not contiguous"
+
+
+async def test_ac_fix_resume_on_tiny_diff(
+    tiny_diff_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Issue #172 risk: ``--start-at fix`` resume on a tiny diff works.
+
+    ``single_stack_mode`` is recomputed at the top of ``run_deep`` from
+    ``changed_files``, so a resume re-enters the same bypass branch. The merge
+    block is skipped (``config.start_at == "fix"``), and the fix gate reads the
+    surviving ``merged-items.json`` produced by the single-stack writer. This
+    test primes the tiny-diff artifacts with a first run, then resumes with
+    ``--start-at fix`` and asserts the fix loop reads the JSON and applies.
+    """
+    from daydream.runner import RunConfig, run
+
+    # Phase 1: produce merged-items.json via a full tiny-diff run.
+    _silence(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, tiny_diff_target)
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_test_and_heal", lambda *a, **k: _ok())
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _noop_commit)
+
+    async def _no_post(target_dir: Path, report_path: Path, *, console: Any) -> None:
+        return None
+
+    monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _no_post)
+
+    rc = await run(RunConfig(target=str(tiny_diff_target), assume="no", cleanup=False))
+    assert rc == 0
+    items_file = tiny_diff_target / ".daydream" / "deep" / "merged-items.json"
+    assert items_file.is_file(), "priming run did not produce merged-items.json"
+
+    # Phase 2: resume with --start-at fix and accept the gate; the fix loop
+    # must read the canonical JSON and dispatch at least one fix prompt.
+    _force_interactive(monkeypatch)
+    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
+
+    rc = await run(
+        RunConfig(target=str(tiny_diff_target), start_at="fix", assume="yes", cleanup=False)
+    )
+    assert rc == 0
+    fix_prompts = [c for c in stub.calls if c["prompt"].startswith("Fix this issue")]
+    assert fix_prompts, "fix loop did not run on --start-at fix resume"

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -3233,6 +3233,43 @@ def test_collapse_stacks_for_tiny_diff_two_languages() -> None:
     assert _single_stack_agent_count(len(collapsed)) < baseline_count
 
 
+def test_collapse_stacks_for_tiny_diff_code_plus_docs_preserves_language_skill() -> None:
+    """Skill-preservation (unit): code+docs tiny diff keeps the per-language skill.
+
+    A code+docs/config tiny diff routes via ``detect_stacks`` to exactly one real
+    language stack plus the ``generic`` bucket (e.g. ``api.py`` + ``README.md`` →
+    ``python`` + ``generic``). That is a single-language diff, so the collapse
+    must absorb the generic files into the language stack and keep its
+    per-language Beagle skill -- NOT downgrade it to the generic fallback
+    (the skill-preservation goal stated in ``_collapse_stacks_for_tiny_diff``'s
+    docstring). Only ≥2 *real* language stacks fall back to generic.
+    """
+    from daydream.deep.detection import detect_stacks
+    from daydream.deep.orchestrator import (
+        _collapse_stacks_for_tiny_diff,
+        _single_stack_agent_count,
+        total_agent_count,
+    )
+
+    files = ["api.py", "README.md"]
+    stacks = detect_stacks(files)
+    # Baseline sanity: python (real language) + generic + structure.
+    assert [s.stack_name for s in stacks] == ["python", "generic", "structure"]
+    baseline_count = total_agent_count(len(stacks))  # 12
+
+    collapsed, single_stack_mode = _collapse_stacks_for_tiny_diff(stacks, files, threshold=2)
+    assert single_stack_mode is True
+    non_structural = [s for s in collapsed if s.stack_name != "structure"]
+    assert len(non_structural) == 1
+    combined = non_structural[0]
+    # The real-language skill survives (NOT downgraded to generic fallback).
+    assert combined.stack_name == "python"
+    assert combined.skill_invocation == "beagle-python:review-python"
+    # The docs file is absorbed into the language stack.
+    assert set(combined.files) == {"api.py", "README.md"}
+    assert _single_stack_agent_count(len(collapsed)) < baseline_count
+
+
 def test_collapse_stacks_for_tiny_diff_disabled_at_threshold_zero() -> None:
     """AC7 edge: threshold=0 disables the short-circuit (no collapse happens)."""
     from daydream.deep.detection import detect_stacks
@@ -3499,3 +3536,87 @@ async def test_ac_fix_resume_on_tiny_diff(
     assert rc == 0
     fix_prompts = [c for c in stub.calls if c["prompt"].startswith("Fix this issue")]
     assert fix_prompts, "fix loop did not run on --start-at fix resume"
+
+
+async def test_ac_merge_resume_on_tiny_diff(
+    tiny_diff_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Issue #172: ``--start-at merge`` resume on a tiny diff routes to the
+    single-stack merge writer, not the multi-stack merge agent.
+
+    Every other ``start_at="merge"`` test drives ``multi_stack_target``. This
+    one drives the tiny-diff resume path the finding flagged as untested:
+    ``single_stack_mode`` is recomputed True for the 2-file diff at the top of
+    ``run_deep``, so the ``config.start_at == "merge"`` branch (which reloads
+    the collapsed-stack records from disk and re-partitions the structural
+    meta-stack) must route to ``_write_single_stack_merged_items`` rather than
+    ``phase_cross_stack_merge``.
+
+    ``phase_cross_stack_merge`` is patched to raise so a regression that fails
+    to recompute ``single_stack_mode`` on resume surfaces as a hard failure
+    instead of silently routing through the multi-stack merge agent.
+    """
+    from daydream.runner import RunConfig, run
+
+    _silence(monkeypatch)
+    _install_stub_backend(monkeypatch, tiny_diff_target)
+    # Regression guard: the multi-stack merge agent must NOT run in
+    # single_stack_mode. If the merge-resume branch misroutes here, raise.
+    async def _fail_merge(*_a: Any, **_k: Any) -> None:
+        raise AssertionError("phase_cross_stack_merge must not run in single_stack_mode")
+
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_cross_stack_merge", _fail_merge)
+    # Stub the post-merge side effects so the run terminates cleanly.
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_test_and_heal", lambda *a, **k: _ok())
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _noop_commit)
+
+    async def _no_post(target_dir: Path, report_path: Path, *, console: Any) -> None:
+        return None
+
+    monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _no_post)
+
+    # Prime the deep artifacts the merge-resume branch reads from disk. The
+    # tiny-diff collapse yields a ``generic`` (collapsed language) stack plus
+    # the ``structure`` meta-stack, so records files must match both.
+    deep = tiny_diff_target / ".daydream" / "deep"
+    deep.mkdir(parents=True, exist_ok=True)
+    (deep / "intent.md").write_text("primed intent")
+    (deep / "alternatives.json").write_text("[]")
+    (deep / "stack-generic-records.json").write_text(
+        json.dumps(
+            [{"id": "gen-1", "description": "generic per-stack issue", "file": "api.py", "line": 1}]
+        )
+    )
+    (deep / "stack-structure-records.json").write_text(
+        json.dumps(
+            [
+                {
+                    "id": "structure-1",
+                    "description": "file-size budget violated",
+                    "file": "api.py",
+                    "line": 1,
+                }
+            ]
+        )
+    )
+
+    rc = await run(
+        RunConfig(target=str(tiny_diff_target), start_at="merge", cleanup=False)
+    )
+    assert rc == 0
+
+    items_file = tiny_diff_target / ".daydream" / "deep" / "merged-items.json"
+    assert items_file.is_file(), "single-stack merge resume did not write merged-items.json"
+    items = json.loads(items_file.read_text())["items"]
+    # ``normalize_items`` reassigns ``id`` to a contiguous sequence, so assert on
+    # the preserved ``description`` + ``lens`` instead. The generic record is
+    # tagged per-stack and the structural record keeps its structural lens (AC6
+    # — lens taxonomy survives the host-written merge).
+    assert any(
+        i.get("description") == "generic per-stack issue" and i.get("lens") == "per-stack"
+        for i in items
+    ), f"generic per-stack item missing or mislabeled: {items}"
+    assert any(
+        i.get("description") == "file-size budget violated" and i.get("lens") == "structural"
+        for i in items
+    ), f"structural item missing or mislabeled: {items}"

--- a/tests/test_deep_pr_comment_integration.py
+++ b/tests/test_deep_pr_comment_integration.py
@@ -259,16 +259,36 @@ class _FakeSDKClient:
                 ),
             ]
 
-        # phase_parse_feedback (FEEDBACK_SCHEMA): ResultMessage must carry
-        # structured_output of the right shape.
+        # phase_parse_feedback (FEEDBACK_SCHEMA / PER_STACK_RECORD_SCHEMA):
+        # ResultMessage must carry structured_output of the right shape.
+        # Issue #172: the tiny-diff short-circuit writes ``merged-items.json``
+        # directly from these parsed records (no merge agent) for ≤2-file
+        # diffs, so the per-stack parse MUST yield a non-empty issue for the
+        # PR-comment pipeline to have content on the single-file fixture.
+        # The structural parse (FEEDBACK_SCHEMA, no ``severity`` in the prompt)
+        # returns empty — the per-stack record drives the assertion below.
         if "extract only actionable issues" in pl or "read the review output file" in pl:
+            if "severity" in pl:  # PER_STACK_RECORD_SCHEMA (per-stack parse)
+                issues = [
+                    {
+                        "id": 1,
+                        "description": "Use a more descriptive function name",
+                        "file": "foo.py",
+                        "line": 1,
+                        "severity": "medium",
+                        "confidence": "MEDIUM",
+                        "rationale": "The current name is ambiguous.",
+                    }
+                ]
+            else:  # FEEDBACK_SCHEMA (structural parse)
+                issues = []
             return [
                 FakeAssistantMessage(
                     content=[FakeTextBlock(text="parsing")],
                     model=FIXTURE_MODEL_ID,
                 ),
                 FakeResultMessage(
-                    structured_output={"issues": []},
+                    structured_output={"issues": issues},
                     total_cost_usd=0.05,
                     usage={
                         "input_tokens": 1500,

--- a/tests/test_deep_pr_comment_integration.py
+++ b/tests/test_deep_pr_comment_integration.py
@@ -268,7 +268,13 @@ class _FakeSDKClient:
         # The structural parse (FEEDBACK_SCHEMA, no ``severity`` in the prompt)
         # returns empty — the per-stack record drives the assertion below.
         if "extract only actionable issues" in pl or "read the review output file" in pl:
-            if "severity" in pl:  # PER_STACK_RECORD_SCHEMA (per-stack parse)
+            # phase_parse_feedback injects the ``severity`` hint/field into the
+            # prompt ONLY when PER_STACK_RECORD_SCHEMA is passed (per-stack parse);
+            # the structural parse uses FEEDBACK_SCHEMA, whose prompt omits
+            # ``severity`` entirely. So the word ``severity`` in the prompt text
+            # is the fingerprint that distinguishes the two schemas.
+            is_per_stack_parse = "severity" in pl
+            if is_per_stack_parse:  # PER_STACK_RECORD_SCHEMA (per-stack parse)
                 issues = [
                     {
                         "id": 1,

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -398,7 +398,7 @@ def test_diff_blocks_for_files_selects_relevant_hunks() -> None:
     """AC4 helper: ``_diff_blocks_for_files`` returns only the blocks for the
     requested files (post-state path match), concatenated as-is.
     """
-    from daydream.deep.orchestrator import _diff_blocks_for_files
+    from daydream.deep.prompts import _diff_blocks_for_files
 
     out = _diff_blocks_for_files(_DIFF_TWO_FILES, ["api.py"])
     assert out is not None
@@ -418,7 +418,7 @@ def test_diff_blocks_for_files_returns_none_above_byte_budget() -> None:
     ``INLINE_DIFF_BUDGET_BYTES``, the helper returns ``None`` so the caller
     keeps the path pointer (the agent is told to Read diff.patch directly).
     """
-    from daydream.deep.orchestrator import INLINE_DIFF_BUDGET_BYTES, _diff_blocks_for_files
+    from daydream.deep.prompts import INLINE_DIFF_BUDGET_BYTES, _diff_blocks_for_files
 
     # Synthesize a diff whose single matching block exceeds the budget.
     huge_line = "x" * (INLINE_DIFF_BUDGET_BYTES + 64)
@@ -434,7 +434,7 @@ def test_diff_blocks_for_files_returns_none_above_byte_budget() -> None:
 
 def test_diff_blocks_for_files_returns_none_when_no_blocks_match() -> None:
     """AC4 no-match fallback: files not in the diff → None (caller keeps pointer)."""
-    from daydream.deep.orchestrator import _diff_blocks_for_files
+    from daydream.deep.prompts import _diff_blocks_for_files
 
     out = _diff_blocks_for_files(_DIFF_TWO_FILES, ["nonexistent.py"])
     assert out is None
@@ -444,7 +444,7 @@ def test_per_stack_prompt_inlines_hunks_and_drops_read_instruction(tmp_path: Pat
     """AC4 (unit): per-stack prompt with ``inline_diff`` supplied contains the
     inlined hunks, NOT the ``Read it directly`` instruction or diff_path.
     """
-    from daydream.deep.orchestrator import _diff_blocks_for_files
+    from daydream.deep.prompts import _diff_blocks_for_files
 
     p = _paths(tmp_path)
     inline = _diff_blocks_for_files(_DIFF_TWO_FILES, ["api.py"])
@@ -467,7 +467,7 @@ def test_generic_fallback_prompt_inlines_hunks_and_drops_read_instruction(
     """AC4 (unit): generic-fallback prompt with ``inline_diff`` supplied contains
     the inlined hunks, NOT the ``Read it directly`` instruction or diff_path.
     """
-    from daydream.deep.orchestrator import _diff_blocks_for_files
+    from daydream.deep.prompts import _diff_blocks_for_files
 
     p = _paths(tmp_path)
     inline = _diff_blocks_for_files(_DIFF_TWO_FILES, ["App.tsx"])

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -106,7 +106,15 @@ def test_generic_fallback_no_docs_notice_by_default(tmp_path: Path) -> None:
 
 
 def test_prompts_embed_no_full_file_contents(tmp_path: Path) -> None:
-    """D-09: prompts reference paths, never embed diffs or file bodies."""
+    """D-09: prompts reference paths, never embed diffs or file bodies.
+
+    Note (issue #172, Fix B): when ``inline_diff`` is supplied the per-stack
+    prompt DOES embed the relevant diff hunks — that is the read-once
+    optimization, not a D-09 violation. This heuristic guards the default
+    (``inline_diff=None``) path only: no line longer than 400 chars there.
+    The inlined path is bounded by ``INLINE_DIFF_BUDGET_BYTES`` separately
+    (see ``test_inline_diff_byte_budget``).
+    """
     p = _paths(tmp_path)
     out = build_per_stack_prompt(
         skill_invocation="/beagle-python:review-python",
@@ -119,15 +127,34 @@ def test_prompts_embed_no_full_file_contents(tmp_path: Path) -> None:
 
 
 def test_per_stack_prompt_points_at_diff_path(tmp_path: Path) -> None:
-    """Prompt references diff_path for agents to read directly."""
+    """Fallback (``inline_diff=None``): prompt references diff_path for agents
+    to read directly.
+
+    Issue #172 Fix B: with ``inline_diff`` supplied, the path pointer is
+    DROPPED (the hunks are inlined instead). The fallback contract — when the
+    byte budget is exceeded or the caller has no diff text — keeps the pointer
+    so the agent can still locate the full diff for whole-file context.
+    """
     p = _paths(tmp_path)
-    out = build_per_stack_prompt(
+    # Default (inline_diff=None) → pointer present (fallback contract).
+    out_fallback = build_per_stack_prompt(
         skill_invocation="/beagle-python:review-python",
         stack_name="python",
         files=["api.py"],
         **p,
     )
-    assert str(p["diff_path"]) in out
+    assert str(p["diff_path"]) in out_fallback
+    # inline_diff supplied → pointer absent (hunks inlined instead).
+    out_inline = build_per_stack_prompt(
+        skill_invocation="/beagle-python:review-python",
+        stack_name="python",
+        files=["api.py"],
+        inline_diff="diff --git a/api.py b/api.py\n+++ b/api.py\n@@ -1 +1 @@\n-x\n+y\n",
+        **p,
+    )
+    assert str(p["diff_path"]) not in out_inline
+    assert "Read it directly" not in out_inline
+    assert "-x" in out_inline and "+y" in out_inline  # hunks inlined
 
 
 def test_per_stack_prompt_omits_bare_git_diff_command(tmp_path: Path) -> None:
@@ -148,13 +175,26 @@ def test_per_stack_prompt_omits_bare_git_diff_command(tmp_path: Path) -> None:
 
 
 def test_generic_fallback_prompt_omits_bare_git_diff_command(tmp_path: Path) -> None:
-    """Generic fallback must not embed the broken git-diff command either."""
+    """Generic fallback must not embed the broken git-diff command either.
+
+    Issue #172 Fix B: with ``inline_diff`` supplied, the diff_path pointer is
+    DROPPED. The fallback (``inline_diff=None``) path still references
+    diff_path so the agent can locate the full diff.
+    """
     p = _paths(tmp_path)
-    out = build_generic_fallback_prompt(files=["config.yaml"], **p)
-    assert "git diff --no-color -- config.yaml" not in out
-    assert "git diff -- config.yaml" not in out
-    # diff_path must still be referenced.
-    assert str(p["diff_path"]) in out
+    # Default (inline_diff=None) → pointer present (fallback contract).
+    out_fallback = build_generic_fallback_prompt(files=["config.yaml"], **p)
+    assert "git diff --no-color -- config.yaml" not in out_fallback
+    assert "git diff -- config.yaml" not in out_fallback
+    assert str(p["diff_path"]) in out_fallback
+    # inline_diff supplied → pointer absent (hunks inlined instead).
+    out_inline = build_generic_fallback_prompt(
+        files=["config.yaml"],
+        inline_diff="diff --git a/config.yaml b/config.yaml\n+++ b/config.yaml\n@@ -1 +1 @@\n-x\n+y\n",
+        **p,
+    )
+    assert str(p["diff_path"]) not in out_inline
+    assert "Read it directly" not in out_inline
 
 
 def _merge_paths(tmp_path: Path) -> dict[str, Path | list[Path] | None]:
@@ -333,3 +373,127 @@ def test_merge_prompt_omits_structural_section_when_path_is_none(tmp_path: Path)
     assert "## Structural Review" not in prompt
     assert "Structural-stack parsed records:" not in prompt
     assert "Structural-stack handling:" not in prompt
+
+
+# =============================================================================
+# Issue #172 — Fix B: read-once inline diff hunks in per-stack / generic prompts
+# =============================================================================
+
+
+_DIFF_TWO_FILES = (
+    "diff --git a/api.py b/api.py\n"
+    "+++ b/api.py\n"
+    "@@ -1 +1 @@\n"
+    "-def hello(): return 'world'\n"
+    "+def hello(): return 'universe'\n"
+    "diff --git a/App.tsx b/App.tsx\n"
+    "+++ b/App.tsx\n"
+    "@@ -1 +1 @@\n"
+    "-export const App = () => <div>hello</div>;\n"
+    "+export const App = () => <div>universe</div>;\n"
+)
+
+
+def test_diff_blocks_for_files_selects_relevant_hunks() -> None:
+    """AC4 helper: ``_diff_blocks_for_files`` returns only the blocks for the
+    requested files (post-state path match), concatenated as-is.
+    """
+    from daydream.deep.orchestrator import _diff_blocks_for_files
+
+    out = _diff_blocks_for_files(_DIFF_TWO_FILES, ["api.py"])
+    assert out is not None
+    assert "diff --git a/api.py b/api.py" in out
+    assert "def hello(): return 'universe'" in out
+    # App.tsx block is NOT in the filtered output.
+    assert "App.tsx" not in out
+    # Two files requested → both blocks present.
+    both = _diff_blocks_for_files(_DIFF_TWO_FILES, ["api.py", "App.tsx"])
+    assert both is not None
+    assert "def hello(): return 'universe'" in both
+    assert "<div>universe</div>" in both
+
+
+def test_diff_blocks_for_files_returns_none_above_byte_budget() -> None:
+    """AC4 byte-bound fallback: when the relevant blocks exceed
+    ``INLINE_DIFF_BUDGET_BYTES``, the helper returns ``None`` so the caller
+    keeps the path pointer (the agent is told to Read diff.patch directly).
+    """
+    from daydream.deep.orchestrator import INLINE_DIFF_BUDGET_BYTES, _diff_blocks_for_files
+
+    # Synthesize a diff whose single matching block exceeds the budget.
+    huge_line = "x" * (INLINE_DIFF_BUDGET_BYTES + 64)
+    huge_diff = (
+        "diff --git a/api.py b/api.py\n"
+        "+++ b/api.py\n"
+        "@@ -1 +1 @@\n"
+        f"-{huge_line}\n"
+        f"+{huge_line}\n"
+    )
+    assert _diff_blocks_for_files(huge_diff, ["api.py"]) is None
+
+
+def test_diff_blocks_for_files_returns_none_when_no_blocks_match() -> None:
+    """AC4 no-match fallback: files not in the diff → None (caller keeps pointer)."""
+    from daydream.deep.orchestrator import _diff_blocks_for_files
+
+    out = _diff_blocks_for_files(_DIFF_TWO_FILES, ["nonexistent.py"])
+    assert out is None
+
+
+def test_per_stack_prompt_inlines_hunks_and_drops_read_instruction(tmp_path: Path) -> None:
+    """AC4 (unit): per-stack prompt with ``inline_diff`` supplied contains the
+    inlined hunks, NOT the ``Read it directly`` instruction or diff_path.
+    """
+    from daydream.deep.orchestrator import _diff_blocks_for_files
+
+    p = _paths(tmp_path)
+    inline = _diff_blocks_for_files(_DIFF_TWO_FILES, ["api.py"])
+    assert inline is not None  # sanity: the helper found a block
+    out = build_per_stack_prompt(
+        skill_invocation="/beagle-python:review-python",
+        stack_name="python",
+        files=["api.py"],
+        inline_diff=inline,
+        **p,
+    )
+    assert "def hello(): return 'universe'" in out  # hunk inlined
+    assert "Read it directly" not in out
+    assert str(p["diff_path"]) not in out
+
+
+def test_generic_fallback_prompt_inlines_hunks_and_drops_read_instruction(
+    tmp_path: Path,
+) -> None:
+    """AC4 (unit): generic-fallback prompt with ``inline_diff`` supplied contains
+    the inlined hunks, NOT the ``Read it directly`` instruction or diff_path.
+    """
+    from daydream.deep.orchestrator import _diff_blocks_for_files
+
+    p = _paths(tmp_path)
+    inline = _diff_blocks_for_files(_DIFF_TWO_FILES, ["App.tsx"])
+    assert inline is not None
+    out = build_generic_fallback_prompt(
+        files=["App.tsx"],
+        inline_diff=inline,
+        **p,
+    )
+    assert "<div>universe</div>" in out
+    assert "Read it directly" not in out
+    assert str(p["diff_path"]) not in out
+
+
+def test_structural_prompt_keeps_diff_pointer_and_read_freedom(tmp_path: Path) -> None:
+    """AC4: structural prompt is NOT inlined — it keeps its diff pointer AND
+    its repo-wide Read/Grep/Bash freedom (the structural lens roams beyond
+    the diff by design). Fix B does not touch the structural / arbiter prompts.
+    """
+    from daydream.deep.prompts import build_structural_prompt
+
+    p = _paths(tmp_path)
+    out = build_structural_prompt(
+        files=["api.py"],
+        **p,
+    )
+    assert "read any file in the codebase" in out
+    assert str(p["diff_path"]) in out  # keeps its pointer
+    assert "Read it directly" in out   # structural prompt unchanged


### PR DESCRIPTION
## Summary

- **Tiny-diff short-circuit**: ≤2-file diffs collapse the language fan-out into a single combined review agent + structural lens, skip the merge agent + arbiter, and write `merged-items.json` directly — ~6–8 agents → ~2 on tiny diffs
- **Read-once diff inlining**: per-stack/generic prompts now inline the relevant diff hunks instead of instructing agents to "Read {diff_path} directly", eliminating ~763 redundant `diff.patch` reads across the fleet (94% of read-runs were re-reading)

## Motivation

Closes #172.

A ≤2-file diff still triggered the full multi-stack pipeline (no short-circuit): detect_stacks returns one StackAssignment per language + an unconditional `structure` meta-stack, so even a 1-file Python change spawned python + structure = 2 agents plus merge + arbiter. Each stack agent then re-Read the same `diff.patch` from disk — 763 redundant reads, 94% of read-runs, max 57× in one run.

## Changes

### Changed
- `run_deep` (`orchestrator.py`): after `changed_files` computation, check `len(changed_files) <= SHALLOW_FANOUT_THRESHOLD`; if so, collapse language stacks into one generic review + structure, skip merge agent + arbiter, write `merged-items.json` via `_append_structural_and_write_merged`
- `_collapse_stacks_for_tiny_diff`: pure function that collapses ≥2 distinct language stacks into one generic assignment (preserves single-language skill)
- `_single_stack_agent_count`: lever 2 formula — skips merge agent + arbiter so even a 1-file diff's count is strictly < `total_agent_count(2)`
- `build_per_stack_prompt` / `build_generic_fallback_prompt` (`prompts.py`): new `inline_diff` kwarg; when supplied, hunks are inlined and the "Read it directly" instruction is dropped. Byte-bounded (`INLINE_DIFF_BUDGET_BYTES = 12KB`); falls back to path pointer above threshold
- `_diff_blocks_for_files` (`prompts.py`): selects diff blocks matching a stack's files, bounded by byte budget
- `phase_per_stack_reviews` (`phases.py`): new `diff_text` kwarg; computes `inline_diff` per stack (structural exempted)
- `DaydreamFileConfig` (`config_file.py`) + `RunConfig` (`runner.py`): `shallow_fanout_threshold` field with CLI > config-file > default precedence

### Added
- `tiny_diff_target` fixture (`conftest.py`): 2-file two-language diff (api.py + App.tsx)
- AC1 unit: threshold precedence + collapse count (1-file 6<8, 2-file 6<12, threshold=0 disables)
- AC2 real-path: paired fan-out comparison (tiny 2 agents vs multi 4 + merge count 0 vs 1)
- AC3 regression guard: ≥3-file fan-out unchanged (4 reviews + 1 merge)
- AC4 unit: hunks inlined, "Read it directly" absent, structural prompt keeps pointer
- AC5 real-path: per-stack prompt has inlined hunks, no Read instruction
- AC6: structural items tagged `lens="structural"`; fix gate / verifier / PR posting unchanged
- AC7: configurable threshold with `0` disable support
- Flipped prompt tests: assert fallback (inline_diff=None) keeps pointer, inline path drops it

## Test Plan

- [x] `make check` — 1693 passed, 3 skipped
- [x] `uv run ruff check daydream tests` — clean
- [x] `uv run mypy daydream tests` — clean (215 files)
- [x] Daydream pre-PR review (pi/GLM-5.2): 13 findings, 12 applied (helper relocation, literal hardening, shared merge writer extraction)

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check`)
- [x] Type checking passes (`uv run mypy daydream tests`)
- [x] Documentation updated (inline comments for collapse/bypass logic)
