### PR TITLE
docs(workflows): document repository-specific Codex credentials (Closes #385)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -11,8 +11,9 @@ These three workflows are this repository's own **repository-only Codex dogfood 
 
 ## Install
 
-To install the dogfood workflows in a repository of your own, follow the
-canonical installation guide:
+To install these repository workflows in a repository of your own, create the
+`OPENAI_API_KEY` repository secret the review job consumes (it authenticates the
+Codex CLI before review), then follow the canonical installation guide:
 [`daydream/templates/workflows/README.md#install`](../../daydream/templates/workflows/README.md#install).
 
 ## Trigger matrix


### PR DESCRIPTION
## Summary
Documents that repository-only dogfood workflows need an `OPENAI_API_KEY` repository secret so the Codex CLI can authenticate before review, pointing to the canonical install guide for the full steps.

Closes #385

## Notes
- Docs-only change to `.github/workflows/README.md` (1 file, +3/-2).
- Two sequential daydream deep-precision reviews passed (round 2: 0 findings).