### PR TITLE
fix(bench): render zero-candidate benchmark reports as an empty-findings state

### DIFF
--- a/bench/benchmark-report/template.html
+++ b/bench/benchmark-report/template.html
@@ -318,11 +318,13 @@ function renderKPIs(){
     return;
   }
   const d=j.daydream,rk=j.ranks;
+  const totalFindings=d.tp+d.fp;
+  const fpRatioText=totalFindings===0?"0 findings flagged":`${d.n_prs} PRs · ${(d.fp/d.tp).toFixed(1)}× FP:TP`;
   const cards=[
     {cls:"",label:"Precision",val:pct(d.precision)+"%",rank:`rank #${rk.precision[0]} / ${rk.precision[1]}`,rc:rankClass(rk.precision[0],rk.precision[1]),sub:`${d.tp} TP / ${d.tp+d.fp} flagged`},
     {cls:"mint",label:"Recall",val:pct(d.recall)+"%",rank:`rank #${rk.recall[0]} / ${rk.recall[1]}`,rc:rankClass(rk.recall[0],rk.recall[1]),sub:`${d.tp} of ${d.tp+d.fn} golden found`},
     {cls:"steel",label:"F1",val:pct(d.f1)+"%",rank:`rank #${rk.f1[0]} / ${rk.f1[1]}`,rc:rankClass(rk.f1[0],rk.f1[1]),sub:"harmonic mean"},
-    {cls:"rust",label:"FP / TP / FN",val:`${d.fp}<span class="unit"> fp</span>`,rank:`${d.tp} tp · ${d.fn} fn`,rc:"",sub:`${d.n_prs} PRs · ${(d.fp/d.tp).toFixed(1)}× FP:TP`},
+    {cls:"rust",label:"FP / TP / FN",val:`${d.fp}<span class="unit"> fp</span>`,rank:`${d.tp} tp · ${d.fn} fn`,rc:"",sub:fpRatioText},
   ];
   cards.forEach(c=>{
     const div=document.createElement("div");div.className="kpi "+c.cls;
@@ -419,15 +421,22 @@ function renderFP(){
     $("#fp-ratio").innerHTML="";return;
   }
   const d=j.daydream;
+  const totalFindings=d.tp+d.fp;
+  if(totalFindings===0){
+    $("#fp-sub").innerHTML=`Under ${esc(j.display)}, daydream flagged no findings, so an FP:TP ratio is not defined.`;
+    $("#fp-stack").innerHTML='<div class="placeholder">0 findings flagged</div>';
+    $("#fp-ratio").innerHTML='<div class="placeholder">No FP:TP ratio when no findings are flagged</div>';
+    return;
+  }
   $("#fp-sub").innerHTML=`Under ${esc(j.display)}, daydream emits <b style="color:var(--rust)">${d.fp} false positives</b> for <b style="color:var(--mint)">${d.tp} true positives</b> — a ${(d.fp/d.tp).toFixed(1)}× FP:TP ratio. The field's median FP:TP is far lower; this is the single biggest lever on daydream's score.`;
   const W=420,H=130;const svg=el("svg",{viewBox:`0 0 ${W} ${H}`});
-  const tot=d.tp+d.fp;const bx=20,bw=W-40,by=48,bh=34;
-  const tpw=bw*d.tp/tot;
+  const bx=20,bw=W-40,by=48,bh=34;
+  const tpw=bw*d.tp/totalFindings;
   svg.appendChild(el("rect",{x:bx,y:by,width:tpw,height:bh,fill:C.mintDeep,rx:4}));
   svg.appendChild(el("rect",{x:bx+tpw,y:by,width:bw-tpw,height:bh,fill:C.rust,rx:4}));
-  svg.appendChild(txt(bx,by-10,`${d.tp} true positive (${pct(d.tp/tot)}%)`,{fill:C.mint,"font-size":"11","font-family":"var(--mono)"}));
-  svg.appendChild(txt(bx+bw,by+bh+18,`${d.fp} false positive (${pct(d.fp/tot)}%)`,{fill:C.rust,"font-size":"11","font-family":"var(--mono)","text-anchor":"end"}));
-  svg.appendChild(txt(bx,by+bh+18,`${tot} findings flagged`,{fill:C.dim,"font-size":"10","font-family":"var(--mono)"}));
+  svg.appendChild(txt(bx,by-10,`${d.tp} true positive (${pct(d.tp/totalFindings)}%)`,{fill:C.mint,"font-size":"11","font-family":"var(--mono)"}));
+  svg.appendChild(txt(bx+bw,by+bh+18,`${d.fp} false positive (${pct(d.fp/totalFindings)}%)`,{fill:C.rust,"font-size":"11","font-family":"var(--mono)","text-anchor":"end"}));
+  svg.appendChild(txt(bx,by+bh+18,`${totalFindings} findings flagged`,{fill:C.dim,"font-size":"10","font-family":"var(--mono)"}));
   $("#fp-stack").innerHTML="";$("#fp-stack").appendChild(svg);
   let rows=j.field.filter(t=>!t.invalid&&t.tp>0).map(t=>({n:t.display,v:t.fp/t.tp,c:t.color}));
   rows.push({n:"daydream",v:d.fp/d.tp,c:C.orange,dd:true});

--- a/tests/test_benchmark_report_build.py
+++ b/tests/test_benchmark_report_build.py
@@ -155,6 +155,51 @@ def test_aggregate_tool_uses_shared_judge_error_ratio_threshold(
     assert build_mod.JUDGE_ERROR_RATIO_THRESHOLD == JUDGE_ERROR_RATIO_THRESHOLD
 
 
+def test_zero_candidate_leaf_builds_daydream_panel(
+    build_mod: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A zero-candidate daydream leaf (tp=0, fp=0) reaches a real judge panel with a
+    non-null, finite-zero daydream aggregate; build() is unchanged. Regression #418."""
+    monkeypatch.setenv("DAYDREAM_PRICES_FILE", str(tmp_path / "absent.toml"))
+    zero_leaf = _leaf(tp=0, fp=0, fn=1, total_candidates=0, total_golden=1)
+    report = build_mod.build(_corpus(tmp_path, judges={_ANCHOR: _tools(5, zero_leaf)}))
+
+    panels = [j for j in report["judges"] if j["has_daydream"]]
+    assert len(panels) == 1
+    d = panels[0]["daydream"]
+    assert d is not None
+    assert (d["tp"], d["fp"], d["fn"]) == (0, 0, 1)
+    assert d["precision"] == 0.0
+    assert d["recall"] == 0.0
+    assert d["fp_per_tp"] == 0.0
+    assert d["invalid"] is False
+    assert report["per_pr_scores"][panels[0]["id"]][PR_URL]["candidates"] == 0
+
+
+def test_template_guards_zero_findings_before_ratio_rendering() -> None:
+    """renderKPIs and renderFP must handle a zero-total (tp+fp==0) daydream aggregate
+    before any ratio division or SVG construction. Static source contract — no DOM.
+    Regression #418."""
+    template = TEMPLATE_HTML.read_text()
+
+    kpi_body = template.split("function renderKPIs(){", 1)[1].split("function renderScatter(){", 1)[0]
+    assert "const totalFindings=d.tp+d.fp;" in kpi_body
+    assert 'const fpRatioText=totalFindings===0?"0 findings flagged":' in kpi_body
+    assert "sub:fpRatioText" in kpi_body
+
+    fp_body = template.split("function renderFP(){", 1)[1].split("function renderJudgeSens(){", 1)[0]
+    assert "const totalFindings=d.tp+d.fp;" in fp_body
+    assert "const tot=" not in fp_body
+    assert "if(totalFindings===0){" in fp_body
+    assert 'Under ${esc(j.display)}, daydream flagged no findings, so an FP:TP ratio is not defined.' in fp_body
+    assert '<div class="placeholder">0 findings flagged</div>' in fp_body
+    assert '<div class="placeholder">No FP:TP ratio when no findings are flagged</div>' in fp_body
+    # guard index must precede every ratio division in the FP renderer
+    assert fp_body.index("if(totalFindings===0){") < fp_body.index("(d.fp/d.tp).toFixed(1)")
+    assert fp_body.index("if(totalFindings===0){") < fp_body.index("d.tp/totalFindings")
+    assert fp_body.index("if(totalFindings===0){") < fp_body.index("d.fp/totalFindings")
+
+
 def test_price_card_comes_from_shared_pricing_table(
     build_mod: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
Implements issue #418: renders zero-candidate benchmark reports as an empty-findings state instead of failing/blank.

- `bench/benchmark-report/template.html`: handle the zero-candidate case in report rendering (+15 -6)
- `tests/test_benchmark_report_build.py`: add coverage for the empty-findings state (+45)

## Test Plan
- [x] New tests for zero-candidate report rendering pass

Closes #418
