### PR TITLE
feat(review): structural evidence gate -- never emit speculative / no-evidence findings

### DIFF
--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -487,6 +487,7 @@ def _apply_arbiter_verdicts(
             "confidence": verdict.get("confidence", records[record_index].get("confidence")),
             "description": verdict.get("description", records[record_index].get("description")),
             "rationale": verdict.get("rationale", records[record_index].get("rationale")),
+            "evidence": verdict.get("evidence", records[record_index].get("evidence")),
         }
 
     new_records: list[dict[str, Any]] = []

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -923,7 +923,12 @@ def _is_evidenced(item: dict[str, Any]) -> bool:
     - ``rationale`` contains ``no exploration evidence`` (the exact string the
       legacy LOW-confidence prompt language emitted) -- case-insensitive;
     - there is no grounded citation: neither a real ``file`` + ``line`` > 0 nor a
-      ``path:line`` pattern anywhere in the evidence string.
+      ``path:line`` (path component + ``:`` + digits) token in the evidence string.
+
+    Items tagged ``lens="structural"`` are exempt from the grounded-citation
+    requirement: they are host-tagged, inherently whole-file findings (file-size
+    budgets, layering) that may legitimately carry ``line: 0`` with colon-free
+    evidence, so non-blank evidence is sufficient grounding for them.
 
     Args:
         item: A finding dict (per-stack, cross-stack, or structural).
@@ -950,7 +955,23 @@ def _is_evidenced(item: dict[str, Any]) -> bool:
     file_val = str(item.get("file", ""))
     line_val = item.get("line", 0)
     has_file_line = bool(file_val) and isinstance(line_val, int) and line_val > 0
-    has_citation = bool(re.search(r"\S+:\d+", evidence))
+    # A grounded citation is a ``path:line`` token (e.g. ``src/foo.py:42``).
+    # Require a path component (``.`` or ``/``) in the prefix so non-citations
+    # like ``port:8080`` / ``ratio 3:2`` / ``see LIFO:1`` are not admitted as
+    # citations (issue #227). This only narrows what counts as a citation, so
+    # a bare symbol like ``helper:42`` (no path separator) no longer satisfies
+    # the gate on its own -- such findings must ground via ``file`` + ``line``.
+    has_citation = bool(re.search(r"\S*[./]\S*:\d+", evidence))
+
+    # Structural findings are host-tagged (``lens="structural"``) and inherently
+    # whole-file (file-size budgets, layering) -- they may legitimately carry
+    # ``line: 0`` with colon-free evidence. They are a different trust class
+    # than agent-emitted per-stack findings, so the grounded-citation
+    # requirement does not apply; non-blank evidence (checked above) is
+    # sufficient grounding (issue #227: the structural lens is high-conviction
+    # by construction and must not be demoted).
+    if item.get("lens") == "structural":
+        return True
 
     return has_file_line or has_citation
 
@@ -1159,37 +1180,6 @@ def _dependency_impact_instructions() -> str:
         "any issues. When an individual issue's rationale cites a dependency, include the "
         "file:symbol reference inline within that issue."
     )
-
-
-def _validate_issue(issue: dict[str, Any]) -> None:
-    """Content-validate a parsed feedback issue for the evidence gate (issue #227).
-
-    The shallow loop and ``phase_parse_feedback`` never produce
-    ``merged-items.json`` and so bypass the structural gate in
-    ``_append_structural_and_write_merged``. This is the parallel enforcement
-    point for those paths: rather than drop, it raises ``ValueError`` (the
-    existing caught-in-runner contract) so a speculative finding cannot survive.
-
-    Args:
-        issue: Issue dict produced by structured-output parsing.
-
-    Raises:
-        ValueError: If ``confidence`` is missing/invalid or ``LOW``, if
-            ``rationale`` is missing or claims "no exploration evidence", or if
-            ``evidence`` is missing/blank.
-
-    """
-    confidence = issue.get("confidence")
-    if not confidence or confidence not in ("HIGH", "MEDIUM"):
-        raise ValueError(f"Issue is missing or has invalid confidence label: {issue!r}")
-    rationale = issue.get("rationale")
-    if not rationale:
-        raise ValueError(f"Issue is missing rationale: {issue!r}")
-    if "no exploration evidence" in str(rationale).lower():
-        raise ValueError(f"Issue is speculative (rationale claims no exploration evidence): {issue!r}")
-    evidence = issue.get("evidence")
-    if not evidence or not str(evidence).strip():
-        raise ValueError(f"Issue is missing evidence: {issue!r}")
 
 
 def _exploration_pointer(exploration_dir: Path | None) -> str:
@@ -1664,6 +1654,29 @@ If there are no actionable issues, return: {{"issues": []}}
         return []
 
     feedback_items = result["issues"]
+
+    # Structural evidence gate (issue #227, AC3): the default parse path
+    # (shallow loop + PR-feedback ingestion, ``input_path is None``) never
+    # produces merged-items.json, so it bypasses the gate in
+    # ``_append_structural_and_write_merged``. Apply the same ``_is_evidenced``
+    # drop the deep merge path uses, but ONLY here: the deep pre-merge
+    # per-stack parse passes ``input_path`` and defers grounding to the merge
+    # epilogue, where structural records are tagged ``lens="structural"`` before
+    # the gate so the structural carve-out applies. Drop (not raise) to match
+    # deep-path semantics and the graceful-degradation contract below.
+    if input_path is None:
+        evidenced: list[dict[str, Any]] = []
+        dropped: list[dict[str, Any]] = []
+        for it in feedback_items:
+            (evidenced if _is_evidenced(it) else dropped).append(it)
+        if dropped:
+            print_info(
+                console,
+                f"Evidence gate: dropped {len(dropped)} speculative finding(s) "
+                f"from the shallow parse (ids: {[d.get('id') for d in dropped]})",
+            )
+        feedback_items = evidenced
+
     issue_count = len(feedback_items)
     print_info(console, f"Found {issue_count} actionable {'issue' if issue_count == 1 else 'issues'}")
     if feedback_items:
@@ -3286,7 +3299,8 @@ def _append_structural_and_write_merged(
         restrictions on repo-root dotfiles).
 
     Callers own the clear-stale step: each clears ``items_path`` /
-    ``report_path`` / ``canonical_path`` at a point appropriate to its own
+    ``report_path`` / ``canonical_path`` (and the ``dropped-speculative.json``
+    audit sidecar) at a point appropriate to its own
     failure semantics (``phase_cross_stack_merge`` clears *before* the merge
     agent runs so a crash leaves no stale output; the single-stack bypass has
     no agent, so it clears immediately before this call). Keeping clear-stale
