### PR TITLE
fix(eval): grounding_rate is undefined, not perfect, over zero findings (#164)

### DIFF
--- a/daydream/eval/analyzer.py
+++ b/daydream/eval/analyzer.py
@@ -364,7 +364,13 @@ def analyze_findings(daydream_dir: Path) -> dict:
 
 
 def analyze_grounding(trajectories: dict, findings: list[dict]) -> dict:
-    """Tier 1 grounding: verify cited files were actually read by the agent."""
+    """Tier 1 grounding: verify cited files were actually read by the agent.
+
+    ``grounding_rate`` is ``None`` over an empty finding set: the ratio is
+    undefined, not perfect. It feeds the RL/SFT reward as a credit axis
+    (``daydream/training/reward.py``), where scoring absence of evidence as 1.0
+    made "report nothing" the cheapest path to a maximal composite.
+    """
     agent_reads: dict[str, set[str]] = {}
     for traj in trajectories["forked"]:
         label = _agent_label(traj["_source_file"])
@@ -404,7 +410,7 @@ def analyze_grounding(trajectories: dict, findings: list[dict]) -> dict:
         "total_findings": total,
         "grounded_count": len(grounded),
         "ungrounded_count": len(ungrounded),
-        "grounding_rate": round(len(grounded) / total, 4) if total > 0 else 1.0,
+        "grounding_rate": round(len(grounded) / total, 4) if total > 0 else None,
         "grounded": grounded,
         "ungrounded": ungrounded,
     }

