### PR TITLE
docs: correct stale ATIF v1.6 references to v1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # daydream
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/existential-birds/daydream)
 
-Daydream is a code-review agent that produces structured training data from its own runs. It reviews diffs using stack-specific [Beagle](https://github.com/existential-birds/beagle) skills, applies fixes, validates via test suite, and records every agent interaction as an [ATIF v1.6](https://www.harborframework.com/docs/agents/trajectory-format) trajectory. A bitemporal corpus pipeline then scores, labels, and projects those trajectories into JSONL datasets for SFT and RL fine-tuning.
+Daydream is a code-review agent that produces structured training data from its own runs. It reviews diffs using stack-specific [Beagle](https://github.com/existential-birds/beagle) skills, applies fixes, validates via test suite, and records every agent interaction as an [ATIF v1.7](https://www.harborframework.com/docs/agents/trajectory-format) trajectory. A bitemporal corpus pipeline then scores, labels, and projects those trajectories into JSONL datasets for SFT and RL fine-tuning.
 
-The goal is an open-weight code-review model (Qwen2.5-Coder-7B, QLoRA) trained on daydream's own trajectory archive, benchmarked against commercial code-review bots on a held-out PR replay corpus.
+The goal is an open-weight code-review model trained on daydream's own trajectory archive, benchmarked against commercial code-review bots on a held-out PR replay corpus.
 
 ![demo](https://github.com/user-attachments/assets/60a80645-36de-410e-afa7-7a96efef3f57)
 
@@ -53,7 +53,7 @@ To update: `git pull && uv sync`
 
 ## Architecture
 
-Daydream runs a deep multi-stack review pipeline (exploration, intent analysis, alternative review, per-stack Beagle skill reviews, arbiter pass, cross-stack merge, recommendation verification), with a `--shallow` single-skill mode for simpler projects. Every run is recorded as an ATIF v1.6 trajectory and archived (unless `--no-archive` is passed). A bitemporal corpus pipeline harvests, scores, and projects those trajectories into JSONL datasets for SFT and RL fine-tuning.
+Daydream runs a deep multi-stack review pipeline (exploration, intent analysis, alternative review, per-stack Beagle skill reviews, arbiter pass, cross-stack merge, recommendation verification), with a `--shallow` single-skill mode for simpler projects. Every run is recorded as an ATIF v1.7 trajectory and archived (unless `--no-archive` is passed). A bitemporal corpus pipeline harvests, scores, and projects those trajectories into JSONL datasets for SFT and RL fine-tuning.
 
 Full architectural details about the review pipeline stages, trajectory recording format, corpus pipeline, training roadmap, and benchmarking methodology are documented on the [project page](https://existentialbirds.com/projects/daydream).
 
@@ -255,7 +255,7 @@ Daydream can run as a self-hosted PR review bot in your own repository's GitHub 
 
 | Path | Description |
 |------|-------------|
-| `.daydream/runs/<id>/trajectory.json` | ATIF v1.6 trajectory (customize with `--trajectory`) |
+| `.daydream/runs/<id>/trajectory.json` | ATIF v1.7 trajectory (customize with `--trajectory`) |
 | `.daydream/runs/<id>/trajectories/` | Forked sub-trajectories from parallel fan-outs |
 | `.daydream/diff.patch` | Unified diff captured at run start |
 | `.daydream/deep/` | Deep pipeline artifacts: intent, per-stack reviews, merged report |

--- a/daydream/backends/pi.py
+++ b/daydream/backends/pi.py
@@ -8,7 +8,7 @@ and translates it into the unified :data:`daydream.backends.AgentEvent` stream.
 Pi is a subprocess + JSONL backend — the same proven shape as
 :mod:`daydream.backends.codex`. The Pi backend is a second instance of that
 pattern; it emits the same event vocabulary so the existing
-:class:`daydream.trajectory.TrajectoryRecorder` produces valid ATIF v1.6
+:class:`daydream.trajectory.TrajectoryRecorder` produces valid ATIF v1.7
 trajectories indistinguishable in shape from the other two backends.
 
 z.ai coding plan wiring (GLM models) is registered via a pi extension at
@@ -380,7 +380,7 @@ class PiBackend:
     """Backend that wraps the Pi CLI subprocess.
 
     Translates the Pi JSONL event stream into the unified ``AgentEvent`` stream
-    so trajectory recording (ATIF v1.6) works identically to Claude/Codex.
+    so trajectory recording (ATIF v1.7) works identically to Claude/Codex.
     """
 
     concise_fix_prompts = True  # GLM produces verbose reasoning in fix prompts

--- a/daydream/benchmark/daydream_run.py
+++ b/daydream/benchmark/daydream_run.py
@@ -202,7 +202,7 @@ def run_daydream_review(
     Args:
         checkout: Path to the target repository checkout to review.
         base_sha: Raw commit-ish (SHA) to diff against, passed verbatim to ``--base``.
-        trajectory_path: Destination for the ATIF v1.6 trajectory JSON.
+        trajectory_path: Destination for the ATIF v1.7 trajectory JSON.
         backend: Reviewer backend; appended as ``--backend <backend>`` when set.
         model: Reviewer model; appended as ``--model <model>`` when set.
         provider: Reviewer provider; forwarded via the ``PI_PROVIDER`` environment

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -193,7 +193,7 @@ def _add_shared_arguments(parser: argparse.ArgumentParser, *, full_help: bool = 
         type=Path,
         dest="trajectory_path",
         help=(
-            "Write ATIF v1.6 trajectory JSON to this path "
+            "Write ATIF v1.7 trajectory JSON to this path "
             "(default: <target>/.daydream/runs/<session_id>/trajectory.json)"
         ) if full_help else argparse.SUPPRESS,
     )

--- a/daydream/eval/analyzer.py
+++ b/daydream/eval/analyzer.py
@@ -1,4 +1,4 @@
-"""Quantitative analysis of ATIF v1.6 trajectory data from daydream runs.
+"""Quantitative analysis of ATIF v1.7 trajectory data from daydream runs.
 
 Parses trajectory JSON files and deep review artifacts, computes metrics
 across cost, tool usage, file coverage, finding quality, grounding, and

--- a/daydream/pr_comment_renderer.py
+++ b/daydream/pr_comment_renderer.py
@@ -192,7 +192,7 @@ def render_run_info_block(trajectory_paths: list[Path]) -> str:
     fallback block ('run details unavailable' + version footer).
 
     Args:
-        trajectory_paths: Filesystem paths to ATIF v1.6 trajectory JSON
+        trajectory_paths: Filesystem paths to ATIF v1.7 trajectory JSON
             files. May be empty (deep-mode parent + sibling forks). Each
             file is parsed independently; metrics are summed across them.
 
@@ -242,7 +242,7 @@ def _load_trajectories(paths: list[Path]) -> list[Trajectory]:
 def _aggregate(trajectories: list[Trajectory], prices: dict[str, ModelPrice]) -> _RunAgg:
     """Walk every step in every trajectory, summing into per-phase rollups.
 
-    ATIF v1.6 spec: ``Step.model_name`` omission implies the model defined in
+    ATIF v1.7 spec: ``Step.model_name`` omission implies the model defined in
     the root-level agent config (``Trajectory.agent.model_name``). We honor
     that by computing ``effective_model = step.model_name or
     traj.agent.model_name`` for each step. Generic backend labels (see
@@ -319,7 +319,7 @@ def _accumulate_metrics(
     - Else mark ``phase.cost_unknown`` and remember the model name for the
       footnote.
 
-    Per ATIF v1.6 (``Step.model_name`` field docs), an omitted step model
+    Per ATIF v1.7 (``Step.model_name`` field docs), an omitted step model
     implies the root-level :attr:`Agent.model_name`. Callers thread that
     value in via ``fallback_model`` so cost synthesis can land on the
     intended model when the step itself doesn't carry an explicit id.

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -160,7 +160,7 @@ class RunConfig:
             :data:`config.DEFAULT_EXPLORATION_MODEL`.
         ignore_paths: Paths to exclude from diffs (passed to `git :(exclude)` pathspecs
             and surfaced in review prompts). Default is an empty list.
-        trajectory_path: Path to write the ATIF v1.6 trajectory JSON. Default-resolved
+        trajectory_path: Path to write the ATIF v1.7 trajectory JSON. Default-resolved
             by run flows to ``<target>/.daydream/runs/<session_id>/trajectory.json``
             when None.
         pr_repo: GitHub repository in ``owner/repo`` format. Auto-detected from ``gh``

--- a/daydream/summarize.py
+++ b/daydream/summarize.py
@@ -1,6 +1,6 @@
 """``daydream summarize <path>`` — print run-info markdown to stdout.
 
-Reads either a single ATIF v1.6 trajectory JSON file or a daydream run
+Reads either a single ATIF v1.7 trajectory JSON file or a daydream run
 directory (``runs/<session_id>/`` shape with a ``trajectory.json`` plus
 optional ``trajectories/<descriptor>.json`` siblings) and prints the same
 rollup + per-phase breakdown table the PR-comment renderer emits, followed

--- a/daydream/training/corpus.py
+++ b/daydream/training/corpus.py
@@ -1,6 +1,6 @@
 """Pure build-corpus projection (gold layer) over the bitemporal archive.
 
-This module owns ATIF-v1.6 trajectory → training-record conversion plus the
+This module owns ATIF-v1.7 trajectory → training-record conversion plus the
 filter/stratify pipeline that selects which archived runs become training
 records. It reads each run's label and reward from the ``as_of``-pinned silver
 annotation (``label_observations``) — *not* the denormalized
@@ -75,7 +75,7 @@ SCHEMA_V1_PATH: Path = Path(__file__).parent / "schema" / "v1.json"
 
 
 def _build_spans(trajectory: dict[str, Any]) -> list[dict[str, Any]]:
-    """Convert an ATIF v1.6 trajectory dict into REASON/ACT span refs.
+    """Convert an ATIF v1.7 trajectory dict into REASON/ACT span refs.
 
     Implements plan §5. The output is a list of ``{step_id, kind, content_path}``
     dicts that point at substructures of ``trajectory["steps"]`` rather than
@@ -282,7 +282,7 @@ def _build_record(
             flat row from the SQLite index. Must carry ``session_id``,
             ``skill``, ``repo_slug``, ``branch``, ``base_branch``, ``head_sha``,
             ``grounding_rate``, and ``archive_path``.
-        trajectory: ATIF v1.6 trajectory dict for this run.
+        trajectory: ATIF v1.7 trajectory dict for this run.
         stack: Routing label (e.g. ``"python"``, ``"react"``). The caller
             derives this from deep-stack detection; pass ``None`` when
             unavailable.


### PR DESCRIPTION
## Summary

The trajectory recorder emits `schema_version="ATIF-v1.7"` (`daydream/trajectory.py:1276`) and the vendored models are pinned to v1.7, but the README and 13 docstrings still described trajectories as v1.6. One of them is user-visible: the `--trajectory` flag's help text.

Found while auditing the README for drift. The README audit turned up nothing else stale — the per-phase flag removals are already documented as removed (line 120), corpus commands already sit under the `corpus` namespace, and `bench` isn't documented at all, so #282 produced no README drift.

## Changes

**README** — three ATIF version corrections (intro, Architecture, Output Files table), plus the stated goal no longer pins a base model or quantization scheme:

> ~~The goal is an open-weight code-review model (Qwen2.5-Coder-7B, QLoRA) trained on...~~
> The goal is an open-weight code-review model trained on...

The training spec no longer fixes either. The base model is selected by criteria — permissive license, first-class support in the training stack, sufficient context, pretrained tool-calling — rather than pinned to a family or parameter count, and the recipe uses bf16 LoRA. Naming a specific 7B model in the README would have been wrong on both counts.

**Docstrings** — `eval/analyzer.py`, `backends/pi.py`, `runner.py`, `cli.py`, `summarize.py`, `pr_comment_renderer.py`, `benchmark/daydream_run.py`, `training/corpus.py`.

## Deliberately not changed

| What | Why |
|---|---|
| `daydream/atif/` | Vendored from Harbor. Its "added in ATIF-v1.6" notes are correct provenance, and its validator legitimately accepts v1.0–v1.7. |
| `training/corpus.py:86` — "(ATIF v1.5 semantics)" | Provenance for when `is_copied_context` was defined, not a claim about what we emit. |

## Verification

`make check` — 2242 passed, 5 skipped. Diff is comments, docstrings, and one argparse help string; no logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)