### PR TITLE
fix(workflows): remove unusable post checkout (Closes #365)

### DIFF
--- a/.github/workflows/daydream-post.yml
+++ b/.github/workflows/daydream-post.yml
@@ -2,9 +2,9 @@
 #
 # Fires when "Daydream Review" (Phase A) completes, downloads its findings
 # artifact, and posts the findings to the PR as the operator's App bot. This
-# job holds the App key, so it NEVER checks out or executes PR code — only the
-# base repo's default branch (trusted), per the locked privilege split: no
-# single job ever holds both PR code and the App key. The artifact is passive
+# job holds the App key, so it NEVER checks out or executes PR code, per the
+# locked privilege split: no single job ever holds both PR code and the App key.
+# The artifact is passive
 # data, validated by `daydream post-findings` against a strict schema before
 # anything is posted.
 #
@@ -40,10 +40,6 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     if: github.event.workflow_run.conclusion == 'success'
     steps:
-      # Trusted code only: the base repo's default branch, no ref override.
-      - name: Check out repository
-        uses: actions/checkout@v4
-
       - name: Set up uv
         uses: astral-sh/setup-uv@v4
 

--- a/.github/workflows/daydream-post.yml
+++ b/.github/workflows/daydream-post.yml
@@ -4,8 +4,7 @@
 # artifact, and posts the findings to the PR as the operator's App bot. This
 # job holds the App key, so it NEVER checks out or executes PR code, per the
 # locked privilege split: no single job ever holds both PR code and the App key.
-# The artifact is passive
-# data, validated by `daydream post-findings` against a strict schema before
+# The artifact is passive data, validated by `daydream post-findings` against a strict schema before
 # anything is posted.
 #
 # Target derivation (Task 0 spike, Step 2 — the event payload is NOT uniform):

--- a/daydream/templates/workflows/daydream-post.yml
+++ b/daydream/templates/workflows/daydream-post.yml
@@ -2,9 +2,9 @@
 #
 # Fires when "Daydream Review" (Phase A) completes, downloads its findings
 # artifact, and posts the findings to the PR as the operator's App bot. This
-# job holds the App key, so it NEVER checks out or executes PR code — only the
-# base repo's default branch (trusted), per the locked privilege split: no
-# single job ever holds both PR code and the App key. The artifact is passive
+# job holds the App key, so it NEVER checks out or executes PR code, per the
+# locked privilege split: no single job ever holds both PR code and the App key.
+# The artifact is passive
 # data, validated by `daydream post-findings` against a strict schema before
 # anything is posted.
 #
@@ -40,10 +40,6 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     if: github.event.workflow_run.conclusion == 'success'
     steps:
-      # Trusted code only: the base repo's default branch, no ref override.
-      - name: Check out repository
-        uses: actions/checkout@v4
-
       - name: Set up uv
         uses: astral-sh/setup-uv@v4
 

--- a/daydream/templates/workflows/daydream-post.yml
+++ b/daydream/templates/workflows/daydream-post.yml
@@ -4,8 +4,7 @@
 # artifact, and posts the findings to the PR as the operator's App bot. This
 # job holds the App key, so it NEVER checks out or executes PR code, per the
 # locked privilege split: no single job ever holds both PR code and the App key.
-# The artifact is passive
-# data, validated by `daydream post-findings` against a strict schema before
+# The artifact is passive data, validated by `daydream post-findings` against a strict schema before
 # anything is posted.
 #
 # Target derivation (Task 0 spike, Step 2 — the event payload is NOT uniform):

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -103,25 +103,28 @@ def test_daydream_install_is_pinned_to_current_release_tag(name: str) -> None:
 # no job ever holds both untrusted PR code and the App key.
 
 
-def test_split_setup_preserves_privilege_split() -> None:
+@pytest.mark.parametrize(
+    "post_path",
+    [TEMPLATES_DIR / "daydream-post.yml", REPO_WORKFLOWS_DIR / "daydream-post.yml"],
+    ids=["template", "live"],
+)
+def test_split_setup_preserves_privilege_split(post_path: Path) -> None:
     review = load_workflow(TEMPLATES_DIR / "daydream-review.yml")
     review_text = (TEMPLATES_DIR / "daydream-review.yml").read_text(encoding="utf-8")
     command_text = (TEMPLATES_DIR / "daydream-command.yml").read_text(encoding="utf-8")
-    post = load_workflow(TEMPLATES_DIR / "daydream-post.yml")
-    post_text = (TEMPLATES_DIR / "daydream-post.yml").read_text(encoding="utf-8")
+    post = load_workflow(post_path)
+    post_text = post_path.read_text(encoding="utf-8")
 
     # Phase A runs untrusted PR code: read-only, and its only secret is the API key.
     assert review["permissions"] == {"contents": "read"}
     assert set(_SECRET_REF_RE.findall(review_text)) == {"ANTHROPIC_API_KEY"}
 
-    # The two App-key holders never check out untrusted code: the command job
-    # never checks out at all; the post job may only take the trusted default
-    # branch (no PR / workflow_run ref override).
+    # The App-key holders never check out code: the command workflow never checks
+    # out at all, and every job in each privileged post workflow performs no
+    # checkout.
     assert "actions/checkout" not in command_text
     for job in post["jobs"].values():
-        for step in job["steps"]:
-            if "actions/checkout" in step.get("uses", ""):
-                assert "workflow_run" not in str(step.get("with", {}).get("ref", ""))
+        assert not has_checkout(job)
     assert set(_SECRET_REF_RE.findall(post_text)) == {"DAYDREAM_APP_ID", "DAYDREAM_APP_PRIVATE_KEY"}
 
 


### PR DESCRIPTION
## Summary
Removes the unusable `actions/checkout@v4` step from both the live and packaged split post workflows (`.github/workflows/daydream-post.yml` and `daydream/templates/workflows/daydream-post.yml`).

The post job holds the App key and runs with only `actions: read` — the checkout lacks repository-content access and no later post step consumes a checked-out file. A successful review could terminate in the post workflow before findings reach the PR.

## Changes
- Delete `Check out repository` (`actions/checkout@v4`) from both post workflows, along with the stale trusted-default-branch comment
- Reflow the header to the checkout-free privilege-split sentence
- Harden `test_split_setup_preserves_privilege_split` (parameterized over template + live, `ids=["template","live"]`) to assert `not has_checkout(job)` for every job in each privileged post workflow

## Test Plan
- `make check` (Ruff, Mypy, parallel pytest, actionlint)
- `uv run pytest -n auto tests/test_workflow_templates.py::test_split_setup_preserves_privilege_split`
- `uv lock --check`

Closes #365