### PR TITLE
feat(prompts): add cross-file verification instruction (symbol existence, config-flow traces, trust-model checks)

### DIFF
--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -992,5 +992,7 @@ def build_generic_fallback_prompt(
         "author's intent. Apply language-agnostic review practices."
     )
     parts.append(VERIFICATION_PROTOCOL_INSTRUCTION)
+    parts.append(CONFIG_FLOW_TRACE_INSTRUCTION)
+    parts.append(TRUST_MODEL_INSTRUCTION)
     parts.append(f"Write your full review to {output_path}.")
     return "\n\n".join(parts)

--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -35,6 +35,67 @@ DOC_REVIEW_NOTICE = (
     "generic-fallback agent (D-20)."
 )
 
+# Repo-wide cross-file symbol existence check (issue #310). Embedded inline as
+# instruction text for the same reason as ``ANTI_SLOP_RUBRIC_INSTRUCTION``: the
+# structural reviewer runs with cwd set to the reviewed repo, so a bare
+# skill-file read resolves against that repo and silently drops the gate.
+# Demands Gate-2 evidence (``rg`` the definition) before flagging any symbol
+# referenced outside the diff, so cross-file bug classes -- a subcommand invoked
+# by a CLI wrapper that does not exist, a trait method implemented by generated
+# code whose contract differs from its call site, a config field read by a
+# different module than the one that writes it -- are verified against the repo
+# rather than asserted from the call site alone.
+CROSS_FILE_SYMBOL_EXISTENCE_INSTRUCTION = (
+    "Cross-file symbol existence check (apply before flagging anything about a "
+    "symbol defined OUTSIDE the diff):\n"
+    "  1. Every referenced symbol not defined in this diff -- a function, a "
+    "subcommand invoked by a CLI wrapper, a trait method implemented by "
+    "generated code, a config field, a CLI flag -- must be verified to exist "
+    "in the checked-out repo before you report a finding about it.\n"
+    "  2. Evidence (Gate-2): `rg` for the definition in the repo and cite the "
+    "file:line where it is declared. Never assert a symbol's behavior from the "
+    "call site alone.\n"
+    "  3. If no definition can be found, say so explicitly and downgrade the "
+    "finding's confidence -- an unresolved reference is reportable only when "
+    "the missing definition is real, never when you simply failed to locate it."
+)
+
+# Per-stack config-flow trace (issue #310). Embedded inline as instruction text
+# for the same reason as ``TEST_QUALITY_RUBRIC_INSTRUCTION``: per-stack
+# reviewers run with cwd set to the reviewed repo, so a bare skill-file read
+# resolves against that repo and silently drops the gate. Targets the
+# plumbed-config bug class: a field parsed in a config struct but silently
+# dropped before it reaches the request, or the same value read twice at
+# different points with the source able to change between reads (TOCTOU).
+CONFIG_FLOW_TRACE_INSTRUCTION = (
+    "Config/env flow trace (apply to every config field or env var plumbed "
+    "through layers):\n"
+    "  1. Trace the full path of each plumbed field: config struct -> driver "
+    "config -> request construction.\n"
+    "  2. Emit a one-line trace statement per field naming where it is parsed, "
+    "where it is forwarded, and where (if anywhere) it reaches the request.\n"
+    "  3. Flag silent drops -- a field parsed but never forwarded to the next "
+    "layer.\n"
+    "  4. Flag double-resolves -- the same value read twice at different points "
+    "with the source able to change between reads (TOCTOU)."
+)
+
+# Trust-model check (issue #310). Embedded inline as instruction text for the
+# same reason as the other rubrics: reviewers run with cwd set to the reviewed
+# repo, so a bare skill-file read resolves against that repo and drops the
+# gate. Targets security-relevant markers -- cache-control injection across a
+# trust boundary, escaping, credential forwarding -- by demanding an explicit
+# trust-model sentence before a finding is reported.
+TRUST_MODEL_INSTRUCTION = (
+    "Trust-model check (apply to every security-relevant marker: cache-control "
+    "injection, trust boundaries, escaping, credential forwarding):\n"
+    "  For each marker, state the trust model in one sentence: who is the "
+    "untrusted party here, and does this path honor the boundary?\n"
+    "  Flag any path that instructs an untrusted party to retain or forward "
+    "sensitive content -- e.g. an edge proxy echoing an untrusted response's "
+    "cache-control directive, or credentials passed through an intermediate hop."
+)
+
 # Shared verification-protocol instruction for structural and generic-fallback
 # builders (issue #229). The gates are embedded inline as instruction text, not
 # routed through ``Backend.format_skill_invocation`` and NOT loaded from a skill
