### PR TITLE
fix(bench): derive evidence-backed benchmark improvement recommendations (Closes #387)

### DIFF
--- a/bench/benchmark-report/build.py
+++ b/bench/benchmark-report/build.py
@@ -267,6 +267,69 @@ def slice_daydream(evals: dict, subset: set[str], labels: dict, dd_tool: str, di
     return sorted(out, key=lambda x: x["n_prs"], reverse=True)
 
 
+def _build_improvements(
+    judges_out: list[dict],
+    slices: list[dict],
+    daydream_tool: str,
+    labels_source: str | None,
+) -> list[dict]:
+    """Derive ordered improvement recommendations from current-run evidence.
+
+    Returns a list of up to 3 dicts (priority 1, 2, 3) with keys:
+    priority, heading, body, measurement, citation. Empty when no evidence fires.
+    """
+    improvements: list[dict] = []
+
+    # ── FP-burden (priority 1) ──
+    anchor = next((j for j in judges_out if j.get("has_daydream") and j.get("daydream")), None)
+    if anchor and anchor["daydream"]["fp"] > 0:
+        d = anchor["daydream"]
+        improvements.append({
+            "priority": 1,
+            "heading": f"Reduce {daydream_display(daydream_tool)} false positives under {anchor['display']}",
+            "body": f"daydream produced {d['fp']} FP for {d['tp']} TP under {anchor['display']} ({anchor['id']}).",
+            "measurement": f"Next-run target: FP below {d['fp']}, TP at or above {d['tp']}, "
+                           f"on the same {anchor['subset_pr_count']}-PR subset.",
+            "citation": f"source: {'; '.join(anchor['dirs'])}",
+        })
+
+    # ── Noisiest slice (priority 2) ──
+    worst = None
+    for sl in slices:
+        for r in sl["rows"]:
+            if r["fp"] < 3:
+                continue
+            ratio = r["fp"] / r["tp"] if r["tp"] > 0 else 99.0
+            if worst is None or ratio > worst["ratio"]:
+                worst = {"dim": sl["title"], "label": r["label"],
+                         "fp": r["fp"], "tp": r["tp"], "n_prs": r["n_prs"],
+                         "ratio": ratio}
+    if worst is not None and labels_source:
+        improvements.append({
+            "priority": 2,
+            "heading": f"Tighten the noisiest label slice: {worst['dim']} = {worst['label']}",
+            "body": f"The {worst['label']} {worst['dim'].lower()} cohort carries {worst['fp']} FP "
+                    f"for {worst['tp']} TP across {worst['n_prs']} PRs.",
+            "measurement": f"Next-run target: FP below {worst['fp']} on {worst['label']} {worst['dim'].lower()} slices.",
+            "citation": f"source: {labels_source} (Slices panel)",
+        })
+
+    # ── Missing-judge (priority 3) ──
+    missing = [j for j in judges_out if not j.get("has_daydream")]
+    if missing:
+        displays = ", ".join(j["display"] for j in missing)
+        ids = ", ".join(j["id"] for j in missing)
+        improvements.append({
+            "priority": 3,
+            "heading": f"Re-judge daydream under {displays}",
+            "body": f"daydream has no leaf under: {ids}.",
+            "measurement": "Next-run target: fill the cross-judge panels and confirm the precision story is judge-robust.",
+            "citation": f"source: discovered judges {ids}",
+        })
+
+    return improvements
+
+
 def build(args: argparse.Namespace) -> dict[str, Any]:
     results_root = Path(args.results_root).resolve()
     dd_tool = args.daydream_tool
@@ -285,7 +348,9 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
     dashboard = json.loads(Path(args.dashboard).read_text()) if Path(args.dashboard).is_file() else {}
     display_names = dashboard.get("tool_display_names", {})
     tool_colors = dashboard.get("tool_colors", {})
-    labels = json.loads(Path(args.pr_labels).read_text()) if Path(args.pr_labels).is_file() else {}
+    labels_path = Path(args.pr_labels)
+    labels = json.loads(labels_path.read_text()) if labels_path.is_file() else {}
+    labels_source = str(labels_path.resolve()) if labels_path.is_file() else None
 
     judges_raw = discover_judges(results_root, args.exclude_tool)
 
@@ -493,6 +558,7 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
         "per_pr_scores": per_pr_scores,
         "slices": slices,
         "latency_field": latency_field,
+        "improvements": _build_improvements(judges_out, slices, dd_tool, labels_source),
     }
 
 

--- a/bench/benchmark-report/build.py
+++ b/bench/benchmark-report/build.py
@@ -309,7 +309,7 @@ def _build_improvements(
             "priority": 2,
             "heading": f"Tighten the noisiest label slice: {worst['dim']} = {worst['label']}",
             "body": f"The {worst['label']} {worst['dim'].lower()} cohort carries {worst['fp']} FP "
-                    f"for {worst['tp']} TP across {worst['n_prs']} PRs.",
+                    f"for {worst['tp']} TP across {worst['n_prs']} PR{'s' if worst['n_prs'] != 1 else ''}.",
             "measurement": f"Next-run target: FP below {worst['fp']} on {worst['label']} "
                            f"{worst['dim'].lower()} slices.",
             "citation": f"source: {labels_source} (Slices panel)",

--- a/bench/benchmark-report/build.py
+++ b/bench/benchmark-report/build.py
@@ -310,7 +310,8 @@ def _build_improvements(
             "heading": f"Tighten the noisiest label slice: {worst['dim']} = {worst['label']}",
             "body": f"The {worst['label']} {worst['dim'].lower()} cohort carries {worst['fp']} FP "
                     f"for {worst['tp']} TP across {worst['n_prs']} PRs.",
-            "measurement": f"Next-run target: FP below {worst['fp']} on {worst['label']} {worst['dim'].lower()} slices.",
+            "measurement": f"Next-run target: FP below {worst['fp']} on {worst['label']} "
+                           f"{worst['dim'].lower()} slices.",
             "citation": f"source: {labels_source} (Slices panel)",
         })
 
@@ -323,7 +324,8 @@ def _build_improvements(
             "priority": 3,
             "heading": f"Re-judge daydream under {displays}",
             "body": f"daydream has no leaf under: {ids}.",
-            "measurement": "Next-run target: fill the cross-judge panels and confirm the precision story is judge-robust.",
+            "measurement": "Next-run target: fill the cross-judge panels and confirm the "
+                           "precision story is judge-robust.",
             "citation": f"source: discovered judges {ids}",
         })
 

