### PR TITLE
fix: redact GitHub App manifest-conversion codes from GitHub CLI errors (Closes #371)

### DIFF
--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -153,16 +153,39 @@ def _gh_token_env_for_request() -> dict[str, str] | None:
 # log line or error message that joins raw args masks these values.
 _SENSITIVE_HEADER_PREFIXES = ("authorization:",)
 
+# The GitHub App manifest-conversion credential rides in the single path segment
+# between the literal prefix and suffix of the ``gh api`` conversion endpoint
+# (e.g. ``/app-manifests/<code>/conversions``). Mask that segment in any
+# rendered diagnostic so the code never leaks verbatim, while preserving the
+# route for debuggability.
+_APP_MANIFEST_CONVERSION_CODE_RE = re.compile(r"(/app-manifests/)[^/\s]+(/conversions)")
+
+
+def _redact_sensitive_text(text: str) -> str:
+    """Mask secrets in *diagnostic* text only; never mutate a live request.
+
+    Replaces the credential segment of any ``/app-manifests/<code>/conversions``
+    endpoint with ``***`` (e.g. ``/app-manifests/***/conversions``), preserving
+    the surrounding route. This is a pure string transform for diagnostics such
+    as error messages and log lines — it must never be applied to the ``args``
+    list passed to :func:`subprocess.run`, which keeps the original endpoint so
+    GitHub still receives the real credential.
+    """
+    return _APP_MANIFEST_CONVERSION_CODE_RE.sub(r"\1***\2", text)
+
 
 def _redact_args(args: list[str]) -> list[str]:
-    """Mask secret-bearing args (e.g. ``Authorization: Bearer <jwt>``).
+    """Mask secret-bearing args for diagnostics (header values + manifest codes).
 
-    The token is passed as a plain ``gh``/``git`` argument, so joining raw args
-    into a warning or :class:`GitError` message would leak it into logs. The
-    header name is kept for debuggability; only the value is replaced.
+    Secrets travel as plain ``gh``/``git`` arguments, so joining raw args into a
+    warning or :class:`GitError` message would leak them into logs. This masks
+    sensitive header values (e.g. ``Authorization: Bearer <jwt>``, keeping the
+    header name for debuggability) and manifest-conversion endpoint segments. It
+    never mutates the input ``args`` list.
 
     Returns:
-        A copy with sensitive header values replaced by ``***``.
+        A copy with sensitive header values and manifest-conversion codes
+        replaced by ``***``.
     """
     redacted: list[str] = []
     for arg in args:
@@ -170,7 +193,7 @@ def _redact_args(args: list[str]) -> list[str]:
             redacted.append(f"{arg.split(':', 1)[0]}: ***")
         else:
             redacted.append(arg)
-    return redacted
+    return [_redact_sensitive_text(a) for a in redacted]
 
 
 # --- Errors ------------------------------------------------------------------
@@ -383,7 +406,9 @@ def _run_gh(
                     retries + 1,
                 )
         except (subprocess.SubprocessError, OSError) as exc:
-            raise GitError(f"gh {' '.join(_redact_args(args))} failed: {type(exc).__name__}: {exc}") from exc
+            raise GitError(
+                f"gh {' '.join(_redact_args(args))} failed: {type(exc).__name__}: {_redact_sensitive_text(str(exc))}"
+            ) from exc
 
     suffix = f" ({retries + 1} attempts)" if retries else ""
     raise GitTimeoutError(
@@ -1743,18 +1768,19 @@ def _gh_error_for(message: str, stderr: str) -> GitError:
     :class:`GitError` so non-rate-limit failures are never swallowed.
     """
     lowered = stderr.lower()
+    redacted_message = _redact_sensitive_text(message)
     is_rate_limit = (
         any(marker in lowered for marker in _RATE_LIMIT_MARKERS)
         or re.search(r"\b429\b", lowered) is not None
         or ("403" in lowered and "rate" in lowered)
     )
     if not is_rate_limit:
-        return GitError(message)
+        return GitError(redacted_message)
     retry_after: float | None = None
     match = re.search(r"retry[- ]after[:\s]+(\d+)", lowered)
     if match:
         retry_after = float(match.group(1))
-    return RateLimitError(message, retry_after=retry_after)
+    return RateLimitError(redacted_message, retry_after=retry_after)
 
 
 def _parse_gh_json(stdout: str, jq: str | None, endpoint: str, *, payload_note: str = "") -> Any:
@@ -1769,7 +1795,9 @@ def _parse_gh_json(stdout: str, jq: str | None, endpoint: str, *, payload_note: 
             return [json.loads(line) for line in stdout.splitlines() if line.strip()]
         return json.loads(stdout)
     except json.JSONDecodeError as exc:
-        raise GitError(f"gh api {endpoint} returned invalid JSON: {exc}{payload_note}") from exc
+        raise GitError(
+            _redact_sensitive_text(f"gh api {endpoint} returned invalid JSON: {exc}{payload_note}")
+        ) from exc
 
 
 def gh_api(

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -1455,11 +1455,14 @@ def test_gh_api_timeout_redacts_authorization_token(
         pytest.param("timeout", "timed out after", id="timeout"),
         pytest.param("api-error", "synthetic API failure", id="api-error"),
         pytest.param("invalid-json", "returned invalid JSON", id="invalid-json"),
+        pytest.param("rate-limit", "rate limit", id="rate-limit"),
+        pytest.param("timeout-warning", "timed out after", id="timeout-warning"),
     ],
 )
 def test_gh_api_manifest_conversion_failures_redact_code(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
     failure_mode: str,
     expected_fragment: str,
 ) -> None:
@@ -1477,8 +1480,12 @@ def test_gh_api_manifest_conversion_failures_redact_code(
     def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
         if failure_mode == "spawn-error":
             raise OSError(f"synthetic subprocess failure: {endpoint}")
-        if failure_mode == "timeout":
+        if failure_mode in ("timeout", "timeout-warning"):
             raise subprocess.TimeoutExpired(cmd=cmd, timeout=1)
+        if failure_mode == "rate-limit":
+            return subprocess.CompletedProcess(
+                args=["gh"], returncode=1, stdout="", stderr=f"secondary rate limit: {endpoint}"
+            )
         if failure_mode == "api-error":
             return subprocess.CompletedProcess(
                 args=["gh"], returncode=1, stdout="", stderr=f"synthetic API failure: {endpoint}"
@@ -1487,13 +1494,32 @@ def test_gh_api_manifest_conversion_failures_redact_code(
 
     monkeypatch.setattr("daydream.git_ops.subprocess.run", fake_run)
 
-    with pytest.raises(GitError) as excinfo:
-        git_ops.gh_api(repo, endpoint, method="POST")
+    # The timeout retry-warning renderer (git_ops.py:403) only fires when the
+    # call is idempotent and _gh_retries()>0; the other rows run with the
+    # default retries=0 to exercise the non-retry paths.
+    kwargs: dict[str, Any] = {"method": "POST"}
+    if failure_mode == "timeout-warning":
+        monkeypatch.setattr(git_ops, "_gh_retries", lambda: 1)
+        kwargs["idempotent"] = True
+
+    with caplog.at_level(logging.WARNING, logger="daydream.git_ops"):
+        with pytest.raises(GitError) as excinfo:
+            git_ops.gh_api(repo, endpoint, **kwargs)
+
+    # The rate-limit stderr must classify into a RateLimitError, not a plain GitError.
+    if failure_mode == "rate-limit":
+        assert isinstance(excinfo.value, git_ops.RateLimitError)
 
     msg = str(excinfo.value)
     assert sentinel not in msg
     assert "/app-manifests/***/conversions" in msg
     assert expected_fragment in msg
+
+    if failure_mode == "timeout-warning":
+        warnings = [r.getMessage() for r in caplog.records]
+        assert warnings, "expected a retry warning to be logged"
+        assert all(sentinel not in w for w in warnings)
+        assert any("/app-manifests/***/conversions" in w for w in warnings)
 
 
 def test_gh_api_jq_invalid_line_raises_git_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -1448,6 +1448,54 @@ def test_gh_api_timeout_redacts_authorization_token(
     assert any("Authorization: ***" in w for w in warnings)
 
 
+@pytest.mark.parametrize(
+    ("failure_mode", "expected_fragment"),
+    [
+        pytest.param("spawn-error", "synthetic subprocess failure", id="spawn-error"),
+        pytest.param("timeout", "timed out after", id="timeout"),
+        pytest.param("api-error", "synthetic API failure", id="api-error"),
+        pytest.param("invalid-json", "returned invalid JSON", id="invalid-json"),
+    ],
+)
+def test_gh_api_manifest_conversion_failures_redact_code(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_mode: str,
+    expected_fragment: str,
+) -> None:
+    """Manifest-conversion codes must never appear in caller-visible gh failures.
+
+    Real-path: ``gh_api`` builds the credential-bearing endpoint and calls the
+    real ``_run_gh``; only ``subprocess.run`` (the external boundary) is faked.
+    Each row exercises one failure producer and asserts the synthetic code is
+    replaced by ``***`` while the route and diagnostic fragment survive.
+    """
+    repo = _make_repo_with_main(tmp_path)
+    sentinel = "manifest-code-sentinel"
+    endpoint = f"/app-manifests/{sentinel}/conversions"
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if failure_mode == "spawn-error":
+            raise OSError(f"synthetic subprocess failure: {endpoint}")
+        if failure_mode == "timeout":
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=1)
+        if failure_mode == "api-error":
+            return subprocess.CompletedProcess(
+                args=["gh"], returncode=1, stdout="", stderr=f"synthetic API failure: {endpoint}"
+            )
+        return subprocess.CompletedProcess(args=["gh"], returncode=0, stdout="not-json", stderr="")
+
+    monkeypatch.setattr("daydream.git_ops.subprocess.run", fake_run)
+
+    with pytest.raises(GitError) as excinfo:
+        git_ops.gh_api(repo, endpoint, method="POST")
+
+    msg = str(excinfo.value)
+    assert sentinel not in msg
+    assert "/app-manifests/***/conversions" in msg
+    assert expected_fragment in msg
+
+
 def test_gh_api_jq_invalid_line_raises_git_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     class _Proc:
         returncode = 0


### PR DESCRIPTION
## Summary

Closes #371

Redact GitHub App **manifest-conversion codes** from GitHub CLI error
messages, warnings, and log lines. These credential-bearing codes previously
leaked verbatim into `gh` diagnostics (e.g. `/app-manifests/<code>/conversions`).

- Adds `_redact_sensitive_text()` which masks the credential segment of any
  `/app-manifests/<code>/conversions` endpoint as `/app-manifests/***/conversions`,
  preserving the route for debuggability.
- Applies the redaction across the diagnostic renderers in `_run_gh` and
  `_gh_error_for` (error text, retry warnings, timeout messages).
- The transform is purely for diagnostics — the real endpoint is still sent to
  GitHub, so functionality is unchanged.
- Adds parametrized test coverage for spawn-error, timeout, API-error,
  invalid-JSON, rate-limit, and timeout-warning failure paths asserting the
  code never appears while the route and diagnostic fragment survive.

## Test Plan

- [x] `tests/test_git_ops.py::test_gh_api_manifest_conversion_failures_redact_code`
      (6 parametrized rows)
- [x] Existing suite green (verified by daydream deep review round 1 & 2)

## Merge gate
Two sequential daydream deep-precision reviews completed (round 1: c918940,
round 2: 61ecb39) with no high/medium findings.