### PR TITLE
Route redrive PR posting through canonical merged items (#400)

### DIFF
--- a/daydream/pr_review.py
+++ b/daydream/pr_review.py
@@ -188,7 +188,17 @@ async def post_review_to_pr_from_report(
     """
     if not merged_items_path.exists():
         return PostStatus.NOTHING_TO_POST
-    items = json.loads(merged_items_path.read_text()).get("items", [])
+    try:
+        items = json.loads(merged_items_path.read_text()).get("items", [])
+    except (OSError, json.JSONDecodeError):
+        # A corrupt/partially-written merged-items.json must not crash the run
+        # with an unhandled JSONDecodeError; treat it like a missing file and
+        # skip the post cleanly (#400).
+        print_warning(
+            console,
+            f"Could not read {merged_items_path.name}; skipping PR post.",
+        )
+        return PostStatus.NOTHING_TO_POST
     issues = parsed_issues_from_items(items)
     if not issues and not approve_on_clean:
         print_info(console, "No parseable issues in review output; skipping PR post.")
@@ -1056,6 +1066,61 @@ def build_payload(
 # --- Core orchestration ---------------------------------------------------
 
 
+def _resolve_pr(
+    target_dir: Path,
+    console: Console,
+    pr_number: int | None,
+) -> PRInfo | None:
+    """Resolve the target PR for posting.
+
+    Handles both the current-branch discovery path (:func:`find_open_pr`) and
+    the explicitly-pinned path (:func:`find_pr_by_number`). On failure it
+    prints a warning describing the cause — distinguishing a missing PR from a
+    failed owner/repo slug resolution — and returns ``None``.
+
+    Returns:
+        The resolved :class:`PRInfo`, or ``None`` (after warning) when the PR
+        cannot be resolved.
+    """
+    if pr_number is not None:
+        data = git_ops.gh_pr_view(target_dir, pr_number)
+        if data is None:
+            print_warning(
+                console,
+                f"PR #{pr_number} not found via `gh pr view`; skipping PR post.",
+            )
+            return None
+        # ``gh pr view`` resolved the PR, but the owner/repo slug (needed to
+        # post) failed to resolve — a different cause than a missing PR, so
+        # report it distinctly instead of a misleading "not found" message.
+        slug = git_ops.gh_repo_view(target_dir)
+        if slug is None:
+            print_warning(
+                console,
+                f"PR #{pr_number} resolved via `gh pr view` but the owner/repo "
+                "slug could not be resolved via `gh repo view`; skipping PR post.",
+            )
+            return None
+        owner, repo = slug
+        return PRInfo(
+            number=pr_number,
+            head_sha=data["headRefOid"],
+            base_sha=data["baseRefOid"],
+            base_ref=data.get("baseRefName", ""),
+            owner=owner,
+            repo=repo,
+            url=data.get("url", ""),
+        )
+    pr = find_open_pr(target_dir)
+    if pr is None:
+        print_warning(
+            console,
+            "No open PR found for the current branch; skipping PR post.",
+        )
+        return None
+    return pr
+
+
 async def _post(
     target_dir: Path,
     issues: list[ParsedIssue],
@@ -1065,22 +1130,9 @@ async def _post(
     approve_on_clean: bool = False,
     pr_number: int | None = None,
 ) -> PostStatus:
-    if pr_number is not None:
-        pr = find_pr_by_number(target_dir, pr_number)
-        if pr is None:
-            print_warning(
-                console,
-                f"PR #{pr_number} not found via `gh pr view`; skipping PR post.",
-            )
-            return PostStatus.NO_PR
-    else:
-        pr = find_open_pr(target_dir)
-        if pr is None:
-            print_warning(
-                console,
-                "No open PR found for the current branch; skipping PR post.",
-            )
-            return PostStatus.NO_PR
+    pr = _resolve_pr(target_dir, console, pr_number)
+    if pr is None:
+        return PostStatus.NO_PR
 
     classified = classify(target_dir, pr, issues)
     if classified.is_empty() and not approve_on_clean:

--- a/daydream/pr_review.py
+++ b/daydream/pr_review.py
@@ -1,10 +1,14 @@
-"""Post daydream review findings as inline comments on the current branch's PR.
+"""Post daydream review findings as inline comments on a target PR.
 
-Shared by deep-review mode (reads canonical `merged-items.json`) and
-comment mode (`--comment`) (consumes alt-review issues directly).
+Shared by deep-review mode (reads canonical `merged-items.json`), comment
+mode (`--comment`) (consumes alt-review issues directly), and
+`scripts/redrive_post.py` (a thin CLI over the same canonical
+`merged-items.json` that a redrive must post).
 
 Flow:
-    1. Locate the open PR for the current branch via `gh pr list`.
+    1. Locate the target PR: by explicit number via `gh pr view` when
+       `pr_number` is supplied (consumer: `scripts/redrive_post.py`), else
+       the current branch's open PR via `gh pr list`.
     2. Parse issues (from canonical merged items or alt-issue dicts).
     3. Resolve each issue to a real head-SHA line via anchor grep.
     4. Classify into inline (line within a diff hunk), file-level (file in
@@ -158,6 +162,7 @@ async def post_review_to_pr_from_report(
     console: Console,
     post: bool = False,
     approve_on_clean: bool = False,
+    pr_number: int | None = None,
 ) -> PostStatus:
     """Read canonical `merged-items.json` and offer to post to the PR.
 
@@ -170,6 +175,11 @@ async def post_review_to_pr_from_report(
 
     ``approve_on_clean=True`` (issue #343) opts into posting
     ``event: "APPROVE"`` when the review has zero high/medium findings.
+
+    ``pr_number``: when set, resolves the target PR by explicit number via
+    ``gh pr view`` (redrive) instead of the current branch's open PR;
+    a failing explicit lookup returns :attr:`PostStatus.NO_PR` with no
+    fallback to current-branch discovery.
 
     Returns:
         A :class:`PostStatus` describing the outcome so the caller can decide
@@ -184,7 +194,12 @@ async def post_review_to_pr_from_report(
         print_info(console, "No parseable issues in review output; skipping PR post.")
         return PostStatus.NOTHING_TO_POST
     return await _post(
-        target_dir, issues, console=console, post=post, approve_on_clean=approve_on_clean
+        target_dir,
+        issues,
+        console=console,
+        post=post,
+        approve_on_clean=approve_on_clean,
+        pr_number=pr_number,
     )
 
 
@@ -1048,14 +1063,24 @@ async def _post(
     console: Console,
     post: bool = False,
     approve_on_clean: bool = False,
+    pr_number: int | None = None,
 ) -> PostStatus:
-    pr = find_open_pr(target_dir)
-    if pr is None:
-        print_warning(
-            console,
-            "No open PR found for the current branch; skipping PR post.",
-        )
-        return PostStatus.NO_PR
+    if pr_number is not None:
+        pr = find_pr_by_number(target_dir, pr_number)
+        if pr is None:
+            print_warning(
+                console,
+                f"PR #{pr_number} not found via `gh pr view`; skipping PR post.",
+            )
+            return PostStatus.NO_PR
+    else:
+        pr = find_open_pr(target_dir)
+        if pr is None:
+            print_warning(
+                console,
+                "No open PR found for the current branch; skipping PR post.",
+            )
+            return PostStatus.NO_PR
 
     classified = classify(target_dir, pr, issues)
     if classified.is_empty() and not approve_on_clean:

--- a/daydream/pr_review.py
+++ b/daydream/pr_review.py
@@ -1083,34 +1083,24 @@ def _resolve_pr(
         cannot be resolved.
     """
     if pr_number is not None:
-        data = git_ops.gh_pr_view(target_dir, pr_number)
-        if data is None:
-            print_warning(
-                console,
-                f"PR #{pr_number} not found via `gh pr view`; skipping PR post.",
-            )
+        pr = find_pr_by_number(target_dir, pr_number)
+        if pr is None:
+            # Distinguish "PR not found" from "owner/repo slug unresolvable"
+            # so the operator gets a precise diagnostic rather than a generic
+            # "could not resolve" message.
+            if git_ops.gh_pr_view(target_dir, pr_number) is None:
+                print_warning(
+                    console,
+                    f"PR #{pr_number} not found via `gh pr view`; skipping PR post.",
+                )
+            else:
+                print_warning(
+                    console,
+                    f"PR #{pr_number} resolved via `gh pr view` but the owner/repo "
+                    "slug could not be resolved via `gh repo view`; skipping PR post.",
+                )
             return None
-        # ``gh pr view`` resolved the PR, but the owner/repo slug (needed to
-        # post) failed to resolve — a different cause than a missing PR, so
-        # report it distinctly instead of a misleading "not found" message.
-        slug = git_ops.gh_repo_view(target_dir)
-        if slug is None:
-            print_warning(
-                console,
-                f"PR #{pr_number} resolved via `gh pr view` but the owner/repo "
-                "slug could not be resolved via `gh repo view`; skipping PR post.",
-            )
-            return None
-        owner, repo = slug
-        return PRInfo(
-            number=pr_number,
-            head_sha=data["headRefOid"],
-            base_sha=data["baseRefOid"],
-            base_ref=data.get("baseRefName", ""),
-            owner=owner,
-            repo=repo,
-            url=data.get("url", ""),
-        )
+        return pr
     pr = find_open_pr(target_dir)
     if pr is None:
         print_warning(

--- a/scripts/redrive_post.py
+++ b/scripts/redrive_post.py
@@ -14,6 +14,7 @@ reintroduce deduped findings or drop structural ones.
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from pathlib import Path
 
@@ -30,13 +31,17 @@ async def _run(target_dir: Path, pr_number: int, auto_yes: bool = False) -> None
         print(f"No canonical merged-items.json found at {items_path}", file=sys.stderr)
         sys.exit(1)
 
-    status = await post_review_to_pr_from_report(
-        target_dir,
-        items_path,
-        console=create_console(),
-        post=auto_yes,
-        pr_number=pr_number,
-    )
+    try:
+        status = await post_review_to_pr_from_report(
+            target_dir,
+            items_path,
+            console=create_console(),
+            post=auto_yes,
+            pr_number=pr_number,
+        )
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"Could not read merged-items.json at {items_path}: {exc}", file=sys.stderr)
+        sys.exit(1)
 
     if status in (PostStatus.NO_PR, PostStatus.FAILED):
         sys.exit(1)

--- a/scripts/redrive_post.py
+++ b/scripts/redrive_post.py
@@ -31,6 +31,18 @@ async def _run(target_dir: Path, pr_number: int, auto_yes: bool = False) -> None
         print(f"No canonical merged-items.json found at {items_path}", file=sys.stderr)
         sys.exit(1)
 
+    # A present-but-corrupt/partially-written merged-items.json is a real error,
+    # not a "nothing to post": validate it here so it exits 1 (distinguishing
+    # corruption from a genuinely-empty finding list) instead of silently
+    # succeeding. The shared poster swallows JSONDecodeError into
+    # NOTHING_TO_POST for the main deep flow, which would otherwise hide input
+    # corruption behind a 0 exit code here (#400, round 2).
+    try:
+        json.loads(items_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"Could not read merged-items.json at {items_path}: {exc}", file=sys.stderr)
+        sys.exit(1)
+
     try:
         status = await post_review_to_pr_from_report(
             target_dir,

--- a/scripts/redrive_post.py
+++ b/scripts/redrive_post.py
@@ -1,305 +1,45 @@
 #!/usr/bin/env python3
-"""Re-drive PR comment posting from existing deep review artifacts.
+"""Re-drive PR comment posting from the canonical deep merged-items file.
 
 Usage:
-    uv run python scripts/redrive_post.py /path/to/target/repo --pr 58
+    uv run python scripts/redrive_post.py /path/to/target/repo --pr N [--yes]
 
-Reads .daydream/deep/{alternatives.json, stack-*-records.json, dedup-candidates.json}
-and synthesizes .review-output.md, then calls the standard PR posting flow.
+The sole input is `.daydream/deep/merged-items.json` — the canonical,
+schema-validated finding list produced by the cross-stack merge. Conversion,
+classification, confirmation, and submission are delegated to
+`daydream.pr_review.post_review_to_pr_from_report`, so a redrive can never
+reintroduce deduped findings or drop structural ones.
 """
 
 from __future__ import annotations
 
 import argparse
-import json
-import subprocess
 import sys
-import tempfile
 from pathlib import Path
 
-
-def _load_artifacts(deep_dir: Path) -> tuple[list[dict], list[dict], list[dict]]:
-    """Load alternatives, per-stack records, and dedup candidates."""
-    alts = json.loads((deep_dir / "alternatives.json").read_text())
-    dedup = json.loads((deep_dir / "dedup-candidates.json").read_text())
-
-    records: list[dict] = []
-    for p in sorted(deep_dir.glob("stack-*-records.json")):
-        records.extend(json.loads(p.read_text()))
-
-    return alts, records, dedup
-
-
-def _record_key(record: dict) -> tuple[str, int]:
-    """Composite key for a per-stack record (file + id)."""
-    return str(record["file"]), int(record["id"])
-
-
-def _find_overlaps(
-    alts: list[dict], records: list[dict]
-) -> tuple[dict[int, list[dict]], set[tuple[str, int]]]:
-    """Match alternatives to generic records by shared file paths."""
-    by_file: dict[str, list[dict]] = {}
-    for r in records:
-        by_file.setdefault(r["file"], []).append(r)
-
-    alt_matches: dict[int, list[dict]] = {}
-    consumed: set[tuple[str, int]] = set()
-    for alt in alts:
-        matches: list[dict] = []
-        for f in alt.get("files", []):
-            for r in by_file.get(f, []):
-                key = _record_key(r)
-                if key not in consumed:
-                    matches.append(r)
-                    consumed.add(key)
-        if matches:
-            alt_matches[alt["id"]] = matches
-
-    return alt_matches, consumed
-
-
-def _fmt_body(
-    *,
-    severity: str = "",
-    confidence: str = "",
-    description: str = "",
-    rationale: str = "",
-    recommendation: str = "",
-    extra: str = "",
-) -> str:
-    parts: list[str] = []
-    if severity:
-        parts.append(f"   **Severity:** {severity}")
-    if confidence:
-        parts.append(f"   **Confidence:** {confidence}")
-    if description:
-        parts.append(f"   {description}")
-    if rationale:
-        parts.append(f"   **Rationale:** {rationale}")
-    if recommendation:
-        parts.append(f"   **Recommendation:** {recommendation}")
-    if extra:
-        parts.append(f"   {extra}")
-    return "\n\n".join(parts)
-
-
-def build_report(
-    alts: list[dict], records: list[dict], dedup: list[dict]
-) -> str:
-    """Merge alternatives + per-stack records into .review-output.md."""
-    alt_matches, consumed_ids = _find_overlaps(alts, records)
-
-    lines: list[str] = ["# Review\n"]
-    lines.append("## Issues\n")
-
-    num = 0
-
-    for alt in alts:
-        files = alt.get("files", [])
-        title = alt.get("title", alt.get("description", ""))
-        matches = alt_matches.get(alt["id"], [])
-
-        file_lines: dict[str, int | None] = {f: None for f in files}
-        for m in matches:
-            if m["file"] in file_lines and m.get("line"):
-                file_lines[m["file"]] = m["line"]
-
-        extra = ""
-        if matches:
-            evidence = "; ".join(m["description"] for m in matches)
-            extra = f"**Per-stack evidence:** {evidence}"
-
-        for f in files:
-            num += 1
-            line = file_lines.get(f)
-            loc = f"{f}:{line}" if line else f
-            body = _fmt_body(
-                severity=alt.get("severity", ""),
-                confidence=alt.get("confidence", ""),
-                description=alt.get("description", ""),
-                rationale=alt.get("rationale", ""),
-                recommendation=alt.get("recommendation", ""),
-                extra=extra,
-            )
-            lines.append(f"{num}. [{loc}] {title}\n{body}\n")
-
-    for r in records:
-        if _record_key(r) in consumed_ids:
-            continue
-        num += 1
-        loc = f"{r['file']}:{r['line']}" if r.get("line") else r["file"]
-        body = _fmt_body(
-            confidence=r.get("confidence", ""),
-            description=r["description"],
-            rationale=r.get("rationale", ""),
-        )
-        lines.append(f"{num}. [{loc}] {r['description']}\n{body}\n")
-
-    return "\n".join(lines)
-
-
-def _lookup_pr(target_dir: Path, pr_number: int) -> dict | None:
-    """Fetch PR details via gh CLI."""
-    try:
-        r = subprocess.run(  # noqa: S603, S607 -- args are hardcoded
-            [
-                "gh", "pr", "view", str(pr_number),
-                "--json", "number,headRefOid,baseRefOid,baseRefName,url",
-            ],
-            cwd=target_dir,
-            capture_output=True,
-            text=True,
-            timeout=15,
-            shell=False,
-        )
-    except (subprocess.SubprocessError, OSError):
-        return None
-    if r.returncode != 0:
-        return None
-    try:
-        return json.loads(r.stdout)
-    except json.JSONDecodeError:
-        return None
-
-
-def _repo_owner_name(target_dir: Path) -> tuple[str | None, str | None]:
-    try:
-        r = subprocess.run(  # noqa: S603, S607
-            ["gh", "repo", "view", "--json", "owner,name"],
-            cwd=target_dir,
-            capture_output=True,
-            text=True,
-            timeout=10,
-            shell=False,
-        )
-    except (subprocess.SubprocessError, OSError):
-        return None, None
-    if r.returncode != 0:
-        return None, None
-    try:
-        data = json.loads(r.stdout)
-    except json.JSONDecodeError:
-        return None, None
-    return data.get("owner", {}).get("login"), data.get("name")
+from daydream.deep.artifacts import merged_items_path
+from daydream.pr_review import PostStatus, post_review_to_pr_from_report
+from daydream.ui import create_console
 
 
 async def _run(target_dir: Path, pr_number: int, auto_yes: bool = False) -> None:
-    from daydream.pr_review import (
-        PRInfo,
-        build_payload,
-        classify,
-        parse_report,
-    )
-
-    # --- Build report from artifacts ---
     deep_dir = target_dir / ".daydream" / "deep"
-    if not deep_dir.is_dir():
-        print(f"No .daydream/deep/ directory found at {target_dir}", file=sys.stderr)
+    items_path = merged_items_path(deep_dir)
+
+    if not items_path.is_file():
+        print(f"No canonical merged-items.json found at {items_path}", file=sys.stderr)
         sys.exit(1)
 
-    alts, records, dedup = _load_artifacts(deep_dir)
-    report = build_report(alts, records, dedup)
-
-    output_path = target_dir / ".review-output.md"
-    output_path.write_text(report)
-    print(f"Wrote merged report ({len(report)} bytes) to {output_path}")
-
-    # --- Parse the report ---
-    issues = parse_report(report)
-    if not issues:
-        print("No parseable issues in report", file=sys.stderr)
-        sys.exit(1)
-    print(f"Parsed {len(issues)} issues from report")
-
-    # --- Resolve PR info ---
-    pr_data = _lookup_pr(target_dir, pr_number)
-    if pr_data is None:
-        print(f"Could not find PR #{pr_number}", file=sys.stderr)
-        sys.exit(1)
-
-    owner, repo = _repo_owner_name(target_dir)
-    if owner is None or repo is None:
-        print("Could not determine repo owner/name", file=sys.stderr)
-        sys.exit(1)
-
-    pr = PRInfo(
-        number=pr_data["number"],
-        head_sha=pr_data["headRefOid"],
-        base_sha=pr_data["baseRefOid"],
-        base_ref=pr_data.get("baseRefName", ""),
-        owner=owner,
-        repo=repo,
-        url=pr_data.get("url", ""),
-    )
-    print(f"PR #{pr.number} ({pr.url})")
-    print(f"  head: {pr.head_sha[:12]}  base: {pr.base_sha[:12]}")
-
-    # --- Classify issues (inline vs body-only) ---
-    classified = classify(target_dir, pr, issues)
-    inline_files = sorted({c["path"] for c in classified.inline})
-    print(
-        f"\n{len(classified.inline)} inline on "
-        f"{', '.join(inline_files) if inline_files else '(none)'}, "
-        f"{len(classified.body_only)} folded into body"
+    status = await post_review_to_pr_from_report(
+        target_dir,
+        items_path,
+        console=create_console(),
+        post=auto_yes,
+        pr_number=pr_number,
     )
 
-    if not classified.inline and not classified.body_only:
-        print("No postable issues after classification")
-        return
-
-    # --- Confirm and post ---
-    if not auto_yes:
-        answer = input("\nPost these as a PR review? [y/N] ").strip().lower()
-        if answer not in ("y", "yes"):
-            print("Skipped.")
-            return
-
-    payload = build_payload(pr, classified)
-    with tempfile.NamedTemporaryFile(
-        mode="w",
-        prefix=f"pr-{pr.number}-review-",
-        suffix=".json",
-        delete=False,
-        encoding="utf-8",
-    ) as tf:
-        tf.write(json.dumps(payload, indent=2))
-        payload_path = Path(tf.name)
-
-    print(f"Payload written to {payload_path}")
-
-    try:
-        r = subprocess.run(  # noqa: S603, S607
-            [
-                "gh", "api",
-                "--method", "POST",
-                f"/repos/{pr.owner}/{pr.repo}/pulls/{pr.number}/reviews",
-                "--input", str(payload_path),
-            ],
-            cwd=target_dir,
-            capture_output=True,
-            text=True,
-            timeout=30,
-            shell=False,
-        )
-    except (subprocess.SubprocessError, OSError) as exc:
-        print(f"Failed to post: {exc}", file=sys.stderr)
-        print(f"Payload kept at {payload_path}")
+    if status in (PostStatus.NO_PR, PostStatus.FAILED):
         sys.exit(1)
-
-    if r.returncode != 0:
-        print(f"gh api failed (rc={r.returncode}): {r.stderr}", file=sys.stderr)
-        print(f"Payload kept at {payload_path}")
-        sys.exit(1)
-
-    try:
-        data = json.loads(r.stdout)
-        url = data.get("html_url", "(no URL returned)")
-    except json.JSONDecodeError:
-        url = "(response not JSON)"
-
-    payload_path.unlink(missing_ok=True)
-    print(f"\nPosted review: {url}")
 
 
 def main() -> None:

--- a/tests/test_redrive_post.py
+++ b/tests/test_redrive_post.py
@@ -1,0 +1,102 @@
+"""Acceptance tests for scripts/redrive_post.py (canonical merged-items posting).
+
+Drives the real CLI entrypoint (scripts.redrive_post.main) through real argument
+parsing, with the fake gh harness only at the external subprocess boundary. The
+delegation functions (post_review_to_pr_from_report / parsed_issues_from_items /
+classify / build_payload / _post) are NOT monkeypatched — the real shared
+canonical posting path must run end-to-end (spec M3).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import scripts.redrive_post as redrive
+from tests.test_extension_seam_integration import _serve_pr_view
+
+CANONICAL_KEEP_INLINE = "CANONICAL_KEEP_INLINE_SENTINEL"
+CANONICAL_KEEP_STRUCTURAL = "CANONICAL_KEEP_STRUCTURAL_SENTINEL"
+LEGACY_DROPPED = "LEGACY_DROPPED_SENTINEL"
+
+
+def _run_cli(*argv: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["redrive_post", *argv])
+    redrive.main()
+
+
+def _write_canonical(target: Path) -> None:
+    deep = target / ".daydream" / "deep"
+    deep.mkdir(parents=True, exist_ok=True)
+    (deep / "merged-items.json").write_text(
+        json.dumps(
+            {
+                "items": [
+                    {"id": 1, "lens": "generic", "file": "api.py", "line": 1,
+                     "description": CANONICAL_KEEP_INLINE, "severity": "high",
+                     "confidence": "HIGH", "rationale": "r"},
+                    {"id": 2, "lens": "structural", "file": "README.md", "line": 1,
+                     "description": CANONICAL_KEEP_STRUCTURAL, "severity": "high",
+                     "confidence": "HIGH", "rationale": "r"},
+                ]
+            }
+        )
+    )
+    # Legacy pre-merge artifacts the OLD redrive would have read. Redrive must
+    # never source findings from these (spec M2).
+    (deep / "alternatives.json").write_text(
+        json.dumps([{"id": 99, "files": ["api.py"], "description": LEGACY_DROPPED}])
+    )
+    (deep / "stack-a-records.json").write_text(
+        json.dumps([{"file": "api.py", "id": 1, "line": 1, "description": LEGACY_DROPPED}])
+    )
+    (deep / "dedup-candidates.json").write_text("[]")
+
+
+def test_redrive_posts_only_canonical_merged_items(
+    multi_stack_target: Path, fake_gh: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _serve_pr_view(fake_gh, multi_stack_target)
+    _write_canonical(multi_stack_target)
+
+    _run_cli(str(multi_stack_target), "--pr", "7", "--yes", monkeypatch=monkeypatch)
+
+    posted = json.dumps(
+        [
+            call.payload
+            for call in (
+                *fake_gh.calls("POST", "repos/acme/widgets/pulls/7/reviews"),
+                *fake_gh.calls("POST", "repos/acme/widgets/pulls/7/comments"),
+            )
+        ]
+    )
+    assert CANONICAL_KEEP_INLINE in posted
+    assert CANONICAL_KEEP_STRUCTURAL in posted
+    assert LEGACY_DROPPED not in posted
+    view_calls = fake_gh.pr_view_calls()
+    assert view_calls and "7" in view_calls[0].argv          # explicit `gh pr view 7`
+    assert fake_gh.command_calls("pr list") == []            # no current-branch discovery
+    assert not (multi_stack_target / ".review-output.md").exists()
+
+
+def test_redrive_requires_canonical_merged_items(
+    multi_stack_target: Path,
+    fake_gh: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    deep = multi_stack_target / ".daydream" / "deep"
+    deep.mkdir(parents=True, exist_ok=True)  # exists, but no merged-items.json
+
+    with pytest.raises(SystemExit) as exc:
+        _run_cli(str(multi_stack_target), "--pr", "7", "--yes", monkeypatch=monkeypatch)
+
+    assert exc.value.code == 1
+    missing = deep / "merged-items.json"
+    assert f"No canonical merged-items.json found at {missing}" in capsys.readouterr().err
+    assert fake_gh.calls("POST") == []       # zero GitHub requests
+    assert not (multi_stack_target / ".review-output.md").exists()

--- a/tests/test_redrive_post.py
+++ b/tests/test_redrive_post.py
@@ -102,7 +102,7 @@ def test_redrive_requires_canonical_merged_items(
     assert not (multi_stack_target / ".review-output.md").exists()
 
 
-def test_redrive_corrupt_merged_items_skips_gracefully(
+def test_redrive_corrupt_merged_items_exits_nonzero(
     multi_stack_target: Path,
     fake_gh: Any,
     monkeypatch: pytest.MonkeyPatch,
@@ -113,9 +113,11 @@ def test_redrive_corrupt_merged_items_skips_gracefully(
     deep.mkdir(parents=True, exist_ok=True)
     (deep / "merged-items.json").write_text("{not valid json}")
 
-    _run_cli(str(multi_stack_target), "--pr", "7", "--yes", monkeypatch=monkeypatch)
+    with pytest.raises(SystemExit) as exc:
+        _run_cli(str(multi_stack_target), "--pr", "7", "--yes", monkeypatch=monkeypatch)
+    assert exc.value.code == 1  # corrupt input is an error, not a silent success
 
-    out = capsys.readouterr().out
-    assert "Could not read merged-items.json" in out
+    captured = capsys.readouterr()
+    assert "Could not read merged-items.json" in (captured.out + captured.err)
     assert fake_gh.calls("POST") == []
     assert not (multi_stack_target / ".review-output.md").exists()

--- a/tests/test_redrive_post.py
+++ b/tests/test_redrive_post.py
@@ -100,3 +100,22 @@ def test_redrive_requires_canonical_merged_items(
     assert f"No canonical merged-items.json found at {missing}" in capsys.readouterr().err
     assert fake_gh.calls("POST") == []       # zero GitHub requests
     assert not (multi_stack_target / ".review-output.md").exists()
+
+
+def test_redrive_corrupt_merged_items_skips_gracefully(
+    multi_stack_target: Path,
+    fake_gh: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _serve_pr_view(fake_gh, multi_stack_target)
+    deep = multi_stack_target / ".daydream" / "deep"
+    deep.mkdir(parents=True, exist_ok=True)
+    (deep / "merged-items.json").write_text("{not valid json}")
+
+    _run_cli(str(multi_stack_target), "--pr", "7", "--yes", monkeypatch=monkeypatch)
+
+    out = capsys.readouterr().out
+    assert "Could not read merged-items.json" in out
+    assert fake_gh.calls("POST") == []
+    assert not (multi_stack_target / ".review-output.md").exists()


### PR DESCRIPTION
## Summary
Routes redrive PR comment posting through the canonical merged-items flow.

The old `scripts/redrive_post.py` re-synthesized review output from the deep
artifacts (`alternatives.json`, `stack-*-records.json`, `dedup-candidates.json`)
and reimplemented conversion, classification, and confirmation — which could
reintroduce deduped findings or drop structural ones. This PR replaces it with a
thin CLI over the canonical, schema-validated `.daydream/deep/merged-items.json`,
delegating everything to `daydream.pr_review.post_review_to_pr_from_report`.

### Changes
- `daydream/pr_review.py`
  - `post_review_to_pr_from_report` / `_post` accept an explicit `pr_number`;
    when set, the target PR is resolved via `find_pr_by_number` (`gh pr view`)
    instead of current-branch discovery, with a precise diagnostic when it
    can't be found.
  - `_resolve_pr` centralizes PR resolution (explicit-number vs open-branch),
    distinguishing "PR not found" from "owner/repo slug unresolvable".
  - Hardens the PR post against a corrupt / partially-written `merged-items.json`
    (skip cleanly instead of crashing on an unhandled `JSONDecodeError`).
- `scripts/redrive_post.py` — slimmed to a thin CLI (`--pr N [--yes]`) over the
  canonical merged-items file; dedup/structural findings can no longer be lost.
- `tests/test_redrive_post.py` — acceptance tests for the new flow, including a
  regression test asserting the corrupt-input guard exits 1.

### Test Plan
- [x] Full suite passes (3291 tests, 0 failures)
- [x] redrive exits 1 on corrupt merged-items.json (regression test asserts it)
- [x] Two sequential daydream deep-precision reviews, no findings left open

Closes #400