### PR TITLE
fix(backends/pi): respect configured model defaults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,13 +183,14 @@ The default wall budget is 1800s; the default tool-call budget varies by phase.
 
 `config.py` holds:
 - `DEFAULT_CLAUDE_MODEL`, `DEFAULT_CODEX_MODEL`, `DEFAULT_PI_MODEL` constants.
-- `PHASE_DEFAULT_MODELS[backend][phase]` per-backend per-phase model tiering.
+- `PHASE_DEFAULT_MODELS[backend][phase]` Claude/Codex per-phase model tiering;
+  Pi resolves its own configured default before falling back to `DEFAULT_PI_MODEL`.
 - Skill mappings (`REVIEW_SKILLS`, `SKILL_MAP`).
 
 Per-phase overrides are config-file-only (`[tool.daydream]` /
 `[tool.daydream.phases.<phase>]` in `pyproject.toml` or `.daydream.toml`). There are
 no per-phase CLI flags. Precedence (highest first): CLI `--model`/`--backend` >
-config-file phase override > config-file global > per-backend default. Resolved in
+config-file phase override > config-file global > backend default. Resolved in
 `runner._resolve_backend()`. `[tool.daydream.phases.<phase>]` accepts any registered
 step's config key, including fork-defined phases (per-flow key tables in
 `docs/extensions.md`).

--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ per-backend table in `daydream/config.py`. The same order applies to backend
 selection via `--backend` / config / the `claude` fallback. (There is no
 environment-variable tier. `DAYDREAM_MODEL`/`DAYDREAM_BACKEND` are not read.)
 
+For the `pi` backend, an unset daydream model leaves Pi's own configured
+`defaultModel` intact. The built-in `glm-5.2` value is used only when neither
+daydream nor Pi has selected a model.
+
 ### Cost Pricing
 
 When a backend does not report a USD cost directly (notably Codex), daydream

--- a/daydream/backends/__init__.py
+++ b/daydream/backends/__init__.py
@@ -305,10 +305,9 @@ def create_backend(name: str, model: str | None = None) -> Backend:
 
     Args:
         name: Backend name ("claude", "codex", or "pi").
-        model: Optional CLI override. When ``None``, the per-backend default
-            from :mod:`daydream.config` is used. This is the *only* place
-            those defaults are read; downstream layers take ``model: str``
-            as required.
+        model: Optional model override. Claude and Codex apply their built-in
+            defaults here. Pi receives ``None`` unchanged so its own configured
+            default can win before Pi's GLM fallback is selected.
 
     Returns:
         A Backend instance whose ``.model`` attribute is a non-empty string.
@@ -316,7 +315,7 @@ def create_backend(name: str, model: str | None = None) -> Backend:
     Raises:
         ValueError: If the backend name is unknown.
     """
-    from daydream.config import DEFAULT_CLAUDE_MODEL, DEFAULT_CODEX_MODEL, DEFAULT_PI_MODEL
+    from daydream.config import DEFAULT_CLAUDE_MODEL, DEFAULT_CODEX_MODEL
 
     if name == "claude":
         from daydream.backends.claude import ClaudeBackend
@@ -326,7 +325,7 @@ def create_backend(name: str, model: str | None = None) -> Backend:
         return CodexBackend(model=model or DEFAULT_CODEX_MODEL)
     if name == "pi":
         from daydream.backends.pi import PiBackend
-        return PiBackend(model=model or DEFAULT_PI_MODEL)
+        return PiBackend(model=model)
     raise ValueError(f"Unknown backend: {name!r}. Expected 'claude', 'codex', or 'pi'.")
 
 

--- a/daydream/backends/__init__.py
+++ b/daydream/backends/__init__.py
@@ -300,7 +300,9 @@ class Backend(Protocol):
     def format_skill_invocation(self, skill_key: str, args: str = "") -> str: ...
 
 
-def create_backend(name: str, model: str | None = None) -> Backend:
+def create_backend(
+    name: str, model: str | None = None, *, cwd: Path | None = None
+) -> Backend:
     """Create a backend by name.
 
     Args:
@@ -308,6 +310,7 @@ def create_backend(name: str, model: str | None = None) -> Backend:
         model: Optional model override. Claude and Codex apply their built-in
             defaults here. Pi receives ``None`` unchanged so its own configured
             default can win before Pi's GLM fallback is selected.
