### PR TITLE
improve: stop prune_stale_reanchor_worktrees racing a live *-reanchor worktree

### DIFF
--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -1448,6 +1448,61 @@ def worktree_remove(repo: Path, path: Path, *, force: bool = True) -> None:
         raise GitError(f"git worktree remove {path} failed: {proc.stderr.strip()}")
 
 
+def worktree_lock(repo: Path, path: Path, *, reason: str | None = None) -> None:
+    """Lock the worktree at *path* so git refuses to remove it.
+
+    Args:
+        reason: Human-readable lock reason (e.g. the run_id), shown by
+            ``git worktree list --porcelain`` and stored in the ``locked`` file.
+
+    Raises:
+        GitError: If ``git worktree lock`` fails.
+    """
+    args = ["worktree", "lock"]
+    if reason is not None:
+        args.extend(["--reason", reason])
+    args.append(str(path))
+    proc = _run_git(repo, args, timeout=30, retries=0)
+    if proc.returncode != 0:
+        raise GitError(f"git worktree lock {path} failed: {proc.stderr.strip()}")
+
+
+def worktree_unlock(repo: Path, path: Path) -> None:
+    """Unlock the worktree at *path*, releasing git's removal guard.
+
+    Raises:
+        GitError: If ``git worktree unlock`` fails.
+    """
+    proc = _run_git(repo, ["worktree", "unlock", str(path)], timeout=30, retries=0)
+    if proc.returncode != 0:
+        raise GitError(f"git worktree unlock {path} failed: {proc.stderr.strip()}")
+
+
+def worktree_lock_mtime(repo: Path, path: Path) -> float | None:
+    """Return the lock-armed time of the worktree at *path*, or None if unlocked.
+
+    The lock file lives at ``<git_dir>/worktrees/<path.name>/locked``; its mtime
+    is when the lock was armed, and its absence means the worktree is unlocked.
+    Returns ``None`` only for a genuinely absent lock file, never on a git
+    failure (which propagates as :class:`GitError`).
+
+    Raises:
+        GitError: If ``git rev-parse --git-dir`` fails.
+    """
+    proc = _run_git(repo, ["rev-parse", "--git-dir"], timeout=5)
+    if proc.returncode != 0:
+        raise GitError(
+            f"git rev-parse --git-dir failed in {repo}: {proc.stderr.strip()}"
+        )
+    git_dir = Path(proc.stdout.strip())
+    if not git_dir.is_absolute():
+        git_dir = repo / git_dir
+    locked = git_dir / "worktrees" / path.name / "locked"
+    if not locked.is_file():
+        return None
+    return locked.stat().st_mtime
+
+
 def create_branch(repo: Path, name: str) -> None:
     """Create and check out a new branch *name* via ``git checkout -b``.
 

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -1487,12 +1487,12 @@ def worktree_lock_mtime(repo: Path, path: Path) -> float | None:
     failure (which propagates as :class:`GitError`).
 
     Raises:
-        GitError: If ``git rev-parse --git-dir`` fails.
+        GitError: If ``git rev-parse --git-common-dir`` fails.
     """
-    proc = _run_git(repo, ["rev-parse", "--git-dir"], timeout=5)
+    proc = _run_git(repo, ["rev-parse", "--git-common-dir"], timeout=5)
     if proc.returncode != 0:
         raise GitError(
-            f"git rev-parse --git-dir failed in {repo}: {proc.stderr.strip()}"
+            f"git rev-parse --git-common-dir failed in {repo}: {proc.stderr.strip()}"
         )
     git_dir = Path(proc.stdout.strip())
     if not git_dir.is_absolute():

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -1463,6 +1463,29 @@ def worktree_remove(repo: Path, path: Path, *, force: bool = True) -> None:
         raise GitError(f"git worktree remove {path} failed: {proc.stderr.strip()}")
 
 
