### PR TITLE
docs: remove task-overriding directives from CLAUDE.md (Closes #379)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,23 +59,6 @@ substitute. Reference exemplar: the non-interactive/EOF gate tests in `tests/tes
 **No caveats.** All work is completed and proven, or explicitly in progress. No deferred items, no
 "optional" follow-ups, no smoke-tests substituted for real coverage.
 
-## Non-negotiable: fix bugs at the root
-
-The highest-priority directive in this file. Violating it makes the agent dangerous and unusable.
-
-1. A bug in a safety or verification mechanism is fixed at its root cause, never bypassed.
-   `git push --no-verify`, skipping tests, commenting out checks, deleting guards, and lowering
-   assertions are all forbidden. Making the gate pass honestly IS the goal.
-2. Own your own bugs in plain language. Do not describe your own defect as the tool, hook, or framework
-   being "destructive" or "buggy."
-3. Fix the bug where it lives, not at a convenient downstream layer.
-4. A dangerous bug (state corruption, data loss, compromised safety mechanism) outranks the assigned
-   task. Stop and fix it first.
-5. Never claim success that isn't verified-working. "Committed" or "pushed" is not "working" unless the
-   actual behavior is verified.
-6. When the user pushes back more than once on the same point, stop defending and do the direct,
-   root-cause fix.
-
 ## Architecture
 
 ```text

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,8 @@ Full contract: `docs/extensions.md`.
 - Ruff: 120 cols, `E F I W`, py312. `daydream/atif/**` is lint-exempt (vendored, mechanical edits only).
 - **Conventional Commits** (`feat(backends): ...`). Stage explicitly (`git add <path>`), never `git add -A`.
 - Fix bugs at the root. Never bypass the hook, skip tests, or `git push --no-verify`.
+- Own your own bugs in plain language. Never describe your defect as the tool being buggy.
+- Never claim success that isn't verified-working.
 
 ## Environment variables
 


### PR DESCRIPTION
## Summary
Removes the `## Non-negotiable: fix bugs at the root` section from `CLAUDE.md` (issue #379). That section labelled itself the file's highest-priority directive and instructed agents to interrupt their assigned task for a broad class of bugs — repository-supplied imperative text that is potential prompt-injection content and can conflict with user authorization.

The deletion removes the priority declaration and its six numbered items. The factual project overview, command reference, testing standard, architecture, and constraints sections are preserved byte-for-byte.

Per daydream round-2 review, the two reporting-honesty guardrails that were NOT task-overriding/autonomy directives ("own your own bugs", "never claim success that isn't verified-working") were preserved — they were restored into the Constraints section (`Fix bugs at the root` block) so accountability standards survive.

## Test Plan
- Non-behavioral, docs-only change: no test-code change required (mode: not-applicable).
- Static invariant confirmed: no `## Non-negotiable: fix bugs at the root` heading; exactly one blank line separates the testing-standard closing paragraph from `## Architecture`.
- Scope integrity: only `CLAUDE.md` changed (`+2 -17`).
- `make check` gate passed during implementation.

Closes #379