### PR TITLE
fix(reconcile): suppress forged daydream-finding markers from non-bot commenters (#254)

### DIFF
--- a/.github/workflows/daydream-post.yml
+++ b/.github/workflows/daydream-post.yml
@@ -111,9 +111,10 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.target.outputs.pr_number }}
           HEAD_SHA: ${{ steps.target.outputs.head_sha }}
+          BOT_LOGIN: ${{ vars.DAYDREAM_BOT_HANDLE }}
         run: |
           daydream post-findings findings/findings.json \
-            --pr "$PR_NUMBER" --head-sha "$HEAD_SHA" --repo "$REPO"
+            --pr "$PR_NUMBER" --head-sha "$HEAD_SHA" --repo "$REPO" --bot-login "$BOT_LOGIN"
 
       - name: Surface failure on the PR
         if: failure()

--- a/daydream/benchmark/harvest.py
+++ b/daydream/benchmark/harvest.py
@@ -24,7 +24,8 @@ All GitHub access goes through :func:`daydream.git_ops.gh_api`, so rate-limit
 and timeout discipline is shared with the rest of daydream.
 
 Exports:
-    bot_login_matches: ``[bot]``-suffix-tolerant login comparison.
+    bot_login_matches: ``[bot]``-suffix-tolerant login comparison (re-exported
+        from :mod:`daydream.bot_identity`, the single source of truth).
     fetch_review_threads: Review-thread resolution state via GraphQL.
     harvest_pr: Collect one PR's bot activity.
     build_harvested_corpus: Project harvest records into a benchmark corpus dict.
@@ -40,6 +41,7 @@ from typing import Any
 from daydream import git_ops
 from daydream.agent import console
 from daydream.benchmark.benchmark_data import save_benchmark_data
+from daydream.bot_identity import bot_login_matches, bot_stem
 from daydream.ui import print_dim, print_info, print_warning
 
 #: GraphQL page size for review threads (GitHub's per-connection maximum).
@@ -60,21 +62,6 @@ query($owner:String!,$repo:String!,$num:Int!,$cursor:String){
   }
 }
 """ % _THREAD_PAGE_SIZE
-
-
-def bot_login_matches(login: str | None, bot: str) -> bool:
-    """Match a bot login tolerant of GitHub's REST/GraphQL ``[bot]`` mismatch.
-
-    REST ``user.login`` keeps the ``[bot]`` suffix (``coderabbitai[bot]``);
-    GraphQL ``author.login`` drops it (``coderabbitai``). Compare on the
-    stripped, lowercased stem so both forms match one ``--bot`` value.
-    """
-    return bot_stem(login) == bot_stem(bot)
-
-
-def bot_stem(login: str | None) -> str:
-    """Return a login's comparison stem: ``[bot]`` suffix dropped, lowercased."""
-    return (login or "").removesuffix("[bot]").lower()
 
 
 def fetch_review_threads(repo_slug: str, pr_number: int) -> tuple[list[dict[str, Any]], bool]:

--- a/daydream/bot_identity.py
+++ b/daydream/bot_identity.py
@@ -1,0 +1,34 @@
+"""Single source of truth for the ``[bot]``-tolerant login comparator (issue #254).
+
+``bot_login_matches`` / ``bot_stem`` compare GitHub login strings tolerant of
+the REST/GraphQL ``[bot]`` suffix mismatch. They live here — a zero-dependency
+leaf mirroring the ``daydream/prompts/<name>.py`` one-constant-per-module
+precedent — so ``daydream.reconcile`` (the author-filter fix for forged
+``daydream-finding`` markers) and ``daydream.benchmark.harvest`` (PR-history
+ingestion) can share one definition without ``reconcile`` pulling benchmark
+deps or risking an import cycle. Relocated verbatim from
+``daydream/benchmark/harvest.py`` (formerly lines 65-77); behavior unchanged.
+
+Exports:
+    bot_login_matches: ``[bot]``-suffix-tolerant login comparison.
+    bot_stem: login's comparison stem — ``[bot]`` suffix dropped, lowercased.
+"""
+
+from __future__ import annotations
+
+__all__ = ["bot_login_matches", "bot_stem"]
+
+
+def bot_login_matches(login: str | None, bot: str) -> bool:
+    """Match a bot login tolerant of GitHub's REST/GraphQL ``[bot]`` mismatch.
+
+    REST ``user.login`` keeps the ``[bot]`` suffix (``coderabbitai[bot]``);
+    GraphQL ``author.login`` drops it (``coderabbitai``). Compare on the
+    stripped, lowercased stem so both forms match one ``--bot`` value.
+    """
+    return bot_stem(login) == bot_stem(bot)
+
+
+def bot_stem(login: str | None) -> str:
+    """Return a login's comparison stem: ``[bot]`` suffix dropped, lowercased."""
+    return (login or "").removesuffix("[bot]").lower()

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -1538,6 +1538,15 @@ def _build_post_findings_parser() -> argparse.ArgumentParser:
         metavar="OWNER/REPO",
         help="Event-derived repository slug the artifact must declare.",
     )
