### PR TITLE
chore(release): 0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0] - 2026-07-15
+
 ### Added
+
+- **extensions:** Support an extension API version range instead of strict equality ([#275](https://github.com/existential-birds/daydream/pull/275))
+
+  Introduces `MIN_SUPPORTED_EXTENSION_API_VERSION` as an explicit floor
+  alongside `EXTENSION_API_VERSION` (the ceiling). The strict-equality
+  `DAYDREAM_EXT_API` check is replaced with an inclusive range so a newer
+  daydream can run an older extension during a rolling upgrade. Absent,
+  non-integer, or out-of-range declarations raise `ExtensionVersionError`
+  naming the declared version and the supported range, and `daydream ext
+  validate` reports the range.
+
+- **cli:** Add `--log` flag for CI-friendly raw output ([#272](https://github.com/existential-birds/daydream/pull/272))
+
+  Bypasses the Rich terminal UI and emits raw agent events as plain text to
+  stdout (`[tool:name]`, `[thinking]`, `[cost]`, `[metrics]`, `[result]`
+  prefixes), suitable for CI log capture. Orthogonal to `--non-interactive`
+  and `--yes`; trajectory recording and benchmark scoring are unaffected.
+
+- **backends/codex:** Expose reasoning-effort control ([#271](https://github.com/existential-birds/daydream/pull/271))
+
+  Adds `--reasoning-effort` (and `[tool.daydream]` `reasoning_effort` /
+  per-phase config override), resolved with the same CLI > file-phase >
+  file-global precedence as `--model`, forwarded by `CodexBackend` as
+  `-c model_reasoning_effort=<value>`. No-op for the Claude and Pi backends.
 
 - **extensions:** Publish the tool-supervision seam as extension API v2 ([#268](https://github.com/existential-birds/daydream/issues/268))
 
@@ -23,6 +49,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **agent:** Add the built-in rule tool supervisor for denied file paths and
   Bash commands, with turn-level veto events and conflict detection against
   extension registrations ([#257](https://github.com/existential-birds/daydream/issues/257))
+
+### Fixed
+
+- **github_app:** Refresh installation tokens before expiry ([#273](https://github.com/existential-birds/daydream/pull/273))
+
+  Long reviews could outlive the one-hour installation token and fail their
+  final GitHub write with a misleading 401. The server-provided expiry is now
+  retained and the token refreshed before launching `gh`, so non-idempotent
+  posts are never replayed after failure.
 
 ## [0.23.1] - 2026-07-11
 
@@ -818,7 +853,8 @@ Initial release of Daydream - an automated code review and fix loop using the Cl
 - `rich` - Terminal UI components
 - `pyfiglet` - ASCII art header generation
 
-[unreleased]: https://github.com/existential-birds/daydream/compare/v0.23.1...HEAD
+[unreleased]: https://github.com/existential-birds/daydream/compare/v0.24.0...HEAD
+[0.24.0]: https://github.com/existential-birds/daydream/compare/v0.23.1...v0.24.0
 [0.23.1]: https://github.com/existential-birds/daydream/compare/v0.23.0...v0.23.1
 [0.23.0]: https://github.com/existential-birds/daydream/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/existential-birds/daydream/compare/v0.21.0...v0.22.0

--- a/daydream/__init__.py
+++ b/daydream/__init__.py
@@ -17,4 +17,4 @@ Submodules:
     ui: User interface utilities for terminal output.
 """
 
-__version__ = "0.23.1"
+__version__ = "0.24.0"

--- a/daydream/templates/workflows/daydream-post.yml
+++ b/daydream/templates/workflows/daydream-post.yml
@@ -51,7 +51,7 @@ jobs:
         # Pinned to a release tag (not `main`) so the bot runs a known daydream
         # version: reproducible and immune to main-drift / uv-cache staleness.
         # Bump in lockstep with the package version on release (a test enforces this).
-        run: uv tool install git+https://github.com/existential-birds/daydream@v0.23.1
+        run: uv tool install git+https://github.com/existential-birds/daydream@v0.24.0
 
       - name: Mint posting token
         id: token

--- a/daydream/templates/workflows/daydream-review.yml
+++ b/daydream/templates/workflows/daydream-review.yml
@@ -92,7 +92,7 @@ jobs:
         # Pinned to a release tag (not `main`) so the bot runs a known daydream
         # version: reproducible and immune to main-drift / uv-cache staleness.
         # Bump in lockstep with the package version on release (a test enforces this).
-        run: uv tool install git+https://github.com/existential-birds/daydream@v0.23.1
+        run: uv tool install git+https://github.com/existential-birds/daydream@v0.24.0
 
       - name: Run daydream review
         env:

--- a/daydream/templates/workflows/single/daydream.yml
+++ b/daydream/templates/workflows/single/daydream.yml
@@ -144,7 +144,7 @@ jobs:
         # Pinned to a release tag (not `main`) so the bot runs a known daydream
         # version: reproducible and immune to main-drift / uv-cache staleness.
         # Bump in lockstep with the package version on release (a test enforces this).
-        run: uv tool install git+https://github.com/existential-birds/daydream@v0.23.1
+        run: uv tool install git+https://github.com/existential-birds/daydream@v0.24.0
 
       # Runs the DEFAULT deep-review pipeline (not --review). In --non-interactive
       # the deep run auto-declines the post/fix gates, so it still only produces a
@@ -191,7 +191,7 @@ jobs:
         uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
 
       - name: Install daydream
-        run: uv tool install git+https://github.com/existential-birds/daydream@v0.23.1
+        run: uv tool install git+https://github.com/existential-birds/daydream@v0.24.0
 
       - name: Download findings artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "daydream"
-version = "0.23.1"
+version = "0.24.0"
 description = "Automated code review and fix loop using Claude"
 requires-python = ">=3.12.13"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -193,7 +193,7 @@ wheels = [
 
 [[package]]
 name = "daydream"
-version = "0.23.1"
+version = "0.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
Release v0.24.0

## Version Changes

| Location | Old | New |
|---|---|---|
| pyproject.toml | 0.23.1 | 0.24.0 |
| daydream/__init__.py | 0.23.1 | 0.24.0 |
| daydream-review.yml | @v0.23.1 | @v0.24.0 |
| daydream-post.yml | @v0.23.1 | @v0.24.0 |
| single/daydream.yml (x2) | @v0.23.1 | @v0.24.0 |
| uv.lock | 0.23.1 | 0.24.0 |

## Changelog

### Added
- **extensions:** Support an extension API version range instead of strict equality (#275)
- **cli:** Add `--log` flag for CI-friendly raw output (#272)
- **backends/codex:** Expose reasoning-effort control (#271)
- **extensions:** Findings meta-control and tool interdiction (#270, #269)

### Fixed
- **github_app:** Refresh installation tokens before expiry (#273)