### PR TITLE
fix(agent): capture structured output under --log mode

### DIFF
--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -586,11 +586,18 @@ async def run_agent(
                                     inv.observe(event)
 
                             elif isinstance(event, ResultEvent):
-                                if _state.log_mode and event.structured_output is not None:
-                                    print(f"[result] {json.dumps(event.structured_output)[:500]}", flush=True)
-                                elif event.structured_output is not None:
-                                    structured_result = event.structured_output
-                                    if not use_callback:
+                                # Capture the structured result unconditionally: the log-mode
+                                # print is an additive side effect, never a substitute for
+                                # capture (otherwise --log silently drops every structured
+                                # result — exploration conventions, review findings, etc.).
+                                structured_result = event.structured_output
+                                if event.structured_output is not None:
+                                    if _state.log_mode:
+                                        print(
+                                            f"[result] {json.dumps(event.structured_output)[:500]}",
+                                            flush=True,
+                                        )
+                                    elif not use_callback:
                                         issues = (
                                             structured_result.get("issues", [])
                                             if isinstance(structured_result, dict)
@@ -609,8 +616,6 @@ async def run_agent(
                                                     label = i.get("title", i.get("description", ""))
                                                     formatted.append(f"[{i.get('id', '?')}] {label}")
                                             agent_renderer.append("\n".join(formatted))
-                                else:
-                                    structured_result = event.structured_output
                                 result_continuation = event.continuation
 
                                 if inv is not None:

--- a/tests/test_agent_structured_render.py
+++ b/tests/test_agent_structured_render.py
@@ -48,3 +48,20 @@ async def test_plain_text_still_renders(monkeypatch, tmp_path):
     )
     result, _, _ = await run_agent(backend, tmp_path, "go", phase=DaydreamPhase.REVIEW)  # no output_schema
     assert "narration here" in rec.export_text()
+
+
+async def test_log_mode_captures_structured_output(monkeypatch, tmp_path, capsys):
+    """Under --log, the structured result must still be captured, not just printed.
+
+    Regression: the log-mode print and the structured-result capture were an
+    if/elif, so --log dropped every structured result (run_agent returned "").
+    Downstream this emptied exploration conventions/dependencies and review
+    findings across the deep pipeline.
+    """
+    monkeypatch.setattr("daydream.agent._state.log_mode", True)
+    backend = MockBackend([ResultEvent(structured_output=PAYLOAD, continuation=None)])
+    result, _, _ = await run_agent(
+        backend, tmp_path, "scan", phase=DaydreamPhase.REVIEW, output_schema={"type": "object"}
+    )
+    assert result == PAYLOAD  # captured, not discarded
+    assert "[result]" in capsys.readouterr().out  # log-mode print is additive, still happens

--- a/tests/test_agent_structured_render.py
+++ b/tests/test_agent_structured_render.py
@@ -65,3 +65,33 @@ async def test_log_mode_captures_structured_output(monkeypatch, tmp_path, capsys
     )
     assert result == PAYLOAD  # captured, not discarded
     assert "[result]" in capsys.readouterr().out  # log-mode print is additive, still happens
+
+
+async def test_log_mode_structured_result_wins_over_prose_stray_json(monkeypatch, tmp_path):
+    """Under --log, prose containing stray JSON must not be scraped over the real result.
+
+    Regression for the deep cross-stack merge crash ("Cross-stack merge returned
+    no item list (got list)"): the merge agent narrates in prose while emitting a
+    ``{"items": [...]}`` structured result. When --log dropped the captured
+    structured result (the if/elif bug), run_agent fell through to the JSON
+    fallback, which scraped the stray ``[]`` out of prose like
+    "all source artifacts are empty: `[]`" and returned a bare list. The merge
+    phase's ``isinstance(result, dict)`` check then failed with "got list".
+
+    With the fix the captured structured result wins, so the payload survives as a
+    dict and the fallback never runs.
+    """
+    monkeypatch.setattr("daydream.agent._state.log_mode", True)
+    merge_prose = "All source artifacts are empty: `stack-python-records.json` is `[]`. Nothing to merge."
+    payload = {"items": []}
+    backend = MockBackend(
+        [
+            TextEvent(text=merge_prose),
+            ResultEvent(structured_output=payload, continuation=None),
+        ]
+    )
+    result, _, _ = await run_agent(
+        backend, tmp_path, "merge", phase=DaydreamPhase.DEEP, output_schema={"type": "object"}
+    )
+    assert result == payload  # the captured dict, NOT the stray [] scraped from prose
+    assert isinstance(result, dict)  # the exact type the merge phase gate requires

--- a/tests/test_agent_structured_render.py
+++ b/tests/test_agent_structured_render.py
@@ -64,7 +64,9 @@ async def test_log_mode_captures_structured_output(monkeypatch, tmp_path, capsys
         backend, tmp_path, "scan", phase=DaydreamPhase.REVIEW, output_schema={"type": "object"}
     )
     assert result == PAYLOAD  # captured, not discarded
-    assert "[result]" in capsys.readouterr().out  # log-mode print is additive, still happens
+    out = capsys.readouterr().out
+    assert "[result]" in out  # log-mode print is additive, still happens
+    assert "OpenAPI First" in out  # the serialized payload, not just the marker
 
 
 async def test_log_mode_structured_result_wins_over_prose_stray_json(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Under `--log`, every structured `run_agent` call printed its result but returned `""` instead of the payload. This silently emptied exploration conventions/dependencies and dropped review findings across the deep pipeline whenever the CI `--log` flag was set.

## Changes

### Fixed
- `daydream/agent.py`: the `ResultEvent` handler made the log-mode `[result]` print and the structured-result capture mutually exclusive (`if`/`elif`), so log mode never assigned `structured_result`. Capture is now unconditional; the log-mode print is an additive side effect and the interactive issue-rendering stays gated to non-log mode.

### Added
- `tests/test_agent_structured_render.py`: real-path `run_agent` test with log mode on and the backend seam mocked, asserting the structured payload survives the call and is still printed.

## Motivation

The regression was introduced by #272 (`feat(cli): add --log flag`). The symptom surfaced as review agents narrating "The exploration data is thin (no conventions/dependencies)": exploration specialists produced conventions and dependency edges, but `run_agent` discarded them, so `pre_scan` fell back to the static-only context and `.daydream/exploration/{conventions,dependencies}.md` recorded "No data collected". The same path affects the review->findings PARSE, per-stack review records, cross-stack merge/dedup, arbiter, alternatives, and recommendation verdicts — any structured call under `--log`.

## Testing

- New test fails against the pre-fix code with `assert '' == {...}` while `[result]` still prints (exact reproduction), and passes with the fix.
- `make check` green: 2172 passed, 5 skipped (lint + typecheck + full pytest).

- [x] Unit tests added/updated
- [x] Tests pass locally
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)