@@ -3431,6 +3445,9 @@ def _write_single_stack_merged_items(
     canonical_path.unlink(missing_ok=True)
     report_path.unlink(missing_ok=True)
     items_path.unlink(missing_ok=True)
+    # Clear the evidence-gate audit sidecar too, so a prior run that dropped
+    # findings can't leave phantom drops on a resume that drops none (#227).
+    (items_path.parent / "dropped-speculative.json").unlink(missing_ok=True)
 
     # Tag per-stack records (the merge agent normally sets lens; here the host
     # does it). ``severity`` is already present from PER_STACK_RECORD_SCHEMA.
@@ -3514,6 +3531,9 @@ async def phase_cross_stack_merge(
     canonical_path.unlink(missing_ok=True)
     report_path.unlink(missing_ok=True)
     items_path.unlink(missing_ok=True)
+    # Clear the evidence-gate audit sidecar too, so a prior run that dropped
+    # findings can't leave phantom drops on a resume that drops none (#227).
+    (items_path.parent / "dropped-speculative.json").unlink(missing_ok=True)
 
     prompt = build_merge_prompt(
         per_stack_records_paths=per_stack_records_paths,

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -3,6 +3,7 @@
 import copy
 import json
 import logging
+import re
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -774,10 +775,11 @@ FEEDBACK_SCHEMA: dict[str, Any] = {
                     "description": {"type": "string"},
                     "file": {"type": "string"},
                     "line": {"type": "integer"},
-                    "confidence": {"type": "string", "enum": ["HIGH", "MEDIUM", "LOW"]},
+                    "confidence": {"type": "string", "enum": ["HIGH", "MEDIUM"]},
                     "rationale": {"type": "string"},
+                    "evidence": {"type": "string"},
                 },
-                "required": ["id", "description", "file", "line", "confidence", "rationale"],
+                "required": ["id", "description", "file", "line", "confidence", "rationale", "evidence"],
                 "additionalProperties": False,
             },
         },
@@ -800,7 +802,7 @@ PER_STACK_RECORD_SCHEMA["properties"]["issues"]["items"]["properties"]["severity
     "enum": ["high", "medium", "low"],
 }
 PER_STACK_RECORD_SCHEMA["properties"]["issues"]["items"]["required"] = [
-    "id", "description", "file", "line", "severity", "confidence", "rationale"
+    "id", "description", "file", "line", "severity", "confidence", "rationale", "evidence"
 ]
 
 ALTERNATIVE_REVIEW_SCHEMA: dict[str, Any] = {
@@ -817,8 +819,9 @@ ALTERNATIVE_REVIEW_SCHEMA: dict[str, Any] = {
                     "recommendation": {"type": "string"},
                     "severity": {"type": "string", "enum": ["high", "medium", "low"]},
                     "files": {"type": "array", "items": {"type": "string"}},
-                    "confidence": {"type": "string", "enum": ["HIGH", "MEDIUM", "LOW"]},
+                    "confidence": {"type": "string", "enum": ["HIGH", "MEDIUM"]},
                     "rationale": {"type": "string"},
+                    "evidence": {"type": "string"},
                 },
                 "required": [
                     "id",
@@ -829,6 +832,7 @@ ALTERNATIVE_REVIEW_SCHEMA: dict[str, Any] = {
                     "files",
                     "confidence",
                     "rationale",
+                    "evidence",
                 ],
                 "additionalProperties": False,
             },
@@ -850,8 +854,9 @@ MERGED_ITEMS_SCHEMA: dict[str, Any] = {
                     "description": {"type": "string"},
                     "file": {"type": "string"},
                     "line": {"type": "integer"},
-                    "confidence": {"type": "string", "enum": ["HIGH", "MEDIUM", "LOW"]},
+                    "confidence": {"type": "string", "enum": ["HIGH", "MEDIUM"]},
                     "rationale": {"type": "string"},
+                    "evidence": {"type": "string"},
                     "lens": {"type": "string", "enum": ["per-stack", "cross-stack", "structural"]},
                     "severity": {"type": "string", "enum": ["high", "medium", "low"]},
                 },
@@ -862,6 +867,7 @@ MERGED_ITEMS_SCHEMA: dict[str, Any] = {
                     "line",
                     "confidence",
                     "rationale",
+                    "evidence",
                     "lens",
                     "severity",
                 ],
@@ -897,6 +903,56 @@ def normalize_items(raw: list[dict[str, Any]]) -> list[dict[str, Any]]:
     for new_id, item in enumerate(raw, start=1):
         normalized.append({**item, "id": new_id})
     return normalized
+
+
+# Placeholder evidence strings that are structurally present but carry no
+# grounding -- treated as "no evidence" by the gate (issue #227).
+_PLACEHOLDER_EVIDENCE: frozenset[str] = frozenset({"n/a", "none", "-"})
+
+
+def _is_evidenced(item: dict[str, Any]) -> bool:
+    """Return True if the finding is grounded in evidence, False if speculative.
+
+    The structural evidence gate (issue #227): every finding Daydream emits must
+    carry a concrete, grounded citation. A finding is dropped as speculative when
+    ANY of the following hold:
+
+    - ``confidence`` is ``LOW`` (legacy tolerance for the collapsed HIGH/MEDIUM
+      enum before the sibling prompt-elimination issue lands, AC4);
+    - ``evidence`` is missing, blank, or a placeholder (``n/a`` / ``none`` / ``-``);
+    - ``rationale`` contains ``no exploration evidence`` (the exact string the
+      legacy LOW-confidence prompt language emitted) -- case-insensitive;
+    - there is no grounded citation: neither a real ``file`` + ``line`` > 0 nor a
+      ``path:line`` pattern anywhere in the evidence string.
+
+    Args:
+        item: A finding dict (per-stack, cross-stack, or structural).
+
+    Returns:
+        True when the finding is grounded and may reach ``merged-items.json``;
+        False when it is speculative and must be dropped.
+    """
+    # Legacy tolerance (AC4): the confidence enum collapsed to HIGH/MEDIUM, but
+    # the sibling prompt-elimination issue still emits LOW today. Treat any
+    # inbound LOW confidence as speculative so this gate is robust before that
+    # prompt change lands.
+    if str(item.get("confidence", "")).upper() == "LOW":
+        return False
+
+    evidence = str(item.get("evidence", "")).strip()
+    if not evidence or evidence.lower() in _PLACEHOLDER_EVIDENCE:
+        return False
+
+    rationale = str(item.get("rationale", ""))
+    if "no exploration evidence" in rationale.lower():
+        return False
+
+    file_val = str(item.get("file", ""))
+    line_val = item.get("line", 0)
+    has_file_line = bool(file_val) and isinstance(line_val, int) and line_val > 0
+    has_citation = bool(re.search(r"\S+:\d+", evidence))
+
+    return has_file_line or has_citation
 
 
 # Canonical severity ordering shared by the deep fix loop and the shallow fix
@@ -1106,21 +1162,34 @@ def _dependency_impact_instructions() -> str:
 
 
 def _validate_issue(issue: dict[str, Any]) -> None:
-    """Validate a parsed feedback issue carries the required confidence/rationale fields.
+    """Content-validate a parsed feedback issue for the evidence gate (issue #227).
+
+    The shallow loop and ``phase_parse_feedback`` never produce
+    ``merged-items.json`` and so bypass the structural gate in
+    ``_append_structural_and_write_merged``. This is the parallel enforcement
+    point for those paths: rather than drop, it raises ``ValueError`` (the
+    existing caught-in-runner contract) so a speculative finding cannot survive.
 
     Args:
         issue: Issue dict produced by structured-output parsing.
 
     Raises:
-        ValueError: If `confidence` or `rationale` is missing or empty.
+        ValueError: If ``confidence`` is missing/invalid or ``LOW``, if
+            ``rationale`` is missing or claims "no exploration evidence", or if
+            ``evidence`` is missing/blank.
 
     """
     confidence = issue.get("confidence")
-    if not confidence or confidence not in ("HIGH", "MEDIUM", "LOW"):
+    if not confidence or confidence not in ("HIGH", "MEDIUM"):
         raise ValueError(f"Issue is missing or has invalid confidence label: {issue!r}")
     rationale = issue.get("rationale")
     if not rationale:
         raise ValueError(f"Issue is missing rationale: {issue!r}")
+    if "no exploration evidence" in str(rationale).lower():
+        raise ValueError(f"Issue is speculative (rationale claims no exploration evidence): {issue!r}")
+    evidence = issue.get("evidence")
+    if not evidence or not str(evidence).strip():
+        raise ValueError(f"Issue is missing evidence: {issue!r}")
 
 
 def _exploration_pointer(exploration_dir: Path | None) -> str:
@@ -3088,11 +3157,12 @@ ARBITER_SCHEMA: dict[str, Any] = {
                     "arb_id": {"type": "integer"},
                     "keep": {"type": "boolean"},
                     "severity": {"type": "string", "enum": ["high", "medium", "low"]},
-                    "confidence": {"type": "string", "enum": ["HIGH", "MEDIUM", "LOW"]},
+                    "confidence": {"type": "string", "enum": ["HIGH", "MEDIUM"]},
                     "description": {"type": "string"},
                     "rationale": {"type": "string"},
+                    "evidence": {"type": "string"},
                 },
-                "required": ["arb_id", "keep", "severity", "confidence", "description", "rationale"],
+                "required": ["arb_id", "keep", "severity", "confidence", "description", "rationale", "evidence"],
                 "additionalProperties": False,
             },
         },
@@ -3159,6 +3229,7 @@ async def phase_arbiter_review(
             "confidence": rec.get("confidence"),
             "description": rec.get("description"),
             "rationale": rec.get("rationale"),
+            "evidence": rec.get("evidence"),
         }
         for i, rec in enumerate(selected_records, start=1)
     ]
@@ -3261,7 +3332,37 @@ def _append_structural_and_write_merged(
                 }
             )
 
-    items = normalize_items(base_items + structural_items)
+    # Structural evidence gate (issue #227): drop speculative / evidence-free
+    # findings BEFORE normalization so nothing ungrounded reaches the canonical
+    # merged-items.json (and therefore review-output.md, the fix stage, PR
+    # posting, or the benchmark). This is the single unconditional enforcement
+    # point shared by both merge paths. Dropped items are logged and written to
+    # an audit sidecar -- never silently discarded.
+    evidenced: list[dict[str, Any]] = []
+    dropped: list[dict[str, Any]] = []
+    for item in base_items + structural_items:
+        (evidenced if _is_evidenced(item) else dropped).append(item)
+
+    if dropped:
+        sidecar_path = items_path.parent / "dropped-speculative.json"
+        dropped_ids = [d.get("id") for d in dropped]
+        sidecar_path.write_text(
+            json.dumps(
+                {
+                    "dropped_count": len(dropped),
+                    "dropped_ids": dropped_ids,
+                    "dropped_items": dropped,
+                },
+                indent=2,
+            )
+        )
+        print_info(
+            console,
+            f"Evidence gate: dropped {len(dropped)} speculative finding(s) "
+            f"(ids: {dropped_ids}), wrote {sidecar_path}",
+        )
+
+    items = normalize_items(evidenced)
     items_path.write_text(json.dumps({"items": items}, indent=2))
     print_info(console, f"Merged into {len(items)} items")
 

--- a/tests/harness/phase_backend.py
+++ b/tests/harness/phase_backend.py
@@ -118,6 +118,21 @@ class PhaseDispatchBackend:
                 else []
             )
             self._parse_call += 1
+            # The shallow parse path now applies the #227 evidence gate, which
+            # drops findings lacking grounded evidence. These harness items
+            # model loop behaviour (not the gate), so default each to a grounded
+            # shape so it survives to the fix phase. Explicit per-item fields
+            # still win (``**it`` last) so a test can deliberately emit a
+            # speculative item.
+            issues = [
+                {
+                    "confidence": "HIGH",
+                    "rationale": "harness fixture",
+                    "evidence": f"{it.get('file') or 'harness.py'}:{it.get('line') or 1}",
+                    **it,
+                }
+                for it in issues
+            ]
             yield TextEvent(text="Parsed.")
             yield ResultEvent(structured_output={"issues": issues}, continuation=None)
         elif "fix this issue" in prompt_lower or prompt_lower.startswith("fix these"):

--- a/tests/test_archive_data_capture.py
+++ b/tests/test_archive_data_capture.py
@@ -158,7 +158,17 @@ class _FixEditingBackend:
             yield TextEvent(text="Parsed.")
             yield ResultEvent(
                 structured_output={
-                    "issues": [{"id": 1, "description": "Add a guard", "file": "main.py", "line": 1}]
+                    "issues": [
+                        {
+                            "id": 1,
+                            "description": "Add a guard",
+                            "file": "main.py",
+                            "line": 1,
+                            "confidence": "HIGH",
+                            "rationale": "guard missing",
+                            "evidence": "main.py:1",
+                        }
+                    ]
                 },
                 continuation=None,
             )

--- a/tests/test_canonical_items.py
+++ b/tests/test_canonical_items.py
@@ -6,7 +6,8 @@ from daydream.phases import MERGED_ITEMS_SCHEMA, normalize_items
 
 def test_schema_requires_lens_and_severity():
     item = {"id": 1, "description": "d", "file": "a.py", "line": 4,
-            "confidence": "HIGH", "rationale": "r", "lens": "structural", "severity": "high"}
+            "confidence": "HIGH", "rationale": "r", "evidence": "a.py:4",
+            "lens": "structural", "severity": "high"}
     jsonschema.validate({"items": [item]}, MERGED_ITEMS_SCHEMA)  # passes
     bad = {k: v for k, v in item.items() if k != "lens"}
     with pytest.raises(jsonschema.ValidationError):

--- a/tests/test_deep_integration.py
+++ b/tests/test_deep_integration.py
@@ -107,6 +107,7 @@ class _DeepMockBackend:
                                 "description": "hello() leaks a god-object boundary",
                                 "file": "api.py",
                                 "line": 1,
+                                "evidence": "api.py:1",
                             }
                         ]
                     },

--- a/tests/test_deep_merge.py
+++ b/tests/test_deep_merge.py
@@ -111,8 +111,9 @@ class _RecordingBackend:
                         "line": 1,
                         "severity": "low",
                         "description": "issue",
-                        "confidence": "LOW",
+                        "confidence": "MEDIUM",
                         "rationale": "r",
+                        "evidence": "api.py:1",
                     }
                 ]
             },

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -3994,3 +3994,151 @@ async def test_evidence_gate_all_speculative_yields_empty(
     dropped_desc = json.dumps(dropped["dropped_items"])
     assert "speculative generic finding" in dropped_desc
     assert "speculative structural finding" in dropped_desc
+
+
+async def test_evidence_gate_keeps_whole_file_structural_finding(
+    tiny_diff_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Issue #227 (findings 3/5): a structural (host-tagged, whole-file) finding
+    with ``line: 0`` and colon-free evidence SURVIVES the gate -- the structural
+    lens is high-conviction by construction and must not be demoted.
+
+    Real path through ``runner.run`` (``--start-at merge`` tiny-diff bypass).
+    Primes a structural record whose evidence has no ``path:line`` token and
+    whose ``line`` is 0: without the structural carve-out it would fail both
+    ``has_file_line`` and ``has_citation`` and be dropped as speculative.
+    """
+    from daydream.runner import RunConfig, run
+
+    _silence(monkeypatch)
+    _install_stub_backend(monkeypatch, tiny_diff_target)
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_test_and_heal", lambda *a, **k: _ok())
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _noop_commit)
+
+    async def _no_post(target_dir: Path, report_path: Path, *, console: Any) -> None:
+        return None
+
+    monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _no_post)
+
+    deep = tiny_diff_target / ".daydream" / "deep"
+    deep.mkdir(parents=True, exist_ok=True)
+    (deep / "intent.md").write_text("primed intent")
+    (deep / "alternatives.json").write_text("[]")
+    (deep / "stack-generic-records.json").write_text(
+        json.dumps(
+            [
+                {
+                    "id": "gen-1",
+                    "description": "grounded generic finding",
+                    "file": "api.py",
+                    "line": 1,
+                    "confidence": "MEDIUM",
+                    "rationale": "r",
+                    "evidence": "api.py:1",
+                }
+            ]
+        )
+    )
+    (deep / "stack-structure-records.json").write_text(
+        json.dumps(
+            [
+                {
+                    "id": "structure-1",
+                    "description": "module exceeds 800 LOC budget",
+                    "file": "big.py",
+                    "line": 0,
+                    "confidence": "HIGH",
+                    "rationale": "file-size budget violated",
+                    "evidence": "big.py is 800 lines",
+                }
+            ]
+        )
+    )
+
+    rc = await run(RunConfig(target=str(tiny_diff_target), start_at="merge", cleanup=False))
+    assert rc == 0
+
+    items = json.loads((deep / "merged-items.json").read_text())["items"]
+    structural = [
+        i for i in items
+        if i.get("lens") == "structural"
+        and i.get("description") == "module exceeds 800 LOC budget"
+    ]
+    assert structural, (
+        f"whole-file structural finding was dropped by the gate: {items}"
+    )
+    assert structural[0].get("line") == 0
+
+
+async def test_evidence_gate_clears_stale_dropped_sidecar(
+    tiny_diff_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Issue #227 (findings 4/6): a resume that drops 0 findings clears a stale
+    ``dropped-speculative.json`` left by a prior run, so the sidecar cannot
+    report phantom drops to eval/benchmark/human auditors.
+
+    Real path through ``runner.run`` (``--start-at merge`` tiny-diff bypass).
+    Primes a stale sidecar alongside well-evidenced records (0 drops) and
+    asserts the sidecar is gone after the run.
+    """
+    from daydream.runner import RunConfig, run
+
+    _silence(monkeypatch)
+    _install_stub_backend(monkeypatch, tiny_diff_target)
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_test_and_heal", lambda *a, **k: _ok())
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _noop_commit)
+
+    async def _no_post(target_dir: Path, report_path: Path, *, console: Any) -> None:
+        return None
+
+    monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _no_post)
+
+    deep = tiny_diff_target / ".daydream" / "deep"
+    deep.mkdir(parents=True, exist_ok=True)
+    (deep / "intent.md").write_text("primed intent")
+    (deep / "alternatives.json").write_text("[]")
+    (deep / "stack-generic-records.json").write_text(
+        json.dumps(
+            [
+                {
+                    "id": "gen-1",
+                    "description": "grounded generic finding",
+                    "file": "api.py",
+                    "line": 1,
+                    "confidence": "MEDIUM",
+                    "rationale": "r",
+                    "evidence": "api.py:1",
+                }
+            ]
+        )
+    )
+    (deep / "stack-structure-records.json").write_text(
+        json.dumps(
+            [
+                {
+                    "id": "structure-1",
+                    "description": "grounded structural finding",
+                    "file": "big.py",
+                    "line": 1,
+                    "confidence": "HIGH",
+                    "rationale": "r",
+                    "evidence": "big.py:1",
+                }
+            ]
+        )
+    )
+    # Stale sidecar from a prior run that dropped a finding.
+    (deep / "dropped-speculative.json").write_text(
+        json.dumps({"dropped_count": 1, "dropped_ids": [99], "dropped_items": [{"id": 99}]})
+    )
+
+    rc = await run(RunConfig(target=str(tiny_diff_target), start_at="merge", cleanup=False))
+    assert rc == 0
+
+    # The well-evidenced records survive (0 drops), so the sidecar is neither
+    # rewritten nor left stale -- it must be gone.
+    items = json.loads((deep / "merged-items.json").read_text())["items"]
+    assert any(i.get("description") == "grounded generic finding" for i in items), items
+    assert not (deep / "dropped-speculative.json").exists(), (
+        "stale dropped-speculative.json survived a 0-drop resume"
+    )

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -222,7 +222,16 @@ class _StubBackend:
             return
 
         if "extract only actionable issues" in pl:  # phase_parse_feedback
-            issue: dict[str, Any] = {"id": 1, "description": "Sample issue", "file": "api.py", "line": 1}
+            # Evidence gate (#227): every parsed finding carries a grounded
+            # citation so it survives _is_evidenced downstream (structural items
+            # and the tiny-diff bypass route these records straight to the gate).
+            issue: dict[str, Any] = {
+                "id": 1,
+                "description": "Sample issue",
+                "file": "api.py",
+                "line": 1,
+                "evidence": "api.py:1",
+            }
             # Deep per-stack parse requests severity (PER_STACK_RECORD_SCHEMA, #168);
             # emit the configured severity so a test can drive arbiter selection.
             # The structural stack parses with FEEDBACK_SCHEMA (no severity prompt),
@@ -279,6 +288,7 @@ class _StubBackend:
                                 "description": rec.get("description"),
                                 "confidence": rec.get("confidence", "MEDIUM"),
                                 "rationale": rec.get("rationale", "rationale"),
+                                "evidence": rec.get("evidence", "api.py:1"),
                             }
                         )
                         next_id += 1
@@ -302,6 +312,7 @@ class _StubBackend:
                             "description": "Python issue",
                             "confidence": "MEDIUM",
                             "rationale": "rationale",
+                            "evidence": "api.py:1",
                         },
                         {
                             "id": 2,
@@ -312,6 +323,7 @@ class _StubBackend:
                             "description": "React issue",
                             "confidence": "MEDIUM",
                             "rationale": "rationale",
+                            "evidence": "App.tsx:1",
                         },
                         {
                             "id": 3,
@@ -322,6 +334,7 @@ class _StubBackend:
                             "description": "Contract drift between Python handler and React caller",
                             "confidence": "HIGH",
                             "rationale": "rationale",
+                            "evidence": "api.py:1",
                         },
                     ]
                 },
@@ -539,7 +552,7 @@ async def _run_deep(target: Path, *, start_at: str = "review") -> int:
 
 
 def _merge_item(item_id: int, file: str, severity: str, *, desc: str | None = None) -> dict[str, Any]:
-    """Build a validated 8-key merged item (shape copied from the stub default)."""
+    """Build a validated merged item (shape copied from the stub default)."""
     return {
         "id": item_id,
         "lens": "per-stack",
@@ -549,6 +562,7 @@ def _merge_item(item_id: int, file: str, severity: str, *, desc: str | None = No
         "description": desc if desc is not None else f"{severity} issue in {file}",
         "confidence": "MEDIUM",
         "rationale": "rationale",
+        "evidence": f"{file}:1",
     }
 
 
@@ -2392,6 +2406,7 @@ async def test_structural_finding_reaches_fix_loop(
             "description": "High-severity per-stack issue",
             "confidence": "HIGH",
             "rationale": "rationale",
+            "evidence": "api.py:1",
         },
         {
             "id": 2,
@@ -2400,8 +2415,9 @@ async def test_structural_finding_reaches_fix_loop(
             "line": 1,
             "severity": "low",
             "description": "Low-severity per-stack issue",
-            "confidence": "LOW",
+            "confidence": "MEDIUM",
             "rationale": "rationale",
+            "evidence": "App.tsx:1",
         },
     ]
 
@@ -2885,20 +2901,22 @@ def _prime_merge_resume_records(deep: Path, *, python_severity: str | None) -> N
     deep.mkdir(parents=True, exist_ok=True)
     (deep / "intent.md").write_text("primed intent")
     (deep / "alternatives.json").write_text("[]")
-    py_record: dict[str, Any] = {"id": 1, "description": "py issue", "file": "api.py", "line": 1}
+    py_record: dict[str, Any] = {
+        "id": 1, "description": "py issue", "file": "api.py", "line": 1, "evidence": "api.py:1"
+    }
     if python_severity is not None:
         py_record["severity"] = python_severity
         py_record["confidence"] = "HIGH"
         py_record["rationale"] = "stub"
     (deep / "stack-python-records.json").write_text(json.dumps([py_record]))
     (deep / "stack-react-records.json").write_text(
-        json.dumps([{"id": 1, "description": "tsx issue", "file": "App.tsx", "line": 1}])
+        json.dumps([{"id": 1, "description": "tsx issue", "file": "App.tsx", "line": 1, "evidence": "App.tsx:1"}])
     )
     (deep / "stack-generic-records.json").write_text(
-        json.dumps([{"id": 1, "description": "docs issue", "file": "README.md", "line": 1}])
+        json.dumps([{"id": 1, "description": "docs issue", "file": "README.md", "line": 1, "evidence": "README.md:1"}])
     )
     (deep / "stack-structure-records.json").write_text(
-        json.dumps([{"id": 1, "description": "structural issue", "file": "api.py", "line": 1}])
+        json.dumps([{"id": 1, "description": "structural issue", "file": "api.py", "line": 1, "evidence": "api.py:1"}])
     )
 
 
@@ -3797,7 +3815,8 @@ async def test_ac_merge_resume_on_tiny_diff(
     (deep / "alternatives.json").write_text("[]")
     (deep / "stack-generic-records.json").write_text(
         json.dumps(
-            [{"id": "gen-1", "description": "generic per-stack issue", "file": "api.py", "line": 1}]
+            [{"id": "gen-1", "description": "generic per-stack issue", "file": "api.py", "line": 1,
+              "evidence": "api.py:1"}]
         )
     )
     (deep / "stack-structure-records.json").write_text(
@@ -3808,6 +3827,7 @@ async def test_ac_merge_resume_on_tiny_diff(
                     "description": "file-size budget violated",
                     "file": "api.py",
                     "line": 1,
+                    "evidence": "api.py:1",
                 }
             ]
         )
@@ -3833,3 +3853,144 @@ async def test_ac_merge_resume_on_tiny_diff(
         i.get("description") == "file-size budget violated" and i.get("lens") == "structural"
         for i in items
     ), f"structural item missing or mislabeled: {items}"
+
+
+async def test_evidence_gate_drops_speculative_finding(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Issue #227 (AC2/AC3/AC6): the structural evidence gate keeps an evidenced
+    finding but drops a speculative one before it reaches merged-items.json.
+
+    Real path through ``runner.run`` (deep default). The merge agent emits one
+    grounded finding (``evidence: "src/foo.py:42"``, HIGH) and one speculative
+    finding (blank evidence, ``rationale`` claiming "no exploration evidence",
+    LOW). Asserts the speculative finding is ABSENT from both the canonical
+    ``merged-items.json`` and the rendered ``review-output.md`` while the
+    evidenced one survives, and that ``dropped-speculative.json`` records the
+    drop.
+    """
+    from daydream.config import REVIEW_OUTPUT_FILE
+
+    _silence(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    stub.merge_items = [
+        {
+            "id": 1,
+            "lens": "per-stack",
+            "file": "api.py",
+            "line": 42,
+            "severity": "high",
+            "description": "Grounded evidenced finding",
+            "confidence": "HIGH",
+            "rationale": "verified against src/foo.py",
+            "evidence": "src/foo.py:42",
+        },
+        {
+            "id": 2,
+            "lens": "per-stack",
+            "file": "App.tsx",
+            "line": 1,
+            "severity": "low",
+            "description": "Speculative unfounded finding",
+            "confidence": "LOW",
+            "rationale": "inferred from the diff alone, no exploration evidence",
+            "evidence": "",
+        },
+    ]
+
+    exit_code = await _run_deep(multi_stack_target)
+    assert exit_code == 0
+
+    deep = multi_stack_target / ".daydream" / "deep"
+    items = json.loads((deep / "merged-items.json").read_text())["items"]
+    descriptions = [i.get("description") for i in items]
+    assert "Grounded evidenced finding" in descriptions, (
+        f"evidenced finding was dropped: {descriptions}"
+    )
+    assert "Speculative unfounded finding" not in descriptions, (
+        f"speculative finding leaked into merged-items.json: {descriptions}"
+    )
+
+    report = (multi_stack_target / REVIEW_OUTPUT_FILE).read_text()
+    assert "Grounded evidenced finding" in report
+    assert "Speculative unfounded finding" not in report, (
+        "speculative finding leaked into review-output.md"
+    )
+
+    dropped = json.loads((deep / "dropped-speculative.json").read_text())
+    assert dropped["dropped_count"] >= 1
+    assert "Speculative unfounded finding" in json.dumps(dropped["dropped_items"])
+    assert 2 in dropped["dropped_ids"]
+
+
+async def test_evidence_gate_all_speculative_yields_empty(
+    tiny_diff_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Issue #227 (AC5, N=1): a single-stack run whose only findings are all
+    speculative writes an EMPTY merged-items.json without crashing and records
+    every drop -- never a silent success.
+
+    Drives the ``_write_single_stack_merged_items`` (tiny-diff bypass) gate path
+    via a ``--start-at merge`` resume with two primed speculative records: one
+    with blank evidence + a "no exploration evidence" rationale, one with LOW
+    confidence. Both must be dropped, leaving ``items == []`` and a
+    ``dropped-speculative.json`` recording both.
+    """
+    from daydream.runner import RunConfig, run
+
+    _silence(monkeypatch)
+    _install_stub_backend(monkeypatch, tiny_diff_target)
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_test_and_heal", lambda *a, **k: _ok())
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _noop_commit)
+
+    async def _no_post(target_dir: Path, report_path: Path, *, console: Any) -> None:
+        return None
+
+    monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _no_post)
+
+    deep = tiny_diff_target / ".daydream" / "deep"
+    deep.mkdir(parents=True, exist_ok=True)
+    (deep / "intent.md").write_text("primed intent")
+    (deep / "alternatives.json").write_text("[]")
+    (deep / "stack-generic-records.json").write_text(
+        json.dumps(
+            [
+                {
+                    "id": "gen-1",
+                    "description": "speculative generic finding",
+                    "file": "api.py",
+                    "line": 1,
+                    "confidence": "MEDIUM",
+                    "rationale": "inferred from the diff alone, no exploration evidence",
+                    "evidence": "",
+                }
+            ]
+        )
+    )
+    (deep / "stack-structure-records.json").write_text(
+        json.dumps(
+            [
+                {
+                    "id": "structure-1",
+                    "description": "speculative structural finding",
+                    "file": "api.py",
+                    "line": 1,
+                    "confidence": "LOW",
+                    "rationale": "hunch",
+                    "evidence": "api.py:1",
+                }
+            ]
+        )
+    )
+
+    rc = await run(RunConfig(target=str(tiny_diff_target), start_at="merge", cleanup=False))
+    assert rc == 0
+
+    items = json.loads((deep / "merged-items.json").read_text())["items"]
+    assert items == [], f"speculative findings survived the gate: {items}"
+
+    dropped = json.loads((deep / "dropped-speculative.json").read_text())
+    assert dropped["dropped_count"] == 2, dropped
+    dropped_desc = json.dumps(dropped["dropped_items"])
+    assert "speculative generic finding" in dropped_desc
+    assert "speculative structural finding" in dropped_desc

--- a/tests/test_deep_pr_comment_integration.py
+++ b/tests/test_deep_pr_comment_integration.py
@@ -284,6 +284,7 @@ class _FakeSDKClient:
                         "severity": "medium",
                         "confidence": "MEDIUM",
                         "rationale": "The current name is ambiguous.",
+                        "evidence": "foo.py:1",
                     }
                 ]
             else:  # FEEDBACK_SCHEMA (structural parse)
@@ -342,6 +343,7 @@ class _FakeSDKClient:
                                 "description": "Use a more descriptive function name",
                                 "confidence": "MEDIUM",
                                 "rationale": "The current name is ambiguous.",
+                                "evidence": "foo.py:1",
                             }
                         ]
                     },

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -727,6 +727,7 @@ async def test_exploration_enriched_output_both_flows(tmp_path, make_work):
         "line": 1,
         "confidence": "HIGH",
         "rationale": "verified by Convention snake_case_modules",
+        "evidence": "a.py:1",
     }
     enriched_trust_issue = {
         "id": 1,

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -220,7 +220,13 @@ async def test_phase_parse_feedback_json_fallback(tmp_path, monkeypatch, make_wo
             self, cwd, prompt, output_schema=None, continuation=None, agents=None,
             max_turns=None, read_only=False,
         ):
-            yield TextEvent(text='{"issues": [{"id": 1, "description": "Bug", "file": "foo.py", "line": 10}]}')
+            yield TextEvent(
+                text=(
+                    '{"issues": [{"id": 1, "description": "Bug", "file": "foo.py", '
+                    '"line": 10, "confidence": "HIGH", "rationale": "r", '
+                    '"evidence": "foo.py:10"}]}'
+                )
+            )
             yield ResultEvent(structured_output=None, continuation=None)
 
         async def cancel(self):
@@ -232,6 +238,70 @@ async def test_phase_parse_feedback_json_fallback(tmp_path, monkeypatch, make_wo
     result = await phase_parse_feedback(JsonTextBackend(), make_work(tmp_path))
     assert len(result) == 1
     assert result[0]["file"] == "foo.py"
+
+
+@pytest.mark.asyncio
+async def test_phase_parse_feedback_default_path_drops_speculative(tmp_path, monkeypatch, make_work):
+    """Issue #227 (AC3): the default (shallow) parse path drops speculative
+    findings before they reach the fix loop -- the grounding gate the deep
+    merge path applies is enforced here too, so AC3 holds for ``--shallow``
+    and PR-feedback ingestion.
+
+    Real path through ``phase_parse_feedback`` (input_path=None): the backend
+    returns one grounded finding and one evidence-free speculative finding;
+    only the grounded one survives.
+    """
+    from daydream.phases import phase_parse_feedback
+
+    monkeypatch.setattr("daydream.phases.print_phase_hero", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.phases.print_info", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.phases.print_warning", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.phases.console", type("C", (), {"print": lambda *a, **kw: None})())
+
+    (tmp_path / REVIEW_OUTPUT_FILE).write_text("# Issues\n")
+
+    class _Backend:
+        model = "test-model"
+        fanout_concurrency = 4
+
+        async def execute(self, cwd, prompt, output_schema=None, continuation=None,
+                          agents=None, max_turns=None, read_only=False):
+            yield ResultEvent(
+                structured_output={
+                    "issues": [
+                        {
+                            "id": 1,
+                            "description": "grounded",
+                            "file": "a.py",
+                            "line": 7,
+                            "confidence": "HIGH",
+                            "rationale": "r",
+                            "evidence": "a.py:7",
+                        },
+                        {
+                            "id": 2,
+                            "description": "speculative gut feeling",
+                            "file": "",
+                            "line": 0,
+                            "confidence": "MEDIUM",
+                            "rationale": "inferred from the diff alone",
+                            "evidence": "gut feeling",
+                        },
+                    ]
+                },
+                continuation=None,
+            )
+
+        async def cancel(self):
+            pass
+
+        def format_skill_invocation(self, skill_key, args=""):
+            return f"/{skill_key}"
+
+    result = await phase_parse_feedback(_Backend(), make_work(tmp_path))
+    assert [i["description"] for i in result] == ["grounded"], (
+        f"speculative finding leaked past the shallow-path gate: {result}"
+    )
 
 
 @pytest.mark.asyncio
@@ -1436,44 +1506,6 @@ def test_alternative_review_schema_requires_confidence_and_rationale():
     assert confidence["enum"] == ["HIGH", "MEDIUM"]
 
 
-def test_parse_feedback_rejects_unlabeled():
-    from daydream.phases import _validate_issue
-
-    with pytest.raises(ValueError):
-        _validate_issue({"id": "1", "description": "x", "file": "a.py", "line": 1})
-
-
-def test_validate_issue_rejects_speculative():
-    """Issue #227 (AC3): _validate_issue rejects blank evidence and a
-    "no exploration evidence" rationale, and accepts a grounded finding."""
-    from daydream.phases import _validate_issue
-
-    # Blank / missing evidence is rejected even with a valid confidence+rationale.
-    with pytest.raises(ValueError):
-        _validate_issue({"confidence": "MEDIUM", "rationale": "grounded", "evidence": ""})
-    with pytest.raises(ValueError):
-        _validate_issue({"confidence": "MEDIUM", "rationale": "grounded"})
-    # A rationale that claims "no exploration evidence" is speculative.
-    with pytest.raises(ValueError):
-        _validate_issue(
-            {
-                "confidence": "MEDIUM",
-                "rationale": "inferred from the diff alone, no exploration evidence",
-                "evidence": "api.py:1",
-            }
-        )
-    # An evidenced HIGH/MEDIUM finding passes (AC6).
-    _validate_issue({"confidence": "HIGH", "rationale": "cites api.py:1", "evidence": "api.py:1"})
-
-
-def test_validate_issue_rejects_low_confidence():
-    """Issue #227 (AC4): the collapsed enum rejects inbound LOW confidence."""
-    from daydream.phases import _validate_issue
-
-    with pytest.raises(ValueError):
-        _validate_issue({"confidence": "LOW", "rationale": "grounded", "evidence": "api.py:1"})
-
-
 def test_is_evidenced_gate_branches():
     """Issue #227: _is_evidenced grounds on evidence content and confidence tier."""
     from daydream.phases import _is_evidenced
@@ -1498,6 +1530,35 @@ def test_is_evidenced_gate_branches():
     # Non-blank evidence but no grounded citation and no file:line -> dropped.
     assert _is_evidenced(
         {"confidence": "HIGH", "rationale": "r", "file": "", "line": 0, "evidence": "trust me"}
+    ) is False
+    # Issue #227: the citation heuristic requires a path component (``.`` or
+    # ``/``) before ``:`` + digits, so non-citations are not admitted.
+    assert _is_evidenced(
+        {**base, "file": "", "line": 0, "evidence": "listen on port:8080"}
+    ) is False
+    assert _is_evidenced(
+        {"confidence": "MEDIUM", "rationale": "r", "file": "", "line": 0,
+         "evidence": "ratio 3:2 is odd"}
+    ) is False
+    # A path-bearing citation still grounds even without file/line.
+    assert _is_evidenced(
+        {"confidence": "MEDIUM", "rationale": "r", "file": "", "line": 0,
+         "evidence": "see src/util.py:88"}
+    ) is True
+    # Issue #227: structural (host-tagged, whole-file) findings survive with
+    # ``line: 0`` + colon-free evidence -- they must not be demoted.
+    assert _is_evidenced(
+        {"confidence": "HIGH", "rationale": "r", "lens": "structural",
+         "file": "big.py", "line": 0, "evidence": "big.py is 1200 lines"}
+    ) is True
+    # Structural still drops on LOW / blank evidence.
+    assert _is_evidenced(
+        {"confidence": "LOW", "rationale": "r", "lens": "structural",
+         "file": "big.py", "line": 0, "evidence": "big.py:1"}
+    ) is False
+    assert _is_evidenced(
+        {"confidence": "HIGH", "rationale": "r", "lens": "structural",
+         "file": "big.py", "line": 0, "evidence": ""}
     ) is False
 
 

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -1420,8 +1420,9 @@ def test_feedback_schema_requires_confidence_and_rationale():
     required = FEEDBACK_SCHEMA["properties"]["issues"]["items"]["required"]
     assert "confidence" in required
     assert "rationale" in required
+    assert "evidence" in required
     confidence = FEEDBACK_SCHEMA["properties"]["issues"]["items"]["properties"]["confidence"]
-    assert confidence["enum"] == ["HIGH", "MEDIUM", "LOW"]
+    assert confidence["enum"] == ["HIGH", "MEDIUM"]
 
 
 def test_alternative_review_schema_requires_confidence_and_rationale():
@@ -1430,8 +1431,9 @@ def test_alternative_review_schema_requires_confidence_and_rationale():
     required = ALTERNATIVE_REVIEW_SCHEMA["properties"]["issues"]["items"]["required"]
     assert "confidence" in required
     assert "rationale" in required
+    assert "evidence" in required
     confidence = ALTERNATIVE_REVIEW_SCHEMA["properties"]["issues"]["items"]["properties"]["confidence"]
-    assert confidence["enum"] == ["HIGH", "MEDIUM", "LOW"]
+    assert confidence["enum"] == ["HIGH", "MEDIUM"]
 
 
 def test_parse_feedback_rejects_unlabeled():
@@ -1439,6 +1441,64 @@ def test_parse_feedback_rejects_unlabeled():
 
     with pytest.raises(ValueError):
         _validate_issue({"id": "1", "description": "x", "file": "a.py", "line": 1})
+
+
+def test_validate_issue_rejects_speculative():
+    """Issue #227 (AC3): _validate_issue rejects blank evidence and a
+    "no exploration evidence" rationale, and accepts a grounded finding."""
+    from daydream.phases import _validate_issue
+
+    # Blank / missing evidence is rejected even with a valid confidence+rationale.
+    with pytest.raises(ValueError):
+        _validate_issue({"confidence": "MEDIUM", "rationale": "grounded", "evidence": ""})
+    with pytest.raises(ValueError):
+        _validate_issue({"confidence": "MEDIUM", "rationale": "grounded"})
+    # A rationale that claims "no exploration evidence" is speculative.
+    with pytest.raises(ValueError):
+        _validate_issue(
+            {
+                "confidence": "MEDIUM",
+                "rationale": "inferred from the diff alone, no exploration evidence",
+                "evidence": "api.py:1",
+            }
+        )
+    # An evidenced HIGH/MEDIUM finding passes (AC6).
+    _validate_issue({"confidence": "HIGH", "rationale": "cites api.py:1", "evidence": "api.py:1"})
+
+
+def test_validate_issue_rejects_low_confidence():
+    """Issue #227 (AC4): the collapsed enum rejects inbound LOW confidence."""
+    from daydream.phases import _validate_issue
+
+    with pytest.raises(ValueError):
+        _validate_issue({"confidence": "LOW", "rationale": "grounded", "evidence": "api.py:1"})
+
+
+def test_is_evidenced_gate_branches():
+    """Issue #227: _is_evidenced grounds on evidence content and confidence tier."""
+    from daydream.phases import _is_evidenced
+
+    base = {"confidence": "HIGH", "rationale": "cites a real edge", "file": "api.py", "line": 42}
+    # Grounded: non-blank evidence + real file:line.
+    assert _is_evidenced({**base, "evidence": "api.py:42"}) is True
+    # Grounded via a path:line citation inside evidence even without file/line.
+    assert _is_evidenced(
+        {"confidence": "MEDIUM", "rationale": "r", "file": "", "line": 0, "evidence": "src/foo.py:7"}
+    ) is True
+    # Speculative: blank / placeholder evidence.
+    assert _is_evidenced({**base, "evidence": ""}) is False
+    assert _is_evidenced({**base, "evidence": "n/a"}) is False
+    assert _is_evidenced({**base, "evidence": "none"}) is False
+    # Speculative: "no exploration evidence" rationale.
+    assert _is_evidenced(
+        {**base, "evidence": "api.py:42", "rationale": "no exploration evidence"}
+    ) is False
+    # Speculative: inbound LOW confidence (legacy tolerance, AC4).
+    assert _is_evidenced({**base, "confidence": "LOW", "evidence": "api.py:42"}) is False
+    # Non-blank evidence but no grounded citation and no file:line -> dropped.
+    assert _is_evidenced(
+        {"confidence": "HIGH", "rationale": "r", "file": "", "line": 0, "evidence": "trust me"}
+    ) is False
 
 
 def test_review_prompt_includes_dependency_impact(tmp_path):
@@ -3324,6 +3384,7 @@ async def test_merge_writes_canonical_json_and_renders_markdown(tmp_path, monkey
                 "description": "bug",
                 "confidence": "HIGH",
                 "rationale": "r",
+                "evidence": "a.py:9",
             }
         ]
     }
@@ -3348,7 +3409,8 @@ async def test_merge_writes_canonical_json_and_renders_markdown(tmp_path, monkey
     # Structural records file: the parsed FEEDBACK_SCHEMA shape produced upstream.
     struct_path = tmp_path / "stack-structure-records.json"
     struct_path.write_text(
-        json.dumps([{"id": 1, "description": "1k-line file", "file": "big.py", "line": 1}])
+        json.dumps([{"id": 1, "description": "1k-line file", "file": "big.py", "line": 1,
+                     "evidence": "big.py:1"}])
     )
 
     report_path = await phase_cross_stack_merge(

--- a/tests/test_phases_render.py
+++ b/tests/test_phases_render.py
@@ -77,6 +77,7 @@ async def test_merge_prints_item_count(monkeypatch, tmp_path, make_work):
             "line": i,
             "confidence": "HIGH",
             "rationale": "r",
+            "evidence": f"f{i}.py:{i}",
             "lens": "per-stack",
             "severity": "high",
         }

--- a/tests/test_phases_render.py
+++ b/tests/test_phases_render.py
@@ -52,6 +52,7 @@ async def test_parse_feedback_renders_issue_table(monkeypatch, tmp_path, make_wo
                 "line": 3,
                 "confidence": "HIGH",
                 "rationale": "crashes on None",
+                "evidence": "f.py:3",
             }
         ]
     }

--- a/tests/test_pr_feedback_integration.py
+++ b/tests/test_pr_feedback_integration.py
@@ -101,6 +101,9 @@ class _PRFeedbackStubBackend:
                             "description": "Align hello() return value with docstring",
                             "file": "api.py",
                             "line": 1,
+                            "confidence": "HIGH",
+                            "rationale": "return value diverges from docstring",
+                            "evidence": "api.py:1",
                         }
                     ]
                 },


