### PR TITLE
feat(backends/codex): expose reasoning-effort control

### DIFF
--- a/daydream/backends/__init__.py
+++ b/daydream/backends/__init__.py
@@ -301,7 +301,7 @@ class Backend(Protocol):
 
 
 def create_backend(
-    name: str, model: str | None = None, *, cwd: Path | None = None
+    name: str, model: str | None = None, *, cwd: Path | None = None, reasoning_effort: str | None = None
 ) -> Backend:
     """Create a backend by name.
 
@@ -311,6 +311,9 @@ def create_backend(
             defaults here. Pi receives ``None`` unchanged so its own configured
             default can win before Pi's GLM fallback is selected.
         cwd: Target workspace used to resolve Pi's configured default model.
+        reasoning_effort: Optional reasoning-effort override (e.g. "low",
+            "medium", "high"). Only Codex applies this today (forwarded as
+            ``-c model_reasoning_effort=...``); ignored for claude/pi.
 
     Returns:
         A Backend instance whose ``.model`` attribute is a non-empty string.
@@ -325,7 +328,7 @@ def create_backend(
         return ClaudeBackend(model=model or DEFAULT_CLAUDE_MODEL)
     if name == "codex":
         from daydream.backends.codex import CodexBackend
-        return CodexBackend(model=model or DEFAULT_CODEX_MODEL)
+        return CodexBackend(model=model or DEFAULT_CODEX_MODEL, reasoning_effort=reasoning_effort)
     if name == "pi":
         from daydream.backends.pi import PiBackend
         return PiBackend(model=model, cwd=cwd)

--- a/daydream/backends/codex.py
+++ b/daydream/backends/codex.py
@@ -71,8 +71,9 @@ class CodexBackend:
 
     concise_fix_prompts = False
 
-    def __init__(self, model: str):
+    def __init__(self, model: str, reasoning_effort: str | None = None):
         self.model = model
+        self.reasoning_effort = reasoning_effort
         self.fanout_concurrency = 4
         self._process: asyncio.subprocess.Process | None = None
         self._processes: list[asyncio.subprocess.Process] = []
@@ -123,6 +124,8 @@ class CodexBackend:
             "--cd",
             str(cwd),
         ]
+        if self.reasoning_effort:
+            args.extend(["-c", f'model_reasoning_effort="{self.reasoning_effort}"'])
 
         schema_path: str | None = None
         if output_schema:

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -227,6 +227,17 @@ def _add_shared_arguments(parser: argparse.ArgumentParser, *, full_help: bool = 
              "This global --model takes precedence over any per-phase config-file override.",
     )
     parser.add_argument(
+        "--reasoning-effort",
+        default=None,
+        type=str,
+        dest="reasoning_effort",
+        metavar="EFFORT",
+        help="Global reasoning-effort override (e.g. low, medium, high). "
+             "Only applied by the Codex backend, forwarded as "
+             "-c model_reasoning_effort=<EFFORT>. Ignored for claude/pi. "
+             "Takes precedence over any per-phase config-file override.",
+    )
+    parser.add_argument(
         "--non-interactive",
         action="store_true",
         dest="non_interactive",
@@ -891,6 +902,7 @@ def _parse_args(argv: list[str] | None = None) -> RunConfig:
         target=args.target,
         skill=args.skill,
         model=args.model,
+        reasoning_effort=args.reasoning_effort,
         file_config=file_config,
         # Per-phase overrides are config-file-only; left None so config is the
         # sole low-precedence source.
@@ -950,6 +962,7 @@ def _build_feedback_config(args: argparse.Namespace) -> RunConfig:
         target=args.target,
         skill=None,
         model=args.model,
+        reasoning_effort=args.reasoning_effort,
         file_config=file_config,
         # Per-phase model/backend overrides are config-file-only (no CLI flags).
         exploration_model=None,

--- a/daydream/config_file.py
+++ b/daydream/config_file.py
@@ -32,6 +32,9 @@ class DaydreamFileConfig:
     Attributes:
         model: Global default model, or None if unset.
         backend: Global default backend name, or None if unset.
+        reasoning_effort: Global default reasoning-effort override, or None if
+            unset. Only consumed by the Codex backend today (forwarded as
+            ``-c model_reasoning_effort=...``); ignored for claude/pi.
         phases: Per-phase sub-tables mapping phase name to a dict of keys
             (e.g. ``{"fix": {"backend": "codex", "model": "..."}}``).
         shallow_fanout_threshold: Max changed-file count that triggers the
@@ -63,6 +66,7 @@ class DaydreamFileConfig:
 
     model: str | None = None
     backend: str | None = None
+    reasoning_effort: str | None = None
     phases: dict[str, dict[str, str]] = field(default_factory=dict)
     bench: dict[str, Any] = field(default_factory=dict)
     shallow_fanout_threshold: int | None = None
@@ -81,6 +85,10 @@ class DaydreamFileConfig:
     def phase_backend(self, phase: str) -> str | None:
         """Return the configured backend for a phase."""
         return self.phases.get(phase, {}).get("backend")
+
+    def phase_reasoning_effort(self, phase: str) -> str | None:
+        """Return the configured reasoning effort for a phase."""
+        return self.phases.get(phase, {}).get("reasoning_effort")
 
 
 def load_toml_or_empty(path: Path) -> dict[str, Any]:
@@ -234,6 +242,7 @@ def load_file_config(root: Path) -> DaydreamFileConfig:
 
     model = merged.get("model")
     backend = merged.get("backend")
+    reasoning_effort = merged.get("reasoning_effort")
     # shallow_fanout_threshold: tolerate non-int (stray string, list, etc.) by
     # degrading to None rather than crashing the loader. ``0`` is a meaningful
     # value (disable the short-circuit) so it must round-trip unchanged.
@@ -257,6 +266,7 @@ def load_file_config(root: Path) -> DaydreamFileConfig:
     return DaydreamFileConfig(
         model=str(model) if model is not None else None,
         backend=str(backend) if backend is not None else None,
+        reasoning_effort=str(reasoning_effort) if reasoning_effort is not None else None,
         phases=_coerce_phases(merged.get("phases")),
         bench=dict(merged["bench"]) if isinstance(merged.get("bench"), dict) else {},
         shallow_fanout_threshold=threshold,

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -1508,9 +1508,10 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
         _resolved_backend_name,
     )
 
-    # Cache one Backend instance per (backend_name, resolved_model) so phases that
-    # resolve to the same model share an instance and differing models stay isolated.
-    backend_cache: dict[tuple[str, str | None], Backend] = {}
+    # Cache one Backend instance per (backend_name, resolved_model, resolved_effort)
+    # so phases that resolve to the same model/effort share an instance and
+    # differing ones stay isolated.
+    backend_cache: dict[tuple[str, str | None, str | None], Backend] = {}
 
     target_dir = work.repo
 

--- a/daydream/flows/engine.py
+++ b/daydream/flows/engine.py
@@ -44,14 +44,17 @@ class FlowContext:
     work: WorkContext
     registry: Registry
     data: dict[str, Any] = field(default_factory=dict)
-    _backend_cache: dict[tuple[str, str | None], Backend] = field(default_factory=dict, repr=False)
+    _backend_cache: dict[tuple[str, str | None, str | None], Backend] = field(
+        default_factory=dict, repr=False
+    )
 
     def backend_for(self, phase: str) -> Backend:
         """Get or create the backend for ``phase``, reusing per-context instances.
 
         Instance-sharing semantics are identical to the flow helpers'
         ``backend_cache`` dicts today: backends are cached per resolved
