### PR TITLE
feat(bench): review-bot comparison harness (daydream vs coderabbit/greptile)

### DIFF
--- a/.claude/skills/rerun-review-bot-bench/SKILL.md
+++ b/.claude/skills/rerun-review-bot-bench/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: rerun-review-bot-bench
+description: >-
+  Re-run the review-bot-compare benchmark pilot — replay daydream against a
+  GitHub review bot's PR history and score the overlap. Use when asked to
+  "re-run the review-bot benchmark", "rerun the GLM pilot", "replay daydream
+  against coderabbit/greptile", "redo the review-bot-compare run", or to
+  benchmark daydream vs a SaaS review bot on a repo's real PRs. Encodes the
+  verified traps (stale artifacts, pi --session-id version floor, z.ai
+  overload, no --provider on replay.py) so the re-run doesn't waste hours.
+---
+
+# Re-run the review-bot-compare benchmark
+
+Harness lives at `bench/review-bot-compare/` (run all `python3` commands from
+there). Pipeline: `harvest.py` → `replay.py` → `judge.py` → `compare.py`.
+Artifacts land in `out/<owner__repo>/{findings,traj,logs,replay,judge,worktrees}/pr-<N>.json`
+plus `report.md` + `comparison.csv`. The `<owner__repo>` slug replaces `/` with
+a double underscore (e.g. `shelfspace-app/shelfspace-mono` → `shelfspace-app__shelfspace-mono`).
+
+Worked example below: the **shelfspace / coderabbit** GLM (pi) pilot.
+Parameterize `--repo`, `--bot`, `--source`, and the PR set for any repo/bot.
+
+Deep mode (no `--shallow`) is ~10–20 min/PR on GLM. Budget accordingly; use
+`--shallow` only for a fast single-stack smoke.
+
+## Steps
+
+### 1. Preflight pi (do this FIRST — skips the #1 and #2 traps below)
+
+```bash
+# (a) version floor: daydream's pi backend passes `--session-id <uuid>`,
+#     which only exists in pi >= 0.80.2. pi 0.74.2 rejects it and every run
+#     aborts in ~2s. Both checks must pass:
+pi --version                                  # must be >= 0.80.2
+pi --help | grep -- --session-id              # must show: --session-id <id>  Use exact project session ID, creating it if missing
+
+# If either fails, upgrade (the `pi` on PATH is the HOMEBREW npm global,
+# NOT nvm's — use the homebrew npm explicitly):
+/opt/homebrew/bin/npm install -g @earendil-works/pi-coding-agent@latest
+# Reference source if you need to inspect: /Users/ka/github/reference_agents/pi-mono
+
+# (b) one-shot smoke — catches z.ai overload AND a broken provider:
+pi -p --no-tools --provider zai --model glm-5.2 'reply with {"ok":true}'
+```
+
+- One-shot 429s/errors → **z.ai is overloaded. STOP** and retry later; deep
+  replays will all fail.
+- One-shot is clean but a real replay still prints `Unknown option:
+  --session-id` → that's the **version trap (1a)**, not overload. Re-run the
+  version check.
+
+### 2. Clear stale per-PR artifacts for the target PRs (before any clean re-run)
+
+`replay/` and `judge/` records are **NOT** auto-cleared, so a fast-abort run
+can leave them showing the PREVIOUS run's numbers (real case: "findings=6/28"
+reported for PRs that actually aborted in 2s — old codex-era findings on disk).
+Clear them for every PR you're about to re-run:
+
+```bash
+REPO_SLUG=shelfspace-app__shelfspace-mono
+for N in 1290 1291 1292 1293 1295; do
+  rm -f out/$REPO_SLUG/findings/pr-$N.json \
+        out/$REPO_SLUG/traj/pr-$N.json \
+        out/$REPO_SLUG/judge/pr-$N.json \
+        out/$REPO_SLUG/replay/pr-$N.json
+done
+# Do NOT delete out/$REPO_SLUG/logs/ — keep crash logs. (Just know logs LAG;
+# never diagnose an in-progress run from them — see Gotchas.)
+```
+
+### 3. (If re-harvesting) refresh the bot's review history — usually skip
+
+Harvest is pure `gh api`, no checkout. Only needed if PRs changed since last
+harvest:
+
+```bash
+python3 harvest.py --repo shelfspace-app/shelfspace-mono --bot "coderabbitai[bot]" --out ./out --limit 300
+# Confirm the real bot handle first:
+#   gh api repos/OWNER/REPO/pulls/N/comments --jq '.[].user.login' | sort -u
+```
+
+### 4. Replay daydream at each snapshot (run in BACKGROUND, then monitor live)
+
+`replay.py` has **NO `--provider`/`--model` flags** — `--backend pi` alone
+gives GLM (its pi backend defaults to `--provider zai` + `glm-5.2`). Passing
+`--provider` to replay.py errors.
+
+```bash
+python3 replay.py --repo shelfspace-app/shelfspace-mono \
+    --source /Users/ka/github/shelfspace-app/shelfspace-mono \
+    --in ./out --backend pi --pr 1295 --pr 1293 --pr 1292 --pr 1291 --pr 1290 \
+    --timeout 2700 --retries 3 --backoff 30
+#   --limit N  instead of repeated --pr to take the first N harvested PRs
+#   --shallow  for a fast single-stack smoke (skip for the real deep review)
+#   --retry-failed  to re-run only PRs whose replay record is not 'ok'
+```
+
+Run this with `run_in_background: true` and tail its output file. The replay's
+own **stdout result line** (`-> ok | findings=N | cost=$...`) is the
+authoritative per-PR completion signal — NOT the on-disk logs/findings.
+
+While it runs, judge live progress ONLY via these signals:
+
+```bash
+# daydream parent + a pi child means it's actively working:
+ps aux | grep -E "[d]aydream|[p]i --mode json"
+# fresh pi session writes in the last 3 min = forward progress:
+find ~/.pi/agent/sessions -name '*.jsonl' -newermt '-3 minutes'
+```
+
+### 5. LLM judge (semantic overlap — one light call per PR)
+
+`judge.py` DOES take `--provider`/`--model` (unlike replay.py):
+
+```bash
+python3 judge.py --repo shelfspace-app/shelfspace-mono --in ./out \
+    --backend pi --provider zai --model glm-5.2 --retries 3
+#   --pr N  to judge specific PRs
+```
+
+### 6. Compare + read the report
+
+```bash
+python3 compare.py --repo shelfspace-app/shelfspace-mono --bot-name coderabbit \
+    --in ./out --min-conf 0.5
+cat out/shelfspace-app__shelfspace-mono/report.md
+```
+
+GLM reports `cost_usd=0`, so `compare.py` synthesizes $ from tokens via the
+`glm-5.2` price card (`--price-model glm-5.2`, the default known card). Cost is
+labeled synthetic in the report — not faked.
+
+## Gotchas / traps
+
+1. **Stale artifacts are the #1 time-waster — NEVER diagnose an in-progress
+   run from `logs/`, `findings/`, or `traj/`.** `replay.py` writes
+   `logs/pr-N.log` and `findings/pr-N.json` only AS/AFTER a PR's daydream run
+   finishes (findings only on a *successful* exit), and the `replay/pr-N.json`
+   record only after `replay_one` returns. During a re-run, those files still
+   hold the PREVIOUS run's output and will show you old errors. A PR's
+   artifacts are trustworthy only once its `replay/pr-N.json` is rewritten OR
+   the replay stdout prints its result line. Trust live signals (step 4),
+   not on-disk per-PR files.
+
+2. **Clear stale artifacts before a clean re-run** (step 2). `replay.py` does
+   **NOT** pre-clear anything — line 111 only `mkdir`s parent dirs. `findings/`
+   and `traj/` are overwritten by daydream *only on a successful exit*; `logs/`
+   only after the run returns; `replay/` + `judge/` records are never
+   auto-cleared. So a fast-abort run leaves the PREVIOUS run's `findings`,
+   `traj`, `replay`, and `judge` files intact → stale numbers (the real
+   "findings=6/28" misreport). Manually `rm` them for every PR you re-run.
+
+3. **pi version floor `>= 0.80.2`.** `--session-id <uuid>` is rejected by
+   0.74.2 (`Error: Unknown option: --session-id`) → every run aborts in ~2s
+   with a "Backend Execution Error". Preflight per step 1a.
+
+4. **z.ai overload.** The one-shot smoke (step 1b) 429ing means deep replays
+   will all fail — stop and retry later, don't burn the batch.
+
+5. **`replay.py` takes no `--provider`/`--model`.** `--backend pi` is enough
+   for GLM. (`judge.py` is the script that takes those flags.)
+
+6. **App-identity hard-abort is already handled** — `replay.py` strips
+   `DAYDREAM_APP_ID` / `DAYDREAM_APP_PRIVATE_KEY` from the child env so
+   `--review` doesn't hard-abort under a GitHub App identity. Don't re-add them.
+
+7. **`[bot]` suffix mismatch is handled** — GitHub REST keeps `coderabbitai[bot]`,
+   GraphQL drops it to `coderabbitai`. The harness matches both; harvest with
+   the REST form (`--bot "coderabbitai[bot]"`).
+
+8. **pi token counters are disjoint** — `prompt`=input, `cached`=cacheRead (a
+   *separate* cache-read bucket). They bill separately; don't sum them as
+   one input total.
+
+9. **A giant-diff PR can kill the pi process.** shelfspace **PR #1292** is a
+   ~17k-line diff that can OOM/terminate pi ("terminated"). The harness
+   isolates per-PR failures — accept 4/5 and move on, or retry just that one:
+   `python3 replay.py ... --backend pi --pr 1292 --retries 3`.
+
+10. **Never `--no-verify`, never bypass a failing gate.** If something fails,
+    fix the root cause (usually the pi version or z.ai availability above).

--- a/bench/review-bot-compare/.gitignore
+++ b/bench/review-bot-compare/.gitignore
@@ -1,0 +1,3 @@
+# Harness output: harvested data, daydream worktrees, findings, trajectories,
+# logs, and generated reports. All reproducible from the scripts.
+out/

