### PR TITLE
feat(benchmark): add direct Anthropic judge route

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,7 +270,8 @@ name inventories, module shape, bump policy — is `docs/extensions.md`.
 | `PI_PROVIDER` / `PI_API_KEY` / `PI_THINKING` | Pi backend | Forwarded as `pi` CLI flags |
 | `DAYDREAM_PI_RETRY_ATTEMPTS` / `DAYDREAM_PI_RETRY_BASE_DELAY_S` | Pi backend | Transient retry tuning |
 | `CLAUDE_CONFIG_DIR` | Claude backend | Override `~/.claude` directory |
-| `MARTIAN_API_KEY` / `MARTIAN_BASE_URL` / `MARTIAN_MODEL` | Benchmark | Judge endpoint and model |
+| `MARTIAN_API_KEY` / `MARTIAN_BASE_URL` / `MARTIAN_MODEL` | Benchmark | Judge endpoint and model (`martian` route) |
+| `ANTHROPIC_API_KEY` | Benchmark | Direct Anthropic judge (`anthropic-direct` route) |
 
 ## Platform requirements
 

--- a/daydream/benchmark/anthropic_score.py
+++ b/daydream/benchmark/anthropic_score.py
@@ -20,6 +20,7 @@ from daydream.benchmark.score import (
     parse_daydream_scores,
 )
 
+
 class _NonRetryableError(BenchmarkStepError):
     """Raised for HTTP 4xx (non-429) and JSON-parse failures that must not be retried."""
 

--- a/daydream/benchmark/anthropic_score.py
+++ b/daydream/benchmark/anthropic_score.py
@@ -1,0 +1,120 @@
+"""Direct Anthropic JSON client for benchmark judge steps."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+import httpx
+
+from daydream.benchmark.score import BenchmarkStepError
+
+_ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages"
+_ANTHROPIC_VERSION = "2023-06-01"
+_REQUEST_TIMEOUT = 60.0
+_MAX_RETRIES = 3
+
+
+class _AsyncHttpClient(Protocol):
+    async def post(
+        self, url: str, *, headers: dict[str, str], json: dict[str, Any], timeout: float
+    ) -> Any:
+        ...
+
+
+@dataclass
+class AnthropicJsonClient:
+    """Small Messages API client that returns strict parsed JSON objects."""
+
+    api_key: str
+    model: str
+    http: _AsyncHttpClient | None = None
+
+    async def complete_json(self, *, system: str, user: str, max_tokens: int) -> dict[str, Any]:
+        """POST a Messages API request and parse the first returned text block as JSON."""
+        payload = {
+            "model": self.model,
+            "max_tokens": max_tokens,
+            "temperature": 0,
+            "system": system,
+            "messages": [{"role": "user", "content": user}],
+        }
+        headers = {
+            "x-api-key": self.api_key,
+            "anthropic-version": _ANTHROPIC_VERSION,
+            "content-type": "application/json",
+        }
+
+        if self.http is not None:
+            return await _complete_json_with_http(self.http, payload=payload, headers=headers)
+        async with httpx.AsyncClient() as http:
+            return await _complete_json_with_http(http, payload=payload, headers=headers)
+
+
+async def _complete_json_with_http(
+    http: _AsyncHttpClient, *, payload: dict[str, Any], headers: dict[str, str]
+) -> dict[str, Any]:
+    for attempt in range(_MAX_RETRIES):
+        try:
+            try:
+                response = await http.post(
+                    _ANTHROPIC_MESSAGES_URL, headers=headers, json=payload, timeout=_REQUEST_TIMEOUT
+                )
+            except Exception as exc:
+                raise BenchmarkStepError(f"Anthropic Messages request failed: {exc}") from exc
+            return _parse_json_response(response)
+        except BenchmarkStepError:
+            if attempt == _MAX_RETRIES - 1:
+                raise
+            await asyncio.sleep(2**attempt)
+    raise BenchmarkStepError("Anthropic Messages request failed after retries")
+
+
+def _parse_json_response(response: Any) -> dict[str, Any]:
+    status_code = getattr(response, "status_code", None)
+    if status_code is None or not 200 <= int(status_code) < 300:
+        body = getattr(response, "text", "")
+        raise BenchmarkStepError(f"Anthropic Messages request failed with HTTP {status_code}: {body}")
+
+    try:
+        body = response.json()
+    except Exception as exc:
+        raise BenchmarkStepError(f"Anthropic Messages response was not valid JSON: {exc}") from exc
+
+    text = _first_text_block(body)
+    try:
+        parsed = json.loads(_strip_markdown_fences(text))
+    except json.JSONDecodeError as exc:
+        raise BenchmarkStepError(f"Anthropic Messages text block was not valid JSON: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise BenchmarkStepError("Anthropic Messages text block JSON was not an object")
+    return parsed
+
+
+def _first_text_block(body: Any) -> str:
+    if not isinstance(body, dict):
+        raise BenchmarkStepError("Anthropic Messages response body was not an object")
+    content = body.get("content")
+    if not isinstance(content, list):
+        raise BenchmarkStepError("Anthropic Messages response missing content blocks")
+    for block in content:
+        if isinstance(block, dict) and block.get("type") == "text" and isinstance(block.get("text"), str):
+            text = block["text"].strip()
+            if text:
+                return text
+    raise BenchmarkStepError("Anthropic Messages response contained no text block")
+
+
+def _strip_markdown_fences(text: str) -> str:
+    stripped = text.strip()
+    if not stripped.startswith("```"):
+        return stripped
+
+    lines = stripped.splitlines()
+    if lines and lines[0].startswith("```"):
+        lines = lines[1:]
+    if lines and lines[-1].strip() == "```":
+        lines = lines[:-1]
+    return "\n".join(lines).strip()

--- a/daydream/benchmark/anthropic_score.py
+++ b/daydream/benchmark/anthropic_score.py
@@ -4,13 +4,21 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
 
 import httpx
 
-from daydream.benchmark.score import BenchmarkArtifactError, BenchmarkStepError, model_results_dir
+from daydream.benchmark.score import (
+    ANTHROPIC_JUDGE_API_KEY_ENV,
+    BenchmarkArtifactError,
+    BenchmarkStepError,
+    DaydreamScores,
+    model_results_dir,
+    parse_daydream_scores,
+)
 
 _ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages"
 _ANTHROPIC_VERSION = "2023-06-01"
@@ -18,11 +26,13 @@ _REQUEST_TIMEOUT = 60.0
 _MAX_RETRIES = 3
 _MAX_EXTRACTION_TOKENS = 4096
 _MAX_DEDUP_TOKENS = 4096
+_MAX_JUDGE_TOKENS = 1024
 _MIN_DEDUP_CANDIDATES = 2
 _TOOL = "daydream"
 
 _EXTRACTION_SYSTEM = "You extract code review issues from comments. Always respond with valid JSON."
 _DEDUP_SYSTEM = "You group duplicate code review comments. Always respond with valid JSON only."
+_JUDGE_SYSTEM = "You are a precise code review evaluator. Always respond with valid JSON."
 
 _EXTRACTION_PROMPT = """You are analyzing an AI code review comment to extract individual issues mentioned.
 