-        ``(backend_name, model)`` pair for the lifetime of this context.
+        ``(backend_name, model, reasoning_effort)`` triple for the lifetime of
+        this context.
         """
         from daydream.runner import _resolve_backend
 

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -132,6 +132,11 @@ class RunConfig:
             per-phase model is set. Resolved by ``_resolved_model`` below the
             per-phase field but above the config-file (phase then global) and
             table sources. Default None.
+        reasoning_effort: Global default reasoning-effort override (e.g. "low",
+            "medium", "high"), resolved by ``_resolved_reasoning_effort``
+            (CLI > config-file phase > config-file global). Only the Codex
+            backend applies it (forwarded as ``-c model_reasoning_effort=...``);
+            ignored for claude/pi. Default None.
         file_config: File-sourced configuration (``[tool.daydream]`` /
             ``.daydream.toml``) feeding ``_resolved_model`` / ``_resolve_backend``
             as a low-precedence source. None is treated as an empty config.
@@ -208,6 +213,7 @@ class RunConfig:
     bot: str | None = None
     backend: str | None = None
     model: str | None = None
+    reasoning_effort: str | None = None
     file_config: DaydreamFileConfig | None = None
     review_backend: str | None = None
     fix_backend: str | None = None
@@ -383,17 +389,37 @@ def _resolved_model(config: RunConfig, phase: str) -> str | None:
     )
 
 
+def _resolved_reasoning_effort(config: RunConfig, phase: str) -> str | None:
+    """Resolve the reasoning effort for ``phase`` across all precedence tiers.
+
+    Order (highest first): global ``config.reasoning_effort``
+    (``--reasoning-effort``), file-config phase override, file-config global.
+    There is no per-phase RunConfig field and no built-in default table (unlike
+    :func:`_resolved_model`) — ``None`` means the backend applies its own
+    ambient default (e.g. Codex reads ``model_reasoning_effort`` from
+    ``~/.codex/config.toml`` when daydream passes nothing).
+
+    Only the Codex backend consumes the resolved value today.
+    """
+    file_config = _file_config_or_empty(config)
+    return (
+        config.reasoning_effort
+        or file_config.phase_reasoning_effort(phase)
+        or file_config.reasoning_effort
+    )
+
+
 def _resolve_backend(
     config: RunConfig,
     phase: str,
-    cache: dict[tuple[str, str | None], Backend] | None = None,
+    cache: dict[tuple[str, str | None, str | None], Backend] | None = None,
     *,
     cwd: Path | None = None,
 ) -> Backend:
     """Get or create the backend for a given phase, respecting all precedence tiers.
 
