### PR TITLE
feat(improve): aggregate cleanup plans and publish issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ To update: `git pull && uv sync`
 prioritizes them by leverage, and writes self-contained implementation plans.
 Every agent call uses a read-only backend profile. Daydream's host code writes
 only run artifacts under `.daydream/` and durable advisory artifacts under
-`daydream_plans/`; it does not modify tracked source files.
+`daydream_plans/`; it does not modify tracked source files. GitHub issue
+publishing is disabled unless the repository explicitly enables it.
 
 ```bash
 daydream improve /path/to/project
@@ -68,9 +69,9 @@ daydream improve --focus security /path/to/project
 
 | Tier | Audit coverage |
 |------|----------------|
-| `quick` | Correctness, security, and tests; serial, HIGH-confidence findings only, capped near six |
-| `standard` | All nine categories with a concurrency ceiling of ten; the default |
-| `deep` | All nine categories with a concurrency ceiling of ten; includes LOW-confidence investigation items |
+| `quick` | Correctness, security, tests, and tech debt; serial, HIGH-confidence findings only, capped near six |
+| `standard` | All eight categories with a concurrency ceiling of ten; the default |
+| `deep` | All eight categories with a concurrency ceiling of ten; includes LOW-confidence investigation items |
 
 `--effort` selects audit *breadth* only. It does not change the model or the
 reasoning effort — those are per-phase (see [Reasoning Effort](#reasoning-effort)).
@@ -100,7 +101,6 @@ truncated.
 | `performance` | Audit only performance |
 | `tests` | Audit only test coverage |
 | `branch` | Audit the merge-base diff and label findings as introduced or inherited |
-| `next` | Produce grounded direction proposals as spike plans |
 
 Use `--scope SERVICE_OR_GLOB` to restrict the audit to matching detected
 services. The report names detected services that the scope did not cover.
@@ -119,9 +119,48 @@ Each audit writes its report and structured intermediate data under
 numbered plan files, a `.index.json` durable plan record, a `README.md` plan
 index rendered from it, and `rejected.json` for findings that later runs should
 suppress. Editing a plan's **Status** cell in `README.md` is honored: that cell
-outranks `.index.json`. In non-interactive mode, Daydream selects the
-top five or fewer vetted defect findings by leverage; direction findings are
-never selected automatically.
+outranks `.index.json`. In non-interactive mode, Daydream selects every vetted
+work package only when automatic GitHub issue publishing is enabled; compatible
+overlapping findings have already been aggregated into those issue-sized
+packages. Without automatic publishing, the unattended default remains the top
+five packages.
+
+### Publish Improve plans as GitHub issues
+
+Repositories can opt into fully unattended issue publication:
+
+```toml
+[tool.daydream.improve.github]
+publish_issues = true
+```
+
+When enabled, Improve first writes and validates each plan locally, then copies
+the complete plan Markdown into the corresponding GitHub issue description.
+It creates no plan branch, commit, or push. A stable marker in each issue makes
+reruns idempotent even from a fresh GitHub Actions checkout; both open and
+closed issues are reconciled before any new issue is created. If reconciliation
+fails, publication stops rather than risking a duplicate issue.
+
+Only one Improve publisher may run against a repository at a time. Marker
+reconciliation makes sequential reruns idempotent, but two concurrent runs can
+both observe that an issue is absent before either creates it. Use a
+repository-scoped GitHub Actions concurrency group (and an equivalent lock for
+cron jobs running elsewhere):
+
+```yaml
+concurrency:
+  group: daydream-improve-${{ github.repository }}
+  cancel-in-progress: false
+```
+
+The workflow token needs issue write access, but Daydream does not need content
+write access. A minimal GitHub Actions permission block is:
+
+```yaml
+permissions:
+  contents: read # required by actions/checkout, not by issue publication
+  issues: write
+```
 
 ## Architecture
 
@@ -446,8 +485,9 @@ Posts are attributed to `<app-slug>[bot]`, and the active identity (bot or
 human) is displayed before any GitHub action.
 
 One-time setup: create a GitHub App (minimum permissions: Pull Requests
-read/write, Contents read, Metadata read, Actions read/write), generate a private key from the
-App settings page, and install the App on the target repository's org or user.
+read/write, Issues read/write, Contents read, Metadata read, Actions
+read/write), generate a private key from the App settings page, and install the
+App on the target repository's org or user.
 
 In GitHub Actions:
 

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -574,9 +574,9 @@ def _build_improve_parser(
         default="standard",
         dest="improve_effort",
         help=(
-            "Audit breadth: quick = correctness/security/tests only, serial, "
+            "Audit breadth: quick = correctness/security/tests/tech-debt, serial, "
             "HIGH-confidence findings capped near six; standard (default) = all "
-            "nine categories in parallel; deep = all nine searched very "
+            "eight categories in parallel; deep = all eight searched very "
             "thoroughly, including labeled LOW-confidence investigate items. "
             "Does not change the model or reasoning effort — those are per-phase "
             "(see [tool.daydream.phases.<phase>])"
@@ -584,13 +584,12 @@ def _build_improve_parser(
     )
     parser.add_argument(
         "--focus",
-        choices=["security", "performance", "tests", "branch", "next"],
+        choices=["security", "performance", "tests", "branch"],
         default=None,
         dest="improve_focus",
         help=(
             "Narrow the audit: a single category, 'branch' to audit only the "
-            "diff against the base branch, or 'next' for product direction "
-            "instead of defects"
+            "diff against the base branch"
         ),
     )
     parser.add_argument(

--- a/daydream/config.py
+++ b/daydream/config.py
@@ -297,7 +297,6 @@ AUDIT_CATEGORIES: tuple[str, ...] = (
     "dependencies",
     "dx",
     "docs",
-    "direction",
 )
 
 
@@ -315,7 +314,7 @@ class EffortTier:
 
 EFFORT_TIERS: dict[str, EffortTier] = {
     "quick": EffortTier(
-        categories=("correctness", "security", "tests"),
+        categories=("correctness", "security", "tests", "tech-debt"),
         max_concurrency=1,
         high_confidence_only=True,
         max_findings=6,
@@ -367,7 +366,6 @@ AUDIT_SKILL_MAP: dict[str, dict[str, str]] = {
     "dependencies": {},
     "dx": {},
     "docs": {},
-    "direction": {},
 }
 
 # CLI skill name to full skill path mapping (derived from REVIEW_SKILLS to avoid duplication)
@@ -415,6 +413,7 @@ SETUP_SECRET_NAMES: tuple[str, ...] = (
 BOT_HANDLE_VAR: str = "DAYDREAM_BOT_HANDLE"
 APP_PERMISSIONS: dict[str, str] = {
     "pull_requests": "write",
+    "issues": "write",
     "contents": "read",
     "metadata": "read",
     "actions": "write",

--- a/daydream/config_file.py
+++ b/daydream/config_file.py
@@ -114,6 +114,10 @@ class DaydreamFileConfig:
         improve_service_roots: Repository-relative glob patterns identifying
             service roots for the improve flow.
         improve_service_groups: Named groups of repository-relative service roots.
+        improve_github_publish_issues: Whether Improve should publish each validated
+            local plan as a GitHub issue. This is an explicit repository-level
+            opt-in under ``[tool.daydream.improve.github]``; absent or malformed
+            values leave publishing disabled.
         trajectory_hub_repo: Opt-in HuggingFace dataset repo id that each run's
             archive bundle is uploaded to. ``None`` (the default when the key is
             absent or junk) leaves the feature off; only a string value is
@@ -146,6 +150,7 @@ class DaydreamFileConfig:
     improve_service_groups: dict[str, list[str]] = field(default_factory=dict)
     improve_partition_max_files: int | None = None
     improve_max_partition_groups: int | None = None
+    improve_github_publish_issues: bool = False
     trajectory_hub_repo: str | None = None
 
     def phase_model(self, phase: str) -> str | None:
@@ -388,6 +393,14 @@ def load_file_config(root: Path) -> DaydreamFileConfig:
     improve = improve if isinstance(improve, dict) else {}
     service_groups = improve.get("service_groups")
     service_groups = service_groups if isinstance(service_groups, dict) else {}
+    improve_github = improve.get("github")
+    improve_github = improve_github if isinstance(improve_github, dict) else {}
+    raw_improve_publish = improve_github.get(
+        "publish_issues", improve_github.get("publish-issues")
+    )
+    improve_github_publish_issues = (
+        raw_improve_publish if isinstance(raw_improve_publish, bool) else False
+    )
     # Per-file-group fix budgets (#201): tolerate junk by degrading to None (the
     # config.py default then applies). bool is excluded even though it subclasses
     # int/float — ``group_max_serial_items = true`` is never a meaningful count.
@@ -421,5 +434,6 @@ def load_file_config(root: Path) -> DaydreamFileConfig:
         },
         improve_partition_max_files=_coerce_positive_int(improve, "partition_max_files"),
         improve_max_partition_groups=_coerce_positive_int(improve, "max_partition_groups"),
+        improve_github_publish_issues=improve_github_publish_issues,
         trajectory_hub_repo=trajectory_hub_repo,
     )

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -2008,3 +2008,81 @@ def gh_issue_list(
     except json.JSONDecodeError:
         return []
     return rows if isinstance(rows, list) else []
+
+
+def gh_issue_list_strict(
+    repo: Path,
+    *,
+    state: str = "all",
+    repo_slug: str,
+) -> list[dict[str, Any]]:
+    """List every issue through the paginated REST API, failing closed.
+
+    Unlike :func:`gh_issue_list`, this helper is for workflows where an empty
+    result after a failed lookup could cause a duplicate write. It therefore
+    raises on transport, API, and response-shape failures. GitHub's REST issue
+    endpoint also returns pull requests; those rows are deliberately excluded.
+
+    Args:
+        repo: Worktree the call is rooted in (cwd for ``gh``).
+        state: One of ``"open"``, ``"closed"``, or ``"all"``.
+        repo_slug: Explicit GitHub ``owner/repo`` target.
+
+    Returns:
+        Normalized issue dictionaries containing ``number``, ``title``,
+        ``body``, ``url``, and ``state``. Pagination is unbounded rather than
+        stopping at GitHub's 100-item page size.
+
+    Raises:
+        GitError: If the arguments are invalid, lookup fails, or GitHub returns
+            an unexpected response shape.
+    """
+    if state not in {"open", "closed", "all"}:
+        raise GitError(f"invalid issue state {state!r}")
+    parsed = split_owner_repo(repo_slug)
+    if parsed is None or "/" in parsed[1]:
+        raise GitError(f"invalid GitHub repository slug {repo_slug!r}")
+    owner, name = parsed
+    endpoint = f"repos/{owner}/{name}/issues?state={state}&per_page=100"
+    rows = gh_api(
+        repo,
+        endpoint,
+        paginate=True,
+        jq=".[]",
+        idempotent=True,
+    )
+    if not isinstance(rows, list):
+        raise GitError("GitHub issue lookup returned a non-list response")
+
+    issues: list[dict[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            raise GitError("GitHub issue lookup returned a non-object row")
+        if row.get("pull_request") is not None:
+            continue
+        number = row.get("number")
+        title = row.get("title")
+        body = row.get("body")
+        url = row.get("html_url", row.get("url"))
+        row_state = row.get("state")
+        if (
+            not isinstance(number, int)
+            or isinstance(number, bool)
+            or not isinstance(title, str)
+            or body is not None
+            and not isinstance(body, str)
+            or not isinstance(url, str)
+            or not url
+            or not isinstance(row_state, str)
+        ):
+            raise GitError("GitHub issue lookup returned a malformed issue row")
+        issues.append(
+            {
+                "number": number,
+                "title": title,
+                "body": body or "",
+                "url": url,
+                "state": row_state,
+            }
+        )
+    return issues

--- a/daydream/improve/artifacts.py
+++ b/daydream/improve/artifacts.py
@@ -35,3 +35,8 @@ def report_path(improve_dir_path: Path) -> Path:
 def plan_write_diagnostics_path(improve_dir_path: Path) -> Path:
     """Return the sanitized plan-writer attempt diagnostics path."""
     return improve_dir_path / "plan-write-diagnostics.json"
+
+
+def published_issues_path(improve_dir_path: Path) -> Path:
+    """Return the GitHub issue-publication disposition artifact path."""
+    return improve_dir_path / "published-issues.json"

--- a/daydream/improve/assemble.py
+++ b/daydream/improve/assemble.py
@@ -10,6 +10,8 @@ model output: filesystem reads only, no randomness, no wall-clock reads.
 
 from __future__ import annotations
 
+import ast
+import re
 from collections.abc import Callable, Iterator, Sequence
 from copy import deepcopy
 from dataclasses import dataclass
@@ -47,6 +49,30 @@ GIT_BRANCH_BASIS = (
 )
 
 _PLACEHOLDER_ARG_TOKENS = {"...", "todo", "tbd", "${todo}"}
+
+_DOCUMENTATION_SUFFIXES = {".adoc", ".md", ".mdx", ".rst", ".txt"}
+_DOCUMENTATION_NAMES = {
+    "authors",
+    "changelog",
+    "code_of_conduct",
+    "contributing",
+    "license",
+    "maintainers",
+    "readme",
+    "security",
+}
+_TEST_DIRECTORY_NAMES = {"__tests__", "spec", "specs", "test", "tests"}
+_COMMENT_KIND = re.compile(r"\b(?:comment|docstring)\b", re.IGNORECASE)
+_ABSENCE_WORD = re.compile(r"\b(?:absent|delete[ds]?|no longer|remove[ds]?)\b", re.IGNORECASE)
+_COMMENT_REWRITE = re.compile(r"\b(?:condense|rewrite|shorten|simplif(?:y|ies)|trim)\b", re.IGNORECASE)
+_UNCHANGED_EXECUTION = re.compile(
+    r"(?:\b(?:code|executable behavior|function body|runtime behavior)\b.{0,100}"
+    r"\b(?:identical|unchanged|unmodified)\b|"
+    r"\b(?:identical|unchanged|unmodified)\b.{0,100}"
+    r"\b(?:code|executable behavior|function body|runtime behavior)\b)",
+    re.IGNORECASE,
+)
+_IDENTIFIER = re.compile(r"[A-Za-z_$][A-Za-z0-9_$]*")
 
 
 @dataclass(frozen=True)
@@ -90,6 +116,9 @@ _AUTHOR_PROSE_FIELD_PATTERNS: tuple[tuple[str, ...], ...] = (
     # unfinished order. An over-length one is now an authoring issue the model
     # repairs by splitting the change, never a silent truncation.
     ("steps", "*", "verification", "note"),
+    ("test_plan", "rationale"),
+    ("test_plan", "existing_coverage", "*", "behavior"),
+    ("test_plan", "existing_coverage", "*", "verification", "note"),
     ("test_plan", "exemplars", "*", "pattern_to_copy"),
     ("test_plan", "cases", "*", "name"),
     ("test_plan", "cases", "*", "setup"),
@@ -183,6 +212,128 @@ def _read_repo_file(repo: Path, path: str) -> str | None:
         return candidate.read_text(encoding="utf-8")
     except (OSError, UnicodeError, ValueError):
         return None
+
+
+def _is_documentation_path(path: str) -> bool:
+    candidate = Path(path)
+    if any(part.casefold() in {"doc", "docs", "documentation"} for part in candidate.parts):
+        return True
+    stem = candidate.stem.casefold()
+    return candidate.suffix.casefold() in _DOCUMENTATION_SUFFIXES or stem in _DOCUMENTATION_NAMES
+
+
+def _is_test_path(path: str) -> bool:
+    candidate = Path(path)
+    parts = {part.casefold() for part in candidate.parts[:-1]}
+    name = candidate.name.casefold()
+    stem = candidate.stem.casefold()
+    return bool(parts & _TEST_DIRECTORY_NAMES) or (
+        stem in {"test", "tests"}
+        or stem.startswith("test_")
+        or stem.endswith("_test")
+        or candidate.stem.endswith(("Test", "Tests"))
+        or ".test." in name
+        or ".spec." in name
+    )
+
+
+def _is_comment_only_change(change: dict[str, Any]) -> bool:
+    if change.get("operation") not in {"modify", "delete"}:
+        return False
+    symbol = str(change.get("symbol") or "")
+    instruction = str(change.get("instruction") or "")
+    target_state = str(change.get("target_state") or "")
+    authored_change = f"{symbol} {instruction}"
+    if not (_COMMENT_KIND.search(authored_change) and _COMMENT_KIND.search(target_state)):
+        return False
+    return bool(
+        _ABSENCE_WORD.search(target_state)
+        or (_COMMENT_REWRITE.search(instruction) and _UNCHANGED_EXECUTION.search(target_state))
+    )
+
+
+def _not_applicable_change_allowed(change: dict[str, Any]) -> bool:
+    """Return whether a change is structurally eligible to omit test coverage.
+
+    The host cannot prove from model prose that production code is dead, so a
+    delete operation is not itself an exemption. Documentation and exact
+    comment/docstring cleanup are non-behavioural by construction; deleting a
+    redundant test is also eligible when the plan supplies a separate static
+    or step gate. Production-source deletion must use existing coverage or a
+    named new/updated test instead.
+    """
+
+    path = change.get("path")
+    if not isinstance(path, str):
+        return False
+    if _is_documentation_path(path) or _is_comment_only_change(change):
+        return True
+    return change.get("operation") == "delete" and _is_test_path(path)
+
+
+def _has_test_declaration(path: str, source: str, symbol: str) -> bool:
+    """Match an exact test declaration, never a substring or prose mention."""
+
+    if not symbol or "\n" in symbol or "\r" in symbol:
+        return False
+    test_path = _is_test_path(path)
+    if Path(path).suffix.casefold() == ".py" and _IDENTIFIER.fullmatch(symbol):
+        if not test_path or not symbol.casefold().startswith("test"):
+            return False
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            return False
+        return any(
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == symbol for node in ast.walk(tree)
+        )
+
+    escaped = re.escape(symbol)
+    if _IDENTIFIER.fullmatch(symbol):
+        path_based_declaration_patterns = (
+            # Python/Ruby, Rust, Go/Swift, and JavaScript named functions.
+            rf"^[ \t]*(?:(?:export|internal|private|protected|public|"
+            rf"pub(?:\([^)]*\))?|async|static)\s+)*(?:def|fn|function)\s+"
+            rf"{escaped}(?![A-Za-z0-9_$])\s*(?:\(|:)",
+            rf"^[ \t]*(?:(?:internal|private|protected|public|static)\s+)*"
+            rf"func(?:\s+\([^)]*\))?\s+{escaped}(?![A-Za-z0-9_$])\s*\(",
+            # JavaScript/TypeScript arrow-function tests.
+            rf"^[ \t]*(?:(?:export|async)\s+)*(?:const|let|var)\s+"
+            rf"{escaped}(?![A-Za-z0-9_$])\s*=",
+            # C#, JVM, and similar method declarations. Requiring at least one
+            # modifier prevents an ordinary call expression from qualifying.
+            rf"^[ \t]*(?:(?:async|final|internal|override|private|protected|"
+            rf"public|static|virtual)\s+)+(?:fun|void|[A-Za-z_$]"
+            rf"[A-Za-z0-9_$<>?,.\[\]]*)\s+{escaped}"
+            rf"(?![A-Za-z0-9_$])\s*\(",
+        )
+        if test_path and any(re.search(pattern, source, re.MULTILINE) for pattern in path_based_declaration_patterns):
+            return True
+        annotated_declaration_patterns = (
+            # C/C++ test macros are test declarations wherever they live.
+            rf"^[ \t]*TEST(?:_[FP])?\s*\([^,\n]+,\s*"
+            rf"{escaped}(?![A-Za-z0-9_$])\s*\)",
+            # Attribute/annotation-driven Rust, JVM, and .NET test methods.
+            rf"(?ms)^[ \t]*(?:#\[[^\]]*test[^\]]*\]|@Test|"
+            rf"\[(?:Fact|Test|TestMethod|Theory)\])\s*\n"
+            rf"[ \t]*(?:(?:public|private|protected|static|final|async|pub)\s+)*"
+            rf"(?:fun|fn|void|[A-Za-z_$][A-Za-z0-9_$<>?,.\[\]]*)\s+"
+            rf"{escaped}(?![A-Za-z0-9_$])\s*\(",
+        )
+        if any(re.search(pattern, source, re.MULTILINE) for pattern in annotated_declaration_patterns):
+            return True
+
+    # Frameworks such as Jest, RSpec, and ExUnit use an exact quoted title as
+    # the test's durable identity rather than a language-level function name.
+    for quote in ('"', "'"):
+        quoted = re.escape(f"{quote}{symbol}{quote}")
+        if re.search(
+            rf"^[ \t]*(?:it|scenario|specify|test)\s*(?:\(\s*)?{quoted}",
+            source,
+            re.MULTILINE,
+        ):
+            return True
+    return False
 
 
 def _entry_paths(entries: Any) -> list[str]:
@@ -419,42 +570,8 @@ def _relocate_existing_new_paths(
     for step in steps if isinstance(steps, list) else []:
         changes = step.get("changes") if isinstance(step, dict) else None
         for change in changes if isinstance(changes, list) else []:
-            if (
-                isinstance(change, dict)
-                and change.get("path") in relocated
-                and change.get("operation") == "create"
-            ):
+            if isinstance(change, dict) and change.get("path") in relocated and change.get("operation") == "create":
                 change["operation"] = "modify"
-
-
-_TEST_SYMBOL_MAX_LENGTH = _author_schema_max_length(
-    ("test_plan", "cases", "*", "test_symbol")
-)
-
-
-def _disambiguate_test_symbols(normalized: dict[str, Any]) -> None:
-    """Number a repeated test symbol instead of blocking on the collision.
-
-    Two cases naming the same test is a naming slip, not a defect in the work
-    the plan describes. The first occurrence keeps the authored name and each
-    repeat gets the lowest unused ``_<n>`` suffix, so every case still names one
-    distinct test the executor can write and run.
-    """
-    test_plan = normalized.get("test_plan")
-    cases = test_plan.get("cases") if isinstance(test_plan, dict) else None
-    seen: set[str] = set()
-    for case in cases if isinstance(cases, list) else []:
-        symbol = case.get("test_symbol") if isinstance(case, dict) else None
-        if not isinstance(symbol, str):
-            continue
-        candidate = symbol
-        suffix = 2
-        while candidate in seen:
-            tail = f"_{suffix}"
-            candidate = symbol[: _TEST_SYMBOL_MAX_LENGTH - len(tail)] + tail
-            suffix += 1
-        seen.add(candidate)
-        case["test_symbol"] = candidate
 
 
 def _clamp_excerpt_end_lines(normalized: dict[str, Any], *, repo: Path) -> None:
@@ -549,7 +666,6 @@ def _normalize_authored(
     _declare_referenced_paths(normalized, repo=repo)
     _dedup_scope(normalized, repo=repo)
     _relocate_existing_new_paths(normalized, repo=repo)
-    _disambiguate_test_symbols(normalized)
     _clamp_excerpt_end_lines(normalized, repo=repo)
     return normalized
 
@@ -666,6 +782,13 @@ def _iter_command_refs(
         if isinstance(step, dict) and isinstance(step.get("verification"), dict):
             yield f"/steps/{index}/verification", step["verification"]
     test_plan = normalized.get("test_plan")
+    existing_coverage = test_plan.get("existing_coverage") if isinstance(test_plan, dict) else None
+    for index, coverage in enumerate(existing_coverage if isinstance(existing_coverage, list) else []):
+        if isinstance(coverage, dict) and isinstance(coverage.get("verification"), dict):
+            yield (
+                f"/test_plan/existing_coverage/{index}/verification",
+                coverage["verification"],
+            )
     cases = test_plan.get("cases") if isinstance(test_plan, dict) else None
     for index, case in enumerate(cases if isinstance(cases, list) else []):
         if isinstance(case, dict) and isinstance(case.get("verification"), dict):
@@ -684,19 +807,16 @@ def _iter_command_refs(
             yield f"/additional_command_refs/{index}", ref
 
 
-_COMMAND_NOTE_MAX_LENGTH = _author_schema_max_length(
-    ("additional_command_refs", "*", "note")
-)
+_COMMAND_NOTE_MAX_LENGTH = _author_schema_max_length(("additional_command_refs", "*", "note"))
 _RETARGETED_COMMAND_NOTE = (
-    "Retargeted by the host: the command this plan named is verified only for "
-    "paths this plan does not change, so this repository-wide command runs "
-    "instead."
+    "Retargeted by the host: the command this plan named does not cover this "
+    "verification's targets, so this repository-wide command runs instead."
 )
 _COMMAND_SCOPE_CAVEAT = (
     "Scope caveat from the host: this command's verified applicability does "
-    "not cover every path this plan changes, and no verified command that "
-    "covers them is available here. Run it as written and report what it "
-    "reports; do not substitute a command of your own."
+    "not cover every target of this verification, and no verified command "
+    "that covers them is available here. Run it as written and report what "
+    "it reports; do not substitute a command of your own."
 )
 
 
@@ -719,12 +839,14 @@ def _repair_command_scope(
 ) -> None:
     """Retarget or annotate a verified command whose scope misses the plan.
 
-    A command whose applicability does not line up with the plan's changed
-    paths runs a slightly too narrow or too broad check; it does not make the
-    plan wrong, so it is repaired rather than thrown away. The host prefers a
-    verified repository-wide command, which by definition covers every path,
-    and otherwise keeps the model's choice and states the caveat in the note
-    the plan renders — the executor is told the truth either way.
+    A command whose applicability does not line up with its verification
+    targets runs a slightly too narrow or too broad check; it does not make the
+    plan wrong, so it is repaired rather than thrown away. Step and authored
+    test gates target writable paths, while an existing-coverage gate targets
+    its cited read-only test path. The host prefers a verified repository-wide
+    command, which by definition covers every path, and otherwise keeps the
+    model's choice and states the caveat in the note the plan renders — the
+    executor is told the truth either way.
 
     Two things are deliberately left alone. A ``recon_command_id`` naming no
     verified command at all is a hallucination, not a scope imperfection, and
@@ -750,22 +872,33 @@ def _repair_command_scope(
         None,
     )
     steps = normalized.get("steps")
-    step_targets: dict[str, list[str]] = {}
+    ref_targets: dict[str, list[str]] = {}
     for index, step in enumerate(steps if isinstance(steps, list) else []):
         changes = step.get("changes") if isinstance(step, dict) else None
-        step_targets[f"/steps/{index}/verification"] = [
+        ref_targets[f"/steps/{index}/verification"] = [
             change["path"]
             for change in (changes if isinstance(changes, list) else [])
             if isinstance(change, dict) and isinstance(change.get("path"), str)
         ]
+    test_plan = normalized.get("test_plan")
+    test_plan = test_plan if isinstance(test_plan, dict) else {}
+    existing_coverage = test_plan.get("existing_coverage")
+    for index, coverage in enumerate(existing_coverage if isinstance(existing_coverage, list) else []):
+        path = coverage.get("path") if isinstance(coverage, dict) else None
+        if isinstance(path, str):
+            ref_targets[f"/test_plan/existing_coverage/{index}/verification"] = [path]
+    cases = test_plan.get("cases")
+    for index, case in enumerate(cases if isinstance(cases, list) else []):
+        path = case.get("test_file") if isinstance(case, dict) else None
+        if isinstance(path, str):
+            ref_targets[f"/test_plan/cases/{index}/verification"] = [path]
     for pointer, ref in _iter_command_refs(normalized):
         recon_id = ref.get("recon_command_id")
         base = recon_by_id.get(recon_id) if isinstance(recon_id, str) else None
         if base is None:
             continue
-        if _command_scope_fits_plan(base, in_scope) and _command_covers_all(
-            base, step_targets.get(pointer, ())
-        ):
+        targets = ref_targets.get(pointer, in_scope)
+        if _command_scope_fits_plan(base, targets) and _command_covers_all(base, targets):
             continue
         if repository_wide is not None and ref.get("appended_args") is None:
             ref["recon_command_id"] = repository_wide
@@ -779,6 +912,7 @@ def _collect_issues(
     *,
     repo: Path,
     recon_by_id: dict[str, dict[str, Any]],
+    expected_fingerprints: Sequence[str] | None = None,
 ) -> list[AssemblyIssue]:
     issues: list[AssemblyIssue] = []
     seen: set[tuple[str, str, str | None]] = set()
@@ -810,6 +944,27 @@ def _collect_issues(
         return True
 
     _schema_issues(normalized, add)
+
+    covered = normalized.get("covered_fingerprints")
+    if isinstance(covered, list) and all(isinstance(item, str) for item in covered):
+        if len(covered) != len(set(covered)):
+            add(
+                "COVERED_FINGERPRINT_DUPLICATE",
+                "/covered_fingerprints",
+                hint="List each finding fingerprint exactly once.",
+            )
+        if expected_fingerprints is not None:
+            expected = set(expected_fingerprints)
+            actual = set(covered)
+            missing = sorted(expected - actual)
+            extra = sorted(actual - expected)
+            if missing or extra:
+                add(
+                    "COVERED_FINGERPRINTS_MISMATCH",
+                    "/covered_fingerprints",
+                    f"missing={len(missing)};extra={len(extra)}",
+                    hint=("replace with exactly: " + ", ".join(str(item) for item in expected_fingerprints)),
+                )
 
     scope = normalized.get("scope")
     scope = scope if isinstance(scope, dict) else {}
@@ -962,10 +1117,112 @@ def _collect_issues(
 
     test_plan = normalized.get("test_plan")
     test_plan = test_plan if isinstance(test_plan, dict) else {}
+    mode = test_plan.get("mode")
+    existing_coverage = test_plan.get("existing_coverage")
+    existing_coverage = existing_coverage if isinstance(existing_coverage, list) else []
     exemplars = test_plan.get("exemplars")
-    for index, exemplar in enumerate(
-        exemplars if isinstance(exemplars, list) else []
-    ):
+    exemplars = exemplars if isinstance(exemplars, list) else []
+    cases = test_plan.get("cases")
+    cases = cases if isinstance(cases, list) else []
+
+    if mode == "new-or-updated-tests":
+        if not cases:
+            # Preserve the long-standing diagnostic while moving this rule out
+            # of JSON Schema and into the mode-aware host boundary.
+            add(
+                "AUTHOR_SCHEMA_INVALID",
+                "/test_plan/cases",
+                "minItems=1;actual=0",
+                "new-or-updated-tests mode requires at least one named case",
+            )
+        if existing_coverage:
+            add(
+                "TEST_PLAN_MODE_CONFLICT",
+                "/test_plan/existing_coverage",
+                hint=("new-or-updated-tests mode uses named cases; leave existing_coverage empty"),
+            )
+    elif mode == "existing-coverage":
+        if not existing_coverage:
+            add(
+                "EXISTING_COVERAGE_REQUIRED",
+                "/test_plan/existing_coverage",
+                hint=("cite at least one existing test path and symbol, or choose another test-plan mode"),
+            )
+        if cases:
+            add(
+                "TEST_PLAN_MODE_CONFLICT",
+                "/test_plan/cases",
+                hint="existing-coverage mode must not author new test cases",
+            )
+        if exemplars:
+            add(
+                "TEST_PLAN_MODE_CONFLICT",
+                "/test_plan/exemplars",
+                hint="existing-coverage mode does not need test-writing exemplars",
+            )
+    elif mode == "not-applicable":
+        for field, entries in (
+            ("existing_coverage", existing_coverage),
+            ("exemplars", exemplars),
+            ("cases", cases),
+        ):
+            if entries:
+                add(
+                    "TEST_PLAN_MODE_CONFLICT",
+                    f"/test_plan/{field}",
+                    hint=f"not-applicable mode requires an empty {field} array",
+                )
+        criteria = normalized.get("done_criteria")
+        criteria = criteria if isinstance(criteria, list) else []
+        if any(isinstance(criterion, dict) and criterion.get("kind") == "test-gate" for criterion in criteria):
+            add(
+                "TEST_PLAN_MODE_CONFLICT",
+                "/done_criteria",
+                hint=("not-applicable mode must not claim a test gate; use a step gate or static invariant"),
+            )
+        if not any(
+            isinstance(criterion, dict) and criterion.get("kind") in {"static-invariant", "step-gate"}
+            for criterion in criteria
+        ):
+            add(
+                "NON_TEST_VERIFICATION_REQUIRED",
+                "/done_criteria",
+                hint=(
+                    "not-applicable mode requires a static-invariant or "
+                    "step-gate criterion stating the exact non-test check"
+                ),
+            )
+        for step_index, step in enumerate(steps):
+            if not isinstance(step, dict):
+                continue
+            changes = step.get("changes")
+            for change_index, change in enumerate(changes if isinstance(changes, list) else []):
+                if not isinstance(change, dict) or _not_applicable_change_allowed(change):
+                    continue
+                add(
+                    "TEST_PLAN_NOT_APPLICABLE_UNSAFE",
+                    f"/steps/{step_index}/changes/{change_index}/operation",
+                    hint=(
+                        "use existing-coverage or new-or-updated-tests for "
+                        "production behavior; not-applicable is limited to "
+                        "documentation, exact comment/docstring cleanup, or "
+                        "deleting a redundant test"
+                    ),
+                )
+
+    for index, coverage in enumerate(existing_coverage):
+        if not isinstance(coverage, dict):
+            continue
+        pointer = f"/test_plan/existing_coverage/{index}"
+        path = coverage.get("path")
+        symbol = coverage.get("symbol")
+        if not isinstance(path, str) or not check_path(f"{pointer}/path", path):
+            continue
+        source = _read_repo_file(repo, path)
+        if source is None or not isinstance(symbol, str) or not _has_test_declaration(path, source, symbol):
+            add("EXISTING_COVERAGE_INVALID", pointer)
+
+    for index, exemplar in enumerate(exemplars):
         if not isinstance(exemplar, dict):
             continue
         pointer = f"/test_plan/exemplars/{index}"
@@ -974,20 +1231,28 @@ def _collect_issues(
         if not isinstance(path, str) or not check_path(f"{pointer}/path", path):
             continue
         source = _read_repo_file(repo, path)
-        if (
-            source is None
-            or not isinstance(symbol, str)
-            or symbol not in source
-        ):
+        if source is None or not isinstance(symbol, str) or not _has_test_declaration(path, source, symbol):
             add("TEST_EXEMPLAR_INVALID", pointer)
-    cases = test_plan.get("cases")
-    for index, case in enumerate(cases if isinstance(cases, list) else []):
+    seen_test_symbols: set[tuple[str, str]] = set()
+    for index, case in enumerate(cases):
         if not isinstance(case, dict):
             continue
-        # Normalization already declared a well-formed test_file in scope and
-        # disambiguated any repeated test_symbol; the check that stays is the
-        # path grammar and confinement one.
-        check_path(f"/test_plan/cases/{index}/test_file", case.get("test_file"))
+        test_file = case.get("test_file")
+        test_symbol = case.get("test_symbol")
+        check_path(f"/test_plan/cases/{index}/test_file", test_file)
+        if isinstance(test_file, str) and isinstance(test_symbol, str):
+            identity = (test_file, test_symbol)
+            if identity in seen_test_symbols:
+                add(
+                    "DUPLICATE_TEST_SYMBOL",
+                    f"/test_plan/cases/{index}/test_symbol",
+                    hint=(
+                        "combine cases with the same behavior into one "
+                        "parameterized test, or use meaningful distinct symbols "
+                        "for genuinely different behaviors"
+                    ),
+                )
+            seen_test_symbols.add(identity)
 
     for pointer, ref in _iter_command_refs(normalized):
         if pointer.startswith("/steps/"):
@@ -1179,11 +1444,15 @@ def _injected_done_criteria(
                 "verification": None,
             },
         )
-    if "test-gate" not in kinds:
-        symbols = ", ".join(
-            case["test_symbol"] for case in normalized["test_plan"]["cases"]
-        )
-        description = f"Every named test-plan case passes: {symbols}."
+    test_plan = normalized["test_plan"]
+    test_mode = test_plan["mode"]
+    if "test-gate" not in kinds and test_mode != "not-applicable":
+        if test_mode == "existing-coverage":
+            symbols = ", ".join(coverage["symbol"] for coverage in test_plan["existing_coverage"])
+            description = f"The cited existing coverage passes: {symbols}."
+        else:
+            symbols = ", ".join(case["test_symbol"] for case in test_plan["cases"])
+            description = f"Every named test-plan case passes: {symbols}."
         criteria.append(
             {
                 "kind": "test-gate",
@@ -1191,6 +1460,30 @@ def _injected_done_criteria(
                 "verification": None,
             }
         )
+    for step in normalized["steps"]:
+        for change in step["changes"]:
+            if change["operation"] != "delete":
+                continue
+            path = change["path"]
+            symbol = change["symbol"]
+            if any(
+                criterion["kind"] == "static-invariant" and change["target_state"] in criterion["description"]
+                for criterion in criteria
+            ):
+                continue
+            if symbol == path:
+                description = f"The deleted path `{path}` is absent. Target state: {change['target_state']}"
+            else:
+                description = (
+                    f"The deleted target `{symbol}` is absent from `{path}`. Target state: {change['target_state']}"
+                )
+            criteria.append(
+                {
+                    "kind": "static-invariant",
+                    "description": description[:description_limit],
+                    "verification": None,
+                }
+            )
     if "scope-integrity" not in kinds:
         scope = normalized["scope"]
         paths = ", ".join(
@@ -1218,6 +1511,7 @@ def assemble_plan(
     *,
     repo: Path,
     recon_commands: Sequence[dict[str, Any]],
+    expected_fingerprints: Sequence[str] | None = None,
 ) -> tuple[dict[str, Any] | None, tuple[AssemblyIssue, ...]]:
     """Normalize, collect ALL authoring issues, then expand.
 
@@ -1236,7 +1530,12 @@ def assemble_plan(
         if isinstance(command, dict) and isinstance(command.get("id"), str)
     }
     _repair_command_scope(normalized, recon_by_id=recon_by_id)
-    issues = _collect_issues(normalized, repo=repo, recon_by_id=recon_by_id)
+    issues = _collect_issues(
+        normalized,
+        repo=repo,
+        recon_by_id=recon_by_id,
+        expected_fingerprints=expected_fingerprints,
+    )
     if issues:
         return None, tuple(issues)
 
@@ -1257,16 +1556,12 @@ def assemble_plan(
     ]
     assembled = {
         "title": normalized["title"],
+        "covered_fingerprints": list(normalized["covered_fingerprints"]),
         "why_this_matters": dict(normalized["why_this_matters"]),
         "current_state_excerpts": current_state_excerpts,
-        "commands_you_will_need": _derived_commands_table(
-            normalized, recon_by_id=recon_by_id
-        ),
+        "commands_you_will_need": _derived_commands_table(normalized, recon_by_id=recon_by_id),
         "scope": {
-            "existing_paths": [
-                {"path": entry["path"], "role": entry["role"]}
-                for entry in scope["existing_paths"]
-            ],
+            "existing_paths": [{"path": entry["path"], "role": entry["role"]} for entry in scope["existing_paths"]],
             "new_paths": deepcopy(scope["new_paths"]),
             "out_of_scope_paths": deepcopy(scope["out_of_scope_paths"]),
             "out_of_scope_behaviors": deepcopy(scope["out_of_scope_behaviors"]),
@@ -1294,6 +1589,15 @@ def assemble_plan(
             for index, step in enumerate(normalized["steps"], start=1)
         ],
         "test_plan": {
+            "mode": normalized["test_plan"]["mode"],
+            "rationale": normalized["test_plan"]["rationale"],
+            "existing_coverage": [
+                {
+                    **{key: coverage[key] for key in coverage if key != "verification"},
+                    "verification": _expand_optional_ref(coverage["verification"], recon_by_id=recon_by_id),
+                }
+                for coverage in normalized["test_plan"]["existing_coverage"]
+            ],
             "exemplars": deepcopy(normalized["test_plan"]["exemplars"]),
             "cases": [
                 {

--- a/daydream/improve/orchestrator.py
+++ b/daydream/improve/orchestrator.py
@@ -30,6 +30,7 @@ from daydream.extensions.api import FlowStep, Stop
 from daydream.improve.artifacts import (
     coverage_path,
     plan_write_diagnostics_path,
+    published_issues_path,
     recon_path,
     report_path,
     vetted_findings_path,
@@ -67,15 +68,17 @@ from daydream.improve.prioritize import (
     aggregate_cross_service,
     leverage_score,
     order_by_leverage,
-    partition_direction,
 )
 from daydream.improve.prompts import (
     AUDIT_FINDINGS_SCHEMA,
+    CHANGE_SHAPES,
+    MAINTENANCE_SIGNALS,
     PLAN_AUTHOR_SCHEMA,
     RECON_COMMAND_CONTRACT_BULLET,
     VET_SCHEMA,
     build_plan_writer_repair_prompt,
 )
+from daydream.improve.publish import ImprovePublishError, IssuePublisher
 from daydream.improve.render import markdown_cell
 from daydream.improve.repo_commands import enumerate_repository_commands
 from daydream.improve.services import Service, enumerate_services, filter_scope
@@ -113,10 +116,11 @@ RECON_SCHEMA: dict[str, Any] = {
     },
 }
 
-_EVIDENCE_LOCATION = re.compile(
-    r"^`?(.+?):(\d+)(?::(\d+))?(?:`|\b)"
-)
+_EVIDENCE_LOCATION = re.compile(r"^`?(.+?):(\d+)(?::(\d+))?(?:`|\b)")
 _PROVENANCE_VALUES = {"introduced", "inherited"}
+_MAINTENANCE_SIGNALS = set(MAINTENANCE_SIGNALS)
+_CHANGE_SHAPES = set(CHANGE_SHAPES)
+_REUSE_TARGET = re.compile(r"^(?:repo:[^#\s]+#[^\s]+|stdlib:[^\s]+|dep:[^:\s]+:[^\s]+)$")
 
 
 def _redact_model_value(value: Any) -> Any:
@@ -756,6 +760,17 @@ def _stamp_finding(
     if evidence_paths is None:
         return None
     stamped = dict(finding)
+    raw_signals = stamped.get("maintenance_signals")
+    stamped["maintenance_signals"] = (
+        list(dict.fromkeys(signal for signal in raw_signals if signal in _MAINTENANCE_SIGNALS))
+        if isinstance(raw_signals, list)
+        else []
+    )
+    if stamped.get("change_shape") not in _CHANGE_SHAPES:
+        stamped["change_shape"] = "unknown"
+    reuse_target = stamped.get("reuse_target")
+    if not isinstance(reuse_target, str) or _REUSE_TARGET.fullmatch(reuse_target) is None:
+        stamped["reuse_target"] = None
     stamped["category"] = category
     stamped["partition"] = _owning_partition(partitions, evidence_paths)
     stamped["services"] = [
@@ -808,8 +823,6 @@ def resolve_categories(
     """Resolve the audit categories for an effort tier and optional focus."""
     if focus in {"security", "performance", "tests"}:
         return (focus,)
-    if focus == "next":
-        return ("direction",)
     if focus == "branch":
         return AUDIT_CATEGORIES
     return tier.categories or AUDIT_CATEGORIES
@@ -861,11 +874,6 @@ async def _step_audit(ctx: FlowContext) -> Stop | None:
                 if assignment.group.stack
                 else "Audit this group's surface."
             )
-            if ctx.config.improve_focus == "next":
-                scope_note += (
-                    "\nReturn 4–6 grounded suggestions with honest tradeoffs "
-                    "and design/spike-sized next steps."
-                )
             if ctx.config.improve_scope:
                 scope_note += (
                     f"\nService scope slice: `{ctx.config.improve_scope}`. "
@@ -1096,6 +1104,8 @@ def _apply_vet_verdicts(
         "effort",
         "risk",
         "confidence",
+        "maintenance_signals",
+        "change_shape",
         "path",
         "line",
         "provenance",
@@ -1120,19 +1130,29 @@ def _apply_vet_verdicts(
         for field in corrected_fields:
             if verdict.get(field) is not None:
                 corrected[field] = verdict[field]
-        location_corrected = (
-            verdict.get("path") is not None or verdict.get("line") is not None
-        )
+        # The vet contract uses human-readable severity names while the
+        # prioritizer's axes use the audit vocabulary. Normalize at the host
+        # boundary so aggregation cannot silently promote every vetted item to
+        # its conservative fallback.
+        severity = corrected.get("severity")
+        if isinstance(severity, str):
+            corrected["severity"] = {
+                "high": "HIGH",
+                "medium": "MED",
+                "low": "LOW",
+            }.get(severity.lower(), severity)
+        # Unlike the other corrected fields, ``None`` is a meaningful vet
+        # correction here: it explicitly retracts an audit-time reuse target.
+        if "reuse_target" in verdict:
+            corrected["reuse_target"] = verdict["reuse_target"]
+        location_corrected = verdict.get("path") is not None or verdict.get("line") is not None
         if location_corrected:
             _correct_primary_evidence_location(
                 corrected,
                 path=str(corrected.get("path", "")),
                 line=corrected.get("line"),
             )
-        if (
-            default_provenance is not None
-            and corrected.get("provenance") not in _PROVENANCE_VALUES
-        ):
+        if default_provenance is not None and corrected.get("provenance") not in _PROVENANCE_VALUES:
             corrected["provenance"] = default_provenance
         if location_corrected:
             restamped = _stamp_finding(
@@ -1261,36 +1281,22 @@ async def _step_vet(ctx: FlowContext) -> None:
 
     record_rejections(plans_dir, rejected)
     findings = aggregate_cross_service(order_by_leverage(kept))
-    defects, direction = partition_direction(findings)
-    ordered_defects = order_by_leverage(defects)
-    ordered_direction = order_by_leverage(direction)
+    ordered_defects = order_by_leverage(findings)
     vetted = _with_artifact_provenance(
         {
-            "findings": [*ordered_defects, *ordered_direction],
+            "findings": ordered_defects,
             "defects": ordered_defects,
-            "direction": ordered_direction,
         },
         phase=DaydreamPhase.VET,
     )
-    vetted_findings_path(directory).write_text(
-        json.dumps(vetted, indent=2) + "\n"
-    )
+    vetted_findings_path(directory).write_text(json.dumps(vetted, indent=2) + "\n")
     ctx.data["vetted"] = vetted
     ctx.data["previously_rejected"] = previously_rejected
     ctx.data["vet_rejected"] = len(rejected)
     ctx.data["defects"] = ordered_defects
-    ctx.data["direction"] = ordered_direction
     if branch_focus:
-        introduced = [
-            finding
-            for finding in ordered_defects
-            if finding.get("provenance") == "introduced"
-        ]
-        inherited = [
-            finding
-            for finding in ordered_defects
-            if finding.get("provenance") != "introduced"
-        ]
+        introduced = [finding for finding in ordered_defects if finding.get("provenance") == "introduced"]
+        inherited = [finding for finding in ordered_defects if finding.get("provenance") != "introduced"]
         ctx.data["findings_table"] = (
             "### Introduced by this branch\n\n"
             f"{_findings_table(introduced)}\n\n"
@@ -1299,10 +1305,6 @@ async def _step_vet(ctx: FlowContext) -> None:
         )
     else:
         ctx.data["findings_table"] = _findings_table(ordered_defects)
-    ctx.data["direction_section"] = _direction_section(
-        ordered_direction,
-        start=len(ordered_defects) + 1,
-    )
 
 
 def _evidence_cell(finding: dict[str, Any]) -> str:
@@ -1318,8 +1320,8 @@ def _findings_table(
     start: int = 1,
 ) -> str:
     lines = [
-        "| # | Finding | Category | Impact | Effort | Risk | Confidence | Evidence |",
-        "|---:|---|---|---|---|---|---|---|",
+        "| # | Finding | Category | Change | Impact | Effort | Risk | Confidence | Evidence |",
+        "|---:|---|---|---|---|---|---|---|---|",
     ]
     for number, finding in enumerate(findings, start=start):
         lines.append(
@@ -1329,6 +1331,7 @@ def _findings_table(
                     str(number),
                     markdown_cell(finding.get("title")),
                     markdown_cell(finding.get("category")),
+                    markdown_cell(finding.get("change_shape", "unknown")),
                     markdown_cell(finding.get("impact")),
                     markdown_cell(finding.get("effort")),
                     markdown_cell(finding.get("risk")),
@@ -1339,29 +1342,8 @@ def _findings_table(
             + " |"
         )
     if not findings:
-        lines.append("| — | No vetted defect findings. | — | — | — | — | — | — |")
+        lines.append("| — | No vetted findings. | — | — | — | — | — | — | — |")
     return "\n".join(lines)
-
-
-def _direction_section(
-    findings: list[dict[str, Any]],
-    *,
-    start: int,
-    limit: int = 4,
-) -> str:
-    if not findings:
-        return "## Direction\n\nNo grounded direction findings."
-    entries: list[str] = []
-    for number, finding in enumerate(findings[:limit], start=start):
-        entries.append(
-            f"### {number}. {markdown_cell(finding.get('title'))}\n\n"
-            f"{markdown_cell(finding.get('body'))} "
-            f"Impact: {markdown_cell(finding.get('impact'))}; "
-            f"effort: {markdown_cell(finding.get('effort'))}; "
-            f"fix risk: {markdown_cell(finding.get('risk'))}. "
-            f"Evidence: {_evidence_cell(finding)}."
-        )
-    return "## Direction\n\n" + "\n\n".join(entries)
 
 
 def _parse_selection(raw: str, *, total: int) -> list[int] | None:
@@ -1397,34 +1379,33 @@ def _default_selection(defects: list[dict[str, Any]]) -> list[int]:
     return list(range(1, min(5, len(defects)) + 1))
 
 
+def _automatic_issue_publishing(ctx: FlowContext) -> bool:
+    """Return whether this Improve run is configured to publish plans."""
+    file_config = ctx.config.file_config or DaydreamFileConfig()
+    return bool(getattr(file_config, "improve_github_publish_issues", False))
+
+
 def _selection_prompt(
-    defects: list[dict[str, Any]],
-    direction: list[dict[str, Any]],
+    findings: list[dict[str, Any]],
 ) -> str:
-    sections = [
-        "Choose findings to turn into plans (comma-separated numbers or ranges).",
-        _findings_table(defects),
-    ]
-    if direction:
-        sections.append(
-            _direction_section(
-                direction,
-                start=len(defects) + 1,
-                limit=len(direction),
-            )
-        )
-    return "\n\n".join(sections)
+    return "\n\n".join(
+        [
+            "Choose findings to turn into plans (comma-separated numbers or ranges).",
+            _findings_table(findings),
+        ]
+    )
 
 
 async def _step_select(ctx: FlowContext) -> Stop | None:
     """Persist the user's plan selection or the silent unattended default."""
-    defects: list[dict[str, Any]] = ctx.data["defects"]
-    direction: list[dict[str, Any]] = ctx.data["direction"]
-    default_findings = (
-        direction if ctx.config.improve_focus == "next" else defects
+    default_findings: list[dict[str, Any]] = ctx.data["defects"]
+    publish_all = get_non_interactive() and _automatic_issue_publishing(ctx)
+    default_numbers = list(range(1, len(default_findings) + 1)) if publish_all else _default_selection(default_findings)
+    mode = (
+        "automatic-publishing"
+        if publish_all
+        else ("non-interactive-default" if get_non_interactive() else "interactive")
     )
-    default_numbers = _default_selection(default_findings)
-    mode = "non-interactive-default" if get_non_interactive() else "interactive"
     selected_numbers = default_numbers
 
     if not default_findings:
@@ -1444,14 +1425,12 @@ async def _step_select(ctx: FlowContext) -> Stop | None:
         return None
 
     if not get_non_interactive():
-        default_text = (
-            f"1-{len(default_numbers)}" if len(default_numbers) > 1 else "1"
-        )
-        prompt = _selection_prompt(defects, direction)
+        default_text = f"1-{len(default_numbers)}" if len(default_numbers) > 1 else "1"
+        prompt = _selection_prompt(default_findings)
         raw = agent.prompt_user(console, prompt, default=default_text)
         parsed = _parse_selection(
             raw,
-            total=len(defects) + len(direction),
+            total=len(default_findings),
         )
         if parsed is None:
             raw = agent.prompt_user(
@@ -1461,17 +1440,13 @@ async def _step_select(ctx: FlowContext) -> Stop | None:
             )
             parsed = _parse_selection(
                 raw,
-                total=len(defects) + len(direction),
+                total=len(default_findings),
             )
         selected_numbers = parsed if parsed is not None else default_numbers
 
-    selectable = [*defects, *direction]
-    selected = [
-        selectable[number - 1]["fingerprint"] for number in selected_numbers
-    ]
-    ctx.data["selected_findings"] = [
-        selectable[number - 1] for number in selected_numbers
-    ]
+    selectable = default_findings
+    selected = [selectable[number - 1]["fingerprint"] for number in selected_numbers]
+    ctx.data["selected_findings"] = [selectable[number - 1] for number in selected_numbers]
     ctx.data["selection_mode"] = mode
     (ctx.data["improve_dir"] / "selected.json").write_text(
         json.dumps(
@@ -1522,12 +1497,25 @@ def _description_finding(description: str) -> dict[str, Any]:
         "risk": "MED",
         "confidence": "HIGH",
         "evidence": [],
+        "maintenance_signals": [],
+        "change_shape": "unknown",
+        "reuse_target": None,
         "fingerprint": compute_fingerprint(
             "",
             description,
             "User-requested improve plan",
         ),
     }
+
+
+def _expected_plan_fingerprints(finding: dict[str, Any]) -> list[str]:
+    members = finding.get("member_fingerprints")
+    if isinstance(members, list):
+        valid = [item for item in members if isinstance(item, str) and item]
+        if valid:
+            return valid
+    fingerprint = finding.get("fingerprint")
+    return [fingerprint] if isinstance(fingerprint, str) and fingerprint else []
 
 
 async def _step_write_plans(ctx: FlowContext) -> None:
@@ -1555,18 +1543,14 @@ async def _step_write_plans(ctx: FlowContext) -> None:
     session = PlanWriteSession(
         plans_dir,
         planned_at=planned_at,
-        non_interactive_default=(
-            ctx.data["selection_mode"] == "non-interactive-default"
-        ),
+        non_interactive_default=(ctx.data["selection_mode"] in {"non-interactive-default", "automatic-publishing"}),
         run_session_id=_run_session_id(),
     )
     # Numbers are claimed here, in selection order, before any writer runs, so
     # a plan's number never depends on which writer finishes first.
     reservations = session.reserve(selected)
     pending = {reservation.index for reservation in reservations}
-    total = sum(
-        1 for reservation in reservations if reservation.number is not None
-    )
+    total = sum(1 for reservation in reservations if reservation.number is not None)
     landed = 0
     announced: set[int] = set()
 
@@ -1721,9 +1705,8 @@ async def _step_write_plans(ctx: FlowContext) -> None:
                             assembled, issues = assemble_plan(
                                 output,
                                 repo=ctx.work.repo,
-                                recon_commands=_verification_commands(
-                                    ctx.data["recon"]
-                                ),
+                                recon_commands=_verification_commands(ctx.data["recon"]),
+                                expected_fingerprints=(_expected_plan_fingerprints(current)),
                             )
                         else:
                             assembled = None
@@ -1761,12 +1744,10 @@ async def _step_write_plans(ctx: FlowContext) -> None:
                                     ),
                                 )
                             )
-                            current_prompt = (
-                                build_plan_writer_repair_prompt(
+                            current_prompt = build_plan_writer_repair_prompt(
                                     task_prompt,
                                     issues,
                                 )
-                            )
                             continue
                         if not isinstance(output, dict):
                             return {
@@ -1882,38 +1863,280 @@ async def _step_write_plans(ctx: FlowContext) -> None:
         )
 
 
-def _render_report(
-    services: list[Service],
-    all_services: list[Service],
-    stacks: list[StackAssignment],
-    audit: dict[str, Any],
-    findings: list[dict[str, Any]],
-    discarded_no_evidence: int,
-    dropped_low_confidence: int,
-    dropped_by_cap: int,
-    previously_rejected: int,
-    vet_rejected: int,
-    findings_table: str,
-    direction_section: str,
-    effort: str,
-    scope: str | None,
-    plan_write: dict[str, list[dict[str, Any]]],
-    partitions: list[Partition],
-    partitions_not_audited: list[Partition],
-    groups: list[PartitionGroup],
+def _local_plan_path(repo: Path, entry: dict[str, Any]) -> Path | None:
+    raw_path = entry.get("path")
+    if not isinstance(raw_path, str) or not raw_path:
+        return None
+    path = Path(raw_path)
+    return path if path.is_absolute() else repo / "daydream_plans" / path
+
+
+def _publication_package_id(
+    finding: dict[str, Any],
+    entry: dict[str, Any] | None = None,
 ) -> str:
-    service_lines = (
-        "\n".join(
-            f"- **{service.name}** — `{service.root.as_posix()}`"
-            for service in services
+    """Return the plan's stored package identity before the current finding's."""
+    return str(
+        (entry or {}).get("package_fingerprint")
+        or finding.get("package_fingerprint")
+        or finding.get("fingerprint")
+        or ""
+    )
+
+
+def _publication_members(
+    entry: dict[str, Any],
+    finding: dict[str, Any],
+    field: str,
+) -> tuple[str, ...]:
+    """Read stored plan membership first, with current-finding compatibility."""
+    raw = entry[field] if field in entry else finding.get(field)
+    if not isinstance(raw, (list, tuple)):
+        return ()
+    return tuple(value for value in raw if isinstance(value, str) and value)
+
+
+def _publication_identity(
+    entry: dict[str, Any],
+    finding: dict[str, Any],
+    plan_path: Path | None,
+) -> dict[str, Any]:
+    """Extract the per-package identity shared by every publication record."""
+    return {
+        "package_id": _publication_package_id(finding, entry),
+        "title": str(entry.get("title") or finding.get("title") or "Improve repository"),
+        "plan_path": plan_path.name if plan_path is not None else None,
+        "member_fingerprints": list(_publication_members(entry, finding, "member_fingerprints")),
+        "member_aliases": list(_publication_members(entry, finding, "member_aliases")),
+    }
+
+
+def _publication_failure(
+    identity: dict[str, Any],
+    *,
+    stage: str,
+    error: str,
+) -> dict[str, Any]:
+    """Build a publication failure record from a shared package identity."""
+    return {**identity, "stage": stage, "error": error}
+
+
+def _write_publication_artifact(
+    ctx: FlowContext,
+    publication: dict[str, Any],
+) -> None:
+    published_issues_path(ctx.data["improve_dir"]).write_text(
+        json.dumps(
+            _with_artifact_provenance(
+                publication,
+                phase=DaydreamPhase.PLAN_WRITE,
+            ),
+            indent=2,
         )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+async def _step_publish_issues(ctx: FlowContext) -> None:
+    """Copy each validated local plan into one idempotent GitHub issue."""
+    enabled = _automatic_issue_publishing(ctx)
+    publication: dict[str, Any] = {
+        "enabled": enabled,
+        "status": "running" if enabled else "disabled",
+        "repository": ctx.config.pr_repo,
+        "published": [],
+        "failed": [],
+    }
+    ctx.data["issue_publication"] = publication
+    if not enabled:
+        _write_publication_artifact(ctx, publication)
+        return
+
+    candidates: list[tuple[dict[str, Any], dict[str, Any], Path]] = []
+    represented: set[str] = set()
+    plan_write = ctx.data["plan_write"]
+    for disposition in ("written", "skipped", "failed"):
+        for entry in plan_write.get(disposition, []):
+            if not isinstance(entry, dict):
+                continue
+            nested_finding = entry.get("finding")
+            finding = nested_finding if isinstance(nested_finding, dict) else entry
+            package_id = _publication_package_id(finding, entry)
+            if package_id:
+                represented.add(package_id)
+            current_package_id = _publication_package_id(finding)
+            if current_package_id:
+                represented.add(current_package_id)
+            plan_path = _local_plan_path(ctx.work.repo, entry)
+            identity = _publication_identity(entry, finding, plan_path)
+            if disposition == "failed":
+                identity["plan_path"] = None
+                publication["failed"].append(
+                    _publication_failure(
+                        identity,
+                        stage="plan-write",
+                        error="Plan writing did not produce a validated local plan.",
+                    )
+                )
+            elif plan_path is None:
+                publication["failed"].append(
+                    _publication_failure(
+                        identity,
+                        stage="plan-reconciliation",
+                        error="The selected package was skipped without an unambiguous validated local plan.",
+                    )
+                )
+            elif not plan_path.is_file():
+                publication["failed"].append(
+                    _publication_failure(
+                        identity,
+                        stage="local-plan",
+                        error="The validated local plan file is unavailable.",
+                    )
+                )
+            else:
+                candidates.append((entry, finding, plan_path))
+
+    for finding in ctx.data.get("selected_findings", []):
+        if not isinstance(finding, dict):
+            continue
+        package_id = _publication_package_id(finding)
+        if package_id in represented:
+            continue
+        publication["failed"].append(
+            {
+                "package_id": package_id,
+                "title": str(finding.get("title") or "Improve repository"),
+                "plan_path": None,
+                "stage": "plan-accounting",
+                "error": ("Plan writing produced no outcome for the selected package."),
+            }
+        )
+
+    _write_publication_artifact(ctx, publication)
+    if not candidates:
+        _finish_publication(ctx, publication)
+        _write_publication_artifact(ctx, publication)
+        return
+
+    try:
+        publisher = IssuePublisher.connect(
+            ctx.work.repo,
+            repo_slug=ctx.config.pr_repo,
+        )
+    except ImprovePublishError as exc:
+        safe_error = redact_text(str(exc))
+        for entry, finding, plan_path in candidates:
+            publication["failed"].append(
+                _publication_failure(
+                    _publication_identity(entry, finding, plan_path),
+                    stage="preflight",
+                    error=safe_error,
+                )
+            )
+        _finish_publication(ctx, publication)
+        _write_publication_artifact(ctx, publication)
+        print_error(console, "Improve issue publishing failed", safe_error)
+        return
+
+    publication["repository"] = publisher.repo_slug
+    for entry, finding, plan_path in sorted(
+        candidates,
+        key=lambda item: int(item[0].get("number") or 0),
+    ):
+        identity = _publication_identity(entry, finding, plan_path)
+        try:
+            result = publisher.publish(
+                package_id=identity["package_id"],
+                title=identity["title"],
+                plan_path=plan_path,
+                member_fingerprints=identity["member_fingerprints"],
+                member_aliases=identity["member_aliases"],
+            )
+        except (ImprovePublishError, ValueError) as exc:
+            publication["failed"].append(
+                _publication_failure(
+                    identity,
+                    stage="issue-create",
+                    error=redact_text(str(exc)),
+                )
+            )
+            print_warning(
+                console,
+                f"Issue publishing failed for {identity['title']}: {redact_text(str(exc))}",
+            )
+        else:
+            publication["published"].append(
+                {
+                    **identity,
+                    "disposition": result.disposition,
+                    "issue_url": result.issue_url,
+                }
+            )
+            print_success(
+                console,
+                f"Issue {result.disposition} for {identity['title']}: {result.issue_url}",
+            )
+        _set_publication_status(publication)
+        _write_publication_artifact(ctx, publication)
+
+    _finish_publication(ctx, publication)
+    _write_publication_artifact(ctx, publication)
+
+
+def _set_publication_status(publication: dict[str, Any]) -> None:
+    """Reflect the current run's issue-publication outcome in its artifact."""
+    if not publication.get("enabled"):
+        publication["status"] = "disabled"
+    elif publication.get("failed") and publication.get("published"):
+        publication["status"] = "partial"
+    elif publication.get("failed"):
+        publication["status"] = "failed"
+    else:
+        publication["status"] = "complete"
+
+
+def _finish_publication(
+    ctx: FlowContext,
+    publication: dict[str, Any],
+) -> None:
+    """Finalize publication status and preserve complete-vs-partial exits."""
+    _set_publication_status(publication)
+    if publication.get("failed"):
+        publication_exit = 2 if publication.get("published") else 1
+        ctx.data["plan_exit_code"] = max(
+            ctx.data["plan_exit_code"],
+            publication_exit,
+        )
+
+
+def _render_report(ctx: FlowContext) -> str:
+    services = ctx.data["services"]
+    all_services = ctx.data["all_services"]
+    stacks = ctx.data["stacks"]
+    audit = ctx.data["audit"]
+    findings = ctx.data["vetted"]["findings"]
+    discarded_no_evidence = ctx.data["audit_discarded_no_evidence"]
+    dropped_low_confidence = ctx.data["audit_dropped_low_confidence"]
+    dropped_by_cap = ctx.data["audit_dropped_by_cap"]
+    previously_rejected = ctx.data["previously_rejected"]
+    vet_rejected = ctx.data["vet_rejected"]
+    findings_table = ctx.data["findings_table"]
+    effort = ctx.config.improve_effort
+    scope = ctx.config.improve_scope
+    plan_write = ctx.data["plan_write"]
+    issue_publication = ctx.data.get("issue_publication")
+    partitions = ctx.data["partitions"]
+    partitions_not_audited = ctx.data["partitions_not_audited"]
+    groups = ctx.data["partition_groups"]
+    service_lines = (
+        "\n".join(f"- **{service.name}** — `{service.root.as_posix()}`" for service in services)
         or "- No service roots detected."
     )
     top_offender_lines = _top_offender_lines(findings)
-    stack_lines = (
-        "\n".join(f"- **{stack.stack_name}**" for stack in stacks)
-        or "- No stacks detected."
-    )
+    cleanup_pressure_lines = _cleanup_pressure_lines(findings)
+    stack_lines = "\n".join(f"- **{stack.stack_name}**" for stack in stacks) or "- No stacks detected."
     roots_by_group = {group.name: _group_roots_cell(group) for group in groups}
     failures = audit.get("failed", {})
     failed_assignment_lines = (
@@ -1940,8 +2163,7 @@ def _render_report(
     )
     tier_bound = {
         "quick": (
-            "Recon hotspots only; categories outside correctness, security, "
-            "and tests were not audited."
+            "Recon hotspots only; categories outside correctness, security, tests, and tech debt were not audited."
         ),
         "standard": (
             "Coverage was hotspot-weighted across key packages; the partition "
@@ -1979,11 +2201,13 @@ def _render_report(
         f"- Plans blocked by plan-writing failure: {len(plan_write['failed'])}\n"
         f"{_blocked_plan_attempt_lines(plan_write)}"
     )
+    publication_lines = _publication_report_lines(issue_publication)
     return (
         "# Improve Report\n\n"
         "## Findings\n\n"
         f"{findings_table}\n\n"
-        f"{direction_section}\n\n"
+        "## Cleanup pressure\n\n"
+        f"{cleanup_pressure_lines}\n\n"
         "## Services\n\n"
         f"{service_lines}\n\n"
         "## Top offenders\n\n"
@@ -2006,7 +2230,9 @@ def _render_report(
         f"- Lowest-leverage findings dropped by tier cap: {dropped_by_cap}\n"
         f"- Previously rejected findings suppressed: {previously_rejected}\n"
         "\n## Plan writing\n\n"
-        f"{plan_lines}"
+        f"{plan_lines}\n\n"
+        "## GitHub issues\n\n"
+        f"{publication_lines}"
     )
 
 
@@ -2065,6 +2291,78 @@ def _top_offender_lines(findings: list[dict[str, Any]]) -> str:
     )
 
 
+def _cleanup_pressure_lines(findings: list[dict[str, Any]]) -> str:
+    """Summarize expected portfolio direction without inventing LOC counts."""
+    counts = Counter(str(finding.get("change_shape", "unknown")) for finding in findings)
+    subtractive = sum(counts[shape] for shape in ("delete", "reuse", "consolidate"))
+    return (
+        f"- Subtractive packages (delete/reuse/consolidate): {subtractive}\n"
+        f"- Neutral or unknown packages: "
+        f"{counts['neutral'] + counts['unknown']}\n"
+        f"- Additive packages: {counts['additive']}\n"
+        "- This is a prioritization preference, not a gate; exact LOC changes "
+        "are measured only after implementation."
+    )
+
+
+def _publication_report_lines(publication: dict[str, Any] | None) -> str:
+    if publication is None or not publication.get("enabled"):
+        return "- Automatic issue publishing was disabled."
+    published = publication.get("published", [])
+    failed = publication.get("failed", [])
+    dispositions = Counter(str(entry.get("disposition")) for entry in published if isinstance(entry, dict))
+    unavailable = sum(
+        1
+        for entry in failed
+        if isinstance(entry, dict)
+        and entry.get("stage")
+        in {
+            "plan-write",
+            "plan-reconciliation",
+            "local-plan",
+            "plan-accounting",
+        }
+    )
+    github_failures = len(failed) - unavailable if isinstance(failed, list) else 0
+    return (
+        f"- Issues created: {dispositions['created']}\n"
+        f"- Existing issues reused: {dispositions['existing']}\n"
+        f"- Ambiguous creates reconciled: {dispositions['reconciled']}\n"
+        f"- Packages without a validated local plan: {unavailable}\n"
+        f"- GitHub publication failures: {github_failures}"
+    )
+
+
+def _improve_failure_message(ctx: FlowContext) -> tuple[str, str]:
+    """Describe planning and publication failures without conflating them."""
+    plan_failures = len(ctx.data["plan_write"]["failed"])
+    publication = ctx.data.get("issue_publication")
+    failed = publication.get("failed", []) if isinstance(publication, dict) and publication.get("enabled") else []
+    local_plan_failures = sum(
+        1
+        for entry in failed
+        if isinstance(entry, dict) and entry.get("stage") in {"plan-reconciliation", "local-plan", "plan-accounting"}
+    )
+    github_failures = sum(
+        1 for entry in failed if isinstance(entry, dict) and entry.get("stage") in {"preflight", "issue-create"}
+    )
+    issue_failures = local_plan_failures + github_failures
+    if plan_failures and issue_failures:
+        heading = "Improve planning and issue publishing failed"
+    elif issue_failures:
+        heading = "Improve issue publishing failed"
+    else:
+        heading = "Improve planning failed"
+    details = []
+    if plan_failures:
+        details.append(f"{plan_failures} selected plan(s) failed")
+    if local_plan_failures:
+        details.append(f"{local_plan_failures} selected package(s) lacked a local plan")
+    if github_failures:
+        details.append(f"{github_failures} GitHub operation(s) failed")
+    return heading, "; ".join(details) + "."
+
+
 async def _step_report(ctx: FlowContext) -> Stop | None:
     """Render the improve report for reconnaissance and audit coverage."""
     if ctx.config.improve_plan_description is not None:
@@ -2079,45 +2377,25 @@ async def _step_report(ctx: FlowContext) -> Stop | None:
                 f"- Plans written: {len(plan_write['written'])}\n"
                 f"- Requests skipped as already planned: {len(plan_write['skipped'])}\n"
                 f"- Plan-writing failures: {len(plan_write['failed'])}\n"
-                f"{_blocked_plan_attempt_lines(plan_write)}"
+                f"{_blocked_plan_attempt_lines(plan_write)}\n\n"
+                "## GitHub issues\n\n"
+                f"{_publication_report_lines(ctx.data.get('issue_publication'))}"
             ),
             encoding="utf-8",
         )
         if ctx.data["plan_exit_code"]:
+            heading, detail = _improve_failure_message(ctx)
+            print_error(console, heading, detail)
             return Stop(ctx.data["plan_exit_code"])
         print_success(console, "Description plan complete.")
         return None
 
     report_path(ctx.data["improve_dir"]).write_text(
-        _report_with_provenance(
-            _render_report(
-                ctx.data["services"],
-                ctx.data["all_services"],
-                ctx.data["stacks"],
-                ctx.data["audit"],
-                ctx.data["vetted"]["findings"],
-                ctx.data["audit_discarded_no_evidence"],
-                ctx.data["audit_dropped_low_confidence"],
-                ctx.data["audit_dropped_by_cap"],
-                ctx.data["previously_rejected"],
-                ctx.data["vet_rejected"],
-                ctx.data["findings_table"],
-                ctx.data["direction_section"],
-                ctx.config.improve_effort,
-                ctx.config.improve_scope,
-                ctx.data["plan_write"],
-                ctx.data["partitions"],
-                ctx.data["partitions_not_audited"],
-                ctx.data["partition_groups"],
-            )
-        )
+        _report_with_provenance(_render_report(ctx))
     )
     if ctx.data["plan_exit_code"]:
-        print_error(
-            console,
-            "Improve planning failed",
-            f"{len(ctx.data['plan_write']['failed'])} selected plan(s) failed.",
-        )
+        heading, detail = _improve_failure_message(ctx)
+        print_error(console, heading, detail)
         return Stop(ctx.data["plan_exit_code"])
     print_success(
         console,
@@ -2142,6 +2420,11 @@ STEPS: tuple[FlowStep, ...] = (
         name="write-plans",
         run=_step_write_plans,
         config_phase="plan_write",
+    ),
+    FlowStep(
+        name="publish-improve-issues",
+        run=_step_publish_issues,
+        config_phase="recon",
     ),
     FlowStep(
         name="improve-report",

--- a/daydream/improve/plans.py
+++ b/daydream/improve/plans.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import re
 import subprocess
+from collections import Counter
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, replace
 from datetime import UTC, date, datetime
@@ -13,7 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from daydream import git_ops
-from daydream.improve.prioritize import plan_priority
+from daydream.improve.prioritize import member_alias, plan_priority
 from daydream.improve.render import (
     _redact_model_value,
     markdown_cell,
@@ -323,6 +324,9 @@ class PlanIndexEntry:
     slug: str
     title: str
     fingerprint: str
+    package_fingerprint: str
+    member_fingerprints: tuple[str, ...]
+    member_aliases: tuple[str, ...]
     priority: str
     effort: str
     risk: str
@@ -330,6 +334,9 @@ class PlanIndexEntry:
     planned_at: str
     status: str
     host_blocked: bool
+    change_shape: str
+    maintenance_signals: tuple[str, ...]
+    reuse_target: str
 
     @property
     def path(self) -> str | None:
@@ -342,12 +349,125 @@ def _index_field(value: Any) -> str:
     return redact_text(str(value or "").strip())
 
 
+def _string_tuple(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple)):
+        return ()
+    return tuple(dict.fromkeys(item.strip() for item in value if isinstance(item, str) and item.strip()))
+
+
+def _string_sequence(value: Any) -> tuple[str, ...]:
+    """Normalize a string sequence while preserving meaningful multiplicity."""
+    if not isinstance(value, (list, tuple)):
+        return ()
+    return tuple(item.strip() for item in value if isinstance(item, str) and item.strip())
+
+
+def _finding_package_fingerprint(finding: dict[str, Any]) -> str:
+    package = finding.get("package_fingerprint")
+    if isinstance(package, str) and package:
+        return package
+    fingerprint = finding.get("fingerprint")
+    return fingerprint if isinstance(fingerprint, str) else ""
+
+
+def _entry_fingerprints(entry: PlanIndexEntry) -> frozenset[str]:
+    return frozenset(
+        value
+        for value in (
+            entry.package_fingerprint,
+            entry.fingerprint,
+            *entry.member_fingerprints,
+            *entry.member_aliases,
+        )
+        if value
+    )
+
+
+def _finding_member_fingerprints(finding: dict[str, Any], *, fallback: str) -> tuple[str, ...]:
+    members = _string_tuple(finding.get("member_fingerprints"))
+    return members or ((fallback,) if fallback else ())
+
+
+def _finding_member_aliases(finding: dict[str, Any]) -> tuple[str, ...]:
+    return _string_sequence(finding.get("member_aliases"))
+
+
+def _finding_member_identities(
+    finding: dict[str, Any],
+) -> tuple[frozenset[str], ...]:
+    """Return the alternative durable IDs for each current package member."""
+    nested = finding.get("members")
+    if isinstance(nested, list):
+        valid_members = [item for item in nested if isinstance(item, dict)]
+        semantic_aliases = [member_alias(item) for item in valid_members]
+        alias_counts = Counter(semantic_aliases)
+        groups: list[frozenset[str]] = []
+        for item, semantic_alias in zip(valid_members, semantic_aliases, strict=True):
+            identities = {
+                value
+                for value in (
+                    item.get("fingerprint"),
+                    (semantic_alias if alias_counts[semantic_alias] == 1 else None),
+                )
+                if isinstance(value, str) and value
+            }
+            if identities:
+                groups.append(frozenset(identities))
+        if groups:
+            return tuple(groups)
+
+    fingerprints = _finding_member_fingerprints(
+        finding,
+        fallback=_finding_package_fingerprint(finding),
+    )
+    aliases = _finding_member_aliases(finding)
+    if aliases and len(aliases) == len(fingerprints):
+        alias_counts = Counter(aliases)
+        groups = [
+            frozenset(
+                value
+                for value in (
+                    fingerprint,
+                    alias if alias_counts[alias] == 1 else None,
+                )
+                if value
+            )
+            for fingerprint, alias in zip(fingerprints, aliases, strict=True)
+        ]
+    else:
+        groups = [frozenset((fingerprint,)) for fingerprint in fingerprints]
+    # A singleton's semantic package ID is itself a valid cross-run alias.
+    # For multi-member packages it must not stand in for every member: doing so
+    # would silently suppress newly added work after a membership change.
+    if len(groups) == 1:
+        package = _finding_package_fingerprint(finding)
+        if package:
+            groups[0] = groups[0] | {package}
+        if aliases and len(aliases) != len(fingerprints):
+            groups[0] = groups[0] | set(aliases)
+    return tuple(groups)
+
+
+def _entry_member_coverage(entry: PlanIndexEntry) -> frozenset[str]:
+    values = {*entry.member_fingerprints, *entry.member_aliases}
+    if len(entry.member_fingerprints) <= 1:
+        values.update((entry.package_fingerprint, entry.fingerprint))
+    return frozenset(value for value in values if value)
+
+
+def _fully_covered(identities: tuple[frozenset[str], ...], coverage: set[str] | frozenset[str]) -> bool:
+    return bool(identities) and all(group & coverage for group in identities)
+
+
 def _entry_payload(entry: PlanIndexEntry) -> dict[str, Any]:
     return {
         "number": entry.number,
         "slug": entry.slug,
         "title": entry.title,
         "fingerprint": entry.fingerprint,
+        "package_fingerprint": entry.package_fingerprint,
+        "member_fingerprints": list(entry.member_fingerprints),
+        "member_aliases": list(entry.member_aliases),
         "priority": entry.priority,
         "effort": entry.effort,
         "risk": entry.risk,
@@ -355,6 +475,9 @@ def _entry_payload(entry: PlanIndexEntry) -> dict[str, Any]:
         "planned_at": entry.planned_at,
         "status": entry.status,
         "host_blocked": entry.host_blocked,
+        "change_shape": entry.change_shape,
+        "maintenance_signals": list(entry.maintenance_signals),
+        "reuse_target": entry.reuse_target,
     }
 
 
@@ -363,6 +486,7 @@ def _entry_from_payload(payload: Any) -> PlanIndexEntry | None:
         return None
     number = payload.get("number")
     fingerprint = payload.get("fingerprint")
+    package_fingerprint = payload.get("package_fingerprint")
     slug = _index_field(payload.get("slug"))
     status = _index_field(payload.get("status"))
     if (
@@ -375,11 +499,20 @@ def _entry_from_payload(payload: Any) -> PlanIndexEntry | None:
         or (slug and _NUMBERED_PLAN.fullmatch(f"{number:03d}-{slug}.md") is None)
     ):
         return None
+    if not isinstance(package_fingerprint, str) or not package_fingerprint:
+        package_fingerprint = fingerprint
+    member_fingerprints = _string_tuple(payload.get("member_fingerprints"))
+    if not member_fingerprints:
+        member_fingerprints = (fingerprint,)
+    member_aliases = _string_sequence(payload.get("member_aliases"))
     return PlanIndexEntry(
         number=number,
         slug=slug,
         title=_index_field(payload.get("title")),
         fingerprint=fingerprint,
+        package_fingerprint=package_fingerprint,
+        member_fingerprints=member_fingerprints,
+        member_aliases=member_aliases,
         priority=_index_field(payload.get("priority")),
         effort=_index_field(payload.get("effort")),
         risk=_index_field(payload.get("risk")),
@@ -387,6 +520,9 @@ def _entry_from_payload(payload: Any) -> PlanIndexEntry | None:
         planned_at=_index_field(payload.get("planned_at")),
         status=status,
         host_blocked=bool(payload.get("host_blocked")),
+        change_shape=_index_field(payload.get("change_shape") or "unknown"),
+        maintenance_signals=_string_tuple(payload.get("maintenance_signals")),
+        reuse_target=_index_field(payload.get("reuse_target")),
     )
 
 
@@ -453,6 +589,9 @@ def _rendered_index_entries(plans_dir: Path) -> dict[str, PlanIndexEntry]:
             slug=link.group(1) if link is not None else "",
             title=_index_field(cells[1]),
             fingerprint=marker.group(1),
+            package_fingerprint=marker.group(1),
+            member_fingerprints=(marker.group(1),),
+            member_aliases=(),
             priority=_index_field(cells[2]),
             effort=_index_field(cells[3]),
             risk="",
@@ -460,6 +599,9 @@ def _rendered_index_entries(plans_dir: Path) -> dict[str, PlanIndexEntry]:
             planned_at="",
             status=status,
             host_blocked=_HOST_BLOCKED_STATUS.fullmatch(status) is not None,
+            change_shape="unknown",
+            maintenance_signals=(),
+            reuse_target="",
         )
     return entries
 
@@ -495,11 +637,12 @@ def _is_retryable(plans_dir: Path, entry: PlanIndexEntry) -> bool:
 
 
 def planned_fingerprints(plans_dir: Path) -> set[str]:
-    """Return fingerprints with durable executable/non-transient status."""
+    """Return package identities and aliases with durable plan status."""
     return {
-        entry.fingerprint
+        fingerprint
         for entry in _merged_index(plans_dir).values()
         if not _is_retryable(plans_dir, entry)
+        for fingerprint in _entry_fingerprints(entry)
     }
 
 
@@ -631,6 +774,9 @@ def _blocked_entry(
         slug="",
         title=_index_field(finding.get("title") or "Selected finding"),
         fingerprint=fingerprint,
+        package_fingerprint=_finding_package_fingerprint(finding) or fingerprint,
+        member_fingerprints=_finding_member_fingerprints(finding, fallback=fingerprint),
+        member_aliases=_finding_member_aliases(finding),
         priority=plan_priority(finding),
         effort=_index_field(finding.get("effort")),
         risk=_index_field(finding.get("risk")),
@@ -638,6 +784,9 @@ def _blocked_entry(
         planned_at=planned_at,
         status=status,
         host_blocked=_HOST_BLOCKED_STATUS.fullmatch(status) is not None,
+        change_shape=_index_field(finding.get("change_shape") or "unknown"),
+        maintenance_signals=_string_tuple(finding.get("maintenance_signals")),
+        reuse_target=_index_field(finding.get("reuse_target")),
     )
 
 
@@ -658,6 +807,9 @@ def _index_entry(
         slug=slug,
         title=_index_field(title),
         fingerprint=fingerprint,
+        package_fingerprint=_finding_package_fingerprint(finding) or fingerprint,
+        member_fingerprints=_finding_member_fingerprints(finding, fallback=fingerprint),
+        member_aliases=_finding_member_aliases(finding),
         priority=plan_priority(finding),
         effort=_index_field(finding.get("effort")),
         risk=_index_field(finding.get("risk")),
@@ -665,6 +817,9 @@ def _index_entry(
         planned_at=planned_at,
         status=status,
         host_blocked=host_blocked,
+        change_shape=_index_field(finding.get("change_shape") or "unknown"),
+        maintenance_signals=_string_tuple(finding.get("maintenance_signals")),
+        reuse_target=_index_field(finding.get("reuse_target")),
     )
 
 
@@ -681,6 +836,11 @@ class PlanReservation:
     index: int
     fingerprint: str
     number: int | None
+    existing_number: int | None = None
+    existing_path: str | None = None
+    existing_package_fingerprint: str | None = None
+    existing_member_fingerprints: tuple[str, ...] = ()
+    existing_member_aliases: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -729,19 +889,11 @@ class PlanWriteSession:
         self._index_path = plans_dir / "README.md"
         self._sidecar_path = plans_dir / PLAN_INDEX_FILENAME
         self._non_interactive_default = (
-            non_interactive_default
-            or "non-interactive default" in _index_text(plans_dir).lower()
+            non_interactive_default or "non-interactive default" in _index_text(plans_dir).lower()
         )
         self._entries = _merged_index(plans_dir)
-        self._fingerprints = {
-            entry.fingerprint
-            for entry in self._entries.values()
-            if not _is_retryable(plans_dir, entry)
-        }
         self._rejected = load_rejections(plans_dir)
-        self._next_number = (
-            _highest_plan_number(plans_dir, self._entries.values()) + 1
-        )
+        self._next_number = _highest_plan_number(plans_dir, self._entries.values()) + 1
         self._reserved_count = 0
         self._written: list[tuple[int, dict[str, Any]]] = []
         self._skipped: list[tuple[int, dict[str, Any]]] = []
@@ -769,19 +921,40 @@ class PlanWriteSession:
             index = self._reserved_count
             self._reserved_count += 1
             if not isinstance(finding, dict):
-                reservations.append(PlanReservation(index, "", None))
+                reservations.append(PlanReservation(index=index, fingerprint="", number=None))
                 continue
-            fingerprint = str(finding.get("fingerprint") or "")
-            if fingerprint in self._fingerprints or fingerprint in self._rejected:
+            fingerprint = _finding_package_fingerprint(finding)
+            identities = _finding_member_identities(finding)
+            existing = self._existing_plan(identities)
+            if existing is not None:
                 reservations.append(
-                    PlanReservation(index, fingerprint, None)
+                    PlanReservation(
+                        index=index,
+                        fingerprint=fingerprint,
+                        number=None,
+                        existing_number=existing.number,
+                        existing_path=(
+                            existing.path
+                            if existing.path is not None and _has_plan_file(self._plans_dir, existing)
+                            else None
+                        ),
+                        existing_package_fingerprint=existing.package_fingerprint,
+                        existing_member_fingerprints=existing.member_fingerprints,
+                        existing_member_aliases=existing.member_aliases,
+                    )
                 )
+                continue
+            durable_coverage = set(self._rejected)
+            for entry in self._entries.values():
+                if not _is_retryable(self._plans_dir, entry):
+                    durable_coverage.update(_entry_member_coverage(entry))
+            if _fully_covered(identities, durable_coverage):
+                reservations.append(PlanReservation(index=index, fingerprint=fingerprint, number=None))
                 continue
             reserved_numbers = [
                 entry.number
                 for entry in self._entries.values()
-                if entry.fingerprint == fingerprint
-                and _is_retryable(self._plans_dir, entry)
+                if _is_retryable(self._plans_dir, entry) and _fully_covered(identities, _entry_member_coverage(entry))
             ]
             for reserved in reserved_numbers:
                 del self._entries[reserved]
@@ -790,8 +963,17 @@ class PlanWriteSession:
             else:
                 number = self._next_number
                 self._next_number += 1
-            reservations.append(PlanReservation(index, fingerprint, number))
+            reservations.append(PlanReservation(index=index, fingerprint=fingerprint, number=number))
         return reservations
+
+    def _existing_plan(self, identities: tuple[frozenset[str], ...]) -> PlanIndexEntry | None:
+        """Resolve one durable plan only when it covers every current member."""
+        candidates = [
+            entry
+            for entry in self._entries.values()
+            if not _is_retryable(self._plans_dir, entry) and _fully_covered(identities, _entry_member_coverage(entry))
+        ]
+        return candidates[0] if len(candidates) == 1 else None
 
     def commit(
         self,
@@ -807,7 +989,16 @@ class PlanWriteSession:
             return PlanOutcome("ignored", None, None, "")
         title = str(finding.get("title") or "Selected finding")
         if reservation.number is None:
-            self._skipped.append((reservation.index, finding))
+            skipped: dict[str, Any] = {"finding": finding}
+            if reservation.existing_number is not None:
+                skipped["number"] = reservation.existing_number
+                if reservation.existing_path is not None:
+                    skipped["path"] = reservation.existing_path
+                if reservation.existing_package_fingerprint is not None:
+                    skipped["package_fingerprint"] = reservation.existing_package_fingerprint
+                    skipped["member_fingerprints"] = list(reservation.existing_member_fingerprints)
+                    skipped["member_aliases"] = list(reservation.existing_member_aliases)
+            self._skipped.append((reservation.index, skipped))
             attempt = self._attempt_of(safe)
             if attempt is not None:
                 self._diagnostics.append(
@@ -823,7 +1014,12 @@ class PlanWriteSession:
                         ),
                     )
                 )
-            return PlanOutcome("skipped", None, None, title)
+            return PlanOutcome(
+                "skipped",
+                reservation.existing_number,
+                reservation.existing_path,
+                title,
+            )
         return self._land(reservation, safe)
 
     def finish(self) -> dict[str, list[dict[str, Any]]]:
@@ -915,7 +1111,6 @@ class PlanWriteSession:
                 ),
             )
         )
-        self._fingerprints.add(reservation.fingerprint)
         return PlanOutcome("written", number, path, title)
 
     def _land(

--- a/daydream/improve/prioritize.py
+++ b/daydream/improve/prioritize.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
+from collections import Counter
 from typing import Any
 
 from daydream.deep.dedup import bigrams, jaccard, normalize_title
@@ -10,7 +13,31 @@ _IMPACT = {"HIGH": 3.0, "MED": 2.0, "LOW": 1.0}
 _EFFORT = {"S": 1.0, "M": 2.0, "L": 3.0}
 _CONFIDENCE = {"HIGH": 1.0, "MED": 0.7, "LOW": 0.4}
 _RISK = {"LOW": 1.0, "MED": 0.8, "HIGH": 0.6}
-_CROSS_SERVICE_SIMILARITY = 0.5
+_SAME_LOCATION_SIMILARITY = 0.5
+_CROSS_CATEGORY_SIMILARITY = 0.7
+_WORK_PACKAGE_MAX_FINDINGS = 5
+_WORK_PACKAGE_MAX_PATHS = 8
+_IMPACT_ORDER = {"LOW": 0, "MED": 1, "HIGH": 2}
+_EFFORT_UNITS = {"S": 1, "M": 2, "L": 3}
+_RISK_ORDER = {"LOW": 0, "MED": 1, "HIGH": 2}
+_CONFIDENCE_ORDER = {"LOW": 0, "MED": 1, "HIGH": 2}
+_SEVERITY_ORDER = {"LOW": 0, "MED": 1, "HIGH": 2, "CRITICAL": 3}
+_CHANGE_SHAPES = {
+    "delete",
+    "reuse",
+    "consolidate",
+    "neutral",
+    "additive",
+    "unknown",
+}
+_CHANGE_SHAPE_PREFERENCE = {
+    "delete": 0,
+    "reuse": 1,
+    "consolidate": 2,
+    "neutral": 3,
+    "unknown": 3,
+    "additive": 4,
+}
 # HIGH impact still clears P1 at medium effort; the P2 floor is a MED/MED/MED
 # finding, so only the low-impact or high-risk tail lands in P3.
 _P1_LEVERAGE = 1.2
@@ -49,69 +76,388 @@ def order_by_leverage(findings: list[dict[str, Any]]) -> list[dict[str, Any]]:
         findings,
         key=lambda finding: (
             -leverage_score(finding),
-            -int(
-                finding.get("category") == "security"
-                and finding.get("confidence") == "HIGH"
+            -int(finding.get("category") == "security" and finding.get("confidence") == "HIGH"),
+            _CHANGE_SHAPE_PREFERENCE.get(
+                str(finding.get("change_shape") or "unknown"),
+                _CHANGE_SHAPE_PREFERENCE["unknown"],
             ),
         ),
     )
 
 
-def partition_direction(
-    findings: list[dict[str, Any]],
-) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-    """Split defect findings from separately presented direction findings."""
-    defects: list[dict[str, Any]] = []
-    direction: list[dict[str, Any]] = []
-    for finding in findings:
-        (direction if finding.get("category") == "direction" else defects).append(finding)
-    return defects, direction
-
-
 def aggregate_cross_service(
     findings: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    """Merge the same finding pattern when it occurs in distinct services."""
-    aggregated: list[dict[str, Any]] = []
-    consumed: set[int] = set()
+    """Build conservative, issue-sized work packages before user selection.
 
-    for index, finding in enumerate(findings):
-        if index in consumed:
+    The historical name remains as a compatibility surface, but aggregation is
+    no longer limited to identical findings in distinct services. Exact aliases,
+    a shared canonical reuse target, and corroborated title similarity can form
+    a package. Every new member must be compatible with *every* existing member;
+    this deliberately avoids transitive ``A ~ B ~ C`` bridge merges.
+    """
+    # Aggregates can be fed back through this function by callers composing
+    # audit partitions. Flatten them first and collapse exact member aliases so
+    # an identical finding cannot consume a package cap more than once.
+    ordered = sorted(
+        (member for finding in findings for member in _package_members(finding)),
+        key=_finding_sort_key,
+    )
+    unique: list[dict[str, Any]] = []
+    seen_fingerprints: set[str] = set()
+    for finding in ordered:
+        fingerprint = _primary_fingerprint(finding)
+        if fingerprint and fingerprint in seen_fingerprints:
             continue
-        services = _finding_services(finding)
-        title_bigrams = bigrams(normalize_title(str(finding.get("title", ""))))
-        group = [finding]
+        if fingerprint:
+            seen_fingerprints.add(fingerprint)
+        unique.append(finding)
+    groups: list[list[dict[str, Any]]] = []
 
-        if services and title_bigrams:
-            for candidate_index in range(index + 1, len(findings)):
-                if candidate_index in consumed:
-                    continue
-                candidate = findings[candidate_index]
-                candidate_services = _finding_services(candidate)
-                if (
-                    candidate.get("category") != finding.get("category")
-                    or not candidate_services
-                    or services & candidate_services
-                ):
-                    continue
-                candidate_bigrams = bigrams(
-                    normalize_title(str(candidate.get("title", "")))
-                )
-                if (
-                    jaccard(title_bigrams, candidate_bigrams)
-                    < _CROSS_SERVICE_SIMILARITY
-                ):
-                    continue
-                group.append(candidate)
-                services.update(candidate_services)
-                consumed.add(candidate_index)
+    for finding in unique:
+        for group in groups:
+            if _can_join_work_package(finding, group):
+                group.append(finding)
+                break
+        else:
+            groups.append([finding])
 
-        if len(group) == 1:
-            aggregated.append(finding)
+    return _with_unique_package_fingerprints([_merge_work_package(group) for group in groups])
+
+
+def _finding_sort_key(finding: dict[str, Any]) -> tuple[Any, ...]:
+    """Return an input-order-independent package construction key."""
+    return (
+        -leverage_score(finding),
+        normalize_title(str(finding.get("title") or "")),
+        str(finding.get("path") or ""),
+        int(finding.get("line") or 0),
+        str(finding.get("fingerprint") or ""),
+    )
+
+
+def _can_join_work_package(finding: dict[str, Any], group: list[dict[str, Any]]) -> bool:
+    members = [member for item in group for member in _package_members(item)]
+    candidate_members = _package_members(finding)
+    if len(members) + len(candidate_members) > _WORK_PACKAGE_MAX_FINDINGS:
+        return False
+    paths = {path for member in [*members, *candidate_members] if (path := _finding_path(member))}
+    if len(paths) > _WORK_PACKAGE_MAX_PATHS:
+        return False
+    return all(_findings_are_compatible(candidate, existing) for candidate in candidate_members for existing in members)
+
+
+def _findings_are_compatible(left: dict[str, Any], right: dict[str, Any]) -> bool:
+    """Return whether two findings describe one coherent implementation unit."""
+    left_target = _reuse_target_key(left)
+    right_target = _reuse_target_key(right)
+    # A finding cannot coherently belong to two different reuse migrations,
+    # even if an upstream model accidentally stamped the same volatile ID.
+    if left_target and right_target and left_target != right_target:
+        return False
+
+    if _finding_aliases(left) & _finding_aliases(right):
+        return True
+
+    if left_target and left_target == right_target:
+        return True
+
+    left_title = bigrams(normalize_title(str(left.get("title") or "")))
+    right_title = bigrams(normalize_title(str(right.get("title") or "")))
+    if not left_title or not right_title:
+        return False
+    similarity = jaccard(left_title, right_title)
+    same_category = left.get("category") == right.get("category")
+    signal_overlap = bool(_maintenance_signals(left) & _maintenance_signals(right))
+    same_path = bool(_finding_path(left) and _finding_path(left) == _finding_path(right))
+    localities = _finding_services(left), _finding_services(right)
+    distinct_localities = bool(localities[0] and localities[1] and not localities[0] & localities[1])
+
+    if same_category and similarity >= _SAME_LOCATION_SIMILARITY:
+        return same_path or signal_overlap or distinct_localities
+    return similarity >= _CROSS_CATEGORY_SIMILARITY and (same_path or signal_overlap)
+
+
+def _package_members(finding: dict[str, Any]) -> list[dict[str, Any]]:
+    members = finding.get("members")
+    if isinstance(members, list):
+        valid = [member for member in members if isinstance(member, dict)]
+        if valid:
+            return [_without_package_fields(member) for member in valid]
+    return [_without_package_fields(finding)]
+
+
+def _without_package_fields(finding: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: value
+        for key, value in finding.items()
+        if key
+        not in {
+            "members",
+            "member_fingerprints",
+            "member_aliases",
+            "package_fingerprint",
+            "categories",
+            "locations",
+            "partitions",
+        }
+    }
+
+
+def _finding_aliases(finding: dict[str, Any]) -> set[str]:
+    aliases = {
+        value
+        for value in (
+            finding.get("fingerprint"),
+            finding.get("package_fingerprint"),
+        )
+        if isinstance(value, str) and value
+    }
+    member_fingerprints = finding.get("member_fingerprints")
+    if isinstance(member_fingerprints, list):
+        aliases.update(value for value in member_fingerprints if isinstance(value, str) and value)
+    return aliases
+
+
+def _primary_fingerprint(finding: dict[str, Any]) -> str:
+    fingerprint = finding.get("fingerprint")
+    return fingerprint if isinstance(fingerprint, str) and fingerprint else ""
+
+
+def _concern_for(target: str, signals: list[str], title: str) -> dict[str, Any]:
+    """Select the shared three-way concern anchor for member and package IDs.
+
+    A canonical reuse target wins, then structured maintenance signals, then
+    the normalized title as the safe fallback. The same ladder backs both the
+    per-member alias and the package fingerprint, so a reworded finding keeps
+    one semantic anchor across both identities.
+    """
+    if target:
+        return {"kind": "reuse-target", "value": target}
+    if signals:
+        return {"kind": "maintenance-signals", "value": signals}
+    return {"kind": "title", "value": normalize_title(title)}
+
+
+def member_alias(finding: dict[str, Any]) -> str:
+    """Return a wording-resistant semantic alias for one finding.
+
+    Audit fingerprints deliberately include model prose. This alias instead
+    uses the repository location and the host-normalized maintenance concern,
+    allowing a later run to recognize a reworded member. The line keeps two
+    independent concerns in one large file from becoming the same alias; when
+    no structured concern exists, normalized title text is the safe fallback.
+    """
+    concern = _concern_for(
+        _reuse_target_key(finding),
+        sorted(_maintenance_signals(finding)),
+        str(finding.get("title") or ""),
+    )
+    line = finding.get("line")
+    canonical = json.dumps(
+        {
+            "kind": "daydream-improve-member-v1",
+            "path": _finding_path(finding),
+            "line": line if isinstance(line, int) and not isinstance(line, bool) else None,
+            "category": str(finding.get("category") or ""),
+            "concern": concern,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return f"member-v1:{hashlib.sha256(canonical.encode()).hexdigest()}"
+
+
+def _reuse_target_key(finding: dict[str, Any]) -> str:
+    target = finding.get("reuse_target")
+    if not isinstance(target, str):
+        return ""
+    normalized = " ".join(target.strip().split()).casefold()
+    return "" if normalized in {"", "none", "null", "n/a"} else normalized
+
+
+def _maintenance_signals(finding: dict[str, Any]) -> set[str]:
+    signals = finding.get("maintenance_signals")
+    if not isinstance(signals, list):
+        return set()
+    return {signal for signal in signals if isinstance(signal, str) and signal}
+
+
+def _finding_path(finding: dict[str, Any]) -> str:
+    path = finding.get("path")
+    return path if isinstance(path, str) else ""
+
+
+def _merge_work_package(findings: list[dict[str, Any]]) -> dict[str, Any]:
+    members = sorted(
+        (member for finding in findings for member in _package_members(finding)),
+        key=_finding_sort_key,
+    )
+    representative = members[0]
+    merged = dict(representative)
+    member_fingerprints = sorted({fingerprint for member in members if (fingerprint := _primary_fingerprint(member))})
+    # Preserve one alias per member. Repeated values are meaningful: they tell
+    # reconciliation that this semantic alias is ambiguous and cannot by
+    # itself prove coverage of multiple distinct members.
+    member_aliases = sorted(member_alias(member) for member in members)
+    package_fingerprint = _work_package_fingerprint(members)
+    merged["fingerprint"] = package_fingerprint
+    merged["package_fingerprint"] = package_fingerprint
+    merged["member_fingerprints"] = member_fingerprints
+    merged["member_aliases"] = member_aliases
+    merged["members"] = members
+    merged["categories"] = sorted(
+        {category for member in members if isinstance((category := member.get("category")), str) and category}
+    )
+    merged["services"] = sorted({service for member in members for service in _service_list(member)})
+    merged["partitions"] = sorted(
+        {partition for member in members if isinstance((partition := member.get("partition")), str) and partition}
+    )
+    merged["evidence"] = sorted({entry for member in members for entry in _evidence_list(member)})
+    merged["locations"] = sorted({_finding_location(member) for member in members if _finding_path(member)})
+    merged["maintenance_signals"] = sorted({signal for member in members for signal in _maintenance_signals(member)})
+    merged["reuse_target"] = _common_reuse_target(members)
+    merged["change_shape"] = _combined_change_shape(members)
+    merged["impact"] = _conservative_axis(members, "impact", _IMPACT_ORDER, "LOW")
+    merged["effort"] = _combined_effort(members)
+    merged["risk"] = _conservative_axis(members, "risk", _RISK_ORDER, "HIGH")
+    merged["confidence"] = _conservative_axis(
+        members,
+        "confidence",
+        _CONFIDENCE_ORDER,
+        "LOW",
+        highest=False,
+    )
+    if any("severity" in member for member in members):
+        merged["severity"] = _conservative_axis(members, "severity", _SEVERITY_ORDER, "HIGH")
+    merged["leverage"] = round(leverage_score(merged), 2)
+
+    if len(members) > 1:
+        body = str(representative.get("body") or "").rstrip()
+        locations = "\n".join(
+            f"- `{_finding_location(member)}` — {member.get('title', 'Finding')}" for member in members
+        )
+        merged["body"] = f"{body}\n\nCombined work-package locations:\n{locations}"
+    return merged
+
+
+def _work_package_fingerprint(members: list[dict[str, Any]]) -> str:
+    """Hash semantic member anchors, leaving volatile audit IDs as aliases."""
+    paths = sorted({_finding_path(member) for member in members if _finding_path(member)})
+    reuse_target = _common_reuse_target(members)
+    signals = sorted({signal for member in members for signal in _maintenance_signals(member)})
+    categories = sorted(
+        {category for member in members if isinstance((category := member.get("category")), str) and category}
+    )
+    semantic_members = sorted(member_alias(member) for member in members)
+    alias_counts = Counter(semantic_members)
+    # Two semantically distinct findings can share the same structured anchor
+    # (most often the same line and a generic maintenance signal). In that
+    # ambiguous case, volatile IDs are the only safe discriminator. Ordinary
+    # rewording remains stable because unique semantic anchors need no such
+    # fallback.
+    collision_members = (
+        sorted(_primary_fingerprint(member) or normalize_title(str(member.get("title") or "")) for member in members)
+        if any(count > 1 for count in alias_counts.values())
+        else []
+    )
+    concern = _concern_for(reuse_target or "", signals, str(members[0].get("title") or ""))
+    canonical = json.dumps(
+        {
+            "kind": "daydream-improve-work-package-v2",
+            "concern": concern,
+            "paths": paths,
+            "members": semantic_members,
+            **({"collision_members": collision_members} if collision_members else {}),
+            **({} if reuse_target else {"categories": categories}),
+            **(
+                {}
+                if paths
+                else {"fallback_members": sorted({alias for member in members for alias in _finding_aliases(member)})}
+            ),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def _with_unique_package_fingerprints(
+    packages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Disambiguate the rare case where capped packages share one base ID."""
+    by_fingerprint: dict[str, list[dict[str, Any]]] = {}
+    for package in packages:
+        by_fingerprint.setdefault(str(package["package_fingerprint"]), []).append(package)
+    for base, collisions in by_fingerprint.items():
+        if len(collisions) < 2:
             continue
-        aggregated.append(_merge_cross_service_group(group))
+        for package in collisions:
+            canonical = json.dumps(
+                {
+                    "kind": "daydream-improve-work-package-split-v1",
+                    "base": base,
+                    "members": sorted(str(value) for value in package.get("member_fingerprints", [])),
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            fingerprint = hashlib.sha256(canonical.encode()).hexdigest()
+            package["fingerprint"] = fingerprint
+            package["package_fingerprint"] = fingerprint
+    return packages
 
-    return aggregated
+
+def _finding_location(finding: dict[str, Any]) -> str:
+    path = _finding_path(finding)
+    line = finding.get("line")
+    return f"{path}:{line}" if line is not None else path
+
+
+def _common_reuse_target(findings: list[dict[str, Any]]) -> str | None:
+    targets = {target for finding in findings if (target := _reuse_target_key(finding))}
+    return next(iter(targets)) if len(targets) == 1 else None
+
+
+def _combined_change_shape(findings: list[dict[str, Any]]) -> str:
+    shapes = {
+        shape
+        for finding in findings
+        if isinstance((shape := finding.get("change_shape")), str) and shape in _CHANGE_SHAPES
+    }
+    if not shapes:
+        return "unknown"
+    if len(shapes) == 1:
+        return next(iter(shapes))
+    if "additive" in shapes:
+        return "additive"
+    if "unknown" in shapes:
+        return "unknown"
+    if "neutral" in shapes:
+        return "neutral"
+    return "consolidate"
+
+
+def _conservative_axis(
+    findings: list[dict[str, Any]],
+    field: str,
+    order: dict[str, int],
+    fallback: str,
+    *,
+    highest: bool = True,
+) -> str:
+    values = [value for finding in findings if isinstance((value := finding.get(field)), str) and value in order]
+    if not values:
+        return fallback
+    choose = max if highest else min
+    return choose(values, key=order.__getitem__)
+
+
+def _combined_effort(findings: list[dict[str, Any]]) -> str:
+    units = sum(_EFFORT_UNITS.get(str(finding.get("effort") or ""), 3) for finding in findings)
+    if units <= 1:
+        return "S"
+    return "M" if units <= 3 else "L"
 
 
 def _finding_services(finding: dict[str, Any]) -> set[str]:
@@ -132,30 +478,6 @@ def _finding_services(finding: dict[str, Any]) -> set[str]:
     return keys
 
 
-def _merge_cross_service_group(
-    findings: list[dict[str, Any]],
-) -> dict[str, Any]:
-    representative = max(findings, key=leverage_score)
-    merged = dict(representative)
-    merged["services"] = _ordered_unique(
-        service for finding in findings for service in _service_list(finding)
-    )
-    merged["partitions"] = _ordered_unique(
-        partition
-        for finding in findings
-        if isinstance((partition := finding.get("partition")), str) and partition
-    )
-    merged["evidence"] = _ordered_unique(
-        entry for finding in findings for entry in _evidence_list(finding)
-    )
-    locations = _cross_service_locations(findings)
-    body = str(representative.get("body", "")).rstrip()
-    merged["body"] = f"{body}\n\nCross-service locations:\n" + "\n".join(
-        f"- **{service}** — `{location}`" for service, location in locations
-    )
-    return merged
-
-
 def _service_list(finding: dict[str, Any]) -> list[str]:
     services = finding.get("services")
     if not isinstance(services, list):
@@ -168,27 +490,6 @@ def _evidence_list(finding: dict[str, Any]) -> list[str]:
     if not isinstance(evidence, list):
         return []
     return [entry for entry in evidence if isinstance(entry, str) and entry]
-
-
-def _ordered_unique(values: Any) -> list[str]:
-    return list(dict.fromkeys(values))
-
-
-def _cross_service_locations(
-    findings: list[dict[str, Any]],
-) -> list[tuple[str, str]]:
-    locations: list[tuple[str, str]] = []
-    for finding in findings:
-        path = str(finding.get("path", ""))
-        line = finding.get("line")
-        location = f"{path}:{line}" if line is not None else path
-        owners = _service_list(finding)
-        if not owners:
-            # An uncovered tree has no service; name the partition instead.
-            partition = finding.get("partition")
-            owners = [partition] if isinstance(partition, str) and partition else []
-        locations.extend((owner, location) for owner in owners)
-    return list(dict.fromkeys(locations))
 
 
 def _axis_value(weights: dict[str, float], value: Any, worst: float) -> float:

--- a/daydream/improve/prompts.py
+++ b/daydream/improve/prompts.py
@@ -45,6 +45,57 @@ RECON_COMMAND_CONTRACT_BULLET = """exact build, test, and lint commands supporte
   enumerates those itself. Never combine a label, arrow, annotation,
   or explanatory prose with the command;"""
 
+MAINTENANCE_SIGNALS: tuple[str, ...] = (
+    "overengineered_structure",
+    "reuse_existing",
+    "hand_rolled_substitute",
+    "duplicated_test_structure",
+    "parameterizable_test_matrix",
+    "excessive_comment",
+    "self_evident_comment",
+    "dead_code",
+)
+
+CHANGE_SHAPES: tuple[str, ...] = (
+    "delete",
+    "reuse",
+    "consolidate",
+    "neutral",
+    "additive",
+    "unknown",
+)
+
+_MAINTENANCE_FINDING_PROPERTIES: dict[str, Any] = {
+    "maintenance_signals": {
+        "type": "array",
+        "description": (
+            "Stable classifications for codebase-growth pressure. Return an "
+            "empty array when none apply; do not invent a signal merely to "
+            "prefer a smaller patch."
+        ),
+        "items": {"type": "string", "enum": list(MAINTENANCE_SIGNALS)},
+    },
+    "change_shape": {
+        "type": "string",
+        "enum": list(CHANGE_SHAPES),
+        "description": (
+            "The expected overall shape of the fix. This is a prioritization "
+            "hint, not a promise about exact line counts."
+        ),
+    },
+    "reuse_target": {
+        "type": ["string", "null"],
+        "maxLength": 500,
+        "description": (
+            "For reuse_existing, identify the verified target as "
+            "repo:<path>#<symbol>. For a standard-library or dependency "
+            "substitute use stdlib:<qualified-name> or dep:<package>:<api>. "
+            "The target must be cited in evidence. "
+            "Return null when no concrete reuse target is proposed."
+        ),
+    },
+}
+
 AUDIT_FINDINGS_SCHEMA: dict[str, Any] = {
     "type": "object",
     "additionalProperties": False,
@@ -66,6 +117,9 @@ AUDIT_FINDINGS_SCHEMA: dict[str, Any] = {
                     "risk",
                     "confidence",
                     "evidence",
+                    "maintenance_signals",
+                    "change_shape",
+                    "reuse_target",
                 ],
                 "properties": {
                     "title": {"type": "string"},
@@ -81,6 +135,7 @@ AUDIT_FINDINGS_SCHEMA: dict[str, Any] = {
                         "type": "array",
                         "items": {"type": "string"},
                     },
+                    **_MAINTENANCE_FINDING_PROPERTIES,
                 },
             },
         },
@@ -108,6 +163,9 @@ VET_SCHEMA: dict[str, Any] = {
                     "confidence",
                     "path",
                     "line",
+                    "maintenance_signals",
+                    "change_shape",
+                    "reuse_target",
                 ],
                 "properties": {
                     "vet_id": {"type": "integer"},
@@ -135,6 +193,7 @@ VET_SCHEMA: dict[str, Any] = {
                     },
                     "path": {"type": ["string", "null"]},
                     "line": {"type": ["integer", "null"]},
+                    **_MAINTENANCE_FINDING_PROPERTIES,
                 },
             },
         },
@@ -162,6 +221,7 @@ PLAN_AUTHOR_SCHEMA: dict[str, Any] = {
     "additionalProperties": False,
     "required": [
         "title",
+        "covered_fingerprints",
         "why_this_matters",
         "scope",
         "context_excerpts",
@@ -174,6 +234,17 @@ PLAN_AUTHOR_SCHEMA: dict[str, Any] = {
     ],
     "properties": {
         "title": {"type": "string", "minLength": 12, "maxLength": 160},
+        "covered_fingerprints": {
+            "type": "array",
+            "minItems": 1,
+            "description": (
+                "Copy the selected finding's complete set of unique "
+                "member_fingerprints exactly. Order is not significant. When "
+                "it has no member_fingerprints, use a one-item array "
+                "containing its fingerprint."
+            ),
+            "items": {"type": "string", "minLength": 1, "maxLength": 128},
+        },
         "why_this_matters": {
             "type": "object",
             "additionalProperties": False,
@@ -383,7 +454,10 @@ PLAN_AUTHOR_SCHEMA: dict[str, Any] = {
                                         "characters to specify, split it into "
                                         "several entries in this array or "
                                         "into another step; it is never "
-                                        "truncated for you."
+                                        "truncated for you. For a delete "
+                                        "operation, name exactly what is "
+                                        "removed and do not invent a "
+                                        "replacement."
                                     ),
                                 },
                                 "target_state": {
@@ -396,7 +470,11 @@ PLAN_AUTHOR_SCHEMA: dict[str, Any] = {
                                         "so the executor can re-read the file "
                                         "and check it sentence by sentence. "
                                         "Describe observable content, not "
-                                        "intent or quality."
+                                        "intent or quality. For a delete "
+                                        "operation, state that the exact "
+                                        "symbol or block is absent; when the "
+                                        "whole file is deleted, state that the "
+                                        "path no longer exists."
                                     ),
                                 },
                             },
@@ -409,8 +487,72 @@ PLAN_AUTHOR_SCHEMA: dict[str, Any] = {
         "test_plan": {
             "type": "object",
             "additionalProperties": False,
-            "required": ["exemplars", "cases"],
+            "required": [
+                "mode",
+                "rationale",
+                "existing_coverage",
+                "exemplars",
+                "cases",
+            ],
             "properties": {
+                "mode": {
+                    "type": "string",
+                    "enum": [
+                        "new-or-updated-tests",
+                        "existing-coverage",
+                        "not-applicable",
+                    ],
+                    "description": (
+                        "Use new-or-updated-tests when test code must change, "
+                        "existing-coverage when named tests already prove the "
+                        "change, and not-applicable only for documentation, "
+                        "exact comment/docstring cleanup, or deletion of a "
+                        "non-runtime artifact or redundant test that cannot "
+                        "usefully be exercised by a test."
+                    ),
+                },
+                "rationale": {
+                    "type": "string",
+                    "minLength": 20,
+                    "maxLength": 700,
+                    "description": (
+                        "Explain why this mode is sufficient for this exact "
+                        "change. Deletion alone is not a reason to omit tests "
+                        "when observable behavior changes."
+                    ),
+                },
+                "existing_coverage": {
+                    "type": "array",
+                    "description": (
+                        "Exact existing tests that already prove the planned "
+                        "behavior. Populate only in existing-coverage mode. "
+                        "These paths are evidence, not writable plan scope."
+                    ),
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "required": [
+                            "path",
+                            "symbol",
+                            "behavior",
+                            "verification",
+                        ],
+                        "properties": {
+                            "path": _REPOSITORY_FILE_PATH_SCHEMA,
+                            "symbol": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 300,
+                            },
+                            "behavior": {
+                                "type": "string",
+                                "minLength": 20,
+                                "maxLength": 700,
+                            },
+                            "verification": _OPTIONAL_COMMAND_REF_SCHEMA,
+                        },
+                    },
+                },
                 "exemplars": {
                     "type": "array",
                     "description": (
@@ -439,7 +581,6 @@ PLAN_AUTHOR_SCHEMA: dict[str, Any] = {
                 },
                 "cases": {
                     "type": "array",
-                    "minItems": 1,
                     "items": {
                         "type": "object",
                         "additionalProperties": False,
@@ -608,23 +749,31 @@ Look for the algorithmic and architectural wins, not micro-optimizations.
 - Frontend: heavyweight dependencies, missing code-splitting on rare routes, unoptimized assets, client fetching for render-time data, and render waterfalls.
 - Backend: synchronous work that belongs in a queue, missing indexes implied by query patterns (flag for verification), and connection-per-request patterns where pooling exists.
 - Build/CI: slow CI from missing caching, redundant pipeline steps, test suites that could parallelize.""",
-    "tests": """## Test Coverage
+    "tests": """## Test Coverage & Test Maintainability
 
 The goal is not a percentage — it is which untested code is dangerous.
 
 - Map critical paths (money, auth, data mutation, the feature the repo exists for) and check which have zero or trivial coverage.
 - Modules with high churn plus no tests are top refactor risks; flag them as characterization-tests-first candidates.
 - Existing test quality: tests that assert nothing meaningful, heavy mocking, unread snapshots, and flaky real-timer/network/order patterns.
+- Test DRY: find repeated setup, fixtures, requests, and assertion blocks that obscure the behavior under test. Prefer an existing helper or fixture over introducing another one.
+- Parameterizable matrices: combine cases that exercise the same behavior through different inputs and expected outputs. Preserve separate tests when setup, behavior, failure diagnosis, or lifecycle is materially different; fewer test functions is not itself a goal.
+- Reuse before invention: cite the existing fixture, factory, harness, or assertion helper that duplicate test code should use. Do not propose a new shared helper when an appropriate repository helper already exists.
 - Missing test layers: unit-only suites with no integration coverage on API boundaries, or slow E2E where unit tests would suffice.
 - Verification infrastructure: if there is no one-command way to know the codebase works, that is a prerequisite finding.""",
     "tech-debt": """## Tech Debt & Architecture
 
-- Duplication: the same logic re-implemented in three or more places, especially divergent copies.
+- Existing-code reuse is the first search, not an afterthought. Look for implementations, adapters, validators, serializers, parsers, fixtures, factories, and utilities that duplicate a repository implementation. A reuse finding cites both the redundant code and the exact canonical target, and explains why their contracts and layer boundaries are compatible.
+- Apply this reuse ladder in order: existing repository code; the language standard library; an already-declared dependency; then a mature new dependency only when the earlier choices do not fit. A new dependency requires a concrete API match and a comparison of maintenance, security, license, transitive-dependency, and migration costs. Do not flag custom code merely because a package exists.
+- Hand-rolled substitutes: flag custom implementations of solved, subtle behavior only when a verified standard-library or dependency API covers the required contract more safely or simply.
+- Duplication: flag repeated logic even across only two sites when one can directly reuse the other and deletion is substantial. Otherwise require a clear maintenance cost, not superficial textual similarity.
 - Layering violations: UI importing data-layer internals, circular dependencies, and high-fan-in junk-drawer utility modules.
 - Dead code: unused modules, fully rolled-out flags still branching, unexplained commented blocks, and unused manifest dependencies.
 - God objects/modules: files far larger than the repo median, high-fan-in modules, double-digit parameters, or deep branching.
 - Inconsistent patterns: multiple ways of fetching data, handling errors, or styling in one repo; identify the recent winner.
-- Abstraction mismatches: single-implementation premature abstractions or missing abstractions where changes require lockstep edits.""",
+- Over-engineering: unnecessary wrappers, layers, registries, factories, interfaces, indirection, and single-implementation abstractions. Prefer deleting the layer and calling the stable implementation directly when that preserves a sound boundary.
+- Comments: flag excessive prose and comments that merely narrate self-evident code. Preserve comments that explain why, invariants, security constraints, compatibility requirements, non-obvious tradeoffs, public API contracts, or temporary workarounds with removal conditions.
+- Abstraction mismatches: single-implementation premature abstractions or missing abstractions where changes require lockstep edits. A proposed new abstraction must delete more duplication than it adds and have a stable, evidence-backed boundary.""",
     "dependencies": """## Dependencies & Migrations
 
 - Major-version lag on core frameworks/runtimes where EOL, security cutoffs, or ecosystem incompatibility create a real cost.
@@ -647,17 +796,6 @@ Lowest default priority — only flag where absence has a concrete cost:
 - Public API surface without reference docs.
 - Architectural decisions nobody can reconstruct in actively contested areas.
 - Stale docs that are actively wrong, such as setup instructions or API examples that no longer work.""",
-    "direction": """## Direction — features & where to take this next
-
-Forward-looking: not what is broken, but what this codebase wants to become. Every suggestion must cite repository evidence.
-
-- Unfinished intent: thematic TODO/FIXME clusters, flags never rolled out, stubs, half-built modules, or abandoned feature work in history.
-- Stated-but-undelivered: README/roadmap promises without code, no-op flags/config, or product docs the implementation has not caught up to.
-- Surface asymmetries: export without import, create without bulk-create, one-way webhooks, incomplete CRUD, or internal workarounds for a missing public API.
-- The adjacent possible: capabilities made disproportionately cheap by existing architecture.
-- Friction worth productizing: work users evidently perform by hand around the project.
-
-For direction findings, Impact is product/user value and Confidence is how well the option is grounded, not certainty that it is the right strategy. State honest tradeoffs and prefer a design/spike plan over build-everything scope.""",
 }
 
 FINDING_FORMAT = """## Finding format
@@ -666,6 +804,10 @@ Every finding must carry:
 - a body containing concrete impact and a 1–3 sentence fix sketch;
 - Effort measured as S (hours), M (about a day), or L (multi-day), including tests;
 - Risk measured on the fix, not on the defect.
+- `maintenance_signals`, using only the stable schema values (or an empty array);
+- `change_shape`, describing whether the whole fix deletes, reuses, consolidates, is neutral, adds, or is still unknown;
+- `reuse_target`, set to a normalized concrete target when reuse is proposed and null otherwise. Repository reuse targets and dependency fit must have their own evidence citation.
+Prefer a deletion, direct reuse, or consolidation when it solves the full problem with equal safety. Seek a net reduction in production and test code across the recommendation, but never trade away correctness, useful coverage, clear diagnostics, rationale comments, or maintainable boundaries merely to reduce line count. Do not claim an exact line reduction before implementation.
 Do not invent a finding without direct evidence."""
 
 HARD_RULE_4 = """Never reproduce secret values. If the audit finds credentials, tokens, or `.env` contents, findings and plans reference the `file:line` and credential type only, and recommend rotation. The value itself must never appear in anything you write."""
@@ -678,6 +820,12 @@ boilerplate STOP conditions (drift, repeated verification failure,
 out-of-scope change), command records, excerpt text, plan numbering,
 planned-at stamps, and Markdown rendering — do not restate any of it.
 
+Copy coverage identity without interpretation: set `covered_fingerprints` to
+the selected finding's complete set of unique `member_fingerprints` when
+present, or to an array containing its single `fingerprint` otherwise. Order is
+not significant. Do not omit, rewrite, or add identifiers. Every member of an
+aggregated finding must be covered by the one plan.
+
 Reference verification commands instead of writing them: each verification
 slot selects one verified recon command by id. Null `appended_args` runs the
 recon command verbatim; otherwise `appended_args` is a focused argument suffix
@@ -686,6 +834,30 @@ substitutions, or placeholders. The `note` states why that gate proves the
 piece it is attached to. If recon lists no verified commands, use null
 verification everywhere and an empty `additional_command_refs` array; never
 invent a command.
+
+Choose the test-plan mode from evidence, not habit:
+- `new-or-updated-tests` requires one or more named cases. Reuse existing
+  fixtures and helpers, and parameterize cases that share setup, action, and
+  assertion shape. Do not emit duplicate test symbols or mechanically numbered
+  variants; use one parameterized symbol or meaningful names for genuinely
+  different behavior.
+- `existing-coverage` requires one or more exact existing test path/symbol
+  references and no authored cases or exemplars. Explain the behavior each
+  existing test already proves. Those tests are read-only evidence unless a
+  step separately declares them writable.
+- `not-applicable` requires empty existing coverage, exemplars, and cases. Use
+  it only when every change is demonstrably non-behavioral documentation or
+  comment cleanup, or deletes a non-runtime artifact or redundant test. Include
+  a `static-invariant` or `step-gate` done criterion that states the exact
+  non-test check and expected result. Deleting production source is not enough
+  to qualify: even code believed to be dead needs a named new/updated test or
+  verified existing coverage when its absence could affect runtime behavior.
+Deletion-only plans are valid: every step operation may be `delete`,
+`scope.new_paths` may be empty, and the plan must not invent a replacement,
+shim, abstraction, or synthetic test. State every deletion target as an absence
+that can be checked in the step's **Verify** block and the plan's done criteria.
+Use step verification, static checks, build/type/lint gates, or existing
+coverage to prove the deletion is safe.
 
 Cite current code with line anchors only, in `context_excerpts` — it is the one
 place excerpts live. Every `scope.existing_paths` path needs at least one
@@ -831,6 +1003,24 @@ Expect and explicitly check the three common failure classes:
 2. real issues with mis-attributed evidence or the wrong file/line; and
 3. duplicate findings from different audit passes.
 
+For maintenance findings, be especially skeptical:
+- A reuse finding is keepable only when you re-open both implementations, verify
+  compatible behavior and layer boundaries, and confirm the normalized
+  `reuse_target` has its own evidence citation.
+- A hand-rolled-substitute finding needs an exact standard-library or dependency
+  API match. For a new dependency, confirm the stated maintenance, security,
+  license, transitive-cost, and migration tradeoff; package popularity alone is
+  not evidence.
+- A DRY or parametrization finding must preserve distinct behavior, lifecycle,
+  and useful failure diagnostics. Similar-looking tests with different reasons
+  to fail stay separate.
+- A comment-removal finding must preserve rationale, invariants, security and
+  compatibility constraints, public contracts, and workaround context.
+- Reject cleanup that adds a helper, abstraction, or dependency without an
+  evidence-backed net simplification. Correct `maintenance_signals`,
+  `change_shape`, and `reuse_target` when the finding is real but classified
+  incorrectly.
+
 Correct supported metadata or citations when needed. If a claim cannot be
 confirmed from the repository, reject it with a concise reason by default.
 
@@ -967,6 +1157,8 @@ def build_plan_writer_repair_prompt(
 __all__ = [
     "AUDIT_FINDINGS_SCHEMA",
     "AUDIT_PLAYBOOK_SECTIONS",
+    "CHANGE_SHAPES",
+    "MAINTENANCE_SIGNALS",
     "PLAN_AUTHOR_SCHEMA",
     "PLAN_WRITER_CONTRACT_INSTRUCTIONS",
     "RECON_COMMAND_CONTRACT_BULLET",

--- a/daydream/improve/publish.py
+++ b/daydream/improve/publish.py
@@ -1,0 +1,321 @@
+"""Idempotent GitHub issue publication for locally written Improve plans.
+
+The local plan remains the plan writer's validated output. Publication copies
+that Markdown verbatim into an issue body; it never creates branches, commits,
+or pushes. A stable marker stored in GitHub makes reconciliation independent of
+local ``daydream_plans`` state, which is important for fresh CI checkouts.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from daydream import git_ops
+
+PublicationDisposition = Literal["created", "existing", "reconciled"]
+_PACKAGE_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,127}")
+_MEMBER_ALIAS_MARKER_PREFIX = "<!-- daydream-improve-member: alias="
+_MEMBER_FINGERPRINT_MARKER_PREFIX = "<!-- daydream-improve-member: fingerprint="
+
+
+class ImprovePublishError(RuntimeError):
+    """Raised when an Improve plan cannot be published without duplication risk."""
+
+
+@dataclass(frozen=True)
+class PublishResult:
+    """Outcome of publishing one locally written plan."""
+
+    package_id: str
+    plan_path: Path
+    disposition: PublicationDisposition
+    issue_url: str
+
+
+def package_marker(package_id: str) -> str:
+    """Return the stable, injection-safe issue marker for a work package."""
+    if _PACKAGE_ID_RE.fullmatch(package_id) is None:
+        raise ValueError(
+            "package_id must contain only letters, numbers, '.', '_', ':', or '-'"
+        )
+    return f"<!-- daydream-improve: package={package_id} -->"
+
+
+def member_marker(member_alias: str) -> str:
+    """Return an injection-safe marker for one stable package member alias."""
+    if _PACKAGE_ID_RE.fullmatch(member_alias) is None:
+        raise ValueError(
+            "member_alias must contain only letters, numbers, '.', '_', ':', or '-'"
+        )
+    return f"{_MEMBER_ALIAS_MARKER_PREFIX}{member_alias} -->"
+
+
+def member_fingerprint_marker(fingerprint: str) -> str:
+    """Return an injection-safe marker for one audit-time member identity."""
+    if _PACKAGE_ID_RE.fullmatch(fingerprint) is None:
+        raise ValueError(
+            "member fingerprint must contain only letters, numbers, '.', '_', ':', or '-'"
+        )
+    return f"{_MEMBER_FINGERPRINT_MARKER_PREFIX}{fingerprint} -->"
+
+
+def _member_markers(member_aliases: Sequence[str]) -> tuple[str, ...]:
+    return tuple(member_marker(alias) for alias in dict.fromkeys(member_aliases))
+
+
+def issue_body(
+    package_id: str,
+    plan_markdown: str,
+    *,
+    member_aliases: Sequence[str] = (),
+    member_fingerprints: Sequence[str] = (),
+) -> str:
+    """Prefix a complete plan with its durable GitHub reconciliation marker."""
+    if not plan_markdown.strip():
+        raise ValueError("plan Markdown must not be empty")
+    markers = (
+        package_marker(package_id),
+        *_member_markers(member_aliases),
+        *tuple(
+            member_fingerprint_marker(fingerprint)
+            for fingerprint in dict.fromkeys(member_fingerprints)
+        ),
+    )
+    return f"{'\n'.join(markers)}\n\n{plan_markdown}"
+
+
+def _repo_slug(repo: Path, explicit: str | None) -> str:
+    if explicit is not None:
+        parsed = git_ops.split_owner_repo(explicit)
+        if parsed is None or "/" in parsed[1]:
+            raise ImprovePublishError(f"Invalid GitHub repository slug {explicit!r}; expected owner/repo")
+        return explicit
+    try:
+        inferred = git_ops.gh_repo_view(repo)
+    except git_ops.GitError as exc:
+        raise ImprovePublishError("Cannot infer the GitHub repository from this checkout") from exc
+    if inferred is None:
+        raise ImprovePublishError("Cannot infer the GitHub repository from this checkout")
+    return f"{inferred[0]}/{inferred[1]}"
+
+
+class IssuePublisher:
+    """Publish plans to one repository with strict cross-run reconciliation.
+
+    Construct with :meth:`connect` once per Improve run. The initial issue
+    lookup doubles as a fail-closed preflight and is cached across all plans.
+    """
+
+    def __init__(
+        self,
+        repo: Path,
+        repo_slug: str,
+        issues: list[dict[str, object]],
+    ) -> None:
+        self._repo = repo
+        self.repo_slug = repo_slug
+        self._issues = issues
+
+    @classmethod
+    def connect(
+        cls,
+        repo: Path,
+        *,
+        repo_slug: str | None = None,
+    ) -> IssuePublisher:
+        """Resolve the repository and load open and closed issues strictly."""
+        resolved = _repo_slug(repo, repo_slug)
+        try:
+            issues = git_ops.gh_issue_list_strict(
+                repo,
+                state="all",
+                repo_slug=resolved,
+            )
+        except git_ops.GitError as exc:
+            raise ImprovePublishError(
+                "Cannot safely reconcile existing Improve issues; no issues were created"
+            ) from exc
+        return cls(repo, resolved, list(issues))
+
+    def _matches(self, marker: str) -> list[dict[str, object]]:
+        return [issue for issue in self._issues if marker in str(issue.get("body") or "")]
+
+    @staticmethod
+    def _issue_key(issue: dict[str, object]) -> str:
+        return str(issue.get("url") or issue.get("number") or id(issue))
+
+    def _existing(
+        self,
+        package: str,
+        required_members: tuple[str, ...],
+        related_members: tuple[str, ...],
+    ) -> dict[str, object] | None:
+        """Resolve one issue only when it covers the complete current package.
+
+        Member aliases let a fresh checkout recognize a package whose wording
+        or grouping changed. Any partial overlap fails closed: reusing that
+        issue would lose new work, while creating another would give the user
+        overlapping issues.
+        """
+        package_matches = self._matches(package)
+        related: list[dict[str, object]] = []
+        full_member_matches: list[dict[str, object]] = []
+        if related_members:
+            for issue in self._issues:
+                body = str(issue.get("body") or "")
+                if any(marker in body for marker in related_members):
+                    related.append(issue)
+                if required_members and all(
+                    marker in body for marker in required_members
+                ):
+                    full_member_matches.append(issue)
+
+        candidates = {
+            self._issue_key(issue): issue
+            for issue in [*package_matches, *full_member_matches]
+        }
+        related_keys = {self._issue_key(issue) for issue in related}
+        if len(candidates) > 1 or (
+            candidates and related_keys - set(candidates)
+        ):
+            ambiguous = {
+                self._issue_key(issue): issue
+                for issue in [*candidates.values(), *related]
+            }
+            urls = ", ".join(
+                str(issue.get("url") or "unknown")
+                for issue in ambiguous.values()
+            )
+            raise ImprovePublishError(
+                "Multiple GitHub issues overlap the same Improve work package: "
+                f"{urls}"
+            )
+
+        if package_matches:
+            existing = package_matches[0]
+            body = str(existing.get("body") or "")
+            has_member_metadata = (
+                _MEMBER_ALIAS_MARKER_PREFIX in body
+                or _MEMBER_FINGERPRINT_MARKER_PREFIX in body
+            )
+            if required_members and has_member_metadata and not all(
+                marker in body for marker in required_members
+            ):
+                raise ImprovePublishError(
+                    "An existing GitHub issue only partially covers this Improve "
+                    "work package; refusing to publish stale or overlapping plan text"
+                )
+            return existing
+        if full_member_matches:
+            return full_member_matches[0]
+        if related:
+            raise ImprovePublishError(
+                "An existing GitHub issue only partially covers this Improve work "
+                "package; refusing to create an overlapping issue"
+            )
+        return None
+
+    def _refresh_after_failed_create(self, create_error: git_ops.GitError) -> None:
+        try:
+            self._issues = git_ops.gh_issue_list_strict(
+                self._repo,
+                state="all",
+                repo_slug=self.repo_slug,
+            )
+        except git_ops.GitError as lookup_error:
+            raise ImprovePublishError(
+                "GitHub issue creation failed and its outcome could not be reconciled; "
+                f"creation error: {create_error}; lookup error: {lookup_error}"
+            ) from create_error
+
+    def publish(
+        self,
+        *,
+        package_id: str,
+        title: str,
+        plan_path: Path,
+        member_aliases: Sequence[str] = (),
+        member_fingerprints: Sequence[str] = (),
+    ) -> PublishResult:
+        """Copy one validated local plan into an idempotent GitHub issue.
+
+        A failed create may have reached GitHub even when the client saw an
+        error. The issue set is therefore refreshed before the error is exposed
+        to a caller that might retry.
+        """
+        try:
+            plan_markdown = plan_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise ImprovePublishError(f"Cannot read Improve plan {plan_path}: {exc}") from exc
+        try:
+            body = issue_body(
+                package_id,
+                plan_markdown,
+                member_aliases=member_aliases,
+                member_fingerprints=member_fingerprints,
+            )
+        except ValueError as exc:
+            raise ImprovePublishError(str(exc)) from exc
+        marker = package_marker(package_id)
+        alias_markers = _member_markers(member_aliases)
+        fingerprint_markers = tuple(
+            member_fingerprint_marker(fingerprint)
+            for fingerprint in dict.fromkeys(member_fingerprints)
+        )
+        # A repeated stable alias is deliberately ambiguous: two independent
+        # findings share the same semantic anchor. In that case only the raw
+        # member fingerprints can prove that every member is covered.
+        aliases_collide = len(set(member_aliases)) < len(member_aliases)
+        required_markers = (
+            fingerprint_markers if aliases_collide else alias_markers
+        ) or fingerprint_markers
+        related_markers = tuple(dict.fromkeys((*alias_markers, *fingerprint_markers)))
+        existing = self._existing(marker, required_markers, related_markers)
+        if existing is not None:
+            return PublishResult(
+                package_id=package_id,
+                plan_path=plan_path,
+                disposition="existing",
+                issue_url=str(existing["url"]),
+            )
+
+        try:
+            url = git_ops.gh_issue_create(
+                self._repo,
+                title=title,
+                body=body,
+                repo_slug=self.repo_slug,
+            )
+        except git_ops.GitError as create_error:
+            self._refresh_after_failed_create(create_error)
+            existing = self._existing(marker, required_markers, related_markers)
+            if existing is None:
+                raise ImprovePublishError(
+                    f"GitHub issue creation failed and no matching issue appeared during reconciliation: {create_error}"
+                ) from create_error
+            return PublishResult(
+                package_id=package_id,
+                plan_path=plan_path,
+                disposition="reconciled",
+                issue_url=str(existing["url"]),
+            )
+
+        self._issues.append(
+            {
+                "number": None,
+                "title": title,
+                "body": body,
+                "url": url,
+                "state": "open",
+            }
+        )
+        return PublishResult(
+            package_id=package_id,
+            plan_path=plan_path,
+            disposition="created",
+            issue_url=url,
+        )

--- a/daydream/improve/render.py
+++ b/daydream/improve/render.py
@@ -110,34 +110,57 @@ def _commands_table(commands: Sequence[dict[str, Any]]) -> str:
     return "\n".join(lines)
 
 
-def _manual_step_check(changed_paths: Sequence[str]) -> str:
+def _target_state_checks(changes: Sequence[dict[str, Any]]) -> str:
+    checks: list[str] = []
+    for change in changes:
+        path = str(change["path"])
+        symbol = str(change["symbol"])
+        target_state = str(change["target_state"])
+        if change["operation"] == "delete":
+            if symbol == path:
+                check = f"confirm `{path}` no longer exists"
+            else:
+                check = (
+                    f"inspect `{path}` and confirm `{symbol}` is absent; if "
+                    "the target state removes the whole file, confirm the path "
+                    "no longer exists"
+                )
+            checks.append(f"- **Deletion check**: {check}. Required target state: {target_state}")
+        else:
+            checks.append(f"- **Target-state check**: re-read `{path}` and confirm: {target_state}")
+    return "\n".join(checks)
+
+
+def _manual_step_check(changes: Sequence[dict[str, Any]]) -> str:
     """Host-owned fallback when the model attached no command to a step.
 
     Never leave the executor with nothing to do: both checks below are
     deterministic, need no repository knowledge, and have a stated expected
     result.
     """
+    changed_paths = [str(change["path"]) for change in changes]
     listed = _path_list(changed_paths)
     return (
         "No repository command was verified during planning for this step. "
-        "Verify it by hand instead, in this order:\n\n"
-        f"1. Re-read {listed} and confirm every **Target state** sentence "
-        "above is now literally true of the file contents. Expected: each one "
-        "describes what the file now says.\n"
-        "2. From the repository root run `git status --porcelain`. Expected: "
+        "Verify it by hand instead: confirm every **Target state** sentence "
+        "above is now literally true using the operation-aware checks below. "
+        "A deletion is verified by absence, not by trying to re-read a deleted "
+        "file.\n\n"
+        + _target_state_checks(changes)
+        + "\n\nFrom the repository root run `git status --porcelain`. Expected: "
         f"the only paths listed are {listed}.\n\n"
         "If either check fails, that is a failed verification — apply the "
-        "\"repeated-verification-failure\" STOP condition."
+        '"repeated-verification-failure" STOP condition.'
     )
 
 
 def _render_verification(
     command: dict[str, Any] | None,
     *,
-    changed_paths: Sequence[str],
+    changes: Sequence[dict[str, Any]],
 ) -> str:
     if command is None:
-        return _manual_step_check(changed_paths)
+        return _manual_step_check(changes)
     expected = command["expected_success"]
     exit_prefix = f"exit {expected['exit_code']} and "
     observable = expected["observable_result"]
@@ -148,7 +171,9 @@ def _render_verification(
     )
     note = command.get("note")
     return (
-        "Run this now, before starting the next step.\n\n"
+        "Confirm every target state before running the repository gate:\n\n"
+        + _target_state_checks(changes)
+        + "\n\nRun this now, before starting the next step.\n\n"
         f"**Purpose**: {command['purpose']}\n\n"
         f"**Run from**: {_run_from(command)}\n\n"
         f"**Command**: `{command['command']}`\n\n"
@@ -206,6 +231,13 @@ def _done_criterion_fallback(kind: str, in_scope_paths: Sequence[str]) -> str:
             "**Check**: from the repository root run "
             "`git status --porcelain`. **Expected**: every listed path is one "
             f"of {_path_list(in_scope_paths)}, and no other path appears."
+        )
+    if kind == "static-invariant":
+        return (
+            "**Check**: inspect the repository and confirm the exact invariant "
+            "stated above. If it names a deleted path, symbol, comment, or "
+            "block, verify that target is absent; a whole-file deletion is "
+            "successful when the path no longer exists."
         )
     return (
         "No repository command was verified during planning for this "
@@ -285,44 +317,71 @@ def render_plan(
             "**Verify**\n\n"
             + _render_verification(
                 step["verification"],
-                changed_paths=[change["path"] for change in step["changes"]],
+                changes=step["changes"],
             )
         )
     test_plan = plan["test_plan"]
-    exemplar_section = (
-        "Copy the shape of these existing tests; do not invent a new style.\n\n"
-        + "\n".join(
-            f"- `{item['path']}` — `{item['symbol']}`: "
-            f"{item['pattern_to_copy']}"
-            for item in test_plan["exemplars"]
-        )
-        if test_plan["exemplars"]
-        else (
-            "This repository has no existing test to copy. Write each named "
-            "case below from its own specification only, and do not go looking "
-            "for a house style that is not there."
-        )
-    )
-    case_lines = "\n\n".join(
-        (
-            f"- **{case['name']}** — `{case['test_file']}::"
-            f"{case['test_symbol']}` ({case['kind']})\n"
-            f"  - Setup: {case['setup']}\n"
-            f"  - Action: {case['action']}\n"
+    test_mode = str(test_plan["mode"])
+    test_plan_header = f"- **Mode**: `{test_mode}`\n- **Rationale**: {test_plan['rationale']}"
+    if test_mode == "new-or-updated-tests":
+        exemplar_section = (
+            "Copy the shape of these existing tests; do not invent a new style.\n\n"
             + "\n".join(
-                f"  - Assert: {assertion}" for assertion in case["assertions"]
+                f"- `{item['path']}` — `{item['symbol']}`: {item['pattern_to_copy']}" for item in test_plan["exemplars"]
             )
-            + "\n  - Verification:\n"
-            + _render_verification_list(
-                case["verification"],
-                indent="    ",
-                fallback=_test_case_fallback(
-                    case["test_file"], case["test_symbol"]
-                ),
+            if test_plan["exemplars"]
+            else (
+                "This repository has no existing test to copy. Write each named "
+                "case below from its own specification only, and do not go looking "
+                "for a house style that is not there."
             )
         )
-        for case in test_plan["cases"]
-    )
+        case_lines = "\n\n".join(
+            (
+                f"- **{case['name']}** — `{case['test_file']}::"
+                f"{case['test_symbol']}` ({case['kind']})\n"
+                f"  - Setup: {case['setup']}\n"
+                f"  - Action: {case['action']}\n"
+                + "\n".join(f"  - Assert: {assertion}" for assertion in case["assertions"])
+                + "\n  - Verification:\n"
+                + _render_verification_list(
+                    case["verification"],
+                    indent="    ",
+                    fallback=_test_case_fallback(case["test_file"], case["test_symbol"]),
+                )
+            )
+            for case in test_plan["cases"]
+        )
+        test_plan_detail = (
+            "These are the tests this plan requires. Where a step above already "
+            "creates one, this section is that test's specification — write it "
+            "once, not twice.\n\n"
+            "### Exemplars\n\n" + exemplar_section + "\n\n### Named cases\n\n" + case_lines
+        )
+    elif test_mode == "existing-coverage":
+        coverage_lines = "\n\n".join(
+            (
+                f"- `{coverage['path']}::{coverage['symbol']}`\n"
+                f"  - Already proves: {coverage['behavior']}\n"
+                "  - Verification:\n"
+                + _render_verification_list(
+                    coverage["verification"],
+                    indent="    ",
+                    fallback=_test_case_fallback(coverage["path"], coverage["symbol"]),
+                )
+            )
+            for coverage in test_plan["existing_coverage"]
+        )
+        test_plan_detail = (
+            "### Existing coverage\n\n"
+            "No test-code change is required. Run and preserve these exact "
+            "existing tests:\n\n" + coverage_lines
+        )
+    else:
+        test_plan_detail = (
+            "No test-code change is required. Verify the non-behavioral change "
+            "through the step gates and done criteria above and below."
+        )
     done_lines = "\n".join(
         f"- [ ] **{criterion['id']} ({criterion['kind']})**: "
         f"{criterion['description']}\n"
@@ -356,12 +415,10 @@ def render_plan(
         f"- **Effort**: {finding.get('effort', '—')}\n"
         f"- **Risk**: {finding.get('risk', '—')}\n"
         f"- **Category**: {finding.get('category', '—')}\n"
+        f"- **Covered finding fingerprints**: "
+        f"{_path_list(plan['covered_fingerprints'])}\n"
         f"- **Planned at**: commit `{planned_at[:7]}`, {planned_on.isoformat()}\n\n"
-        + (
-            f"Daydream run: `{run_session_id}`\n\n"
-            if run_session_id is not None
-            else ""
-        )
+        + (f"Daydream run: `{run_session_id}`\n\n" if run_session_id is not None else "")
         + "## Before you start\n\n"
         "Run these from the repository root, in this order, before Step 1. Each\n"
         "one has an exact expected result.\n\n"
@@ -412,29 +469,19 @@ def render_plan(
         "before reading the next.\n\n"
         + "\n\n".join(step_sections)
         + "\n\n## Test plan\n\n"
-        "These are the tests this plan requires. Where a step above already "
-        "creates one, this section is that test's specification — write it "
-        "once, not twice.\n\n"
-        "### Exemplars\n\n"
-        + exemplar_section
-        + "\n\n### Named cases\n\n"
-        + case_lines
+        + test_plan_header
+        + "\n\n"
+        + test_plan_detail
         + "\n\n## Done criteria\n\n"
-        "Every box must be checked before the plan is done.\n\n"
-        + done_lines
-        + "\n\n## STOP conditions\n\n"
+        "Every box must be checked before the plan is done.\n\n" + done_lines + "\n\n## STOP conditions\n\n"
         "If any of these happens, stop work immediately and report it. Do not "
-        "attempt a workaround and do not continue to the next step.\n\n"
-        + stop_lines
-        + "\n\n## Finishing\n\n"
-        "Only after every box under \"Done criteria\" is checked:\n\n"
+        "attempt a workaround and do not continue to the next step.\n\n" + stop_lines + "\n\n## Finishing\n\n"
+        'Only after every box under "Done criteria" is checked:\n\n'
         f"1. Stage exactly the in-scope paths — never `git add -A`, never "
         f"`git add .`: `git add {' '.join(in_scope_paths)}`\n"
         "2. Confirm nothing else is staged: `git status --porcelain` — "
         f"expected: every line is one of {_path_list(in_scope_paths)}.\n"
-        "3. Commit, following the **Commit boundaries** line under \"Git "
-        f"workflow\": `git commit -m \"{workflow['commit_message_example']}\"`\n"
+        '3. Commit, following the **Commit boundaries** line under "Git '
+        f'workflow": `git commit -m "{workflow["commit_message_example"]}"`\n'
         "4. Do not push and do not open a pull request.\n"
-        f"5. Set this plan's Status cell in `daydream_plans/README.md` from "
-        "`TODO` to `DONE`.\n"
     )

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -572,20 +572,24 @@ def _get_head_sha(cwd: Path) -> str | None:
 
 
 def _run_posts_to_github(config: RunConfig) -> bool:
-    """Return whether the deep single flow (as selected by ``config``) can write to GitHub.
+    """Return whether the selected run can write to GitHub.
 
     This mirrors the mode dispatch's write-capable paths: feedback mode may
     reply to PR comments; an explicit ``--flow deep`` and the default
     non-shallow loop both execute deep's ``post-review`` step; and ``--comment``
-    posts inline comments. ``--review``, shallow mode, and generic custom flows
-    are report-only from the runner's perspective, so they retain the ambient
-    ``gh`` identity. A custom flow that gains a GitHub write must explicitly
-    add its dispatch contract here before it can use App credentials.
+    posts inline comments. Improve is write-capable only when its repository
+    config enables automatic issue publication. ``--review``, shallow mode,
+    and generic custom flows are report-only from the runner's perspective, so
+    they retain the ambient ``gh`` identity. A custom flow that gains a GitHub
+    write must explicitly add its dispatch contract here before it can use App
+    credentials.
     """
     if config.bot is not None:
         return True
 
     if config.flow_name is not None:
+        if config.flow_name == "improve":
+            return _file_config_or_empty(config).improve_github_publish_issues
         return config.flow_name == "deep"
 
     if config.output_mode == "comment":
@@ -932,11 +936,17 @@ async def _run_improve(work: WorkContext, config: RunConfig) -> int:
         ctx = FlowContext(config=config, work=work, registry=get_registry())
         ctx.data["improve_dir"] = directory
         ctx.data["effort_tier"] = tier
+        ctx.data["improve_publish_issues"] = _file_config_or_empty(config).improve_github_publish_issues
+        ctx.data["github_repo"] = config.pr_repo
 
         console.print()
         print_info(console, f"Target directory: {target_dir}")
         print_info(console, f"Effort: {config.improve_effort}")
         print_info(console, f"Focus: {config.improve_focus or 'all'}")
+        print_info(
+            console,
+            f"GitHub issue publishing: {'enabled' if ctx.data['improve_publish_issues'] else 'disabled'}",
+        )
         print_info(console, f"Model: {ctx.backend_for('recon').model}")
         print_info(
             console,

--- a/daydream/templates/workflows/README.md
+++ b/daydream/templates/workflows/README.md
@@ -59,7 +59,10 @@ No single job ever holds both PR code and the App private key:
   identity, not `github-actions[bot]`). Both writes flow through the App token,
   so the job's default GITHUB_TOKEN is unprivileged (`permissions: {}`). This is
   why the App requests `Actions: read & write` and `Pull requests: read & write`
-  — see the setup guide's App-permissions step.
+  — see the setup guide's App-permissions step. The App also requests
+  `Issues: read & write` for repositories that enable unattended Improve plan
+  publication; none of these review-only workflow jobs request that scope in
+  their narrowed runtime token.
 - **Phase B (Daydream Post)** holds the App key but only ever checks out the
   base repo's default branch (trusted code). It mints a token with exactly
   `pull-requests: write, contents: read, metadata: read`, downloads the

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -326,10 +326,13 @@ key (the cheapest tier) and is gated off on `--start-at merge`/`fix` resumes.
 | 3 | `vet` | `vet` |
 | 4 | `select-plans` | `select-plans` |
 | 5 | `write-plans` | `plan_write` |
-| 6 | `improve-report` | `recon` |
+| 6 | `publish-improve-issues` | `recon` |
+| 7 | `improve-report` | `recon` |
 
 The improve run configuration also carries `improve_effort`, `improve_focus`,
-`improve_scope`, and `improve_plan_description`.
+`improve_scope`, and `improve_plan_description`. Issue publication is gated by
+`[tool.daydream.improve.github] publish_issues = true`; when disabled, the
+publication step is a no-op.
 
 Steps carry `enabled` predicates internally (tier gates, mode gates,
 resume points); a step listed here may be skipped for a given run, but the

--- a/docs/self-hosted-bot-setup.md
+++ b/docs/self-hosted-bot-setup.md
@@ -93,6 +93,8 @@ Fill in:
   - **Pull requests: Read and write** — posting and minimizing review comments,
     and the command workflow's 👀 acknowledgement reaction (signed by the App
     token so it shows as `<name>[bot]`, not `github-actions[bot]`).
+  - **Issues: Read and write** — publishing configured `daydream improve`
+    plans directly into issue descriptions and reconciling prior runs.
   - **Contents: Read-only** — required by the posting token's least-privilege trio.
   - **Metadata: Read-only** — implicit baseline.
   - **Actions: Read and write** — the command workflow mints a dispatch token

--- a/tests/harness/improve_backend.py
+++ b/tests/harness/improve_backend.py
@@ -53,6 +53,15 @@ def _plan_ref(
     }
 
 
+def _neutral_maintenance_fields() -> dict[str, Any]:
+    """Required finding metadata for fixtures unrelated to cleanup pressure."""
+    return {
+        "maintenance_signals": [],
+        "change_shape": "unknown",
+        "reuse_target": None,
+    }
+
+
 def _stub_recon_commands(*, all_invalid: bool = False) -> list[dict[str, Any]]:
     scope_kind = "unsupported" if all_invalid else "whole-repository"
     return [
@@ -111,19 +120,9 @@ def _stub_recon_commands(*, all_invalid: bool = False) -> list[dict[str, Any]]:
 
 def _authored_plan_result(finding: dict[str, Any]) -> dict[str, Any]:
     requested_context = (
-        f" for the requested change: {finding['title']}"
-        if finding.get("category") == "requested"
-        else ""
+        f" for the requested change: {finding['title']}" if finding.get("category") == "requested" else ""
     )
-    title = (
-        f"Spike {finding['title']}"
-        if finding.get("category") == "direction"
-        else (
-            finding["title"]
-            if len(finding["title"]) >= 12
-            else f"Implement requested change {finding['title']}"
-        )
-    )
+    title = finding["title"] if len(finding["title"]) >= 12 else f"Implement requested change {finding['title']}"
     step_gate = _plan_ref(
         "test-suite",
         appended_args="apps/billing/test_api.py -q",
@@ -140,36 +139,25 @@ def _authored_plan_result(finding: dict[str, Any]) -> dict[str, Any]:
     )
     return {
         "title": title,
+        "covered_fingerprints": list(finding.get("member_fingerprints") or [finding["fingerprint"]]),
         "why_this_matters": {
-            "problem": (
-                f"{finding['title']} affects the billing service contract today."
-            ),
+            "problem": (f"{finding['title']} affects the billing service contract today."),
             "concrete_cost": (
-                "Leaving the billing behavior unchanged creates avoidable "
-                "maintenance and verification cost."
+                "Leaving the billing behavior unchanged creates avoidable maintenance and verification cost."
             ),
-            "intended_outcome": (
-                "The billing service has an explicit implementation and named "
-                "regression coverage."
-            ),
+            "intended_outcome": ("The billing service has an explicit implementation and named regression coverage."),
         },
         "scope": {
             "existing_paths": [
                 {
                     "path": "apps/billing/api.py",
-                    "role": (
-                        "Implement the selected billing behavior"
-                        f"{requested_context}."
-                    ),
+                    "role": (f"Implement the selected billing behavior{requested_context}."),
                 }
             ],
             "new_paths": [
                 {
                     "path": "apps/billing/test_api.py",
-                    "role": (
-                        "Add named regression coverage for billing"
-                        f"{requested_context}."
-                    ),
+                    "role": (f"Add named regression coverage for billing{requested_context}."),
                 }
             ],
             "out_of_scope_paths": [
@@ -240,36 +228,21 @@ def _authored_plan_result(finding: dict[str, Any]) -> dict[str, Any]:
             },
         ],
         "test_plan": {
-            "exemplars": [
-                {
-                    "path": "apps/catalog/api.py",
-                    "symbol": "service_name",
-                    "pattern_to_copy": (
-                        "Use the neighboring service's direct service_name function style."
-                    ),
-                }
-            ],
+            "mode": "new-or-updated-tests",
+            "rationale": ("The selected behavior changes and needs one focused regression test."),
+            "existing_coverage": [],
+            # The fixture repository intentionally has no tests yet. A source
+            # helper is not a test exemplar, so the honest contract is empty.
+            "exemplars": [],
             "cases": [
                 {
-                    "name": (
-                        "Billing service preserves the requested contract"
-                        f"{requested_context}"
-                    ),
+                    "name": (f"Billing service preserves the requested contract{requested_context}"),
                     "test_file": "apps/billing/test_api.py",
                     "test_symbol": "test_service_name_preserves_contract",
                     "kind": "unit",
-                    "setup": (
-                        "Import service_name from the billing API module"
-                        f"{requested_context}."
-                    ),
-                    "action": (
-                        "Call service_name once without additional arguments"
-                        f"{requested_context}."
-                    ),
-                    "assertions": [
-                        "The returned value is the expected billing service "
-                        f"string{requested_context}."
-                    ],
+                    "setup": (f"Import service_name from the billing API module{requested_context}."),
+                    "action": (f"Call service_name once without additional arguments{requested_context}."),
+                    "assertions": [f"The returned value is the expected billing service string{requested_context}."],
                     "verification": test_gate,
                 }
             ],
@@ -473,16 +446,12 @@ class ImproveStubBackend:
                 "dependencies": "## Dependencies & Migrations",
                 "dx": "## DX & Tooling",
                 "docs": "## Docs",
-                "direction": "## Direction",
             }
-            category = next(
-                name for name, heading in headings.items() if heading in prompt
-            )
+            category = next(name for name, heading in headings.items() if heading in prompt)
         elif "You are the improve vet." in prompt:
             marker = "vet"
         elif "You are writing a self-contained implementation plan" in prompt or (
-            isinstance(output_schema, dict)
-            and "false_assumption" in output_schema.get("properties", {})
+            isinstance(output_schema, dict) and "false_assumption" in output_schema.get("properties", {})
         ):
             marker = "plan-writer"
         self.calls.append(
@@ -600,6 +569,7 @@ class ImproveStubBackend:
                                 "risk": "LOW",
                                 "confidence": "HIGH",
                                 "evidence": [f"{cited}:1"],
+                                **_neutral_maintenance_fields(),
                             }
                             for number in range(1, self.findings_per_category + 1)
                         ]
@@ -637,6 +607,7 @@ class ImproveStubBackend:
                     "risk": "LOW",
                     "confidence": "HIGH",
                     "evidence": [f"{cited}:1"],
+                    **_neutral_maintenance_fields(),
                 }
             ]
             if category == "performance":
@@ -652,6 +623,7 @@ class ImproveStubBackend:
                         "risk": "LOW",
                         "confidence": "HIGH",
                         "evidence": ["apps/catalog/api.py:1"],
+                        **_neutral_maintenance_fields(),
                     }
                 )
             yield ResultEvent(
@@ -691,6 +663,9 @@ class ImproveStubBackend:
                             "confidence": candidate["confidence"],
                             "path": candidate["path"],
                             "line": candidate["line"],
+                            "maintenance_signals": candidate["maintenance_signals"],
+                            "change_shape": candidate["change_shape"],
+                            "reuse_target": candidate["reuse_target"],
                         }
                         for candidate in candidates
                     ]
@@ -953,7 +928,6 @@ class ProductionPathBackend(ImproveStubBackend):
                 "dependencies": "## Dependencies & Migrations",
                 "dx": "## DX & Tooling",
                 "docs": "## Docs",
-                "direction": "## Direction",
             }
             category = next(
                 name for name, heading in headings.items() if heading in prompt
@@ -994,6 +968,7 @@ class ProductionPathBackend(ImproveStubBackend):
                         "risk": "LOW",
                         "confidence": "HIGH",
                         "evidence": ["apps/billing/api.py:1"],
+                        **_neutral_maintenance_fields(),
                     }
                 ]
             yield ResultEvent(
@@ -1015,7 +990,10 @@ class ProductionPathBackend(ImproveStubBackend):
             self.peak_active = max(self.peak_active, self.plan_active)
             try:
                 await anyio.sleep(0.05)
-                if finding["title"] == self.failed_title:
+                member_titles = {
+                    str(member.get("title")) for member in finding.get("members", []) if isinstance(member, dict)
+                }
+                if finding["title"] == self.failed_title or self.failed_title in member_titles:
                     raise _ProductionPathPlannerError(f"planner process metadata {self.planner_secret}")
             finally:
                 self.plan_active -= 1

--- a/tests/test_bot_setup_integration.py
+++ b/tests/test_bot_setup_integration.py
@@ -42,6 +42,17 @@ def test_callback_listener_captures_code_then_exchanges(monkeypatch):
     assert slug == "acme-bot"
 
 
+def test_app_manifest_requests_issue_write_for_improve_publication() -> None:
+    manifest = bot_setup._manifest_payload(
+        redirect_url="http://localhost:8080/callback",
+        org=None,
+    )
+
+    permissions = manifest["default_permissions"]
+    assert isinstance(permissions, dict)
+    assert permissions["issues"] == "write"
+
+
 def test_callback_listener_passes_repo_dir_and_code_through(monkeypatch):
     """The seam threads the listener's repo_dir and the callback code unchanged."""
     captured: dict[str, object] = {}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -48,12 +48,16 @@ def test_audit_categories_match_playbook() -> None:
         "dependencies",
         "dx",
         "docs",
-        "direction",
     }
 
 
 def test_quick_effort_tier_uses_high_confidence_core_categories() -> None:
-    assert EFFORT_TIERS["quick"].categories == ("correctness", "security", "tests")
+    assert EFFORT_TIERS["quick"].categories == (
+        "correctness",
+        "security",
+        "tests",
+        "tech-debt",
+    )
 
 
 def test_effort_tiers_carry_partition_group_ceilings() -> None:

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -21,6 +21,43 @@ def test_improve_config_absent_defaults_empty(tmp_path: Path) -> None:
     assert load_file_config(tmp_path).improve_service_roots == []
 
 
+def test_improve_github_issue_publishing_is_explicitly_configurable(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        "[tool.daydream.improve.github]\npublish_issues = true\n"
+    )
+
+    config = load_file_config(tmp_path)
+
+    assert config.improve_github_publish_issues is True
+
+
+def test_improve_github_issue_publishing_accepts_kebab_case_fallback(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        "[tool.daydream.improve.github]\npublish-issues = true\n"
+    )
+
+    config = load_file_config(tmp_path)
+
+    assert config.improve_github_publish_issues is True
+
+
+@pytest.mark.parametrize("raw", ['"yes"', "1", "[]"])
+def test_improve_github_issue_publishing_rejects_non_boolean_values(
+    tmp_path: Path,
+    raw: str,
+) -> None:
+    (tmp_path / ".daydream.toml").write_text(
+        f"[improve.github]\npublish_issues = {raw}\n"
+    )
+
+    assert load_file_config(tmp_path).improve_github_publish_issues is False
+    assert DaydreamFileConfig().improve_github_publish_issues is False
+
+
 def test_improve_partition_bounds_parse_from_tool_daydream_improve(tmp_path: Path) -> None:
     (tmp_path / "pyproject.toml").write_text(
         "[tool.daydream.improve]\npartition-max-files = 7\nmax-partition-groups = 2\n"

--- a/tests/test_improve_flow.py
+++ b/tests/test_improve_flow.py
@@ -11,7 +11,7 @@ from daydream.config import AUDIT_CATEGORIES, EFFORT_TIERS, VET_BATCH_MAX_FINDIN
 from daydream.config_file import DaydreamFileConfig, load_file_config
 from daydream.exploration_runner import _sample_paths, repo_scan
 from daydream.extensions.loader import build_registry
-from daydream.git_ops import head_sha
+from daydream.git_ops import GitError, head_sha
 from daydream.improve.orchestrator import (
     _apply_vet_verdicts,
     _stamp_finding,
@@ -19,11 +19,14 @@ from daydream.improve.orchestrator import (
 from daydream.improve.partition import Partition
 from daydream.improve.plans import PLAN_INDEX_FILENAME
 from daydream.improve.prompts import (
+    AUDIT_FINDINGS_SCHEMA,
     AUDIT_PLAYBOOK_SECTIONS,
     HARD_RULE_4,
     HARD_RULE_6,
     PLAN_AUTHOR_SCHEMA,
+    VET_SCHEMA,
     build_audit_prompt,
+    build_vet_prompt,
 )
 from daydream.improve.services import Service
 from daydream.runner import RunConfig, run
@@ -111,6 +114,66 @@ def test_audit_prompt_states_slicing_bounds_search_not_reading() -> None:
         tier=EFFORT_TIERS["standard"],
     )
     assert "bounds where you search, never what you may read" in prompt
+
+
+def test_maintenance_audits_demand_reuse_and_subtractive_evidence() -> None:
+    tech_debt = build_audit_prompt(
+        category="tech-debt",
+        skill_invocation=None,
+        group=_GROUP,
+        scope_note="",
+        recon_summary="{}",
+        cwd=Path("/repo"),
+        tier=EFFORT_TIERS["standard"],
+    )
+    tests = build_audit_prompt(
+        category="tests",
+        skill_invocation=None,
+        group=_GROUP,
+        scope_note="",
+        recon_summary="{}",
+        cwd=Path("/repo"),
+        tier=EFFORT_TIERS["standard"],
+    )
+
+    assert "existing repository code" in tech_debt
+    assert "language standard library" in tech_debt
+    assert "already-declared dependency" in tech_debt
+    assert "mature new dependency" in tech_debt
+    assert "comments that merely narrate self-evident code" in tech_debt
+    assert "net reduction in production and test code" in tech_debt
+    assert "Parameterizable matrices" in tests
+    assert "Preserve separate tests" in tests
+
+
+def test_finding_and_vet_schemas_require_stable_maintenance_metadata() -> None:
+    for schema, collection in (
+        (AUDIT_FINDINGS_SCHEMA, "findings"),
+        (VET_SCHEMA, "verdicts"),
+    ):
+        item = schema["properties"][collection]["items"]
+        assert {
+            "maintenance_signals",
+            "change_shape",
+            "reuse_target",
+        } <= set(item["required"])
+        assert item["properties"]["change_shape"]["enum"] == [
+            "delete",
+            "reuse",
+            "consolidate",
+            "neutral",
+            "additive",
+            "unknown",
+        ]
+
+
+def test_vet_prompt_rejects_false_reuse_and_comment_cleanup() -> None:
+    prompt = build_vet_prompt(findings=[], cwd=Path("/repo"))
+
+    assert "re-open both implementations" in prompt
+    assert "layer boundaries" in prompt
+    assert "Similar-looking tests" in prompt
+    assert "preserve rationale, invariants, security" in prompt
 
 
 def _index_numbers_by_fingerprint(index_text: str) -> dict[str, int]:
@@ -460,15 +523,15 @@ async def test_partition_bound_splits_oversized_trees_via_config(
         improve_scaled_monorepo_target,
         "\n[tool.daydream.improve]\npartition-max-files = 5\nmax-partition-groups = 20\n",
     )
-    stub = install_improve_stub(
-        monkeypatch, improve_scaled_monorepo_target, n_findings=0
-    )
+    stub = install_improve_stub(monkeypatch, improve_scaled_monorepo_target, n_findings=0)
 
-    code = await run(make_config(
+    code = await run(
+        make_config(
         improve_scaled_monorepo_target,
         flow_name="improve",
         file_config=file_config,
-    ))
+        )
+    )
 
     assert code == 0
     audit_calls = [call for call in stub.calls if call["marker"] == "audit"]
@@ -499,15 +562,15 @@ async def test_group_ceiling_skips_smallest_groups_and_reports_them(
         improve_scaled_monorepo_target,
         "\n[tool.daydream.improve]\nmax-partition-groups = 1\n",
     )
-    stub = install_improve_stub(
-        monkeypatch, improve_scaled_monorepo_target, n_findings=0
-    )
+    stub = install_improve_stub(monkeypatch, improve_scaled_monorepo_target, n_findings=0)
 
-    code = await run(make_config(
+    code = await run(
+        make_config(
         improve_scaled_monorepo_target,
         flow_name="improve",
         file_config=file_config,
-    ))
+        )
+    )
 
     assert code == 0
     audit_calls = [call for call in stub.calls if call["marker"] == "audit"]
@@ -527,19 +590,19 @@ async def test_quick_tier_audits_whole_repo_in_one_group(
     make_config: MakeConfig,
 ) -> None:
     _pin_stack_availability(monkeypatch, tmp_path)
-    stub = install_improve_stub(
-        monkeypatch, improve_scaled_monorepo_target, n_findings=0
-    )
+    stub = install_improve_stub(monkeypatch, improve_scaled_monorepo_target, n_findings=0)
 
-    code = await run(make_config(
+    code = await run(
+        make_config(
         improve_scaled_monorepo_target,
         flow_name="improve",
         improve_effort="quick",
-    ))
+        )
+    )
 
     assert code == 0
     audit_calls = [call for call in stub.calls if call["marker"] == "audit"]
-    assert len(audit_calls) == 3  # the quick tier's three categories
+    assert len(audit_calls) == 4  # quick also hunts tech-debt/code bloat
     for call in audit_calls:
         assert group_roots(call["prompt"]) == ["."]
     coverage = json.loads(improve_artifact(improve_scaled_monorepo_target, "coverage.json").read_text())
@@ -605,16 +668,16 @@ async def test_report_names_unaudited_partitions_and_failed_groups(
         improve_scaled_monorepo_target,
         "\n[tool.daydream.improve]\nmax-partition-groups = 1\n",
     )
-    stub = install_improve_stub(
-        monkeypatch, improve_scaled_monorepo_target, n_findings=0
-    )
+    stub = install_improve_stub(monkeypatch, improve_scaled_monorepo_target, n_findings=0)
     stub.fail_categories = {"docs"}
 
-    code = await run(make_config(
+    code = await run(
+        make_config(
         improve_scaled_monorepo_target,
         flow_name="improve",
         file_config=file_config,
-    ))
+        )
+    )
 
     assert code == 0
     report = improve_artifact(improve_scaled_monorepo_target, "report.md").read_text()
@@ -711,12 +774,14 @@ async def test_vet_batches_are_bounded_and_parallel(
     stub.findings_per_category = 45
     stub.vet_reject_titles = {"Security finding 45"}
 
-    code = await run(make_config(
+    code = await run(
+        make_config(
         improve_monorepo_target,
         flow_name="improve",
         improve_focus="security",
         file_config=file_config,
-    ))
+        )
+    )
 
     assert code == 0
     vet_calls = [call for call in stub.calls if call["marker"] == "vet"]
@@ -725,18 +790,16 @@ async def test_vet_batches_are_bounded_and_parallel(
         payload = json.loads(call["prompt"].split("```json\n")[1].split("```")[0])
         assert len(payload) <= VET_BATCH_MAX_FINDINGS
     vetted = json.loads(improve_artifact(improve_monorepo_target, "vetted-findings.json").read_text())
-    titles = {finding["title"] for finding in vetted["findings"]}
+    members = [member for package in vetted["findings"] for member in package.get("members", [package])]
+    titles = {finding["title"] for finding in members}
     # Verdicts from every batch apply: the last batch's rejection is honored
-    # and the other 44 keeps survive.
-    assert len(vetted["findings"]) == 44
+    # and the other 44 survive inside nine manageable work packages.
+    assert len(members) == 44
+    assert len(vetted["findings"]) == 9
     assert "Security finding 45" not in titles
     assert "Security finding 01" in titles and "Security finding 44" in titles
-    rejected = json.loads(
-        (improve_monorepo_target / "daydream_plans" / "rejected.json").read_text()
-    )
-    assert any(
-        entry["title"] == "Security finding 45" for entry in rejected["rejected"]
-    )
+    rejected = json.loads((improve_monorepo_target / "daydream_plans" / "rejected.json").read_text())
+    assert any(entry["title"] == "Security finding 45" for entry in rejected["rejected"])
 
 
 @pytest.mark.anyio
@@ -755,18 +818,22 @@ async def test_vet_batch_failure_fails_closed_per_batch(
     stub.findings_per_category = 45
     stub.fail_vet_titles = {"Security finding 41"}  # the third batch's agent raises
 
-    code = await run(make_config(
+    code = await run(
+        make_config(
         improve_monorepo_target,
         flow_name="improve",
         improve_focus="security",
         file_config=file_config,
-    ))
+        )
+    )
 
     assert code == 0
     vetted = json.loads(improve_artifact(improve_monorepo_target, "vetted-findings.json").read_text())
-    titles = {finding["title"] for finding in vetted["findings"]}
+    members = [member for package in vetted["findings"] for member in package.get("members", [package])]
+    titles = {finding["title"] for finding in members}
     # Only the failed batch's five findings drop; the other two batches keep theirs.
-    assert len(vetted["findings"]) == 40
+    assert len(members) == 40
+    assert len(vetted["findings"]) == 8
     assert "Security finding 41" not in titles
     assert "Security finding 01" in titles and "Security finding 40" in titles
 
@@ -1057,22 +1124,19 @@ async def test_non_array_commands_preserve_diagnostics_and_continue_audit(
     for private_value in (secret, model_prose, rejected_command):
         assert private_value not in console_output
 
+
 @pytest.mark.anyio
 @pytest.mark.parametrize(
     ("effort", "focus", "expected_categories"),
     [
-        pytest.param(
-            "standard", None, sorted(AUDIT_CATEGORIES), id="standard-effort"
-        ),
+        pytest.param("standard", None, sorted(AUDIT_CATEGORIES), id="standard-effort"),
         pytest.param(
             "quick",
             None,
-            ["correctness", "security", "tests"],
+            ["correctness", "security", "tech-debt", "tests"],
             id="quick-effort",
         ),
-        pytest.param(
-            "standard", "security", ["security"], id="focus-security"
-        ),
+        pytest.param("standard", "security", ["security"], id="focus-security"),
     ],
 )
 async def test_effort_and_focus_select_the_audited_categories_read_only(
@@ -1084,15 +1148,15 @@ async def test_effort_and_focus_select_the_audited_categories_read_only(
     make_config: MakeConfig,
 ) -> None:
     stub = install_improve_stub(monkeypatch, improve_monorepo_target)
-    await run(make_config(
+    await run(
+        make_config(
         improve_monorepo_target,
         flow_name="improve",
         improve_effort=effort,
         improve_focus=focus,
-    ))
-    audited = json.loads(
-        improve_artifact(improve_monorepo_target, "audit-findings.json").read_text()
     )
+    )
+    audited = json.loads(improve_artifact(improve_monorepo_target, "audit-findings.json").read_text())
     assert sorted(audited["categories_run"]) == expected_categories
     audit_calls = [call for call in stub.calls if call["marker"] == "audit"]
     assert audit_calls and all(call["read_only"] for call in audit_calls)
@@ -1160,20 +1224,16 @@ async def test_pi_improve_retains_valid_commands_and_avoids_provider_overload(
         lambda *args, **kwargs: backend,
     )
 
-    code = await run(make_config(
+    code = await run(
+        make_config(
         improve_monorepo_target,
         flow_name="improve",
         non_interactive=False,
-    ))
-
-    recon = json.loads(
-        improve_artifact(improve_monorepo_target, "recon.json").read_text(encoding="utf-8")
-    )
-    plan_files = sorted(
-        (improve_monorepo_target / "daydream_plans").glob(
-            "[0-9][0-9][0-9]-*.md"
         )
     )
+
+    recon = json.loads(improve_artifact(improve_monorepo_target, "recon.json").read_text(encoding="utf-8"))
+    plan_files = sorted((improve_monorepo_target / "daydream_plans").glob("[0-9][0-9][0-9]-*.md"))
     console_output = capsys.readouterr().out
     observables = [
         console_output,
@@ -1214,27 +1274,21 @@ async def test_pi_improve_partial_failure_is_successful_and_safe(
         lambda *args, **kwargs: backend,
     )
 
-    code = await run(make_config(
+    code = await run(
+        make_config(
         improve_monorepo_target,
         flow_name="improve",
         non_interactive=False,
-    ))
-
-    plan_files = sorted(
-        (improve_monorepo_target / "daydream_plans").glob(
-            "[0-9][0-9][0-9]-*.md"
         )
     )
+
+    plan_files = sorted((improve_monorepo_target / "daydream_plans").glob("[0-9][0-9][0-9]-*.md"))
     diagnostics_text = improve_artifact(
         improve_monorepo_target,
         "plan-write-diagnostics.json",
     ).read_text(encoding="utf-8")
     diagnostics = json.loads(diagnostics_text)
-    failed = [
-        attempt
-        for attempt in diagnostics["attempts"]
-        if attempt["disposition"] == "blocked"
-    ]
+    failed = [attempt for attempt in diagnostics["attempts"] if attempt["disposition"] == "blocked"]
     console_output = capsys.readouterr().out
     observables = [
         console_output,
@@ -1242,34 +1296,17 @@ async def test_pi_improve_partial_failure_is_successful_and_safe(
     ]
 
     assert code == 0
-    assert len(plan_files) == 4
+    assert len(plan_files) == 1
     assert len(failed) == 1
-    assert failed[0]["finding"]["title"] == "Production finding 03"
+    # The failed member is represented by its aggregate package title.
+    assert failed[0]["finding"]["title"] == "Production finding 01"
     assert failed[0]["errors"] == [{"code": "PROCESS_EXIT", "pointer": "/"}]
-    assert "Plan blocked for Production finding 03: PROCESS_EXIT at /." in console_output
+    assert "Plan blocked for Production finding 01: PROCESS_EXIT at /." in console_output
     report = improve_artifact(improve_monorepo_target, "report.md").read_text(encoding="utf-8")
-    assert "Plans written: 4" in report
+    assert "Plans written: 1" in report
     assert "Plans blocked by plan-writing failure: 1" in report
     assert all(backend.recon_secret not in text for text in observables)
     assert all(backend.planner_secret not in text for text in observables)
-
-
-@pytest.mark.anyio
-async def test_focus_next_is_direction_only_and_plans_are_spikes(
-    improve_monorepo_target: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    make_config: MakeConfig,
-) -> None:
-    install_improve_stub(monkeypatch, improve_monorepo_target)
-    await run(make_config(improve_monorepo_target, flow_name="improve", improve_focus="next"))
-    audited = json.loads(
-        improve_artifact(improve_monorepo_target, "audit-findings.json").read_text()
-    )
-    assert audited["categories_run"] == ["direction"]
-    plan = next(
-        (improve_monorepo_target / "daydream_plans").glob("0*.md")
-    ).read_text()
-    assert "spike" in plan.lower()
 
 
 @pytest.mark.anyio
@@ -1307,12 +1344,14 @@ async def test_branch_focus_with_scope_excludes_out_of_scope_service_diff(
     make_config: MakeConfig,
 ) -> None:
     stub = install_improve_stub(monkeypatch, improve_branch_two_services_target)
-    code = await run(make_config(
+    code = await run(
+        make_config(
         improve_branch_two_services_target,
         flow_name="improve",
         improve_focus="branch",
         improve_scope="apps/billing",
-    ))
+        )
+    )
     assert code == 0
     # Isolate the embedded ```diff fenced block so the assertion targets the
     # branch diff itself, not the whole-repo recon context that legitimately
@@ -1337,11 +1376,13 @@ async def test_branch_focus_on_base_branch_reports_and_exits_cleanly(
     make_config: MakeConfig,
 ) -> None:
     install_improve_stub(monkeypatch, improve_monorepo_target)
-    code = await run(make_config(
+    code = await run(
+        make_config(
         improve_monorepo_target,
         flow_name="improve",
         improve_focus="branch",
-    ))
+        )
+    )
     assert code == 1
 
 
@@ -1756,21 +1797,21 @@ async def test_interactive_selection_honors_user_choice(
         improve_monorepo_target,
         n_findings=8,
     )
-    code = await run(make_config(
+    code = await run(
+        make_config(
         improve_monorepo_target,
         flow_name="improve",
         non_interactive=False,
-    ))
-    assert code == 0
-    selected = json.loads(
-        improve_artifact(improve_monorepo_target, "selected.json").read_text()
     )
+    )
+    assert code == 0
+    selected = json.loads(improve_artifact(improve_monorepo_target, "selected.json").read_text())
     assert len(selected["selected"]) == 1
     assert selected["mode"] == "interactive"
 
 
 @pytest.mark.anyio
-async def test_report_orders_by_leverage_and_separates_direction(
+async def test_report_orders_by_leverage_without_non_actionable_direction_section(
     improve_monorepo_target: Path,
     monkeypatch: pytest.MonkeyPatch,
     make_config: MakeConfig,
@@ -1783,10 +1824,9 @@ async def test_report_orders_by_leverage_and_separates_direction(
     code = await run(make_config(improve_monorepo_target, flow_name="improve"))
     assert code == 0
     report = improve_artifact(improve_monorepo_target, "report.md").read_text()
-    assert report.index("high-leverage-title") < report.index(
-        "low-leverage-title"
-    )
-    assert "## Direction" in report
+    assert report.index("high-leverage-title") < report.index("low-leverage-title")
+    assert "## Direction" not in report
+    assert "## Cleanup pressure" in report
     assert "not audited" in report.lower()
 
 
@@ -1797,25 +1837,21 @@ async def test_scope_slices_search_but_report_names_the_unaudited_rest(
     make_config: MakeConfig,
 ) -> None:
     stub = install_improve_stub(monkeypatch, improve_monorepo_target)
-    code = await run(make_config(
+    code = await run(
+        make_config(
         improve_monorepo_target,
         flow_name="improve",
         improve_scope="apps/billing",
-    ))
+        )
+    )
 
     assert code == 0
     audit_calls = [call for call in stub.calls if call["marker"] == "audit"]
     assert all("apps/billing" in call["prompt"] for call in audit_calls)
     # A slice bounds where the audit searches, never what it may read: a
     # cross-service finding must stay reachable (spec.md monorepo requirement).
-    assert all(
-        "bounds where you search, never what you may read" in call["prompt"]
-        for call in audit_calls
-    )
-    assert any(
-        "bounds where the audit searches" in call["prompt"].lower()
-        for call in audit_calls
-    )
+    assert all("bounds where you search, never what you may read" in call["prompt"] for call in audit_calls)
+    assert any("bounds where the audit searches" in call["prompt"].lower() for call in audit_calls)
     report = improve_artifact(improve_monorepo_target, "report.md").read_text()
     assert "catalog" in report and "not audited" in report.lower()
 
@@ -1827,14 +1863,14 @@ async def test_group_scope_expands_named_service_group_to_all_members(
     make_config: MakeConfig,
 ) -> None:
     stub = install_improve_stub(monkeypatch, improve_monorepo_target)
-    code = await run(make_config(
+    code = await run(
+        make_config(
         improve_monorepo_target,
         flow_name="improve",
         improve_scope="core",
-        file_config=DaydreamFileConfig(
-            improve_service_groups={"core": ["apps/billing", "apps/catalog"]}
-        ),
-    ))
+            file_config=DaydreamFileConfig(improve_service_groups={"core": ["apps/billing", "apps/catalog"]}),
+        )
+    )
 
     assert code == 0
     audit_calls = [call for call in stub.calls if call["marker"] == "audit"]
@@ -1853,19 +1889,17 @@ async def test_plan_subverb_skips_audit_and_writes_single_plan(
     make_config: MakeConfig,
 ) -> None:
     install_improve_stub(monkeypatch, improve_monorepo_target)
-    code = await run(make_config(
+    code = await run(
+        make_config(
         improve_monorepo_target,
         flow_name="improve",
         improve_plan_description="add rate limiting",
-    ))
+        )
+    )
 
     assert code == 0
     assert not improve_artifact(improve_monorepo_target, "audit-findings.json").exists()
-    plans = list(
-        (improve_monorepo_target / "daydream_plans").glob(
-            "[0-9][0-9][0-9]-*.md"
-        )
-    )
+    plans = list((improve_monorepo_target / "daydream_plans").glob("[0-9][0-9][0-9]-*.md"))
     assert len(plans) == 1
     assert "rate limiting" in plans[0].read_text().lower()
 
@@ -1879,31 +1913,25 @@ async def test_plan_subverb_repairs_schema_invalid_plan_once(
     stub = install_improve_stub(monkeypatch, improve_monorepo_target)
     stub.return_secret_invalid_enum_once = True
 
-    code = await run(make_config(
+    code = await run(
+        make_config(
         improve_monorepo_target,
         flow_name="improve",
         improve_plan_description="add rate limiting",
-    ))
+        )
+    )
 
-    plan_calls = [
-        call for call in stub.calls if call["marker"] == "plan-writer"
-    ]
+    plan_calls = [call for call in stub.calls if call["marker"] == "plan-writer"]
     assert code == 0
     assert len(plan_calls) == 2
     repair_prompt = plan_calls[1]["prompt"]
     assert "PRIVATE_SCHEMA_SECRET" not in repair_prompt
     assert "TOKEN=" not in repair_prompt
     assert all(
-        call["output_schema"] == PLAN_AUTHOR_SCHEMA
-        and call["read_only"] is True
-        and call["persist_session"] is False
+        call["output_schema"] == PLAN_AUTHOR_SCHEMA and call["read_only"] is True and call["persist_session"] is False
         for call in plan_calls
     )
-    plans = list(
-        (improve_monorepo_target / "daydream_plans").glob(
-            "[0-9][0-9][0-9]-*.md"
-        )
-    )
+    plans = list((improve_monorepo_target / "daydream_plans").glob("[0-9][0-9][0-9]-*.md"))
     assert len(plans) == 1
     persisted = "\n".join(
         path.read_text(encoding="utf-8")
@@ -1951,15 +1979,15 @@ async def test_persistent_authoring_failure_blocks_after_one_repair(
     stub = install_improve_stub(monkeypatch, improve_monorepo_target)
     setattr(stub, stub_attr, stub_value)
 
-    code = await run(make_config(
+    code = await run(
+        make_config(
         improve_monorepo_target,
         flow_name="improve",
         improve_plan_description="add rate limiting",
-    ))
+        )
+    )
 
-    plan_calls = [
-        call for call in stub.calls if call["marker"] == "plan-writer"
-    ]
+    plan_calls = [call for call in stub.calls if call["marker"] == "plan-writer"]
     plans_dir = improve_monorepo_target / "daydream_plans"
     diagnostics = _load_improve_json(
         improve_monorepo_target,
@@ -2000,22 +2028,18 @@ async def test_plan_subverb_clamps_over_length_prose_without_repair(
     assert len(over_length_role) == 306
     stub.plan_file_role_override = over_length_role
 
-    code = await run(make_config(
+    code = await run(
+        make_config(
         improve_monorepo_target,
         flow_name="improve",
         improve_plan_description="add rate limiting",
-    ))
-
-    plan_calls = [
-        call for call in stub.calls if call["marker"] == "plan-writer"
-    ]
-    assert code == 0
-    assert len(plan_calls) == 1
-    plans = list(
-        (improve_monorepo_target / "daydream_plans").glob(
-            "[0-9][0-9][0-9]-*.md"
         )
     )
+
+    plan_calls = [call for call in stub.calls if call["marker"] == "plan-writer"]
+    assert code == 0
+    assert len(plan_calls) == 1
+    plans = list((improve_monorepo_target / "daydream_plans").glob("[0-9][0-9][0-9]-*.md"))
     assert len(plans) == 1
     plan_text = plans[0].read_text(encoding="utf-8")
     assert over_length_role[:299] + "…" in plan_text
@@ -2041,22 +2065,18 @@ async def test_plan_subverb_accepts_placeholder_secret_syntax(
         "production and X-Internal-Service-Secret: test-secret in tests."
     )
 
-    code = await run(make_config(
+    code = await run(
+        make_config(
         improve_monorepo_target,
         flow_name="improve",
         improve_plan_description="add rate limiting",
-    ))
-
-    plan_calls = [
-        call for call in stub.calls if call["marker"] == "plan-writer"
-    ]
-    assert code == 0
-    assert len(plan_calls) == 1
-    plans = list(
-        (improve_monorepo_target / "daydream_plans").glob(
-            "[0-9][0-9][0-9]-*.md"
         )
     )
+
+    plan_calls = [call for call in stub.calls if call["marker"] == "plan-writer"]
+    assert code == 0
+    assert len(plan_calls) == 1
+    plans = list((improve_monorepo_target / "daydream_plans").glob("[0-9][0-9][0-9]-*.md"))
     assert len(plans) == 1
     plan_text = plans[0].read_text(encoding="utf-8")
     assert "X-Internal-Service-Secret: <internalSecret>" in plan_text
@@ -2167,20 +2187,16 @@ async def test_sloppy_but_salvageable_output_is_normalized_and_written(
     stub = install_improve_stub(monkeypatch, improve_monorepo_target)
     stub.plan_sloppy = True
 
-    code = await run(make_config(
+    code = await run(
+        make_config(
         improve_monorepo_target,
         flow_name="improve",
         improve_plan_description="add rate limiting",
-    ))
-
-    plan_calls = [
-        call for call in stub.calls if call["marker"] == "plan-writer"
-    ]
-    plans = list(
-        (improve_monorepo_target / "daydream_plans").glob(
-            "[0-9][0-9][0-9]-*.md"
         )
     )
+
+    plan_calls = [call for call in stub.calls if call["marker"] == "plan-writer"]
+    plans = list((improve_monorepo_target / "daydream_plans").glob("[0-9][0-9][0-9]-*.md"))
     assert code == 0
     assert len(plan_calls) == 1
     assert len(plans) == 1
@@ -2380,16 +2396,16 @@ async def test_injected_skill_availability_drives_routing_without_env(
     target: Path = request.getfixturevalue(target_fixture)
     install_improve_stub(monkeypatch, target, n_findings=0)
 
-    code = await run(make_config(
+    code = await run(
+        make_config(
         target,
         flow_name="improve",
         skill_availability=injected,
-    ))
+        )
+    )
 
     assert code == 0
-    coverage = json.loads(
-        improve_artifact(target, "coverage.json").read_text(encoding="utf-8")
-    )
+    coverage = json.loads(improve_artifact(target, "coverage.json").read_text(encoding="utf-8"))
     # One group per expected stack: no collapse, and no stack split in two.
     assert len(coverage["groups"]) == len(expected_group_stacks)
     assert sorted(group["stack"] for group in coverage["groups"]) == expected_group_stacks
@@ -2405,15 +2421,15 @@ async def test_bad_recon_id_gets_named_feedback_and_retry_succeeds(
     stub.plan_bad_recon_id_attempts = 1
     stub.plan_missing_path_attempts = 1
 
-    code = await run(make_config(
+    code = await run(
+        make_config(
         improve_monorepo_target,
         flow_name="improve",
         improve_plan_description="add rate limiting",
-    ))
+        )
+    )
 
-    plan_calls = [
-        call for call in stub.calls if call["marker"] == "plan-writer"
-    ]
+    plan_calls = [call for call in stub.calls if call["marker"] == "plan-writer"]
     assert code == 0
     assert len(plan_calls) == 2
     repair_prompt = plan_calls[1]["prompt"]
@@ -2459,46 +2475,37 @@ async def test_an_edited_file_left_unquoted_is_repaired_before_the_plan_lands(
     stub = install_improve_stub(monkeypatch, improve_monorepo_target)
     stub.plan_unquoted_path_attempts = 1
 
-    code = await run(make_config(
+    code = await run(
+        make_config(
         improve_monorepo_target,
         flow_name="improve",
         improve_plan_description="add rate limiting",
-    ))
+        )
+    )
 
-    plan_calls = [
-        call for call in stub.calls if call["marker"] == "plan-writer"
-    ]
+    plan_calls = [call for call in stub.calls if call["marker"] == "plan-writer"]
     assert code == 0
     assert len(plan_calls) == 2
     repair_prompt = plan_calls[1]["prompt"]
     assert "EXISTING_PATH_NOT_QUOTED" in repair_prompt
     assert "/scope/existing_paths/0/path" in repair_prompt
     assert "context_excerpts" in repair_prompt
-    plans = list(
-        (improve_monorepo_target / "daydream_plans").glob(
-            "[0-9][0-9][0-9]-*.md"
-        )
-    )
+    plans = list((improve_monorepo_target / "daydream_plans").glob("[0-9][0-9][0-9]-*.md"))
     assert len(plans) == 1
     plan_text = plans[0].read_text(encoding="utf-8")
-    current_state = plan_text.split("## Current state\n\n", 1)[1].split(
-        "\n\n## Commands"
-    )[0]
+    current_state = plan_text.split("## Current state\n\n", 1)[1].split("\n\n## Commands")[0]
     assert "- `apps/billing/api.py:1-2`" in current_state
     assert "def service_name" in current_state
     diagnostics = _load_improve_json(
         improve_monorepo_target,
         "plan-write-diagnostics.json",
     )
-    assert [
-        attempt["disposition"] for attempt in diagnostics["attempts"]
-    ] == ["retried", "success"]
+    assert [attempt["disposition"] for attempt in diagnostics["attempts"]] == ["retried", "success"]
     first_attempt = diagnostics["attempts"][0]
     assert first_attempt["stage"] == "authoring"
-    assert {
-        (error["code"], error["pointer"])
-        for error in first_attempt["errors"]
-    } == {("EXISTING_PATH_NOT_QUOTED", "/scope/existing_paths/0/path")}
+    assert {(error["code"], error["pointer"]) for error in first_attempt["errors"]} == {
+        ("EXISTING_PATH_NOT_QUOTED", "/scope/existing_paths/0/path")
+    }
 
 
 def _out_of_scope_section(plan_text: str) -> str:
@@ -2515,20 +2522,16 @@ async def test_undeclared_stop_condition_path_lands_in_the_out_of_scope_section(
     deleted = "apps/billing/legacy_loader.py"
     stub.plan_stop_condition_path = deleted
 
-    code = await run(make_config(
+    code = await run(
+        make_config(
         improve_monorepo_target,
         flow_name="improve",
         improve_plan_description="add rate limiting",
-    ))
-
-    plan_calls = [
-        call for call in stub.calls if call["marker"] == "plan-writer"
-    ]
-    plans = list(
-        (improve_monorepo_target / "daydream_plans").glob(
-            "[0-9][0-9][0-9]-*.md"
         )
     )
+
+    plan_calls = [call for call in stub.calls if call["marker"] == "plan-writer"]
+    plans = list((improve_monorepo_target / "daydream_plans").glob("[0-9][0-9][0-9]-*.md"))
     assert code == 0
     assert len(plan_calls) == 1
     assert len(plans) == 1
@@ -2571,17 +2574,15 @@ async def test_plan_writer_transient_failure_is_retried_and_the_plan_lands(
     stub = install_improve_stub(monkeypatch, improve_monorepo_target)
     setattr(stub, failure_attr, 1)
 
-    code = await run(make_config(
+    code = await run(
+        make_config(
         improve_monorepo_target,
         flow_name="improve",
         improve_plan_description="add rate limiting",
-    ))
-
-    plans = list(
-        (improve_monorepo_target / "daydream_plans").glob(
-            "[0-9][0-9][0-9]-*.md"
         )
     )
+
+    plans = list((improve_monorepo_target / "daydream_plans").glob("[0-9][0-9][0-9]-*.md"))
     assert code == 0
     assert stub.plan_writer_calls == 2
     assert len(plans) == 1
@@ -2611,11 +2612,13 @@ async def test_persistent_retryable_failure_does_not_restart_the_retry_budget(
     stub.plan_rate_limit_always = True
     stub.retry_attempts = 2
 
-    code = await run(make_config(
+    code = await run(
+        make_config(
         improve_monorepo_target,
         flow_name="improve",
         improve_plan_description="add rate limiting",
-    ))
+        )
+    )
 
     plans_dir = improve_monorepo_target / "daydream_plans"
     assert code == 1
@@ -2634,11 +2637,13 @@ async def test_two_consecutive_transport_crashes_block_the_finding(
     stub = install_improve_stub(monkeypatch, improve_monorepo_target)
     stub.plan_crash_attempts = 2
 
-    code = await run(make_config(
+    code = await run(
+        make_config(
         improve_monorepo_target,
         flow_name="improve",
         improve_plan_description="add rate limiting",
-    ))
+        )
+    )
 
     plans_dir = improve_monorepo_target / "daydream_plans"
     assert code == 1
@@ -2691,7 +2696,6 @@ async def test_every_agent_call_in_every_mode_is_read_only(
 ) -> None:
     configs = (
         make_config(improve_monorepo_target, flow_name="improve"),
-        make_config(improve_monorepo_target, flow_name="improve", improve_focus="next"),
         make_config(improve_monorepo_target, flow_name="improve", improve_plan_description="x"),
     )
     for config in configs:
@@ -2779,6 +2783,23 @@ def test_apply_vet_verdicts_matches_by_vet_id(
     )
     assert {f["fingerprint"] for f in kept} == expected_kept
     assert {f["fingerprint"] for f in rejected} == expected_rejected
+
+
+def test_apply_vet_verdicts_normalizes_schema_severity_for_prioritization() -> None:
+    kept, _ = _apply_vet_verdicts(
+        [_VET_FINDINGS[0]],
+        [
+            {
+                "vet_id": 1,
+                "keep": True,
+                "reason": "confirmed",
+                "severity": "medium",
+            }
+        ],
+        rejected_at_sha="sha",
+    )
+
+    assert kept[0]["severity"] == "MED"
 
 
 def test_apply_vet_verdicts_restamps_a_corrected_location(tmp_path: Path) -> None:
@@ -3002,16 +3023,18 @@ async def test_long_step_instruction_reaches_the_plan_whole(
     assert 1500 < len(instruction) <= 4000
     stub.plan_instruction_override = instruction
 
-    code = await run(make_config(
+    code = await run(
+        make_config(
         improve_monorepo_target,
         flow_name="improve",
         improve_plan_description="add rate limiting",
-    ))
+        )
+    )
 
     assert code == 0
-    plan_text = next(
-        (improve_monorepo_target / "daydream_plans").glob("[0-9][0-9][0-9]-*.md")
-    ).read_text(encoding="utf-8")
+    plan_text = next((improve_monorepo_target / "daydream_plans").glob("[0-9][0-9][0-9]-*.md")).read_text(
+        encoding="utf-8"
+    )
     assert instruction in plan_text
     assert "…" not in plan_text
 
@@ -3026,29 +3049,21 @@ async def test_over_length_instruction_is_repaired_not_silently_truncated(
     stub = install_improve_stub(monkeypatch, improve_monorepo_target)
     stub.plan_instruction_override = "Replace service_name. " + "x" * 4000
 
-    code = await run(make_config(
+    code = await run(
+        make_config(
         improve_monorepo_target,
         flow_name="improve",
         improve_plan_description="add rate limiting",
-    ))
+        )
+    )
 
     assert code == 1
-    diagnostics = json.loads(
-        improve_artifact(improve_monorepo_target, "plan-write-diagnostics.json").read_text()
-    )
-    errors = [
-        error
-        for attempt in diagnostics["attempts"]
-        for error in attempt["errors"]
-    ]
-    assert any(
-        error["pointer"] == "/steps/0/changes/0/instruction" for error in errors
-    ), errors
+    diagnostics = json.loads(improve_artifact(improve_monorepo_target, "plan-write-diagnostics.json").read_text())
+    errors = [error for attempt in diagnostics["attempts"] for error in attempt["errors"]]
+    assert any(error["pointer"] == "/steps/0/changes/0/instruction" for error in errors), errors
     # The plan writer was asked again rather than a mangled plan being written.
     assert stub.plan_writer_calls == 2
-    assert not list(
-        (improve_monorepo_target / "daydream_plans").glob("[0-9][0-9][0-9]-*.md")
-    )
+    assert not list((improve_monorepo_target / "daydream_plans").glob("[0-9][0-9][0-9]-*.md"))
 
 
 @pytest.mark.anyio
@@ -3075,16 +3090,18 @@ async def test_empty_secret_named_assignments_do_not_eat_the_next_line(
         "INTERNAL_SERVICE_SECRET="
     )
 
-    code = await run(make_config(
+    code = await run(
+        make_config(
         improve_monorepo_target,
         flow_name="improve",
         improve_plan_description="repoint dev env secrets",
-    ))
+        )
+    )
 
     assert code == 0
-    plan_text = next(
-        (improve_monorepo_target / "daydream_plans").glob("[0-9][0-9][0-9]-*.md")
-    ).read_text(encoding="utf-8")
+    plan_text = next((improve_monorepo_target / "daydream_plans").glob("[0-9][0-9][0-9]-*.md")).read_text(
+        encoding="utf-8"
+    )
     for key in (
         "CLERK_SECRET_KEY=",
         "CLOUDFLARE_ACCOUNT_ID=",
@@ -3161,13 +3178,12 @@ async def test_rendered_plan_gives_a_literal_executor_no_room_to_guess(
     assert "never `git add -A`" in text
     assert "git add apps/billing/api.py apps/billing/test_api.py" in text
     assert "4. Do not push and do not open a pull request." in text
-    assert "from\n`TODO` to `DONE`" in text or "`TODO` to `DONE`" in text
+    # Issue publication copies the plan without committing the local index, so
+    # an executor must not be told to edit daydream_plans/README.md.
+    assert "`TODO` to `DONE`" not in text
 
     # The two previously unactionable STOP conditions now name the check.
-    assert (
-        "Before editing a file, read the exact line range quoted for it in "
-        "the Current state section" in text
-    )
+    assert "Before editing a file, read the exact line range quoted for it in the Current state section" in text
     assert "two failures total for the same verification" in text
 
 
@@ -3255,3 +3271,336 @@ async def test_plan_writer_is_told_to_leave_the_executor_no_decisions(
         "properties"
     ]["description"]["description"]
     assert "without judgement" in done
+
+
+@pytest.mark.anyio
+async def test_configured_headless_publish_selects_all_and_embeds_local_plans(
+    improve_monorepo_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+) -> None:
+    """Real runner path: configured CI mode writes no branches and files every plan."""
+    install_improve_stub(
+        monkeypatch,
+        improve_monorepo_target,
+        n_findings=len(AUDIT_CATEGORIES),
+    )
+    monkeypatch.setattr(
+        "daydream.git_ops.gh_issue_list_strict",
+        lambda *args, **kwargs: [],
+    )
+    created: list[dict[str, Any]] = []
+
+    def _create_issue(*args: Any, **kwargs: Any) -> str:
+        created.append(dict(kwargs))
+        return f"https://github.com/acme/widgets/issues/{len(created)}"
+
+    monkeypatch.setattr("daydream.git_ops.gh_issue_create", _create_issue)
+    branches_before = git(
+        improve_monorepo_target,
+        "for-each-ref",
+        "--format=%(refname)",
+        "refs/heads",
+    )
+
+    code = await run(
+        make_config(
+            improve_monorepo_target,
+            flow_name="improve",
+            pr_repo="acme/widgets",
+            file_config=DaydreamFileConfig(
+                improve_github_publish_issues=True,
+            ),
+        )
+    )
+
+    assert code == 0
+    selected = _load_improve_json(improve_monorepo_target, "selected.json")
+    vetted = _load_improve_json(
+        improve_monorepo_target,
+        "vetted-findings.json",
+    )
+    assert len(selected["selected"]) == len(vetted["findings"])
+    assert len(selected["selected"]) > 5
+    plan_files = sorted((improve_monorepo_target / "daydream_plans").glob("[0-9][0-9][0-9]-*.md"))
+    assert len(created) == len(plan_files) == len(selected["selected"])
+    assert {str(issue["body"]).partition("\n\n")[2] for issue in created} == {
+        path.read_text(encoding="utf-8") for path in plan_files
+    }
+    assert all(str(issue["body"]).startswith("<!-- daydream-improve: package=") for issue in created)
+    assert (
+        git(
+            improve_monorepo_target,
+            "for-each-ref",
+            "--format=%(refname)",
+            "refs/heads",
+        )
+        == branches_before
+    )
+
+
+@pytest.mark.anyio
+async def test_disabled_publication_overwrites_stale_current_run_artifact(
+    improve_monorepo_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+) -> None:
+    """A disabled run cannot leave an earlier run looking current."""
+    artifact = improve_artifact(
+        improve_monorepo_target,
+        "published-issues.json",
+    )
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.write_text(
+        json.dumps(
+            {
+                "enabled": True,
+                "status": "complete",
+                "published": [{"issue_url": "https://example.test/stale"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    install_improve_stub(monkeypatch, improve_monorepo_target, n_findings=0)
+
+    code = await run(make_config(improve_monorepo_target, flow_name="improve"))
+
+    publication = _load_improve_json(
+        improve_monorepo_target,
+        "published-issues.json",
+    )
+    assert code == 0
+    assert publication["enabled"] is False
+    assert publication["status"] == "disabled"
+    assert publication["published"] == []
+    assert "example.test/stale" not in artifact.read_text(encoding="utf-8")
+
+
+@pytest.mark.anyio
+async def test_configured_publish_records_a_pathless_reconciled_plan(
+    improve_monorepo_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    make_config: MakeConfig,
+) -> None:
+    """An indexed package with no plan file is an explicit hard failure."""
+    install_improve_stub(
+        monkeypatch,
+        improve_monorepo_target,
+        n_findings=1,
+    )
+    first_code = await run(make_config(improve_monorepo_target, flow_name="improve"))
+    plan_path = next((improve_monorepo_target / "daydream_plans").glob("[0-9][0-9][0-9]-*.md"))
+    plan_path.unlink()
+    capsys.readouterr()
+    monkeypatch.setattr(
+        "daydream.git_ops.gh_issue_list_strict",
+        lambda *args, **kwargs: pytest.fail("a pathless package must fail before GitHub reconciliation"),
+    )
+
+    second_code = await run(
+        make_config(
+            improve_monorepo_target,
+            flow_name="improve",
+            pr_repo="acme/widgets",
+            file_config=DaydreamFileConfig(
+                improve_github_publish_issues=True,
+            ),
+        )
+    )
+
+    publication = _load_improve_json(
+        improve_monorepo_target,
+        "published-issues.json",
+    )
+    assert first_code == 0
+    assert second_code == 1
+    assert publication["status"] == "failed"
+    assert publication["published"] == []
+    assert len(publication["failed"]) == 1
+    assert publication["failed"][0]["stage"] == "plan-reconciliation"
+    assert publication["failed"][0]["plan_path"] is None
+    output = capsys.readouterr().out
+    assert "Improve issue publishing failed" in output
+    assert "Improve planning failed" not in output
+
+
+@pytest.mark.anyio
+async def test_reused_plan_publishes_its_stored_package_and_member_identities(
+    improve_monorepo_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+) -> None:
+    """A skipped current finding publishes the complete stored plan identity."""
+    stub = install_improve_stub(
+        monkeypatch,
+        improve_monorepo_target,
+        n_findings=1,
+    )
+    first_code = await run(
+        make_config(improve_monorepo_target, flow_name="improve")
+    )
+    sidecar_path = (
+        improve_monorepo_target / "daydream_plans" / PLAN_INDEX_FILENAME
+    )
+    sidecar = json.loads(sidecar_path.read_text(encoding="utf-8"))
+    stored = sidecar["plans"][0]
+    stored["package_fingerprint"] = "stored-package"
+    # Preserve multiplicity: duplicate semantic aliases tell the publisher it
+    # must reconcile on raw member fingerprints instead.
+    stored["member_aliases"] = ["stored-alias", "stored-alias"]
+    stored_fingerprints = list(stored["member_fingerprints"])
+    sidecar_path.write_text(
+        json.dumps(sidecar, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "daydream.git_ops.gh_issue_list_strict",
+        lambda *args, **kwargs: [],
+    )
+    created: list[dict[str, Any]] = []
+
+    def _create_issue(*args: Any, **kwargs: Any) -> str:
+        created.append(dict(kwargs))
+        return "https://github.com/acme/widgets/issues/1"
+
+    monkeypatch.setattr("daydream.git_ops.gh_issue_create", _create_issue)
+
+    second_code = await run(
+        make_config(
+            improve_monorepo_target,
+            flow_name="improve",
+            pr_repo="acme/widgets",
+            file_config=DaydreamFileConfig(
+                improve_github_publish_issues=True,
+            ),
+        )
+    )
+
+    publication = _load_improve_json(
+        improve_monorepo_target,
+        "published-issues.json",
+    )
+    assert first_code == second_code == 0
+    assert stub.plan_writer_calls == 1
+    assert len(created) == 1
+    body = str(created[0]["body"])
+    assert body.startswith(
+        "<!-- daydream-improve: package=stored-package -->\n"
+        "<!-- daydream-improve-member: alias=stored-alias -->\n"
+    )
+    assert all(
+        f"<!-- daydream-improve-member: fingerprint={fingerprint} -->"
+        in body
+        for fingerprint in stored_fingerprints
+    )
+    assert publication["published"][0]["package_id"] == "stored-package"
+    assert publication["published"][0]["member_aliases"] == [
+        "stored-alias",
+        "stored-alias",
+    ]
+    assert publication["published"][0]["member_fingerprints"] == (
+        stored_fingerprints
+    )
+
+
+@pytest.mark.anyio
+async def test_configured_publish_records_partial_plan_write_failure(
+    improve_monorepo_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+) -> None:
+    """Every selected package remains accounted for when one writer fails."""
+    backend = ProductionPathBackend(
+        improve_monorepo_target,
+        failed_title="Production finding 03",
+    )
+    monkeypatch.setattr(
+        "daydream.runner.create_backend",
+        lambda *args, **kwargs: backend,
+    )
+    monkeypatch.setattr(
+        "daydream.git_ops.gh_issue_list_strict",
+        lambda *args, **kwargs: [],
+    )
+    created: list[str] = []
+
+    def _create_issue(*args: Any, **kwargs: Any) -> str:
+        created.append(str(kwargs["title"]))
+        return "https://github.com/acme/widgets/issues/1"
+
+    monkeypatch.setattr("daydream.git_ops.gh_issue_create", _create_issue)
+
+    code = await run(
+        make_config(
+            improve_monorepo_target,
+            flow_name="improve",
+            pr_repo="acme/widgets",
+            file_config=DaydreamFileConfig(
+                improve_github_publish_issues=True,
+            ),
+        )
+    )
+
+    publication = _load_improve_json(
+        improve_monorepo_target,
+        "published-issues.json",
+    )
+    selected = _load_improve_json(improve_monorepo_target, "selected.json")
+    assert code == 2
+    assert publication["status"] == "partial"
+    assert len(publication["published"]) == len(created) == 1
+    assert len(publication["failed"]) == 1
+    assert publication["failed"][0]["stage"] == "plan-write"
+    assert publication["failed"][0]["plan_path"] is None
+    assert len(publication["published"]) + len(publication["failed"]) == len(selected["selected"])
+
+
+@pytest.mark.anyio
+async def test_publication_only_failure_is_not_reported_as_planning_failure(
+    improve_monorepo_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    make_config: MakeConfig,
+) -> None:
+    install_improve_stub(
+        monkeypatch,
+        improve_monorepo_target,
+        n_findings=1,
+    )
+    monkeypatch.setattr(
+        "daydream.git_ops.gh_issue_list_strict",
+        lambda *args, **kwargs: [],
+    )
+    monkeypatch.setattr(
+        "daydream.git_ops.gh_issue_create",
+        lambda *args, **kwargs: (_ for _ in ()).throw(GitError("offline")),
+    )
+
+    code = await run(
+        make_config(
+            improve_monorepo_target,
+            flow_name="improve",
+            pr_repo="acme/widgets",
+            file_config=DaydreamFileConfig(
+                improve_github_publish_issues=True,
+            ),
+        )
+    )
+
+    publication = _load_improve_json(
+        improve_monorepo_target,
+        "published-issues.json",
+    )
+    output = capsys.readouterr().out
+    report = improve_artifact(
+        improve_monorepo_target,
+        "report.md",
+    ).read_text(encoding="utf-8")
+    assert code == 1
+    assert publication["status"] == "failed"
+    assert publication["published"] == []
+    assert [entry["stage"] for entry in publication["failed"]] == ["issue-create"]
+    assert "Improve issue publishing failed" in output
+    assert "Improve planning failed" not in output
+    assert "GitHub publication failures: 1" in report

--- a/tests/test_improve_plans.py
+++ b/tests/test_improve_plans.py
@@ -29,6 +29,7 @@ from daydream.improve.plans import (
     planned_fingerprints,
     record_rejections,
 )
+from daydream.improve.prioritize import aggregate_cross_service
 from daydream.improve.prompts import (
     PLAN_AUTHOR_SCHEMA,
     build_plan_writer_repair_prompt,
@@ -105,6 +106,9 @@ def _finding(*, fingerprint: str = "fp-fix-n-plus-one") -> dict[str, object]:
         "risk": "MED",
         "confidence": "HIGH",
         "evidence": ["apps/catalog/api.py:1"],
+        "maintenance_signals": [],
+        "change_shape": "unknown",
+        "reuse_target": None,
     }
 
 
@@ -580,6 +584,7 @@ def _authored_plan(*, title: str = "Batch catalog queries") -> dict[str, Any]:
     focused = "tests/test_catalog.py -q"
     return {
         "title": title,
+        "covered_fingerprints": ["fp-fix-n-plus-one"],
         "why_this_matters": {
             "problem": "list_catalog currently loads each catalog item separately.",
             "concrete_cost": "Large catalogs create avoidable query latency per request.",
@@ -654,6 +659,9 @@ def _authored_plan(*, title: str = "Batch catalog queries") -> dict[str, Any]:
             },
         ],
         "test_plan": {
+            "mode": "new-or-updated-tests",
+            "rationale": ("Catalog batching changes runtime behavior and needs a focused regression."),
+            "existing_coverage": [],
             "exemplars": [
                 {
                     "path": "tests/test_catalog.py",
@@ -821,6 +829,9 @@ def test_assembled_plan_renders_complete_deterministic_handoff(repo: Path, head_
     assert "apps/catalog/api.py:1-2" in text
     assert "return [load_item(item_id) for item_id in item_ids]" in text
     assert "**Branch**: improve/batch-catalog-queries" in text
+    assert "**Covered finding fingerprints**: `fp-fix-n-plus-one`" in text
+    assert "Set this plan's Status cell" not in text
+    assert "daydream_plans/README.md" not in text
     assert "TODO" in (repo / "daydream_plans/README.md").read_text()
 
 
@@ -1711,12 +1722,7 @@ def test_valid_linked_plan_is_preserved_for_every_executor_status(
     head_sha: str,
     status: str,
 ) -> None:
-    """A hand-edited Status cell outranks the sidecar and is adopted by it.
-
-    ``render_plan``'s Finishing section tells the executor to set this cell, so
-    the README owns Status; the sidecar owns everything else and converges on
-    the operator's edit rather than overwriting it.
-    """
+    """A hand-edited Status cell outranks the sidecar and is adopted by it."""
     plans_dir = repo / "daydream_plans"
     selection = _selection(repo)
     _write_plans(plans_dir, [selection], planned_at=head_sha)
@@ -2692,11 +2698,12 @@ def test_step_gate_scope_mismatch_falls_back_to_the_repository_wide_command(
     assert "uv run pytest apps/catalog" not in step_section
     assert (
         "**Why this gate**: Retargeted by the host: the command this plan "
-        "named is verified only for paths this plan does not change, so this "
+        "named does not cover this verification's targets, so this "
         "repository-wide command runs instead." in step_section
     )
-    # The test case's own gate fits the plan's scope, so it is left alone.
-    assert "`uv run pytest apps/catalog`" in rendered
+    # The named test case targets tests/test_catalog.py, so its mismatched gate
+    # is retargeted independently too.
+    assert "`uv run pytest apps/catalog`" not in rendered
 
 
 def test_command_scope_mismatch_without_a_repo_wide_command_renders_a_caveat(
@@ -2727,10 +2734,10 @@ def test_command_scope_mismatch_without_a_repo_wide_command_renders_a_caveat(
     assert "**Command**: `uv run pytest apps/billing`" in rendered
     assert (
         "**Why this gate**: Scope caveat from the host: this command's "
-        "verified applicability does not cover every path this plan changes, "
-        "and no verified command that covers them is available here. Run it as "
-        "written and report what it reports; do not substitute a command of "
-        "your own." in rendered
+        "verified applicability does not cover every target of this "
+        "verification, and no verified command that covers them is available "
+        "here. Run it as written and report what it reports; do not substitute "
+        "a command of your own." in rendered
     )
 
 
@@ -2768,9 +2775,9 @@ def test_scope_mismatched_ref_with_appended_args_keeps_its_command(
     assert (
         "**Why this gate**: Runs the focused catalog regression. Scope caveat "
         "from the host: this command's verified applicability does not cover "
-        "every path this plan changes, and no verified command that covers them "
-        "is available here. Run it as written and report what it reports; do "
-        "not substitute a command of your own." in rendered
+        "every target of this verification, and no verified command that "
+        "covers them is available here. Run it as written and report what it "
+        "reports; do not substitute a command of your own." in rendered
     )
 
 
@@ -2780,14 +2787,11 @@ def test_hallucinated_recon_command_still_blocks_the_plan(repo: Path) -> None:
 
     issues = _issues(repo, plan)
 
-    assert [render_issue(issue) for issue in issues] == [
-        "RECON_COMMAND_UNKNOWN@/steps/0/verification/recon_command_id"
-    ]
+    assert [render_issue(issue) for issue in issues] == ["RECON_COMMAND_UNKNOWN@/steps/0/verification/recon_command_id"]
 
 
-def test_duplicate_test_symbols_are_numbered_and_both_cases_survive(
+def test_duplicate_test_symbols_require_parametrization_or_meaningful_names(
     repo: Path,
-    head_sha: str,
 ) -> None:
     plan = _authored_plan()
     duplicate = deepcopy(plan["test_plan"]["cases"][0])
@@ -2796,14 +2800,47 @@ def test_duplicate_test_symbols_are_numbered_and_both_cases_survive(
     third["name"] = "Catalog loading tolerates an empty catalog"
     plan["test_plan"]["cases"].extend([duplicate, third])
 
+    issues = _issues(repo, plan)
+
+    assert [render_issue(issue) for issue in issues] == [
+        "DUPLICATE_TEST_SYMBOL@/test_plan/cases/1/test_symbol",
+        "DUPLICATE_TEST_SYMBOL@/test_plan/cases/2/test_symbol",
+    ]
+    assert all(issue.hint is not None and "parameterized test" in issue.hint for issue in issues)
+
+
+def _use_existing_catalog_coverage(plan: dict[str, Any]) -> None:
+    plan["scope"]["existing_paths"] = [plan["scope"]["existing_paths"][0]]
+    plan["context_excerpts"] = [plan["context_excerpts"][0]]
+    plan["steps"][0]["changes"] = [plan["steps"][0]["changes"][0]]
+    plan["test_plan"] = {
+        "mode": "existing-coverage",
+        "rationale": ("The existing catalog regression already observes the preserved result."),
+        "existing_coverage": [
+            {
+                "path": "tests/test_catalog.py",
+                "symbol": "test_list_catalog_returns_items",
+                "behavior": ("The public catalog query still returns the expected item list."),
+                "verification": _ref(appended_args="tests/test_catalog.py -q"),
+            }
+        ],
+        "exemplars": [],
+        "cases": [],
+    }
+
+
+def test_existing_coverage_mode_keeps_test_evidence_read_only(
+    repo: Path,
+    head_sha: str,
+) -> None:
+    plan = _authored_plan()
+    _use_existing_catalog_coverage(plan)
     assembled = _assembled(repo, plan)
 
-    symbol = "test_list_catalog_batches_item_loading"
-    assert [case["test_symbol"] for case in assembled["test_plan"]["cases"]] == [
-        symbol,
-        f"{symbol}_2",
-        f"{symbol}_3",
-    ]
+    assert [entry["path"] for entry in assembled["scope"]["existing_paths"]] == ["apps/catalog/api.py"]
+    assert assembled["done_criteria"][-2]["description"] == (
+        "The cited existing coverage passes: test_list_catalog_returns_items."
+    )
     rendered = render_plan(
         _finding(),
         plan=assembled,
@@ -2811,15 +2848,352 @@ def test_duplicate_test_symbols_are_numbered_and_both_cases_survive(
         planned_on=date(2024, 1, 1),
         number=1,
     )
-    assert f"`tests/test_catalog.py::{symbol}` (unit)" in rendered
-    assert f"`tests/test_catalog.py::{symbol}_2` (unit)" in rendered
-    assert f"`tests/test_catalog.py::{symbol}_3` (unit)" in rendered
-    assert "**Catalog loading preserves item order**" in rendered
-    assert "**Catalog loading tolerates an empty catalog**" in rendered
-    assert (
-        f"Every named test-plan case passes: {symbol}, {symbol}_2, "
-        f"{symbol}_3."
-    ) in rendered
+    assert "**Mode**: `existing-coverage`" in rendered
+    assert "### Existing coverage" in rendered
+    assert "`tests/test_catalog.py::test_list_catalog_returns_items`" in rendered
+    assert "### Named cases" not in rendered
+
+
+def test_existing_coverage_command_is_scoped_to_read_only_test_evidence(
+    repo: Path,
+    head_sha: str,
+) -> None:
+    plan = _authored_plan()
+    _use_existing_catalog_coverage(plan)
+    plan["test_plan"]["existing_coverage"][0]["verification"] = _ref("catalog-test-only")
+    commands = [
+        *_recon_commands(),
+        _scoped_recon_command(
+            "catalog-test-only",
+            command="uv run pytest tests/test_catalog.py",
+            paths=["tests/test_catalog.py"],
+        ),
+    ]
+
+    assembled = _assembled(repo, plan, commands=commands)
+
+    assert [entry["path"] for entry in assembled["scope"]["existing_paths"]] == ["apps/catalog/api.py"]
+    coverage = assembled["test_plan"]["existing_coverage"][0]
+    assert coverage["verification"]["command"] == ("uv run pytest tests/test_catalog.py")
+    rendered = render_plan(
+        _finding(),
+        plan=assembled,
+        planned_at=head_sha,
+        planned_on=date(2024, 1, 1),
+        number=1,
+    )
+    assert "`uv run pytest tests/test_catalog.py`" in rendered
+    assert "Retargeted by the host" not in rendered.partition("### Existing coverage")[2]
+
+
+@pytest.mark.parametrize(
+    "replacement",
+    [
+        "def test_list_catalog_returns_items_extra():\n    assert list_catalog()\n",
+        "# def test_list_catalog_returns_items():\nVALUE = 1\n",
+        'DESCRIPTION = "def test_list_catalog_returns_items():"\n',
+    ],
+    ids=("longer-symbol", "comment", "string"),
+)
+def test_existing_coverage_requires_an_exact_test_declaration(
+    repo: Path,
+    replacement: str,
+) -> None:
+    (repo / "tests/test_catalog.py").write_text(replacement, encoding="utf-8")
+    plan = _authored_plan()
+    _use_existing_catalog_coverage(plan)
+
+    issues = _issues(repo, plan)
+
+    assert [render_issue(issue) for issue in issues] == ["EXISTING_COVERAGE_INVALID@/test_plan/existing_coverage/0"]
+
+
+@pytest.mark.parametrize(
+    ("path", "symbol", "source"),
+    [
+        (
+            "apps/catalog/api.py",
+            "list_catalog",
+            "def list_catalog():\n    return []\n",
+        ),
+        (
+            "tests/test_catalog.py",
+            "catalog_helper",
+            "def catalog_helper():\n    return []\n",
+        ),
+    ],
+    ids=("source-function", "test-helper"),
+)
+def test_existing_coverage_rejects_non_test_python_functions(
+    repo: Path,
+    path: str,
+    symbol: str,
+    source: str,
+) -> None:
+    (repo / path).write_text(source, encoding="utf-8")
+    plan = _authored_plan()
+    _use_existing_catalog_coverage(plan)
+    plan["test_plan"]["existing_coverage"][0].update(path=path, symbol=symbol)
+
+    issues = _issues(repo, plan)
+
+    assert [render_issue(issue) for issue in issues] == ["EXISTING_COVERAGE_INVALID@/test_plan/existing_coverage/0"]
+
+
+def test_deletion_only_plan_can_omit_test_code_when_non_behavioral(
+    repo: Path,
+    head_sha: str,
+) -> None:
+    plan = _authored_plan(title="Delete obsolete catalog documentation")
+    plan["scope"]["existing_paths"] = [
+        {
+            "path": "README.md",
+            "role": "Delete obsolete catalog documentation.",
+        }
+    ]
+    plan["scope"]["new_paths"] = []
+    plan["scope"]["out_of_scope_paths"] = [
+        {
+            "path": "apps/catalog",
+            "reason": "Deleting obsolete documentation does not change runtime code.",
+        }
+    ]
+    plan["context_excerpts"] = [
+        {
+            "path": "README.md",
+            "start_line": 1,
+            "end_line": 1,
+            "file_role": "Delete obsolete catalog documentation.",
+        }
+    ]
+    plan["steps"] = [
+        {
+            "title": "Delete the obsolete catalog documentation",
+            "changes": [
+                {
+                    "path": "README.md",
+                    "symbol": "README.md",
+                    "operation": "delete",
+                    "instruction": (
+                        "Delete README.md because its obsolete catalog notes are "
+                        "superseded by the maintained documentation site."
+                    ),
+                    "target_state": ("The repository no longer contains the README.md path."),
+                }
+            ],
+            "verification": None,
+        }
+    ]
+    plan["test_plan"] = {
+        "mode": "not-applicable",
+        "rationale": ("This removes documentation and does not alter supported behavior."),
+        "existing_coverage": [],
+        "exemplars": [],
+        "cases": [],
+    }
+    plan["done_criteria"] = [
+        {
+            "kind": "static-invariant",
+            "description": "The repository no longer contains the README.md path.",
+            "verification": None,
+        }
+    ]
+    plan["false_assumption"]["related_paths"] = ["README.md"]
+
+    assembled = _assembled(repo, plan)
+
+    assert all(criterion["kind"] != "test-gate" for criterion in assembled["done_criteria"])
+    rendered = render_plan(
+        _finding(),
+        plan=assembled,
+        planned_at=head_sha,
+        planned_on=date(2024, 1, 1),
+        number=1,
+    )
+    assert "**Mode**: `not-applicable`" in rendered
+    assert "No test-code change is required" in rendered
+    assert "(delete):" in rendered
+    assert "**Deletion check**: confirm `README.md` no longer exists" in rendered
+    assert "(static-invariant)**: The repository no longer contains the README.md path." in rendered
+    assert "### Named cases" not in rendered
+
+
+def test_not_applicable_rejects_behavior_bearing_production_deletion(
+    repo: Path,
+) -> None:
+    plan = _authored_plan(title="Delete obsolete catalog implementation")
+    plan["scope"]["existing_paths"] = [plan["scope"]["existing_paths"][0]]
+    plan["context_excerpts"] = [plan["context_excerpts"][0]]
+    plan["steps"][0]["changes"] = [
+        {
+            "path": "apps/catalog/api.py",
+            "symbol": "apps/catalog/api.py",
+            "operation": "delete",
+            "instruction": (
+                "Delete apps/catalog/api.py because the implementation is believed to be unused by supported callers."
+            ),
+            "target_state": ("The repository no longer contains apps/catalog/api.py."),
+        }
+    ]
+    plan["test_plan"] = {
+        "mode": "not-applicable",
+        "rationale": "The implementation is believed to be dead production code.",
+        "existing_coverage": [],
+        "exemplars": [],
+        "cases": [],
+    }
+    plan["done_criteria"] = [
+        {
+            "kind": "static-invariant",
+            "description": "apps/catalog/api.py is absent from the repository.",
+            "verification": None,
+        }
+    ]
+
+    issues = _issues(repo, plan)
+
+    assert [render_issue(issue) for issue in issues] == ["TEST_PLAN_NOT_APPLICABLE_UNSAFE@/steps/0/changes/0/operation"]
+
+
+def _comment_cleanup_plan(
+    *,
+    instruction: str,
+    target_state: str,
+) -> dict[str, Any]:
+    plan = _authored_plan(title="Remove a self evident catalog comment")
+    plan["scope"]["existing_paths"] = [plan["scope"]["existing_paths"][0]]
+    plan["context_excerpts"] = [plan["context_excerpts"][0]]
+    plan["steps"][0]["changes"] = [
+        {
+            "path": "apps/catalog/api.py",
+            "symbol": "comment above list_catalog",
+            "operation": "modify",
+            "instruction": instruction,
+            "target_state": target_state,
+        }
+    ]
+    plan["test_plan"] = {
+        "mode": "not-applicable",
+        "rationale": "Removing this comment cannot change executable behavior.",
+        "existing_coverage": [],
+        "exemplars": [],
+        "cases": [],
+    }
+    plan["done_criteria"] = [
+        {
+            "kind": "static-invariant",
+            "description": target_state,
+            "verification": None,
+        }
+    ]
+    return plan
+
+
+def test_not_applicable_requires_an_explicit_non_test_done_gate(repo: Path) -> None:
+    plan = _comment_cleanup_plan(
+        instruction=("Remove the self-evident comment above list_catalog without changing the function body."),
+        target_state=("The self-evident comment is absent and list_catalog is unchanged."),
+    )
+    plan["done_criteria"] = [
+        {
+            "kind": "behavior",
+            "description": "The list_catalog function body remains byte-for-byte unchanged.",
+            "verification": None,
+        }
+    ]
+
+    issues = _issues(repo, plan)
+
+    assert [render_issue(issue) for issue in issues] == ["NON_TEST_VERIFICATION_REQUIRED@/done_criteria"]
+
+
+def test_not_applicable_allows_shortening_a_comment_without_code_changes(
+    repo: Path,
+) -> None:
+    target_state = "The catalog comment is shorter while the function body remains unchanged."
+    plan = _comment_cleanup_plan(
+        instruction=(
+            "Shorten the catalog comment to retain only its non-obvious rationale without editing executable code."
+        ),
+        target_state=target_state,
+    )
+
+    assembled = _assembled(repo, plan)
+
+    assert assembled["test_plan"]["mode"] == "not-applicable"
+    assert any(
+        criterion["kind"] == "static-invariant" and criterion["description"] == target_state
+        for criterion in assembled["done_criteria"]
+    )
+
+
+def test_deletion_only_production_plan_can_use_existing_coverage(
+    repo: Path,
+) -> None:
+    plan = _authored_plan(title="Delete obsolete catalog implementation")
+    _use_existing_catalog_coverage(plan)
+    plan["steps"][0]["changes"] = [
+        {
+            "path": "apps/catalog/api.py",
+            "symbol": "legacy_catalog_loader",
+            "operation": "delete",
+            "instruction": (
+                "Delete legacy_catalog_loader while preserving list_catalog and its existing public return behavior."
+            ),
+            "target_state": ("legacy_catalog_loader is absent and list_catalog remains present."),
+        }
+    ]
+
+    assembled = _assembled(repo, plan)
+
+    assert assembled["test_plan"]["mode"] == "existing-coverage"
+    assert all(change["operation"] == "delete" for change in assembled["steps"][0]["changes"])
+    assert any(
+        criterion["kind"] == "static-invariant" and "legacy_catalog_loader" in criterion["description"]
+        for criterion in assembled["done_criteria"]
+    )
+
+
+def test_plan_must_cover_every_expected_aggregate_fingerprint(
+    repo: Path,
+    head_sha: str,
+) -> None:
+    plan = _authored_plan()
+
+    assembled, issues = assemble_plan(
+        plan,
+        repo=repo,
+        recon_commands=_recon_commands(),
+        expected_fingerprints=["fp-fix-n-plus-one", "fp-repeated-tests"],
+    )
+
+    assert assembled is None
+    assert [render_issue(issue) for issue in issues] == [
+        "COVERED_FINGERPRINTS_MISMATCH@/covered_fingerprints#missing=1;extra=0"
+    ]
+
+    plan["covered_fingerprints"].append("fp-repeated-tests")
+    assembled, issues = assemble_plan(
+        plan,
+        repo=repo,
+        recon_commands=_recon_commands(),
+        expected_fingerprints=["fp-repeated-tests", "fp-fix-n-plus-one"],
+    )
+    assert issues == ()
+    assert assembled is not None
+    assert set(assembled["covered_fingerprints"]) == {
+        "fp-fix-n-plus-one",
+        "fp-repeated-tests",
+    }
+    assert "Order is not significant" in PLAN_AUTHOR_SCHEMA["properties"]["covered_fingerprints"]["description"]
+    rendered = render_plan(
+        _finding(),
+        plan=assembled,
+        planned_at=head_sha,
+        planned_on=date(2024, 1, 1),
+        number=1,
+    )
+    assert "**Covered finding fingerprints**: `fp-fix-n-plus-one`, `fp-repeated-tests`" in rendered
 
 
 @pytest.mark.parametrize(
@@ -3176,3 +3550,335 @@ def test_repair_prompt_drops_malformed_detail_segment() -> None:
     assert "/x" in prompt
     assert "bad,stuff!" not in prompt
     assert '"detail"' not in prompt
+
+
+def test_plan_index_persists_package_aliases_and_maintenance_metadata(
+    repo: Path,
+    head_sha: str,
+) -> None:
+    plans_dir = repo / "daydream_plans"
+    finding = _finding(fingerprint="pkg-parser-cleanup")
+    finding.update(
+        {
+            "package_fingerprint": "pkg-parser-cleanup",
+            "member_fingerprints": ["fp-local-parser", "fp-parser-tests"],
+            "member_aliases": ["member-v1:local", "member-v1:tests"],
+            "maintenance_signals": ["dead_code", "reuse_existing"],
+            "change_shape": "reuse",
+            "reuse_target": "repo:src/http.py#parse_headers",
+        }
+    )
+
+    _write_plans(
+        plans_dir,
+        [{"finding": finding, **_assembled(repo)}],
+        planned_at=head_sha,
+    )
+
+    sidecar = json.loads((plans_dir / PLAN_INDEX_FILENAME).read_text(encoding="utf-8"))
+    entry = sidecar["plans"][0]
+    assert entry["package_fingerprint"] == "pkg-parser-cleanup"
+    assert entry["member_fingerprints"] == [
+        "fp-local-parser",
+        "fp-parser-tests",
+    ]
+    assert entry["member_aliases"] == ["member-v1:local", "member-v1:tests"]
+    assert entry["maintenance_signals"] == ["dead_code", "reuse_existing"]
+    assert entry["change_shape"] == "reuse"
+    assert entry["reuse_target"] == "repo:src/http.py#parse_headers"
+    assert planned_fingerprints(plans_dir) == {
+        "pkg-parser-cleanup",
+        "fp-local-parser",
+        "fp-parser-tests",
+        "member-v1:local",
+        "member-v1:tests",
+    }
+
+
+def test_partial_member_overlap_does_not_suppress_uncovered_work(
+    repo: Path,
+    head_sha: str,
+) -> None:
+    plans_dir = repo / "daydream_plans"
+    original = _finding(fingerprint="pkg-original")
+    original.update(
+        {
+            "package_fingerprint": "pkg-original",
+            "member_fingerprints": ["fp-shared", "fp-original-only"],
+        }
+    )
+    _write_plans(
+        plans_dir,
+        [{"finding": original, **_assembled(repo)}],
+        planned_at=head_sha,
+    )
+    repackaged = _finding(fingerprint="pkg-expanded")
+    repackaged.update(
+        {
+            "package_fingerprint": "pkg-expanded",
+            "member_fingerprints": ["fp-shared", "fp-new-member"],
+        }
+    )
+
+    result = _write_plans(
+        plans_dir,
+        [{"finding": repackaged, **_assembled(repo)}],
+        planned_at=head_sha,
+    )
+
+    assert result["skipped"] == []
+    assert result["written"][0]["number"] == 2
+    assert result["written"][0]["path"] == "002-batch-catalog-queries.md"
+    assert len(list(plans_dir.glob("[0-9][0-9][0-9]-*.md"))) == 2
+
+
+def test_stable_member_alias_reuses_complete_plan_with_stored_package_id(
+    repo: Path,
+    head_sha: str,
+) -> None:
+    plans_dir = repo / "daydream_plans"
+    original = _finding(fingerprint="pkg-original")
+    original.update(
+        {
+            "package_fingerprint": "pkg-original",
+            "member_fingerprints": ["fp-old-wording"],
+            "member_aliases": ["member-v1:stable-concern"],
+        }
+    )
+    _write_plans(
+        plans_dir,
+        [{"finding": original, **_assembled(repo)}],
+        planned_at=head_sha,
+    )
+    reworded = _finding(fingerprint="pkg-current")
+    reworded.update(
+        {
+            "package_fingerprint": "pkg-current",
+            "member_fingerprints": ["fp-new-wording"],
+            "member_aliases": ["member-v1:stable-concern"],
+        }
+    )
+
+    result = _write_plans(
+        plans_dir,
+        [{"finding": reworded, **_assembled(repo)}],
+        planned_at=head_sha,
+    )
+
+    assert result["written"] == []
+    assert result["skipped"][0]["number"] == 1
+    assert result["skipped"][0]["path"] == "001-batch-catalog-queries.md"
+    assert result["skipped"][0]["package_fingerprint"] == "pkg-original"
+    assert result["skipped"][0]["member_fingerprints"] == ["fp-old-wording"]
+    assert result["skipped"][0]["member_aliases"] == ["member-v1:stable-concern"]
+    assert result["skipped"][0]["finding"]["package_fingerprint"] == "pkg-current"
+
+
+def test_colliding_semantic_alias_cannot_cover_two_distinct_current_members(
+    repo: Path,
+    head_sha: str,
+) -> None:
+    plans_dir = repo / "daydream_plans"
+    first = _finding(fingerprint="fp-first")
+    first.update(
+        {
+            "title": "Repeated catalog fixture setup obscures behavior",
+            "category": "tests",
+            "line": 1,
+            "maintenance_signals": ["duplicated_test_structure"],
+            "reuse_target": "repo:catalog_fixture",
+        }
+    )
+    second = _finding(fingerprint="fp-second")
+    second.update(
+        {
+            "title": "Catalog fixture setup repeats in every test",
+            "category": "tests",
+            "line": 1,
+            "maintenance_signals": ["duplicated_test_structure"],
+            "reuse_target": "repo:catalog_fixture",
+        }
+    )
+    original = aggregate_cross_service([first])[0]
+    _write_plans(
+        plans_dir,
+        [{"finding": original, **_assembled(repo)}],
+        planned_at=head_sha,
+    )
+    expanded = aggregate_cross_service([first, second])[0]
+
+    assert expanded["member_aliases"] == [
+        original["member_aliases"][0],
+        original["member_aliases"][0],
+    ]
+
+    result = _write_plans(
+        plans_dir,
+        [{"finding": expanded, **_assembled(repo)}],
+        planned_at=head_sha,
+    )
+
+    assert result["skipped"] == []
+    assert result["written"][0]["number"] == 2
+
+
+def test_legacy_singleton_index_entry_recovers_as_its_own_package(
+    repo: Path,
+    head_sha: str,
+) -> None:
+    plans_dir = repo / "daydream_plans"
+    _write_plans(plans_dir, [_selection(repo)], planned_at=head_sha)
+    sidecar_path = plans_dir / PLAN_INDEX_FILENAME
+    sidecar = json.loads(sidecar_path.read_text(encoding="utf-8"))
+    for key in (
+        "package_fingerprint",
+        "member_fingerprints",
+        "member_aliases",
+        "maintenance_signals",
+        "change_shape",
+        "reuse_target",
+    ):
+        sidecar["plans"][0].pop(key)
+    sidecar_path.write_text(json.dumps(sidecar), encoding="utf-8")
+
+    assert planned_fingerprints(plans_dir) == {"fp-fix-n-plus-one"}
+    result = _write_plans(
+        plans_dir,
+        [_selection(repo)],
+        planned_at=head_sha,
+    )
+    assert result["written"] == []
+    assert result["skipped"][0]["path"] == "001-batch-catalog-queries.md"
+
+
+def test_ambiguous_partial_member_overlap_is_planned_instead_of_suppressed(
+    repo: Path,
+    head_sha: str,
+) -> None:
+    plans_dir = repo / "daydream_plans"
+
+    def _package(package: str, unique_member: str) -> dict[str, Any]:
+        finding = _finding(fingerprint=package)
+        finding.update(
+            {
+                "package_fingerprint": package,
+                "member_fingerprints": ["fp-shared", unique_member],
+            }
+        )
+        return {"finding": finding, **_assembled(repo)}
+
+    _write_plans(
+        plans_dir,
+        [_package("pkg-first", "fp-first"), _package("pkg-second", "fp-second")],
+        planned_at=head_sha,
+    )
+
+    result = _write_plans(
+        plans_dir,
+        [_package("pkg-third", "fp-third")],
+        planned_at=head_sha,
+    )
+
+    assert result["skipped"] == []
+    assert result["written"][0]["number"] == 3
+
+
+def test_split_durable_coverage_suppresses_without_stale_plan_path(
+    repo: Path,
+    head_sha: str,
+) -> None:
+    plans_dir = repo / "daydream_plans"
+
+    def _package(package: str, member: str) -> dict[str, Any]:
+        finding = _finding(fingerprint=package)
+        finding.update(
+            {
+                "package_fingerprint": package,
+                "member_fingerprints": [member],
+            }
+        )
+        return {"finding": finding, **_assembled(repo)}
+
+    _write_plans(
+        plans_dir,
+        [_package("pkg-first", "fp-first"), _package("pkg-second", "fp-second")],
+        planned_at=head_sha,
+    )
+    combined = _finding(fingerprint="pkg-combined")
+    combined.update(
+        {
+            "package_fingerprint": "pkg-combined",
+            "member_fingerprints": ["fp-first", "fp-second"],
+        }
+    )
+
+    result = _write_plans(
+        plans_dir,
+        [{"finding": combined, **_assembled(repo)}],
+        planned_at=head_sha,
+    )
+
+    assert result["written"] == []
+    assert len(result["skipped"]) == 1
+    assert "number" not in result["skipped"][0]
+    assert "path" not in result["skipped"][0]
+    assert "package_fingerprint" not in result["skipped"][0]
+
+
+def test_partial_rejection_does_not_suppress_uncovered_package_member(
+    repo: Path,
+    head_sha: str,
+) -> None:
+    plans_dir = repo / "daydream_plans"
+    record_rejections(
+        plans_dir,
+        [{"fingerprint": "fp-rejected", "title": "Rejected member"}],
+    )
+    finding = _finding(fingerprint="pkg-current")
+    finding.update(
+        {
+            "package_fingerprint": "pkg-current",
+            "member_fingerprints": ["fp-rejected", "fp-new"],
+        }
+    )
+
+    result = _write_plans(
+        plans_dir,
+        [{"finding": finding, **_assembled(repo)}],
+        planned_at=head_sha,
+    )
+
+    assert result["skipped"] == []
+    assert len(result["written"]) == 1
+
+
+def test_all_rejected_members_suppress_package_without_plan_identity(
+    repo: Path,
+    head_sha: str,
+) -> None:
+    plans_dir = repo / "daydream_plans"
+    record_rejections(
+        plans_dir,
+        [
+            {"fingerprint": "fp-first", "title": "First rejected member"},
+            {"fingerprint": "fp-second", "title": "Second rejected member"},
+        ],
+    )
+    finding = _finding(fingerprint="pkg-current")
+    finding.update(
+        {
+            "package_fingerprint": "pkg-current",
+            "member_fingerprints": ["fp-first", "fp-second"],
+        }
+    )
+
+    result = _write_plans(
+        plans_dir,
+        [{"finding": finding, **_assembled(repo)}],
+        planned_at=head_sha,
+    )
+
+    assert result["written"] == []
+    assert len(result["skipped"]) == 1
+    assert "number" not in result["skipped"][0]
+    assert "path" not in result["skipped"][0]

--- a/tests/test_improve_prioritize.py
+++ b/tests/test_improve_prioritize.py
@@ -8,13 +8,11 @@ from daydream.improve.prioritize import (
     aggregate_cross_service,
     leverage_score,
     order_by_leverage,
-    partition_direction,
 )
 
 
 def _f(**overrides: Any) -> dict[str, Any]:
     finding = {
-        "fingerprint": "0" * 64,
         "path": "src/example.py",
         "line": 1,
         "placement": "inline",
@@ -32,6 +30,8 @@ def _f(**overrides: Any) -> dict[str, Any]:
         "provenance": "inherited",
     }
     finding.update(overrides)
+    if "fingerprint" not in overrides:
+        finding["fingerprint"] = f"{finding['path']}::{finding['title']}"
     if "evidence" not in overrides:
         finding["evidence"] = [f"{finding['path']}:{finding['line']}"]
     return finding
@@ -50,18 +50,24 @@ def test_high_confidence_security_floats_above_equal_leverage() -> None:
     assert order_by_leverage([bug, sec])[0] is sec
 
 
-def test_direction_findings_partition_separately() -> None:
-    defects, direction = partition_direction(
-        [_f(category="direction"), _f(category="correctness")]
-    )
-    assert [f["category"] for f in defects] == ["correctness"]
-    assert [f["category"] for f in direction] == ["direction"]
-
-
 def test_equal_leverage_same_category_preserves_input_order() -> None:
     first = _f(title="First")
     second = _f(title="Second")
     assert order_by_leverage([first, second]) == [first, second]
+
+
+def test_equal_leverage_prefers_subtractive_change_shape() -> None:
+    additive = _f(title="Add an adapter", change_shape="additive")
+    consolidate = _f(title="Consolidate adapters", change_shape="consolidate")
+    reuse = _f(title="Reuse the shared adapter", change_shape="reuse")
+    delete = _f(title="Delete the redundant adapter", change_shape="delete")
+
+    assert order_by_leverage([additive, consolidate, reuse, delete]) == [
+        delete,
+        reuse,
+        consolidate,
+        additive,
+    ]
 
 
 def test_same_pattern_across_services_aggregates_to_one_finding() -> None:
@@ -115,7 +121,7 @@ def test_cross_partition_findings_merge_like_cross_service() -> None:
     assert "frontend/src/beta" in merged[0]["body"]
 
 
-def test_same_partition_findings_never_merge() -> None:
+def test_shared_partition_alone_does_not_merge() -> None:
     a = _f(
         title="Unbounded query in the list endpoint",
         path="frontend/src/alpha/list.tsx",
@@ -123,7 +129,7 @@ def test_same_partition_findings_never_merge() -> None:
         partition="frontend/src/alpha",
     )
     b = _f(
-        title="Unbounded query in the list endpoint",
+        title="Unbounded query in the detail endpoint",
         path="frontend/src/alpha/table.tsx",
         services=[],
         partition="frontend/src/alpha",
@@ -148,3 +154,255 @@ def test_service_and_partition_stamps_compose() -> None:
     assert len(merged) == 1
     assert set(merged[0]["services"]) == {"billing", "catalog"}
     assert set(merged[0]["partitions"]) == {"billing", "catalog"}
+
+
+def test_reworded_duplicates_at_the_same_path_become_one_package() -> None:
+    first = _f(
+        fingerprint="fp-first",
+        title="Repeated catalog fixture setup obscures behavior",
+        path="tests/test_catalog.py",
+        category="tests",
+    )
+    second = _f(
+        fingerprint="fp-second",
+        title="Catalog fixture setup is repeated in every test",
+        path="tests/test_catalog.py",
+        category="tests",
+    )
+
+    packages = aggregate_cross_service([first, second])
+
+    assert len(packages) == 1
+    assert packages[0]["member_fingerprints"] == ["fp-first", "fp-second"]
+    assert len(packages[0]["members"]) == 2
+    assert packages[0]["fingerprint"] == packages[0]["package_fingerprint"]
+
+
+def test_rewording_does_not_change_semantic_singleton_package_identity() -> None:
+    before = _f(
+        fingerprint="volatile-before",
+        title="Repeated catalog test setup should use the shared fixture",
+        path="tests/test_catalog.py",
+        category="tests",
+        maintenance_signals=["duplicated_test_structure"],
+        reuse_target="repo:tests/conftest.py#catalog_fixture",
+    )
+    after = _f(
+        fingerprint="volatile-after",
+        title="Consolidate duplicated setup in catalog tests",
+        path="tests/test_catalog.py",
+        category="tests",
+        maintenance_signals=["duplicated_test_structure"],
+        reuse_target="repo:tests/conftest.py#catalog_fixture",
+    )
+
+    before_package = aggregate_cross_service([before])[0]
+    after_package = aggregate_cross_service([after])[0]
+
+    assert before_package["package_fingerprint"] == after_package["package_fingerprint"]
+    assert before_package["member_fingerprints"] == ["volatile-before"]
+    assert after_package["member_fingerprints"] == ["volatile-after"]
+
+
+def test_canonical_reuse_target_is_a_strong_cross_category_grouping_key() -> None:
+    local_parser = _f(
+        fingerprint="fp-parser",
+        title="Remove the local header parser",
+        path="src/api/headers.py",
+        category="tech-debt",
+        impact="LOW",
+        effort="S",
+        risk="LOW",
+        confidence="HIGH",
+        maintenance_signals=["reuse_existing", "dead_code"],
+        change_shape="delete",
+        reuse_target="repo:src/http.py#parse_headers",
+    )
+    duplicated_tests = _f(
+        fingerprint="fp-tests",
+        title="Drive header cases through the shared parser",
+        path="tests/test_headers.py",
+        category="tests",
+        impact="HIGH",
+        effort="L",
+        risk="HIGH",
+        confidence="LOW",
+        maintenance_signals=["reuse_existing", "duplicated_test_structure"],
+        change_shape="additive",
+        reuse_target="repo:src/http.py#parse_headers",
+    )
+
+    packages = aggregate_cross_service([duplicated_tests, local_parser])
+
+    assert len(packages) == 1
+    package = packages[0]
+    assert package["categories"] == ["tech-debt", "tests"]
+    assert package["maintenance_signals"] == [
+        "dead_code",
+        "duplicated_test_structure",
+        "reuse_existing",
+    ]
+    assert package["reuse_target"] == "repo:src/http.py#parse_headers"
+    assert package["change_shape"] == "additive"
+    assert (package["impact"], package["effort"]) == ("HIGH", "L")
+    assert (package["risk"], package["confidence"]) == ("HIGH", "LOW")
+    assert package["locations"] == [
+        "src/api/headers.py:1",
+        "tests/test_headers.py:1",
+    ]
+
+
+def test_same_file_without_shared_concern_does_not_form_a_package() -> None:
+    findings = [
+        _f(title="Delete a self-evident comment", category="tech-debt"),
+        _f(title="Fix authentication bypass", category="security"),
+    ]
+
+    assert len(aggregate_cross_service(findings)) == 2
+
+
+def test_same_file_and_generic_signal_still_require_semantic_similarity() -> None:
+    findings = [
+        _f(
+            fingerprint="fp-wrapper",
+            title="Remove the redundant request wrapper",
+            maintenance_signals=["overengineered_structure"],
+        ),
+        _f(
+            fingerprint="fp-cache",
+            title="Collapse duplicate cache bookkeeping",
+            maintenance_signals=["overengineered_structure"],
+        ),
+    ]
+
+    assert len(aggregate_cross_service(findings)) == 2
+
+
+def test_conflicting_reuse_targets_never_form_one_package() -> None:
+    findings = [
+        _f(
+            fingerprint="fp-stdlib",
+            title="Replace the local URL parser",
+            reuse_target="stdlib:urllib.parse.urlparse",
+        ),
+        _f(
+            fingerprint="fp-library",
+            title="Replace the local URL parser",
+            reuse_target="dep:yarl:URL",
+        ),
+    ]
+
+    assert len(aggregate_cross_service(findings)) == 2
+
+
+def test_package_compatibility_is_all_pairs_not_transitive() -> None:
+    common = {
+        "category": "tests",
+        "maintenance_signals": ["duplicated_test_structure"],
+    }
+    left = _f(
+        **common,
+        path="tests/test_catalog_setup.py",
+        fingerprint="fp-left",
+        title="Repeated catalog fixture setup",
+    )
+    bridge = _f(
+        **common,
+        path="tests/test_catalog_cases.py",
+        fingerprint="fp-bridge",
+        title="Repeated catalog fixture setup and assertions",
+    )
+    right = _f(
+        **common,
+        path="tests/test_catalog_assertions.py",
+        fingerprint="fp-right",
+        title="Repeated catalog assertions",
+    )
+
+    packages = aggregate_cross_service([left, bridge, right])
+
+    assert len(packages) == 2
+    assert sorted(len(package["members"]) for package in packages) == [1, 2]
+
+
+def test_work_package_caps_and_identity_are_deterministic() -> None:
+    findings = [
+        _f(
+            fingerprint=f"fp-{index}",
+            title=f"Use shared parser at call site {index}",
+            path=f"src/call_{index}.py",
+            reuse_target="repo:src/parser.py#parse",
+        )
+        for index in range(7)
+    ]
+
+    forward = aggregate_cross_service(findings)
+    reverse = aggregate_cross_service(list(reversed(findings)))
+
+    assert [len(package["members"]) for package in forward] == [5, 2]
+    assert [(package["package_fingerprint"], package["member_fingerprints"]) for package in forward] == [
+        (package["package_fingerprint"], package["member_fingerprints"]) for package in reverse
+    ]
+
+
+def test_same_path_cap_splits_have_distinct_deterministic_package_ids() -> None:
+    findings = [
+        _f(
+            fingerprint=f"fp-{index:02d}",
+            title=f"Use shared parser for request variant {index:02d}",
+            path="src/requests.py",
+            line=1,
+            category="tech-debt",
+            maintenance_signals=["reuse_existing"],
+            reuse_target="repo:src/parser.py#parse",
+        )
+        for index in range(11)
+    ]
+
+    forward = aggregate_cross_service(findings)
+    reverse = aggregate_cross_service(list(reversed(findings)))
+
+    assert [len(package["members"]) for package in forward] == [5, 5, 1]
+    assert len({package["package_fingerprint"] for package in forward}) == 3
+    assert [(package["package_fingerprint"], package["member_fingerprints"]) for package in forward] == [
+        (package["package_fingerprint"], package["member_fingerprints"]) for package in reverse
+    ]
+
+
+def test_member_aliases_survive_wording_and_expose_membership_drift() -> None:
+    first = _f(
+        fingerprint="volatile-first",
+        title="Repeated catalog setup should use the fixture",
+        path="tests/test_catalog.py",
+        line=12,
+        category="tests",
+        maintenance_signals=["duplicated_test_structure"],
+        reuse_target="repo:tests/conftest.py#catalog_fixture",
+    )
+    reworded = _f(
+        fingerprint="volatile-reworded",
+        title="Consolidate the catalog test setup",
+        path="tests/test_catalog.py",
+        line=12,
+        category="tests",
+        maintenance_signals=["duplicated_test_structure"],
+        reuse_target="repo:tests/conftest.py#catalog_fixture",
+    )
+    added = _f(
+        fingerprint="volatile-added",
+        title="Consolidate repeated catalog assertions",
+        path="tests/test_catalog.py",
+        line=30,
+        category="tests",
+        maintenance_signals=["duplicated_test_structure"],
+        reuse_target="repo:tests/conftest.py#catalog_fixture",
+    )
+
+    before = aggregate_cross_service([first])[0]
+    after = aggregate_cross_service([reworded])[0]
+    expanded = aggregate_cross_service([reworded, added])[0]
+
+    assert before["member_aliases"] == after["member_aliases"]
+    assert before["package_fingerprint"] == after["package_fingerprint"]
+    assert set(after["member_aliases"]) < set(expanded["member_aliases"])
+    assert expanded["package_fingerprint"] != after["package_fingerprint"]

--- a/tests/test_improve_publish.py
+++ b/tests/test_improve_publish.py
@@ -1,0 +1,441 @@
+"""Focused contracts for Improve's headless GitHub issue publisher."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from daydream import git_ops, runner
+from daydream.config_file import DaydreamFileConfig
+from daydream.improve.publish import (
+    ImprovePublishError,
+    IssuePublisher,
+    issue_body,
+    member_fingerprint_marker,
+    member_marker,
+    package_marker,
+)
+from daydream.runner import RunConfig
+
+
+def _issue(package_id: str, *, state: str = "open", number: int = 7) -> dict[str, object]:
+    return {
+        "number": number,
+        "title": "Improve code reuse",
+        "body": f"{package_marker(package_id)}\n\nplan",
+        "url": f"https://github.com/acme/widgets/issues/{number}",
+        "state": state,
+    }
+
+
+def test_issue_body_preserves_complete_plan_markdown() -> None:
+    plan = "# Plan\n\nKeep leading structure and final newline.\n"
+
+    body = issue_body("reuse-handler", plan)
+
+    assert body == f"{package_marker('reuse-handler')}\n\n{plan}"
+    assert package_marker("reuse-handler") == (
+        "<!-- daydream-improve: package=reuse-handler -->"
+    )
+
+
+def test_issue_body_embeds_stable_member_aliases_before_the_complete_plan() -> None:
+    plan = "# Plan\n\nDelete duplicate code.\n"
+    aliases = ("member-v1:aaa", "member-v1:bbb")
+
+    body = issue_body("reuse-handler", plan, member_aliases=aliases)
+
+    marker_block, embedded_plan = body.split("\n\n", 1)
+    assert marker_block.splitlines() == [
+        package_marker("reuse-handler"),
+        member_marker("member-v1:aaa"),
+        member_marker("member-v1:bbb"),
+    ]
+    assert embedded_plan == plan
+
+
+def test_package_marker_rejects_comment_injection() -> None:
+    with pytest.raises(ValueError, match="package_id"):
+        package_marker("package -->\nmalicious")
+
+
+def test_connect_fails_closed_when_existing_issues_cannot_be_read(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        git_ops,
+        "gh_issue_list_strict",
+        lambda *args, **kwargs: (_ for _ in ()).throw(git_ops.GitError("offline")),
+    )
+    created = False
+
+    def unexpected_create(*args: Any, **kwargs: Any) -> str:
+        nonlocal created
+        created = True
+        return ""
+
+    monkeypatch.setattr(git_ops, "gh_issue_create", unexpected_create)
+
+    with pytest.raises(ImprovePublishError, match="safely reconcile"):
+        IssuePublisher.connect(tmp_path, repo_slug="acme/widgets")
+    assert created is False
+
+
+def test_connect_infers_repository_and_lists_open_and_closed_issues(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(git_ops, "gh_repo_view", lambda repo: ("acme", "widgets"))
+
+    def list_strict(repo: Path, *, state: str, repo_slug: str) -> list[dict[str, Any]]:
+        captured.update(repo=repo, state=state, repo_slug=repo_slug)
+        return []
+
+    monkeypatch.setattr(git_ops, "gh_issue_list_strict", list_strict)
+
+    publisher = IssuePublisher.connect(tmp_path)
+
+    assert publisher.repo_slug == "acme/widgets"
+    assert captured == {
+        "repo": tmp_path,
+        "state": "all",
+        "repo_slug": "acme/widgets",
+    }
+
+
+def test_existing_closed_issue_is_reused_without_creating_a_duplicate(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    plan_path = tmp_path / "plan.md"
+    plan_path.write_text("# Complete plan\n", encoding="utf-8")
+    monkeypatch.setattr(
+        git_ops,
+        "gh_issue_list_strict",
+        lambda *args, **kwargs: [_issue("reuse-handler", state="closed")],
+    )
+    monkeypatch.setattr(
+        git_ops,
+        "gh_issue_create",
+        lambda *args, **kwargs: pytest.fail("must not create a duplicate issue"),
+    )
+    publisher = IssuePublisher.connect(tmp_path, repo_slug="acme/widgets")
+
+    result = publisher.publish(
+        package_id="reuse-handler",
+        title="Reuse the existing handler",
+        plan_path=plan_path,
+    )
+
+    assert result.disposition == "existing"
+    assert result.issue_url.endswith("/7")
+
+
+def test_all_member_aliases_reconcile_a_regrouped_package(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    plan_path = tmp_path / "plan.md"
+    plan_path.write_text("# Complete plan\n", encoding="utf-8")
+    existing = _issue("older-package")
+    existing["body"] = issue_body(
+        "older-package",
+        "old plan",
+        member_aliases=("member-v1:aaa", "member-v1:bbb"),
+    )
+    monkeypatch.setattr(
+        git_ops,
+        "gh_issue_list_strict",
+        lambda *args, **kwargs: [existing],
+    )
+    monkeypatch.setattr(
+        git_ops,
+        "gh_issue_create",
+        lambda *args, **kwargs: pytest.fail("must reuse complete alias coverage"),
+    )
+    publisher = IssuePublisher.connect(tmp_path, repo_slug="acme/widgets")
+
+    result = publisher.publish(
+        package_id="regrouped-package",
+        title="Reuse the existing handler",
+        plan_path=plan_path,
+        member_aliases=("member-v1:aaa", "member-v1:bbb"),
+    )
+
+    assert result.disposition == "existing"
+
+
+def test_partial_member_alias_overlap_fails_instead_of_creating_duplicate_work(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    plan_path = tmp_path / "plan.md"
+    plan_path.write_text("# Expanded plan\n", encoding="utf-8")
+    existing = _issue("older-package")
+    existing["body"] = issue_body(
+        "older-package",
+        "old plan",
+        member_aliases=("member-v1:shared",),
+    )
+    monkeypatch.setattr(
+        git_ops,
+        "gh_issue_list_strict",
+        lambda *args, **kwargs: [existing],
+    )
+    monkeypatch.setattr(
+        git_ops,
+        "gh_issue_create",
+        lambda *args, **kwargs: pytest.fail("must not create overlapping work"),
+    )
+    publisher = IssuePublisher.connect(tmp_path, repo_slug="acme/widgets")
+
+    with pytest.raises(ImprovePublishError, match="partially covers"):
+        publisher.publish(
+            package_id="expanded-package",
+            title="Expand reuse cleanup",
+            plan_path=plan_path,
+            member_aliases=("member-v1:shared", "member-v1:new"),
+        )
+
+
+def test_matching_package_marker_cannot_hide_stale_member_coverage(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    plan_path = tmp_path / "plan.md"
+    plan_path.write_text("# Expanded plan\n", encoding="utf-8")
+    existing = _issue("same-package")
+    existing["body"] = issue_body(
+        "same-package",
+        "old plan",
+        member_aliases=("member-v1:old",),
+    )
+    monkeypatch.setattr(
+        git_ops,
+        "gh_issue_list_strict",
+        lambda *args, **kwargs: [existing],
+    )
+    monkeypatch.setattr(
+        git_ops,
+        "gh_issue_create",
+        lambda *args, **kwargs: pytest.fail("must not publish stale coverage"),
+    )
+    publisher = IssuePublisher.connect(tmp_path, repo_slug="acme/widgets")
+
+    with pytest.raises(ImprovePublishError, match="stale or overlapping"):
+        publisher.publish(
+            package_id="same-package",
+            title="Expanded cleanup",
+            plan_path=plan_path,
+            member_aliases=("member-v1:old", "member-v1:new"),
+        )
+
+
+def test_colliding_member_aliases_require_every_raw_fingerprint(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    plan_path = tmp_path / "plan.md"
+    plan_path.write_text("# Two distinct cleanups\n", encoding="utf-8")
+    existing = _issue("same-package")
+    existing["body"] = issue_body(
+        "same-package",
+        "one cleanup",
+        member_aliases=("member-v1:shared",),
+        member_fingerprints=("raw-first",),
+    )
+    monkeypatch.setattr(
+        git_ops,
+        "gh_issue_list_strict",
+        lambda *args, **kwargs: [existing],
+    )
+    monkeypatch.setattr(
+        git_ops,
+        "gh_issue_create",
+        lambda *args, **kwargs: pytest.fail("one alias cannot cover two members"),
+    )
+    publisher = IssuePublisher.connect(tmp_path, repo_slug="acme/widgets")
+
+    with pytest.raises(ImprovePublishError, match="stale or overlapping"):
+        publisher.publish(
+            package_id="same-package",
+            title="Two distinct cleanups",
+            plan_path=plan_path,
+            member_aliases=("member-v1:shared", "member-v1:shared"),
+            member_fingerprints=("raw-first", "raw-second"),
+        )
+
+    assert member_fingerprint_marker("raw-second") not in str(existing["body"])
+
+
+def test_publish_creates_issue_with_the_complete_local_plan(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    plan_path = tmp_path / "plan.md"
+    plan = "# Complete plan\n\n- Delete the redundant adapter.\n"
+    plan_path.write_text(plan, encoding="utf-8")
+    monkeypatch.setattr(git_ops, "gh_issue_list_strict", lambda *args, **kwargs: [])
+    captured: dict[str, object] = {}
+
+    def create(repo: Path, **kwargs: object) -> str:
+        captured.update(repo=repo, **kwargs)
+        return "https://github.com/acme/widgets/issues/12"
+
+    monkeypatch.setattr(git_ops, "gh_issue_create", create)
+    publisher = IssuePublisher.connect(tmp_path, repo_slug="acme/widgets")
+
+    result = publisher.publish(
+        package_id="delete-adapter",
+        title="Delete the redundant adapter",
+        plan_path=plan_path,
+    )
+
+    assert result.disposition == "created"
+    assert result.issue_url.endswith("/12")
+    assert captured["repo"] == tmp_path
+    assert captured["repo_slug"] == "acme/widgets"
+    assert captured["title"] == "Delete the redundant adapter"
+    assert captured["body"] == issue_body("delete-adapter", plan)
+
+
+def test_ambiguous_create_failure_reconciles_before_returning(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    plan_path = tmp_path / "plan.md"
+    plan_path.write_text("# Complete plan\n", encoding="utf-8")
+    lookups = iter([[], [_issue("reuse-handler", number=19)]])
+    monkeypatch.setattr(
+        git_ops,
+        "gh_issue_list_strict",
+        lambda *args, **kwargs: next(lookups),
+    )
+    monkeypatch.setattr(
+        git_ops,
+        "gh_issue_create",
+        lambda *args, **kwargs: (_ for _ in ()).throw(git_ops.GitTimeoutError("response lost")),
+    )
+    publisher = IssuePublisher.connect(tmp_path, repo_slug="acme/widgets")
+
+    result = publisher.publish(
+        package_id="reuse-handler",
+        title="Reuse the existing handler",
+        plan_path=plan_path,
+    )
+
+    assert result.disposition == "reconciled"
+    assert result.issue_url.endswith("/19")
+
+
+def test_ambiguous_create_failure_without_a_marker_remains_a_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    plan_path = tmp_path / "plan.md"
+    plan_path.write_text("# Complete plan\n", encoding="utf-8")
+    monkeypatch.setattr(git_ops, "gh_issue_list_strict", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        git_ops,
+        "gh_issue_create",
+        lambda *args, **kwargs: (_ for _ in ()).throw(git_ops.GitTimeoutError("response lost")),
+    )
+    publisher = IssuePublisher.connect(tmp_path, repo_slug="acme/widgets")
+
+    with pytest.raises(ImprovePublishError, match="no matching issue"):
+        publisher.publish(
+            package_id="reuse-handler",
+            title="Reuse the existing handler",
+            plan_path=plan_path,
+        )
+
+
+def test_duplicate_package_markers_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    plan_path = tmp_path / "plan.md"
+    plan_path.write_text("# Complete plan\n", encoding="utf-8")
+    monkeypatch.setattr(
+        git_ops,
+        "gh_issue_list_strict",
+        lambda *args, **kwargs: [
+            _issue("reuse-handler", number=2),
+            _issue("reuse-handler", number=3),
+        ],
+    )
+    monkeypatch.setattr(
+        git_ops,
+        "gh_issue_create",
+        lambda *args, **kwargs: pytest.fail("ambiguous state must not create"),
+    )
+    publisher = IssuePublisher.connect(tmp_path, repo_slug="acme/widgets")
+
+    with pytest.raises(ImprovePublishError, match="Multiple GitHub issues"):
+        publisher.publish(
+            package_id="reuse-handler",
+            title="Reuse the existing handler",
+            plan_path=plan_path,
+        )
+
+
+def test_strict_issue_lookup_paginates_and_filters_pull_requests(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, object] = {}
+    rows: list[dict[str, object]] = [
+        {
+            "number": number,
+            "title": f"Issue {number}",
+            "body": None,
+            "html_url": f"https://github.com/acme/widgets/issues/{number}",
+            "state": "closed" if number % 2 else "open",
+        }
+        for number in range(1, 102)
+    ]
+    rows.append(
+        {
+            "number": 102,
+            "title": "A pull request",
+            "body": "",
+            "html_url": "https://github.com/acme/widgets/pull/102",
+            "state": "open",
+            "pull_request": {"url": "api"},
+        }
+    )
+
+    def api(repo: Path, endpoint: str, **kwargs: object) -> list[dict[str, object]]:
+        captured.update(repo=repo, endpoint=endpoint, **kwargs)
+        return rows
+
+    monkeypatch.setattr(git_ops, "gh_api", api)
+
+    issues = git_ops.gh_issue_list_strict(
+        tmp_path,
+        state="all",
+        repo_slug="acme/widgets",
+    )
+
+    assert len(issues) == 101
+    assert issues[0]["body"] == ""
+    assert captured["paginate"] is True
+    assert captured["jq"] == ".[]"
+    assert captured["idempotent"] is True
+    assert "state=all" in str(captured["endpoint"])
+    assert "per_page=100" in str(captured["endpoint"])
+
+
+def test_runner_treats_configured_improve_as_a_posting_flow() -> None:
+    enabled = RunConfig(
+        flow_name="improve",
+        file_config=DaydreamFileConfig(improve_github_publish_issues=True),
+    )
+    disabled = RunConfig(flow_name="improve", file_config=DaydreamFileConfig())
+
+    assert runner._run_posts_to_github(enabled) is True
+    assert runner._run_posts_to_github(disabled) is False


### PR DESCRIPTION
## Summary

Make Improve converge on smaller, more reusable codebases by explicitly finding agent-generated bloat, combining overlapping findings into issue-sized work packages, and supporting unattended GitHub issue publication. Plans remain local artifacts and their complete Markdown is copied into issue descriptions without creating plan branches, commits, or pushes.

## Changes

### Added

- Structured maintenance signals for overengineering, reuse opportunities, hand-rolled substitutes, duplicated or parameterizable tests, excessive comments, self-evident comments, and dead code.
- Change-shape and reuse-target metadata so subtractive delete, reuse, and consolidation work wins equal-leverage ties.
- Opt-in headless issue publication through `[tool.daydream.improve.github] publish_issues = true`.
- Stable package/member markers, strict paginated issue reconciliation, publication artifacts, and fail-closed handling for partial or ambiguous overlap.
- Unit and real-run integration coverage for aggregation, plan contracts, persistent indexes, publishing, configuration, and permissions.

### Changed

- Aggregate compatible duplicate and overlapping findings before selection into deterministic, bounded work packages suitable for one GitHub issue.
- Select every vetted work package in non-interactive mode when automatic issue publication is enabled.
- Support new-or-updated tests, verified existing coverage, and genuinely not-applicable test plans instead of requiring every plan to add a test.
- Support deletion-only plans with operation-aware verification and durable covered-finding identities.
- Add tech debt to the quick tier and make audit/vet prompts prefer repository reuse, then standard library, then declared dependencies before new code.
- Require a repository-scoped single-writer lock for concurrent Actions or cron publishers.

### Fixed

- Prevent partial plan-index overlap from silently suppressing newly discovered work or publishing stale plan text.
- Prevent capped work packages from sharing an issue identity.
- Reject conflicting reuse targets and unrelated same-file findings during aggregation.
- Return nonzero and record every selected package when planning or publication is incomplete.
- Validate existing test coverage using exact test-like declarations rather than substring matches.

### Removed

- Remove the non-actionable `direction` audit category and `--focus next` mode.
- Remove instructions for issue executors to update a local `daydream_plans/README.md` that is not present in fresh checkouts.

## Motivation

Repeated agent work tends to grow abstractions, duplicate tests, reimplement available functionality, and accumulate explanatory prose. This change turns Improve into a cleanup pressure that can run week after week: it favors safe net code reduction, reuses existing implementation, prevents duplicate plans, and can file all actionable work without an intermediate selection step.

## Testing

- [x] Unit tests added and updated
- [x] Real runner-path integration tests added and updated
- [x] `make check` passed
- [x] Pre-push verification passed: lock check, Ruff, mypy, and 3,168 tests passed with 6 skipped

## Breaking Changes

- `daydream improve --focus next` is removed. Use an actionable audit focus, run the complete Improve audit, or use `daydream improve plan "describe the requested change"` for a targeted plan.
- Custom integrations that enumerate the former `direction` audit category must remove it.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally
- [x] Linting passes
- [x] Documentation updated
