### PR TITLE
Batch reverse-import searches and reuse the Go package index (Closes #425)

### DIFF
--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -1189,10 +1189,11 @@ def grep_fixed_matches(
 
     Returns:
         List of ``(path, matched_pattern)`` pairs parsed from ``git grep``
-        output — the same pattern may appear multiple times for the same file
-        when it matches on separate lines. Only the input patterns are
-        deduplicated. Empty
-        when there are no matches or no usable patterns.
+        output — one tuple per match occurrence, so the same pattern may
+        appear multiple times for the same file even when the matches share a
+        single line (``git grep -o`` emits a record per occurrence). Only the
+        input patterns are deduplicated. Empty when there are no matches or
+        no usable patterns.
 
     Raises:
         GitError: If ``git grep`` exits with an unexpected status or emits a

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -1163,6 +1163,95 @@ def grep(
     return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
 
 
+def grep_fixed_matches(
+    repo: Path,
+    patterns: Sequence[str],
+    *,
+    word: bool = False,
+    pathspecs: Sequence[str] | None = None,
+) -> list[tuple[str, str]]:
+    """Return ``(path, matched_pattern)`` pairs from one batched ``git grep``.
+
+    Runs a single ``git grep -F -o -z -f <file>`` so that every pattern is
+    matched in one process invocation, emitting one ``(path, pattern)`` tuple
+    per match. Patterns are deduplicated in input order; patterns containing
+    NUL, CR, or LF are skipped (they cannot be expressed as a single fixed
+    string in the patterns file).
+
+    Args:
+        repo: Repository root to search.
+        patterns: Fixed-string patterns matched literally (``-F``).
+        word: When true, match only at word boundaries (``-w``) so ``app``
+            does not also match ``application`` or ``mapping``.
+        pathspecs: Optional ``git`` pathspecs limiting the search to matching
+            files (e.g. ``("*.py", "*.ts")``). When omitted, every tracked
+            file is searched.
+
+    Returns:
+        Deduplicated-matches list of ``(path, matched_pattern)`` — a whole-word
+        match of the same pattern in the same file is reported once. Empty
+        when there are no matches or no usable patterns.
+
+    Raises:
+        GitError: If ``git grep`` exits with an unexpected status or emits a
+            malformed record. Exit code ``1`` is "no matches" and is treated
+            as success (empty list).
+    """
+    seen: set[str] = set()
+    normalized: list[str] = []
+    for pattern in patterns:
+        if not pattern or pattern in seen:
+            continue
+        if "\x00" in pattern or "\r" in pattern or "\n" in pattern:
+            continue
+        seen.add(pattern)
+        normalized.append(pattern)
+    if not normalized:
+        return []
+
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    proc: subprocess.CompletedProcess[Any] | None = None
+    try:
+        with tmp:
+            tmp.write(b"\n".join(os.fsencode(p) for p in normalized))
+        args = ["grep", "--no-color", "-F", "-o", "-z", "-f", tmp.name]
+        if word:
+            args.append("-w")
+        if pathspecs:
+            args.append("--")
+            args.extend(pathspecs)
+        proc = _run_git(repo, args, timeout=30, capture_bytes=True)
+    finally:
+        try:
+            os.unlink(tmp.name)
+        except OSError:
+            pass
+
+    if proc is None:  # pragma: no cover - _run_git returns or raises
+        raise GitError("git grep -F -o -z -f failed")
+    if proc.returncode == 1:
+        return []
+    if proc.returncode != 0:
+        stderr = proc.stderr.decode("utf-8", errors="replace") if isinstance(proc.stderr, bytes) else proc.stderr
+        raise GitError(f"git grep -F -o -z -f failed: {stderr.strip()}")
+
+    stdout = proc.stdout if isinstance(proc.stdout, bytes) else proc.stdout.encode()
+    matches: list[tuple[str, str]] = []
+    for line in stdout.split(b"\n"):
+        if not line:
+            continue
+        parts = line.split(b"\x00", 1)
+        if len(parts) != 2 or not parts[0] or not parts[1]:
+            raise GitError("git grep -F -o -z -f returned a malformed record")
+        matches.append(
+            (
+                parts[0].decode("utf-8", errors="surrogateescape"),
+                parts[1].decode("utf-8", errors="surrogateescape"),
+            )
+        )
+    return matches
+
+
 def status_porcelain(repo: Path) -> str:
     """Return ``git status --porcelain`` output.
 

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -1188,8 +1188,10 @@ def grep_fixed_matches(
             file is searched.
 
     Returns:
-        Deduplicated-matches list of ``(path, matched_pattern)`` — a whole-word
-        match of the same pattern in the same file is reported once. Empty
+        List of ``(path, matched_pattern)`` pairs parsed from ``git grep``
+        output — the same pattern may appear multiple times for the same file
+        when it matches on separate lines. Only the input patterns are
+        deduplicated. Empty
         when there are no matches or no usable patterns.
 
     Raises:

--- a/daydream/tree_sitter_index.py
+++ b/daydream/tree_sitter_index.py
@@ -264,23 +264,42 @@ def _resolve_ts_import(import_str: str, repo_root: Path, importer: Path) -> list
     return [c for c in candidates if c.exists() and c.is_file()]
 
 
-def _resolve_go_import(import_str: str, repo_root: Path, importer: Path) -> list[Path]:
-    # Best-effort: walk repo for a directory whose suffix matches the import path.
+def _build_go_package_index(repo_root: Path) -> dict[str, tuple[Path, ...]]:
+    """Index Go files by their parent directory's terminal name.
+
+    Traverses ``repo_root.rglob("*.go")`` exactly once and groups each file
+    under the terminal name of its parent directory. The first directory to
+    claim a terminal name wins: files under a later directory with the same
+    terminal name are ignored. Best-effort: an ``OSError`` during traversal
+    degrades to an empty index.
+    """
+    index: dict[str, list[Path]] = {}
+    owners: dict[str, Path] = {}
+    try:
+        for candidate in repo_root.rglob("*.go"):
+            if not candidate.is_file():
+                continue
+            parent = candidate.parent
+            name = parent.name
+            if not name:
+                continue
+            owner = owners.get(name)
+            if owner is None:
+                owners[name] = parent
+                index[name] = [candidate]
+            elif owner == parent:
+                index[name].append(candidate)
+    except OSError:
+        return {}
+    return {name: tuple(files) for name, files in index.items()}
+
+
+def _resolve_go_import(import_str: str, package_index: dict[str, tuple[Path, ...]]) -> list[Path]:
+    # Best-effort: look up the import's terminal component in the indexed tree.
     if not import_str:
         return []
-    parts = import_str.strip("/").split("/")
-    suffix = parts[-1]
-    matches: list[Path] = []
-    try:
-        for candidate in repo_root.rglob(suffix):
-            if candidate.is_dir():
-                # Confirm at least one .go file lives in it.
-                if any(candidate.glob("*.go")):
-                    matches.extend(candidate.glob("*.go"))
-                    break
-    except OSError:
-        return []
-    return matches
+    suffix = import_str.strip("/").split("/")[-1]
+    return list(package_index.get(suffix, ()))
 
 
 def _resolve_rust_import(import_str: str, repo_root: Path, importer: Path) -> list[Path]:
@@ -303,13 +322,19 @@ def _resolve_rust_import(import_str: str, repo_root: Path, importer: Path) -> li
     return [c for c in candidates if c.exists() and c.is_file()]
 
 
-def _resolve_import(language_id: str, import_str: str, repo_root: Path, importer: Path) -> list[Path]:
+def _resolve_import(
+    language_id: str,
+    import_str: str,
+    repo_root: Path,
+    importer: Path,
+    go_package_index: dict[str, tuple[Path, ...]] | None = None,
+) -> list[Path]:
     if language_id == "python":
         return _resolve_python_import(import_str, repo_root, importer)
     if language_id in ("typescript", "tsx", "javascript"):
         return _resolve_ts_import(import_str, repo_root, importer)
     if language_id == "go":
-        return _resolve_go_import(import_str, repo_root, importer)
+        return _resolve_go_import(import_str, go_package_index or {})
     if language_id == "rust":
         return _resolve_rust_import(import_str, repo_root, importer)
     return []
@@ -344,22 +369,52 @@ _MAX_IMPORTERS = 40
 _CODE_PATHSPECS: tuple[str, ...] = tuple(f"*{suffix}" for suffix in LANGUAGES)
 
 
-def _find_importers(repo_root: Path, modified_path: str) -> list[str]:
-    """Best-effort `git grep` for source files that import the modified file.
+def _build_importer_lookup(repo_root: Path, modified_paths: list[str]) -> dict[str, list[str]]:
+    """Return one batched reverse-import lookup for all *modified_paths*.
 
-    Matches the modified file's stem at word boundaries, restricted to
-    tracked source files, skipping generic stems and capping the result at
-    :data:`_MAX_IMPORTERS`.
+    Feeds every changed module stem to a single :func:`git_ops.grep_fixed_matches`
+    call, then groups the ``(path, pattern)`` pairs per modified path. Each
+    modified path's list excludes that exact path and is capped at
+    :data:`_MAX_IMPORTERS`, so paths sharing a stem keep separate, per-path
+    caps. Best-effort: a ``GitError`` (or no usable stems) degrades to empty
+    lists with zero git calls.
     """
-    stem = Path(modified_path).stem
-    if not stem or stem in _GENERIC_STEMS:
-        return []
+    lookup: dict[str, list[str]] = {path: [] for path in modified_paths}
+    unique_stems: list[str] = []
+    seen_stems: set[str] = set()
+    for path in modified_paths:
+        stem = Path(path).stem
+        if not stem or stem in _GENERIC_STEMS:
+            continue
+        if "\x00" in stem or "\r" in stem or "\n" in stem:
+            continue
+        if stem in seen_stems:
+            continue
+        seen_stems.add(stem)
+        unique_stems.append(stem)
+    if not unique_stems:
+        return lookup
+
     try:
-        matches = git_ops.grep(repo_root, stem, word=True, pathspecs=_CODE_PATHSPECS)
+        pairs = git_ops.grep_fixed_matches(repo_root, unique_stems, word=True, pathspecs=_CODE_PATHSPECS)
     except GitError:
-        return []
-    importers = [line for line in matches if line and line != modified_path]
-    return importers[:_MAX_IMPORTERS]
+        return lookup
+
+    by_stem: dict[str, list[str]] = {}
+    for path, matched in pairs:
+        if matched not in seen_stems:
+            continue
+        bucket = by_stem.setdefault(matched, [])
+        if path not in bucket:
+            bucket.append(path)
+    for path in modified_paths:
+        stem = Path(path).stem
+        if not stem or stem in _GENERIC_STEMS:
+            continue
+        if "\x00" in stem or "\r" in stem or "\n" in stem:
+            continue
+        lookup[path] = [p for p in by_stem.get(stem, ()) if p != path][:_MAX_IMPORTERS]
+    return lookup
 
 
 # --- Public API --------------------------------------------------------------
@@ -400,6 +455,13 @@ def detect_affected_files(
         results.append(FileInfo(path=path, role=role))
 
     entries = _parse_diff_name_status(diff_text)
+    reverse_paths = [
+        entry.path
+        for entry in entries
+        if entry.status != "D" and Path(entry.path).suffix in LANGUAGES
+    ]
+    importers_by_path = _build_importer_lookup(repo_root, reverse_paths)
+    go_package_index: dict[str, tuple[Path, ...]] | None = None
 
     for entry in entries:
         _add(entry.path, "modified")
@@ -425,8 +487,10 @@ def detect_affected_files(
             continue
 
         imports = extract_imports(parser, source, query_string)
+        if language_id == "go" and imports and go_package_index is None:
+            go_package_index = _build_go_package_index(repo_root)
         for imp in imports:
-            resolved_paths = _resolve_import(language_id, imp, repo_root, abs_path)
+            resolved_paths = _resolve_import(language_id, imp, repo_root, abs_path, go_package_index)
             for resolved in resolved_paths:
                 try:
                     rel = resolved.resolve().relative_to(repo_root.resolve())
@@ -434,7 +498,7 @@ def detect_affected_files(
                     continue
                 _add(str(rel), "imports")
 
-        for importer in _find_importers(repo_root, entry.path):
+        for importer in importers_by_path.get(entry.path, ()):
             _add(importer, "imported_by")
 
     return results

--- a/daydream/tree_sitter_index.py
+++ b/daydream/tree_sitter_index.py
@@ -362,6 +362,19 @@ _GENERIC_STEMS = frozenset(
 # Reverse-edge grep is a best-effort seed, not an exhaustive index. A
 # legitimately widely-imported module can match hundreds of files; cap the
 # seed so no single module can blow the downstream prompt's context window.
+def _is_generic_or_invalid_stem(stem: str) -> bool:
+    """Return True if *stem* should be skipped by the reverse-import lookup.
+
+    Skips empty stems, stems in :data:`_GENERIC_STEMS`, and stems containing
+    characters (NUL, CR, LF) that cannot be expressed in a grep patterns file.
+    """
+    if not stem or stem in _GENERIC_STEMS:
+        return True
+    if "\x00" in stem or "\r" in stem or "\n" in stem:
+        return True
+    return False
+
+
 _MAX_IMPORTERS = 40
 
 # Restrict the reverse-edge grep to source files. A doc, plan, or config file
@@ -384,9 +397,7 @@ def _build_importer_lookup(repo_root: Path, modified_paths: list[str]) -> dict[s
     seen_stems: set[str] = set()
     for path in modified_paths:
         stem = Path(path).stem
-        if not stem or stem in _GENERIC_STEMS:
-            continue
-        if "\x00" in stem or "\r" in stem or "\n" in stem:
+        if _is_generic_or_invalid_stem(stem):
             continue
         if stem in seen_stems:
             continue
@@ -409,9 +420,7 @@ def _build_importer_lookup(repo_root: Path, modified_paths: list[str]) -> dict[s
             bucket.append(path)
     for path in modified_paths:
         stem = Path(path).stem
-        if not stem or stem in _GENERIC_STEMS:
-            continue
-        if "\x00" in stem or "\r" in stem or "\n" in stem:
+        if _is_generic_or_invalid_stem(stem):
             continue
         lookup[path] = [p for p in by_stem.get(stem, ()) if p != path][:_MAX_IMPORTERS]
     return lookup

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -490,6 +490,19 @@ def test_grep_pathspecs_restrict_search(tmp_path: Path) -> None:
     assert "notes.md" not in matches
 
 
+def test_grep_fixed_matches_returns_path_pattern_pairs(tmp_path: Path) -> None:
+    repo = _make_repo_with_main(tmp_path)
+    (repo / "widget_user.py").write_text("import widget\n")
+    (repo / "gadget_user.ts").write_text("gadget\n")
+    (repo / "partial.py").write_text("widget_factory\n")
+    (repo / "notes.md").write_text("widget gadget\n")
+    _git(repo, "add", "widget_user.py", "gadget_user.ts", "partial.py", "notes.md")
+    _commit(repo, "add files")
+    matches = git_ops.grep_fixed_matches(repo, ("widget", "gadget"), word=True, pathspecs=("*.py", "*.ts"))
+    assert len(matches) == 2
+    assert set(matches) == {("widget_user.py", "widget"), ("gadget_user.ts", "gadget")}
+
+
 def test_status_porcelain_clean_and_dirty(tmp_path: Path) -> None:
     repo = _make_repo_with_main(tmp_path)
     assert git_ops.status_porcelain(repo) == ""

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -534,6 +534,69 @@ def test_grep_fixed_matches_raises_on_malformed_record(tmp_path: Path, monkeypat
         git_ops.grep_fixed_matches(repo, ("widget",))
 
 
+def test_grep_fixed_matches_empty_when_no_matches(tmp_path: Path) -> None:
+    """Exit code 1 ("no matches") is treated as success: an empty list."""
+    repo = _make_repo_with_main(tmp_path)
+    (repo / "widget.py").write_text("widget\n")
+    _git(repo, "add", "widget.py")
+    _commit(repo, "add widget")
+    assert git_ops.grep_fixed_matches(repo, ("absent_pattern",)) == []
+
+
+def test_grep_fixed_matches_dedups_and_skips_nul_cr_lf_patterns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Duplicate patterns are written once; empty/NUL/CR/LF patterns never
+    reach the patterns file handed to git."""
+    repo = _make_repo_with_main(tmp_path)
+    (repo / "widget.py").write_text("widget\n")
+    _git(repo, "add", "widget.py")
+    _commit(repo, "add widget")
+
+    patterns_files: list[bytes] = []
+
+    def fake_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
+        argv = args[0] if args else []
+        for index, arg in enumerate(argv):
+            if arg == "-f" and index + 1 < len(argv):
+                patterns_files.append(Path(argv[index + 1]).read_bytes())
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr("daydream.git_ops.subprocess.run", fake_run)
+    matches = git_ops.grep_fixed_matches(
+        repo,
+        ("widget", "widget", "", "gadget", "bad\x00pattern", "bad\rpattern", "bad\npattern"),
+        word=True,
+    )
+    assert matches == []
+    assert patterns_files == [b"widget\ngadget"]
+
+
+def test_grep_fixed_matches_empty_when_all_patterns_unsuitable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An all-unsuitable pattern set short-circuits with no git invocation."""
+    repo = _make_repo_with_main(tmp_path)
+    (repo / "widget.py").write_text("widget\n")
+    _git(repo, "add", "widget.py")
+    _commit(repo, "add widget")
+
+    def no_git(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("git must not run when every pattern is unsuitable")
+
+    monkeypatch.setattr("daydream.git_ops.subprocess.run", no_git)
+    assert git_ops.grep_fixed_matches(repo, ("", "a\x00b", "a\rb", "a\nb")) == []
+
+
+def test_grep_fixed_matches_default_word_false_matches_substrings(tmp_path: Path) -> None:
+    """The default word=False mode matches fixed substrings, not whole words."""
+    repo = _make_repo_with_main(tmp_path)
+    (repo / "app.py").write_text("application\n")
+    _git(repo, "add", "app.py")
+    _commit(repo, "add app")
+    assert git_ops.grep_fixed_matches(repo, ("app",)) == [("app.py", "app")]
+
+
 def test_status_porcelain_clean_and_dirty(tmp_path: Path) -> None:
     repo = _make_repo_with_main(tmp_path)
     assert git_ops.status_porcelain(repo) == ""

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -503,6 +503,37 @@ def test_grep_fixed_matches_returns_path_pattern_pairs(tmp_path: Path) -> None:
     assert set(matches) == {("widget_user.py", "widget"), ("gadget_user.ts", "gadget")}
 
 
+def test_grep_fixed_matches_raises_on_nonzero_exit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """grep_fixed_matches raises GitError when git exits with a non-zero,
+    non-1 exit code."""
+    repo = _make_repo_with_main(tmp_path)
+    # Craft a subprocess.run return with exit code 2 (generic git error).
+    # _run_git passes the CompletedProcess through directly.
+    def fake_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
+        return subprocess.CompletedProcess(
+            args=["git"], returncode=2,
+            stdout=b"", stderr=b"fatal: unknown option",
+        )
+    monkeypatch.setattr("daydream.git_ops.subprocess.run", fake_run)
+    with pytest.raises(GitError, match="git grep -F -o -z -f failed"):
+        git_ops.grep_fixed_matches(repo, ("widget",))
+
+
+def test_grep_fixed_matches_raises_on_malformed_record(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """grep_fixed_matches raises GitError when a NUL-separated record is
+    malformed (no NUL separator, empty path, or empty pattern)."""
+    repo = _make_repo_with_main(tmp_path)
+    # A line without a NUL separator produces parts with len != 2.
+    def fake_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
+        return subprocess.CompletedProcess(
+            args=["git"], returncode=0,
+            stdout=b"file.py\n", stderr=b"",
+        )
+    monkeypatch.setattr("daydream.git_ops.subprocess.run", fake_run)
+    with pytest.raises(GitError, match="malformed record"):
+        git_ops.grep_fixed_matches(repo, ("widget",))
+
+
 def test_status_porcelain_clean_and_dirty(tmp_path: Path) -> None:
     repo = _make_repo_with_main(tmp_path)
     assert git_ops.status_porcelain(repo) == ""

--- a/tests/test_tree_sitter_index.py
+++ b/tests/test_tree_sitter_index.py
@@ -2,10 +2,12 @@
 
 import inspect
 from pathlib import Path
+from typing import Any
 
 import pytest
 from conftest import _commit, _git, _make_repo_with_main
 
+from daydream import git_ops
 from daydream.tree_sitter_index import _MAX_IMPORTERS, detect_affected_files
 
 FIXTURES = Path(__file__).parent / "fixtures" / "diffs"
@@ -214,6 +216,39 @@ def test_go_impact_surface(tmp_path: Path):
     assert len(results) >= 2
 
 
+def test_go_imports_reuse_one_package_index(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _materialize(
+        tmp_path,
+        {
+            "cmd/alpha.go": 'package main\n\nimport "example.com/models"\n',
+            "cmd/beta.go": 'package main\n\nimport "example.com/helpers"\n',
+            "models/user.go": "package models\n",
+            "models/order.go": "package models\n",
+            "helpers/format.go": "package helpers\n",
+        },
+    )
+    real_rglob = Path.rglob
+    calls = 0
+
+    def one_go_traversal(self: Path, pattern: str) -> Any:
+        nonlocal calls
+        if self == repo and pattern == "*.go":
+            calls += 1
+            if calls > 1:
+                raise AssertionError("repo_root.rglob('*.go') called more than once")
+            return real_rglob(self, pattern)
+        raise AssertionError(f"unexpected rglob: {pattern!r}")
+
+    monkeypatch.setattr(Path, "rglob", one_go_traversal)
+
+    results = detect_affected_files(
+        _modified_diff("cmd/alpha.go") + _modified_diff("cmd/beta.go"), repo, depth=1
+    )
+    imports_paths = {r.path for r in results if r.role == "imports"}
+    assert imports_paths == {"models/user.go", "models/order.go", "helpers/format.go"}
+    assert {r.path for r in results if r.role == "modified"} == {"cmd/alpha.go", "cmd/beta.go"}
+
+
 def test_rust_impact_surface(tmp_path: Path):
     diff_text = (FIXTURES / "rust_multifile.diff").read_text()
     repo = _materialize(
@@ -312,14 +347,41 @@ def test_reverse_edge_excludes_non_code_files(tmp_path: Path):
     assert "notes.md" not in importers
 
 
-def test_reverse_edge_capped_at_max(tmp_path: Path):
+def test_reverse_edge_capped_at_max(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     repo = _make_repo_with_main(tmp_path)
-    (repo / "widget.py").write_text("x = 1\ny = 2\n")
+    for stem in ("widget", "gadget"):
+        (repo / f"{stem}.py").write_text("x = 1\ny = 2\n")
     overshoot = _MAX_IMPORTERS + 5
-    for i in range(overshoot):
-        (repo / f"importer_{i}.py").write_text("import widget\n")
-    _git(repo, "add", "widget.py", *[f"importer_{i}.py" for i in range(overshoot)])
+    for stem in ("widget", "gadget"):
+        for i in range(overshoot):
+            (repo / f"{stem}_importer_{i}.py").write_text(f"import {stem}\n")
+    _git(repo, "add", "widget.py", "gadget.py",
+         *[f"{stem}_importer_{i}.py" for stem in ("widget", "gadget") for i in range(overshoot)])
     _commit(repo, "many importers")
 
-    importers = _importers(detect_affected_files(_modified_diff("widget.py"), repo, depth=1))
-    assert len(importers) == _MAX_IMPORTERS
+    real_grep_fixed = git_ops.grep_fixed_matches
+    calls = 0
+
+    def one_batch(*args: Any, **kwargs: Any) -> Any:
+        nonlocal calls
+        calls += 1
+        if calls > 1:
+            raise AssertionError("grep_fixed_matches called more than once")
+        return real_grep_fixed(*args, **kwargs)
+
+    def no_legacy_grep(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("legacy git_ops.grep must not be called")
+
+    monkeypatch.setattr(git_ops, "grep_fixed_matches", one_batch)
+    monkeypatch.setattr(git_ops, "grep", no_legacy_grep)
+
+    results = detect_affected_files(
+        _modified_diff("widget.py") + _modified_diff("gadget.py"), repo, depth=1
+    )
+    importers = _importers(results)
+    widget = {p for p in importers if p.startswith("widget_importer_")}
+    gadget = {p for p in importers if p.startswith("gadget_importer_")}
+    assert len(widget) == _MAX_IMPORTERS
+    assert len(gadget) == _MAX_IMPORTERS
+    assert len(importers) == _MAX_IMPORTERS * 2
+    assert {r.path for r in results if r.role == "modified"} == {"widget.py", "gadget.py"}

--- a/tests/test_tree_sitter_index.py
+++ b/tests/test_tree_sitter_index.py
@@ -8,7 +8,11 @@ import pytest
 from conftest import _commit, _git, _make_repo_with_main
 
 from daydream import git_ops
-from daydream.tree_sitter_index import _MAX_IMPORTERS, detect_affected_files
+from daydream.tree_sitter_index import (
+    _MAX_IMPORTERS,
+    _is_generic_or_invalid_stem,
+    detect_affected_files,
+)
 
 FIXTURES = Path(__file__).parent / "fixtures" / "diffs"
 
@@ -385,3 +389,21 @@ def test_reverse_edge_capped_at_max(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     assert len(gadget) == _MAX_IMPORTERS
     assert len(importers) == _MAX_IMPORTERS * 2
     assert {r.path for r in results if r.role == "modified"} == {"widget.py", "gadget.py"}
+
+
+@pytest.mark.parametrize(
+    "stem",
+    ["", "__init__", "mod", "index", "main", "app", "utils", "config", "tests", "conftest"],
+)
+def test_is_generic_or_invalid_stem_skips_empty_and_generic(stem: str) -> None:
+    assert _is_generic_or_invalid_stem(stem) is True
+
+
+@pytest.mark.parametrize("stem", ["a\x00b", "a\rb", "a\nb"])
+def test_is_generic_or_invalid_stem_skips_nul_cr_lf(stem: str) -> None:
+    assert _is_generic_or_invalid_stem(stem) is True
+
+
+@pytest.mark.parametrize("stem", ["widget", "gadget", "indexer", "app_store"])
+def test_is_generic_or_invalid_stem_accepts_specific_stems(stem: str) -> None:
+    assert _is_generic_or_invalid_stem(stem) is False


### PR DESCRIPTION
## Summary

Implements issue #425 — batch reverse-import searches and reuse the Go package index.

- Batch affected-file dependency scans (perf)
- Dedupe import-stem filtering and fix grep docstring
- Correct grep docstring per-occurrence semantics and add tests

Closes #425