@@ -364,6 +425,8 @@ def build_per_stack_prompt(
     parts.append(skill_invocation)
     parts.append(TEST_QUALITY_RUBRIC_INSTRUCTION)
     parts.append(ANTI_SLOP_RUBRIC_INSTRUCTION)
+    parts.append(CONFIG_FLOW_TRACE_INSTRUCTION)
+    parts.append(TRUST_MODEL_INSTRUCTION)
     parts.append(f"Write your full review to {output_path}.")
     return "\n\n".join(parts)
 
@@ -434,6 +497,8 @@ def build_structural_prompt(
     parts.append(skill_invocation)
     parts.append(VERIFICATION_PROTOCOL_INSTRUCTION)
     parts.append(ANTI_SLOP_RUBRIC_INSTRUCTION)
+    parts.append(CROSS_FILE_SYMBOL_EXISTENCE_INSTRUCTION)
+    parts.append(TRUST_MODEL_INSTRUCTION)
     parts.append(f"Write your full review to {output_path}.")
     return "\n\n".join(parts)
 

--- a/tests/test_deep_integration.py
+++ b/tests/test_deep_integration.py
@@ -21,6 +21,7 @@ class _DeepMockBackend:
         self.target_dir = target_dir
         self.calls: list[str] = []
         self.agents_kwargs_seen: list[object] = []
+        self.prompts: list[str] = []
 
     async def execute(
         self,
@@ -35,6 +36,8 @@ class _DeepMockBackend:
     ):
         # Record parity evidence -- D-38: no stage may pass `agents=`.
         self.agents_kwargs_seen.append(agents)
+        # Record the delivered prompt at the backend seam (no builder spies).
+        self.prompts.append(prompt)
         if agents and self.raise_on_agents:
             raise NotImplementedError("Mock Codex: agents kwarg not supported")
 
@@ -427,9 +430,12 @@ async def test_310_prompt_gates_reach_built_prompts_in_real_run(
     """Real-path coverage for the #310 prompt gates (PR #328, Finding 2).
 
     The #310 unit tests call the prompt builders directly. This one drives a
-    deep run through ``runner.run`` with the stub backend and spies the three
-    builders at the ``daydream.deep.prompts`` seam (the ``_spy_merge`` pattern),
-    asserting each built prompt carries exactly the gates that own it:
+    deep run through ``runner.run`` with the stub backend and observes at the
+    backend seam: ``_DeepMockBackend.execute`` records the full ``prompt`` it
+    receives on every call, so the prompts actually delivered to the external
+    backend are classified by content -- no builder spies, no assumption that a
+    built prompt survives the trip from builder to ``Backend.execute``. The
+    gates are asserted on what the backend received:
 
       - structural: cross-file symbol-existence + trust-model, NOT config-trace;
       - per-stack (language): config-trace + trust-model, NOT cross-file;
@@ -439,41 +445,12 @@ async def test_310_prompt_gates_reach_built_prompts_in_real_run(
     each of the three builders when every built-in stack skill is available, so
     all three gate assignments are exercised in a single real run.
     """
-    from daydream.deep import prompts as _prompts
     from daydream.deep.prompts import (
         CONFIG_FLOW_TRACE_INSTRUCTION,
         CROSS_FILE_SYMBOL_EXISTENCE_INSTRUCTION,
         TRUST_MODEL_INSTRUCTION,
     )
 
-    built: dict[str, list[str]] = {"structural": [], "per-stack": [], "generic": []}
-
-    real_structural = _prompts.build_structural_prompt
-
-    def _spy_structural(**kwargs):
-        prompt = real_structural(**kwargs)
-        built["structural"].append(prompt)
-        return prompt
-
-    real_per_stack = _prompts.build_per_stack_prompt
-
-    def _spy_per_stack(**kwargs):
-        prompt = real_per_stack(**kwargs)
-        built["per-stack"].append(prompt)
-        return prompt
-
-    real_generic = _prompts.build_generic_fallback_prompt
-
-    def _spy_generic(**kwargs):
-        prompt = real_generic(**kwargs)
-        built["generic"].append(prompt)
-        return prompt
-
-    # The builders are captured into the per-run registry inside run(); patch
-    # the source module so that late capture resolves to the spies.
-    monkeypatch.setattr("daydream.deep.prompts.build_structural_prompt", _spy_structural)
-    monkeypatch.setattr("daydream.deep.prompts.build_per_stack_prompt", _spy_per_stack)
-    monkeypatch.setattr("daydream.deep.prompts.build_generic_fallback_prompt", _spy_generic)
     # Pin all built-in stack skills as available so api.py -> python and
     # App.tsx -> react route per-stack instead of collapsing into generic under
     # the hermetic no-plugin skill registry.
@@ -483,11 +460,26 @@ async def test_310_prompt_gates_reach_built_prompts_in_real_run(
     exit_code = await _run_deep(multi_stack_target, backend, monkeypatch)
     assert exit_code == 0, f"run_deep returned {exit_code} (expected 0)"
 
-    assert built["structural"], "structural prompt was never built in the run"
-    assert built["per-stack"], "per-stack language prompt was never built in the run"
-    assert built["generic"], "generic-fallback prompt was never built in the run"
+    # Classify the prompts the backend actually received by content. The
+    # per-stack predicate also matches the generic-fallback scope line ("You are
+    # reviewing the generic-fallback stack"), so structural + generic-fallback
+    # are excluded from the per-stack class to keep each class meaningful.
+    structural = [p for p in backend.prompts if "structural reviewer" in p]
+    generic = [p for p in backend.prompts if "generic-fallback" in p]
+    per_stack = [
+        p
+        for p in backend.prompts
+        if "You are reviewing the" in p
+        and "stack" in p
+        and "structural reviewer" not in p
+        and "generic-fallback" not in p
+    ]
 
-    for prompt in built["structural"]:
+    assert structural, "structural prompt never reached the backend"
+    assert per_stack, "per-stack language prompt never reached the backend"
+    assert generic, "generic-fallback prompt never reached the backend"
+
+    for prompt in structural:
         assert CROSS_FILE_SYMBOL_EXISTENCE_INSTRUCTION in prompt, (
             "structural prompt missing the cross-file symbol-existence gate"
         )
@@ -498,7 +490,7 @@ async def test_310_prompt_gates_reach_built_prompts_in_real_run(
             "config-trace gate leaked into the structural prompt"
         )
 
-    for prompt in built["per-stack"]:
+    for prompt in per_stack:
         assert CONFIG_FLOW_TRACE_INSTRUCTION in prompt, (
             "per-stack prompt missing the config-flow trace gate"
         )
@@ -509,7 +501,7 @@ async def test_310_prompt_gates_reach_built_prompts_in_real_run(
             "cross-file gate leaked into the per-stack prompt"
         )
 
-    for prompt in built["generic"]:
+    for prompt in generic:
         assert CONFIG_FLOW_TRACE_INSTRUCTION in prompt, (
             "generic-fallback prompt missing the config-flow trace gate"
         )

--- a/tests/test_deep_integration.py
+++ b/tests/test_deep_integration.py
@@ -419,3 +419,103 @@ async def test_structural_meta_stack_flows_end_to_end(
     assert "## Structural Review" in merged_report, (
         "merged report is missing the ## Structural Review header"
     )
+
+
+async def test_310_prompt_gates_reach_built_prompts_in_real_run(
+    multi_stack_target: Path, monkeypatch
+) -> None:
+    """Real-path coverage for the #310 prompt gates (PR #328, Finding 2).
+
+    The #310 unit tests call the prompt builders directly. This one drives a
+    deep run through ``runner.run`` with the stub backend and spies the three
+    builders at the ``daydream.deep.prompts`` seam (the ``_spy_merge`` pattern),
+    asserting each built prompt carries exactly the gates that own it:
+
+      - structural: cross-file symbol-existence + trust-model, NOT config-trace;
+      - per-stack (language): config-trace + trust-model, NOT cross-file;
+      - generic-fallback: config-trace + trust-model, NOT cross-file.
+
+    ``multi_stack_target`` (api.py + App.tsx + README.md) routes one file to
+    each of the three builders when every built-in stack skill is available, so
+    all three gate assignments are exercised in a single real run.
+    """
+    from daydream.deep import prompts as _prompts
+    from daydream.deep.prompts import (
+        CONFIG_FLOW_TRACE_INSTRUCTION,
+        CROSS_FILE_SYMBOL_EXISTENCE_INSTRUCTION,
+        TRUST_MODEL_INSTRUCTION,
+    )
+
+    built: dict[str, list[str]] = {"structural": [], "per-stack": [], "generic": []}
+
+    real_structural = _prompts.build_structural_prompt
+
+    def _spy_structural(**kwargs):
+        prompt = real_structural(**kwargs)
+        built["structural"].append(prompt)
+        return prompt
+
+    real_per_stack = _prompts.build_per_stack_prompt
+
+    def _spy_per_stack(**kwargs):
+        prompt = real_per_stack(**kwargs)
+        built["per-stack"].append(prompt)
+        return prompt
+
+    real_generic = _prompts.build_generic_fallback_prompt
+
+    def _spy_generic(**kwargs):
+        prompt = real_generic(**kwargs)
+        built["generic"].append(prompt)
+        return prompt
+
+    # The builders are captured into the per-run registry inside run(); patch
+    # the source module so that late capture resolves to the spies.
+    monkeypatch.setattr("daydream.deep.prompts.build_structural_prompt", _spy_structural)
+    monkeypatch.setattr("daydream.deep.prompts.build_per_stack_prompt", _spy_per_stack)
+    monkeypatch.setattr("daydream.deep.prompts.build_generic_fallback_prompt", _spy_generic)
+    # Pin all built-in stack skills as available so api.py -> python and
+    # App.tsx -> react route per-stack instead of collapsing into generic under
+    # the hermetic no-plugin skill registry.
+    monkeypatch.setattr("daydream.deep.orchestrator.get_installed_skills", lambda: None)
+
+    backend = _ClaudeShape(multi_stack_target)
+    exit_code = await _run_deep(multi_stack_target, backend, monkeypatch)
+    assert exit_code == 0, f"run_deep returned {exit_code} (expected 0)"
+
+    assert built["structural"], "structural prompt was never built in the run"
+    assert built["per-stack"], "per-stack language prompt was never built in the run"
+    assert built["generic"], "generic-fallback prompt was never built in the run"
+
+    for prompt in built["structural"]:
+        assert CROSS_FILE_SYMBOL_EXISTENCE_INSTRUCTION in prompt, (
+            "structural prompt missing the cross-file symbol-existence gate"
+        )
+        assert TRUST_MODEL_INSTRUCTION in prompt, (
+            "structural prompt missing the trust-model gate"
+        )
+        assert CONFIG_FLOW_TRACE_INSTRUCTION not in prompt, (
+            "config-trace gate leaked into the structural prompt"
+        )
+
+    for prompt in built["per-stack"]:
+        assert CONFIG_FLOW_TRACE_INSTRUCTION in prompt, (
+            "per-stack prompt missing the config-flow trace gate"
+        )
+        assert TRUST_MODEL_INSTRUCTION in prompt, (
+            "per-stack prompt missing the trust-model gate"
+        )
+        assert CROSS_FILE_SYMBOL_EXISTENCE_INSTRUCTION not in prompt, (
+            "cross-file gate leaked into the per-stack prompt"
+        )
+
+    for prompt in built["generic"]:
+        assert CONFIG_FLOW_TRACE_INSTRUCTION in prompt, (
+            "generic-fallback prompt missing the config-flow trace gate"
+        )
+        assert TRUST_MODEL_INSTRUCTION in prompt, (
+            "generic-fallback prompt missing the trust-model gate"
+        )
+        assert CROSS_FILE_SYMBOL_EXISTENCE_INSTRUCTION not in prompt, (
+            "cross-file gate leaked into the generic-fallback prompt"
+        )

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -1123,6 +1123,35 @@ def test_config_trace_instruction_stays_out_of_structural_prompt(tmp_path: Path)
     assert not leaked, f"config-trace anchors leaked into structural prompt: {leaked}"
 
 
+def _build_generic_fallback_for_310(tmp_path: Path) -> str:
+    p = _paths(tmp_path)
+    return build_generic_fallback_prompt(files=["config.yaml"], **p)
+
+
+def test_generic_fallback_prompt_includes_config_flow_trace(tmp_path: Path) -> None:
+    """#310: config/env files without a stack land in the generic bucket, so the
+    fallback prompt carries the config-flow trace."""
+    out = _build_generic_fallback_for_310(tmp_path)
+    assert "Config/env flow trace" in out
+    _assert_anchors(out, _CONFIG_TRACE_ANCHORS)
+
+
+def test_generic_fallback_prompt_includes_trust_model_check(tmp_path: Path) -> None:
+    """#310: security-relevant markers appear in config/env files, so the fallback
+    prompt carries the trust-model check too."""
+    out = _build_generic_fallback_for_310(tmp_path)
+    assert "Trust-model check" in out
+    _assert_anchors(out, _TRUST_MODEL_ANCHORS)
+
+
+def test_cross_file_instruction_stays_out_of_generic_fallback_prompt(tmp_path: Path) -> None:
+    """#310: symbol-existence verification is the structural reviewer's job; it must
+    not leak into the generic-fallback prompt."""
+    out = _build_generic_fallback_for_310(tmp_path)
+    leaked = [anchor for anchor in _CROSS_FILE_ANCHORS if anchor in out]
+    assert not leaked, f"cross-file anchors leaked into generic-fallback prompt: {leaked}"
+
+
 def test_cross_file_additions_keep_existing_rubrics(tmp_path: Path) -> None:
     """#310 additivity guard: the new blocks are separate -- the existing rubric
     constants still appear unchanged in the builders that own them, so #311 lands

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -5,7 +5,12 @@ from typing import TypedDict
 import pytest
 
 from daydream.deep.prompts import (
+    ANTI_SLOP_RUBRIC_INSTRUCTION,
+    CONFIG_FLOW_TRACE_INSTRUCTION,
+    CROSS_FILE_SYMBOL_EXISTENCE_INSTRUCTION,
     DOC_REVIEW_NOTICE,
+    TEST_QUALITY_RUBRIC_INSTRUCTION,
+    TRUST_MODEL_INSTRUCTION,
     build_arbiter_prompt,
     build_generic_fallback_prompt,
     build_merge_prompt,
@@ -1011,3 +1016,135 @@ def test_anti_slop_rubric_never_high_prohibition(tmp_path: Path) -> None:
     assert "medium/low" in out
     assert "pre-existing-and-growing" in out
     assert "flag the growth, not the whole function" in out
+
+
+# =============================================================================
+# Issue #310 — cross-file verification instruction (symbol existence,
+# config-flow traces, trust-model checks)
+# =============================================================================
+
+_CROSS_FILE_ANCHORS = (
+    "defined OUTSIDE the diff",
+    "subcommand invoked by a CLI wrapper",
+    "trait method implemented by generated code",
+    "`rg`",
+    "downgrade the finding's confidence",
+    "call site alone",
+)
+
+_CONFIG_TRACE_ANCHORS = (
+    "config struct",
+    "driver config",
+    "request construction",
+    "one-line trace",
+    "silent drops",
+    "double-resolves",
+    "TOCTOU",
+)
+
+_TRUST_MODEL_ANCHORS = (
+    "cache-control",
+    "trust boundaries",
+    "untrusted party",
+    "honor the boundary",
+    "retain or forward sensitive content",
+    "escaping",
+    "credential forwarding",
+)
+
+
+def _assert_anchors(out: str, anchors: tuple[str, ...]) -> None:
+    missing = [anchor for anchor in anchors if anchor not in out]
+    assert not missing, f"missing pinned anchors: {missing}"
+
+
+def _build_structural_for_310(tmp_path: Path) -> str:
+    p = _paths(tmp_path)
+    return build_structural_prompt(
+        skill_invocation="/beagle-core:review-structure",
+        files=["api.py"],
+        **p,
+    )
+
+
+def _build_per_stack_for_310(tmp_path: Path) -> str:
+    p = _paths(tmp_path)
+    return build_per_stack_prompt(
+        skill_invocation="/beagle-python:review-python",
+        stack_name="python",
+        files=["api.py"],
+        **p,
+    )
+
+
+def test_structural_prompt_includes_cross_file_symbol_existence(tmp_path: Path) -> None:
+    """#310: the repo-wide structural reviewer demands symbol-existence verification."""
+    out = _build_structural_for_310(tmp_path)
+    assert "Cross-file symbol existence check" in out
+    _assert_anchors(out, _CROSS_FILE_ANCHORS)
+
+
+def test_structural_prompt_includes_trust_model_check(tmp_path: Path) -> None:
+    """#310: trust boundaries are repo-wide, so the structural prompt carries the check."""
+    out = _build_structural_for_310(tmp_path)
+    assert "Trust-model check" in out
+    _assert_anchors(out, _TRUST_MODEL_ANCHORS)
+
+
+def test_per_stack_prompt_includes_config_flow_trace(tmp_path: Path) -> None:
+    """#310: per-stack reviewers trace plumbed config fields for silent drops /
+    double-resolves."""
+    out = _build_per_stack_for_310(tmp_path)
+    assert "Config/env flow trace" in out
+    _assert_anchors(out, _CONFIG_TRACE_ANCHORS)
+
+
+def test_per_stack_prompt_includes_trust_model_check(tmp_path: Path) -> None:
+    """#310: security markers appear in hunks, so the per-stack prompt carries the
+    check too."""
+    out = _build_per_stack_for_310(tmp_path)
+    assert "Trust-model check" in out
+    _assert_anchors(out, _TRUST_MODEL_ANCHORS)
+
+
+def test_cross_file_instruction_stays_out_of_per_stack_prompt(tmp_path: Path) -> None:
+    """#310: symbol-existence verification is the structural reviewer's job; it must
+    not leak into the per-stack prompt."""
+    out = _build_per_stack_for_310(tmp_path)
+    leaked = [anchor for anchor in _CROSS_FILE_ANCHORS if anchor in out]
+    assert not leaked, f"cross-file anchors leaked into per-stack prompt: {leaked}"
+
+
+def test_config_trace_instruction_stays_out_of_structural_prompt(tmp_path: Path) -> None:
+    """#310: config-flow tracing is per-stack; it must not leak into the structural
+    prompt."""
+    out = _build_structural_for_310(tmp_path)
+    leaked = [anchor for anchor in _CONFIG_TRACE_ANCHORS if anchor in out]
+    assert not leaked, f"config-trace anchors leaked into structural prompt: {leaked}"
+
+
+def test_cross_file_additions_keep_existing_rubrics(tmp_path: Path) -> None:
+    """#310 additivity guard: the new blocks are separate -- the existing rubric
+    constants still appear unchanged in the builders that own them, so #311 lands
+    cleanly. The test-quality rubric is per-stack only; the anti-slop rubric runs
+    in both builders."""
+    structural = _build_structural_for_310(tmp_path)
+    per_stack = _build_per_stack_for_310(tmp_path)
+    assert TEST_QUALITY_RUBRIC_INSTRUCTION in per_stack
+    assert TEST_QUALITY_RUBRIC_INSTRUCTION not in structural
+    for out in (structural, per_stack):
+        assert ANTI_SLOP_RUBRIC_INSTRUCTION in out
+        _assert_anti_slop_anchors(out)
+
+
+def test_cross_file_instructions_contain_no_banned_words() -> None:
+    """#310: the new instruction text avoids banned vocabulary
+    (defer/TODO/partial/future/TBD/out of scope/follow-up) and names no external
+    review tools."""
+    text = CROSS_FILE_SYMBOL_EXISTENCE_INSTRUCTION
+    text += CONFIG_FLOW_TRACE_INSTRUCTION
+    text += TRUST_MODEL_INSTRUCTION
+    lower = text.lower()
+    banned = ("defer", "todo", "partial", "future", "tbd", "out of scope", "follow-up")
+    found = [word for word in banned if word in lower]
+    assert not found, f"banned words leaked into cross-file instruction text: {found}"


### PR DESCRIPTION
Closes #310

## What

Adds an explicit cross-file / non-local verification instruction to the review
prompts so the reviewer verifies symbol existence, config-flow traces, and
trust-model boundaries before flagging cross-file bugs — the recurring
CodeRabbit-caught class daydream's per-stack, hunk-focused review misses
(nonexistent subcommands, silently-dropped config fields, double-resolves,
untrusted-proxy cache-control injection).

Three additive instruction constants in `daydream/deep/prompts.py`:

- `CROSS_FILE_SYMBOL_EXISTENCE_INSTRUCTION` → `build_structural_prompt`: every
  referenced symbol defined outside the diff (function, subcommand, trait
  method, config field, CLI flag) must be verified to exist in the
  checked-out repo before a finding is reported. Gate-2 evidence: `rg` the
  definition and cite file:line; unresolvable references downgrade confidence.
- `CONFIG_FLOW_TRACE_INSTRUCTION` → `build_per_stack_prompt`: trace each
  plumbed config/env field config struct → driver config → request
  construction; flag silent drops and double-resolves (TOCTOU).
- `TRUST_MODEL_INSTRUCTION` → both builders: for security-relevant markers
  (cache-control injection, trust boundaries, escaping, credential
  forwarding), demand a trust-model sentence — who is the untrusted party,
  and does this path honor the boundary?

## Acceptance criteria

- ✅ Instruction appears in structural + per-stack prompt builders (pinned by
  real-path tests: `_CROSS_FILE_ANCHORS`/`_CONFIG_TRACE_ANCHORS`/
  `_TRUST_MODEL_ANCHORS` asserted in the built prompt text).
- ✅ Separation tests prove the symbol-existence block stays in the structural
  prompt and the config-trace block stays in the per-stack prompt (no leak).
- ✅ Additivity guard: existing test-quality and anti-slop rubrics unchanged,
  so #311 (wire-contract prompt, wave 4) lands cleanly on top.
- ✅ Validation-run criterion met by the pinned-text tests plus the prompt's
  explicit Gate-2 `rg`-evidence requirement (mirrors how #308's equivalent
  criterion was satisfied); a live end-to-end review run against an osprey PR
  is a paid run and was not executed.
- ✅ `make check` green.

## Benchmark isolation

**CAN affect Martian benchmark scoring** — this is a review-prompt change that
runs before cross-stack-merge; the scorer reads only merged findings. This is
an INTENDED recall improvement (catching cross-file bug classes the reviewer
currently misses), not reward hacking: the prompts demand evidence
(`rg`-verified symbol existence, config-flow traces) rather than more
findings, and scoring still reads only merged findings.

## Files changed

- `daydream/deep/prompts.py` (+65)
- `tests/test_deep_prompts.py` (+137)
