### PR TITLE
feat(fix): add anti-degradation quality gate to the fix phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,18 @@ sources:
 | `uncovered_sweep_max_files` | `10` | Cap on how many uncovered files are swept in one run; files beyond the cap are recorded in `coverage-stats.json` as `sweep_skipped_capacity` (and named in `sweep_skipped_capacity_files`) rather than silently dropped. `0` sweeps nothing. |
 | `uncovered_sweep_min_hunk_lines` | `5` | A file counts as sweepable only when its hunks contain at least this many added/removed lines. `0` removes the floor (every uncovered file is eligible). |
 
+The fix-phase anti-degradation quality gate (issue #315) is configured with
+file-config keys in the same two sources:
+
+| Key | Default | Semantics |
+|-----|---------|-----------|
+| `quality_gate_enabled` | `true` | Toggle the fix-phase anti-degradation quality gate. `false` skips the computation and writes `{"enabled": false}`. |
+| `quality_gate_erosion_delta` | `0.05` | Per-file erosion-delta threshold above which a fixed file is flagged. |
+| `quality_gate_verbosity_delta` | `0.05` | Per-file verbosity-delta threshold above which a fixed file is flagged. |
+
+The gate is fail-open: a flagged file (or an unavailable verdict) surfaces as a
+warning plus a manifest record, never an aborted run.
+
 Resolution precedence is the standard **CLI > config file > default**; a
 negative value (any tier) degrades to the named default, so an invalid floor can
 never make zero-change/trivial blocks eligible.

--- a/README.md
+++ b/README.md
@@ -248,15 +248,17 @@ file-config keys in the same two sources:
 | Key | Default | Semantics |
 |-----|---------|-----------|
 | `quality_gate_enabled` | `true` | Toggle the fix-phase anti-degradation quality gate. `false` skips the computation and writes `{"enabled": false}`. |
-| `quality_gate_erosion_delta` | `0.05` | Per-file erosion-delta threshold above which a fixed file is flagged. |
-| `quality_gate_verbosity_delta` | `0.05` | Per-file verbosity-delta threshold above which a fixed file is flagged. |
+| `quality_gate_erosion_delta` | `0.05` | Per-file erosion-delta threshold above which a fixed file is flagged. Clamped to finite non-negative values; an invalid value (negative, `NaN`, `inf`) falls back to the default. |
+| `quality_gate_verbosity_delta` | `0.05` | Per-file verbosity-delta threshold above which a fixed file is flagged. Clamped to finite non-negative values; an invalid value (negative, `NaN`, `inf`) falls back to the default. |
 
 The gate is fail-open: a flagged file (or an unavailable verdict) surfaces as a
 warning plus a manifest record, never an aborted run.
 
-Resolution precedence is the standard **CLI > config file > default**; a
-negative value (any tier) degrades to the named default, so an invalid floor can
-never make zero-change/trivial blocks eligible.
+Resolution precedence is the standard **CLI > config file > default**. Both
+thresholds are clamped to finite non-negative numbers at parse time and again at
+resolution time: a negative value would flag every unchanged file (a zero delta
+exceeds it) and a `NaN`/`inf` value would silently disable the metric, so any
+invalid value degrades to the named default.
 
 The LLM supervisor uses one batched call. Configure its model under
 `[tool.daydream.phases.supervise]` (or `[phases.supervise]` in `.daydream.toml`).

--- a/daydream/archive/__init__.py
+++ b/daydream/archive/__init__.py
@@ -142,7 +142,7 @@ def _archive_run_inner(
     #     returned, so it is reliably present here), force status to "partial".
     fix_failures = _read_fix_failures(target_dir)
     fix_leftover_untracked = _read_fix_leftover_untracked(target_dir)
-    fix_quality_gate = _read_fix_quality_gate(target_dir)
+    fix_quality_gate = _read_fix_quality_gate(target_dir, recorder.session_id)
     if fix_failures:
         status = "partial"
 
@@ -221,17 +221,28 @@ def _read_fix_leftover_untracked(target_dir: Path) -> list[str] | None:
     return [str(p) for p in data]
 
 
-def _read_fix_quality_gate(target_dir: Path) -> dict[str, Any] | None:
+def _read_fix_quality_gate(target_dir: Path, session_id: str | None) -> dict[str, Any] | None:
     """Read ``deep/fix-quality-gate.json`` from the source tree, if present.
 
     Written by the deep orchestrator's fix-phase anti-degradation gate (#315):
-    ``{"enabled": bool, "rounds": [...]}`` carrying per-file before/after
-    erosion + verbosity deltas over the files the fix phase edited. Returns the
-    parsed dict, or ``None`` when the file is absent, empty, or malformed.
+    ``{"enabled": bool, "session_id": ..., "rounds": [...]}`` carrying per-file
+    before/after erosion + verbosity deltas over the files the fix phase
+    edited. Returns the parsed dict only when its ``session_id`` matches the
+    current run's -- an artifact left behind by a DIFFERENT session (e.g. a
+    prior deep run on the same target repo) must not be attributed to this run
+    (#329). Returns ``None`` when the file is absent, empty, malformed, unbound
+    (no ``session_id`` key), or bound to another session.
     """
     from daydream.deep.artifacts import fix_quality_gate_path
 
-    return _read_json_artifact(fix_quality_gate_path(target_dir / ".daydream" / "deep"), dict)
+    if session_id is None:
+        return None
+    data = _read_json_artifact(fix_quality_gate_path(target_dir / ".daydream" / "deep"), dict)
+    if data is None:
+        return None
+    if data.get("session_id") != session_id:
+        return None
+    return data
 
 
 def _copy_bundle(

--- a/daydream/archive/__init__.py
+++ b/daydream/archive/__init__.py
@@ -142,6 +142,7 @@ def _archive_run_inner(
     #     returned, so it is reliably present here), force status to "partial".
     fix_failures = _read_fix_failures(target_dir)
     fix_leftover_untracked = _read_fix_leftover_untracked(target_dir)
+    fix_quality_gate = _read_fix_quality_gate(target_dir)
     if fix_failures:
         status = "partial"
 
@@ -157,6 +158,7 @@ def _archive_run_inner(
         source_path=source_path,
         fix_failures=fix_failures,
         fix_leftover_untracked=fix_leftover_untracked,
+        fix_quality_gate=fix_quality_gate,
     )
     manifest_path = run_dir / "manifest.json"
     manifest_path.write_text(json.dumps(manifest.to_dict(), indent=2), encoding="utf-8")
@@ -217,6 +219,19 @@ def _read_fix_leftover_untracked(target_dir: Path) -> list[str] | None:
     if data is None:
         return None
     return [str(p) for p in data]
+
+
+def _read_fix_quality_gate(target_dir: Path) -> dict[str, Any] | None:
+    """Read ``deep/fix-quality-gate.json`` from the source tree, if present.
+
+    Written by the deep orchestrator's fix-phase anti-degradation gate (#315):
+    ``{"enabled": bool, "rounds": [...]}`` carrying per-file before/after
+    erosion + verbosity deltas over the files the fix phase edited. Returns the
+    parsed dict, or ``None`` when the file is absent, empty, or malformed.
+    """
+    from daydream.deep.artifacts import fix_quality_gate_path
+
+    return _read_json_artifact(fix_quality_gate_path(target_dir / ".daydream" / "deep"), dict)
 
 
 def _copy_bundle(

--- a/daydream/archive/_schema.py
+++ b/daydream/archive/_schema.py
@@ -63,6 +63,7 @@ CREATE TABLE IF NOT EXISTS runs (
     wall_clock_seconds REAL,
     erosion REAL,
     verbosity REAL,
+    fix_quality_gate TEXT,
     total_prompt_tokens INTEGER,
     total_completion_tokens INTEGER,
     total_cached_tokens INTEGER,
@@ -128,7 +129,7 @@ INSERT OR REPLACE INTO runs (
     review_only, deep, loop, remote_url, repo_slug, source_path, branch, base_branch,
     head_sha, base_sha, changed_files, pr_number, pr_repo, total_cost_usd, total_findings,
     grounding_rate, coverage_ratio, cost_per_finding_usd, wall_clock_seconds,
-    erosion, verbosity,
+    erosion, verbosity, fix_quality_gate,
     total_prompt_tokens, total_completion_tokens, total_cached_tokens,
     outcome_labels, labeled_at, composite_reward, archive_path, schema_version
 ) VALUES (
@@ -137,7 +138,7 @@ INSERT OR REPLACE INTO runs (
     :review_only, :deep, :loop, :remote_url, :repo_slug, :source_path, :branch, :base_branch,
     :head_sha, :base_sha, :changed_files, :pr_number, :pr_repo, :total_cost_usd, :total_findings,
     :grounding_rate, :coverage_ratio, :cost_per_finding_usd, :wall_clock_seconds,
-    :erosion, :verbosity,
+    :erosion, :verbosity, :fix_quality_gate,
     :total_prompt_tokens, :total_completion_tokens, :total_cached_tokens,
     :outcome_labels, :labeled_at, :composite_reward, :archive_path, :schema_version
 )
@@ -183,6 +184,7 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
             ("has_posterior", "INTEGER NOT NULL DEFAULT 0"),
             ("erosion", "REAL"),
             ("verbosity", "REAL"),
+            ("fix_quality_gate", "TEXT"),
         ],
     )
 

--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -228,6 +228,9 @@ def upsert_run(archive_dir: Path, manifest: Manifest) -> None:
                 "wall_clock_seconds": manifest.wall_clock_seconds,
                 "erosion": manifest.erosion,
                 "verbosity": manifest.verbosity,
+                "fix_quality_gate": json.dumps(manifest.fix_quality_gate)
+                if manifest.fix_quality_gate is not None
+                else None,
                 "total_prompt_tokens": manifest.total_prompt_tokens,
                 "total_completion_tokens": manifest.total_completion_tokens,
                 "total_cached_tokens": manifest.total_cached_tokens,

--- a/daydream/archive/manifest.py
+++ b/daydream/archive/manifest.py
@@ -86,6 +86,12 @@ class Manifest:
             parallel groups share one working tree these cannot be attributed to
             a specific group, so they are recorded (never deleted) to make the
             partial run fully auditable. ``None`` when none were left behind.
+        fix_quality_gate: The fix-phase anti-degradation quality-gate verdict
+            (issue #315): ``{"enabled": bool, "rounds": [...]}`` written to
+            ``deep/fix-quality-gate.json`` by the orchestrator, covering
+            per-file before/after erosion + verbosity deltas over the files the
+            fix phase edited. ``None`` when the gate artifact is absent or
+            malformed.
         total_findings: Number of findings (from eval, if available).
         grounding_rate: Grounding rate (from eval, if available).
         coverage_ratio: File coverage ratio (from eval, if available).
@@ -126,6 +132,7 @@ class Manifest:
     loop: bool = False
     fix_failures: dict[str, str] | None = None
     fix_leftover_untracked: list[str] | None = None
+    fix_quality_gate: dict[str, Any] | None = None
 
     # Git context
     source_path: str | None = None
@@ -189,6 +196,7 @@ class Manifest:
             },
             "fix_failures": self.fix_failures,
             "fix_leftover_untracked": self.fix_leftover_untracked,
+            "fix_quality_gate": self.fix_quality_gate,
             "git": {
                 "source_path": self.source_path,
                 "remote_url": self.remote_url,
@@ -242,6 +250,7 @@ def build_manifest(
     source_path: str | None = None,
     fix_failures: dict[str, str] | None = None,
     fix_leftover_untracked: list[str] | None = None,
+    fix_quality_gate: dict[str, Any] | None = None,
 ) -> Manifest:
     """Construct a Manifest from run context.
 
@@ -257,6 +266,9 @@ def build_manifest(
             every fix applied. Recorded verbatim on the manifest.
         fix_leftover_untracked: Sorted list of untracked paths left behind by a
             failed fix pass, or ``None``. Recorded verbatim on the manifest.
+        fix_quality_gate: The fix-phase anti-degradation quality-gate verdict
+            (issue #315), or ``None`` when the artifact is absent. Recorded
+            verbatim on the manifest.
 
     Returns:
         A fully populated Manifest.
@@ -287,6 +299,7 @@ def build_manifest(
         loop=config.loop,
         fix_failures=fix_failures or None,
         fix_leftover_untracked=fix_leftover_untracked or None,
+        fix_quality_gate=fix_quality_gate or None,
         source_path=source_path,
         remote_url=git_ctx.remote_url,
         repo_slug=git_ctx.repo_slug,

--- a/daydream/config.py
+++ b/daydream/config.py
@@ -77,6 +77,17 @@ TEST_WALL_BUDGET_S = 3600.0
 DEFAULT_GROUP_MAX_WALL_S = 600.0  # 10 min of wall-clock across one file group
 DEFAULT_GROUP_MAX_SERIAL_ITEMS = 6  # max per-finding fix calls in one group
 
+# Issue #315: anti-degradation quality gate. Fail-open: flags and surfaces
+# erosion/verbosity growth on files the fix phase edited; never aborts the run
+# (the test gate stays the hard gate). Deltas are per-file before/after ratios
+# from ``analyze_quality``; a file whose delta exceeds a threshold is flagged in
+# ``deep/fix-quality-gate.json`` and the run manifest. Overridable via
+# ``[tool.daydream]`` (``quality_gate_enabled`` / ``quality_gate_erosion_delta`` /
+# ``quality_gate_verbosity_delta``); resolved in ``_step_fix``.
+DEFAULT_QUALITY_GATE_ENABLED = True
+DEFAULT_QUALITY_GATE_EROSION_DELTA = 0.05
+DEFAULT_QUALITY_GATE_VERBOSITY_DELTA = 0.05
+
 # Plan writers are long, expensive turns and hit Pi's provider rate limit when
 # they inherit the standard/deep audit fanout of ten. Keep plan generation at
 # the prior stable Pi fanout while audit retains its independent tier ceiling.

--- a/daydream/config_file.py
+++ b/daydream/config_file.py
@@ -69,6 +69,16 @@ class DaydreamFileConfig:
             ``0`` removes the floor; a negative value degrades to ``None`` (the
             named default applies). ``None`` falls through to the RunConfig field /
             ``config.DEFAULT_UNCOVERED_SWEEP_MIN_HUNK_LINES`` (5).
+        quality_gate_enabled: Issue #315. Toggle the fix-phase anti-degradation
+            quality gate. ``None`` falls through to the orchestrator default
+            (``config.DEFAULT_QUALITY_GATE_ENABLED``, ``True``); ``False`` skips
+            the whole computation and writes ``{"enabled": false}``.
+        quality_gate_erosion_delta: Issue #315. Per-file erosion-delta threshold
+            above which a fixed file is flagged. ``None`` falls through to
+            ``config.DEFAULT_QUALITY_GATE_EROSION_DELTA`` (0.05).
+        quality_gate_verbosity_delta: Issue #315. Per-file verbosity-delta
+            threshold above which a fixed file is flagged. ``None`` falls through
+            to ``config.DEFAULT_QUALITY_GATE_VERBOSITY_DELTA`` (0.05).
         supervisor: Findings supervisor mode (``"off"``, ``"rules"``, or
             ``"llm"``), or None when unset/invalid.
         supervisor_deny_globs: Repository-relative deny globs shared by findings
@@ -93,6 +103,9 @@ class DaydreamFileConfig:
     uncovered_sweep: bool | None = None
     uncovered_sweep_max_files: int | None = None
     uncovered_sweep_min_hunk_lines: int | None = None
+    quality_gate_enabled: bool | None = None
+    quality_gate_erosion_delta: float | None = None
+    quality_gate_verbosity_delta: float | None = None
     supervisor: str | None = None
     supervisor_deny_globs: list[str] = field(default_factory=list)
     tool_supervisor: str | None = None
@@ -306,6 +319,12 @@ def load_file_config(root: Path) -> DaydreamFileConfig:
     uncovered_sweep: bool | None = (
         raw_uncovered_sweep if isinstance(raw_uncovered_sweep, bool) else None
     )
+    # quality_gate_enabled: bool only, same degrade-to-None rule. The delta
+    # thresholds are floats (reject bool, coerce ints) via _coerce_float.
+    raw_quality_gate_enabled = merged.get("quality_gate_enabled")
+    quality_gate_enabled: bool | None = (
+        raw_quality_gate_enabled if isinstance(raw_quality_gate_enabled, bool) else None
+    )
     improve = merged.get("improve")
     improve = improve if isinstance(improve, dict) else {}
     service_groups = improve.get("service_groups")
@@ -326,6 +345,9 @@ def load_file_config(root: Path) -> DaydreamFileConfig:
         uncovered_sweep=uncovered_sweep,
         uncovered_sweep_max_files=_coerce_non_negative_int(merged.get("uncovered_sweep_max_files")),
         uncovered_sweep_min_hunk_lines=_coerce_non_negative_int(merged.get("uncovered_sweep_min_hunk_lines")),
+        quality_gate_enabled=quality_gate_enabled,
+        quality_gate_erosion_delta=_coerce_float(merged.get("quality_gate_erosion_delta")),
+        quality_gate_verbosity_delta=_coerce_float(merged.get("quality_gate_verbosity_delta")),
         supervisor=_coerce_choice(merged.get("supervisor"), {"off", "rules", "llm"}),
         supervisor_deny_globs=_coerce_string_list(merged.get("supervisor_deny_globs")),
         tool_supervisor=_coerce_choice(merged.get("tool_supervisor"), {"off", "rules"}),

--- a/daydream/config_file.py
+++ b/daydream/config_file.py
@@ -17,6 +17,7 @@ Exports:
 from __future__ import annotations
 
 import logging
+import math
 import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -74,11 +75,18 @@ class DaydreamFileConfig:
             (``config.DEFAULT_QUALITY_GATE_ENABLED``, ``True``); ``False`` skips
             the whole computation and writes ``{"enabled": false}``.
         quality_gate_erosion_delta: Issue #315. Per-file erosion-delta threshold
-            above which a fixed file is flagged. ``None`` falls through to
+            above which a fixed file is flagged. Finite non-negative only: a
+            negative, NaN, or infinite value degrades to ``None`` (the named
+            default applies) so a bad threshold can neither flag every unchanged
+            file (a negative floor is exceeded by any delta) nor silently
+            disable the metric (every comparison against NaN is False).
+            ``None`` falls through to
             ``config.DEFAULT_QUALITY_GATE_EROSION_DELTA`` (0.05).
         quality_gate_verbosity_delta: Issue #315. Per-file verbosity-delta
-            threshold above which a fixed file is flagged. ``None`` falls through
-            to ``config.DEFAULT_QUALITY_GATE_VERBOSITY_DELTA`` (0.05).
+            threshold above which a fixed file is flagged. Finite non-negative
+            only, same degrade-to-``None`` rule as ``quality_gate_erosion_delta``.
+            ``None`` falls through to
+            ``config.DEFAULT_QUALITY_GATE_VERBOSITY_DELTA`` (0.05).
         supervisor: Findings supervisor mode (``"off"``, ``"rules"``, or
             ``"llm"``), or None when unset/invalid.
         supervisor_deny_globs: Repository-relative deny globs shared by findings
@@ -271,6 +279,23 @@ def _coerce_float(raw: Any) -> float | None:
     return None
 
 
+def _coerce_quality_threshold(raw: Any) -> float | None:
+    """Return ``raw`` as a finite non-negative float, else None (degrade to default).
+
+    The quality-gate delta thresholds must be finite and non-negative
+    (#329 / Finding 7): a NaN or infinite threshold makes every ``>``
+    comparison False, silently disabling the metric (and non-standard ``NaN``
+    reaches JSON); a negative threshold makes a zero delta (an unchanged file)
+    exceed it, flagging files that did not regress. Anything invalid --
+    negative, NaN, inf, bool, or non-number -- degrades to ``None`` so the
+    ``config.py`` default applies.
+    """
+    value = _coerce_float(raw)
+    if value is None or not math.isfinite(value) or value < 0:
+        return None
+    return value
+
+
 def _coerce_string_list(raw: Any) -> list[str]:
     """Return a list of strings, or an empty list for malformed values."""
     if not isinstance(raw, list) or not all(isinstance(value, str) for value in raw):
@@ -320,7 +345,8 @@ def load_file_config(root: Path) -> DaydreamFileConfig:
         raw_uncovered_sweep if isinstance(raw_uncovered_sweep, bool) else None
     )
     # quality_gate_enabled: bool only, same degrade-to-None rule. The delta
-    # thresholds are floats (reject bool, coerce ints) via _coerce_float.
+    # thresholds are finite non-negative floats (reject bool, coerce ints,
+    # reject negative / NaN / inf) via _coerce_quality_threshold.
     raw_quality_gate_enabled = merged.get("quality_gate_enabled")
     quality_gate_enabled: bool | None = (
         raw_quality_gate_enabled if isinstance(raw_quality_gate_enabled, bool) else None
@@ -346,8 +372,8 @@ def load_file_config(root: Path) -> DaydreamFileConfig:
         uncovered_sweep_max_files=_coerce_non_negative_int(merged.get("uncovered_sweep_max_files")),
         uncovered_sweep_min_hunk_lines=_coerce_non_negative_int(merged.get("uncovered_sweep_min_hunk_lines")),
         quality_gate_enabled=quality_gate_enabled,
-        quality_gate_erosion_delta=_coerce_float(merged.get("quality_gate_erosion_delta")),
-        quality_gate_verbosity_delta=_coerce_float(merged.get("quality_gate_verbosity_delta")),
+        quality_gate_erosion_delta=_coerce_quality_threshold(merged.get("quality_gate_erosion_delta")),
+        quality_gate_verbosity_delta=_coerce_quality_threshold(merged.get("quality_gate_verbosity_delta")),
         supervisor=_coerce_choice(merged.get("supervisor"), {"off", "rules", "llm"}),
         supervisor_deny_globs=_coerce_string_list(merged.get("supervisor_deny_globs")),
         tool_supervisor=_coerce_choice(merged.get("tool_supervisor"), {"off", "rules"}),

--- a/daydream/deep/artifacts.py
+++ b/daydream/deep/artifacts.py
@@ -149,6 +149,18 @@ def fix_failures_path(deep_dir_path: Path) -> Path:
     return deep_dir_path / "fix-failures.json"
 
 
+def fix_quality_gate_path(deep_dir_path: Path) -> Path:
+    """Fix-phase anti-degradation quality gate verdict (issue #315).
+
+    Per-round before/after erosion + verbosity deltas over the files the fix
+    phase edited, computed from :func:`daydream.eval.analyzer.analyze_quality`.
+    Fail-open: written whenever the gate runs (``{"enabled": false}`` when
+    disabled, a per-round ``per_file`` map when enabled), never aborting the
+    run. The archive manifest reads this file to surface flagged files.
+    """
+    return deep_dir_path / "fix-quality-gate.json"
+
+
 def generated_file_violations_path(deep_dir_path: Path) -> Path:
     """Generated-file edits rejected by the fix-phase runtime guard."""
     return deep_dir_path / "generated-file-violations.json"

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -30,6 +30,9 @@ from daydream.backends import effective_fanout_concurrency
 from daydream.config import (
     DEFAULT_GROUP_MAX_SERIAL_ITEMS,
     DEFAULT_GROUP_MAX_WALL_S,
+    DEFAULT_QUALITY_GATE_ENABLED,
+    DEFAULT_QUALITY_GATE_EROSION_DELTA,
+    DEFAULT_QUALITY_GATE_VERBOSITY_DELTA,
     DEFAULT_TOOL_CALL_BUDGET,
     DEFAULT_UNCOVERED_SWEEP_ENABLED,
     DEFAULT_UNCOVERED_SWEEP_MAX_FILES,
@@ -49,6 +52,7 @@ from daydream.deep.artifacts import (
     diff_key_path,
     fix_failures_path,
     fix_leftover_untracked_path,
+    fix_quality_gate_path,
     generated_file_violations_path,
     merged_items_path,
     merged_report_path,
@@ -1981,6 +1985,157 @@ async def _step_verify(ctx: FlowContext) -> None:
     )
 
 
+def _capture_quality_before(daydream_dir: Path) -> dict[str, Any] | None:
+    """Best-effort pre-fix quality snapshot; ``None`` means the gate is unavailable.
+
+    ``analyze_quality`` is pure and deterministic (no backend, no network), but
+    any failure here degrades to "gate unavailable" rather than failing the run
+    -- the anti-degradation gate is fail-open by design (#315).
+    """
+    try:
+        from daydream.eval.analyzer import analyze_quality
+
+        return analyze_quality(daydream_dir)
+    except Exception:
+        return None
+
+
+def _quality_delta(before: float | None, after: float | None) -> float | None:
+    """Rounded per-file metric delta; ``None`` when either side is undefined."""
+    if before is None or after is None:
+        return None
+    return round(after - before, 4)
+
+
+def _quality_flagged(
+    *,
+    erosion_delta: float | None,
+    verbosity_delta: float | None,
+    erosion_after: float | None,
+    verbosity_after: float | None,
+    is_new: bool,
+    erosion_threshold: float,
+    verbosity_threshold: float,
+) -> bool:
+    """Whether a fixed file regressed past a threshold (#315).
+
+    An existing file is flagged when its delta exceeds the threshold. A NEW
+    file (no pre-fix baseline) is flagged on its absolute values vs the same
+    thresholds. ``None`` deltas never flag (the metric has no defined baseline).
+    """
+    if erosion_delta is not None and erosion_delta > erosion_threshold:
+        return True
+    if verbosity_delta is not None and verbosity_delta > verbosity_threshold:
+        return True
+    if is_new:
+        if erosion_after is not None and erosion_after > erosion_threshold:
+            return True
+        if verbosity_after is not None and verbosity_after > verbosity_threshold:
+            return True
+    return False
+
+
+def _evaluate_quality_gate(
+    *,
+    enabled: bool,
+    erosion_delta_threshold: float,
+    verbosity_delta_threshold: float,
+    daydream_dir: Path,
+    dd: Path,
+    candidates: set[str],
+    before: dict[str, Any] | None,
+    iteration: int | None,
+) -> None:
+    """Compute and persist the fix-phase quality-gate verdict (issue #315).
+
+    Fail-open by design: never raises, never stops the run. When disabled,
+    writes ``{"enabled": false}``. When enabled but the quality snapshot is
+    unavailable (``before`` is ``None`` or the post-fix capture raises), writes
+    nothing so an analyzer failure cannot masquerade as a clean gate. Each
+    ``_step_fix`` invocation appends one ``rounds`` entry (keyed by the flow's
+    loop iteration when present, else the next sequence number), so a resume or
+    loop preserves the per-round trend. Flagged files are surfaced as warnings
+    with their before/after numbers.
+    """
+    try:
+        gate_p = fix_quality_gate_path(dd)
+        if not enabled:
+            gate_p.write_text(json.dumps({"enabled": False}, indent=2))
+            return
+        if before is None:
+            return
+        from daydream.eval.analyzer import analyze_quality
+
+        after = analyze_quality(daydream_dir)
+        before_per_file: dict[str, Any] = before.get("per_file") or {}
+        after_per_file: dict[str, Any] = after.get("per_file") or {}
+
+        # Load prior rounds so a ``--start-at fix`` resume appends rather than
+        # clobbering the prior invocation's verdict.
+        rounds: list[dict[str, Any]] = []
+        try:
+            existing = json.loads(gate_p.read_text(encoding="utf-8"))
+            existing_rounds = existing.get("rounds")
+            if isinstance(existing_rounds, list):
+                rounds = existing_rounds
+        except (json.JSONDecodeError, OSError):
+            rounds = []
+
+        round_no = iteration if iteration is not None else len(rounds) + 1
+        per_file: dict[str, dict[str, Any]] = {}
+        for rel in sorted(candidates):
+            before_entry = before_per_file.get(rel)
+            after_entry = after_per_file.get(rel)
+            if before_entry is None and after_entry is None:
+                continue
+            erosion_before = before_entry.get("erosion") if before_entry is not None else None
+            erosion_after = after_entry.get("erosion") if after_entry is not None else None
+            verbosity_before = before_entry.get("verbosity") if before_entry is not None else None
+            verbosity_after = after_entry.get("verbosity") if after_entry is not None else None
+            erosion_delta = _quality_delta(erosion_before, erosion_after)
+            verbosity_delta = _quality_delta(verbosity_before, verbosity_after)
+            is_new = before_entry is None
+            per_file[rel] = {
+                "erosion_before": erosion_before,
+                "erosion_after": erosion_after,
+                "erosion_delta": erosion_delta,
+                "verbosity_before": verbosity_before,
+                "verbosity_after": verbosity_after,
+                "verbosity_delta": verbosity_delta,
+                "flagged": _quality_flagged(
+                    erosion_delta=erosion_delta,
+                    verbosity_delta=verbosity_delta,
+                    erosion_after=erosion_after,
+                    verbosity_after=verbosity_after,
+                    is_new=is_new,
+                    erosion_threshold=erosion_delta_threshold,
+                    verbosity_threshold=verbosity_delta_threshold,
+                ),
+            }
+        rounds.append({"round": round_no, "per_file": per_file})
+        payload = {
+            "enabled": True,
+            "erosion_delta_threshold": erosion_delta_threshold,
+            "verbosity_delta_threshold": verbosity_delta_threshold,
+            "rounds": rounds,
+        }
+        gate_p.write_text(json.dumps(payload, indent=2))
+        flagged = [rel for rel, entry in per_file.items() if entry["flagged"]]
+        if flagged:
+            detail = "\n".join(
+                f"  - {rel}: erosion {per_file[rel]['erosion_before']} -> "
+                f"{per_file[rel]['erosion_after']}, verbosity "
+                f"{per_file[rel]['verbosity_before']} -> {per_file[rel]['verbosity_after']}"
+                for rel in flagged
+            )
+            print_warning(
+                console,
+                f"Quality gate flagged {len(flagged)} file(s) after fixes:\n{detail}",
+            )
+    except Exception:  # noqa: BLE001 - fail-open: the gate must never fail the run
+        return
+
+
 async def _step_fix(ctx: FlowContext) -> Stop | None:
     """Parallel fix pass: pre-fix snapshot capture, phase_fix_parallel, failure protection."""
     from daydream import git_ops
@@ -2029,6 +2184,18 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
     # the config.py default. A runaway file group cannot silently dominate a run.
     group_wall_s = _resolve_config_value(config, "group_max_wall_s", DEFAULT_GROUP_MAX_WALL_S)
     group_serial = _resolve_config_value(config, "group_max_serial_items", DEFAULT_GROUP_MAX_SERIAL_ITEMS)
+    # Issue #315: anti-degradation quality gate. Capture the pre-fix quality
+    # snapshot before any fix runs; the post-fix capture + verdict happen after
+    # failure protection below. Fail-open: a snapshot failure means the gate is
+    # unavailable for this run, never a run failure.
+    quality_gate_enabled = _resolve_config_value(config, "quality_gate_enabled", DEFAULT_QUALITY_GATE_ENABLED)
+    quality_gate_erosion_delta = _resolve_config_value(
+        config, "quality_gate_erosion_delta", DEFAULT_QUALITY_GATE_EROSION_DELTA
+    )
+    quality_gate_verbosity_delta = _resolve_config_value(
+        config, "quality_gate_verbosity_delta", DEFAULT_QUALITY_GATE_VERBOSITY_DELTA
+    )
+    quality_before = _capture_quality_before(daydream_dir) if quality_gate_enabled else None
     async with phase_scope(DaydreamPhase.FIX):
         fix_failures = await phase_fix_parallel(
             ctx.backend_for("fix"),
@@ -2116,6 +2283,19 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
     )
     if generated_guard_result is None:
         return Stop(1)
+    # Issue #315: post-fix anti-degradation gate over the files the fix phase
+    # edited. Tree is post-fix here (every applied or budget-preserved fix is
+    # intact); a regression is flagged and surfaced, never fatal.
+    _evaluate_quality_gate(
+        enabled=quality_gate_enabled,
+        erosion_delta_threshold=quality_gate_erosion_delta,
+        verbosity_delta_threshold=quality_gate_verbosity_delta,
+        daydream_dir=daydream_dir,
+        dd=dd,
+        candidates={item["file"] for item in ctx.data["items"] if item.get("file")},
+        before=quality_before,
+        iteration=ctx.data.get("iteration"),
+    )
     return None
 
 

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -41,7 +41,7 @@ from daydream.config import (
     REVIEW_OUTPUT_FILE,
     STRUCTURE_STACK_NAME,
 )
-from daydream.config_file import _coerce_non_negative_int
+from daydream.config_file import _coerce_non_negative_int, _coerce_quality_threshold
 from daydream.deep.arbiter import select_arbiter_targets, select_suppression_targets
 from daydream.deep.artifacts import (
     adjudication_complete_path,
@@ -2041,14 +2041,39 @@ def _quality_flagged(
     return False
 
 
+def _quality_gate_threshold(config: RunConfig, attr: str, default: float) -> float:
+    """Resolve a quality-gate delta threshold, degrading invalid values to *default*.
+
+    Mirrors ``_uncovered_sweep_max_files``: ``RunConfig`` field > file-config
+    scalar > default, then the same finite non-negative guard the file-config
+    parser applies (#329 / Finding 7). A negative threshold flags every
+    unchanged file (a zero delta exceeds it); a NaN/infinite one disables the
+    metric (every comparison against it is False) and writes a non-standard
+    ``NaN`` to JSON. Both degrade to the named default so a directly-constructed
+    ``RunConfig`` / ``DaydreamFileConfig`` cannot smuggle an invalid floor past
+    the parser.
+    """
+    value = _resolve_config_value(config, attr, default)
+    coerced = _coerce_quality_threshold(value)
+    return coerced if coerced is not None else default
+
+
 def _current_session_id() -> str | None:
     """Session id binding the quality-gate artifact to the current run."""
     recorder = get_current_recorder()
     return recorder.session_id if recorder is not None else None
 
 
-def _load_quality_gate_rounds(gate_p: Path) -> list[dict[str, Any]]:
-    """Load prior rounds so a ``--start-at fix`` resume appends rather than clobbers.
+def _load_quality_gate_rounds(gate_p: Path, session_id: str | None) -> list[dict[str, Any]]:
+    """Load prior rounds for the CURRENT session, or start fresh when rebound.
+
+    Rounds are carried forward only when the artifact's stored ``session_id``
+    matches the current run's session (issue #329 / Finding 5): a ``--start-at
+    fix`` resume of the SAME session appends rather than clobbers, while an
+    artifact left by a DIFFERENT run is discarded with a warning so the first
+    run's verdicts can never be archived as the new run's (corrupting the
+    manifest / SQLite audit history). An artifact with no stored session is
+    treated as belonging to another session.
 
     Never raises, and a malformed artifact is never treated as authoritative
     prior rounds (issue #329 / Finding 6): invalid JSON, a non-object payload
@@ -2066,6 +2091,13 @@ def _load_quality_gate_rounds(gate_p: Path) -> list[dict[str, Any]]:
         existing = None
     if not isinstance(existing, dict):
         print_warning(console, f"Quality gate artifact {gate_p} is malformed; starting rounds fresh")
+        return []
+    if existing.get("session_id") != session_id:
+        print_warning(
+            console,
+            f"Quality gate artifact {gate_p} belongs to another run's session; "
+            "its rounds were not carried forward",
+        )
         return []
     existing_rounds = existing.get("rounds")
     if not isinstance(existing_rounds, list):
@@ -2121,7 +2153,7 @@ def _evaluate_quality_gate(
     verbosity_delta_threshold: float,
     daydream_dir: Path,
     dd: Path,
-    candidates: set[str],
+    candidates: set[str] | None,
     before: dict[str, Any] | None,
     before_unavailable_reason: str | None,
     iteration: int | None,
@@ -2132,14 +2164,15 @@ def _evaluate_quality_gate(
     bound to the current run's ``session_id`` so a later archive step cannot
     attribute another run's verdict to this one (#329). When disabled, writes
     ``{"enabled": false}``. When the gate would run but cannot be evaluated --
-    a pre-fix capture failure, a post-fix capture failure, or a persist failure
-    -- an explicit ``unavailable`` round entry is persisted for THIS round with
-    the failed stage and reason, superseding any stale verdict for that round
-    and keeping the failure auditable instead of reading as a clean gate. Each
-    ``_step_fix`` invocation appends one ``rounds`` entry (keyed by the flow's
-    loop iteration when present, else the next sequence number), so a resume or
-    loop preserves the per-round trend. Flagged files are surfaced as warnings
-    with their before/after numbers.
+    a pre-fix capture failure, a post-fix capture failure, a changed-file
+    enumeration failure (``candidates`` is ``None``, #329 / Finding 6), or a
+    persist failure -- an explicit ``unavailable`` round entry is persisted for
+    THIS round with the failed stage and reason, superseding any stale verdict
+    for that round and keeping the failure auditable instead of reading as a
+    clean gate. Each ``_step_fix`` invocation appends one ``rounds`` entry
+    (keyed by the flow's loop iteration when present, else the next sequence
+    number), so a resume or loop preserves the per-round trend. Flagged files
+    are surfaced as warnings with their before/after numbers.
     """
     session_id = _current_session_id()
     try:
@@ -2149,8 +2182,20 @@ def _evaluate_quality_gate(
                 json.dumps({"enabled": False, "session_id": session_id}, indent=2)
             )
             return
-        rounds = _load_quality_gate_rounds(gate_p)
+        rounds = _load_quality_gate_rounds(gate_p, session_id)
         round_no = iteration if iteration is not None else len(rounds) + 1
+        if candidates is None:
+            _persist_quality_gate_unavailable(
+                gate_p=gate_p,
+                rounds=rounds,
+                round_no=round_no,
+                stage="candidates",
+                reason="could not enumerate files changed by the fix pass against the pre-fix snapshot",
+                session_id=session_id,
+                erosion_delta_threshold=erosion_delta_threshold,
+                verbosity_delta_threshold=verbosity_delta_threshold,
+            )
+            return
         if before is None:
             _persist_quality_gate_unavailable(
                 gate_p=gate_p,
@@ -2266,7 +2311,7 @@ def _evaluate_quality_gate(
         # pass, which is the exact hazard #329 describes.
         try:
             gate_p = fix_quality_gate_path(dd)
-            rounds = _load_quality_gate_rounds(gate_p)
+            rounds = _load_quality_gate_rounds(gate_p, session_id)
             round_no = iteration if iteration is not None else len(rounds) + 1
             _persist_quality_gate_unavailable(
                 gate_p=gate_p,
@@ -2340,10 +2385,10 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
     # failure protection below. Fail-open: a snapshot failure means the gate is
     # unavailable for this run, never a run failure.
     quality_gate_enabled = _resolve_config_value(config, "quality_gate_enabled", DEFAULT_QUALITY_GATE_ENABLED)
-    quality_gate_erosion_delta = _resolve_config_value(
+    quality_gate_erosion_delta = _quality_gate_threshold(
         config, "quality_gate_erosion_delta", DEFAULT_QUALITY_GATE_EROSION_DELTA
     )
-    quality_gate_verbosity_delta = _resolve_config_value(
+    quality_gate_verbosity_delta = _quality_gate_threshold(
         config, "quality_gate_verbosity_delta", DEFAULT_QUALITY_GATE_VERBOSITY_DELTA
     )
     if quality_gate_enabled:
@@ -2440,13 +2485,39 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
     # Issue #315: post-fix anti-degradation gate over the files the fix phase
     # edited. Tree is post-fix here (every applied or budget-preserved fix is
     # intact); a regression is flagged and surfaced, never fatal.
+    #
+    # Issue #329 / Finding 6: gate every python file the fix pass changed, not
+    # just the finding-group targets. The fix agent is explicitly allowed to
+    # touch files outside a group's named file, so a regression in such a
+    # secondary file would otherwise bypass the gate, the artifact, the
+    # manifest, and SQLite. The candidate set is derived from the PRE-FIX git
+    # snapshot (clean tree -> HEAD; dirty tree -> the stash snapshot) -- the
+    # same base the generated-file guard and recommended-patch capture use --
+    # scoped to ``*.py``, then unioned with the finding-target files so finding
+    # targets stay covered even when their on-disk content did not change.
+    # Fail-open: if enumeration raises, candidates stay ``None`` and the gate
+    # persists an explicit ``unavailable`` verdict rather than gating on a
+    # partial candidate set.
+    quality_candidates: set[str] | None
+    if quality_gate_enabled:
+        try:
+            pre_fix_ref = pre_fix_snapshot or "HEAD"
+            changed_after_fix = git_ops.changed_files_against(
+                work.repo, pre_fix_ref, preexisting_untracked=pre_fix_untracked
+            )
+            quality_candidates = {path for path in changed_after_fix if path.endswith(".py")}
+            quality_candidates |= {item["file"] for item in ctx.data["items"] if item.get("file")}
+        except git_ops.GitError:
+            quality_candidates = None
+    else:
+        quality_candidates = set()
     _evaluate_quality_gate(
         enabled=quality_gate_enabled,
         erosion_delta_threshold=quality_gate_erosion_delta,
         verbosity_delta_threshold=quality_gate_verbosity_delta,
         daydream_dir=daydream_dir,
         dd=dd,
-        candidates={item["file"] for item in ctx.data["items"] if item.get("file")},
+        candidates=quality_candidates,
         before=quality_before,
         before_unavailable_reason=quality_before_unavailable,
         iteration=ctx.data.get("iteration"),

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -2048,15 +2048,33 @@ def _current_session_id() -> str | None:
 
 
 def _load_quality_gate_rounds(gate_p: Path) -> list[dict[str, Any]]:
-    """Load prior rounds so a ``--start-at fix`` resume appends rather than clobbers."""
+    """Load prior rounds so a ``--start-at fix`` resume appends rather than clobbers.
+
+    Never raises, and a malformed artifact is never treated as authoritative
+    prior rounds (issue #329 / Finding 6): invalid JSON, a non-object payload
+    (``[]``, ``42``, ...), a missing ``rounds`` list, or non-object round
+    entries all degrade to an empty round list WITH a warning, so the current
+    run repairs the artifact instead of silently losing the gate.
+    """
     try:
-        existing = json.loads(gate_p.read_text(encoding="utf-8"))
-        existing_rounds = existing.get("rounds")
-        if isinstance(existing_rounds, list):
-            return existing_rounds
-    except (json.JSONDecodeError, OSError):
+        raw = gate_p.read_text(encoding="utf-8")
+    except OSError:
         return []
-    return []
+    try:
+        existing = json.loads(raw)
+    except (json.JSONDecodeError, AttributeError, TypeError):
+        existing = None
+    if not isinstance(existing, dict):
+        print_warning(console, f"Quality gate artifact {gate_p} is malformed; starting rounds fresh")
+        return []
+    existing_rounds = existing.get("rounds")
+    if not isinstance(existing_rounds, list):
+        print_warning(console, f"Quality gate artifact {gate_p} has no rounds list; starting rounds fresh")
+        return []
+    valid = [r for r in existing_rounds if isinstance(r, dict)]
+    if len(valid) != len(existing_rounds):
+        print_warning(console, f"Quality gate artifact {gate_p} has non-object round entries; dropping them")
+    return valid
 
 
 def _persist_quality_gate_unavailable(
@@ -2170,6 +2188,26 @@ def _evaluate_quality_gate(
             after_entry = after_per_file.get(rel)
             if before_entry is None and after_entry is None:
                 continue
+            # Issue #329 / Finding 5: a candidate that parsed pre-fix but is
+            # MISSING from the post-fix analyzer output is unparseable after the
+            # fix (analyze_quality omits malformed files). Recording null
+            # after-metrics with ``flagged=false`` would read as a clean
+            # verdict, so mark it explicitly unavailable and flagged -- a fix
+            # that breaks a file is a regression, never a pass. Still fail-open:
+            # never raises, never stops the run.
+            if before_entry is not None and after_entry is None:
+                per_file[rel] = {
+                    "erosion_before": before_entry.get("erosion"),
+                    "erosion_after": None,
+                    "erosion_delta": None,
+                    "verbosity_before": before_entry.get("verbosity"),
+                    "verbosity_after": None,
+                    "verbosity_delta": None,
+                    "unparseable": True,
+                    "flagged": True,
+                    "reason": "file missing from post-fix analyzer output (unparseable?)",
+                }
+                continue
             erosion_before = before_entry.get("erosion") if before_entry is not None else None
             erosion_after = after_entry.get("erosion") if after_entry is not None else None
             verbosity_before = before_entry.get("verbosity") if before_entry is not None else None
@@ -2206,19 +2244,26 @@ def _evaluate_quality_gate(
         gate_p.write_text(json.dumps(payload, indent=2))
         flagged = [rel for rel, entry in per_file.items() if entry["flagged"]]
         if flagged:
-            detail = "\n".join(
-                f"  - {rel}: erosion {per_file[rel]['erosion_before']} -> "
-                f"{per_file[rel]['erosion_after']}, verbosity "
-                f"{per_file[rel]['verbosity_before']} -> {per_file[rel]['verbosity_after']}"
-                for rel in flagged
-            )
+            lines = []
+            for rel in flagged:
+                entry = per_file[rel]
+                if entry.get("unparseable"):
+                    lines.append(f"  - {rel}: {entry['reason']}")
+                else:
+                    lines.append(
+                        f"  - {rel}: erosion {entry['erosion_before']} -> "
+                        f"{entry['erosion_after']}, verbosity "
+                        f"{entry['verbosity_before']} -> {entry['verbosity_after']}"
+                    )
             print_warning(
                 console,
-                f"Quality gate flagged {len(flagged)} file(s) after fixes:\n{detail}",
+                f"Quality gate flagged {len(flagged)} file(s) after fixes:\n" + "\n".join(lines),
             )
     except Exception as exc:  # noqa: BLE001 - fail-open: the gate must never fail the run
         # Stage "persist": the payload itself could not be written. Record the
-        # failure as an unavailable round when the write path still works.
+        # failure as an unavailable round when the write path still works, and
+        # ALWAYS warn -- a gate failure that surfaces nothing reads as a clean
+        # pass, which is the exact hazard #329 describes.
         try:
             gate_p = fix_quality_gate_path(dd)
             rounds = _load_quality_gate_rounds(gate_p)
@@ -2233,8 +2278,13 @@ def _evaluate_quality_gate(
                 erosion_delta_threshold=erosion_delta_threshold,
                 verbosity_delta_threshold=verbosity_delta_threshold,
             )
-        except Exception:  # noqa: BLE001 - nothing left to persist; stay fail-open
-            pass
+        except Exception as inner:  # noqa: BLE001 - nothing left to persist; stay fail-open
+            print_warning(
+                console,
+                f"Quality gate unavailable (round {iteration if iteration is not None else '?'}, "
+                f"persist): {type(exc).__name__}: {exc}; could not persist unavailable verdict "
+                f"({type(inner).__name__}: {inner})",
+            )
 
 
 async def _step_fix(ctx: FlowContext) -> Stop | None:

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -1985,19 +1985,21 @@ async def _step_verify(ctx: FlowContext) -> None:
     )
 
 
-def _capture_quality_before(daydream_dir: Path) -> dict[str, Any] | None:
-    """Best-effort pre-fix quality snapshot; ``None`` means the gate is unavailable.
+def _capture_quality_before(daydream_dir: Path) -> tuple[dict[str, Any] | None, str | None]:
+    """Best-effort pre-fix quality snapshot; ``(None, reason)`` when unavailable.
 
     ``analyze_quality`` is pure and deterministic (no backend, no network), but
     any failure here degrades to "gate unavailable" rather than failing the run
-    -- the anti-degradation gate is fail-open by design (#315).
+    -- the anti-degradation gate is fail-open by design (#315). The failure
+    reason is returned so the gate can persist an auditable unavailable entry
+    instead of leaving a silent blank (#329).
     """
     try:
         from daydream.eval.analyzer import analyze_quality
 
-        return analyze_quality(daydream_dir)
-    except Exception:
-        return None
+        return analyze_quality(daydream_dir), None
+    except Exception as exc:  # noqa: BLE001 -- fail-open: never fail the run
+        return None, f"{type(exc).__name__}: {exc}"
 
 
 def _quality_delta(before: float | None, after: float | None) -> float | None:
@@ -2009,30 +2011,89 @@ def _quality_delta(before: float | None, after: float | None) -> float | None:
 
 def _quality_flagged(
     *,
-    erosion_delta: float | None,
-    verbosity_delta: float | None,
+    erosion_before: float | None,
     erosion_after: float | None,
+    erosion_delta: float | None,
+    verbosity_before: float | None,
     verbosity_after: float | None,
-    is_new: bool,
+    verbosity_delta: float | None,
     erosion_threshold: float,
     verbosity_threshold: float,
 ) -> bool:
     """Whether a fixed file regressed past a threshold (#315).
 
-    An existing file is flagged when its delta exceeds the threshold. A NEW
-    file (no pre-fix baseline) is flagged on its absolute values vs the same
-    thresholds. ``None`` deltas never flag (the metric has no defined baseline).
+    A file is flagged when its delta exceeds the threshold (both sides
+    defined), or on its absolute AFTER value vs the same threshold when the
+    BEFORE metric is undefined -- no functions / no non-blank lines pre-fix --
+    but the AFTER metric is numeric. The absolute fallback fires on ANY file
+    with an undefined baseline, not just new ones, so an EXISTING file that
+    gains a CC>10 function (erosion ``None`` pre-fix) is still caught. A
+    metric with both sides undefined never flags.
     """
     if erosion_delta is not None and erosion_delta > erosion_threshold:
         return True
     if verbosity_delta is not None and verbosity_delta > verbosity_threshold:
         return True
-    if is_new:
-        if erosion_after is not None and erosion_after > erosion_threshold:
-            return True
-        if verbosity_after is not None and verbosity_after > verbosity_threshold:
-            return True
+    if erosion_before is None and erosion_after is not None and erosion_after > erosion_threshold:
+        return True
+    if verbosity_before is None and verbosity_after is not None and verbosity_after > verbosity_threshold:
+        return True
     return False
+
+
+def _current_session_id() -> str | None:
+    """Session id binding the quality-gate artifact to the current run."""
+    recorder = get_current_recorder()
+    return recorder.session_id if recorder is not None else None
+
+
+def _load_quality_gate_rounds(gate_p: Path) -> list[dict[str, Any]]:
+    """Load prior rounds so a ``--start-at fix`` resume appends rather than clobbers."""
+    try:
+        existing = json.loads(gate_p.read_text(encoding="utf-8"))
+        existing_rounds = existing.get("rounds")
+        if isinstance(existing_rounds, list):
+            return existing_rounds
+    except (json.JSONDecodeError, OSError):
+        return []
+    return []
+
+
+def _persist_quality_gate_unavailable(
+    *,
+    gate_p: Path,
+    rounds: list[dict[str, Any]],
+    round_no: int,
+    stage: str,
+    reason: str,
+    session_id: str | None,
+    erosion_delta_threshold: float,
+    verbosity_delta_threshold: float,
+) -> None:
+    """Persist an auditable ``unavailable`` round entry for THIS round.
+
+    Any existing entry with the same round number is dropped first, so an
+    unavailable verdict supersedes a stale successful one from the same round
+    (e.g. a ``--start-at fix`` resume). Never raises.
+    """
+    rounds = [r for r in rounds if r.get("round") != round_no]
+    rounds.append({"round": round_no, "unavailable": {"stage": stage, "reason": reason}})
+    gate_p.write_text(
+        json.dumps(
+            {
+                "enabled": True,
+                "erosion_delta_threshold": erosion_delta_threshold,
+                "verbosity_delta_threshold": verbosity_delta_threshold,
+                "session_id": session_id,
+                "rounds": rounds,
+            },
+            indent=2,
+        )
+    )
+    print_warning(
+        console,
+        f"Quality gate unavailable (round {round_no}, {stage}): {reason}",
+    )
 
 
 def _evaluate_quality_gate(
@@ -2044,44 +2105,65 @@ def _evaluate_quality_gate(
     dd: Path,
     candidates: set[str],
     before: dict[str, Any] | None,
+    before_unavailable_reason: str | None,
     iteration: int | None,
 ) -> None:
     """Compute and persist the fix-phase quality-gate verdict (issue #315).
 
-    Fail-open by design: never raises, never stops the run. When disabled,
-    writes ``{"enabled": false}``. When enabled but the quality snapshot is
-    unavailable (``before`` is ``None`` or the post-fix capture raises), writes
-    nothing so an analyzer failure cannot masquerade as a clean gate. Each
+    Fail-open by design: never raises, never stops the run. Every payload is
+    bound to the current run's ``session_id`` so a later archive step cannot
+    attribute another run's verdict to this one (#329). When disabled, writes
+    ``{"enabled": false}``. When the gate would run but cannot be evaluated --
+    a pre-fix capture failure, a post-fix capture failure, or a persist failure
+    -- an explicit ``unavailable`` round entry is persisted for THIS round with
+    the failed stage and reason, superseding any stale verdict for that round
+    and keeping the failure auditable instead of reading as a clean gate. Each
     ``_step_fix`` invocation appends one ``rounds`` entry (keyed by the flow's
     loop iteration when present, else the next sequence number), so a resume or
     loop preserves the per-round trend. Flagged files are surfaced as warnings
     with their before/after numbers.
     """
+    session_id = _current_session_id()
     try:
         gate_p = fix_quality_gate_path(dd)
         if not enabled:
-            gate_p.write_text(json.dumps({"enabled": False}, indent=2))
+            gate_p.write_text(
+                json.dumps({"enabled": False, "session_id": session_id}, indent=2)
+            )
             return
+        rounds = _load_quality_gate_rounds(gate_p)
+        round_no = iteration if iteration is not None else len(rounds) + 1
         if before is None:
+            _persist_quality_gate_unavailable(
+                gate_p=gate_p,
+                rounds=rounds,
+                round_no=round_no,
+                stage="before",
+                reason=before_unavailable_reason or "pre-fix quality snapshot unavailable",
+                session_id=session_id,
+                erosion_delta_threshold=erosion_delta_threshold,
+                verbosity_delta_threshold=verbosity_delta_threshold,
+            )
             return
-        from daydream.eval.analyzer import analyze_quality
+        try:
+            from daydream.eval.analyzer import analyze_quality
 
-        after = analyze_quality(daydream_dir)
+            after = analyze_quality(daydream_dir)
+        except Exception as exc:  # noqa: BLE001 -- fail-open: the gate must never fail the run
+            _persist_quality_gate_unavailable(
+                gate_p=gate_p,
+                rounds=rounds,
+                round_no=round_no,
+                stage="after",
+                reason=f"{type(exc).__name__}: {exc}",
+                session_id=session_id,
+                erosion_delta_threshold=erosion_delta_threshold,
+                verbosity_delta_threshold=verbosity_delta_threshold,
+            )
+            return
         before_per_file: dict[str, Any] = before.get("per_file") or {}
         after_per_file: dict[str, Any] = after.get("per_file") or {}
 
-        # Load prior rounds so a ``--start-at fix`` resume appends rather than
-        # clobbering the prior invocation's verdict.
-        rounds: list[dict[str, Any]] = []
-        try:
-            existing = json.loads(gate_p.read_text(encoding="utf-8"))
-            existing_rounds = existing.get("rounds")
-            if isinstance(existing_rounds, list):
-                rounds = existing_rounds
-        except (json.JSONDecodeError, OSError):
-            rounds = []
-
-        round_no = iteration if iteration is not None else len(rounds) + 1
         per_file: dict[str, dict[str, Any]] = {}
         for rel in sorted(candidates):
             before_entry = before_per_file.get(rel)
@@ -2094,7 +2176,6 @@ def _evaluate_quality_gate(
             verbosity_after = after_entry.get("verbosity") if after_entry is not None else None
             erosion_delta = _quality_delta(erosion_before, erosion_after)
             verbosity_delta = _quality_delta(verbosity_before, verbosity_after)
-            is_new = before_entry is None
             per_file[rel] = {
                 "erosion_before": erosion_before,
                 "erosion_after": erosion_after,
@@ -2103,20 +2184,23 @@ def _evaluate_quality_gate(
                 "verbosity_after": verbosity_after,
                 "verbosity_delta": verbosity_delta,
                 "flagged": _quality_flagged(
-                    erosion_delta=erosion_delta,
-                    verbosity_delta=verbosity_delta,
+                    erosion_before=erosion_before,
                     erosion_after=erosion_after,
+                    erosion_delta=erosion_delta,
+                    verbosity_before=verbosity_before,
                     verbosity_after=verbosity_after,
-                    is_new=is_new,
+                    verbosity_delta=verbosity_delta,
                     erosion_threshold=erosion_delta_threshold,
                     verbosity_threshold=verbosity_delta_threshold,
                 ),
             }
+        rounds = [r for r in rounds if r.get("round") != round_no]
         rounds.append({"round": round_no, "per_file": per_file})
         payload = {
             "enabled": True,
             "erosion_delta_threshold": erosion_delta_threshold,
             "verbosity_delta_threshold": verbosity_delta_threshold,
+            "session_id": session_id,
             "rounds": rounds,
         }
         gate_p.write_text(json.dumps(payload, indent=2))
@@ -2132,8 +2216,25 @@ def _evaluate_quality_gate(
                 console,
                 f"Quality gate flagged {len(flagged)} file(s) after fixes:\n{detail}",
             )
-    except Exception:  # noqa: BLE001 - fail-open: the gate must never fail the run
-        return
+    except Exception as exc:  # noqa: BLE001 - fail-open: the gate must never fail the run
+        # Stage "persist": the payload itself could not be written. Record the
+        # failure as an unavailable round when the write path still works.
+        try:
+            gate_p = fix_quality_gate_path(dd)
+            rounds = _load_quality_gate_rounds(gate_p)
+            round_no = iteration if iteration is not None else len(rounds) + 1
+            _persist_quality_gate_unavailable(
+                gate_p=gate_p,
+                rounds=rounds,
+                round_no=round_no,
+                stage="persist",
+                reason=f"{type(exc).__name__}: {exc}",
+                session_id=session_id,
+                erosion_delta_threshold=erosion_delta_threshold,
+                verbosity_delta_threshold=verbosity_delta_threshold,
+            )
+        except Exception:  # noqa: BLE001 - nothing left to persist; stay fail-open
+            pass
 
 
 async def _step_fix(ctx: FlowContext) -> Stop | None:
@@ -2195,7 +2296,10 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
     quality_gate_verbosity_delta = _resolve_config_value(
         config, "quality_gate_verbosity_delta", DEFAULT_QUALITY_GATE_VERBOSITY_DELTA
     )
-    quality_before = _capture_quality_before(daydream_dir) if quality_gate_enabled else None
+    if quality_gate_enabled:
+        quality_before, quality_before_unavailable = _capture_quality_before(daydream_dir)
+    else:
+        quality_before, quality_before_unavailable = None, None
     async with phase_scope(DaydreamPhase.FIX):
         fix_failures = await phase_fix_parallel(
             ctx.backend_for("fix"),
@@ -2294,6 +2398,7 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
         dd=dd,
         candidates={item["file"] for item in ctx.data["items"] if item.get("file")},
         before=quality_before,
+        before_unavailable_reason=quality_before_unavailable,
         iteration=ctx.data.get("iteration"),
     )
     return None

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -430,6 +430,80 @@ def test_runs_erosion_verbosity_columns_migrate_existing_db(tmp_path: Path):
     assert row["verbosity"] == pytest.approx(0.08)
 
 
+def test_build_manifest_carries_fix_quality_gate(tmp_path: Path):
+    """Issue #315: the fix-phase quality-gate verdict round-trips on the manifest."""
+    gate = {
+        "enabled": True,
+        "erosion_delta_threshold": 0.05,
+        "verbosity_delta_threshold": 0.05,
+        "rounds": [
+            {
+                "round": 1,
+                "per_file": {
+                    "api.py": {
+                        "erosion_before": 0.0,
+                        "erosion_after": 0.0,
+                        "erosion_delta": 0.0,
+                        "verbosity_before": 0.0,
+                        "verbosity_after": 0.8,
+                        "verbosity_delta": 0.8,
+                        "flagged": True,
+                    }
+                },
+            }
+        ],
+    }
+    m = _build(tmp_path, fix_quality_gate=gate)
+    assert m.fix_quality_gate == gate
+    d = m.to_dict()
+    assert d["fix_quality_gate"] == gate
+    assert d["fix_quality_gate"]["rounds"][0]["per_file"]["api.py"]["flagged"] is True
+
+
+def test_manifest_fix_quality_gate_none_when_absent(tmp_path: Path):
+    """No gate artifact => the manifest field stays null (additive, never invented)."""
+    m = _build(tmp_path)
+    assert m.fix_quality_gate is None
+    assert m.to_dict()["fix_quality_gate"] is None
+
+
+def test_upsert_run_persists_fix_quality_gate(tmp_path: Path):
+    """Issue #315: fix_quality_gate JSON round-trips through upsert_run -> query_runs."""
+    gate = {"enabled": True, "rounds": [{"round": 1, "per_file": {"api.py": {"flagged": True}}}]}
+    upsert_run(tmp_path, make_manifest(session_id="s-gate", fix_quality_gate=gate))
+    row = query_runs(tmp_path, where="session_id = ?", params=("s-gate",))[0]
+    assert json.loads(row["fix_quality_gate"]) == gate
+
+
+def test_runs_fix_quality_gate_column_migrates_existing_db(tmp_path: Path):
+    """A pre-existing index.db without fix_quality_gate gains it via ALTER-ADD.
+
+    Mirrors the erosion/verbosity additive migration: a legacy runs table keeps
+    its rows and gains the column on the next production write, never dropping
+    or rewriting data.
+    """
+    from daydream.archive.index import _CREATE_TABLE
+
+    legacy_ddl = _CREATE_TABLE.replace("    fix_quality_gate TEXT,\n", "")
+    assert "fix_quality_gate" not in legacy_ddl
+    conn = sqlite3.connect(str(tmp_path / "index.db"))
+    conn.execute(legacy_ddl)
+    conn.execute(
+        "INSERT INTO runs (session_id, archived_at, run_flow, archive_path) VALUES (?, ?, ?, ?)",
+        ("legacy-gate-run", "2026-01-01T00:00:00Z", "normal", str(tmp_path / "legacy-gate-run")),
+    )
+    conn.commit()
+    conn.close()
+
+    gate = {"enabled": True, "rounds": []}
+    upsert_run(tmp_path, make_manifest(session_id="s-mig-gate", fix_quality_gate=gate))
+
+    legacy = query_runs(tmp_path, where="session_id = ?", params=("legacy-gate-run",))[0]
+    assert legacy["fix_quality_gate"] is None  # pre-existing row preserved, column nullable
+    row = query_runs(tmp_path, where="session_id = ?", params=("s-mig-gate",))[0]
+    assert json.loads(row["fix_quality_gate"]) == gate
+
+
 def test_get_archive_dir_creates_structure(monkeypatch, tmp_path: Path):
     target = tmp_path / "custom_archive"
     monkeypatch.setenv("DAYDREAM_ARCHIVE_DIR", str(target))

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from daydream.archive import _copy_bundle, archive_run, get_archive_dir
+from daydream.archive import _copy_bundle, _read_fix_quality_gate, archive_run, get_archive_dir
 from daydream.archive.git_context import GitContext, _parse_repo_slug, capture_git_context
 from daydream.archive.index import (
     append_label_observation,
@@ -502,6 +502,35 @@ def test_runs_fix_quality_gate_column_migrates_existing_db(tmp_path: Path):
     assert legacy["fix_quality_gate"] is None  # pre-existing row preserved, column nullable
     row = query_runs(tmp_path, where="session_id = ?", params=("s-mig-gate",))[0]
     assert json.loads(row["fix_quality_gate"]) == gate
+
+
+def test_read_fix_quality_gate_requires_matching_session(tmp_path: Path):
+    """#329: only an artifact bound to the current session is read.
+
+    A gate verdict left behind by another session (e.g. a prior deep run on the
+    same target repo) must not be attributed to the current run's manifest.
+    """
+    gate = {
+        "enabled": True,
+        "session_id": "sess-42",
+        "rounds": [{"round": 1, "per_file": {"api.py": {"flagged": True}}}],
+    }
+    gate_p = tmp_path / ".daydream" / "deep" / "fix-quality-gate.json"
+    gate_p.parent.mkdir(parents=True)
+    gate_p.write_text(json.dumps(gate))
+
+    assert _read_fix_quality_gate(tmp_path, "sess-42") == gate
+    assert _read_fix_quality_gate(tmp_path, "sess-other") is None
+    assert _read_fix_quality_gate(tmp_path, None) is None
+
+
+def test_read_fix_quality_gate_unbound_artifact_is_none(tmp_path: Path):
+    """#329: an artifact with no session_id key cannot be attributed to this run."""
+    gate_p = tmp_path / ".daydream" / "deep" / "fix-quality-gate.json"
+    gate_p.parent.mkdir(parents=True)
+    gate_p.write_text(json.dumps({"enabled": True, "rounds": [{"round": 1, "per_file": {}}]}))
+
+    assert _read_fix_quality_gate(tmp_path, "sess-42") is None
 
 
 def test_get_archive_dir_creates_structure(monkeypatch, tmp_path: Path):

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -187,3 +187,74 @@ def test_empty_config_helper() -> None:
     cfg = DaydreamFileConfig()
     assert cfg.model is None and cfg.backend is None
     assert cfg.phase_model("fix") is None and cfg.phase_backend("review") is None
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        pytest.param(-0.1, None, id="negative"),
+        pytest.param(float("nan"), None, id="nan"),
+        pytest.param(float("inf"), None, id="inf"),
+        pytest.param(float("-inf"), None, id="negative-inf"),
+        pytest.param(True, None, id="bool"),
+        pytest.param("0.05", None, id="string"),
+        pytest.param([0.05], None, id="list"),
+        pytest.param(None, None, id="absent"),
+        pytest.param(0, 0.0, id="zero"),
+        pytest.param(0.05, 0.05, id="valid"),
+        pytest.param(100, 100.0, id="int-coerced"),
+    ],
+)
+def test_quality_gate_threshold_coercion(raw: object, expected: float | None) -> None:
+    """#329/Finding 7: quality-gate thresholds accept only finite non-negative values.
+
+    A negative threshold would flag every unchanged file (a zero delta exceeds
+    it); NaN/inf would silently disable the metric (every comparison is False)
+    and write non-standard ``NaN`` into JSON; bool/string/list are never
+    meaningful floors. Each invalid input degrades to ``None`` so the
+    ``config.py`` default applies.
+    """
+    from daydream.config_file import _coerce_quality_threshold
+
+    value = _coerce_quality_threshold(raw)
+    if expected is None:
+        assert value is None
+    else:
+        assert value == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param("-0.1", id="negative"),
+        pytest.param("nan", id="nan"),
+        pytest.param("inf", id="inf"),
+        pytest.param("true", id="bool"),
+        pytest.param('"0.25"', id="string"),
+    ],
+)
+def test_quality_gate_thresholds_in_file_config_degrade_to_none(tmp_path: Path, value: str) -> None:
+    """#329/Finding 7: invalid thresholds in ``.daydream.toml`` degrade to None.
+
+    Exercises the real TOML parse path: negative, NaN, inf, bool, and string
+    values for either threshold key land as ``None`` in the loaded config, so
+    ``_step_fix`` resolves the named default rather than a gate-breaking floor.
+    """
+    (tmp_path / ".daydream.toml").write_text(
+        f"quality_gate_erosion_delta = {value}\n"
+        f"quality_gate_verbosity_delta = {value}\n"
+    )
+    cfg = load_file_config(tmp_path)
+    assert cfg.quality_gate_erosion_delta is None
+    assert cfg.quality_gate_verbosity_delta is None
+
+
+def test_quality_gate_thresholds_accept_finite_non_negative(tmp_path: Path) -> None:
+    """#329/Finding 7: valid thresholds parse through unchanged."""
+    (tmp_path / ".daydream.toml").write_text(
+        "quality_gate_erosion_delta = 0.0\n"
+        "quality_gate_verbosity_delta = 0.25\n"
+    )
+    cfg = load_file_config(tmp_path)
+    assert cfg.quality_gate_erosion_delta == 0.0
+    assert cfg.quality_gate_verbosity_delta == 0.25

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -859,6 +859,36 @@ _FIX_EDIT_VERBOSE = (
     "        return 2\n"
 )
 
+# Issue #329 (Finding 5): a fix that adds a CC>10 function to a file that had
+# NO functions pre-fix. Pre-fix erosion is ``None`` (no denominator); the gate
+# must flag the absolute post-fix erosion rather than treating the undefined
+# baseline as "nothing to compare".
+_FIX_EDIT_ERODED = (
+    "\ndef route(request):\n"
+    "    if request == 'a':\n"
+    "        return 1\n"
+    "    elif request == 'b':\n"
+    "        return 2\n"
+    "    elif request == 'c':\n"
+    "        return 3\n"
+    "    elif request == 'd':\n"
+    "        return 4\n"
+    "    elif request == 'e':\n"
+    "        return 5\n"
+    "    elif request == 'f':\n"
+    "        return 6\n"
+    "    elif request == 'g':\n"
+    "        return 7\n"
+    "    elif request == 'h':\n"
+    "        return 8\n"
+    "    elif request == 'i':\n"
+    "        return 9\n"
+    "    elif request == 'j':\n"
+    "        return 10\n"
+    "    else:\n"
+    "        return 0\n"
+)
+
 
 def _build_gate_target(tmp_path: Path, name: str) -> Path:
     """Build a python-only fixture repo (the shape the quality gate measures)."""
@@ -870,6 +900,37 @@ def _build_gate_target(tmp_path: Path, name: str) -> Path:
     _commit(project, "init")
     _git(project, "checkout", "-b", "feature")
     (project / "api.py").write_text("def hello():\n    return 'galaxy'\n")
+    _git(project, "add", "api.py")
+    _commit(project, "change")
+    return project
+
+
+def _build_gate_target_no_functions(tmp_path: Path, name: str) -> Path:
+    """A python-only fixture repo whose api.py has NO functions (erosion None pre-fix)."""
+    project = tmp_path / name
+    project.mkdir()
+    (project / "api.py").write_text(
+        "import os\n"
+        "import sys\n"
+        "\n"
+        "NAME = 'gate_five'\n"
+        "VERSION = '1.0.0'\n"
+        "\n"
+        "CONFIG = os.environ.get('APP_CONFIG', 'default')\n"
+    )
+    _init_repo(project)
+    _git(project, "add", "api.py")
+    _commit(project, "init")
+    _git(project, "checkout", "-b", "feature")
+    (project / "api.py").write_text(
+        "import os\n"
+        "import sys\n"
+        "\n"
+        "NAME = 'gate_five'\n"
+        "VERSION = '1.0.1'\n"
+        "\n"
+        "CONFIG = os.environ.get('APP_CONFIG', 'default')\n"
+    )
     _git(project, "add", "api.py")
     _commit(project, "change")
     return project
@@ -1020,10 +1081,12 @@ async def test_fix_quality_gate_fail_open(
     make_config: MakeConfig,
     mute_side_effects: Mute,
 ) -> None:
-    """Real-path (#315): an analyzer failure degrades to "gate unavailable", never fails the run.
+    """Real-path (#315/#329): an analyzer failure degrades to an auditable unavailable round.
 
-    ``analyze_quality`` raising must leave the gate artifact absent (no fake
-    clean verdict) and the run must still complete its fix cycle.
+    ``analyze_quality`` raising on the pre-fix capture must (a) never fail the
+    run, and (b) persist an ``unavailable`` round entry naming the failed stage
+    and reason -- so the failure is auditable and can never read as a clean
+    verdict (and it supersedes any stale verdict for the current round).
     """
     def _boom(*_args: object, **_kwargs: object) -> dict:
         raise RuntimeError("analyzer down")
@@ -1031,8 +1094,77 @@ async def test_fix_quality_gate_fail_open(
     monkeypatch.setattr("daydream.eval.analyzer.analyze_quality", _boom)
     exit_code = await _run_quality_gate_fixture(multi_stack_target, monkeypatch, make_config, mute_side_effects)
     assert exit_code == 0
-    gate_p = multi_stack_target / ".daydream" / "deep" / "fix-quality-gate.json"
-    assert not gate_p.exists(), "gate must be absent when the analyzer is unavailable"
+
+    gate = _read_quality_gate(multi_stack_target)
+    assert gate["enabled"] is True
+    unavailable = gate["rounds"][0]["unavailable"]
+    assert unavailable["stage"] == "before"
+    assert "analyzer down" in unavailable["reason"]
+
+
+async def test_fix_quality_gate_flags_undefined_baseline_erosion(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+    mute_side_effects: Mute,
+) -> None:
+    """Real-path (#329/Finding 5): an EXISTING file with an undefined baseline is flagged.
+
+    Pre-fix api.py has no functions, so its erosion metric is ``None`` (no
+    defined baseline). The fix adds a CC>10 function; before this fix the
+    absolute-threshold fallback only fired for NEW files, so this regression
+    slipped past the gate unflagged. The fallback now fires on any file whose
+    BEFORE metric is undefined but whose AFTER metric is numeric.
+    """
+    target = _build_gate_target_no_functions(tmp_path, "gate_undefined_baseline")
+    exit_code = await _run_quality_gate_fixture(
+        target, monkeypatch, make_config, mute_side_effects, fix_edit_line=_FIX_EDIT_ERODED
+    )
+    assert exit_code == 0
+
+    gate = _read_quality_gate(target)
+    assert gate["enabled"] is True
+    entry = gate["rounds"][0]["per_file"]["api.py"]
+    assert entry["erosion_before"] is None
+    assert entry["erosion_after"] is not None
+    assert entry["erosion_after"] > 0.05
+    assert entry["erosion_delta"] is None
+    assert entry["flagged"] is True
+
+
+async def test_fix_quality_gate_artifact_bound_to_current_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+    archive_dir: Path,
+    mute_side_effects: Mute,
+) -> None:
+    """Real-path (#329/Finding 7): the gate artifact is bound to the run that wrote it.
+
+    Two runs on two byte-identical targets each mint a fresh session; the
+    artifact each writes carries ITS session id (which appears in that run's
+    archived manifest), never the other run's.
+    """
+    alpha = _build_gate_target(tmp_path, "gate_alpha")
+    exit_code = await _run_quality_gate_fixture(alpha, monkeypatch, make_config, mute_side_effects)
+    assert exit_code == 0
+    alpha_gate = _read_quality_gate(alpha)
+    assert alpha_gate["session_id"]
+
+    beta = _build_gate_target(tmp_path, "gate_beta")
+    exit_code = await _run_quality_gate_fixture(beta, monkeypatch, make_config, mute_side_effects)
+    assert exit_code == 0
+    beta_gate = _read_quality_gate(beta)
+    assert beta_gate["session_id"]
+    assert beta_gate["session_id"] != alpha_gate["session_id"]
+
+    manifests = [
+        json.loads((d / "manifest.json").read_text(encoding="utf-8"))
+        for d in (archive_dir / "runs").iterdir()
+    ]
+    archived_sessions = {m["session_id"] for m in manifests}
+    assert alpha_gate["session_id"] in archived_sessions
+    assert beta_gate["session_id"] in archived_sessions
 
 
 async def test_fix_guard_reverts_generated_migration_edit(

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -936,6 +936,53 @@ def _build_gate_target_no_functions(tmp_path: Path, name: str) -> Path:
     return project
 
 
+def _build_gate_target_with_helper(tmp_path: Path, name: str) -> Path:
+    """``_build_gate_target`` plus a second tracked python file (helper.py).
+
+    The quality gate measures python files; this fixture gives the fix agent a
+    SECOND parseable python file to touch outside its finding group (#329 /
+    Finding 6).
+    """
+    project = _build_gate_target(tmp_path, name)
+    (project / "helper.py").write_text("def helper():\n    return 'util'\n")
+    _git(project, "add", "helper.py")
+    _commit(project, "add helper")
+    return project
+
+
+class _SecondaryEditBackend(_StubBackend):
+    """Fix stub that ALSO edits a second tracked python file (#329/Finding 6).
+
+    The fix agent is explicitly permitted to touch files other than its group's
+    named file. The normal fix turn leaves the group's api.py byte-identical on
+    disk; this stub additionally appends a verbosity-raising block to
+    *secondary* -- the shape that used to bypass the quality gate entirely
+    (only finding-target paths were candidates).
+    """
+
+    def __init__(self, target: Path, secondary: Path, secondary_edit: str) -> None:
+        super().__init__(target)
+        self._secondary = secondary
+        self._secondary_edit = secondary_edit
+
+    async def execute(
+        self,
+        cwd: Path,
+        prompt: str,
+        output_schema: Any = None,
+        continuation: Any = None,
+        agents: Any = None,
+        max_turns: Any = None,
+        read_only: bool = False,
+    ):
+        async for event in super().execute(
+            cwd, prompt, output_schema, continuation, agents, max_turns, read_only
+        ):
+            yield event
+        if prompt.lower().startswith(("fix this issue", "fix these")):
+            self._secondary.write_text(self._secondary.read_text() + self._secondary_edit)
+
+
 def _read_quality_gate(target: Path) -> dict[str, Any]:
     gate_p = target / ".daydream" / "deep" / "fix-quality-gate.json"
     assert gate_p.is_file(), "fix-quality-gate.json must be written"
@@ -1268,6 +1315,156 @@ async def test_fix_quality_gate_malformed_resume_artifact_repairs(
     assert gate["enabled"] is True
     assert gate["session_id"]
     assert len(gate["rounds"]) == 1
+
+
+async def test_fix_quality_gate_second_run_discards_prior_session_rounds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+    mute_side_effects: Mute,
+) -> None:
+    """Real-path (#329/Finding 5): a new session never inherits a prior session's rounds.
+
+    Run 1 is a fresh deep run: it writes its verdict with session A. The tree is
+    then reset and the same target is resumed at ``--start-at fix`` (session B).
+    Before this fix the resume loaded run 1's rounds and re-archived them under
+    run 2's fresh session -- the first run's verdicts read as the second run's.
+    The loader now binds rounds to the stored session: B != A, so run 1's round
+    is DISCARDED with a warning and the artifact records only run 2's single
+    round under session B.
+    """
+    from daydream.runner import run
+
+    target = _build_gate_target(tmp_path, "gate_session_resume")
+    _silence(monkeypatch)
+    _force_interactive(monkeypatch)
+    mute_side_effects()
+    stub = _install_stub_backend(monkeypatch, target)
+    stub.merge_items = [_merge_item(1, "api.py", "high")]
+    stub.fix_edit_line = _FIX_EDIT_VERBOSE
+
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        "daydream.deep.orchestrator.print_warning",
+        lambda console, msg, *a, **k: warnings.append(msg),
+    )
+
+    first = await run(make_config(target, assume="yes", output_mode="loop", non_interactive=False))
+    assert first == 0
+    first_gate = _read_quality_gate(target)
+    assert first_gate["session_id"]
+    assert len(first_gate["rounds"]) == 1
+
+    # Restore the tree to the clean pre-fix state (run 1's fix was not
+    # committed) so the resume's worktree-clean + diff-key gates pass; the
+    # daydream artifacts -- including run 1's gate artifact -- survive.
+    _git(target, "reset", "--hard", "HEAD")
+    for sentinel in target.glob(".fixed-*"):
+        sentinel.unlink()
+    (target / ".daydream-fix-applied").unlink(missing_ok=True)
+
+    second = await run(
+        make_config(target, start_at="fix", assume="yes", output_mode="loop", non_interactive=False)
+    )
+    assert second == 0
+    second_gate = _read_quality_gate(target)
+    assert second_gate["session_id"] != first_gate["session_id"]
+    assert len(second_gate["rounds"]) == 1, (
+        "a new session must not inherit a prior session's rounds; run 1's round must be discarded"
+    )
+    assert any("another run's session" in w for w in warnings), (
+        "a session-mismatched artifact must surface a warning, never silently merge rounds"
+    )
+
+
+async def test_fix_quality_gate_covers_secondary_edit_outside_finding_group(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+    mute_side_effects: Mute,
+) -> None:
+    """Real-path (#329/Finding 6): a file edited OUTSIDE its finding group is gated.
+
+    The fix agent is permitted to touch files other than the group's named file.
+    The stub fixes api.py (finding target, left byte-identical on disk) and ALSO
+    appends a verbosity-raising block to helper.py. Before this fix the candidate
+    set came only from finding-target paths, so helper.py's regression bypassed
+    the gate, the artifact, the manifest, and SQLite. The candidate set now
+    derives from the PRE-FIX git snapshot (all changed ``*.py``) unioned with the
+    finding targets: helper.py appears in ``per_file`` with its delta computed
+    and is flagged, while api.py stays covered even though its on-disk content
+    did not change.
+    """
+    from daydream.runner import run
+
+    target = _build_gate_target_with_helper(tmp_path, "gate_secondary_edit")
+    _silence(monkeypatch)
+    _force_interactive(monkeypatch)
+    mute_side_effects()
+    stub = _SecondaryEditBackend(target, target / "helper.py", _FIX_EDIT_VERBOSE)
+    stub.merge_items = [_merge_item(1, "api.py", "high")]
+    monkeypatch.setattr("daydream.runner.create_backend", lambda name, model=None, **kwargs: stub)
+    monkeypatch.setattr("daydream.deep.orchestrator.get_installed_skills", lambda: None)
+    monkeypatch.setattr("daydream.deep.orchestrator.EXPLORATION_AVAILABLE", False)
+
+    exit_code = await run(
+        make_config(target, assume="yes", output_mode="loop", non_interactive=False)
+    )
+    assert exit_code == 0
+
+    gate = _read_quality_gate(target)
+    assert gate["enabled"] is True
+    per_file = gate["rounds"][0]["per_file"]
+    assert "helper.py" in per_file, (
+        "a file the fix agent edited outside its finding group must be gated"
+    )
+    helper = per_file["helper.py"]
+    assert helper["verbosity_delta"] is not None, "the secondary file's delta must be computed"
+    assert helper["verbosity_after"] > helper["verbosity_before"]
+    assert helper["flagged"] is True, "a secondary-file regression must be flagged"
+    assert "api.py" in per_file, (
+        "a finding target must stay covered even when unchanged on disk"
+    )
+    assert per_file["api.py"]["flagged"] is False
+
+
+async def test_fix_quality_gate_clamps_invalid_thresholds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+    mute_side_effects: Mute,
+) -> None:
+    """Real-path (#329/Finding 7): invalid thresholds resolve to the default, never the bad value.
+
+    A directly-constructed ``DaydreamFileConfig`` smuggling ``-0.1`` / ``NaN``
+    thresholds (bypassing the file parser) must resolve to the default at the
+    gate: the artifact records 0.05/0.05, the gate stays live (NaN used to make
+    every comparison False, silently disabling the metric), and an unchanged
+    file is NOT flagged (a negative floor used to flag every zero-delta file).
+    """
+    from daydream.config_file import DaydreamFileConfig
+
+    target = _build_gate_target(tmp_path, "gate_clamped_thresholds")
+    exit_code = await _run_quality_gate_fixture(
+        target,
+        monkeypatch,
+        make_config,
+        mute_side_effects,
+        fix_edit_line=None,
+        file_config=DaydreamFileConfig(
+            quality_gate_erosion_delta=-0.1,
+            quality_gate_verbosity_delta=float("nan"),
+        ),
+    )
+    assert exit_code == 0
+
+    gate = _read_quality_gate(target)
+    assert gate["enabled"] is True
+    assert gate["erosion_delta_threshold"] == 0.05
+    assert gate["verbosity_delta_threshold"] == 0.05
+    entry = gate["rounds"][0]["per_file"]["api.py"]
+    assert entry["erosion_delta"] == 0.0
+    assert entry["flagged"] is False
 
 
 async def test_fix_guard_reverts_generated_migration_edit(

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -842,6 +842,199 @@ async def test_fix_failure_enumerates_leftover_untracked_orphan_in_manifest(
     assert "store/uuid.go" in leftover
 
 
+# Issue #315: the fix-phase stub appends a duplicated if/else branch to the
+# edited file. The analyzer's within-file clone detector flags that block, so
+# the file's verbosity rises over its pre-fix baseline -- the shape the gate
+# exists to catch. The block is appended AFTER ``def hello():`` so api.py stays
+# parseable.
+_FIX_EDIT_VERBOSE = (
+    "\ndef choose(x):\n"
+    "    if x > 0:\n"
+    "        return 1\n"
+    "    else:\n"
+    "        return 2\n"
+    "    if x > 0:\n"
+    "        return 1\n"
+    "    else:\n"
+    "        return 2\n"
+)
+
+
+def _build_gate_target(tmp_path: Path, name: str) -> Path:
+    """Build a python-only fixture repo (the shape the quality gate measures)."""
+    project = tmp_path / name
+    project.mkdir()
+    (project / "api.py").write_text("def hello():\n    return 'universe'\n")
+    _init_repo(project)
+    _git(project, "add", "api.py")
+    _commit(project, "init")
+    _git(project, "checkout", "-b", "feature")
+    (project / "api.py").write_text("def hello():\n    return 'galaxy'\n")
+    _git(project, "add", "api.py")
+    _commit(project, "change")
+    return project
+
+
+def _read_quality_gate(target: Path) -> dict[str, Any]:
+    gate_p = target / ".daydream" / "deep" / "fix-quality-gate.json"
+    assert gate_p.is_file(), "fix-quality-gate.json must be written"
+    return json.loads(gate_p.read_text(encoding="utf-8"))
+
+
+async def _run_quality_gate_fixture(
+    target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+    mute_side_effects: Mute,
+    *,
+    fix_edit_line: str | None = _FIX_EDIT_VERBOSE,
+    file_config: Any = None,
+) -> int:
+    """Drive a deep run to the fix phase over *target*, editing api.py verbosely.
+
+    The stub merge emits one high-severity api.py item; the fix agent appends
+    ``fix_edit_line`` to the tracked file. Returns the run exit code.
+    """
+    from daydream.runner import run
+
+    _silence(monkeypatch)
+    _force_interactive(monkeypatch)
+    mute_side_effects()
+    stub = _install_stub_backend(monkeypatch, target)
+    stub.merge_items = [_merge_item(1, "api.py", "high")]
+    stub.fix_edit_line = fix_edit_line
+    return await run(
+        make_config(
+            target,
+            assume="yes",
+            output_mode="loop",
+            non_interactive=False,
+            archive=True,
+            file_config=file_config,
+        )
+    )
+
+
+async def test_fix_quality_gate_flags_verbosity_regression(
+    multi_stack_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+    mute_side_effects: Mute,
+) -> None:
+    """Real-path (#315): a fix that raises a file's verbosity is flagged, not fatal.
+
+    The stub's fix agent appends a duplicated if/else branch to api.py; the
+    analyzer's clone detector raises that file's verbosity past the default
+    0.05 delta threshold. Asserts observable outcomes:
+
+      (a) ``fix-quality-gate.json`` exists with api.py flagged and
+          ``verbosity_after > verbosity_before``;
+      (b) the run did NOT stop: the fix landed on the tracked file and the
+          run exits 0 (the gate is fail-open, never a hard gate).
+    """
+    exit_code = await _run_quality_gate_fixture(multi_stack_target, monkeypatch, make_config, mute_side_effects)
+    assert exit_code == 0
+    # (b) the fix landed on the tracked file.
+    assert "def choose(x):" in (multi_stack_target / "api.py").read_text()
+
+    gate = _read_quality_gate(multi_stack_target)
+    assert gate["enabled"] is True
+    entry = gate["rounds"][0]["per_file"]["api.py"]
+    assert entry["verbosity_after"] > entry["verbosity_before"]
+    assert entry["flagged"] is True
+
+
+async def test_fix_quality_gate_carries_to_manifest(
+    multi_stack_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    archive_dir: Path,
+    make_config: MakeConfig,
+    mute_side_effects: Mute,
+) -> None:
+    """Real-path (#315): the archived manifest carries the gate verdict + flagged file."""
+    exit_code = await _run_quality_gate_fixture(multi_stack_target, monkeypatch, make_config, mute_side_effects)
+    assert exit_code == 0
+
+    run_dirs = list((archive_dir / "runs").iterdir())
+    assert len(run_dirs) == 1, f"expected exactly one archived run, got {run_dirs}"
+    manifest = json.loads((run_dirs[0] / "manifest.json").read_text(encoding="utf-8"))
+    gate = manifest["fix_quality_gate"]
+    assert gate is not None, "manifest must carry the fix-quality-gate verdict"
+    assert gate["enabled"] is True
+    entry = gate["rounds"][0]["per_file"]["api.py"]
+    assert entry["flagged"] is True
+    assert entry["verbosity_after"] > entry["verbosity_before"]
+
+
+async def test_fix_quality_gate_threshold_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+    mute_side_effects: Mute,
+) -> None:
+    """Real-path (#315): configurable delta thresholds flip the flag on the SAME edit.
+
+    High thresholds tolerate the verbosity growth (no flagged files); 0.0
+    thresholds flag it. Two byte-identical fixture repos keep each run's
+    pre-fix tree clean.
+    """
+    from daydream.config_file import DaydreamFileConfig
+
+    tolerant_target = _build_gate_target(tmp_path, "gate_tolerant")
+    tolerant = await _run_quality_gate_fixture(
+        tolerant_target,
+        monkeypatch,
+        make_config,
+        mute_side_effects,
+        file_config=DaydreamFileConfig(
+            quality_gate_erosion_delta=100.0,
+            quality_gate_verbosity_delta=100.0,
+        ),
+    )
+    assert tolerant == 0
+    gate = _read_quality_gate(tolerant_target)
+    entry = gate["rounds"][0]["per_file"]["api.py"]
+    assert entry["verbosity_after"] > entry["verbosity_before"]
+    assert entry["flagged"] is False
+
+    strict_target = _build_gate_target(tmp_path, "gate_strict")
+    strict = await _run_quality_gate_fixture(
+        strict_target,
+        monkeypatch,
+        make_config,
+        mute_side_effects,
+        file_config=DaydreamFileConfig(
+            quality_gate_erosion_delta=0.0,
+            quality_gate_verbosity_delta=0.0,
+        ),
+    )
+    assert strict == 0
+    gate = _read_quality_gate(strict_target)
+    entry = gate["rounds"][0]["per_file"]["api.py"]
+    assert entry["flagged"] is True
+
+
+async def test_fix_quality_gate_fail_open(
+    multi_stack_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+    mute_side_effects: Mute,
+) -> None:
+    """Real-path (#315): an analyzer failure degrades to "gate unavailable", never fails the run.
+
+    ``analyze_quality`` raising must leave the gate artifact absent (no fake
+    clean verdict) and the run must still complete its fix cycle.
+    """
+    def _boom(*_args: object, **_kwargs: object) -> dict:
+        raise RuntimeError("analyzer down")
+
+    monkeypatch.setattr("daydream.eval.analyzer.analyze_quality", _boom)
+    exit_code = await _run_quality_gate_fixture(multi_stack_target, monkeypatch, make_config, mute_side_effects)
+    assert exit_code == 0
+    gate_p = multi_stack_target / ".daydream" / "deep" / "fix-quality-gate.json"
+    assert not gate_p.exists(), "gate must be absent when the analyzer is unavailable"
+
+
 async def test_fix_guard_reverts_generated_migration_edit(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -1167,6 +1167,109 @@ async def test_fix_quality_gate_artifact_bound_to_current_session(
     assert beta_gate["session_id"] in archived_sessions
 
 
+async def test_fix_quality_gate_flags_unparseable_post_fix_file(
+    multi_stack_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+    mute_side_effects: Mute,
+) -> None:
+    """Real-path (#329/Finding 5): a file missing from post-fix analyzer output is flagged.
+
+    A candidate that parsed pre-fix but is absent from the post-fix
+    ``analyze_quality`` per_file map means the fix made it unparseable (the
+    analyzer omits malformed files). Before this fix the gate recorded null
+    after-metrics with ``flagged=false`` -- a fix that broke a file read as a
+    clean pass. The gate now records the file as explicitly unavailable and
+    flagged, warns naming the file, and the run still completes (fail-open).
+    """
+    from daydream.eval import analyzer as analyzer_mod
+
+    calls = {"n": 0}
+    real_analyze = analyzer_mod.analyze_quality
+
+    def _stub(daydream_dir: Any) -> dict[str, Any]:
+        calls["n"] += 1
+        result = real_analyze(daydream_dir)
+        if calls["n"] == 2:
+            result["per_file"] = {
+                rel: entry for rel, entry in result["per_file"].items() if rel != "api.py"
+            }
+        return result
+
+    monkeypatch.setattr(analyzer_mod, "analyze_quality", _stub)
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        "daydream.deep.orchestrator.print_warning",
+        lambda console, msg, *a, **k: warnings.append(msg),
+    )
+    exit_code = await _run_quality_gate_fixture(
+        multi_stack_target, monkeypatch, make_config, mute_side_effects
+    )
+    assert exit_code == 0
+
+    gate = _read_quality_gate(multi_stack_target)
+    assert gate["enabled"] is True
+    entry = gate["rounds"][0]["per_file"]["api.py"]
+    assert entry["unparseable"] is True
+    assert entry["flagged"] is True
+    assert "post-fix analyzer output" in entry["reason"]
+    assert any("api.py" in w for w in warnings), "the unparseable file must be named in a warning"
+
+
+async def test_fix_quality_gate_malformed_resume_artifact_repairs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+    mute_side_effects: Mute,
+) -> None:
+    """Real-path (#329/Finding 6): a malformed resume artifact can't silently disable the gate.
+
+    Pre-seeding ``fix-quality-gate.json`` with a valid-JSON-but-wrong-shape
+    payload (``[]``) used to raise AttributeError inside the loader; the outer
+    fail-open handler re-raised and swallowed it, so a ``--start-at fix`` resume
+    continued with NO warning, the stale artifact survived, and the gate was
+    silently lost. The loader now degrades a malformed artifact to empty rounds
+    WITH a warning, and the run repairs the file in place -- the gate stays live
+    and the corrupted payload is never treated as authoritative prior rounds.
+    """
+    from daydream.runner import run
+
+    target = _build_gate_target(tmp_path, "gate_malformed_resume")
+    deep = target / ".daydream" / "deep"
+    deep.mkdir(parents=True, exist_ok=True)
+    _write_matching_diff_key(target, deep)
+    (deep / "merged-items.json").write_text(
+        json.dumps({"items": [_merge_item(1, "api.py", "high")]})
+    )
+    gate_p = deep / "fix-quality-gate.json"
+    gate_p.write_text("[]")
+
+    _silence(monkeypatch)
+    _force_interactive(monkeypatch)
+    mute_side_effects()
+    _install_stub_backend(monkeypatch, target)
+
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        "daydream.deep.orchestrator.print_warning",
+        lambda console, msg, *a, **k: warnings.append(msg),
+    )
+    exit_code = await run(
+        make_config(
+            target, start_at="fix", assume="yes", output_mode="loop", non_interactive=False
+        )
+    )
+    assert exit_code == 0
+
+    assert any("fix-quality-gate.json" in w and "malformed" in w for w in warnings), (
+        "a malformed artifact must surface a warning, never fail silently"
+    )
+    gate = json.loads(gate_p.read_text(encoding="utf-8"))
+    assert gate["enabled"] is True
+    assert gate["session_id"]
+    assert len(gate["rounds"]) == 1
+
+
 async def test_fix_guard_reverts_generated_migration_edit(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Closes #315

## What

Adds a fail-open anti-degradation quality gate to the fix phase: after fixes
are applied (before commit/verify), the orchestrator computes erosion and
verbosity deltas on the files the fix phase edited, using the SlopCodeBench
definitions already implemented by `analyze_quality` (#316 / #323). Any file
whose erosion or verbosity grew beyond a small configurable threshold is
flagged and surfaced with before/after numbers — the mechanical gate
SlopCodeBench (arXiv:2603.24755, RQ4) shows is needed because prompt-side
anti-slop guidance alone does not stop iterative degradation.

## Change

- `deep/orchestrator.py` (`_step_fix`): captures the pre-fix quality baseline
  before `phase_fix_parallel`, evaluates the gate after fixes applied (before
  commit), appends one `rounds` entry per fix invocation (loop/resume trend),
  and writes `deep/fix-quality-gate.json`.
- `config.py` + `config_file.py`: `quality_gate_enabled` (default True),
  `quality_gate_erosion_delta` (0.05), `quality_gate_verbosity_delta` (0.05),
  overridable via `[tool.daydream]`.
- `archive/` (additive): `fix_quality_gate` carried verbatim on the manifest —
  `Manifest` field + `to_dict` + `build_manifest` read + `_schema.py` TEXT
  column + `upsert_run` + migration for existing DBs.
- `deep/artifacts.py`: `fix_quality_gate_path()` helper.

## Acceptance criteria

- ✅ Fix phase computes erosion/verbosity deltas on edited files — real-path
  test `test_fix_quality_gate_flags_verbosity_regression` drives a deep run
  through `runner.run` (real fs, stub backend) where the fix agent appends a
  duplicated branch; asserts the delta is computed and the file flagged.
- ✅ A fix that grows erosion/verbosity beyond threshold is flagged with
  before/after numbers — surfaced as warnings and in `fix-quality-gate.json`.
- ✅ Manifest carries the deltas; `--loop` rounds show the per-round trend
  (`rounds[]` in the artifact, carried verbatim on the manifest).
- ✅ Thresholds configurable and honored
  (`test_fix_quality_gate_threshold_config`).
- ✅ Fail-open: gate never raises, never stops the run
  (`test_fix_quality_gate_fail_open`); the test gate stays the hard gate.
- ✅ `make check` green (2992 passed / 6 skipped).

## Benchmark isolation

**CANNOT affect Martian benchmark scoring.** The gate runs in the fix phase,
which is post-merge: the scorer reads only `merged-items.json` written by the
merge phase. The gate changes which fixes get committed, not what findings are
scored. Fail-open by design; the test gate remains the hard gate.

## Files changed

- `daydream/deep/orchestrator.py` (+180)
- `daydream/config.py` (+11)
- `daydream/config_file.py` (+22)
- `daydream/archive/manifest.py` (+13)
- `daydream/archive/_schema.py` (+6)
- `daydream/archive/index.py` (+3)
- `daydream/archive/__init__.py` (+15)
- `daydream/deep/artifacts.py` (+12)
- `tests/test_deep_orchestrator.py` (+193)
- `tests/test_archive.py` (+74)
