### PR TITLE
chore: gitignore local .worktrees/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ Thumbs.db
 
 # Beagle local artifacts
 .beagle/
+
+# Local git worktrees
+.worktrees/


### PR DESCRIPTION
Local git worktrees live under `.worktrees/` and were showing up as untracked in `git status`. Add the directory to `.gitignore`.

No code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)