### PR TITLE
feat(eval): add erosion + verbosity quality metrics to evaluation.json and manifest

### DIFF
--- a/daydream/archive/_schema.py
+++ b/daydream/archive/_schema.py
@@ -61,6 +61,8 @@ CREATE TABLE IF NOT EXISTS runs (
     coverage_ratio REAL,
     cost_per_finding_usd REAL,
     wall_clock_seconds REAL,
+    erosion REAL,
+    verbosity REAL,
     total_prompt_tokens INTEGER,
     total_completion_tokens INTEGER,
     total_cached_tokens INTEGER,
@@ -126,6 +128,7 @@ INSERT OR REPLACE INTO runs (
     review_only, deep, loop, remote_url, repo_slug, source_path, branch, base_branch,
     head_sha, base_sha, changed_files, pr_number, pr_repo, total_cost_usd, total_findings,
     grounding_rate, coverage_ratio, cost_per_finding_usd, wall_clock_seconds,
+    erosion, verbosity,
     total_prompt_tokens, total_completion_tokens, total_cached_tokens,
     outcome_labels, labeled_at, composite_reward, archive_path, schema_version
 ) VALUES (
@@ -134,6 +137,7 @@ INSERT OR REPLACE INTO runs (
     :review_only, :deep, :loop, :remote_url, :repo_slug, :source_path, :branch, :base_branch,
     :head_sha, :base_sha, :changed_files, :pr_number, :pr_repo, :total_cost_usd, :total_findings,
     :grounding_rate, :coverage_ratio, :cost_per_finding_usd, :wall_clock_seconds,
+    :erosion, :verbosity,
     :total_prompt_tokens, :total_completion_tokens, :total_cached_tokens,
     :outcome_labels, :labeled_at, :composite_reward, :archive_path, :schema_version
 )
@@ -177,6 +181,8 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
             ("composite_reward", "REAL"),
             ("source_path", "TEXT"),
             ("has_posterior", "INTEGER NOT NULL DEFAULT 0"),
+            ("erosion", "REAL"),
+            ("verbosity", "REAL"),
         ],
     )
 

--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -226,6 +226,8 @@ def upsert_run(archive_dir: Path, manifest: Manifest) -> None:
                 "coverage_ratio": manifest.coverage_ratio,
                 "cost_per_finding_usd": manifest.cost_per_finding_usd,
                 "wall_clock_seconds": manifest.wall_clock_seconds,
+                "erosion": manifest.erosion,
+                "verbosity": manifest.verbosity,
                 "total_prompt_tokens": manifest.total_prompt_tokens,
                 "total_completion_tokens": manifest.total_completion_tokens,
                 "total_cached_tokens": manifest.total_cached_tokens,

--- a/daydream/archive/manifest.py
+++ b/daydream/archive/manifest.py
@@ -90,6 +90,10 @@ class Manifest:
         grounding_rate: Grounding rate (from eval, if available).
         coverage_ratio: File coverage ratio (from eval, if available).
         cost_per_finding_usd: Cost per finding (from eval, if available).
+        erosion: Structural erosion ratio of the post-fix workspace (from eval,
+            if available).
+        verbosity: Line-flagging verbosity ratio of the post-fix workspace
+            (from eval, if available).
         outcome_labels: JSON-encoded list of outcome labels.
         labeled_at: ISO 8601 timestamp of last label update.
         composite_reward: Cached composite reward scalar mirrored from the
@@ -152,6 +156,8 @@ class Manifest:
     grounding_rate: float | None = None
     coverage_ratio: float | None = None
     cost_per_finding_usd: float | None = None
+    erosion: float | None = None
+    verbosity: float | None = None
 
     # Outcome labels (populated via `daydream harvest`)
     outcome_labels: str = field(default="[]")
@@ -213,6 +219,8 @@ class Manifest:
                 "grounding_rate": self.grounding_rate,
                 "coverage_ratio": self.coverage_ratio,
                 "cost_per_finding_usd": self.cost_per_finding_usd,
