### PR TITLE
feat(bench): preserve confidence/severity as structured fields on submitted comments

### DIFF
--- a/daydream/benchmark/mapping.py
+++ b/daydream/benchmark/mapping.py
@@ -25,15 +25,18 @@ def merged_items_to_review_comments(
         created_at: Timestamp passed verbatim onto every emitted comment.
 
     Returns:
-        A list of ``{path, line, body, created_at}`` dicts, one per item with
-        a non-empty ``file``. Items with an empty ``file`` are skipped, as are
-        items whose assembled ``body`` is empty (no ``description``,
-        ``severity``, ``confidence``, or ``rationale`` text) — an empty-body
-        comment is never emitted. A null
+        A list of ``{path, line, body, created_at, confidence, severity}``
+        dicts, one per item with a non-empty ``file``. Items with an empty
+        ``file`` are skipped, as are items whose assembled ``body`` is empty
+        (no ``description``, ``severity``, ``confidence``, or ``rationale``
+        text) — an empty-body comment is never emitted. A null
         or non-integer ``line`` is preserved as ``None``. The ``body`` leads
         with the finding ``description``, followed by ``**Severity:**`` and
         ``**Confidence:**`` badges, and the ``rationale`` only when it differs
-        from the description; sections are joined with ``"\\n\\n"``.
+        from the description; sections are joined with ``"\\n\\n"``. The
+        structured ``confidence`` (uppercased) and ``severity`` (lowercased)
+        fields carry the same values, ``None`` when absent; the body badges
+        are kept for human/judge readability.
     """
     out: list[dict[str, Any]] = []
     for raw in doc.get("items", []):
@@ -58,6 +61,8 @@ def merged_items_to_review_comments(
                 "line": fields.line_int,
                 "body": body,
                 "created_at": created_at,
+                "confidence": fields.confidence,
+                "severity": fields.severity,
             }
         )
     return out

--- a/daydream/benchmark/mapping.py
+++ b/daydream/benchmark/mapping.py
@@ -2,7 +2,7 @@
 
 Mirrors the transforms in :func:`daydream.pr_review.parsed_issues_from_items`,
 but folds ``description`` into the comment ``body`` and emits the benchmark
-``review_comments`` shape (``{path, line, body, created_at}``) instead of a
+``review_comments`` shape (``{path, line, body, created_at, confidence, severity}``) instead of a
 ``ParsedIssue``. Pure and deterministic — no I/O, no LLM.
 """
 

--- a/tests/test_benchmark_fidelity.py
+++ b/tests/test_benchmark_fidelity.py
@@ -11,16 +11,19 @@ from daydream.benchmark.mapping import merged_items_to_review_comments
 
 URL = "https://github.com/owner/repo/pull/1"
 
-# A step1-harvested review_comment has EXACTLY these keys (code-review-benchmark
-# step1_download_prs.py:134-138). Our injected comments must match key-for-key.
+# A step1-harvested review_comment has these keys (code-review-benchmark
+# step1_download_prs.py:134-138). Our injected comments carry every harvested
+# key and add the structured ``confidence``/``severity`` fields (issue #231).
 HARVEST_KEYS = {"path", "line", "body", "created_at"}
+INJECTED_KEYS = HARVEST_KEYS | {"confidence", "severity"}
 
 
 def test_injected_comment_keys_match_harvested_schema():
     doc = {"items": [{"file": "a.py", "line": 3, "description": "x", "severity": "high",
                       "confidence": "HIGH", "rationale": "y"}]}
     comments = merged_items_to_review_comments(doc, created_at="2026-06-03T00:00:00Z")
-    assert comments and all(set(c) == HARVEST_KEYS for c in comments)
+    assert comments and all(set(c) == INJECTED_KEYS for c in comments)
+    assert all(HARVEST_KEYS <= set(c) for c in comments)   # superset of the harvested schema
     c = comments[0]
     assert isinstance(c["path"], str) and isinstance(c["body"], str) and isinstance(c["created_at"], str)
     assert c["line"] is None or isinstance(c["line"], int)

--- a/tests/test_benchmark_mapping.py
+++ b/tests/test_benchmark_mapping.py
@@ -24,7 +24,32 @@ def test_maps_fields_and_folds_description_into_body():
     [c] = merged_items_to_review_comments({"items": [_item("a/b.go", 48)]}, created_at=TS)
     assert c["path"] == "a/b.go" and c["line"] == 48 and c["created_at"] == TS
     assert "Race on cache write" in c["body"] and "Two goroutines" in c["body"]
-    assert set(c) == {"path", "line", "body", "created_at"}
+    assert set(c) == {"path", "line", "body", "created_at", "confidence", "severity"}
+
+
+def test_structured_confidence_severity_preserved():
+    doc = {"items": [
+        _item("a/b.go", 48, id=1, severity="high", confidence="HIGH"),
+        _item("f.py", None, id=2, severity="", confidence="", description="y", rationale="y"),
+        _item("c.rs", 10, id=3, severity="CRITICAL", confidence="low"),
+        _item("d.ts", 5, id=4, lens="cross-stack", severity="medium", confidence="MEDIUM"),
+    ]}
+    out = merged_items_to_review_comments(doc, created_at=TS)
+    by_path = {c["path"]: c for c in out}
+
+    a = by_path["a/b.go"]
+    assert a["severity"] == "high" and a["confidence"] == "HIGH"
+    assert "**Severity:** high" in a["body"] and "**Confidence:** HIGH" in a["body"]
+
+    b = by_path["f.py"]
+    assert b["severity"] is None and b["confidence"] is None and b["line"] is None
+
+    c = by_path["c.rs"]
+    assert c["severity"] == "critical" and c["confidence"] == "LOW"
+
+    d = by_path["d.ts"]
+    assert d["severity"] == "medium" and d["confidence"] == "MEDIUM"
+    assert "**Severity:** medium" in d["body"] and "**Confidence:** MEDIUM" in d["body"]
 
 
 def test_empty_items_yields_no_comments():


### PR DESCRIPTION
## Summary

- Emitted benchmark review comments now carry `confidence` (uppercased) and `severity` (lowercased) as first-class structured keys alongside the existing `{path, line, body, created_at}` shape.

## Motivation

`merged_items_to_review_comments` embedded severity/confidence only as `**Severity:**`/`**Confidence:**` prose badges inside `body`. The upcoming bench materiality gate (part of #233) needs these as machine-readable fields, not regex-reparsed prose. The values were already normalized by `extract_item_fields` — they just weren't surfaced at emission.

Closes #231.

## Changes

### Added
- `confidence` and `severity` keys to each emitted comment dict in `merged_items_to_review_comments` (`daydream/benchmark/mapping.py`).

### Changed
- Module-level and function-level docstrings updated to document the 6-key shape and the normalization casing.
- `tests/test_benchmark_mapping.py` key-set assertion updated; added `test_structured_confidence_severity_preserved` covering casing normalization, empty-to-None, null line, and cross-stack lens.
- `tests/test_benchmark_fidelity.py` updated to assert injected comments are a strict superset of the harvested schema (`INJECTED_KEYS = HARVEST_KEYS | {confidence, severity}`).

## Test Plan

- [x] `uv run pytest tests/test_benchmark_mapping.py tests/test_benchmark_fidelity.py` — 9/9 pass
- [x] `make check` — 1964 passed, 5 skipped (lint + typecheck + full suite)
- [x] Body badges retained (`**Severity:**`/`**Confidence:**` still present for judge/human readability)

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check`)
- [x] Type checking passes (`uv run mypy daydream`)
- [x] Documentation updated (docstrings updated)
