### PR TITLE
Confine ephemeral workspace copy paths to both roots (Closes #399)

### DIFF
--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -491,7 +491,7 @@ async def test_open_workspace_rejects_escape_without_persistent_copy(tmp_path: P
             force_ephemeral=True,
             extra_copy=[Path("../retained.cfg")],
             skip_tests=False,
-        ) as ctx:
+        ):
             pass  # never reached — the copy boundary rejects before yielding
     # Fail-closed: a regressed guard would copy the seeded source into
     # dest/../retained.cfg == repo/.daydream/worktrees/retained.cfg (the escape

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -474,6 +474,27 @@ async def test_cleanup_runs_on_exception(tmp_path: Path) -> None:
     assert not captured_path.exists()
 
 
+async def test_open_workspace_rejects_escape_without_persistent_copy(tmp_path: Path) -> None:
+    repo, _ = _make_repo_with_origin(tmp_path)
+    with pytest.raises(
+        WorkspaceCopyPathError, match="must be relative and must not contain"
+    ):
+        async with open_workspace(
+            repo,
+            branch=None,
+            base=None,
+            force_ephemeral=True,
+            extra_copy=[Path("../retained.cfg")],
+            skip_tests=False,
+        ) as ctx:
+            pass  # never reached — the copy boundary rejects before yielding
+    # Fail-closed: no file escaped into the persistent parent (escape destination).
+    assert not (tmp_path / "retained.cfg").exists()
+    # Cleanup ran: the ephemeral worktree was removed -> worktrees dir is empty.
+    worktrees = repo / ".daydream" / "worktrees"
+    assert not any(worktrees.iterdir())
+
+
 # --- 13. Stale-local warning fires ------------------------------------------
 
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -476,6 +476,11 @@ async def test_cleanup_runs_on_exception(tmp_path: Path) -> None:
 
 async def test_open_workspace_rejects_escape_without_persistent_copy(tmp_path: Path) -> None:
     repo, _ = _make_repo_with_origin(tmp_path)
+    # Seed the source file the traversal entry reads. `../retained.cfg` resolves
+    # from the source root to tmp_path/retained.cfg; without it the copy loop
+    # would silently skip (not a file) and the fail-closed assertion below could
+    # never detect a regressed guard.
+    (tmp_path / "retained.cfg").write_text("secret\n")
     with pytest.raises(
         WorkspaceCopyPathError, match="must be relative and must not contain"
     ):
@@ -488,8 +493,10 @@ async def test_open_workspace_rejects_escape_without_persistent_copy(tmp_path: P
             skip_tests=False,
         ) as ctx:
             pass  # never reached — the copy boundary rejects before yielding
-    # Fail-closed: no file escaped into the persistent parent (escape destination).
-    assert not (tmp_path / "retained.cfg").exists()
+    # Fail-closed: a regressed guard would copy the seeded source into
+    # dest/../retained.cfg == repo/.daydream/worktrees/retained.cfg (the escape
+    # destination). Assert nothing was written there.
+    assert not (repo / ".daydream" / "worktrees" / "retained.cfg").exists()
     # Cleanup ran: the ephemeral worktree was removed -> worktrees dir is empty.
     worktrees = repo / ".daydream" / "worktrees"
     assert not any(worktrees.iterdir())


### PR DESCRIPTION
Closes #399

## Summary
Confines ephemeral workspace copy paths to both roots (source root and destination root), rejecting parent-traversal copy escapes in `open_workspace`.

## Changes
- Pin `open_workspace` to reject a parent-traversal copy escape (test)
- Seed the escape source so the worktree guard test can fail closed

## Test Plan
- [ ] Full suite (`make check`) passes

---
*Shipped via the two-round daydream deep-precision review gate (no CodeRabbit).*
