### PR TITLE
feat(atif): re-vendor ATIF v1.7 from harbor and emit v1.7

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Guidance for Claude Code (claude.ai/code) when working in this repository.
 
 ## Project overview
 
-Daydream is an automated code review and fix loop. It reviews diffs using stack-specific [Beagle](https://github.com/existential-birds/beagle) skills, applies fixes, validates via test suite, and records every agent interaction as an [ATIF v1.6](https://www.harborframework.com/docs/agents/trajectory-format) trajectory. A bitemporal corpus pipeline scores, labels, and projects those trajectories into JSONL datasets for SFT and RL fine-tuning.
+Daydream is an automated code review and fix loop. It reviews diffs using stack-specific [Beagle](https://github.com/existential-birds/beagle) skills, applies fixes, validates via test suite, and records every agent interaction as an [ATIF v1.7](https://www.harborframework.com/docs/agents/trajectory-format) trajectory. A bitemporal corpus pipeline scores, labels, and projects those trajectories into JSONL datasets for SFT and RL fine-tuning.
 
 The default flow is a deep multi-stack pipeline. `--shallow` opts into a single-skill loop. `--comment` and `--review` produce review-only output (PR comments or markdown report). The `daydream feedback <pr#>` subcommand ingests bot review comments.
 
@@ -134,7 +134,7 @@ cli.py -> runner.py -> flows/engine.py (run_flow over registered FlowSteps)
 | Deep orchestrator | Deep-flow step functions (exploration, intent, alternatives, per-stack, arbiter, merge, verify, fix) | `deep/orchestrator.py` |
 | Phases | Stateless async `phase_*()` workflow steps and prompt builders | `phases.py` |
 | Agent | Backend wrapper, event stream to UI, global state, budget enforcement | `agent.py` |
-| Trajectory | ATIF v1.6 recorder, redaction, ContextVar propagation | `trajectory.py` |
+| Trajectory | ATIF v1.7 recorder, redaction, ContextVar propagation | `trajectory.py` |
 | Backends | `Backend` protocol, `ClaudeBackend`, `CodexBackend`, `PiBackend`, `AgentEvent` union, `create_backend()` | `backends/` |
 | UI | Rich terminal output (Dracula theme): `console`, `panels`, `messages`, `tools`, `agent_text`, `summary`, `theme`, `colorize` | `ui/` |
 | Config | Skill mappings, per-phase model defaults, constants | `config.py` |
@@ -222,8 +222,8 @@ name inventories, module shape, bump policy — is `docs/extensions.md`.
 
 - **SDK**: `claude-agent-sdk==0.2.108`. Agent capabilities go through the `Backend` /
   `AgentEvent` abstraction; Claude is one of three backends.
-- **ATIF**: Vendored from Harbor v0.5.0 under `daydream/atif/` (Apache-2.0). Pinned to
-  ATIF v1.6 emission. `pydantic>=2.11.7` required.
+- **ATIF**: Vendored from Harbor v0.17.1-9 under `daydream/atif/` (Apache-2.0). Pinned to
+  ATIF v1.7 emission. `pydantic>=2.11.7` required.
 - **No `harbor` runtime dep.** ATIF models live in `daydream/trajectory.py` only.
 - **Module-bloat ban**: No ATIF model construction inside `phases.py` or `ui/`.
 

--- a/daydream/atif/NOTICE
+++ b/daydream/atif/NOTICE
@@ -4,7 +4,7 @@ daydream/atif/
 This directory contains source code vendored from the Harbor framework
 (https://github.com/harbor-framework/harbor), Apache License 2.0.
 
-Vendored from harbor-framework/harbor@v0.5.0, commit 5795e7638fbe0ee5d7923b6311df2c9f3747dcf0, on 2026-04-26
+Vendored from harbor-framework/harbor@v0.17.1-9, commit 1d6c38512b2154168a5a4db75a48957ae0fbd807, on 2026-07-05
 
 Vendored to avoid Harbor's transitive dependency surface. The trajectory
 models and validator are pure-Pydantic + stdlib (~700 LOC) and benefit
@@ -28,7 +28,7 @@ Harbor copyright (Apache-2.0):
     (see https://github.com/harbor-framework/harbor and Harbor's pyproject.toml
     authors field for the canonical contributor list).
 
-    Note: Harbor v0.5.0's LICENSE file is the unmodified Apache-2.0 template —
+    Note: Harbor v0.17.1-9's LICENSE file is the unmodified Apache-2.0 template —
     it does not populate the `Copyright [yyyy] [name of copyright owner]`
     placeholder. The attribution above is reconstructed from Harbor's README
     BibTeX citation (`author = {{Harbor Framework Team}}, year = {2026}`) and

--- a/daydream/atif/__init__.py
+++ b/daydream/atif/__init__.py
@@ -1,4 +1,4 @@
-"""ATIF v1.6 trajectory models and validator (vendored from Harbor v0.5.0).
+"""ATIF v1.7 trajectory models and validator (vendored from Harbor).
 
 Re-exports the vendored Harbor surface so callers import a single namespace::
 
@@ -30,7 +30,7 @@ def validate(trajectory: dict[str, Any] | str | Path, *, validate_images: bool =
     """Validate an ATIF trajectory (dict, JSON string, or path).
 
     Pure passthrough to a freshly-constructed TrajectoryValidator (CONTEXT.md D-08).
-    Returns True iff the trajectory matches the ATIF v1.0–v1.6 schema accepted by
+    Returns True iff the trajectory matches the ATIF v1.0–v1.7 schema accepted by
     the vendored validator. Returns False on any validation failure.
 
     For detailed error messages, instantiate TrajectoryValidator() directly and

--- a/daydream/atif/models/observation_result.py
+++ b/daydream/atif/models/observation_result.py
@@ -1,5 +1,7 @@
 """Observation result model for ATIF trajectories."""
 
+from typing import Any
+
 from pydantic import BaseModel, Field
 
 from daydream.atif.models.content import ContentPart
@@ -28,6 +30,13 @@ class ObservationResult(BaseModel):
     subagent_trajectory_ref: list[SubagentTrajectoryRef] | None = Field(
         default=None,
         description="Array of references to delegated subagent trajectories",
+    )
+    extra: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Custom observation-result-level metadata (e.g., confidence score, "
+            "retrieval score, source document ID). Added in ATIF-v1.7."
+        ),
     )
 
     model_config = {"extra": "forbid"}

--- a/daydream/atif/models/step.py
+++ b/daydream/atif/models/step.py
@@ -71,6 +71,18 @@ class Step(BaseModel):
             "Added in ATIF-v1.5."
         ),
     )
+    llm_call_count: int | None = Field(
+        default=None,
+        ge=0,
+        description=(
+            "Number of LLM inferences this step represents. When >1, metrics are "
+            "aggregated across multiple LLM calls. When 1, the step represents exactly "
+            "one inference. When 0 on a `source: 'agent'` step, the step represents a "
+            "deterministic (non-LLM) dispatch; `metrics` and `reasoning_content` MUST "
+            "be absent in that case. When null, the producer did not track this "
+            "(backward-compatible default). Added in ATIF-v1.7."
+        ),
+    )
     extra: dict[str, Any] | None = Field(
         default=None,
         description="Custom step-level metadata",
@@ -105,5 +117,23 @@ class Step(BaseModel):
                     raise ValueError(
                         f"Field '{field}' is only applicable when source is 'agent', "
                         f"but source is '{self.source}'"
+                    )
+        return self
+
+    @model_validator(mode="after")
+    def validate_llm_call_count_zero_fields(self) -> "Step":
+        """Enforce ATIF v1.7 no-LLM orchestration rule.
+
+        When ``llm_call_count == 0`` on a ``source: "agent"`` step, the step
+        represents a deterministic (non-LLM) dispatch. LLM-specific fields
+        (``metrics``, ``reasoning_content``) MUST be absent on such steps.
+        """
+        if self.llm_call_count == 0 and self.source == "agent":
+            llm_only_fields = ["metrics", "reasoning_content"]
+            for field in llm_only_fields:
+                if getattr(self, field) is not None:
+                    raise ValueError(
+                        f"Field '{field}' must be absent when llm_call_count is 0 "
+                        f"(deterministic dispatch on a 'source: agent' step)"
                     )
         return self

--- a/daydream/atif/models/subagent_trajectory_ref.py
+++ b/daydream/atif/models/subagent_trajectory_ref.py
@@ -2,19 +2,61 @@
 
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class SubagentTrajectoryRef(BaseModel):
-    """Reference to a delegated subagent trajectory."""
+    """Reference to a delegated subagent trajectory.
 
-    session_id: str = Field(
-        default=...,
-        description="The session ID of the delegated subagent trajectory",
+    A subagent reference is resolved by one of two mechanisms:
+
+    1. **Embedded form** — set `trajectory_id` to match the
+       `Trajectory.trajectory_id` of an entry in the parent's
+       `subagent_trajectories` array.
+    2. **File-ref form** — set `trajectory_path` to the location
+       (file path, S3 URL, etc.) of an external trajectory file.
+
+    These two mechanisms are the only resolution keys. `session_id`, when
+    present on the ref, is **informational only**: it records the run
+    identity of the delegated subagent for debug / correlation / cross-
+    trajectory search purposes, and MUST NOT be used as a matching key
+    (it is run-scoped and MAY collide across siblings — see
+    `Trajectory.session_id`). A ref therefore MUST set at least one of
+    `trajectory_id` or `trajectory_path`; `session_id` alone is not a
+    resolvable reference.
+    """
+
+    trajectory_id: str | None = Field(
+        default=None,
+        description=(
+            "Canonical identifier of the delegated subagent trajectory. "
+            "Matches `Trajectory.trajectory_id` of an entry in the parent's "
+            "`subagent_trajectories` array and is the resolution key for "
+            "embedded references. Added in ATIF-v1.7 to provide a document-"
+            "unique matching key without overloading `session_id`."
+        ),
+    )
+    session_id: str | None = Field(
+        default=None,
+        description=(
+            "Run identity of the delegated subagent trajectory. Informational "
+            "only: recorded so consumers can correlate this ref back to the "
+            "subagent's run for debug / search / display purposes. Run-scoped "
+            "(see `Trajectory.session_id`) and therefore NOT a valid "
+            "resolution key — consumers MUST resolve via `trajectory_id` "
+            "(embedded) or `trajectory_path` (external file)."
+        ),
     )
     trajectory_path: str | None = Field(
         default=None,
-        description="Reference to the complete subagent trajectory file",
+        description=(
+            "Location of the complete subagent trajectory as an external "
+            "file (file path, S3 URL, database reference, etc.). Resolution "
+            "key for file-ref references. When both `trajectory_id` and "
+            "`trajectory_path` are set, consumers MAY choose either; "
+            "typically `trajectory_id` is preferred when the embedded "
+            "trajectory is available in-memory."
+        ),
     )
     extra: dict[str, Any] | None = Field(
         default=None,
@@ -22,3 +64,22 @@ class SubagentTrajectoryRef(BaseModel):
     )
 
     model_config = {"extra": "forbid"}
+
+    @model_validator(mode="after")
+    def validate_is_resolvable(self) -> "SubagentTrajectoryRef":
+        """A ref must be resolvable: set `trajectory_id` or `trajectory_path`.
+
+        `session_id` alone is not sufficient because it is run-scoped and
+        MAY collide across siblings (see `Trajectory.session_id`), so it
+        cannot unambiguously identify which subagent trajectory a ref
+        points at.
+        """
+        if self.trajectory_id is None and self.trajectory_path is None:
+            raise ValueError(
+                "SubagentTrajectoryRef must be resolvable: set either "
+                "`trajectory_id` (for embedded references) or "
+                "`trajectory_path` (for external-file references). "
+                "`session_id` alone is not a resolution key — it is "
+                "run-scoped and may collide across siblings."
+            )
+        return self

--- a/daydream/atif/models/tool_call.py
+++ b/daydream/atif/models/tool_call.py
@@ -20,5 +20,12 @@ class ToolCall(BaseModel):
         default=...,
         description="Arguments passed to the function (can be empty dict)",
     )
+    extra: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Custom tool-call-level metadata (e.g., timeout, retry count, tool version). "
+            "Added in ATIF-v1.7."
+        ),
+    )
 
     model_config = {"extra": "forbid"}

--- a/daydream/atif/models/trajectory.py
+++ b/daydream/atif/models/trajectory.py
@@ -20,13 +20,43 @@ class Trajectory(BaseModel):
         "ATIF-v1.4",
         "ATIF-v1.5",
         "ATIF-v1.6",
+        "ATIF-v1.7",
     ] = Field(
-        default="ATIF-v1.6",
+        default="ATIF-v1.7",
         description="String defining ATIF compatibility",
     )
-    session_id: str = Field(
-        default=...,
-        description="Unique identifier for the entire agent run",
+    session_id: str | None = Field(
+        default=None,
+        description=(
+            "Identifier for the agent run this trajectory belongs to. Scoped "
+            "to the run, NOT to an individual trajectory document: multiple "
+            "Trajectory objects MAY share the same `session_id` when they "
+            "represent the same logical run (e.g., a parent trajectory and "
+            "its embedded subagents, or a trajectory and its continuation "
+            "segments linked via `continued_trajectory_ref`). Therefore "
+            "`session_id`s within a parent's `subagent_trajectories` array "
+            "are NOT required to be unique. Use `trajectory_id` when a "
+            "per-trajectory-document unique identifier is required (e.g., "
+            "for `SubagentTrajectoryRef` resolution). Optional since "
+            "ATIF-v1.7; producers SHOULD set this on root trajectories for "
+            "run-level traceability, and MAY omit it on embedded subagents "
+            "that inherit the parent's run identity."
+        ),
+    )
+    trajectory_id: str | None = Field(
+        default=None,
+        description=(
+            "Canonical per-trajectory-document identifier, distinct from "
+            "`session_id`. Unlike `session_id` (which is run-scoped and MAY "
+            "be shared), `trajectory_id` uniquely identifies THIS trajectory "
+            "object. Used to resolve `SubagentTrajectoryRef` entries against "
+            "the root's `subagent_trajectories` array without overloading "
+            "`session_id`'s run-scoped semantics. Optional on standalone "
+            "trajectories, but REQUIRED on any trajectory embedded in a "
+            "parent's `subagent_trajectories` array. `trajectory_id`s within "
+            "a single parent's `subagent_trajectories` array MUST be unique. "
+            "Added in ATIF-v1.7."
+        ),
     )
     agent: Agent = Field(
         default=...,
@@ -53,6 +83,25 @@ class Trajectory(BaseModel):
         default=None,
         description="Custom root-level metadata",
     )
+    subagent_trajectories: list["Trajectory"] | None = Field(
+        default=None,
+        description=(
+            "Array of embedded subagent trajectories. Each element is a complete, "
+            "independently-valid ATIF Trajectory with its own schema_version, "
+            "agent, and step_id sequence starting at 1. Enables single-file "
+            "storage of multi-agent workflows: when a "
+            "SubagentTrajectoryRef.trajectory_path is null, consumers resolve "
+            "the reference by matching SubagentTrajectoryRef.trajectory_id "
+            "against Trajectory.trajectory_id of entries in this array. "
+            "Uniqueness rules: every embedded subagent MUST set `trajectory_id`, "
+            "and `trajectory_id`s within this array MUST be unique. "
+            "`session_id`, by contrast, is run-scoped and MAY collide across "
+            "siblings (or match the parent) when all trajectories belong to "
+            "the same logical run; embedded subagents MAY also omit "
+            "`session_id` entirely to inherit the parent's run identity. "
+            "Added in ATIF-v1.7."
+        ),
+    )
 
     model_config = {"extra": "forbid"}
 
@@ -77,6 +126,38 @@ class Trajectory(BaseModel):
                     f"steps[{i}].step_id: expected {expected_step_id} "
                     f"(sequential from 1), got {step.step_id}"
                 )
+        return self
+
+    @model_validator(mode="after")
+    def validate_embedded_subagent_trajectory_ids(self) -> "Trajectory":
+        """Every embedded subagent must carry a unique, non-null `trajectory_id`.
+
+        Embedded subagents are resolved by matching
+        `SubagentTrajectoryRef.trajectory_id` against
+        `Trajectory.trajectory_id`, so the identifier must be present and
+        unique within a parent's `subagent_trajectories` array. Note that
+        no such constraint is placed on `session_id` — siblings MAY share
+        a `session_id` (or omit it entirely to inherit the parent's) when
+        they represent the same logical agent run.
+        """
+        if not self.subagent_trajectories:
+            return self
+        seen: set[str] = set()
+        for i, sub in enumerate(self.subagent_trajectories):
+            if sub.trajectory_id is None:
+                raise ValueError(
+                    f"subagent_trajectories[{i}].trajectory_id is required "
+                    f"for embedded subagents "
+                    f"(agent.name={sub.agent.name!r}, "
+                    f"session_id={sub.session_id!r})"
+                )
+            if sub.trajectory_id in seen:
+                raise ValueError(
+                    f"subagent_trajectories[{i}].trajectory_id "
+                    f"{sub.trajectory_id!r} is not unique within "
+                    f"subagent_trajectories"
+                )
+            seen.add(sub.trajectory_id)
         return self
 
     @model_validator(mode="after")

--- a/daydream/atif/validator.py
+++ b/daydream/atif/validator.py
@@ -6,7 +6,7 @@ the ATIF specification (RFC 0001).
 
 import json
 from pathlib import Path
-from typing import Any, Dict, List, Union
+from typing import Any
 
 from pydantic import ValidationError
 
@@ -24,7 +24,7 @@ class TrajectoryValidator:
 
     def __init__(self):
         """Initialize the validator."""
-        self.errors: List[str] = []
+        self.errors: list[str] = []
         self._trajectory_dir: Path | None = None
 
     def _add_error(self, error: str) -> None:
@@ -44,9 +44,10 @@ class TrajectoryValidator:
         Returns:
             True if the path appears to be a URL, False otherwise.
         """
-        return "://" in path  # scheme:// pattern (https://, s3://, gs://)
+        # Check for scheme:// pattern (e.g., https://, s3://, gs://)
+        return "://" in path
 
-    def _validate_image_paths(self, trajectory_data: dict) -> None:
+    def _validate_image_paths(self, trajectory_data: dict[str, Any]) -> None:
         """Validate that all referenced local image paths exist.
 
         URLs are skipped since they cannot be validated locally.
@@ -67,26 +68,31 @@ class TrajectoryValidator:
                     if isinstance(source, dict):
                         image_path = source.get("path")
                         if image_path:
-                            if self._is_url(image_path):  # URLs can't be validated locally
+                            # Skip URLs - they can't be validated locally
+                            if self._is_url(image_path):  # ty: ignore[invalid-argument-type]
                                 continue
-                            path_obj = Path(image_path)
+                            # Handle both absolute and relative paths
+                            path_obj = Path(image_path)  # ty: ignore[invalid-argument-type]
                             if path_obj.is_absolute():
                                 full_path = path_obj
                             else:
-                                full_path = self._trajectory_dir / image_path
+                                full_path = self._trajectory_dir / image_path  # ty: ignore[unsupported-operator]
                             if not full_path.exists():
                                 self._add_error(
                                     f"{location}[{idx}].source.path: "
                                     f"referenced image file does not exist: {image_path}"
                                 )
 
+        # Check all steps for image references
         for step_idx, step in enumerate(trajectory_data.get("steps", [])):
             step_loc = f"trajectory.steps[{step_idx}]"
 
+            # Check message field
             message = step.get("message")
             if isinstance(message, list):
                 check_content_for_images(message, f"{step_loc}.message")
 
+            # Check observation results
             observation = step.get("observation")
             if observation:
                 for res_idx, result in enumerate(observation.get("results", [])):
@@ -98,7 +104,7 @@ class TrajectoryValidator:
                         )
 
     def validate(
-        self, trajectory: Union[Dict[str, Any], str, Path], validate_images: bool = True
+        self, trajectory: dict[str, Any] | str | Path, validate_images: bool = True
     ) -> bool:
         """Validate a complete trajectory.
 
@@ -114,6 +120,7 @@ class TrajectoryValidator:
         self.errors = []
         self._trajectory_dir = None
 
+        # Load trajectory if it's a string or path
         if isinstance(trajectory, (str, Path)):
             path = Path(trajectory)
             if path.exists():
@@ -140,15 +147,18 @@ class TrajectoryValidator:
             self._add_error("Trajectory must be a JSON object/dict")
             return False
 
+        # Use Pydantic for schema validation
         try:
             Trajectory(**trajectory)
         except ValidationError as e:
+            # Convert Pydantic errors to our error format
             for error in e.errors():
                 loc_str = ".".join(str(x) for x in error["loc"])
                 msg = error["msg"]
                 error_type = error["type"]
                 error_input = error.get("input")
 
+                # Format the error message in a user-friendly way
                 if error_type == "missing":
                     self._add_error(f"trajectory.{loc_str}: required field is missing")
                 elif error_type == "extra_forbidden":
@@ -156,6 +166,7 @@ class TrajectoryValidator:
                         f"trajectory.{loc_str}: unexpected field (not part of ATIF schema)"
                     )
                 elif error_type.startswith("value_error"):
+                    # Custom validation error from our validators
                     self._add_error(f"trajectory.{loc_str}: {msg}")
                 elif error_type.startswith("type_error") or error_type in [
                     "string_type",
@@ -164,7 +175,8 @@ class TrajectoryValidator:
                     "dict_type",
                     "list_type",
                 ]:
-                    # Include the actual value for better debugging
+                    # Type mismatch error
+                    # Include the actual value in the error message for better debugging
                     if error_input is not None:
                         self._add_error(
                             f"trajectory.{loc_str}: expected {error_type.replace('_', ' ')}, got {type(error_input).__name__}"
@@ -172,7 +184,7 @@ class TrajectoryValidator:
                     else:
                         self._add_error(f"trajectory.{loc_str}: {msg}")
                 elif error_type == "literal_error":
-                    # include the actual invalid value
+                    # Literal/enum validation failed - include the actual invalid value
                     if error_input is not None:
                         self._add_error(
                             f"trajectory.{loc_str}: {msg}, got '{error_input}'"
@@ -180,14 +192,16 @@ class TrajectoryValidator:
                     else:
                         self._add_error(f"trajectory.{loc_str}: {msg}")
                 else:
+                    # Generic error
                     self._add_error(f"trajectory.{loc_str}: {msg}")
 
+        # Validate image paths if requested and we have a trajectory directory
         if validate_images and self._trajectory_dir is not None:
             self._validate_image_paths(trajectory)
 
         return len(self.errors) == 0
 
-    def get_errors(self) -> List[str]:
+    def get_errors(self) -> list[str]:
         """Get all validation errors.
 
         Returns:
@@ -196,7 +210,7 @@ class TrajectoryValidator:
         return self.errors
 
 
-def validate_trajectory(trajectory: Union[Dict[str, Any], str, Path]) -> bool:
+def validate_trajectory(trajectory: dict[str, Any] | str | Path) -> bool:
     """Validate a trajectory against the ATIF schema.
 
     Args:
@@ -207,4 +221,3 @@ def validate_trajectory(trajectory: Union[Dict[str, Any], str, Path]) -> bool:
     """
     validator = TrajectoryValidator()
     return validator.validate(trajectory)
-

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -1194,11 +1194,20 @@ class TrajectoryRecorder:
                 rel = str(sibling_path.relative_to(self.target_dir / ".daydream"))
             except ValueError:
                 rel = sibling_path.name
+            # trajectory_id is the sibling's canonical per-document id (mirrors
+            # the fork's build_trajectory: session_id qualified by descriptor).
+            # v1.7 makes it the resolution key for the ref; session_id stays as
+            # informational run identity only (shared across siblings, not a
+            # matching key), and trajectory_path remains the external file ref.
             results.append(
                 ObservationResult(
                     content=f"Dispatched to {desc}",
                     subagent_trajectory_ref=[
-                        SubagentTrajectoryRef(session_id=self.session_id, trajectory_path=rel),
+                        SubagentTrajectoryRef(
+                            trajectory_id=f"{self.session_id}:{desc}",
+                            session_id=self.session_id,
+                            trajectory_path=rel,
+                        ),
                     ],
                 )
             )

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -1,4 +1,4 @@
-"""ATIF v1.6 trajectory recorder for daydream runs.
+"""ATIF v1.7 trajectory recorder for daydream runs.
 
 This module is the SOLE home for ATIF Pydantic model construction (D-19
 module-bloat ban). Other modules (agent.py, phases.py, ui.py, runner.py,
@@ -717,6 +717,7 @@ class Invocation:
             tool_calls=tool_calls,
             observation=observation,
             metrics=d["_metrics"],
+            llm_call_count=1,
             extra=extra,
         )
         self.steps.append(self.recorder.redactor.redact_step(agent_step))
@@ -783,6 +784,7 @@ class Invocation:
             tool_calls=tool_calls,
             observation=observation,
             metrics=d["_metrics"],
+            llm_call_count=1,
             extra=extra,
         )
         return [*self.steps, self.recorder.redactor.redact_step(partial_step)]
@@ -1208,6 +1210,10 @@ class TrajectoryRecorder:
             model_name=self.agent_model_name,
             message=f"Dispatching {count} parallel {phase.value} tasks",
             observation=Observation(results=results),
+            # Deterministic (non-LLM) fan-out dispatch: no inference is made
+            # here, so per the ATIF v1.7 no-LLM-orchestration rule this step
+            # carries llm_call_count=0 and omits metrics / reasoning_content.
+            llm_call_count=0,
             extra={
                 "daydream_phase": phase.value,
                 "daydream_run_flow": self.run_flow.value,
@@ -1239,9 +1245,15 @@ class TrajectoryRecorder:
             extra["phase_events"] = [e.to_dict() for e in self._phase_events]
         if self._subtrajectories:
             extra["subtrajectories"] = [dict(s) for s in self._subtrajectories]
+        # trajectory_id is the per-document identifier (distinct from the
+        # run-scoped session_id): the root uses session_id directly; a fork
+        # qualifies it with its descriptor so sibling documents stay unique
+        # within the run (ATIF v1.7).
+        trajectory_id = self.session_id if not self.descriptor else f"{self.session_id}:{self.descriptor}"
         return Trajectory(
-            schema_version="ATIF-v1.6",
+            schema_version="ATIF-v1.7",
             session_id=self.session_id,
+            trajectory_id=trajectory_id,
             agent=Agent(name="daydream", version=version, model_name=self.agent_model_name),
             steps=list(steps),
             final_metrics=final_metrics,

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -389,7 +389,7 @@ async def test_trajectory_agent_identity_is_daydream(tmp_path: Path) -> None:
 
 
 async def test_schema_version_and_session_id_present(tmp_path: Path) -> None:
-    """schema_version pinned to ATIF-v1.6 (D-09); session_id is non-empty UUID."""
+    """schema_version pinned to ATIF-v1.7; session_id and trajectory_id present."""
     recorder = _make_recorder(tmp_path)
     async with recorder:
         async with recorder.invocation(phase=DaydreamPhase.REVIEW) as inv:
@@ -397,9 +397,83 @@ async def test_schema_version_and_session_id_present(tmp_path: Path) -> None:
             inv.observe(ResultEvent(structured_output=None, continuation=None))
 
     traj = _read_trajectory(recorder.path)
-    assert traj["schema_version"] == "ATIF-v1.6"
+    assert atif_validate(traj, validate_images=False) is True
+    assert traj["schema_version"] == "ATIF-v1.7"
     assert isinstance(traj["session_id"], str)
     assert len(traj["session_id"]) > 0
+    # v1.7: root trajectory carries a per-document trajectory_id. With no fork
+    # descriptor it equals the run-scoped session_id.
+    assert traj["trajectory_id"] == traj["session_id"]
+
+
+async def test_agent_step_carries_llm_call_count_one(tmp_path: Path) -> None:
+    """v1.7: a real assistant turn records llm_call_count == 1."""
+    recorder = _make_recorder(tmp_path)
+    async with recorder:
+        async with recorder.invocation(phase=DaydreamPhase.REVIEW) as inv:
+            inv.observe(TextEvent(text="Hello world"))
+            inv.observe(ResultEvent(structured_output=None, continuation=None))
+
+    traj = _read_trajectory(recorder.path)
+    assert atif_validate(traj, validate_images=False) is True
+    agent_steps = [s for s in traj["steps"] if s["source"] == "agent"]
+    assert len(agent_steps) == 1
+    assert agent_steps[0]["llm_call_count"] == 1
+
+
+async def test_dispatch_step_is_deterministic_zero_llm_calls(tmp_path: Path) -> None:
+    """v1.7 no-LLM-orchestration rule: the fan-out dispatch step is a
+    deterministic (non-LLM) step — llm_call_count == 0 and no metrics /
+    reasoning_content. The vendored validator enforces this, so a passing
+    ``atif_validate`` plus the field assertions prove the constraint holds.
+    """
+    recorder = _make_recorder(tmp_path)
+    async with recorder:
+        async with recorder.fork("fix-0") as child:
+            async with child.invocation(phase=DaydreamPhase.FIX) as inv:
+                _observe_text_and_result(inv)
+        recorder.create_dispatch_step(phase=DaydreamPhase.FIX)
+        async with recorder.invocation(phase=DaydreamPhase.REVIEW) as inv:
+            _observe_text_and_result(inv)
+
+    traj = _read_trajectory(recorder.path)
+    assert atif_validate(traj, validate_images=False) is True
+    dispatch_steps = [
+        s for s in traj["steps"]
+        if s["source"] == "agent" and "Dispatching" in s.get("message", "")
+    ]
+    assert len(dispatch_steps) == 1
+    dispatch = dispatch_steps[0]
+    assert dispatch["llm_call_count"] == 0
+    assert "metrics" not in dispatch
+    assert "reasoning_content" not in dispatch
+
+
+async def test_fork_child_trajectory_id_distinct_from_root(tmp_path: Path) -> None:
+    """v1.7: a fork's per-document trajectory_id is descriptor-qualified so it
+    is distinct from the shared run-scoped session_id, while the sibling ref on
+    the parent stays resolvable via trajectory_path.
+    """
+    recorder = _make_recorder(tmp_path)
+    async with recorder:
+        async with recorder.fork("fix-0") as child:
+            async with child.invocation(phase=DaydreamPhase.FIX) as inv:
+                _observe_text_and_result(inv)
+            child_path = child.path
+        recorder.create_dispatch_step(phase=DaydreamPhase.FIX)
+        async with recorder.invocation(phase=DaydreamPhase.REVIEW) as inv:
+            _observe_text_and_result(inv)
+
+    child_traj = _read_trajectory(child_path)
+    assert atif_validate(child_traj, validate_images=False) is True
+    assert child_traj["session_id"] == recorder.session_id
+    assert child_traj["trajectory_id"] == f"{recorder.session_id}:fix-0"
+
+    parent_traj = _read_trajectory(recorder.path)
+    ref = parent_traj["steps"][
+        next(i for i, s in enumerate(parent_traj["steps"]) if "Dispatching" in s.get("message", ""))
+    ]["observation"]["results"][0]["subagent_trajectory_ref"][0]
+    assert ref["trajectory_path"].startswith("runs/")
 
 
 # Sanity: now_iso, Redactor, Invocation public surface

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -451,8 +451,9 @@ async def test_dispatch_step_is_deterministic_zero_llm_calls(tmp_path: Path) -> 
 
 async def test_fork_child_trajectory_id_distinct_from_root(tmp_path: Path) -> None:
     """v1.7: a fork's per-document trajectory_id is descriptor-qualified so it
-    is distinct from the shared run-scoped session_id, while the sibling ref on
-    the parent stays resolvable via trajectory_path.
+    is distinct from the shared run-scoped session_id, and the sibling ref on
+    the parent carries that canonical trajectory_id as its resolution key (not
+    just the run-scoped session_id) alongside the external trajectory_path.
     """
     recorder = _make_recorder(tmp_path)
     async with recorder:
@@ -474,6 +475,11 @@ async def test_fork_child_trajectory_id_distinct_from_root(tmp_path: Path) -> No
         next(i for i, s in enumerate(parent_traj["steps"]) if "Dispatching" in s.get("message", ""))
     ]["observation"]["results"][0]["subagent_trajectory_ref"][0]
     assert ref["trajectory_path"].startswith("runs/")
+    # v1.7 resolution key: the ref points at the sibling's canonical
+    # per-document trajectory_id, and session_id stays as informational run
+    # identity only (shared with the parent, not a matching key).
+    assert ref["trajectory_id"] == child_traj["trajectory_id"]
+    assert ref["session_id"] == recorder.session_id
 
 
 # Sanity: now_iso, Redactor, Invocation public surface


### PR DESCRIPTION
## Summary

Re-vendor `daydream/atif` wholesale from harbor@1d6c3851 (v0.17.1-9) with no local patches beyond import-path renames and the validator CLI removal. Every `models/*.py` is byte-identical to harbor after reversing the rename; `validator.py` differs only by the dropped `python -m` entrypoint.

Switch the recorder to ATIF-v1.7 emission:
- `schema_version="ATIF-v1.7"`
- populate `trajectory_id` (root=`session_id`, fork=`session_id:descriptor`)
- set `llm_call_count=1` on assistant-turn steps and `0` on the deterministic fan-out dispatch step

The dispatch step already omits metrics/reasoning_content, so it satisfies the v1.7 no-LLM-orchestration rule. `reasoning_effort` and embedded `subagent_trajectories` stay `None` (no value in the event stream; forks use external sibling files).

Also updates NOTICE provenance, `atif/__init__` and recorder docstrings, and CLAUDE.md to v1.7.

## Testing

Extends the trajectory real-path tests to assert the new v1.7 emission shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)