### PR TITLE
feat(review): wire review-verification-protocol into structural + generic-fallback reviewers (#229)

### DIFF
--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -35,23 +35,9 @@ DOC_REVIEW_NOTICE = (
     "generic-fallback agent (D-20)."
 )
 
-# Shared verification-protocol load instruction appended by both the structural
-# and generic-fallback builders (issue #229). Hoisted to a constant next to
-# ``DOC_REVIEW_NOTICE`` to avoid the drift risk of two hand-copied copies.
-#
-# The protocol skill is ``user-invocable:false`` -- a methodology reference the
-# agent reads (``review-verification-protocol/SKILL.md``), NOT a slash-command --
-# so it is embedded as instruction text and is NOT routed through
-# ``Backend.format_skill_invocation``. That decision is locked in by the
-# ``test_no_format_skill_invocation_for_verification_protocol`` contract, which
-# asserts the literal ``review-verification-protocol/SKILL.md`` reference is
-# present while no backend's invocation token leaks into the prompt.
-#
-# Backend-agnostic: the earlier "from the beagle-core plugin" qualifier named a
-# Claude-Code-only plugin filesystem that the Codex and Pi subprocess backends do
-# not have, so it was dropped. The ``review-verification-protocol/SKILL.md``
-# path reference is retained because the contract above requires it; each
-# backend resolves the load through its own ambient skill availability.
+# Shared verification-protocol instruction for structural and generic-fallback
+# builders (issue #229). Embedded as instruction text, not routed through
+# ``Backend.format_skill_invocation``.
 VERIFICATION_PROTOCOL_INSTRUCTION = (
     "Before writing findings, load the review-verification-protocol skill "
     "(read review-verification-protocol/SKILL.md) and apply its "

--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -35,6 +35,31 @@ DOC_REVIEW_NOTICE = (
     "generic-fallback agent (D-20)."
 )
 
+# Shared verification-protocol load instruction appended by both the structural
+# and generic-fallback builders (issue #229). Hoisted to a constant next to
+# ``DOC_REVIEW_NOTICE`` to avoid the drift risk of two hand-copied copies.
+#
+# The protocol skill is ``user-invocable:false`` -- a methodology reference the
+# agent reads (``review-verification-protocol/SKILL.md``), NOT a slash-command --
+# so it is embedded as instruction text and is NOT routed through
+# ``Backend.format_skill_invocation``. That decision is locked in by the
+# ``test_no_format_skill_invocation_for_verification_protocol`` contract, which
+# asserts the literal ``review-verification-protocol/SKILL.md`` reference is
+# present while no backend's invocation token leaks into the prompt.
+#
+# Backend-agnostic: the earlier "from the beagle-core plugin" qualifier named a
+# Claude-Code-only plugin filesystem that the Codex and Pi subprocess backends do
+# not have, so it was dropped. The ``review-verification-protocol/SKILL.md``
+# path reference is retained because the contract above requires it; each
+# backend resolves the load through its own ambient skill availability.
+VERIFICATION_PROTOCOL_INSTRUCTION = (
+    "Before writing findings, load the review-verification-protocol skill "
+    "(read review-verification-protocol/SKILL.md) and apply its "
+    "anchor-evidence-severity gates (gate 1: anchor file:line, gate 2: produce "
+    "evidence artifacts, gate 3: calibrate severity). Do NOT report a finding "
+    "that fails any gate."
+)
+
 
 def _context_pointers(
     *,
@@ -309,13 +334,7 @@ def build_structural_prompt(
         f"returns empty and hides committed changes."
     )
     parts.append(skill_invocation)
-    parts.append(
-        "Before writing findings, load the review-verification-protocol skill "
-        "(read review-verification-protocol/SKILL.md from the beagle-core plugin) "
-        "and apply its anchor-evidence-severity gates (gate 1: anchor file:line, "
-        "gate 2: produce evidence artifacts, gate 3: calibrate severity). "
-        "Do NOT report a finding that fails any gate."
-    )
+    parts.append(VERIFICATION_PROTOCOL_INSTRUCTION)
     parts.append(f"Write your full review to {output_path}.")
     return "\n\n".join(parts)
 
@@ -668,12 +687,6 @@ def build_generic_fallback_prompt(
         "Review these files for correctness, clarity, and consistency with the "
         "author's intent. Apply language-agnostic review practices."
     )
-    parts.append(
-        "Before writing findings, load the review-verification-protocol skill "
-        "(read review-verification-protocol/SKILL.md from the beagle-core plugin) "
-        "and apply its anchor-evidence-severity gates (gate 1: anchor file:line, "
-        "gate 2: produce evidence artifacts, gate 3: calibrate severity). "
-        "Do NOT report a finding that fails any gate."
-    )
+    parts.append(VERIFICATION_PROTOCOL_INSTRUCTION)
     parts.append(f"Write your full review to {output_path}.")
     return "\n\n".join(parts)

--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -309,6 +309,13 @@ def build_structural_prompt(
         f"returns empty and hides committed changes."
     )
     parts.append(skill_invocation)
+    parts.append(
+        "Before writing findings, load the review-verification-protocol skill "
+        "(read review-verification-protocol/SKILL.md from the beagle-core plugin) "
+        "and apply its anchor-evidence-severity gates (gate 1: anchor file:line, "
+        "gate 2: produce evidence artifacts, gate 3: calibrate severity). "
+        "Do NOT report a finding that fails any gate."
+    )
     parts.append(f"Write your full review to {output_path}.")
     return "\n\n".join(parts)
 
@@ -561,6 +568,17 @@ def build_verification_prompt(
         "to narrow the search before opening files with Read."
     )
     parts.append(
+        "Gate-0 anti-confabulation (MANDATORY — applies before any verdict):\n"
+        "  Before issuing ANY verdict (consistent/contradicts/uncertain), you MUST "
+        "echo the exact artifact you are judging, quoted from a source read in THIS "
+        "turn:\n"
+        "    - The file:line plus the cited code, read freshly now (not recalled "
+        "from earlier in the session).\n"
+        "  The artifact is the only source of truth. A verdict issued without a "
+        "same-turn echo of its target is INVALID — emit the echo first, or do not "
+        "emit the verdict."
+    )
+    parts.append(
         "For EACH numbered issue in the merged report, perform these five steps:\n\n"
         "  1. Locate the `impl` / interface / protocol declaration the changed "
         "code participates in. If absent, set `verdict=consistent` only if no "
@@ -649,6 +667,13 @@ def build_generic_fallback_prompt(
     parts.append(
         "Review these files for correctness, clarity, and consistency with the "
         "author's intent. Apply language-agnostic review practices."
+    )
+    parts.append(
+        "Before writing findings, load the review-verification-protocol skill "
+        "(read review-verification-protocol/SKILL.md from the beagle-core plugin) "
+        "and apply its anchor-evidence-severity gates (gate 1: anchor file:line, "
+        "gate 2: produce evidence artifacts, gate 3: calibrate severity). "
+        "Do NOT report a finding that fails any gate."
     )
     parts.append(f"Write your full review to {output_path}.")
     return "\n\n".join(parts)

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -576,3 +576,53 @@ def test_verification_prompt_contains_cwd_grounding(tmp_path: Path) -> None:
         output_path=tmp_path / "verdicts.json",
     )
     assert CWD_GROUNDING_INSTRUCTION.format(cwd=tmp_path) in out
+
+
+def test_build_structural_prompt_includes_verification_protocol(tmp_path: Path) -> None:
+    from daydream.deep.prompts import build_structural_prompt
+
+    p = _paths(tmp_path)
+    prompt = build_structural_prompt(
+        skill_invocation="/beagle-core:review-structure",
+        files=["api.py"],
+        **p,
+    )
+    assert "review-verification-protocol" in prompt
+    assert "anchor" in prompt
+    assert "evidence" in prompt
+
+
+def test_build_generic_fallback_prompt_includes_verification_protocol(tmp_path: Path) -> None:
+    p = _paths(tmp_path)
+    out = build_generic_fallback_prompt(files=["config.yaml"], **p)
+    assert "review-verification-protocol" in out
+    assert "anchor" in out
+    assert "evidence" in out
+
+
+def test_build_verification_prompt_includes_gate_zero_echo(tmp_path: Path) -> None:
+    from daydream.deep.prompts import build_verification_prompt
+
+    items = [{"id": "1", "file": "x.py", "line": 10, "description": "Test finding"}]
+    out = build_verification_prompt(
+        items=items,
+        cwd=tmp_path,
+        output_path=tmp_path / "verdicts.json",
+    )
+    assert "Gate-0" in out or "anti-confabulation" in out
+    assert "same-turn echo" in out or "file:line" in out
+
+
+def test_no_format_skill_invocation_for_verification_protocol() -> None:
+    """The protocol is user-invocable:false — must not be used with format_skill_invocation."""
+    import subprocess
+
+    repo_root = Path(__file__).parent.parent
+    result = subprocess.run(
+        ["grep", "-rn", "format_skill_invocation", "daydream/"],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+    )
+    for line in result.stdout.splitlines():
+        assert "review-verification-protocol" not in line, f"format_skill_invocation references protocol: {line}"

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -613,16 +613,37 @@ def test_build_verification_prompt_includes_gate_zero_echo(tmp_path: Path) -> No
     assert "same-turn echo" in out or "file:line" in out
 
 
-def test_no_format_skill_invocation_for_verification_protocol() -> None:
-    """The protocol is user-invocable:false — must not be used with format_skill_invocation."""
-    import subprocess
+def test_no_format_skill_invocation_for_verification_protocol(tmp_path: Path) -> None:
+    """The protocol is user-invocable:false — embedded as instruction text, never
+    routed through ``backend.format_skill_invocation``.
 
-    repo_root = Path(__file__).parent.parent
-    result = subprocess.run(
-        ["grep", "-rn", "format_skill_invocation", "daydream/"],
-        capture_output=True,
-        text=True,
-        cwd=str(repo_root),
-    )
-    for line in result.stdout.splitlines():
-        assert "review-verification-protocol" not in line, f"format_skill_invocation references protocol: {line}"
+    Observed at the production prompt-builder seam: the structural and
+    generic-fallback prompts are the only builders that embed the protocol
+    directly (the per-stack reviewers bundle it inside their Beagle skill).
+    Build them with a real backend formatter and assert the embedded
+    instruction is present while the protocol's invocation token — as each
+    real backend would emit it — never leaks into the prompt.
+    """
+    from daydream.backends import create_backend
+    from daydream.deep.prompts import build_structural_prompt
+
+    p = _paths(tmp_path)
+    prompts = [
+        build_structural_prompt(
+            skill_invocation="/beagle-core:review-structure",
+            files=["api.py"],
+            **p,
+        ),
+        build_generic_fallback_prompt(files=["config.yaml"], **p),
+    ]
+
+    for backend_name in ("claude", "codex", "pi"):
+        backend = create_backend(backend_name)
+        token = backend.format_skill_invocation("review-verification-protocol")
+        for prompt in prompts:
+            # Embedded as methodology prose (the constant carries the
+            # protocol name and gate descriptions), never as an invocation.
+            assert "review-verification-protocol" in prompt
+            assert token not in prompt, (
+                f"{backend_name} protocol invocation token {token!r} leaked into prompt"
+            )

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -643,7 +643,7 @@ def test_no_format_skill_invocation_for_verification_protocol(tmp_path: Path) ->
         for prompt in prompts:
             # Embedded as methodology prose (the constant carries the
             # protocol name and gate descriptions), never as an invocation.
-            assert "review-verification-protocol" in prompt
+            assert "review-verification-protocol/SKILL.md" in prompt
             assert token not in prompt, (
                 f"{backend_name} protocol invocation token {token!r} leaked into prompt"
             )

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -3502,6 +3502,83 @@ async def test_verifier_excludes_structural_lens(tmp_path, monkeypatch, make_wor
     assert verdicts_path(dd).is_file()
 
 
+async def test_verifier_prompt_carries_gate_zero_protocol(tmp_path, monkeypatch, make_work):
+    """Real-path: ``phase_verify_recommendations`` embeds the Gate-0 anti-confabulation
+    protocol in the prompt actually handed to the backend.
+
+    Guards issue #229's wiring at the production seam — the verifier prompt the
+    agent receives must carry the same-turn-echo anti-confabulation gate, not just
+    the standalone builder (unit-tested in test_deep_prompts.py).
+    """
+    from daydream.deep.artifacts import deep_dir, merged_items_path
+    from daydream.phases import phase_verify_recommendations
+
+    monkeypatch.setattr("daydream.phases.print_phase_hero", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.phases.print_dim", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.phases.console", type("C", (), {"print": lambda *a, **kw: None})())
+
+    work = make_work(tmp_path)
+    dd = deep_dir(work.repo)
+    dd.mkdir(parents=True, exist_ok=True)
+
+    items = {
+        "items": [
+            {
+                "id": 1,
+                "lens": "per-stack",
+                "file": "a.py",
+                "line": 9,
+                "severity": "low",
+                "description": "bug",
+                "confidence": "HIGH",
+                "rationale": "r",
+            }
+        ]
+    }
+    items_path = merged_items_path(dd)
+    items_path.write_text(json.dumps(items))
+
+    structured = {
+        "verdicts": [
+            {
+                "issue_id": 1,
+                "verdict": "consistent",
+                "evidence": "e",
+                "unverified_assumptions": [],
+            }
+        ]
+    }
+
+    class VerifyBackend:
+        model = "test-model"
+        fanout_concurrency = 4
+
+        async def execute(
+            self, cwd, prompt, output_schema=None, continuation=None, agents=None,
+            max_turns=None, read_only=False,
+        ):
+            self.prompt = prompt
+            yield ResultEvent(structured_output=structured, continuation=None)
+
+        async def cancel(self):
+            pass
+
+        def format_skill_invocation(self, skill_key, args=""):
+            return f"/{skill_key}"
+
+    backend = VerifyBackend()
+    await phase_verify_recommendations(
+        backend,
+        work,
+        merged_items_path=items_path,
+        deep_dir=dd,
+    )
+
+    assert "Gate-0" in backend.prompt
+    assert "anti-confabulation" in backend.prompt
+    assert "same-turn echo" in backend.prompt
+
+
 def test_group_items_by_file_preserves_order_within_and_across_groups():
     from daydream.phases import group_items_by_file
 


### PR DESCRIPTION
## Summary

- Structural reviewer (`build_structural_prompt`) and generic-fallback reviewer (`build_generic_fallback_prompt`) now instruct the agent to load `review-verification-protocol` and apply its anchor-evidence-severity gates before writing findings
- Recommendation verifier (`build_verification_prompt`) requires a gate-0 anti-confabulation echo (file:line + cited code read in the current turn) before any verdict
- Guard test ensures `format_skill_invocation` is never used for the protocol (it's `user-invocable:false`)

## Motivation

The `review-verification-protocol` (anti-confabulation / FP-suppression gate) was referenced 0x in daydream code. Per-language umbrella skills already load it internally via their G3 gate, but the structural meta-stack and generic-fallback reviewer emitted findings with no verification gate. This wires the protocol into both gaps via prompt instruction (not skill invocation).

Closes #229.

## Changes

### Added
- `VERIFICATION_PROTOCOL_INSTRUCTION` constant in `deep/prompts.py` (shared instruction text for structural + generic-fallback builders)
- Gate-0 anti-confabulation echo requirement in `build_verification_prompt`
- 4 new tests in `tests/test_deep_prompts.py`: protocol presence in all three prompts + guard test asserting no `format_skill_invocation` token leaks

### Changed
- `build_structural_prompt`: appends `VERIFICATION_PROTOCOL_INSTRUCTION` after skill invocation
- `build_generic_fallback_prompt`: appends same instruction after review directive

## Test Plan

- [x] Tests pass locally (`make test` = 1894 passed, 4 skipped)
- [x] Linting passes (`make lint`)
- [x] Type checking passes (`make typecheck`)
- [x] 4 new tests verify protocol text presence and format_skill_invocation guard

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check`)
- [x] Type checking passes (`uv run mypy daydream`)
