### PR TITLE
feat(review): precision-mode arbiter suppression for evidenced-but-minor findings (#232)

### DIFF
--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -614,6 +614,16 @@ def _build_main_parser(*, full_help: bool = False) -> argparse.ArgumentParser:
         help="Single-stack review (skip multi-stack auto-detection).",
     )
     parser.add_argument(
+        "--precision",
+        action="store_true",
+        default=False,
+        dest="precision",
+        help="Enable precision mode: run a skeptical suppression pass over borderline "
+             "findings after the arbiter (issue #232; fail-closed). Also settable "
+             "via [tool.daydream] precision_mode in a config file."
+        if full_help else argparse.SUPPRESS,
+    )
+    parser.add_argument(
         "--copy",
         action="append",
         default=[],
@@ -911,6 +921,7 @@ def _parse_args(argv: list[str] | None = None) -> RunConfig:
         findings_out=args.findings_out,
         force_worktree=args.force_worktree,
         shallow=args.shallow,
+        precision_mode=args.precision,
         extra_copy=list(args.extra_copy),
         non_interactive=args.non_interactive,
         assume=args.assume,

--- a/daydream/config.py
+++ b/daydream/config.py
@@ -49,8 +49,12 @@ DEFAULT_TOOL_CALL_BUDGET = 50
 #
 # Claude tiering:
 #   - cheap (haiku):   PARSE
-#   - mid   (sonnet):  FIX, TEST, EXPLORATION, PER_STACK_REVIEW, INTENT
+#   - mid   (sonnet):  FIX, TEST, EXPLORATION, PER_STACK_REVIEW, INTENT, SUPPRESSION
 #   - heavy (opus):    REVIEW, WONDER, MERGE, PR_FEEDBACK, ARBITER
+#
+# ``suppression`` (issue #232) is the precision-mode skeptical second opinion over
+# borderline uncontested findings; it runs on the cheap mid tier by design (never
+# per-finding Opus) -- one batched Sonnet call over all suppression targets.
 #
 # ``per_stack_review`` and ``arbiter`` split the deep per-stack fan-out off the
 # heavy ``review`` tier (issue #168): the N per-stack reviewers run on Sonnet
@@ -75,6 +79,7 @@ PHASE_DEFAULT_MODELS: dict[str, dict[str, str]] = {
         "per_stack_review": "claude-sonnet-4-6",
         "review": "claude-opus-4-8",
         "arbiter": "claude-opus-4-8",
+        "suppression": "claude-sonnet-4-6",
         "wonder": "claude-opus-4-8",
         "merge": "claude-opus-4-8",
         "intent": "claude-sonnet-4-6",
@@ -89,6 +94,7 @@ PHASE_DEFAULT_MODELS: dict[str, dict[str, str]] = {
         "per_stack_review": "gpt-5.5",
         "review": "gpt-5.5",
         "arbiter": "gpt-5.5",
+        "suppression": "gpt-5.5",
         "wonder": "gpt-5.5",
         "merge": "gpt-5.5",
         "intent": "gpt-5.5",
@@ -103,6 +109,7 @@ PHASE_DEFAULT_MODELS: dict[str, dict[str, str]] = {
         "per_stack_review": "glm-5.2",
         "review": "glm-5.2",
         "arbiter": "glm-5.2",
+        "suppression": "glm-5.2",
         "wonder": "glm-5.2",
         "merge": "glm-5.2",
         "intent": "glm-5.2",

--- a/daydream/config_file.py
+++ b/daydream/config_file.py
@@ -38,6 +38,9 @@ class DaydreamFileConfig:
             tiny-diff short-circuit in deep mode (issue #172). ``None`` falls
             through to the RunConfig field / orchestrator default. ``0``
             explicitly disables the short-circuit.
+        precision_mode: Opt-in precision suppression (issue #232). ``None`` falls
+            through to the RunConfig field / orchestrator default; ``True`` runs
+            the skeptical suppression pass over borderline findings.
     """
 
     model: str | None = None
@@ -45,6 +48,7 @@ class DaydreamFileConfig:
     phases: dict[str, dict[str, str]] = field(default_factory=dict)
     bench: dict[str, Any] = field(default_factory=dict)
     shallow_fanout_threshold: int | None = None
+    precision_mode: bool | None = None
 
     def phase_model(self, phase: str) -> str | None:
         """Return the configured model for a phase.
@@ -218,10 +222,16 @@ def load_file_config(root: Path) -> DaydreamFileConfig:
         threshold = raw_threshold
     else:
         threshold = None
+    # precision_mode: bool only. Any non-bool value (str, int, list) degrades to
+    # None rather than crashing the loader; truthy ints are *not* coerced to True
+    # so an accidental ``precision_mode = 1`` is treated as unset, not enabled.
+    raw_precision = merged.get("precision_mode")
+    precision: bool | None = raw_precision if isinstance(raw_precision, bool) else None
     return DaydreamFileConfig(
         model=str(model) if model is not None else None,
         backend=str(backend) if backend is not None else None,
         phases=_coerce_phases(merged.get("phases")),
         bench=dict(merged["bench"]) if isinstance(merged.get("bench"), dict) else {},
         shallow_fanout_threshold=threshold,
+        precision_mode=precision,
     )

--- a/daydream/deep/arbiter.py
+++ b/daydream/deep/arbiter.py
@@ -23,6 +23,7 @@ arbitrated — an accepted cost trade-off of the high-OR-contested selection sco
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Iterable
 from typing import Any
 
 
@@ -30,6 +31,12 @@ def _severity(record: dict[str, Any]) -> str:
     """Normalize a record's severity to a lowercase string ("" when absent)."""
     value = record.get("severity")
     return value.lower() if isinstance(value, str) else ""
+
+
+def _confidence(record: dict[str, Any]) -> str:
+    """Normalize a record's confidence to an uppercase string ("" when absent)."""
+    value = record.get("confidence")
+    return value.upper() if isinstance(value, str) else ""
 
 
 def select_arbiter_targets(
@@ -79,3 +86,56 @@ def select_arbiter_targets(
             selected.update(indices)
 
     return sorted(selected)
+
+
+def select_suppression_targets(
+    records: list[dict[str, Any]],
+    sources: list[str],
+    exclude: Iterable[int] = (),
+) -> list[int]:
+    """Return indices of borderline, uncontested records for the suppression pass (#232).
+
+    The precision-mode suppression pass gives a skeptical LLM second opinion to
+    *evidenced-but-minor* findings the arbiter never scrutinizes: records that are
+    ``confidence == "LOW"`` and/or ``severity == "low"`` and are neither
+    high-severity nor contested. It mirrors :func:`select_arbiter_targets` as a
+    pure, side-effect-free predicate so it can be unit-tested against adversarial
+    shapes independent of any agent call.
+
+    High-severity and contested records reach the *arbiter* (fail-open); this pass
+    must never touch them, so callers pass the arbiter's target indices as
+    ``exclude``. Because that set already covers every high-severity and contested
+    record, excluding it leaves only low/medium uncontested records -- of which the
+    LOW-confidence / low-severity ones are the borderline findings selected here.
+
+    Args:
+        records: Parsed per-stack records (each ideally carrying ``severity`` and
+            ``confidence``).
+        sources: Per-record originating stack name, positionally aligned with
+            ``records`` (``len(sources) == len(records)``). Accepted for signature
+            symmetry with :func:`select_arbiter_targets`; contestedness is handled
+            entirely through ``exclude``.
+        exclude: Indices to skip (the arbiter target set). A record already routed
+            to the arbiter is never a suppression target.
+
+    Returns:
+        Sorted, de-duplicated list of indices into ``records`` selected for the
+        suppression pass: every ``exclude``-free record that is LOW-confidence
+        or low-severity.
+
+    Raises:
+        ValueError: If ``records`` and ``sources`` differ in length.
+    """
+    if len(records) != len(sources):
+        raise ValueError(
+            f"records/sources length mismatch: {len(records)} != {len(sources)}"
+        )
+
+    excluded = set(exclude)
+    selected: list[int] = []
+    for i, record in enumerate(records):
+        if i in excluded:
+            continue
+        if _confidence(record) == "LOW" or _severity(record) == "low":
+            selected.append(i)
+    return selected

--- a/daydream/deep/artifacts.py
+++ b/daydream/deep/artifacts.py
@@ -73,6 +73,17 @@ def arbiter_input_path(deep_dir_path: Path) -> Path:
     return deep_dir_path / "arbiter-input.json"
 
 
+def suppression_input_path(deep_dir_path: Path) -> Path:
+    """Precision-mode suppression input findings JSON (issue #232).
+
+    The borderline (LOW-confidence / low-severity uncontested) per-stack records
+    selected for the skeptical suppression pass, each tagged with a ``sup_id`` the
+    suppression agent echoes back. Distinct from ``arbiter-input.json`` so a run's
+    arbiter and suppression inputs are separately auditable.
+    """
+    return deep_dir_path / "suppression-input.json"
+
+
 def arbiter_complete_path(deep_dir_path: Path) -> Path:
     """Marker proving the scoped arbiter pass finalised the per-stack records (#175).
 

--- a/daydream/deep/artifacts.py
+++ b/daydream/deep/artifacts.py
@@ -84,15 +84,23 @@ def suppression_input_path(deep_dir_path: Path) -> Path:
     return deep_dir_path / "suppression-input.json"
 
 
-def arbiter_complete_path(deep_dir_path: Path) -> Path:
-    """Marker proving the scoped arbiter pass finalised the per-stack records (#175).
+def adjudication_complete_path(deep_dir_path: Path) -> Path:
+    """Marker proving the WHOLE adjudication block finalised the per-stack records.
 
-    Written only once the on-disk ``stack-*-records.json`` are known-final for a
-    fresh run -- either after ``_rewrite_stack_records`` persists the arbiter's
-    verdicts, or when nothing qualified for arbitration. Its presence lets a
-    ``--start-at merge`` resume trust the records; its absence forces arbitration
-    to re-run from disk so an interrupted arbiter pass cannot leak unarbitrated
-    high-severity findings into the merge.
+    Covers BOTH adjudication passes that rewrite ``stack-*-records.json`` before
+    the cross-stack merge: the scoped arbiter (#168) AND, when precision mode is
+    on, the suppression pass (#232). Written only once the on-disk records are
+    known-final for a fresh run -- after ``_rewrite_stack_records`` persists the
+    final pass's verdicts, or when nothing qualified for either pass. Its presence
+    lets a ``--start-at merge`` resume trust the records; its absence forces the
+    whole block to re-run from disk so an interrupted arbiter OR suppression pass
+    cannot leak partly-adjudicated findings into the merge.
+
+    The on-disk filename is kept as ``arbiter-complete.marker`` (not renamed when
+    suppression was added) so an in-flight run dir from before that change still
+    satisfies ``--start-at merge`` resume; do not rename the file without a
+    migration. The symbol was renamed from ``arbiter_complete_path`` so the scope
+    it actually proves (both passes) is not silently under-read as arbiter-only.
     """
     return deep_dir_path / "arbiter-complete.marker"
 

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -523,7 +523,6 @@ def _apply_adjudication_verdicts(
         if fail_closed
         else "retaining the original record unchanged"
     )
-    revised: dict[int, dict[str, Any]] = {}
     dropped: set[int] = set()
     for offset, record_index in enumerate(targets):
         verdict_id = offset + 1
@@ -555,21 +554,26 @@ def _apply_adjudication_verdicts(
         if not verdict.get("keep", False):
             dropped.add(record_index)
             continue
-        revised[record_index] = {
-            **records[record_index],
-            "severity": verdict.get("severity", records[record_index].get("severity")),
-            "confidence": verdict.get("confidence", records[record_index].get("confidence")),
-            "description": verdict.get("description", records[record_index].get("description")),
-            "rationale": verdict.get("rationale", records[record_index].get("rationale")),
-            "evidence": verdict.get("evidence", records[record_index].get("evidence")),
-        }
+        # Revise IN PLACE so the record keeps its object identity across this
+        # compaction. The suppression call site keys its arbiter-exclusion set by
+        # ``id(record)`` (#232); a revised record that got a fresh dict here would
+        # escape that set and be wrongly re-judged by the suppression pass.
+        records[record_index].update(
+            {
+                "severity": verdict.get("severity", records[record_index].get("severity")),
+                "confidence": verdict.get("confidence", records[record_index].get("confidence")),
+                "description": verdict.get("description", records[record_index].get("description")),
+                "rationale": verdict.get("rationale", records[record_index].get("rationale")),
+                "evidence": verdict.get("evidence", records[record_index].get("evidence")),
+            }
+        )
 
     new_records: list[dict[str, Any]] = []
     new_sources: list[str] = []
     for i, (record, source) in enumerate(zip(records, sources, strict=True)):
         if i in dropped:
             continue
-        new_records.append(revised.get(i, record))
+        new_records.append(record)
         new_sources.append(source)
     return new_records, new_sources
 
@@ -951,14 +955,15 @@ async def _step_arbiter(ctx: FlowContext) -> None:
         # Capture the identities of records the arbiter will see, before
         # `_apply_adjudication_verdicts` compacts the list (#232). `arbiter_targets`
         # are indices into this pre-apply list; once records are dropped the
-        # indices shift, so suppression exclusion must be keyed by record
-        # identity -- not by the stale positional indices -- or a borderline
-        # record shifting into a dropped slot is silently skipped and an
-        # arbiter-kept record revised down to low severity is wrongly re-judged.
-        arbitrated_ids = {
-            (all_records[i].get("file"), all_records[i].get("line"))
-            for i in arbiter_targets
-        }
+        # indices shift, so suppression exclusion must be keyed by per-record
+        # object identity -- not by the stale positional indices, and not by
+        # `(file, line)`: two findings can share one location while only one is
+        # arbitrated (a HIGH sibling arbitrated, a LOW sibling not), and a
+        # `(file, line)` key would wrongly exclude BOTH, silently skipping the
+        # LOW sibling from suppression. `_apply_adjudication_verdicts` revises
+        # records in place, so kept AND revised arbiter records keep their
+        # identity here; only dropped records fall out.
+        arbitrated_ids = {id(all_records[i]) for i in arbiter_targets}
         if arbiter_targets:
             async with phase_scope(DaydreamPhase.DEEP, stage="arbiter"):
                 verdicts = await phase_arbiter_review(
@@ -991,9 +996,7 @@ async def _step_arbiter(ctx: FlowContext) -> None:
         # phase key (Sonnet default) -- never per-finding Opus.
         if _precision_mode(config):
             suppression_exclude = [
-                i
-                for i, r in enumerate(all_records)
-                if (r.get("file"), r.get("line")) in arbitrated_ids
+                i for i, r in enumerate(all_records) if id(r) in arbitrated_ids
             ]
             suppression_targets = select_suppression_targets(
                 all_records, record_sources, suppression_exclude

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -28,10 +28,7 @@ from daydream.agent import console, get_assume, get_non_interactive, resolve_or_
 from daydream.config import REVIEW_OUTPUT_FILE, STRUCTURE_STACK_NAME
 from daydream.deep.arbiter import select_arbiter_targets, select_suppression_targets
 from daydream.deep.artifacts import (
-    alternatives_path as _alternatives_path,
-)
-from daydream.deep.artifacts import (
-    arbiter_complete_path,
+    adjudication_complete_path,
     check_deep_artifacts,
     dedup_candidates_path,
     deep_dir,
@@ -40,6 +37,9 @@ from daydream.deep.artifacts import (
     merged_items_path,
     per_stack_failures_path,
     per_stack_records_path,
+)
+from daydream.deep.artifacts import (
+    alternatives_path as _alternatives_path,
 )
 from daydream.deep.artifacts import (
     intent_path as _intent_path,
@@ -192,6 +192,35 @@ def _shallow_fanout_threshold(config: RunConfig) -> int:
     if file_config is not None and file_config.shallow_fanout_threshold is not None:
         return file_config.shallow_fanout_threshold
     return DEFAULT_SHALLOW_FANOUT_THRESHOLD
+
+
+def _precision_mode(config: RunConfig) -> bool:
+    """Resolve the precision-mode opt-in (issue #232).
+
+    Precedence (highest first), mirroring ``_shallow_fanout_threshold`` above
+    and ``_resolve_backend`` / ``_resolved_model`` at ``runner.py:295-326``:
+
+      1. ``RunConfig.precision_mode`` (CLI tier / direct construction).
+      2. ``DaydreamFileConfig.precision_mode`` (file-config scalar).
+      3. Built-in default ``False`` (byte-identical behavior: the suppression
+         predicate is never called and arbiter output is unchanged).
+
+    Uses truthiness rather than ``is not None``: ``False`` is the meaningful
+    "off" value, so a set-to-False file-config entry just falls through to the
+    default rather than acting as a distinct sentinel.
+
+    Args:
+        config: Run configuration carrying the CLI/file-config sources.
+
+    Returns:
+        Whether the precision suppression pass should run.
+    """
+    if config.precision_mode:
+        return True
+    file_config = config.file_config
+    if file_config is not None and file_config.precision_mode:
+        return True
+    return False
 
 
 def _collapse_stacks_for_tiny_diff(
@@ -432,137 +461,96 @@ def _candidate_pair_to_json(pair: Any) -> dict[str, Any]:
     return data
 
 
-def _apply_arbiter_verdicts(
+def _apply_adjudication_verdicts(
     records: list[dict[str, Any]],
     sources: list[str],
     targets: list[int],
     verdicts: dict[int, dict[str, Any]],
+    *,
+    pass_name: str,
+    id_field: str,
+    fail_closed: bool,
 ) -> tuple[list[dict[str, Any]], list[str]]:
-    """Fold arbiter verdicts back into the per-stack record set (#168).
+    """Fold arbiter / suppression verdicts back into the per-stack record set.
 
-    Each selected record (``targets[k]`` for 1-based ``arb_id = k + 1``) is
-    revised in place (severity/confidence/description/rationale updated) when the
-    arbiter keeps it, and dropped only on an explicit ``keep:false`` verdict. A
-    missing verdict or an ``arb_id`` mismatch fails open: the original record is
-    retained unchanged (with a warning), because a record reaches arbitration
-    precisely because it is high-severity or contested, so a truncated/lazy
-    arbiter response must not silently delete it. Non-selected records pass
-    through untouched. ``file``/``line`` are never changed -- the arbiter
-    adjudicates, it does not re-target findings.
+    The scoped arbiter (``#168``) and the precision-mode suppression pass
+    (``#232``) share an identical positional-rebuild shape; they differ ONLY in
+    the fail polarity of two branches -- a missing verdict and an ``id_field``
+    mismatch -- which is why this is one parameterised helper rather than two
+    ~80-line near-clones (that duplication is what let the stale-index bug at the
+    call site hide). Each selected record (``targets[k]`` for 1-based
+    ``id = k + 1``) is either revised in place (severity/confidence/description/
+    rationale/evidence taken from the verdict) or dropped. ``file``/``line`` are
+    never changed -- adjudication revises, it does not re-target findings.
+
+    Fail polarity (the sole axis on which the two passes diverge):
+
+    - ``fail_closed=False`` (arbiter): a record reaches arbitration because it is
+      high-severity or contested, so a missing verdict or an ``id_field`` mismatch
+      must NOT delete it. The original record is retained unchanged with a warning
+      (fail OPEN); only an explicit ``keep:false`` drops it.
+    - ``fail_closed=True`` (suppression): a record reaches suppression precisely
+      because it is borderline (neither high-severity nor contested), so an
+      unconfirmable verdict -- missing, mismatched, or ``keep:false`` -- drops it
+      (fail CLOSED), the inverse polarity, safe because nothing important reaches
+      this pass.
+
+    Non-selected records always pass through untouched.
+
+    Args:
+        records: Per-stack records positionally aligned with ``sources``.
+        sources: Per-record originating stack name.
+        targets: Indices into ``records`` selected for this pass; ``targets[k]``
+            carries 1-based ``id = k + 1`` echoed back in the verdict's
+            ``id_field``.
+        verdicts: ``id -> verdict`` mapping from the adjudication agent.
+        pass_name: Human-readable pass name (``"arbiter"`` / ``"suppression"``)
+            used only in warning text.
+        id_field: Verdict key carrying the echoed positional id (``"arb_id"`` for
+            the arbiter, ``"sup_id"`` for suppression).
+        fail_closed: Fail polarity for the missing-verdict / id-mismatch branches
+            (see above).
 
     Returns:
-        New ``(records, sources)`` with explicitly rejected records removed and
-        surviving selected records carrying the arbiter's fields. Positional
-        alignment between the two lists is preserved.
+        New ``(records, sources)`` with dropped records removed and surviving
+        selected records carrying the verdict's fields. Positional alignment
+        between the two lists is preserved.
     """
     import warnings
 
+    polarity_action = (
+        "dropping the unconfirmed record"
+        if fail_closed
+        else "retaining the original record unchanged"
+    )
     revised: dict[int, dict[str, Any]] = {}
     dropped: set[int] = set()
     for offset, record_index in enumerate(targets):
-        arb_id = offset + 1
-        verdict = verdicts.get(arb_id)
+        verdict_id = offset + 1
+        verdict = verdicts.get(verdict_id)
         if verdict is None:
-            # Arbiter returned no verdict for this arb_id -- fail open: retain the
-            # original record unchanged so a truncated/lazy arbiter response cannot
-            # silently delete a high-severity or contested finding. Only an explicit
-            # keep=False below drops a record.
+            # No verdict returned for this id -- fail per the caller's polarity.
             warnings.warn(
-                f"Arbiter returned no verdict for arb_id={arb_id} "
-                f"(record_index={record_index}); retaining original record unchanged.",
+                f"{pass_name.capitalize()} returned no verdict for {id_field}={verdict_id} "
+                f"(record_index={record_index}); {polarity_action}.",
                 stacklevel=2,
             )
+            if fail_closed:
+                dropped.add(record_index)
             continue
-        if verdict.get("arb_id") != arb_id:
-            # Secondary key guard: the arb_id field in the verdict must match the
-            # key we looked it up by.  A mismatch means the arbiter emitted a
-            # finding with a wrong arb_id, which would silently bind the verdict
-            # to the wrong record.  Warn and fail open (retain the original) rather
-            # than mis-apply or drop.
+        if verdict.get(id_field) != verdict_id:
+            # Secondary key guard: the id field in the verdict must match the key
+            # we looked it up by. A mismatch would silently bind the verdict to the
+            # wrong record -- fail per the caller's polarity rather than mis-apply.
             warnings.warn(
-                f"Arbiter verdict arb_id mismatch: expected arb_id={arb_id} "
-                f"but verdict contains arb_id={verdict.get('arb_id')!r} "
-                f"(record_index={record_index}); retaining original record unchanged.",
+                f"{pass_name.capitalize()} verdict {id_field} mismatch: "
+                f"expected {id_field}={verdict_id} "
+                f"but verdict contains {id_field}={verdict.get(id_field)!r} "
+                f"(record_index={record_index}); {polarity_action}.",
                 stacklevel=2,
             )
-            continue
-        if not verdict.get("keep", False):
-            dropped.add(record_index)
-            continue
-        revised[record_index] = {
-            **records[record_index],
-            "severity": verdict.get("severity", records[record_index].get("severity")),
-            "confidence": verdict.get("confidence", records[record_index].get("confidence")),
-            "description": verdict.get("description", records[record_index].get("description")),
-            "rationale": verdict.get("rationale", records[record_index].get("rationale")),
-            "evidence": verdict.get("evidence", records[record_index].get("evidence")),
-        }
-
-    new_records: list[dict[str, Any]] = []
-    new_sources: list[str] = []
-    for i, (record, source) in enumerate(zip(records, sources, strict=True)):
-        if i in dropped:
-            continue
-        new_records.append(revised.get(i, record))
-        new_sources.append(source)
-    return new_records, new_sources
-
-
-def _apply_suppression_verdicts(
-    records: list[dict[str, Any]],
-    sources: list[str],
-    targets: list[int],
-    verdicts: dict[int, dict[str, Any]],
-) -> tuple[list[dict[str, Any]], list[str]]:
-    """Fold suppression verdicts back into the per-stack record set -- fail-CLOSED (#232).
-
-    The exact inverse of :func:`_apply_arbiter_verdicts`. Each selected borderline
-    record (``targets[k]`` for 1-based ``sup_id = k + 1``) is DROPPED unless the
-    suppression reviewer returned an explicit ``keep:true`` verdict for it. A
-    missing verdict, a ``sup_id`` mismatch, or ``keep:false`` all drop the record:
-    a borderline (LOW-confidence / low-severity uncontested) finding the reviewer
-    could not confirm must not survive on a precision run. This is safe precisely
-    because these records were neither high-severity nor contested -- the fail-open
-    protection the arbiter needs does not apply here. Kept records carry the
-    reviewer's revised fields; non-selected records pass through untouched.
-    ``file``/``line`` are never changed.
-
-    Returns:
-        New ``(records, sources)`` with unconfirmed selected records removed and
-        surviving selected records carrying the reviewer's fields. Positional
-        alignment between the two lists is preserved.
-    """
-    import warnings
-
-    revised: dict[int, dict[str, Any]] = {}
-    dropped: set[int] = set()
-    for offset, record_index in enumerate(targets):
-        sup_id = offset + 1
-        verdict = verdicts.get(sup_id)
-        if verdict is None:
-            # Fail-CLOSED: no verdict for a borderline target -> drop it. The
-            # inverse of the arbiter, where a missing verdict fails open. A
-            # truncated/lazy suppression response therefore trims rather than
-            # leaks -- acceptable because nothing high-severity or contested
-            # reaches this pass.
-            warnings.warn(
-                f"Suppression returned no verdict for sup_id={sup_id} "
-                f"(record_index={record_index}); dropping the unconfirmed borderline record.",
-                stacklevel=2,
-            )
-            dropped.add(record_index)
-            continue
-        if verdict.get("sup_id") != sup_id:
-            # Secondary key guard: a mismatched sup_id means the verdict cannot be
-            # trusted to bind to this record -> fail closed (drop) rather than
-            # mis-apply a keep from the wrong finding.
-            warnings.warn(
-                f"Suppression verdict sup_id mismatch: expected sup_id={sup_id} "
-                f"but verdict contains sup_id={verdict.get('sup_id')!r} "
-                f"(record_index={record_index}); dropping the unconfirmed borderline record.",
-                stacklevel=2,
-            )
-            dropped.add(record_index)
+            if fail_closed:
+                dropped.add(record_index)
             continue
         if not verdict.get("keep", False):
             dropped.add(record_index)
@@ -950,9 +938,27 @@ async def _step_arbiter(ctx: FlowContext) -> None:
     # completion marker proves a prior run already finalised them
     # (#175): a crash between the parse write and the rewrite would
     # otherwise let unarbitrated high-severity findings reach merge.
-    arbiter_marker = arbiter_complete_path(dd)
-    if config.start_at != "merge" or not arbiter_marker.is_file():
+    #
+    # The marker covers the WHOLE adjudication block (arbiter +, in
+    # precision mode, suppression): it is written once after BOTH passes
+    # have rewritten the per-stack records, so its presence proves the
+    # records are fully adjudicated -- not just arbitrated. Renamed from
+    # `arbiter_complete_path` so resume reasoning cannot under-read it as
+    # arbiter-only (#232 review).
+    adjudication_marker = adjudication_complete_path(dd)
+    if config.start_at != "merge" or not adjudication_marker.is_file():
         arbiter_targets = select_arbiter_targets(all_records, record_sources)
+        # Capture the identities of records the arbiter will see, before
+        # `_apply_adjudication_verdicts` compacts the list (#232). `arbiter_targets`
+        # are indices into this pre-apply list; once records are dropped the
+        # indices shift, so suppression exclusion must be keyed by record
+        # identity -- not by the stale positional indices -- or a borderline
+        # record shifting into a dropped slot is silently skipped and an
+        # arbiter-kept record revised down to low severity is wrongly re-judged.
+        arbitrated_ids = {
+            (all_records[i].get("file"), all_records[i].get("line"))
+            for i in arbiter_targets
+        }
         if arbiter_targets:
             async with phase_scope(DaydreamPhase.DEEP, stage="arbiter"):
                 verdicts = await phase_arbiter_review(
@@ -964,8 +970,11 @@ async def _step_arbiter(ctx: FlowContext) -> None:
                     alternatives_path=ctx.data["alts_path"],
                     exploration_dir=ctx.data["exploration_dir"],
                 )
-            all_records, record_sources = _apply_arbiter_verdicts(
-                all_records, record_sources, arbiter_targets, verdicts
+            all_records, record_sources = _apply_adjudication_verdicts(
+                all_records, record_sources, arbiter_targets, verdicts,
+                pass_name="arbiter",
+                id_field="arb_id",
+                fail_closed=False,
             )
             _rewrite_stack_records(
                 dd, ctx.data["records_paths"], all_records, record_sources
@@ -980,9 +989,14 @@ async def _step_arbiter(ctx: FlowContext) -> None:
         # is the exclusion set so nothing high-severity / contested is re-judged
         # here. One batched agent call, resolved via the cheaper `suppression`
         # phase key (Sonnet default) -- never per-finding Opus.
-        if config.precision_mode:
+        if _precision_mode(config):
+            suppression_exclude = [
+                i
+                for i, r in enumerate(all_records)
+                if (r.get("file"), r.get("line")) in arbitrated_ids
+            ]
             suppression_targets = select_suppression_targets(
-                all_records, record_sources, arbiter_targets
+                all_records, record_sources, suppression_exclude
             )
             if suppression_targets:
                 async with phase_scope(DaydreamPhase.DEEP, stage="suppression"):
@@ -995,13 +1009,16 @@ async def _step_arbiter(ctx: FlowContext) -> None:
                         alternatives_path=ctx.data["alts_path"],
                         exploration_dir=ctx.data["exploration_dir"],
                     )
-                all_records, record_sources = _apply_suppression_verdicts(
-                    all_records, record_sources, suppression_targets, sup_verdicts
+                all_records, record_sources = _apply_adjudication_verdicts(
+                    all_records, record_sources, suppression_targets, sup_verdicts,
+                    pass_name="suppression",
+                    id_field="sup_id",
+                    fail_closed=True,
                 )
                 _rewrite_stack_records(
                     dd, ctx.data["records_paths"], all_records, record_sources
                 )
-        arbiter_marker.write_text("")
+        adjudication_marker.write_text("")
     ctx.data["records"] = all_records
     ctx.data["record_sources"] = record_sources
 

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -26,7 +26,7 @@ from rich.markup import escape as escape_markup
 
 from daydream.agent import console, get_assume, get_non_interactive, resolve_or_prompt
 from daydream.config import REVIEW_OUTPUT_FILE, STRUCTURE_STACK_NAME
-from daydream.deep.arbiter import select_arbiter_targets
+from daydream.deep.arbiter import select_arbiter_targets, select_suppression_targets
 from daydream.deep.artifacts import (
     alternatives_path as _alternatives_path,
 )
@@ -60,6 +60,7 @@ from daydream.phases import (
     phase_fix_parallel,
     phase_parse_feedback,
     phase_per_stack_reviews,
+    phase_suppression_review,
     phase_test_and_heal,
     phase_understand_intent,
     phase_verify_recommendations,
@@ -507,6 +508,84 @@ def _apply_arbiter_verdicts(
     return new_records, new_sources
 
 
+def _apply_suppression_verdicts(
+    records: list[dict[str, Any]],
+    sources: list[str],
+    targets: list[int],
+    verdicts: dict[int, dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Fold suppression verdicts back into the per-stack record set -- fail-CLOSED (#232).
+
+    The exact inverse of :func:`_apply_arbiter_verdicts`. Each selected borderline
+    record (``targets[k]`` for 1-based ``sup_id = k + 1``) is DROPPED unless the
+    suppression reviewer returned an explicit ``keep:true`` verdict for it. A
+    missing verdict, a ``sup_id`` mismatch, or ``keep:false`` all drop the record:
+    a borderline (LOW-confidence / low-severity uncontested) finding the reviewer
+    could not confirm must not survive on a precision run. This is safe precisely
+    because these records were neither high-severity nor contested -- the fail-open
+    protection the arbiter needs does not apply here. Kept records carry the
+    reviewer's revised fields; non-selected records pass through untouched.
+    ``file``/``line`` are never changed.
+
+    Returns:
+        New ``(records, sources)`` with unconfirmed selected records removed and
+        surviving selected records carrying the reviewer's fields. Positional
+        alignment between the two lists is preserved.
+    """
+    import warnings
+
+    revised: dict[int, dict[str, Any]] = {}
+    dropped: set[int] = set()
+    for offset, record_index in enumerate(targets):
+        sup_id = offset + 1
+        verdict = verdicts.get(sup_id)
+        if verdict is None:
+            # Fail-CLOSED: no verdict for a borderline target -> drop it. The
+            # inverse of the arbiter, where a missing verdict fails open. A
+            # truncated/lazy suppression response therefore trims rather than
+            # leaks -- acceptable because nothing high-severity or contested
+            # reaches this pass.
+            warnings.warn(
+                f"Suppression returned no verdict for sup_id={sup_id} "
+                f"(record_index={record_index}); dropping the unconfirmed borderline record.",
+                stacklevel=2,
+            )
+            dropped.add(record_index)
+            continue
+        if verdict.get("sup_id") != sup_id:
+            # Secondary key guard: a mismatched sup_id means the verdict cannot be
+            # trusted to bind to this record -> fail closed (drop) rather than
+            # mis-apply a keep from the wrong finding.
+            warnings.warn(
+                f"Suppression verdict sup_id mismatch: expected sup_id={sup_id} "
+                f"but verdict contains sup_id={verdict.get('sup_id')!r} "
+                f"(record_index={record_index}); dropping the unconfirmed borderline record.",
+                stacklevel=2,
+            )
+            dropped.add(record_index)
+            continue
+        if not verdict.get("keep", False):
+            dropped.add(record_index)
+            continue
+        revised[record_index] = {
+            **records[record_index],
+            "severity": verdict.get("severity", records[record_index].get("severity")),
+            "confidence": verdict.get("confidence", records[record_index].get("confidence")),
+            "description": verdict.get("description", records[record_index].get("description")),
+            "rationale": verdict.get("rationale", records[record_index].get("rationale")),
+            "evidence": verdict.get("evidence", records[record_index].get("evidence")),
+        }
+
+    new_records: list[dict[str, Any]] = []
+    new_sources: list[str] = []
+    for i, (record, source) in enumerate(zip(records, sources, strict=True)):
+        if i in dropped:
+            continue
+        new_records.append(revised.get(i, record))
+        new_sources.append(source)
+    return new_records, new_sources
+
+
 def _rewrite_stack_records(
     deep_dir_path: Path,
     stack_record_paths: list[Path],
@@ -891,6 +970,37 @@ async def _step_arbiter(ctx: FlowContext) -> None:
             _rewrite_stack_records(
                 dd, ctx.data["records_paths"], all_records, record_sources
             )
+
+        # Precision-mode suppression pass (#232). OPT-IN: when precision_mode is
+        # off (product default) this block never runs, `select_suppression_targets`
+        # is never called, and arbiter output is byte-identical. When on, it gives
+        # the borderline (LOW-confidence / low-severity uncontested) findings the
+        # arbiter never sees a skeptical second opinion, dropping any it cannot
+        # confirm (fail-CLOSED, the inverse of the arbiter). The arbiter target set
+        # is the exclusion set so nothing high-severity / contested is re-judged
+        # here. One batched agent call, resolved via the cheaper `suppression`
+        # phase key (Sonnet default) -- never per-finding Opus.
+        if config.precision_mode:
+            suppression_targets = select_suppression_targets(
+                all_records, record_sources, arbiter_targets
+            )
+            if suppression_targets:
+                async with phase_scope(DaydreamPhase.DEEP, stage="suppression"):
+                    sup_verdicts = await phase_suppression_review(
+                        ctx.backend_for("suppression"),
+                        ctx.work,
+                        selected_records=[all_records[i] for i in suppression_targets],
+                        diff_path=ctx.data["diff_path"],
+                        intent_path=ctx.data["intent_path"],
+                        alternatives_path=ctx.data["alts_path"],
+                        exploration_dir=ctx.data["exploration_dir"],
+                    )
+                all_records, record_sources = _apply_suppression_verdicts(
+                    all_records, record_sources, suppression_targets, sup_verdicts
+                )
+                _rewrite_stack_records(
+                    dd, ctx.data["records_paths"], all_records, record_sources
+                )
         arbiter_marker.write_text("")
     ctx.data["records"] = all_records
     ctx.data["record_sources"] = record_sources

--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -388,6 +388,84 @@ def build_arbiter_prompt(
     return "\n\n".join(parts)
 
 
+def build_suppression_prompt(
+    *,
+    suppression_input_path: Path,
+    diff_path: Path,
+    intent_path: Path,
+    alternatives_path: Path,
+    cwd: Path,
+    exploration_dir: Path | None = None,
+) -> str:
+    """Assemble the skeptical precision-mode suppression prompt (issue #232).
+
+    The suppression reviewer re-examines ONLY the borderline (LOW-confidence /
+    low-severity uncontested) findings the arbiter never scrutinizes. Its default
+    stance is the inverse of the arbiter's: a finding is DROPPED unless the
+    reviewer can point at confirming evidence in the actual code. This trims
+    evidenced-but-immaterial false positives on precision-sensitive runs without
+    the arbiter's fail-open protection (which exists to guard high-severity /
+    contested findings -- exactly the ones this pass never sees).
+
+    Like the arbiter it is an adjudicator, not a discoverer: it may confirm or
+    reject each input finding, but must not invent new ones.
+
+    Args:
+        suppression_input_path: JSON file of the selected borderline findings.
+            Each entry carries a ``sup_id`` the reviewer must echo back, plus the
+            original ``file``/``line``/``severity``/``confidence``/``description``.
+        diff_path: Path to the full diff on disk.
+        intent_path: Path to TTT intent.md.
+        alternatives_path: Path to TTT alternatives.json.
+        cwd: Absolute working directory the agent runs in (grounds path resolution).
+        exploration_dir: Pre-scan exploration directory (if available).
+
+    Returns:
+        Assembled prompt string.
+    """
+    parts: list[str] = []
+    pointer = _exploration_pointer(exploration_dir)
+    if pointer:
+        parts.append(pointer)
+    parts.append(CWD_GROUNDING_INSTRUCTION.format(cwd=cwd))
+    parts.append(_context_pointers(intent_path=intent_path, alternatives_path=alternatives_path))
+    parts.append(
+        f"The full PR diff (base..HEAD) is at {diff_path}. Read it directly; "
+        f"do NOT run `git diff` without a base ref -- on a clean branch that "
+        f"returns empty and hides committed changes."
+    )
+    parts.append(
+        "You are the suppression reviewer. The cheaper per-stack reviewers "
+        "flagged the borderline, low-confidence / low-severity findings listed "
+        f"in {suppression_input_path}. These were NOT contested and NOT "
+        "high-severity, so no heavyweight arbiter looked at them. Your job is to "
+        "cut false positives: re-examine each one against the actual code "
+        "(Read/Grep/Bash) and the diff. You are adjudicating their work, NOT "
+        "starting a fresh review: do not introduce findings that are not in the "
+        "input list."
+    )
+    parts.append(
+        "Default to DROPPING each finding. Keep one ONLY when you can point at "
+        "confirming evidence in the code that it is a real, actionable problem. "
+        "Absence of evidence is a drop, not a keep -- a merely plausible or "
+        "stylistic nit with no concrete grounding must be dropped."
+    )
+    parts.append(
+        "Return a single JSON object matching the structured-output schema: "
+        '{"findings": [ ... ]}. Emit exactly one entry per input finding, echoing '
+        "its `sup_id` unchanged. For each:\n"
+        "  - keep: true ONLY if you cite confirming evidence that the finding is "
+        "real and actionable; false to drop an unconfirmed / immaterial finding.\n"
+        "  - severity: your adjudicated high | medium | low.\n"
+        "  - confidence: your adjudicated HIGH | MEDIUM | LOW.\n"
+        "  - description: a sharpened one-line summary of the SAME finding.\n"
+        "  - rationale: for a keep, the concrete evidence you found; for a drop, "
+        "why it is not confirmable.\n"
+        "  - evidence: the grounded `file:line` citation backing a kept finding."
+    )
+    return "\n\n".join(parts)
+
+
 def build_merge_prompt(
     *,
     per_stack_records_paths: list[Path],

--- a/daydream/extensions/builtins.py
+++ b/daydream/extensions/builtins.py
@@ -47,6 +47,7 @@ def _register_builtin_prompts(registry: Registry) -> None:
     registry.override_prompt("structural", deep_prompts.build_structural_prompt)
     registry.override_prompt("generic-fallback", deep_prompts.build_generic_fallback_prompt)
     registry.override_prompt("arbiter", deep_prompts.build_arbiter_prompt)
+    registry.override_prompt("suppression", deep_prompts.build_suppression_prompt)
     registry.override_prompt("merge", deep_prompts.build_merge_prompt)
     registry.override_prompt("verify", deep_prompts.build_verification_prompt)
 

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -3001,6 +3001,122 @@ async def phase_arbiter_review(
     return verdicts
 
 
+# Suppression schema (issue #232). Mirrors ARBITER_SCHEMA but the confidence enum
+# ALSO admits "LOW": suppression targets are precisely the LOW-confidence findings
+# the arbiter never sees, so a schema that omitted "LOW" (as ARBITER_SCHEMA does)
+# would force the agent to mis-report their confidence on every kept finding.
+SUPPRESSION_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "findings": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "sup_id": {"type": "integer"},
+                    "keep": {"type": "boolean"},
+                    "severity": {"type": "string", "enum": ["high", "medium", "low"]},
+                    "confidence": {"type": "string", "enum": ["HIGH", "MEDIUM", "LOW"]},
+                    "description": {"type": "string"},
+                    "rationale": {"type": "string"},
+                    "evidence": {"type": "string"},
+                },
+                "required": ["sup_id", "keep", "severity", "confidence", "description", "rationale", "evidence"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["findings"],
+    "additionalProperties": False,
+}
+
+
+async def phase_suppression_review(
+    backend: Backend,
+    work: WorkContext,
+    *,
+    selected_records: list[dict[str, Any]],
+    diff_path: Path,
+    intent_path: Path,
+    alternatives_path: Path,
+    exploration_dir: Path | None = None,
+) -> dict[int, dict[str, Any]]:
+    """Skeptical precision-mode second opinion over borderline findings (#232).
+
+    Runs a single cheaper (Sonnet by default) agent over ONLY the borderline
+    (LOW-confidence / low-severity uncontested) findings the arbiter never
+    scrutinizes. The reviewer's default stance is to DROP each finding unless it
+    can cite confirming evidence -- the inverse of the arbiter. The result re-keys
+    onto the input by ``sup_id`` so the caller can drop (missing verdict or
+    ``keep:false``) or retain (``keep:true``) the originating records before the
+    cross-stack merge. All targets are batched into a single agent call.
+
+    Args:
+        backend: The Backend to execute against (resolved via phase ``suppression``).
+        work: Workspace context; ``work.repo`` is the agent cwd.
+        selected_records: Borderline per-stack records selected for suppression.
+            Each is tagged with a fresh 1-based ``sup_id`` before being written to
+            the suppression input artifact; the originals are left untouched.
+        diff_path: Path to the full diff on disk.
+        intent_path: Path to TTT intent.md.
+        alternatives_path: Path to TTT alternatives.json.
+        exploration_dir: Optional pre-scan exploration directory.
+
+    Returns:
+        Mapping of ``sup_id`` -> adjudicated finding dict with keys ``keep``,
+        ``severity``, ``confidence``, ``description``, ``rationale``, ``evidence``.
+        A missing ``sup_id`` is fail-CLOSED at the caller: the original record is
+        DROPPED (a borderline finding the reviewer never confirmed must not
+        survive on precision runs).
+    """
+    from daydream.deep.artifacts import deep_dir, suppression_input_path
+
+    print_phase_hero(console, "SUPPRESS", phase_subtitle("SUPPRESS"))
+    print_dim(console, f"Model: {backend.model}")
+    print_info(console, f"Suppression-reviewing {len(selected_records)} borderline finding(s)")
+
+    dd = deep_dir(work.repo)
+    input_path = suppression_input_path(dd)
+    suppression_input = [
+        {
+            "sup_id": i,
+            "file": rec.get("file"),
+            "line": rec.get("line"),
+            "severity": rec.get("severity"),
+            "confidence": rec.get("confidence"),
+            "description": rec.get("description"),
+            "rationale": rec.get("rationale"),
+            "evidence": rec.get("evidence"),
+        }
+        for i, rec in enumerate(selected_records, start=1)
+    ]
+    input_path.write_text(json.dumps(suppression_input, indent=2))
+
+    prompt = get_registry().prompt("suppression")(
+        suppression_input_path=input_path,
+        diff_path=diff_path,
+        intent_path=intent_path,
+        alternatives_path=alternatives_path,
+        cwd=work.repo,
+        exploration_dir=exploration_dir,
+    )
+    result, _, _ = await run_agent(
+        backend, work.repo, prompt, output_schema=SUPPRESSION_SCHEMA, phase=DaydreamPhase.DEEP
+    )
+
+    if not isinstance(result, dict) or not isinstance(result.get("findings"), list):
+        raise ValueError(f"Suppression returned no findings list (got {type(result).__name__})")
+
+    verdicts: dict[int, dict[str, Any]] = {}
+    for finding in result["findings"]:
+        sup_id = finding.get("sup_id")
+        if isinstance(sup_id, int):
+            verdicts[sup_id] = finding
+    kept = sum(1 for v in verdicts.values() if v.get("keep"))
+    print_info(console, f"Suppression: kept {kept}, dropped {len(verdicts) - kept}")
+    return verdicts
+
+
 def _append_structural_and_write_merged(
     base_items: list[dict[str, Any]],
     structural_records_path: Path | None,

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -182,6 +182,11 @@ class RunConfig:
             through to ``file_config.shallow_fanout_threshold`` then
             ``DEFAULT_SHALLOW_FANOUT_THRESHOLD`` (precedence CLI > file > default,
             mirroring ``_resolve_backend``). ``0`` disables the short-circuit.
+        precision_mode: Opt-in precision suppression (issue #232). When True, the
+            deep pipeline runs a skeptical LLM second opinion over borderline
+            (LOW-confidence / low-severity uncontested) findings after the arbiter
+            and drops any it cannot confirm (fail-closed). Default False keeps the
+            arbiter output byte-identical -- the suppression pass never runs.
 
     """
 
@@ -227,6 +232,12 @@ class RunConfig:
     # override; falls through to file-config scalar then the orchestrator
     # default (DEFAULT_SHALLOW_FANOUT_THRESHOLD). ``0`` disables the gate.
     shallow_fanout_threshold: int | None = None
+    # Issue #232: opt-in precision mode. When True, the deep pipeline runs a
+    # skeptical suppression pass over borderline (LOW-confidence / low-severity
+    # uncontested) findings after the arbiter, dropping any the suppression agent
+    # cannot confirm (fail-closed). Default False => byte-identical behavior; the
+    # suppression predicate is never called and arbiter output is unchanged.
+    precision_mode: bool = False
 
 
 def _print_missing_skill_error(skill_name: str) -> None:

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -185,8 +185,11 @@ class RunConfig:
         precision_mode: Opt-in precision suppression (issue #232). When True, the
             deep pipeline runs a skeptical LLM second opinion over borderline
             (LOW-confidence / low-severity uncontested) findings after the arbiter
-            and drops any it cannot confirm (fail-closed). Default False keeps the
-            arbiter output byte-identical -- the suppression pass never runs.
+            and drops any it cannot confirm (fail-closed). ``False`` falls through
+            to ``file_config.precision_mode`` then the built-in default ``False``
+            (precedence CLI > file > default, mirroring
+            ``shallow_fanout_threshold``; resolved by ``_precision_mode``), so the
+            suppression pass never runs and arbiter output is byte-identical.
 
     """
 

--- a/daydream/ui/theme.py
+++ b/daydream/ui/theme.py
@@ -158,6 +158,12 @@ PHASE_SUBTITLES = {
         "settling the divergence",
         "the deciding voice",
     ],
+    "SUPPRESS": [
+        "cutting the noise",
+        "trusting only the grounded",
+        "silence the unconfirmed",
+        "what survives the skeptic",
+    ],
 }
 
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -178,7 +178,7 @@ reads its own `phase:<name>` slot).
 
 ### Prompts
 
-The 10 registered prompt names and the exact kwargs their builders receive
+The 11 registered prompt names and the exact kwargs their builders receive
 (an override gets the same kwargs). All kwargs are keyword-only except where
 noted.
 
@@ -192,6 +192,7 @@ noted.
 | `structural` | `skill_invocation`, `files`, `diff_path`, `intent_path`, `alternatives_path`, `output_path`, `cwd`, `exploration_dir`, `prior_commits` |
 | `generic-fallback` | `files`, `diff_path`, `intent_path`, `alternatives_path`, `output_path`, `cwd`, `exploration_dir`, `is_docs_only`, `prior_commits`, `inline_diff` |
 | `arbiter` | `arbiter_input_path`, `diff_path`, `intent_path`, `alternatives_path`, `cwd`, `exploration_dir` |
+| `suppression` | `suppression_input_path`, `diff_path`, `intent_path`, `alternatives_path`, `cwd`, `exploration_dir` |
 | `merge` | `per_stack_records_paths`, `intent_path`, `alternatives_path`, `dedup_candidates_path`, `output_path`, `exploration_dir`, `failed_stacks`, `structural_records_path` |
 | `verify` | `items`, `cwd`, `output_path` |
 

--- a/tests/test_arbiter.py
+++ b/tests/test_arbiter.py
@@ -13,7 +13,7 @@ severity) that must NOT trip contested selection.
 
 from __future__ import annotations
 
-from daydream.deep.arbiter import select_arbiter_targets
+from daydream.deep.arbiter import select_arbiter_targets, select_suppression_targets
 
 
 def _rec(file: str, line: int, severity: str) -> dict[str, object]:
@@ -26,6 +26,12 @@ def _rec(file: str, line: int, severity: str) -> dict[str, object]:
         "confidence": "MEDIUM",
         "rationale": "because",
     }
+
+
+def _rec_conf(file: str, line: int, severity: str, confidence: str) -> dict[str, object]:
+    rec = _rec(file, line, severity)
+    rec["confidence"] = confidence
+    return rec
 
 
 def test_mixed_severity_multi_stack_collision_selects_high_and_contested() -> None:
@@ -86,3 +92,72 @@ def test_length_mismatch_raises() -> None:
 
     with pytest.raises(ValueError):
         select_arbiter_targets([_rec("a.py", 1, "high")], ["python", "react"])
+
+
+# Issue #232: precision-mode suppression selection predicate.
+#
+# ``select_suppression_targets`` picks the borderline, uncontested findings the
+# arbiter never sees: LOW-confidence and/or low-severity records NOT in the
+# arbiter's exclusion set. High/contested records (the arbiter's job) must never
+# be selected here.
+
+
+def test_suppression_selects_low_confidence_and_low_severity_uncontested() -> None:
+    # Index map (no exclusions):
+    #  0 low-severity MEDIUM-confidence   -> selected (low severity)
+    #  1 medium-severity LOW-confidence   -> selected (LOW confidence)
+    #  2 medium-severity MEDIUM-confidence-> NOT selected (borderline on neither axis)
+    records = [
+        _rec_conf("a.py", 1, "low", "MEDIUM"),
+        _rec_conf("b.py", 2, "medium", "LOW"),
+        _rec_conf("c.py", 3, "medium", "MEDIUM"),
+    ]
+    sources = ["python", "react", "go"]
+    assert select_suppression_targets(records, sources) == [0, 1]
+
+
+def test_suppression_excludes_arbiter_targets() -> None:
+    # A high finding + a LOW-confidence uncontested finding. The arbiter takes the
+    # high one; suppression must take ONLY the borderline one, never the high.
+    records = [
+        _rec_conf("api.py", 10, "high", "HIGH"),
+        _rec_conf("util.py", 5, "low", "LOW"),
+    ]
+    sources = ["python", "react"]
+    arbiter_targets = select_arbiter_targets(records, sources)
+    assert arbiter_targets == [0]
+    assert select_suppression_targets(records, sources, arbiter_targets) == [1]
+
+
+def test_suppression_excludes_contested_low_finding() -> None:
+    # A low-severity finding that is CONTESTED (same loc, 2 stacks, divergent
+    # severity) reaches the arbiter, so it must be excluded from suppression even
+    # though it is low severity.
+    records = [
+        _rec_conf("api.py", 10, "high", "HIGH"),  # 0 contested + high
+        _rec_conf("api.py", 10, "low", "LOW"),    # 1 contested (excluded despite low)
+        _rec_conf("b.py", 2, "low", "LOW"),       # 2 borderline uncontested -> selected
+    ]
+    sources = ["python", "react", "go"]
+    arbiter_targets = select_arbiter_targets(records, sources)
+    assert arbiter_targets == [0, 1]
+    assert select_suppression_targets(records, sources, arbiter_targets) == [2]
+
+
+def test_suppression_selects_nothing_when_all_medium_uncontested() -> None:
+    records = [_rec_conf("a.py", 1, "medium", "MEDIUM"), _rec_conf("b.py", 2, "medium", "HIGH")]
+    sources = ["python", "react"]
+    assert select_suppression_targets(records, sources) == []
+
+
+def test_suppression_default_exclude_is_empty() -> None:
+    # Called without an exclude set, every borderline record is selected.
+    records = [_rec_conf("a.py", 1, "low", "LOW")]
+    assert select_suppression_targets(records, ["python"]) == [0]
+
+
+def test_suppression_length_mismatch_raises() -> None:
+    import pytest
+
+    with pytest.raises(ValueError):
+        select_suppression_targets([_rec("a.py", 1, "low")], ["python", "react"])

--- a/tests/test_cli_help_tiers.py
+++ b/tests/test_cli_help_tiers.py
@@ -23,6 +23,7 @@ def test_default_help_hides_advanced(capsys):
     out = capsys.readouterr().out
     assert "--comment" in out and "--start-at" not in out and "--ignore-path" not in out
     assert "--findings-out" not in out and "--pr-number" not in out
+    assert "--precision" not in out  # #232: opt-in precision mode is an advanced flag
 
 
 def test_help_all_shows_advanced(capsys):
@@ -31,7 +32,19 @@ def test_help_all_shows_advanced(capsys):
     out = capsys.readouterr().out
     assert "--start-at" in out
     assert "--findings-out" in out and "--pr-number" in out
+    assert "--precision" in out  # #232: reachable from --help-all
 
 
 def test_advanced_flags_still_parse():
     assert _cfg(["--start-at", "fix", "/t"]).start_at == "fix"
+
+
+def test_precision_flag_activates_precision_mode():
+    """#232: ``--precision`` is the activation path into RunConfig.precision_mode.
+
+    Absent the flag the field stays ``False`` (byte-identical default); with it,
+    the field is ``True`` so the deep orchestrator's ``_precision_mode`` resolver
+    runs the suppression pass.
+    """
+    assert _cfg(["/t"]).precision_mode is False
+    assert _cfg(["--precision", "/t"]).precision_mode is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,7 +7,7 @@ from daydream.config import (
 )
 
 PHASE_NAMES = {
-    "review", "per_stack_review", "arbiter", "parse", "fix", "test", "verify",
+    "review", "per_stack_review", "arbiter", "suppression", "parse", "fix", "test", "verify",
     "exploration", "intent", "wonder", "merge", "pr_feedback",
 }
 
@@ -43,6 +43,14 @@ def test_per_stack_review_and_arbiter_split():
     codex = PHASE_DEFAULT_MODELS["codex"]
     assert codex["per_stack_review"] == "gpt-5.5"
     assert codex["arbiter"] == "gpt-5.5"
+
+
+def test_suppression_uses_cheap_tier():
+    """#232: the precision-mode suppression pass defaults to the cheap mid tier
+    (never per-finding Opus). Codex/pi keep their single-model default."""
+    assert PHASE_DEFAULT_MODELS["claude"]["suppression"] == "claude-sonnet-4-6"
+    assert PHASE_DEFAULT_MODELS["codex"]["suppression"] == "gpt-5.5"
+    assert PHASE_DEFAULT_MODELS["pi"]["suppression"] == "glm-5.2"
 
 
 def test_phase_default_models_codex_uses_gpt_5_5_for_every_phase():

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -49,6 +49,20 @@ def test_load_file_config_reads_bench_table(tmp_path: Path) -> None:
     assert cfg.bench["reviewers"]["glm"] == {"backend": "pi", "model": "z-ai/glm-5.2", "provider": "openrouter"}
 
 
+def test_precision_mode_true_parses_as_bool(tmp_path: Path) -> None:
+    (tmp_path / ".daydream.toml").write_text("precision_mode = true\n")
+    cfg = load_file_config(tmp_path)
+    assert cfg.precision_mode is True
+
+
+def test_precision_mode_non_bool_degrades_to_none(tmp_path: Path) -> None:
+    # bool-only coercion (mirrors raw_precision): a truthy int is NOT enabled, it
+    # degrades to None (unset) rather than crashing or coercing to True.
+    (tmp_path / ".daydream.toml").write_text("precision_mode = 1\n")
+    cfg = load_file_config(tmp_path)
+    assert cfg.precision_mode is None
+
+
 def test_empty_config_helper() -> None:
     cfg = DaydreamFileConfig()
     assert cfg.model is None and cfg.backend is None

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -58,6 +58,12 @@ class _StubBackend:
         # verdict), simulating a truncated/lazy Opus response so a test can assert
         # the selected high-severity record fails open and survives (#175).
         self.arbiter_omit_verdicts: bool = False
+        # #232 knobs: per-stack parse override (drives suppression selection with a
+        # distinct file/severity/confidence per stack, so a HIGH and a borderline
+        # LOW finding coexist at NON-colliding locations -> uncontested), and the
+        # keep verdict the suppression-reviewer stub returns for every sup_id.
+        self.parse_by_stack: dict[str, dict[str, Any]] | None = None
+        self.suppression_keep: bool = True
         self.calls: list[dict[str, Any]] = []
         # Verdict the recommendation-verifier branch emits for issue_id=1; flip to
         # "contradicts" to exercise verdict propagation into the phase_fix prompt.
@@ -244,6 +250,20 @@ class _StubBackend:
                 issue["severity"] = self.parse_severity
                 issue["confidence"] = "MEDIUM"
                 issue["rationale"] = "stub"
+            # #232: per-stack override keyed off the review-file path the parse
+            # prompt points at (``stack-<name>-review.md``). Lets one stack emit a
+            # HIGH finding and another a borderline LOW one at DISTINCT locations,
+            # so they stay uncontested and drive the suppression predicate.
+            if self.parse_by_stack is not None and "severity" in pl:
+                sm = re.search(r"stack-(\S+?)-review\.md", prompt)
+                if sm is not None and sm.group(1) in self.parse_by_stack:
+                    ov = self.parse_by_stack[sm.group(1)]
+                    issue["severity"] = ov["severity"]
+                    issue["confidence"] = ov["confidence"]
+                    issue["file"] = ov.get("file", issue["file"])
+                    issue["line"] = ov.get("line", issue["line"])
+                    issue["evidence"] = f"{issue['file']}:{issue['line']}"
+                    issue["rationale"] = "stub"
             yield TextEvent(text="")
             yield ResultEvent(structured_output={"issues": [issue]}, continuation=None)
             return
@@ -269,6 +289,34 @@ class _StubBackend:
                     )
             yield TextEvent(text="")
             yield ResultEvent(structured_output={"findings": findings}, continuation=None)
+            return
+
+        # Precision-mode suppression reviewer (#232). Reads suppression-input.json,
+        # echoes every sup_id back with keep=self.suppression_keep. keep=False drops
+        # the borderline finding (fail-closed apply); keep=True with cited evidence
+        # retains it. Dispatch phrase must not collide with the arbiter or merge
+        # branches above/below.
+        if "you are the suppression reviewer" in pl:
+            in_match = re.search(r"listed in (\S+suppression-input\.json)", prompt)
+            sup_findings: list[dict[str, Any]] = []
+            if in_match is not None:
+                sup_inputs = json.loads(Path(in_match.group(1)).read_text())
+                for entry in sup_inputs:
+                    sup_findings.append(
+                        {
+                            "sup_id": entry["sup_id"],
+                            "keep": self.suppression_keep,
+                            "severity": entry.get("severity") or "low",
+                            "confidence": entry.get("confidence") or "LOW",
+                            "description": entry.get("description") or "finding",
+                            "rationale": (
+                                "confirmed by code" if self.suppression_keep else "no confirming evidence"
+                            ),
+                            "evidence": entry.get("evidence") or "",
+                        }
+                    )
+            yield TextEvent(text="")
+            yield ResultEvent(structured_output={"findings": sup_findings}, continuation=None)
             return
 
         # Cross-stack merge -> schema-validated item list; the host appends
@@ -525,6 +573,8 @@ def _install_model_capturing_stubs(
     parse_severity: str | None = None,
     merge_echo_records: bool = False,
     arbiter_omit_verdicts: bool = False,
+    parse_by_stack: dict[str, dict[str, Any]] | None = None,
+    suppression_keep: bool = True,
 ) -> list[dict[str, Any]]:
     """Patch create_backend with a per-(name, model) stub factory (#168).
 
@@ -543,6 +593,8 @@ def _install_model_capturing_stubs(
         stub.parse_severity = parse_severity
         stub.merge_echo_records = merge_echo_records
         stub.arbiter_omit_verdicts = arbiter_omit_verdicts
+        stub.parse_by_stack = parse_by_stack
+        stub.suppression_keep = suppression_keep
         return stub
 
     monkeypatch.setattr("daydream.runner.create_backend", factory)
@@ -551,11 +603,13 @@ def _install_model_capturing_stubs(
     return shared_calls
 
 
-async def _run_deep(target: Path, *, start_at: str = "review") -> int:
+async def _run_deep(target: Path, *, start_at: str = "review", precision_mode: bool = False) -> int:
     from daydream.runner import RunConfig, run
 
     # cleanup=False suppresses the interactive cleanup prompt; deep is the default.
-    config = RunConfig(target=str(target), start_at=start_at, cleanup=False)
+    config = RunConfig(
+        target=str(target), start_at=start_at, cleanup=False, precision_mode=precision_mode
+    )
     return await run(config)
 
 
@@ -2908,6 +2962,123 @@ async def test_no_arbiter_when_all_findings_low_and_uncontested(
         c["model"] for c in calls if "you are reviewing the" in c["prompt"].lower() and "stack" in c["prompt"].lower()
     }
     assert per_stack_models == {"claude-sonnet-4-6"}
+
+
+# Issue #232: precision-mode suppression pass over borderline uncontested findings.
+#
+# Every test drives runner.run through run_deep with a mock scripting one HIGH
+# finding (python @ api.py:1, an arbiter target) and one borderline low-severity
+# finding (react @ App.tsx:1, a suppression target) at NON-colliding locations so
+# they stay uncontested. App.tsx is the sole discriminator for the borderline
+# finding: its presence/absence in the canonical merged-items.json is the
+# observable outcome.
+#
+# The borderline finding is low-severity but MEDIUM confidence, NOT LOW: the
+# always-on evidence gate (#227) drops every LOW-confidence finding at merge
+# regardless of precision, so a LOW-confidence finding could never observe the
+# suppression pass. Per issue #232, suppression trims by *materiality* (severity),
+# not evidence -- a low-severity MEDIUM-confidence finding survives the gate and
+# is dropped ONLY when suppression declines it.
+_PRECISION_STACKS: dict[str, dict[str, Any]] = {
+    "python": {"severity": "high", "confidence": "HIGH", "file": "api.py", "line": 1},
+    "react": {"severity": "low", "confidence": "MEDIUM", "file": "App.tsx", "line": 1},
+}
+
+
+def _merged_item_files(target: Path) -> list[str]:
+    """Return the ``file`` of every item in the canonical merged-items.json."""
+    items_file = target / ".daydream" / "deep" / "merged-items.json"
+    items = json.loads(items_file.read_text())["items"]
+    return [it.get("file") for it in items]
+
+
+async def test_precision_on_drops_unconfirmed_low_finding(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#232 Test A (precision ON, no evidence): the borderline LOW finding is
+    dropped when the suppression reviewer returns keep=false; the HIGH finding
+    survives, and the suppression pass makes exactly one batched Sonnet call."""
+    _silence(monkeypatch)
+    calls = _install_model_capturing_stubs(
+        monkeypatch,
+        multi_stack_target,
+        merge_echo_records=True,
+        parse_by_stack=_PRECISION_STACKS,
+        suppression_keep=False,
+    )
+
+    exit_code = await _run_deep(multi_stack_target, precision_mode=True)
+    assert exit_code == 0
+
+    files = _merged_item_files(multi_stack_target)
+    # The borderline LOW finding (App.tsx) is suppressed; the HIGH one (api.py) stays.
+    assert "App.tsx" not in files, f"unconfirmed LOW finding must be dropped:\n{files}"
+    assert "api.py" in files, f"HIGH finding must survive suppression:\n{files}"
+
+    # Exactly one batched suppression call, resolved via the cheap `suppression`
+    # phase key (Sonnet), NOT per-finding Opus.
+    sup_calls = [c for c in calls if "you are the suppression reviewer" in c["prompt"].lower()]
+    assert len(sup_calls) == 1, f"suppression must make exactly one batched call, got {len(sup_calls)}"
+    assert sup_calls[0]["model"] == "claude-sonnet-4-6"
+
+    # The arbiter still ran on the HIGH finding (fail-open, unchanged by #232).
+    arbiter_calls = [c for c in calls if "you are the arbiter" in c["prompt"].lower()]
+    assert len(arbiter_calls) == 1
+    assert arbiter_calls[0]["model"] == "claude-opus-4-8"
+
+
+async def test_precision_off_keeps_low_finding(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#232 Test B (precision OFF, product default): identical inputs, but the
+    borderline LOW finding survives to merge and NO suppression pass runs.
+
+    Regression guard for the "don't drop possibly-real findings" non-goal."""
+    _silence(monkeypatch)
+    calls = _install_model_capturing_stubs(
+        monkeypatch,
+        multi_stack_target,
+        merge_echo_records=True,
+        parse_by_stack=_PRECISION_STACKS,
+        suppression_keep=False,  # would drop if it ran -- it must NOT run
+    )
+
+    exit_code = await _run_deep(multi_stack_target, precision_mode=False)
+    assert exit_code == 0
+
+    files = _merged_item_files(multi_stack_target)
+    assert "App.tsx" in files, f"LOW finding must survive when precision is OFF:\n{files}"
+    assert "api.py" in files
+
+    sup_calls = [c for c in calls if "you are the suppression reviewer" in c["prompt"].lower()]
+    assert sup_calls == [], "suppression must never run when precision is OFF"
+
+
+async def test_precision_on_keeps_low_finding_with_evidence(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#232 Test C (precision ON, evidence): a borderline LOW finding the
+    suppression reviewer CONFIRMS (keep=true with a rationale) is retained."""
+    _silence(monkeypatch)
+    calls = _install_model_capturing_stubs(
+        monkeypatch,
+        multi_stack_target,
+        merge_echo_records=True,
+        parse_by_stack=_PRECISION_STACKS,
+        suppression_keep=True,
+    )
+
+    exit_code = await _run_deep(multi_stack_target, precision_mode=True)
+    assert exit_code == 0
+
+    # The suppression pass ran (borderline finding exists) ...
+    sup_calls = [c for c in calls if "you are the suppression reviewer" in c["prompt"].lower()]
+    assert len(sup_calls) == 1
+
+    # ... but confirmed the finding, so App.tsx is retained.
+    files = _merged_item_files(multi_stack_target)
+    assert "App.tsx" in files, f"a confirmed borderline finding must be kept:\n{files}"
+    assert "api.py" in files
 
 
 def _prime_merge_resume_records(deep: Path, *, python_severity: str | None) -> None:

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -254,6 +254,7 @@ class _StubBackend:
             # prompt points at (``stack-<name>-review.md``). Lets one stack emit a
             # HIGH finding and another a borderline LOW one at DISTINCT locations,
             # so they stay uncontested and drive the suppression predicate.
+            issues: list[dict[str, Any]] = [issue]
             if self.parse_by_stack is not None and "severity" in pl:
                 sm = re.search(r"stack-(\S+?)-review\.md", prompt)
                 if sm is not None and sm.group(1) in self.parse_by_stack:
@@ -262,10 +263,33 @@ class _StubBackend:
                     issue["confidence"] = ov["confidence"]
                     issue["file"] = ov.get("file", issue["file"])
                     issue["line"] = ov.get("line", issue["line"])
+                    issue["description"] = ov.get("description", issue["description"])
                     issue["evidence"] = f"{issue['file']}:{issue['line']}"
                     issue["rationale"] = "stub"
+                    # #232: an ``extra`` sibling lets ONE stack emit a second
+                    # finding at the SAME (file, line) as its HIGH finding. Single
+                    # stack -> uncontested, so only the HIGH one is an arbiter
+                    # target; the borderline sibling must still reach suppression,
+                    # which only holds if exclusion is keyed by record identity, not
+                    # by (file, line).
+                    extra = ov.get("extra")
+                    if extra is not None:
+                        ex_file = extra.get("file", issue["file"])
+                        ex_line = extra.get("line", issue["line"])
+                        issues.append(
+                            {
+                                "id": 2,
+                                "description": extra.get("description", "extra finding"),
+                                "file": ex_file,
+                                "line": ex_line,
+                                "severity": extra["severity"],
+                                "confidence": extra["confidence"],
+                                "rationale": "stub",
+                                "evidence": f"{ex_file}:{ex_line}",
+                            }
+                        )
             yield TextEvent(text="")
-            yield ResultEvent(structured_output={"issues": [issue]}, continuation=None)
+            yield ResultEvent(structured_output={"issues": issues}, continuation=None)
             return
 
         # Scoped Opus arbiter (#168). Reads the arbiter-input.json path the prompt
@@ -2990,6 +3014,73 @@ def _merged_item_files(target: Path) -> list[str]:
     items_file = target / ".daydream" / "deep" / "merged-items.json"
     items = json.loads(items_file.read_text())["items"]
     return [it.get("file") for it in items]
+
+
+def _merged_item_descriptions(target: Path) -> list[str]:
+    """Return the ``description`` of every item in the canonical merged-items.json."""
+    items_file = target / ".daydream" / "deep" / "merged-items.json"
+    items = json.loads(items_file.read_text())["items"]
+    return [it.get("description", "") for it in items]
+
+
+# A borderline LOW-severity sibling sharing one (file, line) with a HIGH finding
+# from the SAME stack (py_module.py:7). Single stack -> uncontested, so only the
+# HIGH one is an arbiter target. Other stacks stay on api.py:1 (no severity) so
+# nothing there is high or contested. If suppression exclusion were keyed by
+# (file, line), the HIGH sibling's location would wrongly exclude the LOW sibling
+# too, silently skipping it (#232 review, Comment 2).
+_SUPPRESSION_COLLISION_STACKS: dict[str, dict[str, Any]] = {
+    "python": {
+        "severity": "high",
+        "confidence": "HIGH",
+        "file": "py_module.py",
+        "line": 7,
+        "description": "the HIGH finding",
+        "extra": {
+            "severity": "low",
+            "confidence": "MEDIUM",
+            "file": "py_module.py",
+            "line": 7,
+            "description": "borderline sibling sharing the HIGH location",
+        },
+    },
+}
+
+
+async def test_precision_suppresses_low_sibling_sharing_high_finding_location(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#232 Comment 2: a borderline LOW finding sharing a (file, line) with an
+    arbitrated HIGH finding from the same stack must STILL be suppression-reviewed
+    and dropped. A (file, line)-keyed exclusion excluded both siblings, letting the
+    LOW one survive unreviewed; the per-record-identity key fixes it."""
+    _silence(monkeypatch)
+    calls = _install_model_capturing_stubs(
+        monkeypatch,
+        multi_stack_target,
+        merge_echo_records=True,
+        parse_by_stack=_SUPPRESSION_COLLISION_STACKS,
+        suppression_keep=False,
+    )
+
+    exit_code = await _run_deep(multi_stack_target, precision_mode=True)
+    assert exit_code == 0
+
+    # The LOW sibling reached suppression despite sharing a location with the
+    # arbitrated HIGH finding -- exactly one batched suppression call. Under the
+    # (file, line)-keyed bug it was excluded, so the pass had zero targets.
+    sup_calls = [c for c in calls if "you are the suppression reviewer" in c["prompt"].lower()]
+    assert len(sup_calls) == 1, f"the LOW sibling must reach suppression, got {len(sup_calls)} calls"
+
+    descriptions = _merged_item_descriptions(multi_stack_target)
+    # keep=false -> the reviewed LOW sibling is dropped ...
+    assert not any("borderline sibling" in d for d in descriptions), (
+        f"the LOW sibling sharing the HIGH location must be suppressed:\n{descriptions}"
+    )
+    # ... while the arbitrated HIGH finding at the same location survives.
+    assert any("ARBITRATED" in d and "HIGH finding" in d for d in descriptions), (
+        f"the HIGH finding at the shared location must survive:\n{descriptions}"
+    )
 
 
 async def test_precision_on_drops_unconfirmed_low_finding(


### PR DESCRIPTION
## Summary

- Adds an opt-in `precision_mode` suppression pass to the deep review pipeline: borderline (LOW-confidence / low-severity uncontested) findings get a skeptical LLM second opinion via a single batched agent call with fail-closed semantics.
- Default OFF: arbiter behavior is byte-identical to today. `--precision` flag (hidden from default help, shown via `--help-all`) and `precision_mode` config-file field enable it.

## Motivation

`select_arbiter_targets` routes only `severity=="high"` OR contested findings to the Opus arbiter. LOW-confidence, uncontested low/medium findings are never scrutinized. For precision-sensitive benchmark runs these evidenced-but-minor findings inflate false positives against the thin golden set. This pass gives them a skeptical second opinion while keeping the product default unchanged (dropping possibly-real findings is an explicit non-goal).

Composes with the bench materiality gate (#230 / PR #245): cheap threshold first, LLM second-opinion for borderline.

Closes #232. Part of #233.

## Changes

### Added
- `select_suppression_targets(records, sources, arbiter_targets)` — pure predicate in `deep/arbiter.py` returning indices of borderline findings NOT already selected for arbitration.
- `phase_suppression_review` — batched phase function in `phases.py`, structurally parallel to `phase_arbiter_review`, using the cheaper `"suppression"` phase key.
- `build_suppression_prompt` — skeptical prompt builder in `deep/prompts.py` (defaults to `keep: false`, only keeps when evidence is cited).
- `SUPPRESSION_SCHEMA` — output schema with `sup_id` key and `LOW` in the confidence enum (unlike `ARBITER_SCHEMA`).
- `RunConfig.precision_mode: bool = False` — opt-in toggle with `--precision` CLI flag and config-file support.
- `--precision` hidden CLI flag (`--help-all` only).
- 6 unit tests for the predicate + 3 real-path tests (precision ON drops, precision OFF retains, precision ON keeps with evidence).
- CLI help-tier tests for the `--precision` flag.

### Changed
- `_step_arbiter` (`deep/orchestrator.py`) — runs the suppression pass after the arbiter when `precision_mode` is on, folding verdicts via fail-closed apply.
- `_apply_arbiter_verdicts` / `_apply_suppression_verdicts` unified into `_apply_adjudication_verdicts` with a `fail_closed` parameter (eliminates near-duplicate helpers that hid a stale-index bug).
- `arbiter_complete_path` renamed to `adjudication_complete_path` (on-disk filename unchanged for `--start-at merge` resume compat).
- Suppression targets re-keyed by `(file, line)` identity instead of positional indices, fixing a stale-index bug where suppression exclusion could shift after the arbiter compacted the record list.

## Test Plan

- [x] `make check` passes (1996 passed, 5 skipped)
- [x] Unit tests: `select_suppression_targets` excludes arbiter/contested, includes borderline, handles adversarial shapes
- [x] Real-path Test A (precision ON, `keep: false`): borderline finding dropped from `merged-items.json`
- [x] Real-path Test B (precision OFF, default): identical finding retained (regression guard)
- [x] Real-path Test C (precision ON, `keep: true` with evidence): finding retained
- [x] Daydream pre-PR review passed (stale-index bug found and fixed)

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check`)
- [x] Type checking passes (`uv run mypy daydream`)
- [x] Documentation updated (`docs/extensions.md` — suppression prompt registered)
