### PR TITLE
fix(backends/pi): invoke deep review skills natively

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,7 @@ Daydream is a Python CLI that automates code review and fix loops using the Clau
 - `CLAUDE_CONFIG_DIR` environment variable can override the default `~/.claude` directory (used in `daydream/deep/orchestrator.py`)
 - Codex backend requires `codex` CLI on `$PATH`; credentials managed by the Codex CLI itself
 - Pi backend (`--backend pi`) requires the `pi` CLI (`@earendil-works/pi-coding-agent`) on `$PATH`; z.ai coding plan (GLM models) is registered via a pi extension at `~/.pi/extensions/zai-provider/` (installed once via `pi install`). `--provider` defaults to `zai` (matching `DEFAULT_PI_MODEL = "glm-5.2"`); optional `PI_PROVIDER` / `PI_API_KEY` / `PI_THINKING` env overrides forward as `pi` CLI flags.
+- `DAYDREAM_SKILLS_DIR` — optional override for Beagle skill-directory resolution (Pi `--skill` registration in `daydream/backends/pi.py`). When set it is searched first, ahead of the built-in defaults `~/.agents/skills` (primary), `~/.claude/skills` (legacy mirror), and the project-local `.agents/skills` / `.claude/skills` mirrors.
 - `pyproject.toml` — Single source of truth: project metadata, dependencies, tool configuration
 - `[tool.mypy]` — `python_version = "3.12"`, `ignore_missing_imports = true`
 - `[tool.ruff]` — `line-length = 120`, `target-version = "py312"`, rules: `E`, `F`, `I`, `W`

--- a/daydream/backends/pi.py
+++ b/daydream/backends/pi.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import re
 import uuid
 from collections.abc import AsyncIterator
 from pathlib import Path
@@ -69,6 +70,11 @@ _PI_EVENT_TYPES: frozenset[str] = frozenset(
 
 # Read-only tool subset (plan §3). Excludes the mutating edit/bash/write tools.
 _PI_READ_ONLY_TOOLS = "read,find,ls,grep"
+
+# Matches Pi's native ``/skill:<slug>`` command embedded in a prompt (emitted by
+# ``format_skill_invocation``). Used in ``execute`` to register the referenced
+# skill directories with the subprocess via ``--skill`` flags.
+_SKILL_TOKEN_RE = re.compile(r"/skill:([\w-]+)")
 
 # Pi CLI ships only a minimal built-in system prompt. Claude Code and Codex
 # inject rich guidance (tool efficiency, exploration strategy, conciseness) at
@@ -168,6 +174,17 @@ def _schema_instruction(schema: dict[str, Any]) -> str:
     )
 
 
+def _skill_slug(skill_key: str) -> str:
+    """Strip a Beagle plugin prefix from a skill key, leaving the bare slug.
+
+    ``beagle-python:review-python`` -> ``review-python``; a key that already
+    has no prefix (``review-python``) is returned unchanged. Pi has no plugin
+    namespace, so its native ``/skill:<slug>`` command and on-disk skill
+    directories are keyed by the bare slug.
+    """
+    return skill_key.split(":")[-1]
+
+
 def _resolve_skill_dir(skill_key: str) -> Path | None:
     """Best-effort resolution of a Beagle skill key to its on-disk directory.
 
@@ -182,7 +199,7 @@ def _resolve_skill_dir(skill_key: str) -> Path | None:
     can disagree on where the Beagle skills live; consolidate when the
     full resolver lands.
     """
