### PR TITLE
fix(eval): extract read paths from shell/read/bash tool calls in coverage and grounding analysis

### DIFF
--- a/daydream/eval/analyzer.py
+++ b/daydream/eval/analyzer.py
@@ -13,6 +13,7 @@ Usage::
 
 import json
 import re
+import shlex
 from collections import Counter
 from datetime import datetime
 from pathlib import Path
@@ -165,6 +166,117 @@ def _files_from_diff(diff_path: Path) -> list[str]:
 
 _READ_VERBS = ("sed", "nl", "cat", "rg")
 _SED_RANGE_RE = re.compile(r"^\d+(?:,\d*)?\$?p$")
+_REDIRECT_RE = re.compile(r"^(\d*)([<>]+|&>)(.*)$")
+_SEGMENT_SEPARATORS = frozenset(("&&", ";", "&"))
+_RG_LONG_VALUE_OPTS = frozenset(
+    {
+        "context",
+        "context-before",
+        "context-after",
+        "glob",
+        "ignore-file",
+        "engine",
+        "regexp",
+        "file",
+        "type",
+        "type-not",
+        "type-add",
+        "max-columns",
+        "max-count",
+        "max-filesize",
+        "threads",
+        "pre",
+        "pre-glob",
+        "replace",
+        "sort",
+        "sortr",
+    }
+)
+_RG_SHORT_VALUE_OPTS = frozenset("ABCefgMmtTr")
+
+
+def _tokenize_command(command: str) -> list[str]:
+    """Split a shell command into tokens, honoring quotes and separators.
+
+    ``shlex`` preserves quoted operands as single tokens (``'my file.py'``
+    stays intact) while punctuation mode keeps ``&&``/``;``/``&`` as distinct
+    separator tokens even without surrounding whitespace.
+    """
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=";&")
+    lexer.whitespace_split = True
+    lexer.commenters = ""
+    return list(lexer)
+
+
+def _rg_option_info(tok: str) -> tuple[int, bool]:
+    """How many tokens an ``rg`` option occupies, and whether it supplies the pattern.
+
+    ``-C 3`` → (2, False); ``--glob=*.py`` → (1, False) (value attached);
+    ``-n`` → (1, False); ``-e PAT``/``--regexp=PAT`` → (…, True) because an
+    explicit pattern leaves the next positional operand as a path, not a
+    pattern. Combined short flags (``-ni``) skip only their own token; a
+    value-taking short flag with an attached value (``-C3``) also consumes one.
+    """
+    if tok.startswith("--"):
+        if "=" in tok:
+            name = tok[2:].split("=", 1)[0]
+            return 1, name in ("regexp", "file")
+        name = tok[2:]
+        if name in _RG_LONG_VALUE_OPTS:
+            return 2, name in ("regexp", "file")
+        return 1, False
+    body = tok[1:]
+    if body and body[0] in _RG_SHORT_VALUE_OPTS:
+        value_attached = len(body) > 1
+        return (1 if value_attached else 2), body[0] in ("e", "f")
+    return 1, False
+
+
+def _read_paths_for_segment(verb: str, operands: list[str]) -> set[str]:
+    """File-path operands of one command segment for a given read verb.
+
+    Redirection operators are consumed together with their targets (separated
+    ``> target`` or attached ``2>/dev/null``) so a redirect target is never
+    recorded as a read. Sed address ranges and flags are filtered, and ``rg``
+    skips option values plus the search pattern. ``cat`` operands pass through
+    verbatim.
+    """
+    paths: set[str] = set()
+    i = 0
+    n = len(operands)
+    seen_pattern = False
+    after_ddash = False
+    while i < n:
+        tok = operands[i]
+        m = _REDIRECT_RE.match(tok)
+        if m:
+            i += 1 if m.group(3) else 2
+            continue
+        if verb == "rg":
+            if tok == "--":
+                after_ddash = True
+                i += 1
+                continue
+            if not after_ddash and tok.startswith("-") and tok != "-":
+                skip, supplies_pattern = _rg_option_info(tok)
+                i += skip
+                if supplies_pattern:
+                    seen_pattern = True
+                continue
+            if not seen_pattern:
+                seen_pattern = True
+                i += 1
+                continue
+        elif verb in ("sed", "nl", "cat"):
+            if tok.startswith("-"):
+                i += 1
+                continue
+            if verb == "sed" and _SED_RANGE_RE.fullmatch(tok):
+                i += 1
+                continue
+        paths.add(tok)
+        i += 1
+    return paths
 
 
 def _paths_from_command(command: str) -> set[str]:
