### PR TITLE
Validate GitHub subprocess timeout and retry environment controls (Closes #393)

### DIFF
--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -269,7 +269,25 @@ _GH_DEFAULT_RETRIES = 2
 def _gh_timeout() -> int:
     """Default ``gh`` subprocess timeout in seconds (env-overridable)."""
     raw = os.environ.get("DAYDREAM_GH_TIMEOUT_SECONDS")
-    return int(raw) if raw else _GH_DEFAULT_TIMEOUT
+    if raw is None:
+        return _GH_DEFAULT_TIMEOUT
+    try:
+        value = int(raw)
+    except ValueError:
+        _logger.warning(
+            "DAYDREAM_GH_TIMEOUT_SECONDS=%r is not a valid integer; using default %d",
+            raw,
+            _GH_DEFAULT_TIMEOUT,
+        )
+        return _GH_DEFAULT_TIMEOUT
+    if value <= 0:
+        _logger.warning(
+            "DAYDREAM_GH_TIMEOUT_SECONDS=%r must be positive; using default %d",
+            raw,
+            _GH_DEFAULT_TIMEOUT,
+        )
+        return _GH_DEFAULT_TIMEOUT
+    return value
 
 
 def _gh_retries() -> int:

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -266,52 +266,55 @@ _GH_DEFAULT_TIMEOUT = 60
 _GH_DEFAULT_RETRIES = 2
 
 
-def _gh_timeout() -> int:
-    """Default ``gh`` subprocess timeout in seconds (env-overridable)."""
-    raw = os.environ.get("DAYDREAM_GH_TIMEOUT_SECONDS")
+def _gh_int_env(name: str, default: int, *, is_valid: Callable[[int], bool], invalid_msg: str) -> int:
+    """Read *name* from the environment as an int, falling back to *default*.
+
+    A missing, non-integer, or invalid (per :func:`is_valid`) value logs a
+    warning and returns *default*, never raising.
+    """
+    raw = os.environ.get(name)
     if raw is None:
-        return _GH_DEFAULT_TIMEOUT
+        return default
     try:
         value = int(raw)
     except ValueError:
         _logger.warning(
-            "DAYDREAM_GH_TIMEOUT_SECONDS=%r is not a valid integer; using default %d",
+            "%s=%r is not a valid integer; using default %d",
+            name,
             raw,
-            _GH_DEFAULT_TIMEOUT,
+            default,
         )
-        return _GH_DEFAULT_TIMEOUT
-    if value <= 0:
+        return default
+    if not is_valid(value):
         _logger.warning(
-            "DAYDREAM_GH_TIMEOUT_SECONDS=%r must be positive; using default %d",
+            "%s=%r %s; using default %d",
+            name,
             raw,
-            _GH_DEFAULT_TIMEOUT,
+            invalid_msg,
+            default,
         )
-        return _GH_DEFAULT_TIMEOUT
+        return default
     return value
+
+
+def _gh_timeout() -> int:
+    """Default ``gh`` subprocess timeout in seconds (env-overridable)."""
+    return _gh_int_env(
+        "DAYDREAM_GH_TIMEOUT_SECONDS",
+        _GH_DEFAULT_TIMEOUT,
+        is_valid=lambda value: value > 0,
+        invalid_msg="must be positive",
+    )
 
 
 def _gh_retries() -> int:
     """Read-only ``gh`` timeout-retry budget (env-overridable)."""
-    raw = os.environ.get("DAYDREAM_GH_TIMEOUT_RETRIES")
-    if raw is None:
-        return _GH_DEFAULT_RETRIES
-    try:
-        value = int(raw)
-    except ValueError:
-        _logger.warning(
-            "DAYDREAM_GH_TIMEOUT_RETRIES=%r is not a valid integer; using default %d",
-            raw,
-            _GH_DEFAULT_RETRIES,
-        )
-        return _GH_DEFAULT_RETRIES
-    if value < 0:
-        _logger.warning(
-            "DAYDREAM_GH_TIMEOUT_RETRIES=%r is negative; using default %d",
-            raw,
-            _GH_DEFAULT_RETRIES,
-        )
-        return _GH_DEFAULT_RETRIES
-    return value
+    return _gh_int_env(
+        "DAYDREAM_GH_TIMEOUT_RETRIES",
+        _GH_DEFAULT_RETRIES,
+        is_valid=lambda value: value >= 0,
+        invalid_msg="is negative",
+    )
 
 
 def _run_git(

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -293,7 +293,25 @@ def _gh_timeout() -> int:
 def _gh_retries() -> int:
     """Read-only ``gh`` timeout-retry budget (env-overridable)."""
     raw = os.environ.get("DAYDREAM_GH_TIMEOUT_RETRIES")
-    return int(raw) if raw else _GH_DEFAULT_RETRIES
+    if raw is None:
+        return _GH_DEFAULT_RETRIES
+    try:
+        value = int(raw)
+    except ValueError:
+        _logger.warning(
+            "DAYDREAM_GH_TIMEOUT_RETRIES=%r is not a valid integer; using default %d",
+            raw,
+            _GH_DEFAULT_RETRIES,
+        )
+        return _GH_DEFAULT_RETRIES
+    if value < 0:
+        _logger.warning(
+            "DAYDREAM_GH_TIMEOUT_RETRIES=%r is negative; using default %d",
+            raw,
+            _GH_DEFAULT_RETRIES,
+        )
+        return _GH_DEFAULT_RETRIES
+    return value
 
 
 def _run_git(

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -739,6 +739,40 @@ def test_mutating_wrapper_does_not_retry_on_timeout(
 # --- _run_gh timeout retry (fake-gh flake under load) -----------------------
 
 
+@pytest.mark.parametrize(
+    ("env_value", "expected_timeout", "expected_warning"),
+    [
+        ("6O", 60, "DAYDREAM_GH_TIMEOUT_SECONDS='6O' is not a valid integer; using default 60"),
+        ("-5", 60, "DAYDREAM_GH_TIMEOUT_SECONDS='-5' must be positive; using default 60"),
+        ("0", 60, "DAYDREAM_GH_TIMEOUT_SECONDS='0' must be positive; using default 60"),
+        ("7", 7, None),
+    ],
+    ids=["malformed", "negative", "zero", "valid"],
+)
+def test_run_gh_timeout_environment_validation(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, tmp_path: Path,
+    env_value: str, expected_timeout: int, expected_warning: str | None,
+) -> None:
+    """`_run_gh` resolves the env timeout at call time, warning+falling back on bad values."""
+    repo = _make_repo_with_main(tmp_path)
+    monkeypatch.setenv("DAYDREAM_GH_TIMEOUT_SECONDS", env_value)
+
+    def always_timeout(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
+        raise subprocess.TimeoutExpired(cmd=["gh"], timeout=expected_timeout)
+
+    monkeypatch.setattr("daydream.git_ops.subprocess.run", always_timeout)
+    with pytest.raises(git_ops.GitTimeoutError) as exc:
+        git_ops._run_gh(repo, ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"])
+    assert str(exc.value) == (
+        "gh repo view --json nameWithOwner -q .nameWithOwner "
+        f"timed out after {expected_timeout}s"
+    )
+    if expected_warning is None:
+        assert "DAYDREAM_GH_TIMEOUT_SECONDS" not in caplog.text
+    else:
+        assert expected_warning in caplog.text
+
+
 def test_run_gh_read_wrapper_retries_then_succeeds_and_exhausts(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -793,6 +793,8 @@ def test_read_only_gh_retry_environment_validation(
     repo = _make_repo_with_main(tmp_path)
     if env_value is not None:
         monkeypatch.setenv("DAYDREAM_GH_TIMEOUT_RETRIES", env_value)
+    else:
+        monkeypatch.delenv("DAYDREAM_GH_TIMEOUT_RETRIES", raising=False)
     calls = {"n": 0}
 
     def always_timeout(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -773,6 +773,46 @@ def test_run_gh_timeout_environment_validation(
         assert expected_warning in caplog.text
 
 
+@pytest.mark.parametrize(
+    ("env_value", "expected_attempts", "expected_warning"),
+    [
+        (None, 3, None),
+        ("", 3, "DAYDREAM_GH_TIMEOUT_RETRIES='' is not a valid integer; using default 2"),
+        ("abc", 3, "DAYDREAM_GH_TIMEOUT_RETRIES='abc' is not a valid integer; using default 2"),
+        ("-1", 3, "DAYDREAM_GH_TIMEOUT_RETRIES='-1' is negative; using default 2"),
+        ("0", 1, None),
+        ("1", 2, None),
+    ],
+    ids=["default", "empty-warns", "malformed-warns", "negative-warns", "zero-valid", "one-valid"],
+)
+def test_read_only_gh_retry_environment_validation(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, tmp_path: Path,
+    env_value: str | None, expected_attempts: int, expected_warning: str | None,
+) -> None:
+    """Read-only ``gh`` retry budget is validated at call time; retry 0 stays a valid 1 attempt."""
+    repo = _make_repo_with_main(tmp_path)
+    if env_value is not None:
+        monkeypatch.setenv("DAYDREAM_GH_TIMEOUT_RETRIES", env_value)
+    calls = {"n": 0}
+
+    def always_timeout(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
+        calls["n"] += 1
+        raise subprocess.TimeoutExpired(cmd=["gh"], timeout=60)
+
+    monkeypatch.setattr("daydream.git_ops.subprocess.run", always_timeout)
+    with pytest.raises(git_ops.GitTimeoutError) as exc:
+        git_ops.gh_repo_view(repo)
+    assert calls["n"] == expected_attempts
+    suffix = f" ({expected_attempts} attempts)" if expected_attempts > 1 else ""
+    assert str(exc.value) == (
+        "gh repo view --json nameWithOwner -q .nameWithOwner timed out after 60s" + suffix
+    )
+    if expected_warning is None:
+        assert "DAYDREAM_GH_TIMEOUT_RETRIES" not in caplog.text
+    else:
+        assert expected_warning in caplog.text
+
+
 def test_run_gh_read_wrapper_retries_then_succeeds_and_exhausts(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary
Validates the GitHub subprocess timeout and retry environment controls at call time, so a bad `DAYDREAM_GH_TIMEOUT_SECONDS` / `DAYDREAM_GH_TIMEOUT_RETRIES` value surfaces immediately instead of failing deep inside the gh subprocess.

- `fix(git_ops)`: validate `DAYDREAM_GH_TIMEOUT_SECONDS` at call time
- `fix(git_ops)`: validate `DAYDREAM_GH_TIMEOUT_RETRIES` at call time
- `refactor(git_ops)`: consolidate gh env int parsing helper
- `fix`: clear stale env var in gh retry validation test

## Test Plan
- `uv run pytest -n auto` → 3282 passed / 6 skipped / 0 failed (post round-2 review)
- `uv lock --check` clean

Closes #393