### PR TITLE
fix(pr_review): capture unplaceable findings as file-level comments

### DIFF
--- a/daydream/findings.py
+++ b/daydream/findings.py
@@ -1,7 +1,7 @@
 """Findings artifact for the Phase A → Phase B review handoff.
 
 Phase A (unprivileged analyze job, has the PR checkout) classifies review
-issues into inline vs body-only placement and serializes the result as a
+issues into inline / file-level / body-only placement and serializes it as a
 strict-schema JSON artifact. Phase B (privileged poster, never touches PR
 code) consumes the artifact and renders/posts from artifact data only.
 
@@ -70,7 +70,7 @@ FINDINGS_SCHEMA: dict[str, Any] = {
                     "fingerprint": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
                     "path": {"type": "string"},
                     "line": {"type": ["integer", "null"]},
-                    "placement": {"enum": ["inline", "body"]},
+                    "placement": {"enum": ["inline", "file", "body"]},
                     "title": {"type": "string"},
                     "body": {"type": "string"},
                     "severity": {"type": ["string", "null"]},
@@ -94,8 +94,8 @@ class ArtifactFinding:
     Attributes:
         fingerprint: 64-hex cross-run dedup identity.
         path: Repo-relative file path the finding targets.
-        line: Snapped inline line, or None for body-only findings.
-        placement: "inline" or "body".
+        line: Snapped inline line, or None for file-level / body-only findings.
+        placement: "inline", "file" (file-level comment), or "body".
         title: Finding title.
         body: Finding body (raw, unrendered).
         severity: Severity label, or None.
@@ -166,14 +166,17 @@ def build_findings_artifact(
 
     Returns:
         The artifact dict, matching ``FINDINGS_SCHEMA``: inline findings
-        carry ``placement="inline"`` with the snapped line; body-only
-        findings carry ``placement="body"`` and ``line=None``.
+        carry ``placement="inline"`` with the snapped line; findings with no
+        line home but whose file is in the PR diff carry ``placement="file"``;
+        the remainder carry ``placement="body"``. Both non-inline placements
+        have ``line=None``.
     """
     classified = pr_review.classify(target_dir, pr, issues)
     findings = [
         _finding_dict(issue, placement="inline", line=entry["line"])
         for entry, issue in zip(classified.inline, classified.inline_issues, strict=True)
     ]