+        cwd: Target workspace used to resolve Pi's configured default model.
 
     Returns:
         A Backend instance whose ``.model`` attribute is a non-empty string.
@@ -325,7 +328,7 @@ def create_backend(name: str, model: str | None = None) -> Backend:
         return CodexBackend(model=model or DEFAULT_CODEX_MODEL)
     if name == "pi":
         from daydream.backends.pi import PiBackend
-        return PiBackend(model=model)
+        return PiBackend(model=model, cwd=cwd)
     raise ValueError(f"Unknown backend: {name!r}. Expected 'claude', 'codex', or 'pi'.")
 
 

--- a/daydream/backends/pi.py
+++ b/daydream/backends/pi.py
@@ -387,12 +387,13 @@ class PiBackend:
 
     concise_fix_prompts = True  # GLM produces verbose reasoning in fix prompts
 
-    def __init__(self, model: str | None = None):
-        # Keep the public model attribute useful for banners and trajectory
-        # fallback attribution, while retaining whether the caller supplied an
-        # actual override. A missing model is resolved against Pi settings at
-        # execute time and falls back to GLM only when Pi has no default.
-        self.model = model or DEFAULT_PI_MODEL
+    def __init__(self, model: str | None = None, *, cwd: Path | None = None):
+        """Initialize the backend with an optional explicit model override."""
+        self.model = (
+            model
+            or (_configured_pi_model(cwd) if cwd is not None else None)
+            or DEFAULT_PI_MODEL
+        )
         self._model_override = model
         self.fanout_concurrency = 2
         self.retry_attempts = _pi_retry_attempts()

--- a/daydream/backends/pi.py
+++ b/daydream/backends/pi.py
@@ -14,12 +14,13 @@ trajectories indistinguishable in shape from the other two backends.
 z.ai coding plan wiring (GLM models) is registered via a pi extension at
 ``~/.pi/extensions/zai-provider/`` that calls ``pi.registerProvider()`` with
 ``baseUrl``, ``apiKey``, ``api: "openai-completions"``, and the six GLM
