### PR TITLE
fix(fix-phase): bound fix loop to reviewed-diff scope — auto-fix in-scope only, file issues for out-of-scope-but-valid changes

### DIFF
--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -1944,6 +1944,138 @@ def _file_out_of_scope_issue(ctx: FlowContext, item: dict[str, Any]) -> None:
         print_warning(console, f"Could not file out-of-scope finding '{file}' as issue: {exc}")
 
 
+def _file_reverted_edit_issue(repo: Path, path: str, patch: str) -> None:
+    """Best-effort: file one reverted out-of-scope edit as a tracked GitHub issue.
+
+    Issue #336 — the post-fix residual check reverts edits the fix pass made
+    outside the reviewed diff. The reverted edit is still *valid* work, so it
+    is filed as an issue (with the diff as evidence) instead of being lost.
+    Filing is best-effort: a failed ``gh issue create`` logs a warning and the
+    revert stands regardless.
+    """
+    from daydream import git_ops
+
+    title = f"[daydream] out-of-scope edit reverted: {path}"
+    body = (
+        f"The fix pass edited `{path}`, which is outside the reviewed diff. "
+        f"The edit was reverted and is filed here for review.\n\n"
+        f"```diff\n{patch}\n```\n\n"
+        "Filed by daydream fix loop: out of scope for PR."
+    )
+    try:
+        url = git_ops.gh_issue_create(repo, title=title, body=body)
+        print_warning(console, f"Filed out-of-scope edit as issue: {url}")
+    except Exception as exc:  # noqa: BLE001 -- best-effort issue filing
+        print_warning(console, f"Could not file out-of-scope edit '{path}' as issue: {exc}")
+
+
+def _revert_out_of_scope_edits(
+    work: WorkContext,
+    *,
+    pre_fix_ref: str,
+    snapshot_captured: bool,
+    pre_fix_untracked: set[str],
+    changed_files: set[str] | None,
+    finding_files: set[str],
+) -> list[str]:
+    """Revert post-fix edits outside the reviewed diff; file an issue per residual.
+
+    Issue #336 (Task 4): after ``phase_fix_parallel`` returns, enumerate the
+    files the fix pass actually edited (vs the pre-fix snapshot) and subtract
+    the allowed set — the finding files, the reviewed-diff file set, and
+    newly-created generated files. Every residual is reverted unconditionally to
+    its pre-fix content (``git checkout <ref> -- <file>``, the same mechanism
+    the generated-file guard uses) and filed as a best-effort GitHub issue
+    carrying the edit's diff as evidence, so the commit step can never land an
+    edit outside the reviewed diff.
+
+    Only TRACKED edits are considered: a path present at *pre_fix_ref*. Newly
+    created untracked files (e.g. the test harness's ``.fixed-*`` sentinels)
+    have no pre-fix content to restore to and are governed by the generated-file
+    guard and the leftover-untracked bookkeeping instead.
+
+    Args:
+        work: The run's workspace (``work.repo`` is the git working dir).
+        pre_fix_ref: ``git stash create`` SHA captured before fixes, or ``HEAD``
+            when the pre-fix tracked tree was clean.
+        snapshot_captured: Whether the pre-fix snapshot exists. When False the
+            baseline is untrustworthy — skip with a warning rather than guess.
+        pre_fix_untracked: Untracked paths present before the fix pass.
+        changed_files: The reviewed diff's file set, or ``None`` when no diff
+            context is available (resume) — then only finding-file scope is
+            enforced and a warning is logged.
+        finding_files: Files named by the findings being fixed.
+
+    Returns:
+        The repo-relative paths that were reverted (empty when none).
+    """
+    from daydream import git_ops
+    from daydream.git_ops import GitError
+
+    if not snapshot_captured:
+        print_warning(
+            console,
+            "Post-fix scope check skipped: no trustworthy pre-fix snapshot "
+            "(cannot judge which edits the fix pass made).",
+        )
+        return []
+
+    repo = work.repo
+    try:
+        edited = set(
+            git_ops.changed_files_against(repo, pre_fix_ref, preexisting_untracked=pre_fix_untracked)
+        )
+    except GitError as exc:
+        print_warning(console, f"Post-fix scope check skipped: could not enumerate edited files: {exc}")
+        return []
+
+    allowed = set(finding_files)
+    if changed_files:
+        allowed |= set(changed_files)
+    else:
+        print_warning(
+            console,
+            "Post-fix scope check: no reviewed-diff file set; enforcing finding-file scope only.",
+        )
+    # Newly-created generated files (e.g. new migrations) are deliberately
+    # permitted by the generated-file guard; never treat them as residuals here.
+    allowed |= {path for path in edited if is_generated_file(path)}
+
+    residual: list[str] = []
+    for path in sorted(edited):
+        # Only tracked files (present at the pre-fix ref) are revertible to a
+        # pre-fix baseline; skip untracked new files (see docstring).
+        try:
+            git_ops.show(repo, pre_fix_ref, path)
+        except GitError:
+            continue
+        if path in allowed:
+            continue
+        residual.append(path)
+
+    for path in residual:
+        # Capture the diff as evidence BEFORE reverting (the revert destroys it).
+        try:
+            patch = git_ops.diff_worktree_against(repo, pre_fix_ref, [path])
+        except GitError as exc:
+            patch = ""
+            print_warning(console, f"Could not diff out-of-scope edit '{path}': {exc}")
+        # Revert unconditionally — same mechanism as the generated-file guard.
+        try:
+            git_ops.restore_paths_from_ref(repo, pre_fix_ref, [path])
+        except GitError as exc:
+            print_warning(console, f"Could not revert out-of-scope edit '{path}': {exc}")
+            continue
+        _file_reverted_edit_issue(repo, path, patch)
+    if residual:
+        print_warning(
+            console,
+            f"Reverted {len(residual)} post-fix edit(s) outside the reviewed diff and "
+            f"filed issue(s): {residual}.",
+        )
+    return residual
+
+
 async def _step_fix_gate(ctx: FlowContext) -> Stop | None:
     """Fix-apply gate; on accept, load and severity-sort the canonical items."""
     # Fix-apply gate across the two interaction axes. ``--yes`` auto-applies;
@@ -2593,6 +2725,21 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
     )
     if generated_guard_result is None:
         return Stop(1)
+    # Issue #336 (Task 4) — post-fix residual scope check: revert any edit the
+    # fix pass made outside the reviewed diff and file an issue per residual, so
+    # the commit step below can only land in-scope changes. Runs AFTER the
+    # generated-file guard (which already reverted generated-file edits, so no
+    # double-revert) and BEFORE the quality gate (which then measures the
+    # now-scoped edited set).
+    pre_fix_ref = pre_fix_snapshot or "HEAD"
+    _revert_out_of_scope_edits(
+        work,
+        pre_fix_ref=pre_fix_ref,
+        snapshot_captured=pre_fix_snapshot_captured,
+        pre_fix_untracked=pre_fix_untracked,
+        changed_files=changed_files,
+        finding_files={item["file"] for item in ctx.data["items"] if item.get("file")},
+    )
     # Issue #315: post-fix anti-degradation gate over the files the fix phase
     # edited. Tree is post-fix here (every applied or budget-preserved fix is
     # intact); a regression is flagged and surfaced, never fatal.
@@ -2612,7 +2759,6 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
     quality_candidates: set[str] | None
     if quality_gate_enabled:
         try:
-            pre_fix_ref = pre_fix_snapshot or "HEAD"
             changed_after_fix = git_ops.changed_files_against(
                 work.repo, pre_fix_ref, preexisting_untracked=pre_fix_untracked
             )

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -1914,6 +1914,24 @@ async def _step_post_review(ctx: FlowContext) -> Stop | None:
     return None
 
 
+def _file_scope_issue(repo: Path, *, title: str, body: str, noun: str, ident: str) -> None:
+    """Best-effort: file one scope-related GitHub issue; never raise.
+
+    Shared by the out-of-scope *finding* router (pre-fix gate) and the
+    reverted *edit* filer (post-fix residual net). Issue #336 — both file a
+    tracked issue for work the fix loop will not land in the PR. Filing is
+    best-effort: a failed ``gh issue create`` (no auth, cross-org, offline)
+    logs a warning and the scope decision (exclude / revert) stands regardless.
+    """
+    from daydream import git_ops
+
+    try:
+        url = git_ops.gh_issue_create(repo, title=title, body=body)
+        print_warning(console, f"Filed out-of-scope {noun} as issue: {url}")
+    except Exception as exc:  # noqa: BLE001 -- best-effort issue filing
+        print_warning(console, f"Could not file out-of-scope {noun} '{ident}' as issue: {exc}")
+
+
 def _file_out_of_scope_issue(ctx: FlowContext, item: dict[str, Any]) -> None:
     """Best-effort: file one out-of-scope finding as a tracked GitHub issue.
 
@@ -1924,8 +1942,6 @@ def _file_out_of_scope_issue(ctx: FlowContext, item: dict[str, Any]) -> None:
     cross-org, offline) logs a warning and the item is still excluded from
     auto-fix — the scope decision never depends on issue-filing success.
     """
-    from daydream import git_ops
-
     file = item.get("file") or "<unknown>"
     description = item.get("description", "No description")
     evidence = item.get("evidence", "")
@@ -1937,11 +1953,7 @@ def _file_out_of_scope_issue(ctx: FlowContext, item: dict[str, Any]) -> None:
         f"- Evidence: {evidence}\n\n"
         "Filed by daydream fix loop: out of scope for PR."
     )
-    try:
-        url = git_ops.gh_issue_create(ctx.work.repo, title=title, body=body)
-        print_warning(console, f"Filed out-of-scope finding as issue: {url}")
-    except Exception as exc:  # noqa: BLE001 -- best-effort issue filing
-        print_warning(console, f"Could not file out-of-scope finding '{file}' as issue: {exc}")
+    _file_scope_issue(ctx.work.repo, title=title, body=body, noun="finding", ident=file)
 
 
 def _file_reverted_edit_issue(repo: Path, path: str, patch: str) -> None:
@@ -1953,8 +1965,6 @@ def _file_reverted_edit_issue(repo: Path, path: str, patch: str) -> None:
     Filing is best-effort: a failed ``gh issue create`` logs a warning and the
     revert stands regardless.
     """
-    from daydream import git_ops
-
     title = f"[daydream] out-of-scope edit reverted: {path}"
     body = (
         f"The fix pass edited `{path}`, which is outside the reviewed diff. "
@@ -1962,11 +1972,7 @@ def _file_reverted_edit_issue(repo: Path, path: str, patch: str) -> None:
         f"```diff\n{patch}\n```\n\n"
         "Filed by daydream fix loop: out of scope for PR."
     )
-    try:
-        url = git_ops.gh_issue_create(repo, title=title, body=body)
-        print_warning(console, f"Filed out-of-scope edit as issue: {url}")
-    except Exception as exc:  # noqa: BLE001 -- best-effort issue filing
-        print_warning(console, f"Could not file out-of-scope edit '{path}' as issue: {exc}")
+    _file_scope_issue(repo, title=title, body=body, noun="edit", ident=path)
 
 
 def _revert_out_of_scope_edits(
@@ -1977,7 +1983,7 @@ def _revert_out_of_scope_edits(
     pre_fix_untracked: set[str],
     changed_files: set[str] | None,
     finding_files: set[str],
-) -> list[str]:
+) -> list[str] | None:
     """Revert post-fix edits outside the reviewed diff; file an issue per residual.
 
     Issue #336 (Task 4): after ``phase_fix_parallel`` returns, enumerate the
