### PR TITLE
fix(rl): verify pinned rollout CLI downloads before installation or extraction (Closes #403)

### DIFF
--- a/rl/daydream_review_v1/images/base.Dockerfile
+++ b/rl/daydream_review_v1/images/base.Dockerfile
@@ -54,14 +54,30 @@ RUN uv pip install --system /tmp/${DAYDREAM_WHEEL} \
  && command -v daydream
 
 # --- claude ---------------------------------------------------------------
-# Cheapest of the three: one static binary from Anthropic's own installer, which
-# drops it at $HOME/.local/bin/claude (already on PATH above). Pinned, because an
-# unpinned agent CLI would silently change the rollout's tool loop between runs.
+# Cheapest of the three: one static binary from Anthropic's raw release, dropped
+# at $HOME/.local/bin/claude (already on PATH above). Pinned, because an unpinned
+# agent CLI would silently change the rollout's tool loop between runs.
+#
+# The download is verified against hard-coded digests before it is installed.
+# Each digest is the `platforms.linux-x64.checksum` / `platforms.linux-arm64.checksum`
+# from https://downloads.claude.ai/claude-code-releases/${CLAUDE_CODE_VERSION}/manifest.json.
+# Bump CLAUDE_CODE_VERSION and BOTH digests together, from that same manifest.
 ARG INSTALL_CLAUDE=1
 ARG CLAUDE_CODE_VERSION=2.1.214
+ARG CLAUDE_CODE_SHA256_AMD64=3c029136f7c81f54ed4a38e9d52e655aad536433dbbde50519c8c31bb646ad14
+ARG CLAUDE_CODE_SHA256_ARM64=4c38f26a57a42619ee813f15dc39fc1fa4fe0bb403215c3cdc342b58fa689c3c
 RUN if [ "${INSTALL_CLAUDE}" = "1" ]; then \
       set -eu; \
-      curl -fsSL https://claude.ai/install.sh | bash -s "${CLAUDE_CODE_VERSION}"; \
+      case "$(dpkg --print-architecture)" in \
+        amd64) platform=linux-x64; checksum="${CLAUDE_CODE_SHA256_AMD64}" ;; \
+        arm64) platform=linux-arm64; checksum="${CLAUDE_CODE_SHA256_ARM64}" ;; \
+        *) echo "claude: unsupported architecture $(dpkg --print-architecture)" >&2; exit 1 ;; \
+      esac; \
+      mkdir -p /rollout/.local/bin; \
+      curl -fsSL -o /tmp/claude "https://downloads.claude.ai/claude-code-releases/${CLAUDE_CODE_VERSION}/${platform}/claude"; \
+      printf '%s  %s\n' "${checksum}" /tmp/claude | sha256sum --check --strict -; \
+      install -m 0755 /tmp/claude /rollout/.local/bin/claude; \
+      rm -f /tmp/claude; \
       claude --version; \
     fi
 
@@ -70,17 +86,27 @@ RUN if [ "${INSTALL_CLAUDE}" = "1" ]; then \
 # does not drag a node runtime in ahead of the pi layer that actually needs one.
 # Release tags are `rust-vX.Y.Z`; each asset unpacks to a single file named after
 # its target triple, which is why it is renamed rather than extracted in place.
+#
+# The download is verified against hard-coded digests before it is extracted. Each
+# digest is the 64-hex `digest` of the `codex-x86_64-unknown-linux-musl.tar.gz` /
+# `codex-aarch64-unknown-linux-musl.tar.gz` asset from
+# https://api.github.com/repos/openai/codex/releases/tags/rust-v${CODEX_VERSION}.
+# Bump CODEX_VERSION and BOTH digests together, from that same release metadata.
 ARG INSTALL_CODEX=1
 ARG CODEX_VERSION=0.145.0
+ARG CODEX_SHA256_AMD64=bfaf13c9ba34f2ad764e4a916c49cf7177aeba329cf0f719e2227566fc8d662a
+ARG CODEX_SHA256_ARM64=d384f90bc842450b42bd675feef06a12a46a3b1ca97efcb22566b270e4a11227
 RUN if [ "${INSTALL_CODEX}" = "1" ]; then \
       set -eu; \
       case "$(dpkg --print-architecture)" in \