-    slug = skill_key.split(":")[-1]
+    slug = _skill_slug(skill_key)
     home = Path.home()
     search_roots: list[Path] = [
         home / ".claude" / "skills",
@@ -296,6 +313,23 @@ class PiBackend:
         full_prompt = prompt
         if output_schema:
             full_prompt = prompt + _schema_instruction(output_schema)
+
+        # Register any /skill:<slug> commands referenced in the prompt with the
+        # subprocess via repeatable --skill <dir> flags so availability does not
+        # depend solely on ambient ~/.agents/skills mirrors. Best-effort and
+        # de-duplicated: slugs that don't resolve to an on-disk skill dir are
+        # skipped (pi may still auto-discover them) and never crash the run.
+        registered_dirs: set[str] = set()
+        for slug in _SKILL_TOKEN_RE.findall(full_prompt):
+            skill_dir = _resolve_skill_dir(slug)
+            if skill_dir is None:
+                continue
+            resolved = str(skill_dir)
+            if resolved in registered_dirs:
+                continue
+            registered_dirs.add(resolved)
+            args.extend(["--skill", resolved])
+
         args.append(full_prompt)
 
         session_id: str | None = None
@@ -515,30 +549,25 @@ class PiBackend:
                 await process.wait()
 
     def format_skill_invocation(self, skill_key: str, args: str = "") -> str:
-        """Format a skill invocation for Pi via path-reference injection.
+        """Format a skill invocation as Pi's native ``/skill:<slug>`` command.
 
-        Pi has no skill registry (Beagle skills are Claude Code plugins), so we
-        resolve the skill directory on disk and instruct the agent to read its
-        ``SKILL.md``. When the directory cannot be resolved, the raw skill key
-        is kept as a hint — the review proceeds; this method never raises
-        (design doc §5 degradation path).
+        Pi exposes installed skills through a built-in slash command keyed by
+        the bare slug (it has no plugin namespace), so a Beagle key like
+        ``beagle-python:review-python`` becomes ``/skill:review-python``. The
+        plugin prefix is stripped via :func:`_skill_slug`; the matching skill
+        directory is registered with the subprocess in :meth:`execute` via a
+        ``--skill`` flag so the command resolves even without an ambient
+        mirror. This method never raises.
 
         Args:
             skill_key: Full skill key (e.g. "beagle-python:review-python").
             args: Optional arguments string.
 
         Returns:
-            Formatted skill invocation string.
+            Formatted skill invocation string (``/skill:<slug>`` plus args).
 
         """
-        skill_dir = _resolve_skill_dir(skill_key)
-        if skill_dir is not None:
-            base = (
-                f"Read `{skill_dir}/SKILL.md` and follow it as your review "
-                f"methodology. Read its companion files as it directs."
-            )
-        else:
-            base = f"Follow the `{skill_key}` skill methodology."
+        base = f"/skill:{_skill_slug(skill_key)}"
         if args:
             base = f"{base} {args}"
         return base

--- a/daydream/backends/pi.py
+++ b/daydream/backends/pi.py
@@ -192,10 +192,17 @@ def _skill_slug(skill_key: str) -> str:
 def _resolve_skill_dir(skill_key: str) -> Path | None:
     """Best-effort resolution of a Beagle skill key to its on-disk directory.
 
-    Searches the standard plugin locations for a directory whose slug
-    matches ``skill_key`` and contains a ``SKILL.md``. Returns ``None``
-    when unresolved; the caller degrades gracefully and this function
-    never raises.
+    Searches, in priority order, for a directory whose slug matches
+    ``skill_key`` and contains a ``SKILL.md``:
+
+    1. ``$DAYDREAM_SKILLS_DIR`` — the configurable override; when set it is
+       searched first so it wins over the built-in locations.
+    2. ``~/.agents/skills`` — the primary default location.
+    3. ``~/.claude/skills`` — the legacy Claude Code plugin mirror.
+    4. the project-local ``.agents/skills`` then ``.claude/skills`` mirrors.
+
+    Returns ``None`` when unresolved; the caller degrades gracefully and this
+    function never raises.
 
     Note: this is a parallel skill-location mechanism —
     :func:`daydream.deep.orchestrator.get_installed_skills` answers the
@@ -205,15 +212,18 @@ def _resolve_skill_dir(skill_key: str) -> Path | None:
     """
     slug = _skill_slug(skill_key)
     home = Path.home()
-    search_roots: list[Path] = [
-        home / ".claude" / "skills",
-        home / ".agents" / "skills",
-        Path.cwd() / ".claude" / "skills",
-        Path.cwd() / ".agents" / "skills",
-    ]
+    search_roots: list[Path] = []
     extra = os.environ.get("DAYDREAM_SKILLS_DIR")
     if extra:
         search_roots.append(Path(extra))
+    search_roots.extend(
+        [
+            home / ".agents" / "skills",
+            home / ".claude" / "skills",
+            Path.cwd() / ".agents" / "skills",
+            Path.cwd() / ".claude" / "skills",
+        ]
+    )
     for root in search_roots:
         candidate = root / slug
         if (candidate / "SKILL.md").is_file():

--- a/daydream/backends/pi.py
+++ b/daydream/backends/pi.py
@@ -73,8 +73,12 @@ _PI_READ_ONLY_TOOLS = "read,find,ls,grep"
 
 # Matches Pi's native ``/skill:<slug>`` command embedded in a prompt (emitted by
 # ``format_skill_invocation``). Used in ``execute`` to register the referenced
-# skill directories with the subprocess via ``--skill`` flags.
-_SKILL_TOKEN_RE = re.compile(r"/skill:([\w-]+)")
+# skill directories with the subprocess via ``--skill`` flags. The character
+# class mirrors Pi's documented skill-name grammar (lowercase a-z, 0-9, hyphens
+# only; see pi docs/skills.md "Name Rules"): uppercase and underscore are
+# excluded because no valid Pi slug uses them, so the wider ``\w`` class would
+# otherwise admit tokens that can never resolve to a real skill.
+_SKILL_TOKEN_RE = re.compile(r"/skill:([a-z0-9-]+)")
 
 # Pi CLI ships only a minimal built-in system prompt. Claude Code and Codex
 # inject rich guidance (tool efficiency, exploration strategy, conciseness) at

--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -20,7 +20,6 @@ import re
 from pathlib import Path
 from typing import Any
 
-from daydream.config import STRUCTURE_SKILL
 from daydream.phases import (
     RECOMMENDATION_VERDICTS_SCHEMA,
     _confidence_and_convention_instructions,
@@ -249,6 +248,7 @@ def build_per_stack_prompt(
 
 def build_structural_prompt(
     *,
+    skill_invocation: str,
     files: list[str],
     diff_path: Path,
     intent_path: Path,
@@ -266,6 +266,10 @@ def build_structural_prompt(
     instead of being scoped to a stack subset.
 
     Args:
+        skill_invocation: Backend-formatted invocation for the structural skill
+            (Issue #207). The caller routes ``STRUCTURE_SKILL`` through
+            ``backend.format_skill_invocation`` so Pi emits ``/skill:<slug>``
+            rather than a raw Beagle key.
         files: Full union of changed files across every stack. Used to anchor
             the scope statement; the reviewer is still free to read beyond.
         diff_path: Path to the full diff on disk.
@@ -300,7 +304,7 @@ def build_structural_prompt(
         f"do NOT run `git diff` without a base ref -- on a clean branch that "
         f"returns empty and hides committed changes."
     )
-    parts.append(f"/{STRUCTURE_SKILL}")
+    parts.append(skill_invocation)
     parts.append(f"Write your full review to {output_path}.")
     return "\n\n".join(parts)
 

--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -266,10 +266,7 @@ def build_structural_prompt(
     instead of being scoped to a stack subset.
 
     Args:
-        skill_invocation: Backend-formatted invocation for the structural skill
-            (Issue #207). The caller routes ``STRUCTURE_SKILL`` through
-            ``backend.format_skill_invocation`` so Pi emits ``/skill:<slug>``
-            rather than a raw Beagle key.
+        skill_invocation: Backend-formatted invocation for the structural skill.
         files: Full union of changed files across every stack. Used to anchor
             the scope statement; the reviewer is still free to read beyond.
         diff_path: Path to the full diff on disk.

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -2760,9 +2760,9 @@ async def phase_per_stack_reviews(
             if stack.stack_name == STRUCTURE_STACK_NAME:
                 # Structural prompt is NOT inlined — its lens legitimately roams
                 # beyond the diff, so it keeps its diff_path pointer and its
-                # repo-wide Read/Grep/Bash freedom. The structural skill key is
-                # routed through the backend formatter (Issue #207) so Pi emits
-                # its native /skill:<slug> command instead of a raw Beagle key.
+                # repo-wide Read/Grep/Bash freedom. The skill key is routed
+                # through the backend formatter so each backend emits its own
+                # invocation syntax.
                 structural_invocation = backend.format_skill_invocation(
                     stack.skill_invocation or STRUCTURE_SKILL
                 )
@@ -2799,9 +2799,7 @@ async def phase_per_stack_reviews(
                     )
                 else:
                     # Route the raw Beagle stack key through the backend
-                    # formatter (Issue #207) so each backend emits its own
-                    # invocation syntax (Pi: /skill:<slug>) instead of the raw
-                    # key leaking into the prompt.
+                    # formatter so each backend emits its own invocation syntax.
                     prompt = _prompts.build_per_stack_prompt(
                         skill_invocation=backend.format_skill_invocation(stack.skill_invocation),
                         stack_name=stack.stack_name,

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -2741,7 +2741,7 @@ async def phase_per_stack_reviews(
             dropped.
 
     """
-    from daydream.config import STRUCTURE_STACK_NAME
+    from daydream.config import STRUCTURE_SKILL, STRUCTURE_STACK_NAME
     from daydream.deep import prompts as _prompts
     from daydream.deep.artifacts import deep_dir as _deep_dir
     from daydream.deep.artifacts import per_stack_review_path
@@ -2760,8 +2760,14 @@ async def phase_per_stack_reviews(
             if stack.stack_name == STRUCTURE_STACK_NAME:
                 # Structural prompt is NOT inlined — its lens legitimately roams
                 # beyond the diff, so it keeps its diff_path pointer and its
-                # repo-wide Read/Grep/Bash freedom.
+                # repo-wide Read/Grep/Bash freedom. The structural skill key is
+                # routed through the backend formatter (Issue #207) so Pi emits
+                # its native /skill:<slug> command instead of a raw Beagle key.
+                structural_invocation = backend.format_skill_invocation(
+                    stack.skill_invocation or STRUCTURE_SKILL
+                )
                 prompt = _prompts.build_structural_prompt(
+                    skill_invocation=structural_invocation,
                     files=stack.files,
                     diff_path=diff_path,
                     intent_path=intent_path,
@@ -2792,8 +2798,12 @@ async def phase_per_stack_reviews(
                         inline_diff=inline_diff,
                     )
                 else:
+                    # Route the raw Beagle stack key through the backend
+                    # formatter (Issue #207) so each backend emits its own
+                    # invocation syntax (Pi: /skill:<slug>) instead of the raw
+                    # key leaking into the prompt.
                     prompt = _prompts.build_per_stack_prompt(
-                        skill_invocation=stack.skill_invocation,
+                        skill_invocation=backend.format_skill_invocation(stack.skill_invocation),
                         stack_name=stack.stack_name,
                         files=stack.files,
                         diff_path=diff_path,

--- a/tests/test_backend_pi.py
+++ b/tests/test_backend_pi.py
@@ -592,24 +592,76 @@ def test_resolve_skill_dir_finds_slug(tmp_path, monkeypatch):
     assert resolved == skill_dir
 
 
-def test_format_skill_invocation_unresolved_returns_hint():
+def test_format_skill_invocation_emits_native_command():
+    # Issue #207: Pi formats a Beagle key as its native /skill:<slug> command,
+    # stripping the plugin prefix. The raw key never appears.
     backend = PiBackend(model="glm-5.2")
-    # Force unresolved path.
-    with patch("daydream.backends.pi._resolve_skill_dir", return_value=None):
-        result = backend.format_skill_invocation("beagle-python:review-python", "--pr 7")
-    assert "beagle-python:review-python" in result
-    assert "--pr 7" in result
+    result = backend.format_skill_invocation("beagle-python:review-python")
+    assert result == "/skill:review-python"
+    assert "beagle-python" not in result
 
 
-def test_format_skill_invocation_resolved_uses_path_ref(tmp_path):
+def test_format_skill_invocation_preserves_args():
     backend = PiBackend(model="glm-5.2")
-    skill_dir = tmp_path / "review-python"
-    skill_dir.mkdir()
-    (skill_dir / "SKILL.md").write_text("# x\n")
-    with patch("daydream.backends.pi._resolve_skill_dir", return_value=skill_dir):
-        result = backend.format_skill_invocation("beagle-python:review-python")
-    assert f"{skill_dir}/SKILL.md`" in result
-    assert "methodology" in result
+    result = backend.format_skill_invocation("beagle-core:review-structure", "--pr 7")
+    assert result == "/skill:review-structure --pr 7"
+
+
+def test_format_skill_invocation_bare_slug_unchanged():
+    backend = PiBackend(model="glm-5.2")
+    assert backend.format_skill_invocation("review-go") == "/skill:review-go"
+
+
+@pytest.mark.asyncio
+async def test_execute_registers_resolved_skills_with_skill_flag(tmp_path, monkeypatch):
+    # Issue #207: /skill:<slug> tokens in the prompt are registered with the
+    # subprocess via repeatable --skill <dir> flags (de-duplicated, best-effort).
+    skills_root = tmp_path / "skills"
+    py_dir = skills_root / "review-python"
+    py_dir.mkdir(parents=True)
+    (py_dir / "SKILL.md").write_text("# review-python\n")
+    monkeypatch.setattr("daydream.backends.pi.Path.home", lambda: tmp_path)
+    monkeypatch.setenv("DAYDREAM_SKILLS_DIR", str(skills_root))
+    monkeypatch.chdir(tmp_path)
+
+    backend = PiBackend(model="glm-5.2")
+    mock_proc = make_mock_process(['{"id": "s1"}'])
+    # Two references to the same resolvable skill + one unresolvable -> exactly
+    # one --skill entry, pointing at the resolved dir.
+    prompt = "Review this.\n\n/skill:review-python\n/skill:review-python\n/skill:review-go"
+
+    with patch(
+        "daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc
+    ) as mock_exec:
+        async for _ in backend.execute(Path("/tmp"), prompt):
+            pass
+
+    flat_args = list(mock_exec.call_args.args)
+    skill_indices = [i for i, a in enumerate(flat_args) if a == "--skill"]
+    assert len(skill_indices) == 1, f"expected one --skill flag, got args: {flat_args}"
+    assert flat_args[skill_indices[0] + 1] == str(py_dir)
+    # The --skill flag precedes the positional prompt (last arg).
+    assert skill_indices[0] < len(flat_args) - 1
+
+
+@pytest.mark.asyncio
+async def test_execute_no_skill_flag_when_unresolvable(tmp_path, monkeypatch):
+    # Best-effort: an unresolvable /skill:<slug> never adds a --skill flag and
+    # never crashes the run (pi may still auto-discover it).
+    monkeypatch.setattr("daydream.backends.pi.Path.home", lambda: tmp_path)
+    monkeypatch.setenv("DAYDREAM_SKILLS_DIR", str(tmp_path / "nope"))
+    monkeypatch.chdir(tmp_path)
+
+    backend = PiBackend(model="glm-5.2")
+    mock_proc = make_mock_process(['{"id": "s1"}'])
+
+    with patch(
+        "daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc
+    ) as mock_exec:
+        async for _ in backend.execute(Path("/tmp"), "Review.\n\n/skill:review-rust"):
+            pass
+
+    assert "--skill" not in list(mock_exec.call_args.args)
 
 
 def test_create_backend_pi_returns_pi_backend_with_default_model():

--- a/tests/test_backend_pi.py
+++ b/tests/test_backend_pi.py
@@ -594,8 +594,6 @@ def test_resolve_skill_dir_finds_slug(tmp_path, monkeypatch):
 
 
 def test_format_skill_invocation_emits_native_command():
-    # Issue #207: Pi formats a Beagle key as its native /skill:<slug> command,
-    # stripping the plugin prefix. The raw key never appears.
     backend = PiBackend(model="glm-5.2")
     result = backend.format_skill_invocation("beagle-python:review-python")
     assert result == "/skill:review-python"
@@ -614,13 +612,7 @@ def test_format_skill_invocation_bare_slug_unchanged():
 
 
 def test_skill_token_re_grammar_matches_pi_name_rules():
-    # Pi's documented skill-name grammar (pi docs/skills.md "Name Rules") is
-    # lowercase a-z, 0-9, hyphens only. Every real slug (review-python,
-    # review-frontend, review-go, review-rust, review-elixir, review-ios,
-    # review-structure) matches; uppercase/underscore must NOT match because no
-    # valid Pi slug uses them (e.g. "PDF-Processing" is explicitly invalid).
-    # Without this guard a regression to the wider w class would silently
-    # admit tokens that can never resolve to a real skill.
+    # Pi skill names are lowercase letters, digits, and hyphens.
     admitted = ["review-python", "review-frontend", "review-go", "2-thing", "a"]
     rejected = ["Review_Python", "PDF-Processing", "foo_bar", "CamelCase"]
     for slug in admitted:
@@ -633,14 +625,7 @@ def test_skill_token_re_grammar_matches_pi_name_rules():
 
 @pytest.mark.asyncio
 async def test_format_skill_invocation_token_is_consumed_by_execute(tmp_path, monkeypatch):
-    # Pairing guard: the token emitted by ``format_skill_invocation`` (producer)
-    # must be recognized by ``execute``'s ``_SKILL_TOKEN_RE`` scanner (consumer)
-    # so it is registered as a ``--skill`` flag. The producer and consumer are
-    # otherwise coupled only by the literal ``"/skill:"`` prefix; without this
-    # test a one-sided edit to either side would silently drop the ``--skill``
-    # flag while every isolated unit test stayed green. The prompt is built FROM
-    # the producer (not a hardcoded literal) so this asserts the contract, not a
-    # specific string.
+    # The formatted token must be recognized by execute's scanner and registered.
     skills_root = tmp_path / "skills"
     py_dir = skills_root / "review-python"
     py_dir.mkdir(parents=True)
@@ -670,8 +655,6 @@ async def test_format_skill_invocation_token_is_consumed_by_execute(tmp_path, mo
 
 @pytest.mark.asyncio
 async def test_execute_registers_resolved_skills_with_skill_flag(tmp_path, monkeypatch):
-    # Issue #207: /skill:<slug> tokens in the prompt are registered with the
-    # subprocess via repeatable --skill <dir> flags (de-duplicated, best-effort).
     skills_root = tmp_path / "skills"
     py_dir = skills_root / "review-python"
     py_dir.mkdir(parents=True)
@@ -682,8 +665,7 @@ async def test_execute_registers_resolved_skills_with_skill_flag(tmp_path, monke
 
     backend = PiBackend(model="glm-5.2")
     mock_proc = make_mock_process(['{"id": "s1"}'])
-    # Two references to the same resolvable skill + one unresolvable -> exactly
-    # one --skill entry, pointing at the resolved dir.
+    # Duplicate references are de-duplicated; unresolved skills are skipped.
     prompt = "Review this.\n\n/skill:review-python\n/skill:review-python\n/skill:review-go"
 
     with patch(
@@ -702,8 +684,7 @@ async def test_execute_registers_resolved_skills_with_skill_flag(tmp_path, monke
 
 @pytest.mark.asyncio
 async def test_execute_no_skill_flag_when_unresolvable(tmp_path, monkeypatch):
-    # Best-effort: an unresolvable /skill:<slug> never adds a --skill flag and
-    # never crashes the run (pi may still auto-discover it).
+    # Unresolvable skills do not add flags or fail the run.
     monkeypatch.setattr("daydream.backends.pi.Path.home", lambda: tmp_path)
     monkeypatch.setenv("DAYDREAM_SKILLS_DIR", str(tmp_path / "nope"))
     monkeypatch.chdir(tmp_path)

--- a/tests/test_backend_pi.py
+++ b/tests/test_backend_pi.py
@@ -613,6 +613,43 @@ def test_format_skill_invocation_bare_slug_unchanged():
 
 
 @pytest.mark.asyncio
+async def test_format_skill_invocation_token_is_consumed_by_execute(tmp_path, monkeypatch):
+    # Pairing guard: the token emitted by ``format_skill_invocation`` (producer)
+    # must be recognized by ``execute``'s ``_SKILL_TOKEN_RE`` scanner (consumer)
+    # so it is registered as a ``--skill`` flag. The producer and consumer are
+    # otherwise coupled only by the literal ``"/skill:"`` prefix; without this
+    # test a one-sided edit to either side would silently drop the ``--skill``
+    # flag while every isolated unit test stayed green. The prompt is built FROM
+    # the producer (not a hardcoded literal) so this asserts the contract, not a
+    # specific string.
+    skills_root = tmp_path / "skills"
+    py_dir = skills_root / "review-python"
+    py_dir.mkdir(parents=True)
+    (py_dir / "SKILL.md").write_text("# review-python\n")
+    monkeypatch.setattr("daydream.backends.pi.Path.home", lambda: tmp_path)
+    monkeypatch.setenv("DAYDREAM_SKILLS_DIR", str(skills_root))
+    monkeypatch.chdir(tmp_path)
+
+    backend = PiBackend(model="glm-5.2")
+    prompt = f"Review this.\n\n{backend.format_skill_invocation('beagle-python:review-python')}"
+
+    mock_proc = make_mock_process(['{"id": "s1"}'])
+    with patch(
+        "daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc
+    ) as mock_exec:
+        async for _ in backend.execute(Path("/tmp"), prompt):
+            pass
+
+    flat_args = list(mock_exec.call_args.args)
+    skill_indices = [i for i, a in enumerate(flat_args) if a == "--skill"]
+    assert len(skill_indices) == 1, (
+        f"producer/consumer pairing broken: token from format_skill_invocation "
+        f"was not scanned by execute; args: {flat_args}"
+    )
+    assert flat_args[skill_indices[0] + 1] == str(py_dir)
+
+
+@pytest.mark.asyncio
 async def test_execute_registers_resolved_skills_with_skill_flag(tmp_path, monkeypatch):
     # Issue #207: /skill:<slug> tokens in the prompt are registered with the
     # subprocess via repeatable --skill <dir> flags (de-duplicated, best-effort).

--- a/tests/test_backend_pi.py
+++ b/tests/test_backend_pi.py
@@ -30,6 +30,7 @@ from daydream.backends import (
 )
 from daydream.backends.pi import (
     _PI_STDOUT_LIMIT_BYTES,
+    _SKILL_TOKEN_RE,
     PiBackend,
     PiError,
     _render_tool_result,
@@ -610,6 +611,24 @@ def test_format_skill_invocation_preserves_args():
 def test_format_skill_invocation_bare_slug_unchanged():
     backend = PiBackend(model="glm-5.2")
     assert backend.format_skill_invocation("review-go") == "/skill:review-go"
+
+
+def test_skill_token_re_grammar_matches_pi_name_rules():
+    # Pi's documented skill-name grammar (pi docs/skills.md "Name Rules") is
+    # lowercase a-z, 0-9, hyphens only. Every real slug (review-python,
+    # review-frontend, review-go, review-rust, review-elixir, review-ios,
+    # review-structure) matches; uppercase/underscore must NOT match because no
+    # valid Pi slug uses them (e.g. "PDF-Processing" is explicitly invalid).
+    # Without this guard a regression to the wider w class would silently
+    # admit tokens that can never resolve to a real skill.
+    admitted = ["review-python", "review-frontend", "review-go", "2-thing", "a"]
+    rejected = ["Review_Python", "PDF-Processing", "foo_bar", "CamelCase"]
+    for slug in admitted:
+        assert _SKILL_TOKEN_RE.findall(f"/skill:{slug}") == [slug], slug
+    for slug in rejected:
+        # No token (or a truncated one ending before the disallowed char) is
+        # captured as a *complete* match of the invalid slug.
+        assert slug not in _SKILL_TOKEN_RE.findall(f"/skill:{slug}"), slug
 
 
 @pytest.mark.asyncio

--- a/tests/test_backend_pi.py
+++ b/tests/test_backend_pi.py
@@ -593,6 +593,36 @@ def test_resolve_skill_dir_finds_slug(tmp_path, monkeypatch):
     assert resolved == skill_dir
 
 
+def _install_skill(root: Path, slug: str) -> Path:
+    skill_dir = root / slug
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(f"# {slug}\n")
+    return skill_dir
+
+
+def test_resolve_skill_dir_prefers_agents_over_claude(tmp_path, monkeypatch):
+    # When the same slug exists in both ~/.agents/skills and ~/.claude/skills,
+    # the ~/.agents copy wins -- it is the primary default location.
+    agents_dir = _install_skill(tmp_path / ".agents" / "skills", "review-python")
+    _install_skill(tmp_path / ".claude" / "skills", "review-python")
+    monkeypatch.setattr("daydream.backends.pi.Path.home", lambda: tmp_path)
+    monkeypatch.delenv("DAYDREAM_SKILLS_DIR", raising=False)
+    monkeypatch.chdir(tmp_path)
+    assert _resolve_skill_dir("beagle-python:review-python") == agents_dir
+
+
+def test_resolve_skill_dir_env_override_wins(tmp_path, monkeypatch):
+    # DAYDREAM_SKILLS_DIR is searched first: the override outranks the same
+    # slug installed in a standard location.
+    _install_skill(tmp_path / ".agents" / "skills", "review-python")
+    override_root = tmp_path / "custom"
+    override_dir = _install_skill(override_root, "review-python")
+    monkeypatch.setattr("daydream.backends.pi.Path.home", lambda: tmp_path)
+    monkeypatch.setenv("DAYDREAM_SKILLS_DIR", str(override_root))
+    monkeypatch.chdir(tmp_path)
+    assert _resolve_skill_dir("beagle-python:review-python") == override_dir
+
+
 def test_format_skill_invocation_emits_native_command():
     backend = PiBackend(model="glm-5.2")
     result = backend.format_skill_invocation("beagle-python:review-python")

--- a/tests/test_deep_fanout.py
+++ b/tests/test_deep_fanout.py
@@ -45,13 +45,13 @@ def _mk_stacks() -> list[StackAssignment]:
     return [
         StackAssignment(
             stack_name="python",
-            skill_invocation="/beagle-python:review-python",
+            skill_invocation="beagle-python:review-python",
             files=["api.py"],
             is_docs_only=False,
         ),
         StackAssignment(
             stack_name="react",
-            skill_invocation="/beagle-react:review-frontend",
+            skill_invocation="beagle-react:review-frontend",
             files=["App.tsx"],
             is_docs_only=False,
         ),
@@ -180,7 +180,7 @@ async def test_phase_per_stack_reviews_uses_structural_prompt_for_structure_stac
     stacks = [
         StackAssignment(
             stack_name="python",
-            skill_invocation="/beagle-python:review-python",
+            skill_invocation="beagle-python:review-python",
             files=["a.py"],
             is_docs_only=False,
         ),
@@ -204,7 +204,9 @@ async def test_phase_per_stack_reviews_uses_structural_prompt_for_structure_stac
     assert len(structural_calls) == 1
     assert len(per_stack_calls) == 1
     assert structural_calls[0]["files"] == ["a.py"]
-    assert "skill_invocation" not in structural_calls[0]
+    # Issue #207: the structural skill key is routed through the backend
+    # formatter, so the structural prompt now carries a formatted invocation.
+    assert structural_calls[0]["skill_invocation"] == f"/{STRUCTURE_SKILL}"
     assert "stack_name" not in structural_calls[0]
     assert per_stack_calls[0]["stack_name"] == "python"
 
@@ -248,3 +250,122 @@ async def test_fan_out_continues_after_one_failure(tmp_path: Path, make_work) ->
     # Failure surfaces in the returned failures dict with the exception reason.
     assert "react" in failures
     assert "simulated react failure" in failures["react"]
+
+
+class _PiShapeBackend(_RecordingBackend):
+    """Mock backend that delegates skill formatting to the real PiBackend.
+
+    Proves Issue #207 end-to-end through the production ``phase_per_stack_reviews``
+    path: the per-stack / structural prompt builders receive whatever the real
+    ``PiBackend.format_skill_invocation`` returns (``/skill:<slug>``), not a raw
+    Beagle key. Only ``execute`` is mocked (no subprocess); the formatter is real.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        from daydream.backends.pi import PiBackend
+
+        self._pi = PiBackend(model="glm-5.2")
+
+    def format_skill_invocation(self, skill_key: str, args: str = "") -> str:
+        return self._pi.format_skill_invocation(skill_key, args)
+
+
+async def test_per_stack_prompts_use_pi_native_skill_command(
+    tmp_path: Path, make_work
+) -> None:
+    """Issue #207: every stack with a skill emits Pi's native /skill:<slug>.
+
+    Drives the production fan-out phase with raw Beagle keys (as detect_stacks
+    produces them) and a backend whose formatter is the real PiBackend. Asserts
+    the dispatched prompts carry /skill:<slug> for python, frontend, go, rust,
+    elixir, and structure -- and never the raw beagle-*: keys -- while the
+    generic fallback stack injects no skill token.
+    """
+    from daydream.config import STRUCTURE_SKILL, STRUCTURE_STACK_NAME
+
+    backend = _PiShapeBackend()
+    diff, intent, alts = _mk_context_files(tmp_path)
+
+    stacks = [
+        StackAssignment(
+            stack_name="python",
+            skill_invocation="beagle-python:review-python",
+            files=["api.py"],
+            is_docs_only=False,
+        ),
+        StackAssignment(
+            stack_name="react",
+            skill_invocation="beagle-react:review-frontend",
+            files=["App.tsx"],
+            is_docs_only=False,
+        ),
+        StackAssignment(
+            stack_name="go",
+            skill_invocation="beagle-go:review-go",
+            files=["main.go"],
+            is_docs_only=False,
+        ),
+        StackAssignment(
+            stack_name="rust",
+            skill_invocation="beagle-rust:review-rust",
+            files=["lib.rs"],
+            is_docs_only=False,
+        ),
+        StackAssignment(
+            stack_name="elixir",
+            skill_invocation="beagle-elixir:review-elixir",
+            files=["app.ex"],
+            is_docs_only=False,
+        ),
+        StackAssignment(
+            stack_name="generic",
+            skill_invocation=None,
+            files=["notes.txt"],
+            is_docs_only=False,
+        ),
+        StackAssignment(
+            stack_name=STRUCTURE_STACK_NAME,
+            skill_invocation=STRUCTURE_SKILL,
+            files=["api.py", "App.tsx"],
+            is_docs_only=False,
+        ),
+    ]
+
+    results, failures = await phase_per_stack_reviews(
+        backend,
+        make_work(tmp_path),
+        stacks,
+        diff_path=diff,
+        intent_path=intent,
+        alternatives_path=alts,
+    )
+
+    assert failures == {}
+    assert len(backend.prompts) == 7
+    joined = "\n\n".join(backend.prompts)
+
+    for token in (
+        "/skill:review-python",
+        "/skill:review-frontend",
+        "/skill:review-go",
+        "/skill:review-rust",
+        "/skill:review-elixir",
+        "/skill:review-structure",
+    ):
+        assert token in joined, f"missing {token} in dispatched prompts"
+
+    # No raw Beagle key may leak into any prompt.
+    for raw in (
+        "beagle-python:review-python",
+        "beagle-react:review-frontend",
+        "beagle-go:review-go",
+        "beagle-rust:review-rust",
+        "beagle-elixir:review-elixir",
+        "beagle-core:review-structure",
+    ):
+        assert raw not in joined, f"raw key {raw} leaked into a prompt"
+
+    # Generic fallback stack injects no skill command at all.
+    generic_prompt = next(p for p in backend.prompts if "generic-fallback" in p)
+    assert "/skill:" not in generic_prompt

--- a/tests/test_deep_fanout.py
+++ b/tests/test_deep_fanout.py
@@ -204,8 +204,6 @@ async def test_phase_per_stack_reviews_uses_structural_prompt_for_structure_stac
     assert len(structural_calls) == 1
     assert len(per_stack_calls) == 1
     assert structural_calls[0]["files"] == ["a.py"]
-    # Issue #207: the structural skill key is routed through the backend
-    # formatter, so the structural prompt now carries a formatted invocation.
     assert structural_calls[0]["skill_invocation"] == f"/{STRUCTURE_SKILL}"
     assert "stack_name" not in structural_calls[0]
     assert per_stack_calls[0]["stack_name"] == "python"
@@ -253,13 +251,7 @@ async def test_fan_out_continues_after_one_failure(tmp_path: Path, make_work) ->
 
 
 class _PiShapeBackend(_RecordingBackend):
-    """Mock backend that delegates skill formatting to the real PiBackend.
-
-    Proves Issue #207 end-to-end through the production ``phase_per_stack_reviews``
-    path: the per-stack / structural prompt builders receive whatever the real
-    ``PiBackend.format_skill_invocation`` returns (``/skill:<slug>``), not a raw
-    Beagle key. Only ``execute`` is mocked (no subprocess); the formatter is real.
-    """
+    """Mock backend that uses PiBackend's real skill formatter."""
 
     def __init__(self) -> None:
         super().__init__()
@@ -274,14 +266,7 @@ class _PiShapeBackend(_RecordingBackend):
 async def test_per_stack_prompts_use_pi_native_skill_command(
     tmp_path: Path, make_work
 ) -> None:
-    """Issue #207: every stack with a skill emits Pi's native /skill:<slug>.
-
-    Drives the production fan-out phase with raw Beagle keys (as detect_stacks
-    produces them) and a backend whose formatter is the real PiBackend. Asserts
-    the dispatched prompts carry /skill:<slug> for python, frontend, go, rust,
-    elixir, and structure -- and never the raw beagle-*: keys -- while the
-    generic fallback stack injects no skill token.
-    """
+    """Every stack with a skill emits Pi's native /skill:<slug>."""
     from daydream.config import STRUCTURE_SKILL, STRUCTURE_STACK_NAME
 
     backend = _PiShapeBackend()

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -311,6 +311,7 @@ def test_build_structural_prompt_has_no_stack_scope_restriction(tmp_path: Path) 
     from daydream.deep.prompts import build_structural_prompt
 
     prompt = build_structural_prompt(
+        skill_invocation=f"/{STRUCTURE_SKILL}",
         files=["api/main.py", "ui/App.tsx"],
         diff_path=tmp_path / "diff.patch",
         intent_path=tmp_path / "intent.md",
@@ -328,6 +329,7 @@ def test_build_structural_prompt_omits_exploration_pointer(tmp_path: Path) -> No
     from daydream.deep.prompts import build_structural_prompt
 
     prompt = build_structural_prompt(
+        skill_invocation="/beagle-core:review-structure",
         files=["main.py"],
         diff_path=tmp_path / "diff.patch",
         intent_path=tmp_path / "intent.md",
@@ -491,6 +493,7 @@ def test_structural_prompt_keeps_diff_pointer_and_read_freedom(tmp_path: Path) -
 
     p = _paths(tmp_path)
     out = build_structural_prompt(
+        skill_invocation="/beagle-core:review-structure",
         files=["api.py"],
         **p,
     )


### PR DESCRIPTION
## Summary

- Route Pi deep-review skill invocations through native `/skill:<slug>` commands.
- Register resolvable Pi skill commands as repeatable `--skill <dir>` CLI flags before execution.
- Add real-path and backend tests covering Pi per-stack prompt formatting and skill registration.

## Motivation

Closes #207.

Pi deep mode previously inherited Beagle-style skill keys such as `beagle-python:review-python` in review prompts. Pi expects native slash commands and separately registered skill directories, so the raw keys could not invoke the intended review skills.

## Changes

### Changed
- Added Pi skill slug normalization and native `/skill:<slug>` formatting.
- Registered resolvable `/skill:<slug>` tokens with Pi via `--skill` flags during execution.
- Updated deep per-stack and structural prompt builders to use backend-formatted skill invocations.
- Tightened the Pi skill token regex to match Pi's lowercase/hyphenated skill-name grammar.

### Fixed
- Prevented raw `beagle-*:` skill keys from leaking into Pi deep-review prompts.

## Test Plan

- [x] `uv run pytest tests/test_backend_pi.py tests/test_deep_fanout.py tests/test_deep_prompts.py tests/test_deep_integration.py -q` — `79 passed, 1 skipped`
- [x] `make check` — `1752 passed, 3 skipped, 3 warnings`
- [x] Daydream pre-PR review with Pi backend — completed and pushed follow-up fixes
- [x] Pre-push hook after artifact cleanup — ruff passed, mypy passed, full suite `1733 passed, 3 skipped, 3 warnings`

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check`)
- [x] Type checking passes (`uv run mypy daydream`)
- [x] Documentation updated (if applicable)
