### PR TITLE
chore(release): 0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0] - 2026-07-26
+
+### Added
+
+- **improve:** Advisor flow for repository audit and plan generation ([#291](https://github.com/existential-birds/daydream/pull/291))
+
+  `daydream improve <path>` runs a read-only reconnaissance pass over a
+  repository, producing category-audited findings and prioritized plan
+  artifacts. `daydream improve plan "<request>" <path>` investigates a single
+  improvement request and renders a host-side plan. The flow registers as a
+  first-class step sequence in the flow engine alongside deep, shallow, and
+  review.
+
 ### Changed
 
-- **config:** Update default models and add per-phase reasoning-effort defaults
+- **config:** Move defaults to Sonnet 5 and the GPT-5.6 lineup ([#288](https://github.com/existential-birds/daydream/pull/288))
 
   `DEFAULT_CODEX_MODEL` moves to `gpt-5.6-sol` and the Claude mid tier to
   `claude-sonnet-5`. `PHASE_DEFAULT_MODELS["codex"]` is now tiered across the
@@ -19,6 +32,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `runner._resolved_reasoning_effort` as the lowest precedence tier below
   `--reasoning-effort` and both config-file tiers. Pricing entries are added for
   the new ids; existing entries are retained so archived runs still price.
+
+### Fixed
+
+- **deep:** Propagate authoritative PR-intent framing to the review phases ([#293](https://github.com/existential-birds/daydream/pull/293))
+
+  The intent phase produces an authoritative framing of what the PR does and
+  why. This framing was not being propagated to the downstream per-stack review
+  phases, causing reviewers to occasionally flag intended behavior as defects.
+  The framing is now threaded through to all review prompts.
+
+- **git_ops:** Drop invalid `--body-file` flag from `gh secret set` ([#292](https://github.com/existential-birds/daydream/pull/292))
+
+  `daydream setup` passed `--body-file` to `gh secret set`, which does not
+  accept that flag. The tests that asserted the flag's presence guarded an
+  invalid command shape rather than verifying real behavior.
+
+- **training:** Make corpus labels evidenced, and make the evidence capturable ([#285](https://github.com/existential-birds/daydream/pull/285))
+
+  Corpus harvest labels now require an evidence trace linking each label to
+  the trajectory content that justifies it. The evidence is captured during
+  harvest and projected alongside the label, so downstream training data
+  consumers can audit label provenance.
+
+- **benchmark:** Keep leaf precision consistent with tp/fp ([#283](https://github.com/existential-birds/daydream/pull/283))
+
+  The benchmark scorer computed leaf-node precision from a denominator that
+  diverged from the tp/fp counts used at parent nodes, producing impossible
+  precision values at the leaves. Leaf precision now derives from the same
+  tp/fp pair as the rest of the tree.
+
+- **agent:** Capture structured output under `--log` mode ([#277](https://github.com/existential-birds/daydream/pull/277))
+
+  `--log` mode bypassed the Rich UI but dropped the final structured-output
+  result. The agent's structured response is now emitted as a `[result]` line
+  in the raw log stream, matching what the UI path captures.
 
 ## [0.24.0] - 2026-07-15
 
@@ -866,7 +914,8 @@ Initial release of Daydream - an automated code review and fix loop using the Cl
 - `rich` - Terminal UI components
 - `pyfiglet` - ASCII art header generation
 
-[unreleased]: https://github.com/existential-birds/daydream/compare/v0.24.0...HEAD
+[unreleased]: https://github.com/existential-birds/daydream/compare/v0.25.0...HEAD
+[0.25.0]: https://github.com/existential-birds/daydream/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/existential-birds/daydream/compare/v0.23.1...v0.24.0
 [0.23.1]: https://github.com/existential-birds/daydream/compare/v0.23.0...v0.23.1
 [0.23.0]: https://github.com/existential-birds/daydream/compare/v0.22.0...v0.23.0

--- a/daydream/__init__.py
+++ b/daydream/__init__.py
@@ -17,4 +17,4 @@ Submodules:
     ui: User interface utilities for terminal output.
 """
 
-__version__ = "0.24.0"
+__version__ = "0.25.0"

--- a/daydream/templates/workflows/daydream-post.yml
+++ b/daydream/templates/workflows/daydream-post.yml
@@ -51,7 +51,7 @@ jobs:
         # Pinned to a release tag (not `main`) so the bot runs a known daydream
         # version: reproducible and immune to main-drift / uv-cache staleness.
         # Bump in lockstep with the package version on release (a test enforces this).
-        run: uv tool install git+https://github.com/existential-birds/daydream@v0.24.0
+        run: uv tool install git+https://github.com/existential-birds/daydream@v0.25.0
 
       - name: Mint posting token
         id: token

--- a/daydream/templates/workflows/daydream-review.yml
+++ b/daydream/templates/workflows/daydream-review.yml
@@ -92,7 +92,7 @@ jobs:
         # Pinned to a release tag (not `main`) so the bot runs a known daydream
         # version: reproducible and immune to main-drift / uv-cache staleness.
         # Bump in lockstep with the package version on release (a test enforces this).
-        run: uv tool install git+https://github.com/existential-birds/daydream@v0.24.0
+        run: uv tool install git+https://github.com/existential-birds/daydream@v0.25.0
 
       - name: Run daydream review
         env:

--- a/daydream/templates/workflows/single/daydream.yml
+++ b/daydream/templates/workflows/single/daydream.yml
@@ -144,7 +144,7 @@ jobs:
         # Pinned to a release tag (not `main`) so the bot runs a known daydream
         # version: reproducible and immune to main-drift / uv-cache staleness.
         # Bump in lockstep with the package version on release (a test enforces this).
-        run: uv tool install git+https://github.com/existential-birds/daydream@v0.24.0
+        run: uv tool install git+https://github.com/existential-birds/daydream@v0.25.0
 
       # Runs the DEFAULT deep-review pipeline (not --review). In --non-interactive
       # the deep run auto-declines the post/fix gates, so it still only produces a
@@ -191,7 +191,7 @@ jobs:
         uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
 
       - name: Install daydream
-        run: uv tool install git+https://github.com/existential-birds/daydream@v0.24.0
+        run: uv tool install git+https://github.com/existential-birds/daydream@v0.25.0
 
       - name: Download findings artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "daydream"
-version = "0.24.0"
+version = "0.25.0"
 description = "Automated code review and fix loop using Claude"
 requires-python = ">=3.12.13"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -199,7 +199,7 @@ wheels = [
 
 [[package]]
 name = "daydream"
-version = "0.24.0"
+version = "0.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Release v0.25.0

### Version bump: 0.24.0 → 0.25.0 (minor — new feature)

### Files changed

| File | Old | New |
|---|---|---|
| `pyproject.toml` | `0.24.0` | `0.25.0` |
| `daydream/__init__.py` | `0.24.0` | `0.25.0` |
| `uv.lock` | self-version | re-locked |
| `daydream/templates/workflows/daydream-review.yml` | `@v0.24.0` | `@v0.25.0` |
| `daydream/templates/workflows/daydream-post.yml` | `@v0.24.0` | `@v0.25.0` |
| `daydream/templates/workflows/single/daydream.yml` | `@v0.24.0` (×2) | `@v0.25.0` |
| `CHANGELOG.md` | — | v0.25.0 section + footer links |

### CHANGELOG summary

**Added**
- improve: advisor flow for repository audit and plan generation (#291)

**Changed**
- config: move defaults to Sonnet 5 and the GPT-5.6 lineup (#288)

**Fixed**
- deep: propagate authoritative PR-intent framing to review phases (#293)
- git_ops: drop invalid --body-file flag from gh secret set (#292)
- training: make corpus labels evidenced, and evidence capturable (#285)
- benchmark: keep leaf precision consistent with tp/fp (#283)
- agent: capture structured output under --log mode (#277)

### Pre-push gate
- ruff: passed
- mypy: 0 issues in 294 source files
- pytest: 2699 passed, 5 skipped, 3 warnings (24.99s)
- uv lock --check: in sync