### PR TITLE
feat(archive): add --dump-artifacts flag to export full run bundle for CI upload

### DIFF
--- a/daydream/archive/__init__.py
+++ b/daydream/archive/__init__.py
@@ -164,6 +164,14 @@ def _archive_run_inner(
     # 5. Index in SQLite
     upsert_run(archive_dir, manifest)
 
+    # 6. Optionally copy the fully-assembled bundle to a user-specified directory
+    #    (``--dump-artifacts``) so CI can upload it. Copied wholesale from run_dir
+    #    so it includes the manifest and evaluation written above.
+    if config.dump_artifacts:
+        dest = Path(config.dump_artifacts)
+        dest.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(run_dir, dest, dirs_exist_ok=True)
+
 
 def _read_fix_failures(target_dir: Path) -> dict[str, str] | None:
     """Read ``deep/fix-failures.json`` from the source tree, if present.

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -622,6 +622,16 @@ def _build_main_parser(*, full_help: bool = False) -> argparse.ArgumentParser:
         if full_help else argparse.SUPPRESS,
     )
     parser.add_argument(
+        "--dump-artifacts",
+        default=None,
+        metavar="DIR",
+        dest="dump_artifacts",
+        help="Copy the full run bundle (ATIF trajectory, review output, deep artifacts, "
+             "diffs, findings, manifest, evaluation) into DIR for CI upload. Opt-in "
+             "because the logs may contain sensitive data."
+        if full_help else argparse.SUPPRESS,
+    )
+    parser.add_argument(
         "--pr-number",
         default=None,
         type=int,
@@ -892,6 +902,7 @@ def _parse_args(argv: list[str] | None = None) -> RunConfig:
         base=args.base,
         output_mode=output_mode,  # type: ignore[arg-type]
         findings_out=args.findings_out,
+        dump_artifacts=args.dump_artifacts,
         force_worktree=args.force_worktree,
         shallow=args.shallow,
         precision_mode=args.precision,

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -200,6 +200,16 @@ def _add_shared_arguments(parser: argparse.ArgumentParser, *, full_help: bool = 
         if full_help else argparse.SUPPRESS,
     )
     parser.add_argument(
+        "--dump-artifacts",
+        default=None,
+        metavar="DIR",
+        dest="dump_artifacts",
+        help="Copy the full run bundle (ATIF trajectory, review output, deep artifacts, "
+             "diffs, findings, manifest, evaluation) into DIR for CI upload. Opt-in "
+             "because the logs may contain sensitive data. Works on every flow."
+        if full_help else argparse.SUPPRESS,
+    )
+    parser.add_argument(
         "--backend", "-b",
         choices=["claude", "codex", "pi"],
         default=None,
@@ -622,16 +632,6 @@ def _build_main_parser(*, full_help: bool = False) -> argparse.ArgumentParser:
         if full_help else argparse.SUPPRESS,
     )
     parser.add_argument(
-        "--dump-artifacts",
-        default=None,
-        metavar="DIR",
-        dest="dump_artifacts",
-        help="Copy the full run bundle (ATIF trajectory, review output, deep artifacts, "
-             "diffs, findings, manifest, evaluation) into DIR for CI upload. Opt-in "
-             "because the logs may contain sensitive data."
-        if full_help else argparse.SUPPRESS,
-    )
-    parser.add_argument(
         "--pr-number",
         default=None,
         type=int,
@@ -958,6 +958,7 @@ def _build_feedback_config(args: argparse.Namespace) -> RunConfig:
         output_mode="loop",
         non_interactive=args.non_interactive,
         assume=args.assume,
+        dump_artifacts=args.dump_artifacts,
     )
 
 

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import json
 import os
 import shutil
-import uuid
 from dataclasses import asdict, is_dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -74,8 +73,6 @@ from daydream.phases import (
 from daydream.trajectory import (
     DaydreamPhase,
     DaydreamRunFlow,
-    TrajectoryRecorder,
-    default_trajectory_path,
     phase_scope,
 )
 from daydream.ui import (
@@ -1453,7 +1450,7 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
     from daydream.git_ops import GitError, GitTimeoutError
     from daydream.phases import _git_branch, _git_log
     from daydream.runner import (
-        _make_archive_callback,
+        _open_recorder,
         _resolved_backend_name,
     )
 
@@ -1493,18 +1490,8 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
     tier = select_tier(count_changed_files(diff))
     dd = deep_dir(target_dir)
 
-    session_id = str(uuid.uuid4())
-    trajectory_path = config.trajectory_path or default_trajectory_path(target_dir, session_id)
-    async with TrajectoryRecorder(
-        path=trajectory_path,
-        run_flow=DaydreamRunFlow.DEEP,
-        target_dir=target_dir,
-        agent_model_name="",
-        session_id=session_id,
-        explicit_path=config.trajectory_path is not None,
-        pr_number=config.pr_number,
-        pr_repo=config.pr_repo,
-        on_write=_make_archive_callback(config, target_dir, work),
+    async with _open_recorder(
+        config=config, target_dir=target_dir, work=work, flow_kind=DaydreamRunFlow.DEEP,
     ):
         console.print()
         print_info(console, f"Target directory: {target_dir}")

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -163,6 +163,10 @@ class RunConfig:
             (review + post inline PR comments), or ``"review"`` (review report only).
         findings_out: Path to write the Phase A findings artifact
             (``--findings-out``; review mode only). Default None.
+        dump_artifacts: Directory to copy the full assembled run bundle into
+            (trajectory, review-output, deep artifacts, diffs, findings, manifest,
+            evaluation) so CI can upload it. Opt-in via ``--dump-artifacts`` because
+            the logs may contain sensitive data. Default None.
         force_worktree: Force ephemeral worktree even when ``branch`` is None.
         shallow: Single-stack review (skip multi-stack auto-detection).
         extra_copy: Extra paths to copy into ephemeral worktrees.
@@ -219,6 +223,7 @@ class RunConfig:
     base: str | None = None
     output_mode: OutputMode = "loop"
     findings_out: str | None = None
+    dump_artifacts: str | None = None
     force_worktree: bool = False
     shallow: bool = False
     extra_copy: list[Path] = field(default_factory=list)
@@ -263,8 +268,13 @@ def _print_missing_skill_error(skill_name: str) -> None:
 def _make_archive_callback(
     config: RunConfig, target_dir: Path, work: WorkContext | None = None,
 ) -> Callable[[TrajectoryRecorder, str], None] | None:
-    """Build the on_write archive callback, or None if archiving is disabled."""
-    if not config.archive:
+    """Build the on_write archive callback, or None if archiving is disabled.
+
+    ``--dump-artifacts`` reuses the same bundle assembly, so the callback also
+    fires (to build and copy out the bundle) when a dump target is set even if
+    the centralized archive is disabled.
+    """
+    if not config.archive and not config.dump_artifacts:
         return None
 
     def _cb(recorder: TrajectoryRecorder, status: str) -> None:

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -292,6 +292,38 @@ def _make_archive_callback(
     return _cb
 
 
+def _open_recorder(
+    *,
+    config: RunConfig,
+    target_dir: Path,
+    work: WorkContext | None,
+    flow_kind: DaydreamRunFlow,
+) -> TrajectoryRecorder:
+    """Construct the run's ``TrajectoryRecorder`` with archival + dump wired in.
+
+    The single construction site for every flow's recorder. Centralizing it here
+    guarantees that centralized archival AND ``--dump-artifacts`` apply to every
+    flow — the four built-ins today and any future custom/extension flow tomorrow.
+    New flows MUST open their recorder through this factory rather than
+    constructing ``TrajectoryRecorder`` directly, so the dump/archive callback can
+    never be silently dropped. Session id and trajectory path are resolved here
+    identically for all flows.
+    """
+    session_id = str(uuid.uuid4())
+    trajectory_path = config.trajectory_path or default_trajectory_path(target_dir, session_id)
+    return TrajectoryRecorder(
+        path=trajectory_path,
+        run_flow=flow_kind,
+        target_dir=target_dir,
+        agent_model_name="",
+        session_id=session_id,
+        explicit_path=config.trajectory_path is not None,
+        pr_number=config.pr_number,
+        pr_repo=config.pr_repo,
+        on_write=_make_archive_callback(config, target_dir, work),
+    )
+
+
 def _file_config_or_empty(config: RunConfig) -> DaydreamFileConfig:
     """Return ``config.file_config``, or an empty config when it is None.
 
@@ -627,18 +659,8 @@ async def _run_pr_feedback(work: WorkContext, config: RunConfig) -> int:
     bot = config.bot
     target_dir = work.repo
 
-    session_id = str(uuid.uuid4())
-    trajectory_path = config.trajectory_path or default_trajectory_path(target_dir, session_id)
-    async with TrajectoryRecorder(
-        path=trajectory_path,
-        run_flow=DaydreamRunFlow.PR,
-        target_dir=target_dir,
-        agent_model_name="",
-        session_id=session_id,
-        explicit_path=config.trajectory_path is not None,
-        pr_number=config.pr_number,
-        pr_repo=config.pr_repo,
-        on_write=_make_archive_callback(config, target_dir, work),
+    async with _open_recorder(
+        config=config, target_dir=target_dir, work=work, flow_kind=DaydreamRunFlow.PR,
     ):
         ctx = FlowContext(config=config, work=work, registry=get_registry())
         ctx.data["pr_number"] = pr_number
@@ -828,19 +850,8 @@ async def _run_review_or_comment(
     diff_path = daydream_dir / "diff.patch"
     diff_path.write_text(diff)
 
-    flow = DaydreamRunFlow.TTT
-    session_id = str(uuid.uuid4())
-    trajectory_path = config.trajectory_path or default_trajectory_path(target_dir, session_id)
-    async with TrajectoryRecorder(
-        path=trajectory_path,
-        run_flow=flow,
-        target_dir=target_dir,
-        agent_model_name="",
-        session_id=session_id,
-        explicit_path=config.trajectory_path is not None,
-        pr_number=config.pr_number,
-        pr_repo=config.pr_repo,
-        on_write=_make_archive_callback(config, target_dir, work),
+    async with _open_recorder(
+        config=config, target_dir=target_dir, work=work, flow_kind=DaydreamRunFlow.TTT,
     ):
         ctx = FlowContext(config=config, work=work, registry=get_registry())
         ctx.data["post_to_pr"] = post_to_pr
@@ -942,18 +953,8 @@ async def _run_loop_shallow(work: WorkContext, config: RunConfig) -> int:
             default="n",
         )
 
-    session_id = str(uuid.uuid4())
-    trajectory_path = config.trajectory_path or default_trajectory_path(target_dir, session_id)
-    async with TrajectoryRecorder(
-        path=trajectory_path,
-        run_flow=DaydreamRunFlow.NORMAL,
-        target_dir=target_dir,
-        agent_model_name="",
-        session_id=session_id,
-        explicit_path=config.trajectory_path is not None,
-        pr_number=config.pr_number,
-        pr_repo=config.pr_repo,
-        on_write=_make_archive_callback(config, target_dir, work),
+    async with _open_recorder(
+        config=config, target_dir=target_dir, work=work, flow_kind=DaydreamRunFlow.NORMAL,
     ):
         ctx = FlowContext(config=config, work=work, registry=get_registry())
         ctx.data["skill"] = skill

--- a/tests/test_archive_data_capture.py
+++ b/tests/test_archive_data_capture.py
@@ -95,6 +95,62 @@ async def test_default_deep_run_populates_eval_and_captures_recommended_patch(
     assert "# daydream recommended change" not in diff_text
 
 
+async def test_dump_artifacts_copies_full_bundle_to_target_dir(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch, archive_dir: Path, tmp_path: Path
+) -> None:
+    """``--dump-artifacts DIR`` copies the fully-assembled run bundle into DIR so CI
+    can upload it — trajectory, deep artifacts, diffs, manifest, and evaluation all
+    land in the user-specified directory, mirroring the archived run."""
+    _silence(monkeypatch)
+    _force_interactive(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    stub.merge_items = [_merge_item(1, "api.py", "high")]
+    stub.fix_edit_line = "# daydream recommended change\n"
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_test_and_heal", lambda *a, **k: _ok())
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _noop_commit)
+
+    dump_dir = tmp_path / "uploaded-artifacts"
+
+    exit_code = await run(
+        RunConfig(
+            target=str(multi_stack_target),
+            assume="yes",
+            output_mode="loop",
+            cleanup=False,
+            dump_artifacts=str(dump_dir),
+        )
+    )
+    assert exit_code == 0
+
+    # The dump directory mirrors the archived run bundle.
+    run_dir = _only_archived_run(archive_dir)
+    assert (dump_dir / "manifest.json").is_file()
+    assert (dump_dir / "trajectory.json").is_file()
+    assert (dump_dir / "diff.patch").is_file()
+    assert (dump_dir / "evaluation.json").is_file()
+    assert (dump_dir / "manifest.json").read_text() == (run_dir / "manifest.json").read_text()
+
+
+async def test_no_dump_artifacts_leaves_no_extra_copy(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch, archive_dir: Path, tmp_path: Path
+) -> None:
+    """Without ``--dump-artifacts`` no bundle copy is made outside the archive."""
+    _silence(monkeypatch)
+    _force_interactive(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    stub.merge_items = [_merge_item(1, "api.py", "high")]
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_test_and_heal", lambda *a, **k: _ok())
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _noop_commit)
+
+    dump_dir = tmp_path / "uploaded-artifacts"
+
+    exit_code = await run(
+        RunConfig(target=str(multi_stack_target), assume="yes", output_mode="loop", cleanup=False)
+    )
+    assert exit_code == 0
+    assert not dump_dir.exists()
+
+
 async def test_no_eval_leaves_manifest_eval_fields_null(
     multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch, archive_dir: Path
 ) -> None:

--- a/tests/test_feedback_subcommand_integration.py
+++ b/tests/test_feedback_subcommand_integration.py
@@ -78,7 +78,7 @@ async def test_feedback_subcommand_argv_to_body(
 
 
 async def test_feedback_subcommand_non_interactive_argv_to_body(
-    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """Real-path: ``daydream feedback ... --non-interactive`` parses AND runs.
 
@@ -86,6 +86,11 @@ async def test_feedback_subcommand_non_interactive_argv_to_body(
     main parser: the feedback subparser rejected it (``unrecognized arguments``)
     and ``_build_feedback_config`` never set ``non_interactive``. This drives raw
     argv WITH the flag through the real feedback subparser into the real body.
+
+    Also carries ``--dump-artifacts`` (a shared arg wired into every flow via
+    ``_open_recorder``) to prove the flag is accepted on the feedback subparser
+    AND that this non-deep flow dumps its full bundle — the guarantee that any
+    flow, including a future custom one, keeps dumping.
 
     Crucially it does NOT silence prompts — instead ``builtins.input`` is patched
     to raise on ANY call, so a stray stdin read anywhere in the unattended
@@ -95,14 +100,18 @@ async def test_feedback_subcommand_non_interactive_argv_to_body(
     from daydream.agent import get_non_interactive, reset_state
     from daydream.runner import run_feedback
 
+    dump_dir = tmp_path / "dump-artifacts"
+
     # Pre-fix this raised SystemExit (unrecognized argument).
     config = cli._parse_args(
-        ["feedback", str(PR_NUMBER), "--bot", BOT, "--non-interactive", str(multi_stack_target)]
+        ["feedback", str(PR_NUMBER), "--bot", BOT, "--non-interactive",
+         "--dump-artifacts", str(dump_dir), str(multi_stack_target)]
     )
 
     assert config.non_interactive is True
     assert config.bot == BOT
     assert config.pr_number == PR_NUMBER
+    assert config.dump_artifacts == str(dump_dir)
 
     # No _silence — stdin must never be touched.
     stub = _PRFeedbackStubBackend()
@@ -131,3 +140,8 @@ async def test_feedback_subcommand_non_interactive_argv_to_body(
     assert head_after != head_before
     commit_msg = _git(multi_stack_target, "log", "-1", "--format=%B")
     assert "Daydream-Run:" in commit_msg
+
+    # --dump-artifacts copied the full bundle out of the feedback (pr-feedback)
+    # flow, proving the centralized recorder wires the dump on non-deep paths.
+    assert (dump_dir / "trajectory.json").is_file()
+    assert (dump_dir / "manifest.json").is_file()


### PR DESCRIPTION
## What

Adds an opt-in CLI flag, `--dump-artifacts DIR`, that copies the full local run bundle into `DIR` so CI can upload it. Today only `findings/findings.json` leaves the machine; the ATIF trajectory, `.review-output.md`, `.daydream/deep/*`, and diffs are written locally and discarded when the ephemeral CI runner is torn down. This flag makes the complete bundle available for upload.

Opt-in because the trajectory and deep-analysis logs may contain sensitive data.

## Works on every flow, now and later

`--dump-artifacts` is a shared argument, accepted on both the main parser and the `feedback` subcommand.

Recorder construction is centralized into a single `_open_recorder()` factory in `runner.py`. All four flows (deep, shallow, review/comment, pr-feedback) open their `TrajectoryRecorder` through it, and it always wires the archive/dump callback. A future custom or extension-defined flow that uses the factory dumps artifacts for free — the callback can't be silently dropped by a new construction site.

## How

- `RunConfig.dump_artifacts` field; `--dump-artifacts` added to `_add_shared_arguments` and threaded through both config builders.
- `_make_archive_callback` fires when archive **or** dump is requested.
- After `_archive_run_inner` assembles the bundle at the archive run dir, it `copytree`s that dir into `DIR`. Reuses the existing archive assembly — no duplicated copy logic.
- `_open_recorder()` replaces the four inline `TrajectoryRecorder(...)` sites.

Dumped directory mirrors the archived run: `trajectory.json`, `trajectories/*`, `review-output.md`, `deep/*`, `diff.patch`, `recommended.patch`, `findings.json`, `manifest.json`, `evaluation.json`.

No workflow, template, or `daydream setup` changes — users add the flag to their own command and upload `DIR`.

## Usage

```
daydream --non-interactive --pr-number "$PR" --base "origin/$BASE" \
  --dump-artifacts artifacts/ .
```

## Tests

Real-path tests through `runner.run` / the CLI (backend seam mocked):
- Deep flow: `--dump-artifacts` populates `DIR` with the full bundle; its `manifest.json` matches the archived run's; absence of the flag copies nothing outside the archive.
- Feedback flow: `daydream feedback ... --dump-artifacts` parses on the subparser and dumps `trajectory.json` + `manifest.json` from a non-deep flow.

`make check` green (2084 passed); `mypy daydream tests` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)