### PR TITLE
ci: run GitHub Actions on Blacksmith runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,8 @@
+# actionlint configuration
+# Declare custom Blacksmith self-hosted runner labels so actionlint
+# does not flag runs-on entries as unknown labels.
+self-hosted-runner:
+  labels:
+    - blacksmith-2vcpu-ubuntu-2404
+    - blacksmith-4vcpu-ubuntu-2404
+    - blacksmith-6vcpu-macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
       - name: Checkout code

--- a/.github/workflows/daydream-command.yml
+++ b/.github/workflows/daydream-command.yml
@@ -33,7 +33,7 @@ permissions: {}
 
 jobs:
   dispatch:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     if: >-
       github.event.issue.pull_request &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&

--- a/.github/workflows/daydream-post.yml
+++ b/.github/workflows/daydream-post.yml
@@ -37,7 +37,7 @@ permissions:
 
 jobs:
   post:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     if: github.event.workflow_run.conclusion == 'success'
     steps:
       # Trusted code only: the base repo's default branch, no ref override.
@@ -138,7 +138,7 @@ jobs:
 
   # An analyze failure routes here instead of silently skipping the post job.
   surface-analyze-failure:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions: {}
     if: github.event.workflow_run.conclusion == 'failure'
     steps:

--- a/.github/workflows/daydream-review.yml
+++ b/.github/workflows/daydream-review.yml
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   analyze:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.head.repo.full_name == github.repository &&

--- a/daydream/templates/workflows/daydream-command.yml
+++ b/daydream/templates/workflows/daydream-command.yml
@@ -33,7 +33,7 @@ permissions: {}
 
 jobs:
   dispatch:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     if: >-
       github.event.issue.pull_request &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&

--- a/daydream/templates/workflows/daydream-post.yml
+++ b/daydream/templates/workflows/daydream-post.yml
@@ -37,7 +37,7 @@ permissions:
 
 jobs:
   post:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     if: github.event.workflow_run.conclusion == 'success'
     steps:
       # Trusted code only: the base repo's default branch, no ref override.
@@ -142,7 +142,7 @@ jobs:
 
   # An analyze failure routes here instead of silently skipping the post job.
   surface-analyze-failure:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     if: github.event.workflow_run.conclusion == 'failure'
     steps:
       - name: Mint posting token

--- a/daydream/templates/workflows/daydream-review.yml
+++ b/daydream/templates/workflows/daydream-review.yml
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   analyze:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.head.repo.full_name == github.repository &&

--- a/daydream/templates/workflows/single/daydream.yml
+++ b/daydream/templates/workflows/single/daydream.yml
@@ -37,7 +37,7 @@ jobs:
   # Decides whether to proceed and resolves the PR number. Holds the App key for
   # the 👀 acknowledgement but never checks out code, so it may be privileged.
   gate:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     # Auto-review a same-repo PR on open (unless disabled), OR a trusted, non-bot
     # `@<bot> review` comment on a PR. Fork auto-review is intentionally excluded
     # (fork PRs get no secrets); forks are served by the comment path.
@@ -108,7 +108,7 @@ jobs:
   analyze:
     needs: gate
     if: needs.gate.outputs.proceed == 'true'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
       pull-requests: read
@@ -172,7 +172,7 @@ jobs:
   post:
     needs: [gate, analyze]
     if: needs.gate.outputs.proceed == 'true' && needs.analyze.result == 'success'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     # Same-run artifact download needs no GITHUB_TOKEN scope (that is only required
     # to reach across runs); the App token carries every write.
     permissions: {}
@@ -232,7 +232,7 @@ jobs:
   surface-failure:
     needs: [gate, analyze]
     if: always() && needs.gate.outputs.proceed == 'true' && needs.analyze.result != 'success'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions: {}
     steps:
       - name: Mint posting token

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -8,6 +8,40 @@ set -euo pipefail
 
 echo "Running pre-push checks..."
 
