### PR TITLE
fix(rl): require a fixture target for --red baseline-gate proofs (Closes #416)

### DIFF
--- a/rl/daydream_review_v1/README.md
+++ b/rl/daydream_review_v1/README.md
@@ -96,8 +96,13 @@ baseline against a pi-scaffold trained run moves two variables at once.
    ```bash
    uv run python images/build_images.py --corpus ./corpus-train
    uv run python images/build_images.py --only OWNER/REPO      # one repo
-   uv run python images/build_images.py --red                  # prove the gate fails
+   uv run python images/build_images.py --red --only existential-birds/daydream-rl-fixture  # prove the gate fails (requires a fixture PR selected)
    ```
+
+   ``--red`` requires at least one selected fixture PR (``fixture://daydream-rl-fixture``)
+   and refuses ``--base-only``; both refusals exit status 2 before any build. Mixed
+   selections are accepted but non-fixture repositories in them are never mutated
+   by ``--red``.
 
 ## Running an eval
 

--- a/rl/daydream_review_v1/images/build_images.py
+++ b/rl/daydream_review_v1/images/build_images.py
@@ -41,6 +41,7 @@ from daydream_review_v1.fixture import (
     FIXTURE_BASE_SHA,
     FIXTURE_PR1_HEAD_SHA,
     FIXTURE_PR2_HEAD_SHA,
+    FIXTURE_SLUG,
     build_fixture_repo,
 )
 
@@ -239,6 +240,10 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
+    if args.red and args.base_only:
+        print("--red cannot be combined with --base-only", file=sys.stderr)
+        return 2
+
     if args.base_only:
         return _build_base()
 
@@ -248,6 +253,19 @@ def main(argv: list[str] | None = None) -> int:
         prs = [pr for pr in prs if _repo_slug(pr.clone_url) == args.only]
         if not prs:
             print(f"no PR in {args.corpus} belongs to {args.only}", file=sys.stderr)
+            return 2
+
+    if args.red:
+        fixture_selected = (
+            FIXTURE_SLUG in manifest
+            and manifest[FIXTURE_SLUG].clone_url == FIXTURE_CLONE_URL
+            and any(_repo_slug(pr.clone_url) == FIXTURE_SLUG for pr in prs)
+        )
+        if not fixture_selected:
+            print(
+                "--red requires at least one selected fixture PR backed by fixture://daydream-rl-fixture",
+                file=sys.stderr,
+            )
             return 2
 
     if args.no_base:

--- a/rl/daydream_review_v1/images/build_images.py
+++ b/rl/daydream_review_v1/images/build_images.py
@@ -24,6 +24,11 @@ Usage::
 
 ``--red`` is the gate's own test: it plants a failing assertion in the fixture
 repository's head commit and expects the build to die at the final layer.
+
+Exit codes:
+    0 — all requested images built successfully.
+    1 — one or more images failed to build (Docker, test suite, or setup error).
+    2 — invalid arguments or configuration (refused to run).
 """
 
 from __future__ import annotations
@@ -188,6 +193,31 @@ def materialize_mirror(entry: _ManifestEntry, ctx: Path, *, red: bool) -> dict[s
     }
 
 
+def _validate_red_flags(*, red: bool, base_only: bool, manifest: dict[str, _ManifestEntry], prs: list) -> int | None:
+    """Validate ``--red`` constraints before any build starts.
+
+    Returns ``None`` when the flags are valid, or an exit code (2) when
+    a constraint is violated.
+    """
+    if red and base_only:
+        print("--red cannot be combined with --base-only", file=sys.stderr)
+        return 2
+
+    if red:
+        fixture_selected = (
+            FIXTURE_SLUG in manifest
+            and manifest[FIXTURE_SLUG].clone_url == FIXTURE_CLONE_URL
+            and any(_repo_slug(pr.clone_url) == FIXTURE_SLUG for pr in prs)
+        )
+        if not fixture_selected:
+            print(
+                "--red requires at least one selected fixture PR backed by " + FIXTURE_CLONE_URL,
+                file=sys.stderr,
+            )
+            return 2
+    return None
+
+
 def build_repo_image(entry: _ManifestEntry, *, head_sha: str, base_sha: str, base_image: str, red: bool) -> str:
     """Build one PR-snapshot image and return the tag it was given.
 
@@ -255,18 +285,9 @@ def main(argv: list[str] | None = None) -> int:
             print(f"no PR in {args.corpus} belongs to {args.only}", file=sys.stderr)
             return 2
 
-    if args.red:
-        fixture_selected = (
-            FIXTURE_SLUG in manifest
-            and manifest[FIXTURE_SLUG].clone_url == FIXTURE_CLONE_URL
-            and any(_repo_slug(pr.clone_url) == FIXTURE_SLUG for pr in prs)
-        )
-        if not fixture_selected:
-            print(
-                "--red requires at least one selected fixture PR backed by " + FIXTURE_CLONE_URL,
-                file=sys.stderr,
-            )
-            return 2
+    red_status = _validate_red_flags(red=args.red, base_only=args.base_only, manifest=manifest, prs=prs)
+    if red_status is not None:
+        return red_status
 
     if args.no_base:
         print(f"skipping base build; reusing {BASE_LATEST}")

--- a/rl/daydream_review_v1/images/build_images.py
+++ b/rl/daydream_review_v1/images/build_images.py
@@ -263,7 +263,7 @@ def main(argv: list[str] | None = None) -> int:
         )
         if not fixture_selected:
             print(
-                "--red requires at least one selected fixture PR backed by fixture://daydream-rl-fixture",
+                "--red requires at least one selected fixture PR backed by " + FIXTURE_CLONE_URL,
                 file=sys.stderr,
             )
             return 2

--- a/rl/daydream_review_v1/tests/test_images.py
+++ b/rl/daydream_review_v1/tests/test_images.py
@@ -2,10 +2,12 @@
 
 Two kinds of contract live here. The static ``base.Dockerfile`` checks run with
 no Docker at all — they assert the build pins every remote input to an immutable
-version and verifies it for integrity before use. The two ``slow`` tests execute
-real Docker builds for the red and green baseline paths: a repo whose suite is
-red at the head commit must produce no image, while a green one builds and bakes
-the checkout.
+version and verifies it for integrity before use. A **fast** tier — no Docker
+required — rejects ``--red`` invocations that cannot select the fixture repo,
+ensuring the guard fires before any build side-effect. The two ``slow`` tests
+execute real Docker builds for the red and green baseline paths: the red path
+plants a failing assertion and the build must die (enforcement IS the build
+failing), while a green one builds and bakes the checkout.
 """
 
 from __future__ import annotations
@@ -18,6 +20,7 @@ import pytest
 from conftest import PROJECT_ROOT
 
 from daydream_review_v1.fixture import FIXTURE_SLUG
+from images import build_images
 
 DOCKER_REQUIRED = pytest.mark.skipif(shutil.which("docker") is None, reason="docker is not installed")
 
@@ -45,6 +48,42 @@ def _tags() -> set[str]:
         check=False,
     )
     return {line.strip() for line in listed.stdout.splitlines() if line.strip()}
+
+
+@pytest.mark.parametrize(
+    "argv,expected_stderr",
+    [
+        pytest.param(
+            ["--red", "--base-only"],
+            "--red cannot be combined with --base-only",
+            id="base-only",
+        ),
+        pytest.param(
+            [
+                "--red",
+                "--corpus",
+                str(PROJECT_ROOT / "tests" / "fixtures" / "corpus-reference"),
+                "--only",
+                "pallets/itsdangerous",
+            ],
+            "--red requires at least one selected fixture PR backed by fixture://daydream-rl-fixture",
+            id="non-fixture-only",
+        ),
+    ],
+)
+def test_red_rejects_invocations_without_fixture(
+    argv: list[str], expected_stderr: str, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """--red must fail fast (status 2) when no fixture PR is selected, before any build."""
+    monkeypatch.setattr(build_images, "_build_base", lambda: 0)
+    monkeypatch.setattr(build_images, "_stream", lambda *args, **kwargs: None)
+
+    status = build_images.main(argv)
+    captured = capsys.readouterr()
+
+    assert status == 2
+    assert captured.out == ""
+    assert captured.err == f"{expected_stderr}\n"
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Summary

Closes #416 — require a fixture target for `--red` baseline-gate proofs.

The image-builder CLI forwarded `--red` to every selected repository even though
`materialize_mirror` mutates only the deterministic fixture. A non-fixture
selection could finish with exit status 0 without creating a red test suite,
letting an operator mistake an unrelated successful build for proof that the
green-baseline gate rejects failing tests.

## Changes

- **`rl/daydream_review_v1/images/build_images.py`** — `main()` now returns
  status 2 before any image build when `--red` is combined with `--base-only`,
  and when the selected PRs contain no canonical fixture backed by
  `FIXTURE_CLONE_URL`. Mixed selections containing the fixture continue to the
  existing build loop; non-fixture repositories are not mutated by `--red`.
  `_validate_red_flags()` helper + documented exit codes 0/1/2 (from round-2
  review).
- **`rl/daydream_review_v1/tests/test_images.py`** — added fast parameterized
  regression `test_red_rejects_invocations_without_fixture` (base-only and
  non-fixture-only rows); Docker skip moved to the two slow gate tests; opening
  docstring now names both test tiers.
- **`rl/daydream_review_v1/README.md`** — documents `--red` as fixture-selection
  only and both status-2 rejection cases.

## Test Plan

- `uv run pytest tests/test_images.py::test_red_rejects_invocations_without_fixture` — passes
- Full RL pytest suite: `test_images.py` 20/20 passed (Docker slow tests retain skip behavior when Docker absent)
- `uv run ruff check .` — clean
- `uv lock --check` — no drift

Closes #416
