### PR TITLE
fix(codex): treat non-zero Codex CLI exits as classified backend failures (Closes #391)

### DIFF
--- a/daydream/backends/codex.py
+++ b/daydream/backends/codex.py
@@ -67,7 +67,19 @@ def _unwrap_shell_command(command: str) -> str:
 
 
 class CodexError(Exception):
-    """Raised when a Codex turn fails."""
+    """Raised when a Codex turn fails or the Codex CLI subprocess exits non-zero.
+
+    Two failure shapes, discriminated by ``category``:
+
+    * ``category is None`` — a structured ``turn.failed`` event (the default,
+      used for model-level errors surfaced in the JSONL stream).
+    * ``category == "PROCESS_EXIT"`` — the ``codex`` subprocess exited with a
+      non-zero return code, carrying captured diagnostic output.
+    """
+
+    def __init__(self, message: str, *, category: str | None = None):
+        super().__init__(message)
+        self.category = category
 
 
 class CodexBackend:

--- a/daydream/backends/codex.py
+++ b/daydream/backends/codex.py
@@ -241,8 +241,9 @@ class CodexBackend:
                     # Codex occasionally emits non-JSON status lines on stdout;
                     # skip them but leave a debug breadcrumb for triage.
                     # Capture non-JSON lines for diagnostic surfacing on non-zero exit.
-                    if len(non_json_lines) < 20:
-                        non_json_lines.append(raw_line)
+                    if len(non_json_lines) >= 20:
+                        non_json_lines.pop(0)
+                    non_json_lines.append(raw_line)
                     _logger.debug("codex: non-JSON line skipped: %r", raw_line[:80])
                     continue
 
@@ -544,9 +545,8 @@ class CodexBackend:
         if returncode is not None and returncode != 0:
             tail = "\n".join(non_json_lines[-10:])
             if non_json_lines:
-                shown = min(len(non_json_lines), 10)
                 detail = (
-                    f"\nCodex CLI output (last {shown} "
+                    f"\nCodex CLI output (last {min(len(non_json_lines), 10)} "
                     f"non-JSON lines):\n{tail}"
                 )
             else:

--- a/daydream/backends/codex.py
+++ b/daydream/backends/codex.py
@@ -177,6 +177,7 @@ class CodexBackend:
         pending_item_ids: dict[str, str] = {}  # "type:content" → generated id (legacy)
         updated_text: dict[str, list[str]] = {}  # item_id → [text deltas]
         parse_warnings: list[str] = []  # observable parse-failure surface
+        stderr_lines: list[str] = []  # non-JSON stdout lines for error diagnostics
         unmatched_seq = 0  # monotonic source for orphaned tool-result ids
 
         def _warn(msg: str, **detail: Any) -> None:
@@ -238,6 +239,9 @@ class CodexBackend:
                 except json.JSONDecodeError:
                     # Codex occasionally emits non-JSON status lines on stdout;
                     # skip them but leave a debug breadcrumb for triage.
+                    # Capture non-JSON lines for diagnostic surfacing on non-zero exit.
+                    if len(stderr_lines) < 20:
+                        stderr_lines.append(raw_line)
                     _logger.debug("codex: non-JSON line skipped: %r", raw_line[:80])
                     continue
 
@@ -473,6 +477,28 @@ class CodexBackend:
                     pass
 
             await proc.wait()
+
+            # Fail fast on non-zero exit: if codex crashed without emitting a
+            # turn.failed event, surface the failure with diagnostic output
+            # instead of reporting a successful completion with empty/partial
+            # output.
+            returncode = proc.returncode
+            if returncode is not None and returncode != 0:
+                stderr_tail = "\n".join(stderr_lines[-10:])
+                if stderr_lines:
+                    detail = (
+                        f"\nCodex CLI output (last {len(stderr_lines)} "
+                        f"non-JSON lines):\n{stderr_tail}"
+                    )
+                else:
+                    detail = (
+                        "\n(no non-JSON output captured — codex may have "
+                        "crashed before writing to stdout)"
+                    )
+                raise CodexError(
+                    f"Codex CLI exited with return code {returncode}.{detail}",
+                    category="PROCESS_EXIT",
+                )
 
         finally:
             if proc is not None:

--- a/daydream/backends/codex.py
+++ b/daydream/backends/codex.py
@@ -177,7 +177,8 @@ class CodexBackend:
         pending_item_ids: dict[str, str] = {}  # "type:content" → generated id (legacy)
         updated_text: dict[str, list[str]] = {}  # item_id → [text deltas]
         parse_warnings: list[str] = []  # observable parse-failure surface
-        stderr_lines: list[str] = []  # non-JSON stdout lines for error diagnostics
+        _pending_result: ResultEvent | None = None
+        non_json_lines: list[str] = []  # non-JSON lines (stdout merged with stderr) for error diagnostics
         unmatched_seq = 0  # monotonic source for orphaned tool-result ids
 
         def _warn(msg: str, **detail: Any) -> None:
@@ -240,8 +241,8 @@ class CodexBackend:
                     # Codex occasionally emits non-JSON status lines on stdout;
                     # skip them but leave a debug breadcrumb for triage.
                     # Capture non-JSON lines for diagnostic surfacing on non-zero exit.
-                    if len(stderr_lines) < 20:
-                        stderr_lines.append(raw_line)
+                    if len(non_json_lines) < 20:
+                        non_json_lines.append(raw_line)
                     _logger.debug("codex: non-JSON line skipped: %r", raw_line[:80])
                     continue
 
@@ -464,7 +465,7 @@ class CodexBackend:
                             data={"thread_id": thread_id},
                         )
 
