### PR TITLE
fix(improve): land re-anchored plans durably in the plan index (#349) (#350)

### DIFF
--- a/daydream/improve/orchestrator.py
+++ b/daydream/improve/orchestrator.py
@@ -1578,10 +1578,14 @@ async def _step_write_plans(ctx: FlowContext) -> None:
         landed += 1
         if outcome.status == "written" and outcome.number is not None:
             announced.add(outcome.number)
+            path = outcome.path or ""
+            landing = (
+                path if Path(path).is_absolute() else f"daydream_plans/{path}"
+            )
             print_success(
                 console,
-                f"Plan {outcome.number:03d} written to "
-                f"daydream_plans/{outcome.path} ({landed}/{total}).",
+                f"Plan {outcome.number:03d} written to {landing} "
+                f"({landed}/{total}).",
             )
         else:
             print_info(

--- a/daydream/improve/orchestrator.py
+++ b/daydream/improve/orchestrator.py
@@ -1829,10 +1829,13 @@ async def _step_write_plans(ctx: FlowContext) -> None:
     result = session.finish()
     for entry in result["written"]:
         if entry["number"] not in announced:
+            path = entry["path"] or ""
+            landing = (
+                path if Path(path).is_absolute() else f"daydream_plans/{path}"
+            )
             print_success(
                 console,
-                f"Plan {entry['number']:03d} written to "
-                f"daydream_plans/{entry['path']}.",
+                f"Plan {entry['number']:03d} written to {landing}.",
             )
     record_plan_write_diagnostics(
         plan_write_diagnostics_path(ctx.data["improve_dir"]),

--- a/daydream/improve/orchestrator.py
+++ b/daydream/improve/orchestrator.py
@@ -59,6 +59,7 @@ from daydream.improve.plans import (
     _attempt_diagnostic,
     load_rejections,
     plan_slug,
+    prune_stale_reanchor_worktrees,
     record_plan_write_diagnostics,
     record_rejections,
 )
@@ -1531,6 +1532,7 @@ def _description_finding(description: str) -> dict[str, Any]:
 
 async def _step_write_plans(ctx: FlowContext) -> None:
     """Write selected findings as host-stamped, reconciling handoff plans."""
+    prune_stale_reanchor_worktrees(ctx.work.repo)
     description = ctx.config.improve_plan_description
     if description is not None:
         selected = [_description_finding(description)]

--- a/daydream/improve/plans.py
+++ b/daydream/improve/plans.py
@@ -44,6 +44,9 @@ _INDEX_ROW_LINK = re.compile(r"\[\d{3}\]\(\d{3}-([a-z0-9-]+)\.md\)")
 # a filesystem-safe run id may reach the path; anything else falls back to an
 # anchor-derived name.
 _SAFE_DIRNAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$")
+# Re-anchor worktree dirnames end in this suffix; the prune pass and the
+# re-anchor write share it so a rename can never silently stop pruning.
+_REANCHOR_DIR_SUFFIX = "-reanchor"
 
 
 def load_rejections(plans_dir: Path) -> dict[str, dict[str, Any]]:
@@ -509,7 +512,9 @@ def prune_stale_reanchor_worktrees(repo: Path) -> int:
     so one stale worktree never blocks a plan run.
     """
     removed = 0
-    for path in (repo / ".daydream" / "worktrees").glob("*-reanchor"):
+    for path in (
+        repo / ".daydream" / "worktrees"
+    ).glob(f"*{_REANCHOR_DIR_SUFFIX}"):
         if not path.is_dir():
             continue
         try:
@@ -575,22 +580,29 @@ def _render_index(
         "|------|-------|----------|--------|--------|\n"
         + ("\n".join(rows) if rows else "| — | No plans written. | — | — | — |")
         + "\n\nStatus values: TODO | IN PROGRESS | DONE | BLOCKED "
-        "(with one-line reason) | REJECTED (with one-line rationale)\n\n"
+        "(with one-line reason) | REJECTED (with one-line rationale) | "
+        "REANCHORED (with one-line landing path)\n\n"
         "## Findings considered and rejected\n\n"
         + ("\n".join(rejected_lines) if rejected_lines else "- None.")
         + "\n"
     )
 
 
-def _index_row(entry: PlanIndexEntry) -> str:
+def _index_row(
+    entry: PlanIndexEntry, *, plans_dir: Path | None = None
+) -> str:
     """Render one durable entry as an execution-order row.
 
-    A re-anchored entry names a plan file that lives inside a ``*-reanchor``
-    worktree, not as a sibling of this index, so its plan cell is the bare
-    number (the landing path is carried in the Status cell instead).
+    When *plans_dir* is given, an entry whose plan file is not present there
+    renders as the bare number: the file lives elsewhere (e.g. a re-anchored
+    plan's sibling inside the worktree index), so a link would dangle.
     """
     filename = entry.path
-    if entry.status.startswith("REANCHORED"):
+    if (
+        plans_dir is not None
+        and filename is not None
+        and not _has_plan_file(plans_dir, entry)
+    ):
         plan_cell = f"{entry.number:03d}"
     else:
         plan_cell = (
@@ -626,6 +638,33 @@ def _blocked_entry(
         planned_at=planned_at,
         status=status,
         host_blocked=_HOST_BLOCKED_STATUS.fullmatch(status) is not None,
+    )
+
+
+def _index_entry(
+    *,
+    number: int,
+    slug: str,
+    title: str,
+    fingerprint: str,
+    finding: dict[str, Any],
+    planned_at: str,
+    status: str,
+    host_blocked: bool = False,
+) -> PlanIndexEntry:
+    """Build one durable index entry from a landed plan's finding fields."""
+    return PlanIndexEntry(
+        number=number,
+        slug=slug,
+        title=_index_field(title),
+        fingerprint=fingerprint,
+        priority=plan_priority(finding),
+        effort=_index_field(finding.get("effort")),
+        risk=_index_field(finding.get("risk")),
+        category=_index_field(finding.get("category")),
+        planned_at=planned_at,
+        status=status,
+        host_blocked=host_blocked,
     )
 
 
@@ -843,6 +882,42 @@ class PlanWriteSession:
             str(finding.get("title") or "Selected finding"),
         )
 
+    def _record_written(
+        self,
+        reservation: PlanReservation,
+        selection: dict[str, Any],
+        *,
+        number: int,
+        title: str,
+        finding: dict[str, Any],
+        attempt: dict[str, Any] | None,
+        plan_result: dict[str, Any],
+        path: str,
+        artifact: dict[str, Any],
+    ) -> PlanOutcome:
+        """Record a successfully landed plan and return its outcome."""
+        self._written.append(
+            (
+                reservation.index,
+                {**selection, "number": number, "path": path},
+            )
+        )
+        self._diagnostics.append(
+            (
+                reservation.index,
+                _attempt_diagnostic(
+                    finding=finding,
+                    attempt=attempt,
+                    received=plan_result,
+                    disposition="success",
+                    stage="success",
+                    artifact=artifact,
+                ),
+            )
+        )
+        self._fingerprints.add(reservation.fingerprint)
+        return PlanOutcome("written", number, path, title)
+
     def _land(
         self,
         reservation: PlanReservation,
@@ -950,41 +1025,28 @@ class PlanWriteSession:
                 received=plan_result,
             )
         (self._plans_dir / filename).write_text(text, encoding="utf-8")
-        self._entries[number] = PlanIndexEntry(
+        self._entries[number] = _index_entry(
             number=number,
             slug=slug,
-            title=_index_field(selection.get("title") or title),
+            title=selection.get("title") or title,
             fingerprint=reservation.fingerprint,
-            priority=plan_priority(finding),
-            effort=_index_field(finding.get("effort")),
-            risk=_index_field(finding.get("risk")),
-            category=_index_field(finding.get("category")),
+            finding=finding,
             planned_at=self._planned_at,
             status="TODO",
-            host_blocked=False,
         )
-        self._written.append(
-            (
-                reservation.index,
-                {**selection, "number": number, "path": filename},
-            )
+        outcome = self._record_written(
+            reservation,
+            selection,
+            number=number,
+            title=title,
+            finding=finding,
+            attempt=attempt,
+            plan_result=plan_result,
+            path=filename,
+            artifact={"path": filename, "status": "TODO"},
         )
-        self._diagnostics.append(
-            (
-                reservation.index,
-                _attempt_diagnostic(
-                    finding=finding,
-                    attempt=attempt,
-                    received=plan_result,
-                    disposition="success",
-                    stage="success",
-                    artifact={"path": filename, "status": "TODO"},
-                ),
-            )
-        )
-        self._fingerprints.add(reservation.fingerprint)
         self._write_index()
-        return PlanOutcome("written", number, filename, title)
+        return outcome
 
     def _reanchor_and_write(
         self,
@@ -1001,9 +1063,11 @@ class PlanWriteSession:
         The plan's content is complete; only the ``planned_at`` anchor is stale
         because HEAD advanced past the commit captured at session start. The
         plan lands in a fresh detached worktree at the current HEAD, re-anchored
-        to it, and returns ``written`` with the full path it landed at — a stale
-        anchor alone must not discard a valid plan. Any sub-failure falls back to
-        :meth:`_block` with ``PLAN_REANCHOR_FAILED``; nothing is silently dropped.
+        to it, plus a durable copy in the main index's ``daydream_plans/`` so it
+        survives the next run's worktree pruning, and returns ``written`` with
+        the full worktree path it landed at — a stale anchor alone must not
+        discard a valid plan. Any sub-failure falls back to :meth:`_block` with
+        ``PLAN_REANCHOR_FAILED``; nothing is silently dropped.
         """
         finding = selection["finding"]
         attempt = self._attempt_of(selection)
@@ -1032,9 +1096,14 @@ class PlanWriteSession:
                 if _SAFE_DIRNAME.fullmatch(run_id) is None:
                     run_id = f"run-{self._planned_at[:12]}"
                 worktree = (
-                    self._repo / ".daydream" / "worktrees" / f"{run_id}-reanchor"
+                    self._repo
+                    / ".daydream"
+                    / "worktrees"
+                    / f"{run_id}{_REANCHOR_DIR_SUFFIX}"
                 )
-                git_ops.worktree_add(self._repo, worktree, "HEAD", detach=True)
+                git_ops.worktree_add(
+                    self._repo, worktree, new_head, detach=True
+                )
                 self._reanchor_worktree = worktree
             text = render_plan(
                 finding,
@@ -1047,73 +1116,59 @@ class PlanWriteSession:
             plans_dir = worktree / "daydream_plans"
             plans_dir.mkdir(parents=True, exist_ok=True)
             (plans_dir / filename).write_text(text, encoding="utf-8")
-            self._reanchored[number] = PlanIndexEntry(
+            # The plan text is worktree-independent: land the durable copy in the
+            # main index too, so it survives the next run's worktree pruning.
+            (self._plans_dir / filename).write_text(text, encoding="utf-8")
+            self._reanchored[number] = _index_entry(
                 number=number,
                 slug=slug,
-                title=_index_field(selection.get("title") or title),
+                title=selection.get("title") or title,
                 fingerprint=reservation.fingerprint,
-                priority=plan_priority(finding),
-                effort=_index_field(finding.get("effort")),
-                risk=_index_field(finding.get("risk")),
-                category=_index_field(finding.get("category")),
+                finding=finding,
                 planned_at=new_head,
                 status="TODO",
-                host_blocked=False,
             )
             entries = dict(self._entries)
             entries.update(self._reanchored)
             self._write_index_files(
                 plans_dir,
                 [entries[index] for index in sorted(entries)],
+                check_links=True,
             )
             landed_rel = (
                 (worktree / "daydream_plans" / filename)
                 .relative_to(self._repo)
                 .as_posix()
             )
-            self._entries[number] = PlanIndexEntry(
+            self._entries[number] = _index_entry(
                 number=number,
                 slug=slug,
-                title=_index_field(selection.get("title") or title),
+                title=selection.get("title") or title,
                 fingerprint=reservation.fingerprint,
-                priority=plan_priority(finding),
-                effort=_index_field(finding.get("effort")),
-                risk=_index_field(finding.get("risk")),
-                category=_index_field(finding.get("category")),
+                finding=finding,
                 planned_at=new_head,
                 status=f"REANCHORED (landed at {landed_rel})",
-                host_blocked=False,
             )
         except Exception:  # noqa: BLE001 - persist a safe re-anchor disposition
             return _reanchor_failed()
 
         landed_path = (worktree / "daydream_plans" / filename).as_posix()
-        self._written.append(
-            (
-                reservation.index,
-                {**selection, "number": number, "path": landed_path},
-            )
+        return self._record_written(
+            reservation,
+            selection,
+            number=number,
+            title=title,
+            finding=finding,
+            attempt=attempt,
+            plan_result=plan_result,
+            path=landed_path,
+            artifact={
+                "path": landed_path,
+                "status": "TODO",
+                "reanchored": True,
+                "planned_at": new_head,
+            },
         )
-        self._diagnostics.append(
-            (
-                reservation.index,
-                _attempt_diagnostic(
-                    finding=finding,
-                    attempt=attempt,
-                    received=plan_result,
-                    disposition="success",
-                    stage="success",
-                    artifact={
-                        "path": landed_path,
-                        "status": "TODO",
-                        "reanchored": True,
-                        "planned_at": new_head,
-                    },
-                ),
-            )
-        )
-        self._fingerprints.add(reservation.fingerprint)
-        return PlanOutcome("written", number, landed_path, title)
 
     def _write_index(self) -> None:
         """Rewrite the sidecar and its rendered index from the entries so far.
@@ -1126,7 +1181,11 @@ class PlanWriteSession:
         self._write_index_files(self._plans_dir, entries)
 
     def _write_index_files(
-        self, plans_dir: Path, entries: Sequence[PlanIndexEntry]
+        self,
+        plans_dir: Path,
+        entries: Sequence[PlanIndexEntry],
+        *,
+        check_links: bool = False,
     ) -> None:
         """Write the sidecar and its rendered index for *entries* into *plans_dir*."""
         (plans_dir / PLAN_INDEX_FILENAME).write_text(
@@ -1144,7 +1203,13 @@ class PlanWriteSession:
         )
         (plans_dir / "README.md").write_text(
             _render_index(
-                [_index_row(entry) for entry in entries],
+                [
+                    _index_row(
+                        entry,
+                        plans_dir=plans_dir if check_links else None,
+                    )
+                    for entry in entries
+                ],
                 plans_dir=plans_dir,
                 planned_on=self._planned_on,
                 non_interactive_default=self._non_interactive_default,

--- a/daydream/improve/plans.py
+++ b/daydream/improve/plans.py
@@ -563,13 +563,21 @@ def _render_index(
 
 
 def _index_row(entry: PlanIndexEntry) -> str:
-    """Render one durable entry as an execution-order row."""
+    """Render one durable entry as an execution-order row.
+
+    A re-anchored entry names a plan file that lives inside a ``*-reanchor``
+    worktree, not as a sibling of this index, so its plan cell is the bare
+    number (the landing path is carried in the Status cell instead).
+    """
     filename = entry.path
-    plan_cell = (
-        f"[{entry.number:03d}]({filename})"
-        if filename is not None
-        else f"{entry.number:03d}"
-    )
+    if entry.status.startswith("REANCHORED"):
+        plan_cell = f"{entry.number:03d}"
+    else:
+        plan_cell = (
+            f"[{entry.number:03d}]({filename})"
+            if filename is not None
+            else f"{entry.number:03d}"
+        )
     return (
         f"| {plan_cell} <!-- fingerprint:{entry.fingerprint} --> | "
         f"{markdown_cell(entry.title)} | {markdown_cell(entry.priority)} | "
@@ -1037,6 +1045,24 @@ class PlanWriteSession:
             self._write_index_files(
                 plans_dir,
                 [entries[index] for index in sorted(entries)],
+            )
+            landed_rel = (
+                (worktree / "daydream_plans" / filename)
+                .relative_to(self._repo)
+                .as_posix()
+            )
+            self._entries[number] = PlanIndexEntry(
+                number=number,
+                slug=slug,
+                title=_index_field(selection.get("title") or title),
+                fingerprint=reservation.fingerprint,
+                priority=plan_priority(finding),
+                effort=_index_field(finding.get("effort")),
+                risk=_index_field(finding.get("risk")),
+                category=_index_field(finding.get("category")),
+                planned_at=new_head,
+                status=f"REANCHORED (landed at {landed_rel})",
+                host_blocked=False,
             )
         except Exception:  # noqa: BLE001 - persist a safe re-anchor disposition
             return _reanchor_failed()

--- a/daydream/improve/plans.py
+++ b/daydream/improve/plans.py
@@ -500,6 +500,26 @@ def planned_fingerprints(plans_dir: Path) -> set[str]:
     }
 
 
+def prune_stale_reanchor_worktrees(repo: Path) -> int:
+    """Remove leftover ``*-reanchor`` worktrees from prior plan runs.
+
+    Repeated head-drift runs accumulate detached worktrees under
+    ``.daydream/worktrees/<run_id>-reanchor``; each new plan run prunes them so
+    the directory does not grow unboundedly. Individual failures are tolerated
+    so one stale worktree never blocks a plan run.
+    """
+    removed = 0
+    for path in (repo / ".daydream" / "worktrees").glob("*-reanchor"):
+        if not path.is_dir():
+            continue
+        try:
+            git_ops.worktree_remove(repo, path, force=True)
+        except git_ops.GitError:
+            continue
+        removed += 1
+    return removed
+
+
 def _highest_plan_number(
     plans_dir: Path, entries: Iterable[PlanIndexEntry]
 ) -> int:

--- a/daydream/improve/plans.py
+++ b/daydream/improve/plans.py
@@ -12,6 +12,7 @@ from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import Any
 
+from daydream import git_ops
 from daydream.improve.prioritize import plan_priority
 from daydream.improve.render import (
     _redact_model_value,
@@ -39,6 +40,10 @@ _INDEX_ROW_NUMBER = re.compile(r"\b(\d{3})\b")
 # The slug class admits no separator or dot, so a recovered link can never name
 # anything but a sibling plan file.
 _INDEX_ROW_LINK = re.compile(r"\[\d{3}\]\(\d{3}-([a-z0-9-]+)\.md\)")
+# Re-anchor worktree directory names are built from the run session id, so only
+# a filesystem-safe run id may reach the path; anything else falls back to an
+# anchor-derived name.
+_SAFE_DIRNAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$")
 
 
 def load_rejections(plans_dir: Path) -> dict[str, dict[str, Any]]:
@@ -304,16 +309,6 @@ def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
         capture_output=True,
         text=True,
         check=False,
-    )
-
-
-def _head_matches(repo: Path, planned_at: str) -> bool:
-    planned = _git(repo, "rev-parse", "--verify", f"{planned_at}^{{commit}}")
-    head = _git(repo, "rev-parse", "--verify", "HEAD")
-    return (
-        planned.returncode == 0
-        and head.returncode == 0
-        and planned.stdout.strip() == head.stdout.strip()
     )
 
 
@@ -685,6 +680,8 @@ class PlanWriteSession:
         self._skipped: list[tuple[int, dict[str, Any]]] = []
         self._failed: list[tuple[int, dict[str, Any]]] = []
         self._diagnostics: list[tuple[int, dict[str, Any]]] = []
+        self._reanchored: dict[int, PlanIndexEntry] = {}
+        self._reanchor_worktree: Path | None = None
         self._planned_at_errors: tuple[str, ...] = ()
         commit = _git(self._repo, "cat-file", "-e", f"{planned_at}^{{commit}}")
         if commit.returncode != 0:
@@ -874,10 +871,7 @@ class PlanWriteSession:
             )
 
         plan_result = _plan_payload(selection)
-        errors = self._planned_at_errors
-        if not errors and not _head_matches(self._repo, self._planned_at):
-            errors = ("PLAN_HEAD_CHANGED",)
-        if errors:
+        if self._planned_at_errors:
             return self._block(
                 reservation,
                 selection,
@@ -885,11 +879,25 @@ class PlanWriteSession:
                 finding=finding,
                 status=(
                     "BLOCKED (PLAN_VALIDATION_FAILED: "
-                    f"{','.join(errors)})"
+                    f"{','.join(self._planned_at_errors)})"
                 ),
-                stage=_validation_stage(errors),
-                errors=errors,
+                stage=_validation_stage(self._planned_at_errors),
+                errors=self._planned_at_errors,
                 received=plan_result,
+            )
+
+        try:
+            current_head = git_ops.head_sha(self._repo)
+        except git_ops.GitError:
+            current_head = None
+        if current_head != self._planned_at:
+            return self._reanchor_and_write(
+                reservation,
+                selection,
+                plan_result,
+                number=number,
+                title=title,
+                slug=slug,
             )
 
         filename = f"{number:03d}-{slug}.md"
@@ -911,19 +919,6 @@ class PlanWriteSession:
                 status="BLOCKED (PLAN_VALIDATION_FAILED: RENDER_FAILED)",
                 stage="render",
                 errors=("RENDER_FAILED",),
-                received=plan_result,
-            )
-        if not _head_matches(self._repo, self._planned_at):
-            return self._block(
-                reservation,
-                selection,
-                number=number,
-                finding=finding,
-                status=(
-                    "BLOCKED (PLAN_VALIDATION_FAILED: PLAN_HEAD_CHANGED)"
-                ),
-                stage=_validation_stage(("PLAN_HEAD_CHANGED",)),
-                errors=("PLAN_HEAD_CHANGED",),
                 received=plan_result,
             )
         (self._plans_dir / filename).write_text(text, encoding="utf-8")
@@ -963,6 +958,117 @@ class PlanWriteSession:
         self._write_index()
         return PlanOutcome("written", number, filename, title)
 
+    def _reanchor_and_write(
+        self,
+        reservation: PlanReservation,
+        selection: dict[str, Any],
+        plan_result: dict[str, Any],
+        *,
+        number: int,
+        title: str,
+        slug: str,
+    ) -> PlanOutcome:
+        """Write a finished plan into a fresh detached worktree at current HEAD.
+
+        The plan's content is complete; only the ``planned_at`` anchor is stale
+        because HEAD advanced past the commit captured at session start. The
+        plan lands in a fresh detached worktree at the current HEAD, re-anchored
+        to it, and returns ``written`` with the full path it landed at — a stale
+        anchor alone must not discard a valid plan. Any sub-failure falls back to
+        :meth:`_block` with ``PLAN_REANCHOR_FAILED``; nothing is silently dropped.
+        """
+        finding = selection["finding"]
+        attempt = self._attempt_of(selection)
+        filename = f"{number:03d}-{slug}.md"
+
+        def _reanchor_failed() -> PlanOutcome:
+            return self._block(
+                reservation,
+                selection,
+                number=number,
+                finding=finding,
+                status="BLOCKED (PLAN_WRITER_FAILED: PLAN_REANCHOR_FAILED)",
+                stage="transport",
+                errors=("PLAN_REANCHOR_FAILED",),
+                received=plan_result,
+            )
+
+        try:
+            new_head = git_ops.head_sha(self._repo)
+        except git_ops.GitError:
+            return _reanchor_failed()
+        try:
+            worktree = self._reanchor_worktree
+            if worktree is None:
+                run_id = self._run_session_id or f"run-{self._planned_at[:12]}"
+                if _SAFE_DIRNAME.fullmatch(run_id) is None:
+                    run_id = f"run-{self._planned_at[:12]}"
+                worktree = (
+                    self._repo / ".daydream" / "worktrees" / f"{run_id}-reanchor"
+                )
+                git_ops.worktree_add(self._repo, worktree, "HEAD", detach=True)
+                self._reanchor_worktree = worktree
+            text = render_plan(
+                finding,
+                plan=plan_result,
+                planned_at=new_head,
+                number=number,
+                planned_on=self._planned_on,
+                run_session_id=self._run_session_id,
+            )
+            plans_dir = worktree / "daydream_plans"
+            plans_dir.mkdir(parents=True, exist_ok=True)
+            (plans_dir / filename).write_text(text, encoding="utf-8")
+            self._reanchored[number] = PlanIndexEntry(
+                number=number,
+                slug=slug,
+                title=_index_field(selection.get("title") or title),
+                fingerprint=reservation.fingerprint,
+                priority=plan_priority(finding),
+                effort=_index_field(finding.get("effort")),
+                risk=_index_field(finding.get("risk")),
+                category=_index_field(finding.get("category")),
+                planned_at=new_head,
+                status="TODO",
+                host_blocked=False,
+            )
+            entries = dict(self._entries)
+            entries.update(self._reanchored)
+            self._write_index_files(
+                plans_dir,
+                [entries[index] for index in sorted(entries)],
+            )
+        except Exception:  # noqa: BLE001 - persist a safe re-anchor disposition
+            return _reanchor_failed()
+
+        landed_path = (worktree / "daydream_plans" / filename).as_posix()
+        self._written.append(
+            (
+                reservation.index,
+                {**selection, "number": number, "path": landed_path},
+            )
+        )
+        self._diagnostics.append(
+            (
+                reservation.index,
+                _attempt_diagnostic(
+                    finding=finding,
+                    attempt=attempt,
+                    received=plan_result,
+                    disposition="success",
+                    stage="success",
+                    artifact={
+                        "path": landed_path,
+                        "status": "TODO",
+                        "reanchored": True,
+                        "planned_at": new_head,
+                    },
+                ),
+            )
+        )
+        self._fingerprints.add(reservation.fingerprint)
+        return PlanOutcome("written", number, landed_path, title)
+
     def _write_index(self) -> None:
         """Rewrite the sidecar and its rendered index from the entries so far.
 
@@ -971,7 +1077,13 @@ class PlanWriteSession:
         files already on disk.
         """
         entries = [self._entries[number] for number in sorted(self._entries)]
-        self._sidecar_path.write_text(
+        self._write_index_files(self._plans_dir, entries)
+
+    def _write_index_files(
+        self, plans_dir: Path, entries: Sequence[PlanIndexEntry]
+    ) -> None:
+        """Write the sidecar and its rendered index for *entries* into *plans_dir*."""
+        (plans_dir / PLAN_INDEX_FILENAME).write_text(
             json.dumps(
                 {
                     "schema_version": PLAN_INDEX_SCHEMA_VERSION,
@@ -984,10 +1096,10 @@ class PlanWriteSession:
             + "\n",
             encoding="utf-8",
         )
-        self._index_path.write_text(
+        (plans_dir / "README.md").write_text(
             _render_index(
                 [_index_row(entry) for entry in entries],
-                plans_dir=self._plans_dir,
+                plans_dir=plans_dir,
                 planned_on=self._planned_on,
                 non_interactive_default=self._non_interactive_default,
                 run_session_id=self._run_session_id,

--- a/tests/test_improve_plans.py
+++ b/tests/test_improve_plans.py
@@ -1563,6 +1563,23 @@ def test_head_change_after_planning_reanchors_into_new_worktree(
         (entry["number"], entry["slug"], entry["planned_at"], entry["status"])
         for entry in sidecar["plans"]
     ] == [(1, "batch-catalog-queries", new_head, "TODO")]
+    # main repo durable surface now lists the re-anchored plan
+    main_index = (repo / "daydream_plans" / "README.md").read_text(encoding="utf-8")
+    assert "REANCHORED" in main_index
+    assert (
+        reanchor_plans.relative_to(repo).as_posix() + "/001-batch-catalog-queries.md"
+        in main_index
+    )
+    main_sidecar = json.loads(
+        (repo / "daydream_plans" / PLAN_INDEX_FILENAME).read_text(encoding="utf-8")
+    )
+    reanchored = [e for e in main_sidecar["plans"] if e["number"] == 1]
+    assert len(reanchored) == 1
+    assert reanchored[0]["status"].startswith("REANCHORED")
+    assert "001-batch-catalog-queries.md" in reanchored[0]["status"]
+    # the README row must NOT mislink a main-dir sibling (file lives in the worktree)
+    assert "](001-batch-catalog-queries.md)" not in main_index
+    assert "REANCHORED" in main_index
 
 
 def test_planned_at_still_matching_head_writes_in_place(

--- a/tests/test_improve_plans.py
+++ b/tests/test_improve_plans.py
@@ -1517,14 +1517,23 @@ def test_planned_at_from_an_unrelated_root_is_rejected(repo: Path, head_sha: str
     ).read_text()
 
 
-def test_head_change_after_planning_blocks_stale_todo(repo: Path, head_sha: str) -> None:
+def test_head_change_after_planning_reanchors_into_new_worktree(
+    repo: Path,
+    head_sha: str,
+) -> None:
+    """HEAD advancing after assembling re-anchors the plan instead of blocking.
+
+    The plan's content is finished; only the ``planned_at`` anchor is stale, so
+    the plan lands in a fresh detached worktree at the current HEAD, re-anchored
+    to it, and is reported as written — never silently dropped.
+    """
     assembled = _assembled(repo)
     (repo / "README.md").write_text(
         "# Catalog service\n\nConcurrent branch update.\n",
         encoding="utf-8",
     )
     git(repo, "add", "README.md")
-    git(repo, "commit", "-m", "advance head after plan fan-out")
+    new_head = commit(repo, "advance head after plan fan-out")
 
     result = _write_plans(
         repo / "daydream_plans",
@@ -1532,11 +1541,48 @@ def test_head_change_after_planning_blocks_stale_todo(repo: Path, head_sha: str)
         planned_at=head_sha,
     )
 
-    assert result["written"] == []
-    assert not list((repo / "daydream_plans").glob("[0-9][0-9][0-9]-*.md"))
-    assert "PLAN_HEAD_CHANGED" in (
-        repo / "daydream_plans/README.md"
-    ).read_text()
+    assert len(result["written"]) == 1
+    landed = result["written"][0]["path"]
+    assert ".daydream/worktrees/" in landed
+    assert landed.endswith("daydream_plans/001-batch-catalog-queries.md")
+    assert not (repo / "daydream_plans/001-batch-catalog-queries.md").is_file()
+    plan_file = Path(landed)
+    assert plan_file.is_file()
+    text = plan_file.read_text(encoding="utf-8")
+    assert f"**Planned at**: commit `{new_head[:7]}`" in text
+    assert f"`{new_head}`" in text
+    reanchor_plans = plan_file.parent
+    assert (reanchor_plans / PLAN_INDEX_FILENAME).is_file()
+    index = (reanchor_plans / "README.md").read_text(encoding="utf-8")
+    assert "| [001](001-batch-catalog-queries.md) " in index
+    assert "| TODO |" in index
+    sidecar = json.loads(
+        (reanchor_plans / PLAN_INDEX_FILENAME).read_text(encoding="utf-8")
+    )
+    assert [
+        (entry["number"], entry["slug"], entry["planned_at"], entry["status"])
+        for entry in sidecar["plans"]
+    ] == [(1, "batch-catalog-queries", new_head, "TODO")]
+
+
+def test_planned_at_still_matching_head_writes_in_place(
+    repo: Path,
+    head_sha: str,
+) -> None:
+    """The common case is unchanged: a matching anchor writes in place."""
+    result = _write_plans(
+        repo / "daydream_plans",
+        [{"finding": _finding(), **_assembled(repo)}],
+        planned_at=head_sha,
+    )
+
+    assert len(result["written"]) == 1
+    assert result["written"][0]["path"] == "001-batch-catalog-queries.md"
+    plan_file = repo / "daydream_plans/001-batch-catalog-queries.md"
+    assert plan_file.is_file()
+    text = plan_file.read_text(encoding="utf-8")
+    assert f"**Planned at**: commit `{head_sha[:7]}`" in text
+    assert not list((repo / ".daydream" / "worktrees").glob("*-reanchor"))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_improve_plans.py
+++ b/tests/test_improve_plans.py
@@ -1614,6 +1614,24 @@ def test_reanchored_finding_is_not_replanned_on_a_later_run(
     assert len(later["skipped"]) == 1
 
 
+def test_stale_reanchor_worktrees_are_pruned_at_next_run(
+    repo: Path,
+    head_sha: str,
+) -> None:
+    """The start of a plan run prunes stale *-reanchor worktrees from prior runs."""
+    stale_dir = repo / ".daydream" / "worktrees" / "run-abcd-reanchor"
+    git(repo, "worktree", "add", "--detach", str(stale_dir), "HEAD")
+    (stale_dir / "marker.txt").write_text("leftover", encoding="utf-8")
+
+    from daydream.improve.plans import prune_stale_reanchor_worktrees
+
+    removed = prune_stale_reanchor_worktrees(repo)
+
+    assert removed == 1
+    assert not stale_dir.exists()
+    assert "run-abcd-reanchor" not in git(repo, "worktree", "list")
+
+
 def test_planned_at_still_matching_head_writes_in_place(
     repo: Path,
     head_sha: str,

--- a/tests/test_improve_plans.py
+++ b/tests/test_improve_plans.py
@@ -1525,7 +1525,8 @@ def test_head_change_after_planning_reanchors_into_new_worktree(
 
     The plan's content is finished; only the ``planned_at`` anchor is stale, so
     the plan lands in a fresh detached worktree at the current HEAD, re-anchored
-    to it, and is reported as written — never silently dropped.
+    to it, and is reported as written — never silently dropped. The finished
+    text also lands a durable copy in the main index so it survives pruning.
     """
     assembled = _assembled(repo)
     (repo / "README.md").write_text(
@@ -1545,7 +1546,8 @@ def test_head_change_after_planning_reanchors_into_new_worktree(
     landed = result["written"][0]["path"]
     assert ".daydream/worktrees/" in landed
     assert landed.endswith("daydream_plans/001-batch-catalog-queries.md")
-    assert not (repo / "daydream_plans/001-batch-catalog-queries.md").is_file()
+    main_plan = repo / "daydream_plans/001-batch-catalog-queries.md"
+    assert main_plan.is_file()
     plan_file = Path(landed)
     assert plan_file.is_file()
     text = plan_file.read_text(encoding="utf-8")
@@ -1577,9 +1579,52 @@ def test_head_change_after_planning_reanchors_into_new_worktree(
     assert len(reanchored) == 1
     assert reanchored[0]["status"].startswith("REANCHORED")
     assert "001-batch-catalog-queries.md" in reanchored[0]["status"]
-    # the README row must NOT mislink a main-dir sibling (file lives in the worktree)
-    assert "](001-batch-catalog-queries.md)" not in main_index
+    # the README row links the durable main-dir sibling, exactly like any other
+    # row: the re-anchored content now lives in the main index.
+    assert "| [001](001-batch-catalog-queries.md) " in main_index
     assert "REANCHORED" in main_index
+
+
+def test_reanchored_plan_survives_worktree_pruning(
+    repo: Path,
+    head_sha: str,
+) -> None:
+    """The durable main-index copy outlives the next run's worktree pruning.
+
+    Regression guard for the HIGH finding: the re-anchored plan used to exist
+    only inside the detached worktree that the next run force-removes, so the
+    deliverable was permanently deleted while the index kept a dead pointer.
+    """
+    assembled = _assembled(repo)
+    (repo / "README.md").write_text(
+        "# Catalog service\n\nConcurrent branch update.\n",
+        encoding="utf-8",
+    )
+    git(repo, "add", "README.md")
+    new_head = commit(repo, "advance head after plan fan-out")
+
+    result = _write_plans(
+        repo / "daydream_plans",
+        [{"finding": _finding(), **assembled}],
+        planned_at=head_sha,
+    )
+    assert len(result["written"]) == 1
+    landed = Path(result["written"][0]["path"])
+    main_plan = repo / "daydream_plans/001-batch-catalog-queries.md"
+    assert main_plan.is_file()
+    assert f"`{new_head}`" in main_plan.read_text(encoding="utf-8")
+    assert landed.is_file()
+
+    from daydream.improve.plans import prune_stale_reanchor_worktrees
+
+    removed = prune_stale_reanchor_worktrees(repo)
+
+    assert removed == 1
+    assert not landed.exists()
+    assert main_plan.is_file()
+    assert "REANCHORED" in (repo / "daydream_plans" / "README.md").read_text(
+        encoding="utf-8"
+    )
 
 
 def test_reanchored_finding_is_not_replanned_on_a_later_run(

--- a/tests/test_improve_plans.py
+++ b/tests/test_improve_plans.py
@@ -1582,6 +1582,38 @@ def test_head_change_after_planning_reanchors_into_new_worktree(
     assert "REANCHORED" in main_index
 
 
+def test_reanchored_finding_is_not_replanned_on_a_later_run(
+    repo: Path,
+    head_sha: str,
+) -> None:
+    """A plan re-anchored at a moved HEAD is durably fingerprinted, so a later
+    run in the same repo does not re-plan the same finding (no duplicate number).
+    """
+    assembled = _assembled(repo)
+    (repo / "README.md").write_text(
+        "# Catalog service\n\nConcurrent branch update.\n",
+        encoding="utf-8",
+    )
+    git(repo, "add", "README.md")
+    new_head = commit(repo, "advance head after plan fan-out")
+
+    first = _write_plans(
+        repo / "daydream_plans",
+        [{"finding": _finding(), **assembled}],
+        planned_at=head_sha,
+    )
+    assert len(first["written"]) == 1  # re-anchored as written
+
+    # a later run in the same repo (HEAD now == new_head) must skip the same finding
+    later = _write_plans(
+        repo / "daydream_plans",
+        [{"finding": _finding(), **assembled}],
+        planned_at=new_head,
+    )
+    assert later["written"] == []
+    assert len(later["skipped"]) == 1
+
+
 def test_planned_at_still_matching_head_writes_in_place(
     repo: Path,
     head_sha: str,


### PR DESCRIPTION
## Summary

- Re-anchored plans (written when HEAD moves mid-run) now land a **durable copy in the main repo's `daydream_plans/`**, so the plan deliverable survives the next run's worktree pruning — previously the only copy lived in the detached `*-reanchor` worktree that the next run force-removed, permanently deleting the plan while the index kept a dead `REANCHORED` pointer.
- Re-anchored plans are now visible in the main `daydream_plans/` index and README with a `REANCHORED (landed at …)` status, and `planned_fingerprints()` sees them, so a later `daydream improve plan` run no longer re-plans the same finding.
- Stale `*-reanchor` worktrees are pruned at the start of each plan run so `.daydream/worktrees/` does not grow unboundedly.

## Motivation

Fixes #349
Fixes #350

- **#349** — `PLAN_HEAD_CHANGED` previously blocked writing a valid plan when HEAD advanced mid-run; the re-anchor path wrote it into a fresh detached worktree at the new HEAD instead.
- **#350** — the re-anchored plan was invisible to the durable plan index, so a later run re-planned the same finding and the re-anchored plan became an orphan. The R1 deep review additionally found (HIGH) that the re-anchored plan's only copy lived in the worktree, which the new pruning pass then destroyed on the next run — the durable main-index copy fixes that root cause.

## Changes

### Added
- `prune_stale_reanchor_worktrees(repo)` — prunes leftover `*-reanchor` worktrees at the start of a plan run.
- `_index_entry(...)` / `_record_written(...)` — shared constructors for the (previously triplicated) `PlanIndexEntry` literal and (duplicated) land-record tail.
- Regression test: `test_reanchored_plan_survives_worktree_pruning` — pins that the durable main-index copy outlives pruning.

### Changed
- `_reanchor_and_write` now writes the rendered plan into the main repo's `daydream_plans/` **and** the worktree, registers the entry in `self._entries` with `REANCHORED (landed at …)`, resolves HEAD once and passes the resolved sha to `worktree_add` (no TOCTOU double-resolve), and renders the worktree index without dangling links for entries whose files live elsewhere.
- `_index_row` gained an optional `plans_dir` so the worktree index renders bare numbers for out-of-worktree files; the main index renders normal sibling links (the durable copies are real siblings now).
- Status legend now documents `REANCHORED (with one-line landing path)`.
- Orchestrator's finish-announce lines handle absolute landing paths correctly.

## Test Plan

- `uv run pytest tests/test_improve_plans.py -q` → 170 passed
- `make check` → green (lockcheck + lint + typecheck + full pytest; 3097 passed, 6 skipped)
- New real-path regression test `test_reanchored_plan_survives_worktree_pruning` drives `_write_plans` → prune → asserts the main copy survives while the worktree is removed.

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check`)
- [x] Type checking passes (`uv run mypy daydream`)
- [x] Documentation updated (if applicable) — status legend updated in the rendered index

## Additional Context

Follow-up filed as #353 (assigned anderskev): `_reanchor_and_write` defers the main index write to `finish()` while `_land` writes immediately — a cancel/budget crash in that window leaves the durable plan file on disk but unreferenced, re-planning the finding next run.
