### PR TITLE
fix(rl): reject empty commits from the RL fix reward path

### DIFF
--- a/rl/daydream_review_v1/daydream_review_v1/taskset.py
+++ b/rl/daydream_review_v1/daydream_review_v1/taskset.py
@@ -87,14 +87,20 @@ async def _fixes_applied(runtime: vf.Runtime, repo: str, head_sha: str) -> bool:
     never-committed files reads as "no fix" and scores ``no_fix_reward``. That
     direction costs a gradient; the other direction corrupts one.
 
-    A clean tree at a moved HEAD only counts as a fix when the *committed
-    contents differ* from the snapshot (`git diff --quiet <head_sha> HEAD --`
-    returns 1). HEAD advancing on its own — e.g. an `--allow-empty` commit that
-    leaves the tree byte-identical — is not a fix and scores ``no_fix_reward``.
+    A clean tree at a moved HEAD counts as a fix only when the *committed
+    contents differ* from the snapshot. HEAD advancing on its own — e.g. an
+    `--allow-empty` commit that leaves the tree byte-identical — is not a fix
+    and scores ``no_fix_reward``. Either way the decision is read from the
+    tracked tree, never from daydream's own ``.daydream/`` directory.
     """
     quoted = shlex.quote(repo)
     dirty = await runtime.run(
-        ["sh", "-c", f'cd {quoted} && test -n "$(git status --porcelain --untracked-files=no)"'], {}
+        [
+            "sh",
+            "-c",
+            f'cd {quoted} && test -n "$(git status --porcelain --untracked-files=no -- \':(exclude).daydream\')"',
+        ],
+        {},
     )
     if dirty.exit_code == 0:
         return True
@@ -103,10 +109,18 @@ async def _fixes_applied(runtime: vf.Runtime, repo: str, head_sha: str) -> bool:
     # "moved" is not enough — an empty commit advances HEAD while leaving the
     # committed tree identical to the baked snapshot, so compare the committed
     # contents, not the ref. `git diff --quiet` exits 1 when the trees differ
-    # (a fix) and 0 when they are identical (no fix); any other exit is treated
-    # as no-fix, preserving the deliberate false-negative bias.
+    # (a fix) and 0 when they are identical (no fix); any other exit (e.g. 128
+    # for an unresolvable baked SHA) is treated as no-fix, preserving the
+    # deliberate false-negative bias. Both checks exclude `.daydream/` — the
+    # agent may commit daydream's own artifacts into the tree, but they are
+    # never a fix signal.
     diff = await runtime.run(
-        ["sh", "-c", f"cd {quoted} && git diff --quiet {shlex.quote(head_sha)} HEAD --"], {}
+        [
+            "sh",
+            "-c",
+            f"cd {quoted} && git diff --quiet {shlex.quote(head_sha)} HEAD -- ':(exclude).daydream'",
+        ],
+        {},
     )
     return diff.exit_code == 1
 

--- a/rl/daydream_review_v1/daydream_review_v1/taskset.py
+++ b/rl/daydream_review_v1/daydream_review_v1/taskset.py
@@ -86,6 +86,11 @@ async def _fixes_applied(runtime: vf.Runtime, repo: str, head_sha: str) -> bool:
     Deliberately biased toward false negatives: a fix consisting ONLY of new,
     never-committed files reads as "no fix" and scores ``no_fix_reward``. That
     direction costs a gradient; the other direction corrupts one.
+
+    A clean tree at a moved HEAD only counts as a fix when the *committed
+    contents differ* from the snapshot (`git diff --quiet <head_sha> HEAD --`
+    returns 1). HEAD advancing on its own — e.g. an `--allow-empty` commit that
+    leaves the tree byte-identical — is not a fix and scores ``no_fix_reward``.
     """
     quoted = shlex.quote(repo)
     dirty = await runtime.run(
@@ -94,9 +99,16 @@ async def _fixes_applied(runtime: vf.Runtime, repo: str, head_sha: str) -> bool:
     if dirty.exit_code == 0:
         return True
     # The deep flow commits and pushes once the suite is green, so a clean tree
-    # at a moved HEAD is the successful-fix case, not the untouched one.
-    head = await runtime.run(["sh", "-c", f"cd {quoted} && git rev-parse HEAD"], {})
-    return head.exit_code == 0 and head.stdout.strip() != head_sha
+    # at a moved HEAD is the successful-fix case, not the untouched one. But
+    # "moved" is not enough — an empty commit advances HEAD while leaving the
+    # committed tree identical to the baked snapshot, so compare the committed
+    # contents, not the ref. `git diff --quiet` exits 1 when the trees differ
+    # (a fix) and 0 when they are identical (no fix); any other exit is treated
+    # as no-fix, preserving the deliberate false-negative bias.
+    diff = await runtime.run(
+        ["sh", "-c", f"cd {quoted} && git diff --quiet {shlex.quote(head_sha)} HEAD --"], {}
+    )
+    return diff.exit_code == 1
 
 
 async def _claimed_test_verdict(runtime: vf.Runtime, archive_root: str) -> bool | None:

--- a/rl/daydream_review_v1/daydream_review_v1/taskset.py
+++ b/rl/daydream_review_v1/daydream_review_v1/taskset.py
@@ -70,6 +70,13 @@ def _manifest_row(run_dir: Path) -> dict[str, Any]:
     return {**manifest, **metrics}
 
 
+#: Git pathspec (shell-quoted) excluding daydream's own ``.daydream/`` artifacts
+#: from the fix signal. Shared by both dirty-tree and moved-HEAD probes so the
+#: exclusion set only drifts by intentional edit, never by one string falling
+#: out of sync.
+DAYDREAM_EXCLUDE = "':(exclude).daydream'"
+
+
 async def _fixes_applied(runtime: vf.Runtime, repo: str, head_sha: str) -> bool:
     """Whether the rollout actually changed the code under review.
 
@@ -98,7 +105,7 @@ async def _fixes_applied(runtime: vf.Runtime, repo: str, head_sha: str) -> bool:
         [
             "sh",
             "-c",
-            f'cd {quoted} && test -n "$(git status --porcelain --untracked-files=no -- \':(exclude).daydream\')"',
+            f'cd {quoted} && test -n "$(git status --porcelain --untracked-files=no -- {DAYDREAM_EXCLUDE}")',
         ],
         {},
     )
@@ -118,7 +125,7 @@ async def _fixes_applied(runtime: vf.Runtime, repo: str, head_sha: str) -> bool:
         [
             "sh",
             "-c",
-            f"cd {quoted} && git diff --quiet {shlex.quote(head_sha)} HEAD -- ':(exclude).daydream'",
+            f"cd {quoted} && git diff --quiet {shlex.quote(head_sha)} HEAD -- {DAYDREAM_EXCLUDE}",
         ],
         {},
     )

--- a/rl/daydream_review_v1/tests/test_rewards.py
+++ b/rl/daydream_review_v1/tests/test_rewards.py
@@ -85,6 +85,7 @@ def _stage_repo(
     edit: str | None = None,
     patch: str | None = None,
     commit: bool = False,
+    commit_patch: bool = False,
 ) -> Path:
     """Build the fixture repo detached at *head_sha*, as the rollout image does.
 
@@ -98,17 +99,29 @@ def _stage_repo(
             flow does once the suite goes green. Without an ``edit`` this is an
             ``--allow-empty`` commit: HEAD advances but the committed tree is
             byte-identical to the snapshot (the empty-commit regression).
+        commit_patch: ALSO force-add and commit the planted ``.daydream/``
+            directory. Real targets don't gitignore ``.daydream/`` (only the
+            fixture does), so committing it faithfully reproduces a no-fix
+            rollout whose agent committed daydream's own artifacts — a tree
+            that differs from the snapshot for no reason other than the
+            artifacts. Without this option, ``commit=True`` stages only real
+            edits.
     """
     build_fixture_repo(repo_path)
     subprocess.run(["git", "-C", str(repo_path), "checkout", "--quiet", "--detach", head_sha], check=True)
     if edit is not None:
         (repo_path / "calc.py").write_text(edit, encoding="utf-8")
-    if commit:
-        subprocess.run(["git", "-C", str(repo_path), "commit", "--quiet", "--allow-empty", "-am", "fix"], check=True)
     if patch is not None:
         daydream_dir = repo_path / ".daydream"
         daydream_dir.mkdir(parents=True, exist_ok=True)
         (daydream_dir / "recommended.patch").write_text(patch, encoding="utf-8")
+    if commit:
+        subprocess.run(["git", "-C", str(repo_path), "add", "-A"], check=True)
+        if commit_patch:
+            # The fixture gitignores .daydream/ (fixture.py _GITIGNORE), unlike
+            # real targets, so force-add it to stage the committed-artifacts case.
+            subprocess.run(["git", "-C", str(repo_path), "add", "-f", ".daydream"], check=True)
+        subprocess.run(["git", "-C", str(repo_path), "commit", "--quiet", "--allow-empty", "-m", "fix"], check=True)
     return repo_path
 
 
@@ -289,6 +302,33 @@ async def test_no_fixes_returns_no_fix_reward(
     assert "test_claim_passed_without_fix" not in trace.metrics
 
 
+@pytest.mark.parametrize("head_sha", ["0" * 40], ids=["unresolvable-head"])
+async def test_unresolvable_head_sha_scores_no_fix(
+    head_sha: str, tmp_path: Path, runtime, corpus_mini_dir: Path, fixture_manifest_path: Path
+) -> None:
+    """A baked snapshot object that no longer resolves must read as no fix.
+
+    `git diff --quiet <head_sha> HEAD` exits 128 when the head object is absent
+    from the object store (the documented `exit_code != 1` branch in
+    `_fixes_applied`). Unlike a string comparison on `rev-parse`, that must not
+    be scored as a fix: every non-1 exit is `no_fix_reward`, honoring the
+    deliberate false-negative bias.
+    """
+    archive_root = tmp_path / "archive"
+    (archive_root / "runs").mkdir(parents=True)
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    # Stage the real, resolvable snapshot first so the checkout succeeds, then
+    # simulate snapshot/object-store drift: the baked head object is gone.
+    repo = _stage_repo(tmp_path / "repo", task.data.head_sha)
+    task.data = task.data.model_copy(update={"head_sha": head_sha})
+    trace = _trace(task, archive_root=archive_root, repo_path=repo)
+
+    await task.score(trace, runtime)
+
+    assert trace.metrics["fixes_applied"] == 0.0
+    assert trace.rewards["fix_tests_pass"] == task.config.no_fix_reward
+
+
 @pytest.mark.parametrize("claimed", [True, False], ids=["claimed-green", "claimed-red"])
 async def test_no_fixes_still_records_the_test_claim(
     claimed: bool,
@@ -427,6 +467,67 @@ async def test_committed_fix_counts_even_with_a_clean_tree(
 
     assert trace.metrics["fixes_applied"] == 1.0
     assert trace.rewards["fix_tests_pass"] == 1.0
+
+
+async def test_committed_daydream_artifacts_not_a_fix(
+    tmp_path: Path, runtime, corpus_mini_dir: Path, fixture_manifest_path: Path
+) -> None:
+    """Committing daydream's own .daydream/ artifacts must not read as a fix.
+
+    The pathspec exclusion owns the commit path. Real targets don't gitignore
+    ``.daydream/`` (only the fixture does), so a no-fix rollout whose agent
+    commits daydream's own untracked artifacts produces a tree that differs from
+    the baked snapshot — which ``git diff --quiet <head_sha> HEAD`` would read as
+    a fix and pay the full ``w_tests`` off a still-green baseline. Committing the
+    artifacts (force-added, since the fixture ignores them) must score
+    ``no_fix_reward``.
+    """
+    archive_root = tmp_path / "archive"
+    (archive_root / "runs").mkdir(parents=True)
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    repo = _stage_repo(
+        tmp_path / "repo", task.data.head_sha, patch=_REAL_PATCH, commit=True, commit_patch=True
+    )
+    trace = _trace(task, archive_root=archive_root, repo_path=repo)
+
+    await task.score(trace, runtime)
+
+    assert trace.metrics["fixes_applied"] == 0.0
+    assert trace.rewards["fix_tests_pass"] == task.config.no_fix_reward
+    assert "test_claim_mismatch" not in trace.metrics
+
+
+async def test_unresolvable_snapshot_sha_reads_as_no_fix(
+    tmp_path: Path, runtime, corpus_mini_dir: Path, fixture_manifest_path: Path
+) -> None:
+    """A fix signal that cannot be evaluated reads as no-fix, not a free win.
+
+    ``fix_tests_pass`` stays deliberately false-negative biased: any ``git diff
+    --quiet`` exit other than 1 (0 = identical trees, 128 = unresolvable baked
+    SHA, 127 = missing sh/git) means "no fix found". Here the baked snapshot SHA
+    is not present in the repository at all, so the diff exits 128 — the reward
+    must be ``no_fix_reward``, never the full ``w_tests`` for nothing.
+    """
+    archive_root = tmp_path / "archive"
+    (archive_root / "runs").mkdir(parents=True)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "-C", str(repo), "init", "-q"], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.email", "fix@fixture.invalid"], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "fixture"], check=True)
+    (repo / "calc.py").write_text(_CALC_BROKEN, encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "--quiet", "-m", "snapshot"], check=True)
+
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    # task.data.head_sha is the baked snapshot SHA from the corpus; this fresh
+    # repo has never contained it, so the fix-signal diff cannot resolve it.
+    trace = _trace(task, archive_root=archive_root, repo_path=repo)
+
+    await task.score(trace, runtime)
+
+    assert trace.metrics["fixes_applied"] == 0.0
+    assert trace.rewards["fix_tests_pass"] == task.config.no_fix_reward
 
 
 async def test_reward_version_is_pinned(

--- a/rl/daydream_review_v1/tests/test_rewards.py
+++ b/rl/daydream_review_v1/tests/test_rewards.py
@@ -94,15 +94,17 @@ def _stage_repo(
             WITHOUT an edit is the contamination case: daydream writes that file
             into the repository under review and its own untracked artifacts leak
             into it, so it must never be read as "a fix landed".
-        commit: Commit the edit, moving HEAD past the baked snapshot — what the
-            deep flow does once the suite goes green.
+        commit: Commit, moving HEAD past the baked snapshot — what the deep
+            flow does once the suite goes green. Without an ``edit`` this is an
+            ``--allow-empty`` commit: HEAD advances but the committed tree is
+            byte-identical to the snapshot (the empty-commit regression).
     """
     build_fixture_repo(repo_path)
     subprocess.run(["git", "-C", str(repo_path), "checkout", "--quiet", "--detach", head_sha], check=True)
     if edit is not None:
         (repo_path / "calc.py").write_text(edit, encoding="utf-8")
-        if commit:
-            subprocess.run(["git", "-C", str(repo_path), "commit", "--quiet", "-am", "fix"], check=True)
+    if commit:
+        subprocess.run(["git", "-C", str(repo_path), "commit", "--quiet", "--allow-empty", "-am", "fix"], check=True)
     if patch is not None:
         daydream_dir = repo_path / ".daydream"
         daydream_dir.mkdir(parents=True, exist_ok=True)
@@ -251,12 +253,17 @@ async def test_fix_tests_pass_red(
 
 
 @pytest.mark.parametrize(
-    "patch",
-    [None, "", _REAL_PATCH],
-    ids=["no-patch-file", "empty-patch", "non-empty-patch-but-untouched-tree"],
+    "patch, commit",
+    [
+        (None, False),
+        ("", False),
+        (_REAL_PATCH, False),
+        (None, True),  # empty commit: HEAD advances, committed tree unchanged
+    ],
+    ids=["no-patch-file", "empty-patch", "non-empty-patch-but-untouched-tree", "empty-commit"],
 )
 async def test_no_fixes_returns_no_fix_reward(
-    patch: str | None, tmp_path: Path, runtime, corpus_mini_dir: Path, fixture_manifest_path: Path
+    patch: str | None, commit: bool, tmp_path: Path, runtime, corpus_mini_dir: Path, fixture_manifest_path: Path
 ) -> None:
     """An untouched tree earns no_fix_reward however recommended.patch looks.
 
@@ -270,7 +277,7 @@ async def test_no_fixes_returns_no_fix_reward(
     archive_root = tmp_path / "archive"
     (archive_root / "runs").mkdir(parents=True)
     task = _task(corpus_mini_dir, fixture_manifest_path)
-    repo = _stage_repo(tmp_path / "repo", task.data.head_sha, patch=patch)
+    repo = _stage_repo(tmp_path / "repo", task.data.head_sha, patch=patch, commit=commit)
     trace = _trace(task, archive_root=archive_root, repo_path=repo)
 
     await task.score(trace, runtime)

--- a/rl/daydream_review_v1/uv.lock
+++ b/rl/daydream_review_v1/uv.lock
@@ -396,7 +396,7 @@ wheels = [
 
 [[package]]
 name = "daydream"
-version = "0.25.0"
+version = "0.26.0"
 source = { editable = "../../" }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

Closes #374

Rejects empty commits (commits with no tree changes) from the RL fix reward path in the daydream task setup:

- **test(rl):** add an empty-commit regression to the no-fix reward test (87bcedd)
- **fix(rl):** reject empty commits as fixes (4081954)
- **fix(rl):** exclude `.daydream` artifacts from the fix signal (77faaae)
- **refactor(rl):** share the `.daydream` pathspec constant in both dirty-tree and moved-HEAD fix probes (7ae6744)

## Test Plan

- Tests verified green on VM: 33 passed (test_rewards + test_taskset).

## Review

No CodeRabbit — two sequential daydream deep-precision reviews (rounds 1 & 2) completed genuine passes on fresh exe.dev VMs.
