### PR TITLE
fix(benchmark-report): reject duplicate canonical benchmark-trajectory identities (Closes #395)

### DIFF
--- a/bench/benchmark-report/build.py
+++ b/bench/benchmark-report/build.py
@@ -209,6 +209,8 @@ def load_trajectories(traj_dir: Path, prices: dict[str, ModelPrice], price_model
             wall = (_p(max(stamps)) - _p(min(stamps))).total_seconds()
         pr_repo = (d.get("extra", {}) or {}).get("pr_repo", "")
         key = f"{pr_repo}/{num}" if pr_repo else f"{repo_short}/{num}"
+        if key in out:
+            raise ValueError(f"duplicate trajectory key '{key}'")
         out[key] = {
             "repo_short": repo_short, "pr_number": num,
             "pr_repo": pr_repo,

--- a/bench/benchmark-report/build.py
+++ b/bench/benchmark-report/build.py
@@ -210,7 +210,7 @@ def load_trajectories(traj_dir: Path, prices: dict[str, ModelPrice], price_model
         pr_repo = (d.get("extra", {}) or {}).get("pr_repo", "")
         key = f"{pr_repo}/{num}" if pr_repo else f"{repo_short}/{num}"
         if key in out:
-            raise ValueError(f"duplicate trajectory key '{key}'")
+            raise SystemExit(f"duplicate trajectory key '{key}'")
         out[key] = {
             "repo_short": repo_short, "pr_number": num,
             "pr_repo": pr_repo,

--- a/tests/test_benchmark_report_build.py
+++ b/tests/test_benchmark_report_build.py
@@ -311,6 +311,26 @@ def test_report_allows_mixed_canonical_and_unique_legacy_trajectories(
     )
 
 
+def test_duplicate_trajectory_identity_is_rejected(
+    build_mod: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two files resolving to the same canonical key raise ValueError, never silently overwrite."""
+    monkeypatch.setenv("DAYDREAM_PRICES_FILE", str(tmp_path / "absent.toml"))
+    args = _corpus(
+        tmp_path,
+        pr_trajectories={
+            "https://github.com/calcom/cal.com/pull/10600": (
+                "cal.com-10600.json", "calcom/cal.com", 1_000_000, 1_000_000, 1_000_000, 3, None
+            ),
+            "https://github.com/calcom/cal.com/pull/10601": (
+                "cal.com-dup-10600.json", "calcom/cal.com", 2_000_000, 2_000_000, 2_000_000, 4, None
+            ),
+        },
+    )
+    with pytest.raises(ValueError, match=r"duplicate trajectory key 'calcom/cal\.com/10600'"):
+        build_mod.build(args)
+
+
 TEMPLATE_HTML = BUILD_PY.with_name("template.html")
 # All six literals live only inside the old renderImprovements() body; the
 # generated index.html must contain none of them. "15–25%" uses an EN-DASH.

--- a/tests/test_benchmark_report_build.py
+++ b/tests/test_benchmark_report_build.py
@@ -327,7 +327,7 @@ def test_duplicate_trajectory_identity_is_rejected(
             ),
         },
     )
-    with pytest.raises(ValueError, match=r"duplicate trajectory key 'calcom/cal\.com/10600'"):
+    with pytest.raises(SystemExit, match=r"duplicate trajectory key 'calcom/cal\.com/10600'"):
         build_mod.build(args)
 
 


### PR DESCRIPTION
## Summary

- Reject duplicate canonical benchmark-trajectory identities instead of silently overwriting one trajectory with another.
- `load_trajectories` now raises `SystemExit` (fail-closed, matching the sibling legacy-key convention) the first time two trajectory files resolve to the same `owner/repo/PR` key, and never overwrites the earlier record.
- Add regression test `test_duplicate_trajectory_identity_is_rejected` asserting the duplicate key is surfaced.

## Motivation

Completes Plan 036 (issue #395) — keying trajectories by full owner/repository/PR identity was already merged by #484; this adds the missing duplicate-identity guard so per-PR and aggregate economy numbers are never built from ambiguous or silently-dropped data.

Closes #395

## Test Plan

- [x] `uv run pytest tests/test_benchmark_report_build.py` — 15 passed
- [x] Focused regression test `test_duplicate_trajectory_identity_is_rejected` passes
- [x] Two sequential daydream deep-precision reviews passed (round-2 fixed the guard to exit non-zero on duplicate key)

## Notes for Reviewers

The guard intentionally raises `SystemExit` (not `ValueError`) to match the sibling fail-closed legacy-ambiguity convention in `build`; the round-2 daydream review applied this correction (commit 5cb2a61).