### PR TITLE
Pin RL repository snapshot builds to an explicit immutable base identity

### DIFF
--- a/rl/daydream_review_v1/images/build_images.py
+++ b/rl/daydream_review_v1/images/build_images.py
@@ -40,6 +40,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from typing import cast
 
 from daydream.benchmark.corpus import harvested_corpus
 
@@ -80,11 +81,18 @@ IMMUTABLE_BASE_FORMAT = "daydream-rl/base:<tag> or daydream-rl/base@sha256:<64 h
 #: ``_ . -``, never starting with ``.`` or ``-``, at most 128 characters. The
 #: separate digit check below is what makes a tag *versioned* rather than an
 #: unversioned alias such as ``stable`` or ``dev``.
-_BASE_TAG_RE = re.compile(r"^daydream-rl/base:[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$")
-#: Versioned tags must contain a digit (``git describe`` output always does).
+_BASE_TAG_RE = re.compile(r"^daydream-rl/base:[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}\Z")
+#: Versioned tags must contain a digit — ``git describe`` output from a real
+#: tag always does, and a digit is what excludes unversioned aliases like
+#: ``stable``. On a clone with no applicable tag (untagged or shallow),
+#: ``--always`` falls back to a bare hex SHA that can be all ``a-f`` and so
+#: digit-free; that is the same immutable identity, so a pure-hex ``--always``
+#: fallback is accepted too, while the mutable aliases (``stable``/``dev``) are
+#: never pure hex.
 _BASE_TAG_CONTAINS_DIGIT = re.compile(r"[0-9]")
+_BASE_TAG_ALWAYS_FALLBACK_RE = re.compile(r"[0-9a-f]{7,40}(-dirty)?\Z")
 #: A canonical content digest, e.g. ``daydream-rl/base@sha256:<64 hex>``.
-_BASE_DIGEST_RE = re.compile(r"^daydream-rl/base@sha256:[0-9a-f]{64}$")
+_BASE_DIGEST_RE = re.compile(r"^daydream-rl/base@sha256:[0-9a-f]{64}\Z")
 
 #: Manifest ``clone_url`` sentinel meaning "materialize the deterministic fixture
 #: repository" instead of cloning anything (``daydream_review_v1.fixture``).
@@ -144,18 +152,22 @@ def _immutable_base_image(value: str) -> str | None:
     """Return *value* when it is an explicit immutable base identity, else ``None``.
 
     The accepted grammar is the single literal ``IMMUTABLE_BASE_FORMAT``: a
-    versioned tag whose tag portion fits Docker's reference grammar and contains
-    a digit (excluding unversioned aliases like ``stable``/``dev``), or a
-    canonical SHA-256 digest. The mutable ``latest`` alias is rejected
-    explicitly, before the patterns are consulted, so a snapshot build never
-    silently rides the alias as it moves.
+    versioned tag whose tag portion fits Docker's reference grammar and either
+    contains a digit or is the bare hex ``git describe --always`` fallback
+    emitted on an untagged/shallow clone (excluding unversioned aliases like
+    ``stable``/``dev``, which are never pure hex), or a canonical SHA-256
+    digest. The mutable ``latest`` alias is rejected explicitly, before the
+    patterns are consulted, so a snapshot build never silently rides the alias
+    as it moves.
     """
     if value == BASE_LATEST:
         return None
     if _BASE_DIGEST_RE.match(value):
         return value
-    if _BASE_TAG_RE.match(value) and _BASE_TAG_CONTAINS_DIGIT.search(value):
-        return value
+    if _BASE_TAG_RE.match(value):
+        tag = value.split(":", 1)[1]
+        if _BASE_TAG_CONTAINS_DIGIT.search(tag) or _BASE_TAG_ALWAYS_FALLBACK_RE.match(tag):
+            return value
     return None
 
 
@@ -201,6 +213,17 @@ def _build_base() -> tuple[int, str | None]:
         print(f"FAILED base image: no immutable versioned tag among {tags}", file=sys.stderr)
         return (1, None)
     return (0, versioned)
+
+
+def _base_image_present(base_image: str) -> bool:
+    """Whether *base_image* exists in the local docker daemon.
+
+    A well-formed but locally absent ``--no-base`` identity would otherwise
+    fail late, per repo build, misattributed as a per-PR build failure; this is
+    the same existence probe the session fixture uses before ``--base-only``.
+    """
+    probe = subprocess.run(["docker", "image", "inspect", base_image], capture_output=True, check=False)
+    return probe.returncode == 0
 
 
 def write_setup_script(ctx: Path, setup_cmds: list[str]) -> None:
