### PR TITLE
fix(benchmark): keep leaf precision consistent with tp/fp

### DIFF
--- a/daydream/benchmark/anthropic_score.py
+++ b/daydream/benchmark/anthropic_score.py
@@ -477,7 +477,8 @@ async def _evaluate_review(
     total_candidates = len(candidates)
     total_golden = len(golden)
     tp_count = len(true_positives)
-    precision = tp_count / total_candidates if total_candidates > 0 else 0.0
+    predicted_count = tp_count + len(false_positives)
+    precision = tp_count / predicted_count if predicted_count > 0 else 0.0
     recall = tp_count / total_golden if total_golden > 0 else 0.0
 
     return {

--- a/tests/test_benchmark_anthropic_score.py
+++ b/tests/test_benchmark_anthropic_score.py
@@ -203,6 +203,39 @@ async def test_direct_judge_does_not_reuse_one_candidate_for_two_goldens(tmp_pat
 
 
 @pytest.mark.asyncio
+async def test_direct_judge_precision_counts_dedup_siblings_once(tmp_path):
+    """A dedup sibling group is one logical candidate: matching it must not leave
+    its siblings inflating the precision denominator behind ``fp``'s back."""
+    seed_benchmark_data(tmp_path, tool="daydream", body="same bug, said three ways")
+    client = FakeAnthropicJson(
+        [
+            {"issues": ["same bug A", "same bug B", "same bug C"]},
+            {"groups": [[0, 1, 2]]},
+            {"reasoning": "same", "match": True, "confidence": 0.9},
+            {"reasoning": "same", "match": True, "confidence": 0.8},
+            {"reasoning": "same", "match": True, "confidence": 0.7},
+        ]
+    )
+
+    scores = await run_anthropic_scoring(
+        tmp_path,
+        "claude-opus-4-5-20251101",
+        golden_urls=[URL],
+        tool="daydream",
+        client=client,
+    )
+
+    leaf = json.loads(
+        (model_results_dir(tmp_path, "claude-opus-4-5-20251101") / "evaluations.json").read_text()
+    )[URL]["daydream"]
+    assert leaf["tp"] == 1 and leaf["fp"] == 0
+    assert leaf["total_candidates"] == 3
+    assert leaf["precision"] == 1.0
+    assert leaf["precision"] == leaf["tp"] / (leaf["tp"] + leaf["fp"])
+    assert scores.precision == 1.0
+
+
+@pytest.mark.asyncio
 async def test_direct_route_artifacts_are_martian_compatible(tmp_path):
     seed_benchmark_data(tmp_path, tool="daydream", body="candidate")
     client = FakeAnthropicJson(


### PR DESCRIPTION
Addresses the CodeRabbit finding on #282, which merged without this fix applied.

## Problem

Matched dedup siblings are excluded from `false_positives`, but leaf precision still divided by the raw candidate count. A three-candidate sibling group emitted `tp=1`, `fp=0`, `precision=0.33`, while the aggregate in `score.py:282` reported `1.0` from the same numbers.

## Fix

`daydream/benchmark/anthropic_score.py` — compute leaf precision as `tp_count / (tp_count + len(false_positives))`, so it agrees with the `tp`/`fp` it emits and with the aggregate.

`total_candidates` stays in the returned dict as the raw pair count; it feeds the error-ratio guard in `score.py:265`, which correctly wants raw pairs. `recall` is untouched.

## Test

`tests/test_benchmark_anthropic_score.py` — drives the real entrypoint `run_anthropic_scoring` with a 3-candidate dedup sibling group collapsing to 1 logical candidate matching 1 golden. Asserts `tp=1`, `fp=0`, `total_candidates=3`, `precision == 1.0`, and `precision == tp/(tp+fp)`.

Proven to fail against the pre-fix source (old value `1/3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)