--- a/bench/benchmark-report/template.html
+++ b/bench/benchmark-report/template.html
@@ -245,7 +245,7 @@ svg{display:block;width:100%;height:auto;overflow:visible;}
 
   <section class="section" id="sec-improve" data-nav="Next run">
     <div class="h2"><span class="glyph">◇</span>IMPROVEMENTS BEFORE THE NEXT RUN<span class="n">prioritized · falsifiable</span></div>
-    <p class="subhead">Grounded in the numbers above. Each item names a predicted, measurable effect so the next run can confirm or refute it.</p>
+    <p class="subhead">Derived from this corpus's measured evidence — aggregate judge metrics, label slices, and exact source paths. Each item names a measurable next-run target so the next run can confirm or refute it.</p>
     <div id="improvements"></div>
   </section>
 
@@ -588,37 +588,14 @@ function renderTable(){
 }
 
 function renderImprovements(){
-  const anchor=DATA.judges.find(j=>j.has_daydream);
   const host=$("#improvements");host.innerHTML="";
-  if(!anchor){host.innerHTML='<div class="placeholder">no scored judge</div>';return;}
-  const d=anchor.daydream;
-  let worst=null;
-  DATA.slices.forEach(sl=>sl.rows.forEach(r=>{const ratio=r.tp?r.fp/r.tp:(r.fp?99:0);
-    if(r.fp>=3&&(!worst||ratio>worst.ratio))worst={dim:sl.title,label:r.label,ratio,fp:r.fp,tp:r.tp};}));
-  const fieldF1=DATA.judges.filter(j=>j.field.length).map(j=>j.field[0].f1);
-  const f1Spread=fieldF1.length?((Math.max(...fieldF1)-Math.min(...fieldF1))*100).toFixed(1):"~2";
-  const newP=d.tp*0.9/(d.tp*0.9+d.fp*0.55);
-  const worstLift=worst?((d.tp/(d.tp+d.fp-Math.round(worst.fp/2))-d.precision)*100).toFixed(1):"0";
-  const items=[
-    {p:1,cls:"",h:"Confidence-gate / severity-threshold the candidate set",
-     body:`daydream flags <b>${d.tp+d.fp}</b> findings to capture <b>${d.tp}</b> true positives — precision ${pct(d.precision)}% (#${anchor.ranks.precision[0]} of ${anchor.ranks.precision[1]}). Drop low-confidence / low-severity candidates before they reach the judge.`,
-     pred:`Predict: dropping the bottom ~40% of candidates by confidence cuts FP ${d.fp}→~${Math.round(d.fp*0.55)} while keeping ≥${Math.round(d.tp*0.9)} TP → precision ≈ ${pct(newP)}% (from ${pct(d.precision)}%), F1 ≈ ${pct(2*newP*(d.recall*0.9)/(newP+d.recall*0.9))}%.`,
-     cite:`source: results/${esc(DATA.meta.anchor_judge)}/evaluations.json (${esc(DDTOOL)} false_positives lists)`},
-    {p:1,cls:"",h:"De-duplicate near-identical candidates per PR before submission",
-     body:`Many FPs are restatements of one concern (e.g. the grafana singleflight finding recurs as three distinct candidates). The harness already runs step2.5 dedup corpus-side; mirror it pre-submission so siblings collapse to one.`,
-     pred:`Predict: per-PR candidate dedup removes 15–25% of FP at zero TP loss → precision +3–5 pts independent of item 1.`,
-     cite:`source: step2_5_dedup_candidates module · leaf total_candidates vs fp`},
-    {p:2,cls:"p2",h:worst?`Tighten the worst-precision slice: ${esc(worst.dim)} = ${esc(worst.label)}`:"Tighten the noisiest label slice",
-     body:worst?`The <b>${esc(worst.label)}</b> ${esc(worst.dim.toLowerCase())} cohort carries ${worst.fp} FP for ${worst.tp} TP (${worst.ratio.toFixed(1)}× FP:TP) — daydream's noisiest slice. Add slice-specific guardrails or suppress speculative findings there.`:"Add guardrails on the noisiest label cohort.",
-     pred:worst?`Predict: halving FP on this slice lifts overall precision ~${worstLift} pts.`:"Predict: measurable precision lift on the targeted slice.",
-     cite:`source: results/pr_labels.json joined to daydream leaves (Slices panel)`},
-    {p:3,cls:"p3",h:"Re-judge daydream under Sonnet 4.5 and GPT-5.2",
-     body:`daydream has a leaf only under <b>${esc(anchor.display)}</b>. The other ${DATA.judges.length-1} discovered judges show the field but a placeholder for daydream. Running the judge step under each fills the cross-judge panels and tests whether the precision story is judge-robust.`,
-     pred:`Predict: F1 moves within ±3 pts across judges (the field's best-F1 tool shifts only ${f1Spread} pts across the three), so daydream's bottom-precision standing is judge-robust.`,
-     cite:`source: discovered judges ${esc(DATA.judges.map(j=>j.id).join(", "))}`},
-  ];
-  items.forEach(it=>{const div=document.createElement("div");div.className="imp "+it.cls;
-    div.innerHTML=`<div class="pri">${it.p}</div><div class="body"><h4>${it.h}</h4><p>${it.body}</p><div class="pred">▸ ${it.pred}</div><div class="cite">${it.cite}</div></div>`;host.appendChild(div);});
+  const items=DATA.improvements;
+  if(!items.length){
+    host.innerHTML='<div class="placeholder">No evidence-backed recommendations were generated for this corpus.</div>';
+    return;
+  }
+  items.forEach(it=>{const div=document.createElement("div");div.className="imp "+(it.priority===2?"p2":it.priority===3?"p3":"");
+    div.innerHTML=`<div class="pri">${esc(it.priority)}</div><div class="body"><h4>${esc(it.heading)}</h4><p>${esc(it.body)}</p><div class="pred">\u25b8 ${esc(it.measurement)}</div><div class="cite">${esc(it.citation)}</div></div>`;host.appendChild(div);});
 }
 
 function renderFoot(){

--- a/tests/test_benchmark_report_build.py
+++ b/tests/test_benchmark_report_build.py
@@ -1,4 +1,5 @@
-"""Price resolution and evidence-derived improvement recommendations in the offline benchmark report generator (bench/benchmark-report/build.py)."""
+"""Price resolution and evidence-derived improvement recommendations in
+the offline benchmark report generator (bench/benchmark-report/build.py)."""
 
 from __future__ import annotations
 
@@ -366,7 +367,8 @@ def _recommendation_case(tmp_path: Path, case: str) -> tuple[dict | None, dict |
             "priority": 3,
             "heading": "Re-judge daydream under custom-reviewer",
             "body": "daydream has no leaf under: custom-reviewer.",
-            "measurement": "Next-run target: fill the cross-judge panels and confirm the precision story is judge-robust.",
+            "measurement": "Next-run target: fill the cross-judge panels and confirm the "
+                           "precision story is judge-robust.",
             "citation": "source: discovered judges custom-reviewer",
         }]
     raise AssertionError(f"unknown case {case!r}")
