### PR TITLE
fix(pi): survive transient stream failures in deep reviews

### DIFF
--- a/daydream/backends/_subprocess.py
+++ b/daydream/backends/_subprocess.py
@@ -51,12 +51,11 @@ TERMINATE_GRACE_S = 5.0
 class StreamStalledError(Exception):
     """Raised when a backend CLI produces no stdout for the idle window.
 
-    ``retryable`` is ``False``: the idle window is a terminal bound for a
-    subprocess invocation, so a persistent stalled stream cannot consume the
-    generic retry budget.
+    A stalled request may be a transient provider/network failure, so the
+    normal bounded backend retry loop gets a chance to re-arm the subprocess.
     """
 
-    retryable = False
+    retryable = True
 
     def __init__(self, cli: str, timeout_s: float) -> None:
         super().__init__(

--- a/daydream/backends/pi.py
+++ b/daydream/backends/pi.py
@@ -313,6 +313,13 @@ _SERVER_ERROR_TOKENS = (
 )
 
 
+def _is_stream_truncation_message(normalized_message: str) -> bool:
+    """Return True when a normalized message reports an unfinished stream."""
+    return "finish_reason" in normalized_message and any(
+        token in normalized_message for token in ("stream", "ended", "end")
+    )
+
+
 def _is_retryable_error_message(message: str) -> bool:
     """Return True if the error message signals a transient overload or rate-limit.
 
@@ -327,7 +334,7 @@ def _is_retryable_error_message(message: str) -> bool:
     # Unambiguous literals — plain substring is safe.
     if any(token in lower for token in _RATE_LIMIT_TOKENS + _SERVER_ERROR_TOKENS):
         return True
-    if "finish_reason" in lower and any(token in lower for token in ("stream", "ended", "end")):
+    if _is_stream_truncation_message(lower):
         return True
     if any(token in lower for token in ("timed out", "timeout", "deadline exceeded")):
         return True
@@ -369,7 +376,7 @@ def _pi_error_category(message: str) -> str:
         return "SERVER_ERROR"
     if any(token in lower for token in ("timed out", "timeout", "deadline exceeded")):
         return "TIMEOUT"
-    if "finish_reason" in lower and any(token in lower for token in ("stream", "ended", "end")):
+    if _is_stream_truncation_message(lower):
         return "STREAM_TRUNCATION"
     if any(signature in lower for signature in STREAM_DROP_SIGNATURES):
         return "STREAM_DROP"

--- a/daydream/backends/pi.py
+++ b/daydream/backends/pi.py
@@ -803,6 +803,7 @@ class PiBackend:
 
                 elif event_type == "turn_start":
                     saw_turn_start = True
+                    saw_finish_reason = False
 
                 elif event_type == "message_end":
                     msg = event.get("message") or {}

--- a/daydream/backends/pi.py
+++ b/daydream/backends/pi.py
@@ -327,6 +327,10 @@ def _is_retryable_error_message(message: str) -> bool:
     # Unambiguous literals — plain substring is safe.
     if any(token in lower for token in _RATE_LIMIT_TOKENS + _SERVER_ERROR_TOKENS):
         return True
+    if "finish_reason" in lower and any(token in lower for token in ("stream", "ended", "end")):
+        return True
+    if any(token in lower for token in ("timed out", "timeout", "deadline exceeded")):
+        return True
     if re.search(r"\bnot\s+overloaded\b|\bcapacity\s+planning\b", lower):
         return False
     if bool(
@@ -365,6 +369,8 @@ def _pi_error_category(message: str) -> str:
         return "SERVER_ERROR"
     if any(token in lower for token in ("timed out", "timeout", "deadline exceeded")):
         return "TIMEOUT"
+    if "finish_reason" in lower and any(token in lower for token in ("stream", "ended", "end")):
+        return "STREAM_TRUNCATION"
     if any(signature in lower for signature in STREAM_DROP_SIGNATURES):
         return "STREAM_DROP"
     if "pi cli exited with return code" in lower:
@@ -728,6 +734,8 @@ class PiBackend:
         total_output = 0
         total_cache_read: int | None = None
         total_cost: float | None = None
+        saw_finish_reason = False
+        saw_turn_start = False
 
         proc: asyncio.subprocess.Process | None = None
 
@@ -793,6 +801,9 @@ class PiBackend:
                 if event_type == "agent_start":
                     pass  # Lifecycle marker; nothing to emit.
 
+                elif event_type == "turn_start":
+                    saw_turn_start = True
+
                 elif event_type == "message_end":
                     msg = event.get("message") or {}
                     if msg.get("role") == "assistant":
@@ -837,6 +848,8 @@ class PiBackend:
                             retryable=_is_retryable_error_message(error_msg),
                             category=_pi_error_category(error_msg),
                         )
+                    if stop_reason is not None:
+                        saw_finish_reason = True
                     usage = _extract_usage(msg)
                     inp = usage["input"]
                     outp = usage["output"]
@@ -893,6 +906,13 @@ class PiBackend:
                     f"Pi CLI exited with return code {returncode}.{detail}",
                     retryable=_is_retryable_exit_code(returncode),
                     category="PROCESS_EXIT",
+                )
+
+            if saw_turn_start and not saw_finish_reason:
+                raise PiError(
+                    "Stream ended without finish_reason",
+                    retryable=True,
+                    category="STREAM_TRUNCATION",
                 )
 
             # Single finalization path (plan §10): runs exactly once whether

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -1230,6 +1230,11 @@ async def _step_per_stack_parse(ctx: FlowContext) -> Stop | None:
         async with phase_scope(DaydreamPhase.PARSE):
             async with anyio.create_task_group() as tg:
                 for stack_name, output_path in sorted(per_stack_outputs.items()):
+                    # An exhausted per-stack review has no review markdown to parse.
+                    # Keep completed siblings in the parse/merge pipeline; the
+                    # failure map is the explicit coverage record for this stack.
+                    if stack_name in failed_stacks:
+                        continue
                     # Every stack -- language or the structural meta-stack --
                     # parses with the severity-bearing PER_STACK_RECORD_SCHEMA.
                     # Issue #314: the structural reviewer calibrates anti-slop

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -1149,15 +1149,10 @@ async def _per_stack_body(ctx: FlowContext, *, include_alternatives: bool) -> No
             # Fresh successful run supersedes any stale failures record.
             failures_p.unlink()
     else:
-        # Resume: reconstruct the expected per-stack output paths on disk.
+        # Resume: resurrect any prior failure summary before reconstructing
+        # outputs, so failed stacks never re-enter the parse pipeline.
         from daydream.deep.artifacts import per_stack_review_path
 
-        per_stack_outputs = {
-            stack.stack_name: per_stack_review_path(dd, stack.stack_name)
-            for stack in stacks
-        }
-        # Resume also resurrects any prior failure summary so the merge
-        # prompt can still note uncovered stacks.
         failures_p = per_stack_failures_path(dd)
         if failures_p.is_file():
             try:
@@ -1166,6 +1161,11 @@ async def _per_stack_body(ctx: FlowContext, *, include_alternatives: bool) -> No
                     failed_stacks = {str(k): str(v) for k, v in loaded.items()}
             except json.JSONDecodeError:
                 failed_stacks = {}
+        per_stack_outputs = {
+            stack.stack_name: per_stack_review_path(dd, stack.stack_name)
+            for stack in stacks
+            if stack.stack_name not in failed_stacks
+        }
     ctx.data["per_stack_outputs"] = per_stack_outputs
     ctx.data["failed_stacks"] = failed_stacks
 
@@ -1190,10 +1190,12 @@ async def _step_per_stack_parse(ctx: FlowContext) -> Stop | None:
         expected_paths: list[Path] = []
         missing_stacks: list[str] = []
         for stack in stacks:
+            if stack.stack_name in failed_stacks:
+                continue
             records_path = per_stack_records_path(dd, stack.stack_name)
             if records_path.is_file():
                 expected_paths.append(records_path)
-            elif stack.stack_name not in failed_stacks:
+            else:
                 missing_stacks.append(stack.stack_name)
         if missing_stacks:
             print_error(
@@ -1230,11 +1232,6 @@ async def _step_per_stack_parse(ctx: FlowContext) -> Stop | None:
         async with phase_scope(DaydreamPhase.PARSE):
             async with anyio.create_task_group() as tg:
                 for stack_name, output_path in sorted(per_stack_outputs.items()):
-                    # An exhausted per-stack review has no review markdown to parse.
-                    # Keep completed siblings in the parse/merge pipeline; the
-                    # failure map is the explicit coverage record for this stack.
-                    if stack_name in failed_stacks:
-                        continue
                     # Every stack -- language or the structural meta-stack --
                     # parses with the severity-bearing PER_STACK_RECORD_SCHEMA.
                     # Issue #314: the structural reviewer calibrates anti-slop

--- a/tests/test_backend_pi.py
+++ b/tests/test_backend_pi.py
@@ -42,6 +42,7 @@ from daydream.backends.pi import (
     PiError,
     _is_retryable_error_message,
     _is_retryable_exit_code,
+    _is_stream_truncation_message,
     _pi_error_category,
     _pi_retry_attempts,
     _pi_retry_base_delay,
@@ -1287,6 +1288,10 @@ def test_pi_error_categories_are_stable_host_codes(
 )
 def test_pi_transient_failures_are_retryable(message: str) -> None:
     assert _is_retryable_error_message(message) is True
+
+
+def test_is_stream_truncation_message() -> None:
+    assert _is_stream_truncation_message("stream ended without finish_reason") is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_backend_pi.py
+++ b/tests/test_backend_pi.py
@@ -31,6 +31,7 @@ from daydream.backends import (
     ToolStartEvent,
     TurnEndEvent,
 )
+from daydream.backends._subprocess import StreamStalledError
 from daydream.backends.pi import (
     _PI_DEFAULT_RETRY_ATTEMPTS,
     _PI_DEFAULT_RETRY_BASE_DELAY,
@@ -1274,6 +1275,58 @@ def test_pi_error_categories_are_stable_host_codes(
     expected: str,
 ) -> None:
     assert _pi_error_category(message) == expected
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "503 status code (no body)",
+        "Stream ended without finish_reason",
+        "request timeout while waiting for response",
+    ],
+)
+def test_pi_transient_failures_are_retryable(message: str) -> None:
+    assert _is_retryable_error_message(message) is True
+
+
+@pytest.mark.asyncio
+async def test_stream_eof_without_finish_reason_is_retryable_pi_error() -> None:
+    backend = PiBackend(model="glm-5.2")
+    mock_proc = make_mock_process(
+        [
+            '{"type":"session","sessionId":"pi_ses_truncated"}',
+            '{"type":"agent_start"}',
+            '{"type":"turn_start"}',
+        ]
+    )
+    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc):
+        with pytest.raises(PiError, match="finish_reason") as raised:
+            async for _ in backend.execute(Path("/tmp"), "Truncated"):
+                pass
+    assert raised.value.retryable is True
+    assert raised.value.category == "STREAM_TRUNCATION"
+
+
+@pytest.mark.asyncio
+async def test_pi_stream_timeout_is_retryable() -> None:
+    backend = PiBackend(model="glm-5.2")
+    mock_proc = MagicMock()
+    mock_proc.stdout = MagicMock()
+    mock_proc.wait = AsyncMock(return_value=0)
+    mock_proc.returncode = 0
+    mock_proc.terminate = MagicMock()
+    mock_proc.kill = MagicMock()
+    with (
+        patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc),
+        patch(
+            "daydream.backends.pi.readline_with_idle_timeout",
+            side_effect=StreamStalledError("pi", 1.0),
+        ),
+    ):
+        with pytest.raises(StreamStalledError) as raised:
+            async for _ in backend.execute(Path("/tmp"), "Timeout"):
+                pass
+    assert raised.value.retryable is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_backend_pi.py
+++ b/tests/test_backend_pi.py
@@ -1308,6 +1308,26 @@ async def test_stream_eof_without_finish_reason_is_retryable_pi_error() -> None:
 
 
 @pytest.mark.asyncio
+async def test_stream_eof_after_completed_earlier_turn_is_retryable_pi_error() -> None:
+    backend = PiBackend(model="glm-5.2")
+    mock_proc = make_mock_process(
+        [
+            '{"type":"session","sessionId":"pi_ses_truncated"}',
+            '{"type":"agent_start"}',
+            '{"type":"turn_start"}',
+            '{"type":"turn_end","message":{"role":"assistant","stopReason":"stop"}}',
+            '{"type":"turn_start"}',
+        ]
+    )
+    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc):
+        with pytest.raises(PiError, match="finish_reason") as raised:
+            async for _ in backend.execute(Path("/tmp"), "Truncated"):
+                pass
+    assert raised.value.retryable is True
+    assert raised.value.category == "STREAM_TRUNCATION"
+
+
+@pytest.mark.asyncio
 async def test_pi_stream_timeout_is_retryable() -> None:
     backend = PiBackend(model="glm-5.2")
     mock_proc = MagicMock()

--- a/tests/test_backend_stream_idle.py
+++ b/tests/test_backend_stream_idle.py
@@ -125,7 +125,7 @@ async def test_pi_silent_stream_trips_idle_timeout_and_reaps_subprocess(
 
     assert excinfo.value.cli == "pi"
     assert excinfo.value.timeout_s == float(TINY_WINDOW)
-    assert excinfo.value.retryable is False
+    assert excinfo.value.retryable is True
     assert_stalled_and_reaped(spawner)
 
 
@@ -141,7 +141,7 @@ async def test_codex_silent_stream_trips_idle_timeout_and_reaps_subprocess(
         await drain(CodexBackend(model="test-model"), tmp_path)
 
     assert excinfo.value.cli == "codex"
-    assert excinfo.value.retryable is False
+    assert excinfo.value.retryable is True
     assert_stalled_and_reaped(spawner)
 
 
@@ -267,7 +267,7 @@ def test_default_exceeds_the_wall_budget(monkeypatch: pytest.MonkeyPatch) -> Non
 async def test_stall_is_not_retried(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A persistently-stalling ``pi`` reaches the caller without relaunching."""
+    """A persistently-stalling ``pi`` consumes only the bounded retry budget."""
     spawner = install_fake_cli_process(monkeypatch, "pi", lines=PI_LINES[:2], hang=True)
     monkeypatch.setenv(STREAM_IDLE_TIMEOUT_ENV, TINY_WINDOW)
     monkeypatch.setenv("DAYDREAM_PI_RETRY_ATTEMPTS", "3")
@@ -290,7 +290,7 @@ async def test_stall_is_not_retried(
         async with recorder:
             await run_agent(backend, tmp_path, "review", phase=DaydreamPhase.REVIEW)
 
-    assert_stalled_and_reaped(spawner, expected_spawns=1)
+    assert_stalled_and_reaped(spawner, expected_spawns=4)
 
     trajectory = json.loads(trajectory_path.read_text(encoding="utf-8"))
     assert trajectory["extra"]["partial"] is True

--- a/tests/test_backend_stream_idle.py
+++ b/tests/test_backend_stream_idle.py
@@ -264,7 +264,7 @@ def test_default_exceeds_the_wall_budget(monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 @pytest.mark.asyncio
-async def test_stall_is_not_retried(
+async def test_stall_is_retried_within_bounded_budget(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A persistently-stalling ``pi`` consumes only the bounded retry budget."""

--- a/tests/test_backend_stream_idle.py
+++ b/tests/test_backend_stream_idle.py
@@ -1,7 +1,7 @@
 """Idle-stall detection and teardown for the pi/codex subprocess backends.
 
 Deterministic by construction — no test here races two clocks. The stall,
-no-retry, wall-budget, and SIGKILL-escalation tests drive the real backend
+retry, wall-budget, and SIGKILL-escalation tests drive the real backend
 code (spawn call, readline loop, idle window, shielded teardown) against an
 in-process :class:`~tests.harness.fake_cli_process.FakeCliProcess` at the
 ``asyncio.create_subprocess_exec`` boundary. Silence is modeled as a
@@ -258,8 +258,8 @@ def test_default_exceeds_the_wall_budget(monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 # --------------------------------------------------------------------------
-# Terminal — driven through run_agent, the production call site. A stalled
-# stream must not cause the backend to relaunch after the full idle window.
+# Retryable — driven through run_agent, the production call site. A stalled
+# stream consumes the backend's bounded retry budget after the full idle window.
 # --------------------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary
- Retry Pi 503, stream-truncation, and request-timeout failures through the bounded backend retry policy.
- Detect EOF after a started turn without a terminal finish reason and classify it explicitly.
- Preserve completed per-stack review artifacts when a sibling exhausts retries, and skip only the failed stack during parsing.
- Update idle-stream regression coverage to assert bounded retry behavior.

## Verification
- `uv run pytest -q` — 3,173 passed, 6 skipped.
- Focused retry/backend/deep tests — 307 passed, 1 skipped.
- Ruff and mypy passed.

Closes #360