@@ -172,35 +284,36 @@ def _paths_from_command(command: str) -> set[str]:
 
     Reviewers read files through these verbs: ``sed -n '1,240p'``, ``nl -ba``,
     ``cat``, and ``rg``. Commands may chain segments with ``&&``/``;`` and
-    redirect with ``2>/dev/null``. Extraction is deliberately permissive —
-    ``_path_matches`` matches by ``endswith``, so a stray operand simply never
-    matches a diff file — but flags, redirect targets, sed address ranges, and
-    the ``rg`` search pattern are filtered out.
+    redirect with ``2>/dev/null``. Tokenization is shell-aware: quoted paths
+    survive, redirection targets are consumed with their operator, and ``rg``
+    option values and the search pattern are filtered. Extraction is
+    deliberately permissive — ``_path_matches`` matches by ``endswith``, so a
+    stray operand simply never matches a diff file — but flags, redirect
+    targets, sed address ranges, and the ``rg`` search pattern are filtered.
     """
     paths: set[str] = set()
-    for segment in re.split(r"\s*(?:&&|;)\s*", command):
-        tokens = segment.split()
-        if not tokens:
+    tokens = _tokenize_command(command)
+    i = 0
+    n = len(tokens)
+    while i < n:
+        tok = tokens[i]
+        if tok in _SEGMENT_SEPARATORS:
+            i += 1
             continue
-        verb = tokens[0].split("/")[-1]
+        m = _REDIRECT_RE.match(tok)
+        if m:
+            i += 1 if m.group(3) else 2
+            continue
+        verb = tok.split("/")[-1]
         if verb not in _READ_VERBS:
+            i += 1
             continue
-        operands = [
-            tok.strip("\"'")
-            for tok in tokens[1:]
-            if not tok.startswith("-") and ">" not in tok
-        ]
-        if verb == "rg":
-            # The first non-numeric operand is the search pattern (flags like
-            # ``-C 3`` take numeric args); everything after it is a path.
-            pattern_idx = next(
-                (i for i, o in enumerate(operands) if not o.isdigit()), None
-            )
-            operands = operands[pattern_idx + 1:] if pattern_idx is not None else []
-        for operand in operands:
-            if not operand or _SED_RANGE_RE.fullmatch(operand):
-                continue
-            paths.add(operand)
+        i += 1
+        operands: list[str] = []
+        while i < n and tokens[i] not in _SEGMENT_SEPARATORS:
+            operands.append(tokens[i])
+            i += 1
+        paths.update(_read_paths_for_segment(verb, operands))
     return paths
 
 

--- a/daydream/eval/analyzer.py
+++ b/daydream/eval/analyzer.py
@@ -163,17 +163,74 @@ def _files_from_diff(diff_path: Path) -> list[str]:
     return sorted(files)
 
 
+_READ_VERBS = ("sed", "nl", "cat", "rg")
+_SED_RANGE_RE = re.compile(r"^\d+(?:,\d*)?\$?p$")
+
+
+def _paths_from_command(command: str) -> set[str]:
+    """Extract file-path operands from a codex ``shell`` / pi ``bash`` command.
+
+    Reviewers read files through these verbs: ``sed -n '1,240p'``, ``nl -ba``,
+    ``cat``, and ``rg``. Commands may chain segments with ``&&``/``;`` and
+    redirect with ``2>/dev/null``. Extraction is deliberately permissive —
+    ``_path_matches`` matches by ``endswith``, so a stray operand simply never
+    matches a diff file — but flags, redirect targets, sed address ranges, and
+    the ``rg`` search pattern are filtered out.
+    """
+    paths: set[str] = set()
+    for segment in re.split(r"\s*(?:&&|;)\s*", command):
+        tokens = segment.split()
+        if not tokens:
+            continue
+        verb = tokens[0].split("/")[-1]
+        if verb not in _READ_VERBS:
+            continue
+        operands = [
+            tok.strip("\"'")
+            for tok in tokens[1:]
+            if not tok.startswith("-") and ">" not in tok
+        ]
+        if verb == "rg":
+            # The first non-numeric operand is the search pattern (flags like
+            # ``-C 3`` take numeric args); everything after it is a path.
+            pattern_idx = next(
+                (i for i, o in enumerate(operands) if not o.isdigit()), None
+            )
+            operands = operands[pattern_idx + 1:] if pattern_idx is not None else []
+        for operand in operands:
+            if not operand or _SED_RANGE_RE.fullmatch(operand):
+                continue
+            paths.add(operand)
+    return paths
+
+
+def _read_paths_for_call(tc: dict) -> list[str]:
+    """All file paths a single tool call reads, across backends.
+
+    - claude: ``Read`` → ``arguments.file_path``; ``Grep`` → ``arguments.path``
+    - pi:     lowercase ``read`` → ``arguments.path``
+    - codex/pi: ``shell``/``bash`` → paths embedded in ``arguments.command``
+    """
+    fn = tc["function_name"]
+    args = tc["arguments"]
+    if fn == "Read":
+        p = args.get("file_path", "")
+        return [p] if p else []
+    if fn == "Grep":
+        p = args.get("path", "")
+        return [p] if p else []
+    if fn == "read":
+        p = args.get("path", "")
+        return [p] if p else []
+    if fn in ("shell", "bash"):
+        return sorted(_paths_from_command(args.get("command", "")))
+    return []
+
+
 def _files_read(tool_calls: list[dict]) -> set[str]:
     paths: set[str] = set()
     for tc in tool_calls:
-        if tc["function_name"] == "Read":
-            p = tc["arguments"].get("file_path", "")
-            if p:
-                paths.add(p)
-        elif tc["function_name"] == "Grep":
-            p = tc["arguments"].get("path", "")
-            if p:
-                paths.add(p)
+        paths.update(_read_paths_for_call(tc))
     return paths
 
 
@@ -313,10 +370,7 @@ def analyze_coverage(trajectories: dict, daydream_dir: Path) -> dict:
     if trajectories["main"]:
         for tc in _extract_tool_calls(trajectories["main"]):
             if tc["phase"] in ("deep", "alternatives"):
-                if tc["function_name"] in ("Read", "Grep"):
-                    p = tc["arguments"].get("file_path") or tc["arguments"].get("path", "")
-                    if p:
-                        review_reads.add(p)
+                review_reads.update(_read_paths_for_call(tc))
 
     covered = {df for df in diff_files if any(_path_matches(r, df) for r in review_reads)}
     uncovered = sorted(set(diff_files) - covered)

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -254,6 +254,41 @@ def test_files_read_extracts_pi_read_and_bash_paths():
     assert "core/osprey-cli" in paths
 
 
+def _shell_reads(command: str) -> set[str]:
+    """Extract read paths from a single codex ``shell`` call."""
+    return _files_read([{"function_name": "shell", "arguments": {"command": command}}])
+
+
+def test_files_read_skips_separated_redirect_target():
+    paths = _shell_reads("cat source.txt > target.py")
+
+    assert "source.txt" in paths
+    assert "target.py" not in paths
+
+
+def test_files_read_skips_redirect_and_pattern_for_rg():
+    paths = _shell_reads("rg -n 'pat' a.py b.py 2>/dev/null")
+
+    assert "a.py" in paths
+    assert "b.py" in paths
+    assert "/dev/null" not in paths
+    assert "pat" not in paths
+
+
+def test_files_read_preserves_quoted_paths_with_spaces():
+    assert "my file.py" in _shell_reads("cat 'my file.py'")
+    assert "my file.py" in _shell_reads('cat "my file.py"')
+
+
+def test_files_read_skips_rg_option_values():
+    paths = _shell_reads("rg -C 3 --glob '*.py' 'needle' src/app.py")
+
+    assert paths == {"src/app.py"}
+    assert "3" not in paths
+    assert "*.py" not in paths
+    assert "needle" not in paths
+
+
 def test_files_read_claude_read_and_grep_unchanged():
     calls = [
         {"function_name": "Read", "arguments": {"file_path": "/repo/api.py"}},

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -15,7 +15,13 @@ from pathlib import Path
 import pytest
 
 from daydream.backends import MetricsEvent, ResultEvent, TextEvent
-from daydream.eval.analyzer import analyze_costs, analyze_grounding, load_trajectories
+from daydream.eval.analyzer import (
+    _files_read,
+    analyze_costs,
+    analyze_coverage,
+    analyze_grounding,
+    load_trajectories,
+)
 from daydream.trajectory import DaydreamPhase, DaydreamRunFlow, TrajectoryRecorder
 
 
@@ -203,3 +209,137 @@ def test_grounding_rate_is_undefined_with_zero_findings():
     assert result["grounded_count"] == 0
     assert result["ungrounded_count"] == 0
     assert result["grounding_rate"] is None
+
+
+# --- cross-backend read extraction (issue #307) ---
+
+
+CODEX_READ_COMMAND = (
+    "sed -n '1,240p' .daydream/exploration/summary.md && "
+    "sed -n '1,280p' .daydream/diff.patch; "
+    "rg -n -C 3 'cache_write_tokens|total_cache_write_tokens' "
+    "core/osprey-cli docs README.md 2>/dev/null && "
+    "cat some/file.rb; nl -ba pkg/services/cleanup.go"
+)
+
+
+def test_files_read_extracts_codex_shell_paths():
+    calls = [{"function_name": "shell", "arguments": {"command": CODEX_READ_COMMAND}}]
+
+    paths = _files_read(calls)
+
+    assert ".daydream/exploration/summary.md" in paths
+    assert ".daydream/diff.patch" in paths
+    assert "core/osprey-cli" in paths
+    assert "docs" in paths
+    assert "README.md" in paths
+    assert "some/file.rb" in paths
+    assert "pkg/services/cleanup.go" in paths
+    assert "1,240p" not in paths
+    assert "1,280p" not in paths
+    assert "cache_write_tokens|total_cache_write_tokens" not in paths
+    assert "2>/dev/null" not in paths
+
+
+def test_files_read_extracts_pi_read_and_bash_paths():
+    calls = [
+        {"function_name": "read", "arguments": {"path": "/repo/pkg/services/cleanup.go"}},
+        {"function_name": "bash", "arguments": {"command": "cat README.md && nl -ba core/osprey-cli"}},
+    ]
+
+    paths = _files_read(calls)
+
+    assert "/repo/pkg/services/cleanup.go" in paths
+    assert "README.md" in paths
+    assert "core/osprey-cli" in paths
+
+
+def test_files_read_claude_read_and_grep_unchanged():
+    calls = [
+        {"function_name": "Read", "arguments": {"file_path": "/repo/api.py"}},
+        {"function_name": "Grep", "arguments": {"path": "src/"}},
+    ]
+
+    paths = _files_read(calls)
+
+    assert paths == {"/repo/api.py", "src/"}
+
+
+def test_analyze_coverage_counts_codex_and_pi_reads(tmp_path: Path):
+    daydream_dir = tmp_path / ".daydream"
+    daydream_dir.mkdir()
+    (daydream_dir / "diff.patch").write_text(
+        "diff --git a/pkg/services/cleanup.go b/pkg/services/cleanup.go\n"
+        "diff --git a/core/osprey-cli b/core/osprey-cli\n"
+    )
+    trajectories = {
+        "main": {
+            "_source_file": "trajectory.json",
+            "steps": [
+                {
+                    "step_id": "m0",
+                    "extra": {"daydream_phase": "deep"},
+                    "tool_calls": [
+                        {"function_name": "shell", "arguments": {"command": "sed -n '1,240p' .daydream/diff.patch"}}
+                    ],
+                }
+            ],
+        },
+        "forked": [
+            {
+                "_source_file": "deep-python.json",
+                "steps": [
+                    {
+                        "step_id": "s0",
+                        "tool_calls": [
+                            {"function_name": "read", "arguments": {"path": "/repo/pkg/services/cleanup.go"}},
+                            {"function_name": "bash", "arguments": {"command": "cat core/osprey-cli"}},
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+
+    result = analyze_coverage(trajectories, daydream_dir)
+
+    assert result["coverage_ratio"] == 1.0
+    assert result["files_read_by_reviewers"] == 2
+    assert result["uncovered_files"] == []
+
+
+def test_analyze_grounding_counts_codex_and_pi_reads():
+    trajectories = {
+        "main": None,
+        "forked": [
+            {
+                "_source_file": "deep-python.json",
+                "steps": [
+                    {
+                        "step_id": "s0",
+                        "tool_calls": [
+                            {"function_name": "shell", "arguments": {"command": "cat /repo/api.py"}},
+                            {"function_name": "read", "arguments": {"path": "/repo/api.py"}},
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    findings = [
+        {
+            "id": "py-1",
+            "_stack": "python",
+            "file": "api.py",
+            "rationale": "Read api.py; flag the missing validation.",
+            "confidence": "HIGH",
+        }
+    ]
+
+    result = analyze_grounding(trajectories, findings)
+
+    entry = result["grounded"][0]
+    assert entry["file_was_read"] is True
+    assert result["grounded_count"] == 1
+    assert result["ungrounded_count"] == 0
+    assert result["grounding_rate"] == 1.0


### PR DESCRIPTION
Closes #307

## What

Coverage and grounding analysis (`daydream/eval/analyzer.py`) was blind to Codex and Pi
read tool calls: `_files_read` only counted claude's capitalized `Read`/`Grep` calls, so
every codex/pi deep run reported `coverage_ratio: 0.0` and `grounding_rate: 0.0` with
`file_was_read: False` on all findings — even when the reviewer demonstrably read the
files. Since `--backend codex` is the standing default, essentially all current runs had
blind metrics, and `grounding_rate` silently corrupts the RL/SFT reward
(`daydream/training/reward.py`, `w_grounding = 0.4`).

## Changes

- `daydream/eval/analyzer.py`
  - `_read_paths_for_call(tc)` — single call-level path extractor shared by
    `_files_read` and `analyze_coverage`'s main-trajectory branch (no duplicated regexes):
    - claude `Read` → `arguments.file_path`, `Grep` → `arguments.path` (unchanged)
    - pi lowercase `read` → `arguments.path`
    - codex `shell` + pi `bash` → paths embedded in `arguments.command`
  - `_paths_from_command` — extracts file-path operands for `sed -n '<a>,<b>p'`,
    `nl -ba`, `cat`, `rg` across `&&`/`;`-chained segments; filters flags, redirect
    targets, sed address ranges, and the `rg` search pattern.
  - `analyze_grounding` untouched — it picks up the new extraction automatically via
    `_files_read`.

## Tests

6 new tests in `tests/test_analyzer.py`:
- codex `shell` extraction (chained `sed`/`rg`/`cat`/`nl -ba` with redirects + quoted
  pattern — asserts the pattern and ranges are not falsely emitted as paths)
- pi `read`/`bash` extraction
- claude `Read`/`Grep` regression guard (behavior unchanged)
- real-path `analyze_coverage`: fixture trajectory with codex `shell` + pi `read`/`bash`
  reads + real `diff.patch` → `coverage_ratio == 1.0`, no uncovered files
- real-path `analyze_grounding`: codex `shell` + pi `read` on the cited file →
  `file_was_read: True`, `grounding_rate == 1.0`

## Gate

`make check` green: 2834 passed / 5 skipped (ruff + mypy `daydream tests bench` + full
pytest).

## Benchmark isolation

**Cannot affect Martian benchmark scoring.** This changes post-run analysis only
(`daydream/eval/analyzer.py`); nothing in the review → arbiter → merge pipeline changes.