+# Reject unsigned commits: every pushed commit must carry an SSH signature.
+echo "→ Verifying commit signatures..."
+while read -r _local_ref local_sha remote_ref remote_sha; do
+    # Skip delete operations and empty refs
+    if [ -z "${local_sha:-}" ] || [ "$local_sha" = "0000000000000000000000000000000000000000" ]; then
+        continue
+    fi
+
+    # Range of commits to check, excluding those already on any remote branch
+    if [ -z "${remote_sha:-}" ] || [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
+        range="$local_sha --not --remotes=origin"
+    else
+        range="$local_sha --not $remote_sha --remotes=origin"
+    fi
+
+    unsigned_commits=$(git log --format='%H %G?' $range 2>/dev/null | grep -E ' N$' | cut -d' ' -f1 || true)
+
+    if [ -n "$unsigned_commits" ]; then
+        echo "ERROR: The following commits are not signed:"
+        for commit in $unsigned_commits; do
+            echo "  - $(git log -1 --format='%h %s' "$commit")"
+        done
+        echo ""
+        echo "To sign commits, ensure:"
+        echo "  1. git config --global commit.gpgsign true"
+        echo "  2. Your SSH key is loaded: ssh-add -l"
+        echo ""
+        echo "To sign existing commits: git rebase --exec 'git commit --amend --no-edit -S' HEAD~N"
+        exit 1
+    fi
+done
+
+echo "All commits are signed."
+
 # Must run before any `uv run` below: `uv run`/`uv sync` silently re-lock a
 # drifted uv.lock, which would mask a release that bumped the version but forgot
 # `uv lock`. `--check` is read-only and errors on drift. CI re-runs this on a

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -10,23 +10,26 @@ echo "Running pre-push checks..."
 
 # Reject unsigned commits: every pushed commit must carry an SSH signature.
 echo "→ Verifying commit signatures..."
+remote_name="${1:-origin}"
 while read -r _local_ref local_sha remote_ref remote_sha; do
     # Skip delete operations and empty refs
     if [ -z "${local_sha:-}" ] || [ "$local_sha" = "0000000000000000000000000000000000000000" ]; then
         continue
     fi
 
-    # Range of commits to check, excluding those already on any remote branch
+    # Range of commits to check, excluding those already on the destination remote
     if [ -z "${remote_sha:-}" ] || [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
-        range="$local_sha --not --remotes=origin"
+        range="$local_sha --not --remotes=$remote_name"
     else
-        range="$local_sha --not $remote_sha --remotes=origin"
+        range="$local_sha --not $remote_sha --remotes=$remote_name"
     fi
 
-    unsigned_commits=$(git log --format='%H %G?' $range 2>/dev/null | grep -E ' N$' | cut -d' ' -f1 || true)
+    # Accept only 'G' (good signature): reject unsigned plus bad/error/unknown/
+    # expired/revoked signatures (%G? -> B, E, U, X, Y, R, T, N, ?)
+    unsigned_commits=$(git log --format='%H %G?' $range 2>/dev/null | grep -vE ' G$' | cut -d' ' -f1 || true)
 
     if [ -n "$unsigned_commits" ]; then
-        echo "ERROR: The following commits are not signed:"
+        echo "ERROR: The following commits do not carry a valid signature:"
         for commit in $unsigned_commits; do
             echo "  - $(git log -1 --format='%h %s' "$commit")"
         done
@@ -40,7 +43,7 @@ while read -r _local_ref local_sha remote_ref remote_sha; do
     fi
 done
 
-echo "All commits are signed."
+echo "All commits carry a valid signature."
 
 # Must run before any `uv run` below: `uv run`/`uv sync` silently re-lock a
 # drifted uv.lock, which would mask a release that bumped the version but forgot

--- a/tests/test_subprocess_lifecycle.py
+++ b/tests/test_subprocess_lifecycle.py
@@ -68,7 +68,7 @@ async def test_terminate_process_releases_fds() -> None:
     base = _fd_count()
     proc = await _spawn_holder()
     await terminate_process(proc)
-    assert _fd_count() == base
+    await _wait_for_fd_count(base)
 
 
 async def test_terminate_process_is_idempotent() -> None:
@@ -90,7 +90,7 @@ async def test_cancel_processes_kills_groups_and_releases_fds() -> None:
 
     for pgid in pgids:
         await _wait_for_group_gone(pgid)
-    assert _fd_count() == base
+    await _wait_for_fd_count(base)
 
 
 async def _wait_for_file(path: Path, *, timeout_s: float = 60.0) -> None:
@@ -135,6 +135,27 @@ async def _wait_for_group_gone(pgid: int, *, timeout_s: float = 10.0) -> None:
             return
         if loop.time() > deadline:
             raise TimeoutError(f"process group {pgid} still alive after {timeout_s}s")
+        await asyncio.sleep(0.01)
+
+
+async def _wait_for_fd_count(base: int, *, timeout_s: float = 10.0) -> None:
+    """Await the fd count's return to *base* (a readiness wait, not a fixed sleep).
+
+    The transport close releases the pipe fds, but the release lands in the
+    event loop's connection_lost processing — asserting equality in the same
+    tick as teardown races the loop on a loaded host (CI runners, parallel
+    suites), the same failure mode ``_wait_for_group_gone`` documents. Polling
+    until the count returns makes the assertion deterministic; the loop exits
+    the moment the baseline is reached and the timeout is a failure bound, not
+    a synchronization delay.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_s
+    while _fd_count() != base:
+        if loop.time() > deadline:
+            raise TimeoutError(
+                f"fd count {_fd_count()} did not return to baseline {base} after {timeout_s}s"
+            )
         await asyncio.sleep(0.01)
 
 
@@ -218,4 +239,4 @@ async def test_runner_run_aborted_improve_reaps_group_and_releases_fds(
 
     assert pgid is not None
     await _wait_for_group_gone(pgid)
-    assert _fd_count() == base_fds
+    await _wait_for_fd_count(base_fds)


### PR DESCRIPTION
Convert all workflows (incl. templates) to Blacksmith runners, and add a pre-push hook that rejects unsigned commits.

- `ci.yml`, `daydream-command.yml`, `daydream-post.yml`, `daydream-review.yml`: ubuntu-latest → blacksmith runners
- `daydream/templates/workflows/*` (+ single/daydream.yml): same conversion so generated workflows inherit it
- `scripts/hooks/pre-push`: reject unsigned commits (commit.gpgsign enforced)