### PR TITLE
fix(training): remove stale corpus lineage metadata after empty rebuild

### DIFF
--- a/daydream/training/corpus.py
+++ b/daydream/training/corpus.py
@@ -876,6 +876,9 @@ def run_build_corpus(config: BuildCorpusConfig) -> dict[str, int]:
         config.out_path.parent.mkdir(parents=True, exist_ok=True)
         schema_dst = config.out_path.parent / "schema.json"
         shutil.copyfile(SCHEMA_V1_PATH, schema_dst)
+        # Emits no records, so any prior lineage.json from an earlier build is
+        # removed to keep the manifest faithful to the (now empty) JSONL.
+        (config.out_path.parent / "lineage.json").unlink(missing_ok=True)
         return _summary(0, 0, 0, 0)
 
     # 2. Resolve archive dir.

--- a/daydream/training/corpus.py
+++ b/daydream/training/corpus.py
@@ -995,7 +995,10 @@ def run_build_corpus(config: BuildCorpusConfig) -> dict[str, int]:
     # 9. Lineage manifest beside the JSONL: the included set drives the
     #    content-address; versions reflect the post-stratify annotations; as_of
     #    falls back to write-time. Skipped when empty (an empty-set hash misleads).
+    #    When empty, any prior lineage.json from an earlier build is removed so a
+    #    stale manifest never survives.
     if not records:
+        (config.out_path.parent / "lineage.json").unlink(missing_ok=True)
         print_info(console, f"Wrote 0 records to {config.out_path} — skipping lineage manifest")
         return _summary(total_in_index, after_filters, after_stratify, 0)
     included_session_ids = [r["session_id"] for r in records]

--- a/daydream/training/corpus.py
+++ b/daydream/training/corpus.py
@@ -33,8 +33,10 @@ pinning the snapshot's provenance: a content-addressed ``trajectory_set_hash``
 scalar when uniform, the sorted distinct set when the corpus mixes versions),
 the ``as_of`` pin (echoed from config, or the resolved write-time when
 unpinned), and a wall-clock UTC ``created_at``. The manifest is written
-atomically (tempfile + ``os.replace``) and skipped on ``dry_run``; it subsumes
-the retired ``daydream snapshot`` verb's reproducibility role.
+atomically (tempfile + ``os.replace``) and skipped on ``dry_run``; a completed
+non-dry-run build that emits zero records removes any prior ``lineage.json``
+(rather than writing an empty-set manifest); it subsumes the retired
+``daydream snapshot`` verb's reproducibility role.
 
 The projection is pure: no git, no network, no manifest write-back.
 ``base_sha`` is *read* from the on-disk manifest (harvest materializes it);
@@ -858,6 +860,8 @@ def run_build_corpus(config: BuildCorpusConfig) -> dict[str, int]:
     9. Write ``lineage.json`` beside the JSONL pinning the snapshot's
        provenance (``trajectory_set_hash``, labeler/reward versions, ``as_of``,
        ``created_at``) so the snapshot is reproducible from immutable inputs.
+       When the output is empty (zero records), any prior ``lineage.json`` from
+       an earlier build is removed rather than writing an empty-set manifest.
 
     Returns:
         Summary dict with keys ``total_runs_in_index``, ``after_filters``,

--- a/tests/test_corpus_lineage.py
+++ b/tests/test_corpus_lineage.py
@@ -34,6 +34,26 @@ def test_build_corpus_emits_lineage_manifest(tmp_path, archive_dir):
     assert man["as_of"] == "2026-04-01T00:00:00+00:00"
 
 
