### PR TITLE
refactor: remove dead code, trim docstrings, and DRY the test suite

### DIFF
--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -48,12 +48,7 @@ from daydream.ui import (
 
 
 class MissingSkillError(Exception):
-    """Raised when a required skill is not available.
-
-    Args:
-        skill_name: The name of the skill that was not found.
-
-    """
+    """Raised when a required skill is not available."""
 
     def __init__(self, skill_name: str):
         self.skill_name = skill_name
@@ -65,15 +60,10 @@ class AgentState:
     """Consolidated state for agent module.
 
     Attributes:
-        quiet_mode: True to hide tool calls and results, False to show them.
-        non_interactive: True to take each prompt's safe default without reading stdin.
         assume: A forced yes/no answer for interactive gates — ``"yes"`` (``--yes``),
             ``"no"`` (a future ``--no``), or ``None`` (no assumption). Orthogonal to
             ``non_interactive``: ``non_interactive`` controls *whether* we may block on
             stdin; ``assume`` supplies a *pre-decided answer* regardless of TTY.
-        shutdown_requested: True if shutdown has been requested.
-        current_backends: List of active backend instances.
-
     """
 
     quiet_mode: bool = False
@@ -90,72 +80,29 @@ _state = AgentState()
 console = create_console()
 
 
-def get_state() -> AgentState:
-    """Get the global agent state singleton.
-
-    Returns:
-        The global AgentState instance.
-
-    """
-    return _state
-
-
 def reset_state() -> None:
-    """Reset the global agent state to defaults.
-
-    Creates a new AgentState instance with default values.
-
-    Returns:
-        None
-
-    """
+    """Reset the global agent state to defaults (restores between test runs)."""
     global _state
     _state = AgentState()
 
 
 def set_quiet_mode(quiet: bool) -> None:
-    """Set quiet mode for agent output.
-
-    Args:
-        quiet: True to hide tool calls and results, False to show them.
-
-    Returns:
-        None
-
-    """
+    """Set quiet mode for agent output."""
     _state.quiet_mode = quiet
 
 
 def get_quiet_mode() -> bool:
-    """Get current quiet mode setting.
-
-    Returns:
-        True if quiet mode is enabled, False otherwise.
-
-    """
+    """Get current quiet mode setting."""
     return _state.quiet_mode
 
 
 def set_non_interactive(value: bool) -> None:
-    """Set non-interactive mode for prompts.
-
-    Args:
-        value: True to take each prompt's safe default without reading stdin.
-
-    Returns:
-        None
-
-    """
+    """Set non-interactive mode for prompts."""
     _state.non_interactive = value
 
 
 def get_non_interactive() -> bool:
-    """Get current non-interactive mode setting.
-
-    Returns:
-        True if non-interactive mode is enabled, False otherwise.
-
-    """
+    """Get current non-interactive mode setting."""
     return _state.non_interactive
 
 
@@ -166,10 +113,6 @@ def set_assume(value: str | None) -> None:
         value: ``"yes"`` to auto-approve gates (``--yes``), ``"no"`` to auto-decline,
             or ``None`` for no assumption (gates fall back to prompting or their
             unattended safe default).
-
-    Returns:
-        None
-
     """
     _state.assume = value
 
@@ -179,7 +122,6 @@ def get_assume() -> str | None:
 
     Returns:
         ``"yes"``, ``"no"``, or ``None`` when no assumption is set.
-
     """
     return _state.assume
 
@@ -200,7 +142,6 @@ def resolve_gate(*, assume: str | None, interactive: bool, safe_default: bool) -
     Returns:
         ``True``/``False`` to use the resolved answer directly, or ``None`` when
         the caller should fall back to an interactive prompt.
-
     """
     if assume is not None:
         return assume == "yes"
@@ -236,7 +177,6 @@ def resolve_or_prompt(
 
     Returns:
         ``True`` if the gate is approved, ``False`` if declined.
-
     """
     decision = resolve_gate(assume=assume, interactive=interactive, safe_default=safe_default)
     if decision is None:
@@ -246,35 +186,12 @@ def resolve_or_prompt(
 
 
 def set_shutdown_requested(requested: bool) -> None:
-    """Set shutdown requested flag.
-
-    Args:
-        requested: True to indicate shutdown has been requested, False otherwise.
-
-    Returns:
-        None
-
-    """
+    """Set shutdown requested flag."""
     _state.shutdown_requested = requested
 
 
-def get_shutdown_requested() -> bool:
-    """Get shutdown requested flag.
-
-    Returns:
-        True if shutdown has been requested, False otherwise.
-
-    """
-    return _state.shutdown_requested
-
-
 def get_current_backends() -> list[Backend]:
-    """Get all currently running backends.
-
-    Returns:
-        List of active backend instances.
-
-    """
+    """Get all currently running backends."""
     return list(_state.current_backends)
 
 
@@ -284,13 +201,6 @@ def detect_test_success(output: str) -> bool:
     Extracts structured pass/fail counts first (tolerating "N tests failed"
     wording and any separator between counts), then falls through to sentinel
     pass-phrases emitted by tooling or agents.
-
-    Args:
-        output: Agent output containing test results
-
-    Returns:
-        True if tests clearly passed, False otherwise
-
     """
     if not output:
         return False
@@ -360,13 +270,6 @@ def is_environmental_failure(test_output: str) -> bool:
     reachable). Used to short-circuit the heal loop: re-running an agent fix turn
     cannot bring up a Postgres/Redis container, so an environmental failure must
     abort rather than burn turns on a non-code problem.
-
-    Args:
-        test_output: Test/agent output to inspect.
-
-    Returns:
-        True if the output carries an infrastructure-unavailable signature.
-
     """
     if not test_output:
         return False
@@ -446,7 +349,6 @@ async def run_agent(
         MissingSkillError: If a required skill is not available.
         TypeError: If the keyword-only ``phase`` argument is not provided
             (raised by the Python interpreter at call time).
-
     """
     output_parts: list[str] = []
     structured_result: Any = None

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -69,7 +69,6 @@ class AgentState:
     quiet_mode: bool = False
     non_interactive: bool = False
     assume: str | None = None
-    shutdown_requested: bool = False
     current_backends: list[Backend] = field(default_factory=list)
 
 
@@ -183,11 +182,6 @@ def resolve_or_prompt(
         response = prompt_user(console, question, default)
         decision = response.strip().lower() in ("y", "yes")
     return decision
-
-
-def set_shutdown_requested(requested: bool) -> None:
-    """Set shutdown requested flag."""
-    _state.shutdown_requested = requested
 
 
 def get_current_backends() -> list[Backend]:

--- a/daydream/archive/_schema.py
+++ b/daydream/archive/_schema.py
@@ -151,11 +151,6 @@ def _alter_add_missing(
     Missing columns are added idempotently; a ``duplicate column name`` error
     (raised by a race between concurrent openers) is silently swallowed, which
     preserves the warn-and-continue semantics of the callers it replaces.
-
-    Args:
-        conn: An open SQLite connection.
-        table: Name of the table to inspect and alter.
-        migrations: Ordered list of ``(col, col_type)`` pairs to apply.
     """
     existing = {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}  # noqa: S608 - table is a module-local constant at every call site
     for col, col_type in migrations:
@@ -197,9 +192,6 @@ def _recreate_label_observations_if_stale(conn: sqlite3.Connection) -> None:
     label rows are discarded (spec-sanctioned — repopulate via ``harvest``). The
     ``runs`` table is never touched. Idempotent: after a recreate both columns
     exist, so subsequent calls are a no-op.
-
-    Args:
-        conn: An open connection whose ``label_observations`` table exists.
     """
     existing = {row[1] for row in conn.execute("PRAGMA table_info(label_observations)").fetchall()}
     if existing and ("valid_at" not in existing or "has_posterior" not in existing):
@@ -220,9 +212,6 @@ def _migrate_label_observations_schema(conn: sqlite3.Connection) -> None:
     ``source`` precedence marker is additive, so pre-existing rows are preserved
     and default to ``'auto'``. Delegates to ``_alter_add_missing`` (the shared
     helper that also backs ``_migrate_schema`` for the runs table).
-
-    Args:
-        conn: An open connection whose ``label_observations`` table exists.
     """
     _alter_add_missing(
         conn,

--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -117,12 +117,6 @@ def canonical_utc_iso(ts: str) -> str:
     instant, so conversion is always chronologically correct. Idempotent for
     already-canonical input.
 
-    Args:
-        ts: ISO-8601 timestamp string with an explicit UTC offset.
-
-    Returns:
-        The canonical UTC spelling of the same instant.
-
     Raises:
         ValueError: When *ts* is not parseable ISO-8601, or is naive (no
             offset) — a naive timestamp names no single instant, so it cannot
@@ -149,12 +143,6 @@ def normalize_as_of(value: str) -> str:
     hours invites irreproducible corpora, so the input must already be UTC
     (``Z`` or ``+00:00``, any sub-second precision).
 
-    Args:
-        value: User-supplied ISO-8601 timestamp string.
-
-    Returns:
-        The canonical UTC spelling (``+00:00`` suffix).
-
     Raises:
         ValueError: When *value* is not parseable ISO-8601, is naive, or
             carries a non-UTC offset.
@@ -173,9 +161,6 @@ def _get_connection(archive_dir: Path) -> sqlite3.Connection:
 
     Enables WAL mode for concurrent read access and sets a busy timeout
     to handle contention from parallel daydream runs.
-
-    Args:
-        archive_dir: Path to the archive root (e.g. ``~/.daydream/archive``).
 
     Returns:
         An open sqlite3.Connection with row_factory set to sqlite3.Row.
@@ -203,10 +188,6 @@ def upsert_run(archive_dir: Path, manifest: Manifest) -> None:
 
     Bool fields (review_only, deep, loop) are mapped to integers (0/1)
     for SQLite storage.
-
-    Args:
-        archive_dir: Path to the archive root.
-        manifest: The Manifest to index.
     """
     conn = _get_connection(archive_dir)
     try:
@@ -451,14 +432,9 @@ def latest_label_observation(
     reproducible corpus pinning.
 
     Args:
-        archive_dir: Path to the archive root.
-        session_id: Full session UUID.
         as_of: Optional ISO 8601 cutoff timestamp in the canonical UTC
             spelling (see :func:`normalize_as_of` — the entry boundary
             normalizes once; this lexical cutoff assumes canonical input).
-
-    Returns:
-        The row as a dict, or ``None`` when no matching observation exists.
     """
     conn = _get_connection(archive_dir)
     try:
@@ -498,8 +474,6 @@ def bulk_latest_label_observations(
     :func:`latest_label_observation`.
 
     Args:
-        archive_dir: Path to the archive root.
-        session_ids: Collection of session UUIDs to look up.
         as_of: Optional ISO 8601 cutoff timestamp in the canonical UTC
             spelling (see :func:`normalize_as_of` — the entry boundary
             normalizes once; this lexical cutoff assumes canonical input).
@@ -581,7 +555,6 @@ def reviewer_set_penalty_prior(
     bad row never crashes the aggregate.
 
     Args:
-        archive_dir: Path to the archive root.
         logins: The current run's reviewer set. Empty → no pool.
         before_valid_at: ISO 8601 strict upper bound on ``valid_at``.
             Canonicalized via :func:`canonical_utc_iso` so the lexical ``<``
@@ -698,10 +671,6 @@ def reviewer_set_penalty_prior(
 def label_observation_history(archive_dir: Path, session_id: str) -> list[dict]:
     """Return the full label history for ``session_id`` in chronological order.
 
-    Args:
-        archive_dir: Path to the archive root.
-        session_id: Full session UUID.
-
     Returns:
         List of row dicts ordered by ``observed_at`` ascending.
     """
@@ -726,11 +695,6 @@ def update_labels(archive_dir: Path, session_id: str, labels: list[str]) -> bool
     ``daydream label``. The session_id can be a prefix (e.g. first 8 chars of
     the UUID). If the prefix matches exactly one row, that row is updated. If it
     matches multiple rows, a ValueError is raised asking for a longer prefix.
-
-    Args:
-        archive_dir: Path to the archive root.
-        session_id: Full or prefix session ID to match.
-        labels: List of label strings to set.
 
     Returns:
         True if a row was updated, False if no matching session was found.
@@ -781,12 +745,6 @@ def set_run_pr_link(archive_dir: Path, session_id: str, pr_number: int, pr_repo:
     ``pr_repo`` columns on the ``runs`` table and never writes to
     ``label_observations`` or any cache column. A zero-row match (no such
     ``session_id``) is a silent no-op; the caller guarantees the row exists.
-
-    Args:
-        archive_dir: Path to the archive root.
-        session_id: Full session ID of the run to link.
-        pr_number: Resolved PR number to record.
-        pr_repo: Resolved PR repository slug (``owner/name``) to record.
     """
     conn = _get_connection(archive_dir)
     try:
@@ -803,13 +761,9 @@ def query_runs(archive_dir: Path, where: str = "", params: tuple = ()) -> list[d
     """Query the runs index with an optional WHERE clause.
 
     Args:
-        archive_dir: Path to the archive root.
         where: Optional SQL WHERE clause (without the ``WHERE`` keyword).
             Example: ``"repo_slug = ? AND status = ?"``.
         params: Parameter tuple to bind to the WHERE clause placeholders.
-
-    Returns:
-        List of row dicts, one per matching run.
     """
     conn = _get_connection(archive_dir)
     try:
@@ -841,7 +795,6 @@ def pr_attached_label_coverage(
     yields ``coverage`` ``0.0`` rather than raising ``ZeroDivisionError``.
 
     Args:
-        archive_dir: Path to the archive root.
         as_of: Optional ISO 8601 cutoff; threaded through to
             :func:`bulk_latest_label_observations` so only observations whose
             ``observed_at <= as_of`` are considered (reproducible pinning).
@@ -900,7 +853,6 @@ def label_count_summary(
     :func:`latest_label_observation` once per run.
 
     Args:
-        archive_dir: Path to the archive root.
         as_of: Optional ISO 8601 cutoff timestamp. When ``None``, the
             most recent observation for each session is used regardless of
             ``observed_at``.
@@ -968,12 +920,8 @@ def count_runs(archive_dir: Path, where: str = "", params: tuple = ()) -> int:
     Uses ``SELECT COUNT(*)`` so no rows are materialised.
 
     Args:
-        archive_dir: Path to the archive root.
         where: Optional SQL WHERE clause (without the ``WHERE`` keyword).
         params: Parameter tuple to bind to the WHERE clause placeholders.
-
-    Returns:
-        Integer count of matching rows.
     """
     conn = _get_connection(archive_dir)
     try:

--- a/daydream/backends/__init__.py
+++ b/daydream/backends/__init__.py
@@ -313,7 +313,6 @@ def create_backend(name: str, model: str | None = None) -> Backend:
 
     Raises:
         ValueError: If the backend name is unknown.
-
     """
     from daydream.config import DEFAULT_CLAUDE_MODEL, DEFAULT_CODEX_MODEL, DEFAULT_PI_MODEL
 

--- a/daydream/backends/claude.py
+++ b/daydream/backends/claude.py
@@ -285,9 +285,6 @@ class ClaudeBackend:
         """Execute a prompt and yield unified events.
 
         Args:
-            cwd: Working directory for the agent.
-            prompt: The prompt to send.
-            output_schema: Optional JSON schema for structured output.
             continuation: Ignored by Claude backend.
             agents: Optional mapping of specialist name -> AgentDefinition for
                 subagent support. Keys are the specialist names the lead agent
@@ -298,13 +295,9 @@ class ClaudeBackend:
                 — under ``bypassPermissions`` ``allowed_tools`` does not restrict
                 the toolset — so the tool list is left unchanged.
 
-        Yields:
-            AgentEvent instances.
-
         Raises:
             ClaudeAgentError: If the agent run ends with an error result
                 (``ResultMessage.is_error``), e.g. an invalid API key.
-
         """
         output_format = (
             {"type": "json_schema", "schema": output_schema}
@@ -455,14 +448,6 @@ class ClaudeBackend:
         """Format a skill invocation for Claude.
 
         Claude uses /{namespace:skill} syntax.
-
-        Args:
-            skill_key: Full skill key (e.g. "beagle-python:review-python").
-            args: Optional arguments string.
-
-        Returns:
-            Formatted skill invocation string.
-
         """
         result = f"/{skill_key}"
         if args:

--- a/daydream/backends/codex.py
+++ b/daydream/backends/codex.py
@@ -90,10 +90,6 @@ class CodexBackend:
         """Execute a prompt via Codex CLI and yield unified events.
 
         Args:
-            cwd: Working directory for the agent.
-            prompt: The prompt to send.
-            output_schema: Optional JSON schema for structured output.
-            continuation: Optional token for thread resumption.
             agents: Optional subagent mapping. Codex does not support non-empty
                 subagent maps and will raise if provided.
             read_only: When True, run under ``--sandbox read-only`` so the agent
@@ -103,14 +99,10 @@ class CodexBackend:
                 the working tree — the failure-handoff incident's danger — is
                 fully protected. Default False keeps ``danger-full-access``.
 
-        Yields:
-            AgentEvent instances.
-
         Raises:
             CodexError: If the Codex turn fails.
             NotImplementedError: If ``agents`` is non-empty (Codex backend
                 does not support exploration subagents).
-
         """
         if agents:
             raise NotImplementedError(
@@ -488,14 +480,6 @@ class CodexBackend:
         """Format a skill invocation for Codex.
 
         Codex uses $skill-name syntax. Strips namespace prefix if present.
-
-        Args:
-            skill_key: Full skill key (e.g. "beagle-python:review-python").
-            args: Optional arguments string.
-
-        Returns:
-            Formatted skill invocation string.
-
         """
         if ":" in skill_key:
             skill_name = skill_key.split(":")[-1]

--- a/daydream/backends/pi.py
+++ b/daydream/backends/pi.py
@@ -378,8 +378,6 @@ class PiBackend:
         """Execute a prompt via the Pi CLI and yield unified events.
 
         Args:
-            cwd: Working directory for the agent (passed as the process ``cwd``).
-            prompt: The prompt to send (Pi's positional argument).
             output_schema: Optional JSON schema for structured output. Pi has no
                 native schema flag, so the schema is appended to the prompt and
                 the final assistant text is parsed as JSON at ``agent_end``.
@@ -396,14 +394,10 @@ class PiBackend:
             read_only: When True, restricts Pi's tools to the read-only subset
                 (``read,find,ls,grep``) so the agent cannot write/edit/bash.
 
-        Yields:
-            AgentEvent instances.
-
         Raises:
             PiError: If a Pi turn ends with ``stopReason == "error"``.
             NotImplementedError: If ``agents`` is non-empty (Pi backend does not
                 support exploration subagents).
-
         """
         if agents:
             raise NotImplementedError(
@@ -697,14 +691,6 @@ class PiBackend:
         directory is registered with the subprocess in :meth:`execute` via a
         ``--skill`` flag so the command resolves even without an ambient
         mirror. This method never raises.
-
-        Args:
-            skill_key: Full skill key (e.g. "beagle-python:review-python").
-            args: Optional arguments string.
-
-        Returns:
-            Formatted skill invocation string (``/skill:<slug>`` plus args).
-
         """
         base = f"/skill:{_skill_slug(skill_key)}"
         if args:

--- a/daydream/benchmark/acquire.py
+++ b/daydream/benchmark/acquire.py
@@ -45,16 +45,6 @@ def acquire_checkout(
     the base SHA is fetched if still unresolvable, and HEAD is detached onto
     *head_sha*.
 
-    Args:
-        clone_url: Remote URL or local path to clone from.
-        pr_number: Pull request number whose head to acquire.
-        base_sha: Base commit SHA; must end up resolvable in the checkout.
-        head_sha: Head commit SHA to detach HEAD onto.
-        cache_dir: Directory under which the per-PR checkout lives.
-
-    Returns:
-        Path to the checkout directory (HEAD detached at *head_sha*).
-
     Raises:
         GitError: If any git step fails, or HEAD does not land on *head_sha*.
     """

--- a/daydream/benchmark/benchmark_data.py
+++ b/daydream/benchmark/benchmark_data.py
@@ -26,9 +26,6 @@ DAYDREAM_TOOL = "daydream"
 def load_benchmark_data(path: str | Path) -> dict[str, Any]:
     """Load the benchmark corpus from ``path``.
 
-    Args:
-        path: Filesystem path to ``benchmark_data.json``.
-
     Returns:
         The parsed top-level dict, keyed by golden PR URL.
     """
@@ -49,10 +46,6 @@ def save_benchmark_data(path: str | Path, data: dict[str, Any]) -> None:
     and the second ``os.replace`` wins. The lock does not protect across
     machines or network filesystems — run one bench sweep per benchmark repo
     at a time (see ``docs/benchmark.md``).
-
-    Args:
-        path: Destination path for ``benchmark_data.json``.
-        data: The corpus dict to serialize.
     """
     dest = Path(path)
     lock_path = dest.parent / f"{dest.name}.lock"
@@ -73,15 +66,7 @@ def save_benchmark_data(path: str | Path, data: dict[str, Any]) -> None:
 
 
 def has_daydream_review(entry: dict[str, Any], *, tool: str = DAYDREAM_TOOL) -> bool:
-    """Report whether a corpus entry already carries a synthetic daydream review.
-
-    Args:
-        entry: A single golden-PR corpus entry (the value of one ``golden_url`` key).
-        tool: The reviewer tool label to match (defaults to ``DAYDREAM_TOOL``).
-
-    Returns:
-        ``True`` if any review in ``entry["reviews"]`` has ``tool == tool``.
-    """
+    """Report whether a corpus entry already carries a synthetic daydream review."""
     return any(review.get("tool") == tool for review in entry.get("reviews", []))
 
 
@@ -97,12 +82,8 @@ def inject_daydream_review(
 
     Args:
         data: The benchmark corpus dict (mutated in place).
-        golden_url: The golden upstream PR URL key.
-        comments: ``review_comments`` payload for the daydream review.
         force: When a daydream review already exists, replace its
             ``review_comments`` instead of leaving it untouched.
-        tool: The reviewer tool label to inject and match on (defaults to
-            ``DAYDREAM_TOOL``).
 
     Returns:
         ``True`` if the corpus was modified, ``False`` if an existing daydream

--- a/daydream/benchmark/cli.py
+++ b/daydream/benchmark/cli.py
@@ -32,9 +32,6 @@ def _load_bench_dotenv() -> None:
 def _format_elapsed(seconds: float) -> str:
     """Render an elapsed duration as a compact human string.
 
-    Args:
-        seconds: Elapsed wall-clock seconds.
-
     Returns:
         ``"{n}s"`` for durations under a minute, else ``"{m}m{s}s"`` with the
         seconds component not zero-padded (e.g. ``252`` -> ``"4m12s"``).
@@ -205,7 +202,6 @@ def _resolve_reviewer_preset(
     """Look up a named reviewer preset in the bench config table.
 
     Args:
-        name: The preset name passed via ``--reviewer``.
         bench_cfg: The ``[tool.daydream.bench]`` table from ``load_file_config``.
         parser: The bench parser, used to emit a usage error (``SystemExit``)
             when the preset is unknown.
@@ -227,12 +223,6 @@ def _bench_config_from_argv(argv: list[str]) -> "BenchConfig":
 
     Optional path flags fall back to a ``.daydream-bench`` cache derived from
     ``--benchmark-repo``. No directories are created at parse time.
-
-    Args:
-        argv: The argument vector after the ``bench`` verb.
-
-    Returns:
-        An immutable :class:`BenchConfig` for the requested run.
     """
     from daydream.benchmark import BenchConfig
     from daydream.config_file import load_file_config
@@ -323,12 +313,6 @@ def _handle_bench_command(argv: list[str]) -> int:
     exit. When ``--score`` is set, ``run_bench`` verifies the judge credential
     up front and raises :class:`~daydream.benchmark.score.JudgeEnvError` if it is missing; that error
     is allowed to surface to the top-level CLI boundary as a non-zero exit.
-
-    Args:
-        argv: The argument vector after the ``bench`` verb.
-
-    Returns:
-        The exit code from :func:`run_bench`.
     """
     from daydream.benchmark import run_bench
 

--- a/daydream/benchmark/orchestrator.py
+++ b/daydream/benchmark/orchestrator.py
@@ -130,7 +130,6 @@ def _run_sweep(config: BenchConfig, judge_model: str) -> tuple[bool, DaydreamSco
     this runs, so ``judge_model`` is already resolved (``""`` when not scoring).
 
     Args:
-        config: Run configuration for this sweep (paths, tool label, scoring).
         judge_model: Pre-resolved judge model id (``""`` when ``score`` is off).
 
     Returns:
@@ -262,15 +261,9 @@ def _write_trials_summary(
     """Write ``trials-summary.json`` with reproducibility metadata + distribution.
 
     Args:
-        config: The base run configuration (reviewer/judge/PR selection).
-        judge_model: The resolved judge model id (``""`` when scoring was off).
-        prs: The selected PR set for this run.
         scored_trials: ``(trial_index, scores)`` pairs for each successfully
             scored trial, so ``per_trial`` labels stay accurate even when some
             trials failed scoring and are absent from the list.
-
-    Returns:
-        The path to the written ``trials-summary.json``.
     """
     root = trials_root(config.benchmark_repo, config.tool_label)
     root.mkdir(parents=True, exist_ok=True)
@@ -367,9 +360,6 @@ def run_bench(config: BenchConfig) -> int:
     (back-compat). With ``config.trials > 1`` it runs N isolated trials and
     reports a mean/median/stddev/bootstrap-CI distribution over precision,
     recall, and F1.
-
-    Args:
-        config: Immutable run configuration (selection, force, scoring, paths).
 
     Returns:
         ``0`` when every selected PR was injected (or skipped) and scoring (if

--- a/daydream/benchmark/score.py
+++ b/daydream/benchmark/score.py
@@ -130,9 +130,6 @@ def resolve_judge_model(model: str | None) -> str:
     with an unnamed judge would silently grade against whatever model the
     harness defaults to, in a directory we did not name.
 
-    Args:
-        model: Explicit judge model id from ``--model`` (or ``None``).
-
     Returns:
         The resolved judge model id (``model`` if given, else ``MARTIAN_MODEL``).
 
@@ -158,11 +155,7 @@ def model_results_dir(benchmark_repo: Path, model: str) -> Path:
     the harness actually wrote.
 
     Args:
-        benchmark_repo: Path to the external benchmark checkout.
         model: Resolved judge model id (see `resolve_judge_model`).
-
-    Returns:
-        The `results/<sanitized-model>` directory path.
     """
     return benchmark_repo / "results" / model.strip().replace("/", "_")
 
@@ -202,7 +195,6 @@ def _summarize_judge_errors(errors: list[str], *, cap: int = 3) -> str:
     """Render distinct judge error strings with occurrence counts, most-common first.
 
     Args:
-        errors: The verbatim per-comparison error strings collected from the leaves.
         cap: Maximum number of distinct messages to spell out before summarizing
             the remainder as a count.
 
@@ -229,10 +221,6 @@ def parse_daydream_scores(evals: dict[str, dict[str, Any]], *, tool: str = _TOOL
 
     Args:
         evals: The parsed `evaluations.json` object — golden PR URL → tool → leaf.
-        tool: Results label to extract (defaults to ``_TOOL``).
-
-    Returns:
-        A `DaydreamScores` capturing per-PR tool leaves and the aggregate.
 
     Raises:
         JudgeFailedError: If the judge errored on at least
@@ -308,8 +296,6 @@ def _run_step(module: str, extra_args: list[str], *, cwd: Path, tool: str = _TOO
     Args:
         module: Dotted module path (e.g. `code_review_benchmark.step3_judge_comments`).
         extra_args: Module-specific CLI arguments appended after `--tool <tool>`.
-        cwd: The benchmark repo directory.
-        tool: Results label passed as `--tool` (defaults to ``_TOOL``).
         judge_model: Resolved judge model exported as `MARTIAN_MODEL` for the step.
 
     Raises:
@@ -378,15 +364,9 @@ def run_scoring(
     caller (``run_bench``) before any expensive reviews run.
 
     Args:
-        benchmark_repo: Path to the external benchmark checkout.
         judge_model: Resolved judge model id (see `resolve_judge_model`).
         pr_count: When provided, bounds how many PR reviews the judge evaluates
             (passed as ``--limit`` to Martian step3).
-        tool: Results label under evaluation (defaults to ``_TOOL``).
-        judge_route: ``"martian"`` or ``"anthropic-direct"``.
-
-    Returns:
-        The parsed `DaydreamScores`.
 
     Raises:
         BenchmarkStepError: If scoring fails.

--- a/daydream/benchmark/stats.py
+++ b/daydream/benchmark/stats.py
@@ -69,10 +69,7 @@ def bootstrap_ci(
     reruns get identical endpoints).
 
     Args:
-        values: The per-trial metric values (at least one).
-        n_boot: Number of bootstrap resamples.
         ci: Central probability mass to bracket (e.g. 0.95 → 2.5%/97.5%).
-        seed: RNG seed for reproducibility.
 
     Returns:
         ``(ci_low, ci_high)``. When ``values`` has a single element (or zero
@@ -122,13 +119,6 @@ def _metric_stats(values: list[float], *, seed: int = _DEFAULT_SEED) -> MetricSt
 def compute_distribution(scores: list[DaydreamScores], *, seed: int = _DEFAULT_SEED) -> TrialDistribution:
     """Aggregate N trials' scores into per-metric summary statistics.
 
-    Args:
-        scores: One :class:`DaydreamScores` per trial (at least one).
-        seed: RNG seed forwarded to the bootstrap CI.
-
-    Returns:
-        A :class:`TrialDistribution` with precision/recall/F1 statistics.
-
     Raises:
         ValueError: If ``scores`` is empty.
     """
@@ -144,9 +134,6 @@ def compute_distribution(scores: list[DaydreamScores], *, seed: int = _DEFAULT_S
 
 def format_distribution_table(dist: TrialDistribution) -> str:
     """Render a :class:`TrialDistribution` as a fixed-width text table.
-
-    Args:
-        dist: The aggregated distribution.
 
     Returns:
         A multi-line string with a header row and one row per metric carrying

--- a/daydream/benchmark/trial_isolation.py
+++ b/daydream/benchmark/trial_isolation.py
@@ -38,7 +38,6 @@ def init_trial_corpus(canonical_data_path: Path, trial_dir: Path) -> Path:
     The trial's reviews are injected there, keeping the canonical corpus pristine.
 
     Args:
-        canonical_data_path: Path to the canonical ``results/benchmark_data.json``.
         trial_dir: The per-trial dir (see :func:`trial_corpus_dir`).
 
     Returns:

--- a/daydream/bot_setup.py
+++ b/daydream/bot_setup.py
@@ -84,10 +84,6 @@ def _manifest_payload(*, redirect_url: str, org: str | None) -> dict[str, object
 def _manifest_form_html(*, action_url: str, manifest: dict[str, object]) -> str:
     """Render an auto-submitting HTML form POSTing the manifest to GitHub.
 
-    Args:
-        action_url: GitHub's app-creation URL (org variant when org-scoped).
-        manifest: The manifest payload to POST as the ``manifest`` field.
-
     Returns:
         A self-contained HTML page that submits on load.
     """
@@ -152,9 +148,6 @@ class _ManifestListener:
 
     def serve(self) -> tuple[AppCredentials, str]:
         """Bind a localhost port, open the browser, and block on the callback.
-
-        Returns:
-            The exchanged ``(credentials, slug)`` tuple.
 
         Raises:
             GitHubAppError: If the operator declined or the exchange failed.
@@ -647,13 +640,6 @@ def run_verify(repo_dir: Path, *, scope: Scope) -> VerifyResult:
     This is strictly read-only: it never sets a secret, variable, or file. Each
     failed required check's ``detail`` names the exact missing element and the
     remediation; :attr:`VerifyResult.ok` is True iff every required check passed.
-
-    Args:
-        repo_dir: Repository working directory (ambient ``gh``/``git`` context).
-        scope: Repo- or org-scoped target (exactly one).
-
-    Returns:
-        The aggregated :class:`VerifyResult`.
     """
     creds = resolve_credentials()
     checks = (
@@ -697,11 +683,6 @@ def _confirm_installation(repo_dir: Path, scope: Scope, creds: AppCredentials) -
     happened (e.g. an org-wide App) is auto-satisfied without prompting — this
     is what lets the real-path test drive the full-auto flow without blocking
     on stdin.
-
-    Args:
-        repo_dir: Working directory (``gh`` subprocess context).
-        scope: Repo- or org-scoped target (the owner is derived from it).
-        creds: The freshly registered App credentials (App-JWT auth).
 
     Returns:
         True if the owner appears in the installations after at most one wait.

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -40,7 +40,6 @@ from daydream import git_ops
 from daydream.agent import (
     console,
     get_current_backends,
-    set_shutdown_requested,
 )
 from daydream.benchmark.cli import _handle_bench_command
 from daydream.config_file import load_file_config
@@ -88,7 +87,6 @@ def _signal_handler(signum: int, frame: object) -> None:
     set, so ContextVar reads from here are non-deterministic.
     """
     signal_name = signal.Signals(signum).name
-    set_shutdown_requested(True)
 
     # Flush partial trajectory before tearing down (D-07); write_partial is sync
     # and exception-safe, so it can't crash the shutdown path.

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -70,14 +70,6 @@ def _first_verb(argv: list[str]) -> str:
     argv, a leading flag, and a bare target path — so a plain
     ``daydream /path`` routes through the same parser as ``daydream review
     /path``.
-
-    Args:
-        argv: The raw argument list (``sys.argv[1:]``).
-
-    Returns:
-        str: The dispatched verb name (a member of :data:`KNOWN_VERBS` or
-        ``"review"``).
-
     """
     if argv and argv[0] in KNOWN_VERBS:
         return argv[0]
@@ -127,10 +119,6 @@ def _auto_detect_pr_number(repo: Path) -> int | None:
         repo: Repository working directory to inspect — the target checkout
             being reviewed, not necessarily the cwd where ``daydream`` was
             launched.
-
-    Returns:
-        The PR number if found, or None if detection fails.
-
     """
     try:
         data = git_ops.gh_pr_view(repo, None)
@@ -151,9 +139,6 @@ def _detect_repo_slug(repo: Path) -> str | None:
             launched. Attributing the slug to the target keeps trajectory and
             archive provenance correct when daydream is run from one repo
             against a checkout of another (the benchmark-harness pattern).
-
-    Returns:
-        String like ``"owner/repo"``, or None if detection fails.
     """
     try:
         slug = git_ops.gh_repo_view(repo)
@@ -415,9 +400,6 @@ def _handle_build_corpus_command(argv: list[str]) -> int:
     lineage-manifest write). Returns an exit code rather than calling
     :func:`sys.exit`; ``main()`` is responsible for translating the code into a
     process exit. This keeps the handler easy to drive from tests.
-
-    Args:
-        argv: The argument vector after the ``corpus build`` sub-verb.
 
     Returns:
         ``0`` on success; ``1`` on a validation error.
@@ -798,13 +780,6 @@ def _parse_args(argv: list[str] | None = None) -> RunConfig:
     selection flags (``--branch`` / ``--base``), and modifiers (``--worktree`` /
     ``--shallow`` / ``--copy``). Deep is the default; ``--shallow`` opts into
     single-stack mode.
-
-    Args:
-        argv: Optional list of arguments. Defaults to ``sys.argv[1:]`` when None.
-
-    Returns:
-        RunConfig: Configuration object populated from command line arguments.
-
     """
     raw_argv = sys.argv[1:] if argv is None else list(argv)
 
@@ -1053,9 +1028,6 @@ def _handle_harvest_command(argv: list[str]) -> int:
     harvest errors do not escalate to a non-zero exit — the summary's
     ``errors`` counter surfaces them.
 
-    Args:
-        argv: The argument vector after the ``corpus harvest`` sub-verb.
-
     Returns:
         ``0`` on success; ``1`` on a validation error.
     """
@@ -1145,9 +1117,6 @@ def _handle_label_command(argv: list[str]) -> int:
     observation via :func:`daydream.archive.index.update_labels`. The runs
     cache and every precedence projection settle on the human value.
 
-    Args:
-        argv: The argument vector after the ``corpus label`` sub-verb.
-
     Returns:
         ``0`` on success; ``1`` when no session matches the prefix or the
         prefix is ambiguous.
@@ -1222,9 +1191,6 @@ def _handle_corpus_command(argv: list[str]) -> int:
     corpus`` (no sub-verb) prints help to stdout and exits 2. An unknown
     sub-verb prints help to stderr and exits 2. Exit codes propagate
     unchanged from the handlers.
-
-    Args:
-        argv: The argument vector after the ``corpus`` verb.
 
     Returns:
         int: The sub-handler's exit code; ``2`` for a bare (no-arg)
@@ -1345,9 +1311,6 @@ def _handle_ext_command(argv: list[str]) -> int:
     sub-verb (or trailing arguments — ``validate`` takes none) prints help to
     stderr and exits 2.
 
-    Args:
-        argv: The argument vector after the ``ext`` verb.
-
     Returns:
         int: The sub-handler's exit code; ``2`` for a bare (no-arg)
         invocation or an unknown sub-verb.
@@ -1415,9 +1378,6 @@ def _handle_post_findings_command(argv: list[str]) -> int:
     validate (confused-deputy gate, before any GitHub write), reconcile
     against prior comments, minimize stale findings, post new ones. Sync: no
     agent work, no ATIF trajectory.
-
-    Args:
-        argv: The argument vector after the ``post-findings`` verb.
 
     Returns:
         ``0`` on success (including "no new findings"); ``1`` on validation,
@@ -1499,9 +1459,6 @@ def _handle_setup_command(argv: list[str]) -> int:
     ``GitHubAppError``/``GitError`` are caught here and surfaced via
     :func:`print_error` — never a traceback to the user.
 
-    Args:
-        argv: The argument vector after the ``setup`` verb.
-
     Returns:
         ``0`` on success; ``1`` on a verify failure or any setup error.
     """
@@ -1549,9 +1506,6 @@ def main() -> None:
           and land the workflows via a PR (``--verify`` for the doctor)
         - ``ext`` — extension namespace (``validate`` loads the
           ``daydream_ext`` extension and resolve-checks the registry)
-
-    Returns:
-        None: This function does not return; it exits via sys.exit().
 
     Raises:
         SystemExit: Always raised with exit code 0 on success, 130 on keyboard

--- a/daydream/config_file.py
+++ b/daydream/config_file.py
@@ -51,25 +51,11 @@ class DaydreamFileConfig:
     precision_mode: bool | None = None
 
     def phase_model(self, phase: str) -> str | None:
-        """Return the configured model for a phase.
-
-        Args:
-            phase: Phase name to look up (e.g. ``"fix"``).
-
-        Returns:
-            The configured model, or None if the phase has no ``model`` key.
-        """
+        """Return the configured model for a phase."""
         return self.phases.get(phase, {}).get("model")
 
     def phase_backend(self, phase: str) -> str | None:
-        """Return the configured backend for a phase.
-
-        Args:
-            phase: Phase name to look up (e.g. ``"fix"``).
-
-        Returns:
-            The configured backend, or None if the phase has no ``backend`` key.
-        """
+        """Return the configured backend for a phase."""
         return self.phases.get(phase, {}).get("backend")
 
 
@@ -79,12 +65,6 @@ def load_toml_or_empty(path: Path) -> dict[str, Any]:
     Never raises: callers that must not break on a bad user file (e.g. price
     overrides, workspace copy config) use this instead of the error-raising
     :func:`_load_toml`.
-
-    Args:
-        path: Path to the TOML file.
-
-    Returns:
-        The parsed table, or an empty dict if the file is absent or malformed.
 
     Raises:
         Never. Malformed TOML is logged as a warning and yields ``{}``.
@@ -103,13 +83,7 @@ def load_toml_or_empty(path: Path) -> dict[str, Any]:
 
 
 def _load_toml(path: Path) -> dict[str, Any]:
-    """Parse a TOML file into a dict.
-
-    Args:
-        path: Path to the TOML file.
-
-    Returns:
-        The parsed table, or an empty dict if the file is absent.
+    """Parse a TOML file into a dict, returning ``{}`` when the file is absent.
 
     Raises:
         ValueError: If the file exists but is malformed; the message names
@@ -187,13 +161,7 @@ def load_file_config(root: Path) -> DaydreamFileConfig:
     Reads ``root/pyproject.toml`` ``[tool.daydream]`` (low precedence) and
     ``root/.daydream.toml`` (high precedence), merging the two per-key. The
     dotfile wins on conflicting scalar keys; phase sub-tables merge so each
-    source contributes its own phases.
-
-    Args:
-        root: Repository root directory to search for config files.
-
-    Returns:
-        A ``DaydreamFileConfig``. Absent files yield an empty config.
+    source contributes its own phases. Absent files yield an empty config.
 
     Raises:
         ValueError: If a present config file is malformed TOML; the message

--- a/daydream/deep/artifacts.py
+++ b/daydream/deep/artifacts.py
@@ -31,14 +31,7 @@ _EARLIER_STAGE: dict[str, str] = {
 
 
 def deep_dir(target: Path) -> Path:
-    """Return the `.daydream/deep/` directory for `target`, creating it if absent.
-
-    Args:
-        target: Resolved target directory path.
-
-    Returns:
-        Path to `target / ".daydream" / "deep"`.
-    """
+    """Return the `.daydream/deep/` directory for `target`, creating it if absent."""
     d = target / ".daydream" / "deep"
     d.mkdir(parents=True, exist_ok=True)
     return d
@@ -174,10 +167,6 @@ def verdicts_path(deep_dir_path: Path) -> Path:
 
 def check_deep_artifacts(stage: str, deep_dir_path: Path) -> None:
     """Validate predecessor artifacts exist for the given resume stage.
-
-    Args:
-        stage: One of "ttt", "per-stack", "merge", "fix".
-        deep_dir_path: Path to the `.daydream/deep/` directory.
 
     Raises:
         ValueError: If stage is not a known deep-mode stage.

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -134,9 +134,6 @@ def total_agent_count(stack_count: int) -> int:
     Args:
         stack_count: Number of detected stack assignments (including the
             generic-fallback bucket when present).
-
-    Returns:
-        Total agent invocation count surfaced in the pre-flight notice.
     """
     return 2 + stack_count + stack_count + 1 + 1
 
@@ -160,9 +157,6 @@ def _single_stack_agent_count(stack_count: int) -> int:
 
     Args:
         stack_count: Number of stack assignments AFTER the tiny-diff collapse.
-
-    Returns:
-        Total agent invocation count for the single-stack-mode run.
     """
     return 2 + stack_count + stack_count
 
@@ -179,9 +173,6 @@ def _shallow_fanout_threshold(config: RunConfig) -> int:
 
     Uses ``is not None`` checks rather than truthiness so a configured value
     of ``0`` (explicitly disable the short-circuit) is honored.
-
-    Args:
-        config: Run configuration carrying the CLI/file-config sources.
 
     Returns:
         The resolved integer threshold. ``0`` disables the short-circuit.
@@ -208,12 +199,6 @@ def _precision_mode(config: RunConfig) -> bool:
     Uses truthiness rather than ``is not None``: ``False`` is the meaningful
     "off" value, so a set-to-False file-config entry just falls through to the
     default rather than acting as a distinct sentinel.
-
-    Args:
-        config: Run configuration carrying the CLI/file-config sources.
-
-    Returns:
-        Whether the precision suppression pass should run.
     """
     if config.precision_mode:
         return True
@@ -363,9 +348,6 @@ def _diff_changed_files(diff: str) -> list[str]:
     unified-diff parsing contract is shared with ``_diff_blocks_for_files``
     rather than duplicated here.
 
-    Args:
-        diff: Unified diff text.
-
     Returns:
         Unique, insertion-ordered list of changed file paths (excluding
         ``/dev/null`` sentinels).
@@ -388,16 +370,7 @@ def _stack_preflight_line(stack: StackAssignment) -> str:
 def _write_ttt_artifacts(
     deep_dir_path: Path, *, intent_summary: str, alt_issues: list[dict[str, Any]]
 ) -> tuple[Path, Path]:
-    """Persist TTT intent + alternatives to the deep artifact directory.
-
-    Args:
-        deep_dir_path: Path to ``.daydream/deep/``.
-        intent_summary: Confirmed intent summary from phase_understand_intent.
-        alt_issues: Issues returned by phase_alternative_review.
-
-    Returns:
-        Tuple of (intent_path, alternatives_path).
-    """
+    """Persist TTT intent + alternatives to the deep artifact directory."""
     intent_p = _intent_path(deep_dir_path)
     alts_p = _alternatives_path(deep_dir_path)
     intent_p.write_text(intent_summary)

--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -239,9 +239,6 @@ def build_per_stack_prompt(
         inline_diff: Issue #172 Fix B. Pre-extracted diff hunks for ``files``
             to inline (skips the ``Read it directly`` instruction). ``None``
             falls back to the diff_path pointer.
-
-    Returns:
-        Assembled prompt string.
     """
     parts: list[str] = []
     pointer = _exploration_pointer(exploration_dir)
@@ -295,9 +292,6 @@ def build_structural_prompt(
             body because the structural reviewer discovers context via tool
             calls, not pre-injected pointers.
         prior_commits: Oneline log of prior daydream commits on this branch.
-
-    Returns:
-        Assembled prompt string.
     """
     del exploration_dir  # accepted for signature symmetry; intentionally unused.
     joined = ", ".join(files)
@@ -351,9 +345,6 @@ def build_arbiter_prompt(
         alternatives_path: Path to TTT alternatives.json.
         cwd: Absolute working directory the agent runs in (grounds path resolution).
         exploration_dir: Pre-scan exploration directory (if available).
-
-    Returns:
-        Assembled prompt string.
     """
     parts: list[str] = []
     pointer = _exploration_pointer(exploration_dir)
@@ -419,9 +410,6 @@ def build_suppression_prompt(
         alternatives_path: Path to TTT alternatives.json.
         cwd: Absolute working directory the agent runs in (grounds path resolution).
         exploration_dir: Pre-scan exploration directory (if available).
-
-    Returns:
-        Assembled prompt string.
     """
     parts: list[str] = []
     pointer = _exploration_pointer(exploration_dir)
@@ -511,9 +499,6 @@ def build_merge_prompt(
             records JSON. Retained for call-site compatibility; structural
             findings are appended by ``phase_cross_stack_merge`` in Python (not
             via this prompt), so the agent is never pointed at this file.
-
-    Returns:
-        Assembled prompt string.
     """
     del output_path, structural_records_path  # appended/rendered by the host, not the prompt
     records_block = "\n".join(f"  - {p}" for p in per_stack_records_paths)
@@ -620,9 +605,6 @@ def build_verification_prompt(
             item's canonical ``id`` (the verdict ``issue_id``).
         cwd: Absolute working directory the verifier runs in (grounds path resolution).
         output_path: Where the verifier must write its JSON verdicts file.
-
-    Returns:
-        Assembled prompt string.
     """
     from daydream.deep.render import render_report
 
@@ -728,9 +710,6 @@ def build_generic_fallback_prompt(
         inline_diff: Issue #172 Fix B. Pre-extracted diff hunks for ``files``
             to inline (skips the ``Read it directly`` instruction). ``None``
             falls back to the diff_path pointer.
-
-    Returns:
-        Assembled prompt string.
     """
     parts: list[str] = []
     if is_docs_only:

--- a/daydream/eval/analyzer.py
+++ b/daydream/eval/analyzer.py
@@ -538,9 +538,6 @@ def analyze_session(daydream_dir: str | Path, session_id: str | None = None) -> 
         daydream_dir: Path to the ``.daydream`` directory from a completed run.
         session_id: Optional session ID (or prefix) to analyze. Defaults to the
             most recent session.
-
-    Returns:
-        Complete analysis as a JSON-serializable dict.
     """
     daydream_dir = Path(daydream_dir)
     trajectories = load_trajectories(daydream_dir, session_id=session_id)

--- a/daydream/exploration.py
+++ b/daydream/exploration.py
@@ -86,9 +86,6 @@ class ExplorationContext:
 
         Returns empty string when all fields are empty/default, so it adds
         nothing to the review prompt for unexplored contexts.
-
-        Returns:
-            Markdown-formatted exploration context, or empty string.
         """
         sections: list[str] = []
 
@@ -220,14 +217,6 @@ async def safe_explore(
 
     Catches any exception from explore_fn and returns an empty
     ExplorationContext instead. Displays a warning banner via Rich UI.
-
-    Args:
-        explore_fn: Async callable that performs exploration.
-        *args: Positional args forwarded to explore_fn.
-        **kwargs: Keyword args forwarded to explore_fn.
-
-    Returns:
-        ExplorationContext from explore_fn, or empty ExplorationContext on failure.
     """
     try:
         return await explore_fn(*args, **kwargs)
@@ -248,9 +237,6 @@ def merge_contexts(*contexts: ExplorationContext) -> ExplorationContext:
     - Dependency: keyed on (source, target, relationship).
     - guidelines: keyed on string identity.
     - raw_notes: non-empty values joined with a double newline.
-
-    Args:
-        *contexts: Any number of ExplorationContext instances.
 
     Returns:
         A new merged ExplorationContext (always a fresh instance with fresh

--- a/daydream/exploration_runner.py
+++ b/daydream/exploration_runner.py
@@ -69,9 +69,6 @@ EXPLORATION_ENVELOPE_SCHEMA: dict[str, Any] = {
 def count_changed_files(diff_text: str) -> int:
     """Count unique file paths in a unified-diff string.
 
-    Args:
-        diff_text: Raw ``git diff`` output.
-
     Returns:
         Number of unique ``a/<path>`` entries in ``diff --git`` headers.
     """
@@ -211,16 +208,12 @@ async def pre_scan(
            merge with the static context.
 
     Args:
-        backend: Backend to invoke.
         repo_root: Repository root used by ``detect_affected_files``.
         diff_text: Raw git diff string (used locally for file detection only;
             never embedded in specialist prompts).
         depth: Static-resolution depth (forwarded to ``detect_affected_files``).
         diff_ref: Git ref or range (e.g. ``"main...HEAD"``) passed to specialist
             prompts so they can run ``git diff <ref> -- <file>`` per file.
-
-    Returns:
-        Merged ``ExplorationContext``.
     """
     import anyio
 

--- a/daydream/findings.py
+++ b/daydream/findings.py
@@ -162,10 +162,7 @@ def build_findings_artifact(
     checkout, so the privileged poster never needs PR git objects.
 
     Args:
-        target_dir: Repo root containing the PR checkout.
-        pr: The target PR (declares repo / pr_number / head_sha identity).
         issues: Parsed issues, fingerprinted for cross-run dedup.
-        run_info: Phase A's rendered run-info markdown, or None.
 
     Returns:
         The artifact dict, matching ``FINDINGS_SCHEMA``: inline findings
@@ -189,12 +186,7 @@ def build_findings_artifact(
 
 
 def write_findings_artifact(path: Path, artifact: dict[str, Any]) -> None:
-    """Write the artifact as pretty-printed UTF-8 JSON, creating parent dirs.
-
-    Args:
-        path: Destination file path.
-        artifact: Artifact dict from :func:`build_findings_artifact`.
-    """
+    """Write the artifact as pretty-printed UTF-8 JSON, creating parent dirs."""
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(artifact, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
 
@@ -214,15 +206,6 @@ def load_findings_artifact(
     parse, strict schema validation, then equality of the declared
     ``repo``/``pr_number``/``head_sha`` against the expected (event-derived)
     values. Artifact content is never executed or interpolated.
-
-    Args:
-        path: Artifact file path.
-        expected_repo: Event-derived "owner/repo" slug.
-        expected_pr_number: Event-derived PR number.
-        expected_head_sha: Event-derived PR head SHA.
-
-    Returns:
-        The validated artifact as a typed :class:`FindingsArtifact`.
 
     Raises:
         FindingsValidationError: On any failed check, naming the check.

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -71,10 +71,6 @@ def set_gh_token_env(env: dict[str, str] | None) -> None:
         env: Mapping of env-var overrides (e.g. ``{"GH_TOKEN": token}``) merged
             with the live ``os.environ`` at subprocess call time, or ``None`` to
             inherit the parent process environment without any overrides.
-
-    Returns:
-        None
-
     """
     global _gh_token_env
     _gh_token_env = env
@@ -86,18 +82,12 @@ def get_gh_token_env() -> dict[str, str] | None:
     Returns:
         The environment mapping, or ``None`` when ``gh`` inherits the parent
         process environment.
-
     """
     return _gh_token_env
 
 
 def reset_gh_token_env() -> None:
-    """Reset the ``gh`` subprocess environment to parent-process inheritance.
-
-    Returns:
-        None
-
-    """
+    """Reset the ``gh`` subprocess environment to parent-process inheritance."""
     global _gh_token_env
     _gh_token_env = None
 
@@ -114,9 +104,6 @@ def _redact_args(args: list[str]) -> list[str]:
     The token is passed as a plain ``gh``/``git`` argument, so joining raw args
     into a warning or :class:`GitError` message would leak it into logs. The
     header name is kept for debuggability; only the value is replaced.
-
-    Args:
-        args: The argument list passed after ``gh``/``git``.
 
     Returns:
         A copy with sensitive header values replaced by ``***``.
@@ -223,9 +210,6 @@ def _run_git(
     """Run ``git`` in *repo* with hardened defaults.
 
     Args:
-        repo: Repository working directory.
-        args: Arguments after ``git``.
-        timeout: Subprocess timeout in seconds.
         capture_bytes: When True, capture stdout/stderr as bytes (no decoding).
         retries: How many additional attempts to make after a
             :class:`subprocess.TimeoutExpired` (total attempts = ``retries + 1``).
@@ -285,8 +269,6 @@ def _run_gh(
     """Run ``gh`` in *repo* with hardened defaults.
 
     Args:
-        repo: Repository working directory.
-        args: Arguments after ``gh``.
         timeout: Subprocess timeout in seconds. ``None`` (the default) uses the
             env-overridable :func:`_gh_timeout`.
         input_text: Optional text piped to the subprocess on **stdin** (used to
@@ -357,9 +339,6 @@ def _run_gh(
 def assert_is_worktree(repo: Path) -> None:
     """Verify *repo* is the root of a git worktree.
 
-    Args:
-        repo: Path that should resolve to a worktree top level.
-
     Raises:
         NotAWorktreeError: If *repo* is not inside a git worktree, or if it is
             inside one but is not itself the worktree's top-level directory
@@ -384,14 +363,7 @@ def assert_is_worktree(repo: Path) -> None:
 
 
 def is_inside_worktree(repo: Path) -> bool:
-    """Return True iff :func:`assert_is_worktree` would succeed for *repo*.
-
-    Args:
-        repo: Candidate worktree path.
-
-    Returns:
-        True when *repo* is the top-level of a git worktree, otherwise False.
-    """
+    """Return True iff :func:`assert_is_worktree` would succeed for *repo*."""
     try:
         assert_is_worktree(repo)
     except NotAWorktreeError:
@@ -405,12 +377,6 @@ def is_inside_worktree(repo: Path) -> bool:
 def head_sha(repo: Path) -> str:
     """Return the full SHA of ``HEAD`` in *repo*.
 
-    Args:
-        repo: Repository working directory.
-
-    Returns:
-        The 40-character SHA of the current ``HEAD`` commit.
-
     Raises:
         GitError: If ``git rev-parse HEAD`` fails (e.g. empty repository).
     """
@@ -422,12 +388,6 @@ def head_sha(repo: Path) -> str:
 
 def head_commit_message(repo: Path) -> str:
     """Return the full commit message of ``HEAD``.
-
-    Args:
-        repo: Repository working directory.
-
-    Returns:
-        The commit message body of the current ``HEAD`` commit.
 
     Raises:
         GitError: If ``git log`` fails (e.g. empty repository).
@@ -445,7 +405,6 @@ def amend_trailers(repo: Path, trailers: dict[str, str], *, message: str | None 
     commit with the updated message.  This is a no-op if *trailers* is empty.
 
     Args:
-        repo: Repository working directory.
         trailers: Mapping of trailer keys to values (e.g.
             ``{"Daydream-Run": "abc123"}``).
         message: When provided, use this as the current ``HEAD`` commit message
@@ -503,13 +462,6 @@ def remote_url(repo: Path, remote: str = "origin") -> str | None:
     (mirrors :func:`default_branch` / :func:`merge_base` / :func:`current_branch`
     behavior for "the data isn't there" cases) and on subprocess machinery
     failures (timeout, missing binary).
-
-    Args:
-        repo: Repository working directory.
-        remote: Remote name. Defaults to ``"origin"``.
-
-    Returns:
-        The configured URL, or ``None`` when the remote is not set.
     """
     try:
         proc = _run_git(repo, ["config", "--get", f"remote.{remote}.url"], timeout=5)
@@ -522,12 +474,6 @@ def remote_url(repo: Path, remote: str = "origin") -> str | None:
 
 def current_branch(repo: Path) -> str | None:
     """Return the current branch name, or ``None`` when ``HEAD`` is detached.
-
-    Args:
-        repo: Repository working directory.
-
-    Returns:
-        The branch name (e.g. ``"main"``) or ``None`` for detached ``HEAD``.
 
     Raises:
         GitError: If the underlying subprocess fails to execute.
@@ -545,12 +491,6 @@ def default_branch(repo: Path) -> str:
     Resolution order: ``origin/HEAD`` symbolic ref → local ``main`` → local
     ``master``. Raises if none of those exist.
 
-    Args:
-        repo: Repository working directory.
-
-    Returns:
-        The default branch name (e.g. ``"main"``).
-
     Raises:
         BranchNotFoundError: If no default branch can be detected.
     """
@@ -567,15 +507,7 @@ def default_branch(repo: Path) -> str:
 
 
 def branch_exists(repo: Path, ref: str) -> bool:
-    """Check whether *ref* exists locally or as ``origin/<ref>``.
-
-    Args:
-        repo: Repository working directory.
-        ref: Branch name to look up.
-
-    Returns:
-        True when ``refs/heads/<ref>`` or ``refs/remotes/origin/<ref>`` exists.
-    """
+    """Check whether *ref* exists locally or as ``origin/<ref>``."""
     local = _run_git(repo, ["rev-parse", "--verify", f"refs/heads/{ref}"], timeout=5)
     if local.returncode == 0:
         return True
@@ -589,13 +521,6 @@ def ref_exists(repo: Path, ref: str) -> bool:
     Accepts a named branch (local or ``origin/<ref>``) plus any commit-ish:
     a full or abbreviated SHA, a tag, or a relative expression such as
     ``HEAD~3``.
-
-    Args:
-        repo: Repository working directory.
-        ref: Branch name, SHA, tag, or any commit-ish expression.
-
-    Returns:
-        True when *ref* names a branch or resolves to a commit object.
 
     Raises:
         GitError: Only for unexpected subprocess failures (timeout, missing
@@ -625,14 +550,6 @@ def merge_base(repo: Path, base: str, head: str = "HEAD") -> str | None:
     Returns ``None`` (rather than raising) on the codex-documented "soft"
     failure modes — empty repo, missing ``HEAD``, missing branch — so callers
     can treat them as "no merge-base available" without try/except plumbing.
-
-    Args:
-        repo: Repository working directory.
-        base: Base branch name (e.g. ``"main"``).
-        head: Ref whose merge-base to find. Defaults to ``"HEAD"``.
-
-    Returns:
-        The merge-base SHA, or ``None`` when one cannot be resolved.
 
     Raises:
         GitError: Only for unexpected subprocess failures (timeout, missing
@@ -717,9 +634,6 @@ def diff(repo: Path, base: str, head: str = "HEAD", *, exclude: list[str] | None
     (or identical-to-HEAD) local copy.
 
     Args:
-        repo: Repository working directory.
-        base: Base ref (e.g. ``"main"``).
-        head: Comparison ref. Defaults to ``"HEAD"``.
         exclude: Optional pathspec excludes (each becomes ``:(exclude)<p>``).
 
     Returns:
@@ -749,11 +663,6 @@ def diff_name_only(repo: Path, base: str, head: str = "HEAD") -> list[str]:
     Soft-failure semantics mirror :func:`merge_base`: returns an empty list
     when either ref cannot be resolved or the subprocess fails. Callers in
     archive paths should not propagate git transients into manifest failure.
-
-    Args:
-        repo: Repository working directory.
-        base: Base ref or SHA.
-        head: Comparison ref or SHA. Defaults to ``"HEAD"``.
 
     Returns:
         Repo-relative path strings in git output order. Empty list on any
@@ -788,11 +697,6 @@ def diff_paths(
       * Restricts output to *paths*.
 
     Args:
-        repo: Repository root.
-        base: Base ref.
-        head: Head ref.
-        paths: Pathspec list (relative to repo root).
-        unified: Lines of context.
         merge_base_diff: When False (default), use ``base..head`` (direct diff);
             when True, use ``base...head`` (diff since merge-base).
 
@@ -818,11 +722,6 @@ def diff_worktree_against(repo: Path, ref: str, paths: list[str]) -> str:
     the *current working tree* against *ref*, restricted to *paths*. Used to
     snapshot a path's uncommitted partial-edit content before it is reverted, so
     the patch is recoverable even after the working file is restored.
-
-    Args:
-        repo: Repository working directory.
-        ref: Ref to diff against (e.g. ``"HEAD"`` or a ``git stash create`` SHA).
-        paths: Repo-relative pathspec list.
 
     Returns:
         The diff text. Empty string when *paths* match *ref* exactly (or when a
@@ -863,11 +762,8 @@ def capture_recommended_patch(repo: Path, base_ref: str | None, out_path: Path) 
     Never raises.
 
     Args:
-        repo: Repository working directory.
         base_ref: Pre-fix base ref (a ``stash create`` SHA or a ``HEAD`` SHA),
             or ``None`` when no pre-fix snapshot could be taken.
-        out_path: Destination path for the patch (e.g.
-            ``.daydream/recommended.patch``).
 
     Returns:
         ``True`` when a non-empty patch was written, else ``False``.
@@ -923,12 +819,10 @@ def capture_recommended_patch_with_base(
     Best-effort: never raises (see :func:`capture_recommended_patch`).
 
     Args:
-        repo: Repository working directory.
         pre_fix_snapshot: ``stash create`` SHA, or ``None`` when the tree was
             clean or the snapshot failed.
         pre_fix_head: Pre-fix ``HEAD`` SHA, or ``None``. Used only when
             *pre_fix_snapshot* is ``None``.
-        out_path: Destination path for the patch.
 
     Returns:
         ``True`` when a non-empty patch was written, else ``False``.
@@ -939,11 +833,6 @@ def capture_recommended_patch_with_base(
 
 def log(repo: Path, base: str, head: str = "HEAD") -> str:
     """Return the one-line commit log for ``base..head``.
-
-    Args:
-        repo: Repository working directory.
-        base: Base ref.
-        head: Comparison ref. Defaults to ``"HEAD"``.
 
     Returns:
         Stripped ``--oneline`` log output. Empty string when no commits.
@@ -964,8 +853,6 @@ def log_shas(repo: Path, ref: str, *, since: str) -> list[str]:
     so callers can treat "no commits available" without try/except plumbing.
 
     Args:
-        repo: Repository working directory.
-        ref: Head ref or branch name (e.g. ``"main"``).
         since: Base ref or SHA; commits reachable from *ref* but not from
             *since* are returned (``git log since..ref``).
 
@@ -1015,7 +902,6 @@ def log_shas_since(repo: Path, head: str, base: str) -> list[str]:
     warning so a degraded fix-applied verdict is not silent.
 
     Args:
-        repo: Repository working directory.
         head: The divergence point; commits reachable from *head* are excluded.
         base: The tip ref; only commits reachable from *base* are included.
 
@@ -1061,11 +947,6 @@ def log_shas_since(repo: Path, head: str, base: str) -> list[str]:
 def daydream_commits(repo: Path, base: str, head: str = "HEAD") -> str | None:
     """Return oneline log of prior daydream commits in ``base..head``.
 
-    Args:
-        repo: Repository working directory.
-        base: Base ref (e.g. ``"main"``).
-        head: Comparison ref. Defaults to ``"HEAD"``.
-
     Returns:
         Stripped log output, or ``None`` if no daydream commits found.
     """
@@ -1090,14 +971,6 @@ def daydream_commits(repo: Path, base: str, head: str = "HEAD") -> str | None:
 def show(repo: Path, ref: str, path: str) -> bytes:
     """Return the raw bytes of *path* at *ref* via ``git show``.
 
-    Args:
-        repo: Repository working directory.
-        ref: Commit / branch / tag.
-        path: Path within the repository.
-
-    Returns:
-        Raw bytes of the file at the given revision.
-
     Raises:
         GitError: If ``git show`` fails (e.g. path missing at that revision).
     """
@@ -1110,13 +983,6 @@ def show(repo: Path, ref: str, path: str) -> bytes:
 
 def grep(repo: Path, pattern: str) -> list[str]:
     """Return file paths matching *pattern* via ``git grep -l``.
-
-    Args:
-        repo: Repository working directory.
-        pattern: Pattern passed to ``git grep -l``.
-
-    Returns:
-        List of matching file paths (one per line of stdout).
 
     Raises:
         GitError: If ``git grep`` exits with an unexpected status.  Exit code
@@ -1131,9 +997,6 @@ def grep(repo: Path, pattern: str) -> list[str]:
 
 def status_porcelain(repo: Path) -> str:
     """Return ``git status --porcelain`` output.
-
-    Args:
-        repo: Repository working directory.
 
     Returns:
         Porcelain-formatted status text. Empty when the tree is clean.
@@ -1160,9 +1023,6 @@ def changed_files(repo: Path) -> list[str]:
     repo has no commits yet, or either subcommand fails.  Individual
     subcommand failures are logged and skipped — the other subcommand's
     results are still returned.
-
-    Args:
-        repo: Repository working directory.
 
     Returns:
         De-duplicated list of repo-relative path strings.  Empty on error.
@@ -1193,12 +1053,6 @@ def list_untracked(repo: Path) -> list[str]:
     Soft-failure semantics mirror :func:`changed_files`: returns ``[]`` on any
     git error or non-zero exit. Used to snapshot the untracked set before a fix
     pass so newly-orphaned files created by a failed group can be detected.
-
-    Args:
-        repo: Repository working directory.
-
-    Returns:
-        Untracked file paths (``git ls-files --others --exclude-standard``).
     """
     try:
         proc = _run_git(repo, ["ls-files", "--others", "--exclude-standard"], timeout=10)
@@ -1219,9 +1073,6 @@ def stash_create(repo: Path) -> str | None:
     pre-mutation content. Untracked files are NOT included (``git stash create``
     ignores them), so callers track those separately via :func:`list_untracked`.
 
-    Args:
-        repo: Repository working directory.
-
     Returns:
         The 40-character snapshot SHA, or ``None`` when the tree has no tracked
         changes (``git stash create`` prints nothing). A ``None`` result means
@@ -1238,10 +1089,6 @@ def stash_create(repo: Path) -> str | None:
 
 def upstream_ahead_count(repo: Path, branch: str) -> int:
     """Return the number of commits ``<branch>@{upstream}`` is ahead of *branch*.
-
-    Args:
-        repo: Repository working directory.
-        branch: Branch name to compare against its tracked upstream.
 
     Returns:
         The right-side count from ``rev-list --left-right --count``. Returns
@@ -1277,13 +1124,6 @@ def check_ignore(repo: Path, path: str) -> bool:
     Soft-failure semantics: returns ``False`` on any subprocess error (timeout,
     missing binary, OS-level failure) to avoid blocking callers that use this
     for optional file-copy filtering.
-
-    Args:
-        repo: Repository working directory.
-        path: Path (relative to *repo*) to check.
-
-    Returns:
-        True when *path* is gitignored, False otherwise or on error.
     """
     try:
         proc = _run_git(repo, ["check-ignore", "--quiet", path], timeout=5)
@@ -1297,10 +1137,6 @@ def check_ignore(repo: Path, path: str) -> bool:
 
 def fetch(repo: Path, remote: str = "origin") -> None:
     """Run ``git fetch`` against *remote*.
-
-    Args:
-        repo: Repository working directory.
-        remote: Remote name. Defaults to ``"origin"``.
 
     Raises:
         GitError: If the fetch fails.
@@ -1317,9 +1153,6 @@ def fetch_ref(repo: Path, refspec: str, remote: str = "origin", *, timeout: int 
     configuration, such as ``refs/pull/<N>/head`` on GitHub.
 
     Args:
-        repo: Repository working directory.
-        refspec: Refspec to fetch (e.g. ``"pull/42/head"``).
-        remote: Remote name. Defaults to ``"origin"``.
         timeout: Subprocess timeout in seconds. Defaults to 300 s to
             accommodate first-run blobless fetches of large repositories.
 
@@ -1335,8 +1168,6 @@ def checkout_detach(repo: Path, sha: str, *, timeout: int = 300) -> None:
     """Detach HEAD onto *sha* in *repo*.
 
     Args:
-        repo: Repository working directory.
-        sha: Commit SHA or any commit-ish to detach onto.
         timeout: Subprocess timeout in seconds.  Defaults to 300 s because
             detaching HEAD in a blobless clone triggers lazy blob fetches that
             can take several minutes on large repositories.
@@ -1354,7 +1185,6 @@ def clone(remote_url: str, target: Path, *, blobless: bool = False, timeout: int
 
     Args:
         remote_url: Remote URL or local path to clone from.
-        target: Destination directory for the new working tree.
         blobless: When ``True``, pass ``--filter=blob:none`` to perform a
             partial clone that omits blobs until they are accessed.  Reduces
             initial transfer and storage at the cost of lazy blob fetches on
@@ -1386,7 +1216,6 @@ def checkout_paths(repo: Path, paths: list[Path]) -> None:
     """Run ``git checkout -- <paths>`` to discard local changes for *paths*.
 
     Args:
-        repo: Repository working directory.
         paths: Paths (relative to *repo*) to restore from the index. Pass
             ``[Path(".")]`` to restore the entire working tree.
 
@@ -1411,8 +1240,6 @@ def restore_paths_from_ref(repo: Path, ref: str, paths: list[str]) -> None:
     failed mid-edit, leaving the rest of the tree untouched.
 
     Args:
-        repo: Repository working directory.
-        ref: Ref to restore from (e.g. ``"HEAD"`` or a ``git stash create`` SHA).
         paths: Repo-relative paths to restore. No-op when empty.
 
     Raises:
@@ -1430,9 +1257,6 @@ def restore_paths_from_ref(repo: Path, ref: str, paths: list[str]) -> None:
 def clean_untracked(repo: Path) -> None:
     """Run ``git clean -fd`` to remove untracked files and directories.
 
-    Args:
-        repo: Repository working directory.
-
     Raises:
         GitError: If the clean fails.
     """
@@ -1445,9 +1269,7 @@ def worktree_add(repo: Path, path: Path, ref: str, *, detach: bool = True) -> No
     """Create a new worktree at *path* pointing at *ref*.
 
     Args:
-        repo: The source repository.
         path: Filesystem path for the new worktree (must not already exist).
-        ref: Commit / branch / tag to check out.
         detach: When True, pass ``--detach`` so the new worktree is detached.
 
     Raises:
@@ -1467,7 +1289,6 @@ def worktree_remove(repo: Path, path: Path, *, force: bool = True) -> None:
 
     Args:
         repo: The source repository (or any worktree linked to the same repo).
-        path: Path of the worktree to remove.
         force: When True, pass ``--force`` to remove dirty worktrees.
 
     Raises:
@@ -1485,10 +1306,6 @@ def worktree_remove(repo: Path, path: Path, *, force: bool = True) -> None:
 def create_branch(repo: Path, name: str) -> None:
     """Create and check out a new branch *name* via ``git checkout -b``.
 
-    Args:
-        repo: Repository working directory.
-        name: The branch name to create and switch to.
-
     Raises:
         GitError: If the branch already exists (``git checkout -b`` refuses to
             overwrite it) or the checkout otherwise fails. The caller decides
@@ -1504,10 +1321,6 @@ def checkout_branch(repo: Path, name: str) -> None:
 
     Uses ``git checkout <name>`` when the branch exists locally (``refs/heads/<name>``),
     or ``git checkout -b <name> origin/<name>`` when it exists only on the remote.
-
-    Args:
-        repo: Repository working directory.
-        name: An existing branch name (local or ``origin/<name>``).
 
     Raises:
         GitError: If the checkout fails, or the branch does not exist either
@@ -1530,9 +1343,7 @@ def commit_paths(repo: Path, paths: list[Path], message: str) -> None:
     ``git commit -m <message>``.
 
     Args:
-        repo: Repository working directory.
         paths: Repo-relative paths to stage and commit. Must be non-empty.
-        message: The commit message.
 
     Raises:
         GitError: If *paths* is empty, or the ``git add`` / ``git commit`` call
@@ -1566,11 +1377,6 @@ def push_branch(repo: Path, branch: str, *, remote: str = "origin") -> None:
 
     Runs ``git push -u <remote> <branch>``.
 
-    Args:
-        repo: Repository working directory.
-        branch: The branch to push.
-        remote: Remote name. Defaults to ``"origin"``.
-
     Raises:
         GitError: If the push fails (propagates stderr).
     """
@@ -1588,11 +1394,6 @@ def gh_pr_view(repo: Path, pr: int | None = None) -> dict | None:
     When *pr* is ``None``, ``gh pr view`` infers the PR from the currently
     checked-out branch. This mirrors the auto-detection flow used by the CLI
     when the user does not pass an explicit PR number.
-
-    Args:
-        repo: Repository working directory.
-        pr: Pull request number, or ``None`` to let ``gh`` infer from the
-            current branch.
 
     Returns:
         Parsed JSON dict, or ``None`` when no PR is found / the call fails.
@@ -1623,10 +1424,6 @@ def gh_pr_view(repo: Path, pr: int | None = None) -> dict | None:
 def gh_pr_list_for_branch(repo: Path, branch: str) -> list[dict]:
     """List open PRs whose head ref is *branch*.
 
-    Args:
-        repo: Repository working directory.
-        branch: Head branch name.
-
     Returns:
         List of PR dicts (empty when no PRs match or the call fails).
     """
@@ -1656,13 +1453,6 @@ def gh_pr_list_for_branch(repo: Path, branch: str) -> list[dict]:
 def gh_pr_diff(repo: Path, pr: int) -> str:
     """Return the unified diff for *pr* as text.
 
-    Args:
-        repo: Repository working directory.
-        pr: Pull request number.
-
-    Returns:
-        The diff text.
-
     Raises:
         GitError: If ``gh pr diff`` fails.
     """
@@ -1674,9 +1464,6 @@ def gh_pr_diff(repo: Path, pr: int) -> str:
 
 def split_owner_repo(slug: str) -> tuple[str, str] | None:
     """Split an ``"owner/repo"`` slug into its components.
-
-    Args:
-        slug: A GitHub ``"owner/repo"`` string.
 
     Returns:
         A ``(owner, repo)`` tuple when *slug* contains exactly one ``"/"``
@@ -1692,9 +1479,6 @@ def split_owner_repo(slug: str) -> tuple[str, str] | None:
 
 def gh_repo_view(repo: Path) -> tuple[str, str] | None:
     """Return the ``(owner, name)`` slug for the current repository.
-
-    Args:
-        repo: Repository working directory.
 
     Returns:
         Tuple of ``(owner, name)``, or ``None`` when the call fails or the
@@ -1749,9 +1533,6 @@ def gh_api(
     """Call ``gh api <endpoint>`` and return parsed JSON.
 
     Args:
-        repo: Repository working directory.
-        endpoint: API path (e.g. ``"repos/owner/repo/pulls/1/comments"``).
-        method: HTTP method. Defaults to ``"GET"``.
         paginate: When True, pass ``--paginate`` to walk all result pages.
         input_data: Optional JSON-serialisable payload. When provided, it is
             written to a temporary file and passed via ``--input <path>`` and
@@ -1870,9 +1651,6 @@ def gh_secret_set(
     material such as a PEM private key cannot leak into process listings.
 
     Args:
-        repo: Repository working directory (ambient ``gh`` auth context).
-        name: The secret name.
-        value: The secret value; piped on stdin via ``--body-file -``.
         org: Set at the organization scope (``--org``).
         repo_slug: Set at the repository scope (``--repo <owner/repo>``).
 
@@ -1898,9 +1676,6 @@ def gh_variable_set(
     Variables are non-secret handles, so the value is passed via ``--body``.
 
     Args:
-        repo: Repository working directory.
-        name: The variable name.
-        value: The variable value.
         org: Set at the organization scope (``--org``).
         repo_slug: Set at the repository scope (``--repo <owner/repo>``).
 
@@ -1930,7 +1705,6 @@ def gh_secret_list(repo: Path, *, org: str | None = None, repo_slug: str | None 
     """Return the names of Actions secrets at the given scope.
 
     Args:
-        repo: Repository working directory.
         org: List at the organization scope (``--org``).
         repo_slug: List at the repository scope (``--repo <owner/repo>``).
 
@@ -1947,12 +1721,8 @@ def gh_variable_list(repo: Path, *, org: str | None = None, repo_slug: str | Non
     """Return the names of Actions variables at the given scope.
 
     Args:
-        repo: Repository working directory.
         org: List at the organization scope (``--org``).
         repo_slug: List at the repository scope (``--repo <owner/repo>``).
-
-    Returns:
-        The variable names.
 
     Raises:
         GitError: If neither/both scopes are given, or the ``gh`` call fails.
@@ -1966,16 +1736,8 @@ def gh_pr_create(
     """Open a pull request via ``gh pr create`` and return its URL.
 
     Args:
-        repo: Repository working directory.
-        head: The head branch to open the PR from.
-        base: The base branch to merge into.
-        title: The PR title.
-        body: The PR body.
         repo_slug: Explicit ``owner/repo`` target (``--repo``).  When *None*
             the ambient ``gh`` context (cwd) is used.
-
-    Returns:
-        The PR URL ``gh`` prints on success.
 
     Raises:
         GitError: If the ``gh pr create`` call fails (stderr included).

--- a/daydream/github_app.py
+++ b/daydream/github_app.py
@@ -87,9 +87,6 @@ def mint_jwt(app_id: int, private_key: str) -> str:
     Args:
         app_id: Numeric GitHub App ID, used as the ``iss`` claim.
         private_key: PEM-encoded RSA private key for RS256 signing.
-
-    Returns:
-        The encoded JWT string.
     """
     iat = int(time.time()) - 60
     payload = {
@@ -116,11 +113,7 @@ def build_gh_env(token: str) -> dict[str, str]:
 
 @contextmanager
 def _scoped_gh_token(token: str) -> Generator[None, None, None]:
-    """Temporarily set the git_ops GH token singleton, restoring it on exit.
-
-    Args:
-        token: Token to inject as ``GH_TOKEN`` for the duration of the block.
-    """
+    """Temporarily set the git_ops GH token singleton, restoring it on exit."""
     prior = git_ops.get_gh_token_env()
     git_ops.set_gh_token_env(build_gh_env(token))
     try:
@@ -286,9 +279,6 @@ def get_app_metadata(repo_dir: Path, app_id: int, private_key: str) -> dict:
 
 def resolve_user_identity(repo_dir: Path) -> str:
     """Resolve the ambient ``gh``-authenticated user login via ``GET /user``.
-
-    Args:
-        repo_dir: Working directory for the ``gh`` subprocess.
 
     Returns:
         The login string, or the literal ``"unknown"`` if the lookup fails

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -153,12 +153,8 @@ def _build_setup_investigator_prompt(test_output: str) -> str:
     (wrong command, missing setup step, missing env var) — NOT whether the
     code under test is broken. It is strictly read-only.
 
-    Args:
-        test_output: Raw failing test output to include verbatim.
-
     Returns:
         Prompt string demanding a JSON verdict.
-
     """
     lines = test_output.splitlines()
     if len(lines) > TEST_OUTPUT_TAIL_LINES:
@@ -237,15 +233,9 @@ async def _run_setup_investigator(
     ``run_agent`` or unparseable JSON) so the caller can fall back to the
     original retry command.
 
-    Args:
-        backend: The Backend to execute against.
-        work: Workspace context; ``work.repo`` is the agent cwd.
-        test_output: Raw failing test output to embed in the prompt.
-
     Returns:
         Parsed verdict dict with keys ``verdict``, ``suggested_command``,
         ``reason`` on success, or ``None`` on any failure.
-
     """
     recorder = get_current_recorder()
     prompt = _build_setup_investigator_prompt(test_output)
@@ -648,11 +638,6 @@ async def _run_failure_summarizer(
     ``recorder.fork("failure-summarizer")`` when a recorder is present so
     the diagnostic call is captured as its own sub-trajectory.
 
-    Args:
-        backend: Backend used to invoke the summarizer subagent.
-        work: Workspace context; ``work.repo`` is the agent cwd.
-        test_output: Raw failing test output to ground the summary.
-
     Returns:
         Tuple ``(handoff_body, handoff_path, written)``. ``written`` is
         ``False`` when the filesystem write failed; callers must surface
@@ -859,12 +844,6 @@ def normalize_items(raw: list[dict[str, Any]]) -> list[dict[str, Any]]:
     collide on their original ids end up uniquely keyed. Order and the ``lens``
     field are preserved.
 
-    Args:
-        raw: The incoming list of item dicts.
-
-    Returns:
-        A new list of item dicts with reassigned ``id`` values.
-
     Raises:
         ValueError: If ``raw`` is not a list.
     """
@@ -900,9 +879,6 @@ def _is_evidenced(item: dict[str, Any]) -> bool:
     requirement: they are host-tagged, inherently whole-file findings (file-size
     budgets, layering) that may legitimately carry ``line: 0`` with colon-free
     evidence, so non-blank evidence is sufficient grounding for them.
-
-    Args:
-        item: A finding dict (per-stack, cross-stack, or structural).
 
     Returns:
         True when the finding is grounded and may reach ``merged-items.json``;
@@ -969,10 +945,6 @@ def group_items_by_file(items: list[dict[str, Any]]) -> list[tuple[str, list[dic
     missing/None file bucket into a single ``"<no-file>"`` group (cannot prove
     disjoint -> serialize for safety). Pure: no I/O, no mutation of inputs.
 
-    Args:
-        items: Canonical fix items (each a dict with at least an optional
-            ``"file"`` key).
-
     Returns:
         Ordered list of ``(file_key, items_for_file)`` tuples, where
         *file_key* is the file path string or ``"<no-file>"`` for items
@@ -1017,10 +989,6 @@ def _confidence_and_convention_instructions() -> str:
     Called by all four phase prompt builders to keep them in lockstep on these
     rules. Returns a markdown section that should be appended after the
     Exploration Context section.
-
-    Returns:
-        Markdown-formatted instruction block as a single string.
-
     """
     return (
         "## Confidence and Convention Rules\n\n"
@@ -1069,12 +1037,7 @@ def _confidence_and_convention_instructions() -> str:
 
 
 def _dependency_impact_instructions() -> str:
-    """Prompt language for QUAL-01 cross-file dependency surfacing in review output.
-
-    Returns:
-        Markdown-formatted instruction block as a single string.
-
-    """
+    """Prompt language for QUAL-01 cross-file dependency surfacing in review output."""
     return (
         "## Dependency Impact\n\n"
         "Begin your review output with a 'Dependency Impact' section that summarizes the "
@@ -1102,10 +1065,6 @@ def _settled_decisions_block(prior_commits: str | None) -> str:
     Args:
         prior_commits: Oneline log of prior daydream commits on this branch.
             When None or empty, returns empty string.
-
-    Returns:
-        Prompt block instructing the agent to treat prior commits as settled decisions.
-
     """
     if not prior_commits:
         return ""
@@ -1133,10 +1092,6 @@ def build_review_prompt(
         exploration_dir: Optional path to exploration output directory.
         prior_commits: Oneline log of prior daydream commits on this branch.
             When present, injected as settled-decisions context.
-
-    Returns:
-        Fully assembled prompt string.
-
     """
     parts: list[str] = []
     pointer = _exploration_pointer(exploration_dir)
@@ -1175,10 +1130,6 @@ def build_intent_prompt(
             present (non-empty after strip), an authoritative-intent section is
             prepended ahead of the diff-reading instructions. When ``None`` or
             empty, the prompt is byte-identical to the no-PR-body case.
-
-    Returns:
-        Fully assembled prompt string.
-
     """
     parts: list[str] = []
     pointer = _exploration_pointer(exploration_dir)
@@ -1227,12 +1178,7 @@ def build_alternative_review_prompt(
     diff_path: str = "",
     exploration_dir: Path | None = None,
 ) -> str:
-    """Assemble the prompt for `phase_alternative_review`.
-
-    Returns:
-        Fully assembled prompt string.
-
-    """
+    """Assemble the prompt for `phase_alternative_review`."""
     parts: list[str] = []
     pointer = _exploration_pointer(exploration_dir)
     if pointer:
@@ -1351,12 +1297,8 @@ def _git_branch(cwd: Path) -> str:
 def check_review_file_exists(target_dir: Path) -> None:
     """Check that the review output file exists.
 
-    Args:
-        target_dir: Target directory containing the review output.
-
     Raises:
         FileNotFoundError: If the review output file doesn't exist.
-
     """
     review_output_path = target_dir / REVIEW_OUTPUT_FILE
     if not review_output_path.exists():
@@ -1392,12 +1334,8 @@ async def phase_review(
         exclude: Optional list of paths the agent should exclude when it runs
             `git diff` itself. Applied via git's `:(exclude)` magic pathspec.
 
-    Returns:
-        None
-
     Raises:
         Exception: If the agent fails to execute the review skill.
-
     """
     print_phase_hero(console, "BREATHE", "\"Be guided by beauty\" —Jim Simons")
     print_dim(console, f"Model: {backend.model}")
@@ -1705,9 +1643,6 @@ def _build_intent_suffix(intent_path: Path | None) -> str:
     string so an intent-read failure can never block a fix. A read failure is
     never coerced into a fake intent string.
 
-    Args:
-        intent_path: Optional path to the confirmed author-intent file.
-
     Returns:
         The intent block (with leading newline) when present and readable;
         otherwise an empty string.
@@ -1794,10 +1729,6 @@ async def phase_fix(
             with a rule forbidding fixes that undo a deliberate decision. The
             read is best-effort enrichment: a missing or unreadable file is
             skipped silently so an intent-read failure can never block the fix.
-
-    Returns:
-        None
-
     """
     description = item.get("description", "No description")
     file_path = item.get("file", "Unknown file")
@@ -1881,9 +1812,6 @@ async def phase_fix_batched(
             ``None`` for serial callers.
         intent_path: Optional path to the confirmed author-intent file, injected
             verbatim (same best-effort handling as ``phase_fix``).
-
-    Returns:
-        None
     """
     if len(items) == 1:
         await phase_fix(
@@ -2460,13 +2388,7 @@ async def _do_commit(
 
 
 async def phase_commit_push(backend: Backend, work: WorkContext) -> None:
-    """Prompt user to commit and push changes.
-
-    Args:
-        backend: The Backend to execute against.
-        work: Workspace context for the commit.
-
-    """
+    """Prompt user to commit and push changes."""
     console.print()
     print_info(console, "Committing and pushing changes...")
     committed = await _do_commit(backend, work, push=True, interactive=True)
@@ -2479,18 +2401,8 @@ async def phase_fetch_pr_feedback(
 ) -> None:
     """Fetch PR feedback by invoking the fetch-pr-feedback skill.
 
-    Args:
-        backend: The Backend to execute against.
-        work: Workspace context; ``work.repo`` is the agent cwd.
-        pr_number: Pull request number to fetch feedback from
-        bot: Bot username whose comments to fetch
-
-    Returns:
-        None
-
     Raises:
         Exception: If the agent fails to fetch PR feedback.
-
     """
     print_phase_hero(console, "LISTEN", phase_subtitle("LISTEN"))
     print_dim(console, f"Model: {backend.model}")
@@ -2513,12 +2425,6 @@ async def phase_commit_iteration(backend: Backend, work: WorkContext, iteration:
 
     Ensures a clean working tree before the next review iteration starts.
     Does NOT push — the final push happens at the end of the loop.
-
-    Args:
-        backend: The Backend to execute against.
-        work: Workspace context for the commit; ``work.repo`` is the cwd.
-        iteration: Current iteration number (used in commit message)
-
     """
     print_info(console, f"Committing iteration {iteration} changes...")
     await _do_commit(backend, work, iteration=iteration)
@@ -2531,11 +2437,8 @@ async def phase_commit_push_auto(
     """Automatically commit and push changes without user prompt.
 
     Args:
-        backend: The Backend to execute against.
-        work: Workspace context for the commit.
         items: Optional fix items applied this run; forwarded to the commit
             agent so it can craft an accurate commit message.
-
     """
     console.print()
     print_info(console, "Committing and pushing changes...")
@@ -2557,10 +2460,6 @@ async def phase_respond_pr_feedback(
         pr_number: Pull request number to respond to
         bot: Bot username to respond as
         results: List of (item, success, error) tuples, one per applied fix
-
-    Returns:
-        None
-
     """
     successful = [(item, ok, err) for item, ok, err in results if ok]
 
@@ -2698,16 +2597,9 @@ async def phase_alternative_review(
     codebase to identify concrete, evidence-backed problems — correctness bugs,
     design decisions that cause real failures, and convention violations.
 
-    Args:
-        backend: The Backend to execute against.
-        work: Workspace context; ``work.repo`` is the agent cwd.
-        diff_path: Path to the diff file on disk.
-        intent_summary: Confirmed intent summary from phase_understand_intent.
-
     Returns:
         List of issue dicts, each with id, title, description, recommendation,
         severity, and files keys.
-
     """
     print_phase_hero(console, "WONDER", phase_subtitle("WONDER"))
     print_dim(console, f"Model: {backend.model}")

--- a/daydream/pr_comment_renderer.py
+++ b/daydream/pr_comment_renderer.py
@@ -253,7 +253,6 @@ def _aggregate(trajectories: list[Trajectory], prices: dict[str, ModelPrice]) ->
     (and fall through to ``cost_unknown`` when the label is generic).
 
     Args:
-        trajectories: Parsed ATIF trajectories to roll up.
         prices: Effective model price table (built-ins merged with user
             overrides) threaded into :func:`_accumulate_metrics` for cost
             synthesis.
@@ -328,8 +327,6 @@ def _accumulate_metrics(
     Args:
         agg: Whole-run rollup; ``unknown_models`` is updated when a model
             cannot be priced.
-        phase: Per-phase aggregate to accumulate this step's tokens/cost into.
-        step: The ATIF step whose metrics are being folded in.
         fallback_model: Model id to use when ``step.model_name`` is omitted
             (the root-level :attr:`Agent.model_name`).
         prices: Effective model price table (built-ins merged with user

--- a/daydream/pr_review.py
+++ b/daydream/pr_review.py
@@ -125,11 +125,6 @@ async def post_review_to_pr_from_report(
     structural) via :func:`parsed_issues_from_items` rather than re-parsing
     the rendered markdown — the regex parser silently dropped structural
     findings, which live under ``## Structural Review``.
-
-    Args:
-        target_dir: Repo root.
-        merged_items_path: Path to the canonical ``merged-items.json``.
-        console: Rich console for user-facing output.
     """
     if not merged_items_path.exists():
         return
@@ -147,13 +142,7 @@ async def post_review_to_pr_from_alt_issues(
     *,
     console: Console,
 ) -> None:
-    """Convert alt-review issues (from `--comment`) and offer to post to the PR.
-
-    Args:
-        target_dir: Repo root.
-        alt_issues: Issue dicts from `phase_alternative_review`.
-        console: Rich console for user-facing output.
-    """
+    """Convert alt-review issues (from `--comment`) and offer to post to the PR."""
     issues = alt_issues_to_parsed(alt_issues)
     if not issues:
         return
@@ -352,10 +341,6 @@ def find_pr_by_number(target_dir: Path, pr_number: int) -> PRInfo | None:
     Used when the caller pins the target PR (``--pr-number``) instead of
     deriving it from the current branch like :func:`find_open_pr`.
 
-    Args:
-        target_dir: Repo root.
-        pr_number: The PR number to look up.
-
     Returns:
         The resolved :class:`PRInfo`, or ``None`` when the PR or the
         owner/repo slug cannot be resolved.
@@ -480,10 +465,7 @@ def file_hunks(
     before parsing hunks to avoid attributing other files' hunks to this one.
 
     Args:
-        target_dir: Repo root.
         base_sha: Base commit SHA (may be unreachable locally after a rebase).
-        head_sha: Head commit SHA.
-        path: Repo-relative file path.
         pr_number: Optional PR number; enables the ``gh pr diff`` fallback.
     """
     git_failed = False
@@ -543,14 +525,6 @@ def snap_to_hunk(
     ``tolerance`` lines of a hunk boundary, snap to the nearest boundary
     so the GitHub API receives a line that actually appears in the diff.
     Returns ``None`` when the line is beyond tolerance of every hunk.
-
-    Args:
-        line: Candidate line number on the head side.
-        hunks: (start, end) inclusive ranges from ``_parse_hunks``.
-        tolerance: Max distance from a hunk boundary to still snap.
-
-    Returns:
-        A line number guaranteed to be inside a hunk, or None.
     """
     best: int | None = None
     best_dist = tolerance + 1
@@ -857,8 +831,6 @@ def build_payload(
         Footer (🧙 Posted by daydream vX.Y.Z)
 
     Args:
-        pr: Target PR.
-        classified: Inline/body-only split from :func:`classify`.
         run_info_override: Pre-rendered run-info markdown to use in place of
             the live recorder block (``post-findings`` posts from artifact
             data; there is no recorder in that process). ``None`` renders the
@@ -1018,7 +990,6 @@ def post_findings_from_artifact(
         pr_number: Event-derived target PR number.
         head_sha: Event-derived PR head SHA.
         repo: Event-derived ``owner/repo`` slug.
-        console: Rich console for user-facing output.
 
     Returns:
         ``0`` on success (including "no new findings"); ``1`` when the

--- a/daydream/pricing.py
+++ b/daydream/pricing.py
@@ -72,13 +72,6 @@ def _coerce_price(model: str, table: Any) -> ModelPrice | None:
     Requires ``input`` and ``output`` (numeric, >= 0). ``cached_input`` is
     optional and defaults to ``input``. Any missing, non-numeric, or negative
     required field is logged and yields None so the caller skips the model.
-
-    Args:
-        model: Model identifier the table belongs to (for log messages).
-        table: Raw parsed value for the model's sub-table.
-
-    Returns:
-        A ``ModelPrice`` on success, or None when the entry is invalid.
     """
     if not isinstance(table, dict):
         logger.warning("daydream prices: entry %r is not a table — skipping", model)
@@ -127,12 +120,6 @@ def load_user_prices(path: Path | None = None) -> dict[str, ModelPrice]:
     ``cached_input`` is optional and defaults to ``input``. Invalid entries are
     logged and skipped; an absent file or malformed TOML yields ``{}``.
 
-    Args:
-        path: Explicit path to a prices TOML file. Overrides env/default.
-
-    Returns:
-        A mapping of model name to ``ModelPrice`` for every valid entry.
-
     Raises:
         Never. All error conditions are logged and yield ``{}`` or skip the
         offending entry.
@@ -166,9 +153,6 @@ def load_user_prices(path: Path | None = None) -> dict[str, ModelPrice]:
 def resolve_prices(overrides: dict[str, ModelPrice] | None = None) -> dict[str, ModelPrice]:
     """Merge user overrides over the built-in price table.
 
-    Args:
-        overrides: Per-model overrides; each key replaces the built-in entry.
-
     Returns:
         A new dict of built-in prices with ``overrides`` applied per-model.
     """
@@ -188,14 +172,9 @@ def compute_cost(
     Args:
         model: Model identifier (e.g. "gpt-5.5"). Must match a key in the
             active price table.
-        input_tokens: Count of uncached input tokens.
         cached_input_tokens: Count of cached input tokens (priced separately).
-        output_tokens: Count of output tokens.
         prices: Optional price table to look up in. When None, the built-in
             ``MODEL_PRICES`` is used (back-compatible with existing callers).
-
-    Returns:
-        Total USD cost, or None when model is not in the active price table.
     """
     table = MODEL_PRICES if prices is None else prices
     price = table.get(model)

--- a/daydream/prompts/exploration_subagents.py
+++ b/daydream/prompts/exploration_subagents.py
@@ -167,12 +167,6 @@ def build_pattern_scanner_prompt(affected_files: list[str], diff_ref: str, *, cw
         affected_files: Paths of files touched by the diff under review.
         diff_ref: Git ref (e.g. base branch or SHA) the specialist can diff against.
         cwd: Absolute working directory the agent runs in (grounds path resolution).
-
-    Returns:
-        The fully-rendered prompt string, including the JSON schema block.
-
-    Raises:
-        None.
     """
     files_block = "\n".join(f"- {p}" for p in affected_files) or "- (none yet)"
     return f"""You are the **pattern-scanner** specialist. Detect codebase conventions
@@ -208,12 +202,6 @@ def build_dependency_tracer_prompt(affected_files: list[FileInfo], diff_ref: str
         affected_files: FileInfo entries for files reachable from the diff, each carrying a `path` and `role`.
         diff_ref: Git ref the specialist can diff against when probing call sites.
         cwd: Absolute working directory the agent runs in (grounds path resolution).
-
-    Returns:
-        The fully-rendered prompt string, including the JSON schema block.
-
-    Raises:
-        None.
     """
     files_block = "\n".join(f"- {f.path} ({f.role})" for f in affected_files) or "- (none yet)"
     return f"""You are the **dependency-tracer** specialist. Extend the affected-files
@@ -246,12 +234,6 @@ def build_test_mapper_prompt(affected_files: list[str], diff_ref: str, *, cwd: P
         affected_files: Paths of files touched by the diff under review.
         diff_ref: Git ref the specialist can diff against when locating test files.
         cwd: Absolute working directory the agent runs in (grounds path resolution).
-
-    Returns:
-        The fully-rendered prompt string, including the JSON schema block.
-
-    Raises:
-        None.
     """
     files_block = "\n".join(f"- {p}" for p in affected_files) or "- (none yet)"
     return f"""You are the **test-mapper** specialist. Locate test files for each modified

--- a/daydream/reconcile.py
+++ b/daydream/reconcile.py
@@ -136,11 +136,6 @@ def fetch_prior_findings(target_dir: Path, repo_slug: str, pr_number: int) -> di
     reads as resolved when its thread is resolved (human action) or its
     comment was minimized (a prior daydream run marked it stale).
 
-    Args:
-        target_dir: Repository working directory (for ``gh`` invocation).
-        repo_slug: ``owner/repo`` slug of the PR's base repository.
-        pr_number: PR number to inventory.
-
     Returns:
         Mapping of fingerprint to `PriorFinding`, in discovery order.
 
@@ -197,13 +192,6 @@ def partition(current: Sequence[str], prior: dict[str, PriorFinding]) -> Reconci
         - stale: prior inline findings (``thread_id`` set) absent from
           ``current`` and not yet resolved — to be minimized. Body-only
           findings have no thread and simply stop appearing.
-
-    Args:
-        current: Fingerprints produced by the current run, in post order.
-        prior: Prior-finding inventory from `fetch_prior_findings`.
-
-    Returns:
-        The `ReconcilePlan` for this run.
     """
     current_set = set(current)
     return ReconcilePlan(
@@ -224,10 +212,6 @@ def resolve_threads(target_dir: Path, stale: list[PriorFinding]) -> tuple[int, i
     node id (``resolveReviewThread`` is forbidden for the least-privilege
     installation token — Task 0 spike). Best-effort: a failure on one
     finding warns and continues, matching the `daydream.pr_review` posture.
-
-    Args:
-        target_dir: Repository working directory (for ``gh`` invocation).
-        stale: Stale findings from `partition`.
 
     Returns:
         ``(resolved_count, failed_count)``.

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -99,12 +99,6 @@ def to_canonical_shallow(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
     item's ``confidence`` (HIGH→high, MEDIUM→medium, LOW→low), defaulting to
     ``"medium"`` when ``confidence`` is absent. Items are mutated in place and
     returned for convenience.
-
-    Args:
-        items: Raw feedback items from ``phase_parse_feedback``.
-
-    Returns:
-        The same list, each item carrying ``lens`` and ``severity``.
     """
     for item in items:
         item["lens"] = "per-stack"
@@ -365,10 +359,6 @@ def _resolve_backend(
             When provided, backends are reused only when both the backend kind
             and the resolved model match — so the same backend kind with two
             different models yields two distinct instances.
-
-    Returns:
-        Backend instance for the phase.
-
     """
     backend_name = _resolved_backend_name(config, phase)
     resolved_model = _resolved_model(config, phase)
@@ -384,9 +374,6 @@ def _resolve_backend(
 
 def _truthy(value: str | None) -> bool:
     """Interpret an environment-variable string as a boolean.
-
-    Args:
-        value: The raw environment value, or None when unset.
 
     Returns:
         False for None and for ``""``/``"0"``/``"false"`` (case-insensitive);
@@ -416,9 +403,6 @@ def _resolve_interactive(config: "RunConfig") -> bool:
     Precedence: an explicit ``--non-interactive`` flag forces False; otherwise
     the run is interactive only when stdin is a TTY and ``CI`` is not truthy.
 
-    Args:
-        config: The run configuration carrying the explicit flag.
-
     Returns:
         True if prompts may read stdin; False for unattended/harness runs.
     """
@@ -444,7 +428,6 @@ def _get_head_sha(cwd: Path) -> str | None:
 
     Returns:
         The full SHA string, or None if the command fails.
-
     """
     try:
         return git_ops.head_sha(cwd)
@@ -467,9 +450,6 @@ async def run(config: RunConfig | None = None) -> int:
     Args:
         config: Optional configuration. Defaults to a fresh :class:`RunConfig`
             (interactive prompts for target dir, skill, cleanup).
-
-    Returns:
-        Exit code (0 for success, 1 for failure).
     """
     if config is None:
         config = RunConfig()
@@ -559,13 +539,6 @@ async def run_feedback(config: RunConfig, pr: int) -> int:
     Sets ``config.pr_number`` and re-enters :func:`run` so the dispatch
     routes to :func:`_run_pr_feedback`. Kept as a thin wrapper so cli.py
     has a single named entry point per invocation shape.
-
-    Args:
-        config: Run configuration populated by the feedback subparser.
-        pr: PR number to ingest.
-
-    Returns:
-        Exit code (0 for success, 1 for failure).
     """
     config.pr_number = pr
     return await run(config)
@@ -586,7 +559,6 @@ async def _dispatch(work: WorkContext, config: RunConfig) -> int:
     for metadata (trajectory/archive) without implying feedback mode.
 
     Args:
-        work: Resolved working environment for the run.
         config: Run configuration (``config.identity`` carries the resolved
             GitHub identity set by :func:`run`).
     """

--- a/daydream/summarize.py
+++ b/daydream/summarize.py
@@ -22,9 +22,6 @@ from daydream.ui import NEON_THEME, print_error
 def summarize(path: Path) -> int:
     """Print the run-info markdown for *path* to stdout.
 
-    Args:
-        path: Either a trajectory JSON file or a run directory.
-
     Returns:
         0 on success, non-zero when the path could not be resolved or no
         parseable trajectory could be produced.

--- a/daydream/training/corpus.py
+++ b/daydream/training/corpus.py
@@ -91,9 +91,6 @@ def _build_spans(trajectory: dict[str, Any]) -> list[dict[str, Any]]:
     - Within a single step REASON is appended before ACT, preserving the
       natural reason-then-act ordering required by the schema consumers.
 
-    Args:
-        trajectory: ATIF v1.6 trajectory dict (e.g. ``json.loads(open(p))``).
-
     Returns:
         Spans in insertion order. Empty list when ``trajectory`` has no
         agent-authored steps or when no agent step carries reason/action data.
@@ -169,13 +166,6 @@ def _annotation_labels(annotation: dict[str, Any] | None, session_id: Any) -> li
     (no in-time observation) yields ``[]`` — the run is unlabeled. Malformed
     JSON is warned about and treated as no labels rather than crashing the
     projection.
-
-    Args:
-        annotation: The ``latest_label_observation`` row dict, or ``None``.
-        session_id: Session identifier for warning context.
-
-    Returns:
-        The decoded label list, or ``[]`` when absent/unparseable.
     """
     if annotation is None:
         return []
@@ -200,13 +190,6 @@ def _annotation_reward(
     ``reward_json`` column; ``None`` when the column is missing/empty/non-object
     or unparseable (warned). ``composite_reward`` is the cached scalar on the
     row (already ``float | None``). A ``None`` annotation yields ``(None, None)``.
-
-    Args:
-        annotation: The ``latest_label_observation`` row dict, or ``None``.
-        session_id: Session identifier for warning context.
-
-    Returns:
-        ``(reward_dict_or_none, composite_reward_or_none)``.
     """
     if annotation is None:
         return None, None
@@ -522,9 +505,6 @@ def _build_query(
     4. ``repo_slug IN (...)`` — when ``filters.repos`` is non-empty.
     5. ``grounding_rate >= ?`` — when ``filters.min_grounding`` is set.
 
-    Args:
-        filters: Resolved filter knobs.
-
     Returns:
         ``(where_clause, params)`` where ``where_clause`` has no leading
         ``WHERE`` keyword (per ``query_runs``'s contract) and ``params`` is
@@ -578,11 +558,6 @@ def _query_index(archive_dir: Path, filters: CorpusFilters) -> list[dict[str, An
     Each surviving row is augmented with a derived ``"stack"`` key so
     downstream stratification and record building can route on stack
     without re-deriving from the skill string.
-
-    Args:
-        archive_dir: Path to the daydream archive root (e.g.
-            ``~/.daydream/archive``).
-        filters: Resolved filter knobs.
 
     Returns:
         Rows in lexicographic ``session_id`` order so emission is
@@ -793,14 +768,6 @@ def _is_admitted(label: str | None, composite_reward: float | None, filters: Cor
     on its intrinsic score alone — there is no deduction to remove here. This
     invariant is pinned by
     ``test_is_admitted_min_reward_compares_intrinsic_only``.
-
-    Args:
-        label: The pinned annotation's outcome label, or ``None`` (unlabeled).
-        composite_reward: The pinned annotation's composite reward scalar.
-        filters: Resolved filter knobs.
-
-    Returns:
-        ``True`` when the run should be emitted.
     """
     if filters.include_all_labels:
         return True
@@ -819,12 +786,6 @@ def _trajectory_set_hash(session_ids: list[str]) -> str:
     (order-independent). A single-session corpus collapses to
     ``sha256(b"<session_id>")`` — there is no trailing newline or separator for
     one id.
-
-    Args:
-        session_ids: The ``session_id`` of every record actually emitted.
-
-    Returns:
-        The hex SHA-256 digest of the sorted, newline-joined ids.
     """
     joined = "\n".join(sorted(session_ids)).encode("utf-8")
     return hashlib.sha256(joined).hexdigest()
@@ -837,13 +798,6 @@ def _collapse_versions(versions: list[str | None]) -> str | list[str] | None:
     scalar; a corpus mixing versions records the sorted distinct set so the
     lineage manifest is honest about heterogeneity. An empty corpus yields
     ``None``.
-
-    Args:
-        versions: The version tag observed on each included annotation.
-
-    Returns:
-        The single version string when uniform, the sorted distinct list when
-        mixed, or ``None`` when no annotations were included.
     """
     distinct = sorted({v for v in versions if v is not None})
     if not distinct:
@@ -859,10 +813,6 @@ def _atomic_write_json(out_path: Path, payload: dict[str, Any]) -> None:
     Mirrors the snapshot writer's pattern: a temp file in the destination
     directory, an ``os.replace`` rename, and best-effort cleanup of the temp
     file if writing fails. JSON is sorted and indented for stable diffs.
-
-    Args:
-        out_path: Destination path for the lineage manifest.
-        payload: The lineage dict to serialize.
     """
     out_path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_path = tempfile.mkstemp(
@@ -907,9 +857,6 @@ def run_build_corpus(config: BuildCorpusConfig) -> dict[str, int]:
     9. Write ``lineage.json`` beside the JSONL pinning the snapshot's
        provenance (``trajectory_set_hash``, labeler/reward versions, ``as_of``,
        ``created_at``) so the snapshot is reproducible from immutable inputs.
-
-    Args:
-        config: Resolved build-corpus config.
 
     Returns:
         Summary dict with keys ``total_runs_in_index``, ``after_filters``,

--- a/daydream/training/exclusion.py
+++ b/daydream/training/exclusion.py
@@ -22,12 +22,6 @@ def _load_repo_slugs(path: Path) -> frozenset[str]:
     """Read a one-slug-per-line file into a frozenset.
 
     Blank lines and lines whose stripped form starts with ``#`` are skipped.
-
-    Args:
-        path: Filesystem path to the slug file.
-
-    Returns:
-        Frozen set of stripped ``owner/repo`` strings.
     """
     slugs: set[str] = set()
     with path.open("r", encoding="utf-8") as fh:
@@ -63,9 +57,6 @@ def load_copyleft_list() -> frozenset[str]:
 
 def is_excluded(repo_slug: str | None) -> bool:
     """Check whether a repo slug is on the C5 exclusion list.
-
-    Args:
-        repo_slug: ``owner/repo`` to check, or ``None``.
 
     Returns:
         ``True`` if the slug is on the always-enforced exclusion list;

--- a/daydream/training/harvest.py
+++ b/daydream/training/harvest.py
@@ -143,9 +143,6 @@ def _read_review_output(run_dir: Path) -> str | None:
     then ``deep/review-output.md`` (deep-mode layout), mirroring the former
     exporter's back-compat fallback order.
 
-    Args:
-        run_dir: The archived run directory.
-
     Returns:
         The text of the first review-output file found, or ``None`` when
         neither location exists. Non-``FileNotFoundError`` ``OSError``\s
@@ -164,13 +161,6 @@ def _read_review_output_length(run_dir: Path) -> int | None:
 
     Delegates to :func:`_read_review_output`; see that function for the
     fallback order and error semantics.
-
-    Args:
-        run_dir: The archived run directory.
-
-    Returns:
-        The character count of the first review-output file found, or
-        ``None`` when neither location exists.
     """
     text = _read_review_output(run_dir)
     return len(text) if text is not None else None
@@ -777,9 +767,6 @@ def _resolve_repo_for_row(
     Args:
         row: An indexed manifest row (supplies ``source_path``, ``remote_url``, ``repo_slug``).
         clone_cache: Root directory for cached clones, or ``None`` to skip cloning.
-
-    Returns:
-        Path to a usable working tree, or ``None``.
     """
     source_path = row.get("source_path")
     if source_path and (Path(source_path) / ".git").exists():
@@ -821,11 +808,6 @@ def _materialize_base_sha_if_missing(
 
     Only acts when ``manifest.json`` exists AND ``repo_clone`` is available.
     Any failure is swallowed (opportunistic), leaving ``base_sha`` as ``None``.
-
-    Args:
-        row: The indexed manifest row.
-        run_dir: The archived run directory (holds ``manifest.json``).
-        repo_clone: Resolved repo working tree, or ``None``.
     """
     manifest_path = run_dir / "manifest.json"
     if not manifest_path.exists():
@@ -899,9 +881,6 @@ async def run_harvest(config: HarvestConfig) -> dict[str, int]:
     Per-row error isolation: an exception on one row counts in ``errors`` and
     does not derail subsequent rows. Configuration errors (missing
     ``archive_dir``) raise before the loop begins.
-
-    Args:
-        config: A :class:`HarvestConfig` instance.
 
     Returns:
         Summary dict with keys ``considered``, ``annotated``,

--- a/daydream/training/labeler_signals.py
+++ b/daydream/training/labeler_signals.py
@@ -48,12 +48,6 @@ def _is_daydream_comment(comment: dict[str, Any]) -> bool:
     :data:`DAYDREAM_FOOTER` constant, so that comments posted by any release
     of daydream are correctly identified even when their embedded version
     string differs from the currently-installed package.
-
-    Args:
-        comment: A parsed PR review comment dict (``body`` field read).
-
-    Returns:
-        True iff the comment body contains the daydream footer badge.
     """
     return _DAYDREAM_FOOTER_PREFIX in (comment.get("body") or "")
 

--- a/daydream/training/reward.py
+++ b/daydream/training/reward.py
@@ -185,9 +185,6 @@ def _weights_fingerprint(weights: RewardWeights) -> str:
     SHA-256 digest. ``is_default`` is excluded — it is identity metadata, not
     a scoring parameter. Pure; no I/O.
 
-    Args:
-        weights: The weights to fingerprint.
-
     Returns:
         The first 8 hex characters of the SHA-256 digest of the canonical
         JSON serialization of the scoring parameters.

--- a/daydream/training/rubric.py
+++ b/daydream/training/rubric.py
@@ -101,9 +101,6 @@ def derive_outcome_label(rubric: Rubric) -> str:
       :attr:`Rubric.local_commit_applied`.
     * ``"none"`` — always ``"unknown"``.
 
-    Args:
-        rubric: The rubric to reduce.
-
     Returns:
         One of ``"accepted"``, ``"contested"``, ``"rejected"``, or
         ``"unknown"``.

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -268,9 +268,6 @@ class Redactor:
         degrade to ``"[REDACTION_FAILED]"`` for the offending field — never
         raw pass-through.
 
-        Args:
-            step: ATIF Step about to be appended to the Trajectory.
-
         Returns:
             A new Step instance whose text-bearing fields have been run
             through the redaction rules.
@@ -969,7 +966,6 @@ class TrajectoryRecorder:
         """Record a ``phase_start`` boundary event (issue #203).
 
         Args:
-            phase: The phase entering execution.
             **metadata: Optional structured metadata (e.g. ``stage="review"``
                 for the deep orchestrator's DEEP sub-stages).
         """
@@ -986,7 +982,6 @@ class TrajectoryRecorder:
         """Record a ``phase_end`` boundary event (issue #203).
 
         Args:
-            phase: The phase leaving execution.
             **metadata: Optional structured metadata (mirrors emit_phase_start.
         """
         self._phase_events.append(
@@ -1177,9 +1172,6 @@ class TrajectoryRecorder:
 
         Args:
             descriptor: Semantic label for the sibling (e.g. ``"fix-0"``).
-
-        Returns:
-            An async context manager yielding a child ``TrajectoryRecorder``.
         """
         return _ForkCM(parent=self, descriptor=descriptor)
 

--- a/daydream/tree_sitter_index.py
+++ b/daydream/tree_sitter_index.py
@@ -137,7 +137,6 @@ def extract_imports(parser: Parser, source: bytes, query_string: str) -> list[st
 
     Args:
         parser: A tree-sitter ``Parser`` already configured for the language.
-        source: Raw file bytes to parse.
         query_string: A tree-sitter Query S-expression with ``@import`` captures.
 
     Returns:

--- a/daydream/ui/__init__.py
+++ b/daydream/ui/__init__.py
@@ -51,7 +51,6 @@ from daydream.ui.summary import (
     print_summary,
     print_verification_summary,
     render_exploration_summary,
-    render_ttt_plan,
 )
 from daydream.ui.theme import (
     ASCII_GRADIENT_COLORS,

--- a/daydream/ui/agent_text.py
+++ b/daydream/ui/agent_text.py
@@ -34,11 +34,7 @@ def _highlight_agent_text(text: str, base_style: Style | None = None) -> Text:
     - Bold (**text**) and italic (*text*)
 
     Args:
-        text: Raw agent text to highlight.
         base_style: Style for non-highlighted text. Defaults to STYLE_GREEN.
-
-    Returns:
-        Rich Text with neon styling applied.
 
     """
     if base_style is None:
@@ -127,15 +123,7 @@ _MARKDOWN_HEADER_PATTERN = re.compile(r"#{1,6}\s+\S")
 
 
 def _has_markdown_headers(text: str) -> bool:
-    """Check if text contains markdown headers.
-
-    Args:
-        text: Text to check for markdown headers.
-
-    Returns:
-        True if text contains markdown headers (e.g., ## Summary).
-
-    """
+    """Check if text contains markdown headers."""
     return bool(_MARKDOWN_HEADER_PATTERN.search(text))
 
 
@@ -146,11 +134,7 @@ def _render_agent_lines_with_gradient(
     """Render agent text lines with vertical cyan-to-green gradient.
 
     Args:
-        lines: List of text lines to render.
         use_italic: Whether to apply italic styling (False for markdown content).
-
-    Returns:
-        Rich Text with vertical gradient styling applied.
 
     """
     highlighted = Text()
@@ -179,9 +163,6 @@ class AgentTextRenderer:
     Live-updating Panel that provides proper word wrapping. This solves
     the issue of broken line wrapping when streaming text character-by-character.
 
-    Args:
-        console: Rich Console instance for output.
-
     Usage:
         renderer = AgentTextRenderer(console)
         renderer.start()
@@ -192,12 +173,7 @@ class AgentTextRenderer:
     """
 
     def __init__(self, console: Console) -> None:
-        """Initialize the renderer.
-
-        Args:
-            console: Rich Console instance for output.
-
-        """
+        """Initialize the renderer."""
         self._console = console
         self._buffer: list[str] = []
         self._live: Live | None = None
@@ -212,9 +188,6 @@ class AgentTextRenderer:
 
         Args:
             show_spinner: If True, append animated spinner at end (cursor effect).
-
-        Returns:
-            Rich Panel with gradient styling applied.
 
         """
         full_text = "".join(self._buffer)
@@ -243,10 +216,6 @@ class AgentTextRenderer:
         """Start the Live context for real-time updates.
 
         Call this before appending any text chunks.
-
-        Returns:
-            None
-
         """
         if self._started:
             return
@@ -264,15 +233,7 @@ class AgentTextRenderer:
         self._started = True
 
     def append(self, text: str) -> None:
-        """Append text to the buffer and update the display.
-
-        Args:
-            text: Text chunk to append.
-
-        Returns:
-            None
-
-        """
+        """Append text to the buffer and update the display."""
         if not text:
             return
 
@@ -285,10 +246,6 @@ class AgentTextRenderer:
         """Stop the Live context and print the final Panel.
 
         Call this when all text has been received.
-
-        Returns:
-            None
-
         """
         if self._live is not None:
             self._live.update(self._render_panel(show_spinner=False), refresh=True)
@@ -300,10 +257,5 @@ class AgentTextRenderer:
 
     @property
     def has_content(self) -> bool:
-        """Check if the buffer has any content.
-
-        Returns:
-            bool: True if the buffer contains text, False otherwise.
-
-        """
+        """Check if the buffer has any content."""
         return bool(self._buffer)

--- a/daydream/ui/colorize.py
+++ b/daydream/ui/colorize.py
@@ -69,13 +69,6 @@ def _detect_shell_syntax(content: str) -> bool:
     - Lines starting with $ or # (shell prompts)
     - Shebang lines (#!/bin/bash, etc.)
     - Multiple lines with common shell command patterns
-
-    Args:
-        content: The content to analyze.
-
-    Returns:
-        True if the content appears to be shell script or output.
-
     """
     if _SHEBANG_PATTERN.search(content):
         return True
@@ -93,9 +86,6 @@ def _detect_shell_syntax(content: str) -> bool:
 
 def _colorize_git_line(line: str) -> Text | None:
     """Check if a line matches git output patterns and return styled Text.
-
-    Args:
-        line: The line to check.
 
     Returns:
         Rich Text with git-specific styling, or None if not git output.
@@ -125,16 +115,7 @@ def _colorize_git_line(line: str) -> Text | None:
 
 
 def _colorize_line(line: str, is_error: bool = False) -> Text:
-    """Apply neon syntax highlighting to a single line of output.
-
-    Args:
-        line: The line to colorize.
-        is_error: Whether this is error output.
-
-    Returns:
-        Rich Text with neon styling applied.
-
-    """
+    """Apply neon syntax highlighting to a single line of output."""
     git_result = _colorize_git_line(line)
     if git_result is not None:
         return git_result

--- a/daydream/ui/console.py
+++ b/daydream/ui/console.py
@@ -20,12 +20,7 @@ from daydream.ui.theme import (
 
 
 def create_console() -> Console:
-    """Create a Rich Console with neon theme applied.
-
-    Returns:
-        Console: A new Rich Console instance configured with the neon theme.
-
-    """
+    """Create a Rich Console with neon theme applied."""
     return Console(theme=NEON_THEME)
 
 
@@ -36,9 +31,6 @@ def _interpolate_color(color1: str, color2: str, t: float) -> str:
         color1: Starting hex color (e.g., "#8BE9FD").
         color2: Ending hex color (e.g., "#FF79C6").
         t: Interpolation factor (0.0 = color1, 1.0 = color2).
-
-    Returns:
-        Interpolated hex color string.
 
     """
     r1, g1, b1 = int(color1[1:3], 16), int(color1[3:5], 16), int(color1[5:7], 16)
@@ -56,9 +48,6 @@ def _get_gradient_color(position: float) -> str:
 
     Args:
         position: Position in gradient (0.0 = start, 1.0 = end).
-
-    Returns:
-        Hex color string at the given position.
 
     """
     position = max(0.0, min(1.0, position))
@@ -87,9 +76,7 @@ def print_phase_hero(
     Includes a decorative subtitle below the ASCII art.
 
     Args:
-        console: Rich Console instance for output.
         title: The ASCII art text (e.g., "DAYDREAM", "BREATHE", "HEAL").
-        description: Subtitle text displayed below the ASCII art.
 
     """
     try:

--- a/daydream/ui/messages.py
+++ b/daydream/ui/messages.py
@@ -35,7 +35,6 @@ def print_feedback_table(console: Console, items: list[dict[str, object]]) -> No
     description, file, and line number.
 
     Args:
-        console: Rich Console instance for output.
         items: List of dicts with keys: status, description, file, line.
 
     """
@@ -80,12 +79,6 @@ def print_error(console: Console, title: str, message: str) -> None:
 
     Creates a prominent error display with a warning icon
     and double-edge border.
-
-    Args:
-        console: Rich Console instance for output.
-        title: Error title text.
-        message: Detailed error message.
-
     """
     panel = Panel(
         Text(message, style=STYLE_RED),
@@ -99,13 +92,7 @@ def print_error(console: Console, title: str, message: str) -> None:
 
 
 def print_warning(console: Console, message: str) -> None:
-    """Print a warning panel with yellow styling.
-
-    Args:
-        console: Rich Console instance for output.
-        message: Warning message to display.
-
-    """
+    """Print a warning panel with yellow styling."""
     panel = Panel(
         Text(message, style=STYLE_YELLOW),
         box=box.ROUNDED,
@@ -116,35 +103,17 @@ def print_warning(console: Console, message: str) -> None:
 
 
 def print_success(console: Console, message: str) -> None:
-    """Print a success message with green styling.
-
-    Args:
-        console: Rich Console instance for output.
-        message: Success message to display.
-
-    """
+    """Print a success message with green styling."""
     console.print(f"[neon.success]✔[/] [neon.green]{message}[/]")
 
 
 def print_cost(console: Console, cost_usd: float) -> None:
-    """Print a cost indicator with cyan styling.
-
-    Args:
-        console: Rich Console instance for output.
-        cost_usd: The cost in USD.
-
-    """
+    """Print a cost indicator with cyan styling."""
     console.print(f"[neon.cyan]💰[/] [neon.dim]${cost_usd:.4f}[/]")
 
 
 def print_info(console: Console, message: str) -> None:
-    """Print an info message with cyan styling.
-
-    Args:
-        console: Rich Console instance for output.
-        message: Info message to display.
-
-    """
+    """Print an info message with cyan styling."""
     console.print(f"[neon.cyan]ℹ[/] [neon.fg]{message}[/]")
 
 
@@ -152,7 +121,6 @@ def print_skipped_phases(console: Console, start_at: str) -> None:
     """Print message about skipped phases when starting at a non-default phase.
 
     Args:
-        console: Rich Console instance for output.
         start_at: The phase to start at ("parse", "fix", or "test").
 
     """
@@ -169,13 +137,7 @@ def print_skipped_phases(console: Console, start_at: str) -> None:
 
 
 def print_dim(console: Console, message: str) -> None:
-    """Print a dimmed message for secondary information.
-
-    Args:
-        console: Rich Console instance for output.
-        message: Message to display in dimmed style.
-
-    """
+    """Print a dimmed message for secondary information."""
     console.print(f"[neon.dim]{message}[/]")
 
 
@@ -185,8 +147,6 @@ def print_menu(console: Console, title: str, options: list[tuple[str, str]]) -> 
     Displays numbered options with descriptions in a neon-styled panel.
 
     Args:
-        console: Rich Console instance for output.
-        title: Menu title.
         options: List of (key, description) tuples.
 
     """
@@ -214,7 +174,6 @@ def print_intent_summary(console: Console, text: str) -> None:
     of the live agent transcript.
 
     Args:
-        console: Rich Console instance for output.
         text: The intent summary (markdown-ish agent prose). An empty summary
             renders a placeholder rather than a blank panel.
 
@@ -239,8 +198,6 @@ def prompt_user(console: Console, message: str, default: str = "") -> str:
     """Display a styled input prompt and get user input.
 
     Args:
-        console: Rich Console instance for output.
-        message: Prompt message to display.
         default: Default value if user enters nothing.
 
     Returns:

--- a/daydream/ui/panels.py
+++ b/daydream/ui/panels.py
@@ -58,34 +58,16 @@ class LiveThinkingPanel:
 
     Displays the AI's thought process in a purple-styled panel
     with animated spinners alongside the thought bubble icon.
-
-    Args:
-        console: Rich Console instance for output.
-        content: The thinking content to display.
-        max_length: Maximum content length before truncation.
-
     """
 
     def __init__(self, console: Console, content: str, max_length: int = 300) -> None:
-        """Initialize the panel.
-
-        Args:
-            console: Rich Console instance for output.
-            content: The thinking content to display.
-            max_length: Maximum content length before truncation.
-
-        """
+        """Initialize the panel."""
         self._console = console
         self._content = content if len(content) <= max_length else content[:max_length] + "..."
         self._spinner = CrazySpinner(num_spinners=3)
 
     def __rich__(self) -> Panel:
-        """Render panel with animated title.
-
-        Returns:
-            Rich Panel with animated spinners in title.
-
-        """
+        """Render panel with animated title."""
         title = Text()
         title.append("💭 Thinking")
         title.append_text(self._spinner.render())
@@ -101,12 +83,7 @@ class LiveThinkingPanel:
         )
 
     def show(self, duration: float = 1.0) -> None:
-        """Show animated panel for duration, then persist final state.
-
-        Args:
-            duration: How long to show animation before settling.
-
-        """
+        """Show animated panel for duration, then persist final state."""
         self._console.print()
         with Live(self, console=self._console, refresh_per_second=10, transient=True):
             time.sleep(duration)
@@ -128,12 +105,6 @@ def print_thinking(console: Console, content: str, max_length: int = 300) -> Non
 
     Displays the AI's thought process in a purple-styled panel
     with animated spinners in the title that settle after a brief duration.
-
-    Args:
-        console: Rich Console instance for output.
-        content: The thinking content to display.
-        max_length: Maximum content length before truncation.
-
     """
     panel = LiveThinkingPanel(console, content, max_length)
     panel.show(duration=0.5)
@@ -145,7 +116,6 @@ class CrazySpinner:
     Displays multiple spinner characters simultaneously, each with its own
     animation pattern and gradient color cycling. Creates a chaotic but
     visually striking loading indicator.
-
     """
 
     SPINNERS = [
@@ -168,24 +138,14 @@ class CrazySpinner:
     ]
 
     def __init__(self, num_spinners: int = 3) -> None:
-        """Initialize with multiple independent spinner states.
-
-        Args:
-            num_spinners: Number of spinner characters to display.
-
-        """
+        """Initialize with multiple independent spinner states."""
         self._num_spinners = num_spinners
         self._frame = 0
         self._spinner_indices = [i % len(self.SPINNERS) for i in range(num_spinners)]
         self._offsets = [i * 2 for i in range(num_spinners)]
 
     def render(self) -> Text:
-        """Render the current frame of all spinners with gradient colors.
-
-        Returns:
-            Rich Text with multiple animated spinner characters.
-
-        """
+        """Render the current frame of all spinners with gradient colors."""
         result = Text()
         result.append(" ")
 
@@ -221,13 +181,6 @@ class LiveToolPanel:
 
     In quiet mode, renders the tool header only and skips result display.
 
-    Args:
-        console: Rich Console instance for output.
-        tool_use_id: Unique identifier for the tool use.
-        name: Name of the tool being called.
-        args: Dictionary of arguments passed to the tool.
-        quiet_mode: If True, use static display instead of Live updates.
-
     Usage:
         panel = LiveToolPanel(console, "tool-123", "Bash", {"command": "ls"})
         panel.start()
@@ -249,11 +202,6 @@ class LiveToolPanel:
         """Initialize the LiveToolPanel.
 
         Args:
-            console: Rich Console instance for output.
-            tool_use_id: Unique identifier for the tool use.
-            name: Name of the tool being called.
-            args: Dictionary of arguments passed to the tool.
-            quiet_mode: If True, use static display instead of Live updates.
             label: Resolved human label for background-task tools, threaded
                 through to the header by the registry.
 
@@ -279,10 +227,6 @@ class LiveToolPanel:
         """Build the tool call header content.
 
         Delegates to shared _build_tool_header() helper for consistent styling.
-
-        Returns:
-            Rich Text containing the styled tool header.
-
         """
         return _build_tool_header(self._name, self._args, self._quiet_mode, label=self._label)
 
@@ -291,13 +235,6 @@ class LiveToolPanel:
 
         Delegates to shared _build_result_content() helper for consistent styling.
         Special handling for Glob and Grep tools to show file counts and formatted lists.
-
-        Args:
-            max_lines: Maximum number of lines to display.
-
-        Returns:
-            Rich renderable containing the styled result.
-
         """
         if self._result is None:
             return Text()
@@ -325,15 +262,7 @@ class LiveToolPanel:
         return result
 
     def _build_glob_result(self, max_lines: int = _GLOB_MAX_LINES) -> Text:
-        """Build formatted Glob result showing file count and paths.
-
-        Args:
-            max_lines: Maximum number of files to display.
-
-        Returns:
-            Rich Text with formatted file list.
-
-        """
+        """Build formatted Glob result showing file count and paths."""
         assert self._result is not None  # Caller ensures this
         lines = [line for line in self._result.strip().split("\n") if line.strip()]
         total_files = len(lines)
@@ -368,15 +297,7 @@ class LiveToolPanel:
         return result
 
     def _build_grep_result(self, max_lines: int = _RESULT_MAX_LINES) -> Text | Syntax | Group:
-        """Build formatted Grep result showing match count.
-
-        Args:
-            max_lines: Maximum number of lines to display.
-
-        Returns:
-            Rich renderable with formatted grep output.
-
-        """
+        """Build formatted Grep result showing match count."""
         assert self._result is not None  # Caller ensures this
         lines = [line for line in self._result.strip().split("\n") if line.strip()]
         total_matches = len(lines)
@@ -392,12 +313,7 @@ class LiveToolPanel:
         return Group(result, content)
 
     def _build_edit_result(self) -> Text:
-        """Build formatted Edit result with surgery completion message.
-
-        Returns:
-            Rich Text with harmony restored visualization.
-
-        """
+        """Build formatted Edit result with surgery completion message."""
         result = Text()
 
         result.append("  ")
@@ -421,12 +337,7 @@ class LiveToolPanel:
         return result
 
     def _build_surgery_phase_indicator(self) -> Text:
-        """Build animated surgery phase indicator for Edit tool.
-
-        Returns:
-            Rich Text with animated energy flow and phase status.
-
-        """
+        """Build animated surgery phase indicator for Edit tool."""
         self._frame += 1
 
         result = Text()
@@ -458,10 +369,6 @@ class LiveToolPanel:
         """Render the current state as a Panel.
 
         Shows tool call header + either throbber (if waiting) or result.
-
-        Returns:
-            Rich Panel containing the consolidated tool call display.
-
         """
         header = self._build_tool_header_content()
 
@@ -542,13 +449,7 @@ class LiveToolPanel:
         self._live.start()
 
     def set_result(self, content: str, is_error: bool = False) -> None:
-        """Store result and update the display.
-
-        Args:
-            content: The result content from the tool.
-            is_error: Whether this is an error result.
-
-        """
+        """Store result and update the display."""
         self._result = content
         self._is_error = is_error
 
@@ -590,10 +491,6 @@ class LiveToolPanelRegistry:
     stopped, the finished panel is printed statically, and the ``Live``
     is restarted for any remaining active panels.
 
-    Args:
-        console: Rich Console instance for creating panels.
-        quiet_mode: If True, panels use static display instead of Live updates.
-
     Usage:
         registry = LiveToolPanelRegistry(console, quiet_mode=False)
         panel = registry.create("tool-123", "Bash", {"command": "ls"})
@@ -605,13 +502,7 @@ class LiveToolPanelRegistry:
     """
 
     def __init__(self, console: Console, quiet_mode: bool = False) -> None:
-        """Initialize the registry.
-
-        Args:
-            console: Rich Console instance for creating panels.
-            quiet_mode: If True, panels use static display instead of Live updates.
-
-        """
+        """Initialize the registry."""
         self._console = console
         self._quiet_mode = quiet_mode
         self._panels: dict[str, LiveToolPanel] = {}
@@ -636,12 +527,6 @@ class LiveToolPanelRegistry:
         Called on **every** ``ToolStartEvent`` (both the Live-panel and the
         callback render paths) so that ``observe_result`` can resolve a
         background ``task_id``'s label without a panel having been created.
-
-        Args:
-            tool_use_id: The id of the tool call.
-            name: The tool's name.
-            args: The tool's input args.
-
         """
         self._call_args[tool_use_id] = (name, args)
 
@@ -654,11 +539,6 @@ class LiveToolPanelRegistry:
         originating call's input args. Reads the originating call from the
         ``note_call`` store, so it works in both render modes (panel creation
         is not a prerequisite).
-
-        Args:
-            tool_use_id: The id of the originating tool call.
-            output: The originating tool's result string.
-
         """
         call = self._call_args.pop(tool_use_id, None)
         if call is None or call[0] not in self._LABEL_SOURCE_TOOL_NAMES:
@@ -677,9 +557,6 @@ class LiveToolPanelRegistry:
                 namespace prefix — launch tools vs. TaskCreate).
             task_id: The assigned task id to look up.
 
-        Returns:
-            The mapped label, or None if no mapping was recorded.
-
         """
         return self._task_labels.get(_task_label_ns_key(name, task_id))
 
@@ -690,10 +567,6 @@ class LiveToolPanelRegistry:
         todo-list tools (``TaskGet``/``TaskUpdate``/…) key off ``taskId``. Returns
         the harvested label for that id, or None when no mapping was recorded (the
         caller falls back to a non-opaque rendering).
-
-        Args:
-            name: The tool's name.
-            args: The tool's input args.
 
         Returns:
             The resolved label, or None if the tool is not Task-family or the id
@@ -716,15 +589,6 @@ class LiveToolPanelRegistry:
         The panel is added to the shared ``Live`` context which renders
         all active panels together.  Individual panels do **not** own
         their own ``Live`` instance.
-
-        Args:
-            tool_use_id: Unique identifier for the tool use.
-            name: Name of the tool being called.
-            args: Dictionary of arguments passed to the tool.
-
-        Returns:
-            The created LiveToolPanel.
-
         """
         if tool_use_id in self._panels:
             self._finalize_panel(tool_use_id)
@@ -764,24 +628,11 @@ class LiveToolPanelRegistry:
         return panel
 
     def get(self, tool_use_id: str) -> LiveToolPanel | None:
-        """Get a panel by its tool_use_id.
-
-        Args:
-            tool_use_id: The unique identifier of the tool use.
-
-        Returns:
-            The LiveToolPanel if found, None otherwise.
-
-        """
+        """Get a panel by its tool_use_id."""
         return self._panels.get(tool_use_id)
 
     def iter_active_panels(self) -> Iterator[LiveToolPanel]:
-        """Iterate over active panels in order.
-
-        Yields:
-            LiveToolPanel instances in the order they were created.
-
-        """
+        """Iterate over active panels in order."""
         for tid in self._active_order:
             panel = self._panels.get(tid)
             if panel:
@@ -792,13 +643,6 @@ class LiveToolPanelRegistry:
 
         Stops the shared ``Live``, prints the finalized panel statically,
         then restarts ``Live`` for any remaining active panels.
-
-        Args:
-            tool_use_id: The unique identifier of the tool use to remove.
-
-        Returns:
-            None
-
         """
         self._finalize_panel(tool_use_id)
 
@@ -808,10 +652,6 @@ class LiveToolPanelRegistry:
         Stops the shared ``Live`` and prints each panel's current state
         statically.  Use this for cleanup when a response ends
         unexpectedly.
-
-        Returns:
-            None
-
         """
         self._stop_live()
         for tid in list(self._active_order):
@@ -887,7 +727,6 @@ class ShutdownStep:
     """A step in the shutdown process.
 
     Attributes:
-        message: Description of the shutdown step.
         status: Current status of the step ("pending", "in_progress", or "completed").
 
     """
@@ -902,9 +741,6 @@ class ShutdownPanel:
     Consolidates all shutdown messages into a single panel that
     updates in place, showing the progression of shutdown steps.
 
-    Args:
-        console: Rich Console instance for output.
-
     Usage:
         panel = ShutdownPanel(console)
         panel.start("Received SIGINT, shutting down")
@@ -915,23 +751,13 @@ class ShutdownPanel:
     """
 
     def __init__(self, console: Console) -> None:
-        """Initialize the ShutdownPanel.
-
-        Args:
-            console: Rich Console instance for output.
-
-        """
+        """Initialize the ShutdownPanel."""
         self._console = console
         self._steps: list[ShutdownStep] = []
         self._live: Live | None = None
 
     def _render_panel(self) -> Panel:
-        """Render the current state as a Panel.
-
-        Returns:
-            Rich Panel containing all shutdown steps with status icons.
-
-        """
+        """Render the current state as a Panel."""
         content = Text()
 
         for i, step in enumerate(self._steps):
@@ -958,9 +784,6 @@ class ShutdownPanel:
         Args:
             initial_message: The first message to display (e.g., "Received SIGINT").
 
-        Returns:
-            None
-
         """
         self._steps.append(ShutdownStep(message=initial_message, status="completed"))
 
@@ -977,7 +800,6 @@ class ShutdownPanel:
         """Add a new step to the shutdown sequence.
 
         Args:
-            message: The step message to display.
             status: Initial status ("pending", "in_progress", "completed").
 
         Returns:
@@ -990,27 +812,14 @@ class ShutdownPanel:
         return len(self._steps) - 1
 
     def complete_step(self, index: int) -> None:
-        """Mark a step as completed.
-
-        Args:
-            index: Index of the step to mark as completed.
-
-        Returns:
-            None
-
-        """
+        """Mark a step as completed."""
         if 0 <= index < len(self._steps):
             self._steps[index].status = "completed"
             if self._live is not None:
                 self._live.update(self._render_panel())
 
     def complete_last_step(self) -> None:
-        """Mark the last step as completed.
-
-        Returns:
-            None
-
-        """
+        """Mark the last step as completed."""
         if self._steps:
             self.complete_step(len(self._steps) - 1)
 
@@ -1018,10 +827,6 @@ class ShutdownPanel:
         """Stop the live context and print the final panel.
 
         Call this when all shutdown steps are complete.
-
-        Returns:
-            None
-
         """
         if self._live is not None:
             self._live.stop()
@@ -1036,12 +841,7 @@ _shutdown_panel: ShutdownPanel | None = None
 
 
 def get_shutdown_panel() -> ShutdownPanel | None:
-    """Get the current shutdown panel instance.
-
-    Returns:
-        ShutdownPanel | None: The current shutdown panel, or None if not set.
-
-    """
+    """Get the current shutdown panel instance."""
     return _shutdown_panel
 
 
@@ -1050,9 +850,6 @@ def set_shutdown_panel(panel: ShutdownPanel | None) -> None:
 
     Args:
         panel: The ShutdownPanel instance to set, or None to clear.
-
-    Returns:
-        None
 
     """
     global _shutdown_panel

--- a/daydream/ui/summary.py
+++ b/daydream/ui/summary.py
@@ -1,8 +1,8 @@
 """Summary, table, and deep-review status components.
 
 Fix-progress indicators, the iteration divider, the run summary table, the
-issues table, the verdict-join table, the exploration-context summary, the TTT
-plan renderer, and the deep-mode stage/verification/preflight notices.
+issues table, the verdict-join table, the exploration-context summary, and the
+deep-mode stage/verification/preflight notices.
 """
 
 import json
@@ -45,13 +45,7 @@ def print_fix_progress(
     """Print fix progress indicator.
 
     Args:
-        console: Rich Console instance for output.
         item_num: Current item number (1-indexed).
-        total: Total number of items.
-        description: Description of the fix.
-
-    Returns:
-        None
 
     """
     text = Text()
@@ -67,12 +61,7 @@ def print_fix_complete(console: Console, item_num: int, total: int) -> None:
     """Print fix completion indicator.
 
     Args:
-        console: Rich Console instance for output.
         item_num: Current item number (1-indexed).
-        total: Total number of items.
-
-    Returns:
-        None
 
     """
     text = Text()
@@ -121,11 +110,6 @@ def print_summary(console: Console, data: SummaryData) -> None:
 
     Displays a comprehensive summary of the review/fix session
     with status badges for pass/fail.
-
-    Args:
-        console: Rich Console instance for output.
-        data: SummaryData containing all summary fields.
-
     """
     table = Table(
         title="✨ Review Summary",
@@ -161,7 +145,6 @@ def print_issues_table(console: Console, issues: list[dict]) -> None:
     """Display issues as a numbered Rich table.
 
     Args:
-        console: Rich Console instance.
         issues: List of issue dicts with id, title, severity, description,
                 recommendation, files keys.
 
@@ -223,9 +206,6 @@ def format_verdict_join(
         structural: Ids of structural (verdict-exempt) items.
         other: Leftover ids that fit no other bucket.
         total: Total number of items to fix (len(items)).
-
-    Returns:
-        A rich Table ready to pass to console.print.
 
     """
     table = Table(
@@ -340,57 +320,12 @@ def render_exploration_summary(ctx: "ExplorationContext") -> "Group | Text":
     return Group(Text(""), table)
 
 
-def render_ttt_plan(console: Console, plan: dict) -> None:
-    """Render a TTT plan, visually distinguishing ungrounded steps.
-
-    Plan steps with a non-empty ``references`` list render with default style
-    and their references inline beneath the change line. Steps with an empty
-    ``references`` list render dimmed with an ``(ungrounded)`` marker so the
-    user can spot LOW-grounded recommendations at a glance (D-08).
-
-    Args:
-        console: Rich console to render into.
-        plan: Plan dict. May be the flat shape ``{"changes": [...]}`` or the
-            nested shape ``{"plan": {"issues": [{"changes": [...]}, ...]}}``.
-
-    """
-    changes: list[dict] = []
-    if isinstance(plan.get("changes"), list):
-        changes = list(plan["changes"])
-    else:
-        nested = plan.get("plan", {}) if isinstance(plan.get("plan"), dict) else {}
-        for issue in nested.get("issues", []) or []:
-            if isinstance(issue, dict):
-                changes.extend(issue.get("changes", []) or [])
-
-    for change in changes:
-        if not isinstance(change, dict):
-            continue
-        file_path = change.get("file", "")
-        description = change.get("description", "")
-        references = change.get("references") or []
-        line = f"{file_path}: {description}" if file_path else description
-
-        if references:
-            console.print(Text(line))
-            for ref in references:
-                if not isinstance(ref, dict):
-                    continue
-                ref_file = ref.get("file", "")
-                ref_symbol = ref.get("symbol", "")
-                console.print(Text.assemble(("    → ", STYLE_DIM), (f"{ref_file}::{ref_symbol}", STYLE_DIM)))
-        else:
-            console.print(Text.assemble((line, STYLE_DIM), (" (ungrounded)", "yellow")))
-
-
 def print_stage_progress(console: Console, current: int, total: int, name: str) -> None:
     """Print a ``[stage N/M: name]`` banner at deep-mode stage boundaries (D-44).
 
     Args:
-        console: Rich Console instance for output.
         current: Current stage number (1-indexed).
-        total: Total number of stages.
-        name: Human-readable stage name.
+
     """
     console.print(f"[neon.cyan]▶[/] [neon.fg][stage {current}/{total}: {name}][/]")
 
@@ -405,8 +340,8 @@ def print_verification_summary(console: Console, verdicts_path: Path) -> None:
     never blocked by verifier output.
 
     Args:
-        console: Rich Console instance for output.
         verdicts_path: Path to the ``recommendation-verdicts.json`` file.
+
     """
     try:
         data = json.loads(verdicts_path.read_text())
@@ -442,12 +377,10 @@ def print_preflight_notice(
     (#156) at render time instead.
 
     Args:
-        console: Rich Console instance for output.
-        stages: Ordered list of stage display names.
-        stack_lines: Per-stack human-readable summary lines.
         agent_count: Total agent invocation count (D-30 formula).
         exploration_available: True when the exploration infrastructure
             (Phases 1-4) is installed and the pre-scan is wired in.
+
     """
     console.print("[neon.cyan]▶[/] [neon.fg]Deep-review pipeline pre-flight[/]")
     if exploration_available:

--- a/daydream/ui/tools.py
+++ b/daydream/ui/tools.py
@@ -81,10 +81,6 @@ def _primary_tool_value(name: str, args: dict[str, object]) -> tuple[str, str | 
     still shows something meaningful rather than a stray flag — the old blind
     ``next(iter(args.values()))`` surfaced ``replace_all=False`` as ``"False"``.
 
-    Args:
-        name: The tool's name.
-        args: The tool's input args.
-
     Returns:
         ``(value, key)`` — the primary value as a string and the arg key it came
         from (``None`` when no key matched). ``("", None)`` when nothing
@@ -123,10 +119,6 @@ def _parse_assigned_task_id(name: str, output: str) -> str | None:
     ``Command running in background with ID: <id>. …`` prose string; TaskCreate
     reports it as ``Task #<N> created successfully: …``.
 
-    Args:
-        name: The originating tool's name.
-        output: The tool's result string.
-
     Returns:
         The captured id, or None if the input does not match the expected shape.
     """
@@ -148,10 +140,6 @@ def _task_label_ns_key(name: str, task_id: str) -> str:
     ``1``).  This function prefixes each id with a short namespace tag so the
     two id spaces never share keys.
 
-    Args:
-        name: The originating tool's name.
-        task_id: The raw assigned id string.
-
     Returns:
         ``"bg:<task_id>"`` for launch tools, ``"tc:<task_id>"`` for TaskCreate.
     """
@@ -168,7 +156,6 @@ def _derive_task_label(args: dict[str, object], task_id: str) -> str:
     falling back to the bare id.
 
     Args:
-        args: The originating tool call's input args.
         task_id: The assigned id, used as the fallback when no label key is set.
 
     Returns:
@@ -207,9 +194,6 @@ def _label_source_name(name: str) -> str:
     this mapping here means ``resolve_call_label`` does not have to re-derive it
     with an inline ternary that runs parallel to ``_task_label_ns_key``.
 
-    Args:
-        name: A Task-family consumer tool name (e.g. ``"TaskOutput"``).
-
     Returns:
         The originating-tool name to pass to ``resolve_label`` / ``_task_label_ns_key``.
     """
@@ -236,12 +220,6 @@ def format_callback_progress(
     (when known) and otherwise fall back to a non-opaque derivation
     (``subject``/``description``/first command line), demoting the bare id to a
     parenthesized suffix.
-
-    Args:
-        name: The tool's name.
-        args: The tool's input args.
-        label: The resolved label for the call's id, or None when unknown.
-        max_len: Maximum length of the primary-argument value.
 
     Returns:
         A styled, indented Rich Text line that nests under the fix-progress header.
@@ -275,13 +253,6 @@ def format_callback_text(text: str) -> Text:
     Narration interleaves across concurrent fix agents, so it renders dim and
     indented — secondary to the colored ``[N/total] Fixing:`` headers, but still
     visible as a liveness signal during long parallel fixes.
-
-    Args:
-        text: A single line of agent narration.
-
-    Returns:
-        A dim, indented Rich Text line.
-
     """
     return Text(f"    {text}", style=STYLE_DIM)
 
@@ -294,13 +265,6 @@ def _colorize_tool_args(args: dict[str, object]) -> Text:
     - Strings in orange (paths in cyan)
     - Numbers in yellow
     - Booleans in purple
-
-    Args:
-        args: Dictionary of argument key-value pairs.
-
-    Returns:
-        Rich Text with neon styling applied.
-
     """
     result = Text()
 
@@ -339,8 +303,6 @@ def _format_label_and_id_str(label: str | None, task_id: str, *, id_prefix: str 
     logic is never duplicated.
 
     Args:
-        label: Resolved human-readable label, or None when unresolved.
-        task_id: The opaque/numeric id to demote to a parenthesized suffix.
         id_prefix: Optional prefix for the id (e.g. ``"#"`` for todo ids).
 
     Returns:
@@ -366,8 +328,6 @@ def _append_label_and_id(header_line: Text, label: str | None, task_id: str, *, 
 
     Args:
         header_line: The header Text to append to (mutated in place).
-        label: Resolved human-readable label, or None when unresolved.
-        task_id: The opaque/numeric id to demote to a dim suffix.
         id_prefix: Optional prefix for the id (e.g. ``"#"`` for todo ids).
 
     """
@@ -391,15 +351,9 @@ def _build_tool_header(
     Used by LiveToolPanel._build_tool_header().
 
     Args:
-        name: Name of the tool being called.
-        args: Dictionary of arguments passed to the tool.
-        quiet_mode: If True, hide command details for Bash tools.
         label: Resolved human-readable label for background-task tools
             (``TaskOutput``/``TaskStop``); when provided it leads the header
             and the opaque ``task_id`` is demoted to a dim suffix.
-
-    Returns:
-        Rich Text containing the styled tool header.
 
     """
     content = Text()
@@ -712,11 +666,6 @@ def _build_result_content(
     """Build styled result content with syntax highlighting.
 
     Used by LiveToolPanel._build_result_content().
-
-    Args:
-        content: The result content to display.
-        is_error: Whether this is an error result.
-        max_lines: Maximum number of lines to display.
 
     Returns:
         Tuple of (renderable content, was_truncated).

--- a/daydream/workspace.py
+++ b/daydream/workspace.py
@@ -60,7 +60,6 @@ class WorkContext:
         is_ephemeral: True when :attr:`repo` is an ephemeral worktree.
         run_id: ``<UTC YYYYMMDDHHMMSS>-<hex8>`` identifier used for the
             ephemeral path and intent files.
-
     """
 
     repo: Path
@@ -129,7 +128,6 @@ async def open_workspace(
         :func:`daydream.runner._dispatch` instead because it must fire only for
         ``output_mode="loop"`` (not ``--comment`` or ``--review``), and this
         function is deliberately mode-agnostic.
-
     """
     git_ops.assert_is_worktree(source)
 
@@ -226,15 +224,12 @@ def copy_files_into_ephemeral(
     skipped silently.
 
     Args:
-        source: The original worktree.
-        dest: The ephemeral worktree path.
         extra: Optional additional relative paths from CLI flags.
         skip: When True, return ``[]`` immediately (no-op for read-only
             review flows that do not need test fixtures).
 
     Returns:
         The list of paths actually copied (relative to *source*).
-
     """
     if skip:
         return []

--- a/tests/test_backend_claude.py
+++ b/tests/test_backend_claude.py
@@ -63,115 +63,6 @@ class MockResultMessage:
     subtype: str = "success"
 
 
-class MockClaudeSDKClient:
-    """Mock client that yields a configurable message sequence."""
-
-    def __init__(self, options: Any = None):
-        self.options = options
-        self._prompt: str = ""
-
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, *args):
-        pass
-
-    async def query(self, prompt: str):
-        self._prompt = prompt
-
-    async def receive_response(self):
-        yield MockAssistantMessage(content=[MockTextBlock(text="Hello world")])
-        yield MockResultMessage(total_cost_usd=0.05, structured_output=None)
-
-
-class MockClaudeSDKClientWithTools:
-    """Mock client that yields tool use messages."""
-
-    def __init__(self, options: Any = None):
-        self.options = options
-        self._prompt: str = ""
-
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, *args):
-        pass
-
-    async def query(self, prompt: str):
-        self._prompt = prompt
-
-    async def receive_response(self):
-        yield MockAssistantMessage(content=[
-            MockThinkingBlock(thinking="Let me think..."),
-        ])
-        yield MockAssistantMessage(content=[
-            MockTextBlock(text="I'll run a command."),
-        ])
-        yield MockAssistantMessage(content=[
-            MockToolUseBlock(id="tool-1", name="Bash", input={"command": "ls"}),
-        ])
-        yield MockUserMessage(content=[
-            MockToolResultBlock(tool_use_id="tool-1", content="file.py", is_error=False),
-        ])
-        yield MockResultMessage(total_cost_usd=0.10)
-
-
-class MockClaudeSDKClientErrorResult:
-    """Mock client whose run fails fatally (e.g. invalid API key).
-
-    Mirrors the real SDK shape: the failure arrives as a ResultMessage with
-    ``is_error=True`` and the error text in ``result`` — never as an
-    exception from the SDK itself.
-    """
-
-    def __init__(self, options: Any = None):
-        self.options = options
-        self._prompt: str = ""
-
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, *args):
-        pass
-
-    async def query(self, prompt: str):
-        self._prompt = prompt
-
-    async def receive_response(self):
-        yield MockAssistantMessage(
-            content=[MockTextBlock(text="Invalid API key · Fix external API key")]
-        )
-        yield MockResultMessage(
-            total_cost_usd=None,
-            is_error=True,
-            result="Invalid API key · Fix external API key",
-        )
-
-
-class MockClaudeSDKClientStructured:
-    """Mock client that returns structured output."""
-
-    def __init__(self, options: Any = None):
-        self.options = options
-        self._prompt: str = ""
-
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, *args):
-        pass
-
-    async def query(self, prompt: str):
-        self._prompt = prompt
-
-    async def receive_response(self):
-        yield MockAssistantMessage(content=[MockTextBlock(text="Parsed.")])
-        yield MockResultMessage(
-            total_cost_usd=0.02,
-            structured_output={"issues": [{"id": 1, "description": "Fix X", "file": "a.py", "line": 10}]},
-        )
-
-
 @pytest.fixture
 def patch_sdk(monkeypatch):
     """Return a function that patches the SDK imports in claude.py."""
@@ -187,13 +78,56 @@ def patch_sdk(monkeypatch):
     return _patch
 
 
+def _scripted_client(messages: list[Any]) -> type:
+    """Build a one-off ClaudeSDKClient stand-in yielding *messages* verbatim."""
+
+    class _ScriptedClient:
+        def __init__(self, options: Any = None) -> None:
+            self.options = options
+            self._prompt: str = ""
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args: Any) -> None:
+            return None
+
+        async def query(self, prompt: str) -> None:
+            self._prompt = prompt
+
+        async def receive_response(self):
+            for m in messages:
+                yield m
+
+    return _ScriptedClient
+
+
+async def _drive_claude_backend_to_list(
+    *,
+    messages: list[Any],
+    patch_sdk_fn: Any,
+    output_schema: Any = None,
+    prompt: str = "go",
+) -> list[Any]:
+    """Drive ClaudeBackend.execute with a scripted SDK message sequence."""
+    patch_sdk_fn(_scripted_client(messages))
+    backend = ClaudeBackend(model="opus")
+    events: list[Any] = []
+    async for event in backend.execute(Path("/tmp"), prompt, output_schema=output_schema):
+        events.append(event)
+    return events
+
+
 @pytest.mark.asyncio
 async def test_execute_yields_text_and_result(patch_sdk):
-    patch_sdk(MockClaudeSDKClient)
-    backend = ClaudeBackend(model="opus")
-    events = []
-    async for event in backend.execute(Path("/tmp"), "Say hello"):
-        events.append(event)
+    events = await _drive_claude_backend_to_list(
+        messages=[
+            MockAssistantMessage(content=[MockTextBlock(text="Hello world")]),
+            MockResultMessage(total_cost_usd=0.05, structured_output=None),
+        ],
+        patch_sdk_fn=patch_sdk,
+        prompt="Say hello",
+    )
 
     text_events = [e for e in events if isinstance(e, TextEvent)]
     cost_events = [e for e in events if isinstance(e, CostEvent)]
@@ -210,11 +144,17 @@ async def test_execute_yields_text_and_result(patch_sdk):
 
 @pytest.mark.asyncio
 async def test_execute_yields_tool_events(patch_sdk):
-    patch_sdk(MockClaudeSDKClientWithTools)
-    backend = ClaudeBackend(model="opus")
-    events = []
-    async for event in backend.execute(Path("/tmp"), "Run ls"):
-        events.append(event)
+    events = await _drive_claude_backend_to_list(
+        messages=[
+            MockAssistantMessage(content=[MockThinkingBlock(thinking="Let me think...")]),
+            MockAssistantMessage(content=[MockTextBlock(text="I'll run a command.")]),
+            MockAssistantMessage(content=[MockToolUseBlock(id="tool-1", name="Bash", input={"command": "ls"})]),
+            MockUserMessage(content=[MockToolResultBlock(tool_use_id="tool-1", content="file.py", is_error=False)]),
+            MockResultMessage(total_cost_usd=0.10),
+        ],
+        patch_sdk_fn=patch_sdk,
+        prompt="Run ls",
+    )
 
     thinking_events = [e for e in events if isinstance(e, ThinkingEvent)]
     tool_start_events = [e for e in events if isinstance(e, ToolStartEvent)]
@@ -233,12 +173,18 @@ async def test_execute_yields_tool_events(patch_sdk):
 
 @pytest.mark.asyncio
 async def test_execute_structured_output(patch_sdk):
-    patch_sdk(MockClaudeSDKClientStructured)
-    backend = ClaudeBackend(model="opus")
-    events = []
-    schema = {"type": "object", "properties": {"issues": {"type": "array"}}}
-    async for event in backend.execute(Path("/tmp"), "Parse", output_schema=schema):
-        events.append(event)
+    events = await _drive_claude_backend_to_list(
+        messages=[
+            MockAssistantMessage(content=[MockTextBlock(text="Parsed.")]),
+            MockResultMessage(
+                total_cost_usd=0.02,
+                structured_output={"issues": [{"id": 1, "description": "Fix X", "file": "a.py", "line": 10}]},
+            ),
+        ],
+        patch_sdk_fn=patch_sdk,
+        prompt="Parse",
+        output_schema={"type": "object", "properties": {"issues": {"type": "array"}}},
+    )
 
     result_events = [e for e in events if isinstance(e, ResultEvent)]
     assert len(result_events) == 1
@@ -256,7 +202,18 @@ async def test_error_result_raises_instead_of_clean_empty_result(patch_sdk):
     backend yielded a clean ResultEvent — the review then exited 0 with
     "no issues found" despite the agent never running.
     """
-    patch_sdk(MockClaudeSDKClientErrorResult)
+    patch_sdk(
+        _scripted_client(
+            [
+                MockAssistantMessage(content=[MockTextBlock(text="Invalid API key · Fix external API key")]),
+                MockResultMessage(
+                    total_cost_usd=None,
+                    is_error=True,
+                    result="Invalid API key · Fix external API key",
+                ),
+            ]
+        )
+    )
     backend = ClaudeBackend(model="opus")
     events = []
     with pytest.raises(ClaudeAgentError, match="Invalid API key"):
@@ -266,47 +223,31 @@ async def test_error_result_raises_instead_of_clean_empty_result(patch_sdk):
     assert not [e for e in events if isinstance(e, ResultEvent)]
 
 
-class MockClaudeSDKClientMaxTurns:
-    """Mock client whose run ends by hitting the turn cap.
-
-    Mirrors the real SDK shape for the turn-cap case: a ResultMessage with
-    ``is_error=True`` and ``subtype="error_max_turns"`` (``result`` is None,
-    so the detail falls back to the subtype).
-    """
-
-    def __init__(self, options: Any = None):
-        self.options = options
-        self._prompt: str = ""
-
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, *args):
-        pass
-
-    async def query(self, prompt: str):
-        self._prompt = prompt
-
-    async def receive_response(self):
-        yield MockAssistantMessage(content=[MockTextBlock(text="working on it")])
-        yield MockResultMessage(
-            total_cost_usd=None,
-            is_error=True,
-            result=None,
-            subtype="error_max_turns",
-        )
-
-
 @pytest.mark.asyncio
 async def test_max_turns_result_raises_typed_error(patch_sdk):
     """error_max_turns must raise the typed MaxTurnsError carrying the subtype.
 
     A generic ClaudeAgentError left callers (and the trajectory) unable to
-    distinguish a turn-cap failure from a real backend error.
+    distinguish a turn-cap failure from a real backend error. Mirrors the real
+    SDK shape: a ResultMessage with ``is_error=True`` and
+    ``subtype="error_max_turns"`` (``result`` is None, so the detail falls back
+    to the subtype).
     """
     from daydream.backends.claude import MaxTurnsError
 
-    patch_sdk(MockClaudeSDKClientMaxTurns)
+    patch_sdk(
+        _scripted_client(
+            [
+                MockAssistantMessage(content=[MockTextBlock(text="working on it")]),
+                MockResultMessage(
+                    total_cost_usd=None,
+                    is_error=True,
+                    result=None,
+                    subtype="error_max_turns",
+                ),
+            ]
+        )
+    )
     backend = ClaudeBackend(model="opus")
     with pytest.raises(MaxTurnsError) as excinfo:
         async for _ in backend.execute(Path("/tmp"), "Review this"):
@@ -316,16 +257,18 @@ async def test_max_turns_result_raises_typed_error(patch_sdk):
     assert isinstance(excinfo.value, ClaudeAgentError)
 
 
-def test_format_skill_invocation_full_key():
+@pytest.mark.parametrize(
+    ("skill_key", "args", "expected"),
+    [
+        ("beagle-python:review-python", "", "/beagle-python:review-python"),
+        ("beagle-core:fetch-pr-feedback", "--pr 42 --bot mybot", "/beagle-core:fetch-pr-feedback --pr 42 --bot mybot"),
+    ],
+    ids=["full-key", "with-args"],
+)
+def test_format_skill_invocation(skill_key, args, expected):
     backend = ClaudeBackend(model="fixture-model")
-    result = backend.format_skill_invocation("beagle-python:review-python")
-    assert result == "/beagle-python:review-python"
-
-
-def test_format_skill_invocation_with_args():
-    backend = ClaudeBackend(model="fixture-model")
-    result = backend.format_skill_invocation("beagle-core:fetch-pr-feedback", "--pr 42 --bot mybot")
-    assert result == "/beagle-core:fetch-pr-feedback --pr 42 --bot mybot"
+    result = backend.format_skill_invocation(skill_key, args) if args else backend.format_skill_invocation(skill_key)
+    assert result == expected
 
 
 @pytest.mark.parametrize("cmd,allowed", [
@@ -612,38 +555,6 @@ def _assistant_message(*, text: str, message_id: str) -> MockAssistantMessage:
 
 def _result_message(*, cost: float | None = 0.0) -> MockResultMessage:
     return MockResultMessage(total_cost_usd=cost, structured_output=None)
-
-
-async def _drive_claude_backend_to_list(
-    *,
-    messages: list[Any],
-    patch_sdk_fn: Any,
-) -> list[Any]:
-    """Drive ClaudeBackend.execute with a scripted SDK message sequence."""
-
-    class _ScriptedClient:
-        def __init__(self, options: Any = None) -> None:
-            self.options = options
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *args: Any) -> None:
-            return None
-
-        async def query(self, prompt: str) -> None:
-            return None
-
-        async def receive_response(self):
-            for m in messages:
-                yield m
-
-    patch_sdk_fn(_ScriptedClient)
-    backend = ClaudeBackend(model="opus")
-    events: list[Any] = []
-    async for event in backend.execute(Path("/tmp"), "go"):
-        events.append(event)
-    return events
 
 
 @pytest.mark.asyncio

--- a/tests/test_backend_codex.py
+++ b/tests/test_backend_codex.py
@@ -31,15 +31,17 @@ from tests.harness.codex_replay import make_mock_process, make_mock_process_from
 FIXTURES_DIR = Path(__file__).parent / "fixtures" / "codex_jsonl"
 
 
+async def _run_fixture(backend, prompt, fixture, **kwargs):
+    """Drive ``execute`` over a canned fixture and collect the event list."""
+    mock_proc = make_mock_process_from_fixture(fixture)
+    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
+        return [event async for event in backend.execute(Path("/tmp"), prompt, **kwargs)]
+
+
 @pytest.mark.asyncio
 async def test_simple_text_events():
     backend = CodexBackend(model="gpt-5.3-codex")
-    mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
-
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
-        events = []
-        async for event in backend.execute(Path("/tmp"), "Say hello"):
-            events.append(event)
+    events = await _run_fixture(backend, "Say hello", "simple_text.jsonl")
 
     text_events = [e for e in events if isinstance(e, TextEvent)]
     cost_events = [e for e in events if isinstance(e, CostEvent)]
@@ -70,12 +72,7 @@ async def test_simple_text_events():
 @pytest.mark.asyncio
 async def test_tool_use_events():
     backend = CodexBackend(model="fixture-model")
-    mock_proc = make_mock_process_from_fixture("tool_use.jsonl")
-
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
-        events = []
-        async for event in backend.execute(Path("/tmp"), "Run ls"):
-            events.append(event)
+    events = await _run_fixture(backend, "Run ls", "tool_use.jsonl")
 
     thinking = [e for e in events if isinstance(e, ThinkingEvent)]
     tool_starts = [e for e in events if isinstance(e, ToolStartEvent)]
@@ -95,22 +92,47 @@ async def test_tool_use_events():
     assert any(t.text == "Done!" for t in texts)
 
 
+@pytest.mark.parametrize(
+    ("fixture", "expected_output", "expected_text_count"),
+    [
+        (
+            "structured_output.jsonl",
+            {"issues": [{"id": 1, "description": "Fix type hints", "file": "app.py", "line": 5}]},
+            None,
+        ),
+        (
+            # Text delivered via item.updated deltas (item.completed has empty content).
+            "streamed_structured_output.jsonl",
+            {"issues": [{"id": 1, "description": "Missing type hint", "file": "app.py", "line": 10}]},
+            1,
+        ),
+        (
+            # agent_message with output_text content blocks (schema-constrained).
+            "output_text_blocks.jsonl",
+            {"issues": [{"id": 1, "description": "Bad import", "file": "main.py", "line": 3}]},
+            None,
+        ),
+        (
+            # Structured output returned in turn.completed result field.
+            "turn_completed_result.jsonl",
+            {"issues": [{"id": 1, "description": "Unused variable", "file": "utils.py", "line": 22}]},
+            None,
+        ),
+    ],
+    ids=["item-completed", "streamed-item-updated", "output-text-blocks", "turn-completed-result"],
+)
 @pytest.mark.asyncio
-async def test_structured_output():
+async def test_structured_output(fixture, expected_output, expected_text_count):
+    """Structured output is extracted across the Codex delivery shapes."""
     backend = CodexBackend(model="fixture-model")
-    mock_proc = make_mock_process_from_fixture("structured_output.jsonl")
     schema = {"type": "object", "properties": {"issues": {"type": "array"}}}
-
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
-        events = []
-        async for event in backend.execute(Path("/tmp"), "Parse", output_schema=schema):
-            events.append(event)
+    events = await _run_fixture(backend, "Parse", fixture, output_schema=schema)
 
     result_events = [e for e in events if isinstance(e, ResultEvent)]
     assert len(result_events) == 1
-    assert result_events[0].structured_output == {
-        "issues": [{"id": 1, "description": "Fix type hints", "file": "app.py", "line": 5}]
-    }
+    assert result_events[0].structured_output == expected_output
+    if expected_text_count is not None:
+        assert len([e for e in events if isinstance(e, TextEvent)]) == expected_text_count
 
 
 @pytest.mark.asyncio
@@ -226,57 +248,11 @@ async def test_codex_stdout_limit_allows_large_jsonl_events() -> None:
 
 
 @pytest.mark.asyncio
-async def test_streamed_structured_output_via_item_updated():
-    """Text delivered via item.updated deltas (item.completed has empty content)."""
-    backend = CodexBackend(model="fixture-model")
-    mock_proc = make_mock_process_from_fixture("streamed_structured_output.jsonl")
-    schema = {"type": "object", "properties": {"issues": {"type": "array"}}}
-
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
-        events = []
-        async for event in backend.execute(Path("/tmp"), "Parse", output_schema=schema):
-            events.append(event)
-
-    result_events = [e for e in events if isinstance(e, ResultEvent)]
-    assert len(result_events) == 1
-    assert result_events[0].structured_output == {
-        "issues": [{"id": 1, "description": "Missing type hint", "file": "app.py", "line": 10}]
-    }
-
-    text_events = [e for e in events if isinstance(e, TextEvent)]
-    assert len(text_events) == 1
-
-
-@pytest.mark.asyncio
-async def test_output_text_content_blocks():
-    """agent_message with output_text content blocks (schema-constrained)."""
-    backend = CodexBackend(model="fixture-model")
-    mock_proc = make_mock_process_from_fixture("output_text_blocks.jsonl")
-    schema = {"type": "object", "properties": {"issues": {"type": "array"}}}
-
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
-        events = []
-        async for event in backend.execute(Path("/tmp"), "Parse", output_schema=schema):
-            events.append(event)
-
-    result_events = [e for e in events if isinstance(e, ResultEvent)]
-    assert len(result_events) == 1
-    assert result_events[0].structured_output == {
-        "issues": [{"id": 1, "description": "Bad import", "file": "main.py", "line": 3}]
-    }
-
-
-@pytest.mark.asyncio
 async def test_toplevel_text_field():
     """Real Codex format: text directly on item, not in content blocks."""
     backend = CodexBackend(model="fixture-model")
-    mock_proc = make_mock_process_from_fixture("toplevel_text.jsonl")
     schema = {"type": "object", "properties": {"issues": {"type": "array"}}}
-
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
-        events = []
-        async for event in backend.execute(Path("/tmp"), "Parse", output_schema=schema):
-            events.append(event)
+    events = await _run_fixture(backend, "Parse", "toplevel_text.jsonl", output_schema=schema)
 
     thinking = [e for e in events if isinstance(e, ThinkingEvent)]
     assert len(thinking) == 1
@@ -300,36 +276,12 @@ async def test_toplevel_text_field():
 
 
 @pytest.mark.asyncio
-async def test_turn_completed_result_field():
-    """Structured output returned in turn.completed result field."""
-    backend = CodexBackend(model="fixture-model")
-    mock_proc = make_mock_process_from_fixture("turn_completed_result.jsonl")
-    schema = {"type": "object", "properties": {"issues": {"type": "array"}}}
-
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
-        events = []
-        async for event in backend.execute(Path("/tmp"), "Parse", output_schema=schema):
-            events.append(event)
-
-    result_events = [e for e in events if isinstance(e, ResultEvent)]
-    assert len(result_events) == 1
-    assert result_events[0].structured_output == {
-        "issues": [{"id": 1, "description": "Unused variable", "file": "utils.py", "line": 22}]
-    }
-
-
-@pytest.mark.asyncio
 async def test_turn_completed_cached_input_tokens():
     """Codex emits cached_input_tokens on turn.completed.usage; surface it on
     MetricsEvent and CostEvent so cache-hit ratios work for the Codex backend
     (refs #65, K4 — fix for the historical hardcoded cached_tokens=None)."""
     backend = CodexBackend(model="fixture-model")
-    mock_proc = make_mock_process_from_fixture("turn_completed_cached_tokens.jsonl")
-
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
-        events = []
-        async for event in backend.execute(Path("/tmp"), "Cached"):
-            events.append(event)
+    events = await _run_fixture(backend, "Cached", "turn_completed_cached_tokens.jsonl")
 
     metrics_events = [e for e in events if isinstance(e, MetricsEvent)]
     cost_events = [e for e in events if isinstance(e, CostEvent)]
@@ -434,12 +386,7 @@ async def test_codex_cost_none_for_unknown_model() -> None:
 async def test_codex_backend_emits_turn_end_after_each_agent_message() -> None:
     """One TurnEndEvent per item.completed of type agent_message."""
     backend = CodexBackend(model="fixture-model")
-    mock_proc = make_mock_process_from_fixture("two_agent_turns.jsonl")
-
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
-        events = []
-        async for event in backend.execute(Path("/tmp"), "Two turns"):
-            events.append(event)
+    events = await _run_fixture(backend, "Two turns", "two_agent_turns.jsonl")
 
     texts = [e for e in events if isinstance(e, TextEvent)]
     turn_ends = [e for e in events if isinstance(e, TurnEndEvent)]
@@ -528,22 +475,19 @@ async def test_concurrent_execute_calls_do_not_share_stdout_reader() -> None:
             await second_task
 
 
-def test_format_skill_invocation():
+@pytest.mark.parametrize(
+    ("skill_key", "args", "expected"),
+    [
+        ("beagle-python:review-python", "", "$review-python"),
+        ("beagle-core:fetch-pr-feedback", "--pr 42 --bot mybot", "$fetch-pr-feedback --pr 42 --bot mybot"),
+        ("commit-push", "", "$commit-push"),
+    ],
+    ids=["namespaced", "with-args", "no-namespace"],
+)
+def test_format_skill_invocation(skill_key, args, expected):
     backend = CodexBackend(model="fixture-model")
-    result = backend.format_skill_invocation("beagle-python:review-python")
-    assert result == "$review-python"
-
-
-def test_format_skill_invocation_with_args():
-    backend = CodexBackend(model="fixture-model")
-    result = backend.format_skill_invocation("beagle-core:fetch-pr-feedback", "--pr 42 --bot mybot")
-    assert result == "$fetch-pr-feedback --pr 42 --bot mybot"
-
-
-def test_format_skill_invocation_no_namespace():
-    backend = CodexBackend(model="fixture-model")
-    result = backend.format_skill_invocation("commit-push")
-    assert result == "$commit-push"
+    result = backend.format_skill_invocation(skill_key, args) if args else backend.format_skill_invocation(skill_key)
+    assert result == expected
 
 
 class TestUnwrapShellCommand:
@@ -617,15 +561,8 @@ async def test_well_formed_multi_tool_no_orphans(caplog: pytest.LogCaptureFixtur
     no parser warning may fire.
     """
     backend = CodexBackend(model="fixture-model")
-    mock_proc = make_mock_process_from_fixture("item_started_no_id.jsonl")
-
-    with (
-        patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc),
-        caplog.at_level(logging.WARNING, logger="daydream.backends.codex"),
-    ):
-        events = []
-        async for event in backend.execute(Path("/tmp"), "Run tools"):
-            events.append(event)
+    with caplog.at_level(logging.WARNING, logger="daydream.backends.codex"):
+        events = await _run_fixture(backend, "Run tools", "item_started_no_id.jsonl")
 
     tool_starts = [e for e in events if isinstance(e, ToolStartEvent)]
     tool_results = [e for e in events if isinstance(e, ToolResultEvent)]
@@ -653,15 +590,8 @@ async def test_orphaned_tool_result_is_observable(caplog: pytest.LogCaptureFixtu
     trajectory recorder still buckets it without a silent drop.
     """
     backend = CodexBackend(model="fixture-model")
-    mock_proc = make_mock_process_from_fixture("orphaned_tool_result.jsonl")
-
-    with (
-        patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc),
-        caplog.at_level(logging.WARNING, logger="daydream.backends.codex"),
-    ):
-        events = []
-        async for event in backend.execute(Path("/tmp"), "Orphan"):
-            events.append(event)
+    with caplog.at_level(logging.WARNING, logger="daydream.backends.codex"):
+        events = await _run_fixture(backend, "Orphan", "orphaned_tool_result.jsonl")
 
     tool_results = [e for e in events if isinstance(e, ToolResultEvent)]
     assert len(tool_results) == 1
@@ -687,16 +617,10 @@ async def test_malformed_structured_output_warns(caplog: pytest.LogCaptureFixtur
     ``structured_output=None`` (the schema parse genuinely failed).
     """
     backend = CodexBackend(model="fixture-model")
-    mock_proc = make_mock_process_from_fixture("malformed_structured_output.jsonl")
     schema = {"type": "object", "properties": {"issues": {"type": "array"}}}
 
-    with (
-        patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc),
-        caplog.at_level(logging.WARNING, logger="daydream.backends.codex"),
-    ):
-        events = []
-        async for event in backend.execute(Path("/tmp"), "Parse", output_schema=schema):
-            events.append(event)
+    with caplog.at_level(logging.WARNING, logger="daydream.backends.codex"):
+        events = await _run_fixture(backend, "Parse", "malformed_structured_output.jsonl", output_schema=schema)
 
     result_events = [e for e in events if isinstance(e, ResultEvent)]
     assert len(result_events) == 1

--- a/tests/test_backend_pi.py
+++ b/tests/test_backend_pi.py
@@ -46,6 +46,20 @@ from daydream.backends.pi import (
 from tests.harness.pi_replay import make_mock_process, make_mock_process_from_fixture
 
 
+async def _run_and_capture_args(backend, prompt="p", *, fixture="simple_text.jsonl", **kwargs):
+    """Drive ``execute`` over a canned fixture and return the subprocess argv.
+
+    Consolidates the recurring pattern of patching ``create_subprocess_exec``,
+    draining the event stream, and reading ``mock_exec.call_args``. Returns the
+    ``(flat_args, mock_exec)`` pair so callers can also assert on kwargs.
+    """
+    mock_proc = make_mock_process_from_fixture(fixture)
+    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+        async for _ in backend.execute(Path("/tmp"), prompt, **kwargs):
+            pass
+    return list(mock_exec.call_args.args), mock_exec
+
+
 @pytest.mark.asyncio
 async def test_simple_text_events():
     backend = PiBackend(model="glm-5.2")
@@ -185,17 +199,12 @@ async def test_error_turn_raises_pi_error():
 async def test_continuation_token_uses_session_id_flag():
     """A pi continuation token maps to --session-id <id> (not --no-session)."""
     backend = PiBackend(model="glm-5.2")
-    mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
     token = ContinuationToken(backend="pi", data={"session_id": "pi_resume_me"})
 
-    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-        async for _ in backend.execute(Path("/tmp"), "Continue", continuation=token):
-            pass
-
-        flat_args = list(mock_exec.call_args.args)
-        assert "--session-id" in flat_args
-        assert flat_args[flat_args.index("--session-id") + 1] == "pi_resume_me"
-        assert "--no-session" not in flat_args
+    flat_args, _ = await _run_and_capture_args(backend, "Continue", continuation=token)
+    assert "--session-id" in flat_args
+    assert flat_args[flat_args.index("--session-id") + 1] == "pi_resume_me"
+    assert "--no-session" not in flat_args
 
 
 @pytest.mark.asyncio
@@ -210,38 +219,25 @@ async def test_fresh_run_uses_session_id_not_no_session():
     phase_test_and_heal feeds the token back into its retry loop.
     """
     backend = PiBackend(model="glm-5.2")
-    mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
 
-    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-        async for _ in backend.execute(Path("/tmp"), "Fresh"):
-            pass
-
-        flat_args = list(mock_exec.call_args.args)
-        assert "--no-session" not in flat_args
-        assert "--session-id" in flat_args
-        passed_id = flat_args[flat_args.index("--session-id") + 1]
-        # A genuine UUID: the token must name a resumable persistent session.
-        uuid.UUID(passed_id)
+    flat_args, _ = await _run_and_capture_args(backend, "Fresh")
+    assert "--no-session" not in flat_args
+    assert "--session-id" in flat_args
+    passed_id = flat_args[flat_args.index("--session-id") + 1]
+    # A genuine UUID: the token must name a resumable persistent session.
+    uuid.UUID(passed_id)
 
 
 @pytest.mark.asyncio
 async def test_read_only_restricts_tools():
     """read_only=True adds --tools read,find,ls,grep (excludes mutating tools)."""
     backend = PiBackend(model="glm-5.2")
-    mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
 
-    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-        async for _ in backend.execute(Path("/tmp"), "p", read_only=True):
-            pass
-
-        flat_args = list(mock_exec.call_args.args)
-        assert flat_args[flat_args.index("--tools") + 1] == "read,find,ls,grep"
+    flat_args, _ = await _run_and_capture_args(backend, read_only=True)
+    assert flat_args[flat_args.index("--tools") + 1] == "read,find,ls,grep"
     # read_only=False by default → no --tools flag.
-    mock_proc2 = make_mock_process_from_fixture("simple_text.jsonl")
-    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc2) as mock_exec2:
-        async for _ in backend.execute(Path("/tmp"), "p"):
-            pass
-        assert "--tools" not in list(mock_exec2.call_args.args)
+    flat_args_default, _ = await _run_and_capture_args(backend)
+    assert "--tools" not in flat_args_default
 
 
 @pytest.mark.asyncio
@@ -252,16 +248,11 @@ async def test_env_overrides_forwarded_as_flags(monkeypatch):
     monkeypatch.setenv("PI_THINKING", "medium")
 
     backend = PiBackend(model="glm-5.2")
-    mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
 
-    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-        async for _ in backend.execute(Path("/tmp"), "p"):
-            pass
-
-        flat_args = list(mock_exec.call_args.args)
-        assert flat_args[flat_args.index("--provider") + 1] == "zai"
-        assert flat_args[flat_args.index("--api-key") + 1] == "secret-key"
-        assert flat_args[flat_args.index("--thinking") + 1] == "medium"
+    flat_args, _ = await _run_and_capture_args(backend)
+    assert flat_args[flat_args.index("--provider") + 1] == "zai"
+    assert flat_args[flat_args.index("--api-key") + 1] == "secret-key"
+    assert flat_args[flat_args.index("--thinking") + 1] == "medium"
 
 
 @pytest.mark.asyncio
@@ -553,22 +544,19 @@ async def test_concurrent_execute_calls_do_not_share_stdout_reader():
             await second_task
 
 
-def test_render_tool_result_text_blocks():
-    result = {"content": [{"type": "text", "text": "line1"}, {"type": "text", "text": "line2"}]}
-    assert _render_tool_result(result) == "line1line2"
-
-
-def test_render_tool_result_string_content():
-    assert _render_tool_result({"content": "raw"}) == "raw"
-
-
-def test_render_tool_result_falls_back_to_details():
-    assert _render_tool_result({"details": {"note": "x"}}) == "{'note': 'x'}"
-
-
-def test_render_tool_result_non_dict():
-    assert _render_tool_result("plain") == "plain"
-    assert _render_tool_result(None) == ""
+@pytest.mark.parametrize(
+    ("result", "expected"),
+    [
+        ({"content": [{"type": "text", "text": "line1"}, {"type": "text", "text": "line2"}]}, "line1line2"),
+        ({"content": "raw"}, "raw"),
+        ({"details": {"note": "x"}}, "{'note': 'x'}"),
+        ("plain", "plain"),
+        (None, ""),
+    ],
+    ids=["text-blocks", "string-content", "details-fallback", "non-dict-str", "non-dict-none"],
+)
+def test_render_tool_result(result, expected):
+    assert _render_tool_result(result) == expected
 
 
 def test_schema_instruction_contains_schema_json():
@@ -629,22 +617,20 @@ def test_resolve_skill_dir_env_override_wins(tmp_path, monkeypatch):
     assert _resolve_skill_dir("beagle-python:review-python") == override_dir
 
 
-def test_format_skill_invocation_emits_native_command():
+@pytest.mark.parametrize(
+    ("skill_key", "args", "expected"),
+    [
+        ("beagle-python:review-python", "", "/skill:review-python"),
+        ("beagle-core:review-structure", "--pr 7", "/skill:review-structure --pr 7"),
+        ("review-go", "", "/skill:review-go"),
+    ],
+    ids=["namespaced-strips-prefix", "preserves-args", "bare-slug-unchanged"],
+)
+def test_format_skill_invocation(skill_key, args, expected):
     backend = PiBackend(model="glm-5.2")
-    result = backend.format_skill_invocation("beagle-python:review-python")
-    assert result == "/skill:review-python"
-    assert "beagle-python" not in result
-
-
-def test_format_skill_invocation_preserves_args():
-    backend = PiBackend(model="glm-5.2")
-    result = backend.format_skill_invocation("beagle-core:review-structure", "--pr 7")
-    assert result == "/skill:review-structure --pr 7"
-
-
-def test_format_skill_invocation_bare_slug_unchanged():
-    backend = PiBackend(model="glm-5.2")
-    assert backend.format_skill_invocation("review-go") == "/skill:review-go"
+    result = backend.format_skill_invocation(skill_key, args) if args else backend.format_skill_invocation(skill_key)
+    assert result == expected
+    assert "beagle-" not in result
 
 
 def test_skill_token_re_grammar_matches_pi_name_rules():
@@ -745,13 +731,9 @@ def test_create_backend_pi_returns_pi_backend_with_default_model():
     assert isinstance(backend, PiBackend)
     assert backend.model == DEFAULT_PI_MODEL
 
-
-def test_create_backend_pi_custom_model():
-    from daydream.backends import create_backend
-
-    backend = create_backend("pi", model="glm-4.5-air")
-    assert isinstance(backend, PiBackend)
-    assert backend.model == "glm-4.5-air"
+    custom = create_backend("pi", model="glm-4.5-air")
+    assert isinstance(custom, PiBackend)
+    assert custom.model == "glm-4.5-air"
 
 
 def test_create_backend_invalid_includes_pi_in_message():
@@ -857,41 +839,27 @@ async def test_pi_trajectory_is_valid_atif_v1_6(tmp_path: Path):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize(
+    ("env_provider", "expected"),
+    [(None, "zai"), ("my-proxy", "my-proxy")],
+    ids=["default-zai", "PI_PROVIDER-override"],
+)
 @pytest.mark.asyncio
-async def test_default_provider_is_zai(monkeypatch):
-    """Without PI_PROVIDER, --provider defaults to ``zai`` (matches DEFAULT_PI_MODEL).
+async def test_provider_flag(monkeypatch, env_provider, expected):
+    """--provider defaults to ``zai`` (matches DEFAULT_PI_MODEL) unless PI_PROVIDER overrides it.
 
     The z.ai provider is registered by the ``~/.pi/extensions/zai-provider``
     pi extension; daydream must always point pi at it so the default GLM model
     resolves without relying on a user-configured models.json entry.
     """
-    monkeypatch.delenv("PI_PROVIDER", raising=False)
+    if env_provider is None:
+        monkeypatch.delenv("PI_PROVIDER", raising=False)
+    else:
+        monkeypatch.setenv("PI_PROVIDER", env_provider)
 
     backend = PiBackend(model="glm-5.2")
-    mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
-
-    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-        async for _ in backend.execute(Path("/tmp"), "p"):
-            pass
-
-        flat_args = list(mock_exec.call_args.args)
-        assert flat_args[flat_args.index("--provider") + 1] == "zai"
-
-
-@pytest.mark.asyncio
-async def test_pi_provider_override(monkeypatch):
-    """PI_PROVIDER overrides the z.ai default."""
-    monkeypatch.setenv("PI_PROVIDER", "my-proxy")
-
-    backend = PiBackend(model="glm-5.2")
-    mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
-
-    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-        async for _ in backend.execute(Path("/tmp"), "p"):
-            pass
-
-        flat_args = list(mock_exec.call_args.args)
-        assert flat_args[flat_args.index("--provider") + 1] == "my-proxy"
+    flat_args, _ = await _run_and_capture_args(backend)
+    assert flat_args[flat_args.index("--provider") + 1] == expected
 
 
 # ---------------------------------------------------------------------------
@@ -911,20 +879,14 @@ async def test_append_system_prompt_preamble_in_args():
     from daydream.backends.pi import _PI_SYSTEM_PREAMBLE
 
     backend = PiBackend(model="glm-5.2")
-    mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
-
-    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-        async for _ in backend.execute(Path("/tmp"), "p"):
-            pass
-
-        flat_args = list(mock_exec.call_args.args)
-        assert "--append-system-prompt" in flat_args
-        preamble = flat_args[flat_args.index("--append-system-prompt") + 1]
-        assert preamble == _PI_SYSTEM_PREAMBLE
-        # Preamble must actually carry the budget-awareness guidance, not be
-        # an empty stub a future refactor could silently collapse to.
-        assert "tool-call budget" in preamble
-        assert "grep" in preamble.lower()
+    flat_args, _ = await _run_and_capture_args(backend)
+    assert "--append-system-prompt" in flat_args
+    preamble = flat_args[flat_args.index("--append-system-prompt") + 1]
+    assert preamble == _PI_SYSTEM_PREAMBLE
+    # Preamble must actually carry the budget-awareness guidance, not be
+    # an empty stub a future refactor could silently collapse to.
+    assert "tool-call budget" in preamble
+    assert "grep" in preamble.lower()
 
 
 # ---------------------------------------------------------------------------
@@ -932,19 +894,10 @@ async def test_append_system_prompt_preamble_in_args():
 # ---------------------------------------------------------------------------
 
 
-def test_pierror_retryable_default():
-    err = PiError("something went wrong")
-    assert err.retryable is False
-
-
-def test_pierror_retryable_kwarg():
-    err = PiError("429 rate limit", retryable=True)
-    assert err.retryable is True
-
-
-def test_pierror_message_preserved():
-    err = PiError("auth failed", retryable=False)
-    assert str(err) == "auth failed"
+def test_pierror_retryable_default_and_kwarg_and_message():
+    assert PiError("something went wrong").retryable is False
+    assert PiError("429 rate limit", retryable=True).retryable is True
+    assert str(PiError("auth failed", retryable=False)) == "auth failed"
 
 
 # ---------------------------------------------------------------------------
@@ -952,73 +905,56 @@ def test_pierror_message_preserved():
 # ---------------------------------------------------------------------------
 
 
-def test_is_retryable_error_message_429():
-    assert _is_retryable_error_message("429 Too Many Requests") is True
-
-
-def test_is_retryable_error_message_overload():
-    assert _is_retryable_error_message("Service is currently overloaded") is True
-
-
-def test_is_retryable_error_message_rate_limit_space():
-    assert _is_retryable_error_message("rate limit exceeded") is True
-
-
-def test_is_retryable_error_message_rate_limit_underscore():
-    assert _is_retryable_error_message("rate_limit hit") is True
-
-
-def test_is_retryable_error_message_capacity():
-    assert _is_retryable_error_message("Capacity unavailable") is True
-
-
-def test_is_retryable_error_message_too_many_requests():
-    assert _is_retryable_error_message("too many requests from this IP") is True
-
-
-def test_is_retryable_error_message_throttle():
-    assert _is_retryable_error_message("Request throttled") is True
-
-
-def test_is_retryable_error_message_throttling():
-    assert _is_retryable_error_message("throttling in effect") is True
-
-
-def test_is_retryable_error_message_case_insensitive():
-    assert _is_retryable_error_message("OVERLOAD detected") is True
-
-
-def test_is_retryable_error_message_non_retryable():
-    assert _is_retryable_error_message("auth failed") is False
-
-
-def test_is_retryable_error_message_not_overloaded_is_non_retryable():
-    assert _is_retryable_error_message("service is not overloaded") is False
-
-
-def test_is_retryable_error_message_capacity_planning_is_non_retryable():
-    assert _is_retryable_error_message("capacity planning required") is False
-
-
-def test_is_retryable_error_message_empty():
-    assert _is_retryable_error_message("") is False
-
-
-def test_is_retryable_error_message_unknown_pi_error():
-    assert _is_retryable_error_message("Unknown Pi error") is False
-
-
-def test_is_retryable_error_message_stream_drop_signatures():
-    """Stream-drop signatures are classified as retryable (z.ai/GLM connection drops)."""
-    for sig in (
-        "terminated",
-        "ECONNRESET",
-        "connection reset",
-        "socket hang up",
-        "premature close",
-        "EPIPE",
-    ):
-        assert _is_retryable_error_message(sig) is True, f"Expected {sig!r} to be retryable"
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        ("429 Too Many Requests", True),
+        ("Service is currently overloaded", True),
+        ("rate limit exceeded", True),
+        ("rate_limit hit", True),
+        ("Capacity unavailable", True),
+        ("too many requests from this IP", True),
+        ("Request throttled", True),
+        ("throttling in effect", True),
+        ("OVERLOAD detected", True),  # case-insensitive
+        # Stream-drop signatures (z.ai/GLM connection drops).
+        ("terminated", True),
+        ("ECONNRESET", True),
+        ("connection reset", True),
+        ("socket hang up", True),
+        ("premature close", True),
+        ("EPIPE", True),
+        ("auth failed", False),
+        ("service is not overloaded", False),
+        ("capacity planning required", False),
+        ("", False),
+        ("Unknown Pi error", False),
+    ],
+    ids=[
+        "429",
+        "overload",
+        "rate-limit-space",
+        "rate_limit-underscore",
+        "capacity",
+        "too-many-requests",
+        "throttle",
+        "throttling",
+        "case-insensitive",
+        "stream-drop-terminated",
+        "stream-drop-econnreset",
+        "stream-drop-connection-reset",
+        "stream-drop-socket-hang-up",
+        "stream-drop-premature-close",
+        "stream-drop-epipe",
+        "auth-failed",
+        "not-overloaded",
+        "capacity-planning",
+        "empty",
+        "unknown",
+    ],
+)
+def test_is_retryable_error_message(message, expected):
+    assert _is_retryable_error_message(message) is expected
 
 
 # ---------------------------------------------------------------------------
@@ -1026,24 +962,13 @@ def test_is_retryable_error_message_stream_drop_signatures():
 # ---------------------------------------------------------------------------
 
 
-def test_is_retryable_exit_code_sigkill():
-    assert _is_retryable_exit_code(-9) is True
-
-
-def test_is_retryable_exit_code_oom_137():
-    assert _is_retryable_exit_code(137) is True
-
-
-def test_is_retryable_exit_code_normal_exit_1():
-    assert _is_retryable_exit_code(1) is False
-
-
-def test_is_retryable_exit_code_normal_exit_2():
-    assert _is_retryable_exit_code(2) is False
-
-
-def test_is_retryable_exit_code_zero():
-    assert _is_retryable_exit_code(0) is False
+@pytest.mark.parametrize(
+    ("code", "expected"),
+    [(-9, True), (137, True), (1, False), (2, False), (0, False)],
+    ids=["sigkill", "oom-137", "exit-1", "exit-2", "zero"],
+)
+def test_is_retryable_exit_code(code, expected):
+    assert _is_retryable_exit_code(code) is expected
 
 
 # ---------------------------------------------------------------------------
@@ -1051,16 +976,24 @@ def test_is_retryable_exit_code_zero():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize(
+    ("error_message", "expected_retryable"),
+    [
+        ("429 Too Many Requests - rate limit exceeded", True),
+        ("authentication required", False),
+    ],
+    ids=["429-retryable", "auth-non-retryable"],
+)
 @pytest.mark.asyncio
-async def test_error_turn_sets_retryable_on_429():
-    """A 429 errorMessage in turn_end sets retryable=True on PiError."""
+async def test_error_turn_sets_retryable_via_classifier(error_message, expected_retryable):
+    """The turn_end errorMessage is run through the retryable classifier."""
     backend = PiBackend(model="glm-5.2")
     lines = [
-        '{"type":"session","sessionId":"pi_ses_429"}',
+        '{"type":"session","sessionId":"pi_ses_err"}',
         '{"type":"agent_start"}',
         '{"type":"turn_start"}',
         '{"type":"turn_end","message":{"role":"assistant","content":[],'
-        '"stopReason":"error","errorMessage":"429 Too Many Requests - rate limit exceeded"}}',
+        f'"stopReason":"error","errorMessage":{json.dumps(error_message)}}}}}',
     ]
     mock_proc = make_mock_process(lines)
 
@@ -1069,58 +1002,30 @@ async def test_error_turn_sets_retryable_on_429():
             async for _ in backend.execute(Path("/tmp"), "p"):
                 pass
 
-    assert exc_info.value.retryable is True
+    assert exc_info.value.retryable is expected_retryable
 
 
+@pytest.mark.parametrize(
+    ("returncode", "output_lines", "expected_retryable"),
+    [
+        (-9, [], True),  # SIGKILL/OOM
+        (1, ["Error: not authenticated"], False),  # auth/config error
+    ],
+    ids=["oom-sigkill-retryable", "exit-1-non-retryable"],
+)
 @pytest.mark.asyncio
-async def test_error_turn_non_retryable_for_auth_failure():
-    """A non-transient errorMessage in turn_end sets retryable=False."""
+async def test_nonzero_exit_sets_retryable_via_exit_code(returncode, output_lines, expected_retryable):
+    """The subprocess return code is run through the exit-code retryable classifier."""
     backend = PiBackend(model="glm-5.2")
-    lines = [
-        '{"type":"session","sessionId":"pi_ses_auth"}',
-        '{"type":"agent_start"}',
-        '{"type":"turn_start"}',
-        '{"type":"turn_end","message":{"role":"assistant","content":[],'
-        '"stopReason":"error","errorMessage":"authentication required"}}',
-    ]
-    mock_proc = make_mock_process(lines)
+    mock_proc = make_mock_process(output_lines)
+    mock_proc.returncode = returncode
 
     with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc):
         with pytest.raises(PiError) as exc_info:
             async for _ in backend.execute(Path("/tmp"), "p"):
                 pass
 
-    assert exc_info.value.retryable is False
-
-
-@pytest.mark.asyncio
-async def test_oom_exit_sets_retryable():
-    """Exit code -9 (SIGKILL/OOM) sets retryable=True on the PiError."""
-    backend = PiBackend(model="glm-5.2")
-    mock_proc = make_mock_process([])
-    mock_proc.returncode = -9
-
-    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc):
-        with pytest.raises(PiError) as exc_info:
-            async for _ in backend.execute(Path("/tmp"), "p"):
-                pass
-
-    assert exc_info.value.retryable is True
-
-
-@pytest.mark.asyncio
-async def test_normal_exit_1_not_retryable():
-    """Exit code 1 (auth error, config error) is NOT retryable."""
-    backend = PiBackend(model="glm-5.2")
-    mock_proc = make_mock_process(["Error: not authenticated"])
-    mock_proc.returncode = 1
-
-    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc):
-        with pytest.raises(PiError) as exc_info:
-            async for _ in backend.execute(Path("/tmp"), "p"):
-                pass
-
-    assert exc_info.value.retryable is False
+    assert exc_info.value.retryable is expected_retryable
 
 
 # ---------------------------------------------------------------------------
@@ -1128,32 +1033,31 @@ async def test_normal_exit_1_not_retryable():
 # ---------------------------------------------------------------------------
 
 
-def test_pi_retry_attempts_default():
-    assert _pi_retry_attempts() == _PI_DEFAULT_RETRY_ATTEMPTS
+@pytest.mark.parametrize(
+    ("env_value", "expected"),
+    [(None, _PI_DEFAULT_RETRY_ATTEMPTS), ("5", 5)],
+    ids=["default", "env-override"],
+)
+def test_pi_retry_attempts(monkeypatch, env_value, expected):
+    if env_value is not None:
+        monkeypatch.setenv("DAYDREAM_PI_RETRY_ATTEMPTS", env_value)
+    assert _pi_retry_attempts() == expected
 
 
-def test_pi_retry_attempts_env_override(monkeypatch):
-    monkeypatch.setenv("DAYDREAM_PI_RETRY_ATTEMPTS", "5")
-    assert _pi_retry_attempts() == 5
-
-
-def test_pi_retry_base_delay_default():
-    assert _pi_retry_base_delay() == _PI_DEFAULT_RETRY_BASE_DELAY
-
-
-def test_pi_retry_base_delay_env_override(monkeypatch):
-    monkeypatch.setenv("DAYDREAM_PI_RETRY_BASE_DELAY_S", "0.5")
-    assert _pi_retry_base_delay() == pytest.approx(0.5)
-
-
-def test_pi_retry_base_delay_nan_falls_back(monkeypatch):
-    monkeypatch.setenv("DAYDREAM_PI_RETRY_BASE_DELAY_S", "nan")
-    assert _pi_retry_base_delay() == _PI_DEFAULT_RETRY_BASE_DELAY
-
-
-def test_pi_retry_base_delay_inf_falls_back(monkeypatch):
-    monkeypatch.setenv("DAYDREAM_PI_RETRY_BASE_DELAY_S", "inf")
-    assert _pi_retry_base_delay() == _PI_DEFAULT_RETRY_BASE_DELAY
+@pytest.mark.parametrize(
+    ("env_value", "expected"),
+    [
+        (None, _PI_DEFAULT_RETRY_BASE_DELAY),
+        ("0.5", 0.5),
+        ("nan", _PI_DEFAULT_RETRY_BASE_DELAY),
+        ("inf", _PI_DEFAULT_RETRY_BASE_DELAY),
+    ],
+    ids=["default", "env-override", "nan-falls-back", "inf-falls-back"],
+)
+def test_pi_retry_base_delay(monkeypatch, env_value, expected):
+    if env_value is not None:
+        monkeypatch.setenv("DAYDREAM_PI_RETRY_BASE_DELAY_S", env_value)
+    assert _pi_retry_base_delay() == pytest.approx(expected)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_benchmark_score.py
+++ b/tests/test_benchmark_score.py
@@ -7,7 +7,6 @@ import pytest
 from daydream.benchmark.score import (
     JUDGE_BASE_URL_ENV,
     JUDGE_MODEL_ENV,
-    BenchmarkArtifactError,
     DaydreamScores,
     JudgeEnvError,
     JudgeFailedError,
@@ -152,56 +151,72 @@ def test_preflight_passes_when_key_present(monkeypatch):
     preflight_judge_env()
 
 
-def test_direct_anthropic_preflight_requires_anthropic_key(monkeypatch):
-    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+@pytest.mark.parametrize(
+    ("anthropic_key", "martian_base_url", "match"),
+    [
+        # Missing Anthropic key.
+        (None, None, "ANTHROPIC_API_KEY"),
+        # An OpenRouter key is not a direct-Anthropic credential.
+        ("sk-or-not-direct", None, "OpenRouter key supplied for Anthropic-direct judge"),
+        # A Martian base URL is invalid for direct scoring.
+        ("sk-ant-direct", "https://api.anthropic.com", "MARTIAN_BASE_URL is invalid for direct Anthropic scoring"),
+    ],
+    ids=["missing-key", "openrouter-key", "martian-base-url"],
+)
+def test_direct_anthropic_preflight_rejects(monkeypatch, anthropic_key, martian_base_url, match):
+    """Direct-Anthropic preflight rejects a missing key, an OpenRouter key, and a
+    Martian base URL, each with its own diagnostic message."""
     monkeypatch.setenv("MARTIAN_MODEL", "claude-opus-4-5-20251101")
-    with pytest.raises(JudgeEnvError, match="ANTHROPIC_API_KEY"):
+    if anthropic_key is None:
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    else:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", anthropic_key)
+    if martian_base_url is not None:
+        monkeypatch.setenv("MARTIAN_BASE_URL", martian_base_url)
+    with pytest.raises(JudgeEnvError, match=match):
         preflight_judge_env(judge_route="anthropic-direct")
 
 
-def test_direct_anthropic_preflight_rejects_openrouter_key(monkeypatch):
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-or-not-direct")
-    monkeypatch.setenv("MARTIAN_MODEL", "claude-opus-4-5-20251101")
-    with pytest.raises(JudgeEnvError, match="OpenRouter key supplied for Anthropic-direct judge"):
-        preflight_judge_env(judge_route="anthropic-direct")
+_P_MIXED, _R_MIXED = 2 / 5, 2 / 6
 
 
-def test_direct_anthropic_preflight_rejects_martian_base_url(monkeypatch):
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-direct")
-    monkeypatch.setenv("MARTIAN_MODEL", "claude-opus-4-5-20251101")
-    monkeypatch.setenv("MARTIAN_BASE_URL", "https://api.anthropic.com")
-    with pytest.raises(JudgeEnvError, match="MARTIAN_BASE_URL is invalid for direct Anthropic scoring"):
-        preflight_judge_env(judge_route="anthropic-direct")
-
-
-def test_f1_computation():
-    """F1 is the harmonic mean of the aggregate precision and recall.
-
-    url1 contributes tp=2 fp=1 fn=1, url2 tp=0 fp=2 fn=3, so aggregate
-    precision = 2/5 = 0.4 and recall = 2/6 ≈ 0.3333, giving
-    f1 = 2·0.4·0.3333 / (0.4 + 0.3333) ≈ 0.3636.
-    """
-    evals = {
-        "url1": {"daydream": {"tp": 2, "fp": 1, "fn": 1, "total_candidates": 3, "total_golden": 3}},
-        "url2": {"daydream": {"tp": 0, "fp": 2, "fn": 3, "total_candidates": 2, "total_golden": 3}},
-    }
+@pytest.mark.parametrize(
+    ("evals", "expected_precision", "expected_recall", "expected_f1"),
+    [
+        # Harmonic mean of aggregate precision/recall across two PRs.
+        (
+            {
+                "url1": {"daydream": {"tp": 2, "fp": 1, "fn": 1, "total_candidates": 3, "total_golden": 3}},
+                "url2": {"daydream": {"tp": 0, "fp": 2, "fn": 3, "total_candidates": 2, "total_golden": 3}},
+            },
+            _P_MIXED,
+            _R_MIXED,
+            2 * _P_MIXED * _R_MIXED / (_P_MIXED + _R_MIXED),
+        ),
+        # Perfect precision and recall → f1 == 1.0.
+        (
+            {"url1": {"daydream": {"tp": 3, "fp": 0, "fn": 0, "total_candidates": 3, "total_golden": 3}}},
+            1.0,
+            1.0,
+            1.0,
+        ),
+        # P + R == 0 → f1 == 0.0 (no division by zero).
+        (
+            {"url1": {"daydream": {"tp": 0, "fp": 4, "fn": 5, "total_candidates": 4, "total_golden": 5}}},
+            0.0,
+            0.0,
+            0.0,
+        ),
+    ],
+    ids=["mixed", "perfect", "zero"],
+)
+def test_f1_computation(evals, expected_precision, expected_recall, expected_f1):
+    """F1 is the harmonic mean of the aggregate precision and recall, with the
+    degenerate perfect (1.0) and zero (0.0, no division-by-zero) cases pinned."""
     s = parse_daydream_scores(evals)
-    p, r = 2 / 5, 2 / 6
-    assert s.f1 == pytest.approx(2 * p * r / (p + r))
-
-
-def test_f1_perfect_scores():
-    """Perfect precision and recall → f1 == 1.0."""
-    evals = {"url1": {"daydream": {"tp": 3, "fp": 0, "fn": 0, "total_candidates": 3, "total_golden": 3}}}
-    s = parse_daydream_scores(evals)
-    assert s.precision == 1.0 and s.recall == 1.0 and s.f1 == 1.0
-
-
-def test_f1_zero_when_precision_and_recall_zero():
-    """P + R == 0 → f1 == 0.0 (no division by zero)."""
-    evals = {"url1": {"daydream": {"tp": 0, "fp": 4, "fn": 5, "total_candidates": 4, "total_golden": 5}}}
-    s = parse_daydream_scores(evals)
-    assert s.precision == 0.0 and s.recall == 0.0 and s.f1 == 0.0
+    assert s.precision == pytest.approx(expected_precision)
+    assert s.recall == pytest.approx(expected_recall)
+    assert s.f1 == pytest.approx(expected_f1)
 
 
 def test_parse_daydream_scores_extracts_per_pr_and_aggregate():
@@ -328,15 +343,32 @@ def test_run_scoring_raises_judge_failed_when_evaluations_all_errored(tmp_path, 
         run_scoring(tmp_path, model, pr_count=1, tool="daydream-glm")
 
 
-def test_run_scoring_invokes_three_steps_in_order(tmp_path, monkeypatch):
+def _record_run_scoring_calls(tmp_path, monkeypatch, *, pr_count=None):
+    """Run run_scoring with faked subprocess capture, returning the captured cmds.
+
+    Sets MARTIAN_API_KEY, stubs subprocess.run to record each argv and drop an
+    empty evaluations.json, then drives the real run_scoring path.
+    """
     monkeypatch.setenv("MARTIAN_API_KEY", "sk-or-x")
-    calls = []
-    monkeypatch.setattr("daydream.benchmark.score.subprocess.run",
-        lambda cmd, **k: calls.append(cmd) or SimpleNamespace(returncode=0, stdout="", stderr=""))
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        "daydream.benchmark.score.subprocess.run",
+        lambda cmd, **k: calls.append(cmd) or SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
     rdir = tmp_path / "results" / "anthropic_claude-opus-4.5"
     rdir.mkdir(parents=True)
     (rdir / "evaluations.json").write_text("{}")
-    run_scoring(tmp_path, "anthropic/claude-opus-4.5")
+    kwargs = {} if pr_count is None else {"pr_count": pr_count}
+    run_scoring(tmp_path, "anthropic/claude-opus-4.5", **kwargs)
+    return calls
+
+
+def _step3_cmd(calls):
+    return next(c for c in calls if c[c.index("-m") + 1] == "code_review_benchmark.step3_judge_comments")
+
+
+def test_run_scoring_invokes_three_steps_in_order(tmp_path, monkeypatch):
+    calls = _record_run_scoring_calls(tmp_path, monkeypatch)
     mods = [c[c.index("-m") + 1] for c in calls]
     assert mods == ["code_review_benchmark.step2_extract_comments",
                     "code_review_benchmark.step2_5_dedup_candidates",
@@ -344,31 +376,19 @@ def test_run_scoring_invokes_three_steps_in_order(tmp_path, monkeypatch):
     assert all(c[c.index("--tool") + 1] == "daydream" for c in calls)
 
 
-def test_run_scoring_passes_limit_to_step3_when_pr_count_given(tmp_path, monkeypatch):
-    monkeypatch.setenv("MARTIAN_API_KEY", "sk-or-x")
-    calls = []
-    monkeypatch.setattr("daydream.benchmark.score.subprocess.run",
-        lambda cmd, **k: calls.append(cmd) or SimpleNamespace(returncode=0, stdout="", stderr=""))
-    rdir = tmp_path / "results" / "anthropic_claude-opus-4.5"
-    rdir.mkdir(parents=True)
-    (rdir / "evaluations.json").write_text("{}")
-    run_scoring(tmp_path, "anthropic/claude-opus-4.5", pr_count=3)
-    step3_cmd = next(c for c in calls if c[c.index("-m") + 1] == "code_review_benchmark.step3_judge_comments")
-    assert "--limit" in step3_cmd
-    assert step3_cmd[step3_cmd.index("--limit") + 1] == "3"
-
-
-def test_run_scoring_omits_limit_from_step3_when_pr_count_not_given(tmp_path, monkeypatch):
-    monkeypatch.setenv("MARTIAN_API_KEY", "sk-or-x")
-    calls = []
-    monkeypatch.setattr("daydream.benchmark.score.subprocess.run",
-        lambda cmd, **k: calls.append(cmd) or SimpleNamespace(returncode=0, stdout="", stderr=""))
-    rdir = tmp_path / "results" / "anthropic_claude-opus-4.5"
-    rdir.mkdir(parents=True)
-    (rdir / "evaluations.json").write_text("{}")
-    run_scoring(tmp_path, "anthropic/claude-opus-4.5")
-    step3_cmd = next(c for c in calls if c[c.index("-m") + 1] == "code_review_benchmark.step3_judge_comments")
-    assert "--limit" not in step3_cmd
+@pytest.mark.parametrize(
+    ("pr_count", "expect_limit"),
+    [(3, "3"), (None, None)],
+    ids=["pr-count-given", "pr-count-omitted"],
+)
+def test_run_scoring_limit_passthrough_to_step3(tmp_path, monkeypatch, pr_count, expect_limit):
+    """step3 gets --limit exactly when pr_count is supplied, with the given value."""
+    step3_cmd = _step3_cmd(_record_run_scoring_calls(tmp_path, monkeypatch, pr_count=pr_count))
+    if expect_limit is None:
+        assert "--limit" not in step3_cmd
+    else:
+        assert "--limit" in step3_cmd
+        assert step3_cmd[step3_cmd.index("--limit") + 1] == expect_limit
 
 
 def _emulating_fake_run(model_dir_name: str):
@@ -432,22 +452,8 @@ def test_run_scoring_with_relative_benchmark_repo_resolves_dedup_path(tmp_path, 
 
     assert scores.scored_pr_count == 1
     assert scores.total_tp == 1
-    # The dedup file step3 was pointed at actually exists on disk.
+    # The dedup file step3 was pointed at actually exists on disk. That the
+    # call did not raise BenchmarkArtifactError also pins the absolute-path
+    # resolution: a relative benchmark_repo would double up step3's --dedup-groups
+    # path, write no evaluations.json, and raise.
     assert (tmp_path / "bench" / "results" / model_dir_name / "evaluations.json").exists()
-
-
-def test_run_scoring_relative_repo_regression_fails_without_absolute_resolution(tmp_path, monkeypatch):
-    """Guard the fix directly: if benchmark_repo were left relative, step3's
-    dedup path would miss and run_scoring would raise. We assert the post-fix
-    behavior (no raise) here; the companion test above asserts the parsed
-    scores. Together they pin the absolute-path resolution in place."""
-    monkeypatch.setenv("MARTIAN_API_KEY", "sk-or-x")
-    model = "anthropic/claude-opus-4.5"
-    model_dir_name = "anthropic_claude-opus-4.5"
-    (tmp_path / "bench" / "results" / model_dir_name).mkdir(parents=True)
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr("daydream.benchmark.score.subprocess.run", _emulating_fake_run(model_dir_name))
-    try:
-        run_scoring(Path("bench"), model, pr_count=2)
-    except BenchmarkArtifactError as exc:  # pragma: no cover - only on regression
-        pytest.fail(f"relative benchmark_repo broke step3 dedup resolution: {exc}")

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -120,27 +120,27 @@ def test_default_branch_falls_back_to_main(tmp_path: Path) -> None:
     assert git_ops.default_branch(repo) == "main"
 
 
-def test_default_branch_falls_back_to_master(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    ("init_branch", "expected"),
+    [
+        ("master", "master"),  # falls back to local master when no main/origin
+        ("trunk", BranchNotFoundError),  # neither main nor master present -> raises
+    ],
+    ids=["falls_back_to_master", "raises_when_none_present"],
+)
+def test_default_branch_fallback(tmp_path: Path, init_branch: str, expected: object) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
-    _git(repo, "init", "-b", "master")
+    _git(repo, "init", "-b", init_branch)
     _configure_identity(repo)
     (repo / "f.txt").write_text("hi\n")
     _git(repo, "add", "f.txt")
     _commit(repo, "first")
-    assert git_ops.default_branch(repo) == "master"
-
-
-def test_default_branch_raises_when_none_present(tmp_path: Path) -> None:
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    _git(repo, "init", "-b", "trunk")
-    _configure_identity(repo)
-    (repo / "f.txt").write_text("hi\n")
-    _git(repo, "add", "f.txt")
-    _commit(repo, "first")
-    with pytest.raises(BranchNotFoundError):
-        git_ops.default_branch(repo)
+    if isinstance(expected, type) and issubclass(expected, Exception):
+        with pytest.raises(expected):
+            git_ops.default_branch(repo)
+    else:
+        assert git_ops.default_branch(repo) == expected
 
 
 def test_remote_url_returns_url_when_remote_configured(tmp_path: Path) -> None:
@@ -191,36 +191,39 @@ def test_branch_exists_missing(tmp_path: Path) -> None:
 # --- ref_exists -------------------------------------------------------------
 
 
-def test_ref_exists_raw_sha(tmp_path: Path) -> None:
-    repo = _make_repo_with_main(tmp_path)
-    sha = _git(repo, "rev-parse", "HEAD")
-    assert git_ops.ref_exists(repo, sha) is True
+def _ref_raw_sha(repo: Path) -> str:
+    return _git(repo, "rev-parse", "HEAD")
 
 
-def test_ref_exists_abbreviated_sha(tmp_path: Path) -> None:
-    repo = _make_repo_with_main(tmp_path)
-    short = _git(repo, "rev-parse", "--short", "HEAD")
-    assert git_ops.ref_exists(repo, short) is True
+def _ref_abbreviated_sha(repo: Path) -> str:
+    return _git(repo, "rev-parse", "--short", "HEAD")
 
 
-def test_ref_exists_tag(tmp_path: Path) -> None:
-    repo = _make_repo_with_main(tmp_path)
+def _ref_tag(repo: Path) -> str:
     _git(repo, "tag", "v1.0")
-    assert git_ops.ref_exists(repo, "v1.0") is True
+    return "v1.0"
 
 
-def test_ref_exists_relative_commit_ish(tmp_path: Path) -> None:
-    repo = _make_repo_with_main(tmp_path)
+def _ref_relative_commit_ish(repo: Path) -> str:
     (repo / "two.txt").write_text("two\n")
     _git(repo, "add", "two.txt")
     _commit(repo, "second")
-    assert git_ops.ref_exists(repo, "HEAD~1") is True
+    return "HEAD~1"
 
 
-def test_ref_exists_named_branch_still_resolves(tmp_path: Path) -> None:
-    repo = _make_repo_with_main(tmp_path)
+def _ref_named_branch(repo: Path) -> str:
     _git(repo, "checkout", "-b", "feat-local")
-    assert git_ops.ref_exists(repo, "feat-local") is True
+    return "feat-local"
+
+
+@pytest.mark.parametrize(
+    "build_ref",
+    [_ref_raw_sha, _ref_abbreviated_sha, _ref_tag, _ref_relative_commit_ish, _ref_named_branch],
+    ids=["raw_sha", "abbreviated_sha", "tag", "relative_commit_ish", "named_branch"],
+)
+def test_ref_exists_true(tmp_path: Path, build_ref: Any) -> None:
+    repo = _make_repo_with_main(tmp_path)
+    assert git_ops.ref_exists(repo, build_ref(repo)) is True
 
 
 def test_ref_exists_missing(tmp_path: Path) -> None:
@@ -954,8 +957,13 @@ def test_gh_api_input_data_preserves_tempfile_on_failure(
     preserved.unlink(missing_ok=True)
 
 
-def test_gh_pr_view_omits_pr_arg_when_none(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize(
+    ("pr", "number"),
+    [(None, 7), (42, 42)],
+    ids=["omits_pr_arg_when_none", "includes_pr_arg_when_given"],
+)
+def test_gh_pr_view_pr_arg(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, pr: int | None, number: int
 ) -> None:
     repo = _make_repo_with_main(tmp_path)
     captured: dict[str, list[str]] = {}
@@ -963,17 +971,20 @@ def test_gh_pr_view_omits_pr_arg_when_none(
     def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
         captured["cmd"] = cmd
         return subprocess.CompletedProcess(
-            args=cmd, returncode=0, stdout='{"number": 7}', stderr=""
+            args=cmd, returncode=0, stdout=f'{{"number": {number}}}', stderr=""
         )
 
     monkeypatch.setattr("daydream.git_ops.subprocess.run", fake_run)
 
-    result = git_ops.gh_pr_view(repo)
-    assert result == {"number": 7}
+    result = git_ops.gh_pr_view(repo) if pr is None else git_ops.gh_pr_view(repo, pr)
+    assert result == {"number": number}
     cmd = captured["cmd"]
-    assert cmd[:3] == ["gh", "pr", "view"]
-    # No PR number anywhere in the argv.
-    assert all(not part.isdigit() for part in cmd)
+    if pr is None:
+        assert cmd[:3] == ["gh", "pr", "view"]
+        # No PR number anywhere in the argv.
+        assert all(not part.isdigit() for part in cmd)
+    else:
+        assert cmd[:4] == ["gh", "pr", "view", str(pr)]
 
 
 # --- daydream_commits ---------------------------------------------------------
@@ -1007,26 +1018,6 @@ def test_daydream_commits_none_when_no_commits(tmp_path: Path) -> None:
     assert result is None
 
 
-def test_gh_pr_view_includes_pr_arg_when_given(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    repo = _make_repo_with_main(tmp_path)
-    captured: dict[str, list[str]] = {}
-
-    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
-        captured["cmd"] = cmd
-        return subprocess.CompletedProcess(
-            args=cmd, returncode=0, stdout='{"number": 42}', stderr=""
-        )
-
-    monkeypatch.setattr("daydream.git_ops.subprocess.run", fake_run)
-
-    result = git_ops.gh_pr_view(repo, 42)
-    assert result == {"number": 42}
-    cmd = captured["cmd"]
-    assert cmd[:4] == ["gh", "pr", "view", "42"]
-
-
 # --- clone -------------------------------------------------------------------
 
 
@@ -1054,8 +1045,15 @@ def test_clone_raises_on_invalid_remote(tmp_path: Path) -> None:
         git_ops.clone("file:///nonexistent/repo.git", target)
 
 
-def test_clone_blobless_passes_filter_flag(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """clone(blobless=True) includes --filter=blob:none in the git invocation."""
+@pytest.mark.parametrize(
+    ("blobless", "filter_present"),
+    [(True, True), (False, False)],
+    ids=["blobless_passes_filter_flag", "default_no_filter_flag"],
+)
+def test_clone_filter_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, blobless: bool, filter_present: bool
+) -> None:
+    """clone(blobless=True) includes --filter=blob:none; the default omits it."""
     captured: dict[str, list[str]] = {}
 
     def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
@@ -1064,22 +1062,8 @@ def test_clone_blobless_passes_filter_flag(tmp_path: Path, monkeypatch: pytest.M
 
     monkeypatch.setattr("daydream.git_ops.subprocess.run", fake_run)
 
-    git_ops.clone("https://example.com/repo.git", tmp_path / "out", blobless=True)
-    assert "--filter=blob:none" in captured["cmd"]
-
-
-def test_clone_default_no_filter_flag(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """clone() without blobless does not pass --filter."""
-    captured: dict[str, list[str]] = {}
-
-    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
-        captured["cmd"] = cmd
-        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
-
-    monkeypatch.setattr("daydream.git_ops.subprocess.run", fake_run)
-
-    git_ops.clone("https://example.com/repo.git", tmp_path / "out")
-    assert "--filter=blob:none" not in captured["cmd"]
+    git_ops.clone("https://example.com/repo.git", tmp_path / "out", blobless=blobless)
+    assert ("--filter=blob:none" in captured["cmd"]) is filter_present
 
 
 def test_gh_api_raises_rate_limit_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_pr_comment_renderer.py
+++ b/tests/test_pr_comment_renderer.py
@@ -72,6 +72,17 @@ def _agent_step(
     return step
 
 
+def _user_step(phase: str = "review") -> dict[str, Any]:
+    """Build the leading user step (step_id 1) the Trajectory validator expects."""
+    return {
+        "step_id": 1,
+        "timestamp": "2026-05-02T00:00:00.000000Z",
+        "source": "user",
+        "message": "go",
+        "extra": {"daydream_phase": phase, "daydream_run_flow": "ttt"},
+    }
+
+
 def _write_trajectory(
     tmp_path: Path,
     *,
@@ -140,13 +151,7 @@ def test_m5_cost_source_per_backend(tmp_path: Path) -> None:
     p = _write_trajectory(
         tmp_path,
         steps=[
-            {
-                "step_id": 1,
-                "timestamp": "2026-05-02T00:00:00.000000Z",
-                "source": "user",
-                "message": "go",
-                "extra": {"daydream_phase": "review", "daydream_run_flow": "ttt"},
-            },
+            _user_step(),
             _agent_step(
                 step_id=2,
                 phase="review",
@@ -179,13 +184,7 @@ def test_m6_unknown_model_renders_dash_and_footnote(tmp_path: Path) -> None:
         tmp_path,
         model="mystery-model",
         steps=[
-            {
-                "step_id": 1,
-                "timestamp": "2026-05-02T00:00:00.000000Z",
-                "source": "user",
-                "message": "go",
-                "extra": {"daydream_phase": "review", "daydream_run_flow": "ttt"},
-            },
+            _user_step(),
             _agent_step(
                 step_id=2,
                 phase="review",
@@ -225,13 +224,7 @@ def test_m6b_user_override_synthesizes_cost_for_unknown_model(
         tmp_path,
         model="custom-codex-op",
         steps=[
-            {
-                "step_id": 1,
-                "timestamp": "2026-05-02T00:00:00.000000Z",
-                "source": "user",
-                "message": "go",
-                "extra": {"daydream_phase": "review", "daydream_run_flow": "ttt"},
-            },
+            _user_step(),
             _agent_step(
                 step_id=2,
                 phase="review",
@@ -256,13 +249,7 @@ def test_m7_mixed_models_render_breakdown_pointer(tmp_path: Path) -> None:
     p = _write_trajectory(
         tmp_path,
         steps=[
-            {
-                "step_id": 1,
-                "timestamp": "2026-05-02T00:00:00.000000Z",
-                "source": "user",
-                "message": "go",
-                "extra": {"daydream_phase": "review", "daydream_run_flow": "ttt"},
-            },
+            _user_step(),
             _agent_step(step_id=2, phase="review", model="gpt-5.5", cost_usd=0.10),
             _agent_step(step_id=3, phase="fix", model="claude-sonnet-4-5", cost_usd=0.20),
         ],
@@ -277,13 +264,7 @@ def test_m8_cache_hit_ratio_rendered_when_input_nonzero(tmp_path: Path) -> None:
     p = _write_trajectory(
         tmp_path,
         steps=[
-            {
-                "step_id": 1,
-                "timestamp": "2026-05-02T00:00:00.000000Z",
-                "source": "user",
-                "message": "go",
-                "extra": {"daydream_phase": "review", "daydream_run_flow": "ttt"},
-            },
+            _user_step(),
             _agent_step(
                 step_id=2,
                 phase="review",
@@ -330,13 +311,7 @@ def test_m10_number_formatting_rules(tmp_path: Path) -> None:
         tmp_path,
         name="subcent.json",
         steps=[
-            {
-                "step_id": 1,
-                "timestamp": "2026-05-02T00:00:00.000000Z",
-                "source": "user",
-                "message": "go",
-                "extra": {"daydream_phase": "review", "daydream_run_flow": "ttt"},
-            },
+            _user_step(),
             _agent_step(
                 step_id=2,
                 phase="review",
@@ -361,13 +336,7 @@ def test_m10_number_formatting_rules(tmp_path: Path) -> None:
         tmp_path,
         name="big.json",
         steps=[
-            {
-                "step_id": 1,
-                "timestamp": "2026-05-02T00:00:00.000000Z",
-                "source": "user",
-                "message": "go",
-                "extra": {"daydream_phase": "review", "daydream_run_flow": "ttt"},
-            },
+            _user_step(),
             _agent_step(
                 step_id=2,
                 phase="review",
@@ -389,13 +358,7 @@ def test_m10_number_formatting_rules(tmp_path: Path) -> None:
         tmp_path,
         name="zero_input.json",
         steps=[
-            {
-                "step_id": 1,
-                "timestamp": "2026-05-02T00:00:00.000000Z",
-                "source": "user",
-                "message": "go",
-                "extra": {"daydream_phase": "review", "daydream_run_flow": "ttt"},
-            },
+            _user_step(),
             _agent_step(
                 step_id=2,
                 phase="review",
@@ -664,13 +627,7 @@ def test_metrics_clamped_when_cached_exceeds_prompt(tmp_path: Path) -> None:
     p = _write_trajectory(
         tmp_path,
         steps=[
-            {
-                "step_id": 1,
-                "timestamp": "2026-05-02T00:00:00.000000Z",
-                "source": "user",
-                "message": "go",
-                "extra": {"daydream_phase": "review", "daydream_run_flow": "ttt"},
-            },
+            _user_step(),
             _agent_step(
                 step_id=2,
                 phase="review",
@@ -703,13 +660,7 @@ def test_metrics_clamp_negative_token_counts(tmp_path: Path) -> None:
     p = _write_trajectory(
         tmp_path,
         steps=[
-            {
-                "step_id": 1,
-                "timestamp": "2026-05-02T00:00:00.000000Z",
-                "source": "user",
-                "message": "go",
-                "extra": {"daydream_phase": "review", "daydream_run_flow": "ttt"},
-            },
+            _user_step(),
             _agent_step(
                 step_id=2,
                 phase="review",
@@ -750,13 +701,7 @@ def test_step_model_falls_back_to_root_agent_model(tmp_path: Path) -> None:
         # Use a model that's in MODEL_PRICES so cost synthesis lands.
         model="gpt-5.5",
         steps=[
-            {
-                "step_id": 1,
-                "timestamp": "2026-05-02T00:00:00.000000Z",
-                "source": "user",
-                "message": "go",
-                "extra": {"daydream_phase": "review", "daydream_run_flow": "ttt"},
-            },
+            _user_step(),
             # All agent steps omit model_name -> renderer must fall back to
             # agent.model_name from the root config.
             _agent_step(
@@ -787,34 +732,35 @@ def test_step_model_falls_back_to_root_agent_model(tmp_path: Path) -> None:
 
 
 # Duration formatting
-def test_format_duration_none_renders_dash() -> None:
-    assert _format_duration(None) == "—"
-
-
-def test_format_duration_sub_second() -> None:
-    assert _format_duration(0.0) == "<1s"
-    assert _format_duration(0.5) == "<1s"
-    assert _format_duration(0.999) == "<1s"
-
-
-def test_format_duration_seconds() -> None:
-    assert _format_duration(1.0) == "1s"
-    assert _format_duration(30.0) == "30s"
-    assert _format_duration(59.9) == "59s"
-
-
-def test_format_duration_minutes() -> None:
-    assert _format_duration(60.0) == "1m"
-    assert _format_duration(61.0) == "1m 1s"
-    assert _format_duration(150.0) == "2m 30s"
-    assert _format_duration(3599.0) == "59m 59s"
-
-
-def test_format_duration_hours() -> None:
-    assert _format_duration(3600.0) == "1h"
-    assert _format_duration(3660.0) == "1h 1m"
-    assert _format_duration(7200.0) == "2h"
-    assert _format_duration(7380.0) == "2h 3m"
+@pytest.mark.parametrize(
+    ("seconds", "expected"),
+    [
+        (None, "—"),
+        (0.0, "<1s"),
+        (0.5, "<1s"),
+        (0.999, "<1s"),
+        (1.0, "1s"),
+        (30.0, "30s"),
+        (59.9, "59s"),
+        (60.0, "1m"),
+        (61.0, "1m 1s"),
+        (150.0, "2m 30s"),
+        (3599.0, "59m 59s"),
+        (3600.0, "1h"),
+        (3660.0, "1h 1m"),
+        (7200.0, "2h"),
+        (7380.0, "2h 3m"),
+    ],
+    ids=[
+        "none", "zero", "half", "sub-second",
+        "1s", "30s", "59s",
+        "1m", "1m1s", "2m30s", "59m59s",
+        "1h", "1h1m", "2h", "2h3m",
+    ],
+)
+def test_format_duration(seconds: float | None, expected: str) -> None:
+    """_format_duration covers None, sub-second, seconds, minutes, and hours."""
+    assert _format_duration(seconds) == expected
 
 
 # Duration in rollup and phase table

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -45,51 +45,29 @@ def _agent_step(
     )
 
 
-# ---- API key patterns (REDA-01) ----
+# ---- Single-token secret patterns in free text (REDA-01) ----
+
+_JWT = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.aBcDeF12345"
 
 
-def test_redactor_scrubs_openai_api_key() -> None:
-    """REDA-01: sk-* tokens replaced with [REDACTED_API_KEY]."""
-    out = Redactor().redact_step(_user_step("token=sk-test-12345abcdef done"))
+@pytest.mark.parametrize(
+    ("text", "raw_secret", "marker"),
+    [
+        ("token=sk-test-12345abcdef done", "sk-test-12345abcdef", "[REDACTED_API_KEY]"),
+        ("auth=ghp_test123abcdef bearer", "ghp_test123abcdef", "[REDACTED_API_KEY]"),
+        ("slack=xoxb-test456abcdef", "xoxb-test456abcdef", "[REDACTED_API_KEY]"),
+        ("aws=AKIA0000TESTKEY00000", "AKIA0000TESTKEY00000", "[REDACTED_API_KEY]"),
+        ("token=ghs_abc123DEF456ghi789jkl012 done", "ghs_abc123DEF456ghi789jkl012", "[REDACTED_API_KEY]"),
+        (f"bearer {_JWT}", _JWT, "[REDACTED_JWT]"),
+    ],
+    ids=["openai", "github", "slack", "aws", "github_installation", "jwt"],
+)
+def test_redactor_scrubs_single_token_secret(text: str, raw_secret: str, marker: str) -> None:
+    """REDA-01: sk-/ghp_/xoxb-/AKIA/ghs_ tokens → [REDACTED_API_KEY], JWTs → [REDACTED_JWT]."""
+    out = Redactor().redact_step(_user_step(text))
     assert isinstance(out.message, str)
-    assert "sk-test-12345abcdef" not in out.message
-    assert "[REDACTED_API_KEY]" in out.message
-
-
-def test_redactor_scrubs_github_token() -> None:
-    """REDA-01: ghp_* tokens replaced with [REDACTED_API_KEY]."""
-    out = Redactor().redact_step(_user_step("auth=ghp_test123abcdef bearer"))
-    assert isinstance(out.message, str)
-    assert "ghp_test123abcdef" not in out.message
-    assert "[REDACTED_API_KEY]" in out.message
-
-
-def test_redactor_scrubs_slack_bot_token() -> None:
-    """REDA-01: xoxb-* tokens replaced with [REDACTED_API_KEY]."""
-    out = Redactor().redact_step(_user_step("slack=xoxb-test456abcdef"))
-    assert isinstance(out.message, str)
-    assert "xoxb-test456abcdef" not in out.message
-    assert "[REDACTED_API_KEY]" in out.message
-
-
-def test_redactor_scrubs_aws_access_key() -> None:
-    """REDA-01: AKIA-prefixed AWS keys replaced with [REDACTED_API_KEY]."""
-    out = Redactor().redact_step(_user_step("aws=AKIA0000TESTKEY00000"))
-    assert isinstance(out.message, str)
-    assert "AKIA0000TESTKEY00000" not in out.message
-    assert "[REDACTED_API_KEY]" in out.message
-
-
-# ---- JWT pattern (REDA-01) ----
-
-
-def test_redactor_scrubs_jwt_token() -> None:
-    """REDA-01: eyJ JWT tokens replaced with [REDACTED_JWT]."""
-    jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.aBcDeF12345"
-    out = Redactor().redact_step(_user_step(f"bearer {jwt}"))
-    assert isinstance(out.message, str)
-    assert jwt not in out.message
-    assert "[REDACTED_JWT]" in out.message
+    assert raw_secret not in out.message
+    assert marker in out.message
 
 
 # ---- JWT negative case (TEST-03 gap fill) ----
@@ -135,49 +113,42 @@ def test_redactor_scrubs_git_url_credentials() -> None:
 # ---- Username path patterns (REDA-02) ----
 
 
-def test_redactor_scrubs_macos_username_path() -> None:
-    """REDA-02: /Users/<name>/ → /Users/[REDACTED_USER]/ (project-relative tail preserved)."""
-    out = Redactor().redact_step(_user_step("path=/Users/ka/github/proj/app.py"))
+@pytest.mark.parametrize(
+    ("text", "absent", "present", "preserved_tail"),
+    [
+        ("path=/Users/ka/github/proj/app.py", "/Users/ka", "/Users/[REDACTED_USER]", "github/proj/app.py"),
+        ("path=/home/alice/foo/bar", "/home/alice", "/home/[REDACTED_USER]", "foo/bar"),
+        ("path=C:\\Users\\bob\\repo", "Users\\bob", "[REDACTED_USER]", None),
+    ],
+    ids=["macos", "linux", "windows"],
+)
+def test_redactor_scrubs_username_path(text: str, absent: str, present: str, preserved_tail: str | None) -> None:
+    """REDA-02: /Users//home//C:\\Users\\ <name> → [REDACTED_USER], project-relative tail preserved."""
+    out = Redactor().redact_step(_user_step(text))
     assert isinstance(out.message, str)
-    assert "/Users/ka" not in out.message
-    assert "/Users/[REDACTED_USER]" in out.message
-    assert "github/proj/app.py" in out.message
-
-
-def test_redactor_scrubs_linux_username_path() -> None:
-    """REDA-02: /home/<name>/ → /home/[REDACTED_USER]/."""
-    out = Redactor().redact_step(_user_step("path=/home/alice/foo/bar"))
-    assert isinstance(out.message, str)
-    assert "/home/alice" not in out.message
-    assert "/home/[REDACTED_USER]" in out.message
-    assert "foo/bar" in out.message
-
-
-def test_redactor_scrubs_windows_username_path() -> None:
-    """REDA-02: C:\\Users\\<name>\\ → C:\\Users\\[REDACTED_USER]\\."""
-    out = Redactor().redact_step(_user_step("path=C:\\Users\\bob\\repo"))
-    assert isinstance(out.message, str)
-    assert "Users\\bob" not in out.message
-    assert "[REDACTED_USER]" in out.message
+    assert absent not in out.message
+    assert present in out.message
+    if preserved_tail is not None:
+        assert preserved_tail in out.message
 
 
 # ---- Env-var pattern (REDA-03) ----
 
 
-def test_redactor_scrubs_env_var_secret() -> None:
-    """REDA-03: KEY=value secret-keyname env vars get value redacted, key preserved."""
-    out = Redactor().redact_step(_user_step("OPENAI_API_KEY=sk-realvalue123"))
+@pytest.mark.parametrize(
+    ("text", "raw_value", "expected_fragment"),
+    [
+        ("OPENAI_API_KEY=sk-realvalue123", "sk-realvalue123", "OPENAI_API_KEY=[REDACTED_ENV_VAR]"),
+        ("DB_PASSWORD=hunter2", "hunter2", "DB_PASSWORD=[REDACTED_ENV_VAR]"),
+    ],
+    ids=["key", "password"],
+)
+def test_redactor_scrubs_env_var(text: str, raw_value: str, expected_fragment: str) -> None:
+    """REDA-03: secret-keyname env vars get value redacted, key preserved."""
+    out = Redactor().redact_step(_user_step(text))
     assert isinstance(out.message, str)
-    assert "sk-realvalue123" not in out.message
-    assert "OPENAI_API_KEY=[REDACTED_ENV_VAR]" in out.message
-
-
-def test_redactor_scrubs_env_var_password() -> None:
-    """REDA-03: PASSWORD= env vars get value redacted, key preserved."""
-    out = Redactor().redact_step(_user_step("DB_PASSWORD=hunter2"))
-    assert isinstance(out.message, str)
-    assert "hunter2" not in out.message
-    assert "DB_PASSWORD=[REDACTED_ENV_VAR]" in out.message
+    assert raw_value not in out.message
+    assert expected_fragment in out.message
 
 
 # ---- Negative cases ----
@@ -470,63 +441,41 @@ def test_redactor_scrubs_text_content_parts() -> None:
     assert out.message[2].text == "clean text"
 
 
-def test_redactor_scrubs_github_installation_token() -> None:
-    """ghs_* installation tokens replaced with [REDACTED_API_KEY]."""
-    out = Redactor().redact_step(_user_step("token=ghs_abc123DEF456ghi789jkl012 done"))
-    assert isinstance(out.message, str)
-    assert "ghs_abc123DEF456ghi789jkl012" not in out.message
-    assert "[REDACTED_API_KEY]" in out.message
+_PKCS1_PEM = (
+    "-----BEGIN RSA PRIVATE KEY-----\n"
+    "MIIEpAIBAAKCAQEA0Z3VS5JJcds3xfn/ygWyF8PbnGPgjF\n"
+    "-----END RSA PRIVATE KEY-----"
+)
+_PKCS8_PEM = (
+    "-----BEGIN PRIVATE KEY-----\n"
+    "MIIEvgIBADANBgkqhkiG9w0BAQEFAASC\n"
+    "-----END PRIVATE KEY-----"
+)
 
 
-def test_redactor_scrubs_pkcs1_private_key_block() -> None:
-    """-----BEGIN RSA PRIVATE KEY----- blocks replaced with [REDACTED_PEM_KEY]."""
-    pem = (
-        "-----BEGIN RSA PRIVATE KEY-----\n"
-        "MIIEpAIBAAKCAQEA0Z3VS5JJcds3xfn/ygWyF8PbnGPgjF\n"
-        "-----END RSA PRIVATE KEY-----"
-    )
+@pytest.mark.parametrize(
+    ("pem", "body"),
+    [(_PKCS1_PEM, "MIIEpAIBAAKCAQEA0Z3VS5JJcds3xfn"), (_PKCS8_PEM, "MIIEvgIBADANBgkqhkiG9w0BAQEFAASC")],
+    ids=["pkcs1", "pkcs8"],
+)
+def test_redactor_scrubs_private_key_block(pem: str, body: str) -> None:
+    """-----BEGIN (RSA )PRIVATE KEY----- blocks replaced with [REDACTED_PEM_KEY]."""
     out = Redactor().redact_step(_user_step(f"key is {pem} ok"))
     assert isinstance(out.message, str)
-    assert "MIIEpAIBAAKCAQEA0Z3VS5JJcds3xfn" not in out.message
+    assert body not in out.message
     assert "[REDACTED_PEM_KEY]" in out.message
 
 
-def test_redactor_scrubs_pkcs8_private_key_block() -> None:
-    """-----BEGIN PRIVATE KEY----- (PKCS8) blocks also redacted."""
-    pem = (
-        "-----BEGIN PRIVATE KEY-----\n"
-        "MIIEvgIBADANBgkqhkiG9w0BAQEFAASC\n"
-        "-----END PRIVATE KEY-----"
-    )
-    out = Redactor().redact_step(_user_step(f"key: {pem}"))
-    assert isinstance(out.message, str)
-    assert "MIIEvgIBADANBgkqhkiG9w0BAQEFAASC" not in out.message
-    assert "[REDACTED_PEM_KEY]" in out.message
-
-
-def test_redactor_scrubs_pkcs1_private_key_in_env_assignment() -> None:
-    """VAR=<PKCS1 PEM> redacts fully — PEM rule must run before the env-var rule."""
-    pem = (
-        "-----BEGIN RSA PRIVATE KEY-----\n"
-        "MIIEpAIBAAKCAQEA0Z3VSecretBody1234567890abcdef\n"
-        "-----END RSA PRIVATE KEY-----"
-    )
+@pytest.mark.parametrize(
+    ("pem", "body"),
+    [(_PKCS1_PEM, "MIIEpAIBAAKCAQEA0Z3VS5JJcds3xfn"), (_PKCS8_PEM, "MIIEvgIBADANBgkqhkiG9w0BAQEFAASC")],
+    ids=["pkcs1", "pkcs8"],
+)
+def test_redactor_scrubs_private_key_in_env_assignment(pem: str, body: str) -> None:
+    """VAR=<PEM> redacts fully — PEM rule must run before the env-var rule, no base64 body survives."""
     out = Redactor().redact_step(_user_step(f"DAYDREAM_APP_PRIVATE_KEY={pem}"))
     assert isinstance(out.message, str)
-    assert "MIIEpAIBAAKCAQEA0Z3VSecretBody" not in out.message
-    assert out.message == "DAYDREAM_APP_PRIVATE_KEY=[REDACTED_ENV_VAR]"
-
-
-def test_redactor_scrubs_pkcs8_private_key_in_env_assignment() -> None:
-    """VAR=<PKCS8 PEM> redacts fully — no base64 body survives the assignment form."""
-    pem = (
-        "-----BEGIN PRIVATE KEY-----\n"
-        "MIIEvgIBADANBgkqhkiG9w0BAQEFAASC\n"
-        "-----END PRIVATE KEY-----"
-    )
-    out = Redactor().redact_step(_user_step(f"DAYDREAM_APP_PRIVATE_KEY={pem}"))
-    assert isinstance(out.message, str)
-    assert "MIIEvgIBADANBgkqhkiG9w0BAQEFAASC" not in out.message
+    assert body not in out.message
     assert out.message == "DAYDREAM_APP_PRIVATE_KEY=[REDACTED_ENV_VAR]"
 
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -7,32 +7,6 @@ from pathlib import Path
 import pytest
 
 
-def test_plan_renderer_dims_ungrounded_steps():
-    from rich.console import Console
-
-    from daydream.ui import render_ttt_plan  # type: ignore[attr-defined]
-
-    plan = {
-        "changes": [
-            {
-                "file": "x.py",
-                "description": "grounded change",
-                "references": [{"file": "x.py", "symbol": "f"}],
-            },
-            {
-                "file": "y.py",
-                "description": "ungrounded change",
-                "references": [],
-            },
-        ]
-    }
-
-    console = Console(record=True)
-    render_ttt_plan(console, plan)
-    output = console.export_text()
-    assert "(ungrounded)" in output
-
-
 def test_format_verdict_join_renders_table_counts():
     from rich.console import Console
 


### PR DESCRIPTION
## Summary

Cross-cutting cleanup pass over `daydream/` and its tests: removes dead code, trims docstring boilerplate that merely restated signatures, and collapses near-duplicate tests into parametrized cases. No behavior change. Net ~1900 lines removed.

## Changes

### Removed
- Unused functions (`get_state`/`get_shutdown_requested` in `agent.py`, the test-only `render_ttt_plan` renderer and its export/test) and other dead code across `daydream/` (vendored `atif/` untouched).
- Single-use mock SDK client classes and a duplicate helper in the backend tests.
- One exact-subset duplicate test each in `test_backend_pi.py` and `test_benchmark_score.py`.

### Changed
- Stripped `Args:`/`Returns:` docstring sections that only restated parameter names/types or the one-line summary, plus `Returns: None` blocks. Kept summaries, `Raises:`, `Attributes:`, and non-obvious rationale; docstrings remain Google-style valid.
- Parametrized near-duplicate tests across the backend (pi/codex/claude), git_ops, pr_comment_renderer, benchmark_score, and redaction suites, extracting shared local helpers/fixtures. Every scenario is preserved as a labeled param.

## Motivation

LLM-generated boilerplate and copy-paste test duplication had accumulated. This removes it in one focused sweep so the surface is smaller and the tests are easier to extend.

## Testing

- [x] Tests pass locally
- [x] Linting passes

`make check` green: 2066 passed, 5 skipped; `mypy daydream tests` clean. No coverage lost — every collapsed test scenario remains as a labeled parametrized case.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)