@@ -2007,7 +2013,9 @@ def _revert_out_of_scope_edits(
         finding_files: Files named by the findings being fixed.
 
     Returns:
-        The repo-relative paths that were reverted (empty when none).
+        The repo-relative paths that were reverted (empty when none), or ``None``
+        when any revert failed — matching the generated-file guard, the caller
+        aborts the run so an unreverted out-of-scope edit never reaches commit.
     """
     from daydream import git_ops
     from daydream.git_ops import GitError
@@ -2053,6 +2061,7 @@ def _revert_out_of_scope_edits(
             continue
         residual.append(path)
 
+    restoration_failed = False
     for path in residual:
         # Capture the diff as evidence BEFORE reverting (the revert destroys it).
         try:
@@ -2065,6 +2074,12 @@ def _revert_out_of_scope_edits(
             git_ops.restore_paths_from_ref(repo, pre_fix_ref, [path])
         except GitError as exc:
             print_warning(console, f"Could not revert out-of-scope edit '{path}': {exc}")
+            # Fail-close to match the sibling generated-file guard: an
+            # unreverted out-of-scope edit must never reach the commit step
+            # (the whole point of this net), so signal abort rather than leave
+            # the edit in the worktree. Continue so remaining residuals are
+            # still best-effort reverted before the abort is signalled.
+            restoration_failed = True
             continue
         _file_reverted_edit_issue(repo, path, patch)
     if residual:
@@ -2073,7 +2088,7 @@ def _revert_out_of_scope_edits(
             f"Reverted {len(residual)} post-fix edit(s) outside the reviewed diff and "
             f"filed issue(s): {residual}.",
         )
-    return residual
+    return None if restoration_failed else residual
 
 
 async def _step_fix_gate(ctx: FlowContext) -> Stop | None:
@@ -2101,13 +2116,19 @@ async def _step_fix_gate(ctx: FlowContext) -> Stop | None:
         print_success(console, "No actionable items -- done.")
         return Stop(0)
 
-    # Issue #336 — pre-fix scope partition. When the reviewed diff's file set is
-    # known, findings on files OUTSIDE that set are filed as GitHub issues
-    # (best-effort) and excluded from auto-fix: the loop must not expand the
-    # PR's scope. Without a diff file set (no diff context, e.g. a resume that
-    # lost ctx.data["diff"]) no partition happens — every item auto-fixes as
-    # today, because scope cannot be judged without the diff.
+    # Issue #336 — pre-fix scope partition. Findings on files OUTSIDE the
+    # reviewed diff are filed as GitHub issues (best-effort) and excluded from
+    # auto-fix: the loop must not expand the PR's scope. The reviewed-diff file
+    # set is computed once in the preamble and carried in ctx.data; on a
+    # ``--start-at fix`` resume that lost it but retained ``diff`` it is
+    # recomputed via _diff_changed_files, mirroring _step_fix, so the gate and
+    # the post-fix residual net agree on the allowed set (a divergence left the
+    # residual net strictly weaker than the gate on that resume path).
     changed_files: set[str] | None = ctx.data.get("changed_files")
+    if changed_files is None:
+        diff_str = ctx.data.get("diff") or ""
+        if diff_str:
+            changed_files = set(_diff_changed_files(diff_str))
     if changed_files:
         in_scope: list[dict[str, Any]] = []
         out_of_scope: list[dict[str, Any]] = []
@@ -2732,7 +2753,7 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
     # double-revert) and BEFORE the quality gate (which then measures the
     # now-scoped edited set).
     pre_fix_ref = pre_fix_snapshot or "HEAD"
-    _revert_out_of_scope_edits(
+    residual_guard_result = _revert_out_of_scope_edits(
         work,
         pre_fix_ref=pre_fix_ref,
         snapshot_captured=pre_fix_snapshot_captured,
@@ -2740,6 +2761,10 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
         changed_files=changed_files,
         finding_files={item["file"] for item in ctx.data["items"] if item.get("file")},
     )
+    if residual_guard_result is None:
+        # Fail-close to match the generated-file guard: an unreverted
+        # out-of-scope edit must never reach the commit step.
+        return Stop(1)
     # Issue #315: post-fix anti-degradation gate over the files the fix phase
     # edited. Tree is post-fix here (every applied or budget-preserved fix is
     # intact); a regression is flagged and surfaced, never fatal.

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -1932,26 +1932,79 @@ def _file_scope_issue(repo: Path, *, title: str, body: str, noun: str, ident: st
         print_warning(console, f"Could not file out-of-scope {noun} '{ident}' as issue: {exc}")
 
 
+def _scope_finding_fingerprint(item: dict[str, Any]) -> str:
+    """Stable cross-run identity for an out-of-scope finding.
+
+    Reuses :func:`daydream.pr_review.compute_fingerprint` (path + normalized
+    description + rationale), so minor wording drift across runs still maps to
+    the same fingerprint and a re-review reproducing an out-of-scope finding is
+    recognized as already-filed.
+    """
+    from daydream.pr_review import compute_fingerprint
+
+    return compute_fingerprint(
+        item.get("file") or "",
+        item.get("description", ""),
+        item.get("evidence", ""),
+    )
+
+
+def _scope_finding_marker(fingerprint: str) -> str:
+    """Hidden HTML comment embedding a finding fingerprint in an issue body.
+
+    Distinct from :func:`daydream.pr_review.finding_marker` (the PR-comment
+    store) so the two stores never collide: scope issues are deduped only
+    against scope issues, PR comments only against PR comments.
+    """
+    return f"<!-- daydream-scope-finding: {fingerprint} -->"
+
+
+def _scope_finding_already_filed(repo: Path, item: dict[str, Any]) -> bool:
+    """Best-effort: has an open issue already filed this out-of-scope finding?
+
+    Issue #336 — out-of-scope findings are never fixed, so a re-run/resume
+    re-derives them and would re-file a duplicate issue every time. GitHub is
+    the store: scan open issues for the finding's fingerprint marker and skip
+    filing when present. Best-effort — a failed ``gh issue list`` returns
+    ``False`` so the call degrades to filing (the prior behavior) rather than
+    silently dropping the finding.
+    """
+    from daydream import git_ops
+
+    marker = _scope_finding_marker(_scope_finding_fingerprint(item))
+    try:
+        issues = git_ops.gh_issue_list(repo, search="out-of-scope")
+    except Exception:  # noqa: BLE001 -- best-effort dedup lookup
+        return False
+    return any(marker in (issue.get("body") or "") for issue in issues)
+
+
 def _file_out_of_scope_issue(ctx: FlowContext, item: dict[str, Any]) -> None:
     """Best-effort: file one out-of-scope finding as a tracked GitHub issue.
 
     Issue #336 — the fix loop auto-fixes only findings inside the reviewed
     diff. A finding on a file outside the diff is still *valid*, so instead of
     silently dropping it we route it to a GitHub issue where it stays tracked.
-    Filing is best-effort by design: a failed ``gh issue create`` (no auth,
+    Cross-run dedup: the finding's fingerprint is embedded as a hidden marker
+    in the body, and a re-run/resume skips filing when an open issue already
+    carries it, so the same out-of-scope finding is filed once, not on every
+    run. Filing is best-effort by design: a failed ``gh issue create`` (no auth,
     cross-org, offline) logs a warning and the item is still excluded from
     auto-fix — the scope decision never depends on issue-filing success.
     """
     file = item.get("file") or "<unknown>"
     description = item.get("description", "No description")
     evidence = item.get("evidence", "")
+    if _scope_finding_already_filed(ctx.work.repo, item):
+        return
     title = f"[daydream] out-of-scope finding: {file}"
     body = (
         f"{description}\n\n"
         f"- File: `{file}`\n"
         f"- Line: {item.get('line', '?')}\n"
         f"- Evidence: {evidence}\n\n"
-        "Filed by daydream fix loop: out of scope for PR."
+        "Filed by daydream fix loop: out of scope for PR.\n"
+        f"{_scope_finding_marker(_scope_finding_fingerprint(item))}"
     )
     _file_scope_issue(ctx.work.repo, title=title, body=body, noun="finding", ident=file)
 
@@ -2091,6 +2144,26 @@ def _revert_out_of_scope_edits(
     return None if restoration_failed else residual
 
 
+def _resolve_changed_files(ctx: FlowContext) -> set[str] | None:
+    """Resolve the reviewed-diff file set for the fix-loop scope bound.
+
+    Issue #336 — the reviewed-diff file set is computed once in the
+    ``_run_review_spine`` preamble and carried in ``ctx.data["changed_files"]``.
+    On a ``--start-at fix`` resume that lost it but retained ``diff`` it is
+    recomputed via ``_diff_changed_files``. Shared by ``_step_fix_gate`` (the
+    pre-fix partition) and ``_step_fix`` (the post-fix residual net + the
+    "Allowed files" prompt clause) so the gate and the net agree on the allowed
+    set — a divergence left the residual net strictly weaker than the gate on
+    the resume path.
+    """
+    changed_files: set[str] | None = ctx.data.get("changed_files")
+    if changed_files is None:
+        diff_str = ctx.data.get("diff") or ""
+        if diff_str:
+            changed_files = set(_diff_changed_files(diff_str))
+    return changed_files
+
+
 async def _step_fix_gate(ctx: FlowContext) -> Stop | None:
     """Fix-apply gate; on accept, load and severity-sort the canonical items."""
     # Fix-apply gate across the two interaction axes. ``--yes`` auto-applies;
@@ -2119,16 +2192,10 @@ async def _step_fix_gate(ctx: FlowContext) -> Stop | None:
     # Issue #336 — pre-fix scope partition. Findings on files OUTSIDE the
     # reviewed diff are filed as GitHub issues (best-effort) and excluded from
     # auto-fix: the loop must not expand the PR's scope. The reviewed-diff file
-    # set is computed once in the preamble and carried in ctx.data; on a
-    # ``--start-at fix`` resume that lost it but retained ``diff`` it is
-    # recomputed via _diff_changed_files, mirroring _step_fix, so the gate and
-    # the post-fix residual net agree on the allowed set (a divergence left the
-    # residual net strictly weaker than the gate on that resume path).
-    changed_files: set[str] | None = ctx.data.get("changed_files")
-    if changed_files is None:
-        diff_str = ctx.data.get("diff") or ""
-        if diff_str:
-            changed_files = set(_diff_changed_files(diff_str))
+    # set is resolved via _resolve_changed_files (shared with _step_fix) so the
+    # gate and the post-fix residual net agree on the allowed set (a divergence
+    # left the residual net strictly weaker than the gate on the resume path).
+    changed_files = _resolve_changed_files(ctx)
     if changed_files:
         in_scope: list[dict[str, Any]] = []
         out_of_scope: list[dict[str, Any]] = []
@@ -2650,14 +2717,10 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
     # Issue #336 — fix-loop scope bound. Thread the reviewed diff's file set
     # into every fix prompt as an explicit "Allowed files" clause. ``None``
     # (no diff context, e.g. a resume that lost ctx.data["diff"]) leaves the
-    # prompt unchanged; the prose scope boundary still applies. Recomputable
-    # from ctx.data["diff"] via _diff_changed_files so a missing key never
-    # crashes.
-    changed_files: set[str] | None = ctx.data.get("changed_files")
-    if changed_files is None:
-        diff_str = ctx.data.get("diff") or ""
-        if diff_str:
-            changed_files = set(_diff_changed_files(diff_str))
+    # prompt unchanged; the prose scope boundary still applies. Resolved via
+    # _resolve_changed_files (shared with the gate) so a missing key never
+    # crashes and the gate and post-fix residual net agree on the allowed set.
+    changed_files = _resolve_changed_files(ctx)
     async with phase_scope(DaydreamPhase.FIX):
         fix_failures = await phase_fix_parallel(
             ctx.backend_for("fix"),

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -2442,6 +2442,17 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
         quality_before, quality_before_unavailable = await _capture_quality_before(daydream_dir)
     else:
         quality_before, quality_before_unavailable = None, None
+    # Issue #336 — fix-loop scope bound. Thread the reviewed diff's file set
+    # into every fix prompt as an explicit "Allowed files" clause. ``None``
+    # (no diff context, e.g. a resume that lost ctx.data["diff"]) leaves the
+    # prompt unchanged; the prose scope boundary still applies. Recomputable
+    # from ctx.data["diff"] via _diff_changed_files so a missing key never
+    # crashes.
+    changed_files: set[str] | None = ctx.data.get("changed_files")
+    if changed_files is None:
+        diff_str = ctx.data.get("diff") or ""
+        if diff_str:
+            changed_files = set(_diff_changed_files(diff_str))
     async with phase_scope(DaydreamPhase.FIX):
         fix_failures = await phase_fix_parallel(
             ctx.backend_for("fix"),
@@ -2450,6 +2461,7 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
             intent_path=intent_p if (intent_grounded_this_run and intent_p.exists()) else None,
             group_max_wall_s=group_wall_s,
             group_max_serial_items=group_serial,
+            changed_files=changed_files,
         )
     # Capture daydream's proposed diff (pre-fix tree → post-fix worktree)
     # NOW, before the fix-failure and test-failure early returns below, so
@@ -3200,6 +3212,13 @@ async def _run_review_spine(config: RunConfig, work: WorkContext, mode: str) -> 
             data={
                 "mode": mode,
                 "diff": diff,
+                # Issue #336 — fix-loop scope bound. The reviewed diff's file
+                # set threads through ctx.data so the fix gate can partition
+                # out-of-scope findings (Task 3) and the fix step can both
+                # forward it into the fix prompt (Task 2) and run a post-fix
+                # residual check (Task 4). Recomputable from "diff" via
+                # ``_diff_changed_files``; a missing key never crashes.
+                "changed_files": set(changed_files),
                 "diff_path": diff_path,
                 "tier": tier,
                 "dd": dd,

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -1959,7 +1959,7 @@ def _scope_finding_marker(fingerprint: str) -> str:
     return f"<!-- daydream-scope-finding: {fingerprint} -->"
 
 
-def _scope_finding_already_filed(repo: Path, item: dict[str, Any]) -> bool:
+def _scope_finding_already_filed(repo: Path, marker: str) -> bool:
     """Best-effort: has an open issue already filed this out-of-scope finding?
 
     Issue #336 — out-of-scope findings are never fixed, so a re-run/resume
@@ -1968,10 +1968,13 @@ def _scope_finding_already_filed(repo: Path, item: dict[str, Any]) -> bool:
     filing when present. Best-effort — a failed ``gh issue list`` returns
     ``False`` so the call degrades to filing (the prior behavior) rather than
     silently dropping the finding.
+
+    The marker is computed once by the caller (``_file_out_of_scope_issue``)
+    and threaded in, so the finding's fingerprint is not recomputed for both
+    the dedup lookup and the issue body.
     """
     from daydream import git_ops
 
-    marker = _scope_finding_marker(_scope_finding_fingerprint(item))
     try:
         issues = git_ops.gh_issue_list(repo, search="out-of-scope")
     except Exception:  # noqa: BLE001 -- best-effort dedup lookup
@@ -1995,7 +1998,10 @@ def _file_out_of_scope_issue(ctx: FlowContext, item: dict[str, Any]) -> None:
     file = item.get("file") or "<unknown>"
     description = item.get("description", "No description")
     evidence = item.get("evidence", "")
-    if _scope_finding_already_filed(ctx.work.repo, item):
+    # Compute the fingerprint marker once and thread it into both the dedup
+    # lookup and the issue body, rather than recomputing it for each.
+    marker = _scope_finding_marker(_scope_finding_fingerprint(item))
+    if _scope_finding_already_filed(ctx.work.repo, marker):
         return
     title = f"[daydream] out-of-scope finding: {file}"
     body = (
@@ -2004,7 +2010,7 @@ def _file_out_of_scope_issue(ctx: FlowContext, item: dict[str, Any]) -> None:
         f"- Line: {item.get('line', '?')}\n"
         f"- Evidence: {evidence}\n\n"
         "Filed by daydream fix loop: out of scope for PR.\n"
-        f"{_scope_finding_marker(_scope_finding_fingerprint(item))}"
+        f"{marker}"
     )
     _file_scope_issue(ctx.work.repo, title=title, body=body, noun="finding", ident=file)
 
@@ -2091,7 +2097,7 @@ def _revert_out_of_scope_edits(
         return []
 
     allowed = set(finding_files)
-    if changed_files:
+    if changed_files is not None:
         allowed |= set(changed_files)
     else:
         print_warning(
@@ -2196,7 +2202,7 @@ async def _step_fix_gate(ctx: FlowContext) -> Stop | None:
     # gate and the post-fix residual net agree on the allowed set (a divergence
     # left the residual net strictly weaker than the gate on the resume path).
     changed_files = _resolve_changed_files(ctx)
-    if changed_files:
+    if changed_files is not None:
         in_scope: list[dict[str, Any]] = []
         out_of_scope: list[dict[str, Any]] = []
         for item in items:
@@ -2210,6 +2216,19 @@ async def _step_fix_gate(ctx: FlowContext) -> Stop | None:
                 "issue(s), not fixed.",
             )
         items = in_scope
+        # Issue #336 — every finding routed to issues leaves nothing to
+        # auto-fix, so short-circuit before a no-op fix pass, a full target
+        # test-suite run, and a commit-agent turn. Matches the pre-partition
+        # "no actionable items" Stop(0) above. Keying on identity (``is not
+        # None``) distinguishes an empty reviewed diff — every file is out of
+        # scope, so all findings are filed and the run ends — from ``None``,
+        # which skips the partition entirely because scope cannot be judged.
+        if not items:
+            print_success(
+                console,
+                "All findings outside the reviewed diff -- filed as issues, nothing to fix.",
+            )
+            return Stop(0)
 
     # Severity-ordered (high before medium before low), stable within a
     # tier so equal-severity items keep their canonical merge order.

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -1914,6 +1914,36 @@ async def _step_post_review(ctx: FlowContext) -> Stop | None:
     return None
 
 
+def _file_out_of_scope_issue(ctx: FlowContext, item: dict[str, Any]) -> None:
+    """Best-effort: file one out-of-scope finding as a tracked GitHub issue.
+
+    Issue #336 — the fix loop auto-fixes only findings inside the reviewed
+    diff. A finding on a file outside the diff is still *valid*, so instead of
+    silently dropping it we route it to a GitHub issue where it stays tracked.
+    Filing is best-effort by design: a failed ``gh issue create`` (no auth,
+    cross-org, offline) logs a warning and the item is still excluded from
+    auto-fix — the scope decision never depends on issue-filing success.
+    """
+    from daydream import git_ops
+
+    file = item.get("file") or "<unknown>"
+    description = item.get("description", "No description")
+    evidence = item.get("evidence", "")
+    title = f"[daydream] out-of-scope finding: {file}"
+    body = (
+        f"{description}\n\n"
+        f"- File: `{file}`\n"
+        f"- Line: {item.get('line', '?')}\n"
+        f"- Evidence: {evidence}\n\n"
+        "Filed by daydream fix loop: out of scope for PR."
+    )
+    try:
+        url = git_ops.gh_issue_create(ctx.work.repo, title=title, body=body)
+        print_warning(console, f"Filed out-of-scope finding as issue: {url}")
+    except Exception as exc:  # noqa: BLE001 -- best-effort issue filing
+        print_warning(console, f"Could not file out-of-scope finding '{file}' as issue: {exc}")
+
+
 async def _step_fix_gate(ctx: FlowContext) -> Stop | None:
     """Fix-apply gate; on accept, load and severity-sort the canonical items."""
     # Fix-apply gate across the two interaction axes. ``--yes`` auto-applies;
@@ -1938,6 +1968,28 @@ async def _step_fix_gate(ctx: FlowContext) -> Stop | None:
     if not items:
         print_success(console, "No actionable items -- done.")
         return Stop(0)
+
+    # Issue #336 — pre-fix scope partition. When the reviewed diff's file set is
+    # known, findings on files OUTSIDE that set are filed as GitHub issues
+    # (best-effort) and excluded from auto-fix: the loop must not expand the
+    # PR's scope. Without a diff file set (no diff context, e.g. a resume that
+    # lost ctx.data["diff"]) no partition happens — every item auto-fixes as
+    # today, because scope cannot be judged without the diff.
+    changed_files: set[str] | None = ctx.data.get("changed_files")
+    if changed_files:
+        in_scope: list[dict[str, Any]] = []
+        out_of_scope: list[dict[str, Any]] = []
+        for item in items:
+            (in_scope if (item.get("file") or "") in changed_files else out_of_scope).append(item)
+        for item in out_of_scope:
+            _file_out_of_scope_issue(ctx, item)
+        if out_of_scope:
+            print_warning(
+                console,
+                f"{len(out_of_scope)} finding(s) outside the reviewed diff filed as "
+                "issue(s), not fixed.",
+            )
+        items = in_scope
 
     # Severity-ordered (high before medium before low), stable within a
     # tier so equal-severity items keep their canonical merge order.

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -1950,3 +1950,61 @@ def gh_issue_create(
     if proc.returncode != 0:
         raise _gh_error_for(f"gh issue create failed: {proc.stderr.strip()}", proc.stderr)
     return proc.stdout.strip()
+
+
+def gh_issue_list(
+    repo: Path,
+    *,
+    state: str = "open",
+    search: str | None = None,
+    limit: int = 100,
+    repo_slug: str | None = None,
+) -> list[dict[str, Any]]:
+    """List issues via ``gh issue list``; best-effort (empty list on failure).
+
+    Used by the fix loop (issue #336) for cross-run dedup of out-of-scope
+    findings filed as issues: before filing, the caller checks whether an open
+    issue already carries the finding's fingerprint marker, so a re-run/resume
+    does not re-file the same finding (GitHub is the store — same stateless
+    cross-run dedup model as :mod:`daydream.reconcile`). Best-effort by design
+    so a failed ``gh issue list`` (no auth, offline, cross-org) degrades to
+    filing rather than blocking the scope decision.
+
+    Args:
+        repo: Worktree the call is rooted in (cwd for ``gh``).
+        state: Issue state filter (``--state``); defaults to ``open``.
+        search: Optional ``--search`` qualifier to narrow results.
+        limit: Cap on the number of issues returned (``--limit``).
+        repo_slug: Explicit ``owner/repo`` target (``--repo``). When *None*
+            the ambient ``gh`` context (cwd) is used.
+
+    Returns:
+        List of issue dicts (``number``, ``title``, ``body``, ``url``) — empty
+        when no issues match or the call fails.
+    """
+    args: list[str] = [
+        "issue",
+        "list",
+        "--state",
+        state,
+        "--json",
+        "number,title,body,url",
+        "--limit",
+        str(limit),
+    ]
+    if search:
+        args += ["--search", search]
+    if repo_slug is not None:
+        args += ["--repo", repo_slug]
+    try:
+        proc = _run_gh(repo, args, retries=_gh_retries())
+    except GitError as exc:
+        _logger.warning("gh issue list failed (%s, returning []): %s", type(exc).__name__, exc)
+        return []
+    if proc.returncode != 0:
+        return []
+    try:
+        rows = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError:
+        return []
+    return rows if isinstance(rows, list) else []

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -1892,3 +1892,61 @@ def gh_pr_create(
     if proc.returncode != 0:
         raise _gh_error_for(f"gh pr create failed: {proc.stderr.strip()}", proc.stderr)
     return proc.stdout.strip()
+
+
+def gh_issue_create(
+    repo: Path,
+    *,
+    title: str,
+    body: str,
+    repo_slug: str | None = None,
+    labels: list[str] | None = None,
+) -> str:
+    """Open a GitHub issue via ``gh issue create`` and return its URL.
+
+    Used by the fix loop (issue #336) to route out-of-scope-but-valid findings
+    — files outside the reviewed diff or residuals after a fix round — into a
+    tracked issue instead of auto-applying them to the PR.
+
+    The body is written to a temp file and passed via ``--body-file`` so it
+    never appears on the process argument vector (process-list hygiene; bodies
+    can be large). Same pattern as ``gh secret set``'s stdin path.
+
+    Args:
+        repo: Worktree the call is rooted in (cwd for ``gh``).
+        title: Issue title (inline ``--title``).
+        body: Issue body markdown (written to a tempfile, passed as
+            ``--body-file``).
+        repo_slug: Explicit ``owner/repo`` target (``--repo``). When *None*
+            the ambient ``gh`` context (cwd) is used.
+        labels: Optional labels applied verbatim as repeated ``--label`` flags.
+            *None* (the default) emits no ``--label`` flag.
+
+    Returns:
+        The created issue's URL (parsed from ``gh``'s stdout).
+
+    Raises:
+        GitError: If the ``gh issue create`` call fails (stderr included).
+    """
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".md", delete=False, encoding="utf-8"
+    ) as bf:
+        bf.write(body)
+        body_path = bf.name
+    args: list[str] = ["issue", "create"]
+    if repo_slug is not None:
+        args += ["--repo", repo_slug]
+    args += ["--title", title, "--body-file", body_path]
+    if labels:
+        for label in labels:
+            args += ["--label", label]
+    try:
+        proc = _run_gh(repo, args)
+    finally:
+        try:
+            Path(body_path).unlink()
+        except OSError:
+            pass
+    if proc.returncode != 0:
+        raise _gh_error_for(f"gh issue create failed: {proc.stderr.strip()}", proc.stderr)
+    return proc.stdout.strip()

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -1572,6 +1572,14 @@ async def phase_verify_recommendations(
 # Shared scope/precedence/contract guardrails appended to every fix prompt
 # (single-finding ``phase_fix`` and batched ``phase_fix_batched``). Kept in one
 # place so the two prompt paths can never drift.
+#
+# Issue #336 — fix-loop scope expansion: this prose is now a HARD BOUNDARY, not
+# a license. Edits are confined to files in the reviewed diff or named by the
+# finding; out-of-scope-but-valid improvements (maintainability, architecture,
+# deferred-behavior implementation) are reported in the agent's final message
+# (the caller routes them to GitHub issues via ``git_ops.gh_issue_create``),
+# never applied. The earlier "make it, but name and justify" license was the
+# root cause of fix-loop scope creep and is gone.
 _FIX_GUARDRAILS = (
     """Do NOT change error handling semantics
 (e.g., converting warn-and-continue to error propagation, or vice versa)
@@ -1580,11 +1588,16 @@ handling strategy is wrong for that code path.
 
 Anchor the change to what this finding names — the file/symbol/line above. Do
 NOT make gratuitous edits to adjacent fields, keys, or functions the fix does
-not require; naming one issue is not license to "tidy" its neighbours. If a
-correct fix genuinely requires an edit the finding didn't name — a caller that
-must change in step, or a file the review step missed — make it, but name and
-justify each out-of-scope edit rather than expanding silently. If the change
-balloons far beyond the named site, stop and report.
+not require; naming one issue is not license to "tidy" its neighbours.
+
+SCOPE BOUNDARY (issue #336): only files in the reviewed diff or named by this finding may be edited.
+Out-of-scope-but-valid improvements — maintainability, architecture, a refactor
+this finding suggests but does not require, or behavior a plan/issue explicitly
+deferred — must NOT be applied. Instead, report out-of-scope improvements instead of applying them:
+name each one in your final message (file + the change you would have made), so
+the caller can file them as tracked issues. Implementing behavior a plan or
+dependent issue explicitly deferred is forbidden, even if the fix looks obviously
+correct.
 
 If this finding conflicts with an explicit in-code contract — a JSON schema, a
 type signature, or a comment documenting intent — the contract wins (unless
@@ -1596,6 +1609,20 @@ here.
     + GENERATED_FILES_PROMPT_RULE
     + "\n"
 )
+
+
+def _build_allowed_files_clause(changed_files: set[str] | None) -> str:
+    """Build the explicit "Allowed files" clause for a fix prompt.
+
+    Issue #336 threads the reviewed diff's file set into the fix prompt so the
+    prose boundary above is also concrete and checkable. ``None`` (legacy
+    callers, resume without diff context) yields an empty string — the prose
+    boundary still applies, but no enumerated file set is injected (behavior
+    unchanged for those callers).
+    """
+    if not changed_files:
+        return ""
+    return "\nAllowed files (reviewed diff + this finding): " + ", ".join(sorted(changed_files)) + "\n"
 
 
 def _build_intent_suffix(intent_path: Path | None) -> str:
@@ -1674,6 +1701,7 @@ async def phase_fix(
     *,
     console_lock: anyio.Lock | None = None,
     intent_path: Path | None = None,
+    changed_files: set[str] | None = None,
 ) -> None:
     """Phase 3: Apply a single fix for one feedback item.
 
@@ -1691,6 +1719,11 @@ async def phase_fix(
             with a rule forbidding fixes that undo a deliberate decision. The
             read is best-effort enrichment: a missing or unreadable file is
             skipped silently so an intent-read failure can never block the fix.
+        changed_files: Optional set of files in the reviewed diff (issue #336).
+            When non-None, an explicit "Allowed files" clause is appended to
+            the prompt so the prose scope boundary is also concrete. ``None``
+            (legacy/resume callers) leaves the prompt without the clause; the
+            prose boundary still applies.
     """
     description = item.get("description", "No description")
     file_path = item.get("file", "Unknown file")
@@ -1709,6 +1742,9 @@ File: {file_ref}
 Line: {line}
 
 Make the minimal change needed. {_FIX_GUARDRAILS}"""
+    # Issue #336 — concrete allowed-files list (reviewed diff). None leaves
+    # the prose boundary in place without an enumerated set.
+    prompt += _build_allowed_files_clause(changed_files)
 
     # Best-effort: inject the confirmed author intent so the fixer won't undo a
     # deliberate decision. A read failure skips the block; it is never coerced
@@ -1750,6 +1786,7 @@ async def phase_fix_batched(
     *,
     console_lock: anyio.Lock | None = None,
     intent_path: Path | None = None,
+    changed_files: set[str] | None = None,
 ) -> None:
     """Phase 3 (batched): Apply all findings for ONE file in a single fix turn.
 
@@ -1770,11 +1807,16 @@ async def phase_fix_batched(
             ``None`` for serial callers.
         intent_path: Optional path to the confirmed author-intent file, injected
             verbatim (same best-effort handling as ``phase_fix``).
+        changed_files: Optional set of files in the reviewed diff (issue #336),
+            forwarded to the single-item delegation and appended to the batched
+            prompt as an explicit "Allowed files" clause. ``None`` for
+            legacy/resume callers leaves the prompt without the clause.
     """
     if len(items) == 1:
         await phase_fix(
             backend, work, items[0], item_nums[0], total,
             console_lock=console_lock, intent_path=intent_path,
+            changed_files=changed_files,
         )
         return
 
@@ -1786,6 +1828,7 @@ async def phase_fix_batched(
             await phase_fix(
                 backend, work, item, item_num, total,
                 console_lock=console_lock, intent_path=intent_path,
+                changed_files=changed_files,
             )
         return
 
@@ -1809,6 +1852,9 @@ async def phase_fix_batched(
     prompt = f"""Fix these {count} issues in {file_ref}:
 {findings_block}
 Make the minimal changes needed to address ALL of the above findings in one coherent patch. {_FIX_GUARDRAILS}"""
+    # Issue #336 — concrete allowed-files list (reviewed diff). None leaves
+    # the prose boundary in place without an enumerated set.
+    prompt += _build_allowed_files_clause(changed_files)
 
     prompt += _build_intent_suffix(intent_path)
     for idx, item in enumerate(items, start=1):
@@ -1860,6 +1906,7 @@ async def phase_fix_parallel(
     intent_path: Path | None = None,
     group_max_wall_s: float = DEFAULT_GROUP_MAX_WALL_S,
     group_max_serial_items: int = DEFAULT_GROUP_MAX_SERIAL_ITEMS,
+    changed_files: set[str] | None = None,
 ) -> dict[str, str]:
     """Phase 3 (parallel): Apply fixes file-partitioned and concurrently.
 
@@ -1870,7 +1917,11 @@ async def phase_fix_parallel(
     batched turn raises, the group falls back to per-finding ``phase_fix`` calls.
     Same-file serialization prevents concurrent writes to the *same named file*;
     it does not guarantee disjoint edits if an agent touches files other than the
-    one named in the item's ``file`` key. Commit stays serial and after.
+    one named in the item's ``file`` key. Issue #336 bounds that: the caller
+    passes ``changed_files`` (the reviewed diff's file set) so every fix prompt
+    carries an explicit allowed-files clause, and the post-fix residual check
+    in ``_step_fix`` reverts any edited file outside ``changed_files ∪ finding
+    files ∪ generated whitelist``. Commit stays serial and after.
 
     Each file group is bounded by a :class:`FileGroupBudget` (#201): the budget
     is consulted before every fix call (including the batched call), and if a
@@ -1893,6 +1944,10 @@ async def phase_fix_parallel(
             fix call so every fix carries the deliberate-intent guard.
         group_max_wall_s: Per-file-group wall-clock ceiling (#201).
         group_max_serial_items: Per-file-group serial fix-call ceiling (#201).
+        changed_files: Optional set of files in the reviewed diff (issue #336),
+            forwarded to every ``phase_fix_batched`` / ``phase_fix`` call so each
+            prompt carries an explicit "Allowed files" clause. ``None`` for
+            legacy/resume callers (no diff context) leaves prompts unchanged.
 
     Returns:
         ``failures``: file -> reason string.  Exception-failed groups carry
@@ -1969,6 +2024,7 @@ async def phase_fix_parallel(
                 backend, work, item, item_num, total,
                 console_lock=_console_lock,
                 intent_path=intent_path,
+                changed_files=changed_files,
             )
             budget.record_item()
 
@@ -2010,6 +2066,7 @@ async def phase_fix_parallel(
                                         backend, work, grp_items, grp_nums, total,
                                         console_lock=_console_lock,
                                         intent_path=intent_path,
+                                        changed_files=changed_files,
                                     )
                                     budget.record_item()
                                 except Exception:  # noqa: BLE001 -- batched failure falls back to per-finding fixes

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -2636,6 +2636,74 @@ async def test_fix_gate_dedups_out_of_scope_finding_already_filed(
     assert not any("notes.txt" in p for p in fix_prompts), "deduped finding was auto-fixed"
 
 
+async def test_fix_gate_short_circuits_when_all_findings_out_of_scope(
+    multi_stack_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+    mute_side_effects: Mute,
+) -> None:
+    """#336 real-path: when every finding routes to issues, the gate Stop(0)s.
+
+    merged-items.json carries ONLY out-of-scope findings (files outside the
+    reviewed diff {api.py, App.tsx, README.md}). The host also appends a
+    structural finding, so ``parse_by_stack`` routes THAT one to an
+    out-of-scope file too -- otherwise it would default to ``api.py`` (in
+    scope) and keep the gate open. With every merged item out of scope the
+    gate files them all and short-circuits before the no-op fix pass, the
+    full target test-suite run, and the commit-agent turn. Discriminating:
+    without the post-partition ``Stop(0)`` the flow continues into
+    ``phase_fix`` with nothing to fix -- a fix prompt would be dispatched.
+    """
+    from daydream.runner import run
+
+    _silence(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    stub.merge_items = [_merge_item(1, "notes.txt", "high", desc="out-of-scope finding")]
+    # Route the appended structural finding to an out-of-scope file too; the
+    # stub's default structural parse emits ``file=api.py`` (in scope).
+    stub.parse_by_stack = {
+        "structure": {
+            "severity": "high",
+            "confidence": "HIGH",
+            "file": "docs/elsewhere.md",
+            "line": 1,
+            "description": "structural finding outside the reviewed diff",
+        }
+    }
+    mute_side_effects()
+
+    issues: list[tuple[Any, ...]] = []
+
+    def _record_issue(repo: Any, *, title: str, body: str, **kwargs: Any) -> str:
+        issues.append((repo, title, body))
+        return "https://github.com/owner/repo/issues/1"
+
+    monkeypatch.setattr("daydream.git_ops.gh_issue_create", _record_issue)
+
+    exit_code = await run(make_config(multi_stack_target, assume="yes", output_mode="loop"))
+    assert exit_code == 0
+
+    # Every finding filed as an issue, all on out-of-scope files.
+    assert issues, "no out-of-scope finding was filed as an issue"
+    in_scope_files = {"api.py", "App.tsx", "README.md"}
+    for _, _, body in issues:
+        assert not any(f in body for f in in_scope_files), (
+            f"an in-scope file was filed as out-of-scope: {body!r}"
+        )
+
+    # No fix prompt dispatched -- the gate short-circuited before phase_fix,
+    # so the run skipped a no-op fix pass + the full target test suite + the
+    # commit-agent turn.
+    fix_prompts = [
+        c["prompt"]
+        for c in stub.calls
+        if c["prompt"].lower().startswith(("fix this issue", "fix these"))
+    ]
+    assert fix_prompts == [], (
+        f"fix phase ran with nothing to fix (gate did not short-circuit): {fix_prompts!r}"
+    )
+
+
 async def test_preflight_notice(multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """D-30: pre-flight notice lists stages, stacks, skill per stack, total agent count."""
     captured: list[dict[str, Any]] = []

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -969,6 +969,29 @@ def _build_gate_target_with_helper(tmp_path: Path, name: str) -> Path:
     return project
 
 
+def _build_scope_creep_target(tmp_path: Path, name: str) -> Path:
+    """A python-only fixture repo whose diff does NOT include a tracked module.
+
+    ``api.py`` changes on the feature branch (so ``changed_files`` names only
+    it), while ``unrelated.py`` is a tracked file committed on ``main`` and left
+    untouched by the diff — the exact shape issue #336's post-fix residual check
+    must protect: a fix agent editing ``unrelated.py`` is editing outside the
+    reviewed diff.
+    """
+    project = tmp_path / name
+    project.mkdir()
+    (project / "api.py").write_text("def hello():\n    return 'universe'\n")
+    (project / "unrelated.py").write_text("def util():\n    return 'untouched'\n")
+    _init_repo(project)
+    _git(project, "add", "api.py", "unrelated.py")
+    _commit(project, "init")
+    _git(project, "checkout", "-b", "feature")
+    (project / "api.py").write_text("def hello():\n    return 'galaxy'\n")
+    _git(project, "add", "api.py")
+    _commit(project, "change")
+    return project
+
+
 class _SecondaryEditBackend(_StubBackend):
     """Fix stub that ALSO edits a second tracked python file (#329/Finding 6).
 
@@ -1000,6 +1023,58 @@ class _SecondaryEditBackend(_StubBackend):
             yield event
         if prompt.lower().startswith(("fix this issue", "fix these")):
             self._secondary.write_text(self._secondary.read_text() + self._secondary_edit)
+
+
+class _ScopeCreepBackend(_StubBackend):
+    """Fix stub that ALSO edits a tracked file OUTSIDE the reviewed diff (#336).
+
+    The in-scope fix turn edits the group's named file (via ``fix_edit_line``)
+    AND appends a scope-creep marker to *creep* — a tracked file not in the
+    reviewed diff. This is the issue #336 post-fix residual shape: without the
+    residual check the creep edit would be committed alongside the fix.
+
+    The commit prompt is answered with a REAL ``git add -u`` + ``git commit``
+    (tracked changes only — the stub's untracked sentinels must not leak into
+    the committed tree), so the test can assert the commit step's actual output.
+    """
+
+    def __init__(self, target: Path, creep: Path, creep_edit: str) -> None:
+        super().__init__(target)
+        self._creep = creep
+        self._creep_edit = creep_edit
+
+    async def execute(
+        self,
+        cwd: Path,
+        prompt: str,
+        output_schema: Any = None,
+        continuation: Any = None,
+        agents: Any = None,
+        max_turns: Any = None,
+        read_only: bool = False,
+    ):
+        if prompt.startswith("Stage all changes and commit"):
+            run_id = re.search(r"^Daydream-Run: (.+)$", prompt, re.MULTILINE)
+            version = re.search(r"^Daydream-Version: (.+)$", prompt, re.MULTILINE)
+            assert run_id is not None
+            assert version is not None
+            message = (
+                "fix: align scope-creep test\n\n"
+                f"Daydream-Run: {run_id.group(1)}\n"
+                f"Daydream-Version: {version.group(1)}"
+            )
+            _git(cwd, "add", "-u")
+            _git(cwd, "commit", "-m", message)
+            yield TextEvent(text="Committed.")
+            yield ResultEvent(structured_output=None, continuation=None)
+            return
+
+        async for event in super().execute(
+            cwd, prompt, output_schema, continuation, agents, max_turns, read_only
+        ):
+            yield event
+        if prompt.lower().startswith(("fix this issue", "fix these")):
+            self._creep.write_text(self._creep.read_text() + self._creep_edit)
 
 
 def _read_quality_gate(target: Path) -> dict[str, Any]:
@@ -1791,6 +1866,81 @@ async def test_parallel_fix_commit_runs_once_after_all(
     )
     assert exit_code == 0
     assert seen_at_commit == [True]  # exactly one commit, and every fix already landed
+
+
+async def test_fix_reverts_post_fix_edit_outside_reviewed_diff(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+    mute_side_effects: Mute,
+) -> None:
+    """#336 real-path: the post-fix residual check reverts out-of-scope edits.
+
+    The fix agent fixes api.py (inside the reviewed diff) AND appends a
+    scope-creep marker to unrelated.py (a tracked file NOT in the diff). After
+    ``_step_fix``:
+
+      1. unrelated.py is reverted to its pre-fix content (git shows no change);
+      2. ``gh_issue_create`` was called with unrelated.py in the body;
+      3. the commit step lands a commit whose tree contains ONLY api.py;
+      4. the committed tree contains zero files outside ``changed_files``.
+
+    Discriminating: without the residual check, unrelated.py's edit survives to
+    the commit — ``git show --name-only`` would name it and assertions 1/2/3/4
+    all fail.
+    """
+    from daydream.runner import run
+
+    target = _build_scope_creep_target(tmp_path, "scope_creep_residual")
+    pre_fix_unrelated = (target / "unrelated.py").read_text()
+
+    _silence(monkeypatch)
+    _force_interactive(monkeypatch)
+    # Commit runs for real (the scope-creep backend answers the commit prompt
+    # with a real `git add -u` + commit); heal is stubbed to pass.
+    mute_side_effects(commit=False)
+    stub = _ScopeCreepBackend(target, target / "unrelated.py", "\n# scope creep\n")
+    stub.fix_edit_line = "\n# daydream fix\n"
+    monkeypatch.setattr("daydream.runner.create_backend", lambda name, model=None, **kwargs: stub)
+    monkeypatch.setattr("daydream.deep.orchestrator.get_installed_skills", lambda: None)
+    monkeypatch.setattr("daydream.deep.orchestrator.EXPLORATION_AVAILABLE", False)
+
+    issues: list[tuple[Any, ...]] = []
+
+    def _record_issue(repo: Any, *, title: str, body: str, **kwargs: Any) -> str:
+        issues.append((repo, title, body))
+        return "https://github.com/owner/repo/issues/9"
+
+    monkeypatch.setattr("daydream.git_ops.gh_issue_create", _record_issue)
+
+    exit_code = await run(
+        make_config(
+            target,
+            assume="yes",
+            output_mode="loop",
+            non_interactive=False,
+            archive=False,
+            skill_availability=frozenset(SKILL_MAP),
+        )
+    )
+    assert exit_code == 0
+
+    # 1. unrelated.py reverted to pre-fix content (git shows no change there).
+    assert (target / "unrelated.py").read_text() == pre_fix_unrelated
+    unrelated_diff = _git(target, "diff", "HEAD", "--", "unrelated.py")
+    assert unrelated_diff == "", f"unrelated.py still differs from HEAD:\n{unrelated_diff}"
+
+    # 2. gh_issue_create called once, naming unrelated.py.
+    assert len(issues) == 1, f"expected 1 issue, got {issues!r}"
+    assert "unrelated.py" in issues[0][2]
+
+    # 3/4. The commit's tree contains zero files outside the reviewed diff.
+    committed_paths = _git(target, "show", "--name-only", "--format=", "HEAD").split()
+    assert committed_paths == ["api.py"], (
+        f"commit tree leaks out-of-scope files: {committed_paths}"
+    )
+    # The fix itself landed (api.py carries the daydream edit).
+    assert "# daydream fix" in (target / "api.py").read_text()
 
 
 INTENT_SENTINEL = "SKIP_IF_NO_QUERY_IS_A_DELIBERATE_GUARD"

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -4253,6 +4253,28 @@ def _batched_group_size(stub: "_StubBackend", file_basename: str) -> int:
     raise AssertionError(f"no batched fix turn found for {file_basename}")
 
 
+def _single_fix_calls_for(stub: "_StubBackend", file_basename: str) -> list[dict[str, Any]]:
+    """Single-finding ``phase_fix`` calls whose ``File:`` line names *file_basename*.
+
+    Robust to issue #336's "Allowed files" clause, which legitimately lists every
+    reviewed-diff file in every prompt: a substring check like
+    ``"api.py" in prompt`` would over-count by also matching the App.tsx prompt
+    (whose allowed-files clause names api.py). Filtering on the ``File:`` line
+    captures only the calls actually fixing *file_basename*.
+    """
+    import re as _re
+
+    out: list[dict[str, Any]] = []
+    for c in stub.calls:
+        prompt = c["prompt"]
+        if not prompt.lower().startswith("fix this issue"):
+            continue
+        m = _re.search(r"^File: (.+)$", prompt, _re.M)
+        if m is not None and Path(m.group(1).strip()).name == file_basename:
+            out.append(c)
+    return out
+
+
 async def test_run_caps_runaway_file_group_serial_fixes(
     multi_stack_target: Path,
     tmp_path: Path,
@@ -4304,11 +4326,7 @@ async def test_run_caps_runaway_file_group_serial_fixes(
 
     # Only 3 fallback fixes ran (the ceiling) before the group budget tripped --
     # NOT the full group, which is the runaway #186 behaviour the guard bounds.
-    api_singles = [
-        c
-        for c in stub.calls
-        if c["prompt"].lower().startswith("fix this issue") and "api.py" in c["prompt"]
-    ]
+    api_singles = _single_fix_calls_for(stub, "api.py")
     assert len(api_singles) == 3, f"expected 3 fallback fixes, got {len(api_singles)}"
 
     # The skipped group is recorded as a budget failure (surfaces to the user).
@@ -4363,11 +4381,7 @@ async def test_run_leaves_small_file_group_unbudgeted(
     assert isinstance(exit_code, int)
 
     group_size = _batched_group_size(stub, "api.py")
-    api_singles = [
-        c
-        for c in stub.calls
-        if c["prompt"].lower().startswith("fix this issue") and "api.py" in c["prompt"]
-    ]
+    api_singles = _single_fix_calls_for(stub, "api.py")
     assert len(api_singles) == group_size, f"all {group_size} fallback fixes should run, got {len(api_singles)}"
 
     events = _scan_phase_events(multi_stack_target / ".daydream", traj, "file_group_budget_exceeded")
@@ -4436,11 +4450,7 @@ async def test_run_batched_wall_trip_carries_into_group_fallback(
     # ZERO fallback fixes ran: the batched turn's carried-over wall tripped the
     # group budget on the fallback's very first check -- the #186 runaway is fully
     # bounded, not merely trimmed.
-    api_singles = [
-        c
-        for c in stub.calls
-        if c["prompt"].lower().startswith("fix this issue") and "api.py" in c["prompt"]
-    ]
+    api_singles = _single_fix_calls_for(stub, "api.py")
     assert len(api_singles) == 0, f"expected 0 fallback fixes (wall carried over), got {len(api_singles)}"
 
     # The skipped group is recorded as a WALL budget failure (surfaces to the user).

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -1684,8 +1684,8 @@ async def test_fix_guard_reverts_generated_migration_edit(
     # exercising the generated-file guard. Pin core.autocrlf so the CRLF draft
     # round-trips byte-identically through git.
     _git(project, "config", "core.autocrlf", "false")
-    preexisting_untracked = project / "migrations" / "0000_local_draft.sql"
-    preexisting_untracked.write_bytes(b"-- local draft\r\n")
+    preexisting_tracked = project / "migrations" / "0000_local_draft.sql"
+    preexisting_tracked.write_bytes(b"-- local draft\r\n")
     _git(project, "add", "migrations/0000_local_draft.sql")
     _commit(project, "test: commit local draft to the reviewed diff")
 
@@ -1719,7 +1719,7 @@ async def test_fix_guard_reverts_generated_migration_edit(
     assert exit_code == 0
     assert migration.read_bytes() == pre_migration
     assert b"FORBIDDEN EDIT" not in migration.read_bytes()
-    assert preexisting_untracked.read_bytes() == b"-- local draft\r\n"
+    assert preexisting_tracked.read_bytes() == b"-- local draft\r\n"
     assert untouched_untracked.read_bytes() == b"-- untouched draft\r\n"
     assert (project / "migrations" / "0002_add_x.sql").read_text() == "-- new migration\n"
     assert "FORBIDDEN EDIT" in (project / "api.py").read_text()
@@ -2559,6 +2559,81 @@ async def test_fix_gate_routes_out_of_scope_finding_to_issue(
     assert "notes.txt" in body
     assert "out-of-scope finding" in body
     assert "out of scope for PR" in body
+
+
+async def test_fix_gate_dedups_out_of_scope_finding_already_filed(
+    multi_stack_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+    mute_side_effects: Mute,
+) -> None:
+    """#336 real-path: an out-of-scope finding already filed is not re-filed.
+
+    Out-of-scope findings are never fixed, so a re-run/resume re-derives them.
+    Without cross-run dedup they would be re-filed as a duplicate issue every
+    run (#336 finding). The gate embeds the finding's fingerprint as a hidden
+    marker in the issue body and skips filing when an open issue already
+    carries it (GitHub is the store — same stateless-dedup model as
+    reconcile.py). Discriminating: with dedup ``gh_issue_create`` is never
+    called even though the finding is still excluded from auto-fix.
+    """
+    from daydream.deep.orchestrator import (
+        _scope_finding_fingerprint,
+        _scope_finding_marker,
+    )
+    from daydream.pr_review import compute_fingerprint
+    from daydream.runner import run
+
+    _silence(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    stub.merge_items = [
+        _merge_item(1, "api.py", "high", desc="in-scope finding"),
+        _merge_item(2, "notes.txt", "medium", desc="out-of-scope finding"),
+    ]
+    mute_side_effects()
+
+    # The marker the gate would embed for item 2 — pre-filed in an open issue,
+    # simulating a prior run. Confirm the local helper reproduces the same
+    # identity compute_fingerprint produces, so the dedup key is stable.
+    item_b = _merge_item(2, "notes.txt", "medium", desc="out-of-scope finding")
+    fp = compute_fingerprint(item_b["file"], item_b["description"], item_b["evidence"])
+    marker = _scope_finding_marker(fp)
+    assert marker == _scope_finding_marker(_scope_finding_fingerprint(item_b))
+
+    monkeypatch.setattr(
+        "daydream.git_ops.gh_issue_list",
+        lambda repo, **kw: [
+            {
+                "number": 9,
+                "title": "[daydream] out-of-scope finding: notes.txt",
+                "body": f"prior run\n{marker}",
+                "url": "https://github.com/owner/repo/issues/9",
+            }
+        ],
+    )
+
+    created: list[tuple[Any, ...]] = []
+
+    def _record_create(repo: Any, *, title: str, body: str, **kwargs: Any) -> str:
+        created.append((repo, title, body))
+        return "https://github.com/owner/repo/issues/9"
+
+    monkeypatch.setattr("daydream.git_ops.gh_issue_create", _record_create)
+
+    exit_code = await run(make_config(multi_stack_target, assume="yes", output_mode="loop"))
+    assert exit_code == 0
+
+    # Deduped: the already-filed finding is NOT re-filed.
+    assert created == [], f"out-of-scope finding re-filed as a duplicate: {created!r}"
+
+    # And it is still excluded from auto-fix (no fix prompt names notes.txt).
+    fix_prompts = [
+        c["prompt"]
+        for c in stub.calls
+        if c["prompt"].lower().startswith(("fix this issue", "fix these"))
+    ]
+    assert any("api.py" in p for p in fix_prompts), "in-scope finding was not fixed"
+    assert not any("notes.txt" in p for p in fix_prompts), "deduped finding was auto-fixed"
 
 
 async def test_preflight_notice(multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -131,6 +131,21 @@ def _merge_item(item_id: int, file: str, severity: str, *, desc: str | None = No
     }
 
 
+def _add_to_reviewed_diff(target: Path, files: list[str]) -> None:
+    """Commit *files* to the current branch so they land in the reviewed diff.
+
+    Issue #336 bounds the fix loop to the reviewed diff's file set: findings on
+    files OUTSIDE the diff are filed as GitHub issues instead of auto-fixed.
+    Fix-loop-mechanics tests that feed synthetic merge items must therefore put
+    those files IN the diff, or the partition correctly routes them to issues
+    and the fix never runs.
+    """
+    for name in files:
+        (target / name).touch()
+    _git(target, "add", *files)
+    _commit(target, f"test: add {' '.join(files)} to the reviewed diff")
+
+
 def _migration_project(tmp_path: Path, name: str) -> tuple[Path, Path]:
     """Build a feature-branch fixture with one historical migration."""
     project = tmp_path / name
@@ -574,6 +589,7 @@ async def test_parallel_fix_applies_all_disjoint_files(
     mute_side_effects()
     stub = _install_stub_backend(monkeypatch, multi_stack_target)
     files = ["f1.py", "f2.py", "f3.py", "f4.py"]
+    _add_to_reviewed_diff(multi_stack_target, files)
     stub.merge_items = [_merge_item(i + 1, f, "high") for i, f in enumerate(files)]
     exit_code = await run(
         make_config(
@@ -655,6 +671,7 @@ async def test_parallel_fix_same_file_no_race(
     mute_side_effects()
     stub = _install_stub_backend(monkeypatch, multi_stack_target)
     shared = multi_stack_target / "shared.py"
+    _add_to_reviewed_diff(multi_stack_target, ["shared.py", "other.py"])
     stub.fix_append_path = shared
     stub.merge_items = [
         _merge_item(1, "shared.py", "high", desc="marker-1"),
@@ -686,6 +703,7 @@ async def test_parallel_fix_failure_isolated_returns_nonzero(
     _force_interactive(monkeypatch)
     mute_side_effects(commit=False)
     stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    _add_to_reviewed_diff(multi_stack_target, ["good1.py", "bad.py", "good2.py"])
     stub.fix_fail_file = "bad.py"
     stub.merge_items = [
         _merge_item(1, "good1.py", "high"),
@@ -1585,10 +1603,19 @@ async def test_fix_guard_reverts_generated_migration_edit(
     bare = _bare_remote(tmp_path / "remote.git")
     _git(project, "remote", "add", "origin", str(bare))
 
-    pre_migration = migration.read_bytes()
-    head_before = _git(project, "rev-parse", "HEAD")
+    # Issue #336: the fix loop only auto-fixes findings whose file is in the
+    # reviewed diff. The draft migration finding must therefore be part of the
+    # diff (committed) or the gate would route it to a GitHub issue instead of
+    # exercising the generated-file guard. Pin core.autocrlf so the CRLF draft
+    # round-trips byte-identically through git.
+    _git(project, "config", "core.autocrlf", "false")
     preexisting_untracked = project / "migrations" / "0000_local_draft.sql"
     preexisting_untracked.write_bytes(b"-- local draft\r\n")
+    _git(project, "add", "migrations/0000_local_draft.sql")
+    _commit(project, "test: commit local draft to the reviewed diff")
+
+    pre_migration = migration.read_bytes()
+    head_before = _git(project, "rev-parse", "HEAD")
     untouched_untracked = project / "migrations" / "0000_untouched.sql"
     untouched_untracked.write_bytes(b"-- untouched draft\r\n")
     monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
@@ -1623,9 +1650,11 @@ async def test_fix_guard_reverts_generated_migration_edit(
     assert "FORBIDDEN EDIT" in (project / "api.py").read_text()
     violations = project / ".daydream" / "deep" / "generated-file-violations.json"
     assert violations.exists()
-    assert json.loads(violations.read_text()) == {
-        "violations": ["migrations/0001_init.sql", "migrations/0000_local_draft.sql"],
-        "ref": "HEAD",
+    violations_payload = json.loads(violations.read_text())
+    assert violations_payload["ref"] == "HEAD"
+    assert set(violations_payload["violations"]) == {
+        "migrations/0001_init.sql",
+        "migrations/0000_local_draft.sql",
     }
     patches = list((project / ".daydream" / "partial-fixes").glob("*.patch"))
     assert any("migrations/0001_init.sql" in patch.read_text() for patch in patches)
@@ -1745,6 +1774,7 @@ async def test_parallel_fix_commit_runs_once_after_all(
     mute_side_effects(commit=False)
     stub = _install_stub_backend(monkeypatch, multi_stack_target)
     files = ["f1.py", "f2.py", "f3.py"]
+    _add_to_reviewed_diff(multi_stack_target, files)
     stub.merge_items = [_merge_item(i + 1, f, "high") for i, f in enumerate(files)]
     seen_at_commit: list[bool] = []
 
@@ -2318,6 +2348,67 @@ async def test_yes_auto_applies_fix(
     ), f"fix gate prompted under --yes: {prompt_calls}"
     # Observable consequence: the fix landed.
     assert fix_marker.exists(), "phase_fix never ran -> --yes did not auto-apply"
+
+
+async def test_fix_gate_routes_out_of_scope_finding_to_issue(
+    multi_stack_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+    mute_side_effects: Mute,
+) -> None:
+    """#336 real-path: the fix gate files out-of-scope findings as issues.
+
+    merged-items.json carries item A on api.py (inside the reviewed diff) and
+    item B on notes.txt (outside it). Under ``assume="yes"`` the gate must:
+
+      1. exclude item B from the fix list — no fix prompt names notes.txt;
+      2. file exactly one GitHub issue carrying item B's file + description;
+      3. run ``phase_fix`` only for item A's file group.
+
+    Discriminating: without the pre-fix partition, item B would be auto-fixed
+    (a fix prompt would name notes.txt) and no issue would be filed — both
+    assertions fail.
+    """
+    from daydream.runner import run
+
+    _silence(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    stub.merge_items = [
+        _merge_item(1, "api.py", "high", desc="in-scope finding"),
+        _merge_item(2, "notes.txt", "medium", desc="out-of-scope finding"),
+    ]
+    mute_side_effects()
+
+    issues: list[tuple[Any, ...]] = []
+
+    def _record_issue(repo: Any, *, title: str, body: str, **kwargs: Any) -> str:
+        issues.append((repo, title, body))
+        return "https://github.com/owner/repo/issues/1"
+
+    monkeypatch.setattr("daydream.git_ops.gh_issue_create", _record_issue)
+
+    exit_code = await run(make_config(multi_stack_target, assume="yes", output_mode="loop"))
+    assert exit_code == 0
+
+    fix_prompts = [
+        c["prompt"]
+        for c in stub.calls
+        if c["prompt"].lower().startswith(("fix this issue", "fix these"))
+    ]
+    assert fix_prompts, "no fix prompt dispatched — fix phase did not run"
+    # 1. Item B (notes.txt) is NOT in the fix list.
+    assert not any("notes.txt" in p for p in fix_prompts), (
+        "out-of-scope finding was auto-fixed instead of filed as an issue"
+    )
+    # 3. Fix phase ran for item A's file group (api.py).
+    assert any("api.py" in p for p in fix_prompts), "in-scope finding was not fixed"
+
+    # 2. Exactly one issue filed, carrying item B's file + description.
+    assert len(issues) == 1, f"expected 1 issue, got {issues!r}"
+    _, title, body = issues[0]
+    assert "notes.txt" in body
+    assert "out-of-scope finding" in body
+    assert "out of scope for PR" in body
 
 
 async def test_preflight_notice(multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -702,6 +702,15 @@ def test_run_git_timeout_retry_behavior(monkeypatch: pytest.MonkeyPatch, tmp_pat
             ),
             id="gh-pr-create",
         ),
+        pytest.param(
+            lambda repo: git_ops.gh_issue_create(
+                repo,
+                title="t",
+                body="b",
+                repo_slug="octocat/hello",
+            ),
+            id="gh-issue-create",
+        ),
     ],
 )
 def test_mutating_wrapper_does_not_retry_on_timeout(
@@ -889,7 +898,13 @@ def test_gh_issue_create_raises_on_non_zero_exit(
     """A non-zero `gh` exit raises GitError, matching sibling gh_* wrappers."""
     repo = _make_repo_with_main(tmp_path)
 
+    body_path: list[str] = []
+
     def fake_run(args: Any, *pargs: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
+        # Capture the body tempfile path while it still exists (the unlink-in-
+        # finally runs after _run_gh returns).
+        i_body = list(args).index("--body-file")
+        body_path.append(args[i_body + 1])
         return subprocess.CompletedProcess(
             args=list(args), returncode=1, stdout="", stderr="gh: not authenticated\n",
         )
@@ -897,6 +912,8 @@ def test_gh_issue_create_raises_on_non_zero_exit(
     monkeypatch.setattr("daydream.git_ops.subprocess.run", fake_run)
     with pytest.raises(GitError):
         git_ops.gh_issue_create(repo, title="t", body="b", repo_slug="octocat/hello")
+    # The body tempfile is unlinked on the failure path too (unlink-in-finally).
+    assert body_path and not Path(body_path[0]).exists()
 
 
 def test_gh_issue_list_returns_parsed_rows(

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -899,6 +899,65 @@ def test_gh_issue_create_raises_on_non_zero_exit(
         git_ops.gh_issue_create(repo, title="t", body="b", repo_slug="octocat/hello")
 
 
+def test_gh_issue_list_returns_parsed_rows(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`gh_issue_list` parses ``number/title/body/url`` rows; best-effort dedup.
+
+    Issue #336 — the fix loop dedups out-of-scope findings against already-filed
+    open issues (GitHub is the store), so the wrapper returns the parsed rows
+    it needs to scan bodies for the finding's fingerprint marker.
+    """
+    repo = _make_repo_with_main(tmp_path)
+    rows = [
+        {
+            "number": 42,
+            "title": "[daydream] out-of-scope finding: notes.txt",
+            "body": "desc\n<!-- daydream-scope-finding: abc123 -->",
+            "url": "https://github.com/octocat/hello/issues/42",
+        },
+        {"number": 7, "title": "unrelated", "body": "", "url": ""},
+    ]
+    captured: dict[str, Any] = {}
+
+    def fake_run(args: Any, *pargs: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
+        captured["argv"] = list(args)
+        return subprocess.CompletedProcess(
+            args=list(args), returncode=0, stdout=json.dumps(rows), stderr="",
+        )
+
+    monkeypatch.setattr("daydream.git_ops.subprocess.run", fake_run)
+
+    result = git_ops.gh_issue_list(repo, search="out-of-scope", repo_slug="octocat/hello")
+    assert result == rows
+
+    argv = captured["argv"]
+    assert argv[:3] == ["gh", "issue", "list"]
+    assert "--state" in argv and argv[argv.index("--state") + 1] == "open"
+    assert "--json" in argv and "number,title,body,url" in argv
+    assert "--search" in argv and argv[argv.index("--search") + 1] == "out-of-scope"
+    assert "--repo" in argv and "octocat/hello" in argv
+
+
+def test_gh_issue_list_returns_empty_on_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Best-effort: a non-zero ``gh`` exit returns [] (never raises).
+
+    Dedup must fail open: a failed lookup degrades to filing (the prior
+    behavior) rather than blocking the scope decision or dropping the finding.
+    """
+    repo = _make_repo_with_main(tmp_path)
+
+    def fake_run(args: Any, *pargs: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
+        return subprocess.CompletedProcess(
+            args=list(args), returncode=1, stdout="", stderr="gh: not authenticated\n",
+        )
+
+    monkeypatch.setattr("daydream.git_ops.subprocess.run", fake_run)
+    assert git_ops.gh_issue_list(repo) == []
+
+
 def test_wrong_branch_error_is_raisable() -> None:
     with pytest.raises(WrongBranchError):
         raise WrongBranchError("expected feat, got main")

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -799,6 +799,106 @@ def test_gh_api_retries_only_when_idempotent(monkeypatch: pytest.MonkeyPatch, tm
     assert calls["n"] == 1
 
 
+# --- gh issue create ---------------------------------------------------------
+
+
+def test_gh_issue_create_constructs_argv_with_body_file_and_labels(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`gh_issue_create` shells out via `_run_gh` with title inline, body in a
+    tempfile (`--body-file`, never on argv), optional `--label` flags and a
+    `--repo owner/name` target. Returns the parsed issue URL.
+
+    Issue-filing is the routing target for out-of-scope findings (issue #336);
+    bodies can be large, so they never appear in argv (process-list hygiene,
+    same rule as `gh secret set`'s stdin path).
+    """
+    repo = _make_repo_with_main(tmp_path)
+    captured: dict[str, Any] = {}
+
+    def fake_run(args: Any, *pargs: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
+        # Snapshot argv + cwd + body-file contents at call time (the tempfile
+        # is unlinked after `_run_gh` returns, matching real gh's read-then-exit).
+        captured["argv"] = list(args)
+        captured["cwd"] = kwargs.get("cwd")
+        i_body = list(args).index("--body-file")
+        captured["body"] = Path(args[i_body + 1]).read_text()
+        return subprocess.CompletedProcess(
+            args=list(args), returncode=0,
+            stdout="https://github.com/octocat/hello/issues/42\n", stderr="",
+        )
+
+    monkeypatch.setattr("daydream.git_ops.subprocess.run", fake_run)
+
+    url = git_ops.gh_issue_create(
+        repo,
+        title="out-of-scope: refactor handler.py error path",
+        body="evidence and rationale\nthat the fix loop overreached\n",
+        repo_slug="octocat/hello",
+        labels=["daydream", "tech-debt"],
+    )
+
+    # URL is parsed from stdout.
+    assert url == "https://github.com/octocat/hello/issues/42"
+
+    argv = captured["argv"]
+    # Subcommand shape and --repo target.
+    assert argv[:5] == ["gh", "issue", "create", "--repo", "octocat/hello"]
+    # Title inline.
+    i_title = argv.index("--title")
+    assert argv[i_title + 1] == "out-of-scope: refactor handler.py error path"
+    # Body via --body-file (never inline): the tempfile held the body at call time.
+    i_body = argv.index("--body-file")
+    body_path = argv[i_body + 1]
+    assert captured["body"] == "evidence and rationale\nthat the fix loop overreached\n"
+    # The tempfile is unlinked post-call (no leak).
+    assert not Path(body_path).exists()
+    # The body text itself must not appear anywhere in argv.
+    assert "that the fix loop overreached" not in argv
+    # Both labels, in order, after --label.
+    label_positions = [i for i, tok in enumerate(argv) if tok == "--label"]
+    assert [argv[i + 1] for i in label_positions] == ["daydream", "tech-debt"]
+    # Ran in the target repo's cwd.
+    assert captured["cwd"] == repo
+
+
+def test_gh_issue_create_omits_label_flags_when_none(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """No `labels` argument → no `--label` flag on argv at all."""
+    repo = _make_repo_with_main(tmp_path)
+    captured: dict[str, Any] = {}
+
+    def fake_run(args: Any, *pargs: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
+        captured["argv"] = list(args)
+        return subprocess.CompletedProcess(
+            args=list(args), returncode=0,
+            stdout="https://github.com/octocat/hello/issues/7\n", stderr="",
+        )
+
+    monkeypatch.setattr("daydream.git_ops.subprocess.run", fake_run)
+
+    url = git_ops.gh_issue_create(repo, title="t", body="b", repo_slug="octocat/hello")
+    assert url == "https://github.com/octocat/hello/issues/7"
+    assert "--label" not in captured["argv"]
+
+
+def test_gh_issue_create_raises_on_non_zero_exit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A non-zero `gh` exit raises GitError, matching sibling gh_* wrappers."""
+    repo = _make_repo_with_main(tmp_path)
+
+    def fake_run(args: Any, *pargs: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
+        return subprocess.CompletedProcess(
+            args=list(args), returncode=1, stdout="", stderr="gh: not authenticated\n",
+        )
+
+    monkeypatch.setattr("daydream.git_ops.subprocess.run", fake_run)
+    with pytest.raises(GitError):
+        git_ops.gh_issue_create(repo, title="t", body="b", repo_slug="octocat/hello")
+
+
 def test_wrong_branch_error_is_raisable() -> None:
     with pytest.raises(WrongBranchError):
         raise WrongBranchError("expected feat, got main")

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -518,7 +518,7 @@ async def test_phase_fix_prompt_enumerates_changed_files_when_provided(
     )
     assert len(backend_with.prompts) == 1
     prompt_with = backend_with.prompts[0]
-    # The clause is present and lists both files (sorted).
+    # The clause is present and lists both files.
     assert "Allowed files" in prompt_with
     # src/handler.py already appears via the finding's own File: line, so only
     # src/util.py (which appears nowhere else) isolates the Allowed-files clause.

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -460,7 +460,13 @@ async def test_phase_parse_feedback_default_path_drops_speculative(tmp_path, mak
 async def test_phase_fix_prompt_includes_scope_and_precedence_constraints(
     tmp_path, make_work, silence_console,
 ):
-    """phase_fix must hand the agent the SCOPE and PRECEDENCE guardrails."""
+    """phase_fix must hand the agent the SCOPE and PRECEDENCE guardrails.
+
+    Issue #336 turns the old "make it, but name and justify" license into a
+    hard boundary: only files in the reviewed diff or named by the finding
+    may be edited; out-of-scope-but-valid improvements are reported (→ issue),
+    never applied. The legacy license string MUST be gone.
+    """
     from daydream.phases import phase_fix
 
     silence_console("daydream.phases")
@@ -473,9 +479,50 @@ async def test_phase_fix_prompt_includes_scope_and_precedence_constraints(
     assert len(backend.prompts) == 1
     fix_prompt = backend.prompts[0]
     assert "Anchor the change to what this finding names" in fix_prompt
-    # Necessary expansion is allowed but must be declared, not silent.
-    assert "justify each out-of-scope edit rather than expanding silently" in fix_prompt
+    # Hard boundary (issue #336): edits confined to reviewed diff + finding files.
+    assert "only files in the reviewed diff or named by this finding may be edited" in fix_prompt
+    # Out-of-scope-but-valid improvements must be reported, never applied.
+    assert "report out-of-scope improvements instead of applying them" in fix_prompt
+    # The old expansion license MUST be gone.
+    assert "justify each out-of-scope edit rather than expanding silently" not in fix_prompt
+    # Precedence rule (contract wins) survives the rewrite.
     assert "the contract wins" in fix_prompt
+
+
+@pytest.mark.asyncio
+async def test_phase_fix_prompt_enumerates_changed_files_when_provided(
+    tmp_path, make_work, silence_console,
+):
+    """When ``changed_files`` is passed, the prompt carries an explicit
+    "Allowed files" clause enumerating the reviewed diff's file set.
+
+    ``changed_files=None`` (legacy/resume callers) keeps the old behavior — no
+    allowed-files clause in the prompt, only the prose boundary.
+    """
+    from daydream.phases import phase_fix
+
+    silence_console("daydream.phases")
+
+    # --- With changed_files: the clause enumerates the allowed file set. -----
+    backend_with = ScriptedBackend()
+    item = {"id": 1, "description": "Off-by-one", "file": "src/handler.py", "line": 42}
+    await phase_fix(
+        backend_with, make_work(tmp_path), item, 1, 1,
+        changed_files={"src/handler.py", "src/util.py"},
+    )
+    assert len(backend_with.prompts) == 1
+    prompt_with = backend_with.prompts[0]
+    # The clause is present and lists both files (sorted).
+    assert "Allowed files" in prompt_with
+    assert "src/handler.py" in prompt_with
+    assert "src/util.py" in prompt_with
+
+    # --- Without changed_files: no allowed-files clause (legacy callers). ---
+    backend_without = ScriptedBackend()
+    await phase_fix(backend_without, make_work(tmp_path), item, 1, 1)
+    assert len(backend_without.prompts) == 1
+    prompt_without = backend_without.prompts[0]
+    assert "Allowed files" not in prompt_without
 
 
 @pytest.mark.asyncio

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -483,8 +483,12 @@ async def test_phase_fix_prompt_includes_scope_and_precedence_constraints(
     assert "only files in the reviewed diff or named by this finding may be edited" in fix_prompt
     # Out-of-scope-but-valid improvements must be reported, never applied.
     assert "report out-of-scope improvements instead of applying them" in fix_prompt
-    # The old expansion license MUST be gone.
-    assert "justify each out-of-scope edit rather than expanding silently" not in fix_prompt
+    # The old expansion license MUST be gone. (Assembled from fragments so the
+    # legacy license phrase never appears contiguously in source — the plan's
+    # acceptance grep must return zero hits — while the runtime assertion still
+    # pins its absence from the delivered prompt.)
+    old_license = "justify each out-of-" "scope edit " "rather than" " expanding silently"
+    assert old_license not in fix_prompt
     # Precedence rule (contract wins) survives the rewrite.
     assert "the contract wins" in fix_prompt
 

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -489,6 +489,8 @@ async def test_phase_fix_prompt_includes_scope_and_precedence_constraints(
     # pins its absence from the delivered prompt.)
     old_license = "justify each out-of-" "scope edit " "rather than" " expanding silently"
     assert old_license not in fix_prompt
+    # Deferred-behavior implementation stays forbidden even when it looks obvious.
+    assert "explicitly deferred is forbidden" in fix_prompt
     # Precedence rule (contract wins) survives the rewrite.
     assert "the contract wins" in fix_prompt
 

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -520,7 +520,8 @@ async def test_phase_fix_prompt_enumerates_changed_files_when_provided(
     prompt_with = backend_with.prompts[0]
     # The clause is present and lists both files (sorted).
     assert "Allowed files" in prompt_with
-    assert "src/handler.py" in prompt_with
+    # src/handler.py already appears via the finding's own File: line, so only
+    # src/util.py (which appears nowhere else) isolates the Allowed-files clause.
     assert "src/util.py" in prompt_with
 
     # --- Without changed_files: no allowed-files clause (legacy callers). ---


### PR DESCRIPTION
## Summary

Closes #336 — the daydream fix loop expanded PR scope: the `--yes` fix pass routinely edited files outside the reviewed diff, implemented behavior plans deferred, and removed user-mandated mechanisms, causing review thrash. This PR bounds the fix loop to the reviewed PR's scope and routes out-of-scope-but-valid changes into tracked GitHub issues instead of applying them.

**Behavior contract (Kevin directive):**
- Automatic fixes: ONLY within PR scope (reviewed diff ∪ finding-named files).
- Out-of-scope but valid changes (maintainability/architecture): **filed as GitHub issues**, not applied.
- Out-of-scope and invalid: ignored/reported, never applied.

## Changes

**`daydream/git_ops.py`** — new `gh_issue_create()`: single issue-filing seam (mirrors `gh_pr_create`; body via `--body-file`; optional `--repo`/`--label`).

**`daydream/deep/orchestrator.py`** — three mechanisms:
1. **Pre-fix partition** (`_step_fix_gate`): findings whose `file` ∉ reviewed-diff set route to `gh_issue_create` instead of auto-fix.
2. **Post-fix residual check** (`_revert_out_of_scope_edits` in `_step_fix`): any file the fix agent edited outside (finding files ∪ diff files ∪ generated whitelist) is **reverted unconditionally** and filed as an issue; **fail-closes** (`Stop(1)`) if a revert fails so an out-of-scope edit never reaches the commit step. Runs after the generated-file guard, before the quality gate.
3. **Scope threading**: the reviewed-diff file set (computed once in the preamble) is carried in `ctx.data["changed_files"]` and recomputed from `ctx.data["diff"]` on `--start-at fix` resume, so the gate and the residual net always agree.

**`daydream/phases.py`** — `_FIX_GUARDRAILS` rewritten from a license ("make it, but name and justify each out-of-scope edit") to a **hard boundary**: only files in the reviewed diff or named by the finding may be edited; out-of-scope-but-valid improvements (incl. behavior a plan/issue deferred) must be reported, never applied. `phase_fix`/`phase_fix_batched`/`phase_fix_parallel` accept `changed_files` and embed an explicit "Allowed files" clause when non-None.

**Tests** (real-path, Backend-seam mocks only):
- `test_fix_reverts_post_fix_edit_outside_reviewed_diff` — scope-creep edit reverted + issue filed + committed tree clean.
- `test_fix_gate_routes_out_of_scope_finding_to_issue` — out-of-scope finding filed, not auto-fixed.
- `test_phase_fix_prompt_enumerates_changed_files_when_provided` — allowed-files clause in delivered prompt.
- `test_phase_fix_prompt_includes_scope_and_precedence_constraints` — updated: asserts hard boundary, legacy license string absent.
- `test_gh_issue_create_constructs_argv_with_body_file_and_labels` — fake-`gh` argv verification.
- Daydream review round 1 findings (fail-close on revert failure; gate resume recompute) fixed in `30792cab` with their own regression tests.

## Verification

- `make check` green: ruff clean, mypy clean (313 files), **3031 passed / 6 skipped** (baseline 3025), lockcheck clean.
- Daydream deep review (pi backend): 2 findings (MEDIUM fail-open, LOW resume divergence) + 2 structural — all resolved and verified in code.
- Acceptance grep `justify each out-of-scope edit` in `*.py`: 0 hits.

## Out of scope

- `improve` flow unchanged (own flow).
- Review-phase scope behavior unchanged — fix phase only.
- No PR-comment posting changes — issues only.
