### PR TITLE
feat(prompts): add per-stack test-quality review rubric (vacuous assertions, internal-field assertions, determinism)

### DIFF
--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -63,6 +63,35 @@ VERIFICATION_PROTOCOL_INSTRUCTION = (
     "Do NOT report a finding that fails any gate."
 )
 
+# Per-stack test-quality rubric (issue #308). Embedded inline as instruction text
+# for the same reason as ``VERIFICATION_PROTOCOL_INSTRUCTION``: per-stack
+# reviewers run with cwd set to the reviewed repo, so a bare skill-file read
+# resolves against that repo and silently drops the gates. The rubric targets
+# test hunks in the diff: vacuous assertions, internal-field/pointer-identity
+# assertions, nondeterminism, canonical-path bypasses, and portability breaks.
+TEST_QUALITY_RUBRIC_INSTRUCTION = (
+    "Apply the test-quality rubric to every test hunk in the diff "
+    "(stated inline here — no skill file read is required):\n"
+    "  1. Would this test fail if the behavior under test were wrong? Scan for "
+    "vacuous assertions — e.g. `read_to_string(...).unwrap_or_default()` "
+    "returning empty on failure, expected values built with the same helper "
+    "under test, a wait/retry helper returning the last nonmatching frame.\n"
+    "  2. Does it assert observable consequences (output, filesystem, exit code, "
+    "store state) rather than internal fields/pointers/dispatch plumbing "
+    "(`context as *const _ as usize`, dispatch internals, event payloads with no "
+    "observable check)?\n"
+    "  3. Is it deterministic (no sleeps, no `yield_now()` reaping assumptions, "
+    "no environment leaks — require restore guards for any env mutation)?\n"
+    "  4. Does it exercise the new behavior through the canonical public path (no "
+    "raw `system_prompt` copies, no bypassing the public API the behavior lives "
+    "behind)?\n"
+    "  5. Does it compile on all platforms (`#[cfg]` gates)?\n"
+    "Layering awareness: legitimate pure-function seams are fine — a unit test of "
+    "a pure `build_driver_request` or driver-boundary propagation helper is NOT an "
+    "internal-field assertion. Flag a seam ONLY when it bypasses the observable "
+    "behavior the test claims to cover."
+)
+
 
 def _context_pointers(
     *,
@@ -303,6 +332,7 @@ def build_per_stack_prompt(
     parts.append(_stack_scope_instruction(stack_name, files))
     parts.append(_diff_instruction(diff_path, files, inline_diff=inline_diff))
     parts.append(skill_invocation)
+    parts.append(TEST_QUALITY_RUBRIC_INSTRUCTION)
     parts.append(f"Write your full review to {output_path}.")
     return "\n\n".join(parts)
 

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -823,3 +823,63 @@ def test_adjudication_builders_keep_alternatives_unconditionally(tmp_path: Path)
     for name in ("build_arbiter_prompt", "build_merge_prompt"):
         sig = inspect.signature(getattr(dp, name))
         assert "include_alternatives" not in sig.parameters, name
+
+
+# =============================================================================
+# Issue #308 — test-quality rubric in the per-stack review prompt
+# =============================================================================
+
+
+def test_per_stack_prompt_includes_test_quality_rubric(tmp_path: Path) -> None:
+    """#308: the per-stack review prompt ships the test-quality rubric.
+
+    The rubric targets test hunks in the diff: vacuous assertions,
+    internal-field/pointer-identity assertions, nondeterminism, canonical-path
+    bypasses, and portability breaks.
+    """
+    p = _paths(tmp_path)
+    out = build_per_stack_prompt(
+        skill_invocation="/beagle-python:review-python",
+        stack_name="python",
+        files=["api.py"],
+        **p,
+    )
+    assert "test-quality rubric" in out
+    assert "vacuous assertions" in out
+    assert "observable consequences" in out
+    assert "canonical public path" in out
+    assert "deterministic" in out
+    assert "`#[cfg]`" in out
+
+
+def test_per_stack_prompt_test_quality_rubric_layering_awareness(tmp_path: Path) -> None:
+    """#308: the rubric must not over-apply to legitimate pure-function seams.
+
+    A unit test of a pure ``build_driver_request`` / driver-boundary propagation
+    helper is NOT an internal-field assertion; the rubric only flags a seam when
+    it bypasses the observable behavior the test claims to cover.
+    """
+    p = _paths(tmp_path)
+    out = build_per_stack_prompt(
+        skill_invocation="/beagle-python:review-python",
+        stack_name="python",
+        files=["api.py"],
+        **p,
+    )
+    assert "pure-function seams" in out
+    assert "`build_driver_request`" in out
+    assert "internal-field assertion" in out
+    assert "bypasses the observable behavior" in out
+
+
+def test_per_stack_prompt_test_quality_rubric_sits_after_skill_invocation(tmp_path: Path) -> None:
+    """#308: the rubric lands after the skill invocation so the reviewer applies
+    it to each test hunk, not ahead of the per-stack review instructions."""
+    p = _paths(tmp_path)
+    out = build_per_stack_prompt(
+        skill_invocation="/beagle-python:review-python",
+        stack_name="python",
+        files=["api.py"],
+        **p,
+    )
+    assert out.index("test-quality rubric") > out.index("/beagle-python:review-python")


### PR DESCRIPTION
Closes #308

## What

Daydream's per-stack review prompts had no test-quality rubric, so the single biggest
value class in the osprey corpus (test-quality: 37/57 of recent substantive findings)
was under-caught. This adds the rubric to the per-stack review prompt.

## Changes

- `daydream/deep/prompts.py`
  - New `TEST_QUALITY_RUBRIC_INSTRUCTION` constant (inline instruction text, same style
    as `VERIFICATION_PROTOCOL_INSTRUCTION` — no skill-file read, so it cannot be dropped
    by cwd resolution):
    1. Would this test fail if the behavior under test were wrong? (vacuous-assertion scan)
    2. Does it assert observable consequences (output, fs, exit code, store state) rather
       than internal fields/pointers/dispatch plumbing?
    3. Is it deterministic (no sleeps, no `yield_now()` reaping assumptions, no env leaks —
       restore guards)?
    4. Does it exercise the new behavior through the canonical public path?
    5. Does it compile on all platforms (`#[cfg]` gates)?
  - **Layering awareness** baked in: legitimate pure-function seams (e.g. a pure
    `build_driver_request` / driver-boundary propagation unit test) are explicitly NOT
    internal-field assertions — a seam is flagged only when it bypasses the observable
    behavior the test claims to cover. This addresses the CodeRabbit over-application
    regression (3/6 withdrawals on a known PR).
  - Appended to the per-stack review prompt in `build_per_stack_prompt` after the scope /
    diff instructions and skill invocation.

## Tests

3 new tests in `tests/test_deep_prompts.py`, all exercising the real
`build_per_stack_prompt` with real tmp paths:
- pins all five rubric points visible in the per-stack prompt
- pins the layering-awareness clause (pure-function seams allowed)
- pins placement after the skill invocation

## Gate

`make check` green: 2832 passed / 5 skipped (ruff + mypy `daydream tests bench` + full
pytest).

## Benchmark isolation

**Can affect Martian benchmark scoring — intended recall improvement, not reward
hacking.** This changes review-phase prompts, which run before cross-stack-merge. The
scorer reads only merged findings, and the rubric targets test files; it is a deliberate
recall improvement for the test-quality class, not a reward-maximizing change.