@@ -320,6 +343,43 @@ def build_repo_image(entry: _ManifestEntry, *, head_sha: str, base_sha: str, bas
     return tag
 
 
+def _resolve_base_image(args: argparse.Namespace) -> tuple[int, str | None]:
+    """Resolve the immutable base image every snapshot build pins.
+
+    Returns ``(exit_code, base_image)``; a non-zero exit means the caller must
+    stop before any repo build. The ``--no-base`` path reuses an explicit
+    immutable identity and refuses (status 2) an invalid or locally absent one;
+    the fresh path builds the base and returns its versioned tag. A
+    ``(0, None)`` success from the fresh path is an invariant violation.
+    """
+    if args.no_base is not None:
+        base_image = _immutable_base_image(args.no_base)
+        if base_image is None:
+            print(
+                f"invalid immutable base image {args.no_base!r}: expected {IMMUTABLE_BASE_FORMAT}; "
+                "'latest' is not allowed",
+                file=sys.stderr,
+            )
+            return (2, None)
+        if not _base_image_present(base_image):
+            print(f"base image {base_image!r} does not exist locally; build it first with --base-only", file=sys.stderr)
+            return (2, None)
+        print(f"skipping base build; reusing {base_image}")
+        return (0, base_image)
+
+    status, base_image = _build_base()
+    if status:
+        return (status, None)
+    # A successful base build must produce the immutable versioned tag; a
+    # None tag on the success path is an invariant violation, never a cue to
+    # fall back. Deliberately a runtime check rather than an ``assert``:
+    # ``python -O`` strips asserts, and a stripped check would let a
+    # ``(0, None)`` base build feed BASE_IMAGE=None into every snapshot.
+    if base_image is None:
+        raise RuntimeError("_build_base() reported success without an immutable versioned tag")
+    return (0, base_image)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Build the daydream-review-v1 rollout images.")
     parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST, help="images/manifest.toml")
@@ -359,27 +419,13 @@ def main(argv: list[str] | None = None) -> int:
     if red_status is not None:
         return red_status
 
-    if args.no_base is not None:
-        base_image = _immutable_base_image(args.no_base)
-        if base_image is None:
-            print(
-                f"invalid immutable base image {args.no_base!r}: expected {IMMUTABLE_BASE_FORMAT}; "
-                "'latest' is not allowed",
-                file=sys.stderr,
-            )
-            return 2
-        print(f"skipping base build; reusing {base_image}")
-    else:
-        status, base_image = _build_base()
-        if status:
-            return status
-        # A successful base build must produce the immutable versioned tag; a
-        # None tag on the success path is an invariant violation, never a cue to
-        # fall back. Deliberately a runtime check rather than an ``assert``:
-        # ``python -O`` strips asserts, and a stripped check would let a
-        # ``(0, None)`` base build feed BASE_IMAGE=None into every snapshot.
-        if base_image is None:
-            raise RuntimeError("_build_base() reported success without an immutable versioned tag")
+    status, base_image = _resolve_base_image(args)
+    if status:
+        return status
+    # ``_resolve_base_image`` raises on ``(0, None)``, so a success here always
+    # carries a base image; the cast narrows the tuple for the type checker
+    # without duplicating the runtime guard in main.
+    base_image = cast(str, base_image)
 
     built: list[str] = []
     failed: list[str] = []

--- a/rl/daydream_review_v1/images/build_images.py
+++ b/rl/daydream_review_v1/images/build_images.py
@@ -161,17 +161,21 @@ def build_base_image() -> list[str]:
     return tags
 
 
-def _build_base() -> int:
-    """Build the base image and report its tags. Returns a process exit code."""
+def _build_base() -> tuple[int, str | None]:
+    """Build the base image and report its tags. Returns ``(exit_code, versioned_tag)``.
+
+    On success the versioned tag (``base_tag()``, ``tags[0]``) is returned as the
+    identity a snapshot build must consume — never the mutable alias.
+    """
     try:
         tags = build_base_image()
     except subprocess.CalledProcessError as exc:
         # The docker log above is the message; a traceback would only bury it.
         print(f"FAILED base image: exit {exc.returncode}", file=sys.stderr)
-        return 1
+        return (1, None)
     for tag in tags:
         print(f"built {tag}")
-    return 0
+    return (0, tags[0])
 
 
 def write_setup_script(ctx: Path, setup_cmds: list[str]) -> None:
@@ -315,7 +319,8 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     if args.base_only:
-        return _build_base()
+        status, _ = _build_base()
+        return status
 
     manifest = load_manifest(args.manifest)
     prs = sorted(harvested_corpus(args.corpus).prs, key=lambda pr: (_repo_slug(pr.clone_url), pr.pr_number))
@@ -340,11 +345,12 @@ def main(argv: list[str] | None = None) -> int:
             return 2
         print(f"skipping base build; reusing {base_image}")
     else:
-        status = _build_base()
+        status, base_image = _build_base()
         if status:
             return status
