### PR TITLE
feat(improve): operator-initiated pruning of executed re-anchor worktrees (#351)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,8 @@ daydream /path/to/project                          # review -> fix -> test (deep
 daydream --comment /path/to/project                # review -> post inline PR comments, then exit
 daydream improve /path/to/project                  # read-only repo audit -> prioritized plans
 daydream improve plan "add rate limiting" /path/to/project  # investigate one request -> plan
+daydream improve prune-reanchor <NAME> /path/to/project   # remove one executed re-anchor worktree (exit 0 on removal, non-zero when the name is rejected/absent/git-failed)
+daydream improve list-reanchor /path/to/project   # list existing -reanchor worktrees
 
 # Other verbs / flags (`--help-all` for the full advanced surface)
 daydream --shallow -s python /path/to/project      # shallow Python single-pass review-fix-test

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -49,8 +49,11 @@ from daydream.runner import RunConfig, run, run_feedback
 from daydream.trajectory import get_signal_recorder
 from daydream.ui import (
     ShutdownPanel,
+    create_console,
     get_shutdown_panel,
     print_error,
+    print_info,
+    print_success,
     set_shutdown_panel,
 )
 
@@ -567,6 +570,12 @@ def _build_improve_parser(
             metavar="DESCRIPTION",
             help="Change to investigate and turn into one implementation plan",
         )
+    if subverb == "prune-reanchor":
+        parser.add_argument(
+            "improve_prune_name",
+            metavar="NAME",
+            help="name of the -reanchor worktree to remove",
+        )
     parser.add_argument("target", metavar="TARGET", help="Repository to audit")
     parser.add_argument(
         "--effort",
@@ -611,7 +620,8 @@ def _parse_improve_args(argv: list[str]) -> RunConfig:
     improve_argv = argv[1:] if argv and argv[0] == "improve" else argv
     subverb = (
         improve_argv[0]
-        if improve_argv and improve_argv[0] == "plan"
+        if improve_argv
+        and improve_argv[0] in {"plan", "prune-reanchor", "list-reanchor"}
         else None
     )
     if subverb is not None:
@@ -639,6 +649,7 @@ def _parse_improve_args(argv: list[str]) -> RunConfig:
         improve_plan_description=getattr(
             args, "improve_plan_description", None
         ),
+        improve_prune_name=getattr(args, "improve_prune_name", None),
     )
 
 
@@ -1646,6 +1657,57 @@ def _handle_setup_command(argv: list[str]) -> int:
         return 1
 
 
+def _handle_prune_reanchor(config: RunConfig) -> int:
+    """Remove one named ``-reanchor`` worktree; sync cleanup, no improve flow.
+
+    Returns ``0`` on removal and ``1`` for every other verdict, so the exit
+    code reads as a reliable removal contract for scripts/operators.
+    """
+    from daydream.improve.plans import (
+        PRUNE_NOT_FOUND,
+        PRUNE_NOT_REANCHOR,
+        PRUNE_REMOVED,
+        prune_named_reanchor_worktree,
+    )
+
+    console = create_console()
+    name = config.improve_prune_name
+    assert name is not None  # the prune-reanchor sub-verb guard guarantees this
+    repo = Path(config.target) if config.target else Path.cwd()
+    outcome = prune_named_reanchor_worktree(repo, name)
+    if outcome.verdict == PRUNE_REMOVED:
+        suffix = (
+            f" (held {outcome.plan_count} re-anchored plans)"
+            if outcome.plan_count > 1
+            else ""
+        )
+        print_success(console, f"Removed worktree {name}{suffix}")
+        return 0
+    if outcome.verdict == PRUNE_NOT_FOUND:
+        print_error(console, "Prune re-anchor", f"No such worktree: {name}")
+    elif outcome.verdict == PRUNE_NOT_REANCHOR:
+        print_error(
+            console, "Prune re-anchor", f"{name!r} is not a -reanchor worktree"
+        )
+    else:  # PRUNE_GIT_FAILURE
+        print_error(console, "Prune re-anchor", f"Could not remove {name}")
+    return 1
+
+
+def _handle_list_reanchor(config: RunConfig) -> int:
+    """List existing ``-reanchor`` worktrees; sync, no improve flow.
+
+    An empty list still exits ``0`` — listing nothing is not an error.
+    """
+    from daydream.improve.plans import list_reanchor_worktrees
+
+    console = create_console()
+    repo = Path(config.target) if config.target else Path.cwd()
+    for path in list_reanchor_worktrees(repo):
+        print_info(console, path.name)
+    return 0
+
+
 def main() -> None:
     """Run the CLI entry point.
 
@@ -1667,6 +1729,9 @@ def main() -> None:
           and land the workflows via a PR (``--verify`` for the doctor)
         - ``ext`` — extension namespace (``validate`` loads the
           ``daydream_ext`` extension and resolve-checks the registry)
+        - ``improve`` — repository audit + advisory plans; sub-verbs
+          ``prune-reanchor`` / ``list-reanchor`` short-circuit to sync
+          filesystem cleanup, everything else runs the async audit flow
 
     Raises:
         SystemExit: Always raised with exit code 0 on success, 130 on keyboard
@@ -1704,6 +1769,19 @@ def main() -> None:
         # short-circuit before anyio.run.
         if verb == "ext":
             sys.exit(_handle_ext_command(argv[1:]))
+
+        # ``improve prune-reanchor`` / ``list-reanchor`` are pure filesystem
+        # cleanup (no agent work), so short-circuit to a sync handler instead of
+        # routing every improve invocation through anyio.run(run, ...). Peek
+        # ``argv[1]`` exactly as ``_parse_improve_args`` does.
+        if verb == "improve" and (argv[1] if len(argv) > 1 else None) in {
+            "prune-reanchor",
+            "list-reanchor",
+        }:
+            config = _parse_improve_args(argv)
+            if argv[1] == "prune-reanchor":
+                sys.exit(_handle_prune_reanchor(config))
+            sys.exit(_handle_list_reanchor(config))
 
         config = (
             _parse_improve_args(argv)

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -1683,7 +1683,7 @@ def _handle_prune_reanchor(config: RunConfig) -> int:
     console = create_console()
     name = config.improve_prune_name
     assert name is not None  # the prune-reanchor sub-verb guard guarantees this
-    repo = Path(config.target)
+    repo = Path(config.target) if config.target else Path.cwd()
     outcome = prune_named_reanchor_worktree(repo, name)
     if outcome.verdict == PRUNE_REMOVED:
         plans = "plans" if outcome.plan_count != 1 else "plan"
@@ -1713,7 +1713,7 @@ def _handle_list_reanchor(config: RunConfig) -> int:
     from daydream.improve.plans import list_reanchor_worktrees
 
     console = create_console()
-    repo = Path(config.target)
+    repo = Path(config.target) if config.target else Path.cwd()
     for path in list_reanchor_worktrees(repo):
         print_info(console, path.name)
     return 0

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -75,6 +75,16 @@ KNOWN_VERBS = {
     "ext",
 }
 
+# Sub-verbs recognized under the ``improve`` verb. Single source of truth for
+# improve sub-verb dispatch: ``_parse_improve_args`` strips any of these from
+# argv, and ``main()`` derives its sync short-circuit set from this constant so
+# the two can never drift apart.
+IMPROVE_SUB_VERBS = frozenset({"plan", "prune-reanchor", "list-reanchor"})
+# Sub-verbs that do no agent work and short-circuit to sync handlers in
+# ``main()`` — everything except the ``plan`` flow, which routes through
+# ``anyio.run(run, ...)``.
+IMPROVE_SYNC_SUB_VERBS = IMPROVE_SUB_VERBS - {"plan"}
+
 
 def _first_verb(argv: list[str]) -> str:
     """Classify the leading argv token into a verb.
@@ -620,8 +630,7 @@ def _parse_improve_args(argv: list[str]) -> RunConfig:
     improve_argv = argv[1:] if argv and argv[0] == "improve" else argv
     subverb = (
         improve_argv[0]
-        if improve_argv
-        and improve_argv[0] in {"plan", "prune-reanchor", "list-reanchor"}
+        if improve_argv and improve_argv[0] in IMPROVE_SUB_VERBS
         else None
     )
     if subverb is not None:
@@ -1667,6 +1676,7 @@ def _handle_prune_reanchor(config: RunConfig) -> int:
         PRUNE_NOT_FOUND,
         PRUNE_NOT_REANCHOR,
         PRUNE_REMOVED,
+        PRUNE_UNSAFE_NAME,
         prune_named_reanchor_worktree,
     )
 
