### PR TITLE
fix(bench): preserve benchmark metrics when trajectory timestamps are malformed

### DIFF
--- a/bench/benchmark-report/build.py
+++ b/bench/benchmark-report/build.py
@@ -28,6 +28,8 @@ import json
 import shutil
 from collections import Counter
 from datetime import UTC, datetime
+
+from daydream.timeutil import parse_iso_timestamp
 from pathlib import Path
 from typing import Any, TypeGuard
 
@@ -204,11 +206,9 @@ def load_trajectories(traj_dir: Path, prices: dict[str, ModelPrice], price_model
         stamps = [e.get("timestamp") for e in events if e.get("timestamp")]
         wall = None
         if len(stamps) >= 2:
-            def _p(s: str) -> datetime:
-                return datetime.fromisoformat(s.replace("Z", "+00:00"))
             try:
-                wall = (_p(max(stamps)) - _p(min(stamps))).total_seconds()
-            except ValueError:
+                wall = (parse_iso_timestamp(max(stamps)) - parse_iso_timestamp(min(stamps))).total_seconds()
+            except (ValueError, TypeError, AttributeError):
                 pass
         pr_repo = (d.get("extra", {}) or {}).get("pr_repo", "")
         key = f"{pr_repo}/{num}" if pr_repo else f"{repo_short}/{num}"

--- a/bench/benchmark-report/build.py
+++ b/bench/benchmark-report/build.py
@@ -208,6 +208,7 @@ def load_trajectories(traj_dir: Path, prices: dict[str, ModelPrice], price_model
             try:
                 wall = (parse_iso_timestamp(max(stamps)) - parse_iso_timestamp(min(stamps))).total_seconds()
             except ValueError:
+                # malformed timestamp nulls only this trajectory's wall time (intentional fallback)
                 pass
         pr_repo = (d.get("extra", {}) or {}).get("pr_repo", "")
         key = f"{pr_repo}/{num}" if pr_repo else f"{repo_short}/{num}"

--- a/bench/benchmark-report/build.py
+++ b/bench/benchmark-report/build.py
@@ -28,12 +28,11 @@ import json
 import shutil
 from collections import Counter
 from datetime import UTC, datetime
-
-from daydream.timeutil import parse_iso_timestamp
 from pathlib import Path
 from typing import Any, TypeGuard
 
 from daydream.pricing import ModelPrice, compute_cost, load_user_prices, resolve_prices
+from daydream.timeutil import parse_iso_timestamp
 
 # Judge-error guard from daydream/benchmark/score.py: above this ratio of failed
 # comparisons the tp/fp/fn collapse to noise, not a real zero.
@@ -208,7 +207,7 @@ def load_trajectories(traj_dir: Path, prices: dict[str, ModelPrice], price_model
         if len(stamps) >= 2:
             try:
                 wall = (parse_iso_timestamp(max(stamps)) - parse_iso_timestamp(min(stamps))).total_seconds()
-            except (ValueError, TypeError, AttributeError):
+            except ValueError:
                 pass
         pr_repo = (d.get("extra", {}) or {}).get("pr_repo", "")
         key = f"{pr_repo}/{num}" if pr_repo else f"{repo_short}/{num}"

--- a/bench/benchmark-report/build.py
+++ b/bench/benchmark-report/build.py
@@ -206,7 +206,10 @@ def load_trajectories(traj_dir: Path, prices: dict[str, ModelPrice], price_model
         if len(stamps) >= 2:
             def _p(s: str) -> datetime:
                 return datetime.fromisoformat(s.replace("Z", "+00:00"))
-            wall = (_p(max(stamps)) - _p(min(stamps))).total_seconds()
+            try:
+                wall = (_p(max(stamps)) - _p(min(stamps))).total_seconds()
+            except ValueError:
+                pass
         pr_repo = (d.get("extra", {}) or {}).get("pr_repo", "")
         key = f"{pr_repo}/{num}" if pr_repo else f"{repo_short}/{num}"
         if key in out:

--- a/tests/test_benchmark_report_build.py
+++ b/tests/test_benchmark_report_build.py
@@ -58,7 +58,7 @@ def _corpus(
     labels: dict[str, Any] | None = None,
 ) -> argparse.Namespace:
     """Minimal corpus. pr_trajectories maps PR url -> (filename, pr_repo, prompt,
-    completion, cached, steps, (start_iso, end_iso) | None). Omitted -> the existing
+    completion, cached, steps, (start_iso, ...) | None). Omitted -> the existing
     one-PR legacy corpus (cal.com-10600.json with no pr_repo)."""
     if pr_trajectories is None:
         pr_trajectories = {PR_URL: ("cal.com-10600.json", None, 1_000_000, 1_000_000, 1_000_000, 3, None)}

--- a/tests/test_benchmark_report_build.py
+++ b/tests/test_benchmark_report_build.py
@@ -53,7 +53,7 @@ _ANCHOR = "anthropic_claude-opus-4-5-20251101"  # -> display "Opus 4.5"
 def _corpus(
     root: Path,
     *,
-    pr_trajectories: dict[str, tuple[str, str | None, int, int, int, int, tuple[str, str] | None]] | None = None,
+    pr_trajectories: dict[str, tuple[str, str | None, int, int, int, int, tuple[str, ...] | None]] | None = None,
     judges: dict[str, dict[str, dict]] | None = None,
     labels: dict[str, Any] | None = None,
 ) -> argparse.Namespace:
@@ -172,6 +172,41 @@ def test_unknown_price_model_is_rejected(
     args.price_model = "no-such-model"
     with pytest.raises(SystemExit, match="unknown --price-model"):
         build_mod.build(args)
+
+
+def test_malformed_phase_event_timestamp_preserves_trajectory_metrics(
+    build_mod: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A malformed phase-event timestamp nulls only that trajectory's wall time;
+    its token counters and synthesized cost are retained in the report."""
+    monkeypatch.setenv("DAYDREAM_PRICES_FILE", str(tmp_path / "absent.toml"))
+    args = _corpus(
+        tmp_path,
+        pr_trajectories={
+            PR_URL: (
+                "cal.com-10600.json", None, 1_000_000, 1_000_000, 1_000_000, 3,
+                ("2026-01-01T00:00:00Z", "2026-01-01T00:02:00Z", "not-a-timestamp"),
+            ),
+        },
+    )
+    report = build_mod.build(args)  # must NOT raise
+
+    row = report["per_pr"][0]
+    assert row["wall_seconds"] is None
+    assert row["prompt_tokens"] == 1_000_000
+    assert row["completion_tokens"] == 1_000_000
+    assert row["cached_tokens"] == 1_000_000
+    assert row["cost_usd"] == pytest.approx(6.06)
+
+    eco = report["economy"]
+    assert eco["n_with_trajectory"] == 1
+    assert eco["n_with_wall"] == 0
+    assert eco["median_wall_seconds"] is None
+    assert eco["mean_wall_seconds"] is None
+    assert eco["total_prompt_tokens"] == 1_000_000
+    assert eco["total_completion_tokens"] == 1_000_000
+    assert eco["total_cached_tokens"] == 1_000_000
+    assert eco["total_cost_usd"] == pytest.approx(6.06)
 
 
 @pytest.mark.parametrize("incomplete_leaf", [None, {"skipped": True}], ids=["missing", "skipped"])


### PR DESCRIPTION
## Summary

Preserves benchmark report metrics when trajectory phase-event timestamps are malformed. Previously a bad timestamp raised inside the wall-time computation, dropping the whole trajectory's metrics from the report; now it nulls only that trajectory's wall time and retains its token counters and synthesized cost.

- Replace the inline timestamp parser with the shared `parse_iso_timestamp` from `daydream.timeutil`
- Guard the wall-time computation with a `ValueError` catch that falls back to a `None` wall time (comment documents the intentional fallback)
- Add a regression test covering the malformed-timestamp path: metrics preserved, `wall_seconds` null, economy aggregates consistent

## Test Plan
- New regression test `test_malformed_phase_event_timestamp_preserves_trajectory_metrics`
- Target test 20/20; full suite 3294 passed / 6 skipped / 0 failed (on review VM)
- ruff clean

Closes #407
