### PR TITLE
fix(rl): reject occupied fixture destinations before Git initialization (#372)

### DIFF
--- a/rl/daydream_review_v1/daydream_review_v1/fixture.py
+++ b/rl/daydream_review_v1/daydream_review_v1/fixture.py
@@ -208,10 +208,13 @@ def build_fixture_repo(dest: Path, *, red: bool = False) -> FixtureRepo:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("dest", type=Path, help="directory to build the repository in")
+    parser.add_argument("dest", type=Path, help="new or empty directory to build the repository in")
     parser.add_argument("--red", action="store_true", help="plant a failing test in the head commit")
     args = parser.parse_args(argv)
-    repo = build_fixture_repo(args.dest, red=args.red)
+    try:
+        repo = build_fixture_repo(args.dest, red=args.red)
+    except ValueError as exc:
+        parser.error(str(exc))
     print(f"repo       {repo.path}")
     print(f"base_sha   {repo.base_sha}")
     print(f"pr1_head   {repo.pr1_head_sha}")

--- a/rl/daydream_review_v1/daydream_review_v1/fixture.py
+++ b/rl/daydream_review_v1/daydream_review_v1/fixture.py
@@ -171,13 +171,17 @@ def build_fixture_repo(dest: Path, *, red: bool = False) -> FixtureRepo:
     """Build the deterministic three-commit fixture repository at *dest*.
 
     Args:
-        dest: Directory to create the repository in; created if absent.
+        dest: New or empty directory to create the repository in; created if
+            absent. An occupied destination (an existing file or a non-empty
+            directory) is rejected before any mutation.
         red: Plant a failing assertion in the final commit's test file, to prove
             the image build's green-baseline gate actually fails.
 
     Returns:
         The built repository and its commit SHAs.
     """
+    if dest.exists() and (not dest.is_dir() or any(dest.iterdir())):
+        raise ValueError(f"fixture destination must be a new or empty directory: {dest}")
     dest.mkdir(parents=True, exist_ok=True)
     _git(dest, "init", "--quiet", "--initial-branch", "main")
     _git(dest, "config", "commit.gpgsign", "false")

--- a/rl/daydream_review_v1/tests/test_taskset.py
+++ b/rl/daydream_review_v1/tests/test_taskset.py
@@ -61,9 +61,13 @@ def _write_manifest(path: Path, slugs: list[str]) -> Path:
     return path
 
 
-def test_fixture_repo_is_deterministic(tmp_path: Path) -> None:
+@pytest.mark.parametrize("precreate_dest", [False, True], ids=["missing-destination", "empty-destination"])
+def test_fixture_repo_is_deterministic(tmp_path: Path, precreate_dest: bool) -> None:
     """The SHAs pinned in fixture.py, corpus-mini and the manifest are the real ones."""
-    repo = build_fixture_repo(tmp_path / "fx")
+    dest = tmp_path / "fx"
+    if precreate_dest:
+        dest.mkdir()
+    repo = build_fixture_repo(dest)
     assert (repo.base_sha, repo.pr1_head_sha, repo.pr2_head_sha) == (
         FIXTURE_BASE_SHA,
         FIXTURE_PR1_HEAD_SHA,

--- a/rl/daydream_review_v1/tests/test_taskset.py
+++ b/rl/daydream_review_v1/tests/test_taskset.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -99,6 +100,43 @@ def test_fixture_repo_rejects_occupied_destination(tmp_path: Path, kind: str) ->
         assert sorted(p.name for p in dest.iterdir()) == ["caller.txt"]
     else:
         assert dest.read_text(encoding="utf-8") == "caller-owned"
+
+
+def test_fixture_cli_rejects_existing_git_repository_without_modification(tmp_path: Path) -> None:
+    """An occupied git destination is rejected before any mutation; the CLI exits 2."""
+    dest = tmp_path / "occupied"
+    dest.mkdir()
+    subprocess.run(["git", "-C", str(dest), "init", "--quiet", "--initial-branch", "main"], check=True)
+    subprocess.run(["git", "-C", str(dest), "config", "user.name", "Caller"], check=True)
+    subprocess.run(["git", "-C", str(dest), "config", "user.email", "caller@example.com"], check=True)
+    (dest / "caller.txt").write_text("caller-owned", encoding="utf-8")
+    subprocess.run(["git", "-C", str(dest), "add", "caller.txt"], check=True)
+    subprocess.run(["git", "-C", str(dest), "commit", "-m", "caller commit"], check=True)
+
+    head_before = (dest / ".git" / "HEAD").read_text(encoding="utf-8")
+    config_before = (dest / ".git" / "config").read_text(encoding="utf-8")
+    status_before = subprocess.run(
+        ["git", "-C", str(dest), "status", "--porcelain"], capture_output=True, text=True
+    ).stdout
+    entries_before = sorted(p.name for p in dest.iterdir())
+
+    proc = subprocess.run(
+        [sys.executable, "-m", "daydream_review_v1.fixture", str(dest)],
+        capture_output=True,
+        text=True,
+    )
+
+    assert proc.returncode == 2
+    assert proc.stdout == ""
+    assert "fixture destination must be a new or empty directory" in proc.stderr
+    assert (dest / "caller.txt").read_text(encoding="utf-8") == "caller-owned"
+    assert (dest / ".git" / "HEAD").read_text(encoding="utf-8") == head_before
+    assert (dest / ".git" / "config").read_text(encoding="utf-8") == config_before
+    assert (
+        subprocess.run(["git", "-C", str(dest), "status", "--porcelain"], capture_output=True, text=True).stdout
+        == status_before
+    )
+    assert sorted(p.name for p in dest.iterdir()) == entries_before
 
 
 def test_load_builds_tasks_from_fixture_corpus(corpus_mini_dir: Path, fixture_manifest_path: Path) -> None:

--- a/rl/daydream_review_v1/tests/test_taskset.py
+++ b/rl/daydream_review_v1/tests/test_taskset.py
@@ -77,6 +77,30 @@ def test_fixture_repo_is_deterministic(tmp_path: Path, precreate_dest: bool) -> 
     assert green.returncode == 0, green.stderr
 
 
+@pytest.mark.parametrize(
+    "kind",
+    ["non-empty-dir", "existing-file"],
+    ids=["non-empty-directory", "existing-file"],
+)
+def test_fixture_repo_rejects_occupied_destination(tmp_path: Path, kind: str) -> None:
+    """build_fixture_repo raises before mutating an occupied destination."""
+    dest = tmp_path / "occupied"
+    if kind == "non-empty-dir":
+        dest.mkdir()
+        (dest / "caller.txt").write_text("caller-owned", encoding="utf-8")
+    else:
+        dest.write_text("caller-owned", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="fixture destination must be a new or empty directory"):
+        build_fixture_repo(dest)
+
+    if kind == "non-empty-dir":
+        assert (dest / "caller.txt").read_text(encoding="utf-8") == "caller-owned"
+        assert sorted(p.name for p in dest.iterdir()) == ["caller.txt"]
+    else:
+        assert dest.read_text(encoding="utf-8") == "caller-owned"
+
+
 def test_load_builds_tasks_from_fixture_corpus(corpus_mini_dir: Path, fixture_manifest_path: Path) -> None:
     taskset = DaydreamReviewTaskset(
         DaydreamReviewConfig(


### PR DESCRIPTION
Closes #372

## Summary
Reject occupied fixture destinations in `build_fixture_repo` **before** Git initialization, so an existing file or non-empty directory is never mutated.

- `fixture.py`: add an upfront occupancy check — a destination that exists and is either a non-file or non-empty directory raises `ValueError` before any `git init` / file writes.
- CLI: catch that `ValueError` and surface it via `parser.error` (exit 2, clean stderr), keeping the argparse contract.
- `test_taskset.py`: parametrize the determinism test over missing/empty destinations; add tests that a non-empty dir, an existing file, and an existing git repository are all rejected without modification (files, `.git/HEAD`, `.git/config`, and `git status` all unchanged).

## Test Plan
- Unit tests: parametrized determinism + occupied-destination rejection suite.
- Two sequential daydream deep-precision reviews passed (round 2 clean pass, coverage ratio 1.0 on the 2 changed files).