### PR TITLE
feat(training): complete archive-time data capture (eval-by-default + recommended-change patch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ daydream --start-at fix /path/to/project      # resume from a specific phase
 daydream --trajectory /tmp/run.json /path/to/project
 daydream --ignore-path vendor /path/to/project
 daydream --worktree /path/to/project          # force ephemeral worktree
-daydream --no-eval /path/to/project           # skip the deterministic trajectory analysis (on by default)
+daydream --no-eval /path/to/project           # skip the deterministic evaluation analysis (on by default)
 daydream --no-archive /path/to/project        # skip run archival
 daydream --non-interactive /path/to/project   # run unattended; take every prompt's safe default
 ```

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ daydream --start-at fix /path/to/project      # resume from a specific phase
 daydream --trajectory /tmp/run.json /path/to/project
 daydream --ignore-path vendor /path/to/project
 daydream --worktree /path/to/project          # force ephemeral worktree
-daydream --eval /path/to/project              # run deterministic trajectory analysis
+daydream --no-eval /path/to/project           # skip the deterministic trajectory analysis (on by default)
 daydream --no-archive /path/to/project        # skip run archival
 daydream --non-interactive /path/to/project   # run unattended; take every prompt's safe default
 ```

--- a/daydream/archive/__init__.py
+++ b/daydream/archive/__init__.py
@@ -55,7 +55,7 @@ def archive_run(
     target_dir: Path,
     config: RunConfig,
     status: str = "complete",
-    run_eval: bool = False,
+    run_eval: bool = True,
     work: WorkContext | None = None,
 ) -> None:
     """Copy artifact bundle to archive and index in SQLite.
@@ -250,10 +250,15 @@ def _copy_bundle(target_dir: Path, run_dir: Path, recorder: TrajectoryRecorder) 
     if deep_dir.is_dir():
         shutil.copytree(deep_dir, run_dir / "deep", dirs_exist_ok=True)
 
-    # Diff patch
+    # Diff patch (the PR-under-review diff, captured before fixes)
     diff_patch = daydream_dir / "diff.patch"
     if diff_patch.is_file():
         shutil.copy2(diff_patch, run_dir / "diff.patch")
+
+    # Recommended-change patch (daydream's proposed diff, captured after fixes)
+    recommended_patch = daydream_dir / "recommended.patch"
+    if recommended_patch.is_file():
+        shutil.copy2(recommended_patch, run_dir / "recommended.patch")
 
 
 def _run_eval(target_dir: Path, session_id: str, run_dir: Path) -> dict[str, Any] | None:

--- a/daydream/archive/manifest.py
+++ b/daydream/archive/manifest.py
@@ -131,7 +131,8 @@ class Manifest:
     total_cached_tokens: int | None = None
 
     # wall_clock_seconds and phase_timings are derived from step/phase events
-    # on every run; the remaining metrics below are populated only with --eval.
+    # on every run; the remaining metrics below are populated by the eval pass,
+    # which runs by default (skipped only with --no-eval).
     wall_clock_seconds: float | None = None
     phase_timings: dict[str, Any] | None = None
     total_findings: int | None = None
@@ -281,7 +282,7 @@ def build_manifest(
         archive_path=str(archive_path),
     )
 
-    # Derivable from step timestamps, so populated for every run; the --eval
+    # Derivable from step timestamps, so populated for every run; the eval pass's
     # fork-inclusive value (eval.analyzer.analyze_timing) takes precedence below.
     m.wall_clock_seconds = recorder.compute_wall_clock_seconds()
     # Per-phase breakdown from explicit phase_start/phase_end events (#203).

--- a/daydream/archive/manifest.py
+++ b/daydream/archive/manifest.py
@@ -34,6 +34,13 @@ class Manifest:
 
     Attributes:
         schema_version: Manifest schema version for forward compatibility.
+        recommended_patch_supported: Provenance flag read by training signals.
+            ``True`` for every manifest written by recommended.patch-aware
+            daydream. When ``True``, a missing ``recommended.patch`` means the
+            run made no recommendation (review-only / all-declined / wash), not
+            a legacy archive — so ``_read_recommended_patch`` returns ``""``
+            instead of falling back to ``diff.patch``. Legacy manifests omit the
+            key.
         session_id: UUID4 session identifier from the trajectory recorder.
         archived_at: ISO 8601 timestamp of when the archive was created.
         status: Run status — ``complete``, ``partial``, or ``failed``.
@@ -92,6 +99,12 @@ class Manifest:
     """
 
     schema_version: str = MANIFEST_SCHEMA_VERSION
+    # Provenance flag consumed by labeler_signals._read_recommended_patch:
+    # when True, a missing recommended.patch means "no recommendation"
+    # (review-only / all-declined / wash), NOT a legacy archive, so the
+    # diff.patch fallback must not fire. Defaults True for every new manifest;
+    # legacy manifests simply omit the key.
+    recommended_patch_supported: bool = True
     session_id: str = ""
     archived_at: str = ""
     status: str = "complete"
@@ -152,6 +165,7 @@ class Manifest:
         """Return a JSON-serializable dict."""
         return {
             "schema_version": self.schema_version,
+            "recommended_patch_supported": self.recommended_patch_supported,
             "session_id": self.session_id,
             "archived_at": self.archived_at,
             "status": self.status,

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -179,7 +179,7 @@ def _add_shared_arguments(parser: argparse.ArgumentParser, *, full_help: bool = 
     Args:
         parser: The parser (or subparser) to add the shared arguments to.
         full_help: When False, advanced flags (``--trajectory``, ``--no-archive``,
-            ``--eval``, ``--non-interactive``) are added with their help text
+            ``--no-eval``, ``--non-interactive``) are added with their help text
             suppressed so the default ``--help`` stays focused on common flags.
             They still parse and populate ``RunConfig`` unchanged; ``--help-all``
             re-builds the parser with ``full_help=True`` to surface them.
@@ -203,11 +203,12 @@ def _add_shared_arguments(parser: argparse.ArgumentParser, *, full_help: bool = 
         help="Disable automatic archival to ~/.daydream/archive/" if full_help else argparse.SUPPRESS,
     )
     parser.add_argument(
-        "--eval",
-        action="store_true",
-        default=False,
+        "--no-eval",
+        action="store_false",
+        default=True,
         dest="run_eval",
-        help="Run deterministic evaluation analysis and store evaluation.json in archive"
+        help="Skip the deterministic evaluation analysis during archive "
+        "(eval runs by default: it is file-based and cheap)"
         if full_help else argparse.SUPPRESS,
     )
     parser.add_argument(

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -1157,6 +1157,13 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
                     items,
                     intent_path=intent_p if (intent_grounded_this_run and intent_p.exists()) else None,
                 )
+            # Capture daydream's proposed diff (pre-fix tree → post-fix worktree)
+            # NOW, before the fix-failure and test-failure early returns below, so
+            # a run that generated a recommendation always archives it — even when
+            # tests fail or a fix group is reverted. Best-effort; never raises.
+            git_ops.capture_recommended_patch_with_base(
+                work.repo, pre_fix_snapshot, pre_fix_head, daydream_dir / "recommended.patch"
+            )
             fix_failures_p = fix_failures_path(dd)
             if fix_failures:
                 # Persist so the archive marks the run "partial" instead of
@@ -1208,12 +1215,6 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
             # the fix backend (no separate "commit" phase identifier).
             await phase_commit_push(
                 _resolve_backend(config, "fix", backend_cache), work
-            )
-            # Capture daydream's proposed diff (pre-fix tree → post-fix worktree)
-            # so training signals score the RECOMMENDED changes, not the diff
-            # under review. Best-effort; never blocks a successful run.
-            git_ops.capture_recommended_patch_with_base(
-                work.repo, pre_fix_snapshot, pre_fix_head, daydream_dir / "recommended.patch"
             )
             return 0
 

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -1139,12 +1139,16 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
                 print_warning(console, f"Could not snapshot tree before fixes: {exc}")
                 pre_fix_snapshot = None
                 pre_fix_untracked = set()
-            # Pre-fix HEAD is the recommended-patch base when the tree is clean
-            # (stash_create returns None then). Captured now because the commit
-            # phase below advances HEAD past the fix.
-            try:
-                pre_fix_head = git_ops.head_sha(work.repo)
-            except git_ops.GitError:
+            # Pre-fix HEAD is the recommended-patch base only when the tree was
+            # clean (stash_create returns None then) -- otherwise the snapshot is
+            # the base and HEAD is unused, so skip the rev-parse. Captured now
+            # because the commit phase below advances HEAD past the fix.
+            if pre_fix_snapshot is None:
+                try:
+                    pre_fix_head = git_ops.head_sha(work.repo)
+                except git_ops.GitError:
+                    pre_fix_head = None
+            else:
                 pre_fix_head = None
             async with phase_scope(DaydreamPhase.FIX):
                 fix_failures = await phase_fix_parallel(
@@ -1208,8 +1212,8 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
             # Capture daydream's proposed diff (pre-fix tree → post-fix worktree)
             # so training signals score the RECOMMENDED changes, not the diff
             # under review. Best-effort; never blocks a successful run.
-            git_ops.capture_recommended_patch(
-                work.repo, pre_fix_snapshot or pre_fix_head, daydream_dir / "recommended.patch"
+            git_ops.capture_recommended_patch_with_base(
+                work.repo, pre_fix_snapshot, pre_fix_head, daydream_dir / "recommended.patch"
             )
             return 0
 

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -1139,6 +1139,13 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
                 print_warning(console, f"Could not snapshot tree before fixes: {exc}")
                 pre_fix_snapshot = None
                 pre_fix_untracked = set()
+            # Pre-fix HEAD is the recommended-patch base when the tree is clean
+            # (stash_create returns None then). Captured now because the commit
+            # phase below advances HEAD past the fix.
+            try:
+                pre_fix_head = git_ops.head_sha(work.repo)
+            except git_ops.GitError:
+                pre_fix_head = None
             async with phase_scope(DaydreamPhase.FIX):
                 fix_failures = await phase_fix_parallel(
                     _resolve_backend(config, "fix", backend_cache),
@@ -1197,6 +1204,12 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
             # the fix backend (no separate "commit" phase identifier).
             await phase_commit_push(
                 _resolve_backend(config, "fix", backend_cache), work
+            )
+            # Capture daydream's proposed diff (pre-fix tree → post-fix worktree)
+            # so training signals score the RECOMMENDED changes, not the diff
+            # under review. Best-effort; never blocks a successful run.
+            git_ops.capture_recommended_patch(
+                work.repo, pre_fix_snapshot or pre_fix_head, daydream_dir / "recommended.patch"
             )
             return 0
 

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -878,6 +878,16 @@ def capture_recommended_patch(repo: Path, base_ref: str | None, out_path: Path) 
         recommended = diff_worktree_against(repo, base_ref, ["."])
     except GitError:
         return False
+    # `git diff <base_ref>` only reports tracked-file changes, so new files the
+    # fix phase created are absent. Append a creation hunk for each via
+    # `git diff --no-index /dev/null <file>` (exit 1 = "files differ", expected).
+    try:
+        for rel in list_untracked(repo):
+            proc = _run_git(repo, ["diff", "--no-index", "/dev/null", rel], timeout=30, retries=0)
+            if proc.returncode in (0, 1):
+                recommended += proc.stdout
+    except GitError:
+        return False
     out_path.parent.mkdir(parents=True, exist_ok=True)
     if not recommended.strip():
         # Empty marker: a present-but-empty recommended.patch distinguishes a

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -855,7 +855,12 @@ def capture_recommended_patch(repo: Path, base_ref: str | None, out_path: Path) 
     because the commit phase advances ``HEAD`` past the fix.
 
     Best-effort: writes nothing and returns ``False`` when *base_ref* is
-    ``None``, the diff is empty (no fix landed), or git fails. Never raises.
+    ``None`` or git fails. When the diff is empty (no fix landed) it writes an
+    *empty* marker file (and returns ``False``) so the run is distinguishable
+    from a legacy archive, which has no ``recommended.patch`` at all —
+    otherwise ``_read_recommended_patch`` falls back to ``diff.patch`` (the
+    PR-under-review diff) and mislabels a no-recommendation run as "applied".
+    Never raises.
 
     Args:
         repo: Repository working directory.
@@ -873,11 +878,53 @@ def capture_recommended_patch(repo: Path, base_ref: str | None, out_path: Path) 
         recommended = diff_worktree_against(repo, base_ref, ["."])
     except GitError:
         return False
-    if not recommended.strip():
-        return False
     out_path.parent.mkdir(parents=True, exist_ok=True)
+    if not recommended.strip():
+        # Empty marker: a present-but-empty recommended.patch distinguishes a
+        # no-fix run from a legacy archive (no file at all), preventing the
+        # diff.patch fallback in _read_recommended_patch. Returns False since
+        # no non-empty patch was written.
+        out_path.write_text("")
+        return False
     out_path.write_text(recommended)
     return True
+
+
+def capture_recommended_patch_with_base(
+    repo: Path,
+    pre_fix_snapshot: str | None,
+    pre_fix_head: str | None,
+    out_path: Path,
+) -> bool:
+    """Capture the recommended patch, resolving the pre-fix base centrally.
+
+    Thin wrapper over :func:`capture_recommended_patch` that resolves the
+    pre-fix base as ``pre_fix_snapshot or pre_fix_head`` in one place, so the
+    deep and shallow fix paths cannot drift apart in how they pick the base.
+
+    *pre_fix_snapshot* is a ``stash create`` SHA of the tracked tree taken
+    before fixes; :func:`stash_create` returns ``None`` on a clean tree (the
+    common pre-fix case), so *pre_fix_head* -- the pre-fix ``HEAD`` SHA -- is
+    the fallback base. *pre_fix_head* is therefore only consulted when the
+    snapshot is ``None`` and need not be captured otherwise. Both must be
+    captured *before* the fix/commit phase, which advances ``HEAD`` past the
+    fix.
+
+    Best-effort: never raises (see :func:`capture_recommended_patch`).
+
+    Args:
+        repo: Repository working directory.
+        pre_fix_snapshot: ``stash create`` SHA, or ``None`` when the tree was
+            clean or the snapshot failed.
+        pre_fix_head: Pre-fix ``HEAD`` SHA, or ``None``. Used only when
+            *pre_fix_snapshot* is ``None``.
+        out_path: Destination path for the patch.
+
+    Returns:
+        ``True`` when a non-empty patch was written, else ``False``.
+    """
+    base_ref = pre_fix_snapshot or pre_fix_head
+    return capture_recommended_patch(repo, base_ref, out_path)
 
 
 def log(repo: Path, base: str, head: str = "HEAD") -> str:

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -840,6 +840,46 @@ def diff_worktree_against(repo: Path, ref: str, paths: list[str]) -> str:
     return proc.stdout
 
 
+def capture_recommended_patch(repo: Path, base_ref: str | None, out_path: Path) -> bool:
+    """Write daydream's proposed diff (``base_ref`` → working tree) to *out_path*.
+
+    Captures the *recommended-change patch*: the difference between the pre-fix
+    tree named by *base_ref* and the current working tree — i.e. the edits
+    daydream applied during the fix phase. This is distinct from ``diff.patch``,
+    which is the PR-under-review diff captured before any fix ran.
+
+    *base_ref* must be resolved by the caller BEFORE fixes run, as
+    ``pre_fix_snapshot or pre_fix_head_sha``: :func:`stash_create` returns
+    ``None`` on a clean tree (the common pre-fix case), so the pre-fix ``HEAD``
+    SHA is the fallback base. The ``HEAD`` SHA must be captured before fixes
+    because the commit phase advances ``HEAD`` past the fix.
+
+    Best-effort: writes nothing and returns ``False`` when *base_ref* is
+    ``None``, the diff is empty (no fix landed), or git fails. Never raises.
+
+    Args:
+        repo: Repository working directory.
+        base_ref: Pre-fix base ref (a ``stash create`` SHA or a ``HEAD`` SHA),
+            or ``None`` when no pre-fix snapshot could be taken.
+        out_path: Destination path for the patch (e.g.
+            ``.daydream/recommended.patch``).
+
+    Returns:
+        ``True`` when a non-empty patch was written, else ``False``.
+    """
+    if not base_ref:
+        return False
+    try:
+        recommended = diff_worktree_against(repo, base_ref, ["."])
+    except GitError:
+        return False
+    if not recommended.strip():
+        return False
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(recommended)
+    return True
+
+
 def log(repo: Path, base: str, head: str = "HEAD") -> str:
     """Return the one-line commit log for ``base..head``.
 

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -1129,6 +1129,16 @@ async def _run_loop_shallow(work: WorkContext, config: RunConfig) -> int:
                     await phase_fix(fix_backend, work, item, i, len(items))
                     fixes_count += 1
 
+            # Capture the recommended patch NOW, before tests run and a failure
+            # reverts the tree below. Overwritten each iteration so the file holds
+            # the cumulative fix against the pre-first-fix base. Best-effort.
+            git_ops.capture_recommended_patch_with_base(
+                target_dir,
+                pre_fix_snapshot,
+                pre_fix_head,
+                target_dir / ".daydream" / "recommended.patch",
+            )
+
             async with phase_scope(DaydreamPhase.TEST):
                 passed, retries = await phase_test_and_heal(test_backend, work, feedback_items=items)
 
@@ -1250,6 +1260,15 @@ async def _run_loop_shallow(work: WorkContext, config: RunConfig) -> int:
                 else:
                     print_info(console, "No feedback items found, skipping fix phase")
 
+            # Capture the recommended patch NOW, before tests run and a failure
+            # returns early below. Best-effort; never blocks the run.
+            git_ops.capture_recommended_patch_with_base(
+                target_dir,
+                pre_fix_snapshot,
+                pre_fix_head,
+                target_dir / ".daydream" / "recommended.patch",
+            )
+
             async with phase_scope(DaydreamPhase.TEST):
                 tests_passed, test_retries = await phase_test_and_heal(
                     test_backend, work, feedback_items=feedback_items
@@ -1288,16 +1307,6 @@ async def _run_loop_shallow(work: WorkContext, config: RunConfig) -> int:
             elif commit_decision is None:
                 await phase_commit_push(review_backend, work)
             # commit_decision is False -> forced decline, skip commit.
-
-            # Capture daydream's proposed diff (pre-fix tree → post-fix worktree)
-            # so training signals score the RECOMMENDED changes, not the diff
-            # under review. Best-effort; never blocks a successful run.
-            git_ops.capture_recommended_patch_with_base(
-                target_dir,
-                pre_fix_snapshot,
-                pre_fix_head,
-                target_dir / ".daydream" / "recommended.patch",
-            )
 
             if cleanup_enabled:
                 review_output_path = target_dir / REVIEW_OUTPUT_FILE

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -177,7 +177,8 @@ class RunConfig:
         pr_repo: GitHub repository in ``owner/repo`` format. Auto-detected from ``gh``
             in deep (default) mode. Stored in trajectory metadata for eval linkage.
         archive: Archive run artifacts to centralized store. Default True.
-        run_eval: Run deterministic evaluation on archived artifacts. Default False.
+        run_eval: Run deterministic evaluation on archived artifacts. Default True
+            (``analyze_session`` is file-based and cheap); ``--no-eval`` opts out.
         branch: Specific branch to review. If None, uses cwd's HEAD.
         base: Base ref to compare against. If None, auto-resolves.
         output_mode: ``"loop"`` (review→fix→test, default), ``"comment"``
@@ -227,7 +228,7 @@ class RunConfig:
     trajectory_path: Path | None = None
     pr_repo: str | None = None
     archive: bool = True
-    run_eval: bool = False
+    run_eval: bool = True
 
     branch: str | None = None
     base: str | None = None
@@ -1074,6 +1075,19 @@ async def _run_loop_shallow(work: WorkContext, config: RunConfig) -> int:
         diff_base: str | None = None
         exploration_dir: Path | None = None
 
+        # Recommended-change patch base: snapshot the tracked tree + HEAD BEFORE
+        # any fix runs. stash_create returns None on a clean tree (the common
+        # pre-fix case), so the pre-fix HEAD SHA is the fallback base. HEAD is
+        # captured now because the commit gate below advances it past the fixes.
+        try:
+            pre_fix_snapshot = git_ops.stash_create(target_dir)
+        except GitError:
+            pre_fix_snapshot = None
+        try:
+            pre_fix_head = git_ops.head_sha(target_dir)
+        except GitError:
+            pre_fix_head = None
+
         async def _run_loop_iteration() -> tuple[list[dict[str, Any]], int, int, bool, bool]:
             """Execute one iteration of the review-parse-fix-test loop.
 
@@ -1272,6 +1286,15 @@ async def _run_loop_shallow(work: WorkContext, config: RunConfig) -> int:
             elif commit_decision is None:
                 await phase_commit_push(review_backend, work)
             # commit_decision is False -> forced decline, skip commit.
+
+            # Capture daydream's proposed diff (pre-fix tree → post-fix worktree)
+            # so training signals score the RECOMMENDED changes, not the diff
+            # under review. Best-effort; never blocks a successful run.
+            git_ops.capture_recommended_patch(
+                target_dir,
+                pre_fix_snapshot or pre_fix_head,
+                target_dir / ".daydream" / "recommended.patch",
+            )
 
             if cleanup_enabled:
                 review_output_path = target_dir / REVIEW_OUTPUT_FILE

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -1079,6 +1079,8 @@ async def _run_loop_shallow(work: WorkContext, config: RunConfig) -> int:
         # any fix runs. stash_create returns None on a clean tree (the common
         # pre-fix case), so the pre-fix HEAD SHA is the fallback base. HEAD is
         # captured now because the commit gate below advances it past the fixes.
+        # Captured once before the loop so the final file is the cumulative fix
+        # against the pre-first-fix base (recommended.patch is overwritten each iteration).
         try:
             pre_fix_snapshot = git_ops.stash_create(target_dir)
         except GitError:
@@ -1290,9 +1292,10 @@ async def _run_loop_shallow(work: WorkContext, config: RunConfig) -> int:
             # Capture daydream's proposed diff (pre-fix tree → post-fix worktree)
             # so training signals score the RECOMMENDED changes, not the diff
             # under review. Best-effort; never blocks a successful run.
-            git_ops.capture_recommended_patch(
+            git_ops.capture_recommended_patch_with_base(
                 target_dir,
-                pre_fix_snapshot or pre_fix_head,
+                pre_fix_snapshot,
+                pre_fix_head,
                 target_dir / ".daydream" / "recommended.patch",
             )
 

--- a/daydream/training/corpus.py
+++ b/daydream/training/corpus.py
@@ -230,10 +230,12 @@ def _build_record(
 ) -> dict[str, Any]:
     """Assemble a training record matching ``schema/v1.json``.
 
-    The returned dict carries refs (``fix_diff_ref``, ``trajectory_ref``,
-    ``spans[*].content_path``) instead of embedded content, so records stay
-    small and downstream consumers materialize bytes from the archive on
-    demand.
+    The returned dict carries refs (``fix_diff_ref``, ``recommended_diff_ref``,
+    ``trajectory_ref``, ``spans[*].content_path``) instead of embedded content,
+    so records stay small and downstream consumers materialize bytes from the
+    archive on demand. ``fix_diff_ref`` is the reviewed-INPUT diff
+    (``diff.patch``); ``recommended_diff_ref`` is daydream's OUTCOME diff
+    (``recommended.patch``, the proposed base->worktree edit).
 
     ``base_sha`` and ``changed_files`` are *read* from the on-disk
     ``manifest.json`` (passed as ``manifest``) via its ``code_context`` block.
@@ -304,10 +306,23 @@ def _build_record(
         A dict that validates against ``daydream/training/schema/v1.json``.
     """
     archive_path = Path(manifest_row.get("archive_path", ""))
+    # fix_diff_ref points at the REVIEWED-INPUT diff (diff.patch = the PR-under-
+    # review diff daydream was asked to review), NOT daydream's own fix. The
+    # name is retained for schema-v1 compatibility; treat it as the input.
     diff_path = archive_path / "diff.patch"
     fix_diff_ref = {
         "available": diff_path.is_file(),
         "archive_relative_path": "diff.patch",
+    }
+    # recommended_diff_ref points at the OUTCOME diff (recommended.patch =
+    # daydream's proposed base->worktree edit, captured best-effort after the
+    # fix phase). Best-effort capture writes nothing on no-fix/legacy runs, so
+    # available=False there; deliberately does NOT fall back to diff.patch,
+    # which would collapse the input/outcome split.
+    recommended_path = archive_path / "recommended.patch"
+    recommended_diff_ref = {
+        "available": recommended_path.is_file(),
+        "archive_relative_path": "recommended.patch",
     }
 
     # Label from the as_of-pinned silver annotation (NOT runs.outcome_labels);
@@ -350,6 +365,7 @@ def _build_record(
         },
         "review_output": review_output,
         "fix_diff_ref": fix_diff_ref,
+        "recommended_diff_ref": recommended_diff_ref,
         "outcome_label": _single_outcome_label(labels, manifest_row["session_id"]),
         "grounding_score": manifest_row.get("grounding_rate"),
         "spans": _build_spans(trajectory),

--- a/daydream/training/harvest.py
+++ b/daydream/training/harvest.py
@@ -340,10 +340,10 @@ _FIX_APPLIED_STUB = FixAppliedSignal(
     hunks_total=0,
     window_commits=[],
 )
-"""Returned when the fix-applied cascade cannot run (missing diff.patch,
-empty changed_files, or any subprocess error). The rubric still carries
-the field for schema stability; outcome derivation does not depend on it
-for the PR-review path."""
+"""Returned when the fix-applied cascade cannot run (missing recommended.patch
+/ diff.patch, empty changed_files, or any subprocess error). The rubric still
+carries the field for schema stability; outcome derivation does not depend on
+it for the PR-review path."""
 
 
 def _safe_fix_applied(
@@ -354,9 +354,10 @@ def _safe_fix_applied(
 ) -> FixAppliedSignal:
     """Run :func:`fix_applied_signal`, swallowing missing-data errors.
 
-    The cascade needs ``archive_path/diff.patch`` to exist. When the archive
-    directory is missing (older runs, dry fixtures), or when ``changed_files``
-    is empty, return :data:`_FIX_APPLIED_STUB`.
+    The cascade reads ``recommended.patch`` (falling back to ``diff.patch``
+    for legacy archives). When the archive directory is missing (older runs,
+    dry fixtures), or when ``changed_files`` is empty, return
+    :data:`_FIX_APPLIED_STUB`.
     """
     if not changed_files:
         return _FIX_APPLIED_STUB

--- a/daydream/training/labeler_signals.py
+++ b/daydream/training/labeler_signals.py
@@ -184,6 +184,29 @@ def _hunk_lines_present(added_lines: tuple[str, ...], post_content: str) -> bool
     return all(line in haystack_lines for line in added_lines)
 
 
+def _read_recommended_patch(archive_path: Path) -> str:
+    """Read daydream's recommended-change patch for a run.
+
+    Prefers ``recommended.patch`` — daydream's proposed diff, captured post-fix
+    — so the applied-signal cascades score the RECOMMENDED changes rather than
+    the PR-under-review diff. Falls back to ``diff.patch`` for backward
+    compatibility with archives created before ``recommended.patch`` existed.
+
+    Args:
+        archive_path: The archived run directory (bronze bundle root).
+
+    Returns:
+        The unified-diff text to parse into recommended hunks.
+
+    Raises:
+        OSError: If neither patch file can be read (the fallback ``diff.patch``
+            is expected to exist for every archived run).
+    """
+    recommended = archive_path / "recommended.patch"
+    patch_path = recommended if recommended.is_file() else archive_path / "diff.patch"
+    return patch_path.read_text()
+
+
 # Signal extractors
 
 
@@ -233,7 +256,9 @@ def fix_applied_signal(
     2. Compute the file overlap between ``changed_files`` and the files
        actually touched by ``diff_fetcher``. If empty → ``not_applied``
        with ``hunks_applied=0`` and ``hunks_total = parsed hunks``.
-    3. Parse ``archive_path/diff.patch`` into hunks. For each hunk on a
+    3. Parse the recommended-change patch (``archive_path/recommended.patch``,
+       falling back to ``diff.patch`` for pre-recommended.patch archives) into
+       hunks. For each hunk on a
        file in the overlap, read ``file_at_fetcher(repo, file, window[-1])``
        and check whether every added line appears verbatim.
     4. Verdict: ``applied`` if ``hunks_applied / hunks_total >= 0.5``;
@@ -260,7 +285,8 @@ def fix_applied_signal(
     Raises:
         KeyError: If ``row`` is missing ``head_sha``, ``base_branch``,
             or ``archive_path``.
-        OSError: If ``archive_path/diff.patch`` cannot be read.
+        OSError: If neither ``recommended.patch`` nor ``diff.patch`` can be
+            read from ``archive_path``.
         Exception: Any exception raised by ``diff_fetcher``,
             ``commits_in_window_fetcher``, or ``file_at_fetcher`` is
             propagated unchanged.
@@ -269,7 +295,7 @@ def fix_applied_signal(
     base_branch = row["base_branch"]
     archive_path = Path(row["archive_path"])
 
-    diff_patch = (archive_path / "diff.patch").read_text()
+    diff_patch = _read_recommended_patch(archive_path)
     hunks = _parse_diff_hunks(diff_patch)
     hunks_total = len(hunks)
 
@@ -408,7 +434,8 @@ def local_commit_applied_signal(
 
     See ``/tmp/research-no-pr.md``. Walks the commits on ``row["branch"]``
     that landed after ``row["head_sha"]`` and checks whether any commit
-    contains the added lines from the recommended ``diff.patch``.
+    contains the added lines from the recommended-change patch
+    (``recommended.patch``, falling back to ``diff.patch`` for older archives).
 
     Args:
         row: Manifest row with ``branch``, ``head_sha``, ``archive_path``.
@@ -426,7 +453,8 @@ def local_commit_applied_signal(
     Raises:
         KeyError: If ``row`` is missing ``archive_path``, ``branch``,
             or ``head_sha``.
-        OSError: If ``archive_path/diff.patch`` cannot be read.
+        OSError: If neither ``recommended.patch`` nor ``diff.patch`` can be
+            read from ``archive_path``.
         Exception: Any exception raised by ``commits_since_fetcher`` or
             ``file_at_fetcher`` is propagated unchanged.
     """
@@ -434,7 +462,7 @@ def local_commit_applied_signal(
         return LocalCommitAppliedSignal(verdict="unknown")
 
     archive_path = Path(row["archive_path"])
-    diff_patch = (archive_path / "diff.patch").read_text()
+    diff_patch = _read_recommended_patch(archive_path)
     hunks = _parse_diff_hunks(diff_patch)
 
     commits = commits_since_fetcher(repo_clone, row["branch"], row["head_sha"])

--- a/daydream/training/labeler_signals.py
+++ b/daydream/training/labeler_signals.py
@@ -23,6 +23,7 @@ HTTP calls.
 
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -82,7 +83,8 @@ class FixAppliedSignal:
             if no window commits exist.
         hunks_applied: Count of hunks whose added lines appear verbatim
             in the post-window file content.
-        hunks_total: Total hunks parsed from the recommended ``diff.patch``.
+        hunks_total: Total hunks parsed from ``recommended.patch`` (daydream's
+            proposed diff); ``diff.patch`` is the legacy-only fallback.
         window_commits: Ordered commit SHAs considered (oldest → newest).
     """
 
@@ -184,27 +186,60 @@ def _hunk_lines_present(added_lines: tuple[str, ...], post_content: str) -> bool
     return all(line in haystack_lines for line in added_lines)
 
 
+def _archive_is_recommended_patch_aware(archive_path: Path) -> bool:
+    """Return True if *archive_path*'s manifest was written by recommended.patch-aware daydream.
+
+    Reads the archived ``manifest.json`` provenance flag
+    ``recommended_patch_supported``. When set, a missing ``recommended.patch``
+    means the run made no recommendation (review-only, all-declined, reverted,
+    or wash) — not a legacy archive — so callers must NOT fall back to
+    ``diff.patch`` (the PR-under-review diff). A missing or unparseable manifest
+    is treated as legacy, preserving the backward-compatible ``diff.patch``
+    fallback for archives created before ``recommended.patch`` existed.
+    """
+    try:
+        data = json.loads((archive_path / "manifest.json").read_text())
+    except (OSError, ValueError):
+        return False
+    return data.get("recommended_patch_supported") is True
+
+
 def _read_recommended_patch(archive_path: Path) -> str:
     """Read daydream's recommended-change patch for a run.
 
     Prefers ``recommended.patch`` — daydream's proposed diff, captured post-fix
     — so the applied-signal cascades score the RECOMMENDED changes rather than
-    the PR-under-review diff. Falls back to ``diff.patch`` for backward
-    compatibility with archives created before ``recommended.patch`` existed.
+    the PR-under-review diff. When ``recommended.patch`` is absent the behaviour
+    depends on archive provenance (``manifest.json`` →
+    ``recommended_patch_supported``):
+
+    * **New-format archive** (flag set): absence means daydream made no
+      recommendation (review-only, all-declined, reverted, or wash). Returns
+      ``""`` so the cascade scores no hunks — it must NOT fall back to
+      ``diff.patch``, which is the PR-under-review diff and would mislabel such
+      runs as "applied".
+    * **Legacy archive** (flag absent / no manifest): falls back to
+      ``diff.patch`` for backward compatibility with archives created before
+      ``recommended.patch`` existed.
 
     Args:
         archive_path: The archived run directory (bronze bundle root).
 
     Returns:
-        The unified-diff text to parse into recommended hunks.
+        The unified-diff text to parse into recommended hunks (``""`` for a
+        new-format run that made no recommendation).
 
     Raises:
-        OSError: If neither patch file can be read (the fallback ``diff.patch``
-            is expected to exist for every archived run).
+        OSError: For a legacy archive (no ``recommended.patch``) when
+            ``diff.patch`` cannot be read. New-format archives with no
+            ``recommended.patch`` return ``""`` rather than raising.
     """
     recommended = archive_path / "recommended.patch"
-    patch_path = recommended if recommended.is_file() else archive_path / "diff.patch"
-    return patch_path.read_text()
+    if recommended.is_file():
+        return recommended.read_text()
+    if _archive_is_recommended_patch_aware(archive_path):
+        return ""
+    return (archive_path / "diff.patch").read_text()
 
 
 # Signal extractors
@@ -285,8 +320,10 @@ def fix_applied_signal(
     Raises:
         KeyError: If ``row`` is missing ``head_sha``, ``base_branch``,
             or ``archive_path``.
-        OSError: If neither ``recommended.patch`` nor ``diff.patch`` can be
-            read from ``archive_path``.
+        OSError: For a legacy archive (no ``recommended.patch``) when
+            ``diff.patch`` cannot be read from ``archive_path``. New-format
+            archives with no ``recommended.patch`` yield an empty patch rather
+            than raising (see :func:`_read_recommended_patch`).
         Exception: Any exception raised by ``diff_fetcher``,
             ``commits_in_window_fetcher``, or ``file_at_fetcher`` is
             propagated unchanged.
@@ -453,8 +490,10 @@ def local_commit_applied_signal(
     Raises:
         KeyError: If ``row`` is missing ``archive_path``, ``branch``,
             or ``head_sha``.
-        OSError: If neither ``recommended.patch`` nor ``diff.patch`` can be
-            read from ``archive_path``.
+        OSError: For a legacy archive (no ``recommended.patch``) when
+            ``diff.patch`` cannot be read from ``archive_path``. New-format
+            archives with no ``recommended.patch`` yield an empty patch rather
+            than raising (see :func:`_read_recommended_patch`).
         Exception: Any exception raised by ``commits_since_fetcher`` or
             ``file_at_fetcher`` is propagated unchanged.
     """

--- a/daydream/training/schema/v1.json
+++ b/daydream/training/schema/v1.json
@@ -12,6 +12,7 @@
     "code_context",
     "review_output",
     "fix_diff_ref",
+    "recommended_diff_ref",
     "outcome_label",
     "grounding_score",
     "spans",
@@ -68,6 +69,22 @@
       "type": ["string", "null"]
     },
     "fix_diff_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "available",
+        "archive_relative_path"
+      ],
+      "properties": {
+        "available": {
+          "type": "boolean"
+        },
+        "archive_relative_path": {
+          "type": "string"
+        }
+      }
+    },
+    "recommended_diff_ref": {
       "type": "object",
       "additionalProperties": false,
       "required": [

--- a/daydream/training/schema/v1.json
+++ b/daydream/training/schema/v1.json
@@ -12,7 +12,6 @@
     "code_context",
     "review_output",
     "fix_diff_ref",
-    "recommended_diff_ref",
     "outcome_label",
     "grounding_score",
     "spans",

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -1085,10 +1085,11 @@ class TrajectoryRecorder:
         recorder's steps. Returns ``None`` when fewer than two timestamped
         steps exist (no measurable span).
 
-        Independent of ``--eval``: this mirrors the timestamp-span derivation
+        Independent of the eval pass: this mirrors the timestamp-span derivation
         in :func:`daydream.eval.analyzer.analyze_timing`, but reads in-memory
-        steps so every archived run captures duration without the deterministic
-        evaluation pass. Fork-only steps live in sibling recorders and are not
+        steps so every archived run captures duration even when ``--no-eval``
+        skips the deterministic evaluation pass. Fork-only steps live in sibling
+        recorders and are not
         included here; the main flow's span bounds them because forks are
         dispatched and merged within it.
 

--- a/tests/test_archive_data_capture.py
+++ b/tests/test_archive_data_capture.py
@@ -259,13 +259,18 @@ def test_capture_recommended_patch_none_base_writes_nothing(tmp_path: Path) -> N
     assert not out.exists()
 
 
-def test_capture_recommended_patch_no_change_writes_nothing(tmp_path: Path) -> None:
-    """When nothing changed (base == worktree) no patch is written."""
+def test_capture_recommended_patch_no_change_writes_empty_marker(tmp_path: Path) -> None:
+    """When nothing changed (no fix landed) an EMPTY recommended.patch marker is
+    written so the run is distinguishable from a legacy archive (which has no
+    recommended.patch at all). This prevents _read_recommended_patch from
+    falling back to diff.patch (the PR-under-review diff) and mislabeling a
+    no-recommendation run as 'applied'. Returns False (no non-empty patch)."""
     repo = _init_repo_with_commit(tmp_path)
     base = git_ops.head_sha(repo)
     out = repo / ".daydream" / "recommended.patch"
     assert git_ops.capture_recommended_patch(repo, base, out) is False
-    assert not out.exists()
+    assert out.is_file()
+    assert out.read_text() == ""
 
 
 # --- AC4: applied-signal cascades read recommended.patch (fallback to diff.patch) ---
@@ -334,6 +339,38 @@ def test_fix_applied_signal_falls_back_to_diff_patch(tmp_path: Path) -> None:
     )
     assert sig.verdict == "applied"
     assert sig.hunks_total == 1
+
+
+def test_fix_applied_signal_new_archive_no_recommendation_skips_fallback(tmp_path: Path) -> None:
+    """A new-format archive (manifest ``recommended_patch_supported=True``) with
+    no ``recommended.patch`` made NO recommendation (review-only / all-declined /
+    wash). The cascade must score zero hunks and NOT fall back to ``diff.patch``
+    (the PR-under-review diff), even when diff.patch's line is present
+    post-window — otherwise such runs are mislabeled 'applied'."""
+    from daydream.training.labeler_signals import fix_applied_signal
+
+    (tmp_path / "diff.patch").write_text(_diff_adding("reviewed = 2"))
+    (tmp_path / "manifest.json").write_text(
+        json.dumps({"schema_version": "1.0", "recommended_patch_supported": True})
+    )
+    row = {
+        "repo_slug": "org/repo",
+        "head_sha": "abc",
+        "base_branch": "main",
+        "archive_path": str(tmp_path),
+    }
+    # Post-window carries the REVIEWED line; diff.patch would match if the
+    # (forbidden) fallback fired.
+    sig = fix_applied_signal(
+        row,
+        changed_files=["app.py"],
+        repo_clone=tmp_path,
+        diff_fetcher=lambda repo, base, head: ["app.py"],
+        commits_in_window_fetcher=lambda repo, base, head: ["c1"],
+        file_at_fetcher=lambda repo, path, sha: "existing\nreviewed = 2\n",
+    )
+    assert sig.hunks_total == 0
+    assert sig.verdict == "not_applied"
 
 
 def test_local_commit_applied_signal_prefers_recommended_patch(tmp_path: Path) -> None:

--- a/tests/test_archive_data_capture.py
+++ b/tests/test_archive_data_capture.py
@@ -1,0 +1,381 @@
+"""Archive-time data-capture tests (issue #124).
+
+Covers the two capture gaps this feature closes:
+
+1. **Eval on by default.** ``analyze_session`` is file-based and cheap, so it
+   runs on every archive unless ``--no-eval`` opts out. AC1/AC1b assert the
+   manifest's eval metrics are populated on a default run and null with
+   ``--no-eval``.
+2. **Recommended-change patch.** A separate ``recommended.patch`` (daydream's
+   proposed diff, captured post-fix) is archived distinct from ``diff.patch``
+   (the PR-under-review diff), and the applied-signal cascades read it. AC3/AC4.
+
+The deep AC1/AC3 test drives the production entrypoint (``runner.run`` →
+``run_deep``) through a real temp git worktree, reusing the deep-orchestrator
+stub harness. The shallow AC3 test drives the shallow single-pass path. Only the
+backend seam is mocked.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from daydream import git_ops
+from daydream.runner import RunConfig, run
+
+# Reuse the deep-orchestrator stub harness (the hard-won prompt-dispatch heuristics
+# live there; re-rolling them would be fragile). tests/ is a namespace package, so
+# a sibling test module imports cleanly.
+from tests.test_deep_orchestrator import (
+    _force_interactive,
+    _install_stub_backend,
+    _merge_item,
+    _noop_commit,
+    _ok,
+    _silence,
+)
+
+
+def _only_archived_run(archive_dir: Path) -> Path:
+    """Return the single archived run directory, asserting there is exactly one."""
+    run_dirs = list((archive_dir / "runs").iterdir())
+    assert len(run_dirs) == 1, f"expected exactly one archived run, got {run_dirs}"
+    return run_dirs[0]
+
+
+# --- AC1 + AC3: default deep run populates eval metrics AND captures recommended.patch ---
+
+
+async def test_default_deep_run_populates_eval_and_captures_recommended_patch(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch, archive_dir: Path
+) -> None:
+    """AC1 + AC3: a default deep run (no --no-eval) populates the manifest's eval
+    metrics AND writes a recommended.patch distinct from diff.patch.
+
+    The fix stage edits a TRACKED file (api.py), so the pre-fix → post-fix diff
+    is non-empty; commit is a no-op so the edit stays in the worktree for capture.
+    """
+    _silence(monkeypatch)
+    _force_interactive(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    stub.merge_items = [_merge_item(1, "api.py", "high")]
+    stub.fix_edit_line = "# daydream recommended change\n"
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_test_and_heal", lambda *a, **k: _ok())
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _noop_commit)
+
+    exit_code = await run(
+        RunConfig(target=str(multi_stack_target), assume="yes", output_mode="loop", cleanup=False)
+    )
+    assert exit_code == 0
+
+    run_dir = _only_archived_run(archive_dir)
+    manifest = json.loads((run_dir / "manifest.json").read_text())
+
+    # AC1: eval ran by default -> all four metrics non-null.
+    metrics = manifest["metrics"]
+    assert metrics["grounding_rate"] is not None
+    assert metrics["total_findings"] is not None
+    assert metrics["coverage_ratio"] is not None
+    assert metrics["cost_per_finding_usd"] is not None
+    assert (run_dir / "evaluation.json").is_file()
+
+    # AC3: recommended.patch archived and distinct from diff.patch.
+    recommended = run_dir / "recommended.patch"
+    diff = run_dir / "diff.patch"
+    assert recommended.is_file()
+    assert diff.is_file()
+    recommended_text = recommended.read_text()
+    diff_text = diff.read_text()
+    assert recommended_text != diff_text
+    # The recommended patch carries daydream's fix line; the review diff does not.
+    assert "# daydream recommended change" in recommended_text
+    assert "# daydream recommended change" not in diff_text
+
+
+async def test_no_eval_leaves_manifest_eval_fields_null(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch, archive_dir: Path
+) -> None:
+    """AC1b: --no-eval (run_eval=False) skips the eval pass, leaving its metrics null."""
+    _silence(monkeypatch)
+    _force_interactive(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    stub.merge_items = [_merge_item(1, "api.py", "high")]
+    stub.fix_edit_line = "# daydream recommended change\n"
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_test_and_heal", lambda *a, **k: _ok())
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _noop_commit)
+
+    exit_code = await run(
+        RunConfig(
+            target=str(multi_stack_target),
+            assume="yes",
+            output_mode="loop",
+            cleanup=False,
+            run_eval=False,
+        )
+    )
+    assert exit_code == 0
+
+    run_dir = _only_archived_run(archive_dir)
+    manifest = json.loads((run_dir / "manifest.json").read_text())
+    metrics = manifest["metrics"]
+    assert metrics["grounding_rate"] is None
+    assert metrics["total_findings"] is None
+    assert metrics["coverage_ratio"] is None
+    assert metrics["cost_per_finding_usd"] is None
+    assert not (run_dir / "evaluation.json").exists()
+
+
+# --- AC3 (shallow path): recommended.patch captured through the shallow runner ---
+
+
+class _FixEditingBackend:
+    """Shallow-dispatch backend whose fix stage edits a tracked file.
+
+    Mirrors ``PhaseDispatchBackend`` dispatch but writes a real change to
+    ``main.py`` on the fix turn so the shallow runner's recommended-patch capture
+    has a non-empty diff to record.
+    """
+
+    model = "mock-model"
+
+    def __init__(self, repo: Path) -> None:
+        self._repo = repo
+
+    async def execute(
+        self, cwd, prompt, output_schema=None, continuation=None,
+        agents=None, max_turns=None, read_only=False,
+    ):
+        from daydream.backends import ResultEvent, TextEvent
+
+        pl = prompt.lower()
+        if "beagle-" in pl and "review" in pl:
+            yield TextEvent(text="Review complete.")
+            yield ResultEvent(structured_output=None, continuation=None)
+        elif "extract" in pl and "json" in pl:
+            yield TextEvent(text="Parsed.")
+            yield ResultEvent(
+                structured_output={
+                    "issues": [{"id": 1, "description": "Add a guard", "file": "main.py", "line": 1}]
+                },
+                continuation=None,
+            )
+        elif "fix this issue" in pl or pl.startswith("fix these"):
+            main_py = self._repo / "main.py"
+            main_py.write_text(main_py.read_text() + "# daydream recommended change\n")
+            yield TextEvent(text="Fixed.")
+            yield ResultEvent(structured_output=None, continuation=None)
+        elif "test suite" in pl or "run the project" in pl:
+            yield TextEvent(text="All 1 tests passed. 0 failed.")
+            yield ResultEvent(structured_output=None, continuation=None)
+        else:
+            yield TextEvent(text="OK")
+            yield ResultEvent(structured_output=None, continuation=None)
+
+    async def cancel(self) -> None:
+        pass
+
+    def format_skill_invocation(self, skill_key: str, args: str = "") -> str:
+        return f"/{skill_key}"
+
+
+async def test_shallow_run_captures_recommended_patch(
+    feature_branch_repo: Path, monkeypatch: pytest.MonkeyPatch, archive_dir: Path
+) -> None:
+    """AC3 (shallow): the shallow single-pass fix path archives a recommended.patch
+    carrying daydream's edit.
+
+    The shallow review-fix-test path never persists a ``diff.patch`` (the review
+    agent runs ``git diff`` itself), so recommended.patch is the sole patch here;
+    the "distinct from diff.patch" comparison is covered by the deep test where
+    both artifacts exist.
+    """
+    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "n")
+    monkeypatch.setattr("daydream.runner.prompt_user", lambda *a, **kw: "n")
+    backend = _FixEditingBackend(feature_branch_repo)
+    monkeypatch.setattr("daydream.runner.create_backend", lambda name, model=None: backend)
+
+    exit_code = await run(
+        RunConfig(
+            target=str(feature_branch_repo),
+            skill="python",
+            quiet=True,
+            cleanup=False,
+            loop=False,
+            shallow=True,
+            assume="yes",
+        )
+    )
+    assert exit_code == 0
+
+    run_dir = _only_archived_run(archive_dir)
+    recommended = run_dir / "recommended.patch"
+    assert recommended.is_file()
+    recommended_text = recommended.read_text()
+    # The captured patch is daydream's fix edit as an ADDED line, diffed against
+    # the pre-fix HEAD. It is NOT the reviewed world->universe change: 'world'
+    # exists only on the base branch, so it never appears in this post-HEAD diff.
+    assert "+# daydream recommended change" in recommended_text
+    assert "world" not in recommended_text
+
+
+# --- git_ops.capture_recommended_patch (the shared helper) ---
+
+
+def _init_repo_with_commit(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    git_ops._run_git(repo, ["init", "-b", "main"], timeout=10)
+    git_ops._run_git(repo, ["config", "user.email", "t@t.com"], timeout=10)
+    git_ops._run_git(repo, ["config", "user.name", "T"], timeout=10)
+    (repo / "a.py").write_text("x = 1\n")
+    git_ops._run_git(repo, ["add", "."], timeout=10)
+    git_ops._run_git(repo, ["commit", "-m", "init"], timeout=10)
+    return repo
+
+
+def test_capture_recommended_patch_clean_tree_uses_head_base(tmp_path: Path) -> None:
+    """On a clean tree (stash_create is None) the pre-fix HEAD is the base: the
+    post-fix worktree diff against it is captured."""
+    repo = _init_repo_with_commit(tmp_path)
+    base = git_ops.head_sha(repo)  # captured before the "fix"
+    (repo / "a.py").write_text("x = 1\ny = 2\n")  # the fix
+
+    out = repo / ".daydream" / "recommended.patch"
+    wrote = git_ops.capture_recommended_patch(repo, base, out)
+
+    assert wrote is True
+    assert out.is_file()
+    assert "+y = 2" in out.read_text()
+
+
+def test_capture_recommended_patch_none_base_writes_nothing(tmp_path: Path) -> None:
+    """A None base (no pre-fix snapshot could be taken) is a no-op."""
+    repo = _init_repo_with_commit(tmp_path)
+    out = repo / ".daydream" / "recommended.patch"
+    assert git_ops.capture_recommended_patch(repo, None, out) is False
+    assert not out.exists()
+
+
+def test_capture_recommended_patch_no_change_writes_nothing(tmp_path: Path) -> None:
+    """When nothing changed (base == worktree) no patch is written."""
+    repo = _init_repo_with_commit(tmp_path)
+    base = git_ops.head_sha(repo)
+    out = repo / ".daydream" / "recommended.patch"
+    assert git_ops.capture_recommended_patch(repo, base, out) is False
+    assert not out.exists()
+
+
+# --- AC4: applied-signal cascades read recommended.patch (fallback to diff.patch) ---
+
+
+def _diff_adding(line: str, *, file: str = "app.py") -> str:
+    """One-hunk unified diff that adds ``line`` to ``file``."""
+    return (
+        f"diff --git a/{file} b/{file}\n"
+        "index 1111111..2222222 100644\n"
+        f"--- a/{file}\n"
+        f"+++ b/{file}\n"
+        "@@ -1,1 +1,2 @@\n"
+        " existing\n"
+        f"+{line}\n"
+    )
+
+
+def test_fix_applied_signal_prefers_recommended_patch(tmp_path: Path) -> None:
+    """AC4: with both patches present, the signal parses recommended.patch hunks,
+    not diff.patch hunks — a run whose RECOMMENDATION landed labels 'applied' even
+    though the reviewed line is absent post-window."""
+    from daydream.training.labeler_signals import fix_applied_signal
+
+    (tmp_path / "diff.patch").write_text(_diff_adding("reviewed = 2"))
+    (tmp_path / "recommended.patch").write_text(_diff_adding("recommended = 1"))
+    row = {
+        "repo_slug": "org/repo",
+        "head_sha": "abc",
+        "base_branch": "main",
+        "archive_path": str(tmp_path),
+    }
+    # Post-window state carries the RECOMMENDED line but NOT the reviewed line.
+    sig = fix_applied_signal(
+        row,
+        changed_files=["app.py"],
+        repo_clone=tmp_path,
+        diff_fetcher=lambda repo, base, head: ["app.py"],
+        commits_in_window_fetcher=lambda repo, base, head: ["c1"],
+        file_at_fetcher=lambda repo, path, sha: "existing\nrecommended = 1\n",
+    )
+    assert sig.verdict == "applied"
+    assert sig.hunks_applied == 1
+    assert sig.hunks_total == 1
+
+
+def test_fix_applied_signal_falls_back_to_diff_patch(tmp_path: Path) -> None:
+    """AC4 backward compat: an old archive with only diff.patch still labels via
+    the diff.patch hunks."""
+    from daydream.training.labeler_signals import fix_applied_signal
+
+    (tmp_path / "diff.patch").write_text(_diff_adding("reviewed = 2"))
+    row = {
+        "repo_slug": "org/repo",
+        "head_sha": "abc",
+        "base_branch": "main",
+        "archive_path": str(tmp_path),
+    }
+    sig = fix_applied_signal(
+        row,
+        changed_files=["app.py"],
+        repo_clone=tmp_path,
+        diff_fetcher=lambda repo, base, head: ["app.py"],
+        commits_in_window_fetcher=lambda repo, base, head: ["c1"],
+        file_at_fetcher=lambda repo, path, sha: "existing\nreviewed = 2\n",
+    )
+    assert sig.verdict == "applied"
+    assert sig.hunks_total == 1
+
+
+def test_local_commit_applied_signal_prefers_recommended_patch(tmp_path: Path) -> None:
+    """AC4: local-commit signal parses recommended.patch when present."""
+    from daydream.training.labeler_signals import local_commit_applied_signal
+
+    (tmp_path / "diff.patch").write_text(_diff_adding("reviewed = 2"))
+    (tmp_path / "recommended.patch").write_text(_diff_adding("recommended = 1"))
+    row = {
+        "repo_slug": "org/repo",
+        "head_sha": "abc",
+        "branch": "feature",
+        "archive_path": str(tmp_path),
+    }
+    sig = local_commit_applied_signal(
+        row,
+        repo_clone=tmp_path,
+        commits_since_fetcher=lambda repo, branch, since: ["c1"],
+        # The later commit carries the recommended line, not the reviewed line.
+        file_at_fetcher=lambda repo, path, sha: "existing\nrecommended = 1\n",
+    )
+    assert sig.verdict == "applied"
+
+
+def test_local_commit_applied_signal_recommended_line_absent_is_rejected(tmp_path: Path) -> None:
+    """AC4: when recommended.patch is present but its line never lands, the reviewed
+    line (in diff.patch) must NOT rescue it — proving diff.patch is not consulted."""
+    from daydream.training.labeler_signals import local_commit_applied_signal
+
+    (tmp_path / "diff.patch").write_text(_diff_adding("reviewed = 2"))
+    (tmp_path / "recommended.patch").write_text(_diff_adding("recommended = 1"))
+    row = {
+        "repo_slug": "org/repo",
+        "head_sha": "abc",
+        "branch": "feature",
+        "archive_path": str(tmp_path),
+    }
+    sig = local_commit_applied_signal(
+        row,
+        repo_clone=tmp_path,
+        commits_since_fetcher=lambda repo, branch, since: ["c1"],
+        # Commit carries only the REVIEWED line; recommended line absent.
+        file_at_fetcher=lambda repo, path, sha: "existing\nreviewed = 2\n",
+    )
+    assert sig.verdict == "rejected"

--- a/tests/test_archive_integration.py
+++ b/tests/test_archive_integration.py
@@ -3,7 +3,7 @@
 
 Verifies that the on_write callback fires at the right times, that the full
 archive round-trip produces valid bundles, and that CLI flags for --no-archive
-and --eval are parsed correctly into RunConfig.
+and --no-eval are parsed correctly into RunConfig.
 """
 
 from __future__ import annotations
@@ -230,22 +230,22 @@ def test_cli_no_archive_flag(monkeypatch: pytest.MonkeyPatch) -> None:
     assert config.archive is False
 
 
-# CLI --eval flag
-def test_cli_eval_flag(monkeypatch: pytest.MonkeyPatch) -> None:
-    """--eval sets config.run_eval to True."""
+# CLI --no-eval flag
+def test_cli_no_eval_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--no-eval opts out: sets config.run_eval to False."""
     from daydream.cli import _parse_args
 
-    monkeypatch.setattr(sys, "argv", ["daydream", "/tmp/fake", "--eval"])
+    monkeypatch.setattr(sys, "argv", ["daydream", "/tmp/fake", "--no-eval"])
     config = _parse_args()
-    assert config.run_eval is True
+    assert config.run_eval is False
 
 
 # CLI defaults for archive and eval
 def test_cli_defaults_archive_and_eval(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Without --no-archive or --eval, archive=True and run_eval=False."""
+    """Without --no-archive or --no-eval, archive=True and run_eval=True (eval on by default)."""
     from daydream.cli import _parse_args
 
     monkeypatch.setattr(sys, "argv", ["daydream", "/tmp/fake"])
     config = _parse_args()
     assert config.archive is True
-    assert config.run_eval is False
+    assert config.run_eval is True

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -102,6 +102,10 @@ class _StubBackend:
         # writes ``.daydream-heal-fix-applied`` -- a sentinel that MUST be absent
         # when the short-circuit aborts before re-entering a fix turn (AC#6b).
         self.environmental_test_failure: bool = False
+        # When set, the fix branch APPENDS this text to the fixed TRACKED file
+        # (in addition to the sentinels), producing a real tracked-tree change so
+        # a test can assert the recommended-change patch captures daydream's edit.
+        self.fix_edit_line: str | None = None
 
     async def execute(
         self,
@@ -360,6 +364,10 @@ class _StubBackend:
                 raise RuntimeError(f"stub fix failure for {fixed_name}")
             (cwd / ".daydream-fix-applied").write_text("applied\n")  # legacy sentinel
             (cwd / f".fixed-{fixed_name.replace('.', '_')}").write_text("applied\n")
+            if self.fix_edit_line is not None:
+                edit_target = Path(fixed_file) if Path(fixed_file).is_absolute() else (cwd / fixed_file)
+                if edit_target.exists():
+                    edit_target.write_text(edit_target.read_text() + self.fix_edit_line)
             if self.fix_append_path is not None and fixed_name == self.fix_append_path.name:
                 # A batched fix turn addresses EVERY finding it is handed, so append
                 # each marker the prompt names (in prompt/severity order), not just

--- a/tests/test_training_harvest.py
+++ b/tests/test_training_harvest.py
@@ -421,6 +421,31 @@ def test_assemble_malformed_verdicts_flags_format_invalid(tmp_path: Path):
     assert inputs.format_valid is False
 
 
+def test_score_trajectory_grounding_axis_present_on_default_run(tmp_path: Path):
+    """AC2: a default-run row (eval-by-default populated grounding_rate) yields a
+    non-absent grounding axis; a --no-eval row (grounding_rate=None) omits it.
+
+    Drives the real harvest → reward path: assemble_scoring_inputs reads the
+    indexed ``grounding_rate`` and score_trajectory flags the axis present.
+    """
+    from daydream.training.reward import score_trajectory
+
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    # Default run: eval ran by default, so the manifest row carries grounding_rate.
+    default_inputs = assemble_scoring_inputs(run_dir, {"grounding_rate": 1.0})
+    default_breakdown = score_trajectory(default_inputs)
+    assert default_breakdown.axes_present["grounding"] is True
+    assert default_breakdown.grounding == 1.0
+
+    # --no-eval run: no grounding_rate, so the axis is absent.
+    no_eval_inputs = assemble_scoring_inputs(run_dir, {"grounding_rate": None})
+    no_eval_breakdown = score_trajectory(no_eval_inputs)
+    assert no_eval_breakdown.axes_present["grounding"] is False
+    assert no_eval_breakdown.grounding is None
+
+
 def _seed_archived_deep_run(
     archive_dir: Path, session_id: str, *, merged_at: str, source_path: Path | None = None
 ) -> Path:

--- a/tests/test_training_record.py
+++ b/tests/test_training_record.py
@@ -159,6 +159,21 @@ def test_record_fix_diff_ref_reflects_archive_state(tmp_path: Path) -> None:
     assert record["fix_diff_ref"]["available"] is True
 
 
+def test_record_recommended_diff_ref_reflects_archive_state(tmp_path: Path) -> None:
+    manifest_row = _make_manifest_row(archive_path=str(tmp_path))
+    trajectory: dict[str, Any] = {"steps": []}
+
+    # No recommended.patch on disk yet (no-fix / legacy archive).
+    record = _build_record(manifest_row, trajectory, stack="python")
+    assert record["recommended_diff_ref"]["available"] is False
+    assert record["recommended_diff_ref"]["archive_relative_path"] == "recommended.patch"
+
+    # Write daydream's outcome diff and confirm the next call sees it.
+    (tmp_path / "recommended.patch").write_text("diff --git a/x b/x\n", encoding="utf-8")
+    record = _build_record(manifest_row, trajectory, stack="python")
+    assert record["recommended_diff_ref"]["available"] is True
+
+
 def test_record_code_context_sourced_from_manifest_dict(tmp_path: Path) -> None:
     """``base_sha`` + ``changed_files`` are read from the manifest dict."""
     manifest_row = _make_manifest_row(archive_path=str(tmp_path))


### PR DESCRIPTION
## Summary

- **Eval is now on by default.** Flipped `--eval` → `--no-eval` (opt-out), so every run populates `grounding_rate`, `total_findings`, `coverage_ratio`, and `cost_per_finding_usd` on the archive manifest — and the reward's grounding axis is always recorded.
- **New `recommended.patch` artifact** captures daydream's proposed diff separately from the PR-under-review `diff.patch`, and the applied-signal labelers now read it instead of mistaking the reviewed code for daydream's recommendations.

## Motivation

Closes #124.

Two archive-time data-completeness gaps degraded reward quality:

1. **Eval metrics gated behind an opt-in flag defaulting off** — the grounding axis (the central "grounded, not guessing" thesis metric) was silently absent on every default run.
2. **"Was the recommendation applied?" signals searched the wrong diff** — `fix_applied_signal` / `local_commit_applied_signal` read `diff.patch` (the code under review), detecting "did the reviewed code persist" rather than "were daydream's fixes applied," producing noisy labels.

## Changes

### Added
- `recommended.patch` artifact: daydream's proposed fix diff, captured per run and distinct from the PR-under-review `diff.patch`
- `git_ops.capture_recommended_patch()` — handles the clean-tree case (stash returns None) via a pre-fix HEAD fallback
- `git_ops.capture_recommended_patch_with_base()` — centralized base-resolution wrapper for deep + shallow fix paths
- `recommended_patch_supported` manifest provenance flag (distinguishes new-format archives from legacy)
- `recommended_diff_ref` field in training corpus records + `schema/v1.json`
- `tests/test_archive_data_capture.py` — 12 tests covering all 4 acceptance criteria

### Changed
- `--eval` → `--no-eval`; `run_eval` now defaults to `True` (`cli.py`, `runner.py`)
- `_read_recommended_patch` reads `recommended.patch` with provenance-aware fallback (returns `""` for new-format archives, preserves `diff.patch` fallback only for legacy)
- `fix_diff_ref` documented as the reviewed-INPUT diff (not daydream's own fix)
- Updated docstrings in `harvest.py`, `trajectory.py`, and `corpus.py` for `recommended.patch`

### Fixed
- No-recommendation runs (review-only / all-declined / wash) are now distinct from legacy archives — empty `recommended.patch` marker written on no-fix runs instead of falling back to `diff.patch`

## Test Plan

- [x] `uv run pytest` — 1904 passed, 4 skipped
- [x] `make lint` — clean
- [x] `make typecheck` — clean
- [x] AC1: default run populates all four eval metrics (non-null) — `test_archive_data_capture.py`
- [x] AC2: reward grounding axis non-absent on default-run row — `test_training_harvest.py`
- [x] AC3: `recommended.patch` exists and differs from `diff.patch` — `test_archive_data_capture.py`
- [x] AC4: applied/declined runs label differently when reading `recommended.patch` — `test_archive_data_capture.py`

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check`)
- [x] Type checking passes (`uv run mypy daydream`)
- [x] Documentation updated (docstrings + schema)
