### PR TITLE
docs(workflows): align repository workflow setup docs with Codex authentication

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -59,9 +59,9 @@ only the `@<bot> review` command path can serve them.
 No single job ever holds both PR code and the App private key:
 
 - **Phase A (Daydream Review)** checks out and analyzes untrusted PR code,
-  so it is unprivileged: `contents: read` GITHUB_TOKEN, `ANTHROPIC_API_KEY`
-  as its only secret, no App material anywhere. Its output is a passive data
-  artifact (`findings.json`), never code.
+  so it is unprivileged: `contents: read` GITHUB_TOKEN, `OPENAI_API_KEY`
+  as its only secret to authenticate the Codex CLI, no App material anywhere.
+  Its output is a passive data artifact (`findings.json`), never code.
 - **Daydream Command** never checks out code, so it may hold App credentials:
   it mints a short-lived App token with `actions: write` (to dispatch the
   review — see Install step 1) plus `pull-requests: write` (to post the 👀

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -33,7 +33,7 @@ GitHub App identity — no maintainer server, no third-party service.
    Actions → Secrets):
    - `DAYDREAM_APP_ID` — the App's numeric ID
    - `DAYDREAM_APP_PRIVATE_KEY` — the App's PEM private key, pasted verbatim
-   - `ANTHROPIC_API_KEY` — used only by the unprivileged review job
+   - `OPENAI_API_KEY` — used only by the unprivileged review job to authenticate the Codex CLI
 4. **Add one repository variable** (Settings → Secrets and variables →
    Actions → Variables):
    - `DAYDREAM_BOT_HANDLE` — the mention handle the command workflow matches,

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -12,7 +12,9 @@ cannot verify and that a careless edit could silently break:
 - The privilege split holds: the job that checks out untrusted PR code never
   holds the App key, and the privileged jobs never check out PR code.
 - The repo's own Codex dogfood workflow persists ``codex login`` before the
-  review runs (``codex exec`` does not read ``OPENAI_API_KEY`` for auth).
+  review runs (``codex exec`` does not read ``OPENAI_API_KEY`` for auth), and
+  the repository workflow README names ``OPENAI_API_KEY`` as the credential the
+  live Codex workflow consumes.
 
 PyYAML parses the bare ``on:`` key as boolean ``True``; ``wf_on()`` normalizes it.
 """
@@ -221,9 +223,10 @@ def test_single_setup_preserves_privilege_split() -> None:
     }
 
 
-# Repo dogfood workflow (Codex): the one non-obvious behavioral constraint worth
-# guarding — `codex exec` does not read OPENAI_API_KEY for model-API auth, so
-# `codex login --with-api-key` must persist auth.json BEFORE the review runs.
+# Repo dogfood workflow (Codex): `codex exec` does not read OPENAI_API_KEY for
+# model-API auth, so `codex login --with-api-key` must persist auth.json BEFORE
+# the review runs, and the repo workflow README documents OPENAI_API_KEY as the
+# credential this live workflow consumes.
 
 
 def test_repo_review_authenticates_codex_before_running() -> None:

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -228,10 +228,15 @@ def test_single_setup_preserves_privilege_split() -> None:
 # login-persistence ordering that rationale requires.
 
 
-def test_repo_review_authenticates_codex_before_running() -> None:
-    wf = load_workflow(REPO_WORKFLOWS_DIR / "daydream-review.yml")
+def _assert_repo_workflow_uses_openai_credential() -> None:
+    """Assert the repo's live review workflow uses OPENAI_API_KEY as its only secret."""
     text = (REPO_WORKFLOWS_DIR / "daydream-review.yml").read_text(encoding="utf-8")
     assert set(_SECRET_REF_RE.findall(text)) == {"OPENAI_API_KEY"}