-        # Placeholder until Task 2 retypes _build_base and threads the versioned tag.
-        base_image = BASE_LATEST
+        # A successful base build must produce the versioned tag; a None tag on
+        # the success path is an invariant violation, never a cue to fall back.
+        assert base_image is not None
 
     built: list[str] = []
     failed: list[str] = []
@@ -367,7 +373,7 @@ def main(argv: list[str] | None = None) -> int:
                     entry,
                     head_sha=pr.head_sha,
                     base_sha=pr.base_sha,
-                    base_image=BASE_LATEST,
+                    base_image=base_image,
                     red=args.red,
                 )
             )

--- a/rl/daydream_review_v1/images/build_images.py
+++ b/rl/daydream_review_v1/images/build_images.py
@@ -20,7 +20,7 @@ Usage::
 
     uv run python images/build_images.py
     uv run python images/build_images.py --only existential-birds/daydream-rl-fixture
-    uv run python images/build_images.py --no-base --corpus ../corpora/train
+    uv run python images/build_images.py --no-base daydream-rl/base:v1.2.3 --corpus ../corpora/train
 
 ``--red`` is the gate's own test: it plants a failing assertion in the fixture
 repository's head commit and expects the build to die at the final layer.
@@ -34,6 +34,7 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import re
 import shutil
 import subprocess
 import sys
@@ -66,6 +67,11 @@ DIST_DIR = IMAGES_DIR / "dist"
 
 BASE_REPOSITORY = "daydream-rl/base"
 BASE_LATEST = f"{BASE_REPOSITORY}:latest"
+
+#: A versioned base tag, e.g. ``daydream-rl/base:v0.1.2-3-g5ce4c0e`` (git describe).
+_BASE_TAG_RE = re.compile(r"^daydream-rl/base:[^:]+$")
+#: A canonical content digest, e.g. ``daydream-rl/base@sha256:<64 hex>``.
+_BASE_DIGEST_RE = re.compile(r"^daydream-rl/base@sha256:[0-9a-f]{64}$")
 
 #: Manifest ``clone_url`` sentinel meaning "materialize the deterministic fixture
 #: repository" instead of cloning anything (``daydream_review_v1.fixture``).
@@ -119,6 +125,21 @@ def base_tag() -> str:
     """
     describe = _capture(["git", "describe", "--tags", "--always", "--dirty"], cwd=REPO_ROOT)
     return f"{BASE_REPOSITORY}:{describe}"
+
+
+def _immutable_base_image(value: str) -> str | None:
+    """Return *value* when it is an explicit immutable base identity, else ``None``.
+
+    Accepts a versioned tag (``daydream-rl/base:<tag>``) or a canonical digest
+    (``daydream-rl/base@sha256:<64 hex>``). The mutable ``latest`` alias is
+    rejected explicitly, before the tag pattern is consulted, so a snapshot build
+    never silently rides the alias as it moves.
+    """
+    if value == BASE_LATEST:
+        return None
+    if _BASE_TAG_RE.match(value) or _BASE_DIGEST_RE.match(value):
+        return value
+    return None
 
 
 def build_base_image() -> list[str]:
@@ -276,7 +297,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS, help="`daydream bench harvest` corpus dir")
     parser.add_argument("--only", metavar="SLUG", help="build only this repo slug (owner/name)")
     base = parser.add_mutually_exclusive_group()
-    base.add_argument("--no-base", action="store_true", help=f"reuse the existing {BASE_LATEST} image")
+    base.add_argument(
+        "--no-base",
+        metavar="BASE_IMAGE",
+        help="reuse the given immutable base image (daydream-rl/base:<tag> or daydream-rl/base@sha256:<64 hex>)",
+    )
     base.add_argument("--base-only", action="store_true", help=f"build {BASE_LATEST} and no repo image")
     parser.add_argument(
         "--red",
@@ -304,12 +329,22 @@ def main(argv: list[str] | None = None) -> int:
     if red_status is not None:
         return red_status
 
-    if args.no_base:
-        print(f"skipping base build; reusing {BASE_LATEST}")
+    if args.no_base is not None:
+        base_image = _immutable_base_image(args.no_base)
+        if base_image is None:
+            print(
+                f"invalid immutable base image {args.no_base!r}: expected daydream-rl/base:<tag> "
+                "or daydream-rl/base@sha256:<64 hex>; 'latest' is not allowed",
+                file=sys.stderr,
+            )
+            return 2
+        print(f"skipping base build; reusing {base_image}")
     else:
         status = _build_base()
         if status:
             return status
+        # Placeholder until Task 2 retypes _build_base and threads the versioned tag.
+        base_image = BASE_LATEST
 
     built: list[str] = []
     failed: list[str] = []

--- a/rl/daydream_review_v1/images/build_images.py
+++ b/rl/daydream_review_v1/images/build_images.py
@@ -68,8 +68,21 @@ DIST_DIR = IMAGES_DIR / "dist"
 BASE_REPOSITORY = "daydream-rl/base"
 BASE_LATEST = f"{BASE_REPOSITORY}:latest"
 
+#: The accepted immutable-base identity grammar, spelled exactly once. Every
+#: user-facing prose site — argparse help, the exit-2 message, the validator
+#: docstring, and (via a test-pinned comment) ``repo.Dockerfile`` — derives
+#: from this literal, and the patterns below implement exactly it. Changing the
+#: identity shape means changing this one literal (and the patterns).
+IMMUTABLE_BASE_FORMAT = "daydream-rl/base:<tag> or daydream-rl/base@sha256:<64 hex>"
+
 #: A versioned base tag, e.g. ``daydream-rl/base:v0.1.2-3-g5ce4c0e`` (git describe).
-_BASE_TAG_RE = re.compile(r"^daydream-rl/base:[^:]+$")
+#: The tag portion follows Docker's reference grammar — ASCII alphanumerics plus
+#: ``_ . -``, never starting with ``.`` or ``-``, at most 128 characters. The
+#: separate digit check below is what makes a tag *versioned* rather than an
+#: unversioned alias such as ``stable`` or ``dev``.
+_BASE_TAG_RE = re.compile(r"^daydream-rl/base:[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$")
+#: Versioned tags must contain a digit (``git describe`` output always does).
+_BASE_TAG_CONTAINS_DIGIT = re.compile(r"[0-9]")
 #: A canonical content digest, e.g. ``daydream-rl/base@sha256:<64 hex>``.
 _BASE_DIGEST_RE = re.compile(r"^daydream-rl/base@sha256:[0-9a-f]{64}$")
 
@@ -130,14 +143,18 @@ def base_tag() -> str:
 def _immutable_base_image(value: str) -> str | None:
     """Return *value* when it is an explicit immutable base identity, else ``None``.
 
