### PR TITLE
feat(training): stable per-finding join key for accept/reject labels

### DIFF
--- a/daydream/archive/__init__.py
+++ b/daydream/archive/__init__.py
@@ -110,7 +110,7 @@ def _archive_run_inner(
     run_dir.mkdir(parents=True, exist_ok=True)
 
     # 1. Copy artifact bundle
-    _copy_bundle(target_dir, run_dir, recorder)
+    _copy_bundle(target_dir, run_dir, recorder, config)
 
     # 2. Capture git context — prefer pre-resolved WorkContext over re-deriving
     #    from disk (HEAD may have moved; base-branch detection fails in worktrees).
@@ -210,14 +210,19 @@ def _read_fix_leftover_untracked(target_dir: Path) -> list[str] | None:
     return [str(p) for p in data]
 
 
-def _copy_bundle(target_dir: Path, run_dir: Path, recorder: TrajectoryRecorder) -> None:
+def _copy_bundle(
+    target_dir: Path,
+    run_dir: Path,
+    recorder: TrajectoryRecorder,
+    config: RunConfig,
+) -> None:
     """Copy ``.daydream/`` artifacts to the archive run directory.
 
     Trajectory subtree (``runs/<session_id>/trajectory.json`` plus
     ``runs/<session_id>/trajectories/``) is copied wholesale via copytree
     so the archive layout mirrors the live layout exactly. Other artifacts
-    (``review-output.md``, ``deep/``, ``diff.patch``) keep their existing
-    copy logic. Missing files are silently skipped.
+    (``review-output.md``, ``deep/``, ``diff.patch``, ``findings.json``)
+    keep their existing copy logic. Missing files are silently skipped.
     """
     daydream_dir = target_dir / ".daydream"
 
@@ -259,6 +264,20 @@ def _copy_bundle(target_dir: Path, run_dir: Path, recorder: TrajectoryRecorder) 
     recommended_patch = daydream_dir / "recommended.patch"
     if recommended_patch.is_file():
         shutil.copy2(recommended_patch, run_dir / "recommended.patch")
+
+    # Findings artifact (``--findings-out`` / Phase A). Archived so the corpus
+    # harvest per-finding join has a fingerprint source for real PR runs —
+    # without it ``_row_recorded_fingerprints`` always returns ``[]`` and the
+    # per-finding supervision never reaches the corpus. The writer resolves
+    # ``config.findings_out`` against CWD (the repo root in the review-bot
+    # workflow), so fall back to target_dir-relative for runs invoked elsewhere.
+    findings_out = config.findings_out
+    if findings_out:
+        findings_src = Path(findings_out)
+        if not findings_src.is_absolute() and not findings_src.is_file():
+            findings_src = target_dir / findings_out
+        if findings_src.is_file():
+            shutil.copy2(findings_src, run_dir / "findings.json")
 
 
 def _run_eval(target_dir: Path, session_id: str, run_dir: Path) -> dict[str, Any] | None:

--- a/daydream/training/__init__.py
+++ b/daydream/training/__init__.py
@@ -8,3 +8,16 @@ Modules under this package land incrementally per the JSONL exporter plan
 Future R2/R3/R5/R8 work (reward composition, auto-labeling, training recipes,
 bootstrap collection) will also live here.
 """
+
+from daydream.training.labeler_signals import (
+    PerFindingResolution,
+    per_finding_resolution_signal,
+)
+from daydream.training.rubric import PerFindingLabel, derive_per_finding_labels
+
+__all__ = [
+    "PerFindingLabel",
+    "PerFindingResolution",
+    "derive_per_finding_labels",
+    "per_finding_resolution_signal",
+]

--- a/daydream/training/harvest.py
+++ b/daydream/training/harvest.py
@@ -83,7 +83,7 @@ from __future__ import annotations
 import json
 import re
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -110,12 +110,13 @@ from daydream.training.labeler_signals import (
     comment_resolution_signal,
     fix_applied_signal,
     local_commit_applied_signal,
+    per_finding_resolution_signal,
     pr_link_signal,
     pr_merge_signal,
     reviewer_logins_signal,
 )
 from daydream.training.reward import ScoringInputs, score_trajectory
-from daydream.training.rubric import Rubric, derive_outcome_label
+from daydream.training.rubric import Rubric, derive_outcome_label, derive_per_finding_labels
 from daydream.ui import create_console, print_warning
 
 _VERDICTS_FILE = "recommendation-verdicts.json"
@@ -393,6 +394,32 @@ def _row_is_pr(row: dict[str, Any]) -> bool:
     return bool(row.get("pr_repo")) and row.get("pr_number") is not None
 
 
+def _row_recorded_fingerprints(row: dict[str, Any]) -> list[str]:
+    """Return the finding fingerprints recorded for a row, in order.
+
+    Prefers a pre-extracted ``findings_fingerprints`` column; otherwise reads
+    the archived ``findings.json`` artifact and collects each finding's
+    ``fingerprint``. Returns ``[]`` when neither source is available or the
+    artifact is missing / malformed — a row with no recorded findings simply
+    yields no per-finding join.
+    """
+    pre_extracted = row.get("findings_fingerprints")
+    if isinstance(pre_extracted, list):
+        return [str(fp) for fp in pre_extracted]
+
+    archive_path = row.get("archive_path")
+    if not archive_path:
+        return []
+    try:
+        data = json.loads((Path(archive_path) / "findings.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    findings = data.get("findings") if isinstance(data, dict) else None
+    if not isinstance(findings, list):
+        return []
+    return [str(f["fingerprint"]) for f in findings if isinstance(f, dict) and "fingerprint" in f]
+
+
 # HTTP statuses meaning the PR/commit is genuinely absent (fork/deleted PR 404,
 # unpushed-SHA 422) so a row may degrade to its local posterior; every other gh
 # failure is transient and must propagate so resume retries, not mislabel (#166).
@@ -435,13 +462,20 @@ def _build_rubric_pr(
         changed_files=changed_files,
         repo_clone=repo_clone,
     )
-    return Rubric(
+    rubric = Rubric(
         pr_merge=pr_merge,
         fix_applied=fix,
         comment_resolution=comments,
         local_commit_applied=None,
         posterior_source="pr_review",
     )
+    recorded_fingerprints = _row_recorded_fingerprints(row)
+    if recorded_fingerprints:
+        per_finding = per_finding_resolution_signal(
+            signal_row, recorded_fingerprints=recorded_fingerprints, gh_api=gh_api
+        )
+        rubric = replace(rubric, per_finding_labels=list(derive_per_finding_labels(rubric, per_finding)))
+    return rubric
 
 
 def _build_rubric_local(

--- a/daydream/training/harvest.py
+++ b/daydream/training/harvest.py
@@ -109,6 +109,7 @@ from daydream.training.labeler_signals import (
     PRMergeSignal,
     comment_resolution_signal,
     fix_applied_signal,
+    index_pr_review_comments,
     local_commit_applied_signal,
     per_finding_resolution_signal,
     pr_link_signal,
@@ -456,7 +457,10 @@ def _build_rubric_pr(
     signal_row = {**row, "changed_files": changed_files}
     if pr_merge is None:
         pr_merge = pr_merge_signal(signal_row, gh_api=gh_api)
-    comments = comment_resolution_signal(signal_row, gh_api=gh_api)
+    # Fetch + index the PR's review comments once; both resolution signals
+    # consume this index instead of each hitting the /comments endpoint.
+    comment_threads = index_pr_review_comments(signal_row, gh_api=gh_api)
+    comments = comment_resolution_signal(signal_row, gh_api=gh_api, threads=comment_threads)
     fix = _safe_fix_applied(
         signal_row,
         changed_files=changed_files,
@@ -472,7 +476,10 @@ def _build_rubric_pr(
     recorded_fingerprints = _row_recorded_fingerprints(row)
     if recorded_fingerprints:
         per_finding = per_finding_resolution_signal(
-            signal_row, recorded_fingerprints=recorded_fingerprints, gh_api=gh_api
+            signal_row,
+            recorded_fingerprints=recorded_fingerprints,
+            gh_api=gh_api,
+            threads=comment_threads,
         )
         rubric = replace(rubric, per_finding_labels=list(derive_per_finding_labels(rubric, per_finding)))
     return rubric

--- a/daydream/training/labeler_signals.py
+++ b/daydream/training/labeler_signals.py
@@ -29,6 +29,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Literal
 
+from daydream.pr_review import parse_finding_markers
+
 # Version-stable footer prefix: matching only this prefix (not the full
 # version-pinned DAYDREAM_FOOTER) recognises comments from any daydream release.
 _DAYDREAM_FOOTER_PREFIX = "<sub>🧙 Posted by [daydream v"
@@ -107,6 +109,24 @@ class CommentResolutionSignal:
     total: int
     replied: int
     unresolved: int
+
+
+@dataclass(frozen=True)
+class PerFindingResolution:
+    """Resolution state for one recorded finding, joined by fingerprint.
+
+    Attributes:
+        fingerprint: The 64-hex finding fingerprint recorded at review time.
+        resolved: ``True`` when the finding's posted comment received at
+            least one reply (proxy for "addressed").
+        comment_id: GitHub review-comment ID carrying the finding marker,
+            or ``None`` when no surviving comment carries the fingerprint
+            (deleted, edited away, or never posted).
+    """
+
+    fingerprint: str
+    resolved: bool
+    comment_id: int | None
 
 
 @dataclass(frozen=True)
@@ -421,6 +441,69 @@ def comment_resolution_signal(
     total = len(top_level_daydream_ids)
     replied = sum(1 for cid in top_level_daydream_ids if replies_by_parent.get(cid, 0) >= 1)
     return CommentResolutionSignal(total=total, replied=replied, unresolved=total - replied)
+
+
+def per_finding_resolution_signal(
+    row: dict[str, Any],
+    *,
+    recorded_fingerprints: list[str],
+    gh_api: Callable[..., Any],
+) -> list[PerFindingResolution]:
+    """Resolve each recorded finding to its posted comment and reply state.
+
+    Joins the fingerprints recorded at review time (``recorded_fingerprints``)
+    against the PR's live review comments by the hidden
+    ``<!-- daydream-finding: <fp> -->`` marker embedded in each daydream
+    comment body. A finding is ``resolved`` when its comment received at
+    least one reply; a fingerprint with no surviving comment yields
+    ``comment_id=None`` (deleted / edited away / never posted).
+
+    Args:
+        row: Manifest row carrying ``pr_repo`` and ``pr_number``.
+        recorded_fingerprints: Fingerprints captured at review time. The
+            returned list preserves this order, one entry per fingerprint.
+        gh_api: Callable returning the parsed comment list.
+
+    Returns:
+        One :class:`PerFindingResolution` per recorded fingerprint, or an
+        empty list when the row has no associated PR.
+    """
+    repo = row.get("pr_repo")
+    number = row.get("pr_number")
+    if repo is None or number is None:
+        return []
+
+    comments = gh_api(repo, f"repos/{repo}/pulls/{number}/comments", paginate=True)
+
+    # Pass 1: top-level daydream comment IDs.
+    top_level_daydream_ids: set[int] = set()
+    for comment in comments:
+        if comment.get("in_reply_to_id") is None and _is_daydream_comment(comment):
+            top_level_daydream_ids.add(comment["id"])
+
+    # Pass 2: which top-level comments received a reply.
+    replied_ids: set[int] = set()
+    for comment in comments:
+        in_reply_to = comment.get("in_reply_to_id")
+        if in_reply_to in top_level_daydream_ids:
+            replied_ids.add(in_reply_to)
+
+    # Pass 3: map fingerprint -> the comment ID that carries its marker.
+    comment_id_by_fingerprint: dict[str, int] = {}
+    for comment in comments:
+        if comment["id"] not in top_level_daydream_ids:
+            continue
+        for fingerprint in parse_finding_markers(comment.get("body") or ""):
+            comment_id_by_fingerprint.setdefault(fingerprint, comment["id"])
+
+    resolutions: list[PerFindingResolution] = []
+    for fingerprint in recorded_fingerprints:
+        comment_id = comment_id_by_fingerprint.get(fingerprint)
+        resolved = comment_id is not None and comment_id in replied_ids
+        resolutions.append(
+            PerFindingResolution(fingerprint=fingerprint, resolved=resolved, comment_id=comment_id)
+        )
+    return resolutions
 
 
 def pr_link_signal(

--- a/daydream/training/labeler_signals.py
+++ b/daydream/training/labeler_signals.py
@@ -401,10 +401,88 @@ def fix_applied_signal(
     )
 
 
+@dataclass(frozen=True)
+class PRCommentThreads:
+    """Indexed view of a PR's review comments shared by the resolution signals.
+
+    Centralises the ``/comments`` fetch and daydream-thread indexing so the
+    aggregate (:func:`comment_resolution_signal`) and per-finding
+    (:func:`per_finding_resolution_signal`) signals do not refetch or
+    re-index the same row's comments. Built by
+    :func:`index_pr_review_comments`.
+
+    Attributes:
+        top_level_daydream_ids: IDs of footer-marked daydream comments with
+            no parent (the "issue" comments).
+        replied_ids: Subset of ``top_level_daydream_ids`` that received at
+            least one reply.
+        comment_id_by_fingerprint: First comment ID carrying each finding
+            marker, keyed by 64-hex fingerprint.
+    """
+
+    top_level_daydream_ids: set[int]
+    replied_ids: set[int]
+    comment_id_by_fingerprint: dict[str, int]
+
+
+def index_pr_review_comments(
+    row: dict[str, Any],
+    *,
+    gh_api: Callable[..., Any],
+) -> PRCommentThreads | None:
+    """Fetch and index a PR's review comments for the resolution signals.
+
+    Single source of truth for the ``repos/{repo}/pulls/{n}/comments`` fetch
+    and daydream-thread indexing shared by :func:`comment_resolution_signal`
+    and :func:`per_finding_resolution_signal`, so the two signals invoked
+    back-to-back on the same row hit the endpoint once (the caller computes
+    this and passes it as ``threads=`` to both).
+
+    Args:
+        row: Manifest row carrying ``pr_repo`` and ``pr_number``.
+        gh_api: Callable returning the parsed comment list. Exceptions
+            propagate to the caller.
+
+    Returns:
+        :class:`PRCommentThreads`, or ``None`` when the row has no
+        associated PR (no fetch performed).
+    """
+    repo = row.get("pr_repo")
+    number = row.get("pr_number")
+    if repo is None or number is None:
+        return None
+
+    comments = gh_api(repo, f"repos/{repo}/pulls/{number}/comments", paginate=True)
+
+    # Pass 1: top-level daydream comment IDs and the fingerprints they carry.
+    top_level_daydream_ids: set[int] = set()
+    comment_id_by_fingerprint: dict[str, int] = {}
+    for comment in comments:
+        if comment.get("in_reply_to_id") is None and _is_daydream_comment(comment):
+            cid = comment["id"]
+            top_level_daydream_ids.add(cid)
+            for fingerprint in parse_finding_markers(comment.get("body") or ""):
+                comment_id_by_fingerprint.setdefault(fingerprint, cid)
+
+    # Pass 2: which top-level comments received a reply.
+    replied_ids: set[int] = set()
+    for comment in comments:
+        in_reply_to = comment.get("in_reply_to_id")
+        if in_reply_to in top_level_daydream_ids:
+            replied_ids.add(in_reply_to)
+
+    return PRCommentThreads(
+        top_level_daydream_ids=top_level_daydream_ids,
+        replied_ids=replied_ids,
+        comment_id_by_fingerprint=comment_id_by_fingerprint,
+    )
+
+
 def comment_resolution_signal(
     row: dict[str, Any],
     *,
     gh_api: Callable[..., Any],
+    threads: PRCommentThreads | None = None,
 ) -> CommentResolutionSignal:
     """Return a proxy for "review comments addressed".
 
@@ -415,31 +493,24 @@ def comment_resolution_signal(
 
     Args:
         row: Manifest row carrying ``pr_repo`` and ``pr_number``.
-        gh_api: Callable returning the parsed comment list.
+        gh_api: Callable returning the parsed comment list. Ignored when
+            ``threads`` is supplied.
+        threads: Pre-indexed comment threads from
+            :func:`index_pr_review_comments`. When supplied, the
+            ``/comments`` fetch is skipped, letting a caller that needs
+            both this and :func:`per_finding_resolution_signal` on one row
+            fetch the endpoint once.
 
     Returns:
         :class:`CommentResolutionSignal` with ``(0, 0, 0)`` when the row
         has no associated PR.
     """
-    repo = row.get("pr_repo")
-    number = row.get("pr_number")
-    if repo is None or number is None:
+    if threads is None:
+        threads = index_pr_review_comments(row, gh_api=gh_api)
+    if threads is None:
         return CommentResolutionSignal(total=0, replied=0, unresolved=0)
-
-    comments = gh_api(repo, f"repos/{repo}/pulls/{number}/comments", paginate=True)
-    top_level_daydream_ids: list[int] = []
-    replies_by_parent: dict[int, int] = {}
-
-    for comment in comments:
-        in_reply_to = comment.get("in_reply_to_id")
-        if in_reply_to is None:
-            if _is_daydream_comment(comment):
-                top_level_daydream_ids.append(comment["id"])
-        else:
-            replies_by_parent[in_reply_to] = replies_by_parent.get(in_reply_to, 0) + 1
-
-    total = len(top_level_daydream_ids)
-    replied = sum(1 for cid in top_level_daydream_ids if replies_by_parent.get(cid, 0) >= 1)
+    total = len(threads.top_level_daydream_ids)
+    replied = len(threads.replied_ids)
     return CommentResolutionSignal(total=total, replied=replied, unresolved=total - replied)
 
 
@@ -448,6 +519,7 @@ def per_finding_resolution_signal(
     *,
     recorded_fingerprints: list[str],
     gh_api: Callable[..., Any],
+    threads: PRCommentThreads | None = None,
 ) -> list[PerFindingResolution]:
     """Resolve each recorded finding to its posted comment and reply state.
 
@@ -462,44 +534,27 @@ def per_finding_resolution_signal(
         row: Manifest row carrying ``pr_repo`` and ``pr_number``.
         recorded_fingerprints: Fingerprints captured at review time. The
             returned list preserves this order, one entry per fingerprint.
-        gh_api: Callable returning the parsed comment list.
+        gh_api: Callable returning the parsed comment list. Ignored when
+            ``threads`` is supplied.
+        threads: Pre-indexed comment threads from
+            :func:`index_pr_review_comments`. When supplied, the
+            ``/comments`` fetch is skipped, letting a caller that needs
+            both this and :func:`comment_resolution_signal` on one row
+            fetch the endpoint once.
 
     Returns:
         One :class:`PerFindingResolution` per recorded fingerprint, or an
         empty list when the row has no associated PR.
     """
-    repo = row.get("pr_repo")
-    number = row.get("pr_number")
-    if repo is None or number is None:
+    if threads is None:
+        threads = index_pr_review_comments(row, gh_api=gh_api)
+    if threads is None:
         return []
-
-    comments = gh_api(repo, f"repos/{repo}/pulls/{number}/comments", paginate=True)
-
-    # Pass 1: top-level daydream comment IDs.
-    top_level_daydream_ids: set[int] = set()
-    for comment in comments:
-        if comment.get("in_reply_to_id") is None and _is_daydream_comment(comment):
-            top_level_daydream_ids.add(comment["id"])
-
-    # Pass 2: which top-level comments received a reply.
-    replied_ids: set[int] = set()
-    for comment in comments:
-        in_reply_to = comment.get("in_reply_to_id")
-        if in_reply_to in top_level_daydream_ids:
-            replied_ids.add(in_reply_to)
-
-    # Pass 3: map fingerprint -> the comment ID that carries its marker.
-    comment_id_by_fingerprint: dict[str, int] = {}
-    for comment in comments:
-        if comment["id"] not in top_level_daydream_ids:
-            continue
-        for fingerprint in parse_finding_markers(comment.get("body") or ""):
-            comment_id_by_fingerprint.setdefault(fingerprint, comment["id"])
 
     resolutions: list[PerFindingResolution] = []
     for fingerprint in recorded_fingerprints:
-        comment_id = comment_id_by_fingerprint.get(fingerprint)
-        resolved = comment_id is not None and comment_id in replied_ids
+        comment_id = threads.comment_id_by_fingerprint.get(fingerprint)
+        resolved = comment_id is not None and comment_id in threads.replied_ids
         resolutions.append(
             PerFindingResolution(fingerprint=fingerprint, resolved=resolved, comment_id=comment_id)
         )

--- a/daydream/training/rubric.py
+++ b/daydream/training/rubric.py
@@ -24,10 +24,13 @@ from daydream.training.labeler_signals import (
     CommentResolutionSignal,
     FixAppliedSignal,
     LocalCommitAppliedSignal,
+    PerFindingResolution,
     PRMergeSignal,
 )
 
 PosteriorSource = Literal["pr_review", "local_branch", "none"]
+
+PerFindingLabel = Literal["accepted", "contested", "rejected", "unknown", "missing"]
 
 
 @dataclass(frozen=True)
@@ -43,6 +46,9 @@ class Rubric:
             row originated from a PR.
         posterior_source: Discriminator selecting which sub-signal
             carries the authoritative outcome label.
+        per_finding_labels: One outcome label per recorded finding
+            (fingerprint-joined), or ``None`` when no per-finding join was
+            performed.
     """
 
     pr_merge: PRMergeSignal
@@ -50,6 +56,7 @@ class Rubric:
     comment_resolution: CommentResolutionSignal
     local_commit_applied: LocalCommitAppliedSignal | None
     posterior_source: PosteriorSource
+    per_finding_labels: list[str] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-serializable representation with explicit key order.
@@ -77,6 +84,8 @@ class Rubric:
         }
         if self.local_commit_applied is not None:
             out["local_commit_applied"] = {"verdict": self.local_commit_applied.verdict}
+        if self.per_finding_labels is not None:
+            out["per_finding_outcomes"] = list(self.per_finding_labels)
         return out
 
 
@@ -119,3 +128,44 @@ def derive_outcome_label(rubric: Rubric) -> str:
             return "rejected"
         return "unknown"
     return "unknown"
+
+
+def derive_per_finding_labels(
+    rubric: Rubric,
+    per_finding: list[PerFindingResolution],
+) -> list[PerFindingLabel]:
+    """Reduce per-finding resolutions to one outcome label per finding.
+
+    Only ``posterior_source == "pr_review"`` yields decisive per-finding
+    labels; any other source is inconclusive at finding granularity:
+
+    * ``"pr_review"`` on a **merged** PR:
+      - resolved (replied) → ``"accepted"``
+      - unresolved with a surviving comment → ``"contested"``
+      - unresolved with no comment (deleted / never posted) → ``"missing"``
+    * ``"pr_review"`` on an **unmerged** PR → all ``"rejected"``.
+    * any other posterior source → all ``"unknown"``.
+
+    Args:
+        rubric: The rubric whose posterior source and merge state decide
+            the mapping.
+        per_finding: The per-finding resolutions to label, in order.
+
+    Returns:
+        One :data:`PerFindingLabel` per entry in ``per_finding``, order
+        preserved.
+    """
+    if rubric.posterior_source != "pr_review":
+        return ["unknown" for _ in per_finding]
+    if not rubric.pr_merge.merged:
+        return ["rejected" for _ in per_finding]
+
+    labels: list[PerFindingLabel] = []
+    for resolution in per_finding:
+        if resolution.resolved:
+            labels.append("accepted")
+        elif resolution.comment_id is not None:
+            labels.append("contested")
+        else:
+            labels.append("missing")
+    return labels

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -75,6 +75,7 @@ class _MockConfig:
     archive: bool = True
     run_eval: bool = False
     file_config: DaydreamFileConfig | None = None
+    findings_out: str | None = None
 
 
 def test_parse_repo_slug_ssh():
@@ -493,7 +494,7 @@ def _setup_bundle(
 
 def test_copy_bundle_trajectory(tmp_path: Path):
     target, run_dir, recorder = _setup_bundle(tmp_path)
-    _copy_bundle(target, run_dir, recorder)
+    _copy_bundle(target, run_dir, recorder, RunConfig())
 
     assert (run_dir / "trajectory.json").exists()
     assert json.loads((run_dir / "trajectory.json").read_text())["session_id"] == "test"
@@ -509,28 +510,28 @@ def test_copy_bundle_partial_trajectory(tmp_path: Path):
     )
     partial.write_text('{"partial": true}')
 
-    _copy_bundle(target, run_dir, recorder)
+    _copy_bundle(target, run_dir, recorder, RunConfig())
 
     assert json.loads((run_dir / "trajectory.json.partial").read_text())["partial"] is True
 
 
 def test_copy_bundle_review_output(tmp_path: Path):
     target, run_dir, recorder = _setup_bundle(tmp_path)
-    _copy_bundle(target, run_dir, recorder)
+    _copy_bundle(target, run_dir, recorder, RunConfig())
 
     assert (run_dir / "review-output.md").read_text() == "review findings"
 
 
 def test_copy_bundle_deep_directory(tmp_path: Path):
     target, run_dir, recorder = _setup_bundle(tmp_path)
-    _copy_bundle(target, run_dir, recorder)
+    _copy_bundle(target, run_dir, recorder, RunConfig())
 
     assert (run_dir / "deep" / "intent.md").read_text() == "intent"
 
 
 def test_copy_bundle_diff_patch(tmp_path: Path):
     target, run_dir, recorder = _setup_bundle(tmp_path)
-    _copy_bundle(target, run_dir, recorder)
+    _copy_bundle(target, run_dir, recorder, RunConfig())
 
     assert (run_dir / "diff.patch").read_text() == "diff content"
 
@@ -538,7 +539,7 @@ def test_copy_bundle_diff_patch(tmp_path: Path):
 def test_copy_bundle_sub_trajectories_copied(tmp_path: Path):
     """Sibling trajectories under the live run dir copy verbatim — no prefix filtering."""
     target, run_dir, recorder = _setup_bundle(tmp_path)
-    _copy_bundle(target, run_dir, recorder)
+    _copy_bundle(target, run_dir, recorder, RunConfig())
 
     sub = run_dir / "trajectories"
     assert sub.is_dir()
@@ -556,7 +557,7 @@ def test_copy_bundle_explicit_trajectory_path(tmp_path: Path):
     custom_traj.write_text('{"custom": true}')
 
     recorder = _make_recorder_mock(session_id, custom_traj, explicit_path=True)
-    _copy_bundle(target, run_dir, recorder)
+    _copy_bundle(target, run_dir, recorder, RunConfig())
 
     # The custom path is copied on top of the run dir as trajectory.json.
     archived = json.loads((run_dir / "trajectory.json").read_text())
@@ -571,12 +572,36 @@ def test_copy_bundle_skips_missing(tmp_path: Path):
     run_dir.mkdir()
 
     recorder = _make_recorder_mock("no-match-session-id-here", tmp_path / "nonexistent.json")
-    _copy_bundle(target, run_dir, recorder)
+    _copy_bundle(target, run_dir, recorder, RunConfig())
 
     assert not (run_dir / "trajectory.json").exists()
     assert not (run_dir / "review-output.md").exists()
     assert not (run_dir / "deep").exists()
     assert not (run_dir / "diff.patch").exists()
+
+
+def test_copy_bundle_archives_findings_artifact(tmp_path: Path):
+    """findings.json from --findings-out is archived so harvest's per-finding join has a source."""
+    target, run_dir, recorder = _setup_bundle(tmp_path)
+    # Review-bot workflow writes findings.json under the repo root (CWD at run time).
+    findings_src = target / "findings" / "findings.json"
+    findings_src.parent.mkdir(parents=True)
+    findings_src.write_text('{"findings": [{"fingerprint": "abc"}]}')
+
+    config = RunConfig(findings_out="findings/findings.json")
+    _copy_bundle(target, run_dir, recorder, config)
+
+    archived = run_dir / "findings.json"
+    assert archived.exists()
+    assert json.loads(archived.read_text())["findings"][0]["fingerprint"] == "abc"
+
+
+def test_copy_bundle_findings_artifact_skipped_without_findings_out(tmp_path: Path):
+    """No findings_out means no findings.json is archived (no source to copy)."""
+    target, run_dir, recorder = _setup_bundle(tmp_path)
+    _copy_bundle(target, run_dir, recorder, RunConfig())
+
+    assert not (run_dir / "findings.json").exists()
 
 
 def test_archive_run_round_trip(tmp_path: Path, archive_dir: Path):

--- a/tests/test_archive_integration.py
+++ b/tests/test_archive_integration.py
@@ -152,6 +152,50 @@ async def test_full_archive_round_trip(tmp_path: Path, archive_dir: Path) -> Non
         conn.close()
 
 
+async def test_archive_persists_findings_artifact_for_pr_run(tmp_path: Path, archive_dir: Path) -> None:
+    """Real-path: findings.json from --findings-out is archived so harvest's per-finding join is non-inert."""
+    from daydream.runner import RunConfig, _make_archive_callback
+
+    target_dir = tmp_path / "project"
+    target_dir.mkdir()
+    daydream_dir = target_dir / ".daydream"
+    daydream_dir.mkdir()
+    (target_dir / ".review-output.md").write_text("# Review\n")
+
+    # The review-bot workflow writes findings.json under the repo root (CWD at run time).
+    findings_src = target_dir / "findings" / "findings.json"
+    findings_src.parent.mkdir(parents=True)
+    findings_src.write_text(
+        '{"schema_version": 1, "findings": [{"fingerprint": "deadbeef"}]}'
+    )
+
+    config = RunConfig(
+        target=str(target_dir),
+        skill="python",
+        backend="claude",
+        archive=True,
+        run_eval=False,
+        findings_out="findings/findings.json",
+    )
+
+    recorder = TrajectoryRecorder(
+        path=daydream_dir / "trajectory.json",
+        run_flow=DaydreamRunFlow.NORMAL,
+        target_dir=target_dir,
+        agent_model_name="opus",
+        session_id="findings-test",
+        on_write=_make_archive_callback(config, target_dir),
+    )
+
+    async with recorder:
+        _add_user_step(recorder)
+
+    run_dir = archive_dir / "runs" / recorder.session_id
+    archived = run_dir / "findings.json"
+    assert archived.is_file()
+    assert json.loads(archived.read_text(encoding="utf-8"))["findings"][0]["fingerprint"] == "deadbeef"
+
+
 async def test_archive_populates_wall_clock_without_eval(tmp_path: Path, archive_dir: Path) -> None:
     """Real-path: manifest.json carries wall_clock_seconds even when --eval did not run."""
     from daydream.runner import RunConfig, _make_archive_callback

--- a/tests/test_training_harvest.py
+++ b/tests/test_training_harvest.py
@@ -20,7 +20,7 @@ from daydream.archive.index import (
 )
 from daydream.archive.manifest import Manifest
 from daydream.git_ops import GitError
-from daydream.pr_review import DAYDREAM_FOOTER
+from daydream.pr_review import DAYDREAM_FOOTER, finding_marker
 from daydream.training import harvest
 from daydream.training.backfill_cache import BackfillCache
 from daydream.training.harvest import (
@@ -179,6 +179,56 @@ def test_build_annotation_pr_row_carries_label_reward_and_merge_valid_at(tmp_pat
     assert ann.labels == ["accepted"]
     assert ann.valid_at == "2026-02-01T00:00:00+00:00"        # PR merge time (Q2)
     assert ann.composite_reward == json.loads(ann.reward_json)["composite"]
+
+
+def _fake_gh_merged_per_finding(merged_at: str, fp_replied: str, fp_unreplied: str):
+    """A merged PR with two daydream finding comments: one replied, one not.
+
+    Reuses the labeler responder shape but the ``comments`` endpoint carries
+    two footer-marked daydream comments whose bodies embed the finding
+    markers; a human reply targets only the first.
+    """
+
+    def responder(repo: str, endpoint: str, **kwargs: Any) -> Any:
+        if endpoint.endswith("/comments"):
+            return [
+                {
+                    "id": 1,
+                    "in_reply_to_id": None,
+                    "user": {"login": "daydream-runner"},
+                    "body": f"finding\n\n{finding_marker(fp_replied)}\n\n{DAYDREAM_FOOTER}",
+                },
+                {
+                    "id": 2,
+                    "in_reply_to_id": None,
+                    "user": {"login": "daydream-runner"},
+                    "body": f"finding\n\n{finding_marker(fp_unreplied)}\n\n{DAYDREAM_FOOTER}",
+                },
+                {"id": 3, "in_reply_to_id": 1, "user": {"login": "human"}, "body": "fixed"},
+            ]
+        if endpoint.endswith("/reviews"):
+            return []
+        return {"merged": True, "merged_at": merged_at}
+
+    return responder
+
+
+def test_build_annotation_pr_row_carries_per_finding_outcomes(tmp_path):
+    """A merged PR with a findings.json in the archive yields per-finding labels
+    joined by fingerprint: the replied finding is accepted, the unreplied one contested."""
+    fp_a = "a" * 64
+    fp_b = "b" * 64
+    run_dir = _seed_deep_bronze(tmp_path, verdict="consistent", grounding=1.0)
+    (run_dir / "findings.json").write_text(
+        json.dumps({"findings": [{"fingerprint": fp_a}, {"fingerprint": fp_b}]})
+    )
+    row = {"session_id": "s_pf", "pr_repo": "o/r", "pr_number": 7, "head_sha": "h",
+           "base_branch": "main", "archive_path": str(run_dir),
+           "grounding_rate": 1.0, "changed_files": "[]"}
+    ann = build_annotation(row, run_dir=run_dir, archive_dir=tmp_path,
+                           gh_api=_fake_gh_merged_per_finding("2026-02-01T00:00:00+00:00", fp_a, fp_b),
+                           repo_clone=tmp_path)
+    assert json.loads(ann.rubric_json)["per_finding_outcomes"] == ["accepted", "contested"]
 
 
 def test_build_annotation_applies_posterior_penalty_for_rejected_pr(tmp_path):

--- a/tests/test_training_labeler_signals.py
+++ b/tests/test_training_labeler_signals.py
@@ -9,15 +9,17 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from daydream.pr_review import DAYDREAM_FOOTER
+from daydream.pr_review import DAYDREAM_FOOTER, finding_marker
 from daydream.training.labeler_signals import (
     CommentResolutionSignal,
     FixAppliedSignal,
     LocalCommitAppliedSignal,
+    PerFindingResolution,
     PRMergeSignal,
     comment_resolution_signal,
     fix_applied_signal,
     local_commit_applied_signal,
+    per_finding_resolution_signal,
     pr_link_signal,
     pr_merge_signal,
     reviewer_logins_signal,
@@ -304,3 +306,76 @@ def test_pr_link_signal_returns_none_when_no_head_sha_match() -> None:
 def test_pr_link_signal_returns_none_without_required_fields() -> None:
     gh = _fake_commits_pulls([])  # must NOT be called (missing head_sha short-circuits)
     assert pr_link_signal({"repo_slug": "org/repo"}, gh_api=gh) is None
+
+
+_FP_A = "a" * 64
+_FP_B = "b" * 64
+_FP_C = "c" * 64
+
+
+def _daydream_finding_comment(comment_id: int, fingerprint: str) -> dict:
+    """A top-level daydream review comment carrying the footer + finding marker."""
+    return {
+        "id": comment_id,
+        "in_reply_to_id": None,
+        "user": {"login": "daydream-runner"},
+        "body": f"A finding.\n\n{finding_marker(fingerprint)}\n\n{DAYDREAM_FOOTER}",
+    }
+
+
+def test_per_finding_resolution_signal_mixed_outcomes() -> None:
+    """Two findings: one replied (resolved), one not (unresolved)."""
+    row = {"pr_repo": "org/repo", "pr_number": 42}
+    gh = _fake_gh_responder(
+        {
+            ("org/repo", "repos/org/repo/pulls/42/comments"): [
+                _daydream_finding_comment(1, _FP_A),
+                _daydream_finding_comment(2, _FP_B),
+                {"id": 3, "in_reply_to_id": 1, "user": {"login": "human"}, "body": "fixed"},
+            ],
+        }
+    )
+    result = per_finding_resolution_signal(row, recorded_fingerprints=[_FP_A, _FP_B], gh_api=gh)
+    assert result == [
+        PerFindingResolution(fingerprint=_FP_A, resolved=True, comment_id=1),
+        PerFindingResolution(fingerprint=_FP_B, resolved=False, comment_id=2),
+    ]
+
+
+def test_per_finding_resolution_signal_deleted_comment() -> None:
+    """A recorded fingerprint with no surviving comment → comment_id=None, unresolved."""
+    row = {"pr_repo": "org/repo", "pr_number": 42}
+    gh = _fake_gh_responder(
+        {
+            ("org/repo", "repos/org/repo/pulls/42/comments"): [
+                _daydream_finding_comment(1, _FP_A),
+            ],
+        }
+    )
+    result = per_finding_resolution_signal(row, recorded_fingerprints=[_FP_A, _FP_C], gh_api=gh)
+    assert result == [
+        PerFindingResolution(fingerprint=_FP_A, resolved=False, comment_id=1),
+        PerFindingResolution(fingerprint=_FP_C, resolved=False, comment_id=None),
+    ]
+
+
+def test_per_finding_resolution_signal_single_finding() -> None:
+    """Standard single-finding case with a reply → resolved."""
+    row = {"pr_repo": "org/repo", "pr_number": 42}
+    gh = _fake_gh_responder(
+        {
+            ("org/repo", "repos/org/repo/pulls/42/comments"): [
+                _daydream_finding_comment(9, _FP_A),
+                {"id": 10, "in_reply_to_id": 9, "user": {"login": "human"}, "body": "ack"},
+            ],
+        }
+    )
+    result = per_finding_resolution_signal(row, recorded_fingerprints=[_FP_A], gh_api=gh)
+    assert result == [PerFindingResolution(fingerprint=_FP_A, resolved=True, comment_id=9)]
+
+
+def test_per_finding_resolution_signal_no_pr() -> None:
+    """No PR (repo/number None) → empty list, no API call."""
+    row = {"pr_repo": None, "pr_number": None}
+    result = per_finding_resolution_signal(row, recorded_fingerprints=[_FP_A], gh_api=_fake_gh_responder({}))
+    assert result == []

--- a/tests/test_training_rubric.py
+++ b/tests/test_training_rubric.py
@@ -6,9 +6,15 @@ from daydream.training.labeler_signals import (
     CommentResolutionSignal,
     FixAppliedSignal,
     LocalCommitAppliedSignal,
+    PerFindingResolution,
     PRMergeSignal,
 )
-from daydream.training.rubric import Rubric, derive_outcome_label
+from daydream.training.rubric import (
+    PosteriorSource,
+    Rubric,
+    derive_outcome_label,
+    derive_per_finding_labels,
+)
 
 
 def test_rubric_serializes_to_dict_with_pr_source() -> None:
@@ -101,3 +107,51 @@ def test_outcome_label_unknown_when_no_signal_at_all() -> None:
         posterior_source="none",
     )
     assert derive_outcome_label(rub) == "unknown"
+
+
+def _pr_rubric(*, merged: bool, source: PosteriorSource = "pr_review") -> Rubric:
+    """A minimal rubric for per-finding label derivation."""
+    return Rubric(
+        pr_merge=PRMergeSignal(merged, "2026-01-01T00:00:00Z" if merged else None),
+        fix_applied=FixAppliedSignal("unknown", 0, 0, []),
+        comment_resolution=CommentResolutionSignal(0, 0, 0),
+        local_commit_applied=None if source == "pr_review" else LocalCommitAppliedSignal("unknown"),
+        posterior_source=source,
+    )
+
+
+def test_derive_per_finding_labels_mixed() -> None:
+    """Merged PR: a replied finding is accepted, an unreplied one contested."""
+    rub = _pr_rubric(merged=True)
+    per_finding = [
+        PerFindingResolution(fingerprint="a" * 64, resolved=True, comment_id=1),
+        PerFindingResolution(fingerprint="b" * 64, resolved=False, comment_id=2),
+    ]
+    assert derive_per_finding_labels(rub, per_finding) == ["accepted", "contested"]
+
+
+def test_derive_per_finding_labels_rejected() -> None:
+    """Unmerged PR: every finding is rejected regardless of reply state."""
+    rub = _pr_rubric(merged=False)
+    per_finding = [
+        PerFindingResolution(fingerprint="a" * 64, resolved=True, comment_id=1),
+        PerFindingResolution(fingerprint="b" * 64, resolved=False, comment_id=None),
+    ]
+    assert derive_per_finding_labels(rub, per_finding) == ["rejected", "rejected"]
+
+
+def test_derive_per_finding_labels_missing() -> None:
+    """Merged PR: an unresolved finding whose comment vanished is missing."""
+    rub = _pr_rubric(merged=True)
+    per_finding = [PerFindingResolution(fingerprint="a" * 64, resolved=False, comment_id=None)]
+    assert derive_per_finding_labels(rub, per_finding) == ["missing"]
+
+
+def test_derive_per_finding_labels_local_branch() -> None:
+    """Non-pr_review posterior yields unknown for every finding."""
+    rub = _pr_rubric(merged=False, source="local_branch")
+    per_finding = [
+        PerFindingResolution(fingerprint="a" * 64, resolved=True, comment_id=1),
+        PerFindingResolution(fingerprint="b" * 64, resolved=False, comment_id=2),
+    ]
+    assert derive_per_finding_labels(rub, per_finding) == ["unknown", "unknown"]


### PR DESCRIPTION
# feat(training): stable per-finding join key for accept/reject labels

## Summary

- Adds per-finding resolution tracking to the training pipeline: each recorded finding is joined back to its posted PR comment via the existing 64-hex fingerprint, yielding individual `accepted`/`contested`/`rejected`/`missing` labels rather than a single run-level aggregate.
- Archives `findings.json` into the run bundle so `_row_recorded_fingerprints` has a real data source in production.
- Deduplicates the `/comments` API call between `comment_resolution_signal` and `per_finding_resolution_signal` via a shared `index_pr_review_comments()` helper.

## Motivation

Auto-labeling could only produce one run-level outcome label — never per-finding accept/reject — because there was no stable join key linking a recorded finding to its PR comment's resolution state. The fingerprint already flowed from finding to PR comment body (`<!-- daydream-finding: <fp> -->`), but `comment_resolution_signal` counted aggregate comment totals only. For a code-review reward model, per-finding signal is the point: "this finding was acted on, that one was noise."

Closes #123.

## Changes

### Added
- `PerFindingResolution` dataclass + `per_finding_resolution_signal()` in `labeler_signals.py` — fetches PR comments, extracts fingerprints via `parse_finding_markers`, matches each recorded fingerprint to its comment's reply state (resolved/unresolved/comment-missing).
- `PerFindingLabel` type + `derive_per_finding_labels()` in `rubric.py` — produces per-finding labels from the rubric + per-finding resolution list.
- `per_finding_labels: list[str] | None` field on `Rubric`, serialized as `per_finding_outcomes` in `to_dict()`.
- `_row_recorded_fingerprints()` in `harvest.py` — extracts fingerprints from a pre-extracted column or the archived `findings.json`.
- `findings.json` archiving in `_copy_bundle` — the findings artifact is now persisted in the run bundle so the per-finding join has a real data source.
- `index_pr_review_comments()` shared helper — single source of truth for the `/comments` fetch + daydream-thread indexing, used by both `comment_resolution_signal` and `per_finding_resolution_signal`.

### Changed
- `_build_rubric_pr()` in `harvest.py` — now calls `per_finding_resolution_signal()` + `derive_per_finding_labels()` when recorded fingerprints are available, storing the result on the Rubric.
- `Rubric.to_dict()` — emits `per_finding_outcomes` when `per_finding_labels` is not None.

### Unchanged (backward compatible)
- `CommentResolutionSignal` dataclass and `comment_resolution_signal()` signature unchanged.
- `derive_outcome_label()` unchanged — run-level aggregate label is preserved.
- Existing Rubric constructors work unchanged (`per_finding_labels` defaults to `None`).

## Test Plan

- [x] `uv run make check` — lint + typecheck + 1996 passed, 5 skipped
- [x] `test_per_finding_resolution_signal_mixed_outcomes` — 2 findings, one replied, one not
- [x] `test_per_finding_resolution_signal_deleted_comment` — fingerprint in recorded set, no comment found
- [x] `test_per_finding_resolution_signal_single_finding` — standard single-finding case
- [x] `test_per_finding_resolution_signal_no_pr` — empty result when no PR
- [x] `test_derive_per_finding_labels_mixed` — merged PR, one accepted, one contested
- [x] `test_derive_per_finding_labels_rejected` — not merged
- [x] `test_derive_per_finding_labels_missing` — comment deleted
- [x] `test_derive_per_finding_labels_local_branch` — local_branch posterior
- [x] `test_build_annotation_pr_row_carries_per_finding_outcomes` — real-path integration test through harvest
- [x] Findings.json archiving verified via real-path archive integration test

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check`)
- [x] Type checking passes (`uv run mypy daydream`)
- [ ] Documentation updated (if applicable)