@@ -1685,6 +1695,10 @@ def _handle_prune_reanchor(config: RunConfig) -> int:
     elif outcome.verdict == PRUNE_NOT_REANCHOR:
         print_error(
             console, "Prune re-anchor", f"{name!r} is not a -reanchor worktree"
+        )
+    elif outcome.verdict == PRUNE_UNSAFE_NAME:
+        print_error(
+            console, "Prune re-anchor", f"{name!r} is not a safe worktree name"
         )
     else:  # PRUNE_GIT_FAILURE
         print_error(console, "Prune re-anchor", f"Could not remove {name}")
@@ -1770,11 +1784,12 @@ def main() -> None:
         # ``improve prune-reanchor`` / ``list-reanchor`` are pure filesystem
         # cleanup (no agent work), so short-circuit to a sync handler instead of
         # routing every improve invocation through anyio.run(run, ...). Peek
-        # ``argv[1]`` exactly as ``_parse_improve_args`` does.
-        if verb == "improve" and (argv[1] if len(argv) > 1 else None) in {
-            "prune-reanchor",
-            "list-reanchor",
-        }:
+        # ``argv[1]`` exactly as ``_parse_improve_args`` does; the set comes from
+        # :data:`IMPROVE_SYNC_SUB_VERBS`, derived from the shared
+        # :data:`IMPROVE_SUB_VERBS` so dispatch can't drift.
+        if verb == "improve" and (
+            argv[1] if len(argv) > 1 else None
+        ) in IMPROVE_SYNC_SUB_VERBS:
             config = _parse_improve_args(argv)
             if argv[1] == "prune-reanchor":
                 sys.exit(_handle_prune_reanchor(config))

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -1673,14 +1673,11 @@ def _handle_prune_reanchor(config: RunConfig) -> int:
     console = create_console()
     name = config.improve_prune_name
     assert name is not None  # the prune-reanchor sub-verb guard guarantees this
