### PR TITLE
fix(training): make corpus labels evidenced, and make the evidence capturable

### DIFF
--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -349,7 +349,7 @@ def append_label_observation(
         # appended in between cannot mask a genuine automated re-score.
         if source == "auto":
             latest_auto = conn.execute(
-                "SELECT evidence_sha, reward_version, labels FROM label_observations "
+                "SELECT evidence_sha, reward_version, labels, has_posterior FROM label_observations "
                 "WHERE session_id = ? AND source = 'auto' "
                 "ORDER BY observed_at DESC LIMIT 1",
                 (session_id,),
@@ -359,6 +359,9 @@ def append_label_observation(
                 and latest_auto["evidence_sha"] == evidence_sha
                 and latest_auto["reward_version"] == reward_version
                 and latest_auto["labels"] == labels_json
+                # Population membership varies independently of the label (a
+                # local_branch outcome is labeled but not posterior evidence).
+                and latest_auto["has_posterior"] == has_posterior_int
             ):
                 return False
         # Bump observed_at by a microsecond and retry on a same-microsecond

--- a/daydream/findings.py
+++ b/daydream/findings.py
@@ -1,7 +1,7 @@
 """Findings artifact for the Phase A → Phase B review handoff.
 
 Phase A (unprivileged analyze job, has the PR checkout) classifies review
-issues into inline vs body-only placement and serializes the result as a
+issues into inline / file-level / body-only placement and serializes it as a
 strict-schema JSON artifact. Phase B (privileged poster, never touches PR
 code) consumes the artifact and renders/posts from artifact data only.
 
@@ -70,7 +70,7 @@ FINDINGS_SCHEMA: dict[str, Any] = {
                     "fingerprint": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
                     "path": {"type": "string"},
                     "line": {"type": ["integer", "null"]},
-                    "placement": {"enum": ["inline", "body"]},
+                    "placement": {"enum": ["inline", "file", "body"]},
                     "title": {"type": "string"},
                     "body": {"type": "string"},
                     "severity": {"type": ["string", "null"]},
@@ -94,8 +94,8 @@ class ArtifactFinding:
     Attributes:
         fingerprint: 64-hex cross-run dedup identity.
         path: Repo-relative file path the finding targets.
-        line: Snapped inline line, or None for body-only findings.
-        placement: "inline" or "body".
+        line: Snapped inline line, or None for file-level / body-only findings.
+        placement: "inline", "file" (file-level comment), or "body".
         title: Finding title.
         body: Finding body (raw, unrendered).
         severity: Severity label, or None.
@@ -166,14 +166,17 @@ def build_findings_artifact(
 
     Returns:
         The artifact dict, matching ``FINDINGS_SCHEMA``: inline findings
-        carry ``placement="inline"`` with the snapped line; body-only
-        findings carry ``placement="body"`` and ``line=None``.
+        carry ``placement="inline"`` with the snapped line; findings with no
+        line home but whose file is in the PR diff carry ``placement="file"``;
+        the remainder carry ``placement="body"``. Both non-inline placements
+        have ``line=None``.
     """
     classified = pr_review.classify(target_dir, pr, issues)
     findings = [
         _finding_dict(issue, placement="inline", line=entry["line"])
         for entry, issue in zip(classified.inline, classified.inline_issues, strict=True)
     ]
+    findings.extend(_finding_dict(issue, placement="file", line=None) for issue in classified.file_level)
     findings.extend(_finding_dict(issue, placement="body", line=None) for issue in classified.body_only)
     return {
         "schema_version": FINDINGS_SCHEMA_VERSION,

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -906,11 +906,14 @@ def log(repo: Path, base: str, head: str = "HEAD") -> str:
     return proc.stdout.strip()
 
 
-def log_shas(repo: Path, ref: str, *, since: str) -> list[str]:
+def log_shas(repo: Path, ref: str, *, since: str) -> list[str] | None:
     """Return full SHAs of commits on ``since..ref``.
 
-    Soft-failure semantics: returns ``[]`` on any git error or non-zero exit
-    so callers can treat "no commits available" without try/except plumbing.
+    Soft-failure semantics distinguish "we looked and found nothing" from
+    "we could not look": a git failure (commonly a deleted branch ref or a
+    squash-merged SHA that no longer resolves) returns ``None``, never
+    ``[]``. Collapsing the two lets callers read an unanswerable query as a
+    negative answer.
 
     Args:
         since: Base ref or SHA; commits reachable from *ref* but not from
@@ -918,36 +921,37 @@ def log_shas(repo: Path, ref: str, *, since: str) -> list[str]:
 
     Returns:
         List of 40-character SHA strings in ``git log`` output order
-        (newest first). Empty list on any soft failure.
+        (newest first), possibly empty. ``None`` if the query could not be
+        answered.
     """
     try:
         proc = _run_git(repo, ["log", "--pretty=%H", f"{since}..{ref}"], timeout=30)
     except GitTimeoutError:
         _logger.warning(
             "log_shas: git log %s..%s timed out after retries; "
-            "returning empty list",
+            "returning None (commit window unavailable)",
             since,
             ref,
         )
-        return []
+        return None
     except GitError as exc:
         _logger.warning(
             "log_shas: git log %s..%s failed: %s; "
-            "returning empty list",
+            "returning None (commit window unavailable)",
             since,
             ref,
             exc,
         )
-        return []
+        return None
     if proc.returncode != 0:
         _logger.warning(
             "log_shas: git log %s..%s exited non-zero (%d); "
-            "returning empty list",
+            "returning None (commit window unavailable)",
             since,
             ref,
             proc.returncode,
         )
-        return []
+        return None
     return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
 
 

--- a/daydream/pr_review.py
+++ b/daydream/pr_review.py
@@ -7,7 +7,8 @@ Flow:
     1. Locate the open PR for the current branch via `gh pr list`.
     2. Parse issues (from canonical merged items or alt-issue dicts).
     3. Resolve each issue to a real head-SHA line via anchor grep.
-    4. Classify into inline (line within a diff hunk) vs body-only.
+    4. Classify into inline (line within a diff hunk), file-level (file in
+       the diff but no line home), or body-only (last resort).
     5. Render comment bodies, embedding a hidden `daydream-finding` marker
        per fingerprinted issue (cross-run dedup; see `finding_marker`).
     6. Build a single review payload, show a summary, ask y/n.
@@ -108,6 +109,27 @@ class _ClassifiedIssues:
     # Parallel list to `inline`: the original ParsedIssue for each inline
     # comment. Used to roll severity/confidence into the summary body.
     inline_issues: list[ParsedIssue] = field(default_factory=list)
+    # Findings with no diff-line home whose file is still part of the PR
+    # diff. Posted as file-level review comments so they land in
+    # `/pulls/{n}/comments` as repliable threads the labeler can read back.
+    file_level: list[ParsedIssue] = field(default_factory=list)
+
+    def is_empty(self) -> bool:
+        """True when nothing would be posted in any placement.
+
+        Checks ``inline`` (the rendered comment dicts) rather than
+        ``inline_issues``, so the guard holds even if the two parallel lists
+        ever drift.
+        """
+        return not (self.inline or self.file_level or self.body_only)
+
+    def total(self) -> int:
+        """Count of findings across every placement."""
+        return len(self.inline) + len(self.file_level) + len(self.body_only)
+
+    def all_issues(self) -> list[ParsedIssue]:
+        """Every classified :class:`ParsedIssue`, for severity/confidence rollups."""
+        return [*self.inline_issues, *self.file_level, *self.body_only]
 
 
 # --- Public entry points ----------------------------------------------------
@@ -505,6 +527,31 @@ def _gh_pr_diff_for_path(target_dir: Path, pr_number: int, path: str) -> str:
     return ""
 
 
+_DIFF_GIT_HEADER = re.compile(r"(?m)^diff --git a/.+ b/(.+)$")
+
+
+def pr_changed_files(target_dir: Path, pr: PRInfo) -> set[str]:
+    """Return the head-side paths touched by ``pr``.
+
+    Primary path is ``git diff <base>..<head>``; when the local clone cannot
+    resolve ``base_sha`` (rewritten by a rebase) the full PR diff from
+    ``gh pr diff`` is parsed instead — the same two-tier strategy as
+    :func:`file_hunks`.
+
+    GitHub rejects a file-level review comment whose path is not part of the
+    PR diff (HTTP 422), so this set gates file-level placement in
+    :func:`classify`.
+    """
+    changed = set(git_ops.diff_name_only(target_dir, pr.base_sha, pr.head_sha))
+    if changed:
+        return changed
+    try:
+        full_diff = git_ops.gh_pr_diff(target_dir, pr.number)
+    except GitError:
+        return set()
+    return set(_DIFF_GIT_HEADER.findall(full_diff))
+
+
 def _parse_hunks(diff_text: str) -> list[tuple[int, int]]:
     hunks: list[tuple[int, int]] = []
     for m in _HUNK_HEADER.finditer(diff_text):
@@ -549,16 +596,32 @@ def snap_to_hunk(
 def classify(
     target_dir: Path, pr: PRInfo, issues: list[ParsedIssue]
 ) -> _ClassifiedIssues:
-    """Split issues into inline vs body-only based on diff hunks."""
+    """Split issues into inline, file-level, and body-only placements.
+
+    A finding with no resolvable diff-line home is not automatically demoted
+    to the review body: when its file is part of the PR diff it becomes a
+    file-level comment instead. The review body is invisible to the
+    ``/pulls/{n}/comments`` endpoint the labeler reads back, so body-only is
+    the placement of last resort — used only when GitHub could not accept a
+    comment for that path at all.
+    """
     out = _ClassifiedIssues()
     hunks_cache: dict[str, list[tuple[int, int]]] = {}
+    changed_files = pr_changed_files(target_dir, pr)
+
+    def _unplaced(issue: ParsedIssue) -> None:
+        if issue.path in changed_files:
+            out.file_level.append(issue)
+        else:
+            out.body_only.append(issue)
+
     for issue in issues:
         if issue.is_cross_stack:
-            out.body_only.append(issue)
+            _unplaced(issue)
             continue
         line = resolve_line(target_dir, pr.head_sha, issue)
         if line is None:
-            out.body_only.append(issue)
+            _unplaced(issue)
             continue
         if issue.path not in hunks_cache:
             hunks_cache[issue.path] = file_hunks(
@@ -570,7 +633,7 @@ def classify(
             )
         snapped = snap_to_hunk(line, hunks_cache[issue.path])
         if snapped is None:
-            out.body_only.append(issue)
+            _unplaced(issue)
             continue
         out.inline.append(_inline_comment(issue, snapped))
         out.inline_issues.append(issue)
@@ -617,6 +680,23 @@ def _format_inline_body(issue: ParsedIssue) -> str:
     parts = [p for p in (header_line, issue.body) if p]
     agent_prompt = _build_agent_prompt(issue)
     parts.append(agent_prompt)
+    parts.append(DAYDREAM_FOOTER)
+    if issue.fingerprint:
+        parts.append(finding_marker(issue.fingerprint))
+    return "\n\n".join(parts).strip()
+
+
+def _format_file_level_body(issue: ParsedIssue) -> str:
+    """Render the body of a file-level review comment.
+
+    Carries the same :data:`DAYDREAM_FOOTER` badge and hidden finding marker
+    as an inline comment, so the labeler's author check and fingerprint join
+    recognise it without any read-side special-casing.
+    """
+    prefix = "[cross-stack] " if issue.is_cross_stack else ""
+    header = _issue_header(issue, prefix=prefix, always_bold=True)
+    parts = [p for p in (header, issue.body) if p]
+    parts.append(_build_agent_prompt(issue))
     parts.append(DAYDREAM_FOOTER)
     if issue.fingerprint:
         parts.append(finding_marker(issue.fingerprint))
@@ -714,7 +794,7 @@ def _build_consolidated_prompt(
     pr: PRInfo,
 ) -> str:
     """Build a single collapsible prompt block that tells AI agents to fetch and fix review comments."""
-    total = len(classified.inline_issues) + len(classified.body_only)
+    total = classified.total()
 
     prompt_body = (
         f"Fix the {total} review comment(s) posted on this PR.\n"
@@ -841,8 +921,7 @@ def build_payload(
             data; there is no recorder in that process). ``None`` renders the
             live block as usual.
     """
-    all_issues_with_inline_meta = [*classified.body_only]
-    all_issues_with_inline_meta.extend(classified.inline_issues)
+    all_issues_with_inline_meta = classified.all_issues()
 
     body_chunks: list[str] = []
     body_chunks.append("**Code Review Summary**")
@@ -852,7 +931,7 @@ def build_payload(
         body_chunks.append(body_section)
 
     # Consolidated AI agent prompt.
-    if classified.inline_issues or classified.body_only:
+    if not classified.is_empty():
         body_chunks.append(_build_consolidated_prompt(classified, pr))
 
     # Collapsible review info: enriched run-info (rollup + per-phase
@@ -913,7 +992,7 @@ async def _post(
         return
 
     classified = classify(target_dir, pr, issues)
-    if not classified.inline and not classified.body_only:
+    if classified.is_empty():
         print_info(
             console, "No postable issues after classification; skipping PR post."
         )
@@ -923,6 +1002,7 @@ async def _post(
     summary = (
         f"{len(classified.inline)} inline on "
         f"{', '.join(inline_files) if inline_files else '(none)'}, "
+        f"{len(classified.file_level)} file-level, "
         f"{len(classified.body_only)} folded into body"
     )
     print_info(console, f"PR #{pr.number}: {summary}")
@@ -937,6 +1017,17 @@ async def _post(
         print_info(console, "Skipped posting to PR.")
         return
 
+    # File-level comments post first: a failure here has to fall back into the
+    # review body, which is built below.
+    posted, failed = _submit_file_level_comments(target_dir, pr, classified.file_level)
+    if failed:
+        classified.file_level = posted
+        classified.body_only.extend(failed)
+        print_warning(
+            console,
+            f"{len(failed)} file-level comment(s) failed to post; folded into the review body.",
+        )
+
     payload = build_payload(pr, classified)
     review_url, error_msg = _submit_review(target_dir, pr, payload)
     if review_url is None:
@@ -950,6 +1041,43 @@ async def _post(
         return
 
     print_success(console, f"Posted review: {review_url}")
+
+
+def _submit_file_level_comments(
+    target_dir: Path, pr: PRInfo, issues: list[ParsedIssue]
+) -> tuple[list[ParsedIssue], list[ParsedIssue]]:
+    """POST each issue as a file-level review comment; return the ones that failed.
+
+    GitHub rejects ``subject_type`` inside a batch review payload (HTTP 422),
+    so file-level comments must be posted one at a time against
+    ``/pulls/{n}/comments``. Each one becomes a top-level, repliable thread on
+    that endpoint — the surface :func:`index_pr_review_comments` reads — which
+    is what makes these findings labelable at all.
+
+    Failures are returned rather than raised so the caller can fold them back
+    into the review body: a finding that cannot get its own thread must still
+    reach the maintainer.
+
+    Returns:
+        ``(posted, failed)`` partitioning ``issues`` in input order.
+    """
+    endpoint = f"/repos/{pr.owner}/{pr.repo}/pulls/{pr.number}/comments"
+    posted: list[ParsedIssue] = []
+    failed: list[ParsedIssue] = []
+    for issue in issues:
+        payload = {
+            "commit_id": pr.head_sha,
+            "path": issue.path,
+            "subject_type": "file",
+            "body": _format_file_level_body(issue),
+        }
+        try:
+            git_ops.gh_api(target_dir, endpoint, method="POST", input_data=payload)
+        except GitError:
+            failed.append(issue)
+        else:
+            posted.append(issue)
+    return posted, failed
 
 
 def _submit_review(
@@ -1039,10 +1167,12 @@ def post_findings_from_artifact(
         if finding.placement == "inline" and finding.line is not None:
             classified.inline.append(_inline_comment(issue, finding.line))
             classified.inline_issues.append(issue)
+        elif finding.placement == "file":
+            classified.file_level.append(issue)
         else:
             classified.body_only.append(issue)
 
-    if not classified.inline and not classified.body_only:
+    if classified.is_empty():
         print_info(
             console,
             f"No new findings to post ({len(plan.matched)} already on PR #{pr_number}).",
@@ -1059,6 +1189,15 @@ def post_findings_from_artifact(
         repo=repo_name,
         url="",
     )
+    posted_files, failed_files = _submit_file_level_comments(target_dir, pr, classified.file_level)
+    if failed_files:
+        classified.file_level = posted_files
+        classified.body_only.extend(failed_files)
+        print_info(
+            console,
+            f"{len(failed_files)} file-level comment(s) failed to post; folded into the review body.",
+        )
+
     payload = build_payload(pr, classified, run_info_override=artifact.run_info)
     review_url, error_msg = _submit_review(target_dir, pr, payload)
     if review_url is None:

--- a/daydream/pr_review.py
+++ b/daydream/pr_review.py
@@ -1034,10 +1034,14 @@ async def _post(
         # ``error_msg`` carries the GitError text from git_ops, which includes
         # the preserved tempfile path on failure (see git_ops.gh_api).
         suffix = f" ({error_msg})" if error_msg else ""
-        print_warning(
-            console,
-            f"Failed to post PR review; no comments were posted.{suffix}",
+        # File-level comments post before the review, so some may already be
+        # live on the PR — saying "no comments were posted" would be false.
+        already = (
+            f" {len(classified.file_level)} file-level comment(s) were already posted."
+            if classified.file_level
+            else " No comments were posted."
         )
+        print_warning(console, f"Failed to post PR review;{already}{suffix}")
         return
 
     print_success(console, f"Posted review: {review_url}")
@@ -1202,11 +1206,12 @@ def post_findings_from_artifact(
     review_url, error_msg = _submit_review(target_dir, pr, payload)
     if review_url is None:
         suffix = f" ({error_msg})" if error_msg else ""
-        print_error(
-            console,
-            "PR Review Post Failed",
-            f"No comments were posted.{suffix}",
+        already = (
+            f"{len(posted_files)} file-level comment(s) were already posted."
+            if posted_files
+            else "No comments were posted."
         )
+        print_error(console, "PR Review Post Failed", f"{already}{suffix}")
         return 1
     print_success(console, f"Posted review: {review_url}")
     return 0

--- a/daydream/training/corpus.py
+++ b/daydream/training/corpus.py
@@ -751,15 +751,30 @@ def _is_posterior_leak(annotation: dict[str, Any] | None, as_of: str | None) -> 
     return datetime.fromisoformat(valid_at) > datetime.fromisoformat(as_of)
 
 
-def _is_admitted(label: str | None, composite_reward: float | None, filters: CorpusFilters) -> bool:
+def _is_admitted(
+    label: str | None,
+    composite_reward: float | None,
+    filters: CorpusFilters,
+    *,
+    has_posterior: bool = False,
+) -> bool:
     """Decide whether a run is admitted into the corpus.
 
     Admission rule (C9, with an alternative reward path):
 
     - ``include_all_labels=True`` ⇒ always admit.
     - Otherwise admit when the pinned ``label`` is in ``filters.labels``
-      (C9 accepted-only), **OR** when ``filters.min_reward`` is set and the
-      intrinsic ``composite_reward`` is present and ``>= min_reward``.
+      **and the row carries posterior evidence** (C9 accepted-only), **OR**
+      when ``filters.min_reward`` is set and the intrinsic
+      ``composite_reward`` is present and ``>= min_reward``.
+
+    The ``has_posterior`` conjunct is what makes the label path mean
+    "a maintainer acted on this in a PR". A ``local_branch`` outcome carries a
+    label but no posterior evidence (a local commit is not a maintainer acting
+    in a PR), so a bare label check would admit it into an accepted-only corpus
+    as though it were an evidenced maintainer accept, silently mixing evidence
+    tiers. Rows whose label is not backed by a posterior are admissible only via
+    the explicit intrinsic ``min_reward`` path or ``include_all_labels``.
 
     The ``min_reward`` comparison is intrinsic-only **by construction** (C5),
     not by stripping a posterior term. Post-C5 the stored ``composite_reward``
@@ -773,7 +788,7 @@ def _is_admitted(label: str | None, composite_reward: float | None, filters: Cor
     """
     if filters.include_all_labels:
         return True
-    if label is not None and label in filters.labels:
+    if label is not None and label in filters.labels and has_posterior:
         return True
     if filters.min_reward is not None and composite_reward is not None and composite_reward >= filters.min_reward:
         return True
@@ -897,7 +912,9 @@ def run_build_corpus(config: BuildCorpusConfig) -> dict[str, int]:
             labels = _annotation_labels(annotation, session_id)
             label = _single_outcome_label(labels, session_id)
         composite_reward = annotation.get("composite_reward") if annotation is not None else None
-        if not _is_admitted(label, composite_reward, config.filters):
+        # A leaked posterior is not evidence at this pin, so it cannot admit on the label path.
+        has_posterior = bool(annotation.get("has_posterior")) and not posterior_leak if annotation else False
+        if not _is_admitted(label, composite_reward, config.filters, has_posterior=has_posterior):
             continue
         after_filters += 1
 

--- a/daydream/training/harvest.py
+++ b/daydream/training/harvest.py
@@ -306,11 +306,13 @@ def _commits_in_window(repo: Path, head: str, base: str) -> list[str]:
     return list(reversed(git_ops.log_shas_since(repo, head, base)))
 
 
-def _commits_since(repo: Path, branch: str, since: str) -> list[str]:
-    """Return commits on ``branch`` after ``since``.
+def _commits_since(repo: Path, branch: str, since: str) -> list[str] | None:
+    """Return commits on ``branch`` after ``since``, or ``None`` if unknowable.
 
     Used by the local-branch posterior path to walk commits pushed after
-    the daydream-recorded ``head_sha``.
+    the daydream-recorded ``head_sha``. ``None`` propagates the "could not
+    look" case (deleted branch ref, squash-merged head SHA) so the caller
+    does not read it as "no follow-up commit".
     """
     return git_ops.log_shas(repo, branch, since=since)
 

--- a/daydream/training/harvest.py
+++ b/daydream/training/harvest.py
@@ -562,8 +562,11 @@ class AnnotationPayload:
             seeded the posterior axis — captured at harvest time (irreproducible
             later) and persisted. ``[]`` for local/non-PR rows.
         has_posterior: Population discriminator — ``True`` when the scored
-            breakdown is a :class:`~daydream.training.reward.PosteriorBreakdown`
-            (a mapped maintainer outcome label was supplied).
+            breakdown is a :class:`~daydream.training.reward.PosteriorBreakdown`,
+            i.e. a ``pr_review`` row whose maintainer outcome label mapped to a
+            penalty. ``local_branch`` rows keep their label but are **not**
+            posterior evidence (a local commit is not a maintainer acting in a
+            PR), so they carry ``False`` and no ``posterior_cost``.
     """
 
     labels: list[str]
@@ -621,11 +624,13 @@ def build_annotation(
     rows have no reviewer set (``reviewer_logins=[]``, ``outcome_prior=None``,
     ``outcome_prior_n=0``).
 
-    Scores the reward via :func:`~daydream.training.reward.score_trajectory` with
-    the outcome label + prior; a mapped label yields a
-    :class:`~daydream.training.reward.PosteriorBreakdown` whose ``composite`` is
-    the pure intrinsic score (C5 — the posterior penalty is a sibling, never
-    folded in). Asserts the breakdown carries the canonical
+    Scores the reward via :func:`~daydream.training.reward.score_trajectory`. The
+    outcome label is fed to the posterior axis **only** for ``pr_review`` rows;
+    ``local_branch`` outcomes keep their label but are withheld from
+    ``pr_feedback`` so they never enter the posterior population. A mapped label
+    yields a :class:`~daydream.training.reward.PosteriorBreakdown` whose
+    ``composite`` is the pure intrinsic score (C5 — the posterior penalty is a
+    sibling, never folded in). Asserts the breakdown carries the canonical
     :data:`~daydream.training.reward.REWARD_VERSION` before returning, so a
     non-canonical (analysis-time override) score can never reach canonical
     storage. Returns a frozen :class:`AnnotationPayload`; the orchestrator
@@ -722,9 +727,13 @@ def build_annotation(
     labels = [outcome_label] if outcome_label != "unknown" else []
 
     inputs = assemble_scoring_inputs(run_dir, row)
+    # Only a maintainer acting on a real PR is posterior evidence; a local commit
+    # containing the recommended lines is a weaker tier and must not enter the
+    # posterior population (the label is still recorded on `labels`).
+    posterior_feedback = outcome_label if rubric.posterior_source == "pr_review" else None
     rb = score_trajectory(
         inputs,
-        pr_feedback=outcome_label,
+        pr_feedback=posterior_feedback,
         outcome_prior=outcome_prior,
         outcome_prior_n=prior_n,
     )

--- a/daydream/training/labeler_signals.py
+++ b/daydream/training/labeler_signals.py
@@ -593,6 +593,45 @@ def pr_link_signal(
     return None
 
 
+def _default_branch_applied(
+    row: dict[str, Any],
+    *,
+    repo_clone: Path,
+    hunks: list[_Hunk],
+    file_at_fetcher: Callable[[Path, str, str], str],
+) -> LocalCommitAppliedSignal:
+    """Fallback posterior when the recorded branch ref no longer resolves.
+
+    A squash merge rewrites the commit and deletes the branch, so the
+    per-commit walk has nothing to walk. The recommended change, if it
+    landed, is still visible at the tip of the base branch — so check there.
+
+    ``origin/<base>`` is tried before the bare local ref: a stale worktree's
+    local branch can sit behind the remote, which would read a landed change
+    as absent. ``file_at_fetcher`` yields ``""`` for an unresolvable ref, so
+    an unusable candidate simply falls through.
+
+    Returns ``"applied"`` when a recommended hunk is present, else
+    ``"unknown"`` — absence at the tip is not evidence of rejection, since
+    the squash may have reworked the change beyond verbatim matching.
+    """
+    base_branch = row.get("base_branch")
+    if not base_branch or not hunks:
+        return LocalCommitAppliedSignal(verdict="unknown")
+
+    for ref in (f"origin/{base_branch}", base_branch):
+        file_content_cache: dict[str, str] = {}
+        for hunk in hunks:
+            content = file_content_cache.get(hunk.file)
+            if content is None:
+                content = file_at_fetcher(repo_clone, hunk.file, ref)
+                file_content_cache[hunk.file] = content
+            if _hunk_lines_present(hunk.added_lines, content):
+                return LocalCommitAppliedSignal(verdict="applied")
+
+    return LocalCommitAppliedSignal(verdict="unknown")
+
+
 def local_commit_applied_signal(
     row: dict[str, Any],
     *,
@@ -616,10 +655,13 @@ def local_commit_applied_signal(
 
     Returns:
         :class:`LocalCommitAppliedSignal` with ``verdict="unknown"``
-        when ``repo_clone`` is not a directory or the commit window is
-        unknowable, ``"rejected"`` when no commits follow ``head_sha`` or
-        none contain the recommended hunk's added lines, and ``"applied"``
-        when at least one does.
+        when ``repo_clone`` is not a directory, ``"rejected"`` when no
+        commits follow ``head_sha`` or none contain the recommended hunk's
+        added lines, and ``"applied"`` when at least one does.
+
+        When the branch ref no longer resolves (``commits_since_fetcher``
+        returns ``None``), falls back to :func:`_default_branch_applied`,
+        which yields ``"applied"`` or ``"unknown"`` — never ``"rejected"``.
 
     Raises:
         KeyError: If ``row`` is missing ``archive_path``, ``branch``,
@@ -640,9 +682,13 @@ def local_commit_applied_signal(
 
     commits = commits_since_fetcher(repo_clone, row["branch"], row["head_sha"])
     if commits is None:
-        # Window unknowable (deleted branch ref / squash-merged head SHA) —
-        # indistinguishable from "no follow-up commit", so do not call it rejected.
-        return LocalCommitAppliedSignal(verdict="unknown")
+        # Branch ref unreadable — the usual cause is a squash merge, which
+        # deletes the branch. The question the posterior actually asks ("did
+        # the recommended change land?") survives that, so ask it of the
+        # default branch instead of giving up.
+        return _default_branch_applied(
+            row, repo_clone=repo_clone, hunks=hunks, file_at_fetcher=file_at_fetcher
+        )
     if not commits:
         return LocalCommitAppliedSignal(verdict="rejected")
 

--- a/daydream/training/labeler_signals.py
+++ b/daydream/training/labeler_signals.py
@@ -130,7 +130,8 @@ class LocalCommitAppliedSignal:
     Attributes:
         verdict: ``"applied"`` if a later local commit contains the
             recommended diff content; ``"rejected"`` if no qualifying
-            commit exists; ``"unknown"`` if the repo clone is missing.
+            commit exists; ``"unknown"`` if the repo clone is missing or
+            the commit window could not be read.
     """
 
     verdict: Literal["applied", "rejected", "unknown"]
@@ -596,7 +597,7 @@ def local_commit_applied_signal(
     row: dict[str, Any],
     *,
     repo_clone: Path,
-    commits_since_fetcher: Callable[[Path, str, str], list[str]],
+    commits_since_fetcher: Callable[[Path, str, str], list[str] | None],
     file_at_fetcher: Callable[[Path, str, str], str],
 ) -> LocalCommitAppliedSignal:
     """Posterior signal for PR-less runs.
@@ -610,14 +611,15 @@ def local_commit_applied_signal(
         row: Manifest row with ``branch``, ``head_sha``, ``archive_path``.
         repo_clone: Path to local clone. ``"unknown"`` if not a directory.
         commits_since_fetcher: Returns ordered commit SHAs on ``branch``
-            after ``since_sha``.
+            after ``since_sha``, or ``None`` if the window is unknowable.
         file_at_fetcher: Returns file content at a given SHA.
 
     Returns:
         :class:`LocalCommitAppliedSignal` with ``verdict="unknown"``
-        when ``repo_clone`` is not a directory, ``"rejected"`` when no
-        commits follow ``head_sha`` or none contain the recommended
-        hunk's added lines, and ``"applied"`` when at least one does.
+        when ``repo_clone`` is not a directory or the commit window is
+        unknowable, ``"rejected"`` when no commits follow ``head_sha`` or
+        none contain the recommended hunk's added lines, and ``"applied"``
+        when at least one does.
 
     Raises:
         KeyError: If ``row`` is missing ``archive_path``, ``branch``,
@@ -637,6 +639,10 @@ def local_commit_applied_signal(
     hunks = _parse_diff_hunks(diff_patch)
 
     commits = commits_since_fetcher(repo_clone, row["branch"], row["head_sha"])
+    if commits is None:
+        # Window unknowable (deleted branch ref / squash-merged head SHA) —
+        # indistinguishable from "no follow-up commit", so do not call it rejected.
+        return LocalCommitAppliedSignal(verdict="unknown")
     if not commits:
         return LocalCommitAppliedSignal(verdict="rejected")
 

--- a/daydream/training/rubric.py
+++ b/daydream/training/rubric.py
@@ -95,8 +95,12 @@ def derive_outcome_label(rubric: Rubric) -> str:
     Selection follows ``rubric.posterior_source``:
 
     * ``"pr_review"`` — merge-state plus comment resolution decide:
-      ``"accepted"`` (merged, no unresolved bot comments), ``"contested"``
-      (merged but unresolved > 0), or ``"rejected"`` (not merged).
+      ``"accepted"`` (merged, at least one tracked daydream comment, none
+      unresolved), ``"contested"`` (merged but unresolved > 0),
+      ``"rejected"`` (not merged), or ``"unknown"`` (merged with **zero**
+      tracked comments). A merge alone is not an accept: with ``total == 0``
+      the run has no evidence it contributed anything to the PR, and
+      ``unresolved == 0`` would otherwise be vacuously true.
     * ``"local_branch"`` — passes through the verdict on
       :attr:`Rubric.local_commit_applied`.
     * ``"none"`` — always ``"unknown"``.
@@ -107,6 +111,9 @@ def derive_outcome_label(rubric: Rubric) -> str:
     """
     if rubric.posterior_source == "pr_review":
         if rubric.pr_merge.merged:
+            if rubric.comment_resolution.total == 0:
+                # No tracked comments ⇒ unresolved == 0 is vacuous, not evidence.
+                return "unknown"
             if rubric.comment_resolution.unresolved == 0:
                 return "accepted"
             return "contested"

--- a/tests/fixtures/training/build_archive.py
+++ b/tests/fixtures/training/build_archive.py
@@ -183,4 +183,7 @@ def build_fixture_archive(root: Path) -> None:
             labeler_version="fixture",
             evidence_sha=None,
             valid_at=None,
+            # Fixture labels stand in for evidenced pr_review outcomes, which is
+            # what the label path admits post-posterior-gate.
+            has_posterior=bool(session.outcome_labels),
         )

--- a/tests/harness/fake_gh.py
+++ b/tests/harness/fake_gh.py
@@ -129,6 +129,14 @@ def _opt(argv, name):
     return None
 
 
+def _next_comment_seq():
+    """Monotonic counter so each posted comment gets a distinct id."""
+    seq_file = HERE / "comment_seq"
+    n = int(seq_file.read_text()) + 1 if seq_file.exists() else 1
+    seq_file.write_text(str(n))
+    return n
+
+
 def _record(kind, argv, stdin):
     with CALLS.open("a", encoding="utf-8") as f:
         f.write(json.dumps({"kind": kind, "argv": argv, "stdin": stdin}) + "\\n")
@@ -254,6 +262,19 @@ def main():
         return 0
     if method == "POST" and re.fullmatch(r"repos/[^/]+/[^/]+/pulls/\\d+/reviews", endpoint):
         print(json.dumps({"html_url": "https://github.test/fake/pull/7#pullrequestreview-1"}))
+        return 0
+    if method == "POST" and re.fullmatch(r"repos/[^/]+/[^/]+/pulls/\\d+/comments", endpoint):
+        # Real GitHub 422s a file-level comment whose path is not in the PR
+        # diff; `diff-paths`, when configured, reproduces that rejection.
+        allowed = responses.get("diff-paths")
+        path = (payload or {}).get("path")
+        if allowed is not None and path not in allowed:
+            sys.stderr.write("fake gh: path %r not in PR diff (422)\\n" % (path,))
+            return 1
+        print(json.dumps({
+            "id": 9000 + _next_comment_seq(),
+            "html_url": "https://github.test/fake/pull/7#discussion_r1",
+        }))
         return 0
     sys.stderr.write("fake gh: no canned response for %s\\n" % key)
     return 1

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -764,6 +764,32 @@ def test_auto_append_dedups_on_unchanged_evidence(tmp_path: Path):
     assert len(label_observation_history(tmp_path, "s-dedup")) == 2
 
 
+def test_auto_append_appends_when_only_has_posterior_changes(tmp_path: Path):
+    """A re-score that moves a row out of the posterior population must append.
+
+    ``has_posterior`` is no longer a function of the label: a ``local_branch``
+    outcome carries a label but is not maintainer-PR evidence. If the
+    idempotency key ignored it, a re-harvest that demotes such a row would
+    silently no-op and leave the stale population flag in place.
+    """
+    upsert_run(tmp_path, _make_manifest(session_id="s-pop"))
+    first = append_label_observation(tmp_path, "s-pop", labels=["accepted"], pr_state=None,
+                                     labeler_version="rv1", evidence_sha="shaA",
+                                     reward_version="rv1", has_posterior=True, source="auto")
+    demoted = append_label_observation(tmp_path, "s-pop", labels=["accepted"], pr_state=None,
+                                       labeler_version="rv1", evidence_sha="shaA",
+                                       reward_version="rv1", has_posterior=False, source="auto")
+    assert first is True and demoted is True
+    assert len(label_observation_history(tmp_path, "s-pop")) == 2
+    latest = latest_label_observation(tmp_path, "s-pop")
+    assert latest is not None and latest["has_posterior"] == 0
+    # Still idempotent once the demotion has landed.
+    assert append_label_observation(tmp_path, "s-pop", labels=["accepted"], pr_state=None,
+                                    labeler_version="rv1", evidence_sha="shaA",
+                                    reward_version="rv1", has_posterior=False,
+                                    source="auto") is False
+
+
 def test_human_append_never_dedups(tmp_path: Path):
     upsert_run(tmp_path, _make_manifest(session_id="s-h"))
     append_label_observation(tmp_path, "s-h", labels=["accepted"], pr_state=None,

--- a/tests/test_capture_loop.py
+++ b/tests/test_capture_loop.py
@@ -1,0 +1,262 @@
+"""Real-path tests that the posterior-capture loop closes.
+
+A finding is only labelable if it reaches ``/pulls/{n}/comments`` as a
+top-level, repliable thread carrying :data:`DAYDREAM_FOOTER` and
+``finding_marker(fingerprint)``. The review *body* carries those markers too,
+but that surface is invisible to :func:`index_pr_review_comments` — so a
+finding folded into the body is permanently unlabelable.
+
+These tests cover the two halves of that loop:
+
+* placement — a finding with no diff-line home whose file IS in the PR diff
+  must be classified ``"file"``, not ``"body"`` (driven through
+  ``runner.run`` with a real git worktree);
+* capture — driving ``daydream post-findings`` from ``cli.main`` with a real
+  ``gh`` subprocess seam must produce a comment on ``/pulls/{n}/comments``
+  that the labeler's own signals read back, count, and resolve on reply.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from daydream import cli, git_ops
+from daydream.backends import ResultEvent, TextEvent
+from daydream.findings import FINDINGS_SCHEMA_VERSION, write_findings_artifact
+from daydream.pr_review import PRInfo, parse_finding_markers
+from daydream.runner import RunConfig, run
+from daydream.training.labeler_signals import (
+    comment_resolution_signal,
+    index_pr_review_comments,
+    per_finding_resolution_signal,
+)
+from tests.harness.phase_backend import PhaseDispatchBackend
+
+FILE_FINGERPRINT = "f" * 64
+
+
+def _never_fetch(*_args, **_kwargs):
+    """A gh_api that must never be called: `threads=` makes the fetch unnecessary."""
+    raise AssertionError("gh_api must not be called when threads= is supplied")
+
+
+def cli_main(argv: list[str]) -> int:
+    """Drive ``cli.main`` with ``argv`` and return its exit code."""
+    import sys
+
+    saved = sys.argv
+    sys.argv = ["daydream", *argv]
+    try:
+        cli.main()
+    except SystemExit as exc:
+        return int(exc.code or 0)
+    finally:
+        sys.argv = saved
+    raise AssertionError("cli.main() must exit via sys.exit")
+
+
+# --- Placement: an unplaceable finding on a changed file goes file-level -----
+
+
+@contextmanager
+def _review_run_env(repo: Path, monkeypatch, out: Path, backend, pr: PRInfo):
+    """`--review --findings-out` real-path setup, mocking only the backend + gh lookups."""
+    monkeypatch.delenv("DAYDREAM_APP_ID", raising=False)
+    monkeypatch.delenv("DAYDREAM_APP_PRIVATE_KEY", raising=False)
+    config = RunConfig(
+        target=str(repo),
+        output_mode="review",
+        pr_number=7,
+        findings_out=str(out),
+        non_interactive=True,
+    )
+    with (
+        patch("daydream.runner.create_backend", return_value=backend),
+        patch("daydream.github_app.resolve_user_identity", return_value="tester"),
+        patch("daydream.pr_review.find_pr_by_number", return_value=pr),
+    ):
+        yield config
+
+
+async def test_unanchorable_finding_on_changed_file_is_placed_file_level(
+    feature_branch_repo, monkeypatch, tmp_path
+):
+    """A finding whose anchors match nothing still gets a trackable placement.
+
+    Enters from ``runner.run`` against a real git worktree. The scripted issue
+    targets ``main.py`` — a file genuinely in the PR diff — but its text
+    contains no token present in that file, so anchor resolution yields no
+    line. Before the fix this fell through to ``placement="body"``, which no
+    posterior signal can ever read back. It must now be ``"file"``.
+    """
+    out = tmp_path / "findings.json"
+    issue = {
+        "id": 1,
+        "title": "Module lacks a rollback barrier",
+        "description": "No `quiescent_rollback_barrier` guards this module",
+        "recommendation": "Introduce a `quiescent_rollback_barrier`",
+        "severity": "medium",
+        "confidence": "HIGH",
+        "files": ["main.py"],
+        "rationale": "",
+    }
+    backend = PhaseDispatchBackend(
+        events=[
+            TextEvent(text="Review complete."),
+            ResultEvent(structured_output={"issues": [issue]}, continuation=None),
+        ]
+    )
+    head = git_ops.head_sha(feature_branch_repo)
+    base = subprocess.run(  # noqa: S603 - arguments are not user-controlled
+        ["git", "rev-parse", "main"],  # noqa: S607 - git is a trusted command
+        cwd=feature_branch_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    pr = PRInfo(
+        number=7,
+        head_sha=head,
+        base_sha=base,
+        base_ref="main",
+        owner="o",
+        repo="r",
+        url="https://example.invalid/pr/7",
+    )
+
+    with _review_run_env(feature_branch_repo, monkeypatch, out, backend, pr) as config:
+        assert await run(config) == 0
+
+    findings = json.loads(out.read_text())["findings"]
+    assert findings, "scripted issue must survive to the artifact"
+    main_py = [f for f in findings if f["path"] == "main.py"]
+    assert main_py, "the finding must target the changed file"
+    assert [f["placement"] for f in main_py] == ["file"], (
+        "a finding on a file in the PR diff with no resolvable line must be "
+        f"placed file-level, not folded into the invisible review body: {main_py}"
+    )
+
+
+# --- Capture: the posted comment is read back by the labeler's own signals ---
+
+
+def _artifact(path: Path, findings: list[dict]) -> Path:
+    write_findings_artifact(
+        path,
+        {
+            "schema_version": FINDINGS_SCHEMA_VERSION,
+            "repo": "o/r",
+            "pr_number": 7,
+            "head_sha": "h" * 40,
+            "run_info": "test run info",
+            "findings": findings,
+        },
+    )
+    return path
+
+
+@pytest.fixture
+def file_level_artifact(tmp_path: Path) -> Path:
+    """One finding with ``placement="file"`` on a path inside the PR diff."""
+    return _artifact(
+        tmp_path / "findings.json",
+        [
+            {
+                "fingerprint": FILE_FINGERPRINT,
+                "path": "b.py",
+                "line": None,
+                "placement": "file",
+                "title": "Cross-cutting concern in b.py",
+                "body": "Body text",
+                "severity": "high",
+                "confidence": "HIGH",
+                "is_cross_stack": True,
+            }
+        ],
+    )
+
+
+def _posted_comments(fake_gh) -> list[dict]:
+    """Rebuild the ``/comments`` GET payload from what actually crossed the gh boundary."""
+    posts = fake_gh.calls("POST", "/repos/o/r/pulls/7/comments")
+    return [
+        {
+            "id": 9000 + i,
+            "in_reply_to_id": None,
+            "user": {"login": "daydream-review"},
+            "body": call.payload["body"],
+        }
+        for i, call in enumerate(posts, start=1)
+    ]
+
+
+def test_file_level_finding_is_captured_and_resolvable(fake_gh, file_level_artifact) -> None:
+    """The full loop: post → read back → count → resolve on reply.
+
+    Drives ``daydream post-findings`` from ``cli.main`` with the real
+    ``git_ops`` subprocess seam (only the ``gh`` binary is faked), then feeds
+    the comments that actually crossed that boundary into the labeler's own
+    signals. Asserts the rubric-visible outcome, not that anything was called.
+    """
+    fake_gh.set_response("diff-paths", value=["b.py"])
+    assert cli_main(
+        ["post-findings", str(file_level_artifact), "--pr", "7", "--head-sha", "h" * 40, "--repo", "o/r"]
+    ) == 0
+
+    # 1. The finding reached /pulls/{n}/comments carrying footer + marker.
+    posts = fake_gh.calls("POST", "/repos/o/r/pulls/7/comments")
+    assert len(posts) == 1, "the file-level finding must be posted as its own comment"
+    body = posts[0].payload["body"]
+    assert posts[0].payload["subject_type"] == "file"
+    assert "<sub>🧙 Posted by [daydream v" in body, "footer identifies daydream authorship"
+    assert parse_finding_markers(body) == [FILE_FINGERPRINT]
+
+    # 2. The labeler reads it back off that endpoint.
+    comments = _posted_comments(fake_gh)
+    row = {"pr_repo": "o/r", "pr_number": 7}
+    threads = index_pr_review_comments(row, gh_api=lambda *a, **k: comments)
+    assert threads is not None
+    unreplied = comment_resolution_signal(row, gh_api=_never_fetch, threads=threads)
+    assert unreplied.total == 1, "the finding must be a trackable top-level comment"
+    assert unreplied.unresolved == 1
+
+    # 3. A maintainer reply moves it to resolved — per-finding, by fingerprint.
+    reply = {
+        "id": 9999,
+        "in_reply_to_id": comments[0]["id"],
+        "user": {"login": "kevin"},
+        "body": "fixed",
+    }
+    replied = [*comments, reply]
+    threads = index_pr_review_comments(row, gh_api=lambda *a, **k: replied)
+    assert threads is not None
+    assert comment_resolution_signal(row, gh_api=_never_fetch, threads=threads).unresolved == 0
+    per_finding = per_finding_resolution_signal(
+        row, recorded_fingerprints=[FILE_FINGERPRINT], gh_api=_never_fetch, threads=threads
+    )
+    assert [(r.fingerprint, r.resolved) for r in per_finding] == [(FILE_FINGERPRINT, True)]
+
+
+def test_file_level_post_rejected_falls_back_to_review_body(fake_gh, file_level_artifact) -> None:
+    """A finding GitHub refuses a file-level comment for is never silently dropped.
+
+    ``diff-paths`` excludes ``b.py``, so the shim 422s the file-level POST the
+    way real GitHub does for a path outside the PR diff. The finding must then
+    appear in the review body — worse for capture, but delivered.
+    """
+    fake_gh.set_response("diff-paths", value=["other.py"])
+    assert cli_main(
+        ["post-findings", str(file_level_artifact), "--pr", "7", "--head-sha", "h" * 40, "--repo", "o/r"]
+    ) == 0
+
+    reviews = fake_gh.calls("POST", "/repos/o/r/pulls/7/reviews")
+    assert len(reviews) == 1
+    assert parse_finding_markers(reviews[0].payload["body"]) == [FILE_FINGERPRINT], (
+        "a rejected file-level finding must fall back into the review body"
+    )

--- a/tests/test_capture_loop.py
+++ b/tests/test_capture_loop.py
@@ -19,7 +19,6 @@ These tests cover the two halves of that loop:
 from __future__ import annotations
 
 import json
-import subprocess
 from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
@@ -29,7 +28,7 @@ import pytest
 from daydream import cli, git_ops
 from daydream.backends import ResultEvent, TextEvent
 from daydream.findings import FINDINGS_SCHEMA_VERSION, write_findings_artifact
-from daydream.pr_review import PRInfo, parse_finding_markers
+from daydream.pr_review import parse_finding_markers
 from daydream.runner import RunConfig, run
 from daydream.training.labeler_signals import (
     comment_resolution_signal,
@@ -65,10 +64,27 @@ def cli_main(argv: list[str]) -> int:
 
 
 @contextmanager
-def _review_run_env(repo: Path, monkeypatch, out: Path, backend, pr: PRInfo):
-    """`--review --findings-out` real-path setup, mocking only the backend + gh lookups."""
+def _review_run_env(repo: Path, monkeypatch, out: Path, backend, fake_gh):
+    """`--review --findings-out` real-path setup, mocking ONLY the backend seam.
+
+    PR discovery runs for real through ``git_ops``' ``gh`` subprocess seam
+    against the fake ``gh`` binary, so a regression in PR lookup surfaces here
+    instead of being patched out.
+    """
     monkeypatch.delenv("DAYDREAM_APP_ID", raising=False)
     monkeypatch.delenv("DAYDREAM_APP_PRIVATE_KEY", raising=False)
+    fake_gh.serve_pr_view(
+        {
+            "number": 7,
+            "state": "OPEN",
+            "headRefName": "feature",
+            "baseRefName": "main",
+            "headRefOid": git_ops.head_sha(repo),
+            "baseRefOid": git_ops.merge_base(repo, "main"),
+            "url": "https://github.com/acme/widgets/pull/7",
+            "body": "",
+        }
+    )
     config = RunConfig(
         target=str(repo),
         output_mode="review",
@@ -76,16 +92,12 @@ def _review_run_env(repo: Path, monkeypatch, out: Path, backend, pr: PRInfo):
         findings_out=str(out),
         non_interactive=True,
     )
-    with (
-        patch("daydream.runner.create_backend", return_value=backend),
-        patch("daydream.github_app.resolve_user_identity", return_value="tester"),
-        patch("daydream.pr_review.find_pr_by_number", return_value=pr),
-    ):
+    with patch("daydream.runner.create_backend", return_value=backend):
         yield config
 
 
 async def test_unanchorable_finding_on_changed_file_is_placed_file_level(
-    feature_branch_repo, monkeypatch, tmp_path
+    feature_branch_repo, monkeypatch, tmp_path, fake_gh
 ):
     """A finding whose anchors match nothing still gets a trackable placement.
 
@@ -112,25 +124,7 @@ async def test_unanchorable_finding_on_changed_file_is_placed_file_level(
             ResultEvent(structured_output={"issues": [issue]}, continuation=None),
         ]
     )
-    head = git_ops.head_sha(feature_branch_repo)
-    base = subprocess.run(  # noqa: S603 - arguments are not user-controlled
-        ["git", "rev-parse", "main"],  # noqa: S607 - git is a trusted command
-        cwd=feature_branch_repo,
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout.strip()
-    pr = PRInfo(
-        number=7,
-        head_sha=head,
-        base_sha=base,
-        base_ref="main",
-        owner="o",
-        repo="r",
-        url="https://example.invalid/pr/7",
-    )
-
-    with _review_run_env(feature_branch_repo, monkeypatch, out, backend, pr) as config:
+    with _review_run_env(feature_branch_repo, monkeypatch, out, backend, fake_gh) as config:
         assert await run(config) == 0
 
     findings = json.loads(out.read_text())["findings"]
@@ -260,3 +254,27 @@ def test_file_level_post_rejected_falls_back_to_review_body(fake_gh, file_level_
     assert parse_finding_markers(reviews[0].payload["body"]) == [FILE_FINGERPRINT], (
         "a rejected file-level finding must fall back into the review body"
     )
+
+
+def test_review_failure_still_reports_live_file_level_comments(
+    fake_gh, file_level_artifact, capsys
+) -> None:
+    """A failed review POST must not claim nothing was posted.
+
+    File-level comments post *before* the consolidated review, so when the
+    review POST fails they are already live on the PR. Reporting "no comments
+    were posted" would send the operator looking for a clean slate that does
+    not exist.
+    """
+    fake_gh.set_response("diff-paths", value=["b.py"])
+    fake_gh.set_response("POST", "/repos/o/r/pulls/7/reviews", value=None)
+
+    rc = cli_main(
+        ["post-findings", str(file_level_artifact), "--pr", "7", "--head-sha", "h" * 40, "--repo", "o/r"]
+    )
+
+    assert rc == 1, "a failed review POST is still a failure"
+    assert len(fake_gh.calls("POST", "/repos/o/r/pulls/7/comments")) == 1
+    out = capsys.readouterr().out
+    assert "1 file-level comment(s) were already posted" in out, out
+    assert "No comments were posted" not in out, out

--- a/tests/test_extension_seam_integration.py
+++ b/tests/test_extension_seam_integration.py
@@ -206,13 +206,22 @@ async def test_fork_filter_controls_pr_post_payload(
             archive=False,
         )
     )
-    post = fake_gh.calls("POST", "repos/acme/widgets/pulls/7/reviews")[0]
-    payload = json.dumps(post.payload)
+    # A finding reaches the PR either in the review payload or as its own
+    # file-level comment; the fork's filter must govern both surfaces.
+    posted = json.dumps(
+        [
+            call.payload
+            for call in (
+                *fake_gh.calls("POST", "repos/acme/widgets/pulls/7/reviews"),
+                *fake_gh.calls("POST", "repos/acme/widgets/pulls/7/comments"),
+            )
+        ]
+    )
 
     assert rc == 0
     assert fake_gh.pr_view_calls()
-    assert KEEP_ME in payload
-    assert DROP_ME not in payload
+    assert KEEP_ME in posted
+    assert DROP_ME not in posted
 
 
 async def test_fork_filter_controls_fix_prompts(

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -1307,6 +1307,43 @@ def test_gh_pr_create_failure_raises_git_error(fake_gh: FakeGh, git_repo: Path) 
         git_ops.gh_pr_create(git_repo, head="b", base="main", title="t", body="b")
 
 
+def test_log_shas_returns_none_when_ref_is_gone(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """A deleted branch ref yields None ("could not look"), never [].
+
+    Squash-merge deletes the branch, so the recorded ref no longer resolves and
+    git exits 128. Returning [] here made callers read the unanswerable query as
+    "no follow-up commits" and label the run rejected.
+    """
+    repo = _make_repo_with_main(tmp_path)
+
+    with caplog.at_level(logging.WARNING, logger="daydream.git_ops"):
+        result = git_ops.log_shas(repo, "deleted-branch", since="main")
+
+    assert result is None
+    assert any("log_shas" in record.message for record in caplog.records)
+
+
+def test_log_shas_returns_empty_list_when_range_is_genuinely_empty(tmp_path: Path) -> None:
+    """A resolvable ref with no commits ahead yields [] — distinct from None."""
+    repo = _make_repo_with_main(tmp_path)
+    _git(repo, "checkout", "-b", "topic")
+
+    assert git_ops.log_shas(repo, "topic", since="main") == []
+
+
+def test_log_shas_returns_commits_ahead_of_since(tmp_path: Path) -> None:
+    """The success path still returns SHAs, newest first."""
+    repo = _make_repo_with_main(tmp_path)
+    _git(repo, "checkout", "-b", "topic")
+    (repo / "a.txt").write_text("a\n")
+    _git(repo, "add", "a.txt")
+    _commit(repo, "topic-1")
+
+    shas = git_ops.log_shas(repo, "topic", since="main")
+
+    assert shas == [_git(repo, "rev-parse", "topic").strip()]
+
+
 def test_log_shas_since_returns_commits_in_range(tmp_path: Path) -> None:
     """log_shas_since returns SHAs for commits in head..base range."""
     repo = _make_repo_with_main(tmp_path)

--- a/tests/test_training_corpus.py
+++ b/tests/test_training_corpus.py
@@ -42,6 +42,7 @@ def _seed_run_with_annotation(
     composite_reward: float | None = None,
     reward_version: str = "r1",
     rubric_json: str | None = None,
+    has_posterior: bool | None = None,
     observed_at: str,
     valid_at: str,
 ) -> Path:
@@ -114,6 +115,9 @@ def _seed_run_with_annotation(
         reward_json=reward_json,
         composite_reward=composite_reward,
         rubric_json=rubric_json,
+        # Default: a labeled seed is an evidenced (pr_review) one, which is what
+        # every caller means. A local_branch row passes has_posterior=False.
+        has_posterior=(label is not None) if has_posterior is None else has_posterior,
     )
     # append_label_observation stamps observed_at with wall clock; overwrite it
     # so as_of pins in tests are deterministic.
@@ -442,6 +446,54 @@ def test_is_admitted_min_reward_compares_intrinsic_only() -> None:
         )
         is True
     )
+
+
+def test_default_build_excludes_accepted_without_posterior_evidence(tmp_path: Path) -> None:
+    """A ``local_branch`` "accepted" must not enter a default accepted-only corpus.
+
+    The C9 default admits ``labels=("accepted",)``. A local-commit outcome
+    carries exactly that label but no posterior evidence — a local commit is not
+    a maintainer acting in a PR. Admitting on the bare label silently mixed the
+    two evidence tiers in the training set (156 such rows in the real archive
+    against 18 evidenced accepts). Only the evidenced run may be projected.
+    """
+    _seed_run_with_annotation(
+        tmp_path, "s-evidenced", label="accepted", composite_reward=0.9,
+        rubric_json=json.dumps({"posterior_source": "pr_review"}),
+        has_posterior=True,
+        observed_at="2026-05-01T00:00:00+00:00", valid_at="2026-04-01T00:00:00+00:00",
+    )
+    _seed_run_with_annotation(
+        tmp_path, "s-local-tier", label="accepted", composite_reward=0.9,
+        rubric_json=json.dumps({"posterior_source": "local_branch"}),
+        has_posterior=False,
+        observed_at="2026-05-01T00:00:00+00:00", valid_at="2026-04-01T00:00:00+00:00",
+    )
+    out = tmp_path / "corpus.jsonl"
+    run_build_corpus(_cfg(tmp_path, out_path=out))
+
+    emitted = [json.loads(line)["session_id"] for line in out.read_text().splitlines()]
+    assert emitted == ["s-evidenced"]
+
+
+def test_min_reward_still_admits_unevidenced_run_on_intrinsic_score(tmp_path: Path) -> None:
+    """The intrinsic ``min_reward`` path is unchanged by the posterior gate.
+
+    ``min_reward`` is an explicit opt-in to intrinsic-only admission (C5), so it
+    still admits a run with no posterior evidence. The gate constrains only the
+    *label* path, which is the one that claims maintainer evidence.
+    """
+    _seed_run_with_annotation(
+        tmp_path, "s-local-tier", label="accepted", composite_reward=0.9,
+        rubric_json=json.dumps({"posterior_source": "local_branch"}),
+        has_posterior=False,
+        observed_at="2026-05-01T00:00:00+00:00", valid_at="2026-04-01T00:00:00+00:00",
+    )
+    out = tmp_path / "corpus.jsonl"
+    run_build_corpus(_cfg(tmp_path, out_path=out, filters=CorpusFilters(min_reward=0.5)))
+
+    emitted = [json.loads(line)["session_id"] for line in out.read_text().splitlines()]
+    assert emitted == ["s-local-tier"]
 
 
 def test_build_record_emits_posterior_discriminator_only_for_labeled(tmp_path: Path) -> None:

--- a/tests/test_training_harvest.py
+++ b/tests/test_training_harvest.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from conftest import _commit, _git, _make_repo_with_main
 
 from daydream import git_ops
 from daydream.archive.index import (
@@ -532,7 +533,13 @@ def _seed_archived_deep_run(
 
 
 def _seed_orphan_run(
-    archive_dir: Path, bronze_parent: Path, *, session_id: str, head_sha: str = "orphsha"
+    archive_dir: Path,
+    bronze_parent: Path,
+    *,
+    session_id: str,
+    head_sha: str = "orphsha",
+    branch: str = "feat/x",
+    source_path: Path | None = None,
 ) -> Path:
     """Seed an orphan deep run (no PR linkage) and index it under ``archive_dir``.
 
@@ -540,6 +547,10 @@ def _seed_orphan_run(
     the re-link path consumes: ``pr_number``/``pr_repo`` are ``None`` and the row
     carries only a ``branch``/``head_sha``. Bronze artifacts go under
     ``bronze_parent``; returns the run directory.
+
+    ``source_path`` records a working tree on the manifest so
+    :func:`_resolve_repo_for_row` resolves a clone for the row
+    (``clone_resolved`` True), enabling the local-commit walk.
     """
     run_dir = _seed_deep_bronze(bronze_parent, verdict="consistent", grounding=1.0)
     upsert_run(
@@ -550,7 +561,7 @@ def _seed_orphan_run(
             run_flow="normal",
             backend="claude",
             repo_slug="org/repo",
-            branch="feat/x",
+            branch=branch,
             head_sha=head_sha,
             base_branch="main",
             pr_number=None,
@@ -558,6 +569,7 @@ def _seed_orphan_run(
             grounding_rate=1.0,
             changed_files=["app.py"],
             archive_path=str(run_dir),
+            source_path=str(source_path) if source_path else None,
         ),
     )
     return run_dir
@@ -721,14 +733,6 @@ async def test_harvest_orphan_422_degrades_not_drops(tmp_path, archive_dir, monk
     clone — the label degrades to ``"unknown"`` (empty), never ``"rejected"``.
     """
     _seed_orphan_run(archive_dir, tmp_path, session_id="s-orph-422")
-
-    def _gh_unpushed_422(repo: str, endpoint: str, **kwargs: Any) -> Any:
-        if "/commits/" in endpoint and endpoint.endswith("/pulls"):
-            raise GitError("gh: No commit found for SHA (HTTP 422)")
-        if endpoint.endswith("/comments") or endpoint.endswith("/reviews"):
-            return []
-        return {}
-
     monkeypatch.setattr("daydream.training.harvest._gh_api", _gh_unpushed_422)
     summary = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
 
@@ -738,6 +742,123 @@ async def test_harvest_orphan_422_degrades_not_drops(tmp_path, archive_dir, monk
     assert row["pr_number"] is None and row["pr_repo"] is None  # linkage NOT applied
     # No resolvable clone → local posterior is "unknown", never "rejected".
     assert json.loads(row["outcome_labels"]) == []
+
+
+def _gh_unpushed_422(repo: str, endpoint: str, **kwargs: Any) -> Any:
+    """gh stub for a squash-merged head SHA: the link probe 422s, nothing else."""
+    if "/commits/" in endpoint and endpoint.endswith("/pulls"):
+        raise GitError("gh: No commit found for SHA (HTTP 422)")
+    if endpoint.endswith("/comments") or endpoint.endswith("/reviews"):
+        return []
+    return {}
+
+
+async def test_harvest_deleted_branch_ref_labels_unknown_not_rejected(tmp_path, archive_dir, monkeypatch):
+    """Real-path: a squash-merged run whose branch ref is gone must NOT be "rejected".
+
+    This is the shape that mislabeled 286 archived runs. After a squash merge
+    GitHub deletes the branch and rewrites the commit, so at harvest time:
+      * ``commits/<sha>/pulls`` 422s (the recorded SHA was never on the remote), and
+      * ``git log <sha>..<branch>`` exits 128 (the branch ref no longer resolves).
+
+    Crucially a working tree IS resolved here (``clone_resolved`` True), so the
+    existing no-clone guard does not apply — the local-commit walk runs for real
+    against a real repo and really fails. ``log_shas`` used to swallow that into
+    ``[]``, which ``local_commit_applied_signal`` read as "no follow-up commit"
+    and labeled ``"rejected"``: a false negative fed straight into the corpus.
+
+    Drives ``run_harvest`` end-to-end and asserts the observable label.
+    """
+    clone = _make_repo_with_main(tmp_path, name="clone")
+    head_sha = _git(clone, "rev-parse", "HEAD").strip()
+    # The branch the run recorded was squash-merged and deleted — never created here.
+    _seed_orphan_run(
+        archive_dir,
+        tmp_path / "bronze",
+        session_id="s-gone",
+        head_sha=head_sha,
+        branch="feat/squash-merged-and-deleted",
+        source_path=clone,
+    )
+    monkeypatch.setattr("daydream.training.harvest._gh_api", _gh_unpushed_422)
+
+    summary = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
+
+    assert summary["errors"] == 0  # benign 422 + unreadable window degrade, not error
+    assert latest_label_observation(archive_dir, "s-gone") is not None  # still annotated
+    row = query_runs(archive_dir, "session_id = ?", ("s-gone",))[0]
+    # The central contract: unreadable commit window → "unknown" (empty), NOT "rejected".
+    assert json.loads(row["outcome_labels"]) == []
+
+
+async def test_harvest_live_branch_with_no_followup_commits_still_labels_rejected(
+    tmp_path, archive_dir, monkeypatch
+):
+    """Real-path counterpart: a readable window with no follow-up IS "rejected".
+
+    Same code path as the deleted-ref test, differing only in that the recorded
+    branch still exists and is readable. This pins the distinction the fix
+    introduces — "could not look" is now ``unknown``, but "looked and found
+    nothing applied" must remain a genuine negative label, or the fix would have
+    silently erased every true rejection from the corpus.
+    """
+    clone = _make_repo_with_main(tmp_path, name="clone")
+    _git(clone, "checkout", "-b", "feat/still-here")
+    head_sha = _git(clone, "rev-parse", "HEAD").strip()
+    _seed_orphan_run(
+        archive_dir,
+        tmp_path / "bronze",
+        session_id="s-live",
+        head_sha=head_sha,
+        branch="feat/still-here",
+        source_path=clone,
+    )
+    monkeypatch.setattr("daydream.training.harvest._gh_api", _gh_unpushed_422)
+
+    summary = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
+
+    assert summary["errors"] == 0
+    row = query_runs(archive_dir, "session_id = ?", ("s-live",))[0]
+    # Branch resolves and carries no follow-up commit → a real negative, preserved.
+    assert json.loads(row["outcome_labels"]) == ["rejected"]
+
+
+async def test_harvest_live_branch_with_applied_fix_labels_accepted(tmp_path, archive_dir, monkeypatch):
+    """Real-path counterpart: a follow-up commit carrying the fix IS "accepted".
+
+    Completes the three-way distinction (unknown / rejected / accepted) through
+    the same real-git path, so the fix is pinned on the positive arm too.
+    """
+    clone = _make_repo_with_main(tmp_path, name="clone")
+    _git(clone, "checkout", "-b", "feat/fixed")
+    head_sha = _git(clone, "rev-parse", "HEAD").strip()
+    run_dir = _seed_orphan_run(
+        archive_dir,
+        tmp_path / "bronze",
+        session_id="s-applied",
+        head_sha=head_sha,
+        branch="feat/fixed",
+        source_path=clone,
+    )
+    # The recommended patch adds a line; a later commit on the branch lands it.
+    (run_dir / "recommended.patch").write_text(
+        "diff --git a/app.py b/app.py\n"
+        "index 1111111..2222222 100644\n"
+        "--- a/app.py\n"
+        "+++ b/app.py\n"
+        "@@ -1,1 +1,2 @@\n"
+        " existing\n"
+        "+guarded = True\n"
+    )
+    (clone / "app.py").write_text("existing\nguarded = True\n")
+    _git(clone, "add", "app.py")
+    _commit(clone, "apply the recommended fix")
+    monkeypatch.setattr("daydream.training.harvest._gh_api", _gh_unpushed_422)
+
+    await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
+
+    row = query_runs(archive_dir, "session_id = ?", ("s-applied",))[0]
+    assert json.loads(row["outcome_labels"]) == ["accepted"]
 
 
 async def test_harvest_dry_run_mutates_row_in_memory_but_suppresses_set_run_pr_link(

--- a/tests/test_training_harvest.py
+++ b/tests/test_training_harvest.py
@@ -788,7 +788,65 @@ async def test_harvest_deleted_branch_ref_labels_unknown_not_rejected(tmp_path, 
     assert latest_label_observation(archive_dir, "s-gone") is not None  # still annotated
     row = query_runs(archive_dir, "session_id = ?", ("s-gone",))[0]
     # The central contract: unreadable commit window → "unknown" (empty), NOT "rejected".
+    # The recommended change is absent from main here, so the base-branch
+    # fallback cannot upgrade it — see the squash-merge test below for that arm.
     assert json.loads(row["outcome_labels"]) == []
+
+
+async def test_harvest_squash_merged_branch_recovers_accepted_from_base_branch(
+    tmp_path, archive_dir, monkeypatch
+):
+    """Real-path: a squash-merged run is recovered as "accepted", not lost to "unknown".
+
+    The full production shape of the 286-row mislabel. The branch was squash-
+    merged and deleted, so ``git log <sha>..<branch>`` exits 128 and the
+    per-commit walk is impossible — but the recommended change IS on ``main``,
+    carried there by the squash commit. The posterior's real question ("did the
+    change land?") is therefore still answerable, and the run is a genuine
+    positive that must not be discarded.
+
+    Uses real git throughout: the branch is created, committed, merged with
+    ``--squash``, then deleted, exactly as GitHub leaves the repo.
+    """
+    clone = _make_repo_with_main(tmp_path, name="clone")
+    head_sha_holder: dict[str, str] = {}
+    _git(clone, "checkout", "-b", "feat/squash-me")
+    (clone / "app.py").write_text("existing\nguarded = True\n")
+    _git(clone, "add", "app.py")
+    _commit(clone, "add the guard")
+    head_sha_holder["sha"] = _git(clone, "rev-parse", "HEAD").strip()
+    # Squash-merge into main and delete the branch — the GitHub end state.
+    _git(clone, "checkout", "main")
+    _git(clone, "merge", "--squash", "feat/squash-me")
+    _commit(clone, "add the guard (#220)")
+    _git(clone, "branch", "-D", "feat/squash-me")
+
+    run_dir = _seed_orphan_run(
+        archive_dir,
+        tmp_path / "bronze",
+        session_id="s-squash",
+        head_sha=head_sha_holder["sha"],
+        branch="feat/squash-me",
+        source_path=clone,
+    )
+    (run_dir / "recommended.patch").write_text(
+        "diff --git a/app.py b/app.py\n"
+        "index 1111111..2222222 100644\n"
+        "--- a/app.py\n"
+        "+++ b/app.py\n"
+        "@@ -1,1 +1,2 @@\n"
+        " existing\n"
+        "+guarded = True\n"
+    )
+    monkeypatch.setattr("daydream.training.harvest._gh_api", _gh_unpushed_422)
+
+    summary = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
+
+    assert summary["errors"] == 0
+    row = query_runs(archive_dir, "session_id = ?", ("s-squash",))[0]
+    # Recovered as a real positive — not "rejected" (the bug) and not "unknown"
+    # (giving up on evidence that is plainly there on the base branch).
+    assert json.loads(row["outcome_labels"]) == ["accepted"]
 
 
 async def test_harvest_live_branch_with_no_followup_commits_still_labels_rejected(

--- a/tests/test_training_harvest.py
+++ b/tests/test_training_harvest.py
@@ -59,11 +59,43 @@ def _seed_deep_bronze(tmp_path: Path, *, verdict: str, grounding: float) -> Path
 
 
 def _fake_gh_merged(merged_at: str):
-    """Return a ``gh_api(repo, endpoint, **kw)`` responder for a merged PR.
+    """Return a ``gh_api(repo, endpoint, **kw)`` responder for an *evidenced*
+    merged PR — daydream posted a finding and it was addressed.
 
-    Reuses the labeler-test responder shape: keyed on the endpoint, the
-    ``pulls/<n>`` endpoint reports merged with the given timestamp and the
-    ``comments`` endpoint reports no comments (clean → ``accepted``).
+    Keyed on the endpoint: ``pulls/<n>`` reports merged with the given
+    timestamp, and ``comments`` carries one footer-marked daydream finding plus
+    a human reply to it — ``comment_resolution == (1, 1, 0)``, so the rubric
+    yields ``accepted`` on real evidence.
+
+    A merged PR with *no* tracked comments is deliberately NOT this shape: it
+    labels ``unknown``, and :func:`_fake_gh_merged_no_comments` covers it.
+    """
+
+    def responder(repo: str, endpoint: str, **kwargs: Any) -> Any:
+        if endpoint.endswith("/reviews"):
+            return []
+        if endpoint.endswith("/comments"):
+            return [
+                {
+                    "id": 1,
+                    "in_reply_to_id": None,
+                    "user": {"login": "daydream-runner"},
+                    "body": f"finding\n\n{DAYDREAM_FOOTER}",
+                },
+                {"id": 2, "in_reply_to_id": 1, "user": {"login": "human"}, "body": "fixed"},
+            ]
+        return {"merged": True, "merged_at": merged_at}
+
+    return responder
+
+
+def _fake_gh_merged_no_comments(merged_at: str):
+    """Return a ``gh_api`` responder for a merged PR with NO daydream comments.
+
+    The vacuous-accept shape: the PR merged, but daydream produced nothing
+    tracked, so ``comment_resolution`` is ``(0, 0, 0)`` and ``unresolved == 0``
+    is vacuously true. The rubric must read this as ``unknown``, never
+    ``accepted`` — a merge alone is not evidence daydream contributed.
     """
 
     def responder(repo: str, endpoint: str, **kwargs: Any) -> Any:
@@ -387,11 +419,11 @@ def test_build_annotation_below_threshold_falls_back_to_default_prior(tmp_path, 
 
 
 def test_build_annotation_local_row_has_no_reviewer_prior(tmp_path, monkeypatch):
-    # PR-less row -> reviewer_logins == [], outcome_prior None, prior query never
-    # consulted; still a PosteriorBreakdown when the local verdict maps to a label.
+    # PR-less row -> reviewer_logins == [], prior query never consulted, and the
+    # local verdict is withheld from the posterior axis: a local commit is not a
+    # maintainer acting in a PR, so the label is kept but has_posterior is False.
     from daydream.training.labeler_signals import LocalCommitAppliedSignal
 
-    # Mapped local verdict "rejected" so the posterior axis is present.
     monkeypatch.setattr(
         harvest, "local_commit_applied_signal", lambda *a, **k: LocalCommitAppliedSignal(verdict="rejected")
     )
@@ -406,11 +438,11 @@ def test_build_annotation_local_row_has_no_reviewer_prior(tmp_path, monkeypatch)
     p = build_annotation(row, run_dir=run_dir, archive_dir=tmp_path, gh_api=_unused_gh,
                          repo_clone=tmp_path)
     assert p.reviewer_logins == []
-    assert p.labels == ["rejected"]
-    assert p.has_posterior is True
+    assert p.labels == ["rejected"]  # label kept — consumers may still want it
+    assert p.has_posterior is False  # ...but it is not maintainer-PR evidence
     rb = json.loads(p.reward_json)
-    assert rb["outcome_prior"] is None and rb["outcome_prior_n"] == 0
-    assert rb["posterior_cost"] == 0.5  # max(0, 1.0 - 0.5 default prior)
+    assert "posterior_cost" not in rb and "outcome_prior" not in rb
+    assert rb["composite"] is not None  # the intrinsic axes are unaffected
 
 
 def test_build_annotation_asserts_canonical_version(tmp_path, monkeypatch):
@@ -919,6 +951,115 @@ async def test_harvest_live_branch_with_applied_fix_labels_accepted(tmp_path, ar
     assert json.loads(row["outcome_labels"]) == ["accepted"]
 
 
+async def test_harvest_merged_pr_with_zero_comments_is_not_labeled_accepted(
+    tmp_path, archive_dir, monkeypatch
+):
+    """Real-path: a merged PR where daydream tracked NO comments is unlabeled.
+
+    The vacuous-accept bug. ``comment_resolution == (0, 0, 0)`` made
+    ``unresolved == 0`` trivially true, so "merged, daydream contributed
+    nothing observable" scored identically to "merged, every finding
+    addressed" — 152 of 170 ``pr_review`` accepts in the real archive were this
+    shape. Such a run carries no evidence either way, so it must persist as
+    ``unknown`` (empty labels) and stay out of the posterior population.
+    """
+    _seed_archived_deep_run(archive_dir, "s-vacuous", merged_at="2026-02-01T00:00:00+00:00")
+    monkeypatch.setattr(
+        "daydream.training.harvest._gh_api",
+        _fake_gh_merged_no_comments("2026-02-01T00:00:00+00:00"),
+    )
+
+    summary = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
+
+    assert summary["errors"] == 0 and summary["annotated"] == 1
+    row = query_runs(archive_dir, "session_id = ?", ("s-vacuous",))[0]
+    assert json.loads(row["outcome_labels"]) == []  # NOT ["accepted"]
+    obs = latest_label_observation(archive_dir, "s-vacuous")
+    assert obs["pr_state"] == "merged"  # merge state still recorded, just not decisive
+    assert json.loads(obs["rubric_json"])["comment_resolution"]["total"] == 0
+    # "unknown" maps to no penalty, so the row is excluded from the posterior population.
+    assert obs["has_posterior"] == 0
+    assert "posterior_cost" not in json.loads(obs["reward_json"])
+
+
+async def test_harvest_merged_pr_with_replied_comment_is_labeled_accepted(
+    tmp_path, archive_dir, monkeypatch
+):
+    """Real-path: the evidenced accept survives the fix and IS posterior evidence.
+
+    The positive arm of the same distinction: one tracked daydream finding, a
+    human reply resolving it, PR merged. This must stay ``accepted`` with
+    ``has_posterior`` set, or the fix would have erased the only genuinely
+    discriminative positives in the corpus.
+    """
+    _seed_archived_deep_run(archive_dir, "s-evidenced", merged_at="2026-02-01T00:00:00+00:00")
+    monkeypatch.setattr(
+        "daydream.training.harvest._gh_api",
+        _fake_gh_merged("2026-02-01T00:00:00+00:00"),
+    )
+
+    summary = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
+
+    assert summary["errors"] == 0 and summary["annotated"] == 1
+    row = query_runs(archive_dir, "session_id = ?", ("s-evidenced",))[0]
+    assert json.loads(row["outcome_labels"]) == ["accepted"]
+    obs = latest_label_observation(archive_dir, "s-evidenced")
+    resolution = json.loads(obs["rubric_json"])["comment_resolution"]
+    assert (resolution["total"], resolution["unresolved"]) == (1, 0)
+    # A maintainer acting on a real PR IS posterior evidence.
+    assert obs["has_posterior"] == 1
+    assert json.loads(obs["reward_json"])["false_positive_penalty"] == 0.0
+
+
+async def test_harvest_local_branch_accept_keeps_label_but_is_not_posterior_evidence(
+    tmp_path, archive_dir, monkeypatch
+):
+    """Real-path: a local-commit "accepted" is a weaker evidence tier.
+
+    A commit on the recorded branch containing the recommended lines is not a
+    maintainer acting in a PR, so it must not enter the reward-model posterior
+    population. The label is still persisted (consumers may want it), but
+    ``has_posterior`` is 0 and no ``posterior_cost`` is written — letting
+    consumers split on the column instead of silently mixing evidence tiers
+    with real merged-PR outcomes.
+    """
+    clone = _make_repo_with_main(tmp_path, name="clone")
+    _git(clone, "checkout", "-b", "feat/local-tier")
+    head_sha = _git(clone, "rev-parse", "HEAD").strip()
+    run_dir = _seed_orphan_run(
+        archive_dir,
+        tmp_path / "bronze",
+        session_id="s-local-tier",
+        head_sha=head_sha,
+        branch="feat/local-tier",
+        source_path=clone,
+    )
+    (run_dir / "recommended.patch").write_text(
+        "diff --git a/app.py b/app.py\n"
+        "index 1111111..2222222 100644\n"
+        "--- a/app.py\n"
+        "+++ b/app.py\n"
+        "@@ -1,1 +1,2 @@\n"
+        " existing\n"
+        "+guarded = True\n"
+    )
+    (clone / "app.py").write_text("existing\nguarded = True\n")
+    _git(clone, "add", "app.py")
+    _commit(clone, "apply the recommended fix")
+    monkeypatch.setattr("daydream.training.harvest._gh_api", _gh_unpushed_422)
+
+    summary = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
+
+    assert summary["errors"] == 0
+    row = query_runs(archive_dir, "session_id = ?", ("s-local-tier",))[0]
+    assert json.loads(row["outcome_labels"]) == ["accepted"]  # label kept
+    obs = latest_label_observation(archive_dir, "s-local-tier")
+    assert json.loads(obs["rubric_json"])["posterior_source"] == "local_branch"
+    # Weaker tier: labeled, but withheld from the posterior population.
+    assert obs["has_posterior"] == 0
+    assert "posterior_cost" not in json.loads(obs["reward_json"])
+
+
 async def test_harvest_dry_run_mutates_row_in_memory_but_suppresses_set_run_pr_link(
     tmp_path, archive_dir, monkeypatch
 ):
@@ -1232,7 +1373,16 @@ async def test_harvest_keeps_labeled_row_when_reviewer_lookup_errors(tmp_path, a
         if endpoint.endswith("/reviews"):
             raise GitError("gh: Internal Server Error (HTTP 500)")
         if endpoint.endswith("/comments"):
-            return []
+            # A resolved daydream thread: the evidence that makes the merge decisive.
+            return [
+                {
+                    "id": 1,
+                    "in_reply_to_id": None,
+                    "user": {"login": "daydream-runner"},
+                    "body": f"finding\n\n{DAYDREAM_FOOTER}",
+                },
+                {"id": 2, "in_reply_to_id": 1, "user": {"login": "human"}, "body": "fixed"},
+            ]
         return {"merged": True, "merged_at": "2026-02-01T00:00:00+00:00"}
 
     monkeypatch.setattr("daydream.training.harvest._gh_api", _gh_reviews_fail)

--- a/tests/test_training_labeler_signals.py
+++ b/tests/test_training_labeler_signals.py
@@ -279,13 +279,15 @@ def test_local_commit_applied_signal_unreadable_window_returns_unknown(tmp_path:
 
     Same inputs as the rejected case above; only the fetcher's answer differs
     ([] vs None). The verdicts must differ too, or an unreadable branch ref
-    silently becomes a negative training label.
+    silently becomes a negative training label. Here the change is absent from
+    the base branch too, so the fallback cannot upgrade it past "unknown".
     """
     (tmp_path / "diff.patch").write_text(_simple_diff_adding("foo = 1"))
     row = {
         "repo_slug": "org/repo",
         "head_sha": "abc",
         "branch": "feat/x",
+        "base_branch": "main",
         "archive_path": str(tmp_path),
     }
     sig = local_commit_applied_signal(
@@ -293,6 +295,92 @@ def test_local_commit_applied_signal_unreadable_window_returns_unknown(tmp_path:
         repo_clone=tmp_path,
         commits_since_fetcher=lambda repo, branch, since_sha: None,
         file_at_fetcher=lambda repo, path, sha: "",
+    )
+    assert sig == LocalCommitAppliedSignal(verdict="unknown")
+
+
+def test_local_commit_applied_signal_unreadable_window_falls_back_to_base_branch(tmp_path: Path) -> None:
+    """A deleted branch ref still resolves via the base branch tip.
+
+    The squash-merge case: the branch is gone, but the recommended line is
+    present on ``main``, so the change demonstrably landed → "applied".
+    """
+    (tmp_path / "diff.patch").write_text(_simple_diff_adding("foo = 1"))
+    row = {
+        "repo_slug": "org/repo",
+        "head_sha": "abc",
+        "branch": "feat/squashed-away",
+        "base_branch": "main",
+        "archive_path": str(tmp_path),
+    }
+    seen_refs: list[str] = []
+
+    def _file_at(repo: Path, path: str, ref: str) -> str:
+        seen_refs.append(ref)
+        return "existing\nfoo = 1\n" if ref == "origin/main" else ""
+
+    sig = local_commit_applied_signal(
+        row,
+        repo_clone=tmp_path,
+        commits_since_fetcher=lambda repo, branch, since_sha: None,
+        file_at_fetcher=_file_at,
+    )
+    assert sig == LocalCommitAppliedSignal(verdict="applied")
+    assert seen_refs == ["origin/main"]  # remote ref preferred; no stale-local read needed
+
+
+def test_local_commit_applied_signal_base_branch_fallback_prefers_remote_over_stale_local(
+    tmp_path: Path,
+) -> None:
+    """``origin/<base>`` is consulted before the bare local ref.
+
+    A worktree's local ``main`` can sit behind the remote. Reading it first
+    would report a landed change as absent, so the remote ref must win — but
+    the local ref is still tried when the remote is unresolvable.
+    """
+    (tmp_path / "diff.patch").write_text(_simple_diff_adding("foo = 1"))
+    row = {
+        "repo_slug": "org/repo",
+        "head_sha": "abc",
+        "branch": "feat/squashed-away",
+        "base_branch": "main",
+        "archive_path": str(tmp_path),
+    }
+    seen_refs: list[str] = []
+
+    def _file_at(repo: Path, path: str, ref: str) -> str:
+        seen_refs.append(ref)
+        return "existing\nfoo = 1\n" if ref == "main" else ""  # no origin/ ref in this clone
+
+    sig = local_commit_applied_signal(
+        row,
+        repo_clone=tmp_path,
+        commits_since_fetcher=lambda repo, branch, since_sha: None,
+        file_at_fetcher=_file_at,
+    )
+    assert sig == LocalCommitAppliedSignal(verdict="applied")
+    assert seen_refs == ["origin/main", "main"]  # remote tried first, then local fallback
+
+
+def test_local_commit_applied_signal_unreadable_window_no_hunks_is_unknown(tmp_path: Path) -> None:
+    """A run that recommended nothing cannot be "applied" by the fallback.
+
+    With no recommended hunks there is nothing to look for on the base branch,
+    so the fallback must not read "no hunks absent" as "everything landed".
+    """
+    (tmp_path / "diff.patch").write_text("")
+    row = {
+        "repo_slug": "org/repo",
+        "head_sha": "abc",
+        "branch": "feat/squashed-away",
+        "base_branch": "main",
+        "archive_path": str(tmp_path),
+    }
+    sig = local_commit_applied_signal(
+        row,
+        repo_clone=tmp_path,
+        commits_since_fetcher=lambda repo, branch, since_sha: None,
+        file_at_fetcher=lambda repo, path, ref: "anything at all\n",
     )
     assert sig == LocalCommitAppliedSignal(verdict="unknown")
 

--- a/tests/test_training_labeler_signals.py
+++ b/tests/test_training_labeler_signals.py
@@ -274,6 +274,29 @@ def test_local_commit_applied_signal_no_local_commits_returns_rejected(tmp_path:
     assert sig == LocalCommitAppliedSignal(verdict="rejected")
 
 
+def test_local_commit_applied_signal_unreadable_window_returns_unknown(tmp_path: Path) -> None:
+    """A None commit window means "could not look" — not "nobody applied it".
+
+    Same inputs as the rejected case above; only the fetcher's answer differs
+    ([] vs None). The verdicts must differ too, or an unreadable branch ref
+    silently becomes a negative training label.
+    """
+    (tmp_path / "diff.patch").write_text(_simple_diff_adding("foo = 1"))
+    row = {
+        "repo_slug": "org/repo",
+        "head_sha": "abc",
+        "branch": "feat/x",
+        "archive_path": str(tmp_path),
+    }
+    sig = local_commit_applied_signal(
+        row,
+        repo_clone=tmp_path,
+        commits_since_fetcher=lambda repo, branch, since_sha: None,
+        file_at_fetcher=lambda repo, path, sha: "",
+    )
+    assert sig == LocalCommitAppliedSignal(verdict="unknown")
+
+
 def _fake_commits_pulls(pulls):
     # pulls: list returned by repos/{slug}/commits/{sha}/pulls
     def responder(repo, endpoint, **kwargs):

--- a/tests/test_training_rubric.py
+++ b/tests/test_training_rubric.py
@@ -54,6 +54,46 @@ def test_outcome_label_accepted_when_pr_merged_and_no_unresolved() -> None:
     assert derive_outcome_label(rub) == "accepted"
 
 
+def test_outcome_label_unknown_when_merged_but_no_comments_tracked() -> None:
+    """A merged PR with zero tracked daydream comments is NOT evidence of accept.
+
+    ``unresolved == 0`` is vacuously true at ``total == 0``, which made every
+    merged PR where daydream produced no tracked comment score identically to
+    one where every finding was addressed. Such a run must be ``"unknown"``.
+    """
+    rub = Rubric(
+        pr_merge=PRMergeSignal(True, "2026-01-01T00:00:00Z"),
+        fix_applied=FixAppliedSignal("unknown", 0, 0, []),
+        comment_resolution=CommentResolutionSignal(0, 0, 0),
+        local_commit_applied=None,
+        posterior_source="pr_review",
+    )
+    assert derive_outcome_label(rub) == "unknown"
+
+
+def test_outcome_label_accepted_requires_real_comments_all_resolved() -> None:
+    """The evidenced accept still works: three comments, none unresolved."""
+    rub = Rubric(
+        pr_merge=PRMergeSignal(True, "2026-01-01T00:00:00Z"),
+        fix_applied=FixAppliedSignal("applied", 3, 3, ["c1"]),
+        comment_resolution=CommentResolutionSignal(3, 3, 0),
+        local_commit_applied=None,
+        posterior_source="pr_review",
+    )
+    assert derive_outcome_label(rub) == "accepted"
+
+
+def test_outcome_label_contested_when_merged_with_one_unresolved_of_three() -> None:
+    rub = Rubric(
+        pr_merge=PRMergeSignal(True, "2026-01-01T00:00:00Z"),
+        fix_applied=FixAppliedSignal("applied", 2, 3, ["c1"]),
+        comment_resolution=CommentResolutionSignal(3, 2, 1),
+        local_commit_applied=None,
+        posterior_source="pr_review",
+    )
+    assert derive_outcome_label(rub) == "contested"
+
+
 def test_outcome_label_contested_when_merged_but_unresolved() -> None:
     rub = Rubric(
         pr_merge=PRMergeSignal(True, "2026-01-01T00:00:00Z"),


### PR DESCRIPTION
Seven fixes to the reward-model corpus pipeline: **labeling integrity** (1-5) and **capture** (6-7). They belong together — 1-5 shrink the corpus to what is genuinely evidenced, which is only tolerable because 6-7 fix the capture path that produces new evidence.

| # | commit | fixes |
|---|---|---|
| 1 | `stop labeling unreadable commit windows as "rejected"` | git error → false `rejected` |
| 2 | `recover squash-merged runs as accepted, not unknown` | 152 genuine positives stranded at `unknown` |
| 3 | `require comment evidence for the "accepted" label` | merged-with-zero-comments → vacuous `accepted` |
| 4 | `include has_posterior in the auto-append idempotency key` | re-harvest silently no-ops on the corrected rows |
| 5 | `require posterior evidence on the label admission path` | weak-tier rows enter an accepted-only corpus |
| 6 | `capture unplaceable findings as file-level comments` | 40% of posted findings unlabelable |
| 7 | `report file-level comments already live on a failed review` | false "no comments were posted" |

---

## 1. Git errors collapsed to "rejected"

`git_ops.log_shas` soft-failed to `[]` on any git error. `local_commit_applied_signal` then could not tell "no follow-up commit applied the fix" from "we could not look", and labeled both `"rejected"`:

```python
commits = commits_since_fetcher(repo_clone, row["branch"], row["head_sha"])
if not commits:
    return LocalCommitAppliedSignal(verdict="rejected")   # also fires on git failure
```

The trigger is a **squash merge**. GitHub rewrites the commit and deletes the branch, so at harvest time both lookups fail:

- `gh api repos/.../commits/<sha>/pulls` → 422, the recorded SHA was never on the remote
- `git log <sha>..<branch>` → exit 128, the branch ref no longer resolves

Found via a harvest log with 120 `exited non-zero (128)` warnings across 95 distinct SHA/branch pairs. The archive index carried **286 rows labeled `rejected` through the `local_branch` path** — the single largest bucket, feeding SFT/KTO as negative examples.

Two confirmed mislabels:

| session | branch | label | reality |
|---|---|---|---|
| `ca7026a5` | `feat/subtrajectory-parallel-fix` | `rejected` | squash-merged as `dbcf1c2` (#220) |
| `a40c2c32` | `fix/198-detect-test-success-deselected` | `rejected` | merged as `75f36d5` (#204) |

`harvest.py:488-492` already guarded this exact conflation for the no-clone case. That reasoning was never extended to the git-error case.

**Fix:** `log_shas` returns `list[str] | None` — `None` for "could not look", `[]` only for a genuinely empty range. `local_commit_applied_signal` no longer maps a failed lookup to `"rejected"`.

## 2. Recovering the true label, not stopping at "unknown"

Stopping at `"unknown"` would leave 152 genuine positives unlabeled and strip that volume from the corpus. The question the posterior actually asks — "did the recommended change land?" — survives the branch deletion, because the squash commit carries the change onto the base branch. So when the commit walk is impossible, `_default_branch_applied` checks the base-branch tip for the recommended hunks.

- `origin/<base>` is tried before the bare local ref: a stale worktree's local branch can sit behind the remote, which would read a landed change as absent.
- Absence at the tip yields `"unknown"`, never `"rejected"` — a squash can rework a change past verbatim matching, so absence is not evidence of rejection.

Measured against the real archive, all 289 `rejected` local-branch rows scored with the implemented mechanism (not a proxy):

| bucket | n | label |
|---|---|---|
| recommended change is on the base-branch tip | **152** | `accepted` |
| no `repo_slug` and no `source_path` — unlocatable | 120 | `unknown` |
| run recommended nothing (no hunks) | 12 | `unknown` |
| genuinely did not land | 5 | `rejected` |

The 120 unlocatable rows are an archiver data-capture gap (neither field was recorded), not something the labeler can resolve. Worth a separate issue.

## 3. "Accepted" required no evidence at all

`derive_outcome_label` returned `"accepted"` for any merged PR whose `comment_resolution.unresolved == 0`. **At `total == 0` that condition is vacuously true**, so "merged PR where daydream produced no tracked comments" scored identically to "merged PR where every finding was addressed". 152 of the 170 `pr_review` accepts in the local archive were this shape, leaving ~18 genuinely evidenced positives.

A merged PR with zero tracked comments now derives `"unknown"`: the merge alone is no evidence daydream contributed anything. The evidenced arms are unchanged (merged + `total > 0` + `unresolved == 0` → `accepted`; `unresolved > 0` → `contested`; not merged → `rejected`).

This commit also stops feeding `local_branch` outcomes into the posterior axis. A local commit containing the recommended lines is not a maintainer acting in a PR, so those rows keep their label but score a plain `RewardBreakdown` — `has_posterior` is False and no `posterior_cost` is written. Gating `pr_feedback` at the single call site keeps the two population discriminators (`label_observations.has_posterior` and `"posterior_cost" in reward_json`, `corpus.py:371`) in agreement rather than decoupling the flag from the data it describes.

## 4. The correction had to be able to land

The auto-append dedup compared `(evidence_sha, reward_version, labels)`. That was complete while `has_posterior` was a pure function of the label — every mapped label yielded a `PosteriorBreakdown`. Withholding `local_branch` outcomes from the posterior axis breaks that coupling: **a row can keep its label and change population membership.**

Without this, re-harvesting the existing archive would silently no-op on the 156 already-labeled `local_branch` rows and leave `has_posterior = 1` in place, so the corpus split would still mix evidence tiers. Comparing the flag makes the demotion append a new generation while keeping a genuinely unchanged re-score a no-op.

## 5. Nothing forced consumers to split on the evidence flag

The C9 default admits `labels=("accepted",)`. A `local_branch` outcome carries exactly that label with `has_posterior=0`, so a default corpus build pulled those rows in as though they were evidenced maintainer accepts. In the real archive that is **156 weak-tier rows against 18 evidenced ones**.

Making `has_posterior` honest was not enough on its own. The label path now requires it, so no weak-tier row can enter an accepted-only corpus regardless of filter settings, and newly harvested unlabeled/local rows cannot reintroduce the problem.

The intrinsic `min_reward` path is deliberately unchanged — it is an explicit opt-in to intrinsic-only admission (C5). `include_all_labels` likewise still means everything.


## 6. 40% of posted findings were unlabelable

Fixes 1-5 make the labeler honest, which exposes the real bottleneck: it is not labeling, it is **capture**. A label needs a daydream comment carrying `DAYDREAM_FOOTER` and `finding_marker(fingerprint)`, plus a maintainer reply to read back.

The write path put findings in two places — inline comments, and the review body. Both carry the footer and marker correctly. But `index_pr_review_comments` reads only `/pulls/{n}/comments`, and **the review body is not on that endpoint**. Every body-only finding was posted and permanently invisible to the labeler.

Swept this repo's own last 60 PRs: **8 of 20 posted findings (40%) were stranded in the review body.** PR #282 had 3 markers in the body against 1 inline.

`classify()` sent a finding to the body whenever it was cross-stack, its anchors did not resolve, or its line fell outside a hunk — none of which are rare.

**Fix:** findings whose file is still in the PR diff post as **file-level review comments** (`subject_type: "file"`). These land on `/comments` as top-level repliable threads the existing read-back joins by fingerprint — the write chokepoint is canonicalized, no read-side shim.

The design was settled against the real GitHub API, not assumed:

| probe | result |
|---|---|
| `subject_type` in a batch review payload | **422 rejected** |
| `subject_type` on `POST /pulls/{n}/comments` | accepted |
| reply to a file-level comment | threads correctly (`in_reply_to_id` set) |
| file-level comment on a path outside the diff | **422 rejected** |

Hence: they post individually rather than in the review payload, placement is gated on the PR's changed-file set, and a rejected one falls back into the review body rather than being dropped. Body-only is now the placement of last resort.

## 7. A failed review claimed nothing was posted

Because file-level comments post *before* the consolidated review, a review POST failure left live comments on the PR while the message said "no comments were posted" — sending the operator to look for a clean slate that does not exist. Both flows now report the count that did post. (Found by CodeRabbit on the now-closed #287, along with the test-seam fix below.)

## Capture verification

Ran the real `daydream post-findings` against a live throwaway PR with real `gh` — no fakes — then read it back through the labeler's own signal functions:

```
before reply: CommentResolutionSignal(total=1, replied=0, unresolved=1)
after reply:  CommentResolutionSignal(total=1, replied=1, unresolved=0)
per_finding:  PerFindingResolution(resolved=True, comment_id=3609171866)
```

The loop closes end to end on current code. Four real-path tests in `tests/test_capture_loop.py`; all four fail against the unfixed code — the placement test fails with `placement='body'`, the exact defect. PR discovery runs through the fake `gh` subprocess seam, so only the backend is mocked.

## Expected capture rate

- **Of findings posted on a PR:** ~100% trackable, up from ~60%. The residual is findings on paths outside the diff, which GitHub refuses a comment for in any form.
- **Of PRs daydream runs against:** unchanged by this PR.

That second line is the honest caveat. Only **4 of the last 60 PRs** carry any daydream finding at all — 152-of-170 zero-comment PRs is not a capture bug, nothing was posted there to observe. Growing the corpus needs `--comment` run at volume; that is operational, not a code fix. At ~3-5 findings/PR and ~100% trackability, ~50 reviewed PRs would yield more labelable rows than the entire current corpus.

## Net effect on the corpus

The archive drops from an apparent ~170 accepts to **18 evidenced accepts**, with the remainder correctly demoted to `unknown` or held out of the accepted-only corpus. That is a large reduction in volume and the right one: the removed rows were never evidence of anything. It also makes capture — not labeling — the binding constraint, which is what fixes 6-7 address.

## Tests

`log_shas` had **no coverage of its failure mode** — that is how this shipped. New real-path tests drive `run_harvest` against a real git worktree (`clone_resolved=True`, so the no-clone guard does not mask the path), pinning every arm:

- squash-merged branch (real `merge --squash` + real branch delete), change on `main` → `accepted`
- deleted branch ref, change absent → `unknown`
- live branch, no follow-up commit → `rejected` (a genuine negative, preserved — the fix must not blanket-erase true rejections)
- live branch, follow-up commit carrying the hunk → `accepted`
- `origin/<base>` preferred over stale local `<base>`
- no recommended hunks → `unknown`, never a vacuous `applied`
- merged PR with zero tracked comments → `unknown`; `_fake_gh_merged` now carries a resolved daydream comment thread so its call sites keep asserting a genuinely evidenced accept, with the vacuous shape moved to `_fake_gh_merged_no_comments`
- `has_posterior` demotion appends a new generation rather than no-opping
- label-path admission rejects a `has_posterior=0` accept

Every new test was verified to **fail against the unfixed code** before being accepted.

Gate on the branch head: `uv lock --check`, ruff clean, mypy clean over 269 files, **2267 passed / 5 skipped**.

## Re-labeling the existing rows

The schema is bitemporal, so a re-harvest appends corrected observations with no destructive migration:

```
daydream corpus harvest
```

One trap: `BackfillCache.completed_sessions()` filters the queue (`harvest.py:920-921`), and the default `--cache-dir` is the same `~/.daydream/harvest-cache/` the last run wrote — so every session reads as already done and the queue comes back empty (`considered: 0`). Clear `progress.jsonl` (keeping the cached `gh` responses, which avoids re-fetching every row against secondary rate limits) rather than passing a fresh `--cache-dir`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