+                "erosion": self.erosion,
+                "verbosity": self.verbosity,
             },
             "outcome": {
                 "labels": json.loads(self.outcome_labels),
@@ -316,6 +324,10 @@ def build_manifest(
 
         coverage = evaluation.get("coverage", {})
         m.coverage_ratio = coverage.get("coverage_ratio")
+
+        quality = evaluation.get("quality", {})
+        m.erosion = quality.get("erosion")
+        m.verbosity = quality.get("verbosity")
 
         derived = evaluation.get("derived", {})
         m.cost_per_finding_usd = derived.get("cost_per_finding_usd")

--- a/daydream/eval/analyzer.py
+++ b/daydream/eval/analyzer.py
@@ -21,6 +21,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any, Iterator
 
+from daydream.generated_files import is_generated_file
 from daydream.timeutil import parse_iso_timestamp
 
 # Trajectory loading
@@ -745,7 +746,10 @@ def analyze_training_signals(
 # Quality metrics (issue #316) ----------------------------------------------
 
 _QUALITY_EXCLUDED_DIRS = frozenset(
-    {".git", ".daydream", "node_modules", ".venv", "venv", "__pycache__", ".worktrees", "dist", "build"}
+    {
+        ".git", ".daydream", "node_modules", ".venv", "venv", "__pycache__", ".worktrees",
+        "dist", "build", "vendor", "third_party", "migrations",
+    }
 )
 
 # Node types that add cyclomatic complexity (tree-sitter-python). ``else_clause``
@@ -766,7 +770,14 @@ _CC_DECISION_TYPES = frozenset(
     }
 )
 
-_COMPREHENSION_TYPES = frozenset({"list_comprehension", "set_comprehension", "dictionary_comprehension"})
+_COMPREHENSION_TYPES = frozenset(
+    {
+        "list_comprehension",
+        "set_comprehension",
+        "dictionary_comprehension",
+        "generator_expression",
+    }
+)
 
 _MIN_CLONE_BLOCK = 3
 _MAX_CLONE_BLOCK = 20
@@ -859,7 +870,11 @@ def _scoped_python_files(workspace: Path) -> list[tuple[Path, str]]:
 
     Excluded directories are matched on exact path components so a nested
     ``node_modules_extra/`` or a sibling ``.worktrees`` checkout never shadows
-    real source.
+    real source. Generated files are also out of scope: path-based rules
+    (``*_generated.py``, ``*.pb.py``, ``migrations/*.py``, …) and the
+    generated-file header marker are both applied via ``is_generated_file``,
+    so vendor/third_party trees and generated artifacts never reach the
+    metric denominators (Finding #8).
     """
     files: list[tuple[Path, str]] = []
     for path in workspace.rglob("*.py"):
@@ -869,15 +884,31 @@ def _scoped_python_files(workspace: Path) -> list[tuple[Path, str]]:
             continue
         if any(part in _QUALITY_EXCLUDED_DIRS for part in rel.parts):
             continue
+        try:
+            content = path.read_bytes()
+        except OSError:
+            continue
+        if is_generated_file(str(rel), content):
+            continue
         files.append((path, str(rel)))
     return sorted(files, key=lambda item: item[1])
 
 
-def _file_quality(path: Path) -> dict | None:
+def _file_quality(
+    path: Path,
+    cross_file_flagged: set[int] | None = None,
+) -> dict | None:
     """Erosion + verbosity metrics for one Python file, or ``None`` on parse failure.
 
     A file that cannot be parsed is counted in ``scoped_files`` by the caller
-    but excluded from the aggregates — quality analysis never crashes.
+    but excluded from the aggregates — quality analysis never crashes. Tree-sitter
+    returns a PARTIAL tree with ERROR/missing nodes for malformed Python, so a
+    root whose tree carries any error is treated as a parse failure instead of
+    aggregating garbage (Finding #9).
+
+    *cross_file_flagged* carries line rows (0-based) that duplicate a block also
+    present in another scoped file; they are OR'd into the verbosity set before
+    the ratio is computed (Finding #6).
     """
     parser = _quality_python_parser()
     if parser is None:
@@ -893,6 +924,8 @@ def _file_quality(path: Path) -> dict | None:
     if tree is None:
         return None
     root = tree.root_node
+    if root.has_error:
+        return None
 
     # Erosion: pooled cyclomatic mass of functions with CC > 10.
     functions = [node for node in _iter_tree(root) if node.type == "function_definition"]
@@ -914,6 +947,8 @@ def _file_quality(path: Path) -> dict | None:
     sloc_file = sum(1 for line in lines if line.strip())
     flagged = _verbosity_flagged_lines(root)
     flagged |= _clone_flagged_lines(lines)
+    if cross_file_flagged:
+        flagged |= cross_file_flagged
     flagged &= {i for i, line in enumerate(lines) if line.strip()}
     verbosity = len(flagged) / sloc_file if sloc_file > 0 else 0.0
 
@@ -944,9 +979,13 @@ def _verbosity_flagged_lines(root: Any) -> set[int]:
 
 
 def _comprehension_body(node: Any) -> Any | None:
-    """The output expression of a comprehension (skipping brackets)."""
+    """The output expression of a comprehension (skipping delimiters).
+
+    A generator expression wraps its output expression in ``(``/``)``, so
+    parens are skipped alongside the list/set/dict brackets.
+    """
     for child in node.children:
-        if child.type not in ("[", "]", "{", "}"):
+        if child.type not in ("[", "]", "{", "}", "(", ")"):
             return child
     return None
 
@@ -1284,6 +1323,46 @@ def _clone_flagged_lines(lines: list[str]) -> set[int]:
     return flagged
 
 
+def _cross_file_clone_flagged_lines(
+    file_lines: list[tuple[Path, list[str]]],
+) -> dict[Path, set[int]]:
+    """Line rows whose block also appears verbatim in another scoped file.
+
+    Same rule as ``_clone_flagged_lines`` (exact stripped contiguous block of
+    3..20 lines; blank-containing blocks skipped) but the match set spans
+    files: a block present in ≥2 distinct files flags every occurrence in
+    every file that holds it. Within-file duplicates stay
+    ``_clone_flagged_lines``'s job and are still counted per file, so the two
+    passes compose — a block duplicated twice inside ``a.py`` and once in
+    ``b.py`` is flagged in both, once per occurrence.
+    """
+    stripped_lines = {path: [line.strip() for line in lines] for path, lines in file_lines}
+    flagged: dict[Path, set[int]] = {path: set() for path in stripped_lines}
+
+    for length in range(_MIN_CLONE_BLOCK, _MAX_CLONE_BLOCK + 1):
+        by_first: dict[str, list[tuple[Path, int]]] = {}
+        for path, stripped in stripped_lines.items():
+            n = len(stripped)
+            if length > n:
+                continue
+            for i in range(n - length + 1):
+                if any(not stripped[j] for j in range(i, i + length)):
+                    continue
+                by_first.setdefault(stripped[i], []).append((path, i))
+        for starts in by_first.values():
+            if len({path for path, _ in starts}) < 2:
+                continue
+            by_block: dict[tuple[str, ...], list[tuple[Path, int]]] = {}
+            for path, i in starts:
+                by_block.setdefault(tuple(stripped_lines[path][i : i + length]), []).append((path, i))
+            for occurrences in by_block.values():
+                if len({path for path, _ in occurrences}) < 2:
+                    continue
+                for path, i in occurrences:
+                    flagged[path].update(range(i, i + length))
+    return flagged
+
+
 def analyze_quality(daydream_dir: str | Path) -> dict:
     """Structural erosion and verbosity of the post-fix workspace (issue #316).
 
@@ -1301,16 +1380,30 @@ def analyze_quality(daydream_dir: str | Path) -> dict:
     daydream_dir = Path(daydream_dir)
     workspace = daydream_dir.parent
 
+    scoped_files = _scoped_python_files(workspace)
+    scoped = len(scoped_files)
+
+    # Cross-file clone pass: read every scoped file's lines once and find
+    # blocks duplicated verbatim across >=2 files, then feed each file's
+    # cross-file line rows into its per-file verbosity below (Finding #6).
+    # Within-file duplicates are still handled per file inside _file_quality.
+    file_lines: list[tuple[Path, list[str]]] = []
+    for path, _rel in scoped_files:
+        try:
+            source = path.read_bytes()
+        except OSError:
+            continue
+        file_lines.append((path, source.decode("utf-8", errors="replace").splitlines()))
+    cross_file_flagged = _cross_file_clone_flagged_lines(file_lines)
+
     per_file: dict[str, dict] = {}
     total_mass = 0.0
     high_mass = 0.0
     total_flagged = 0
     total_loc = 0
-    scoped = 0
 
-    for path, rel in _scoped_python_files(workspace):
-        scoped += 1
-        quality = _file_quality(path)
+    for path, rel in scoped_files:
+        quality = _file_quality(path, cross_file_flagged=cross_file_flagged.get(path))
         if quality is None:
             continue
         per_file[rel] = quality["entry"]

--- a/daydream/eval/analyzer.py
+++ b/daydream/eval/analyzer.py
@@ -12,11 +12,14 @@ Usage::
 """
 
 import json
+import math
 import re
 import shlex
 from collections import Counter
 from datetime import datetime
+from functools import lru_cache
 from pathlib import Path
+from typing import Any, Iterator
 
 from daydream.timeutil import parse_iso_timestamp
 
@@ -739,6 +742,458 @@ def analyze_training_signals(
     }
 
 
+# Quality metrics (issue #316) ----------------------------------------------
+
+_QUALITY_EXCLUDED_DIRS = frozenset(
+    {".git", ".daydream", "node_modules", ".venv", "venv", "__pycache__", ".worktrees", "dist", "build"}
+)
+
+# Node types that add cyclomatic complexity (tree-sitter-python). ``else_clause``
+# is intentionally absent: an else adds no new path.
+_CC_DECISION_TYPES = frozenset(
+    {
+        "if_statement",
+        "elif_clause",
+        "for_statement",
+        "while_statement",
+        "except_clause",
+        "with_statement",
+        "assert_statement",
+        "conditional_expression",
+        "boolean_operator",
+        "case_clause",
+    }
+)
+
+_COMPREHENSION_TYPES = frozenset({"list_comprehension", "set_comprehension", "dictionary_comprehension"})
+
+_MIN_CLONE_BLOCK = 3
+_MAX_CLONE_BLOCK = 20
+
+_QUALITY_CALIBRATION = {
+    "human_verbosity": 0.19,
+    "human_erosion": 0.34,
+    "paper": "arXiv:2603.24755",
+}
+
+
+@lru_cache(maxsize=1)
+def _quality_python_parser():
+    """Cached tree-sitter Python parser.
+
+    Lazy factory mirroring ``daydream/tree_sitter_index.py``; returns ``None``
+    when tree-sitter-python is unavailable so quality analysis degrades to an
+    empty shape instead of crashing ``analyze_session``.
+    """
+    try:
+        import tree_sitter_python
+        from tree_sitter import Language, Parser
+
+        return Parser(Language(tree_sitter_python.language()))
+    except Exception:
+        return None
+
+
+def _iter_tree(node: Any) -> Iterator[Any]:
+    """Yield *node* and all descendants in a deterministic depth-first order."""
+    stack = [node]
+    while stack:
+        current = stack.pop()
+        yield current
+        stack.extend(reversed(current.children))
+
+
+def _iter_function(func: Any) -> Iterator[Any]:
+    """Yield *func* and its descendants, skipping nested function definitions.
+
+    Nested ``def`` nodes are yielded but their subtrees are not descended into,
+    because each nested def is measured as its own function.
+    """
+    stack = [func]
+    while stack:
+        node = stack.pop()
+        yield node
+        if node is not func and node.type == "function_definition":
+            continue
+        stack.extend(reversed(node.children))
+
+
+def _count_decision_nodes(node: Any) -> int:
+    """Cyclomatic decision count of a subtree, skipping nested functions."""
+    total = 1 if node.type in _CC_DECISION_TYPES else 0
+    for child in node.children:
+        if child.type == "function_definition":
+            continue
+        total += _count_decision_nodes(child)
+    return total
+
+
+def _scoped_python_files(workspace: Path) -> list[tuple[Path, str]]:
+    """All ``*.py`` files under *workspace* minus excluded dirs, as ``(path, rel)``.
+
+    Excluded directories are matched on exact path components so a nested
+    ``node_modules_extra/`` or a sibling ``.worktrees`` checkout never shadows
+    real source.
+    """
+    files: list[tuple[Path, str]] = []
+    for path in workspace.rglob("*.py"):
+        try:
+            rel = path.relative_to(workspace)
+        except ValueError:
+            continue
+        if any(part in _QUALITY_EXCLUDED_DIRS for part in rel.parts):
+            continue
+        files.append((path, str(rel)))
+    return sorted(files, key=lambda item: item[1])
+
+
+def _file_quality(path: Path) -> dict | None:
+    """Erosion + verbosity metrics for one Python file, or ``None`` on parse failure.
+
+    A file that cannot be parsed is counted in ``scoped_files`` by the caller
+    but excluded from the aggregates — quality analysis never crashes.
+    """
+    parser = _quality_python_parser()
+    if parser is None:
+        return None
+    try:
+        source = path.read_bytes()
+    except OSError:
+        return None
+    try:
+        tree = parser.parse(source)
+    except Exception:
+        return None
+    if tree is None:
+        return None
+    root = tree.root_node
+
+    # Erosion: pooled cyclomatic mass of functions with CC > 10.
+    functions = [node for node in _iter_tree(root) if node.type == "function_definition"]
+    metrics: list[tuple[int, int, float]] = []  # (cc, sloc, mass)
+    for func in functions:
+        body = func.child_by_field_name("body")
+        cc = 1 + _count_decision_nodes(body) if body is not None else 1
+        sloc = func.end_point.row - func.start_point.row + 1
+        if sloc < 1:
+            continue
+        metrics.append((cc, sloc, cc * math.sqrt(sloc)))
+
+    total_mass = sum(mass for _, _, mass in metrics)
+    high_mass = sum(mass for cc, _, mass in metrics if cc > 10)
+    erosion = high_mass / total_mass if total_mass > 0 else 0.0
+
+    # Verbosity: deterministic rule subset + clone detection over lines.
+    lines = source.decode("utf-8", errors="replace").splitlines()
+    sloc_file = sum(1 for line in lines if line.strip())
+    flagged = _verbosity_flagged_lines(root)
+    flagged |= _clone_flagged_lines(lines)
+    verbosity = len(flagged) / sloc_file if sloc_file > 0 else 0.0
+
+    return {
+        "entry": {
+            "erosion": round(erosion, 4),
+            "verbosity": round(verbosity, 4),
+            "sloc": sloc_file,
+            "functions": len(metrics),
+            "high_cc_functions": sum(1 for cc, _, _ in metrics if cc > 10),
+        },
+        "mass": total_mass,
+        "high_mass": high_mass,
+        "flagged": len(flagged),
+        "loc": sloc_file,
+    }
+
+
+def _verbosity_flagged_lines(root: Any) -> set[int]:
+    """Line rows (0-based) flagged by the deterministic taxonomy subset."""
+    flagged: set[int] = set()
+    flagged |= _identity_comprehension_lines(root)
+    flagged |= _empty_list_guard_lines(root)
+    flagged |= _single_use_variable_lines(root)
+    flagged |= _trivial_wrapper_lines(root)
+    flagged |= _nested_ladder_lines(root)
+    return flagged
+
+
+def _comprehension_body(node: Any) -> Any | None:
+    """The output expression of a comprehension (skipping brackets)."""
+    for child in node.children:
+        if child.type not in ("[", "]", "{", "}"):
+            return child
+    return None
+
+
+def _identity_comprehension_lines(root: Any) -> set[int]:
+    """``[x for x in items]``-style comprehensions whose output is the loop var."""
+    flagged: set[int] = set()
+    for node in _iter_tree(root):
+        if node.type not in _COMPREHENSION_TYPES:
+            continue
+        for_clauses = [child for child in node.children if child.type == "for_in_clause"]
+        if not for_clauses:
+            continue
+        target = for_clauses[0].child_by_field_name("left")
+        if target is None or target.type != "identifier":
+            continue
+        body = _comprehension_body(node)
+        if body is not None and body.text == target.text:
+            flagged.update(range(node.start_point.row, node.end_point.row + 1))
+    return flagged
+
+
+def _empty_guard_variable(if_node: Any) -> str | None:
+    """The variable tested by ``len(x) == 0`` or ``not x``, else ``None``."""
+    cond = if_node.child_by_field_name("condition")
+    if cond is None:
+        return None
+    if cond.type == "not_operator":
+        arg = cond.child_by_field_name("argument")
+        if arg is not None and arg.type == "identifier":
+            return arg.text.decode()
+        return None
+    if cond.type == "comparison_operator":
+        call = None
+        zero = None
+        for child in cond.children:
+            if child.type == "call":
+                call = child
+            elif child.type == "integer":
+                zero = child
+        if call is None or zero is None or zero.text.decode().strip() != "0":
+            return None
+        fn = call.child_by_field_name("function")
+        args = call.child_by_field_name("arguments")
+        if fn is None or fn.type != "identifier" or fn.text.decode() != "len" or args is None:
+            return None
+        arg_ids = [child for child in args.children if child.type == "identifier"]
+        if len(arg_ids) != 1:
+            return None
+        return arg_ids[0].text.decode()
+    return None
+
+
+def _tree_contains_identifier(node: Any, name: str) -> bool:
+    if node is None:
+        return False
+    return any(
+        n.type == "identifier" and n.text.decode() == name
+        for n in _iter_tree(node)
+    )
+
+
+def _empty_list_guard_lines(root: Any) -> set[int]:
+    """``if len(x) == 0`` / ``if not x`` guard directly inside a loop over ``x``."""
+    flagged: set[int] = set()
+    for node in _iter_tree(root):
+        if node.type not in ("for_statement", "while_statement"):
+            continue
+        body = node.child_by_field_name("body")
+        if body is None:
+            continue
+        for child in body.children:
+            if child.type != "if_statement":
+                continue
+            guard_var = _empty_guard_variable(child)
+            if guard_var is None:
+                continue
+            if node.type == "for_statement":
+                iterable = node.child_by_field_name("right")
+                if (
+                    iterable is not None
+                    and iterable.type == "identifier"
+                    and iterable.text.decode() == guard_var
+                ):
+                    flagged.update(range(child.start_point.row, child.end_point.row + 1))
+            elif _tree_contains_identifier(node.child_by_field_name("condition"), guard_var):
+                flagged.update(range(child.start_point.row, child.end_point.row + 1))
+    return flagged
+
+
+def _count_later_references(func: Any, name: str, after_row: int) -> int:
+    """Identifier occurrences of *name* after *after_row* inside *func*."""
+    return sum(
+        1
+        for node in _iter_function(func)
+        if node.type == "identifier"
+        and node.text.decode() == name
+        and node.start_point.row > after_row
+    )
+
+
+def _single_use_variable_lines(root: Any) -> set[int]:
+    """Assignments to a plain identifier referenced exactly once later in the fn.
+
+    Tuple unpacking, attribute, and subscript targets are excluded; names
+    starting with ``_`` are ignored.
+    """
+    flagged: set[int] = set()
+    for func in _iter_tree(root):
+        if func.type != "function_definition":
+            continue
+        for node in _iter_function(func):
+            if node.type != "assignment":
+                continue
+            target = node.child_by_field_name("left")
+            if target is None or target.type != "identifier":
+                continue
+            name = target.text.decode()
+            if name.startswith("_"):
+                continue
+            if _count_later_references(func, name, node.start_point.row) == 1:
+                flagged.add(node.start_point.row)
+    return flagged
+
+
+def _return_value(return_node: Any) -> Any | None:
+    """The expression a ``return`` yields (the ``return`` keyword is a token)."""
+    for child in return_node.children:
+        if child.type != "return":
+            return child
+    return None
+
+
+def _trivial_wrapper(func: Any) -> set[int] | None:
+    """Flag a function whose whole body is ``return other(same args)``."""
+    body = func.child_by_field_name("body")
+    if body is None:
+        return None
+    statements = list(body.children)
+    if len(statements) != 1 or statements[0].type != "return_statement":
+        return None
+    value = _return_value(statements[0])
+    if value is None or value.type != "call":
+        return None
+    fn_name = value.child_by_field_name("function")
+    args = value.child_by_field_name("arguments")
+    params = func.child_by_field_name("parameters")
+    if fn_name is None or fn_name.type != "identifier" or args is None or params is None:
+        return None
+    param_names = [child.text.decode() for child in params.children if child.type == "identifier"]
+    arg_names = [child.text.decode() for child in args.children if child.type == "identifier"]
+    if param_names == arg_names:
+        return set(range(func.start_point.row, func.end_point.row + 1))
+    return None
+
+
+def _trivial_wrapper_lines(root: Any) -> set[int]:
+    flagged: set[int] = set()
+    for func in _iter_tree(root):
+        if func.type != "function_definition":
+            continue
+        lines = _trivial_wrapper(func)
+        if lines is not None:
+            flagged.update(lines)
+    return flagged
+
+
+def _direct_nested_ifs(if_node: Any) -> list[Any]:
+    """Direct ``if`` children of *if_node*'s consequence/alternative blocks."""
+    nested: list[Any] = []
+    consequence = if_node.child_by_field_name("consequence")
+    if consequence is not None:
+        nested.extend(child for child in consequence.children if child.type == "if_statement")
+    alternative = if_node.child_by_field_name("alternative")
+    if alternative is not None and alternative.type in ("elif_clause", "else_clause"):
+        block = alternative.child_by_field_name("consequence") or alternative.child_by_field_name("body")
+        if block is not None:
+            nested.extend(child for child in block.children if child.type == "if_statement")
+    return nested
+
+
+def _nested_ladder_lines(root: Any) -> set[int]:
+    """Innermost ``if`` of any ≥3-deep directly-nested if ladder."""
+    flagged: set[int] = set()
+
+    def visit(if_node: Any, depth: int) -> None:
+        nested = _direct_nested_ifs(if_node)
+        if nested:
+            for child in nested:
+                visit(child, depth + 1)
+        elif depth >= 3:
+            flagged.update(range(if_node.start_point.row, if_node.end_point.row + 1))
+
+    for node in _iter_tree(root):
+        if node.type == "if_statement":
+            visit(node, 1)
+    return flagged
+
+
+def _clone_flagged_lines(lines: list[str]) -> set[int]:
+    """Line rows in ≥2 occurrences of an identical contiguous block (3..20 lines).
+
+    Lines are normalized by stripping; blocks containing blank lines are
+    skipped so whitespace runs are never counted as clones.
+    """
+    stripped = [line.strip() for line in lines]
+    n = len(stripped)
+    flagged: set[int] = set()
+    for length in range(_MIN_CLONE_BLOCK, _MAX_CLONE_BLOCK + 1):
+        if length > n:
+            break
+        by_first: dict[str, list[int]] = {}
+        for i in range(n - length + 1):
+            if any(not stripped[j] for j in range(i, i + length)):
+                continue
+            by_first.setdefault(stripped[i], []).append(i)
+        for starts in by_first.values():
+            if len(starts) < 2:
+                continue
+            by_block: dict[tuple[str, ...], list[int]] = {}
+            for i in starts:
+                by_block.setdefault(tuple(stripped[i : i + length]), []).append(i)
+            for occurrences in by_block.values():
+                if len(occurrences) < 2:
+                    continue
+                for i in occurrences:
+                    flagged.update(range(i, i + length))
+    return flagged
+
+
+def analyze_quality(daydream_dir: str | Path) -> dict:
+    """Structural erosion and verbosity of the post-fix workspace (issue #316).
+
+    Computes SlopCodeBench-style metrics (arXiv:2603.24755) over every scoped
+    ``*.py`` file in ``daydream_dir.parent`` — the live reviewed tree at eval
+    time, after daydream's fix phase ran. Pure and deterministic: no backend,
+    no network, no randomness. A file whose tree-sitter parse fails is counted
+    in ``scoped_files`` but excluded from the aggregates.
+
+    Returns:
+        ``{erosion, verbosity, per_file, calibration, scoped_files}``.
+        ``erosion``/``verbosity`` are ``None`` only when no functions / no
+        lines are in scope; ``per_file`` keys are workspace-relative paths.
+    """
+    daydream_dir = Path(daydream_dir)
+    workspace = daydream_dir.parent
+
+    per_file: dict[str, dict] = {}
+    total_mass = 0.0
+    high_mass = 0.0
+    total_flagged = 0
+    total_loc = 0
+    scoped = 0
+
+    for path, rel in _scoped_python_files(workspace):
+        scoped += 1
+        quality = _file_quality(path)
+        if quality is None:
+            continue
+        per_file[rel] = quality["entry"]
+        total_mass += quality["mass"]
+        high_mass += quality["high_mass"]
+        total_flagged += quality["flagged"]
+        total_loc += quality["loc"]
+
+    return {
+        "erosion": round(high_mass / total_mass, 4) if total_mass > 0 else None,
+        "verbosity": round(total_flagged / total_loc, 4) if total_loc > 0 else None,
+        "per_file": per_file,
+        "calibration": dict(_QUALITY_CALIBRATION),
+        "scoped_files": scoped,
+    }
+
+
 # Top-level entry point
 
 def analyze_session(daydream_dir: str | Path, session_id: str | None = None) -> dict:
@@ -774,6 +1229,7 @@ def analyze_session(daydream_dir: str | Path, session_id: str | None = None) -> 
     training = analyze_training_signals(
         trajectories, findings_data["findings"], grounding,
     )
+    quality = analyze_quality(daydream_dir)
 
     finding_count = findings_data["total"]
     cost_per_finding = (
@@ -801,6 +1257,7 @@ def analyze_session(daydream_dir: str | Path, session_id: str | None = None) -> 
         "grounding": grounding,
         "exploration_utilization": exploration,
         "training_signals": training,
+        "quality": quality,
         "derived": {
             "cost_per_finding_usd": cost_per_finding,
         },

--- a/daydream/eval/analyzer.py
+++ b/daydream/eval/analyzer.py
@@ -749,6 +749,9 @@ _QUALITY_EXCLUDED_DIRS = frozenset(
     {
         ".git", ".daydream", "node_modules", ".venv", "venv", "__pycache__", ".worktrees",
         "dist", "build", "vendor", "third_party", "migrations",
+        # ``atif`` is daydream/atif, explicitly vendored from Harbor
+        # (see daydream/atif/NOTICE) — out of metric scope (Finding #5).
+        "atif",
     }
 )
 
@@ -870,7 +873,9 @@ def _scoped_python_files(workspace: Path) -> list[tuple[Path, str]]:
 
     Excluded directories are matched on exact path components so a nested
     ``node_modules_extra/`` or a sibling ``.worktrees`` checkout never shadows
-    real source. Generated files are also out of scope: path-based rules
+    real source. Vendored subtrees with non-obvious basenames (``atif``, see
+    ``daydream/atif/NOTICE``) are excluded by name too. Generated files are
+    also out of scope: path-based rules
     (``*_generated.py``, ``*.pb.py``, ``migrations/*.py``, …) and the
     generated-file header marker are both applied via ``is_generated_file``,
     so vendor/third_party trees and generated artifacts never reach the
@@ -894,21 +899,14 @@ def _scoped_python_files(workspace: Path) -> list[tuple[Path, str]]:
     return sorted(files, key=lambda item: item[1])
 
 
-def _file_quality(
-    path: Path,
-    cross_file_flagged: set[int] | None = None,
-) -> dict | None:
-    """Erosion + verbosity metrics for one Python file, or ``None`` on parse failure.
+def _parse_python_file(path: Path) -> tuple[Any, list[str]] | None:
+    """Parse *path* once; return ``(root, lines)`` or ``None`` on any failure.
 
     A file that cannot be parsed is counted in ``scoped_files`` by the caller
-    but excluded from the aggregates — quality analysis never crashes. Tree-sitter
-    returns a PARTIAL tree with ERROR/missing nodes for malformed Python, so a
-    root whose tree carries any error is treated as a parse failure instead of
-    aggregating garbage (Finding #9).
-
-    *cross_file_flagged* carries line rows (0-based) that duplicate a block also
-    present in another scoped file; they are OR'd into the verbosity set before
-    the ratio is computed (Finding #6).
+    but excluded from the aggregates — quality analysis never crashes.
+    Tree-sitter returns a PARTIAL tree with ERROR/missing nodes for malformed
+    Python, so a root whose tree carries any error is treated as a parse
+    failure instead of aggregating garbage (Finding #9).
     """
     parser = _quality_python_parser()
     if parser is None:
@@ -926,7 +924,26 @@ def _file_quality(
     root = tree.root_node
     if root.has_error:
         return None
+    lines = source.decode("utf-8", errors="replace").splitlines()
+    return root, lines
 
+
+def _file_quality_from_tree(
+    root: Any,
+    lines: list[str],
+    cross_file_flagged: set[int] | None = None,
+) -> dict:
+    """Erosion + verbosity metrics from an already-parsed file.
+
+    *cross_file_flagged* carries line rows (0-based) that duplicate a block also
+    present in another scoped file; they are OR'd into the verbosity set before
+    the ratio is computed (Finding #6).
+
+    Per-file ratios are ``None`` when their denominator is zero: ``erosion``
+    with no functions, ``verbosity`` with no non-blank lines. The numeric mass
+    and line counts are still returned so the caller can pool them for the
+    workspace aggregate (Finding #2).
+    """
     # Erosion: pooled cyclomatic mass of functions with CC > 10.
     functions = [node for node in _iter_tree(root) if node.type == "function_definition"]
     metrics: list[tuple[int, int, float]] = []  # (cc, sloc, mass)
@@ -940,22 +957,21 @@ def _file_quality(
 
     total_mass = sum(mass for _, _, mass in metrics)
     high_mass = sum(mass for cc, _, mass in metrics if cc > 10)
-    erosion = high_mass / total_mass if total_mass > 0 else 0.0
+    erosion = high_mass / total_mass if total_mass > 0 else None
 
     # Verbosity: deterministic rule subset + clone detection over lines.
-    lines = source.decode("utf-8", errors="replace").splitlines()
     sloc_file = sum(1 for line in lines if line.strip())
     flagged = _verbosity_flagged_lines(root)
     flagged |= _clone_flagged_lines(lines)
     if cross_file_flagged:
         flagged |= cross_file_flagged
     flagged &= {i for i, line in enumerate(lines) if line.strip()}
-    verbosity = len(flagged) / sloc_file if sloc_file > 0 else 0.0
+    verbosity = len(flagged) / sloc_file if sloc_file > 0 else None
 
     return {
         "entry": {
-            "erosion": round(erosion, 4),
-            "verbosity": round(verbosity, 4),
+            "erosion": round(erosion, 4) if erosion is not None else None,
+            "verbosity": round(verbosity, 4) if verbosity is not None else None,
             "sloc": sloc_file,
             "functions": len(metrics),
             "high_cc_functions": sum(1 for cc, _, _ in metrics if cc > 10),
@@ -1054,22 +1070,22 @@ def _empty_guard_variable(if_node: Any) -> str | None:
     return None
 
 
-def _is_len_call(node: Any, name: str) -> bool:
-    """``len(name)`` — a ``len`` call with exactly the single argument *name*."""
+def _len_call_argument(node: Any) -> str | None:
+    """The single argument name of a ``len(x)`` call, else ``None``."""
     if node is None or node.type != "call":
-        return False
+        return None
     fn = node.child_by_field_name("function")
     args = node.child_by_field_name("arguments")
-    if fn is None or fn.type != "identifier" or fn.text.decode() != "len":
-        return False
-    if args is None:
-        return False
+    if fn is None or fn.type != "identifier" or fn.text.decode() != "len" or args is None:
+        return None
     arg_ids = [child for child in args.children if child.type == "identifier"]
-    return len(arg_ids) == 1 and arg_ids[0].text.decode() == name
+    if len(arg_ids) == 1:
+        return arg_ids[0].text.decode()
+    return None
 
 
-def _while_condition_proves_nonempty(condition: Any, name: str) -> bool:
-    """Does the *condition* prove *name* is a nonempty collection?
+def _empty_guard_collection(condition: Any) -> str | None:
+    """The collection a ``while`` condition proves nonempty, else ``None``.
 
     Only exact shapes prove it: the bare collection (``while items:``), a
     bare ``len`` call (``while len(items):``), or a positive length
@@ -1078,25 +1094,51 @@ def _while_condition_proves_nonempty(condition: Any, name: str) -> bool:
     may be required.
     """
     if condition is None:
-        return False
+        return None
     if condition.type == "identifier":
-        return condition.text.decode() == name
-    if _is_len_call(condition, name):
-        return True
+        return condition.text.decode()
+    name = _len_call_argument(condition)
+    if name is not None:
+        return name
     if condition.type == "comparison_operator":
         operands = list(condition.children)
         if len(operands) == 3 and operands[1].type == ">":
             left, _, right = operands
-            return (
-                _is_len_call(left, name)
-                and right.type == "integer"
-                and right.text.decode().strip() == "0"
-            )
+            if right.type == "integer" and right.text.decode().strip() == "0":
+                return _len_call_argument(left)
+    return None
+
+
+def _statement_mutates(node: Any, name: str) -> bool:
+    """May *node* mutate the collection *name*?
+
+    A method call on the collection (``items.pop()``, ``items.clear()``,
+    ``items.remove()``, …) or a reassignment of *name* invalidates the
+    loop-header's nonemptiness proof, so a later empty guard is meaningful.
+    """
+    for sub in _iter_tree(node):
+        if sub.type in ("assignment", "augmented_assignment"):
+            target = sub.child_by_field_name("left")
+            if target is not None and target.type == "identifier" and target.text.decode() == name:
+                return True
+        if sub.type == "call":
+            fn = sub.child_by_field_name("function")
+            if fn is not None and fn.type == "attribute":
+                obj = fn.child_by_field_name("object")
+                if obj is not None and obj.type == "identifier" and obj.text.decode() == name:
+                    return True
     return False
 
 
 def _empty_list_guard_lines(root: Any) -> set[int]:
-    """``if len(x) == 0`` / ``if not x`` guard directly inside a loop over ``x``."""
+    """``if len(x) == 0`` / ``if not x`` guard directly inside a loop over ``x``.
+
+    The guard is redundant only at a program point where the loop header's
+    nonemptiness proof still holds. A statement between the header and the
+    guard that may mutate the collection (``items.pop()``, ``items.clear()``,
+    reassignment) invalidates that proof, so the guard is a necessary
+    post-mutation termination check and is not flagged (Finding #3).
+    """
     flagged: set[int] = set()
     for node in _iter_tree(root):
         if node.type not in ("for_statement", "while_statement"):
@@ -1104,22 +1146,23 @@ def _empty_list_guard_lines(root: Any) -> set[int]:
         body = node.child_by_field_name("body")
         if body is None:
             continue
+        if node.type == "for_statement":
+            iterable = node.child_by_field_name("right")
+            if iterable is None or iterable.type != "identifier":
+                continue
+            guarded = iterable.text.decode()
+        else:
+            guarded = _empty_guard_collection(node.child_by_field_name("condition"))
+            if guarded is None:
+                continue
+        mutated = False
         for child in body.children:
-            if child.type != "if_statement":
-                continue
-            guard_var = _empty_guard_variable(child)
-            if guard_var is None:
-                continue
-            if node.type == "for_statement":
-                iterable = node.child_by_field_name("right")
-                if (
-                    iterable is not None
-                    and iterable.type == "identifier"
-                    and iterable.text.decode() == guard_var
-                ):
+            if child.type == "if_statement":
+                guard_var = _empty_guard_variable(child)
+                if guard_var == guarded and not mutated:
                     flagged.update(range(child.start_point.row, child.end_point.row + 1))
-            elif _while_condition_proves_nonempty(node.child_by_field_name("condition"), guard_var):
-                flagged.update(range(child.start_point.row, child.end_point.row + 1))
+            if _statement_mutates(child, guarded):
+                mutated = True
     return flagged
 
 
@@ -1220,12 +1263,26 @@ def _forwarded_argument_names(args: Any) -> list[str] | None:
     return names
 
 
+def _is_docstring_statement(node: Any) -> bool:
+    """An ``expression_statement`` whose whole content is a string literal."""
+    if node.type != "expression_statement":
+        return False
+    contents = [child for child in node.children if child.type != ";"]
+    return len(contents) == 1 and contents[0].type == "string"
+
+
 def _trivial_wrapper(func: Any) -> set[int] | None:
-    """Flag a function whose whole body is ``return other(same args)``."""
+    """Flag a function whose whole body is ``return other(same args)``.
+
+    A leading function-docstring is not an executable statement, so a
+    pass-through wrapper with a docstring is still a wrapper (Finding #4).
+    """
     body = func.child_by_field_name("body")
     if body is None:
         return None
     statements = list(body.children)
+    if statements and _is_docstring_statement(statements[0]):
+        statements = statements[1:]
     if len(statements) != 1 or statements[0].type != "return_statement":
         return None
     value = _return_value(statements[0])
@@ -1370,12 +1427,16 @@ def analyze_quality(daydream_dir: str | Path) -> dict:
     ``*.py`` file in ``daydream_dir.parent`` — the live reviewed tree at eval
     time, after daydream's fix phase ran. Pure and deterministic: no backend,
     no network, no randomness. A file whose tree-sitter parse fails is counted
-    in ``scoped_files`` but excluded from the aggregates.
+    in ``scoped_files`` but excluded from the aggregates and from the
+    cross-file clone index, so malformed source never shifts valid files'
+    verbosity (Finding #1).
 
     Returns:
         ``{erosion, verbosity, per_file, calibration, scoped_files}``.
         ``erosion``/``verbosity`` are ``None`` only when no functions / no
-        lines are in scope; ``per_file`` keys are workspace-relative paths.
+        lines are in scope; per-file entries use ``None`` for a ratio whose
+        denominator is zero (no functions / no non-blank lines). ``per_file``
+        keys are workspace-relative paths.
     """
     daydream_dir = Path(daydream_dir)
     workspace = daydream_dir.parent
@@ -1383,17 +1444,27 @@ def analyze_quality(daydream_dir: str | Path) -> dict:
     scoped_files = _scoped_python_files(workspace)
     scoped = len(scoped_files)
 
-    # Cross-file clone pass: read every scoped file's lines once and find
-    # blocks duplicated verbatim across >=2 files, then feed each file's
-    # cross-file line rows into its per-file verbosity below (Finding #6).
-    # Within-file duplicates are still handled per file inside _file_quality.
+    # Parse and validate every scoped file ONCE. Only successfully parsed
+    # files feed the cross-file clone index and the per-file aggregates; a
+    # malformed file stays in ``scoped_files`` but its lines can no longer
+    # flag matching blocks in valid files (Finding #1). The parse results are
+    # reused below, so no file is ever parsed twice.
+    parsed: dict[Path, Any] = {}
+    parsed_lines: dict[Path, list[str]] = {}
     file_lines: list[tuple[Path, list[str]]] = []
     for path, _rel in scoped_files:
-        try:
-            source = path.read_bytes()
-        except OSError:
+        result = _parse_python_file(path)
+        if result is None:
             continue
-        file_lines.append((path, source.decode("utf-8", errors="replace").splitlines()))
+        root, lines = result
+        parsed[path] = root
+        parsed_lines[path] = lines
+        file_lines.append((path, lines))
+
+    # Cross-file clone pass over successfully parsed files only: find blocks
+    # duplicated verbatim across >=2 files, then feed each file's cross-file
+    # line rows into its per-file verbosity below (Finding #6). Within-file
+    # duplicates are still handled per file inside _file_quality_from_tree.
     cross_file_flagged = _cross_file_clone_flagged_lines(file_lines)
 
     per_file: dict[str, dict] = {}
@@ -1403,9 +1474,14 @@ def analyze_quality(daydream_dir: str | Path) -> dict:
     total_loc = 0
 
     for path, rel in scoped_files:
-        quality = _file_quality(path, cross_file_flagged=cross_file_flagged.get(path))
-        if quality is None:
+        root = parsed.get(path)
+        if root is None:
             continue
+        quality = _file_quality_from_tree(
+            root,
+            parsed_lines[path],
+            cross_file_flagged=cross_file_flagged.get(path),
+        )
         per_file[rel] = quality["entry"]
         total_mass += quality["mass"]
         high_mass += quality["high_mass"]

--- a/daydream/eval/analyzer.py
+++ b/daydream/eval/analyzer.py
@@ -762,6 +762,7 @@ _CC_DECISION_TYPES = frozenset(
         "conditional_expression",
         "boolean_operator",
         "case_clause",
+        "for_in_clause",
     }
 )
 
@@ -818,9 +819,34 @@ def _iter_function(func: Any) -> Iterator[Any]:
         stack.extend(reversed(node.children))
 
 
+def _is_comprehension_filter(node: Any) -> bool:
+    """An ``if_clause`` attached to a comprehension, not a match-case guard."""
+    parent = node.parent
+    if parent is None:
+        return False
+    if parent.type in _COMPREHENSION_TYPES:
+        return True
+    grandparent = parent.parent
+    return grandparent is not None and grandparent.type in _COMPREHENSION_TYPES
+
+
+def _is_wildcard_case(node: Any) -> bool:
+    """A ``case _:`` clause (no guard) — matches any value, adds no path."""
+    if node.type != "case_clause":
+        return False
+    if node.child_by_field_name("guard") is not None:
+        return False
+    pattern = next((c for c in node.children if c.type == "case_pattern"), None)
+    return pattern is not None and pattern.text.decode().strip() == "_"
+
+
 def _count_decision_nodes(node: Any) -> int:
     """Cyclomatic decision count of a subtree, skipping nested functions."""
     total = 1 if node.type in _CC_DECISION_TYPES else 0
+    if node.type == "case_clause" and _is_wildcard_case(node):
+        total -= 1
+    elif node.type == "if_clause" and _is_comprehension_filter(node):
+        total += 1
     for child in node.children:
         if child.type == "function_definition":
             continue
@@ -888,6 +914,7 @@ def _file_quality(path: Path) -> dict | None:
     sloc_file = sum(1 for line in lines if line.strip())
     flagged = _verbosity_flagged_lines(root)
     flagged |= _clone_flagged_lines(lines)
+    flagged &= {i for i, line in enumerate(lines) if line.strip()}
     verbosity = len(flagged) / sloc_file if sloc_file > 0 else 0.0
 
     return {
@@ -925,16 +952,31 @@ def _comprehension_body(node: Any) -> Any | None:
 
 
 def _identity_comprehension_lines(root: Any) -> set[int]:
-    """``[x for x in items]``-style comprehensions whose output is the loop var."""
+    """``[x for x in items]``-style comprehensions whose output is the loop var.
+
+    Only a single unfiltered generator whose body is exactly the generator
+    target qualifies; a filter or extra generator means the comprehension
+    does real work and is never flagged.
+    """
     flagged: set[int] = set()
     for node in _iter_tree(root):
         if node.type not in _COMPREHENSION_TYPES:
             continue
         for_clauses = [child for child in node.children if child.type == "for_in_clause"]
-        if not for_clauses:
+        if len(for_clauses) != 1:
             continue
         target = for_clauses[0].child_by_field_name("left")
         if target is None or target.type != "identifier":
+            continue
+        has_filter = any(
+            child.type == "if_clause"
+            or (
+                child.type == "for_in_clause"
+                and any(grandchild.type == "if_clause" for grandchild in child.children)
+            )
+            for child in node.children
+        )
+        if has_filter:
             continue
         body = _comprehension_body(node)
         if body is not None and body.text == target.text:
@@ -973,13 +1015,45 @@ def _empty_guard_variable(if_node: Any) -> str | None:
     return None
 
 
-def _tree_contains_identifier(node: Any, name: str) -> bool:
-    if node is None:
+def _is_len_call(node: Any, name: str) -> bool:
+    """``len(name)`` — a ``len`` call with exactly the single argument *name*."""
+    if node is None or node.type != "call":
         return False
-    return any(
-        n.type == "identifier" and n.text.decode() == name
-        for n in _iter_tree(node)
-    )
+    fn = node.child_by_field_name("function")
+    args = node.child_by_field_name("arguments")
+    if fn is None or fn.type != "identifier" or fn.text.decode() != "len":
+        return False
+    if args is None:
+        return False
+    arg_ids = [child for child in args.children if child.type == "identifier"]
+    return len(arg_ids) == 1 and arg_ids[0].text.decode() == name
+
+
+def _while_condition_proves_nonempty(condition: Any, name: str) -> bool:
+    """Does the *condition* prove *name* is a nonempty collection?
+
+    Only exact shapes prove it: the bare collection (``while items:``), a
+    bare ``len`` call (``while len(items):``), or a positive length
+    comparison (``while len(items) > 0:``). A predicate that merely receives
+    the collection (``while should_continue(items):``) does not, so the guard
+    may be required.
+    """
+    if condition is None:
+        return False
+    if condition.type == "identifier":
+        return condition.text.decode() == name
+    if _is_len_call(condition, name):
+        return True
+    if condition.type == "comparison_operator":
+        operands = list(condition.children)
+        if len(operands) == 3 and operands[1].type == ">":
+            left, _, right = operands
+            return (
+                _is_len_call(left, name)
+                and right.type == "integer"
+                and right.text.decode().strip() == "0"
+            )
+    return False
 
 
 def _empty_list_guard_lines(root: Any) -> set[int]:
@@ -1005,7 +1079,7 @@ def _empty_list_guard_lines(root: Any) -> set[int]:
                     and iterable.text.decode() == guard_var
                 ):
                     flagged.update(range(child.start_point.row, child.end_point.row + 1))
-            elif _tree_contains_identifier(node.child_by_field_name("condition"), guard_var):
+            elif _while_condition_proves_nonempty(node.child_by_field_name("condition"), guard_var):
                 flagged.update(range(child.start_point.row, child.end_point.row + 1))
     return flagged
 
@@ -1053,6 +1127,60 @@ def _return_value(return_node: Any) -> Any | None:
     return None
 
 
+def _param_definitions(params: Any) -> list[tuple[str, bool]] | None:
+    """Ordered ``(name, has_default)`` per parameter, or ``None`` if complex.
+
+    ``None`` covers positional-only ``/``, keyword-only ``*``, ``*args``, and
+    ``**kwargs``: a wrapper cannot forward those as plain positional names.
+    """
+    definitions: list[tuple[str, bool]] = []
+    for child in params.children:
+        if child.type in (",", "(", ")"):
+            continue
+        if child.type in (
+            "/",
+            "*",
+            "**",
+            "positional_separator",
+            "keyword_separator",
+            "list_splat",
+            "dictionary_splat",
+        ):
+            return None
+        if child.type == "identifier":
+            definitions.append((child.text.decode(), False))
+        elif child.type == "typed_parameter":
+            name = next((c for c in child.children if c.type == "identifier"), None)
+            if name is None:
+                return None
+            definitions.append((name.text.decode(), False))
+        elif child.type in ("default_parameter", "typed_default_parameter"):
+            name = child.child_by_field_name("name")
+            if name is None or name.type != "identifier":
+                return None
+            definitions.append((name.text.decode(), True))
+        else:
+            return None
+    return definitions
+
+
+def _forwarded_argument_names(args: Any) -> list[str] | None:
+    """Positional argument names of a call, or ``None`` if not plain identifiers.
+
+    A literal, keyword, ``*args``/``**kwargs``, or any other non-identifier
+    argument makes the call non-trivial (``None``).
+    """
+    names: list[str] = []
+    for child in args.children:
+        if child.type in (",", "(", ")"):
+            continue
+        if child.type == "identifier":
+            names.append(child.text.decode())
+        else:
+            return None
+    return names
+
+
 def _trivial_wrapper(func: Any) -> set[int] | None:
     """Flag a function whose whole body is ``return other(same args)``."""
     body = func.child_by_field_name("body")
@@ -1069,11 +1197,17 @@ def _trivial_wrapper(func: Any) -> set[int] | None:
     params = func.child_by_field_name("parameters")
     if fn_name is None or fn_name.type != "identifier" or args is None or params is None:
         return None
-    param_names = [child.text.decode() for child in params.children if child.type == "identifier"]
-    arg_names = [child.text.decode() for child in args.children if child.type == "identifier"]
-    if param_names == arg_names:
-        return set(range(func.start_point.row, func.end_point.row + 1))
-    return None
+    param_defs = _param_definitions(params)
+    arg_names = _forwarded_argument_names(args)
+    if param_defs is None or arg_names is None:
+        return None
+    if len(param_defs) != len(arg_names):
+        return None
+    if any(has_default for _, has_default in param_defs):
+        return None
+    if [name for name, _ in param_defs] != arg_names:
+        return None
+    return set(range(func.start_point.row, func.end_point.row + 1))
 
 
 def _trivial_wrapper_lines(root: Any) -> set[int]:

--- a/docs/evaluation-framework.md
+++ b/docs/evaluation-framework.md
@@ -276,6 +276,36 @@ Operational metrics informed by Atlassian RovoDev's production deployment metric
 
 ---
 
+## Quality Metrics (Erosion & Verbosity)
+
+Deterministic post-fix quality metrics computed on the reviewed workspace at
+archive/eval time, recorded under `quality` in `evaluation.json` and summarized
+as `erosion`/`verbosity` scalars in `manifest.json` metrics. Python stack only —
+the SlopCodeBench paper defines the metrics on Python code.
+
+**Erosion.** Cyclomatic mass share concentrated in high-complexity functions:
+
+```
+mass(f) = CC(f) × √SLOC(f)
+erosion = Σ_{f: CC(f) > 10} mass(f) / Σ_f mass(f)
+```
+
+CC counts decision nodes (if/elif, for, while, except, with, assert, ternary,
+boolean operators, match arms) via tree-sitter; SLOC is the function's raw line
+span. Per-file and per-run ratios; `None` when no functions are in scope.
+
+**Verbosity.** A deterministic subset of the 137-rule ast-grep taxonomy plus
+clone detection, implemented as a line-tagging pass: identity comprehensions,
+empty-list guards inside loops, single-use intermediate variables, trivial
+wrappers, nested if ladders (≥3 deep), and exact-duplicate contiguous line
+blocks (≥3 lines). `verbosity = flagged lines / non-blank lines`, pooled per
+file and per run; `None` when no lines are in scope.
+
+Human-panel calibration from the paper: verbosity 0.19, erosion 0.34. These are
+reference anchors, not thresholds.
+
+---
+
 ## Additional Benchmarks (Optional for v1)
 
 | Benchmark | Why | N | Source |

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -10,6 +10,7 @@ undefined (zero-findings) case, which must not report a perfect score.
 """
 
 import json
+import math
 from pathlib import Path
 
 import pytest
@@ -20,6 +21,8 @@ from daydream.eval.analyzer import (
     analyze_costs,
     analyze_coverage,
     analyze_grounding,
+    analyze_quality,
+    analyze_session,
     load_trajectories,
 )
 from daydream.trajectory import DaydreamPhase, DaydreamRunFlow, TrajectoryRecorder
@@ -378,3 +381,281 @@ def test_analyze_grounding_counts_codex_and_pi_reads():
     assert result["grounded_count"] == 1
     assert result["ungrounded_count"] == 0
     assert result["grounding_rate"] == 1.0
+
+
+# --- quality metrics (issue #316) ---
+
+
+def _quality_workspace(tmp_path: Path, files: dict[str, str], name: str = "workspace") -> Path:
+    """Create a temp workspace with the given ``{relative_path: content}`` files."""
+    ws = tmp_path / name
+    ws.mkdir(parents=True)
+    for rel, content in files.items():
+        target = ws / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content)
+    return ws
+
+
+def _big_function(max_x: int) -> str:
+    """A single-function if/elif chain reaching ``max_x``.
+
+    ``big`` has ``max_x + 1`` cyclomatic complexity (1 + the ``if`` + every
+    ``elif``) and ``2 * max_x + 2`` sloc lines.
+    """
+    lines = ["def big(x):", "    if x == 1:", "        return 1"]
+    for i in range(2, max_x + 1):
+        lines.append(f"    elif x == {i}:")
+        lines.append(f"        return {i}")
+    lines.append("    return 0")
+    return "\n".join(lines) + "\n"
+
+
+def _mass(cc: int, sloc: int) -> float:
+    return cc * math.sqrt(sloc)
+
+
+def test_quality_erosion_computes_cc_mass_share(tmp_path: Path):
+    """Pooled erosion is the high-CC mass share, hand-computed from the file."""
+    ws = _quality_workspace(
+        tmp_path,
+        {"app.py": "def small(x):\n    return x * 2\n\n" + _big_function(11)},
+    )
+
+    result = analyze_quality(ws / ".daydream")
+
+    small_mass = _mass(1, 2)
+    big_mass = _mass(12, 24)
+    expected = round(big_mass / (small_mass + big_mass), 4)
+    assert result["erosion"] == pytest.approx(expected)
+    entry = result["per_file"]["app.py"]
+    assert entry["erosion"] == pytest.approx(expected)
+    assert entry["functions"] == 2
+    assert entry["high_cc_functions"] == 1
+
+
+def test_quality_erosion_zero_when_no_high_cc(tmp_path: Path):
+    ws = _quality_workspace(
+        tmp_path,
+        {"app.py": "def one(x):\n    return x + 1\n\ndef two(x, y):\n    return x + y\n"},
+    )
+
+    result = analyze_quality(ws / ".daydream")
+
+    assert result["erosion"] == 0.0
+    assert result["per_file"]["app.py"]["erosion"] == 0.0
+    assert result["per_file"]["app.py"]["high_cc_functions"] == 0
+
+
+def test_quality_verbosity_flags_identity_comprehension(tmp_path: Path):
+    ws = _quality_workspace(tmp_path, {"app.py": "def f(items):\n    return [x for x in items]\n"})
+
+    result = analyze_quality(ws / ".daydream")
+
+    entry = result["per_file"]["app.py"]
+    assert entry["verbosity"] > 0
+    assert entry["verbosity"] == pytest.approx(1 / 2)
+
+
+def test_quality_verbosity_flags_empty_list_guard(tmp_path: Path):
+    ws = _quality_workspace(
+        tmp_path,
+        {
+            "app.py": (
+                "def process(items):\n"
+                "    for x in items:\n"
+                "        if len(items) == 0:\n"
+                "            return None\n"
+                "        print(x)\n"
+            )
+        },
+    )
+
+    result = analyze_quality(ws / ".daydream")
+
+    entry = result["per_file"]["app.py"]
+    assert entry["verbosity"] > 0
+    assert entry["verbosity"] == pytest.approx(2 / 5)
+
+
+def test_quality_verbosity_flags_single_use_variable(tmp_path: Path):
+    ws = _quality_workspace(
+        tmp_path,
+        {
+            "app.py": (
+                "def compute(x):\n"
+                "    intermediate = x + 1\n"
+                "    return intermediate * 2\n"
+            )
+        },
+    )
+
+    result = analyze_quality(ws / ".daydream")
+
+    entry = result["per_file"]["app.py"]
+    assert entry["verbosity"] > 0
+    assert entry["verbosity"] == pytest.approx(round(1 / 3, 4))
+
+
+def test_quality_verbosity_flags_trivial_wrapper(tmp_path: Path):
+    ws = _quality_workspace(
+        tmp_path,
+        {
+            "app.py": (
+                "def inner(x, y):\n"
+                "    return x + y\n"
+                "\n"
+                "def outer(x, y):\n"
+                "    return inner(x, y)\n"
+            )
+        },
+    )
+
+    result = analyze_quality(ws / ".daydream")
+
+    entry = result["per_file"]["app.py"]
+    assert entry["verbosity"] > 0
+    assert entry["verbosity"] == pytest.approx(2 / 4)
+
+
+def test_quality_verbosity_flags_nested_ladder(tmp_path: Path):
+    ws = _quality_workspace(
+        tmp_path,
+        {
+            "app.py": (
+                "def f(a, b, c):\n"
+                "    if a:\n"
+                "        if b:\n"
+                "            if c:\n"
+                "                return 1\n"
+                "    return 0\n"
+            )
+        },
+    )
+
+    result = analyze_quality(ws / ".daydream")
+
+    entry = result["per_file"]["app.py"]
+    assert entry["verbosity"] > 0
+    assert entry["verbosity"] == pytest.approx(round(2 / 6, 4))
+
+
+def test_quality_verbosity_flags_clone_block(tmp_path: Path):
+    ws = _quality_workspace(
+        tmp_path,
+        {
+            "app.py": (
+                "def a():\n"
+                "    if x > 1:\n"
+                "        return 1\n"
+                "    return 0\n"
+                "\n"
+                "def b():\n"
+                "    if x > 1:\n"
+                "        return 1\n"
+                "    return 0\n"
+            )
+        },
+    )
+
+    result = analyze_quality(ws / ".daydream")
+
+    entry = result["per_file"]["app.py"]
+    assert entry["verbosity"] > 0
+    assert entry["verbosity"] == pytest.approx(6 / 8)
+
+
+def test_quality_per_file_keyed_by_relative_path(tmp_path: Path):
+    ws = _quality_workspace(tmp_path, {"pkg/mod.py": "def f(x):\n    return x\n"})
+
+    result = analyze_quality(ws / ".daydream")
+
+    assert "pkg/mod.py" in result["per_file"]
+    assert result["per_file"]["pkg/mod.py"]["functions"] == 1
+
+
+def test_quality_returns_none_when_no_python_files(tmp_path: Path):
+    ws = _quality_workspace(tmp_path, {"README.md": "# nothing here\n"})
+
+    result = analyze_quality(ws / ".daydream")
+
+    assert result["erosion"] is None
+    assert result["verbosity"] is None
+    assert result["scoped_files"] == 0
+    assert result["per_file"] == {}
+    assert result["calibration"] == {
+        "human_verbosity": 0.19,
+        "human_erosion": 0.34,
+        "paper": "arXiv:2603.24755",
+    }
+
+
+def test_quality_excludes_vendored_and_internal_dirs(tmp_path: Path):
+    ws = _quality_workspace(
+        tmp_path,
+        {
+            "app.py": "def f(x):\n    return x\n",
+            ".daydream/deep/fixture.py": "def g(x):\n    return x\n",
+            "node_modules/pkg/index.py": "def h(x):\n    return x\n",
+            "sub/venv/lib/x.py": "def i(x):\n    return x\n",
+        },
+    )
+
+    result = analyze_quality(ws / ".daydream")
+
+    assert result["scoped_files"] == 1
+    assert list(result["per_file"]) == ["app.py"]
+
+
+def test_quality_monotone_across_eroding_fix(tmp_path: Path):
+    """An eroding fix to an already-large function raises erosion (verbosity holds)."""
+    clean_ws = _quality_workspace(
+        tmp_path,
+        {"app.py": "def small(x):\n    return x * 2\n\n" + _big_function(11)},
+        name="clean",
+    )
+    eroded_ws = _quality_workspace(
+        tmp_path,
+        {"app.py": "def small(x):\n    return x * 2\n\n" + _big_function(13)},
+        name="eroded",
+    )
+
+    clean = analyze_quality(clean_ws / ".daydream")
+    eroded = analyze_quality(eroded_ws / ".daydream")
+
+    assert eroded["erosion"] > clean["erosion"]
+    assert eroded["verbosity"] >= clean["verbosity"]
+
+
+def test_analyze_session_includes_quality_for_post_fix_workspace(tmp_path: Path):
+    """Real-path: analyze_session computes quality on the live workspace tree."""
+    ws = _quality_workspace(
+        tmp_path,
+        {"app.py": "def small(x):\n    return x * 2\n\n" + _big_function(11)},
+    )
+    daydream_dir = ws / ".daydream"
+    run_dir = daydream_dir / "runs" / "quality-real"
+    run_dir.mkdir(parents=True)
+    (run_dir / "trajectory.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "ATIF-v1.6",
+                "session_id": "quality-real",
+                "agent": {"name": "daydream", "model_name": "claude-sonnet-4-5"},
+                "steps": [],
+            }
+        )
+    )
+
+    result = analyze_session(daydream_dir, session_id="quality-real")
+
+    quality = result["quality"]
+    assert set(quality) == {"erosion", "verbosity", "per_file", "calibration", "scoped_files"}
+    assert quality["scoped_files"] == 1
+    assert quality["calibration"]["human_erosion"] == 0.34
+    assert quality["calibration"]["human_verbosity"] == 0.19
+    entry = quality["per_file"]["app.py"]
+    assert entry["functions"] == 2
+    assert entry["high_cc_functions"] == 1
+    expected = round(_mass(12, 24) / (_mass(1, 2) + _mass(12, 24)), 4)
+    assert quality["erosion"] == pytest.approx(expected)

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -891,3 +891,165 @@ def test_quality_verbosity_trivial_wrapper_with_default_not_flagged(tmp_path: Pa
     result = analyze_quality(ws / ".daydream")
 
     assert result["per_file"]["app.py"]["verbosity"] == 0.0
+
+
+# --- review round 2 fix regressions (#316) ---
+
+
+_TEN_COMPREHENSION_FILTERS = " ".join(f"if x != {i}" for i in range(10))
+
+
+def test_quality_verbosity_flags_clones_across_files(tmp_path: Path):
+    """An exact block copied from ``a.py`` into ``b.py`` flags BOTH files.
+
+    Per-file clone detection alone never sees the duplicate — each per-file
+    invocation observes a single occurrence. The cross-file pass must index
+    blocks across scoped files and attribute them back.
+    """
+    block = "    if x > 1:\n        return 1\n    return 0\n"
+    ws = _quality_workspace(
+        tmp_path,
+        {"a.py": "def a():\n" + block, "b.py": "def b():\n" + block},
+    )
+
+    result = analyze_quality(ws / ".daydream")
+
+    assert result["per_file"]["a.py"]["verbosity"] > 0
+    assert result["per_file"]["b.py"]["verbosity"] > 0
+    assert result["verbosity"] > 0
+
+
+def test_quality_verbosity_cross_file_clone_needs_two_files(tmp_path: Path):
+    """A block present in only one file flags neither file."""
+    ws = _quality_workspace(
+        tmp_path,
+        {
+            "a.py": "def a():\n    if x > 1:\n        return 1\n    return 0\n",
+            "b.py": "def b(y):\n    return y * 2\n",
+        },
+    )
+
+    result = analyze_quality(ws / ".daydream")
+
+    assert result["per_file"]["a.py"]["verbosity"] == 0.0
+    assert result["per_file"]["b.py"]["verbosity"] == 0.0
+
+
+def test_quality_verbosity_within_file_clones_still_count_across_pass(tmp_path: Path):
+    """Within-file duplicates keep counting now that the cross-file pass exists."""
+    ws = _quality_workspace(
+        tmp_path,
+        {
+            "app.py": (
+                "def a():\n"
+                "    if x > 1:\n"
+                "        return 1\n"
+                "    return 0\n"
+                "\n"
+                "def b():\n"
+                "    if x > 1:\n"
+                "        return 1\n"
+                "    return 0\n"
+            )
+        },
+    )
+
+    result = analyze_quality(ws / ".daydream")
+
+    assert result["per_file"]["app.py"]["verbosity"] == pytest.approx(6 / 8)
+
+
+def test_quality_erosion_generator_expression_filters_count_toward_cc(tmp_path: Path):
+    """Generator-expression filters are real branch paths, like list comprehensions."""
+    ws = _quality_workspace(
+        tmp_path,
+        {
+            "app.py": (
+                "def f(xs):\n"
+                "    return (x for x in xs "
+                + _TEN_COMPREHENSION_FILTERS
+                + ")\n"
+            )
+        },
+    )
+
+    result = analyze_quality(ws / ".daydream")
+
+    entry = result["per_file"]["app.py"]
+    assert entry["high_cc_functions"] == 1
+    assert entry["erosion"] == 1.0
+
+
+@pytest.mark.parametrize(
+    ("comprehension", "label"),
+    [
+        (f"[x for x in xs {_TEN_COMPREHENSION_FILTERS}]", "list"),
+        (f"{{x for x in xs {_TEN_COMPREHENSION_FILTERS}}}", "set"),
+        (f"{{x: x for x in xs {_TEN_COMPREHENSION_FILTERS}}}", "dict"),
+        (f"(x for x in xs {_TEN_COMPREHENSION_FILTERS})", "generator"),
+    ],
+)
+def test_quality_erosion_comprehension_types_cc_parity(
+    tmp_path: Path, comprehension: str, label: str
+):
+    """List/set/dict/generator comprehensions count generators + filters identically."""
+    ws = _quality_workspace(tmp_path, {"app.py": f"def f(xs):\n    return {comprehension}\n"})
+
+    result = analyze_quality(ws / ".daydream")
+
+    entry = result["per_file"]["app.py"]
+    assert entry["high_cc_functions"] == 1, label
+    assert entry["erosion"] == 1.0
+
+
+def test_quality_verbosity_unfiltered_generator_expression_is_identity(tmp_path: Path):
+    """``(x for x in items)`` is an identity comprehension, exactly like a list one."""
+    ws = _quality_workspace(tmp_path, {"app.py": "def f(items):\n    return (x for x in items)\n"})
+
+    result = analyze_quality(ws / ".daydream")
+
+    assert result["per_file"]["app.py"]["verbosity"] > 0
+
+
+def test_quality_excludes_generated_and_vendored_files(tmp_path: Path):
+    """Generated and vendored Python is out of metric scope (Finding #8).
+
+    Path-based generated files (``*_generated.py``, ``*.pb.py``,
+    ``migrations/*.py``), the generated-file header marker, and vendored
+    trees (``vendor``/``third_party``) must not reach ``per_file``,
+    ``scoped_files``, or the aggregate denominators.
+    """
+    ws = _quality_workspace(
+        tmp_path,
+        {
+            "app.py": "def f(x):\n    return x\n",
+            "api_generated.py": "def g(x):\n    return x\n",
+            "svc.pb.py": "def h(x):\n    return x\n",
+            "vendor/lib/v.py": "def i(x):\n    return x\n",
+            "third_party/lib/t.py": "def j(x):\n    return x\n",
+            "migrations/0001_init.py": "def k(x):\n    return x\n",
+            "gen_tool.py": "# Code generated by protoc. DO NOT EDIT.\ndef m(x):\n    return x\n",
+        },
+    )
+
+    result = analyze_quality(ws / ".daydream")
+
+    assert list(result["per_file"]) == ["app.py"]
+    assert result["scoped_files"] == 1
+
+
+def test_quality_syntax_error_file_excluded_from_aggregates(tmp_path: Path):
+    """A malformed file stays in scoped_files but not per_file or the ratios."""
+    ws = _quality_workspace(
+        tmp_path,
+        {
+            "good.py": "def f(x):\n    return x\n",
+            "broken.py": "def broken(:\n    return 1\n",
+        },
+    )
+
+    result = analyze_quality(ws / ".daydream")
+
+    assert result["scoped_files"] == 2
+    assert list(result["per_file"]) == ["good.py"]
+    assert result["verbosity"] == 0.0

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1053,3 +1053,177 @@ def test_quality_syntax_error_file_excluded_from_aggregates(tmp_path: Path):
     assert result["scoped_files"] == 2
     assert list(result["per_file"]) == ["good.py"]
     assert result["verbosity"] == 0.0
+
+
+# --- review round 3 fix regressions (#316) ---
+
+
+def test_quality_unparseable_file_does_not_contaminate_cross_file_clones(tmp_path: Path):
+    """A malformed file's lines must never flag matching blocks in valid files.
+
+    ``analyze_quality`` indexes the cross-file clone pass over successfully
+    parsed files only. A broken file holding a block that also appears in a
+    valid file would otherwise be a second occurrence and flag the valid
+    file, shifting its verbosity (Finding #1).
+    """
+    block = "    if x > 1:\n        return 1\n    return 0\n"
+    clean_ws = _quality_workspace(tmp_path, {"app.py": "def a():\n" + block}, name="clean")
+    dirty_ws = _quality_workspace(
+        tmp_path,
+        {"app.py": "def a():\n" + block, "broken.py": "def broken(:\n" + block},
+        name="dirty",
+    )
+
+    clean = analyze_quality(clean_ws / ".daydream")
+    dirty = analyze_quality(dirty_ws / ".daydream")
+
+    assert dirty["scoped_files"] == 2
+    assert list(dirty["per_file"]) == ["app.py"]
+    assert clean["per_file"]["app.py"]["verbosity"] == dirty["per_file"]["app.py"]["verbosity"]
+    assert clean["verbosity"] == dirty["verbosity"]
+
+
+def test_quality_per_file_erosion_none_without_functions(tmp_path: Path):
+    """A module with no functions has no mass, so its erosion ratio is None.
+
+    Zero is a meaningful value (no high-CC mass), so undefined must be None;
+    the workspace aggregate pools mass across files and stays numeric.
+    """
+    ws = _quality_workspace(
+        tmp_path,
+        {
+            "m.py": "import os\nX = 1\n",
+            "app.py": "def f(x):\n    return x\n",
+        },
+    )
+
+    result = analyze_quality(ws / ".daydream")
+
+    assert result["per_file"]["m.py"]["erosion"] is None
+    assert result["per_file"]["m.py"]["functions"] == 0
+    assert result["per_file"]["app.py"]["erosion"] == 0.0
+    assert result["erosion"] == 0.0
+
+
+def test_quality_per_file_verbosity_none_on_blank_only_file(tmp_path: Path):
+    """A file with no non-blank lines has an undefined verbosity ratio.
+
+    ``None`` signals the undefined denominator; the workspace aggregate keeps
+    pooling the zero lines harmlessly and stays ``None`` for verbosity too.
+    """
+    ws = _quality_workspace(tmp_path, {"blank.py": "\n\n\n"})
+
+    result = analyze_quality(ws / ".daydream")
+
+    assert result["per_file"]["blank.py"]["verbosity"] is None
+    assert result["per_file"]["blank.py"]["sloc"] == 0
+    assert result["verbosity"] is None
+
+
+@pytest.mark.parametrize(
+    ("mutation", "label"),
+    [
+        ("        item = items.pop()\n", "pop"),
+        ("        items.clear()\n", "clear"),
+    ],
+)
+def test_quality_verbosity_guard_after_mutation_not_flagged(
+    tmp_path: Path, mutation: str, label: str
+):
+    """A post-mutation empty check is a necessary termination guard.
+
+    ``while items:`` proves nonemptiness only at the header; once the body
+    mutates the collection, ``if not items:`` is meaningful and must not be
+    counted as redundant slop (Finding #3).
+    """
+    ws = _quality_workspace(
+        tmp_path,
+        {"app.py": "def f(items):\n    while items:\n" + mutation + "        if not items:\n            break\n"},
+    )
+
+    result = analyze_quality(ws / ".daydream")
+
+    assert result["per_file"]["app.py"]["verbosity"] == 0.0, label
+
+
+def test_quality_verbosity_guard_without_prior_mutation_still_flagged(tmp_path: Path):
+    """A non-mutating statement between header and guard keeps it redundant.
+
+    ``while items: x = f(); if not items: break`` — nothing touches ``items``,
+    so the header's nonemptiness proof still holds at the guard, which stays
+    flagged (Finding #3).
+    """
+    ws = _quality_workspace(
+        tmp_path,
+        {
+            "app.py": (
+                "def f(items):\n"
+                "    while items:\n"
+                "        x = f()\n"
+                "        if not items:\n"
+                "            break\n"
+            )
+        },
+    )
+
+    result = analyze_quality(ws / ".daydream")
+
+    assert result["per_file"]["app.py"]["verbosity"] > 0
+
+
+@pytest.mark.parametrize(
+    ("wrapper_body", "label"),
+    [
+        ('    """Pass through."""\n    return inner(x, y)\n', "documented"),
+        ("    return inner(x, y)\n", "undocumented"),
+    ],
+)
+def test_quality_verbosity_wrapper_docstring_does_not_hide_wrapper(
+    tmp_path: Path, wrapper_body: str, label: str
+):
+    """A leading docstring is not an executable statement for wrapper detection.
+
+    ``_trivial_wrapper`` must count only the real body statement, so a
+    documented pass-through wrapper is flagged exactly like an undocumented
+    one (Finding #4).
+    """
+    ws = _quality_workspace(
+        tmp_path,
+        {
+            "app.py": (
+                "def inner(x, y):\n"
+                "    return x + y\n"
+                "\n"
+                "def outer(x, y):\n"
+                + wrapper_body
+            )
+        },
+    )
+
+    result = analyze_quality(ws / ".daydream")
+
+    assert result["per_file"]["app.py"]["verbosity"] > 0, label
+
+
+def test_quality_excludes_explicitly_vendored_subtree(tmp_path: Path):
+    """A vendored dir whose basename is not vendor/third_party is still excluded.
+
+    ``daydream/atif/`` is explicitly vendored from Harbor (see
+    daydream/atif/NOTICE) but its basename ``atif`` is not in the obvious
+    vendored set — it must not reach ``per_file`` or the aggregates
+    (Finding #5).
+    """
+    ws = _quality_workspace(
+        tmp_path,
+        {
+            "app.py": "def f(x):\n    return x\n",
+            "daydream/atif/models.py": "def g(x):\n    return x\n",
+            "daydream/atif/validator.py": "def h(x):\n    return x\n",
+        },
+    )
+
+    result = analyze_quality(ws / ".daydream")
+
+    assert result["scoped_files"] == 1
+    assert list(result["per_file"]) == ["app.py"]
+    assert result["erosion"] == 0.0

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -659,3 +659,235 @@ def test_analyze_session_includes_quality_for_post_fix_workspace(tmp_path: Path)
     assert entry["high_cc_functions"] == 1
     expected = round(_mass(12, 24) / (_mass(1, 2) + _mass(12, 24)), 4)
     assert quality["erosion"] == pytest.approx(expected)
+
+
+# --- review round 1 fix regressions (#316) ---
+
+
+def test_quality_verbosity_stays_within_zero_one_when_spans_include_blank_lines(tmp_path: Path):
+    """Blank rows inside a flagged span must not count toward the ratio.
+
+    A trivial wrapper's span covers the whole function, blank lines included;
+    previously ``verbosity`` divided those rows by non-blank LOC and could
+    exceed 1.0, corrupting the per-file and workspace aggregates.
+    """
+    ws = _quality_workspace(
+        tmp_path,
+        {
+            "app.py": (
+                "def outer(x, y):\n"
+                "\n"
+                "\n"
+                "    return inner(x, y)\n"
+            )
+        },
+    )
+
+    result = analyze_quality(ws / ".daydream")
+
+    entry = result["per_file"]["app.py"]
+    assert 0.0 <= entry["verbosity"] <= 1.0
+    assert entry["verbosity"] == pytest.approx(1.0)
+
+
+def test_quality_erosion_counts_comprehension_filters_toward_cc(tmp_path: Path):
+    """A comprehension's generators and filters are real branch paths.
+
+    A function whose only decision points live inside a comprehension must
+    cross the CC>10 erosion threshold; previously they were invisible.
+    """
+    ws = _quality_workspace(
+        tmp_path,
+        {
+            "app.py": (
+                "def f(xs):\n"
+                "    return [x for x in xs "
+                + " ".join(f"if x != {i}" for i in range(10))
+                + "]\n"
+            )
+        },
+    )
+
+    result = analyze_quality(ws / ".daydream")
+
+    entry = result["per_file"]["app.py"]
+    assert entry["high_cc_functions"] == 1
+    assert entry["erosion"] == 1.0
+
+
+def test_quality_erosion_ignores_wildcard_match_case(tmp_path: Path):
+    """``case _:`` matches any value and adds no decision path."""
+    ws = _quality_workspace(
+        tmp_path,
+        {
+            "app.py": (
+                "def f(x):\n"
+                "    match x:\n"
+                "        case _:\n"
+                "            return 0\n"
+            )
+        },
+    )
+
+    result = analyze_quality(ws / ".daydream")
+
+    assert result["per_file"]["app.py"]["high_cc_functions"] == 0
+    assert result["erosion"] == 0.0
+
+
+def test_quality_erosion_counts_real_match_cases_toward_cc(tmp_path: Path):
+    """Each real ``case <value>:`` adds a decision path; 11 cross the threshold."""
+    lines = ["def f(x):", "    match x:"]
+    for i in range(1, 12):
+        lines.append(f"        case {i}:")
+        lines.append(f"            return {i}")
+    ws = _quality_workspace(tmp_path, {"app.py": "\n".join(lines) + "\n"})
+
+    result = analyze_quality(ws / ".daydream")
+
+    entry = result["per_file"]["app.py"]
+    assert entry["high_cc_functions"] == 1
+    assert entry["erosion"] == 1.0
+
+
+def test_quality_verbosity_filtered_comprehension_not_flagged(tmp_path: Path):
+    """``[x for x in items if x > 0]`` filters, so it is not an identity."""
+    ws = _quality_workspace(
+        tmp_path,
+        {"app.py": "def f(items):\n    return [x for x in items if x > 0]\n"},
+    )
+
+    result = analyze_quality(ws / ".daydream")
+
+    assert result["per_file"]["app.py"]["verbosity"] == 0.0
+
+
+def test_quality_verbosity_multi_generator_comprehension_not_flagged(tmp_path: Path):
+    """``[x for x in a for y in b]`` is a product, not a passthrough."""
+    ws = _quality_workspace(
+        tmp_path,
+        {"app.py": "def f(a, b):\n    return [x for x in a for y in b]\n"},
+    )
+
+    result = analyze_quality(ws / ".daydream")
+
+    assert result["per_file"]["app.py"]["verbosity"] == 0.0
+
+
+def test_quality_verbosity_while_predicate_guard_not_flagged(tmp_path: Path):
+    """A predicate merely receiving the collection does not prove it nonempty."""
+    ws = _quality_workspace(
+        tmp_path,
+        {
+            "app.py": (
+                "def f(items):\n"
+                "    while should_continue(items):\n"
+                "        if not items:\n"
+                "            break\n"
+            )
+        },
+    )
+
+    result = analyze_quality(ws / ".daydream")
+
+    assert result["per_file"]["app.py"]["verbosity"] == 0.0
+
+
+def test_quality_verbosity_while_bare_collection_guard_flagged(tmp_path: Path):
+    """``while items:`` proves nonemptiness, so the guard is redundant."""
+    ws = _quality_workspace(
+        tmp_path,
+        {
+            "app.py": (
+                "def f(items):\n"
+                "    while items:\n"
+                "        if not items:\n"
+                "            break\n"
+            )
+        },
+    )
+
+    result = analyze_quality(ws / ".daydream")
+
+    entry = result["per_file"]["app.py"]
+    assert entry["verbosity"] > 0
+    assert entry["verbosity"] == pytest.approx(2 / 4)
+
+
+def test_quality_verbosity_while_len_comparison_guard_flagged(tmp_path: Path):
+    """``while len(items) > 0:`` proves nonemptiness, so the guard is redundant."""
+    ws = _quality_workspace(
+        tmp_path,
+        {
+            "app.py": (
+                "def f(items):\n"
+                "    while len(items) > 0:\n"
+                "        if not items:\n"
+                "            break\n"
+            )
+        },
+    )
+
+    result = analyze_quality(ws / ".daydream")
+
+    entry = result["per_file"]["app.py"]
+    assert entry["verbosity"] > 0
+    assert entry["verbosity"] == pytest.approx(2 / 4)
+
+
+def test_quality_verbosity_trivial_wrapper_with_literal_not_flagged(tmp_path: Path):
+    """``g(x, 42)`` supplies a literal, so the wrapper is not a pure passthrough."""
+    ws = _quality_workspace(
+        tmp_path,
+        {"app.py": "def f(x):\n    return g(x, 42)\n"},
+    )
+
+    result = analyze_quality(ws / ".daydream")
+
+    assert result["per_file"]["app.py"]["verbosity"] == 0.0
+
+
+def test_quality_verbosity_trivial_wrapper_with_keyword_arg_not_flagged(tmp_path: Path):
+    ws = _quality_workspace(
+        tmp_path,
+        {"app.py": "def f(x):\n    return g(x=x)\n"},
+    )
+
+    result = analyze_quality(ws / ".daydream")
+
+    assert result["per_file"]["app.py"]["verbosity"] == 0.0
+
+
+def test_quality_verbosity_trivial_wrapper_with_starred_args_not_flagged(tmp_path: Path):
+    ws = _quality_workspace(
+        tmp_path,
+        {"app.py": "def f(*xs):\n    return g(*xs)\n"},
+    )
+
+    result = analyze_quality(ws / ".daydream")
+
+    assert result["per_file"]["app.py"]["verbosity"] == 0.0
+
+
+def test_quality_verbosity_trivial_wrapper_typed_param_still_flagged(tmp_path: Path):
+    """A type annotation adds no behavior, so ``def f(x: int): return g(x)`` is a wrapper."""
+    ws = _quality_workspace(
+        tmp_path,
+        {"app.py": "def f(x: int):\n    return g(x)\n"},
+    )
+
+    result = analyze_quality(ws / ".daydream")
+
+    assert result["per_file"]["app.py"]["verbosity"] == 1.0
+
+
+def test_quality_verbosity_trivial_wrapper_with_default_not_flagged(tmp_path: Path):
+    """A default supplies behavior, so ``def f(x=1): return g(x)`` is not a wrapper."""
+    ws = _quality_workspace(
+        tmp_path,
+        {"app.py": "def f(x=1):\n    return g(x)\n"},
+    )
+
+    result = analyze_quality(ws / ".daydream")
+
+    assert result["per_file"]["app.py"]["verbosity"] == 0.0

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -374,6 +374,62 @@ def test_query_runs_with_where(tmp_path: Path):
     assert ids == {"s1", "s3"}
 
 
+def test_upsert_run_persists_erosion_verbosity(tmp_path: Path):
+    """erosion/verbosity round-trip through upsert_run -> query_runs, filterable and sortable."""
+    upsert_run(tmp_path, make_manifest(session_id="s-q1", erosion=0.34, verbosity=0.19))
+    upsert_run(tmp_path, make_manifest(session_id="s-q2", archive_path="/tmp/s-q2"))
+    upsert_run(
+        tmp_path,
+        make_manifest(session_id="s-q3", erosion=0.51, verbosity=0.07, archive_path="/tmp/s-q3"),
+    )
+
+    row = query_runs(tmp_path, where="session_id = ?", params=("s-q1",))[0]
+    assert row["erosion"] == pytest.approx(0.34)
+    assert row["verbosity"] == pytest.approx(0.19)
+
+    # The query layer's WHERE binds against the new columns.
+    scored = query_runs(tmp_path, where="erosion IS NOT NULL")
+    assert {r["session_id"] for r in scored} == {"s-q1", "s-q3"}
+
+    # The columns are sortable (NULLs sort first in SQLite).
+    conn = sqlite3.connect(str(tmp_path / "index.db"))
+    try:
+        ordered = [r[0] for r in conn.execute("SELECT session_id FROM runs ORDER BY erosion")]
+    finally:
+        conn.close()
+    assert ordered == ["s-q2", "s-q1", "s-q3"]
+
+
+def test_runs_erosion_verbosity_columns_migrate_existing_db(tmp_path: Path):
+    """A pre-existing index.db without erosion/verbosity gains them via ALTER-ADD.
+
+    Mirrors the source_path/composite_reward additive migration: a legacy runs
+    table (no erosion/verbosity columns) must keep its rows and gain the
+    columns on the next production write, never dropping or rewriting data.
+    """
+    from daydream.archive.index import _CREATE_TABLE
+
+    legacy_ddl = _CREATE_TABLE.replace("    erosion REAL,\n    verbosity REAL,\n", "")
+    assert "erosion" not in legacy_ddl
+    conn = sqlite3.connect(str(tmp_path / "index.db"))
+    conn.execute(legacy_ddl)
+    conn.execute(
+        "INSERT INTO runs (session_id, archived_at, run_flow, archive_path) VALUES (?, ?, ?, ?)",
+        ("legacy-run", "2026-01-01T00:00:00Z", "normal", str(tmp_path / "legacy-run")),
+    )
+    conn.commit()
+    conn.close()
+
+    # The production write path must ALTER-ADD the columns non-destructively.
+    upsert_run(tmp_path, make_manifest(session_id="s-mig-q", erosion=0.42, verbosity=0.08))
+
+    legacy = query_runs(tmp_path, where="session_id = ?", params=("legacy-run",))[0]
+    assert legacy["erosion"] is None  # pre-existing row preserved, columns nullable
+    row = query_runs(tmp_path, where="session_id = ?", params=("s-mig-q",))[0]
+    assert row["erosion"] == pytest.approx(0.42)
+    assert row["verbosity"] == pytest.approx(0.08)
+
+
 def test_get_archive_dir_creates_structure(monkeypatch, tmp_path: Path):
     target = tmp_path / "custom_archive"
     monkeypatch.setenv("DAYDREAM_ARCHIVE_DIR", str(target))

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -258,6 +258,21 @@ def test_build_manifest_with_evaluation(tmp_path: Path):
     assert m.cost_per_finding_usd == 0.007
 
 
+def test_build_manifest_with_quality(tmp_path: Path):
+    m = _build(
+        tmp_path,
+        evaluation={
+            "quality": {"erosion": 0.34, "verbosity": 0.19},
+        },
+    )
+
+    assert m.erosion == 0.34
+    assert m.verbosity == 0.19
+    d = m.to_dict()
+    assert d["metrics"]["erosion"] == 0.34
+    assert d["metrics"]["verbosity"] == 0.19
+
+
 def test_build_manifest_without_evaluation(tmp_path: Path):
     m = _build(tmp_path)
 
@@ -265,6 +280,8 @@ def test_build_manifest_without_evaluation(tmp_path: Path):
     assert m.grounding_rate is None
     assert m.coverage_ratio is None
     assert m.cost_per_finding_usd is None
+    assert m.erosion is None
+    assert m.verbosity is None
 
 
 def test_build_manifest_wall_clock_without_evaluation(tmp_path: Path):


### PR DESCRIPTION
Closes #316

## What

Adds SlopCodeBench-defined **structural erosion** and **verbosity** quality metrics to daydream's deterministic eval output, computed on the **post-fix workspace** (the reviewed repo tree after daydream's fix phase ran).

- `analyze_quality()` in `daydream/eval/analyzer.py`: per-file and per-run erosion (`mass(f) = CC(f) × √SLOC(f)`; `Erosion = Σ_{CC>10} mass / Σ mass`, pooled per-run) and verbosity (a deterministic subset of the 137-rule ast-grep taxonomy + clone detection: identity comprehensions, empty-list guards, single-use intermediates, trivial wrappers, nested ladders, ≥3-line duplicate blocks).
- CC computed via **tree-sitter-python** (already a dependency; no radon added). Parser failures skip the file — quality analysis never crashes the archive.
- Recorded as `quality: {erosion, verbosity, per_file: {...}, calibration: {human_verbosity: 0.19, human_erosion: 0.34}}` in `evaluation.json`; `erosion`/`verbosity` scalars added to `manifest.json` metrics.
- Python stack only (paper is Python-track; Rust/TS are follow-up).

## Acceptance criteria

- `evaluation.json` includes `quality: {erosion, verbosity}` computed on the post-fix tree — real-path test calls `analyze_session` on a fixture workspace with a minimal trajectory and asserts the full quality shape.
- `manifest.json` metrics include the two numbers — `build_manifest` wiring test in `test_archive.py`.
- Unit + real-path tests (fixture repo, run deep flow, quality block present and **monotone across a crafted eroding fix**) — 11 new tests in `test_analyzer.py` including the monotonicity assertion (eroding fix raises erosion; verbosity non-decreasing).
- `make check` green: 2895 passed / 6 skipped.

## Benchmark isolation

CANNOT affect Martian benchmark scoring — post-run analysis only, the same surface as #307 (`analyzer.py` + archive wiring). Runs after the review→arbiter→merge→fix pipeline completes; `merged-items.json` and the reviewer pipeline are byte-identical. No reward-hacking path.

## Files changed

- `daydream/eval/analyzer.py`
- `daydream/archive/manifest.py`
- `tests/test_analyzer.py`
- `tests/test_archive.py`
- `docs/evaluation-framework.md`