-    repo = Path(config.target) if config.target else Path.cwd()
+    repo = Path(config.target)
     outcome = prune_named_reanchor_worktree(repo, name)
     if outcome.verdict == PRUNE_REMOVED:
-        suffix = (
-            f" (held {outcome.plan_count} re-anchored plans)"
-            if outcome.plan_count > 1
-            else ""
-        )
+        plans = "plans" if outcome.plan_count != 1 else "plan"
+        suffix = f" (held {outcome.plan_count} re-anchored {plans})"
         print_success(console, f"Removed worktree {name}{suffix}")
         return 0
     if outcome.verdict == PRUNE_NOT_FOUND:
@@ -1702,7 +1699,7 @@ def _handle_list_reanchor(config: RunConfig) -> int:
     from daydream.improve.plans import list_reanchor_worktrees
 
     console = create_console()
-    repo = Path(config.target) if config.target else Path.cwd()
+    repo = Path(config.target)
     for path in list_reanchor_worktrees(repo):
         print_info(console, path.name)
     return 0

--- a/daydream/improve/plans.py
+++ b/daydream/improve/plans.py
@@ -722,6 +722,22 @@ def prune_named_reanchor_worktree(repo: Path, name: str) -> NamedPruneOutcome:
     return NamedPruneOutcome(PRUNE_REMOVED, plan_count)
 
 
+def list_reanchor_worktrees(repo: Path) -> list[Path]:
+    """List the ``*.{_REANCHOR_DIR_SUFFIX}`` directories under ``.daydream/worktrees``.
+
+    Returns the exact names the automatic prune would remove, so an operator
+    can discover them before pruning. Existing directories only; non-directory
+    entries are skipped, matching ``prune_stale_reanchor_worktrees``.
+    """
+    return [
+        path
+        for path in (repo / ".daydream" / "worktrees").glob(
+            f"*{_REANCHOR_DIR_SUFFIX}"
+        )
+        if path.is_dir()
+    ]
+
+
 def _highest_plan_number(
     plans_dir: Path, entries: Iterable[PlanIndexEntry]
 ) -> int:

--- a/daydream/improve/plans.py
+++ b/daydream/improve/plans.py
@@ -692,13 +692,24 @@ class NamedPruneOutcome:
 def prune_named_reanchor_worktree(repo: Path, name: str) -> NamedPruneOutcome:
     """Remove the single ``-reanchor`` worktree named *name*, returning a verdict.
 
-    The worktree lives at ``.daydream/worktrees/<name>``. A ``daydream_plans``
-    directory's ``*.md`` count is captured (*before* removal) purely as
-    blast-radius metadata for the removal notice; it never affects removal.
-    Removal failures are reported as :data:`PRUNE_GIT_FAILURE`, never coerced
-    to success.
+    The worktree lives at ``.daydream/worktrees/<name>``. The name is
+    validated against the shared filesystem-safe dirname rules before any
+    filesystem or git access. A ``daydream_plans`` directory's ``*.md`` count
+    is captured (*before* removal) purely as blast-radius metadata for the
+    removal notice; it never affects removal. Removal failures are reported as
+    :data:`PRUNE_GIT_FAILURE`, never coerced to success.
+
+    Returns :data:`PRUNE_NOT_REANCHOR` for an invalid name, :data:`PRUNE_NOT_FOUND`
+    when the named directory is absent, :data:`PRUNE_REMOVED` on a successful
+    removal, and :data:`PRUNE_GIT_FAILURE` when removal itself fails.
     """
+    if _SAFE_DIRNAME.fullmatch(name) is None or not name.endswith(
+        _REANCHOR_DIR_SUFFIX
+    ):
+        return NamedPruneOutcome(PRUNE_NOT_REANCHOR)
     path = repo / ".daydream" / "worktrees" / name
+    if not path.is_dir():
+        return NamedPruneOutcome(PRUNE_NOT_FOUND)
     plans = path / "daydream_plans"
     if plans.is_dir():
         plan_count = sum(1 for _ in plans.glob("*.md"))

