### PR TITLE
feat(improve): surface re-anchored plans outside the README execution board (Closes #352)

### DIFF
--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -1196,6 +1196,79 @@ def _handle_harvest_command(argv: list[str]) -> int:
     return 0
 
 
+def _build_list_reanchored_parser() -> argparse.ArgumentParser:
+    """Build the parser for ``daydream improve list-reanchored <target>``.
+
+    A read-only listing of re-anchored plans from the durable plan index.
+    ``--json`` switches the output from the human summary table to a JSON
+    array, so the reading is scriptable.
+    """
+    parser = argparse.ArgumentParser(
+        prog="daydream improve list-reanchored",
+        description="List every re-anchored plan from the durable plan index.",
+    )
+    parser.add_argument("target", metavar="TARGET", help="Repository to list")
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the rows as a JSON array instead of a human table.",
+    )
+    return parser
+
+
+def _handle_list_reanchored_command(argv: list[str]) -> int:
+    """Handle ``daydream improve list-reanchored <target>``.
+
+    A one-purpose, read-only listing of re-anchored plans from the durable
+    ``daydream_plans/.index.json``. Every row carries the plan number, title,
+    status, and landing path. An empty result prints a clear line and exits 0.
+
+    Returns:
+        ``0`` always on non-exceptional paths.
+    """
+    import json
+
+    from daydream.improve.plans import reanchored_plan_rows
+    from daydream.ui import create_console, print_info
+
+    parser = _build_list_reanchored_parser()
+    args = parser.parse_args(argv)
+    rows = reanchored_plan_rows(Path(args.target) / "daydream_plans")
+
+    console = create_console()
+    if args.json:
+        console.print(
+            json.dumps(
+                [
+                    {
+                        "number": entry.number,
+                        "title": entry.title,
+                        "status": entry.status,
+                        "landing_path": entry.landing_path,
+                    }
+                    for entry in rows
+                ],
+                indent=2,
+            ),
+            soft_wrap=True,
+        )
+        return 0
+    if not rows:
+        print_info(console, "No re-anchored plans.")
+        return 0
+    print_info(console, "Re-anchored plans:")
+    # Long landing paths must not wrap mid-string (rich would otherwise insert
+    # a newline inside the path at the console width), so rows use soft_wrap.
+    for entry in rows:
+        console.print(
+            f"[neon.cyan]ℹ[/] [neon.fg]{entry.number:03d} {entry.title} "
+            f"| {entry.status} | "
+            f"{entry.landing_path or '(unavailable)'}[/]",
+            soft_wrap=True,
+        )
+    return 0
+
+
 def _build_label_parser() -> argparse.ArgumentParser:
     """Build the parser for ``daydream corpus label <session-prefix> --outcome ...``.
 
@@ -1704,6 +1777,12 @@ def main() -> None:
         # short-circuit before anyio.run.
         if verb == "ext":
             sys.exit(_handle_ext_command(argv[1:]))
+
+        # ``improve list-reanchored`` is a sync, read-only one-purpose command
+        # (mirroring the corpus/bench/ext short-circuits), so it never spins up
+        # a flow through ``_parse_improve_args``/``anyio.run``.
+        if verb == "improve" and len(argv) > 1 and argv[1] == "list-reanchored":
+            sys.exit(_handle_list_reanchored_command(argv[2:]))
 
         config = (
             _parse_improve_args(argv)

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -1228,6 +1228,8 @@ def _handle_list_reanchored_command(argv: list[str]) -> int:
     """
     import json
 
+    from rich.markup import escape
+
     from daydream.improve.plans import reanchored_plan_rows
     from daydream.ui import create_console, print_info
 
@@ -1251,6 +1253,7 @@ def _handle_list_reanchored_command(argv: list[str]) -> int:
                 indent=2,
             ),
             soft_wrap=True,
+            markup=False,
         )
         return 0
     if not rows:
@@ -1261,9 +1264,9 @@ def _handle_list_reanchored_command(argv: list[str]) -> int:
     # a newline inside the path at the console width), so rows use soft_wrap.
     for entry in rows:
         console.print(
-            f"[neon.cyan]ℹ[/] [neon.fg]{entry.number:03d} {entry.title} "
-            f"| {entry.status} | "
-            f"{entry.landing_path or '(unavailable)'}[/]",
+            f"[neon.cyan]ℹ[/] [neon.fg]{entry.number:03d} "
+            f"{escape(entry.title)} | {escape(entry.status)} | "
+            f"{escape(entry.landing_path) if entry.landing_path else '(unavailable)'}[/]",
             soft_wrap=True,
         )
     return 0

--- a/daydream/improve/orchestrator.py
+++ b/daydream/improve/orchestrator.py
@@ -61,6 +61,7 @@ from daydream.improve.plans import (
     load_rejections,
     plan_slug,
     prune_stale_reanchor_worktrees,
+    reanchored_plan_rows,
     record_plan_write_diagnostics,
     record_rejections,
 )
@@ -2111,6 +2112,29 @@ def _finish_publication(
         )
 
 
+def _reanchored_report_section(plans_dir: Path) -> str:
+    """Render the durable ``Re-anchored plans`` report section.
+
+    Reads the durable plan index (never the session result), so prior-run
+    re-anchors surface even when the current run re-anchored none. Returns a
+    self-contained markdown section including its own header and a trailing
+    blank line.
+    """
+    rows = reanchored_plan_rows(plans_dir)
+    if not rows:
+        return "## Re-anchored plans\n\n- No re-anchored plans.\n\n"
+    table = (
+        "| Plan | Title | Status | Landing path |\n"
+        "| --- | --- | --- | --- |\n"
+    )
+    for entry in rows:
+        table += (
+            f"| {entry.number:03d} | {markdown_cell(entry.title)} "
+            f"| `{entry.status}` | `{entry.landing_path or '(unavailable)'}` |\n"
+        )
+    return f"## Re-anchored plans\n\n{table}\n"
+
+
 def _render_report(ctx: FlowContext) -> str:
     services = ctx.data["services"]
     all_services = ctx.data["all_services"]
@@ -2231,6 +2255,7 @@ def _render_report(ctx: FlowContext) -> str:
         f"- Previously rejected findings suppressed: {previously_rejected}\n"
         "\n## Plan writing\n\n"
         f"{plan_lines}\n\n"
+        f"{_reanchored_report_section(ctx.work.repo / 'daydream_plans')}"
         "## GitHub issues\n\n"
         f"{publication_lines}"
     )

--- a/daydream/improve/plans.py
+++ b/daydream/improve/plans.py
@@ -1355,10 +1355,11 @@ class PlanWriteSession:
                 [entries[index] for index in sorted(entries)],
                 check_links=True,
             )
+            # The re-anchor worktree is pruned at the start of the next plan run,
+            # so the durable status must point at the surviving copy in the main
+            # index rather than a path that will no longer exist.
             landed_rel = (
-                (worktree / "daydream_plans" / filename)
-                .relative_to(self._repo)
-                .as_posix()
+                (self._plans_dir / filename).relative_to(self._repo).as_posix()
             )
             self._entries[number] = _index_entry(
                 number=number,
@@ -1367,7 +1368,7 @@ class PlanWriteSession:
                 fingerprint=reservation.fingerprint,
                 finding=finding,
                 planned_at=new_head,
-                status=f"REANCHORED (landed at {landed_rel})",
+                status=f"{REANCHORED_STATUS_PREFIX} (landed at {landed_rel})",
             )
         except Exception:  # noqa: BLE001 - persist a safe re-anchor disposition
             return _reanchor_failed()

--- a/daydream/improve/plans.py
+++ b/daydream/improve/plans.py
@@ -49,7 +49,7 @@ _SAFE_DIRNAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$")
 # re-anchor write share it so a rename can never silently stop pruning.
 _REANCHOR_DIR_SUFFIX = "-reanchor"
 REANCHORED_STATUS_PREFIX = "REANCHORED"
-_REANCHORED_LANDED = re.compile(r"^REANCHORED \(landed at (.+)\)$")
+_REANCHORED_LANDED = re.compile(rf"^{re.escape(REANCHORED_STATUS_PREFIX)} \(landed at (.+)\)$")
 
 
 def load_rejections(plans_dir: Path) -> dict[str, dict[str, Any]]:

--- a/daydream/improve/plans.py
+++ b/daydream/improve/plans.py
@@ -48,6 +48,8 @@ _SAFE_DIRNAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$")
 # Re-anchor worktree dirnames end in this suffix; the prune pass and the
 # re-anchor write share it so a rename can never silently stop pruning.
 _REANCHOR_DIR_SUFFIX = "-reanchor"
+REANCHORED_STATUS_PREFIX = "REANCHORED"
+_REANCHORED_LANDED = re.compile(r"^REANCHORED \(landed at (.+)\)$")
 
 
 def load_rejections(plans_dir: Path) -> dict[str, dict[str, Any]]:
@@ -343,6 +345,16 @@ class PlanIndexEntry:
         """The plan file this entry names, or ``None`` when none was written."""
         return f"{self.number:03d}-{self.slug}.md" if self.slug else None
 
+    @property
+    def landing_path(self) -> str | None:
+        """The repo-relative landing path of a re-anchored plan, or ``None``.
+
+        ``None`` when the status lacks the ``(landed at ...)`` suffix — the
+        path is parsed tolerantly and never synthesized.
+        """
+        match = _REANCHORED_LANDED.match(self.status)
+        return match.group(1) if match else None
+
 
 def _index_field(value: Any) -> str:
     """Normalize a model- or operator-supplied index field for durable storage."""
@@ -549,6 +561,19 @@ def load_plan_index(plans_dir: Path) -> list[PlanIndexEntry]:
         entry
         for item in payload["plans"]
         if (entry := _entry_from_payload(item)) is not None
+    ]
+
+
+def reanchored_plan_rows(plans_dir: Path) -> list[PlanIndexEntry]:
+    """Return every re-anchored plan recorded in the durable index.
+
+    Reuses :func:`load_plan_index`, which treats an absent/malformed sidecar
+    as empty, so this helper never raises on a missing or broken index.
+    """
+    return [
+        entry
+        for entry in load_plan_index(plans_dir)
+        if entry.status.startswith(REANCHORED_STATUS_PREFIX)
     ]
 
 

--- a/tests/test_improve_plans.py
+++ b/tests/test_improve_plans.py
@@ -14,7 +14,6 @@ from daydream.improve.assemble import (
     assemble_plan,
     render_issue,
 )