+    parser.add_argument(
+        "--bot-login",
+        type=str,
+        default=None,
+        dest="bot_login",
+        metavar="LOGIN",
+        help="Bot login (App slug) for prior-finding author filtering. "
+        "Defaults to $DAYDREAM_BOT_HANDLE.",
+    )
     return parser
 
 
@@ -1567,6 +1576,7 @@ def _handle_post_findings_command(argv: list[str]) -> int:
         head_sha=args.head_sha,
         repo=args.repo,
         console=create_console(),
+        bot_login=args.bot_login,
     )
 
 

--- a/daydream/pr_review.py
+++ b/daydream/pr_review.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import contextlib
 import hashlib
 import json
+import os
 import re
 import tempfile
 from dataclasses import dataclass, field
@@ -1112,6 +1113,7 @@ def post_findings_from_artifact(
     head_sha: str,
     repo: str,
     console: Console,
+    bot_login: str | None = None,
 ) -> int:
     """Post a Phase A findings artifact to the PR (the Phase B privileged poster).
 
@@ -1127,6 +1129,12 @@ def post_findings_from_artifact(
         pr_number: Event-derived target PR number.
         head_sha: Event-derived PR head SHA.
         repo: Event-derived ``owner/repo`` slug.
+        console: Rich console for status output.
+        bot_login: Optional bot login (App slug) for prior-finding author
+            filtering. When ``None``, falls back to ``$DAYDREAM_BOT_HANDLE``;
+            if still unresolved, dedup degrades safely (GraphQL is still
+            protected by ``viewerDidAuthor``; REST dedup is unavailable) and
+            a warning is printed. Never suppresses on an unresolved login.
 
     Returns:
         ``0`` on success (including "no new findings"); ``1`` when the
@@ -1138,6 +1146,18 @@ def post_findings_from_artifact(
     # call time — the same no-cycle pattern as ``daydream.deep.orchestrator``.
     from daydream.findings import FindingsValidationError, load_findings_artifact
     from daydream.reconcile import fetch_prior_findings, partition, resolve_threads
+
+    # Resolve the effective bot login in ONE place (here), so both the CLI
+    # and any library caller get the env fallback. Precedence: explicit param
+    # over $DAYDREAM_BOT_HANDLE. An unresolved login degrades dedup safely.
+    effective_login = bot_login or os.environ.get("DAYDREAM_BOT_HANDLE") or None
+    if effective_login is None:
+        print_warning(
+            console,
+            "BOT_LOGIN_UNRESOLVED: no --bot-login and $DAYDREAM_BOT_HANDLE is unset; "
+            "prior-finding dedup is degraded (GraphQL still protected by viewerDidAuthor; "
+            "REST dedup unavailable) — may double-post, will never suppress.",
+        )
 
     target_dir = Path.cwd()
     try:
@@ -1152,7 +1172,7 @@ def post_findings_from_artifact(
         return 1
 
     try:
-        prior = fetch_prior_findings(target_dir, repo, pr_number)
+        prior = fetch_prior_findings(target_dir, repo, pr_number, bot_login=effective_login)
     except GitError as exc:
         print_error(console, "Prior-Finding Inventory Failed", str(exc))
         return 1

--- a/daydream/reconcile.py
+++ b/daydream/reconcile.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from daydream import git_ops
+from daydream.bot_identity import bot_login_matches
 from daydream.git_ops import GitError
 from daydream.pr_review import parse_finding_markers
 from daydream.ui import print_warning
@@ -80,7 +81,7 @@ query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
           id
           isResolved
           comments(first: 100) {
-            nodes { id databaseId body isMinimized }
+            nodes { id databaseId body isMinimized author { login } viewerDidAuthor }
           }
         }
       }
@@ -121,7 +122,23 @@ def _graphql(repo: Path, query: str, variables: dict[str, Any], *, idempotent: b
     return response
 
 
-def fetch_prior_findings(target_dir: Path, repo_slug: str, pr_number: int) -> dict[str, PriorFinding]:
+def _authored_by_bot(login: str | None, viewer_did_author: bool, bot_login: str | None) -> bool:
+    """True iff GitHub proves the bot authored this node.
+
+    ``viewerDidAuthor`` is decided server-side from the installation token
+    (GraphQL only); the ``[bot]``-tolerant login match covers REST reviews
+    and acts as defense-in-depth on GraphQL. Either proof suffices. When
+    ``bot_login`` is None only ``viewerDidAuthor`` can save a node — REST
+    nodes are never trusted in that case (safe degradation).
+    """
+    if viewer_did_author:
+        return True
+    return bot_login is not None and bot_login_matches(login, bot_login)
+
+
+def fetch_prior_findings(
+    target_dir: Path, repo_slug: str, pr_number: int, *, bot_login: str | None = None
+) -> dict[str, PriorFinding]:
     """Inventory the bot's prior findings on a PR, keyed by fingerprint.
 
     Combines two sources:
