### PR TITLE
chore: ignore per-developer agent tooling directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,10 @@ Thumbs.db
 
 # Machine-local daydream config (benchmark-repo, reviewer presets)
 .daydream.toml
+
+# Per-developer agent tooling config and session transcripts
+.codex/
+.cursor/
+.entire/
+.opencode/
+.pi/


### PR DESCRIPTION
Adds `.codex/`, `.cursor/`, `.entire/`, `.opencode/`, and `.pi/` to `.gitignore`.

These are local agent tooling config that varies per developer and per tool, so they were showing up as untracked noise in every `git status`.

`.entire/` is the one that actually matters: it holds `logs/entire.log` and `metadata/<session-id>/full.jsonl` — recordings of agent sessions, not project source. Those shouldn't be committed to a public repo.

Verified with `git check-ignore -v` that all five resolve to the new rules, and `git status` is now clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)