### PR TITLE
fix(workflows): reject unvalidated artifact-derived failure targets (Closes #384)

### DIFF
--- a/.github/workflows/daydream-post.yml
+++ b/.github/workflows/daydream-post.yml
@@ -124,9 +124,6 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           PR_NUMBER="${DERIVED_PR_NUMBER:-$EVENT_PR_NUMBER}"
-          if [ -z "$PR_NUMBER" ] && [ -f findings/findings.json ]; then
-            PR_NUMBER="$(jq -r '.pr_number // empty' findings/findings.json)"
-          fi
           if [ -z "$PR_NUMBER" ]; then
             echo "no PR resolvable; cannot surface the failure" >&2
             exit 0

--- a/daydream/templates/workflows/daydream-post.yml
+++ b/daydream/templates/workflows/daydream-post.yml
@@ -125,9 +125,6 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           PR_NUMBER="${DERIVED_PR_NUMBER:-$EVENT_PR_NUMBER}"
-          if [ -z "$PR_NUMBER" ] && [ -f findings/findings.json ]; then
-            PR_NUMBER="$(jq -r '.pr_number // empty' findings/findings.json)"
-          fi
           if [ -z "$PR_NUMBER" ]; then
             echo "no PR resolvable; cannot surface the failure" >&2
             exit 0

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -291,6 +291,52 @@ def test_post_findings_step_exports_bot_login(wf_path: Path) -> None:
     assert '--bot-login "$BOT_LOGIN"' in text, f"{wf_path.name}: Post findings step must pass --bot-login explicitly"
 
 
+@pytest.mark.parametrize(
+    "wf_path",
+    [TEMPLATES_DIR / "daydream-post.yml", REPO_WORKFLOWS_DIR / "daydream-post.yml"],
+    ids=["template", "live"],
+)
+def test_failure_comment_target_never_uses_findings_artifact(wf_path: Path) -> None:
+    """The 'Surface failure on the PR' handler must derive its comment target
+    only from DERIVED_PR_NUMBER or EVENT_PR_NUMBER — never from the
+    findings/findings.json artifact, which is unvalidated in this failure
+    path (issue #384). When both sources are empty it logs the diagnostic
+    and exits 0 without writing a comment.
+
+    Pinned on BOTH the shipped template and the repo's own live workflow —
+    the two files retain distinct failure-surfacing conditions, but this
+    target-source invariant must hold for both.
+    """
+    wf = load_workflow(wf_path)
+    steps = job_steps(wf, "post")
+    handler = next(s for s in steps if s.get("name") == "Surface failure on the PR")
+    run = handler["run"]
+
+    # Exactly one PR_NUMBER assignment, sourced only from the two allowed env vars.
+    assert run.count("PR_NUMBER=") == 1, (
+        f"{wf_path.name}: failure handler must assign PR_NUMBER exactly once"
+    )
+    assert 'PR_NUMBER="${DERIVED_PR_NUMBER:-$EVENT_PR_NUMBER}"' in run, (
+        f"{wf_path.name}: failure target must come only from DERIVED_PR_NUMBER or EVENT_PR_NUMBER (issue #384)"
+    )
+
+    # No unvalidated artifact read / jq extraction in the failure handler.
+    assert "findings/findings.json" not in run, (
+        f"{wf_path.name}: failure handler must not read findings/findings.json (issue #384)"
+    )
+    assert "jq" not in run, (
+        f"{wf_path.name}: failure handler must not run jq over an artifact (issue #384)"
+    )
+
+    # The empty-result guard precedes the comment write, so no write happens
+    # when neither source yields a number.
+    guard = 'echo "no PR resolvable; cannot surface the failure" >&2'
+    assert guard in run, f"{wf_path.name}: empty-result diagnostic must be present"
+    assert run.index(guard) < run.index('gh api "repos/${REPO}/issues/${PR_NUMBER}/comments"'), (
+        f"{wf_path.name}: empty-result guard must precede the comment write (issue #384)"
+    )
+
+
 def test_single_setup_preserves_privilege_split() -> None:
     wf = load_workflow(TEMPLATES_DIR / "single" / "daydream.yml")
     text = (TEMPLATES_DIR / "single" / "daydream.yml").read_text(encoding="utf-8")

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -328,12 +328,17 @@ def test_failure_comment_target_never_uses_findings_artifact(wf_path: Path) -> N
         f"{wf_path.name}: failure handler must not run jq over an artifact (issue #384)"
     )
 
-    # The empty-result guard precedes the comment write, so no write happens
-    # when neither source yields a number.
+    # The empty-result guard exits 0 before the comment write, so no write
+    # happens when neither source yields a number.
     guard = 'echo "no PR resolvable; cannot surface the failure" >&2'
+    exit_guard = "exit 0"
     assert guard in run, f"{wf_path.name}: empty-result diagnostic must be present"
-    assert run.index(guard) < run.index('gh api "repos/${REPO}/issues/${PR_NUMBER}/comments"'), (
-        f"{wf_path.name}: empty-result guard must precede the comment write (issue #384)"
+    assert exit_guard in run, f"{wf_path.name}: exit 0 must be present in the empty-result guard"
+    assert run.index(guard) < run.index(exit_guard), (
+        f"{wf_path.name}: empty-result diagnostic must precede exit 0"
+    )
+    assert run.index(exit_guard) < run.index('gh api "repos/${REPO}/issues/${PR_NUMBER}/comments"'), (
+        f"{wf_path.name}: exit 0 must precede the comment write (issue #384)"
     )
 
 


### PR DESCRIPTION
## Summary

Fixes #384 — **Prevent unvalidated artifacts from selecting failure-comment targets**.

When the failure handler derives the PR-number source for its comment target, it must only trust
validated, vetted artifact content. This change rejects artifact-derived failure targets so an
unvalidated artifact can never select where the failure comment is posted.

## Changes

- `.github/workflows/daydream-post.yml` — reject artifact-derived failure targets (+3)
- `daydream/templates/workflows/daydream-post.yml` — same guard in the template (+3)
- `tests/test_workflow_templates.py` — tighten failure-handler guard assertions for `exit 0`
  blocking the comment write when both PR-number sources are empty (+51)

## Test Plan

- [x] `tests/test_workflow_templates.py` — 30 passed (2 new/strengthened assertions verified)

Closes #384
