### PR TITLE
fix(prompts): ground review/exploration agents to cwd in linked worktrees

### DIFF
--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -27,6 +27,7 @@ from daydream.phases import (
     _exploration_pointer,
     _settled_decisions_block,
 )
+from daydream.prompts.grounding import CWD_GROUNDING_INSTRUCTION
 
 DOC_REVIEW_NOTICE = (
     "[Notice] Dedicated documentation review (beagle-docs) is planned but not yet "
@@ -206,6 +207,7 @@ def build_per_stack_prompt(
     intent_path: Path,
     alternatives_path: Path,
     output_path: Path,
+    cwd: Path,
     exploration_dir: Path | None = None,
     prior_commits: str | None = None,
     inline_diff: str | None = None,
@@ -220,6 +222,7 @@ def build_per_stack_prompt(
         intent_path: Path to TTT intent.md.
         alternatives_path: Path to TTT alternatives.json.
         output_path: Where the agent must write its review.
+        cwd: Absolute working directory the agent runs in (grounds path resolution).
         exploration_dir: Pre-scan exploration directory (if available).
         prior_commits: Oneline log of prior daydream commits on this branch.
         inline_diff: Issue #172 Fix B. Pre-extracted diff hunks for ``files``
@@ -236,6 +239,7 @@ def build_per_stack_prompt(
     settled = _settled_decisions_block(prior_commits)
     if settled:
         parts.append(settled)
+    parts.append(CWD_GROUNDING_INSTRUCTION.format(cwd=cwd))
     parts.append(_context_pointers(intent_path=intent_path, alternatives_path=alternatives_path))
     parts.append(_confidence_and_convention_instructions())
     parts.append(_dependency_impact_instructions())
@@ -254,6 +258,7 @@ def build_structural_prompt(
     intent_path: Path,
     alternatives_path: Path,
     output_path: Path,
+    cwd: Path,
     exploration_dir: Path | None = None,
     prior_commits: str | None = None,
 ) -> str:
@@ -273,6 +278,7 @@ def build_structural_prompt(
         intent_path: Path to TTT intent.md.
         alternatives_path: Path to TTT alternatives.json.
         output_path: Where the agent must write its review.
+        cwd: Absolute working directory the agent runs in (grounds path resolution).
         exploration_dir: Accepted for signature symmetry with
             ``build_per_stack_prompt``; intentionally ignored in the prompt
             body because the structural reviewer discovers context via tool
@@ -288,6 +294,7 @@ def build_structural_prompt(
     settled = _settled_decisions_block(prior_commits)
     if settled:
         parts.append(settled)
+    parts.append(CWD_GROUNDING_INSTRUCTION.format(cwd=cwd))
     parts.append(_context_pointers(intent_path=intent_path, alternatives_path=alternatives_path))
     parts.append(
         f"You are the structural reviewer. The full change spans: {joined}. "
@@ -312,6 +319,7 @@ def build_arbiter_prompt(
     diff_path: Path,
     intent_path: Path,
     alternatives_path: Path,
+    cwd: Path,
     exploration_dir: Path | None = None,
 ) -> str:
     """Assemble the scoped Opus arbiter prompt (issue #168).
@@ -329,6 +337,7 @@ def build_arbiter_prompt(
         diff_path: Path to the full diff on disk.
         intent_path: Path to TTT intent.md.
         alternatives_path: Path to TTT alternatives.json.
+        cwd: Absolute working directory the agent runs in (grounds path resolution).
         exploration_dir: Pre-scan exploration directory (if available).
 
     Returns:
@@ -338,6 +347,7 @@ def build_arbiter_prompt(
     pointer = _exploration_pointer(exploration_dir)
     if pointer:
         parts.append(pointer)
+    parts.append(CWD_GROUNDING_INSTRUCTION.format(cwd=cwd))
     parts.append(_context_pointers(intent_path=intent_path, alternatives_path=alternatives_path))
     parts.append(
         f"The full PR diff (base..HEAD) is at {diff_path}. Read it directly; "
@@ -493,7 +503,7 @@ def build_merge_prompt(
 def build_verification_prompt(
     *,
     items: list[dict[str, Any]],
-    target_dir: Path,
+    cwd: Path,
     output_path: Path,
 ) -> str:
     """Assemble the recommendation-verifier prompt.
@@ -518,7 +528,7 @@ def build_verification_prompt(
         items: The non-structural (per-stack / cross-stack) canonical items to
             verify. Rendered inline into the prompt; verdicts are keyed by each
             item's canonical ``id`` (the verdict ``issue_id``).
-        target_dir: Repository root the verifier runs against.
+        cwd: Absolute working directory the verifier runs in (grounds path resolution).
         output_path: Where the verifier must write its JSON verdicts file.
 
     Returns:
@@ -532,7 +542,7 @@ def build_verification_prompt(
         "numbered issue in the finding list below against the actual codebase "
         "and decide whether its recommendation is consistent with trait/interface "
         "specs and sibling implementations.\n\n"
-        f"Repository root: {target_dir}\n"
+        f"{CWD_GROUNDING_INSTRUCTION.format(cwd=cwd)}\n"
         "The numbered findings to verify (each `issue_id` in your output MUST "
         "match the leading number `N.` of the finding it verifies):\n\n"
         + render_report(items)
@@ -594,6 +604,7 @@ def build_generic_fallback_prompt(
     intent_path: Path,
     alternatives_path: Path,
     output_path: Path,
+    cwd: Path,
     exploration_dir: Path | None = None,
     is_docs_only: bool = False,
     prior_commits: str | None = None,
@@ -609,6 +620,7 @@ def build_generic_fallback_prompt(
         intent_path: Path to TTT intent.md.
         alternatives_path: Path to TTT alternatives.json.
         output_path: Where the agent must write its review.
+        cwd: Absolute working directory the agent runs in (grounds path resolution).
         exploration_dir: Pre-scan exploration directory (if available).
         is_docs_only: Whether the whole diff is docs-only (D-20).
         prior_commits: Oneline log of prior daydream commits on this branch.
@@ -628,6 +640,7 @@ def build_generic_fallback_prompt(
     settled = _settled_decisions_block(prior_commits)
     if settled:
         parts.append(settled)
+    parts.append(CWD_GROUNDING_INSTRUCTION.format(cwd=cwd))
     parts.append(_context_pointers(intent_path=intent_path, alternatives_path=alternatives_path))
     parts.append(_confidence_and_convention_instructions())
     parts.append(_dependency_impact_instructions())

--- a/daydream/exploration_runner.py
+++ b/daydream/exploration_runner.py
@@ -261,25 +261,33 @@ async def pre_scan(
     # they treat the list as "files to process" and fan out a tool call per
     # entry, so the import-expanded static_files (10K+ on monorepos) would make
     # them run 50+ minutes. The dependency-tracer still gets static_files.
-    changed_paths = sorted({m.group(1) for m in _DIFF_HEADER_RE.finditer(diff_text)})
+    #
+    # Paths handed to specialists are cwd-absolute (rooted at repo_root, the
+    # actual worktree). In a linked worktree the agent must not re-root a bare
+    # relative path via git topology, which points at the sibling main worktree.
+    changed_paths = sorted({str(repo_root / m.group(1)) for m in _DIFF_HEADER_RE.finditer(diff_text)})
+    static_files_abs = [
+        FileInfo(path=str(repo_root / f.path), role=f.role, summary=f.summary) for f in static_files
+    ]
 
     with anyio.move_on_after(_SPECIALIST_TIMEOUT_SECONDS):
         async with anyio.create_task_group() as tg:
             if tier == "single":
-                dep_prompt = build_dependency_tracer_prompt(static_files, diff_ref)
+                dep_prompt = build_dependency_tracer_prompt(static_files_abs, diff_ref, cwd=repo_root)
                 tg.start_soon(_run_specialist, "dependency_tracer", dep_prompt, DEPENDENCY_TRACER_SCHEMA)
             else:  # parallel
                 tg.start_soon(
                     _run_specialist, "pattern_scanner",
-                    build_pattern_scanner_prompt(changed_paths, diff_ref), PATTERN_SCANNER_SCHEMA,
+                    build_pattern_scanner_prompt(changed_paths, diff_ref, cwd=repo_root), PATTERN_SCANNER_SCHEMA,
                 )
                 tg.start_soon(
                     _run_specialist, "dependency_tracer",
-                    build_dependency_tracer_prompt(static_files, diff_ref), DEPENDENCY_TRACER_SCHEMA,
+                    build_dependency_tracer_prompt(static_files_abs, diff_ref, cwd=repo_root),
+                    DEPENDENCY_TRACER_SCHEMA,
                 )
                 tg.start_soon(
                     _run_specialist, "test_mapper",
-                    build_test_mapper_prompt(changed_paths, diff_ref), TEST_MAPPER_SCHEMA,
+                    build_test_mapper_prompt(changed_paths, diff_ref, cwd=repo_root), TEST_MAPPER_SCHEMA,
                 )
 
     if recorder is not None:

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -1686,7 +1686,7 @@ async def phase_verify_recommendations(
 
     prompt = build_verification_prompt(
         items=verifiable,
-        target_dir=work.repo,
+        cwd=work.repo,
         output_path=output_path,
     )
 
@@ -3004,6 +3004,7 @@ async def phase_per_stack_reviews(
                     intent_path=intent_path,
                     alternatives_path=alternatives_path,
                     output_path=output_path,
+                    cwd=work.repo,
                     exploration_dir=exploration_dir,
                     prior_commits=prior_commits,
                 )
@@ -3023,6 +3024,7 @@ async def phase_per_stack_reviews(
                         intent_path=intent_path,
                         alternatives_path=alternatives_path,
                         output_path=output_path,
+                        cwd=work.repo,
                         exploration_dir=exploration_dir,
                         is_docs_only=stack.is_docs_only,
                         prior_commits=prior_commits,
@@ -3039,6 +3041,7 @@ async def phase_per_stack_reviews(
                         intent_path=intent_path,
                         alternatives_path=alternatives_path,
                         output_path=output_path,
+                        cwd=work.repo,
                         exploration_dir=exploration_dir,
                         prior_commits=prior_commits,
                         inline_diff=inline_diff,
@@ -3166,6 +3169,7 @@ async def phase_arbiter_review(
         diff_path=diff_path,
         intent_path=intent_path,
         alternatives_path=alternatives_path,
+        cwd=work.repo,
         exploration_dir=exploration_dir,
     )
     result, _, _ = await run_agent(backend, work.repo, prompt, output_schema=ARBITER_SCHEMA, phase=DaydreamPhase.DEEP)

--- a/daydream/prompts/exploration_subagents.py
+++ b/daydream/prompts/exploration_subagents.py
@@ -21,7 +21,11 @@ from typing import TYPE_CHECKING, Any
 
 from claude_agent_sdk.types import AgentDefinition
 
+from daydream.prompts.grounding import CWD_GROUNDING_INSTRUCTION
+
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from daydream.exploration import FileInfo
 
 
@@ -152,7 +156,7 @@ Emit a FileInfo entry with role="test" for each test file you find.
 
 
 # Dynamic prompt builders (per-run prompts injecting diff + affected files)
-def build_pattern_scanner_prompt(affected_files: list[str], diff_ref: str) -> str:
+def build_pattern_scanner_prompt(affected_files: list[str], diff_ref: str, *, cwd: Path) -> str:
     """Build the per-run pattern-scanner prompt.
 
     The prompt passes the affected file list and a diff ref. The specialist
@@ -162,6 +166,7 @@ def build_pattern_scanner_prompt(affected_files: list[str], diff_ref: str) -> st
     Args:
         affected_files: Paths of files touched by the diff under review.
         diff_ref: Git ref (e.g. base branch or SHA) the specialist can diff against.
+        cwd: Absolute working directory the agent runs in (grounds path resolution).
 
     Returns:
         The fully-rendered prompt string, including the JSON schema block.
@@ -178,6 +183,8 @@ Instructions:
 - Read any other house-style config files you find (ruff.toml, .editorconfig, tsconfig.json, go.mod, Cargo.toml).
 - Infer conventions from the code itself where config files are silent.
 
+{CWD_GROUNDING_INSTRUCTION.format(cwd=cwd)}
+
 <affected_files>
 {files_block}
 </affected_files>
@@ -190,7 +197,7 @@ work file-by-file so your context stays small.
 """
 
 
-def build_dependency_tracer_prompt(affected_files: list[FileInfo], diff_ref: str) -> str:
+def build_dependency_tracer_prompt(affected_files: list[FileInfo], diff_ref: str, *, cwd: Path) -> str:
     """Build the per-run dependency-tracer prompt.
 
     The prompt passes the affected file list and a diff ref. The specialist
@@ -200,6 +207,7 @@ def build_dependency_tracer_prompt(affected_files: list[FileInfo], diff_ref: str
     Args:
         affected_files: FileInfo entries for files reachable from the diff, each carrying a `path` and `role`.
         diff_ref: Git ref the specialist can diff against when probing call sites.
+        cwd: Absolute working directory the agent runs in (grounds path resolution).
 
     Returns:
         The fully-rendered prompt string, including the JSON schema block.
@@ -213,6 +221,8 @@ list beyond the static-resolved imports by grepping for call sites and
 reading the implementations. For every import or call edge you confirm,
 emit a Dependency record.
 
+{CWD_GROUNDING_INSTRUCTION.format(cwd=cwd)}
+
 <affected_files>
 {files_block}
 </affected_files>
@@ -225,7 +235,7 @@ work file-by-file so your context stays small.
 """
 
 
-def build_test_mapper_prompt(affected_files: list[str], diff_ref: str) -> str:
+def build_test_mapper_prompt(affected_files: list[str], diff_ref: str, *, cwd: Path) -> str:
     """Build the per-run test-mapper prompt.
 
     The prompt passes the affected file list and a diff ref. The specialist
@@ -235,6 +245,7 @@ def build_test_mapper_prompt(affected_files: list[str], diff_ref: str) -> str:
     Args:
         affected_files: Paths of files touched by the diff under review.
         diff_ref: Git ref the specialist can diff against when locating test files.
+        cwd: Absolute working directory the agent runs in (grounds path resolution).
 
     Returns:
         The fully-rendered prompt string, including the JSON schema block.
@@ -247,6 +258,8 @@ def build_test_mapper_prompt(affected_files: list[str], diff_ref: str) -> str:
 source file using conventional path mapping (tests/test_X.py, *.test.ts,
 *_test.go, tests/<crate>_test.rs). Emit a FileInfo with role="test" for
 each test file you find.
+
+{CWD_GROUNDING_INSTRUCTION.format(cwd=cwd)}
 
 <affected_files>
 {files_block}

--- a/daydream/prompts/grounding.py
+++ b/daydream/prompts/grounding.py
@@ -1,0 +1,21 @@
+"""Shared cwd-grounding instruction for review/exploration prompts.
+
+When daydream runs in a linked git worktree whose shared git dir lives in a
+sibling main worktree, agents that derive the repo root from git topology
+(`git worktree list`, `git rev-parse --git-common-dir`, the `.git` gitdir line)
+resolve paths against the WRONG worktree. This instruction grounds every agent
+to its actual working directory so file paths resolve correctly.
+"""
+
+from __future__ import annotations
+
+CWD_GROUNDING_INSTRUCTION = (
+    "Your working directory is {cwd}. This is a git worktree whose shared git "
+    "dir may belong to a different worktree. Resolve every file path relative "
+    "to this directory (or `git rev-parse --show-toplevel`). NEVER derive "
+    "paths from `git worktree list`, `git rev-parse --git-common-dir`, or the "
+    "`.git` file. Any path passed to a subagent must live under this working "
+    "directory."
+)
+
+__all__ = ["CWD_GROUNDING_INSTRUCTION"]

--- a/daydream/prompts/review_system_prompt.py
+++ b/daydream/prompts/review_system_prompt.py
@@ -7,6 +7,9 @@ LLM agents with tool use and code execution environments.
 """
 
 from dataclasses import dataclass
+from pathlib import Path
+
+from daydream.prompts.grounding import CWD_GROUNDING_INSTRUCTION
 
 
 @dataclass
@@ -20,7 +23,7 @@ class CodebaseMetadata:
     changed_files: list[str] | None = None  # For PR reviews
 
 
-def build_review_system_prompt(metadata: CodebaseMetadata) -> str:
+def build_review_system_prompt(metadata: CodebaseMetadata, *, cwd: Path) -> str:
     """
     Build the system prompt for the code review agent.
 
@@ -32,10 +35,16 @@ def build_review_system_prompt(metadata: CodebaseMetadata) -> str:
 
     Args:
         metadata: Information about the codebase to review
+        cwd: Absolute working directory the agent runs in (grounds path resolution).
 
     Returns:
         Complete system prompt string
     """
+    grounding_section = f"""
+## Working Directory
+
+{CWD_GROUNDING_INSTRUCTION.format(cwd=cwd)}
+"""
     languages_str = ", ".join(metadata.languages) if metadata.languages else "Unknown"
     largest_files_str = "\n".join(
         f"  - {path}: {tokens:,} tokens" for path, tokens in metadata.largest_files[:5]
@@ -78,7 +87,7 @@ full content and return summarized findings that fit in your context window.
 
 ### Largest Files
 {largest_files_str}
-{changed_files_section}
+{changed_files_section}{grounding_section}
 ---
 
 ## Available Data Structures
@@ -354,6 +363,8 @@ def build_pr_review_prompt(
     metadata: CodebaseMetadata,
     pr_title: str,
     pr_description: str,
+    *,
+    cwd: Path,
 ) -> str:
     """
     Build a specialized prompt for PR-focused reviews.
@@ -364,11 +375,12 @@ def build_pr_review_prompt(
         metadata: Codebase metadata (should include changed_files)
         pr_title: Title of the pull request
         pr_description: Description/body of the pull request
+        cwd: Absolute working directory the agent runs in (grounds path resolution).
 
     Returns:
         Complete system prompt for PR review
     """
-    base_prompt = build_review_system_prompt(metadata)
+    base_prompt = build_review_system_prompt(metadata, cwd=cwd)
 
     pr_context = f"""
 ---
@@ -405,6 +417,8 @@ def get_review_prompt(
     changed_files: list[str] | None = None,
     pr_title: str | None = None,
     pr_description: str | None = None,
+    *,
+    cwd: Path,
 ) -> str:
     """
     Convenience function to generate a review prompt.
@@ -417,6 +431,7 @@ def get_review_prompt(
         changed_files: Files changed in this PR (optional)
         pr_title: PR title for PR reviews (optional)
         pr_description: PR description for PR reviews (optional)
+        cwd: Absolute working directory the agent runs in (grounds path resolution).
 
     Returns:
         Complete system prompt string
@@ -434,6 +449,7 @@ def get_review_prompt(
             metadata=metadata,
             pr_title=pr_title,
             pr_description=pr_description or "",
+            cwd=cwd,
         )
 
-    return build_review_system_prompt(metadata)
+    return build_review_system_prompt(metadata, cwd=cwd)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,6 +120,38 @@ def feature_branch_repo(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
+def linked_worktree(tmp_path: Path) -> tuple[Path, Path]:
+    """A main worktree + a linked worktree on a feature branch (issue #221).
+
+    The main repo lives at ``main_repo`` on ``main`` and contains only
+    ``base.txt``. A ``feature`` branch adds files under ``services/taste/`` that
+    do NOT exist on ``main``. A linked worktree is checked out on ``feature`` at
+    ``linked_worktree``, sharing the main repo's git dir.
+
+    This reproduces the bug's trap: from the linked worktree, git topology
+    (``git rev-parse --git-common-dir`` / ``git worktree list``) points at the
+    MAIN worktree, where ``services/taste/`` does not exist. An agent that
+    re-roots a relative path via git topology reads the wrong worktree.
+
+    Returns:
+        ``(main_repo_path, linked_worktree_path)``.
+    """
+    main_repo = _make_repo_with_main(tmp_path, name="main_repo")
+    _git(main_repo, "checkout", "-b", "feature")
+    taste = main_repo / "services" / "taste"
+    taste.mkdir(parents=True, exist_ok=True)
+    for name in ("parser.go", "lexer.go", "token.go", "ast.go"):
+        (taste / name).write_text(f"package taste\n\n// {name}\nfunc {name[:-3].title()}() {{}}\n")
+    _git(main_repo, "add", "services/taste")
+    _commit(main_repo, "add taste service")
+    # Return the main worktree to `main` so it does NOT contain services/taste/.
+    _git(main_repo, "checkout", "main")
+    linked = tmp_path / "linked_worktree"
+    _git(main_repo, "worktree", "add", str(linked), "feature")
+    return main_repo, linked
+
+
+@pytest.fixture
 def bare_origin(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """A bare repo suitable for use as `origin`."""
     path = tmp_path_factory.mktemp("origin") / "remote.git"

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -22,6 +22,7 @@ class _PromptPaths(TypedDict):
     intent_path: Path
     alternatives_path: Path
     output_path: Path
+    cwd: Path
 
 
 def _paths(tmp_path: Path) -> _PromptPaths:
@@ -30,6 +31,7 @@ def _paths(tmp_path: Path) -> _PromptPaths:
         "intent_path": tmp_path / ".daydream" / "deep" / "intent.md",
         "alternatives_path": tmp_path / ".daydream" / "deep" / "alternatives.json",
         "output_path": tmp_path / ".daydream" / "deep" / "stack-python-review.md",
+        "cwd": tmp_path,
     }
 
 
@@ -122,8 +124,13 @@ def test_prompts_embed_no_full_file_contents(tmp_path: Path) -> None:
         files=["api.py"],
         **p,
     )
-    # Heuristic: no line longer than 400 chars (an embedded diff would blow this up)
-    assert all(len(line) < 400 for line in out.splitlines())
+    # Heuristic: no line longer than 400 chars (an embedded diff would blow this
+    # up). The cwd-grounding instruction (issue #221) is one fixed long line and
+    # is not file content, so exclude it from this check.
+    from daydream.prompts.grounding import CWD_GROUNDING_INSTRUCTION
+
+    grounding = CWD_GROUNDING_INSTRUCTION.format(cwd=tmp_path)
+    assert all(len(line) < 400 for line in out.splitlines() if line != grounding)
 
 
 def test_per_stack_prompt_points_at_diff_path(tmp_path: Path) -> None:
@@ -317,6 +324,7 @@ def test_build_structural_prompt_has_no_stack_scope_restriction(tmp_path: Path) 
         intent_path=tmp_path / "intent.md",
         alternatives_path=tmp_path / "alternatives.json",
         output_path=tmp_path / "out.md",
+        cwd=tmp_path,
     )
     assert "Focus ONLY on these files" not in prompt
     assert "Do NOT review files from other stacks" not in prompt
@@ -336,6 +344,7 @@ def test_build_structural_prompt_omits_exploration_pointer(tmp_path: Path) -> No
         alternatives_path=tmp_path / "alternatives.json",
         output_path=tmp_path / "out.md",
         exploration_dir=tmp_path / "exploration",
+        cwd=tmp_path,
     )
     assert "exploration" not in prompt.lower()
 
@@ -500,3 +509,70 @@ def test_structural_prompt_keeps_diff_pointer_and_read_freedom(tmp_path: Path) -
     assert "read any file in the codebase" in out
     assert str(p["diff_path"]) in out  # keeps its pointer
     assert "Read it directly" in out   # structural prompt unchanged
+
+
+# =============================================================================
+# Issue #221 — cwd grounding injected into every deep prompt builder
+# =============================================================================
+
+
+def test_per_stack_prompt_contains_cwd_grounding(tmp_path: Path) -> None:
+    from daydream.prompts.grounding import CWD_GROUNDING_INSTRUCTION
+
+    p = _paths(tmp_path)
+    out = build_per_stack_prompt(
+        skill_invocation="/beagle-python:review-python",
+        stack_name="python",
+        files=["api.py"],
+        **p,
+    )
+    assert CWD_GROUNDING_INSTRUCTION.format(cwd=tmp_path) in out
+    assert str(tmp_path) in out
+
+
+def test_structural_prompt_contains_cwd_grounding(tmp_path: Path) -> None:
+    from daydream.deep.prompts import build_structural_prompt
+    from daydream.prompts.grounding import CWD_GROUNDING_INSTRUCTION
+
+    p = _paths(tmp_path)
+    out = build_structural_prompt(
+        skill_invocation="/beagle-core:review-structure",
+        files=["api.py"],
+        **p,
+    )
+    assert CWD_GROUNDING_INSTRUCTION.format(cwd=tmp_path) in out
+
+
+def test_arbiter_prompt_contains_cwd_grounding(tmp_path: Path) -> None:
+    from daydream.deep.prompts import build_arbiter_prompt
+    from daydream.prompts.grounding import CWD_GROUNDING_INSTRUCTION
+
+    out = build_arbiter_prompt(
+        arbiter_input_path=tmp_path / "arbiter-input.json",
+        diff_path=tmp_path / "diff.patch",
+        intent_path=tmp_path / "intent.md",
+        alternatives_path=tmp_path / "alternatives.json",
+        cwd=tmp_path,
+    )
+    assert CWD_GROUNDING_INSTRUCTION.format(cwd=tmp_path) in out
+
+
+def test_generic_fallback_prompt_contains_cwd_grounding(tmp_path: Path) -> None:
+    from daydream.prompts.grounding import CWD_GROUNDING_INSTRUCTION
+
+    p = _paths(tmp_path)
+    out = build_generic_fallback_prompt(files=["config.yaml"], **p)
+    assert CWD_GROUNDING_INSTRUCTION.format(cwd=tmp_path) in out
+
+
+def test_verification_prompt_contains_cwd_grounding(tmp_path: Path) -> None:
+    from daydream.deep.prompts import build_verification_prompt
+    from daydream.prompts.grounding import CWD_GROUNDING_INSTRUCTION
+
+    out = build_verification_prompt(
+        items=[{"id": 1, "lens": "per-stack", "severity": "high", "file": "api.py",
+                "line": 10, "description": "x", "rationale": "y"}],
+        cwd=tmp_path,
+        output_path=tmp_path / "verdicts.json",
+    )
+    assert CWD_GROUNDING_INSTRUCTION.format(cwd=tmp_path) in out

--- a/tests/test_exploration_runner.py
+++ b/tests/test_exploration_runner.py
@@ -26,6 +26,7 @@ from daydream.prompts.exploration_subagents import (
     build_pattern_scanner_prompt,
     build_test_mapper_prompt,
 )
+from daydream.prompts.grounding import CWD_GROUNDING_INSTRUCTION
 
 FIXTURES = Path(__file__).parent / "fixtures" / "diffs"
 
@@ -34,7 +35,7 @@ FIXTURES = Path(__file__).parent / "fixtures" / "diffs"
 def test_pattern_scanner_prompt_includes_guideline_files():
     assert "CLAUDE.md" in PATTERN_SCANNER_SYSTEM_PROMPT
 
-    dynamic = build_pattern_scanner_prompt(["daydream/foo.py"], "main...HEAD")
+    dynamic = build_pattern_scanner_prompt(["daydream/foo.py"], "main...HEAD", cwd=Path("/repo"))
     assert "CLAUDE.md" in dynamic
     assert "main...HEAD" in dynamic
     assert "daydream/foo.py" in dynamic
@@ -50,7 +51,7 @@ def test_pattern_scanner_prompt_includes_guideline_files():
 
 def test_dependency_tracer_prompt_mentions_affected_files():
     files = [FileInfo("daydream/a.py", "modified"), FileInfo("daydream/b.py", "modified")]
-    prompt = build_dependency_tracer_prompt(files, "main...HEAD")
+    prompt = build_dependency_tracer_prompt(files, "main...HEAD", cwd=Path("/repo"))
     assert "daydream/a.py" in prompt
     assert "daydream/b.py" in prompt
     assert "main...HEAD" in prompt
@@ -59,12 +60,34 @@ def test_dependency_tracer_prompt_mentions_affected_files():
 
 
 def test_test_mapper_prompt_instructs_mapping():
-    prompt = build_test_mapper_prompt(["daydream/x.py"], "main...HEAD")
+    prompt = build_test_mapper_prompt(["daydream/x.py"], "main...HEAD", cwd=Path("/repo"))
     assert "test" in prompt.lower()
     assert "daydream/x.py" in prompt
     assert "main...HEAD" in prompt
     assert "```json" in prompt
     assert "<diff>" not in prompt
+
+
+def test_pattern_scanner_prompt_contains_cwd_grounding():
+    cwd = Path("/tmp/linked/worktree")
+    prompt = build_pattern_scanner_prompt(["daydream/foo.py"], "main...HEAD", cwd=cwd)
+    assert CWD_GROUNDING_INSTRUCTION.format(cwd=cwd) in prompt
+    assert str(cwd) in prompt
+
+
+def test_dependency_tracer_prompt_contains_cwd_grounding():
+    cwd = Path("/tmp/linked/worktree")
+    files = [FileInfo("daydream/a.py", "modified")]
+    prompt = build_dependency_tracer_prompt(files, "main...HEAD", cwd=cwd)
+    assert CWD_GROUNDING_INSTRUCTION.format(cwd=cwd) in prompt
+    assert str(cwd) in prompt
+
+
+def test_test_mapper_prompt_contains_cwd_grounding():
+    cwd = Path("/tmp/linked/worktree")
+    prompt = build_test_mapper_prompt(["daydream/x.py"], "main...HEAD", cwd=cwd)
+    assert CWD_GROUNDING_INSTRUCTION.format(cwd=cwd) in prompt
+    assert str(cwd) in prompt
 
 
 def test_schemas_are_valid_objects():
@@ -217,7 +240,11 @@ def test_parallel_tier_routes_correct_file_lists(tmp_path):
     backend = _SpecialistMockBackend()
     anyio.run(pre_scan, backend, tmp_path, diff_text)
 
-    diff_changed = {"daydream_demo/api.py", "daydream_demo/models.py", "src/api.ts", "src/models.ts"}
+    # Paths are now cwd-absolute (issue #221): rooted at repo_root (tmp_path).
+    diff_changed = {
+        str(tmp_path / p)
+        for p in ("daydream_demo/api.py", "daydream_demo/models.py", "src/api.ts", "src/models.ts")
+    }
 
     calls_by_schema = {}
     for call in backend.execute_calls:
@@ -292,3 +319,43 @@ def test_specialist_failure_doesnt_cancel_others(tmp_path):
     assert call_count == 3
     assert ctx.conventions == []  # pattern scanner failed
     assert any(f.path == "daydream/extra.py" for f in ctx.affected_files)
+
+
+def _multifile_diff(paths: list[str]) -> str:
+    return "".join(
+        f"diff --git a/{p} b/{p}\n--- a/{p}\n+++ b/{p}\n@@ -1 +1 @@\n-old\n+new\n"
+        for p in paths
+    )
+
+
+def test_pre_scan_passes_cwd_absolute_changed_paths(tmp_path):
+    # 4 files => parallel tier => pattern_scanner & test_mapper receive changed_paths.
+    paths = [f"services/taste/file{i}.py" for i in range(4)]
+    diff_text = _multifile_diff(paths)
+    backend = _SpecialistMockBackend()
+
+    anyio.run(pre_scan, backend, tmp_path, diff_text)
+
+    joined = "\n".join(c["prompt"] for c in backend.execute_calls)
+    # Specialists receive cwd-absolute paths, never bare relatives.
+    assert str(tmp_path / "services/taste/file0.py") in joined
+    assert "- services/taste/file0.py\n" not in joined
+
+
+def test_pre_scan_passes_cwd_absolute_static_files(tmp_path, monkeypatch):
+    import daydream.exploration_runner as er
+
+    monkeypatch.setattr(
+        er,
+        "detect_affected_files",
+        lambda diff_text, repo_root, depth: [FileInfo("services/taste/dep.py", "imports", "helper")],
+    )
+    # 2 files => single tier => dependency_tracer gets static_files.
+    diff_text = _multifile_diff(["services/taste/a.py", "services/taste/b.py"])
+    backend = _SpecialistMockBackend()
+
+    anyio.run(pre_scan, backend, tmp_path, diff_text)
+
+    dep_prompt = backend.execute_calls[0]["prompt"]
+    assert str(tmp_path / "services/taste/dep.py") in dep_prompt
+    assert "- services/taste/dep.py (" not in dep_prompt

--- a/tests/test_prompts_grounding.py
+++ b/tests/test_prompts_grounding.py
@@ -1,0 +1,21 @@
+"""Unit tests for the shared cwd-grounding instruction constant."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from daydream.prompts.grounding import CWD_GROUNDING_INSTRUCTION
+
+
+def test_grounding_instruction_contains_cwd_warning() -> None:
+    text = CWD_GROUNDING_INSTRUCTION
+    assert "git worktree" in text
+    assert "git rev-parse --show-toplevel" in text
+    assert "git rev-parse --git-common-dir" in text
+    assert "git worktree list" in text
+
+
+def test_grounding_instruction_formats_cwd() -> None:
+    cwd = Path("/tmp/some/linked/worktree")
+    rendered = CWD_GROUNDING_INSTRUCTION.format(cwd=cwd)
+    assert str(cwd) in rendered

--- a/tests/test_review_system_prompt.py
+++ b/tests/test_review_system_prompt.py
@@ -1,0 +1,41 @@
+"""Tests for cwd-grounding in the review system prompt builders."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from daydream.prompts.grounding import CWD_GROUNDING_INSTRUCTION
+from daydream.prompts.review_system_prompt import (
+    CodebaseMetadata,
+    build_pr_review_prompt,
+    build_review_system_prompt,
+)
+
+
+def _metadata() -> CodebaseMetadata:
+    return CodebaseMetadata(
+        file_count=10,
+        total_tokens=1000,
+        languages=["Python"],
+        largest_files=[("daydream/runner.py", 500)],
+        changed_files=["daydream/runner.py"],
+    )
+
+
+def test_review_prompt_contains_cwd_grounding() -> None:
+    cwd = Path("/tmp/linked/worktree")
+    prompt = build_review_system_prompt(_metadata(), cwd=cwd)
+    assert CWD_GROUNDING_INSTRUCTION.format(cwd=cwd) in prompt
+    assert str(cwd) in prompt
+
+
+def test_pr_review_prompt_contains_cwd_grounding() -> None:
+    cwd = Path("/tmp/linked/worktree")
+    prompt = build_pr_review_prompt(
+        _metadata(),
+        pr_title="Add taste parser",
+        pr_description="Implements the parser",
+        cwd=cwd,
+    )
+    assert CWD_GROUNDING_INSTRUCTION.format(cwd=cwd) in prompt
+    assert str(cwd) in prompt

--- a/tests/test_worktree_cwd_grounding.py
+++ b/tests/test_worktree_cwd_grounding.py
@@ -1,0 +1,97 @@
+"""Real-path test for cwd grounding in a linked git worktree (issue #221).
+
+Drives the real ``pre_scan`` exploration pipeline against an actual linked git
+worktree whose sibling main worktree contains different content at the same
+relative paths. Only the backend is mocked. Asserts that the specialist prompts
+carry cwd-absolute paths under the LINKED worktree (never the main worktree) and
+the cwd-grounding instruction — the deterministic contract the fix locks.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+import anyio
+
+from daydream.backends import AgentEvent, ResultEvent
+from daydream.exploration_runner import pre_scan
+from daydream.prompts.exploration_subagents import (
+    DEPENDENCY_TRACER_SCHEMA,
+    PATTERN_SCANNER_SCHEMA,
+    TEST_MAPPER_SCHEMA,
+)
+from daydream.prompts.grounding import CWD_GROUNDING_INSTRUCTION
+
+
+class _PromptCapturingBackend:
+    """Backend stub: captures every prompt and returns schema-shaped output."""
+
+    model = "mock-model"
+
+    def __init__(self) -> None:
+        self.prompts: list[str] = []
+
+    async def execute(  # type: ignore[no-untyped-def]
+        self,
+        cwd,
+        prompt,
+        output_schema=None,
+        continuation=None,
+        agents=None,
+        max_turns=None,
+        read_only=False,
+    ) -> AsyncIterator[AgentEvent]:
+        self.prompts.append(prompt)
+        result: dict[str, Any] = {}
+        if output_schema == PATTERN_SCANNER_SCHEMA:
+            result = {"conventions": [], "guidelines": []}
+        elif output_schema == DEPENDENCY_TRACER_SCHEMA:
+            result = {"affected_files": [], "dependencies": []}
+        elif output_schema == TEST_MAPPER_SCHEMA:
+            result = {"affected_files": []}
+        yield ResultEvent(structured_output=result, continuation=None)
+
+    async def cancel(self) -> None:
+        return None
+
+    def format_skill_invocation(self, skill_key: str, args: str = "") -> str:
+        return f"/{skill_key}"
+
+
+def test_pre_scan_grounds_specialists_to_linked_worktree(linked_worktree: tuple[Path, Path]) -> None:
+    main_repo, linked = linked_worktree
+
+    # Sanity: the trap is real — services/taste/ exists only in the linked worktree.
+    assert (linked / "services" / "taste" / "parser.go").exists()
+    assert not (main_repo / "services" / "taste").exists()
+
+    diff_text = subprocess.run(  # noqa: S603 - args are not user-controlled
+        ["git", "diff", "main...HEAD"],  # noqa: S607 - git is a trusted command
+        cwd=linked,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    # 4 changed files => parallel tier => all three specialists run.
+    assert "services/taste/parser.go" in diff_text
+
+    backend = _PromptCapturingBackend()
+    anyio.run(pre_scan, backend, linked, diff_text)
+
+    assert backend.prompts, "expected specialist prompts to be captured"
+    joined = "\n".join(backend.prompts)
+
+    # Every specialist prompt carries the cwd-grounding instruction rooted at the
+    # linked worktree.
+    for prompt in backend.prompts:
+        assert CWD_GROUNDING_INSTRUCTION.format(cwd=linked) in prompt
+
+    # Specialist file lists are cwd-absolute under the LINKED worktree.
+    assert str(linked / "services" / "taste" / "parser.go") in joined
+
+    # The main worktree path never leaks into any prompt (its sibling, where
+    # services/taste/ does not exist).
+    assert str(main_repo) not in joined


### PR DESCRIPTION
## Summary

- Inject a shared `CWD_GROUNDING_INSTRUCTION` into every review/exploration prompt builder telling agents to resolve paths relative to their cwd (or `git rev-parse --show-toplevel`), never via git topology (`git worktree list`, `--git-common-dir`, `.git` gitdir line)
- Pass cwd-absolute paths (`repo_root / path`) in `exploration_runner.pre_scan` to specialist prompts instead of bare relatives, eliminating the need for agents to resolve paths at all
- Update all call sites in `phases.py` to pass `cwd=work.repo` to the modified prompt builders

## Motivation

When daydream runs in a **linked git worktree** whose shared git directory lives in a **sibling main worktree**, review/exploration agents construct absolute file paths rooted at the main worktree (via git topology) and try to read source files there instead of in the cwd worktree. Those paths do not exist in the main worktree (it is on a different branch), so reads fail and the review runs against wrong/missing files.

Daydream's cwd wiring is correct — every agent is launched with `cwd = work.repo` (the linked worktree). The leak is **agent-side path resolution**: agents derive the repo root from git topology, which points at the main worktree from a linked worktree, then glue relative subpaths onto that wrong root.

Closes #221

## Changes

### Added
- `daydream/prompts/grounding.py` — shared `CWD_GROUNDING_INSTRUCTION` constant
- `tests/test_prompts_grounding.py` — unit tests for the grounding instruction
- `tests/test_review_system_prompt.py` — tests for cwd grounding in review prompts
- `tests/test_worktree_cwd_grounding.py` — real-path test driving `pre_scan` through an actual linked worktree
- `linked_worktree` fixture in `tests/conftest.py`

### Changed
- `daydream/prompts/review_system_prompt.py` — added `cwd: Path` to `build_review_system_prompt`, `build_pr_review_prompt`, `get_review_prompt`; injects grounding instruction
- `daydream/prompts/exploration_subagents.py` — added `cwd: Path` to all three specialist prompt builders; injects grounding instruction
- `daydream/deep/prompts.py` — added `cwd: Path` to `build_per_stack_prompt`, `build_structural_prompt`, `build_arbiter_prompt`, `build_generic_fallback_prompt`; renamed `target_dir` to `cwd` in `build_verification_prompt`
- `daydream/exploration_runner.py` — `pre_scan` passes `cwd=repo_root` to specialists; `changed_paths` and `static_files` are now cwd-absolute
- `daydream/phases.py` — all prompt builder call sites pass `cwd=work.repo`

### Fixed
- Review/exploration agents no longer resolve repo root via git topology in linked worktrees

## Test Plan

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check`)
- [x] Type checking passes (`uv run mypy daydream`)
- [x] Real-path test creates an actual linked worktree with different content in the main worktree, drives `pre_scan` through it, and asserts prompts carry cwd-absolute paths under the linked worktree (never the main worktree) plus the grounding instruction

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check`)
- [x] Type checking passes (`uv run mypy daydream`)
- [x] Documentation updated (if applicable)