-models (see https://pi.dev/docs/latest/custom-provider). daydream defaults
-``--provider`` to ``zai`` (matching ``DEFAULT_PI_MODEL = "glm-5.2"``) and
-forwards optional ``PI_PROVIDER`` / ``PI_API_KEY`` / ``PI_THINKING`` env
-overrides as CLI flags. The provider extension is installed once via
-``pi install ~/.pi/extensions/zai-provider``; daydream never fabricates a
-base URL or writes a models.json override.
+models (see https://pi.dev/docs/latest/custom-provider). When no model is
+selected by daydream, Pi's configured ``defaultModel`` is respected; only when
+Pi has no configured model does daydream pass ``glm-5.2`` with provider
+``zai`` as its fallback. Explicit model and ``PI_PROVIDER`` / ``PI_API_KEY`` /
+``PI_THINKING`` values remain CLI overrides. The provider extension is
+installed once via ``pi install ~/.pi/extensions/zai-provider``; daydream never
+fabricates a base URL or writes a models.json override.
 """
 
 from __future__ import annotations
@@ -47,6 +48,7 @@ from daydream.backends import (
     ToolStartEvent,
     TurnEndEvent,
 )
+from daydream.config import DEFAULT_PI_MODEL
 from daydream.json_utils import extract_json
 
 # Mirror Codex's generous stdout cap so large JSONL events (big file reads,
@@ -72,6 +74,34 @@ _PI_EVENT_TYPES: frozenset[str] = frozenset(
 
 # Read-only tool subset (plan §3). Excludes the mutating edit/bash/write tools.
 _PI_READ_ONLY_TOOLS = "read,find,ls,grep"
+
+
+def _read_pi_default_model(path: Path) -> str | None:
+    """Read Pi's configured default model, ignoring malformed settings."""
+    try:
+        with path.open(encoding="utf-8") as settings_file:
+            settings = json.load(settings_file)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    model = settings.get("defaultModel") if isinstance(settings, dict) else None
+    return model.strip() if isinstance(model, str) and model.strip() else None
+
+
+def _configured_pi_model(cwd: Path) -> str | None:
+    """Return the effective Pi settings default, if one is configured.
+
+    Pi merges project settings over global settings. We mirror only the
+    ``defaultModel`` field because that is the setting daydream must not replace
+    with its GLM fallback.
+    """
+    agent_dir = Path(os.environ.get("PI_CODING_AGENT_DIR", Path.home() / ".pi" / "agent"))
+    settings_paths = (cwd / ".pi" / "settings.json", agent_dir / "settings.json")
+    for settings_path in settings_paths:
+        model = _read_pi_default_model(settings_path)
+        if model:
+            return model
+    return None
 
 # Matches Pi's native ``/skill:<slug>`` command embedded in a prompt (emitted by
 # ``format_skill_invocation``). Used in ``execute`` to register the referenced
@@ -357,8 +387,13 @@ class PiBackend:
 
     concise_fix_prompts = True  # GLM produces verbose reasoning in fix prompts
 
-    def __init__(self, model: str):
-        self.model = model
+    def __init__(self, model: str | None = None):
+        # Keep the public model attribute useful for banners and trajectory
+        # fallback attribution, while retaining whether the caller supplied an
+        # actual override. A missing model is resolved against Pi settings at
+        # execute time and falls back to GLM only when Pi has no default.
+        self.model = model or DEFAULT_PI_MODEL
+        self._model_override = model
         self.fanout_concurrency = 2
         self.retry_attempts = _pi_retry_attempts()
         self.retry_base_delay_s = _pi_retry_base_delay()
@@ -404,18 +439,27 @@ class PiBackend:
                 "Pi backend does not support exploration subagents; use --backend claude for exploration."
             )
 
-        args: list[str] = [
-            "pi",
-            "--mode",
-            "json",
-            "--model",
-            self.model,
-        ]
+        args: list[str] = ["pi", "--mode", "json"]
 
-        provider = os.environ.get("PI_PROVIDER", "zai")
+        configured_model = None
+        provider: str | None = None
+        if self._model_override is not None:
+            self.model = self._model_override
+            args.extend(["--model", self.model])
+            provider = os.environ.get("PI_PROVIDER", "zai")
+        else:
+            configured_model = _configured_pi_model(cwd)
+            self.model = configured_model or DEFAULT_PI_MODEL
+            if configured_model is None:
+                args.extend(["--model", self.model])
+            provider = os.environ.get("PI_PROVIDER")
+            if provider is None and configured_model is None:
+                provider = "zai"
+
         api_key = os.environ.get("PI_API_KEY")
         thinking = os.environ.get("PI_THINKING")
-        args.extend(["--provider", provider])
+        if provider:
+            args.extend(["--provider", provider])
         if api_key:
             args.extend(["--api-key", api_key])
         if thinking:

--- a/daydream/config.py
+++ b/daydream/config.py
@@ -15,7 +15,7 @@ Exports:
         coding plan GLM default).
     DEFAULT_EXPLORATION_MODEL: str - Default model for the EXPLORE phase.
     PHASE_DEFAULT_MODELS: dict[str, dict[str, str]] - Per-backend per-phase default
-        model mapping. Outer key is backend name ("claude", "codex", or "pi"),
+        model mapping. Outer key is backend name ("claude" or "codex"),
         inner key is the phase name (lowercase, e.g. "review", "parse", "fix"),
         value is the concrete model id.
     STRUCTURE_SKILL: str - Beagle skill name for the structural-maintainability
@@ -82,9 +82,9 @@ DEFAULT_GROUP_MAX_SERIAL_ITEMS = 6  # max per-finding fix calls in one group
 # for codex is deferred until concrete model picks across the codex lineup are
 # settled.
 #
