### PR TITLE
feat(bench): repeated-trial benchmarking with variance reporting (#249)

### DIFF
--- a/daydream/benchmark/cli.py
+++ b/daydream/benchmark/cli.py
@@ -154,6 +154,15 @@ def _build_bench_parser() -> argparse.ArgumentParser:
         help="Cap the number of PRs processed",
     )
     parser.add_argument(
+        "--trials",
+        type=int,
+        default=None,
+        dest="trials",
+        metavar="N",
+        help="Run each reviewer config N times (default: 1). N>1 isolates each trial "
+        "and enables distribution reporting (mean/median/stddev/bootstrap CI).",
+    )
+    parser.add_argument(
         "--force",
         action="store_true",
         dest="force",
@@ -232,6 +241,8 @@ def _bench_config_from_argv(argv: list[str]) -> "BenchConfig":
     args = parser.parse_args(argv)
     if args.limit is not None and args.limit <= 0:
         parser.error("--limit must be a positive integer")
+    if args.trials is not None and args.trials <= 0:
+        parser.error("--trials must be a positive integer")
     if (
         args.tool_label is None
         and args.reviewer is None
@@ -256,6 +267,9 @@ def _bench_config_from_argv(argv: list[str]) -> "BenchConfig":
         parser.error("--judge-route must be one of: martian, anthropic-direct")
     min_confidence = args.min_confidence if args.min_confidence is not None else bench.get("min-confidence")
     min_severity = args.min_severity if args.min_severity is not None else bench.get("min-severity")
+    trials = args.trials if args.trials is not None else bench.get("trials", 1)
+    if not isinstance(trials, int) or trials <= 0:
+        parser.error("--trials must be a positive integer")
     if min_confidence is not None and min_confidence.lower() not in {"low", "medium", "high"}:
         parser.error("--min-confidence must be one of: LOW, MEDIUM, HIGH")
     if min_severity is not None and min_severity.lower() not in {"low", "medium", "high"}:
@@ -296,6 +310,7 @@ def _bench_config_from_argv(argv: list[str]) -> "BenchConfig":
         verbose=args.verbose,
         min_confidence=min_confidence,
         min_severity=min_severity,
+        trials=trials,
     )
 
 

--- a/daydream/benchmark/config.py
+++ b/daydream/benchmark/config.py
@@ -36,6 +36,9 @@ class BenchConfig:
             (low/medium/high) before benchmark submission; None submits all.
         min_severity: When set, drop findings below this severity
             (low/medium/high) before benchmark submission; None submits all.
+        trials: Number of full end-to-end trials to run per reviewer config
+            (default 1 = single-shot, back-compat). N>1 isolates each trial in
+            its own corpus dir and enables distribution reporting.
     """
 
     benchmark_repo: Path
@@ -54,3 +57,4 @@ class BenchConfig:
     verbose: bool = False
     min_confidence: str | None = None
     min_severity: str | None = None
+    trials: int = 1

--- a/daydream/benchmark/orchestrator.py
+++ b/daydream/benchmark/orchestrator.py
@@ -205,18 +205,23 @@ def _run_sweep(config: BenchConfig, judge_model: str) -> tuple[bool, DaydreamSco
                 "corpus is saved and can be re-scored separately (re-run with --score)",
             )
         else:
-            for golden_url, leaf in scores.per_pr.items():
-                print_info(
-                    console,
-                    f"{golden_url}: tp={leaf.get('tp', 0)} fp={leaf.get('fp', 0)} fn={leaf.get('fn', 0)}",
-                )
-            print_success(
-                console,
-                f"daydream aggregate over {scores.scored_pr_count} PR(s): "
-                f"precision={scores.precision:.3f} recall={scores.recall:.3f} f1={scores.f1:.3f}",
-            )
+            _print_score_breakdown(scores)
 
     return (failed == 0 and not score_failed, scores)
+
+
+def _print_score_breakdown(scores: DaydreamScores) -> None:
+    """Print each PR's tp/fp/fn leaf and the aggregate precision/recall/F1."""
+    for golden_url, leaf in scores.per_pr.items():
+        print_info(
+            console,
+            f"{golden_url}: tp={leaf.get('tp', 0)} fp={leaf.get('fp', 0)} fn={leaf.get('fn', 0)}",
+        )
+    print_success(
+        console,
+        f"daydream aggregate over {scores.scored_pr_count} PR(s): "
+        f"precision={scores.precision:.3f} recall={scores.recall:.3f} f1={scores.f1:.3f}",
+    )
 
 
 def _daydream_git_sha() -> str:
@@ -289,7 +294,19 @@ def _write_trials_summary(
         "pr_set": [pr.golden_url for pr in prs],
         "distribution": (distribution_to_dict(compute_distribution(trial_scores)) if trial_scores else None),
         "per_trial": [
-            {"trial": t, "precision": s.precision, "recall": s.recall, "f1": s.f1}
+            {
+                "trial": t,
+                "tool_label": trial_tool_label(config.tool_label, t),
+                "scored_pr_count": s.scored_pr_count,
+                "total_tp": s.total_tp,
+                "total_fp": s.total_fp,
+                "total_fn": s.total_fn,
+                "total_errors": s.total_errors,
+                "total_comparisons": s.total_comparisons,
+                "precision": s.precision,
+                "recall": s.recall,
+                "f1": s.f1,
+            }
             for t, s in scored_trials
         ],
     }
@@ -343,6 +360,8 @@ def _run_trials(config: BenchConfig, judge_model: str) -> int:
         if trial_scores:
             dist = compute_distribution(trial_scores)
             console.print(format_distribution_table(dist))
+            total_comparisons = sum(s.total_comparisons for s in trial_scores)
+            print_info(console, f"Actual judge comparisons recorded: {total_comparisons}")
 
     return 0 if not any_failed else 1
 

--- a/daydream/benchmark/orchestrator.py
+++ b/daydream/benchmark/orchestrator.py
@@ -20,7 +20,10 @@ aggregate precision/recall are printed.
 from __future__ import annotations
 
 import json
+import subprocess
 import time
+from dataclasses import replace
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -36,7 +39,9 @@ from daydream.benchmark.cli import _format_elapsed
 from daydream.benchmark.daydream_run import run_daydream_review
 from daydream.benchmark.mapping import merged_items_to_review_comments
 from daydream.benchmark.prs import load_evaluable_prs
-from daydream.benchmark.score import preflight_judge_env, resolve_judge_model, run_scoring
+from daydream.benchmark.score import DaydreamScores, preflight_judge_env, resolve_judge_model, run_scoring
+from daydream.benchmark.stats import compute_distribution, distribution_to_dict, format_distribution_table
+from daydream.benchmark.trial_isolation import init_trial_corpus, trial_corpus_dir, trial_tool_label, trials_root
 from daydream.ui import print_dim, print_error, print_info, print_success, print_warning
 
 if TYPE_CHECKING:
@@ -115,22 +120,24 @@ def _process_pr(config: BenchConfig, pr: EvaluablePR, data: dict[str, Any]) -> b
     return inject_daydream_review(data, pr.golden_url, comments, force=config.force, tool=config.tool_label)
 
 
-def run_bench(config: BenchConfig) -> int:
-    """Run the benchmark sweep over the selected PRs.
+def _run_sweep(config: BenchConfig, judge_model: str) -> tuple[bool, DaydreamScores | None]:
+    """Run the per-PR review/inject sweep (and optional scoring) for one config.
+
+    This is the single-config workhorse: a repeated-trial run calls it once per
+    trial with a trial-specific ``config`` (isolated corpus dir + suffixed tool
+    label), and the back-compat single-shot path calls it exactly once with the
+    caller's config. The judge credential is preflighted by ``run_bench`` before
+    this runs, so ``judge_model`` is already resolved (``""`` when not scoring).
 
     Args:
-        config: Immutable run configuration (selection, force, scoring, paths).
+        config: Run configuration for this sweep (paths, tool label, scoring).
+        judge_model: Pre-resolved judge model id (``""`` when ``score`` is off).
 
     Returns:
-        ``0`` when every selected PR was injected (or skipped) and scoring (if
-        requested) succeeded; non-zero if any selected PR failed or scoring
-        failed.
+        ``(ok, scores)`` where ``ok`` is ``False`` if any PR or the scoring step
+        failed, and ``scores`` is the parsed :class:`DaydreamScores` when scoring
+        ran and succeeded, else ``None``.
     """
-    judge_model = ""
-    if config.score:
-        preflight_judge_env(judge_route=config.judge_route)
-        judge_model = resolve_judge_model(config.model)
-
     data_path = _benchmark_data_path(config)
     data = load_benchmark_data(data_path)
     prs = _select_prs(config)
@@ -177,6 +184,7 @@ def run_bench(config: BenchConfig) -> int:
         print_warning(console, f"{failed} of {len(prs)} selected PR(s) failed")
 
     score_failed = False
+    scores: DaydreamScores | None = None
     if config.score:
         try:
             scores = run_scoring(
@@ -188,6 +196,7 @@ def run_bench(config: BenchConfig) -> int:
             )
         except Exception as exc:  # noqa: BLE001 - report scoring failure without raising past the CLI
             score_failed = True
+            scores = None
             print_error(console, "Scoring failed", f"{type(exc).__name__}: {exc}")
             injected = len(prs) - failed
             print_info(
@@ -204,7 +213,163 @@ def run_bench(config: BenchConfig) -> int:
             print_success(
                 console,
                 f"daydream aggregate over {scores.scored_pr_count} PR(s): "
-                f"precision={scores.precision:.3f} recall={scores.recall:.3f}",
+                f"precision={scores.precision:.3f} recall={scores.recall:.3f} f1={scores.f1:.3f}",
             )
 
-    return 0 if failed == 0 and not score_failed else 1
+    return (failed == 0 and not score_failed, scores)
+
+
+def _daydream_git_sha() -> str:
+    """Resolve the daydream source git SHA for reproducibility metadata.
+
+    Runs ``git rev-parse HEAD`` in the daydream package's own repository (not the
+    process cwd, which is the operator's directory) so the recorded SHA pins the
+    reviewer code that produced the trials. Returns ``"unknown"`` if git is
+    unavailable or the source tree is not a checkout.
+    """
+    try:
+        out = subprocess.check_output(  # noqa: S603,S607 - fixed args, trusted command
+            ["git", "rev-parse", "HEAD"],
+            cwd=Path(__file__).resolve().parent,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        return out.strip()
+    except Exception:  # noqa: BLE001 - metadata is best-effort; never abort a run on it
+        return "unknown"
+
+
+def _print_cost_estimate(prs: list[EvaluablePR], trials: int) -> None:
+    """Print the up-front judge-call estimate before a multi-trial run.
+
+    Trials multiply judge cost linearly, so the estimate is surfaced before any
+    expensive review starts (R8). The judge compares every candidate against
+    every golden comment per PR, so the per-PR grid is ``|candidates| × |golden|``
+    — unknown until the review runs — leaving the multipliers we do know.
+    """
+    print_info(
+        console,
+        f"Estimated judge cost: ~|candidates| × |golden| × {len(prs)} PRs × {trials} trials judge calls "
+        f"(scales linearly with --trials).",
+    )
+
+
+def _write_trials_summary(
+    config: BenchConfig,
+    judge_model: str,
+    prs: list[EvaluablePR],
+    scored_trials: list[tuple[int, DaydreamScores]],
+) -> Path:
+    """Write ``trials-summary.json`` with reproducibility metadata + distribution.
+
+    Args:
+        config: The base run configuration (reviewer/judge/PR selection).
+        judge_model: The resolved judge model id (``""`` when scoring was off).
+        prs: The selected PR set for this run.
+        scored_trials: ``(trial_index, scores)`` pairs for each successfully
+            scored trial, so ``per_trial`` labels stay accurate even when some
+            trials failed scoring and are absent from the list.
+
+    Returns:
+        The path to the written ``trials-summary.json``.
+    """
+    root = trials_root(config.benchmark_repo, config.tool_label)
+    root.mkdir(parents=True, exist_ok=True)
+    trial_scores = [s for _, s in scored_trials]
+    summary: dict[str, Any] = {
+        "tool_label": config.tool_label,
+        "trials": config.trials,
+        "git_sha": _daydream_git_sha(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "reviewer_backend": config.reviewer_backend,
+        "reviewer_model": config.reviewer_model,
+        "reviewer_provider": config.reviewer_provider,
+        "judge_route": config.judge_route,
+        "judge_model": judge_model or None,
+        "pr_set": [pr.golden_url for pr in prs],
+        "distribution": (distribution_to_dict(compute_distribution(trial_scores)) if trial_scores else None),
+        "per_trial": [
+            {"trial": t, "precision": s.precision, "recall": s.recall, "f1": s.f1}
+            for t, s in scored_trials
+        ],
+    }
+    dest = root / "trials-summary.json"
+    dest.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    return dest
+
+
+def _run_trials(config: BenchConfig, judge_model: str) -> int:
+    """Run ``config.trials`` isolated trials and report the score distribution.
+
+    Each trial materializes its own corpus dir (a fresh copy of the canonical
+    ``benchmark_data.json``) and runs under a trial-suffixed tool label, so the
+    unmodified withmartian steps write a distinct ``evaluations.json`` per trial
+    and no trial ever overwrites another. The canonical corpus is only read, never
+    written.
+
+    Args:
+        config: Base run configuration (``config.trials > 1``).
+        judge_model: Pre-resolved judge model id (``""`` when not scoring).
+
+    Returns:
+        ``0`` if every trial's sweep succeeded, non-zero otherwise.
+    """
+    canonical = _benchmark_data_path(config)
+    prs = _select_prs(config)
+    if config.score:
+        _print_cost_estimate(prs, config.trials)
+
+    scored_trials: list[tuple[int, DaydreamScores]] = []
+    any_failed = False
+    for t in range(config.trials):
+        trial_dir = trial_corpus_dir(config.benchmark_repo, config.tool_label, t)
+        init_trial_corpus(canonical, trial_dir)
+        trial_config = replace(
+            config,
+            benchmark_repo=trial_dir,
+            tool_label=trial_tool_label(config.tool_label, t),
+            trajectory_dir=trial_dir / "trajectories",
+        )
+        print_info(console, f"══ Trial [{t + 1}/{config.trials}] · label {trial_config.tool_label} ══")
+        ok, scores = _run_sweep(trial_config, judge_model)
+        any_failed = any_failed or not ok
+        if scores is not None:
+            scored_trials.append((t, scores))
+
+    if config.score:
+        summary_path = _write_trials_summary(config, judge_model, prs, scored_trials)
+        print_info(console, f"Wrote trial summary to {summary_path}")
+        trial_scores = [s for _, s in scored_trials]
+        if trial_scores:
+            dist = compute_distribution(trial_scores)
+            console.print(format_distribution_table(dist))
+
+    return 0 if not any_failed else 1
+
+
+def run_bench(config: BenchConfig) -> int:
+    """Run the benchmark sweep over the selected PRs.
+
+    With ``config.trials == 1`` (default) this is a single end-to-end sweep
+    (back-compat). With ``config.trials > 1`` it runs N isolated trials and
+    reports a mean/median/stddev/bootstrap-CI distribution over precision,
+    recall, and F1.
+
+    Args:
+        config: Immutable run configuration (selection, force, scoring, paths).
+
+    Returns:
+        ``0`` when every selected PR was injected (or skipped) and scoring (if
+        requested) succeeded; non-zero if any selected PR failed or scoring
+        failed.
+    """
+    judge_model = ""
+    if config.score:
+        preflight_judge_env(judge_route=config.judge_route)
+        judge_model = resolve_judge_model(config.model)
+
+    if config.trials > 1:
+        return _run_trials(config, judge_model)
+
+    ok, _scores = _run_sweep(config, judge_model)
+    return 0 if ok else 1

--- a/daydream/benchmark/orchestrator.py
+++ b/daydream/benchmark/orchestrator.py
@@ -20,13 +20,13 @@ aggregate precision/recall are printed.
 from __future__ import annotations
 
 import json
-import subprocess
 import time
 from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from daydream import git_ops
 from daydream.agent import console
 from daydream.benchmark.acquire import acquire_checkout
 from daydream.benchmark.benchmark_data import (
@@ -233,14 +233,8 @@ def _daydream_git_sha() -> str:
     unavailable or the source tree is not a checkout.
     """
     try:
-        out = subprocess.check_output(  # noqa: S603,S607 - fixed args, trusted command
-            ["git", "rev-parse", "HEAD"],
-            cwd=Path(__file__).resolve().parent,
-            stderr=subprocess.DEVNULL,
-            text=True,
-        )
-        return out.strip()
-    except Exception:  # noqa: BLE001 - metadata is best-effort; never abort a run on it
+        return git_ops.head_sha(Path(__file__).resolve().parent)
+    except git_ops.GitError:  # metadata is best-effort; never abort a run on it
         return "unknown"
 
 

--- a/daydream/benchmark/score.py
+++ b/daydream/benchmark/score.py
@@ -183,6 +183,7 @@ class DaydreamScores:
             (Σ candidates × golden) across all scored PRs.
         precision: Aggregate ΣTP / (ΣTP + ΣFP); 0.0 when the denominator is 0.
         recall: Aggregate ΣTP / (ΣTP + ΣFN); 0.0 when the denominator is 0.
+        f1: Harmonic mean 2·P·R / (P + R); 0.0 when P + R is 0.
     """
 
     per_pr: dict[str, dict[str, Any]] = field(default_factory=dict)
@@ -194,6 +195,7 @@ class DaydreamScores:
     total_comparisons: int = 0
     precision: float = 0.0
     recall: float = 0.0
+    f1: float = 0.0
 
 
 def _summarize_judge_errors(errors: list[str], *, cap: int = 3) -> str:
@@ -279,6 +281,7 @@ def parse_daydream_scores(evals: dict[str, dict[str, Any]], *, tool: str = _TOOL
 
     precision = total_tp / (total_tp + total_fp) if (total_tp + total_fp) else 0.0
     recall = total_tp / (total_tp + total_fn) if (total_tp + total_fn) else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
     return DaydreamScores(
         per_pr=per_pr,
         scored_pr_count=len(per_pr),
@@ -289,6 +292,7 @@ def parse_daydream_scores(evals: dict[str, dict[str, Any]], *, tool: str = _TOOL
         total_comparisons=total_comparisons,
         precision=precision,
         recall=recall,
+        f1=f1,
     )
 
 

--- a/daydream/benchmark/stats.py
+++ b/daydream/benchmark/stats.py
@@ -33,17 +33,7 @@ _DEFAULT_SEED = 42
 
 @dataclass(frozen=True)
 class MetricStats:
-    """Summary statistics for one metric across N trials.
-
-    Attributes:
-        mean: Arithmetic mean of the trial values.
-        median: Median of the trial values.
-        stddev: Sample standard deviation (0.0 when fewer than 2 values).
-        min: Smallest trial value.
-        max: Largest trial value.
-        ci_low: Lower endpoint of the percentile bootstrap CI of the mean.
-        ci_high: Upper endpoint of the percentile bootstrap CI of the mean.
-    """
+    """Per-metric summary statistics across N trials."""
 
     mean: float
     median: float
@@ -56,14 +46,7 @@ class MetricStats:
 
 @dataclass(frozen=True)
 class TrialDistribution:
-    """Aggregated per-metric statistics over N benchmark trials.
-
-    Attributes:
-        n: Number of trials aggregated.
-        precision: Statistics for aggregate precision across trials.
-        recall: Statistics for aggregate recall across trials.
-        f1: Statistics for aggregate F1 across trials.
-    """
+    """Aggregated precision/recall/F1 statistics over N benchmark trials."""
 
     n: int
     precision: MetricStats

--- a/daydream/benchmark/stats.py
+++ b/daydream/benchmark/stats.py
@@ -96,10 +96,15 @@ def bootstrap_ci(
         variance) both endpoints equal that value.
 
     Raises:
-        ValueError: If ``values`` is empty.
+        ValueError: If ``values`` is empty, ``n_boot`` is not positive, or
+            ``ci`` is not strictly inside ``(0, 1)``.
     """
     if not values:
         raise ValueError("bootstrap_ci requires at least one value")
+    if n_boot <= 0:
+        raise ValueError(f"n_boot must be positive, got {n_boot}")
+    if not 0 < ci < 1:
+        raise ValueError(f"ci must be in (0, 1), got {ci}")
     if len(values) == 1:
         return (values[0], values[0])
 

--- a/daydream/benchmark/stats.py
+++ b/daydream/benchmark/stats.py
@@ -1,0 +1,185 @@
+"""Distribution statistics over repeated benchmark trials.
+
+Both the reviewer LLM and the LLM judge are stochastic, so a single trial's
+precision/recall/F1 is one draw from a distribution with unknown variance. This
+module aggregates N trials into per-metric summary statistics — mean, median,
+sample standard deviation, min, max, and a seeded percentile bootstrap
+confidence interval — so configs can be compared with their spread visible
+rather than as bare point estimates.
+
+Exports:
+    MetricStats: Per-metric summary (mean/median/stddev/min/max/ci_low/ci_high).
+    TrialDistribution: Precision/recall/F1 stats over N trials.
+    compute_distribution: Aggregate a list of DaydreamScores into a TrialDistribution.
+    bootstrap_ci: Seeded percentile bootstrap CI for a list of values.
+    format_distribution_table: Render a TrialDistribution as a printable table.
+"""
+
+from __future__ import annotations
+
+import random
+import statistics
+from dataclasses import asdict, dataclass
+
+from daydream.benchmark.score import DaydreamScores
+
+#: Default bootstrap resample count. 10k keeps the CI endpoints stable to ~2
+#: decimal places while staying fast for the small N (≤~30) trials produce.
+_DEFAULT_N_BOOT = 10000
+
+#: Fixed RNG seed so the bootstrap CI is reproducible across runs and tests.
+_DEFAULT_SEED = 42
+
+
+@dataclass(frozen=True)
+class MetricStats:
+    """Summary statistics for one metric across N trials.
+
+    Attributes:
+        mean: Arithmetic mean of the trial values.
+        median: Median of the trial values.
+        stddev: Sample standard deviation (0.0 when fewer than 2 values).
+        min: Smallest trial value.
+        max: Largest trial value.
+        ci_low: Lower endpoint of the percentile bootstrap CI of the mean.
+        ci_high: Upper endpoint of the percentile bootstrap CI of the mean.
+    """
+
+    mean: float
+    median: float
+    stddev: float
+    min: float
+    max: float
+    ci_low: float
+    ci_high: float
+
+
+@dataclass(frozen=True)
+class TrialDistribution:
+    """Aggregated per-metric statistics over N benchmark trials.
+
+    Attributes:
+        n: Number of trials aggregated.
+        precision: Statistics for aggregate precision across trials.
+        recall: Statistics for aggregate recall across trials.
+        f1: Statistics for aggregate F1 across trials.
+    """
+
+    n: int
+    precision: MetricStats
+    recall: MetricStats
+    f1: MetricStats
+
+
+def bootstrap_ci(
+    values: list[float],
+    *,
+    n_boot: int = _DEFAULT_N_BOOT,
+    ci: float = 0.95,
+    seed: int = _DEFAULT_SEED,
+) -> tuple[float, float]:
+    """Percentile bootstrap confidence interval for the mean of ``values``.
+
+    Resamples ``values`` with replacement ``n_boot`` times, takes each
+    resample's mean, and returns the lower/upper percentile endpoints for the
+    requested central mass. Seeded so the interval is deterministic (tests and
+    reruns get identical endpoints).
+
+    Args:
+        values: The per-trial metric values (at least one).
+        n_boot: Number of bootstrap resamples.
+        ci: Central probability mass to bracket (e.g. 0.95 → 2.5%/97.5%).
+        seed: RNG seed for reproducibility.
+
+    Returns:
+        ``(ci_low, ci_high)``. When ``values`` has a single element (or zero
+        variance) both endpoints equal that value.
+
+    Raises:
+        ValueError: If ``values`` is empty.
+    """
+    if not values:
+        raise ValueError("bootstrap_ci requires at least one value")
+    if len(values) == 1:
+        return (values[0], values[0])
+
+    rng = random.Random(seed)
+    n = len(values)
+    means = []
+    for _ in range(n_boot):
+        resample = [values[rng.randrange(n)] for _ in range(n)]
+        means.append(sum(resample) / n)
+    means.sort()
+    lo_frac = (1.0 - ci) / 2.0
+    hi_frac = 1.0 - lo_frac
+    lo_idx = max(0, min(n_boot - 1, int(lo_frac * n_boot)))
+    hi_idx = max(0, min(n_boot - 1, int(hi_frac * n_boot)))
+    return (means[lo_idx], means[hi_idx])
+
+
+def _metric_stats(values: list[float], *, seed: int = _DEFAULT_SEED) -> MetricStats:
+    """Compute summary statistics (incl. bootstrap CI) for one metric's values."""
+    ci_low, ci_high = bootstrap_ci(values, seed=seed)
+    return MetricStats(
+        mean=statistics.fmean(values),
+        median=statistics.median(values),
+        stddev=statistics.stdev(values) if len(values) > 1 else 0.0,
+        min=min(values),
+        max=max(values),
+        ci_low=ci_low,
+        ci_high=ci_high,
+    )
+
+
+def compute_distribution(scores: list[DaydreamScores], *, seed: int = _DEFAULT_SEED) -> TrialDistribution:
+    """Aggregate N trials' scores into per-metric summary statistics.
+
+    Args:
+        scores: One :class:`DaydreamScores` per trial (at least one).
+        seed: RNG seed forwarded to the bootstrap CI.
+
+    Returns:
+        A :class:`TrialDistribution` with precision/recall/F1 statistics.
+
+    Raises:
+        ValueError: If ``scores`` is empty.
+    """
+    if not scores:
+        raise ValueError("compute_distribution requires at least one trial's scores")
+    return TrialDistribution(
+        n=len(scores),
+        precision=_metric_stats([s.precision for s in scores], seed=seed),
+        recall=_metric_stats([s.recall for s in scores], seed=seed),
+        f1=_metric_stats([s.f1 for s in scores], seed=seed),
+    )
+
+
+def format_distribution_table(dist: TrialDistribution) -> str:
+    """Render a :class:`TrialDistribution` as a fixed-width text table.
+
+    Args:
+        dist: The aggregated distribution.
+
+    Returns:
+        A multi-line string with a header row and one row per metric carrying
+        mean, median, stddev, min, max, and the 95% bootstrap CI.
+    """
+    header = f"{'metric':<10} {'mean':>7} {'median':>7} {'stddev':>7} {'min':>7} {'max':>7} {'ci95':>17}"
+    lines = [f"Distribution over {dist.n} trial(s):", header, "-" * len(header)]
+    for name, stats in (("precision", dist.precision), ("recall", dist.recall), ("f1", dist.f1)):
+        ci = f"[{stats.ci_low:.3f}, {stats.ci_high:.3f}]"
+        lines.append(
+            f"{name:<10} {stats.mean:>7.3f} {stats.median:>7.3f} {stats.stddev:>7.3f} "
+            f"{stats.min:>7.3f} {stats.max:>7.3f} {ci:>17}"
+        )
+    return "\n".join(lines)
+
+
+def distribution_to_dict(dist: TrialDistribution) -> dict:
+    """Serialize a :class:`TrialDistribution` to a plain JSON-ready dict."""
+    return {
+        "n": dist.n,
+        "precision": asdict(dist.precision),
+        "recall": asdict(dist.recall),
+        "f1": asdict(dist.f1),
+    }

--- a/daydream/benchmark/trial_isolation.py
+++ b/daydream/benchmark/trial_isolation.py
@@ -26,16 +26,7 @@ def trials_root(benchmark_repo: Path, tool_label: str) -> Path:
 
 
 def trial_corpus_dir(benchmark_repo: Path, tool_label: str, trial_index: int) -> Path:
-    """Resolve the isolated corpus dir for a single trial.
-
-    Args:
-        benchmark_repo: Path to the external benchmark checkout.
-        tool_label: Base reviewer results label (e.g. ``daydream``).
-        trial_index: Zero-based trial number.
-
-    Returns:
-        ``<benchmark_repo>/.daydream-bench/trials/<tool_label>/trial-<NN>``.
-    """
+    """Resolve ``<benchmark_repo>/.daydream-bench/trials/<tool_label>/trial-<NN>``."""
     return trials_root(benchmark_repo, tool_label) / f"trial-{trial_index:02d}"
 
 
@@ -61,16 +52,9 @@ def init_trial_corpus(canonical_data_path: Path, trial_dir: Path) -> Path:
 
 
 def trial_tool_label(base_label: str, trial_index: int) -> str:
-    """Suffix a base results label with a zero-padded trial index.
+    """Suffix a base label with a zero-padded trial index (``daydream`` -> ``daydream-t00``).
 
-    The suffix makes each trial write a distinct ``evaluations.json`` under the
+    The suffix lets each trial write a distinct ``evaluations.json`` under the
     unmodified withmartian steps, so trials never overwrite one another.
-
-    Args:
-        base_label: The base reviewer label (e.g. ``daydream``).
-        trial_index: Zero-based trial number.
-
-    Returns:
-        ``<base_label>-t<NN>`` (e.g. ``daydream-t00``).
     """
     return f"{base_label}-t{trial_index:02d}"

--- a/daydream/benchmark/trial_isolation.py
+++ b/daydream/benchmark/trial_isolation.py
@@ -1,0 +1,76 @@
+"""Isolated per-trial corpus dirs for repeated-trial benchmarking.
+
+Each repeated trial materializes its own standard corpus dir — its own
+``results/benchmark_data.json`` plus a trial-suffixed tool label — so every
+trial stays independently re-scorable by the unmodified withmartian steps.
+The canonical ``results/benchmark_data.json`` (the external leaderboard
+contract) is never touched: trial data lives entirely under
+``<benchmark_repo>/.daydream-bench/trials/<tool_label>/``.
+
+Exports:
+    trials_root: Root dir holding all trials for one reviewer label.
+    trial_corpus_dir: Per-trial dir path.
+    init_trial_corpus: Seed a trial dir with a copy of the canonical corpus.
+    trial_tool_label: Suffix a base label with the trial index (e.g. ``daydream-t00``).
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+
+def trials_root(benchmark_repo: Path, tool_label: str) -> Path:
+    """Resolve the root dir holding every trial for one reviewer label."""
+    return benchmark_repo / ".daydream-bench" / "trials" / tool_label
+
+
+def trial_corpus_dir(benchmark_repo: Path, tool_label: str, trial_index: int) -> Path:
+    """Resolve the isolated corpus dir for a single trial.
+
+    Args:
+        benchmark_repo: Path to the external benchmark checkout.
+        tool_label: Base reviewer results label (e.g. ``daydream``).
+        trial_index: Zero-based trial number.
+
+    Returns:
+        ``<benchmark_repo>/.daydream-bench/trials/<tool_label>/trial-<NN>``.
+    """
+    return trials_root(benchmark_repo, tool_label) / f"trial-{trial_index:02d}"
+
+
+def init_trial_corpus(canonical_data_path: Path, trial_dir: Path) -> Path:
+    """Seed a trial dir with a fresh copy of the canonical corpus.
+
+    Creates ``<trial_dir>/results/`` and copies the canonical
+    ``benchmark_data.json`` into it as the trial's independent working corpus.
+    The trial's reviews are injected there, keeping the canonical corpus pristine.
+
+    Args:
+        canonical_data_path: Path to the canonical ``results/benchmark_data.json``.
+        trial_dir: The per-trial dir (see :func:`trial_corpus_dir`).
+
+    Returns:
+        The path to the trial's ``results/benchmark_data.json``.
+    """
+    trial_results = trial_dir / "results"
+    trial_results.mkdir(parents=True, exist_ok=True)
+    dest = trial_results / "benchmark_data.json"
+    shutil.copy2(canonical_data_path, dest)
+    return dest
+
+
+def trial_tool_label(base_label: str, trial_index: int) -> str:
+    """Suffix a base results label with a zero-padded trial index.
+
+    The suffix makes each trial write a distinct ``evaluations.json`` under the
+    unmodified withmartian steps, so trials never overwrite one another.
+
+    Args:
+        base_label: The base reviewer label (e.g. ``daydream``).
+        trial_index: Zero-based trial number.
+
+    Returns:
+        ``<base_label>-t<NN>`` (e.g. ``daydream-t00``).
+    """
+    return f"{base_label}-t{trial_index:02d}"

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -184,6 +184,35 @@ Re-running is resumable and idempotent. `benchmark_data.json` is saved after eac
 
 **Run one sweep per benchmark repo at a time.** Each save acquires an exclusive `benchmark_data.json.lock` file to serialise concurrent writers on the same machine, but two sweeps sharing the same `--benchmark-repo` would still race at the read-inject-write level: the second run reads a stale corpus, overwrites the first run's injections, and you lose results. Start a second sweep only after the first has finished (or been interrupted).
 
+## Repeated trials and variance reporting
+
+Both the reviewer LLM and the LLM judge are stochastic, so a single sweep's precision/recall/F1 is one draw from a distribution with unknown variance. Ranking two reviewer configs by one sweep each compares two draws from possibly-overlapping distributions — the classic way to ship a false "X beats Y." `--trials N` runs each reviewer config `N` times end-to-end (review + score) and reports the spread.
+
+```bash
+daydream bench --benchmark-repo ../code-review-benchmark/offline --trials 10
+```
+
+Each trial is fully isolated. Rather than change the idempotent inject/save logic, a trial materializes its own **standard corpus dir** under `<benchmark-repo>/.daydream-bench/trials/<tool-label>/trial-NN/`, seeded with a fresh copy of the canonical `results/benchmark_data.json`, and runs under a **trial-suffixed tool label** (`daydream-t00`, `daydream-t01`, …). The unmodified withmartian steps therefore write a distinct `evaluations.json` per trial and no trial overwrites another. The canonical `results/benchmark_data.json` — the external leaderboard submission contract — is only read, never written, when `--trials > 1`.
+
+After all trials, the harness computes per-metric statistics over precision, recall, and F1 — mean, median, sample standard deviation, min, max, and a **percentile bootstrap 95% confidence interval** of the mean — and prints a distribution table:
+
+```text
+Distribution over 10 trial(s):
+metric        mean  median  stddev     min     max              ci95
+----------------------------------------------------------------------
+precision    0.214   0.210   0.018   0.190   0.250   [0.203, 0.226]
+recall       0.585   0.590   0.031   0.530   0.630   [0.566, 0.604]
+f1           0.313   0.311   0.021   0.280   0.350   [0.300, 0.327]
+```
+
+The bootstrap resamples the `N` trial values with replacement (10 000 resamples, seeded for reproducibility) and reports the 2.5th/97.5th percentiles of the resampled means — a distribution-free CI that makes no normality assumption. It is a best-effort estimate at small `N`, not a substitute for it.
+
+A `trials-summary.json` is written to `<benchmark-repo>/.daydream-bench/trials/<tool-label>/` carrying full reproducibility metadata: the reviewer backend/model/provider, the judge route + model, the PR set, the daydream git SHA, a UTC timestamp, the aggregate distribution, and each trial's raw precision/recall/F1.
+
+**Choosing N.** The bootstrap CI width shrinks roughly as `1/√N`. Use `N ≥ 10` for a reasonable band and `N ≥ 30` when you need a tight interval to separate two close configs. Trials multiply judge cost linearly, so the harness prints an up-front estimate (`~|candidates| × |golden| × PRs × N` judge calls) before the loop starts.
+
+**Seeds are best-effort.** LLM provider seeds are soft-honored at best and never guaranteed across a fleet; aggregation across trials is the mechanism that quantifies the residual noise, and it is mandatory regardless of any seed the provider accepts. Only the bootstrap resampling itself is deterministically seeded.
+
 ## Comparability caveat
 
 What matters is the reviewer. A different reviewer pipeline (different backend, model config, or tool label) produces different findings — changing the reviewer changes the numbers. The offline HTML report at `bench/benchmark-report/runs/latest/index.html` documents the reviewer configuration for each run.

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -204,6 +204,31 @@ def test_trials_flag_overrides_config_file(tmp_path, monkeypatch):
     assert cfg.trials == 2
 
 
+@pytest.mark.parametrize("toml_value", ["2.5", '"3"'])
+def test_trials_config_file_rejects_non_int(tmp_path, monkeypatch, toml_value):
+    # The config-file fallback reaches the isinstance(trials, int) branch at
+    # cli.py: load_file_config stores TOML values verbatim (no coercion), so a
+    # float or string trials value must be rejected there.
+    (tmp_path / "pyproject.toml").write_text(
+        f'[tool.daydream.bench]\nbenchmark-repo="/b"\ntrials={toml_value}\n'
+    )
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(SystemExit):
+        _bench_config_from_argv(["--no-score"])
+
+
+@pytest.mark.parametrize("toml_value", ["0", "-1"])
+def test_trials_config_file_rejects_non_positive(tmp_path, monkeypatch, toml_value):
+    # Non-positive trials via config-file fallback reaches the trials <= 0
+    # branch at cli.py (the CLI-flag path is caught earlier by argparse).
+    (tmp_path / "pyproject.toml").write_text(
+        f'[tool.daydream.bench]\nbenchmark-repo="/b"\ntrials={toml_value}\n'
+    )
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(SystemExit):
+        _bench_config_from_argv(["--no-score"])
+
+
 def test_bench_parser_accepts_positive_limit():
     cfg = _bench_config_from_argv(["--benchmark-repo", "/b", "--limit", "3"])
     assert cfg.limit == 3

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -171,6 +171,39 @@ def test_reviewer_override_without_label_fails_through_compiled_entrypoint(tmp_p
     assert r.returncode != 0 and "--tool-label" in (r.stdout + r.stderr)
 
 
+def test_trials_flag_parsed(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    cfg = _bench_config_from_argv(["--benchmark-repo", "/b", "--no-score", "--trials", "3"])
+    assert cfg.trials == 3
+
+
+def test_trials_defaults_to_one(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    cfg = _bench_config_from_argv(["--benchmark-repo", "/b", "--no-score"])
+    assert cfg.trials == 1
+
+
+@pytest.mark.parametrize("bad", ["0", "-1"])
+def test_trials_rejects_non_positive(tmp_path, monkeypatch, bad):
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(SystemExit):
+        _bench_config_from_argv(["--benchmark-repo", "/b", "--no-score", "--trials", bad])
+
+
+def test_trials_config_file_fallback(tmp_path, monkeypatch):
+    (tmp_path / "pyproject.toml").write_text('[tool.daydream.bench]\nbenchmark-repo="/b"\ntrials=5\n')
+    monkeypatch.chdir(tmp_path)
+    cfg = _bench_config_from_argv(["--no-score"])  # no --trials flag
+    assert cfg.trials == 5
+
+
+def test_trials_flag_overrides_config_file(tmp_path, monkeypatch):
+    (tmp_path / "pyproject.toml").write_text('[tool.daydream.bench]\nbenchmark-repo="/b"\ntrials=5\n')
+    monkeypatch.chdir(tmp_path)
+    cfg = _bench_config_from_argv(["--no-score", "--trials", "2"])
+    assert cfg.trials == 2
+
+
 def test_bench_parser_accepts_positive_limit():
     cfg = _bench_config_from_argv(["--benchmark-repo", "/b", "--limit", "3"])
     assert cfg.limit == 3

--- a/tests/test_benchmark_orchestrator.py
+++ b/tests/test_benchmark_orchestrator.py
@@ -261,7 +261,17 @@ def _scores_by_trial(tmp_path, monkeypatch):
         p = 0.4 + 0.1 * idx
         r = 0.5 + 0.1 * idx
         f1 = 2 * p * r / (p + r)
-        return DaydreamScores(scored_pr_count=1, total_tp=1, precision=p, recall=r, f1=f1)
+        return DaydreamScores(
+            scored_pr_count=1,
+            total_tp=1,
+            total_fp=idx,
+            total_fn=idx + 1,
+            total_errors=0,
+            total_comparisons=10 + idx,
+            precision=p,
+            recall=r,
+            f1=f1,
+        )
 
     monkeypatch.setattr("daydream.benchmark.orchestrator.run_scoring", fake_score)
     return captured
@@ -337,6 +347,13 @@ def test_trials_writes_summary_with_distribution_and_metadata(tmp_path, monkeypa
     assert len(summary["per_trial"]) == 3
     # per-trial precisions are the three distinct values, in trial order.
     assert [round(pt["precision"], 3) for pt in summary["per_trial"]] == [0.4, 0.5, 0.6]
+    # Richer per-trial fields carry the tp/fp/fn/comparison counts for post-hoc auditing.
+    assert [pt["tool_label"] for pt in summary["per_trial"]] == ["daydream-t00", "daydream-t01", "daydream-t02"]
+    assert [pt["total_fp"] for pt in summary["per_trial"]] == [0, 1, 2]
+    assert [pt["total_fn"] for pt in summary["per_trial"]] == [1, 2, 3]
+    assert [pt["total_comparisons"] for pt in summary["per_trial"]] == [10, 11, 12]
+    for pt in summary["per_trial"]:
+        assert pt["scored_pr_count"] == 1 and pt["total_tp"] == 1 and pt["total_errors"] == 0
     dist = summary["distribution"]
     for metric in ("precision", "recall", "f1"):
         assert set(dist[metric]) == {"mean", "median", "stddev", "min", "max", "ci_low", "ci_high"}
@@ -360,6 +377,8 @@ def test_trials_prints_distribution_and_cost_estimate(tmp_path, monkeypatch):
     assert "Estimated judge cost" in out and "3 trials" in out  # cost surfaced before the loop
     assert "precision" in out and "recall" in out and "f1" in out  # distribution table
     assert "median" in out and "stddev" in out and "ci95" in out
+    # Post-loop close on the up-front estimate: 10 + 11 + 12 comparisons across the 3 trials.
+    assert "Actual judge comparisons recorded: 33" in out
 
 
 def test_trials_1_is_backcompat_no_trial_dirs(tmp_path, monkeypatch):

--- a/tests/test_benchmark_orchestrator.py
+++ b/tests/test_benchmark_orchestrator.py
@@ -233,6 +233,153 @@ def test_materiality_gate_filters_submission(tmp_path, monkeypatch):
     assert _injected_comment_count(data, golden_url, "daydream") == 1  # only the HIGH item survives the gate
 
 
+def _mock_review(tmp_path, monkeypatch):
+    """Wire acquire_checkout + run_daydream_review to a one-finding fake review."""
+    monkeypatch.setattr(
+        "daydream.benchmark.orchestrator.acquire_checkout",
+        lambda *a, **k: _fake_checkout(tmp_path),
+    )
+    monkeypatch.setattr(
+        "daydream.benchmark.orchestrator.run_daydream_review",
+        lambda checkout, **k: _write_items(checkout, [_item("f.py", 1)]),
+    )
+
+
+def _scores_by_trial(tmp_path, monkeypatch):
+    """Mock run_scoring: derive distinct precision/recall/f1 from the trial label.
+
+    The trial-suffixed tool label (``daydream-t00``…) encodes the trial index, so
+    the mock returns a different score per trial — proving the distribution is
+    aggregated over genuinely separate trial runs, not one value repeated.
+    """
+    captured = {"tools": [], "repos": []}
+
+    def fake_score(repo, model, *, pr_count, tool, judge_route):
+        captured["tools"].append(tool)
+        captured["repos"].append(repo)
+        idx = int(tool.rsplit("-t", 1)[1]) if "-t" in tool else 0
+        p = 0.4 + 0.1 * idx
+        r = 0.5 + 0.1 * idx
+        f1 = 2 * p * r / (p + r)
+        return DaydreamScores(scored_pr_count=1, total_tp=1, precision=p, recall=r, f1=f1)
+
+    monkeypatch.setattr("daydream.benchmark.orchestrator.run_scoring", fake_score)
+    return captured
+
+
+def _scored_trials_config(tmp_path, data_path, trials):
+    """Build a scoring-enabled BenchConfig with N trials over the grafana subset."""
+    return replace(_config(tmp_path, data_path, score=True, only="grafana"), limit=1, trials=trials)
+
+
+def test_trials_3_creates_3_isolated_trial_dirs(tmp_path, monkeypatch):
+    monkeypatch.setenv("MARTIAN_API_KEY", "sk-x")
+    monkeypatch.setenv("MARTIAN_MODEL", "judge-model")
+    data_path = _seed_benchmark_data_with_all_26_keys(tmp_path)
+    _mock_review(tmp_path, monkeypatch)
+    captured = _scores_by_trial(tmp_path, monkeypatch)
+
+    rc = run_bench(_scored_trials_config(tmp_path, data_path, 3))
+
+    assert rc == 0
+    trials_dir = tmp_path / ".daydream-bench" / "trials" / "daydream"
+    trial_dirs = sorted(p.name for p in trials_dir.iterdir() if p.name.startswith("trial-"))
+    assert trial_dirs == ["trial-00", "trial-01", "trial-02"]
+    # Each trial owns its own corpus, scored under its own suffixed label + repo.
+    for i in range(3):
+        corpus = trials_dir / f"trial-{i:02d}" / "results" / "benchmark_data.json"
+        assert corpus.exists()
+    assert captured["tools"] == ["daydream-t00", "daydream-t01", "daydream-t02"]
+    assert all(r == trials_dir / f"trial-{i:02d}" for i, r in enumerate(captured["repos"]))
+
+
+def test_trials_injects_into_trial_corpus_not_canonical(tmp_path, monkeypatch):
+    monkeypatch.setenv("MARTIAN_API_KEY", "sk-x")
+    monkeypatch.setenv("MARTIAN_MODEL", "judge-model")
+    data_path = _seed_benchmark_data_with_all_26_keys(tmp_path)
+    canonical_before = data_path.read_bytes()
+    _mock_review(tmp_path, monkeypatch)
+    _scores_by_trial(tmp_path, monkeypatch)
+
+    run_bench(_scored_trials_config(tmp_path, data_path, 2))
+
+    # R3: the canonical corpus is byte-for-byte unchanged (no trial keys leak in).
+    assert data_path.read_bytes() == canonical_before
+    # The trial's own corpus carries the injected trial-labeled review.
+    trial0_corpus = (
+        tmp_path / ".daydream-bench" / "trials" / "daydream" / "trial-00" / "results" / "benchmark_data.json"
+    )
+    trial0 = json.loads(trial0_corpus.read_text())
+    grafana = [u for u in trial0 if "grafana" in u]
+    injected = [u for u in grafana if any(r["tool"] == "daydream-t00" for r in trial0[u]["reviews"])]
+    assert len(injected) == 1
+
+
+def test_trials_writes_summary_with_distribution_and_metadata(tmp_path, monkeypatch):
+    monkeypatch.setenv("MARTIAN_API_KEY", "sk-x")
+    monkeypatch.setenv("MARTIAN_MODEL", "judge-model")
+    data_path = _seed_benchmark_data_with_all_26_keys(tmp_path)
+    _mock_review(tmp_path, monkeypatch)
+    _scores_by_trial(tmp_path, monkeypatch)
+
+    run_bench(_scored_trials_config(tmp_path, data_path, 3))
+
+    summary_path = tmp_path / ".daydream-bench" / "trials" / "daydream" / "trials-summary.json"
+    assert summary_path.exists()
+    summary = json.loads(summary_path.read_text())
+    assert summary["tool_label"] == "daydream"
+    assert summary["trials"] == 3
+    assert summary["judge_route"] == "martian"
+    assert summary["judge_model"] == "judge-model"
+    assert isinstance(summary["git_sha"], str) and summary["git_sha"]
+    assert summary["timestamp"]
+    assert len(summary["pr_set"]) == 1
+    assert len(summary["per_trial"]) == 3
+    # per-trial precisions are the three distinct values, in trial order.
+    assert [round(pt["precision"], 3) for pt in summary["per_trial"]] == [0.4, 0.5, 0.6]
+    dist = summary["distribution"]
+    for metric in ("precision", "recall", "f1"):
+        assert set(dist[metric]) == {"mean", "median", "stddev", "min", "max", "ci_low", "ci_high"}
+    assert dist["precision"]["mean"] == pytest.approx(0.5)
+    assert dist["precision"]["min"] == pytest.approx(0.4)
+    assert dist["precision"]["max"] == pytest.approx(0.6)
+
+
+def test_trials_prints_distribution_and_cost_estimate(tmp_path, monkeypatch):
+    rec = Console(record=True, force_terminal=True, width=120)
+    monkeypatch.setattr("daydream.benchmark.orchestrator.console", rec)
+    monkeypatch.setenv("MARTIAN_API_KEY", "sk-x")
+    monkeypatch.setenv("MARTIAN_MODEL", "judge-model")
+    data_path = _seed_benchmark_data_with_all_26_keys(tmp_path)
+    _mock_review(tmp_path, monkeypatch)
+    _scores_by_trial(tmp_path, monkeypatch)
+
+    run_bench(_scored_trials_config(tmp_path, data_path, 3))
+
+    out = rec.export_text()
+    assert "Estimated judge cost" in out and "3 trials" in out  # cost surfaced before the loop
+    assert "precision" in out and "recall" in out and "f1" in out  # distribution table
+    assert "median" in out and "stddev" in out and "ci95" in out
+
+
+def test_trials_1_is_backcompat_no_trial_dirs(tmp_path, monkeypatch):
+    monkeypatch.setenv("MARTIAN_API_KEY", "sk-x")
+    monkeypatch.setenv("MARTIAN_MODEL", "judge-model")
+    data_path = _seed_benchmark_data_with_all_26_keys(tmp_path)
+    _mock_review(tmp_path, monkeypatch)
+    captured = _scores_by_trial(tmp_path, monkeypatch)
+
+    rc = run_bench(replace(_config(tmp_path, data_path, score=True, only="grafana"), limit=1, trials=1))
+
+    assert rc == 0
+    # trials==1 keeps the legacy path: canonical corpus is written, no sidecar dirs.
+    assert not (tmp_path / ".daydream-bench" / "trials").exists()
+    data = json.loads(data_path.read_text())
+    grafana_injected = [u for u in data if "grafana" in u and any(r["tool"] == "daydream" for r in data[u]["reviews"])]
+    assert len(grafana_injected) == 1
+    assert captured["tools"] == ["daydream"]  # scored under the base label, not a trial suffix
+
+
 def test_rerun_skips_already_injected_unless_forced(tmp_path, monkeypatch):
     data_path = _seed_benchmark_data_with_all_26_keys(tmp_path)
     calls = {"n": 0}

--- a/tests/test_benchmark_score.py
+++ b/tests/test_benchmark_score.py
@@ -174,6 +174,36 @@ def test_direct_anthropic_preflight_rejects_martian_base_url(monkeypatch):
         preflight_judge_env(judge_route="anthropic-direct")
 
 
+def test_f1_computation():
+    """F1 is the harmonic mean of the aggregate precision and recall.
+
+    url1 contributes tp=2 fp=1 fn=1, url2 tp=0 fp=2 fn=3, so aggregate
+    precision = 2/5 = 0.4 and recall = 2/6 ≈ 0.3333, giving
+    f1 = 2·0.4·0.3333 / (0.4 + 0.3333) ≈ 0.3636.
+    """
+    evals = {
+        "url1": {"daydream": {"tp": 2, "fp": 1, "fn": 1, "total_candidates": 3, "total_golden": 3}},
+        "url2": {"daydream": {"tp": 0, "fp": 2, "fn": 3, "total_candidates": 2, "total_golden": 3}},
+    }
+    s = parse_daydream_scores(evals)
+    p, r = 2 / 5, 2 / 6
+    assert s.f1 == pytest.approx(2 * p * r / (p + r))
+
+
+def test_f1_perfect_scores():
+    """Perfect precision and recall → f1 == 1.0."""
+    evals = {"url1": {"daydream": {"tp": 3, "fp": 0, "fn": 0, "total_candidates": 3, "total_golden": 3}}}
+    s = parse_daydream_scores(evals)
+    assert s.precision == 1.0 and s.recall == 1.0 and s.f1 == 1.0
+
+
+def test_f1_zero_when_precision_and_recall_zero():
+    """P + R == 0 → f1 == 0.0 (no division by zero)."""
+    evals = {"url1": {"daydream": {"tp": 0, "fp": 4, "fn": 5, "total_candidates": 4, "total_golden": 5}}}
+    s = parse_daydream_scores(evals)
+    assert s.precision == 0.0 and s.recall == 0.0 and s.f1 == 0.0
+
+
 def test_parse_daydream_scores_extracts_per_pr_and_aggregate():
     evals = {
       "url1": {"daydream": {"tp": 2, "fp": 1, "fn": 1, "precision": 0.667, "recall": 0.667,

--- a/tests/test_benchmark_stats.py
+++ b/tests/test_benchmark_stats.py
@@ -75,6 +75,17 @@ def test_bootstrap_ci_empty_raises():
         bootstrap_ci([])
 
 
+def test_bootstrap_ci_nonpositive_n_boot_raises():
+    with pytest.raises(ValueError, match="n_boot must be positive"):
+        bootstrap_ci([0.4, 0.6], n_boot=0)
+
+
+def test_bootstrap_ci_out_of_range_confidence_raises():
+    for bad_ci in (0.0, 1.0, 1.5):
+        with pytest.raises(ValueError, match=r"ci must be in \(0, 1\)"):
+            bootstrap_ci([0.4, 0.6], ci=bad_ci)
+
+
 def test_format_distribution_table_contains_metrics_and_stats():
     dist = compute_distribution([_scores(0.4, 0.5, 0.44), _scores(0.6, 0.7, 0.65)])
     out = format_distribution_table(dist)

--- a/tests/test_benchmark_stats.py
+++ b/tests/test_benchmark_stats.py
@@ -1,0 +1,92 @@
+"""Tests for the trial distribution statistics module."""
+
+from __future__ import annotations
+
+import statistics
+
+import pytest
+
+from daydream.benchmark.score import DaydreamScores
+from daydream.benchmark.stats import (
+    bootstrap_ci,
+    compute_distribution,
+    distribution_to_dict,
+    format_distribution_table,
+)
+
+
+def _scores(precision: float, recall: float, f1: float) -> DaydreamScores:
+    return DaydreamScores(precision=precision, recall=recall, f1=f1)
+
+
+def test_compute_distribution_mean_median_stddev():
+    trials = [
+        _scores(0.4, 0.5, 0.44),
+        _scores(0.6, 0.5, 0.55),
+        _scores(0.5, 0.8, 0.62),
+    ]
+    dist = compute_distribution(trials)
+    assert dist.n == 3
+    assert dist.precision.mean == pytest.approx(statistics.fmean([0.4, 0.6, 0.5]))
+    assert dist.precision.median == pytest.approx(0.5)
+    assert dist.precision.stddev == pytest.approx(statistics.stdev([0.4, 0.6, 0.5]))
+    assert dist.precision.min == 0.4 and dist.precision.max == 0.6
+    assert dist.recall.mean == pytest.approx(0.6)
+
+
+def test_compute_distribution_single_trial_zero_stddev():
+    dist = compute_distribution([_scores(0.5, 0.5, 0.5)])
+    assert dist.n == 1
+    assert dist.precision.stddev == 0.0
+    assert dist.precision.ci_low == 0.5 and dist.precision.ci_high == 0.5
+
+
+def test_compute_distribution_empty_raises():
+    with pytest.raises(ValueError):
+        compute_distribution([])
+
+
+def test_bootstrap_ci_is_seeded_and_deterministic():
+    values = [0.1, 0.3, 0.5, 0.7, 0.9]
+    a = bootstrap_ci(values, seed=42)
+    b = bootstrap_ci(values, seed=42)
+    assert a == b
+
+
+def test_bootstrap_ci_brackets_the_mean():
+    values = [0.4, 0.45, 0.5, 0.55, 0.6, 0.5, 0.48, 0.52]
+    mean = statistics.fmean(values)
+    lo, hi = bootstrap_ci(values, seed=42)
+    assert lo <= mean <= hi
+    assert lo < hi
+
+
+def test_bootstrap_ci_zero_variance_is_a_point():
+    lo, hi = bootstrap_ci([0.5, 0.5, 0.5, 0.5], seed=42)
+    assert lo == 0.5 and hi == 0.5
+
+
+def test_bootstrap_ci_single_value():
+    assert bootstrap_ci([0.7]) == (0.7, 0.7)
+
+
+def test_bootstrap_ci_empty_raises():
+    with pytest.raises(ValueError):
+        bootstrap_ci([])
+
+
+def test_format_distribution_table_contains_metrics_and_stats():
+    dist = compute_distribution([_scores(0.4, 0.5, 0.44), _scores(0.6, 0.7, 0.65)])
+    out = format_distribution_table(dist)
+    assert "precision" in out and "recall" in out and "f1" in out
+    assert "mean" in out and "median" in out and "stddev" in out
+    assert "ci95" in out
+    assert "2 trial" in out
+
+
+def test_distribution_to_dict_shape():
+    dist = compute_distribution([_scores(0.4, 0.5, 0.44), _scores(0.6, 0.7, 0.65)])
+    d = distribution_to_dict(dist)
+    assert d["n"] == 2
+    for metric in ("precision", "recall", "f1"):
+        assert set(d[metric]) == {"mean", "median", "stddev", "min", "max", "ci_low", "ci_high"}

--- a/tests/test_trial_isolation.py
+++ b/tests/test_trial_isolation.py
@@ -1,0 +1,53 @@
+"""Tests for isolated per-trial corpus dirs."""
+
+from __future__ import annotations
+
+import json
+
+from daydream.benchmark.trial_isolation import (
+    init_trial_corpus,
+    trial_corpus_dir,
+    trial_tool_label,
+    trials_root,
+)
+
+
+def test_trial_corpus_dir_path(tmp_path):
+    d = trial_corpus_dir(tmp_path, "daydream", 3)
+    assert d == tmp_path / ".daydream-bench" / "trials" / "daydream" / "trial-03"
+
+
+def test_trials_root_path(tmp_path):
+    assert trials_root(tmp_path, "daydream-glm") == tmp_path / ".daydream-bench" / "trials" / "daydream-glm"
+
+
+def test_trial_tool_label_format():
+    assert trial_tool_label("daydream", 0) == "daydream-t00"
+    assert trial_tool_label("daydream", 12) == "daydream-t12"
+    assert trial_tool_label("daydream-glm", 1) == "daydream-glm-t01"
+
+
+def test_init_trial_corpus_copies_data(tmp_path):
+    canonical = tmp_path / "results" / "benchmark_data.json"
+    canonical.parent.mkdir(parents=True)
+    payload = {"https://x/pull/1": {"golden_comments": [], "reviews": []}}
+    canonical.write_text(json.dumps(payload), encoding="utf-8")
+
+    trial_dir = trial_corpus_dir(tmp_path, "daydream", 0)
+    dest = init_trial_corpus(canonical, trial_dir)
+
+    assert dest == trial_dir / "results" / "benchmark_data.json"
+    assert dest.exists()
+    assert json.loads(dest.read_text()) == payload
+
+
+def test_init_trial_corpus_is_independent_of_canonical(tmp_path):
+    """Mutating the trial copy must not touch the canonical corpus."""
+    canonical = tmp_path / "results" / "benchmark_data.json"
+    canonical.parent.mkdir(parents=True)
+    canonical.write_text(json.dumps({"a": 1}), encoding="utf-8")
+
+    dest = init_trial_corpus(canonical, trial_corpus_dir(tmp_path, "daydream", 0))
+    dest.write_text(json.dumps({"a": 2}), encoding="utf-8")
+
+    assert json.loads(canonical.read_text()) == {"a": 1}


### PR DESCRIPTION
## Summary

- Adds `--trials N` to `daydream bench`: runs each reviewer config `N` times end-to-end and reports a distribution (mean/median/stddev/95% bootstrap CI) over precision, recall, and F1.
- Adds F1 to the score model so the distribution has a single ranking metric that balances precision and recall.
- Each trial is fully isolated: its own corpus dir and trial-suffixed tool label, so the unmodified withmartian scoring steps never overwrite one another and the canonical `results/benchmark_data.json` is read-only when `--trials > 1`.

## Motivation

Both the reviewer LLM and the LLM judge are stochastic, so a single benchmark sweep produces one draw from a distribution with unknown variance. Ranking two reviewer configs by one sweep each compares two draws from possibly-overlapping distributions, which is the classic way to ship a false "X beats Y." Repeated trials with distribution reporting make the spread visible and let close configs be separated honestly.

Closes #249

## Changes

### Added

- `daydream/benchmark/stats.py`: `MetricStats`, `TrialDistribution`, `compute_distribution`, seeded percentile `bootstrap_ci`, `format_distribution_table`, `distribution_to_dict`.
- `daydream/benchmark/trial_isolation.py`: `trials_root`, `trial_corpus_dir`, `init_trial_corpus`, `trial_tool_label`.
- `--trials N` CLI flag with positive-int validation and `[tool.daydream.bench] trials` config-file fallback.
- `f1` field on `DaydreamScores` (harmonic mean of aggregate precision/recall).
- `trials-summary.json` with reproducibility metadata (reviewer backend/model/provider, judge route/model, PR set, daydream git SHA, UTC timestamp, per-trial raw metrics, aggregate distribution).
- Up-front judge-cost estimate printed before a multi-trial run.
- `docs/benchmark.md`: "Repeated trials and variance reporting" section.
- Tests: `tests/test_benchmark_stats.py`, `tests/test_trial_isolation.py`, plus trials coverage in `tests/test_benchmark_orchestrator.py`, `tests/test_benchmark_cli.py`, and F1 cases in `tests/test_benchmark_score.py`.

### Changed

- `run_bench` split into `_run_sweep` (single-config workhorse) and `_run_trials` (N-trial loop + distribution report). `trials == 1` keeps the legacy single-shot path with no sidecar dirs.
- Aggregate score line now prints `f1` alongside precision/recall.

## Test Plan

- [x] `make check` (lint + typecheck + full pytest): 2055 passed, 5 skipped
- [x] `tests/test_benchmark_stats.py`: bootstrap CI determinism/bracketing/edge cases, distribution mean/median/stddev, single-trial zero stddev, empty-raises, table/serializer shape
- [x] `tests/test_trial_isolation.py`: path layout, canonical independence, fresh copy
- [x] `tests/test_benchmark_orchestrator.py`: trials=3 creates 3 isolated dirs with suffixed labels; canonical corpus byte-for-byte unchanged; summary JSON carries distribution + metadata; cost estimate + distribution table printed; trials=1 is back-compat (no sidecar dirs, base label)
- [x] `tests/test_benchmark_cli.py`: `--trials` parsing, default=1, non-positive rejection, config-file fallback, flag override, non-int/non-positive config rejection
- [x] `tests/test_benchmark_score.py`: F1 computation, perfect scores, zero-when-P+R=0

## Implementation note

This was built twice in parallel (Claude Code and OpenAI Codex) and independently judged; the Claude Code implementation is the base, with the richer summary fields, cost-estimate print, and bootstrap validation cherry-picked from the Codex implementation.

## Scope

Phase 1 of issue #249 (repeated trials + variance reporting). Phases 2 (paired/comparative CI across two configs) and 3 (regression-aware aggregation) are deferred to follow-up PRs.

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check`)
- [x] Type checking passes (`uv run mypy daydream`)
- [x] Documentation updated (`docs/benchmark.md`)