-from daydream.improve.orchestrator import _reanchored_report_section
 from daydream.improve.command_contract import (
     canonicalize_directory_scope,
     literal_command_error,
@@ -25,6 +24,7 @@ from daydream.improve.command_contract import (
     validate_host_commands,
     validate_recon_commands,
 )
+from daydream.improve.orchestrator import _reanchored_report_section
 from daydream.improve.plans import (
     PLAN_INDEX_FILENAME,
     PlanIndexEntry,

--- a/tests/test_improve_plans.py
+++ b/tests/test_improve_plans.py
@@ -14,6 +14,7 @@ from daydream.improve.assemble import (
     assemble_plan,
     render_issue,
 )
+from daydream.improve.orchestrator import _reanchored_report_section
 from daydream.improve.command_contract import (
     canonicalize_directory_scope,
     literal_command_error,
@@ -4021,3 +4022,24 @@ def test_improve_list_reanchored_json_mode(
     assert rows[0]["title"] == "Fix N+1 catalog queries"
     assert rows[0]["status"].startswith("REANCHORED")
     assert rows[0]["landing_path"] == expected_rel
+
+
+def test_reanchored_report_section_lists_rows(repo: Path, head_sha: str) -> None:
+    expected_rel = _make_reanchored_repo(repo, head_sha)
+
+    section = _reanchored_report_section(repo / "daydream_plans")
+
+    assert "## Re-anchored plans" in section
+    assert "001" in section
+    assert "Fix N+1 catalog queries" in section
+    assert expected_rel in section
+
+
+def test_reanchored_report_section_empty(tmp_path: Path) -> None:
+    plans_dir = tmp_path / "daydream_plans"
+    plans_dir.mkdir(parents=True)  # no .index.json
+
+    section = _reanchored_report_section(plans_dir)
+
+    assert "## Re-anchored plans" in section
+    assert "No re-anchored plans" in section

--- a/tests/test_improve_plans.py
+++ b/tests/test_improve_plans.py
@@ -24,9 +24,12 @@ from daydream.improve.command_contract import (
 )
 from daydream.improve.plans import (
     PLAN_INDEX_FILENAME,
+    PlanIndexEntry,
     PlanWriteSession,
+    _entry_payload,
     load_rejections,
     planned_fingerprints,
+    reanchored_plan_rows,
     record_rejections,
 )
 from daydream.improve.prioritize import aggregate_cross_service
@@ -3882,3 +3885,61 @@ def test_all_rejected_members_suppress_package_without_plan_identity(
     assert len(result["skipped"]) == 1
     assert "number" not in result["skipped"][0]
     assert "path" not in result["skipped"][0]
+
+
+def _write_single_entry_sidecar(plans_dir: Path, status: str) -> None:
+    """Write a one-entry durable plan index with the given ``status``."""
+    plans_dir.mkdir(parents=True, exist_ok=True)
+    entry = PlanIndexEntry(
+        number=1,
+        slug="batch-catalog-queries",
+        title="Fix N+1 catalog queries",
+        fingerprint="fp-fix-n-plus-one",
+        package_fingerprint="fp-fix-n-plus-one",
+        member_fingerprints=("fp-fix-n-plus-one",),
+        member_aliases=(),
+        priority="P1",
+        effort="M",
+        risk="MED",
+        category="performance",
+        planned_at="0000000000000000000000000000000000000000",
+        status=status,
+        host_blocked=False,
+        change_shape="unknown",
+        maintenance_signals=(),
+        reuse_target="",
+    )
+    (plans_dir / ".index.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "plans": [_entry_payload(entry)],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_reanchored_plan_rows_tolerant_of_status_without_landed_suffix(
+    tmp_path: Path,
+) -> None:
+    plans_dir = tmp_path / "daydream_plans"
+    _write_single_entry_sidecar(plans_dir, "REANCHORED")
+
+    rows = reanchored_plan_rows(plans_dir)
+
+    assert len(rows) == 1
+    assert rows[0].number == 1
+    assert rows[0].status.startswith("REANCHORED")
+    assert rows[0].landing_path is None
+
+
+def test_reanchored_plan_rows_returns_empty_when_none_reanchored(
+    tmp_path: Path,
+) -> None:
+    plans_dir = tmp_path / "daydream_plans"
+    _write_single_entry_sidecar(plans_dir, "TODO")
+
+    assert reanchored_plan_rows(plans_dir) == []
+    # An absent index is also an empty result, never an error.
+    assert reanchored_plan_rows(tmp_path / "does-not-exist") == []

--- a/tests/test_improve_plans.py
+++ b/tests/test_improve_plans.py
@@ -1585,10 +1585,9 @@ def test_head_change_after_planning_reanchors_into_new_worktree(
     # main repo durable surface now lists the re-anchored plan
     main_index = (repo / "daydream_plans" / "README.md").read_text(encoding="utf-8")
     assert "REANCHORED" in main_index
-    assert (
-        reanchor_plans.relative_to(repo).as_posix() + "/001-batch-catalog-queries.md"
-        in main_index
-    )
+    # the durable status points at the surviving main-index sibling, not the
+    # pruned re-anchor worktree path.
+    assert "landed at daydream_plans/001-batch-catalog-queries.md" in main_index
     main_sidecar = json.loads(
         (repo / "daydream_plans" / PLAN_INDEX_FILENAME).read_text(encoding="utf-8")
     )
@@ -3963,7 +3962,13 @@ def _make_reanchored_repo(repo: Path, head_sha: str) -> str:
         planned_at=head_sha,
     )
     assert len(result["written"]) == 1
-    return Path(result["written"][0]["path"]).relative_to(repo).as_posix()
+    # The durable landing path is what survives into the index, so source it
+    # from the sidecar rather than the (pruned) re-anchor worktree path.
+    rows = reanchored_plan_rows(repo / "daydream_plans")
+    assert rows, "expected one re-anchored plan"
+    landing = rows[0].landing_path
+    assert landing is not None
+    return landing
 
 
 def test_improve_list_reanchored_real_path_lists_reanchored_plan(

--- a/tests/test_improve_plans.py
+++ b/tests/test_improve_plans.py
@@ -1,4 +1,5 @@
 import json
+import sys
 from copy import deepcopy
 from datetime import date
 from pathlib import Path
@@ -7,6 +8,7 @@ from typing import Any
 import pytest
 from jsonschema import Draft202012Validator
 
+from daydream.cli import main as cli_main
 from daydream.improve.assemble import (
     AssemblyIssue,
     assemble_plan,
@@ -3943,3 +3945,79 @@ def test_reanchored_plan_rows_returns_empty_when_none_reanchored(
     assert reanchored_plan_rows(plans_dir) == []
     # An absent index is also an empty result, never an error.
     assert reanchored_plan_rows(tmp_path / "does-not-exist") == []
+
+
+def _make_reanchored_repo(repo: Path, head_sha: str) -> str:
+    """Re-anchor one plan into a fresh worktree; return the repo-relative landing path."""
+    assembled = _assembled(repo, _authored_plan(title="Fix N+1 catalog queries"))
+    (repo / "README.md").write_text(
+        "# Catalog service\n\nConcurrent branch update.\n",
+        encoding="utf-8",
+    )
+    git(repo, "add", "README.md")
+    commit(repo, "advance head after plan fan-out")
+    result = _write_plans(
+        repo / "daydream_plans",
+        [{"finding": _finding(), **assembled}],
+        planned_at=head_sha,
+    )
+    assert len(result["written"]) == 1
+    return Path(result["written"][0]["path"]).relative_to(repo).as_posix()
+
+
+def test_improve_list_reanchored_real_path_lists_reanchored_plan(
+    repo: Path,
+    head_sha: str,
+    monkeypatch,
+    capsys,
+) -> None:
+    expected_rel = _make_reanchored_repo(repo, head_sha)
+
+    monkeypatch.setattr(
+        sys, "argv", ["daydream", "improve", "list-reanchored", str(repo)]
+    )
+    with pytest.raises(SystemExit) as exc:
+        cli_main()
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "001" in out
+    assert "Fix N+1 catalog queries" in out
+    assert expected_rel in out
+
+
+def test_improve_list_reanchored_real_path_empty_exits_zero(
+    repo: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setattr(
+        sys, "argv", ["daydream", "improve", "list-reanchored", str(repo)]
+    )
+    with pytest.raises(SystemExit) as exc:
+        cli_main()
+    assert exc.value.code == 0
+    assert "No re-anchored plans" in capsys.readouterr().out
+
+
+def test_improve_list_reanchored_json_mode(
+    repo: Path,
+    head_sha: str,
+    monkeypatch,
+    capsys,
+) -> None:
+    expected_rel = _make_reanchored_repo(repo, head_sha)
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["daydream", "improve", "list-reanchored", "--json", str(repo)],
+    )
+    with pytest.raises(SystemExit) as exc:
+        cli_main()
+    assert exc.value.code == 0
+    rows = json.loads(capsys.readouterr().out)
+    assert len(rows) == 1
+    assert rows[0]["number"] == 1
+    assert rows[0]["title"] == "Fix N+1 catalog queries"
+    assert rows[0]["status"].startswith("REANCHORED")
+    assert rows[0]["landing_path"] == expected_rel


### PR DESCRIPTION
## Summary
Closes #352

Follow-up to #350. Re-anchored plans currently appear in `daydream_plans/.index.json` / `README.md` with a `REANCHORED (landed at <path>)` status, but the landing path is only discoverable by reading the README or sidecar files. This PR surfaces re-anchored plan entries (number, title, status, landing path) outside the README execution board.

## Changes
- Add `reanchored_plan_rows` helper and `landing_path` extraction
- Add `daydream improve list-reanchored` CLI sync command
- Add re-anchored plans section to the improve report
- Verify re-anchored surfaces against canonical fixture (tests)
- Use status constant in re-anchored landed regex
- Point re-anchor status at surviving index path

## Test Plan
- `3175 passed, 6 skipped` (full fix quality gate)

## Review
Two sequential daydream deep-precision reviews passed (round 1 + round 2).