+def test_emit_schema_only_removes_stale_lineage(tmp_path, archive_dir):
+    _seed_run_with_annotation(archive_dir, "s1", label="accepted",
+                              reward_version="r1", observed_at="2026-03-01T00:00:00+00:00",
+                              valid_at="2026-03-01T00:00:00+00:00")
+    out = tmp_path / "c.jsonl"
+    as_of = "2026-04-01T00:00:00+00:00"
+    # First build emits a non-empty corpus with a lineage manifest.
+    run_build_corpus(BuildCorpusConfig(out_path=out, archive_dir=archive_dir,
+                                       filters=CorpusFilters(), as_of=as_of))
+    assert (tmp_path / "lineage.json").exists()
+    # Schema-only re-run on the same path emits no records and must not leave
+    # the prior build's stale lineage manifest behind.
+    summary = run_build_corpus(BuildCorpusConfig(out_path=out, archive_dir=archive_dir,
+                                                 filters=CorpusFilters(), as_of=as_of,
+                                                 emit_schema_only=True))
+    assert summary["emitted"] == 0
+    assert (tmp_path / "schema.json").exists()
+    assert not (tmp_path / "lineage.json").exists()
+
+
 def test_build_corpus_removes_stale_lineage_when_rebuilt_empty(tmp_path, archive_dir):
     _seed_run_with_annotation(archive_dir, "s1", label="accepted",
                               reward_version="r1", observed_at="2026-03-01T00:00:00+00:00",

--- a/tests/test_corpus_lineage.py
+++ b/tests/test_corpus_lineage.py
@@ -29,3 +29,21 @@ def test_build_corpus_emits_lineage_manifest(tmp_path, archive_dir):
                         "as_of", "created_at"}
     assert man["trajectory_set_hash"] == hashlib.sha256(b"s1").hexdigest()
     assert man["as_of"] == "2026-04-01T00:00:00+00:00"
+
+
+def test_build_corpus_removes_stale_lineage_when_rebuilt_empty(tmp_path, archive_dir):
+    _seed_run_with_annotation(archive_dir, "s1", label="accepted",
+                              reward_version="r1", observed_at="2026-03-01T00:00:00+00:00",
+                              valid_at="2026-03-01T00:00:00+00:00")
+    out = tmp_path / "c.jsonl"
+    as_of = "2026-04-01T00:00:00+00:00"
+    # First build emits a non-empty corpus with a lineage manifest.
+    run_build_corpus(BuildCorpusConfig(out_path=out, archive_dir=archive_dir,
+                                       filters=CorpusFilters(), as_of=as_of))
+    assert (tmp_path / "lineage.json").exists()
+    # Rebuild the same path with no admitted runs -> empty JSONL, no lineage.
+    summary = run_build_corpus(BuildCorpusConfig(out_path=out, archive_dir=archive_dir,
+                                                 filters=CorpusFilters(labels=()), as_of=as_of))
+    assert summary["emitted"] == 0
+    assert out.read_text() == ""
+    assert not (tmp_path / "lineage.json").exists()

--- a/tests/test_corpus_lineage.py
+++ b/tests/test_corpus_lineage.py
@@ -3,9 +3,12 @@
 Each ``run_build_corpus`` invocation writes ``lineage.json`` beside the JSONL
 output, pinning the provenance of the snapshot: the content-addressed
 ``trajectory_set_hash`` of the included sessions, the observed labeler/reward
-versions, the ``as_of`` pin, and a wall-clock ``created_at``. These tests drive
+versions, the ``as_of`` pin, and a wall-clock ``created_at``. A completed
+non-dry-run build that emits zero records removes any prior ``lineage.json``
+(rather than writing an empty-set manifest), so a stale manifest never
+survives after an empty rebuild. These tests drive
 :func:`run_build_corpus` against a real SQLite index (no archive-layer mocking)
-and assert on the manifest the user would inspect on disk.
+and assert on the manifest the user would inspect on disk (or its absence).
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
Removes stale corpus lineage metadata (`lineage.json`) when a corpus is rebuilt with no data (empty/schema-only rebuild). Previously a freshly-written empty `schema.json` could be left alongside an outdated `lineage.json`, confusing downstream tooling that reads the two together.

## Changes
- `daydream/training/corpus.py` — remove stale `lineage.json` on empty corpus rebuild
- `tests/test_corpus_lineage.py` — regression coverage for lineage removal on schema-only re-build

## Test Plan
- Unit tests pass (`test_corpus_lineage.py`)
- Two sequential daydream deep-precision reviews (round 1 + round 2) passed

## Notes
- No CodeRabbit in this org; merge gate is the two daydream reviews.

Closes #378
