### PR TITLE
feat: add findings meta-control and tool interdiction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   lets a step after `load-items` rewrite canonical findings before downstream
   consumers read them.
 
+- **deep:** Add config-driven findings supervision with rule and batched LLM
+  modes, including drop, edit, hold, and trajectory verdict events ([#256](https://github.com/existential-birds/daydream/issues/256))
+
+- **agent:** Add the built-in rule tool supervisor for denied file paths and
+  Bash commands, with turn-level veto events and conflict detection against
+  extension registrations ([#257](https://github.com/existential-birds/daydream/issues/257))
+
 ## [0.23.1] - 2026-07-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -140,6 +140,18 @@ model = "gpt-5.5"
 model = "claude-opus-4-8"
 ```
 
+Supervisor settings are config-file-only:
+
+| Key | Default | Semantics |
+|-----|---------|-----------|
+| `supervisor` | `"off"` | Findings supervisor mode: `"off"`, `"rules"`, or `"llm"`. |
+| `supervisor_deny_globs` | `[]` | Repository-relative globs shared by findings and tool rules. |
+| `tool_supervisor` | `"off"` | Built-in tool policy mode: `"off"` or `"rules"`. |
+| `tool_bash_deny` | `[]` | Regular expressions for Bash commands the built-in policy vetoes. |
+
+The LLM supervisor uses one batched call. Configure its model under
+`[tool.daydream.phases.supervise]` (or `[phases.supervise]` in `.daydream.toml`).
+
 ```toml
 # .daydream.toml  (top-level keys; no [tool.daydream] prefix)
 model = "claude-opus-4-8"

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ backend = "codex"
 
 Phase names are the flow-step config keys (`exploration`, `intent`, `wonder`,
 `per_stack_review`, `arbiter`, `merge`, `review`, `parse`, `fix`, `test`, `verify`,
-`pr_feedback`, …); any name is accepted, including phases a fork defines through the
+`pr_feedback`, `supervise`, …); any name is accepted, including phases a fork defines through the
 [extension seam](docs/extensions.md), which lists the per-flow key tables.
 Resolution precedence, highest first:
 

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -479,6 +479,10 @@ async def run_agent(
                                     except Exception as exc:  # noqa: BLE001 - policy failures must propagate
                                         raise _ToolSupervisorFailure(exc) from exc
                                     if decision.veto:
+                                        if recorder is not None:
+                                            recorder.emit_tool_veto(
+                                                event.name, decision.reason, phase=phase
+                                            )
                                         budget_reason = f"tool_vetoed:{event.name}"
                                         break
 

--- a/daydream/config.py
+++ b/daydream/config.py
@@ -71,6 +71,8 @@ DEFAULT_GROUP_MAX_SERIAL_ITEMS = 6  # max per-finding fix calls in one group
 # ``suppression`` (issue #232) is the precision-mode skeptical second opinion over
 # borderline uncontested findings; it runs on the cheap mid tier by design (never
 # per-finding Opus) -- one batched Sonnet call over all suppression targets.
+# ``supervise`` is the batched findings supervisor over canonical merged items;
+# it uses the same Sonnet tier by default.
 #
 # ``per_stack_review`` and ``arbiter`` split the deep per-stack fan-out off the
 # heavy ``review`` tier (issue #168): the N per-stack reviewers run on Sonnet
@@ -96,6 +98,7 @@ PHASE_DEFAULT_MODELS: dict[str, dict[str, str]] = {
         "review": "claude-opus-4-8",
         "arbiter": "claude-opus-4-8",
         "suppression": "claude-sonnet-4-6",
+        "supervise": "claude-sonnet-4-6",
         "wonder": "claude-opus-4-8",
         "merge": "claude-opus-4-8",
         "intent": "claude-sonnet-4-6",
@@ -111,6 +114,7 @@ PHASE_DEFAULT_MODELS: dict[str, dict[str, str]] = {
         "review": "gpt-5.5",
         "arbiter": "gpt-5.5",
         "suppression": "gpt-5.5",
+        "supervise": "gpt-5.5",
         "wonder": "gpt-5.5",
         "merge": "gpt-5.5",
         "intent": "gpt-5.5",

--- a/daydream/config_file.py
+++ b/daydream/config_file.py
@@ -52,6 +52,13 @@ class DaydreamFileConfig:
             calls in one file group (the group is severity-sorted, so the dropped
             tail is lowest-severity). ``None`` (the default when the key is absent
             or junk) falls through to ``config.DEFAULT_GROUP_MAX_SERIAL_ITEMS`` (6).
+        supervisor: Findings supervisor mode (``"off"``, ``"rules"``, or
+            ``"llm"``), or None when unset/invalid.
+        supervisor_deny_globs: Repository-relative deny globs shared by findings
+            and tool supervision.
+        tool_supervisor: Built-in tool supervisor mode (``"off"`` or ``"rules"``),
+            or None when unset/invalid.
+        tool_bash_deny: Regular expressions for denied Bash commands.
     """
 
     model: str | None = None
@@ -62,6 +69,10 @@ class DaydreamFileConfig:
     precision_mode: bool | None = None
     group_max_wall_s: float | None = None
     group_max_serial_items: int | None = None
+    supervisor: str | None = None
+    supervisor_deny_globs: list[str] = field(default_factory=list)
+    tool_supervisor: str | None = None
+    tool_bash_deny: list[str] = field(default_factory=list)
 
     def phase_model(self, phase: str) -> str | None:
         """Return the configured model for a phase."""
@@ -188,6 +199,18 @@ def _coerce_float(raw: Any) -> float | None:
     return None
 
 
+def _coerce_string_list(raw: Any) -> list[str]:
+    """Return a list of strings, or an empty list for malformed values."""
+    if not isinstance(raw, list) or not all(isinstance(value, str) for value in raw):
+        return []
+    return list(raw)
+
+
+def _coerce_choice(raw: Any, choices: set[str]) -> str | None:
+    """Return a configured choice, or None for an invalid value."""
+    return raw if isinstance(raw, str) and raw in choices else None
+
+
 def load_file_config(root: Path) -> DaydreamFileConfig:
     """Load and merge daydream file configuration from a repo root.
 
@@ -240,4 +263,8 @@ def load_file_config(root: Path) -> DaydreamFileConfig:
         precision_mode=precision,
         group_max_wall_s=_coerce_float(merged.get("group_max_wall_s")),
         group_max_serial_items=_coerce_int(merged.get("group_max_serial_items")),
+        supervisor=_coerce_choice(merged.get("supervisor"), {"off", "rules", "llm"}),
+        supervisor_deny_globs=_coerce_string_list(merged.get("supervisor_deny_globs")),
+        tool_supervisor=_coerce_choice(merged.get("tool_supervisor"), {"off", "rules"}),
+        tool_bash_deny=_coerce_string_list(merged.get("tool_bash_deny")),
     )

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -70,6 +70,7 @@ from daydream.phases import (
     phase_verify_recommendations,
     severity_sorted,
 )
+from daydream.supervision import revise_finding_fields
 from daydream.trajectory import (
     DaydreamPhase,
     DaydreamRunFlow,
@@ -569,15 +570,7 @@ def _apply_adjudication_verdicts(
         # compaction. The suppression call site keys its arbiter-exclusion set by
         # ``id(record)`` (#232); a revised record that got a fresh dict here would
         # escape that set and be wrongly re-judged by the suppression pass.
-        records[record_index].update(
-            {
-                "severity": verdict.get("severity", records[record_index].get("severity")),
-                "confidence": verdict.get("confidence", records[record_index].get("confidence")),
-                "description": verdict.get("description", records[record_index].get("description")),
-                "rationale": verdict.get("rationale", records[record_index].get("rationale")),
-                "evidence": verdict.get("evidence", records[record_index].get("evidence")),
-            }
-        )
+        revise_finding_fields(records[record_index], verdict)
 
     new_records: list[dict[str, Any]] = []
     new_sources: list[str] = []

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -39,6 +39,7 @@ from daydream.deep.artifacts import (
     fix_failures_path,
     fix_leftover_untracked_path,
     merged_items_path,
+    merged_report_path,
     per_stack_failures_path,
     per_stack_records_path,
 )
@@ -65,17 +66,24 @@ from daydream.phases import (
     phase_parse_feedback,
     phase_per_stack_reviews,
     phase_suppression_review,
+    phase_supervise_review,
     phase_test_and_heal,
     phase_understand_intent,
     phase_verify_recommendations,
     severity_sorted,
 )
-from daydream.supervision import revise_finding_fields
+from daydream.supervision import (
+    RuleBasedSupervisor,
+    apply_findings_verdicts,
+    revise_finding_fields,
+)
 from daydream.trajectory import (
     DaydreamPhase,
     DaydreamRunFlow,
+    get_current_recorder,
     phase_scope,
 )
+from daydream.deep.render import render_held_section, render_report
 from daydream.ui import (
     format_verdict_join,
     phase_subtitle,
@@ -209,6 +217,18 @@ def _precision_mode(config: RunConfig) -> bool:
     if file_config is not None and file_config.precision_mode:
         return True
     return False
+
+
+def _supervisor_mode(config: RunConfig) -> str:
+    """Resolve the file-config-only findings supervisor mode."""
+    file_config = config.file_config
+    mode = file_config.supervisor if file_config is not None else None
+    return mode if mode in {"off", "rules", "llm"} else "off"
+
+
+def _supervise_enabled(ctx: FlowContext) -> bool:
+    """Run supervision on fresh flows, not on a fix-only resume."""
+    return _supervisor_mode(ctx.config) in {"rules", "llm"} and ctx.config.start_at != "fix"
 
 
 def _resolve_group_max_wall_s(config: RunConfig) -> float:
@@ -1129,6 +1149,44 @@ async def _step_findings_out(ctx: FlowContext) -> Stop:
     return Stop(_emit_findings_from_items(ctx.work.repo, ctx.config, findings_items))
 
 
+async def _step_supervise(ctx: FlowContext) -> None:
+    """Apply the configured findings supervisor to canonical merged items."""
+    mode = _supervisor_mode(ctx.config)
+    file_config = ctx.config.file_config
+    items_file: Path = ctx.data["items_file"]
+    items = json.loads(items_file.read_text())["items"]
+    if mode == "rules":
+        deny_globs = file_config.supervisor_deny_globs if file_config is not None else []
+        verdicts = RuleBasedSupervisor(deny_globs=deny_globs).review_findings(items)
+    else:
+        async with phase_scope(DaydreamPhase.DEEP, stage="supervise"):
+            verdicts = await phase_supervise_review(
+                ctx.backend_for("supervise"),
+                ctx.work,
+                items=items,
+                diff_path=ctx.data["diff_path"],
+                intent_path=ctx.data["intent_path"],
+                alternatives_path=ctx.data["alts_path"],
+                exploration_dir=ctx.data["exploration_dir"],
+            )
+    kept, held, events = apply_findings_verdicts(items, verdicts)
+    items_file.write_text(json.dumps({"items": kept, "held": held}, indent=2))
+
+    report = render_report(kept)
+    held_section = render_held_section(held)
+    if held_section:
+        report = report.rstrip() + "\n\n" + held_section + "\n"
+    deep_report = merged_report_path(ctx.data["dd"])
+    deep_report.write_text(report)
+    Path(ctx.data["merged_report"]).write_text(report)
+
+    recorder = get_current_recorder()
+    if recorder is not None:
+        for finding_id, action, reason in events:
+            recorder.emit_supervisor_verdict(finding_id, action, reason)
+    return None
+
+
 async def _step_post_review(ctx: FlowContext) -> None:
     """Offer to post findings as inline PR review comments."""
     from daydream.pr_review import post_review_to_pr_from_report
@@ -1388,7 +1446,7 @@ def _findings_out_enabled(ctx: FlowContext) -> bool:
 #     exploration pre-scan -> TTT intent -> TTT alternative-review ->
 #     per-stack reviews -> per-stack parse + dedup -> arbiter ->
 #     cross-stack merge (or the tiny-diff single-stack bypass) ->
-#     findings-out stop / post-review -> fix gate -> verify -> fix ->
+#     supervise -> findings-out stop / post-review -> fix gate -> verify -> fix ->
 #     test -> commit.
 #
 # ``register_builtins`` registers :data:`STEPS` and the ``deep`` flow
@@ -1408,6 +1466,7 @@ STEPS: tuple[FlowStep, ...] = (
     ),
     FlowStep(name="single-stack-merge", run=_step_single_stack_merge, enabled=_single_stack_merge_enabled),
     FlowStep(name="load-items", run=_step_load_items),
+    FlowStep(name="supervise", run=_step_supervise, config_phase="supervise", enabled=_supervise_enabled),
     FlowStep(name="findings-out", run=_step_findings_out, enabled=_findings_out_enabled),
     FlowStep(name="post-review", run=_step_post_review, enabled=_before_fix_resume),
     FlowStep(name="fix-gate", run=_step_fix_gate),

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -51,6 +51,7 @@ from daydream.deep.artifacts import (
 )
 from daydream.deep.dedup import build_dedup_candidates, build_record_dedup_candidates
 from daydream.deep.detection import GENERIC_STACK, StackAssignment, detect_stacks
+from daydream.deep.render import render_held_section, render_report
 from daydream.extensions import get_registry
 from daydream.extensions.api import FlowStep, Stop
 from daydream.flows.engine import FlowContext, run_flow
@@ -65,8 +66,8 @@ from daydream.phases import (
     phase_fix_parallel,
     phase_parse_feedback,
     phase_per_stack_reviews,
-    phase_suppression_review,
     phase_supervise_review,
+    phase_suppression_review,
     phase_test_and_heal,
     phase_understand_intent,
     phase_verify_recommendations,
@@ -83,7 +84,6 @@ from daydream.trajectory import (
     get_current_recorder,
     phase_scope,
 )
-from daydream.deep.render import render_held_section, render_report
 from daydream.ui import (
     format_verdict_join,
     phase_subtitle,

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -1156,7 +1156,8 @@ async def _step_supervise(ctx: FlowContext) -> None:
     items_file: Path = ctx.data["items_file"]
     items = json.loads(items_file.read_text())["items"]
     if mode == "rules":
-        deny_globs = file_config.supervisor_deny_globs if file_config is not None else []
+        assert file_config is not None, "rules mode requires file_config (guaranteed by _supervisor_mode)"
+        deny_globs = file_config.supervisor_deny_globs
         verdicts = RuleBasedSupervisor(deny_globs=deny_globs).review_findings(items)
     else:
         async with phase_scope(DaydreamPhase.DEEP, stage="supervise"):
@@ -1178,7 +1179,7 @@ async def _step_supervise(ctx: FlowContext) -> None:
         report = report.rstrip() + "\n\n" + held_section + "\n"
     deep_report = merged_report_path(ctx.data["dd"])
     deep_report.write_text(report)
-    Path(ctx.data["merged_report"]).write_text(report)
+    ctx.data["merged_report"].write_text(report)
 
     recorder = get_current_recorder()
     if recorder is not None:

--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -396,6 +396,43 @@ def build_arbiter_prompt(
     return "\n\n".join(parts)
 
 
+def build_supervise_prompt(
+    *,
+    supervise_input_path: Path,
+    diff_path: Path,
+    intent_path: Path,
+    alternatives_path: Path,
+    cwd: Path,
+    exploration_dir: Path | None = None,
+) -> str:
+    """Assemble the batched canonical findings supervisor prompt."""
+    parts: list[str] = []
+    pointer = _exploration_pointer(exploration_dir)
+    if pointer:
+        parts.append(pointer)
+    parts.append(CWD_GROUNDING_INSTRUCTION.format(cwd=cwd))
+    parts.append(_context_pointers(intent_path=intent_path, alternatives_path=alternatives_path))
+    parts.append(
+        f"The full PR diff (base..HEAD) is at {diff_path}. Read it directly; "
+        "do NOT run `git diff` without a base ref -- on a clean branch that "
+        "returns empty and hides committed changes."
+    )
+    parts.append(
+        "Supervisor adjudication: review the canonical findings listed in "
+        f"{supervise_input_path}. This is an adjudication pass, not a fresh "
+        "review: do not invent findings or change their file, line, or id."
+    )
+    parts.append(
+        "Return one JSON object matching the structured-output schema with one "
+        "verdict per finding when possible. Each verdict must echo the canonical "
+        "id and choose exactly one action: allow, drop, edit, or hold. Explain "
+        "the decision in reason. For edit, revise only severity, confidence, "
+        "description, rationale, or evidence; never file, line, or id. Missing "
+        "verdicts are treated as allow by the host."
+    )
+    return "\n\n".join(parts)
+
+
 def build_suppression_prompt(
     *,
     suppression_input_path: Path,

--- a/daydream/deep/render.py
+++ b/daydream/deep/render.py
@@ -62,3 +62,11 @@ def render_report(items: list[dict[str, Any]]) -> str:
         sections.append(f"## Cross-Stack Issues\n{body}")
 
     return "\n\n".join(sections) + "\n"
+
+
+def render_held_section(held: list[dict[str, Any]]) -> str:
+    """Render findings withheld from the actionable report."""
+    if not held:
+        return ""
+    body = "\n".join(_finding_line(item) for item in held)
+    return f"## Held Findings\n{body}"

--- a/daydream/extensions/builtins.py
+++ b/daydream/extensions/builtins.py
@@ -47,6 +47,7 @@ def _register_builtin_prompts(registry: Registry) -> None:
     registry.override_prompt("structural", deep_prompts.build_structural_prompt)
     registry.override_prompt("generic-fallback", deep_prompts.build_generic_fallback_prompt)
     registry.override_prompt("arbiter", deep_prompts.build_arbiter_prompt)
+    registry.override_prompt("supervise", deep_prompts.build_supervise_prompt)
     registry.override_prompt("suppression", deep_prompts.build_suppression_prompt)
     registry.override_prompt("merge", deep_prompts.build_merge_prompt)
     registry.override_prompt("verify", deep_prompts.build_verification_prompt)

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -2851,7 +2851,7 @@ async def phase_per_stack_reviews(
         lines = "\n".join(f"  - {name}: {reason}" for name, reason in sorted(failures.items()))
         print_warning(
             console,
-            f"Per-stack reviews failed for {len(failures)} stack(s).\n"
+            f"Per-stack reviews failed for {len(failures)} stack(s); "
             "failures will be passed to the merge step.\n" + lines,
         )
 

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -2887,6 +2887,80 @@ ARBITER_SCHEMA: dict[str, Any] = {
 }
 
 
+SUPERVISE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "verdicts": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "integer"},
+                    "action": {"type": "string", "enum": ["allow", "drop", "edit", "hold"]},
+                    "reason": {"type": "string"},
+                    "severity": {"type": "string", "enum": ["high", "medium", "low"]},
+                    "confidence": {"type": "string", "enum": ["HIGH", "MEDIUM", "LOW"]},
+                    "description": {"type": "string"},
+                    "rationale": {"type": "string"},
+                    "evidence": {"type": "string"},
+                },
+                "required": ["id", "action", "reason"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["verdicts"],
+    "additionalProperties": False,
+}
+
+
+async def phase_supervise_review(
+    backend: Backend,
+    work: WorkContext,
+    *,
+    items: list[dict[str, Any]],
+    diff_path: Path,
+    intent_path: Path,
+    alternatives_path: Path,
+    exploration_dir: Path | None = None,
+) -> dict[int, dict[str, Any]]:
+    """Adjudicate canonical merged findings in one batched LLM call."""
+    from daydream.deep.artifacts import deep_dir
+
+    print_phase_hero(console, "SUPERVISE", phase_subtitle("SUPERVISE"))
+    print_dim(console, f"Model: {backend.model}")
+    print_info(console, f"Supervising {len(items)} merged finding(s)")
+
+    dd = deep_dir(work.repo)
+    input_path = dd / "supervise-input.json"
+    input_path.write_text(json.dumps(items, indent=2))
+    prompt = get_registry().prompt("supervise")(
+        supervise_input_path=input_path,
+        diff_path=diff_path,
+        intent_path=intent_path,
+        alternatives_path=alternatives_path,
+        cwd=work.repo,
+        exploration_dir=exploration_dir,
+    )
+    result, _, _ = await run_agent(
+        backend,
+        work.repo,
+        prompt,
+        output_schema=SUPERVISE_SCHEMA,
+        phase=DaydreamPhase.DEEP,
+    )
+    if not isinstance(result, dict) or not isinstance(result.get("verdicts"), list):
+        raise ValueError(f"Supervisor returned no verdicts list (got {type(result).__name__})")
+
+    item_ids = {item.get("id") for item in items if isinstance(item.get("id"), int)}
+    verdicts: dict[int, dict[str, Any]] = {}
+    for verdict in result["verdicts"]:
+        item_id = verdict.get("id")
+        if isinstance(item_id, int) and item_id in item_ids:
+            verdicts[item_id] = verdict
+    return verdicts
+
+
 async def phase_arbiter_review(
     backend: Backend,
     work: WorkContext,

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -2851,7 +2851,7 @@ async def phase_per_stack_reviews(
         lines = "\n".join(f"  - {name}: {reason}" for name, reason in sorted(failures.items()))
         print_warning(
             console,
-            f"Per-stack reviews failed for {len(failures)} stack(s); "
+            f"Per-stack reviews failed for {len(failures)} stack(s).\n"
             "failures will be passed to the merge step.\n" + lines,
         )
 
@@ -2898,13 +2898,26 @@ SUPERVISE_SCHEMA: dict[str, Any] = {
                     "id": {"type": "integer"},
                     "action": {"type": "string", "enum": ["allow", "drop", "edit", "hold"]},
                     "reason": {"type": "string"},
-                    "severity": {"type": "string", "enum": ["high", "medium", "low"]},
-                    "confidence": {"type": "string", "enum": ["HIGH", "MEDIUM", "LOW"]},
-                    "description": {"type": "string"},
-                    "rationale": {"type": "string"},
-                    "evidence": {"type": "string"},
+                    "severity": {
+                        "anyOf": [
+                            {"type": "string", "enum": ["high", "medium", "low"]},
+                            {"type": "null"},
+                        ]
+                    },
+                    "confidence": {
+                        "anyOf": [
+                            {"type": "string", "enum": ["HIGH", "MEDIUM", "LOW"]},
+                            {"type": "null"},
+                        ]
+                    },
+                    "description": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                    "rationale": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                    "evidence": {"anyOf": [{"type": "string"}, {"type": "null"}]},
                 },
-                "required": ["id", "action", "reason"],
+                "required": [
+                    "id", "action", "reason", "severity", "confidence", "description",
+                    "rationale", "evidence",
+                ],
                 "additionalProperties": False,
             },
         },
@@ -2957,7 +2970,11 @@ async def phase_supervise_review(
     for verdict in result["verdicts"]:
         item_id = verdict.get("id")
         if isinstance(item_id, int) and item_id in item_ids:
-            verdicts[item_id] = verdict
+            cleaned = dict(verdict)
+            for field in ("severity", "confidence", "description", "rationale", "evidence"):
+                if cleaned.get(field) is None:
+                    cleaned.pop(field, None)
+            verdicts[item_id] = cleaned
     return verdicts
 
 

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -536,7 +536,25 @@ async def run(config: RunConfig | None = None) -> int:
     # Build the per-run registry (builtins + optional daydream_ext) and set it
     # on the ContextVar so every downstream phase resolves through it.
     try:
-        set_registry(build_registry())
+        registry = build_registry()
+        file_config = _file_config_or_empty(config)
+        if file_config.tool_supervisor == "rules":
+            from daydream.supervision import RuleBasedToolSupervisor
+
+            try:
+                registry.register_tool_supervisor(
+                    RuleBasedToolSupervisor(
+                        deny_globs=file_config.supervisor_deny_globs,
+                        bash_deny=file_config.tool_bash_deny,
+                    )
+                )
+            except ExtensionError as exc:
+                raise ExtensionError(
+                    "tool supervisor conflict: config-enabled built-in "
+                    "RuleBasedToolSupervisor cannot coexist with an "
+                    f"extension-registered tool supervisor ({exc})"
+                ) from exc
+        set_registry(registry)
     except ExtensionError as exc:
         print_error(console, "Extension Error", str(exc))
         return 1

--- a/daydream/supervision.py
+++ b/daydream/supervision.py
@@ -68,8 +68,8 @@ def apply_findings_verdicts(
 def _matched_glob(path: str, deny_globs: tuple[str, ...]) -> str | None:
     normalized = path.replace("\\", "/").lstrip("/")
     parts = normalized.split("/")
-    candidates = ("/".join(parts[index:]) for index in range(len(parts)))
     for pattern in deny_globs:
+        candidates = ("/".join(parts[index:]) for index in range(len(parts)))
         if any(fnmatch.fnmatchcase(candidate, pattern) for candidate in candidates):
             return pattern
     return None

--- a/daydream/supervision.py
+++ b/daydream/supervision.py
@@ -13,9 +13,43 @@ _REVISABLE_FINDING_FIELDS = (
     "evidence",
 )
 
+FindingVerdictEvent = tuple[int, str, str]
+
 
 def revise_finding_fields(record: dict[str, Any], verdict: dict[str, Any]) -> None:
     """Apply only verdict fields that may revise a finding in place."""
     for field in _REVISABLE_FINDING_FIELDS:
         if field in verdict:
             record[field] = verdict[field]
+
+
+def apply_findings_verdicts(
+    items: list[dict[str, Any]],
+    verdicts: dict[int, dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[FindingVerdictEvent]]:
+    """Apply id-keyed findings verdicts in one fail-open pass."""
+    kept: list[dict[str, Any]] = []
+    held: list[dict[str, Any]] = []
+    events: list[FindingVerdictEvent] = []
+
+    for item in items:
+        item_id = item.get("id")
+        verdict = verdicts.get(item_id) if isinstance(item_id, int) else None
+        if verdict is None or verdict.get("id") != item_id:
+            kept.append(item)
+            continue
+
+        action = verdict.get("action")
+        if action == "drop":
+            events.append((item_id, action, str(verdict.get("reason", ""))))
+        elif action == "edit":
+            revise_finding_fields(item, verdict)
+            kept.append(item)
+            events.append((item_id, action, str(verdict.get("reason", ""))))
+        elif action == "hold":
+            held.append(item)
+            events.append((item_id, action, str(verdict.get("reason", ""))))
+        else:
+            kept.append(item)
+
+    return kept, held, events

--- a/daydream/supervision.py
+++ b/daydream/supervision.py
@@ -38,12 +38,18 @@ def apply_findings_verdicts(
 
     for item in items:
         item_id = item.get("id")
-        verdict = verdicts.get(item_id) if isinstance(item_id, int) else None
+        if not isinstance(item_id, int):
+            kept.append(item)
+            continue
+        verdict = verdicts.get(item_id)
         if verdict is None or verdict.get("id") != item_id:
             kept.append(item)
             continue
 
         action = verdict.get("action")
+        if not isinstance(action, str):
+            kept.append(item)
+            continue
         if action == "drop":
             events.append((item_id, action, str(verdict.get("reason", ""))))
         elif action == "edit":

--- a/daydream/supervision.py
+++ b/daydream/supervision.py
@@ -1,0 +1,21 @@
+"""Runtime findings and tool supervision helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+_REVISABLE_FINDING_FIELDS = (
+    "severity",
+    "confidence",
+    "description",
+    "rationale",
+    "evidence",
+)
+
+
+def revise_finding_fields(record: dict[str, Any], verdict: dict[str, Any]) -> None:
+    """Apply only verdict fields that may revise a finding in place."""
+    for field in _REVISABLE_FINDING_FIELDS:
+        if field in verdict:
+            record[field] = verdict[field]

--- a/daydream/supervision.py
+++ b/daydream/supervision.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import fnmatch
+import re
 from typing import Any
 
+from daydream.extensions import ToolDecision
+from daydream.trajectory import DaydreamPhase
 
 _REVISABLE_FINDING_FIELDS = (
     "severity",
@@ -53,3 +57,70 @@ def apply_findings_verdicts(
             kept.append(item)
 
     return kept, held, events
+
+
+def _matched_glob(path: str, deny_globs: tuple[str, ...]) -> str | None:
+    normalized = path.replace("\\", "/").lstrip("/")
+    parts = normalized.split("/")
+    candidates = ("/".join(parts[index:]) for index in range(len(parts)))
+    for pattern in deny_globs:
+        if any(fnmatch.fnmatchcase(candidate, pattern) for candidate in candidates):
+            return pattern
+    return None
+
+
+class RuleBasedSupervisor:
+    """Apply deny-glob rules to canonical findings."""
+
+    def __init__(self, *, deny_globs: list[str]) -> None:
+        self._deny_globs = tuple(deny_globs)
+
+    def review_findings(self, items: list[dict[str, Any]]) -> dict[int, dict[str, Any]]:
+        """Return drop verdicts for findings whose files match a deny glob."""
+        verdicts: dict[int, dict[str, Any]] = {}
+        for item in items:
+            item_id = item.get("id")
+            file_path = item.get("file")
+            if not isinstance(item_id, int) or not isinstance(file_path, str):
+                continue
+            matched = _matched_glob(file_path, self._deny_globs)
+            if matched is not None:
+                verdicts[item_id] = {
+                    "id": item_id,
+                    "action": "drop",
+                    "reason": f"denied by glob '{matched}'",
+                }
+        return verdicts
+
+
+class RuleBasedToolSupervisor:
+    """Veto denied file writes/edits and Bash commands."""
+
+    def __init__(self, *, deny_globs: list[str], bash_deny: list[str]) -> None:
+        self._deny_globs = tuple(deny_globs)
+        self._bash_deny = tuple(re.compile(pattern) for pattern in bash_deny)
+
+    def __call__(
+        self,
+        tool_name: str,
+        tool_input: dict[str, Any],
+        *,
+        phase: DaydreamPhase,
+    ) -> ToolDecision:
+        del phase
+        if tool_name in {"Write", "Edit"}:
+            path = tool_input.get("file_path") or tool_input.get("path")
+            if isinstance(path, str):
+                matched = _matched_glob(path, self._deny_globs)
+                if matched is not None:
+                    return ToolDecision(veto=True, reason=f"denied by glob '{matched}'")
+        elif tool_name == "Bash":
+            command = tool_input.get("command")
+            if isinstance(command, str):
+                for pattern in self._bash_deny:
+                    if pattern.search(command):
+                        return ToolDecision(
+                            veto=True,
+                            reason=f"Bash command denied by regex '{pattern.pattern}'",
+                        )
+        return ToolDecision(veto=False)

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -1029,6 +1029,34 @@ class TrajectoryRecorder:
             )
         )
 
+    def emit_supervisor_verdict(self, finding_id: int, action: str, reason: str) -> None:
+        """Record a findings supervisor verdict in the deep phase."""
+        self._phase_events.append(
+            PhaseEvent(
+                phase=DaydreamPhase.DEEP,
+                event="supervisor_verdict",
+                timestamp=now_iso(),
+                metadata={
+                    "finding_id": finding_id,
+                    "action": action,
+                    "reason": reason,
+                },
+            )
+        )
+
+    def emit_tool_veto(
+        self, tool_name: str, reason: str, *, phase: DaydreamPhase = DaydreamPhase.FIX
+    ) -> None:
+        """Record a tool-supervisor veto in the firing phase."""
+        self._phase_events.append(
+            PhaseEvent(
+                phase=phase,
+                event="tool_veto",
+                timestamp=now_iso(),
+                metadata={"tool_name": tool_name, "reason": reason},
+            )
+        )
+
     def _register_subtrajectory(self, inv: Invocation) -> None:
         """Register a per-Invocation timing summary (issue #203).
 

--- a/daydream/workspace.py
+++ b/daydream/workspace.py
@@ -291,7 +291,7 @@ def _resolve_ref(source: Path, branch: str | None) -> str:
         print_warning(
             console,
             f"{branch} is checked out in cwd and is {ahead} commits behind "
-            f"origin/{branch} — reviewing origin/{branch}.",
+            f"origin/{branch}.\nreviewing origin/{branch}.",
         )
 
     return f"origin/{branch}"

--- a/daydream/workspace.py
+++ b/daydream/workspace.py
@@ -291,7 +291,7 @@ def _resolve_ref(source: Path, branch: str | None) -> str:
         print_warning(
             console,
             f"{branch} is checked out in cwd and is {ahead} commits behind "
-            f"origin/{branch}.\nreviewing origin/{branch}.",
+            f"origin/{branch} — reviewing origin/{branch}.",
         )
 
     return f"origin/{branch}"

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -142,7 +142,44 @@ being treated as a backend retry.
 registration or a non-callable value raises `ExtensionError`. If an extension
 does not register a supervisor, tool supervision is a no-op. Supervision runs
 when `run_agent` receives the backend's `ToolStartEvent`; it does not change
-backend-specific dispatch timing or add an earlier backend hook.
+backend-specific dispatch timing or add an earlier backend hook. The built-in
+rule supervisor uses this same turn-level enforcement point; it cannot intercept
+a tool before the backend emits its start event.
+
+### Built-in supervisor configuration
+
+The built-in findings supervisor is disabled by default. Set
+`supervisor = "rules"` to drop findings whose repository-relative `file` matches
+one of `supervisor_deny_globs`, or set `supervisor = "llm"` for one batched
+adjudication call. The LLM call uses the model configured at
+`[tool.daydream.phases.supervise]` (or `[phases.supervise]` in `.daydream.toml`)
+and defaults to the Sonnet tier for supported backends.
+
+```toml
+supervisor = "rules"
+supervisor_deny_globs = ["vendor/**", "generated/**"]
+tool_supervisor = "rules"
+tool_bash_deny = ["rm -rf", "git push --force"]
+
+[phases.supervise]
+model = "claude-sonnet-4-6"
+```
+
+The built-in tool supervisor applies the shared file globs to `Write` and
+`Edit`, and applies `tool_bash_deny` as regular expressions to `Bash` commands.
+Claude's always-on dangerous-command guard remains active; this configuration
+adds rules and does not replace it.
+
+Supervisor actions are `allow`, `drop`, `edit`, and `hold`. A held finding is
+removed from the actionable `items` list and stored under the top-level `held`
+key in `merged-items.json`; the rendered report keeps it under **Held Findings**.
+All downstream readers continue to consume `items`, so held findings do not
+reach findings artifacts, PR posts, or fix prompts.
+
+Only one tool supervisor may be registered per run. If an extension registers a
+tool supervisor while `tool_supervisor = "rules"` enables the built-in one, the
+run fails at registry construction with a conflict error. Choose the extension
+policy or the built-in policy.
 
 ## Inventories
 
@@ -272,7 +309,7 @@ every other key is internal and may change without a version bump:
 | `exploration_dir` | Exploration pre-scan output directory (or None) |
 | `intent_path` | Path to the intent-analysis output |
 | `alts_path` | Path to the alternatives-review output |
-| `items_file` | `Path` published after `load-items`; it contains canonical `{"items": [...]}` JSON. An extension may read this file and rewrite its `items` before downstream consumers run. |
+| `items_file` | `Path` published after `load-items`; it contains canonical `{"items": [...]}` JSON and may include top-level `held`. An extension may read this file and rewrite its `items` before downstream consumers run. |
 | `items` | Parsed finding items, populated by `fix-gate` from the (potentially rewritten) `items_file`. Not present before `fix-gate` runs; rewriting `items_file` before that step is sufficient to affect all consumers. |
 
 ## Recipes

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -362,6 +362,16 @@ def register(r):
 The inserted step runs before `findings-out`, `post-review`, and the fix
 consumers, so their reads observe the rewritten canonical JSON.
 
+> **Note — preserve `payload` when inserting after `supervise`.**  The
+> recipe above anchors at `load-items`, where `items_file` contains only
+> `{"items": [...]}`.  If you move the anchor to after `supervise`, the
+> file will already contain a top-level `held` key (items withheld by the
+> supervisor).  Rewriting the file as a fresh `{"items": filtered}` dict at
+> that point silently drops the held list.  Always round-trip through the
+> full payload dict as shown — `payload = json.loads(...); payload["items"]
+> = ...; write_text(json.dumps(payload))` — so any keys the runtime wrote
+> are preserved.
+
 ### Disable a phase
 
 ```python

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -174,13 +174,14 @@ an existing config key.
 | 7 | `cross-stack-merge` | `merge` |
 | 8 | `single-stack-merge` | `single-stack-merge` |
 | 9 | `load-items` | `load-items` |
-| 10 | `findings-out` | `findings-out` |
-| 11 | `post-review` | `post-review` |
-| 12 | `fix-gate` | `fix-gate` |
-| 13 | `verify` | `verify` |
-| 14 | `fix` | `fix` |
-| 15 | `test` | `test` |
-| 16 | `commit` | `fix` |
+| 10 | `supervise` | `supervise` |
+| 11 | `findings-out` | `findings-out` |
+| 12 | `post-review` | `post-review` |
+| 13 | `fix-gate` | `fix-gate` |
+| 14 | `verify` | `verify` |
+| 15 | `fix` | `fix` |
+| 16 | `test` | `test` |
+| 17 | `commit` | `fix` |
 
 #### `shallow` (`--shallow` single-skill loop)
 
@@ -239,7 +240,7 @@ reads its own `phase:<name>` slot).
 
 ### Prompts
 
-The 11 registered prompt names and the exact kwargs their builders receive
+The 12 registered prompt names and the exact kwargs their builders receive
 (an override gets the same kwargs). All kwargs are keyword-only except where
 noted.
 
@@ -253,6 +254,7 @@ noted.
 | `structural` | `skill_invocation`, `files`, `diff_path`, `intent_path`, `alternatives_path`, `output_path`, `cwd`, `exploration_dir`, `prior_commits` |
 | `generic-fallback` | `files`, `diff_path`, `intent_path`, `alternatives_path`, `output_path`, `cwd`, `exploration_dir`, `is_docs_only`, `prior_commits`, `inline_diff` |
 | `arbiter` | `arbiter_input_path`, `diff_path`, `intent_path`, `alternatives_path`, `cwd`, `exploration_dir` |
+| `supervise` | `supervise_input_path`, `diff_path`, `intent_path`, `alternatives_path`, `cwd`, `exploration_dir` |
 | `suppression` | `suppression_input_path`, `diff_path`, `intent_path`, `alternatives_path`, `cwd`, `exploration_dir` |
 | `merge` | `per_stack_records_paths`, `intent_path`, `alternatives_path`, `dedup_candidates_path`, `output_path`, `exploration_dir`, `failed_stacks`, `structural_records_path` |
 | `verify` | `items`, `cwd`, `output_path` |

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,7 +7,7 @@ from daydream.config import (
 )
 
 PHASE_NAMES = {
-    "review", "per_stack_review", "arbiter", "suppression", "parse", "fix", "test", "verify",
+    "review", "per_stack_review", "arbiter", "suppression", "supervise", "parse", "fix", "test", "verify",
     "exploration", "intent", "wonder", "merge", "pr_feedback",
 }
 

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -63,6 +63,38 @@ def test_precision_mode_non_bool_degrades_to_none(tmp_path: Path) -> None:
     assert cfg.precision_mode is None
 
 
+def test_supervision_config_parses_all_keys(tmp_path: Path) -> None:
+    (tmp_path / ".daydream.toml").write_text(
+        'supervisor = "rules"\n'
+        'supervisor_deny_globs = ["vendor/**"]\n'
+        'tool_supervisor = "rules"\n'
+        'tool_bash_deny = ["rm -rf"]\n'
+    )
+
+    cfg = load_file_config(tmp_path)
+
+    assert cfg.supervisor == "rules"
+    assert cfg.supervisor_deny_globs == ["vendor/**"]
+    assert cfg.tool_supervisor == "rules"
+    assert cfg.tool_bash_deny == ["rm -rf"]
+
+
+def test_supervision_config_bad_values_degrade_to_unset(tmp_path: Path) -> None:
+    (tmp_path / ".daydream.toml").write_text(
+        'supervisor = "unknown"\n'
+        "supervisor_deny_globs = [1]\n"
+        'tool_supervisor = "unknown"\n'
+        "tool_bash_deny = [1]\n"
+    )
+
+    cfg = load_file_config(tmp_path)
+
+    assert cfg.supervisor is None
+    assert cfg.supervisor_deny_globs == []
+    assert cfg.tool_supervisor is None
+    assert cfg.tool_bash_deny == []
+
+
 def test_empty_config_helper() -> None:
     cfg = DaydreamFileConfig()
     assert cfg.model is None and cfg.backend is None

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -78,6 +78,8 @@ class _StubBackend:
         self.merge_items: list[dict[str, Any]] | None = None
         # Optional LLM supervisor verdicts keyed by canonical item id.
         self.supervise_verdicts: dict[int, dict[str, Any]] | None = None
+        # Optional deferred Write tool pairs for the built-in tool-supervisor tests.
+        self.deferred_write_pairs: list[str] | None = None
         # When set, the fix branch appends the prompt's marker token to this file
         # via read-modify-write with an anyio.sleep(0) interleave point -- a
         # per-ITEM fan-out would lose/reorder appends; correct per-file
@@ -497,6 +499,18 @@ class _StubBackend:
                 raise MaxTurnsError(f"stub: max turns exhausted mid-fix for {fixed_name}")
             if self.fix_fail_file is not None and fixed_name == self.fix_fail_file:
                 raise RuntimeError(f"stub fix failure for {fixed_name}")
+            if self.deferred_write_pairs is not None:
+                for index, path in enumerate(self.deferred_write_pairs, start=1):
+                    edit_target = Path(path) if Path(path).is_absolute() else cwd / path
+                    yield ToolStartEvent(
+                        id=f"deferred-write-{index}",
+                        name="Write",
+                        input={"file_path": str(edit_target), "content": "backend resumed"},
+                    )
+                    edit_target.write_text("backend resumed")
+                yield TextEvent(text="Applied the deferred writes.")
+                yield ResultEvent(structured_output=None, continuation=None)
+                return
             (cwd / ".daydream-fix-applied").write_text("applied\n")  # legacy sentinel
             (cwd / f".fixed-{fixed_name.replace('.', '_')}").write_text("applied\n")
             if self.fix_edit_line is not None:
@@ -1336,6 +1350,147 @@ def _fix_prompts(stub: _StubBackend) -> list[str]:
     # Same-file findings are batched into one "Fix these N issues" turn; a lone
     # finding still uses the single-finding "Fix this issue" prompt. Match both.
     return [c["prompt"] for c in stub.calls if c["prompt"].startswith(("Fix this issue", "Fix these"))]
+
+
+async def test_fix_tool_veto_blocks_denied_write(
+    multi_stack_target: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Built-in rules veto a deferred denied Write and record the abort/event."""
+    from daydream.config_file import load_file_config
+    from daydream.runner import RunConfig, run
+
+    _silence(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    stub.merge_items = [_merge_item(1, "api.py", "high", desc="protected write")]
+    stub.deferred_write_pairs = ["api.py"]
+    (multi_stack_target / ".daydream.toml").write_text(
+        'tool_supervisor = "rules"\nsupervisor_deny_globs = ["api.py"]\n'
+    )
+    async def _no_post(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _no_post)
+    source_before = (multi_stack_target / "api.py").read_bytes()
+    traj = tmp_path / "trajectory.json"
+
+    rc = await run(
+        RunConfig(
+            target=str(multi_stack_target),
+            assume="yes",
+            output_mode="loop",
+            cleanup=False,
+            file_config=load_file_config(multi_stack_target),
+            trajectory_path=traj,
+        )
+    )
+
+    assert isinstance(rc, int)
+    assert (multi_stack_target / "api.py").read_bytes() == source_before
+    stop_reasons = _scan_trajectory_extra(multi_stack_target / ".daydream", traj, "stop_reason")
+    assert "tool_vetoed:Write" in stop_reasons
+    events = _scan_phase_events(multi_stack_target / ".daydream", traj, "tool_veto")
+    assert any(event.get("metadata", {}).get("tool_name") == "Write" for event in events)
+
+
+async def test_fix_tool_veto_allows_unmatched_write(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Built-in rules allow a Write whose path does not match the deny glob."""
+    from daydream.config_file import load_file_config
+    from daydream.runner import RunConfig, run
+
+    _silence(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    stub.merge_items = [_merge_item(1, "App.tsx", "high", desc="allowed write")]
+    stub.deferred_write_pairs = ["App.tsx"]
+    (multi_stack_target / ".daydream.toml").write_text(
+        'tool_supervisor = "rules"\nsupervisor_deny_globs = ["api.py"]\n'
+    )
+    async def _no_post(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _no_post)
+
+    rc = await run(
+        RunConfig(
+            target=str(multi_stack_target),
+            assume="yes",
+            output_mode="loop",
+            cleanup=False,
+            file_config=load_file_config(multi_stack_target),
+        )
+    )
+
+    assert isinstance(rc, int)
+    assert (multi_stack_target / "App.tsx").read_text() == "backend resumed"
+    assert not _scan_trajectory_extra(multi_stack_target / ".daydream", Path("/missing"), "stop_reason")
+
+
+async def test_fix_tool_veto_stops_subsequent_calls(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A vetoed first deferred Write prevents the generator's later Write."""
+    from daydream.config_file import load_file_config
+    from daydream.runner import RunConfig, run
+
+    _silence(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    stub.merge_items = [_merge_item(1, "api.py", "high", desc="first"), _merge_item(2, "App.tsx", "low", desc="second")]
+    stub.deferred_write_pairs = ["api.py", "App.tsx"]
+    (multi_stack_target / ".daydream.toml").write_text(
+        'tool_supervisor = "rules"\nsupervisor_deny_globs = ["api.py"]\n'
+    )
+    async def _no_post(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _no_post)
+    api_before = (multi_stack_target / "api.py").read_bytes()
+    app_before = (multi_stack_target / "App.tsx").read_bytes()
+
+    rc = await run(
+        RunConfig(
+            target=str(multi_stack_target),
+            assume="yes",
+            output_mode="loop",
+            cleanup=False,
+            file_config=load_file_config(multi_stack_target),
+        )
+    )
+
+    assert isinstance(rc, int)
+    assert (multi_stack_target / "api.py").read_bytes() == api_before
+    assert (multi_stack_target / "App.tsx").read_bytes() == app_before
+
+
+async def test_fix_tool_supervisor_off_writes(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With tool supervision off, the deferred Write resumes and writes."""
+    from daydream.config_file import load_file_config
+    from daydream.runner import RunConfig, run
+
+    _silence(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    stub.merge_items = [_merge_item(1, "api.py", "high", desc="unprotected write")]
+    stub.deferred_write_pairs = ["api.py"]
+    (multi_stack_target / ".daydream.toml").write_text('tool_supervisor = "off"\n')
+    async def _no_post(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _no_post)
+
+    rc = await run(
+        RunConfig(
+            target=str(multi_stack_target),
+            assume="yes",
+            output_mode="loop",
+            cleanup=False,
+            file_config=load_file_config(multi_stack_target),
+        )
+    )
+
+    assert isinstance(rc, int)
+    assert (multi_stack_target / "api.py").read_text() == "backend resumed"
 
 
 async def test_confirmed_intent_reaches_fix_prompt(

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -76,6 +76,8 @@ class _StubBackend:
         self.fail_first_test_run: bool = False
         # Override for the merge agent's item list (None -> default three-item payload).
         self.merge_items: list[dict[str, Any]] | None = None
+        # Optional LLM supervisor verdicts keyed by canonical item id.
+        self.supervise_verdicts: dict[int, dict[str, Any]] | None = None
         # When set, the fix branch appends the prompt's marker token to this file
         # via read-modify-write with an anyio.sleep(0) interleave point -- a
         # per-ITEM fan-out would lose/reorder appends; correct per-file
@@ -433,6 +435,18 @@ class _StubBackend:
             )
             return
 
+        if "supervisor adjudication" in pl:
+            in_match = re.search(r"listed in (\S+supervise-input\.json)", prompt)
+            input_items = json.loads(Path(in_match.group(1)).read_text()) if in_match else []
+            verdicts = []
+            for item in input_items:
+                verdict = (self.supervise_verdicts or {}).get(item["id"])
+                if verdict is not None:
+                    verdicts.append({"id": item["id"], **verdict})
+            yield TextEvent(text="")
+            yield ResultEvent(structured_output={"verdicts": verdicts}, continuation=None)
+            return
+
         # phase_fix -> "apply" the edit by writing a sentinel file, the observable
         # consequence the --yes real-path test asserts the fix gate auto-approved.
         if pl.startswith("fix this issue") or pl.startswith("fix these"):
@@ -686,6 +700,339 @@ def _merge_item(item_id: int, file: str, severity: str, *, desc: str | None = No
         "rationale": "rationale",
         "evidence": f"{file}:1",
     }
+
+
+def _pin_findings_pr(monkeypatch: pytest.MonkeyPatch, target: Path) -> None:
+    """Provide the PR metadata required by the findings-out artifact."""
+    from daydream import git_ops
+    from daydream.pr_review import PRInfo
+
+    head = git_ops.head_sha(target)
+    base = subprocess.run(  # noqa: S603 - arguments are not user-controlled
+        ["git", "rev-parse", "main"],  # noqa: S607 - git is a trusted command
+        cwd=target,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    pr = PRInfo(
+        number=7,
+        head_sha=head,
+        base_sha=base,
+        base_ref="main",
+        owner="o",
+        repo="r",
+        url="https://example.invalid/pr/7",
+    )
+    monkeypatch.setattr("daydream.pr_review.find_pr_by_number", lambda target_dir, n: pr)
+
+
+async def test_supervise_rules_drops_deny_globbed_finding(
+    multi_stack_target: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Rule supervision rewrites the canonical items before findings-out."""
+    from daydream.config_file import load_file_config
+    from daydream.runner import RunConfig, run
+
+    _silence(monkeypatch)
+    _pin_findings_pr(monkeypatch, multi_stack_target)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    stub.merge_items = [
+        _merge_item(1, "vendor/generated.py", "high", desc="drop this finding"),
+        _merge_item(2, "src/app.py", "low", desc="keep this finding"),
+    ]
+    (multi_stack_target / ".daydream.toml").write_text(
+        'supervisor = "rules"\nsupervisor_deny_globs = ["vendor/**"]\n'
+    )
+    out = multi_stack_target / "findings.json"
+    traj = tmp_path / "trajectory.json"
+
+    async def _post_forbidden(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("findings-out must not post to the PR")
+
+    monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _post_forbidden)
+    rc = await run(
+        RunConfig(
+            target=str(multi_stack_target),
+            pr_number=7,
+            findings_out=str(out),
+            start_at="review",
+            cleanup=False,
+            non_interactive=True,
+            file_config=load_file_config(multi_stack_target),
+            trajectory_path=traj,
+        )
+    )
+
+    assert rc == 0
+    items = json.loads((multi_stack_target / ".daydream" / "deep" / "merged-items.json").read_text())
+    descriptions = [item["description"] for item in items["items"]]
+    assert "drop this finding" not in descriptions
+    assert "keep this finding" in descriptions
+    findings = json.loads(out.read_text())["findings"]
+    finding_descriptions = [finding["title"] for finding in findings]
+    assert "drop this finding" not in finding_descriptions
+    assert "keep this finding" in finding_descriptions
+    events = _scan_phase_events(multi_stack_target / ".daydream", traj, "supervisor_verdict")
+    assert any(
+        event.get("metadata", {}).get("finding_id") == 1
+        and event.get("metadata", {}).get("action") == "drop"
+        for event in events
+    )
+
+
+async def test_supervise_hold_excluded_but_rendered(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Held findings leave the actionable items but remain visible in the report."""
+    from daydream.config_file import load_file_config
+    from daydream.runner import RunConfig, run
+
+    _silence(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    stub.merge_items = [
+        _merge_item(1, "vendor/generated.py", "high", desc="hold this finding"),
+        _merge_item(2, "src/app.py", "low", desc="keep this finding"),
+    ]
+    stub.supervise_verdicts = {
+        1: {"action": "hold", "reason": "needs human review"},
+        2: {"action": "allow", "reason": "confirmed"},
+    }
+    (multi_stack_target / ".daydream.toml").write_text(
+        'supervisor = "llm"\n'
+    )
+    async def _no_post(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _no_post)
+
+    rc = await run(
+        RunConfig(
+            target=str(multi_stack_target),
+            cleanup=False,
+            non_interactive=True,
+            file_config=load_file_config(multi_stack_target),
+        )
+    )
+
+    assert rc == 0
+    payload = json.loads((multi_stack_target / ".daydream" / "deep" / "merged-items.json").read_text())
+    actionable = [item["description"] for item in payload["items"]]
+    held = [item["description"] for item in payload["held"]]
+    assert "keep this finding" in actionable
+    assert "hold this finding" in held
+    report = (multi_stack_target / ".review-output.md").read_text()
+    assert "Held Findings" in report
+    assert "hold this finding" in report
+
+
+async def test_supervise_llm_drop_records_step(
+    multi_stack_target: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """LLM supervision drops by canonical id and records its deep stage."""
+    from daydream.config_file import load_file_config
+    from daydream.runner import RunConfig, run
+
+    _silence(monkeypatch)
+    _pin_findings_pr(monkeypatch, multi_stack_target)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    stub.merge_items = [
+        _merge_item(1, "api.py", "high", desc="drop by llm"),
+        _merge_item(2, "App.tsx", "low", desc="keep by llm"),
+    ]
+    stub.supervise_verdicts = {
+        1: {"action": "drop", "reason": "duplicate"},
+        2: {"action": "allow", "reason": "confirmed"},
+    }
+    (multi_stack_target / ".daydream.toml").write_text('supervisor = "llm"\n')
+    out = multi_stack_target / "findings.json"
+    traj = tmp_path / "trajectory.json"
+    async def _post_forbidden(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("findings-out must not post to the PR")
+
+    monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _post_forbidden)
+    rc = await run(
+        RunConfig(
+            target=str(multi_stack_target),
+            pr_number=7,
+            findings_out=str(out),
+            cleanup=False,
+            non_interactive=True,
+            file_config=load_file_config(multi_stack_target),
+            trajectory_path=traj,
+        )
+    )
+
+    assert rc == 0
+    items = json.loads((multi_stack_target / ".daydream" / "deep" / "merged-items.json").read_text())
+    descriptions = [item["description"] for item in items["items"]]
+    assert "drop by llm" not in descriptions
+    assert "keep by llm" in descriptions
+    starts = _scan_phase_events(multi_stack_target / ".daydream", traj, "phase_start")
+    assert any(event.get("metadata", {}).get("stage") == "supervise" for event in starts)
+
+
+async def test_supervise_llm_edit_revises_severity(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """LLM edit verdicts revise severity in canonical items and findings-out."""
+    from daydream.config_file import load_file_config
+    from daydream.runner import RunConfig, run
+
+    _silence(monkeypatch)
+    _pin_findings_pr(monkeypatch, multi_stack_target)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    stub.merge_items = [_merge_item(1, "api.py", "high", desc="downgrade me")]
+    stub.supervise_verdicts = {
+        1: {"action": "edit", "reason": "less severe", "severity": "low"},
+    }
+    (multi_stack_target / ".daydream.toml").write_text('supervisor = "llm"\n')
+    out = multi_stack_target / "findings.json"
+    async def _no_post(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _no_post)
+
+    rc = await run(
+        RunConfig(
+            target=str(multi_stack_target),
+            pr_number=7,
+            findings_out=str(out),
+            cleanup=False,
+            non_interactive=True,
+            file_config=load_file_config(multi_stack_target),
+        )
+    )
+
+    assert rc == 0
+    payload = json.loads((multi_stack_target / ".daydream" / "deep" / "merged-items.json").read_text())
+    revised = next(item for item in payload["items"] if item["description"] == "downgrade me")
+    assert revised["severity"] == "low"
+    findings = json.loads(out.read_text())["findings"]
+    assert any(finding["title"] == "downgrade me" and finding["severity"] == "low" for finding in findings)
+
+
+async def test_supervise_drop_all_writes_empty_artifact_exit_zero(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """All findings may be dropped while findings-out still writes an empty artifact."""
+    from daydream.config_file import load_file_config
+    from daydream.runner import RunConfig, run
+
+    _silence(monkeypatch)
+    _pin_findings_pr(monkeypatch, multi_stack_target)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    stub.merge_items = [_merge_item(1, "api.py", "high", desc="drop everything")]
+    (multi_stack_target / ".daydream.toml").write_text(
+        'supervisor = "rules"\nsupervisor_deny_globs = ["**"]\n'
+    )
+    out = multi_stack_target / "findings.json"
+    async def _no_post(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _no_post)
+
+    rc = await run(
+        RunConfig(
+            target=str(multi_stack_target),
+            pr_number=7,
+            findings_out=str(out),
+            cleanup=False,
+            non_interactive=True,
+            file_config=load_file_config(multi_stack_target),
+        )
+    )
+
+    assert rc == 0
+    assert json.loads(out.read_text())["findings"] == []
+
+
+async def test_supervise_off_byte_identical(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No config and explicit off produce the same canonical items bytes."""
+    from daydream.config_file import load_file_config
+    from daydream.runner import RunConfig, run
+
+    _silence(monkeypatch)
+    _pin_findings_pr(monkeypatch, multi_stack_target)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    stub.merge_items = [
+        _merge_item(1, "api.py", "high", desc="first finding"),
+        _merge_item(2, "App.tsx", "low", desc="second finding"),
+    ]
+    monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", lambda *_a, **_k: None)
+    out = multi_stack_target / "findings.json"
+
+    empty_config = load_file_config(multi_stack_target)
+    first_rc = await run(
+        RunConfig(
+            target=str(multi_stack_target),
+            pr_number=7,
+            findings_out=str(out),
+            cleanup=False,
+            non_interactive=True,
+            file_config=empty_config,
+        )
+    )
+    first_items = (multi_stack_target / ".daydream" / "deep" / "merged-items.json").read_bytes()
+    first_findings = json.loads(out.read_text())["findings"]
+
+    (multi_stack_target / ".daydream.toml").write_text('supervisor = "off"\n')
+    second_rc = await run(
+        RunConfig(
+            target=str(multi_stack_target),
+            pr_number=7,
+            findings_out=str(out),
+            cleanup=False,
+            non_interactive=True,
+            file_config=load_file_config(multi_stack_target),
+        )
+    )
+    second_items = (multi_stack_target / ".daydream" / "deep" / "merged-items.json").read_bytes()
+    second_findings = json.loads(out.read_text())["findings"]
+
+    assert first_rc == second_rc == 0
+    assert first_items == second_items
+    assert first_findings == second_findings
+
+
+async def test_supervise_dropped_finding_never_reaches_fix(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A dropped finding is absent from the real fix prompt and remains unmodified."""
+    from daydream.config_file import load_file_config
+    from daydream.runner import RunConfig, run
+
+    _silence(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    stub.merge_items = [
+        _merge_item(1, "api.py", "high", desc="drop before fix"),
+        _merge_item(2, "App.tsx", "low", desc="fix this survivor"),
+    ]
+    (multi_stack_target / ".daydream.toml").write_text(
+        'supervisor = "rules"\nsupervisor_deny_globs = ["api.py"]\n'
+    )
+    async def _no_post(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _no_post)
+    source_before = (multi_stack_target / "api.py").read_bytes()
+
+    rc = await run(
+        RunConfig(
+            target=str(multi_stack_target),
+            assume="yes",
+            output_mode="loop",
+            cleanup=False,
+            file_config=load_file_config(multi_stack_target),
+        )
+    )
+
+    assert rc == 0
+    assert (multi_stack_target / "api.py").read_bytes() == source_before
+    prompts = "\n".join(_fix_prompts(stub))
+    assert "drop before fix" not in prompts
 
 
 async def _ok(*_a: Any, **_k: Any) -> tuple[bool, int]:

--- a/tests/test_extension_seam_integration.py
+++ b/tests/test_extension_seam_integration.py
@@ -652,6 +652,43 @@ async def _run_tool_case(
     return written, trajectory, rc
 
 
+async def test_builtin_and_fork_tool_supervisor_conflict_fails_loud(
+    ext_dir: ExtDir,
+    multi_stack_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Config-enabled built-in and fork supervisors cannot silently compose."""
+    from daydream.config_file import load_file_config
+
+    ext_dir.write_module(
+        "from daydream.extensions import ToolDecision\n"
+        "DAYDREAM_EXT_API = 2\n"
+        "def _fork_supervisor(name, tool_input, *, phase):\n"
+        "    return ToolDecision(veto=False)\n"
+        "def register(r):\n"
+        "    r.register_tool_supervisor(_fork_supervisor)\n"
+    )
+    (multi_stack_target / ".daydream.toml").write_text('tool_supervisor = "rules"\n')
+    monkeypatch.delenv("DAYDREAM_APP_ID", raising=False)
+    monkeypatch.delenv("DAYDREAM_APP_PRIVATE_KEY", raising=False)
+
+    rc = await runner.run(
+        runner.RunConfig(
+            target=str(multi_stack_target),
+            non_interactive=True,
+            cleanup=False,
+            file_config=load_file_config(multi_stack_target),
+        )
+    )
+
+    assert rc == 1
+    output = capsys.readouterr().out.lower()
+    assert "tool supervisor conflict" in output
+    assert "config-enabled built-in" in output
+    assert "extension-registered" in output
+
+
 async def test_fork_tool_supervisor_vetoes_write(
     ext_dir: ExtDir, multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_supervision.py
+++ b/tests/test_supervision.py
@@ -1,0 +1,30 @@
+"""Tests for runtime findings and tool supervision."""
+
+from __future__ import annotations
+
+from daydream.supervision import revise_finding_fields
+
+
+def test_revise_finding_fields_updates_whitelist_only() -> None:
+    item = {
+        "id": 7,
+        "severity": "high",
+        "confidence": "medium",
+        "description": "original",
+        "rationale": "because",
+        "evidence": ["line 1"],
+        "file": "safe.py",
+        "line": 12,
+    }
+    item_id = id(item)
+
+    revise_finding_fields(
+        item,
+        {"severity": "low", "file": "hacked.py", "line": 999, "reason": "x"},
+    )
+
+    assert id(item) == item_id
+    assert item["severity"] == "low"
+    assert item["file"] == "safe.py"
+    assert item["line"] == 12
+    assert item["id"] == 7

--- a/tests/test_supervision.py
+++ b/tests/test_supervision.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from daydream.supervision import revise_finding_fields
+from daydream.supervision import apply_findings_verdicts, revise_finding_fields
 
 
 def test_revise_finding_fields_updates_whitelist_only() -> None:
@@ -28,3 +28,33 @@ def test_revise_finding_fields_updates_whitelist_only() -> None:
     assert item["file"] == "safe.py"
     assert item["line"] == 12
     assert item["id"] == 7
+
+
+def test_apply_findings_verdicts_handles_actions_and_fails_open() -> None:
+    items = [
+        {"id": 1, "description": "allowed", "severity": "low"},
+        {"id": 2, "description": "duplicate", "severity": "medium"},
+        {"id": 3, "description": "needs edit", "severity": "high"},
+        {"id": 4, "description": "held", "severity": "low"},
+        {"id": 5, "description": "missing verdict", "severity": "medium"},
+    ]
+
+    kept, held, events = apply_findings_verdicts(
+        items,
+        {
+            1: {"id": 1, "action": "allow", "reason": "confirmed"},
+            2: {"id": 2, "action": "drop", "reason": "dup"},
+            3: {"id": 3, "action": "edit", "reason": "more precise", "severity": "low"},
+            4: {"id": 4, "action": "hold", "reason": "needs review"},
+            99: {"id": 99, "action": "drop", "reason": "unknown"},
+        },
+    )
+
+    assert [item["id"] for item in kept] == [1, 3, 5]
+    assert [item["id"] for item in held] == [4]
+    assert kept[1]["severity"] == "low"
+    assert events == [
+        (2, "drop", "dup"),
+        (3, "edit", "more precise"),
+        (4, "hold", "needs review"),
+    ]

--- a/tests/test_supervision.py
+++ b/tests/test_supervision.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-from daydream.supervision import apply_findings_verdicts, revise_finding_fields
+from daydream.extensions import ToolDecision
+from daydream.supervision import (
+    RuleBasedSupervisor,
+    RuleBasedToolSupervisor,
+    apply_findings_verdicts,
+    revise_finding_fields,
+)
+from daydream.trajectory import DaydreamPhase
 
 
 def test_revise_finding_fields_updates_whitelist_only() -> None:
@@ -58,3 +65,52 @@ def test_apply_findings_verdicts_handles_actions_and_fails_open() -> None:
         (3, "edit", "more precise"),
         (4, "hold", "needs review"),
     ]
+
+
+def test_rule_based_supervisor_drops_matching_repo_relative_files() -> None:
+    items = [
+        {"id": 1, "file": "vendor/x.py", "description": "vendored"},
+        {"id": 2, "file": "src/app.py", "description": "application"},
+    ]
+
+    verdicts = RuleBasedSupervisor(deny_globs=["vendor/**"]).review_findings(items)
+
+    assert verdicts == {
+        1: {"id": 1, "action": "drop", "reason": "denied by glob 'vendor/**'"}
+    }
+
+
+def test_rule_based_tool_supervisor_vetoes_paths_and_bash() -> None:
+    supervisor = RuleBasedToolSupervisor(
+        deny_globs=["vendor/**"],
+        bash_deny=[r"rm -rf"],
+    )
+
+    write_decision = supervisor(
+        "Write",
+        {"file_path": "/repo/vendor/x.py"},
+        phase=DaydreamPhase.FIX,
+    )
+    edit_decision = supervisor(
+        "Edit",
+        {"path": "/repo/vendor/y.py"},
+        phase=DaydreamPhase.FIX,
+    )
+    allowed_decision = supervisor(
+        "Write",
+        {"file_path": "/repo/src/app.py"},
+        phase=DaydreamPhase.FIX,
+    )
+    bash_decision = supervisor(
+        "Bash",
+        {"command": "rm -rf /"},
+        phase=DaydreamPhase.FIX,
+    )
+    unknown_decision = supervisor("Read", {}, phase=DaydreamPhase.FIX)
+
+    assert isinstance(write_decision, ToolDecision) and write_decision.veto
+    assert "vendor/**" in write_decision.reason
+    assert edit_decision.veto
+    assert not allowed_decision.veto
+    assert bash_decision.veto and "rm -rf" in bash_decision.reason
+    assert not unknown_decision.veto

--- a/tests/test_trajectory_phase_events.py
+++ b/tests/test_trajectory_phase_events.py
@@ -102,6 +102,28 @@ async def test_emit_phase_carries_metadata(tmp_path: Path) -> None:
     assert rec._phase_events[0].metadata == {"stage": "arbiter"}
 
 
+async def test_emit_supervisor_and_tool_veto_events(tmp_path: Path) -> None:
+    """Supervisor decisions and tool vetoes are recorded as phase events."""
+    rec = _make_recorder(tmp_path)
+
+    rec.emit_supervisor_verdict(7, "drop", "duplicate")
+    rec.emit_tool_veto("Write", "protected path", phase=DaydreamPhase.FIX)
+
+    assert rec._phase_events[0].event == "supervisor_verdict"
+    assert rec._phase_events[0].phase is DaydreamPhase.DEEP
+    assert rec._phase_events[0].metadata == {
+        "finding_id": 7,
+        "action": "drop",
+        "reason": "duplicate",
+    }
+    assert rec._phase_events[1].event == "tool_veto"
+    assert rec._phase_events[1].phase is DaydreamPhase.FIX
+    assert rec._phase_events[1].metadata == {
+        "tool_name": "Write",
+        "reason": "protected path",
+    }
+
+
 async def test_phase_events_serialize_into_trajectory_extra(tmp_path: Path) -> None:
     """Phase events appear in Trajectory.extra["phase_events"] when present."""
     rec = _make_recorder(tmp_path)


### PR DESCRIPTION
## Summary

- Add an opt-in findings supervisor over the canonical `merged-items.json` surface.
- Add config-driven rule and LLM findings actions plus a built-in tool veto policy.
- Record supervisor verdicts and tool vetoes in the ATIF trajectory.

Closes #256
Closes #257
Related to #268

## Recorded deviations

- No run-level `Stop`: all-drop writes an empty findings artifact and exits successfully so `--findings-out` remains usable.
- No CLI option: supervision is config-file-only, matching the reviewed repository configuration model.
- The shared helper is narrowed to `revise_finding_fields()`: the existing arbiter keeps its positional bookkeeping, fail polarity, and join-id semantics because those do not apply to the canonical id-keyed pass.
- No new `run_agent` parameter: #268's per-run registry resolution is the established seam and preserves fork composition rules; built-in and fork supervisors fail loudly on conflict.

## Verification

- `make check`: `uv lock --check`, Ruff, mypy, and the full pytest suite pass.
- The normal pre-push hook passed before publishing this branch.

Generated with [Codex](https://openai.com/codex)
