### PR TITLE
feat(deep): add uncovered-diff-file sweep second-pass reviewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,20 @@ Supervisor settings are config-file-only:
 | `tool_supervisor` | `"off"` | Built-in tool policy mode: `"off"` or `"rules"`. |
 | `tool_bash_deny` | `[]` | Regular expressions for Bash commands the built-in policy vetoes. |
 
+The uncovered-diff-file sweep (a second-pass reviewer over diff files no
+per-stack reviewer read) is configured with file-config keys in the same two
+sources:
+
+| Key | Default | Semantics |
+|-----|---------|-----------|
+| `uncovered_sweep` | `true` | Toggle the sweep. `false` disables the second pass entirely. |
+| `uncovered_sweep_max_files` | `10` | Cap on how many uncovered files are swept in one run; files beyond the cap are recorded in `coverage-stats.json` as `sweep_skipped_capacity` (and named in `sweep_skipped_capacity_files`) rather than silently dropped. `0` sweeps nothing. |
+| `uncovered_sweep_min_hunk_lines` | `5` | A file counts as sweepable only when its hunks contain at least this many added/removed lines. `0` removes the floor (every uncovered file is eligible). |
+
+Resolution precedence is the standard **CLI > config file > default**; a
+negative value (any tier) degrades to the named default, so an invalid floor can
+never make zero-change/trivial blocks eligible.
+
 The LLM supervisor uses one batched call. Configure its model under
 `[tool.daydream.phases.supervise]` (or `[phases.supervise]` in `.daydream.toml`).
 

--- a/daydream/config.py
+++ b/daydream/config.py
@@ -367,6 +367,7 @@ UNKNOWN_SKILL_PATTERN = r"Unknown skill: ([\w:-]+)"
 # `uncovered_sweep_max_files` caps how many uncovered files are swept in one run
 # (the remainder is recorded, not silently dropped);
 # `uncovered_sweep_min_hunk_lines` skips files whose hunks are trivially small.
+DEFAULT_UNCOVERED_SWEEP_ENABLED: bool = True
 DEFAULT_UNCOVERED_SWEEP_MAX_FILES: int = 10
 DEFAULT_UNCOVERED_SWEEP_MIN_HUNK_LINES: int = 5
 

--- a/daydream/config.py
+++ b/daydream/config.py
@@ -361,6 +361,15 @@ REVIEW_OUTPUT_FILE = ".review-output.md"
 # Pattern to detect unknown skill errors
 UNKNOWN_SKILL_PATTERN = r"Unknown skill: ([\w:-]+)"
 
+# Issue #309: uncovered-diff-file sweep. After per-stack reviews + parse, the
+# deep flow re-reviews diff files no reviewer read with a cheap second-pass
+# agent. `uncovered_sweep` toggles the pass (default True);
+# `uncovered_sweep_max_files` caps how many uncovered files are swept in one run
+# (the remainder is recorded, not silently dropped);
+# `uncovered_sweep_min_hunk_lines` skips files whose hunks are trivially small.
+DEFAULT_UNCOVERED_SWEEP_MAX_FILES: int = 10
+DEFAULT_UNCOVERED_SWEEP_MIN_HUNK_LINES: int = 5
+
 # Structural-maintainability meta-stack. Deep mode appends a synthetic
 # ``StackAssignment`` with ``stack_name=STRUCTURE_STACK_NAME`` and
 # ``skill_invocation=STRUCTURE_SKILL`` so the structural reviewer always runs

--- a/daydream/config_file.py
+++ b/daydream/config_file.py
@@ -55,6 +55,17 @@ class DaydreamFileConfig:
             calls in one file group (the group is severity-sorted, so the dropped
             tail is lowest-severity). ``None`` (the default when the key is absent
             or junk) falls through to ``config.DEFAULT_GROUP_MAX_SERIAL_ITEMS`` (6).
+        uncovered_sweep: Issue #309. Toggle the uncovered-diff-file sweep
+            (second-pass reviewer over diff files no per-stack reviewer read).
+            ``None`` falls through to the RunConfig field / orchestrator default
+            (``True``); ``False`` disables the pass.
+        uncovered_sweep_max_files: Issue #309. Cap on how many uncovered files
+            are swept in one run. ``None`` falls through to the RunConfig field /
+            ``config.DEFAULT_UNCOVERED_SWEEP_MAX_FILES`` (10).
+        uncovered_sweep_min_hunk_lines: Issue #309. Minimum added/removed lines
+            a file's hunks must contain to warrant a sweep. ``None`` falls
+            through to the RunConfig field /
+            ``config.DEFAULT_UNCOVERED_SWEEP_MIN_HUNK_LINES`` (5).
         supervisor: Findings supervisor mode (``"off"``, ``"rules"``, or
             ``"llm"``), or None when unset/invalid.
         supervisor_deny_globs: Repository-relative deny globs shared by findings
@@ -76,6 +87,9 @@ class DaydreamFileConfig:
     precision_mode: bool | None = None
     group_max_wall_s: float | None = None
     group_max_serial_items: int | None = None
+    uncovered_sweep: bool | None = None
+    uncovered_sweep_max_files: int | None = None
+    uncovered_sweep_min_hunk_lines: int | None = None
     supervisor: str | None = None
     supervisor_deny_globs: list[str] = field(default_factory=list)
     tool_supervisor: str | None = None
@@ -269,6 +283,12 @@ def load_file_config(root: Path) -> DaydreamFileConfig:
     # so an accidental ``precision_mode = 1`` is treated as unset, not enabled.
     raw_precision = merged.get("precision_mode")
     precision: bool | None = raw_precision if isinstance(raw_precision, bool) else None
+    # uncovered_sweep: bool only, same degrade-to-None rule as precision_mode so
+    # an accidental ``uncovered_sweep = 1`` is treated as unset, not enabled.
+    raw_uncovered_sweep = merged.get("uncovered_sweep")
+    uncovered_sweep: bool | None = (
+        raw_uncovered_sweep if isinstance(raw_uncovered_sweep, bool) else None
+    )
     improve = merged.get("improve")
     improve = improve if isinstance(improve, dict) else {}
     service_groups = improve.get("service_groups")
@@ -286,6 +306,9 @@ def load_file_config(root: Path) -> DaydreamFileConfig:
         precision_mode=precision,
         group_max_wall_s=_coerce_float(merged.get("group_max_wall_s")),
         group_max_serial_items=_coerce_int(merged.get("group_max_serial_items")),
+        uncovered_sweep=uncovered_sweep,
+        uncovered_sweep_max_files=_coerce_int(merged.get("uncovered_sweep_max_files")),
+        uncovered_sweep_min_hunk_lines=_coerce_int(merged.get("uncovered_sweep_min_hunk_lines")),
         supervisor=_coerce_choice(merged.get("supervisor"), {"off", "rules", "llm"}),
         supervisor_deny_globs=_coerce_string_list(merged.get("supervisor_deny_globs")),
         tool_supervisor=_coerce_choice(merged.get("tool_supervisor"), {"off", "rules"}),

--- a/daydream/config_file.py
+++ b/daydream/config_file.py
@@ -60,11 +60,14 @@ class DaydreamFileConfig:
             ``None`` falls through to the RunConfig field / orchestrator default
             (``True``); ``False`` disables the pass.
         uncovered_sweep_max_files: Issue #309. Cap on how many uncovered files
-            are swept in one run. ``None`` falls through to the RunConfig field /
+            are swept in one run. Non-negative only: ``0`` disables the sweep;
+            a negative value degrades to ``None`` (the named default applies).
+            ``None`` falls through to the RunConfig field /
             ``config.DEFAULT_UNCOVERED_SWEEP_MAX_FILES`` (10).
         uncovered_sweep_min_hunk_lines: Issue #309. Minimum added/removed lines
-            a file's hunks must contain to warrant a sweep. ``None`` falls
-            through to the RunConfig field /
+            a file's hunks must contain to warrant a sweep. Non-negative only:
+            ``0`` removes the floor; a negative value degrades to ``None`` (the
+            named default applies). ``None`` falls through to the RunConfig field /
             ``config.DEFAULT_UNCOVERED_SWEEP_MIN_HUNK_LINES`` (5).
         supervisor: Findings supervisor mode (``"off"``, ``"rules"``, or
             ``"llm"``), or None when unset/invalid.
@@ -218,6 +221,20 @@ def _coerce_int(raw: Any) -> int | None:
     return raw if isinstance(raw, int) else None
 
 
+def _coerce_non_negative_int(raw: Any) -> int | None:
+    """Return ``raw`` as a non-negative int, or None otherwise (degrade to default).
+
+    Unlike :func:`_coerce_int`, a negative value degrades to ``None`` so the
+    named default applies (issue #309): a negative sweep capacity cap or hunk
+    floor is never a meaningful count. Explicit ``0`` is preserved — ``0`` max
+    files means "sweep nothing" and ``0`` min hunk lines means "no hunk-size
+    floor".
+    """
+    if isinstance(raw, bool):
+        return None
+    return raw if isinstance(raw, int) and raw >= 0 else None
+
+
 def _coerce_positive_int(table: dict[str, Any], key: str) -> int | None:
     """Return a positive int bound from ``key``, accepting its hyphenated spelling.
 
@@ -307,8 +324,8 @@ def load_file_config(root: Path) -> DaydreamFileConfig:
         group_max_wall_s=_coerce_float(merged.get("group_max_wall_s")),
         group_max_serial_items=_coerce_int(merged.get("group_max_serial_items")),
         uncovered_sweep=uncovered_sweep,
-        uncovered_sweep_max_files=_coerce_int(merged.get("uncovered_sweep_max_files")),
-        uncovered_sweep_min_hunk_lines=_coerce_int(merged.get("uncovered_sweep_min_hunk_lines")),
+        uncovered_sweep_max_files=_coerce_non_negative_int(merged.get("uncovered_sweep_max_files")),
+        uncovered_sweep_min_hunk_lines=_coerce_non_negative_int(merged.get("uncovered_sweep_min_hunk_lines")),
         supervisor=_coerce_choice(merged.get("supervisor"), {"off", "rules", "llm"}),
         supervisor_deny_globs=_coerce_string_list(merged.get("supervisor_deny_globs")),
         tool_supervisor=_coerce_choice(merged.get("tool_supervisor"), {"off", "rules"}),

--- a/daydream/deep/coverage.py
+++ b/daydream/deep/coverage.py
@@ -57,25 +57,28 @@ def _completed_read_paths(
     """Read paths from ``trajectory`` whose tool call carries a completed observation.
 
     A Read only covers a diff file when the read tool call is paired with a
-    ToolResult in the same step's observation: ``observation.results[].source_call_id``
-    must equal the tool call's ``tool_call_id``. An interrupted read
-    (ToolStartEvent with no ToolResultEvent) returns no content, so it must NOT
-    count as coverage — the sweep treats it as uncovered (fail-open: the file
-    gets swept, never skipped). ``phases``, when given, restricts the steps
-    considered to those whose ``extra.daydream_phase`` is in the set.
+    ToolResult in the SAME step's observation:
+    ``observation.results[].source_call_id`` must equal the tool call's
+    ``tool_call_id``. Tool-call IDs are scoped to individual invocations and
+    are NOT required to be trajectory-global, so the completed set is built per
+    step and never leaks across steps: an interrupted read whose ID collides
+    with a completed read in another step stays uncovered (fail-open: the file
+    gets swept, never skipped). An interrupted read (ToolStartEvent with no
+    ToolResultEvent) returns no content, so it must NOT count as coverage.
+    ``phases``, when given, restricts the steps considered to those whose
+    ``extra.daydream_phase`` is in the set.
     """
-    completed_call_ids: set[str] = set()
+    paths: set[str] = set()
     for step in trajectory.get("steps", []):
+        if phases is not None and ((step.get("extra") or {}).get("daydream_phase")) not in phases:
+            continue
+        completed_call_ids: set[str] = set()
         for result in (step.get("observation") or {}).get("results") or []:
             if not isinstance(result, dict):
                 continue
             call_id = result.get("source_call_id")
             if isinstance(call_id, str):
                 completed_call_ids.add(call_id)
-    paths: set[str] = set()
-    for step in trajectory.get("steps", []):
-        if phases is not None and ((step.get("extra") or {}).get("daydream_phase")) not in phases:
-            continue
         for tc in step.get("tool_calls") or []:
             if tc.get("tool_call_id") not in completed_call_ids:
                 continue
@@ -237,8 +240,8 @@ def build_uncovered_sweep_prompt(
         f"diff.patch for these):\n{hunks.rstrip()}"
     )
     parts.append(
-        "For whole-file context beyond these hunks you MAY Read the source "
-        "file directly."
+        "Read the source file FIRST; you may only comment on hunks you have "
+        "read. The inlined hunks are not a substitute for reading the file."
     )
     parts.append(_confidence_and_convention_instructions())
     parts.append(_dependency_impact_instructions())

--- a/daydream/deep/coverage.py
+++ b/daydream/deep/coverage.py
@@ -6,6 +6,10 @@ reviewer per uncovered file above a small budget threshold. This module holds
 the pure, deterministic pieces: coverage computation, budget filtering
 (hunk-size + capacity cap), and the sweep prompt builder.
 
+The sweep's coverage set is computed HERE, not via ``analyzer.analyze_coverage``:
+a read covers a diff file only at a path-component boundary (a read of
+``notapi.py`` never covers ``api.py``) and only when the read tool call
+carries a completed observation (an interrupted read never covers anything).
 ``daydream.eval.analyzer`` is imported read-only -- issue #316 owns that
 module. The sweep prompt builder lives here, NOT in ``daydream.deep.prompts``
 (issue #314 owns that module).
@@ -17,13 +21,70 @@ from pathlib import Path
 from typing import Any
 
 from daydream.deep.prompts import _DIFF_BLOCK_SPLIT, _diff_block_path
-from daydream.eval.analyzer import analyze_coverage, load_trajectories
+from daydream.eval.analyzer import (
+    _agent_label,
+    _files_from_diff,
+    _read_paths_for_call,
+    load_trajectories,
+)
+
+
+def _path_component_matches(absolute: str, relative: str) -> bool:
+    """Whether an absolute read path corresponds to ``relative`` at a path boundary.
+
+    ``absolute == relative`` (the read path is already repo-relative) or
+    ``absolute`` ends with ``"/" + relative`` — the basename boundary. A bare
+    ``endswith(relative)`` would let a read of ``/repo/notapi.py`` cover the
+    changed file ``api.py``; the component boundary excludes suffix
+    collisions. The sweep uses this matcher instead of ``analyzer._path_matches``
+    so it never inherits that false positive (issue #316 owns the analyzer).
+    """
+    return absolute == relative or absolute.endswith("/" + relative)
+
+
+def _completed_read_paths(
+    trajectory: dict[str, Any], phases: set[str] | None = None
+) -> set[str]:
+    """Read paths from ``trajectory`` whose tool call carries a completed observation.
+
+    A Read only covers a diff file when the read tool call is paired with a
+    ToolResult in the same step's observation: ``observation.results[].source_call_id``
+    must equal the tool call's ``tool_call_id``. An interrupted read
+    (ToolStartEvent with no ToolResultEvent) returns no content, so it must NOT
+    count as coverage — the sweep treats it as uncovered (fail-open: the file
+    gets swept, never skipped). ``phases``, when given, restricts the steps
+    considered to those whose ``extra.daydream_phase`` is in the set.
+    """
+    completed_call_ids: set[str] = set()
+    for step in trajectory.get("steps", []):
+        for result in (step.get("observation") or {}).get("results") or []:
+            if not isinstance(result, dict):
+                continue
+            call_id = result.get("source_call_id")
+            if isinstance(call_id, str):
+                completed_call_ids.add(call_id)
+    paths: set[str] = set()
+    for step in trajectory.get("steps", []):
+        if phases is not None and ((step.get("extra") or {}).get("daydream_phase")) not in phases:
+            continue
+        for tc in step.get("tool_calls") or []:
+            if tc.get("tool_call_id") not in completed_call_ids:
+                continue
+            paths.update(_read_paths_for_call(tc))
+    return paths
 
 
 def compute_uncovered_files(
     daydream_dir: Path, session_id: str | None
 ) -> tuple[list[str], dict[str, Any]]:
-    """Return the diff files no reviewer read, plus the full coverage stats.
+    """Return the diff files no reviewer read, plus the coverage stats.
+
+    Mirrors ``analyzer.analyze_coverage``'s shape but applies the sweep's own
+    matching rules: reads are counted only when the tool call is completed
+    (paired ToolResult observation) and a read path covers a diff file only at
+    a path-component boundary. A read of ``/repo/notapi.py`` therefore never
+    covers ``api.py``, and an interrupted read never covers anything. Both
+    rules fail open — a genuinely unread file is swept, never skipped.
 
     Args:
         daydream_dir: The run's ``.daydream`` directory (parent of the
@@ -32,13 +93,32 @@ def compute_uncovered_files(
             most recent trajectory.
 
     Returns:
-        ``(uncovered_files, stats)`` where ``stats`` is the full
-        ``analyze_coverage`` dict and ``uncovered_files`` is its sorted list of
-        diff files no review agent read.
+        ``(uncovered_files, stats)`` where ``stats`` is the coverage dict
+        (``files_in_diff`` / ``files_read_by_reviewers`` / ``coverage_ratio`` /
+        ``uncovered_files``) and ``uncovered_files`` is its sorted list of diff
+        files no review agent read.
     """
     trajectories = load_trajectories(daydream_dir, session_id=session_id)
-    stats = analyze_coverage(trajectories, daydream_dir)
-    return stats["uncovered_files"], stats
+    diff_files = _files_from_diff(daydream_dir / "diff.patch")
+
+    review_reads: set[str] = set()
+    for traj in trajectories["forked"]:
+        if _agent_label(traj["_source_file"]).startswith("deep-"):
+            review_reads.update(_completed_read_paths(traj))
+    if trajectories["main"]:
+        review_reads.update(
+            _completed_read_paths(trajectories["main"], phases={"deep", "alternatives"})
+        )
+
+    covered = {df for df in diff_files if any(_path_component_matches(r, df) for r in review_reads)}
+    uncovered = sorted(set(diff_files) - covered)
+
+    return uncovered, {
+        "files_in_diff": len(diff_files),
+        "files_read_by_reviewers": len(covered),
+        "coverage_ratio": round(len(covered) / len(diff_files), 4) if diff_files else 1.0,
+        "uncovered_files": uncovered,
+    }
 
 
 def diff_block_for_file(diff: str, file: str) -> str | None:

--- a/daydream/deep/coverage.py
+++ b/daydream/deep/coverage.py
@@ -20,12 +20,21 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from daydream.deep.prompts import _DIFF_BLOCK_SPLIT, _diff_block_path
+from daydream.deep.prompts import (
+    _DIFF_BLOCK_SPLIT,
+    VERIFICATION_PROTOCOL_INSTRUCTION,
+    _diff_block_path,
+)
 from daydream.eval.analyzer import (
     _agent_label,
     _files_from_diff,
     _read_paths_for_call,
     load_trajectories,
+)
+from daydream.phases import (
+    _confidence_and_convention_instructions,
+    _dependency_impact_instructions,
+    _exploration_pointer,
 )
 
 
@@ -155,7 +164,7 @@ def filter_sweepable_files(
     *,
     min_hunk_lines: int,
     max_files: int,
-) -> tuple[list[str], int, int]:
+) -> tuple[list[str], list[str], list[str]]:
     """Budget-filter the uncovered list into the files actually swept.
 
     A file is sweepable only when its hunks contain at least ``min_hunk_lines``
@@ -165,34 +174,22 @@ def filter_sweepable_files(
     skipped-for-capacity rather than silently dropped.
 
     Returns:
-        ``(swept_files, skipped_small_hunks, skipped_capacity)``.
+        ``(swept_files, skipped_small_hunk_files, skipped_capacity_files)``.
+        The two skip lists name the omitted files in diff order (mirroring
+        ``swept_files``) so consumers can audit exactly which files the
+        hunk-size floor and the capacity cap left out; the integer skip counts
+        are ``len(...)`` of these lists.
     """
     swept: list[str] = []
