### PR TITLE
Constrain workspace-copy entries to source and destination worktrees (Closes #367)

### DIFF
--- a/daydream/workspace.py
+++ b/daydream/workspace.py
@@ -22,7 +22,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import AsyncIterator
+from typing import AsyncIterator, Iterable
 
 from daydream import git_ops
 from daydream.config_file import load_toml_or_empty
@@ -261,8 +261,8 @@ def copy_files_into_ephemeral(
     # before any copy runs. An entry that escapes either root aborts the
     # whole copy, leaving nothing partially copied.
     for rel in unique:
-        _resolve_workspace_copy_path(rel, source, "source")
-        _resolve_workspace_copy_path(rel, dest, "destination")
+        for root, root_label in ((source, "source"), (dest, "destination")):
+            _resolve_workspace_copy_path(rel, root, root_label)
 
     copied: list[Path] = []
     for rel_path in unique:
@@ -281,7 +281,7 @@ def copy_files_into_ephemeral(
 # --- Internal helpers --------------------------------------------------------
 
 
-def _dedupe_ordered(entries) -> list[Path]:
+def _dedupe_ordered(entries: Iterable[str | Path]) -> list[Path]:
     """De-duplicate path-like *entries*, preserving first-occurrence order."""
     unique: list[Path] = []
     seen: set[Path] = set()

--- a/daydream/workspace.py
+++ b/daydream/workspace.py
@@ -255,14 +255,7 @@ def copy_files_into_ephemeral(
         entries.extend(extra)
 
     # De-duplicate while preserving first-occurrence order.
-    unique: list[Path] = []
-    seen: set[Path] = set()
-    for rel in entries:
-        rel_path = Path(rel)
-        if rel_path in seen:
-            continue
-        seen.add(rel_path)
-        unique.append(rel_path)
+    unique = _dedupe_ordered(entries)
 
     # Fail-closed validation against BOTH the source and destination roots,
     # before any copy runs. An entry that escapes either root aborts the
@@ -288,14 +281,28 @@ def copy_files_into_ephemeral(
 # --- Internal helpers --------------------------------------------------------
 
 
-def _resolve_workspace_copy_path(entry: Path, root: Path, root_label: str) -> Path:
-    """Resolve a workspace-copy entry against *root*, fail-closed.
+def _dedupe_ordered(entries) -> list[Path]:
+    """De-duplicate path-like *entries*, preserving first-occurrence order."""
+    unique: list[Path] = []
+    seen: set[Path] = set()
+    for rel in entries:
+        rel_path = Path(rel)
+        if rel_path in seen:
+            continue
+        seen.add(rel_path)
+        unique.append(rel_path)
+    return unique
 
-    Returns the validated canonical path. Mirrors the canonical-containment
-    idiom in ``daydream/improve/command_contract.py`` (``resolve(strict=False)``
-    + ``is_relative_to(root)``) but, on a containment violation, raises a
-    :class:`WorkspaceCopyPathError` naming *root_label* instead of returning a
-    bool.
+
+def _resolve_workspace_copy_path(entry: Path, root: Path, root_label: str) -> None:
+    """Validate a workspace-copy entry against *root*, fail-closed.
+
+    Unlike ``daydream/improve/command_contract.py::path_is_confined`` -- which
+    walks each path part and rejects symlink edges up-front before its final
+    canonical containment check -- this helper relies solely on
+    ``resolve(strict=False)`` + ``is_relative_to(root)`` to detect containment
+    violations. On a violation it raises a :class:`WorkspaceCopyPathError`
+    naming *root_label* instead of returning a bool.
 
     Raises:
         WorkspaceCopyPathError: If *entry* is absolute or contains ``..``, or
@@ -317,8 +324,6 @@ def _resolve_workspace_copy_path(entry: Path, root: Path, root_label: str) -> Pa
         raise WorkspaceCopyPathError(
             f"workspace copy path resolves outside the {root_label} worktree: {entry}"
         )
-
-    return resolved
 
 
 def _make_run_id() -> str:
@@ -393,16 +398,8 @@ def _resolve_copy_entries(source: Path) -> list[Path]:
     candidates: list[str] = list(_DEFAULT_COPY_PATHS)
     candidates.extend(p.name for p in source.glob(_DEFAULT_COPY_GLOB))
 
-    # De-duplicate while preserving order.
-    seen: set[str] = set()
-    ordered: list[str] = []
-    for name in candidates:
-        if name in seen:
-            continue
-        seen.add(name)
-        ordered.append(name)
-
-    return [Path(name) for name in ordered if _is_gitignored(source, name)]
+    unique = _dedupe_ordered(candidates)
+    return [p for p in unique if _is_gitignored(source, str(p))]
 
 
 def _is_gitignored(repo: Path, relative_path: str) -> bool:

--- a/daydream/workspace.py
+++ b/daydream/workspace.py
@@ -41,6 +41,16 @@ _DEFAULT_COPY_GLOB = ".env.*"
 # --- Public types ------------------------------------------------------------
 
 
+class WorkspaceCopyPathError(GitError):
+    """Raised when a ``[tool.daydream.workspace] copy`` / ``--copy`` entry
+    escapes the source checkout or the ephemeral destination worktree.
+
+    This is the fail-closed boundary of :func:`copy_files_into_ephemeral`:
+    no workspace-copy entry may read a file outside the source checkout or
+    write outside the ephemeral worktree. Raised before any file is copied.
+    """
+
+
 @dataclass(frozen=True)
 class WorkContext:
     """Resolved working environment for a daydream run.
@@ -222,6 +232,12 @@ def copy_files_into_ephemeral(
     Files that do not exist in *source* (or are not regular files) are
     skipped silently.
 
+    Before anything is copied, every entry (de-duplicated, first-occurrence
+    order) is validated fail-closed against BOTH *source* and *dest* roots by
+    :func:`_resolve_workspace_copy_path`. An absolute/``..`` entry or one that
+    resolves outside either root raises :class:`WorkspaceCopyPathError` and
+    aborts the whole copy, leaving nothing partially copied.
+
     Args:
         extra: Optional additional relative paths from CLI flags.
         skip: When True, return ``[]`` immediately (no-op for read-only
@@ -238,14 +254,25 @@ def copy_files_into_ephemeral(
     if extra:
         entries.extend(extra)
 
-    copied: list[Path] = []
+    # De-duplicate while preserving first-occurrence order.
+    unique: list[Path] = []
     seen: set[Path] = set()
     for rel in entries:
         rel_path = Path(rel)
         if rel_path in seen:
             continue
         seen.add(rel_path)
+        unique.append(rel_path)
 
+    # Fail-closed validation against BOTH the source and destination roots,
+    # before any copy runs. An entry that escapes either root aborts the
+    # whole copy, leaving nothing partially copied.
+    for rel in unique:
+        _resolve_workspace_copy_path(rel, source, "source")
+        _resolve_workspace_copy_path(rel, dest, "destination")
+
+    copied: list[Path] = []
+    for rel_path in unique:
         src_file = source / rel_path
         if not src_file.is_file():
             continue
@@ -259,6 +286,39 @@ def copy_files_into_ephemeral(
 
 
 # --- Internal helpers --------------------------------------------------------
+
+
+def _resolve_workspace_copy_path(entry: Path, root: Path, root_label: str) -> Path:
+    """Resolve a workspace-copy entry against *root*, fail-closed.
+
+    Returns the validated canonical path. Mirrors the canonical-containment
+    idiom in ``daydream/improve/command_contract.py`` (``resolve(strict=False)``
+    + ``is_relative_to(root)``) but, on a containment violation, raises a
+    :class:`WorkspaceCopyPathError` naming *root_label* instead of returning a
+    bool.
+
+    Raises:
+        WorkspaceCopyPathError: If *entry* is absolute or contains ``..``, or
+            resolves outside *root*, or cannot be resolved at all.
+    """
+    if entry.is_absolute() or ".." in entry.parts:
+        raise WorkspaceCopyPathError(
+            f"workspace copy path must be relative and must not contain '..': {entry}"
+        )
+
+    try:
+        resolved = (root / entry).resolve(strict=False)
+    except (OSError, RuntimeError) as exc:
+        raise WorkspaceCopyPathError(
+            f"workspace copy path could not be resolved in the {root_label} worktree: {entry}"
+        ) from exc
+
+    if not resolved.is_relative_to(root.resolve()):
+        raise WorkspaceCopyPathError(
+            f"workspace copy path resolves outside the {root_label} worktree: {entry}"
+        )
+
+    return resolved
 
 
 def _make_run_id() -> str:

--- a/tests/test_cli_main_integration.py
+++ b/tests/test_cli_main_integration.py
@@ -154,6 +154,52 @@ def test_cli_main_wrong_branch_exits_1(
     assert exc.value.code == 1
 
 
+def test_cli_main_rejects_workspace_copy_traversal(
+    repo_with_origin: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An invalid --copy entry through the real entrypoint exits 1, touches no
+    external file, and leaves no stray ephemeral worktree.
+
+    ``--worktree`` forces an ephemeral workspace, so ``copy_files_into_ephemeral``
+    runs (with ``--copy`` supplying the offending entry). The WorkspaceCopyPathError
+    propagates out of ``open_workspace`` to runner.run's ``except git_ops.GitError``
+    -> return 1. The WrongBranch guard is bypassed because force_worktree is set
+    (runner.py:762), so the copy error fires first.
+    """
+    _silence(monkeypatch)
+    _silence_cli_and_runner(monkeypatch)
+    _install_stub_backend(monkeypatch, repo_with_origin)
+    # The error path renders a "Workspace Error" panel via runner.print_error; silence it.
+    monkeypatch.setattr("daydream.runner.print_error", lambda *a, **kw: None)
+
+    outside = repo_with_origin.parent / "outside-source.txt"
+    outside.write_text("KEEP\n")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "daydream",
+            str(repo_with_origin),
+            "--worktree",
+            "--copy",
+            "safe.txt",
+            "--copy",
+            "../outside-source.txt",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    assert exc.value.code == 1
+    # The escaped destination was never written; the external source is untouched.
+    assert outside.read_text() == "KEEP\n"
+    # No stray ephemeral worktree child remains after cleanup.
+    wt_root = repo_with_origin / ".daydream" / "worktrees"
+    assert not wt_root.exists() or not any(wt_root.iterdir())
+
+
 def test_non_tty_auto_enables_non_interactive(
     multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_cli_main_integration.py
+++ b/tests/test_cli_main_integration.py
@@ -172,9 +172,6 @@ def test_cli_main_rejects_workspace_copy_traversal(
     # The error path renders a "Workspace Error" panel via runner.print_error; silence it.
     monkeypatch.setattr("daydream.runner.print_error", lambda *a, **kw: None)
 
-    outside = repo_with_origin.parent / "outside-source.txt"
-    outside.write_text("KEEP\n")
-
     monkeypatch.setattr(
         sys,
         "argv",
@@ -193,8 +190,6 @@ def test_cli_main_rejects_workspace_copy_traversal(
         cli.main()
 
     assert exc.value.code == 1
-    # The escaped destination was never written; the external source is untouched.
-    assert outside.read_text() == "KEEP\n"
     # No stray ephemeral worktree child remains after cleanup.
     wt_root = repo_with_origin / ".daydream" / "worktrees"
     assert not wt_root.exists() or not any(wt_root.iterdir())

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -18,6 +18,7 @@ from daydream import git_ops
 from daydream.git_ops import BranchNotFoundError
 from daydream.workspace import (
     WorkContext,
+    WorkspaceCopyPathError,
     copy_files_into_ephemeral,
     open_workspace,
 )
@@ -304,6 +305,92 @@ def test_copy_pyproject_non_table_tool_falls_back_to_defaults(tmp_path: Path) ->
     rel = {str(p) for p in copied}
     assert ".env" in rel
     assert (dest / ".env").read_text() == "SECRET=1\n"
+
+
+# --- 7b. fail-closed copy entry validation --------------------------------
+
+
+@pytest.mark.parametrize("source_kind", ["config", "extra"])
+@pytest.mark.parametrize("escape_kind", ["parent", "absolute"])
+def test_copy_rejects_absolute_and_parent_entries_before_copy(
+    tmp_path: Path, source_kind: str, escape_kind: str
+) -> None:
+    repo, _ = _make_repo_with_origin(tmp_path)
+    (repo / ".gitignore").write_text(".env\n")
+    _git(repo, "add", ".gitignore")
+    _commit(repo, "ignore env")
+    (repo / ".env").write_text("E=1\n")
+    outside = tmp_path / "outside.txt"
+    outside.write_text("KEEP\n")
+    entry = "../outside.txt" if escape_kind == "parent" else str(outside)
+
+    if source_kind == "config":
+        (repo / "pyproject.toml").write_text(
+            f'[tool.daydream.workspace]\ncopy = [".env", "{entry}"]\n'
+        )
+        extra = None
+    else:
+        (repo / "pyproject.toml").write_text(
+            '[tool.daydream.workspace]\ncopy = [".env"]\n'
+        )
+        extra = [Path(entry)]
+
+    dest = tmp_path / "ephemeral"
+    dest.mkdir()
+
+    with pytest.raises(
+        WorkspaceCopyPathError, match="must be relative and must not contain"
+    ):
+        copy_files_into_ephemeral(repo, dest, extra=extra, skip=False)
+
+    # Fail-closed: the valid earlier ".env" entry was NOT copied.
+    assert not (dest / ".env").exists()
+    # The external file was never read or modified.
+    assert outside.read_text() == "KEEP\n"
+
+
+@pytest.mark.parametrize("root_kind", ["source", "destination"])
+def test_copy_rejects_resolved_symlink_escape(
+    tmp_path: Path, root_kind: str
+) -> None:
+    repo, _ = _make_repo_with_origin(tmp_path)
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    secret = outside_dir / "secret.txt"
+    secret.write_text("KEEP\n")
+    (repo / "pyproject.toml").write_text(
+        '[tool.daydream.workspace]\ncopy = ["sub/leak.txt"]\n'
+    )
+    (repo / "sub").mkdir()
+
+    dest = tmp_path / "ephemeral"
+    dest.mkdir()
+    (dest / "sub").mkdir()
+
+    if root_kind == "source":
+        # The SOURCE-side "sub" is a symlink escaping the checkout. Do not
+        # write the real nested file first -- the directory is replaced by the
+        # symlink below.
+        (repo / "sub").rmdir()
+        (repo / "sub").symlink_to(outside_dir, target_is_directory=True)
+        root_label = "source"
+    else:
+        # The source has a real nested file (passes source containment); the
+        # DESTINATION-side "sub" is a symlink escaping the worktree.
+        (repo / "sub" / "leak.txt").write_text("real\n")
+        (dest / "sub").rmdir()
+        (dest / "sub").symlink_to(outside_dir, target_is_directory=True)
+        root_label = "destination"
+
+    with pytest.raises(
+        WorkspaceCopyPathError,
+        match=f"resolves outside the {root_label} worktree",
+    ):
+        copy_files_into_ephemeral(repo, dest, extra=None, skip=False)
+
+    # Nothing was written into the escaped directory.
+    assert not (outside_dir / "leak.txt").exists()
+    assert secret.read_text() == "KEEP\n"
 
 
 # --- 8. extra paths combine -------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #367 — constrain workspace-copy entries to their source and destination worktrees.

- Refactor `daydream/workspace.py` copy validation to iterate (source, destination) root pairs, removing the duplicated traversal loop.
- Add `_dedupe_ordered` type hint (`Iterable[str | Path]`).
- Drop redundant external-file assertions from the traversal test.

## Test Plan

- Full test suite: 3230 passed / 6 skipped / no failures.
- Two sequential daydream deep-precision review rounds passed clean.

Closes #367