@@ -84,6 +94,23 @@ Example for 4 candidates where 0 and 2 are duplicates:
 {{"groups": [[0, 2], [1], [3]]}}
 
 Your response:"""
+
+_JUDGE_PROMPT = """You are evaluating AI code review tools.
+Determine if the candidate issue matches the golden (expected) comment.
+
+Golden Comment (the issue we're looking for):
+{golden_comment}
+
+Candidate Issue (from the tool's review):
+{candidate}
+
+Instructions:
+- Determine if the candidate identifies the SAME underlying issue as the golden comment
+- Accept semantic matches - different wording is fine if it's the same problem
+- Focus on whether they point to the same bug, concern, or code issue
+
+Respond with ONLY a JSON object:
+{{"reasoning": "brief explanation", "match": true/false, "confidence": 0.0-1.0}}"""
 
 
 class _AsyncHttpClient(Protocol):
@@ -231,11 +258,308 @@ async def run_anthropic_dedup(
     groups_file.write_text(json.dumps(all_groups, indent=2))
 
 
+async def run_anthropic_scoring(
+    benchmark_repo: Path,
+    judge_model: str,
+    *,
+    pr_count: int | None = None,
+    tool: str = _TOOL,
+    client: _AnthropicJsonCompleter | None = None,
+) -> DaydreamScores:
+    """Run direct Anthropic extraction, dedup, and evaluation for benchmark scores."""
+    benchmark_repo = benchmark_repo.resolve()
+    if client is None:
+        api_key = os.environ.get(ANTHROPIC_JUDGE_API_KEY_ENV)
+        if not api_key:
+            raise BenchmarkStepError(
+                f"{ANTHROPIC_JUDGE_API_KEY_ENV} is not set; cannot run Anthropic-direct scoring."
+            )
+        client = AnthropicJsonClient(api_key=api_key, model=judge_model)
+
+    await run_anthropic_extraction(benchmark_repo, judge_model, tool=tool, client=client)
+    await run_anthropic_dedup(benchmark_repo, judge_model, tool=tool, client=client)
+    evals = await run_anthropic_evaluation(
+        benchmark_repo,
+        judge_model,
+        pr_count=pr_count,
+        tool=tool,
+        client=client,
+    )
+    return parse_daydream_scores(evals, tool=tool)
+
+
+async def run_anthropic_evaluation(
+    benchmark_repo: Path,
+    judge_model: str,
+    *,
+    pr_count: int | None = None,
+    tool: str = _TOOL,
+    client: _AnthropicJsonCompleter,
+) -> dict[str, dict[str, Any]]:
+    """Write Martian-compatible evaluations using direct Anthropic JSON calls."""
+    benchmark_data_file = benchmark_repo / "results" / "benchmark_data.json"
+    if not benchmark_data_file.exists():
+        raise BenchmarkArtifactError(f"{benchmark_data_file} not found; cannot evaluate benchmark candidates.")
+
+    data = json.loads(benchmark_data_file.read_text())
+    if not isinstance(data, dict):
+        raise BenchmarkStepError(f"{benchmark_data_file} must contain a JSON object.")
+
+    results_dir = model_results_dir(benchmark_repo, judge_model)
+    candidates_file = results_dir / "candidates.json"
+    if candidates_file.exists():
+        all_candidates = json.loads(candidates_file.read_text())
+        if not isinstance(all_candidates, dict):
+            raise BenchmarkStepError(f"{candidates_file} must contain a JSON object.")
+    else:
+        all_candidates = {}
+
+    groups_file = results_dir / "dedup_groups.json"
+    if groups_file.exists():
+        all_dedup_groups = json.loads(groups_file.read_text())
+        if not isinstance(all_dedup_groups, dict):
+            raise BenchmarkStepError(f"{groups_file} must contain a JSON object.")
+    else:
+        all_dedup_groups = {}
+
+    evaluations_file = results_dir / "evaluations.json"
+    if evaluations_file.exists():
+        evals = json.loads(evaluations_file.read_text())
+        if not isinstance(evals, dict):
+            raise BenchmarkStepError(f"{evaluations_file} must contain a JSON object.")
+    else:
+        evals = {}
+
+    evaluated = 0
+    for golden_url, entry in data.items():
+        if not isinstance(entry, dict):
+            continue
+        golden_comments = entry.get("golden_comments", [])
+        if not isinstance(golden_comments, list):
+            golden_comments = []
+        reviews = entry.get("reviews", [])
+        if not isinstance(reviews, list):
+            continue
+
+        for review in reviews:
+            if not isinstance(review, dict) or review.get("tool") != tool:
+                continue
+            existing_leaf = evals.get(golden_url, {}).get(tool)
+            if isinstance(existing_leaf, dict) and existing_leaf.get("errors_count", 0) == 0:
+                continue
+            if pr_count is not None and evaluated >= pr_count:
+                evaluations_file.write_text(json.dumps(evals, indent=2))
+                return evals
+
+            candidates = _get_candidates_for_review(review, all_candidates, golden_url)
+            dedup_groups = _get_dedup_groups(all_dedup_groups, golden_url, tool)
+            result = await _evaluate_review(client, golden_comments, candidates, dedup_groups)
+            result["tool"] = tool
+            result["repo_name"] = review.get("repo_name")
+            result["pr_url"] = review.get("pr_url")
+            result["judge_route"] = "anthropic-direct"
+            result["judge_model"] = judge_model
+
+            evals.setdefault(golden_url, {})[tool] = result
+            evaluations_file.write_text(json.dumps(evals, indent=2))
+            evaluated += 1
+
+    evaluations_file.write_text(json.dumps(evals, indent=2))
+    return evals
+
+
 def _get_all_comment_text(review_comments: Any) -> str:
     if not isinstance(review_comments, list):
         return ""
     bodies = [comment["body"] for comment in review_comments if isinstance(comment, dict) and comment.get("body")]
     return "\n\n---\n\n".join(bodies)
+
+
+def _get_candidates_for_review(review: dict[str, Any], all_candidates: dict[str, Any], golden_url: str) -> list[str]:
+    tool = review["tool"]
+    tools = all_candidates.get(golden_url)
+    if isinstance(tools, dict) and isinstance(tools.get(tool), list):
+        return _candidate_texts(tools[tool])
+
+    review_comments = review.get("review_comments", [])
+    if not isinstance(review_comments, list):
+        return []
+    return [comment["body"] for comment in review_comments if isinstance(comment, dict) and comment.get("body")]
+
+
+def _get_dedup_groups(all_dedup_groups: dict[str, Any], golden_url: str, tool: str) -> list[list[int]] | None:
+    tools = all_dedup_groups.get(golden_url)
+    if not isinstance(tools, dict):
+        return None
+    groups = tools.get(tool)
+    if not isinstance(groups, list):
+        return None
+    parsed: list[list[int]] = []
+    for group in groups:
+        if not isinstance(group, list) or not all(isinstance(index, int) for index in group):
+            return None
+        parsed.append(group)
+    return parsed
+
+
+async def _evaluate_review(
+    client: _AnthropicJsonCompleter,
+    golden_comments: list[Any],
+    candidates: list[str],
+    dedup_groups: list[list[int]] | None,
+) -> dict[str, Any]:
+    golden = [
+        comment
+        for comment in golden_comments
+        if isinstance(comment, dict) and isinstance(comment.get("comment"), str)
+    ]
+
+    if not golden:
+        return {"skipped": True, "reason": "No golden comments"}
+
+    if not candidates:
+        return {
+            "skipped": False,
+            "true_positives": [],
+            "false_positives": [],
+            "false_negatives": [
+                {"golden_comment": comment["comment"], "severity": comment.get("severity")} for comment in golden
+            ],
+            "errors": [],
+            "total_candidates": 0,
+            "total_golden": len(golden),
+            "tp": 0,
+            "fp": 0,
+            "fn": len(golden),
+            "errors_count": 0,
+            "precision": 0.0,
+            "recall": 0.0,
+        }
+
+    tasks = []
+    task_meta = []
+    for golden_comment in golden:
+        for candidate in candidates:
+            tasks.append(_match_comment(client, golden_comment["comment"], candidate))
+            task_meta.append(
+                {
+                    "golden": golden_comment["comment"],
+                    "golden_severity": golden_comment.get("severity"),
+                    "candidate": candidate,
+                }
+            )
+
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    golden_matched = {
+        comment["comment"]: {
+            "severity": comment.get("severity"),
+            "matched": False,
+            "best_confidence": 0.0,
+            "matched_candidate": None,
+        }
+        for comment in golden
+    }
+    candidate_matched = dict.fromkeys(candidates, False)
+    sibling_map = _build_sibling_map(candidates, dedup_groups)
+    errors = []
+
+    for index, result in enumerate(results):
+        meta = task_meta[index]
+        golden_text = meta["golden"]
+        candidate = meta["candidate"]
+        if isinstance(result, Exception):
+            errors.append({"golden": golden_text, "candidate": candidate, "error": str(result)})
+            continue
+        if result.get("error"):
+            errors.append({"golden": golden_text, "candidate": candidate, "error": result["error"]})
+            continue
+
+        confidence = result.get("confidence", 0)
+        if result.get("match") and confidence > golden_matched[golden_text]["best_confidence"]:
+            golden_matched[golden_text]["matched"] = True
+            golden_matched[golden_text]["best_confidence"] = confidence
+            golden_matched[golden_text]["matched_candidate"] = candidate
+            golden_matched[golden_text]["reasoning"] = result.get("reasoning")
+            candidate_matched[candidate] = True
+            for sibling in sibling_map.get(candidate, set()):
+                candidate_matched[sibling] = True
+
+    true_positives = []
+    false_negatives = []
+    for golden_text, info in golden_matched.items():
+        if info["matched"]:
+            true_positives.append(
+                {
+                    "golden_comment": golden_text,
+                    "severity": info["severity"],
+                    "matched_candidate": info["matched_candidate"],
+                    "confidence": info["best_confidence"],
+                    "reasoning": info.get("reasoning"),
+                }
+            )
+        else:
+            false_negatives.append({"golden_comment": golden_text, "severity": info["severity"]})
+
+    false_positives = [{"candidate": candidate} for candidate, matched in candidate_matched.items() if not matched]
+    total_candidates = len(candidates)
+    total_golden = len(golden)
+    tp_count = len(true_positives)
+    precision = tp_count / total_candidates if total_candidates > 0 else 0.0
+    recall = tp_count / total_golden if total_golden > 0 else 0.0
+
+    return {
+        "skipped": False,
+        "true_positives": true_positives,
+        "false_positives": false_positives,
+        "false_negatives": false_negatives,
+        "errors": errors,
+        "total_candidates": total_candidates,
+        "total_golden": total_golden,
+        "tp": tp_count,
+        "fp": len(false_positives),
+        "fn": len(false_negatives),
+        "errors_count": len(errors),
+        "precision": precision,
+        "recall": recall,
+    }
+
+
+async def _match_comment(client: _AnthropicJsonCompleter, golden_comment: str, candidate: str) -> dict[str, Any]:
+    try:
+        response = await client.complete_json(
+            system=_JUDGE_SYSTEM,
+            user=_JUDGE_PROMPT.format(golden_comment=golden_comment, candidate=candidate),
+            max_tokens=_MAX_JUDGE_TOKENS,
+        )
+    except Exception as exc:
+        return {"error": str(exc)}
+    return _extract_match_result(response)
+
+
+def _extract_match_result(response: dict[str, Any]) -> dict[str, Any]:
+    if "error" in response:
+        return {"error": str(response["error"])}
+    if not isinstance(response.get("match"), bool):
+        return {"error": "Anthropic judge response 'match' must be a boolean."}
+    confidence = response.get("confidence")
+    if not isinstance(confidence, int | float):
+        return {"error": "Anthropic judge response 'confidence' must be a number."}
+    reasoning = response.get("reasoning", "")
+    if not isinstance(reasoning, str):
+        return {"error": "Anthropic judge response 'reasoning' must be a string."}
+    return {"reasoning": reasoning, "match": response["match"], "confidence": float(confidence)}
+
+
+def _build_sibling_map(candidates: list[str], groups: list[list[int]] | None) -> dict[str, set[str]]:
+    if not groups:
+        return {}
+    sibling_map: dict[str, set[str]] = {}
+    for group in groups:
+        group_texts = {candidates[index] for index in group if index < len(candidates)}
+        for index in group:
+            if index < len(candidates):
+                sibling_map[candidates[index]] = group_texts - {candidates[index]}
+    return sibling_map
 
 
 def _extract_issues(response: dict[str, Any]) -> list[str]:

--- a/daydream/benchmark/anthropic_score.py
+++ b/daydream/benchmark/anthropic_score.py
@@ -5,22 +5,61 @@ from __future__ import annotations
 import asyncio
 import json
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Protocol
 
 import httpx
 
-from daydream.benchmark.score import BenchmarkStepError
+from daydream.benchmark.score import BenchmarkArtifactError, BenchmarkStepError, model_results_dir
 
 _ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages"
 _ANTHROPIC_VERSION = "2023-06-01"
 _REQUEST_TIMEOUT = 60.0
 _MAX_RETRIES = 3
+_MAX_EXTRACTION_TOKENS = 4096
+_TOOL = "daydream"
+
+_EXTRACTION_SYSTEM = "You extract code review issues from comments. Always respond with valid JSON."
+
+_EXTRACTION_PROMPT = """You are analyzing an AI code review comment to extract individual issues mentioned.
+
+The comment may discuss multiple distinct problems. Extract each separate issue as a standalone item.
+
+Code Review Comment:
+{comment}
+
+Instructions:
+- Extract each distinct code issue, bug, or concern mentioned
+- Each issue should be a single, specific problem (not a general observation)
+- Ignore meta-commentary like "I found 2 issues" - extract the actual issues
+- Ignore sign-offs, greetings, or formatting instructions
+- If the comment contains no actionable code review issues, return an empty list
+
+Example input:
+"Found several problems: 1) The getUserById function doesn't handle null input, which will cause a crash.
+2) The cache key uses user.name but should use user.id for uniqueness.
+Also, consider adding retry logic for the API call."
+
+Example output:
+{{"issues": [
+  "getUserById function doesn't handle null input, causing potential crash",
+  "Cache key uses user.name instead of user.id, breaking uniqueness",
+  "Missing retry logic for API call"
+]}}
+
+Respond with ONLY a JSON object:
+{{"issues": ["issue 1", "issue 2", ...]}}"""
 
 
 class _AsyncHttpClient(Protocol):
     async def post(
         self, url: str, *, headers: dict[str, str], json: dict[str, Any], timeout: float
     ) -> Any:
+        ...
+
+
+class _AnthropicJsonCompleter(Protocol):
+    async def complete_json(self, *, system: str, user: str, max_tokens: int) -> dict[str, Any]:
         ...
 
 
@@ -51,6 +90,74 @@ class AnthropicJsonClient:
             return await _complete_json_with_http(self.http, payload=payload, headers=headers)
         async with httpx.AsyncClient() as http:
             return await _complete_json_with_http(http, payload=payload, headers=headers)
+
+
+async def run_anthropic_extraction(
+    benchmark_repo: Path,
+    judge_model: str,
+    *,
+    tool: str = _TOOL,
+    client: _AnthropicJsonCompleter,
+) -> None:
+    """Extract Martian-compatible candidate issues using direct Anthropic JSON calls."""
+    benchmark_data_file = benchmark_repo / "results" / "benchmark_data.json"
+    if not benchmark_data_file.exists():
+        raise BenchmarkArtifactError(f"{benchmark_data_file} not found; cannot extract benchmark candidates.")
+
+    data = json.loads(benchmark_data_file.read_text())
+    if not isinstance(data, dict):
+        raise BenchmarkStepError(f"{benchmark_data_file} must contain a JSON object.")
+
+    results_dir = model_results_dir(benchmark_repo, judge_model)
+    results_dir.mkdir(parents=True, exist_ok=True)
+    candidates_file = results_dir / "candidates.json"
+    if candidates_file.exists():
+        all_candidates = json.loads(candidates_file.read_text())
+        if not isinstance(all_candidates, dict):
+            raise BenchmarkStepError(f"{candidates_file} must contain a JSON object.")
+    else:
+        all_candidates = {}
+
+    for golden_url, entry in data.items():
+        reviews = entry.get("reviews", []) if isinstance(entry, dict) else []
+        for review in reviews:
+            if not isinstance(review, dict) or review.get("tool") != tool:
+                continue
+            existing_tools = all_candidates.get(golden_url)
+            if isinstance(existing_tools, dict) and tool in existing_tools:
+                continue
+
+            all_text = _get_all_comment_text(review.get("review_comments", []))
+            if not all_text or len(all_text.strip()) < 20:
+                continue
+
+            response = await client.complete_json(
+                system=_EXTRACTION_SYSTEM,
+                user=_EXTRACTION_PROMPT.format(comment=all_text),
+                max_tokens=_MAX_EXTRACTION_TOKENS,
+            )
+            issues = _extract_issues(response)
+            all_candidates.setdefault(golden_url, {})[tool] = [
+                {"text": issue, "path": None, "line": None, "source": "extracted"} for issue in issues
+            ]
+
+    candidates_file.write_text(json.dumps(all_candidates, indent=2))
+
+
+def _get_all_comment_text(review_comments: Any) -> str:
+    if not isinstance(review_comments, list):
+        return ""
+    bodies = [comment["body"] for comment in review_comments if isinstance(comment, dict) and comment.get("body")]
+    return "\n\n---\n\n".join(bodies)
+
+
+def _extract_issues(response: dict[str, Any]) -> list[str]:
+    if "issues" not in response:
+        raise BenchmarkStepError("Anthropic extraction response missing required 'issues' key.")
+    issues = response["issues"]
+    if not isinstance(issues, list) or not all(isinstance(issue, str) for issue in issues):
+        raise BenchmarkStepError("Anthropic extraction response 'issues' must be a list of strings.")
+    return issues
 
 
 async def _complete_json_with_http(

--- a/daydream/benchmark/anthropic_score.py
+++ b/daydream/benchmark/anthropic_score.py
@@ -20,6 +20,10 @@ from daydream.benchmark.score import (
     parse_daydream_scores,
 )
 
+class _NonRetryableError(BenchmarkStepError):
+    """Raised for HTTP 4xx (non-429) and JSON-parse failures that must not be retried."""
+
+
 _ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages"
 _ANTHROPIC_VERSION = "2023-06-01"
 _REQUEST_TIMEOUT = 60.0
@@ -28,6 +32,7 @@ _MAX_EXTRACTION_TOKENS = 4096
 _MAX_DEDUP_TOKENS = 4096
 _MAX_JUDGE_TOKENS = 1024
 _MIN_DEDUP_CANDIDATES = 2
+_JUDGE_CONCURRENCY = 10  # max parallel judge calls; mirrors CapacityLimiter convention in phases.py
 _TOOL = "daydream"
 
 _EXTRACTION_SYSTEM = "You extract code review issues from comments. Always respond with valid JSON."
@@ -436,11 +441,12 @@ async def _evaluate_review(
             "recall": 0.0,
         }
 
+    semaphore = asyncio.Semaphore(_JUDGE_CONCURRENCY)
     tasks = []
     task_meta = []
     for golden_comment in golden:
         for candidate in candidates:
-            tasks.append(_match_comment(client, golden_comment["comment"], candidate))
+            tasks.append(_match_comment_limited(semaphore, client, golden_comment["comment"], candidate))
             task_meta.append(
                 {
                     "golden": golden_comment["comment"],
@@ -454,7 +460,7 @@ async def _evaluate_review(
         comment["comment"]: {
             "severity": comment.get("severity"),
             "matched": False,
-            "best_confidence": 0.0,
+            "best_confidence": -1.0,  # sentinel: any valid confidence (including 0.0) beats this
             "matched_candidate": None,
         }
         for comment in golden
@@ -475,7 +481,7 @@ async def _evaluate_review(
             continue
 
         confidence = result.get("confidence", 0)
-        if result.get("match") and confidence > golden_matched[golden_text]["best_confidence"]:
+        if result.get("match") and confidence >= golden_matched[golden_text]["best_confidence"]:
             golden_matched[golden_text]["matched"] = True
             golden_matched[golden_text]["best_confidence"] = confidence
             golden_matched[golden_text]["matched_candidate"] = candidate
@@ -522,6 +528,13 @@ async def _evaluate_review(
         "precision": precision,
         "recall": recall,
     }
+
+
+async def _match_comment_limited(
+    semaphore: asyncio.Semaphore, client: _AnthropicJsonCompleter, golden_comment: str, candidate: str
+) -> dict[str, Any]:
+    async with semaphore:
+        return await _match_comment(client, golden_comment, candidate)
 
 
 async def _match_comment(client: _AnthropicJsonCompleter, golden_comment: str, candidate: str) -> dict[str, Any]:
@@ -622,6 +635,8 @@ async def _complete_json_with_http(
             except Exception as exc:
                 raise BenchmarkStepError(f"Anthropic Messages request failed: {exc}") from exc
             return _parse_json_response(response)
+        except _NonRetryableError:
+            raise  # 4xx (non-429) and malformed-JSON are permanent; never retry
         except BenchmarkStepError:
             if attempt == _MAX_RETRIES - 1:
                 raise
@@ -633,20 +648,24 @@ def _parse_json_response(response: Any) -> dict[str, Any]:
     status_code = getattr(response, "status_code", None)
     if status_code is None or not 200 <= int(status_code) < 300:
         body = getattr(response, "text", "")
+        code = int(status_code) if status_code is not None else -1
+        # 429 is retryable (rate-limit); all other 4xx are permanent client errors.
+        if 400 <= code < 500 and code != 429:
+            raise _NonRetryableError(f"Anthropic Messages request failed with HTTP {status_code}: {body}")
         raise BenchmarkStepError(f"Anthropic Messages request failed with HTTP {status_code}: {body}")
 
     try:
         body = response.json()
     except Exception as exc:
-        raise BenchmarkStepError(f"Anthropic Messages response was not valid JSON: {exc}") from exc
+        raise _NonRetryableError(f"Anthropic Messages response was not valid JSON: {exc}") from exc
 
     text = _first_text_block(body)
     try:
         parsed = json.loads(_strip_markdown_fences(text))
     except json.JSONDecodeError as exc:
-        raise BenchmarkStepError(f"Anthropic Messages text block was not valid JSON: {exc}") from exc
+        raise _NonRetryableError(f"Anthropic Messages text block was not valid JSON: {exc}") from exc
     if not isinstance(parsed, dict):
-        raise BenchmarkStepError("Anthropic Messages text block JSON was not an object")
+        raise _NonRetryableError("Anthropic Messages text block JSON was not an object")
     return parsed
 
 

--- a/daydream/benchmark/anthropic_score.py
+++ b/daydream/benchmark/anthropic_score.py
@@ -190,7 +190,7 @@ async def run_anthropic_extraction(
                 continue
 
             all_text = _get_all_comment_text(review.get("review_comments", []))
-            if not all_text or len(all_text.strip()) < 20:
+            if not all_text.strip():
                 continue
 
             response = await client.complete_json(
@@ -467,7 +467,7 @@ async def _evaluate_review(
         meta = task_meta[index]
         golden_text = meta["golden"]
         candidate = meta["candidate"]
-        if isinstance(result, Exception):
+        if isinstance(result, BaseException):
             errors.append({"golden": golden_text, "candidate": candidate, "error": str(result)})
             continue
         if result.get("error"):

--- a/daydream/benchmark/anthropic_score.py
+++ b/daydream/benchmark/anthropic_score.py
@@ -17,9 +17,12 @@ _ANTHROPIC_VERSION = "2023-06-01"
 _REQUEST_TIMEOUT = 60.0
 _MAX_RETRIES = 3
 _MAX_EXTRACTION_TOKENS = 4096
+_MAX_DEDUP_TOKENS = 4096
+_MIN_DEDUP_CANDIDATES = 2
 _TOOL = "daydream"
 
 _EXTRACTION_SYSTEM = "You extract code review issues from comments. Always respond with valid JSON."
+_DEDUP_SYSTEM = "You group duplicate code review comments. Always respond with valid JSON only."
 
 _EXTRACTION_PROMPT = """You are analyzing an AI code review comment to extract individual issues mentioned.
 
@@ -49,6 +52,38 @@ Example output:
 
 Respond with ONLY a JSON object:
 {{"issues": ["issue 1", "issue 2", ...]}}"""
+
+_DEDUP_PROMPT = """You are identifying duplicate code review comments.
+
+Below is a numbered list of issues extracted from an AI tool's code review.
+Some tools post the same issue in both a summary comment and an inline comment,
+creating near-identical duplicates. Your job is to find those duplicates.
+
+Two candidates are duplicates ONLY IF:
+- They describe the same problem AND
+- A single code change would fix both (i.e., they would be one bug report)
+
+Two candidates are NOT duplicates if:
+- They describe the same TYPE of bug but in different files, functions, or
+  classes (e.g., "negative slicing in OptimizedCursorPaginator" vs "negative
+  slicing in BasePaginator" are separate issues - fixing one does not fix
+  the other)
+- They describe related but distinct problems (e.g., "returns wrong type" vs
+  "caller crashes because of wrong type" are separate issues)
+
+When in doubt, keep candidates separate - it is better to leave a duplicate
+ungrouped than to incorrectly merge two distinct issues.
+
+Candidates:
+{candidates}
+
+Return ONLY a JSON object where each group is a list of 0-based indices.
+Singletons (no duplicate) must still appear as single-element groups.
+
+Example for 4 candidates where 0 and 2 are duplicates:
+{{"groups": [[0, 2], [1], [3]]}}
+
+Your response:"""
 
 
 class _AsyncHttpClient(Protocol):
@@ -144,6 +179,58 @@ async def run_anthropic_extraction(
     candidates_file.write_text(json.dumps(all_candidates, indent=2))
 
 
+async def run_anthropic_dedup(
+    benchmark_repo: Path,
+    judge_model: str,
+    *,
+    tool: str = _TOOL,
+    client: _AnthropicJsonCompleter,
+) -> None:
+    """Write Martian-compatible dedup groups using direct Anthropic JSON calls."""
+    results_dir = model_results_dir(benchmark_repo, judge_model)
+    candidates_file = results_dir / "candidates.json"
+    if not candidates_file.exists():
+        raise BenchmarkArtifactError(f"{candidates_file} not found; cannot deduplicate benchmark candidates.")
+
+    all_candidates = json.loads(candidates_file.read_text())
+    if not isinstance(all_candidates, dict):
+        raise BenchmarkStepError(f"{candidates_file} must contain a JSON object.")
+
+    groups_file = results_dir / "dedup_groups.json"
+    if groups_file.exists():
+        all_groups = json.loads(groups_file.read_text())
+        if not isinstance(all_groups, dict):
+            raise BenchmarkStepError(f"{groups_file} must contain a JSON object.")
+    else:
+        all_groups = {}
+
+    for golden_url, tools in all_candidates.items():
+        if not isinstance(tools, dict):
+            continue
+        candidates = tools.get(tool)
+        if not isinstance(candidates, list) or len(candidates) < _MIN_DEDUP_CANDIDATES:
+            continue
+
+        texts = _candidate_texts(candidates)
+        if len(texts) < _MIN_DEDUP_CANDIDATES:
+            continue
+
+        try:
+            response = await client.complete_json(
+                system=_DEDUP_SYSTEM,
+                user=_DEDUP_PROMPT.format(candidates=_numbered_candidates(texts)),
+                max_tokens=_MAX_DEDUP_TOKENS,
+            )
+        except Exception:
+            response = None
+        groups = _extract_dedup_groups(response, len(texts)) if isinstance(response, dict) else None
+        if groups is None:
+            groups = _singleton_groups(len(texts))
+        all_groups.setdefault(golden_url, {})[tool] = groups
+
+    groups_file.write_text(json.dumps(all_groups, indent=2))
+
+
 def _get_all_comment_text(review_comments: Any) -> str:
     if not isinstance(review_comments, list):
         return ""
@@ -158,6 +245,45 @@ def _extract_issues(response: dict[str, Any]) -> list[str]:
     if not isinstance(issues, list) or not all(isinstance(issue, str) for issue in issues):
         raise BenchmarkStepError("Anthropic extraction response 'issues' must be a list of strings.")
     return issues
+
+
+def _candidate_texts(candidates: list[Any]) -> list[str]:
+    return [
+        candidate["text"]
+        for candidate in candidates
+        if isinstance(candidate, dict) and isinstance(candidate.get("text"), str) and candidate["text"].strip()
+    ]
+
+
+def _numbered_candidates(texts: list[str]) -> str:
+    return "\n".join(f"{index}. {text}" for index, text in enumerate(texts))
+
+
+def _extract_dedup_groups(response: dict[str, Any], n_candidates: int) -> list[list[int]] | None:
+    groups = response.get("groups")
+    if not isinstance(groups, list):
+        return None
+
+    seen: set[int] = set()
+    parsed_groups: list[list[int]] = []
+    for group in groups:
+        if not isinstance(group, list):
+            return None
+        parsed_group: list[int] = []
+        for idx in group:
+            if not isinstance(idx, int) or idx < 0 or idx >= n_candidates or idx in seen:
+                return None
+            seen.add(idx)
+            parsed_group.append(idx)
+        parsed_groups.append(parsed_group)
+
+    if seen != set(range(n_candidates)):
+        return None
+    return parsed_groups
+
+
+def _singleton_groups(n_candidates: int) -> list[list[int]]:
+    return [[index] for index in range(n_candidates)]
 
 
 async def _complete_json_with_http(

--- a/daydream/benchmark/cli.py
+++ b/daydream/benchmark/cli.py
@@ -19,12 +19,12 @@ if TYPE_CHECKING:
 
 
 def _load_bench_dotenv() -> None:
-    """Load a ``.env`` from the invocation cwd so ``MARTIAN_*`` can live there.
+    """Load a ``.env`` from the invocation cwd so benchmark credentials can live there.
 
     Reads ``.env`` from the operator's current working directory (``usecwd=True``;
-    the library default walks up from this module's file instead). ``override`` is
-    left at its default ``False`` so an inline ``MARTIAN_API_KEY`` still wins over
-    the file. A missing or malformed ``.env`` is a silent no-op.
+    the library default walks up from this module's file instead). ``override``
+    is left at its default ``False`` so inline environment variables still win
+    over the file. A missing or malformed ``.env`` is a silent no-op.
     """
     dotenv.load_dotenv(dotenv.find_dotenv(usecwd=True))
 
@@ -86,9 +86,17 @@ def _build_bench_parser() -> argparse.ArgumentParser:
         type=str,
         default=None,
         dest="model",
-        help="Judge model id (e.g. anthropic/claude-opus-4-5-20251101). If omitted, "
-        "the MARTIAN_MODEL env is used; one of the two is required for --score. "
+        help="Judge model id (e.g. anthropic/claude-opus-4-5-20251101). If omitted, the route-specific "
+        "environment fallback is used; one of the two is required for --score. "
         "Whatever resolves drives both the judge and the per-model results dir.",
+    )
+    parser.add_argument(
+        "--judge-route",
+        type=str,
+        choices=["martian", "anthropic-direct"],
+        default=None,
+        dest="judge_route",
+        help="Benchmark scoring route (default: martian, or [tool.daydream.bench] judge-route)",
     )
     parser.add_argument(
         "--reviewer",
@@ -229,6 +237,9 @@ def _bench_config_from_argv(argv: list[str]) -> "BenchConfig":
         else None
     )
     model = args.model if args.model is not None else bench.get("model")