--- a/bench/review-bot-compare/README.md
+++ b/bench/review-bot-compare/README.md
@@ -1,0 +1,89 @@
+# review-bot-compare
+
+Benchmark **daydream** against any GitHub review bot (CodeRabbit, Greptile, …)
+on a repo's real PR history, by replaying daydream at the *exact snapshot* the
+bot reviewed.
+
+Three stages, each a standalone script (stdlib + `gh`/`git` CLIs only):
+
+```
+harvest.py   bot's historic reviews  → out/<owner__repo>/pr-<N>.json + index.json
+replay.py    daydream @ same snapshot → out/<owner__repo>/findings|traj|replay/
+judge.py     LLM semantic matching    → out/<owner__repo>/judge/pr-<N>.json   (optional)
+compare.py   align + score            → out/<owner__repo>/report.md + comparison.csv
+```
+
+## Why "same snapshot" matters
+
+A review bot reviews a PR at a specific commit. The GitHub review object carries
+`commit_id`. `replay.py` reconstructs the bot's exact view of the diff:
+
+- `head` = the bot review's `commit_id`
+- `base` = `git merge-base origin/<base_ref> <head>` (GitHub's 3-dot compare base)
+
+It checks `head` out in a **detached worktree** and runs daydream in-place with
+`--base <merge-base>`, so daydream reviews byte-for-byte the same diff the bot saw
+— not today's HEAD.
+
+## Usage
+
+```bash
+# 1. Harvest (no checkout needed — pure gh api)
+python3 harvest.py --repo OWNER/REPO --bot "coderabbitai[bot]" --out ./out --limit 300
+
+# 2. Replay daydream at each snapshot (needs a local clone with the remote)
+python3 replay.py --repo OWNER/REPO --source /path/to/clone \
+    --in ./out --backend codex --limit 5          # pilot: first 5 PRs
+#   add --shallow for a fast single-stack pass; drop it for the real deep review
+#   --pr 1292 --pr 1290  to target specific PRs
+
+# 3. (optional but recommended) LLM judge for semantic overlap — one light call per PR
+python3 judge.py --repo OWNER/REPO --in ./out --backend pi --provider zai --model glm-5.2
+
+# 4. Compare (auto-uses judge matches when present, else deterministic lower bound)
+python3 compare.py --repo OWNER/REPO --bot-name coderabbit --in ./out --min-conf 0.5
+```
+
+## Why the LLM judge
+
+Two tools phrase the same issue differently and anchor it to different lines, so
+the deterministic file+line+wording matcher reports ~0 overlap even when they
+agree. `judge.py` makes ONE light LLM call per PR (no tools, no repo checkout —
+works on subscription backends that rate-limit deep reviews) to decide which
+findings describe the same underlying issue. `compare.py` picks up the judge
+artifact automatically. Example: on a pilot PR the deterministic matcher found 0
+overlap; the judge correctly matched 2 issues both tools flagged (an `os.Exit`
+in a deps-init path, and DB errors masked as HTTP 200s).
+
+## Generalization
+
+- `--bot` is any `user.login`. The harness matches tolerant of GitHub's
+  REST-vs-GraphQL `[bot]`-suffix mismatch (`coderabbitai[bot]` ≡ `coderabbitai`).
+  Confirm the real handle first: `gh api repos/OWNER/REPO/pulls/N/comments
+  --jq '.[].user.login' | sort -u`.
+- `--repo` is any `owner/repo`.
+- `--backend` is daydream's backend (`codex`, `claude`, `pi`). Codex/Pi allow
+  subscription auth for unattended batches; Claude needs an `ANTHROPIC_API_KEY`
+  (subscription keys are disallowed for automation).
+
+## What's measured
+
+| Axis | daydream | bot |
+|---|---|---|
+| Issues raised | findings artifact | inline comments |
+| Overlap / unique | deterministic file+line+token match (a **lower bound**) | |
+| Acted-upon precision | findings hitting a **resolved** bot thread | resolved-thread rate |
+| Cost | measured (`trajectory.final_metrics.total_cost_usd` + tokens) | **not observable** (SaaS) — use amortized list price |
+| Latency | wall-clock per PR | review timestamp − PR open |
+
+## Known limitations
+
+- **Overlap is a lower bound.** Deterministic matching misses semantically-equal
+  findings phrased differently or snapped to different lines. Layer an LLM judge
+  on top for the headline overlap number; the resolved-thread axis is unaffected.
+- **Bot cost is amortized, daydream's is measured.** Stated explicitly in the
+  report; not faked.
+- **Bot summary bodies aren't split into discrete findings** — only inline
+  comments are counted as bot findings (add a per-bot normalizer to change this).
+- Codex cost fields may be partial depending on backend parity; tokens are always
+  populated and are the more honest cross-backend comparison.

--- a/bench/review-bot-compare/README.md
+++ b/bench/review-bot-compare/README.md
@@ -6,7 +6,7 @@ bot reviewed.
 
 Three stages, each a standalone script (stdlib + `gh`/`git` CLIs only):
 
-```
+```text
 harvest.py   bot's historic reviews  → out/<owner__repo>/pr-<N>.json + index.json
 replay.py    daydream @ same snapshot → out/<owner__repo>/findings|traj|replay/
 judge.py     LLM semantic matching    → out/<owner__repo>/judge/pr-<N>.json   (optional)

--- a/bench/review-bot-compare/common.py
+++ b/bench/review-bot-compare/common.py
@@ -60,12 +60,15 @@ def gh_paginate(endpoint: str, *, jq: str | None = None) -> list[Any]:
     return flat
 
 
-def graphql_review_threads(owner: str, repo: str, number: int) -> list[dict[str, Any]]:
+def graphql_review_threads(owner: str, repo: str, number: int) -> tuple[list[dict[str, Any]], bool]:
     """Fetch PR review threads (resolution + first comment author) via GraphQL.
 
-    Returns one dict per thread: {is_resolved, is_outdated, path, line, author}.
-    Used to derive the "acted upon" ground-truth signal. Best-effort: returns
-    [] on any failure so harvest never dies on a GraphQL hiccup.
+    Returns ``(threads, ok)``, one dict per thread:
+    {is_resolved, is_outdated, path, line, author}. Used to derive the "acted
+    upon" ground-truth signal. ``ok`` is ``False`` when a transport/shape error
+    truncated the set, so the caller can mark that PR's resolved-thread count as
+    unreliable rather than reading a partial fetch as a real value. Best-effort:
+    never raises on a GraphQL hiccup.
     """
     query = """
     query($owner:String!,$repo:String!,$num:Int!,$cursor:String){
@@ -114,17 +117,17 @@ def graphql_review_threads(owner: str, repo: str, number: int) -> list[dict[str,
                 break
             cursor = page["endCursor"]
     except (RuntimeError, KeyError, TypeError, json.JSONDecodeError):
-        return threads
-    return threads
+        return threads, False
+    return threads, True
 
 
 def write_json(path: Path, obj: Any) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(obj, indent=2, ensure_ascii=False))
+    path.write_text(json.dumps(obj, indent=2, ensure_ascii=False), encoding="utf-8")
 
 
 def read_json(path: Path) -> Any:
-    return json.loads(path.read_text())
+    return json.loads(path.read_text(encoding="utf-8"))
 
 
 def repo_slug(repo: str) -> str:

--- a/bench/review-bot-compare/common.py
+++ b/bench/review-bot-compare/common.py
@@ -1,0 +1,144 @@
+"""Shared helpers for the review-bot comparison harness.
+
+Generalized over any GitHub review bot (coderabbit, greptile, ...) and any
+repo. Pure stdlib + the `gh` and `git` CLIs — no third-party deps so the
+harness runs under the system Python.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+def run(cmd: list[str], *, cwd: str | Path | None = None, timeout: int | None = None,
+        check: bool = True, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    """Run a subprocess, returning the completed process (text mode)."""
+    proc = subprocess.run(  # noqa: S603 - args are constructed from trusted CLI inputs
+        cmd,
+        cwd=str(cwd) if cwd else None,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env=env,
+    )
+    if check and proc.returncode != 0:
+        raise RuntimeError(
+            f"command failed ({proc.returncode}): {' '.join(cmd)}\n{proc.stderr.strip()}"
+        )
+    return proc
+
+
+def gh_json(args: list[str]) -> Any:
+    """Run `gh <args>` and parse stdout as JSON."""
+    proc = run(["gh", *args])
+    return json.loads(proc.stdout) if proc.stdout.strip() else None
+
+
+def gh_paginate(endpoint: str, *, jq: str | None = None) -> list[Any]:
+    """Run `gh api --paginate <endpoint>` and return a flat list of items.
+
+    REST list endpoints return a JSON array per page; --paginate concatenates
+    pages with `\\n` between top-level arrays unless --slurp is given, so we
+    request --slurp and flatten.
+    """
+    args = ["api", "--paginate", "--slurp", endpoint]
+    if jq:
+        args += ["--jq", jq]
+    data = gh_json(args)
+    if data is None:
+        return []
+    # --slurp wraps the per-page arrays in an outer array; flatten one level.
+    flat: list[Any] = []
+    for page in data:
+        if isinstance(page, list):
+            flat.extend(page)
+        else:
+            flat.append(page)
+    return flat
+
+
+def graphql_review_threads(owner: str, repo: str, number: int) -> list[dict[str, Any]]:
+    """Fetch PR review threads (resolution + first comment author) via GraphQL.
+
+    Returns one dict per thread: {is_resolved, is_outdated, path, line, author}.
+    Used to derive the "acted upon" ground-truth signal. Best-effort: returns
+    [] on any failure so harvest never dies on a GraphQL hiccup.
+    """
+    query = """
+    query($owner:String!,$repo:String!,$num:Int!,$cursor:String){
+      repository(owner:$owner,name:$repo){
+        pullRequest(number:$num){
+          reviewThreads(first:100,after:$cursor){
+            nodes{
+              isResolved isOutdated path line
+              comments(first:1){ nodes{ author{login} } }
+            }
+            pageInfo{ hasNextPage endCursor }
+          }
+        }
+      }
+    }
+    """
+    threads: list[dict[str, Any]] = []
+    cursor: str | None = None
+    try:
+        while True:
+            args = [
+                "api", "graphql",
+                "-f", f"query={query}",
+                "-F", f"owner={owner}",
+                "-F", f"repo={repo}",
+                "-F", f"num={number}",
+            ]
+            if cursor:
+                args += ["-F", f"cursor={cursor}"]
+            data = gh_json(args)
+            node = data["data"]["repository"]["pullRequest"]["reviewThreads"]
+            for t in node["nodes"]:
+                comments = t.get("comments", {}).get("nodes", [])
+                author = ""
+                if comments and comments[0].get("author"):
+                    author = comments[0]["author"].get("login", "")
+                threads.append({
+                    "is_resolved": t.get("isResolved", False),
+                    "is_outdated": t.get("isOutdated", False),
+                    "path": t.get("path"),
+                    "line": t.get("line"),
+                    "author": author,
+                })
+            page = node["pageInfo"]
+            if not page["hasNextPage"]:
+                break
+            cursor = page["endCursor"]
+    except (RuntimeError, KeyError, TypeError, json.JSONDecodeError):
+        return threads
+    return threads
+
+
+def write_json(path: Path, obj: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj, indent=2, ensure_ascii=False))
+
+
+def read_json(path: Path) -> Any:
+    return json.loads(path.read_text())
+
+
+def repo_slug(repo: str) -> str:
+    """owner/repo -> owner__repo for filesystem-safe dir names."""
+    return repo.replace("/", "__")
+
+
+def bot_login_matches(login: str | None, bot: str) -> bool:
+    """Match a bot login tolerant of GitHub's REST/GraphQL `[bot]` mismatch.
+
+    REST `user.login` keeps the `[bot]` suffix (`coderabbitai[bot]`); GraphQL
+    `author.login` drops it (`coderabbitai`). Compare on the stripped stem.
+    """
+    def stem(s: str | None) -> str:
+        return (s or "").removesuffix("[bot]").lower()
+
+    return stem(login) == stem(bot)

--- a/bench/review-bot-compare/compare.py
+++ b/bench/review-bot-compare/compare.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""Compare a review bot vs daydream on the same PR snapshots.
+
+Aligns the bot's inline comments against daydream's findings per PR using a
+deterministic matcher (same file + line proximity + body token overlap), then
+scores:
+  - issues raised (counts, per-severity)
+  - overlap / bot-only / daydream-only
+  - "acted upon" precision: fraction of each side's findings that line up with
+    a RESOLVED bot thread (the closest available ground-truth signal)
+  - cost (daydream measured $ + tokens; bot cost is not observable — see notes)
+  - latency (daydream wall-clock)
+
+Deterministic matching is the pilot baseline; phrasing/line drift means it is a
+LOWER BOUND on true semantic overlap. Layer an LLM judge on top later for the
+final numbers.
+
+Output: <in>/<owner__repo>/report.md and comparison.csv
+
+Usage:
+  python compare.py --repo owner/repo --bot-name coderabbit --in ./out
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+from pathlib import Path
+
+from common import read_json, repo_slug, write_json
+
+LINE_DELTA = 12  # lines apart still considered the same locus
+JACCARD_MIN = 0.10  # min body token overlap to confirm a same-locus match
+
+# Per-1M-token prices (USD). Used to synthesize a $ cost when the backend
+# reports none (pi/GLM via z.ai subscription reports $0 but real tokens).
+PRICING = {
+    # GLM-5.2 on z.ai: input $1.40 / cached-input $0.26 / output $4.40 per 1M.
+    "glm-5.2": {"input": 1.40, "cached": 0.26, "output": 4.40},
+}
+
+
+def synth_cost(prompt: int, completion: int, cached: int, model: str) -> float | None:
+    """Synthesize $ cost from token counts using the model's price card.
+
+    These counters are DISJOINT, matching provider usage semantics (and how the
+    pi backend maps them): ``prompt`` = fresh input (usage.input, billed at the
+    full input rate), ``cached`` = cache reads (usage.cacheRead, billed at the
+    cached-input rate), ``completion`` = output. Do not subtract cached from
+    prompt — for GLM, cache reads dwarf fresh input (e.g. 980k vs 107k).
+    """
+    price = PRICING.get(model)
+    if not price:
+        return None
+    return (
+        (prompt or 0) / 1e6 * price["input"]
+        + (cached or 0) / 1e6 * price["cached"]
+        + (completion or 0) / 1e6 * price["output"]
+    )
+
+_WORD = re.compile(r"[a-z0-9_]+")
+_STOP = {
+    "the", "a", "an", "is", "are", "to", "of", "in", "on", "and", "or", "this",
+    "that", "it", "be", "should", "could", "will", "with", "for", "you", "if",
+    "as", "at", "by", "not", "can", "may", "from", "use", "using", "code",
+}
+
+
+def tokens(text: str) -> set[str]:
+    return {w for w in _WORD.findall((text or "").lower()) if w not in _STOP and len(w) > 2}
+
+
+def jaccard(a: set[str], b: set[str]) -> float:
+    if not a or not b:
+        return 0.0
+    return len(a & b) / len(a | b)
+
+
+def norm_path(p: str | None) -> str:
+    return (p or "").lstrip("./").strip()
+
+
+def bot_findings(record: dict) -> list[dict]:
+    """One finding per inline comment, tagged with thread-resolution status."""
+    # Index resolved status by (path, line) from review threads.
+    resolved_loci = {
+        (norm_path(t.get("path")), t.get("line"))
+        for t in record.get("threads", [])
+        if t.get("is_resolved")
+    }
+    out = []
+    for c in record.get("comments", []):
+        if c.get("in_reply_to_id"):
+            continue  # skip follow-up replies; keep the originating comment
+        line = c.get("line") or c.get("original_line") or c.get("start_line")
+        path = norm_path(c.get("path"))
+        out.append({
+            "path": path,
+            "line": line,
+            "text": c.get("body") or "",
+            "resolved": (path, line) in resolved_loci or (path, c.get("line")) in resolved_loci,
+        })
+    return out
+
+
+def dd_findings(art: dict) -> list[dict]:
+    out = []
+    for f in art.get("findings", []):
+        out.append({
+            "path": norm_path(f.get("path")),
+            "line": f.get("line"),
+            "text": f"{f.get('title') or ''}\n{f.get('body') or ''}",
+            "severity": f.get("severity"),
+        })
+    return out
+
+
+def match(bot: list[dict], dd: list[dict]) -> list[tuple[int, int, float]]:
+    """Greedy one-to-one matches: list of (bot_idx, dd_idx, score)."""
+    cands = []
+    for i, b in enumerate(bot):
+        bt = tokens(b["text"])
+        for j, d in enumerate(dd):
+            if b["path"] != d["path"]:
+                continue
+            if b["line"] and d["line"] and abs(b["line"] - d["line"]) > LINE_DELTA:
+                continue
+            score = jaccard(bt, tokens(d["text"]))
+            # Same file + close line is itself weak evidence; require some overlap
+            # unless lines coincide almost exactly.
+            close = b["line"] and d["line"] and abs(b["line"] - d["line"]) <= 3
+            if score >= JACCARD_MIN or close:
+                cands.append((score + (0.2 if close else 0.0), i, j))
+    cands.sort(reverse=True)
+    used_b, used_d, pairs = set(), set(), []
+    for score, i, j in cands:
+        if i in used_b or j in used_d:
+            continue
+        used_b.add(i)
+        used_d.add(j)
+        pairs.append((i, j, round(score, 3)))
+    return pairs
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--repo", required=True)
+    ap.add_argument("--bot-name", default="bot", help="display name, e.g. coderabbit")
+    ap.add_argument("--in", dest="in_root", default="./out", type=Path)
+    ap.add_argument("--price-model", default="glm-5.2",
+                    help=f"price card for synthetic cost when backend reports $0 "
+                         f"(known: {', '.join(PRICING)})")
+    ap.add_argument("--min-conf", type=float, default=0.5,
+                    help="min confidence for an LLM-judge match to count (default 0.5)")
+    args = ap.parse_args()
+
+    base = args.in_root / repo_slug(args.repo)
+    replay = read_json(base / "replay" / "summary.json")["results"]
+
+    rows = []
+    measured_cost = False  # any PR where the backend itself reported a real $
+    synth_cost_used = False  # any PR where we synthesized $ from tokens
+
+    for res in replay:
+        n = res["pr_number"]
+        record = read_json(base / f"pr-{n}.json")
+        bf = bot_findings(record)
+        ok = res.get("status") == "ok"
+        # A run is USABLE for comparison if it produced a valid findings
+        # artifact, even when it exited nonzero afterward (e.g. a late-phase
+        # usage-limit error). "complete" = clean exit; "partial" = errored but
+        # findings emitted; "failed" = no findings at all.
+        fp = base / "findings" / f"pr-{n}.json"
+        art = read_json(fp) if fp.exists() else None
+        df = dd_findings(art) if art else []
+        usable = ok or len(df) > 0
+        state = "complete" if ok else ("partial" if df else "failed")
+
+        pairs = match(bf, df) if usable else []
+        overlap = len(pairs)
+        bot_resolved = sum(1 for b in bf if b["resolved"])
+        overlap_resolved = sum(1 for i, _, _ in pairs if bf[i]["resolved"])
+
+        # Prefer the LLM judge's semantic matches when a judge artifact exists.
+        overlap_source = "deterministic"
+        jp = base / "judge" / f"pr-{n}.json"
+        if usable and jp.exists():
+            jrec = read_json(jp)
+            if not jrec.get("error"):
+                jm = [m for m in jrec.get("matches", [])
+                      if float(m.get("confidence", 0)) >= args.min_conf]
+                overlap = len(jm)
+                overlap_resolved = sum(1 for m in jm if m.get("a_resolved"))
+                overlap_source = "llm-judge"
+
+        # File-level overlap: a no-LLM signal that both tools targeted the same
+        # file, even when line/wording drift defeats finding-level matching.
+        bot_files = {b["path"] for b in bf if b["path"]}
+        dd_files = {d["path"] for d in df if d["path"]}
+        common_files = bot_files & dd_files
+
+        ptok = res.get("prompt_tokens") or 0
+        ctok = res.get("completion_tokens") or 0
+        cached = res.get("cached_tokens") or 0
+
+        # Prefer the backend's own $ if it reported a real (non-zero) cost;
+        # otherwise synthesize from tokens via the price card. Unknown if a
+        # partial run never wrote token metrics.
+        backend_cost = res.get("cost_usd")
+        if backend_cost:
+            cost = backend_cost
+            measured_cost = True
+            cost_kind = "measured"
+        elif ptok or ctok or cached:
+            cost = synth_cost(ptok, ctok, cached, args.price_model)
+            if cost is not None:
+                synth_cost_used = True
+            cost_kind = "synth"
+        else:
+            cost = None
+            cost_kind = "unknown"
+
+        rows.append({
+            "pr": n,
+            "title": record["title"],
+            "state": state,
+            "usable": usable,
+            "bot_findings": len(bf),
+            "dd_findings": len(df) if usable else None,
+            "overlap": overlap if usable else None,
+            "bot_only": (len(bf) - overlap) if usable else None,
+            "dd_only": (len(df) - overlap) if usable else None,
+            "bot_resolved": bot_resolved,
+            "dd_on_resolved": overlap_resolved if usable else None,
+            "overlap_source": overlap_source if usable else None,
+            "bot_files": len(bot_files),
+            "dd_files": len(dd_files) if usable else None,
+            "common_files": len(common_files) if usable else None,
+            "cost_usd": round(cost, 4) if cost is not None else None,
+            "cost_kind": cost_kind,
+            "prompt_tok": ptok,
+            "completion_tok": ctok,
+            "cached_tok": cached,
+            "wall_s": res.get("wall_seconds"),
+            "status": res.get("status"),
+        })
+
+    # Comparison metrics aggregate over USABLE runs (complete + partial). A
+    # crash with no findings is excluded — it is not "daydream found nothing".
+    done = [r for r in rows if r["usable"]]
+    failed = [r for r in rows if not r["usable"]]
+    tot = {
+        "bot": sum(r["bot_findings"] for r in done),
+        "dd": sum(r["dd_findings"] for r in done),
+        "overlap": sum(r["overlap"] for r in done),
+        "bot_only": sum(r["bot_only"] for r in done),
+        "dd_only": sum(r["dd_only"] for r in done),
+        "bot_resolved": sum(r["bot_resolved"] for r in done),
+        "overlap_resolved": sum(r["dd_on_resolved"] for r in done),
+        "common_files": sum(r["common_files"] for r in done),
+        "bot_files": sum(r["bot_files"] for r in done),
+        "dd_files": sum(r["dd_files"] for r in done),
+        "cost": sum(r["cost_usd"] or 0 for r in done),
+        "ptok": sum(r["prompt_tok"] for r in done),
+        "ctok": sum(r["completion_tok"] for r in done),
+        "cached": sum(r["cached_tok"] for r in done),
+        "secs": sum(r["wall_s"] or 0 for r in done),
+        "wasted_cost": sum(r["cost_usd"] or 0 for r in failed),
+    }
+
+    # CSV
+    csv_path = base / "comparison.csv"
+    with csv_path.open("w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=list(rows[0].keys()) if rows else ["pr"])
+        w.writeheader()
+        w.writerows(rows)
+
+    def cell(v: object) -> str:
+        return "—" if v is None else str(v)
+
+    # Markdown report
+    bn = args.bot_name
+    nd = len(done)
+    n_complete = sum(1 for r in rows if r["state"] == "complete")
+    n_partial = sum(1 for r in rows if r["state"] == "partial")
+    glyph = {"complete": "✓", "partial": "◐", "failed": "✗"}
+    md = [f"# {bn} vs daydream — {args.repo}\n"]
+    md.append(f"PRs: **{len(rows)}** total — daydream **{n_complete}** complete, "
+              f"**{n_partial}** partial (findings emitted then errored), "
+              f"**{len(failed)}** failed (no findings).\n")
+    md.append("## Per-PR\n")
+    md.append(f"| PR | dd | {bn} | daydream | overlap | file-overlap | "
+              f"{bn} resolved | cost $ | wall s |")
+    md.append("|---|---|---|---|---|---|---|---|---|")
+    for r in rows:
+        dd_disp = cell(r["dd_findings"]) if r["usable"] else f"✗ {r['status']}"
+        files = (f"{r['common_files']}/{r['dd_files']}∩{r['bot_files']}"
+                 if r["usable"] else "—")
+        md.append(
+            f"| #{r['pr']} | {glyph[r['state']]} | {r['bot_findings']} | {dd_disp} "
+            f"| {cell(r['overlap'])} | {files} "
+            f"| {r['bot_resolved']} | {cell(r['cost_usd'])} | {cell(r['wall_s'])} |"
+        )
+    md.append("\n_overlap: same underlying issue — per the LLM judge where a judge "
+              "artifact exists, else deterministic file+line+wording (a lower bound). "
+              "file-overlap: common/daydream∩bot files both flagged._")
+
+    if failed:
+        md.append(f"\n**Failed runs ({len(failed)}, no findings — excluded):** "
+                  + ", ".join(f"#{r['pr']} ({r['status']})" for r in failed) + "\n")
+    if n_partial:
+        md.append(f"**Partial runs ({n_partial}):** findings were emitted before a "
+                  f"late error (e.g. usage limit); included in counts, but their "
+                  f"cost/tokens may be missing and the review may be pre-merge.\n")
+
+    md.append(f"\n## Totals (over {nd} usable daydream runs: "
+              f"{n_complete} complete + {n_partial} partial)\n")
+    if nd:
+        md.append(f"- **{bn} findings:** {tot['bot']}")
+        md.append(f"- **daydream findings:** {tot['dd']}")
+        sources = {r["overlap_source"] for r in done if r["overlap_source"]}
+        osrc = ("LLM-judge" if sources == {"llm-judge"}
+                else "deterministic (lower bound — run judge.py for semantic overlap)"
+                if sources == {"deterministic"} else "mixed judge/deterministic")
+        md.append(f"- **Issue-level overlap [{osrc}]:** {tot['overlap']}")
+        md.append(f"- **File-level overlap:** {tot['common_files']} files flagged by both "
+                  f"({tot['bot_files']} {bn} files, {tot['dd_files']} daydream files)")
+        md.append(f"- **{bn}-only:** {tot['bot_only']}  |  **daydream-only:** {tot['dd_only']}")
+        if tot["bot"]:
+            md.append(f"- **Overlap as % of {bn}:** {100*tot['overlap']/tot['bot']:.0f}%")
+        if tot["dd"]:
+            md.append(f"- **Overlap as % of daydream:** {100*tot['overlap']/tot['dd']:.0f}%")
+        md.append(f"- **{bn} resolved threads (acted-upon proxy):** {tot['bot_resolved']}"
+                  f" / {tot['bot']}")
+        md.append(f"- **daydream findings that hit a resolved {bn} thread:** "
+                  f"{tot['overlap_resolved']}")
+    else:
+        md.append("_No completed daydream runs — re-run on a more stable backend._")
+
+    md.append("\n### Cost & throughput (daydream, completed runs)\n")
+    if measured_cost and not synth_cost_used:
+        cost_label = "measured by backend"
+    elif synth_cost_used and not measured_cost:
+        cost_label = f"synthesized from tokens @ {args.price_model} price card"
+    else:
+        cost_label = "mixed (measured where reported, else synthesized from tokens)"
+    npr = nd or 1
+    md.append(f"- **Total cost:** ${tot['cost']:.4f} ({cost_label})")
+    md.append(f"- **Avg $/PR:** ${tot['cost']/npr:.4f}")
+    md.append(f"- **Tokens:** {tot['ptok']:,} fresh input / {tot['cached']:,} cached-read "
+              f"/ {tot['ctok']:,} output")
+    if synth_cost_used:
+        pc = PRICING.get(args.price_model, {})
+        md.append(f"- **Price card ({args.price_model}):** "
+                  f"${pc.get('input', '?')}/1M in, ${pc.get('cached', '?')}/1M cached-in, "
+                  f"${pc.get('output', '?')}/1M out (disjoint counters)")
+    md.append(f"- **Wall-clock:** {tot['secs']:.0f}s total"
+              f" ({tot['secs']/npr:.0f}s/PR avg)")
+    if tot["wasted_cost"]:
+        md.append(f"- **Spend wasted on {len(failed)} failed runs:** ${tot['wasted_cost']:.4f}")
+    md.append(f"\n> {bn} per-review LLM cost is **not observable** (SaaS). Compare "
+              f"daydream's $/PR above against {bn}'s amortized list price "
+              f"(plan ÷ PRs reviewed).\n")
+    md.append("> Overlap is a deterministic **lower bound** (file+line+token "
+              "match). Add an LLM judge for semantic alignment.\n")
+
+    report_path = base / "report.md"
+    report_path.write_text("\n".join(md))
+    write_json(base / "comparison.json", {"repo": args.repo, "totals": tot, "rows": rows})
+
+    print("\n".join(md))
+    print(f"\nWrote {report_path}\nWrote {csv_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/review-bot-compare/compare.py
+++ b/bench/review-bot-compare/compare.py
@@ -25,6 +25,8 @@ from __future__ import annotations
 
 import argparse
 import csv
+import hashlib
+import json
 import re
 from pathlib import Path
 
@@ -116,6 +118,24 @@ def dd_findings(art: dict) -> list[dict]:
     return out
 
 
+def findings_digest(bot: list[dict], dd: list[dict]) -> str:
+    """Stable hash of the exact (path, line, text) inputs a judge run scored.
+
+    judge.py records this; compare.py recomputes it from the current findings and
+    rejects a judge artifact whose digest no longer matches (e.g. replay was rerun
+    with a different backend), so stale semantic matches can't skew the report.
+    """
+    payload = json.dumps(
+        {
+            "bot": [[f["path"], f["line"], f["text"]] for f in bot],
+            "dd": [[f["path"], f["line"], f["text"]] for f in dd],
+        },
+        sort_keys=True,
+        ensure_ascii=False,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
 def match(bot: list[dict], dd: list[dict]) -> list[tuple[int, int, float]]:
     """Greedy one-to-one matches: list of (bot_idx, dd_idx, score)."""
     cands = []
@@ -161,10 +181,13 @@ def main() -> int:
     rows = []
     measured_cost = False  # any PR where the backend itself reported a real $
     synth_cost_used = False  # any PR where we synthesized $ from tokens
+    incomplete_threads = []  # PRs whose GraphQL thread fetch was truncated
 
     for res in replay:
         n = res["pr_number"]
         record = read_json(base / f"pr-{n}.json")
+        if record.get("threads_complete") is False:
+            incomplete_threads.append(n)
         bf = bot_findings(record)
         ok = res.get("status") == "ok"
         # A run is USABLE for comparison if it produced a valid findings
@@ -182,12 +205,16 @@ def main() -> int:
         bot_resolved = sum(1 for b in bf if b["resolved"])
         overlap_resolved = sum(1 for i, _, _ in pairs if bf[i]["resolved"])
 
-        # Prefer the LLM judge's semantic matches when a judge artifact exists.
+        # Prefer the LLM judge's semantic matches when a judge artifact exists —
+        # but only if it was scored against THESE findings. A digest mismatch
+        # means replay was rerun since the judge ran, so the matches are stale;
+        # reject them and fall back to the deterministic lower bound.
         overlap_source = "deterministic"
         jp = base / "judge" / f"pr-{n}.json"
         if usable and jp.exists():
             jrec = read_json(jp)
-            if not jrec.get("error"):
+            fresh = jrec.get("findings_digest") == findings_digest(bf, df)
+            if not jrec.get("error") and fresh:
                 jm = [m for m in jrec.get("matches", [])
                       if float(m.get("confidence", 0)) >= args.min_conf]
                 overlap = len(jm)
@@ -313,6 +340,11 @@ def main() -> int:
         md.append(f"**Partial runs ({n_partial}):** findings were emitted before a "
                   f"late error (e.g. usage limit); included in counts, but their "
                   f"cost/tokens may be missing and the review may be pre-merge.\n")
+    if incomplete_threads:
+        md.append(f"**Unreliable resolved-thread counts ({len(incomplete_threads)}):** "
+                  + ", ".join(f"#{n}" for n in incomplete_threads)
+                  + " — the GraphQL thread fetch was truncated at harvest, so the "
+                  "acted-upon proxy understates these PRs. Re-harvest to refresh.\n")
 
     md.append(f"\n## Totals (over {nd} usable daydream runs: "
               f"{n_complete} complete + {n_partial} partial)\n")

--- a/bench/review-bot-compare/harvest.py
+++ b/bench/review-bot-compare/harvest.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Harvest a review bot's historic PR reviews from GitHub.
+
+Generalized over any bot (`--bot coderabbitai[bot]`, a greptile handle, ...)
+and any repo (`--repo owner/repo`). Pure `gh api` — no local checkout needed.
+
+For every PR the bot reviewed, captures:
+  - the bot's review summaries (with the commit_id each was made against)
+  - the bot's inline review comments (path, line, body, commit_id)
+  - review-thread resolution status (the "acted upon" ground-truth signal)
+  - the snapshot SHA to replay against (latest bot review's commit_id)
+
+Output: <out>/<owner__repo>/pr-<N>.json plus index.json.
+
+Usage:
+  python harvest.py --repo owner/repo --bot "coderabbitai[bot]" \
+      --out ./out --limit 200
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from common import (
+    bot_login_matches,
+    gh_json,
+    gh_paginate,
+    graphql_review_threads,
+    repo_slug,
+    write_json,
+)
+
+
+def harvest_pr(repo: str, owner: str, name: str, pr: dict, bot: str) -> dict | None:
+    """Collect one PR's bot activity, or None if the bot left nothing."""
+    n = pr["number"]
+
+    reviews = gh_paginate(f"repos/{repo}/pulls/{n}/reviews")
+    bot_reviews = [r for r in reviews if bot_login_matches((r.get("user") or {}).get("login"), bot)]
+
+    comments = gh_paginate(f"repos/{repo}/pulls/{n}/comments")
+    bot_comments = [c for c in comments if bot_login_matches((c.get("user") or {}).get("login"), bot)]
+
+    # Keep reviews carrying a body or any inline comment; skip pure approvals.
+    bot_reviews = [r for r in bot_reviews if (r.get("body") or "").strip()]
+
+    if not bot_reviews and not bot_comments:
+        return None
+
+    # Snapshot to replay against: latest bot review's commit_id, falling back to
+    # the latest inline comment's commit_id.
+    review_commit_id = None
+    if bot_reviews:
+        latest = max(bot_reviews, key=lambda r: r.get("submitted_at") or "")
+        review_commit_id = latest.get("commit_id")
+    if not review_commit_id and bot_comments:
+        latest_c = max(bot_comments, key=lambda c: c.get("created_at") or "")
+        review_commit_id = latest_c.get("commit_id") or latest_c.get("original_commit_id")
+
+    threads = graphql_review_threads(owner, name, n)
+    bot_threads = [t for t in threads if bot_login_matches(t.get("author"), bot)]
+
+    return {
+        "repo": repo,
+        "pr_number": n,
+        "title": pr.get("title"),
+        "state": pr.get("state"),
+        "merged_at": pr.get("mergedAt"),
+        "created_at": pr.get("createdAt"),
+        "base_ref": pr.get("baseRefName"),
+        "head_ref": pr.get("headRefName"),
+        "bot": bot,
+        "review_commit_id": review_commit_id,
+        "n_review_summaries": len(bot_reviews),
+        "n_inline_comments": len(bot_comments),
+        "reviews": [
+            {
+                "id": r.get("id"),
+                "commit_id": r.get("commit_id"),
+                "submitted_at": r.get("submitted_at"),
+                "state": r.get("state"),
+                "body": r.get("body"),
+            }
+            for r in bot_reviews
+        ],
+        "comments": [
+            {
+                "id": c.get("id"),
+                "path": c.get("path"),
+                "line": c.get("line"),
+                "original_line": c.get("original_line"),
+                "start_line": c.get("start_line"),
+                "commit_id": c.get("commit_id"),
+                "original_commit_id": c.get("original_commit_id"),
+                "in_reply_to_id": c.get("in_reply_to_id"),
+                "subject_type": c.get("subject_type"),
+                "created_at": c.get("created_at"),
+                "body": c.get("body"),
+            }
+            for c in bot_comments
+        ],
+        "threads": bot_threads,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--repo", required=True, help="owner/repo")
+    ap.add_argument("--bot", required=True, help="bot user.login, e.g. coderabbitai[bot]")
+    ap.add_argument("--out", default="./out", type=Path, help="output root dir")
+    ap.add_argument("--limit", type=int, default=200, help="max PRs to scan")
+    ap.add_argument("--state", default="all", choices=["all", "open", "closed", "merged"])
+    args = ap.parse_args()
+
+    owner, _, name = args.repo.partition("/")
+    if not name:
+        print("--repo must be owner/repo", file=sys.stderr)
+        return 2
+
+    out_dir = args.out / repo_slug(args.repo)
+
+    print(f"Listing up to {args.limit} {args.state} PRs in {args.repo} ...", file=sys.stderr)
+    prs = gh_json([
+        "pr", "list", "--repo", args.repo,
+        "--state", args.state, "--limit", str(args.limit),
+        "--json", "number,title,state,baseRefName,headRefName,mergedAt,createdAt",
+    ]) or []
+
+    index = []
+    for pr in prs:
+        n = pr["number"]
+        try:
+            record = harvest_pr(args.repo, owner, name, pr, args.bot)
+        except RuntimeError as e:
+            print(f"  PR #{n}: error ({e}); skipping", file=sys.stderr)
+            continue
+        if record is None:
+            continue
+        write_json(out_dir / f"pr-{n}.json", record)
+        resolved = sum(1 for t in record["threads"] if t.get("is_resolved"))
+        index.append({
+            "pr_number": n,
+            "title": record["title"],
+            "state": record["state"],
+            "merged": bool(record["merged_at"]),
+            "review_commit_id": record["review_commit_id"],
+            "n_inline_comments": record["n_inline_comments"],
+            "n_review_summaries": record["n_review_summaries"],
+            "n_resolved_threads": resolved,
+        })
+        print(
+            f"  PR #{n}: {record['n_inline_comments']} inline, "
+            f"{record['n_review_summaries']} summaries, "
+            f"{resolved} resolved @ {str(record['review_commit_id'])[:8]}",
+            file=sys.stderr,
+        )
+
+    index.sort(key=lambda r: r["pr_number"], reverse=True)
+    write_json(out_dir / "index.json", {
+        "repo": args.repo,
+        "bot": args.bot,
+        "n_prs_with_bot_activity": len(index),
+        "prs": index,
+    })
+    print(
+        f"\nHarvested {len(index)} PRs with {args.bot} activity -> {out_dir}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/review-bot-compare/harvest.py
+++ b/bench/review-bot-compare/harvest.py
@@ -20,6 +20,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from pathlib import Path
 
@@ -41,7 +42,15 @@ def harvest_pr(repo: str, owner: str, name: str, pr: dict, bot: str) -> dict | N
     bot_reviews = [r for r in reviews if bot_login_matches((r.get("user") or {}).get("login"), bot)]
 
     comments = gh_paginate(f"repos/{repo}/pulls/{n}/comments")
-    bot_comments = [c for c in comments if bot_login_matches((c.get("user") or {}).get("login"), bot)]
+    # Drop thread replies (in_reply_to_id set): they're not standalone findings,
+    # and counting them inflates n_inline_comments / can taint review_commit_id.
+    # compare.py applies the same filter, so harvest and compare stay aligned.
+    bot_comments = [
+        c
+        for c in comments
+        if not c.get("in_reply_to_id")
+        and bot_login_matches((c.get("user") or {}).get("login"), bot)
+    ]
 
     # Keep reviews carrying a body or any inline comment; skip pure approvals.
     bot_reviews = [r for r in bot_reviews if (r.get("body") or "").strip()]
@@ -59,7 +68,7 @@ def harvest_pr(repo: str, owner: str, name: str, pr: dict, bot: str) -> dict | N
         latest_c = max(bot_comments, key=lambda c: c.get("created_at") or "")
         review_commit_id = latest_c.get("commit_id") or latest_c.get("original_commit_id")
 
-    threads = graphql_review_threads(owner, name, n)
+    threads, threads_complete = graphql_review_threads(owner, name, n)
     bot_threads = [t for t in threads if bot_login_matches(t.get("author"), bot)]
 
     return {
@@ -102,6 +111,7 @@ def harvest_pr(repo: str, owner: str, name: str, pr: dict, bot: str) -> dict | N
             for c in bot_comments
         ],
         "threads": bot_threads,
+        "threads_complete": threads_complete,
     }
 
 
@@ -133,7 +143,7 @@ def main() -> int:
         n = pr["number"]
         try:
             record = harvest_pr(args.repo, owner, name, pr, args.bot)
-        except RuntimeError as e:
+        except (RuntimeError, json.JSONDecodeError) as e:
             print(f"  PR #{n}: error ({e}); skipping", file=sys.stderr)
             continue
         if record is None:
@@ -149,6 +159,7 @@ def main() -> int:
             "n_inline_comments": record["n_inline_comments"],
             "n_review_summaries": record["n_review_summaries"],
             "n_resolved_threads": resolved,
+            "threads_complete": record["threads_complete"],
         })
         print(
             f"  PR #{n}: {record['n_inline_comments']} inline, "

--- a/bench/review-bot-compare/judge.py
+++ b/bench/review-bot-compare/judge.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""LLM judge: semantically match a bot's findings against daydream's findings.
+
+The deterministic matcher in compare.py only catches findings that share a file,
+a nearby line, AND overlapping wording — a strict LOWER BOUND. Two tools almost
+always phrase the same issue differently and anchor it to different lines, so
+that matcher reports ~0 overlap even when the tools agree. This judge asks an
+LLM to decide, per PR, which findings describe the SAME underlying issue.
+
+Per PR it makes ONE LLM call (a light text task — no tools, no repo), so it is
+far cheaper/more reliable than a full review and works on subscription backends
+that rate-limit deep mode. Output: <in>/<owner__repo>/judge/pr-<N>.json, which
+compare.py picks up automatically to compute semantic overlap.
+
+Usage:
+  python judge.py --repo owner/repo --in ./out \
+      --backend pi --provider zai --model glm-5.2 [--pr 1293] [--min-conf 0.5]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+from pathlib import Path
+
+from common import read_json, repo_slug, run, write_json
+from compare import bot_findings, dd_findings
+
+MAX_TEXT = 600  # per-finding char cap to bound prompt size
+
+_TRANSIENT = ("429", "overloaded", "rate limit", "try again later", "temporarily")
+
+PROMPT_HEADER = """You are comparing two automated code-review tools that reviewed the SAME pull \
+request. Tool A is the existing review bot; Tool B is "daydream".
+
+Match findings that describe the SAME underlying issue — same file and same root \
+problem — even when the wording differs or the line numbers differ. Do NOT match \
+findings that merely touch the same file but raise different problems.
+
+Return ONLY a JSON object of this exact shape, no prose:
+{"matches": [{"a": <A index>, "b": <B index>, "confidence": <0.0-1.0>, "reason": "<short>"}]}
+Include a pair only when you are reasonably confident it is the same issue. \
+Each A index and each B index may appear at most once.
+"""
+
+
+def _fmt(findings: list[dict], kind: str) -> str:
+    lines = []
+    for i, f in enumerate(findings):
+        text = (f.get("text") or "").strip().replace("\n", " ")
+        if len(text) > MAX_TEXT:
+            text = text[:MAX_TEXT] + "…"
+        loc = f"{f.get('path')}:{f.get('line')}"
+        lines.append(f"[{kind}{i}] {loc} — {text}")
+    return "\n".join(lines) if lines else f"(no {kind} findings)"
+
+
+def _build_cmd(backend: str, provider: str, model: str, prompt: str) -> list[str]:
+    if backend == "pi":
+        return ["pi", "-p", "--no-tools", "--provider", provider, "--model", model, prompt]
+    if backend == "codex":
+        return ["codex", "exec", prompt]
+    raise ValueError(f"unsupported judge backend: {backend}")
+
+
+def _extract_json(text: str) -> dict | None:
+    """Pull the first JSON object out of model output (tolerates code fences)."""
+    text = text.strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```[a-z]*\n?|\n?```$", "", text).strip()
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+    # Fall back to the largest brace-balanced span.
+    start = text.find("{")
+    end = text.rfind("}")
+    if start != -1 and end > start:
+        try:
+            return json.loads(text[start : end + 1])
+        except json.JSONDecodeError:
+            return None
+    return None
+
+
+def call_llm(backend: str, provider: str, model: str, prompt: str,
+             retries: int, backoff: int) -> str:
+    last = ""
+    for attempt in range(1, retries + 2):
+        proc = run(_build_cmd(backend, provider, model, prompt), check=False, timeout=300)
+        out = (proc.stdout or "").strip()
+        if proc.returncode == 0 and out:
+            return out
+        last = out or (proc.stderr or "")
+        if attempt <= retries and any(s in last.lower() for s in _TRANSIENT):
+            wait = backoff * (2 ** (attempt - 1))
+            print(f"    transient judge error; retry in {wait}s", file=sys.stderr)
+            time.sleep(wait)
+            continue
+        break
+    raise RuntimeError(f"judge LLM call failed: {last[:200]}")
+
+
+def judge_pr(record: dict, art: dict, backend: str, provider: str, model: str,
+             retries: int, backoff: int) -> dict:
+    a = bot_findings(record)
+    b = dd_findings(art)
+    n = record["pr_number"]
+    if not a or not b:
+        return {"pr_number": n, "a_count": len(a), "b_count": len(b), "matches": [],
+                "note": "one side empty"}
+
+    prompt = (
+        f"{PROMPT_HEADER}\n\n=== Tool A findings ({len(a)}) ===\n{_fmt(a, 'A')}\n\n"
+        f"=== Tool B (daydream) findings ({len(b)}) ===\n{_fmt(b, 'B')}\n"
+    )
+    raw = call_llm(backend, provider, model, prompt, retries, backoff)
+    parsed = _extract_json(raw)
+    if not parsed or "matches" not in parsed:
+        return {"pr_number": n, "a_count": len(a), "b_count": len(b), "matches": [],
+                "error": "unparseable judge output", "raw": raw[:500]}
+
+    # Validate indices and dedupe so each side is used at most once.
+    seen_a, seen_b, clean = set(), set(), []
+    for m in parsed["matches"]:
+        try:
+            ai, bi = int(m["a"]), int(m["b"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        if not (0 <= ai < len(a) and 0 <= bi < len(b)):
+            continue
+        if ai in seen_a or bi in seen_b:
+            continue
+        seen_a.add(ai)
+        seen_b.add(bi)
+        clean.append({
+            "a": ai, "b": bi,
+            "confidence": float(m.get("confidence", 1.0)),
+            "reason": str(m.get("reason", ""))[:200],
+            "a_resolved": bool(a[ai].get("resolved")),
+            "a_path": a[ai].get("path"),
+            "b_path": b[bi].get("path"),
+        })
+    return {"pr_number": n, "backend": backend, "model": model,
+            "a_count": len(a), "b_count": len(b), "matches": clean}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--repo", required=True)
+    ap.add_argument("--in", dest="in_root", default="./out", type=Path)
+    ap.add_argument("--backend", default="pi", choices=["pi", "codex"])
+    ap.add_argument("--provider", default="zai", help="pi provider (default: zai)")
+    ap.add_argument("--model", default="glm-5.2")
+    ap.add_argument("--pr", type=int, action="append", help="judge only these PRs")
+    ap.add_argument("--retries", type=int, default=3)
+    ap.add_argument("--backoff", type=int, default=20)
+    args = ap.parse_args()
+
+    base = args.in_root / repo_slug(args.repo)
+    findings_dir = base / "findings"
+    # Judge every PR that has BOTH a harvest record and a daydream findings file.
+    targets = []
+    for fp in sorted(findings_dir.glob("pr-*.json")):
+        n = int(fp.stem.split("-")[1])
+        if args.pr and n not in set(args.pr):
+            continue
+        rec_path = base / f"pr-{n}.json"
+        if rec_path.exists():
+            targets.append((n, rec_path, fp))
+
+    print(f"Judging {len(targets)} PRs with {args.backend}/{args.model}", file=sys.stderr)
+    for n, rec_path, fp in targets:
+        try:
+            art = read_json(fp)
+            if not art.get("findings"):
+                print(f"  PR #{n}: no daydream findings; skip", file=sys.stderr)
+                continue
+            res = judge_pr(read_json(rec_path), art, args.backend, args.provider,
+                           args.model, args.retries, args.backoff)
+        except (RuntimeError, ValueError, OSError) as e:
+            res = {"pr_number": n, "error": str(e), "matches": []}
+        write_json(base / "judge" / f"pr-{n}.json", res)
+        print(f"  PR #{n}: {len(res.get('matches', []))} semantic matches "
+              f"(A={res.get('a_count')}, B={res.get('b_count')})"
+              + (f" [{res['error']}]" if res.get("error") else ""), file=sys.stderr)
+
+    print(f"\nJudge complete -> {base / 'judge'}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/review-bot-compare/judge.py
+++ b/bench/review-bot-compare/judge.py
@@ -27,7 +27,7 @@ import time
 from pathlib import Path
 
 from common import read_json, repo_slug, run, write_json
-from compare import bot_findings, dd_findings
+from compare import bot_findings, dd_findings, findings_digest
 
 MAX_TEXT = 600  # per-finding char cap to bound prompt size
 
@@ -109,9 +109,16 @@ def judge_pr(record: dict, art: dict, backend: str, provider: str, model: str,
     a = bot_findings(record)
     b = dd_findings(art)
     n = record["pr_number"]
+    # Bind this judgement to the exact findings it scored + the snapshot it ran
+    # against, so compare.py can reject it if replay is later rerun with different
+    # findings (a stale judge artifact would otherwise silently skew overlap).
+    provenance = {
+        "review_commit_id": record.get("review_commit_id"),
+        "findings_digest": findings_digest(a, b),
+    }
     if not a or not b:
         return {"pr_number": n, "a_count": len(a), "b_count": len(b), "matches": [],
-                "note": "one side empty"}
+                "note": "one side empty", **provenance}
 
     prompt = (
         f"{PROMPT_HEADER}\n\n=== Tool A findings ({len(a)}) ===\n{_fmt(a, 'A')}\n\n"
@@ -121,11 +128,19 @@ def judge_pr(record: dict, art: dict, backend: str, provider: str, model: str,
     parsed = _extract_json(raw)
     if not parsed or "matches" not in parsed:
         return {"pr_number": n, "a_count": len(a), "b_count": len(b), "matches": [],
-                "error": "unparseable judge output", "raw": raw[:500]}
+                "error": "unparseable judge output", "raw": raw[:500], **provenance}
 
-    # Validate indices and dedupe so each side is used at most once.
+    def _confidence(match: dict) -> float:
+        try:
+            return float(match.get("confidence", 1.0))
+        except (TypeError, ValueError, AttributeError):
+            return -1.0
+
+    # Validate indices and dedupe so each side is used at most once. Process by
+    # descending confidence so a conflicting index keeps the stronger pair rather
+    # than whichever the model happened to emit first.
     seen_a, seen_b, clean = set(), set(), []
-    for m in parsed["matches"]:
+    for m in sorted(parsed["matches"], key=_confidence, reverse=True):
         try:
             ai, bi = int(m["a"]), int(m["b"])
         except (KeyError, TypeError, ValueError):
@@ -145,7 +160,7 @@ def judge_pr(record: dict, art: dict, backend: str, provider: str, model: str,
             "b_path": b[bi].get("path"),
         })
     return {"pr_number": n, "backend": backend, "model": model,
-            "a_count": len(a), "b_count": len(b), "matches": clean}
+            "a_count": len(a), "b_count": len(b), "matches": clean, **provenance}
 
 
 def main() -> int:

--- a/bench/review-bot-compare/replay.py
+++ b/bench/review-bot-compare/replay.py
@@ -50,10 +50,35 @@ _TRANSIENT_SIGNATURES = (
     "try again later",
 )
 
+# Provider/network stream-drop signatures: the z.ai/GLM provider closes the
+# streaming HTTP connection mid-generation, which undici surfaces as a literal
+# "terminated" error and pi propagates as `PiError: terminated`. These are
+# completed-but-lost reviews worth a retry. Matched case-insensitively, but ONLY
+# inside a backend/fatal error context so an ordinary review finding that merely
+# mentions one of these words in prose is not mistaken for a retryable failure.
+_STREAM_DROP_SIGNATURES = (
+    "terminated",
+    "econnreset",
+    "connection reset",
+    "socket hang up",
+    "premature close",
+    "epipe",
+)
+_ERROR_CONTEXT_MARKERS = (
+    "pierror",
+    "backend execution error",
+    "fatal error",
+)
+
 
 def _is_transient(stdout: str) -> bool:
     low = (stdout or "").lower()
-    return any(sig in low for sig in _TRANSIENT_SIGNATURES)
+    if any(sig in low for sig in _TRANSIENT_SIGNATURES):
+        return True
+    # Stream-drop signatures only count when daydream actually errored out.
+    if any(marker in low for marker in _ERROR_CONTEXT_MARKERS):
+        return any(sig in low for sig in _STREAM_DROP_SIGNATURES)
+    return False
 
 
 def git(source: Path, args: list[str], *, check: bool = True, timeout: int | None = None):

--- a/bench/review-bot-compare/replay.py
+++ b/bench/review-bot-compare/replay.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Replay daydream against the exact snapshot a review bot saw.
+
+For each harvested PR record, reconstruct the bot's view of the diff:
+  head = the bot review's commit_id
+  base = merge-base(origin/<base_ref>, head)   # == GitHub's 3-dot compare base
+checked out in a detached worktree, then run daydream in review-only mode and
+collect its findings artifact + trajectory cost.
+
+daydream is run in IN-PLACE mode (target = the detached worktree, no --branch,
+no --worktree) so it diffs `--base ... HEAD` exactly over the bot's snapshot.
+
+Usage:
+  python replay.py --repo owner/repo --source /path/to/local/clone \
+      --in ./out --backend codex [--shallow] [--limit 5] [--pr 123]
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+
+from common import read_json, repo_slug, run, write_json
+
+# daydream resolves a GitHub App identity (and hard-aborts on failure) when these
+# are set and the run is "posting" (--review counts). The benchmark reviews a
+# detached local worktree with no posting, so run it under plain user identity.
+_APP_ENV_VARS = ("DAYDREAM_APP_ID", "DAYDREAM_APP_PRIVATE_KEY")
+
+
+def _local_identity_env() -> dict[str, str]:
+    env = dict(os.environ)
+    for var in _APP_ENV_VARS:
+        env.pop(var, None)
+    return env
+
+
+# Backend overload / rate-limit signatures worth a retry (vs. a real review
+# failure). Matched case-insensitively against daydream's captured stdout.
+_TRANSIENT_SIGNATURES = (
+    "429",
+    "service may be temporarily overloaded",
+    "temporarily overloaded",
+    "rate limit",
+    "rate_limit",
+    "overloaded_error",
+    "try again later",
+)
+
+
+def _is_transient(stdout: str) -> bool:
+    low = (stdout or "").lower()
+    return any(sig in low for sig in _TRANSIENT_SIGNATURES)
+
+
+def git(source: Path, args: list[str], *, check: bool = True, timeout: int | None = None):
+    return run(["git", "-C", str(source), *args], check=check, timeout=timeout)
+
+
+def ensure_commit(source: Path, pr_number: int, sha: str, base_ref: str) -> None:
+    """Make `sha` and `origin/<base_ref>` reachable in the local clone."""
+    # PR head ref makes every commit in the PR history (incl. older review SHAs)
+    # reachable even when the source branch was deleted after merge.
+    git(source, ["fetch", "origin", f"pull/{pr_number}/head"], check=False, timeout=300)
+    git(source, ["fetch", "origin", base_ref], check=False, timeout=300)
+    if git(source, ["cat-file", "-e", f"{sha}^{{commit}}"], check=False).returncode != 0:
+        # Last resort: try fetching the bare SHA directly.
+        git(source, ["fetch", "origin", sha], check=False, timeout=300)
+
+
+def resolve_base(source: Path, base_ref: str, head: str) -> str | None:
+    mb = git(source, ["merge-base", f"origin/{base_ref}", head], check=False)
+    if mb.returncode == 0 and mb.stdout.strip():
+        return mb.stdout.strip()
+    # Fallback: first parent of head (two-dot diff). Less faithful but non-empty.
+    parent = git(source, ["rev-parse", f"{head}^"], check=False)
+    return parent.stdout.strip() if parent.returncode == 0 else None
+
+
+def replay_one(
+    record: dict, source: Path, out_dir: Path, backend: str, shallow: bool, timeout: int,
+    retries: int = 2, backoff: int = 30,
+) -> dict:
+    n = record["pr_number"]
+    head = record["review_commit_id"]
+    base_ref = record["base_ref"] or "main"
+    result: dict = {"pr_number": n, "head": head, "base_ref": base_ref}
+
+    if not head:
+        result["status"] = "skipped-no-commit"
+        return result
+
+    ensure_commit(source, n, head, base_ref)
+    if git(source, ["cat-file", "-e", f"{head}^{{commit}}"], check=False).returncode != 0:
+        result["status"] = "skipped-unreachable-head"
+        return result
+
+    base = resolve_base(source, base_ref, head)
+    if not base:
+        result["status"] = "skipped-no-base"
+        return result
+    result["base"] = base
+
+    wt = (out_dir / "worktrees" / f"pr-{n}").resolve()
+    findings_path = (out_dir / "findings" / f"pr-{n}.json").resolve()
+    traj_path = (out_dir / "traj" / f"pr-{n}.json").resolve()
+    log_path = (out_dir / "logs" / f"pr-{n}.log").resolve()
+    for p in (findings_path, traj_path, log_path):
+        p.parent.mkdir(parents=True, exist_ok=True)
+
+    # Fresh worktree at the bot's snapshot.
+    git(source, ["worktree", "remove", "--force", str(wt)], check=False)
+    git(source, ["worktree", "add", "--detach", str(wt), head], timeout=300)
+
+    cmd = [
+        "daydream", "--review", "--non-interactive",
+        "--backend", backend,
+        "--pr-number", str(n),
+        "--base", base,
+        "--findings-out", str(findings_path),
+        "--trajectory", str(traj_path),
+    ]
+    if shallow:
+        cmd.append("--shallow")
+    cmd.append(str(wt))
+
+    # Retry transient backend overload/rate-limit (e.g. z.ai GLM "429 service
+    # temporarily overloaded") with exponential backoff. A fresh worktree is
+    # already in place; daydream re-runs cleanly over it.
+    start = time.monotonic()
+    attempts = 0
+    while True:
+        attempts += 1
+        proc = run(cmd, cwd=wt, check=False, timeout=timeout, env=_local_identity_env())
+        if proc.returncode == 0 or attempts > retries or not _is_transient(proc.stdout):
+            break
+        wait = backoff * (2 ** (attempts - 1))
+        print(f"  transient backend error (attempt {attempts}/{retries+1}); "
+              f"retrying in {wait}s", file=sys.stderr)
+        time.sleep(wait)
+    elapsed = time.monotonic() - start
+    log_path.write_text(
+        f"$ {' '.join(cmd)}\n\n=== STDOUT ===\n{proc.stdout}\n\n=== STDERR ===\n{proc.stderr}"
+    )
+
+    result["exit_code"] = proc.returncode
+    result["attempts"] = attempts
+    result["wall_seconds"] = round(elapsed, 1)
+    if proc.returncode != 0 and _is_transient(proc.stdout):
+        result["transient_error"] = True
+
+    # Collect findings.
+    if findings_path.exists():
+        try:
+            art = read_json(findings_path)
+            result["n_findings"] = len(art.get("findings", []))
+            result["findings_path"] = str(findings_path)
+        except (ValueError, OSError):
+            result["n_findings"] = None
+    else:
+        result["n_findings"] = 0
+
+    # Collect cost/tokens from the trajectory's final_metrics.
+    if traj_path.exists():
+        try:
+            traj = read_json(traj_path)
+            fm = traj.get("final_metrics") or {}
+            result["cost_usd"] = fm.get("total_cost_usd")
+            result["prompt_tokens"] = fm.get("total_prompt_tokens")
+            result["completion_tokens"] = fm.get("total_completion_tokens")
+            result["cached_tokens"] = fm.get("total_cached_tokens")
+        except (ValueError, OSError):
+            pass
+
+    git(source, ["worktree", "remove", "--force", str(wt)], check=False)
+    result["status"] = "ok" if proc.returncode == 0 else f"daydream-exit-{proc.returncode}"
+    return result
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--repo", required=True, help="owner/repo")
+    ap.add_argument("--source", required=True, type=Path, help="local clone with the GitHub remote")
+    ap.add_argument("--in", dest="in_root", default="./out", type=Path, help="harvest output root")
+    ap.add_argument("--backend", default="codex", choices=["claude", "codex", "pi"])
+    ap.add_argument("--shallow", action="store_true", help="single-stack review (faster pilot)")
+    ap.add_argument("--limit", type=int, default=0, help="max PRs to replay (0 = all)")
+    ap.add_argument("--pr", type=int, action="append", help="replay only these PR numbers (repeatable)")
+    ap.add_argument("--timeout", type=int, default=1800, help="per-PR daydream timeout (seconds)")
+    ap.add_argument("--retries", type=int, default=2, help="retries on transient backend 429/overload")
+    ap.add_argument("--backoff", type=int, default=30, help="base backoff seconds (doubles per retry)")
+    ap.add_argument("--retry-failed", action="store_true",
+                    help="only re-run PRs whose existing replay record is not 'ok'")
+    args = ap.parse_args()
+
+    base_dir = args.in_root / repo_slug(args.repo)
+    index = read_json(base_dir / "index.json")
+    prs = index["prs"]
+
+    if args.pr:
+        wanted = set(args.pr)
+        prs = [p for p in prs if p["pr_number"] in wanted]
+    if args.retry_failed:
+        failed = set()
+        for f in sorted((base_dir / "replay").glob("pr-*.json")):
+            rec = read_json(f)
+            if rec.get("status") != "ok":
+                failed.add(rec["pr_number"])
+        prs = [p for p in prs if p["pr_number"] in failed]
+        print(f"Retrying {len(prs)} previously-failed PRs: "
+              f"{sorted(p['pr_number'] for p in prs)}", file=sys.stderr)
+    # Only PRs with a usable snapshot + at least one inline comment.
+    prs = [p for p in prs if p["review_commit_id"] and p["n_inline_comments"] > 0]
+    if args.limit:
+        prs = prs[: args.limit]
+
+    if not args.source.exists():
+        print(f"--source {args.source} does not exist", file=sys.stderr)
+        return 2
+
+    print(f"Replaying {len(prs)} PRs with backend={args.backend} shallow={args.shallow}",
+          file=sys.stderr)
+
+    results = []
+    for p in prs:
+        n = p["pr_number"]
+        record = read_json(base_dir / f"pr-{n}.json")
+        print(f"\n=== PR #{n} :: {record['title']!r} ===", file=sys.stderr)
+        try:
+            res = replay_one(record, args.source, base_dir, args.backend, args.shallow,
+                             args.timeout, retries=args.retries, backoff=args.backoff)
+        except Exception as e:  # noqa: BLE001 - isolate one PR's failure from the batch
+            res = {"pr_number": n, "status": f"error: {e}"}
+        results.append(res)
+        write_json(base_dir / "replay" / f"pr-{n}.json", res)
+        print(
+            f"  -> {res.get('status')} | findings={res.get('n_findings')} "
+            f"cost={res.get('cost_usd')} tok={res.get('prompt_tokens')}/"
+            f"{res.get('completion_tokens')} {res.get('wall_seconds')}s "
+            f"(attempts={res.get('attempts')})",
+            file=sys.stderr,
+        )
+
+    # Rebuild summary from ALL per-PR records on disk so partial/retry runs
+    # accumulate into one complete summary for compare.py.
+    all_recs = [read_json(f) for f in sorted((base_dir / "replay").glob("pr-*.json"))]
+    write_json(base_dir / "replay" / "summary.json", {"repo": args.repo, "results": all_recs})
+    print(f"\nReplay complete -> {base_dir / 'replay'} "
+          f"({len(all_recs)} PRs in summary)", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/review-bot-compare/replay.py
+++ b/bench/review-bot-compare/replay.py
@@ -81,6 +81,50 @@ def _is_transient(stdout: str) -> bool:
     return False
 
 
+def _findings_complete(findings_path: Path, traj_path: Path) -> bool:
+    """True when a prior attempt already produced a *complete* review on disk.
+
+    daydream writes the findings artifact and the trajectory's `final_metrics`
+    only at the very end of the review pipeline. A z.ai/GLM stream-drop at the
+    closing stream (`PiError: terminated`) exits the subprocess non-zero but
+    leaves both files fully written — the review is done, only the socket died.
+    Re-running it wastes ~9 min and risks dropping again, so we treat this as a
+    success and never retry it.
+    """
+    try:
+        art = read_json(findings_path)
+        if not isinstance(art.get("findings"), list):
+            return False
+        traj = read_json(traj_path)
+    except (ValueError, OSError):
+        return False
+    return bool(traj.get("final_metrics"))
+
+
+def _collect(findings_path: Path, traj_path: Path) -> dict:
+    """Read finding count + cost/token metrics off the on-disk artifacts."""
+    out: dict = {}
+    if findings_path.exists():
+        try:
+            art = read_json(findings_path)
+            out["n_findings"] = len(art.get("findings", []))
+            out["findings_path"] = str(findings_path)
+        except (ValueError, OSError):
+            out["n_findings"] = None
+    else:
+        out["n_findings"] = 0
+    if traj_path.exists():
+        try:
+            fm = read_json(traj_path).get("final_metrics") or {}
+            out["cost_usd"] = fm.get("total_cost_usd")
+            out["prompt_tokens"] = fm.get("total_prompt_tokens")
+            out["completion_tokens"] = fm.get("total_completion_tokens")
+            out["cached_tokens"] = fm.get("total_cached_tokens")
+        except (ValueError, OSError):
+            pass
+    return out
+
+
 def git(source: Path, args: list[str], *, check: bool = True, timeout: int | None = None):
     return run(["git", "-C", str(source), *args], check=check, timeout=timeout)
 
@@ -136,6 +180,16 @@ def replay_one(
     for p in (findings_path, traj_path, log_path):
         p.parent.mkdir(parents=True, exist_ok=True)
 
+    # Resume: a prior attempt already produced a complete review (a tail-end
+    # stream-drop leaves findings + trajectory fully written). Never re-run it.
+    if _findings_complete(findings_path, traj_path):
+        result.update(_collect(findings_path, traj_path))
+        result["attempts"] = 0
+        result["wall_seconds"] = 0.0
+        result["reused_existing"] = True
+        result["status"] = "ok"
+        return result
+
     # Fresh worktree at the bot's snapshot.
     git(source, ["worktree", "remove", "--force", str(wt)], check=False)
     git(source, ["worktree", "add", "--detach", str(wt), head], timeout=300)
@@ -162,6 +216,10 @@ def replay_one(
         proc = run(cmd, cwd=wt, check=False, timeout=timeout, env=_local_identity_env())
         if proc.returncode == 0 or attempts > retries or not _is_transient(proc.stdout):
             break
+        # The review may have completed and only the closing stream dropped —
+        # findings + trajectory are on disk. That's a success; don't re-run it.
+        if _findings_complete(findings_path, traj_path):
+            break
         wait = backoff * (2 ** (attempts - 1))
         print(f"  transient backend error (attempt {attempts}/{retries+1}); "
               f"retrying in {wait}s", file=sys.stderr)
@@ -177,31 +235,18 @@ def replay_one(
     if proc.returncode != 0 and _is_transient(proc.stdout):
         result["transient_error"] = True
 
-    # Collect findings.
-    if findings_path.exists():
-        try:
-            art = read_json(findings_path)
-            result["n_findings"] = len(art.get("findings", []))
-            result["findings_path"] = str(findings_path)
-        except (ValueError, OSError):
-            result["n_findings"] = None
-    else:
-        result["n_findings"] = 0
-
-    # Collect cost/tokens from the trajectory's final_metrics.
-    if traj_path.exists():
-        try:
-            traj = read_json(traj_path)
-            fm = traj.get("final_metrics") or {}
-            result["cost_usd"] = fm.get("total_cost_usd")
-            result["prompt_tokens"] = fm.get("total_prompt_tokens")
-            result["completion_tokens"] = fm.get("total_completion_tokens")
-            result["cached_tokens"] = fm.get("total_cached_tokens")
-        except (ValueError, OSError):
-            pass
+    result.update(_collect(findings_path, traj_path))
 
     git(source, ["worktree", "remove", "--force", str(wt)], check=False)
-    result["status"] = "ok" if proc.returncode == 0 else f"daydream-exit-{proc.returncode}"
+    # A non-zero exit whose review nonetheless completed (stream dropped at the
+    # tail) is a success: findings + metrics are intact on disk.
+    if proc.returncode == 0:
+        result["status"] = "ok"
+    elif _findings_complete(findings_path, traj_path):
+        result["status"] = "ok"
+        result["stream_dropped_at_tail"] = True
+    else:
+        result["status"] = f"daydream-exit-{proc.returncode}"
     return result
 
 

--- a/bench/review-bot-compare/replay.py
+++ b/bench/review-bot-compare/replay.py
@@ -194,59 +194,64 @@ def replay_one(
     git(source, ["worktree", "remove", "--force", str(wt)], check=False)
     git(source, ["worktree", "add", "--detach", str(wt), head], timeout=300)
 
-    cmd = [
-        "daydream", "--review", "--non-interactive",
-        "--backend", backend,
-        "--pr-number", str(n),
-        "--base", base,
-        "--findings-out", str(findings_path),
-        "--trajectory", str(traj_path),
-    ]
-    if shallow:
-        cmd.append("--shallow")
-    cmd.append(str(wt))
+    try:
+        cmd = [
+            "daydream", "--review", "--non-interactive",
+            "--backend", backend,
+            "--pr-number", str(n),
+            "--base", base,
+            "--findings-out", str(findings_path),
+            "--trajectory", str(traj_path),
+        ]
+        if shallow:
+            cmd.append("--shallow")
+        cmd.append(str(wt))
 
-    # Retry transient backend overload/rate-limit (e.g. z.ai GLM "429 service
-    # temporarily overloaded") with exponential backoff. A fresh worktree is
-    # already in place; daydream re-runs cleanly over it.
-    start = time.monotonic()
-    attempts = 0
-    while True:
-        attempts += 1
-        proc = run(cmd, cwd=wt, check=False, timeout=timeout, env=_local_identity_env())
-        if proc.returncode == 0 or attempts > retries or not _is_transient(proc.stdout):
-            break
-        # The review may have completed and only the closing stream dropped —
-        # findings + trajectory are on disk. That's a success; don't re-run it.
-        if _findings_complete(findings_path, traj_path):
-            break
-        wait = backoff * (2 ** (attempts - 1))
-        print(f"  transient backend error (attempt {attempts}/{retries+1}); "
-              f"retrying in {wait}s", file=sys.stderr)
-        time.sleep(wait)
-    elapsed = time.monotonic() - start
-    log_path.write_text(
-        f"$ {' '.join(cmd)}\n\n=== STDOUT ===\n{proc.stdout}\n\n=== STDERR ===\n{proc.stderr}"
-    )
+        # Retry transient backend overload/rate-limit (e.g. z.ai GLM "429 service
+        # temporarily overloaded") with exponential backoff. A fresh worktree is
+        # already in place; daydream re-runs cleanly over it.
+        start = time.monotonic()
+        attempts = 0
+        while True:
+            attempts += 1
+            proc = run(cmd, cwd=wt, check=False, timeout=timeout, env=_local_identity_env())
+            if proc.returncode == 0 or attempts > retries or not _is_transient(proc.stdout):
+                break
+            # The review may have completed and only the closing stream dropped —
+            # findings + trajectory are on disk. That's a success; don't re-run it.
+            if _findings_complete(findings_path, traj_path):
+                break
+            wait = backoff * (2 ** (attempts - 1))
+            print(f"  transient backend error (attempt {attempts}/{retries+1}); "
+                  f"retrying in {wait}s", file=sys.stderr)
+            time.sleep(wait)
+        elapsed = time.monotonic() - start
+        log_path.write_text(
+            f"$ {' '.join(cmd)}\n\n=== STDOUT ===\n{proc.stdout}\n\n=== STDERR ===\n{proc.stderr}"
+        )
 
-    result["exit_code"] = proc.returncode
-    result["attempts"] = attempts
-    result["wall_seconds"] = round(elapsed, 1)
-    if proc.returncode != 0 and _is_transient(proc.stdout):
-        result["transient_error"] = True
+        result["exit_code"] = proc.returncode
+        result["attempts"] = attempts
+        result["wall_seconds"] = round(elapsed, 1)
+        if proc.returncode != 0 and _is_transient(proc.stdout):
+            result["transient_error"] = True
 
-    result.update(_collect(findings_path, traj_path))
+        result.update(_collect(findings_path, traj_path))
 
-    git(source, ["worktree", "remove", "--force", str(wt)], check=False)
-    # A non-zero exit whose review nonetheless completed (stream dropped at the
-    # tail) is a success: findings + metrics are intact on disk.
-    if proc.returncode == 0:
-        result["status"] = "ok"
-    elif _findings_complete(findings_path, traj_path):
-        result["status"] = "ok"
-        result["stream_dropped_at_tail"] = True
-    else:
-        result["status"] = f"daydream-exit-{proc.returncode}"
+        # A non-zero exit whose review nonetheless completed (stream dropped at the
+        # tail) is a success: findings + metrics are intact on disk.
+        if proc.returncode == 0:
+            result["status"] = "ok"
+        elif _findings_complete(findings_path, traj_path):
+            result["status"] = "ok"
+            result["stream_dropped_at_tail"] = True
+        else:
+            result["status"] = f"daydream-exit-{proc.returncode}"
+    finally:
+        # Always reclaim the detached worktree, even if daydream timed out or
+        # raised — run(..., timeout=) raises TimeoutExpired through here, and
+        # leaked worktrees would otherwise accumulate across a long batch.
+        git(source, ["worktree", "remove", "--force", str(wt)], check=False)
     return result
 
 

--- a/bench/review-bot-compare/test_replay.py
+++ b/bench/review-bot-compare/test_replay.py
@@ -8,6 +8,7 @@ pytest suite. Run directly:  python3 test_replay.py
 from __future__ import annotations
 
 import json
+import subprocess
 import tempfile
 import types
 import unittest
@@ -188,6 +189,30 @@ class ReplayRetryTest(unittest.TestCase):
         self.assertEqual(res["attempts"], 0)
         self.assertEqual(res["status"], "ok")
         self.assertEqual(res["n_findings"], 2)
+
+    def test_worktree_removed_when_run_raises(self) -> None:
+        # run(..., timeout=) raises TimeoutExpired straight through replay_one.
+        # The detached worktree must still be reclaimed in the finally block,
+        # or leaked worktrees accumulate across a long batch.
+        removes = []
+
+        def tracking_git(source, args, *, check=True, timeout=None):
+            if args[:2] == ["worktree", "remove"]:
+                removes.append(args)
+            return types.SimpleNamespace(returncode=0, stdout="deadbeef\n", stderr="")
+
+        def boom_run(cmd, *, cwd=None, check=False, timeout=None, env=None):
+            raise subprocess.TimeoutExpired(cmd, 10)
+
+        replay.git = tracking_git
+        replay.run = boom_run
+        with self.assertRaises(subprocess.TimeoutExpired):
+            replay_one(self.record, self.source, self.out, "pi", False, 10,
+                       retries=0, backoff=0)
+
+        # Two removes: the pre-add cleanup AND the post-failure finally cleanup.
+        # Pre-fix there was only the pre-add remove (1) on the exception path.
+        self.assertEqual(len(removes), 2, "worktree must be removed in finally")
 
     def test_transient_drop_without_findings_does_retry(self) -> None:
         # No findings ever written -> the loop must exhaust its retries.

--- a/bench/review-bot-compare/test_replay.py
+++ b/bench/review-bot-compare/test_replay.py
@@ -7,9 +7,14 @@ pytest suite. Run directly:  python3 test_replay.py
 
 from __future__ import annotations
 
+import json
+import tempfile
+import types
 import unittest
+from pathlib import Path
 
-from replay import _is_transient
+import replay
+from replay import _findings_complete, _is_transient, replay_one
 
 # A real `PiError: terminated` Backend-Execution-Error panel as captured in
 # daydream's stdout when the z.ai/GLM provider drops the streaming connection.
@@ -78,6 +83,128 @@ class IsTransientTest(unittest.TestCase):
 
     def test_empty_is_not_transient(self) -> None:
         self.assertFalse(_is_transient(""))
+
+
+def _write(path: Path, obj: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj))
+
+
+# A complete review: findings artifact with a findings list + a trajectory whose
+# final_metrics is populated. This is exactly what's on disk after a tail-end
+# stream-drop (the review finished; only the closing socket died).
+COMPLETE_FINDINGS = {"schema_version": 1, "findings": [{"id": "a"}, {"id": "b"}]}
+COMPLETE_TRAJ = {"final_metrics": {"total_prompt_tokens": 100, "total_completion_tokens": 50,
+                                   "total_cached_tokens": 0, "total_cost_usd": 0.0}}
+
+
+class FindingsCompleteTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+        self.f = self.tmp / "findings.json"
+        self.t = self.tmp / "traj.json"
+
+    def test_complete_when_both_present(self) -> None:
+        _write(self.f, COMPLETE_FINDINGS)
+        _write(self.t, COMPLETE_TRAJ)
+        self.assertTrue(_findings_complete(self.f, self.t))
+
+    def test_incomplete_when_findings_missing(self) -> None:
+        _write(self.t, COMPLETE_TRAJ)
+        self.assertFalse(_findings_complete(self.f, self.t))
+
+    def test_incomplete_when_findings_has_no_list(self) -> None:
+        _write(self.f, {"schema_version": 1})  # no "findings" array
+        _write(self.t, COMPLETE_TRAJ)
+        self.assertFalse(_findings_complete(self.f, self.t))
+
+    def test_incomplete_when_traj_has_no_metrics(self) -> None:
+        _write(self.f, COMPLETE_FINDINGS)
+        _write(self.t, {"steps": []})  # trajectory written but no final_metrics
+        self.assertFalse(_findings_complete(self.f, self.t))
+
+
+def _fake_git(source, args, *, check=True, timeout=None):
+    # Every git call succeeds; merge-base / rev-parse yield a usable sha.
+    return types.SimpleNamespace(returncode=0, stdout="deadbeef\n", stderr="")
+
+
+def _arg(cmd: list[str], flag: str) -> str:
+    return cmd[cmd.index(flag) + 1]
+
+
+class ReplayRetryTest(unittest.TestCase):
+    """Drive the real replay_one retry loop; stub only git/ensure_commit/run."""
+
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+        self.source = self.tmp / "src"
+        self.source.mkdir()
+        self.out = self.tmp / "out"
+        self.record = {"pr_number": 1295, "review_commit_id": "deadbeef", "base_ref": "main"}
+        self._orig = (replay.git, replay.ensure_commit, replay.run)
+        replay.git = _fake_git
+        replay.ensure_commit = lambda *a, **k: None
+
+    def tearDown(self) -> None:
+        replay.git, replay.ensure_commit, replay.run = self._orig
+
+    def test_tail_drop_with_complete_findings_does_not_retry(self) -> None:
+        calls = {"n": 0}
+
+        def fake_run(cmd, *, cwd=None, check=False, timeout=None, env=None):
+            # daydream "completes" (writes findings + metrics) but the closing
+            # stream dies — exits non-zero with a PiError: terminated panel.
+            calls["n"] += 1
+            _write(Path(_arg(cmd, "--findings-out")), COMPLETE_FINDINGS)
+            _write(Path(_arg(cmd, "--trajectory")), COMPLETE_TRAJ)
+            return types.SimpleNamespace(
+                returncode=1, stdout=PIERROR_TERMINATED_STDOUT, stderr="")
+
+        replay.run = fake_run
+        res = replay_one(self.record, self.source, self.out, "pi", False, 10,
+                         retries=3, backoff=0)
+
+        self.assertEqual(calls["n"], 1, "must NOT re-run a completed review")
+        self.assertEqual(res["attempts"], 1)
+        self.assertEqual(res["status"], "ok")
+        self.assertTrue(res["stream_dropped_at_tail"])
+        self.assertEqual(res["n_findings"], 2)
+        self.assertEqual(res["completion_tokens"], 50)
+
+    def test_resume_skips_run_when_findings_already_on_disk(self) -> None:
+        # Pre-seed a complete review (as a prior killed run would leave behind).
+        _write((self.out / "findings" / "pr-1295.json"), COMPLETE_FINDINGS)
+        _write((self.out / "traj" / "pr-1295.json"), COMPLETE_TRAJ)
+
+        def fail_run(*a, **k):
+            raise AssertionError("run() must not be called when findings exist")
+
+        replay.run = fail_run
+        res = replay_one(self.record, self.source, self.out, "pi", False, 10,
+                         retries=3, backoff=0)
+
+        self.assertTrue(res["reused_existing"])
+        self.assertEqual(res["attempts"], 0)
+        self.assertEqual(res["status"], "ok")
+        self.assertEqual(res["n_findings"], 2)
+
+    def test_transient_drop_without_findings_does_retry(self) -> None:
+        # No findings ever written -> the loop must exhaust its retries.
+        calls = {"n": 0}
+
+        def fake_run(cmd, *, cwd=None, check=False, timeout=None, env=None):
+            calls["n"] += 1
+            return types.SimpleNamespace(
+                returncode=1, stdout=PIERROR_TERMINATED_STDOUT, stderr="")
+
+        replay.run = fake_run
+        res = replay_one(self.record, self.source, self.out, "pi", False, 10,
+                         retries=2, backoff=0)
+
+        self.assertEqual(calls["n"], 3, "1 initial + 2 retries")
+        self.assertEqual(res["status"], "daydream-exit-1")
+        self.assertTrue(res["transient_error"])
 
 
 if __name__ == "__main__":

--- a/bench/review-bot-compare/test_replay.py
+++ b/bench/review-bot-compare/test_replay.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Tests for replay._is_transient.
+
+Standalone (stdlib unittest) — the bench scripts are not wired into the package
+pytest suite. Run directly:  python3 test_replay.py
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from replay import _is_transient
+
+# A real `PiError: terminated` Backend-Execution-Error panel as captured in
+# daydream's stdout when the z.ai/GLM provider drops the streaming connection.
+PIERROR_TERMINATED_STDOUT = """\
+Reviewing changed files...
+
+╔═ ⚠️  Backend Execution Error ═════════════════════════════════════════════
+║ PiError: terminated
+╚═══════════════════════════════════════════════════════════════════════════
+
+╔═ ⚠️  Fatal Error ═════════════════════════════════════════════════════════
+║ terminated
+╚═══════════════════════════════════════════════════════════════════════════
+"""
+
+ECONNRESET_STDOUT = """\
+╔═ ⚠️  Backend Execution Error ═════════════════════════════════════════════
+║ PiError: read ECONNRESET
+╚═══════════════════════════════════════════════════════════════════════════
+"""
+
+SOCKET_HANG_UP_STDOUT = """\
+╔═ ⚠️  Fatal Error ═════════════════════════════════════════════════════════
+║ socket hang up
+╚═══════════════════════════════════════════════════════════════════════════
+"""
+
+OVERLOADED_429_STDOUT = """\
+╔═ ⚠️  Backend Execution Error ═════════════════════════════════════════════
+║ 429 service may be temporarily overloaded, please try again later
+╚═══════════════════════════════════════════════════════════════════════════
+"""
+
+# A clean, successful review with NO error. Deliberately mentions "error" in
+# benign prose ("error handling", "ECONNRESET") to guard against over-broad
+# matching that would retry a perfectly good review forever.
+CLEAN_SUCCESS_STDOUT = """\
+Review complete. 2 findings written to findings.json.
+
+  - [medium] The new fetch() call has no error handling; a dropped
+    connection (e.g. ECONNRESET) would crash the worker. Wrap it in
+    try/except and log the failure.
+  - [low] The "terminated" status string is hardcoded; prefer an enum.
+
+Done.
+"""
+
+
+class IsTransientTest(unittest.TestCase):
+    def test_pierror_terminated_is_transient(self) -> None:
+        # Regression guard: the stream-drop that motivated this fix MUST retry.
+        self.assertTrue(_is_transient(PIERROR_TERMINATED_STDOUT))
+
+    def test_econnreset_is_transient(self) -> None:
+        self.assertTrue(_is_transient(ECONNRESET_STDOUT))
+
+    def test_socket_hang_up_is_transient(self) -> None:
+        self.assertTrue(_is_transient(SOCKET_HANG_UP_STDOUT))
+
+    def test_429_overload_still_transient(self) -> None:
+        self.assertTrue(_is_transient(OVERLOADED_429_STDOUT))
+
+    def test_clean_success_is_not_transient(self) -> None:
+        # Mentions "error"/"ECONNRESET"/"terminated" in prose but did NOT error.
+        self.assertFalse(_is_transient(CLEAN_SUCCESS_STDOUT))
+
+    def test_empty_is_not_transient(self) -> None:
+        self.assertFalse(_is_transient(""))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
De-risks the "vendor-output capture is the biggest unknown" spike called out in #92 by prototyping a capture mechanism (harvest a bot's historic PR reviews via the GitHub API). This is **not** an implementation of #92: #92 runs the R4 held-out corpus through three paths with SPEC-C6 blinded two-stage scoring (κ≥0.7 judge, both-ordering paired comparison, human spot-check gate, R2 reward-module import) — none of which this harness does, and it scores live-PR overlap rather than the held-out corpus.

## What

A standalone harness (`bench/review-bot-compare/`) that benchmarks **daydream** against **any GitHub review bot** (CodeRabbit, Greptile, …) on a repo's real PR history, by replaying daydream at the *exact commit the bot reviewed*.

Generalized over `--repo` and `--bot` — same code path for CodeRabbit and Greptile; just change `--bot`.

```
harvest.py   bot's historic reviews   → out/<owner__repo>/pr-<N>.json + index.json
replay.py    daydream @ same snapshot  → out/<owner__repo>/findings|traj|replay/
judge.py     LLM semantic matching     → out/<owner__repo>/judge/pr-<N>.json   (optional)
compare.py   align + score             → out/<owner__repo>/report.md + comparison.csv
```

## How the "same snapshot" works

The bot's review object carries a `commit_id`. `replay.py` reconstructs the bot's exact view of the diff:
- `head` = the bot review's `commit_id`
- `base` = `git merge-base origin/<base_ref> <head>` (GitHub's 3-dot compare base)

It checks `head` out in a detached worktree and runs daydream in-place with `--base <merge-base>`, so daydream reviews byte-for-byte the same diff the bot saw — not today's HEAD.

## What it measures

| Axis | daydream | bot |
|---|---|---|
| Issues raised | findings artifact | inline comments |
| Overlap / unique | LLM judge (semantic) where available, else deterministic lower bound | |
| Acted-upon precision | findings hitting a **resolved** bot thread | resolved-thread rate |
| Cost | measured (trajectory `total_cost_usd` + tokens), or synthesized from a price card | **not observable** (SaaS) — amortized list price |
| Latency | wall-clock per PR | review timestamp − PR open |

## Validation target

Exercised against **a closed-source repo**: a ~235k-LOC polyglot monorepo —
- **Go** (~107k LOC, 380 files) across an 11-module `go.work` workspace (API gateway, several domain microservices, and shared libraries),
- a **Python** FastAPI + SQLAlchemy backend (~38k LOC, 191 files, Alembic migrations), and
- **React 19 / React Router 7 / Tailwind / Three.js** frontends (~90k LOC of TS/TSX across a customer app and an admin dashboard).

## GLM pilot results (pi / glm-5.2, deep mode, 5 PRs)

Replayed daydream at CodeRabbit's exact snapshot on 5 merged PRs of the validation
monorepo. **4 of 5 completed clean**; PR #1292 (a ~17k-line diff) hit the 45-min
timeout — GLM deep mode is too slow on diffs that large (not a stream-drop; the
retry correctly did not re-run a timeout).

| PR | daydream | CodeRabbit (actionable) | issue overlap (judge) | $ (synth) | wall |
|---|---|---|---|---|---|
| #1290 | 8 | 7 | 1 | $1.19 | 17.1m |
| #1291 | 15 | 17 | 0 | $1.28 | 15.7m |
| #1293 | 12 | 20 | 2 | $1.76 | 23.0m |
| #1295 | 5 | 1 | 0 | $0.68 | 15.2m |
| #1292 | — timed out @ 45m — | 3 | — | — | — |

**Totals (4 usable):** CodeRabbit **45** actionable findings vs daydream **40**.
Issue-level semantic overlap (LLM judge, conf ≥ 0.5): **3** — all spot-checked real
(username `COALESCE`-clobber in `users.sql`; `os.Exit` skipping deferred cleanup and
DB-errors-masked-as-200s, both in the taste service). That's **~7% of CodeRabbit /
~8% of daydream** — the two tools mostly surface *different* issues. 11 files were
flagged by both.

- **Acted-upon:** CodeRabbit resolved 25/45 threads; 1 daydream finding landed on a
  resolved CodeRabbit thread (the 1290 username bug — a confirmed acted-upon hit).
- **Cost / throughput (daydream, synthesized — GLM bills $0):** **$4.91 total,
  $1.23/PR** @ glm-5.2 price card; 1.15M fresh-input / 8.25M cached-read / 265k output
  tokens; 1065s/PR avg. CodeRabbit per-review cost is SaaS-opaque (amortize plan ÷ PRs).
- **Reliability:** zero stream-drops this run — every completed PR succeeded on the
  first attempt (`attempts=1`), including #1293 which a prior run lost to a tail-end
  z.ai drop. The harness's findings-aware retry (this PR) prevents wasteful re-runs of
  a completed-but-socket-dropped review; daydream-side in-process retry is tracked in
  #209.

## Notes

- Three bot-agnostic gotchas handled: `DAYDREAM_APP_*` env hard-aborts `--review` (stripped for local runs); GitHub REST keeps the `[bot]` login suffix while GraphQL drops it (tolerant match, else the resolved-thread signal silently reads 0); pi/GLM token counters are disjoint (fresh input vs cache-read) — billed separately.
- `out/` (harvested data, worktrees, findings, reports) is gitignored.
- Standalone dev tooling — intentionally **not** wired into package CI (`make lint`/`mypy` cover `daydream tests`). All five scripts are ruff-clean.

## Test plan / next steps

- [ ] Re-run on a metered key for clean 5/5 numbers (and real $ on every PR)
- [ ] Point at the actual Greptile repo: `--bot <greptile-login>` (confirm the login via `gh api .../comments --jq '.[].user.login' | sort -u` first)
- [ ] Optionally tune `judge.py --min-conf` and spot-check matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