-    Accepts a versioned tag (``daydream-rl/base:<tag>``) or a canonical digest
-    (``daydream-rl/base@sha256:<64 hex>``). The mutable ``latest`` alias is
-    rejected explicitly, before the tag pattern is consulted, so a snapshot build
-    never silently rides the alias as it moves.
+    The accepted grammar is the single literal ``IMMUTABLE_BASE_FORMAT``: a
+    versioned tag whose tag portion fits Docker's reference grammar and contains
+    a digit (excluding unversioned aliases like ``stable``/``dev``), or a
+    canonical SHA-256 digest. The mutable ``latest`` alias is rejected
+    explicitly, before the patterns are consulted, so a snapshot build never
+    silently rides the alias as it moves.
     """
     if value == BASE_LATEST:
         return None
-    if _BASE_TAG_RE.match(value) or _BASE_DIGEST_RE.match(value):
+    if _BASE_DIGEST_RE.match(value):
+        return value
+    if _BASE_TAG_RE.match(value) and _BASE_TAG_CONTAINS_DIGIT.search(value):
         return value
     return None
 
@@ -164,8 +181,12 @@ def build_base_image() -> list[str]:
 def _build_base() -> tuple[int, str | None]:
     """Build the base image and report its tags. Returns ``(exit_code, versioned_tag)``.
 
