### PR TITLE
Share the scorer judge-error ratio threshold with the benchmark report

### DIFF
--- a/bench/benchmark-report/build.py
+++ b/bench/benchmark-report/build.py
@@ -31,12 +31,9 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, TypeGuard
 
+from daydream.benchmark.score import JUDGE_ERROR_RATIO_THRESHOLD
 from daydream.pricing import ModelPrice, compute_cost, load_user_prices, resolve_prices
 from daydream.timeutil import parse_iso_timestamp
-
-# Judge-error guard from daydream/benchmark/score.py: above this ratio of failed
-# comparisons the tp/fp/fn collapse to noise, not a real zero.
-JUDGE_ERROR_RATIO_THRESHOLD = 0.5
 
 # Vendor prefixes the published SaaS field carries; the harness writes daydream
 # with no prefix. Stripping these collapses the two dirs onto one judge id.

--- a/daydream/benchmark/score.py
+++ b/daydream/benchmark/score.py
@@ -4,6 +4,7 @@ Exports:
     preflight_judge_env: Verify the route-specific judge credential/config is present.
     resolve_judge_model: Resolve the judge model from --model or the MARTIAN_MODEL env.
     model_results_dir: Resolve the per-model results directory for a benchmark repo.
+    JUDGE_ERROR_RATIO_THRESHOLD: The ratio of judge errors to comparisons at or above which a scoring run is treated as invalid.
     run_scoring: Run the selected judge route and parse the resulting daydream precision/recall.
     parse_daydream_scores: Extract per-PR and aggregate daydream scores from evaluations.
     DaydreamScores: Aggregated daydream scoring result.
@@ -53,7 +54,7 @@ _STDERR_TAIL = 4000
 #: credential, a model id the gateway does not recognize, a wrong base URL,
 #: timeouts); the real per-call message is surfaced in the raised error rather
 #: than guessed. Above this ratio the scores are noise, not a real zero.
-_JUDGE_ERROR_RATIO_THRESHOLD = 0.5
+JUDGE_ERROR_RATIO_THRESHOLD = 0.5
 
 #: Maximum wall-clock seconds to wait for each benchmark step subprocess.
 #: Step 3 calls an external judge API and can be slow; 30 minutes is generous.
