### PR TITLE
chore(release): 0.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.1] - 2026-07-11
+
+### Fixed
+
+- **backends/claude:** Upgrade `claude-agent-sdk` to 0.2.116 for shielded subprocess teardown ([#266](https://github.com/existential-birds/daydream/pull/266))
+
+  Pins the Claude SDK to 0.2.116, whose cancellation path shields the CLI subprocess teardown. Earlier versions tore the subprocess down unshielded, so a budget/fan-out cancellation mid-stream corrupted anyio's cancel-scope stack ("Attempted to exit a cancel scope that isn't the current task's current cancel scope").
+
+- **backends/pi:** Respect configured model defaults ([#265](https://github.com/existential-birds/daydream/pull/265))
+
+  The Pi backend now resolves its own configured default model before falling back to `DEFAULT_PI_MODEL`, so per-phase and config-file model settings are honored instead of being overridden by the built-in default.
+
 ## [0.23.0] - 2026-07-10
 
 ### Added
@@ -789,7 +801,8 @@ Initial release of Daydream - an automated code review and fix loop using the Cl
 - `rich` - Terminal UI components
 - `pyfiglet` - ASCII art header generation
 
-[unreleased]: https://github.com/existential-birds/daydream/compare/v0.23.0...HEAD
+[unreleased]: https://github.com/existential-birds/daydream/compare/v0.23.1...HEAD
+[0.23.1]: https://github.com/existential-birds/daydream/compare/v0.23.0...v0.23.1
 [0.23.0]: https://github.com/existential-birds/daydream/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/existential-birds/daydream/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/existential-birds/daydream/compare/v0.20.0...v0.21.0

--- a/daydream/__init__.py
+++ b/daydream/__init__.py
@@ -17,4 +17,4 @@ Submodules:
     ui: User interface utilities for terminal output.
 """
 
-__version__ = "0.23.0"
+__version__ = "0.23.1"

--- a/daydream/templates/workflows/daydream-post.yml
+++ b/daydream/templates/workflows/daydream-post.yml
@@ -51,7 +51,7 @@ jobs:
         # Pinned to a release tag (not `main`) so the bot runs a known daydream
         # version: reproducible and immune to main-drift / uv-cache staleness.
         # Bump in lockstep with the package version on release (a test enforces this).
-        run: uv tool install git+https://github.com/existential-birds/daydream@v0.23.0
+        run: uv tool install git+https://github.com/existential-birds/daydream@v0.23.1
 
       - name: Mint posting token
         id: token

--- a/daydream/templates/workflows/daydream-review.yml
+++ b/daydream/templates/workflows/daydream-review.yml
@@ -92,7 +92,7 @@ jobs:
         # Pinned to a release tag (not `main`) so the bot runs a known daydream
         # version: reproducible and immune to main-drift / uv-cache staleness.
         # Bump in lockstep with the package version on release (a test enforces this).
-        run: uv tool install git+https://github.com/existential-birds/daydream@v0.23.0
+        run: uv tool install git+https://github.com/existential-birds/daydream@v0.23.1
 
       - name: Run daydream review
         env:

--- a/daydream/templates/workflows/single/daydream.yml
+++ b/daydream/templates/workflows/single/daydream.yml
@@ -144,7 +144,7 @@ jobs:
         # Pinned to a release tag (not `main`) so the bot runs a known daydream
         # version: reproducible and immune to main-drift / uv-cache staleness.
         # Bump in lockstep with the package version on release (a test enforces this).
-        run: uv tool install git+https://github.com/existential-birds/daydream@v0.23.0
+        run: uv tool install git+https://github.com/existential-birds/daydream@v0.23.1
 
       # Runs the DEFAULT deep-review pipeline (not --review). In --non-interactive
       # the deep run auto-declines the post/fix gates, so it still only produces a
@@ -191,7 +191,7 @@ jobs:
         uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
 
       - name: Install daydream
-        run: uv tool install git+https://github.com/existential-birds/daydream@v0.23.0
+        run: uv tool install git+https://github.com/existential-birds/daydream@v0.23.1
 
       - name: Download findings artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "daydream"
-version = "0.23.0"
+version = "0.23.1"
 description = "Automated code review and fix loop using Claude"
 requires-python = ">=3.12.13"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -193,7 +193,7 @@ wheels = [
 
 [[package]]
 name = "daydream"
-version = "0.23.0"
+version = "0.23.1"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

- Bump version to 0.23.1
- Update CHANGELOG.md with changes since v0.23.0

### Fixed

- **backends/claude:** Upgrade `claude-agent-sdk` to 0.2.116 for shielded subprocess teardown ([#266](https://github.com/existential-birds/daydream/pull/266))
- **backends/pi:** Respect configured model defaults ([#265](https://github.com/existential-birds/daydream/pull/265))

Also bumps the daydream install pin to `@v0.23.1` in all three workflow templates (`daydream-review.yml`, `daydream-post.yml`, and `single/daydream.yml`).

## Post-merge steps

After merging, run:
\`\`\`
/release-tag 0.23.1
\`\`\`

---

Generated with [Claude Code](https://claude.com/claude-code)