### PR TITLE
fix(backends): classify pi 502 responses as retryable (#356)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   comment) and only on successful completion; `feedback` mode writes no report
   and is gated off.
 
+- **backends:** Classify pi `502` responses as retryable (#356)
+
+  The pi backend's transient-error guard covered `429`/`503` but treated a
+  `502` (e.g. `502 status code (no body)` from an upstream gateway) as fatal on
+  first occurrence, killing the whole deep cycle mid-run. `502` and
+  `bad gateway` are now matched alongside the existing server-error literals,
+  so a bounded backoff window replaces the fatal path and a sustained `502`
+  window still terminates cleanly with previously written verdicts preserved.
+
 ## [0.25.0] - 2026-07-26
 
 ### Added

--- a/daydream/backends/pi.py
+++ b/daydream/backends/pi.py
@@ -304,15 +304,22 @@ def _pi_retry_max_delay() -> float:
 # the stable diagnostic category so the two views of the taxonomy cannot drift
 # out of sync.
 _RATE_LIMIT_TOKENS = ("429", "rate limit", "rate_limit", "too many requests")
-_SERVER_ERROR_TOKENS = ("503", "service unavailable", "server error")
+_SERVER_ERROR_TOKENS = (
+    "502",
+    "503",
+    "bad gateway",
+    "service unavailable",
+    "server error",
+)
 
 
 def _is_retryable_error_message(message: str) -> bool:
     """Return True if the error message signals a transient overload or rate-limit.
 
     High-precision literals (429, rate limit/rate_limit, too many requests,
-    503, service unavailable, server error) are matched as plain substrings —
-    they are extremely unlikely to appear in a non-transient context. Ambiguous
+    502/503, bad gateway, service unavailable, server error) are matched as
+    plain substrings — they are extremely unlikely to appear in a non-transient
+    context. Ambiguous
     terms require positive overload/capacity wording and explicitly reject
     negated or planning contexts.
     """

--- a/tests/test_agent_retry.py
+++ b/tests/test_agent_retry.py
@@ -72,6 +72,20 @@ def _always_raises(error: BaseException) -> ScriptedBackend:
             "Review complete after retry",
             id="stream-drop",
         ),
+        # 502 Bad Gateway (issue #356). First attempt is a 502; second succeeds.
+        # ``retryable`` comes from the PRODUCTION classifier, so this proves a 502 is
+        # actually retried end-to-end through run_agent rather than treated as fatal.
+        pytest.param(
+            lambda: _fail_then_succeed(
+                PiError(
+                    "502 status code (no body)",
+                    retryable=_is_retryable_error_message("502 status code (no body)"),
+                ),
+                text="Review complete after 502 retry",
+            ),
+            "Review complete after 502 retry",
+            id="502-bad-gateway-retried",
+        ),
     ],
 )
 @pytest.mark.asyncio
