### PR TITLE
fix(ci): pin GitHub App token action in live and packaged posting workflows

### DIFF
--- a/.github/workflows/daydream-post.yml
+++ b/.github/workflows/daydream-post.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Mint posting token
         id: token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ secrets.DAYDREAM_APP_ID }}
           private-key: ${{ secrets.DAYDREAM_APP_PRIVATE_KEY }}
@@ -144,7 +144,7 @@ jobs:
     steps:
       - name: Mint posting token
         id: token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ secrets.DAYDREAM_APP_ID }}
           private-key: ${{ secrets.DAYDREAM_APP_PRIVATE_KEY }}

--- a/daydream/templates/workflows/daydream-post.yml
+++ b/daydream/templates/workflows/daydream-post.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Mint posting token
         id: token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ secrets.DAYDREAM_APP_ID }}
           private-key: ${{ secrets.DAYDREAM_APP_PRIVATE_KEY }}
@@ -147,7 +147,7 @@ jobs:
     steps:
       - name: Mint posting token
         id: token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ secrets.DAYDREAM_APP_ID }}
           private-key: ${{ secrets.DAYDREAM_APP_PRIVATE_KEY }}

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -8,6 +8,7 @@ cannot verify and that a careless edit could silently break:
 - No untrusted event data is interpolated into a ``run:`` body (injection).
 - The daydream install stays pinned to the current release tag (cross-file
   drift against ``pyproject.toml``).
+- Every App-token action in the live and packaged posting workflows stays pinned to the approved v2.2.2 commit.
 - The privilege split holds: the job that checks out untrusted PR code never
   holds the App key, and the privileged jobs never check out PR code.
 - The repo's own Codex dogfood workflow persists ``codex login`` before the
@@ -123,6 +124,25 @@ def test_split_setup_preserves_privilege_split() -> None:
             if "actions/checkout" in step.get("uses", ""):
                 assert "workflow_run" not in str(step.get("with", {}).get("ref", ""))
     assert set(_SECRET_REF_RE.findall(post_text)) == {"DAYDREAM_APP_ID", "DAYDREAM_APP_PRIVATE_KEY"}
+
+
+@pytest.mark.parametrize(
+    "wf_path",
+    [TEMPLATES_DIR / "daydream-post.yml", REPO_WORKFLOWS_DIR / "daydream-post.yml"],
+    ids=["template", "live"],
+)
+def test_post_workflows_pin_create_github_app_token(wf_path: Path) -> None:
+    wf = load_workflow(wf_path)
+    expected_action = "actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349"
+    token_action_uses = [
+        (job_name, str(step.get("uses", "")))
+        for job_name, job in wf["jobs"].items()
+        for step in job["steps"]
+        if str(step.get("uses", "")).startswith("actions/create-github-app-token@")
+    ]
+    assert sorted(token_action_uses) == sorted(
+        [("post", expected_action), ("surface-analyze-failure", expected_action)]
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -126,23 +126,39 @@ def test_split_setup_preserves_privilege_split() -> None:
     assert set(_SECRET_REF_RE.findall(post_text)) == {"DAYDREAM_APP_ID", "DAYDREAM_APP_PRIVATE_KEY"}
 
 
-@pytest.mark.parametrize(
-    "wf_path",
-    [TEMPLATES_DIR / "daydream-post.yml", REPO_WORKFLOWS_DIR / "daydream-post.yml"],
-    ids=["template", "live"],
-)
-def test_post_workflows_pin_create_github_app_token(wf_path: Path) -> None:
+_APP_TOKEN_ACTION = "actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349"
+
+# Every token-minting workflow, shipped or live, pins every App-token action to
+# the approved v2.2.2 commit. Lists the concrete (job, action) pairs so a renamed
+# job, a refloated pin, or a newly added unpinned token action fails loudly rather
+# than being silently absorbed by a wildcard.
+_APP_TOKEN_PIN_CASES = [
+    (TEMPLATES_DIR / "daydream-post.yml", "template-post",
+     [("post", _APP_TOKEN_ACTION), ("surface-analyze-failure", _APP_TOKEN_ACTION)]),
+    (REPO_WORKFLOWS_DIR / "daydream-post.yml", "live-post",
+     [("post", _APP_TOKEN_ACTION), ("surface-analyze-failure", _APP_TOKEN_ACTION)]),
+    (TEMPLATES_DIR / "daydream-command.yml", "template-command",
+     [("dispatch", _APP_TOKEN_ACTION)]),
+    (REPO_WORKFLOWS_DIR / "daydream-command.yml", "live-command",
+     [("dispatch", _APP_TOKEN_ACTION)]),
+    (TEMPLATES_DIR / "single" / "daydream.yml", "single",
+     [("gate", _APP_TOKEN_ACTION), ("post", _APP_TOKEN_ACTION),
+      ("surface-failure", _APP_TOKEN_ACTION)]),
+]
+
+
+@pytest.mark.parametrize("wf_path,expected",
+                         [(p, e) for p, _id, e in _APP_TOKEN_PIN_CASES],
+                         ids=[_id for _, _id, _ in _APP_TOKEN_PIN_CASES])
+def test_workflows_pin_create_github_app_token(wf_path: Path, expected: list) -> None:
     wf = load_workflow(wf_path)
-    expected_action = "actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349"
     token_action_uses = [
         (job_name, str(step.get("uses", "")))
         for job_name, job in wf["jobs"].items()
         for step in job["steps"]
         if str(step.get("uses", "")).startswith("actions/create-github-app-token@")
     ]
-    assert sorted(token_action_uses) == sorted(
-        [("post", expected_action), ("surface-analyze-failure", expected_action)]
-    )
+    assert sorted(token_action_uses) == sorted(expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Pins the `actions/create-github-app-token` action to the approved v2.2.2 commit (`fee1f7d63c2ff003460e3d139729b119787bc349`) in both the live and packaged posting workflows, replacing the mutable `@v2` reference in the privileged `Mint posting token` steps of jobs `post` and `surface-analyze-failure`.

## Why

The `post` and `surface-analyze-failure` jobs execute privileged token-minting steps with the GitHub App private-key credential. A mutable action reference could disclose that credential or mint unauthorized installation tokens. Pinning to the vetted commit removes that risk.

## Changes
- Pin both `Mint posting token` steps in `.github/workflows/daydream-post.yml` to `fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2`
- Pin both `Mint posting token` steps in `daydream/templates/workflows/daydream-post.yml` to the same commit
- Add parsed-YAML invariant `test_post_workflows_pin_create_github_app_token` covering both workflow copies

## Test plan
- [x] Focused invariant test passed
- [x] Full root pytest suite green (3212 passed)

Closes #363
