### PR TITLE
chore: remove .codex hooks feature config from public repo

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,3 +1,0 @@
-
-[features]
-hooks = true


### PR DESCRIPTION
## What

Removes the last tracked file left under the private agent-tooling dirs after #341: `.codex/config.toml` (`[features] hooks = true`).

## Why

That entry only existed to pair with the auto-generated `.codex/hooks.json` (removed in #341). Without the hooks file the config is inert, and it belongs to the maintainer's local setup, not the public repo.

## How

Pure deletion, same pattern as #341: `.codex/` is already gitignored, so `git rm --cached` makes the existing ignore rule effective. No code touched.