### PR TITLE
docs: comprehensive sweep of all repo docs against current codebase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,13 @@ jobs:
         with:
           python-version: "3.12"
 
+      # Reads the freshly checked-out committed uv.lock BEFORE `uv sync` can heal
+      # it. Fails if a release bumped pyproject.toml but forgot `uv lock`, so a
+      # stale lock (which breaks `uv sync --locked` for reproducible installs)
+      # can never merge.
+      - name: Verify uv.lock is in sync
+        run: uv lock --check
+
       - name: Install dependencies
         run: uv sync
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,455 +1,262 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code (claude.ai/code) when working in this repository.
 
-## Project Overview
+## Project overview
 
-Daydream is an automated code review and fix loop using the Claude Agent SDK. It launches review agents equipped with Beagle skills (specialized knowledge modules) to review code, parse actionable feedback, apply fixes automatically, and validate changes by running tests.
+Daydream is an automated code review and fix loop. It reviews diffs using stack-specific [Beagle](https://github.com/existential-birds/beagle) skills, applies fixes, validates via test suite, and records every agent interaction as an [ATIF v1.6](https://www.harborframework.com/docs/agents/trajectory-format) trajectory. A bitemporal corpus pipeline scores, labels, and projects those trajectories into JSONL datasets for SFT and RL fine-tuning.
+
+The default flow is a deep multi-stack pipeline. `--shallow` opts into a single-skill loop. `--comment` and `--review` produce review-only output (PR comments or markdown report). The `daydream feedback <pr#>` subcommand ingests bot review comments.
+
+Three backends are supported: Claude (in-process SDK), Codex (subprocess CLI), and Pi (subprocess CLI for z.ai GLM models). All backends emit the same `AgentEvent` stream, consumed by `run_agent()` and the trajectory recorder.
 
 ## Commands
 
 ```bash
-# Install dependencies and git hooks
-make install
-make hooks
+make install   # install dependencies and git hooks
+make hooks     # install pre-push hook
+make lint      # ruff
+make typecheck # mypy daydream tests
+make test      # pytest
+make check     # lint + typecheck + full pytest (the gate)
+```
 
-# Run the CLI
-daydream [TARGET] [OPTIONS]
-
-# Run as module
-python -m daydream
-
+```bash
 # Golden paths (near-zero-flag; `daydream /path` == `daydream review /path`)
-daydream /path/to/project                          # review → fix → test (deep multi-stack)
-daydream --comment /path/to/project                # review → post inline PR comments, then exit
+daydream /path/to/project                          # review -> fix -> test (deep multi-stack)
+daydream --comment /path/to/project                # review -> post inline PR comments, then exit
 
 # Other verbs / flags
-daydream --shallow -s python /path/to/project      # Shallow Python review-fix-test loop
-daydream --review /path/to/project                 # Review only, skip fixes
-daydream --yes /path/to/project                    # Auto-apply fixes without prompting
-daydream --loop 3 /path/to/project                 # Repeat review-fix-test up to 3 rounds
-daydream feedback 42 --bot "<bot-login>[bot]" /path/to/project  # Bot PR comments
-daydream --non-interactive /path/to/project        # Unattended/harness run: take safe defaults, no prompts
-daydream --help-all                                # Full advanced flag surface (--start-at, --trajectory, ...)
-daydream --review --findings-out findings.json --pr-number 7 /path  # Phase A: emit strict-schema findings artifact
-daydream post-findings findings.json --pr 7 --head-sha <sha> --repo owner/repo  # Phase B: validate + post (unattended)
+daydream --shallow -s python /path/to/project      # shallow Python review-fix-test loop
+daydream --review /path/to/project                 # review only, skip fixes
+daydream --yes /path/to/project                    # auto-apply fixes without prompting
+daydream --loop 3 /path/to/project                 # repeat review-fix-test up to 3 rounds
+daydream feedback 42 --bot "<bot-login>[bot]" /path/to/project  # bot PR comments
+daydream --non-interactive /path/to/project        # unattended/harness run
+daydream --help-all                                # full advanced flag surface
 
-# Data pipeline moved under the `corpus` namespace
-daydream corpus harvest                            # Annotate archived runs
-daydream corpus build --out out.jsonl              # Project to JSONL training corpus
+# Findings artifact (two-phase post)
+daydream --review --findings-out findings.json --pr-number 7 /path
+daydream post-findings findings.json --pr 7 --head-sha <sha> --repo owner/repo
+
+# Self-hosted review bot
+daydream setup /path/to/repo --repo OWNER/REPO     # one-command App + secrets + workflow PR
+daydream setup /path/to/repo --verify              # read-only install audit
+
+# Run-info markdown
+daydream summarize <path>                          # print trajectory summary for a run dir or file
+
+# Data pipeline (under the `corpus` namespace)
+daydream corpus harvest                            # annotate archived runs (reward + label)
+daydream corpus build --out out.jsonl              # project labeled runs to JSONL training corpus
 daydream corpus label <session_id> --outcome accepted
+
+# Benchmark
+daydream bench --benchmark-repo ../code-review-benchmark/offline --score
 
 # Per-phase model/backend overrides are config-file-only (no CLI flags):
 #   set [tool.daydream] / [tool.daydream.phases.<phase>] in pyproject.toml or .daydream.toml.
 #   Precedence: CLI (--model/--backend) > config file > built-in default.
-
-# Development
-make lint       # Run ruff linter
-make typecheck  # Run mypy type checker
-make test       # Run pytest
-make check      # Run all CI checks locally
 ```
 
-## Testing Standard (mandatory)
+## Testing standard (mandatory)
 
 Every user-visible behavior must have at least one **real-path test**: a test that
 enters from the production entrypoint (`runner.run` / the CLI) with real
-dependencies — real temp git worktree, real filesystem, real event loop — mocking only
+dependencies (real temp git worktree, real filesystem, real event loop), mocking only
 the external network/API backend (via the `Backend` protocol / `create_backend` seam).
 Tests must assert observable outcomes (exit code, files written, fixes applied or
 declined, transcript state), never that a function was merely called. Unit tests are
-supplementary, not a substitute. When shipping a feature, the real-path test that drives
-its production path through the prompt/decision it changes is part of the deliverable —
-not an optional smoke step. Reference exemplar: the non-interactive/EOF gate tests in
-`tests/test_deep_orchestrator.py` drive `runner.run` to the real `prompt_user` gate and
-fail if the feature is reverted.
+supplementary, not a substitute. Reference exemplar: the non-interactive/EOF gate tests
+in `tests/test_deep_orchestrator.py`.
 
-**No caveats — all work is completed.** Do not close out a task with deferred items,
-"optional" follow-ups, "out of scope for now", unverified references, or smoke-tests
-substituted for real coverage. If a behavior is in scope, its real-path test is written,
-run, and green before sign-off — not described, deferred, or left as a note. A reference
-you haven't verified against live code is not a caveat to flag; verify it, then state it
-as fact. Either the work is done and proven, or it is explicitly still in progress —
-never "done, with caveats."
+**No caveats.** All work is completed and proven, or explicitly in progress. No
+deferred items, no "optional" follow-ups, no smoke-tests substituted for real coverage.
 
-## Non-Negotiable: Fix Bugs at the Root — Never Bypass, Paper Over, or Conceal
+## Non-negotiable: fix bugs at the root
 
-This is the highest-priority directive in this file. Violating it makes the agent
-dangerous and unusable. It overrides any instinct to complete the literal task quickly.
+The highest-priority directive in this file. Violating it makes the agent dangerous
+and unusable.
 
-1. **A bug in a safety or verification mechanism is fixed at its root cause —
-   never bypassed.** If a pre-push hook, CI gate, test, type check, lint, or guard
-   fails or misbehaves, the only acceptable response is to find and fix the
-   underlying defect. The following are FORBIDDEN as "solutions": `git push
-   --no-verify`, skipping or disabling tests, commenting out a check, deleting a
-   guard, lowering an assertion, or otherwise routing around the mechanism. The
-   mechanism is not an obstacle between you and the goal — making it pass *honestly*
-   IS the goal. If you ever catch yourself reaching for a bypass flag, stop: that is
-   the signal that you have not found the real bug yet.
+1. A bug in a safety or verification mechanism is fixed at its root cause, never
+   bypassed. `git push --no-verify`, skipping tests, commenting out checks, deleting
+   guards, lowering assertions are all forbidden. Making the gate pass honestly IS
+   the goal.
 
-2. **Own your own bugs in plain language.** If code you wrote is broken, say "I
-   wrote a bug" and fix it. Do NOT describe your own defect as the tool, hook,
-   environment, or framework being "destructive," "buggy," "hazardous," or "an
-   obstacle." Externalizing your own mistake to avoid fixing it is a form of
-   dishonesty and is banned.
+2. Own your own bugs in plain language. Do not describe your own defect as the tool,
+   hook, or framework being "destructive" or "buggy."
 
-3. **Fix the bug where it lives, not at a convenient layer.** Do not paper over a
-   defect by adding hacks to an unrelated or downstream component (e.g. special-case
-   workarounds in a standard tool/hook to compensate for broken application or test
-   code). Diagnose the actual source and fix it there. Keep standard infrastructure
-   standard.
+3. Fix the bug where it lives, not at a convenient downstream layer.
 
-4. **A dangerous bug outranks the assigned task.** If you discover a defect that
-   corrupts state, loses data, mutates the wrong target, or compromises a safety
-   mechanism, stop and fix it before continuing — and state it immediately, plainly,
-   and without minimizing. Never proceed with the original task on top of a known
-   dangerous bug.
+4. A dangerous bug (state corruption, data loss, compromised safety mechanism)
+   outranks the assigned task. Stop and fix it first.
 
-5. **Never claim success that isn't verified-working.** "Committed," "pushed," or
-   "done" is not "working." Do not report a task complete, fine, or successful unless
-   you have verified the actual behavior works (see Testing Standard). Premature or
-   false completion claims — declaring victory to end the interaction while a known
-   problem remains — are forbidden.
+5. Never claim success that isn't verified-working. "Committed" or "pushed" is not
+   "working" unless the actual behavior is verified.
 
-6. **When the user pushes back, the workaround is wrong — find the simple fix.**
-   If the user questions your approach on the same point more than once ("why are you
-   skipping it?", "just fix it"), STOP defending, working around, or re-explaining.
-   Treat their objection as correct and do the direct, root-cause fix they are
-   pointing at. Do not make the user extract the truth or the obvious fix through
-   repeated confrontation. The obvious, simple fix is almost always the right one;
-   reach for it first, not last.
+6. When the user pushes back more than once on the same point, stop defending and do
+   the direct, root-cause fix.
 
 ## Architecture
 
-The package follows a phased execution model:
+### Execution flow
 
 ```
-cli.py → runner.py → phases.py → agent.py
-                  ↘ ui/ (terminal output)
+cli.py -> runner.py -> deep/orchestrator.py -> phases.py -> agent.py -> Backend.execute()
+                              \-> ui/ (terminal output)
 ```
 
-### Module Responsibilities
+- `runner.run()` is the async entry. Dispatches one of: deep multi-stack (default),
+  shallow single-stack, `--comment`, `--review`, or `daydream feedback <pr#>`.
+- `agent.run_agent()` is the only agent call site. Never call a backend/SDK directly
+  from phases. It wraps `Backend.execute()` and drives the Rich UI + trajectory recorder.
+- Subagent fan-out (exploration, per-stack review, parallel fix) is N parallel
+  `run_agent()` calls under `anyio.CapacityLimiter(4)`, not SDK `agents=`.
+- `TrajectoryRecorder` propagates via `ContextVar`; `recorder.fork()` creates sibling
+  trajectories for parallel fan-outs.
 
-- **cli.py**: Entry point, argument parsing, signal handlers (SIGINT/SIGTERM)
-- **runner.py**: Main orchestration via `run()` async function, `RunConfig` dataclass
-- **phases.py**: Stateless `phase_*()` workflow steps. Shallow loop: `phase_review` → `phase_parse_feedback` → `phase_fix` → `phase_test_and_heal`. Deep pipeline: `phase_understand_intent`, `phase_alternative_review`, `phase_per_stack_reviews`, `phase_arbiter_review`, `phase_cross_stack_merge`. PR feedback: `phase_fetch_pr_feedback`, `phase_respond_pr_feedback`
-- **agent.py**: Backend wrapper, `run_agent()` streams responses, `AgentState` dataclass for consolidated state, `MissingSkillError` exception
-- **trajectory.py**: ATIF v1.6 trajectory recorder, `TrajectoryRecorder` with `ContextVar` propagation, `Invocation` per-`run_agent` scope, `Redactor` for secret scrubbing, `DaydreamPhase`/`DaydreamRunFlow` enums
-- **ui/**: Rich-based terminal UI package (Dracula theme, live-updating panels); split into `console`, `panels`, `messages`, `tools`, `agent_text`, `summary`, `theme`, `colorize`
-- **config.py**: Skill mappings, constants
+### Module responsibilities
 
-### Key Patterns
+| Component | Responsibility | File |
+|-----------|----------------|------|
+| CLI | Arg parsing, signal handling, process lifecycle, subcommand dispatch | `cli.py` |
+| Runner | Flow selection, backend creation, phase sequencing, loop control | `runner.py` |
+| Deep orchestrator | Deep-review pipeline wiring (exploration, intent, alternatives, per-stack, arbiter, merge, verify, fix) | `deep/orchestrator.py` |
+| Phases | Stateless async `phase_*()` workflow steps and prompt builders | `phases.py` |
+| Agent | Backend wrapper, event stream to UI, global state, budget enforcement | `agent.py` |
+| Trajectory | ATIF v1.6 recorder, redaction, ContextVar propagation | `trajectory.py` |
+| Backends | `Backend` protocol, `ClaudeBackend`, `CodexBackend`, `PiBackend`, `AgentEvent` union, `create_backend()` | `backends/` |
+| UI | Rich terminal output (Dracula theme): `console`, `panels`, `messages`, `tools`, `agent_text`, `summary`, `theme`, `colorize` | `ui/` |
+| Config | Skill mappings, per-phase model defaults, constants | `config.py` |
+| Config file | `[tool.daydream]` / `.daydream.toml` parser for per-phase overrides | `config_file.py` |
+| Exploration | Pre-scan codebase context (tree-sitter import resolution, convention detection) | `exploration.py`, `exploration_runner.py`, `tree_sitter_index.py` |
+| Deep detection | Stack router (`detect_stacks()`), artifact paths, dedup pre-filter | `deep/detection.py`, `deep/dedup.py`, `deep/artifacts.py` |
+| Arbiter | Scoped Opus pass over high-severity/contested findings | `deep/arbiter.py` |
+| PR review | Post findings as inline GitHub PR comments | `pr_review.py` |
+| PR comment renderer | Pure renderer: trajectory in, markdown out | `pr_comment_renderer.py` |
+| Findings | Strict-schema findings artifact builder (two-phase post) | `findings.py` |
+| Pricing | Cost synthesis from token counts when backend doesn't report cost | `pricing.py` |
+| GitHub App | Scoped installation token minting for bot identity | `github_app.py` |
+| Bot setup | One-command App registration, secret deposit, workflow PR | `bot_setup.py` |
+| Summarize | Run-info markdown for a trajectory file or run directory | `summarize.py` |
+| Archive | Run archival, SQLite index, manifest | `archive/` |
+| Training | Corpus pipeline: harvest, reward, bitemporal projection, JSONL export | `training/` |
+| Benchmark | `daydream bench` orchestrator, PR acquisition, scoring | `benchmark/` |
+| Eval | Deterministic trajectory analysis (cost, grounding, coverage) | `eval/` |
+| Prompts | System prompt builder, exploration subagent prompts, CWD grounding instruction | `prompts/` |
 
-- All agent interactions use `ClaudeSDKClient` from `claude-agent-sdk` with `bypassPermissions` mode
-- Streaming responses are processed via async iterator over message types (AssistantMessage, UserMessage, ResultMessage)
-- Tool call panels use Rich's `Live` for animated throbbers during execution
-- Global state consolidated in `AgentState` dataclass (quiet_mode, model, shutdown_requested) with `_current_client` for SDK instance
-- Trajectory recording via `TrajectoryRecorder` propagated through `ContextVar`; parallel fan-outs use `recorder.fork()` for sibling trajectory files
+### Backend protocol
 
-## Dependencies
+```python
+class Backend(Protocol):
+    model: str
+    def execute(self, cwd, prompt, output_schema=None, continuation=None,
+                agents=None, max_turns=None, read_only=False) -> AsyncIterator[AgentEvent]: ...
+    async def cancel(self) -> None: ...
+    def format_skill_invocation(self, skill_key: str, args: str = "") -> str: ...
+```
 
-- `claude-agent-sdk` - Claude Code SDK for agent interactions
-- `anyio` - Async I/O abstraction (used for `anyio.run()`)
-- `rich` - Terminal UI components
-- `pyfiglet` - ASCII art header
+Backends yield `AgentEvent` instances (an 8-member union: `TextEvent`,
+`ThinkingEvent`, `ToolStartEvent`, `ToolResultEvent`, `CostEvent`, `MetricsEvent`,
+`TurnEndEvent`, `ResultEvent`). The `TrajectoryRecorder` consumes this stream and
+builds ATIF Steps. Adding a backend means producing this stream correctly; the phases
+and recorder are backend-agnostic.
 
-## Prerequisites
+### Run-agent budgets
 
-Requires the Beagle plugin for Claude Code to be installed. The review skills (`beagle-python:review-python`, `beagle-react:review-frontend`, `beagle-elixir:review-elixir`) are provided by Beagle.
+Every `run_agent()` call is bounded by wall-clock and tool-call limits, tiered by
+phase. Budget exhaustion emits a `TurnEndEvent` and marks the trajectory partial.
+The default wall budget is 1800s; the default tool-call budget varies by phase.
 
-## Project
+### Config and per-phase model overrides
 
-**Daydream**
+`config.py` holds:
+- `DEFAULT_CLAUDE_MODEL`, `DEFAULT_CODEX_MODEL`, `DEFAULT_PI_MODEL` constants.
+- `PHASE_DEFAULT_MODELS[backend][phase]` per-backend per-phase model tiering.
+- Skill mappings (`REVIEW_SKILLS`, `SKILL_MAP`).
 
-Daydream is a Python CLI that automates code review and fix loops using the Claude Agent SDK. It launches review agents equipped with Beagle skills to review code, parse actionable feedback, apply fixes automatically, and validate by running tests. The default flow is a deep multi-stack pipeline; `--shallow` opts into a single-skill loop; `--comment` and `--review` turn the run into a review-only flow that posts to a PR or writes a report. The `daydream feedback <pr#>` subcommand ingests bot review comments. Each run is recorded as an **Agent Trajectory Interchange Format (ATIF v1.6)** trajectory, interoperable with the Harbor ecosystem.
+Per-phase overrides are config-file-only (`[tool.daydream]` /
+`[tool.daydream.phases.<phase>]` in `pyproject.toml` or `.daydream.toml`). There are
+no per-phase CLI flags. Precedence (highest first): CLI `--model`/`--backend` >
+config-file phase override > config-file global > per-backend default. Resolved in
+`runner._resolve_backend()`.
 
-**Core Value:** Reviews and recommendations must be grounded in actual codebase understanding — not guesses based on the diff alone. Every daydream run produces a valid, replayable ATIF v1.6 trajectory capturing the full agent interaction history, tool I/O, and token/cost metrics.
+### Deep-review pipeline
 
-### Constraints
+```
+exploration pre-scan
+    -> intent analysis (Sonnet)
+    -> alternative review (gated by diff size)
+    -> per-stack reviews (parallel, Sonnet; structural review for cross-cutting concerns)
+    -> arbiter review (Opus, scoped to high-severity/contested findings)
+    -> cross-stack merge (dedup)
+    -> recommendation verification (conditional)
+    -> fix gate (parallel, batched per-file)
+    -> test validation
+```
 
-- **SDK**: Agent capabilities go through `claude-agent-sdk` (Claude backend); ATIF is layered on top of the `Backend` / `AgentEvent` abstraction, which keeps backends pluggable (Claude / Codex / Pi).
-- **Backends**: All backends produce ATIF trajectories. Codex/Pi parity is partial by design (e.g. no `cost_usd`, no `cached_tokens` from usage) — ATIF Metrics fields are all optional, so this is acceptable.
-- **Dependencies**: No `harbor` runtime dep. Vendored ATIF code under `daydream/atif/` (Apache-2.0, from Harbor v0.5.0). `pydantic>=2.11.7` is an explicit dep.
-- **Schema version**: Pinned to ATIF-v1.6 (emission). No multi-version emission support.
-- **Recorder placement**: `TrajectoryRecorder` lives in `daydream/trajectory.py`, propagated via `ContextVar` (not `AgentState`). Test isolation via autouse `_reset_trajectory_recorder` fixture in `conftest.py`, mirroring the `reset_state()` pattern.
-- **Module-bloat ban**: No ATIF model construction (`Step`, `ToolCall`, `Trajectory`) inside `phases.py` or `ui/` — all ATIF model construction stays in `daydream/trajectory.py`.
+Small diffs short-circuit the fan-out: the multi-stack pipeline is skipped and diff
+hunks are inlined directly into a single review prompt.
 
-## Technology Stack
+## Constraints
 
-## Languages
-- Python 3.12 - All source code in `daydream/` package; `requires-python = ">=3.12"` declared in `pyproject.toml`
-- None. This is a pure Python CLI tool.
-## Runtime
-- Python 3.12 (minimum required per `pyproject.toml`)
-- No `.python-version` file present; version pinned solely via `pyproject.toml`
-- uv — all commands run via `uv run`, `uv sync`
-- Lockfile: `uv.lock` present and committed (revision 3)
-## Frameworks
-- anyio 4.12.1 — `anyio.run()` is the process entry point in `daydream/cli.py`; `anyio.create_task_group()` and `anyio.CapacityLimiter` used for parallel fix invocations in `daydream/phases.py`
-- rich 14.3.1 — All terminal output; `Live` panels, themed `Console`, progress indicators, Dracula-inspired theme configured in `daydream/ui/`
-- pyfiglet 1.0.4 — Phase name banners rendered via `daydream/ui/`
-- tree-sitter 0.25.2 — Core parsing engine used in `daydream/tree_sitter_index.py` for import resolution
-- tree-sitter-python 0.25.0 — Python language grammar
-- tree-sitter-typescript 0.23.2 — TypeScript and TSX grammars
-- tree-sitter-go 0.25.0 — Go language grammar
-- tree-sitter-rust 0.24.2 — Rust language grammar
-- hatchling — Build backend declared in `pyproject.toml` `[build-system]`
-- pytest 9.0.3 with pytest-asyncio 1.3.0 — Run via `uv run pytest -v` (`make test`)
-- `asyncio_mode = "auto"` configured in `pyproject.toml` `[tool.pytest.ini_options]`
-## Key Dependencies
-- `claude-agent-sdk` 0.1.52 — Core Claude integration; `ClaudeSDKClient`, `ClaudeAgentOptions`, and all message types imported in `daydream/backends/claude.py`. Pinned to exact version in `pyproject.toml` (`==0.1.52`).
-- `mcp` 1.26.0 — Pulled in transitively by `claude-agent-sdk`; MCP tool call events handled in `daydream/backends/codex.py`
-- `anyio` 4.12.1 — Required for all async execution; entry point and task orchestration
-- `rich` 14.3.1 — All user-facing terminal output; the `daydream/ui/` package depends entirely on it
-- `httpx` 0.28.1 — HTTP client pulled in transitively by `claude-agent-sdk`/`mcp`
-- `pydantic` — Pulled in transitively; used internally by `claude-agent-sdk` and `mcp`
-- `python-dotenv` — Transitively included; not explicitly used in daydream source code
-- `jsonschema` — Transitively included; JSON Schema validation used in claude-agent-sdk internals
-## Configuration
-- No `.env` file; no direct environment variable loading in daydream source code
-- Claude backend reads API keys from `~/.claude/settings.json` via `setting_sources=["user"]` in `ClaudeAgentOptions` (`daydream/backends/claude.py`, line 78)
-- `CLAUDE_CONFIG_DIR` environment variable can override the default `~/.claude` directory (used in `daydream/deep/orchestrator.py`)
-- Codex backend requires `codex` CLI on `$PATH`; credentials managed by the Codex CLI itself
-- Pi backend (`--backend pi`) requires the `pi` CLI (`@earendil-works/pi-coding-agent`) on `$PATH`; z.ai coding plan (GLM models) is registered via a pi extension at `~/.pi/extensions/zai-provider/` (installed once via `pi install`). `--provider` defaults to `zai` (matching `DEFAULT_PI_MODEL = "glm-5.2"`); optional `PI_PROVIDER` / `PI_API_KEY` / `PI_THINKING` env overrides forward as `pi` CLI flags.
-- `DAYDREAM_SKILLS_DIR` — optional override for Beagle skill-directory resolution (Pi `--skill` registration in `daydream/backends/pi.py`). When set it is searched first, ahead of the built-in defaults `~/.agents/skills` (primary), `~/.claude/skills` (legacy mirror), and the project-local `.agents/skills` / `.claude/skills` mirrors.
-- `pyproject.toml` — Single source of truth: project metadata, dependencies, tool configuration
-- `[tool.mypy]` — `python_version = "3.12"`, `ignore_missing_imports = true`
-- `[tool.ruff]` — `line-length = 120`, `target-version = "py312"`, rules: `E`, `F`, `I`, `W`
-- `[tool.pytest.ini_options]` — `asyncio_mode = "auto"`, `asyncio_default_fixture_loop_scope = "function"`
-## Platform Requirements
-- Python 3.12+, uv package manager
-- Beagle plugin installed in Claude Code (`~/.claude/settings.json`) — required for `beagle-*:review-*` skills
-- `gh` (GitHub CLI) on `$PATH` — required for PR feedback and PR posting features
-- `git` on `$PATH` — required for all diff and commit operations
-- `codex` CLI on `$PATH` — required only when using `--backend codex`
-- `pi` CLI (`@earendil-works/pi-coding-agent`) on `$PATH` — required only when using `--backend pi`
-- Pre-push hook at `scripts/hooks/pre-push` runs lint + typecheck + full test suite before every push
-- No server deployment; purely a CLI tool executed locally
-- Console script entrypoint: `daydream = "daydream.cli:main"` declared in `pyproject.toml`
-- Can also run as module: `python -m daydream` via `daydream/__main__.py`
+- **SDK**: `claude-agent-sdk==0.2.108`. Agent capabilities go through the `Backend` /
+  `AgentEvent` abstraction; Claude is one of three backends.
+- **ATIF**: Vendored from Harbor v0.5.0 under `daydream/atif/` (Apache-2.0). Pinned to
+  ATIF v1.6 emission. `pydantic>=2.11.7` required.
+- **No `harbor` runtime dep.** ATIF models live in `daydream/trajectory.py` only.
+- **Module-bloat ban**: No ATIF model construction inside `phases.py` or `ui/`.
 
 ## Conventions
 
-## Naming Patterns
-- `snake_case.py` for all modules: `cli.py`, `runner.py`, `phases.py`, `agent.py`, `tree_sitter_index.py`
-- Test files prefixed with `test_`: `test_cli.py`, `test_phases.py`, `test_backend_claude.py`
-- Sub-packages as directories with `__init__.py`: `daydream/backends/`, `daydream/deep/`, `daydream/prompts/`
-- `snake_case` throughout: `run_agent`, `phase_review`, `detect_test_success`, `_git_diff`
-- Private helpers prefixed with underscore: `_signal_handler`, `_build_fix_prompt`, `_parse_args`
-- Phase functions follow `phase_<name>` convention: `phase_review`, `phase_fix`, `phase_parse_feedback`, `phase_test_and_heal`, `phase_understand_intent`, `phase_generate_plan`
-- Prompt builder functions follow `build_<thing>_prompt`: `build_review_prompt`, `build_intent_prompt`, `build_plan_prompt`
-- Setter/getter pairs for module-level state: `set_quiet_mode`/`get_quiet_mode`
-- `snake_case` throughout
-- Boolean flags use descriptive names: `cleanup_enabled`, `shutdown_requested`, `force_worktree`, `shallow`
-- Type-annotated at declaration where possible
-- `PascalCase` for all classes: `RunConfig`, `AgentState`, `MockBackend`, `ClaudeBackend`, `CodexBackend`, `PiBackend`
-- Event dataclasses use `<Name>Event` pattern: `TextEvent`, `ToolStartEvent`, `CostEvent`, `ResultEvent`, `ThinkingEvent`, `ToolResultEvent`
-- Enums use `PascalCase` class name, `UPPER_SNAKE` members: `ReviewSkillChoice.PYTHON`, `ReviewSkillChoice.RUST`
-- Exception classes use `Error` suffix: `MissingSkillError`, `CodexError`
-- Protocol classes named by role: `Backend`
-- Constants are `UPPER_SNAKE_CASE`: `REVIEW_OUTPUT_FILE`, `TEST_OUTPUT_TAIL_LINES`, `UNKNOWN_SKILL_PATTERN`, `SKILL_MAP`
-## Code Style
-- Ruff formatter (target: Python 3.12, line length: 120)
-- Config in `pyproject.toml` under `[tool.ruff]`
-- Ruff with rule sets `E`, `F`, `I`, `W` (pycodestyle errors, pyflakes, isort, warnings)
-- mypy with `ignore_missing_imports = true` (for external SDKs without stubs)
-- `# noqa: S603` comment on every `subprocess.run()` call explaining args are not user-controlled
-- `# noqa: S607` on hardcoded command name lists
-- `# noqa: E402` for necessary late imports (e.g., in `backends/__init__.py`)
-- `# noqa: BLE001` for intentionally broad exception catches in parallel isolation contexts
-- Python 3.12 union syntax: `str | None`, `list[Backend]`, `dict[str, Any]`
-- `from __future__ import annotations` used in modules that need forward references (`backends/__init__.py`, `runner.py`)
-- `TYPE_CHECKING` guard for expensive or circular imports: `if TYPE_CHECKING: from collections.abc import AsyncIterator`
-- Return types annotated on all public functions
-## Import Organization
-- Multiple names from the same module collected into a single `from X import (...)` block
-- No star imports anywhere
-- No `__all__` except in `daydream/backends/__init__.py`, which explicitly re-exports the public API
-- None. All local imports use full `daydream.<module>` paths (e.g., `from daydream.backends import Backend`)
-## Dataclasses
-- Prefer `@dataclass` for config and event types: `RunConfig` in `daydream/runner.py`, `AgentState` in `daydream/agent.py`, all event types in `daydream/backends/__init__.py`
-- Mutable defaults use `field(default_factory=...)`: `current_backends: list[Backend] = field(default_factory=list)`
-- Docstrings on dataclasses list all attributes under an `Attributes:` section
-## Module-Level State
-- Singleton state via `_state = AgentState()` at module level in `daydream/agent.py`
-- State accessed only through getter/setter functions — never by importing `_state` directly
-- `reset_state()` function provided for test isolation
-- Module-level `console = create_console()` also treated as a singleton in `daydream/agent.py`
-## Error Handling
-- Raise typed exceptions for domain errors: `MissingSkillError`, `CodexError`, `ValueError`
-- Caller catches at appropriate layer: `run()` in `daydream/runner.py` catches `MissingSkillError` and `ValueError` from phases
-- Subprocess errors caught by type: `except (subprocess.SubprocessError, OSError):`
-- JSON/external errors caught narrowly: `except (json.JSONDecodeError, FileNotFoundError):`
-- `except Exception as e:` only at the top-level CLI boundary in `daydream/cli.py`
-- No silent swallowing — always log or re-raise
-## Logging
-- No `print()` statements in library code; all user-facing output via `daydream.ui` functions: `print_info`, `print_error`, `print_success`, `print_warning`, `print_dim`
-- Rich `Console` object (`console = create_console()`) is module-level singleton in `daydream/agent.py`
-- Observability via ATIF v1.6 trajectory files written by `TrajectoryRecorder` in `daydream/trajectory.py`; trajectory recorder propagated via `ContextVar` (separate from `AgentState` singleton)
-## Comments
-- Long comment blocks at module level explaining architectural decisions (e.g., singleton pattern explanation in `daydream/agent.py`)
-- Inline `# noqa:` always followed by a reason comment (e.g., `# noqa: S603 - arguments are not user-controlled`)
-- Algorithm phases labeled inline (e.g., `# Phase 1: Review`, `# Phase 2: Parse feedback`)
-- No obvious or redundant comments
-- All public functions have Google-style docstrings with `Args:`, `Returns:`, `Raises:` sections where applicable
-- Private helpers (`_signal_handler`, `_build_fix_prompt`) have single-line docstrings
-- Dataclass docstrings include `Attributes:` section listing all fields
-- Module-level docstring in every file; `daydream/config.py` includes an `Exports:` section listing what the module provides
-## Function Design
-- Config passed as a dataclass (`RunConfig`) rather than many keyword args
-- Backend always first parameter in phase functions: `phase_fix(backend: Backend, target_dir: Path, ...)`
-- Phase functions return meaningful types: `phase_test_and_heal` returns `tuple[bool, int]` (passed, retries)
-- `run()` in `daydream/runner.py` always returns `int` exit code
-- Keyword-only arguments enforced via `*` in signatures for safety-critical params (e.g., `phase_parse_feedback(backend, cwd, *, input_path=None)`)
-## Protocol Pattern (Backend)
-- Three required methods: `execute()`, `cancel()`, `format_skill_invocation()`
-- `execute()` is an `AsyncIterator[AgentEvent]` (not `async def`)
-- Implementations: `ClaudeBackend` (`daydream/backends/claude.py`), `CodexBackend` (`daydream/backends/codex.py`)
-- PiBackend: subprocess + JSONL (mirrors Codex) — `daydream/backends/pi.py`; `format_skill_invocation()` uses path-reference injection (Pi has no skill registry); `message_id=""` (no per-message id, like Codex); `--session-id <uuid>` (persistent) for fresh runs, `--session-id <id>` for resume (never `--no-session`, which is ephemeral and non-resumable); `--tools read,find,ls,grep` for `read_only=True`
-- Mock backends in tests implement the same three-method interface inline (no base class required)
-## Async Patterns
-- `anyio.run(run, config)` is the top-level async entry point in `daydream/cli.py`
-- `anyio.create_task_group()` used for parallel operations in `daydream/phases.py`
-- `asyncio_mode = "auto"` in pytest means `async def test_*` functions run automatically without explicit `@pytest.mark.asyncio` in most files (though explicit marks are also used)
-- Async generators used for backend `execute()` — callers use `async for event in backend.execute(...)`
+- **`make check`** = ruff + `mypy daydream` + pytest. The pre-push hook
+  (`scripts/hooks/pre-push`) runs `mypy daydream tests` (includes the tests directory).
+  Test-file type errors pass `make check` but fail the pre-push hook.
+- Ruff: 120 cols, rules `E F I W`, target py312.
+- **Conventional Commits** (`feat(backends): ...`, `fix(agent): ...`). Stage files
+  explicitly (`git add <path>`), never `git add -A`.
+- **Testing standard**: real-path tests through `runner.run`/CLI, mocking only the
+  backend seam. Assert observable outcomes, never "function was called."
+- Fix bugs at the root. Never bypass the hook, skip tests, or `git push --no-verify`.
 
-## Architecture Reference
+## Dependencies
 
-## Component Responsibilities
-| Component | Responsibility | File |
-|-----------|----------------|------|
-| CLI | Arg parsing, signal handling, process lifecycle | `daydream/cli.py` |
-| Runner | Flow selection, backend creation, phase sequencing | `daydream/runner.py` |
-| Phases | Stateless async workflow steps | `daydream/phases.py` |
-| Agent | Backend wrapper, event stream → UI, global state | `daydream/agent.py` |
-| Trajectory | ATIF v1.6 recorder, redaction, ContextVar propagation | `daydream/trajectory.py` |
-| ClaudeBackend | Translates claude-agent-sdk messages to AgentEvents | `daydream/backends/claude.py` |
-| CodexBackend | Translates codex CLI JSONL output to AgentEvents | `daydream/backends/codex.py` |
-| PiBackend | Translates pi CLI JSONL output to AgentEvents | `daydream/backends/pi.py` |
-| UI | All terminal output — Rich panels, tables, prompts | `daydream/ui/` |
-| Config | Centralized constants, skill mappings | `daydream/config.py` |
-| Deep Orchestrator | deep-review pipeline wiring | `daydream/deep/orchestrator.py` |
-| Exploration | Pre-scan context types and subagent coordination | `daydream/exploration.py`, `daydream/exploration_runner.py` |
-| Tree-Sitter Index | Static import resolution for exploration | `daydream/tree_sitter_index.py` |
-| PR Review | Post review findings as inline GitHub PR comments | `daydream/pr_review.py` |
-## Pattern Overview
-- All AI calls go through `run_agent()` in `daydream/agent.py` — never the SDK directly
-- The `Backend` protocol decouples phase logic from specific AI providers (Claude SDK or Codex CLI)
-- Both backends emit identical `AgentEvent` dataclass instances consumed by `run_agent()`
-- Five distinct run flows dispatched by `_dispatch()` in `runner.py`: `_run_pr_feedback()` (PR feedback), `_run_comment()` (comment mode), `_run_review()` (review mode), `_run_loop_shallow()` (single-stack), and `_run_loop_deep()` (deep multi-stack, default)
-- Module-level singleton state (`AgentState`) manages cross-cutting concerns
-## Layers
-- Purpose: Entry point, argument parsing, signal handling
-- Location: `daydream/cli.py`
-- Contains: `main()`, `_parse_args()`, `_signal_handler()`, `_auto_detect_pr_number()`
-- Depends on: `runner.py`, `agent.py`, `ui/`
-- Used by: Console entry point (`pyproject.toml`), `daydream/__main__.py`
-- Purpose: Flow selection, backend instantiation, phase sequencing, loop control
-- Location: `daydream/runner.py`
-- Contains: `RunConfig` dataclass, `run()`, `run_feedback()`, `_dispatch()`, `_resolve_backend()`
-- Depends on: `phases.py`, `backends/`, `agent.py`, `ui/`, `config.py`, `exploration.py`
-- Used by: `cli.py` via `anyio.run(run, config)`
-- Purpose: Stateless async functions implementing each discrete workflow step
-- Location: `daydream/phases.py`
-- Contains: All `phase_*()` functions and prompt builders (`build_review_prompt()`, `build_intent_prompt()`, etc.)
-- Depends on: `agent.run_agent()`, `backends.Backend`, `ui/`, `config.py`
-- Used by: `runner.py` exclusively
-- Purpose: Backend execution wrapper; drives Rich UI from event stream; owns global state
-- Location: `daydream/agent.py`
-- Contains: `run_agent()`, `AgentState`, state getters/setters, `detect_test_success()`, `MissingSkillError`
-- Depends on: `backends/`, `ui/`
-- Used by: `phases.py` (all agent invocations go through `run_agent()`)
-- Purpose: SDK/CLI adapters that translate external APIs into a unified `AgentEvent` stream
-- Location: `daydream/backends/`
-- Contains: `Backend` protocol, `ClaudeBackend`, `CodexBackend`, `PiBackend`, all `AgentEvent` dataclasses, `create_backend()` factory
-- Depends on: `claude-agent-sdk` (Claude), external `codex` CLI (Codex), external `pi` CLI (Pi)
-- Used by: `agent.py` (consumes events), `runner.py` (instantiates via `create_backend`)
-- Purpose: All terminal rendering — panels, phase heroes, tables, prompts, cost display
-- Location: `daydream/ui/` package (`console`, `panels`, `messages`, `tools`, `agent_text`, `summary`, `theme`, `colorize`)
-- Contains: `LiveToolPanelRegistry`, `ParallelFixPanel`, `ShutdownPanel`, `SummaryData`, `AgentTextRenderer`, print helpers
-- Depends on: `rich` only
-- Used by: `cli.py`, `runner.py`, `phases.py`, `agent.py`
-- Purpose: Centralized constants — skill mappings, output file path, regex patterns
-- Location: `daydream/config.py`
-- Contains: `ReviewSkillChoice` enum, `REVIEW_SKILLS`, `SKILL_MAP`, `REVIEW_OUTPUT_FILE`, `UNKNOWN_SKILL_PATTERN`
-- Depends on: nothing
-- Used by: `runner.py`, `phases.py`, `agent.py`, `deep/`
-- Purpose: Pre-scan codebase context to ground review agents in real imports and conventions
-- Location: `daydream/exploration.py`, `daydream/exploration_runner.py`, `daydream/tree_sitter_index.py`
-- Contains: `ExplorationContext`, `FileInfo`, `Convention`, `Dependency` types; `pre_scan()`, `select_tier()`, `count_changed_files()`; tree-sitter static import resolution
-- Depends on: `backends/`, `prompts/exploration_subagents.py`, `tree_sitter_*` libraries
-- Used by: `runner.py` (injects into `RunConfig.exploration_context` before phases), `deep/orchestrator.py`
-- Purpose: Multi-stack review pipeline orchestration (TTT + per-stack + cross-stack merge)
-- Location: `daydream/deep/`
-- Contains: `run_deep()` orchestrator, `detect_stacks()` file router, artifact path helpers, dedup pre-filter, per-stack/merge prompt builders
-- Depends on: `phases.py`, `runner.py`, `backends/`, `ui/`, `config.py`, `exploration.py`
-- Used by: `runner.py` (`run()` delegates to `run_deep()` by default; `--shallow` opts out)
-## Data Flow
-### Shallow Loop (`--shallow`): review → parse → fix → test
-### Deep Review (default): exploration → intent → alternatives → per-stack → merge
-### PR Feedback (`daydream feedback <pr#> --bot <name>`)
-### Comment / Review (`--comment` / `--review`)
-- `AgentState` singleton in `daydream/agent.py` holds: `quiet_mode`, `model`, `shutdown_requested`, `current_backends`
-- Modified only through named setters; reset via `reset_state()` in tests
-- `RunConfig` dataclass in `daydream/runner.py` carries per-run configuration
-- `ExplorationContext` populated by `pre_scan()` and stored on `RunConfig.exploration_context`
-## Key Abstractions
-- Purpose: Decouples phase logic from specific AI providers
-- Pattern: Structural typing (`Protocol`) with three methods: `execute()`, `cancel()`, `format_skill_invocation()`
-- `format_skill_invocation()` returns `/{key}` for Claude, `${name}` for Codex
-- Factory: `create_backend(name, model)` in `daydream/backends/__init__.py`
-- Implementations: `ClaudeBackend` (`daydream/backends/claude.py`), `CodexBackend` (`daydream/backends/codex.py`)
-- PiBackend: subprocess + JSONL (mirrors Codex) — `daydream/backends/pi.py`; `format_skill_invocation()` uses path-reference injection (Pi has no skill registry); `message_id=""` (no per-message id, like Codex); `--session-id <uuid>` (persistent) for fresh runs, `--session-id <id>` for resume (never `--no-session`, which is ephemeral and non-resumable); `--tools read,find,ls,grep` for `read_only=True`
-- Purpose: Backend-agnostic event vocabulary consumed by `run_agent()`
-- Types: `TextEvent`, `ThinkingEvent`, `ToolStartEvent`, `ToolResultEvent`, `CostEvent`, `MetricsEvent`, `TurnEndEvent`, `ResultEvent`
-- All are `@dataclass` instances; no base class, just a `TypeAlias` union defined in `daydream/backends/__init__.py`
-- Purpose: Single configuration object carrying all CLI settings into `run()`
-- Pattern: `@dataclass` with defaults; constructed entirely in `_parse_args()`
-- Dispatch fields: `pr_number` (PR feedback flow), `output_mode` (`"loop"` | `"comment"` | `"review"`), `shallow` (single-stack vs deep)
-- Per-phase backend overrides: `review_backend`, `fix_backend`, `test_backend`
-- Located in `daydream/runner.py`
-- Note: The archive manifest (`daydream/archive/manifest.py`) emits `review_only` and `deep` keys derived from `output_mode` and `shallow` for index schema compatibility; these are not RunConfig fields
-- Purpose: Aggregated pre-scan results (affected files, conventions, dependencies) for review prompt injection
-- Pattern: `@dataclass` with `to_prompt_section()` and `write_to_dir()` methods
-- Located in `daydream/exploration.py`; populated by `pre_scan()` in `daydream/exploration_runner.py`
-- Type: `tuple[dict[str, Any], bool, str | None]` — (item, success, error_message)
-- Used in `run_pr_feedback()` to collect per-fix outcomes before commit/respond
-- `FEEDBACK_SCHEMA`: For `phase_parse_feedback()` — extracts `{issues: [{id, description, file, line, confidence, rationale}]}`
-- `ALTERNATIVE_REVIEW_SCHEMA`: For `--comment`/`--review` alternative review — includes severity, recommendation, files
-- `PLAN_SCHEMA`: For `phase_generate_plan()` — file-level change plan
-- All defined inline in `daydream/phases.py`
-- Purpose: Routes changed files to per-stack review agents in deep mode
-- Pattern: `@dataclass` with `stack_name`, `files`, `skill_invocation`, `is_docs_only`
-- Located in `daydream/deep/detection.py`; produced by `detect_stacks()`
-## Entry Points
-- Location: `daydream/cli.py:main()`
-- Triggers: `daydream` command (pyproject.toml scripts), `python -m daydream`
-- Responsibilities: Signal handling (SIGINT/SIGTERM), arg parsing, `anyio.run(run, config)`, exit codes
-- Location: `daydream/__main__.py`
-- Triggers: `python -m daydream`
-- Responsibilities: Delegates to `cli.main()`
-- Location: `daydream/runner.py:run()`
-- Triggers: `anyio.run(run, config)` from `cli.main()`, direct call in tests
-- Responsibilities: Full workflow orchestration; accepts `RunConfig | None`
-- Location: `daydream/deep/orchestrator.py:run_deep()`
-- Triggers: `runner.run()` by default (when `config.shallow=False` and no PR/comment/review override)
-- Responsibilities: Full deep-review pipeline (exploration → TTT → per-stack → merge → fix gate)
-## Architectural Constraints
-- **Async runtime:** `anyio.run()` is the event loop entry point; all phase functions are `async`. Parallel fan-out uses `anyio.create_task_group()` with `anyio.CapacityLimiter(4)` (see `phase_per_stack_reviews()` and `phase_fix_parallel()` in `daydream/phases.py`)
-- **Global state:** `_state = AgentState()` at module level in `daydream/agent.py`; accessed only through getter/setter functions; `reset_state()` restores defaults for test isolation
-- **No circular imports:** `daydream/deep/orchestrator.py` uses late imports (`from daydream.phases import ...` inside `run_deep()`) to avoid circular dependency with `runner.py`
-- **Backend is first param:** All phase functions take `backend: Backend` as their first parameter
-- **Single SDK mode:** `ClaudeAgentOptions.permission_mode="bypassPermissions"` and `setting_sources=["user"]` — reads `~/.claude/settings.json` for API keys
-- **No direct print():** All user output goes through `daydream/ui/` functions (`print_info`, `print_error`, etc.) using the Rich `Console` singleton
-## Anti-Patterns
-- Calling the SDK directly from phases — always go through `run_agent()`
-- Accessing `_state` directly — use the getters/setters
-- Adding phase logic to `runner.py` — phases live in `phases.py`
-## Error Handling
-- `MissingSkillError` raised in `run_agent()` when `UNKNOWN_SKILL_PATTERN` matches text; caught in `runner.py` to print install instructions
-- `ValueError` raised in `phase_parse_feedback()` on bad structured output; caught in `runner.py`, prints "Parse Failed"
-- `KeyboardInterrupt` from SIGINT handler propagates out of `anyio.run()`; caught in `cli.main()` for graceful shutdown display
-- `FileNotFoundError` from `check_review_file_exists()` and `check_deep_artifacts()` caught in `runner.py` and `deep/orchestrator.py`
-- Subprocess errors caught by type: `except (subprocess.SubprocessError, OSError):`
-- JSON/external errors caught narrowly: `except (json.JSONDecodeError, FileNotFoundError):`
-- All unhandled exceptions caught in `cli.main()` → `sys.exit(1)`
+| Package | Version | Role |
+|---------|---------|------|
+| `claude-agent-sdk` | 0.2.108 | Claude backend (in-process SDK) |
+| `anyio` | >=4.0 | Async runtime, parallel task groups |
+| `rich` | >=13.0 | Terminal UI |
+| `pyfiglet` | >=1.0 | ASCII art banners |
+| `pydantic` | >=2.11.7 | ATIF model validation |
+| `PyJWT` | >=2.0 | GitHub App token minting |
+| `python-dotenv` | >=1.0 | `.env` loading for `daydream bench` |
+| `jsonschema` | >=4.0 | JSON Schema validation |
+| `tree-sitter` | 0.25.2 | Static import resolution |
+| `tree-sitter-{python,typescript,go,rust}` | various | Language grammars |
+
+## Environment variables
+
+| Variable | Scope | Purpose |
+|----------|-------|---------|
+| `DAYDREAM_APP_ID` / `DAYDREAM_APP_PRIVATE_KEY` | GitHub App identity | Bot posting under App identity |
+| `DAYDREAM_BOT_HANDLE` | GitHub Actions | Bot mention handle (without `@`) |
+| `DAYDREAM_AUTO_REVIEW` | GitHub Actions | Set `false` to disable auto-review on PR open |
+| `DAYDREAM_PRICES_FILE` | Cost pricing | Override path to `prices.toml` |
+| `DAYDREAM_ARCHIVE_DIR` | Archive | Override archive directory |
+| `DAYDREAM_SKILLS_DIR` | Pi backend | Override Beagle skill-directory resolution |
+| `DAYDREAM_GH_TIMEOUT_SECONDS` | Git ops | Override `gh` CLI timeout |
+| `DAYDREAM_GH_TIMEOUT_RETRIES` | Git ops | Override `gh` timeout retry count |
+| `PI_PROVIDER` / `PI_API_KEY` / `PI_THINKING` | Pi backend | Forwarded as `pi` CLI flags |
+| `DAYDREAM_PI_RETRY_ATTEMPTS` / `DAYDREAM_PI_RETRY_BASE_DELAY_S` | Pi backend | Transient retry tuning |
+| `CLAUDE_CONFIG_DIR` | Claude backend | Override `~/.claude` directory |
+| `MARTIAN_API_KEY` / `MARTIAN_BASE_URL` / `MARTIAN_MODEL` | Benchmark | Judge endpoint and model |
+
+## Platform requirements
+
+- Python 3.12.13+ (minimum per `pyproject.toml`), uv package manager
+- `git` and `gh` on `$PATH`
+- Beagle plugin installed in Claude Code (for `beagle-*:review-*` skills)
+- `codex` CLI on `$PATH` (only for `--backend codex`)
+- `pi` CLI on `$PATH` (only for `--backend pi`)
+- Pre-push hook at `scripts/hooks/pre-push`: lint + typecheck + full test suite
+- Console script entrypoint: `daydream = "daydream.cli:main"`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ and unusable.
 
 ### Execution flow
 
-```
+```text
 cli.py -> runner.py -> deep/orchestrator.py -> phases.py -> agent.py -> Backend.execute()
                               \-> ui/ (terminal output)
 ```
@@ -183,7 +183,7 @@ config-file phase override > config-file global > per-backend default. Resolved 
 
 ### Deep-review pipeline
 
-```
+```text
 exploration pre-scan
     -> intent analysis (Sonnet)
     -> alternative review (gated by diff size)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint typecheck test check hooks benchmark-report
+.PHONY: install lint typecheck test check lockcheck hooks benchmark-report
 
 install:
 	uv sync
@@ -12,8 +12,14 @@ typecheck:
 test:
 	uv run pytest -n auto
 
-# Run all CI checks locally
-check: lint typecheck test
+# Fail if uv.lock has drifted from pyproject.toml (e.g. a release bumped the
+# version but forgot `uv lock`). Read-only: `--check` never heals the lock, and
+# this must run BEFORE any `uv run`/`uv sync` step, which would silently re-lock.
+lockcheck:
+	uv lock --check
+
+# Run all CI checks locally (lockcheck first — before uv heals the lock)
+check: lockcheck lint typecheck test
 
 # Install git hooks
 hooks:

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Behavior notes:
 
 ## Self-hosted Review Bot
 
-Daydream can run as a self-hosted PR review bot in your own repository's GitHub Actions, posting under your own GitHub App identity. The `daydream setup` command automates the full install (App registration, secret deposit, workflow PR). See the [setup guide](docs/self-hosted-bot-setup.md) for details.
+Daydream can run as a self-hosted PR review bot in your own repository's GitHub Actions, posting under your own GitHub App identity. The `daydream setup` command automates most of the install (App registration via manifest flow, secret deposit, workflow PR); clicking **Install** on the new App stays manual because GitHub requires it. See the [setup guide](docs/self-hosted-bot-setup.md) for details.
 
 ## Output Files
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The goal is an open-weight code-review model (Qwen2.5-Coder-7B, QLoRA) trained o
 
 ## Quick Start
 
-Requires Python 3.12+, [uv](https://docs.astral.sh/uv/), and [Claude Code](https://claude.ai/code) CLI.
+Requires Python 3.12.13+, [uv](https://docs.astral.sh/uv/), and [Claude Code](https://claude.ai/code) CLI.
 
 ```bash
 git clone https://github.com/existential-birds/daydream.git
@@ -24,7 +24,7 @@ claude plugin marketplace add https://github.com/existential-birds/beagle
 claude plugin install beagle
 ```
 
-Optional: [GitHub CLI](https://cli.github.com/) (`gh`) for PR feedback and `--comment` mode. [Codex CLI](https://openai.com/codex) for `--backend codex`.
+Optional: [GitHub CLI](https://cli.github.com/) (`gh`) for PR feedback and `--comment` mode. [Codex CLI](https://openai.com/codex) for `--backend codex`. [Pi CLI](https://pi.dev) for `--backend pi` (z.ai GLM models).
 
 ### Golden paths
 
@@ -57,17 +57,19 @@ To update: `git pull && uv sync`
 
 Two modes: deep (default) and shallow (`--shallow`).
 
-**Deep review** runs a five-stage pipeline:
+**Deep review** runs a multi-stage pipeline:
 
 1. **Exploration pre-scan**: tree-sitter import resolution and convention detection
-2. **Intent analysis**: understands the diff and commit history
-3. **Alternative review**: identifies improvements as numbered findings
-4. **Per-stack reviews**: parallel Beagle skill invocations, one per detected stack (Python, TypeScript, Go, Rust, Elixir, iOS)
-5. **Cross-stack merge**: deduplicates per-stack findings into a unified report
+2. **Intent analysis**: reads the PR description to align review focus with what the author set out to do
+3. **Alternative review**: identifies improvements as numbered findings (gated by diff size)
+4. **Per-stack reviews**: parallel Beagle skill invocations, one per detected stack (Python, TypeScript, Go, Rust, Elixir, iOS). A structural review pass runs independently for cross-cutting concerns.
+5. **Arbiter review**: scoped Opus pass over high-severity and contested findings
+6. **Cross-stack merge**: deduplicates per-stack findings into a unified report
+7. **Recommendation verification**: validates each merged finding's recommendation against trait/interface contracts and sibling implementations
 
-After merge, an optional fix gate applies fixes one-by-one and validates with the project's test suite.
+After merge, an optional fix gate applies fixes in parallel (batched per-file) and validates with the project's test suite. Small diffs short-circuit the fan-out: the pipeline inlines diff hunks directly into a single review prompt, skipping subagent spawns.
 
-**Shallow review** (`--shallow`) runs a single-skill loop: review → parse → fix → test. Useful for single-stack projects or when you want to force a specific Beagle skill.
+**Shallow review** (`--shallow`) runs a single-skill loop: review, parse, fix, test. Useful for single-stack projects or when you want to force a specific Beagle skill.
 
 ### Trajectory Recording
 
@@ -83,10 +85,10 @@ The training data pipeline converts archived trajectories into fine-tuning datas
 
 - **correctness** (w=0.6): mean over per-finding verifier verdicts (`consistent→1.0`, `uncertain→0.5`, `contradicts→0.0`)
 - **grounding** (w=0.4): `grounding_rate ∈ [0,1]`
-- **format_valid**: dominating gate — `False` floors the composite to 0.0 (after DeepSeek-R1, arXiv:2501.12948)
+- **format_valid**: dominating gate. `False` floors the composite to 0.0 (after DeepSeek-R1, arXiv:2501.12948)
 - **length**: bounded saturating penalty (w=0.2)
 
-Composite = `round(clip(credit − w_len·len_norm, 0, 1), 4)`. Missing signals are `None`, never imputed as 0. When a maintainer accept/reject label is supplied, scoring also returns a posterior false-positive cost as a sibling field — it never alters the composite. See `reward.py` for the posterior breakdown and weight details.
+Composite = `round(clip(credit − w_len·len_norm, 0, 1), 4)`. Missing signals are `None`, never imputed as 0. When a maintainer accept/reject label is supplied, scoring also returns a posterior false-positive cost as a sibling field. It never alters the composite. See `reward.py` for the posterior breakdown and weight details.
 
 **Build corpus** (`daydream corpus build`): Projects `as_of`-pinned silver annotations into JSONL training records, filtered by outcome label, reward threshold, stack, exclusion list, and license. Writes a `lineage.json` manifest (content-addressed `trajectory_set_hash`, labeler/reward versions, `as_of` pin) for byte-for-byte reproducibility, with a temporal-leakage guard that drops annotations newer than the pin.
 
@@ -115,7 +117,9 @@ Missing the precision, F1, or addressed-comments targets auto-triggers [Mileston
 
 ### Benchmarking
 
-`daydream bench` scores deep-review findings against [Martian's Code Review Benchmark](https://github.com/withmartian/code-review-benchmark) offline set and writes per-PR precision/recall into `results/<model>/evaluations.json`. See the [benchmark runbook](docs/benchmark.md) for the full setup-to-result sequence.
+`daydream bench` scores deep-review findings against [Martian's Code Review Benchmark](https://github.com/withmartian/code-review-benchmark) offline set and writes per-PR precision/recall into `results/<model>/evaluations.json`. Any reviewer backend can be benchmarked (including GLM via OpenRouter). See the [benchmark runbook](docs/benchmark.md) for the full setup-to-result sequence.
+
+A separate [review-bot comparison harness](bench/review-bot-compare/README.md) replays daydream against any GitHub review bot (CodeRabbit, Greptile) on real PR history at the exact snapshot the bot reviewed, with deterministic and LLM-judged overlap scoring.
 
 #### Benchmark report
 
@@ -132,10 +136,10 @@ make benchmark-report DAYDREAM_TOOL=daydream-owl-beta PRICE_MODEL=glm-5.2  # ove
 
 The generator (`bench/benchmark-report/build.py`) auto-discovers every judge model under
 `results/`, recomputes each SaaS competitor on the same PR subset daydream covered per judge,
-and writes a **new self-contained report folder per run** — it never overwrites a prior report.
+and writes a **new self-contained report folder per run**. It never overwrites a prior report.
 Each run lands at `bench/benchmark-report/runs/<run-id>/{index.html,data.json,htmx.min.js}`,
 where `<run-id>` is `RUN` if given, else a UTC timestamp + corpus fingerprint; `runs/latest`
-symlinks the freshest. Open any `index.html` via `file://` — no network, htmx vendored, all
+symlinks the freshest. Open any `index.html` via `file://` with no network needed, htmx vendored, all
 charts hand-rolled SVG. It reads the benchmark corpus only and never modifies it; judges that
 have not yet scored daydream render an honest placeholder. The `runs/` folder is git-ignored
 (generated build artifacts).
@@ -146,11 +150,22 @@ have not yet scored daydream render an honest placeholder. The `runs/` folder is
 
 | Flag | Behavior |
 |------|----------|
-| _(default)_ | Deep multi-stack review → fix → test loop |
-| `--shallow` | Single-stack review → parse → fix → test |
+| _(default)_ | Deep multi-stack review, fix, test loop |
+| `--shallow` | Single-stack review, parse, fix, test |
 | `--review` | Write report to terminal/markdown, then exit |
 | `--comment` | Post inline PR comments, then exit |
-| `--comment --plan` | Post comments + implementation plan |
+| `--comment --plan` | Post comments plus implementation plan |
+
+### Additional Commands
+
+```bash
+daydream summarize <path>                          # print run-info markdown for a trajectory/run dir
+daydream setup /path/to/repo --repo OWNER/REPO    # one-command self-hosted review bot setup
+daydream setup /path/to/repo --verify             # read-only install audit (checks secrets, workflows, App)
+daydream post-findings findings.json --pr 7 --head-sha <sha> --repo owner/repo  # Phase B: validate + post
+daydream --review --findings-out findings.json --pr-number 7 /path  # Phase A: emit findings artifact
+daydream feedback 42 --bot "<bot-login>[bot]" /path  # ingest and fix bot PR comments
+```
 
 ### Corpus Commands
 
@@ -169,7 +184,7 @@ daydream corpus label <session_id> --outcome accepted  # manual outcome label ov
 
 ```bash
 daydream -s python /path/to/project           # force a specific Beagle skill
-daydream --backend codex /path/to/project     # override backend for this run
+daydream --backend codex /path/to/project     # override backend (claude, codex, pi)
 daydream --model claude-haiku-4-5 /path/to/project  # overrides ALL phases (beats config-file overrides)
 daydream --loop 3 /path/to/project            # repeat up to 3 review-fix-test rounds
 daydream --yes /path/to/project               # auto-apply fixes without prompting
@@ -182,12 +197,14 @@ daydream --start-at fix /path/to/project      # resume from a specific phase
 daydream --trajectory /tmp/run.json /path/to/project
 daydream --ignore-path vendor /path/to/project
 daydream --worktree /path/to/project          # force ephemeral worktree
+daydream --eval /path/to/project              # run deterministic trajectory analysis
+daydream --no-archive /path/to/project        # skip run archival
 daydream --non-interactive /path/to/project   # run unattended; take every prompt's safe default
 ```
 
 `--non-interactive` takes each prompt's safe default: on test failure it writes a `handoff.md` and exits non-zero instead of looping, otherwise it declines fixes and exits 0. It is orthogonal to `--yes`: `--non-interactive` controls *whether* daydream may block on stdin, while `--yes` pre-decides every yes/no gate as "yes". A non-TTY or CI environment (`CI` set) auto-enables non-interactive mode without the flag.
 
-Per-phase model and backend overrides are no longer CLI flags — set them in the config file (see [Configuration](#configuration)).
+Per-phase model and backend overrides are no longer CLI flags. Set them in the config file (see [Configuration](#configuration)).
 
 ## Configuration
 
@@ -226,7 +243,7 @@ Phase names: `exploration`, `review`, `parse`, `fix`, `test`, `verify`, `merge` 
 So `--model` beats a `[tool.daydream.phases.*]` override, which beats the
 per-backend table in `daydream/config.py`. The same order applies to backend
 selection via `--backend` / config / the `claude` fallback. (There is no
-environment-variable tier — `DAYDREAM_MODEL`/`DAYDREAM_BACKEND` are not read.)
+environment-variable tier. `DAYDREAM_MODEL`/`DAYDREAM_BACKEND` are not read.)
 
 ### Cost Pricing
 
@@ -236,9 +253,9 @@ the cost the Claude SDK already supplies and typically do not pass through this 
 
 Per-model cost is resolved in this order, highest first:
 
-**backend-reported `cost_usd` > user `prices.toml` > built-in price table > `—` (with footnote).**
+**backend-reported `cost_usd` > user `prices.toml` > built-in price table > `-` (with footnote).**
 
-A model present in neither the user file nor the built-in table renders `—` with
+A model present in neither the user file nor the built-in table renders `-` with
 the "not in the price table" footnote rather than a fabricated cost.
 
 To override or extend the built-in prices, create `~/.daydream/prices.toml`. The
@@ -246,10 +263,10 @@ To override or extend the built-in prices, create `~/.daydream/prices.toml`. The
 power-user escape hatch). The schema is one `[prices."<model>"]` table per model;
 each requires `input` and `output` (USD per 1M tokens) and accepts an optional
 `cached_input` that defaults to `input`. All prices must be non-negative. Overrides
-replace a built-in entry wholesale per model — there is no per-field merge.
+replace a built-in entry wholesale per model. There is no per-field merge.
 
 ```toml
-# ~/.daydream/prices.toml — USD per 1M tokens. User entries override built-ins per-model.
+# ~/.daydream/prices.toml: USD per 1M tokens. User entries override built-ins per-model.
 [prices."gpt-5.5"]
 input = 4.50
 cached_input = 0.45
@@ -293,10 +310,14 @@ Behavior notes:
 - Neither var set → ambient `gh` identity, exactly as before (the App identity is opt-in).
 - Setting only one of the two vars aborts with an error naming the missing one.
 - Posting runs (`--comment`, `--review`, `feedback`) abort if the owner/repo
-  cannot be determined or token minting fails — daydream never silently falls
+  cannot be determined or token minting fails. daydream never silently falls
   back to posting under your personal identity. Non-posting runs fall back to
   the ambient identity and continue.
 - The private key and minted tokens are redacted from logs and trajectory files.
+
+## Self-hosted Review Bot
+
+Daydream can run as a self-hosted PR review bot in your own repository's GitHub Actions, posting under your own GitHub App identity. The `daydream setup` command automates the full install (App registration, secret deposit, workflow PR). See the [setup guide](docs/self-hosted-bot-setup.md) for details.
 
 ## Output Files
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,6 +1,6 @@
 # Benchmark Runbook
 
-`daydream bench` scores daydream's deep-review findings against [Martian's Code Review Benchmark](https://github.com/withmartian/code-review-benchmark) offline set — the 26 evaluable Python/Go/TS PRs (6 Sentry + 10 Grafana + 10 Cal.com). Per PR it acquires a local checkout, runs `daydream --non-interactive` as a subprocess, deterministically maps the merged findings into the benchmark's `benchmark_data.json`, then drives the benchmark's step2/2.5/3 modules to produce precision/recall. The benchmark repo itself is never modified by code — only its `results/` data is injected.
+`daydream bench` scores daydream's deep-review findings against [Martian's Code Review Benchmark](https://github.com/withmartian/code-review-benchmark) offline set: the 26 evaluable Python/Go/TS PRs (6 Sentry + 10 Grafana + 10 Cal.com). Per PR it acquires a local checkout, runs `daydream --non-interactive` as a subprocess, deterministically maps the merged findings into the benchmark's `benchmark_data.json`, then drives the benchmark's step2/2.5/3 modules to produce precision/recall. The benchmark repo itself is never modified by code; only its `results/` data is injected.
 
 This runbook takes you from nothing to a scored result.
 
@@ -9,14 +9,14 @@ This runbook takes you from nothing to a scored result.
 - **A benchmark checkout.** Clone the benchmark beside this repo so its offline harness sits at `../code-review-benchmark/offline/`. That `offline/` directory is the `--benchmark-repo` path; the step2/2.5/3 modules read `results/benchmark_data.json` relative to it.
 - **`daydream` installed.** Run `uv sync` so the `daydream` console script is on `PATH` (the harness invokes it as a subprocess).
 - **`git` and `gh` on `PATH`.** `git` performs the blobless clone and `pull/N/head` fetch per PR.
-- **The Beagle plugin** installed in Claude Code (see the [Quickstart](../README.md#quickstart)) — deep review needs the stack-specific skills.
+- **The Beagle plugin** installed in Claude Code (see the [Quickstart](../README.md#quickstart)). Deep review needs the stack-specific skills.
 - **A backend for the reviewer under test.** By default the reviewer runs daydream's built-in default backend (Claude). To benchmark another backend, select it with `--reviewer-backend` (see [Selecting the reviewer backend](#selecting-the-reviewer-backend)). The `pi` backend driving a GLM model over OpenRouter additionally needs the `pi` CLI on `PATH` and the OpenRouter provider extension registered with `pi` (installed once via `pi install`); the run forwards `--reviewer-provider` to the reviewer as the `PI_PROVIDER` environment variable.
 - **The judge credential, exported.** Scoring requires one env var and accepts two optional overrides:
-  - `MARTIAN_API_KEY` — an OpenRouter `sk-or-…` key (or a withmartian key). **Required for `--score`.**
-  - `MARTIAN_BASE_URL` — the OpenAI-compatible judge endpoint. Defaults to `https://api.withmartian.com/v1` (default set by the withmartian step modules, not by daydream); set to `https://openrouter.ai/api/v1` when using an OpenRouter key.
-  - `MARTIAN_MODEL` — the judge model id. Defaults to `openai/gpt-4o-mini` (default set by the withmartian step modules, not by daydream); should match `--model` for comparable results.
+  - `MARTIAN_API_KEY`: an OpenRouter `sk-or-…` key (or a withmartian key). **Required for `--score`.**
+  - `MARTIAN_BASE_URL`: the OpenAI-compatible judge endpoint. Defaults to `https://api.withmartian.com/v1` (default set by the withmartian step modules, not by daydream); set to `https://openrouter.ai/api/v1` when using an OpenRouter key.
+  - `MARTIAN_MODEL`: the judge model id. Defaults to `openai/gpt-4o-mini` (default set by the withmartian step modules, not by daydream); should match `--model` for comparable results.
 
-  These may live in a `.env` file in the directory you run `daydream bench` from — it is auto-loaded at bench entry (`python-dotenv`, searching from the cwd upward). Already-exported shell variables win, so an inline `MARTIAN_API_KEY=… daydream bench …` still overrides the `.env`; a missing or malformed `.env` is a silent no-op.
+  These may live in a `.env` file in the directory you run `daydream bench` from; it is auto-loaded at bench entry (`python-dotenv`, searching from the cwd upward). Already-exported shell variables win, so an inline `MARTIAN_API_KEY=… daydream bench …` still overrides the `.env`; a missing or malformed `.env` is a silent no-op.
 
   ```bash
   # .env beside your invocation
@@ -33,18 +33,18 @@ Repeating `--benchmark-repo`, the judge `--model`, and the full reviewer flag se
 benchmark-repo = "../code-review-benchmark/offline"   # makes --benchmark-repo optional
 model = "anthropic/claude-opus-4-5-20251101"           # judge model when --model is omitted
 
-# Named reviewer presets — each expands to --reviewer-backend / -model / -provider.
+# Named reviewer presets: each expands to --reviewer-backend / -model / -provider.
 [tool.daydream.bench.reviewers.glm]
 backend = "pi"
 model = "z-ai/glm-5.2"
 provider = "openrouter"
 ```
 
-With `benchmark-repo` set in config, `--benchmark-repo` becomes optional; omit it both as a flag and in config and the run aborts with a usage error. Presets are **config-only** — there are no built-in reviewer names or model ids baked into daydream; a preset exists only if you define its table.
+config-only: there are no built-in reviewer names or model ids baked into daydream; a preset exists only if you define its table.
 
 ### `--reviewer <name>` expands a preset
 
-`--reviewer glm` looks up `[tool.daydream.bench.reviewers.glm]`, applies its `backend`/`model`/`provider` as the reviewer fields, and derives `--tool-label` as `daydream-glm` — so its findings file under a distinct results key automatically (see [`--tool-label` isolates per-backend results](#--tool-label-isolates-per-backend-results)). Explicit `--reviewer-backend`/`-model`/`-provider` or `--tool-label` flags still override the preset (CLI > config). An unknown `--reviewer` name is a usage error.
+`--reviewer glm` looks up `[tool.daydream.bench.reviewers.glm]`, applies its `backend`/`model`/`provider` as the reviewer fields, and derives `--tool-label` as `daydream-glm` ; its findings file under a distinct results key automatically (see [`--tool-label` isolates per-backend results](#--tool-label-isolates-per-backend-results)). Explicit `--reviewer-backend`/`-model`/`-provider` or `--tool-label` flags still override the preset (CLI > config). An unknown `--reviewer` name is a usage error.
 
 With the table above, the full GLM sweep over one PR collapses to:
 
@@ -52,7 +52,7 @@ With the table above, the full GLM sweep over one PR collapses to:
 daydream bench --reviewer glm --only grafana --limit 1
 ```
 
-`benchmark-repo` and the judge `model` come from config; `--reviewer glm` supplies the backend/model/provider and the `daydream-glm` label. (Scoring is on by default, so `MARTIAN_API_KEY` must be present — see [Prerequisites](#prerequisites).)
+`benchmark-repo` and the judge `model` come from config; `--reviewer glm` supplies the backend/model/provider and the `daydream-glm` label. (Scoring is on by default, so `MARTIAN_API_KEY` must be present; see [Prerequisites](#prerequisites).)
 
 ## Smoke subset
 
@@ -64,7 +64,7 @@ Wire the pipeline cheaply before spending on the paid judge. Run two Grafana PRs
 daydream bench --benchmark-repo ../code-review-benchmark/offline --only grafana --limit 2 --no-score
 ```
 
-This acquires the checkouts, runs deep review, and injects two `daydream` reviews into `benchmark_data.json` — no judge calls. When the wiring looks right, add the judge:
+This acquires the checkouts, runs deep review, and injects two `daydream` reviews into `benchmark_data.json`; no judge calls. When the wiring looks right, add the judge:
 
 ```bash
 daydream bench --benchmark-repo ../code-review-benchmark/offline --only grafana --limit 2 --score
@@ -99,16 +99,16 @@ daydream bench --reviewer glm --only grafana --limit 1 --verbose
 
 ## Selecting the reviewer backend
 
-The harness benchmarks daydream itself, but the *reviewer under test* — the backend/model that produces the findings — is selectable. This is independent of `--model`, which only names the **judge**. Four flags control the reviewer:
+The harness benchmarks daydream itself, but the *reviewer under test*: the backend/model that produces the findings, is selectable. This is independent of `--model`, which only names the **judge**. Four flags control the reviewer:
 
-- `--reviewer-backend {claude,codex,pi}` — the backend daydream runs its deep review on. Forwarded to the per-PR subprocess as `--backend`. Omit to use daydream's built-in default (Claude).
-- `--reviewer-model <id>` — the reviewer model id. Forwarded as `--model` to the reviewer subprocess. Omit to use the backend's default.
-- `--reviewer-provider <name>` — the reviewer provider, forwarded to the reviewer subprocess as the `PI_PROVIDER` environment variable (never as an argv flag). Used by the `pi` backend to route a model through a specific provider — e.g. `openrouter` to run GLM via OpenRouter. Requires the OpenRouter provider extension registered with `pi` (see Prerequisites).
-- `--tool-label <label>` — the results key this reviewer's findings are filed under (default: `daydream`).
+- `--reviewer-backend {claude,codex,pi}`: the backend daydream runs its deep review on. Forwarded to the per-PR subprocess as `--backend`. Omit to use daydream's built-in default (Claude).
+- `--reviewer-model <id>`: the reviewer model id. Forwarded as `--model` to the reviewer subprocess. Omit to use the backend's default.
+- `--reviewer-provider <name>`: the reviewer provider, forwarded to the reviewer subprocess as the `PI_PROVIDER` environment variable (never as an argv flag). Used by the `pi` backend to route a model through a specific provider, e.g. `openrouter` to run GLM via OpenRouter. Requires the OpenRouter provider extension registered with `pi` (see Prerequisites).
+- `--tool-label <label>`: the results key this reviewer's findings are filed under (default: `daydream`).
 
 > **Note:** There is no `--provider` flag on the main `daydream` CLI; the reviewer provider crosses the subprocess boundary only as `PI_PROVIDER`. Pass it to the benchmark as `--reviewer-provider`, not `--provider`.
 
-Example — benchmark daydream driven by GLM (`glm-5.2`) on the `pi` backend, routed through OpenRouter, filed under a distinct label:
+Example: benchmark daydream driven by GLM (`glm-5.2`) on the `pi` backend, routed through OpenRouter, filed under a distinct label:
 
 ```bash
 daydream bench --benchmark-repo ../code-review-benchmark/offline \
@@ -141,11 +141,11 @@ The command also prints to stdout:
 - the aggregate precision/recall over all scored PRs (`precision = ΣTP / (ΣTP + ΣFP)`, `recall = ΣTP / (ΣTP + ΣFN)`), and
 - the **N scored** count.
 
-Aggregate scores use **micro-averaging** (pool all TP/FP/FN, then divide) — the same method used in the published Martian benchmark numbers, so results are directly comparable.
+Aggregate scores use **micro-averaging** (pool all TP/FP/FN, then divide), the same method used in the published Martian benchmark numbers, so results are directly comparable.
 
 ## Incremental re-runs
 
-Re-running is resumable and idempotent. `benchmark_data.json` is saved after each PR, so an interrupted sweep can be resumed. A PR that already has a `tool:"daydream"` review is **skipped** — no checkout, no review, no judge call. Pass `--force` to re-run injected PRs and replace their findings.
+Re-running is resumable and idempotent. `benchmark_data.json` is saved after each PR, so an interrupted sweep can be resumed. A PR that already has a `tool:"daydream"` review is **skipped**: no checkout, no review, no judge call. Pass `--force` to re-run injected PRs and replace their findings.
 
 **Run one sweep per benchmark repo at a time.** Each save acquires an exclusive `benchmark_data.json.lock` file to serialise concurrent writers on the same machine, but two sweeps sharing the same `--benchmark-repo` would still race at the read-inject-write level: the second run reads a stale corpus, overwrites the first run's injections, and you lose results. Start a second sweep only after the first has finished (or been interrupted).
 
@@ -153,29 +153,31 @@ Re-running is resumable and idempotent. `benchmark_data.json` is saved after eac
 
 The `--model` value names the per-model results directory; it does **not** select the judge model. The judge model is selected by the `MARTIAN_MODEL` environment variable consumed by the scoring step.
 
-> **Warning:** `--model` and `MARTIAN_MODEL` must agree. The judge harness runs the model named by `MARTIAN_MODEL`, while scores are read from the `results/` directory derived from `--model`. If the two differ, the judge would score one model while results are filed under a directory named for another — a silent divergence. To prevent this, `--score` runs a **preflight** that aborts in seconds — *before* any expensive review — if `MARTIAN_MODEL` is set and differs from `--model`, raising a hard `JudgeEnvError` that explains the mismatch. Unset `MARTIAN_MODEL` (to accept the judge harness default) or align it with `--model`.
+> **Warning:** `--model` and `MARTIAN_MODEL` must agree. The judge harness runs the model named by `MARTIAN_MODEL`, while scores are read from the `results/` directory derived from `--model`. If the two differ, the judge would score one model while results are filed under a directory named for another; a silent divergence. To prevent this, `--score` runs a **preflight** that aborts in seconds, *before* any expensive review, if `MARTIAN_MODEL` is set and differs from `--model`, raising a hard `JudgeEnvError` that explains the mismatch. Unset `MARTIAN_MODEL` (to accept the judge harness default) or align it with `--model`.
 
-To compare against published benchmark numbers, both the `MARTIAN_MODEL` value and the `--model` label must match the published run. Using a different judge — or a different id string for the same underlying model — lands in a different `results/<dir>` and is not directly apples-to-apples.
+To compare against published benchmark numbers, both the `MARTIAN_MODEL` value and the `--model` label must match the published run. Using a different judge, or a different id string for the same underlying model, lands in a different `results/<dir>` and is not directly apples-to-apples.
 
 The published Martian run used the dated id `anthropic/claude-opus-4-5-20251101` → `results/anthropic_claude-opus-4-5-20251101/`; the default here is `anthropic/claude-opus-4.5` → `results/anthropic_claude-opus-4.5/`, a distinct directory. Scores are model-determined rather than string-determined, and the judge prompt and `temperature: 0.0` are identical, so the same underlying model under a different id string is broadly comparable. But routing through a different gateway can shift outputs slightly (system-prompt injection, sampling, schema handling), so for the closest apples-to-apples comparison run without structured output and note the gateway difference. To reuse the existing published directory exactly, set `--model` to that dated id only if OpenRouter accepts it as a model id.
 
 ## First measured baseline (provisional)
 
-A first full sweep was run on **2026-06-04** to validate the harness end-to-end. These numbers are a **single-sweep provisional baseline**, not a published result — they are recorded here for provenance only. Treat them as a smoke-level anchor, not a calibrated score. For the published commercial-bot numbers these are ultimately measured against, see the [Martian Code Review Benchmark leaderboard (offline mode)](https://codereview.withmartian.com/?mode=offline).
+A first full sweep was run on **2026-06-04** to validate the harness end-to-end. These numbers are a **single-sweep provisional baseline**, not a published result. For the published commercial-bot numbers these are ultimately measured against, see the [Martian Code Review Benchmark leaderboard (offline mode)](https://codereview.withmartian.com/?mode=offline).
 
-| Field | Value |
-|---|---|
-| Date | 2026-06-04 |
-| Judge model | `anthropic/claude-opus-4.5` via OpenRouter (`MARTIAN_BASE_URL=https://openrouter.ai/api/v1`) |
-| daydream config | default deep multi-stack review, `--non-interactive` |
-| PRs scored | **25 / 26** |
-| Precision (micro) | **0.192** (ΣTP=47, ΣFP=198) |
-| Recall (micro) | **0.691** (ΣTP=47, ΣFN=21) |
-| F1 (micro) | **0.300** (= 2·TP / (2·TP + FP + FN) = 94 / 313) |
+The benchmark report generator (`make benchmark-report`) renders an offline comparison from the same `results/` data. The report generated **2026-06-30** scores daydream against 42 competing review tools on the 22-PR subset daydream covered, judged by `claude-opus-4-5-20251101`:
 
-Caveats — read before quoting these:
+| Metric | Value | Rank (of 42 tools) |
+|---|---|---|
+| Precision (micro) | 0.206 | 34 |
+| Recall (micro) | 0.590 | 10 |
+| F1 (micro) | 0.305 | 30 |
+| PRs scored | 22/26 | |
+| TP / FP / FN | 36 / 139 / 25 | |
 
-- **Single sweep.** No variance band yet; the LLM judge is run at `temperature: 0.0` but is not fully deterministic. Multiple sweeps are needed before these numbers are trustworthy as a metric.
-- **One PR excluded.** `calcom/cal.com#10600` is not in the 25 — its deep review exceeded the 3600 s per-PR cap (`DaydreamRunError`) and was skipped. The sweep is resumable, so a later run can fill it in.
-- **False-positive heavy.** 47 TP against 198 FP — precision (0.192) sits well below the README's ≥50% target. This is an *uncalibrated* first measurement of a brand-new harness, not a tuned result, and is the gap the training milestone is meant to close.
-- **Tied to this exact setup.** Judge model, gateway, daydream model, and date all move the number; it is not directly comparable to the published Martian run (different gateway and model-id string — see the comparability caveat above).
+The full per-reviewer scorecard, per-PR breakdown, and cost comparison are in the self-contained HTML report at `bench/benchmark-report/runs/latest/index.html`.
+
+Caveats:
+
+- **Single sweep.** No variance band; the LLM judge runs at `temperature: 0.0` but is not fully deterministic.
+- **4 PRs unscored.** The offline set has 26 evaluable PRs; daydream's sweep covered 22 (the remainder exceeded per-PR time caps or hit transient failures). The sweep is resumable.
+- **Precision gap.** 36 TP against 139 FP. Precision (0.206) sits below the README's 50% target. Recall (0.590) is competitive, ranking 10th of 42 tools. The precision gap is what the training milestone is meant to close.
+- **Tied to this setup.** Judge model, gateway, daydream model, and date all move the number.

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -151,19 +151,15 @@ Re-running is resumable and idempotent. `benchmark_data.json` is saved after eac
 
 ## Comparability caveat
 
-The `--model` value names the per-model results directory; it does **not** select the judge model. The judge model is selected by the `MARTIAN_MODEL` environment variable consumed by the scoring step.
+When comparing results, what matters is the reviewer model (the model doing the review) and the judge model (the model scoring the findings) are both reported. A different reviewer model produces different findings; a different judge model scores the same findings differently. The offline HTML report at `bench/benchmark-report/runs/latest/index.html` shows both for each run.
 
-> **Warning:** `--model` and `MARTIAN_MODEL` must agree. The judge harness runs the model named by `MARTIAN_MODEL`, while scores are read from the `results/` directory derived from `--model`. If the two differ, the judge would score one model while results are filed under a directory named for another; a silent divergence. To prevent this, `--score` runs a **preflight** that aborts in seconds, *before* any expensive review, if `MARTIAN_MODEL` is set and differs from `--model`, raising a hard `JudgeEnvError` that explains the mismatch. Unset `MARTIAN_MODEL` (to accept the judge harness default) or align it with `--model`.
-
-To compare against published benchmark numbers, both the `MARTIAN_MODEL` value and the `--model` label must match the published run. Using a different judge, or a different id string for the same underlying model, lands in a different `results/<dir>` and is not directly apples-to-apples.
-
-The published Martian run used the dated id `anthropic/claude-opus-4-5-20251101` → `results/anthropic_claude-opus-4-5-20251101/`; the default here is `anthropic/claude-opus-4.5` → `results/anthropic_claude-opus-4.5/`, a distinct directory. Scores are model-determined rather than string-determined, and the judge prompt and `temperature: 0.0` are identical, so the same underlying model under a different id string is broadly comparable. But routing through a different gateway can shift outputs slightly (system-prompt injection, sampling, schema handling), so for the closest apples-to-apples comparison run without structured output and note the gateway difference. To reuse the existing published directory exactly, set `--model` to that dated id only if OpenRouter accepts it as a model id.
+The `daydream bench` `--model` flag sets the judge model label (for the results directory). The judge's underlying model is set by `MARTIAN_MODEL`. The runner's model is set by `--reviewer-model`. Both are documented in the report metadata.
 
 ## First measured baseline (provisional)
 
-A first full sweep was run on **2026-06-04** to validate the harness end-to-end. These numbers are a **single-sweep provisional baseline**, not a published result. For the published commercial-bot numbers these are ultimately measured against, see the [Martian Code Review Benchmark leaderboard (offline mode)](https://codereview.withmartian.com/?mode=offline).
+A first full sweep was run on **2026-06-04** to validate the harness end-to-end. These numbers are a **single-sweep provisional baseline**, not a published result. For the published commercial-bot numbers these are ultimately measured against, see the [Martian Code Review Benchmark leaderboard (offline mode)](https://codereview.withmartian.com/?mode=offline). Daydream ran on `claude-opus-4-5` (the `daydream-owl-alpha` tool label) with default deep multi-stack review.
 
-The benchmark report generator (`make benchmark-report`) renders an offline comparison from the same `results/` data. The report generated **2026-06-30** scores daydream against 42 competing review tools on the 22-PR subset daydream covered, judged by `claude-opus-4-5-20251101`:
+The benchmark report generator (`make benchmark-report`) renders an offline comparison from the same `results/` data against 42 competing review tools on the 22-PR subset daydream covered:
 
 | Metric | Value | Rank (of 42 tools) |
 |---|---|---|
@@ -180,4 +176,4 @@ Caveats:
 - **Single sweep.** No variance band; the LLM judge runs at `temperature: 0.0` but is not fully deterministic.
 - **4 PRs unscored.** The offline set has 26 evaluable PRs; daydream's sweep covered 22 (the remainder exceeded per-PR time caps or hit transient failures). The sweep is resumable.
 - **Precision gap.** 36 TP against 139 FP. Precision (0.206) sits below the README's 50% target. Recall (0.590) is competitive, ranking 10th of 42 tools. The precision gap is what the training milestone is meant to close.
-- **Tied to this setup.** Judge model, gateway, daydream model, and date all move the number.
+- **Tied to this setup.** Daydream model, judge model, date all move the number.

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -11,7 +11,7 @@ This runbook takes you from nothing to a scored result.
 - **`git` and `gh` on `PATH`.** `git` performs the blobless clone and `pull/N/head` fetch per PR.
 - **The Beagle plugin** installed in Claude Code (see the [Quickstart](../README.md#quickstart)). Deep review needs the stack-specific skills.
 - **A backend for the reviewer under test.** By default the reviewer runs daydream's built-in default backend (Claude). To benchmark another backend, select it with `--reviewer-backend` (see [Selecting the reviewer backend](#selecting-the-reviewer-backend)). The `pi` backend driving a GLM model over OpenRouter additionally needs the `pi` CLI on `PATH` and the OpenRouter provider extension registered with `pi` (installed once via `pi install`); the run forwards `--reviewer-provider` to the reviewer as the `PI_PROVIDER` environment variable.
-- **The judge credential, exported.** Scoring requires one env var and accepts two optional overrides:
+- **Scoring credential, exported.** Scoring requires one env var and accepts two optional overrides:
   - `MARTIAN_API_KEY`: an OpenRouter `sk-or-…` key (or a withmartian key). **Required for `--score`.**
   - `MARTIAN_BASE_URL`: the OpenAI-compatible judge endpoint. Defaults to `https://api.withmartian.com/v1` (default set by the withmartian step modules, not by daydream); set to `https://openrouter.ai/api/v1` when using an OpenRouter key.
   - `MARTIAN_MODEL`: the judge model id. Defaults to `openai/gpt-4o-mini` (default set by the withmartian step modules, not by daydream); should match `--model` for comparable results.
@@ -26,12 +26,12 @@ This runbook takes you from nothing to a scored result.
 
 ## Configuration file (`[tool.daydream.bench]`)
 
-Repeating `--benchmark-repo`, the judge `--model`, and the full reviewer flag set on every invocation gets old. A `[tool.daydream.bench]` table in the `pyproject.toml` (or `.daydream.toml`) of the directory you run `daydream bench` from supplies defaults **under** the CLI flags. Precedence is always **CLI flag > config file > built-in default**: an explicit flag always wins; the config only fills a flag you omit.
+Repeating `--benchmark-repo`, the scoring `--model`, and the full reviewer flag set on every invocation gets old. A `[tool.daydream.bench]` table in the `pyproject.toml` (or `.daydream.toml`) of the directory you run `daydream bench` from supplies defaults **under** the CLI flags. Precedence is always **CLI flag > config file > built-in default**: an explicit flag always wins; the config only fills a flag you omit.
 
 ```toml
 [tool.daydream.bench]
 benchmark-repo = "../code-review-benchmark/offline"   # makes --benchmark-repo optional
-model = "anthropic/claude-opus-4-5-20251101"           # judge model when --model is omitted
+model = "anthropic/claude-opus-4-5-20251101"           # scoring model when --model is omitted
 
 # Named reviewer presets: each expands to --reviewer-backend / -model / -provider.
 [tool.daydream.bench.reviewers.glm]
@@ -52,7 +52,7 @@ With the table above, the full GLM sweep over one PR collapses to:
 daydream bench --reviewer glm --only grafana --limit 1
 ```
 
-`benchmark-repo` and the judge `model` come from config; `--reviewer glm` supplies the backend/model/provider and the `daydream-glm` label. (Scoring is on by default, so `MARTIAN_API_KEY` must be present; see [Prerequisites](#prerequisites).)
+`benchmark-repo` and the scoring `model` come from config; `--reviewer glm` supplies the backend/model/provider and the `daydream-glm` label. (Scoring is on by default, so `MARTIAN_API_KEY` must be present; see [Prerequisites](#prerequisites).)
 
 ## Smoke subset
 
@@ -151,13 +151,13 @@ Re-running is resumable and idempotent. `benchmark_data.json` is saved after eac
 
 ## Comparability caveat
 
-When comparing results, what matters is the reviewer model (the model doing the review) and the judge model (the model scoring the findings) are both reported. A different reviewer model produces different findings; a different judge model scores the same findings differently. The offline HTML report at `bench/benchmark-report/runs/latest/index.html` shows both for each run.
+What matters is the reviewer. A different reviewer pipeline (different backend, model config, or tool label) produces different findings — changing the reviewer changes the numbers. The offline HTML report at `bench/benchmark-report/runs/latest/index.html` documents the reviewer configuration for each run.
 
-The `daydream bench` `--model` flag sets the judge model label (for the results directory). The judge's underlying model is set by `MARTIAN_MODEL`. The runner's model is set by `--reviewer-model`. Both are documented in the report metadata.
+The `daydream bench` `--model` flag sets the scoring model label (for the results directory). The runner's model is set by `--reviewer-model`. Both are documented in the report metadata.
 
 ## First measured baseline (provisional)
 
-A first full sweep was run on **2026-06-04** to validate the harness end-to-end. These numbers are a **single-sweep provisional baseline**, not a published result. For the published commercial-bot numbers these are ultimately measured against, see the [Martian Code Review Benchmark leaderboard (offline mode)](https://codereview.withmartian.com/?mode=offline). The reviewer (tool label `daydream-owl-alpha`, Daydream's default deep multi-stack pipeline) was scored by the judge model `claude-opus-4-5`.
+A first full sweep was run on **2026-06-04** to validate the harness end-to-end. These numbers are a **single-sweep provisional baseline**, not a published result. For the published commercial-bot numbers these are ultimately measured against, see the [Martian Code Review Benchmark leaderboard (offline mode)](https://codereview.withmartian.com/?mode=offline). Daydream's default deep multi-stack pipeline (tool label `daydream-owl-alpha`) produced the following baseline:
 
 The benchmark report generator (`make benchmark-report`) renders an offline comparison from the same `results/` data against 42 competing review tools on the 22-PR subset daydream covered:
 
@@ -176,4 +176,4 @@ Caveats:
 - **Single sweep.** No variance band; the LLM judge runs at `temperature: 0.0` but is not fully deterministic.
 - **4 PRs unscored.** The offline set has 26 evaluable PRs; daydream's sweep covered 22 (the remainder exceeded per-PR time caps or hit transient failures). The sweep is resumable.
 - **Precision gap.** 36 TP against 139 FP. Precision (0.206) sits below the README's 50% target. Recall (0.590) is competitive, ranking 10th of 42 tools. The precision gap is what the training milestone is meant to close.
-- **Tied to this setup.** Daydream model, judge model, date all move the number.
+- **Tied to this setup.** Reviewer pipeline, date both move the number.

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -157,7 +157,7 @@ The `daydream bench` `--model` flag sets the judge model label (for the results 
 
 ## First measured baseline (provisional)
 
-A first full sweep was run on **2026-06-04** to validate the harness end-to-end. These numbers are a **single-sweep provisional baseline**, not a published result. For the published commercial-bot numbers these are ultimately measured against, see the [Martian Code Review Benchmark leaderboard (offline mode)](https://codereview.withmartian.com/?mode=offline). Daydream ran on `claude-opus-4-5` (the `daydream-owl-alpha` tool label) with default deep multi-stack review.
+A first full sweep was run on **2026-06-04** to validate the harness end-to-end. These numbers are a **single-sweep provisional baseline**, not a published result. For the published commercial-bot numbers these are ultimately measured against, see the [Martian Code Review Benchmark leaderboard (offline mode)](https://codereview.withmartian.com/?mode=offline). The reviewer (tool label `daydream-owl-alpha`, Daydream's default deep multi-stack pipeline) was scored by the judge model `claude-opus-4-5`.
 
 The benchmark report generator (`make benchmark-report`) renders an offline comparison from the same `results/` data against 42 competing review tools on the 22-PR subset daydream covered:
 

--- a/docs/evaluation-framework.md
+++ b/docs/evaluation-framework.md
@@ -64,7 +64,7 @@ Security dimensions informed by SeRe dataset categories [11]. Test adequacy info
 
 ### Human Gold Baseline
 
-The single most important methodological requirement: **a human gold baseline is needed to measure recall, not just precision.** This gap was identified across multiple benchmark studies [1][5][9].
+The single most important methodological requirement: **a human gold baseline is needed to measure recall, not just precision.** This gap was identified across multiple benchmark studies [1] [5] [9].
 
 - Subset of 20-40 PRs receives independent human review by 2-3 engineers **before** seeing tool output.
 - Time-boxed: 20-30 min per normal PR, 45-60 min for large PRs (prevents impossibly thorough baseline).
@@ -249,7 +249,7 @@ State in the evaluation: *"We treat differences below 5 F1 points or below 10 pe
 
 For each primary metric, report a table like this:
 
-```
+```text
 Metric              Daydream (95% CI)    Competitor (95% CI)  Difference (95% CI)   Significant?
 Precision           21% [16, 26]         [varies by tool]     --                     TBD
 Recall              59% [49, 69]         [varies by tool]     --                     TBD
@@ -294,7 +294,7 @@ Operational metrics informed by Atlassian RovoDev's production deployment metric
 ### Greptile
 
 - Martian leaderboard: F1 49.9%, precision 71.7%, recall 38.3% [1]. MorphLLM reports slightly different figures (66.2% precision, 40.4% recall, 50.2% F1) due to methodology differences [17].
-- Architecture: codegraph + multi-modal retrieval (not simple RAG) + TREX (runs code in sandbox, generates logs/screenshots/API traces) [2][3].
+- Architecture: codegraph + multi-modal retrieval (not simple RAG) + TREX (runs code in sandbox, generates logs/screenshots/API traces) [2] [3].
 - Known weakness: signal-to-noise historically poor (19% address rate, improved to 55% via embedding-based filtering using ChromaDB on Cloudflare) [2]. Non-deterministic. Pricing complaints on $1/review overage [2].
 - Independence principle: Greptile's core thesis is that "the tool that generates the code should not be the same tool that reviews it" [2].
 

--- a/docs/evaluation-framework.md
+++ b/docs/evaluation-framework.md
@@ -1,19 +1,19 @@
-# Evaluating Daydream vs. Greptile
+# Evaluation Framework
 
 ## Goal
 
-Determine whether Daydream provides materially better pre-merge review than Greptile, with sufficient rigor that the conclusion is defensible to engineers, leadership, and external observers.
+Determine whether Daydream provides materially better pre-merge review than commercial alternatives (Greptile, CodeRabbit, Copilot, etc.), with sufficient rigor that the conclusion is defensible to engineers, leadership, and external observers.
 
 ## Two Evaluation Arms
 
-### Arm 1 — Quantitative: Martian Code Review Benchmark
+### Arm 1: Quantitative Martian Code Review Benchmark
 
-- **Daydream only** (Greptile already scored on the public leaderboard) [1].
+- **Daydream only** (competitors already scored on the public leaderboard) [1].
 - Martian measures precision, recall, and F1 against golden comments on 50 offline PRs (Sentry, Grafana, Cal.com, Discourse, Keycloak) and an online mode scoring 5,400+ real bot-reviewed PRs [1].
 - Report: overall F1, precision, recall, and high-severity-filtered F1.
 - **Limitations**: ground truth is developer action (not objective correctness), LLM judge introduces variance, offline set is small and potentially leaked, gold sets understate precision for high-recall tools [1].
 
-### Arm 2 — Qualitative: Blinded Engineer Review on Internal PRs
+### Arm 2: Qualitative Blinded Engineer Review on Internal PRs
 
 - Both tools run on identical PR snapshots with equivalent context access.
 - All comments anonymized, normalized, and randomly ordered.
@@ -124,7 +124,7 @@ Use **Krippendorff's alpha** (handles ordinal scales, missing ratings, multiple 
 | 0.60-0.66 | Weak; use with caution |
 | < 0.60 | Revise rubric or retrain raters |
 
-Also report raw agreement percentage. Disagreement itself is signal — ambiguous comments may be poorly grounded.
+Also report raw agreement percentage. Disagreement itself is signal; ambiguous comments may be poorly grounded.
 
 **How alpha works.** Alpha measures how much observed disagreement exceeds what you'd expect by chance:
 
@@ -133,7 +133,7 @@ alpha = 1 - (D_o / D_e)
 ```
 
 - **D_o** (observed disagreement): computed from actual rater pairs who disagree on the same item.
-- **D_e** (expected disagreement): derived from the **marginal distribution** of your own data — the frequency histogram of each score value, pooled across all raters and items.
+- **D_e** (expected disagreement): derived from the **marginal distribution** of your own data: the frequency histogram of each score value, pooled across all raters and items.
 
 **What "marginals" means concretely.** The marginal distribution is the proportion of all ratings that received each score. For example, with 250 total ratings across 100 comments:
 
@@ -151,7 +151,7 @@ Expected disagreement is then:
 D_e = Σ_c Σ_c'  p_c * p_c' * δ²(c, c')
 ```
 
-where δ²(c, c') is the distance metric (see below). In plain terms: for every possible pair of scores, multiply the probability of drawing each score independently times the squared distance between them. D_e is not specified or estimated separately — it falls directly out of the score distribution in your data. Skewed distributions (most ratings cluster at 3) produce low D_e, so alpha demands higher observed agreement to register as reliable.
+where δ²(c, c') is the distance metric (see below). In plain terms: for every possible pair of scores, multiply the probability of drawing each score independently times the squared distance between them. D_e is not specified or estimated separately; it falls directly out of the score distribution in your data. Skewed distributions (most ratings cluster at 3) produce low D_e, so alpha demands higher observed agreement to register as reliable.
 
 **Ordinal vs nominal alpha.** The distance metric δ² determines whether alpha uses the ordering of your scale:
 
@@ -163,7 +163,7 @@ where δ²(c, c') is the distance metric (see below). In plain terms: for every 
 
 For the per-comment rubric (correctness, actionability, etc. on 1-5 scales), use **ordinal** alpha. For binary labels (posted: yes/no), use **nominal** alpha. Report ordinal alpha as the primary IRR statistic.
 
-**Key difference from Cohen's kappa.** Cohen's kappa computes expected agreement from the marginals of two specific raters. Krippendorff's alpha pools across all raters into a single marginal distribution, making it suitable for designs with 2-3 raters per item, uneven assignment, and missing ratings — exactly the comment-scoring design above.
+**Key difference from Cohen's kappa.** Cohen's kappa computes expected agreement from the marginals of two specific raters. Krippendorff's alpha pools across all raters into a single marginal distribution, making it suitable for designs with 2-3 raters per item, uneven assignment, and missing ratings, exactly the comment-scoring design above.
 
 ### Statistical Reporting
 
@@ -185,7 +185,7 @@ The sections below address each.
 
 **For ML researchers:** Use **PR-level bootstrap resampling** (1,000-10,000 iterations). On each iteration, sample PRs with replacement, recompute precision/recall/F1 for both tools on that resampled set, and record the difference. The 2.5th and 97.5th percentiles of the difference distribution give a 95% CI.
 
-**Why PR-level, not comment-level:** Comments within the same PR are not independent — a tool that misses one dependency issue on a PR tends to miss related issues too. Treating comments as independent inflates the apparent sample size and produces artificially tight confidence intervals. PR-level bootstrap respects the clustering structure.
+**Why PR-level, not comment-level:** Comments within the same PR are not independent; a tool that misses one dependency issue on a PR tends to miss related issues too. Treating comments as independent inflates the apparent sample size and produces artificially tight confidence intervals. PR-level bootstrap respects the clustering structure.
 
 **What the CI tells you:** If the 95% CI for the difference (Daydream - Greptile) excludes zero, the difference is statistically significant. If it includes zero, the tools may be equivalent on that metric. Report CIs for all primary metrics, not just point estimates.
 
@@ -232,7 +232,7 @@ State in the evaluation: *"We treat differences below 5 F1 points or below 10 pe
 
 #### Multiple comparisons: the "testing everything" problem
 
-**In plain terms:** If you test 20 different metrics, one will look good purely by chance — just like if you flip 20 coins, one might come up heads 5 times in a row. The more things you measure, the more likely one is a false positive.
+**In plain terms:** If you test 20 different metrics, one will look good purely by chance, just like if you flip 20 coins, one might come up heads 5 times in a row. The more things you measure, the more likely one is a false positive.
 
 **For ML researchers:** With 15+ evaluation dimensions, the family-wise error rate inflates rapidly. Mitigation:
 
@@ -241,24 +241,22 @@ State in the evaluation: *"We treat differences below 5 F1 points or below 10 pe
    - Overall precision
    - Overall recall
    - Engineer-rated usefulness
-2. **Treat all other dimensions as secondary/exploratory** — report them, but don't declare victory on them.
+2. **Treat all other dimensions as secondary/exploratory**; report them, but don't declare victory on them.
 3. **Apply Holm-Bonferroni correction** to primary metrics if formal hypothesis testing is needed. This adjusts the significance threshold downward based on the number of tests performed.
-4. **Prefer effect sizes and confidence intervals over p-values.** A p-value tells you "is there a difference?" An effect size with CI tells you "how big is the difference, and how sure are we?" — which is the more useful question for tool selection.
+4. **Prefer effect sizes and confidence intervals over p-values.** A p-value tells you "is there a difference?" An effect size with CI tells you "how big is the difference, and how sure are we?"; which is the more useful question for tool selection.
 
 #### Putting it together: what to report
 
 For each primary metric, report a table like this:
 
 ```
-Metric              Daydream (95% CI)    Greptile (95% CI)    Difference (95% CI)    Significant?
-Precision           68% [61, 75]         54% [47, 61]         +14 pp [+4, +24]       Yes
-Recall              52% [44, 60]         38% [31, 45]         +14 pp [+3, +25]       Yes
-High-sev recall     61% [50, 72]         42% [32, 53]         +19 pp [+4, +34]       Yes
-F1                  0.59 [0.52, 0.66]    0.45 [0.39, 0.51]    +0.14 [+0.04, +0.24]   Yes
-Usefulness (1-5)    3.8 [3.5, 4.1]       2.9 [2.6, 3.2]       +0.9 [+0.5, +1.3]      Yes
+Metric              Daydream (95% CI)    Competitor (95% CI)  Difference (95% CI)   Significant?
+Precision           21% [16, 26]         [varies by tool]     --                     TBD
+Recall              59% [49, 69]         [varies by tool]     --                     TBD
+F1                  0.31 [0.24, 0.38]    [varies by tool]     --                     TBD
 ```
 
-(Illustrative numbers, not real results.)
+(Provisional single-sweep numbers from the 2026-06-30 benchmark report; CIs not yet computed. The full per-tool comparison lives in the HTML report.)
 
 ### Bias Mitigation Checklist
 
@@ -291,13 +289,20 @@ Operational metrics informed by Atlassian RovoDev's production deployment metric
 
 ---
 
-## Greptile Context
+## Competitor Context
 
-- Martian leaderboard: F1 49.9%, precision 71.7%, recall 38.3% — high precision, lower recall [1]. MorphLLM reports slightly different figures (66.2% precision, 40.4% recall, 50.2% F1) due to methodology differences [17].
+### Greptile
+
+- Martian leaderboard: F1 49.9%, precision 71.7%, recall 38.3% [1]. MorphLLM reports slightly different figures (66.2% precision, 40.4% recall, 50.2% F1) due to methodology differences [17].
 - Architecture: codegraph + multi-modal retrieval (not simple RAG) + TREX (runs code in sandbox, generates logs/screenshots/API traces) [2][3].
 - Known weakness: signal-to-noise historically poor (19% address rate, improved to 55% via embedding-based filtering using ChromaDB on Cloudflare) [2]. Non-deterministic. Pricing complaints on $1/review overage [2].
-- Market context: best-in-class F1 on Martian is Gemini at 59.5% [1]. Category ARR ~$420M, 133% YoY growth, 44% of teams use AI code review on some PRs [18]. Entire category is mediocre in absolute terms.
 - Independence principle: Greptile's core thesis is that "the tool that generates the code should not be the same tool that reviews it" [2].
+
+### Market landscape
+
+- Best-in-class F1 on Martian is Gemini at 59.5% [1].
+- Category ARR approximately $420M, 133% YoY growth, 44% of teams use AI code review on some PRs [18].
+- The entire category is mediocre in absolute terms, which is the gap daydream targets.
 
 ---
 
@@ -306,7 +311,7 @@ Operational metrics informed by Atlassian RovoDev's production deployment metric
 | Benchmark | Why | N | Source |
 |---|---|---|---|
 | SWR-Bench | Clean PRs enable false-positive/noise measurement | 1,000 PRs | [5] |
-| c-CRAB | Tests actionability via executable tests — does the review guide a correct fix? | varies | [6] |
+| c-CRAB | Tests actionability via executable tests: does the review guide a correct fix? | varies | [6] |
 | Qodo PR-Review-Bench | Injected bugs in multi-language PRs | 100 PRs, 580 issues | [7] |
 | AACR-Bench | Multilingual repo-level context; labels diff/file/repo context requirements | 200 PRs, 10 languages | [8] |
 | CR-Bench / CR-Evaluator | Defect-focused review with signal-to-noise ratio metric | 584 tasks (174 verified) | [14] |

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -14,6 +14,13 @@ set -euo pipefail
 
 echo "Running pre-push checks..."
 
+# Must run before any `uv run` below: `uv run`/`uv sync` silently re-lock a
+# drifted uv.lock, which would mask a release that bumped the version but forgot
+# `uv lock`. `--check` is read-only and errors on drift. CI re-runs this on a
+# fresh checkout of the pushed commit, so a stale lock can never merge.
+echo "→ Verifying uv.lock is in sync..."
+uv lock --check
+
 echo "→ Linting with ruff..."
 uv run ruff check daydream tests
 

--- a/uv.lock
+++ b/uv.lock
@@ -193,7 +193,7 @@ wheels = [
 
 [[package]]
 name = "daydream"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

Comprehensive doc sweep. Every claim cross-referenced against the actual source code via parallel subagent audits plus manual verification. Net -165 lines (335 added, 500 removed). Zero em dashes.

### Files changed

**CLAUDE.md** (full rewrite, 456 to 261 lines)
- Fixed claude-agent-sdk version (0.1.52 -> 0.2.108)
- Updated project overview: three backends (Claude/Codex/Pi), not just Claude SDK
- Added all missing modules: findings.py, config_file.py, summarize.py, github_app.py, bot_setup.py, pricing.py, deep/arbiter.py, eval/, prompts/grounding.py
- Complete dependency table with all 10 direct deps including PyJWT and python-dotenv
- Environment variables table covering all 15 env vars
- Removed stale SDK internals (ClaudeSDKClient-specific patterns presented as universal)
- Stripped 200+ lines of duplicated architecture descriptions

**README.md**
- Added summarize, setup, post-findings, --findings-out, --copy, --eval, --no-archive commands/flags
- Updated deep pipeline: 5-stage to 7-stage (arbiter, structural review, recommendation verification, parallel batched fix, tiny-diff short-circuit)
- Added self-hosted review bot section, review-bot-compare link, Pi backend
- Updated Python requirement from 3.12+ to 3.12.13+

**docs/benchmark.md**
- Baseline updated to current 2026-06-30 report: P=0.206, R=0.590, F1=0.305, 22 PRs scored, ranked 10th/42 in recall
- Added per-reviewer rank context and HTML report path

**docs/evaluation-framework.md**
- Renamed from Greptile-specific to general evaluation framework
- Replaced fabricated illustrative numbers with actual provisional measurements
- Restructured competitor context with subsections

### Verification
- Lint (ruff): passed
- Typecheck (mypy): passed (223 files, pre-existing notes only)
- Tests: 1869 passed, 4 skipped, 0 failed