### PR TITLE
feat(runner): add --flow flag to select a registered flow (#259)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **runner:** `--flow <name>` selects a registered flow for dispatch ([#259](https://github.com/existential-birds/daydream/pull/259))
+
+  A fork can register a brand-new flow via `registry.set_flow(...)` in `daydream_ext` and now run it end-to-end with `--flow <name>` (or `RunConfig(flow_name=...)`). Built-in names (`deep`/`shallow`/`review`) route to their existing dedicated helpers so behavior is unchanged; `pr-feedback` is not selectable this way (use `daydream feedback`); unknown names fail with the standard Extension Error panel. Custom flows open their recorder through the shared factory, so `--dump-artifacts`/archival apply automatically.
+
 ### Fixed
 
 - **review:** Embed verification-protocol gates inline instead of a skill-file read in the structural and generic-fallback reviewers ([#260](https://github.com/existential-birds/daydream/pull/260))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **runner:** `--flow <name>` selects a registered flow for dispatch ([#259](https://github.com/existential-birds/daydream/pull/259))
+- **runner:** `--flow <name>` selects a registered flow for dispatch ([#263](https://github.com/existential-birds/daydream/pull/263))
 
   A fork can register a brand-new flow via `registry.set_flow(...)` in `daydream_ext` and now run it end-to-end with `--flow <name>` (or `RunConfig(flow_name=...)`). Built-in names (`deep`/`shallow`/`review`) route to their existing dedicated helpers so behavior is unchanged; `pr-feedback` is not selectable this way (use `daydream feedback`); unknown names fail with the standard Extension Error panel. Custom flows open their recorder through the shared factory, so `--dump-artifacts`/archival apply automatically.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,10 +112,11 @@ cli.py -> runner.py -> flows/engine.py (run_flow over registered FlowSteps)
 ```
 
 - `runner.run()` is the async entry. It builds the per-run extension `Registry`
-  (`build_registry()`), sets it on a `ContextVar`, and dispatches one of four
+  (`build_registry()`), sets it on a `ContextVar`, and dispatches one of five
   registered flows — `deep` (default), `shallow`, `review` (`--review`/`--comment`),
-  or `pr-feedback` (`daydream feedback <pr#>`) — each a preamble plus
-  `flows.run_flow()` over the flow's ordered `FlowStep` list.
+  `pr-feedback` (`daydream feedback <pr#>`), or a custom extension flow
+  (`--flow NAME`) — each a preamble plus `flows.run_flow()` over the flow's
+  ordered `FlowStep` list.
 - `agent.run_agent()` is the only agent call site. Never call a backend/SDK directly
   from phases. It wraps `Backend.execute()` and drives the Rich UI + trajectory recorder.
 - Subagent fan-out (exploration, per-stack review, parallel fix) is N parallel

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -604,6 +604,15 @@ def _build_main_parser(*, full_help: bool = False) -> argparse.ArgumentParser:
         help="Single-stack review (skip multi-stack auto-detection).",
     )
     parser.add_argument(
+        "--flow",
+        default=None,
+        metavar="NAME",
+        dest="flow_name",
+        help="Dispatch a registered flow by name (built-in: deep/shallow/review; "
+             "or a daydream_ext custom flow). Built-in names behave like their "
+             "dedicated flag." if full_help else argparse.SUPPRESS,
+    )
+    parser.add_argument(
         "--precision",
         action="store_true",
         default=False,
@@ -860,6 +869,14 @@ def _parse_args(argv: list[str] | None = None) -> RunConfig:
     if loop and args.start_at != "review":
         parser.error("--loop requires starting at review phase (incompatible with --start-at)")
 
+    if args.flow_name is not None:
+        if args.comment or args.review:
+            parser.error("--flow cannot be combined with --review/--comment")
+        if args.shallow:
+            parser.error("--flow cannot be combined with --shallow")
+        if loop:
+            parser.error("--flow cannot be combined with --loop")
+
     # Attribute provenance to the target checkout, not the invoking cwd —
     # daydream may run from one repo against a checkout of another.
     target_repo = Path(args.target) if args.target else Path.cwd()
@@ -905,6 +922,7 @@ def _parse_args(argv: list[str] | None = None) -> RunConfig:
         dump_artifacts=args.dump_artifacts,
         force_worktree=args.force_worktree,
         shallow=args.shallow,
+        flow_name=args.flow_name,
         precision_mode=args.precision,
         extra_copy=list(args.extra_copy),
         non_interactive=args.non_interactive,

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -2,10 +2,15 @@
 
 The runner is unified around a single :func:`run` entry point. ``run`` opens
 the workspace via :func:`daydream.workspace.open_workspace` and then dispatches
-to a private helper based on ``config.bot`` / ``config.output_mode`` /
-``config.shallow``::
+to a private helper based on ``config.bot`` / ``config.flow_name`` /
+``config.output_mode`` / ``config.shallow``::
 
     bot set (feedback mode)  -> _run_pr_feedback (registered "pr-feedback" flow)
+    flow_name set (--flow)   -> _dispatch_selected_flow:
+        "review"             -> _run_review     (registered "review" flow, report only, no posting)
+        "shallow"            -> _run_loop_shallow (registered "shallow" flow)
+        "deep"               -> _run_loop_deep  (deep multi-stack pipeline)
+        other registered     -> _run_custom_flow (fork-registered custom flow)
     output_mode == "comment" -> _run_comment    (registered "review" flow, posts inline PR comments)
     output_mode == "review"  -> _run_review     (registered "review" flow, report only, no posting)
     output_mode == "loop":
@@ -541,7 +546,10 @@ async def run(config: RunConfig | None = None) -> int:
     # Resolve the active GitHub identity once onto config.identity. Under App
     # credentials this also mints + injects the installation token into every ``gh``
     # subprocess; every hard-abort case surfaces as GitHubAppError.
-    is_posting = config.bot is not None or config.output_mode in ("comment", "review")
+    # ``--flow review`` is equivalent to ``--review``: treat it as posting so the
+    # GitHub App token is minted and injected the same way.
+    _flow_is_review = config.flow_name == "review"
+    is_posting = config.bot is not None or config.output_mode in ("comment", "review") or _flow_is_review
     try:
         identity = github_app.resolve_run_identity(target_dir, config.pr_repo, is_posting=is_posting)
     except github_app.GitHubAppError as exc:
@@ -550,7 +558,8 @@ async def run(config: RunConfig | None = None) -> int:
     config.identity = identity
 
     # ``--comment``/``--review`` skip the test phase, hence the .env copy too.
-    skip_tests = config.output_mode != "loop"
+    # ``--flow review`` matches this behaviour for parity.
+    skip_tests = config.output_mode != "loop" or _flow_is_review
 
     # ``open_workspace`` runs ``assert_is_worktree`` and surfaces
     # ``NotAWorktreeError`` (a ``GitError``) caught below — a loud error instead of
@@ -962,6 +971,7 @@ async def _run_custom_flow(work: WorkContext, config: RunConfig) -> int:
         config=config, target_dir=target_dir, work=work, flow_kind=DaydreamRunFlow.CUSTOM,
     ):
         ctx = FlowContext(config=config, work=work, registry=get_registry())
+        ctx.data["post_to_pr"] = False  # custom flows do not post to PR by default
         ctx.data["diff"] = diff
         ctx.data["log"] = log
         ctx.data["branch"] = branch

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -593,6 +593,30 @@ async def run_feedback(config: RunConfig, pr: int) -> int:
 # Dispatch
 
 
+def _require_reviewable_branch(work: WorkContext, config: RunConfig) -> None:
+    """Raise WrongBranchError when a loop run has nothing to review against.
+
+    A worktree on the base branch with no --branch/--worktree would review
+    itself. Raised for cli.main() to render the actionable panel. Extracted
+    from _dispatch so both the default loop path and --flow deep/shallow reuse
+    the identical guard.
+    """
+    if (
+        config.branch is None
+        and not config.force_worktree
+        and work.head_branch is not None
+        and work.head_branch == work.base_branch
+    ):
+        raise git_ops.WrongBranchError(
+            f"cwd is on the base branch {work.base_branch!r} -- "
+            "there's nothing to review against itself.\n"
+            "Either:\n"
+            f"  - check out a feature branch in this worktree and re-run, or\n"
+            f"  - run with --branch <feature-branch> to review the server's version, or\n"
+            f"  - run with --worktree to force ephemeral isolation."
+        )
+
+
 async def _dispatch(work: WorkContext, config: RunConfig) -> int:
     """Pick the flow helper for the resolved workspace + config.
 
@@ -617,23 +641,8 @@ async def _dispatch(work: WorkContext, config: RunConfig) -> int:
     if config.output_mode == "review":
         return await _run_review(work, config)
 
-    # output_mode == "loop". Guard the silent-failure case: a worktree on the
-    # base branch with no --branch/--worktree has nothing to review against
-    # itself, so raise loudly for cli.main() to render.
-    if (
-        config.branch is None
-        and not config.force_worktree
-        and work.head_branch is not None
-        and work.head_branch == work.base_branch
-    ):
-        raise git_ops.WrongBranchError(
-            f"cwd is on the base branch {work.base_branch!r} -- "
-            "there's nothing to review against itself.\n"
-            "Either:\n"
-            f"  - check out a feature branch in this worktree and re-run, or\n"
-            f"  - run with --branch <feature-branch> to review the server's version, or\n"
-            f"  - run with --worktree to force ephemeral isolation."
-        )
+    # output_mode == "loop".
+    _require_reviewable_branch(work, config)
 
     if config.shallow:
         return await _run_loop_shallow(work, config)

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -188,6 +188,9 @@ class RunConfig:
             (precedence CLI > file > default, mirroring
             ``shallow_fanout_threshold``; resolved by ``_precision_mode``), so the
             suppression pass never runs and arbiter output is byte-identical.
+        flow_name: Name of a registered flow to dispatch (``--flow``); built-in
+            names route to their dedicated helper, other registered names to the
+            generic custom-flow runner.
 
     """
 
@@ -240,6 +243,7 @@ class RunConfig:
     # cannot confirm (fail-closed). Default False => byte-identical behavior; the
     # suppression predicate is never called and arbiter output is unchanged.
     precision_mode: bool = False
+    flow_name: str | None = None
 
 
 def _print_missing_skill_error(skill_name: str) -> None:

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -617,13 +617,52 @@ def _require_reviewable_branch(work: WorkContext, config: RunConfig) -> None:
         )
 
 
+async def _dispatch_selected_flow(work: WorkContext, config: RunConfig) -> int:
+    """Route an explicit ``--flow <name>`` selection.
+
+    Validates registration first (unknown names raise
+    ``UnresolvedExtensionError``, which propagates to :func:`run`'s Extension
+    Error panel). Built-in names route to their existing dedicated helper so
+    behavior matches the default / ``--shallow`` / ``--review`` paths;
+    ``pr-feedback`` is not selectable this way (it needs a PR number + bot);
+    any other registered name runs the generic :func:`_run_custom_flow`.
+    """
+    name = config.flow_name
+    assert name is not None
+
+    # Resolve-check first; unknown names raise UnresolvedExtensionError, caught
+    # by run()'s Extension Error panel (exit 1). Do not swallow it here.
+    get_registry().flow(name)
+
+    if name == "pr-feedback":
+        print_error(
+            console,
+            "Flow not selectable",
+            "The pr-feedback flow needs a PR number and bot identity; "
+            "use: daydream feedback <pr#> --bot <name>.",
+        )
+        return 1
+    if name == "review":
+        return await _run_review(work, config)
+    if name == "shallow":
+        _require_reviewable_branch(work, config)
+        return await _run_loop_shallow(work, config)
+    if name == "deep":
+        _require_reviewable_branch(work, config)
+        return await _run_loop_deep(work, config)
+
+    return await _run_custom_flow(work, config)
+
+
 async def _dispatch(work: WorkContext, config: RunConfig) -> int:
     """Pick the flow helper for the resolved workspace + config.
 
     Order matters: ``bot`` signals PR feedback mode (set only by the
-    ``daydream feedback <pr#>`` subcommand). Then output_mode picks comment vs
-    review vs loop. Inside loop, ``config.shallow`` selects the single-stack
-    pipeline; otherwise the deep multi-stack pipeline runs (default).
+    ``daydream feedback <pr#>`` subcommand). Then an explicit ``flow_name``
+    (``--flow``) routes via :func:`_dispatch_selected_flow`. Then output_mode
+    picks comment vs review vs loop. Inside loop, ``config.shallow`` selects
+    the single-stack pipeline; otherwise the deep multi-stack pipeline runs
+    (default).
 
     Note: ``config.pr_number`` can be auto-detected from the current branch
     for metadata (trajectory/archive) without implying feedback mode.
@@ -634,6 +673,9 @@ async def _dispatch(work: WorkContext, config: RunConfig) -> int:
     """
     if config.bot is not None:
         return await _run_pr_feedback(work, config)
+
+    if config.flow_name is not None:
+        return await _dispatch_selected_flow(work, config)
 
     if config.output_mode == "comment":
         return await _run_comment(work, config)
@@ -883,6 +925,58 @@ async def _run_review_or_comment(
         console.print()
 
         return await run_flow(ctx.registry, "review", ctx)
+
+
+# Helper: generic custom flow (--flow <name>)
+
+
+async def _run_custom_flow(work: WorkContext, config: RunConfig) -> int:
+    """Generic preamble for a fork-registered flow selected via ``--flow``.
+
+    Mirrors :func:`_run_review_or_comment`'s diff seed so custom flows composed
+    of built-in review steps work, but an empty/unavailable diff is a dim note
+    rather than an early return (a custom flow may not need a diff). Opens the
+    recorder through the shared factory so ``--dump-artifacts``/archival apply.
+    """
+    flow_name = config.flow_name
+    assert flow_name is not None
+    target_dir = work.repo
+
+    try:
+        diff = git_ops.diff(work.repo, work.base_branch, exclude=config.ignore_paths)
+    except GitError:
+        diff = None
+    log = _git_log(target_dir)
+    branch = work.head_branch or _git_branch(target_dir)
+
+    if not diff:
+        print_dim(console, "No diff found — custom flow will run without a diff seed.")
+        diff = ""
+
+    daydream_dir = target_dir / ".daydream"
+    daydream_dir.mkdir(exist_ok=True)
+    diff_path = daydream_dir / "diff.patch"
+    diff_path.write_text(diff)
+
+    async with _open_recorder(
+        config=config, target_dir=target_dir, work=work, flow_kind=DaydreamRunFlow.CUSTOM,
+    ):
+        ctx = FlowContext(config=config, work=work, registry=get_registry())
+        ctx.data["diff"] = diff
+        ctx.data["log"] = log
+        ctx.data["branch"] = branch
+        ctx.data["daydream_dir"] = daydream_dir
+        ctx.data["diff_path"] = diff_path
+
+        console.print()
+        print_info(console, f"Target directory: {target_dir}")
+        print_info(console, f"Flow: {flow_name}")
+        print_info(console, f"Branch: {branch}")
+        # Bot logins look like ``my-app[bot]``; escape so Rich doesn't eat the brackets.
+        print_info(console, f"GitHub identity: {escape_markup(config.identity)}")
+        console.print()
+
+        return await run_flow(ctx.registry, flow_name, ctx)
 
 
 # Helper: shallow loop (single-stack review-fix-test)

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -185,6 +185,7 @@ class DaydreamRunFlow(str, Enum):
     TTT = "ttt"
     PR = "pr"
     DEEP = "deep"
+    CUSTOM = "custom"
 
 
 class Redactor:

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -255,6 +255,26 @@ pass (and `daydream ext validate`), not at `set_flow` time, so registration
 order does not matter. `insert_before` / `insert_after` / `remove` validate
 their anchors eagerly.
 
+### Selecting a flow
+
+The built-in flows dispatch through their existing flags and defaults: the
+default run selects `deep`, `--shallow` selects `shallow`, `--review`/`--comment`
+select `review`, and `daydream feedback <pr#>` selects `pr-feedback`.
+
+A newly registered flow is dispatched by name with `--flow <name>` (or
+`RunConfig(flow_name=...)`):
+
+```python
+r.set_flow("ro-audit", ["ro_audit"])
+# daydream --flow ro-audit /path/to/project
+```
+
+A built-in name passed to `--flow` (`deep`/`shallow`/`review`) routes to its
+dedicated helper, so behavior matches the corresponding flag. `pr-feedback` is
+not selectable via `--flow` (it needs a PR number and bot identity — use
+`daydream feedback`). An unregistered name errors with the same resolve check
+`daydream ext validate` runs.
+
 ### Remap a built-in stack's skill
 
 ```python

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -75,6 +75,22 @@ def test_run_config_flow_name_settable():
     assert RunConfig(target="/tmp/p", flow_name="ro-audit").flow_name == "ro-audit"
 
 
+def test_flow_flag_sets_flow_name(monkeypatch):
+    cfg = _cfg(monkeypatch, ["--flow", "ro-audit", "/tmp/project"])
+    assert cfg.flow_name == "ro-audit"
+
+
+def test_flow_default_none(monkeypatch):
+    assert _cfg(monkeypatch, ["/tmp/project"]).flow_name is None
+
+
+@pytest.mark.parametrize("conflict", [["--review"], ["--comment"], ["--shallow"], ["--loop"]])
+def test_flow_conflicts_rejected(monkeypatch, conflict):
+    monkeypatch.setattr(sys, "argv", ["daydream", "--flow", "x", *conflict, "/tmp/project"])
+    with pytest.raises(SystemExit):
+        _parse_args()
+
+
 def test_loop_flag_default_off(monkeypatch):
     config = _cfg(monkeypatch, ["/tmp/project"])
     assert config.loop is False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -67,6 +67,14 @@ def _cfg(monkeypatch, args: list[str]) -> RunConfig:
     return _parse_args()
 
 
+def test_run_config_flow_name_defaults_none():
+    assert RunConfig(target="/tmp/p").flow_name is None
+
+
+def test_run_config_flow_name_settable():
+    assert RunConfig(target="/tmp/p", flow_name="ro-audit").flow_name == "ro-audit"
+
+
 def test_loop_flag_default_off(monkeypatch):
     config = _cfg(monkeypatch, ["/tmp/project"])
     assert config.loop is False

--- a/tests/test_extension_seam_integration.py
+++ b/tests/test_extension_seam_integration.py
@@ -302,6 +302,96 @@ FULL_RO_EXT = (
 )
 
 
+# A minimal fork flow: one custom step that sends a marker prompt, registered
+# as a brand-new flow name (NOT one of the four built-ins).
+CUSTOM_FLOW_EXT = (
+    "from daydream.extensions import FlowStep\n"
+    "DAYDREAM_EXT_API = 1\n"
+    "async def _audit(ctx):\n"
+    "    from daydream.agent import run_agent\n"
+    "    from daydream.trajectory import DaydreamPhase\n"
+    "    await run_agent(ctx.backend_for('ro_audit'), ctx.work.repo, 'CUSTOM-FLOW-PROMPT',\n"
+    "                    phase=DaydreamPhase.REVIEW)\n"
+    "def register(r):\n"
+    "    r.register_phase(FlowStep(name='ro_audit', run=_audit))\n"
+    "    r.set_flow('ro-audit', ['ro_audit'])\n"
+)
+
+
+async def test_custom_flow_dispatches_and_dumps_artifacts(
+    ext_dir: ExtDir, multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch,
+    archive_dir: Path, tmp_path: Path,
+) -> None:
+    """A fork-registered custom flow selected via flow_name runs end-to-end and
+    --dump-artifacts writes the bundle (must-haves 1 + 2)."""
+    ext_dir.write_module(CUSTOM_FLOW_EXT)
+    backend = RecordingBackend()
+    monkeypatch.setattr("daydream.runner.create_backend", lambda name, model=None: backend)
+    monkeypatch.delenv("DAYDREAM_APP_ID", raising=False)
+    monkeypatch.delenv("DAYDREAM_APP_PRIVATE_KEY", raising=False)
+
+    dump_dir = tmp_path / "uploaded-artifacts"
+    rc = await runner.run(
+        RunConfig(
+            target=str(multi_stack_target),
+            flow_name="ro-audit",
+            non_interactive=True,
+            cleanup=False,
+            archive=False,
+            dump_artifacts=str(dump_dir),
+        )
+    )
+
+    assert rc == 0
+    assert "CUSTOM-FLOW-PROMPT" in backend.prompts  # custom flow actually ran
+    assert (dump_dir / "manifest.json").is_file()    # dump fired on the custom path
+    assert (dump_dir / "trajectory.json").is_file()
+
+
+async def test_unknown_flow_name_errors(
+    ext_dir: ExtDir, multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unregistered flow name fails with exit 1 (Extension Error panel; must-have 3)."""
+    backend = RecordingBackend()
+    monkeypatch.setattr("daydream.runner.create_backend", lambda name, model=None: backend)
+    monkeypatch.delenv("DAYDREAM_APP_ID", raising=False)
+    monkeypatch.delenv("DAYDREAM_APP_PRIVATE_KEY", raising=False)
+
+    rc = await runner.run(
+        RunConfig(
+            target=str(multi_stack_target),
+            flow_name="does-not-exist",
+            non_interactive=True,
+            cleanup=False,
+            archive=False,
+        )
+    )
+
+    assert rc == 1
+    assert not any("CUSTOM-FLOW-PROMPT" in p for p in backend.prompts)
+
+
+async def test_pr_feedback_not_selectable_via_flow(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--flow pr-feedback errors (needs PR number + bot; must-have 5)."""
+    backend = RecordingBackend()
+    monkeypatch.setattr("daydream.runner.create_backend", lambda name, model=None: backend)
+    monkeypatch.delenv("DAYDREAM_APP_ID", raising=False)
+    monkeypatch.delenv("DAYDREAM_APP_PRIVATE_KEY", raising=False)
+
+    rc = await runner.run(
+        RunConfig(
+            target=str(multi_stack_target),
+            flow_name="pr-feedback",
+            non_interactive=True,
+            cleanup=False,
+            archive=False,
+        )
+    )
+    assert rc == 1
+
+
 async def test_custom_phase_full_stack(
     ext_dir: ExtDir, multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_extension_seam_integration.py
+++ b/tests/test_extension_seam_integration.py
@@ -446,3 +446,32 @@ async def test_custom_phase_full_stack(
     assert rc == 0
     assert ro_prompts and "ro-core:gate-skill" in ro_prompts[0]  # own prompt + bound skill
     assert ("claude", "test-model-x") in created  # [tool.daydream.phases.ro_gate] honored
+
+
+async def test_flow_deep_routes_to_deep_helper(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--flow deep runs the real deep pipeline (must-have 4): the intent prompt
+    reaches the backend via the deep flow, exit 0."""
+    from tests.test_deep_orchestrator import _install_stub_backend, _silence
+
+    backend = _install_stub_backend(monkeypatch, multi_stack_target)
+    _silence(monkeypatch)
+
+    async def _no_post(target_dir: Path, report_path: Path, *, console) -> None:
+        return None
+    monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _no_post)
+
+    rc = await runner.run(
+        RunConfig(
+            target=str(multi_stack_target),
+            flow_name="deep",
+            non_interactive=True,
+            cleanup=False,
+            archive=False,
+        )
+    )
+
+    prompts = [call["prompt"] for call in backend.calls]
+    assert rc == 0
+    assert any("intent" in p.lower() for p in prompts)  # deep pipeline ran

--- a/tests/test_extension_seam_integration.py
+++ b/tests/test_extension_seam_integration.py
@@ -475,3 +475,54 @@ async def test_flow_deep_routes_to_deep_helper(
     prompts = [call["prompt"] for call in backend.calls]
     assert rc == 0
     assert any("intent" in p.lower() for p in prompts)  # deep pipeline ran
+
+
+async def test_flow_review_routes_to_review_helper(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--flow review runs the real review pipeline: the alternatives prompt
+    reaches the backend via the review flow, exit 0."""
+    backend = RecordingBackend()
+    monkeypatch.setattr("daydream.runner.create_backend", lambda name, model=None: backend)
+    monkeypatch.delenv("DAYDREAM_APP_ID", raising=False)
+    monkeypatch.delenv("DAYDREAM_APP_PRIVATE_KEY", raising=False)
+
+    rc = await runner.run(
+        RunConfig(
+            target=str(multi_stack_target),
+            flow_name="review",
+            non_interactive=True,
+            cleanup=False,
+            archive=False,
+        )
+    )
+
+    assert rc == 0
+    assert any(ALTERNATIVES_MARKER in p for p in backend.prompts)  # review pipeline ran
+
+
+async def test_flow_shallow_routes_to_shallow_helper(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--flow shallow runs the real shallow pipeline: the parse phase fires,
+    exit 0."""
+    backend = ShallowRecordingBackend(
+        parse_results=[[{"id": 1, "description": "Align return", "file": "api.py", "line": 1}]]
+    )
+    monkeypatch.setattr("daydream.runner.create_backend", lambda name, model=None: backend)
+    monkeypatch.delenv("DAYDREAM_APP_ID", raising=False)
+    monkeypatch.delenv("DAYDREAM_APP_PRIVATE_KEY", raising=False)
+
+    rc = await runner.run(
+        RunConfig(
+            target=str(multi_stack_target),
+            flow_name="shallow",
+            skill="python",
+            non_interactive=True,
+            cleanup=False,
+            archive=False,
+        )
+    )
+
+    assert rc == 0
+    assert backend.parse_calls >= 1  # shallow pipeline ran

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -1237,3 +1237,9 @@ async def test_recorder_does_not_mark_partial_on_clean_exit(tmp_path: Path) -> N
     assert recorder.path.exists()
     traj = _read_trajectory(recorder.path)
     assert "partial" not in traj.get("extra", {})
+
+
+def test_custom_run_flow_member_exists() -> None:
+    assert DaydreamRunFlow.CUSTOM.value == "custom"
+    # str-Enum: the value round-trips as a plain string for metadata serialization
+    assert DaydreamRunFlow("custom") is DaydreamRunFlow.CUSTOM


### PR DESCRIPTION
## Summary

Adds a `--flow <name>` flag (and `RunConfig.flow_name`) that dispatches any registered flow by name. This lets a fork register a brand-new flow via `registry.set_flow(...)` in `daydream_ext` and run it end-to-end, advancing the flow-modularization goal of registry-driven dispatch.

## Changes

### Added
- `--flow NAME` CLI flag selecting a registered flow for dispatch (`daydream/cli.py`).
- `RunConfig.flow_name` field carrying the selection (`daydream/runner.py`).
- `_dispatch_selected_flow()` routing: built-in names (`deep`/`shallow`/`review`) reuse their dedicated helpers; other registered names run the generic `_run_custom_flow()` preamble; `pr-feedback` is rejected (needs a PR number + bot).
- `_run_custom_flow()` generic preamble — seeds the diff like the review path but tolerates an empty/absent diff, opens the recorder through the shared factory so `--dump-artifacts`/archival apply, and sets `post_to_pr=False` by default.
- `DaydreamRunFlow.CUSTOM` trajectory label for custom-flow dispatch (`daydream/trajectory.py`).
- Integration tests for `--flow deep`, `--flow review`, and `--flow shallow` routing; CLI tests for flag parsing and mutual-exclusion errors.

### Changed
- Extracted `_require_reviewable_branch()` guard from `_dispatch` so the default loop path and `--flow deep`/`shallow` share the identical base-branch check.
- `--flow review` treated as `is_posting` (mints the GitHub App token) and skips the test phase, matching `--review` parity.
- `--flow` rejects combination with `--review`/`--comment`, `--shallow`, and `--loop`.
- Documented the flow-selection seam in `docs/extensions.md` and the five registered flows in `CLAUDE.md`.

## Motivation

Previously a fork could register a custom flow but had no way to run it — dispatch was hardcoded to `bot`/`output_mode`/`shallow`. `--flow` closes that gap and unifies built-in and custom flows behind a single name-based dispatch, moving toward the single modular flow goal.

## Testing

- [x] Unit tests added/updated (`tests/test_cli.py`, `tests/test_trajectory.py`)
- [x] Integration tests added/updated (`tests/test_extension_seam_integration.py` — real-path through `runner.run`, mocking only the backend seam)
- [ ] Manual testing performed

## Related Issues

- Related to #259

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Tests pass locally
- [ ] Linting passes
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)