### PR TITLE
Resolve Python parent-relative and bare-relative imports in exploration

### DIFF
--- a/daydream/tree_sitter_index.py
+++ b/daydream/tree_sitter_index.py
@@ -211,6 +211,14 @@ def _parse_diff_name_status(diff_text: str) -> list[_DiffEntry]:
 # --- Import resolution -------------------------------------------------------
 
 
+def _module_candidates(base: Path, dotted: str) -> list[Path]:
+    """Resolve a dotted module name under `base` to .py and package candidates."""
+    target = base
+    for part in dotted.split("."):
+        target = target / part
+    return [target.with_suffix(".py"), target / "__init__.py"]
+
+
 def _resolve_python_import(import_str: str, repo_root: Path, importer: Path) -> list[Path]:
     candidates: list[Path] = []
     if import_str.startswith("from "):
@@ -230,31 +238,19 @@ def _resolve_python_import(import_str: str, repo_root: Path, importer: Path) -> 
         for _ in range(node.level - 1):
             base = base.parent
         if node.module is not None:
-            target = base
-            for part in node.module.split("."):
-                target = target / part
-            candidates.extend([target.with_suffix(".py"), target / "__init__.py"])
+            candidates.extend(_module_candidates(base, node.module))
         else:
             candidates.append(base / "__init__.py")
             for alias in node.names:
                 if alias.name == "*":
                     continue
-                target = base
-                for part in alias.name.split("."):
-                    target = target / part
-                candidates.extend([target.with_suffix(".py"), target / "__init__.py"])
+                candidates.extend(_module_candidates(base, alias.name))
     else:
         parts = import_str.split(".")
-        target = repo_root
-        for part in parts:
-            target = target / part
-        candidates.extend([target.with_suffix(".py"), target / "__init__.py"])
+        candidates.extend(_module_candidates(repo_root, import_str))
         # Also try resolving the parent (e.g. `from foo.bar import baz`).
         if len(parts) >= 2:
-            parent = repo_root
-            for part in parts[:-1]:
-                parent = parent / part
-            candidates.extend([parent.with_suffix(".py"), parent / "__init__.py"])
+            candidates.extend(_module_candidates(repo_root, ".".join(parts[:-1])))
     return [c for c in candidates if c.exists() and c.is_file()]
 
 

--- a/daydream/tree_sitter_index.py
+++ b/daydream/tree_sitter_index.py
@@ -13,6 +13,7 @@ Adding a new language requires only:
 
 from __future__ import annotations
 