--- a/daydream/improve/plans.py
+++ b/daydream/improve/plans.py
@@ -692,6 +692,7 @@ def prune_stale_reanchor_worktrees(repo: Path) -> int:
 PRUNE_REMOVED = "removed"
 PRUNE_NOT_FOUND = "not-found"
 PRUNE_NOT_REANCHOR = "not-reanchor"
+PRUNE_UNSAFE_NAME = "unsafe-name"
 PRUNE_GIT_FAILURE = "git-failure"
 
 
@@ -700,7 +701,8 @@ class NamedPruneOutcome:
     """Outcome of a prune of one named re-anchor worktree.
 
     ``verdict`` is one of :data:`PRUNE_REMOVED`, :data:`PRUNE_NOT_FOUND`,
-    :data:`PRUNE_NOT_REANCHOR`, or :data:`PRUNE_GIT_FAILURE`. ``plan_count``
+    :data:`PRUNE_NOT_REANCHOR`, :data:`PRUNE_UNSAFE_NAME`, or
+    :data:`PRUNE_GIT_FAILURE`. ``plan_count``
     is best-effort metadata for the removal notice only, never a gate.
     """
 
@@ -718,13 +720,15 @@ def prune_named_reanchor_worktree(repo: Path, name: str) -> NamedPruneOutcome:
     removal notice; it never affects removal. Removal failures are reported as
     :data:`PRUNE_GIT_FAILURE`, never coerced to success.
 
-    Returns :data:`PRUNE_NOT_REANCHOR` for an invalid name, :data:`PRUNE_NOT_FOUND`
-    when the named directory is absent, :data:`PRUNE_REMOVED` on a successful
-    removal, and :data:`PRUNE_GIT_FAILURE` when removal itself fails.
+    Returns :data:`PRUNE_UNSAFE_NAME` for a name that fails the
+    filesystem-safe dirname rules, :data:`PRUNE_NOT_REANCHOR` for a safe name
+    lacking the ``-reanchor`` suffix, :data:`PRUNE_NOT_FOUND` when the named
+    directory is absent, :data:`PRUNE_REMOVED` on a successful removal, and
+    :data:`PRUNE_GIT_FAILURE` when removal itself fails.
     """
-    if _SAFE_DIRNAME.fullmatch(name) is None or not name.endswith(
-        _REANCHOR_DIR_SUFFIX
-    ):
+    if _SAFE_DIRNAME.fullmatch(name) is None:
+        return NamedPruneOutcome(PRUNE_UNSAFE_NAME)
+    if not name.endswith(_REANCHOR_DIR_SUFFIX):
         return NamedPruneOutcome(PRUNE_NOT_REANCHOR)
     path = _worktrees_dir(repo) / name
     if not path.is_dir():

--- a/daydream/improve/plans.py
+++ b/daydream/improve/plans.py
@@ -646,6 +646,29 @@ def planned_fingerprints(plans_dir: Path) -> set[str]:
     }
 
 
+def _worktrees_dir(repo: Path) -> Path:
+    """Return the ``.daydream/worktrees`` base directory for a repo.
+
+    Shared by every re-anchor worktree consumer so the base path cannot be
+    broadened in one place while others drift.
+    """
+    return repo / ".daydream" / "worktrees"
+
+
+def _iter_reanchor_worktrees(repo: Path) -> Iterable[Path]:
+    """Yield existing ``*-reanchor`` worktree directories under ``.daydream/worktrees``.
+
+    Single source of truth for which worktrees the automatic prune removes and
+    the manual list reports, so the discovery contract cannot drift. Existing
+    directories only; non-directory entries are skipped.
+    """
+    return (
+        path
+        for path in _worktrees_dir(repo).glob(f"*{_REANCHOR_DIR_SUFFIX}")
+        if path.is_dir()
+    )
+
+
 def prune_stale_reanchor_worktrees(repo: Path) -> int:
     """Remove leftover ``*-reanchor`` worktrees from prior plan runs.
 
@@ -655,11 +678,7 @@ def prune_stale_reanchor_worktrees(repo: Path) -> int:
     so one stale worktree never blocks a plan run.
     """
     removed = 0
-    for path in (
-        repo / ".daydream" / "worktrees"
-    ).glob(f"*{_REANCHOR_DIR_SUFFIX}"):
-        if not path.is_dir():
-            continue
+    for path in _iter_reanchor_worktrees(repo):
         try:
             git_ops.worktree_remove(repo, path, force=True)
         except git_ops.GitError:
@@ -707,7 +726,7 @@ def prune_named_reanchor_worktree(repo: Path, name: str) -> NamedPruneOutcome:
         _REANCHOR_DIR_SUFFIX
     ):
         return NamedPruneOutcome(PRUNE_NOT_REANCHOR)
-    path = repo / ".daydream" / "worktrees" / name
+    path = _worktrees_dir(repo) / name
     if not path.is_dir():
         return NamedPruneOutcome(PRUNE_NOT_FOUND)
     plans = path / "daydream_plans"
@@ -729,13 +748,7 @@ def list_reanchor_worktrees(repo: Path) -> list[Path]:
     can discover them before pruning. Existing directories only; non-directory
     entries are skipped, matching ``prune_stale_reanchor_worktrees``.
     """
