### PR TITLE
fix(agent): detect_test_success false-negative on deselected/skipped pytest output

### DIFF
--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -295,9 +295,11 @@ def detect_test_success(output: str) -> bool:
     output_lower = output.lower()
 
     # finditer so a later non-zero count isn't hidden by an earlier "0 failed".
+    # pytest "errors" (collection errors) are genuine non-passes — counted
+    # alongside failures here.
     failed_counts = [
         int(match.group(1).replace(",", ""))
-        for match in re.finditer(r"(\d[\d,]*)\s+(?:tests?\s+)?fail(?:ed|ures?)\b", output_lower)
+        for match in re.finditer(r"(\d[\d,]*)\s+(?:tests?\s+)?(?:fail(?:ed|ures?)|errors?)\b", output_lower)
     ]
     passed_counts = [
         int(match.group(1).replace(",", ""))
@@ -329,15 +331,19 @@ def detect_test_success(output: str) -> bool:
         r"all tests pass",
         r"no (?:test )?failures?",
         r"\b0\s+failures?\b",
+        r"\d+\s+passed(?:,\s*\d+\s+(?:deselected|skipped|xfailed))*(?:,\s*\d+\s+warnings?)?",
     ]
     for pattern in success_sentinels:
         if re.search(pattern, output_lower):
             return True
 
-    # Structured: saw a passed count and an explicit 0-failure count.
-    has_explicit_zero_failed = any(count == 0 for count in failed_counts)
+    # Structured: positive passed count and no failures at all.
+    # pytest omits "0 failed" entirely when there are zero failures — an empty
+    # failed_counts means "no failures mentioned". When "0 failed" IS present,
+    # failed_counts is [0] (non-empty). Both cases are passes.
     max_passed = max(passed_counts) if passed_counts else None
-    if max_passed is not None and max_passed > 0 and has_explicit_zero_failed:
+    no_failures = not failed_counts or all(c == 0 for c in failed_counts)
+    if max_passed is not None and max_passed > 0 and no_failures:
         return True
 
     # Conservative fallback: bare "passed" with no count is not enough.

--- a/tests/test_agent_detect_success.py
+++ b/tests/test_agent_detect_success.py
@@ -133,3 +133,34 @@ Traceback (most recent call last):
     foo()
 """
     assert detect_test_success(output) is False
+
+
+def test_pytest_deselected_passed() -> None:
+    """pytest summary with deselected tests must be a pass (issue #198)."""
+    assert detect_test_success("2528 passed, 391 deselected, 1 warning in 30.30s") is True
+
+
+def test_pytest_bare_passed_no_failed() -> None:
+    """Bare 'N passed' with no failure mention must be a pass."""
+    assert detect_test_success("100 passed in 5.2s") is True
+
+
+def test_pytest_skipped_passed() -> None:
+    """pytest summary with skipped tests must be a pass."""
+    assert detect_test_success("50 passed, 3 skipped in 2.1s") is True
+
+
+def test_pytest_xfailed_passed() -> None:
+    """pytest summary with xfailed tests must be a pass."""
+    assert detect_test_success("10 passed, 2 xfailed") is True
+
+
+def test_explicit_zero_failed_with_tests_passed() -> None:
+    """'N tests passed, 0 failed' must be a pass (regression: not failed_counts
+    broke this because failed_counts is [0], a truthy list)."""
+    assert detect_test_success("100 tests passed, 0 failed") is True
+
+
+def test_pytest_errors_are_not_pass() -> None:
+    """pytest 'errors' (collection errors) are genuine non-passes."""
+    assert detect_test_success("1 passed, 2 errors in 1.0s") is False


### PR DESCRIPTION
## Summary

- Fix `detect_test_success` classifying clean pytest suites (`N passed, M deselected`) as failures, which caused false aborts on 3 consecutive daydream runs against amelia

## Motivation

`detect_test_success()` returned `False` for standard pytest output like `"2528 passed, 391 deselected, 1 warning"` because it required an explicit `0 failed` count, which pytest omits entirely when there are zero failures. This caused daydream fix-phase gates to inject a contradictory "The tests failed" prompt over green output. Fixes #198.

## Changes

### Fixed
- **Broadened `failed_counts` regex** to also match pytest `"errors"` (collection errors are genuine non-passes). Prevents false-positive from the new sentinel matching `"1 passed, 2 errors"`.
- **Added pytest summary sentinel** regex for `N passed, M deselected/skipped/xfailed, K warnings` format (defense-in-depth).
- **Relaxed structured-count check**: empty `failed_counts` OR all-zero counts both indicate no failures. The original `not failed_counts` broke the explicit `"0 failed"` case (`failed_counts` is `[0]`, a truthy list) — caught by daydream pre-PR review.

## Test Plan

- [x] 6 new test cases added: deselected, bare-passed-no-failure, skipped, xfailed, explicit-zero-failed, errors-not-pass
- [x] All 27 `detect_test_success` tests pass (21 existing + 6 new)
- [x] Full suite: 1704 passed, 3 skipped
- [x] `uv run ruff check daydream tests` clean
- [x] `uv run mypy daydream tests` clean (215 files)

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check`)
- [x] Type checking passes (`uv run mypy daydream tests`)
