### PR TITLE
fix(github_app): refresh installation tokens before expiry

### DIFF
--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -43,8 +43,9 @@ import os
 import re
 import subprocess
 import tempfile
+import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 _logger = logging.getLogger(__name__)
 
@@ -57,23 +58,39 @@ _RATE_LIMIT_MARKERS: tuple[str, ...] = (
     "secondary rate limit",
 )
 
-# Module-level singleton for the ``gh`` subprocess environment. Set once at run
-# entry from GitHub App credentials; read by ``_run_gh`` so every ``gh`` call
-# authenticates under the minted token. ``None`` means inherit the parent env.
-# Access only through the getter/setter/reset functions below.
+# Module-level state for the ``gh`` subprocess environment. Configured at run
+# entry from GitHub App credentials and refreshed before expiry; read by
+# ``_run_gh`` so every ``gh`` call authenticates under a current installation
+# token. ``None`` means inherit the parent env. Access only through the helpers
+# below.
 _gh_token_env: dict[str, str] | None = None
+_gh_token_expires_at: float | None = None
+_gh_token_refresh: Callable[[], tuple[dict[str, str], float]] | None = None
+
+# Refresh before the credential's actual deadline so a request cannot start
+# with a token that expires while GitHub is processing it.
+_GH_TOKEN_REFRESH_SKEW_SECONDS = 300
 
 
-def set_gh_token_env(env: dict[str, str] | None) -> None:
+def set_gh_token_env(
+    env: dict[str, str] | None,
+    *,
+    expires_at: float | None = None,
+    refresh: Callable[[], tuple[dict[str, str], float]] | None = None,
+) -> None:
     """Set the environment overrides passed to ``gh`` subprocesses.
 
     Args:
         env: Mapping of env-var overrides (e.g. ``{"GH_TOKEN": token}``) merged
             with the live ``os.environ`` at subprocess call time, or ``None`` to
             inherit the parent process environment without any overrides.
+        expires_at: Unix timestamp at which the injected token expires.
+        refresh: Callback that returns a replacement environment and expiry.
     """
-    global _gh_token_env
+    global _gh_token_env, _gh_token_expires_at, _gh_token_refresh
     _gh_token_env = env
+    _gh_token_expires_at = expires_at
+    _gh_token_refresh = refresh
 
 
 def get_gh_token_env() -> dict[str, str] | None:
@@ -88,8 +105,34 @@ def get_gh_token_env() -> dict[str, str] | None:
 
 def reset_gh_token_env() -> None:
     """Reset the ``gh`` subprocess environment to parent-process inheritance."""
-    global _gh_token_env
+    global _gh_token_env, _gh_token_expires_at, _gh_token_refresh
     _gh_token_env = None
+    _gh_token_expires_at = None
+    _gh_token_refresh = None
+
+
+def _gh_token_env_for_request() -> dict[str, str] | None:
+    """Return the injected token environment, refreshing it before expiry."""
+    global _gh_token_env, _gh_token_expires_at, _gh_token_refresh
+    if (
+        _gh_token_env is None
+        or _gh_token_expires_at is None
+        or _gh_token_refresh is None
+        or time.time() < _gh_token_expires_at - _GH_TOKEN_REFRESH_SKEW_SECONDS
+    ):
+        return _gh_token_env
+
+    prior = (_gh_token_env, _gh_token_expires_at, _gh_token_refresh)
+    try:
+        env, expires_at = _gh_token_refresh()
+    except Exception as exc:
+        _gh_token_env, _gh_token_expires_at, _gh_token_refresh = prior
+        raise GitError(f"failed to refresh GitHub App installation token: {exc}") from exc
+
+    _gh_token_env = env
+    _gh_token_expires_at = expires_at
+    _gh_token_refresh = prior[2]
+    return _gh_token_env
 
 
 # Header names whose values are secrets. ``gh api -H "Authorization: Bearer