### PR DESCRIPTION
## Summary

- Adds a first-class `evidence` field to all finding schemas (FEEDBACK, PER_STACK, ALTERNATIVE_REVIEW, MERGED_ITEMS, arbiter output)
- Adds a structural gate in `_append_structural_and_write_merged` that drops speculative / no-evidence findings BEFORE they reach `merged-items.json` -- the single enforcement point shared by both merge paths (cross-stack merge + tiny-diff single-stack bypass)
- Collapses confidence enum from HIGH/MEDIUM/LOW to HIGH/MEDIUM, with legacy LOW tolerance in the gate
- Hardens shallow parse path: `_is_evidenced` drop applied in `phase_parse_feedback` so the `--shallow` flow is also gated

## Motivation

Daydream finding schemas required `confidence` + `rationale` but only validated presence, not content. The prompt explicitly defined a `LOW: inferred from the diff alone, no exploration evidence` category and instructed agents to `Prefer LOW over MEDIUM when uncertain`. So speculative findings were schema-valid and flowed through to `merged-items.json`, which the fix stage, PR posting, `review-output.md`, and the benchmark all consume. The only guard was the prompt -- and prompts are advisory.

This gate is the structural enforcement backstop: every finding Daydream emits must carry a concrete grounded citation. Evidence-free findings are dropped and logged to a `dropped-speculative.json` audit sidecar.

