### PR TITLE
fix(rl): verify the pi package tarball checksum before install (Closes #405)

### DIFF
--- a/rl/daydream_review_v1/images/base.Dockerfile
+++ b/rl/daydream_review_v1/images/base.Dockerfile
@@ -150,7 +150,10 @@ RUN if [ "${INSTALL_CODEX}" = "1" ]; then \
 # used, not .tar.xz, so the base needs no xz-utils. The Node archive is
 # downloaded to a temp file and verified against a locally pinned SHA256 constant
 # (captured from v22.17.1's published signed SHASUMS256.txt at pin time) before it
-# is extracted.
+# is extracted. The pi package tarball is likewise downloaded to a temp file and
+# verified against a locally pinned SHA256 constant (captured from the npm
+# registry tarball at pin time) before npm installs it — no streaming install
+# from the registry whose bytes were never pinned.
 ARG INSTALL_PI=1
 ARG NODE_VERSION=22.17.1
 ARG PI_VERSION=0.82.1
@@ -167,7 +170,12 @@ RUN if [ "${INSTALL_PI}" = "1" ]; then \
       tar -xzf "${archive}" -C /usr/local --strip-components=1 \
           --exclude CHANGELOG.md --exclude LICENSE --exclude README.md; \
       rm "${archive}"; \
-      npm install -g --no-fund --no-audit "@earendil-works/pi-coding-agent@${PI_VERSION}"; \
+      pi_checksum=8343ab95cbab5766f2f5d48844df8db13e772ead2e2976166cbb820a29dacb7d; \
+      pi_tarball="/tmp/pi-coding-agent-${PI_VERSION}.tgz"; \
+      curl -fsSL "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-${PI_VERSION}.tgz" -o "${pi_tarball}"; \
+      printf '%s *%s\n' "${pi_checksum}" "${pi_tarball}" | sha256sum -c -; \
+      npm install -g --no-fund --no-audit "${pi_tarball}"; \
+      rm "${pi_tarball}"; \
       npm cache clean --force; \
       pi --version; \
     fi

--- a/rl/daydream_review_v1/tests/test_images.py
+++ b/rl/daydream_review_v1/tests/test_images.py
@@ -203,6 +203,14 @@ def test_base_dockerfile_pins_immutable_versions_and_checksums(
             ),
             id="node",
         ),
+        pytest.param(
+            (
+                "pi-coding-agent-${PI_VERSION}.tgz",  # pi package tarball download
+                "sha256sum -c -",                     # verify
+                "npm install -g",                     # install from verified tarball
+            ),
+            id="pi",
+        ),
     ],
 )
 def test_base_dockerfile_verifies_downloads_before_use(marker_chain: tuple[str, ...]) -> None:


### PR DESCRIPTION
## Summary

Closes issue #405 ("pin and verify every RL rollout image release download").

Main already merged #505/#506, which pin and verify the claude (via a gnupg
signed-manifest flow), codex, and node downloads in the rollout base image.
This PR adds the one download main still installs from the registry stream with
no integrity check: the **pi package tarball**.

- Fetch the pi tgz to /tmp and verify it against a pinned SHA256 constant
  (captured from the npm registry tarball at pin time) before installing.
- Install from the verified local tarball, never from a streamed npm install.
- Add a pi marker-chain to `test_base_dockerfile_verifies_downloads_before_use`
  so the new download-verify-install ordering is enforced by the static
  build-contract test.

## Test Plan
- `test_base_dockerfile_*` static contract tests: 16 passed (incl. new pi chain)
- ruff clean

Closes #405