@@ -282,10 +325,11 @@ def _run_gh(
             Read-only callers pass :func:`_gh_retries` to ride out host CPU
             starvation.
 
-    The subprocess environment is sourced from the module ``_gh_token_env``
-    singleton when set (via :func:`set_gh_token_env`), so ``gh`` authenticates
-    under the minted installation token. When the singleton is ``None``, ``env``
-    is ``None`` and ``gh`` inherits the parent process environment.
+    The subprocess environment is sourced from the module token state when set
+    (via :func:`set_gh_token_env`), so ``gh`` authenticates under the minted
+    installation token. Expiring tokens are refreshed before the subprocess is
+    launched. When no token state is configured, ``env`` is ``None`` and ``gh``
+    inherits the parent process environment.
 
     Returns:
         The completed process with text-decoded stdout/stderr.
@@ -298,7 +342,7 @@ def _run_gh(
     """
     if timeout is None:
         timeout = _gh_timeout()
-    token_env = get_gh_token_env()
+    token_env = _gh_token_env_for_request()
     env = {**os.environ, **token_env} if token_env is not None else None
     last_timeout: subprocess.TimeoutExpired | None = None
     for attempt in range(retries + 1):

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -44,8 +44,9 @@ import re
 import subprocess
 import tempfile
 import time
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Generator
 
 _logger = logging.getLogger(__name__)
 
@@ -101,6 +102,17 @@ def get_gh_token_env() -> dict[str, str] | None:
         process environment.
     """
     return _gh_token_env
+
+
+@contextmanager
+def scoped_gh_token_env(env: dict[str, str] | None) -> Generator[None, None, None]:
+    """Temporarily replace the complete ``gh`` token state."""
+    prior = (_gh_token_env, _gh_token_expires_at, _gh_token_refresh)
+    set_gh_token_env(env)
+    try:
+        yield
+    finally:
+        set_gh_token_env(prior[0], expires_at=prior[1], refresh=prior[2])
 
 
 def reset_gh_token_env() -> None:

--- a/daydream/github_app.py
+++ b/daydream/github_app.py
@@ -18,6 +18,7 @@ import os
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import Generator
 
@@ -49,6 +50,15 @@ class AppCredentials:
 
     app_id: int
     private_key: str
+
+
+@dataclass(frozen=True)
+class _InstallationToken:
+    """A minted installation credential and its GitHub-provided expiry."""
+
+    token: str
+    identity: str
+    expires_at: float
 
 
 def resolve_credentials() -> AppCredentials | None:
@@ -151,6 +161,18 @@ def mint_installation_token(repo_dir: Path, app_id: int, private_key: str, owner
             installation for *owner*, or the token exchange fails or omits the
             ``token`` field.
     """
+    minted = _mint_installation_token(repo_dir, app_id, private_key, owner, repo)
+    return minted.token, minted.identity
+
+
+def _mint_installation_token(
+    repo_dir: Path,
+    app_id: int,
+    private_key: str,
+    owner: str,
+    repo: str,
+) -> _InstallationToken:
+    """Mint an installation token while retaining its expiry metadata."""
     jwt_token = mint_jwt(app_id, private_key)
     # GitHub only accepts App JWTs as Bearer (gh sends GH_TOKEN as token scheme),
     # so the explicit Bearer header authenticates; GH_TOKEN is set only so gh
@@ -158,7 +180,8 @@ def mint_installation_token(repo_dir: Path, app_id: int, private_key: str, owner
     bearer = {"Authorization": f"Bearer {jwt_token}"}
     with _scoped_gh_token(jwt_token):
         installation_id, identity = _find_installation(repo_dir, owner, repo, bearer)
-        return _exchange_for_token(repo_dir, installation_id, owner, repo, bearer), identity
+        token, expires_at = _exchange_for_token(repo_dir, installation_id, owner, repo, bearer)
+    return _InstallationToken(token=token, identity=identity, expires_at=expires_at)
 
 
 def _find_installation(repo_dir: Path, owner: str, repo: str, headers: dict[str, str]) -> tuple[int, str]:
@@ -183,7 +206,13 @@ def _find_installation(repo_dir: Path, owner: str, repo: str, headers: dict[str,
     raise ValueError(f"no App installation found for owner {owner!r} (repo {owner}/{repo})")
 
 
-def _exchange_for_token(repo_dir: Path, installation_id: int, owner: str, repo: str, headers: dict[str, str]) -> str:
+def _exchange_for_token(
+    repo_dir: Path,
+    installation_id: int,
+    owner: str,
+    repo: str,
+    headers: dict[str, str],
+) -> tuple[str, float]:
     """Exchange an installation id for an access token scoped to *repo*."""
     try:
         payload = git_ops.gh_api(
@@ -199,7 +228,14 @@ def _exchange_for_token(repo_dir: Path, installation_id: int, owner: str, repo: 
     token = payload.get("token") if isinstance(payload, dict) else None
     if not isinstance(token, str) or not token:
         raise ValueError(f"installation token response for {owner}/{repo} is missing the 'token' field")
-    return token
+    expires_at_raw = payload.get("expires_at") if isinstance(payload, dict) else None
+    if not isinstance(expires_at_raw, str) or not expires_at_raw:
+        raise ValueError(f"installation token response for {owner}/{repo} is missing the 'expires_at' field")
+    try:
+        expires_at = datetime.fromisoformat(expires_at_raw.replace("Z", "+00:00")).timestamp()
+    except ValueError as exc:
+        raise ValueError(f"installation token response for {owner}/{repo} has invalid 'expires_at'") from exc
+    return token, expires_at
 
 
 def exchange_manifest_code(repo_dir: Path, code: str) -> tuple[AppCredentials, str]:
@@ -336,14 +372,21 @@ def resolve_run_identity(target_dir: Path, pr_repo: str | None, *, is_posting: b
 
     owner, repo = owner_repo
     try:
-        token, identity = mint_installation_token(
-            target_dir, credentials.app_id, credentials.private_key, owner, repo
+        minted = _mint_installation_token(target_dir, credentials.app_id, credentials.private_key, owner, repo)
+
+        def refresh() -> tuple[dict[str, str], float]:
+            fresh = _mint_installation_token(target_dir, credentials.app_id, credentials.private_key, owner, repo)
+            return build_gh_env(fresh.token), fresh.expires_at
+
+        git_ops.set_gh_token_env(
+            build_gh_env(minted.token),
+            expires_at=minted.expires_at,
+            refresh=refresh,
         )
-        git_ops.set_gh_token_env(build_gh_env(token))
     except Exception as exc:
         raise GitHubAppError(f"App token resolution failed: {exc}") from exc
 
-    return identity
+    return minted.identity
 
 
 def _owner_repo_for(pr_repo: str | None, target_dir: Path) -> tuple[str, str] | None:

--- a/daydream/github_app.py
+++ b/daydream/github_app.py
@@ -124,12 +124,8 @@ def build_gh_env(token: str) -> dict[str, str]:
 @contextmanager
 def _scoped_gh_token(token: str) -> Generator[None, None, None]:
     """Temporarily set the git_ops GH token singleton, restoring it on exit."""
-    prior = git_ops.get_gh_token_env()
-    git_ops.set_gh_token_env(build_gh_env(token))
-    try:
+    with git_ops.scoped_gh_token_env(build_gh_env(token)):
         yield
-    finally:
-        git_ops.set_gh_token_env(prior)
 
 
 def mint_installation_token(repo_dir: Path, app_id: int, private_key: str, owner: str, repo: str) -> tuple[str, str]:
@@ -213,7 +209,12 @@ def _exchange_for_token(
     repo: str,
     headers: dict[str, str],
 ) -> tuple[str, float]:
-    """Exchange an installation id for an access token scoped to *repo*."""
+    """Exchange an installation id for an access token scoped to *repo*.
+
+    Raises:
+        ValueError: If the API call fails, the response has missing or invalid
+            token data, or its expiry is missing or invalid.
+    """
     try:
         payload = git_ops.gh_api(
             repo_dir,

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -390,6 +390,33 @@ def test_get_app_metadata_uses_bearer_jwt_and_clears_env():
     assert git_ops.get_gh_token_env() is None  # restored after
 
 
+def test_get_app_metadata_restores_refreshable_token_state():
+    """A scoped App JWT preserves the installation token's refresh behavior."""
+    captured = {}
+    refresh_calls = 0
+
+    def refresh():
+        nonlocal refresh_calls
+        refresh_calls += 1
+        return {"GH_TOKEN": "ghs_fresh"}, float("inf")
+
+    def spy_run(*args, **kwargs):
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(args[0], 0, stdout="", stderr="")
+
+    git_ops.set_gh_token_env({"GH_TOKEN": "ghs_expired"}, expires_at=0, refresh=refresh)
+    try:
+        with patch("daydream.git_ops.gh_api", return_value={"permissions": {}, "slug": "acme-bot"}):
+            get_app_metadata(Path("."), 42, _TEST_PEM)
+        with patch("subprocess.run", side_effect=spy_run):
+            git_ops._run_gh(Path("/tmp"), ["api", "/user"])
+    finally:
+        git_ops.reset_gh_token_env()
+
+    assert refresh_calls == 1
+    assert captured["env"]["GH_TOKEN"] == "ghs_fresh"
+
+
 def test_get_app_metadata_wraps_gh_api_failure():
     """A gh api failure (GitError) surfaces as GitHubAppError, never silent."""
     with patch("daydream.git_ops.gh_api", side_effect=git_ops.GitError("HTTP 401")):

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -21,8 +21,22 @@ from daydream.github_app import (
     mint_installation_token,
     mint_jwt,
     resolve_credentials,
+    resolve_run_identity,
     resolve_user_identity,
 )
+
+
+@pytest.fixture(autouse=True)
+def _block_real_gh(monkeypatch):
+    """Keep this suite hermetic even when the developer is authenticated."""
+    real_run = subprocess.run
+
+    def guarded_run(args, *pargs, **kwargs):
+        if args and args[0] == "gh":
+            raise AssertionError("test attempted to execute the real gh CLI")
+        return real_run(args, *pargs, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", guarded_run)
 
 
 def test_run_gh_injects_token_env_when_set():
@@ -41,6 +55,35 @@ def test_run_gh_injects_token_env_when_set():
         git_ops.reset_gh_token_env()
 
     assert captured["env"]["GH_TOKEN"] == "ghs_test123"
+
+
+def test_run_gh_refreshes_expired_token_before_request():
+    """An expired App token is replaced before the gh subprocess starts."""
+    captured = {}
+    refresh_calls = 0
+
+    def refresh():
+        nonlocal refresh_calls
+        refresh_calls += 1
+        return {"GH_TOKEN": "ghs_fresh"}, float("inf")
+
+    def spy_run(*args, **kwargs):
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(args[0], 0, stdout="", stderr="")
+
+    git_ops.set_gh_token_env(
+        {"GH_TOKEN": "ghs_expired"},
+        expires_at=0,
+        refresh=refresh,
+    )
+    try:
+        with patch("subprocess.run", side_effect=spy_run):
+            git_ops._run_gh(Path("/tmp"), ["api", "/user"])
+    finally:
+        git_ops.reset_gh_token_env()
+
+    assert refresh_calls == 1
+    assert captured["env"]["GH_TOKEN"] == "ghs_fresh"
 
 
 def test_run_gh_passes_none_env_when_unset():
@@ -157,7 +200,7 @@ def test_mint_installation_token_happy_path():
     def fake_gh_api(repo, endpoint, **kwargs):
         calls.append((endpoint, kwargs))
         if "access_tokens" in endpoint:
-            return {"token": "ghs_minted"}
+            return {"token": "ghs_minted", "expires_at": "2099-01-01T00:00:00Z"}
         return [{"id": 999, "account": {"login": "MyOrg"}, "app_slug": "daydream-bot"}]
 
     with patch("daydream.git_ops.gh_api", side_effect=fake_gh_api):
@@ -183,7 +226,7 @@ def test_mint_installation_token_missing_app_slug_yields_unknown_identity():
 
     def fake_gh_api(repo, endpoint, **kwargs):
         if "access_tokens" in endpoint:
-            return {"token": "ghs_minted"}
+            return {"token": "ghs_minted", "expires_at": "2099-01-01T00:00:00Z"}
         return [{"id": 999, "account": {"login": "myorg"}}]
 
     with patch("daydream.git_ops.gh_api", side_effect=fake_gh_api):
@@ -218,7 +261,7 @@ def test_mint_installation_token_sets_and_clears_jwt_env():
     def fake_gh_api(repo, endpoint, **kwargs):
         seen_during["env"] = git_ops.get_gh_token_env()
         if "access_tokens" in endpoint:
-            return {"token": "ghs_x"}
+            return {"token": "ghs_x", "expires_at": "2099-01-01T00:00:00Z"}
         return [{"id": 7, "account": {"login": "myorg"}, "app_slug": "daydream-bot"}]
 
     git_ops.reset_gh_token_env()
@@ -228,6 +271,38 @@ def test_mint_installation_token_sets_and_clears_jwt_env():
     assert seen_during["env"] is not None
     assert "ghs_x" not in (seen_during["env"].get("GH_TOKEN") or "")  # JWT, not installation token
     assert git_ops.get_gh_token_env() is None  # restored after minting
+
+
+def test_resolve_run_identity_refreshes_installation_token_after_expiry(monkeypatch):
+    """A long-running review remints before its next GitHub request."""
+    monkeypatch.setenv("DAYDREAM_APP_ID", "12345")
+    monkeypatch.setenv("DAYDREAM_APP_PRIVATE_KEY", _TEST_PEM)
+    minted = 0
+    captured = {}
+
+    def fake_gh_api(repo, endpoint, **kwargs):
+        nonlocal minted
+        if endpoint == "/app/installations":
+            return [{"id": 999, "account": {"login": "myorg"}, "app_slug": "daydream-bot"}]
+        assert endpoint == "/app/installations/999/access_tokens"
+        minted += 1
+        if minted == 1:
+            return {"token": "ghs_expired", "expires_at": "1970-01-01T00:00:00Z"}
+        return {"token": "ghs_fresh", "expires_at": "9999-01-01T00:00:00Z"}
+
+    def spy_run(*args, **kwargs):
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(args[0], 0, stdout="{}", stderr="")
+
+    with patch("daydream.git_ops.gh_api", side_effect=fake_gh_api):
+        identity = resolve_run_identity(Path("/tmp"), "myorg/myrepo", is_posting=True)
+
+        with patch("subprocess.run", side_effect=spy_run):
+            git_ops._run_gh(Path("/tmp"), ["api", "/user"])
+
+    assert identity == "daydream-bot[bot]"
+    assert minted == 2
+    assert captured["env"]["GH_TOKEN"] == "ghs_fresh"
 
 
 def test_resolve_user_identity_returns_login():

--- a/tests/test_github_app_integration.py
+++ b/tests/test_github_app_integration.py
@@ -6,13 +6,29 @@ loop. Mocks only the Backend (no real AI) and the github_app network helpers
 """
 from __future__ import annotations
 
+import subprocess
+from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
 from rich.console import Console
 
 from daydream import git_ops
 from daydream.backends import ResultEvent, TextEvent
 from daydream.runner import RunConfig, run
+
+
+@pytest.fixture(autouse=True)
+def _block_real_gh(monkeypatch):
+    """Fail instead of contacting GitHub if an integration seam is missed."""
+    real_run = subprocess.run
+
+    def guarded_run(args, *pargs, **kwargs):
+        if args and args[0] == "gh":
+            raise AssertionError("test attempted to execute the real gh CLI")
+        return real_run(args, *pargs, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", guarded_run)
 
 
 class _MinimalBackend:
@@ -45,11 +61,13 @@ async def test_app_identity_shown_and_token_injected(feature_branch_repo, monkey
 
     # Pin a wide recording console so the identity line is captured at the
     # rendered content level, independent of terminal width / TTY / Live state.
-    rec = Console(record=True, force_terminal=True, width=200)
+    rec = Console(record=True, force_terminal=True, width=200, height=25)
     monkeypatch.setattr("daydream.runner.console", rec)
 
-    with patch("daydream.github_app.mint_installation_token",
-               return_value=("ghs_injected", "my-app[bot]")) as mock_mint, \
+    with patch("daydream.github_app._mint_installation_token",
+               return_value=SimpleNamespace(
+                   token="ghs_injected", identity="my-app[bot]", expires_at=float("inf")
+               )) as mock_mint, \
          patch("daydream.runner.create_backend", return_value=_MinimalBackend()):
         exit_code = await run(config)
 
@@ -68,7 +86,7 @@ async def test_fallback_identity_without_app_creds(feature_branch_repo, monkeypa
                        output_mode="review", shallow=True, skill="python", quiet=False)
 
     with patch("daydream.github_app.resolve_user_identity", return_value="personal-user"), \
-         patch("daydream.github_app.mint_installation_token") as mock_mint, \
+         patch("daydream.github_app._mint_installation_token") as mock_mint, \
          patch("daydream.runner.create_backend", return_value=_MinimalBackend()):
         exit_code = await run(config)
 
@@ -109,7 +127,7 @@ async def test_posting_aborts_when_owner_repo_undeterminable(feature_branch_repo
                        output_mode="comment", shallow=True, skill="python", quiet=False)
 
     with patch("daydream.git_ops.gh_repo_view", return_value=None), \
-         patch("daydream.github_app.mint_installation_token") as mock_mint, \
+         patch("daydream.github_app._mint_installation_token") as mock_mint, \
          patch("daydream.runner.create_backend", return_value=_MinimalBackend()):
         exit_code = await run(config)
 
@@ -128,7 +146,7 @@ async def test_minting_failure_aborts_run(feature_branch_repo, monkeypatch, caps
                        output_mode="review", shallow=True, skill="python", quiet=False,
                        pr_repo="myorg/myrepo")
 
-    with patch("daydream.github_app.mint_installation_token",
+    with patch("daydream.github_app._mint_installation_token",
                side_effect=ValueError("no App installation found for owner 'myorg'")), \
          patch("daydream.runner.create_backend", return_value=_MinimalBackend()):
         exit_code = await run(config)

--- a/tests/test_phases_render.py
+++ b/tests/test_phases_render.py
@@ -36,7 +36,7 @@ from daydream.phases import (
 
 
 def _rec(monkeypatch: Any) -> Console:
-    rec = Console(record=True, force_terminal=True, width=100)
+    rec = Console(record=True, force_terminal=True, width=100, height=25)
     monkeypatch.setattr("daydream.phases.console", rec)
     return rec
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -468,7 +468,7 @@ async def test_stale_local_warning_fires(
     # Pin a wide recording console so the warning text is captured intact,
     # independent of terminal width (the warning renders through the lazily
     # imported ``daydream.agent.console``).
-    rec = Console(record=True, force_terminal=True, width=200)
+    rec = Console(record=True, force_terminal=True, width=200, height=25)
     monkeypatch.setattr("daydream.agent.console", rec)
 
     async with open_workspace(


### PR DESCRIPTION
## Summary

Refresh GitHub App installation credentials before they expire so long-running reviews can complete final GitHub operations without stale-token 401 failures. Preserve the complete token state across temporary App JWT scopes so metadata requests cannot silently disable later refreshes.

## Changes

### Added

- Track the server-provided installation-token expiration and retain a callback that can mint a replacement token.
- Add unit and integration coverage for expiry refresh, scoped-state restoration, and hermetic GitHub CLI execution.

### Changed

- Refresh an installation token within a five-minute safety window before launching a GitHub CLI subprocess.
- Preserve the token environment, expiration, and refresh callback while temporarily authenticating App API requests with a JWT.
- Pin Rich recording-console heights in affected tests for deterministic rendering.

### Fixed

- Prevent long-running reviews from reaching final GitHub writes with an expired installation token.
- Document the validation failures raised while exchanging an installation ID for a token.

## Motivation

GitHub App installation tokens expire after a bounded lifetime, while a review can run longer than the original credential remains valid. Refreshing immediately before subprocess launch avoids stale-token failures without retrying non-idempotent GitHub operations, and complete scoped-state restoration keeps that refresh mechanism intact after App metadata calls.

## Testing

- `make check`
  - lockfile verification
  - Ruff
  - mypy across 254 source files
  - pytest: 2,153 passed, 5 skipped
- Pre-push validation: 2,129 passed, 5 skipped
- Manual regression reproduction confirmed a scoped metadata call restores the expired token state and the next request invokes refresh exactly once.

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally
- [x] Linting passes
- [x] Documentation updated