@@ -302,5 +316,47 @@ async def test_run_agent_retry_exhausted_marks_trajectory_partial(
     # The trajectory was written and stamped partial=true by the recorder's
     # exception-exit path (TrajectoryRecorder._aborted → _write).
     assert trajectory_path.exists(), "trajectory.json was not written on retry exhaustion"
+    trajectory = json.loads(trajectory_path.read_text(encoding="utf-8"))
+    assert trajectory["extra"]["partial"] is True
+
+
+@pytest.mark.asyncio
+async def test_run_agent_502_exhaustion_preserves_artifacts(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """A sustained 502 window terminates cleanly with existing artifacts preserved (#356).
+
+    A stub returns a 502 PiError through every attempt. After the retry bound,
+    ``run_agent`` fails cleanly (raises — never hangs, never silently succeeds) and
+    the trajectory already written is preserved and stamped ``partial``, so verdicts
+    written before the 502 window are not lost.
+    """
+    monkeypatch.setenv("DAYDREAM_PI_RETRY_BASE_DELAY_S", "0.01")
+    monkeypatch.setenv("DAYDREAM_PI_RETRY_ATTEMPTS", "2")
+    # `retryable` from the PRODUCTION classifier proves the exhaustion path is reached
+    # precisely because 502 is retryable — not because of a misclassified fatal.
+    backend = _always_raises(
+        PiError("502 status code (no body)", retryable=_is_retryable_error_message("502 status code (no body)"))
+    )
+
+    trajectory_path = tmp_path / ".daydream" / "trajectory.json"
+    recorder = TrajectoryRecorder(
+        path=trajectory_path,
+        run_flow=DaydreamRunFlow.NORMAL,
+        target_dir=tmp_path,
+        agent_model_name="test-model",
+        session_id="test-502-exhaust",
+    )
+
+    with pytest.raises(PiError, match="502 status code"):
+        async with recorder:
+            await run_agent(backend, tmp_path, "review", phase=DaydreamPhase.REVIEW)
+
+    # 1 original attempt + 2 retries = 3 total, then re-raised.
+    assert backend.call_count == 3
+
+    # Clean failure, artifacts preserved: the trajectory survived the exhaustion and
+    # is explicitly marked partial so downstream consumers know the run was aborted.
+    assert trajectory_path.exists(), "trajectory.json was not written on 502 exhaustion"
     trajectory = json.loads(trajectory_path.read_text(encoding="utf-8"))
     assert trajectory["extra"]["partial"] is True

--- a/tests/test_backend_pi.py
+++ b/tests/test_backend_pi.py
@@ -1248,6 +1248,7 @@ def test_pierror_retryable_default_and_kwarg_and_message():
     ("message", "expected"),
     [
         ("429 Too Many Requests", "RATE_LIMIT"),
+        ("502 status code (no body)", "SERVER_ERROR"),
         ("503 status code (no body)", "SERVER_ERROR"),
         ("service unavailable", "SERVER_ERROR"),
         ("request timed out after 30 seconds", "TIMEOUT"),
@@ -1258,6 +1259,7 @@ def test_pierror_retryable_default_and_kwarg_and_message():
     ],
     ids=[
         "rate-limit",
+        "server-error-502",
         "server-error-503",
         "server-error-service-unavailable",
         "timeout",
@@ -1283,6 +1285,8 @@ def test_pi_error_categories_are_stable_host_codes(
     ("message", "expected"),
     [
         ("429 Too Many Requests", True),
+        ("502 status code (no body)", True),
+        ("502 Bad Gateway", True),
         ("503 status code (no body)", True),
         ("503 Service Unavailable", True),
         ("Service is currently overloaded", True),
@@ -1308,6 +1312,8 @@ def test_pi_error_categories_are_stable_host_codes(
     ],
     ids=[
         "429",
+        "502-status-code",
+        "502-bad-gateway",
         "503-status-code",
         "503-service-unavailable",
         "overload",
@@ -1358,9 +1364,10 @@ def test_is_retryable_exit_code(code, expected):
     ("error_message", "expected_retryable"),
     [
         ("429 Too Many Requests - rate limit exceeded", True),
+        ("502 status code (no body)", True),
         ("authentication required", False),
     ],
-    ids=["429-retryable", "auth-non-retryable"],
+    ids=["429-retryable", "502-retryable", "auth-non-retryable"],
 )
 @pytest.mark.asyncio
 async def test_error_turn_sets_retryable_via_classifier(error_message, expected_retryable):


### PR DESCRIPTION
Closes #356

## What

The pi backend's transient-error retry guard covered `429`/`503` but not `502`. A pi
`502 status code (no body)` (upstream gateway error) matched no token in
`_SERVER_ERROR_TOKENS`, classifying it `UNKNOWN`/non-retryable and killing the whole deep
cycle on first occurrence (hit twice 2026-08-10 on remote workers).

Added `502` and `bad gateway` to the shared `_SERVER_ERROR_TOKENS` tuple, which both
`_is_retryable_error_message` and `_pi_error_category` consume — retry classification and
diagnostic category stay consistent from a single source.

## Acceptance criteria

- [x] 502 responses are retried with bounded backoff like 429/503, not treated as fatal on first occurrence.
- [x] Retry count and backoff are represented in Daydream's typed runtime/service configuration, not in an external skill.
- [x] A sustained 502 window still terminates with a clear error; previously written verdicts are preserved.
- [x] Backend-path test: stub returns one 502 then succeeds — run completes with the retry's output (call_count==2).
- [x] Exhaustion-path test: stub returns 502 through the retry bound — run fails cleanly, artifacts preserved and stamped `extra.partial=True`.
- [x] Tests run through the backend independently of the execution substrate.

## Tests

Real-path / observable-outcome (no mock-implementation):
1. `test_pi_error_categories_are_stable_host_codes` — 502 → SERVER_ERROR
2. `test_is_retryable_error_message` — `502 status code (no body)` and `502 Bad Gateway` → retryable
3. `test_error_turn_sets_retryable_via_classifier` — stub `turn_end`/`stopReason=="error"` with 502 through `PiBackend.execute` → PiError.retryable True
4. `test_run_agent_retries_and_returns_the_successful_attempt[502-bad-gateway-retried]` — production classifier genuinely exercised; run completes after one retry
5. `test_run_agent_502_exhaustion_preserves_artifacts` — 502 through retry bound; clean raise + trajectory preserved/partial

## Verification

- `uv lock --check` clean
- `ruff check daydream tests bench` passed
- `mypy daydream tests bench` clean (316 files)
- `pytest -n auto`: **3103 passed, 6 skipped** (pre-existing skips), 0 failures
- Pre-push hook: all checks passed on push

## Benchmark isolation

This touches backend error classification (pre-review runtime plumbing) only — it does not
change review/arbiter/merge output, so it CANNOT affect Martian benchmark scoring.

## Files changed

- `daydream/backends/pi.py`
- `tests/test_agent_retry.py`
- `tests/test_backend_pi.py`
- `CHANGELOG.md`

## Note on #357

The exact-SHA service (#357) may layer fleet-wide circuit breaking over this bounded
backend behavior. No duplicate issue created — coordinate there.