### PR TITLE
fix(bench): unify benchmark report around largest-subset anchor judge (Closes #392)

### DIFF
--- a/bench/benchmark-report/build.py
+++ b/bench/benchmark-report/build.py
@@ -434,6 +434,14 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
 
     # ── daydream economy (judge-independent: token/cost/wall come from ATIF trajectories) ──
     anchor_judge = next((j for j in judges_out if j["id"] == anchor_judge_id), None)
+    if anchor_judge is None:
+        # The largest-subset judge may be panel-skipped (fails the SaaS-coverage
+        # gate), so it never reaches judges_out. Fall back to a retained judge that
+        # still carries daydream so the report-wide anchor, label slices, and
+        # priority-1 improvements don't silently vanish.
+        anchor_judge = next((j for j in judges_out if j.get("has_daydream")), None)
+        if anchor_judge is not None:
+            anchor_judge_id = anchor_judge["id"]
     anchor_evals = judges_raw[anchor_judge_id]["evals"]
     per_pr_rows = []
     tot_prompt = tot_completion = tot_cached = 0

--- a/bench/benchmark-report/build.py
+++ b/bench/benchmark-report/build.py
@@ -272,6 +272,7 @@ def _build_improvements(
     slices: list[dict],
     daydream_tool: str,
     labels_source: str | None,
+    anchor_id: str,
 ) -> list[dict]:
     """Derive ordered improvement recommendations from current-run evidence.
 
@@ -281,7 +282,7 @@ def _build_improvements(
     improvements: list[dict] = []
 
     # ── FP-burden (priority 1) ──
-    anchor = next((j for j in judges_out if j.get("has_daydream") and j.get("daydream")), None)
+    anchor = next((j for j in judges_out if j.get("id") == anchor_id), None)
     if anchor and anchor["daydream"]["fp"] > 0:
         d = anchor["daydream"]
         improvements.append({
@@ -358,11 +359,11 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
 
     # The daydream-scored PR set is the fixed cross-judge anchor (daydream only ran on these).
     dd_subset: set[str] = set()
-    dd_source_dir = ""
+    anchor_judge_id = ""
     for canon, b in judges_raw.items():
         prs = {pr for pr, t in b["evals"].items() if _leaf_present(t.get(dd_tool))}
         if len(prs) > len(dd_subset):
-            dd_subset, dd_source_dir = prs, canon
+            dd_subset, anchor_judge_id = prs, canon
     if not dd_subset:
         raise SystemExit(f"no judge has a present leaf for --daydream-tool {dd_tool!r}")
 
@@ -432,8 +433,8 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
         raise SystemExit("\n".join(lines))
 
     # ── daydream economy (judge-independent: token/cost/wall come from ATIF trajectories) ──
-    anchor_judge = next((j for j in judges_out if j["has_daydream"]), None)
-    anchor_evals = judges_raw[dd_source_dir]["evals"]
+    anchor_judge = next((j for j in judges_out if j["id"] == anchor_judge_id), None)
+    anchor_evals = judges_raw[anchor_judge_id]["evals"]
     per_pr_rows = []
     tot_prompt = tot_completion = tot_cached = 0
     tot_cost = 0.0
@@ -551,7 +552,7 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
             "daydream_tool": dd_tool,
             "daydream_display": daydream_display(dd_tool),
             "excluded_tool": args.exclude_tool,
-            "anchor_judge": dd_source_dir,
+            "anchor_judge": anchor_judge_id,
             "subset_pr_count": len(dd_subset),
             "subset_prs": sorted(dd_subset),
             "judge_error_ratio_threshold": JUDGE_ERROR_RATIO_THRESHOLD,
@@ -568,7 +569,7 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
         "per_pr_scores": per_pr_scores,
         "slices": slices,
         "latency_field": latency_field,
-        "improvements": _build_improvements(judges_out, slices, dd_tool, labels_source),
+        "improvements": _build_improvements(judges_out, slices, dd_tool, labels_source, anchor_judge_id),
     }
 
 

--- a/bench/benchmark-report/build.py
+++ b/bench/benchmark-report/build.py
@@ -442,6 +442,15 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
         anchor_judge = next((j for j in judges_out if j.get("has_daydream")), None)
         if anchor_judge is not None:
             anchor_judge_id = anchor_judge["id"]
+            # The fallback anchor's real daydream coverage may be a strict subset
+            # of the (skipped) largest-subset judge's. Re-point dd_subset to it so
+            # economy.n_prs, meta.subset_pr_count/subset_prs, anchor_evals, and the
+            # label slices all trace to the retained anchor instead of reporting the
+            # skipped judge's larger subset.
+            dd_subset = {
+                pr for pr, t in judges_raw[anchor_judge_id]["evals"].items()
+                if _leaf_present(t.get(dd_tool))
+            }
     anchor_evals = judges_raw[anchor_judge_id]["evals"]
     per_pr_rows = []
     tot_prompt = tot_completion = tot_cached = 0

--- a/bench/benchmark-report/template.html
+++ b/bench/benchmark-report/template.html
@@ -272,6 +272,7 @@ function fmtSec(x){return x==null?"—":Math.round(x)+"s";}
 let STATE={judge:DATA.judges[0]?DATA.judges[0].id:null};
 function curJudge(){return DATA.judges.find(j=>j.id===STATE.judge)||DATA.judges[0];}
 const DDTOOL=DATA.meta.daydream_tool;
+function anchorJudge(){return DATA.judges.find(j=>j.id===DATA.meta.anchor_judge);}
 
 function renderJudgeBtns(){
   const host=$("#judgebtns");host.innerHTML="";
@@ -294,7 +295,7 @@ function renderNav(){
 }
 
 function renderLead(){
-  const anchor=DATA.judges.find(j=>j.has_daydream);
+  const anchor=anchorJudge();
   const d=anchor?anchor.daydream:null;const rk=anchor?anchor.ranks:null;
   $("#leadcopy").innerHTML=d?
     `On <b>${DATA.meta.subset_pr_count} PRs</b> (of ${DATA.meta.total_daydream_attempts} attempted) judged by <b>${esc(anchor.display)}</b>, daydream lands <b class="mint">recall ${pct(d.recall)}%</b> (#${rk.recall[0]} of ${rk.recall[1]}) but <b>precision ${pct(d.precision)}%</b> (#${rk.precision[0]} of ${rk.precision[1]}) — <b>top-class recall, bottom-class precision</b>. The story is <b>${d.fp} false positives against ${d.tp} true positives</b>. Every SaaS competitor is recomputed on this exact subset; cost is synthesized from daydream's measured tokens.`
@@ -469,7 +470,7 @@ function renderJudgeSens(){
 }
 
 function renderSlices(){
-  const anchor=DATA.judges.find(j=>j.has_daydream);
+  const anchor=anchorJudge();
   $("#slice-judgetag").textContent=anchor?"· "+anchor.display:"";
   const host=$("#slices");host.innerHTML="";
   const grid=document.createElement("div");grid.className="grid2";
@@ -494,7 +495,7 @@ function renderCost(){
   const e=DATA.economy;
   $("#cost-sub").innerHTML=`Computed from measured tokens @ <b>${esc(e.price_model)}</b> price card (in $${e.price_card.input} / cached $${e.price_card.cached} / out $${e.price_card.output} per 1M; counters disjoint). Backend records $0 (GLM via z.ai) — this is synthesized, not read. ${e.n_with_trajectory} of ${e.n_prs} PRs have a trajectory.`;
   const host=$("#cost-kpis");host.innerHTML="";
-  const ddtp=(DATA.judges.find(j=>j.has_daydream)||{daydream:{tp:1}}).daydream.tp||1;
+  const ddtp=(anchorJudge()||{daydream:{tp:1}}).daydream.tp||1;
   const cards=[
     {label:"Total cost",val:fmtUSD(e.total_cost_usd),sub:`${e.n_with_trajectory} PRs`},
     {label:"Cost / PR",val:fmtUSD(e.cost_per_pr),sub:"mean over scored PRs"},

--- a/tests/test_benchmark_report_build.py
+++ b/tests/test_benchmark_report_build.py
@@ -511,3 +511,67 @@ def test_template_consumers_resolve_anchor_judge_by_id(tmp_path: Path) -> None:
     assert template.count("const anchor=anchorJudge();") == 2  # renderLead, renderSlices
     assert "const ddtp=(anchorJudge()||{daydream:{tp:1}})" in template  # renderCost
     assert "DATA.judges.find(j=>j.has_daydream)" not in template
+
+
+def _anchor_skipped_corpus(root: Path) -> argparse.Namespace:
+    """Two-PR corpus where the LARGEST-subset judge (a-skip-anchor, daydream on both
+    PRs) is panel-skipped for failing the SaaS-coverage gate (<5 SaaS tools), while a
+    later retained judge (z-retained, 5 SaaS tools) carries daydream on both PRs.
+    Pre-fix this made the report-wide anchor resolve to None: slices and the
+    priority-1 improvement silently vanished and the template anchor was undefined."""
+    args = _corpus(
+        root,
+        pr_trajectories={
+            PR_URL: ("cal.com-10600.json", None, 1_000_000, 1_000_000, 1_000_000, 3, None),
+            SECOND_PR_URL: ("cal.com-10601.json", None, 1_000_000, 1_000_000, 1_000_000, 3, None),
+        },
+        judges={},
+        labels={
+            PR_URL: {"derived": {"language": "python"}},
+            SECOND_PR_URL: {"derived": {"language": "python"}},
+        },
+    )
+    saas5 = {f"saas-{i}": _leaf(tp=1, fp=0) for i in range(5)}
+    skip_anchor = {"saas-0": _leaf(tp=1, fp=0), "saas-1": _leaf(tp=1, fp=0)}
+    evals = {
+        # Largest daydream subset (2 PRs) but only 2 SaaS tools -> SaaS-coverage skip.
+        "a-skip-anchor": {
+            PR_URL: {**skip_anchor, "daydream-owl-alpha": _leaf(tp=1, fp=2, fn=1)},
+            SECOND_PR_URL: {**skip_anchor, "daydream-owl-alpha": _leaf(tp=2, fp=1, fn=1)},
+        },
+        # Retained judge carrying daydream on both PRs -> the fallback anchor.
+        "z-retained": {
+            PR_URL: {**saas5, "daydream-owl-alpha": _leaf(tp=2, fp=1, fn=1)},
+            SECOND_PR_URL: {**saas5, "daydream-owl-alpha": _leaf(tp=3, fp=0, fn=0)},
+        },
+    }
+    for dname, j_evals in evals.items():
+        jdir = root / "results" / dname
+        jdir.mkdir(parents=True, exist_ok=True)
+        (jdir / "evaluations.json").write_text(json.dumps(j_evals))
+    return args
+
+
+def test_report_anchor_falls_back_to_retained_judge_when_largest_subset_is_skipped(
+    build_mod: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the largest-subset judge is panel-skipped, the report-wide anchor, label
+    slices, and priority-1 improvement resolve to a retained judge carrying daydream
+    instead of silently vanishing. Regressions #384/#392."""
+    monkeypatch.setenv("DAYDREAM_PRICES_FILE", str(tmp_path / "absent.toml"))
+    report: dict[str, Any] = build_mod.build(_anchor_skipped_corpus(tmp_path))
+
+    # The skipped judge is not retained, and the anchor re-points to a retained one.
+    assert [j["id"] for j in report["judges"]] == ["z-retained"]
+    assert [s["id"] for s in report["skipped_judges"]] == ["a-skip-anchor"]
+    assert report["meta"]["anchor_judge"] == "z-retained"
+
+    # Slice evidence is keyed off the fallback anchor's evals, spanning both PRs.
+    lang = next(sl for sl in report["slices"] if sl["title"] == "Language")
+    row = next(r for r in lang["rows"] if r["label"] == "python")
+    assert (row["n_prs"], row["tp"], row["fp"], row["fn"]) == (2, 5, 1, 1)
+
+    # Priority-1 cites the retained fallback anchor, not the skipped one.
+    p1 = next(im for im in report["improvements"] if im["priority"] == 1)
+    assert "z-retained" in p1["heading"]
+    assert "a-skip-anchor" not in p1["body"]

--- a/tests/test_benchmark_report_build.py
+++ b/tests/test_benchmark_report_build.py
@@ -436,3 +436,78 @@ def test_main_rejects_report_with_no_eligible_judge_panel(
     assert "no SaaS field (superseded or partial run)" in msg
     # both skipped judges listed, in sorted (skipped_judges) order
     assert msg.index("claude-opus-4-5-20251101") < msg.index("gpt-5.2")
+
+def _anchor_corpus(root: Path) -> argparse.Namespace:
+    """Two retained judges where sorted-first (a-first-judge, daydream on 1 PR,
+    totals TP=1/FP=9/FN=0) and largest-subset (z-anchor-judge, daydream on 2 PRs,
+    totals TP=5/FP=1/FN=1) differ. Both carry 5 fully-covered SaaS tools so both
+    are panel-retained; the shared daydream subset is z-anchor's 2 PRs."""
+    args = _corpus(
+        root,
+        pr_trajectories={
+            PR_URL: ("cal.com-10600.json", None, 1_000_000, 1_000_000, 1_000_000, 3, None),
+            SECOND_PR_URL: ("cal.com-10601.json", None, 1_000_000, 1_000_000, 1_000_000, 3, None),
+        },
+        judges={},
+        labels={
+            PR_URL: {"derived": {"language": "python"}},
+            SECOND_PR_URL: {"derived": {"language": "python"}},
+        },
+    )
+    saas = {f"saas-{i}": _leaf(tp=1, fp=0) for i in range(5)}
+    a_first = dict(saas)
+    a_first["daydream-owl-alpha"] = _leaf(tp=1, fp=9, fn=0)
+    z_anchor = dict(saas)
+    evals = {
+        "a-first-judge": {PR_URL: dict(a_first)},  # SECOND_PR_URL absent -> 1-PR subset
+        "z-anchor-judge": {
+            PR_URL: {**z_anchor, "daydream-owl-alpha": _leaf(tp=2, fp=1, fn=1)},
+            SECOND_PR_URL: {**z_anchor, "daydream-owl-alpha": _leaf(tp=3, fp=0, fn=0)},
+        },
+    }
+    for dname, j_evals in evals.items():
+        jdir = root / "results" / dname
+        jdir.mkdir(parents=True, exist_ok=True)
+        (jdir / "evaluations.json").write_text(json.dumps(j_evals))
+    return args
+
+
+def test_report_build_resolves_anchor_judge_by_id(
+    build_mod: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Report-wide build outputs all trace to the serialized largest-subset anchor,
+    not the sorted-first judge. Regression for #392."""
+    monkeypatch.setenv("DAYDREAM_PRICES_FILE", str(tmp_path / "absent.toml"))
+    report: dict[str, Any] = build_mod.build(_anchor_corpus(tmp_path))
+
+    # Judge order stays sorted; the anchor is the largest-subset judge.
+    assert [j["id"] for j in report["judges"]] == ["a-first-judge", "z-anchor-judge"]
+    assert report["meta"]["anchor_judge"] == "z-anchor-judge"
+
+    by_id = {j["id"]: j for j in report["judges"]}
+    af = by_id["a-first-judge"]["daydream"]
+    za = by_id["z-anchor-judge"]["daydream"]
+    assert (af["tp"], af["fp"], af["fn"]) == (1, 9, 0)
+    assert (za["tp"], za["fp"], za["fn"]) == (5, 1, 1)
+
+    # Slice evidence is keyed off the anchor's evaluation data, spanning both PRs.
+    lang = next(sl for sl in report["slices"] if sl["title"] == "Language")
+    row = next(r for r in lang["rows"] if r["label"] == "python")
+    assert (row["n_prs"], row["tp"], row["fp"], row["fn"]) == (2, 5, 1, 1)
+
+    # Improvement metrics cite the canonical anchor, not the sorted-first judge.
+    p1 = next(im for im in report["improvements"] if im["priority"] == 1)
+    assert "z-anchor-judge" in p1["heading"]
+    assert "a-first-judge" not in p1["body"]
+
+
+def test_template_consumers_resolve_anchor_judge_by_id(tmp_path: Path) -> None:
+    """The template defines one anchorJudge() helper keyed on DATA.meta.anchor_judge
+    and routes its 3 report-wide consumers through it; no first-scored re-selection
+    remains. Regression for #392."""
+    template = TEMPLATE_HTML.read_text()
+
+    assert "function anchorJudge(){return DATA.judges.find(j=>j.id===DATA.meta.anchor_judge);}" in template
+    assert template.count("const anchor=anchorJudge();") == 2  # renderLead, renderSlices
+    assert "const ddtp=(anchorJudge()||{daydream:{tp:1}})" in template  # renderCost
+    assert "DATA.judges.find(j=>j.has_daydream)" not in template

--- a/tests/test_benchmark_report_build.py
+++ b/tests/test_benchmark_report_build.py
@@ -437,11 +437,14 @@ def test_main_rejects_report_with_no_eligible_judge_panel(
     # both skipped judges listed, in sorted (skipped_judges) order
     assert msg.index("claude-opus-4-5-20251101") < msg.index("gpt-5.2")
 
-def _anchor_corpus(root: Path) -> argparse.Namespace:
-    """Two retained judges where sorted-first (a-first-judge, daydream on 1 PR,
-    totals TP=1/FP=9/FN=0) and largest-subset (z-anchor-judge, daydream on 2 PRs,
-    totals TP=5/FP=1/FN=1) differ. Both carry 5 fully-covered SaaS tools so both
-    are panel-retained; the shared daydream subset is z-anchor's 2 PRs."""
+def _anchor_corpus(root: Path, judge_evals: dict[str, dict[str, dict]]) -> argparse.Namespace:
+    """Two-PR corpus whose per-judge evaluations are given verbatim.
+
+    Each judge dir receives its own evaluations.json from ``judge_evals`` (judge id
+    -> {pr url -> tool leaves}); trajectories and PR labels are shared. The caller
+    controls retention/skip by how many SaaS tools each judge carries (>=5 is
+    panel-retained) and the daydream coverage, i.e. which PRs have a present
+    ``daydream-owl-alpha`` leaf."""
     args = _corpus(
         root,
         pr_trajectories={
@@ -454,18 +457,7 @@ def _anchor_corpus(root: Path) -> argparse.Namespace:
             SECOND_PR_URL: {"derived": {"language": "python"}},
         },
     )
-    saas = {f"saas-{i}": _leaf(tp=1, fp=0) for i in range(5)}
-    a_first = dict(saas)
-    a_first["daydream-owl-alpha"] = _leaf(tp=1, fp=9, fn=0)
-    z_anchor = dict(saas)
-    evals = {
-        "a-first-judge": {PR_URL: dict(a_first)},  # SECOND_PR_URL absent -> 1-PR subset
-        "z-anchor-judge": {
-            PR_URL: {**z_anchor, "daydream-owl-alpha": _leaf(tp=2, fp=1, fn=1)},
-            SECOND_PR_URL: {**z_anchor, "daydream-owl-alpha": _leaf(tp=3, fp=0, fn=0)},
-        },
-    }
-    for dname, j_evals in evals.items():
+    for dname, j_evals in judge_evals.items():
         jdir = root / "results" / dname
         jdir.mkdir(parents=True, exist_ok=True)
         (jdir / "evaluations.json").write_text(json.dumps(j_evals))
@@ -478,7 +470,20 @@ def test_report_build_resolves_anchor_judge_by_id(
     """Report-wide build outputs all trace to the serialized largest-subset anchor,
     not the sorted-first judge. Regression for #392."""
     monkeypatch.setenv("DAYDREAM_PRICES_FILE", str(tmp_path / "absent.toml"))
-    report: dict[str, Any] = build_mod.build(_anchor_corpus(tmp_path))
+    saas = {f"saas-{i}": _leaf(tp=1, fp=0) for i in range(5)}
+    a_first = dict(saas)
+    a_first["daydream-owl-alpha"] = _leaf(tp=1, fp=9, fn=0)
+    z_anchor = dict(saas)
+    # Both judges carry 5 SaaS tools (both panel-retained) and differ only in the
+    # sorted-first (1-PR daydream) vs largest-subset (2-PR daydream) identity.
+    evals = {
+        "a-first-judge": {PR_URL: dict(a_first)},  # SECOND_PR_URL absent -> 1-PR subset
+        "z-anchor-judge": {
+            PR_URL: {**z_anchor, "daydream-owl-alpha": _leaf(tp=2, fp=1, fn=1)},
+            SECOND_PR_URL: {**z_anchor, "daydream-owl-alpha": _leaf(tp=3, fp=0, fn=0)},
+        },
+    }
+    report: dict[str, Any] = build_mod.build(_anchor_corpus(tmp_path, evals))
 
     # Judge order stays sorted; the anchor is the largest-subset judge.
     assert [j["id"] for j in report["judges"]] == ["a-first-judge", "z-anchor-judge"]
@@ -513,24 +518,13 @@ def test_template_consumers_resolve_anchor_judge_by_id(tmp_path: Path) -> None:
     assert "DATA.judges.find(j=>j.has_daydream)" not in template
 
 
-def _anchor_skipped_corpus(root: Path) -> argparse.Namespace:
-    """Two-PR corpus where the LARGEST-subset judge (a-skip-anchor, daydream on both
-    PRs) is panel-skipped for failing the SaaS-coverage gate (<5 SaaS tools), while a
-    later retained judge (z-retained, 5 SaaS tools) carries daydream on both PRs.
-    Pre-fix this made the report-wide anchor resolve to None: slices and the
-    priority-1 improvement silently vanished and the template anchor was undefined."""
-    args = _corpus(
-        root,
-        pr_trajectories={
-            PR_URL: ("cal.com-10600.json", None, 1_000_000, 1_000_000, 1_000_000, 3, None),
-            SECOND_PR_URL: ("cal.com-10601.json", None, 1_000_000, 1_000_000, 1_000_000, 3, None),
-        },
-        judges={},
-        labels={
-            PR_URL: {"derived": {"language": "python"}},
-            SECOND_PR_URL: {"derived": {"language": "python"}},
-        },
-    )
+def test_report_anchor_falls_back_to_retained_judge_when_largest_subset_is_skipped(
+    build_mod: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the largest-subset judge is panel-skipped, the report-wide anchor, label
+    slices, and priority-1 improvement resolve to a retained judge carrying daydream
+    instead of silently vanishing. Regressions #384/#392."""
+    monkeypatch.setenv("DAYDREAM_PRICES_FILE", str(tmp_path / "absent.toml"))
     saas5 = {f"saas-{i}": _leaf(tp=1, fp=0) for i in range(5)}
     skip_anchor = {"saas-0": _leaf(tp=1, fp=0), "saas-1": _leaf(tp=1, fp=0)}
     evals = {
@@ -539,27 +533,14 @@ def _anchor_skipped_corpus(root: Path) -> argparse.Namespace:
             PR_URL: {**skip_anchor, "daydream-owl-alpha": _leaf(tp=1, fp=2, fn=1)},
             SECOND_PR_URL: {**skip_anchor, "daydream-owl-alpha": _leaf(tp=2, fp=1, fn=1)},
         },
-        # Retained judge carrying daydream on both PRs -> the fallback anchor.
+        # Retained judge carrying daydream on both PRs, so its coverage equals the
+        # skipped judge's subset -> the fallback anchor.
         "z-retained": {
             PR_URL: {**saas5, "daydream-owl-alpha": _leaf(tp=2, fp=1, fn=1)},
             SECOND_PR_URL: {**saas5, "daydream-owl-alpha": _leaf(tp=3, fp=0, fn=0)},
         },
     }
-    for dname, j_evals in evals.items():
-        jdir = root / "results" / dname
-        jdir.mkdir(parents=True, exist_ok=True)
-        (jdir / "evaluations.json").write_text(json.dumps(j_evals))
-    return args
-
-
-def test_report_anchor_falls_back_to_retained_judge_when_largest_subset_is_skipped(
-    build_mod: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """When the largest-subset judge is panel-skipped, the report-wide anchor, label
-    slices, and priority-1 improvement resolve to a retained judge carrying daydream
-    instead of silently vanishing. Regressions #384/#392."""
-    monkeypatch.setenv("DAYDREAM_PRICES_FILE", str(tmp_path / "absent.toml"))
-    report: dict[str, Any] = build_mod.build(_anchor_skipped_corpus(tmp_path))
+    report: dict[str, Any] = build_mod.build(_anchor_corpus(tmp_path, evals))
 
     # The skipped judge is not retained, and the anchor re-points to a retained one.
     assert [j["id"] for j in report["judges"]] == ["z-retained"]
@@ -570,6 +551,51 @@ def test_report_anchor_falls_back_to_retained_judge_when_largest_subset_is_skipp
     lang = next(sl for sl in report["slices"] if sl["title"] == "Language")
     row = next(r for r in lang["rows"] if r["label"] == "python")
     assert (row["n_prs"], row["tp"], row["fp"], row["fn"]) == (2, 5, 1, 1)
+
+    # Priority-1 cites the retained fallback anchor, not the skipped one.
+    p1 = next(im for im in report["improvements"] if im["priority"] == 1)
+    assert "z-retained" in p1["heading"]
+    assert "a-skip-anchor" not in p1["body"]
+
+
+def test_report_anchor_falls_back_to_retained_judge_with_strict_smaller_dd_subset(
+    build_mod: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Strict-subset fallback: the retained fallback judge's daydream coverage is a
+    PROPER subset of the skipped largest-subset judge's daydream set. The anchor
+    re-points to the retained judge and its label slices and priority-1 improvement
+    reflect the retained judge's SMALLER daydream subset, rather than vanishing."""
+    monkeypatch.setenv("DAYDREAM_PRICES_FILE", str(tmp_path / "absent.toml"))
+    saas5 = {f"saas-{i}": _leaf(tp=1, fp=0) for i in range(5)}
+    skip_anchor = {"saas-0": _leaf(tp=1, fp=0), "saas-1": _leaf(tp=1, fp=0)}
+    evals = {
+        # Largest daydream subset (2 PRs) but only 2 SaaS tools -> SaaS-coverage skip.
+        "a-skip-anchor": {
+            PR_URL: {**skip_anchor, "daydream-owl-alpha": _leaf(tp=1, fp=2, fn=1)},
+            SECOND_PR_URL: {**skip_anchor, "daydream-owl-alpha": _leaf(tp=2, fp=1, fn=1)},
+        },
+        # Retained judge (5 SaaS tools) but daydream scored on ONLY the first PR:
+        # a strict subset of the skipped judge's 2-PR daydream set.
+        "z-retained": {
+            PR_URL: {**saas5, "daydream-owl-alpha": _leaf(tp=4, fp=2, fn=0)},
+            SECOND_PR_URL: dict(saas5),  # no daydream leaf on the second PR
+        },
+    }
+    report: dict[str, Any] = build_mod.build(_anchor_corpus(tmp_path, evals))
+
+    # The skipped judge is not retained; the anchor re-points to the retained one.
+    assert [j["id"] for j in report["judges"]] == ["z-retained"]
+    assert [s["id"] for s in report["skipped_judges"]] == ["a-skip-anchor"]
+    assert report["meta"]["anchor_judge"] == "z-retained"
+    # On fallback the cross-judge subset re-points to the retained anchor's real
+    # (smaller) daydream coverage, not the skipped judge's larger 2-PR set.
+    assert report["meta"]["subset_pr_count"] == 1
+    assert report["meta"]["subset_prs"] == [PR_URL]
+
+    # Slice evidence is keyed off the fallback anchor's OWN (smaller) daydream subset.
+    lang = next(sl for sl in report["slices"] if sl["title"] == "Language")
+    row = next(r for r in lang["rows"] if r["label"] == "python")
+    assert (row["n_prs"], row["tp"], row["fp"], row["fn"]) == (1, 4, 2, 0)
 
     # Priority-1 cites the retained fallback anchor, not the skipped one.
     p1 = next(im for im in report["improvements"] if im["priority"] == 1)


### PR DESCRIPTION
## Summary
Unifies the benchmark report around its largest-subset anchor judge. The daydream anchor is now resolved by serialized judge id (not by the first judge with daydream), and the report panels (lead copy, slices, cost KPIs, priority-1 improvements) all route through that resolved anchor.

Also handles the case where the largest-subset judge is panel-skipped (fails the SaaS-coverage gate and never reaches the output panel set): the report now falls back to a retained judge that still carries daydream, and re-points `dd_subset`/`anchor_evals` to that retained judge's own coverage so `economy.n_prs`, subset counts, label slices, and the fallback anchor's outputs all trace consistently.

## Changes
- `bench/benchmark-report/build.py`: resolve anchor by serialized id; fallback + re-point subset when the largest-subset judge is skipped
- `bench/benchmark-report/template.html`: panels use a shared `anchorJudge()` resolved from `meta.anchor_judge`
- `tests/test_benchmark_report_build.py`: regression tests (anchor resolved by id, fallback subset tracing)

Closes #392