### PR TITLE
perf(benchmark): filter direct benchmark extraction and deduplication by selected PR URLs

### DIFF
--- a/daydream/benchmark/anthropic_score.py
+++ b/daydream/benchmark/anthropic_score.py
@@ -165,6 +165,11 @@ def _load_json_dict(path: Path, *, required: bool, missing_hint: str = "") -> di
     return data
 
 
+def _make_selection(golden_urls: Collection[str] | None) -> set[str] | None:
+    """Return a set of PR URLs to restrict work to, or ``None`` for no filter."""
+    return set(golden_urls) if golden_urls is not None else None
+
+
 async def run_anthropic_extraction(
     benchmark_repo: Path,
     judge_model: str,
@@ -187,7 +192,7 @@ async def run_anthropic_extraction(
     candidates_file = results_dir / "candidates.json"
     all_candidates = _load_json_dict(candidates_file, required=False)
 
-    selected = set(golden_urls) if golden_urls is not None else None
+    selected = _make_selection(golden_urls)
     for golden_url, entry in data.items():
         if selected is not None and golden_url not in selected:
             continue
@@ -236,7 +241,7 @@ async def run_anthropic_dedup(
     groups_file = results_dir / "dedup_groups.json"
     all_groups = _load_json_dict(groups_file, required=False)
 
-    selected = set(golden_urls) if golden_urls is not None else None
+    selected = _make_selection(golden_urls)
     for golden_url, tools in all_candidates.items():
         if selected is not None and golden_url not in selected:
             continue
@@ -354,7 +359,7 @@ async def run_anthropic_evaluation(
     evals = _load_json_dict(evaluations_file, required=False)
 
     judge = AnthropicFindingJudge(client)
-    selected = set(golden_urls) if golden_urls is not None else None
+    selected = _make_selection(golden_urls)
     for golden_url, entry in data.items():
         if selected is not None and golden_url not in selected:
             continue

--- a/daydream/benchmark/anthropic_score.py
+++ b/daydream/benchmark/anthropic_score.py
@@ -171,8 +171,14 @@ async def run_anthropic_extraction(
     *,
     tool: str = _TOOL,
     client: _AnthropicJsonCompleter,
+    golden_urls: Collection[str] | None = None,
 ) -> None:
-    """Extract Martian-compatible candidate issues using the injected JSON completer."""
+    """Extract Martian-compatible candidate issues using the injected JSON completer.
+
+    ``golden_urls``, when given, restricts extraction to those PR URLs; entries
+    already present in a resumable `candidates.json` for other PRs are left
+    untouched.
+    """
     benchmark_data_file = benchmark_repo / "results" / "benchmark_data.json"
     data = _load_json_dict(benchmark_data_file, required=True, missing_hint="cannot extract benchmark candidates.")
 
@@ -182,6 +188,8 @@ async def run_anthropic_extraction(
     all_candidates = _load_json_dict(candidates_file, required=False)
 
     for golden_url, entry in data.items():
+        if golden_urls is not None and golden_url not in golden_urls:
+            continue
         reviews = entry.get("reviews", []) if isinstance(entry, dict) else []
         for review in reviews:
             if not isinstance(review, dict) or review.get("tool") != tool:
@@ -210,8 +218,14 @@ async def run_anthropic_dedup(
     *,
     tool: str = _TOOL,
     client: _AnthropicJsonCompleter,
+    golden_urls: Collection[str] | None = None,
 ) -> None:
-    """Write Martian-compatible dedup groups using the injected JSON completer."""
+    """Write Martian-compatible dedup groups using the injected JSON completer.
+
+    ``golden_urls``, when given, restricts dedup to those PR URLs; entries
+    already present in a resumable `dedup_groups.json` for other PRs are left
+    untouched.
+    """
     results_dir = model_results_dir(benchmark_repo, judge_model)
     candidates_file = results_dir / "candidates.json"
     all_candidates = _load_json_dict(
@@ -222,6 +236,8 @@ async def run_anthropic_dedup(
     all_groups = _load_json_dict(groups_file, required=False)
 
     for golden_url, tools in all_candidates.items():
+        if golden_urls is not None and golden_url not in golden_urls:
+            continue
         if not isinstance(tools, dict):
             continue
         candidates = tools.get(tool)
@@ -265,7 +281,8 @@ async def run_direct_scoring(
     from the environment, preserving the ``anthropic-direct`` default behavior.
 
     ``judge_route`` is stamped onto every evaluation leaf so trend reports can
-    tell the in-process judge routes apart.
+    tell the in-process judge routes apart. When ``golden_urls`` is given,
+    extraction and dedup are restricted to the same selection as evaluation.
     """
     benchmark_repo = benchmark_repo.resolve()
     if client is None:
@@ -274,8 +291,8 @@ async def run_direct_scoring(
             raise BenchmarkStepError(f"{ANTHROPIC_JUDGE_API_KEY_ENV} is not set; cannot run direct scoring.")
         client = AnthropicJsonClient(api_key=api_key, model=judge_model)
 
-    await run_anthropic_extraction(benchmark_repo, judge_model, tool=tool, client=client)
-    await run_anthropic_dedup(benchmark_repo, judge_model, tool=tool, client=client)
+    await run_anthropic_extraction(benchmark_repo, judge_model, tool=tool, client=client, golden_urls=golden_urls)
+    await run_anthropic_dedup(benchmark_repo, judge_model, tool=tool, client=client, golden_urls=golden_urls)
     evals = await run_anthropic_evaluation(
         benchmark_repo,
         judge_model,

--- a/daydream/benchmark/anthropic_score.py
+++ b/daydream/benchmark/anthropic_score.py
@@ -187,8 +187,9 @@ async def run_anthropic_extraction(
     candidates_file = results_dir / "candidates.json"
     all_candidates = _load_json_dict(candidates_file, required=False)
 
+    selected = set(golden_urls) if golden_urls is not None else None
     for golden_url, entry in data.items():
-        if golden_urls is not None and golden_url not in golden_urls:
+        if selected is not None and golden_url not in selected:
             continue
         reviews = entry.get("reviews", []) if isinstance(entry, dict) else []
         for review in reviews:
@@ -235,8 +236,9 @@ async def run_anthropic_dedup(
     groups_file = results_dir / "dedup_groups.json"
     all_groups = _load_json_dict(groups_file, required=False)
 
+    selected = set(golden_urls) if golden_urls is not None else None
     for golden_url, tools in all_candidates.items():
-        if golden_urls is not None and golden_url not in golden_urls:
+        if selected is not None and golden_url not in selected:
             continue
         if not isinstance(tools, dict):
             continue

--- a/tests/test_benchmark_orchestrator.py
+++ b/tests/test_benchmark_orchestrator.py
@@ -14,10 +14,23 @@ import pytest
 from rich.console import Console
 
 from daydream.benchmark.acquire import AcquiredCheckout
+from daydream.benchmark.anthropic_score import (
+    _DEDUP_SYSTEM,
+    _EXTRACTION_SYSTEM,
+    AnthropicJsonClient,
+    run_anthropic_dedup,
+    run_anthropic_extraction,
+)
 from daydream.benchmark.config import BenchConfig
+from daydream.benchmark.judge import _JUDGE_SYSTEM
 from daydream.benchmark.orchestrator import run_bench
 from daydream.benchmark.prs import load_evaluable_prs
-from daydream.benchmark.score import DaydreamScores
+from daydream.benchmark.score import (
+    ANTHROPIC_JUDGE_API_KEY_ENV,
+    JUDGE_BASE_URL_ENV,
+    DaydreamScores,
+    model_results_dir,
+)
 
 
 def _item(file: str, line: int, **kw: Any) -> dict[str, Any]:
@@ -363,6 +376,110 @@ def test_scoring_ignores_unselected_prs_left_in_evaluations(tmp_path, monkeypatc
     assert "aggregate over 1 PR(s)" in out
     assert stale not in out
     assert "precision=1.000" in out and "recall=1.000" in out
+
+
+def test_limit_restricts_direct_extraction_and_dedup_to_selected_prs(tmp_path, monkeypatch):
+    data_path = _seed_benchmark_data_with_all_26_keys(tmp_path)
+    data = json.loads(data_path.read_text(encoding="utf-8"))
+    grafana = [url for url in data if "grafana" in url]
+    selected, unselected = grafana[0], grafana[1]
+    for url in (selected, unselected):  # give both PRs a valid daydream review
+        # The judge only reads golden comments carrying the "comment" key.
+        data[url]["golden_comments"] = [{"comment": "golden", "severity": "medium"}]
+        data[url]["reviews"].append({
+            "tool": "daydream", "repo_name": "daydream", "pr_url": url,
+            "review_comments": [{"path": "f.py", "line": 1, "body": "real review comment"}],
+        })
+    data_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+    results_dir = model_results_dir(tmp_path, "judge-model")
+    results_dir.mkdir(parents=True, exist_ok=True)
+    unselected_candidates = {
+        "daydream": [
+            {"text": "keep unselected candidate one", "path": None, "line": None, "source": "extracted"},
+            {"text": "keep unselected candidate two", "path": None, "line": None, "source": "extracted"},
+        ],
+        "other-tool": [{"text": "keep other tool candidate", "path": None, "line": None, "source": "extracted"}],
+    }
+    unselected_groups = {"daydream": [[0], [1]], "other-tool": [[0]]}
+    (results_dir / "candidates.json").write_text(
+        json.dumps({unselected: unselected_candidates}, indent=2), encoding="utf-8")
+    (results_dir / "dedup_groups.json").write_text(
+        json.dumps({unselected: unselected_groups}, indent=2), encoding="utf-8")
+
+    monkeypatch.setenv(ANTHROPIC_JUDGE_API_KEY_ENV, "sk-ant-test")
+    monkeypatch.delenv(JUDGE_BASE_URL_ENV, raising=False)
+
+    async def _canned(self, *, system, user, max_tokens):
+        if system == _EXTRACTION_SYSTEM:
+            return {"issues": ["fresh selected one", "fresh selected two"]}
+        if system == _DEDUP_SYSTEM:
+            return {"groups": [[0, 1]]}
+        assert system == _JUDGE_SYSTEM
+        return {"reasoning": "same underlying issue", "match": True, "confidence": 1.0}
+
+    monkeypatch.setattr(AnthropicJsonClient, "complete_json", _canned)
+    _mock_review(tmp_path, monkeypatch)
+
+    cfg = replace(_config(tmp_path, data_path, score=True, only="grafana"),
+                  limit=1, judge_route="anthropic-direct", model="judge-model")
+    assert run_bench(cfg) == 0
+
+    candidates = json.loads((results_dir / "candidates.json").read_text(encoding="utf-8"))
+    groups = json.loads((results_dir / "dedup_groups.json").read_text(encoding="utf-8"))
+    # selected recomputed fresh
+    assert [c["text"] for c in candidates[selected]["daydream"]] == ["fresh selected one", "fresh selected two"]
+    assert groups[selected]["daydream"] == [[0, 1]]
+    # unselected leaves preserved byte-for-byte (extraction+dedup skipped them)
+    assert candidates[unselected] == unselected_candidates
+    assert groups[unselected] == unselected_groups
+    # evaluation restricted to the selected PR only
+    evals = json.loads((results_dir / "evaluations.json").read_text(encoding="utf-8"))
+    assert list(evals) == [selected]
+    assert evals[selected]["daydream"]["tp"] == 1
+
+
+class _CountingJudgeClient:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def complete_json(self, *, system: str, user: str, max_tokens: int) -> dict:
+        self.calls += 1
+        return {}
+
+
+async def test_empty_selection_skips_all_extraction_and_dedup_judge_calls(tmp_path):
+    data_path = _seed_benchmark_data_with_all_26_keys(tmp_path)
+    data = json.loads(data_path.read_text(encoding="utf-8"))
+    url = next(u for u in data if "grafana" in u)
+    data[url]["reviews"].append({
+        "tool": "daydream", "repo_name": "daydream", "pr_url": url,
+        "review_comments": [{"path": "f.py", "line": 1, "body": "real review comment"}],
+    })
+    data_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+    results_dir = model_results_dir(tmp_path, "judge-model")
+    results_dir.mkdir(parents=True, exist_ok=True)
+    seeded_candidates = {
+        "daydream": [{"text": "a", "path": None, "line": None, "source": "extracted"},
+                     {"text": "b", "path": None, "line": None, "source": "extracted"}],
+    }
+    seeded_groups = {"daydream": [[0], [1]]}
+    (results_dir / "candidates.json").write_text(
+        json.dumps({url: seeded_candidates}, indent=2), encoding="utf-8")
+    (results_dir / "dedup_groups.json").write_text(
+        json.dumps({url: seeded_groups}, indent=2), encoding="utf-8")
+
+    client = _CountingJudgeClient()
+
+    await run_anthropic_extraction(tmp_path, "judge-model", tool="daydream", client=client, golden_urls=[])
+    await run_anthropic_dedup(tmp_path, "judge-model", tool="daydream", client=client, golden_urls=[])
+
+    assert client.calls == 0
+    candidates = json.loads((results_dir / "candidates.json").read_text(encoding="utf-8"))
+    groups = json.loads((results_dir / "dedup_groups.json").read_text(encoding="utf-8"))
+    assert candidates[url] == seeded_candidates
+    assert groups[url] == seeded_groups
 
 
 def test_materiality_gate_filters_submission(tmp_path, monkeypatch):

--- a/tests/test_benchmark_orchestrator.py
+++ b/tests/test_benchmark_orchestrator.py
@@ -89,6 +89,18 @@ def _write_items(checkout: Path, items: list[dict[str, Any]]) -> Path:
     return artifact
 
 
+def _seed_resumable_scoring_artifacts(
+    tmp_path: Path, *, url: str, candidates: dict[str, Any], groups: dict[str, Any]
+) -> None:
+    """Seed resumable candidates.json/dedup_groups.json leaves for a PR."""
+    results_dir = model_results_dir(tmp_path, "judge-model")
+    results_dir.mkdir(parents=True, exist_ok=True)
+    (results_dir / "candidates.json").write_text(
+        json.dumps({url: candidates}, indent=2), encoding="utf-8")
+    (results_dir / "dedup_groups.json").write_text(
+        json.dumps({url: groups}, indent=2), encoding="utf-8")
+
+
 def _config(tmp_path: Path, data_path: Path, *, score: bool, only: str) -> BenchConfig:
     """Build a BenchConfig whose benchmark_repo derives data_path.
 
@@ -393,7 +405,6 @@ def test_limit_restricts_direct_extraction_and_dedup_to_selected_prs(tmp_path, m
     data_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
     results_dir = model_results_dir(tmp_path, "judge-model")
-    results_dir.mkdir(parents=True, exist_ok=True)
     unselected_candidates = {
         "daydream": [
             {"text": "keep unselected candidate one", "path": None, "line": None, "source": "extracted"},
@@ -402,10 +413,7 @@ def test_limit_restricts_direct_extraction_and_dedup_to_selected_prs(tmp_path, m
         "other-tool": [{"text": "keep other tool candidate", "path": None, "line": None, "source": "extracted"}],
     }
     unselected_groups = {"daydream": [[0], [1]], "other-tool": [[0]]}
-    (results_dir / "candidates.json").write_text(
-        json.dumps({unselected: unselected_candidates}, indent=2), encoding="utf-8")
-    (results_dir / "dedup_groups.json").write_text(
-        json.dumps({unselected: unselected_groups}, indent=2), encoding="utf-8")
+    _seed_resumable_scoring_artifacts(tmp_path, url=unselected, candidates=unselected_candidates, groups=unselected_groups)
 
     monkeypatch.setenv(ANTHROPIC_JUDGE_API_KEY_ENV, "sk-ant-test")
     monkeypatch.delenv(JUDGE_BASE_URL_ENV, raising=False)
@@ -459,16 +467,12 @@ async def test_empty_selection_skips_all_extraction_and_dedup_judge_calls(tmp_pa
     data_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
     results_dir = model_results_dir(tmp_path, "judge-model")
-    results_dir.mkdir(parents=True, exist_ok=True)
     seeded_candidates = {
         "daydream": [{"text": "a", "path": None, "line": None, "source": "extracted"},
                      {"text": "b", "path": None, "line": None, "source": "extracted"}],
     }
     seeded_groups = {"daydream": [[0], [1]]}
-    (results_dir / "candidates.json").write_text(
-        json.dumps({url: seeded_candidates}, indent=2), encoding="utf-8")
-    (results_dir / "dedup_groups.json").write_text(
-        json.dumps({url: seeded_groups}, indent=2), encoding="utf-8")
+    _seed_resumable_scoring_artifacts(tmp_path, url=url, candidates=seeded_candidates, groups=seeded_groups)
 
     client = _CountingJudgeClient()
 

--- a/tests/test_benchmark_orchestrator.py
+++ b/tests/test_benchmark_orchestrator.py
@@ -413,7 +413,12 @@ def test_limit_restricts_direct_extraction_and_dedup_to_selected_prs(tmp_path, m
         "other-tool": [{"text": "keep other tool candidate", "path": None, "line": None, "source": "extracted"}],
     }
     unselected_groups = {"daydream": [[0], [1]], "other-tool": [[0]]}
-    _seed_resumable_scoring_artifacts(tmp_path, url=unselected, candidates=unselected_candidates, groups=unselected_groups)
+    _seed_resumable_scoring_artifacts(
+        tmp_path,
+        url=unselected,
+        candidates=unselected_candidates,
+        groups=unselected_groups,
+    )
 
     monkeypatch.setenv(ANTHROPIC_JUDGE_API_KEY_ENV, "sk-ant-test")
     monkeypatch.delenv(JUDGE_BASE_URL_ENV, raising=False)


### PR DESCRIPTION
## Summary
Filters direct benchmark extraction and deduplication to only the selected PR URLs (per issue #368, `critical` + `performance` + `improve`).

- `run_anthropic_extraction` and `run_anthropic_dedup` now skip golden URLs not in the selected set, instead of scoring everything.
- Hoists `golden_urls` into a `set` for O(1) membership lookups (built once, not per-iteration).
- Extracts a shared `_make_selection()` helper, removing triplicated `set(golden_urls) if ... else None` idiom across extraction/dedup/evaluation (round-2 review finding).
- Adds tests covering the limit and empty-selection cases via a shared `_seed` helper.

## Test Plan
- [x] 16 orchestrator tests pass
- [x] 30 benchmark tests pass (anthropic_score + orchestrator + openai_score)

Closes #368