Closes #227.

## Changes

### Added
- `evidence` field (required string) to FEEDBACK_SCHEMA, PER_STACK_RECORD_SCHEMA (inherited via deepcopy), ALTERNATIVE_REVIEW_SCHEMA, MERGED_ITEMS_SCHEMA, and arbiter output schema
- `_is_evidenced(item)` helper: returns `True` if a finding is grounded, `False` if speculative. Checks: non-blank non-placeholder evidence, rationale does not claim "no exploration evidence", confidence is not LOW (legacy tolerance), and a grounded citation (file:line or path:line pattern in evidence)
- Structural gate in `_append_structural_and_write_merged`: filters `base_items + structural_items` through `_is_evidenced` before `normalize_items`. Dropped items written to `dropped-speculative.json` with count + ids + full items
- `_is_evidenced` drop in `phase_parse_feedback` (shallow parse path, `input_path is None`): same gate logic applied to shallow/PR-feedback findings
- `dropped-speculative.json` sidecar cleanup on both merge entry points (`_write_single_stack_merged_items` and `phase_cross_stack_merge`) to prevent phantom drops on resume
- Structural lens carve-out: `lens="structural"` findings exempt from grounded-citation requirement (host-tagged, whole-file by construction)
- Citation heuristic requires path separator (`.`, `/`) before `:digits` so `port:8080` / `ratio 3:2` are not admitted