--- a/rl/daydream_review_v1/daydream_review_v1/taskset.py
+++ b/rl/daydream_review_v1/daydream_review_v1/taskset.py
@@ -184,16 +184,20 @@ class DaydreamReviewTask(vf.Task[DaydreamReviewData, vf.State, DaydreamReviewTas
     #91's offline ranking gate, golden-comment agreement is exposed only as the
     non-summed ``golden_overlap`` metric.
 
-    KNOWN DEGENERATE OPTIMUM — input for #91, not a bug in this file. A rollout
-    that reports ZERO findings scores ``intrinsic_composite`` 1.0: the grounding
-    axis is vacuously perfect over an empty finding set, correctness is absent,
-    and the length penalty is nil. Observed on a live codex rollout (27 captured
-    turns, 0 findings, composite 1.0). ``score_trajectory`` is reused verbatim on
-    purpose — an online reward and an offline label must not disagree about the
-    same run — so the fix belongs in the rubric #91 owns, not here. Until then,
-    watch the ``n_findings`` metric alongside the reward: a training curve where
-    reward climbs while ``n_findings`` falls is the policy learning to say
-    nothing.
+    A rollout that reports ZERO findings scores ``intrinsic_composite`` 0.0, not
+    1.0. ``analyze_grounding`` returns ``grounding_rate = None`` over an empty
+    finding set (undefined, not perfect), so no credit axis is present and
+    ``score_trajectory`` returns ``composite = None``, mapped to 0.0 below. This
+    was a live defect — a codex rollout with 27 captured turns and 0 findings
+    scored 1.0 — fixed at the write chokepoint in ``daydream/eval/analyzer.py``
+    so the offline corpus and this reward agree. Archived runs scored before that
+    fix keep their 1.0 and were not migrated.
+
+    A correct "nothing wrong here" therefore scores the same as a broken run.
+    Any positive floor for a genuinely clean review is reward design and belongs
+    to the #91 Stage-0 rubric, not here. Keep watching ``n_findings`` alongside
+    the reward regardless: reward climbing while ``n_findings`` falls is still
+    the signal that the policy is learning to say nothing.
     """
 
     @vf.reward(weight=1.0)

--- a/rl/daydream_review_v1/tests/test_rewards.py
+++ b/rl/daydream_review_v1/tests/test_rewards.py
@@ -157,6 +157,52 @@ async def test_intrinsic_composite_carries_the_grounding_axis(
     assert breakdown["grounding"] == expected_grounding
 
 
+async def test_zero_finding_rollout_scores_no_intrinsic_reward(
+    tmp_path: Path, runtime, rundir_golden: Path, corpus_mini_dir: Path, fixture_manifest_path: Path
+) -> None:
+    """Saying nothing must not be the cheapest path to a perfect reward.
+
+    A review that reports ZERO findings has an UNDEFINED grounding rate — the
+    ratio has no denominator — and no verified recommendations, so it has no
+    credit axis at all. Scoring the empty ratio as a vacuous 1.0 handed such a
+    rollout the maximum ``intrinsic_composite``, making silence the degenerate
+    optimum the policy would learn first. With ``grounding_rate`` undefined the
+    whole credit side must be absent, ``composite`` must be ``None``, and the
+    reward the trainer sums must be 0.0.
+    """
+    archive_root = tmp_path / "archive"
+    run_dir = _stage_run(archive_root, rundir_golden)
+
+    (run_dir / "deep" / "merged-items.json").write_text(json.dumps({"items": []}), encoding="utf-8")
+    # The correctness axis comes from deep/recommendation-verdicts.json
+    # (daydream/training/harvest.py:196-201 -> daydream/training/reward.py:369-374);
+    # the golden run ships one, and leaving it would keep the composite non-None.
+    (run_dir / "deep" / "recommendation-verdicts.json").unlink()
+
+    manifest = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
+    manifest["metrics"]["grounding_rate"] = None
+    manifest["metrics"]["total_findings"] = 0
+    (run_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    evaluation = json.loads((run_dir / "evaluation.json").read_text(encoding="utf-8"))
+    evaluation["grounding"]["grounding_rate"] = None
+    evaluation["findings"]["total"] = 0
+    (run_dir / "evaluation.json").write_text(json.dumps(evaluation), encoding="utf-8")
+
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    trace = _trace(task, archive_root=archive_root, repo_path=tmp_path / "repo")
+
+    await task.score(trace, runtime)
+
+    breakdown = trace.info["reward_breakdown"]
+    assert trace.rewards["intrinsic_composite"] == 0.0
+    assert breakdown["axes_present"]["grounding"] is False
+    assert breakdown["composite"] is None
+    # Not merely "grounding went away": no credit axis survives, so the
+    # composite is uncomputable rather than carried by a stale verdict file.
+    assert breakdown["axes_present"]["correctness"] is False
+
+
 async def test_missing_run_dir_scores_zero(
     tmp_path: Path, runtime, corpus_mini_dir: Path, fixture_manifest_path: Path
 ) -> None:

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1,9 +1,12 @@
-"""Tests for daydream.eval.analyzer trajectory loading.
+"""Tests for daydream.eval.analyzer trajectory loading and grounding.
 
 Focused on session-id resolution semantics inside ``load_trajectories``:
 ambiguous prefixes must raise instead of silently picking one, exact
 matches must take precedence over prefix matches, and unique prefixes
 must still resolve.
+
+Also covers ``analyze_grounding``'s rate arithmetic, including the
+undefined (zero-findings) case, which must not report a perfect score.
 """
 
 import json
@@ -11,7 +14,7 @@ from pathlib import Path
 
 import pytest
 
-from daydream.eval.analyzer import load_trajectories
+from daydream.eval.analyzer import analyze_grounding, load_trajectories
 
 
 def _write_run(daydream_dir: Path, session_id: str, marker: str) -> Path:
@@ -60,3 +63,82 @@ def test_exact_match_takes_precedence(tmp_path: Path):
 
     assert result["main"] is not None
     assert result["main"]["marker"] == "exact"
+
+
+# --- analyze_grounding ---
+
+
+def _read_traj(source_file: str, *read_paths: str) -> dict:
+    """Forked-trajectory fixture whose agent Read each of ``read_paths``.
+
+    Shaped for ``_extract_tool_calls``: every step needs a ``step_id`` and its
+    ``tool_calls`` need ``function_name``/``arguments``. ``_files_read`` keeps
+    only the ``file_path`` of ``Read`` calls, and ``_agent_label`` derives the
+    ``deep-<stack>`` key from ``_source_file``.
+    """
+    return {
+        "_source_file": source_file,
+        "steps": [
+            {
+                "step_id": f"s{i}",
+                "tool_calls": [
+                    {"function_name": "Read", "arguments": {"file_path": path}}
+                ],
+            }
+            for i, path in enumerate(read_paths)
+        ],
+    }
+
+
+def test_grounding_rate_is_undefined_with_zero_findings():
+    """A review that produced NO findings has an undefined grounding rate.
+
+    Reporting 1.0 here would hand a review that found nothing a perfect
+    grounding score, which flows into the manifest and becomes a top RL
+    reward. ``None`` is the only honest value for 0/0.
+    """
+    trajectories = {"main": None, "forked": [_read_traj("deep-python.json", "/repo/api.py")]}
+
+    result = analyze_grounding(trajectories, [])
+
+    assert result["total_findings"] == 0
+    assert result["grounded_count"] == 0
+    assert result["ungrounded_count"] == 0
+    assert result["grounding_rate"] is None
+
+
+def test_grounding_rate_is_the_real_fraction_for_mixed_findings():
+    """Regression guard: with findings present the rate stays the true ratio.
+
+    One finding cites a file the matching stack agent actually read; the other
+    cites a file it never opened. Half of two findings are grounded -> 0.5.
+    """
+    trajectories = {
+        "main": None,
+        "forked": [_read_traj("deep-python.json", "/repo/api.py")],
+    }
+    findings = [
+        {
+            "id": 1,
+            "_stack": "python",
+            "file": "api.py",
+            "confidence": "HIGH",
+            "rationale": "The handler is missing a guard.",
+        },
+        {
+            "id": 2,
+            "_stack": "python",
+            "file": "utils.py",
+            "confidence": "MEDIUM",
+            "rationale": "The helper is missing a guard.",
+        },
+    ]
+
+    result = analyze_grounding(trajectories, findings)
+
+    assert result["total_findings"] == 2
+    assert result["grounded_count"] == 1
+    assert result["ungrounded_count"] == 1
+    assert result["grounding_rate"] == 0.5
+    assert [f["id"] for f in result["grounded"]] == [1]
+    assert [f["id"] for f in result["ungrounded"]] == [2]

--- a/tests/test_archive_data_capture.py
+++ b/tests/test_archive_data_capture.py
@@ -24,6 +24,7 @@ from pathlib import Path
 import pytest
 
 from daydream import git_ops
+from daydream.backends import ResultEvent, TextEvent
 from daydream.runner import RunConfig, run
 
 # Reuse the deep-orchestrator stub harness (the hard-won prompt-dispatch heuristics
@@ -182,6 +183,54 @@ async def test_no_eval_leaves_manifest_eval_fields_null(
     assert metrics["coverage_ratio"] is None
     assert metrics["cost_per_finding_usd"] is None
     assert not (run_dir / "evaluation.json").exists()
+
+
+async def test_zero_finding_run_leaves_grounding_rate_undefined(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch, archive_dir: Path
+) -> None:
+    """A DEFAULT deep run whose review produced ZERO findings records a NULL
+    grounding rate, not a perfect one.
+
+    This is emphatically NOT the ``--no-eval`` path: eval runs here (asserted via
+    ``evaluation.json`` on disk), so the null is the eval pass reporting an
+    undefined 0/0 rate, not the eval pass never having happened. Without that
+    distinction the test would pass vacuously. A perfect 1.0 for a review that
+    found nothing propagates into the manifest and becomes a top RL reward.
+    """
+    _silence(monkeypatch)
+    _force_interactive(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    stub.merge_items = []  # empty list: the merge agent ran and returned nothing
+
+    # The manifest's total_findings comes from the per-stack records, not the
+    # merged items, so a genuinely zero-finding run also needs every per-stack
+    # parse to return no issues. Wrap the shared stub rather than adding a knob
+    # to it: only this test needs the clean-review shape.
+    _stub_execute = stub.execute
+
+    async def _no_issues_parsed(cwd, prompt, *args, **kwargs):
+        if "extract only actionable issues" in prompt.lower():
+            yield TextEvent(text="")
+            yield ResultEvent(structured_output={"issues": []}, continuation=None)
+            return
+        async for event in _stub_execute(cwd, prompt, *args, **kwargs):
+            yield event
+
+    monkeypatch.setattr(stub, "execute", _no_issues_parsed)
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_test_and_heal", lambda *a, **k: _ok())
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _noop_commit)
+
+    exit_code = await run(
+        RunConfig(target=str(multi_stack_target), assume="yes", output_mode="loop", cleanup=False)
+    )
+    assert exit_code == 0
+
+    run_dir = _only_archived_run(archive_dir)
+    assert (run_dir / "evaluation.json").is_file()
+
+    metrics = json.loads((run_dir / "manifest.json").read_text())["metrics"]
+    assert metrics["total_findings"] == 0
+    assert metrics["grounding_rate"] is None
 
 
 # --- AC3 (shallow path): recommended.patch captured through the shallow runner ---


### PR DESCRIPTION
## Base branch

Targets **`feat/verifiers-env-164`** (PR #295), not `main` — this change depends on
`rl/daydream_review_v1/` existing. #295 is still open.

## The bug

A rollout that reports **zero findings** scored `intrinsic_composite` **1.0** — the
maximum. The policy's cheapest path to a perfect intrinsic reward was to say nothing.
Observed on two real runs: a live codex rollout (27 captured turns, `n_findings` 0.0,
composite 1.0) and a stub rollout (36 calls, `axes_present` = `{correctness: false,
grounding: true, length: true}`).

Root cause, `daydream/eval/analyzer.py:407`:

```python
"grounding_rate": round(len(grounded) / total, 4) if total > 0 else 1.0,
```

With `total == 0` the ratio is undefined and the code returned `1.0`. For an eval
report ("no ungrounded findings") that reads fine. As a reward it scores absence of
evidence as perfect evidence. The value flows unchanged: `analyzer` →
`evaluation.json["grounding"]["grounding_rate"]` → `archive/manifest.py:315` →
`manifest.json["metrics"]` → `training/harvest.py:223` → `ScoringInputs.grounding_rate`.
A review-only rollout has no `correctness` axis (`deep/recommendation-verdicts.json`
is written only when the fix gate accepted, `deep/orchestrator.py:1213-1229`), so
grounding was the *only* credit axis and carried the composite to ~1.0.

**This was never only an RL bug.** The same path feeds the offline training corpus, so
fixing it downstream in the RL env would have left the corpus wrong and broken the
"one scorer, online and offline agree" property.

## The fix

One line at the write chokepoint — `grounding_rate` is `None` when
`total_findings == 0`. It then flows correctly everywhere with no read-side
special-casing: `axes_present["grounding"]` → `False`, `present_weights` empty,
`score_trajectory` returns `composite = None`, and
`DaydreamReviewTask.intrinsic_composite` already maps `None` → `0.0`.

No fork of `score_trajectory`, no compensating term in the RL env, no migration of
archived runs — old runs keep their 1.0.

Also rewrites the now-stale `KNOWN DEGENERATE OPTIMUM` block in
`rl/daydream_review_v1/daydream_review_v1/taskset.py`, which documented this as
working-as-intended and deferred to #91.

## The two judgement calls

**1. Is `composite = None` → `0.0` right for a genuinely clean diff? Yes — ship it.**
It removes the degenerate optimum. It does mean a correct "nothing wrong here" scores
the same as a broken run, and under `--yes` such a rollout also gets
`fix_tests_pass = no_fix_reward` (0.0), so total reward is 0.0. A positive floor for a
clean review is reward *design*, not a bug fix, and belongs to the **#91 Stage-0
rubric**. Stated explicitly in the taskset docstring so the next reader doesn't
re-litigate it.

**2. Does anything consume `grounding_rate` expecting a float? No crashes. One
behavior change worth naming.** Audited every hit of
`grep -rn "grounding_rate\|grounding_score" daydream/ tests/ bench/ rl/`:

- `training/schema/v1.json:105` — `"type": ["number", "null"]`. **Safe**, null already allowed.
- `archive/manifest.py:152` `float | None`, `archive/_schema.py:60` `grounding_rate REAL` (nullable), `archive/index.py:225`. **Safe.**
- `training/reward.py:376-418` — `None` handled by design (`axes_present`, `present_weights`, `composite = None`). **Safe.**
- `summarize.py`, `ui/`, `bench/` — **no consumer renders grounding at all**; there is no `f"{rate:.0%}"` anywhere to crash. **Safe.**
- `training/corpus.py:544` + `cli.py:363` `--min-grounding` — **behavior change**: SQLite `NULL >= ?` is never true, so zero-finding runs are now excluded from *every* threshold, including `--min-grounding 0.0`. This is the correct semantics (a run with an undefined rate should not satisfy a grounding floor) and the mechanism already existed for `--no-eval` runs; only the population it removes changes. Calling it out rather than burying it.

**REWARD_VERSION is deliberately not bumped.** `training/reward.py:89` says "bump on any
change to axis weights, verdict map, gate, or composite shape" — none of those changed.
`score_trajectory` is byte-identical; only one of its inputs became honest. Bumping
would relabel every already-scored run while their composites stayed as-is.
`test_reward_version_is_pinned` stays green. Flagging it here as required rather than
deciding it silently.

## Tests — three, each written before the fix

1. `tests/test_analyzer.py::test_grounding_rate_is_undefined_with_zero_findings` —
   unit at the root. Failed pre-fix with `assert 1.0 is None`.
   Paired with `test_grounding_rate_is_the_real_fraction_for_mixed_findings` (1 grounded
   / 1 ungrounded → exactly 0.5, asserting which ids land in each bucket), which passed
   before *and* after — the guard that only the undefined case moved.
   `analyze_grounding` had **zero** test coverage before this.
2. `tests/test_archive_data_capture.py::test_zero_finding_run_leaves_grounding_rate_undefined`
   — real-path through `runner.run` with a real temp git worktree, mocking only the
   backend seam, asserting on `manifest.json` **on disk**:
   `metrics["total_findings"] == 0` and `metrics["grounding_rate"] is None`, plus
   `evaluation.json` exists so it can't pass vacuously via the `--no-eval` path.
   Failed pre-fix with `assert 1.0 is None`.
   *Non-obvious finding:* `stub.merge_items = []` alone does **not** produce a
   zero-finding run — `total_findings` comes from `analyze_findings` counting
   `deep/stack-*-records.json`, not the merged items. Without also returning
   `{"issues": []}` from the per-stack parse the run still recorded
   `total_findings == 4`. Exit code is 0 ("No actionable items -- done."); no
   assertion was weakened.
3. `rl/daydream_review_v1/tests/test_rewards.py::test_zero_finding_rollout_scores_no_intrinsic_reward`
   — scores a staged run through `await task.score(trace, runtime)` with a **real**
   `SubprocessRuntime`. Asserts `trace.rewards["intrinsic_composite"] == 0.0`,
   `axes_present["grounding"] is False`, `composite is None`, and
   `axes_present["correctness"] is False` (so the composite is `None` for the right
   reason). Requires deleting the staged `deep/recommendation-verdicts.json` — the
   golden fixture ships one, and it would otherwise supply a correctness axis and
   defeat the test.

`tests/fixtures/rundir-golden/` is **unmodified** (1 finding, grounding 1.0); all
mutation happens on the `_stage_run` copy under `tmp_path`.
`test_intrinsic_composite_parity` and `test_reward_version_is_pinned` are green.

## Gates

```
make check                    -> 2717 passed, 5 skipped   ("✓ All checks passed")
cd rl/daydream_review_v1
  uv run ruff check .         -> All checks passed!
  uv run mypy ...             -> Success: no issues found in 14 source files
  uv run pytest               -> 45 passed, 1 skipped
```

The pre-push hook (lockcheck + ruff + mypy + full pytest) ran clean on push, and no
gate was bypassed, weakened, or skipped.

## Not done

- No positive floor for a clean review — #91 owns that.
- No re-scoring or migration of archived runs.
- No change to the training-repo set.
- `.planning/specs/open-weight-review-model/SPEC.md` was **not** edited; nothing in it
  contradicted this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
