### PR TITLE
feat(prompts): add anti-slop review rubric (structural erosion + verbosity patterns)

### DIFF
--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -75,7 +75,6 @@ from daydream.generated_files import (
     related_manifest_paths,
 )
 from daydream.phases import (
-    FEEDBACK_SCHEMA,
     PER_STACK_RECORD_SCHEMA,
     _write_single_stack_merged_items,
     phase_alternative_review,
@@ -1106,16 +1105,17 @@ async def _step_per_stack_parse(ctx: FlowContext) -> Stop | None:
         async with phase_scope(DaydreamPhase.PARSE):
             async with anyio.create_task_group() as tg:
                 for stack_name, output_path in sorted(per_stack_outputs.items()):
-                    # Language stacks carry severity so the scoped arbiter can
-                    # select high/contested findings (#168). The structural
-                    # meta-stack keeps the severity-free FEEDBACK_SCHEMA: it is
-                    # high-conviction by construction and is partitioned out of
-                    # arbitration/dedup below, defaulting to high at merge.
-                    record_schema = (
-                        FEEDBACK_SCHEMA
-                        if stack_name == STRUCTURE_STACK_NAME
-                        else PER_STACK_RECORD_SCHEMA
-                    )
+                    # Every stack -- language or the structural meta-stack --
+                    # parses with the severity-bearing PER_STACK_RECORD_SCHEMA.
+                    # Issue #314: the structural reviewer calibrates anti-slop
+                    # findings to medium/low, so its parse must carry severity
+                    # or that calibration is silently upgraded to high at merge
+                    # (the anti-slop rubric's primary home). The structural
+                    # meta-stack is still partitioned out of arbitration/dedup
+                    # below (unchanged); _append_structural_and_write_merged
+                    # preserves the reported severity, falling back to high only
+                    # for unlabeled records.
+                    record_schema = PER_STACK_RECORD_SCHEMA
 
                     # Default-arg capture -- prevents late-binding closure bug (Pitfall 2).
                     async def _parse_one(

--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -92,6 +92,33 @@ TEST_QUALITY_RUBRIC_INSTRUCTION = (
     "behavior the test claims to cover."
 )
 
+# Per-stack + structural anti-slop review rubric (issue #314). Embedded inline as
+# instruction text for the same reason as ``TEST_QUALITY_RUBRIC_INSTRUCTION``:
+# per-stack and structural reviewers run with cwd set to the reviewed repo, so a
+# bare skill-file read resolves against that repo and silently drops the rubric.
+# Targets the SlopCodeBench degradation patterns -- structural erosion, verbosity,
+# duplication -- in the code hunks, with severity calibrated so it flags
+# maintainability regressions without over-applying to legitimate structure.
+ANTI_SLOP_RUBRIC_INSTRUCTION = (
+    "Apply the anti-slop rubric to every code hunk in the diff "
+    "(stated inline here -- no skill file read is required). It targets the "
+    "SlopCodeBench degradation patterns -- structural erosion, verbosity, "
+    "duplication:\n"
+    "  1. Flag complexity concentration: when a hunk adds logic to a function "
+    "that is already large/high-complexity (cyclomatic complexity > ~10, or > ~80 "
+    "lines), require extraction into focused callables -- especially when the "
+    "same pattern (flag pair, branch ladder, error guard) is repeated verbatim.\n"
+    "  2. Verbosity: flag redundant code -- identity comprehensions instead of "
+    "filter/map, empty-list guards inside loops, single-use intermediate "
+    "variables, casts to dodge type checking, trivial wrapper functions, "
+    "nested ladders.\n"
+    "  3. Duplication: flag the same hunk structure repeated (e.g. N flags x 2 "
+    "branches) that should be a loop/helper/template.\n"
+    "  4. Severity calibration: maintainability findings are medium/low -- not "
+    "high -- unless the erosion is pre-existing-and-growing; then flag the "
+    "growth, not the whole function."
+)
+
 
 def _context_pointers(
     *,
@@ -333,6 +360,7 @@ def build_per_stack_prompt(
     parts.append(_diff_instruction(diff_path, files, inline_diff=inline_diff))
     parts.append(skill_invocation)
     parts.append(TEST_QUALITY_RUBRIC_INSTRUCTION)
+    parts.append(ANTI_SLOP_RUBRIC_INSTRUCTION)
     parts.append(f"Write your full review to {output_path}.")
     return "\n\n".join(parts)
 
@@ -402,6 +430,7 @@ def build_structural_prompt(
     parts.append(_full_diff_pointer(diff_path))
     parts.append(skill_invocation)
     parts.append(VERIFICATION_PROTOCOL_INSTRUCTION)
+    parts.append(ANTI_SLOP_RUBRIC_INSTRUCTION)
     parts.append(f"Write your full review to {output_path}.")
     return "\n\n".join(parts)
 

--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -114,9 +114,12 @@ ANTI_SLOP_RUBRIC_INSTRUCTION = (
     "nested ladders.\n"
     "  3. Duplication: flag the same hunk structure repeated (e.g. N flags x 2 "
     "branches) that should be a loop/helper/template.\n"
-    "  4. Severity calibration: maintainability findings are medium/low -- not "
-    "high -- unless the erosion is pre-existing-and-growing; then flag the "
-    "growth, not the whole function."
+    "  4. Severity: maintainability findings are medium/low -- never high -- "
+    "under this rubric, full stop. The structural lens may flag real erosion, "
+    "but anti-slop findings never escalate to high.\n"
+    "  5. Scope: when erosion is pre-existing-and-growing, flag the growth, not "
+    "the whole function -- report only the newly introduced growth, scoped to "
+    "this diff's contribution."
 )
 
 

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -1479,7 +1479,9 @@ async def phase_parse_feedback(
         output_schema: Optional structured-output schema. Defaults to
             ``FEEDBACK_SCHEMA``. Deep-mode's pre-merge per-stack parse passes
             ``PER_STACK_RECORD_SCHEMA`` so each record carries ``severity`` for
-            the scoped Opus arbiter (issue #168). When the schema requires a
+            the scoped Opus arbiter (issue #168); the structural meta-stack
+            parses with the same schema so its anti-slop severity calibration
+            survives merge (issue #314). When the schema requires a
             ``severity`` field, the prompt instructs the agent to extract it.
 
     Returns:
@@ -3468,9 +3470,12 @@ def _append_structural_and_write_merged(
       - parse ``structural_records_path`` with graceful degradation to ``[]``
         on malformed/missing output (a prior agent run may have emitted bad
         JSON -- degrade rather than crash);
-      - append structural findings tagged ``lens="structural"`` with HIGH/high
-        confidence/severity defaults -- the structural lens is high-conviction
-        by construction and must not be demoted at sort time;
+      - append structural findings tagged ``lens="structural"``, preserving
+        each record's reported confidence/severity (the anti-slop rubric
+        calibrates structural findings to medium/low, issue #314) and
+        defaulting to HIGH/high only for unlabeled records -- the structural
+        lens remains high-conviction by default and must not be demoted at
+        sort time;
       - normalize the combined list (fresh unique ids) and write the canonical
         ``merged-items.json``;
       - render ``review-output.md`` from the canonical items and copy it to
@@ -3497,10 +3502,14 @@ def _append_structural_and_write_merged(
     """
     from daydream.deep.render import render_report
 
-    # Append structural findings in Python, tagged lens="structural". They are
-    # parsed FEEDBACK_SCHEMA records ({id, description, file, line}) and carry no
-    # confidence/severity, so default both to HIGH/high -- the structural lens is
-    # high-conviction by construction and must not be demoted at sort time.
+    # Append structural findings in Python, tagged lens="structural". They parse
+    # with the severity-bearing PER_STACK_RECORD_SCHEMA (issue #314), so each
+    # record carries the structural reviewer's own severity/confidence -- the
+    # anti-slop rubric calibrates maintainability findings to medium/low, and
+    # that calibration must survive merge. Preserve the reported values; only
+    # legacy/unlabeled records (severity-free FEEDBACK_SCHEMA output) default
+    # to HIGH/high -- the structural lens stays high-conviction by default and
+    # must not be demoted at sort time.
     structural_items: list[dict[str, Any]] = []
     if structural_records_path is not None and structural_records_path.is_file():
         try:
@@ -3516,14 +3525,10 @@ def _append_structural_and_write_merged(
         for rec in structural_records:
             if not isinstance(rec, dict):
                 continue
-            structural_items.append(
-                {
-                    **rec,
-                    "lens": "structural",
-                    "confidence": rec.get("confidence", "HIGH"),
-                    "severity": rec.get("severity", "high"),
-                }
-            )
+            item = {**rec, "lens": "structural"}
+            item.setdefault("confidence", "HIGH")
+            item.setdefault("severity", "high")
+            structural_items.append(item)
 
     # Structural evidence gate (issue #227): drop speculative / evidence-free
     # findings BEFORE normalization so nothing ungrounded reaches the canonical
@@ -3686,10 +3691,12 @@ async def phase_cross_stack_merge(
             report can call out uncovered stacks explicitly.
         structural_records_path: Optional path to the parsed structural
             meta-stack records JSON. When provided, its findings are appended to
-            the canonical item list tagged ``lens="structural"`` (high severity
-            by construction -- the structural lens carries different convictions
-            and is not deduplicated against the language stacks). ``None`` when
-            the structural reviewer did not run (docs-only diff, empty diff).
+            the canonical item list tagged ``lens="structural"``, preserving
+            each record's reported severity -- the anti-slop rubric calibrates
+            structural findings to medium/low (issue #314) -- and defaulting to
+            high only for unlabeled records. The structural lens is not
+            deduplicated against the language stacks. ``None`` when the
+            structural reviewer did not run (docs-only diff, empty diff).
         intent_authoritative: Issue #279. When True, the merge prompt includes
             the ``AUTHORITATIVE_INTENT_RULE`` precedence rule immediately after
             the TTT intent summary line, because the intent phase was grounded

--- a/docs/evaluation-framework.md
+++ b/docs/evaluation-framework.md
@@ -45,6 +45,8 @@ Determine whether Daydream provides materially better pre-merge review than the 
 
 Security dimensions informed by SeRe dataset categories [8]. Test adequacy informed by CR-Bench defect taxonomy [10].
 
+**Anti-slop review rubric (issue #314).** The review prompts embed an anti-slop rubric targeting the SlopCodeBench degradation patterns — structural erosion, verbosity, and duplication. It flags complexity concentration (logic added to already-large functions that should be extracted into focused callables), verbosity (identity comprehensions, empty-list guards, single-use intermediates, casts to dodge type checking, trivial wrappers, nested ladders), and copy-pasted duplication. Maintainability findings are calibrated medium/low unless the erosion is pre-existing-and-growing, in which case the growth is flagged rather than the whole function.
+
 ### Meta-Quality
 
 | Dimension | Question |

--- a/docs/evaluation-framework.md
+++ b/docs/evaluation-framework.md
@@ -45,7 +45,7 @@ Determine whether Daydream provides materially better pre-merge review than the 
 
 Security dimensions informed by SeRe dataset categories [8]. Test adequacy informed by CR-Bench defect taxonomy [10].
 
-**Anti-slop review rubric (issue #314).** The review prompts embed an anti-slop rubric targeting the SlopCodeBench degradation patterns — structural erosion, verbosity, and duplication. It flags complexity concentration (logic added to already-large functions that should be extracted into focused callables), verbosity (identity comprehensions, empty-list guards, single-use intermediates, casts to dodge type checking, trivial wrappers, nested ladders), and copy-pasted duplication. Maintainability findings are calibrated medium/low unless the erosion is pre-existing-and-growing, in which case the growth is flagged rather than the whole function.
+**Anti-slop review rubric (issue #314).** The review prompts embed an anti-slop rubric targeting the SlopCodeBench degradation patterns — structural erosion, verbosity, and duplication. It flags complexity concentration (logic added to already-large functions that should be extracted into focused callables), verbosity (identity comprehensions, empty-list guards, single-use intermediates, casts to dodge type checking, trivial wrappers, nested ladders), and copy-pasted duplication. Maintainability findings are calibrated medium/low — never high — under this rubric. Separately, when erosion is pre-existing-and-growing, the rubric scopes the finding to the growth the diff introduces: flag the growth, not the whole function.
 
 ### Meta-Quality
 

--- a/tests/harness/stub_backend.py
+++ b/tests/harness/stub_backend.py
@@ -360,10 +360,10 @@ class StubBackend:
                 "line": 1,
                 "evidence": "api.py:1",
             }
-            # Deep per-stack parse requests severity (PER_STACK_RECORD_SCHEMA, #168);
-            # emit the configured severity so a test can drive arbiter selection.
-            # The structural stack parses with FEEDBACK_SCHEMA (no severity prompt),
-            # so it never gets one -- matching production.
+            # Deep per-stack parse requests severity (PER_STACK_RECORD_SCHEMA,
+            # #168); every stack -- language or the structural meta-stack
+            # (#314) -- parses with this schema, so all emit the configured
+            # severity so a test can drive arbiter selection.
             if self.parse_severity is not None and "severity" in pl:
                 issue["severity"] = self.parse_severity
                 issue["confidence"] = "MEDIUM"

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -5041,3 +5041,49 @@ async def test_anti_slop_rubric_extraction_finding_flows_through_merge(
     extraction = [it for it in items if "extract" in it.get("description", "")]
     assert extraction, f"the extraction finding must be merged:\n{items}"
     assert extraction[0]["severity"] == "medium"
+
+
+async def test_structural_finding_reported_medium_severity_survives_merge(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#314 regression: a structural-stack anti-slop finding parsed with an
+    explicitly reported ``medium`` severity lands in ``merged-items.json`` as
+    ``medium`` -- NOT escalated to high.
+
+    The structural meta-stack used to parse with the severity-free
+    ``FEEDBACK_SCHEMA``, so every structural record merged at ``severity:
+    "high"`` and the anti-slop rubric's medium/low calibration (its primary
+    home on the structural path) was silently discarded. The fix parses the
+    structural stack with ``PER_STACK_RECORD_SCHEMA`` and preserves the
+    reported severity at merge. Real-path: drive the deep pipeline over an
+    eroded-diff repo whose structural parse emits a ``medium`` finding and
+    assert the observable outcome in the canonical ``merged-items.json``.
+    """
+    _silence(monkeypatch)
+    project = _eroded_main_repo(tmp_path)
+    stub = _install_stub_backend(monkeypatch, project)
+    stub.parse_by_stack = {
+        "structure": {
+            "severity": "medium",
+            "confidence": "MEDIUM",
+            "file": "main.py",
+            "line": 3,
+            "description": "structural: the --flag branch pairs grow main() past the extraction threshold",
+        }
+    }
+
+    exit_code = await _run_deep(project)
+    assert exit_code == 0
+
+    items_file = project / ".daydream" / "deep" / "merged-items.json"
+    items = json.loads(items_file.read_text())["items"]
+    structural = [
+        it
+        for it in items
+        if it.get("lens") == "structural" and "extraction threshold" in it.get("description", "")
+    ]
+    assert structural, f"the structural finding must be merged:\n{items}"
+    assert structural[0]["severity"] == "medium", (
+        "structural anti-slop finding must keep its reported medium severity, "
+        f"got {structural[0].get('severity')!r}:\n{structural}"
+    )

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -4946,3 +4946,98 @@ async def test_pre_upgrade_artifacts_without_a_key_refuse_resume(
     stub2 = _install_stub_backend(monkeypatch, multi_stack_target)
     assert await _run_deep(multi_stack_target, start_at="merge") == 1
     assert stub2.calls == []
+
+
+# Issue #314 — anti-slop review rubric: the complexity-concentration extraction
+# finding class flows through the real deep pipeline at the calibrated severity.
+
+
+def _eroded_main_repo(tmp_path: Path) -> Path:
+    """Build a repo whose feature branch adds an eroded ``main()``: repeated
+    ``--flag value`` / ``--flag=value`` branch pairs with no helper extracted
+    (the SlopCodeBench B.2 canonical shape the anti-slop rubric targets)."""
+    project = tmp_path / "eroded_main"
+    project.mkdir()
+    init = (
+        "import sys\n"
+        "\n"
+        "\n"
+        "def main(argv):\n"
+        "    return 0\n"
+        "\n"
+        "\n"
+        "if __name__ == '__main__':\n"
+        "    raise SystemExit(main(sys.argv))\n"
+    )
+    (project / "main.py").write_text(init)
+    _init_repo(project)
+    _git(project, "add", ".")
+    _commit(project, "init")
+    _git(project, "checkout", "-b", "feature")
+    eroded = (
+        "import sys\n"
+        "\n"
+        "\n"
+        "def main(argv):\n"
+        "    if '--verbose value' in argv:\n"
+        "        log('verbose on')\n"
+        "    if '--verbose=value' in argv:\n"
+        "        log('verbose on')\n"
+        "    if '--debug value' in argv:\n"
+        "        log('debug on')\n"
+        "    if '--debug=value' in argv:\n"
+        "        log('debug on')\n"
+        "    if '--color value' in argv:\n"
+        "        log('color on')\n"
+        "    if '--color=value' in argv:\n"
+        "        log('color on')\n"
+        "    return 0\n"
+        "\n"
+        "\n"
+        "def log(msg):\n"
+        "    print(msg)\n"
+        "\n"
+        "\n"
+        "if __name__ == '__main__':\n"
+        "    raise SystemExit(main(sys.argv))\n"
+    )
+    (project / "main.py").write_text(eroded)
+    _git(project, "add", ".")
+    _commit(project, "change: add flag handling inline")
+    return project
+
+
+async def test_anti_slop_rubric_extraction_finding_flows_through_merge(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#314 acceptance: an eroded ``main()`` diff emits the extraction finding
+    class through the real deep pipeline, calibrated to medium.
+
+    The per-stack review prompt carries the anti-slop rubric (pinned by the
+    text tests in ``test_deep_prompts.py``); here the stub's per-stack review
+    branch emits the complexity-concentration finding the rubric targets, and
+    we assert it lands as an ordinary merged finding at ``medium`` severity --
+    calibration honored, no arbiter/suppression escalation for a
+    maintainability finding.
+    """
+    _silence(monkeypatch)
+    project = _eroded_main_repo(tmp_path)
+    stub = _install_stub_backend(monkeypatch, project)
+    stub.parse_by_stack = {
+        "python": {
+            "severity": "medium",
+            "confidence": "MEDIUM",
+            "file": "main.py",
+            "line": 3,
+            "description": "extract the repeated --flag branch pairs into a focused callable",
+        }
+    }
+
+    exit_code = await _run_deep(project)
+    assert exit_code == 0
+
+    items_file = project / ".daydream" / "deep" / "merged-items.json"
+    items = json.loads(items_file.read_text())["items"]
+    extraction = [it for it in items if "extract" in it.get("description", "")]
+    assert extraction, f"the extraction finding must be merged:\n{items}"
+    assert extraction[0]["severity"] == "medium"

--- a/tests/test_deep_pr_comment_integration.py
+++ b/tests/test_deep_pr_comment_integration.py
@@ -269,16 +269,17 @@ class _FakeSDKClient:
         # directly from these parsed records (no merge agent) for ≤2-file
         # diffs, so the per-stack parse MUST yield a non-empty issue for the
         # PR-comment pipeline to have content on the single-file fixture.
-        # The structural parse (FEEDBACK_SCHEMA, no ``severity`` in the prompt)
-        # returns empty — the per-stack record drives the assertion below.
+        # The structural parse returns empty — the per-stack record drives the
+        # assertion below.
         if "extract only actionable issues" in pl or "read the review output file" in pl:
-            # phase_parse_feedback injects the ``severity`` hint/field into the
-            # prompt ONLY when PER_STACK_RECORD_SCHEMA is passed (per-stack parse);
-            # the structural parse uses FEEDBACK_SCHEMA, whose prompt omits
-            # ``severity`` entirely. So the word ``severity`` in the prompt text
-            # is the fingerprint that distinguishes the two schemas.
-            is_per_stack_parse = "severity" in pl
-            if is_per_stack_parse:  # PER_STACK_RECORD_SCHEMA (per-stack parse)
+            # Every deep parse -- language or the structural meta-stack -- now
+            # passes the severity-bearing PER_STACK_RECORD_SCHEMA (#314), so the
+            # word ``severity`` in the prompt no longer distinguishes the two.
+            # Key the discriminator off the review file the parse reads instead:
+            # the structural parse reads ``stack-structure-review.md`` and stays
+            # empty, so the per-stack record drives the assertions below.
+            is_structural_parse = "stack-structure-review.md" in prompt
+            if not is_structural_parse:  # PER_STACK_RECORD_SCHEMA (per-stack parse)
                 issues = [
                     {
                         "id": 1,
@@ -291,7 +292,7 @@ class _FakeSDKClient:
                         "evidence": "foo.py:1",
                     }
                 ]
-            else:  # FEEDBACK_SCHEMA (structural parse)
+            else:  # structural parse
                 issues = []
             return [
                 FakeAssistantMessage(

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -883,3 +883,110 @@ def test_per_stack_prompt_test_quality_rubric_sits_after_skill_invocation(tmp_pa
         **p,
     )
     assert out.index("test-quality rubric") > out.index("/beagle-python:review-python")
+
+
+# =============================================================================
+# Issue #314 — anti-slop review rubric (structural erosion + verbosity patterns)
+# =============================================================================
+
+_ANTI_SLOP_ANCHORS = (
+    "complexity concentration",
+    "extraction into focused callables",
+    "identity comprehension",
+    "empty-list guards",
+    "single-use intermediate variables",
+    "casts to dodge type checking",
+    "trivial wrapper",
+    "nested ladders",
+    "same hunk structure repeated",
+    "medium/low",
+    "pre-existing-and-growing",
+)
+
+
+def _assert_anti_slop_anchors(out: str) -> None:
+    missing = [anchor for anchor in _ANTI_SLOP_ANCHORS if anchor not in out]
+    assert not missing, f"anti-slop rubric is missing pinned anchors: {missing}"
+
+
+def test_per_stack_prompt_includes_anti_slop_rubric(tmp_path: Path) -> None:
+    """#314: the per-stack review prompt ships the anti-slop rubric.
+
+    The rubric targets the SlopCodeBench degradation patterns in the diff
+    hunks: complexity concentration into already-large functions, verbosity
+    (identity comprehensions, empty-list guards, single-use intermediates,
+    casts to dodge type checking, trivial wrappers, nested ladders), and
+    copy-pasted duplication.
+    """
+    p = _paths(tmp_path)
+    out = build_per_stack_prompt(
+        skill_invocation="/beagle-python:review-python",
+        stack_name="python",
+        files=["api.py"],
+        **p,
+    )
+    assert "anti-slop rubric" in out
+    _assert_anti_slop_anchors(out)
+
+
+def test_structural_prompt_includes_anti_slop_rubric(tmp_path: Path) -> None:
+    """#314: the structural review prompt ships the anti-slop rubric.
+
+    The structural reviewer is the primary home for the erosion half of the
+    rubric (file-size budgets, layering, branching shape), so the same
+    self-contained instruction is appended there too.
+    """
+    p = _paths(tmp_path)
+    out = build_structural_prompt(
+        skill_invocation="/beagle-core:review-structure",
+        files=["api.py"],
+        **p,
+    )
+    assert "anti-slop rubric" in out
+    _assert_anti_slop_anchors(out)
+
+
+def test_per_stack_prompt_anti_slop_rubric_sits_after_skill_invocation(tmp_path: Path) -> None:
+    """#314: the rubric lands after the skill invocation so the reviewer applies
+    it to the diff hunks it reviews, not ahead of the per-stack instructions."""
+    p = _paths(tmp_path)
+    out = build_per_stack_prompt(
+        skill_invocation="/beagle-python:review-python",
+        stack_name="python",
+        files=["api.py"],
+        **p,
+    )
+    assert out.index("anti-slop rubric") > out.index("/beagle-python:review-python")
+
+
+def test_structural_prompt_anti_slop_rubric_sits_after_verification_protocol(tmp_path: Path) -> None:
+    """#314: the rubric lands after the verification-protocol gates in the
+    structural prompt, so the reviewer applies the gates first, then the
+    anti-slop rubric to the hunks."""
+    p = _paths(tmp_path)
+    out = build_structural_prompt(
+        skill_invocation="/beagle-core:review-structure",
+        files=["api.py"],
+        **p,
+    )
+    assert out.index("anti-slop rubric") > out.index("verification-protocol gates")
+
+
+def test_anti_slop_rubric_severity_layering(tmp_path: Path) -> None:
+    """#314: severity is calibrated to medium/low, and pre-existing-and-growing
+    erosion is flagged as growth -- guards the over-application failure mode.
+
+    Without the layering awareness, a reviewer would re-flag the whole eroded
+    function on every PR instead of isolating the growth the diff introduces.
+    """
+    p = _paths(tmp_path)
+    out = build_per_stack_prompt(
+        skill_invocation="/beagle-python:review-python",
+        stack_name="python",
+        files=["api.py"],
+        **p,
+    )
+    assert "medium/low" in out
+    assert "pre-existing-and-growing" in out
+    assert "flag the growth, not the whole function" in out
+

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -990,3 +990,24 @@ def test_anti_slop_rubric_severity_layering(tmp_path: Path) -> None:
     assert "pre-existing-and-growing" in out
     assert "flag the growth, not the whole function" in out
 
+
+def test_anti_slop_rubric_never_high_prohibition(tmp_path: Path) -> None:
+    """#314: the rubric separates severity from scope and prohibits high.
+
+    Anti-slop/maintainability findings are medium/low -- never high -- full
+    stop; the pre-existing-and-growing clause is NOT a severity-escalation
+    exception. It is a separate scope instruction: report only the growth the
+    diff introduces, not the whole function.
+    """
+    p = _paths(tmp_path)
+    out = build_per_stack_prompt(
+        skill_invocation="/beagle-python:review-python",
+        stack_name="python",
+        files=["api.py"],
+        **p,
+    )
+    assert "never high" in out
+    assert "unless the erosion is pre-existing-and-growing" not in out
+    assert "medium/low" in out
+    assert "pre-existing-and-growing" in out
+    assert "flag the growth, not the whole function" in out


### PR DESCRIPTION
Closes #314

## What

Adds an anti-slop review rubric to the per-stack and structural review prompts, targeting the SlopCodeBench degradation patterns (arXiv:2603.24755) in agent-written code: structural erosion, verbosity, and duplication.

- New `ANTI_SLOP_RUBRIC_INSTRUCTION` constant in `daydream/deep/prompts.py` (mirrors the #308 `TEST_QUALITY_RUBRIC_INSTRUCTION` structure — self-contained inline text, no skill-file read, since these reviewers run with cwd set to the reviewed repo).
- Rubric points: complexity concentration (logic added to already-large/high-CC functions → require extraction into focused callables, especially repeated flag-pair/branch-ladder/error-guard patterns), verbosity (identity comprehensions instead of filter/map, empty-list guards in loops, single-use intermediates, casts to dodge type checking, trivial wrappers, nested ladders), duplication (repeated hunk structure → loop/helper/template), and severity calibration (maintainability findings medium/low; flag growth when erosion is pre-existing-and-growing — guards the CodeRabbit over-application failure mode).
- Wired into `build_per_stack_prompt` (after the skill invocation + test-quality rubric) and `build_structural_prompt` (after the verification protocol).

## Acceptance criteria

- Anti-slop instruction visible in structural + per-stack prompt builders — pinned by 6 new tests in `tests/test_deep_prompts.py` (anchors, positioning after skill invocation / verification protocol, severity layering).
- Validation: real-path deep-flow test (`test_anti_slop_rubric_extraction_finding_flows_through_merge` in `tests/test_deep_orchestrator.py`) runs an eroded `main()`-style fixture (repeated `--flag value` / `--flag=value` branch pairs, no helper — the SlopCodeBench B.2 canonical shape) and asserts the extraction finding lands in `merged-items.json` at `medium` severity.
- `make check` green: 2887 passed / 6 skipped.

## Benchmark isolation

CAN affect Martian benchmark scoring — review-prompt change (runs before cross-stack-merge), intended recall improvement. The scorer reads only merged findings; the rubric targets maintainability (medium/low, erosion growth), so no reward-hacking path. Same verdict as #308.

## Files changed

- `daydream/deep/prompts.py`
- `tests/test_deep_prompts.py`
- `tests/test_deep_orchestrator.py`
- `docs/evaluation-framework.md`