+    judge_route = args.judge_route if args.judge_route is not None else bench.get("judge-route", "martian")
+    if judge_route not in {"martian", "anthropic-direct"}:
+        parser.error("--judge-route must be one of: martian, anthropic-direct")
     if benchmark_repo is None:
         parser.error("--benchmark-repo is required (pass the flag or set [tool.daydream.bench] benchmark-repo)")
     bench_root = benchmark_repo / ".daydream-bench"
@@ -256,6 +267,7 @@ def _bench_config_from_argv(argv: list[str]) -> "BenchConfig":
         only=args.only,
         limit=args.limit,
         trajectory_dir=trajectory_dir,
+        judge_route=judge_route,
         model=model,
         reviewer_backend=reviewer_backend,
         reviewer_model=reviewer_model,

--- a/daydream/benchmark/config.py
+++ b/daydream/benchmark/config.py
@@ -17,8 +17,11 @@ class BenchConfig:
     Attributes:
         benchmark_repo: Path to the external `code-review-benchmark` checkout.
         cache_dir: Directory for per-PR blobless clones and fetched heads.
-        model: Judge model id; None defers to the MARTIAN_MODEL env. Whatever
-            resolves drives both the judge and the per-model results dir.
+        judge_route: Benchmark scoring route; "martian" preserves the existing
+            OpenAI-compatible Martian path.
+        model: Judge model id; None defers to the selected judge route's
+            environment fallback. Whatever resolves drives both the judge and
+            the per-model results dir.
         reviewer_backend: Optional daydream review backend (claude/codex/pi); None uses the default.
         reviewer_model: Optional model id for the reviewer backend; None uses the backend default.
         reviewer_provider: Optional provider for the reviewer backend (forwarded via env); None uses the default.