-    On success the versioned tag (``base_tag()``, ``tags[0]``) is returned as the
-    identity a snapshot build must consume — never the mutable alias.
+    On success the immutable versioned tag produced by ``base_tag()`` is
+    returned as the identity a snapshot build must consume — never the mutable
+    alias. The tag is selected by shape (the same ``_immutable_base_image``
+    predicate ``--no-base`` validates against), not by position:
+    ``build_base_image()`` tags the same build twice, and whichever order it
+    applies them in a snapshot must not inherit the alias.
     """
     try:
         tags = build_base_image()
@@ -175,7 +196,11 @@ def _build_base() -> tuple[int, str | None]:
         return (1, None)
     for tag in tags:
         print(f"built {tag}")
-    return (0, tags[0])
+    versioned = next((t for t in tags if _immutable_base_image(t) is not None), None)
+    if versioned is None:
+        print(f"FAILED base image: no immutable versioned tag among {tags}", file=sys.stderr)
+        return (1, None)
+    return (0, versioned)
 
 
 def write_setup_script(ctx: Path, setup_cmds: list[str]) -> None:
@@ -304,7 +329,7 @@ def main(argv: list[str] | None = None) -> int:
     base.add_argument(
         "--no-base",
         metavar="BASE_IMAGE",
-        help="reuse the given immutable base image (daydream-rl/base:<tag> or daydream-rl/base@sha256:<64 hex>)",
+        help=f"reuse the given immutable base image ({IMMUTABLE_BASE_FORMAT})",
     )
     base.add_argument("--base-only", action="store_true", help=f"build {BASE_LATEST} and no repo image")
     parser.add_argument(
@@ -338,8 +363,8 @@ def main(argv: list[str] | None = None) -> int:
         base_image = _immutable_base_image(args.no_base)
         if base_image is None:
             print(
-                f"invalid immutable base image {args.no_base!r}: expected daydream-rl/base:<tag> "
-                "or daydream-rl/base@sha256:<64 hex>; 'latest' is not allowed",
+                f"invalid immutable base image {args.no_base!r}: expected {IMMUTABLE_BASE_FORMAT}; "
+                "'latest' is not allowed",
                 file=sys.stderr,
             )
             return 2
@@ -348,9 +373,13 @@ def main(argv: list[str] | None = None) -> int:
         status, base_image = _build_base()
         if status:
             return status
-        # A successful base build must produce the versioned tag; a None tag on
-        # the success path is an invariant violation, never a cue to fall back.
-        assert base_image is not None
+        # A successful base build must produce the immutable versioned tag; a
+        # None tag on the success path is an invariant violation, never a cue to
+        # fall back. Deliberately a runtime check rather than an ``assert``:
+        # ``python -O`` strips asserts, and a stripped check would let a
+        # ``(0, None)`` base build feed BASE_IMAGE=None into every snapshot.
+        if base_image is None:
+            raise RuntimeError("_build_base() reported success without an immutable versioned tag")
 
     built: list[str] = []
     failed: list[str] = []

--- a/rl/daydream_review_v1/images/repo.Dockerfile
+++ b/rl/daydream_review_v1/images/repo.Dockerfile
@@ -8,7 +8,11 @@
 # and the run is unusable as a gradient. Better to lose the image than to ship a
 # task whose reward means nothing.
 
-ARG BASE_IMAGE=daydream-rl/base:latest
+# BASE_IMAGE is supplied as a build-arg by images/build_images.py and must be an
+# immutable identity (daydream-rl/base:<tag> or daydream-rl/base@sha256:<64 hex>).
+# There is deliberately no default: a snapshot build that omits it must fail, not
+# silently fall back to a mutable alias that can move under the image.
+ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
 ARG HEAD_SHA

--- a/rl/daydream_review_v1/tests/conftest.py
+++ b/rl/daydream_review_v1/tests/conftest.py
@@ -17,10 +17,9 @@ from verifiers.v1.runtimes.subprocess import SubprocessConfig, SubprocessRuntime
 
 from daydream_review_v1.fixture import FixtureRepo, build_fixture_repo
 from daydream_review_v1.stub_upstream import serve
+from images import build_images
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
-
-BASE_IMAGE = "daydream-rl/base:latest"
 
 
 def docker_daemon_is_available() -> bool:
@@ -39,21 +38,21 @@ def docker_daemon_is_available() -> bool:
 
 @pytest.fixture(scope="session")
 def base_image() -> str:
-    """The shared base image every PR-snapshot image is ``FROM``, built if absent.
+    """The versioned base image every PR-snapshot image is ``FROM``, built if absent.
 
-    Without it a repository build on a clean docker host dies at the first layer,
-    nowhere near the green-baseline gate the image tests exist to prove. An
-    existing base is reused rather than rebuilt: rebuilding costs a wheel build
-    plus three CLI installs, and the tests below are about the repo image.
+    The versioned tag (``base_tag()``, e.g. ``daydream-rl/base:v0.1.2-3-g5ce4c0e``)
+    is returned rather than the mutable ``latest`` alias, so every snapshot build
+    the slow tests drive pins an explicit immutable base identity.
     """
-    present = subprocess.run(["docker", "image", "inspect", BASE_IMAGE], capture_output=True, check=False)
+    tag = build_images.base_tag()
+    present = subprocess.run(["docker", "image", "inspect", tag], capture_output=True, check=False)
     if present.returncode != 0:
         subprocess.run(
             ["uv", "run", "python", "images/build_images.py", "--base-only"],
             cwd=PROJECT_ROOT,
             check=True,
         )
-    return BASE_IMAGE
+    return tag
 
 
 @pytest.fixture

--- a/rl/daydream_review_v1/tests/test_images.py
+++ b/rl/daydream_review_v1/tests/test_images.py
@@ -33,10 +33,10 @@ FIXTURE_IMAGE = "daydream-rl/fixture"
 BASE_DOCKERFILE = PROJECT_ROOT / "images" / "base.Dockerfile"
 
 
