### PR TITLE
fix(backends/pi): retry transient 429 and OOM failures

### DIFF
--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import inspect
+import os
 import random
 import re
 from collections.abc import AsyncGenerator, Callable
@@ -28,7 +29,6 @@ from daydream.backends import (
     ToolResultEvent,
     ToolStartEvent,
 )
-from daydream.backends.pi import _pi_retry_attempts, _pi_retry_base_delay
 from daydream.config import UNKNOWN_SKILL_PATTERN
 from daydream.json_utils import extract_json
 from daydream.trajectory import DaydreamPhase, get_current_recorder
@@ -466,8 +466,10 @@ async def run_agent(
         # with-shape uniform otherwise (CORE-09 no-op). D-19: no ATIF construction
         # here — only inv.observe()/inv.observe_user_step() against the recorder.
         recorder = get_current_recorder()
-        max_attempts = _pi_retry_attempts()
-        base_delay = _pi_retry_base_delay()
+        _default_attempts = int(os.environ.get("DAYDREAM_PI_RETRY_ATTEMPTS", "3"))
+        _default_delay = float(os.environ.get("DAYDREAM_PI_RETRY_BASE_DELAY_S", "2.0"))
+        max_attempts = getattr(backend, "retry_attempts", _default_attempts)
+        base_delay = getattr(backend, "retry_base_delay_s", _default_delay)
 
         for attempt in range(max_attempts + 1):
             # Reset accumulated state so a failed attempt's partial output
@@ -653,20 +655,28 @@ async def run_agent(
             except Exception as exc:
                 if attempt < max_attempts and getattr(exc, "retryable", False):
                     delay = base_delay * (2 ** attempt) + random.uniform(0, 1)
-                    print_warning(
-                        console,
+                    retry_msg = (
                         f"Backend error ({type(exc).__name__}), retrying "
-                        f"attempt {attempt + 2}/{max_attempts + 1} after {delay:.1f}s...",
+                        f"attempt {attempt + 2}/{max_attempts + 1} after {delay:.1f}s..."
                     )
+                    if use_callback and progress_callback is not None:
+                        result = progress_callback(format_callback_text(f"[retry] {retry_msg}"))
+                        if inspect.isawaitable(result):
+                            await result
+                    elif not use_callback:
+                        print_warning(console, retry_msg)
                     if event_iter is not None:
                         try:
                             await event_iter.aclose()
                         except Exception:  # noqa: BLE001
                             pass
-                    try:
-                        await backend.cancel()
-                    except Exception:  # noqa: BLE001
-                        pass
+                        event_iter = None
+                    # Do NOT call backend.cancel() here: the execute() generator's
+                    # finally block already terminates and removes the failed
+                    # invocation's process when event_iter.aclose() is called above.
+                    # Calling cancel() would terminate all processes on the shared
+                    # backend instance, killing sibling concurrent tasks under
+                    # fan-out (phases.py phase_per_stack_reviews).
                     await anyio.sleep(delay)
                     continue
                 raise

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import inspect
+import random
 import re
 from collections.abc import AsyncGenerator, Callable
 from contextlib import nullcontext
@@ -27,6 +28,7 @@ from daydream.backends import (
     ToolResultEvent,
     ToolStartEvent,
 )
+from daydream.backends.pi import _pi_retry_attempts, _pi_retry_base_delay
 from daydream.config import UNKNOWN_SKILL_PATTERN
 from daydream.json_utils import extract_json
 from daydream.trajectory import DaydreamPhase, get_current_recorder
@@ -460,185 +462,215 @@ async def run_agent(
         if not use_callback:
             agent_renderer = AgentTextRenderer(console)
 
-        try:
-            event_iter = cast(
-                AsyncGenerator[Any, None],
-                backend.execute(
-                    cwd, prompt, output_schema, continuation,
-                    agents=agents, max_turns=max_turns, read_only=read_only,
-                ),
-            )
-        except Exception as exc:
-            print_error(console, "Backend Init Error", f"{type(exc).__name__}: {exc}")
-            raise
-
         # Open Invocation scope when a recorder is active; nullcontext keeps the
         # with-shape uniform otherwise (CORE-09 no-op). D-19: no ATIF construction
         # here — only inv.observe()/inv.observe_user_step() against the recorder.
         recorder = get_current_recorder()
-        invocation_cm: Any = (
-            recorder.invocation(phase=phase) if recorder is not None else nullcontext(None)
-        )
+        max_attempts = _pi_retry_attempts()
+        base_delay = _pi_retry_base_delay()
 
-        async with invocation_cm as inv:
-            if inv is not None:
-                inv.observe_user_step(prompt=prompt)
-
-            # Per-invocation budgets live here so both backends are covered
-            # without a backend-signature change. The wall budget cancels the
-            # async-for via move_on_after; the tool-call ceiling breaks in-loop.
+        for attempt in range(max_attempts + 1):
+            # Reset accumulated state so a failed attempt's partial output
+            # does not leak into the next attempt's return value.
+            output_parts = []
+            structured_result = None
+            result_continuation = None
             tool_calls = 0
             budget_reason: str | None = None
-            wall_scope: Any = (
-                anyio.move_on_after(wall_budget_s) if wall_budget_s is not None else nullcontext()
-            )
 
-            with wall_scope:
-                async for event in event_iter:
-                    if isinstance(event, TextEvent):
-                        output_parts.append(event.text)
+            try:
+                event_iter = cast(
+                    AsyncGenerator[Any, None],
+                    backend.execute(
+                        cwd, prompt, output_schema, continuation,
+                        agents=agents, max_turns=max_turns, read_only=read_only,
+                    ),
+                )
+                invocation_cm: Any = (
+                    recorder.invocation(phase=phase) if recorder is not None else nullcontext(None)
+                )
 
-                        skill_match = re.search(UNKNOWN_SKILL_PATTERN, event.text)
-                        if skill_match:
-                            if not use_callback:
-                                agent_renderer.finish()
-                                tool_registry.finish_all()
-                            raise MissingSkillError(skill_match.group(1))
+                async with invocation_cm as inv:
+                    if inv is not None:
+                        inv.observe_user_step(prompt=prompt)
 
+                    # Per-invocation budgets live here so both backends are covered
+                    # without a backend-signature change. The wall budget cancels the
+                    # async-for via move_on_after; the tool-call ceiling breaks in-loop.
+                    wall_scope: Any = (
+                        anyio.move_on_after(wall_budget_s) if wall_budget_s is not None else nullcontext()
+                    )
+
+                    with wall_scope:
+                        async for event in event_iter:
+                            if isinstance(event, TextEvent):
+                                output_parts.append(event.text)
+
+                                skill_match = re.search(UNKNOWN_SKILL_PATTERN, event.text)
+                                if skill_match:
+                                    if not use_callback:
+                                        agent_renderer.finish()
+                                        tool_registry.finish_all()
+                                    raise MissingSkillError(skill_match.group(1))
+
+                                if use_callback and progress_callback is not None:
+                                    last_line = event.text.strip().split("\n")[-1]
+                                    if last_line:
+                                        result = progress_callback(format_callback_text(last_line))
+                                        if inspect.isawaitable(result):
+                                            await result
+                                elif output_schema is None:
+                                    # Structured-output text is the JSON payload, redundant with
+                                    # the returned structured result — don't echo it to the terminal.
+                                    agent_renderer.append(event.text)
+
+                                if inv is not None:
+                                    inv.observe(event)
+
+                            elif isinstance(event, ThinkingEvent):
+                                if not use_callback:
+                                    if agent_renderer.has_content:
+                                        agent_renderer.finish()
+                                    print_thinking(console, event.text)
+
+                                if inv is not None:
+                                    inv.observe(event)
+
+                            elif isinstance(event, ToolStartEvent):
+                                if progress_callback is not None:
+                                    # Record the originating call so a backgrounded launch's result
+                                    # can later resolve a Task-family label for the progress line.
+                                    tool_registry.note_call(event.id, event.name, event.input)
+                                    label = tool_registry.resolve_call_label(event.name, event.input)
+                                    result = progress_callback(format_callback_progress(event.name, event.input, label))
+                                    if inspect.isawaitable(result):
+                                        await result
+                                else:
+                                    if agent_renderer.has_content:
+                                        agent_renderer.finish()
+                                    tool_registry.create(event.id, event.name, event.input)
+
+                                if inv is not None:
+                                    inv.observe(event)
+
+                                tool_calls += 1
+                                if tool_call_budget is not None and tool_calls > tool_call_budget:
+                                    budget_reason = "tool_call_budget_exceeded"
+                                    break
+
+                            elif isinstance(event, ToolResultEvent):
+                                # Populate the task_id→label map in both modes, so a later
+                                # TaskOutput/TaskStop resolves its originating label.
+                                tool_registry.observe_result(event.id, event.output)
+                                if not use_callback:
+                                    panel = tool_registry.get(event.id)
+                                    if panel:
+                                        panel.set_result(event.output, event.is_error)
+                                        panel.finish()
+                                        tool_registry.remove(event.id)
+
+                                if inv is not None:
+                                    inv.observe(event)
+
+                            elif isinstance(event, MetricsEvent):
+                                # EVNT-02 / MAP-06: recorder-only, no UI. Must precede the
+                                # CostEvent branch so isinstance order is correct.
+                                if inv is not None:
+                                    inv.observe(event)
+
+                            elif isinstance(event, CostEvent):
+                                if event.cost_usd:
+                                    if not use_callback:
+                                        if agent_renderer.has_content:
+                                            agent_renderer.finish()
+                                        console.print()
+                                        print_cost(console, event.cost_usd)
+
+                                if inv is not None:
+                                    inv.observe(event)
+
+                            elif isinstance(event, ResultEvent):
+                                if event.structured_output is not None:
+                                    structured_result = event.structured_output
+                                    if not use_callback:
+                                        issues = (
+                                            structured_result.get("issues", [])
+                                            if isinstance(structured_result, dict)
+                                            else []
+                                        )
+                                        if issues:
+                                            formatted = []
+                                            for i in issues:
+                                                if "file" in i and "line" in i:
+                                                    desc = i.get("description", "")
+                                                    issue_id = i.get("id", "?")
+                                                    formatted.append(
+                                                        f"[{issue_id}] {i['file']}:{i['line']} - {desc}"
+                                                    )
+                                                else:
+                                                    label = i.get("title", i.get("description", ""))
+                                                    formatted.append(f"[{i.get('id', '?')}] {label}")
+                                            agent_renderer.append("\n".join(formatted))
+                                result_continuation = event.continuation
+
+                                if inv is not None:
+                                    inv.observe(event)
+
+                    # Budget abort: the wall scope cancelled the loop, or the tool-call
+                    # ceiling broke out. Cancel the backend (swallow any error — an abort
+                    # must NEVER raise into the CLI), mark the ATIF turn aborted, surface
+                    # a marker, then fall through to the partial-output return.
+                    wall_cancelled = bool(getattr(wall_scope, "cancelled_caught", False))
+                    if budget_reason is None and wall_cancelled:
+                        budget_reason = "wall_budget_exceeded"
+                    aborted_reason = budget_reason
+                    if budget_reason is not None:
+                        try:
+                            await event_iter.aclose()
+                        except Exception:  # noqa: BLE001 - abort must not raise into the CLI
+                            pass
+                        try:
+                            await backend.cancel()
+                        except Exception:  # noqa: BLE001 - abort must not raise into the CLI
+                            pass
+                        if inv is not None:
+                            inv.mark_aborted(budget_reason)
                         if use_callback and progress_callback is not None:
-                            last_line = event.text.strip().split("\n")[-1]
-                            if last_line:
-                                result = progress_callback(format_callback_text(last_line))
-                                if inspect.isawaitable(result):
-                                    await result
-                        elif output_schema is None:
-                            # Structured-output text is the JSON payload, redundant with
-                            # the returned structured result — don't echo it to the terminal.
-                            agent_renderer.append(event.text)
-
-                        if inv is not None:
-                            inv.observe(event)
-
-                    elif isinstance(event, ThinkingEvent):
-                        if not use_callback:
-                            if agent_renderer.has_content:
-                                agent_renderer.finish()
-                            print_thinking(console, event.text)
-
-                        if inv is not None:
-                            inv.observe(event)
-
-                    elif isinstance(event, ToolStartEvent):
-                        if progress_callback is not None:
-                            # Record the originating call so a backgrounded launch's result
-                            # can later resolve a Task-family label for the progress line.
-                            tool_registry.note_call(event.id, event.name, event.input)
-                            label = tool_registry.resolve_call_label(event.name, event.input)
-                            result = progress_callback(format_callback_progress(event.name, event.input, label))
+                            result = progress_callback(format_callback_text(f"[budget] aborted: {budget_reason}"))
                             if inspect.isawaitable(result):
                                 await result
-                        else:
-                            if agent_renderer.has_content:
-                                agent_renderer.finish()
-                            tool_registry.create(event.id, event.name, event.input)
+                        elif not use_callback:
+                            print_warning(console, f"Turn aborted: {budget_reason}")
 
-                        if inv is not None:
-                            inv.observe(event)
+                    if not use_callback:
+                        if agent_renderer.has_content:
+                            agent_renderer.finish()
+                        tool_registry.finish_all()
+                        console.print()
 
-                        tool_calls += 1
-                        if tool_call_budget is not None and tool_calls > tool_call_budget:
-                            budget_reason = "tool_call_budget_exceeded"
-                            break
+                break  # success — exit the retry loop
 
-                    elif isinstance(event, ToolResultEvent):
-                        # Populate the task_id→label map in both modes, so a later
-                        # TaskOutput/TaskStop resolves its originating label.
-                        tool_registry.observe_result(event.id, event.output)
-                        if not use_callback:
-                            panel = tool_registry.get(event.id)
-                            if panel:
-                                panel.set_result(event.output, event.is_error)
-                                panel.finish()
-                                tool_registry.remove(event.id)
+            except Exception as exc:
+                if attempt < max_attempts and getattr(exc, "retryable", False):
+                    delay = base_delay * (2 ** attempt) + random.uniform(0, 1)
+                    print_warning(
+                        console,
+                        f"Backend error ({type(exc).__name__}), retrying "
+                        f"attempt {attempt + 2}/{max_attempts + 1} after {delay:.1f}s...",
+                    )
+                    if event_iter is not None:
+                        try:
+                            await event_iter.aclose()
+                        except Exception:  # noqa: BLE001
+                            pass
+                    try:
+                        await backend.cancel()
+                    except Exception:  # noqa: BLE001
+                        pass
+                    await anyio.sleep(delay)
+                    continue
+                raise
 
-                        if inv is not None:
-                            inv.observe(event)
-
-                    elif isinstance(event, MetricsEvent):
-                        # EVNT-02 / MAP-06: recorder-only, no UI. Must precede the
-                        # CostEvent branch so isinstance order is correct.
-                        if inv is not None:
-                            inv.observe(event)
-
-                    elif isinstance(event, CostEvent):
-                        if event.cost_usd:
-                            if not use_callback:
-                                if agent_renderer.has_content:
-                                    agent_renderer.finish()
-                                console.print()
-                                print_cost(console, event.cost_usd)
-
-                        if inv is not None:
-                            inv.observe(event)
-
-                    elif isinstance(event, ResultEvent):
-                        if event.structured_output is not None:
-                            structured_result = event.structured_output
-                            if not use_callback:
-                                issues = (
-                                    structured_result.get("issues", [])
-                                    if isinstance(structured_result, dict)
-                                    else []
-                                )
-                                if issues:
-                                    formatted = []
-                                    for i in issues:
-                                        if "file" in i and "line" in i:
-                                            desc = i.get("description", "")
-                                            issue_id = i.get("id", "?")
-                                            formatted.append(
-                                                f"[{issue_id}] {i['file']}:{i['line']} - {desc}"
-                                            )
-                                        else:
-                                            label = i.get("title", i.get("description", ""))
-                                            formatted.append(f"[{i.get('id', '?')}] {label}")
-                                    agent_renderer.append("\n".join(formatted))
-                        result_continuation = event.continuation
-
-                        if inv is not None:
-                            inv.observe(event)
-
-            # Budget abort: the wall scope cancelled the loop, or the tool-call
-            # ceiling broke out. Cancel the backend (swallow any error — an abort
-            # must NEVER raise into the CLI), mark the ATIF turn aborted, surface
-            # a marker, then fall through to the partial-output return.
-            wall_cancelled = bool(getattr(wall_scope, "cancelled_caught", False))
-            if budget_reason is None and wall_cancelled:
-                budget_reason = "wall_budget_exceeded"
-            aborted_reason = budget_reason
-            if budget_reason is not None:
-                try:
-                    await event_iter.aclose()
-                except Exception:  # noqa: BLE001 - abort must not raise into the CLI
-                    pass
-                try:
-                    await backend.cancel()
-                except Exception:  # noqa: BLE001 - abort must not raise into the CLI
-                    pass
-                if inv is not None:
-                    inv.mark_aborted(budget_reason)
-                if use_callback and progress_callback is not None:
-                    result = progress_callback(format_callback_text(f"[budget] aborted: {budget_reason}"))
-                    if inspect.isawaitable(result):
-                        await result
-                elif not use_callback:
-                    print_warning(console, f"Turn aborted: {budget_reason}")
-
-            if not use_callback:
-                if agent_renderer.has_content:
-                    agent_renderer.finish()
-                tool_registry.finish_all()
-                console.print()
     except Exception as exc:
         print_error(console, "Backend Execution Error", f"{type(exc).__name__}: {exc}")
         raise

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import inspect
+import math
 import os
 import random
 import re
@@ -456,12 +457,6 @@ async def run_agent(
     _state.current_backends.append(backend)
     event_iter: AsyncGenerator[Any, None] | None = None
     try:
-        # Created unconditionally for task_id→label correlation; in callback mode
-        # only its label methods run — no panels or Live display.
-        tool_registry = LiveToolPanelRegistry(console, _state.quiet_mode)
-        if not use_callback:
-            agent_renderer = AgentTextRenderer(console)
-
         # Open Invocation scope when a recorder is active; nullcontext keeps the
         # with-shape uniform otherwise (CORE-09 no-op). D-19: no ATIF construction
         # here — only inv.observe()/inv.observe_user_step() against the recorder.
@@ -470,6 +465,12 @@ async def run_agent(
         _default_delay = float(os.environ.get("DAYDREAM_PI_RETRY_BASE_DELAY_S", "2.0"))
         max_attempts = getattr(backend, "retry_attempts", _default_attempts)
         base_delay = getattr(backend, "retry_base_delay_s", _default_delay)
+        if max_attempts < 0:
+            raise ValueError("retry attempts must be >= 0")
+        if not math.isfinite(base_delay):
+            raise ValueError("retry base delay must be finite")
+        if base_delay < 0:
+            raise ValueError("retry base delay must be >= 0")
 
         for attempt in range(max_attempts + 1):
             # Reset accumulated state so a failed attempt's partial output
@@ -479,6 +480,10 @@ async def run_agent(
             result_continuation = None
             tool_calls = 0
             budget_reason: str | None = None
+            # Created per attempt so a failed retry's UI panels and task-label
+            # mappings cannot be flushed or reused by a later successful attempt.
+            tool_registry = LiveToolPanelRegistry(console, _state.quiet_mode)
+            agent_renderer = AgentTextRenderer(console)
 
             try:
                 event_iter = cast(
@@ -677,6 +682,7 @@ async def run_agent(
                     # Calling cancel() would terminate all processes on the shared
                     # backend instance, killing sibling concurrent tasks under
                     # fan-out (phases.py phase_per_stack_reviews).
+                    tool_registry.discard_all()
                     await anyio.sleep(delay)
                     continue
                 raise

--- a/daydream/backends/__init__.py
+++ b/daydream/backends/__init__.py
@@ -257,7 +257,6 @@ class Backend(Protocol):
     """
 
     model: str
-    fanout_concurrency: int
 
     def execute(
         self,

--- a/daydream/backends/__init__.py
+++ b/daydream/backends/__init__.py
@@ -257,6 +257,7 @@ class Backend(Protocol):
     """
 
     model: str
+    fanout_concurrency: int
 
     def execute(
         self,

--- a/daydream/backends/__init__.py
+++ b/daydream/backends/__init__.py
@@ -249,6 +249,11 @@ class Backend(Protocol):
     """Protocol for agent backends.
 
     Each backend yields a stream of AgentEvent instances from execute().
+
+    Optional extension: backends may expose ``fanout_concurrency: int`` to
+    advertise how many parallel execute() calls phase_per_stack_reviews should
+    run concurrently. When absent, the caller falls back to 4 via
+    ``getattr(backend, "fanout_concurrency", 4)``.
     """
 
     model: str

--- a/daydream/backends/claude.py
+++ b/daydream/backends/claude.py
@@ -218,6 +218,7 @@ class ClaudeBackend:
 
     def __init__(self, model: str):
         self.model = model
+        self.fanout_concurrency = 4
         self._active_clients: set[ClaudeSDKClient] = set()
 
     async def execute(

--- a/daydream/backends/codex.py
+++ b/daydream/backends/codex.py
@@ -71,6 +71,7 @@ class CodexBackend:
 
     def __init__(self, model: str):
         self.model = model
+        self.fanout_concurrency = 4
         self._process: asyncio.subprocess.Process | None = None
         self._processes: list[asyncio.subprocess.Process] = []
 

--- a/daydream/backends/pi.py
+++ b/daydream/backends/pi.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import math
 import os
 import re
 import uuid
@@ -158,7 +159,13 @@ def _pi_retry_base_delay() -> float:
                 _PI_DEFAULT_RETRY_BASE_DELAY,
             )
         else:
-            if value < 0:
+            if not math.isfinite(value):
+                logger.warning(
+                    "DAYDREAM_PI_RETRY_BASE_DELAY_S=%r is not finite; using default %g",
+                    raw,
+                    _PI_DEFAULT_RETRY_BASE_DELAY,
+                )
+            elif value < 0:
                 logger.warning(
                     "DAYDREAM_PI_RETRY_BASE_DELAY_S=%r is negative; using default %g",
                     raw,
@@ -174,17 +181,20 @@ def _is_retryable_error_message(message: str) -> bool:
 
     High-precision literals (429, rate limit/rate_limit, too many requests) are
     matched as plain substrings — they are extremely unlikely to appear in a
-    non-transient context.  Ambiguous stems (overload, capacity, throttl) require
-    a left word boundary so that phrases like "not overloaded", "capacity
-    planning", or "preloaded" do not produce false positives.
+    non-transient context. Ambiguous terms require positive overload/capacity
+    wording and explicitly reject negated or planning contexts.
     """
     lower = message.lower()
     # Unambiguous literals — plain substring is safe.
     if any(token in lower for token in ("429", "rate limit", "rate_limit", "too many requests")):
         return True
-    # Ambiguous stems — require a word boundary on the left to avoid false
-    # positives (e.g. "not overloaded", "preloaded", "capacity planning").
-    return bool(re.search(r"\b(?:overload|capacity|throttl)", lower))
+    if re.search(r"\bnot\s+overloaded\b|\bcapacity\s+planning\b", lower):
+        return False
+    return bool(
+        re.search(r"\boverloaded?\b|\boverload(?:ed|ing)?\b", lower)
+        or re.search(r"\bcapacity\s+(?:unavailable|exceeded|limit|limited|full|reached)\b", lower)
+        or re.search(r"\bthrottl(?:e|ed|ing)\b", lower)
+    )
 
 
 def _is_retryable_exit_code(code: int) -> bool:

--- a/daydream/backends/pi.py
+++ b/daydream/backends/pi.py
@@ -116,8 +116,40 @@ Be concise in your responses. Do not narrate exploration step by step; report
 findings and conclusions."""
 
 
+_PI_DEFAULT_RETRY_ATTEMPTS = 3
+_PI_DEFAULT_RETRY_BASE_DELAY = 2.0
+
+
+def _pi_retry_attempts() -> int:
+    raw = os.environ.get("DAYDREAM_PI_RETRY_ATTEMPTS")
+    return int(raw) if raw else _PI_DEFAULT_RETRY_ATTEMPTS
+
+
+def _pi_retry_base_delay() -> float:
+    raw = os.environ.get("DAYDREAM_PI_RETRY_BASE_DELAY_S")
+    return float(raw) if raw else _PI_DEFAULT_RETRY_BASE_DELAY
+
+
+def _is_retryable_error_message(message: str) -> bool:
+    """Return True if the error message signals a transient overload or rate-limit."""
+    lower = message.lower()
+    return any(
+        token in lower
+        for token in ("429", "overload", "rate limit", "rate_limit", "capacity", "too many requests", "throttl")
+    )
+
+
+def _is_retryable_exit_code(code: int) -> bool:
+    """Return True for exit codes that indicate OOM/SIGKILL rather than a logic error."""
+    return code in (-9, 137)
+
+
 class PiError(Exception):
     """Raised when a Pi turn fails (e.g. ``stopReason == "error"``)."""
+
+    def __init__(self, message: str, *, retryable: bool = False):
+        super().__init__(message)
+        self.retryable = retryable
 
 
 def _render_tool_result(result: Any) -> str:
@@ -240,6 +272,7 @@ class PiBackend:
 
     def __init__(self, model: str):
         self.model = model
+        self.fanout_concurrency = 2
         self._process: asyncio.subprocess.Process | None = None
         self._processes: list[asyncio.subprocess.Process] = []
 
@@ -456,7 +489,8 @@ class PiBackend:
                     msg = event.get("message") or {}
                     stop_reason = msg.get("stopReason")
                     if stop_reason == "error":
-                        raise PiError(msg.get("errorMessage") or "Unknown Pi error")
+                        error_msg = msg.get("errorMessage") or "Unknown Pi error"
+                        raise PiError(error_msg, retryable=_is_retryable_error_message(error_msg))
                     usage = _extract_usage(msg)
                     inp = usage["input"]
                     outp = usage["output"]
@@ -496,7 +530,8 @@ class PiBackend:
             # turn_end error event, surface the failure with diagnostic output
             # instead of reporting a successful completion with empty/partial
             # output.
-            if proc.returncode != 0:
+            returncode = proc.returncode
+            if returncode is not None and returncode != 0:
                 stderr_tail = "\n".join(stderr_lines[-10:])
                 if stderr_lines:
                     detail = (
@@ -509,7 +544,8 @@ class PiBackend:
                         "crashed before writing to stdout)"
                     )
                 raise PiError(
-                    f"Pi CLI exited with return code {proc.returncode}.{detail}"
+                    f"Pi CLI exited with return code {returncode}.{detail}",
+                    retryable=_is_retryable_exit_code(returncode),
                 )
 
             # Single finalization path (plan §10): runs exactly once whether

--- a/daydream/backends/pi.py
+++ b/daydream/backends/pi.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 import re
 import uuid
@@ -119,24 +120,71 @@ findings and conclusions."""
 _PI_DEFAULT_RETRY_ATTEMPTS = 3
 _PI_DEFAULT_RETRY_BASE_DELAY = 2.0
 
+logger = logging.getLogger(__name__)
+
 
 def _pi_retry_attempts() -> int:
     raw = os.environ.get("DAYDREAM_PI_RETRY_ATTEMPTS")
-    return int(raw) if raw else _PI_DEFAULT_RETRY_ATTEMPTS
+    if raw:
+        try:
+            value = int(raw)
+        except ValueError:
+            logger.warning(
+                "DAYDREAM_PI_RETRY_ATTEMPTS=%r is not a valid integer; using default %d",
+                raw,
+                _PI_DEFAULT_RETRY_ATTEMPTS,
+            )
+        else:
+            if value < 0:
+                logger.warning(
+                    "DAYDREAM_PI_RETRY_ATTEMPTS=%r is negative; using default %d",
+                    raw,
+                    _PI_DEFAULT_RETRY_ATTEMPTS,
+                )
+            else:
+                return value
+    return _PI_DEFAULT_RETRY_ATTEMPTS
 
 
 def _pi_retry_base_delay() -> float:
     raw = os.environ.get("DAYDREAM_PI_RETRY_BASE_DELAY_S")
-    return float(raw) if raw else _PI_DEFAULT_RETRY_BASE_DELAY
+    if raw:
+        try:
+            value = float(raw)
+        except ValueError:
+            logger.warning(
+                "DAYDREAM_PI_RETRY_BASE_DELAY_S=%r is not a valid float; using default %g",
+                raw,
+                _PI_DEFAULT_RETRY_BASE_DELAY,
+            )
+        else:
+            if value < 0:
+                logger.warning(
+                    "DAYDREAM_PI_RETRY_BASE_DELAY_S=%r is negative; using default %g",
+                    raw,
+                    _PI_DEFAULT_RETRY_BASE_DELAY,
+                )
+            else:
+                return value
+    return _PI_DEFAULT_RETRY_BASE_DELAY
 
 
 def _is_retryable_error_message(message: str) -> bool:
-    """Return True if the error message signals a transient overload or rate-limit."""
+    """Return True if the error message signals a transient overload or rate-limit.
+
+    High-precision literals (429, rate limit/rate_limit, too many requests) are
+    matched as plain substrings — they are extremely unlikely to appear in a
+    non-transient context.  Ambiguous stems (overload, capacity, throttl) require
+    a left word boundary so that phrases like "not overloaded", "capacity
+    planning", or "preloaded" do not produce false positives.
+    """
     lower = message.lower()
-    return any(
-        token in lower
-        for token in ("429", "overload", "rate limit", "rate_limit", "capacity", "too many requests", "throttl")
-    )
+    # Unambiguous literals — plain substring is safe.
+    if any(token in lower for token in ("429", "rate limit", "rate_limit", "too many requests")):
+        return True
+    # Ambiguous stems — require a word boundary on the left to avoid false
+    # positives (e.g. "not overloaded", "preloaded", "capacity planning").
+    return bool(re.search(r"\b(?:overload|capacity|throttl)", lower))
 
 
 def _is_retryable_exit_code(code: int) -> bool:
@@ -273,6 +321,8 @@ class PiBackend:
     def __init__(self, model: str):
         self.model = model
         self.fanout_concurrency = 2
+        self.retry_attempts = _pi_retry_attempts()
+        self.retry_base_delay_s = _pi_retry_base_delay()
         self._process: asyncio.subprocess.Process | None = None
         self._processes: list[asyncio.subprocess.Process] = []
 

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -2751,7 +2751,7 @@ async def phase_per_stack_reviews(
     recorder = get_current_recorder()
     results: dict[str, Path] = {}
     failures: dict[str, str] = {}
-    limiter = anyio.CapacityLimiter(4)
+    limiter = anyio.CapacityLimiter(getattr(backend, "fanout_concurrency", 4))
     prior_commits = _prior_daydream_commits(work)
 
     async with anyio.create_task_group() as tg:

--- a/daydream/ui/panels.py
+++ b/daydream/ui/panels.py
@@ -823,6 +823,14 @@ class LiveToolPanelRegistry:
         self._call_args.clear()
         self._task_labels.clear()
 
+    def discard_all(self) -> None:
+        """Stop rendering and clear tracked panels without printing them."""
+        self._stop_live()
+        self._active_order.clear()
+        self._panels.clear()
+        self._call_args.clear()
+        self._task_labels.clear()
+
     def _ensure_live(self) -> None:
         """Start the shared ``Live`` if there are active panels."""
         if self._active_order:

--- a/tests/test_agent_budget.py
+++ b/tests/test_agent_budget.py
@@ -47,6 +47,7 @@ class _BurstBackend:
     """
 
     model = "mock-model"
+    fanout_concurrency: int = 4
     count: int = 200
     sleep_s: float = 0.0
     cancel_calls: int = 0

--- a/tests/test_agent_recorder_integration.py
+++ b/tests/test_agent_recorder_integration.py
@@ -70,6 +70,7 @@ class MockBackend:
     """
 
     model = "mock-model"
+    fanout_concurrency = 4
     events: list[AgentEvent]
 
     def execute(
@@ -377,6 +378,7 @@ class MaxTurnsBackend:
     """
 
     model = "mock-model"
+    fanout_concurrency = 4
     pre_events: list[AgentEvent]
 
     def execute(

--- a/tests/test_agent_retry.py
+++ b/tests/test_agent_retry.py
@@ -1,0 +1,196 @@
+"""Tests for retry/backoff logic in run_agent (daydream/agent.py).
+
+Every test drives run_agent — the production entrypoint — with a mock backend
+that simulates retryable and non-retryable failures. Tests assert on observable
+outcomes (returned output, call count) never on internal implementation details.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from daydream.agent import run_agent
+from daydream.backends import ResultEvent, TextEvent
+from daydream.backends.pi import PiError
+from daydream.trajectory import DaydreamPhase
+
+
+class _RetryableThenSuccessBackend:
+    """Raises a retryable PiError on the first call, succeeds on the second."""
+
+    model = "test-model"
+    fanout_concurrency = 4
+
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    async def execute(
+        self,
+        cwd: Path,
+        prompt: str,
+        output_schema: Any = None,
+        continuation: Any = None,
+        agents: Any = None,
+        max_turns: Any = None,
+        read_only: bool = False,
+    ):
+        self.call_count += 1
+        if self.call_count == 1:
+            raise PiError("429 Too Many Requests - rate limit exceeded", retryable=True)
+        yield TextEvent(text="Review complete")
+        yield ResultEvent(structured_output=None, continuation=None)
+
+    async def cancel(self) -> None:
+        pass
+
+    def format_skill_invocation(self, *a: Any, **kw: Any) -> str:
+        return ""
+
+
+class _NonRetryableBackend:
+    """Always raises a non-retryable PiError."""
+
+    model = "test-model"
+    fanout_concurrency = 4
+
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    async def execute(
+        self,
+        cwd: Path,
+        prompt: str,
+        output_schema: Any = None,
+        continuation: Any = None,
+        agents: Any = None,
+        max_turns: Any = None,
+        read_only: bool = False,
+    ):
+        self.call_count += 1
+        raise PiError("auth failed", retryable=False)
+        yield  # make this an async generator
+
+    async def cancel(self) -> None:
+        pass
+
+    def format_skill_invocation(self, *a: Any, **kw: Any) -> str:
+        return ""
+
+
+class _AlwaysRetryableBackend:
+    """Always raises a retryable PiError (used to test retry exhaustion)."""
+
+    model = "test-model"
+    fanout_concurrency = 4
+
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    async def execute(
+        self,
+        cwd: Path,
+        prompt: str,
+        output_schema: Any = None,
+        continuation: Any = None,
+        agents: Any = None,
+        max_turns: Any = None,
+        read_only: bool = False,
+    ):
+        self.call_count += 1
+        raise PiError("429 rate limit", retryable=True)
+        yield  # make this an async generator
+
+    async def cancel(self) -> None:
+        pass
+
+    def format_skill_invocation(self, *a: Any, **kw: Any) -> str:
+        return ""
+
+
+class _PartialThenRetryBackend:
+    """Yields partial text then raises retryable on attempt 1; yields final text on attempt 2."""
+
+    model = "test-model"
+    fanout_concurrency = 4
+
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    async def execute(
+        self,
+        cwd: Path,
+        prompt: str,
+        output_schema: Any = None,
+        continuation: Any = None,
+        agents: Any = None,
+        max_turns: Any = None,
+        read_only: bool = False,
+    ):
+        self.call_count += 1
+        if self.call_count == 1:
+            yield TextEvent(text="partial text")
+            raise PiError("429 overload", retryable=True)
+        yield TextEvent(text="final text")
+        yield ResultEvent(structured_output=None, continuation=None)
+
+    async def cancel(self) -> None:
+        pass
+
+    def format_skill_invocation(self, *a: Any, **kw: Any) -> str:
+        return ""
+
+
+@pytest.mark.asyncio
+async def test_run_agent_retries_on_retryable_error(monkeypatch, tmp_path: Path) -> None:
+    """First call raises retryable PiError; second succeeds. Output is from the second call."""
+    monkeypatch.setenv("DAYDREAM_PI_RETRY_BASE_DELAY_S", "0.01")
+    backend = _RetryableThenSuccessBackend()
+
+    output, _, _ = await run_agent(
+        backend, tmp_path, "review this", phase=DaydreamPhase.REVIEW
+    )
+
+    assert output == "Review complete"
+    assert backend.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_run_agent_no_retry_on_non_retryable(monkeypatch, tmp_path: Path) -> None:
+    """Non-retryable PiError propagates immediately without any retry."""
+    monkeypatch.setenv("DAYDREAM_PI_RETRY_BASE_DELAY_S", "0.01")
+    backend = _NonRetryableBackend()
+
+    with pytest.raises(PiError, match="auth failed"):
+        await run_agent(backend, tmp_path, "review", phase=DaydreamPhase.REVIEW)
+
+    assert backend.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_run_agent_retry_exhausted(monkeypatch, tmp_path: Path) -> None:
+    """Always-retryable backend is called max_attempts+1 times total, then raises."""
+    monkeypatch.setenv("DAYDREAM_PI_RETRY_BASE_DELAY_S", "0.01")
+    monkeypatch.setenv("DAYDREAM_PI_RETRY_ATTEMPTS", "2")
+    backend = _AlwaysRetryableBackend()
+
+    with pytest.raises(PiError):
+        await run_agent(backend, tmp_path, "review", phase=DaydreamPhase.REVIEW)
+
+    # 1 original attempt + 2 retries = 3 total
+    assert backend.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_run_agent_retry_resets_output(monkeypatch, tmp_path: Path) -> None:
+    """Partial output from a failed attempt is discarded; only the final output is returned."""
+    monkeypatch.setenv("DAYDREAM_PI_RETRY_BASE_DELAY_S", "0.01")
+    backend = _PartialThenRetryBackend()
+
+    output, _, _ = await run_agent(
+        backend, tmp_path, "review", phase=DaydreamPhase.REVIEW
+    )
+
+    assert output == "final text"
+    assert backend.call_count == 2

--- a/tests/test_agent_retry.py
+++ b/tests/test_agent_retry.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+import anyio
 import pytest
 
 from daydream.agent import run_agent
@@ -194,3 +195,106 @@ async def test_run_agent_retry_resets_output(monkeypatch, tmp_path: Path) -> Non
 
     assert output == "final text"
     assert backend.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_concurrent_retry_does_not_kill_sibling_invocations(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Shared-backend concurrency shape: a retryable failure on one concurrent invocation
+    must not abort sibling invocations that share the same backend instance.
+
+    This mirrors phases.phase_per_stack_reviews, where multiple run_agent calls share
+    a single Backend under an anyio TaskGroup with a CapacityLimiter.
+
+    The key contract under test: agent.py's retry path does NOT call backend.cancel()
+    (which would kill all subprocesses on the shared backend, including siblings).
+    It only closes the individual event iterator for the failing invocation.
+    """
+    monkeypatch.setenv("DAYDREAM_PI_RETRY_BASE_DELAY_S", "0.01")
+
+    cancel_calls: list[str] = []
+
+    class _SharedBackend:
+        """Three named prompt → behaviour mappings on one shared instance.
+
+        - prompt containing "fail-once": retryable PiError on first call, succeeds on retry.
+        - prompt containing "ok-a" / "ok-b": always succeeds immediately.
+
+        cancel() is tracked; the test asserts it is NOT called during retry so that
+        sibling concurrent invocations are unaffected.
+        """
+
+        model = "test-model"
+        fanout_concurrency = 3
+        # retry_attempts read by agent.py via getattr(backend, "retry_attempts", 3)
+        retry_attempts = 3
+        retry_base_delay_s = 0.01
+
+        def __init__(self) -> None:
+            self.call_counts: dict[str, int] = {}
+
+        async def execute(
+            self,
+            cwd: Path,
+            prompt: str,
+            output_schema: Any = None,
+            continuation: Any = None,
+            agents: Any = None,
+            max_turns: Any = None,
+            read_only: bool = False,
+        ):
+            key = (
+                "fail-once"
+                if "fail-once" in prompt
+                else "ok-a"
+                if "ok-a" in prompt
+                else "ok-b"
+            )
+            self.call_counts[key] = self.call_counts.get(key, 0) + 1
+            if key == "fail-once" and self.call_counts[key] == 1:
+                raise PiError("429 overload", retryable=True)
+            yield TextEvent(text=f"done-{key}")
+            yield ResultEvent(structured_output=None, continuation=None)
+
+        async def cancel(self) -> None:
+            cancel_calls.append("cancel")
+
+        def format_skill_invocation(self, *a: Any, **kw: Any) -> str:
+            return ""
+
+    backend = _SharedBackend()
+
+    results: list[tuple[str, str]] = []
+
+    async def _run(prompt: str) -> None:
+        output, _, _ = await run_agent(
+            backend, tmp_path, prompt, phase=DaydreamPhase.REVIEW
+        )
+        results.append((prompt, output))
+
+    # Run all three concurrently — same shape as phase_per_stack_reviews TaskGroup.
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(_run, "fail-once review")
+        tg.start_soon(_run, "ok-a review")
+        tg.start_soon(_run, "ok-b review")
+
+    # All three invocations must have produced output — siblings must survive the retry.
+    assert len(results) == 3, f"Expected 3 results, got {len(results)}: {results}"
+
+    outputs = {prompt: out for prompt, out in results}
+    assert outputs["fail-once review"] == "done-fail-once"
+    assert outputs["ok-a review"] == "done-ok-a"
+    assert outputs["ok-b review"] == "done-ok-b"
+
+    # backend.cancel() must NOT have been called during retry — calling it would kill
+    # all subprocesses on the shared backend, terminating sibling concurrent tasks.
+    assert cancel_calls == [], (
+        f"backend.cancel() was called {len(cancel_calls)} time(s) during retry; "
+        "this would kill sibling concurrent invocations"
+    )
+
+    # The fail-once slot was called twice (fail + retry); others exactly once.
+    assert backend.call_counts.get("fail-once", 0) == 2
+    assert backend.call_counts.get("ok-a", 0) == 1
+    assert backend.call_counts.get("ok-b", 0) == 1

--- a/tests/test_backend_pi.py
+++ b/tests/test_backend_pi.py
@@ -992,6 +992,14 @@ def test_is_retryable_error_message_non_retryable():
     assert _is_retryable_error_message("auth failed") is False
 
 
+def test_is_retryable_error_message_not_overloaded_is_non_retryable():
+    assert _is_retryable_error_message("service is not overloaded") is False
+
+
+def test_is_retryable_error_message_capacity_planning_is_non_retryable():
+    assert _is_retryable_error_message("capacity planning required") is False
+
+
 def test_is_retryable_error_message_empty():
     assert _is_retryable_error_message("") is False
 
@@ -1123,6 +1131,16 @@ def test_pi_retry_base_delay_default():
 def test_pi_retry_base_delay_env_override(monkeypatch):
     monkeypatch.setenv("DAYDREAM_PI_RETRY_BASE_DELAY_S", "0.5")
     assert _pi_retry_base_delay() == pytest.approx(0.5)
+
+
+def test_pi_retry_base_delay_nan_falls_back(monkeypatch):
+    monkeypatch.setenv("DAYDREAM_PI_RETRY_BASE_DELAY_S", "nan")
+    assert _pi_retry_base_delay() == _PI_DEFAULT_RETRY_BASE_DELAY
+
+
+def test_pi_retry_base_delay_inf_falls_back(monkeypatch):
+    monkeypatch.setenv("DAYDREAM_PI_RETRY_BASE_DELAY_S", "inf")
+    assert _pi_retry_base_delay() == _PI_DEFAULT_RETRY_BASE_DELAY
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_backend_pi.py
+++ b/tests/test_backend_pi.py
@@ -29,10 +29,16 @@ from daydream.backends import (
     TurnEndEvent,
 )
 from daydream.backends.pi import (
+    _PI_DEFAULT_RETRY_ATTEMPTS,
+    _PI_DEFAULT_RETRY_BASE_DELAY,
     _PI_STDOUT_LIMIT_BYTES,
     _SKILL_TOKEN_RE,
     PiBackend,
     PiError,
+    _is_retryable_error_message,
+    _is_retryable_exit_code,
+    _pi_retry_attempts,
+    _pi_retry_base_delay,
     _render_tool_result,
     _resolve_skill_dir,
     _schema_instruction,
@@ -919,4 +925,212 @@ async def test_append_system_prompt_preamble_in_args():
         # an empty stub a future refactor could silently collapse to.
         assert "tool-call budget" in preamble
         assert "grep" in preamble.lower()
+
+
+# ---------------------------------------------------------------------------
+# Task 1: PiError.retryable attribute
+# ---------------------------------------------------------------------------
+
+
+def test_pierror_retryable_default():
+    err = PiError("something went wrong")
+    assert err.retryable is False
+
+
+def test_pierror_retryable_kwarg():
+    err = PiError("429 rate limit", retryable=True)
+    assert err.retryable is True
+
+
+def test_pierror_message_preserved():
+    err = PiError("auth failed", retryable=False)
+    assert str(err) == "auth failed"
+
+
+# ---------------------------------------------------------------------------
+# Task 1: _is_retryable_error_message
+# ---------------------------------------------------------------------------
+
+
+def test_is_retryable_error_message_429():
+    assert _is_retryable_error_message("429 Too Many Requests") is True
+
+
+def test_is_retryable_error_message_overload():
+    assert _is_retryable_error_message("Service is currently overloaded") is True
+
+
+def test_is_retryable_error_message_rate_limit_space():
+    assert _is_retryable_error_message("rate limit exceeded") is True
+
+
+def test_is_retryable_error_message_rate_limit_underscore():
+    assert _is_retryable_error_message("rate_limit hit") is True
+
+
+def test_is_retryable_error_message_capacity():
+    assert _is_retryable_error_message("Capacity unavailable") is True
+
+
+def test_is_retryable_error_message_too_many_requests():
+    assert _is_retryable_error_message("too many requests from this IP") is True
+
+
+def test_is_retryable_error_message_throttle():
+    assert _is_retryable_error_message("Request throttled") is True
+
+
+def test_is_retryable_error_message_throttling():
+    assert _is_retryable_error_message("throttling in effect") is True
+
+
+def test_is_retryable_error_message_case_insensitive():
+    assert _is_retryable_error_message("OVERLOAD detected") is True
+
+
+def test_is_retryable_error_message_non_retryable():
+    assert _is_retryable_error_message("auth failed") is False
+
+
+def test_is_retryable_error_message_empty():
+    assert _is_retryable_error_message("") is False
+
+
+def test_is_retryable_error_message_unknown_pi_error():
+    assert _is_retryable_error_message("Unknown Pi error") is False
+
+
+# ---------------------------------------------------------------------------
+# Task 1: _is_retryable_exit_code
+# ---------------------------------------------------------------------------
+
+
+def test_is_retryable_exit_code_sigkill():
+    assert _is_retryable_exit_code(-9) is True
+
+
+def test_is_retryable_exit_code_oom_137():
+    assert _is_retryable_exit_code(137) is True
+
+
+def test_is_retryable_exit_code_normal_exit_1():
+    assert _is_retryable_exit_code(1) is False
+
+
+def test_is_retryable_exit_code_normal_exit_2():
+    assert _is_retryable_exit_code(2) is False
+
+
+def test_is_retryable_exit_code_zero():
+    assert _is_retryable_exit_code(0) is False
+
+
+# ---------------------------------------------------------------------------
+# Task 1: error turn uses retryable classifier
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_error_turn_sets_retryable_on_429():
+    """A 429 errorMessage in turn_end sets retryable=True on PiError."""
+    backend = PiBackend(model="glm-5.2")
+    lines = [
+        '{"type":"session","sessionId":"pi_ses_429"}',
+        '{"type":"agent_start"}',
+        '{"type":"turn_start"}',
+        '{"type":"turn_end","message":{"role":"assistant","content":[],'
+        '"stopReason":"error","errorMessage":"429 Too Many Requests - rate limit exceeded"}}',
+    ]
+    mock_proc = make_mock_process(lines)
+
+    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc):
+        with pytest.raises(PiError) as exc_info:
+            async for _ in backend.execute(Path("/tmp"), "p"):
+                pass
+
+    assert exc_info.value.retryable is True
+
+
+@pytest.mark.asyncio
+async def test_error_turn_non_retryable_for_auth_failure():
+    """A non-transient errorMessage in turn_end sets retryable=False."""
+    backend = PiBackend(model="glm-5.2")
+    lines = [
+        '{"type":"session","sessionId":"pi_ses_auth"}',
+        '{"type":"agent_start"}',
+        '{"type":"turn_start"}',
+        '{"type":"turn_end","message":{"role":"assistant","content":[],'
+        '"stopReason":"error","errorMessage":"authentication required"}}',
+    ]
+    mock_proc = make_mock_process(lines)
+
+    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc):
+        with pytest.raises(PiError) as exc_info:
+            async for _ in backend.execute(Path("/tmp"), "p"):
+                pass
+
+    assert exc_info.value.retryable is False
+
+
+@pytest.mark.asyncio
+async def test_oom_exit_sets_retryable():
+    """Exit code -9 (SIGKILL/OOM) sets retryable=True on the PiError."""
+    backend = PiBackend(model="glm-5.2")
+    mock_proc = make_mock_process([])
+    mock_proc.returncode = -9
+
+    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc):
+        with pytest.raises(PiError) as exc_info:
+            async for _ in backend.execute(Path("/tmp"), "p"):
+                pass
+
+    assert exc_info.value.retryable is True
+
+
+@pytest.mark.asyncio
+async def test_normal_exit_1_not_retryable():
+    """Exit code 1 (auth error, config error) is NOT retryable."""
+    backend = PiBackend(model="glm-5.2")
+    mock_proc = make_mock_process(["Error: not authenticated"])
+    mock_proc.returncode = 1
+
+    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc):
+        with pytest.raises(PiError) as exc_info:
+            async for _ in backend.execute(Path("/tmp"), "p"):
+                pass
+
+    assert exc_info.value.retryable is False
+
+
+# ---------------------------------------------------------------------------
+# Task 2: Retry env knobs
+# ---------------------------------------------------------------------------
+
+
+def test_pi_retry_attempts_default():
+    assert _pi_retry_attempts() == _PI_DEFAULT_RETRY_ATTEMPTS
+
+
+def test_pi_retry_attempts_env_override(monkeypatch):
+    monkeypatch.setenv("DAYDREAM_PI_RETRY_ATTEMPTS", "5")
+    assert _pi_retry_attempts() == 5
+
+
+def test_pi_retry_base_delay_default():
+    assert _pi_retry_base_delay() == _PI_DEFAULT_RETRY_BASE_DELAY
+
+
+def test_pi_retry_base_delay_env_override(monkeypatch):
+    monkeypatch.setenv("DAYDREAM_PI_RETRY_BASE_DELAY_S", "0.5")
+    assert _pi_retry_base_delay() == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# Task 4: fanout_concurrency
+# ---------------------------------------------------------------------------
+
+
+def test_pi_backend_fanout_concurrency():
+    backend = PiBackend(model="glm-5.2")
+    assert backend.fanout_concurrency == 2
 

--- a/tests/test_backend_pi.py
+++ b/tests/test_backend_pi.py
@@ -928,7 +928,7 @@ async def test_append_system_prompt_preamble_in_args():
 
 
 # ---------------------------------------------------------------------------
-# Task 1: PiError.retryable attribute
+# PiError.retryable attribute
 # ---------------------------------------------------------------------------
 
 
@@ -948,7 +948,7 @@ def test_pierror_message_preserved():
 
 
 # ---------------------------------------------------------------------------
-# Task 1: _is_retryable_error_message
+# _is_retryable_error_message
 # ---------------------------------------------------------------------------
 
 
@@ -1001,7 +1001,7 @@ def test_is_retryable_error_message_unknown_pi_error():
 
 
 # ---------------------------------------------------------------------------
-# Task 1: _is_retryable_exit_code
+# _is_retryable_exit_code
 # ---------------------------------------------------------------------------
 
 
@@ -1026,7 +1026,7 @@ def test_is_retryable_exit_code_zero():
 
 
 # ---------------------------------------------------------------------------
-# Task 1: error turn uses retryable classifier
+# Error turn uses retryable classifier
 # ---------------------------------------------------------------------------
 
 
@@ -1103,7 +1103,7 @@ async def test_normal_exit_1_not_retryable():
 
 
 # ---------------------------------------------------------------------------
-# Task 2: Retry env knobs
+# Retry env knobs
 # ---------------------------------------------------------------------------
 
 
@@ -1126,7 +1126,7 @@ def test_pi_retry_base_delay_env_override(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Task 4: fanout_concurrency
+# fanout_concurrency
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_deep_fanout.py
+++ b/tests/test_deep_fanout.py
@@ -82,7 +82,7 @@ async def test_fan_out_invokes_each_stack(tmp_path: Path, make_work) -> None:
     diff, intent, alts = _mk_context_files(tmp_path)
 
     results, failures = await phase_per_stack_reviews(
-        backend,
+        backend,  # type: ignore[arg-type]
         make_work(tmp_path),
         _mk_stacks(),
         diff_path=diff,
@@ -101,7 +101,7 @@ async def test_fan_out_never_passes_agents_kwarg(tmp_path: Path, make_work) -> N
     diff, intent, alts = _mk_context_files(tmp_path)
 
     await phase_per_stack_reviews(
-        backend,
+        backend,  # type: ignore[arg-type]
         make_work(tmp_path),
         _mk_stacks(),
         diff_path=diff,
@@ -118,7 +118,7 @@ async def test_fan_out_unique_output_paths(tmp_path: Path, make_work) -> None:
     diff, intent, alts = _mk_context_files(tmp_path)
 
     results, _ = await phase_per_stack_reviews(
-        backend,
+        backend,  # type: ignore[arg-type]
         make_work(tmp_path),
         _mk_stacks(),
         diff_path=diff,
@@ -138,7 +138,7 @@ async def test_fan_out_closure_capture(tmp_path: Path, make_work) -> None:
     diff, intent, alts = _mk_context_files(tmp_path)
 
     await phase_per_stack_reviews(
-        backend,
+        backend,  # type: ignore[arg-type]
         make_work(tmp_path),
         _mk_stacks(),
         diff_path=diff,
@@ -195,7 +195,7 @@ async def test_phase_per_stack_reviews_uses_structural_prompt_for_structure_stac
     ]
 
     await _phase(
-        backend,
+        backend,  # type: ignore[arg-type]
         make_work(tmp_path),
         stacks,
         diff_path=diff,
@@ -215,6 +215,8 @@ async def test_fan_out_continues_after_one_failure(tmp_path: Path, make_work) ->
     """A single stack failure does not abort the whole fan-out, and is reported."""
 
     class _FlakyBackend(_RecordingBackend):
+        fanout_concurrency = 4
+
         async def execute(
             self,
             cwd: Path,
@@ -375,7 +377,7 @@ async def test_fanout_default_concurrency(tmp_path: Path, make_work, monkeypatch
     diff, intent, alts = _mk_context_files(tmp_path)
 
     await phase_per_stack_reviews(
-        backend,
+        backend,  # type: ignore[arg-type]
         make_work(tmp_path),
         _mk_stacks(),
         diff_path=diff,

--- a/tests/test_deep_fanout.py
+++ b/tests/test_deep_fanout.py
@@ -257,8 +257,6 @@ async def test_fan_out_continues_after_one_failure(tmp_path: Path, make_work) ->
 class _PiShapeBackend(_RecordingBackend):
     """Mock backend that uses PiBackend's real skill formatter."""
 
-    fanout_concurrency = 4
-
     def __init__(self) -> None:
         super().__init__()
         from daydream.backends.pi import PiBackend

--- a/tests/test_deep_fanout.py
+++ b/tests/test_deep_fanout.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+import anyio
+
 from daydream.backends import ResultEvent, TextEvent
 from daydream.deep.detection import StackAssignment
 from daydream.phases import phase_per_stack_reviews
@@ -354,3 +356,60 @@ async def test_per_stack_prompts_use_pi_native_skill_command(
     # Generic fallback stack injects no skill command at all.
     generic_prompt = next(p for p in backend.prompts if "generic-fallback" in p)
     assert "/skill:" not in generic_prompt
+
+
+async def test_fanout_default_concurrency(tmp_path: Path, make_work, monkeypatch) -> None:
+    """Backend without fanout_concurrency attribute → limiter defaults to 4."""
+    captured: list[int] = []
+    real_limiter = anyio.CapacityLimiter
+
+    def patched_limiter(n: int) -> anyio.CapacityLimiter:
+        captured.append(n)
+        return real_limiter(n)
+
+    monkeypatch.setattr(anyio, "CapacityLimiter", patched_limiter)
+
+    # _RecordingBackend has no fanout_concurrency attr → getattr(..., 4) returns 4.
+    backend = _RecordingBackend()
+    assert not hasattr(backend, "fanout_concurrency")
+    diff, intent, alts = _mk_context_files(tmp_path)
+
+    await phase_per_stack_reviews(
+        backend,
+        make_work(tmp_path),
+        _mk_stacks(),
+        diff_path=diff,
+        intent_path=intent,
+        alternatives_path=alts,
+    )
+
+    assert 4 in captured
+
+
+async def test_fanout_low_concurrency(tmp_path: Path, make_work, monkeypatch) -> None:
+    """Backend with fanout_concurrency=2 → limiter uses 2."""
+    captured: list[int] = []
+    real_limiter = anyio.CapacityLimiter
+
+    def patched_limiter(n: int) -> anyio.CapacityLimiter:
+        captured.append(n)
+        return real_limiter(n)
+
+    monkeypatch.setattr(anyio, "CapacityLimiter", patched_limiter)
+
+    class _LowConcurrencyBackend(_RecordingBackend):
+        fanout_concurrency = 2
+
+    backend = _LowConcurrencyBackend()
+    diff, intent, alts = _mk_context_files(tmp_path)
+
+    await phase_per_stack_reviews(
+        backend,
+        make_work(tmp_path),
+        _mk_stacks(),
+        diff_path=diff,
+        intent_path=intent,
+        alternatives_path=alts,
+    )
+
+    assert captured == [2]

--- a/tests/test_deep_fanout.py
+++ b/tests/test_deep_fanout.py
@@ -257,6 +257,8 @@ async def test_fan_out_continues_after_one_failure(tmp_path: Path, make_work) ->
 class _PiShapeBackend(_RecordingBackend):
     """Mock backend that uses PiBackend's real skill formatter."""
 
+    fanout_concurrency = 4
+
     def __init__(self) -> None:
         super().__init__()
         from daydream.backends.pi import PiBackend

--- a/tests/test_deep_merge.py
+++ b/tests/test_deep_merge.py
@@ -81,6 +81,7 @@ class _RecordingBackend:
     """Records every execute call; verifies no `agents` kwarg was passed."""
 
     model = "test-model"
+    fanout_concurrency = 4
 
     def __init__(self) -> None:
         self.agents_seen: list[Any] = []

--- a/tests/test_multi_turn_tokens.py
+++ b/tests/test_multi_turn_tokens.py
@@ -56,6 +56,7 @@ class MockBackend:
     """Minimal Backend replaying a canned event list."""
 
     model = "mock-model"
+    fanout_concurrency = 4
     events: list[AgentEvent]
 
     def execute(

--- a/tests/test_phase_2_integration.py
+++ b/tests/test_phase_2_integration.py
@@ -83,6 +83,7 @@ class MockBackend:
     """
 
     model = "mock-model"
+    fanout_concurrency = 4
     events: list[AgentEvent]
 
     def execute(

--- a/tests/test_phase_parse_input_path.py
+++ b/tests/test_phase_parse_input_path.py
@@ -11,6 +11,7 @@ from daydream.phases import phase_parse_feedback
 
 class _SpyBackend:
     model = "test-model"
+    fanout_concurrency = 4
 
     def __init__(self) -> None:
         self.last_prompt: str = ""

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -35,6 +35,7 @@ async def test_phase_test_and_heal_fix_uses_fresh_context(tmp_path, monkeypatch,
 
     class FreshContextBackend:
         model = "test-model"
+        fanout_concurrency = 4
 
         async def execute(
             self, cwd, prompt, output_schema=None, continuation=None, agents=None,
@@ -113,6 +114,7 @@ async def test_phase_test_and_heal_fix_prompt_absolute_path_and_turn_budget(
 
     class RecordingBackend:
         model = "test-model"
+        fanout_concurrency = 4
 
         async def execute(
             self, cwd, prompt, output_schema=None, continuation=None, agents=None,
@@ -175,6 +177,7 @@ async def test_phase_parse_feedback_empty_response_returns_empty_list(tmp_path, 
         """Simulates a schema miss: no structured output, no text."""
 
         model = "test-model"
+        fanout_concurrency = 4
 
         async def execute(
             self, cwd, prompt, output_schema=None, continuation=None, agents=None,
@@ -208,6 +211,7 @@ async def test_phase_parse_feedback_json_fallback(tmp_path, monkeypatch, make_wo
         """Simulates a schema miss where the model outputs JSON as plain text."""
 
         model = "test-model"
+        fanout_concurrency = 4
 
         async def execute(
             self, cwd, prompt, output_schema=None, continuation=None, agents=None,
@@ -240,6 +244,7 @@ async def test_phase_fix_prompt_includes_scope_and_precedence_constraints(tmp_pa
 
     class CapturingBackend:
         model = "test-model"
+        fanout_concurrency = 4
 
         async def execute(
             self, cwd, prompt, output_schema=None, continuation=None, agents=None,
@@ -283,6 +288,7 @@ async def test_phase_fix_resolves_existing_file_to_absolute_path(tmp_path, monke
 
     class CapturingBackend:
         model = "test-model"
+        fanout_concurrency = 4
 
         async def execute(
             self, cwd, prompt, output_schema=None, continuation=None, agents=None,
@@ -320,6 +326,7 @@ async def test_phase_fix_falls_back_to_relative_path_when_missing(tmp_path, monk
 
     class CapturingBackend:
         model = "test-model"
+        fanout_concurrency = 4
 
         async def execute(
             self, cwd, prompt, output_schema=None, continuation=None, agents=None,
@@ -355,6 +362,7 @@ async def test_phase_fix_passes_turn_budget(tmp_path, monkeypatch, make_work):
 
     class CapturingBackend:
         model = "test-model"
+        fanout_concurrency = 4
 
         async def execute(
             self, cwd, prompt, output_schema=None, continuation=None, agents=None,
@@ -673,6 +681,7 @@ async def test_phase_understand_intent_confirmed_first_try(tmp_path, monkeypatch
 
     class IntentBackend:
         model = "test-model"
+        fanout_concurrency = 4
 
         async def execute(
             self, cwd, prompt, output_schema=None, continuation=None, agents=None,
@@ -715,6 +724,7 @@ async def test_phase_understand_intent_correction_then_confirm(tmp_path, monkeyp
 
     class IntentBackend:
         model = "test-model"
+        fanout_concurrency = 4
 
         async def execute(
             self, cwd, prompt, output_schema=None, continuation=None, agents=None,
@@ -776,6 +786,7 @@ async def test_phase_understand_intent_forced_no_interactive_falls_through(tmp_p
 
         class IntentBackend:
             model = "test-model"
+            fanout_concurrency = 4
 
             async def execute(
                 self, cwd, prompt, output_schema=None, continuation=None, agents=None,
@@ -888,6 +899,7 @@ async def test_phase_alternative_review_returns_issues(tmp_path, monkeypatch, ma
 
     class ReviewBackend:
         model = "test-model"
+        fanout_concurrency = 4
 
         async def execute(
             self, cwd, prompt, output_schema=None, continuation=None, agents=None,
@@ -928,6 +940,7 @@ async def test_phase_alternative_review_no_issues(tmp_path, monkeypatch, make_wo
 
     class NoIssuesBackend:
         model = "test-model"
+        fanout_concurrency = 4
 
         async def execute(
             self, cwd, prompt, output_schema=None, continuation=None, agents=None,
@@ -981,6 +994,7 @@ async def test_phase_generate_plan_writes_markdown(tmp_path, monkeypatch, make_w
 
     class PlanBackend:
         model = "test-model"
+        fanout_concurrency = 4
 
         async def execute(
             self, cwd, prompt, output_schema=None, continuation=None, agents=None,
@@ -1036,6 +1050,7 @@ async def test_phase_generate_plan_skip_on_none(tmp_path, monkeypatch, make_work
 
     class NeverCalledBackend:
         model = "test-model"
+        fanout_concurrency = 4
 
         async def execute(
             self, cwd, prompt, output_schema=None, continuation=None, agents=None,
@@ -1284,6 +1299,7 @@ class _ScriptedBackend:
     # their heros (Task 6). Tests don't assert this value — they just need the
     # attribute to exist on the duck-typed Backend.
     model = "test-model"
+    fanout_concurrency = 4
 
     def __init__(self, script: list) -> None:
         self.script = list(script)
@@ -2295,6 +2311,7 @@ async def test_phase_test_and_heal_yes_bounded_loop_exactly_one_auto_attempt(
 
         class _BoundedLoopBackend:
             model = "test-model"
+            fanout_concurrency = 4
             read_only_calls: list[bool] = []
 
             async def execute(
@@ -2622,6 +2639,7 @@ async def test_phase_review_prints_model_line_after_hero(
 
     class _Backend:
         model = "claude-opus-4-6"
+        fanout_concurrency = 4
 
         async def execute(
             self, cwd, prompt, output_schema=None, continuation=None, agents=None,
@@ -2656,6 +2674,7 @@ async def test_phase_parse_feedback_prints_model_line_after_hero(
 
     class _Backend:
         model = "claude-haiku-4-5"
+        fanout_concurrency = 4
 
         async def execute(
             self, cwd, prompt, output_schema=None, continuation=None, agents=None,
@@ -2691,6 +2710,7 @@ async def test_phase_test_and_heal_prints_model_line_after_hero(
 
     class _Backend:
         model = "claude-sonnet-4-6"
+        fanout_concurrency = 4
 
         async def execute(
             self, cwd, prompt, output_schema=None, continuation=None, agents=None,
@@ -2725,6 +2745,7 @@ async def test_phase_fetch_pr_feedback_prints_model_line_after_hero(
 
     class _Backend:
         model = "claude-opus-4-6"
+        fanout_concurrency = 4
 
         async def execute(
             self, cwd, prompt, output_schema=None, continuation=None, agents=None,
@@ -2756,6 +2777,7 @@ async def test_phase_understand_intent_prints_model_line_after_hero(
 
     class _Backend:
         model = "claude-opus-4-6"
+        fanout_concurrency = 4
 
         async def execute(
             self, cwd, prompt, output_schema=None, continuation=None, agents=None,
@@ -2799,6 +2821,7 @@ async def test_phase_alternative_review_prints_model_line_after_hero(
 
     class _Backend:
         model = "claude-opus-4-6"
+        fanout_concurrency = 4
 
         async def execute(
             self, cwd, prompt, output_schema=None, continuation=None, agents=None,
@@ -2853,6 +2876,7 @@ async def test_phase_generate_plan_prints_model_line_after_hero(
 
     class _Backend:
         model = "claude-opus-4-6"
+        fanout_concurrency = 4
 
         async def execute(
             self, cwd, prompt, output_schema=None, continuation=None, agents=None,
@@ -2899,6 +2923,7 @@ async def test_phase_cross_stack_merge_prints_model_line_after_hero(
 
     class _Backend:
         model = "claude-opus-4-6"
+        fanout_concurrency = 4
 
         async def execute(
             self, cwd, prompt, output_schema=None, continuation=None, agents=None,
@@ -2976,6 +3001,7 @@ async def test_merge_writes_canonical_json_and_renders_markdown(tmp_path, monkey
 
     class MergeBackend:
         model = "test-model"
+        fanout_concurrency = 4
 
         async def execute(
             self, cwd, prompt, output_schema=None, continuation=None, agents=None,
@@ -3025,6 +3051,7 @@ async def test_merge_raises_on_empty_agent_output(tmp_path, monkeypatch, make_wo
 
     class EmptyBackend:
         model = "test-model"
+        fanout_concurrency = 4
 
         async def execute(
             self, cwd, prompt, output_schema=None, continuation=None, agents=None,
@@ -3112,6 +3139,7 @@ async def test_verifier_excludes_structural_lens(tmp_path, monkeypatch, make_wor
 
     class VerifyBackend:
         model = "test-model"
+        fanout_concurrency = 4
 
         async def execute(
             self, cwd, prompt, output_schema=None, continuation=None, agents=None,

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -268,6 +268,8 @@ async def test_pr_feedback_banner_echoes_resolved_backend_model(
     work = _fake_work(tmp_path)
 
     class _StubBackend:
+        fanout_concurrency = 4
+
         def __init__(self, model: str):
             self.model = model
 
@@ -378,6 +380,8 @@ async def test_run_loop_shallow_heal_hero_followed_by_model_line(
     # Stub backends to carry distinct phase-specific models so the dim line's
     # source is unambiguous.
     class _StubBackend:
+        fanout_concurrency = 4
+
         def __init__(self, model: str):
             self.model = model
 
@@ -474,6 +478,8 @@ async def test_shallow_items_canonicalized_and_severity_ordered(monkeypatch, tmp
     work = _fake_work(tmp_path)
 
     class _StubBackend:
+        fanout_concurrency = 4
+
         def __init__(self, model: str):
             self.model = model
 
@@ -597,6 +603,7 @@ async def test_non_interactive_shallow_calls_phase_commit_push_auto(monkeypatch,
 
     class _StubBackend:
         model = "stub-model"
+        fanout_concurrency = 4
 
     monkeypatch.setattr(
         "daydream.runner._resolve_backend",
@@ -694,6 +701,7 @@ async def test_non_interactive_shallow_failing_tests_write_handoff_no_fix(monkey
 
     class _StubBackend:
         model = "stub-model"
+        fanout_concurrency = 4
 
     def _resolve(_config, phase, _cache=None):
         return test_backend if phase == "test" else _StubBackend()
@@ -811,6 +819,7 @@ async def test_yes_shallow_failing_tests_bounded_fix_and_abort(monkeypatch, tmp_
 
     class _StubBackend:
         model = "stub-model"
+        fanout_concurrency = 4
 
     def _resolve(_config, phase, _cache=None):
         return test_backend if phase == "test" else _StubBackend()


### PR DESCRIPTION
## Summary

- Adds retry/backoff handling for transient Pi backend 429/overload failures and OOM/SIGKILL process kills.
- Ensures retry attempts reset partial run state so failed-attempt output does not leak into final results.
- Lowers Pi deep-review fanout concurrency while preserving higher default concurrency for other backends.

## Motivation

Closes #210.

The Pi backend can fail transiently under load with 429/overload turn-end errors or process kills. Retrying those failures with backoff improves backend reliability without retrying non-transient failures or sharing failed partial output with callers.

## Changes

### Added
- `PiError.retryable` metadata plus Pi retryability classifiers for transient message patterns and OOM/SIGKILL exit codes.
- Runtime retry configuration via `DAYDREAM_PI_RETRY_ATTEMPTS` and `DAYDREAM_PI_RETRY_BASE_DELAY_S`.
- Real-path retry, classifier, and fanout-concurrency test coverage.

### Changed
- `run_agent` now retries retryable backend execution failures with exponential backoff and jitter, resetting accumulated output/structured state per attempt.
- Backend protocol implementations expose `fanout_concurrency`; Pi uses a lower concurrency limit for deep review fanout.
- Retry cleanup avoids cancelling shared backend instances so sibling concurrent invocations are not terminated.

### Fixed
- Transient Pi 429/overload and OOM/SIGKILL failures no longer fail immediately when retry attempts remain.
- Invalid Pi retry environment values fall back safely with warnings.

## Test Plan

- [x] `uv run python -m pytest tests/test_agent_retry.py tests/test_backend_pi.py tests/test_deep_fanout.py -x -q` — PASS (`76 passed, 1 skipped`).
- [x] `make check` — PASS; ruff passed, mypy passed, pytest `1785 passed, 3 skipped`.
- [x] Pre-push hook passed on branch push per Beagle ground truth: lint, mypy, and test suite (`1764 passed, 3 skipped`).

## Checklist

- [x] Tests pass locally (`uv run pytest` via `make check`)
- [x] Linting passes (`uv run ruff check` via `make check`)
- [x] Type checking passes (`uv run mypy daydream` via `make check`)
- [x] Documentation updated (if applicable)
