### PR TITLE
fix(bench): reject reports with no eligible judge panel (Closes #389)

### DIFF
--- a/bench/benchmark-report/build.py
+++ b/bench/benchmark-report/build.py
@@ -423,6 +423,14 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
             "field": sorted(field, key=lambda r: r["f1"], reverse=True),
         })
 
+    if not judges_out:
+        lines = [
+            f"no eligible judge panel: every judge lacks a {_MIN_SAAS_TOOLS_FOR_PANEL}-SaaS-tool comparison field",
+        ]
+        for s in skipped_judges:
+            lines.append(f"  - {s['id']} ({s['saas_tools']} saas tools): {s['reason']}")
+        raise SystemExit("\n".join(lines))
+
     # ── daydream economy (judge-independent: token/cost/wall come from ATIF trajectories) ──
     anchor_judge = next((j for j in judges_out if j["has_daydream"]), None)
     anchor_evals = judges_raw[dd_source_dir]["evals"]

--- a/tests/test_benchmark_report_build.py
+++ b/tests/test_benchmark_report_build.py
@@ -406,3 +406,33 @@ def test_report_entrypoint_omits_unsupported_recommendations(tmp_path: Path, mon
     for literal in _REMOVED_LITERALS:
         assert literal not in html
         assert literal not in template_text
+
+
+def test_main_rejects_report_with_no_eligible_judge_panel(
+    build_mod: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every judge ineligible -> main() exits nonzero, no report dir written, and the
+    message lists each skipped judge's id and specific reason (in sorted order)."""
+    monkeypatch.setenv("DAYDREAM_PRICES_FILE", str(tmp_path / "absent.toml"))
+    args = _corpus(tmp_path, judges={
+        # 4 SaaS tools < 5 -> ineligible
+        "anthropic_claude-opus-4-5-20251101": _tools(4, _leaf(tp=1, fp=0)),
+        # 3 SaaS tools < 5 -> ineligible
+        "openai_gpt-5.2": _tools(3, _leaf(tp=1, fp=0)),
+    })
+    out_dir = tmp_path / "report"
+    monkeypatch.setattr(sys, "argv", [
+        "build.py", str(args.results_root),
+        "--daydream-tool", args.daydream_tool, "--price-model", args.price_model,
+        "--trajectories", args.trajectories, "--out", str(out_dir),
+    ])
+    with pytest.raises(SystemExit) as exc:
+        build_mod.main()
+    # no-write invariant: report dir must never have been created
+    assert out_dir.exists() is False
+    msg = str(exc.value)
+    assert "claude-opus-4-5-20251101" in msg
+    assert "gpt-5.2" in msg
+    assert "no SaaS field (superseded or partial run)" in msg
+    # both skipped judges listed, in sorted (skipped_judges) order
+    assert msg.index("claude-opus-4-5-20251101") < msg.index("gpt-5.2")


### PR DESCRIPTION
## Summary
Exit nonzero — before writing any report dir — when **every** judge in the offline benchmark corpus lacks a 5-SaaS-tool comparison field. Previously the report built with an empty judge panel. The guard lists each skipped judge's id and reason (e.g. "no SaaS field (superseded or partial run)").

## Changes
- `bench/benchmark-report/build.py`: add `if not judges_out:` guard raising `SystemExit` after judge classification.
- `tests/test_benchmark_report_build.py`: `test_main_rejects_report_with_no_eligible_judge_panel` — asserts nonzero exit, report dir never created, and each skipped judge + reason listed in sorted order.

## Test plan
- [x] `uv run pytest tests/test_benchmark_report_build.py` — 14 passed
- [x] `ruff check` — clean

Closes #389