+import ast
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable
@@ -99,7 +100,7 @@ def get_parser(language_id: str) -> Parser | None:
 PYTHON_IMPORT_QUERY = """
 (import_statement name: (dotted_name) @import)
 (import_from_statement module_name: (dotted_name) @import)
-(import_from_statement module_name: (relative_import) @import)
+(import_from_statement module_name: (relative_import)) @import
 """
 
 TYPESCRIPT_IMPORT_QUERY = """
@@ -212,19 +213,36 @@ def _parse_diff_name_status(diff_text: str) -> list[_DiffEntry]:
 
 def _resolve_python_import(import_str: str, repo_root: Path, importer: Path) -> list[Path]:
     candidates: list[Path] = []
-    if import_str.startswith("."):
-        # Relative import; ascend N-1 package levels for N leading dots,
-        # then resolve the remaining path against that ancestor.
-        relative_level = len(import_str) - len(import_str.lstrip("."))
+    if import_str.startswith("from "):
+        # Relative component of a `from` statement; parse it to read the
+        # ImportFrom level (ascent) and retained aliases (bare-relative names).
+        # Best-effort: malformed/unsupported captures degrade to no candidates.
+        try:
+            body = ast.parse(import_str).body
+        except SyntaxError:
+            return []
+        if len(body) != 1 or not isinstance(body[0], ast.ImportFrom):
+            return []
+        node = body[0]
+        if node.level < 1:
+            return []
         base = importer.parent
-        for _ in range(relative_level - 1):
+        for _ in range(node.level - 1):
             base = base.parent
-        cleaned = import_str[relative_level:]
-        parts = cleaned.split(".") if cleaned else []
-        target = base
-        for part in parts:
-            target = target / part
-        candidates.extend([target.with_suffix(".py"), target / "__init__.py"])
+        if node.module is not None:
+            target = base
+            for part in node.module.split("."):
+                target = target / part
+            candidates.extend([target.with_suffix(".py"), target / "__init__.py"])
+        else:
+            candidates.append(base / "__init__.py")
+            for alias in node.names:
+                if alias.name == "*":
+                    continue
+                target = base
+                for part in alias.name.split("."):
+                    target = target / part
+                candidates.extend([target.with_suffix(".py"), target / "__init__.py"])
     else:
         parts = import_str.split(".")
         target = repo_root

--- a/tests/test_tree_sitter_index.py
+++ b/tests/test_tree_sitter_index.py
@@ -91,8 +91,9 @@ _SHARED_FIXTURES: dict[str, str] = {
             "package/models.py",
         ),
         # `from . import something` resolves to the current package's __init__.py
-        # because tree-sitter captures only the relative import node (the dot),
-        # not the imported name after the dot.
+        # AND the sibling module package/feature/something.py, because the
+        # capture now spans the whole statement, not just the relative import
+        # node (the dot).
         (
             "package/feature/api.py",
             _SHARED_FIXTURES
@@ -100,8 +101,9 @@ _SHARED_FIXTURES: dict[str, str] = {
                 "package/feature/api.py": (
                     '"""API module."""\nfrom . import something\n\nthing = something.thing\n'
                 ),
+                "package/feature/something.py": "",
             },
-            "package/feature/__init__.py",
+            {"package/feature/__init__.py", "package/feature/something.py"},
         ),
         # `from ....something import name` with 4+ dots ascends to the great-grandparent package.
         (
@@ -120,12 +122,15 @@ _SHARED_FIXTURES: dict[str, str] = {
     ],
 )
 def test_python_multilevel_relative_imports(
-    tmp_path: Path, api_rel: str, files: dict[str, str], expected_import_path: str
+    tmp_path: Path, api_rel: str, files: dict[str, str], expected_import_path: str | set[str]
 ):
     repo = _materialize(tmp_path, files)
     results = detect_affected_files(_modified_diff(api_rel), repo, depth=1)
     imports_pairs = {(r.path, r.role) for r in results if r.role == "imports"}
-    assert imports_pairs == {(expected_import_path, "imports")}
+    if isinstance(expected_import_path, str):
+        assert imports_pairs == {(expected_import_path, "imports")}
+    else:
+        assert imports_pairs == {(p, "imports") for p in expected_import_path}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_tree_sitter_index.py
+++ b/tests/test_tree_sitter_index.py
@@ -128,6 +128,48 @@ def test_python_multilevel_relative_imports(
     assert imports_pairs == {(expected_import_path, "imports")}
 
 
+@pytest.mark.parametrize(
+    "api_rel, files, expected_import_paths",
+    [
+        # R2 regression pin: `from ..models` in package/feature/api.py resolves
+        # to the parent package's models module. Already works on main after
+        # #390; pinned so it cannot regress.
+        (
+            "package/feature/api.py",
+            _SHARED_FIXTURES
+            | {
+                "package/feature/api.py": (
+                    '"""API module."""\nfrom ..models import User\n\ndef get_user():\n    return User()\n'
+                ),
+            },
+            {"package/models.py"},
+        ),
+        # R3 primary fix: `from .. import services` in package/feature/api.py
+        # resolves to BOTH the parent package __init__.py AND the imported
+        # sibling package's __init__.py — and must NOT include the importer's
+        # own package/feature/__init__.py (C3).
+        (
+            "package/feature/api.py",
+            _SHARED_FIXTURES
+            | {
+                "package/services/__init__.py": "",
+                "package/feature/api.py": (
+                    '"""API module."""\nfrom .. import services\n'
+                ),
+            },
+            {"package/__init__.py", "package/services/__init__.py"},
+        ),
+    ],
+)
+def test_python_parent_relative_imports(
+    tmp_path: Path, api_rel: str, files: dict[str, str], expected_import_paths: set[str]
+):
+    repo = _materialize(tmp_path, files)
+    results = detect_affected_files(_modified_diff(api_rel), repo, depth=1)
+    imports_paths = {r.path for r in results if r.role == "imports"}
+    assert imports_paths == expected_import_paths
+
+
 def test_typescript_impact_surface(tmp_path: Path):
     diff_text = (FIXTURES / "typescript_multifile.diff").read_text()
     repo = _materialize(


### PR DESCRIPTION
Fixes #414

## Summary
- Resolve parent-relative Python imports in the tree-sitter index
- Extract module candidate resolution into a helper
- Add tests for parent-relative and bare-relative import resolution

Closes #414