### PR TITLE
fix(benchmark-report): exclude incomplete SaaS tools from common-subset rankings (Closes #382)

### DIFF
--- a/bench/benchmark-report/build.py
+++ b/bench/benchmark-report/build.py
@@ -327,7 +327,7 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
         field = []
         for tool in saas_tools:
             agg = aggregate_tool(evals, tool, dd_subset)
-            if agg is None or agg["n_prs"] != len(dd_subset):
+            if agg is None or agg["n_prs"] != len(overlap):
                 continue
             agg["display"] = display_names.get(tool, tool)
             agg["color"] = tool_colors.get(tool, "#5B7C99")

--- a/bench/benchmark-report/build.py
+++ b/bench/benchmark-report/build.py
@@ -327,7 +327,7 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
         field = []
         for tool in saas_tools:
             agg = aggregate_tool(evals, tool, dd_subset)
-            if agg is None:
+            if agg is None or agg["n_prs"] != len(dd_subset):
                 continue
             agg["display"] = display_names.get(tool, tool)
             agg["color"] = tool_colors.get(tool, "#5B7C99")

--- a/tests/test_benchmark_report_build.py
+++ b/tests/test_benchmark_report_build.py
@@ -29,6 +29,7 @@ PR_URL = "https://github.com/calcom/cal.com/pull/10600"
 
 SECOND_PR_URL = "https://github.com/calcom/cal.com/pull/10601"
 _COMPLETE_SAAS_TOOLS = ("saas-alpha", "saas-beta", "saas-delta", "saas-gamma", "saas-zeta")
+_JUDGE_DIRNAME = "anthropic_claude-opus-4-5-20251101"
 
 
 def _corpus(
@@ -41,7 +42,7 @@ def _corpus(
     one-PR legacy corpus (cal.com-10600.json with no pr_repo)."""
     if pr_trajectories is None:
         pr_trajectories = {PR_URL: ("cal.com-10600.json", None, 1_000_000, 1_000_000, 1_000_000, 3, None)}
-    judge = root / "results" / "anthropic_claude-opus-4-5-20251101"
+    judge = root / "results" / _JUDGE_DIRNAME
     judge.mkdir(parents=True)
     leaf = {"tp": 1, "fp": 0, "fn": 0, "total_candidates": 1, "total_golden": 1}
     (judge / "evaluations.json").write_text(
@@ -82,8 +83,14 @@ def _comparison_corpus(root: Path, incomplete_leaf: dict[str, Any] | None) -> ar
     """Two-PR corpus: daydream + five fully-covered SaaS tools on both PRs, plus one
     incomplete tool (``saas-incomplete``) present only on the first PR. The second PR's
     leaf for it is ``incomplete_leaf``: None (absent) or ``{"skipped": True}`` (skipped).
-    Reuses _corpus for the judge dir + trajectory, then overwrites evaluations.json."""
-    args = _corpus(root)
+    Reuses _corpus for the judge dir + trajectories, then overwrites evaluations.json."""
+    args = _corpus(
+        root,
+        pr_trajectories={
+            PR_URL: ("cal.com-10600.json", None, 1_000_000, 1_000_000, 1_000_000, 3, None),
+            SECOND_PR_URL: ("cal.com-10601.json", None, 1_000_000, 1_000_000, 1_000_000, 3, None),
+        },
+    )
     dd_leaf = {"tp": 1, "fp": 0, "fn": 0, "total_candidates": 1, "total_golden": 1}
     complete_leaf = {"tp": 1, "fp": 1, "fn": 1, "total_candidates": 1, "total_golden": 1}
     pr1 = {"daydream-owl-alpha": dd_leaf}
@@ -94,7 +101,7 @@ def _comparison_corpus(root: Path, incomplete_leaf: dict[str, Any] | None) -> ar
     pr1["saas-incomplete"] = dd_leaf
     if incomplete_leaf is not None:
         pr2["saas-incomplete"] = incomplete_leaf
-    judge = root / "results" / "anthropic_claude-opus-4-5-20251101"
+    judge = root / "results" / _JUDGE_DIRNAME
     (judge / "evaluations.json").write_text(json.dumps({PR_URL: pr1, SECOND_PR_URL: pr2}))
     return args
 

--- a/tests/test_benchmark_report_build.py
+++ b/tests/test_benchmark_report_build.py
@@ -1,4 +1,4 @@
-"""Price resolution in the offline benchmark report generator (bench/benchmark-report/build.py)."""
+"""Tests for the offline benchmark report generator (bench/benchmark-report/build.py)."""
 
 from __future__ import annotations
 
@@ -26,6 +26,9 @@ def build_mod() -> ModuleType:
 
 
 PR_URL = "https://github.com/calcom/cal.com/pull/10600"
+
+SECOND_PR_URL = "https://github.com/calcom/cal.com/pull/10601"
+_COMPLETE_SAAS_TOOLS = ("saas-alpha", "saas-beta", "saas-delta", "saas-gamma", "saas-zeta")
 
 
 def _corpus(
@@ -75,6 +78,27 @@ def _corpus(
     )
 
 
+def _comparison_corpus(root: Path, incomplete_leaf: dict[str, Any] | None) -> argparse.Namespace:
+    """Two-PR corpus: daydream + five fully-covered SaaS tools on both PRs, plus one
+    incomplete tool (``saas-incomplete``) present only on the first PR. The second PR's
+    leaf for it is ``incomplete_leaf``: None (absent) or ``{"skipped": True}`` (skipped).
+    Reuses _corpus for the judge dir + trajectory, then overwrites evaluations.json."""
+    args = _corpus(root)
+    dd_leaf = {"tp": 1, "fp": 0, "fn": 0, "total_candidates": 1, "total_golden": 1}
+    complete_leaf = {"tp": 1, "fp": 1, "fn": 1, "total_candidates": 1, "total_golden": 1}
+    pr1 = {"daydream-owl-alpha": dd_leaf}
+    pr2 = {"daydream-owl-alpha": dd_leaf}
+    for tool in _COMPLETE_SAAS_TOOLS:
+        pr1[tool] = complete_leaf
+        pr2[tool] = complete_leaf
+    pr1["saas-incomplete"] = dd_leaf
+    if incomplete_leaf is not None:
+        pr2["saas-incomplete"] = incomplete_leaf
+    judge = root / "results" / "anthropic_claude-opus-4-5-20251101"
+    (judge / "evaluations.json").write_text(json.dumps({PR_URL: pr1, SECOND_PR_URL: pr2}))
+    return args
+
+
 def test_price_card_comes_from_shared_pricing_table(
     build_mod: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -112,6 +136,26 @@ def test_unknown_price_model_is_rejected(
     args.price_model = "no-such-model"
     with pytest.raises(SystemExit, match="unknown --price-model"):
         build_mod.build(args)
+
+
+@pytest.mark.parametrize("incomplete_leaf", [None, {"skipped": True}], ids=["missing", "skipped"])
+def test_build_excludes_incomplete_saas_tools_from_field_and_rank(
+    build_mod: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    incomplete_leaf: dict[str, Any] | None,
+) -> None:
+    """A SaaS tool measured on fewer than the full daydream subset is omitted from the
+    field and rank denominator; every admitted tool is fully covered. Regression for #382."""
+    monkeypatch.setenv("DAYDREAM_PRICES_FILE", str(tmp_path / "absent.toml"))
+    report: dict[str, Any] = build_mod.build(_comparison_corpus(tmp_path, incomplete_leaf))
+
+    judge = next(j for j in report["judges"] if j["id"] == "claude-opus-4-5-20251101")
+    field_tools = {r["tool"] for r in judge["field"]}
+    assert field_tools == set(_COMPLETE_SAAS_TOOLS)
+    assert "saas-incomplete" not in field_tools
+    assert {r["n_prs"] for r in judge["field"]} == {2}
+    assert judge["subset_pr_count"] == 2
+    assert judge["ranks"]["f1"] == (1, 6)
+    assert report["meta"]["subset_pr_count"] == 2
 
 
 def test_report_joins_trajectories_by_full_repository_identity(


### PR DESCRIPTION
## Summary

Closes #382 — excludes incomplete SaaS tools from the common-subset benchmark field and rankings.

Changes in `bench/benchmark-report/build.py`:
- Skip any SaaS tool whose aggregate PR count (`agg["n_prs"]`) does not match the overlap set size, so tools without complete data don't skew the common-subset rankings.
- Compare against `len(overlap)` rather than `len(dd_subset)` for correct filtering of the aggregate tool list.

Tests in `tests/test_benchmark_report_build.py`:
- Extends the `_comparison_corpus` fixture to pass both PR trajectories explicitly and adds coverage for the incomplete-tool exclusion path (+53 lines).

## Test Plan
- [x] `pytest tests/test_benchmark_report_build.py` — 8 passed
- [x] Rebased cleanly onto latest `main`

Two sequential daydream deep-precision reviews passed (rounds 1 & 2, each on a fresh VM); round 2 fix included.