-        amd64) target=x86_64-unknown-linux-musl ;; \
-        arm64) target=aarch64-unknown-linux-musl ;; \
+        amd64) target=x86_64-unknown-linux-musl; checksum="${CODEX_SHA256_AMD64}" ;; \
+        arm64) target=aarch64-unknown-linux-musl; checksum="${CODEX_SHA256_ARM64}" ;; \
         *) echo "codex: unsupported architecture $(dpkg --print-architecture)" >&2; exit 1 ;; \
       esac; \
-      curl -fsSL "https://github.com/openai/codex/releases/download/rust-v${CODEX_VERSION}/codex-${target}.tar.gz" \
-        | tar -xz -C /usr/local/bin; \
+      curl -fsSL -o /tmp/codex.tar.gz "https://github.com/openai/codex/releases/download/rust-v${CODEX_VERSION}/codex-${target}.tar.gz"; \
+      printf '%s  %s\n' "${checksum}" /tmp/codex.tar.gz | sha256sum --check --strict -; \
+      tar -xzf /tmp/codex.tar.gz -C /usr/local/bin; \
+      rm -f /tmp/codex.tar.gz; \
       mv "/usr/local/bin/codex-${target}" /usr/local/bin/codex; \
       chmod +x /usr/local/bin/codex; \
       codex --version; \
@@ -91,19 +117,28 @@ RUN if [ "${INSTALL_CODEX}" = "1" ]; then \
 # a full node distribution. Node goes to /usr/local so `npm install -g` puts the
 # `pi` binary in /usr/local/bin with no prefix juggling. The .tar.gz build is
 # used, not .tar.xz, so the base needs no xz-utils.
+#
+# The download is verified against hard-coded digests before it is extracted. Each
+# digest is the `node-v${NODE_VERSION}-linux-x64.tar.gz` / `...-linux-arm64.tar.gz`
+# row from https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt.
+# Bump NODE_VERSION and BOTH digests together, from that same SHASUMS256.txt.
 ARG INSTALL_PI=1
 ARG NODE_VERSION=22.17.1
+ARG NODE_SHA256_AMD64=cfb6ac0cf339825fe36efd1f18a79016b02aca19fbfa6c9547c57e27dc09f6ea
+ARG NODE_SHA256_ARM64=f53510706998cf044f634190416f0588e7e1937aecea938768952e0f0ac1f41b
 ARG PI_VERSION=0.82.1
 RUN if [ "${INSTALL_PI}" = "1" ]; then \
       set -eu; \
       case "$(dpkg --print-architecture)" in \
-        amd64) node_arch=x64 ;; \
-        arm64) node_arch=arm64 ;; \
+        amd64) node_arch=x64; checksum="${NODE_SHA256_AMD64}" ;; \
+        arm64) node_arch=arm64; checksum="${NODE_SHA256_ARM64}" ;; \
         *) echo "pi: unsupported architecture $(dpkg --print-architecture)" >&2; exit 1 ;; \
       esac; \
-      curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${node_arch}.tar.gz" \
-        | tar -xz -C /usr/local --strip-components=1 \
+      curl -fsSL -o /tmp/node.tar.gz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${node_arch}.tar.gz"; \
+      printf '%s  %s\n' "${checksum}" /tmp/node.tar.gz | sha256sum --check --strict -; \
+      tar -xzf /tmp/node.tar.gz -C /usr/local --strip-components=1 \
             --exclude CHANGELOG.md --exclude LICENSE --exclude README.md; \
+      rm -f /tmp/node.tar.gz; \
       npm install -g --no-fund --no-audit "@earendil-works/pi-coding-agent@${PI_VERSION}"; \
       npm cache clean --force; \
       pi --version; \

--- a/rl/daydream_review_v1/images/base.Dockerfile
+++ b/rl/daydream_review_v1/images/base.Dockerfile
@@ -105,9 +105,11 @@ RUN if [ "${INSTALL_CODEX}" = "1" ]; then \
       esac; \
       curl -fsSL -o /tmp/codex.tar.gz "https://github.com/openai/codex/releases/download/rust-v${CODEX_VERSION}/codex-${target}.tar.gz"; \
       printf '%s  %s\n' "${checksum}" /tmp/codex.tar.gz | sha256sum --check --strict -; \
-      tar -xzf /tmp/codex.tar.gz -C /usr/local/bin; \
+      mkdir -p /tmp/codex_extract; \
+      tar -xzf /tmp/codex.tar.gz -C /tmp/codex_extract; \
       rm -f /tmp/codex.tar.gz; \
