### PR TITLE
fix(rl): reject unknown keys in RL image manifests

### DIFF
--- a/rl/daydream_review_v1/daydream_review_v1/taskset.py
+++ b/rl/daydream_review_v1/daydream_review_v1/taskset.py
@@ -27,7 +27,7 @@ from daydream.benchmark.corpus import harvested_corpus
 from daydream.training.exclusion import load_exclusion_list
 from daydream.training.harvest import assemble_scoring_inputs
 from daydream.training.reward import score_trajectory
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from daydream_review_v1.rundir import DEFAULT_ARCHIVE_ROOT, fetch_run_dir
 
@@ -339,6 +339,7 @@ class DaydreamReviewConfig(vf.TasksetConfig):
 
 
 class _ManifestEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     clone_url: str
     image: str
     test_command: str

--- a/rl/daydream_review_v1/daydream_review_v1/taskset.py
+++ b/rl/daydream_review_v1/daydream_review_v1/taskset.py
@@ -156,6 +156,7 @@ class GoldenComment(BaseModel):
     Used only for the non-summed ``golden_overlap`` metric — never a reward.
     """
 
+    model_config = ConfigDict(extra="forbid")
     comment: str
     path: str | None = None
     line: int | None = None

--- a/rl/daydream_review_v1/tests/test_taskset.py
+++ b/rl/daydream_review_v1/tests/test_taskset.py
@@ -21,6 +21,7 @@ from daydream_review_v1.fixture import (
 from daydream_review_v1.taskset import (
     DaydreamReviewConfig,
     DaydreamReviewTaskset,
+    GoldenComment,
     load_manifest,
 )
 
@@ -261,6 +262,21 @@ def test_load_manifest_rejects_unknown_key(tmp_path: Path) -> None:
     with pytest.raises(ValidationError) as excinfo:
         load_manifest(manifest)
     assert ("extra_forbidden", ("setp_cmds",)) in [
+        (err["type"], err["loc"]) for err in excinfo.value.errors()
+    ]
+
+
+def test_golden_comment_rejects_unknown_key() -> None:
+    """A misspelled/extra key in benchmark_data.json must not be silently dropped.
+
+    GoldenComment parses user-supplied corpus data (harvested upstream review
+    comments). Rejecting unknown keys mirrors the extra="forbid" guard on
+    _ManifestEntry so schema drift in the corpus fails loudly instead of being
+    silently ignored.
+    """
+    with pytest.raises(ValidationError) as excinfo:
+        GoldenComment(comment="looks good", typo_field="nope")
+    assert ("extra_forbidden", ("typo_field",)) in [
         (err["type"], err["loc"]) for err in excinfo.value.errors()
     ]
 

--- a/rl/daydream_review_v1/tests/test_taskset.py
+++ b/rl/daydream_review_v1/tests/test_taskset.py
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from daydream_review_v1.fixture import (
     FIXTURE_BASE_SHA,
@@ -17,7 +18,11 @@ from daydream_review_v1.fixture import (
     FIXTURE_TEST_COMMAND,
     build_fixture_repo,
 )
-from daydream_review_v1.taskset import DaydreamReviewConfig, DaydreamReviewTaskset
+from daydream_review_v1.taskset import (
+    DaydreamReviewConfig,
+    DaydreamReviewTaskset,
+    load_manifest,
+)
 
 
 def _write_corpus(root: Path, repo: str, prs: list[dict[str, object]]) -> Path:
@@ -243,6 +248,21 @@ def test_load_rejects_missing_manifest_entry(tmp_path: Path) -> None:
         list(taskset.load())
     assert "acme/widgets" in str(excinfo.value)
     assert "manifest" in str(excinfo.value).lower()
+
+
+def test_load_manifest_rejects_unknown_key(tmp_path: Path) -> None:
+    """A misspelled optional key (setp_cmds) fails load_manifest, naming the key."""
+    manifest = _write_manifest(tmp_path / "manifest.toml", ["acme/widgets"])
+    manifest.write_text(
+        manifest.read_text(encoding="utf-8") + 'setp_cmds = ["true"]\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValidationError) as excinfo:
+        load_manifest(manifest)
+    assert ("extra_forbidden", ("setp_cmds",)) in [
+        (err["type"], err["loc"]) for err in excinfo.value.errors()
+    ]
 
 
 def test_load_rejects_record_without_base_sha(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Reject unknown keys in RL image manifests (and forbid extra fields on the GoldenComment model) so malformed/unknown config keys are surfaced as errors instead of silently ignored.

Closes #415

## Test Plan
- [x] Unit tests pass
- [x] Two sequential daydream deep-precision reviews passed (round 1 + round 2)