### Changed
- Confidence enum collapsed from `[HIGH, MEDIUM, LOW]` to `[HIGH, MEDIUM]` at all 4 schema sites
- `_validate_issue` updated to reject `LOW` confidence, blank `evidence`, and "no exploration evidence" rationale
- `_validate_issue` docstring updated to reflect new validation rules
- Arbiter record projection (`phase_arbiter_review`, `_apply_arbiter_verdicts`) carries `evidence` through

### Fixed
- Stale `dropped-speculative.json` from prior runs no longer persists across resumes

## Test Plan

- [x] `make check` -- 1895 passed, 4 skipped (ruff clean, mypy clean)
- [x] `test_evidence_gate_drops_speculative_finding` -- real-path deep run: evidenced finding survives, speculative dropped, `dropped-speculative.json` records the drop
- [x] `test_evidence_gate_all_speculative_yields_empty` -- tiny-diff bypass: all-speculative yields empty `merged-items.json` without crashing
- [x] `test_validate_issue_rejects_speculative` -- blank evidence and "no exploration evidence" rationale rejected
- [x] `test_validate_issue_rejects_low_confidence` -- LOW confidence rejected by collapsed enum
- [x] `test_is_evidenced_gate_branches` -- all gate branches covered (placeholder evidence, no-citation, structural carve-out, legacy LOW)
- [x] Existing tests updated with `evidence` field in mock data (backward compatible)

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check`)
- [x] Type checking passes (`uv run mypy daydream`)
- [ ] Documentation updated (if applicable) -- not applicable, internal gate

## Additional Context

Part of #233. Daydream pre-PR review completed (pi backend): tightened citation heuristic, added structural lens carve-out, wired shallow parse path, added stale sidecar cleanup. 1895 tests pass after review fixes.

Note: `_validate_issue` is called from `phase_parse_feedback` production path via the `_is_evidenced` drop (not the raise path). The raise path remains available as a latent guard for direct callers. Wiring the parse prompt to request `evidence` is the sibling prompt-elimination issue's scope.