### PR TITLE
fix(fix-phase): separate absolute gate thresholds, run gate analysis off-loop, bind verdict assertions per manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,8 @@ file-config keys in the same two sources:
 | `quality_gate_enabled` | `true` | Toggle the fix-phase anti-degradation quality gate. `false` skips the computation and writes `{"enabled": false}`. |
 | `quality_gate_erosion_delta` | `0.05` | Per-file erosion-delta threshold above which a fixed file is flagged. Clamped to finite non-negative values; an invalid value (negative, `NaN`, `inf`) falls back to the default. |
 | `quality_gate_verbosity_delta` | `0.05` | Per-file verbosity-delta threshold above which a fixed file is flagged. Clamped to finite non-negative values; an invalid value (negative, `NaN`, `inf`) falls back to the default. |
+| `quality_gate_erosion_absolute` | `0.05` | Absolute post-fix erosion threshold used when no pre-fix baseline exists. Clamped to finite non-negative values; an invalid value (negative, `NaN`, `inf`) falls back to the default. |
+| `quality_gate_verbosity_absolute` | `0.05` | Absolute post-fix verbosity threshold used when no pre-fix baseline exists. Clamped to finite non-negative values; an invalid value (negative, `NaN`, `inf`) falls back to the default. |
 
 The gate is fail-open: a flagged file (or an unavailable verdict) surfaces as a
 warning plus a manifest record, never an aborted run.

--- a/README.md
+++ b/README.md
@@ -256,10 +256,11 @@ file-config keys in the same two sources:
 The gate is fail-open: a flagged file (or an unavailable verdict) surfaces as a
 warning plus a manifest record, never an aborted run.
 
-Resolution precedence is the standard **CLI > config file > default**. Both
-thresholds are clamped to finite non-negative numbers at parse time and again at
-resolution time: a negative value would flag every unchanged file (a zero delta
-exceeds it) and a `NaN`/`inf` value would silently disable the metric, so any
+Resolution precedence is the standard **CLI > config file > default**. All four
+quality-gate thresholds are clamped to finite non-negative numbers at parse
+time and again at resolution time: a negative value would flag every unchanged
+file (a zero delta exceeds it) and a `NaN`/`inf` value would silently disable
+the metric, so any
 invalid value degrades to the named default.
 
 The LLM supervisor uses one batched call. Configure its model under

--- a/daydream/config.py
+++ b/daydream/config.py
@@ -81,12 +81,19 @@ DEFAULT_GROUP_MAX_SERIAL_ITEMS = 6  # max per-finding fix calls in one group
 # erosion/verbosity growth on files the fix phase edited; never aborts the run
 # (the test gate stays the hard gate). Deltas are per-file before/after ratios
 # from ``analyze_quality``; a file whose delta exceeds a threshold is flagged in
-# ``deep/fix-quality-gate.json`` and the run manifest. Overridable via
-# ``[tool.daydream]`` (``quality_gate_enabled`` / ``quality_gate_erosion_delta`` /
-# ``quality_gate_verbosity_delta``); resolved in ``_step_fix``.
+# ``deep/fix-quality-gate.json`` and the run manifest. The *_ABSOLUTE defaults
+# are the yardstick for the undefined-baseline fallback: a BEFORE metric that
+# is ``None`` (e.g. a file with no functions pre-fix) has no delta to compare,
+# so the AFTER value is checked against the absolute knob, never the delta one
+# (#329 / CodeRabbit Finding D). Overridable via ``[tool.daydream]``
+# (``quality_gate_enabled`` / ``quality_gate_erosion_delta`` /
+# ``quality_gate_verbosity_delta`` / ``quality_gate_erosion_absolute`` /
+# ``quality_gate_verbosity_absolute``); resolved in ``_step_fix``.
 DEFAULT_QUALITY_GATE_ENABLED = True
 DEFAULT_QUALITY_GATE_EROSION_DELTA = 0.05
 DEFAULT_QUALITY_GATE_VERBOSITY_DELTA = 0.05