@@ -131,6 +148,13 @@ def fetch_prior_findings(target_dir: Path, repo_slug: str, pr_number: int) -> di
        ``daydream-finding`` marker.
     2. REST ``GET /repos/<owner>/<repo>/pulls/<n>/reviews`` for body-only
        findings embedded in review bodies (``thread_id=None``).
+
+    A marker is trusted **only** when GitHub proves the bot authored it:
+    ``viewerDidAuthor == true`` (GraphQL) or ``author.login`` / ``user.login``
+    matching *bot_login* via the ``[bot]``-suffix-tolerant comparator. When
+    ``bot_login`` is None, GraphQL is still protected by ``viewerDidAuthor``
+    and REST harvests nothing (a misconfigured bot double-posts rather than
+    ever suppressing a real finding).
 
     The first occurrence of a fingerprint wins on duplicates. A finding
     reads as resolved when its thread is resolved (human action) or its
@@ -152,6 +176,12 @@ def fetch_prior_findings(target_dir: Path, repo_slug: str, pr_number: int) -> di
         threads = response["data"]["repository"]["pullRequest"]["reviewThreads"]
         for thread in threads["nodes"]:
             for comment in thread["comments"]["nodes"]:
+                if not _authored_by_bot(
+                    (comment.get("author") or {}).get("login"),
+                    bool(comment.get("viewerDidAuthor")),
+                    bot_login,
+                ):
+                    continue
                 for fingerprint in parse_finding_markers(comment.get("body") or ""):
                     if fingerprint in prior:
                         continue
@@ -170,6 +200,10 @@ def fetch_prior_findings(target_dir: Path, repo_slug: str, pr_number: int) -> di
         target_dir, f"repos/{owner}/{name}/pulls/{pr_number}/reviews", paginate=True, idempotent=True
     )
     for review in reviews:
+        if not _authored_by_bot(
+            (review.get("user") or {}).get("login"), False, bot_login
+        ):
+            continue
         for fingerprint in parse_finding_markers(review.get("body") or ""):
             if fingerprint in prior:
                 continue

--- a/daydream/templates/workflows/daydream-post.yml
+++ b/daydream/templates/workflows/daydream-post.yml
@@ -115,9 +115,10 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.target.outputs.pr_number }}
           HEAD_SHA: ${{ steps.target.outputs.head_sha }}
+          BOT_LOGIN: ${{ vars.DAYDREAM_BOT_HANDLE }}
         run: |
           daydream post-findings findings/findings.json \
-            --pr "$PR_NUMBER" --head-sha "$HEAD_SHA" --repo "$REPO"
+            --pr "$PR_NUMBER" --head-sha "$HEAD_SHA" --repo "$REPO" --bot-login "$BOT_LOGIN"
 
       - name: Surface failure on the PR
         if: failure() && steps.download.outcome == 'success'

--- a/tests/harness/fake_gh.py
+++ b/tests/harness/fake_gh.py
@@ -404,17 +404,41 @@ class FakeGh:
         """
         self.set_response("GET", "/app/installations", value=installations)
 
-    def serve_prior_threads(self, *, fingerprints: list[str], thread_ids: list[str]) -> None:
-        """Serve a prior-thread inventory: one unresolved inline thread per fingerprint."""
+    def serve_prior_threads(
+        self,
+        *,
+        fingerprints: list[str],
+        thread_ids: list[str],
+        authors: list[str] | None = None,
+        viewer_did_author: bool | None = None,
+    ) -> None:
+        """Serve a prior-thread inventory: one unresolved inline thread per fingerprint.
+
+        When *authors* is provided it must parallel *fingerprints* and is zipped
+        into the comment nodes as ``author { login }``. When *viewer_did_author*
+        is set the comment nodes carry ``viewerDidAuthor``. Either None leaves
+        the key absent so absence remains testable.
+        """
+        if authors is not None and len(authors) != len(fingerprints):
+            raise ValueError("authors must parallel fingerprints")
         nodes = [
-            self._thread_node(thread_id, f"RC_{i}", 1000 + i, finding_marker(fingerprint))
+            self._thread_node(
+                thread_id,
+                f"RC_{i}",
+                1000 + i,
+                finding_marker(fingerprint),
+                author=authors[i - 1] if authors is not None else None,
+                viewer_did_author=viewer_did_author,
+            )
             for i, (fingerprint, thread_id) in enumerate(
                 zip(fingerprints, thread_ids, strict=True), start=1
             )
         ]
         self._write_threads(nodes)
 
-    def serve_prior_threads_from(self, call: GhCall) -> None:
+    def serve_prior_threads_from(
+        self, call: GhCall, *, viewer_did_author: bool | None = None
+    ) -> None:
         """Make GitHub "remember" a recorded review POST as prior findings.
 
         Each inline comment in the posted payload becomes an unresolved review
