### PR TITLE
docs(changelog): backfill #260 PR link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **review:** Embed verification-protocol gates inline instead of a skill-file read in the structural and generic-fallback reviewers
+- **review:** Embed verification-protocol gates inline instead of a skill-file read in the structural and generic-fallback reviewers ([#260](https://github.com/existential-birds/daydream/pull/260))
 
   These two reviewers run with cwd set to the reviewed repo, so the previous `read review-verification-protocol/SKILL.md` instruction resolved against that repo, failed ("skill doesn't exist as a file"), and silently dropped the anchor/evidence/severity gates. The gates (0–3) are now stated inline in `VERIFICATION_PROTOCOL_INSTRUCTION`, mirroring the inline gate-0 embedding already used by `build_verification_prompt`. Both reviewers are language-agnostic, so the protocol's language-specific valid-pattern tables were of little use to them; the gate discipline is what mattered and is now self-contained.
 


### PR DESCRIPTION
## Summary

Backfills the missing PR link on the #260 changelog entry. It merged before its PR number was known, leaving it the only recent `### Fixed` entry without a `([#NNN](...))` link. This restores consistency with the other 150 linked entries.

## Changes

- One-line edit to `CHANGELOG.md` appending `([#260](https://github.com/existential-birds/daydream/pull/260))`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)