### PR TITLE
chore(release): 0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-07-02
+
+### Added
+
+- **extensions:** Versioned extension seam with `daydream_ext` discovery, flow engine, and `daydream ext validate` CLI ([#241](https://github.com/existential-birds/daydream/pull/241))
+
+  Daydream now has a first-class, versioned extension API. An installed `daydream_ext` package is auto-discovered with a version gate and exposed through a `Registry` on a `ContextVar`. The registry routes skill slots (stack, structural, pr-feedback, phase-bound), named prompts (with wholesale override), and stack rules through a single seam, replacing scattered hardcoded lookups. All four flows (deep, shallow, review, pr-feedback) now run through a `run_flow()` engine with enabled gating, `Stop`/`BreakLoop` control, and loop groups. New `daydream ext validate` CLI resolve-checks the entire extension registry.
+
+- **deep:** `--findings-out` drives the deep pipeline and stops before post/fix ([#239](https://github.com/existential-birds/daydream/pull/239))
+
+  The single-file review-bot workflow now points at the default deep pipeline so the bot consumes the validated, arbiter-merged review. When `--findings-out` is set, the orchestrator writes the artifact from merged-items.json and returns before the PR-post block and apply-fixes gate. Also removes the vestigial `--plan`/ENVISION advisory pass and fixes `--review` to stop after findings instead of writing a stray plan file.
+
+- **review:** Structural evidence gate drops speculative/no-evidence findings before merge ([#236](https://github.com/existential-birds/daydream/pull/236))
+
+  Adds a first-class `evidence` field to all finding schemas. A structural gate in the merge path drops any finding without a grounded citation (path:line) before it reaches merged-items.json, review-output.md, the fix stage, PR posting, or the benchmark. Dropped items are logged to a `dropped-speculative.json` audit sidecar. Applies to both the cross-stack merge and the tiny-diff single-stack bypass. The confidence enum collapses to HIGH/MEDIUM (LOW/no-evidence removed).
+
+- **prompts:** Eliminate speculative and breadth-padding generation in review prompts ([#238](https://github.com/existential-birds/daydream/pull/238))
+
+  Removes language that invites evidence-free guesses and scope creep: drops the LOW/no-evidence confidence tier, replaces "Prefer LOW over MEDIUM" with a grounding directive, removes the "Would you have done this differently?" breadth invitation from alternative review, and requires concrete recommendations per issue rather than just the problem.
+
+- **review:** Wire review-verification-protocol into structural and generic-fallback reviewers ([#235](https://github.com/existential-birds/daydream/pull/235))
+
+  The structural and generic-fallback review prompts now load the review-verification-protocol skill (anchor/evidence/severity gates). The verification prompt adds a gate-0 anti-confabulation echo requirement. Product default is unchanged: verdicts stay advisory, zero findings dropped.
+
+- **templates:** Optional single-file review-bot workflow (drops `actions: write`) ([#237](https://github.com/existential-birds/daydream/pull/237))
+
+  Adds `daydream/templates/workflows/single/daydream.yml` as an optional manual-copy alternative to the three-file split. It chains gate, analyze, and post as `needs:`-ordered jobs in one workflow run, replacing the cross-workflow `workflow_dispatch` that required `actions: write`. The privilege split is preserved at the job level: gate holds the App key but no code, analyze holds PR code but no App key, post holds the App key but no PR code. Every action is pinned to a full commit SHA.
+
+- **training:** Eval-on-by-default and recommended-change patch capture ([#234](https://github.com/existential-birds/daydream/pull/234))
+
+  Eval is now on by default (`--eval` becomes `--no-eval` opt-out); `analyze_session` runs on every archive unless explicitly skipped, populating all four eval metrics (grounding_rate, total_findings, coverage_ratio, cost_per_finding_usd). A separate `recommended.patch` (daydream's proposed diff) is captured distinct from the PR-under-review `diff.patch`, with backward-compat fallback for legacy archives. Untracked files created during the fix phase are included in the capture.
+
 ## [0.21.0] - 2026-06-30
 
 ### Added
@@ -687,7 +719,8 @@ Initial release of Daydream - an automated code review and fix loop using the Cl
 - `rich` - Terminal UI components
 - `pyfiglet` - ASCII art header generation
 
-[unreleased]: https://github.com/existential-birds/daydream/compare/v0.21.0...HEAD
+[unreleased]: https://github.com/existential-birds/daydream/compare/v0.22.0...HEAD
+[0.22.0]: https://github.com/existential-birds/daydream/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/existential-birds/daydream/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/existential-birds/daydream/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/existential-birds/daydream/compare/v0.18.0...v0.19.0

--- a/daydream/templates/workflows/daydream-post.yml
+++ b/daydream/templates/workflows/daydream-post.yml
@@ -51,7 +51,7 @@ jobs:
         # Pinned to a release tag (not `main`) so the bot runs a known daydream
         # version: reproducible and immune to main-drift / uv-cache staleness.
         # Bump in lockstep with the package version on release (a test enforces this).
-        run: uv tool install git+https://github.com/existential-birds/daydream@v0.21.0
+        run: uv tool install git+https://github.com/existential-birds/daydream@v0.22.0
 
       - name: Mint posting token
         id: token

--- a/daydream/templates/workflows/daydream-review.yml
+++ b/daydream/templates/workflows/daydream-review.yml
@@ -92,7 +92,7 @@ jobs:
         # Pinned to a release tag (not `main`) so the bot runs a known daydream
         # version: reproducible and immune to main-drift / uv-cache staleness.
         # Bump in lockstep with the package version on release (a test enforces this).
-        run: uv tool install git+https://github.com/existential-birds/daydream@v0.21.0
+        run: uv tool install git+https://github.com/existential-birds/daydream@v0.22.0
 
       - name: Run daydream review
         env:

--- a/daydream/templates/workflows/single/daydream.yml
+++ b/daydream/templates/workflows/single/daydream.yml
@@ -144,7 +144,7 @@ jobs:
         # Pinned to a release tag (not `main`) so the bot runs a known daydream
         # version: reproducible and immune to main-drift / uv-cache staleness.
         # Bump in lockstep with the package version on release (a test enforces this).
-        run: uv tool install git+https://github.com/existential-birds/daydream@v0.21.0
+        run: uv tool install git+https://github.com/existential-birds/daydream@v0.22.0
 
       # Runs the DEFAULT deep-review pipeline (not --review). In --non-interactive
       # the deep run auto-declines the post/fix gates, so it still only produces a
@@ -191,7 +191,7 @@ jobs:
         uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
 
       - name: Install daydream
-        run: uv tool install git+https://github.com/existential-birds/daydream@v0.21.0
+        run: uv tool install git+https://github.com/existential-birds/daydream@v0.22.0
 
       - name: Download findings artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "daydream"
-version = "0.21.0"
+version = "0.22.0"
 description = "Automated code review and fix loop using Claude"
 requires-python = ">=3.12.13"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -193,7 +193,7 @@ wheels = [
 
 [[package]]
 name = "daydream"
-version = "0.21.0"
+version = "0.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Release 0.22.0

### Version bumps

| Location | Old | New |
|----------|-----|-----|
| `pyproject.toml` | 0.21.0 | 0.22.0 |
| `uv.lock` | 0.21.0 | 0.22.0 |
| `daydream-review.yml` | @v0.21.0 | @v0.22.0 |
| `daydream-post.yml` | @v0.21.0 | @v0.22.0 |
| `single/daydream.yml` | @v0.21.0 | @v0.22.0 (x2) |

### Changelog

7 feature PRs (MINOR bump):

- **extensions:** Versioned extension seam with `daydream_ext` discovery, flow engine, and `daydream ext validate` CLI ([#241](https://github.com/existential-birds/daydream/pull/241))
- **deep:** `--findings-out` drives the deep pipeline and stops before post/fix ([#239](https://github.com/existential-birds/daydream/pull/239))
- **review:** Structural evidence gate drops speculative/no-evidence findings before merge ([#236](https://github.com/existential-birds/daydream/pull/236))
- **prompts:** Eliminate speculative and breadth-padding generation in review prompts ([#238](https://github.com/existential-birds/daydream/pull/238))
- **review:** Wire review-verification-protocol into structural and generic-fallback reviewers ([#235](https://github.com/existential-birds/daydream/pull/235))
- **templates:** Optional single-file review-bot workflow (drops `actions: write`) ([#237](https://github.com/existential-birds/daydream/pull/237))
- **training:** Eval-on-by-default and recommended-change patch capture ([#234](https://github.com/existential-birds/daydream/pull/234))

Pre-push hook: 1923 passed, 4 skipped.