@@ -422,7 +446,10 @@ class FakeGh:
         """
         payload = call.payload or {}
         nodes = [
-            self._thread_node(f"RT_{i}", f"RC_{i}", i, comment.get("body", ""))
+            self._thread_node(
+                f"RT_{i}", f"RC_{i}", i, comment.get("body", ""),
+                viewer_did_author=viewer_did_author,
+            )
             for i, comment in enumerate(payload.get("comments", []), start=1)
         ]
         self._write_threads(nodes)
@@ -434,21 +461,28 @@ class FakeGh:
 
     @staticmethod
     def _thread_node(
-        thread_id: str, comment_node_id: str, database_id: int, body: str
+        thread_id: str,
+        comment_node_id: str,
+        database_id: int,
+        body: str,
+        *,
+        author: str | None = None,
+        viewer_did_author: bool | None = None,
     ) -> dict[str, Any]:
+        comment: dict[str, Any] = {
+            "id": comment_node_id,
+            "databaseId": database_id,
+            "body": body,
+            "isMinimized": False,
+        }
+        if author is not None:
+            comment["author"] = {"login": author}
+        if viewer_did_author is not None:
+            comment["viewerDidAuthor"] = bool(viewer_did_author)
         return {
             "id": thread_id,
             "isResolved": False,
-            "comments": {
-                "nodes": [
-                    {
-                        "id": comment_node_id,
-                        "databaseId": database_id,
-                        "body": body,
-                        "isMinimized": False,
-                    }
-                ]
-            },
+            "comments": {"nodes": [comment]},
         }
 
     def _write_threads(self, nodes: list[dict[str, Any]]) -> None:

--- a/tests/harness/fake_gh.py
+++ b/tests/harness/fake_gh.py
@@ -437,25 +437,31 @@ class FakeGh:
         self._write_threads(nodes)
 
     def serve_prior_threads_from(
-        self, call: GhCall, *, viewer_did_author: bool | None = None
+        self, call: GhCall, *,
+        author: str | None = None,
+        viewer_did_author: bool | None = None,
     ) -> None:
         """Make GitHub "remember" a recorded review POST as prior findings.
 
         Each inline comment in the posted payload becomes an unresolved review
         thread, and the review body becomes a REST review (body-only markers).