-    Both the backend kind and the model are resolved through the source-tiered
-    precedence ``CLI > config-file > default``:
+    The backend kind, model, and reasoning effort are each resolved through the
+    source-tiered precedence ``CLI > config-file > default``:
 
     - Backend kind via :func:`_resolved_backend_name`
       (per-phase flag → ``config.backend`` → file-config phase →
@@ -402,27 +428,39 @@ def _resolve_backend(
       (per-phase field → ``config.model`` → file-config phase →
       file-config global → ``PHASE_DEFAULT_MODELS`` →
       ``None``, where ``None`` falls through to the backend's own default).
+    - Reasoning effort via :func:`_resolved_reasoning_effort`
+      (``config.reasoning_effort`` → file-config phase → file-config global →
+      ``None``, where ``None`` falls through to the backend's own default).
+      Only Codex applies the resolved value.
 
     Args:
-        config: Run configuration with backend/model and file-config sources.
+        config: Run configuration with backend/model/reasoning-effort and
+            file-config sources.
         phase: Phase name (e.g. ``"review"``, ``"parse"``, ``"fix"``, ``"test"``,
             ``"intent"``, ``"wonder"``, ``"merge"``,
             ``"exploration"``, ``"pr_feedback"``).
-        cache: Optional dict to cache backends by ``(backend_name, model)``.
-            When provided, backends are reused only when both the backend kind
-            and the resolved model match — so the same backend kind with two
-            different models yields two distinct instances.
+        cache: Optional dict to cache backends by
+            ``(backend_name, model, reasoning_effort)``. When provided,
+            backends are reused only when the backend kind, resolved model,
+            and resolved reasoning effort all match — so the same backend kind
+            with two different models or effort levels yields two distinct
+            instances.
         cwd: Target workspace used for backend-specific configuration.
     """
     backend_name = _resolved_backend_name(config, phase)
     resolved_model = _resolved_model(config, phase)
+    resolved_effort = _resolved_reasoning_effort(config, phase)
 
-    cache_key = (backend_name, resolved_model)
+    cache_key = (backend_name, resolved_model, resolved_effort)
     if cache is not None:
         if cache_key not in cache:
             if backend_name == "pi":
                 cache[cache_key] = create_backend(
                     backend_name, model=resolved_model, cwd=cwd
+                )
+            elif backend_name == "codex":
+                cache[cache_key] = create_backend(
+                    backend_name, model=resolved_model, reasoning_effort=resolved_effort
                 )
             else:
                 cache[cache_key] = create_backend(backend_name, model=resolved_model)
@@ -430,6 +468,8 @@ def _resolve_backend(
 
     if backend_name == "pi":
         return create_backend(backend_name, model=resolved_model, cwd=cwd)
+    if backend_name == "codex":
+        return create_backend(backend_name, model=resolved_model, reasoning_effort=resolved_effort)
     return create_backend(backend_name, model=resolved_model)
 
 

--- a/tests/test_backend_codex.py
+++ b/tests/test_backend_codex.py
@@ -197,6 +197,34 @@ async def test_codex_default_uses_full_access_sandbox():
 
 
 @pytest.mark.asyncio
+async def test_codex_reasoning_effort_appends_config_override():
+    """reasoning_effort forwards as -c model_reasoning_effort=<value>."""
+    backend = CodexBackend(model="fixture-model", reasoning_effort="high")
+    mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
+
+    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+        async for _ in backend.execute(Path("/tmp"), "p"):
+            pass
+
+        flat_args = list(mock_exec.call_args.args)
+        assert flat_args[flat_args.index("-c") + 1] == 'model_reasoning_effort="high"'
+
+
+@pytest.mark.asyncio
+async def test_codex_no_reasoning_effort_omits_config_override():
+    """reasoning_effort=None (default) never adds a -c flag."""
+    backend = CodexBackend(model="fixture-model")
+    mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
+
+    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+        async for _ in backend.execute(Path("/tmp"), "p"):
+            pass
+
+        flat_args = list(mock_exec.call_args.args)
+        assert "-c" not in flat_args
+
+
+@pytest.mark.asyncio
 async def test_codex_stdout_limit_allows_large_jsonl_events() -> None:
     backend = CodexBackend(model="fixture-model")
     large_text = "x" * (70 * 1024)

--- a/tests/test_cli_config_precedence.py
+++ b/tests/test_cli_config_precedence.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from daydream.config_file import DaydreamFileConfig
-from daydream.runner import RunConfig, _resolved_backend_name, _resolved_model
+from daydream.runner import RunConfig, _resolved_backend_name, _resolved_model, _resolved_reasoning_effort
 
 
 def test_model_precedence_cli_over_file_over_table(monkeypatch, tmp_path: Path) -> None:
@@ -87,6 +87,23 @@ def test_env_vars_are_not_a_precedence_tier(monkeypatch, tmp_path: Path) -> None
     cfg2 = RunConfig(target=str(tmp_path), backend=None, model=None, file_config=DaydreamFileConfig())
     assert _resolved_model(cfg2, "parse") == "claude-haiku-4-5"
     assert _resolved_backend_name(cfg2, "parse") == "claude"
+
+
+def test_reasoning_effort_precedence_cli_over_file(tmp_path: Path) -> None:
+    """reasoning_effort mirrors model precedence: CLI global > file phase > file global > None."""
+    fc = DaydreamFileConfig(
+        model=None, backend=None, reasoning_effort="file-global",
+        phases={"fix": {"reasoning_effort": "file-fix"}},
+    )
+    cfg = RunConfig(target=str(tmp_path), reasoning_effort=None, file_config=fc)
+    assert _resolved_reasoning_effort(cfg, "fix") == "file-fix"       # file phase override, nothing higher
+    cfg.reasoning_effort = "cli-global"
+    assert _resolved_reasoning_effort(cfg, "fix") == "cli-global"     # global --reasoning-effort wins
+    assert _resolved_reasoning_effort(cfg, "review") == "cli-global"  # applies to every phase
+    cfg.reasoning_effort = None
+    assert _resolved_reasoning_effort(cfg, "review") == "file-global"  # no phase override -> file global
+    cfg2 = RunConfig(target=str(tmp_path), reasoning_effort=None, file_config=DaydreamFileConfig())
+    assert _resolved_reasoning_effort(cfg2, "review") is None  # no source -> backend applies its own default
 
 
 def test_pi_native_model_is_not_replaced_by_glm_fallback(tmp_path: Path) -> None:

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -19,6 +19,17 @@ def test_dotfile_wins_over_pyproject(tmp_path: Path) -> None:
 def test_absent_config_is_empty(tmp_path: Path) -> None:
     cfg = load_file_config(tmp_path)
     assert cfg.model is None and cfg.backend is None and cfg.phase_model("fix") is None
+    assert cfg.reasoning_effort is None and cfg.phase_reasoning_effort("fix") is None
+
+
+def test_reasoning_effort_global_and_phase_override(tmp_path: Path) -> None:
+    (tmp_path / ".daydream.toml").write_text(
+        'reasoning_effort = "medium"\n[phases.fix]\nreasoning_effort = "high"\n'
+    )
+    cfg = load_file_config(tmp_path)
+    assert cfg.reasoning_effort == "medium"
+    assert cfg.phase_reasoning_effort("fix") == "high"
+    assert cfg.phase_reasoning_effort("review") is None
 
 
 def test_malformed_toml_raises_valueerror(tmp_path: Path) -> None:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -356,7 +356,16 @@ class TestResolveBackendPhaseModel:
         review_backend = runner._resolve_backend(config, "review", cache)
         parse_backend = runner._resolve_backend(config, "parse", cache)
         assert review_backend is not parse_backend
-        assert review_backend.model != parse_backend.model
+
+    def test_codex_backend_receives_resolved_reasoning_effort_and_cache_splits_on_it(self):
+        cache: dict = {}
+        config = RunConfig(backend="codex", reasoning_effort="low")
+        low_backend = runner._resolve_backend(config, "review", cache)
+        assert low_backend.reasoning_effort == "low"
+        config.reasoning_effort = "high"
+        high_backend = runner._resolve_backend(config, "review", cache)
+        assert high_backend.reasoning_effort == "high"
+        assert low_backend is not high_backend  # different effort -> distinct cached instance
 
 
 # --- Task 6: HEAL hero is followed by Model: dim line ----------------------


### PR DESCRIPTION
## Summary
- Adds `--reasoning-effort` (global CLI flag) and `[tool.daydream] reasoning_effort` / per-phase `[tool.daydream.phases.<phase>] reasoning_effort` config-file keys, resolved with the same CLI > file-phase > file-global precedence as `--model` (`_resolved_reasoning_effort` in `runner.py`, mirroring `_resolved_model`).
- `CodexBackend` forwards the resolved value as `-c model_reasoning_effort="<value>"` to the `codex exec` subprocess. No-op for claude/pi (only Codex's constructor accepts it).
- Backend cache key in `_resolve_backend` / `FlowContext._backend_cache` / deep orchestrator's `backend_cache` now includes reasoning effort so two different effort levels on the same phase/backend get distinct backend instances.

Example:
```bash
daydream --backend codex --model gpt-5.5 --reasoning-effort high /path/to/project
```
```toml
[tool.daydream]
backend = "codex"

[tool.daydream.phases.fix]
reasoning_effort = "low"
```

## Test plan
- [x] `make check` (ruff + mypy daydream tests + full pytest, 2126 passed)
- [x] `uv lock --check`
- [x] New unit tests: `CodexBackend` argv construction with/without `reasoning_effort` (`tests/test_backend_codex.py`)
- [x] New precedence tests mirroring the existing `--model` precedence suite (`tests/test_cli_config_precedence.py`, `tests/test_config_file.py`, `tests/test_runner.py`)
- [x] Manually verified `_parse_args` and `_resolve_backend` end-to-end resolve `--reasoning-effort` into a `CodexBackend` instance