-    skipped_small = 0
+    skipped_small: list[str] = []
     for file in uncovered_files:
         block = diff_block_for_file(diff, file)
         if block is None or hunk_change_line_count(block) < min_hunk_lines:
-            skipped_small += 1
+            skipped_small.append(file)
             continue
         swept.append(file)
-    total_sweepable = len(swept)
-    skipped_capacity = max(0, total_sweepable - max_files)
+    skipped_capacity = swept[max_files:]
     return swept[:max_files], skipped_small, skipped_capacity
-
-
-_SWEEP_VERIFICATION_GATES = (
-    "Before writing findings, apply the review-verification gates (stated "
-    "inline here -- no skill file read is required):\n"
-    "  Gate-0 anti-confabulation: echo the exact artifact you are judging -- "
-    "file:line plus the cited code, read freshly in THIS turn, not recalled.\n"
-    "  Gate 1 (anchor): read the full enclosing symbol/module, not just the "
-    "hunk; state the file path and line range you are judging.\n"
-    "  Gate 2 (evidence): produce an artifact for the finding's type -- pasted "
-    'tool output, a file:line citation, or an explicit "none" after a search.\n'
-    "  Gate 3 (severity): calibrate severity to impact; a request for net-new "
-    "code outside the diff is Informational only.\n"
-    "Do NOT report a finding that fails any gate."
-)
 
 
 def build_uncovered_sweep_prompt(
@@ -202,32 +199,49 @@ def build_uncovered_sweep_prompt(
     intent_path: Path,
     cwd: Path,
     output_path: Path,
+    exploration_dir: Path | None = None,
 ) -> str:
     """Build the second-pass sweep reviewer prompt for one uncovered file.
 
     The reviewer scopes itself to ``file``'s hunks only (no per-stack reviewer
     read this file), uses the TTT intent for authorial context, and writes its
-    findings to ``output_path``. The verification gates are embedded inline --
-    not routed through ``Backend.format_skill_invocation`` and NOT loaded from
-    a skill file -- because the reviewer runs with cwd set to the reviewed
-    repo, where a bare ``read review-verification-protocol/SKILL.md`` resolves
-    against that repo and silently drops the gates (same rationale as
-    ``VERIFICATION_PROTOCOL_INSTRUCTION`` in ``daydream.deep.prompts``).
+    findings to ``output_path``. The sweep reviewer is held to the same standard
+    as ordinary per-stack reviewers -- its findings are parsed into
+    ``PER_STACK_RECORD_SCHEMA`` and merged as ordinary findings -- so the prompt
+    is composed from the CANONICAL deep prompt primitives (imported from
+    ``daydream.phases`` / ``daydream.deep.prompts``, read-only): the exploration
+    pointer, the Confidence and Convention Rules (incl. QUAL-04 error
+    semantics), the Dependency Impact instructions, and the full
+    ``VERIFICATION_PROTOCOL_INSTRUCTION``. The gates are embedded inline -- not
+    routed through ``Backend.format_skill_invocation`` and NOT loaded from a
+    skill file -- because the reviewer runs with cwd set to the reviewed repo,
+    where a bare ``read review-verification-protocol/SKILL.md`` resolves against
+    that repo and silently drops the gates (same rationale as the canonical
+    constant).
     """
-    return "\n\n".join(
-        [
-            "You are the uncovered file sweep reviewer for the deep-review "
-            "pipeline (issue #309).\n"
-            f"The changed file {file} was NOT read by any per-stack reviewer, "
-            "so you are the second pass that covers it. Review ONLY this "
-            "file's hunks below -- correctness, error handling, test quality, "
-            "and maintainability. Do NOT review other files.",
-            f"TTT author intent is at {intent_path}. Read it before starting.",
-            f"Relevant diff hunks for {file} (inlined; do NOT re-read "
-            f"diff.patch for these):\n{hunks.rstrip()}",
-            "For whole-file context beyond these hunks you MAY Read the source "
-            "file directly.",
-            _SWEEP_VERIFICATION_GATES,
-            f"Work in {cwd}. Write your full review to {output_path}.",
-        ]
+    parts: list[str] = []
+    pointer = _exploration_pointer(exploration_dir)
+    if pointer:
+        parts.append(pointer)
+    parts.append(
+        "You are the uncovered file sweep reviewer for the deep-review "
+        "pipeline (issue #309).\n"
+        f"The changed file {file} was NOT read by any per-stack reviewer, "
+        "so you are the second pass that covers it. Review ONLY this "
+        "file's hunks below -- correctness, error handling, test quality, "
+        "and maintainability. Do NOT review other files."
     )
+    parts.append(f"TTT author intent is at {intent_path}. Read it before starting.")
+    parts.append(
+        f"Relevant diff hunks for {file} (inlined; do NOT re-read "
+        f"diff.patch for these):\n{hunks.rstrip()}"
+    )
+    parts.append(
+        "For whole-file context beyond these hunks you MAY Read the source "
+        "file directly."
+    )
+    parts.append(_confidence_and_convention_instructions())
+    parts.append(_dependency_impact_instructions())
+    parts.append(VERIFICATION_PROTOCOL_INSTRUCTION)
+    parts.append(f"Work in {cwd}. Write your full review to {output_path}.")
+    return "\n\n".join(parts)

--- a/daydream/deep/coverage.py
+++ b/daydream/deep/coverage.py
@@ -1,0 +1,153 @@
+"""Uncovered-diff-file sweep helpers (issue #309).
+
+After per-stack reviews + parse, the deep flow computes which diff files NO
+reviewer read (``analyze_coverage``), then dispatches a cheap second-pass
+reviewer per uncovered file above a small budget threshold. This module holds
+the pure, deterministic pieces: coverage computation, budget filtering
+(hunk-size + capacity cap), and the sweep prompt builder.
+
+``daydream.eval.analyzer`` is imported read-only -- issue #316 owns that
+module. The sweep prompt builder lives here, NOT in ``daydream.deep.prompts``
+(issue #314 owns that module).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from daydream.deep.prompts import _DIFF_BLOCK_SPLIT, _diff_block_path
+from daydream.eval.analyzer import analyze_coverage, load_trajectories
+
+
+def compute_uncovered_files(
+    daydream_dir: Path, session_id: str | None
+) -> tuple[list[str], dict[str, Any]]:
+    """Return the diff files no reviewer read, plus the full coverage stats.
+
+    Args:
+        daydream_dir: The run's ``.daydream`` directory (parent of the
+            ``deep/`` artifact dir).
+        session_id: The run's recorder session id, or ``None`` to resolve the
+            most recent trajectory.
+
+    Returns:
+        ``(uncovered_files, stats)`` where ``stats`` is the full
+        ``analyze_coverage`` dict and ``uncovered_files`` is its sorted list of
+        diff files no review agent read.
+    """
+    trajectories = load_trajectories(daydream_dir, session_id=session_id)
+    stats = analyze_coverage(trajectories, daydream_dir)
+    return stats["uncovered_files"], stats
+
+
+def diff_block_for_file(diff: str, file: str) -> str | None:
+    """Return the unified-diff block for ``file``, or ``None`` when absent.
+
+    Reuses the shared ``diff --git`` block splitter and post-state path
+    resolution from ``daydream.deep.prompts`` so the unified-diff parse
+    contract is not duplicated here.
+    """
+    for block in _DIFF_BLOCK_SPLIT.split(diff):
+        if _diff_block_path(block) == file:
+            return block if block.endswith("\n") else block + "\n"
+    return None
+
+
+def hunk_change_line_count(hunks: str) -> int:
+    """Count added/removed lines (``+``/``-``) in a diff block, headers excluded.
+
+    ``+++``/``---`` file headers carry leading plus/minus signs but are not
+    content changes, so they are excluded from the count.
+    """
+    count = 0
+    for line in hunks.splitlines():
+        if line.startswith("+++") or line.startswith("---"):
+            continue
+        if line.startswith("+") or line.startswith("-"):
+            count += 1
+    return count
+
+
+def filter_sweepable_files(
+    uncovered_files: list[str],
+    diff: str,
+    *,
+    min_hunk_lines: int,
+    max_files: int,
+) -> tuple[list[str], int, int]:
+    """Budget-filter the uncovered list into the files actually swept.
+
+    A file is sweepable only when its hunks contain at least ``min_hunk_lines``
+    added/removed lines -- a trivially small hunk does not justify a second
+    pass. The sweepable set is capped at ``max_files`` in diff order (the
+    uncovered list arrives sorted); the remainder is reported as
+    skipped-for-capacity rather than silently dropped.
+
+    Returns:
+        ``(swept_files, skipped_small_hunks, skipped_capacity)``.
+    """
+    swept: list[str] = []
+    skipped_small = 0
+    for file in uncovered_files:
+        block = diff_block_for_file(diff, file)
+        if block is None or hunk_change_line_count(block) < min_hunk_lines:
+            skipped_small += 1
+            continue
+        swept.append(file)
+    total_sweepable = len(swept)
+    skipped_capacity = max(0, total_sweepable - max_files)
+    return swept[:max_files], skipped_small, skipped_capacity
+
+
+_SWEEP_VERIFICATION_GATES = (
+    "Before writing findings, apply the review-verification gates (stated "
+    "inline here -- no skill file read is required):\n"
+    "  Gate-0 anti-confabulation: echo the exact artifact you are judging -- "
+    "file:line plus the cited code, read freshly in THIS turn, not recalled.\n"
+    "  Gate 1 (anchor): read the full enclosing symbol/module, not just the "
+    "hunk; state the file path and line range you are judging.\n"
+    "  Gate 2 (evidence): produce an artifact for the finding's type -- pasted "
+    'tool output, a file:line citation, or an explicit "none" after a search.\n'
+    "  Gate 3 (severity): calibrate severity to impact; a request for net-new "
+    "code outside the diff is Informational only.\n"
+    "Do NOT report a finding that fails any gate."
+)
+
+
+def build_uncovered_sweep_prompt(
+    *,
+    file: str,
+    hunks: str,
+    intent_path: Path,
+    cwd: Path,
+    output_path: Path,
+) -> str:
+    """Build the second-pass sweep reviewer prompt for one uncovered file.
+
+    The reviewer scopes itself to ``file``'s hunks only (no per-stack reviewer
+    read this file), uses the TTT intent for authorial context, and writes its
+    findings to ``output_path``. The verification gates are embedded inline --
+    not routed through ``Backend.format_skill_invocation`` and NOT loaded from
+    a skill file -- because the reviewer runs with cwd set to the reviewed
+    repo, where a bare ``read review-verification-protocol/SKILL.md`` resolves
+    against that repo and silently drops the gates (same rationale as
+    ``VERIFICATION_PROTOCOL_INSTRUCTION`` in ``daydream.deep.prompts``).
+    """
+    return "\n\n".join(
+        [
+            "You are the uncovered file sweep reviewer for the deep-review "
+            "pipeline (issue #309).\n"
+            f"The changed file {file} was NOT read by any per-stack reviewer, "
+            "so you are the second pass that covers it. Review ONLY this "
+            "file's hunks below -- correctness, error handling, test quality, "
+            "and maintainability. Do NOT review other files.",
+            f"TTT author intent is at {intent_path}. Read it before starting.",
+            f"Relevant diff hunks for {file} (inlined; do NOT re-read "
+            f"diff.patch for these):\n{hunks.rstrip()}",
+            "For whole-file context beyond these hunks you MAY Read the source "
+            "file directly.",
+            _SWEEP_VERIFICATION_GATES,
+            f"Work in {cwd}. Write your full review to {output_path}.",
+        ]
+    )

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -1259,17 +1259,32 @@ def _clear_sweep_artifacts(dd: Path) -> None:
     behind, and a later merge resume would reload them as this run's coverage.
     Merge/fix resumes keep the artifacts (the sweep is a no-op there and the
     records must survive).
+
+    Fail-CLOSED: this cleanup is resume-safety-critical, not best-effort
+    diagnostics. When a targeted artifact cannot be removed (a ``OSError`` from
+    ``unlink()``, or an artifact that survives the loop), the function raises an
+    ``OSError`` with an actionable message and the per-stack resume stops --
+    it must never continue with a stale ``stack-uncovered-records.json`` in
+    place that a later merge resume would reload as current findings.
     """
-    for pattern in (
+    patterns = (
         "coverage-stats.json",
         "stack-uncovered-records.json",
         "uncovered-*-review.md",
-    ):
+    )
+    for pattern in patterns:
         for path in dd.glob(pattern):
             try:
                 path.unlink()
             except OSError:
                 pass
+    remaining = [p for pattern in patterns for p in dd.glob(pattern)]
+    if remaining:
+        names = ", ".join(sorted(p.name for p in remaining))
+        raise OSError(
+            f"stale sweep artifact(s) could not be removed: {names}; "
+            "refusing to resume per-stack"
+        )
 
 
 async def _step_uncovered_sweep(ctx: FlowContext) -> None:
@@ -1307,7 +1322,7 @@ async def _run_uncovered_sweep(ctx: FlowContext) -> None:
 
     uncovered_files, coverage_stats = compute_uncovered_files(dd.parent, session_id)
 
-    swept_files, skipped_small, skipped_capacity = filter_sweepable_files(
+    swept_files, skipped_small_files, skipped_capacity_files = filter_sweepable_files(
         uncovered_files,
         ctx.data["diff"],
         min_hunk_lines=_uncovered_sweep_min_hunk_lines(config),
@@ -1330,8 +1345,12 @@ async def _run_uncovered_sweep(ctx: FlowContext) -> None:
             "coverage_ratio": coverage_stats["coverage_ratio"],
         },
         "sweep_finding_count": 0,
-        "sweep_skipped_capacity": skipped_capacity,
-        "sweep_skipped_small_hunks": skipped_small,
+        # The integer skip counts are derived from the filename lists so the
+        # two views cannot diverge (issue #309 finding 10).
+        "sweep_skipped_capacity": len(skipped_capacity_files),
+        "sweep_skipped_small_hunks": len(skipped_small_files),
+        "sweep_skipped_capacity_files": skipped_capacity_files,
+        "sweep_skipped_small_hunks_files": skipped_small_files,
     }
     stats_p = dd / "coverage-stats.json"
 
@@ -1361,6 +1380,7 @@ async def _run_uncovered_sweep(ctx: FlowContext) -> None:
                 intent_path=ctx.data["intent_path"],
                 cwd=ctx.work.repo,
                 output_path=output_path,
+                exploration_dir=ctx.data["exploration_dir"],
             )
 
             async def _sweep_one(
@@ -1382,8 +1402,15 @@ async def _run_uncovered_sweep(ctx: FlowContext) -> None:
                             )
                             if budget_reason:
                                 sweep_failures[file] = f"budget exhausted: {budget_reason}"
-                            else:
+                            elif task_output.is_file():
+                                # A backend can return normally without writing
+                                # its output (phase_review guards the same
+                                # possibility); only an actual review file
+                                # counts as coverage, so the parse loop and
+                                # `completed_files` never see phantom outputs.
                                 review_outputs[file] = task_output
+                            else:
+                                sweep_failures[file] = "no review output written"
                         except Exception as exc:  # noqa: BLE001 -- parallel isolation; fail-open
                             sweep_failures[file] = f"{type(exc).__name__}: {exc}"
 
@@ -1393,9 +1420,12 @@ async def _run_uncovered_sweep(ctx: FlowContext) -> None:
         recorder.create_dispatch_step(phase=DaydreamPhase.DEEP)
 
     # Parse each sweep review into PER_STACK_RECORD_SCHEMA records (fail-open:
-    # unparseable or failed parses are dropped, never fatal).
+    # unparseable or failed parses are dropped, never fatal). Parse failures are
+    # tracked BY FILENAME into `sweep_failures`, not just the `parse_dropped`
+    # count, so coverage-stats.json names exactly which file's parse failed.
     parse_results: dict[str, list[dict[str, Any]]] = {}
     parse_dropped = 0
+    parse_failures: dict[str, str] = {}
 
     async def _parse_all() -> None:
         nonlocal parse_dropped
@@ -1417,8 +1447,11 @@ async def _run_uncovered_sweep(ctx: FlowContext) -> None:
                                     output_schema=PER_STACK_RECORD_SCHEMA,
                                 )
                                 parse_results[file] = records
-                            except Exception:  # noqa: BLE001 -- fail-open drop
+                            except Exception as exc:  # noqa: BLE001 -- fail-open drop
                                 parse_dropped += 1
+                                parse_failures[file] = (
+                                    f"parse failed: {type(exc).__name__}: {exc}"
+                                )
 
                 tg.start_soon(_parse_one)
 
@@ -1448,7 +1481,7 @@ async def _run_uncovered_sweep(ctx: FlowContext) -> None:
     for file in sorted(parse_results):
         sweep_records.extend(parse_results[file])
     stats["sweep_parse_dropped"] = parse_dropped
-    stats["sweep_failures"] = sweep_failures
+    stats["sweep_failures"] = {**sweep_failures, **parse_failures}
     stats["completed_files"] = sorted(review_outputs)
     if review_outputs:
         records_path = per_stack_records_path(dd, "uncovered")
@@ -1678,50 +1711,63 @@ def _append_coverage_section(dd: Path, report: Path, deep_copy: Path) -> None:
     landed); only files whose sweep review produced completed output are labeled
     covered. Failed sweep attempts are surfaced as failures, not claimed as
     coverage. A missing or malformed stats file is a silent no-op -- coverage