+        When *author* is set, both the GraphQL thread comments and the REST
+        review carry it (``author { login }`` / ``user { login }`` respectively)
+        so the bot-author trust rule in ``fetch_prior_findings`` accepts them.
         """
         payload = call.payload or {}
         nodes = [
             self._thread_node(
                 f"RT_{i}", f"RC_{i}", i, comment.get("body", ""),
-                viewer_did_author=viewer_did_author,
+                author=author, viewer_did_author=viewer_did_author,
             )
             for i, comment in enumerate(payload.get("comments", []), start=1)
         ]
         self._write_threads(nodes)
-        self.set_response(
-            "GET", call.endpoint, [{"id": 1, "node_id": "PRR_1", "body": payload.get("body", "")}]
-        )
+        review: dict[str, Any] = {"id": 1, "node_id": "PRR_1", "body": payload.get("body", "")}
+        if author is not None:
+            review["user"] = {"login": author}
+        self.set_response("GET", call.endpoint, [review])
 
     # --- internals ------------------------------------------------------------
 

--- a/tests/test_bot_identity.py
+++ b/tests/test_bot_identity.py
@@ -1,0 +1,17 @@
+"""One source of truth for the [bot]-tolerant login comparator (issue #254)."""
+
+from daydream.bot_identity import bot_login_matches, bot_stem
+
+
+def test_bot_stem_strips_bot_suffix_and_lowercases() -> None:
+    assert bot_stem("daydream[bot]") == "daydream"
+    assert bot_stem("Daydream") == "daydream"          # GraphQL drops [bot]
+    assert bot_stem(None) == ""
+
+
+def test_bot_login_matches_across_rest_and_graphql_forms() -> None:
+    # --bot value is the bare slug (DAYDREAM_BOT_HANDLE shape).
+    assert bot_login_matches("daydream[bot]", "daydream") is True   # REST form
+    assert bot_login_matches("daydream", "daydream") is True        # GraphQL form
+    assert bot_login_matches("evil-attacker", "daydream") is False
+    assert bot_login_matches(None, "daydream") is False

--- a/tests/test_post_findings_integration.py
+++ b/tests/test_post_findings_integration.py
@@ -139,3 +139,51 @@ def test_malformed_artifact_aborts(fake_gh, tmp_path) -> None:
     bad.write_text("{not json")
     rc = cli_main(_post_argv(bad))
     assert rc == 1 and fake_gh.calls("POST") == []
+
+
+def _forged_marker_argv(artifact: Path, *extra: str) -> list[str]:
+    """``post-findings`` argv for a single-finding artifact, plus extra flags."""
+    return ["post-findings", str(artifact), "--pr", "7", "--head-sha", "h" * 40, "--repo", "o/r", *extra]
+
+
+def _write_single_finding_artifact(path: Path, fingerprint: str) -> Path:
+    return _write_artifact(
+        path / "findings.json",
+        [_finding(fingerprint, path="src/app.py", line=10, placement="inline", title="Real finding")],
+    )
+
+
+def test_forged_marker_from_non_bot_commenter_does_not_suppress_finding(
+    fake_gh, tmp_path
+) -> None:
+    # Prior thread carries the SAME fingerprint, but authored by a human -> forged.
+    artifact = _write_single_finding_artifact(tmp_path, "a" * 64)
+    fake_gh.serve_prior_threads(
+        fingerprints=["a" * 64], thread_ids=["RT_X"], authors=["evil-attacker"]
+    )
+    code = cli_main(_forged_marker_argv(artifact, "--bot-login", "daydream"))
+    assert code == 0
+    # Not suppressed -> review still posted once.
+    assert len(fake_gh.calls("POST", "/repos/o/r/pulls/7/reviews")) == 1
+
+
+def test_bot_authored_marker_with_bot_login_suppresses_repost(fake_gh, tmp_path) -> None:
+    artifact = _write_single_finding_artifact(tmp_path, "a" * 64)
+    fake_gh.serve_prior_threads(
+        fingerprints=["a" * 64], thread_ids=["RT_X"], authors=["daydream[bot]"]
+    )
+    code = cli_main(_forged_marker_argv(artifact, "--bot-login", "daydream"))
+    assert code == 0
+    # Already on the PR -> NO review posted (idempotent).
+    assert len(fake_gh.calls("POST", "/repos/o/r/pulls/7/reviews")) == 0
+
+
+def test_bot_login_env_fallback(monkeypatch, fake_gh, tmp_path) -> None:
+    artifact = _write_single_finding_artifact(tmp_path, "a" * 64)
+    fake_gh.serve_prior_threads(
+        fingerprints=["a" * 64], thread_ids=["RT_X"], authors=["daydream[bot]"]
+    )
+    monkeypatch.setenv("DAYDREAM_BOT_HANDLE", "daydream")  # no --bot-login flag
+    code = cli_main(_forged_marker_argv(artifact))  # env supplies the login
+    assert code == 0
+    assert len(fake_gh.calls("POST", "/repos/o/r/pulls/7/reviews")) == 0

--- a/tests/test_post_findings_integration.py
+++ b/tests/test_post_findings_integration.py
@@ -102,13 +102,24 @@ def test_fresh_post_then_idempotent_repost(fake_gh, artifact_on_disk) -> None:
     posts = fake_gh.calls("POST", "/repos/o/r/pulls/7/reviews")
     assert len(posts) == 1
     assert parse_finding_markers(json.dumps(posts[0].payload))  # markers shipped
-    fake_gh.serve_prior_threads_from(posts[0])  # GitHub now "remembers" run 1
+    # Replay the posted markers as trusted prior threads (viewerDidAuthor
+    # simulates the bot's authorship of its own prior post). REST body-only
+    # dedup additionally requires a threaded bot_login — Task 3 — so we
+    # surface every posted marker, inline and body-only alike, via GraphQL.
+    posted_markers = parse_finding_markers(json.dumps(posts[0].payload))
+    fake_gh.serve_prior_threads(
+        fingerprints=posted_markers,
+        thread_ids=[f"RT_{i}" for i in range(len(posted_markers))],
+        viewer_did_author=True,
+    )
     assert cli_main(argv) == 0
     assert len(fake_gh.calls("POST", "/repos/o/r/pulls/7/reviews")) == 1  # no dup review
 
 
 def test_stale_finding_resolved_new_finding_posted(fake_gh, artifact_on_disk_v2) -> None:
-    fake_gh.serve_prior_threads(fingerprints=["a" * 64], thread_ids=["RT_1"])
+    fake_gh.serve_prior_threads(
+        fingerprints=["a" * 64], thread_ids=["RT_1"], viewer_did_author=True
+    )
     assert cli_main(_post_argv(artifact_on_disk_v2)) == 0
     # Task 0 spike: resolveReviewThread is FORBIDDEN for the least-privilege
     # installation token; stale findings are minimized via minimizeComment.

--- a/tests/test_post_findings_integration.py
+++ b/tests/test_post_findings_integration.py
@@ -97,21 +97,18 @@ def artifact_on_disk_v2(tmp_path: Path) -> Path:
 
 
 def test_fresh_post_then_idempotent_repost(fake_gh, artifact_on_disk) -> None:
-    argv = _post_argv(artifact_on_disk)
+    argv = _post_argv(artifact_on_disk) + ["--bot-login", "daydream"]
     assert cli_main(argv) == 0
     posts = fake_gh.calls("POST", "/repos/o/r/pulls/7/reviews")
     assert len(posts) == 1
     assert parse_finding_markers(json.dumps(posts[0].payload))  # markers shipped
-    # Replay the posted markers as trusted prior threads (viewerDidAuthor
-    # simulates the bot's authorship of its own prior post). REST body-only
-    # dedup additionally requires a threaded bot_login — Task 3 — so we
-    # surface every posted marker, inline and body-only alike, via GraphQL.
-    posted_markers = parse_finding_markers(json.dumps(posts[0].payload))
-    fake_gh.serve_prior_threads(
-        fingerprints=posted_markers,
-        thread_ids=[f"RT_{i}" for i in range(len(posted_markers))],
-        viewer_did_author=True,
-    )
+    # Replay the ACTUAL posted review as prior state: inline comments become
+    # GraphQL threads, the review body becomes a REST review. Author is set to
+    # the bot login so both harvest paths trust it via the [bot]-tolerant
+    # comparator. This proves the wire-format round trip (poster emits ->
+    # harvester reads) through the real CLI, on the real posted payload —
+    # not just unit-level fabricated markers.
+    fake_gh.serve_prior_threads_from(posts[0], author="daydream[bot]")
     assert cli_main(argv) == 0
     assert len(fake_gh.calls("POST", "/repos/o/r/pulls/7/reviews")) == 1  # no dup review
 

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -9,16 +9,30 @@ from daydream.reconcile import PriorFinding, fetch_prior_findings, partition
 # --- Canned gh_api responses for fetch_prior_findings ----------------------
 
 
-def _thread(thread_id: str, *, comment_node_id: str, database_id: int, body: str) -> dict[str, Any]:
+def _thread(
+    thread_id: str,
+    *,
+    comment_node_id: str,
+    database_id: int,
+    body: str,
+    author: str | None = None,
+    viewer_did_author: bool | None = None,
+) -> dict[str, Any]:
     """One reviewThreads node carrying a single comment."""
+    comment: dict[str, Any] = {
+        "id": comment_node_id,
+        "databaseId": database_id,
+        "body": body,
+        "isMinimized": False,
+    }
+    if author is not None:
+        comment["author"] = {"login": author}
+    if viewer_did_author is not None:
+        comment["viewerDidAuthor"] = bool(viewer_did_author)
     return {
         "id": thread_id,
         "isResolved": False,
-        "comments": {
-            "nodes": [
-                {"id": comment_node_id, "databaseId": database_id, "body": body, "isMinimized": False}
-            ]
-        },
+        "comments": {"nodes": [comment]},
     }
 
 
@@ -45,12 +59,14 @@ _GRAPHQL_PAGE_1: dict[str, Any] = _page(
 
 _GRAPHQL_PAGE_2: dict[str, Any] = _page(
     [_thread("RT_1", comment_node_id="PRRC_1", database_id=101,
-             body="Race in cache\n\n" + finding_marker("a" * 64))],
+             body="Race in cache\n\n" + finding_marker("a" * 64),
+             viewer_did_author=True)],
 )
 
 _REST_REVIEWS: list[dict[str, Any]] = [
     {"id": 900, "node_id": "PRR_900", "body": "review summary, no marker"},
-    {"id": 901, "node_id": "PRR_901", "body": "File-level note\n\n" + finding_marker("b" * 64)},
+    {"id": 901, "node_id": "PRR_901", "body": "File-level note\n\n" + finding_marker("b" * 64),
+     "user": {"login": "daydream-bot"}},
 ]
 
 
