### PR TITLE
feat(extensions): support extension API version range instead of strict equality

### DIFF
--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -1331,7 +1331,12 @@ def _handle_ext_validate_command() -> int:
     import importlib.util
     import os
 
-    from daydream.extensions import EXTENSION_API_VERSION, ExtensionError, build_registry
+    from daydream.extensions import (
+        EXTENSION_API_VERSION,
+        MIN_SUPPORTED_EXTENSION_API_VERSION,
+        ExtensionError,
+        build_registry,
+    )
 
     try:
         registry = build_registry()
@@ -1347,7 +1352,10 @@ def _handle_ext_validate_command() -> int:
     else:
         source = "extension source: no extension found (builtins only)"
     console.print(source, soft_wrap=True)
-    console.print(f"extension API version {EXTENSION_API_VERSION}")
+    console.print(
+        f"extension API version {EXTENSION_API_VERSION} "
+        f"(supported: {MIN_SUPPORTED_EXTENSION_API_VERSION}..{EXTENSION_API_VERSION})"
+    )
     supervisor_status = "registered" if registry.tool_supervisor_if_registered() is not None else "none"
     console.print(f"tool supervisor: {supervisor_status}")
 

--- a/daydream/extensions/__init__.py
+++ b/daydream/extensions/__init__.py
@@ -6,6 +6,7 @@ against: the versioned contract types from ``api`` and the ``Registry``.
 
 from daydream.extensions.api import (
     EXTENSION_API_VERSION,
+    MIN_SUPPORTED_EXTENSION_API_VERSION,
     BreakLoop,
     ExtensionError,
     ExtensionVersionError,
@@ -22,6 +23,7 @@ from daydream.extensions.registry import Registry
 
 __all__ = [
     "EXTENSION_API_VERSION",
+    "MIN_SUPPORTED_EXTENSION_API_VERSION",
     "BreakLoop",
     "ExtensionError",
     "ExtensionVersionError",

--- a/daydream/extensions/api.py
+++ b/daydream/extensions/api.py
@@ -19,7 +19,10 @@ if TYPE_CHECKING:
     from daydream.flows.engine import FlowContext
     from daydream.trajectory import DaydreamPhase
 
+# Current/preferred extension contract version; doubles as the max accepted (range ceiling).
 EXTENSION_API_VERSION: int = 2
+# Oldest extension contract version still accepted (range floor).
+MIN_SUPPORTED_EXTENSION_API_VERSION: int = 1
 
 
 class ExtensionError(Exception):

--- a/daydream/extensions/loader.py
+++ b/daydream/extensions/loader.py
@@ -23,6 +23,7 @@ from types import ModuleType
 
 from daydream.extensions.api import (
     EXTENSION_API_VERSION,
+    MIN_SUPPORTED_EXTENSION_API_VERSION,
     ExtensionError,
     ExtensionVersionError,
 )
@@ -71,12 +72,14 @@ def _require_version(module: ModuleType, source: str) -> None:
     if version is None:
         raise ExtensionVersionError(
             f"extension module at {source} does not export DAYDREAM_EXT_API; "
-            f"this daydream expects {EXTENSION_API_VERSION} (see {_CONTRACT_DOC})"
+            f"this daydream supports {MIN_SUPPORTED_EXTENSION_API_VERSION}..{EXTENSION_API_VERSION} "
+            f"(see {_CONTRACT_DOC})"
         )
-    if version != EXTENSION_API_VERSION:
+    if not (MIN_SUPPORTED_EXTENSION_API_VERSION <= version <= EXTENSION_API_VERSION):
         raise ExtensionVersionError(
             f"extension module at {source} declares DAYDREAM_EXT_API = {version!r}; "
-            f"this daydream expects {EXTENSION_API_VERSION} (see {_CONTRACT_DOC})"
+            f"this daydream supports {MIN_SUPPORTED_EXTENSION_API_VERSION}..{EXTENSION_API_VERSION} "
+            f"(see {_CONTRACT_DOC})"
         )
 
 

--- a/daydream/extensions/loader.py
+++ b/daydream/extensions/loader.py
@@ -75,7 +75,11 @@ def _require_version(module: ModuleType, source: str) -> None:
             f"this daydream supports {MIN_SUPPORTED_EXTENSION_API_VERSION}..{EXTENSION_API_VERSION} "
             f"(see {_CONTRACT_DOC})"
         )
-    if not (MIN_SUPPORTED_EXTENSION_API_VERSION <= version <= EXTENSION_API_VERSION):
+    if not (
+        isinstance(version, int)
+        and not isinstance(version, bool)
+        and MIN_SUPPORTED_EXTENSION_API_VERSION <= version <= EXTENSION_API_VERSION
+    ):
         raise ExtensionVersionError(
             f"extension module at {source} declares DAYDREAM_EXT_API = {version!r}; "
             f"this daydream supports {MIN_SUPPORTED_EXTENSION_API_VERSION}..{EXTENSION_API_VERSION} "

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -9,7 +9,7 @@ programs against, and the policy for when those names may change. A drift-guard
 test (`tests/test_extension_contract_doc.py`) pins this document to the
 registered inventories in the code.
 
-Current contract version: **`EXTENSION_API_VERSION = 2`**.
+Current contract version: **`EXTENSION_API_VERSION = 2`** (supported: `1..2`).
 
 ## Extension module contract
 
@@ -41,6 +41,7 @@ The `daydream.extensions` package exports these contract symbols:
 | Symbol | Purpose |
 |--------|---------|
 | `EXTENSION_API_VERSION` | Running extension contract version |
+| `MIN_SUPPORTED_EXTENSION_API_VERSION` | Oldest extension contract version still accepted (range floor) |
 | `BreakLoop` | End the current loop group and continue the flow |
 | `ExtensionError` | Base error for extension failures |
 | `ExtensionVersionError` | Error for an absent or incompatible extension version |
@@ -67,8 +68,8 @@ The `daydream.extensions` package exports these contract symbols:
 
 A *present-but-broken* extension is a loud, named error before any workspace,
 recorder, or agent work happens: a missing or mismatched `DAYDREAM_EXT_API`
-raises `ExtensionVersionError` naming the module source path and both
-versions; a missing `register`, an import failure, or an exception inside
+raises `ExtensionVersionError` naming the module source path, the declared
+version, and the supported range; a missing `register`, an import failure, or an exception inside
 `register()` raises `ExtensionError` with the original message. All of them
 exit the run with code 1.
 
@@ -96,10 +97,26 @@ It bumps on **any** breaking change to:
 - the documented stable `ctx.data` keys below,
 - the tool-supervisor decision and findings-file semantics below.
 
-The loader hard-rejects an extension whose `DAYDREAM_EXT_API` does not equal
-the running daydream's `EXTENSION_API_VERSION` — there is no compatibility
-range. Additive changes (new steps, new slots, new prompts, new optional
-kwargs) do not bump the version.
+The loader accepts any `DAYDREAM_EXT_API` within the inclusive range
+`[MIN_SUPPORTED_EXTENSION_API_VERSION, EXTENSION_API_VERSION]` — the floor is
+the oldest contract the tool still understands and `EXTENSION_API_VERSION` is
+the ceiling. A declared version above the ceiling (newer than the tool
+understands), below the floor (a contract the tool has dropped), or absent is a
+loud `ExtensionVersionError` that exits the run with code 1.
+
+On a bump, advance `EXTENSION_API_VERSION`. An **additive** bump leaves the
+floor where it is, widening the supported window so a not-yet-upgraded
+extension keeps loading — that window is the deprecation window. A
+**hard-breaking** bump raises the floor to the new version in the same release,
+since no older extension can run against the changed contract. Deprecating an
+aged-out version later is one edit: raise the floor.
+
+Upgrade ordering: upgrade the tool before the extension. A newer tool runs an
+older in-range extension (the rolling-upgrade window), but an older tool cannot
+run a newer contract — forward compatibility is unachievable by any gate.
+
+Additive changes (new steps, new slots, new prompts, new optional kwargs) do
+not bump the version.
 
 ### Changelog
 
@@ -107,7 +124,8 @@ kwargs) do not bump the version.
   `ToolDecision` result, and the public `items_file` findings surface. The
   extension module literal is now `DAYDREAM_EXT_API = 2`.
 - **Version 1** — initial flow, skill, prompt, stack, loader, and validation
-  contract.
+  contract. Remains within the supported range (`1..2`) as the current
+  deprecation window: a v1 extension still loads under v2 tooling.
 
 ## Tool supervision
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -23,7 +23,7 @@ daydream_ext/
 `__init__.py` must export exactly two things:
 
 ```python
-DAYDREAM_EXT_API = 2          # must equal daydream's EXTENSION_API_VERSION
+DAYDREAM_EXT_API = 2          # must be within daydream's supported range
 
 def register(registry):       # receives a daydream.extensions.Registry
     ...                       # mutate flows / skills / prompts / stacks here

--- a/tests/test_ext_validate_cli.py
+++ b/tests/test_ext_validate_cli.py
@@ -91,6 +91,13 @@ def test_ext_validate_broken_ref(ext_dir, capsys) -> None:
     assert "ghost" in strip_ansi(capsys.readouterr().out)
 
 
+def test_ext_validate_reports_supported_range(ext_dir, capsys) -> None:
+    ext_dir.write_module("DAYDREAM_EXT_API = 2\ndef register(r): ...\n")
+    rc = _run_main(["ext", "validate"])
+    assert rc == 0
+    assert "supported: 1..2" in strip_ansi(capsys.readouterr().out).lower()
+
+
 def test_bare_ext_prints_help_exits_2(capsys) -> None:
     rc = _run_main(["ext"])
     assert rc == 2

--- a/tests/test_extension_contract_doc.py
+++ b/tests/test_extension_contract_doc.py
@@ -21,6 +21,7 @@ def test_contract_doc_names_every_registered_surface() -> None:
         "read",
         "rewrite",
         "DAYDREAM_EXT_API = 2",
+        "raise the floor",
     ):
         assert fragment in doc, f"contract detail {fragment!r} undocumented"
     for symbol in extension_api.__all__:

--- a/tests/test_extension_errors_integration.py
+++ b/tests/test_extension_errors_integration.py
@@ -90,7 +90,7 @@ async def test_version_mismatch_exits_1_naming_versions(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """A DAYDREAM_EXT_API mismatch exits 1 naming both versions, before any git work."""
-    # Intentional incompatibility fixture: 99 must remain rejected by the v2 gate.
+    # 99 is above the ceiling.
     ext_dir.write_module("DAYDREAM_EXT_API = 99\ndef register(r): ...\n")
     backend = RecordingBackend()
     monkeypatch.setattr("daydream.runner.create_backend", lambda name, model=None: backend)

--- a/tests/test_extensions_loader.py
+++ b/tests/test_extensions_loader.py
@@ -44,6 +44,27 @@ def test_version_below_floor_is_rejected(ext_dir: ExtDir) -> None:
         build_registry()
 
 
+def test_string_version_is_rejected(ext_dir: ExtDir) -> None:
+    # A str declaration must not slip through the range comparison as a TypeError.
+    ext_dir.write_module("DAYDREAM_EXT_API = '1'\ndef register(registry): ...\n")
+    with pytest.raises(ExtensionVersionError, match=r"= '1';.*supports 1\.\.2"):
+        build_registry()
+
+
+def test_float_version_is_rejected(ext_dir: ExtDir) -> None:
+    # 1.5 sits inside the numeric range but is not an integer contract version.
+    ext_dir.write_module("DAYDREAM_EXT_API = 1.5\ndef register(registry): ...\n")
+    with pytest.raises(ExtensionVersionError, match=r"= 1\.5;.*supports 1\.\.2"):
+        build_registry()
+
+
+def test_bool_version_is_rejected(ext_dir: ExtDir) -> None:
+    # True == 1 would pass the range check; bool is not a valid API declaration.
+    ext_dir.write_module("DAYDREAM_EXT_API = True\ndef register(registry): ...\n")
+    with pytest.raises(ExtensionVersionError, match=r"= True;.*supports 1\.\.2"):
+        build_registry()
+
+
 def test_register_exception_is_wrapped_and_named(ext_dir: ExtDir) -> None:
     ext_dir.write_module("DAYDREAM_EXT_API = 2\ndef register(registry):\n    raise RuntimeError('boom')\n")
     with pytest.raises(ExtensionError, match=r"daydream_ext.*boom"):

--- a/tests/test_extensions_loader.py
+++ b/tests/test_extensions_loader.py
@@ -19,10 +19,28 @@ def test_loader_applies_extension(ext_dir: ExtDir) -> None:
     assert build_registry().skill("structural") == "ro-core:review-structure"
 
 
-def test_version_mismatch_names_both_versions(ext_dir: ExtDir) -> None:
-    # Intentional incompatibility fixture: 99 must remain rejected by the v2 gate.
+def test_supported_nonpreferred_version_is_accepted(ext_dir: ExtDir) -> None:
+    # DAYDREAM_EXT_API = 1 is within the supported range but below the preferred
+    # version: the rolling-upgrade window (issue #274). Strict equality rejected it.
+    ext_dir.write_module(
+        "DAYDREAM_EXT_API = 1\n"
+        "def register(registry):\n"
+        "    registry.override_skill('structural', 'ro-core:review-structure')\n"
+    )
+    assert build_registry().skill("structural") == "ro-core:review-structure"
+
+
+def test_version_above_ceiling_is_rejected(ext_dir: ExtDir) -> None:
+    # 99 is above the ceiling.
     ext_dir.write_module("DAYDREAM_EXT_API = 99\ndef register(registry): ...\n")
-    with pytest.raises(ExtensionVersionError, match=r"99.*expects 2|expects 2.*99"):
+    with pytest.raises(ExtensionVersionError, match=r"99.*supports 1\.\.2"):
+        build_registry()
+
+
+def test_version_below_floor_is_rejected(ext_dir: ExtDir) -> None:
+    # Below the supported floor: a contract the tool has dropped.
+    ext_dir.write_module("DAYDREAM_EXT_API = 0\ndef register(registry): ...\n")
+    with pytest.raises(ExtensionVersionError, match=r"= 0;.*supports 1\.\.2"):
         build_registry()
 
 

--- a/tests/test_extensions_loader.py
+++ b/tests/test_extensions_loader.py
@@ -30,3 +30,12 @@ def test_register_exception_is_wrapped_and_named(ext_dir: ExtDir) -> None:
     ext_dir.write_module("DAYDREAM_EXT_API = 2\ndef register(registry):\n    raise RuntimeError('boom')\n")
     with pytest.raises(ExtensionError, match=r"daydream_ext.*boom"):
         build_registry()
+
+
+def test_supported_range_invariant() -> None:
+    from daydream.extensions import (
+        EXTENSION_API_VERSION,
+        MIN_SUPPORTED_EXTENSION_API_VERSION,
+    )
+
+    assert 1 <= MIN_SUPPORTED_EXTENSION_API_VERSION <= EXTENSION_API_VERSION


### PR DESCRIPTION
Closes #274.

Replaces the extension seam's strict-equality API version gate with an inclusive supported-version **range** (a floor plus the tool's own version as the ceiling), so a `daydream` tool and a `daydream_ext` extension can roll-upgrade — a newer tool running an older extension — instead of requiring an atomic flag-day.

## Changes

- **`daydream/extensions/api.py`** — add `MIN_SUPPORTED_EXTENSION_API_VERSION: int = 1`. `EXTENSION_API_VERSION` stays `2` as the current/preferred contract and doubles as the range ceiling.
- **`daydream/extensions/__init__.py`** — export the new symbol on the facade (import + `__all__`).
- **`daydream/extensions/loader.py`** — gate changes from `version != EXTENSION_API_VERSION` to `not (MIN_SUPPORTED_EXTENSION_API_VERSION <= version <= EXTENSION_API_VERSION)`. Both error branches (absent, out-of-range) now name the declared version and the supported range: `this daydream supports 1..2 (see docs/extensions.md)`.
- **`daydream/cli.py`** — `ext validate` now prints `extension API version 2 (supported: 1..2)`.
- **`docs/extensions.md`** — symbol-table row, `1..2` range, "deprecate by raising the floor" procedure, upgrade ordering (tool before extension), changelog note. Drift-guard test stays green.

The loud-failure safety property is preserved: an absent or out-of-range `DAYDREAM_EXT_API` still raises a named `ExtensionVersionError` and exits 1.

## Tests

Real-path tests via the `$DAYDREAM_EXT_DIR` seam (`ext_dir` fixture), driving the real loader/registry/CLI:

- `test_supported_range_invariant` — pins `1 <= MIN <= EXTENSION_API_VERSION`.
- `test_supported_nonpreferred_version_is_accepted` — `DAYDREAM_EXT_API = 1` (in-range, below preferred) loads; the rolling-upgrade window.
- `test_version_above_ceiling_is_rejected` (`= 99`) and `test_version_below_floor_is_rejected` (`= 0`) — the two together pin a two-sided range, not a one-sided gate.
- `test_ext_validate_reports_supported_range` — asserts `supported: 1..2` in `ext validate` output.

## Out of scope

No `EXTENSION_API_VERSION` bump to 3, no registry/discovery changes, no forward-compat attempt (unachievable by any gate; operational rule is upgrade the tool first).

## Verification

- `make check` (ruff + `mypy daydream` + full pytest): 2165 passed, 5 skipped.
- `uv run mypy daydream tests` (pre-push hook scope): no issues in 255 source files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)