### PR TITLE
fix: support pre-push hook installation from linked git worktrees (Closes #388)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ check: lockcheck lint typecheck test
 
 # Install git hooks
 hooks:
-	ln -sf ../../scripts/hooks/pre-push .git/hooks/pre-push
+	ln -sf "$$(git rev-parse --show-toplevel)/scripts/hooks/pre-push" "$$(git rev-parse --git-path hooks/pre-push)"
 	@echo "Pre-push hook installed"
 
 # Generate the offline benchmark report from a benchmark run.

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ check: lockcheck lint typecheck test
 
 # Install git hooks
 hooks:
-	ln -sf "$$(git rev-parse --show-toplevel)/scripts/hooks/pre-push" "$$(git rev-parse --git-path hooks/pre-push)"
+	ln -sf "$$(git rev-parse --show-toplevel)/scripts/hooks/pre-push" \
+	       "$$(git rev-parse --git-path hooks/pre-push)"
 	@echo "Pre-push hook installed"
 
 # Generate the offline benchmark report from a benchmark run.

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -2,7 +2,7 @@
 #
 # Pre-push hook: lint + typecheck + the full test suite.
 #
-# Install with: ln -sf ../../scripts/hooks/pre-push .git/hooks/pre-push
+# Install with: make hooks
 #
 set -euo pipefail
 

--- a/tests/test_makefile_hooks.py
+++ b/tests/test_makefile_hooks.py
@@ -1,0 +1,50 @@
+"""Real-path test for ``make hooks`` pre-push hook installation (issue #388).
+
+Runs the real Makefile's ``hooks:`` target from a real git worktree — both a
+primary worktree (``.git`` is a directory) and a linked worktree (``.git`` is a
+gitdir-pointer file) — and asserts the hook is installed as a symlink at Git's
+resolved ``hooks/pre-push`` path pointing at the invoking worktree's
+``scripts/hooks/pre-push``. Installation only; never executes the installed hook.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.harness.git_helpers import git as _git
+
+
+@pytest.mark.parametrize("worktree_name", ["main", "linked"])
+def test_hooks_installs_pre_push_from_worktree(
+    linked_worktree: tuple[Path, Path], worktree_name: str
+) -> None:
+    main_repo, linked = linked_worktree
+    worktree = main_repo if worktree_name == "main" else linked
+
+    # The fixture repo doesn't ship the daydream tooling — drop the real
+    # Makefile + hook script into the invoking worktree so `make hooks`
+    # exercises the real recipe against a real worktree topology.
+    repo_root = Path(__file__).resolve().parents[1]
+    shutil.copy(repo_root / "Makefile", worktree / "Makefile")
+    script_dir = worktree / "scripts" / "hooks"
+    script_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy(repo_root / "scripts" / "hooks" / "pre-push", script_dir / "pre-push")
+
+    proc = subprocess.run(
+        ["make", "hooks"],
+        cwd=worktree,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "Pre-push hook installed" in proc.stdout
+
+    # Installed at Git's worktree-aware resolved path, as a symlink.
+    dest = worktree / _git(worktree, "rev-parse", "--git-path", "hooks/pre-push")
+    assert dest.is_symlink()
+    # The symlink resolves to THIS worktree's source file (never a sibling's).
+    assert dest.resolve() == (worktree / "scripts" / "hooks" / "pre-push").resolve()


### PR DESCRIPTION
## Summary
Fixes #388: `make hooks` failed to install the pre-push hook when the repo was checked out as a linked Git worktree.

The old recipe hard-coded `../../scripts/hooks/pre-push` and `.git/hooks/pre-push`, which broke for linked worktrees where:
- `.git` is a gitdir-pointer file, not a directory; and
- the worktree's hooks dir lives under its own `gitdir` path, not the main worktree's `.git/hooks`.

## Changes
- **Makefile**: `make hooks` now resolves both paths via git itself — `git rev-parse --show-toplevel` for the hook source and `git rev-parse --git-path hooks/pre-push` for the install destination — so it works in both primary and linked worktrees.
- **scripts/hooks/pre-push**: comment updated to point at `make hooks`.
- **tests/test_makefile_hooks.py**: new parametrized test that runs the real `make hooks` recipe in a primary worktree and a linked worktree, asserting the hook installs as a symlink at Git's worktree-aware resolved path pointing at the invoking worktree's source.

## Test Plan
- [x] `pytest tests/test_makefile_hooks.py` passes (2 cases)
- [x] Two sequential daydream deep-precision reviews passed (round 1 + round 2), trajectory uploaded to HF

Closes #388