@@ -38,6 +41,7 @@ class BenchConfig:
     only: str | None
     limit: int | None
     trajectory_dir: Path
+    judge_route: str = "martian"
     model: str | None = None
     reviewer_backend: str | None = None
     reviewer_model: str | None = None

--- a/daydream/benchmark/orchestrator.py
+++ b/daydream/benchmark/orchestrator.py
@@ -7,8 +7,8 @@ synthetic ``daydream`` review into the corpus.
 
 Path convention: the benchmark corpus is read from and written to
 ``config.benchmark_repo / "results" / "benchmark_data.json"`` (the layout the
-withmartian ``code-review-benchmark`` step modules expect). The corpus is saved
-after every PR so an interrupted sweep is resumable.
+benchmark scoring artifacts expect). The corpus is saved after every PR so an
+interrupted sweep is resumable.
 
 A single PR's failure is logged and recorded but does not abort the sweep; the
 returned exit code is non-zero if any selected PR failed. When ``config.score``
@@ -174,7 +174,13 @@ def run_bench(config: BenchConfig) -> int:
     score_failed = False
     if config.score:
         try:
-            scores = run_scoring(config.benchmark_repo, judge_model, pr_count=len(prs), tool=config.tool_label)
+            scores = run_scoring(
+                config.benchmark_repo,
+                judge_model,
+                pr_count=len(prs),
+                tool=config.tool_label,
+                judge_route=config.judge_route,
+            )
         except Exception as exc:  # noqa: BLE001 - report scoring failure without raising past the CLI
             score_failed = True
             print_error(console, "Scoring failed", f"{type(exc).__name__}: {exc}")

--- a/daydream/benchmark/orchestrator.py
+++ b/daydream/benchmark/orchestrator.py
@@ -123,7 +123,7 @@ def run_bench(config: BenchConfig) -> int:
     """
     judge_model = ""
     if config.score:
-        preflight_judge_env()
+        preflight_judge_env(judge_route=config.judge_route)
         judge_model = resolve_judge_model(config.model)
 
     data_path = _benchmark_data_path(config)

--- a/daydream/benchmark/score.py
+++ b/daydream/benchmark/score.py
@@ -1,7 +1,7 @@
 """Judge-step scoring helpers for the benchmark harness.
 
 Exports:
-    preflight_judge_env: Verify the judge credential is present in the environment.
+    preflight_judge_env: Verify the route-specific judge credential/config is present.
     resolve_judge_model: Resolve the judge model from --model or the MARTIAN_MODEL env.
     model_results_dir: Resolve the per-model results directory for a benchmark repo.
     run_scoring: Run step2/2.5/3 and parse the resulting daydream precision/recall.
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any
 
 JUDGE_API_KEY_ENV = "MARTIAN_API_KEY"
+ANTHROPIC_JUDGE_API_KEY_ENV = "ANTHROPIC_API_KEY"
 JUDGE_MODEL_ENV = "MARTIAN_MODEL"
 JUDGE_BASE_URL_ENV = "MARTIAN_BASE_URL"
 
@@ -56,7 +57,7 @@ _STEP_TIMEOUT = 1800
 
 
 class JudgeEnvError(Exception):
-    """Raised when the judge API credential is absent from the environment."""
+    """Raised when the judge environment is missing or route-inconsistent."""
 
 
 class BenchmarkStepError(Exception):
@@ -79,15 +80,36 @@ class JudgeFailedError(Exception):
     """
 
 
-def preflight_judge_env() -> None:
-    """Verify the judge API credential is present in the process environment.
+def preflight_judge_env(*, judge_route: str = "martian") -> None:
+    """Verify route-specific judge configuration before expensive benchmark work.
 
-    Reads `os.environ` only (no `.env` or secret-file parsing). The credential
-    value is never logged.
+    Reads `os.environ` only (no `.env` or secret-file parsing). Credential values
+    are never logged.
+
+    Args:
+        judge_route: ``"martian"`` for the existing OpenAI-compatible judge path,
+            or ``"anthropic-direct"`` for direct Anthropic scoring preflight.
 
     Raises:
-        JudgeEnvError: If `MARTIAN_API_KEY` is unset or empty.
+        JudgeEnvError: If the route-specific credential is unset or the direct
+            Anthropic route is configured with proxy/OpenAI-compatible settings.
     """