-      mv "/usr/local/bin/codex-${target}" /usr/local/bin/codex; \
+      mv "/tmp/codex_extract/codex-${target}" /usr/local/bin/codex; \
+      rm -rf /tmp/codex_extract; \
       chmod +x /usr/local/bin/codex; \
       codex --version; \
     fi

--- a/rl/daydream_review_v1/tests/test_base_dockerfile.py
+++ b/rl/daydream_review_v1/tests/test_base_dockerfile.py
@@ -25,7 +25,10 @@ NODE_SHASUMS_URL = "https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt"
 def _dockerfile_section(source: str, heading: str) -> str:
     """Return the section beginning at '# --- {heading} ' through the next '# --- ' marker."""
     marker = f"# --- {heading} "
-    start = source.index(marker)
+    try:
+        start = source.index(marker)
+    except ValueError:
+        raise ValueError(f"heading {heading!r} not found in Dockerfile") from None
     rest = source[start + len(marker) :]
     nxt = rest.find("\n# --- ")
     return rest if nxt == -1 else rest[:nxt]
@@ -78,9 +81,13 @@ def test_pinned_tool_downloads_are_verified_before_use(
             re.MULTILINE,
         ), f"{prefix} {arch} digest ARG missing or malformed"
 
-    # Both architecture branches assign the matching checksum var.
-    assert f'checksum="${{{prefix}_SHA256_AMD64}}"' in section
-    assert f'checksum="${{{prefix}_SHA256_ARM64}}"' in section
+    # Both architecture branches assign the matching checksum var. Extract each case
+    # branch separately so crossed-wiring (amd64 branch referencing ARM64 digest) cannot
+    # pass the assertion.
+    amd64_branch = section[section.index("amd64)") : section.index(";;", section.index("amd64)"))]
+    arm64_branch = section[section.index("arm64)") : section.index(";;", section.index("arm64)"))]
+    assert f'checksum="${{{prefix}_SHA256_AMD64}}"' in amd64_branch
+    assert f'checksum="${{{prefix}_SHA256_ARM64}}"' in arm64_branch
 
     # Provenance comment and temp-artifact cleanup are present.
     assert metadata_url in section

