### PR TITLE
feat(extensions): add versioned supervision seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **extensions:** Publish the tool-supervision seam as extension API v2 ([#268](https://github.com/existential-birds/daydream/issues/268))
+
+  Extensions can register one synchronous tool supervisor that returns a
+  `ToolDecision` for each tool invocation. `daydream ext validate` reports
+  whether the supervisor is registered, and the stable `items_file` surface
+  lets a step after `load-items` rewrite canonical findings before downstream
+  consumers read them.
+
 ## [0.23.1] - 2026-07-11
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,9 +216,11 @@ hunks are inlined directly into a single review prompt.
 
 A fork customizes phases, skills, and prompts from a top-level `daydream_ext` package
 (discovered via `$DAYDREAM_EXT_DIR` → `import daydream_ext`) without editing `daydream/`.
-The module exports `DAYDREAM_EXT_API` equal to `EXTENSION_API_VERSION` (currently 1);
+The module exports `DAYDREAM_EXT_API` equal to `EXTENSION_API_VERSION` (currently 2);
+extensions can also register one `ToolDecision`-returning tool supervisor, and
 `daydream ext validate` resolve-checks the loaded registry. The versioned contract —
-name inventories, module shape, bump policy — is `docs/extensions.md`.
+name inventories, module shape, supervision seam, and bump policy — is
+`docs/extensions.md`.
 
 ## Constraints
 

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -56,6 +56,14 @@ class MissingSkillError(Exception):
         super().__init__(f"Skill '{skill_name}' is not available")
 
 
+class _ToolSupervisorFailure(Exception):
+    """Internal marker that keeps supervisor failures out of backend retries."""
+
+    def __init__(self, original: Exception) -> None:
+        self.original = original
+        super().__init__(str(original))
+
+
 @dataclass
 class AgentState:
     """Consolidated state for agent module.
@@ -461,7 +469,10 @@ async def run_agent(
                                     inv.observe(event)
 
                                 if tool_supervisor is not None:
-                                    decision = tool_supervisor(event.name, event.input, phase=phase)
+                                    try:
+                                        decision = tool_supervisor(event.name, event.input, phase=phase)
+                                    except Exception as exc:  # noqa: BLE001 - policy failures must propagate
+                                        raise _ToolSupervisorFailure(exc) from exc
                                     if decision.veto:
                                         budget_reason = f"tool_vetoed:{event.name}"
                                         break
@@ -564,6 +575,8 @@ async def run_agent(
 
                 break  # success — exit the retry loop
 
+            except _ToolSupervisorFailure as exc:
+                raise exc.original from None
             except Exception as exc:
                 if attempt < max_attempts and getattr(exc, "retryable", False):
                     delay = base_delay * (2 ** attempt) + random.uniform(0, 1)

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -63,6 +63,11 @@ class _ToolSupervisorFailure(Exception):
         self.original = original
         super().__init__(str(original))
 
+    @property
+    def subtype(self) -> str:
+        """Expose the original error's type name for trajectory recording."""
+        return type(self.original).__name__
+
 
 @dataclass
 class AgentState:
@@ -575,8 +580,8 @@ async def run_agent(
 
                 break  # success — exit the retry loop
 
-            except _ToolSupervisorFailure as exc:
-                raise exc.original from None
+            except _ToolSupervisorFailure:
+                raise
             except Exception as exc:
                 if attempt < max_attempts and getattr(exc, "retryable", False):
                     delay = base_delay * (2 ** attempt) + random.uniform(0, 1)
@@ -607,6 +612,9 @@ async def run_agent(
                     continue
                 raise
 
+    except _ToolSupervisorFailure as exc:
+        print_error(console, "Extension Failure", f"{type(exc.original).__name__}: {exc.original}")
+        raise exc.original from None
     except Exception as exc:
         print_error(console, "Backend Execution Error", f"{type(exc).__name__}: {exc}")
         raise

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -31,6 +31,7 @@ from daydream.backends import (
     ToolStartEvent,
 )
 from daydream.config import UNKNOWN_SKILL_PATTERN
+from daydream.extensions import get_registry
 from daydream.json_utils import extract_json
 from daydream.trajectory import DaydreamPhase, get_current_recorder
 from daydream.ui import (
@@ -337,7 +338,8 @@ async def run_agent(
         Tuple of (output, continuation_token, budget_reason). Output is text
         or structured data. ``budget_reason`` is ``None`` on a normal
         completion, or a string such as ``"wall_budget_exceeded"`` /
-        ``"tool_call_budget_exceeded"`` when the turn was cut short.
+        ``"tool_call_budget_exceeded"`` / ``"tool_vetoed:Write"`` when the
+        turn was cut short.
 
     Raises:
         MissingSkillError: If a required skill is not available.
@@ -349,6 +351,7 @@ async def run_agent(
     result_continuation: ContinuationToken | None = None
     aborted_reason: str | None = None
     use_callback = progress_callback is not None
+    tool_supervisor = get_registry().tool_supervisor_if_registered()
 
     _state.current_backends.append(backend)
     event_iter: AsyncGenerator[Any, None] | None = None
@@ -397,9 +400,10 @@ async def run_agent(
                     if inv is not None:
                         inv.observe_user_step(prompt=prompt)
 
-                    # Per-invocation budgets live here so both backends are covered
-                    # without a backend-signature change. The wall budget cancels the
-                    # async-for via move_on_after; the tool-call ceiling breaks in-loop.
+                    # Per-invocation abort controls live here so both backends are
+                    # covered without a backend-signature change. The wall budget
+                    # cancels the async-for via move_on_after; the tool-call ceiling
+                    # and supervisor veto break in-loop.
                     wall_scope: Any = (
                         anyio.move_on_after(wall_budget_s) if wall_budget_s is not None else nullcontext()
                     )
@@ -455,6 +459,12 @@ async def run_agent(
 
                                 if inv is not None:
                                     inv.observe(event)
+
+                                if tool_supervisor is not None:
+                                    decision = tool_supervisor(event.name, event.input, phase=phase)
+                                    if decision.veto:
+                                        budget_reason = f"tool_vetoed:{event.name}"
+                                        break
 
                                 tool_calls += 1
                                 if tool_call_budget is not None and tool_calls > tool_call_budget:
@@ -519,10 +529,11 @@ async def run_agent(
                                 if inv is not None:
                                     inv.observe(event)
 
-                    # Budget abort: the wall scope cancelled the loop, or the tool-call
-                    # ceiling broke out. Cancel the backend (swallow any error — an abort
-                    # must NEVER raise into the CLI), mark the ATIF turn aborted, surface
-                    # a marker, then fall through to the partial-output return.
+                    # Abort handling: the wall scope cancelled the loop, a quantitative
+                    # tool ceiling fired, or a supervisor veto broke out. Cancel the
+                    # backend (swallow any error — an abort must NEVER raise into the
+                    # CLI), mark the ATIF turn aborted, surface a marker, then fall
+                    # through to the partial-output return.
                     wall_cancelled = bool(getattr(wall_scope, "cancelled_caught", False))
                     if budget_reason is None and wall_cancelled:
                         budget_reason = "wall_budget_exceeded"

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -1289,7 +1289,8 @@ def _handle_ext_validate_command() -> int:
 
     Builds the per-run registry for real (builtins seeded, extension module
     discovered, version-gated, and applied), reports the extension source and
-    API version, then resolve-checks every namespace. Runs anywhere —
+    API version, reports tool-supervisor registration, then resolve-checks the
+    registry. Runs anywhere —
     validation is registry-shaped, not repo-shaped, so no target directory is
     required.
 
@@ -1317,6 +1318,8 @@ def _handle_ext_validate_command() -> int:
         source = "extension source: no extension found (builtins only)"
     console.print(source, soft_wrap=True)
     console.print(f"extension API version {EXTENSION_API_VERSION}")
+    supervisor_status = "registered" if registry.tool_supervisor_if_registered() is not None else "none"
+    console.print(f"tool supervisor: {supervisor_status}")
 
     failure = _ext_resolve_failure(registry)
     if failure is not None:

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -1140,8 +1140,9 @@ async def _step_post_review(ctx: FlowContext) -> None:
     """Offer to post findings as inline PR review comments."""
     from daydream.pr_review import post_review_to_pr_from_report
 
+    items_file: Path = ctx.data["items_file"]
     await post_review_to_pr_from_report(
-        ctx.work.repo, merged_items_path(ctx.data["dd"]), console=console
+        ctx.work.repo, items_file, console=console
     )
 
 

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -1191,7 +1191,7 @@ async def _step_verify(ctx: FlowContext) -> None:
         verdicts_file, verdicts_payload = await phase_verify_recommendations(
             ctx.backend_for("verify"),
             ctx.work,
-            merged_items_path=merged_items_path(dd),
+            merged_items_path=ctx.data["items_file"],
             deep_dir=dd,
         )
     print_verification_summary(console, verdicts_file)

--- a/daydream/extensions/__init__.py
+++ b/daydream/extensions/__init__.py
@@ -13,6 +13,8 @@ from daydream.extensions.api import (
     LoopGroup,
     StackRule,
     Stop,
+    ToolDecision,
+    ToolSupervisor,
     UnresolvedExtensionError,
 )
 from daydream.extensions.loader import build_registry, get_registry, set_registry
@@ -28,6 +30,8 @@ __all__ = [
     "Registry",
     "StackRule",
     "Stop",
+    "ToolDecision",
+    "ToolSupervisor",
     "UnresolvedExtensionError",
     "build_registry",
     "get_registry",

--- a/daydream/extensions/api.py
+++ b/daydream/extensions/api.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from daydream.flows.engine import FlowContext
     from daydream.trajectory import DaydreamPhase
 
-EXTENSION_API_VERSION: int = 1
+EXTENSION_API_VERSION: int = 2
 
 
 class ExtensionError(Exception):

--- a/daydream/extensions/api.py
+++ b/daydream/extensions/api.py
@@ -13,10 +13,11 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
     from daydream.flows.engine import FlowContext
+    from daydream.trajectory import DaydreamPhase
 
 EXTENSION_API_VERSION: int = 1
 
@@ -31,6 +32,31 @@ class ExtensionVersionError(ExtensionError):
 
 class UnresolvedExtensionError(ExtensionError):
     """A registry lookup or flow entry names a piece that is not registered."""
+
+
+@dataclass(frozen=True)
+class ToolDecision:
+    """Decision returned by a tool supervisor."""
+
+    veto: bool
+    reason: str = ""
+
+    def __post_init__(self) -> None:
+        if self.veto and not self.reason.strip():
+            raise ValueError("veto decisions require a non-blank reason")
+
+
+class ToolSupervisor(Protocol):
+    """Synchronous callable that can veto a tool invocation."""
+
+    def __call__(
+        self,
+        tool_name: str,
+        tool_input: dict[str, Any],
+        *,
+        phase: DaydreamPhase,
+    ) -> ToolDecision:
+        ...
 
 
 @dataclass(frozen=True)

--- a/daydream/extensions/registry.py
+++ b/daydream/extensions/registry.py
@@ -11,6 +11,7 @@ This module must not import from ``daydream.runner`` or ``daydream.phases``
 
 from __future__ import annotations
 
+import inspect
 from collections.abc import Callable, Sequence
 
 from daydream.extensions.api import (
@@ -167,6 +168,8 @@ class Registry:
             raise ExtensionError("tool supervisor must be callable")
         if self._tool_supervisor is not None:
             raise ExtensionError("tool supervisor is already registered")
+        if inspect.iscoroutinefunction(fn) or inspect.iscoroutinefunction(getattr(fn, "__call__", None)):
+            raise ExtensionError("tool supervisor must be synchronous")
         self._tool_supervisor = fn
 
     def tool_supervisor_if_registered(self) -> ToolSupervisor | None:

--- a/daydream/extensions/registry.py
+++ b/daydream/extensions/registry.py
@@ -1,7 +1,7 @@
 """Per-run extension registry.
 
-``Registry`` holds three namespaces — phases + flows, skill slots, and named
-prompts — plus fork stack rules. ``register_builtins()`` seeds it with
+``Registry`` holds phases + flows, skill slots, named prompts, a tool
+supervisor, and fork stack rules. ``register_builtins()`` seeds it with
 everything daydream does today; an optional ``daydream_ext`` package mutates
 it through the same API.
 
@@ -18,6 +18,7 @@ from daydream.extensions.api import (
     FlowStep,
     LoopGroup,
     StackRule,
+    ToolSupervisor,
     UnresolvedExtensionError,
 )
 
@@ -27,7 +28,7 @@ _VALIDATE_HINT = "run 'daydream ext validate' to check the extension registry"
 
 
 class Registry:
-    """Mutable per-run store for phases, flows, skill slots, prompts, and stack rules."""
+    """Mutable per-run store for phases, flows, skills, prompts, supervision, and stack rules."""
 
     def __init__(self) -> None:
         self._phases: dict[str, FlowStep] = {}
@@ -35,6 +36,7 @@ class Registry:
         self._skills: dict[str, str] = {}
         self._prompts: dict[str, Callable[..., str]] = {}
         self._stack_rules: dict[str, StackRule] = {}
+        self._tool_supervisor: ToolSupervisor | None = None
 
     # -- phases -----------------------------------------------------------
 
@@ -156,6 +158,20 @@ class Registry:
     def prompt_names(self) -> tuple[str, ...]:
         """Return every registered prompt name in registration order."""
         return tuple(self._prompts)
+
+    # -- tool supervision -------------------------------------------------
+
+    def register_tool_supervisor(self, fn: ToolSupervisor) -> None:
+        """Register the single per-run tool supervisor."""
+        if not callable(fn):
+            raise ExtensionError("tool supervisor must be callable")
+        if self._tool_supervisor is not None:
+            raise ExtensionError("tool supervisor is already registered")
+        self._tool_supervisor = fn
+
+    def tool_supervisor_if_registered(self) -> ToolSupervisor | None:
+        """Return the registered tool supervisor, or None when absent."""
+        return self._tool_supervisor
 
     # -- stack rules ------------------------------------------------------
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -271,7 +271,7 @@ every other key is internal and may change without a version bump:
 | `intent_path` | Path to the intent-analysis output |
 | `alts_path` | Path to the alternatives-review output |
 | `items_file` | `Path` published after `load-items`; it contains canonical `{"items": [...]}` JSON. An extension may read this file and rewrite its `items` before downstream consumers run. |
-| `items` | Parsed, merged actionable finding items |
+| `items` | Parsed finding items, populated by `fix-gate` from the (potentially rewritten) `items_file`. Not present before `fix-gate` runs; rewriting `items_file` before that step is sufficient to affect all consumers. |
 
 ## Recipes
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,14 +1,15 @@
 # Extension contract (`daydream_ext`)
 
 Daydream's extension seam lets a fork customize which phases run, which skills
-those phases use, and the prompts — entirely from a top-level `daydream_ext`
-package, without editing any file under `daydream/`. This document is the
-versioned contract: the module shape daydream loads, the exact name
-inventories a fork programs against, and the policy for when those names may
-change. A drift-guard test (`tests/test_extension_contract_doc.py`) pins this
-document to the registered inventories in the code.
+those phases use, the prompts, stack routing, tool supervision, and the
+canonical findings surface — entirely from a top-level `daydream_ext` package,
+without editing any file under `daydream/`. This document is the versioned
+contract: the module shape daydream loads, the exact name inventories a fork
+programs against, and the policy for when those names may change. A drift-guard
+test (`tests/test_extension_contract_doc.py`) pins this document to the
+registered inventories in the code.
 
-Current contract version: **`EXTENSION_API_VERSION = 1`**.
+Current contract version: **`EXTENSION_API_VERSION = 2`**.
 
 ## Extension module contract
 
@@ -22,7 +23,7 @@ daydream_ext/
 `__init__.py` must export exactly two things:
 
 ```python
-DAYDREAM_EXT_API = 1          # must equal daydream's EXTENSION_API_VERSION
+DAYDREAM_EXT_API = 2          # must equal daydream's EXTENSION_API_VERSION
 
 def register(registry):       # receives a daydream.extensions.Registry
     ...                       # mutate flows / skills / prompts / stacks here
@@ -32,6 +33,28 @@ def register(registry):       # receives a daydream.extensions.Registry
 has seeded the registry with everything daydream does today, so the extension
 sees (and may mutate) the full built-in state through the same API the
 built-ins used.
+
+### Public API symbols
+
+The `daydream.extensions` package exports these contract symbols:
+
+| Symbol | Purpose |
+|--------|---------|
+| `EXTENSION_API_VERSION` | Running extension contract version |
+| `BreakLoop` | End the current loop group and continue the flow |
+| `ExtensionError` | Base error for extension failures |
+| `ExtensionVersionError` | Error for an absent or incompatible extension version |
+| `FlowStep` | Named async flow step |
+| `LoopGroup` | Repeated ordered group of flow steps |
+| `Registry` | Per-run extension registry |
+| `StackRule` | Fork-defined changed-file-to-skill routing rule |
+| `Stop` | End a flow with an exit code |
+| `ToolDecision` | Continue or veto a tool invocation |
+| `ToolSupervisor` | Callable protocol for tool supervision |
+| `UnresolvedExtensionError` | Error for a missing registered name |
+| `build_registry` | Seed and load a per-run registry |
+| `get_registry` | Read the current async context's registry |
+| `set_registry` | Set the current async context's registry |
 
 ### Discovery order
 
@@ -70,7 +93,8 @@ It bumps on **any** breaking change to:
 - flow names or step names,
 - prompt names or their kwargs,
 - skill slot names,
-- the documented stable `ctx.data` keys below.
+- the documented stable `ctx.data` keys below,
+- the tool-supervisor decision and findings-file semantics below.
 
 The loader hard-rejects an extension whose `DAYDREAM_EXT_API` does not equal
 the running daydream's `EXTENSION_API_VERSION` — there is no compatibility
@@ -79,9 +103,46 @@ kwargs) do not bump the version.
 
 ### Changelog
 
-- **Version 1** — initial contract: the four flows below as registered step
-  lists; skill slots; the 10 named prompts; `$DAYDREAM_EXT_DIR` /
-  `daydream_ext` discovery; `daydream ext validate`.
+- **Version 2** — adds the synchronous tool-supervisor seam, the
+  `ToolDecision` result, and the public `items_file` findings surface. The
+  extension module literal is now `DAYDREAM_EXT_API = 2`.
+- **Version 1** — initial flow, skill, prompt, stack, loader, and validation
+  contract.
+
+## Tool supervision
+
+An extension may register one synchronous callable for the lifetime of the
+per-run `Registry`. Daydream calls it for each `ToolStartEvent` emitted by a
+backend:
+
+```python
+from daydream.extensions import ToolDecision
+
+def supervise(name, tool_input, *, phase):
+    return ToolDecision(veto=False)
+
+def register(r):
+    r.register_tool_supervisor(supervise)
+```
+
+The callable has the signature
+`(name: str, tool_input: dict[str, Any], *, phase: DaydreamPhase) -> ToolDecision`.
+`name` is the tool name, `tool_input` is the backend-provided input mapping,
+and `phase` identifies the current `DaydreamPhase`. The callable is
+synchronous; it must not be declared with `async def`.
+
+Return `ToolDecision(veto=False)` to let the invocation continue. Return
+`ToolDecision(veto=True, reason="...")` to abort the current agent turn; a veto
+requires a non-blank reason. Daydream cancels the backend, records the partial
+turn, and returns a `tool_vetoed:<name>` budget reason to the caller. If the
+supervisor raises, the failure propagates as an extension failure rather than
+being treated as a backend retry.
+
+`register_tool_supervisor` accepts only one callable per registry. A second
+registration or a non-callable value raises `ExtensionError`. If an extension
+does not register a supervisor, tool supervision is a no-op. Supervision runs
+when `run_agent` receives the backend's `ToolStartEvent`; it does not change
+backend-specific dispatch timing or add an earlier backend hook.
 
 ## Inventories
 
@@ -209,6 +270,7 @@ every other key is internal and may change without a version bump:
 | `exploration_dir` | Exploration pre-scan output directory (or None) |
 | `intent_path` | Path to the intent-analysis output |
 | `alts_path` | Path to the alternatives-review output |
+| `items_file` | `Path` published after `load-items`; it contains canonical `{"items": [...]}` JSON. An extension may read this file and rewrite its `items` before downstream consumers run. |
 | `items` | Parsed, merged actionable finding items |
 
 ## Recipes
@@ -228,6 +290,38 @@ def register(r):
     r.insert_after("deep", anchor="intent", step="my_gate")
     # or: r.insert_before("deep", anchor="fix-gate", step="my_gate")
 ```
+
+### Filter findings and supervise tools
+
+This v2 recipe inserts a step after `load-items` to rewrite the canonical
+findings file, and registers a singleton supervisor for tool invocations:
+
+```python
+import json
+
+from daydream.extensions import FlowStep, ToolDecision
+
+DAYDREAM_EXT_API = 2
+
+async def _filter_items(ctx):
+    items_file = ctx.data["items_file"]
+    payload = json.loads(items_file.read_text())
+    payload["items"] = [item for item in payload["items"] if item["severity"] != "low"]
+    items_file.write_text(json.dumps(payload))
+
+def _supervise(name, tool_input, *, phase):
+    if name == "Write":
+        return ToolDecision(veto=True, reason="writes require a separate approval policy")
+    return ToolDecision(veto=False)
+
+def register(r):
+    r.register_phase(FlowStep(name="filter-items", run=_filter_items))
+    r.insert_after("deep", anchor="load-items", step="filter-items")
+    r.register_tool_supervisor(_supervise)
+```
+
+The inserted step runs before `findings-out`, `post-review`, and the fix
+consumers, so their reads observe the rewritten canonical JSON.
 
 ### Disable a phase
 
@@ -327,7 +421,7 @@ builders' outputs and are replaced along with them).
 ```python
 from daydream.extensions import FlowStep, get_registry
 
-DAYDREAM_EXT_API = 1
+DAYDREAM_EXT_API = 2
 
 def _ro_prompt(skill):
     return f"RO-GATE {skill}"
@@ -361,15 +455,18 @@ model = "claude-sonnet-4-5"
 daydream ext validate
 ```
 
-Loads the extension, reports its source and API version, resolve-checks every
-flow entry, skill slot, and stack rule, and prints a per-namespace summary.
-Broken references exit 1 naming the broken piece. Runs anywhere — no target
-repo needed.
+Loads the extension, reports its source and API version, reports whether a tool
+supervisor is `registered` or `none`, resolve-checks every flow entry, skill
+slot, and stack rule, and prints a registry summary. Broken references exit 1
+naming the broken piece. Runs anywhere — no target repo needed.
 
-## Exclusions (v1 limits)
+## Exclusions (Version 2)
 
-- **No backend discovery.** Backends are the built-in `Backend`
+- **No backend registration.** Backends are the built-in `Backend`
   implementations (claude, codex, pi); forks cannot register new ones.
+- **Backend dispatch timing is host-controlled.** A tool supervisor runs after
+  `run_agent` receives a backend `ToolStartEvent`; extensions cannot move that
+  check earlier or later in a backend's internal dispatch pipeline.
 - **No prompt append.** Prompt override is wholesale only.
 - **Parse/test/commit/setup-investigator/failure-summarizer prompts are not
   registered** — they are schema- and control-loop-coupled.

--- a/tests/harness/fake_gh.py
+++ b/tests/harness/fake_gh.py
@@ -16,6 +16,11 @@ response map (``responses.json``) plus built-in behaviors:
 - ``GET repos/<o>/<r>/pulls/<n>/reviews`` returns the configured review list
   (``[]`` by default);
 - ``POST repos/<o>/<r>/pulls/<n>/reviews`` returns a fake ``html_url``.
+- ``gh pr view [<number>] --json ...`` emits the configured ``pr-view`` JSON
+  and records the invocation; ``gh pr list`` projects that same response into
+  the one-row list used by ``find_open_pr``;
+- ``gh repo view --json nameWithOwner -q .nameWithOwner`` emits the configured
+  ``repo-view`` slug (or ``acme/widgets`` when ``pr-view`` is configured).
 
 Any other invocation exits non-zero so unexpected calls surface as failures.
 """
@@ -138,14 +143,63 @@ def _handle_pr_create(argv):
     return 0
 
 
+def _handle_pr_view(argv):
+    _record("pr view", argv, "")
+    responses = json.loads(RESPONSES.read_text(encoding="utf-8")) if RESPONSES.exists() else {}
+    value = responses.get("pr-view")
+    if value is None:
+        sys.stderr.write("fake gh: no pr-view response configured\\n")
+        return 1
+    print(json.dumps(value))
+    return 0
+
+
+def _handle_pr_list(argv):
+    _record("pr list", argv, "")
+    responses = json.loads(RESPONSES.read_text(encoding="utf-8")) if RESPONSES.exists() else {}
+    value = responses.get("pr-list")
+    if value is None:
+        pr_view = responses.get("pr-view")
+        if pr_view is None:
+            sys.stderr.write("fake gh: no pr-list or pr-view response configured\\n")
+            return 1
+        value = [pr_view]
+    print(json.dumps(value))
+    return 0
+
+
+def _handle_repo_view(argv):
+    _record("repo view", argv, "")
+    responses = json.loads(RESPONSES.read_text(encoding="utf-8")) if RESPONSES.exists() else {}
+    value = responses.get("repo-view")
+    if value is None:
+        if "pr-view" not in responses:
+            sys.stderr.write("fake gh: no repo-view response configured\\n")
+            return 1
+        value = "acme/widgets"
+    if isinstance(value, dict):
+        value = value.get("nameWithOwner")
+    if not isinstance(value, str):
+        sys.stderr.write("fake gh: invalid repo-view response configured\\n")
+        return 1
+    print(value)
+    return 0
+
+
 def main():
     argv = sys.argv[1:]
     if argv[:2] in (["secret", "set"], ["variable", "set"]):
         return _handle_set(argv[0], argv)
     if argv[:2] in (["secret", "list"], ["variable", "list"]):
         return _handle_list(argv[0], argv)
+    if argv[:2] == ["pr", "view"]:
+        return _handle_pr_view(argv)
+    if argv[:2] == ["pr", "list"]:
+        return _handle_pr_list(argv)
     if argv[:2] == ["pr", "create"]:
         return _handle_pr_create(argv)
+    if argv[:2] == ["repo", "view"]:
+        return _handle_repo_view(argv)
     if not argv or argv[0] != "api":
         sys.stderr.write("fake gh: unsupported invocation: %r\\n" % (argv,))
         return 1
@@ -200,6 +254,14 @@ class GhCall:
 
 
 @dataclass
+class GhCommandCall:
+    """One recorded non-API ``gh`` invocation."""
+
+    kind: str
+    argv: list[str]
+
+
+@dataclass
 class GhSetCall:
     """One recorded ``gh secret set`` / ``gh variable set`` invocation.
 
@@ -245,6 +307,21 @@ class FakeGh:
             out.append(GhCall(endpoint=record["endpoint"], payload=record["payload"]))
         return out
 
+    def command_calls(self, kind: str) -> list[GhCommandCall]:
+        """Return recorded non-API calls matching *kind* (for example ``pr view``)."""
+        out: list[GhCommandCall] = []
+        if not self._calls_path.exists():
+            return out
+        for line in self._calls_path.read_text(encoding="utf-8").splitlines():
+            record = json.loads(line)
+            if record.get("kind") == kind:
+                out.append(GhCommandCall(kind=kind, argv=record["argv"]))
+        return out
+
+    def pr_view_calls(self) -> list[GhCommandCall]:
+        """Return recorded ``gh pr view`` invocations in order."""
+        return self.command_calls("pr view")
+
     def _set_calls(self, kind: str) -> list[GhSetCall]:
         out: list[GhSetCall] = []
         if not self._calls_path.exists():
@@ -282,8 +359,8 @@ class FakeGh:
         Two call shapes are supported:
         - ``set_response(method, endpoint, value)`` — keys the ``gh api``
           response under ``"<METHOD> <endpoint>"`` (existing behavior).
-        - ``set_response("pr-create", value=...)`` — keys a non-api response
-          (e.g. the PR URL the ``gh pr create`` shim prints) under the bare
+        - ``set_response("pr-create", value=...)`` (or ``"pr-view"`` /
+          ``"repo-view"``) — keys a non-api response under the bare
           ``method`` token.
         """
         responses = self._read_responses()
@@ -292,6 +369,14 @@ class FakeGh:
         else:
             responses[f"{method.upper()} {endpoint.lstrip('/')}"] = value
         self._responses_path.write_text(json.dumps(responses), encoding="utf-8")
+
+    def serve_pr_view(self, response: dict[str, Any]) -> None:
+        """Make ``gh pr view`` emit *response* and feed ``gh pr list``."""
+        self.set_response("pr-view", value=response)
+
+    def serve_repo_view(self, name_with_owner: str) -> None:
+        """Make ``gh repo view`` emit *name_with_owner*."""
+        self.set_response("repo-view", value=name_with_owner)
 
     def serve_secret_list(self, names: list[str]) -> None:
         """Make ``gh secret list --json name`` return *names*."""

--- a/tests/test_ext_validate_cli.py
+++ b/tests/test_ext_validate_cli.py
@@ -65,6 +65,21 @@ def test_ext_validate_rejects_invalid_supervisor_registration(ext_dir, capsys) -
     assert "tool supervisor" in strip_ansi(capsys.readouterr().out).lower()
 
 
+def test_ext_validate_rejects_async_supervisor_registration(ext_dir, capsys) -> None:
+    ext_dir.write_module(
+        "from daydream.extensions import ToolDecision\n"
+        "DAYDREAM_EXT_API = 2\n"
+        "async def supervise(name, tool_input, *, phase):\n"
+        "    return ToolDecision(veto=False)\n"
+        "def register(r): r.register_tool_supervisor(supervise)\n"
+    )
+    rc = _run_main(["ext", "validate"])
+    assert rc == 1
+    out = strip_ansi(capsys.readouterr().out).lower()
+    assert "tool supervisor" in out
+    assert "synchronous" in out
+
+
 def test_ext_validate_broken_ref(ext_dir, capsys) -> None:
     ext_dir.write_module(
         "DAYDREAM_EXT_API = 2\n"

--- a/tests/test_ext_validate_cli.py
+++ b/tests/test_ext_validate_cli.py
@@ -34,16 +34,40 @@ def _run_main(argv: list[str]) -> int:
 
 
 def test_ext_validate_ok(ext_dir, capsys) -> None:
-    ext_dir.write_module("DAYDREAM_EXT_API = 1\ndef register(r): ...\n")
+    ext_dir.write_module(
+        "from daydream.extensions import ToolDecision\n"
+        "DAYDREAM_EXT_API = 2\n"
+        "def supervise(name, tool_input, *, phase):\n"
+        "    return ToolDecision(veto=False)\n"
+        "def register(r): r.register_tool_supervisor(supervise)\n"
+    )
     rc = _run_main(["ext", "validate"])
     assert rc == 0
     out = strip_ansi(capsys.readouterr().out)
-    assert "DAYDREAM_EXT_DIR" in out and "api version 1" in out.lower()
+    assert "DAYDREAM_EXT_DIR" in out and "api version 2" in out.lower()
+    assert "tool supervisor: registered" in out.lower()
+
+
+def test_ext_validate_without_supervisor_reports_none(ext_dir, capsys) -> None:
+    ext_dir.write_module("DAYDREAM_EXT_API = 2\ndef register(r): ...\n")
+    rc = _run_main(["ext", "validate"])
+    assert rc == 0
+    assert "tool supervisor: none" in strip_ansi(capsys.readouterr().out).lower()
+
+
+def test_ext_validate_rejects_invalid_supervisor_registration(ext_dir, capsys) -> None:
+    ext_dir.write_module(
+        "DAYDREAM_EXT_API = 2\n"
+        "def register(r): r.register_tool_supervisor(None)\n"
+    )
+    rc = _run_main(["ext", "validate"])
+    assert rc == 1
+    assert "tool supervisor" in strip_ansi(capsys.readouterr().out).lower()
 
 
 def test_ext_validate_broken_ref(ext_dir, capsys) -> None:
     ext_dir.write_module(
-        "DAYDREAM_EXT_API = 1\n"
+        "DAYDREAM_EXT_API = 2\n"
         "def register(r):\n"
         "    r.set_flow('deep', ['ghost'])\n"
     )

--- a/tests/test_extension_contract_doc.py
+++ b/tests/test_extension_contract_doc.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+import daydream.extensions as extension_api
 from daydream.extensions import EXTENSION_API_VERSION, Registry
 from daydream.extensions.builtins import register_builtins
 
@@ -13,6 +14,17 @@ def test_contract_doc_names_every_registered_surface() -> None:
     reg = Registry()
     register_builtins(reg)
     assert f"DAYDREAM_EXT_API = {EXTENSION_API_VERSION}" in doc
+    for fragment in (
+        "register_tool_supervisor",
+        "ToolDecision",
+        "items_file",
+        "read",
+        "rewrite",
+        "DAYDREAM_EXT_API = 2",
+    ):
+        assert fragment in doc, f"contract detail {fragment!r} undocumented"
+    for symbol in extension_api.__all__:
+        assert symbol in doc, f"public symbol {symbol!r} undocumented"
     for flow in ("deep", "shallow", "review", "pr-feedback"):
         assert flow in doc, f"flow {flow!r} undocumented"
         for entry in reg.flow(flow):

--- a/tests/test_extension_errors_integration.py
+++ b/tests/test_extension_errors_integration.py
@@ -67,7 +67,7 @@ async def test_broken_flow_ref_fails_before_any_agent(
     outcome through ``runner.run``: exit 1, zero agents, named broken piece.
     """
     ext_dir.write_module(
-        "DAYDREAM_EXT_API = 1\n"
+        "DAYDREAM_EXT_API = 2\n"
         "def register(r):\n"
         "    r.insert_after('deep', anchor='intent', step='ghost_phase')\n"
     )
@@ -90,6 +90,7 @@ async def test_version_mismatch_exits_1_naming_versions(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """A DAYDREAM_EXT_API mismatch exits 1 naming both versions, before any git work."""
+    # Intentional incompatibility fixture: 99 must remain rejected by the v2 gate.
     ext_dir.write_module("DAYDREAM_EXT_API = 99\ndef register(r): ...\n")
     backend = RecordingBackend()
     monkeypatch.setattr("daydream.runner.create_backend", lambda name, model=None: backend)
@@ -100,4 +101,4 @@ async def test_version_mismatch_exits_1_naming_versions(
 
     assert rc == 1
     out = capsys.readouterr().out
-    assert "99" in out and "1" in out
+    assert "99" in out and "2" in out

--- a/tests/test_extension_prompts_integration.py
+++ b/tests/test_extension_prompts_integration.py
@@ -89,7 +89,7 @@ async def test_fork_prompt_override_reaches_backend(
     the exact built-in kwargs — the wholesale-override contract.
     """
     ext_dir.write_module(
-        "DAYDREAM_EXT_API = 1\n"
+        "DAYDREAM_EXT_API = 2\n"
         "def register(r):\n"
         "    r.override_prompt('review', lambda **kw: f\"RO-REVIEW {kw['skill_invocation']}\")\n"
     )

--- a/tests/test_extension_seam_integration.py
+++ b/tests/test_extension_seam_integration.py
@@ -102,9 +102,12 @@ class DeferredWriteBackend:
 
     model = "mock-model"
     fanout_concurrency = 4
+    retry_attempts = 1
+    retry_base_delay_s = 0.0
 
     def __init__(self, target: Path) -> None:
         self.target = target
+        self.execute_calls = 0
 
     async def execute(
         self,
@@ -116,6 +119,7 @@ class DeferredWriteBackend:
         max_turns: Any = None,
         read_only: bool = False,
     ):
+        self.execute_calls += 1
         yield ToolStartEvent(
             id="write-1",
             name="Write",
@@ -371,15 +375,26 @@ async def _run_tool_case(
     monkeypatch: pytest.MonkeyPatch,
     *,
     register_supervisor: bool,
+    supervisor_raises: bool = False,
+    backend_capture: list[DeferredWriteBackend] | None = None,
 ) -> tuple[Path, Path, int]:
     """Run the extension-defined custom flow against the deferred-write backend."""
     supervisor_registration = ""
     if register_supervisor:
-        supervisor_registration = (
-            "    def _supervise(name, tool_input, *, phase):\n"
-            "        return ToolDecision(veto=name == 'Write', reason='protected path')\n"
-            "    r.register_tool_supervisor(_supervise)\n"
-        )
+        if supervisor_raises:
+            supervisor_registration = (
+                "    class RetryableSupervisorError(RuntimeError):\n"
+                "        retryable = True\n"
+                "    def _supervise(name, tool_input, *, phase):\n"
+                "        raise RetryableSupervisorError('supervisor failed')\n"
+                "    r.register_tool_supervisor(_supervise)\n"
+            )
+        else:
+            supervisor_registration = (
+                "    def _supervise(name, tool_input, *, phase):\n"
+                "        return ToolDecision(veto=name == 'Write', reason='protected path')\n"
+                "    r.register_tool_supervisor(_supervise)\n"
+            )
 
     ext_dir.write_module(
         "from daydream.extensions import FlowStep, ToolDecision\n"
@@ -398,6 +413,8 @@ async def _run_tool_case(
     written = target / "deferred-write.txt"
     trajectory = target / ".daydream" / "tool-supervisor-trajectory.json"
     backend = DeferredWriteBackend(written)
+    if backend_capture is not None:
+        backend_capture.append(backend)
     monkeypatch.setattr("daydream.runner.create_backend", lambda name, model=None: backend)
     monkeypatch.delenv("DAYDREAM_APP_ID", raising=False)
     monkeypatch.delenv("DAYDREAM_APP_PRIVATE_KEY", raising=False)
@@ -441,6 +458,27 @@ async def test_no_tool_supervisor_allows_write(
     assert rc == 0
     assert written.read_text() == "backend resumed"
     assert "tool_vetoed:Write" not in traj.read_text()
+
+
+async def test_retryable_tool_supervisor_failure_propagates_without_retry(
+    ext_dir: ExtDir, multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A retryable supervisor error propagates without entering backend retry."""
+    backends: list[DeferredWriteBackend] = []
+
+    with pytest.raises(RuntimeError, match="supervisor failed") as exc_info:
+        await _run_tool_case(
+            ext_dir,
+            multi_stack_target,
+            monkeypatch,
+            register_supervisor=True,
+            supervisor_raises=True,
+            backend_capture=backends,
+        )
+
+    assert getattr(exc_info.value, "retryable", False) is True
+    assert len(backends) == 1
+    assert backends[0].execute_calls == 1
 
 
 async def test_custom_flow_dispatches_and_dumps_artifacts(

--- a/tests/test_extension_seam_integration.py
+++ b/tests/test_extension_seam_integration.py
@@ -37,7 +37,7 @@ import json
 
 from daydream.extensions import FlowStep
 
-DAYDREAM_EXT_API = 1
+DAYDREAM_EXT_API = 2
 
 
 async def _filter_items(ctx):
@@ -365,7 +365,7 @@ async def test_fork_disables_respond_step(
     backend), and the removed respond step never invoked its skill.
     """
     ext_dir.write_module(
-        "DAYDREAM_EXT_API = 1\n"
+        "DAYDREAM_EXT_API = 2\n"
         "def register(r):\n"
         "    r.remove('pr-feedback', 'respond-feedback')\n"
     )
@@ -391,7 +391,7 @@ async def test_fork_inserts_custom_phase_into_review_flow(
     """
     ext_dir.write_module(
         "from daydream.extensions import FlowStep\n"
-        "DAYDREAM_EXT_API = 1\n"
+        "DAYDREAM_EXT_API = 2\n"
         "async def _ro(ctx):\n"
         "    from daydream.agent import run_agent\n"
         "    from daydream.trajectory import DaydreamPhase\n"
@@ -460,7 +460,7 @@ async def test_fork_inserts_phase_before_summary_in_shallow(
     """
     ext_dir.write_module(
         "from daydream.extensions import FlowStep\n"
-        "DAYDREAM_EXT_API = 1\n"
+        "DAYDREAM_EXT_API = 2\n"
         "async def _ro(ctx):\n"
         "    from daydream.agent import run_agent\n"
         "    from daydream.trajectory import DaydreamPhase\n"
@@ -510,7 +510,7 @@ async def test_fork_disables_alternatives_in_deep(
     from tests.test_deep_orchestrator import _install_stub_backend, _silence
 
     ext_dir.write_module(
-        "DAYDREAM_EXT_API = 1\n"
+        "DAYDREAM_EXT_API = 2\n"
         "def register(r):\n"
         "    r.remove('deep', 'alternatives')\n"
     )
@@ -544,7 +544,7 @@ async def test_fork_disables_alternatives_in_deep(
 # (``skill('phase:ro_gate')``), then inserts it into the deep flow after ``intent``.
 FULL_RO_EXT = (
     "from daydream.extensions import FlowStep, get_registry\n"
-    "DAYDREAM_EXT_API = 1\n"
+    "DAYDREAM_EXT_API = 2\n"
     "def _ro_prompt(skill):\n"
     "    return f'RO-GATE {skill}'\n"
     "async def _ro(ctx):\n"
@@ -566,7 +566,7 @@ FULL_RO_EXT = (
 # as a brand-new flow name (NOT one of the four built-ins).
 CUSTOM_FLOW_EXT = (
     "from daydream.extensions import FlowStep\n"
-    "DAYDREAM_EXT_API = 1\n"
+    "DAYDREAM_EXT_API = 2\n"
     "async def _audit(ctx):\n"
     "    from daydream.agent import run_agent\n"
     "    from daydream.trajectory import DaydreamPhase\n"
@@ -618,7 +618,7 @@ async def _run_tool_case(
 
     ext_dir.write_module(
         "from daydream.extensions import FlowStep, ToolDecision\n"
-        "DAYDREAM_EXT_API = 1\n"
+        "DAYDREAM_EXT_API = 2\n"
         "async def _audit(ctx):\n"
         "    from daydream.agent import run_agent\n"
         "    from daydream.trajectory import DaydreamPhase\n"

--- a/tests/test_extension_seam_integration.py
+++ b/tests/test_extension_seam_integration.py
@@ -28,7 +28,6 @@ from tests.conftest import ExtDir
 from tests.harness.fake_gh import FakeGh
 from tests.harness.phase_backend import PhaseDispatchBackend
 
-
 KEEP_ME = "KEEP_ME"
 DROP_ME = "DROP_ME"
 

--- a/tests/test_extension_seam_integration.py
+++ b/tests/test_extension_seam_integration.py
@@ -17,11 +17,232 @@ from typing import Any
 
 import pytest
 
-from daydream import runner
+from daydream import git_ops, runner
 from daydream.backends import ResultEvent, TextEvent, ToolStartEvent
+from daydream.deep.orchestrator import _step_post_review
+from daydream.extensions.registry import Registry
+from daydream.flows.engine import FlowContext
 from daydream.runner import RunConfig
+from daydream.workspace import WorkContext
 from tests.conftest import ExtDir
+from tests.harness.fake_gh import FakeGh
 from tests.harness.phase_backend import PhaseDispatchBackend
+
+
+KEEP_ME = "KEEP_ME"
+DROP_ME = "DROP_ME"
+
+
+FILTER_ITEMS_EXT = """
+import json
+
+from daydream.extensions import FlowStep
+
+DAYDREAM_EXT_API = 1
+
+
+async def _filter_items(ctx):
+    items_file = ctx.data["items_file"]
+    payload = json.loads(items_file.read_text())
+    payload["items"] = [
+        item for item in payload["items"] if item["description"] != "DROP_ME"
+    ]
+    items_file.write_text(json.dumps(payload))
+
+
+def register(r):
+    r.register_phase(FlowStep(name="filter-items", run=_filter_items))
+    r.insert_after("deep", anchor="load-items", step="filter-items")
+"""
+
+
+def _post_context(*, dd: Path, items_file: Path) -> FlowContext:
+    """Build the smallest context needed by the post-review step."""
+    return FlowContext(
+        config=RunConfig(),
+        work=WorkContext(
+            repo=dd.parent,
+            source=dd.parent,
+            base_branch="main",
+            base_sha="base",
+            head_branch="feature",
+            head_sha="head",
+            is_ephemeral=False,
+            run_id="test-run",
+        ),
+        registry=Registry(),
+        data={"dd": dd, "items_file": items_file},
+    )
+
+
+async def _record_path(paths: list[Path], path: Path) -> None:
+    paths.append(path)
+
+
+def _filtered_items() -> list[dict[str, Any]]:
+    """Return valid canonical items with distinctive post-filter markers."""
+    return [
+        {
+            "id": 1,
+            "lens": "per-stack",
+            "file": "api.py",
+            "line": 1,
+            "severity": "high",
+            "description": KEEP_ME,
+            "confidence": "HIGH",
+            "rationale": "keep this finding",
+            "evidence": "api.py:1",
+        },
+        {
+            "id": 2,
+            "lens": "per-stack",
+            "file": "api.py",
+            "line": 1,
+            "severity": "medium",
+            "description": DROP_ME,
+            "confidence": "MEDIUM",
+            "rationale": "drop this finding",
+            "evidence": "api.py:1",
+        },
+    ]
+
+
+def _install_filtered_surface(
+    ext_dir: ExtDir,
+    target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Any:
+    """Install the one extension fork and a real-path deep backend."""
+    from tests.test_deep_orchestrator import _install_stub_backend, _silence
+
+    ext_dir.write_module(FILTER_ITEMS_EXT)
+    backend = _install_stub_backend(monkeypatch, target)
+    backend.merge_items = _filtered_items()
+    _silence(monkeypatch)
+    return backend
+
+
+def _serve_pr_view(fake_gh: FakeGh, target: Path) -> None:
+    """Configure a PR whose SHAs match the real fixture repository."""
+    fake_gh.serve_pr_view(
+        {
+            "number": 7,
+            "state": "OPEN",
+            "headRefName": "feature",
+            "baseRefName": "main",
+            "headRefOid": git_ops.head_sha(target),
+            "baseRefOid": git_ops.merge_base(target, "main"),
+            "url": "https://github.com/acme/widgets/pull/7",
+            "body": "",
+        }
+    )
+
+
+async def test_post_review_uses_published_items_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The post step passes through the canonical path published by load-items."""
+    private_dir = tmp_path / "private-deep"
+    stable_items = tmp_path / "stable-merged-items.json"
+    ctx = _post_context(dd=private_dir, items_file=stable_items)
+    posted_paths: list[Path] = []
+    monkeypatch.setattr(
+        "daydream.pr_review.post_review_to_pr_from_report",
+        lambda repo, path, *, console: _record_path(posted_paths, path),
+    )
+
+    await _step_post_review(ctx)
+
+    assert posted_paths == [stable_items]
+
+
+async def test_fork_filter_controls_findings_artifact(
+    ext_dir: ExtDir,
+    multi_stack_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_gh: Any,
+    tmp_path: Path,
+) -> None:
+    """A load-items fork controls the canonical findings export surface."""
+    _install_filtered_surface(ext_dir, multi_stack_target, monkeypatch)
+    _serve_pr_view(fake_gh, multi_stack_target)
+    findings_out = tmp_path / "findings.json"
+    merged_items = multi_stack_target / ".daydream" / "deep" / "merged-items.json"
+
+    rc = await runner.run(
+        RunConfig(
+            target=str(multi_stack_target),
+            pr_number=7,
+            findings_out=str(findings_out),
+            non_interactive=True,
+            cleanup=False,
+            archive=False,
+        )
+    )
+    artifact = findings_out.read_text()
+    canonical = merged_items.read_text()
+
+    assert rc == 0
+    assert KEEP_ME in artifact and KEEP_ME in canonical
+    assert DROP_ME not in artifact and DROP_ME not in canonical
+
+
+async def test_fork_filter_controls_pr_post_payload(
+    ext_dir: ExtDir,
+    multi_stack_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_gh: Any,
+) -> None:
+    """A load-items fork controls the canonical PR review payload."""
+    _install_filtered_surface(ext_dir, multi_stack_target, monkeypatch)
+    _serve_pr_view(fake_gh, multi_stack_target)
+
+    rc = await runner.run(
+        RunConfig(
+            target=str(multi_stack_target),
+            pr_number=7,
+            assume="yes",
+            non_interactive=True,
+            cleanup=False,
+            archive=False,
+        )
+    )
+    post = fake_gh.calls("POST", "repos/acme/widgets/pulls/7/reviews")[0]
+    payload = json.dumps(post.payload)
+
+    assert rc == 0
+    assert fake_gh.pr_view_calls()
+    assert KEEP_ME in payload
+    assert DROP_ME not in payload
+
+
+async def test_fork_filter_controls_fix_prompts(
+    ext_dir: ExtDir,
+    multi_stack_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_gh: Any,
+) -> None:
+    """A load-items fork controls the findings that reach the fix phase."""
+    from tests.test_deep_orchestrator import _fix_prompts
+
+    backend = _install_filtered_surface(ext_dir, multi_stack_target, monkeypatch)
+    _serve_pr_view(fake_gh, multi_stack_target)
+
+    rc = await runner.run(
+        RunConfig(
+            target=str(multi_stack_target),
+            pr_number=7,
+            assume="yes",
+            non_interactive=True,
+            cleanup=False,
+            archive=False,
+        )
+    )
+    fix_prompts = "\n".join(_fix_prompts(backend))
+
+    assert rc == 0
+    assert KEEP_ME in fix_prompts
+    assert DROP_ME not in fix_prompts
 
 
 class RecordingBackend:

--- a/tests/test_extension_seam_integration.py
+++ b/tests/test_extension_seam_integration.py
@@ -11,13 +11,14 @@ extension-seam plan, one flow migration at a time.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
 import pytest
 
 from daydream import runner
-from daydream.backends import ResultEvent, TextEvent
+from daydream.backends import ResultEvent, TextEvent, ToolStartEvent
 from daydream.runner import RunConfig
 from tests.conftest import ExtDir
 from tests.harness.phase_backend import PhaseDispatchBackend
@@ -94,6 +95,41 @@ class RecordingBackend:
         if args:
             result = f"{result} {args}"
         return result
+
+
+class DeferredWriteBackend:
+    """Yield a write start before performing the write on generator resumption."""
+
+    model = "mock-model"
+    fanout_concurrency = 4
+
+    def __init__(self, target: Path) -> None:
+        self.target = target
+
+    async def execute(
+        self,
+        cwd: Path,
+        prompt: str,
+        output_schema: Any = None,
+        continuation: Any = None,
+        agents: Any = None,
+        max_turns: Any = None,
+        read_only: bool = False,
+    ):
+        yield ToolStartEvent(
+            id="write-1",
+            name="Write",
+            input={"path": str(self.target), "content": "backend resumed"},
+        )
+        self.target.write_text("backend resumed")
+        yield TextEvent(text="")
+        yield ResultEvent(structured_output=None, continuation=None)
+
+    async def cancel(self) -> None:
+        pass
+
+    def format_skill_invocation(self, skill_key: str, args: str = "") -> str:
+        return f"/{skill_key}"
 
 
 async def test_fork_disables_respond_step(
@@ -316,6 +352,95 @@ CUSTOM_FLOW_EXT = (
     "    r.register_phase(FlowStep(name='ro_audit', run=_audit))\n"
     "    r.set_flow('ro-audit', ['ro_audit'])\n"
 )
+
+
+def _step_for_tool(trajectory: dict[str, Any], tool_name: str) -> dict[str, Any]:
+    """Return the recorded agent step containing a call to *tool_name*."""
+    for step in trajectory["steps"]:
+        if any(
+            call.get("function_name") == tool_name
+            for call in step.get("tool_calls", [])
+        ):
+            return step
+    raise AssertionError(f"no trajectory step recorded tool {tool_name!r}")
+
+
+async def _run_tool_case(
+    ext_dir: ExtDir,
+    target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    register_supervisor: bool,
+) -> tuple[Path, Path, int]:
+    """Run the extension-defined custom flow against the deferred-write backend."""
+    supervisor_registration = ""
+    if register_supervisor:
+        supervisor_registration = (
+            "    def _supervise(name, tool_input, *, phase):\n"
+            "        return ToolDecision(veto=name == 'Write', reason='protected path')\n"
+            "    r.register_tool_supervisor(_supervise)\n"
+        )
+
+    ext_dir.write_module(
+        "from daydream.extensions import FlowStep, ToolDecision\n"
+        "DAYDREAM_EXT_API = 1\n"
+        "async def _audit(ctx):\n"
+        "    from daydream.agent import run_agent\n"
+        "    from daydream.trajectory import DaydreamPhase\n"
+        "    await run_agent(ctx.backend_for('ro_audit'), ctx.work.repo, 'CUSTOM-TOOL-PROMPT',\n"
+        "                    phase=DaydreamPhase.REVIEW)\n"
+        "def register(r):\n"
+        "    r.register_phase(FlowStep(name='ro_audit', run=_audit))\n"
+        "    r.set_flow('ro-audit', ['ro_audit'])\n"
+        + supervisor_registration
+    )
+
+    written = target / "deferred-write.txt"
+    trajectory = target / ".daydream" / "tool-supervisor-trajectory.json"
+    backend = DeferredWriteBackend(written)
+    monkeypatch.setattr("daydream.runner.create_backend", lambda name, model=None: backend)
+    monkeypatch.delenv("DAYDREAM_APP_ID", raising=False)
+    monkeypatch.delenv("DAYDREAM_APP_PRIVATE_KEY", raising=False)
+
+    rc = await runner.run(
+        RunConfig(
+            target=str(target),
+            flow_name="ro-audit",
+            non_interactive=True,
+            cleanup=False,
+            archive=False,
+            trajectory_path=trajectory,
+        )
+    )
+    return written, trajectory, rc
+
+
+async def test_fork_tool_supervisor_vetoes_write(
+    ext_dir: ExtDir, multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A registered supervisor veto closes the deferred backend before its write."""
+    denied, traj, rc = await _run_tool_case(
+        ext_dir, multi_stack_target, monkeypatch, register_supervisor=True
+    )
+
+    assert rc == 0
+    assert not denied.exists()
+    step = _step_for_tool(json.loads(traj.read_text()), "Write")
+    assert step["tool_calls"][0]["function_name"] == "Write"
+    assert step["extra"]["stop_reason"] == "tool_vetoed:Write"
+
+
+async def test_no_tool_supervisor_allows_write(
+    ext_dir: ExtDir, multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without registration, the same deferred backend resumes and writes."""
+    written, traj, rc = await _run_tool_case(
+        ext_dir, multi_stack_target, monkeypatch, register_supervisor=False
+    )
+
+    assert rc == 0
+    assert written.read_text() == "backend resumed"
+    assert "tool_vetoed:Write" not in traj.read_text()
 
 
 async def test_custom_flow_dispatches_and_dumps_artifacts(

--- a/tests/test_extension_skills.py
+++ b/tests/test_extension_skills.py
@@ -8,7 +8,7 @@ from tests.conftest import ExtDir
 def test_fork_stack_rule_and_remap_reach_detection(ext_dir: ExtDir) -> None:
     ext_dir.write_module(
         "from daydream.extensions import StackRule\n"
-        "DAYDREAM_EXT_API = 1\n"
+        "DAYDREAM_EXT_API = 2\n"
         "def register(r):\n"
         "    r.add_stack(StackRule('proto', ('*.proto',), 'ro-proto:review-proto'))\n"
         "    r.override_skill('stack:python', 'ro-python:review-python')\n"

--- a/tests/test_extension_skills_integration.py
+++ b/tests/test_extension_skills_integration.py
@@ -88,7 +88,7 @@ async def test_fork_overrides_pr_feedback_fetch_skill(
     prompt the backend received, and the built-in literal appears in none.
     """
     ext_dir.write_module(
-        "DAYDREAM_EXT_API = 1\n"
+        "DAYDREAM_EXT_API = 2\n"
         "def register(r):\n"
         "    r.override_skill('pr-feedback-fetch', 'ro-core:fetch-pr-feedback')\n"
     )
@@ -114,7 +114,7 @@ async def test_stack_slot_override_reaches_shallow_skill_flag(
     ``beagle-python:review-python`` literal.
     """
     ext_dir.write_module(
-        "DAYDREAM_EXT_API = 1\n"
+        "DAYDREAM_EXT_API = 2\n"
         "def register(r):\n"
         "    r.override_skill('stack:python', 'ro-python:review-python')\n"
     )
@@ -150,7 +150,7 @@ async def test_fork_stack_rule_routes_deep_per_stack_review(
 
     ext_dir.write_module(
         "from daydream.extensions import StackRule\n"
-        "DAYDREAM_EXT_API = 1\n"
+        "DAYDREAM_EXT_API = 2\n"
         "def register(r):\n"
         "    r.add_stack(StackRule('proto', ('*.proto',), 'ro-proto:review-proto'))\n"
     )
@@ -195,7 +195,7 @@ async def test_phase_review_slot_supplies_shallow_skill(
     bound skill invocation.
     """
     ext_dir.write_module(
-        "DAYDREAM_EXT_API = 1\n"
+        "DAYDREAM_EXT_API = 2\n"
         "def register(r):\n"
         "    r.override_skill('phase:review', 'ro-python:review-python')\n"
     )

--- a/tests/test_extensions_loader.py
+++ b/tests/test_extensions_loader.py
@@ -12,7 +12,7 @@ from tests.conftest import ExtDir
 
 def test_loader_applies_extension(ext_dir: ExtDir) -> None:
     ext_dir.write_module(
-        "DAYDREAM_EXT_API = 1\n"
+        "DAYDREAM_EXT_API = 2\n"
         "def register(registry):\n"
         "    registry.override_skill('structural', 'ro-core:review-structure')\n"
     )
@@ -20,12 +20,13 @@ def test_loader_applies_extension(ext_dir: ExtDir) -> None:
 
 
 def test_version_mismatch_names_both_versions(ext_dir: ExtDir) -> None:
+    # Intentional incompatibility fixture: 99 must remain rejected by the v2 gate.
     ext_dir.write_module("DAYDREAM_EXT_API = 99\ndef register(registry): ...\n")
-    with pytest.raises(ExtensionVersionError, match=r"99.*expects 1|expects 1.*99"):
+    with pytest.raises(ExtensionVersionError, match=r"99.*expects 2|expects 2.*99"):
         build_registry()
 
 
 def test_register_exception_is_wrapped_and_named(ext_dir: ExtDir) -> None:
-    ext_dir.write_module("DAYDREAM_EXT_API = 1\ndef register(registry):\n    raise RuntimeError('boom')\n")
+    ext_dir.write_module("DAYDREAM_EXT_API = 2\ndef register(registry):\n    raise RuntimeError('boom')\n")
     with pytest.raises(ExtensionError, match=r"daydream_ext.*boom"):
         build_registry()

--- a/tests/test_extensions_registry.py
+++ b/tests/test_extensions_registry.py
@@ -93,3 +93,25 @@ def test_tool_supervisor_registration_is_exclusive() -> None:
         reg.register_tool_supervisor(supervisor)
     with pytest.raises(ValueError, match="veto.*reason"):
         ToolDecision(veto=True, reason="")
+
+
+def test_tool_supervisor_registration_rejects_async_function() -> None:
+    reg = Registry()
+
+    async def supervisor(name, tool_input, *, phase):
+        return ToolDecision(veto=False)
+
+    with pytest.raises(ExtensionError, match="tool supervisor.*synchronous"):
+        reg.register_tool_supervisor(supervisor)
+    assert reg.tool_supervisor_if_registered() is None
+
+
+def test_tool_supervisor_registration_rejects_async_callable_object() -> None:
+    class AsyncSupervisor:
+        async def __call__(self, name, tool_input, *, phase):
+            return ToolDecision(veto=False)
+
+    reg = Registry()
+    with pytest.raises(ExtensionError, match="tool supervisor.*synchronous"):
+        reg.register_tool_supervisor(AsyncSupervisor())
+    assert reg.tool_supervisor_if_registered() is None

--- a/tests/test_extensions_registry.py
+++ b/tests/test_extensions_registry.py
@@ -9,6 +9,7 @@ from daydream.extensions import (
     FlowStep,
     LoopGroup,
     Registry,
+    ToolDecision,
     UnresolvedExtensionError,
 )
 
@@ -77,3 +78,18 @@ def test_stack_keys_returns_stack_slot_keys_only() -> None:
     reg.override_skill("structural", "ro:review-structure")
     reg.override_skill("pr-feedback-fetch", "ro:fetch-pr-feedback")
     assert reg.stack_keys() == {"python", "proto"}
+
+
+def test_tool_supervisor_registration_is_exclusive() -> None:
+    reg = Registry()
+
+    def supervisor(name, tool_input, *, phase):
+        return ToolDecision(veto=name == "Write", reason="protected path")
+
+    reg.register_tool_supervisor(supervisor)
+    assert reg.tool_supervisor_if_registered() is supervisor
+    assert supervisor("Write", {}, phase="fix").veto is True
+    with pytest.raises(ExtensionError, match="tool supervisor.*already registered"):
+        reg.register_tool_supervisor(supervisor)
+    with pytest.raises(ValueError, match="veto.*reason"):
+        ToolDecision(veto=True, reason="")


### PR DESCRIPTION
## Summary

Implements issue #268 by publishing the versioned extension supervision seam and stable merged-findings rewrite surface. Extensions can now filter canonical findings after load-items and synchronously veto tool turns through the per-run registry.

## Changes

### Added

- Public API v2 ToolDecision and ToolSupervisor contracts with exclusive registry registration.
- Runtime tool-supervisor consultation after ToolStartEvent recording, with veto-driven abort cleanup and trajectory stop reasons.
- Stable items_file consumption across findings export, PR posting, and fix selection.
- Real-path integration coverage for filtered findings, PR payloads, fix prompts, and deferred backend veto behavior.
- CLI validation reporting for registered, absent, invalid, and asynchronous supervisors.

### Changed

- Migrated valid extension fixtures and documentation to DAYDREAM_EXT_API = 2.
- Extended the fake GitHub CLI harness with strict, recorded pull-request discovery support.
- Documented the v2 contract, recipes, limitations, changelog entry, and migration history.

### Fixed

- Supervisor failures propagate without entering backend retry handling.
- Asynchronous supervisors are rejected at registration instead of failing during tool dispatch.

## Motivation

Issue #268 needs public, versioned seams for future findings supervision and tool interdiction without exposing private deep-flow internals. The stable path and registry hook let forks implement those policies while preserving existing flow and trajectory behavior.

## Testing

- make check: 2,123 passed, 5 skipped, 3 warnings.
- uv run mypy daydream tests: passed with no issues.
- Extension contract suite: 44 passed.
- Ruff and git diff --check: passed.
- Audits confirm no stale valid-v1 contract literals and no PR-post path re-derivation.

## Breaking Changes

Extension modules must update DAYDREAM_EXT_API from 1 to 2 to load under this contract. The documented v2 surface remains synchronous and observes backend ToolStartEvent timing; it does not claim backend-specific pre-execution guarantees.

## Related Issues

- Closes #268

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review and independent spec/quality reviews completed
- [x] Tests pass locally
- [x] Linting and type checking pass
- [x] Documentation updated