+    findings.extend(_finding_dict(issue, placement="file", line=None) for issue in classified.file_level)
     findings.extend(_finding_dict(issue, placement="body", line=None) for issue in classified.body_only)
     return {
         "schema_version": FINDINGS_SCHEMA_VERSION,

--- a/daydream/pr_review.py
+++ b/daydream/pr_review.py
@@ -7,7 +7,8 @@ Flow:
     1. Locate the open PR for the current branch via `gh pr list`.
     2. Parse issues (from canonical merged items or alt-issue dicts).
     3. Resolve each issue to a real head-SHA line via anchor grep.
-    4. Classify into inline (line within a diff hunk) vs body-only.
+    4. Classify into inline (line within a diff hunk), file-level (file in
+       the diff but no line home), or body-only (last resort).
     5. Render comment bodies, embedding a hidden `daydream-finding` marker
        per fingerprinted issue (cross-run dedup; see `finding_marker`).
     6. Build a single review payload, show a summary, ask y/n.
@@ -108,6 +109,27 @@ class _ClassifiedIssues:
     # Parallel list to `inline`: the original ParsedIssue for each inline
     # comment. Used to roll severity/confidence into the summary body.
     inline_issues: list[ParsedIssue] = field(default_factory=list)
+    # Findings with no diff-line home whose file is still part of the PR
+    # diff. Posted as file-level review comments so they land in
+    # `/pulls/{n}/comments` as repliable threads the labeler can read back.
+    file_level: list[ParsedIssue] = field(default_factory=list)
+
+    def is_empty(self) -> bool:
+        """True when nothing would be posted in any placement.
+
+        Checks ``inline`` (the rendered comment dicts) rather than
+        ``inline_issues``, so the guard holds even if the two parallel lists
+        ever drift.
+        """
+        return not (self.inline or self.file_level or self.body_only)
+
+    def total(self) -> int:
+        """Count of findings across every placement."""
+        return len(self.inline) + len(self.file_level) + len(self.body_only)
+
+    def all_issues(self) -> list[ParsedIssue]:
+        """Every classified :class:`ParsedIssue`, for severity/confidence rollups."""
+        return [*self.inline_issues, *self.file_level, *self.body_only]
 
 
 # --- Public entry points ----------------------------------------------------
@@ -505,6 +527,31 @@ def _gh_pr_diff_for_path(target_dir: Path, pr_number: int, path: str) -> str:
     return ""
 
 
+_DIFF_GIT_HEADER = re.compile(r"(?m)^diff --git a/.+ b/(.+)$")
+
+
+def pr_changed_files(target_dir: Path, pr: PRInfo) -> set[str]:
+    """Return the head-side paths touched by ``pr``.
+
+    Primary path is ``git diff <base>..<head>``; when the local clone cannot
+    resolve ``base_sha`` (rewritten by a rebase) the full PR diff from
+    ``gh pr diff`` is parsed instead — the same two-tier strategy as
+    :func:`file_hunks`.
+
+    GitHub rejects a file-level review comment whose path is not part of the
+    PR diff (HTTP 422), so this set gates file-level placement in
+    :func:`classify`.
+    """
+    changed = set(git_ops.diff_name_only(target_dir, pr.base_sha, pr.head_sha))
+    if changed:
+        return changed
+    try:
+        full_diff = git_ops.gh_pr_diff(target_dir, pr.number)
+    except GitError:
+        return set()
+    return set(_DIFF_GIT_HEADER.findall(full_diff))
+
+
 def _parse_hunks(diff_text: str) -> list[tuple[int, int]]:
     hunks: list[tuple[int, int]] = []
     for m in _HUNK_HEADER.finditer(diff_text):
@@ -549,16 +596,32 @@ def snap_to_hunk(
 def classify(
     target_dir: Path, pr: PRInfo, issues: list[ParsedIssue]
 ) -> _ClassifiedIssues:
-    """Split issues into inline vs body-only based on diff hunks."""
+    """Split issues into inline, file-level, and body-only placements.
+
+    A finding with no resolvable diff-line home is not automatically demoted
+    to the review body: when its file is part of the PR diff it becomes a
+    file-level comment instead. The review body is invisible to the
+    ``/pulls/{n}/comments`` endpoint the labeler reads back, so body-only is
+    the placement of last resort — used only when GitHub could not accept a
+    comment for that path at all.
+    """
     out = _ClassifiedIssues()
     hunks_cache: dict[str, list[tuple[int, int]]] = {}
+    changed_files = pr_changed_files(target_dir, pr)
+
+    def _unplaced(issue: ParsedIssue) -> None:
+        if issue.path in changed_files:
+            out.file_level.append(issue)
+        else:
+            out.body_only.append(issue)
+
     for issue in issues:
         if issue.is_cross_stack:
-            out.body_only.append(issue)
+            _unplaced(issue)
             continue
         line = resolve_line(target_dir, pr.head_sha, issue)
         if line is None:
-            out.body_only.append(issue)
+            _unplaced(issue)
             continue
         if issue.path not in hunks_cache:
             hunks_cache[issue.path] = file_hunks(
@@ -570,7 +633,7 @@ def classify(
             )
         snapped = snap_to_hunk(line, hunks_cache[issue.path])
         if snapped is None:
-            out.body_only.append(issue)
+            _unplaced(issue)
             continue
         out.inline.append(_inline_comment(issue, snapped))
         out.inline_issues.append(issue)
@@ -617,6 +680,23 @@ def _format_inline_body(issue: ParsedIssue) -> str:
     parts = [p for p in (header_line, issue.body) if p]
     agent_prompt = _build_agent_prompt(issue)
     parts.append(agent_prompt)
+    parts.append(DAYDREAM_FOOTER)
+    if issue.fingerprint:
+        parts.append(finding_marker(issue.fingerprint))
+    return "\n\n".join(parts).strip()
+
+
+def _format_file_level_body(issue: ParsedIssue) -> str:
+    """Render the body of a file-level review comment.
+
+    Carries the same :data:`DAYDREAM_FOOTER` badge and hidden finding marker
+    as an inline comment, so the labeler's author check and fingerprint join
+    recognise it without any read-side special-casing.
+    """
+    prefix = "[cross-stack] " if issue.is_cross_stack else ""
+    header = _issue_header(issue, prefix=prefix, always_bold=True)
+    parts = [p for p in (header, issue.body) if p]
+    parts.append(_build_agent_prompt(issue))
     parts.append(DAYDREAM_FOOTER)
     if issue.fingerprint:
         parts.append(finding_marker(issue.fingerprint))
@@ -714,7 +794,7 @@ def _build_consolidated_prompt(
     pr: PRInfo,
 ) -> str:
     """Build a single collapsible prompt block that tells AI agents to fetch and fix review comments."""
-    total = len(classified.inline_issues) + len(classified.body_only)
+    total = classified.total()
 
     prompt_body = (
         f"Fix the {total} review comment(s) posted on this PR.\n"
@@ -841,8 +921,7 @@ def build_payload(
             data; there is no recorder in that process). ``None`` renders the
             live block as usual.
     """
-    all_issues_with_inline_meta = [*classified.body_only]
-    all_issues_with_inline_meta.extend(classified.inline_issues)
+    all_issues_with_inline_meta = classified.all_issues()
 
     body_chunks: list[str] = []
     body_chunks.append("**Code Review Summary**")
@@ -852,7 +931,7 @@ def build_payload(
         body_chunks.append(body_section)
 
     # Consolidated AI agent prompt.
-    if classified.inline_issues or classified.body_only:
+    if not classified.is_empty():
         body_chunks.append(_build_consolidated_prompt(classified, pr))
 
     # Collapsible review info: enriched run-info (rollup + per-phase
@@ -913,7 +992,7 @@ async def _post(
         return
 
     classified = classify(target_dir, pr, issues)
-    if not classified.inline and not classified.body_only:
+    if classified.is_empty():
         print_info(
             console, "No postable issues after classification; skipping PR post."
         )
@@ -923,6 +1002,7 @@ async def _post(
     summary = (
         f"{len(classified.inline)} inline on "
         f"{', '.join(inline_files) if inline_files else '(none)'}, "
+        f"{len(classified.file_level)} file-level, "
         f"{len(classified.body_only)} folded into body"
     )
     print_info(console, f"PR #{pr.number}: {summary}")
@@ -937,6 +1017,17 @@ async def _post(
         print_info(console, "Skipped posting to PR.")
         return
 
+    # File-level comments post first: a failure here has to fall back into the
+    # review body, which is built below.
+    posted, failed = _submit_file_level_comments(target_dir, pr, classified.file_level)
+    if failed:
+        classified.file_level = posted
+        classified.body_only.extend(failed)
+        print_warning(
+            console,
+            f"{len(failed)} file-level comment(s) failed to post; folded into the review body.",
+        )
+
     payload = build_payload(pr, classified)
     review_url, error_msg = _submit_review(target_dir, pr, payload)
     if review_url is None:
@@ -950,6 +1041,43 @@ async def _post(
         return
 
     print_success(console, f"Posted review: {review_url}")
+
+
+def _submit_file_level_comments(
+    target_dir: Path, pr: PRInfo, issues: list[ParsedIssue]
+) -> tuple[list[ParsedIssue], list[ParsedIssue]]:
+    """POST each issue as a file-level review comment; return the ones that failed.
+
+    GitHub rejects ``subject_type`` inside a batch review payload (HTTP 422),
+    so file-level comments must be posted one at a time against
+    ``/pulls/{n}/comments``. Each one becomes a top-level, repliable thread on
+    that endpoint — the surface :func:`index_pr_review_comments` reads — which
+    is what makes these findings labelable at all.
+
+    Failures are returned rather than raised so the caller can fold them back
+    into the review body: a finding that cannot get its own thread must still
+    reach the maintainer.
+
+    Returns:
+        ``(posted, failed)`` partitioning ``issues`` in input order.
+    """
+    endpoint = f"/repos/{pr.owner}/{pr.repo}/pulls/{pr.number}/comments"
+    posted: list[ParsedIssue] = []
+    failed: list[ParsedIssue] = []
+    for issue in issues:
+        payload = {
+            "commit_id": pr.head_sha,
+            "path": issue.path,
+            "subject_type": "file",
+            "body": _format_file_level_body(issue),
+        }
+        try:
+            git_ops.gh_api(target_dir, endpoint, method="POST", input_data=payload)
+        except GitError:
+            failed.append(issue)
+        else:
+            posted.append(issue)
+    return posted, failed
 
 
 def _submit_review(
@@ -1039,10 +1167,12 @@ def post_findings_from_artifact(
         if finding.placement == "inline" and finding.line is not None:
             classified.inline.append(_inline_comment(issue, finding.line))
             classified.inline_issues.append(issue)
+        elif finding.placement == "file":
+            classified.file_level.append(issue)
         else:
             classified.body_only.append(issue)
 
-    if not classified.inline and not classified.body_only:
+    if classified.is_empty():
         print_info(
             console,
             f"No new findings to post ({len(plan.matched)} already on PR #{pr_number}).",
@@ -1059,6 +1189,15 @@ def post_findings_from_artifact(
         repo=repo_name,
         url="",
     )
+    posted_files, failed_files = _submit_file_level_comments(target_dir, pr, classified.file_level)
+    if failed_files:
+        classified.file_level = posted_files
+        classified.body_only.extend(failed_files)
+        print_info(
+            console,
+            f"{len(failed_files)} file-level comment(s) failed to post; folded into the review body.",
+        )
+
     payload = build_payload(pr, classified, run_info_override=artifact.run_info)
     review_url, error_msg = _submit_review(target_dir, pr, payload)
     if review_url is None:

--- a/tests/harness/fake_gh.py
+++ b/tests/harness/fake_gh.py
@@ -129,6 +129,14 @@ def _opt(argv, name):
     return None
 
 
+def _next_comment_seq():
+    """Monotonic counter so each posted comment gets a distinct id."""
+    seq_file = HERE / "comment_seq"
+    n = int(seq_file.read_text()) + 1 if seq_file.exists() else 1
+    seq_file.write_text(str(n))
+    return n
+
+
 def _record(kind, argv, stdin):
     with CALLS.open("a", encoding="utf-8") as f:
         f.write(json.dumps({"kind": kind, "argv": argv, "stdin": stdin}) + "\\n")
@@ -254,6 +262,19 @@ def main():
         return 0
     if method == "POST" and re.fullmatch(r"repos/[^/]+/[^/]+/pulls/\\d+/reviews", endpoint):
         print(json.dumps({"html_url": "https://github.test/fake/pull/7#pullrequestreview-1"}))
+        return 0
+    if method == "POST" and re.fullmatch(r"repos/[^/]+/[^/]+/pulls/\\d+/comments", endpoint):
+        # Real GitHub 422s a file-level comment whose path is not in the PR
+        # diff; `diff-paths`, when configured, reproduces that rejection.
+        allowed = responses.get("diff-paths")
+        path = (payload or {}).get("path")
+        if allowed is not None and path not in allowed:
+            sys.stderr.write("fake gh: path %r not in PR diff (422)\\n" % (path,))
+            return 1
+        print(json.dumps({
+            "id": 9000 + _next_comment_seq(),
+            "html_url": "https://github.test/fake/pull/7#discussion_r1",
+        }))
         return 0
     sys.stderr.write("fake gh: no canned response for %s\\n" % key)
     return 1

--- a/tests/test_capture_loop.py
+++ b/tests/test_capture_loop.py
@@ -1,0 +1,262 @@
+"""Real-path tests that the posterior-capture loop closes.
+
+A finding is only labelable if it reaches ``/pulls/{n}/comments`` as a
+top-level, repliable thread carrying :data:`DAYDREAM_FOOTER` and
+``finding_marker(fingerprint)``. The review *body* carries those markers too,
+but that surface is invisible to :func:`index_pr_review_comments` — so a
+finding folded into the body is permanently unlabelable.
+
+These tests cover the two halves of that loop:
+
+* placement — a finding with no diff-line home whose file IS in the PR diff
+  must be classified ``"file"``, not ``"body"`` (driven through
+  ``runner.run`` with a real git worktree);
+* capture — driving ``daydream post-findings`` from ``cli.main`` with a real
+  ``gh`` subprocess seam must produce a comment on ``/pulls/{n}/comments``
+  that the labeler's own signals read back, count, and resolve on reply.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from daydream import cli, git_ops
+from daydream.backends import ResultEvent, TextEvent
+from daydream.findings import FINDINGS_SCHEMA_VERSION, write_findings_artifact
+from daydream.pr_review import PRInfo, parse_finding_markers
+from daydream.runner import RunConfig, run
+from daydream.training.labeler_signals import (
+    comment_resolution_signal,
+    index_pr_review_comments,
+    per_finding_resolution_signal,
+)
+from tests.harness.phase_backend import PhaseDispatchBackend
+
+FILE_FINGERPRINT = "f" * 64
+
+
+def _never_fetch(*_args, **_kwargs):
+    """A gh_api that must never be called: `threads=` makes the fetch unnecessary."""
+    raise AssertionError("gh_api must not be called when threads= is supplied")
+
+
+def cli_main(argv: list[str]) -> int:
+    """Drive ``cli.main`` with ``argv`` and return its exit code."""
+    import sys
+
+    saved = sys.argv
+    sys.argv = ["daydream", *argv]
+    try:
+        cli.main()
+    except SystemExit as exc:
+        return int(exc.code or 0)
+    finally:
+        sys.argv = saved
+    raise AssertionError("cli.main() must exit via sys.exit")
+
+
+# --- Placement: an unplaceable finding on a changed file goes file-level -----
+
+
+@contextmanager
+def _review_run_env(repo: Path, monkeypatch, out: Path, backend, pr: PRInfo):
+    """`--review --findings-out` real-path setup, mocking only the backend + gh lookups."""
+    monkeypatch.delenv("DAYDREAM_APP_ID", raising=False)
+    monkeypatch.delenv("DAYDREAM_APP_PRIVATE_KEY", raising=False)
+    config = RunConfig(
+        target=str(repo),
+        output_mode="review",
+        pr_number=7,
+        findings_out=str(out),
+        non_interactive=True,
+    )
+    with (
+        patch("daydream.runner.create_backend", return_value=backend),
+        patch("daydream.github_app.resolve_user_identity", return_value="tester"),
+        patch("daydream.pr_review.find_pr_by_number", return_value=pr),
+    ):
+        yield config
+
+
+async def test_unanchorable_finding_on_changed_file_is_placed_file_level(
+    feature_branch_repo, monkeypatch, tmp_path
+):
+    """A finding whose anchors match nothing still gets a trackable placement.
+
+    Enters from ``runner.run`` against a real git worktree. The scripted issue
+    targets ``main.py`` — a file genuinely in the PR diff — but its text
+    contains no token present in that file, so anchor resolution yields no
+    line. Before the fix this fell through to ``placement="body"``, which no
+    posterior signal can ever read back. It must now be ``"file"``.
+    """
+    out = tmp_path / "findings.json"
+    issue = {
+        "id": 1,
+        "title": "Module lacks a rollback barrier",
+        "description": "No `quiescent_rollback_barrier` guards this module",
+        "recommendation": "Introduce a `quiescent_rollback_barrier`",
+        "severity": "medium",
+        "confidence": "HIGH",
+        "files": ["main.py"],
+        "rationale": "",
+    }
+    backend = PhaseDispatchBackend(
+        events=[
+            TextEvent(text="Review complete."),
+            ResultEvent(structured_output={"issues": [issue]}, continuation=None),
+        ]
+    )
+    head = git_ops.head_sha(feature_branch_repo)
+    base = subprocess.run(  # noqa: S603 - arguments are not user-controlled
+        ["git", "rev-parse", "main"],  # noqa: S607 - git is a trusted command
+        cwd=feature_branch_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    pr = PRInfo(
+        number=7,
+        head_sha=head,
+        base_sha=base,
+        base_ref="main",
+        owner="o",
+        repo="r",
+        url="https://example.invalid/pr/7",
+    )
+
+    with _review_run_env(feature_branch_repo, monkeypatch, out, backend, pr) as config:
+        assert await run(config) == 0
+
+    findings = json.loads(out.read_text())["findings"]
+    assert findings, "scripted issue must survive to the artifact"
+    main_py = [f for f in findings if f["path"] == "main.py"]
+    assert main_py, "the finding must target the changed file"
+    assert [f["placement"] for f in main_py] == ["file"], (
+        "a finding on a file in the PR diff with no resolvable line must be "
+        f"placed file-level, not folded into the invisible review body: {main_py}"
+    )
+
+
+# --- Capture: the posted comment is read back by the labeler's own signals ---
+
+
+def _artifact(path: Path, findings: list[dict]) -> Path:
+    write_findings_artifact(
+        path,
+        {
+            "schema_version": FINDINGS_SCHEMA_VERSION,
+            "repo": "o/r",
+            "pr_number": 7,
+            "head_sha": "h" * 40,
+            "run_info": "test run info",
+            "findings": findings,
+        },
+    )
+    return path
+
+
+@pytest.fixture
+def file_level_artifact(tmp_path: Path) -> Path:
+    """One finding with ``placement="file"`` on a path inside the PR diff."""
+    return _artifact(
+        tmp_path / "findings.json",
+        [
+            {
+                "fingerprint": FILE_FINGERPRINT,
+                "path": "b.py",
+                "line": None,
+                "placement": "file",
+                "title": "Cross-cutting concern in b.py",
+                "body": "Body text",
+                "severity": "high",
+                "confidence": "HIGH",
+                "is_cross_stack": True,
+            }
+        ],
+    )
+
+
+def _posted_comments(fake_gh) -> list[dict]:
+    """Rebuild the ``/comments`` GET payload from what actually crossed the gh boundary."""
+    posts = fake_gh.calls("POST", "/repos/o/r/pulls/7/comments")
+    return [
+        {
+            "id": 9000 + i,
+            "in_reply_to_id": None,
+            "user": {"login": "daydream-review"},
+            "body": call.payload["body"],
+        }
+        for i, call in enumerate(posts, start=1)
+    ]
+
+
+def test_file_level_finding_is_captured_and_resolvable(fake_gh, file_level_artifact) -> None:
+    """The full loop: post → read back → count → resolve on reply.
+
+    Drives ``daydream post-findings`` from ``cli.main`` with the real
+    ``git_ops`` subprocess seam (only the ``gh`` binary is faked), then feeds
+    the comments that actually crossed that boundary into the labeler's own
+    signals. Asserts the rubric-visible outcome, not that anything was called.
+    """
+    fake_gh.set_response("diff-paths", value=["b.py"])
+    assert cli_main(
+        ["post-findings", str(file_level_artifact), "--pr", "7", "--head-sha", "h" * 40, "--repo", "o/r"]
+    ) == 0
+
+    # 1. The finding reached /pulls/{n}/comments carrying footer + marker.
+    posts = fake_gh.calls("POST", "/repos/o/r/pulls/7/comments")
+    assert len(posts) == 1, "the file-level finding must be posted as its own comment"
+    body = posts[0].payload["body"]
+    assert posts[0].payload["subject_type"] == "file"
+    assert "<sub>🧙 Posted by [daydream v" in body, "footer identifies daydream authorship"
+    assert parse_finding_markers(body) == [FILE_FINGERPRINT]
+
+    # 2. The labeler reads it back off that endpoint.
+    comments = _posted_comments(fake_gh)
+    row = {"pr_repo": "o/r", "pr_number": 7}
+    threads = index_pr_review_comments(row, gh_api=lambda *a, **k: comments)
+    assert threads is not None
+    unreplied = comment_resolution_signal(row, gh_api=_never_fetch, threads=threads)
+    assert unreplied.total == 1, "the finding must be a trackable top-level comment"
+    assert unreplied.unresolved == 1
+
+    # 3. A maintainer reply moves it to resolved — per-finding, by fingerprint.
+    reply = {
+        "id": 9999,
+        "in_reply_to_id": comments[0]["id"],
+        "user": {"login": "kevin"},
+        "body": "fixed",
+    }
+    replied = [*comments, reply]
+    threads = index_pr_review_comments(row, gh_api=lambda *a, **k: replied)
+    assert threads is not None
+    assert comment_resolution_signal(row, gh_api=_never_fetch, threads=threads).unresolved == 0
+    per_finding = per_finding_resolution_signal(
+        row, recorded_fingerprints=[FILE_FINGERPRINT], gh_api=_never_fetch, threads=threads
+    )
+    assert [(r.fingerprint, r.resolved) for r in per_finding] == [(FILE_FINGERPRINT, True)]
+
+
+def test_file_level_post_rejected_falls_back_to_review_body(fake_gh, file_level_artifact) -> None:
+    """A finding GitHub refuses a file-level comment for is never silently dropped.
+
+    ``diff-paths`` excludes ``b.py``, so the shim 422s the file-level POST the
+    way real GitHub does for a path outside the PR diff. The finding must then
+    appear in the review body — worse for capture, but delivered.
+    """
+    fake_gh.set_response("diff-paths", value=["other.py"])
+    assert cli_main(
+        ["post-findings", str(file_level_artifact), "--pr", "7", "--head-sha", "h" * 40, "--repo", "o/r"]
+    ) == 0
+
+    reviews = fake_gh.calls("POST", "/repos/o/r/pulls/7/reviews")
+    assert len(reviews) == 1
+    assert parse_finding_markers(reviews[0].payload["body"]) == [FILE_FINGERPRINT], (
+        "a rejected file-level finding must fall back into the review body"
+    )

--- a/tests/test_extension_seam_integration.py
+++ b/tests/test_extension_seam_integration.py
@@ -206,13 +206,22 @@ async def test_fork_filter_controls_pr_post_payload(
             archive=False,
         )
     )
-    post = fake_gh.calls("POST", "repos/acme/widgets/pulls/7/reviews")[0]
-    payload = json.dumps(post.payload)
+    # A finding reaches the PR either in the review payload or as its own
+    # file-level comment; the fork's filter must govern both surfaces.
+    posted = json.dumps(
+        [
+            call.payload
+            for call in (
+                *fake_gh.calls("POST", "repos/acme/widgets/pulls/7/reviews"),
+                *fake_gh.calls("POST", "repos/acme/widgets/pulls/7/comments"),
+            )
+        ]
+    )
 
     assert rc == 0
     assert fake_gh.pr_view_calls()
-    assert KEEP_ME in payload
-    assert DROP_ME not in payload
+    assert KEEP_ME in posted
+    assert DROP_ME not in posted
 
 
 async def test_fork_filter_controls_fix_prompts(


### PR DESCRIPTION
## Problem

A finding with no resolvable diff-line home was folded into the review body. The review body is **not** part of `/pulls/{n}/comments` — the only surface `index_pr_review_comments` reads — so every body-only finding was posted but permanently unlabelable.

Measured on this repo's own PRs (last 60): **8 of 20 posted findings (40%) were stranded in the review body.** PR #282 alone had 3 markers in the body and 1 inline.

## Fix

Findings whose file is still in the PR diff are now posted as **file-level review comments** (`subject_type: "file"`). These land on `/comments` as top-level, repliable threads that the existing read-back joins by fingerprint — no reader change, no read-side shim.

Verified against the GitHub API directly:

| | result |
|---|---|
| `subject_type` in batch review payload | 422 rejected |
| `subject_type` on `POST /pulls/{n}/comments` | accepted |
| reply to a file-level comment | threads correctly (`in_reply_to_id` set) |
| file-level comment on a path outside the diff | 422 rejected |

So they post individually, before the review; a rejected one falls back into the review body rather than being dropped. Body-only is now the placement of last resort.

## Verification

Ran end to end against a live throwaway PR (#286, now closed) with real `gh` — no fakes — then read it back through the labeler's own signals:

```
before reply: CommentResolutionSignal(total=1, replied=0, unresolved=1)
after reply:  CommentResolutionSignal(total=1, replied=1, unresolved=0)
per_finding:  PerFindingResolution(resolved=True, comment_id=3609171866)
```

Three real-path tests in `tests/test_capture_loop.py`; all three fail when the production change is reverted (the placement test fails with `placement='body'` — the exact defect). `make check` green: 2246 passed.