### PR TITLE
fix(deep): honor --cleanup when the fix-gate declines (Stop(0)) (#335)

### DIFF
--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -3316,12 +3316,8 @@ async def _run_review_spine(config: RunConfig, work: WorkContext, mode: str) -> 
         # .daydream/deep/ is preserved per RESEARCH.md Open Question 1 so
         # subsequent --start-at resumes can find the artifacts they need.
         #
-        # Terminal cleanup (#330) is tied to a SUCCESSFUL outcome, not to a
-        # position in STEPS: an early `Stop(0)` (e.g. the fix gate declining) is
-        # a successful end of review mode and still honors `--cleanup`, while a
-        # non-zero (failure) exit returns before the guard so evidence survives
-        # (#335).
+        # Cleanup is success-path only (#335); a non-zero exit returns before the guard so evidence survives.
         exit_code = await run_flow(ctx.registry, "deep", ctx)
-        if exit_code == 0 and _cleanup_applies(ctx):
+        if exit_code == 0 and _cleanup_applies(ctx) and ctx.config.findings_out is None:
             await _perform_cleanup(ctx)
         return exit_code

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -2685,16 +2685,17 @@ async def _step_commit(ctx: FlowContext) -> None:
     await phase_commit_push(ctx.backend_for("fix"), ctx.work)
 
 
-async def _step_cleanup(ctx: FlowContext) -> None:
+async def _perform_cleanup(ctx: FlowContext) -> None:
     """Terminal cleanup: remove the review output when enabled (#330).
 
     Restores the shallow ``commit-gate`` semantics the single-flow collapse
     dropped: ``--cleanup`` removes ``.review-output.md`` after a successful
     run, ``--no-cleanup`` keeps it, and an unspecified flag falls back to the
     old preamble gate (``--yes`` cleans up, unattended runs keep the artifact
-    via ``safe_default=False``, interactive runs prompt). This is the LAST
-    step, so every failure path (``Stop(1)`` short-circuits) skips it — a
-    failed or partial run keeps its evidence.
+    via ``safe_default=False``, interactive runs prompt). Not a flow step: it
+    is invoked by ``_run_review_spine`` on any successful exit, so an early
+    ``Stop(0)`` (e.g. a declined fix gate) still honors ``--cleanup`` while
+    every failure path (a non-zero exit) skips it to keep evidence.
     """
     config = ctx.config
     target_dir = ctx.work.repo
@@ -2941,7 +2942,7 @@ def _spine_findings_out(ctx: FlowContext) -> bool:
 #     per-stack reviews -> per-stack parse + dedup -> uncovered-file sweep (#309)
 #     -> arbiter -> cross-stack merge (or the tiny-diff single-stack bypass) ->
 #     supervise -> findings-out stop / post-review -> fix gate -> verify -> fix ->
-#     test -> commit -> cleanup.
+#     test -> commit.
 #
 # ``register_builtins`` registers :data:`STEPS` and the ``deep`` flow
 # definition; ``run_deep`` keeps the preamble and delegates here via
@@ -2952,6 +2953,12 @@ def _spine_findings_out(ctx: FlowContext) -> bool:
 # feedback mode runs only the prefix (the review spine is gated off and
 # ``respond-feedback`` ends the flow), and review/comment modes stop after
 # ``post-review`` (the fix cycle is gated off).
+#
+# Terminal cleanup (#330) is NOT a step: it is a success-path helper invoked by
+# ``_run_review_spine`` after ``run_flow`` returns. Tying it to the run's exit
+# code (rather than the end of this tuple) means an early successful ``Stop(0)``
+# -- the fix gate declining -- still honors ``--cleanup``, while any non-zero
+# (failure) exit skips it to keep evidence (#335).
 STEPS: tuple[FlowStep, ...] = (
     # Feedback-mode prefix (was the ``pr-feedback`` flow): runs first and
     # ``respond-feedback`` ends the flow, so the review spine below never runs.
@@ -2988,10 +2995,6 @@ STEPS: tuple[FlowStep, ...] = (
     FlowStep(name="test", run=_step_test, enabled=_fix_cycle_enabled),
     # config_phase "fix" mirrors the old body's use of the fix backend for the commit.
     FlowStep(name="commit", run=_step_commit, config_phase="fix", enabled=_fix_cycle_enabled),
-    # Terminal cleanup (#330): the last step, so it only runs on successful
-    # completion. Review modes fall off the end after post-review; loop/shallow
-    # reach it after commit; feedback mode never writes the report.
-    FlowStep(name="cleanup", run=_step_cleanup, enabled=_cleanup_applies),
 )
 
 
@@ -3312,4 +3315,13 @@ async def _run_review_spine(config: RunConfig, work: WorkContext, mode: str) -> 
         # on an exact head+diff+tier+depth match and rewrites on a miss, and
         # .daydream/deep/ is preserved per RESEARCH.md Open Question 1 so
         # subsequent --start-at resumes can find the artifacts they need.
-        return await run_flow(ctx.registry, "deep", ctx)
+        #
+        # Terminal cleanup (#330) is tied to a SUCCESSFUL outcome, not to a
+        # position in STEPS: an early `Stop(0)` (e.g. the fix gate declining) is
+        # a successful end of review mode and still honors `--cleanup`, while a
+        # non-zero (failure) exit returns before the guard so evidence survives
+        # (#335).
+        exit_code = await run_flow(ctx.registry, "deep", ctx)
+        if exit_code == 0 and _cleanup_applies(ctx):
+            await _perform_cleanup(ctx)
+        return exit_code

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -2891,6 +2891,18 @@ def _cleanup_applies(ctx: FlowContext) -> bool:
     return _mode_of(ctx) in ("loop", "shallow", "review", "comment")
 
 
+def _cleanup_should_run(ctx: FlowContext, exit_code: int) -> bool:
+    """Whether terminal cleanup runs after a deep flow — success-path only.
+
+    A zero exit is a successful completion (an early ``Stop(0)``, e.g. a
+    declined fix gate, still honors ``--cleanup``); any non-zero (failure)
+    exit skips cleanup so evidence survives (#335). ``--findings-out`` runs
+    stop with exit 0 but must keep the rendered report the run was asked to
+    produce, so they are excluded (``findings_out is None``).
+    """
+    return exit_code == 0 and _cleanup_applies(ctx) and ctx.config.findings_out is None
+
+
 def _spine_enabled(ctx: FlowContext) -> bool:
     """The review spine is skipped entirely in feedback mode."""
     return not _feedback_mode(ctx)
@@ -3318,6 +3330,6 @@ async def _run_review_spine(config: RunConfig, work: WorkContext, mode: str) -> 
         #
         # Cleanup is success-path only (#335); a non-zero exit returns before the guard so evidence survives.
         exit_code = await run_flow(ctx.registry, "deep", ctx)
-        if exit_code == 0 and _cleanup_applies(ctx) and ctx.config.findings_out is None:
+        if _cleanup_should_run(ctx, exit_code):
             await _perform_cleanup(ctx)
         return exit_code

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -284,7 +284,6 @@ unique step names, and use `config_phase` to reuse an existing config key.
 | 20 | `fix` | `fix` |
 | 21 | `test` | `test` |
 | 22 | `commit` | `fix` |
-| 23 | `cleanup` | `cleanup` |
 
 The steps are gated by the run's mode (`ctx.data["mode"]`), set in the dispatch
 preamble: `feedback` runs only the prefix (steps 1-5, ending at
@@ -293,11 +292,13 @@ preamble: `feedback` runs only the prefix (steps 1-5, ending at
 `comment`); `shallow` forces `single_stack_mode` (no arbiter / cross-stack
 merge); `loop` is the unchanged default fixing everything.
 
-`cleanup` (step 23) is the terminal step in every mode that writes the rendered
-report: it only runs on successful completion (any `Stop` short-circuits before
-it) and removes `.review-output.md` per `--cleanup` / `--no-cleanup` /
-interactive-or-unattended prompt defaults. It is gated off in `feedback` mode
-(no report is written there).
+`.review-output.md` cleanup is not a flow step; it runs in `_run_review_spine`
+after `run_flow` returns, tied to a successful outcome (`exit_code == 0`), the
+mode gate (loop/shallow/review/comment — never `feedback`, which writes no
+report), and `config.findings_out is None` (a `--findings-out` run keeps the
+rendered report the user asked it to produce). It is skipped entirely on any
+non-zero (failure) exit so evidence survives, and removes the report per
+`--cleanup` / `--no-cleanup` / interactive-or-unattended prompt defaults (#335).
 
 `per-stack-reviews` runs the TTT alternative-review (wonder) as well: on a fresh
 multi-stack run the two are siblings in one task group, so wonder has no step of

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -135,6 +135,14 @@ not bump the version.
   retarget: shallow/comment/review run the `deep` flow (replacing the per-stack
   prompt, or inserting a step anchored to a `deep` step name), and the feedback
   prefix is a mode of `deep`, not a separately registered flow.
+  Also removed in this series: the `cleanup` step name is gone from the `deep`
+  flow inventory — terminal `.review-output.md` cleanup now runs as a
+  success-path helper invoked by the review spine after `run_flow` returns
+  (gated on a zero exit, the loop/shallow/review/comment modes, and no
+  `--findings-out`), not as a registered step (#335). Forks that did
+  `r.remove("deep", "cleanup")` or
+  `insert_after("deep", anchor="cleanup", ...)` must retarget — `cleanup` is
+  no longer a step name (the step table below reflects the reduced inventory).
 - **Version 4** — **hard-breaking**. The `alternatives` step is removed from
   the `deep` flow: the TTT alternative-review (wonder) now runs concurrently
   with the per-stack fan-out inside the `per-stack-reviews` step, so on a fresh

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -6114,6 +6114,47 @@ async def test_deep_findings_out_emits_artifact_and_stops(
     assert not (multi_stack_target / ".daydream-fix-applied").exists()
 
 
+async def test_cleanup_keeps_report_on_findings_out_run(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch, make_config: MakeConfig
+) -> None:
+    """Real-path: ``--findings-out --cleanup`` keeps ``.review-output.md``.
+
+    A ``--findings-out`` run stops with exit 0 (``_step_findings_out``) after
+    ``load-items`` has rendered the report, so the success-path cleanup guard
+    would delete the very report the run was asked to emit unless the
+    ``findings_out is None`` clause excludes it. This test pins that clause:
+    the run must exit 0, write the findings artifact, and still leave
+    ``.review-output.md`` in place despite ``cleanup=True``.
+    """
+    from daydream.config import REVIEW_OUTPUT_FILE
+    from daydream.runner import run
+
+    _silence_gate_noise(monkeypatch)
+    monkeypatch.delenv("DAYDREAM_APP_ID", raising=False)
+    monkeypatch.delenv("DAYDREAM_APP_PRIVATE_KEY", raising=False)
+    _install_stub_backend(monkeypatch, multi_stack_target)
+
+    async def _post_forbidden(target_dir: Path, report_path: Path, *, console: Any) -> None:
+        raise AssertionError("--findings-out must not post to the PR")
+
+    monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _post_forbidden)
+    _pin_findings_pr(monkeypatch, multi_stack_target)
+
+    out = multi_stack_target / "findings.json"
+    report = multi_stack_target / REVIEW_OUTPUT_FILE
+
+    rc = await run(
+        make_config(multi_stack_target, pr_number=7, findings_out=str(out), cleanup=True)
+    )
+
+    assert rc == 0
+    assert out.exists(), "--findings-out must still write the findings artifact"
+    assert report.exists(), (
+        "--findings-out --cleanup must keep .review-output.md: the run exits 0 but "
+        "was asked to emit the report, so cleanup must not delete it"
+    )
+
+
 async def test_test_verdict_artifact_written_on_passing_suite(
     tiny_diff_target: Path, monkeypatch: pytest.MonkeyPatch, make_config: MakeConfig, mute_side_effects: Mute
 ) -> None:

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -4092,8 +4092,16 @@ async def test_cleanup_none_interactive_prompts_before_keeping(
     assert report.exists(), "declining the cleanup prompt must keep .review-output.md"
 
 
-async def test_cleanup_true_removes_review_output_when_gate_declines(
-    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch, make_config: MakeConfig, mute_side_effects: Mute
+@pytest.mark.parametrize(
+    ("cleanup", "expected_exists"), [(True, False), (False, True)]
+)
+async def test_cleanup_gate_declines_honors_cleanup_flag(
+    cleanup: bool,
+    expected_exists: bool,
+    multi_stack_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+    mute_side_effects: Mute,
 ) -> None:
     """#335 real-path: ``--cleanup`` is honored even when the fix gate declines.
 
@@ -4101,7 +4109,8 @@ async def test_cleanup_true_removes_review_output_when_gate_declines(
     ``_step_fix_gate``), which short-circuits the flow before the old terminal
     step. Cleanup is tied to the run's exit code, not its position in the
     flow, so an interactive ``--cleanup`` run that declines the fix gate still
-    removes ``.review-output.md`` by the time the run returns 0.
+    removes ``.review-output.md`` (and ``--no-cleanup`` keeps it) by the time
+    the run returns 0.
     """
     from daydream.config import REVIEW_OUTPUT_FILE
     from daydream.runner import run
@@ -4119,32 +4128,15 @@ async def test_cleanup_true_removes_review_output_when_gate_declines(
     monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
 
     report = multi_stack_target / REVIEW_OUTPUT_FILE
-    exit_code = await run(make_config(multi_stack_target, cleanup=True, non_interactive=False))
-
-    assert exit_code == 0
-    assert not report.exists(), (
-        "cleanup=True must remove .review-output.md even when the fix gate declines"
+    exit_code = await run(
+        make_config(multi_stack_target, cleanup=cleanup, non_interactive=False)
     )
 
-
-async def test_cleanup_false_retains_review_output_when_gate_declines(
-    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch, make_config: MakeConfig, mute_side_effects: Mute
-) -> None:
-    """#335 real-path: ``--no-cleanup`` keeps the report on a declined fix gate."""
-    from daydream.config import REVIEW_OUTPUT_FILE
-    from daydream.runner import run
-
-    _install_stub_backend(monkeypatch, multi_stack_target)
-    mute_side_effects()
-    _force_interactive(monkeypatch)
-    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "n")
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
-
-    report = multi_stack_target / REVIEW_OUTPUT_FILE
-    exit_code = await run(make_config(multi_stack_target, cleanup=False, non_interactive=False))
-
     assert exit_code == 0
-    assert report.exists(), "cleanup=False must keep .review-output.md when the fix gate declines"
+    assert report.exists() is expected_exists, (
+        f"cleanup={cleanup} must {'remove' if expected_exists is False else 'keep'} "
+        ".review-output.md when the fix gate declines"
+    )
 
 
 async def test_cleanup_skips_on_failure_keeps_evidence(

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -4092,6 +4092,101 @@ async def test_cleanup_none_interactive_prompts_before_keeping(
     assert report.exists(), "declining the cleanup prompt must keep .review-output.md"
 
 
+async def test_cleanup_true_removes_review_output_when_gate_declines(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch, make_config: MakeConfig, mute_side_effects: Mute
+) -> None:
+    """#335 real-path: ``--cleanup`` is honored even when the fix gate declines.
+
+    A declined fix gate is a SUCCESSFUL end of review mode (``Stop(0)`` from
+    ``_step_fix_gate``), which short-circuits the flow before the old terminal
+    step. Cleanup is tied to the run's exit code, not its position in the
+    flow, so an interactive ``--cleanup`` run that declines the fix gate still
+    removes ``.review-output.md`` by the time the run returns 0.
+    """
+    from daydream.config import REVIEW_OUTPUT_FILE
+    from daydream.runner import run
+
+    _install_stub_backend(monkeypatch, multi_stack_target)
+    mute_side_effects()
+    # Pin interactivity ON so the fix-gate prompt path runs (resolve_gate
+    # returns None when interactive with no assumption, then prompts).
+    _force_interactive(monkeypatch)
+
+    # Decline the apply-fixes gate: the fix-gate prompt is the one under
+    # observation (routed through daydream.agent.prompt_user).
+    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "n")
+    # Accept the intent gate so the review spine proceeds.
+    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
+
+    report = multi_stack_target / REVIEW_OUTPUT_FILE
+    exit_code = await run(make_config(multi_stack_target, cleanup=True, non_interactive=False))
+
+    assert exit_code == 0
+    assert not report.exists(), (
+        "cleanup=True must remove .review-output.md even when the fix gate declines"
+    )
+
+
+async def test_cleanup_false_retains_review_output_when_gate_declines(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch, make_config: MakeConfig, mute_side_effects: Mute
+) -> None:
+    """#335 real-path: ``--no-cleanup`` keeps the report on a declined fix gate."""
+    from daydream.config import REVIEW_OUTPUT_FILE
+    from daydream.runner import run
+
+    _install_stub_backend(monkeypatch, multi_stack_target)
+    mute_side_effects()
+    _force_interactive(monkeypatch)
+    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "n")
+    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
+
+    report = multi_stack_target / REVIEW_OUTPUT_FILE
+    exit_code = await run(make_config(multi_stack_target, cleanup=False, non_interactive=False))
+
+    assert exit_code == 0
+    assert report.exists(), "cleanup=False must keep .review-output.md when the fix gate declines"
+
+
+async def test_cleanup_skips_on_failure_keeps_evidence(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch, make_config: MakeConfig, mute_side_effects: Mute
+) -> None:
+    """#335 real-path: a non-zero exit skips ``--cleanup`` so evidence survives.
+
+    Cleanup is tied to a SUCCESSFUL outcome (exit 0). A step that returns
+    ``Stop(1)`` from inside the flow must leave ``.review-output.md`` in place
+    even with ``--cleanup``. The merged report is rendered by ``load-items``
+    before the fix gate, so a failing fix gate is exactly the post-report
+    failure a user would want to keep as evidence.
+    """
+    import dataclasses
+
+    from daydream.config import REVIEW_OUTPUT_FILE
+    from daydream.deep import orchestrator as deep_orchestrator
+    from daydream.extensions.api import Stop
+    from daydream.runner import run
+
+    _install_stub_backend(monkeypatch, multi_stack_target)
+    mute_side_effects()
+
+    async def _fail_fix_gate(_ctx: object) -> Stop:
+        return Stop(1)
+
+    # build_registry() reads deep.STEPS fresh on every run(), so swapping the
+    # fix-gate step's body makes the real runner entry fail cleanly after the
+    # report is written, without touching the flow engine or any other step.
+    patched_steps = tuple(
+        dataclasses.replace(step, run=_fail_fix_gate) if step.name == "fix-gate" else step
+        for step in deep_orchestrator.STEPS
+    )
+    monkeypatch.setattr(deep_orchestrator, "STEPS", patched_steps)
+
+    report = multi_stack_target / REVIEW_OUTPUT_FILE
+    exit_code = await run(make_config(multi_stack_target, cleanup=True))
+
+    assert exit_code == 1
+    assert report.exists(), "a failed run must keep .review-output.md as evidence even with --cleanup"
+
+
 # Git timeout under load (issue #120)
 
 


### PR DESCRIPTION
## Summary

`--cleanup` was silently ignored when the fix-gate declined a fix. `_step_cleanup` was a positional `FlowStep` at the tail of `deep.STEPS`, so `run_flow`'s `Stop(0)` from a declined fix gate short-circuited before it — the run ended with exit 0 but left `.review-output.md` behind despite `--cleanup`.

## Root-cause fix

Tie cleanup to **outcome**, not tuple position: run it in `_run_review_spine` after `run_flow` returns, gated on `exit_code == 0`. This honors `--cleanup` on an early `Stop(0)` (declined fix gate) while still skipping on any non-zero (failure) exit so evidence survives.

Two additional items surfaced by the deep daydream review on the sprite:

- **`--findings-out` widening:** the guard keys to any exit-0, so a `--findings-out` run would now delete (with `--cleanup`) or prompt about the rendered report the user explicitly asked it to produce. Scoped the guard to `config.findings_out is None` so findings-output runs keep the report.
- **Docs staleness:** `docs/extensions.md` still documented the removed `cleanup` FlowStep (step 23) with pre-#335 semantics. Removed the stale row and described the new success-path guard.

## Tests

Three real-path tests through `runner.run` with the stub backend (expanded to a parametrized pair after the review):

- declined gate + `--cleanup` → report removed (RED before fix, GREEN after)
- declined gate + `--no-cleanup` → report kept
- failure exit (`Stop(1)`) under `--cleanup` → evidence kept

## Verification

`make check` path: **3092 passed, 6 skipped** (only pre-existing arbiter UserWarnings).

Fixes #335