### PR TITLE
fix(review): embed verification-protocol gates inline instead of skill-file read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **review:** Embed verification-protocol gates inline instead of a skill-file read in the structural and generic-fallback reviewers
+
+  These two reviewers run with cwd set to the reviewed repo, so the previous `read review-verification-protocol/SKILL.md` instruction resolved against that repo, failed ("skill doesn't exist as a file"), and silently dropped the anchor/evidence/severity gates. The gates (0–3) are now stated inline in `VERIFICATION_PROTOCOL_INSTRUCTION`, mirroring the inline gate-0 embedding already used by `build_verification_prompt`. Both reviewers are language-agnostic, so the protocol's language-specific valid-pattern tables were of little use to them; the gate discipline is what mattered and is now self-contained.
+
 ## [0.22.0] - 2026-07-02
 
 ### Added

--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -36,14 +36,31 @@ DOC_REVIEW_NOTICE = (
 )
 
 # Shared verification-protocol instruction for structural and generic-fallback
-# builders (issue #229). Embedded as instruction text, not routed through
-# ``Backend.format_skill_invocation``.
+# builders (issue #229). The gates are embedded inline as instruction text, not
+# routed through ``Backend.format_skill_invocation`` and NOT loaded from a skill
+# file: these two reviewers run with cwd set to the reviewed repo, so a bare
+# ``read review-verification-protocol/SKILL.md`` resolves against that repo and
+# fails ("skill doesn't exist as a file"), silently dropping the gates. Both
+# reviewers are language-agnostic (repo-wide structural / non-stack fallback), so
+# the protocol's language-specific valid-pattern tables add little here — the
+# gate discipline is what matters, and it is self-contained below. Mirrors the
+# inline gate-0 embedding in ``build_verification_prompt``.
 VERIFICATION_PROTOCOL_INSTRUCTION = (
-    "Before writing findings, load the review-verification-protocol skill "
-    "(read review-verification-protocol/SKILL.md) and apply its "
-    "anchor-evidence-severity gates (gate 1: anchor file:line, gate 2: produce "
-    "evidence artifacts, gate 3: calibrate severity). Do NOT report a finding "
-    "that fails any gate."
+    "Before writing findings, apply the review-verification-protocol gates "
+    "(stated inline here — no skill file read is required):\n"
+    "  Gate-0 anti-confabulation (before ANY finding): echo the exact artifact "
+    "you are judging — file:line plus the cited code, read freshly in THIS turn, "
+    "not recalled. The source is the only truth; never infer a finding from the "
+    "branch name, cwd, or memory. A finding without a same-turn echo of its "
+    "target is INVALID.\n"
+    "  Gate 1 (anchor): read the full enclosing symbol/module, not just the diff "
+    "hunk; state the file path and line range you are judging.\n"
+    "  Gate 2 (evidence): produce an artifact for the finding's type — pasted "
+    'tool output, a file:line citation, or an explicit "none" / "N matches" '
+    'after a repo search. Never claim you "looked" without an artifact.\n'
+    "  Gate 3 (severity): calibrate severity to impact; a request for net-new "
+    "code that did not exist in scope is Informational only.\n"
+    "Do NOT report a finding that fails any gate."
 )
 
 

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -614,15 +614,15 @@ def test_build_verification_prompt_includes_gate_zero_echo(tmp_path: Path) -> No
 
 
 def test_no_format_skill_invocation_for_verification_protocol(tmp_path: Path) -> None:
-    """The protocol is user-invocable:false — embedded as instruction text, never
-    routed through ``backend.format_skill_invocation``.
+    """The protocol gates are embedded inline as instruction text — never routed
+    through ``backend.format_skill_invocation`` AND never loaded from a skill file.
 
-    Observed at the production prompt-builder seam: the structural and
-    generic-fallback prompts are the only builders that embed the protocol
-    directly (the per-stack reviewers bundle it inside their Beagle skill).
-    Build them with a real backend formatter and assert the embedded
-    instruction is present while the protocol's invocation token — as each
-    real backend would emit it — never leaks into the prompt.
+    The structural and generic-fallback reviewers run with cwd set to the
+    reviewed repo, so a bare ``read review-verification-protocol/SKILL.md`` would
+    resolve against that repo and fail. The gates are therefore stated inline
+    (see ``VERIFICATION_PROTOCOL_INSTRUCTION``). Build the prompts with a real
+    backend formatter and assert the gate discipline is present while neither a
+    skill-file read nor the protocol's invocation token leaks into the prompt.
     """
     from daydream.backends import create_backend
     from daydream.deep.prompts import build_structural_prompt
@@ -641,9 +641,11 @@ def test_no_format_skill_invocation_for_verification_protocol(tmp_path: Path) ->
         backend = create_backend(backend_name)
         token = backend.format_skill_invocation("review-verification-protocol")
         for prompt in prompts:
-            # Embedded as methodology prose (the constant carries the
-            # protocol name and gate descriptions), never as an invocation.
-            assert "review-verification-protocol/SKILL.md" in prompt
+            # Gates are embedded as methodology prose (the constant names the
+            # protocol and states gates 0-3 inline), never as an invocation and
+            # never as an unresolvable skill-file read.
+            assert "review-verification-protocol" in prompt
+            assert "SKILL.md" not in prompt
             assert token not in prompt, (
                 f"{backend_name} protocol invocation token {token!r} leaked into prompt"
             )


### PR DESCRIPTION
## Problem

The structural and generic-fallback reviewers append `VERIFICATION_PROTOCOL_INSTRUCTION`, which instructed the agent to `read review-verification-protocol/SKILL.md`. Both reviewers run with cwd set to the **repo under review**, so that bare relative path resolved against the reviewed repo — not the installed skill directory. The read failed and the agent narrated:

> The review-verification-protocol skill doesn't exist as a file. I'll proceed with the review using the gates described in the prompt itself (gate 1: anchor file:line, gate 2: produce evidence artifacts, gate 3: calibrate severity).

So the anchor/evidence/severity gates were silently dropped on every structural / non-stack review (e.g. reviewing a workflow YAML → generic-fallback bucket).

## Fix

State gates 0–3 inline in `VERIFICATION_PROTOCOL_INSTRUCTION` — no skill-file read. This mirrors the inline gate-0 embedding already used by `build_verification_prompt`. Both reviewers are language-agnostic (repo-wide structural / non-stack fallback), so the protocol's language-specific valid-pattern tables added little value here; the gate discipline is what mattered and is now self-contained.

The per-stack language reviewers are unaffected — they bundle the full protocol via their Beagle skill's relative link, which resolves correctly because it is anchored to the Skill-invoked skill's own directory.

## Tests

- `test_no_format_skill_invocation_for_verification_protocol` updated: asserts the gates are embedded as prose with **no** skill-file read (`SKILL.md`) and **no** invocation-token leak across the claude/codex/pi backends.
- Existing `test_build_{structural,generic_fallback}_prompt_includes_verification_protocol` still pass (protocol name + `anchor` + `evidence` present).
- `uv run pytest tests/test_deep_prompts.py` → 38 passed; ruff + mypy clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)