### PR TITLE
feat(bench): add in-process openai-compatible judge route

### DIFF
--- a/daydream/benchmark/anthropic_score.py
+++ b/daydream/benchmark/anthropic_score.py
@@ -1,11 +1,18 @@
-"""Direct Anthropic JSON client for benchmark judge steps."""
+"""In-process JSON completers and the shared direct-scoring pipeline for benchmark judge steps.
+
+The pipeline (extraction → dedup → per-pair evaluation) is provider-agnostic: it
+runs against any ``complete_json``-shaped client. ``AnthropicJsonClient`` speaks
+the Anthropic Messages API; :mod:`daydream.benchmark.openai_score` supplies an
+OpenAI-compatible Chat Completions twin. :func:`run_direct_scoring` is the shared
+entry both in-process judge routes drive.
+"""
 
 from __future__ import annotations
 
 import asyncio
 import json
 import os
-from collections.abc import Collection
+from collections.abc import Callable, Collection
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
@@ -138,9 +145,13 @@ class AnthropicJsonClient:
         }
 
         if self.http is not None:
-            return await _complete_json_with_http(self.http, payload=payload, headers=headers)
+            return await _complete_json_with_http(
+                self.http, url=_ANTHROPIC_MESSAGES_URL, payload=payload, headers=headers, content=_anthropic_content
+            )
         async with httpx.AsyncClient() as http:
-            return await _complete_json_with_http(http, payload=payload, headers=headers)
+            return await _complete_json_with_http(
+                http, url=_ANTHROPIC_MESSAGES_URL, payload=payload, headers=headers, content=_anthropic_content
+            )
 
 
 def _load_json_dict(path: Path, *, required: bool, missing_hint: str = "") -> dict[str, Any]:
@@ -161,7 +172,7 @@ async def run_anthropic_extraction(
     tool: str = _TOOL,
     client: _AnthropicJsonCompleter,
 ) -> None:
-    """Extract Martian-compatible candidate issues using direct Anthropic JSON calls."""
+    """Extract Martian-compatible candidate issues using the injected JSON completer."""
     benchmark_data_file = benchmark_repo / "results" / "benchmark_data.json"
     data = _load_json_dict(benchmark_data_file, required=True, missing_hint="cannot extract benchmark candidates.")
 
@@ -200,7 +211,7 @@ async def run_anthropic_dedup(
     tool: str = _TOOL,
     client: _AnthropicJsonCompleter,
 ) -> None:
