### PR TITLE
feat: batch same-file findings into single run_agent() call

### DIFF
--- a/daydream/exploration_runner.py
+++ b/daydream/exploration_runner.py
@@ -48,9 +48,9 @@ _DIFF_HEADER_RE = re.compile(r"^diff --git a/(.+) b/", re.MULTILINE)
 
 _SPECIALIST_TIMEOUT_SECONDS = 300  # 5 minutes
 
-# Cap subagents at 15 turns: on large repos they otherwise exhaust their
+# Cap subagents at 50 turns: on large repos they otherwise exhaust their
 # context window and lose track of the task (D-06 graceful degradation).
-EXPLORATION_MAX_TURNS = 15
+EXPLORATION_MAX_TURNS = 50
 
 
 EXPLORATION_ENVELOPE_SCHEMA: dict[str, Any] = {

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -1901,27 +1901,47 @@ async def phase_fix_batched(
         )
         return
 
+    # Items with no file cannot be meaningfully batched under a shared file
+    # header — "<no-file>" is not a real path.  Delegate each one individually
+    # to phase_fix (which already handles the unknown-file case correctly).
+    if not items[0].get("file"):
+        for item, item_num in zip(items, item_nums):
+            await phase_fix(
+                backend, work, item, item_num, total,
+                console_lock=console_lock, intent_path=intent_path,
+            )
+        return
+
     count = len(items)
-    file_path = items[0].get("file", "Unknown file")
-    resolved = work.repo / file_path
-    file_ref = str(resolved) if resolved.is_file() else file_path
+    file_path = items[0].get("file") or "Unknown file"
+    resolved = work.repo / file_path if file_path != "Unknown file" else None
+    file_ref = str(resolved) if resolved is not None and resolved.is_file() else file_path
 
     async with (console_lock if console_lock is not None else anyio.Lock()):
         console.print()
-        print_fix_progress(console, item_nums[0], total, f"{count} findings in {file_path}")
+        for item_num, item in zip(item_nums, items):
+            desc = item.get("description", "No description")
+            print_fix_progress(console, item_num, total, desc)
 
     findings_block = ""
     for idx, item in enumerate(items, start=1):
         desc = item.get("description", "No description")
         line = item.get("line", "Unknown")
         findings_block += f"\n{idx}. {desc}\n   File: {file_ref}\n   Line: {line}\n"
-        findings_block += _build_verifier_suffix(item)
 
     prompt = f"""Fix these {count} issues in {file_ref}:
 {findings_block}
 Make the minimal changes needed to address ALL of the above findings in one coherent patch. {_FIX_GUARDRAILS}"""
 
     prompt += _build_intent_suffix(intent_path)
+    for item in items:
+        prompt += _build_verifier_suffix(item)
+
+    # Scale budgets linearly with the number of findings so a batched group of N
+    # findings gets the same per-finding headroom as a single-finding turn.
+    scaled_max_turns = FIX_MAX_TURNS * count
+    scaled_tool_budget = DEFAULT_TOOL_CALL_BUDGET * count
+    scaled_wall_budget = DEFAULT_WALL_BUDGET_S * count
 
     if console_lock is not None:
         # Concurrent path: suppress the Live renderer in run_agent and serialize
@@ -1930,22 +1950,29 @@ Make the minimal changes needed to address ALL of the above findings in one cohe
             async with console_lock:
                 console.print(text)
 
-        await run_agent(
+        _, _, budget_reason = await run_agent(
             backend, work.repo, prompt,
-            phase=DaydreamPhase.FIX, max_turns=FIX_MAX_TURNS,
-            tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
-            wall_budget_s=DEFAULT_WALL_BUDGET_S,
+            phase=DaydreamPhase.FIX, max_turns=scaled_max_turns,
+            tool_call_budget=scaled_tool_budget,
+            wall_budget_s=scaled_wall_budget,
             progress_callback=_cb,
         )
     else:
-        await run_agent(
+        _, _, budget_reason = await run_agent(
             backend, work.repo, prompt,
-            phase=DaydreamPhase.FIX, max_turns=FIX_MAX_TURNS,
-            tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
-            wall_budget_s=DEFAULT_WALL_BUDGET_S,
+            phase=DaydreamPhase.FIX, max_turns=scaled_max_turns,
+            tool_call_budget=scaled_tool_budget,
+            wall_budget_s=scaled_wall_budget,
+        )
+
+    if budget_reason is not None:
+        raise RuntimeError(
+            f"Batched fix turn budget exhausted ({budget_reason}); "
+            f"falling back to per-finding fixes for {file_ref}"
         )
     async with (console_lock if console_lock is not None else anyio.Lock()):
-        print_fix_complete(console, item_nums[-1], total)
+        for item_num in item_nums:
+            print_fix_complete(console, item_num, total)
 
 
 async def phase_fix_parallel(
@@ -2021,6 +2048,18 @@ async def phase_fix_parallel(
                                     intent_path=intent_path,
                                 )
                             except Exception:  # noqa: BLE001 -- batched failure falls back to per-finding fixes
+                                # Restore the file to HEAD before falling back so
+                                # per-finding fixes don't re-apply partial edits
+                                # that the batched turn may have already written.
+                                if fkey and fkey != "<no-file>":
+                                    try:
+                                        git_ops.checkout_paths(work.repo, [Path(fkey)])
+                                    except Exception as _restore_err:  # noqa: BLE001 -- restore is best-effort; don't block fallback
+                                        if not get_quiet_mode():
+                                            print_warning(
+                                                console,
+                                                f"Could not restore {fkey} before fallback: {_restore_err}",
+                                            )
                                 for item, item_num in grp:
                                     await phase_fix(
                                         backend, work, item, item_num, total,

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -1682,6 +1682,103 @@ async def phase_verify_recommendations(
     return output_path, payload
 
 
+# Shared scope/precedence/contract guardrails appended to every fix prompt
+# (single-finding ``phase_fix`` and batched ``phase_fix_batched``). Kept in one
+# place so the two prompt paths can never drift.
+_FIX_GUARDRAILS = """Do NOT change error handling semantics
+(e.g., converting warn-and-continue to error propagation, or vice versa)
+unless the issue description specifically explains why the current error
+handling strategy is wrong for that code path.
+
+Anchor the change to what this finding names — the file/symbol/line above. Do
+NOT make gratuitous edits to adjacent fields, keys, or functions the fix does
+not require; naming one issue is not license to "tidy" its neighbours. If a
+correct fix genuinely requires an edit the finding didn't name — a caller that
+must change in step, or a file the review step missed — make it, but name and
+justify each out-of-scope edit in your commit message rather than expanding
+silently. If the change balloons far beyond the named site, stop and report.
+
+If this finding conflicts with an explicit in-code contract — a JSON schema, a
+type signature, or a comment documenting intent — the contract wins (unless
+confirmed author intent below overrides it). Do not override documented intent
+to satisfy the finding; note the conflict in your commit message (or report
+inability to fix). Treat low/medium-confidence findings with extra skepticism
+here.
+"""
+
+
+def _build_intent_suffix(intent_path: Path | None) -> str:
+    """Build the confirmed-author-intent block for a fix prompt.
+
+    Best-effort enrichment: a missing or unreadable intent file yields an empty
+    string so an intent-read failure can never block a fix. A read failure is
+    never coerced into a fake intent string.
+
+    Args:
+        intent_path: Optional path to the confirmed author-intent file.
+
+    Returns:
+        The intent block (with leading newline) when present and readable;
+        otherwise an empty string.
+    """
+    if intent_path is None or not intent_path.exists():
+        return ""
+    try:
+        confirmed_intent = intent_path.read_text()
+    except OSError:
+        return ""
+    if not (confirmed_intent and confirmed_intent.strip()):
+        return ""
+    return (
+        "\nCONFIRMED AUTHOR INTENT for this change (authoritative):\n"
+        f"{confirmed_intent.strip()}\n\n"
+        "This confirmed intent is the highest-priority authority: it outranks both "
+        "the in-code-contract rule above and the finding itself. "
+        "If applying this fix would undo, revert, or contradict a decision the "
+        "confirmed intent describes as deliberate, do NOT apply it. Report the "
+        "conflict in your commit message (or report inability to fix) instead of "
+        "overriding the author's deliberate choice.\n"
+    )
+
+
+def _build_verifier_suffix(item: dict[str, Any]) -> str:
+    """Build the recommendation-verifier block for one finding.
+
+    Mirrors the single-finding verdict/evidence/assumptions text so batched and
+    single-finding prompts carry identical per-finding verifier guidance.
+
+    Args:
+        item: Feedback item, optionally carrying ``verifier_verdict``,
+            ``evidence``, and ``unverified_assumptions``.
+
+    Returns:
+        The verifier block (with leading newline) when a verdict is present;
+        otherwise an empty string.
+    """
+    verifier_verdict = item.get("verifier_verdict")
+    if not verifier_verdict:
+        return ""
+    evidence = item.get("evidence", "")
+    out = f"\nVerifier verdict: {verifier_verdict}. Evidence: {evidence}.\n"
+    assumptions = item.get("unverified_assumptions") or []
+    if isinstance(assumptions, list) and assumptions:
+        joined = "; ".join(str(a) for a in assumptions)
+        out += f"Unverified assumptions: {joined}.\n"
+    if verifier_verdict == "contradicts":
+        out += (
+            "\nDo NOT apply the recommendation literally if it contradicts the cited spec.\n"
+            "Explain the conflict in your commit message and choose a fix that preserves\n"
+            "the spec, or stop and report inability to fix.\n"
+        )
+    elif verifier_verdict == "uncertain":
+        out += (
+            "\nThe verifier could not confirm whether this recommendation is correct.\n"
+            "Proceed cautiously: apply the minimal fix and note the uncertainty in your\n"
+            "commit message.\n"
+        )
+    return out
+
+
 async def phase_fix(
     backend: Backend,
     work: WorkContext,
@@ -1729,69 +1826,13 @@ async def phase_fix(
 File: {file_ref}
 Line: {line}
 
-Make the minimal change needed. Do NOT change error handling semantics
-(e.g., converting warn-and-continue to error propagation, or vice versa)
-unless the issue description specifically explains why the current error
-handling strategy is wrong for that code path.
-
-Anchor the change to what this finding names — the file/symbol/line above. Do
-NOT make gratuitous edits to adjacent fields, keys, or functions the fix does
-not require; naming one issue is not license to "tidy" its neighbours. If a
-correct fix genuinely requires an edit the finding didn't name — a caller that
-must change in step, or a file the review step missed — make it, but name and
-justify each out-of-scope edit in your commit message rather than expanding
-silently. If the change balloons far beyond the named site, stop and report.
-
-If this finding conflicts with an explicit in-code contract — a JSON schema, a
-type signature, or a comment documenting intent — the contract wins (unless
-confirmed author intent below overrides it). Do not override documented intent
-to satisfy the finding; note the conflict in your commit message (or report
-inability to fix). Treat low/medium-confidence findings with extra skepticism
-here.
-"""
+Make the minimal change needed. {_FIX_GUARDRAILS}"""
 
     # Best-effort: inject the confirmed author intent so the fixer won't undo a
-    # deliberate decision. Guarded on .exists() and wrapped so an intent-read
-    # failure NEVER blocks or crashes a fix (deliberate deviation from strict
-    # propagation). A read failure skips the block; it is never coerced into a
-    # fake intent string.
-    if intent_path is not None and intent_path.exists():
-        try:
-            confirmed_intent = intent_path.read_text()
-        except OSError:
-            confirmed_intent = None
-        if confirmed_intent and confirmed_intent.strip():
-            prompt += (
-                "\nCONFIRMED AUTHOR INTENT for this change (authoritative):\n"
-                f"{confirmed_intent.strip()}\n\n"
-                "This confirmed intent is the highest-priority authority: it outranks both "
-                "the in-code-contract rule above and the finding itself. "
-                "If applying this fix would undo, revert, or contradict a decision the "
-                "confirmed intent describes as deliberate, do NOT apply it. Report the "
-                "conflict in your commit message (or report inability to fix) instead of "
-                "overriding the author's deliberate choice.\n"
-            )
-
-    verifier_verdict = item.get("verifier_verdict")
-    if verifier_verdict:
-        evidence = item.get("evidence", "")
-        prompt += f"\nVerifier verdict: {verifier_verdict}. Evidence: {evidence}.\n"
-        assumptions = item.get("unverified_assumptions") or []
-        if isinstance(assumptions, list) and assumptions:
-            joined = "; ".join(str(a) for a in assumptions)
-            prompt += f"Unverified assumptions: {joined}.\n"
-        if verifier_verdict == "contradicts":
-            prompt += (
-                "\nDo NOT apply the recommendation literally if it contradicts the cited spec.\n"
-                "Explain the conflict in your commit message and choose a fix that preserves\n"
-                "the spec, or stop and report inability to fix.\n"
-            )
-        elif verifier_verdict == "uncertain":
-            prompt += (
-                "\nThe verifier could not confirm whether this recommendation is correct.\n"
-                "Proceed cautiously: apply the minimal fix and note the uncertainty in your\n"
-                "commit message.\n"
-            )
+    # deliberate decision. A read failure skips the block; it is never coerced
+    # into a fake intent string (see _build_intent_suffix).
+    prompt += _build_intent_suffix(intent_path)
+    prompt += _build_verifier_suffix(item)
 
     if console_lock is not None:
         # Concurrent path: suppress the Live/LiveToolPanelRegistry renderer in
@@ -1820,6 +1861,93 @@ here.
         print_fix_complete(console, item_num, total)
 
 
+async def phase_fix_batched(
+    backend: Backend,
+    work: WorkContext,
+    items: list[dict[str, Any]],
+    item_nums: list[int],
+    total: int,
+    *,
+    console_lock: anyio.Lock | None = None,
+    intent_path: Path | None = None,
+) -> None:
+    """Phase 3 (batched): Apply all findings for ONE file in a single fix turn.
+
+    All ``items`` must target the same file; the caller (``phase_fix_parallel``)
+    groups them with ``group_items_by_file``. Batching collapses N per-finding
+    ``run_agent`` calls into one so the agent reads the file's context once and
+    produces a single coherent patch. A single-item group delegates straight to
+    ``phase_fix`` — there is no batched prompt to build.
+
+    Args:
+        backend: The Backend to execute against.
+        work: Workspace context for the fix; ``work.repo`` is the agent cwd.
+        items: Feedback items, all targeting the same file.
+        item_nums: 1-based progress counters aligned with ``items``.
+        total: Total number of items across the whole fix run.
+        console_lock: Optional lock to serialize console writes across concurrent
+            callers. Pass the same lock to every concurrent invocation; leave
+            ``None`` for serial callers.
+        intent_path: Optional path to the confirmed author-intent file, injected
+            verbatim (same best-effort handling as ``phase_fix``).
+
+    Returns:
+        None
+    """
+    if len(items) == 1:
+        await phase_fix(
+            backend, work, items[0], item_nums[0], total,
+            console_lock=console_lock, intent_path=intent_path,
+        )
+        return
+
+    count = len(items)
+    file_path = items[0].get("file", "Unknown file")
+    resolved = work.repo / file_path
+    file_ref = str(resolved) if resolved.is_file() else file_path
+
+    async with (console_lock if console_lock is not None else anyio.Lock()):
+        console.print()
+        print_fix_progress(console, item_nums[0], total, f"{count} findings in {file_path}")
+
+    findings_block = ""
+    for idx, item in enumerate(items, start=1):
+        desc = item.get("description", "No description")
+        line = item.get("line", "Unknown")
+        findings_block += f"\n{idx}. {desc}\n   File: {file_ref}\n   Line: {line}\n"
+        findings_block += _build_verifier_suffix(item)
+
+    prompt = f"""Fix these {count} issues in {file_ref}:
+{findings_block}
+Make the minimal changes needed to address ALL of the above findings in one coherent patch. {_FIX_GUARDRAILS}"""
+
+    prompt += _build_intent_suffix(intent_path)
+
+    if console_lock is not None:
+        # Concurrent path: suppress the Live renderer in run_agent and serialize
+        # progress lines through the shared lock (see phase_fix).
+        async def _cb(text: Text) -> None:
+            async with console_lock:
+                console.print(text)
+
+        await run_agent(
+            backend, work.repo, prompt,
+            phase=DaydreamPhase.FIX, max_turns=FIX_MAX_TURNS,
+            tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
+            wall_budget_s=DEFAULT_WALL_BUDGET_S,
+            progress_callback=_cb,
+        )
+    else:
+        await run_agent(
+            backend, work.repo, prompt,
+            phase=DaydreamPhase.FIX, max_turns=FIX_MAX_TURNS,
+            tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
+            wall_budget_s=DEFAULT_WALL_BUDGET_S,
+        )
+    async with (console_lock if console_lock is not None else anyio.Lock()):
+        print_fix_complete(console, item_nums[-1], total)
+
+
 async def phase_fix_parallel(
     backend: Backend,
     work: WorkContext,
@@ -1831,11 +1959,13 @@ async def phase_fix_parallel(
     """Phase 3 (parallel): Apply fixes file-partitioned and concurrently.
 
     Items are grouped by ``file`` (preserving the caller's severity ordering).
-    Each file-group becomes one task that applies its items serially, while
-    distinct files run concurrently under an ``anyio.CapacityLimiter``. Same-file
-    serialization prevents concurrent writes to the *same named file*; it does
-    not guarantee disjoint edits if an agent touches files other than the one
-    named in the item's ``file`` key. Commit stays serial and after.
+    Each file-group becomes one task whose findings are fixed together in a
+    single ``phase_fix_batched`` call (one ``run_agent`` turn per file), while
+    distinct files run concurrently under an ``anyio.CapacityLimiter``. If the
+    batched turn raises, the group falls back to per-finding ``phase_fix`` calls.
+    Same-file serialization prevents concurrent writes to the *same named file*;
+    it does not guarantee disjoint edits if an agent touches files other than the
+    one named in the item's ``file`` key. Commit stays serial and after.
 
     Args:
         backend: The Backend to execute against (shared across tasks).
@@ -1843,7 +1973,7 @@ async def phase_fix_parallel(
         items: Feedback items, already severity-sorted by the caller.
         limiter_size: Max number of file-groups to fix concurrently.
         intent_path: Optional confirmed-intent file forwarded unchanged to each
-            ``phase_fix`` call so every fix carries the deliberate-intent guard.
+            fix call so every fix carries the deliberate-intent guard.
 
     Returns:
         ``failures``: file -> "<ExceptionType>: <message>" for file-groups whose
@@ -1882,12 +2012,21 @@ async def phase_fix_parallel(
                 async with limiter:
                     async with maybe_fork(recorder, f"fix-{_fkey_slug}"):
                         try:
-                            for item, item_num in grp:
-                                await phase_fix(
-                                    backend, work, item, item_num, total,
+                            grp_items = [item for item, _ in grp]
+                            grp_nums = [num for _, num in grp]
+                            try:
+                                await phase_fix_batched(
+                                    backend, work, grp_items, grp_nums, total,
                                     console_lock=_console_lock,
                                     intent_path=intent_path,
                                 )
+                            except Exception:  # noqa: BLE001 -- batched failure falls back to per-finding fixes
+                                for item, item_num in grp:
+                                    await phase_fix(
+                                        backend, work, item, item_num, total,
+                                        console_lock=_console_lock,
+                                        intent_path=intent_path,
+                                    )
                         except Exception as e:  # noqa: BLE001 -- intentionally broad for parallel isolation
                             reason = f"{type(e).__name__}: {e}"
                             async with _failures_lock:

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -1934,8 +1934,10 @@ async def phase_fix_batched(
 Make the minimal changes needed to address ALL of the above findings in one coherent patch. {_FIX_GUARDRAILS}"""
 
     prompt += _build_intent_suffix(intent_path)
-    for item in items:
-        prompt += _build_verifier_suffix(item)
+    for idx, item in enumerate(items, start=1):
+        verifier_suffix = _build_verifier_suffix(item)
+        if verifier_suffix:
+            prompt += f"\nVerifier guidance for finding {idx}:{verifier_suffix}"
 
     # Scale budgets linearly with the number of findings so a batched group of N
     # findings gets the same per-finding headroom as a single-finding turn.
@@ -2041,17 +2043,28 @@ async def phase_fix_parallel(
                         try:
                             grp_items = [item for item, _ in grp]
                             grp_nums = [num for _, num in grp]
-                            try:
-                                await phase_fix_batched(
-                                    backend, work, grp_items, grp_nums, total,
-                                    console_lock=_console_lock,
-                                    intent_path=intent_path,
-                                )
-                            except Exception:  # noqa: BLE001 -- batched failure falls back to per-finding fixes
-                                # Restore the file to HEAD before falling back so
-                                # per-finding fixes don't re-apply partial edits
-                                # that the batched turn may have already written.
-                                if fkey and fkey != "<no-file>":
+                            is_real_batch = len(grp_items) > 1 and fkey != "<no-file>"
+                            if not is_real_batch:
+                                # Single-item or <no-file> groups: go straight to
+                                # per-finding phase_fix (no batched prompt to build,
+                                # no fallback retry on failure).
+                                for item, item_num in grp:
+                                    await phase_fix(
+                                        backend, work, item, item_num, total,
+                                        console_lock=_console_lock,
+                                        intent_path=intent_path,
+                                    )
+                            else:
+                                try:
+                                    await phase_fix_batched(
+                                        backend, work, grp_items, grp_nums, total,
+                                        console_lock=_console_lock,
+                                        intent_path=intent_path,
+                                    )
+                                except Exception:  # noqa: BLE001 -- batched failure falls back to per-finding fixes
+                                    # Restore the file to HEAD before falling back so
+                                    # per-finding fixes don't re-apply partial edits
+                                    # that the batched turn may have already written.
                                     try:
                                         git_ops.checkout_paths(work.repo, [Path(fkey)])
                                     except Exception as _restore_err:  # noqa: BLE001 -- restore is best-effort; don't block fallback
@@ -2060,12 +2073,12 @@ async def phase_fix_parallel(
                                                 console,
                                                 f"Could not restore {fkey} before fallback: {_restore_err}",
                                             )
-                                for item, item_num in grp:
-                                    await phase_fix(
-                                        backend, work, item, item_num, total,
-                                        console_lock=_console_lock,
-                                        intent_path=intent_path,
-                                    )
+                                    for item, item_num in grp:
+                                        await phase_fix(
+                                            backend, work, item, item_num, total,
+                                            console_lock=_console_lock,
+                                            intent_path=intent_path,
+                                        )
                         except Exception as e:  # noqa: BLE001 -- intentionally broad for parallel isolation
                             reason = f"{type(e).__name__}: {e}"
                             async with _failures_lock:

--- a/tests/harness/phase_backend.py
+++ b/tests/harness/phase_backend.py
@@ -120,7 +120,7 @@ class PhaseDispatchBackend:
             self._parse_call += 1
             yield TextEvent(text="Parsed.")
             yield ResultEvent(structured_output={"issues": issues}, continuation=None)
-        elif "fix this issue" in prompt_lower:
+        elif "fix this issue" in prompt_lower or prompt_lower.startswith("fix these"):
             yield TextEvent(text="Fixed.")
             yield ResultEvent(structured_output=None, continuation=None)
         elif "test suite" in prompt_lower or "run the project" in prompt_lower:

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -3111,7 +3111,7 @@ async def test_run_batches_same_file_findings_into_one_fix_turn(
         RunConfig(target=str(multi_stack_target), assume="yes", output_mode="loop", cleanup=False)
     )
 
-    assert isinstance(exit_code, int)
+    assert exit_code == 0
 
     fix_prompts = [
         c["prompt"]

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -331,7 +331,7 @@ class _StubBackend:
 
         # phase_fix -> "apply" the edit by writing a sentinel file, the observable
         # consequence the --yes real-path test asserts the fix gate auto-approved.
-        if pl.startswith("fix this issue"):
+        if pl.startswith("fix this issue") or pl.startswith("fix these"):
             if self.runaway_fix:
                 # Emit a long burst of tool calls and NEVER a ResultEvent. A
                 # generator that never returns models the 1.5-5h time-tail the
@@ -340,7 +340,11 @@ class _StubBackend:
                     yield ToolStartEvent(id=f"tc-{n}", name="Bash", input={"command": "find /"})
                     await anyio.sleep(self.runaway_fix_sleep_s)
                 return
+            # Single-finding prompts carry "File: <path>"; batched prompts name the
+            # one target file in their "Fix these N issues in <path>:" header.
             m = re.search(r"^File: (.+)$", prompt, re.M)
+            if m is None:
+                m = re.search(r"^Fix these \d+ issues in (.+):$", prompt, re.M)
             fixed_file = m.group(1).strip() if m else "unknown"
             # phase_fix emits an absolute path when the file exists on disk; the stub keys fixes by basename.
             fixed_name = Path(fixed_file).name
@@ -357,10 +361,13 @@ class _StubBackend:
             (cwd / ".daydream-fix-applied").write_text("applied\n")  # legacy sentinel
             (cwd / f".fixed-{fixed_name.replace('.', '_')}").write_text("applied\n")
             if self.fix_append_path is not None and fixed_name == self.fix_append_path.name:
-                tok = re.search(r"marker-\d+", prompt)
+                # A batched fix turn addresses EVERY finding it is handed, so append
+                # each marker the prompt names (in prompt/severity order), not just
+                # the first. A single-finding prompt names exactly one marker.
+                toks = re.findall(r"marker-\d+", prompt) or ["?"]
                 cur = self.fix_append_path.read_text() if self.fix_append_path.exists() else ""
                 await anyio.sleep(0)  # deterministic interleave point
-                self.fix_append_path.write_text(cur + (tok.group(0) if tok else "?") + "\n")
+                self.fix_append_path.write_text(cur + "".join(t + "\n" for t in toks))
             yield TextEvent(text="Applied the fix.")
             yield ResultEvent(structured_output=None, continuation=None)
             return
@@ -621,15 +628,11 @@ async def test_parallel_fix_applies_all_disjoint_files(
 async def test_parallel_fix_same_file_no_race(
     multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """3 items on ONE file (read-modify-write append) + 1 on another. Correct
-    per-file serialization keeps all markers in severity order; a per-ITEM
-    fan-out would lose/interleave appends (the anyio.sleep(0) makes that race
-    deterministic).
-
-    Discrimination validated: temporarily fanning out ``phase_fix_parallel``
-    per item (one task per item) makes this FAIL -- the racing read-modify-write
-    append + anyio.sleep(0) drops/reorders markers in shared.py; the correct
-    per-file-group serialization keeps them ordered. Reverting restores PASS.
+    """3 items on ONE file + 1 on another. The 3 same-file findings collapse into
+    ONE batched fix turn that addresses every marker in severity order, while the
+    other file's group runs concurrently. The read-modify-write append +
+    anyio.sleep(0) makes any cross-file race deterministic; per-file partitioning
+    keeps shared.py's markers ordered and intact.
     """
     from daydream.runner import RunConfig, run
 
@@ -847,7 +850,9 @@ INTENT_SENTINEL = "SKIP_IF_NO_QUERY_IS_A_DELIBERATE_GUARD"
 
 
 def _fix_prompts(stub: _StubBackend) -> list[str]:
-    return [c["prompt"] for c in stub.calls if c["prompt"].startswith("Fix this issue")]
+    # Same-file findings are batched into one "Fix these N issues" turn; a lone
+    # finding still uses the single-finding "Fix this issue" prompt. Match both.
+    return [c["prompt"] for c in stub.calls if c["prompt"].startswith(("Fix this issue", "Fix these"))]
 
 
 async def test_confirmed_intent_reaches_fix_prompt(
@@ -2262,7 +2267,13 @@ async def test_verifier_contradicts_propagates_to_fix_prompt(
     exit_code = await _run_deep(multi_stack_target)
     assert exit_code == 0
 
-    fix_prompts = [c["prompt"] for c in stub.calls if c["prompt"].lower().startswith("fix this issue:")]
+    # api.py carries two same-file findings, so its fix turn is batched
+    # ("Fix these N issues"); the verdict for id=1 rides in that batched prompt.
+    fix_prompts = [
+        c["prompt"]
+        for c in stub.calls
+        if c["prompt"].lower().startswith(("fix this issue:", "fix these"))
+    ]
     assert fix_prompts, "no fix prompt dispatched -- fix loop did not run"
     assert any("Verifier verdict: contradicts" in p for p in fix_prompts), (
         "contradicts verdict did not propagate into the fix prompt; "
@@ -2396,8 +2407,11 @@ async def test_structural_finding_reaches_fix_loop(
 
     fixed: list[dict[str, Any]] = []
 
-    async def _capture_fix(backend, work, item, idx, total, **kwargs):  # noqa: ARG001
-        fixed.append(item)
+    # Capture at the batched dispatch point: phase_fix_parallel now hands every
+    # file-group (single- or multi-item) to phase_fix_batched, so this is where
+    # every item that reaches the fix loop is observable.
+    async def _capture_fix(backend, work, items, item_nums, total, **kwargs):  # noqa: ARG001
+        fixed.extend(items)
 
     async def _stub_test(backend, work, feedback_items=None):  # noqa: ARG001
         return (True, 0)
@@ -2408,7 +2422,7 @@ async def test_structural_finding_reaches_fix_loop(
     async def _no_post(target_dir: Path, report_path: Path, *, console: Any) -> None:
         return None
 
-    monkeypatch.setattr("daydream.phases.phase_fix", _capture_fix)
+    monkeypatch.setattr("daydream.phases.phase_fix_batched", _capture_fix)
     monkeypatch.setattr("daydream.deep.orchestrator.phase_test_and_heal", _stub_test)
     monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _stub_commit)
     monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _no_post)
@@ -3061,6 +3075,66 @@ async def test_run_terminates_under_wall_budget(
     assert "wall_budget_exceeded" in stop_reasons
 
 
+async def test_run_batches_same_file_findings_into_one_fix_turn(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#202 real-path: N findings on ONE file collapse to a single FIX run_agent turn.
+
+    Driven through the real ``runner.run`` -> deep orchestrator ->
+    ``phase_fix_parallel`` -> ``phase_fix_batched`` -> ``run_agent`` path. Several
+    findings target api.py and one targets App.tsx, so the fix stage must issue
+    exactly TWO fix turns (one batched per file-group), never one-per-finding.
+    The batched api.py turn carries a single "Fix these N issues" prompt naming
+    every same-file finding, and still lands the per-file sentinel.
+
+    Discriminating: a per-finding loop (the pre-#202 state) issues one fix turn
+    PER finding, so the fix-prompt count balloons past two and no single batched
+    "Fix these N issues" prompt exists -- both assertions fail.
+    """
+    import re
+
+    from daydream.runner import RunConfig, run
+
+    _silence(monkeypatch)
+    _force_interactive(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    stub.merge_items = [
+        _merge_item(1, "api.py", "high"),
+        _merge_item(2, "api.py", "medium"),
+        _merge_item(3, "api.py", "low"),
+        _merge_item(4, "App.tsx", "high"),
+    ]
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_test_and_heal", lambda *a, **k: _ok())
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _noop_commit)
+
+    exit_code = await run(
+        RunConfig(target=str(multi_stack_target), assume="yes", output_mode="loop", cleanup=False)
+    )
+
+    assert isinstance(exit_code, int)
+
+    fix_prompts = [
+        c["prompt"]
+        for c in stub.calls
+        if c["prompt"].lower().startswith(("fix this issue", "fix these"))
+    ]
+    # Two file-groups -> two fix turns, regardless of how many findings each holds
+    # (the pre-#202 per-finding loop would emit one turn per finding instead).
+    assert len(fix_prompts) == 2
+    batched = [p for p in fix_prompts if p.lower().startswith("fix these")]
+    singles = [p for p in fix_prompts if p.lower().startswith("fix this issue")]
+    assert len(batched) == 1 and len(singles) == 1
+    # The batched api.py turn collapses all three of my api.py findings (the host
+    # may add a structural finding to the same file, so assert >= 3) into one turn.
+    m = re.search(r"^Fix these (\d+) issues in (.+):$", batched[0], re.M)
+    assert m is not None
+    assert int(m.group(1)) >= 3
+    assert Path(m.group(2)).name == "api.py"
+    # The batched turn still lands its per-file sentinel (observable apply).
+    assert (multi_stack_target / ".fixed-api_py").exists()
+    assert (multi_stack_target / ".fixed-App_tsx").exists()
+
+
 async def test_environmental_failure_aborts_heal_loop(
     multi_stack_target: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -3671,7 +3745,7 @@ async def test_ac_fix_resume_on_tiny_diff(
         RunConfig(target=str(tiny_diff_target), start_at="fix", assume="yes", cleanup=False)
     )
     assert rc == 0
-    fix_prompts = [c for c in stub.calls if c["prompt"].startswith("Fix this issue")]
+    fix_prompts = [c for c in stub.calls if c["prompt"].startswith(("Fix this issue", "Fix these"))]
     assert fix_prompts, "fix loop did not run on --start-at fix resume"
 
 

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -3,11 +3,14 @@
 
 import json
 import subprocess
+from collections.abc import AsyncIterator
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from daydream.backends import (
+    AgentEvent,
     ContinuationToken,
     ResultEvent,
     TextEvent,
@@ -386,9 +389,15 @@ class _CapturingBatchBackend:
         self.prompts: list[str] = []
 
     async def execute(
-        self, cwd, prompt, output_schema=None, continuation=None, agents=None,
-        max_turns=None, read_only=False,
-    ):
+        self,
+        cwd: Path,
+        prompt: str,
+        output_schema: dict[str, Any] | None = None,
+        continuation: ContinuationToken | None = None,
+        agents: dict[str, Any] | None = None,
+        max_turns: int | None = None,
+        read_only: bool = False,
+    ) -> AsyncIterator[AgentEvent]:
         self.prompts.append(prompt)
         yield ResultEvent(structured_output=None, continuation=None)
 

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -3363,24 +3363,28 @@ async def test_phase_fix_parallel_calls_count_serial_per_file_and_collects_failu
 
     from daydream import phases
 
-    active_files, order = set(), []
+    active_files, batched_calls, fix_calls = set(), [], []
 
     async def _fake_batched(backend, work, items, item_nums, total, **kwargs):
         f = items[0]["file"]
-        if f == "boom.py":
-            raise RuntimeError("kaboom")
+        batched_calls.append(f)
         assert f not in active_files, "two concurrent fixes on the same file"
         active_files.add(f)
-        order.append(f)  # one batched call per file-group
         await anyio.sleep(0)  # force interleave window
         active_files.discard(f)
 
-    async def _fail_fix(backend, work, item, item_num, total, **kwargs):
-        # Fallback for the failing batched group: also raise so the failure surfaces.
-        raise RuntimeError("kaboom")
+    async def _fake_fix(backend, work, item, item_num, total, **kwargs):
+        f = item["file"]
+        if f == "boom.py":
+            raise RuntimeError("kaboom")
+        fix_calls.append(f)
+        assert f not in active_files, "two concurrent fixes on the same file"
+        active_files.add(f)
+        await anyio.sleep(0)  # force interleave window
+        active_files.discard(f)
 
     monkeypatch.setattr("daydream.phases.phase_fix_batched", _fake_batched)
-    monkeypatch.setattr("daydream.phases.phase_fix", _fail_fix)
+    monkeypatch.setattr("daydream.phases.phase_fix", _fake_fix)
     items = [
         {"id": 1, "file": "a.py"},
         {"id": 2, "file": "a.py"},
@@ -3388,6 +3392,8 @@ async def test_phase_fix_parallel_calls_count_serial_per_file_and_collects_failu
         {"id": 4, "file": "boom.py"},
     ]
     failures = await phases.phase_fix_parallel(object(), object(), items)
-    # One batched call per file-group (a.py's two findings are NOT two calls).
-    assert order.count("a.py") == 1 and order.count("b.py") == 1
+    # a.py has 2 findings -> one batched call. b.py and boom.py have 1 finding
+    # each -> direct phase_fix (no batched prompt, no fallback retry).
+    assert batched_calls == ["a.py"]
+    assert sorted(fix_calls) == ["b.py"]
     assert set(failures) == {"boom.py"} and "RuntimeError" in failures["boom.py"]

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -377,6 +377,194 @@ async def test_phase_fix_passes_turn_budget(tmp_path, monkeypatch, make_work):
     assert FIX_MAX_TURNS == 40
 
 
+class _CapturingBatchBackend:
+    """Backend that records every prompt it is handed (one per run_agent call)."""
+
+    model = "test-model"
+
+    def __init__(self) -> None:
+        self.prompts: list[str] = []
+
+    async def execute(
+        self, cwd, prompt, output_schema=None, continuation=None, agents=None,
+        max_turns=None, read_only=False,
+    ):
+        self.prompts.append(prompt)
+        yield ResultEvent(structured_output=None, continuation=None)
+
+    async def cancel(self):
+        pass
+
+    def format_skill_invocation(self, skill_key, args=""):
+        return f"/{skill_key}"
+
+
+def _silence_fix_output(monkeypatch):
+    monkeypatch.setattr("daydream.phases.print_fix_progress", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.phases.print_fix_complete", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.phases.console", type("C", (), {"print": lambda *a, **kw: None})())
+
+
+@pytest.mark.asyncio
+async def test_phase_fix_batched_prompt_lists_all_findings(tmp_path, monkeypatch, make_work):
+    """Multiple same-file findings collapse into ONE prompt listing every finding."""
+    from daydream.phases import phase_fix_batched
+
+    _silence_fix_output(monkeypatch)
+    backend = _CapturingBatchBackend()
+    items = [
+        {"id": 1, "description": "Off-by-one in loop bound", "file": "src/handler.py", "line": 42},
+        {"id": 2, "description": "Unchecked None deref", "file": "src/handler.py", "line": 88},
+        {"id": 3, "description": "Missing await on coroutine", "file": "src/handler.py", "line": 130},
+    ]
+
+    await phase_fix_batched(backend, make_work(tmp_path), items, [1, 2, 3], 3)
+
+    # One file-group -> exactly one run_agent call.
+    assert len(backend.prompts) == 1
+    prompt = backend.prompts[0]
+    # Every finding's description and line is present.
+    assert "Off-by-one in loop bound" in prompt
+    assert "Unchecked None deref" in prompt
+    assert "Missing await on coroutine" in prompt
+    assert "42" in prompt and "88" in prompt and "130" in prompt
+    # Batched framing.
+    assert "Fix these 3 issues" in prompt
+    assert "address ALL of the above findings in one coherent patch" in prompt
+    # Shared scope/precedence guardrails carried over from phase_fix.
+    assert "Anchor the change" in prompt
+    assert "the contract wins" in prompt
+
+
+@pytest.mark.asyncio
+async def test_phase_fix_batched_single_item_delegates_to_phase_fix(tmp_path, monkeypatch, make_work):
+    """A one-item group delegates to phase_fix instead of building a batched prompt."""
+    from daydream import phases
+
+    _silence_fix_output(monkeypatch)
+
+    calls: list[tuple[dict, int]] = []
+
+    async def _fake_fix(backend, work, item, item_num, total, **kwargs):
+        calls.append((item, item_num))
+
+    monkeypatch.setattr("daydream.phases.phase_fix", _fake_fix)
+    backend = _CapturingBatchBackend()
+    item = {"id": 1, "description": "Solo finding", "file": "src/handler.py", "line": 5}
+
+    await phases.phase_fix_batched(backend, make_work(tmp_path), [item], [7], 9)
+
+    assert len(calls) == 1
+    assert calls[0] == (item, 7)
+    # Delegation means no batched run_agent prompt was emitted.
+    assert backend.prompts == []
+
+
+@pytest.mark.asyncio
+async def test_phase_fix_batched_includes_verifier_verdicts(tmp_path, monkeypatch, make_work):
+    """Per-finding verifier verdict/evidence/assumptions reach the batched prompt."""
+    from daydream.phases import phase_fix_batched
+
+    _silence_fix_output(monkeypatch)
+    backend = _CapturingBatchBackend()
+    items = [
+        {
+            "id": 1,
+            "description": "First issue",
+            "file": "src/handler.py",
+            "line": 10,
+            "verifier_verdict": "contradicts",
+            "evidence": "the spec says otherwise",
+            "unverified_assumptions": ["assumes UTC timezone"],
+        },
+        {
+            "id": 2,
+            "description": "Second issue",
+            "file": "src/handler.py",
+            "line": 20,
+            "verifier_verdict": "uncertain",
+            "evidence": "could not reproduce",
+            "unverified_assumptions": ["assumes single-threaded"],
+        },
+    ]
+
+    await phase_fix_batched(backend, make_work(tmp_path), items, [1, 2], 2)
+
+    assert len(backend.prompts) == 1
+    prompt = backend.prompts[0]
+    assert "Verifier verdict: contradicts" in prompt
+    assert "the spec says otherwise" in prompt
+    assert "assumes UTC timezone" in prompt
+    assert "Verifier verdict: uncertain" in prompt
+    assert "could not reproduce" in prompt
+    assert "assumes single-threaded" in prompt
+
+
+@pytest.mark.asyncio
+async def test_phase_fix_parallel_batches_same_file_findings(monkeypatch):
+    """phase_fix_parallel calls phase_fix_batched once per file-group, never falls back."""
+    from daydream import phases
+
+    batched_calls: list[list[dict]] = []
+
+    async def _fake_batched(backend, work, items, item_nums, total, **kwargs):
+        batched_calls.append(items)
+
+    async def _fail_fix(*a, **kw):
+        raise AssertionError("phase_fix must not be called when batched succeeds")
+
+    monkeypatch.setattr("daydream.phases.phase_fix_batched", _fake_batched)
+    monkeypatch.setattr("daydream.phases.phase_fix", _fail_fix)
+    items = [
+        {"id": 1, "file": "a.py"},
+        {"id": 2, "file": "a.py"},
+        {"id": 3, "file": "a.py"},
+        {"id": 4, "file": "b.py"},
+        {"id": 5, "file": "b.py"},
+    ]
+
+    failures = await phases.phase_fix_parallel(object(), object(), items)
+
+    assert failures == {}
+    # Two file-groups -> two batched calls (NOT five per-finding calls).
+    assert len(batched_calls) == 2
+    grouped = sorted([[i["id"] for i in grp] for grp in batched_calls])
+    assert grouped == [[1, 2, 3], [4, 5]]
+
+
+@pytest.mark.asyncio
+async def test_phase_fix_parallel_falls_back_to_per_finding_on_batch_failure(monkeypatch):
+    """When the batched turn raises, the group retries each finding via phase_fix."""
+    from daydream import phases
+
+    fix_calls: list[int] = []
+
+    async def _flaky_batched(backend, work, items, item_nums, total, **kwargs):
+        if any(i["file"] == "boom.py" for i in items):
+            raise RuntimeError("batched kaboom")
+
+    async def _fake_fix(backend, work, item, item_num, total, **kwargs):
+        fix_calls.append(item["id"])
+
+    monkeypatch.setattr("daydream.phases.phase_fix_batched", _flaky_batched)
+    monkeypatch.setattr("daydream.phases.phase_fix", _fake_fix)
+    items = [
+        {"id": 1, "file": "ok.py"},
+        {"id": 2, "file": "ok.py"},
+        {"id": 3, "file": "boom.py"},
+        {"id": 4, "file": "boom.py"},
+    ]
+
+    failures = await phases.phase_fix_parallel(object(), object(), items)
+
+    # Fallback ran each finding in the failing group individually...
+    assert sorted(fix_calls) == [3, 4]
+    # ...and never touched the successful group.
+    assert 1 not in fix_calls and 2 not in fix_calls
+    # The fallback succeeded, so no failure was collected.
+    assert failures == {}
+
+
 class TestBuildFixPrompt:
     """Tests for _build_fix_prompt helper."""
 
@@ -3168,17 +3356,22 @@ async def test_phase_fix_parallel_calls_count_serial_per_file_and_collects_failu
 
     active_files, order = set(), []
 
-    async def _fake_fix(backend, work, item, item_num, total, **kwargs):
-        f = item["file"]
+    async def _fake_batched(backend, work, items, item_nums, total, **kwargs):
+        f = items[0]["file"]
         if f == "boom.py":
             raise RuntimeError("kaboom")
         assert f not in active_files, "two concurrent fixes on the same file"
         active_files.add(f)
-        order.append(item["id"])
+        order.append(f)  # one batched call per file-group
         await anyio.sleep(0)  # force interleave window
         active_files.discard(f)
 
-    monkeypatch.setattr("daydream.phases.phase_fix", _fake_fix)
+    async def _fail_fix(backend, work, item, item_num, total, **kwargs):
+        # Fallback for the failing batched group: also raise so the failure surfaces.
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr("daydream.phases.phase_fix_batched", _fake_batched)
+    monkeypatch.setattr("daydream.phases.phase_fix", _fail_fix)
     items = [
         {"id": 1, "file": "a.py"},
         {"id": 2, "file": "a.py"},
@@ -3186,6 +3379,6 @@ async def test_phase_fix_parallel_calls_count_serial_per_file_and_collects_failu
         {"id": 4, "file": "boom.py"},
     ]
     failures = await phases.phase_fix_parallel(object(), object(), items)
-    assert order.count(1) == 1 and order.count(2) == 1 and order.count(3) == 1  # 3 successful calls
-    assert order.index(1) < order.index(2)  # a.py items kept in input order
+    # One batched call per file-group (a.py's two findings are NOT two calls).
+    assert order.count("a.py") == 1 and order.count("b.py") == 1
     assert set(failures) == {"boom.py"} and "RuntimeError" in failures["boom.py"]


### PR DESCRIPTION
## Summary

- New `phase_fix_batched` function batches all findings for one file into a single `run_agent()` call
- `phase_fix_parallel` now uses batched-first with per-finding fallback on failure
- Shared helpers extracted (`_FIX_GUARDRAILS`, `_build_intent_suffix`, `_build_verifier_suffix`) to DRY prompt construction
- Budget scaling: max_turns, tool_call_budget, wall_budget_s multiplied by finding count
- No-file guard: `<no-file>` items delegate to per-finding phase_fix instead of incorrect batching
- Budget exhaustion triggers per-finding fallback with clean git checkout

## Motivation

Closes #202 — Instead of N separate run_agent() calls for N findings in the same file, all findings for one file are now passed to run_agent() in a single prompt. This reduces repeated context-reading, GLM explanation overhead, and tool-call overhead.

## Changes

### Added
- `phase_fix_batched` function in phases.py
- `_FIX_GUARDRAILS`, `_build_intent_suffix`, `_build_verifier_suffix` shared helpers
- Budget scaling for batched fixes (N x single-finding budget)
- No-file guard for file-less findings
- Budget exhaustion to fallback path
- Clean git checkout before fallback

### Changed
- `phase_fix_parallel` now calls `phase_fix_batched` per file-group with per-finding fallback
- `phase_fix` refactored to use shared helpers
- 6 new tests + 4 existing tests updated

## Test Plan

- [x] Tests pass locally (`make check` — 1754 passed, 3 skipped)
- [x] Linting passes (`make lint`)
- [x] Type checking passes (`make typecheck`)
- [x] Real-path test: multiple findings in one file produce a single batched fix invocation

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check`)
- [x] Type checking passes (`uv run mypy daydream`)
- [ ] Documentation updated (if applicable)
