### PR TITLE
feat(bench): materiality gate — --min-confidence / --min-severity

### DIFF
--- a/daydream/benchmark/cli.py
+++ b/daydream/benchmark/cli.py
@@ -173,6 +173,20 @@ def _build_bench_parser() -> argparse.ArgumentParser:
         dest="score",
         help="Drive the step2/2.5/3 scoring pipeline (default: on; use --no-score to skip)",
     )
+    parser.add_argument(
+        "--min-confidence",
+        choices=["LOW", "MEDIUM", "HIGH"],
+        default=None,
+        dest="min_confidence",
+        help="Drop findings below this confidence from benchmark submission (default: submit all)",
+    )
+    parser.add_argument(
+        "--min-severity",
+        choices=["low", "medium", "high"],
+        default=None,
+        dest="min_severity",
+        help="Drop findings below this severity from benchmark submission (default: submit all)",
+    )
     return parser
 
 
@@ -274,6 +288,8 @@ def _bench_config_from_argv(argv: list[str]) -> "BenchConfig":
         reviewer_provider=reviewer_provider,
         tool_label=tool_label,
         verbose=args.verbose,
+        min_confidence=args.min_confidence if args.min_confidence is not None else bench.get("min-confidence"),
+        min_severity=args.min_severity if args.min_severity is not None else bench.get("min-severity"),
     )
 
 

--- a/daydream/benchmark/cli.py
+++ b/daydream/benchmark/cli.py
@@ -254,6 +254,12 @@ def _bench_config_from_argv(argv: list[str]) -> "BenchConfig":
     judge_route = args.judge_route if args.judge_route is not None else bench.get("judge-route", "martian")
     if judge_route not in {"martian", "anthropic-direct"}:
         parser.error("--judge-route must be one of: martian, anthropic-direct")
+    min_confidence = args.min_confidence if args.min_confidence is not None else bench.get("min-confidence")
+    min_severity = args.min_severity if args.min_severity is not None else bench.get("min-severity")
+    if min_confidence is not None and min_confidence.lower() not in {"low", "medium", "high"}:
+        parser.error("--min-confidence must be one of: LOW, MEDIUM, HIGH")
+    if min_severity is not None and min_severity.lower() not in {"low", "medium", "high"}:
+        parser.error("--min-severity must be one of: low, medium, high")
     if benchmark_repo is None:
         parser.error("--benchmark-repo is required (pass the flag or set [tool.daydream.bench] benchmark-repo)")
     bench_root = benchmark_repo / ".daydream-bench"
@@ -288,8 +294,8 @@ def _bench_config_from_argv(argv: list[str]) -> "BenchConfig":
         reviewer_provider=reviewer_provider,
         tool_label=tool_label,
         verbose=args.verbose,
-        min_confidence=args.min_confidence if args.min_confidence is not None else bench.get("min-confidence"),
-        min_severity=args.min_severity if args.min_severity is not None else bench.get("min-severity"),
+        min_confidence=min_confidence,
+        min_severity=min_severity,
     )
 
 

--- a/daydream/benchmark/config.py
+++ b/daydream/benchmark/config.py
@@ -32,6 +32,10 @@ class BenchConfig:
         limit: Optional cap on the number of PRs processed.
         trajectory_dir: Directory for per-PR ATIF trajectory files.
         verbose: Stream the review subprocess output live (vs. the quiet spinner).