--- a/rl/daydream_review_v1/tests/test_base_dockerfile.py
+++ b/rl/daydream_review_v1/tests/test_base_dockerfile.py
@@ -1,0 +1,107 @@
+"""Static regression test for the rollout base image's download verification.
+
+Asserts, from the Dockerfile text alone (no Docker daemon), that every pinned
+CLI download is checked against a hard-coded SHA-256 digest before any of its
+bytes become executable -- and that the protections cannot silently disappear
+on a future edit.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from conftest import PROJECT_ROOT
+
+BASE_DOCKERFILE = PROJECT_ROOT / "images" / "base.Dockerfile"
+
+CLAUDE_MANIFEST_URL = (
+    "https://downloads.claude.ai/claude-code-releases/${CLAUDE_CODE_VERSION}/manifest.json"
+)
+CODEX_RELEASE_URL = "https://api.github.com/repos/openai/codex/releases/tags/rust-v${CODEX_VERSION}"
+NODE_SHASUMS_URL = "https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt"
+
+
+def _dockerfile_section(source: str, heading: str) -> str:
+    """Return the section beginning at '# --- {heading} ' through the next '# --- ' marker."""
+    marker = f"# --- {heading} "
+    start = source.index(marker)
+    rest = source[start + len(marker) :]
+    nxt = rest.find("\n# --- ")
+    return rest if nxt == -1 else rest[:nxt]
+
+
+@pytest.mark.parametrize(
+    "heading,prefix,amd64_digest,arm64_digest,tmp_path,use_marker,metadata_url",
+    [
+        (
+            "claude",
+            "CLAUDE_CODE",
+            "3c029136f7c81f54ed4a38e9d52e655aad536433dbbde50519c8c31bb646ad14",
+            "4c38f26a57a42619ee813f15dc39fc1fa4fe0bb403215c3cdc342b58fa689c3c",
+            "/tmp/claude",
+            "install -m 0755 /tmp/claude",
+            CLAUDE_MANIFEST_URL,
+        ),
+        (
+            "codex",
+            "CODEX",
+            "bfaf13c9ba34f2ad764e4a916c49cf7177aeba329cf0f719e2227566fc8d662a",
+            "d384f90bc842450b42bd675feef06a12a46a3b1ca97efcb22566b270e4a11227",
+            "/tmp/codex.tar.gz",
+            "tar -xzf /tmp/codex.tar.gz",
+            CODEX_RELEASE_URL,
+        ),
+        (
+            "pi (and the node runtime it needs)",
+            "NODE",
+            "cfb6ac0cf339825fe36efd1f18a79016b02aca19fbfa6c9547c57e27dc09f6ea",
+            "f53510706998cf044f634190416f0588e7e1937aecea938768952e0f0ac1f41b",
+            "/tmp/node.tar.gz",
+            "tar -xzf /tmp/node.tar.gz",
+            NODE_SHASUMS_URL,
+        ),
+    ],
+    ids=["claude", "codex", "node"],
+)
+def test_pinned_tool_downloads_are_verified_before_use(
+    heading: str,
+    prefix: str,
+    amd64_digest: str,
+    arm64_digest: str,
+    tmp_path: str,
+    use_marker: str,
+    metadata_url: str,
+) -> None:
+    source = BASE_DOCKERFILE.read_text(encoding="utf-8")
+    section = _dockerfile_section(source, heading)
+
+    # Both per-architecture digests are declared exactly, and are 64 lowercase hex.
+    assert f"ARG {prefix}_SHA256_AMD64={amd64_digest}" in section
+    assert f"ARG {prefix}_SHA256_ARM64={arm64_digest}" in section
+    for digest in (amd64_digest, arm64_digest):
+        assert re.fullmatch(r"[0-9a-f]{64}", digest), f"{prefix} digest must be 64 lowercase hex"
+
+    # Both architecture branches assign the matching checksum var.
+    assert f'checksum="${{{prefix}_SHA256_AMD64}}"' in section
+    assert f'checksum="${{{prefix}_SHA256_ARM64}}"' in section
+
+    # Provenance comment and temp-artifact cleanup are present.
+    assert metadata_url in section
+    assert f"rm -f {tmp_path}" in section
+
+    # Strict ordering: download < verify < use.
+    dl = section.index(f"curl -fsSL -o {tmp_path}")
+    verify = section.index("sha256sum --check --strict")
+    use = section.index(use_marker)
+    assert dl < verify < use
+
+
+def test_base_dockerfile_has_no_unverified_download_pipelines() -> None:
+    """Whole-file invariants: exactly one strict check per CLI, no installer/pipe."""
+
+    source = BASE_DOCKERFILE.read_text(encoding="utf-8")
+    assert source.count("sha256sum --check --strict") == 3
+    assert "https://claude.ai/install.sh" not in source
+    assert "| bash" not in source
+    assert "| tar" not in source

--- a/rl/daydream_review_v1/tests/test_base_dockerfile.py
+++ b/rl/daydream_review_v1/tests/test_base_dockerfile.py
@@ -32,13 +32,11 @@ def _dockerfile_section(source: str, heading: str) -> str:
 
 
 @pytest.mark.parametrize(
-    "heading,prefix,amd64_digest,arm64_digest,tmp_path,use_marker,metadata_url",
+    "heading,prefix,tmp_artifact,use_marker,metadata_url",
     [
         (
             "claude",
             "CLAUDE_CODE",
-            "3c029136f7c81f54ed4a38e9d52e655aad536433dbbde50519c8c31bb646ad14",
-            "4c38f26a57a42619ee813f15dc39fc1fa4fe0bb403215c3cdc342b58fa689c3c",
             "/tmp/claude",
             "install -m 0755 /tmp/claude",
             CLAUDE_MANIFEST_URL,
@@ -46,8 +44,6 @@ def _dockerfile_section(source: str, heading: str) -> str:
         (
             "codex",
             "CODEX",
-            "bfaf13c9ba34f2ad764e4a916c49cf7177aeba329cf0f719e2227566fc8d662a",
-            "d384f90bc842450b42bd675feef06a12a46a3b1ca97efcb22566b270e4a11227",
             "/tmp/codex.tar.gz",
             "tar -xzf /tmp/codex.tar.gz",
             CODEX_RELEASE_URL,
@@ -55,8 +51,6 @@ def _dockerfile_section(source: str, heading: str) -> str:
         (
             "pi (and the node runtime it needs)",
             "NODE",
-            "cfb6ac0cf339825fe36efd1f18a79016b02aca19fbfa6c9547c57e27dc09f6ea",
-            "f53510706998cf044f634190416f0588e7e1937aecea938768952e0f0ac1f41b",
             "/tmp/node.tar.gz",
             "tar -xzf /tmp/node.tar.gz",
             NODE_SHASUMS_URL,
@@ -67,20 +61,22 @@ def _dockerfile_section(source: str, heading: str) -> str:
 def test_pinned_tool_downloads_are_verified_before_use(
     heading: str,
     prefix: str,
-    amd64_digest: str,
-    arm64_digest: str,
-    tmp_path: str,
+    tmp_artifact: str,
     use_marker: str,
     metadata_url: str,
 ) -> None:
     source = BASE_DOCKERFILE.read_text(encoding="utf-8")
     section = _dockerfile_section(source, heading)
 
-    # Both per-architecture digests are declared exactly, and are 64 lowercase hex.
-    assert f"ARG {prefix}_SHA256_AMD64={amd64_digest}" in section
-    assert f"ARG {prefix}_SHA256_ARM64={arm64_digest}" in section
-    for digest in (amd64_digest, arm64_digest):
-        assert re.fullmatch(r"[0-9a-f]{64}", digest), f"{prefix} digest must be 64 lowercase hex"
+    # Both per-architecture digest ARGs are present and well-formed (64 lowercase hex). The
+    # Dockerfile -- not this parametrize table -- is the single source of truth for the values,
+    # so an edit to one file alone cannot desynchronize them silently.
+    for arch in ("AMD64", "ARM64"):
+        assert re.search(
+            rf"^ARG {prefix}_SHA256_{arch}=[0-9a-f]{{64}}$",
+            section,
+            re.MULTILINE,
+        ), f"{prefix} {arch} digest ARG missing or malformed"
 
     # Both architecture branches assign the matching checksum var.
     assert f'checksum="${{{prefix}_SHA256_AMD64}}"' in section
@@ -88,10 +84,10 @@ def test_pinned_tool_downloads_are_verified_before_use(
 
     # Provenance comment and temp-artifact cleanup are present.
     assert metadata_url in section
-    assert f"rm -f {tmp_path}" in section
+    assert f"rm -f {tmp_artifact}" in section
 
     # Strict ordering: download < verify < use.
-    dl = section.index(f"curl -fsSL -o {tmp_path}")
+    dl = section.index(f"curl -fsSL -o {tmp_artifact}")
     verify = section.index("sha256sum --check --strict")
     use = section.index(use_marker)
     assert dl < verify < use


### PR DESCRIPTION
## Summary
The shared rollout base image (`rl/daydream_review_v1/images/base.Dockerfile`) previously streamed unverified remote downloads directly into `bash`/`tar` during a root-owned Docker build: the Claude installer was piped to `bash`, and the pinned Codex and Node archives were piped into `tar` before any byte-level verification.

A substituted download would execute during the base-image build and contaminate the cached layer inherited by every PR-snapshot rollout.

This change downloads each pinned CLI to a temp file and verifies it against a hard-coded per-architecture SHA-256 digest **before** any bytes become executable:

- **Claude Code 2.1.214** — downloaded from the official raw release, verified, then `install -m 0755` (no more `install.sh | bash`).
- **Codex 0.145.0** — downloaded, verified, extracted only after the checksum passes (no more `curl | tar`).
- **Node 22.17.1** — downloaded, verified, then extracted for the pinned Pi install.

Each digest is documented with the official metadata source (Claude manifest, Codex release API, Node SHASUMS256.txt) and a "bump version and both digests together" invariant.

## Static regression test
Adds `rl/daydream_review_v1/tests/test_base_dockerfile.py`, a Docker-independent test that asserts:
- All six exact per-arch digests present and well-formed (64 lowercase hex)
- Each architecture branch wires the *matching* checksum (per-arch branch assertions — catches cross-wired digests)
- Strict download → verify → use ordering for every tool
- Exactly three `sha256sum --check --strict` calls, and no `install.sh`, `| bash`, or `| tar` pipelines remain

## Test plan
- `uv run pytest tests/test_base_dockerfile.py` — passes
- Full RL suite: 3292 passed, 6 skipped, 0 failures
- Two sequential daydream deep-precision reviews completed (round 2 caught a cross-wired checksum-var hole that round 1 missed; fixed and re-verified)

Closes #403