+
+
+def test_repo_review_authenticates_codex_before_running() -> None:
+    wf = load_workflow(REPO_WORKFLOWS_DIR / "daydream-review.yml")
+    _assert_repo_workflow_uses_openai_credential()
 
     steps = job_steps(wf, "analyze")
     login = next(s for s in steps if "codex login --with-api-key" in s.get("run", ""))
@@ -251,11 +256,8 @@ def test_repo_review_authenticates_codex_before_running() -> None:
     ids=["install", "security-model"],
 )
 def test_repo_workflow_readme_documents_codex_credential(section_start: str, section_end: str) -> None:
-    wf_text = (REPO_WORKFLOWS_DIR / "daydream-review.yml").read_text(encoding="utf-8")
+    _assert_repo_workflow_uses_openai_credential()
     readme_text = (REPO_WORKFLOWS_DIR / "README.md").read_text(encoding="utf-8")
-
-    credentials = set(_SECRET_REF_RE.findall(wf_text))
-    assert credentials == {"OPENAI_API_KEY"}
 
     start = readme_text.find(section_start)
     assert start != -1, (

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -223,10 +223,11 @@ def test_single_setup_preserves_privilege_split() -> None:
     }
 
 
-# Repo dogfood workflow (Codex): `codex exec` does not read OPENAI_API_KEY for
-# model-API auth, so `codex login --with-api-key` must persist auth.json BEFORE
-# the review runs, and the repo workflow README documents OPENAI_API_KEY as the
-# credential this live workflow consumes.
+# Repo dogfood workflow (Codex). The full rationale — the `codex exec` auth
+# gap, the `codex login --with-api-key` persistence, and the README's naming of
+# the live credential — lives in the module docstring and is exercised by
+# test_repo_workflow_readme_documents_codex_credential; this test asserts the
+# login-persistence ordering that rationale requires.
 
 
 def test_repo_review_authenticates_codex_before_running() -> None:
@@ -260,10 +261,17 @@ def test_repo_workflow_readme_documents_codex_credential(
     credentials = set(_SECRET_REF_RE.findall(wf_text))
     assert credentials == {"OPENAI_API_KEY"}
 
-    start = readme_text.index(section_start)
-    end = readme_text.index(section_end, start)
+    start = readme_text.find(section_start)
+    assert start != -1, (
+        f"{REPO_WORKFLOWS_DIR.name}/README.md: missing section header {section_start!r} "
+        f"— renamed or re-worded? Keep it in sync with this test."
+    )
+    end = readme_text.find(section_end, start)
+    assert end != -1, (
+        f"{REPO_WORKFLOWS_DIR.name}/README.md: missing header {section_end!r} after "
+        f"{section_start!r} — renamed/re-worded, or did the two headers swap order?"
+    )
     section = readme_text[start:end]
 
-    for cred in credentials:
-        assert f"`{cred}`" in section
+    assert "`OPENAI_API_KEY`" in section
     assert "ANTHROPIC_API_KEY" not in section

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -57,9 +57,7 @@ def has_checkout(job: dict[str, Any]) -> bool:
 # never ${{ }} interpolation, which would splice attacker-controlled text into the
 # shell.
 
-_EVENT_INTERP = re.compile(
-    r"\$\{\{[^}]*github\.event\.(comment|issue|pull_request|workflow_run|review)[^}]*\}\}"
-)
+_EVENT_INTERP = re.compile(r"\$\{\{[^}]*github\.event\.(comment|issue|pull_request|workflow_run|review)[^}]*\}\}")
 
 
 @pytest.mark.parametrize("wf_path", sorted(TEMPLATES_DIR.rglob("*.yml")), ids=lambda p: p.name)
@@ -69,8 +67,7 @@ def test_no_event_data_interpolated_into_run_steps(wf_path: Path) -> None:
         for step in job["steps"]:
             if "run" in step:
                 assert not _EVENT_INTERP.search(step["run"]), (
-                    f"{wf_path.name}:{job_name}: event data must reach run: via env:, "
-                    f"never ${{{{ }}}} interpolation"
+                    f"{wf_path.name}:{job_name}: event data must reach run: via env:, never ${{{{ }}}} interpolation"
                 )
 
 
@@ -78,9 +75,7 @@ def test_no_event_data_interpolated_into_run_steps(wf_path: Path) -> None:
 # the moving `main` tip. Fails on release until the template pin is bumped in
 # lockstep with the package version.
 
-_INSTALL_RE = re.compile(
-    r"uv tool install\s+git\+https://github\.com/existential-birds/daydream(?P<ref>@\S+)?"
-)
+_INSTALL_RE = re.compile(r"uv tool install\s+git\+https://github\.com/existential-birds/daydream(?P<ref>@\S+)?")
 
 
 def _package_version() -> str:
@@ -138,23 +133,29 @@ _APP_TOKEN_ACTION = "actions/create-github-app-token@fee1f7d63c2ff003460e3d13972
 # job, a refloated pin, or a newly added unpinned token action fails loudly rather
 # than being silently absorbed by a wildcard.
 _APP_TOKEN_PIN_CASES = [
-    (TEMPLATES_DIR / "daydream-post.yml", "template-post",
-     [("post", _APP_TOKEN_ACTION), ("surface-analyze-failure", _APP_TOKEN_ACTION)]),
-    (REPO_WORKFLOWS_DIR / "daydream-post.yml", "live-post",
-     [("post", _APP_TOKEN_ACTION), ("surface-analyze-failure", _APP_TOKEN_ACTION)]),
-    (TEMPLATES_DIR / "daydream-command.yml", "template-command",
-     [("dispatch", _APP_TOKEN_ACTION)]),
-    (REPO_WORKFLOWS_DIR / "daydream-command.yml", "live-command",
-     [("dispatch", _APP_TOKEN_ACTION)]),
-    (TEMPLATES_DIR / "single" / "daydream.yml", "single",
-     [("gate", _APP_TOKEN_ACTION), ("post", _APP_TOKEN_ACTION),
-      ("surface-failure", _APP_TOKEN_ACTION)]),
+    (
+        TEMPLATES_DIR / "daydream-post.yml",
+        "template-post",
+        [("post", _APP_TOKEN_ACTION), ("surface-analyze-failure", _APP_TOKEN_ACTION)],
+    ),
+    (
+        REPO_WORKFLOWS_DIR / "daydream-post.yml",
+        "live-post",
+        [("post", _APP_TOKEN_ACTION), ("surface-analyze-failure", _APP_TOKEN_ACTION)],
+    ),
+    (TEMPLATES_DIR / "daydream-command.yml", "template-command", [("dispatch", _APP_TOKEN_ACTION)]),
+    (REPO_WORKFLOWS_DIR / "daydream-command.yml", "live-command", [("dispatch", _APP_TOKEN_ACTION)]),
+    (
+        TEMPLATES_DIR / "single" / "daydream.yml",
+        "single",
+        [("gate", _APP_TOKEN_ACTION), ("post", _APP_TOKEN_ACTION), ("surface-failure", _APP_TOKEN_ACTION)],
+    ),
 ]
 
 
-@pytest.mark.parametrize("wf_path,expected",
-                         [(p, e) for p, _id, e in _APP_TOKEN_PIN_CASES],
-                         ids=[_id for _, _id, _ in _APP_TOKEN_PIN_CASES])
+@pytest.mark.parametrize(
+    "wf_path,expected", [(p, e) for p, _id, e in _APP_TOKEN_PIN_CASES], ids=[_id for _, _id, _ in _APP_TOKEN_PIN_CASES]
+)
 def test_workflows_pin_create_github_app_token(wf_path: Path, expected: list) -> None:
     wf = load_workflow(wf_path)
     token_action_uses = [
@@ -184,12 +185,9 @@ def test_post_findings_step_exports_bot_login(wf_path: Path) -> None:
     """
     text = wf_path.read_text(encoding="utf-8")
     assert "BOT_LOGIN: ${{ vars.DAYDREAM_BOT_HANDLE }}" in text, (
-        f"{wf_path.name}: Post findings step must export BOT_LOGIN from "
-        f"vars.DAYDREAM_BOT_HANDLE (issue #254)"
+        f"{wf_path.name}: Post findings step must export BOT_LOGIN from vars.DAYDREAM_BOT_HANDLE (issue #254)"
     )
-    assert '--bot-login "$BOT_LOGIN"' in text, (
-        f"{wf_path.name}: Post findings step must pass --bot-login explicitly"
-    )
+    assert '--bot-login "$BOT_LOGIN"' in text, f"{wf_path.name}: Post findings step must pass --bot-login explicitly"
 
 
 def test_single_setup_preserves_privilege_split() -> None:
@@ -252,9 +250,7 @@ def test_repo_review_authenticates_codex_before_running() -> None:
     ],
     ids=["install", "security-model"],
 )
-def test_repo_workflow_readme_documents_codex_credential(
-    section_start: str, section_end: str
-) -> None:
+def test_repo_workflow_readme_documents_codex_credential(section_start: str, section_end: str) -> None:
     wf_text = (REPO_WORKFLOWS_DIR / "daydream-review.yml").read_text(encoding="utf-8")
     readme_text = (REPO_WORKFLOWS_DIR / "README.md").read_text(encoding="utf-8")
 

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -238,3 +238,29 @@ def test_repo_review_authenticates_codex_before_running() -> None:
     assert steps.index(login) < review_idx, "Codex auth must be persisted before the review runs"
     # The review step authenticates via auth.json, not a redundant env secret.
     assert "OPENAI_API_KEY" not in steps[review_idx].get("env", {})
+
+
+@pytest.mark.parametrize(
+    "section_start,section_end",
+    [
+        ("## Install", "## Trigger matrix"),
+        ("## Security model — the privilege split", "## Dedup limitations (v1)"),
+    ],
+    ids=["install", "security-model"],
+)
+def test_repo_workflow_readme_documents_codex_credential(
+    section_start: str, section_end: str
+) -> None:
+    wf_text = (REPO_WORKFLOWS_DIR / "daydream-review.yml").read_text(encoding="utf-8")
+    readme_text = (REPO_WORKFLOWS_DIR / "README.md").read_text(encoding="utf-8")
+
+    credentials = set(_SECRET_REF_RE.findall(wf_text))
+    assert credentials == {"OPENAI_API_KEY"}
+
+    start = readme_text.index(section_start)
+    end = readme_text.index(section_end, start)
+    section = readme_text[start:end]
+
+    for cred in credentials:
+        assert f"`{cred}`" in section
+    assert "ANTHROPIC_API_KEY" not in section


### PR DESCRIPTION
## Summary

Closes #376

Aligns the repository workflow setup documentation with the live Codex authentication contract. The review workflow authenticates the Codex CLI using the OpenAI credential `OPENAI_API_KEY`, but the README told operators to provide `ANTHROPIC_API_KEY`.

## Changes

- `.github/workflows/README.md`
  - Install section: third repo secret now names `OPENAI_API_KEY` (used by the unprivileged review job to authenticate the Codex CLI), replacing `ANTHROPIC_API_KEY`
  - Security model — Phase A bullet: identifies `OPENAI_API_KEY` as the only repository credential for Codex CLI authentication
- `tests/test_workflow_templates.py`
  - Added `test_repo_workflow_readme_documents_codex_credential` (parameterized over `install` and `security-model`) comparing the two README sections against the credential reference extracted from the live `daydream-review.yml`
  - Documented both Codex credential-drift contracts in the module docstring
  - Deduplicated the shared credential-assertion helper (`_assert_repo_workflow_uses_openai_credential`)

## Test Plan

- `make check` — 3234 passed / 6 skipped
- Two sequential daydream deep-precision reviews (round 1 + round 2) passed, round-2 finding addressed and verified