@@ -78,7 +79,7 @@ class JudgeFailedError(Exception):
     The withmartian step3 records each failed judge LLM call as an error (storing
     the verbatim message in the leaf's ``errors`` list) and still exits 0, emitting
     an `evaluations.json` whose tp/fp/fn collapse to a clean-looking zero. This is
-    raised when the error ratio crosses `_JUDGE_ERROR_RATIO_THRESHOLD`, so a
+    raised when the error ratio crosses `JUDGE_ERROR_RATIO_THRESHOLD`, so a
     wholesale-failed judge surfaces loudly instead of as a genuine zero — and the
     message reports the actual recorded judge error, not a guessed cause.
     """
@@ -254,7 +255,7 @@ def parse_daydream_scores(
 
     Raises:
         JudgeFailedError: If the judge errored on at least
-            `_JUDGE_ERROR_RATIO_THRESHOLD` of all attempted comparisons — the
+            `JUDGE_ERROR_RATIO_THRESHOLD` of all attempted comparisons — the
             scores are then noise, not a real zero (see `JudgeFailedError`).
     """
     per_pr: dict[str, dict[str, Any]] = {}
@@ -285,7 +286,7 @@ def parse_daydream_scores(
         # attempted comparison count is the product (matches step3's task grid).
         total_comparisons += int(leaf.get("total_candidates", 0)) * int(leaf.get("total_golden", 0))
 
-    if total_comparisons and total_errors / total_comparisons >= _JUDGE_ERROR_RATIO_THRESHOLD:
+    if total_comparisons and total_errors / total_comparisons >= JUDGE_ERROR_RATIO_THRESHOLD:
         ratio = total_errors / total_comparisons
         if judge_errors:
             cause = f"The judge reported: {_summarize_judge_errors(judge_errors)}."

--- a/daydream/benchmark/score.py
+++ b/daydream/benchmark/score.py
@@ -4,7 +4,7 @@ Exports:
     preflight_judge_env: Verify the route-specific judge credential/config is present.
     resolve_judge_model: Resolve the judge model from --model or the MARTIAN_MODEL env.
     model_results_dir: Resolve the per-model results directory for a benchmark repo.
-    JUDGE_ERROR_RATIO_THRESHOLD: The ratio of judge errors to comparisons at or above which a scoring run is treated as invalid.
+    JUDGE_ERROR_RATIO_THRESHOLD: ratio of judge errors to comparisons at or above which a scoring run is invalid.
     run_scoring: Run the selected judge route and parse the resulting daydream precision/recall.
     parse_daydream_scores: Extract per-PR and aggregate daydream scores from evaluations.
     DaydreamScores: Aggregated daydream scoring result.

--- a/tests/test_benchmark_report_build.py
+++ b/tests/test_benchmark_report_build.py
@@ -1,5 +1,4 @@
-"""Price resolution and evidence-derived improvement recommendations in
-the offline benchmark report generator (bench/benchmark-report/build.py)."""
+"""Tests for the offline benchmark report generator in bench/benchmark-report/build.py."""
 
 from __future__ import annotations
 
@@ -13,6 +12,8 @@ from types import ModuleType
 from typing import Any
 
 import pytest
+
+from daydream.benchmark.score import JUDGE_ERROR_RATIO_THRESHOLD
 
 BUILD_PY = Path(__file__).resolve().parents[1] / "bench" / "benchmark-report" / "build.py"
 
@@ -133,6 +134,25 @@ def _comparison_corpus(root: Path, incomplete_leaf: dict[str, Any] | None) -> ar
     judge = root / "results" / _JUDGE_DIRNAME
     (judge / "evaluations.json").write_text(json.dumps({PR_URL: pr1, SECOND_PR_URL: pr2}))
     return args
+
+
+@pytest.mark.parametrize(
+    ("errors_count", "expected_invalid"),
+    [pytest.param(49, False, id="below-threshold"),
+     pytest.param(50, True, id="at-threshold")],
+)
+def test_aggregate_tool_uses_shared_judge_error_ratio_threshold(
+    build_mod: ModuleType, errors_count: int, expected_invalid: bool,
+) -> None:
+    evals = {PR_URL: {"candidate-tool": {
+        "tp": 0, "fp": 0, "fn": 0,
+        "errors_count": errors_count,
+        "total_candidates": 100, "total_golden": 1,
+        "false_positives": [],
+    }}}
+    row = build_mod.aggregate_tool(evals, "candidate-tool", {PR_URL})
+    assert row is not None and row["invalid"] is expected_invalid
+    assert build_mod.JUDGE_ERROR_RATIO_THRESHOLD == JUDGE_ERROR_RATIO_THRESHOLD
 
 
 def test_price_card_comes_from_shared_pricing_table(


### PR DESCRIPTION
## Summary

Share the scorer's judge-error ratio threshold with the benchmark report generator, removing the duplicated magic constant.

- **`daydream/benchmark/score.py`** — promote `_JUDGE_ERROR_RATIO_THRESHOLD` (0.5) to a public `JUDGE_ERROR_RATIO_THRESHOLD` constant and update all internal references.
- **`bench/benchmark-report/build.py`** — import the shared constant from the scorer instead of re-defining a private copy.
- **`tests/test_benchmark_report_build.py`** — add a parametrized boundary test (below / at threshold) asserting the report's aggregate tool uses the exact same shared constant.

## Test Plan
- [x] Unit tests pass (boundary at exactly 50% errors → invalid; below → valid)
- [x] No duplication of the threshold constant across the codebase

Closes #412