-    surfacing is advisory, never a gate.
+    surfacing is advisory, never a gate. ANY failure here (read error, invalid
+    JSON, structurally-malformed root, a non-dict shape) warns and returns; it
+    can never fail the merge step.
     """
     stats_p = dd / "coverage-stats.json"
     if not stats_p.is_file():
         return
     try:
         stats = json.loads(stats_p.read_text())
-    except json.JSONDecodeError:
-        return
-    pre_sweep = stats.get("pre_sweep")
-    if not isinstance(pre_sweep, dict):
-        return
-    files_in_diff = pre_sweep.get("files_in_diff")
-    if not isinstance(files_in_diff, int):
-        return
-    lines = [
-        "## Coverage",
-        f"- Files in diff: {files_in_diff}",
-    ]
-    # Prefer the POST-sweep numbers (the ratio the sweep actually achieved);
-    # fall back to the pre-sweep snapshot when the sweep did not recompute.
-    post_sweep = stats.get("post_sweep")
-    read_source = post_sweep if isinstance(post_sweep, dict) else pre_sweep
-    files_read = read_source.get("files_read_by_reviewers")
-    if isinstance(files_read, int):
-        lines.append(f"- Files read by reviewers: {files_read}")
-    ratio = read_source.get("coverage_ratio")
-    if isinstance(ratio, (int, float)):
-        lines.append(f"- Coverage ratio: {ratio}")
-    completed = stats.get("completed_files")
-    if isinstance(completed, list) and completed:
-        lines.append(f"- Second-pass sweep covered: {', '.join(str(f) for f in completed)}")
-    failures = stats.get("sweep_failures")
-    if isinstance(failures, dict) and failures:
-        lines.append(f"- Best-effort sweep failures: {', '.join(sorted(str(f) for f in failures))}")
-    skipped = stats.get("sweep_skipped_capacity")
-    if isinstance(skipped, int) and skipped:
-        lines.append(f"- Sweep capacity-skipped files: {skipped}")
-    section = "\n".join(lines) + "\n"
-    for target in (report, deep_copy):
-        if target.is_file():
-            text = target.read_text(encoding="utf-8")
-            if "## Coverage" not in text:
-                target.write_text(text.rstrip() + "\n\n" + section, encoding="utf-8")
+        if not isinstance(stats, dict):
+            print_warning(
+                console,
+                "Ignoring malformed coverage stats (expected a JSON object): "
+                f"{stats_p}",
+            )
+            return
+        pre_sweep = stats.get("pre_sweep")
+        if not isinstance(pre_sweep, dict):
+            return
+        files_in_diff = pre_sweep.get("files_in_diff")
+        if not isinstance(files_in_diff, int):
+            return
+        lines = [
+            "## Coverage",
+            f"- Files in diff: {files_in_diff}",
+        ]
+        # Prefer the POST-sweep numbers (the ratio the sweep actually achieved);
+        # fall back to the pre-sweep snapshot when the sweep did not recompute.
+        post_sweep = stats.get("post_sweep")
+        read_source = post_sweep if isinstance(post_sweep, dict) else pre_sweep
+        files_read = read_source.get("files_read_by_reviewers")
+        if isinstance(files_read, int):
+            lines.append(f"- Files read by reviewers: {files_read}")
+        ratio = read_source.get("coverage_ratio")
+        if isinstance(ratio, (int, float)):
+            lines.append(f"- Coverage ratio: {ratio}")
+        completed = stats.get("completed_files")
+        if isinstance(completed, list) and completed:
+            lines.append(f"- Second-pass sweep covered: {', '.join(str(f) for f in completed)}")
+        failures = stats.get("sweep_failures")
+        if isinstance(failures, dict) and failures:
+            lines.append(f"- Best-effort sweep failures: {', '.join(sorted(str(f) for f in failures))}")
+        skipped = stats.get("sweep_skipped_capacity")
+        if isinstance(skipped, int) and skipped:
+            lines.append(f"- Sweep capacity-skipped files: {skipped}")
+        section = "\n".join(lines) + "\n"
+        for target in (report, deep_copy):
+            if target.is_file():
+                text = target.read_text(encoding="utf-8")
+                if "## Coverage" not in text:
+                    target.write_text(text.rstrip() + "\n\n" + section, encoding="utf-8")
+    except Exception as exc:  # noqa: BLE001 -- advisory decoration: never fail the step
+        print_warning(
+            console,
+            "Skipping coverage stats render (advisory; run continues): "
+            f"{type(exc).__name__}: {exc}",
+        )
 
 
 async def _step_findings_out(ctx: FlowContext) -> Stop:
@@ -2197,8 +2243,18 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
             # finds nothing, or produces no output cannot leave stale records
             # that a later merge resume would reload. Merge/fix resumes keep
             # them (the sweep is a no-op there and the records must survive).
+            # Fail-CLOSED: an artifact that cannot be removed stops the resume
+            # (stale records reloaded as current findings would be worse than
+            # no resume); this call is at the resume boundary, OUTSIDE the
+            # sweep step's fail-open wrapper, so the raise cannot be swallowed.
             if config.start_at == "per-stack":
-                _clear_sweep_artifacts(dd)
+                try:
+                    _clear_sweep_artifacts(dd)
+                except OSError as exc:
+                    print_error(
+                        console, "Unusable Deep Artifacts", f"{exc}\n\nRe-run without --start-at to regenerate them."
+                    )
+                    return 1
 
         # Stack detection (from diff file list). Availability is resolved once in
         # runner.run and threaded via config; None flows through to detect_stacks'

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -31,6 +31,7 @@ from daydream.config import (
     DEFAULT_GROUP_MAX_SERIAL_ITEMS,
     DEFAULT_GROUP_MAX_WALL_S,
     DEFAULT_TOOL_CALL_BUDGET,
+    DEFAULT_UNCOVERED_SWEEP_ENABLED,
     DEFAULT_UNCOVERED_SWEEP_MAX_FILES,
     DEFAULT_UNCOVERED_SWEEP_MIN_HUNK_LINES,
     DEFAULT_WALL_BUDGET_S,
@@ -263,30 +264,45 @@ def _supervise_enabled(ctx: FlowContext) -> bool:
 
 
 def _uncovered_sweep_max_files(config: RunConfig) -> int:
-    """Resolve the per-run uncovered-file sweep capacity cap (issue #309)."""
-    return _resolve_config_value(
+    """Resolve the per-run uncovered-file sweep capacity cap (issue #309).
+
+    Non-negative only: an explicit ``0`` disables the sweep (nothing is
+    swept) while a negative value degrades to the named default -- mirroring
+    the file-config coercion in ``config_file._coerce_non_negative_int`` so a
+    directly-constructed ``RunConfig`` cannot smuggle an invalid capacity in.
+    """
+    value = _resolve_config_value(
         config, "uncovered_sweep_max_files", DEFAULT_UNCOVERED_SWEEP_MAX_FILES
     )
+    return value if value is not None and value >= 0 else DEFAULT_UNCOVERED_SWEEP_MAX_FILES
 
 
 def _uncovered_sweep_min_hunk_lines(config: RunConfig) -> int:
-    """Resolve the minimum hunk size for a file to be swept (issue #309)."""
-    return _resolve_config_value(
+    """Resolve the minimum hunk size for a file to be swept (issue #309).
+
+    Non-negative only: ``0`` removes the hunk-size floor (every uncovered file
+    is eligible) while a negative value degrades to the named default --
+    mirroring the file-config coercion so a negative floor can never make
+    zero-change/trivial blocks eligible.
+    """
+    value = _resolve_config_value(
         config, "uncovered_sweep_min_hunk_lines", DEFAULT_UNCOVERED_SWEEP_MIN_HUNK_LINES
     )
+    return value if value is not None and value >= 0 else DEFAULT_UNCOVERED_SWEEP_MIN_HUNK_LINES
 
 
 def _uncovered_sweep_enabled(ctx: FlowContext) -> bool:
     """Resolve the uncovered-file sweep toggle (issue #309).
 
     Precedence mirrors ``_precision_mode``: ``RunConfig`` field > file-config
-    scalar > built-in default ``True``. Resume at ``merge``/``fix`` disables the
-    step outright -- the per-stack records are already finalized on disk, so a
-    sweep would re-review stale coverage.
+    scalar > built-in default (:data:`DEFAULT_UNCOVERED_SWEEP_ENABLED`, the
+    single source of configuration defaults). Resume at ``merge``/``fix``
+    disables the step outright -- the per-stack records are already finalized
+    on disk, so a sweep would re-review stale coverage.
     """
     if ctx.config.start_at in ("merge", "fix"):
         return False
-    return _resolve_config_value(ctx.config, "uncovered_sweep", True)
+    return _resolve_config_value(ctx.config, "uncovered_sweep", DEFAULT_UNCOVERED_SWEEP_ENABLED)
 
 
 def _collapse_stacks_for_tiny_diff(
@@ -1232,6 +1248,30 @@ async def _step_per_stack_parse(ctx: FlowContext) -> Stop | None:
     return None
 
 
+def _clear_sweep_artifacts(dd: Path) -> None:
+    """Delete the uncovered-file sweep's owned artifacts from ``dd``.
+
+    ``coverage-stats.json``, ``stack-uncovered-records.json``, and every
+    ``uncovered-*-review.md`` are the sweep's outputs. A ``--start-at per-stack``
+    resume re-runs the sweep, so any artifact left from the prior run must be
+    removed BEFORE new per-stack work: otherwise a rerun whose sweep is
+    disabled / finds nothing / produces no output would leave stale records
+    behind, and a later merge resume would reload them as this run's coverage.
+    Merge/fix resumes keep the artifacts (the sweep is a no-op there and the
+    records must survive).
+    """
+    for pattern in (
+        "coverage-stats.json",
+        "stack-uncovered-records.json",
+        "uncovered-*-review.md",
+    ):
+        for path in dd.glob(pattern):
+            try:
+                path.unlink()
+            except OSError:
+                pass
+
+
 async def _step_uncovered_sweep(ctx: FlowContext) -> None:
     """Issue #309: fail-open second-pass sweep over diff files no reviewer read.
 
@@ -1275,11 +1315,20 @@ async def _run_uncovered_sweep(ctx: FlowContext) -> None:
     )
 
     stats: dict[str, Any] = {
-        "files_in_diff": coverage_stats["files_in_diff"],
-        "files_read_by_reviewers": coverage_stats["files_read_by_reviewers"],
-        "coverage_ratio": coverage_stats["coverage_ratio"],
-        "uncovered_files": uncovered_files,
-        "swept_files": swept_files,
+        "pre_sweep": {
+            "files_in_diff": coverage_stats["files_in_diff"],
+            "files_read_by_reviewers": coverage_stats["files_read_by_reviewers"],
+            "coverage_ratio": coverage_stats["coverage_ratio"],
+            "uncovered_files": uncovered_files,
+        },
+        "attempted_files": swept_files,
+        "completed_files": [],
+        # POST-sweep ratio is recomputed below after the sweep forks land; this
+        # pre-sweep snapshot is the fallback when the sweep produces no reads.
+        "post_sweep": {
+            "files_read_by_reviewers": coverage_stats["files_read_by_reviewers"],
+            "coverage_ratio": coverage_stats["coverage_ratio"],
+        },
         "sweep_finding_count": 0,
         "sweep_skipped_capacity": skipped_capacity,
         "sweep_skipped_small_hunks": skipped_small,
@@ -1287,6 +1336,11 @@ async def _run_uncovered_sweep(ctx: FlowContext) -> None:
     stats_p = dd / "coverage-stats.json"
 
     if not swept_files:
+        # A re-run that finds nothing to sweep must still refresh the records
+        # artifact to a current empty list so a stale prior file (from the run
+        # being resumed) cannot linger and be reloaded by a later merge resume.
+        if config.start_at == "per-stack":
+            per_stack_records_path(dd, "uncovered").write_text(json.dumps([]))
         stats_p.write_text(json.dumps(stats, indent=2))
         return
 
@@ -1370,16 +1424,32 @@ async def _run_uncovered_sweep(ctx: FlowContext) -> None:
 
     await _parse_all()
 
+    # Recompute coverage AFTER the sweep so the report shows the ratio the
+    # sweep actually achieved (the ``deep-uncovered-*`` forks' completed reads
+    # now count), never the pre-sweep snapshot. The recompute is fail-open: a
+    # failure here falls back to the pre-sweep numbers already stored.
+    try:
+        _, post_coverage = compute_uncovered_files(dd.parent, session_id)
+        stats["post_sweep"] = {
+            "files_read_by_reviewers": post_coverage["files_read_by_reviewers"],
+            "coverage_ratio": post_coverage["coverage_ratio"],
+        }
+    except Exception:  # noqa: BLE001 -- fail-open: keep the pre-sweep fallback
+        pass
+
     # Merge the sweep records into the per-stack record set exactly like the
     # per-stack parse loop does, so arbiter/merge consume them as ordinary
     # per-stack records (no separate score path). The records file is written
     # whenever at least one sweep review produced output -- an emptied sweep
-    # stack is ``[]``, mirroring ``_rewrite_stack_records`` semantics.
+    # stack is ``[]``, mirroring ``_rewrite_stack_records`` semantics. When NO
+    # review produced output, a current empty records artifact is still written
+    # so a stale file from a prior run cannot linger.
     sweep_records: list[dict[str, Any]] = []
     for file in sorted(parse_results):
         sweep_records.extend(parse_results[file])
     stats["sweep_parse_dropped"] = parse_dropped
     stats["sweep_failures"] = sweep_failures
+    stats["completed_files"] = sorted(review_outputs)
     if review_outputs:
         records_path = per_stack_records_path(dd, "uncovered")
         records_path.write_text(json.dumps(sweep_records, indent=2))
@@ -1387,6 +1457,11 @@ async def _run_uncovered_sweep(ctx: FlowContext) -> None:
         ctx.data["records"].extend(sweep_records)
         ctx.data["record_sources"].extend("uncovered" for _ in sweep_records)
         stats["sweep_finding_count"] = len(sweep_records)
+    else:
+        # No review produced output: on a re-run, write a current empty records
+        # artifact so a stale file from the resumed run cannot linger.
+        if config.start_at == "per-stack":
+            per_stack_records_path(dd, "uncovered").write_text(json.dumps([]))
     stats_p.write_text(json.dumps(stats, indent=2))
 
 
@@ -1597,10 +1672,13 @@ async def _step_load_items(ctx: FlowContext) -> Stop | None:
 def _append_coverage_section(dd: Path, report: Path, deep_copy: Path) -> None:
     """Append a short ``## Coverage`` section when the sweep produced stats.
 
-    Reads ``deep/coverage-stats.json`` and appends files_read / files_in_diff /
-    ratio / swept files to both the canonical report and its deep-dir copy. A
-    missing or malformed stats file is a silent no-op -- coverage surfacing is
-    advisory, never a gate.
+    Reads ``deep/coverage-stats.json`` and appends files_in_diff / files read /
+    ratio / swept files to both the canonical report and its deep-dir copy. The
+    ratio rendered is the POST-sweep value (recomputed after the sweep's forks
+    landed); only files whose sweep review produced completed output are labeled
+    covered. Failed sweep attempts are surfaced as failures, not claimed as
+    coverage. A missing or malformed stats file is a silent no-op -- coverage
+    surfacing is advisory, never a gate.
     """
     stats_p = dd / "coverage-stats.json"
     if not stats_p.is_file():
@@ -1609,19 +1687,35 @@ def _append_coverage_section(dd: Path, report: Path, deep_copy: Path) -> None:
         stats = json.loads(stats_p.read_text())
     except json.JSONDecodeError:
         return
-    files_in_diff = stats.get("files_in_diff")
-    files_read = stats.get("files_read_by_reviewers")
-    if not isinstance(files_in_diff, int) or not isinstance(files_read, int):
+    pre_sweep = stats.get("pre_sweep")
+    if not isinstance(pre_sweep, dict):
+        return
+    files_in_diff = pre_sweep.get("files_in_diff")
+    if not isinstance(files_in_diff, int):
         return
     lines = [
         "## Coverage",
         f"- Files in diff: {files_in_diff}",
-        f"- Files read by reviewers: {files_read}",
-        f"- Coverage ratio: {stats.get('coverage_ratio')}",
     ]
-    swept = stats.get("swept_files")
-    if isinstance(swept, list) and swept:
-        lines.append(f"- Second-pass sweep covered: {', '.join(str(f) for f in swept)}")
+    # Prefer the POST-sweep numbers (the ratio the sweep actually achieved);
+    # fall back to the pre-sweep snapshot when the sweep did not recompute.
+    post_sweep = stats.get("post_sweep")
+    read_source = post_sweep if isinstance(post_sweep, dict) else pre_sweep
+    files_read = read_source.get("files_read_by_reviewers")
+    if isinstance(files_read, int):
+        lines.append(f"- Files read by reviewers: {files_read}")
+    ratio = read_source.get("coverage_ratio")
+    if isinstance(ratio, (int, float)):
+        lines.append(f"- Coverage ratio: {ratio}")
+    completed = stats.get("completed_files")
+    if isinstance(completed, list) and completed:
+        lines.append(f"- Second-pass sweep covered: {', '.join(str(f) for f in completed)}")
+    failures = stats.get("sweep_failures")
+    if isinstance(failures, dict) and failures:
+        lines.append(f"- Best-effort sweep failures: {', '.join(sorted(str(f) for f in failures))}")
+    skipped = stats.get("sweep_skipped_capacity")
+    if isinstance(skipped, int) and skipped:
+        lines.append(f"- Sweep capacity-skipped files: {skipped}")
     section = "\n".join(lines) + "\n"
     for target in (report, deep_copy):
         if target.is_file():
@@ -1980,7 +2074,7 @@ STEPS: tuple[FlowStep, ...] = (
     FlowStep(name="intent", run=_step_intent, enabled=_fresh_ttt),
     FlowStep(name="per-stack-reviews", run=_step_wonder_and_per_stack, config_phase="per_stack_review"),
     FlowStep(name="per-stack-parse", run=_step_per_stack_parse, config_phase="parse", enabled=_before_fix_resume),
-    FlowStep(name="uncovered-sweep", run=_step_uncovered_sweep, enabled=_uncovered_sweep_enabled),
+    FlowStep(name="uncovered-sweep", run=_step_uncovered_sweep, enabled=_uncovered_sweep_enabled, config_phase="parse"),
     FlowStep(name="arbiter", run=_step_arbiter, enabled=_multi_stack_merge_enabled),
     FlowStep(
         name="cross-stack-merge", run=_step_cross_stack_merge, config_phase="merge", enabled=_multi_stack_merge_enabled
@@ -2097,6 +2191,14 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
             except FileNotFoundError as exc:
                 print_error(console, "Unusable Deep Artifacts", str(exc))
                 return 1
+            # Issue #309: a per-stack resume re-runs the sweep, so the prior
+            # run's sweep artifacts are about to be superseded. Clear them now
+            # (before new per-stack work) so a rerun whose sweep is disabled,
+            # finds nothing, or produces no output cannot leave stale records
+            # that a later merge resume would reload. Merge/fix resumes keep
+            # them (the sweep is a no-op there and the records must survive).
+            if config.start_at == "per-stack":
+                _clear_sweep_artifacts(dd)
 
         # Stack detection (from diff file list). Availability is resolved once in
         # runner.run and threaded via config; None flows through to detect_stacks'

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -25,11 +25,15 @@ from typing import TYPE_CHECKING, Any
 import anyio
 from rich.markup import escape as escape_markup
 
-from daydream.agent import console, get_assume, get_non_interactive, resolve_or_prompt
+from daydream.agent import console, get_assume, get_non_interactive, resolve_or_prompt, run_agent
 from daydream.backends import effective_fanout_concurrency
 from daydream.config import (
     DEFAULT_GROUP_MAX_SERIAL_ITEMS,
     DEFAULT_GROUP_MAX_WALL_S,
+    DEFAULT_TOOL_CALL_BUDGET,
+    DEFAULT_UNCOVERED_SWEEP_MAX_FILES,
+    DEFAULT_UNCOVERED_SWEEP_MIN_HUNK_LINES,
+    DEFAULT_WALL_BUDGET_S,
     REVIEW_OUTPUT_FILE,
     STRUCTURE_STACK_NAME,
 )
@@ -55,6 +59,12 @@ from daydream.deep.artifacts import (
 )
 from daydream.deep.artifacts import (
     intent_path as _intent_path,
+)
+from daydream.deep.coverage import (
+    build_uncovered_sweep_prompt,
+    compute_uncovered_files,
+    diff_block_for_file,
+    filter_sweepable_files,
 )
 from daydream.deep.dedup import (
     CandidatePair,
@@ -191,7 +201,7 @@ def _single_stack_agent_count(stack_count: int) -> int:
     return 2 + stack_count + stack_count
 
 
-def _resolve_config_value[T: (int, float)](config: RunConfig, attr: str, default: T) -> T:
+def _resolve_config_value[T: (int, float, bool)](config: RunConfig, attr: str, default: T) -> T:
     """Resolve a scalar setting: ``RunConfig`` attr (when present) > file config > default.
 
     Precedence mirrors ``_resolve_backend`` / ``_resolved_model`` at
@@ -250,6 +260,33 @@ def _supervisor_mode(config: RunConfig) -> str:
 def _supervise_enabled(ctx: FlowContext) -> bool:
     """Run supervision on fresh flows, not on a fix-only resume."""
     return _supervisor_mode(ctx.config) in {"rules", "llm"} and ctx.config.start_at != "fix"
+
+
+def _uncovered_sweep_max_files(config: RunConfig) -> int:
+    """Resolve the per-run uncovered-file sweep capacity cap (issue #309)."""
+    return _resolve_config_value(
+        config, "uncovered_sweep_max_files", DEFAULT_UNCOVERED_SWEEP_MAX_FILES
+    )
+
+
+def _uncovered_sweep_min_hunk_lines(config: RunConfig) -> int:
+    """Resolve the minimum hunk size for a file to be swept (issue #309)."""
+    return _resolve_config_value(
+        config, "uncovered_sweep_min_hunk_lines", DEFAULT_UNCOVERED_SWEEP_MIN_HUNK_LINES
+    )
+
+
+def _uncovered_sweep_enabled(ctx: FlowContext) -> bool:
+    """Resolve the uncovered-file sweep toggle (issue #309).
+
+    Precedence mirrors ``_precision_mode``: ``RunConfig`` field > file-config
+    scalar > built-in default ``True``. Resume at ``merge``/``fix`` disables the
+    step outright -- the per-stack records are already finalized on disk, so a
+    sweep would re-review stale coverage.
+    """
+    if ctx.config.start_at in ("merge", "fix"):
+        return False
+    return _resolve_config_value(ctx.config, "uncovered_sweep", True)
 
 
 def _collapse_stacks_for_tiny_diff(
@@ -1085,6 +1122,13 @@ async def _step_per_stack_parse(ctx: FlowContext) -> Stop | None:
                 + ", ".join(sorted(missing_stacks)),
             )
             return Stop(1)
+        # Issue #309: a prior run's uncovered-file sweep records are
+        # per-stack-style findings already finalized on disk (the sweep itself
+        # is a no-op on resume). Load them so a merge resume keeps the sweep's
+        # findings instead of silently dropping them.
+        sweep_path = per_stack_records_path(dd, "uncovered")
+        if sweep_path.is_file():
+            expected_paths.append(sweep_path)
         for records_path in sorted(expected_paths):
             records = json.loads(records_path.read_text())
             per_stack_records_paths.append(records_path)
@@ -1186,6 +1230,164 @@ async def _step_per_stack_parse(ctx: FlowContext) -> Stop | None:
     ctx.data["record_sources"] = record_sources
     ctx.data["structural_records_path"] = structural_records_path
     return None
+
+
+async def _step_uncovered_sweep(ctx: FlowContext) -> None:
+    """Issue #309: fail-open second-pass sweep over diff files no reviewer read.
+
+    After per-stack reviews + parse, computes which diff files no ``deep-``
+    reviewer read (via ``analyze_coverage``), budget-filters them (hunk size +
+    capacity cap), dispatches one cheap reviewer per surviving file, parses the
+    findings into ordinary ``PER_STACK_RECORD_SCHEMA`` records, and appends
+    them to ``ctx.data`` so the arbiter/merge consume them exactly like any
+    per-stack stack's records. Coverage stats land in ``deep/coverage-stats.json``.
+
+    Fail-open: any exception here is caught, logged as a warning, and the step
+    returns normally -- the sweep must NEVER fail the run.
+    """
+    if ctx.config.start_at in ("merge", "fix"):
+        # Resume: records are already finalized on disk; a sweep would
+        # re-review stale coverage against a diff that already ran.
+        return None
+    try:
+        await _run_uncovered_sweep(ctx)
+    except Exception as exc:  # noqa: BLE001 -- fail-open: never fail the run
+        print_warning(
+            console,
+            f"Uncovered-file sweep failed (fail-open): {type(exc).__name__}: {exc}",
+        )
+
+
+async def _run_uncovered_sweep(ctx: FlowContext) -> None:
+    """Run the uncovered-file sweep body (issue #309)."""
+    config = ctx.config
+    dd = ctx.data["dd"]
+    recorder = get_current_recorder()
+    session_id = recorder.session_id if recorder is not None else None
+
+    uncovered_files, coverage_stats = compute_uncovered_files(dd.parent, session_id)
+
+    swept_files, skipped_small, skipped_capacity = filter_sweepable_files(
+        uncovered_files,
+        ctx.data["diff"],
+        min_hunk_lines=_uncovered_sweep_min_hunk_lines(config),
+        max_files=_uncovered_sweep_max_files(config),
+    )
+
+    stats: dict[str, Any] = {
+        "files_in_diff": coverage_stats["files_in_diff"],
+        "files_read_by_reviewers": coverage_stats["files_read_by_reviewers"],
+        "coverage_ratio": coverage_stats["coverage_ratio"],
+        "uncovered_files": uncovered_files,
+        "swept_files": swept_files,
+        "sweep_finding_count": 0,
+        "sweep_skipped_capacity": skipped_capacity,
+        "sweep_skipped_small_hunks": skipped_small,
+    }
+    stats_p = dd / "coverage-stats.json"
+
+    if not swept_files:
+        stats_p.write_text(json.dumps(stats, indent=2))
+        return
+
+    # Cheap-tier dispatch (parse tier), parallel, in diff order. Each sweep
+    # fork is `deep-uncovered-<n>` so post-run analyze_coverage counts its
+    # reads (the coverage-ratio-improves acceptance criterion).
+    parse_backend = ctx.backend_for("parse")
+    limiter = anyio.CapacityLimiter(effective_fanout_concurrency(10, parse_backend))
+    review_outputs: dict[str, Path] = {}
+    sweep_failures: dict[str, str] = {}
+
+    async with anyio.create_task_group() as tg:
+        for n, file in enumerate(swept_files):
+            output_path = dd / f"uncovered-{n}-review.md"
+            prompt = build_uncovered_sweep_prompt(
+                file=file,
+                hunks=diff_block_for_file(ctx.data["diff"], file) or "",
+                intent_path=ctx.data["intent_path"],
+                cwd=ctx.work.repo,
+                output_path=output_path,
+            )
+
+            async def _sweep_one(
+                file: str = file,
+                task_prompt: str = prompt,
+                task_output: Path = output_path,
+                n: int = n,
+            ) -> None:
+                async with limiter:
+                    async with maybe_fork(recorder, f"deep-uncovered-{n}"):
+                        try:
+                            _, _, budget_reason = await run_agent(
+                                parse_backend,
+                                ctx.work.repo,
+                                task_prompt,
+                                phase=DaydreamPhase.DEEP,
+                                tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
+                                wall_budget_s=DEFAULT_WALL_BUDGET_S,
+                            )
+                            if budget_reason:
+                                sweep_failures[file] = f"budget exhausted: {budget_reason}"
+                            else:
+                                review_outputs[file] = task_output
+                        except Exception as exc:  # noqa: BLE001 -- parallel isolation; fail-open
+                            sweep_failures[file] = f"{type(exc).__name__}: {exc}"
+
+            tg.start_soon(_sweep_one)
+
+    if recorder is not None:
+        recorder.create_dispatch_step(phase=DaydreamPhase.DEEP)
+
+    # Parse each sweep review into PER_STACK_RECORD_SCHEMA records (fail-open:
+    # unparseable or failed parses are dropped, never fatal).
+    parse_results: dict[str, list[dict[str, Any]]] = {}
+    parse_dropped = 0
+
+    async def _parse_all() -> None:
+        nonlocal parse_dropped
+        async with anyio.create_task_group() as tg:
+            for i, (file, output_path) in enumerate(sorted(review_outputs.items())):
+                async def _parse_one(
+                    file: str = file,
+                    input_path: Path = output_path,
+                    i: int = i,
+                ) -> None:
+                    nonlocal parse_dropped
+                    async with limiter:
+                        async with maybe_fork(recorder, f"parse-uncovered-{i}"):
+                            try:
+                                records = await phase_parse_feedback(
+                                    parse_backend,
+                                    ctx.work,
+                                    input_path=input_path,
+                                    output_schema=PER_STACK_RECORD_SCHEMA,
+                                )
+                                parse_results[file] = records
+                            except Exception:  # noqa: BLE001 -- fail-open drop
+                                parse_dropped += 1
+
+                tg.start_soon(_parse_one)
+
+    await _parse_all()
+
+    # Merge the sweep records into the per-stack record set exactly like the
+    # per-stack parse loop does, so arbiter/merge consume them as ordinary
+    # per-stack records (no separate score path). The records file is written
+    # whenever at least one sweep review produced output -- an emptied sweep
+    # stack is ``[]``, mirroring ``_rewrite_stack_records`` semantics.
+    sweep_records: list[dict[str, Any]] = []
+    for file in sorted(parse_results):
+        sweep_records.extend(parse_results[file])
+    stats["sweep_parse_dropped"] = parse_dropped
+    stats["sweep_failures"] = sweep_failures
+    if review_outputs:
+        records_path = per_stack_records_path(dd, "uncovered")
+        records_path.write_text(json.dumps(sweep_records, indent=2))
+        ctx.data["records_paths"].append(records_path)
+        ctx.data["records"].extend(sweep_records)
+        ctx.data["record_sources"].extend("uncovered" for _ in sweep_records)
+        stats["sweep_finding_count"] = len(sweep_records)
+    stats_p.write_text(json.dumps(stats, indent=2))
 
 
 async def _step_arbiter(ctx: FlowContext) -> None:
@@ -1375,15 +1577,57 @@ async def _step_load_items(ctx: FlowContext) -> Stop | None:
     # the exit message when the canonical file is absent (e.g. a --start-at fix
     # resume where the copy to the canonical path never ran). Non-fatal.
     if not merged_report.exists():
-        from daydream.deep.artifacts import merged_report_path
+        from daydream.deep.artifacts import merged_report_path as _deep_report_path
 
-        deep_copy = merged_report_path(dd)
+        deep_copy = _deep_report_path(dd)
         if deep_copy.exists():
             merged_report.write_text(deep_copy.read_text())
+
+    # Issue #309: surface the uncovered-sweep coverage stats on the rendered
+    # report. The sweep runs BEFORE the merge writes review-output.md, so the
+    # section is appended here, once the report exists, to both the canonical
+    # report and its deep-dir copy.
+    _append_coverage_section(dd, merged_report, merged_report_path(dd))
 
     ctx.data["merged_report"] = merged_report
     ctx.data["items_file"] = items_file
     return None
+
+
+def _append_coverage_section(dd: Path, report: Path, deep_copy: Path) -> None:
+    """Append a short ``## Coverage`` section when the sweep produced stats.
+
+    Reads ``deep/coverage-stats.json`` and appends files_read / files_in_diff /
+    ratio / swept files to both the canonical report and its deep-dir copy. A
+    missing or malformed stats file is a silent no-op -- coverage surfacing is
+    advisory, never a gate.
+    """
+    stats_p = dd / "coverage-stats.json"
+    if not stats_p.is_file():
+        return
+    try:
+        stats = json.loads(stats_p.read_text())
+    except json.JSONDecodeError:
+        return
+    files_in_diff = stats.get("files_in_diff")
+    files_read = stats.get("files_read_by_reviewers")
+    if not isinstance(files_in_diff, int) or not isinstance(files_read, int):
+        return
+    lines = [
+        "## Coverage",
+        f"- Files in diff: {files_in_diff}",
+        f"- Files read by reviewers: {files_read}",
+        f"- Coverage ratio: {stats.get('coverage_ratio')}",
+    ]
+    swept = stats.get("swept_files")
+    if isinstance(swept, list) and swept:
+        lines.append(f"- Second-pass sweep covered: {', '.join(str(f) for f in swept)}")
+    section = "\n".join(lines) + "\n"
+    for target in (report, deep_copy):
+        if target.is_file():
+            text = target.read_text(encoding="utf-8")
+            if "## Coverage" not in text:
+                target.write_text(text.rstrip() + "\n\n" + section, encoding="utf-8")
 
 
 async def _step_findings_out(ctx: FlowContext) -> Stop:
@@ -1721,8 +1965,8 @@ def _findings_out_enabled(ctx: FlowContext) -> bool:
 # The deep pipeline as a registered flow (D-07):
 #
 #     exploration pre-scan -> TTT intent -> TTT alternative-review ->
-#     per-stack reviews -> per-stack parse + dedup -> arbiter ->
-#     cross-stack merge (or the tiny-diff single-stack bypass) ->
+#     per-stack reviews -> per-stack parse + dedup -> uncovered-file sweep (#309)
+#     -> arbiter -> cross-stack merge (or the tiny-diff single-stack bypass) ->
 #     supervise -> findings-out stop / post-review -> fix gate -> verify -> fix ->
 #     test -> commit.
 #
@@ -1736,6 +1980,7 @@ STEPS: tuple[FlowStep, ...] = (
     FlowStep(name="intent", run=_step_intent, enabled=_fresh_ttt),
     FlowStep(name="per-stack-reviews", run=_step_wonder_and_per_stack, config_phase="per_stack_review"),
     FlowStep(name="per-stack-parse", run=_step_per_stack_parse, config_phase="parse", enabled=_before_fix_resume),
+    FlowStep(name="uncovered-sweep", run=_step_uncovered_sweep, enabled=_uncovered_sweep_enabled),
     FlowStep(name="arbiter", run=_step_arbiter, enabled=_multi_stack_merge_enabled),
     FlowStep(
         name="cross-stack-merge", run=_step_cross_stack_merge, config_phase="merge", enabled=_multi_stack_merge_enabled

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -38,6 +38,7 @@ from daydream.config import (
     REVIEW_OUTPUT_FILE,
     STRUCTURE_STACK_NAME,
 )
+from daydream.config_file import _coerce_non_negative_int
 from daydream.deep.arbiter import select_arbiter_targets, select_suppression_targets
 from daydream.deep.artifacts import (
     adjudication_complete_path,
@@ -266,29 +267,36 @@ def _supervise_enabled(ctx: FlowContext) -> bool:
 def _uncovered_sweep_max_files(config: RunConfig) -> int:
     """Resolve the per-run uncovered-file sweep capacity cap (issue #309).
 
-    Non-negative only: an explicit ``0`` disables the sweep (nothing is
-    swept) while a negative value degrades to the named default -- mirroring
-    the file-config coercion in ``config_file._coerce_non_negative_int`` so a
-    directly-constructed ``RunConfig`` cannot smuggle an invalid capacity in.
+    Integer-only non-negative: an explicit ``0`` disables the sweep (nothing is
+    swept) while a negative value, a float, a bool, or any non-int degrades to
+    the named default -- the same integer-only predicate as the file-config
+    coercion ``config_file._coerce_non_negative_int`` (reused, import read-only)
+    so a directly-constructed ``RunConfig`` cannot smuggle an invalid capacity
+    in. ``filter_sweepable_files`` slices with ``max_files``, so a float here
+    would raise TypeError and the fail-open wrapper would discard the ENTIRE
+    sweep -- type validation lives at the resolver.
     """
     value = _resolve_config_value(
         config, "uncovered_sweep_max_files", DEFAULT_UNCOVERED_SWEEP_MAX_FILES
     )
-    return value if value is not None and value >= 0 else DEFAULT_UNCOVERED_SWEEP_MAX_FILES
+    coerced = _coerce_non_negative_int(value)
+    return coerced if coerced is not None else DEFAULT_UNCOVERED_SWEEP_MAX_FILES
 
 
 def _uncovered_sweep_min_hunk_lines(config: RunConfig) -> int:
     """Resolve the minimum hunk size for a file to be swept (issue #309).
 
-    Non-negative only: ``0`` removes the hunk-size floor (every uncovered file
-    is eligible) while a negative value degrades to the named default --
-    mirroring the file-config coercion so a negative floor can never make
-    zero-change/trivial blocks eligible.
+    Integer-only non-negative: ``0`` removes the hunk-size floor (every
+    uncovered file is eligible) while a negative value, a float, a bool, or any
+    non-int degrades to the named default -- mirroring
+    ``config_file._coerce_non_negative_int`` so a negative or malformed floor
+    can never make zero-change/trivial blocks eligible.
     """
     value = _resolve_config_value(
         config, "uncovered_sweep_min_hunk_lines", DEFAULT_UNCOVERED_SWEEP_MIN_HUNK_LINES
     )
-    return value if value is not None and value >= 0 else DEFAULT_UNCOVERED_SWEEP_MIN_HUNK_LINES
+    coerced = _coerce_non_negative_int(value)
+    return coerced if coerced is not None else DEFAULT_UNCOVERED_SWEEP_MIN_HUNK_LINES
 
 
 def _uncovered_sweep_enabled(ctx: FlowContext) -> bool:
@@ -303,6 +311,31 @@ def _uncovered_sweep_enabled(ctx: FlowContext) -> bool:
     if ctx.config.start_at in ("merge", "fix"):
         return False
     return _resolve_config_value(ctx.config, "uncovered_sweep", DEFAULT_UNCOVERED_SWEEP_ENABLED)
+
+
+def _uncovered_sweep_preflight_note(config: RunConfig, changed_files: list[str]) -> str | None:
+    """Sweep additive for the pre-flight agent estimate (issue #309 finding 8).
+
+    The pre-flight total counts only the known phases; the uncovered files the
+    sweep will review are not known until after per-stack reviews + parse. Every
+    swept file adds one review invocation AND one parse invocation (parse per
+    stack file), so an honest estimate appends an upper-bound note: 2 agents per
+    file, capped by the configured capacity and the number of changed files that
+    could possibly be swept. Returns ``None`` when the sweep is disabled or
+    nothing could be swept.
+    """
+    if config.start_at in ("merge", "fix"):
+        return None
+    if not _resolve_config_value(config, "uncovered_sweep", DEFAULT_UNCOVERED_SWEEP_ENABLED):
+        return None
+    max_files = _uncovered_sweep_max_files(config)
+    eligible = min(len(changed_files), max_files)
+    if eligible <= 0:
+        return None
+    return (
+        f"(+ up to {2 * eligible} sweep agents: review + parse per uncovered "
+        "file, capped by eligible changed files)"
+    )
 
 
 def _collapse_stacks_for_tiny_diff(
@@ -1338,6 +1371,12 @@ async def _run_uncovered_sweep(ctx: FlowContext) -> None:
         },
         "attempted_files": swept_files,
         "completed_files": [],
+        # Issue #309 finding 6: ``covered_files`` is filled from the POST-sweep
+        # recompute (verified completed reads of the swept files) and may be a
+        # strict subset of ``completed_files`` -- a review written without a
+        # Read of the file is an attempt, never coverage. Until the recompute
+        # runs it starts empty (fail-open: unverifiable means not claimed).
+        "covered_files": [],
         # POST-sweep ratio is recomputed below after the sweep forks land; this
         # pre-sweep snapshot is the fallback when the sweep produces no reads.
         "post_sweep": {
@@ -1460,13 +1499,20 @@ async def _run_uncovered_sweep(ctx: FlowContext) -> None:
     # Recompute coverage AFTER the sweep so the report shows the ratio the
     # sweep actually achieved (the ``deep-uncovered-*`` forks' completed reads
     # now count), never the pre-sweep snapshot. The recompute is fail-open: a
-    # failure here falls back to the pre-sweep numbers already stored.
+    # failure here falls back to the pre-sweep numbers already stored. The same
+    # recompute drives ``covered_files`` (issue #309 finding 6): a swept file is
+    # covered only when the post-sweep uncovered list no longer contains it --
+    # i.e. a verified completed read of the file happened. A successful review
+    # output WITHOUT a read leaves the file in the uncovered list, so it is
+    # never claimed as covered.
+    post_uncovered: list[str] | None = None
     try:
-        _, post_coverage = compute_uncovered_files(dd.parent, session_id)
+        post_uncovered, post_coverage = compute_uncovered_files(dd.parent, session_id)
         stats["post_sweep"] = {
             "files_read_by_reviewers": post_coverage["files_read_by_reviewers"],
             "coverage_ratio": post_coverage["coverage_ratio"],
         }
+        stats["covered_files"] = sorted(f for f in review_outputs if f not in post_uncovered)
     except Exception:  # noqa: BLE001 -- fail-open: keep the pre-sweep fallback
         pass
 
@@ -1483,6 +1529,15 @@ async def _run_uncovered_sweep(ctx: FlowContext) -> None:
     stats["sweep_parse_dropped"] = parse_dropped
     stats["sweep_failures"] = {**sweep_failures, **parse_failures}
     stats["completed_files"] = sorted(review_outputs)
+    # Issue #309 finding 6: per-file attempt status. A completed review output
+    # is a completed ATTEMPT; only files with a verified post-sweep completed
+    # read are "read". Anything else is "reviewed (hunks only)" and must not
+    # move files_read_by_reviewers / coverage_ratio.
+    covered_set = set(stats.get("covered_files") or [])
+    stats["sweep_attempt_status"] = {
+        file: ("read" if file in covered_set else "reviewed (hunks only)")
+        for file in sorted(review_outputs)
+    }
     if review_outputs:
         records_path = per_stack_records_path(dd, "uncovered")
         records_path.write_text(json.dumps(sweep_records, indent=2))
@@ -1747,9 +1802,22 @@ def _append_coverage_section(dd: Path, report: Path, deep_copy: Path) -> None:
         ratio = read_source.get("coverage_ratio")
         if isinstance(ratio, (int, float)):
             lines.append(f"- Coverage ratio: {ratio}")
+        # Issue #309 finding 6: only files with a verified completed read are
+        # labeled covered. A completed review output WITHOUT a read is a
+        # completed attempt -- rendered as "reviewed (hunks only)" -- and never
+        # appears on the covered line nor moves the ratio above.
+        covered = stats.get("covered_files")
+        if isinstance(covered, list) and covered:
+            lines.append(f"- Second-pass sweep covered: {', '.join(str(f) for f in covered)}")
         completed = stats.get("completed_files")
-        if isinstance(completed, list) and completed:
-            lines.append(f"- Second-pass sweep covered: {', '.join(str(f) for f in completed)}")
+        if isinstance(completed, list):
+            hunks_only = [
+                str(f) for f in completed if not (isinstance(covered, list) and f in covered)
+            ]
+            if hunks_only:
+                lines.append(
+                    f"- Second-pass sweep reviewed (hunks only): {', '.join(hunks_only)}"
+                )
         failures = stats.get("sweep_failures")
         if isinstance(failures, dict) and failures:
             lines.append(f"- Best-effort sweep failures: {', '.join(sorted(str(f) for f in failures))}")
@@ -2286,6 +2354,7 @@ async def run_deep(config: RunConfig, work: WorkContext) -> int:
             stack_lines=stack_lines,
             agent_count=notice_agent_count,
             exploration_available=EXPLORATION_AVAILABLE,
+            sweep_note=_uncovered_sweep_preflight_note(config, changed_files),
         )
 
         # Flow context (steps communicate through ctx.data); ctx shares

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -220,6 +220,21 @@ class RunConfig:
             means unresolved or registry-unreadable (→ optimistic routing in
             ``detect_stacks``). Set explicitly to inject availability and bypass
             the probe (tests).
+        uncovered_sweep: Issue #309. Toggle the uncovered-diff-file sweep (the
+            second-pass reviewer over diff files no per-stack reviewer read).
+            ``None`` falls through to ``file_config.uncovered_sweep`` then the
+            built-in default ``True`` (precedence CLI > file > default,
+            mirroring ``shallow_fanout_threshold``; resolved by
+            ``_uncovered_sweep_enabled``).
+        uncovered_sweep_max_files: Issue #309. Cap on how many uncovered files
+            are swept in one run; files beyond the cap are recorded in
+            ``coverage-stats.json`` as ``sweep_skipped_capacity`` rather than
+            silently dropped. ``None`` falls through to file config then
+            ``DEFAULT_UNCOVERED_SWEEP_MAX_FILES`` (10).
+        uncovered_sweep_min_hunk_lines: Issue #309. A file counts as sweepable
+            only when its hunks contain at least this many added/removed lines.
+            ``None`` falls through to file config then
+            ``DEFAULT_UNCOVERED_SWEEP_MIN_HUNK_LINES`` (5).
 
     """
 
@@ -280,6 +295,13 @@ class RunConfig:
     improve_scope: str | None = None
     improve_plan_description: str | None = None
     skill_availability: frozenset[str] | None = None
+    # Issue #309: uncovered-diff-file sweep (second-pass reviewer). CLI-tier
+    # overrides; ``None`` falls through to the file-config scalar then the
+    # orchestrator default (True / DEFAULT_UNCOVERED_SWEEP_MAX_FILES /
+    # DEFAULT_UNCOVERED_SWEEP_MIN_HUNK_LINES).
+    uncovered_sweep: bool | None = None
+    uncovered_sweep_max_files: int | None = None
+    uncovered_sweep_min_hunk_lines: int | None = None
 
 
 def _print_missing_skill_error(skill_name: str) -> None:

--- a/daydream/ui/summary.py
+++ b/daydream/ui/summary.py
@@ -367,6 +367,7 @@ def print_preflight_notice(
     stack_lines: list[str],
     agent_count: int,
     exploration_available: bool,
+    sweep_note: str | None = None,
 ) -> None:
     """Print the deep-mode pre-flight notice (D-30).
 
@@ -380,6 +381,11 @@ def print_preflight_notice(
         agent_count: Total agent invocation count (D-30 formula).
         exploration_available: True when the exploration infrastructure
             (Phases 1-4) is installed and the pre-scan is wired in.
+        sweep_note: Optional additive line for the uncovered-file sweep agent
+            estimate (issue #309 finding 8). Uncovered files are not known at
+            pre-flight time, so the sweep's review + parse invocations are
+            shown as an explicit upper-bound note rather than folded into the
+            count.
 
     """
     console.print("[neon.cyan]▶[/] [neon.fg]Deep-review pipeline pre-flight[/]")
@@ -397,3 +403,5 @@ def print_preflight_notice(
     for line in stack_lines:
         console.print(f"    - {line}")
     console.print(f"[neon.fg]  Total agents: {agent_count}[/]")
+    if sweep_note:
+        console.print(f"  {sweep_note}", style="dim")

--- a/docs/evaluation-framework.md
+++ b/docs/evaluation-framework.md
@@ -276,6 +276,10 @@ Operational metrics informed by Atlassian RovoDev's production deployment metric
 | FPs per PR | Absolute false-positive burden |
 | Repeatability | Jaccard similarity of findings across repeated runs on same PR |
 
+### Coverage and the uncovered-file sweep
+
+The deep flow tracks file-level review coverage — `files_in_diff` vs `files_read_by_reviewers` (derived from the `deep-*` fork trajectories) — and records it in `deep/coverage-stats.json` plus a short `## Coverage` section on the merged report. After per-stack reviews + parse, an uncovered-diff-file sweep (issue #309) re-reviews each diff file no reviewer read with a cheap second-pass agent, filtering out trivially small hunks and capping the sweep at `uncovered_sweep_max_files` (default 10). The sweep's findings are ordinary merged findings, and its reads are counted by the post-run coverage analysis, so the sweep improves `coverage_ratio`; it is deliberately fail-open, so a broken sweep can only reduce recall, never fail the run.
+
 ---
 
 ## Quality Metrics (Erosion & Verbosity)

--- a/docs/evaluation-framework.md
+++ b/docs/evaluation-framework.md
@@ -278,7 +278,7 @@ Operational metrics informed by Atlassian RovoDev's production deployment metric
 
 ### Coverage and the uncovered-file sweep
 
-The deep flow tracks file-level review coverage — `files_in_diff` vs `files_read_by_reviewers` (derived from the `deep-*` fork trajectories) — and records it in `deep/coverage-stats.json` plus a short `## Coverage` section on the merged report. After per-stack reviews + parse, an uncovered-diff-file sweep (issue #309) re-reviews each diff file no reviewer read with a cheap second-pass agent, filtering out trivially small hunks and capping the sweep at `uncovered_sweep_max_files` (default 10). The sweep's findings are ordinary merged findings, and its reads are counted by the post-run coverage analysis, so the sweep improves `coverage_ratio`; it is deliberately fail-open, so a broken sweep can only reduce recall, never fail the run.
+The deep flow tracks file-level review coverage — `files_in_diff` vs `files_read_by_reviewers` (derived from the `deep-*` fork trajectories) — and records it in `deep/coverage-stats.json` plus a short `## Coverage` section on the merged report. After per-stack reviews + parse, an uncovered-diff-file sweep (issue #309) re-reviews each diff file no reviewer read with a cheap second-pass agent, filtering out trivially small hunks and capping the sweep at `uncovered_sweep_max_files`. The sweep's findings are ordinary merged findings, and its reads are counted by the post-run coverage analysis, so the sweep improves `coverage_ratio`; it is deliberately fail-open, so a broken sweep can only reduce recall, never fail the run. The sweep's config keys (`uncovered_sweep`, `uncovered_sweep_max_files`, `uncovered_sweep_min_hunk_lines`) are documented in the README Configuration section.
 
 ---
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -251,23 +251,28 @@ an existing config key.
 | 2 | `intent` | `intent` |
 | 3 | `per-stack-reviews` | `per_stack_review` |
 | 4 | `per-stack-parse` | `parse` |
-| 5 | `arbiter` | `arbiter` |
-| 6 | `cross-stack-merge` | `merge` |
-| 7 | `single-stack-merge` | `single-stack-merge` |
-| 8 | `load-items` | `load-items` |
-| 9 | `supervise` | `supervise` |
-| 10 | `findings-out` | `findings-out` |
-| 11 | `post-review` | `post-review` |
-| 12 | `fix-gate` | `fix-gate` |
-| 13 | `verify` | `verify` |
-| 14 | `fix` | `fix` |
-| 15 | `test` | `test` |
-| 16 | `commit` | `fix` |
+| 5 | `uncovered-sweep` | `parse` |
+| 6 | `arbiter` | `arbiter` |
+| 7 | `cross-stack-merge` | `merge` |
+| 8 | `single-stack-merge` | `single-stack-merge` |
+| 9 | `load-items` | `load-items` |
+| 10 | `supervise` | `supervise` |
+| 11 | `findings-out` | `findings-out` |
+| 12 | `post-review` | `post-review` |
+| 13 | `fix-gate` | `fix-gate` |
+| 14 | `verify` | `verify` |
+| 15 | `fix` | `fix` |
+| 16 | `test` | `test` |
+| 17 | `commit` | `fix` |
 
 `per-stack-reviews` runs the TTT alternative-review (wonder) as well: on a fresh
 multi-stack run the two are siblings in one task group, so wonder no longer has
 a step of its own. Its per-phase config key is still `wonder`
 (`[tool.daydream.phases.wonder]`), resolved inside the step.
+
+`uncovered-sweep` (issue #309) re-reviews diff files no per-stack reviewer read
+with a cheap second-pass agent; it resolves its backend via the `parse` phase
+key (the cheapest tier) and is gated off on `--start-at merge`/`fix` resumes.
 
 #### `shallow` (`--shallow` single-skill loop)
 

--- a/tests/harness/stub_backend.py
+++ b/tests/harness/stub_backend.py
@@ -34,6 +34,7 @@ from daydream.backends import (
     MaxTurnsError,
     ResultEvent,
     TextEvent,
+    ToolResultEvent,
     ToolStartEvent,
 )
 
@@ -375,6 +376,9 @@ class StubBackend:
             yield ToolStartEvent(
                 id=f"sweep-read-{swept_file}", name="Read", input={"file_path": swept_file}
             )
+            yield ToolResultEvent(
+                id=f"sweep-read-{swept_file}", output="sweep read returned", is_error=False
+            )
             yield TextEvent(text="")
             yield ResultEvent(structured_output=None, continuation=None)
             return
@@ -398,6 +402,11 @@ class StubBackend:
                         continue
                     yield ToolStartEvent(
                         id=f"read-{scope_file}", name="Read", input={"file_path": scope_file}
+                    )
+                    # Completed read: a ToolResultEvent paired with the start,
+                    # so the sweep's coverage computation counts the file as read.
+                    yield ToolResultEvent(
+                        id=f"read-{scope_file}", output="file content", is_error=False
                     )
             out_match = re.search(r"write your full review to (\S+)", prompt, flags=re.IGNORECASE)
             if out_match is not None:

--- a/tests/harness/stub_backend.py
+++ b/tests/harness/stub_backend.py
@@ -201,6 +201,11 @@ class StubBackend:
         # (instead of the default api.py), so stack-uncovered-records.json names
         # the swept file.
         self.sweep_file: str | None = None
+        # When True, the uncovered-file-sweep branch returns success WITHOUT
+        # writing the review output file -- a backend can return normally while
+        # producing nothing (issue #309 finding 7). A successful return must
+        # NOT be recorded as completed coverage.
+        self.sweep_no_output: bool = False
         # When True, the uncovered-file-sweep branch raises -- exercising the
         # sweep's fail-open contract.
         self.fail_sweep: bool = False
@@ -365,14 +370,15 @@ class StubBackend:
                 raise RuntimeError("stub: uncovered-file sweep blew up")
             file_match = re.search(r"changed file (\S+) was NOT read", prompt)
             swept_file = file_match.group(1) if file_match else "notes.txt"
-            out_match = re.search(r"write your full review to (\S+)", prompt, flags=re.IGNORECASE)
-            if out_match is not None:
-                out_path = Path(out_match.group(1).rstrip("."))
-                out_path.parent.mkdir(parents=True, exist_ok=True)
-                out_path.write_text(
-                    f"# Review (uncovered)\n\n## Issues\n\n"
-                    f"1. [{swept_file}:1] Uncovered-file finding for {swept_file}\n"
-                )
+            if not self.sweep_no_output:
+                out_match = re.search(r"write your full review to (\S+)", prompt, flags=re.IGNORECASE)
+                if out_match is not None:
+                    out_path = Path(out_match.group(1).rstrip("."))
+                    out_path.parent.mkdir(parents=True, exist_ok=True)
+                    out_path.write_text(
+                        f"# Review (uncovered)\n\n## Issues\n\n"
+                        f"1. [{swept_file}:1] Uncovered-file finding for {swept_file}\n"
+                    )
             yield ToolStartEvent(
                 id=f"sweep-read-{swept_file}", name="Read", input={"file_path": swept_file}
             )

--- a/tests/harness/stub_backend.py
+++ b/tests/harness/stub_backend.py
@@ -185,6 +185,36 @@ class StubBackend:
         # the real pre_scan degrade path runs: specialist_failed -> completed
         # False -> exploration dir materialized without a cache-key.
         self.fail_exploration: bool = False
+        # Issue #309 (uncovered-file sweep): knobs for the per-stack review
+        # branches' simulated reads and the sweep branch/parse.
+        # When True, the per-stack / generic review branch emits a Read
+        # ToolStartEvent per file in its scope (except `per_stack_unread`), so
+        # analyze_coverage sees per-stack reviewers as having read their own
+        # files -- leaving only genuinely-unread files uncovered.
+        self.per_stack_emit_reads: bool = False
+        # Files in a stack's scope to NOT emit a read for, even when
+        # per_stack_emit_reads is on (the uncovered-file-sweep test uses this to
+        # leave one diff file unread by every reviewer).
+        self.per_stack_unread: frozenset[str] = frozenset()
+        # When set, the sweep parse branch emits its finding for this file
+        # (instead of the default api.py), so stack-uncovered-records.json names
+        # the swept file.
+        self.sweep_file: str | None = None
+        # When True, the uncovered-file-sweep branch raises -- exercising the
+        # sweep's fail-open contract.
+        self.fail_sweep: bool = False
+
+    @staticmethod
+    def _stack_scope_files(prompt: str) -> list[str]:
+        """Extract the file list from a per-stack/generic scope instruction.
+
+        ``_stack_scope_instruction`` renders the files comma-joined on a single
+        line (``  api.py, README.md``), so the single line is split on commas.
+        """
+        m = re.search(r"Focus ONLY on these files:\n\s*([^\n]+)", prompt)
+        if m is None:
+            return []
+        return [part.strip() for part in m.group(1).split(",") if part.strip()]
 
     def _is_runaway(self, prompt: str, pl: str) -> bool:
         """Whether this turn should emit the unbounded budget-tripping burst."""
@@ -323,6 +353,32 @@ class StubBackend:
             yield ResultEvent(structured_output=None, continuation=None)
             return
 
+        # Issue #309: uncovered-file sweep reviewer. Dispatch marker phrase is
+        # unique to build_uncovered_sweep_prompt. Emits a Read of the swept
+        # file (so post-run analyze_coverage counts it as read) and writes a
+        # review the sweep parse pass turns into a PER_STACK_RECORD_SCHEMA
+        # finding for that file. fail_sweep raises to exercise the fail-open
+        # contract.
+        if "uncovered file sweep" in pl:
+            if self.fail_sweep:
+                raise RuntimeError("stub: uncovered-file sweep blew up")
+            file_match = re.search(r"changed file (\S+) was NOT read", prompt)
+            swept_file = file_match.group(1) if file_match else "notes.txt"
+            out_match = re.search(r"write your full review to (\S+)", prompt, flags=re.IGNORECASE)
+            if out_match is not None:
+                out_path = Path(out_match.group(1).rstrip("."))
+                out_path.parent.mkdir(parents=True, exist_ok=True)
+                out_path.write_text(
+                    f"# Review (uncovered)\n\n## Issues\n\n"
+                    f"1. [{swept_file}:1] Uncovered-file finding for {swept_file}\n"
+                )
+            yield ToolStartEvent(
+                id=f"sweep-read-{swept_file}", name="Read", input={"file_path": swept_file}
+            )
+            yield TextEvent(text="")
+            yield ResultEvent(structured_output=None, continuation=None)
+            return
+
         # Per-stack review -> write a markdown file + emit done.
         m = re.search(r"you are reviewing the (\S+) stack", pl)
         if m is None:
@@ -336,6 +392,13 @@ class StubBackend:
 
             m = _M()  # type: ignore[assignment]
         if m is not None:
+            if self.per_stack_emit_reads:
+                for scope_file in self._stack_scope_files(prompt):
+                    if scope_file in self.per_stack_unread:
+                        continue
+                    yield ToolStartEvent(
+                        id=f"read-{scope_file}", name="Read", input={"file_path": scope_file}
+                    )
             out_match = re.search(r"write your full review to (\S+)", prompt, flags=re.IGNORECASE)
             if out_match is not None:
                 raw = out_match.group(1).rstrip(".")
@@ -368,6 +431,17 @@ class StubBackend:
                 issue["severity"] = self.parse_severity
                 issue["confidence"] = "MEDIUM"
                 issue["rationale"] = "stub"
+            # Issue #309: the uncovered-sweep parse (prompt points at an
+            # `uncovered-<n>-review.md`) emits its finding for the swept file.
+            if self.sweep_file is not None and re.search(r"uncovered-\d+-review\.md", prompt):
+                issue["file"] = self.sweep_file
+                issue["line"] = 1
+                issue["description"] = f"Sweep finding for {self.sweep_file}"
+                issue["evidence"] = f"{self.sweep_file}:1"
+                if "severity" in pl:
+                    issue["severity"] = self.parse_severity or "low"
+                    issue["confidence"] = "MEDIUM"
+                    issue["rationale"] = "stub"
             # #232: per-stack override keyed off the review-file path the parse
             # prompt points at (``stack-<name>-review.md``). Lets one stack emit a
             # HIGH finding and another a borderline LOW one at DISTINCT locations,

--- a/tests/harness/stub_backend.py
+++ b/tests/harness/stub_backend.py
@@ -206,6 +206,11 @@ class StubBackend:
         # producing nothing (issue #309 finding 7). A successful return must
         # NOT be recorded as completed coverage.
         self.sweep_no_output: bool = False
+        # When True, the uncovered-file-sweep branch writes its review output
+        # but emits NO Read tool call -- a successful hunk-only review (issue
+        # #309 finding 6). The file must be recorded as a completed ATTEMPT
+        # ("reviewed (hunks only)"), never as covered.
+        self.sweep_no_read: bool = False
         # When True, the uncovered-file-sweep branch raises -- exercising the
         # sweep's fail-open contract.
         self.fail_sweep: bool = False
@@ -379,12 +384,13 @@ class StubBackend:
                         f"# Review (uncovered)\n\n## Issues\n\n"
                         f"1. [{swept_file}:1] Uncovered-file finding for {swept_file}\n"
                     )
-            yield ToolStartEvent(
-                id=f"sweep-read-{swept_file}", name="Read", input={"file_path": swept_file}
-            )
-            yield ToolResultEvent(
-                id=f"sweep-read-{swept_file}", output="sweep read returned", is_error=False
-            )
+            if not self.sweep_no_read:
+                yield ToolStartEvent(
+                    id=f"sweep-read-{swept_file}", name="Read", input={"file_path": swept_file}
+                )
+                yield ToolResultEvent(
+                    id=f"sweep-read-{swept_file}", output="sweep read returned", is_error=False
+                )
             yield TextEvent(text="")
             yield ResultEvent(structured_output=None, continuation=None)
             return

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -120,6 +120,34 @@ def test_precision_mode_non_bool_degrades_to_none(tmp_path: Path) -> None:
     assert cfg.precision_mode is None
 
 
+def test_uncovered_sweep_toggle_is_bool_only(tmp_path: Path) -> None:
+    """``uncovered_sweep`` is bool-only: an accidental int degrades to unset."""
+    (tmp_path / ".daydream.toml").write_text("uncovered_sweep = false\n")
+    assert load_file_config(tmp_path).uncovered_sweep is False
+    (tmp_path / ".daydream.toml").write_text("uncovered_sweep = 1\n")
+    assert load_file_config(tmp_path).uncovered_sweep is None
+
+
+def test_uncovered_sweep_numerics_accept_zero_and_keep_non_negative(tmp_path: Path) -> None:
+    """Non-negative-only coercion: ``0`` is meaningful, negatives degrade to None."""
+    (tmp_path / ".daydream.toml").write_text(
+        "uncovered_sweep_max_files = 0\nuncovered_sweep_min_hunk_lines = 0\n"
+    )
+    cfg = load_file_config(tmp_path)
+    assert cfg.uncovered_sweep_max_files == 0
+    assert cfg.uncovered_sweep_min_hunk_lines == 0
+
+
+def test_uncovered_sweep_numerics_negative_degrade_to_none(tmp_path: Path) -> None:
+    """A negative capacity cap or hunk floor is never meaningful: degrade to None."""
+    (tmp_path / ".daydream.toml").write_text(
+        "uncovered_sweep_max_files = -1\nuncovered_sweep_min_hunk_lines = -5\n"
+    )
+    cfg = load_file_config(tmp_path)
+    assert cfg.uncovered_sweep_max_files is None
+    assert cfg.uncovered_sweep_min_hunk_lines is None
+
+
 @pytest.mark.parametrize(
     ("content", "expected"),
     [

--- a/tests/test_deep_coverage.py
+++ b/tests/test_deep_coverage.py
@@ -1,0 +1,182 @@
+"""Unit tests for the uncovered-file sweep helpers (issue #309).
+
+Covers ``daydream/deep/coverage.py``: coverage computation against a crafted
+``.daydream`` dir, the hunk-size + capacity budget filter, and the sweep prompt
+builder. The real-path sweep behavior lives in ``tests/test_deep_orchestrator.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from daydream.deep.coverage import (
+    build_uncovered_sweep_prompt,
+    compute_uncovered_files,
+    diff_block_for_file,
+    filter_sweepable_files,
+    hunk_change_line_count,
+)
+
+_DIFF = (
+    "diff --git a/api.py b/api.py\n"
+    "index 000..111 100644\n"
+    "--- a/api.py\n"
+    "+++ b/api.py\n"
+    "@@ -1 +1 @@\n"
+    "-'world'\n"
+    "+'universe'\n"
+    "diff --git a/notes.txt b/notes.txt\n"
+    "index 000..222 100644\n"
+    "--- a/notes.txt\n"
+    "+++ b/notes.txt\n"
+    "@@ -1 +1,7 @@\n"
+    "+line1\n"
+    "+line2\n"
+    "+line3\n"
+    "+line4\n"
+    "+line5\n"
+    "+line6\n"
+)
+
+
+def _write_fork(run_dir: Path, name: str, read_paths: list[str]) -> None:
+    """Write one sibling trajectory whose tool calls read *read_paths*."""
+    trajectories_dir = run_dir / "trajectories"
+    trajectories_dir.mkdir(parents=True, exist_ok=True)
+    (trajectories_dir / name).write_text(
+        json.dumps(
+            {
+                "session_id": run_dir.name,
+                "steps": [
+                    {
+                        "step_id": "s0",
+                        "tool_calls": [
+                            {
+                                "function_name": "Read",
+                                "arguments": {"file_path": path},
+                            }
+                            for path in read_paths
+                        ],
+                    }
+                ],
+            }
+        )
+    )
+
+
+def _write_main(run_dir: Path) -> None:
+    (run_dir / "trajectory.json").write_text(
+        json.dumps({"session_id": run_dir.name, "steps": []})
+    )
+
+
+def test_compute_uncovered_files_reports_unread_diff_files(tmp_path: Path) -> None:
+    """Files no ``deep-`` reviewer read land in the uncovered list."""
+    daydream_dir = tmp_path / ".daydream"
+    daydream_dir.mkdir()
+    (daydream_dir / "diff.patch").write_text(_DIFF)
+    run_dir = daydream_dir / "runs" / "sess-1"
+    run_dir.mkdir(parents=True)
+    _write_main(run_dir)
+    _write_fork(run_dir, "deep-python.json", ["/repo/api.py"])
+    # parse forks must NOT count toward coverage (label does not start with deep-).
+    _write_fork(run_dir, "parse-python.json", ["/repo/notes.txt"])
+
+    uncovered, stats = compute_uncovered_files(daydream_dir, "sess-1")
+
+    assert uncovered == ["notes.txt"]
+    assert stats["files_in_diff"] == 2
+    assert stats["files_read_by_reviewers"] == 1
+    assert stats["coverage_ratio"] == 0.5
+
+
+def test_compute_uncovered_files_empty_when_everything_read(tmp_path: Path) -> None:
+    """A fully-covered diff reports no uncovered files."""
+    daydream_dir = tmp_path / ".daydream"
+    daydream_dir.mkdir()
+    (daydream_dir / "diff.patch").write_text(_DIFF)
+    run_dir = daydream_dir / "runs" / "sess-2"
+    run_dir.mkdir(parents=True)
+    _write_main(run_dir)
+    _write_fork(run_dir, "deep-python.json", ["/repo/api.py"])
+    _write_fork(run_dir, "deep-generic.json", ["/repo/notes.txt"])
+
+    uncovered, stats = compute_uncovered_files(daydream_dir, "sess-2")
+
+    assert uncovered == []
+    assert stats["coverage_ratio"] == 1.0
+
+
+def test_hunk_change_line_count_excludes_headers() -> None:
+    """+++/--- file headers are not counted as added/removed lines."""
+    assert hunk_change_line_count(diff_block_for_file(_DIFF, "api.py") or "") == 2
+    assert hunk_change_line_count(diff_block_for_file(_DIFF, "notes.txt") or "") == 6
+
+
+def test_filter_sweepable_files_caps_capacity_and_counts_small_hunks() -> None:
+    """Small hunks are skipped; excess sweepable files are counted, not dropped."""
+    uncovered = ["api.py", "notes.txt"]
+
+    swept, small, capacity = filter_sweepable_files(
+        uncovered, _DIFF, min_hunk_lines=5, max_files=10
+    )
+
+    assert swept == ["notes.txt"]
+    assert small == 1  # api.py has only 2 +/- lines
+    assert capacity == 0
+
+
+def test_filter_sweepable_files_skips_nonexistent_diff_files() -> None:
+    """An uncovered file absent from the diff is skipped as non-sweepable."""
+    swept, small, capacity = filter_sweepable_files(
+        ["ghost.txt"], _DIFF, min_hunk_lines=1, max_files=10
+    )
+
+    assert swept == []
+    assert small == 1
+    assert capacity == 0
+
+
+def test_filter_sweepable_files_capacity_cap_keeps_diff_order() -> None:
+    """With more sweepable files than max_files, only the first N are kept."""
+    diff = _DIFF + (
+        "diff --git a/third.txt b/third.txt\n"
+        "--- a/third.txt\n"
+        "+++ b/third.txt\n"
+        "@@ -1 +1,6 @@\n"
+        "+a\n+b\n+c\n+d\n+e\n+f\n"
+    )
+
+    swept, small, capacity = filter_sweepable_files(
+        ["notes.txt", "third.txt"], diff, min_hunk_lines=5, max_files=1
+    )
+
+    assert swept == ["notes.txt"]
+    assert small == 0
+    assert capacity == 1
+
+
+def test_build_uncovered_sweep_prompt_includes_context_and_markers(tmp_path: Path) -> None:
+    """The prompt names the file, inlines hunks, points at intent + output."""
+    intent = tmp_path / ".daydream" / "deep" / "intent.md"
+    output = tmp_path / ".daydream" / "deep" / "uncovered-0-review.md"
+    hunks = diff_block_for_file(_DIFF, "notes.txt") or ""
+    prompt = build_uncovered_sweep_prompt(
+        file="notes.txt",
+        hunks=hunks,
+        intent_path=intent,
+        cwd=tmp_path,
+        output_path=output,
+    )
+
+    assert "notes.txt" in prompt
+    assert "uncovered file sweep" in prompt
+    assert str(intent) in prompt
+    assert str(output) in prompt
+    # Hunks are inlined (not a pointer to diff.patch).
+    assert "+line6" in prompt
+    assert "changed file notes.txt was NOT read" in prompt
+    # The verification gates are embedded, not a skill-file read instruction.
+    assert "Gate-0 anti-confabulation" in prompt
+    assert "review-verification-protocol/SKILL.md" not in prompt

--- a/tests/test_deep_coverage.py
+++ b/tests/test_deep_coverage.py
@@ -207,27 +207,30 @@ def test_hunk_change_line_count_excludes_headers() -> None:
 
 
 def test_filter_sweepable_files_caps_capacity_and_counts_small_hunks() -> None:
-    """Small hunks are skipped; excess sweepable files are counted, not dropped."""
+    """Small hunks are skipped; excess sweepable files are named, not dropped."""
     uncovered = ["api.py", "notes.txt"]
 
-    swept, small, capacity = filter_sweepable_files(
+    swept, small_files, capacity_files = filter_sweepable_files(
         uncovered, _DIFF, min_hunk_lines=5, max_files=10
     )
 
     assert swept == ["notes.txt"]
-    assert small == 1  # api.py has only 2 +/- lines
-    assert capacity == 0
+    assert small_files == ["api.py"]  # api.py has only 2 +/- lines
+    assert capacity_files == []
+    # Integer counts are derived from the lists (issue #309 finding 10).
+    assert len(small_files) == 1
+    assert len(capacity_files) == 0
 
 
 def test_filter_sweepable_files_skips_nonexistent_diff_files() -> None:
     """An uncovered file absent from the diff is skipped as non-sweepable."""
-    swept, small, capacity = filter_sweepable_files(
+    swept, small_files, capacity_files = filter_sweepable_files(
         ["ghost.txt"], _DIFF, min_hunk_lines=1, max_files=10
     )
 
     assert swept == []
-    assert small == 1
-    assert capacity == 0
+    assert small_files == ["ghost.txt"]
+    assert capacity_files == []
 
 
 def test_filter_sweepable_files_capacity_cap_keeps_diff_order() -> None:
@@ -240,13 +243,25 @@ def test_filter_sweepable_files_capacity_cap_keeps_diff_order() -> None:
         "+a\n+b\n+c\n+d\n+e\n+f\n"
     )
 
-    swept, small, capacity = filter_sweepable_files(
+    swept, small_files, capacity_files = filter_sweepable_files(
         ["notes.txt", "third.txt"], diff, min_hunk_lines=5, max_files=1
     )
 
     assert swept == ["notes.txt"]
-    assert small == 0
-    assert capacity == 1
+    assert small_files == []
+    assert capacity_files == ["third.txt"]
+    assert len(capacity_files) == 1
+
+
+def test_filter_sweepable_files_zero_max_files_sweeps_nothing() -> None:
+    """max_files=0 sweeps nothing; every sweepable file is capacity-skipped."""
+    swept, small_files, capacity_files = filter_sweepable_files(
+        ["api.py", "notes.txt"], _DIFF, min_hunk_lines=1, max_files=0
+    )
+
+    assert swept == []
+    assert small_files == []
+    assert capacity_files == ["api.py", "notes.txt"]
 
 
 def test_build_uncovered_sweep_prompt_includes_context_and_markers(tmp_path: Path) -> None:
@@ -269,6 +284,40 @@ def test_build_uncovered_sweep_prompt_includes_context_and_markers(tmp_path: Pat
     # Hunks are inlined (not a pointer to diff.patch).
     assert "+line6" in prompt
     assert "changed file notes.txt was NOT read" in prompt
-    # The verification gates are embedded, not a skill-file read instruction.
+    # The canonical prompt primitives are present, not reduced duplicates: the
+    # sweep reviewer is held to the same standard as per-stack reviewers
+    # (issue #309 finding 11).
+    assert "## Confidence and Convention Rules" in prompt
+    assert "Error Handling Semantics (QUAL-04)" in prompt
+    assert "## Dependency Impact" in prompt
     assert "Gate-0 anti-confabulation" in prompt
     assert "review-verification-protocol/SKILL.md" not in prompt
+
+
+def test_build_uncovered_sweep_prompt_exploration_pointer(tmp_path: Path) -> None:
+    """The exploration pointer is inlined only when a directory is supplied."""
+    intent = tmp_path / ".daydream" / "deep" / "intent.md"
+    output = tmp_path / ".daydream" / "deep" / "uncovered-0-review.md"
+    hunks = diff_block_for_file(_DIFF, "notes.txt") or ""
+    exploration = tmp_path / ".daydream" / "exploration"
+    prompt = build_uncovered_sweep_prompt(
+        file="notes.txt",
+        hunks=hunks,
+        intent_path=intent,
+        cwd=tmp_path,
+        output_path=output,
+        exploration_dir=exploration,
+    )
+
+    assert "Pre-scan exploration results are available" in prompt
+    assert str(exploration) in prompt
+
+    prompt_no_dir = build_uncovered_sweep_prompt(
+        file="notes.txt",
+        hunks=hunks,
+        intent_path=intent,
+        cwd=tmp_path,
+        output_path=output,
+        exploration_dir=None,
+    )
+    assert "Pre-scan exploration results" not in prompt_no_dir

--- a/tests/test_deep_coverage.py
+++ b/tests/test_deep_coverage.py
@@ -41,7 +41,49 @@ _DIFF = (
 
 
 def _write_fork(run_dir: Path, name: str, read_paths: list[str]) -> None:
-    """Write one sibling trajectory whose tool calls read *read_paths*."""
+    """Write one sibling trajectory whose *completed* reads cover *read_paths*.
+
+    Each read tool call carries a matching ``observation.results[].source_call_id``
+    so the sweep counts it as coverage (a read without a ToolResult observation
+    is treated as interrupted and does NOT cover the file).
+    """
+    trajectories_dir = run_dir / "trajectories"
+    trajectories_dir.mkdir(parents=True, exist_ok=True)
+    tool_calls = []
+    results = []
+    for i, path in enumerate(read_paths):
+        call_id = f"read-{i}"
+        tool_calls.append(
+            {
+                "tool_call_id": call_id,
+                "function_name": "Read",
+                "arguments": {"file_path": path},
+            }
+        )
+        results.append({"source_call_id": call_id, "content": "file content"})
+    (trajectories_dir / name).write_text(
+        json.dumps(
+            {
+                "session_id": run_dir.name,
+                "steps": [
+                    {
+                        "step_id": "s0",
+                        "tool_calls": tool_calls,
+                        "observation": {"results": results},
+                    }
+                ],
+            }
+        )
+    )
+
+
+def _write_interrupted_read_fork(run_dir: Path, name: str, read_paths: list[str]) -> None:
+    """Write a sibling trajectory whose reads carry NO ToolResult observation.
+
+    Models an interrupted Read (a ToolStartEvent with no matching
+    ToolResultEvent): the file was not actually read, so the sweep must treat
+    it as uncovered (fail-open: it gets swept, never skipped).
+    """
     trajectories_dir = run_dir / "trajectories"
     trajectories_dir.mkdir(parents=True, exist_ok=True)
     (trajectories_dir / name).write_text(
@@ -53,10 +95,11 @@ def _write_fork(run_dir: Path, name: str, read_paths: list[str]) -> None:
                         "step_id": "s0",
                         "tool_calls": [
                             {
+                                "tool_call_id": f"read-{i}",
                                 "function_name": "Read",
                                 "arguments": {"file_path": path},
                             }
-                            for path in read_paths
+                            for i, path in enumerate(read_paths)
                         ],
                     }
                 ],
@@ -106,6 +149,55 @@ def test_compute_uncovered_files_empty_when_everything_read(tmp_path: Path) -> N
 
     assert uncovered == []
     assert stats["coverage_ratio"] == 1.0
+
+
+def test_compute_uncovered_files_boundary_ignores_suffix_collisions(tmp_path: Path) -> None:
+    """A read of ``notapi.py`` must NOT cover the changed file ``api.py``.
+
+    Regression for the suffix-collision false positive: coverage is matched at
+    a path-component boundary (``endswith("/" + relative)``), so
+    ``/repo/notapi.py`` never counts as a read of ``api.py`` and the file stays
+    in the sweep.
+    """
+    daydream_dir = tmp_path / ".daydream"
+    daydream_dir.mkdir()
+    (daydream_dir / "diff.patch").write_text(_DIFF)
+    run_dir = daydream_dir / "runs" / "sess-3"
+    run_dir.mkdir(parents=True)
+    _write_main(run_dir)
+    _write_fork(run_dir, "deep-python.json", ["/repo/notapi.py"])
+    _write_fork(run_dir, "deep-generic.json", ["/repo/notes.txt"])
+
+    uncovered, stats = compute_uncovered_files(daydream_dir, "sess-3")
+
+    assert "api.py" in uncovered  # /repo/notapi.py must not cover api.py
+    assert stats["files_read_by_reviewers"] == 1  # only notes.txt covered
+    swept, _, _ = filter_sweepable_files(uncovered, _DIFF, min_hunk_lines=1, max_files=10)
+    assert "api.py" in swept  # api.py is swept, not silently skipped
+
+
+def test_compute_uncovered_files_requires_completed_reads(tmp_path: Path) -> None:
+    """An interrupted Read (no ToolResult observation) leaves the file uncovered.
+
+    A reviewer that starts a Read but never receives a result has not read the
+    file; counting it as coverage would let the sweep skip a genuinely unread
+    file. Fail-open: the file stays uncovered and is swept.
+    """
+    daydream_dir = tmp_path / ".daydream"
+    daydream_dir.mkdir()
+    (daydream_dir / "diff.patch").write_text(_DIFF)
+    run_dir = daydream_dir / "runs" / "sess-4"
+    run_dir.mkdir(parents=True)
+    _write_main(run_dir)
+    _write_interrupted_read_fork(run_dir, "deep-python.json", ["/repo/api.py"])
+    _write_fork(run_dir, "deep-generic.json", ["/repo/notes.txt"])
+
+    uncovered, stats = compute_uncovered_files(daydream_dir, "sess-4")
+
+    assert "api.py" in uncovered  # the interrupted read covers nothing
+    assert stats["files_read_by_reviewers"] == 1  # only notes.txt's completed read
+    swept, _, _ = filter_sweepable_files(uncovered, _DIFF, min_hunk_lines=1, max_files=10)
+    assert "api.py" in swept  # the unread file is swept, never skipped
 
 
 def test_hunk_change_line_count_excludes_headers() -> None:

--- a/tests/test_deep_coverage.py
+++ b/tests/test_deep_coverage.py
@@ -114,6 +114,51 @@ def _write_main(run_dir: Path) -> None:
     )
 
 
+def _write_colliding_read_id_fork(run_dir: Path) -> None:
+    """Write a two-step sibling trajectory that reuses one tool-call ID.
+
+    Tool-call IDs are scoped to individual invocations, not trajectory-global.
+    Step ``s0`` holds an interrupted Read of ``/repo/api.py`` whose ID collides
+    with the completed Read of ``/repo/notes.txt`` in step ``s1``. The
+    completed result in ``s1`` must NOT retroactively complete the interrupted
+    read in ``s0`` -- the sweep treats ``api.py`` as uncovered.
+    """
+    trajectories_dir = run_dir / "trajectories"
+    trajectories_dir.mkdir(parents=True, exist_ok=True)
+    (trajectories_dir / "deep-python.json").write_text(
+        json.dumps(
+            {
+                "session_id": run_dir.name,
+                "steps": [
+                    {
+                        "step_id": "s0",
+                        "tool_calls": [
+                            {
+                                "tool_call_id": "read-0",
+                                "function_name": "Read",
+                                "arguments": {"file_path": "/repo/api.py"},
+                            }
+                        ],
+                    },
+                    {
+                        "step_id": "s1",
+                        "tool_calls": [
+                            {
+                                "tool_call_id": "read-0",
+                                "function_name": "Read",
+                                "arguments": {"file_path": "/repo/notes.txt"},
+                            }
+                        ],
+                        "observation": {
+                            "results": [{"source_call_id": "read-0", "content": "file content"}]
+                        },
+                    },
+                ],
+            }
+        )
+    )
+
+
 def test_compute_uncovered_files_reports_unread_diff_files(tmp_path: Path) -> None:
     """Files no ``deep-`` reviewer read land in the uncovered list."""
     daydream_dir = tmp_path / ".daydream"
@@ -200,6 +245,32 @@ def test_compute_uncovered_files_requires_completed_reads(tmp_path: Path) -> Non
     assert "api.py" in swept  # the unread file is swept, never skipped
 
 
+def test_compute_uncovered_files_scopes_completed_ids_to_step(tmp_path: Path) -> None:
+    """A tool-call ID reused across steps must not leak completion state.
+
+    Regression (issue #309 finding 5): completion is matched WITHIN a step, so
+    a completed read in one step cannot mark an interrupted read in another
+    step (sharing the same ID) as completed. The interrupted read stays
+    uncovered and the file is swept, never skipped.
+    """
+    daydream_dir = tmp_path / ".daydream"
+    daydream_dir.mkdir()
+    (daydream_dir / "diff.patch").write_text(_DIFF)
+    run_dir = daydream_dir / "runs" / "sess-5"
+    run_dir.mkdir(parents=True)
+    _write_main(run_dir)
+    _write_colliding_read_id_fork(run_dir)
+
+    uncovered, stats = compute_uncovered_files(daydream_dir, "sess-5")
+
+    # The interrupted read of api.py (ID collision with s1's completed read of
+    # notes.txt) covers nothing: api.py stays uncovered and is swept.
+    assert "api.py" in uncovered
+    assert stats["files_read_by_reviewers"] == 1  # only notes.txt's completed read
+    swept, _, _ = filter_sweepable_files(uncovered, _DIFF, min_hunk_lines=1, max_files=10)
+    assert "api.py" in swept
+
+
 def test_hunk_change_line_count_excludes_headers() -> None:
     """+++/--- file headers are not counted as added/removed lines."""
     assert hunk_change_line_count(diff_block_for_file(_DIFF, "api.py") or "") == 2
@@ -284,6 +355,10 @@ def test_build_uncovered_sweep_prompt_includes_context_and_markers(tmp_path: Pat
     # Hunks are inlined (not a pointer to diff.patch).
     assert "+line6" in prompt
     assert "changed file notes.txt was NOT read" in prompt
+    # Reading the source file is REQUIRED, not optional (issue #309 finding 6):
+    # a hunk-only review must not be reported as read coverage.
+    assert "Read the source file FIRST" in prompt
+    assert "you may only comment on hunks you have read" in prompt
     # The canonical prompt primitives are present, not reduced duplicates: the
     # sweep reviewer is held to the same standard as per-stack reviewers
     # (issue #309 finding 11).

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -5176,6 +5176,11 @@ async def test_run_deep_uncovered_sweep_merges_and_improves_coverage(
     assert stats["completed_files"] == ["notes.txt"]
     assert stats["sweep_finding_count"] == len(records) >= 1
     assert stats["sweep_skipped_small_hunks"] == 0
+    # Finding 10: the skip filename lists are persisted alongside the counts
+    # (derived from the lists) so capacity/hunk skips stay auditable.
+    assert stats["sweep_skipped_small_hunks_files"] == []
+    assert stats["sweep_skipped_capacity"] == 0
+    assert stats["sweep_skipped_capacity_files"] == []
     # The POST-sweep ratio reflects the sweep fork's completed read of notes.txt.
     assert stats["post_sweep"]["files_read_by_reviewers"] == 4
     assert stats["post_sweep"]["coverage_ratio"] > pre_sweep["coverage_ratio"]  # 0.75 -> 1.0
@@ -5350,6 +5355,118 @@ async def test_uncovered_sweep_per_stack_resume_no_findings_writes_empty_records
     assert await _run_deep(target, start_at="per-stack") == 0
 
     assert json.loads((deep / "stack-uncovered-records.json").read_text()) == []
+
+
+async def test_run_deep_uncovered_sweep_missing_output_not_claimed_as_coverage(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, make_config: MakeConfig, mute_side_effects: Mute
+) -> None:
+    """A sweep backend that returns success WITHOUT writing its review output is
+    NOT recorded as completed coverage (issue #309 finding 7).
+
+    A backend can return normally while producing nothing; without a
+    ``task_output.is_file()`` guard the file would be claimed covered and the
+    parse would fail on a phantom output. The file must land in
+    ``sweep_failures`` (``"no review output written"``), never in
+    ``completed_files`` / the report's covered line.
+    """
+    from daydream.runner import run
+
+    target = _uncovered_sweep_target(tmp_path)
+    _silence(monkeypatch)
+    mute_side_effects()
+    stub = _install_stub_backend(monkeypatch, target)
+    stub.per_stack_emit_reads = True
+    stub.per_stack_unread = frozenset({"notes.txt"})
+    stub.sweep_file = "notes.txt"
+    stub.sweep_no_output = True  # backend returns normally but writes nothing
+    stub.merge_echo_records = True
+
+    exit_code = await run(make_config(target, assume="yes", output_mode="loop"))
+    assert exit_code == 0
+
+    deep = target / ".daydream" / "deep"
+    stats = json.loads((deep / "coverage-stats.json").read_text())
+    assert stats["attempted_files"] == ["notes.txt"]
+    assert stats["completed_files"] == []  # no actual review output to parse
+    assert stats["sweep_finding_count"] == 0
+    assert stats["sweep_failures"] == {"notes.txt": "no review output written"}
+    # No review output, no records artifact on a fresh run.
+    assert not (deep / "stack-uncovered-records.json").exists()
+
+    report = (target / ".review-output.md").read_text()
+    assert "## Coverage" in report
+    assert "Second-pass sweep covered" not in report
+    assert "Best-effort sweep failures: notes.txt" in report
+
+
+async def test_uncovered_sweep_per_stack_resume_fails_closed_on_unremovable_artifact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A per-stack resume whose stale sweep artifact cannot be removed STOPS
+    with an actionable error instead of continuing (issue #309 finding 8).
+
+    The cleanup is resume-safety-critical (a stale ``stack-uncovered-records.json``
+    surviving would be reloaded by a later merge resume as current findings), so
+    an unremovable artifact aborts the resume at exit 1 before any new per-stack
+    work is dispatched.
+    """
+    target = _uncovered_sweep_target(tmp_path)
+    _silence(monkeypatch)
+
+    stub = _install_stub_backend(monkeypatch, target)
+    stub.per_stack_emit_reads = True
+    stub.per_stack_unread = frozenset({"notes.txt"})
+    stub.sweep_file = "notes.txt"
+    stub.merge_echo_records = True
+    assert await _run_deep(target) == 0
+
+    deep = target / ".daydream" / "deep"
+    assert (deep / "stack-uncovered-records.json").is_file()
+
+    # Make one artifact unremovable: a directory sharing the artifact name makes
+    # Path.unlink() raise IsADirectoryError, and the cleanup must fail closed.
+    (deep / "coverage-stats.json").unlink()
+    (deep / "coverage-stats.json").mkdir()
+
+    stub2 = _install_stub_backend(monkeypatch, target)
+    exit_code = await _run_deep(target, start_at="per-stack")
+    assert exit_code == 1
+    # The resume aborted BEFORE new per-stack work, so no backend call ran and
+    # the unremovable artifact is still present (it was NOT silently skipped).
+    assert stub2.calls == []
+    assert (deep / "coverage-stats.json").is_dir()
+
+
+async def test_uncovered_sweep_malformed_stats_does_not_fail_run(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A structurally-malformed ``coverage-stats.json`` must NOT abort the run
+    (issue #309 finding 9).
+
+    ``[]`` is syntactically valid JSON but the wrong shape: without the
+    ``isinstance(stats, dict)`` guard + blanket advisory try/except, the
+    ``stats.get(...)`` in ``_append_coverage_section`` raises AttributeError and
+    kills an otherwise-completed review. The run must still complete (exit 0,
+    report written) with no Coverage section rendered.
+    """
+    _silence(monkeypatch)
+    _install_stub_backend(monkeypatch, multi_stack_target)
+    deep = _prime_merge_resume(
+        multi_stack_target,
+        python=[_record(confidence="HIGH")],
+        react=[_record()],
+        generic=[_record()],
+        structure=[_record()],
+    )
+    # Malformed shape: valid JSON but a list, so stats.get(...) would raise
+    # AttributeError without the shape guard.
+    (deep / "coverage-stats.json").write_text("[]")
+
+    exit_code = await _run_deep(multi_stack_target, start_at="merge")
+    assert exit_code == 0
+
+    report = (multi_stack_target / ".review-output.md").read_text()
+    assert "## Coverage" not in report
 
 
 def test_uncovered_sweep_step_resolves_via_parse_phase_key() -> None:

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -5087,3 +5087,172 @@ async def test_structural_finding_reported_medium_severity_survives_merge(
         "structural anti-slop finding must keep its reported medium severity, "
         f"got {structural[0].get('severity')!r}:\n{structural}"
     )
+
+
+def _uncovered_sweep_target(tmp_path: Path) -> Path:
+    """Git repo whose diff has one file NO per-stack reviewer reads.
+
+    ``notes.txt`` is an ambiguous-extension file routed to the generic stack;
+    the stub leaves it unread (``per_stack_unread``) and its hunk is large
+    enough (6 added lines) to clear the sweep's ``uncovered_sweep_min_hunk_lines``
+    budget, so it is the single file the sweep covers. The other files' hunks
+    are trivially small (<5 changed lines), so the sweep has exactly one target.
+    """
+    project = tmp_path / "sweep_target"
+    project.mkdir()
+    (project / "api.py").write_text("def hello():\n    return 'world'\n")
+    (project / "App.tsx").write_text("export const App = () => <div>hello</div>;\n")
+    (project / "README.md").write_text("# Project\n")
+    _init_repo(project)
+    _git(project, "add", ".")
+    _commit(project, "init")
+    _git(project, "checkout", "-b", "feature")
+    (project / "api.py").write_text("def hello():\n    return 'universe'\n")
+    (project / "App.tsx").write_text("export const App = () => <div>universe</div>;\n")
+    (project / "README.md").write_text("# Project\n\nUpdated.\n")
+    (project / "notes.txt").write_text("".join(f"line{i}\n" for i in range(1, 7)))
+    _git(project, "add", ".")
+    _commit(project, "change")
+    return project
+
+
+async def test_run_deep_uncovered_sweep_merges_and_improves_coverage(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, make_config: MakeConfig, mute_side_effects: Mute
+) -> None:
+    """AC (issue #309): the sweep reviews an uncovered file, its finding is an
+    ordinary merged finding, coverage stats improve, and the report surfaces
+    coverage.
+
+    Real path: ``runner.run`` through the deep flow with a real temp git repo,
+    real filesystem, and real event loop; only the backend is stubbed. The
+    stub per-stack reviewers read their own files (leaving ``notes.txt`` the
+    single uncovered file), and the sweep branch emits a read + a finding for
+    it.
+    """
+    from daydream.eval.analyzer import analyze_coverage, load_trajectories
+    from daydream.runner import run
+
+    target = _uncovered_sweep_target(tmp_path)
+    _silence(monkeypatch)
+    mute_side_effects()
+    stub = _install_stub_backend(monkeypatch, target)
+    stub.per_stack_emit_reads = True
+    stub.per_stack_unread = frozenset({"notes.txt"})
+    stub.sweep_file = "notes.txt"
+    stub.merge_echo_records = True
+
+    exit_code = await run(make_config(target, assume="yes", output_mode="loop"))
+    assert exit_code == 0
+
+    deep = target / ".daydream" / "deep"
+
+    # (a) The sweep records file exists and its finding is a MERGED finding.
+    records_file = deep / "stack-uncovered-records.json"
+    assert records_file.is_file()
+    records = json.loads(records_file.read_text())
+    assert any(r.get("file") == "notes.txt" for r in records)
+    merged_items = json.loads((deep / "merged-items.json").read_text())
+    merged_files = {item.get("file") for item in merged_items["items"]}
+    assert "notes.txt" in merged_files
+
+    # (b) coverage-stats records the pre-sweep state and the swept file.
+    stats = json.loads((deep / "coverage-stats.json").read_text())
+    assert stats["files_in_diff"] == 4
+    assert stats["files_read_by_reviewers"] == 3  # api.py, App.tsx, README.md read pre-sweep
+    assert stats["uncovered_files"] == ["notes.txt"]
+    assert stats["swept_files"] == ["notes.txt"]
+    assert stats["sweep_finding_count"] == len(records) >= 1
+    assert stats["sweep_skipped_small_hunks"] == 0
+
+    # (c) post-run analyze_coverage sees the sweep fork's read: ratio improves.
+    trajectories = load_trajectories(target / ".daydream")
+    post = analyze_coverage(trajectories, target / ".daydream")
+    assert post["files_read_by_reviewers"] == 4
+    assert post["coverage_ratio"] == 1.0
+    assert post["coverage_ratio"] > stats["coverage_ratio"]  # 0.75 -> 1.0
+
+    # (d) the merged report carries the Coverage section (the pre-sweep
+    # snapshot from coverage-stats.json plus the swept-file line).
+    report = (target / ".review-output.md").read_text()
+    assert "## Coverage" in report
+    assert "Files in diff: 4" in report
+    assert "Files read by reviewers: 3" in report
+    assert "Second-pass sweep covered: notes.txt" in report
+
+
+async def test_run_deep_uncovered_sweep_fails_open(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, make_config: MakeConfig, mute_side_effects: Mute
+) -> None:
+    """A broken sweep (backend raise) never fails the run: exit 0, the failure
+    is recorded in coverage-stats.json, and merged-items.json is still written.
+    """
+    from daydream.runner import run
+
+    target = _uncovered_sweep_target(tmp_path)
+    _silence(monkeypatch)
+    mute_side_effects()
+    stub = _install_stub_backend(monkeypatch, target)
+    stub.per_stack_emit_reads = True
+    stub.per_stack_unread = frozenset({"notes.txt"})
+    stub.fail_sweep = True
+
+    exit_code = await run(make_config(target, assume="yes", output_mode="loop"))
+    assert exit_code == 0
+
+    deep = target / ".daydream" / "deep"
+    stats = json.loads((deep / "coverage-stats.json").read_text())
+    assert stats["swept_files"] == ["notes.txt"]
+    assert stats["sweep_finding_count"] == 0
+    assert "notes.txt" in stats["sweep_failures"]
+    assert (deep / "merged-items.json").is_file()
+    assert not (deep / "stack-uncovered-records.json").exists()  # no review output to parse
+
+
+async def test_uncovered_sweep_disabled_by_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, make_config: MakeConfig, mute_side_effects: Mute
+) -> None:
+    """Setting ``uncovered_sweep = false`` (CLI tier) skips the sweep entirely."""
+    from daydream.runner import run
+
+    target = _uncovered_sweep_target(tmp_path)
+    _silence(monkeypatch)
+    mute_side_effects()
+    stub = _install_stub_backend(monkeypatch, target)
+    stub.per_stack_emit_reads = True
+    stub.per_stack_unread = frozenset({"notes.txt"})
+    stub.sweep_file = "notes.txt"
+    stub.merge_echo_records = True
+
+    exit_code = await run(
+        make_config(target, assume="yes", output_mode="loop", uncovered_sweep=False)
+    )
+    assert exit_code == 0
+
+    deep = target / ".daydream" / "deep"
+    assert not (deep / "coverage-stats.json").exists()
+    assert not (deep / "stack-uncovered-records.json").exists()
+    merged_items = json.loads((deep / "merged-items.json").read_text())
+    assert all(item.get("file") != "notes.txt" for item in merged_items["items"])
+
+
+async def test_uncovered_sweep_noop_on_merge_resume(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A ``--start-at merge`` resume is a sweep no-op: no sweep artifacts are
+    created and the resume still succeeds.
+    """
+    _silence(monkeypatch)
+    _install_stub_backend(monkeypatch, multi_stack_target)
+    _prime_merge_resume(
+        multi_stack_target,
+        python=[_record(confidence="HIGH")],
+        react=[_record()],
+        generic=[_record()],
+        structure=[_record()],
+    )
+
+    exit_code = await _run_deep(multi_stack_target, start_at="merge")
+    assert exit_code == 0
+    deep = multi_stack_target / ".daydream" / "deep"
+    assert not (deep / "stack-uncovered-records.json").exists()
+    assert not (deep / "coverage-stats.json").exists()

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -95,12 +95,22 @@ def _install_model_capturing_stubs(
     return shared_calls
 
 
-async def _run_deep(target: Path, *, start_at: str = "review", precision_mode: bool = False) -> int:
+async def _run_deep(
+    target: Path,
+    *,
+    start_at: str = "review",
+    precision_mode: bool = False,
+    uncovered_sweep: bool | None = None,
+) -> int:
     from daydream.runner import RunConfig, run
 
     # cleanup=False suppresses the interactive cleanup prompt; deep is the default.
     config = RunConfig(
-        target=str(target), start_at=start_at, cleanup=False, precision_mode=precision_mode
+        target=str(target),
+        start_at=start_at,
+        cleanup=False,
+        precision_mode=precision_mode,
+        uncovered_sweep=uncovered_sweep,
     )
     return await run(config)
 
@@ -5155,28 +5165,35 @@ async def test_run_deep_uncovered_sweep_merges_and_improves_coverage(
     merged_files = {item.get("file") for item in merged_items["items"]}
     assert "notes.txt" in merged_files
 
-    # (b) coverage-stats records the pre-sweep state and the swept file.
+    # (b) coverage-stats records the PRE-sweep state separately from the
+    # POST-sweep recompute, and labels the swept files it actually completed.
     stats = json.loads((deep / "coverage-stats.json").read_text())
-    assert stats["files_in_diff"] == 4
-    assert stats["files_read_by_reviewers"] == 3  # api.py, App.tsx, README.md read pre-sweep
-    assert stats["uncovered_files"] == ["notes.txt"]
-    assert stats["swept_files"] == ["notes.txt"]
+    pre_sweep = stats["pre_sweep"]
+    assert pre_sweep["files_in_diff"] == 4
+    assert pre_sweep["files_read_by_reviewers"] == 3  # api.py, App.tsx, README.md read pre-sweep
+    assert pre_sweep["uncovered_files"] == ["notes.txt"]
+    assert stats["attempted_files"] == ["notes.txt"]
+    assert stats["completed_files"] == ["notes.txt"]
     assert stats["sweep_finding_count"] == len(records) >= 1
     assert stats["sweep_skipped_small_hunks"] == 0
+    # The POST-sweep ratio reflects the sweep fork's completed read of notes.txt.
+    assert stats["post_sweep"]["files_read_by_reviewers"] == 4
+    assert stats["post_sweep"]["coverage_ratio"] > pre_sweep["coverage_ratio"]  # 0.75 -> 1.0
 
     # (c) post-run analyze_coverage sees the sweep fork's read: ratio improves.
     trajectories = load_trajectories(target / ".daydream")
     post = analyze_coverage(trajectories, target / ".daydream")
     assert post["files_read_by_reviewers"] == 4
     assert post["coverage_ratio"] == 1.0
-    assert post["coverage_ratio"] > stats["coverage_ratio"]  # 0.75 -> 1.0
+    assert post["coverage_ratio"] == stats["post_sweep"]["coverage_ratio"]  # report shows the achieved ratio
 
-    # (d) the merged report carries the Coverage section (the pre-sweep
-    # snapshot from coverage-stats.json plus the swept-file line).
+    # (d) the merged report carries the Coverage section with the POST-sweep
+    # ratio and the completed swept-file line.
     report = (target / ".review-output.md").read_text()
     assert "## Coverage" in report
     assert "Files in diff: 4" in report
-    assert "Files read by reviewers: 3" in report
+    assert "Files read by reviewers: 4" in report
+    assert "Coverage ratio: 1.0" in report
     assert "Second-pass sweep covered: notes.txt" in report
 
 
@@ -5201,11 +5218,20 @@ async def test_run_deep_uncovered_sweep_fails_open(
 
     deep = target / ".daydream" / "deep"
     stats = json.loads((deep / "coverage-stats.json").read_text())
-    assert stats["swept_files"] == ["notes.txt"]
+    assert stats["attempted_files"] == ["notes.txt"]
+    assert stats["completed_files"] == []
     assert stats["sweep_finding_count"] == 0
     assert "notes.txt" in stats["sweep_failures"]
     assert (deep / "merged-items.json").is_file()
-    assert not (deep / "stack-uncovered-records.json").exists()  # no review output to parse
+    # No review output to parse on a fresh run -> no records artifact at all
+    # (nothing stale to replace).
+    assert not (deep / "stack-uncovered-records.json").exists()
+    # The report does NOT claim the failed sweep covered anything: it names the
+    # failure instead.
+    report = (target / ".review-output.md").read_text()
+    assert "## Coverage" in report
+    assert "Second-pass sweep covered" not in report
+    assert "Best-effort sweep failures: notes.txt" in report
 
 
 async def test_uncovered_sweep_disabled_by_config(
@@ -5256,3 +5282,154 @@ async def test_uncovered_sweep_noop_on_merge_resume(
     deep = multi_stack_target / ".daydream" / "deep"
     assert not (deep / "stack-uncovered-records.json").exists()
     assert not (deep / "coverage-stats.json").exists()
+
+
+async def test_uncovered_sweep_per_stack_resume_clears_stale_artifacts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A ``--start-at per-stack`` resume drops the prior run's sweep artifacts.
+
+    First run: the sweep produces output (records + stats + review files).
+    Resume at per-stack with the sweep disabled: the rerun re-reviews
+    per-stack work but must NOT inherit the prior run's coverage -- the stale
+    records file is gone, so a later merge resume cannot reload it.
+    """
+    target = _uncovered_sweep_target(tmp_path)
+    _silence(monkeypatch)
+
+    stub = _install_stub_backend(monkeypatch, target)
+    stub.per_stack_emit_reads = True
+    stub.per_stack_unread = frozenset({"notes.txt"})
+    stub.sweep_file = "notes.txt"
+    stub.merge_echo_records = True
+    assert await _run_deep(target) == 0
+
+    deep = target / ".daydream" / "deep"
+    assert (deep / "stack-uncovered-records.json").is_file()
+    assert (deep / "coverage-stats.json").is_file()
+    assert list(deep.glob("uncovered-*-review.md"))
+
+    stub2 = _install_stub_backend(monkeypatch, target)
+    stub2.per_stack_emit_reads = True
+    stub2.per_stack_unread = frozenset({"notes.txt"})
+    stub2.merge_echo_records = True
+    assert await _run_deep(target, start_at="per-stack", uncovered_sweep=False) == 0
+
+    assert not (deep / "stack-uncovered-records.json").exists()
+    assert not (deep / "coverage-stats.json").exists()
+    assert not list(deep.glob("uncovered-*-review.md"))
+
+
+async def test_uncovered_sweep_per_stack_resume_no_findings_writes_empty_records(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A per-stack resume whose rerun sweep produces no findings writes ``[]``.
+
+    The prior run's records file must not survive a rerun that yields no
+    findings: the rerun writes a current empty records artifact so a later
+    merge resume reloads ``[]`` instead of stale records.
+    """
+    target = _uncovered_sweep_target(tmp_path)
+    _silence(monkeypatch)
+
+    stub = _install_stub_backend(monkeypatch, target)
+    stub.per_stack_emit_reads = True
+    stub.per_stack_unread = frozenset({"notes.txt"})
+    stub.sweep_file = "notes.txt"
+    stub.merge_echo_records = True
+    assert await _run_deep(target) == 0
+
+    deep = target / ".daydream" / "deep"
+    assert json.loads((deep / "stack-uncovered-records.json").read_text())
+
+    stub2 = _install_stub_backend(monkeypatch, target)
+    stub2.per_stack_emit_reads = True
+    stub2.per_stack_unread = frozenset({"notes.txt"})
+    stub2.fail_sweep = True  # the rerun sweep attempts and fails -> no findings
+    stub2.merge_echo_records = True
+    assert await _run_deep(target, start_at="per-stack") == 0
+
+    assert json.loads((deep / "stack-uncovered-records.json").read_text()) == []
+
+
+def test_uncovered_sweep_step_resolves_via_parse_phase_key() -> None:
+    """The sweep step registers ``config_phase="parse"`` (docs/extensions.md)."""
+    from daydream.deep.orchestrator import STEPS
+
+    steps = {s.name: s for s in STEPS}
+    assert steps["uncovered-sweep"].phase_key == "parse"
+    assert steps["per-stack-parse"].phase_key == "parse"
+
+
+def test_uncovered_sweep_enabled_resolution(tmp_path: Path) -> None:
+    """The sweep toggle resolves via the named default constant, with config tiers."""
+    from daydream.config import DEFAULT_UNCOVERED_SWEEP_ENABLED
+    from daydream.config_file import DaydreamFileConfig
+    from daydream.deep.orchestrator import _uncovered_sweep_enabled
+    from daydream.extensions import Registry
+    from daydream.flows.engine import FlowContext
+    from daydream.runner import RunConfig
+    from daydream.workspace import WorkContext
+
+    assert DEFAULT_UNCOVERED_SWEEP_ENABLED is True
+
+    def _ctx(config: RunConfig) -> FlowContext:
+        work = WorkContext(
+            repo=tmp_path,
+            source=tmp_path,
+            base_branch="main",
+            base_sha="",
+            head_branch=None,
+            head_sha="",
+            is_ephemeral=False,
+            run_id="test",
+        )
+        return FlowContext(config=config, work=work, registry=Registry(), data={})
+
+    # Default on.
+    assert _uncovered_sweep_enabled(_ctx(RunConfig(target=str(tmp_path)))) is True
+    # File-config False disables.
+    fc = DaydreamFileConfig(uncovered_sweep=False)
+    assert _uncovered_sweep_enabled(_ctx(RunConfig(target=str(tmp_path), file_config=fc))) is False
+    # RunConfig False (highest tier) beats a file-config True.
+    fc_on = DaydreamFileConfig(uncovered_sweep=True)
+    cfg = RunConfig(target=str(tmp_path), uncovered_sweep=False, file_config=fc_on)
+    assert _uncovered_sweep_enabled(_ctx(cfg)) is False
+    # Merge/fix resumes always disable the sweep.
+    assert _uncovered_sweep_enabled(_ctx(RunConfig(target=str(tmp_path), start_at="merge"))) is False
+
+
+def test_uncovered_sweep_numeric_resolution_rejects_negatives(tmp_path: Path) -> None:
+    """Negative sweep numerics degrade to the named defaults; explicit 0 survives."""
+    from daydream.config import (
+        DEFAULT_UNCOVERED_SWEEP_MAX_FILES,
+        DEFAULT_UNCOVERED_SWEEP_MIN_HUNK_LINES,
+    )
+    from daydream.config_file import DaydreamFileConfig
+    from daydream.deep.orchestrator import (
+        _uncovered_sweep_max_files,
+        _uncovered_sweep_min_hunk_lines,
+    )
+    from daydream.runner import RunConfig
+
+    # A directly-constructed RunConfig negative override degrades to the default.
+    cfg = RunConfig(target=str(tmp_path), uncovered_sweep_max_files=-1, uncovered_sweep_min_hunk_lines=-5)
+    assert _uncovered_sweep_max_files(cfg) == DEFAULT_UNCOVERED_SWEEP_MAX_FILES
+    assert _uncovered_sweep_min_hunk_lines(cfg) == DEFAULT_UNCOVERED_SWEEP_MIN_HUNK_LINES
+
+    # Explicit 0 is preserved (0 max = sweep nothing; 0 min = no hunk floor).
+    cfg = RunConfig(target=str(tmp_path), uncovered_sweep_max_files=0, uncovered_sweep_min_hunk_lines=0)
+    assert _uncovered_sweep_max_files(cfg) == 0
+    assert _uncovered_sweep_min_hunk_lines(cfg) == 0
+
+    # A negative file-config value is coerced to None at load -> default applies.
+    fc = DaydreamFileConfig(uncovered_sweep_max_files=-1, uncovered_sweep_min_hunk_lines=-3)
+    cfg = RunConfig(target=str(tmp_path), file_config=fc)
+    assert _uncovered_sweep_max_files(cfg) == DEFAULT_UNCOVERED_SWEEP_MAX_FILES
+    assert _uncovered_sweep_min_hunk_lines(cfg) == DEFAULT_UNCOVERED_SWEEP_MIN_HUNK_LINES
+
+    # A file-config 0 with no RunConfig override stays 0.
+    fc = DaydreamFileConfig(uncovered_sweep_max_files=0, uncovered_sweep_min_hunk_lines=0)
+    cfg = RunConfig(target=str(tmp_path), file_config=fc)
+    assert _uncovered_sweep_max_files(cfg) == 0
+    assert _uncovered_sweep_min_hunk_lines(cfg) == 0

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -1594,13 +1594,16 @@ async def test_preflight_notice(multi_stack_target: Path, monkeypatch: pytest.Mo
     """D-30: pre-flight notice lists stages, stacks, skill per stack, total agent count."""
     captured: list[dict[str, Any]] = []
 
-    def _capture(console, *, stages, stack_lines, agent_count, exploration_available) -> None:
+    def _capture(
+        console, *, stages, stack_lines, agent_count, exploration_available, sweep_note=None
+    ) -> None:
         captured.append(
             {
                 "stages": stages,
                 "stack_lines": stack_lines,
                 "agent_count": agent_count,
                 "exploration_available": exploration_available,
+                "sweep_note": sweep_note,
             }
         )
 
@@ -1619,6 +1622,41 @@ async def test_preflight_notice(multi_stack_target: Path, monkeypatch: pytest.Mo
     # fixture yields N=4 (python + react + generic + structure), so 2 + 2*4 + 1 + 1 = 12.
     assert notice["agent_count"] == 12
     assert len(notice["stack_lines"]) >= 1
+    # Issue #309 finding 8: the sweep is enabled by default, so the pre-flight
+    # estimate appends an upper-bound note. The fixture changes 3 files, so the
+    # sweep could add up to 2 x min(3, max_files=10) = 6 review+parse agents.
+    assert notice["sweep_note"] == (
+        "(+ up to 6 sweep agents: review + parse per uncovered file, "
+        "capped by eligible changed files)"
+    )
+
+
+async def test_preflight_notice_sweep_note_disabled_when_sweep_off(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No sweep additive in the pre-flight estimate when the sweep is disabled."""
+    captured: list[dict[str, Any]] = []
+
+    def _capture(
+        console, *, stages, stack_lines, agent_count, exploration_available, sweep_note=None
+    ) -> None:
+        captured.append(
+            {
+                "agent_count": agent_count,
+                "sweep_note": sweep_note,
+            }
+        )
+
+    monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
+    monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", _capture)
+    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "n")
+    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
+    _install_stub_backend(monkeypatch, multi_stack_target)
+
+    exit_code = await _run_deep(multi_stack_target, uncovered_sweep=False)
+    assert exit_code == 0
+    assert len(captured) == 1
+    assert captured[0]["sweep_note"] is None
 
 
 async def test_resume_per_stack_reruns_all(multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -5174,6 +5212,8 @@ async def test_run_deep_uncovered_sweep_merges_and_improves_coverage(
     assert pre_sweep["uncovered_files"] == ["notes.txt"]
     assert stats["attempted_files"] == ["notes.txt"]
     assert stats["completed_files"] == ["notes.txt"]
+    assert stats["covered_files"] == ["notes.txt"]  # sweep fork's read is verified
+    assert stats["sweep_attempt_status"] == {"notes.txt": "read"}
     assert stats["sweep_finding_count"] == len(records) >= 1
     assert stats["sweep_skipped_small_hunks"] == 0
     # Finding 10: the skip filename lists are persisted alongside the counts
@@ -5399,6 +5439,54 @@ async def test_run_deep_uncovered_sweep_missing_output_not_claimed_as_coverage(
     assert "Best-effort sweep failures: notes.txt" in report
 
 
+async def test_run_deep_uncovered_sweep_review_without_read_not_claimed_as_covered(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, make_config: MakeConfig, mute_side_effects: Mute
+) -> None:
+    """A successful sweep review WITHOUT a file Read is an attempt, not coverage
+    (issue #309 finding 6).
+
+    The sweep prompt now requires reading the file before reviewing hunks; a
+    backend that still writes a valid review without emitting a Read must not
+    move ``files_read_by_reviewers`` / ``coverage_ratio``. The file lands in
+    ``completed_files`` (completed attempt) but NOT ``covered_files``, and the
+    report labels it ``reviewed (hunks only)``.
+    """
+    from daydream.runner import run
+
+    target = _uncovered_sweep_target(tmp_path)
+    _silence(monkeypatch)
+    mute_side_effects()
+    stub = _install_stub_backend(monkeypatch, target)
+    stub.per_stack_emit_reads = True
+    stub.per_stack_unread = frozenset({"notes.txt"})
+    stub.sweep_file = "notes.txt"
+    stub.sweep_no_read = True  # review written, but no Read tool call emitted
+    stub.merge_echo_records = True
+
+    exit_code = await run(make_config(target, assume="yes", output_mode="loop"))
+    assert exit_code == 0
+
+    deep = target / ".daydream" / "deep"
+    stats = json.loads((deep / "coverage-stats.json").read_text())
+    pre_sweep = stats["pre_sweep"]
+    assert pre_sweep["uncovered_files"] == ["notes.txt"]
+    # The review output WAS written -> the file is a completed ATTEMPT.
+    assert stats["completed_files"] == ["notes.txt"]
+    # But no verified completed read of the file -> never "covered".
+    assert stats["covered_files"] == []
+    assert stats["sweep_attempt_status"] == {"notes.txt": "reviewed (hunks only)"}
+    # The coverage numbers are unchanged by the hunk-only review.
+    assert stats["post_sweep"]["files_read_by_reviewers"] == 3
+    assert stats["post_sweep"]["coverage_ratio"] == pre_sweep["coverage_ratio"] == 0.75
+
+    report = (target / ".review-output.md").read_text()
+    assert "## Coverage" in report
+    assert "Second-pass sweep covered" not in report
+    assert "Second-pass sweep reviewed (hunks only): notes.txt" in report
+    assert "Files read by reviewers: 3" in report
+    assert "Coverage ratio: 0.75" in report
+
+
 async def test_uncovered_sweep_per_stack_resume_fails_closed_on_unremovable_artifact(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -5550,3 +5638,56 @@ def test_uncovered_sweep_numeric_resolution_rejects_negatives(tmp_path: Path) ->
     cfg = RunConfig(target=str(tmp_path), file_config=fc)
     assert _uncovered_sweep_max_files(cfg) == 0
     assert _uncovered_sweep_min_hunk_lines(cfg) == 0
+
+
+def test_uncovered_sweep_numeric_resolution_rejects_non_ints(tmp_path: Path) -> None:
+    """RunConfig numeric overrides are type-validated, not just range-checked
+    (issue #309 finding 7).
+
+    Booleans subclass int and floats pass a ``>= 0`` check, but
+    ``filter_sweepable_files`` needs an int slice: ``max_files=1.5`` raises
+    TypeError and the fail-open wrapper discards the ENTIRE sweep. The resolver
+    accepts a value only when it is an int, not a bool, and >= 0; everything
+    else degrades to the named default.
+    """
+    from daydream.config import (
+        DEFAULT_UNCOVERED_SWEEP_MAX_FILES,
+        DEFAULT_UNCOVERED_SWEEP_MIN_HUNK_LINES,
+    )
+    from daydream.deep.orchestrator import (
+        _uncovered_sweep_max_files,
+        _uncovered_sweep_min_hunk_lines,
+    )
+    from daydream.runner import RunConfig
+
+    # Bool overrides degrade to the defaults (True is not a meaningful count).
+    cfg = RunConfig(
+        target=str(tmp_path),
+        uncovered_sweep_max_files=True,  # type: ignore[arg-type]
+        uncovered_sweep_min_hunk_lines=True,  # type: ignore[arg-type]
+    )
+    assert _uncovered_sweep_max_files(cfg) == DEFAULT_UNCOVERED_SWEEP_MAX_FILES
+    assert _uncovered_sweep_min_hunk_lines(cfg) == DEFAULT_UNCOVERED_SWEEP_MIN_HUNK_LINES
+
+    # Float overrides degrade to the defaults (an int slice is required).
+    cfg = RunConfig(
+        target=str(tmp_path),
+        uncovered_sweep_max_files=1.5,  # type: ignore[arg-type]
+        uncovered_sweep_min_hunk_lines=1.5,  # type: ignore[arg-type]
+    )
+    assert _uncovered_sweep_max_files(cfg) == DEFAULT_UNCOVERED_SWEEP_MAX_FILES
+    assert _uncovered_sweep_min_hunk_lines(cfg) == DEFAULT_UNCOVERED_SWEEP_MIN_HUNK_LINES
+
+    # String overrides degrade to the defaults (never compared or sliced).
+    cfg = RunConfig(
+        target=str(tmp_path),
+        uncovered_sweep_max_files="10",  # type: ignore[arg-type]
+        uncovered_sweep_min_hunk_lines="5",  # type: ignore[arg-type]
+    )
+    assert _uncovered_sweep_max_files(cfg) == DEFAULT_UNCOVERED_SWEEP_MAX_FILES
+    assert _uncovered_sweep_min_hunk_lines(cfg) == DEFAULT_UNCOVERED_SWEEP_MIN_HUNK_LINES
+
+    # Valid ints still pass through unchanged.
+    cfg = RunConfig(target=str(tmp_path), uncovered_sweep_max_files=7, uncovered_sweep_min_hunk_lines=2)
+    assert _uncovered_sweep_max_files(cfg) == 7
+    assert _uncovered_sweep_min_hunk_lines(cfg) == 2


### PR DESCRIPTION
Closes #309

## What

Adds a **fail-open uncovered-diff-file sweep** to the deep flow. After per-stack reviews + parse, the flow computes which diff files no reviewer read (reusing `analyze_coverage` from `daydream/eval/analyzer.py`), budget-filters them (hunk size ≥ 5 changed lines, capped at 10 files per run), and dispatches a **cheap second-pass reviewer** (parse tier) per surviving file with just that file's hunks + the TTT intent.

- New `daydream/deep/coverage.py`: `compute_uncovered_files()` (imports `analyze_coverage`/`load_trajectories` read-only — #316 owns `analyzer.py`), `filter_sweepable_files()` (hunk-size + capacity budget), `build_uncovered_sweep_prompt()` (lives here, NOT in `prompts.py` — #314 owns that).
- Orchestrator: new `uncovered-sweep` FlowStep between `per-stack-parse` and `arbiter`; sweep findings are parsed into `PER_STACK_RECORD_SCHEMA` records, written to `deep/stack-uncovered-records.json`, and appended to `records`/`records_paths`/`record_sources` so the **arbiter and merge consume them as ordinary per-stack findings** — no separate score path.
- Sweep forks are `deep-uncovered-<n>` so post-run `analyze_coverage` counts their reads → `coverage_ratio` improves.
- Coverage stats written to `deep/coverage-stats.json` and surfaced as a `## Coverage` section on the merged report (appended in `_step_load_items`).
- Config: `uncovered_sweep` (default on), `uncovered_sweep_max_files` (10), `uncovered_sweep_min_hunk_lines` (5) — CLI > file-config > default, mirroring `shallow_fanout_threshold`; disabled on `--start-at merge`/`fix` resumes; a merge resume loads the prior sweep's records file so findings aren't dropped.

## Acceptance criteria

- A run with uncovered diff files dispatches the second-pass reviewer — real-path test: fixture diff where `notes.txt` is read by no stack reviewer; the sweep reviews it, the finding lands in `merged-items.json`.
- `manifest.json` / review output carries coverage stats — `## Coverage` section on the merged report + `deep/coverage-stats.json` (`files_in_diff` / `files_read_by_reviewers` / ratio / swept files).
- Coverage ratio improves — post-run `analyze_coverage` goes 0.75 → 1.0 in the test (the sweep fork's read counts).
- Fail-open — a sweep backend exception still exits 0 and writes the report (`test_run_deep_uncovered_sweep_fails_open`).
- `make check` green: 2894 passed / 6 skipped.

## Benchmark isolation

CAN affect Martian benchmark scoring — **intended recall improvement, NOT reward hacking**. The sweep runs before cross-stack-merge; its findings flow through arbiter/merge as ordinary per-stack records and can change `merged-items.json` (that is the point). The scorer reads only merged findings; there is no separate scoring route. Fail-open semantics mean a broken sweep can only reduce recall, never add gamed findings.

## Files changed

- `daydream/deep/coverage.py` (new)
- `daydream/deep/orchestrator.py`
- `daydream/runner.py`
- `daydream/config.py`, `daydream/config_file.py`
- `tests/test_deep_coverage.py` (new), `tests/test_deep_orchestrator.py`, `tests/harness/stub_backend.py`
- `docs/evaluation-framework.md`, `docs/extensions.md`