@@ -83,5 +99,65 @@ def test_partition_new_matched_stale_and_respects_human_resolution() -> None:
 
 def test_fetch_prior_findings_parses_markers_across_pages(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(git_ops, "gh_api", _fake_gh_api_two_pages)  # canned GraphQL + REST pages
-    prior = fetch_prior_findings(tmp_path, "o/r", 7)
+    prior = fetch_prior_findings(tmp_path, "o/r", 7, bot_login="daydream-bot")
     assert prior["a" * 64].thread_id == "RT_1" and prior["b" * 64].thread_id is None
+
+
+def test_fetch_prior_findings_ignores_marker_from_non_bot_author(monkeypatch, tmp_path) -> None:
+    # A thread whose comment carries the marker but is authored by a human.
+    fp = "a" * 64
+    pages = [_page([
+        _thread("RT_1", comment_node_id="PRRC_1", database_id=101,
+                body=finding_marker(fp), author="evil-attacker"),  # no viewerDidAuthor
+    ])]
+    def _gh(repo, endpoint, **kw):
+        if endpoint == "graphql":
+            return pages.pop(0) if pages else _page([])
+        if endpoint.endswith("/pulls/7/reviews"):
+            return []
+        raise AssertionError(endpoint)
+    monkeypatch.setattr(git_ops, "gh_api", _gh)
+    prior = fetch_prior_findings(tmp_path, "o/r", 7, bot_login="daydream")
+    assert prior == {}   # forged marker ignored -> not trusted
+
+
+def test_fetch_prior_findings_ignores_review_marker_from_non_bot_user(monkeypatch, tmp_path) -> None:
+    fp = "b" * 64
+    def _gh(repo, endpoint, **kw):
+        if endpoint == "graphql":
+            return _page([])
+        if endpoint.endswith("/pulls/7/reviews"):
+            return [{"id": 9, "node_id": "PRR_9", "body": finding_marker(fp),
+                     "user": {"login": "evil-attacker"}}]
+        raise AssertionError(endpoint)
+    monkeypatch.setattr(git_ops, "gh_api", _gh)
+    prior = fetch_prior_findings(tmp_path, "o/r", 7, bot_login="daydream")
+    assert prior == {}
+
+
+def test_fetch_prior_findings_trusts_bot_login_match(monkeypatch, tmp_path) -> None:
+    fp = "c" * 64
+    def _gh(repo, endpoint, **kw):
+        if endpoint == "graphql":
+            return _page([_thread("RT_2", comment_node_id="PRRC_2", database_id=102,
+                                  body=finding_marker(fp), author="daydream[bot]")])
+        if endpoint.endswith("/pulls/7/reviews"):
+            return []
+        raise AssertionError(endpoint)
+    monkeypatch.setattr(git_ops, "gh_api", _gh)
+    prior = fetch_prior_findings(tmp_path, "o/r", 7, bot_login="daydream")
+    assert fp in prior and prior[fp].thread_id == "RT_2"
+
+
+def test_fetch_prior_findings_trusts_viewerDidAuthor_without_bot_login(monkeypatch, tmp_path) -> None:
+    fp = "d" * 64
+    def _gh(repo, endpoint, **kw):
+        if endpoint == "graphql":
+            return _page([_thread("RT_3", comment_node_id="PRRC_3", database_id=103,
+                                  body=finding_marker(fp), viewer_did_author=True)])
+        if endpoint.endswith("/pulls/7/reviews"):
+            return []
+        raise AssertionError(endpoint)
+    monkeypatch.setattr(git_ops, "gh_api", _gh)
+    prior = fetch_prior_findings(tmp_path, "o/r", 7, bot_login=None)  # misconfigured
+    assert fp in prior   # viewerDidAuthor still proves authorship

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -125,15 +125,30 @@ def test_split_setup_preserves_privilege_split() -> None:
     assert set(_SECRET_REF_RE.findall(post_text)) == {"DAYDREAM_APP_ID", "DAYDREAM_APP_PRIVATE_KEY"}
 
 
-def test_post_findings_step_exports_bot_login() -> None:
+@pytest.mark.parametrize(
+    "wf_path",
+    [TEMPLATES_DIR / "daydream-post.yml", REPO_WORKFLOWS_DIR / "daydream-post.yml"],
+    ids=["template", "live"],
+)
+def test_post_findings_step_exports_bot_login(wf_path: Path) -> None:
     """The Post findings step must export BOT_LOGIN from the deposited
     ``DAYDREAM_BOT_HANDLE`` variable and pass it to ``daydream post-findings``
     via ``--bot-login`` so the author filter has a bot login to match against
     (issue #254). Without it, the post job degrades to viewerDidAuthor-only
-    GraphQL dedup and suppresses nothing on the REST side."""
-    text = (TEMPLATES_DIR / "daydream-post.yml").read_text(encoding="utf-8")
-    assert "BOT_LOGIN: ${{ vars.DAYDREAM_BOT_HANDLE }}" in text
-    assert '--bot-login "$BOT_LOGIN"' in text
+    GraphQL dedup and suppresses nothing on the REST side.
+
+    Pinned on BOTH the shipped template and the repo's own live workflow —
+    the two files are intentionally divergent in other fields (install-pin,
+    surface-failure guard) but this invariant must hold for both.
+    """
+    text = wf_path.read_text(encoding="utf-8")
+    assert "BOT_LOGIN: ${{ vars.DAYDREAM_BOT_HANDLE }}" in text, (
+        f"{wf_path.name}: Post findings step must export BOT_LOGIN from "
+        f"vars.DAYDREAM_BOT_HANDLE (issue #254)"
+    )
+    assert '--bot-login "$BOT_LOGIN"' in text, (
+        f"{wf_path.name}: Post findings step must pass --bot-login explicitly"
+    )
 
 
 def test_single_setup_preserves_privilege_split() -> None:

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -125,6 +125,17 @@ def test_split_setup_preserves_privilege_split() -> None:
     assert set(_SECRET_REF_RE.findall(post_text)) == {"DAYDREAM_APP_ID", "DAYDREAM_APP_PRIVATE_KEY"}
 
 
+def test_post_findings_step_exports_bot_login() -> None:
+    """The Post findings step must export BOT_LOGIN from the deposited
+    ``DAYDREAM_BOT_HANDLE`` variable and pass it to ``daydream post-findings``
+    via ``--bot-login`` so the author filter has a bot login to match against
+    (issue #254). Without it, the post job degrades to viewerDidAuthor-only
+    GraphQL dedup and suppresses nothing on the REST side."""
+    text = (TEMPLATES_DIR / "daydream-post.yml").read_text(encoding="utf-8")
+    assert "BOT_LOGIN: ${{ vars.DAYDREAM_BOT_HANDLE }}" in text
+    assert '--bot-login "$BOT_LOGIN"' in text
+
+
 def test_single_setup_preserves_privilege_split() -> None:
     wf = load_workflow(TEMPLATES_DIR / "single" / "daydream.yml")
     text = (TEMPLATES_DIR / "single" / "daydream.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Fixes a trust-boundary defect in `fetch_prior_findings` (issue #254): the cross-run dedup inventory was built by harvesting `<!-- daydream-finding: <64-hex> -->` markers from **every** review-thread comment and review body with **no author check**. Because the marker format and the fingerprint algorithm are both public and deterministic, any PR commenter (including a fork contributor) could forge a marker that suppresses a real finding as "already on PR."

The fix restricts marker harvesting to the bot's own comments.

Closes #254.

## Trust rule

A prior finding is trusted **only** when GitHub proves the bot authored it:

- **GraphQL** (`reviewThreads.comments.nodes`): `viewerDidAuthor == true` (decided server-side from the installation token) **OR** `author.login` matches the threaded bot login via the `[bot]`-suffix-tolerant comparator.
- **REST** (`GET /pulls/{n}/reviews`): `user.login` matches the bot login (REST has no `viewerDidAuthor`).

When no bot login is resolvable (`--bot-login` unset and `DAYDREAM_BOT_HANDLE` absent), GraphQL is still protected by `viewerDidAuthor` and REST harvests nothing — a misconfigured bot **double-posts rather than ever suppressing**.

## Changes

| Commit | Substance |
|--------|-----------|
| `0086046` | Promote `bot_login_matches`/`bot_stem` out of `benchmark/harvest.py` into a zero-dependency leaf module (`daydream/bot_identity.py`) so `reconcile` can import them without pulling benchmark deps. Pure relocation. |
| `7208d2c` | **Core fix.** `_REVIEW_THREADS_QUERY` selects `author { login }` + `viewerDidAuthor`; `fetch_prior_findings` gains keyword-only `bot_login` and applies the trust rule at both GraphQL and REST harvest sites via the `_authored_by_bot` helper. |
| `356b564` | Thread `--bot-login` from the CLI through `post_findings_from_artifact` (resolves env fallback to `DAYDREAM_BOT_HANDLE` in one place; warns `BOT_LOGIN_UNRESOLVED` on degradation). |
| `36fdae2` | Export `BOT_LOGIN: ${{ vars.DAYDREAM_BOT_HANDLE }}` into the CI `Post findings` step env and pass it via `--bot-login "$BOT_LOGIN"`. |

## Out of scope (per plan)

- HMAC-signing the marker (would change the marker format and invalidate already-posted markers — worthwhile follow-up ADR, not this fix).
- Salting the fingerprint (cross-run dedup **requires** identical fingerprints; salting breaks matching).
- The interactive `_post` flow (does not call `fetch_prior_findings`; posts unconditionally — not the privileged Phase B poster).
- The `findings.py` artifact schema (bot login is a posting-identity property, not a Phase A artifact property).

## What was verified

- `make check` green: `uv lock --check` + `ruff` + `mypy` (`Success: no issues found in 296 source files`) + full pytest (**2711 passed, 5 skipped**, zero regressions vs. baseline of 2699 passed).
- Real-path tests through `cli.main` (`daydream post-findings ...`) with `gh` faked in-process prove:
  - A forged marker from a non-bot commenter (`evil-attacker`) does **not** suppress a finding — the review is still posted.
  - A bot-authored marker (`daydream[bot]` or `viewerDidAuthor=true`) still dedups (idempotent repost).
  - `DAYDREAM_BOT_HANDLE` env fallback works when `--bot-login` is omitted.
- Unit tests in `test_reconcile.py` pin the trust rule on both GraphQL and REST sources, including the `viewerDidAuthor`-without-bot-login path and the safe-degradation path.
- New `test_bot_identity.py` pins the single comparator definition.
- New `test_workflow_templates.py` assertion pins the `BOT_LOGIN` export in the template.

## Note on the live workflow

The plan assumed a drift test syncs `.github/workflows/daydream-post.yml` with the template. That assumption is **false** — the two files are already independently drifted in other fields, and no test pins their equality. Both files were edited identically; the new template test guards only the template side (consistent with the existing divergence posture).