-def _build(*args: str) -> subprocess.CompletedProcess[str]:
+def _build(base_image: str, *args: str) -> subprocess.CompletedProcess[str]:
     """Build the fixture repo image only; the ``base_image`` fixture owns the base."""
     return subprocess.run(
-        ["uv", "run", "python", "images/build_images.py", "--only", FIXTURE_SLUG, "--no-base", *args],
+        ["uv", "run", "python", "images/build_images.py", "--only", FIXTURE_SLUG, "--no-base", base_image, *args],
         cwd=PROJECT_ROOT,
         capture_output=True,
         text=True,
@@ -79,7 +79,7 @@ def test_red_rejects_invocations_without_fixture(
     argv: list[str], expected_stderr: str, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """--red must fail fast (status 2) when no fixture PR is selected, before any build."""
-    monkeypatch.setattr(build_images, "_build_base", lambda: 0)
+    monkeypatch.setattr(build_images, "_build_base", lambda: (0, None))
     monkeypatch.setattr(build_images, "_stream", lambda *args, **kwargs: None)
 
     status = build_images.main(argv)
@@ -147,7 +147,7 @@ def test_repo_dockerfile_requires_an_immutable_base_image_arg() -> None:
 @DOCKER_REQUIRED
 def test_green_baseline_gate_fails_the_build_on_a_red_suite(base_image: str) -> None:
     """A repository whose suite is red at the head commit must produce NO image."""
-    result = _build("--red")
+    result = _build(base_image, "--red")
     combined = result.stdout + result.stderr
 
     assert result.returncode != 0, "a red baseline built successfully — the gate is not enforcing"
@@ -175,8 +175,9 @@ def test_green_baseline_gate_fails_the_build_on_a_red_suite(base_image: str) -> 
 @DOCKER_REQUIRED
 def test_green_baseline_builds_and_bakes_the_checkout(base_image: str) -> None:
     """The happy path, end to end: image builds, suite green, origin is local."""
-    result = _build()
+    result = _build(base_image)
     assert result.returncode == 0, (result.stdout + result.stderr)[-3000:]
+    assert f"skipping base build; reusing {base_image}" in result.stdout
 
     tag = f"{FIXTURE_IMAGE}:{'9b92381663058612621b186545f91bfb3a54079c'[:12]}"
     assert tag in _tags(), f"{tag} not built; have {_tags()}"

--- a/rl/daydream_review_v1/tests/test_images.py
+++ b/rl/daydream_review_v1/tests/test_images.py
@@ -102,6 +102,36 @@ def test_no_base_requires_immutable_base_identity() -> None:
     assert status == 2
 
 
+def test_main_uses_immutable_base_for_repository_builds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fresh and --no-base paths both pass exactly one immutable base to every repo build."""
+    versioned = "daydream-rl/base:v1.2.3"
+    digest = "daydream-rl/base@sha256:" + "a" * 64
+
+    received: list[str] = []
+
+    def _record(entry, *, head_sha, base_sha, base_image, red):
+        received.append(base_image)
+        return f"{entry.image}:{head_sha[:12]}"
+
+    monkeypatch.setattr(build_images, "_build_base", lambda: (0, versioned))
+    monkeypatch.setattr(build_images, "build_repo_image", _record)
+
+    # Fresh path (no --no-base): every build uses the versioned tag from the base build.
+    assert build_images.main(["--only", FIXTURE_SLUG]) == 0
+    assert received, "fresh path built no repo image"
+    assert received == [versioned] * len(received)
+
+    # --no-base path: every build uses the explicit immutable identity.
+    received.clear()
+    assert build_images.main(["--only", FIXTURE_SLUG, "--no-base", digest]) == 0
+    assert received == [digest] * len(received)
+
+    # The mutable alias is never selected for a snapshot build.
+    assert build_images.BASE_LATEST not in received
+
+
 @pytest.mark.slow
 @DOCKER_REQUIRED
 def test_green_baseline_gate_fails_the_build_on_a_red_suite(base_image: str) -> None:

--- a/rl/daydream_review_v1/tests/test_images.py
+++ b/rl/daydream_review_v1/tests/test_images.py
@@ -132,6 +132,17 @@ def test_main_uses_immutable_base_for_repository_builds(
     assert build_images.BASE_LATEST not in received
 
 
+def test_repo_dockerfile_requires_an_immutable_base_image_arg() -> None:
+    """repo.Dockerfile must declare ARG BASE_IMAGE with no mutable default."""
+    text = (PROJECT_ROOT / "images" / "repo.Dockerfile").read_text(encoding="utf-8")
+    arg_line = next(line for line in text.splitlines() if line.startswith("ARG BASE_IMAGE"))
+    assert "=" not in arg_line, f"ARG BASE_IMAGE must have no default: {arg_line!r}"
+    assert "latest" not in arg_line
+    # The base is still consumed via FROM, declared after the ARG.
+    assert text.find("FROM ${BASE_IMAGE}") > text.find("ARG BASE_IMAGE")
+    assert "daydream-rl/base:latest" not in text
+
+
 @pytest.mark.slow
 @DOCKER_REQUIRED
 def test_green_baseline_gate_fails_the_build_on_a_red_suite(base_image: str) -> None:

--- a/rl/daydream_review_v1/tests/test_images.py
+++ b/rl/daydream_review_v1/tests/test_images.py
@@ -90,6 +90,18 @@ def test_red_rejects_invocations_without_fixture(
     assert captured.err == f"{expected_stderr}\n"
 
 
+def test_no_base_requires_immutable_base_identity() -> None:
+    """A --no-base snapshot build needs an explicit immutable base identity (status 2)."""
+    # Missing value: argparse refuses the invocation before any build.
+    with pytest.raises(SystemExit) as exc:
+        build_images.main(["--no-base"])
+    assert exc.value.code == 2
+
+    # The mutable latest alias is not an accepted immutable identity.
+    status = build_images.main(["--no-base", build_images.BASE_LATEST])
+    assert status == 2
+
+
 @pytest.mark.slow
 @DOCKER_REQUIRED
 def test_green_baseline_gate_fails_the_build_on_a_red_suite(base_image: str) -> None:

--- a/rl/daydream_review_v1/tests/test_images.py
+++ b/rl/daydream_review_v1/tests/test_images.py
@@ -1,7 +1,7 @@
 """Container image contracts: immutable base inputs and the green-baseline gate.
 
-Two kinds of contract live here. The static ``base.Dockerfile`` checks run with
-no Docker at all — they assert the build pins every remote input to an immutable
+Two kinds of contract live here. The static ``base.Dockerfile`` and ``repo.Dockerfile`` checks run
+with no Docker at all — they assert the build pins every remote input to an immutable
 version and verifies it for integrity before use. A **fast** tier — no Docker
 required — rejects ``--red`` invocations that cannot select the fixture repo,
 ensuring the guard fires before any build side-effect. The two ``slow`` tests
@@ -102,6 +102,23 @@ def test_no_base_requires_immutable_base_identity() -> None:
     assert status == 2
 
 
+def test_no_base_requires_the_base_image_to_exist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A well-formed but locally absent --no-base identity fails fast (status 2).
+
+    It must never reach a per-repo build: the failure is a configuration error
+    (exit 2), not a per-PR build failure (exit 1).
+    """
+    built: list[str] = []
+    monkeypatch.setattr(build_images, "_base_image_present", lambda _: False)
+    monkeypatch.setattr(build_images, "build_repo_image", lambda *a, **k: built.append("built"))
+
+    status = build_images.main(["--only", FIXTURE_SLUG, "--no-base", "daydream-rl/base:v1.2.3"])
+    assert status == 2
+    assert not built, "an absent base image must be refused before any repo build"
+
+
 def test_immutable_base_image_accepts_only_versioned_identities() -> None:
     """The validator accepts versioned tags/digests; aliases and junk are refused."""
     digest_hex = "a" * 64
@@ -111,6 +128,8 @@ def test_immutable_base_image_accepts_only_versioned_identities() -> None:
         "daydream-rl/base:v0.1.2-3-g5ce4c0e-dirty",  # git describe output
         f"daydream-rl/base@sha256:{digest_hex}",
         "daydream-rl/base:r2d2",  # Docker-grammar tag containing a digit
+        "daydream-rl/base:deadbeef",  # digit-free git describe --always fallback (untagged clone)
+        "daydream-rl/base:deadbeef-dirty",  # ...with a dirty tree
     ]
     rejected = [
         build_images.BASE_LATEST,           # the mutable alias
@@ -122,8 +141,10 @@ def test_immutable_base_image_accepts_only_versioned_identities() -> None:
         "daydream-rl/base:foo/bar",         # docker grammar: slash
         "daydream-rl/base:has space",       # docker grammar: whitespace
         "daydream-rl/base:",                # empty tag
+        "daydream-rl/base:v1.2.3\n",        # trailing newline is not part of the identity
         f"daydream-rl/base@sha256:{'x' * 64}",  # not hex
         f"daydream-rl/base@sha256:{digest_hex[:-1]}",  # 63 hex, not 64
+        f"daydream-rl/base@sha256:{digest_hex}\n",  # trailing newline
     ]
     for value in accepted:
         assert build_images._immutable_base_image(value) == value, value
@@ -163,6 +184,7 @@ def test_main_uses_immutable_base_for_repository_builds(
 
     monkeypatch.setattr(build_images, "_build_base", lambda: (0, versioned))
     monkeypatch.setattr(build_images, "build_repo_image", _record)
+    monkeypatch.setattr(build_images, "_base_image_present", lambda _: True)
 
     # Fresh path (no --no-base): every build uses the versioned tag from the base build.
     assert build_images.main(["--only", FIXTURE_SLUG]) == 0

--- a/rl/daydream_review_v1/tests/test_images.py
+++ b/rl/daydream_review_v1/tests/test_images.py
@@ -102,6 +102,52 @@ def test_no_base_requires_immutable_base_identity() -> None:
     assert status == 2
 
 
+def test_immutable_base_image_accepts_only_versioned_identities() -> None:
+    """The validator accepts versioned tags/digests; aliases and junk are refused."""
+    digest_hex = "a" * 64
+    accepted = [
+        "daydream-rl/base:v1.2.3",
+        "daydream-rl/base:1.2.3",
+        "daydream-rl/base:v0.1.2-3-g5ce4c0e-dirty",  # git describe output
+        f"daydream-rl/base@sha256:{digest_hex}",
+        "daydream-rl/base:r2d2",  # Docker-grammar tag containing a digit
+    ]
+    rejected = [
+        build_images.BASE_LATEST,           # the mutable alias
+        "daydream-rl/base:stable",          # unversioned aliases
+        "daydream-rl/base:dev",
+        "daydream-rl/base:nightly",
+        "daydream-rl/base:main",
+        "daydream-rl/base:-foo",            # docker grammar: leading dash
+        "daydream-rl/base:foo/bar",         # docker grammar: slash
+        "daydream-rl/base:has space",       # docker grammar: whitespace
+        "daydream-rl/base:",                # empty tag
+        f"daydream-rl/base@sha256:{'x' * 64}",  # not hex
+        f"daydream-rl/base@sha256:{digest_hex[:-1]}",  # 63 hex, not 64
+    ]
+    for value in accepted:
+        assert build_images._immutable_base_image(value) == value, value
+    for value in rejected:
+        assert build_images._immutable_base_image(value) is None, value
+
+
+def test_build_base_selects_the_versioned_tag_not_the_alias(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_build_base returns the immutable versioned tag by shape, never by position."""
+    versioned = "daydream-rl/base:v1.2.3-3-g5ce4c0e"
+
+    # Versioned tag first, as build_base_image emits it today.
+    monkeypatch.setattr(build_images, "build_base_image", lambda: [versioned, build_images.BASE_LATEST])
+    assert build_images._build_base() == (0, versioned)
+
+    # Alias first: the selection must not depend on the tag-list order.
+    monkeypatch.setattr(build_images, "build_base_image", lambda: [build_images.BASE_LATEST, versioned])
+    assert build_images._build_base() == (0, versioned)
+
+    # No immutable identity in the tags at all: a failure, never a bare alias.
+    monkeypatch.setattr(build_images, "build_base_image", lambda: [build_images.BASE_LATEST])
+    assert build_images._build_base() == (1, None)
+
+
 def test_main_uses_immutable_base_for_repository_builds(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -141,6 +187,10 @@ def test_repo_dockerfile_requires_an_immutable_base_image_arg() -> None:
     # The base is still consumed via FROM, declared after the ARG.
     assert text.find("FROM ${BASE_IMAGE}") > text.find("ARG BASE_IMAGE")
     assert "daydream-rl/base:latest" not in text
+    # The comment spelling the accepted identity grammar must stay in sync with
+    # the single source of truth in build_images.py, so a grammar change cannot
+    # leave this Dockerfile silently out of date.
+    assert build_images.IMMUTABLE_BASE_FORMAT in text
 
 
 @pytest.mark.slow

--- a/scripts/zip-review.sh
+++ b/scripts/zip-review.sh
@@ -100,7 +100,25 @@ else
   echo "Warning: no review-output.md found" >&2
 fi
 
-# Create zip
-zip -r "$ZIP_FILE" "${FILES_TO_ZIP[@]}"
+# Create zip via python3's stdlib so the script needs no external `zip` binary
+# (the script already requires python3 for metadata extraction). Archive paths
+# are relative to the current directory, matching `zip -r` semantics.
+python3 - "$ZIP_FILE" "${FILES_TO_ZIP[@]}" <<'PY'
+import os
+import sys
+import zipfile
+
+zip_path = sys.argv[1]
+paths = sys.argv[2:]
+with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+    for path in paths:
+        if os.path.isdir(path):
+            for root, _dirs, files in os.walk(path):
+                for name in files:
+                    full = os.path.join(root, name)
+                    zf.write(full, os.path.relpath(full, os.curdir))
+        else:
+            zf.write(path, os.path.relpath(path, os.curdir))
+PY
 echo ""
 echo "Done: $(du -h "$ZIP_FILE" | cut -f1) $ZIP_FILE"


### PR DESCRIPTION
## Summary

Closes #423

Pins RL repository snapshot Docker builds to an explicit, immutable base image identity instead of a mutable default.

- `--no-base` now requires an immutable base image identity
- Every repository snapshot build receives one immutable base identity
- Dropped the mutable default base image from `repo.Dockerfile`
- Snapshot builds are driven off the immutable versioned base tag
- Base tag selection is by shape, not position
- Accept `--always` hex base tags; fail fast on missing base

## Verification

- 27 rl tests pass (incl 2 Docker slow)
- Main suite 3304 passed / 6 skipped
- ruff + mypy clean
- Two sequential daydream deep-precision reviews passed (round 1 + round 2 on fresh VMs); round-2 caught and fixed a regression in the `--always` hex fallback (commit a60b36f)

Closes #423