### PR TITLE
fix(improve): make command-contract schema patterns lookaround-free

### DIFF
--- a/daydream/improve/command_contract.py
+++ b/daydream/improve/command_contract.py
@@ -12,14 +12,9 @@ from typing import Any
 
 from jsonschema import Draft202012Validator
 
-REPOSITORY_FILE_PATH_PATTERN = (
-    r"^(?!/)(?!.*(?:^|/)\.{1,2}(?:/|$))(?!.*\$\(|.*\$\{)"
-    r"[A-Za-z0-9._+@$-]+(?:/[A-Za-z0-9._+@$-]+)*$"
-)
-DIRECTORY_SCOPE_PATTERN = (
-    r"^(?!/)(?!.*(?:^|/)\.{1,2}(?:/|$))(?!.*\$\(|.*\$\{)"
-    r"[A-Za-z0-9._+@$-]+(?:/[A-Za-z0-9._+@$-]+)*/?$"
-)
+_PATH_SEGMENT = r"\.?[A-Za-z0-9_+@$-][A-Za-z0-9._+@$-]*"
+REPOSITORY_FILE_PATH_PATTERN = rf"^{_PATH_SEGMENT}(?:/{_PATH_SEGMENT})*$"
+DIRECTORY_SCOPE_PATTERN = rf"^{_PATH_SEGMENT}(?:/{_PATH_SEGMENT})*/?$"
 
 REPOSITORY_FILE_PATH_SCHEMA: dict[str, Any] = {
     "type": "string",

--- a/daydream/improve/command_contract.py
+++ b/daydream/improve/command_contract.py
@@ -12,7 +12,11 @@ from typing import Any
 
 from jsonschema import Draft202012Validator
 
-_PATH_SEGMENT = r"\.?[A-Za-z0-9_+@$-][A-Za-z0-9._+@$-]*"
+_PATH_SEGMENT = (
+    r"(?:[A-Za-z0-9_+@$-][A-Za-z0-9._+@$-]*|"
+    r"\.[A-Za-z0-9_+@$-][A-Za-z0-9._+@$-]*|"
+    r"\.\.[A-Za-z0-9._+@$-]+)"
+)
 REPOSITORY_FILE_PATH_PATTERN = rf"^{_PATH_SEGMENT}(?:/{_PATH_SEGMENT})*$"
 DIRECTORY_SCOPE_PATTERN = rf"^{_PATH_SEGMENT}(?:/{_PATH_SEGMENT})*/?$"
 

--- a/tests/test_command_contract.py
+++ b/tests/test_command_contract.py
@@ -1,0 +1,93 @@
+"""Lookaround-free command-contract schema patterns (issue #304).
+
+OpenAI rejects regex lookaround in JSON Schema ``pattern`` values with
+``invalid_json_schema``. The exported path patterns must contain none, while
+preserving the accept/reject grammar.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from daydream.improve.command_contract import (
+    DIRECTORY_SCOPE_SCHEMA,
+    REPOSITORY_FILE_PATH_SCHEMA,
+    WORKING_DIRECTORY_SCHEMA,
+)
+
+ALL_SCHEMA_PATTERNS = [
+    REPOSITORY_FILE_PATH_SCHEMA["pattern"],
+    DIRECTORY_SCOPE_SCHEMA["pattern"],
+    WORKING_DIRECTORY_SCHEMA["pattern"],
+]
+
+
+@pytest.mark.parametrize("pattern", ALL_SCHEMA_PATTERNS)
+def test_schema_patterns_are_lookaround_free(pattern: str) -> None:
+    """Regression pin: no lookaround may reach an exported schema pattern.
+
+    OpenAI rejects ``(?=``, ``(?!``, ``(?<=``, ``(?<!`` with
+    ``invalid_json_schema``. Plain ``(?:`` groups are valid and expected.
+    """
+    assert re.search(r"\(\?[=!<]", pattern) is None
+
+
+PATH_ACCEPTS = [
+    "src/main.rs",
+    "a/b/c",
+    ".github/workflows/ci.yml",
+    "foo.bar",
+    "foo..bar",
+]
+
+PATH_REJECTS = [
+    "a/b/./c",
+    "..",
+    "a/../b",
+    "/abs/path",
+    "a//b",
+    "$()",
+    "${x}",
+]
+
+
+@pytest.mark.parametrize("value", PATH_ACCEPTS)
+def test_file_path_schema_accepts(value: str) -> None:
+    assert Draft202012Validator(REPOSITORY_FILE_PATH_SCHEMA).is_valid(value)
+    assert re.compile(REPOSITORY_FILE_PATH_SCHEMA["pattern"]).match(value)
+
+
+@pytest.mark.parametrize("value", PATH_REJECTS)
+def test_file_path_schema_rejects(value: str) -> None:
+    assert not Draft202012Validator(REPOSITORY_FILE_PATH_SCHEMA).is_valid(value)
+    assert not re.compile(REPOSITORY_FILE_PATH_SCHEMA["pattern"]).match(value)
+
+
+@pytest.mark.parametrize("value", PATH_ACCEPTS)
+def test_directory_scope_schema_accepts(value: str) -> None:
+    assert Draft202012Validator(DIRECTORY_SCOPE_SCHEMA).is_valid(value)
+    assert re.compile(DIRECTORY_SCOPE_SCHEMA["pattern"]).match(value)
+
+
+@pytest.mark.parametrize("value", PATH_REJECTS)
+def test_directory_scope_schema_rejects(value: str) -> None:
+    assert not Draft202012Validator(DIRECTORY_SCOPE_SCHEMA).is_valid(value)
+    assert not re.compile(DIRECTORY_SCOPE_SCHEMA["pattern"]).match(value)
+
+
+def test_file_path_empty_and_length_bounds() -> None:
+    assert not Draft202012Validator(REPOSITORY_FILE_PATH_SCHEMA).is_valid("")
+    assert not Draft202012Validator(REPOSITORY_FILE_PATH_SCHEMA).is_valid(
+        "a" * 513
+    )
+
+
+def test_working_directory_accepts_cwd() -> None:
+    assert Draft202012Validator(WORKING_DIRECTORY_SCHEMA).is_valid(".")
+    regex = re.compile(WORKING_DIRECTORY_SCHEMA["pattern"])
+    assert regex.match(".")
+    assert regex.match("src/main.rs")
+    assert not regex.match("/abs/path")

--- a/tests/test_command_contract.py
+++ b/tests/test_command_contract.py
@@ -8,7 +8,9 @@ preserving the accept/reject grammar.
 from __future__ import annotations
 
 import re
+from collections.abc import Callable, Iterator
 from pathlib import Path
+from typing import Any
 
 import pytest
 from jsonschema import Draft202012Validator
@@ -21,6 +23,10 @@ from daydream.improve.command_contract import (
     valid_directory_scope_lexical,
     valid_repository_file_path,
 )
+from daydream.runner import RunConfig, run
+from tests.harness.improve_backend import install_improve_stub
+
+MakeConfig = Callable[..., RunConfig]
 
 ALL_SCHEMA_PATTERNS = [
     REPOSITORY_FILE_PATH_SCHEMA["pattern"],
@@ -114,3 +120,36 @@ def test_multi_dot_paths_are_accepted_by_schemas_and_validators(
     assert valid_directory_scope_lexical(value)
     assert path_is_confined(tmp_path, value)
     assert path_is_confined(tmp_path, value, directory_scope=True)
+
+
+def _iter_schema_patterns(schema: Any) -> Iterator[str]:
+    """Yield the string value of every ``pattern`` key in a schema tree."""
+    if isinstance(schema, dict):
+        for key, value in schema.items():
+            if key == "pattern" and isinstance(value, str):
+                yield value
+            else:
+                yield from _iter_schema_patterns(value)
+    elif isinstance(schema, list):
+        for item in schema:
+            yield from _iter_schema_patterns(item)
+
+
+@pytest.mark.anyio
+async def test_improve_recon_schema_sent_to_backend_is_lookaround_free(
+    improve_monorepo_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+) -> None:
+    stub = install_improve_stub(monkeypatch, improve_monorepo_target)
+    code = await run(make_config(improve_monorepo_target, flow_name="improve"))
+    assert code == 0
+    schemas = [
+        call["output_schema"]
+        for call in stub.calls
+        if call.get("output_schema")
+    ]
+    assert schemas, "expected at least one structured-output turn"
+    for schema in schemas:
+        for pattern in _iter_schema_patterns(schema):
+            assert re.search(r"\(\?[=!<]", pattern) is None

--- a/tests/test_command_contract.py
+++ b/tests/test_command_contract.py
@@ -8,6 +8,7 @@ preserving the accept/reject grammar.
 from __future__ import annotations
 
 import re
+from pathlib import Path
 
 import pytest
 from jsonschema import Draft202012Validator
@@ -16,6 +17,9 @@ from daydream.improve.command_contract import (
     DIRECTORY_SCOPE_SCHEMA,
     REPOSITORY_FILE_PATH_SCHEMA,
     WORKING_DIRECTORY_SCHEMA,
+    path_is_confined,
+    valid_directory_scope_lexical,
+    valid_repository_file_path,
 )
 
 ALL_SCHEMA_PATTERNS = [
@@ -41,6 +45,12 @@ PATH_ACCEPTS = [
     ".github/workflows/ci.yml",
     "foo.bar",
     "foo..bar",
+]
+
+MULTI_DOT_PATHS = [
+    "..cache",
+    "...",
+    "src/...generated",
 ]
 
 PATH_REJECTS = [
@@ -91,3 +101,16 @@ def test_working_directory_accepts_cwd() -> None:
     assert regex.match(".")
     assert regex.match("src/main.rs")
     assert not regex.match("/abs/path")
+
+
+@pytest.mark.parametrize("value", MULTI_DOT_PATHS)
+def test_multi_dot_paths_are_accepted_by_schemas_and_validators(
+    value: str, tmp_path: Path
+) -> None:
+    assert Draft202012Validator(REPOSITORY_FILE_PATH_SCHEMA).is_valid(value)
+    assert Draft202012Validator(DIRECTORY_SCOPE_SCHEMA).is_valid(value)
+    assert Draft202012Validator(WORKING_DIRECTORY_SCHEMA).is_valid(value)
+    assert valid_repository_file_path(value)
+    assert valid_directory_scope_lexical(value)
+    assert path_is_confined(tmp_path, value)
+    assert path_is_confined(tmp_path, value, directory_scope=True)


### PR DESCRIPTION
## Summary

Fixes #304 — the `daydream improve` flow with `--backend codex` dies with a
fatal `invalid_json_schema` from OpenAI because the command-contract schema
patterns in `daydream/improve/command_contract.py` use regex **lookaround**
(negative lookaheads `(?!/)`, `(?!...)`), which OpenAI's structured output
(`text.format.schema`) rejects.

## What changed

- `daydream/improve/command_contract.py`: replaced the lookahead-based
  `REPOSITORY_FILE_PATH_PATTERN` / `DIRECTORY_SCOPE_PATTERN` with a
  lookaround-free segment grammar (`_PATH_SEGMENT`) that:
  - contains **no lookaround** (JSON-Schema-safe for OpenAI structured output)
  - still rejects absolute paths, empty segments, and `$(`/`${` substitution
    (enforced by the character class, as before)
  - rejects `.` and `..` as complete path segments
  - accepts single- and multi-dot names (`.git`, `..cache`, `...`) — parity
    with the previous contract
- `tests/test_command_contract.py` (new): no-lookaround regression pin across
  all three exported schema patterns, accept/reject matrix via
  `Draft202012Validator` + `re.match`, working-directory `.` handling, and
  multi-dot coverage across schemas, lexical validators, and confinement
  checks.

## Verification

- `ruff check daydream tests` clean
- `mypy daydream tests` clean (305 files, includes tests/)
- Full suite: 2814 passed, 5 skipped
- Pre-PR daydream review (codex backend) completed; its 2 findings (multi-dot
  narrowing) were addressed in the follow-up commit with regression tests.

Closes #304