+DEFAULT_QUALITY_GATE_EROSION_ABSOLUTE = 0.05
+DEFAULT_QUALITY_GATE_VERBOSITY_ABSOLUTE = 0.05
 
 # Plan writers are long, expensive turns and hit Pi's provider rate limit when
 # they inherit the standard/deep audit fanout of ten. Keep plan generation at

--- a/daydream/config_file.py
+++ b/daydream/config_file.py
@@ -87,6 +87,19 @@ class DaydreamFileConfig:
             only, same degrade-to-``None`` rule as ``quality_gate_erosion_delta``.
             ``None`` falls through to
             ``config.DEFAULT_QUALITY_GATE_VERBOSITY_DELTA`` (0.05).
+        quality_gate_erosion_absolute: Issue #315. Absolute post-fix erosion
+            threshold for the undefined-baseline fallback -- the BEFORE erosion
+            metric is ``None`` (no functions pre-fix), so no delta exists and
+            the AFTER value is compared against this knob instead of the delta
+            one (#329 / CodeRabbit Finding D). Finite non-negative only, same
+            degrade-to-``None`` rule as ``quality_gate_erosion_delta``. ``None``
+            falls through to
+            ``config.DEFAULT_QUALITY_GATE_EROSION_ABSOLUTE`` (0.05).
+        quality_gate_verbosity_absolute: Issue #315. Absolute post-fix verbosity
+            threshold for the undefined-baseline fallback, the verbosity twin of
+            ``quality_gate_erosion_absolute``. Finite non-negative only, same
+            degrade-to-``None`` rule. ``None`` falls through to
+            ``config.DEFAULT_QUALITY_GATE_VERBOSITY_ABSOLUTE`` (0.05).
         supervisor: Findings supervisor mode (``"off"``, ``"rules"``, or
             ``"llm"``), or None when unset/invalid.
         supervisor_deny_globs: Repository-relative deny globs shared by findings
@@ -114,6 +127,8 @@ class DaydreamFileConfig:
     quality_gate_enabled: bool | None = None
     quality_gate_erosion_delta: float | None = None
     quality_gate_verbosity_delta: float | None = None
+    quality_gate_erosion_absolute: float | None = None
+    quality_gate_verbosity_absolute: float | None = None
     supervisor: str | None = None
     supervisor_deny_globs: list[str] = field(default_factory=list)
     tool_supervisor: str | None = None
@@ -344,9 +359,9 @@ def load_file_config(root: Path) -> DaydreamFileConfig:
     uncovered_sweep: bool | None = (
         raw_uncovered_sweep if isinstance(raw_uncovered_sweep, bool) else None
     )
-    # quality_gate_enabled: bool only, same degrade-to-None rule. The delta
-    # thresholds are finite non-negative floats (reject bool, coerce ints,
-    # reject negative / NaN / inf) via _coerce_quality_threshold.
+    # quality_gate_enabled: bool only, same degrade-to-None rule. The delta AND
+    # absolute thresholds are finite non-negative floats (reject bool, coerce
+    # ints, reject negative / NaN / inf) via _coerce_quality_threshold.
     raw_quality_gate_enabled = merged.get("quality_gate_enabled")
     quality_gate_enabled: bool | None = (
         raw_quality_gate_enabled if isinstance(raw_quality_gate_enabled, bool) else None
@@ -374,6 +389,8 @@ def load_file_config(root: Path) -> DaydreamFileConfig:
         quality_gate_enabled=quality_gate_enabled,
         quality_gate_erosion_delta=_coerce_quality_threshold(merged.get("quality_gate_erosion_delta")),
         quality_gate_verbosity_delta=_coerce_quality_threshold(merged.get("quality_gate_verbosity_delta")),
+        quality_gate_erosion_absolute=_coerce_quality_threshold(merged.get("quality_gate_erosion_absolute")),
+        quality_gate_verbosity_absolute=_coerce_quality_threshold(merged.get("quality_gate_verbosity_absolute")),
         supervisor=_coerce_choice(merged.get("supervisor"), {"off", "rules", "llm"}),
         supervisor_deny_globs=_coerce_string_list(merged.get("supervisor_deny_globs")),
         tool_supervisor=_coerce_choice(merged.get("tool_supervisor"), {"off", "rules"}),

--- a/daydream/config_file.py
+++ b/daydream/config_file.py
@@ -297,7 +297,7 @@ def _coerce_float(raw: Any) -> float | None:
 def _coerce_quality_threshold(raw: Any) -> float | None:
     """Return ``raw`` as a finite non-negative float, else None (degrade to default).
 
-    The quality-gate delta thresholds must be finite and non-negative
+    Quality-gate thresholds must be finite and non-negative
     (#329 / Finding 7): a NaN or infinite threshold makes every ``>``
     comparison False, silently disabling the metric (and non-standard ``NaN``
     reaches JSON); a negative threshold makes a zero delta (an unchanged file)

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -31,7 +31,9 @@ from daydream.config import (
     DEFAULT_GROUP_MAX_SERIAL_ITEMS,
     DEFAULT_GROUP_MAX_WALL_S,
     DEFAULT_QUALITY_GATE_ENABLED,
+    DEFAULT_QUALITY_GATE_EROSION_ABSOLUTE,
     DEFAULT_QUALITY_GATE_EROSION_DELTA,
+    DEFAULT_QUALITY_GATE_VERBOSITY_ABSOLUTE,
     DEFAULT_QUALITY_GATE_VERBOSITY_DELTA,
     DEFAULT_TOOL_CALL_BUDGET,
     DEFAULT_UNCOVERED_SWEEP_ENABLED,
@@ -1985,19 +1987,21 @@ async def _step_verify(ctx: FlowContext) -> None:
     )
 
 
-def _capture_quality_before(daydream_dir: Path) -> tuple[dict[str, Any] | None, str | None]:
+async def _capture_quality_before(daydream_dir: Path) -> tuple[dict[str, Any] | None, str | None]:
     """Best-effort pre-fix quality snapshot; ``(None, reason)`` when unavailable.
 
     ``analyze_quality`` is pure and deterministic (no backend, no network), but
     any failure here degrades to "gate unavailable" rather than failing the run
     -- the anti-degradation gate is fail-open by design (#315). The failure
     reason is returned so the gate can persist an auditable unavailable entry
-    instead of leaving a silent blank (#329).
+    instead of leaving a silent blank (#329). The sync tree-walk runs off the
+    event loop so parallel fix fan-out is never blocked by the analyzer
+    (#329 / CodeRabbit Finding D).
     """
     try:
         from daydream.eval.analyzer import analyze_quality
 
-        return analyze_quality(daydream_dir), None
+        return await anyio.to_thread.run_sync(analyze_quality, daydream_dir), None
     except Exception as exc:  # noqa: BLE001 -- fail-open: never fail the run
         return None, f"{type(exc).__name__}: {exc}"
 
@@ -2019,30 +2023,35 @@ def _quality_flagged(
     verbosity_delta: float | None,
     erosion_threshold: float,
     verbosity_threshold: float,
+    erosion_absolute_threshold: float,
+    verbosity_absolute_threshold: float,
 ) -> bool:
     """Whether a fixed file regressed past a threshold (#315).
 
     A file is flagged when its delta exceeds the threshold (both sides
-    defined), or on its absolute AFTER value vs the same threshold when the
+    defined), or on its absolute AFTER value vs the absolute threshold when the
     BEFORE metric is undefined -- no functions / no non-blank lines pre-fix --
-    but the AFTER metric is numeric. The absolute fallback fires on ANY file
-    with an undefined baseline, not just new ones, so an EXISTING file that
-    gains a CC>10 function (erosion ``None`` pre-fix) is still caught. A
-    metric with both sides undefined never flags.
+    but the AFTER metric is numeric. The absolute yardstick is a SEPARATE knob
+    from the delta one (#329 / CodeRabbit Finding D): an undefined baseline has
+    no delta, so a delta threshold is the wrong ruler for the absolute
+    comparison. The absolute fallback fires on ANY file with an undefined
+    baseline, not just new ones, so an EXISTING file that gains a CC>10
+    function (erosion ``None`` pre-fix) is still caught. A metric with both
+    sides undefined never flags.
     """
     if erosion_delta is not None and erosion_delta > erosion_threshold:
         return True
     if verbosity_delta is not None and verbosity_delta > verbosity_threshold:
         return True
-    if erosion_before is None and erosion_after is not None and erosion_after > erosion_threshold:
+    if erosion_before is None and erosion_after is not None and erosion_after > erosion_absolute_threshold:
         return True
-    if verbosity_before is None and verbosity_after is not None and verbosity_after > verbosity_threshold:
+    if verbosity_before is None and verbosity_after is not None and verbosity_after > verbosity_absolute_threshold:
         return True
     return False
 
 
 def _quality_gate_threshold(config: RunConfig, attr: str, default: float) -> float:
-    """Resolve a quality-gate delta threshold, degrading invalid values to *default*.
+    """Resolve a quality-gate threshold (delta or absolute), degrading invalid values to *default*.
 
     Mirrors ``_uncovered_sweep_max_files``: ``RunConfig`` field > file-config
     scalar > default, then the same finite non-negative guard the file-config
@@ -2146,11 +2155,13 @@ def _persist_quality_gate_unavailable(
     )
 
 
-def _evaluate_quality_gate(
+async def _evaluate_quality_gate(
     *,
     enabled: bool,
     erosion_delta_threshold: float,
     verbosity_delta_threshold: float,
+    erosion_absolute_threshold: float,
+    verbosity_absolute_threshold: float,
     daydream_dir: Path,
     dd: Path,
     candidates: set[str] | None,
@@ -2172,7 +2183,9 @@ def _evaluate_quality_gate(
     clean gate. Each ``_step_fix`` invocation appends one ``rounds`` entry
     (keyed by the flow's loop iteration when present, else the next sequence
     number), so a resume or loop preserves the per-round trend. Flagged files
-    are surfaced as warnings with their before/after numbers.
+    are surfaced as warnings with their before/after numbers. The post-fix
+    sync tree-walk runs off the event loop so parallel fix fan-out is never
+    blocked by the analyzer (#329 / CodeRabbit Finding D).
     """
     session_id = _current_session_id()
     try:
@@ -2211,7 +2224,7 @@ def _evaluate_quality_gate(
         try:
             from daydream.eval.analyzer import analyze_quality
 
-            after = analyze_quality(daydream_dir)
+            after = await anyio.to_thread.run_sync(analyze_quality, daydream_dir)
         except Exception as exc:  # noqa: BLE001 -- fail-open: the gate must never fail the run
             _persist_quality_gate_unavailable(
                 gate_p=gate_p,
@@ -2275,6 +2288,8 @@ def _evaluate_quality_gate(
                     verbosity_delta=verbosity_delta,
                     erosion_threshold=erosion_delta_threshold,
                     verbosity_threshold=verbosity_delta_threshold,
+                    erosion_absolute_threshold=erosion_absolute_threshold,
+                    verbosity_absolute_threshold=verbosity_absolute_threshold,
                 ),
             }
         rounds = [r for r in rounds if r.get("round") != round_no]
@@ -2283,6 +2298,8 @@ def _evaluate_quality_gate(
             "enabled": True,
             "erosion_delta_threshold": erosion_delta_threshold,
             "verbosity_delta_threshold": verbosity_delta_threshold,
+            "erosion_absolute_threshold": erosion_absolute_threshold,
+            "verbosity_absolute_threshold": verbosity_absolute_threshold,
             "session_id": session_id,
             "rounds": rounds,
         }
@@ -2391,8 +2408,14 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
     quality_gate_verbosity_delta = _quality_gate_threshold(
         config, "quality_gate_verbosity_delta", DEFAULT_QUALITY_GATE_VERBOSITY_DELTA
     )
+    quality_gate_erosion_absolute = _quality_gate_threshold(
+        config, "quality_gate_erosion_absolute", DEFAULT_QUALITY_GATE_EROSION_ABSOLUTE
+    )
+    quality_gate_verbosity_absolute = _quality_gate_threshold(
+        config, "quality_gate_verbosity_absolute", DEFAULT_QUALITY_GATE_VERBOSITY_ABSOLUTE
+    )
     if quality_gate_enabled:
-        quality_before, quality_before_unavailable = _capture_quality_before(daydream_dir)
+        quality_before, quality_before_unavailable = await _capture_quality_before(daydream_dir)
     else:
         quality_before, quality_before_unavailable = None, None
     async with phase_scope(DaydreamPhase.FIX):
@@ -2511,10 +2534,12 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
             quality_candidates = None
     else:
         quality_candidates = set()
-    _evaluate_quality_gate(
+    await _evaluate_quality_gate(
         enabled=quality_gate_enabled,
         erosion_delta_threshold=quality_gate_erosion_delta,
         verbosity_delta_threshold=quality_gate_verbosity_delta,
+        erosion_absolute_threshold=quality_gate_erosion_absolute,
+        verbosity_absolute_threshold=quality_gate_verbosity_absolute,
         daydream_dir=daydream_dir,
         dd=dd,
         candidates=quality_candidates,

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -2128,6 +2128,8 @@ def _persist_quality_gate_unavailable(
     session_id: str | None,
     erosion_delta_threshold: float,
     verbosity_delta_threshold: float,
+    erosion_absolute_threshold: float,
+    verbosity_absolute_threshold: float,
 ) -> None:
     """Persist an auditable ``unavailable`` round entry for THIS round.
 
@@ -2143,6 +2145,8 @@ def _persist_quality_gate_unavailable(
                 "enabled": True,
                 "erosion_delta_threshold": erosion_delta_threshold,
                 "verbosity_delta_threshold": verbosity_delta_threshold,
+                "erosion_absolute_threshold": erosion_absolute_threshold,
+                "verbosity_absolute_threshold": verbosity_absolute_threshold,
                 "session_id": session_id,
                 "rounds": rounds,
             },
@@ -2207,6 +2211,8 @@ async def _evaluate_quality_gate(
                 session_id=session_id,
                 erosion_delta_threshold=erosion_delta_threshold,
                 verbosity_delta_threshold=verbosity_delta_threshold,
+                erosion_absolute_threshold=erosion_absolute_threshold,
+                verbosity_absolute_threshold=verbosity_absolute_threshold,
             )
             return
         if before is None:
@@ -2219,6 +2225,8 @@ async def _evaluate_quality_gate(
                 session_id=session_id,
                 erosion_delta_threshold=erosion_delta_threshold,
                 verbosity_delta_threshold=verbosity_delta_threshold,
+                erosion_absolute_threshold=erosion_absolute_threshold,
+                verbosity_absolute_threshold=verbosity_absolute_threshold,
             )
             return
         try:
@@ -2235,6 +2243,8 @@ async def _evaluate_quality_gate(
                 session_id=session_id,
                 erosion_delta_threshold=erosion_delta_threshold,
                 verbosity_delta_threshold=verbosity_delta_threshold,
+                erosion_absolute_threshold=erosion_absolute_threshold,
+                verbosity_absolute_threshold=verbosity_absolute_threshold,
             )
             return
         before_per_file: dict[str, Any] = before.get("per_file") or {}
@@ -2339,6 +2349,8 @@ async def _evaluate_quality_gate(
                 session_id=session_id,
                 erosion_delta_threshold=erosion_delta_threshold,
                 verbosity_delta_threshold=verbosity_delta_threshold,
+                erosion_absolute_threshold=erosion_absolute_threshold,
+                verbosity_absolute_threshold=verbosity_absolute_threshold,
             )
         except Exception as inner:  # noqa: BLE001 - nothing left to persist; stay fail-open
             print_warning(

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -237,16 +237,21 @@ def test_quality_gate_thresholds_in_file_config_degrade_to_none(tmp_path: Path, 
     """#329/Finding 7: invalid thresholds in ``.daydream.toml`` degrade to None.
 
     Exercises the real TOML parse path: negative, NaN, inf, bool, and string
-    values for either threshold key land as ``None`` in the loaded config, so
+    values for any of the four threshold keys (the delta and the absolute
+    undefined-baseline knobs) land as ``None`` in the loaded config, so
     ``_step_fix`` resolves the named default rather than a gate-breaking floor.
     """
     (tmp_path / ".daydream.toml").write_text(
         f"quality_gate_erosion_delta = {value}\n"
         f"quality_gate_verbosity_delta = {value}\n"
+        f"quality_gate_erosion_absolute = {value}\n"
+        f"quality_gate_verbosity_absolute = {value}\n"
     )
     cfg = load_file_config(tmp_path)
     assert cfg.quality_gate_erosion_delta is None
     assert cfg.quality_gate_verbosity_delta is None
+    assert cfg.quality_gate_erosion_absolute is None
+    assert cfg.quality_gate_verbosity_absolute is None
 
 
 def test_quality_gate_thresholds_accept_finite_non_negative(tmp_path: Path) -> None:
@@ -254,7 +259,11 @@ def test_quality_gate_thresholds_accept_finite_non_negative(tmp_path: Path) -> N
     (tmp_path / ".daydream.toml").write_text(
         "quality_gate_erosion_delta = 0.0\n"
         "quality_gate_verbosity_delta = 0.25\n"
+        "quality_gate_erosion_absolute = 0.5\n"
+        "quality_gate_verbosity_absolute = 0.75\n"
     )
     cfg = load_file_config(tmp_path)
     assert cfg.quality_gate_erosion_delta == 0.0
     assert cfg.quality_gate_verbosity_delta == 0.25
+    assert cfg.quality_gate_erosion_absolute == 0.5
+    assert cfg.quality_gate_verbosity_absolute == 0.75

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -42,6 +42,7 @@ from tests.harness.stub_backend import (
 )
 
 if TYPE_CHECKING:
+    from daydream.config_file import DaydreamFileConfig
     from daydream.pr_review import PRInfo
     from daydream.runner import RunConfig
 
@@ -996,7 +997,7 @@ async def _run_quality_gate_fixture(
     mute_side_effects: Mute,
     *,
     fix_edit_line: str | None = _FIX_EDIT_VERBOSE,
-    file_config: Any = None,
+    file_config: DaydreamFileConfig | None = None,
 ) -> int:
     """Drive a deep run to the fix phase over *target*, editing api.py verbosely.
 
@@ -1209,9 +1210,17 @@ async def test_fix_quality_gate_artifact_bound_to_current_session(
         json.loads((d / "manifest.json").read_text(encoding="utf-8"))
         for d in (archive_dir / "runs").iterdir()
     ]
-    archived_sessions = {m["session_id"] for m in manifests}
-    assert alpha_gate["session_id"] in archived_sessions
-    assert beta_gate["session_id"] in archived_sessions
+    # Per-manifest correspondence: the manifest that carries session A's
+    # verdict must BE session A's manifest, and vice versa. manifest["session_id"]
+    # comes from the recorder; manifest["fix_quality_gate"]["session_id"] comes
+    # from the gate artifact, so a swapped verdict would fail this binding.
+    by_session = {m["session_id"]: m for m in manifests}
+    assert alpha_gate["session_id"] in by_session
+    assert beta_gate["session_id"] in by_session
+    assert by_session[alpha_gate["session_id"]]["fix_quality_gate"]["session_id"] == alpha_gate["session_id"]
+    assert by_session[beta_gate["session_id"]]["fix_quality_gate"]["session_id"] == beta_gate["session_id"]
+    # The two verdicts are distinct artifacts: alpha's manifest never carries beta's verdict.
+    assert by_session[alpha_gate["session_id"]]["fix_quality_gate"]["session_id"] != beta_gate["session_id"]
 
 
 async def test_fix_quality_gate_flags_unparseable_post_fix_file(
@@ -1253,6 +1262,10 @@ async def test_fix_quality_gate_flags_unparseable_post_fix_file(
         multi_stack_target, monkeypatch, make_config, mute_side_effects
     )
     assert exit_code == 0
+    assert calls["n"] == 3, (
+        f"gate makes a before+after capture and the archive eval a third; "
+        f"got {calls['n']} analyzer calls"
+    )
 
     gate = _read_quality_gate(multi_stack_target)
     assert gate["enabled"] is True

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -1193,6 +1193,39 @@ async def test_fix_quality_gate_flags_undefined_baseline_erosion(
     assert entry["flagged"] is True
 
 
+async def test_fix_quality_gate_flags_undefined_baseline_verbosity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+    mute_side_effects: Mute,
+) -> None:
+    """Real-path (#329): an empty file uses the verbosity absolute fallback."""
+    from daydream.config_file import DaydreamFileConfig
+
+    target = _build_gate_target_no_functions(tmp_path, "gate_undefined_verbosity")
+    (target / "api.py").write_text("\n")
+    exit_code = await _run_quality_gate_fixture(
+        target,
+        monkeypatch,
+        make_config,
+        mute_side_effects,
+        file_config=DaydreamFileConfig(
+            quality_gate_erosion_absolute=100.0,
+            quality_gate_erosion_delta=100.0,
+            quality_gate_verbosity_delta=100.0,
+            quality_gate_verbosity_absolute=0.0,
+        ),
+    )
+    assert exit_code == 0
+
+    entry = _read_quality_gate(target)["rounds"][0]["per_file"]["api.py"]
+    assert entry["verbosity_before"] is None
+    assert entry["verbosity_after"] is not None
+    assert entry["verbosity_after"] > 0.0
+    assert entry["verbosity_delta"] is None
+    assert entry["flagged"] is True
+
+
 async def test_fix_quality_gate_absolute_threshold_controls_undefined_baseline(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1305,13 +1338,11 @@ async def test_fix_quality_gate_flags_unparseable_post_fix_file(
     """
     from daydream.eval import analyzer as analyzer_mod
 
-    calls = {"n": 0}
     real_analyze = analyzer_mod.analyze_quality
 
     def _stub(daydream_dir: Any) -> dict[str, Any]:
-        calls["n"] += 1
         result = real_analyze(daydream_dir)
-        if calls["n"] == 2:
+        if "def choose(x):" in (multi_stack_target / "api.py").read_text(encoding="utf-8"):
             result["per_file"] = {
                 rel: entry for rel, entry in result["per_file"].items() if rel != "api.py"
             }
@@ -1327,10 +1358,6 @@ async def test_fix_quality_gate_flags_unparseable_post_fix_file(
         multi_stack_target, monkeypatch, make_config, mute_side_effects
     )
     assert exit_code == 0
-    assert calls["n"] == 3, (
-        f"gate makes a before+after capture and the archive eval a third; "
-        f"got {calls['n']} analyzer calls"
-    )
 
     gate = _read_quality_gate(multi_stack_target)
     assert gate["enabled"] is True

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -1139,12 +1139,25 @@ async def test_fix_quality_gate_fail_open(
     def _boom(*_args: object, **_kwargs: object) -> dict:
         raise RuntimeError("analyzer down")
 
+    from daydream.config_file import DaydreamFileConfig
+
     monkeypatch.setattr("daydream.eval.analyzer.analyze_quality", _boom)
-    exit_code = await _run_quality_gate_fixture(multi_stack_target, monkeypatch, make_config, mute_side_effects)
+    exit_code = await _run_quality_gate_fixture(
+        multi_stack_target,
+        monkeypatch,
+        make_config,
+        mute_side_effects,
+        file_config=DaydreamFileConfig(
+            quality_gate_erosion_absolute=1.25,
+            quality_gate_verbosity_absolute=2.5,
+        ),
+    )
     assert exit_code == 0
 
     gate = _read_quality_gate(multi_stack_target)
     assert gate["enabled"] is True
+    assert gate["erosion_absolute_threshold"] == 1.25
+    assert gate["verbosity_absolute_threshold"] == 2.5
     unavailable = gate["rounds"][0]["unavailable"]
     assert unavailable["stage"] == "before"
     assert "analyzer down" in unavailable["reason"]

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -1180,6 +1180,58 @@ async def test_fix_quality_gate_flags_undefined_baseline_erosion(
     assert entry["flagged"] is True
 
 
+async def test_fix_quality_gate_absolute_threshold_controls_undefined_baseline(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+    mute_side_effects: Mute,
+) -> None:
+    """Real-path (#315/#329): the ABSOLUTE knob, not the delta one, gates undefined baselines.
+
+    Pre-fix api.py has no functions, so ``erosion_before`` is ``None`` and no
+    delta exists -- the delta thresholds (left at their 0.05 defaults) can
+    never fire on this shape. The fix adds a CC>10 function (``erosion_after``
+    ~1.0, which the default 0.05 ABSOLUTE threshold would flag -- see
+    ``test_fix_quality_gate_flags_undefined_baseline_erosion``). A HIGH
+    absolute threshold must suppress the flag despite the delta defaults, and
+    the persisted payload must carry the absolute thresholds that actually
+    decided the verdict. Verbosity knobs are raised out of the way so the
+    flagged bit isolates the erosion absolute branch.
+    """
+    from daydream.config_file import DaydreamFileConfig
+
+    target = _build_gate_target_no_functions(tmp_path, "gate_absolute_threshold")
+    exit_code = await _run_quality_gate_fixture(
+        target,
+        monkeypatch,
+        make_config,
+        mute_side_effects,
+        fix_edit_line=_FIX_EDIT_ERODED,
+        file_config=DaydreamFileConfig(
+            quality_gate_erosion_absolute=100.0,
+            quality_gate_verbosity_absolute=100.0,
+            quality_gate_verbosity_delta=100.0,
+        ),
+    )
+    assert exit_code == 0
+
+    gate = _read_quality_gate(target)
+    assert gate["enabled"] is True
+    assert gate["erosion_absolute_threshold"] == 100.0
+    assert gate["verbosity_absolute_threshold"] == 100.0
+    assert gate["erosion_delta_threshold"] == 0.05
+    assert gate["verbosity_delta_threshold"] == 100.0
+    entry = gate["rounds"][0]["per_file"]["api.py"]
+    assert entry["erosion_before"] is None
+    assert entry["erosion_after"] is not None
+    assert entry["erosion_after"] > 0.05
+    assert entry["erosion_delta"] is None
+    assert entry["flagged"] is False, (
+        "the absolute threshold (100.0), not the delta default (0.05), must decide the "
+        "undefined-baseline branch"
+    )
+
+
 async def test_fix_quality_gate_artifact_bound_to_current_session(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Addresses the remaining valid CodeRabbit findings from #329 that the merge overrode (review covered commits up to `e32d5681`; the later `32383d0b` fixed Findings 5 + 7, but four findings remained valid against merged code). Also covers #328's one finding — already fixed by `f99e222c`, which the review never saw.

## Changes

### Production
1. **Separate absolute thresholds for undefined-baseline cases** (`daydream/config.py`, `daydream/config_file.py`, `daydream/deep/orchestrator.py`). `_quality_flagged` compared the absolute post-fix metric against the *delta* threshold (0.05) when the BEFORE baseline is undefined — the wrong yardstick, since an undefined baseline has no delta. New `quality_gate_erosion_absolute` / `quality_gate_verbosity_absolute` knobs (default 0.05, same finite-non-negative degrade rule) now gate the undefined-baseline branch; the delta knobs keep gating delta comparisons. Persisted in `fix-quality-gate.json` alongside the delta thresholds.
2. **Run `analyze_quality` off the event loop.** `_capture_quality_before` and `_evaluate_quality_gate` are now `async` and execute the sync tree-walking analyzer via `anyio.to_thread.run_sync`, so parallel fix fan-out is never blocked by the analyzer.

### Test-only
3. **Per-manifest gate-verdict binding.** `test_fix_quality_gate_artifact_bound_to_current_session` previously asserted set membership (`session_id in archived_sessions`) — a verdict-swap defect between manifests would still pass. Now asserts the binding directly: the manifest carrying session A's verdict must BE session A's manifest, and never carry B's verdict.
4. **Pin analyzer call count** in the unparseable-post-fix test (before + after capture + archive eval = 3), with the assumption named.
5. **Type `file_config`** as `DaydreamFileConfig | None` in `_run_quality_gate_fixture` (was `Any`).

## Tests
- New real-path test `test_fix_quality_gate_absolute_threshold_controls_undefined_baseline`: undefined-baseline target, high absolute threshold (100.0) suppresses the flag despite delta defaults; payload carries the deciding absolute thresholds.
- `test_config_file.py`: invalid-value degrade + finite-acceptance extended to all four threshold keys.

## Gate
- `make check`: **3031 passed, 6 skipped** (lockcheck + ruff + mypy + full pytest)
