### PR TITLE
feat(trajectory): register fork subtrajectory entries

### DIFF
--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -1015,6 +1015,26 @@ class TrajectoryRecorder:
             }
         )
 
+    def _register_fork_subtrajectory(
+        self,
+        *,
+        phase: str,
+        descriptor: str,
+        started_at: str,
+        ended_at: str,
+        sibling_trajectory_ref: str,
+    ) -> None:
+        """Register a per-fork timing summary on the parent trajectory."""
+        self._subtrajectories.append(
+            {
+                "phase": phase,
+                "descriptor": descriptor,
+                "started_at": started_at,
+                "ended_at": ended_at,
+                "sibling_trajectory_ref": sibling_trajectory_ref,
+            }
+        )
+
     def _next_step_id(self) -> int:
         self._step_id_counter += 1
         return self._step_id_counter
@@ -1331,6 +1351,8 @@ class _ForkCM:
         self._parent = parent
         self._descriptor = descriptor
         self._child: TrajectoryRecorder | None = None
+        self._entered_at: str | None = None
+        self._exited_at: str | None = None
 
     async def __aenter__(self) -> TrajectoryRecorder:
         child = TrajectoryRecorder(
@@ -1348,6 +1370,7 @@ class _ForkCM:
         child._previous_token = _RECORDER_VAR.set(child)
         _ACTIVE_RECORDERS.append(child)
         self._child = child
+        self._entered_at = now_iso()
         return child
 
     async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
@@ -1370,8 +1393,28 @@ class _ForkCM:
             _ACTIVE_RECORDERS.remove(child)
         except ValueError:
             pass
+        self._exited_at = now_iso()
         if write_ok and child.parent is not None:
             child.parent._register_sibling(child.path, self._descriptor)
+            try:
+                sibling_ref = str(child.path.relative_to(child.parent.target_dir / ".daydream"))
+            except ValueError:
+                sibling_ref = child.path.name
+            phase = DaydreamPhase.FIX.value
+            for step in child.steps:
+                if step.extra is None:
+                    continue
+                candidate = step.extra.get("daydream_phase")
+                if isinstance(candidate, str):
+                    phase = candidate
+                    break
+            child.parent._register_fork_subtrajectory(
+                phase=phase,
+                descriptor=self._descriptor,
+                started_at=self._entered_at or now_iso(),
+                ended_at=self._exited_at or now_iso(),
+                sibling_trajectory_ref=sibling_ref,
+            )
 
 
 class _InvocationCM:

--- a/tests/test_trajectory_phase_events.py
+++ b/tests/test_trajectory_phase_events.py
@@ -234,6 +234,34 @@ async def test_subtrajectory_step_ids_track_multiple_invocations(tmp_path: Path)
     assert subs[1]["step_ids"] == [2]
 
 
+async def test_fork_subtrajectory_entries_have_timestamps(tmp_path: Path) -> None:
+    """Fork siblings register subtrajectory entries on the parent (issue #212)."""
+    from daydream.trajectory import maybe_fork
+
+    rec = _make_recorder(tmp_path)
+    async with rec:
+        # Seed a parent step so _write does not take its empty-steps early
+        # return; in a real run the parent always has prior-phase steps.
+        rec._extend_steps([Step(step_id=1, source="user", message="seed")])
+        async with maybe_fork(rec, "fix-src-foo-py") as child:
+            async with child.invocation(phase=DaydreamPhase.FIX) as inv:
+                inv.observe(TextEvent(text="fixing foo"))
+                inv.observe(ResultEvent(structured_output=None, continuation=None))
+    traj = _read_trajectory(rec.path)
+    subs = traj["extra"].get("subtrajectories", [])
+    assert len(subs) == 1, f"expected 1 fork subtrajectory, got {len(subs)}: {subs}"
+    sub = subs[0]
+    assert sub["phase"] == "fix", f"expected phase 'fix' for descriptor 'fix-src-foo-py', got {sub['phase']!r}"
+    assert sub["descriptor"] == "fix-src-foo-py", f"descriptor missing/incorrect: {sub}"
+    assert sub["started_at"], "started_at must be non-empty"
+    assert sub["ended_at"], "ended_at must be non-empty"
+    assert sub["sibling_trajectory_ref"], "sibling_trajectory_ref must be non-empty"
+    assert "step_ids" not in sub, "step_ids should be replaced by sibling_trajectory_ref"
+    assert ".json" in sub["sibling_trajectory_ref"], (
+        f"sibling_trajectory_ref should be a .json path, got {sub['sibling_trajectory_ref']!r}"
+    )
+
+
 # --- compute_phase_timings -------------------------------------------------
 
 
@@ -518,6 +546,72 @@ async def test_deep_run_accept_gate_wraps_fix_test_verify(
     for phase in ("intent", "alternatives", "parse", "verify", "fix", "test", "deep"):
         assert phase in phase_timings, (
             f"{phase} missing from deep phase_timings: {phase_timings!r}"
+        )
+
+
+async def test_parallel_fix_registers_subtrajectories(
+    multi_stack_target: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Real-path: parallel fix phase registers per-file subtrajectory entries.
+
+    Drives ``runner.run`` through the deep pipeline with the stub backend,
+    producing >=2 file findings that exercise ``phase_fix_parallel`` and the
+    ``recorder.fork()`` path. Asserts multiple ``fix`` entries appear in
+    ``extra["subtrajectories"]``.
+    """
+    from tests.test_deep_orchestrator import (
+        _install_stub_backend,
+        _merge_item,
+        _noop_commit,
+        _ok,
+        _silence,
+    )
+
+    _silence(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    # Override merge items to produce 2 findings on distinct files.
+    stub.merge_items = [
+        _merge_item(1, "api.py", "high"),
+        _merge_item(2, "App.tsx", "medium"),
+    ]
+
+    async def _no_post(target_dir: Path, report_path: Path, *, console: Any) -> None:
+        return None
+
+    monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _no_post)
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_test_and_heal", lambda *a, **k: _ok())
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _noop_commit)
+
+    from daydream.runner import RunConfig, run
+
+    traj = tmp_path / "trajectory.json"
+    config = RunConfig(
+        target=str(multi_stack_target),
+        assume="yes",
+        trajectory_path=traj,
+        cleanup=False,
+    )
+    exit_code = await run(config)
+    assert exit_code == 0
+
+    assert traj.exists(), "deep run must write the trajectory to disk"
+    data = json.loads(traj.read_text(encoding="utf-8"))
+    assert atif_validate(data, validate_images=False) is True
+
+    subs = data["extra"].get("subtrajectories", [])
+    fix_subs = [s for s in subs if s["phase"] == "fix"]
+    assert len(fix_subs) >= 2, (
+        f"expected >=2 fix subtrajectories from parallel forks, got {len(fix_subs)}: {fix_subs}"
+    )
+    for sub in fix_subs:
+        assert sub["descriptor"].startswith("fix-"), (
+            f"fix subtrajectory descriptor must start with 'fix-': {sub}"
+        )
+        assert sub["started_at"], f"fix subtrajectory missing started_at: {sub}"
+        assert sub["ended_at"], f"fix subtrajectory missing ended_at: {sub}"
+        assert sub["sibling_trajectory_ref"], f"fix subtrajectory missing sibling_trajectory_ref: {sub}"
+        assert "step_ids" not in sub, (
+            f"step_ids should be replaced by sibling_trajectory_ref: {sub}"
         )
 
 


### PR DESCRIPTION
## Summary

- Records per-fork subtrajectory entries for parallel fix-phase sibling trajectories.
- Uses sibling trajectory refs instead of child-local step IDs so subtrajectory entries remain resolvable.
- Adds unit and real-path coverage for fork subtrajectory recording through the deep runner path.

## Motivation

Parallel fix-phase work already writes per-file sibling trajectory files, but those fork timings were not surfaced in the parent trajectory's `extra.subtrajectories` array. That made fix-phase timing less observable than sequential phases.

Closes #212.

## Changes

### Added
- Parent-level fork subtrajectory registration with `descriptor`, `started_at`, `ended_at`, and `sibling_trajectory_ref`.
- Unit coverage for direct `recorder.fork()` subtrajectory registration.
- Real-path coverage driving `runner.run` through `phase_fix_parallel` with multiple file findings.

### Changed
- Fork subtrajectory phase labels now derive from the child recorder's recorded `daydream_phase`, with `fix` as fallback.
- Fork subtrajectory entries reference the sibling trajectory file instead of storing child-local `step_ids`.

## Test Plan

- [x] `make lint`
- [x] `make typecheck`
- [x] `uv run python -m pytest tests/test_trajectory_phase_events.py::test_fork_subtrajectory_entries_have_timestamps tests/test_trajectory_phase_events.py::test_parallel_fix_registers_subtrajectories -q`
- [x] `make check` → 1821 passed, 3 skipped

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check`)
- [x] Type checking passes (`uv run mypy daydream`)
- [x] Documentation updated (if applicable)