+    if judge_route == "anthropic-direct":
+        key = os.environ.get(ANTHROPIC_JUDGE_API_KEY_ENV)
+        if not key:
+            raise JudgeEnvError(
+                f"{ANTHROPIC_JUDGE_API_KEY_ENV} is not set; export it before running "
+                "the Anthropic-direct judge step."
+            )
+        if key.startswith(_OPENROUTER_KEY_PREFIX):
+            raise JudgeEnvError("OpenRouter key supplied for Anthropic-direct judge")
+        if os.environ.get(JUDGE_BASE_URL_ENV):
+            raise JudgeEnvError(
+                f"{JUDGE_BASE_URL_ENV} is invalid for direct Anthropic scoring; "
+                "unset it when --judge-route anthropic-direct is selected."
+            )
+        return
+
     if not os.environ.get(JUDGE_API_KEY_ENV):
         raise JudgeEnvError(
             f"{JUDGE_API_KEY_ENV} is not set; export it (e.g. an OpenRouter sk-or-… key) "

--- a/daydream/benchmark/score.py
+++ b/daydream/benchmark/score.py
@@ -345,11 +345,12 @@ async def run_anthropic_scoring(
     *,
     pr_count: int | None = None,
     tool: str = _TOOL,
+    client: Any | None = None,
 ) -> DaydreamScores:
     """Lazy bridge to the direct Anthropic scorer, kept patchable for tests."""
     from daydream.benchmark.anthropic_score import run_anthropic_scoring as direct_run_anthropic_scoring
 
-    return await direct_run_anthropic_scoring(benchmark_repo, judge_model, pr_count=pr_count, tool=tool)
+    return await direct_run_anthropic_scoring(benchmark_repo, judge_model, pr_count=pr_count, tool=tool, client=client)
 
 
 def run_scoring(

--- a/daydream/benchmark/score.py
+++ b/daydream/benchmark/score.py
@@ -4,13 +4,14 @@ Exports:
     preflight_judge_env: Verify the route-specific judge credential/config is present.
     resolve_judge_model: Resolve the judge model from --model or the MARTIAN_MODEL env.
     model_results_dir: Resolve the per-model results directory for a benchmark repo.
-    run_scoring: Run step2/2.5/3 and parse the resulting daydream precision/recall.
+    run_scoring: Run the selected judge route and parse the resulting daydream precision/recall.
     parse_daydream_scores: Extract per-PR and aggregate daydream scores from evaluations.
     DaydreamScores: Aggregated daydream scoring result.
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import subprocess
@@ -338,39 +339,59 @@ def _run_step(module: str, extra_args: list[str], *, cwd: Path, tool: str = _TOO
         raise BenchmarkStepError(f"{module} failed (exit {result.returncode}):\n{stderr_tail}")
 
 
-def run_scoring(
-    benchmark_repo: Path, judge_model: str, *, pr_count: int | None = None, tool: str = _TOOL
+async def run_anthropic_scoring(
+    benchmark_repo: Path,
+    judge_model: str,
+    *,
+    pr_count: int | None = None,
+    tool: str = _TOOL,
 ) -> DaydreamScores:
-    """Run step2/2.5/3 against the benchmark repo and parse the tool's scores.
+    """Lazy bridge to the direct Anthropic scorer, kept patchable for tests."""
+    from daydream.benchmark.anthropic_score import run_anthropic_scoring as direct_run_anthropic_scoring
 
-    Runs the three benchmark step modules in order (extract → dedup → judge),
-    each with `--tool <tool>`, `cwd` set to the benchmark checkout, and
-    `MARTIAN_MODEL` exported as ``judge_model``. step3 additionally receives
-    `--dedup-groups` pointing at step2.5's output. Finally loads
-    `evaluations.json` and parses it.
+    return await direct_run_anthropic_scoring(benchmark_repo, judge_model, pr_count=pr_count, tool=tool)
 
-    ``judge_model`` is the single source of truth: it is exported into every
-    step's environment (so the harness writes to `results/<judge_model>`) **and**
-    used to derive the results dir we read from — eliminating any drift between a
-    bench-supplied model string and the model the harness actually ran. Resolve
-    it via `resolve_judge_model` before calling. The judge credential is verified
-    by the caller (``run_bench``) before any expensive reviews run.
+
+def run_scoring(
+    benchmark_repo: Path,
+    judge_model: str,
+    *,
+    pr_count: int | None = None,
+    tool: str = _TOOL,
+    judge_route: str = "martian",
+) -> DaydreamScores:
+    """Run the selected benchmark scoring route and parse the tool's scores.
+
+    The default ``"martian"`` route preserves the OpenAI-compatible subprocess
+    path. The ``"anthropic-direct"`` route runs extraction, deduplication, and
+    judging through Anthropic's Messages API.
+
+    ``judge_model`` is the single source of truth for the per-model results dir.
+    The Martian route also exports it into each step's environment so the harness
+    writes to the same directory this function reads. Resolve it via
+    `resolve_judge_model` before calling. The judge credential is verified by the
+    caller (``run_bench``) before any expensive reviews run.
 
     Args:
         benchmark_repo: Path to the external benchmark checkout.
         judge_model: Resolved judge model id (see `resolve_judge_model`).
-        pr_count: When provided, passed as ``--limit`` to step3 so the judge
-            only evaluates that many PRs.  Use this to bound judge cost when
-            ``--limit`` was passed to the harness.
+        pr_count: When provided, bounds how many PR reviews the judge evaluates
+            (passed as ``--limit`` to Martian step3).
         tool: Results label under evaluation (defaults to ``_TOOL``).
+        judge_route: ``"martian"`` or ``"anthropic-direct"``.
 
     Returns:
         The parsed `DaydreamScores`.
 
     Raises:
-        BenchmarkStepError: If any step exits non-zero.
-        BenchmarkArtifactError: If `evaluations.json` is absent after a successful step3.
+        BenchmarkStepError: If scoring fails.
+        BenchmarkArtifactError: If `evaluations.json` is absent after scoring.
     """
+    if judge_route == "anthropic-direct":
+        return asyncio.run(run_anthropic_scoring(benchmark_repo, judge_model, pr_count=pr_count, tool=tool))
+    if judge_route != "martian":
+        raise BenchmarkStepError(f"Unknown judge route: {judge_route}")
+
     # Resolve to an absolute path: each step runs with ``cwd`` set to the
     # benchmark checkout, so any path handed to a step as an argument (notably
     # step3's ``--dedup-groups``) is re-interpreted against that cwd. A

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -10,18 +10,30 @@ This runbook takes you from nothing to a scored result.
 - **`daydream` installed.** Run `uv sync` so the `daydream` console script is on `PATH` (the harness invokes it as a subprocess).
 - **`git` and `gh` on `PATH`.** `git` performs the blobless clone and `pull/N/head` fetch per PR.
 - **The Beagle plugin** installed in Claude Code (see the [Quickstart](../README.md#quickstart)). Deep review needs the stack-specific skills.
-- **A backend for the reviewer under test.** By default the reviewer runs daydream's built-in default backend (Claude). To benchmark another backend, select it with `--reviewer-backend` (see [Selecting the reviewer backend](#selecting-the-reviewer-backend)). The `pi` backend driving a GLM model over OpenRouter additionally needs the `pi` CLI on `PATH` and the OpenRouter provider extension registered with `pi` (installed once via `pi install`); the run forwards `--reviewer-provider` to the reviewer as the `PI_PROVIDER` environment variable.
-- **Scoring credential, exported.** Scoring requires one env var and accepts two optional overrides:
-  - `MARTIAN_API_KEY`: an OpenRouter `sk-or-…` key (or a withmartian key). **Required for `--score`.**
-  - `MARTIAN_BASE_URL`: the OpenAI-compatible judge endpoint. Defaults to `https://api.withmartian.com/v1` (default set by the withmartian step modules, not by daydream); set to `https://openrouter.ai/api/v1` when using an OpenRouter key.
-  - `MARTIAN_MODEL`: the judge model id. Defaults to `openai/gpt-4o-mini` (default set by the withmartian step modules, not by daydream); should match `--model` for comparable results.
+- **A backend for the reviewer under test.** By default the reviewer runs daydream's built-in default backend (Claude), using the normal credentials for that backend. To benchmark another reviewer, select it with `--reviewer-backend` and optionally `--reviewer-model` / `--reviewer-provider` (see [Selecting the reviewer backend](#selecting-the-reviewer-backend)). These reviewer settings are separate from the judge route and judge `--model`. The `pi` backend driving a GLM model over OpenRouter additionally needs the `pi` CLI on `PATH` and the OpenRouter provider extension registered with `pi` (installed once via `pi install`); the run forwards `--reviewer-provider` to the reviewer as the `PI_PROVIDER` environment variable.
+- **A judge route and judge credential.** Scoring is controlled by `--judge-route` and the judge `--model`; this is independent of the reviewer backend/model that produced the findings.
 
-  These may live in a `.env` file in the directory you run `daydream bench` from; it is auto-loaded at bench entry (`python-dotenv`, searching from the cwd upward). Already-exported shell variables win, so an inline `MARTIAN_API_KEY=… daydream bench …` still overrides the `.env`; a missing or malformed `.env` is a silent no-op.
+  `--judge-route martian` is the default, backward-compatible OpenAI-compatible Martian/OpenRouter route. It drives the benchmark step2/2.5/3 modules through their OpenAI Chat Completions-compatible client.
+  - `MARTIAN_API_KEY`: an OpenRouter `sk-or-...` key (or a withmartian key). Required for `--score` on this route.
+  - `MARTIAN_BASE_URL`: the OpenAI-compatible judge endpoint. Defaults to `https://api.withmartian.com/v1` (default set by the withmartian step modules, not by daydream); set to `https://openrouter.ai/api/v1` when using an OpenRouter key.
+  - `MARTIAN_MODEL`: the judge model id fallback when `--model` is omitted. Defaults to `openai/gpt-4o-mini` in the withmartian step modules.
+
+  `--judge-route anthropic-direct` sends scoring calls directly to the Anthropic Messages API for extraction, deduplication, and final judging. It is not a `MARTIAN_BASE_URL` setting and it is not an OpenAI-compatible proxy route.
+  - `ANTHROPIC_API_KEY`: required for `--score` on this route.
+  - `--model`: the Anthropic judge model id, for example `claude-opus-4-5-20251101`. If omitted, `MARTIAN_MODEL` is used as the judge model fallback and result-directory label.
+  - `MARTIAN_BASE_URL is invalid` for direct Anthropic scoring. Unset it when selecting `--judge-route anthropic-direct`; `https://api.anthropic.com` is not an OpenAI Chat Completions-compatible endpoint.
+
+  These env vars may live in a `.env` file in the directory you run `daydream bench` from; it is auto-loaded at bench entry (`python-dotenv`, searching from the cwd upward). Already-exported shell variables win, so an inline `ANTHROPIC_API_KEY=... daydream bench ...` still overrides the `.env`; a missing or malformed `.env` is a silent no-op.
 
   ```bash
-  # .env beside your invocation
-  MARTIAN_API_KEY=sk-or-…
+  # .env beside your invocation, OpenAI-compatible Martian/OpenRouter judge route
+  MARTIAN_API_KEY=sk-or-...
+  MARTIAN_BASE_URL=https://openrouter.ai/api/v1
   MARTIAN_MODEL=anthropic/claude-opus-4-5-20251101
+
+  # .env beside your invocation, direct Anthropic judge route
+  ANTHROPIC_API_KEY=sk-ant-...
+  MARTIAN_MODEL=claude-opus-4-5-20251101
   ```
 
 ## Configuration file (`[tool.daydream.bench]`)
@@ -32,6 +44,7 @@ Repeating `--benchmark-repo`, the scoring `--model`, and the full reviewer flag 
 [tool.daydream.bench]
 benchmark-repo = "../code-review-benchmark/offline"   # makes --benchmark-repo optional
 model = "anthropic/claude-opus-4-5-20251101"           # scoring model when --model is omitted
+judge-route = "martian"                               # or "anthropic-direct"
 
 # Named reviewer presets: each expands to --reviewer-backend / -model / -provider.
 [tool.daydream.bench.reviewers.glm]
@@ -52,7 +65,7 @@ With the table above, the full GLM sweep over one PR collapses to:
 daydream bench --reviewer glm --only grafana --limit 1
 ```
 
-`benchmark-repo` and the scoring `model` come from config; `--reviewer glm` supplies the backend/model/provider and the `daydream-glm` label. (Scoring is on by default, so `MARTIAN_API_KEY` must be present; see [Prerequisites](#prerequisites).)
+`benchmark-repo`, `judge-route`, and the scoring `model` come from config; `--reviewer glm` supplies the backend/model/provider and the `daydream-glm` label. (Scoring is on by default, so the selected judge route's credential must be present; see [Prerequisites](#prerequisites).)
 
 ## Smoke subset
 
@@ -64,10 +77,21 @@ Wire the pipeline cheaply before spending on the paid judge. Run two Grafana PRs
 daydream bench --benchmark-repo ../code-review-benchmark/offline --only grafana --limit 2 --no-score
 ```
 
-This acquires the checkouts, runs deep review, and injects two `daydream` reviews into `benchmark_data.json`; no judge calls. When the wiring looks right, add the judge:
+This acquires the checkouts, runs deep review, and injects two `daydream` reviews into `benchmark_data.json`; no judge calls. When the wiring looks right, add the default OpenAI-compatible Martian/OpenRouter judge:
 
 ```bash
-daydream bench --benchmark-repo ../code-review-benchmark/offline --only grafana --limit 2 --score
+daydream bench --benchmark-repo ../code-review-benchmark/offline \
+  --judge-route martian \
+  --only grafana --limit 2 --score
+```
+
+For direct Anthropic scoring, keep the default Claude reviewer and select the Anthropic Messages API judge route explicitly:
+
+```bash
+daydream bench --benchmark-repo ../code-review-benchmark/offline \
+  --judge-route anthropic-direct \
+  --model claude-opus-4-5-20251101 \
+  --only grafana --limit 2 --score
 ```
 
 `--only` matches a source-repo name (`sentry`, `grafana`, `cal.com`) or a golden-URL substring. `--limit N` caps how many of the selected PRs run.
@@ -77,7 +101,18 @@ daydream bench --benchmark-repo ../code-review-benchmark/offline --only grafana 
 Drop `--only` and `--limit` to run all 26 evaluable PRs:
 
 ```bash
-daydream bench --benchmark-repo ../code-review-benchmark/offline --score
+daydream bench --benchmark-repo ../code-review-benchmark/offline \
+  --judge-route martian \
+  --score
+```
+
+Full sweep with the default Claude reviewer and direct Anthropic judge:
+
+```bash
+daydream bench --benchmark-repo ../code-review-benchmark/offline \
+  --judge-route anthropic-direct \
+  --model claude-opus-4-5-20251101 \
+  --score
 ```
 
 This is the load-bearing, money-spending run: 26 deep reviews plus 26 judge passes.
@@ -133,7 +168,7 @@ For each scored PR the harness writes a leaf (keyed by the reviewer's `--tool-la
 <benchmark-repo>/results/<sanitized-model>/evaluations.json
 ```
 
-`<sanitized-model>` is the `--model` (judge) id with `/` replaced by `_`. For the default judge the directory is `results/anthropic_claude-opus-4.5/` (the dot is preserved). Inside each PR's entry the scores are filed under the reviewer's `--tool-label` (default `daydream`; e.g. `daydream-glm` for a GLM reviewer). Each leaf carries `tp`, `fp`, `fn`, `precision`, and `recall` for that PR.
+`<sanitized-model>` is the resolved judge model id with `/` replaced by `_`; `--model` wins over the route-specific environment fallback. Inside each PR's entry the scores are filed under the reviewer's `--tool-label` (default `daydream`; e.g. `daydream-glm` for a GLM reviewer). Each leaf carries `tp`, `fp`, `fn`, `precision`, and `recall` for that PR. Leaves produced by `--judge-route anthropic-direct` also carry `judge_route: "anthropic-direct"`.
 
 The command also prints to stdout:
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -21,7 +21,7 @@ This runbook takes you from nothing to a scored result.
   `--judge-route anthropic-direct` sends scoring calls directly to the Anthropic Messages API for extraction, deduplication, and final judging. It is not a `MARTIAN_BASE_URL` setting and it is not an OpenAI-compatible proxy route.
   - `ANTHROPIC_API_KEY`: required for `--score` on this route.
   - `--model`: the Anthropic judge model id, for example `claude-opus-4-5-20251101`. If omitted, `MARTIAN_MODEL` is used as the judge model fallback and result-directory label.
-  - `MARTIAN_BASE_URL is invalid` for direct Anthropic scoring. Unset it when selecting `--judge-route anthropic-direct`; `https://api.anthropic.com` is not an OpenAI Chat Completions-compatible endpoint.
+  - `MARTIAN_BASE_URL` is invalid for direct Anthropic scoring. Unset it when selecting `--judge-route anthropic-direct`; `https://api.anthropic.com` is not an OpenAI Chat Completions-compatible endpoint.
 
   These env vars may live in a `.env` file in the directory you run `daydream bench` from; it is auto-loaded at bench entry (`python-dotenv`, searching from the cwd upward). Already-exported shell variables win, so an inline `ANTHROPIC_API_KEY=... daydream bench ...` still overrides the `.env`; a missing or malformed `.env` is a silent no-op.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "pyfiglet>=1.0",
     "pydantic>=2.11.7",
     "python-dotenv>=1.0",
+    "httpx>=0.28",
     "PyJWT>=2.0",
     "jsonschema>=4.0",
     "tree-sitter==0.25.2",

--- a/tests/test_benchmark_anthropic_score.py
+++ b/tests/test_benchmark_anthropic_score.py
@@ -2,7 +2,12 @@ import json
 
 import pytest
 
-from daydream.benchmark.anthropic_score import AnthropicJsonClient, run_anthropic_dedup, run_anthropic_extraction
+from daydream.benchmark.anthropic_score import (
+    AnthropicJsonClient,
+    run_anthropic_dedup,
+    run_anthropic_extraction,
+    run_anthropic_scoring,
+)
 from daydream.benchmark.score import model_results_dir
 
 URL = "https://x/pull/1"
@@ -23,6 +28,7 @@ def seed_benchmark_data(tmp_path, *, tool, body):
         json.dumps(
             {
                 URL: {
+                    "golden_comments": [{"comment": body, "severity": "medium"}],
                     "reviews": [
                         {
                             "tool": tool,
@@ -43,6 +49,12 @@ def seed_candidates(tmp_path, *, model, tool, texts):
     (scores_dir / "candidates.json").write_text(
         json.dumps({URL: {tool: [{"text": text, "path": None, "line": None} for text in texts]}})
     )
+
+
+def seed_dedup_groups(tmp_path, *, model, tool, groups):
+    scores_dir = model_results_dir(tmp_path, model)
+    scores_dir.mkdir(parents=True, exist_ok=True)
+    (scores_dir / "dedup_groups.json").write_text(json.dumps({URL: {tool: groups}}))
 
 
 class FakeResponse:
@@ -107,3 +119,27 @@ async def test_direct_dedup_invalid_response_uses_singletons(tmp_path):
 
     groups = json.loads((model_results_dir(tmp_path, "claude-opus-4-5-20251101") / "dedup_groups.json").read_text())
     assert groups[URL]["daydream"] == [[0], [1]]
+
+
+@pytest.mark.asyncio
+async def test_direct_judge_writes_evaluations_and_metadata(tmp_path):
+    seed_benchmark_data(tmp_path, tool="daydream", body="candidate")
+    seed_candidates(tmp_path, model="claude-opus-4-5-20251101", tool="daydream", texts=["candidate"])
+    seed_dedup_groups(tmp_path, model="claude-opus-4-5-20251101", tool="daydream", groups=[[0]])
+    client = FakeAnthropicJson([{"reasoning": "same bug", "match": True, "confidence": 0.91}])
+
+    scores = await run_anthropic_scoring(
+        tmp_path,
+        "claude-opus-4-5-20251101",
+        pr_count=1,
+        tool="daydream",
+        client=client,
+    )
+
+    assert scores.scored_pr_count == 1
+    assert scores.total_tp == 1 and scores.total_fp == 0 and scores.total_fn == 0
+    evals = json.loads((model_results_dir(tmp_path, "claude-opus-4-5-20251101") / "evaluations.json").read_text())
+    leaf = evals[URL]["daydream"]
+    assert leaf["judge_route"] == "anthropic-direct"
+    assert leaf["judge_model"] == "claude-opus-4-5-20251101"
+    assert leaf["tp"] == 1 and leaf["precision"] == 1.0 and leaf["recall"] == 1.0

--- a/tests/test_benchmark_anthropic_score.py
+++ b/tests/test_benchmark_anthropic_score.py
@@ -1,6 +1,40 @@
+import json
+
 import pytest
 
-from daydream.benchmark.anthropic_score import AnthropicJsonClient
+from daydream.benchmark.anthropic_score import AnthropicJsonClient, run_anthropic_extraction
+from daydream.benchmark.score import model_results_dir
+
+URL = "https://x/pull/1"
+
+
+class FakeAnthropicJson:
+    def __init__(self, responses):
+        self._responses = list(responses)
+
+    async def complete_json(self, *, system, user, max_tokens):
+        return self._responses.pop(0)
+
+
+def seed_benchmark_data(tmp_path, *, tool, body):
+    results = tmp_path / "results"
+    results.mkdir()
+    (results / "benchmark_data.json").write_text(
+        json.dumps(
+            {
+                URL: {
+                    "reviews": [
+                        {
+                            "tool": tool,
+                            "repo_name": "repo",
+                            "pr_url": URL,
+                            "review_comments": [{"body": body}],
+                        }
+                    ]
+                }
+            }
+        )
+    )
 
 
 class FakeResponse:
@@ -29,3 +63,17 @@ async def test_anthropic_json_client_posts_messages_and_parses_json():
     assert calls[0][1]["x-api-key"] == "sk-ant-x"
     assert calls[0][2]["model"] == "claude-opus-4-5-20251101"
     assert calls[0][2]["temperature"] == 0
+
+
+@pytest.mark.asyncio
+async def test_direct_extraction_writes_martian_candidates(tmp_path):
+    seed_benchmark_data(tmp_path, tool="daydream", body="Bug one.\n\nBug two in cache keys.")
+    client = FakeAnthropicJson([{"issues": ["Bug one", "Bug two"]}])
+
+    scores_dir = model_results_dir(tmp_path, "claude-opus-4-5-20251101")
+    await run_anthropic_extraction(tmp_path, "claude-opus-4-5-20251101", tool="daydream", client=client)
+
+    candidates = json.loads((scores_dir / "candidates.json").read_text())
+    leaf = candidates[URL]["daydream"]
+    assert [c["text"] for c in leaf] == ["Bug one", "Bug two"]
+    assert all(c["source"] == "extracted" and c["path"] is None and c["line"] is None for c in leaf)

--- a/tests/test_benchmark_anthropic_score.py
+++ b/tests/test_benchmark_anthropic_score.py
@@ -143,3 +143,26 @@ async def test_direct_judge_writes_evaluations_and_metadata(tmp_path):
     assert leaf["judge_route"] == "anthropic-direct"
     assert leaf["judge_model"] == "claude-opus-4-5-20251101"
     assert leaf["tp"] == 1 and leaf["precision"] == 1.0 and leaf["recall"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_direct_route_artifacts_are_martian_compatible(tmp_path):
+    seed_benchmark_data(tmp_path, tool="daydream", body="candidate")
+    client = FakeAnthropicJson(
+        [
+            {"issues": ["candidate"]},
+            {"reasoning": "same", "match": True, "confidence": 1.0},
+        ]
+    )
+    scores = await run_anthropic_scoring(
+        tmp_path,
+        "claude-opus-4-5-20251101",
+        pr_count=1,
+        tool="daydream",
+        client=client,
+    )
+    model_dir = model_results_dir(tmp_path, "claude-opus-4-5-20251101")
+    assert (model_dir / "candidates.json").exists()
+    assert (model_dir / "dedup_groups.json").exists()
+    assert (model_dir / "evaluations.json").exists()
+    assert scores.total_tp == 1

--- a/tests/test_benchmark_anthropic_score.py
+++ b/tests/test_benchmark_anthropic_score.py
@@ -1,0 +1,31 @@
+import pytest
+
+from daydream.benchmark.anthropic_score import AnthropicJsonClient
+
+
+class FakeResponse:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = str(payload)
+
+    def json(self):
+        return self._payload
+
+
+@pytest.mark.asyncio
+async def test_anthropic_json_client_posts_messages_and_parses_json():
+    calls = []
+
+    class FakeClient:
+        async def post(self, url, *, headers, json, timeout):
+            calls.append((url, headers, json, timeout))
+            return FakeResponse(200, {"content": [{"type": "text", "text": '{"issues":["x"]}'}]})
+
+    client = AnthropicJsonClient(api_key="sk-ant-x", model="claude-opus-4-5-20251101", http=FakeClient())
+    result = await client.complete_json(system="extract", user="return json", max_tokens=128)
+    assert result == {"issues": ["x"]}
+    assert calls[0][0] == "https://api.anthropic.com/v1/messages"
+    assert calls[0][1]["x-api-key"] == "sk-ant-x"
+    assert calls[0][2]["model"] == "claude-opus-4-5-20251101"
+    assert calls[0][2]["temperature"] == 0

--- a/tests/test_benchmark_anthropic_score.py
+++ b/tests/test_benchmark_anthropic_score.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from daydream.benchmark.anthropic_score import AnthropicJsonClient, run_anthropic_extraction
+from daydream.benchmark.anthropic_score import AnthropicJsonClient, run_anthropic_dedup, run_anthropic_extraction
 from daydream.benchmark.score import model_results_dir
 
 URL = "https://x/pull/1"
@@ -34,6 +34,14 @@ def seed_benchmark_data(tmp_path, *, tool, body):
                 }
             }
         )
+    )
+
+
+def seed_candidates(tmp_path, *, model, tool, texts):
+    scores_dir = model_results_dir(tmp_path, model)
+    scores_dir.mkdir(parents=True)
+    (scores_dir / "candidates.json").write_text(
+        json.dumps({URL: {tool: [{"text": text, "path": None, "line": None} for text in texts]}})
     )
 
 
@@ -77,3 +85,25 @@ async def test_direct_extraction_writes_martian_candidates(tmp_path):
     leaf = candidates[URL]["daydream"]
     assert [c["text"] for c in leaf] == ["Bug one", "Bug two"]
     assert all(c["source"] == "extracted" and c["path"] is None and c["line"] is None for c in leaf)
+
+
+@pytest.mark.asyncio
+async def test_direct_dedup_writes_groups_and_falls_back_to_singletons(tmp_path):
+    seed_candidates(tmp_path, model="claude-opus-4-5-20251101", tool="daydream", texts=["same bug", "same issue"])
+    client = FakeAnthropicJson([{"groups": [[0, 1]]}])
+
+    await run_anthropic_dedup(tmp_path, "claude-opus-4-5-20251101", tool="daydream", client=client)
+
+    groups = json.loads((model_results_dir(tmp_path, "claude-opus-4-5-20251101") / "dedup_groups.json").read_text())
+    assert groups[URL]["daydream"] == [[0, 1]]
+
+
+@pytest.mark.asyncio
+async def test_direct_dedup_invalid_response_uses_singletons(tmp_path):
+    seed_candidates(tmp_path, model="claude-opus-4-5-20251101", tool="daydream", texts=["a", "b"])
+    client = FakeAnthropicJson([{"groups": [[0, 0]]}])
+
+    await run_anthropic_dedup(tmp_path, "claude-opus-4-5-20251101", tool="daydream", client=client)
+
+    groups = json.loads((model_results_dir(tmp_path, "claude-opus-4-5-20251101") / "dedup_groups.json").read_text())
+    assert groups[URL]["daydream"] == [[0], [1]]

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -225,6 +225,14 @@ def test_direct_anthropic_preflight_fails_through_compiled_entrypoint(tmp_path):
     assert r.returncode != 0 and "ANTHROPIC_API_KEY" in (r.stdout + r.stderr)
 
 
+def test_benchmark_docs_name_direct_anthropic_judge_route():
+    text = Path("docs/benchmark.md").read_text()
+    assert "--judge-route anthropic-direct" in text
+    assert "ANTHROPIC_API_KEY" in text
+    assert "MARTIAN_BASE_URL is invalid" in text
+    assert "--reviewer-backend" in text and "--model" in text
+
+
 def test_bench_dotenv_autoloads_credential_through_compiled_entrypoint(tmp_path):
     (tmp_path / ".env").write_text("MARTIAN_API_KEY=sk-from-dotenv\n")
     env = {**os.environ}

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -32,7 +32,19 @@ def test_bench_parser_defaults_and_flags(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     cfg = _bench_config_from_argv(["--benchmark-repo", "/b", "--only", "grafana", "--no-score"])
     assert cfg.benchmark_repo == Path("/b") and cfg.only == "grafana" and cfg.score is False
-    assert cfg.model is None  # no hardcoded default; judge model comes from --model or MARTIAN_MODEL
+    assert cfg.model is None  # no hardcoded default; judge model comes from --model or route-specific env
+
+
+def test_bench_parser_accepts_direct_anthropic_judge_route(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    cfg = _bench_config_from_argv([
+        "--benchmark-repo", "/b",
+        "--judge-route", "anthropic-direct",
+        "--model", "claude-opus-4-5-20251101",
+        "--no-score",
+    ])
+    assert cfg.judge_route == "anthropic-direct"
+    assert cfg.model == "claude-opus-4-5-20251101"
 
 
 def test_bench_config_has_reviewer_defaults(tmp_path, monkeypatch):
@@ -60,6 +72,15 @@ def test_config_supplies_benchmark_repo_when_flag_omitted(tmp_path, monkeypatch)
     monkeypatch.chdir(tmp_path)
     cfg = _bench_config_from_argv(["--no-score"])  # no --benchmark-repo
     assert cfg.benchmark_repo == Path("/from/config")
+
+
+def test_config_supplies_judge_route_when_flag_omitted(tmp_path, monkeypatch):
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.daydream.bench]\nbenchmark-repo="/b"\njudge-route="anthropic-direct"\n'
+    )
+    monkeypatch.chdir(tmp_path)
+    cfg = _bench_config_from_argv(["--no-score"])
+    assert cfg.judge_route == "anthropic-direct"
 
 
 def test_missing_benchmark_repo_everywhere_errors(tmp_path, monkeypatch):

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -229,7 +229,7 @@ def test_benchmark_docs_name_direct_anthropic_judge_route():
     text = Path("docs/benchmark.md").read_text()
     assert "--judge-route anthropic-direct" in text
     assert "ANTHROPIC_API_KEY" in text
-    assert "MARTIAN_BASE_URL is invalid" in text
+    assert "`MARTIAN_BASE_URL` is invalid" in text
     assert "--reviewer-backend" in text and "--model" in text
 
 

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -204,6 +204,27 @@ def test_bench_subcommand_preflights_through_compiled_entrypoint(tmp_path):
     assert r.returncode != 0 and "MARTIAN_API_KEY" in (r.stdout + r.stderr)
 
 
+def test_direct_anthropic_preflight_fails_through_compiled_entrypoint(tmp_path):
+    env = {**os.environ, "MARTIAN_MODEL": "claude-opus-4-5-20251101"}
+    env.pop("ANTHROPIC_API_KEY", None)
+    r = subprocess.run(  # noqa: S603 - args are not user-controlled
+        [  # noqa: S607 - daydream is a trusted command
+            "daydream",
+            "bench",
+            "--benchmark-repo",
+            str(tmp_path),
+            "--judge-route",
+            "anthropic-direct",
+            "--score",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=tmp_path,
+    )
+    assert r.returncode != 0 and "ANTHROPIC_API_KEY" in (r.stdout + r.stderr)
+
+
 def test_bench_dotenv_autoloads_credential_through_compiled_entrypoint(tmp_path):
     (tmp_path / ".env").write_text("MARTIAN_API_KEY=sk-from-dotenv\n")
     env = {**os.environ}

--- a/tests/test_benchmark_e2e.py
+++ b/tests/test_benchmark_e2e.py
@@ -1,16 +1,20 @@
 """Manual end-to-end acceptance test for the ``daydream bench`` pipeline.
 
-This test is SKIPPED BY DEFAULT: a real run spends money (two daydream deep
-reviews driven by local Claude credentials plus OpenRouter judge calls) and
-takes many minutes over the network. It is committed as executable
-documentation of the Task 11 acceptance procedure, so the real-path contract
-is reproducible by hand:
+This test module is SKIPPED BY DEFAULT: real runs spend money (daydream deep
+reviews driven by local reviewer credentials plus real judge calls) and take
+minutes over the network. It is committed as executable documentation of the
+manual benchmark acceptance procedures, so the real-path contracts are
+reproducible by hand:
 
     set -a; source daydream/.env; set +a
     export MARTIAN_BASE_URL=https://openrouter.ai/api/v1
     export MARTIAN_MODEL=anthropic/claude-opus-4.5
     DAYDREAM_BENCH_E2E_REPO=/path/to/code-review-benchmark/offline \\
         pytest tests/test_benchmark_e2e.py -s --no-skip   # (drop the skip mark)
+
+For direct Anthropic judge acceptance, export ``ANTHROPIC_API_KEY`` and run
+``test_bench_acceptance_direct_anthropic_judge_real_run`` after removing the
+module-level skip mark.
 
 See ``docs/benchmark.md`` and
 ``.beagle/concepts/code-review-benchmark-harness/research/smoke-run.md`` for the
@@ -142,6 +146,25 @@ def test_bench_acceptance_2pr_subset_real_run():
     after = data_path.read_text()
     assert json.loads(after) == json.loads(before), "re-run mutated the corpus (not incremental)"
     assert len(_grafana_daydream_reviews(json.loads(after))) == 2
+
+
+def test_bench_acceptance_direct_anthropic_judge_real_run():
+    repo_env = os.environ.get("DAYDREAM_BENCH_E2E_REPO")
+    assert repo_env, "set DAYDREAM_BENCH_E2E_REPO to the code-review-benchmark/offline checkout"
+    assert os.environ.get("ANTHROPIC_API_KEY"), "export ANTHROPIC_API_KEY before running"
+    repo = Path(repo_env)
+    model = os.environ.get("MARTIAN_MODEL", "claude-opus-4-5-20251101")
+    cmd = [
+        "daydream", "bench", "--benchmark-repo", str(repo),
+        "--judge-route", "anthropic-direct",
+        "--model", model,
+        "--only", "grafana", "--limit", "1", "--score",
+    ]
+    first = subprocess.run(cmd, capture_output=True, text=True, env=os.environ.copy())
+    assert first.returncode == 0, f"direct Anthropic run failed: {first.stdout}\n{first.stderr}"
+    evals = json.loads((repo / "results" / model.replace("/", "_") / "evaluations.json").read_text())
+    leaves = {url: tools["daydream"] for url, tools in evals.items() if "daydream" in tools}
+    assert leaves and all(leaf.get("judge_route") == "anthropic-direct" for leaf in leaves.values())
 
 
 def test_bench_acceptance_glm_reviewer_real_run():

--- a/tests/test_benchmark_orchestrator.py
+++ b/tests/test_benchmark_orchestrator.py
@@ -183,6 +183,7 @@ def test_direct_anthropic_preflight_runs_before_review(tmp_path, monkeypatch):
 def test_orchestrator_passes_judge_route_to_scoring(tmp_path, monkeypatch):
     data_path = _seed_benchmark_data_with_all_26_keys(tmp_path)
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-direct")
+    monkeypatch.delenv("MARTIAN_BASE_URL", raising=False)
     monkeypatch.setenv("MARTIAN_MODEL", "claude-opus-4-5-20251101")
     monkeypatch.setattr("daydream.benchmark.orchestrator.acquire_checkout", lambda *a, **k: _fake_checkout(tmp_path))
     monkeypatch.setattr(

--- a/tests/test_benchmark_orchestrator.py
+++ b/tests/test_benchmark_orchestrator.py
@@ -14,6 +14,7 @@ from rich.console import Console
 from daydream.benchmark.config import BenchConfig
 from daydream.benchmark.orchestrator import run_bench
 from daydream.benchmark.prs import load_evaluable_prs
+from daydream.benchmark.score import DaydreamScores
 
 
 def _item(file: str, line: int, **kw: Any) -> dict[str, Any]:
@@ -177,6 +178,28 @@ def test_direct_anthropic_preflight_runs_before_review(tmp_path, monkeypatch):
     with pytest.raises(Exception, match="ANTHROPIC_API_KEY"):
         run_bench(cfg)
     assert calls["review"] == 0
+
+
+def test_orchestrator_passes_judge_route_to_scoring(tmp_path, monkeypatch):
+    data_path = _seed_benchmark_data_with_all_26_keys(tmp_path)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-direct")
+    monkeypatch.setenv("MARTIAN_MODEL", "claude-opus-4-5-20251101")
+    monkeypatch.setattr("daydream.benchmark.orchestrator.acquire_checkout", lambda *a, **k: _fake_checkout(tmp_path))
+    monkeypatch.setattr(
+        "daydream.benchmark.orchestrator.run_daydream_review",
+        lambda checkout, **k: _write_items(checkout, [_item("f.py", 1)]),
+    )
+    captured = {}
+
+    def fake_score(repo, model, *, pr_count, tool, judge_route):
+        captured.update(model=model, pr_count=pr_count, tool=tool, judge_route=judge_route)
+        return DaydreamScores(scored_pr_count=1, total_tp=1, precision=1.0, recall=1.0)
+
+    monkeypatch.setattr("daydream.benchmark.orchestrator.run_scoring", fake_score)
+    cfg = replace(_config(tmp_path, data_path, score=True, only="grafana"), limit=1, judge_route="anthropic-direct")
+    assert run_bench(cfg) == 0
+    assert captured["judge_route"] == "anthropic-direct"
+    assert captured["pr_count"] == 1
 
 
 def test_rerun_skips_already_injected_unless_forced(tmp_path, monkeypatch):

--- a/tests/test_benchmark_orchestrator.py
+++ b/tests/test_benchmark_orchestrator.py
@@ -8,6 +8,7 @@ from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
+import pytest
 from rich.console import Console
 
 from daydream.benchmark.config import BenchConfig
@@ -162,6 +163,20 @@ def test_orchestrator_forwards_reviewer_fields(tmp_path, monkeypatch):
     cfg = replace(cfg, reviewer_backend="pi", reviewer_model="glm-5.2", reviewer_provider="openrouter")
     run_bench(cfg)
     assert (captured["backend"], captured["model"], captured["provider"]) == ("pi", "glm-5.2", "openrouter")
+
+
+def test_direct_anthropic_preflight_runs_before_review(tmp_path, monkeypatch):
+    data_path = _seed_benchmark_data_with_all_26_keys(tmp_path)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    calls = {"review": 0}
+    monkeypatch.setattr(
+        "daydream.benchmark.orchestrator.run_daydream_review",
+        lambda *a, **k: calls.__setitem__("review", 1),
+    )
+    cfg = replace(_config(tmp_path, data_path, score=True, only="grafana"), judge_route="anthropic-direct")
+    with pytest.raises(Exception, match="ANTHROPIC_API_KEY"):
+        run_bench(cfg)
+    assert calls["review"] == 0
 
 
 def test_rerun_skips_already_injected_unless_forced(tmp_path, monkeypatch):

--- a/tests/test_benchmark_score.py
+++ b/tests/test_benchmark_score.py
@@ -7,6 +7,7 @@ from daydream.benchmark.score import (
     JUDGE_BASE_URL_ENV,
     JUDGE_MODEL_ENV,
     BenchmarkArtifactError,
+    DaydreamScores,
     JudgeEnvError,
     JudgeFailedError,
     model_results_dir,
@@ -66,6 +67,25 @@ def test_resolve_judge_model(monkeypatch):
         resolve_judge_model(None)  # no hardcoded default
     monkeypatch.setenv(JUDGE_MODEL_ENV, "anthropic/claude-opus-4-5-20251101")
     assert resolve_judge_model(None) == "anthropic/claude-opus-4-5-20251101"
+
+
+def test_run_scoring_dispatches_to_anthropic_direct(tmp_path, monkeypatch):
+    called = {}
+
+    async def fake_direct(repo, model, *, pr_count, tool):
+        called.update(repo=repo, model=model, pr_count=pr_count, tool=tool)
+        return DaydreamScores(scored_pr_count=1, total_tp=1, precision=1.0, recall=1.0)
+
+    monkeypatch.setattr("daydream.benchmark.score.run_anthropic_scoring", fake_direct)
+    scores = run_scoring(
+        tmp_path,
+        "claude-opus-4-5-20251101",
+        pr_count=1,
+        tool="daydream",
+        judge_route="anthropic-direct",
+    )
+    assert called == {"repo": tmp_path, "model": "claude-opus-4-5-20251101", "pr_count": 1, "tool": "daydream"}
+    assert scores.scored_pr_count == 1
 
 
 def test_run_scoring_passes_custom_tool_and_judge_env_to_each_step(tmp_path, monkeypatch):

--- a/tests/test_benchmark_score.py
+++ b/tests/test_benchmark_score.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -113,6 +114,30 @@ def test_run_scoring_passes_custom_tool_and_judge_env_to_each_step(tmp_path, mon
 
 def test_model_results_dir_sanitizes_slashes(tmp_path):
     assert model_results_dir(tmp_path, "anthropic/claude-opus-4.5").name == "anthropic_claude-opus-4.5"
+
+
+def test_scoring_routes_share_model_dir_and_score_parser_contract(tmp_path, monkeypatch):
+    model = "claude-opus-4-5-20251101"
+    direct_dir = model_results_dir(tmp_path, model)
+    direct_dir.mkdir(parents=True)
+    (direct_dir / "evaluations.json").write_text(
+        json.dumps(
+            {
+                URL: {
+                    "daydream": {
+                        "tp": 1,
+                        "fp": 0,
+                        "fn": 0,
+                        "total_candidates": 1,
+                        "total_golden": 1,
+                    }
+                }
+            }
+        )
+    )
+    scores = parse_daydream_scores(json.loads((direct_dir / "evaluations.json").read_text()))
+    assert scores.scored_pr_count == 1
+    assert direct_dir.name == "claude-opus-4-5-20251101"
 
 
 def test_preflight_raises_when_key_unset(monkeypatch):
@@ -263,10 +288,9 @@ def test_run_scoring_raises_judge_failed_when_evaluations_all_errored(tmp_path, 
     model = "anthropic/claude-opus-4-5-20251101"
     rdir = tmp_path / "results" / "anthropic_claude-opus-4-5-20251101"
     rdir.mkdir(parents=True)
-    import json as _json
 
     def fake_run(cmd, **k):
-        (rdir / "evaluations.json").write_text(_json.dumps({URL: {"daydream-glm": dict(_ALL_ERRORED_LEAF)}}))
+        (rdir / "evaluations.json").write_text(json.dumps({URL: {"daydream-glm": dict(_ALL_ERRORED_LEAF)}}))
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr("daydream.benchmark.score.subprocess.run", fake_run)

--- a/tests/test_benchmark_score.py
+++ b/tests/test_benchmark_score.py
@@ -107,6 +107,28 @@ def test_preflight_passes_when_key_present(monkeypatch):
     preflight_judge_env()
 
 
+def test_direct_anthropic_preflight_requires_anthropic_key(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("MARTIAN_MODEL", "claude-opus-4-5-20251101")
+    with pytest.raises(JudgeEnvError, match="ANTHROPIC_API_KEY"):
+        preflight_judge_env(judge_route="anthropic-direct")
+
+
+def test_direct_anthropic_preflight_rejects_openrouter_key(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-or-not-direct")
+    monkeypatch.setenv("MARTIAN_MODEL", "claude-opus-4-5-20251101")
+    with pytest.raises(JudgeEnvError, match="OpenRouter key supplied for Anthropic-direct judge"):
+        preflight_judge_env(judge_route="anthropic-direct")
+
+
+def test_direct_anthropic_preflight_rejects_martian_base_url(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-direct")
+    monkeypatch.setenv("MARTIAN_MODEL", "claude-opus-4-5-20251101")
+    monkeypatch.setenv("MARTIAN_BASE_URL", "https://api.anthropic.com")
+    with pytest.raises(JudgeEnvError, match="MARTIAN_BASE_URL is invalid for direct Anthropic scoring"):
+        preflight_judge_env(judge_route="anthropic-direct")
+
+
 def test_parse_daydream_scores_extracts_per_pr_and_aggregate():
     evals = {
       "url1": {"daydream": {"tp": 2, "fp": 1, "fn": 1, "precision": 0.667, "recall": 0.667,

--- a/uv.lock
+++ b/uv.lock
@@ -198,6 +198,7 @@ source = { editable = "." }
 dependencies = [
     { name = "anyio" },
     { name = "claude-agent-sdk" },
+    { name = "httpx" },
     { name = "jsonschema" },
     { name = "pydantic" },
     { name = "pyfiglet" },
@@ -226,6 +227,7 @@ dev = [
 requires-dist = [
     { name = "anyio", specifier = ">=4.0" },
     { name = "claude-agent-sdk", specifier = "==0.2.108" },
+    { name = "httpx", specifier = ">=0.28" },
     { name = "jsonschema", specifier = ">=4.0" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pyfiglet", specifier = ">=1.0" },


### PR DESCRIPTION
## Summary

Adds an `anthropic-direct` benchmark scoring route that runs the judge (extraction → dedup → evaluation) against Anthropic's Messages API directly, alongside the existing OpenAI-compatible `martian` route. Operators select it with `--judge-route anthropic-direct` and authenticate via `ANTHROPIC_API_KEY`.

## Changes

### Added
- `AnthropicJsonClient`: a small Messages-API JSON client (`temperature=0`, first text block parsed as strict JSON), with an injectable `_AsyncHttpClient`/`_AnthropicJsonCompleter` seam for tests.
- `daydream/benchmark/anthropic_score.py`: the full direct-Anthropic judge pipeline — `run_anthropic_extraction`, `run_anthropic_dedup`, `run_anthropic_evaluation`, and the orchestrating `run_anthropic_scoring` — writing Martian-compatible `candidates.json` / `dedup_groups.json` / `evaluations.json` artifacts.
- `--judge-route {martian,anthropic-direct}` CLI flag and `judge_route` field on `BenchConfig` (default `martian`), resolved through `[tool.daydream.bench] judge-route`.
- Route-aware `preflight_judge_env(judge_route=...)`: the `anthropic-direct` route requires `ANTHROPIC_API_KEY` and refuses an OpenRouter (`sk-or-`) key or a stray `MARTIAN_BASE_URL` that would proxy the direct call.

### Changed
- `run_scoring` now dispatches on `judge_route`; the `anthropic-direct` branch calls `asyncio.run(run_anthropic_scoring(...))`, and `run_bench` threads `judge_route` through to it.
- `resolve_judge_model` and the `--model` help text are route-agnostic (`MARTIAN_MODEL` remains the env fallback; it is not a Martian-specific name).
- Docs (`docs/benchmark.md`, `CLAUDE.md`) describe both routes and the `ANTHROPIC_API_KEY` env var.

### Fixed
- Anthropic judge retry/concurrency hardening: a `_NonRetryableError` skips retries on 4xx (non-429) and malformed-JSON failures; a `_JUDGE_CONCURRENCY=10` semaphore caps parallel judge calls; the best-confidence sentinel moved from `0.0` to `-1.0` so a valid `0.0` confidence match is not dropped; the `>=` comparison now keeps equal-confidence matches.
- Hermetic test isolation: `test_orchestrator_passes_judge_route_to_scoring` now deletes any ambient `MARTIAN_BASE_URL` so the preflight guard isn't tripped by the operator shell.

## Motivation

The benchmark previously had a single judge path routed through an OpenAI-compatible Martian proxy. A direct Anthropic Messages-API route removes the proxy hop, simplifies credential management (one `ANTHROPIC_API_KEY`), and gives deterministic `temperature=0` JSON judging without subprocess step modules.

## Testing

- [x] Unit tests added/updated — `tests/test_benchmark_anthropic_score.py` (new), plus `test_benchmark_cli.py`, `test_benchmark_e2e.py`, `test_benchmark_orchestrator.py`, `test_benchmark_score.py`.
- [x] `make check` (ruff + mypy + full pytest) passes: 1963 passed, 5 skipped.

### Manual Testing Steps

```bash
ANTHROPIC_API_KEY=sk-ant-... daydream bench --benchmark-repo ../code-review-benchmark/offline   --judge-route anthropic-direct --model claude-opus-4-5-20251101 --score --only <repo> --limit 1
```

Expect `results/<model>/evaluations.json` with `judge_route == "anthropic-direct"` entries, and an aggregate `DaydreamScores` reported.

## Related Issues

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally
- [x] Linting passes
- [x] Documentation updated