### PR TITLE
feat(backends/pi): retry transient stream-drop errors + mark aborted trajectories partial

### DIFF
--- a/bench/review-bot-compare/replay.py
+++ b/bench/review-bot-compare/replay.py
@@ -25,6 +25,8 @@ from pathlib import Path
 
 from common import read_json, repo_slug, run, write_json
 
+from daydream.backends.pi import _STREAM_DROP_SIGNATURES
+
 # daydream resolves a GitHub App identity (and hard-aborts on failure) when these
 # are set and the run is "posting" (--review counts). The benchmark reviews a
 # detached local worktree with no posting, so run it under plain user identity.
@@ -50,20 +52,6 @@ _TRANSIENT_SIGNATURES = (
     "try again later",
 )
 
-# Provider/network stream-drop signatures: the z.ai/GLM provider closes the
-# streaming HTTP connection mid-generation, which undici surfaces as a literal
-# "terminated" error and pi propagates as `PiError: terminated`. These are
-# completed-but-lost reviews worth a retry. Matched case-insensitively, but ONLY
-# inside a backend/fatal error context so an ordinary review finding that merely
-# mentions one of these words in prose is not mistaken for a retryable failure.
-_STREAM_DROP_SIGNATURES = (
-    "terminated",
-    "econnreset",
-    "connection reset",
-    "socket hang up",
-    "premature close",
-    "epipe",
-)
 _ERROR_CONTEXT_MARKERS = (
     "pierror",
     "backend execution error",

--- a/bench/review-bot-compare/replay.py
+++ b/bench/review-bot-compare/replay.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 from common import read_json, repo_slug, run, write_json
 
-from daydream.backends.pi import _STREAM_DROP_SIGNATURES
+from daydream.backends.pi import STREAM_DROP_SIGNATURES
 
 # daydream resolves a GitHub App identity (and hard-aborts on failure) when these
 # are set and the run is "posting" (--review counts). The benchmark reviews a
@@ -65,7 +65,7 @@ def _is_transient(stdout: str) -> bool:
         return True
     # Stream-drop signatures only count when daydream actually errored out.
     if any(marker in low for marker in _ERROR_CONTEXT_MARKERS):
-        return any(sig in low for sig in _STREAM_DROP_SIGNATURES)
+        return any(sig in low for sig in STREAM_DROP_SIGNATURES)
     return False
 
 

--- a/daydream/backends/pi.py
+++ b/daydream/backends/pi.py
@@ -121,7 +121,7 @@ findings and conclusions."""
 _PI_DEFAULT_RETRY_ATTEMPTS = 3
 _PI_DEFAULT_RETRY_BASE_DELAY = 2.0
 
-_STREAM_DROP_SIGNATURES = (
+STREAM_DROP_SIGNATURES = (
     "terminated",
     "econnreset",
     "connection reset",
@@ -129,6 +129,9 @@ _STREAM_DROP_SIGNATURES = (
     "premature close",
     "epipe",
 )
+# Public alias; the canonical tuple is also referenced internally as the
+# underscore-prefixed name for backward compatibility.
+_STREAM_DROP_SIGNATURES = STREAM_DROP_SIGNATURES
 
 logger = logging.getLogger(__name__)
 
@@ -205,6 +208,17 @@ def _is_retryable_error_message(message: str) -> bool:
         or re.search(r"\bthrottl(?:e|ed|ing)\b", lower)
     ):
         return True
+    # Stream-drop signatures (terminated, econnreset, premature close, ...).
+    #
+    # Unlike bench/review-bot-compare/replay.py:_is_transient — which scans raw
+    # stdout and therefore gates _STREAM_DROP_SIGNATURES behind
+    # _ERROR_CONTEXT_MARKERS so the substrings only count when daydream actually
+    # errored — this function is only ever invoked on a PiError `errorMessage`
+    # (see the turn_end / stopReason == "error" call site below), where error
+    # context is already implied by construction. The asymmetry is deliberate:
+    # the benchmark's _ERROR_CONTEXT_MARKERS gate is the harness's own concern
+    # for stdout scanning, not a contract production must mirror. Matching these
+    # signatures unconditionally here is therefore safe and correct.
     if any(sig in lower for sig in _STREAM_DROP_SIGNATURES):
         return True
     return False

--- a/daydream/backends/pi.py
+++ b/daydream/backends/pi.py
@@ -121,6 +121,15 @@ findings and conclusions."""
 _PI_DEFAULT_RETRY_ATTEMPTS = 3
 _PI_DEFAULT_RETRY_BASE_DELAY = 2.0
 
+_STREAM_DROP_SIGNATURES = (
+    "terminated",
+    "econnreset",
+    "connection reset",
+    "socket hang up",
+    "premature close",
+    "epipe",
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -190,11 +199,15 @@ def _is_retryable_error_message(message: str) -> bool:
         return True
     if re.search(r"\bnot\s+overloaded\b|\bcapacity\s+planning\b", lower):
         return False
-    return bool(
+    if bool(
         re.search(r"\boverloaded?\b|\boverload(?:ed|ing)?\b", lower)
         or re.search(r"\bcapacity\s+(?:unavailable|exceeded|limit|limited|full|reached)\b", lower)
         or re.search(r"\bthrottl(?:e|ed|ing)\b", lower)
-    )
+    ):
+        return True
+    if any(sig in lower for sig in _STREAM_DROP_SIGNATURES):
+        return True
+    return False
 
 
 def _is_retryable_exit_code(code: int) -> bool:

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -903,6 +903,7 @@ class TrajectoryRecorder:
     # Per-Invocation timing summaries registered at _InvocationCM.__aexit__.
     # Serialized into Trajectory.extra["subtrajectories"] when non-empty.
     _subtrajectories: list[dict[str, Any]] = field(default_factory=list)
+    _aborted: bool = False
     on_write: Callable[[TrajectoryRecorder, str], None] | None = None
 
     async def __aenter__(self) -> "TrajectoryRecorder":
@@ -912,6 +913,8 @@ class TrajectoryRecorder:
 
     async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         try:
+            if exc_type is not None:
+                self._aborted = True
             self._write()
         except Exception as exc:  # noqa: BLE001 - branch on explicit_path per D-06
             if self.explicit_path:
@@ -1240,7 +1243,11 @@ class TrajectoryRecorder:
             return
         trajectory = self.build_trajectory()
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        data = json.dumps(trajectory.to_json_dict(), indent=2)
+        trajectory_dict = trajectory.to_json_dict()
+        if self._aborted:
+            extra = trajectory_dict.setdefault("extra", {})
+            extra["partial"] = True
+        data = json.dumps(trajectory_dict, indent=2)
         fd, tmp = tempfile.mkstemp(dir=self.path.parent, suffix=".tmp")
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -1354,6 +1354,8 @@ class _ForkCM:
         child = self._child
         if child is None:
             return
+        if exc_type is not None:
+            child._aborted = True
         write_ok = False
         try:
             child._write()

--- a/tests/test_agent_retry.py
+++ b/tests/test_agent_retry.py
@@ -15,7 +15,7 @@ import pytest
 
 from daydream.agent import run_agent
 from daydream.backends import ResultEvent, TextEvent
-from daydream.backends.pi import PiError
+from daydream.backends.pi import PiError, _is_retryable_error_message
 from daydream.trajectory import DaydreamPhase, DaydreamRunFlow, TrajectoryRecorder
 
 
@@ -302,7 +302,14 @@ async def test_concurrent_retry_does_not_kill_sibling_invocations(
 
 
 class _StreamDropThenSuccessBackend:
-    """Raises a stream-drop PiError on the first call, succeeds on the second."""
+    """Raises a stream-drop PiError on the first call, succeeds on the second.
+
+    Uses the production classifier ``_is_retryable_error_message`` to set
+    ``retryable``, mirroring how ``PiBackend`` constructs ``PiError`` in
+    production. This ensures the test exercises the real classification path:
+    if ``_is_retryable_error_message("terminated")`` ever returns ``False``,
+    ``run_agent`` would NOT retry and the test would fail.
+    """
 
     model = "test-model"
     fanout_concurrency = 4
@@ -322,7 +329,14 @@ class _StreamDropThenSuccessBackend:
     ):
         self.call_count += 1
         if self.call_count == 1:
-            raise PiError("terminated", retryable=True)
+            # Mirrors production: PiBackend raises PiError with retryable set
+            # by the _is_retryable_error_message classifier. If the classifier
+            # stops recognizing "terminated" as retryable, this raises with
+            # retryable=False and run_agent does NOT retry — the test fails.
+            raise PiError(
+                "terminated",
+                retryable=_is_retryable_error_message("terminated"),
+            )
         yield TextEvent(text="Review complete after retry")
         yield ResultEvent(structured_output=None, continuation=None)
 

--- a/tests/test_agent_retry.py
+++ b/tests/test_agent_retry.py
@@ -6,6 +6,7 @@ outcomes (returned output, call count) never on internal implementation details.
 """
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
@@ -15,7 +16,7 @@ import pytest
 from daydream.agent import run_agent
 from daydream.backends import ResultEvent, TextEvent
 from daydream.backends.pi import PiError
-from daydream.trajectory import DaydreamPhase
+from daydream.trajectory import DaydreamPhase, DaydreamRunFlow, TrajectoryRecorder
 
 
 class _RetryableThenSuccessBackend:
@@ -300,29 +301,6 @@ async def test_concurrent_retry_does_not_kill_sibling_invocations(
     assert backend.call_counts.get("ok-b", 0) == 1
 
 
-def test_is_retryable_error_message_stream_drop_signatures() -> None:
-    """Stream-drop signatures are classified as retryable."""
-    from daydream.backends.pi import _is_retryable_error_message
-
-    for sig in (
-        "terminated",
-        "ECONNRESET",
-        "connection reset",
-        "socket hang up",
-        "premature close",
-        "EPIPE",
-    ):
-        assert _is_retryable_error_message(sig) is True, f"Expected {sig!r} to be retryable"
-
-
-def test_is_retryable_error_message_non_retryable() -> None:
-    """Non-transient messages are NOT classified as retryable."""
-    from daydream.backends.pi import _is_retryable_error_message
-
-    for msg in ("some real review failure", "auth failed", "invalid API key"):
-        assert _is_retryable_error_message(msg) is False, f"Expected {msg!r} to NOT be retryable"
-
-
 class _StreamDropThenSuccessBackend:
     """Raises a stream-drop PiError on the first call, succeeds on the second."""
 
@@ -367,3 +345,45 @@ async def test_run_agent_retries_on_stream_drop(monkeypatch, tmp_path: Path) -> 
 
     assert output == "Review complete after retry"
     assert backend.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_run_agent_retry_exhausted_marks_trajectory_partial(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Retry-exhaustion → trajectory ``partial`` composition (PR headline).
+
+    When a retryable ``PiError`` exhausts all retries, ``run_agent`` re-raises
+    and the exception propagates through the active ``TrajectoryRecorder``
+    scope. The recorder stamps ``extra.partial = True`` on the emitted
+    trajectory so downstream consumers can distinguish clean completions from
+    aborted ones. Real-path test driving the PR's headline behavior through
+    the production entrypoint (``run_agent``) with a real recorder on the real
+    filesystem.
+    """
+    monkeypatch.setenv("DAYDREAM_PI_RETRY_BASE_DELAY_S", "0.01")
+    monkeypatch.setenv("DAYDREAM_PI_RETRY_ATTEMPTS", "2")
+    backend = _AlwaysRetryableBackend()
+
+    trajectory_path = tmp_path / ".daydream" / "trajectory.json"
+    recorder = TrajectoryRecorder(
+        path=trajectory_path,
+        run_flow=DaydreamRunFlow.NORMAL,
+        target_dir=tmp_path,
+        agent_model_name="test-model",
+        session_id="test",
+    )
+
+    with pytest.raises(PiError):
+        async with recorder:
+            await run_agent(backend, tmp_path, "review", phase=DaydreamPhase.REVIEW)
+
+    # 1 original attempt + 2 retries = 3 total, then re-raised through the
+    # recorder scope (which stamps partial=true) and caught here.
+    assert backend.call_count == 3
+
+    # The trajectory was written and stamped partial=true by the recorder's
+    # exception-exit path (TrajectoryRecorder._aborted → _write).
+    assert trajectory_path.exists(), "trajectory.json was not written on retry exhaustion"
+    trajectory = json.loads(trajectory_path.read_text(encoding="utf-8"))
+    assert trajectory["extra"]["partial"] is True

--- a/tests/test_agent_retry.py
+++ b/tests/test_agent_retry.py
@@ -298,3 +298,72 @@ async def test_concurrent_retry_does_not_kill_sibling_invocations(
     assert backend.call_counts.get("fail-once", 0) == 2
     assert backend.call_counts.get("ok-a", 0) == 1
     assert backend.call_counts.get("ok-b", 0) == 1
+
+
+def test_is_retryable_error_message_stream_drop_signatures() -> None:
+    """Stream-drop signatures are classified as retryable."""
+    from daydream.backends.pi import _is_retryable_error_message
+
+    for sig in (
+        "terminated",
+        "ECONNRESET",
+        "connection reset",
+        "socket hang up",
+        "premature close",
+        "EPIPE",
+    ):
+        assert _is_retryable_error_message(sig) is True, f"Expected {sig!r} to be retryable"
+
+
+def test_is_retryable_error_message_non_retryable() -> None:
+    """Non-transient messages are NOT classified as retryable."""
+    from daydream.backends.pi import _is_retryable_error_message
+
+    for msg in ("some real review failure", "auth failed", "invalid API key"):
+        assert _is_retryable_error_message(msg) is False, f"Expected {msg!r} to NOT be retryable"
+
+
+class _StreamDropThenSuccessBackend:
+    """Raises a stream-drop PiError on the first call, succeeds on the second."""
+
+    model = "test-model"
+    fanout_concurrency = 4
+
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    async def execute(
+        self,
+        cwd: Path,
+        prompt: str,
+        output_schema: Any = None,
+        continuation: Any = None,
+        agents: Any = None,
+        max_turns: Any = None,
+        read_only: bool = False,
+    ):
+        self.call_count += 1
+        if self.call_count == 1:
+            raise PiError("terminated", retryable=True)
+        yield TextEvent(text="Review complete after retry")
+        yield ResultEvent(structured_output=None, continuation=None)
+
+    async def cancel(self) -> None:
+        pass
+
+    def format_skill_invocation(self, *a: Any, **kw: Any) -> str:
+        return ""
+
+
+@pytest.mark.asyncio
+async def test_run_agent_retries_on_stream_drop(monkeypatch, tmp_path: Path) -> None:
+    """First call raises PiError('terminated') (stream-drop); second succeeds."""
+    monkeypatch.setenv("DAYDREAM_PI_RETRY_BASE_DELAY_S", "0.01")
+    backend = _StreamDropThenSuccessBackend()
+
+    output, _, _ = await run_agent(
+        backend, tmp_path, "review this", phase=DaydreamPhase.REVIEW
+    )
+
+    assert output == "Review complete after retry"
+    assert backend.call_count == 2

--- a/tests/test_backend_pi.py
+++ b/tests/test_backend_pi.py
@@ -1008,6 +1008,19 @@ def test_is_retryable_error_message_unknown_pi_error():
     assert _is_retryable_error_message("Unknown Pi error") is False
 
 
+def test_is_retryable_error_message_stream_drop_signatures():
+    """Stream-drop signatures are classified as retryable (z.ai/GLM connection drops)."""
+    for sig in (
+        "terminated",
+        "ECONNRESET",
+        "connection reset",
+        "socket hang up",
+        "premature close",
+        "EPIPE",
+    ):
+        assert _is_retryable_error_message(sig) is True, f"Expected {sig!r} to be retryable"
+
+
 # ---------------------------------------------------------------------------
 # _is_retryable_exit_code
 # ---------------------------------------------------------------------------

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -1089,3 +1089,32 @@ async def test_forked_child_write_partial_captures_in_flight_steps(tmp_path: Pat
     assert len(data["steps"]) >= 2, (
         f"Child partial missing in-flight steps: {data['steps']!r}"
     )
+
+
+async def test_recorder_marks_partial_on_exception_exit(tmp_path: Path) -> None:
+    """When __aexit__ receives an exception, the trajectory is marked partial."""
+    recorder = _make_recorder(tmp_path)
+    with pytest.raises(RuntimeError, match="boom"):
+        async with recorder:
+            async with recorder.invocation(phase=DaydreamPhase.REVIEW) as inv:
+                inv.observe_user_step(prompt="hello")
+                inv.observe(TextEvent(text="partial output"))
+                raise RuntimeError("boom")
+
+    assert recorder.path.exists()
+    traj = _read_trajectory(recorder.path)
+    assert traj.get("extra", {}).get("partial") is True
+
+
+async def test_recorder_does_not_mark_partial_on_clean_exit(tmp_path: Path) -> None:
+    """Clean exit does NOT mark the trajectory as partial."""
+    recorder = _make_recorder(tmp_path)
+    async with recorder:
+        async with recorder.invocation(phase=DaydreamPhase.REVIEW) as inv:
+            inv.observe_user_step(prompt="hello")
+            inv.observe(TextEvent(text="world"))
+            inv.observe(ResultEvent(structured_output=None, continuation=None))
+
+    assert recorder.path.exists()
+    traj = _read_trajectory(recorder.path)
+    assert "partial" not in traj.get("extra", {})

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -1106,6 +1106,45 @@ async def test_recorder_marks_partial_on_exception_exit(tmp_path: Path) -> None:
     assert traj.get("extra", {}).get("partial") is True
 
 
+async def test_forked_child_marks_partial_on_exception_exit(tmp_path: Path) -> None:
+    """A sibling that dies mid-flight is marked partial on exception exit.
+
+    Regression for the fork path: _ForkCM.__aexit__ must mirror the top-level
+    recorder and set child._aborted when an exception escapes the fork scope,
+    so the sibling trajectory's extra.partial reflects that it was aborted —
+    not silently written as if it completed cleanly.
+    """
+    recorder = _make_recorder(tmp_path)
+    with pytest.raises(RuntimeError, match="boom"):
+        async with recorder:
+            async with recorder.fork("fix-0") as child:
+                async with child.invocation(phase=DaydreamPhase.FIX) as inv:
+                    inv.observe_user_step(prompt="hello")
+                    inv.observe(TextEvent(text="partial sibling output"))
+                    raise RuntimeError("boom")
+
+    assert child.path.exists(), "Sibling trajectory should be written on exception exit"
+    sibling_traj = _read_trajectory(child.path)
+    assert sibling_traj.get("extra", {}).get("partial") is True, (
+        "Forked child trajectory must be marked partial when an exception escapes the fork"
+    )
+
+
+async def test_forked_child_does_not_mark_partial_on_clean_exit(tmp_path: Path) -> None:
+    """A sibling that exits cleanly is NOT marked partial."""
+    recorder = _make_recorder(tmp_path)
+    async with recorder:
+        async with recorder.fork("fix-0") as child:
+            async with child.invocation(phase=DaydreamPhase.FIX) as inv:
+                inv.observe_user_step(prompt="hello")
+                inv.observe(TextEvent(text="sibling output"))
+                inv.observe(ResultEvent(structured_output=None, continuation=None))
+
+    assert child.path.exists()
+    sibling_traj = _read_trajectory(child.path)
+    assert "partial" not in sibling_traj.get("extra", {})
+
+
 async def test_recorder_does_not_mark_partial_on_clean_exit(tmp_path: Path) -> None:
     """Clean exit does NOT mark the trajectory as partial."""
     recorder = _make_recorder(tmp_path)


### PR DESCRIPTION
## Summary

- Stream-drop errors (`terminated`, `ECONNRESET`, `connection reset`, `socket hang up`, `premature close`, `EPIPE`) from z.ai/GLM provider are now classified as retryable, so the existing retry loop in `run_agent()` retries them with exponential backoff instead of aborting the entire review.
- Aborted runs (exception escaping `TrajectoryRecorder.__aexit__`) now mark the trajectory `extra.partial = true`, so downstream consumers can distinguish partial from complete trajectories. Forked/sibling trajectories get the same treatment via `_ForkCM.__aexit__`.
- `STREAM_DROP_SIGNATURES` is now the single source of truth in `daydream.backends.pi`, imported by the benchmark harness (`replay.py`) instead of maintaining a duplicate.

## Motivation

Closes #209. When z.ai/GLM closes the streaming HTTP connection mid-generation, pi surfaces it as `PiError: terminated` and the entire multi-phase deep review aborted. PR #215 added the retry loop infrastructure and a partial classifier (429/overload/rate-limit/OOM), but stream-drop signatures were not classified. Tasks 2 and 3 from the issue (per-stack retry granularity test, partial trajectory marking) were unaddressed.

Task 4 (phase-level checkpoint/resume) is low priority and deferred to a follow-up issue.

## Changes

### Added
- `STREAM_DROP_SIGNATURES` tuple in `daydream/backends/pi.py` as the canonical source of truth for stream-drop error signatures.
- `_is_retryable_error_message()` extended to classify stream-drop signatures as retryable, with a comment documenting the deliberate asymmetry between production (operates on PiError messages where error context is implied) and the benchmark harness (scans raw stdout, gates behind `_ERROR_CONTEXT_MARKERS`).
- `TrajectoryRecorder._aborted` flag: when `__aexit__` receives an exception, the trajectory is stamped `extra.partial = true`.
- `_ForkCM.__aexit__` mirrors the top-level recorder, setting `child._aborted = True` on exception exit so forked/sibling trajectories are also marked partial.
- `_STREAM_DROP_SIGNATURES` backward-compat alias for the private name.

### Changed
- `bench/review-bot-compare/replay.py` imports `STREAM_DROP_SIGNATURES` from `daydream.backends.pi` instead of maintaining a duplicate tuple.

### Fixed
- Forked/sibling trajectories were silently written as complete even when an exception escaped the fork scope.

## Test Plan

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check`)
- [x] Type checking passes (`uv run mypy daydream`)
- [x] Classifier unit tests: stream-drop signatures are retryable, non-transient messages are not (`test_backend_pi.py`)
- [x] Real-path test: `run_agent()` retries a `PiError("terminated")` stream-drop and succeeds on the second attempt (`test_agent_retry.py`)
- [x] Real-path test: retry-exhaustion through a real `TrajectoryRecorder` stamps `extra.partial = true` (`test_agent_retry.py`)
- [x] Real-path test: exception exit marks trajectory partial, clean exit does not (`test_trajectory.py`)
- [x] Real-path test: forked child marks partial on exception exit, clean exit does not (`test_trajectory.py`)
- [x] Full suite: `make check` — 1819 passed, 3 skipped

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check`)
- [x] Type checking passes (`uv run mypy daydream`)
- [x] Documentation updated (if applicable)