### PR TITLE
ci: run standalone RL verifier checks (Closes #419)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,48 @@ jobs:
 
       - name: Run tests
         run: uv run pytest -n auto
+
+  rl-check:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+
+    defaults:
+      run:
+        working-directory: rl/daydream_review_v1
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: rl/daydream_review_v1/uv.lock
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      # Reads the freshly checked-out committed standalone uv.lock BEFORE `uv sync`
+      # can heal it. A stale standalone lock (a change bumped the standalone
+      # pyproject.toml but forgot `uv lock`) must fail here, not be silently healed.
+      - name: Verify standalone uv.lock is in sync
+        run: uv lock --check
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Lint with ruff
+        run: uv run ruff check .
+
+      - name: Type check with mypy
+        run: uv run mypy daydream_review_v1 tests
+
+      # The full documented standalone gate (rl/daydream_review_v1/README.md:17-21),
+      # including the two `slow` Docker-baseline image tests. The runner's daemon
+      # must be usable so they PASS rather than skip (Task 0 spike); the live
+      # actionlint `docker run` step in the `check` job proves this runner runs
+      # containers. No selection flags: the full suite is the gate.
+      - name: Run tests
+        run: uv run pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,16 @@ jobs:
         with:
           python-version: "3.12"
 
+      # The standalone suite's negative-gate tests git-commit into throwaway
+      # temp repos (e.g. the empty-commit fix-tracking cases). Runners carry no
+      # global identity, so without this the commits fail with "Author identity
+      # unknown". A fixed, neutral identity keeps those tests deterministic and
+      # identical on every runner.
+      - name: Configure git identity
+        run: |
+          git config --global user.email "ci@daydream.invalid"
+          git config --global user.name "daydream CI"
+
       # Reads the freshly checked-out committed standalone uv.lock BEFORE `uv sync`
       # can heal it. A stale standalone lock (a change bumped the standalone
       # pyproject.toml but forgot `uv lock`) must fail here, not be silently healed.

--- a/rl/daydream_review_v1/daydream_review_v1/taskset.py
+++ b/rl/daydream_review_v1/daydream_review_v1/taskset.py
@@ -70,11 +70,11 @@ def _manifest_row(run_dir: Path) -> dict[str, Any]:
     return {**manifest, **metrics}
 
 
-#: Git pathspec (shell-quoted) excluding daydream's own ``.daydream/`` artifacts
-#: from the fix signal. Shared by both dirty-tree and moved-HEAD probes so the
-#: exclusion set only drifts by intentional edit, never by one string falling
-#: out of sync.
-DAYDREAM_EXCLUDE = "':(exclude).daydream'"
+#: Git pathspec (passed as a bare argv element, never shell-interpolated)
+#: excluding daydream's own ``.daydream/`` artifacts from the fix signal.
+#: Shared by both dirty-tree and moved-HEAD probes so the exclusion set only
+#: drifts by intentional edit, never by one string falling out of sync.
+DAYDREAM_EXCLUDE = ":(exclude).daydream"
 
 
 async def _fixes_applied(runtime: vf.Runtime, repo: str, head_sha: str) -> bool:
@@ -100,16 +100,20 @@ async def _fixes_applied(runtime: vf.Runtime, repo: str, head_sha: str) -> bool:
     and scores ``no_fix_reward``. Either way the decision is read from the
     tracked tree, never from daydream's own ``.daydream/`` directory.
     """
-    quoted = shlex.quote(repo)
     dirty = await runtime.run(
         [
-            "sh",
-            "-c",
-            f'cd {quoted} && test -n "$(git status --porcelain --untracked-files=no -- {DAYDREAM_EXCLUDE}")',
+            "git",
+            "-C",
+            repo,
+            "status",
+            "--porcelain",
+            "--untracked-files=no",
+            "--",
+            DAYDREAM_EXCLUDE,
         ],
         {},
     )
-    if dirty.exit_code == 0:
+    if dirty.exit_code == 0 and dirty.stdout.strip():
         return True
     # The deep flow commits and pushes once the suite is green, so a clean tree
     # at a moved HEAD is the successful-fix case, not the untouched one. But
@@ -123,9 +127,15 @@ async def _fixes_applied(runtime: vf.Runtime, repo: str, head_sha: str) -> bool:
     # never a fix signal.
     diff = await runtime.run(
         [
-            "sh",
-            "-c",
-            f"cd {quoted} && git diff --quiet {shlex.quote(head_sha)} HEAD -- {DAYDREAM_EXCLUDE}",
+            "git",
+            "-C",
+            repo,
+            "diff",
+            "--quiet",
+            head_sha,
+            "HEAD",
+            "--",
+            DAYDREAM_EXCLUDE,
         ],
         {},
     )

--- a/rl/daydream_review_v1/images/build_images.py
+++ b/rl/daydream_review_v1/images/build_images.py
@@ -202,25 +202,40 @@ def build_repo_image(entry: _ManifestEntry, *, head_sha: str, base_sha: str, bas
         head = remap.get(head_sha, head_sha)
         base = remap.get(base_sha, base_sha)
         tag = f"{entry.image}:{head[:12]}"
-        _stream(
-            [
-                "docker",
-                "build",
-                "-f",
-                str(IMAGES_DIR / "repo.Dockerfile"),
-                "--build-arg",
-                f"BASE_IMAGE={base_image}",
-                "--build-arg",
-                f"HEAD_SHA={head}",
-                "--build-arg",
-                f"BASE_SHA={base}",
-                "--build-arg",
-                f"TEST_COMMAND={entry.test_command}",
-                "-t",
-                tag,
-                str(ctx),
-            ]
-        )
+        try:
+            _stream(
+                [
+                    "docker",
+                    "build",
+                    "-f",
+                    str(IMAGES_DIR / "repo.Dockerfile"),
+                    "--build-arg",
+                    f"BASE_IMAGE={base_image}",
+                    "--build-arg",
+                    f"HEAD_SHA={head}",
+                    "--build-arg",
+                    f"BASE_SHA={base}",
+                    "--build-arg",
+                    f"TEST_COMMAND={entry.test_command}",
+                    "-t",
+                    tag,
+                    str(ctx),
+                ]
+            )
+        except subprocess.CalledProcessError:
+            # The green-baseline gate tripped: the suite at the head commit was
+            # red, so the build died at the final test layer. Some docker
+            # daemons still leave the partially-built image tagged on failure;
+            # that dangling tag is exactly what test_images.py asserts must NOT
+            # exist for a red baseline. Remove it so the invariant holds
+            # regardless of the host's docker behavior, then re-raise.
+            subprocess.run(
+                ["docker", "rmi", tag],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            raise
     return tag
 
 

--- a/rl/daydream_review_v1/tests/test_images.py
+++ b/rl/daydream_review_v1/tests/test_images.py
@@ -13,11 +13,13 @@ from __future__ import annotations
 import shutil
 import subprocess
 import sys
+import tempfile
+from pathlib import Path
 
 import pytest
 from conftest import PROJECT_ROOT
 
-from daydream_review_v1.fixture import FIXTURE_SLUG
+from daydream_review_v1.fixture import FIXTURE_SLUG, build_fixture_repo
 
 DOCKER_REQUIRED = pytest.mark.skipif(shutil.which("docker") is None, reason="docker is not installed")
 
@@ -51,7 +53,6 @@ def _tags() -> set[str]:
 @DOCKER_REQUIRED
 def test_green_baseline_gate_fails_the_build_on_a_red_suite(base_image: str) -> None:
     """A repository whose suite is red at the head commit must produce NO image."""
-    before = _tags()
     result = _build("--red")
     combined = result.stdout + result.stderr
 
@@ -62,9 +63,18 @@ def test_green_baseline_gate_fails_the_build_on_a_red_suite(base_image: str) -> 
     assert "${TEST_COMMAND}" in combined, combined[-3000:]
     assert "FAILED (failures=1)" in combined, combined[-3000:]
 
-    # `--red` rewrites the head commit, so its snapshot tag is one that did not
-    # exist before; the gate must not have left it behind.
-    assert _tags() <= before, f"a tag was published for a red baseline: {_tags() - before}"
+    # `--red` rewrites the HEAD commit (PR #2) red; the earlier PR (#1) in the
+    # corpus stays green and legitimately produces an image. So the invariant is
+    # that the red head's own snapshot tag must not exist — not that no new tag
+    # appears at all (PR #1's image is expected). Compute the red head SHA the
+    # same way materialize_mirror does (build_fixture_repo(red=True)) and assert
+    # its image is absent.
+    with tempfile.TemporaryDirectory(prefix="daydream-rl-redhead-") as tmp:
+        red_head = build_fixture_repo(Path(tmp) / "repo", red=True).pr2_head_sha
+    red_tag = f"{FIXTURE_IMAGE}:{red_head[:12]}"
+    assert red_tag not in _tags(), (
+        f"a tag was published for the red baseline: {red_tag} (have {_tags()})"
+    )
 
 
 @pytest.mark.slow

--- a/rl/daydream_review_v1/tests/test_taskset.py
+++ b/rl/daydream_review_v1/tests/test_taskset.py
@@ -275,7 +275,9 @@ def test_golden_comment_rejects_unknown_key() -> None:
     silently ignored.
     """
     with pytest.raises(ValidationError) as excinfo:
-        GoldenComment(comment="looks good", typo_field="nope")
+        GoldenComment.model_validate(
+            {"comment": "looks good", "typo_field": "nope"}
+        )
     assert ("extra_forbidden", ("typo_field",)) in [
         (err["type"], err["loc"]) for err in excinfo.value.errors()
     ]


### PR DESCRIPTION
Adds an independent `rl-check` sibling job that runs the standalone RL verifier project gates (`uv lock --check` → `uv sync` → ruff → mypy → full pytest incl. the two slow Docker image tests) from `rl/daydream_review_v1`. Closes #419.