### PR TITLE
fix(bench): join benchmark trajectories by canonical repository and PR identity

### DIFF
--- a/bench/benchmark-report/build.py
+++ b/bench/benchmark-report/build.py
@@ -219,10 +219,14 @@ def load_trajectories(traj_dir: Path, prices: dict[str, ModelPrice], price_model
     return out
 
 
+def _split_pr_url(pr_url: str) -> list[str]:
+    return pr_url.rstrip("/").split("/")
+
+
 def traj_key_for_pr(pr_url: str) -> str:
     """Canonical (owner/repo, number) join key for a PR url, matching trajectories with extra.pr_repo."""
     # https://github.com/alpha/widgets/pull/7 -> "alpha/widgets/7"
-    parts = pr_url.rstrip("/").split("/")
+    parts = _split_pr_url(pr_url)
     num = parts[-1]
     owner_repo = "/".join(parts[-4:-2]) if len(parts) >= 4 else ""
     return f"{owner_repo}/{num}"
@@ -231,7 +235,7 @@ def traj_key_for_pr(pr_url: str) -> str:
 def _legacy_traj_key_for_pr(pr_url: str) -> str:
     """Legacy (repo-last-segment, number) join key, matching trajectories without extra.pr_repo."""
     # https://github.com/alpha/widgets/pull/7 -> "widgets/7"
-    parts = pr_url.rstrip("/").split("/")
+    parts = _split_pr_url(pr_url)
     num = parts[-1]
     repo_last = parts[-3] if len(parts) >= 3 else ""
     return f"{repo_last}/{num}"
@@ -364,13 +368,14 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
         tj = trajectories.get(traj_key_for_pr(pr), {})
         if not tj:
             legacy_key = _legacy_traj_key_for_pr(pr)
-            if legacy_shares[legacy_key] > 1:
+            legacy_tj = trajectories.get(legacy_key, {})
+            if legacy_shares[legacy_key] > 1 and legacy_tj:
                 matching = sorted(pr for pr in dd_subset if _legacy_traj_key_for_pr(pr) == legacy_key)
                 raise SystemExit(
                     f"ambiguous legacy trajectory key {legacy_key!r} matches multiple benchmark PRs: "
                     f"{', '.join(matching)}; regenerate the trajectory with extra.pr_repo"
                 )
-            tj = trajectories.get(legacy_key, {})
+            tj = legacy_tj
         lab = labels.get(pr, {})
         cost = tj.get("cost_usd")
         if tj:

--- a/bench/benchmark-report/build.py
+++ b/bench/benchmark-report/build.py
@@ -363,7 +363,11 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
     tot_prompt = tot_completion = tot_cached = 0
     tot_cost = 0.0
     walls = []
-    legacy_shares = Counter(_legacy_traj_key_for_pr(pr) for pr in dd_subset)
+    # Count legacy basename shares only across PRs that genuinely need the
+    # legacy fallback (no canonical trajectory), so a canonical PR whose
+    # basename happens to collide does not inflate the ambiguity guard.
+    legacy_needed = [pr for pr in dd_subset if not trajectories.get(traj_key_for_pr(pr), {})]
+    legacy_shares = Counter(_legacy_traj_key_for_pr(pr) for pr in legacy_needed)
     for pr in sorted(dd_subset):
         tj = trajectories.get(traj_key_for_pr(pr), {})
         if not tj:

--- a/bench/benchmark-report/build.py
+++ b/bench/benchmark-report/build.py
@@ -26,6 +26,7 @@ import argparse
 import hashlib
 import json
 import shutil
+from collections import Counter
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, TypeGuard
@@ -174,10 +175,11 @@ def rank_of(rows: list[dict], target_tool: str, key: str) -> tuple[int, int]:
 def load_trajectories(traj_dir: Path, prices: dict[str, ModelPrice], price_model: str) -> dict[str, dict]:
     """Map PR-url -> {tokens, synth cost, wall seconds, steps} from ATIF trajectories.
 
-    Join key: (repo-last-segment, pr-number) parsed from the filename. Cost is
-    SYNTHESIZED from measured tokens (the backend records $0 for GLM via z.ai).
-    The counters are DISJOINT (prompt = fresh input, cached = cache reads), which
-    is what :func:`compute_cost` prices — not ``compute_cost_from_totals``.
+    Join key: trajectories with nonempty ``extra.pr_repo`` are indexed under
+    ``pr_repo/number``; artifacts lacking it fall back to ``repo_short/number``.
+    Cost is SYNTHESIZED from measured tokens (the backend records $0 for GLM via
+    z.ai). The counters are DISJOINT (prompt = fresh input, cached = cache reads),
+    which is what :func:`compute_cost` prices — not ``compute_cost_from_totals``.
     """
     out: dict[str, dict] = {}
     if not traj_dir.is_dir():
@@ -205,9 +207,11 @@ def load_trajectories(traj_dir: Path, prices: dict[str, ModelPrice], price_model
             def _p(s: str) -> datetime:
                 return datetime.fromisoformat(s.replace("Z", "+00:00"))
             wall = (_p(max(stamps)) - _p(min(stamps))).total_seconds()
-        out[f"{repo_short}/{num}"] = {
+        pr_repo = (d.get("extra", {}) or {}).get("pr_repo", "")
+        key = f"{pr_repo}/{num}" if pr_repo else f"{repo_short}/{num}"
+        out[key] = {
             "repo_short": repo_short, "pr_number": num,
-            "pr_repo": (d.get("extra", {}) or {}).get("pr_repo", ""),
+            "pr_repo": pr_repo,
             "prompt_tokens": prompt, "completion_tokens": completion, "cached_tokens": cached,
             "cost_usd": cost, "wall_seconds": wall, "steps": int(fm.get("total_steps", 0)),
             "price_model": price_model,
@@ -216,8 +220,17 @@ def load_trajectories(traj_dir: Path, prices: dict[str, ModelPrice], price_model
 
 
 def traj_key_for_pr(pr_url: str) -> str:
-    """(repo-last-segment, number) join key for a PR url, matching trajectory filenames."""
-    # https://github.com/calcom/cal.com/pull/10600 -> "cal.com/10600"
+    """Canonical (owner/repo, number) join key for a PR url, matching trajectories with extra.pr_repo."""
+    # https://github.com/alpha/widgets/pull/7 -> "alpha/widgets/7"
+    parts = pr_url.rstrip("/").split("/")
+    num = parts[-1]
+    owner_repo = "/".join(parts[-4:-2]) if len(parts) >= 4 else ""
+    return f"{owner_repo}/{num}"
+
+
+def _legacy_traj_key_for_pr(pr_url: str) -> str:
+    """Legacy (repo-last-segment, number) join key, matching trajectories without extra.pr_repo."""
+    # https://github.com/alpha/widgets/pull/7 -> "widgets/7"
     parts = pr_url.rstrip("/").split("/")
     num = parts[-1]
     repo_last = parts[-3] if len(parts) >= 3 else ""
@@ -346,8 +359,18 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
     tot_prompt = tot_completion = tot_cached = 0
     tot_cost = 0.0
     walls = []
+    legacy_shares = Counter(_legacy_traj_key_for_pr(pr) for pr in dd_subset)
     for pr in sorted(dd_subset):
         tj = trajectories.get(traj_key_for_pr(pr), {})
+        if not tj:
+            legacy_key = _legacy_traj_key_for_pr(pr)
+            if legacy_shares[legacy_key] > 1:
+                matching = sorted(pr for pr in dd_subset if _legacy_traj_key_for_pr(pr) == legacy_key)
+                raise SystemExit(
+                    f"ambiguous legacy trajectory key {legacy_key!r} matches multiple benchmark PRs: "
+                    f"{', '.join(matching)}; regenerate the trajectory with extra.pr_repo"
+                )
+            tj = trajectories.get(legacy_key, {})
         lab = labels.get(pr, {})
         cost = tj.get("cost_usd")
         if tj:

--- a/tests/test_benchmark_report_build.py
+++ b/tests/test_benchmark_report_build.py
@@ -181,3 +181,51 @@ def test_report_rejects_ambiguous_legacy_trajectory_fallback(
     )
     with pytest.raises(SystemExit, match="ambiguous legacy trajectory key 'widgets/7'"):
         build_mod.build(args)
+
+
+def test_report_allows_mixed_canonical_and_unique_legacy_trajectories(
+    build_mod: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A canonical PR plus a same-basename PR resolving via a UNIQUE legacy trajectory must not crash.
+
+    Regression for the legacy-guard false positive: pre-fix, the share counter
+    counted every PR (including ones resolving canonically), so a single legacy
+    trajectory shared its basename with a canonical PR and failed closed despite
+    the legacy key being unambiguous.
+    """
+    monkeypatch.setenv("DAYDREAM_PRICES_FILE", str(tmp_path / "absent.toml"))
+    args = _corpus(
+        tmp_path,
+        pr_trajectories={
+            # Resolves canonically via extra.pr_repo.
+            "https://github.com/alpha/widgets/pull/7": (
+                "alpha_widgets-7.json", "alpha/widgets", 1_000_000, 1_000_000, 1_000_000, 3, None
+            ),
+            # Same basename, but only a unique legacy trajectory (no pr_repo).
+            "https://github.com/beta/widgets/pull/7": (
+                "widgets-7.json", None, 4_000_000, 5_000_000, 6_000_000, 9, None
+            ),
+        },
+    )
+    report = build_mod.build(args)  # must NOT raise SystemExit
+
+    rows = {r["pr_url"]: r for r in report["per_pr"]}
+    assert len(rows) == 2
+    alpha = rows["https://github.com/alpha/widgets/pull/7"]
+    beta = rows["https://github.com/beta/widgets/pull/7"]
+    assert alpha["prompt_tokens"] == 1_000_000
+    assert alpha["steps"] == 3
+    assert beta["prompt_tokens"] == 4_000_000
+    assert beta["completion_tokens"] == 5_000_000
+    assert beta["cached_tokens"] == 6_000_000
+    assert beta["steps"] == 9
+
+    eco = report["economy"]
+    assert eco["n_with_trajectory"] == 2
+    assert eco["total_prompt_tokens"] == 5_000_000
+    assert eco["total_completion_tokens"] == 6_000_000
+    assert eco["total_cached_tokens"] == 7_000_000
+    assert eco["total_cost_usd"] == pytest.approx(
+        1.4 + 1_000_000 * 0.26 / 1e6 + 1_000_000 * 4.4 / 1e6
+        + 4_000_000 * 1.4 / 1e6 + 6_000_000 * 0.26 / 1e6 + 5_000_000 * 4.4 / 1e6
+    )

--- a/tests/test_benchmark_report_build.py
+++ b/tests/test_benchmark_report_build.py
@@ -28,27 +28,41 @@ def build_mod() -> ModuleType:
 PR_URL = "https://github.com/calcom/cal.com/pull/10600"
 
 
-def _corpus(root: Path) -> argparse.Namespace:
-    """A minimal one-PR, one-judge corpus plus one trajectory with known token counts."""
+def _corpus(
+    root: Path,
+    *,
+    pr_trajectories: dict[str, tuple[str, str | None, int, int, int, int, tuple[str, str] | None]] | None = None,
+) -> argparse.Namespace:
+    """Minimal corpus. pr_trajectories maps PR url -> (filename, pr_repo, prompt,
+    completion, cached, steps, (start_iso, end_iso) | None). Omitted -> the existing
+    one-PR legacy corpus (cal.com-10600.json with no pr_repo)."""
+    if pr_trajectories is None:
+        pr_trajectories = {PR_URL: ("cal.com-10600.json", None, 1_000_000, 1_000_000, 1_000_000, 3, None)}
     judge = root / "results" / "anthropic_claude-opus-4-5-20251101"
     judge.mkdir(parents=True)
     leaf = {"tp": 1, "fp": 0, "fn": 0, "total_candidates": 1, "total_golden": 1}
-    (judge / "evaluations.json").write_text(json.dumps({PR_URL: {"daydream-owl-alpha": leaf}}))
-
+    (judge / "evaluations.json").write_text(
+        json.dumps({pr: {"daydream-owl-alpha": leaf} for pr in pr_trajectories})
+    )
     traj = root / "trajectories"
     traj.mkdir()
-    (traj / "cal.com-10600.json").write_text(
-        json.dumps(
-            {
-                "final_metrics": {
-                    "total_prompt_tokens": 1_000_000,
-                    "total_completion_tokens": 1_000_000,
-                    "total_cached_tokens": 1_000_000,
-                    "total_steps": 3,
-                }
+    for fname, pr_repo, prompt, completion, cached, steps, stamps in pr_trajectories.values():
+        body: dict[str, Any] = {
+            "final_metrics": {
+                "total_prompt_tokens": prompt,
+                "total_completion_tokens": completion,
+                "total_cached_tokens": cached,
+                "total_steps": steps,
             }
-        )
-    )
+        }
+        extra: dict[str, Any] = {}
+        if pr_repo is not None:
+            extra["pr_repo"] = pr_repo
+        if stamps is not None:
+            extra["phase_events"] = [{"timestamp": s} for s in stamps]
+        if extra:
+            body["extra"] = extra
+        (traj / fname).write_text(json.dumps(body))
     return argparse.Namespace(
         results_root=str(root / "results"),
         daydream_tool="daydream-owl-alpha",
@@ -97,4 +111,69 @@ def test_unknown_price_model_is_rejected(
     args = _corpus(tmp_path)
     args.price_model = "no-such-model"
     with pytest.raises(SystemExit, match="unknown --price-model"):
+        build_mod.build(args)
+
+
+def test_report_joins_trajectories_by_full_repository_identity(
+    build_mod: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two same-basename PRs (alpha/widgets vs beta/widgets, PR 7) each get their own metrics."""
+    monkeypatch.setenv("DAYDREAM_PRICES_FILE", str(tmp_path / "absent.toml"))
+    args = _corpus(
+        tmp_path,
+        pr_trajectories={
+            "https://github.com/alpha/widgets/pull/7": (
+                "alpha_widgets-7.json", "alpha/widgets", 1_000_000, 2_000_000, 3_000_000, 5,
+                ("2026-01-01T00:00:00Z", "2026-01-01T00:02:00Z"),
+            ),
+            "https://github.com/beta/widgets/pull/7": (
+                "beta_widgets-7.json", "beta/widgets", 4_000_000, 5_000_000, 6_000_000, 9,
+                ("2026-01-01T00:00:00Z", "2026-01-01T00:01:00Z"),
+            ),
+        },
+    )
+    report = build_mod.build(args)
+
+    rows = {r["pr_url"]: r for r in report["per_pr"]}
+    assert len(rows) == 2
+    alpha = rows["https://github.com/alpha/widgets/pull/7"]
+    beta = rows["https://github.com/beta/widgets/pull/7"]
+    assert alpha["prompt_tokens"] == 1_000_000
+    assert alpha["completion_tokens"] == 2_000_000
+    assert alpha["cached_tokens"] == 3_000_000
+    assert alpha["steps"] == 5
+    assert alpha["cost_usd"] == pytest.approx(1.4 + 3_000_000 * 0.26 / 1e6 + 2_000_000 * 4.4 / 1e6)
+    assert alpha["wall_seconds"] == pytest.approx(120.0)
+    assert beta["prompt_tokens"] == 4_000_000
+    assert beta["completion_tokens"] == 5_000_000
+    assert beta["cached_tokens"] == 6_000_000
+    assert beta["steps"] == 9
+    assert beta["cost_usd"] == pytest.approx(4_000_000 * 1.4 / 1e6 + 6_000_000 * 0.26 / 1e6 + 5_000_000 * 4.4 / 1e6)
+    assert beta["wall_seconds"] == pytest.approx(60.0)
+
+    eco = report["economy"]
+    assert eco["n_with_trajectory"] == 2
+    assert eco["total_prompt_tokens"] == 5_000_000
+    assert eco["total_completion_tokens"] == 7_000_000
+    assert eco["total_cached_tokens"] == 9_000_000
+    assert eco["total_cost_usd"] == pytest.approx(
+        1.4 + 3_000_000 * 0.26 / 1e6 + 2_000_000 * 4.4 / 1e6
+        + 4_000_000 * 1.4 / 1e6 + 6_000_000 * 0.26 / 1e6 + 5_000_000 * 4.4 / 1e6
+    )
+    assert eco["n_with_wall"] == 2
+
+
+def test_report_rejects_ambiguous_legacy_trajectory_fallback(
+    build_mod: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A legacy basename key shared by two PRs raises a fail-closed SystemExit."""
+    monkeypatch.setenv("DAYDREAM_PRICES_FILE", str(tmp_path / "absent.toml"))
+    args = _corpus(
+        tmp_path,
+        pr_trajectories={
+            "https://github.com/alpha/widgets/pull/7": ("widgets-7.json", None, 1_000_000, 1_000_000, 1_000_000, 3, None),
+            "https://github.com/beta/widgets/pull/7": ("widgets-7.json", None, 1_000_000, 1_000_000, 1_000_000, 3, None),
+        },
+    )
+    with pytest.raises(SystemExit, match="ambiguous legacy trajectory key 'widgets/7'"):
         build_mod.build(args)

--- a/tests/test_benchmark_report_build.py
+++ b/tests/test_benchmark_report_build.py
@@ -171,8 +171,12 @@ def test_report_rejects_ambiguous_legacy_trajectory_fallback(
     args = _corpus(
         tmp_path,
         pr_trajectories={
-            "https://github.com/alpha/widgets/pull/7": ("widgets-7.json", None, 1_000_000, 1_000_000, 1_000_000, 3, None),
-            "https://github.com/beta/widgets/pull/7": ("widgets-7.json", None, 1_000_000, 1_000_000, 1_000_000, 3, None),
+            "https://github.com/alpha/widgets/pull/7": (
+                "widgets-7.json", None, 1_000_000, 1_000_000, 1_000_000, 3, None
+            ),
+            "https://github.com/beta/widgets/pull/7": (
+                "widgets-7.json", None, 1_000_000, 1_000_000, 1_000_000, 3, None
+            ),
         },
     )
     with pytest.raises(SystemExit, match="ambiguous legacy trajectory key 'widgets/7'"):


### PR DESCRIPTION
## Summary
Join benchmark trajectories by canonical repository and pull-request identity (owner/repo), instead of only the repo's last path segment. Trajectories carrying a nonempty `extra.pr_repo` are indexed under `owner/repo/number`; artifacts lacking it fall back to the legacy `repo_short/number` key.

## Changes
- `bench/benchmark-report/build.py`:
  - `load_trajectories` indexes under `pr_repo/number` when `extra.pr_repo` is present, else legacy `repo_short/number`.
  - `traj_key_for_pr` now returns the canonical `owner/repo/number` key; new `_legacy_traj_key_for_pr` keeps the legacy basename key for fallback.
  - The legacy ambiguity guard (fail-closed on multiple benchmark PRs sharing a basename) now counts shares only across PRs that genuinely need the legacy fallback, so a canonical PR whose basename collides no longer fail-closes the build.
- `tests/test_benchmark_report_build.py`: regression tests for full-repository-identity joins, ambiguous-legacy-fallback rejection, and mixed canonical + unique-legacy trajectories.

## Test Plan
- `tests/test_benchmark_report_build.py` passes (13 benchmark report tests, independently rerun).
- Full suite passes (3235 passed / 6 skipped).

Closes #375