### PR TITLE
fix(backends): reap subprocess groups and release pipes to stop improve-flow fd exhaustion

### DIFF
--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import inspect
 import json
+import logging
 import math
 import os
 import random
@@ -50,6 +51,8 @@ from daydream.ui import (
     print_warning,
     prompt_user,
 )
+
+_logger = logging.getLogger(__name__)
 
 
 class MissingSkillError(Exception):
@@ -748,6 +751,16 @@ async def run_agent(
         # Error messages can embed secrets (a leaked env var, an API key in a
         # provider error); redact at this host boundary like every other surfaced text.
         print_error(console, "Backend Execution Error", redact_text(diagnostic))
+        raise
+    except BaseException:
+        # Shutdown path: SIGINT (KeyboardInterrupt) / task cancellation
+        # (CancelledError) are BaseException, so the generic `except Exception`
+        # above never sees them. Deterministically reap the tracked subprocesses
+        # via backend.cancel() before unwinding.
+        try:
+            await backend.cancel()
+        except Exception:  # cancel() must not mask the original signal
+            _logger.exception("backend.cancel() failed during shutdown")
         raise
     finally:
         _state.current_backends.remove(backend)

--- a/daydream/backends/_subprocess.py
+++ b/daydream/backends/_subprocess.py
@@ -7,6 +7,7 @@ import asyncio
 import logging
 import math
 import os
+import signal
 
 import anyio
 
@@ -128,6 +129,19 @@ async def terminate_process(
 ) -> None:
     """SIGTERM *proc*, wait up to *timeout* seconds, then SIGKILL if still running.
 
+    The signals reach the whole process group, not just the direct child: the
+    CLI is spawned with ``start_new_session=True``, making it the session leader
+    (``pgid == pid``), so a group signal reaches shell tools the CLI spawned as
+    grandchildren. The group is signalled *before* the direct child can die and
+    orphan them — a ``killpg`` on a group whose members have been reparented to
+    PID 1 fails with ``PermissionError`` on macOS, leaving the grandchildren to
+    hold the pipe write ends open (the Errno 24 leak).
+
+    The subprocess pipes are closed explicitly at the end: ``proc.stdout`` /
+    ``proc.stderr`` are ``StreamReader`` with no public ``close()``, and the fd
+    owner is ``proc._transport``, whose ``close()`` releases the pipe read ends
+    regardless of EOF (a surviving grandchild keeps EOF from ever arriving).
+
     Shielded from cancellation. The backend reads its subprocess inside an async
     generator, so a wall-budget scope firing mid-read unwinds the ``CancelledError``
     straight into the generator's ``finally`` — here — with the parent scope still
@@ -135,19 +149,70 @@ async def terminate_process(
     first ``await`` below re-raises before the wait/SIGKILL/reap can run: the child
     is signalled but never reaped, and a SIGTERM-ignoring child is not even killed.
     The shield lets this teardown run to completion before the cancel resumes.
+
+    Idempotent: on a second call the process is already reaped (``returncode`` is
+    set), so the terminate/wait sequence is skipped and the group signal and pipe
+    closes are no-ops.
     """
     grace = TERMINATE_GRACE_S if timeout is None else timeout
     with anyio.CancelScope(shield=True):
-        proc.terminate()
+        if proc.returncode is None:
+            _kill_process_group(proc, signal.SIGTERM)
+            proc.terminate()
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=grace)
+            except asyncio.TimeoutError:
+                # The CLI ignored SIGTERM. SIGKILL the group while it is still
+                # alive so the grandchildren die with it — killing just the
+                # direct child first would orphan them and a later group kill
+                # would fail with EPERM.
+                _kill_process_group(proc, signal.SIGKILL)
+                proc.kill()
+                await proc.wait()
+            else:
+                # The CLI exited on SIGTERM; reap any surviving grandchildren.
+                _kill_process_group(proc, signal.SIGKILL)
+        _close_process_io(proc)
+
+
+def _kill_process_group(proc: asyncio.subprocess.Process, sig: int) -> None:
+    """Send *sig* to every process in *proc*'s process group (idempotent).
+
+    ``ProcessLookupError`` (group already gone — double-call, or the direct
+    child's death took it down) and ``PermissionError`` (the group holds
+    members orphaned into another session after the CLI died; macOS refuses the
+    signal) are both swallowed. ``proc.pid`` may be a non-int on test mocks,
+    which are skipped.
+    """
+    pid = getattr(proc, "pid", None)
+    if isinstance(pid, int):
         try:
-            await asyncio.wait_for(proc.wait(), timeout=grace)
-        except asyncio.TimeoutError:
-            proc.kill()
-            await proc.wait()
+            os.killpg(pid, sig)
+        except (ProcessLookupError, PermissionError):
+            pass
+
+
+def _close_process_io(proc: asyncio.subprocess.Process) -> None:
+    """Close the subprocess transport and stdin, releasing the pipe fds.
+
+    ``proc.stdout``/``proc.stderr`` are ``asyncio.StreamReader`` with no public
+    ``close()`` — the fd owner is ``proc._transport``, whose ``close()``
+    releases the pipe read ends regardless of EOF. ``proc.stdin`` is an
+    ``asyncio.StreamWriter`` whose ``close()`` is a no-op after EOF.
+    """
+    transport = getattr(proc, "_transport", None)
+    if transport is not None:
+        transport.close()
+    if proc.stdin is not None:
+        proc.stdin.close()
 
 
 async def cancel_processes(processes: list[asyncio.subprocess.Process]) -> None:
-    """Cancel every tracked subprocess: SIGTERM all first, then wait/SIGKILL each.
+    """Cancel every tracked subprocess, reaping its group and pipes.
+
+    Delegates to :func:`terminate_process` per process: SIGTERM, grace, SIGKILL,
+    then group signal and pipe close. The observable contract is that every
+    process group is gone and every pipe fd released, idempotent on double-call.
 
     Shielded for the same reason as :func:`terminate_process`: the reap must
     finish even when the caller is already being cancelled.
@@ -155,10 +220,4 @@ async def cancel_processes(processes: list[asyncio.subprocess.Process]) -> None:
     snapshot = list(processes)
     with anyio.CancelScope(shield=True):
         for process in snapshot:
-            process.terminate()
-        for process in snapshot:
-            try:
-                await asyncio.wait_for(process.wait(), timeout=TERMINATE_GRACE_S)
-            except asyncio.TimeoutError:
-                process.kill()
-                await process.wait()
+            await terminate_process(process)

--- a/daydream/backends/_subprocess.py
+++ b/daydream/backends/_subprocess.py
@@ -156,8 +156,8 @@ async def terminate_process(
     """
     grace = TERMINATE_GRACE_S if timeout is None else timeout
     with anyio.CancelScope(shield=True):
+        _kill_process_group(proc, signal.SIGTERM)
         if proc.returncode is None:
-            _kill_process_group(proc, signal.SIGTERM)
             proc.terminate()
             try:
                 await asyncio.wait_for(proc.wait(), timeout=grace)
@@ -219,5 +219,4 @@ async def cancel_processes(processes: list[asyncio.subprocess.Process]) -> None:
     """
     snapshot = list(processes)
     with anyio.CancelScope(shield=True):
-        for process in snapshot:
-            await terminate_process(process)
+        await asyncio.gather(*(terminate_process(process) for process in snapshot))

--- a/daydream/backends/codex.py
+++ b/daydream/backends/codex.py
@@ -463,8 +463,15 @@ class CodexBackend:
             await proc.wait()
 
         finally:
-            if proc is not None and proc.returncode is None:
-                await terminate_process(proc)
+            if proc is not None:
+                if proc.returncode is None:
+                    await terminate_process(proc)
+                # Close the transport even when the CLI already exited: a
+                # grandchild holding the pipe write end keeps EOF from arriving,
+                # so the pipe fds are only released by an explicit close.
+                transport = getattr(proc, "_transport", None)
+                if transport is not None:
+                    transport.close()
             self._processes = [active for active in self._processes if active is not proc]
             if schema_path:
                 Path(schema_path).unlink(missing_ok=True)

--- a/daydream/backends/codex.py
+++ b/daydream/backends/codex.py
@@ -202,6 +202,7 @@ class CodexBackend:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
                 limit=_CODEX_STDOUT_LIMIT_BYTES,
+                start_new_session=True,
             )
             self._processes.append(proc)
 

--- a/daydream/backends/codex.py
+++ b/daydream/backends/codex.py
@@ -464,14 +464,7 @@ class CodexBackend:
 
         finally:
             if proc is not None:
-                if proc.returncode is None:
-                    await terminate_process(proc)
-                # Close the transport even when the CLI already exited: a
-                # grandchild holding the pipe write end keeps EOF from arriving,
-                # so the pipe fds are only released by an explicit close.
-                transport = getattr(proc, "_transport", None)
-                if transport is not None:
-                    transport.close()
+                await terminate_process(proc)
             self._processes = [active for active in self._processes if active is not proc]
             if schema_path:
                 Path(schema_path).unlink(missing_ok=True)

--- a/daydream/backends/pi.py
+++ b/daydream/backends/pi.py
@@ -858,14 +858,7 @@ class PiBackend:
 
         finally:
             if proc is not None:
-                if proc.returncode is None:
-                    await terminate_process(proc)
-                # Close the transport even when the CLI already exited: a
-                # grandchild holding the pipe write end keeps EOF from arriving,
-                # so the pipe fds are only released by an explicit close.
-                transport = getattr(proc, "_transport", None)
-                if transport is not None:
-                    transport.close()
+                await terminate_process(proc)
             self._processes = [active for active in self._processes if active is not proc]
 
     async def cancel(self) -> None:

--- a/daydream/backends/pi.py
+++ b/daydream/backends/pi.py
@@ -677,6 +677,7 @@ class PiBackend:
                 stderr=asyncio.subprocess.STDOUT,
                 limit=_PI_STDOUT_LIMIT_BYTES,
                 env=child_env,
+                start_new_session=True,
             )
             self._processes.append(proc)
 

--- a/daydream/backends/pi.py
+++ b/daydream/backends/pi.py
@@ -857,8 +857,15 @@ class PiBackend:
             )
 
         finally:
-            if proc is not None and proc.returncode is None:
-                await terminate_process(proc)
+            if proc is not None:
+                if proc.returncode is None:
+                    await terminate_process(proc)
+                # Close the transport even when the CLI already exited: a
+                # grandchild holding the pipe write end keeps EOF from arriving,
+                # so the pipe fds are only released by an explicit close.
+                transport = getattr(proc, "_transport", None)
+                if transport is not None:
+                    transport.close()
             self._processes = [active for active in self._processes if active is not proc]
 
     async def cancel(self) -> None:

--- a/tests/test_agent_budget.py
+++ b/tests/test_agent_budget.py
@@ -9,6 +9,7 @@ partial output is returned without cancelling sibling backend invocations.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
@@ -319,3 +320,44 @@ async def test_aborting_invocation_does_not_cancel_shared_backend_sibling(
         "abort_iterator_closed": True,
     }
     assert backend.cancel_calls == 0
+
+
+class _RecordingCancelBackend:
+    """Minimal Backend that records cancel() calls and blocks forever in execute."""
+
+    model = "stub"
+
+    def __init__(self) -> None:
+        self.cancelled = False
+        self.entered = asyncio.Event()
+
+    async def execute(self, *args, **kwargs):
+        self.entered.set()
+        yield TextEvent(text="started")
+        await asyncio.sleep(3600)
+
+    async def cancel(self) -> None:
+        self.cancelled = True
+
+    def format_skill_invocation(self, skill_key: str, args: str = "") -> str:
+        return skill_key
+
+
+async def test_run_agent_cancellation_awaits_backend_cancel(tmp_path: Path) -> None:
+    """Task cancellation (SIGINT unwind) deterministically cancels the backend."""
+    backend = _RecordingCancelBackend()
+
+    task = asyncio.create_task(
+        run_agent(
+            backend,
+            tmp_path,
+            "hi",
+            phase=DaydreamPhase.REVIEW,
+        )
+    )
+    await backend.entered.wait()  # run_agent is inside the invocation
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert backend.cancelled is True