-    return [
-        path
-        for path in (repo / ".daydream" / "worktrees").glob(
-            f"*{_REANCHOR_DIR_SUFFIX}"
-        )
-        if path.is_dir()
-    ]
+    return list(_iter_reanchor_worktrees(repo))
 
 
 def _highest_plan_number(
@@ -1360,12 +1373,7 @@ class PlanWriteSession:
                 run_id = self._run_session_id or f"run-{self._planned_at[:12]}"
                 if _SAFE_DIRNAME.fullmatch(run_id) is None:
                     run_id = f"run-{self._planned_at[:12]}"
-                worktree = (
-                    self._repo
-                    / ".daydream"
-                    / "worktrees"
-                    / f"{run_id}{_REANCHOR_DIR_SUFFIX}"
-                )
+                worktree = _worktrees_dir(self._repo) / f"{run_id}{_REANCHOR_DIR_SUFFIX}"
                 git_ops.worktree_add(
                     self._repo, worktree, new_head, detach=True
                 )

--- a/daydream/improve/plans.py
+++ b/daydream/improve/plans.py
@@ -668,6 +668,49 @@ def prune_stale_reanchor_worktrees(repo: Path) -> int:
     return removed
 
 
+# Verdicts for a named prune of a single re-anchor worktree. Distinct outcomes
+# let the caller report precisely what happened instead of a bare success/fail.
+PRUNE_REMOVED = "removed"
+PRUNE_NOT_FOUND = "not-found"
+PRUNE_NOT_REANCHOR = "not-reanchor"
+PRUNE_GIT_FAILURE = "git-failure"
+
+
+@dataclass(frozen=True)
+class NamedPruneOutcome:
+    """Outcome of a prune of one named re-anchor worktree.
+
+    ``verdict`` is one of :data:`PRUNE_REMOVED`, :data:`PRUNE_NOT_FOUND`,
+    :data:`PRUNE_NOT_REANCHOR`, or :data:`PRUNE_GIT_FAILURE`. ``plan_count``
+    is best-effort metadata for the removal notice only, never a gate.
+    """
+
+    verdict: str
+    plan_count: int = 0
+
+
+def prune_named_reanchor_worktree(repo: Path, name: str) -> NamedPruneOutcome:
+    """Remove the single ``-reanchor`` worktree named *name*, returning a verdict.
+
+    The worktree lives at ``.daydream/worktrees/<name>``. A ``daydream_plans``
+    directory's ``*.md`` count is captured (*before* removal) purely as
+    blast-radius metadata for the removal notice; it never affects removal.
+    Removal failures are reported as :data:`PRUNE_GIT_FAILURE`, never coerced
+    to success.
+    """
+    path = repo / ".daydream" / "worktrees" / name
+    plans = path / "daydream_plans"
+    if plans.is_dir():
+        plan_count = sum(1 for _ in plans.glob("*.md"))
+    else:
+        plan_count = 0
+    try:
+        git_ops.worktree_remove(repo, path, force=True)
+    except git_ops.GitError:
+        return NamedPruneOutcome(PRUNE_GIT_FAILURE, plan_count)
+    return NamedPruneOutcome(PRUNE_REMOVED, plan_count)
+
+
 def _highest_plan_number(
     plans_dir: Path, entries: Iterable[PlanIndexEntry]
 ) -> int:

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -193,6 +193,8 @@ class RunConfig:
         improve_scope: Optional service name/root/glob to audit.
         improve_plan_description: One-line request for ``daydream improve plan``;
             switches the flow to single-request investigation mode.
+        improve_prune_name: Name of the ``-reanchor`` worktree to remove for the
+            ``daydream improve prune-reanchor`` sub-verb (only set there).
         skill_availability: Stack keys with an installed Beagle review skill,
             resolved once by :func:`run` from ``get_installed_skills()``. ``None``
             means unresolved or registry-unreadable (→ optimistic routing in
@@ -278,6 +280,7 @@ class RunConfig:
     improve_focus: str | None = None
     improve_scope: str | None = None
     improve_plan_description: str | None = None
+    improve_prune_name: str | None = None
     skill_availability: frozenset[str] | None = None
     # Issue #309: uncovered-diff-file sweep (second-pass reviewer). CLI-tier
     # overrides; ``None`` falls through to the file-config scalar then the

--- a/tests/test_cli_main_integration.py
+++ b/tests/test_cli_main_integration.py
@@ -180,3 +180,53 @@ def test_non_tty_auto_enables_non_interactive(
         cli.main()
 
     assert captured["v"] is True  # auto-enabled with no flag
+
+
+def test_cli_main_prune_reanchor_removes_and_exits_0(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from tests.harness.git_helpers import git
+    from tests.test_improve_plans import _repo
+
+    repo, _ = _repo(tmp_path)
+    target = repo / ".daydream" / "worktrees" / "run-abcd-reanchor"
+    git(repo, "worktree", "add", "--detach", str(target), "HEAD")
+
+    _silence(monkeypatch)
+    _silence_cli_and_runner(monkeypatch)
+    monkeypatch.setattr("daydream.cli.print_success", lambda *a, **k: None)
+    monkeypatch.setattr("daydream.cli.print_error", lambda *a, **k: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["daydream", "improve", "prune-reanchor", "run-abcd-reanchor", str(repo)],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert exc.value.code == 0
+    assert not target.exists()
+    assert "run-abcd-reanchor" not in git(repo, "worktree", "list")
+
+
+def test_cli_main_prune_reanchor_rejects_name_exits_1(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from tests.test_improve_plans import _repo
+
+    repo, _ = _repo(tmp_path)
+    _silence(monkeypatch)
+    _silence_cli_and_runner(monkeypatch)
+    monkeypatch.setattr("daydream.cli.print_success", lambda *a, **k: None)
+    monkeypatch.setattr("daydream.cli.print_error", lambda *a, **k: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["daydream", "improve", "prune-reanchor", "run-abc", str(repo)],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert exc.value.code == 1
+    assert "run-abc" not in (repo / ".daydream" / "worktrees").glob("*")
+    assert not (repo / ".daydream" / "worktrees" / "run-abc").exists()

--- a/tests/test_cli_main_integration.py
+++ b/tests/test_cli_main_integration.py
@@ -228,5 +228,7 @@ def test_cli_main_prune_reanchor_rejects_name_exits_1(
     with pytest.raises(SystemExit) as exc:
         cli.main()
     assert exc.value.code == 1
-    assert "run-abc" not in (repo / ".daydream" / "worktrees").glob("*")
+    assert not any(
+        p.name == "run-abc" for p in (repo / ".daydream" / "worktrees").glob("*")
+    )
     assert not (repo / ".daydream" / "worktrees" / "run-abc").exists()

--- a/tests/test_cli_main_integration.py
+++ b/tests/test_cli_main_integration.py
@@ -232,3 +232,60 @@ def test_cli_main_prune_reanchor_rejects_name_exits_1(
         p.name == "run-abc" for p in (repo / ".daydream" / "worktrees").glob("*")
     )
     assert not (repo / ".daydream" / "worktrees" / "run-abc").exists()
+
+
+def test_cli_main_list_reanchor_lists_and_exits_0(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``improve list-reanchor`` through cli.main exits 0 and names the
+    re-anchor worktrees the automatic prune would remove.
+
+    The sync sub-verb short-circuits in ``main()`` (no anyio/agent work), so no
+    stub backend is needed; the observable outcome is the exit code and the
+    printed worktree names.
+    """
+    from tests.harness.git_helpers import git
+    from tests.test_improve_plans import _repo
+
+    repo, _ = _repo(tmp_path)
+    target = repo / ".daydream" / "worktrees" / "run-abcd-reanchor"
+    git(repo, "worktree", "add", "--detach", str(target), "HEAD")
+
+    _silence(monkeypatch)
+    _silence_cli_and_runner(monkeypatch)
+    listed: list[str] = []
+    monkeypatch.setattr(
+        "daydream.cli.print_info",
+        lambda _console, name: listed.append(str(name)),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["daydream", "improve", "list-reanchor", str(repo)],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert exc.value.code == 0
+    assert listed == ["run-abcd-reanchor"]
+
+
+def test_cli_main_list_reanchor_empty_exits_0(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An empty re-anchor set still exits 0 — listing nothing is not an error."""
+    from tests.test_improve_plans import _repo
+
+    repo, _ = _repo(tmp_path)
+    _silence(monkeypatch)
+    _silence_cli_and_runner(monkeypatch)
+    monkeypatch.setattr("daydream.cli.print_info", lambda *a, **k: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["daydream", "improve", "list-reanchor", str(repo)],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert exc.value.code == 0

--- a/tests/test_improve_plans.py
+++ b/tests/test_improve_plans.py
@@ -24,6 +24,7 @@ from daydream.improve.command_contract import (
 )
 from daydream.improve.plans import (
     PLAN_INDEX_FILENAME,
+    PRUNE_REMOVED,
     PlanWriteSession,
     load_rejections,
     planned_fingerprints,
@@ -1686,6 +1687,39 @@ def test_stale_reanchor_worktrees_are_pruned_at_next_run(
     assert removed == 1
     assert not stale_dir.exists()
     assert "run-abcd-reanchor" not in git(repo, "worktree", "list")
+
+
+def test_prune_named_reanchor_worktree_removes_valid_worktree(
+    repo: Path, head_sha: str
+) -> None:
+    from daydream.improve.plans import prune_named_reanchor_worktree
+
+    target = repo / ".daydream" / "worktrees" / "run-abcd-reanchor"
+    git(repo, "worktree", "add", "--detach", str(target), "HEAD")
+
+    outcome = prune_named_reanchor_worktree(repo, "run-abcd-reanchor")
+
+    assert outcome.verdict == PRUNE_REMOVED
+    assert not target.exists()
+    assert "run-abcd-reanchor" not in git(repo, "worktree", "list")
+
+
+def test_prune_named_reanchor_worktree_reports_plan_count(
+    repo: Path, head_sha: str
+) -> None:
+    from daydream.improve.plans import prune_named_reanchor_worktree
+
+    target = repo / ".daydream" / "worktrees" / "run-abcd-reanchor"
+    git(repo, "worktree", "add", "--detach", str(target), "HEAD")
+    plans = target / "daydream_plans"
+    plans.mkdir(parents=True, exist_ok=True)
+    for n in ("001-x.md", "002-y.md"):
+        (plans / n).write_text("# plan\n", encoding="utf-8")
+
+    outcome = prune_named_reanchor_worktree(repo, "run-abcd-reanchor")
+
+    assert outcome.verdict == PRUNE_REMOVED
+    assert outcome.plan_count == 2
 
 
 def test_planned_at_still_matching_head_writes_in_place(

--- a/tests/test_improve_plans.py
+++ b/tests/test_improve_plans.py
@@ -24,6 +24,9 @@ from daydream.improve.command_contract import (
 )
 from daydream.improve.plans import (
     PLAN_INDEX_FILENAME,
+    PRUNE_GIT_FAILURE,
+    PRUNE_NOT_FOUND,
+    PRUNE_NOT_REANCHOR,
     PRUNE_REMOVED,
     PlanWriteSession,
     load_rejections,
@@ -1720,6 +1723,60 @@ def test_prune_named_reanchor_worktree_reports_plan_count(
 
     assert outcome.verdict == PRUNE_REMOVED
     assert outcome.plan_count == 2
+
+
+@pytest.mark.parametrize(
+    "bad_name",
+    [
+        "run-abc",          # no -reanchor suffix
+        "../etc-reanchor",  # traversal: slash + leading dot
+        ".hidden-reanchor",  # first char not [A-Za-z0-9]
+        "a" * 81,           # over _SAFE_DIRNAME's 0-79 tail bound
+        "run abc-reanchor",  # space outside the safe class
+    ],
+)
+def test_prune_named_reanchor_worktree_rejects_invalid_names(
+    repo: Path, bad_name: str
+) -> None:
+    from daydream.improve.plans import prune_named_reanchor_worktree
+
+    before = set((repo / ".daydream" / "worktrees").glob("*")) if (
+        repo / ".daydream" / "worktrees"
+    ).exists() else set()
+
+    outcome = prune_named_reanchor_worktree(repo, bad_name)
+
+    assert outcome.verdict == PRUNE_NOT_REANCHOR
+    after = set((repo / ".daydream" / "worktrees").glob("*")) if (
+        repo / ".daydream" / "worktrees"
+    ).exists() else set()
+    assert before == after  # nothing reached the filesystem or git
+    assert "run-abcd-reanchor" not in git(repo, "worktree", "list")
+
+
+def test_prune_named_reanchor_worktree_not_found(repo: Path) -> None:
+    from daydream.improve.plans import prune_named_reanchor_worktree
+
+    outcome = prune_named_reanchor_worktree(repo, "run-zzzz-reanchor")
+
+    assert outcome.verdict == PRUNE_NOT_FOUND
+
+
+def test_prune_named_reanchor_worktree_unregistered_dir_is_git_failure(
+    repo: Path,
+) -> None:
+    from daydream.improve.plans import prune_named_reanchor_worktree
+
+    target = repo / ".daydream" / "worktrees" / "run-abcd-reanchor"
+    target.mkdir(parents=True, exist_ok=True)  # plain dir, NOT a git worktree
+
+    outcome = prune_named_reanchor_worktree(repo, "run-abcd-reanchor")
+
+    assert outcome.verdict == PRUNE_GIT_FAILURE
+    assert target.exists()  # left in place; git refused to remove a non-worktree
+    # a plain dir is never a registered worktree, so this holds regardless of
+    # how many real re-anchor worktrees the suite created
+    assert "run-abcd-reanchor" not in git(repo, "worktree", "list")
 
 
 def test_planned_at_still_matching_head_writes_in_place(

--- a/tests/test_improve_plans.py
+++ b/tests/test_improve_plans.py
@@ -1779,6 +1779,23 @@ def test_prune_named_reanchor_worktree_unregistered_dir_is_git_failure(
     assert "run-abcd-reanchor" not in git(repo, "worktree", "list")
 
 
+def test_list_reanchor_worktrees_lists_only_reanchor_worktrees(
+    repo: Path, head_sha: str
+) -> None:
+    from daydream.improve.plans import list_reanchor_worktrees
+
+    a = repo / ".daydream" / "worktrees" / "run-aaaa-reanchor"
+    b = repo / ".daydream" / "worktrees" / "run-bbbb-reanchor"
+    other = repo / ".daydream" / "worktrees" / "feature"
+    for w in (a, b, other):
+        git(repo, "worktree", "add", "--detach", str(w), "HEAD")
+
+    names = [p.name for p in list_reanchor_worktrees(repo)]
+
+    assert sorted(names) == ["run-aaaa-reanchor", "run-bbbb-reanchor"]
+    assert "feature" not in names
+
+
 def test_planned_at_still_matching_head_writes_in_place(
     repo: Path,
     head_sha: str,

--- a/tests/test_improve_plans.py
+++ b/tests/test_improve_plans.py
@@ -28,6 +28,7 @@ from daydream.improve.plans import (
     PRUNE_NOT_FOUND,
     PRUNE_NOT_REANCHOR,
     PRUNE_REMOVED,
+    PRUNE_UNSAFE_NAME,
     PlanWriteSession,
     load_rejections,
     planned_fingerprints,
@@ -1728,14 +1729,13 @@ def test_prune_named_reanchor_worktree_reports_plan_count(
 @pytest.mark.parametrize(
     "bad_name",
     [
-        "run-abc",          # no -reanchor suffix
         "../etc-reanchor",  # traversal: slash + leading dot
         ".hidden-reanchor",  # first char not [A-Za-z0-9]
         "a" * 81,           # over _SAFE_DIRNAME's 0-79 tail bound
         "run abc-reanchor",  # space outside the safe class
     ],
 )
-def test_prune_named_reanchor_worktree_rejects_invalid_names(
+def test_prune_named_reanchor_worktree_rejects_unsafe_names(
     repo: Path, bad_name: str
 ) -> None:
     from daydream.improve.plans import prune_named_reanchor_worktree
@@ -1745,6 +1745,25 @@ def test_prune_named_reanchor_worktree_rejects_invalid_names(
     ).exists() else set()
 
     outcome = prune_named_reanchor_worktree(repo, bad_name)
+
+    assert outcome.verdict == PRUNE_UNSAFE_NAME
+    after = set((repo / ".daydream" / "worktrees").glob("*")) if (
+        repo / ".daydream" / "worktrees"
+    ).exists() else set()
+    assert before == after  # nothing reached the filesystem or git
+    assert "run-abcd-reanchor" not in git(repo, "worktree", "list")
+
+
+def test_prune_named_reanchor_worktree_rejects_non_reanchor_name(
+    repo: Path,
+) -> None:
+    from daydream.improve.plans import prune_named_reanchor_worktree
+
+    before = set((repo / ".daydream" / "worktrees").glob("*")) if (
+        repo / ".daydream" / "worktrees"
+    ).exists() else set()
+
+    outcome = prune_named_reanchor_worktree(repo, "run-abc")
 
     assert outcome.verdict == PRUNE_NOT_REANCHOR
     after = set((repo / ".daydream" / "worktrees").glob("*")) if (


### PR DESCRIPTION
## Summary

Implements **operator-initiated pruning of executed re-anchor worktrees** — the follow-up to #350.

#350 added automatic pruning of stale `*-reanchor` worktrees at the start of a plan run, but left no way to prune a *specific* re-anchor worktree after its plan has been executed. This PR adds that CLI surface.

### New `daydream improve` sub-verbs
- **`prune-reanchor`** — remove one named `*-reanchor` worktree once its plan has been executed (DONE on the execution board). Validates names, reports not-found / git-failure clearly, and splits the unsafe-name rejection from the wrong-suffix rejection into distinct verdicts (`PRUNE_UNSAFE_NAME` vs `PRUNE_NOT_REANCHOR`).
- **`list-reanchor`** — list existing re-anchor worktrees.

### Refactors / fixes
- Centralized re-anchor worktree path discovery and the sub-verb dispatch set (`IMPROVE_SUB_VERBS` / `IMPROVE_SYNC_SUB_VERBS`) as a single source of truth (previously `main()` and `_parse_improve_args` each kept a hand-maintained literal set).
- Removed the duplicated sub-verb dispatch set.

### Tests
- Real-path CLI integration tests for the new `prune-reanchor` and `list-reanchor` sub-verbs.
- Unit tests for name validation, not-found / git-failure reporting, and the split verdicts.

Full suite: **3182 passed, 6 skipped**.

## Test Plan
- [x] Unit tests for plans.py validation and verdict paths
- [x] CLI integration tests for prune-reanchor / list-reanchor
- [x] Full suite green (3182 passed, 6 skipped)

Closes #351