+        min_confidence: When set, drop findings below this confidence
+            (low/medium/high) before benchmark submission; None submits all.
+        min_severity: When set, drop findings below this severity
+            (low/medium/high) before benchmark submission; None submits all.
     """
 
     benchmark_repo: Path
@@ -48,3 +52,5 @@ class BenchConfig:
     reviewer_provider: str | None = None
     tool_label: str = "daydream"
     verbose: bool = False
+    min_confidence: str | None = None
+    min_severity: str | None = None

--- a/daydream/benchmark/mapping.py
+++ b/daydream/benchmark/mapping.py
@@ -12,17 +12,36 @@ from typing import Any
 
 from daydream.pr_review import extract_item_fields
 
+_RANKS: dict[str, int] = {"low": 1, "medium": 2, "high": 3}
+
+
+def _below_threshold(value: str | None, threshold: str | None) -> bool:
+    """Return True when threshold is set and value is missing or ranks below it."""
+    if threshold is None:
+        return False
+    if value is None:
+        return True  # missing field + threshold set → drop (conservative)
+    return _RANKS.get(value.lower(), 0) < _RANKS.get(threshold.lower(), 0)
+
 
 def merged_items_to_review_comments(
     doc: dict[str, Any],
     *,
     created_at: str,
+    min_confidence: str | None = None,
+    min_severity: str | None = None,
 ) -> list[dict[str, Any]]:
     """Convert a merged-items document into benchmark review comments.
 
     Args:
         doc: Parsed ``merged-items.json`` with a top-level ``items`` list.
         created_at: Timestamp passed verbatim onto every emitted comment.
+        min_confidence: When set, drop any item whose confidence ranks below
+            this threshold (or is missing). Compared case-insensitively on the
+            low/medium/high scale.
+        min_severity: When set, drop any item whose severity ranks below this
+            threshold (or is missing). Compared case-insensitively on the
+            low/medium/high scale.
 
     Returns:
         A list of ``{path, line, body, created_at}`` dicts, one per item with
@@ -39,6 +58,10 @@ def merged_items_to_review_comments(
     for raw in doc.get("items", []):
         fields = extract_item_fields(raw)
         if fields is None:
+            continue
+        if _below_threshold(fields.confidence, min_confidence):
+            continue
+        if _below_threshold(fields.severity, min_severity):
             continue
         body_parts: list[str] = []
         if fields.description:

--- a/daydream/benchmark/orchestrator.py
+++ b/daydream/benchmark/orchestrator.py
@@ -106,7 +106,12 @@ def _process_pr(config: BenchConfig, pr: EvaluablePR, data: dict[str, Any]) -> b
         on_line=on_line,
     )
     doc = json.loads(artifact.read_text(encoding="utf-8"))
-    comments = merged_items_to_review_comments(doc, created_at=_CREATED_AT)
+    comments = merged_items_to_review_comments(
+        doc,
+        created_at=_CREATED_AT,
+        min_confidence=config.min_confidence,
+        min_severity=config.min_severity,
+    )
     return inject_daydream_review(data, pr.golden_url, comments, force=config.force, tool=config.tool_label)
 
 

--- a/tests/test_benchmark_mapping.py
+++ b/tests/test_benchmark_mapping.py
@@ -51,3 +51,30 @@ def test_mapping_skips_items_that_would_produce_empty_body():
     out = merged_items_to_review_comments(doc, created_at="T")
     assert [c["path"] for c in out] == ["b.py"]          # empty-body item dropped
     assert all(c["body"].strip() for c in out)           # no harvested comment is ever empty
+
+
+def test_min_confidence_high_excludes_medium_and_unrated():
+    doc = {"items": [
+        _item("high.py", 1, id=1, confidence="HIGH"),
+        _item("med.py", 2, id=2, confidence="MEDIUM"),
+        _item("none.py", 3, id=3, confidence=""),  # normalises to None
+    ]}
+    out = merged_items_to_review_comments(doc, created_at=TS, min_confidence="HIGH")
+    assert [c["path"] for c in out] == ["high.py"]
+
+
+def test_min_severity_high_excludes_medium_and_unrated():
+    doc = {"items": [
+        _item("high.py", 1, id=1, severity="high"),
+        _item("med.py", 2, id=2, severity="medium"),
+        _item("none.py", 3, id=3, severity=""),  # normalises to None
+    ]}
+    out = merged_items_to_review_comments(doc, created_at=TS, min_severity="high")
+    assert [c["path"] for c in out] == ["high.py"]
+
+
+def test_combined_thresholds_item_must_clear_both():
+    # HIGH confidence clears --min-confidence, but medium severity fails --min-severity.
+    doc = {"items": [_item("f.py", 1, confidence="HIGH", severity="medium")]}
+    out = merged_items_to_review_comments(doc, created_at=TS, min_confidence="HIGH", min_severity="high")
+    assert out == []

