### PR TITLE
ci: lint the shipped single-file workflow with actionlint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         run: uv run mypy daydream tests bench
 
       - name: Lint workflows with actionlint
-        run: docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:1.7.7 -color .github/workflows/*.yml daydream/templates/workflows/*.yml
+        run: docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:1.7.7 -color .github/workflows/*.yml daydream/templates/workflows/*.yml daydream/templates/workflows/single/*.yml
 
       - name: Run tests
         run: uv run pytest -n auto

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -428,3 +428,31 @@ def test_repo_workflow_readme_declares_codex_and_points_to_canonical_install() -
     # Absence of the stale strings.
     for stale in ("Copy the three workflow files", "Install step 1", "ANTHROPIC_API_KEY"):
         assert stale not in text
+
+
+# CI coverage guard: the actionlint step in .github/workflows/ci.yml must
+# receive EVERY workflow the project ships — the repo's own top-level workflows
+# plus all recursively discovered template workflows (the nested
+# single/daydream.yml included). Reads the live selectors out of the ci.yml
+# actionlint step and expands them, so a selector that stops covering a shipped
+# file (or a newly nested template) fails this test rather than silently
+# shipping un-linted workflows.
+
+
+def test_ci_actionlint_covers_all_workflow_sources() -> None:
+    wf = load_workflow(REPO_WORKFLOWS_DIR / "ci.yml")
+    steps = job_steps(wf, "check")
+    actionlint = next(s for s in steps if s.get("name") == "Lint workflows with actionlint")
+    selectors = [tok for tok in actionlint["run"].split() if tok.endswith(".yml")]
+
+    actual = {p for s in selectors for p in _REPO_ROOT.glob(s)}
+    expected = {*REPO_WORKFLOWS_DIR.glob("*.yml"), *TEMPLATES_DIR.rglob("*.yml")}
+    actual_rel = sorted(p.relative_to(_REPO_ROOT).as_posix() for p in actual)
+    expected_rel = sorted(p.relative_to(_REPO_ROOT).as_posix() for p in expected)
+    assert actual == expected, (
+        "actionlint selectors in .github/workflows/ci.yml cover a different set "
+        "of workflows than the project ships. "
+        f"actual={actual_rel} expected={expected_rel}. "
+        "Extend the actionlint run's selectors so the glob-expanded set equals "
+        "the repo workflows plus all shipped template workflows (nested included)."
+    )

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -443,7 +443,9 @@ def test_ci_actionlint_covers_all_workflow_sources() -> None:
     wf = load_workflow(REPO_WORKFLOWS_DIR / "ci.yml")
     steps = job_steps(wf, "check")
     actionlint = next(s for s in steps if s.get("name") == "Lint workflows with actionlint")
-    selectors = [tok for tok in actionlint["run"].split() if tok.endswith(".yml")]
+    selectors = [
+        tok for tok in actionlint["run"].split() if tok.endswith(".yml") and not tok.startswith("-")
+    ]
 
     actual = {p for s in selectors for p in _REPO_ROOT.glob(s)}
     expected = {*REPO_WORKFLOWS_DIR.glob("*.yml"), *TEMPLATES_DIR.rglob("*.yml")}

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -20,6 +20,10 @@ cannot verify and that a careless edit could silently break:
 - The repository workflow README declares these files as repository-only Codex
   dogfood configuration and points to the packaged install guide (never copies
   ``ANTHROPIC_API_KEY``).
+- The CI actionlint step covers every workflow the project ships — the repo's
+  own top-level workflows plus all recursively discovered template workflows
+  (the nested ``single/daydream.yml`` included) — and each selector still has
+  to match at least one real workflow file (no stale selectors).
 
 PyYAML parses the bare ``on:`` key as boolean ``True``; ``wf_on()`` normalizes it.
 """
@@ -447,7 +451,14 @@ def test_ci_actionlint_covers_all_workflow_sources() -> None:
         tok for tok in actionlint["run"].split() if tok.endswith(".yml") and not tok.startswith("-")
     ]
 
-    actual = {p for s in selectors for p in _REPO_ROOT.glob(s)}
+    actual: set[Path] = set()
+    for selector in selectors:
+        matches = set(_REPO_ROOT.glob(selector))
+        assert matches, (
+            f"actionlint selector {selector!r} in .github/workflows/ci.yml matches "
+            "no workflow files; drop the stale selector or fix its glob"
+        )
+        actual |= matches
     expected = {*REPO_WORKFLOWS_DIR.glob("*.yml"), *TEMPLATES_DIR.rglob("*.yml")}
     actual_rel = sorted(p.relative_to(_REPO_ROOT).as_posix() for p in actual)
     expected_rel = sorted(p.relative_to(_REPO_ROOT).as_posix() for p in expected)


### PR DESCRIPTION
## Summary
Closes #421

Lint the shipped single-file workflow template with `actionlint` in CI.

- Adds a CI step that runs `actionlint` against the single-file workflow template.
- Hardens the actionlint coverage guard so every selector must match at least one real workflow file (fails on stale selectors).
- Adds a regression test covering the coverage invariant.

## Test Plan
- Full suite green (3305 passed) verified in two sequential daydream deep-precision review rounds.
- Two LOW findings from round-1 fixed and re-verified in round-2 (genuine clean pass).

Closes #421