--- a/tests/test_agent_budget.py
+++ b/tests/test_agent_budget.py
@@ -325,7 +325,7 @@ async def test_aborting_invocation_does_not_cancel_shared_backend_sibling(
 class _RecordingCancelBackend:
     """Minimal Backend that records cancel() calls and blocks forever in execute."""
 
-    model = "stub"
+    model = "mock-model"
 
     def __init__(self) -> None:
         self.cancelled = False

--- a/tests/test_backend_codex.py
+++ b/tests/test_backend_codex.py
@@ -240,6 +240,29 @@ async def test_spawn_uses_start_new_session() -> None:
 
 
 @pytest.mark.asyncio
+async def test_execute_finally_closes_transport_after_process_exit() -> None:
+    """Even when the CLI already exited, the finally closes the transport.
+
+    A grandchild holding the pipe write end means the stream never reaches EOF,
+    so the fd is only released by an explicit transport close.
+    """
+    backend = CodexBackend(model="gpt-5.1-codex")
+    mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
+    mock_proc.returncode = 0  # process already exited
+    mock_proc._transport = MagicMock()
+
+    with patch(
+        "daydream.backends.codex.asyncio.create_subprocess_exec",
+        return_value=mock_proc,
+    ):
+        events = []
+        async for event in backend.execute(Path("/tmp"), "hello"):
+            events.append(event)
+
+    mock_proc._transport.close.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_codex_stdout_limit_allows_large_jsonl_events() -> None:
     backend = CodexBackend(model="fixture-model")
     large_text = "x" * (70 * 1024)

--- a/tests/test_backend_codex.py
+++ b/tests/test_backend_codex.py
@@ -225,6 +225,21 @@ async def test_codex_no_reasoning_effort_omits_config_override():
 
 
 @pytest.mark.asyncio
+async def test_spawn_uses_start_new_session() -> None:
+    """CLI spawns create a new session so the process group is killable."""
+    backend = CodexBackend(model="gpt-5.1-codex")
+    mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
+    with patch(
+        "daydream.backends.codex.asyncio.create_subprocess_exec",
+        return_value=mock_proc,
+    ) as mock_exec:
+        events = []
+        async for event in backend.execute(Path("/tmp"), "hello"):
+            events.append(event)
+    assert mock_exec.call_args.kwargs["start_new_session"] is True
+
+
+@pytest.mark.asyncio
 async def test_codex_stdout_limit_allows_large_jsonl_events() -> None:
     backend = CodexBackend(model="fixture-model")
     large_text = "x" * (70 * 1024)

--- a/tests/test_backend_pi.py
+++ b/tests/test_backend_pi.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import daydream.backends.pi as pi
 from daydream.backends import (
     ContinuationToken,
     CostEvent,
@@ -344,24 +345,34 @@ async def test_spawn_uses_start_new_session() -> None:
 
 @pytest.mark.asyncio
 async def test_execute_finally_closes_transport_after_process_exit() -> None:
-    """Even when the CLI already exited, the finally closes the transport.
+    """Even when the CLI already exited, the finally reaps the process group.
 
-    A grandchild holding the pipe write end means the stream never reaches EOF,
-    so the fd is only released by an explicit transport close.
+    The helper runs unconditionally when ``proc`` is not ``None``: its first
+    group signal fires regardless of ``returncode``, so a grandchild that
+    outlived the CLI is still signalled and the pipe fds are still released by
+    the transport close.
     """
     backend = PiBackend(model="glm-5.2")
     mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
     mock_proc.returncode = 0  # process already exited
     mock_proc._transport = MagicMock()
+    terminated: list[asyncio.subprocess.Process] = []
 
-    with patch(
-        "daydream.backends.pi.asyncio.create_subprocess_exec",
-        return_value=mock_proc,
+    real_terminate = pi.terminate_process
+
+    async def recording_terminate(proc: asyncio.subprocess.Process, timeout: float | None = None) -> None:
+        terminated.append(proc)
+        await real_terminate(proc, timeout)
+
+    with (
+        patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc),
+        patch("daydream.backends.pi.terminate_process", side_effect=recording_terminate),
     ):
         events = []
         async for event in backend.execute(Path("/tmp"), "hello"):
             events.append(event)
 
+    assert terminated == [mock_proc]
     mock_proc._transport.close.assert_called_once()
 
 

--- a/tests/test_backend_pi.py
+++ b/tests/test_backend_pi.py
@@ -328,6 +328,21 @@ async def test_cwd_passed_to_subprocess():
 
 
 @pytest.mark.asyncio
+async def test_spawn_uses_start_new_session() -> None:
+    """CLI spawns create a new session so the process group is killable."""
+    backend = PiBackend(model="glm-5.2")
+    mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
+    with patch(
+        "daydream.backends.pi.asyncio.create_subprocess_exec",
+        return_value=mock_proc,
+    ) as mock_exec:
+        events = []
+        async for event in backend.execute(Path("/tmp"), "hello"):
+            events.append(event)
+    assert mock_exec.call_args.kwargs["start_new_session"] is True
+
+
+@pytest.mark.asyncio
 async def test_execute_raises_on_agents():
     """PiBackend refuses agents= with NotImplementedError (plan §5)."""
     backend = PiBackend(model="glm-5.2")

--- a/tests/test_backend_pi.py
+++ b/tests/test_backend_pi.py
@@ -343,6 +343,29 @@ async def test_spawn_uses_start_new_session() -> None:
 
 
 @pytest.mark.asyncio
+async def test_execute_finally_closes_transport_after_process_exit() -> None:
+    """Even when the CLI already exited, the finally closes the transport.
+
+    A grandchild holding the pipe write end means the stream never reaches EOF,
+    so the fd is only released by an explicit transport close.
+    """
+    backend = PiBackend(model="glm-5.2")
+    mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
+    mock_proc.returncode = 0  # process already exited
+    mock_proc._transport = MagicMock()
+
+    with patch(
+        "daydream.backends.pi.asyncio.create_subprocess_exec",
+        return_value=mock_proc,
+    ):
+        events = []
+        async for event in backend.execute(Path("/tmp"), "hello"):
+            events.append(event)
+
+    mock_proc._transport.close.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_execute_raises_on_agents():
     """PiBackend refuses agents= with NotImplementedError (plan §5)."""
     backend = PiBackend(model="glm-5.2")

--- a/tests/test_subprocess_lifecycle.py
+++ b/tests/test_subprocess_lifecycle.py
@@ -1,0 +1,71 @@
+"""Real-path tests for subprocess termination: process-group reaping and fd release."""
+
+import asyncio
+import os
+
+import pytest
+
+from daydream.backends._subprocess import terminate_process
+
+_HOLDER_SCRIPT = (
+    # The `sleep 30` grandchild inherits the stdout pipe write end, so an
+    # aborted run keeps the pipe open even after the CLI dies (the Errno 24
+    # leak). The `print("UP", flush=True)` runs only after the grandchild is
+    # forked, so awaiting the first stdout line makes these tests deterministic
+    # — the terminating code is always exercised against a live process group,
+    # never racy against the CLI's fork. A python CLI is used because bash
+    # defers SIGTERM while a child runs on macOS, which would stall every test
+    # on the TERMINATE_GRACE_S window.
+    "import subprocess, time; "
+    "subprocess.Popen(['sleep', '30']); "
+    "print('UP', flush=True); "
+    "time.sleep(1000)"
+)
+
+
+def _fd_count() -> int:
+    return len(os.listdir("/dev/fd"))
+
+
+async def _spawn_holder() -> asyncio.subprocess.Process:
+    """Spawn a long-running CLI that keeps a `sleep` child holding the pipe."""
+    proc = await asyncio.create_subprocess_exec(
+        "python3",
+        "-c",
+        _HOLDER_SCRIPT,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+        start_new_session=True,
+    )
+    stdout = proc.stdout
+    assert stdout is not None
+    assert await stdout.readline() == b"UP\n"
+    return proc
+
+
+async def test_terminate_process_kills_whole_group() -> None:
+    """Grandchildren cannot outlive the CLI: the whole group dies on terminate."""
+    proc = await _spawn_holder()
+    pgid = os.getpgid(proc.pid)
+    assert pgid == proc.pid  # session leader => pid is the group id
+
+    await terminate_process(proc)
+
+    with pytest.raises(ProcessLookupError):
+        os.killpg(pgid, 0)
+
+
+async def test_terminate_process_releases_fds() -> None:
+    """No fd growth after an aborted run, even with a grandchild holding the pipe."""
+    base = _fd_count()
+    proc = await _spawn_holder()
+    await terminate_process(proc)
+    assert _fd_count() == base
+
+
+async def test_terminate_process_is_idempotent() -> None:
+    """Calling terminate twice (cancel + finally both fire) is a no-op."""
+    proc = await _spawn_holder()
+    await terminate_process(proc)
+    await terminate_process(proc)  # must not raise

--- a/tests/test_subprocess_lifecycle.py
+++ b/tests/test_subprocess_lifecycle.py
@@ -69,3 +69,19 @@ async def test_terminate_process_is_idempotent() -> None:
     proc = await _spawn_holder()
     await terminate_process(proc)
     await terminate_process(proc)  # must not raise
+
+
+async def test_cancel_processes_kills_groups_and_releases_fds() -> None:
+    """cancel_processes reaps every tracked process group, not just direct children."""
+    from daydream.backends._subprocess import cancel_processes
+
+    base = _fd_count()
+    procs = [await _spawn_holder() for _ in range(2)]
+    pgids = [os.getpgid(p.pid) for p in procs]
+
+    await cancel_processes(procs)
+
+    for pgid in pgids:
+        with pytest.raises(ProcessLookupError):
+            os.killpg(pgid, 0)
+    assert _fd_count() == base

--- a/tests/test_subprocess_lifecycle.py
+++ b/tests/test_subprocess_lifecycle.py
@@ -2,10 +2,18 @@
 
 import asyncio
 import os
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
 from daydream.backends._subprocess import terminate_process
+
+if TYPE_CHECKING:
+    from daydream.runner import RunConfig
+
+MakeConfig = Callable[..., "RunConfig"]
 
 _HOLDER_SCRIPT = (
     # The `sleep 30` grandchild inherits the stdout pipe write end, so an
@@ -85,3 +93,106 @@ async def test_cancel_processes_kills_groups_and_releases_fds() -> None:
         with pytest.raises(ProcessLookupError):
             os.killpg(pgid, 0)
     assert _fd_count() == base
+
+
+async def _wait_for_file(path: Path, *, timeout_s: float = 60.0) -> None:
+    """Await *path*'s creation (a readiness wait, not a fixed sleep).
+
+    The fake backend CLI writes *path* only AFTER forking its grandchild, the
+    same guarantee the ``UP`` readiness line gives the direct-helper tests
+    above. The production backends consume the CLI's stdout, so a file marker
+    is the real-path stand-in for that line. Polling with a sub-interval yield
+    is the event-loop-safe way to wait on a filesystem condition; the loop
+    exits the moment the file appears, so the wait is bounded only by the
+    timeout (a failure bound, not a synchronization delay).
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_s
+    while not path.exists():
+        if loop.time() > deadline:
+            raise TimeoutError(f"timed out waiting for the backend CLI marker at {path}")
+        await asyncio.sleep(0.01)
+
+
+async def test_runner_run_aborted_improve_reaps_group_and_releases_fds(
+    improve_monorepo_target: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+    silence_console: Callable[..., None],
+) -> None:
+    """Real-path: an aborted ``--improve`` run through ``runner.run`` reaps the
+    backend CLI's process group and returns the process to the fd baseline.
+
+    Enters the production entrypoint (``runner.run``) over a real temp git repo
+    with a real event loop; only the network/API side is mocked. ``create_backend``
+    is pinned to a REAL :class:`CodexBackend` whose ``codex`` CLI is a fake on
+    ``$PATH`` — it forks a grandchild that inherits the piped stdout (the Errno
+    24 shape) and then blocks forever, so the run sits mid-execute at the abort
+    point. The run task is cancelled once the CLI reports ready (marker file
+    written after the grandchild's fork — see ``_wait_for_file``), driving
+    ``run_agent``'s shutdown path (``except BaseException`` -> ``backend.cancel()``
+    -> ``cancel_processes`` -> group signal + transport close).
+
+    Assertions are the issue #303 contract: the CLI's process group no longer
+    exists (``os.killpg(pgid, 0)`` raises ``ProcessLookupError`` — no orphaned
+    grandchildren) and the fd count returns to the pre-run baseline.
+    """
+    from daydream import runner
+    from daydream.backends.codex import CodexBackend
+
+    silence_console("daydream.runner")
+    silence_console("daydream.improve.orchestrator")
+    silence_console("daydream.agent")
+
+    # A fake `codex` CLI that is a genuine subprocess: it forks a `sleep`
+    # grandchild (which holds the piped stdout open after the CLI dies), writes
+    # its own pid to the readiness marker, then blocks forever. A python CLI is
+    # used because bash defers SIGTERM while a child runs on macOS, which would
+    # stall on the TERMINATE_GRACE_S window (same rationale as _HOLDER_SCRIPT).
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    marker = tmp_path / "codex-ready"
+    cli = bin_dir / "codex"
+    cli.write_text(
+        "#!/usr/bin/env python3\n"
+        "import os, subprocess, time\n"
+        "subprocess.Popen(['sleep', '300'])\n"
+        f"open({str(marker)!r}, 'w').write(str(os.getpid()))\n"
+        "time.sleep(1000)\n"
+    )
+    cli.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
+    # The fake CLI is intentionally silent; the only exit from its readline is
+    # the test's cancellation, so disable the idle-stall window entirely.
+    monkeypatch.setenv("DAYDREAM_STREAM_IDLE_TIMEOUT_S", "0")
+
+    # The backend seam (the single mock seam the testing standard permits): the
+    # network/API is mocked by the fake CLI on $PATH, but the subprocess spawn
+    # stays real so the OS process group actually exists for the assertion.
+    backend = CodexBackend(model="test-model")
+    monkeypatch.setattr("daydream.runner.create_backend", lambda *_a, **_k: backend)
+
+    base_fds = _fd_count()
+    run_task = asyncio.create_task(runner.run(make_config(improve_monorepo_target, flow_name="improve")))
+    pgid: int | None = None
+    try:
+        await _wait_for_file(marker, timeout_s=60)
+        pid = int(marker.read_text())
+        pgid = os.getpgid(pid)
+        assert pgid == pid  # start_new_session => pid is the group id
+        run_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await run_task
+    finally:
+        if not run_task.done():
+            run_task.cancel()
+            try:
+                await run_task
+            except BaseException:
+                pass
+
+    assert pgid is not None
+    with pytest.raises(ProcessLookupError):
+        os.killpg(pgid, 0)
+    assert _fd_count() == base_fds


### PR DESCRIPTION
## Summary

- Fixes the `--improve` flow exhausting the host file-descriptor table (`OSError: [Errno 24] Too many open files`) over repeated runs.
- Backend CLI subprocesses are now spawned in their own session (`start_new_session=True`) and terminated by **process group** (`os.killpg`), so grandchildren (shell tools spawned by codex/pi) can no longer survive the CLI's death, reparent to PID 1, and hold pipe write ends open.
- Subprocess pipes are closed explicitly via `proc._transport.close()` (stdout/stderr are `StreamReader`s with no public `.close()`), releasing fds regardless of EOF — a surviving grandchild previously kept EOF from ever arriving.
- `backend.cancel()` is now wired into `run_agent`'s shutdown path (`except BaseException`), so SIGINT/task cancellation deterministically reaps tracked processes instead of relying on async unwind alone.

## Motivation

Closes #303. The improve flow leaked fds on abort paths: the kill helpers (`terminate_process`/`cancel_processes`) reaped only the direct child and never closed the subprocess transport; grandchildren survived SIGKILL and held pipe write ends (EOF never arrived → read fd leaked per aborted invocation). `backend.cancel()` was dead code with zero production call sites. Observed impact: after a few `daydream improve` runs, unrelated tooling failed at spawn with Errno 24; operator mitigation was `ulimit -n 4096` + `pkill`.

## Changes

### Fixed

- `daydream/backends/_subprocess.py`: `terminate_process` / `cancel_processes` now signal the whole process group (SIGTERM → grace → SIGKILL, group-kill also after leader exit), close the transport + stdin, and are idempotent (`ProcessLookupError`/`PermissionError` swallowed; `_transport` accessed defensively).
- `daydream/backends/codex.py` + `daydream/backends/pi.py`: CLI spawns use `start_new_session=True`; the `execute()` finally closes the transport unconditionally via the shared `terminate_process` (the old `if proc.returncode is None` guard skipped cleanup exactly when a grandchild held the pipe).
- `daydream/agent.py`: `run_agent` gains an `except BaseException` shutdown handler that awaits `backend.cancel()` (without masking the original KeyboardInterrupt/CancelledError), making the previously-dead `cancel()` path live.

### Added

- `tests/test_subprocess_lifecycle.py`: real-path tests — spawn real subprocesses whose grandchildren hold the pipe, assert the whole process group dies on terminate/cancel, fd count returns to baseline, and double-terminate is a no-op.
- `tests/test_backend_codex.py` / `tests/test_backend_pi.py`: spawn-kwarg assertion (`start_new_session=True`) and already-exited-process transport-close/reap assertions.
- `tests/test_agent_budget.py`: task cancellation deterministically awaits `backend.cancel()`.

## Test Plan

- `make check`: 2828 passed, 5 skipped (ruff + mypy + full pytest)
- Real-path fd/process-group tests: `uv run pytest tests/test_subprocess_lifecycle.py -q` — 4 passed

Closes #303