--- a/tests/test_benchmark_orchestrator.py
+++ b/tests/test_benchmark_orchestrator.py
@@ -203,6 +203,36 @@ def test_orchestrator_passes_judge_route_to_scoring(tmp_path, monkeypatch):
     assert captured["pr_count"] == 1
 
 
+def test_materiality_gate_filters_submission(tmp_path, monkeypatch):
+    from daydream.benchmark.orchestrator import _injected_comment_count
+
+    data_path = _seed_benchmark_data_with_all_26_keys(tmp_path)
+    monkeypatch.setattr(
+        "daydream.benchmark.orchestrator.acquire_checkout",
+        lambda *a, **k: _fake_checkout(tmp_path),
+    )
+    monkeypatch.setattr(
+        "daydream.benchmark.orchestrator.run_daydream_review",
+        lambda checkout, **k: _write_items(
+            checkout,
+            [
+                _item("high.py", 1, id=1, confidence="HIGH"),
+                _item("med.py", 2, id=2, confidence="MEDIUM"),
+                _item("low.py", 3, id=3, confidence="LOW"),
+            ],
+        ),
+    )
+    cfg = replace(
+        _config(tmp_path, data_path, score=False, only="grafana"),
+        limit=1,
+        min_confidence="HIGH",
+    )
+    assert run_bench(cfg) == 0
+    data = json.loads(data_path.read_text())
+    [golden_url] = [u for u in data if "grafana" in u and any(r["tool"] == "daydream" for r in data[u]["reviews"])]
+    assert _injected_comment_count(data, golden_url, "daydream") == 1  # only the HIGH item survives the gate
+
+
 def test_rerun_skips_already_injected_unless_forced(tmp_path, monkeypatch):
     data_path = _seed_benchmark_data_with_all_26_keys(tmp_path)
     calls = {"n": 0}


### PR DESCRIPTION
## Summary

- Add `--min-confidence {LOW,MEDIUM,HIGH}` and `--min-severity {low,medium,high}` flags to `daydream bench` that filter findings before benchmark submission
- Bench-scoped only: the materiality gate lives in `merged_items_to_review_comments` and drops items below the configured threshold(s); product posting and deep-review loops are untouched
- Config-file thresholds validated against the allowed set, mirroring the `judge-route` precedent

## Motivation

On the offline benchmark the Martian judge counts every non-gapped candidate as a false positive with no severity threshold and no per-PR cap. Daydream's latest run: precision 0.20 / recall 0.62 on 25 PRs (~8.4 findings/PR). This gate lets operators trim evidenced-but-minor findings to match the golden set for scoring, without changing the product default of surfacing every real finding.

Closes #230.

## Changes

### Added
- `_RANKS` map and `_below_threshold()` helper in `mapping.py` — pure, deterministic, case-insensitive rank comparison
- `min_confidence` and `min_severity` fields on `BenchConfig` (default `None` = drop nothing)
- `--min-confidence` / `--min-severity` CLI flags with config-file fallback (`[tool.daydream.bench] min-confidence` / `min-severity`)
- Config-file threshold validation in `_bench_config_from_argv` (rejects typos/whitespace via `parser.error`, matching the `judge-route` pattern)

### Changed
- `merged_items_to_review_comments` accepts `min_confidence`/`min_severity` kwargs; items below either threshold are dropped before body assembly
- `_process_pr` in `orchestrator.py` passes `config.min_confidence`/`config.min_severity` through to the mapping call

## Test Plan

- [x] Unit tests: `test_min_confidence_high_excludes_medium_and_unrated`, `test_min_severity_high_excludes_medium_and_unrated`, `test_combined_thresholds_item_must_clear_both`
- [x] Real-path test: `test_materiality_gate_filters_submission` drives `run_bench` with mixed-confidence items and asserts only HIGH survives via `_injected_comment_count`
- [x] `make check` (ruff + mypy + full pytest): 1988 passed, 5 skipped
- [x] CLI parse smoke check: flags populate correctly and reject out-of-choice values

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check`)
- [x] Type checking passes (`uv run mypy daydream`)
- [x] Documentation updated (if applicable)