-    """Write Martian-compatible dedup groups using direct Anthropic JSON calls."""
+    """Write Martian-compatible dedup groups using the injected JSON completer."""
     results_dir = model_results_dir(benchmark_repo, judge_model)
     candidates_file = results_dir / "candidates.json"
     all_candidates = _load_json_dict(
@@ -237,22 +248,30 @@ async def run_anthropic_dedup(
     groups_file.write_text(json.dumps(all_groups, indent=2))
 
 
-async def run_anthropic_scoring(
+async def run_direct_scoring(
     benchmark_repo: Path,
     judge_model: str,
     *,
     golden_urls: Collection[str] | None = None,
     tool: str = _TOOL,
     client: _AnthropicJsonCompleter | None = None,
+    judge_route: str = "anthropic-direct",
 ) -> DaydreamScores:
-    """Run direct Anthropic extraction, dedup, and evaluation for benchmark scores."""
+    """Run the shared in-process extraction, dedup, and evaluation pipeline.
+
+    The pipeline is provider-agnostic: ``client`` is any ``complete_json``-shaped
+    completer (Anthropic Messages or an OpenAI-compatible Chat Completions
+    endpoint). When ``client`` is omitted the Anthropic Messages client is built
+    from the environment, preserving the ``anthropic-direct`` default behavior.
+
+    ``judge_route`` is stamped onto every evaluation leaf so trend reports can
+    tell the in-process judge routes apart.
+    """
     benchmark_repo = benchmark_repo.resolve()
     if client is None:
         api_key = os.environ.get(ANTHROPIC_JUDGE_API_KEY_ENV)
         if not api_key:
-            raise BenchmarkStepError(
-                f"{ANTHROPIC_JUDGE_API_KEY_ENV} is not set; cannot run Anthropic-direct scoring."
-            )
+            raise BenchmarkStepError(f"{ANTHROPIC_JUDGE_API_KEY_ENV} is not set; cannot run direct scoring.")
         client = AnthropicJsonClient(api_key=api_key, model=judge_model)
 
     await run_anthropic_extraction(benchmark_repo, judge_model, tool=tool, client=client)
@@ -263,8 +282,28 @@ async def run_anthropic_scoring(
         golden_urls=golden_urls,
         tool=tool,
         client=client,
+        judge_route=judge_route,
     )
     return parse_daydream_scores(evals, tool=tool, golden_urls=golden_urls)
+
+
+async def run_anthropic_scoring(
+    benchmark_repo: Path,
+    judge_model: str,
+    *,
+    golden_urls: Collection[str] | None = None,
+    tool: str = _TOOL,
+    client: _AnthropicJsonCompleter | None = None,
+) -> DaydreamScores:
+    """Back-compat entry: the ``anthropic-direct`` in-process scoring pipeline."""
+    return await run_direct_scoring(
+        benchmark_repo,
+        judge_model,
+        golden_urls=golden_urls,
+        tool=tool,
+        client=client,
+        judge_route="anthropic-direct",
+    )
 
 
 async def run_anthropic_evaluation(
@@ -274,12 +313,13 @@ async def run_anthropic_evaluation(
     golden_urls: Collection[str] | None = None,
     tool: str = _TOOL,
     client: _AnthropicJsonCompleter,
+    judge_route: str = "anthropic-direct",
 ) -> dict[str, dict[str, Any]]:
-    """Write Martian-compatible evaluations using direct Anthropic JSON calls.
+    """Write Martian-compatible evaluations using the injected JSON completer.
 
     ``golden_urls``, when given, restricts evaluation to those PR URLs; entries
     already present in a resumable `evaluations.json` for other PRs are left
-    untouched and unscored.
+    untouched and unscored. ``judge_route`` labels each leaf.
     """
     benchmark_data_file = benchmark_repo / "results" / "benchmark_data.json"
     data = _load_json_dict(benchmark_data_file, required=True, missing_hint="cannot evaluate benchmark candidates.")
@@ -317,7 +357,7 @@ async def run_anthropic_evaluation(
             result["tool"] = tool
             result["repo_name"] = review.get("repo_name")
             result["pr_url"] = review.get("pr_url")
-            result["judge_route"] = "anthropic-direct"
+            result["judge_route"] = judge_route
             result["judge_model"] = judge_model
 
             evals.setdefault(golden_url, {})[tool] = result
@@ -520,10 +560,10 @@ def _build_sibling_map(candidates: list[str], groups: list[list[int]] | None) ->
 
 def _extract_issues(response: dict[str, Any]) -> list[str]:
     if "issues" not in response:
-        raise BenchmarkStepError("Anthropic extraction response missing required 'issues' key.")
+        raise BenchmarkStepError("Extraction response missing required 'issues' key.")
     issues = response["issues"]
     if not isinstance(issues, list) or not all(isinstance(issue, str) for issue in issues):
-        raise BenchmarkStepError("Anthropic extraction response 'issues' must be a list of strings.")
+        raise BenchmarkStepError("Extraction response 'issues' must be a list of strings.")
     return issues
 
 
@@ -567,63 +607,67 @@ def _singleton_groups(n_candidates: int) -> list[list[int]]:
 
 
 async def _complete_json_with_http(
-    http: _AsyncHttpClient, *, payload: dict[str, Any], headers: dict[str, str]
+    http: _AsyncHttpClient,
+    *,
+    url: str,
+    payload: dict[str, Any],
+    headers: dict[str, str],
+    content: Callable[[Any], str],
 ) -> dict[str, Any]:
     for attempt in range(_MAX_RETRIES):
         try:
             try:
-                response = await http.post(
-                    _ANTHROPIC_MESSAGES_URL, headers=headers, json=payload, timeout=_REQUEST_TIMEOUT
-                )
+                response = await http.post(url, headers=headers, json=payload, timeout=_REQUEST_TIMEOUT)
             except Exception as exc:
-                raise BenchmarkStepError(f"Anthropic Messages request failed: {exc}") from exc
-            return _parse_json_response(response)
+                raise BenchmarkStepError(f"Judge request failed: {exc}") from exc
+            return _parse_json_response(response, content=content)
         except _NonRetryableError:
             raise  # 4xx (non-429) and malformed-JSON are permanent; never retry
         except BenchmarkStepError:
             if attempt == _MAX_RETRIES - 1:
                 raise
             await asyncio.sleep(2**attempt)
-    raise BenchmarkStepError("Anthropic Messages request failed after retries")
+    raise BenchmarkStepError("Judge request failed after retries")
 
 
-def _parse_json_response(response: Any) -> dict[str, Any]:
+def _parse_json_response(response: Any, *, content: Callable[[Any], str]) -> dict[str, Any]:
     status_code = getattr(response, "status_code", None)
     if status_code is None or not 200 <= int(status_code) < 300:
         body = getattr(response, "text", "")
         code = int(status_code) if status_code is not None else -1
         # 429 is retryable (rate-limit); all other 4xx are permanent client errors.
         if 400 <= code < 500 and code != 429:
-            raise _NonRetryableError(f"Anthropic Messages request failed with HTTP {status_code}: {body}")
-        raise BenchmarkStepError(f"Anthropic Messages request failed with HTTP {status_code}: {body}")
+            raise _NonRetryableError(f"Judge request failed with HTTP {status_code}: {body}")
+        raise BenchmarkStepError(f"Judge request failed with HTTP {status_code}: {body}")
 
     try:
-        body = response.json()
+        parsed_body = response.json()
     except Exception as exc:
-        raise _NonRetryableError(f"Anthropic Messages response was not valid JSON: {exc}") from exc
+        raise _NonRetryableError(f"Judge response was not valid JSON: {exc}") from exc
 
-    text = _first_text_block(body)
+    text = content(parsed_body)
     try:
         parsed = json.loads(_strip_markdown_fences(text))
     except json.JSONDecodeError as exc:
-        raise _NonRetryableError(f"Anthropic Messages text block was not valid JSON: {exc}") from exc
+        raise _NonRetryableError(f"Judge text content was not valid JSON: {exc}") from exc
     if not isinstance(parsed, dict):
-        raise _NonRetryableError("Anthropic Messages text block JSON was not an object")
+        raise _NonRetryableError("Judge text content JSON was not an object")
     return parsed
 
 
-def _first_text_block(body: Any) -> str:
+def _anthropic_content(body: Any) -> str:
+    """Extract the first text block from an Anthropic Messages response body."""
     if not isinstance(body, dict):
-        raise BenchmarkStepError("Anthropic Messages response body was not an object")
+        raise BenchmarkStepError("Judge response body was not an object")
     content = body.get("content")
     if not isinstance(content, list):
-        raise BenchmarkStepError("Anthropic Messages response missing content blocks")
+        raise BenchmarkStepError("Judge response missing content blocks")
     for block in content:
         if isinstance(block, dict) and block.get("type") == "text" and isinstance(block.get("text"), str):
             text = block["text"].strip()
             if text:
                 return text
-    raise BenchmarkStepError("Anthropic Messages response contained no text block")
+    raise BenchmarkStepError("Judge response contained no text block")
 
 
 def _strip_markdown_fences(text: str) -> str:

--- a/daydream/benchmark/cli.py
+++ b/daydream/benchmark/cli.py
@@ -76,7 +76,8 @@ def _build_bench_parser() -> argparse.ArgumentParser:
         dest="harvest_dir",
         metavar="PATH",
         help="Root of a harvested bot-review corpus (see 'daydream bench harvest'); "
-        "mutually exclusive with --benchmark-repo and requires --judge-route anthropic-direct",
+        "mutually exclusive with --benchmark-repo and requires an in-process judge "
+        "route (anthropic-direct or openai-compatible)",
     )
     parser.add_argument(
         "--cache-dir",
@@ -106,7 +107,7 @@ def _build_bench_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--judge-route",
         type=str,
-        choices=["martian", "anthropic-direct"],
+        choices=["martian", "anthropic-direct", "openai-compatible"],
         default=None,
         dest="judge_route",
         help="Benchmark scoring route (default: martian, or [tool.daydream.bench] judge-route)",
@@ -271,8 +272,8 @@ def _bench_config_from_argv(argv: list[str]) -> "BenchConfig":
     )
     model = args.model if args.model is not None else bench.get("model")
     judge_route = args.judge_route if args.judge_route is not None else bench.get("judge-route", "martian")
-    if judge_route not in {"martian", "anthropic-direct"}:
-        parser.error("--judge-route must be one of: martian, anthropic-direct")
+    if judge_route not in {"martian", "anthropic-direct", "openai-compatible"}:
+        parser.error("--judge-route must be one of: martian, anthropic-direct, openai-compatible")
     min_confidence = args.min_confidence if args.min_confidence is not None else bench.get("min-confidence")
     min_severity = args.min_severity if args.min_severity is not None else bench.get("min-severity")
     trials = args.trials if args.trials is not None else bench.get("trials", 1)
@@ -302,7 +303,10 @@ def _bench_config_from_argv(argv: list[str]) -> "BenchConfig":
         # with cwd=<corpus root>; that package only exists inside the withmartian
         # checkout, so a harvested corpus can only be scored in-process. Gated on
         # --score because the route is never driven when scoring is off.
-        parser.error("--judge-route martian requires --benchmark-repo; score a harvested corpus with anthropic-direct")
+        parser.error(
+            "--judge-route martian requires --benchmark-repo; score a harvested corpus "
+            "with an in-process route (anthropic-direct or openai-compatible)"
+        )
     bench_root = corpus_root / ".daydream-bench"
     cache_dir = args.cache_dir if args.cache_dir is not None else bench_root / "cache"
     trajectory_dir = args.trajectory_dir if args.trajectory_dir is not None else bench_root / "trajectories"

--- a/daydream/benchmark/config.py
+++ b/daydream/benchmark/config.py
@@ -19,7 +19,8 @@ class BenchConfig:
             or None when the run is driven by a harvested corpus instead.
         cache_dir: Directory for per-PR blobless clones and fetched heads.
         judge_route: Benchmark scoring route; "martian" preserves the existing
-            OpenAI-compatible Martian path.
+            OpenAI-compatible Martian subprocess path, and the in-process routes
+            are "anthropic-direct" / "openai-compatible".
         model: Judge model id; None defers to the selected judge route's
             environment fallback. Whatever resolves drives both the judge and
             the per-model results dir.

--- a/daydream/benchmark/judge.py
+++ b/daydream/benchmark/judge.py
@@ -3,8 +3,8 @@
 Every in-process "are these two findings the same issue?" decision in the
 repo goes through :class:`FindingJudge`. Both scored corpora reach it by the
 same route: the withmartian golden corpus and a harvested bot-review corpus
-are the same data shape, scored by the same ``anthropic-direct`` path, so the
-vendor-overlap comparison and the golden-corpus comparison share one judge
+are the same data shape, scored by the same in-process direct-scoring path, so
+the vendor-overlap comparison and the golden-corpus comparison share one judge
 implementation and one prompt.
 
 (The ``martian`` scoring route is deliberately outside this seam: it does not
@@ -112,14 +112,14 @@ def _parse_verdict(response: dict[str, Any]) -> JudgeVerdict:
     if "error" in response:
         raise JudgeError(str(response["error"]))
     if not isinstance(response.get("match"), bool):
-        raise JudgeError("Anthropic judge response 'match' must be a boolean.")
+        raise JudgeError("Judge response 'match' must be a boolean.")
     confidence = response.get("confidence")
     if isinstance(confidence, bool) or not isinstance(confidence, int | float):
-        raise JudgeError("Anthropic judge response 'confidence' must be a number.")
+        raise JudgeError("Judge response 'confidence' must be a number.")
     confidence = float(confidence)
     if not math.isfinite(confidence) or not 0.0 <= confidence <= 1.0:
-        raise JudgeError("Anthropic judge response 'confidence' must be between 0.0 and 1.0.")
+        raise JudgeError("Judge response 'confidence' must be between 0.0 and 1.0.")
     reasoning = response.get("reasoning", "")
     if not isinstance(reasoning, str):
-        raise JudgeError("Anthropic judge response 'reasoning' must be a string.")
+        raise JudgeError("Judge response 'reasoning' must be a string.")
     return JudgeVerdict(match=response["match"], confidence=confidence, reasoning=reasoning)

--- a/daydream/benchmark/openai_score.py
+++ b/daydream/benchmark/openai_score.py
@@ -1,0 +1,145 @@
+"""In-process OpenAI-compatible JSON completer for the benchmark judge.
+
+Any OpenAI Chat Completions-compatible endpoint — OpenAI direct, OpenRouter, or
+a compatible gateway — can serve as the benchmark judge. ``OpenAIJsonCompleter``
+implements the same ``complete_json`` seam as ``AnthropicJsonClient``, so the
+shared direct-scoring pipeline in :mod:`daydream.benchmark.anthropic_score`
+(extraction → dedup → per-pair evaluation) runs against it unchanged.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Collection
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from daydream.benchmark.anthropic_score import (
+    _AsyncHttpClient,
+    _complete_json_with_http,
+    run_direct_scoring,
+)
+from daydream.benchmark.score import (
+    _OPENROUTER_BASE_URL,
+    _OPENROUTER_KEY_PREFIX,
+    _TOOL,
+    OPENAI_JUDGE_API_KEY_ENV,
+    OPENAI_JUDGE_BASE_URL_ENV,
+    BenchmarkStepError,
+    DaydreamScores,
+)
+
+#: Chat Completions base URL for OpenAI's own API. OpenRouter is auto-routed when
+#: the key carries the ``sk-or-`` prefix (see `_resolve_openai_base_url`).
+_OPENAI_DEFAULT_BASE_URL = "https://api.openai.com/v1"
+_OPENAI_CHAT_COMPLETIONS_PATH = "/chat/completions"
+
+
+def _resolve_openai_base_url(api_key: str, base_url_env: str | None) -> str:
+    """Resolve the Chat Completions base URL from the environment.
+
+    An explicit ``OPENAI_BASE_URL`` always wins; an ``sk-or-`` OpenRouter key
+    with no pin routes to OpenRouter (mirroring the martian route's auto-route,
+    score.py); anything else defaults to OpenAI direct.
+    """
+    if base_url_env:
+        return base_url_env
+    if api_key.startswith(_OPENROUTER_KEY_PREFIX):
+        return _OPENROUTER_BASE_URL
+    return _OPENAI_DEFAULT_BASE_URL
+
+
+def _openai_content(body: Any) -> str:
+    """Extract ``choices[0].message.content`` from an OpenAI-compatible response body."""
+    if not isinstance(body, dict):
+        raise BenchmarkStepError("Judge response body was not an object")
+    choices = body.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise BenchmarkStepError("Judge response missing a choices list")
+    choice = choices[0]
+    if not isinstance(choice, dict):
+        raise BenchmarkStepError("Judge response choice was not an object")
+    message = choice.get("message")
+    if not isinstance(message, dict):
+        raise BenchmarkStepError("Judge response missing a message object")
+    content = message.get("content")
+    if not isinstance(content, str):
+        raise BenchmarkStepError("Judge response message content was not a string")
+    text = content.strip()
+    if not text:
+        raise BenchmarkStepError("Judge response message content was empty")
+    return text
+
+
+@dataclass
+class OpenAIJsonCompleter:
+    """Small OpenAI Chat Completions client that returns strict parsed JSON objects."""
+
+    api_key: str
+    model: str
+    base_url: str = _OPENAI_DEFAULT_BASE_URL
+    http: _AsyncHttpClient | None = None
+
+    async def complete_json(self, *, system: str, user: str, max_tokens: int) -> dict[str, Any]:
+        """POST a Chat Completions request and parse ``choices[0].message.content`` as JSON."""
+        payload = {
+            "model": self.model,
+            "max_tokens": max_tokens,
+            "temperature": 0,
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+        }
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "content-type": "application/json",
+        }
+        url = self.base_url.rstrip("/") + _OPENAI_CHAT_COMPLETIONS_PATH
+
+        if self.http is not None:
+            return await _complete_json_with_http(
+                self.http, url=url, payload=payload, headers=headers, content=_openai_content
+            )
+        async with httpx.AsyncClient() as http:
+            return await _complete_json_with_http(
+                http, url=url, payload=payload, headers=headers, content=_openai_content
+            )
+
+
+async def run_openai_scoring(
+    benchmark_repo: Path,
+    judge_model: str,
+    *,
+    golden_urls: Collection[str] | None = None,
+    tool: str = _TOOL,
+    client: OpenAIJsonCompleter | None = None,
+) -> DaydreamScores:
+    """Run extraction, dedup, and evaluation against an OpenAI-compatible endpoint.
+
+    When ``client`` is omitted the completer is built from ``OPENAI_API_KEY`` /
+    ``OPENAI_BASE_URL`` (with OpenRouter auto-routing for ``sk-or-`` keys). The
+    pipeline is the shared in-process scorer with the ``openai-compatible`` leaf
+    stamp, so results land in the same `results/<model>/evaluations.json` shape
+    as ``anthropic-direct``.
+    """
+    if client is None:
+        api_key = os.environ.get(OPENAI_JUDGE_API_KEY_ENV)
+        if not api_key:
+            raise BenchmarkStepError(
+                f"{OPENAI_JUDGE_API_KEY_ENV} is not set; cannot run OpenAI-compatible scoring."
+            )
+        base_url = _resolve_openai_base_url(api_key, os.environ.get(OPENAI_JUDGE_BASE_URL_ENV))
+        client = OpenAIJsonCompleter(api_key=api_key, model=judge_model, base_url=base_url)
+
+    return await run_direct_scoring(
+        benchmark_repo,
+        judge_model,
+        golden_urls=golden_urls,
+        tool=tool,
+        client=client,
+        judge_route="openai-compatible",
+    )

--- a/daydream/benchmark/score.py
+++ b/daydream/benchmark/score.py
@@ -22,8 +22,10 @@ from typing import Any
 
 JUDGE_API_KEY_ENV = "MARTIAN_API_KEY"
 ANTHROPIC_JUDGE_API_KEY_ENV = "ANTHROPIC_API_KEY"
+OPENAI_JUDGE_API_KEY_ENV = "OPENAI_API_KEY"
 JUDGE_MODEL_ENV = "MARTIAN_MODEL"
 JUDGE_BASE_URL_ENV = "MARTIAN_BASE_URL"
+OPENAI_JUDGE_BASE_URL_ENV = "OPENAI_BASE_URL"
 
 #: OpenRouter API keys carry this prefix. The upstream judge defaults its base
 #: URL to the Martian host, which rejects an OpenRouter key with HTTP 401; such a
@@ -89,12 +91,15 @@ def preflight_judge_env(*, judge_route: str = "martian") -> None:
     are never logged.
 
     Args:
-        judge_route: ``"martian"`` for the existing OpenAI-compatible judge path,
-            or ``"anthropic-direct"`` for direct Anthropic scoring preflight.
+        judge_route: ``"martian"`` for the existing OpenAI-compatible subprocess
+            path, ``"anthropic-direct"`` for direct Anthropic Messages scoring,
+            or ``"openai-compatible"`` for the in-process OpenAI Chat
+            Completions judge.
 
     Raises:
         JudgeEnvError: If the route-specific credential is unset or the direct
-            Anthropic route is configured with proxy/OpenAI-compatible settings.
+            in-process routes are configured with the martian route's
+            ``MARTIAN_BASE_URL``.
     """
     if judge_route == "anthropic-direct":
         key = os.environ.get(ANTHROPIC_JUDGE_API_KEY_ENV)
@@ -109,6 +114,22 @@ def preflight_judge_env(*, judge_route: str = "martian") -> None:
             raise JudgeEnvError(
                 f"{JUDGE_BASE_URL_ENV} is invalid for direct Anthropic scoring; "
                 "unset it when --judge-route anthropic-direct is selected."
+            )
+        return
+
+    if judge_route == "openai-compatible":
+        key = os.environ.get(OPENAI_JUDGE_API_KEY_ENV)
+        if not key:
+            raise JudgeEnvError(
+                f"{OPENAI_JUDGE_API_KEY_ENV} is not set; export it before running "
+                "the OpenAI-compatible judge step."
+            )
+        # An OpenRouter (sk-or-) key is fine: it auto-routes to OpenRouter when
+        # OPENAI_BASE_URL is unset (mirroring the martian route's sk-or- routing).
+        if os.environ.get(JUDGE_BASE_URL_ENV):
+            raise JudgeEnvError(
+                f"{JUDGE_BASE_URL_ENV} is invalid for OpenAI-compatible scoring; "
+                "unset it when --judge-route openai-compatible is selected."
             )
         return
 
@@ -357,6 +378,22 @@ async def run_anthropic_scoring(
     )
 
 
+async def run_openai_scoring(
+    benchmark_repo: Path,
+    judge_model: str,
+    *,
+    golden_urls: Collection[str] | None = None,
+    tool: str = _TOOL,
+    client: Any | None = None,
+) -> DaydreamScores:
+    """Lazy bridge to the in-process OpenAI-compatible scorer, kept patchable for tests."""
+    from daydream.benchmark.openai_score import run_openai_scoring as direct_run_openai_scoring
+
+    return await direct_run_openai_scoring(
+        benchmark_repo, judge_model, golden_urls=golden_urls, tool=tool, client=client
+    )
+
+
 def run_scoring(
     benchmark_repo: Path,
     judge_model: str,
@@ -368,8 +405,10 @@ def run_scoring(
     """Run the selected benchmark scoring route and parse the tool's scores.
 
     The default ``"martian"`` route preserves the OpenAI-compatible subprocess
-    path. The ``"anthropic-direct"`` route runs extraction, deduplication, and
-    judging through Anthropic's Messages API.
+    path. The ``"anthropic-direct"`` and ``"openai-compatible"`` routes run
+    extraction, deduplication, and judging in-process through the shared
+    direct-scoring pipeline (Anthropic Messages vs. any OpenAI-compatible Chat
+    Completions endpoint).
 
     ``judge_model`` is the single source of truth for the per-model results dir.
     The Martian route also exports it into each step's environment so the harness
@@ -390,6 +429,8 @@ def run_scoring(
     """
     if judge_route == "anthropic-direct":
         return asyncio.run(run_anthropic_scoring(benchmark_repo, judge_model, golden_urls=golden_urls, tool=tool))
+    if judge_route == "openai-compatible":
+        return asyncio.run(run_openai_scoring(benchmark_repo, judge_model, golden_urls=golden_urls, tool=tool))
     if judge_route != "martian":
         raise BenchmarkStepError(f"Unknown judge route: {judge_route}")
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -23,6 +23,12 @@ This runbook takes you from nothing to a scored result.
   - `--model`: the Anthropic judge model id, for example `claude-opus-4-5-20251101`. If omitted, `MARTIAN_MODEL` is used as the judge model fallback and result-directory label.
   - `MARTIAN_BASE_URL` is invalid for direct Anthropic scoring. Unset it when selecting `--judge-route anthropic-direct`; `https://api.anthropic.com` is not an OpenAI Chat Completions-compatible endpoint.
 
+  `--judge-route openai-compatible` runs the same in-process pipeline (extraction → deduplication → per-pair judging) directly against any OpenAI Chat Completions-compatible endpoint — OpenAI direct, OpenRouter, or a compatible gateway. It is not a `MARTIAN_BASE_URL` setting.
+  - `OPENAI_API_KEY`: required for `--score` on this route.
+  - `OPENAI_BASE_URL`: the Chat Completions base URL. Defaults to `https://api.openai.com/v1`; an `sk-or-` OpenRouter key with no explicit `OPENAI_BASE_URL` auto-routes to `https://openrouter.ai/api/v1` (mirroring the martian route's OpenRouter handling). An explicit `OPENAI_BASE_URL` always wins.
+  - `--model`: the judge model id (e.g. `gpt-5.6-luna`, or `openai/gpt-5.6-luna` when routing through OpenRouter). If omitted, `MARTIAN_MODEL` is used as the judge model fallback and result-directory label.
+  - `MARTIAN_BASE_URL` is invalid for OpenAI-compatible scoring. Unset it when selecting `--judge-route openai-compatible`.
+
   These env vars may live in a `.env` file in the directory you run `daydream bench` from; it is auto-loaded at bench entry (`python-dotenv`, searching from the cwd upward). Already-exported shell variables win, so an inline `ANTHROPIC_API_KEY=... daydream bench ...` still overrides the `.env`; a missing or malformed `.env` is a silent no-op.
 
   ```bash
@@ -34,6 +40,11 @@ This runbook takes you from nothing to a scored result.
   # .env beside your invocation, direct Anthropic judge route
   ANTHROPIC_API_KEY=sk-ant-...
   MARTIAN_MODEL=claude-opus-4-5-20251101
+
+  # .env beside your invocation, in-process OpenAI-compatible judge route
+  OPENAI_API_KEY=sk-...
+  OPENAI_BASE_URL=https://openrouter.ai/api/v1   # optional; sk-or- keys auto-route without it
+  MARTIAN_MODEL=gpt-5.6-luna
   ```
 
 ## Configuration file (`[tool.daydream.bench]`)
@@ -44,7 +55,7 @@ Repeating `--benchmark-repo`, the scoring `--model`, and the full reviewer flag 
 [tool.daydream.bench]
 benchmark-repo = "../code-review-benchmark/offline"   # makes --benchmark-repo optional
 model = "anthropic/claude-opus-4-5-20251101"           # scoring model when --model is omitted
-judge-route = "martian"                               # or "anthropic-direct"
+judge-route = "martian"                               # or "anthropic-direct" / "openai-compatible"
 
 # Named reviewer presets: each expands to --reviewer-backend / -model / -provider.
 [tool.daydream.bench.reviewers.glm]
@@ -168,7 +179,7 @@ For each scored PR the harness writes a leaf (keyed by the reviewer's `--tool-la
 <benchmark-repo>/results/<sanitized-model>/evaluations.json
 ```
 
-`<sanitized-model>` is the resolved judge model id with `/` replaced by `_`; `--model` wins over the route-specific environment fallback. Inside each PR's entry the scores are filed under the reviewer's `--tool-label` (default `daydream`; e.g. `daydream-glm` for a GLM reviewer). Each leaf carries `tp`, `fp`, `fn`, `precision`, and `recall` for that PR. Leaves produced by `--judge-route anthropic-direct` also carry `judge_route: "anthropic-direct"`.
+`<sanitized-model>` is the resolved judge model id with `/` replaced by `_`; `--model` wins over the route-specific environment fallback. Inside each PR's entry the scores are filed under the reviewer's `--tool-label` (default `daydream`; e.g. `daydream-glm` for a GLM reviewer). Each leaf carries `tp`, `fp`, `fn`, `precision`, and `recall` for that PR. Every in-process leaf also carries `judge_model` and `judge_route` (`"anthropic-direct"` or `"openai-compatible"`), so trend reports can tell the routes apart.
 
 The command also prints to stdout:
 
@@ -238,11 +249,17 @@ daydream bench --harvest-dir ./cr-corpus \
   --judge-route anthropic-direct \
   --model claude-opus-4-5-20251101 \
   --score
+
+# or score the same corpus with any OpenAI-compatible judge endpoint
+daydream bench --harvest-dir ./cr-corpus \
+  --judge-route openai-compatible \
+  --model gpt-5.6-luna \
+  --score
 ```
 
 The two flags are mutually exclusive: a run has exactly one corpus, and exactly one of them must resolve — from the flag or from a `[tool.daydream.bench]` `harvest-dir` / `benchmark-repo` key. Everything else — `--only`/`--limit`, `--reviewer*`/`--tool-label`, `--trials`, `--force`, resumability — behaves identically, because both corpora share the same on-disk shape.
 
-**Scoring a harvested corpus requires `--judge-route anthropic-direct`.** This is a hard constraint, not a preference: the `martian` route does not judge in-process, it shells `python -m code_review_benchmark.step2/2.5/3` with the corpus root as the working directory, and that package only exists inside the withmartian checkout. Pairing `--harvest-dir` with `--judge-route martian` and `--score` is a usage error.
+**Scoring a harvested corpus requires an in-process judge route (`--judge-route anthropic-direct` or `--judge-route openai-compatible`).** This is a hard constraint, not a preference: the `martian` route does not judge in-process, it shells `python -m code_review_benchmark.step2/2.5/3` with the corpus root as the working directory, and that package only exists inside the withmartian checkout. Pairing `--harvest-dir` with `--judge-route martian` and `--score` is a usage error.
 
 **Golden semantics.** Golden comments are *all* of the bot's standalone inline comments on the PR — thread replies are excluded (they are follow-ups, not findings) and so are body-only review summaries. Each golden comment also carries a `resolved` flag derived from GitHub's review-thread resolution state. That flag is recorded metadata only: nothing scores on it today. It is the raw "acted upon" signal, on the assumption that a resolved thread is a finding the author acted on, and an unresolved one may be noise. Treat unfiltered bot comments as a noisy recall denominator when reading precision/recall from a harvested run.
 
@@ -285,13 +302,21 @@ benchmark/corpora/osprey-coderabbit/results/       # benchmark_data.json (gitign
 **Re-running the parity harness** against this corpus:
 
 ```bash
+# Anthropic judge (Anthropic spend)
 daydream bench --harvest-dir benchmark/corpora/osprey-coderabbit \
   --tool-label daydream-owl-alpha \
   --judge-route anthropic-direct \
   --score
+
+# OpenAI-compatible judge (no Anthropic spend — the #317 unblock)
+daydream bench --harvest-dir benchmark/corpora/osprey-coderabbit \
+  --tool-label daydream-owl-alpha \
+  --judge-route openai-compatible \
+  --model gpt-5.6-luna \
+  --score
 ```
 
-The command is the contract: it replays daydream at each bot snapshot and scores overlap against the golden set. **Baseline scoring is deferred — see [#317](https://github.com/existential-birds/daydream/issues/317)**; this PR ships the harness, corpus, and manifest only, and the one-liner must not be run until the #317 judge budget is allocated (it spends real Anthropic-judge money).
+The command is the contract: it replays daydream at each bot snapshot and scores overlap against the golden set. The one-liner runs through any in-process judge route, so it can score the corpus without Anthropic budget — see [#324](https://github.com/existential-birds/daydream/issues/324), the in-process OpenAI-compatible judge that unblocks the baseline scoring deferred in [#317](https://github.com/existential-birds/daydream/issues/317).
 
 ## The run report
 

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -47,6 +47,18 @@ def test_bench_parser_accepts_direct_anthropic_judge_route(tmp_path, monkeypatch
     assert cfg.model == "claude-opus-4-5-20251101"
 
 
+def test_bench_parser_accepts_openai_compatible_judge_route(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    cfg = _bench_config_from_argv([
+        "--benchmark-repo", "/b",
+        "--judge-route", "openai-compatible",
+        "--model", "gpt-5.6-luna",
+        "--no-score",
+    ])
+    assert cfg.judge_route == "openai-compatible"
+    assert cfg.model == "gpt-5.6-luna"
+
+
 def test_bench_config_has_reviewer_defaults(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     cfg = _bench_config_from_argv(["--benchmark-repo", "/b", "--no-score"])
@@ -109,11 +121,14 @@ def test_harvest_dir_and_benchmark_repo_are_mutually_exclusive(tmp_path, monkeyp
 def test_harvest_dir_with_martian_route_errors(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     # The martian route shells the withmartian step modules, which only exist
-    # inside that checkout; a harvested corpus must score anthropic-direct.
+    # inside that checkout; a harvested corpus must score in-process.
     with pytest.raises(SystemExit):
         _bench_config_from_argv(["--harvest-dir", "/h", "--score", "--judge-route", "martian"])
     cfg = _bench_config_from_argv(["--harvest-dir", "/h", "--score", "--judge-route", "anthropic-direct"])
     assert cfg.judge_route == "anthropic-direct"
+    # The in-process OpenAI-compatible route parses on a harvested corpus too.
+    cfg = _bench_config_from_argv(["--harvest-dir", "/h", "--score", "--judge-route", "openai-compatible"])
+    assert cfg.judge_route == "openai-compatible"
 
 
 def test_harvest_dir_config_file_fallback(tmp_path, monkeypatch):
@@ -295,6 +310,10 @@ def test_benchmark_docs_name_direct_anthropic_judge_route():
     assert "ANTHROPIC_API_KEY" in text
     assert "`MARTIAN_BASE_URL` is invalid" in text
     assert "--reviewer-backend" in text and "--model" in text
+    # The in-process OpenAI-compatible route is documented too.
+    assert "--judge-route openai-compatible" in text
+    assert "OPENAI_API_KEY" in text
+    assert "OPENAI_BASE_URL" in text
 
 
 def test_bench_dotenv_autoloads_credential_through_compiled_entrypoint(tmp_path):

--- a/tests/test_benchmark_harvested_e2e.py
+++ b/tests/test_benchmark_harvested_e2e.py
@@ -24,7 +24,14 @@ from daydream.benchmark.acquire import _cache_subdir_name
 from daydream.benchmark.anthropic_score import _DEDUP_SYSTEM, _EXTRACTION_SYSTEM, AnthropicJsonClient
 from daydream.benchmark.cli import _handle_bench_command
 from daydream.benchmark.judge import _JUDGE_SYSTEM
-from daydream.benchmark.score import ANTHROPIC_JUDGE_API_KEY_ENV, JUDGE_BASE_URL_ENV, model_results_dir
+from daydream.benchmark.openai_score import OpenAIJsonCompleter
+from daydream.benchmark.score import (
+    ANTHROPIC_JUDGE_API_KEY_ENV,
+    JUDGE_BASE_URL_ENV,
+    OPENAI_JUDGE_API_KEY_ENV,
+    OPENAI_JUDGE_BASE_URL_ENV,
+    model_results_dir,
+)
 from tests.harness.git_helpers import git as _git
 
 #: Slug used for the fixture corpus. The derived ``clone_url``
@@ -328,6 +335,81 @@ def test_harvested_corpus_scored_run_calls_judge_per_pair(harvested_run, monkeyp
     assert report["schema_version"] == 1 and report["corpus"] == "harvested"
     assert len(report["prs"]) == 2
     assert report["judge_route"] == "anthropic-direct" and report["judge_model"] == "judge-x"
+    assert report["aggregate"] == {
+        "scored_pr_count": 2,
+        "tp": 2,
+        "fp": 0,
+        "fn": 0,
+        "precision": 1.0,
+        "recall": 1.0,
+        "f1": 1.0,
+    }
+    assert all(entry["tp"] == 1 and entry["fp"] == 0 and entry["fn"] == 0 for entry in report["prs"])
+
+    # One judge call per (golden, candidate) pair, each carrying both texts.
+    assert len(judged_pairs) == 2
+    for pr_number, prompt in zip((1, 2), judged_pairs, strict=True):
+        assert f"bot finding on PR {pr_number}" in prompt
+        assert "daydream finding" in prompt
+
+
+def test_harvested_corpus_scored_run_openai_compatible_route(harvested_run, monkeypatch):
+    """An openai-compatible scored harvested run is entirely in-process.
+
+    The network is mocked at the OpenAI client seam only; extraction, dedup and
+    every per-pair ``same_issue`` call run through the production
+    ``openai-compatible`` scoring path.
+    """
+    _upstream, harvest_dir, cache_dir, calls = harvested_run
+
+    monkeypatch.setenv(OPENAI_JUDGE_API_KEY_ENV, "sk-openai-test")
+    monkeypatch.delenv(OPENAI_JUDGE_BASE_URL_ENV, raising=False)
+    monkeypatch.delenv(JUDGE_BASE_URL_ENV, raising=False)
+
+    judged_pairs: list[str] = []
+
+    async def _canned(self, *, system, user, max_tokens):
+        if system == _EXTRACTION_SYSTEM:
+            return {"issues": ["daydream finding"]}
+        if system == _DEDUP_SYSTEM:
+            return {"groups": [[0]]}
+        assert system == _JUDGE_SYSTEM, f"unexpected judge-client system prompt: {system}"
+        judged_pairs.append(user)
+        return {"reasoning": "same underlying issue", "match": True, "confidence": 0.95}
+
+    monkeypatch.setattr(OpenAIJsonCompleter, "complete_json", _canned)
+
+    rc = _handle_bench_command(
+        [
+            "--harvest-dir",
+            str(harvest_dir),
+            "--cache-dir",
+            str(cache_dir),
+            "--score",
+            "--judge-route",
+            "openai-compatible",
+            "--model",
+            "judge-x",
+        ]
+    )
+
+    assert rc == 0
+    assert len(calls) == 2  # both PRs were reviewed before scoring
+
+    evals = json.loads((model_results_dir(harvest_dir, "judge-x") / "evaluations.json").read_text(encoding="utf-8"))
+    for pr_number in (1, 2):
+        leaf = evals[_golden_url(pr_number)]["daydream"]
+        assert leaf["judge_route"] == "openai-compatible"
+        assert leaf["judge_model"] == "judge-x"
+        assert leaf["errors_count"] == 0
+        assert leaf["tp"] == 1 and leaf["fp"] == 0 and leaf["fn"] == 0
+        assert leaf["precision"] == 1.0 and leaf["recall"] == 1.0
+
+    # The emitted report carries the aggregate the canned judge produced.
+    report = json.loads((harvest_dir / ".daydream-bench" / "report-daydream.json").read_text(encoding="utf-8"))
+    assert report["schema_version"] == 1 and report["corpus"] == "harvested"
+    assert len(report["prs"]) == 2
+    assert report["judge_route"] == "openai-compatible" and report["judge_model"] == "judge-x"
     assert report["aggregate"] == {
         "scored_pr_count": 2,
         "tp": 2,

--- a/tests/test_benchmark_openai_score.py
+++ b/tests/test_benchmark_openai_score.py
@@ -1,0 +1,109 @@
+import json
+
+import pytest
+
+from daydream.benchmark.openai_score import (
+    OpenAIJsonCompleter,
+    _resolve_openai_base_url,
+    run_openai_scoring,
+)
+from daydream.benchmark.score import BenchmarkStepError, model_results_dir
+from tests.test_benchmark_anthropic_score import URL, seed_benchmark_data
+
+OPENAI_CHAT_COMPLETIONS_URL = "https://api.openai.com/v1/chat/completions"
+OPENROUTER_CHAT_COMPLETIONS_URL = "https://openrouter.ai/api/v1/chat/completions"
+
+
+class FakeResponse:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = str(payload)
+
+    def json(self):
+        return self._payload
+
+
+class FakeOpenAIJson:
+    def __init__(self, responses):
+        self._responses = list(responses)
+
+    async def complete_json(self, *, system, user, max_tokens):
+        return self._responses.pop(0)
+
+
+@pytest.mark.asyncio
+async def test_openai_json_completer_posts_chat_completions_and_parses_json():
+    calls = []
+
+    class FakeClient:
+        async def post(self, url, *, headers, json, timeout):
+            calls.append((url, headers, json, timeout))
+            return FakeResponse(200, {"choices": [{"message": {"content": '{"issues":["x"]}'}}]})
+
+    client = OpenAIJsonCompleter(api_key="sk-openai-x", model="gpt-5.6-luna", http=FakeClient())
+    result = await client.complete_json(system="extract", user="return json", max_tokens=128)
+    assert result == {"issues": ["x"]}
+    url, headers, payload, _ = calls[0]
+    assert url == OPENAI_CHAT_COMPLETIONS_URL
+    assert headers["Authorization"] == "Bearer sk-openai-x"
+    assert payload["model"] == "gpt-5.6-luna"
+    assert payload["temperature"] == 0
+    assert payload["messages"] == [
+        {"role": "system", "content": "extract"},
+        {"role": "user", "content": "return json"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_openai_json_completer_posts_to_custom_base_url():
+    """An explicit base URL (e.g. OpenRouter) wins over the OpenAI default."""
+    urls = []
+
+    class FakeClient:
+        async def post(self, url, *, headers, json, timeout):
+            urls.append(url)
+            return FakeResponse(200, {"choices": [{"message": {"content": "{}"}}]})
+
+    client = OpenAIJsonCompleter(
+        api_key="sk-or-v1-x", model="openai/gpt-5.6-luna", base_url="https://openrouter.ai/api/v1", http=FakeClient()
+    )
+    await client.complete_json(system="s", user="u", max_tokens=1)
+    assert urls == [OPENROUTER_CHAT_COMPLETIONS_URL]
+
+
+def test_openai_base_url_resolution():
+    assert _resolve_openai_base_url("sk-proj-x", None) == "https://api.openai.com/v1"
+    # An sk-or- OpenRouter key with no pin auto-routes to OpenRouter.
+    assert _resolve_openai_base_url("sk-or-v1-x", None) == "https://openrouter.ai/api/v1"
+    # An explicit OPENAI_BASE_URL always wins over the auto-route.
+    assert _resolve_openai_base_url("sk-or-v1-x", "https://gateway.example/v1") == "https://gateway.example/v1"
+
+
+@pytest.mark.asyncio
+async def test_openai_direct_scoring_stamps_route_on_evaluation_leaf(tmp_path):
+    """The shared pipeline, driven by the OpenAI completer, stamps the openai route."""
+    seed_benchmark_data(tmp_path, tool="daydream", body="candidate")
+    client = FakeOpenAIJson(
+        [
+            {"issues": ["candidate"]},
+            {"reasoning": "same bug", "match": True, "confidence": 0.91},
+        ]
+    )
+
+    scores = await run_openai_scoring(tmp_path, "gpt-5.6-luna", golden_urls=[URL], tool="daydream", client=client)
+
+    assert scores.scored_pr_count == 1
+    assert scores.total_tp == 1 and scores.total_fp == 0 and scores.total_fn == 0
+    evals = json.loads((model_results_dir(tmp_path, "gpt-5.6-luna") / "evaluations.json").read_text())
+    leaf = evals[URL]["daydream"]
+    assert leaf["judge_route"] == "openai-compatible"
+    assert leaf["judge_model"] == "gpt-5.6-luna"
+    assert leaf["tp"] == 1 and leaf["precision"] == 1.0 and leaf["recall"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_openai_scoring_requires_api_key_env(tmp_path, monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with pytest.raises(BenchmarkStepError, match="OPENAI_API_KEY"):
+        await run_openai_scoring(tmp_path, "gpt-5.6-luna")

--- a/tests/test_benchmark_score.py
+++ b/tests/test_benchmark_score.py
@@ -88,6 +88,25 @@ def test_run_scoring_dispatches_to_anthropic_direct(tmp_path, monkeypatch):
     assert scores.scored_pr_count == 1
 
 
+def test_run_scoring_dispatches_to_openai_compatible(tmp_path, monkeypatch):
+    called = {}
+
+    async def fake_openai(repo, model, *, golden_urls, tool):
+        called.update(repo=repo, model=model, golden_urls=golden_urls, tool=tool)
+        return DaydreamScores(scored_pr_count=1, total_tp=1, precision=1.0, recall=1.0)
+
+    monkeypatch.setattr("daydream.benchmark.score.run_openai_scoring", fake_openai)
+    scores = run_scoring(
+        tmp_path,
+        "gpt-5.6-luna",
+        golden_urls=[URL],
+        tool="daydream",
+        judge_route="openai-compatible",
+    )
+    assert called == {"repo": tmp_path, "model": "gpt-5.6-luna", "golden_urls": [URL], "tool": "daydream"}
+    assert scores.scored_pr_count == 1
+
+
 def test_run_scoring_passes_custom_tool_and_judge_env_to_each_step(tmp_path, monkeypatch):
     monkeypatch.setenv("MARTIAN_API_KEY", "sk-or-x")
     monkeypatch.delenv(JUDGE_MODEL_ENV, raising=False)
@@ -175,6 +194,37 @@ def test_direct_anthropic_preflight_rejects(monkeypatch, anthropic_key, martian_
         monkeypatch.setenv("MARTIAN_BASE_URL", martian_base_url)
     with pytest.raises(JudgeEnvError, match=match):
         preflight_judge_env(judge_route="anthropic-direct")
+
+
+@pytest.mark.parametrize(
+    ("openai_key", "martian_base_url", "match"),
+    [
+        # Missing OpenAI key.
+        (None, None, "OPENAI_API_KEY"),
+        # A Martian base URL is invalid for OpenAI-compatible scoring.
+        ("sk-openai-direct", "https://api.openai.com/v1", "MARTIAN_BASE_URL is invalid for OpenAI-compatible scoring"),
+    ],
+    ids=["missing-key", "martian-base-url"],
+)
+def test_openai_compatible_preflight_rejects(monkeypatch, openai_key, martian_base_url, match):
+    """OpenAI-compatible preflight rejects a missing key and a Martian base URL."""
+    monkeypatch.setenv("MARTIAN_MODEL", "gpt-5.6-luna")
+    if openai_key is None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    else:
+        monkeypatch.setenv("OPENAI_API_KEY", openai_key)
+    if martian_base_url is not None:
+        monkeypatch.setenv("MARTIAN_BASE_URL", martian_base_url)
+    with pytest.raises(JudgeEnvError, match=match):
+        preflight_judge_env(judge_route="openai-compatible")
+
+
+def test_openai_compatible_preflight_accepts_openrouter_key(monkeypatch):
+    """An sk-or- OpenRouter key is a valid OpenAI-compatible credential; it
+    auto-routes to OpenRouter when OPENAI_BASE_URL is unset."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-or-v1-realkey")
+    monkeypatch.delenv("MARTIAN_BASE_URL", raising=False)
+    preflight_judge_env(judge_route="openai-compatible")
 
 
 _P_MIXED, _R_MIXED = 2 / 5, 2 / 6


### PR DESCRIPTION
## Summary

Adds `--judge-route openai-compatible`: an in-process benchmark judge that runs the
existing extraction → dedup → per-pair evaluation pipeline against any OpenAI
Chat Completions-compatible endpoint (OpenAI direct, OpenRouter, or a compatible
gateway). This unblocks harvested-corpus baseline scoring (#317) without Anthropic
spend — previously the only in-process route to score a harvested corpus was
`anthropic-direct`.

## What changed

- **`daydream/benchmark/openai_score.py` (new)** — `OpenAIJsonCompleter`
  implementing the same `complete_json` seam as `AnthropicJsonClient`, plus
  `run_openai_scoring` driving the shared pipeline with the `openai-compatible`
  leaf stamp. Base-URL resolution: explicit `OPENAI_BASE_URL` wins; an `sk-or-`
  OpenRouter key with no pin auto-routes to OpenRouter (mirroring the martian
  route); otherwise defaults to `https://api.openai.com/v1`.
- **`daydream/benchmark/anthropic_score.py`** — generalized `run_anthropic_scoring`
  into a shared `run_direct_scoring(..., client, judge_route)` (extraction/dedup/
  evaluation were already client-parameterized); back-compat `run_anthropic_scoring`
  wrapper retained. `judge_route` is now stamped from the route on every leaf, not
  hard-coded to `"anthropic-direct"`. Request/response handoff via a
  `content=` accessor hook (`_anthropic_content` / `_openai_content`).
- **`daydream/benchmark/score.py`** — `OPENAI_API_KEY` / `OPENAI_BASE_URL` env
  constants; `preflight_judge_env` branch for the route (key required, `MARTIAN_BASE_URL`
  rejected); `run_scoring` dispatch.
- **`daydream/benchmark/cli.py`** — `--judge-route` choices + validation extended;
  `--harvest-dir` help and the martian+harvest gate updated to "in-process route
  (anthropic-direct or openai-compatible)".
- **`daydream/benchmark/judge.py`** — route-neutral error wording.
- **`docs/benchmark.md`** — documents the route, env contract, OpenRouter
  auto-route, the same-corpus `openai-compatible` example, and reframes
  "harvested corpus requires anthropic-direct" into "requires an in-process route".
- **Tests** — `tests/test_benchmark_openai_score.py` (unit: client URL/auth/payload,
  base-URL resolution, shared-pipeline leaf stamp, key-required), plus a
  **real-path e2e** `test_harvested_corpus_scored_run_openai_compatible_route`
  (enters `_handle_bench_command`, mocks only the client seam, asserts leaf +
  report + per-pair call accounting), and dispatch/preflight coverage in
  `test_benchmark_cli.py` / `test_benchmark_score.py`.

## Verification

Gate run on the branch (all four, verbatim):
- `uv lock --check` — clean
- `uv run ruff check daydream tests bench` — all checks passed
- `uv run mypy daydream tests bench` — success, no issues
- `uv run pytest -n auto` — **2894 passed, 6 skipped, 0 failed**

## Notes / decisions

- Route name `openai-compatible`; env-only endpoint config (matches the `MARTIAN_*`
  convention). Model fallback reuses `MARTIAN_MODEL` (results dirs stay consistent).
- The `martian` subprocess route and withmartian integration are untouched.

Closes #324.