-                    yield ResultEvent(
+                    _pending_result = ResultEvent(
                         structured_output=structured_result,
                         continuation=continuation_token,
                     )
@@ -482,23 +483,9 @@ class CodexBackend:
             # turn.failed event, surface the failure with diagnostic output
             # instead of reporting a successful completion with empty/partial
             # output.
-            returncode = proc.returncode
-            if returncode is not None and returncode != 0:
-                stderr_tail = "\n".join(stderr_lines[-10:])
-                if stderr_lines:
-                    detail = (
-                        f"\nCodex CLI output (last {len(stderr_lines)} "
-                        f"non-JSON lines):\n{stderr_tail}"
-                    )
-                else:
-                    detail = (
-                        "\n(no non-JSON output captured — codex may have "
-                        "crashed before writing to stdout)"
-                    )
-                raise CodexError(
-                    f"Codex CLI exited with return code {returncode}.{detail}",
-                    category="PROCESS_EXIT",
-                )
+            self._check_return_code(proc.returncode, non_json_lines)
+            if _pending_result is not None:
+                yield _pending_result
 
         finally:
             if proc is not None:
@@ -547,6 +534,30 @@ class CodexBackend:
             if isinstance(block, dict) and block.get("type") in ("text", "output_text"):
                 parts.append(block.get("text", ""))
         return "".join(parts)
+
+    @staticmethod
+    def _check_return_code(
+        returncode: int | None,
+        non_json_lines: list[str],
+    ) -> None:
+        """Raise CodexError(PROCESS_EXIT) if the subprocess exited non-zero."""
+        if returncode is not None and returncode != 0:
+            tail = "\n".join(non_json_lines[-10:])
+            if non_json_lines:
+                shown = min(len(non_json_lines), 10)
+                detail = (
+                    f"\nCodex CLI output (last {shown} "
+                    f"non-JSON lines):\n{tail}"
+                )
+            else:
+                detail = (
+                    "\n(no non-JSON output captured — codex may have "
+                    "crashed before writing to stdout)"
+                )
+            raise CodexError(
+                f"Codex CLI exited with return code {returncode}.{detail}",
+                category="PROCESS_EXIT",
+            )
 
     @staticmethod
     def _write_temp_schema(schema: dict[str, Any]) -> str:

--- a/tests/test_backend_codex.py
+++ b/tests/test_backend_codex.py
@@ -172,6 +172,22 @@ async def test_nonzero_exit_raises_with_captured_output():
 
 
 @pytest.mark.asyncio
+async def test_nonzero_exit_with_no_output_still_informative():
+    """If codex crashes with zero output, the error says so explicitly."""
+    backend = CodexBackend(model="fixture-model")
+    mock_proc = make_mock_process([])
+    mock_proc.returncode = 1
+
+    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
+        with pytest.raises(CodexError, match="return code 1") as exc_info:
+            async for _ in backend.execute(Path("/tmp"), "Fail"):
+                pass
+
+    assert "no non-JSON output captured" in str(exc_info.value)
+    assert exc_info.value.category == "PROCESS_EXIT"
+
+
+@pytest.mark.asyncio
 async def test_continuation_token_resumes():
     """Test that continuation token is passed as 'resume' argument."""
     from daydream.backends import ContinuationToken

--- a/tests/test_backend_codex.py
+++ b/tests/test_backend_codex.py
@@ -150,6 +150,28 @@ async def test_turn_failed_raises():
 
 
 @pytest.mark.asyncio
+async def test_nonzero_exit_raises_with_captured_output():
+    """Non-zero exit surfaces codex's diagnostic output as a PROCESS_EXIT CodexError."""
+    backend = CodexBackend(model="fixture-model")
+    mock_proc = make_mock_process(
+        ["Error: authentication required. Run `codex login` to authenticate."]
+    )
+    mock_proc.returncode = 1
+
+    events = []
+    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
+        with pytest.raises(CodexError, match="return code 1") as exc_info:
+            async for event in backend.execute(Path("/tmp"), "Fail"):
+                events.append(event)
+
+    # No events yielded — the run must not appear successful.
+    assert events == []
+    msg = str(exc_info.value)
+    assert "authentication required" in msg
+    assert exc_info.value.category == "PROCESS_EXIT"
+
+
+@pytest.mark.asyncio
 async def test_continuation_token_resumes():
     """Test that continuation token is passed as 'resume' argument."""
     from daydream.backends import ContinuationToken

--- a/tests/test_backend_codex.py
+++ b/tests/test_backend_codex.py
@@ -141,9 +141,12 @@ async def test_turn_failed_raises():
     mock_proc = make_mock_process_from_fixture("turn_failed.jsonl")
 
     with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
-        with pytest.raises(CodexError, match="Model returned an error"):
+        with pytest.raises(CodexError, match="Model returned an error") as exc_info:
             async for _ in backend.execute(Path("/tmp"), "Fail"):
                 pass
+
+    # Structured turn.failed is NOT reclassified — category stays None.
+    assert exc_info.value.category is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Addresses issue #391: non-zero Codex CLI exits are now treated as classified backend failures.

- Add optional `category` to `CodexError` for process-exit classification
- Raise a classified `PROCESS_EXIT` `CodexError` on non-zero CLI exit
- State explicitly when a non-zero exit captured no output
- Defer `ResultEvent` yield until after the return-code check
- Keep the last 20 non-JSON lines (sliding window) for the non-zero-exit diagnostic

## Test Plan
- Full suite green (3263 passed, 6 skipped)
- Two sequential daydream deep-precision reviews passed (rounds 1 & 2)

Closes #391