+def worktree_remove_unlocked(repo: Path, path: Path, *, force: bool = True) -> None:
+    """Unlock *path* (if locked), then remove the worktree.
+
+    git refuses to remove a locked worktree even with ``--force``, so any
+    removal of a possibly-locked worktree must release the lock first. This is
+    the single place encoding that unlock-before-remove ordering; callers that
+    remove a worktree which may still hold a lock use this instead of inlining
+    ``worktree_unlock`` + ``worktree_remove``.
+
+    The unlock is best-effort: ``git worktree unlock`` fails on an
+    already-unlocked worktree, which is expected here and ignored. The removal
+    itself is authoritative and raises :class:`GitError` on failure.
+
+    Raises:
+        GitError: If ``git worktree remove`` fails.
+    """
+    try:
+        worktree_unlock(repo, path)
+    except GitError:
+        pass
+    worktree_remove(repo, path, force=force)
+
+
 def worktree_lock(repo: Path, path: Path, *, reason: str | None = None) -> None:
     """Lock the worktree at *path* so git refuses to remove it.
 

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -1410,12 +1410,24 @@ def clean_untracked(repo: Path) -> None:
         raise GitError(f"git clean -fd failed in {repo}: {proc.stderr.strip()}")
 
 
-def worktree_add(repo: Path, path: Path, ref: str, *, detach: bool = True) -> None:
+def worktree_add(
+    repo: Path,
+    path: Path,
+    ref: str,
+    *,
+    detach: bool = True,
+    lock_reason: str | None = None,
+) -> None:
     """Create a new worktree at *path* pointing at *ref*.
 
     Args:
         path: Filesystem path for the new worktree (must not already exist).
         detach: When True, pass ``--detach`` so the new worktree is detached.
+        lock_reason: When set, pass ``--lock --reason <lock_reason>`` so the
+            worktree is created already-locked in the same ``git worktree add``
+            invocation. Arming the lock atomically with creation closes the
+            window in which a concurrent prune could force-remove the fresh
+            worktree between an add and a separate lock call.
 
     Raises:
         GitError: If ``git worktree add`` fails.
@@ -1423,6 +1435,9 @@ def worktree_add(repo: Path, path: Path, ref: str, *, detach: bool = True) -> No
     args = ["worktree", "add"]
     if detach:
         args.append("--detach")
+    if lock_reason is not None:
+        args.append("--lock")
+        args.extend(["--reason", lock_reason])
     args.extend([str(path), ref])
     proc = _run_git(repo, args, timeout=30, retries=0)
     if proc.returncode != 0:

--- a/daydream/improve/plans.py
+++ b/daydream/improve/plans.py
@@ -1169,7 +1169,10 @@ class PlanWriteSession:
 
         A failed unlock must never surface or fail the plan run, so the unlock
         is swallowed via :class:`~root.git_ops.GitError`. Clear the reference
-        regardless so a later release is a no-op.
+        regardless so a later release is a no-op. The worktree itself is kept on
+        a successful finish() (the durable plan lives in the main index and the
+        worktree is pruned at the next run); only a re-anchor failure removes it
+        (see ``_reanchor_failed``) so the path can be re-used.
         """
         if self._reanchor_worktree is None:
             return
@@ -1418,7 +1421,15 @@ class PlanWriteSession:
         def _reanchor_failed() -> PlanOutcome:
             # Best-effort release: a graceful re-anchor failure must not leave
             # the worktree locked forever (it would wedge a later prune).
+            failed_wt = self._reanchor_worktree
             self._release_reanchor_worktree()
+            # Remove the worktree so a later re-anchorable finding can re-add
+            # the path instead of failing with PLAN_REANCHOR_FAILED (fix #2).
+            if failed_wt is not None:
+                try:
+                    git_ops.worktree_remove(self._repo, failed_wt, force=True)
+                except git_ops.GitError:
+                    pass
             return self._block(
                 reservation,
                 selection,
@@ -1441,15 +1452,18 @@ class PlanWriteSession:
                 if _SAFE_DIRNAME.fullmatch(run_id) is None:
                     run_id = f"run-{self._planned_at[:12]}"
                 worktree = _worktrees_dir(self._repo) / f"{run_id}{_REANCHOR_DIR_SUFFIX}"
-                git_ops.worktree_add(
-                    self._repo, worktree, new_head, detach=True
-                )
-                # Arm the git worktree lock exactly once, at creation, so a
+                # Create the worktree already-locked in one git invocation so a
                 # concurrent run's start-of-run prune cannot destroy the live
-                # worktree while the plan is mid-write. Released best-effort on
-                # finish()/failure; a lock failure blocks the plan (git refuses
-                # to remove a locked worktree with a single --force).
-                git_ops.worktree_lock(self._repo, worktree, reason=run_id)
+                # worktree between an add and a separate lock (fix #3). Released
+                # best-effort on finish()/failure; git refuses to remove a
+                # locked worktree, so release unlocks before removing.
+                git_ops.worktree_add(
+                    self._repo,
+                    worktree,
+                    new_head,
+                    detach=True,
+                    lock_reason=run_id,
+                )
                 self._reanchor_worktree = worktree
             text = render_plan(
                 finding,

--- a/daydream/improve/plans.py
+++ b/daydream/improve/plans.py
@@ -709,11 +709,12 @@ def prune_stale_reanchor_worktrees(repo: Path) -> int:
     so one stale worktree never blocks a plan run.
 
     The prune is lock-aware: a live re-anchor worktree (locked at creation, age
-    near zero) is refused by the single ``--force`` and skipped, so a concurrent
-    run mid-write is never destroyed. A worktree whose lock is older than
+    near zero) is skipped without any removal attempt, so a concurrent run
+    mid-write is never destroyed. A worktree whose lock is older than
     ``_REANCHOR_LOCK_STALE_AFTER_S`` is a crashed session's leftover: it is
-    unlocked first, then force-removed, so it is reclaimed rather than wedged
-    forever. Unlocked stale worktrees are removed as before.
+    reclaimed via ``git_ops.worktree_remove_unlocked`` (unlock, then
+    force-remove) rather than wedged forever. Unlocked worktrees are removed
+    the same way, the unlock being a no-op for them.
     """
     removed = 0
     for path in _iter_reanchor_worktrees(repo):