-# Pi side defaults to ``glm-5.2`` (z.ai coding plan) across the board; per-phase
-# tiering is deferred until the GLM lineup (glm-5.2 / glm-4.5-air / etc.) is
-# mapped to tiers.
+# Pi's ``DEFAULT_PI_MODEL`` is resolved by ``PiBackend`` after Pi's own settings
+# have had a chance to select a model. It is a backend fallback, not a
+# per-phase override, so it intentionally does not appear in this table.
 PHASE_DEFAULT_MODELS: dict[str, dict[str, str]] = {
     "claude": {
         "parse": "claude-haiku-4-5",
@@ -115,21 +115,6 @@ PHASE_DEFAULT_MODELS: dict[str, dict[str, str]] = {
         "merge": "gpt-5.5",
         "intent": "gpt-5.5",
         "pr_feedback": "gpt-5.5",
-    },
-    "pi": {
-        "parse": "glm-5.2",
-        "fix": "glm-5.2",
-        "test": "glm-5.2",
-        "verify": "glm-5.2",
-        "exploration": "glm-5.2",
-        "per_stack_review": "glm-5.2",
-        "review": "glm-5.2",
-        "arbiter": "glm-5.2",
-        "suppression": "glm-5.2",
-        "wonder": "glm-5.2",
-        "merge": "glm-5.2",
-        "intent": "glm-5.2",
-        "pr_feedback": "glm-5.2",
     },
 }
 

--- a/daydream/flows/engine.py
+++ b/daydream/flows/engine.py
@@ -55,7 +55,9 @@ class FlowContext:
         """
         from daydream.runner import _resolve_backend
 
-        return _resolve_backend(self.config, phase, cache=self._backend_cache)
+        return _resolve_backend(
+            self.config, phase, cache=self._backend_cache, cwd=self.work.repo
+        )
 
 
 def _resolve_steps(registry: Registry, flow_name: str, entries: list[FlowEntry]) -> dict[str, FlowStep]:

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -387,6 +387,8 @@ def _resolve_backend(
     config: RunConfig,
     phase: str,
     cache: dict[tuple[str, str | None], Backend] | None = None,
+    *,
+    cwd: Path | None = None,
 ) -> Backend:
     """Get or create the backend for a given phase, respecting all precedence tiers.
 
@@ -410,6 +412,7 @@ def _resolve_backend(
             When provided, backends are reused only when both the backend kind
             and the resolved model match — so the same backend kind with two
             different models yields two distinct instances.
+        cwd: Target workspace used for backend-specific configuration.
     """
     backend_name = _resolved_backend_name(config, phase)
     resolved_model = _resolved_model(config, phase)
@@ -417,9 +420,16 @@ def _resolve_backend(
     cache_key = (backend_name, resolved_model)
     if cache is not None:
         if cache_key not in cache:
-            cache[cache_key] = create_backend(backend_name, model=resolved_model)
+            if backend_name == "pi":
+                cache[cache_key] = create_backend(
+                    backend_name, model=resolved_model, cwd=cwd
+                )
+            else:
+                cache[cache_key] = create_backend(backend_name, model=resolved_model)
         return cache[cache_key]
 
+    if backend_name == "pi":
+        return create_backend(backend_name, model=resolved_model, cwd=cwd)
     return create_backend(backend_name, model=resolved_model)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,15 @@ for _git_env_var in (
 ):
     os.environ.pop(_git_env_var, None)
 
+# Test-created repositories commit non-interactively and must not inherit a
+# developer's global signing requirement. Append an environment-scoped Git
+# override so every descendant git process is deterministic, including helpers
+# defined outside this file.
+_git_config_count = int(os.environ.get("GIT_CONFIG_COUNT", "0"))
+os.environ[f"GIT_CONFIG_KEY_{_git_config_count}"] = "commit.gpgsign"
+os.environ[f"GIT_CONFIG_VALUE_{_git_config_count}"] = "false"
+os.environ["GIT_CONFIG_COUNT"] = str(_git_config_count + 1)
+
 # --- Real-git fixtures ------------------------------------------------------
 #
 # Mirrors the helpers that previously lived only in tests/test_git_ops.py.

--- a/tests/test_backend_pi.py
+++ b/tests/test_backend_pi.py
@@ -885,6 +885,17 @@ async def test_default_model_does_not_override_pi_settings(tmp_path, monkeypatch
     assert "--provider" not in flat_args
 
 
+def test_public_model_reflects_pi_settings_before_execute(tmp_path):
+    """The public model is resolved from the target workspace at construction."""
+    settings = tmp_path / ".pi" / "settings.json"
+    settings.parent.mkdir()
+    settings.write_text('{"defaultProvider": "openai", "defaultModel": "gpt-5.6-luna"}')
+
+    backend = PiBackend(cwd=tmp_path)
+
+    assert backend.model == "gpt-5.6-luna"
+
+
 @pytest.mark.asyncio
 async def test_explicit_model_overrides_pi_settings(tmp_path, monkeypatch):
     """An explicit daydream model still wins over Pi's configured default."""

--- a/tests/test_backend_pi.py
+++ b/tests/test_backend_pi.py
@@ -862,6 +862,62 @@ async def test_provider_flag(monkeypatch, env_provider, expected):
     assert flat_args[flat_args.index("--provider") + 1] == expected
 
 
+@pytest.mark.asyncio
+async def test_default_model_does_not_override_pi_settings(tmp_path, monkeypatch):
+    """A Pi-configured default wins when daydream did not select a model."""
+    settings = tmp_path / ".pi" / "settings.json"
+    settings.parent.mkdir()
+    settings.write_text(
+        '{"defaultProvider": "openai", "defaultModel": "gpt-5.6-luna"}'
+    )
+    monkeypatch.delenv("PI_PROVIDER", raising=False)
+
+    backend = PiBackend()
+    mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
+    with patch(
+        "daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc
+    ) as mock_exec:
+        async for _ in backend.execute(tmp_path, "Reply"):
+            pass
+
+    flat_args = list(mock_exec.call_args.args)
+    assert "--model" not in flat_args
+    assert "--provider" not in flat_args
+
+
+@pytest.mark.asyncio
+async def test_explicit_model_overrides_pi_settings(tmp_path, monkeypatch):
+    """An explicit daydream model still wins over Pi's configured default."""
+    settings = tmp_path / ".pi" / "settings.json"
+    settings.parent.mkdir()
+    settings.write_text('{"defaultProvider": "openai", "defaultModel": "gpt-5.6-luna"}')
+    monkeypatch.delenv("PI_PROVIDER", raising=False)
+
+    backend = PiBackend(model="custom-model")
+    mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
+    with patch(
+        "daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc
+    ) as mock_exec:
+        async for _ in backend.execute(tmp_path, "Reply"):
+            pass
+
+    flat_args = list(mock_exec.call_args.args)
+    assert flat_args[flat_args.index("--model") + 1] == "custom-model"
+
+
+@pytest.mark.asyncio
+async def test_glm_is_pi_fallback_when_no_model_is_configured(tmp_path, monkeypatch):
+    """GLM remains the fallback when neither daydream nor Pi selects a model."""
+    monkeypatch.delenv("PI_PROVIDER", raising=False)
+    monkeypatch.setenv("PI_CODING_AGENT_DIR", str(tmp_path / "pi-agent"))
+
+    backend = PiBackend()
+    flat_args, _ = await _run_and_capture_args(backend)
+
+    assert flat_args[flat_args.index("--model") + 1] == "glm-5.2"
+    assert flat_args[flat_args.index("--provider") + 1] == "zai"
+
+
 # ---------------------------------------------------------------------------
 # System prompt preamble (--append-system-prompt)
 # ---------------------------------------------------------------------------
@@ -1068,4 +1124,3 @@ def test_pi_retry_base_delay(monkeypatch, env_value, expected):
 def test_pi_backend_fanout_concurrency():
     backend = PiBackend(model="glm-5.2")
     assert backend.fanout_concurrency == 2
-

--- a/tests/test_cli_config_precedence.py
+++ b/tests/test_cli_config_precedence.py
@@ -87,3 +87,12 @@ def test_env_vars_are_not_a_precedence_tier(monkeypatch, tmp_path: Path) -> None
     cfg2 = RunConfig(target=str(tmp_path), backend=None, model=None, file_config=DaydreamFileConfig())
     assert _resolved_model(cfg2, "parse") == "claude-haiku-4-5"
     assert _resolved_backend_name(cfg2, "parse") == "claude"
+
+
+def test_pi_native_model_is_not_replaced_by_glm_fallback(tmp_path: Path) -> None:
+    """Pi's own default remains available when daydream has no model setting."""
+    cfg = RunConfig(target=str(tmp_path), backend="pi", model=None)
+    assert _resolved_model(cfg, "review") is None
+
+    cfg.model = "custom-model"
+    assert _resolved_model(cfg, "review") == "custom-model"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -62,6 +62,7 @@ def test_phase_default_models_codex_uses_gpt_5_5_for_every_phase():
 
 
 def test_pi_model_is_a_backend_fallback_not_a_phase_override():
+    """Pi uses one backend fallback instead of phase-specific defaults."""
     assert "pi" not in PHASE_DEFAULT_MODELS
     assert DEFAULT_PI_MODEL == "glm-5.2"
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,11 +13,11 @@ PHASE_NAMES = {
 
 
 def test_phase_default_models_covers_all_backends():
-    assert set(PHASE_DEFAULT_MODELS.keys()) == {"claude", "codex", "pi"}
+    assert set(PHASE_DEFAULT_MODELS.keys()) == {"claude", "codex"}
 
 
 def test_phase_default_models_covers_every_phase_for_each_backend():
-    for backend_name in ("claude", "codex", "pi"):
+    for backend_name in ("claude", "codex"):
         assert set(PHASE_DEFAULT_MODELS[backend_name].keys()) == PHASE_NAMES, (
             f"{backend_name} default table missing phase entries"
         )
@@ -47,10 +47,10 @@ def test_per_stack_review_and_arbiter_split():
 
 def test_suppression_uses_cheap_tier():
     """#232: the precision-mode suppression pass defaults to the cheap mid tier
-    (never per-finding Opus). Codex/pi keep their single-model default."""
+    (never per-finding Opus). Pi keeps its single backend fallback."""
     assert PHASE_DEFAULT_MODELS["claude"]["suppression"] == "claude-sonnet-4-6"
     assert PHASE_DEFAULT_MODELS["codex"]["suppression"] == "gpt-5.5"
-    assert PHASE_DEFAULT_MODELS["pi"]["suppression"] == "glm-5.2"
+    assert DEFAULT_PI_MODEL == "glm-5.2"
 
 
 def test_phase_default_models_codex_uses_gpt_5_5_for_every_phase():
@@ -61,12 +61,9 @@ def test_phase_default_models_codex_uses_gpt_5_5_for_every_phase():
         )
 
 
-def test_phase_default_models_pi_uses_glm_5_2_for_every_phase():
-    pi = PHASE_DEFAULT_MODELS["pi"]
-    for phase in PHASE_NAMES:
-        assert pi[phase] == "glm-5.2", (
-            f"pi phase {phase} should default to glm-5.2 (z.ai coding plan)"
-        )
+def test_pi_model_is_a_backend_fallback_not_a_phase_override():
+    assert "pi" not in PHASE_DEFAULT_MODELS
+    assert DEFAULT_PI_MODEL == "glm-5.2"
 
 
 def test_default_pi_model_is_glm_5_2():

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -2167,9 +2167,9 @@ async def test_resolve_backend_called_with_each_phase_in_deep_flow(
     seen_phases: list[str] = []
     original = _runner._resolve_backend
 
-    def spy(config, phase, cache=None):
+    def spy(config, phase, cache=None, *, cwd=None):
         seen_phases.append(phase)
-        return original(config, phase, cache)
+        return original(config, phase, cache, cwd=cwd)
 
     # run_deep imports _resolve_backend from daydream.runner, so patching it there
     # intercepts every call site under per-phase resolution.

--- a/tests/test_flow_engine.py
+++ b/tests/test_flow_engine.py
@@ -61,6 +61,25 @@ def _ctx(reg: Registry) -> FlowContext:
     return FlowContext(config=RunConfig(), work=work, registry=reg)
 
 
+def test_backend_for_resolves_pi_model_from_workspace(tmp_path: Path) -> None:
+    settings = tmp_path / ".pi" / "settings.json"
+    settings.parent.mkdir()
+    settings.write_text('{"defaultModel": "gpt-5.6-luna"}')
+    work = WorkContext(
+        repo=tmp_path,
+        source=tmp_path,
+        base_branch="main",
+        base_sha="0" * 40,
+        head_branch="feature",
+        head_sha="1" * 40,
+        is_ephemeral=False,
+        run_id="test-run",
+    )
+    ctx = FlowContext(config=RunConfig(backend="pi"), work=work, registry=Registry())
+
+    assert ctx.backend_for("review").model == "gpt-5.6-luna"
+
+
 async def test_order_gating_stop_and_loop() -> None:
     reg = Registry()
     reg.register_phase(FlowStep("a", run=_trace("a")))

--- a/tests/test_git_test_isolation.py
+++ b/tests/test_git_test_isolation.py
@@ -1,0 +1,15 @@
+"""Regression tests for Git configuration isolation in the test suite."""
+
+import subprocess
+
+
+def test_git_subprocesses_disable_commit_signing() -> None:
+    """Test-created repositories must never require an interactive signing key."""
+    result = subprocess.run(
+        ["git", "config", "--bool", "commit.gpgsign"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout.strip() == "false"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -279,7 +279,7 @@ async def test_pr_feedback_banner_echoes_resolved_backend_model(
     # (late import) and passes ``cache=`` by keyword.
     monkeypatch.setattr(
         "daydream.runner._resolve_backend",
-        lambda _config, _phase, cache=None: _StubBackend(chosen_model),
+        lambda _config, _phase, cache=None, **_kwargs: _StubBackend(chosen_model),
     )
 
     async def _no_op_fetch(*_args, **_kwargs):
@@ -397,7 +397,7 @@ async def test_run_loop_shallow_heal_hero_followed_by_model_line(
 
     monkeypatch.setattr(
         "daydream.runner._resolve_backend",
-        lambda _config, phase, cache=None: backends_by_phase[phase],
+        lambda _config, phase, cache=None, **_kwargs: backends_by_phase[phase],
     )
 
     async def _stub_phase_parse_feedback(_backend, _work):
@@ -488,7 +488,7 @@ async def test_shallow_items_canonicalized_and_severity_ordered(monkeypatch, tmp
 
     monkeypatch.setattr(
         "daydream.runner._resolve_backend",
-        lambda _config, _phase, cache=None: _StubBackend("stub-model"),
+        lambda _config, _phase, cache=None, **_kwargs: _StubBackend("stub-model"),
     )
 
     async def _stub_phase_parse_feedback(_backend, _work):
@@ -610,7 +610,7 @@ async def test_non_interactive_shallow_calls_phase_commit_push_auto(monkeypatch,
 
     monkeypatch.setattr(
         "daydream.runner._resolve_backend",
-        lambda _config, _phase, cache=None: _StubBackend(),
+        lambda _config, _phase, cache=None, **_kwargs: _StubBackend(),
     )
 
     async def _stub_phase_parse_feedback(_backend, _work):
@@ -706,7 +706,7 @@ async def test_non_interactive_shallow_failing_tests_write_handoff_no_fix(monkey
         model = "stub-model"
         fanout_concurrency = 4
 
-    def _resolve(_config, phase, cache=None):
+    def _resolve(_config, phase, cache=None, **_kwargs):
         return test_backend if phase == "test" else _StubBackend()
 
     monkeypatch.setattr("daydream.runner._resolve_backend", _resolve)
@@ -824,7 +824,7 @@ async def test_yes_shallow_failing_tests_bounded_fix_and_abort(monkeypatch, tmp_
         model = "stub-model"
         fanout_concurrency = 4
 
-    def _resolve(_config, phase, cache=None):
+    def _resolve(_config, phase, cache=None, **_kwargs):
         return test_backend if phase == "test" else _StubBackend()
 
     monkeypatch.setattr("daydream.runner._resolve_backend", _resolve)


### PR DESCRIPTION
## Summary

- preserve Pi's configured project/global `defaultModel` when daydream does not select a model
- keep explicit daydream model choices as overrides
- use `glm-5.2` with the `zai` provider only as the final fallback
- add regression coverage and update model-precedence documentation

## Root cause

The Pi phase default table resolved every unset Pi model to `glm-5.2`, and `PiBackend` always forwarded that value as `--model`. This bypassed Pi's own configured default.

## Validation

- `uv run ruff check daydream tests`
- `uv run mypy daydream tests`
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false uv run pytest -n auto -m "not integration" -q`
- Result: 2,084 passed, 5 skipped

The pre-push hook's unmodified run is blocked by the machine's global SSH signing configuration when its temporary fixture repositories commit; the code checks pass with signing disabled for the test subprocess.