@@ -381,3 +383,25 @@ def test_improvements_derive_from_corpus_evidence(
     judges, labels, expected = _recommendation_case(tmp_path, case)
     report: dict[str, Any] = build_mod.build(_corpus(tmp_path, judges=judges, labels=labels))
     assert report["improvements"] == expected
+
+
+def test_report_entrypoint_omits_unsupported_recommendations(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Real entrypoint on a no-evidence corpus: empty improvements, neutral placeholder, no hardcoded advice."""
+    monkeypatch.setenv("DAYDREAM_PRICES_FILE", str(tmp_path / "absent.toml"))
+    args = _corpus(tmp_path)
+    out_dir = tmp_path / "report"
+    r = subprocess.run(  # noqa: S603 - args are paths/tool names from the fixture, not user-controlled
+        [sys.executable, str(BUILD_PY), args.results_root,
+         "--daydream-tool", args.daydream_tool, "--price-model", args.price_model,
+         "--trajectories", args.trajectories, "--out", str(out_dir)],
+        capture_output=True, text=True, cwd=BUILD_PY.parents[2],
+    )
+    assert r.returncode == 0, (r.stdout, r.stderr)
+    data = json.loads((out_dir / "data.json").read_text())
+    assert data["improvements"] == []
+    html = (out_dir / "index.html").read_text()
+    assert "No evidence-backed recommendations were generated for this corpus." in html
+    template_text = TEMPLATE_HTML.read_text()
+    for literal in _REMOVED_LITERALS:
+        assert literal not in html
+        assert literal not in template_text

--- a/tests/test_benchmark_report_build.py
+++ b/tests/test_benchmark_report_build.py
@@ -326,7 +326,8 @@ _REMOVED_LITERALS = (
 
 def _recommendation_case(tmp_path: Path, case: str) -> tuple[dict | None, dict | None, list[dict]]:
     """Return (judges, labels, expected_improvements) for one evidence shape."""
-    anchor_src = str(tmp_path / "results" / _ANCHOR / "evaluations.json")
+    resolved = tmp_path.resolve()
+    anchor_src = str(resolved / "results" / _ANCHOR / "evaluations.json")
     if case == "no-evidence":
         return None, None, []
     if case == "aggregate-fp":
@@ -341,7 +342,7 @@ def _recommendation_case(tmp_path: Path, case: str) -> tuple[dict | None, dict |
     if case == "label-slice":
         judges = {_ANCHOR: _tools(5, _leaf(tp=1, fp=3))}
         labels = {PR_URL: {"derived": {"language": "python"}}}
-        labels_src = str(tmp_path / "results" / "pr_labels.json")
+        labels_src = str(resolved / "results" / "pr_labels.json")
         return judges, labels, [
             {
                 "priority": 1,

--- a/tests/test_benchmark_report_build.py
+++ b/tests/test_benchmark_report_build.py
@@ -354,7 +354,7 @@ def _recommendation_case(tmp_path: Path, case: str) -> tuple[dict | None, dict |
             {
                 "priority": 2,
                 "heading": "Tighten the noisiest label slice: Language = python",
-                "body": "The python language cohort carries 3 FP for 1 TP across 1 PRs.",
+                "body": "The python language cohort carries 3 FP for 1 TP across 1 PR.",
                 "measurement": "Next-run target: FP below 3 on python language slices.",
                 "citation": f"source: {labels_src} (Slices panel)",
             },

--- a/tests/test_benchmark_report_build.py
+++ b/tests/test_benchmark_report_build.py
@@ -1,10 +1,11 @@
-"""Tests for the offline benchmark report generator (bench/benchmark-report/build.py)."""
+"""Price resolution and evidence-derived improvement recommendations in the offline benchmark report generator (bench/benchmark-report/build.py)."""
 
 from __future__ import annotations
 
 import argparse
 import importlib.util
 import json
+import subprocess
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -32,22 +33,44 @@ _COMPLETE_SAAS_TOOLS = ("saas-alpha", "saas-beta", "saas-delta", "saas-gamma", "
 _JUDGE_DIRNAME = "anthropic_claude-opus-4-5-20251101"
 
 
+def _leaf(tp: int = 1, fp: int = 0, fn: int = 0,
+          total_candidates: int = 1, total_golden: int = 1) -> dict[str, int]:
+    return {"tp": tp, "fp": fp, "fn": fn,
+            "total_candidates": total_candidates, "total_golden": total_golden}
+
+
+def _tools(n: int, daydream: dict[str, int] | None = None) -> dict[str, dict]:
+    tools = {f"saas-{i}": _leaf(tp=1, fp=0) for i in range(n)}
+    if daydream is not None:
+        tools["daydream-owl-alpha"] = daydream
+    return tools
+
+
+_ANCHOR = "anthropic_claude-opus-4-5-20251101"  # -> display "Opus 4.5"
+
+
 def _corpus(
     root: Path,
     *,
     pr_trajectories: dict[str, tuple[str, str | None, int, int, int, int, tuple[str, str] | None]] | None = None,
+    judges: dict[str, dict[str, dict]] | None = None,
+    labels: dict[str, Any] | None = None,
 ) -> argparse.Namespace:
     """Minimal corpus. pr_trajectories maps PR url -> (filename, pr_repo, prompt,
     completion, cached, steps, (start_iso, end_iso) | None). Omitted -> the existing
     one-PR legacy corpus (cal.com-10600.json with no pr_repo)."""
     if pr_trajectories is None:
         pr_trajectories = {PR_URL: ("cal.com-10600.json", None, 1_000_000, 1_000_000, 1_000_000, 3, None)}
-    judge = root / "results" / _JUDGE_DIRNAME
-    judge.mkdir(parents=True)
-    leaf = {"tp": 1, "fp": 0, "fn": 0, "total_candidates": 1, "total_golden": 1}
-    (judge / "evaluations.json").write_text(
-        json.dumps({pr: {"daydream-owl-alpha": leaf} for pr in pr_trajectories})
-    )
+    results_root = root / "results"
+    results_root.mkdir(parents=True, exist_ok=True)
+    if judges is None:
+        judges = {_ANCHOR: _tools(5, _leaf(tp=1, fp=0))}
+    for dirname, tools in judges.items():
+        jdir = results_root / dirname
+        jdir.mkdir(parents=True, exist_ok=True)
+        (jdir / "evaluations.json").write_text(
+            json.dumps({pr: dict(tools) for pr in pr_trajectories})
+        )
     traj = root / "trajectories"
     traj.mkdir()
     for fname, pr_repo, prompt, completion, cached, steps, stamps in pr_trajectories.values():
@@ -67,8 +90,8 @@ def _corpus(
         if extra:
             body["extra"] = extra
         (traj / fname).write_text(json.dumps(body))
-    return argparse.Namespace(
-        results_root=str(root / "results"),
+    ns = argparse.Namespace(
+        results_root=str(results_root),
         daydream_tool="daydream-owl-alpha",
         exclude_tool="daydream-glm",
         price_model="glm-5.2",
@@ -77,6 +100,11 @@ def _corpus(
         dashboard="",
         speed_analysis="",
     )
+    if labels is not None:
+        labels_path = results_root / "pr_labels.json"
+        labels_path.write_text(json.dumps(labels))
+        ns.pr_labels = str(labels_path)
+    return ns
 
 
 def _comparison_corpus(root: Path, incomplete_leaf: dict[str, Any] | None) -> argparse.Namespace:
@@ -280,3 +308,76 @@ def test_report_allows_mixed_canonical_and_unique_legacy_trajectories(
         1.4 + 1_000_000 * 0.26 / 1e6 + 1_000_000 * 4.4 / 1e6
         + 4_000_000 * 1.4 / 1e6 + 6_000_000 * 0.26 / 1e6 + 5_000_000 * 4.4 / 1e6
     )
+
+
+TEMPLATE_HTML = BUILD_PY.with_name("template.html")
+# All six literals live only inside the old renderImprovements() body; the
+# generated index.html must contain none of them. "15–25%" uses an EN-DASH.
+_REMOVED_LITERALS = (
+    "grafana singleflight",
+    "step2_5_dedup_candidates",
+    "Sonnet 4.5",
+    "GPT-5.2",
+    "15\u201325%",
+    "bottom ~40%",
+)
+
+
+def _recommendation_case(tmp_path: Path, case: str) -> tuple[dict | None, dict | None, list[dict]]:
+    """Return (judges, labels, expected_improvements) for one evidence shape."""
+    anchor_src = str(tmp_path / "results" / _ANCHOR / "evaluations.json")
+    if case == "no-evidence":
+        return None, None, []
+    if case == "aggregate-fp":
+        judges = {_ANCHOR: _tools(5, _leaf(tp=1, fp=2))}
+        return judges, None, [{
+            "priority": 1,
+            "heading": "Reduce daydream (owl-alpha) false positives under Opus 4.5",
+            "body": "daydream produced 2 FP for 1 TP under Opus 4.5 (claude-opus-4-5-20251101).",
+            "measurement": "Next-run target: FP below 2, TP at or above 1, on the same 1-PR subset.",
+            "citation": f"source: {anchor_src}",
+        }]
+    if case == "label-slice":
+        judges = {_ANCHOR: _tools(5, _leaf(tp=1, fp=3))}
+        labels = {PR_URL: {"derived": {"language": "python"}}}
+        labels_src = str(tmp_path / "results" / "pr_labels.json")
+        return judges, labels, [
+            {
+                "priority": 1,
+                "heading": "Reduce daydream (owl-alpha) false positives under Opus 4.5",
+                "body": "daydream produced 3 FP for 1 TP under Opus 4.5 (claude-opus-4-5-20251101).",
+                "measurement": "Next-run target: FP below 3, TP at or above 1, on the same 1-PR subset.",
+                "citation": f"source: {anchor_src}",
+            },
+            {
+                "priority": 2,
+                "heading": "Tighten the noisiest label slice: Language = python",
+                "body": "The python language cohort carries 3 FP for 1 TP across 1 PRs.",
+                "measurement": "Next-run target: FP below 3 on python language slices.",
+                "citation": f"source: {labels_src} (Slices panel)",
+            },
+        ]
+    if case == "missing-judge":
+        judges = {
+            _ANCHOR: _tools(5, _leaf(tp=1, fp=0)),
+            "custom-reviewer": _tools(5),
+        }
+        return judges, None, [{
+            "priority": 3,
+            "heading": "Re-judge daydream under custom-reviewer",
+            "body": "daydream has no leaf under: custom-reviewer.",
+            "measurement": "Next-run target: fill the cross-judge panels and confirm the precision story is judge-robust.",
+            "citation": "source: discovered judges custom-reviewer",
+        }]
+    raise AssertionError(f"unknown case {case!r}")
+
+
+@pytest.mark.parametrize("case", ["no-evidence", "aggregate-fp", "label-slice", "missing-judge"])
+def test_improvements_derive_from_corpus_evidence(
+    build_mod: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, case: str
+) -> None:
+    """Recommendations derive only from current-run evidence, in priority order."""
+    monkeypatch.setenv("DAYDREAM_PRICES_FILE", str(tmp_path / "absent.toml"))
+    judges, labels, expected = _recommendation_case(tmp_path, case)
+    report: dict[str, Any] = build_mod.build(_corpus(tmp_path, judges=judges, labels=labels))
+    assert report["improvements"] == expected


### PR DESCRIPTION
## Summary

- Derives ordered, evidence-backed improvement recommendations in the offline benchmark report (`bench/benchmark-report/build.py`).
- Adds a `_build_improvements` pass that surfaces up to 3 prioritized recommendations from the current run's corpus evidence: FP burden under the anchor judge (P1), the noisiest label slice (P2), and missing cross-judge daydream panels (P3).
- Renders these recommendations in `template.html` (replacing the previous static placeholder section) and wires them through the report build + `build()` output.

## Motivation

Today the benchmark report describes *what happened* but offers no actionable *what to improve next*. This PR closes that gap by mining the corpus for concrete, measurable next-run targets derived directly from run evidence.

Closes #387

## Changes

- `bench/benchmark-report/build.py` — add `_build_improvements(...)` producing up to 3 priority-ranked recommendations (heading, body, measurement, citation) with a fallback empty list when no evidence fires; wire into `build()`.
- `bench/benchmark-report/template.html` — render the recommendations panel from the structured output.
- `tests/test_benchmark_report_build.py` — generalize `_corpus` fixture (multi-judge `judges`/`labels` support) and add evidence-shape tests covering P1/P2/P3 firing and the no-firing empty case; also fix tmp_path handling and PR pluralization.

## Test Plan

- [x] `pytest tests/test_benchmark_report_build.py` — 13 passed
- [x] `ruff check` on changed files — clean
- [x] `mypy` on changed files — clean
- [x] Full `pytest` suite green (CI)

## Notes for Reviewers

Two sequential daydream deep-precision reviews (rounds 1 & 2) have already passed on this branch; the rebase onto latest main (which picked up the #382 common-subset fix) resolved a small test-fixture conflict by taking the generalized multi-judge `_corpus` superset, which is a strict superset of the main-side default.