@@ -721,10 +722,12 @@ def prune_stale_reanchor_worktrees(repo: Path) -> int:
             locked_at = git_ops.worktree_lock_mtime(repo, path)
             if (
                 locked_at is not None
-                and time.time() - locked_at > _REANCHOR_LOCK_STALE_AFTER_S
+                and time.time() - locked_at <= _REANCHOR_LOCK_STALE_AFTER_S
             ):
-                git_ops.worktree_unlock(repo, path)
-            git_ops.worktree_remove(repo, path, force=True)
+                # Live re-anchor worktree (lock age near zero): never unlock or
+                # remove it, so a concurrent run mid-write is not destroyed.
+                continue
+            git_ops.worktree_remove_unlocked(repo, path)
         except git_ops.GitError:
             continue
         removed += 1
@@ -1425,9 +1428,12 @@ class PlanWriteSession:
             self._release_reanchor_worktree()
             # Remove the worktree so a later re-anchorable finding can re-add
             # the path instead of failing with PLAN_REANCHOR_FAILED (fix #2).
+            # Removal goes through worktree_remove_unlocked — the single place
+            # encoding unlock-before-remove; the release above already unlocked,
+            # so the helper's unlock is a no-op.
             if failed_wt is not None:
                 try:
-                    git_ops.worktree_remove(self._repo, failed_wt, force=True)
+                    git_ops.worktree_remove_unlocked(self._repo, failed_wt)
                 except git_ops.GitError:
                     pass
             return self._block(
@@ -1456,7 +1462,8 @@ class PlanWriteSession:
                 # concurrent run's start-of-run prune cannot destroy the live
                 # worktree between an add and a separate lock (fix #3). Released
                 # best-effort on finish()/failure; git refuses to remove a
-                # locked worktree, so release unlocks before removing.
+                # locked worktree, so removal goes through
+                # git_ops.worktree_remove_unlocked (unlock, then remove).
                 git_ops.worktree_add(
                     self._repo,
                     worktree,

--- a/daydream/improve/plans.py
+++ b/daydream/improve/plans.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import re
 import subprocess
+import time
 from collections import Counter
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, replace
@@ -48,6 +49,11 @@ _SAFE_DIRNAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$")
 # Re-anchor worktree dirnames end in this suffix; the prune pass and the
 # re-anchor write share it so a rename can never silently stop pruning.
 _REANCHOR_DIR_SUFFIX = "-reanchor"
+# A still-locked re-anchor worktree whose lock is older than this is treated as
+# a crashed session's leftover and reclaimed (unlocked then removed). A live
+# concurrent lock is under this age in any realistic session, so "stale" here
+# is generous and only a crashed lock (unboundedly old) is ever reclaimed.
+_REANCHOR_LOCK_STALE_AFTER_S = 24 * 3600
 REANCHORED_STATUS_PREFIX = "REANCHORED"
 _REANCHORED_LANDED = re.compile(rf"^{re.escape(REANCHORED_STATUS_PREFIX)} \(landed at (.+)\)$")
 
@@ -701,10 +707,23 @@ def prune_stale_reanchor_worktrees(repo: Path) -> int:
     ``.daydream/worktrees/<run_id>-reanchor``; each new plan run prunes them so
     the directory does not grow unboundedly. Individual failures are tolerated
     so one stale worktree never blocks a plan run.
+
+    The prune is lock-aware: a live re-anchor worktree (locked at creation, age
+    near zero) is refused by the single ``--force`` and skipped, so a concurrent
+    run mid-write is never destroyed. A worktree whose lock is older than
+    ``_REANCHOR_LOCK_STALE_AFTER_S`` is a crashed session's leftover: it is
+    unlocked first, then force-removed, so it is reclaimed rather than wedged
+    forever. Unlocked stale worktrees are removed as before.
     """
     removed = 0
     for path in _iter_reanchor_worktrees(repo):
         try:
+            locked_at = git_ops.worktree_lock_mtime(repo, path)
+            if (
+                locked_at is not None
+                and time.time() - locked_at > _REANCHOR_LOCK_STALE_AFTER_S
+            ):
+                git_ops.worktree_unlock(repo, path)
             git_ops.worktree_remove(repo, path, force=True)
         except git_ops.GitError:
             continue
@@ -1397,6 +1416,9 @@ class PlanWriteSession:
         filename = f"{number:03d}-{slug}.md"
 
         def _reanchor_failed() -> PlanOutcome:
+            # Best-effort release: a graceful re-anchor failure must not leave
+            # the worktree locked forever (it would wedge a later prune).
+            self._release_reanchor_worktree()
             return self._block(
                 reservation,
                 selection,

--- a/daydream/improve/plans.py
+++ b/daydream/improve/plans.py
@@ -1137,12 +1137,28 @@ class PlanWriteSession:
     def finish(self) -> dict[str, list[dict[str, Any]]]:
         """Reconcile the index and return what this session landed."""
         self._write_index()
+        self._release_reanchor_worktree()
         return {
             "written": _by_reservation(self._written),
             "skipped": _by_reservation(self._skipped),
             "failed": _by_reservation(self._failed),
             "diagnostics": _by_reservation(self._diagnostics),
         }
+
+    def _release_reanchor_worktree(self) -> None:
+        """Best-effort release of the re-anchor worktree's git lock.
+
+        A failed unlock must never surface or fail the plan run, so the unlock
+        is swallowed via :class:`~root.git_ops.GitError`. Clear the reference
+        regardless so a later release is a no-op.
+        """
+        if self._reanchor_worktree is None:
+            return
+        try:
+            git_ops.worktree_unlock(self._repo, self._reanchor_worktree)
+        except git_ops.GitError:
+            pass
+        self._reanchor_worktree = None
 
     @staticmethod
     def _attempt_of(selection: dict[str, Any]) -> dict[str, Any] | None:
@@ -1406,6 +1422,12 @@ class PlanWriteSession:
                 git_ops.worktree_add(
                     self._repo, worktree, new_head, detach=True
                 )
+                # Arm the git worktree lock exactly once, at creation, so a
+                # concurrent run's start-of-run prune cannot destroy the live
+                # worktree while the plan is mid-write. Released best-effort on
+                # finish()/failure; a lock failure blocks the plan (git refuses
+                # to remove a locked worktree with a single --force).
+                git_ops.worktree_lock(self._repo, worktree, reason=run_id)
                 self._reanchor_worktree = worktree
             text = render_plan(
                 finding,

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -1583,6 +1583,28 @@ def test_worktree_lock_and_lock_mtime_roundtrip(tmp_path: Path) -> None:
     assert git_ops.worktree_lock_mtime(repo, wt) is None  # released
 
 
+def test_worktree_remove_unlocked_unlocks_before_removing(tmp_path: Path) -> None:
+    """worktree_remove_unlocked centralizes the unlock-before-remove ordering:
+    it removes a locked worktree (unlocking it first) and an already-unlocked
+    one (the unlock attempt is a no-op), so callers never inline the rule."""
+    repo = _make_repo_with_main(tmp_path)
+
+    # Locked worktree: removal must unlock first, then remove.
+    locked_wt = repo / "wt-locked"
+    git_ops.worktree_add(repo, locked_wt, "main", detach=True)
+    git_ops.worktree_lock(repo, locked_wt, reason="run-A")
+    assert git_ops.worktree_lock_mtime(repo, locked_wt) is not None
+    git_ops.worktree_remove_unlocked(repo, locked_wt)
+    assert not locked_wt.exists()
+
+    # Unlocked worktree: the unlock attempt fails harmlessly, removal proceeds.
+    unlocked_wt = repo / "wt-unlocked"
+    git_ops.worktree_add(repo, unlocked_wt, "main", detach=True)
+    assert git_ops.worktree_lock_mtime(repo, unlocked_wt) is None
+    git_ops.worktree_remove_unlocked(repo, unlocked_wt)
+    assert not unlocked_wt.exists()
+
+
 def test_worktree_add_with_lock_reason_arms_lock_atomically(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -1560,3 +1560,24 @@ def test_log_shas_since_warns_on_git_error(tmp_path: Path, caplog: pytest.LogCap
         result = git_ops.log_shas_since(repo, "main", "nonexistent-ref")
     assert result == []
     assert any("log_shas_since" in record.message for record in caplog.records)
+
+
+def test_worktree_lock_and_lock_mtime_roundtrip(tmp_path: Path) -> None:
+    """The lock primitives arm a real git worktree lock, expose its mtime,
+    make a single-force remove refuse it, and release it on unlock."""
+    repo = _make_repo_with_main(tmp_path)
+    wt = repo / "wt1"
+    git_ops.worktree_add(repo, wt, "main", detach=True)
+
+    assert git_ops.worktree_lock_mtime(repo, wt) is None  # unlocked
+
+    git_ops.worktree_lock(repo, wt, reason="run-A")
+    locked_at = git_ops.worktree_lock_mtime(repo, wt)
+    assert locked_at is not None
+
+    # the liveness guard: a single --force remove is refused while locked
+    with pytest.raises(GitError):
+        git_ops.worktree_remove(repo, wt, force=True)
+
+    git_ops.worktree_unlock(repo, wt)
+    assert git_ops.worktree_lock_mtime(repo, wt) is None  # released

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -1581,3 +1581,24 @@ def test_worktree_lock_and_lock_mtime_roundtrip(tmp_path: Path) -> None:
 
     git_ops.worktree_unlock(repo, wt)
     assert git_ops.worktree_lock_mtime(repo, wt) is None  # released
+
+
+def test_worktree_add_with_lock_reason_arms_lock_atomically(
+    tmp_path: Path,
+) -> None:
+    """Fix #3: worktree_add(lock_reason=...) must create the worktree already
+    locked in a single git invocation, so there is no unlocked window in which
+    a concurrent prune could force-remove the fresh worktree."""
+    repo = _make_repo_with_main(tmp_path)
+    wt = repo / "wt-locked"
+
+    git_ops.worktree_add(repo, wt, "main", detach=True, lock_reason="run-A")
+
+    # locked marker present with the reason; no separate worktree_lock call needed
+    assert git_ops.worktree_lock_mtime(repo, wt) is not None
+    git_dir = Path(_git(repo, "rev-parse", "--git-common-dir").strip())
+    if not git_dir.is_absolute():
+        git_dir = repo / git_dir
+    locked = git_dir / "worktrees" / wt.name / "locked"
+    assert locked.is_file()
+    assert "run-A" in locked.read_text(encoding="utf-8")

--- a/tests/test_improve_plans.py
+++ b/tests/test_improve_plans.py
@@ -4265,3 +4265,56 @@ def test_reanchored_report_section_empty(tmp_path: Path) -> None:
 
     assert "## Re-anchored plans" in section
     assert "No re-anchored plans" in section
+
+def test_reanchored_failure_releases_worktree_lock(
+    repo: Path, head_sha: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Should-have #1: a graceful re-anchor write failure releases the lock."""
+    from daydream import git_ops
+
+    (repo / "README.md").write_text(
+        "# Catalog service\n\nConcurrent branch update.\n", encoding="utf-8"
+    )
+    git(repo, "add", "README.md")
+    commit(repo, "advance head after plan fan-out")
+
+    def _boom(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("render failure")
+
+    # Only intentional failure-injection mock in the plan: deterministically
+    # fail INSIDE the post-lock write window (permission sabotage breaks under
+    # root CI; the real-path rule protects the network/API backend, not this).
+    monkeypatch.setattr("daydream.improve.plans.render_plan", _boom)
+
+    session = PlanWriteSession(
+        repo / "daydream_plans", planned_at=head_sha, run_session_id="run-A"
+    )
+    reservations = session.reserve([_finding()])
+    out = session.commit(reservations[0], _selection(repo))
+    assert out.status == "blocked"
+
+    worktree = repo / ".daydream" / "worktrees" / "run-A-reanchor"
+    assert worktree.is_dir()                                   # created
+    assert git_ops.worktree_lock_mtime(repo, worktree) is None  # released
+
+
+def test_stale_locked_reanchor_worktree_is_reclaimed(
+    repo: Path, head_sha: str
+) -> None:
+    """Acceptance #3: a crashed session's still-locked worktree is eventually
+    reclaimed (lock backdated past the staleness window), not wedged forever."""
+    import os
+    from daydream import git_ops
+    from daydream.improve.plans import prune_stale_reanchor_worktrees
+
+    stale = repo / ".daydream" / "worktrees" / "run-dead-reanchor"
+    git(repo, "worktree", "add", "--detach", str(stale), "HEAD")
+    git_ops.worktree_lock(repo, stale, reason="run-dead")
+    locked = repo / ".git" / "worktrees" / "run-dead-reanchor" / "locked"
+    os.utime(locked, (0, 0))  # backdate to 1970: older than any staleness window
+
+    removed = prune_stale_reanchor_worktrees(repo)
+
+    assert removed == 1
+    assert not stale.exists()
+    assert "run-dead-reanchor" not in git(repo, "worktree", "list")

--- a/tests/test_improve_plans.py
+++ b/tests/test_improve_plans.py
@@ -4304,6 +4304,7 @@ def test_stale_locked_reanchor_worktree_is_reclaimed(
     """Acceptance #3: a crashed session's still-locked worktree is eventually
     reclaimed (lock backdated past the staleness window), not wedged forever."""
     import os
+
     from daydream import git_ops
     from daydream.improve.plans import prune_stale_reanchor_worktrees
 

--- a/tests/test_improve_plans.py
+++ b/tests/test_improve_plans.py
@@ -4294,8 +4294,52 @@ def test_reanchored_failure_releases_worktree_lock(
     assert out.status == "blocked"
 
     worktree = repo / ".daydream" / "worktrees" / "run-A-reanchor"
-    assert worktree.is_dir()                                   # created
+    assert not worktree.exists()                               # removed (fix #2)
     assert git_ops.worktree_lock_mtime(repo, worktree) is None  # released
+
+def test_failed_reanchor_frees_worktree_for_later_finding(
+    repo: Path, head_sha: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fix #2: a re-anchor failure must remove the worktree so a later
+    re-anchorable finding in the same run can re-add the path instead of
+    failing with PLAN_REANCHOR_FAILED."""
+    from daydream.improve.plans import PlanWriteSession
+
+    (repo / "README.md").write_text(
+        "# Catalog service\n\nConcurrent branch update.\n", encoding="utf-8"
+    )
+    git(repo, "add", "README.md")
+    commit(repo, "advance head after plan fan-out")
+
+    calls = {"n": 0}
+
+    from daydream.improve import plans as plans_mod
+
+    real_render = plans_mod.render_plan
+
+    def _boom(*args: Any, **kwargs: Any) -> Any:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("first re-anchor render fails")
+        # second render (re-anchor of the next finding) succeeds
+        return real_render(*args, **kwargs)
+
+    monkeypatch.setattr("daydream.improve.plans.render_plan", _boom)
+
+    session = PlanWriteSession(
+        repo / "daydream_plans", planned_at=head_sha, run_session_id="run-A"
+    )
+    reservations = session.reserve([_finding(), _finding()])
+    first = session.commit(reservations[0], _selection(repo))
+    assert first.status == "blocked"
+
+    second = session.commit(reservations[1], _selection(repo))
+    assert second.status == "written", "later re-anchorable finding must still land"
+
+    result = session.finish()
+    assert len(result["written"]) == 1
+
+
 
 
 def test_stale_locked_reanchor_worktree_is_reclaimed(

--- a/tests/test_improve_plans.py
+++ b/tests/test_improve_plans.py
@@ -4311,7 +4311,10 @@ def test_stale_locked_reanchor_worktree_is_reclaimed(
     stale = repo / ".daydream" / "worktrees" / "run-dead-reanchor"
     git(repo, "worktree", "add", "--detach", str(stale), "HEAD")
     git_ops.worktree_lock(repo, stale, reason="run-dead")
-    locked = repo / ".git" / "worktrees" / "run-dead-reanchor" / "locked"
+    git_dir = Path(git(repo, "rev-parse", "--git-common-dir"))
+    if not git_dir.is_absolute():
+        git_dir = repo / git_dir
+    locked = git_dir / "worktrees" / "run-dead-reanchor" / "locked"
     os.utime(locked, (0, 0))  # backdate to 1970: older than any staleness window
 
     removed = prune_stale_reanchor_worktrees(repo)

--- a/tests/test_improve_plans.py
+++ b/tests/test_improve_plans.py
@@ -1744,6 +1744,50 @@ def test_stale_reanchor_worktrees_are_pruned_at_next_run(
     assert "run-abcd-reanchor" not in git(repo, "worktree", "list")
 
 
+def test_concurrent_runs_prune_does_not_destroy_live_reanchored_plan(
+    repo: Path, head_sha: str
+) -> None:
+    """Acceptance #1/#4/#5: run B's start-of-run prune must not destroy run A's
+    live re-anchor worktree; A's finished plan still lands on finish()."""
+    from daydream import git_ops
+    from daydream.improve.plans import prune_stale_reanchor_worktrees
+
+    (repo / "README.md").write_text(
+        "# Catalog service\n\nConcurrent branch update.\n", encoding="utf-8"
+    )
+    git(repo, "add", "README.md")
+    new_head = commit(repo, "advance head after plan fan-out")
+
+    # Run A: mid-write — worktree created + locked, session NOT finished yet
+    session_a = PlanWriteSession(
+        repo / "daydream_plans",
+        planned_at=head_sha,
+        run_session_id="run-A",
+    )
+    reservations_a = session_a.reserve([_finding()])
+    assert session_a.commit(reservations_a[0], _selection(repo)).status == "written"
+    worktree_a = repo / ".daydream" / "worktrees" / "run-A-reanchor"
+    assert worktree_a.is_dir()
+    assert git_ops.worktree_lock_mtime(repo, worktree_a) is not None  # live lock
+
+    # Run B starts: its start-of-run prune runs while A is mid-write
+    removed = prune_stale_reanchor_worktrees(repo)
+    assert removed == 0                        # A's live worktree is skipped
+    assert worktree_a.is_dir()                 # never force-removed
+    assert (worktree_a / "daydream_plans/001-batch-catalog-queries.md").is_file()
+
+    # A finishes: durable main copy + REANCHORED entry land; lock released
+    result_a = session_a.finish()
+    assert len(result_a["written"]) == 1
+    main_plan = repo / "daydream_plans/001-batch-catalog-queries.md"
+    assert main_plan.is_file()
+    assert f"`{new_head}`" in main_plan.read_text(encoding="utf-8")
+    assert "REANCHORED" in (repo / "daydream_plans" / "README.md").read_text(
+        encoding="utf-8"
+    )
+    assert git_ops.worktree_lock_mtime(repo, worktree_a) is None  # released
+
+
 def test_prune_named_reanchor_worktree_removes_valid_worktree(
     repo: Path, head_sha: str
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes a race where `prune_stale_reanchor_worktrees` could destroy a concurrent run's live `*-reanchor` worktree, or fail to reclaim genuinely stale ones.

## Changes
- Add git_ops worktree lock/unlock primitives with mtime readback (`b9c3d0f`)
- Lock re-anchor worktree at creation, release on finish (`a57dc16`)
- Reclaim stale locked re-anchor worktrees in the start-of-run prune (`2d6abe0`)
- Reconcile prune liveness guard with lint and deployment verification (`dcc524c`)
- Locate worktree locks via `--git-common-dir` (`eddaf17`)
- Atomic worktree lock-at-creation + free worktree path on re-anchor failure (`2fde06b`)
- Skip live re-anchor worktrees, unlock before removal (centralized in `worktree_remove_unlocked`) (`b860f1a`)

## Verification
- Full suite: 3214 passed / 6 skipped / 0 failed
- ruff + mypy clean
- Two sequential daydream deep-precision reviews passed

Closes #355