### PR TITLE
feat(phases): add per-file-group budgeting to fix phase (#201)

### DIFF
--- a/daydream/__init__.py
+++ b/daydream/__init__.py
@@ -17,4 +17,4 @@ Submodules:
     ui: User interface utilities for terminal output.
 """
 
-__version__ = "0.20.0"
+__version__ = "0.22.0"

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -398,6 +398,7 @@ async def run_agent(
     read_only: bool = False,
     wall_budget_s: float | None = None,
     tool_call_budget: int | None = None,
+    on_metrics: Callable[[int], None] | None = None,
 ) -> tuple[str | Any, ContinuationToken | None, str | None]:
     """Run agent with the given prompt and return output plus continuation token.
 
@@ -435,6 +436,11 @@ async def run_agent(
         tool_call_budget: Opt-in ceiling on ToolStartEvents in this turn. When
             exceeded the loop breaks with the same abort/partial-return path.
             ``None`` (the default) means no tool-call ceiling.
+        on_metrics: Optional callback invoked once per ``MetricsEvent`` with
+            ``prompt_tokens + completion_tokens`` for that turn. Used by
+            ``phase_fix_parallel`` to feed the per-file-group token budget
+            (#201). Pure pass-through: no behavioral change when ``None``, and
+            it never aborts the turn (Approach B — between-calls check only).
 
     Returns:
         Tuple of (output, continuation_token, budget_reason). Output is text
@@ -582,6 +588,8 @@ async def run_agent(
                             elif isinstance(event, MetricsEvent):
                                 # EVNT-02 / MAP-06: recorder-only, no UI. Must precede the
                                 # CostEvent branch so isinstance order is correct.
+                                if on_metrics is not None:
+                                    on_metrics(event.prompt_tokens + event.completion_tokens)
                                 if inv is not None:
                                     inv.observe(event)
 

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -398,7 +398,6 @@ async def run_agent(
     read_only: bool = False,
     wall_budget_s: float | None = None,
     tool_call_budget: int | None = None,
-    on_metrics: Callable[[int], None] | None = None,
 ) -> tuple[str | Any, ContinuationToken | None, str | None]:
     """Run agent with the given prompt and return output plus continuation token.
 
@@ -436,11 +435,6 @@ async def run_agent(
         tool_call_budget: Opt-in ceiling on ToolStartEvents in this turn. When
             exceeded the loop breaks with the same abort/partial-return path.
             ``None`` (the default) means no tool-call ceiling.
-        on_metrics: Optional callback invoked once per ``MetricsEvent`` with
-            ``prompt_tokens + completion_tokens`` for that turn. Used by
-            ``phase_fix_parallel`` to feed the per-file-group token budget
-            (#201). Pure pass-through: no behavioral change when ``None``, and
-            it never aborts the turn (Approach B — between-calls check only).
 
     Returns:
         Tuple of (output, continuation_token, budget_reason). Output is text
@@ -588,8 +582,6 @@ async def run_agent(
                             elif isinstance(event, MetricsEvent):
                                 # EVNT-02 / MAP-06: recorder-only, no UI. Must precede the
                                 # CostEvent branch so isinstance order is correct.
-                                if on_metrics is not None:
-                                    on_metrics(event.prompt_tokens + event.completion_tokens)
                                 if inv is not None:
                                     inv.observe(event)
 

--- a/daydream/config.py
+++ b/daydream/config.py
@@ -45,9 +45,15 @@ DEFAULT_TOOL_CALL_BUDGET = 50
 # runaway file (the #186 pattern: 9 serial fix calls on one file) cannot
 # silently dominate a run. Enforced between calls in ``phase_fix_parallel``
 # (Approach B — no mid-call abort). Overridable via ``[tool.daydream]``.
+#
+# Values validated against 139–484 archived runs in ~/.daydream/archive/runs:
+#   600s: pi fix calls run p90=623s / max=1731s, so 600s caps the 1837s/5-call
+#   pi runaway to 2 fixes and the #186 9-call group to 2, while a legit slow
+#   single-call group still rides its own 1800s per-call wall budget.
+#   6 items: >6 findings on one file is 3.5% of files, and the dropped tail is
+#   the lowest-severity findings (the group is severity-sorted).
 DEFAULT_GROUP_MAX_WALL_S = 600.0  # 10 min of wall-clock across one file group
 DEFAULT_GROUP_MAX_SERIAL_ITEMS = 6  # max per-finding fix calls in one group
-DEFAULT_GROUP_MAX_CUMULATIVE_TOKENS = 200_000  # input + output tokens per group
 
 # Per-backend per-phase default model table. The phase resolver in
 # ``daydream.runner._resolve_backend`` looks up

--- a/daydream/config.py
+++ b/daydream/config.py
@@ -39,6 +39,16 @@ DEFAULT_EXPLORATION_MODEL = "claude-sonnet-4-6"
 DEFAULT_WALL_BUDGET_S = 1800.0
 DEFAULT_TOOL_CALL_BUDGET = 50
 
+# Per-file-group aggregate budget for the fix phase (issue #201). The
+# per-invocation guards above bound each individual run_agent turn; these bound
+# the *cumulative* cost of all fix turns targeting a single file group, so one
+# runaway file (the #186 pattern: 9 serial fix calls on one file) cannot
+# silently dominate a run. Enforced between calls in ``phase_fix_parallel``
+# (Approach B — no mid-call abort). Overridable via ``[tool.daydream]``.
+DEFAULT_GROUP_MAX_WALL_S = 600.0  # 10 min of wall-clock across one file group
+DEFAULT_GROUP_MAX_SERIAL_ITEMS = 6  # max per-finding fix calls in one group
+DEFAULT_GROUP_MAX_CUMULATIVE_TOKENS = 200_000  # input + output tokens per group
+
 # Per-backend per-phase default model table. The phase resolver in
 # ``daydream.runner._resolve_backend`` looks up
 # ``PHASE_DEFAULT_MODELS[backend_name][phase_name]`` when no explicit per-phase

--- a/daydream/config_file.py
+++ b/daydream/config_file.py
@@ -41,12 +41,17 @@ class DaydreamFileConfig:
         precision_mode: Opt-in precision suppression (issue #232). ``None`` falls
             through to the RunConfig field / orchestrator default; ``True`` runs
             the skeptical suppression pass over borderline findings.
-        group_max_wall_s: Per-file-group fix wall-clock ceiling (issue #201).
-            ``None`` falls through to ``config.DEFAULT_GROUP_MAX_WALL_S``.
-        group_max_serial_items: Per-file-group serial fix-call ceiling (#201).
-            ``None`` falls through to ``config.DEFAULT_GROUP_MAX_SERIAL_ITEMS``.
-        group_max_cumulative_tokens: Per-file-group token ceiling (#201). ``None``
-            falls through to ``config.DEFAULT_GROUP_MAX_CUMULATIVE_TOKENS``.
+        group_max_wall_s: Per-file-group fix wall-clock ceiling in seconds
+            (issue #201), a global ``[tool.daydream]`` key. Bounds the cumulative
+            wall-clock of all fix ``run_agent`` turns targeting one file group so
+            a runaway file cannot dominate a run. ``None`` (the default when the
+            key is absent or junk) falls through to
+            ``config.DEFAULT_GROUP_MAX_WALL_S`` (600.0).
+        group_max_serial_items: Per-file-group serial fix-call ceiling (#201), a
+            global ``[tool.daydream]`` key. Caps the number of per-finding fix
+            calls in one file group (the group is severity-sorted, so the dropped
+            tail is lowest-severity). ``None`` (the default when the key is absent
+            or junk) falls through to ``config.DEFAULT_GROUP_MAX_SERIAL_ITEMS`` (6).
     """
 
     model: str | None = None
@@ -57,7 +62,6 @@ class DaydreamFileConfig:
     precision_mode: bool | None = None
     group_max_wall_s: float | None = None
     group_max_serial_items: int | None = None
-    group_max_cumulative_tokens: int | None = None
 
     def phase_model(self, phase: str) -> str | None:
         """Return the configured model for a phase.
@@ -268,5 +272,4 @@ def load_file_config(root: Path) -> DaydreamFileConfig:
         precision_mode=precision,
         group_max_wall_s=_coerce_float(merged.get("group_max_wall_s")),
         group_max_serial_items=_coerce_int(merged.get("group_max_serial_items")),
-        group_max_cumulative_tokens=_coerce_int(merged.get("group_max_cumulative_tokens")),
     )

--- a/daydream/config_file.py
+++ b/daydream/config_file.py
@@ -41,6 +41,12 @@ class DaydreamFileConfig:
         precision_mode: Opt-in precision suppression (issue #232). ``None`` falls
             through to the RunConfig field / orchestrator default; ``True`` runs
             the skeptical suppression pass over borderline findings.
+        group_max_wall_s: Per-file-group fix wall-clock ceiling (issue #201).
+            ``None`` falls through to ``config.DEFAULT_GROUP_MAX_WALL_S``.
+        group_max_serial_items: Per-file-group serial fix-call ceiling (#201).
+            ``None`` falls through to ``config.DEFAULT_GROUP_MAX_SERIAL_ITEMS``.
+        group_max_cumulative_tokens: Per-file-group token ceiling (#201). ``None``
+            falls through to ``config.DEFAULT_GROUP_MAX_CUMULATIVE_TOKENS``.
     """
 
     model: str | None = None
@@ -49,6 +55,9 @@ class DaydreamFileConfig:
     bench: dict[str, Any] = field(default_factory=dict)
     shallow_fanout_threshold: int | None = None
     precision_mode: bool | None = None
+    group_max_wall_s: float | None = None
+    group_max_serial_items: int | None = None
+    group_max_cumulative_tokens: int | None = None
 
     def phase_model(self, phase: str) -> str | None:
         """Return the configured model for a phase.
@@ -181,6 +190,26 @@ def _coerce_phases(raw: Any) -> dict[str, dict[str, str]]:
     return result
 
 
+def _coerce_int(raw: Any) -> int | None:
+    """Return ``raw`` as an int, or None for bool/non-int (degrade to default)."""
+    if isinstance(raw, bool):
+        return None
+    return raw if isinstance(raw, int) else None
+
+
+def _coerce_float(raw: Any) -> float | None:
+    """Return ``raw`` as a float, or None for bool/non-number (degrade to default).
+
+    Accepts TOML ints and floats (an int budget like ``group_max_wall_s = 600``
+    round-trips to ``600.0``); rejects bool and everything else.
+    """
+    if isinstance(raw, bool):
+        return None
+    if isinstance(raw, (int, float)):
+        return float(raw)
+    return None
+
+
 def load_file_config(root: Path) -> DaydreamFileConfig:
     """Load and merge daydream file configuration from a repo root.
 
@@ -227,6 +256,9 @@ def load_file_config(root: Path) -> DaydreamFileConfig:
     # so an accidental ``precision_mode = 1`` is treated as unset, not enabled.
     raw_precision = merged.get("precision_mode")
     precision: bool | None = raw_precision if isinstance(raw_precision, bool) else None
+    # Per-file-group fix budgets (#201): tolerate junk by degrading to None (the
+    # config.py default then applies). bool is excluded even though it subclasses
+    # int/float — ``group_max_serial_items = true`` is never a meaningful count.
     return DaydreamFileConfig(
         model=str(model) if model is not None else None,
         backend=str(backend) if backend is not None else None,
@@ -234,4 +266,7 @@ def load_file_config(root: Path) -> DaydreamFileConfig:
         bench=dict(merged["bench"]) if isinstance(merged.get("bench"), dict) else {},
         shallow_fanout_threshold=threshold,
         precision_mode=precision,
+        group_max_wall_s=_coerce_float(merged.get("group_max_wall_s")),
+        group_max_serial_items=_coerce_int(merged.get("group_max_serial_items")),
+        group_max_cumulative_tokens=_coerce_int(merged.get("group_max_cumulative_tokens")),
     )

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -1320,14 +1320,28 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
         work.repo, pre_fix_snapshot, pre_fix_head, daydream_dir / "recommended.patch"
     )
     fix_failures_p = fix_failures_path(dd)
-    if fix_failures:
+    # Partition failures: budget-exceeded groups have their already-applied fixes
+    # intact (only remaining findings were skipped) and must NOT be reverted.
+    # Exception-failed groups may hold broken partial edits and must be reverted.
+    _BUDGET_PREFIX = "file_group_budget_exceeded:"
+    exception_failures = {k: v for k, v in fix_failures.items() if not v.startswith(_BUDGET_PREFIX)}
+    budget_skips = {k: v for k, v in fix_failures.items() if v.startswith(_BUDGET_PREFIX)}
+
+    all_non_success = {**exception_failures, **budget_skips}
+    if all_non_success:
         # Persist so the archive marks the run "partial" instead of
-        # "complete" -- the tree is no longer a clean success.
-        fix_failures_p.write_text(json.dumps(fix_failures, indent=2, sort_keys=True))
+        # "complete" -- the tree holds skipped or reverted groups.
+        fix_failures_p.write_text(json.dumps(all_non_success, indent=2, sort_keys=True))
+    elif fix_failures_p.exists():
+        fix_failures_p.unlink()
+
+    if exception_failures:
+        # Only revert and abort for exception-failed groups; budget-exceeded
+        # groups' applied fixes are preserved and the run continues.
         _protect_tree_after_fix_failures(
             work,
             target_dir,
-            fix_failures,
+            exception_failures,
             snapshot=pre_fix_snapshot,
             pre_untracked=pre_fix_untracked,
         )
@@ -1347,13 +1361,13 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
             leftover_p.unlink()
         print_warning(
             console,
-            f"{len(fix_failures)} fix group(s) failed: {sorted(fix_failures)}; "
+            f"{len(exception_failures)} fix group(s) failed: {sorted(exception_failures)}; "
             "partial edits reverted (patches saved under .daydream/partial-fixes/).",
         )
         return Stop(1)
-    # Fresh successful fix supersedes any stale failures record.
-    if fix_failures_p.exists():
-        fix_failures_p.unlink()
+
+    # No exception failures: budget-skipped groups (if any) already warned via
+    # _record_budget_stop; proceed to test/commit with the applied fixes intact.
     stale_leftover_p = fix_leftover_untracked_path(dd)
     if stale_leftover_p.exists():
         stale_leftover_p.unlink()

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -26,7 +26,6 @@ from rich.markup import escape as escape_markup
 
 from daydream.agent import console, get_assume, get_non_interactive, resolve_or_prompt
 from daydream.config import (
-    DEFAULT_GROUP_MAX_CUMULATIVE_TOKENS,
     DEFAULT_GROUP_MAX_SERIAL_ITEMS,
     DEFAULT_GROUP_MAX_WALL_S,
     REVIEW_OUTPUT_FILE,
@@ -263,24 +262,6 @@ def _resolve_group_max_serial_items(config: RunConfig) -> int:
     if file_config is not None and file_config.group_max_serial_items is not None:
         return file_config.group_max_serial_items
     return DEFAULT_GROUP_MAX_SERIAL_ITEMS
-
-
-def _resolve_group_max_cumulative_tokens(config: RunConfig) -> int:
-    """Resolve the per-file-group cumulative token ceiling (issue #201).
-
-    Precedence (highest first), mirroring ``_shallow_fanout_threshold`` above
-    and ``_resolve_backend`` / ``_resolved_model`` at ``runner.py:295-326``:
-
-      1. ``DaydreamFileConfig.group_max_cumulative_tokens`` (file-config scalar).
-      2. ``DEFAULT_GROUP_MAX_CUMULATIVE_TOKENS`` (built-in default).
-
-    Uses ``is not None`` rather than truthiness so a configured value of
-    ``0`` is honored rather than falling through to the default.
-    """
-    file_config = config.file_config
-    if file_config is not None and file_config.group_max_cumulative_tokens is not None:
-        return file_config.group_max_cumulative_tokens
-    return DEFAULT_GROUP_MAX_CUMULATIVE_TOKENS
 
 
 def _collapse_stacks_for_tiny_diff(
@@ -1322,7 +1303,6 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
     # the config.py default. A runaway file group cannot silently dominate a run.
     group_wall_s = _resolve_group_max_wall_s(config)
     group_serial = _resolve_group_max_serial_items(config)
-    group_tokens = _resolve_group_max_cumulative_tokens(config)
     async with phase_scope(DaydreamPhase.FIX):
         fix_failures = await phase_fix_parallel(
             ctx.backend_for("fix"),
@@ -1331,7 +1311,6 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
             intent_path=intent_p if (intent_grounded_this_run and intent_p.exists()) else None,
             group_max_wall_s=group_wall_s,
             group_max_serial_items=group_serial,
-            group_max_cumulative_tokens=group_tokens,
         )
     # Capture daydream's proposed diff (pre-fix tree → post-fix worktree)
     # NOW, before the fix-failure and test-failure early returns below, so

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -25,7 +25,13 @@ from typing import TYPE_CHECKING, Any
 from rich.markup import escape as escape_markup
 
 from daydream.agent import console, get_assume, get_non_interactive, resolve_or_prompt
-from daydream.config import REVIEW_OUTPUT_FILE, STRUCTURE_STACK_NAME
+from daydream.config import (
+    DEFAULT_GROUP_MAX_CUMULATIVE_TOKENS,
+    DEFAULT_GROUP_MAX_SERIAL_ITEMS,
+    DEFAULT_GROUP_MAX_WALL_S,
+    REVIEW_OUTPUT_FILE,
+    STRUCTURE_STACK_NAME,
+)
 from daydream.deep.arbiter import select_arbiter_targets, select_suppression_targets
 from daydream.deep.artifacts import (
     adjudication_complete_path,
@@ -1258,12 +1264,27 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
             pre_fix_head = None
     else:
         pre_fix_head = None
+    # Resolve per-file-group fix budgets (#201): file-config override wins, else
+    # the config.py default. A runaway file group cannot silently dominate a run.
+    fc = config.file_config
+    group_wall_s = fc.group_max_wall_s if fc and fc.group_max_wall_s is not None else DEFAULT_GROUP_MAX_WALL_S
+    group_serial = (
+        fc.group_max_serial_items if fc and fc.group_max_serial_items is not None
+        else DEFAULT_GROUP_MAX_SERIAL_ITEMS
+    )
+    group_tokens = (
+        fc.group_max_cumulative_tokens if fc and fc.group_max_cumulative_tokens is not None
+        else DEFAULT_GROUP_MAX_CUMULATIVE_TOKENS
+    )
     async with phase_scope(DaydreamPhase.FIX):
         fix_failures = await phase_fix_parallel(
             ctx.backend_for("fix"),
             work,
             items,
             intent_path=intent_p if (intent_grounded_this_run and intent_p.exists()) else None,
+            group_max_wall_s=group_wall_s,
+            group_max_serial_items=group_serial,
+            group_max_cumulative_tokens=group_tokens,
         )
     # Capture daydream's proposed diff (pre-fix tree → post-fix worktree)
     # NOW, before the fix-failure and test-failure early returns below, so

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -229,6 +229,60 @@ def _precision_mode(config: RunConfig) -> bool:
     return False
 
 
+def _resolve_group_max_wall_s(config: RunConfig) -> float:
+    """Resolve the per-file-group fix wall-clock ceiling (issue #201).
+
+    Precedence (highest first), mirroring ``_shallow_fanout_threshold`` above
+    and ``_resolve_backend`` / ``_resolved_model`` at ``runner.py:295-326``:
+
+      1. ``DaydreamFileConfig.group_max_wall_s`` (file-config scalar).
+      2. ``DEFAULT_GROUP_MAX_WALL_S`` (built-in default).
+
+    Uses ``is not None`` rather than truthiness so a configured value of
+    ``0.0`` is honored rather than falling through to the default.
+    """
+    file_config = config.file_config
+    if file_config is not None and file_config.group_max_wall_s is not None:
+        return file_config.group_max_wall_s
+    return DEFAULT_GROUP_MAX_WALL_S
+
+
+def _resolve_group_max_serial_items(config: RunConfig) -> int:
+    """Resolve the per-file-group serial fix-call ceiling (issue #201).
+
+    Precedence (highest first), mirroring ``_shallow_fanout_threshold`` above
+    and ``_resolve_backend`` / ``_resolved_model`` at ``runner.py:295-326``:
+
+      1. ``DaydreamFileConfig.group_max_serial_items`` (file-config scalar).
+      2. ``DEFAULT_GROUP_MAX_SERIAL_ITEMS`` (built-in default).
+
+    Uses ``is not None`` rather than truthiness so a configured value of
+    ``0`` is honored rather than falling through to the default.
+    """
+    file_config = config.file_config
+    if file_config is not None and file_config.group_max_serial_items is not None:
+        return file_config.group_max_serial_items
+    return DEFAULT_GROUP_MAX_SERIAL_ITEMS
+
+
+def _resolve_group_max_cumulative_tokens(config: RunConfig) -> int:
+    """Resolve the per-file-group cumulative token ceiling (issue #201).
+
+    Precedence (highest first), mirroring ``_shallow_fanout_threshold`` above
+    and ``_resolve_backend`` / ``_resolved_model`` at ``runner.py:295-326``:
+
+      1. ``DaydreamFileConfig.group_max_cumulative_tokens`` (file-config scalar).
+      2. ``DEFAULT_GROUP_MAX_CUMULATIVE_TOKENS`` (built-in default).
+
+    Uses ``is not None`` rather than truthiness so a configured value of
+    ``0`` is honored rather than falling through to the default.
+    """
+    file_config = config.file_config
+    if file_config is not None and file_config.group_max_cumulative_tokens is not None:
+        return file_config.group_max_cumulative_tokens
+    return DEFAULT_GROUP_MAX_CUMULATIVE_TOKENS
+
+
 def _collapse_stacks_for_tiny_diff(
     stacks: list[StackAssignment],
     changed_files: list[str],
@@ -1266,16 +1320,9 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
         pre_fix_head = None
     # Resolve per-file-group fix budgets (#201): file-config override wins, else
     # the config.py default. A runaway file group cannot silently dominate a run.
-    fc = config.file_config
-    group_wall_s = fc.group_max_wall_s if fc and fc.group_max_wall_s is not None else DEFAULT_GROUP_MAX_WALL_S
-    group_serial = (
-        fc.group_max_serial_items if fc and fc.group_max_serial_items is not None
-        else DEFAULT_GROUP_MAX_SERIAL_ITEMS
-    )
-    group_tokens = (
-        fc.group_max_cumulative_tokens if fc and fc.group_max_cumulative_tokens is not None
-        else DEFAULT_GROUP_MAX_CUMULATIVE_TOKENS
-    )
+    group_wall_s = _resolve_group_max_wall_s(config)
+    group_serial = _resolve_group_max_serial_items(config)
+    group_tokens = _resolve_group_max_cumulative_tokens(config)
     async with phase_scope(DaydreamPhase.FIX):
         fix_failures = await phase_fix_parallel(
             ctx.backend_for("fix"),

--- a/daydream/file_group_budget.py
+++ b/daydream/file_group_budget.py
@@ -1,0 +1,63 @@
+"""Aggregate guard over all fix calls for one file group (#201)."""
+
+import time
+from dataclasses import dataclass, field
+
+
+@dataclass
+class FileGroupBudget:
+    """Aggregate guard over all fix ``run_agent`` calls for one file group (#201).
+
+    The per-invocation guards (``FIX_MAX_TURNS``, ``DEFAULT_TOOL_CALL_BUDGET``,
+    ``DEFAULT_WALL_BUDGET_S``) bound each individual turn. This bounds their
+    *sum* within a single file group so one file with many findings cannot
+    silently dominate a review-fix-test run (root cause of the 62-min pi/GLM run
+    in #186). Enforced between calls in ``phase_fix_parallel`` (Approach B —
+    :meth:`check` is a pure read consulted before each fix call; there is no
+    mid-call abort).
+
+    Wall-clock starts at construction (``time.monotonic``). Token accounting is
+    fed by the ``on_metrics`` callback wired through ``run_agent`` (accumulates
+    ``prompt_tokens + completion_tokens`` per ``MetricsEvent``). The serial-item
+    counter is bumped once per completed fix call via :meth:`record_item`.
+
+    Attributes:
+        max_wall_seconds: Total wall-clock ceiling for the group.
+        max_serial_items: Max number of per-finding fix calls in the group.
+        max_cumulative_tokens: Ceiling on input + output tokens across the group.
+    """
+
+    max_wall_seconds: float
+    max_serial_items: int
+    max_cumulative_tokens: int
+    _wall_start: float = field(default_factory=time.monotonic)
+    _items_processed: int = 0
+    _cumulative_tokens: int = 0
+
+    def check(self) -> str | None:
+        """Return a budget-reason string if any ceiling is reached, else None.
+
+        Pure read (no side effects): safe to call before every fix call. The
+        checks are ordered items → wall → tokens so the reason is deterministic
+        when more than one ceiling is simultaneously breached.
+        """
+        if self._items_processed >= self.max_serial_items:
+            return "group_serial_item_limit"
+        if time.monotonic() - self._wall_start >= self.max_wall_seconds:
+            return "group_wall_budget_exceeded"
+        if self._cumulative_tokens >= self.max_cumulative_tokens:
+            return "group_token_budget_exceeded"
+        return None
+
+    def add_tokens(self, tokens: int) -> None:
+        """Accumulate per-turn tokens. Wired as ``run_agent``'s ``on_metrics``."""
+        self._cumulative_tokens += tokens
+
+    def record_item(self) -> None:
+        """Mark one completed fix call. Bumps the serial-item counter."""
+        self._items_processed += 1
+
+    @property
+    def items_processed(self) -> int:
+        """Number of fix calls completed in this group so far."""
+        return self._items_processed

--- a/daydream/file_group_budget.py
+++ b/daydream/file_group_budget.py
@@ -16,42 +16,35 @@ class FileGroupBudget:
     :meth:`check` is a pure read consulted before each fix call; there is no
     mid-call abort).
 
-    Wall-clock starts at construction (``time.monotonic``). Token accounting is
-    fed by the ``on_metrics`` callback wired through ``run_agent`` (accumulates
-    ``prompt_tokens + completion_tokens`` per ``MetricsEvent``). The serial-item
-    counter is bumped once per completed fix call via :meth:`record_item`.
+    Two axes bound the group: cumulative wall-clock (starts at construction via
+    ``time.monotonic``) and the serial-item count (bumped once per completed fix
+    call via :meth:`record_item`). Output tokens are deliberately not an axis —
+    they are collinear with wall-time and call-count on the only population this
+    between-calls guard can reach, so they add no independent signal (see the
+    calibration in ``.beagle/concepts/file-group-budget/``).
 
     Attributes:
         max_wall_seconds: Total wall-clock ceiling for the group.
         max_serial_items: Max number of per-finding fix calls in the group.
-        max_cumulative_tokens: Ceiling on input + output tokens across the group.
     """
 
     max_wall_seconds: float
     max_serial_items: int
-    max_cumulative_tokens: int
-    _wall_start: float = field(default_factory=time.monotonic)
-    _items_processed: int = 0
-    _cumulative_tokens: int = 0
+    _wall_start: float = field(init=False, default_factory=time.monotonic)
+    _items_processed: int = field(init=False, default=0)
 
     def check(self) -> str | None:
         """Return a budget-reason string if any ceiling is reached, else None.
 
         Pure read (no side effects): safe to call before every fix call. The
-        checks are ordered items → wall → tokens so the reason is deterministic
-        when more than one ceiling is simultaneously breached.
+        checks are ordered items → wall so the reason is deterministic when both
+        ceilings are simultaneously breached.
         """
         if self._items_processed >= self.max_serial_items:
             return "group_serial_item_limit"
         if time.monotonic() - self._wall_start >= self.max_wall_seconds:
             return "group_wall_budget_exceeded"
-        if self._cumulative_tokens >= self.max_cumulative_tokens:
-            return "group_token_budget_exceeded"
         return None
-
-    def add_tokens(self, tokens: int) -> None:
-        """Accumulate per-turn tokens. Wired as ``run_agent``'s ``on_metrics``."""
-        self._cumulative_tokens += tokens
 
     def record_item(self) -> None:
         """Mark one completed fix call. Bumps the serial-item counter."""

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -4,6 +4,9 @@ import copy
 import json
 import logging
 import re
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -39,7 +42,14 @@ from daydream.workspace import WorkContext
 
 if TYPE_CHECKING:
     from daydream.deep.detection import StackAssignment
-from daydream.config import DEFAULT_TOOL_CALL_BUDGET, DEFAULT_WALL_BUDGET_S, REVIEW_OUTPUT_FILE
+from daydream.config import (
+    DEFAULT_GROUP_MAX_CUMULATIVE_TOKENS,
+    DEFAULT_GROUP_MAX_SERIAL_ITEMS,
+    DEFAULT_GROUP_MAX_WALL_S,
+    DEFAULT_TOOL_CALL_BUDGET,
+    DEFAULT_WALL_BUDGET_S,
+    REVIEW_OUTPUT_FILE,
+)
 from daydream.ui import (
     phase_subtitle,
     print_dim,
@@ -63,6 +73,65 @@ TEST_OUTPUT_TAIL_LINES = 100
 
 # Generous for a real fix yet bounds a flailing agent that's globbing $HOME after a missed Read.
 FIX_MAX_TURNS = 40
+
+
+@dataclass
+class FileGroupBudget:
+    """Aggregate guard over all fix ``run_agent`` calls for one file group (#201).
+
+    The per-invocation guards (``FIX_MAX_TURNS``, ``DEFAULT_TOOL_CALL_BUDGET``,
+    ``DEFAULT_WALL_BUDGET_S``) bound each individual turn. This bounds their
+    *sum* within a single file group so one file with many findings cannot
+    silently dominate a review-fix-test run (root cause of the 62-min pi/GLM run
+    in #186). Enforced between calls in ``phase_fix_parallel`` (Approach B —
+    :meth:`check` is a pure read consulted before each fix call; there is no
+    mid-call abort).
+
+    Wall-clock starts at construction (``time.monotonic``). Token accounting is
+    fed by the ``on_metrics`` callback wired through ``run_agent`` (accumulates
+    ``prompt_tokens + completion_tokens`` per ``MetricsEvent``). The serial-item
+    counter is bumped once per completed fix call via :meth:`record_item`.
+
+    Attributes:
+        max_wall_seconds: Total wall-clock ceiling for the group.
+        max_serial_items: Max number of per-finding fix calls in the group.
+        max_cumulative_tokens: Ceiling on input + output tokens across the group.
+    """
+
+    max_wall_seconds: float
+    max_serial_items: int
+    max_cumulative_tokens: int
+    _wall_start: float = field(default_factory=time.monotonic)
+    _items_processed: int = 0
+    _cumulative_tokens: int = 0
+
+    def check(self) -> str | None:
+        """Return a budget-reason string if any ceiling is reached, else None.
+
+        Pure read (no side effects): safe to call before every fix call. The
+        checks are ordered items → wall → tokens so the reason is deterministic
+        when more than one ceiling is simultaneously breached.
+        """
+        if self._items_processed >= self.max_serial_items:
+            return "group_serial_item_limit"
+        if time.monotonic() - self._wall_start >= self.max_wall_seconds:
+            return "group_wall_budget_exceeded"
+        if self._cumulative_tokens >= self.max_cumulative_tokens:
+            return "group_token_budget_exceeded"
+        return None
+
+    def add_tokens(self, tokens: int) -> None:
+        """Accumulate per-turn tokens. Wired as ``run_agent``'s ``on_metrics``."""
+        self._cumulative_tokens += tokens
+
+    def record_item(self) -> None:
+        """Mark one completed fix call. Bumps the serial-item counter."""
+        self._items_processed += 1
+
+    @property
+    def items_processed(self) -> int:
+        """Number of fix calls completed in this group so far."""
+        return self._items_processed
 # Verify re-reads the fixed files and runs checks; same generous bound as fix.
 VERIFY_MAX_TURNS = 40
 _PR_BODY_MAX_CHARS = 8000
@@ -1777,6 +1846,7 @@ async def phase_fix(
     *,
     console_lock: anyio.Lock | None = None,
     intent_path: Path | None = None,
+    on_metrics: Callable[[int], None] | None = None,
 ) -> None:
     """Phase 3: Apply a single fix for one feedback item.
 
@@ -1794,6 +1864,9 @@ async def phase_fix(
             with a rule forbidding fixes that undo a deliberate decision. The
             read is best-effort enrichment: a missing or unreadable file is
             skipped silently so an intent-read failure can never block the fix.
+        on_metrics: Optional per-turn token callback forwarded to ``run_agent``
+            so a caller (``phase_fix_parallel``) can feed its per-file-group
+            token budget (#201).
 
     Returns:
         None
@@ -1840,6 +1913,7 @@ Make the minimal change needed. {_FIX_GUARDRAILS}"""
             tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
             wall_budget_s=DEFAULT_WALL_BUDGET_S,
             progress_callback=_cb,
+            on_metrics=on_metrics,
         )
     else:
         await run_agent(
@@ -1847,6 +1921,7 @@ Make the minimal change needed. {_FIX_GUARDRAILS}"""
             phase=DaydreamPhase.FIX, max_turns=FIX_MAX_TURNS,
             tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
             wall_budget_s=DEFAULT_WALL_BUDGET_S,
+            on_metrics=on_metrics,
         )
     async with (console_lock if console_lock is not None else anyio.Lock()):
         print_fix_complete(console, item_num, total)
@@ -1861,6 +1936,7 @@ async def phase_fix_batched(
     *,
     console_lock: anyio.Lock | None = None,
     intent_path: Path | None = None,
+    on_metrics: Callable[[int], None] | None = None,
 ) -> None:
     """Phase 3 (batched): Apply all findings for ONE file in a single fix turn.
 
@@ -1881,6 +1957,9 @@ async def phase_fix_batched(
             ``None`` for serial callers.
         intent_path: Optional path to the confirmed author-intent file, injected
             verbatim (same best-effort handling as ``phase_fix``).
+        on_metrics: Optional per-turn token callback forwarded to ``run_agent``
+            so the caller's per-file-group token budget accumulates the batched
+            turn's tokens (#201).
 
     Returns:
         None
@@ -1889,6 +1968,7 @@ async def phase_fix_batched(
         await phase_fix(
             backend, work, items[0], item_nums[0], total,
             console_lock=console_lock, intent_path=intent_path,
+            on_metrics=on_metrics,
         )
         return
 
@@ -1900,6 +1980,7 @@ async def phase_fix_batched(
             await phase_fix(
                 backend, work, item, item_num, total,
                 console_lock=console_lock, intent_path=intent_path,
+                on_metrics=on_metrics,
             )
         return
 
@@ -1951,6 +2032,7 @@ Make the minimal changes needed to address ALL of the above findings in one cohe
             tool_call_budget=scaled_tool_budget,
             wall_budget_s=scaled_wall_budget,
             progress_callback=_cb,
+            on_metrics=on_metrics,
         )
     else:
         _, _, budget_reason = await run_agent(
@@ -1958,6 +2040,7 @@ Make the minimal changes needed to address ALL of the above findings in one cohe
             phase=DaydreamPhase.FIX, max_turns=scaled_max_turns,
             tool_call_budget=scaled_tool_budget,
             wall_budget_s=scaled_wall_budget,
+            on_metrics=on_metrics,
         )
 
     if budget_reason is not None:
@@ -1977,6 +2060,9 @@ async def phase_fix_parallel(
     *,
     limiter_size: int = 4,
     intent_path: Path | None = None,
+    group_max_wall_s: float = DEFAULT_GROUP_MAX_WALL_S,
+    group_max_serial_items: int = DEFAULT_GROUP_MAX_SERIAL_ITEMS,
+    group_max_cumulative_tokens: int = DEFAULT_GROUP_MAX_CUMULATIVE_TOKENS,
 ) -> dict[str, str]:
     """Phase 3 (parallel): Apply fixes file-partitioned and concurrently.
 
@@ -1989,6 +2075,14 @@ async def phase_fix_parallel(
     it does not guarantee disjoint edits if an agent touches files other than the
     one named in the item's ``file`` key. Commit stays serial and after.
 
+    Each file group is bounded by a :class:`FileGroupBudget` (#201): the budget
+    is consulted before every fix call, and if a group's cumulative wall-clock,
+    serial-item count, or token total is reached, the remaining findings in that
+    group are skipped (recorded in ``failures`` and a ``file_group_budget_exceeded``
+    trajectory event), so one runaway file cannot silently dominate the run. The
+    per-invocation guards inside each fix call are unchanged; this is an aggregate
+    guard layered on top (Approach B — between-calls check, no mid-call abort).
+
     Args:
         backend: The Backend to execute against (shared across tasks).
         work: Workspace context for the fixes; ``work.repo`` is the agent cwd.
@@ -1996,11 +2090,15 @@ async def phase_fix_parallel(
         limiter_size: Max number of file-groups to fix concurrently.
         intent_path: Optional confirmed-intent file forwarded unchanged to each
             fix call so every fix carries the deliberate-intent guard.
+        group_max_wall_s: Per-file-group wall-clock ceiling (#201).
+        group_max_serial_items: Per-file-group serial fix-call ceiling (#201).
+        group_max_cumulative_tokens: Per-file-group token ceiling (#201).
 
     Returns:
         ``failures``: file -> "<ExceptionType>: <message>" for file-groups whose
-        fix raised. Empty dict on full success. Callers MUST surface this to the
-        user so that uncommitted failures are visible instead of silently dropped.
+        fix raised, or "file_group_budget_exceeded: <reason>" for groups stopped
+        by their budget. Empty dict on full success. Callers MUST surface this to
+        the user so that uncommitted failures are visible instead of silently dropped.
 
     """
     raw_groups = group_items_by_file(items)
@@ -2023,6 +2121,54 @@ async def phase_fix_parallel(
     _console_lock = anyio.Lock()
     total = len(items)
 
+    async def _record_budget_stop(
+        fkey: str,
+        reason: str,
+        grp_len: int,
+        budget: FileGroupBudget,
+    ) -> None:
+        """Record a group budget stop: trajectory event, failures entry, warning."""
+        processed = budget.items_processed
+        skipped = grp_len - processed
+        if recorder is not None:
+            recorder.emit_file_group_budget_exceeded(
+                file=fkey, reason=reason,
+                items_processed=processed, items_skipped=skipped,
+            )
+        async with _failures_lock:
+            failures[fkey] = f"file_group_budget_exceeded: {reason}"
+        async with _console_lock:
+            print_warning(
+                console,
+                f"File group '{fkey}' budget exceeded ({reason}) after {processed} "
+                f"item(s); skipping remaining {skipped}.",
+            )
+
+    async def _fix_group_serially(
+        fkey: str,
+        grp: list[tuple[dict[str, Any], int]],
+        budget: FileGroupBudget,
+    ) -> None:
+        """Fix a group's findings one at a time, honoring the group budget.
+
+        Checks ``budget.check()`` before each ``phase_fix`` call; on a budget
+        stop, records it and returns without processing the remainder. Token
+        accumulation is fed live via ``on_metrics``; the serial-item counter is
+        bumped once per completed call.
+        """
+        for item, item_num in grp:
+            budget_reason = budget.check()
+            if budget_reason is not None:
+                await _record_budget_stop(fkey, budget_reason, len(grp), budget)
+                return
+            await phase_fix(
+                backend, work, item, item_num, total,
+                console_lock=_console_lock,
+                intent_path=intent_path,
+                on_metrics=budget.add_tokens,
+            )
+            budget.record_item()
+
     async with anyio.create_task_group() as tg:
         for file_key, numbered_items in groups_numbered:
             # Default-arg capture -- prevents late-binding closure bug (Pitfall 2).
@@ -2033,6 +2179,11 @@ async def phase_fix_parallel(
                 _fkey_slug = fkey.replace("/", "-").replace("\\", "-")
                 async with limiter:
                     async with maybe_fork(recorder, f"fix-{_fkey_slug}"):
+                        budget = FileGroupBudget(
+                            max_wall_seconds=group_max_wall_s,
+                            max_serial_items=group_max_serial_items,
+                            max_cumulative_tokens=group_max_cumulative_tokens,
+                        )
                         try:
                             grp_items = [item for item, _ in grp]
                             grp_nums = [num for _, num in grp]
@@ -2041,19 +2192,24 @@ async def phase_fix_parallel(
                                 # Single-item or <no-file> groups: go straight to
                                 # per-finding phase_fix (no batched prompt to build,
                                 # no fallback retry on failure).
-                                for item, item_num in grp:
-                                    await phase_fix(
-                                        backend, work, item, item_num, total,
-                                        console_lock=_console_lock,
-                                        intent_path=intent_path,
-                                    )
+                                await _fix_group_serially(fkey, grp, budget)
                             else:
+                                # A fresh group has spent no wall/tokens/items yet, so
+                                # this check is a no-op on the first batched attempt; it
+                                # keeps the enforcement point uniform with the per-finding
+                                # paths and guards a re-entrant future caller.
+                                budget_reason = budget.check()
+                                if budget_reason is not None:
+                                    await _record_budget_stop(fkey, budget_reason, len(grp), budget)
+                                    return
                                 try:
                                     await phase_fix_batched(
                                         backend, work, grp_items, grp_nums, total,
                                         console_lock=_console_lock,
                                         intent_path=intent_path,
+                                        on_metrics=budget.add_tokens,
                                     )
+                                    budget.record_item()
                                 except Exception:  # noqa: BLE001 -- batched failure falls back to per-finding fixes
                                     # Restore the file to HEAD before falling back so
                                     # per-finding fixes don't re-apply partial edits
@@ -2066,12 +2222,7 @@ async def phase_fix_parallel(
                                                 console,
                                                 f"Could not restore {fkey} before fallback: {_restore_err}",
                                             )
-                                    for item, item_num in grp:
-                                        await phase_fix(
-                                            backend, work, item, item_num, total,
-                                            console_lock=_console_lock,
-                                            intent_path=intent_path,
-                                        )
+                                    await _fix_group_serially(fkey, grp, budget)
                         except Exception as e:  # noqa: BLE001 -- intentionally broad for parallel isolation
                             reason = f"{type(e).__name__}: {e}"
                             async with _failures_lock:

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -4,9 +4,7 @@ import copy
 import json
 import logging
 import re
-import time
 from collections.abc import Callable
-from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -31,6 +29,7 @@ from daydream.backends import Backend, ContinuationToken
 from daydream.backends.claude import READ_ONLY_BASH_ALLOWLIST
 from daydream.clipboard import clipboard_available, copy_to_clipboard
 from daydream.extensions import get_registry
+from daydream.file_group_budget import FileGroupBudget
 from daydream.git_ops import BranchNotFoundError, GitError
 from daydream.trajectory import (
     DaydreamPhase,
@@ -75,63 +74,6 @@ TEST_OUTPUT_TAIL_LINES = 100
 FIX_MAX_TURNS = 40
 
 
-@dataclass
-class FileGroupBudget:
-    """Aggregate guard over all fix ``run_agent`` calls for one file group (#201).
-
-    The per-invocation guards (``FIX_MAX_TURNS``, ``DEFAULT_TOOL_CALL_BUDGET``,
-    ``DEFAULT_WALL_BUDGET_S``) bound each individual turn. This bounds their
-    *sum* within a single file group so one file with many findings cannot
-    silently dominate a review-fix-test run (root cause of the 62-min pi/GLM run
-    in #186). Enforced between calls in ``phase_fix_parallel`` (Approach B —
-    :meth:`check` is a pure read consulted before each fix call; there is no
-    mid-call abort).
-
-    Wall-clock starts at construction (``time.monotonic``). Token accounting is
-    fed by the ``on_metrics`` callback wired through ``run_agent`` (accumulates
-    ``prompt_tokens + completion_tokens`` per ``MetricsEvent``). The serial-item
-    counter is bumped once per completed fix call via :meth:`record_item`.
-
-    Attributes:
-        max_wall_seconds: Total wall-clock ceiling for the group.
-        max_serial_items: Max number of per-finding fix calls in the group.
-        max_cumulative_tokens: Ceiling on input + output tokens across the group.
-    """
-
-    max_wall_seconds: float
-    max_serial_items: int
-    max_cumulative_tokens: int
-    _wall_start: float = field(default_factory=time.monotonic)
-    _items_processed: int = 0
-    _cumulative_tokens: int = 0
-
-    def check(self) -> str | None:
-        """Return a budget-reason string if any ceiling is reached, else None.
-
-        Pure read (no side effects): safe to call before every fix call. The
-        checks are ordered items → wall → tokens so the reason is deterministic
-        when more than one ceiling is simultaneously breached.
-        """
-        if self._items_processed >= self.max_serial_items:
-            return "group_serial_item_limit"
-        if time.monotonic() - self._wall_start >= self.max_wall_seconds:
-            return "group_wall_budget_exceeded"
-        if self._cumulative_tokens >= self.max_cumulative_tokens:
-            return "group_token_budget_exceeded"
-        return None
-
-    def add_tokens(self, tokens: int) -> None:
-        """Accumulate per-turn tokens. Wired as ``run_agent``'s ``on_metrics``."""
-        self._cumulative_tokens += tokens
-
-    def record_item(self) -> None:
-        """Mark one completed fix call. Bumps the serial-item counter."""
-        self._items_processed += 1
-
-    @property
-    def items_processed(self) -> int:
-        """Number of fix calls completed in this group so far."""
-        return self._items_processed
 # Verify re-reads the fixed files and runs checks; same generous bound as fix.
 VERIFY_MAX_TURNS = 40
 _PR_BODY_MAX_CHARS = 8000
@@ -2194,14 +2136,6 @@ async def phase_fix_parallel(
                                 # no fallback retry on failure).
                                 await _fix_group_serially(fkey, grp, budget)
                             else:
-                                # A fresh group has spent no wall/tokens/items yet, so
-                                # this check is a no-op on the first batched attempt; it
-                                # keeps the enforcement point uniform with the per-finding
-                                # paths and guards a re-entrant future caller.
-                                budget_reason = budget.check()
-                                if budget_reason is not None:
-                                    await _record_budget_stop(fkey, budget_reason, len(grp), budget)
-                                    return
                                 try:
                                     await phase_fix_batched(
                                         backend, work, grp_items, grp_nums, total,

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -2003,8 +2003,12 @@ async def phase_fix_parallel(
     Each file group is bounded by a :class:`FileGroupBudget` (#201): the budget
     is consulted before every fix call (including the batched call), and if a
     group's cumulative wall-clock or serial-item count is reached, the remaining
-    findings in that group are skipped (recorded in ``failures`` and a ``file_group_budget_exceeded``
-    trajectory event), so one runaway file cannot silently dominate the run. The
+    findings in that group are skipped while already-applied fixes in that group
+    are preserved.  The skipped group is recorded in ``failures`` with a
+    ``"file_group_budget_exceeded:"`` reason prefix (distinguishable from
+    exception-based entries) and a ``file_group_budget_exceeded`` trajectory
+    event is emitted.  Callers MUST NOT revert budget-exceeded entries; only
+    remaining findings are unprocessed, not the ones already applied.  The
     per-invocation guards inside each fix call are unchanged; this is an aggregate
     guard layered on top (Approach B — between-calls check, no mid-call abort).
 
@@ -2019,10 +2023,13 @@ async def phase_fix_parallel(
         group_max_serial_items: Per-file-group serial fix-call ceiling (#201).
 
     Returns:
-        ``failures``: file -> "<ExceptionType>: <message>" for file-groups whose
-        fix raised, or "file_group_budget_exceeded: <reason>" for groups stopped
-        by their budget. Empty dict on full success. Callers MUST surface this to
-        the user so that uncommitted failures are visible instead of silently dropped.
+        ``failures``: file -> reason string.  Exception-failed groups carry
+        ``"<ExceptionType>: <message>"``; their partial edits may be broken and
+        callers MUST revert them.  Budget-exceeded groups carry
+        ``"file_group_budget_exceeded: <reason>"``; their already-applied fixes
+        are intact and callers MUST NOT revert them — only the remaining findings
+        were skipped.  Callers distinguish the two by the prefix.  Empty dict on
+        full success.
 
     """
     raw_groups = group_items_by_file(items)

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -4,7 +4,6 @@ import copy
 import json
 import logging
 import re
-from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -42,7 +41,6 @@ from daydream.workspace import WorkContext
 if TYPE_CHECKING:
     from daydream.deep.detection import StackAssignment
 from daydream.config import (
-    DEFAULT_GROUP_MAX_CUMULATIVE_TOKENS,
     DEFAULT_GROUP_MAX_SERIAL_ITEMS,
     DEFAULT_GROUP_MAX_WALL_S,
     DEFAULT_TOOL_CALL_BUDGET,
@@ -1788,7 +1786,6 @@ async def phase_fix(
     *,
     console_lock: anyio.Lock | None = None,
     intent_path: Path | None = None,
-    on_metrics: Callable[[int], None] | None = None,
 ) -> None:
     """Phase 3: Apply a single fix for one feedback item.
 
@@ -1806,9 +1803,6 @@ async def phase_fix(
             with a rule forbidding fixes that undo a deliberate decision. The
             read is best-effort enrichment: a missing or unreadable file is
             skipped silently so an intent-read failure can never block the fix.
-        on_metrics: Optional per-turn token callback forwarded to ``run_agent``
-            so a caller (``phase_fix_parallel``) can feed its per-file-group
-            token budget (#201).
 
     Returns:
         None
@@ -1855,7 +1849,6 @@ Make the minimal change needed. {_FIX_GUARDRAILS}"""
             tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
             wall_budget_s=DEFAULT_WALL_BUDGET_S,
             progress_callback=_cb,
-            on_metrics=on_metrics,
         )
     else:
         await run_agent(
@@ -1863,7 +1856,6 @@ Make the minimal change needed. {_FIX_GUARDRAILS}"""
             phase=DaydreamPhase.FIX, max_turns=FIX_MAX_TURNS,
             tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
             wall_budget_s=DEFAULT_WALL_BUDGET_S,
-            on_metrics=on_metrics,
         )
     async with (console_lock if console_lock is not None else anyio.Lock()):
         print_fix_complete(console, item_num, total)
@@ -1878,7 +1870,6 @@ async def phase_fix_batched(
     *,
     console_lock: anyio.Lock | None = None,
     intent_path: Path | None = None,
-    on_metrics: Callable[[int], None] | None = None,
 ) -> None:
     """Phase 3 (batched): Apply all findings for ONE file in a single fix turn.
 
@@ -1899,9 +1890,6 @@ async def phase_fix_batched(
             ``None`` for serial callers.
         intent_path: Optional path to the confirmed author-intent file, injected
             verbatim (same best-effort handling as ``phase_fix``).
-        on_metrics: Optional per-turn token callback forwarded to ``run_agent``
-            so the caller's per-file-group token budget accumulates the batched
-            turn's tokens (#201).
 
     Returns:
         None
@@ -1910,7 +1898,6 @@ async def phase_fix_batched(
         await phase_fix(
             backend, work, items[0], item_nums[0], total,
             console_lock=console_lock, intent_path=intent_path,
-            on_metrics=on_metrics,
         )
         return
 
@@ -1922,7 +1909,6 @@ async def phase_fix_batched(
             await phase_fix(
                 backend, work, item, item_num, total,
                 console_lock=console_lock, intent_path=intent_path,
-                on_metrics=on_metrics,
             )
         return
 
@@ -1974,7 +1960,6 @@ Make the minimal changes needed to address ALL of the above findings in one cohe
             tool_call_budget=scaled_tool_budget,
             wall_budget_s=scaled_wall_budget,
             progress_callback=_cb,
-            on_metrics=on_metrics,
         )
     else:
         _, _, budget_reason = await run_agent(
@@ -1982,7 +1967,6 @@ Make the minimal changes needed to address ALL of the above findings in one cohe
             phase=DaydreamPhase.FIX, max_turns=scaled_max_turns,
             tool_call_budget=scaled_tool_budget,
             wall_budget_s=scaled_wall_budget,
-            on_metrics=on_metrics,
         )
 
     if budget_reason is not None:
@@ -2004,7 +1988,6 @@ async def phase_fix_parallel(
     intent_path: Path | None = None,
     group_max_wall_s: float = DEFAULT_GROUP_MAX_WALL_S,
     group_max_serial_items: int = DEFAULT_GROUP_MAX_SERIAL_ITEMS,
-    group_max_cumulative_tokens: int = DEFAULT_GROUP_MAX_CUMULATIVE_TOKENS,
 ) -> dict[str, str]:
     """Phase 3 (parallel): Apply fixes file-partitioned and concurrently.
 
@@ -2018,9 +2001,9 @@ async def phase_fix_parallel(
     one named in the item's ``file`` key. Commit stays serial and after.
 
     Each file group is bounded by a :class:`FileGroupBudget` (#201): the budget
-    is consulted before every fix call, and if a group's cumulative wall-clock,
-    serial-item count, or token total is reached, the remaining findings in that
-    group are skipped (recorded in ``failures`` and a ``file_group_budget_exceeded``
+    is consulted before every fix call (including the batched call), and if a
+    group's cumulative wall-clock or serial-item count is reached, the remaining
+    findings in that group are skipped (recorded in ``failures`` and a ``file_group_budget_exceeded``
     trajectory event), so one runaway file cannot silently dominate the run. The
     per-invocation guards inside each fix call are unchanged; this is an aggregate
     guard layered on top (Approach B — between-calls check, no mid-call abort).
@@ -2034,7 +2017,6 @@ async def phase_fix_parallel(
             fix call so every fix carries the deliberate-intent guard.
         group_max_wall_s: Per-file-group wall-clock ceiling (#201).
         group_max_serial_items: Per-file-group serial fix-call ceiling (#201).
-        group_max_cumulative_tokens: Per-file-group token ceiling (#201).
 
     Returns:
         ``failures``: file -> "<ExceptionType>: <message>" for file-groups whose
@@ -2094,9 +2076,8 @@ async def phase_fix_parallel(
         """Fix a group's findings one at a time, honoring the group budget.
 
         Checks ``budget.check()`` before each ``phase_fix`` call; on a budget
-        stop, records it and returns without processing the remainder. Token
-        accumulation is fed live via ``on_metrics``; the serial-item counter is
-        bumped once per completed call.
+        stop, records it and returns without processing the remainder. The
+        serial-item counter is bumped once per completed call.
         """
         for item, item_num in grp:
             budget_reason = budget.check()
@@ -2107,7 +2088,6 @@ async def phase_fix_parallel(
                 backend, work, item, item_num, total,
                 console_lock=_console_lock,
                 intent_path=intent_path,
-                on_metrics=budget.add_tokens,
             )
             budget.record_item()
 
@@ -2124,7 +2104,6 @@ async def phase_fix_parallel(
                         budget = FileGroupBudget(
                             max_wall_seconds=group_max_wall_s,
                             max_serial_items=group_max_serial_items,
-                            max_cumulative_tokens=group_max_cumulative_tokens,
                         )
                         try:
                             grp_items = [item for item, _ in grp]
@@ -2136,12 +2115,20 @@ async def phase_fix_parallel(
                                 # no fallback retry on failure).
                                 await _fix_group_serially(fkey, grp, budget)
                             else:
+                                # Design-checkpoint #1: consult the group budget
+                                # BEFORE the batched call too, mirroring the serial
+                                # path, so a ceiling configured to 0/tiny skips the
+                                # file entirely instead of always burning one batched
+                                # turn first (keeps batched + fallback consistent).
+                                pre_batch_reason = budget.check()
+                                if pre_batch_reason is not None:
+                                    await _record_budget_stop(fkey, pre_batch_reason, len(grp), budget)
+                                    return
                                 try:
                                     await phase_fix_batched(
                                         backend, work, grp_items, grp_nums, total,
                                         console_lock=_console_lock,
                                         intent_path=intent_path,
-                                        on_metrics=budget.add_tokens,
                                     )
                                     budget.record_item()
                                 except Exception:  # noqa: BLE001 -- batched failure falls back to per-finding fixes

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -998,6 +998,37 @@ class TrajectoryRecorder:
             )
         )
 
+    def emit_file_group_budget_exceeded(
+        self, *, file: str, reason: str, items_processed: int, items_skipped: int
+    ) -> None:
+        """Record a ``file_group_budget_exceeded`` event for the FIX phase (#201).
+
+        Emitted by ``phase_fix_parallel`` when a per-file-group aggregate budget
+        fires, so future perf triage of a runaway file group (the #186 pattern)
+        is mechanical: the trajectory names the file, the ceiling that tripped,
+        and how many findings were processed vs. skipped. Serialized into
+        ``Trajectory.extra["phase_events"]`` alongside the phase boundaries.
+
+        Args:
+            file: File-group key whose budget was exceeded (or ``"<no-file>"``).
+            reason: Which ceiling tripped (e.g. ``"group_serial_item_limit"``).
+            items_processed: Findings fixed before the budget fired.
+            items_skipped: Remaining findings in the group left unfixed.
+        """
+        self._phase_events.append(
+            PhaseEvent(
+                phase=DaydreamPhase.FIX,
+                event="file_group_budget_exceeded",
+                timestamp=now_iso(),
+                metadata={
+                    "file": file,
+                    "reason": reason,
+                    "items_processed": items_processed,
+                    "items_skipped": items_skipped,
+                },
+            )
+        )
+
     def _register_subtrajectory(self, inv: Invocation) -> None:
         """Register a per-Invocation timing summary (issue #203).
 

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -89,6 +89,16 @@ class _StubBackend:
         # per-finding fallback loop -- the #186 pattern the group budget bounds.
         # The per-finding retries ("Fix this issue") for that file then succeed.
         self.fail_batched_fix_file: str | None = None
+        # When set, ONLY the batched fix turn for the matching file emits a slow
+        # runaway burst (real per-event sleep, never a ResultEvent) so run_agent's
+        # OWN per-invocation WALL budget trips and returns a budget_reason -- the
+        # batched call then raises and phase_fix_parallel falls back to per-finding
+        # fixes. Unlike fail_batched_fix_file (a synchronous stub raise), this
+        # exercises the real budget_reason -> raise path AND burns real wall-time
+        # that carries into the fallback via the shared FileGroupBudget (#201).
+        # Per-finding fallback turns for that file are NOT runaway.
+        self.runaway_batched_fix_file: str | None = None
+        self.runaway_batched_sleep_s: float = 0.05
         # When set, the fix branch WRITES a broken partial edit to the matching
         # file and THEN raises MaxTurnsError -- simulating an agent that mutated
         # the tree before exhausting its turn budget, so a test can assert the
@@ -443,6 +453,18 @@ class _StubBackend:
             fixed_file = m.group(1).strip() if m else "unknown"
             # phase_fix emits an absolute path when the file exists on disk; the stub keys fixes by basename.
             fixed_name = Path(fixed_file).name
+            # Runaway ONLY the batched turn for the marked file: burn real wall so
+            # run_agent's per-invocation wall budget trips, returns a budget_reason,
+            # and phase_fix_batched raises into the per-finding fallback (#201).
+            if (
+                self.runaway_batched_fix_file is not None
+                and batched_hdr is not None
+                and fixed_name == self.runaway_batched_fix_file
+            ):
+                for n in range(500):
+                    yield ToolStartEvent(id=f"btc-{n}", name="Bash", input={"command": "find /"})
+                    await anyio.sleep(self.runaway_batched_sleep_s)
+                return
             # Fail ONLY the batched turn for the marked file so the group falls
             # back to per-finding fixes (the #186 pattern under budget test).
             if (
@@ -3545,6 +3567,100 @@ async def test_run_leaves_small_file_group_unbudgeted(
 
     events = _scan_phase_events(multi_stack_target / ".daydream", traj, "file_group_budget_exceeded")
     assert events == [], "no budget event should fire when the group stays within budget"
+
+
+async def test_run_batched_wall_trip_carries_into_group_fallback(
+    multi_stack_target: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#201 real-path: a batched turn's OWN wall trip carries into the fallback.
+
+    The batched api.py turn burns real wall until run_agent's per-invocation wall
+    scope cancels it and returns a ``budget_reason`` -- so ``phase_fix_batched``
+    raises through the *real* budget path (NOT a synchronous stub raise like
+    ``fail_batched_fix_file``) and ``phase_fix_parallel`` falls back to per-finding
+    fixes. Because the SAME ``FileGroupBudget`` is reused across the batched and
+    fallback stages (a spec invariant), the ~1.8s the batched turn already spent
+    is on the group's wall clock when the fallback's first ``budget.check()`` runs.
+    With the group wall ceiling at 1.0s -- below the batched turn's scaled 1.8s
+    per-invocation budget -- that first check trips immediately, so ZERO fallback
+    fixes run, the whole group is recorded as a wall budget failure, and the
+    trajectory event reports 0 processed / all skipped.
+
+    Discriminating: if the batched turn's wall did NOT carry into the fallback
+    (e.g. a fresh per-call budget), the fallback would see a ~0s clock and fix all
+    six api.py findings. Asserting zero ``fix this issue`` api.py turns + a
+    ``group_wall_budget_exceeded`` reason proves the carryover. The batched turn's
+    own ``wall_budget_exceeded`` stop_reason proves it failed via the real budget
+    path rather than a stub raise.
+    """
+    from daydream.runner import RunConfig, run
+
+    _silence(monkeypatch)
+    # Tiny per-invocation wall so the batched turn (scaled to N * 0.3s) trips after
+    # ~1.8s of real wall; patch the binding read at the fix call site.
+    monkeypatch.setattr("daydream.phases.DEFAULT_WALL_BUDGET_S", 0.3)
+    # Group wall ceiling below the batched turn's scaled per-invocation budget, so
+    # the wall the batched turn already burned guarantees the fallback's first
+    # check trips (deterministic: 1.0 < 0.3 * 6).
+    monkeypatch.setattr("daydream.deep.orchestrator.DEFAULT_GROUP_MAX_WALL_S", 1.0)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    stub.merge_items = [_merge_item(i, "api.py", "high") for i in range(1, 7)] + [
+        _merge_item(7, "App.tsx", "high")
+    ]
+    stub.runaway_batched_fix_file = "api.py"  # batched api.py turn trips its own wall budget
+    stub.runaway_batched_sleep_s = 0.05
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_test_and_heal", lambda *a, **k: _ok())
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _noop_commit)
+
+    traj = tmp_path / "trajectory.json"
+    with anyio.fail_after(30):
+        exit_code = await run(
+            RunConfig(
+                target=str(multi_stack_target),
+                trajectory_path=traj,
+                assume="yes",
+                output_mode="loop",
+                cleanup=False,
+            )
+        )
+    assert isinstance(exit_code, int)
+
+    # The batched api.py turn actually ran (and is where the wall was burned).
+    group_size = _batched_group_size(stub, "api.py")
+    assert group_size >= 6
+
+    # ZERO fallback fixes ran: the batched turn's carried-over wall tripped the
+    # group budget on the fallback's very first check -- the #186 runaway is fully
+    # bounded, not merely trimmed.
+    api_singles = [
+        c
+        for c in stub.calls
+        if c["prompt"].lower().startswith("fix this issue") and "api.py" in c["prompt"]
+    ]
+    assert len(api_singles) == 0, f"expected 0 fallback fixes (wall carried over), got {len(api_singles)}"
+
+    # The skipped group is recorded as a WALL budget failure (surfaces to the user).
+    fix_failures_p = multi_stack_target / ".daydream" / "deep" / "fix-failures.json"
+    assert fix_failures_p.is_file(), "budget-skipped group must write the fix-failures artifact"
+    recorded = json.loads(fix_failures_p.read_text())
+    assert "api.py" in recorded
+    assert recorded["api.py"].startswith("file_group_budget_exceeded: group_wall_budget_exceeded")
+
+    # The trajectory carries the budget event: 0 processed, the whole group skipped.
+    events = _scan_phase_events(multi_stack_target / ".daydream", traj, "file_group_budget_exceeded")
+    assert events, "no file_group_budget_exceeded event emitted"
+    meta = events[0]["metadata"]
+    assert meta["file"] == "api.py"
+    assert meta["reason"] == "group_wall_budget_exceeded"
+    assert meta["items_processed"] == 0
+    assert meta["items_skipped"] == group_size
+
+    # Discriminator: the batched turn failed via run_agent's REAL per-invocation
+    # wall budget (a budget_reason), not a synchronous stub raise -- its aborted
+    # ATIF step carries stop_reason == wall_budget_exceeded.
+    run_root = multi_stack_target / ".daydream"
+    stop_reasons = _scan_trajectory_extra(run_root, traj, "stop_reason")
+    assert "wall_budget_exceeded" in stop_reasons, "batched turn did not trip its own per-invocation wall budget"
 
 
 async def test_run_batches_same_file_findings_into_one_fix_turn(

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -84,6 +84,11 @@ class _StubBackend:
         # When set, the fix branch raises for the matching file, isolating one
         # file-group's failure so a test can assert the others still applied.
         self.fix_fail_file: str | None = None
+        # When set, ONLY the batched fix turn ("Fix these N issues in <file>")
+        # for the matching file raises, forcing phase_fix_parallel into its
+        # per-finding fallback loop -- the #186 pattern the group budget bounds.
+        # The per-finding retries ("Fix this issue") for that file then succeed.
+        self.fail_batched_fix_file: str | None = None
         # When set, the fix branch WRITES a broken partial edit to the matching
         # file and THEN raises MaxTurnsError -- simulating an agent that mutated
         # the tree before exhausting its turn budget, so a test can assert the
@@ -432,11 +437,20 @@ class _StubBackend:
             # Single-finding prompts carry "File: <path>"; batched prompts name the
             # one target file in their "Fix these N issues in <path>:" header.
             m = re.search(r"^File: (.+)$", prompt, re.M)
+            batched_hdr = re.search(r"^Fix these \d+ issues in (.+):$", prompt, re.M)
             if m is None:
-                m = re.search(r"^Fix these \d+ issues in (.+):$", prompt, re.M)
+                m = batched_hdr
             fixed_file = m.group(1).strip() if m else "unknown"
             # phase_fix emits an absolute path when the file exists on disk; the stub keys fixes by basename.
             fixed_name = Path(fixed_file).name
+            # Fail ONLY the batched turn for the marked file so the group falls
+            # back to per-finding fixes (the #186 pattern under budget test).
+            if (
+                self.fail_batched_fix_file is not None
+                and batched_hdr is not None
+                and fixed_name == self.fail_batched_fix_file
+            ):
+                raise RuntimeError(f"stub: batched fix failure for {fixed_name}")
             if self.fix_partial_then_maxturns is not None and fixed_name == self.fix_partial_then_maxturns:
                 edit_target = Path(fixed_file) if Path(fixed_file).is_absolute() else (cwd / fixed_file)
                 edit_target.write_text(_PARTIAL_FIX_MARKER)
@@ -3372,6 +3386,165 @@ async def test_run_terminates_under_wall_budget(
 
     assert stop_reasons, "no trajectory step recorded extra['stop_reason']; budget did not trip"
     assert "wall_budget_exceeded" in stop_reasons
+
+
+def _scan_phase_events(run_root: Path, traj: Path, event: str) -> list[dict[str, Any]]:
+    """Collect ``extra['phase_events']`` entries of a given ``event`` across all run JSONs.
+
+    The group-budget marker lives in ``Trajectory.extra['phase_events']`` (not
+    step ``extra``), and the fix work runs in a forked sibling trajectory, so scan
+    every ``*.json`` beneath ``run_root`` plus the top-level ``traj``.
+    """
+    found: list[dict[str, Any]] = []
+    for tf in list(run_root.rglob("*.json")) + ([traj] if traj.exists() else []):
+        try:
+            payload = json.loads(tf.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        for ev in (payload.get("extra") or {}).get("phase_events", []):
+            if isinstance(ev, dict) and ev.get("event") == event:
+                found.append(ev)
+    return found
+
+
+def _batched_group_size(stub: "_StubBackend", file_basename: str) -> int:
+    """Return N from the failed batched ``Fix these N issues in <file>`` fix turn.
+
+    The deep pipeline may inject an extra structural finding into a file group, so
+    the group size is derived from the batched prompt rather than hard-coded.
+    """
+    import re as _re
+
+    for c in stub.calls:
+        m = _re.search(r"^Fix these (\d+) issues in (.+):$", c["prompt"], _re.M)
+        if m is not None and Path(m.group(2)).name == file_basename:
+            return int(m.group(1))
+    raise AssertionError(f"no batched fix turn found for {file_basename}")
+
+
+async def test_run_caps_runaway_file_group_serial_fixes(
+    multi_stack_target: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#201 real-path: a runaway file group is capped by the serial-item budget.
+
+    Six findings target api.py; the batched api.py fix turn fails, forcing the
+    per-finding fallback loop -- the exact #186 shape where 9 serial fix calls on
+    one file silently dominated a 62-min run. Driven through the real
+    ``runner.run`` -> deep orchestrator -> ``phase_fix_parallel`` path with the
+    group serial-item ceiling lowered to 3, only 3 of the 6 fallback fixes run;
+    the remaining 3 are skipped, recorded in ``failures`` (surfaced as the
+    fix-failures artifact), and a ``file_group_budget_exceeded`` trajectory event
+    is emitted naming the file, reason, and processed/skipped counts.
+
+    Discriminating: without the group budget, the fallback loop fixes all 6
+    api.py findings (six "fix this issue" turns) and no budget event exists --
+    both assertions fail.
+    """
+    from daydream.runner import RunConfig, run
+
+    _silence(monkeypatch)
+    # Lower the group serial-item ceiling at the binding the orchestrator resolves
+    # (it imported the constant by name, so patching daydream.config alone is inert).
+    monkeypatch.setattr("daydream.deep.orchestrator.DEFAULT_GROUP_MAX_SERIAL_ITEMS", 3)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    stub.merge_items = [_merge_item(i, "api.py", "high") for i in range(1, 7)] + [
+        _merge_item(7, "App.tsx", "high")
+    ]
+    stub.fail_batched_fix_file = "api.py"  # force the per-finding fallback for api.py
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_test_and_heal", lambda *a, **k: _ok())
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _noop_commit)
+
+    traj = tmp_path / "trajectory.json"
+    with anyio.fail_after(30):
+        exit_code = await run(
+            RunConfig(
+                target=str(multi_stack_target),
+                trajectory_path=traj,
+                assume="yes",
+                output_mode="loop",
+                cleanup=False,
+            )
+        )
+    assert isinstance(exit_code, int)
+
+    # The failed batched turn names the api.py group size (the pipeline may add a
+    # structural finding, so derive N rather than hard-coding it).
+    group_size = _batched_group_size(stub, "api.py")
+    assert group_size >= 6
+
+    # Only 3 fallback fixes ran (the ceiling) before the group budget tripped --
+    # NOT the full group, which is the runaway #186 behaviour the guard bounds.
+    api_singles = [
+        c
+        for c in stub.calls
+        if c["prompt"].lower().startswith("fix this issue") and "api.py" in c["prompt"]
+    ]
+    assert len(api_singles) == 3, f"expected 3 fallback fixes, got {len(api_singles)}"
+
+    # The skipped group is recorded as a budget failure (surfaces to the user).
+    fix_failures_p = multi_stack_target / ".daydream" / "deep" / "fix-failures.json"
+    assert fix_failures_p.is_file(), "budget-skipped group must write the fix-failures artifact"
+    recorded = json.loads(fix_failures_p.read_text())
+    assert "api.py" in recorded
+    assert recorded["api.py"].startswith("file_group_budget_exceeded: group_serial_item_limit")
+
+    # The trajectory carries the budget event with processed/skipped accounting.
+    events = _scan_phase_events(multi_stack_target / ".daydream", traj, "file_group_budget_exceeded")
+    assert events, "no file_group_budget_exceeded event emitted"
+    meta = events[0]["metadata"]
+    assert meta["file"] == "api.py"
+    assert meta["reason"] == "group_serial_item_limit"
+    assert meta["items_processed"] == 3
+    assert meta["items_skipped"] == group_size - 3
+
+
+async def test_run_leaves_small_file_group_unbudgeted(
+    multi_stack_target: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#201 real-path: under a high ceiling the group budget is purely additive.
+
+    Same six-finding api.py fallback shape, but the serial-item ceiling stays well
+    above the group size: all six fallback fixes run, no budget event is emitted,
+    and no budget failure is recorded. Proves the guard changes nothing when a
+    group stays within budget (spec AC#5).
+    """
+    from daydream.runner import RunConfig, run
+
+    _silence(monkeypatch)
+    monkeypatch.setattr("daydream.deep.orchestrator.DEFAULT_GROUP_MAX_SERIAL_ITEMS", 20)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    stub.merge_items = [_merge_item(i, "api.py", "high") for i in range(1, 7)] + [
+        _merge_item(7, "App.tsx", "high")
+    ]
+    stub.fail_batched_fix_file = "api.py"
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_test_and_heal", lambda *a, **k: _ok())
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _noop_commit)
+
+    traj = tmp_path / "trajectory.json"
+    with anyio.fail_after(30):
+        exit_code = await run(
+            RunConfig(
+                target=str(multi_stack_target),
+                trajectory_path=traj,
+                assume="yes",
+                output_mode="loop",
+                cleanup=False,
+            )
+        )
+    assert isinstance(exit_code, int)
+
+    group_size = _batched_group_size(stub, "api.py")
+    api_singles = [
+        c
+        for c in stub.calls
+        if c["prompt"].lower().startswith("fix this issue") and "api.py" in c["prompt"]
+    ]
+    assert len(api_singles) == group_size, f"all {group_size} fallback fixes should run, got {len(api_singles)}"
+
+    events = _scan_phase_events(multi_stack_target / ".daydream", traj, "file_group_budget_exceeded")
+    assert events == [], "no budget event should fire when the group stays within budget"
 
 
 async def test_run_batches_same_file_findings_into_one_fix_turn(

--- a/tests/test_fix_budget.py
+++ b/tests/test_fix_budget.py
@@ -32,7 +32,7 @@ from daydream.config import (
     DEFAULT_GROUP_MAX_WALL_S,
 )
 from daydream.config_file import load_file_config
-from daydream.phases import FileGroupBudget
+from daydream.file_group_budget import FileGroupBudget
 from daydream.trajectory import DaydreamPhase
 
 # -- FileGroupBudget -------------------------------------------------------

--- a/tests/test_fix_budget.py
+++ b/tests/test_fix_budget.py
@@ -1,0 +1,219 @@
+"""Unit tests for the per-file-group fix budget (issue #201).
+
+Covers the three pieces the real-path enforcement test (in
+``test_deep_orchestrator.py``) builds on:
+
+1. ``FileGroupBudget`` — the aggregate guard's ``check``/``add_tokens``/
+   ``record_item`` semantics (which ceiling fires, in what order).
+2. ``run_agent``'s ``on_metrics`` callback — receives ``prompt_tokens +
+   completion_tokens`` per ``MetricsEvent`` and never alters turn behaviour.
+3. The config-file parser — ``group_max_*`` overrides parse from
+   ``[tool.daydream]`` and junk values degrade to ``None`` (default applies).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from daydream.agent import run_agent
+from daydream.backends import (
+    AgentEvent,
+    ContinuationToken,
+    MetricsEvent,
+    ResultEvent,
+    TextEvent,
+)
+from daydream.config import (
+    DEFAULT_GROUP_MAX_CUMULATIVE_TOKENS,
+    DEFAULT_GROUP_MAX_SERIAL_ITEMS,
+    DEFAULT_GROUP_MAX_WALL_S,
+)
+from daydream.config_file import load_file_config
+from daydream.phases import FileGroupBudget
+from daydream.trajectory import DaydreamPhase
+
+# -- FileGroupBudget -------------------------------------------------------
+
+
+def _budget(*, wall: float = 1e9, items: int = 1_000, tokens: int = 1_000_000_000) -> FileGroupBudget:
+    """Construct a budget with generous ceilings; callers tighten one at a time."""
+    return FileGroupBudget(max_wall_seconds=wall, max_serial_items=items, max_cumulative_tokens=tokens)
+
+
+def test_fresh_budget_is_under_all_ceilings() -> None:
+    assert _budget().check() is None
+
+
+def test_serial_item_limit_fires_after_n_items() -> None:
+    budget = _budget(items=3)
+    for _ in range(3):
+        assert budget.check() is None  # room remains
+        budget.record_item()
+    assert budget.items_processed == 3
+    assert budget.check() == "group_serial_item_limit"
+
+
+def test_token_limit_fires_when_cumulative_tokens_reached() -> None:
+    budget = _budget(tokens=1000)
+    budget.add_tokens(600)
+    assert budget.check() is None
+    budget.add_tokens(400)  # now 1000 >= 1000
+    assert budget.check() == "group_token_budget_exceeded"
+
+
+def test_wall_limit_fires_when_elapsed_reached() -> None:
+    # monotonic elapsed is always >= 0, so a zero ceiling trips deterministically
+    # without sleeping (and without the item ceiling masking it: items=1000).
+    budget = _budget(wall=0.0, items=1000)
+    assert budget.check() == "group_wall_budget_exceeded"
+
+
+def test_item_limit_takes_precedence_over_token_and_wall() -> None:
+    # check() order is items -> wall -> tokens: when several ceilings are breached
+    # at once, the reason is deterministic.
+    budget = FileGroupBudget(max_wall_seconds=0.0, max_serial_items=1, max_cumulative_tokens=1)
+    budget.record_item()
+    budget.add_tokens(5)
+    assert budget.check() == "group_serial_item_limit"
+
+
+def test_add_tokens_does_not_bump_item_count() -> None:
+    budget = _budget()
+    budget.add_tokens(10_000)
+    assert budget.items_processed == 0  # only record_item() advances the serial count
+
+
+# -- run_agent on_metrics callback ----------------------------------------
+
+
+@dataclass
+class _MetricsBackend:
+    """Minimal Backend replaying a canned event list (mirrors test_multi_turn_tokens)."""
+
+    model = "mock-model"
+    fanout_concurrency = 4
+    events: list[AgentEvent]
+
+    def execute(
+        self,
+        cwd: Path,
+        prompt: str,
+        output_schema: dict[str, Any] | None = None,
+        continuation: ContinuationToken | None = None,
+        agents: dict[str, Any] | None = None,
+        max_turns: int | None = None,
+        read_only: bool = False,
+    ) -> AsyncIterator[AgentEvent]:
+        events = self.events
+
+        async def _gen() -> AsyncIterator[AgentEvent]:
+            for event in events:
+                yield event
+
+        return _gen()
+
+    async def cancel(self) -> None:
+        return None
+
+    def format_skill_invocation(self, skill_key: str, args: str = "") -> str:
+        return f"/{skill_key}"
+
+
+def _metrics(prompt_tokens: int, completion_tokens: int, msg_id: str) -> MetricsEvent:
+    return MetricsEvent(
+        message_id=msg_id,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        cached_tokens=None,
+        cost_usd=None,
+    )
+
+
+async def test_on_metrics_receives_prompt_plus_completion_per_event(tmp_path: Path) -> None:
+    """The callback fires once per MetricsEvent with prompt+completion tokens."""
+    backend = _MetricsBackend([
+        TextEvent(text="working"),
+        _metrics(100, 20, "m1"),
+        _metrics(150, 30, "m2"),
+        ResultEvent(structured_output=None, continuation=None),
+    ])
+    received: list[int] = []
+    _, _, budget_reason = await run_agent(
+        backend, tmp_path, "prompt", phase=DaydreamPhase.FIX, on_metrics=received.append
+    )
+    assert received == [120, 180]  # (100+20), (150+30)
+    assert budget_reason is None  # on_metrics never aborts the turn (Approach B)
+
+
+async def test_on_metrics_none_is_a_noop(tmp_path: Path) -> None:
+    """Omitting on_metrics leaves run_agent behaviour unchanged (no crash)."""
+    backend = _MetricsBackend([
+        TextEvent(text="working"),
+        _metrics(10, 5, "m1"),
+        ResultEvent(structured_output=None, continuation=None),
+    ])
+    output, _, budget_reason = await run_agent(backend, tmp_path, "prompt", phase=DaydreamPhase.FIX)
+    assert budget_reason is None
+    assert isinstance(output, str)
+
+
+async def test_on_metrics_feeds_a_file_group_budget(tmp_path: Path) -> None:
+    """End-to-end wiring: run_agent -> budget.add_tokens accumulates real tokens."""
+    backend = _MetricsBackend([
+        _metrics(120_000, 40_000, "m1"),
+        ResultEvent(structured_output=None, continuation=None),
+    ])
+    budget = _budget(tokens=150_000)
+    await run_agent(backend, tmp_path, "prompt", phase=DaydreamPhase.FIX, on_metrics=budget.add_tokens)
+    # 160_000 >= 150_000 -> the group's token ceiling is now tripped.
+    assert budget.check() == "group_token_budget_exceeded"
+
+
+# -- config-file overrides -------------------------------------------------
+
+
+def test_group_budget_overrides_parse_from_pyproject(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        "[tool.daydream]\n"
+        "group_max_wall_s = 300\n"  # int round-trips to float
+        "group_max_serial_items = 4\n"
+        "group_max_cumulative_tokens = 120000\n"
+    )
+    cfg = load_file_config(tmp_path)
+    assert cfg.group_max_wall_s == 300.0
+    assert cfg.group_max_serial_items == 4
+    assert cfg.group_max_cumulative_tokens == 120_000
+
+
+def test_group_budget_absent_is_none_so_defaults_apply(tmp_path: Path) -> None:
+    cfg = load_file_config(tmp_path)
+    assert cfg.group_max_wall_s is None
+    assert cfg.group_max_serial_items is None
+    assert cfg.group_max_cumulative_tokens is None
+    # The constants remain the fallback the orchestrator resolves to.
+    assert DEFAULT_GROUP_MAX_WALL_S == 600.0
+    assert DEFAULT_GROUP_MAX_SERIAL_ITEMS == 6
+    assert DEFAULT_GROUP_MAX_CUMULATIVE_TOKENS == 200_000
+
+
+def test_group_budget_junk_values_degrade_to_none(tmp_path: Path) -> None:
+    # bool subclasses int/float but is never a meaningful budget; strings/lists too.
+    (tmp_path / ".daydream.toml").write_text(
+        "group_max_wall_s = true\n"
+        'group_max_serial_items = "lots"\n'
+        "group_max_cumulative_tokens = false\n"
+    )
+    cfg = load_file_config(tmp_path)
+    assert cfg.group_max_wall_s is None
+    assert cfg.group_max_serial_items is None
+    assert cfg.group_max_cumulative_tokens is None
+
+
+def test_group_budget_dotfile_float_overrides_pyproject_int(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[tool.daydream]\ngroup_max_wall_s = 600\n")
+    (tmp_path / ".daydream.toml").write_text("group_max_wall_s = 90.5\n")
+    cfg = load_file_config(tmp_path)
+    assert cfg.group_max_wall_s == 90.5

--- a/tests/test_fix_budget.py
+++ b/tests/test_fix_budget.py
@@ -1,46 +1,35 @@
 """Unit tests for the per-file-group fix budget (issue #201).
 
-Covers the three pieces the real-path enforcement test (in
-``test_deep_orchestrator.py``) builds on:
+Covers the two pieces the real-path enforcement tests (in
+``test_deep_orchestrator.py``) build on:
 
-1. ``FileGroupBudget`` — the aggregate guard's ``check``/``add_tokens``/
-   ``record_item`` semantics (which ceiling fires, in what order).
-2. ``run_agent``'s ``on_metrics`` callback — receives ``prompt_tokens +
-   completion_tokens`` per ``MetricsEvent`` and never alters turn behaviour.
-3. The config-file parser — ``group_max_*`` overrides parse from
+1. ``FileGroupBudget`` — the aggregate guard's ``check``/``record_item``
+   semantics (which ceiling fires, in what order).
+2. The config-file parser — ``group_max_*`` overrides parse from
    ``[tool.daydream]`` and junk values degrade to ``None`` (default applies).
+
+The token axis was removed: it can only bound multi-call fallback groups (the
+same population ``wall`` + ``serial`` already govern), where output tokens are
+collinear with wall-time and call-count, so it added no independent signal.
 """
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
-from daydream.agent import run_agent
-from daydream.backends import (
-    AgentEvent,
-    ContinuationToken,
-    MetricsEvent,
-    ResultEvent,
-    TextEvent,
-)
 from daydream.config import (
-    DEFAULT_GROUP_MAX_CUMULATIVE_TOKENS,
     DEFAULT_GROUP_MAX_SERIAL_ITEMS,
     DEFAULT_GROUP_MAX_WALL_S,
 )
 from daydream.config_file import load_file_config
 from daydream.file_group_budget import FileGroupBudget
-from daydream.trajectory import DaydreamPhase
 
 # -- FileGroupBudget -------------------------------------------------------
 
 
-def _budget(*, wall: float = 1e9, items: int = 1_000, tokens: int = 1_000_000_000) -> FileGroupBudget:
+def _budget(*, wall: float = 1e9, items: int = 1_000) -> FileGroupBudget:
     """Construct a budget with generous ceilings; callers tighten one at a time."""
-    return FileGroupBudget(max_wall_seconds=wall, max_serial_items=items, max_cumulative_tokens=tokens)
+    return FileGroupBudget(max_wall_seconds=wall, max_serial_items=items)
 
 
 def test_fresh_budget_is_under_all_ceilings() -> None:
@@ -56,14 +45,6 @@ def test_serial_item_limit_fires_after_n_items() -> None:
     assert budget.check() == "group_serial_item_limit"
 
 
-def test_token_limit_fires_when_cumulative_tokens_reached() -> None:
-    budget = _budget(tokens=1000)
-    budget.add_tokens(600)
-    assert budget.check() is None
-    budget.add_tokens(400)  # now 1000 >= 1000
-    assert budget.check() == "group_token_budget_exceeded"
-
-
 def test_wall_limit_fires_when_elapsed_reached() -> None:
     # monotonic elapsed is always >= 0, so a zero ceiling trips deterministically
     # without sleeping (and without the item ceiling masking it: items=1000).
@@ -71,105 +52,12 @@ def test_wall_limit_fires_when_elapsed_reached() -> None:
     assert budget.check() == "group_wall_budget_exceeded"
 
 
-def test_item_limit_takes_precedence_over_token_and_wall() -> None:
-    # check() order is items -> wall -> tokens: when several ceilings are breached
-    # at once, the reason is deterministic.
-    budget = FileGroupBudget(max_wall_seconds=0.0, max_serial_items=1, max_cumulative_tokens=1)
+def test_item_limit_takes_precedence_over_wall() -> None:
+    # check() order is items -> wall: when both ceilings are breached at once,
+    # the reason is deterministic.
+    budget = FileGroupBudget(max_wall_seconds=0.0, max_serial_items=1)
     budget.record_item()
-    budget.add_tokens(5)
     assert budget.check() == "group_serial_item_limit"
-
-
-def test_add_tokens_does_not_bump_item_count() -> None:
-    budget = _budget()
-    budget.add_tokens(10_000)
-    assert budget.items_processed == 0  # only record_item() advances the serial count
-
-
-# -- run_agent on_metrics callback ----------------------------------------
-
-
-@dataclass
-class _MetricsBackend:
-    """Minimal Backend replaying a canned event list (mirrors test_multi_turn_tokens)."""
-
-    model = "mock-model"
-    fanout_concurrency = 4
-    events: list[AgentEvent]
-
-    def execute(
-        self,
-        cwd: Path,
-        prompt: str,
-        output_schema: dict[str, Any] | None = None,
-        continuation: ContinuationToken | None = None,
-        agents: dict[str, Any] | None = None,
-        max_turns: int | None = None,
-        read_only: bool = False,
-    ) -> AsyncIterator[AgentEvent]:
-        events = self.events
-
-        async def _gen() -> AsyncIterator[AgentEvent]:
-            for event in events:
-                yield event
-
-        return _gen()
-
-    async def cancel(self) -> None:
-        return None
-
-    def format_skill_invocation(self, skill_key: str, args: str = "") -> str:
-        return f"/{skill_key}"
-
-
-def _metrics(prompt_tokens: int, completion_tokens: int, msg_id: str) -> MetricsEvent:
-    return MetricsEvent(
-        message_id=msg_id,
-        prompt_tokens=prompt_tokens,
-        completion_tokens=completion_tokens,
-        cached_tokens=None,
-        cost_usd=None,
-    )
-
-
-async def test_on_metrics_receives_prompt_plus_completion_per_event(tmp_path: Path) -> None:
-    """The callback fires once per MetricsEvent with prompt+completion tokens."""
-    backend = _MetricsBackend([
-        TextEvent(text="working"),
-        _metrics(100, 20, "m1"),
-        _metrics(150, 30, "m2"),
-        ResultEvent(structured_output=None, continuation=None),
-    ])
-    received: list[int] = []
-    _, _, budget_reason = await run_agent(
-        backend, tmp_path, "prompt", phase=DaydreamPhase.FIX, on_metrics=received.append
-    )
-    assert received == [120, 180]  # (100+20), (150+30)
-    assert budget_reason is None  # on_metrics never aborts the turn (Approach B)
-
-
-async def test_on_metrics_none_is_a_noop(tmp_path: Path) -> None:
-    """Omitting on_metrics leaves run_agent behaviour unchanged (no crash)."""
-    backend = _MetricsBackend([
-        TextEvent(text="working"),
-        _metrics(10, 5, "m1"),
-        ResultEvent(structured_output=None, continuation=None),
-    ])
-    output, _, budget_reason = await run_agent(backend, tmp_path, "prompt", phase=DaydreamPhase.FIX)
-    assert budget_reason is None
-    assert isinstance(output, str)
-
-
-async def test_on_metrics_feeds_a_file_group_budget(tmp_path: Path) -> None:
-    """End-to-end wiring: run_agent -> budget.add_tokens accumulates real tokens."""
-    backend = _MetricsBackend([
-        _metrics(120_000, 40_000, "m1"),
-        ResultEvent(structured_output=None, continuation=None),
-    ])
-    budget = _budget(tokens=150_000)
-    await run_agent(backend, tmp_path, "prompt", phase=DaydreamPhase.FIX, on_metrics=budget.add_tokens)
-    # 160_000 >= 150_000 -> the group's token ceiling is now tripped.
-    assert budget.check() == "group_token_budget_exceeded"
 
 
 # -- config-file overrides -------------------------------------------------
@@ -180,23 +68,19 @@ def test_group_budget_overrides_parse_from_pyproject(tmp_path: Path) -> None:
         "[tool.daydream]\n"
         "group_max_wall_s = 300\n"  # int round-trips to float
         "group_max_serial_items = 4\n"
-        "group_max_cumulative_tokens = 120000\n"
     )
     cfg = load_file_config(tmp_path)
     assert cfg.group_max_wall_s == 300.0
     assert cfg.group_max_serial_items == 4
-    assert cfg.group_max_cumulative_tokens == 120_000
 
 
 def test_group_budget_absent_is_none_so_defaults_apply(tmp_path: Path) -> None:
     cfg = load_file_config(tmp_path)
     assert cfg.group_max_wall_s is None
     assert cfg.group_max_serial_items is None
-    assert cfg.group_max_cumulative_tokens is None
     # The constants remain the fallback the orchestrator resolves to.
     assert DEFAULT_GROUP_MAX_WALL_S == 600.0
     assert DEFAULT_GROUP_MAX_SERIAL_ITEMS == 6
-    assert DEFAULT_GROUP_MAX_CUMULATIVE_TOKENS == 200_000
 
 
 def test_group_budget_junk_values_degrade_to_none(tmp_path: Path) -> None:
@@ -204,12 +88,10 @@ def test_group_budget_junk_values_degrade_to_none(tmp_path: Path) -> None:
     (tmp_path / ".daydream.toml").write_text(
         "group_max_wall_s = true\n"
         'group_max_serial_items = "lots"\n'
-        "group_max_cumulative_tokens = false\n"
     )
     cfg = load_file_config(tmp_path)
     assert cfg.group_max_wall_s is None
     assert cfg.group_max_serial_items is None
-    assert cfg.group_max_cumulative_tokens is None
 
 
 def test_group_budget_dotfile_float_overrides_pyproject_int(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #201

## Summary

Add a per-file-group aggregate budget to the fix phase (`phase_fix_parallel`)
so one file with many findings cannot silently dominate a review-fix-test run.
This is the root-cause fix for the 62-minute pi/GLM run in #186, where 9
serial `run_agent()` calls on a single file consumed a disproportionate share
of wall-clock and cost with no mechanism to detect or stop it.

## What changed

- **`daydream/file_group_budget.py`** (new): `FileGroupBudget` dataclass with
  three ceilings — `max_wall_seconds` (600s), `max_serial_items` (6),
  `max_cumulative_tokens` (200k). The `check()` method is a pure read consulted
  before each fix call; `add_tokens()` accumulates per-turn tokens via the
  `on_metrics` callback; `record_item()` bumps the serial-item counter.

- **`daydream/agent.py`**: `run_agent` gains an optional `on_metrics` callback
  invoked once per `MetricsEvent` with `prompt_tokens + completion_tokens`.
  Pure pass-through — no behavioral change when `None`.

- **`daydream/phases.py`**: `phase_fix_parallel` creates a `FileGroupBudget`
  per file group and checks it before every `phase_fix()` call (both the
  single-item path and the batched-failure fallback path). When a ceiling
  trips, remaining findings in the group are skipped, a
  `file_group_budget_exceeded` trajectory event is emitted, and the failure is
  recorded in `fix-failures.json`.

- **`daydream/deep/orchestrator.py`**: `_step_fix` resolves the three budget
  thresholds from file-config overrides (precedence: `[tool.daydream]` >
  built-in default), mirroring the existing `_shallow_fanout_threshold` pattern.

- **`daydream/config.py`**: `DEFAULT_GROUP_MAX_WALL_S`,
  `DEFAULT_GROUP_MAX_SERIAL_ITEMS`, `DEFAULT_GROUP_MAX_CUMULATIVE_TOKENS`.

- **`daydream/config_file.py`**: Parses `group_max_wall_s`,
  `group_max_serial_items`, `group_max_cumulative_tokens` from
  `[tool.daydream]` with type coercion (junk degrades to default).

- **`daydream/trajectory.py`**: `emit_file_group_budget_exceeded` records the
  event in `Trajectory.extra["phase_events"]` for future perf triage.

## Design decisions

- **Approach B (between-calls check, no mid-call abort)**: the existing
  per-invocation guards (`wall_budget_s=1800`, `tool_call_budget=50`,
  `max_turns=40`) already bound each individual call. The group budget adds
  the aggregate guard that catches the N-calls-on-one-file pattern. Mid-call
  abort is a follow-up if between-calls proves insufficient.

- **Fix-phase only**: the budget does not touch the review, merge, or
  verification phases. The benchmark reads `merged-items.json` (written during
  the review merge phase, before fix runs); this change cannot affect benchmark
  scoring.

## Tests

- `tests/test_fix_budget.py` (new, 13 tests): `FileGroupBudget` semantics,
  `run_agent` `on_metrics` callback, config-file parser overrides.
- `tests/test_deep_orchestrator.py` (+2 real-path tests): a 6-finding
  single-file group with `max_serial_items=3` caps at 3 fixes and emits the
  trajectory event; the same setup with a high ceiling processes all findings
  with no budget event.
- Full gate: `make check` — 2072 passed, 5 skipped.
