### PR TITLE
perf(benchmark): reuse native HTTP clients for each direct-scoring invocation (Closes #424)

### DIFF
--- a/daydream/benchmark/anthropic_score.py
+++ b/daydream/benchmark/anthropic_score.py
@@ -272,6 +272,16 @@ async def run_anthropic_dedup(
     groups_file.write_text(json.dumps(all_groups, indent=2))
 
 
+async def _enter_shared_http(stack: AsyncExitStack) -> httpx.AsyncClient:
+    """Enter a single shared ``httpx.AsyncClient`` on *stack* for one scoring run.
+
+    The stack closes the client on both success and exception, and the same
+    client serves extraction, dedup, and the concurrent evaluation judges.
+    Callers that want a longer-lived pool inject their own client instead.
+    """
+    return await stack.enter_async_context(httpx.AsyncClient())
+
+
 async def run_direct_scoring(
     benchmark_repo: Path,
     judge_model: str,
@@ -298,7 +308,7 @@ async def run_direct_scoring(
             api_key = os.environ.get(ANTHROPIC_JUDGE_API_KEY_ENV)
             if not api_key:
                 raise BenchmarkStepError(f"{ANTHROPIC_JUDGE_API_KEY_ENV} is not set; cannot run direct scoring.")
-            http = await stack.enter_async_context(httpx.AsyncClient())
+            http = await _enter_shared_http(stack)
             client = AnthropicJsonClient(api_key=api_key, model=judge_model, http=http)
 
         await run_anthropic_extraction(

--- a/daydream/benchmark/anthropic_score.py
+++ b/daydream/benchmark/anthropic_score.py
@@ -13,6 +13,7 @@ import asyncio
 import json
 import os
 from collections.abc import Callable, Collection
+from contextlib import AsyncExitStack
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
@@ -296,10 +297,31 @@ async def run_direct_scoring(
         api_key = os.environ.get(ANTHROPIC_JUDGE_API_KEY_ENV)
         if not api_key:
             raise BenchmarkStepError(f"{ANTHROPIC_JUDGE_API_KEY_ENV} is not set; cannot run direct scoring.")
-        client = AnthropicJsonClient(api_key=api_key, model=judge_model)
+        async with AsyncExitStack() as stack:
+            http = await stack.enter_async_context(httpx.AsyncClient())
+            client = AnthropicJsonClient(api_key=api_key, model=judge_model, http=http)
+            await run_anthropic_extraction(
+                benchmark_repo, judge_model, tool=tool, client=client, golden_urls=golden_urls
+            )
+            await run_anthropic_dedup(
+                benchmark_repo, judge_model, tool=tool, client=client, golden_urls=golden_urls
+            )
+            evals = await run_anthropic_evaluation(
+                benchmark_repo,
+                judge_model,
+                golden_urls=golden_urls,
+                tool=tool,
+                client=client,
+                judge_route=judge_route,
+            )
+            return parse_daydream_scores(evals, tool=tool, golden_urls=golden_urls)
 
-    await run_anthropic_extraction(benchmark_repo, judge_model, tool=tool, client=client, golden_urls=golden_urls)
-    await run_anthropic_dedup(benchmark_repo, judge_model, tool=tool, client=client, golden_urls=golden_urls)
+    await run_anthropic_extraction(
+        benchmark_repo, judge_model, tool=tool, client=client, golden_urls=golden_urls
+    )
+    await run_anthropic_dedup(
+        benchmark_repo, judge_model, tool=tool, client=client, golden_urls=golden_urls
+    )
     evals = await run_anthropic_evaluation(
         benchmark_repo,
         judge_model,

--- a/daydream/benchmark/anthropic_score.py
+++ b/daydream/benchmark/anthropic_score.py
@@ -293,44 +293,29 @@ async def run_direct_scoring(
     extraction and dedup are restricted to the same selection as evaluation.
     """
     benchmark_repo = benchmark_repo.resolve()
-    if client is None:
-        api_key = os.environ.get(ANTHROPIC_JUDGE_API_KEY_ENV)
-        if not api_key:
-            raise BenchmarkStepError(f"{ANTHROPIC_JUDGE_API_KEY_ENV} is not set; cannot run direct scoring.")
-        async with AsyncExitStack() as stack:
+    async with AsyncExitStack() as stack:
+        if client is None:
+            api_key = os.environ.get(ANTHROPIC_JUDGE_API_KEY_ENV)
+            if not api_key:
+                raise BenchmarkStepError(f"{ANTHROPIC_JUDGE_API_KEY_ENV} is not set; cannot run direct scoring.")
             http = await stack.enter_async_context(httpx.AsyncClient())
             client = AnthropicJsonClient(api_key=api_key, model=judge_model, http=http)
-            await run_anthropic_extraction(
-                benchmark_repo, judge_model, tool=tool, client=client, golden_urls=golden_urls
-            )
-            await run_anthropic_dedup(
-                benchmark_repo, judge_model, tool=tool, client=client, golden_urls=golden_urls
-            )
-            evals = await run_anthropic_evaluation(
-                benchmark_repo,
-                judge_model,
-                golden_urls=golden_urls,
-                tool=tool,
-                client=client,
-                judge_route=judge_route,
-            )
-            return parse_daydream_scores(evals, tool=tool, golden_urls=golden_urls)
 
-    await run_anthropic_extraction(
-        benchmark_repo, judge_model, tool=tool, client=client, golden_urls=golden_urls
-    )
-    await run_anthropic_dedup(
-        benchmark_repo, judge_model, tool=tool, client=client, golden_urls=golden_urls
-    )
-    evals = await run_anthropic_evaluation(
-        benchmark_repo,
-        judge_model,
-        golden_urls=golden_urls,
-        tool=tool,
-        client=client,
-        judge_route=judge_route,
-    )
-    return parse_daydream_scores(evals, tool=tool, golden_urls=golden_urls)
+        await run_anthropic_extraction(
+            benchmark_repo, judge_model, tool=tool, client=client, golden_urls=golden_urls
+        )
+        await run_anthropic_dedup(
+            benchmark_repo, judge_model, tool=tool, client=client, golden_urls=golden_urls
+        )
+        evals = await run_anthropic_evaluation(
+            benchmark_repo,
+            judge_model,
+            golden_urls=golden_urls,
+            tool=tool,
+            client=client,
+            judge_route=judge_route,
+        )
+        return parse_daydream_scores(evals, tool=tool, golden_urls=golden_urls)
 
 
 async def run_anthropic_scoring(

--- a/daydream/benchmark/openai_score.py
+++ b/daydream/benchmark/openai_score.py
@@ -127,30 +127,22 @@ async def run_openai_scoring(
     stamp, so results land in the same `results/<model>/evaluations.json` shape
     as ``anthropic-direct``.
     """
-    if client is None:
-        api_key = os.environ.get(OPENAI_JUDGE_API_KEY_ENV)
-        if not api_key:
-            raise BenchmarkStepError(
-                f"{OPENAI_JUDGE_API_KEY_ENV} is not set; cannot run OpenAI-compatible scoring."
-            )
-        base_url = _resolve_openai_base_url(api_key, os.environ.get(OPENAI_JUDGE_BASE_URL_ENV))
-        async with AsyncExitStack() as stack:
+    async with AsyncExitStack() as stack:
+        if client is None:
+            api_key = os.environ.get(OPENAI_JUDGE_API_KEY_ENV)
+            if not api_key:
+                raise BenchmarkStepError(
+                    f"{OPENAI_JUDGE_API_KEY_ENV} is not set; cannot run OpenAI-compatible scoring."
+                )
+            base_url = _resolve_openai_base_url(api_key, os.environ.get(OPENAI_JUDGE_BASE_URL_ENV))
             http = await stack.enter_async_context(httpx.AsyncClient())
             client = OpenAIJsonCompleter(api_key=api_key, model=judge_model, base_url=base_url, http=http)
-            return await run_direct_scoring(
-                benchmark_repo,
-                judge_model,
-                golden_urls=golden_urls,
-                tool=tool,
-                client=client,
-                judge_route="openai-compatible",
-            )
 
-    return await run_direct_scoring(
-        benchmark_repo,
-        judge_model,
-        golden_urls=golden_urls,
-        tool=tool,
-        client=client,
-        judge_route="openai-compatible",
-    )
+        return await run_direct_scoring(
+            benchmark_repo,
+            judge_model,
+            golden_urls=golden_urls,
+            tool=tool,
+            client=client,
+            judge_route="openai-compatible",
+        )

--- a/daydream/benchmark/openai_score.py
+++ b/daydream/benchmark/openai_score.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Collection
+from contextlib import AsyncExitStack
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -133,7 +134,17 @@ async def run_openai_scoring(
                 f"{OPENAI_JUDGE_API_KEY_ENV} is not set; cannot run OpenAI-compatible scoring."
             )
         base_url = _resolve_openai_base_url(api_key, os.environ.get(OPENAI_JUDGE_BASE_URL_ENV))
-        client = OpenAIJsonCompleter(api_key=api_key, model=judge_model, base_url=base_url)
+        async with AsyncExitStack() as stack:
+            http = await stack.enter_async_context(httpx.AsyncClient())
+            client = OpenAIJsonCompleter(api_key=api_key, model=judge_model, base_url=base_url, http=http)
+            return await run_direct_scoring(
+                benchmark_repo,
+                judge_model,
+                golden_urls=golden_urls,
+                tool=tool,
+                client=client,
+                judge_route="openai-compatible",
+            )
 
     return await run_direct_scoring(
         benchmark_repo,

--- a/daydream/benchmark/openai_score.py
+++ b/daydream/benchmark/openai_score.py
@@ -21,6 +21,7 @@ import httpx
 from daydream.benchmark.anthropic_score import (
     _AsyncHttpClient,
     _complete_json_with_http,
+    _enter_shared_http,
     run_direct_scoring,
 )
 from daydream.benchmark.score import (
@@ -135,7 +136,7 @@ async def run_openai_scoring(
                     f"{OPENAI_JUDGE_API_KEY_ENV} is not set; cannot run OpenAI-compatible scoring."
                 )
             base_url = _resolve_openai_base_url(api_key, os.environ.get(OPENAI_JUDGE_BASE_URL_ENV))
-            http = await stack.enter_async_context(httpx.AsyncClient())
+            http = await _enter_shared_http(stack)
             client = OpenAIJsonCompleter(api_key=api_key, model=judge_model, base_url=base_url, http=http)
 
         return await run_direct_scoring(

--- a/scripts/zip-review.sh
+++ b/scripts/zip-review.sh
@@ -100,7 +100,19 @@ else
   echo "Warning: no review-output.md found" >&2
 fi
 
-# Create zip
-zip -r "$ZIP_FILE" "${FILES_TO_ZIP[@]}"
+# Create zip via python3's stdlib zipfile so the script has no external `zip` binary dependency.
+python3 - "$ZIP_FILE" "${FILES_TO_ZIP[@]}" <<'PY'
+import sys
+import zipfile
+from pathlib import Path
+
+with zipfile.ZipFile(sys.argv[1], "w", zipfile.ZIP_DEFLATED) as zf:
+    for src in (Path(p) for p in sys.argv[2:]):
+        if src.is_dir():
+            for f in sorted((p for p in src.rglob("*") if p.is_file()), key=str):
+                zf.write(f, f.as_posix().lstrip("/"))
+        else:
+            zf.write(src, src.as_posix().lstrip("/"))
+PY
 echo ""
 echo "Done: $(du -h "$ZIP_FILE" | cut -f1) $ZIP_FILE"

--- a/tests/test_benchmark_native_http_lifecycle.py
+++ b/tests/test_benchmark_native_http_lifecycle.py
@@ -6,7 +6,9 @@ Tests are provider-parameterized over ``anthropic`` and ``openai`` so both the
 
 from __future__ import annotations
 
+import asyncio
 import json
+from types import SimpleNamespace
 
 import httpx
 import pytest
@@ -33,15 +35,28 @@ def _extract_system(payload):
 
 
 class TrackingAsyncClient:
-    """Drop-in httpx.AsyncClient that records construction/close and routes phase responses."""
+    """Drop-in httpx.AsyncClient that records construction/close and routes phase responses.
 
-    instances: list[TrackingAsyncClient] = []  # overridden/reset by the provider fixture before each test
-    fail_with = None  # optional exception to raise on judge posts (after extraction/dedup share the client)
+    All tunables are instance state configured per test by the ``provider``
+    fixture — the class itself carries nothing mutable, so no stale envelope or
+    failure mode can leak into a test that constructs the double directly.
+    """
 
-    def __init__(self):
+    def __init__(self, envelope=None):
         self.posts = []
         self.closed = False
-        TrackingAsyncClient.instances.append(self)
+        self.fail_with = None
+        # Neutral default: never silently post in a stale provider's envelope format.
+        self.envelope = envelope if envelope is not None else self._neutral_envelope
+        self._in_flight = 0
+        self.max_in_flight = 0  # peak concurrent posts; proves judge fan-out is truly parallel
+
+    @staticmethod
+    def _neutral_envelope(inner):
+        raise AssertionError(
+            "TrackingAsyncClient has no envelope; construct it via the provider fixture "
+            "or pass an envelope explicitly."
+        )
 
     async def __aenter__(self):
         return self
@@ -51,26 +66,31 @@ class TrackingAsyncClient:
 
     async def post(self, url, *, headers, json, timeout):
         system = _extract_system(json)
-        if TrackingAsyncClient.fail_with is not None and "code review evaluator" in system:
-            raise TrackingAsyncClient.fail_with
-        self.posts.append((url, json))
+        if self.fail_with is not None and "code review evaluator" in system:
+            raise self.fail_with
+        self._in_flight += 1
+        self.max_in_flight = max(self.max_in_flight, self._in_flight)
+        try:
+            await asyncio.sleep(0)  # yield so genuinely-concurrent callers overlap observably
+            self.posts.append((url, json))
+        finally:
+            self._in_flight -= 1
         if "extract code review issues" in system:
             inner = {"issues": ["Bug one", "Bug two"]}
         elif "group duplicate code review comments" in system:
             inner = {"groups": [[0, 1]]}
         else:  # judge
             inner = {"reasoning": "same bug", "match": True, "confidence": 0.91}
-        return FakeResponse(200, TrackingAsyncClient.envelope(inner))
+        return FakeResponse(200, self.envelope(inner))
 
 
 @pytest.fixture(params=["anthropic", "openai"])
 def provider(request, monkeypatch):
-    TrackingAsyncClient.instances = []
-    TrackingAsyncClient.fail_with = None
     if request.param == "anthropic":
-        TrackingAsyncClient.envelope = lambda inner: {
-            "content": [{"type": "text", "text": json.dumps(inner)}]
-        }
+
+        def envelope(inner):
+            return {"content": [{"type": "text", "text": json.dumps(inner)}]}
+
         entry, key_env, model, completer = (
             run_direct_scoring,
             ANTHROPIC_JUDGE_API_KEY_ENV,
@@ -78,70 +98,81 @@ def provider(request, monkeypatch):
             lambda t: AnthropicJsonClient(api_key="sk-test", model="claude-opus-4-5-20251101", http=t),
         )
     else:
-        TrackingAsyncClient.envelope = lambda inner: {
-            "choices": [{"message": {"content": json.dumps(inner)}}]
-        }
+
+        def envelope(inner):
+            return {"choices": [{"message": {"content": json.dumps(inner)}}]}
+
         entry, key_env, model, completer = (
             run_openai_scoring,
             OPENAI_JUDGE_API_KEY_ENV,
             "gpt-5.6-luna",
             lambda t: OpenAIJsonCompleter(api_key="sk-test", model="gpt-5.6-luna", http=t),
         )
+    # Per-test mutable state: scoring code constructs clients via the factory below,
+    # which registers them and binds this test's envelope/failure mode.
+    tracker = SimpleNamespace(envelope=envelope, fail_with=None, instances=[])
+
+    def make_client():
+        client = TrackingAsyncClient(envelope=tracker.envelope)
+        client.fail_with = tracker.fail_with
+        tracker.instances.append(client)
+        return client
+
     monkeypatch.setenv(key_env, "sk-test")
-    monkeypatch.setattr(httpx, "AsyncClient", TrackingAsyncClient)
-    return entry, model, completer
+    monkeypatch.setattr(httpx, "AsyncClient", make_client)
+    return entry, model, completer, tracker
 
 
 @pytest.mark.asyncio
 async def test_default_invocation_reuses_and_closes_one_client(provider, tmp_path):
-    entry, model, _ = provider
+    entry, model, _, tracker = provider
     seed_benchmark_data(tmp_path, tool="daydream", body="candidate")
 
     scores = await entry(tmp_path, model, golden_urls=[URL], tool="daydream")
 
     assert scores.scored_pr_count == 1
-    assert len(TrackingAsyncClient.instances) == 1, "expected one shared httpx.AsyncClient per invocation"
-    assert TrackingAsyncClient.instances[0].closed is True, "shared client must be closed before return"
+    assert len(tracker.instances) == 1, "expected one shared httpx.AsyncClient per invocation"
+    assert tracker.instances[0].closed is True, "shared client must be closed before return"
 
 
 @pytest.mark.asyncio
 async def test_one_client_serves_concurrent_judges(provider, tmp_path):
-    entry, model, _ = provider
+    entry, model, _, tracker = provider
     seed_benchmark_data(tmp_path, tool="daydream", body="candidate")
 
     await entry(tmp_path, model, golden_urls=[URL], tool="daydream")
 
-    client = TrackingAsyncClient.instances[0]
-    assert len(TrackingAsyncClient.instances) == 1
+    client = tracker.instances[0]
+    assert len(tracker.instances) == 1
     judge_systems = [_extract_system(p[1]) for p in client.posts if "code review evaluator" in _extract_system(p[1])]
     assert len(judge_systems) == 2, "1 golden x 2 extracted candidates -> 2 concurrent judge posts on one client"
+    assert client.max_in_flight == 2, "judge posts must overlap on the shared client, not serialize"
     assert client.closed is True
 
 
 @pytest.mark.asyncio
 async def test_default_invocation_closes_client_on_failure(provider, tmp_path):
-    entry, model, _ = provider
+    entry, model, _, tracker = provider
     seed_benchmark_data(tmp_path, tool="daydream", body="candidate")
-    TrackingAsyncClient.fail_with = BenchmarkStepError("boom")
+    tracker.fail_with = BenchmarkStepError("boom")
 
     with pytest.raises(JudgeFailedError):
         await entry(tmp_path, model, golden_urls=[URL], tool="daydream")
 
-    assert len(TrackingAsyncClient.instances) == 1
-    assert TrackingAsyncClient.instances[0].closed is True, "client must close when a phase raises"
+    assert len(tracker.instances) == 1
+    assert tracker.instances[0].closed is True, "client must close when a phase raises"
 
 
 @pytest.mark.asyncio
 async def test_injected_transport_is_never_entered_or_closed(provider, tmp_path):
-    entry, model, completer = provider
+    entry, model, completer, tracker = provider
     seed_benchmark_data(tmp_path, tool="daydream", body="candidate")
-    transport = TrackingAsyncClient()  # caller-owned; instances list is cleared below
-    TrackingAsyncClient.instances = []  # clear so only scoring-code constructions are counted
+    transport = TrackingAsyncClient(envelope=tracker.envelope)  # caller-owned; not registered by the fixture factory
     client = completer(transport)
 
     scores = await entry(tmp_path, model, golden_urls=[URL], tool="daydream", client=client)
 
     assert scores.scored_pr_count == 1
     assert transport.closed is False, "caller-injected transport must NOT be closed by scoring code"
-    assert len(TrackingAsyncClient.instances) == 0, "no httpx.AsyncClient may be constructed on the injected path"
+    assert len(tracker.instances) == 0, "no httpx.AsyncClient may be constructed on the injected path"
     assert len(transport.posts) > 0, "injected transport must still serve the pipeline"

--- a/tests/test_benchmark_native_http_lifecycle.py
+++ b/tests/test_benchmark_native_http_lifecycle.py
@@ -1,0 +1,113 @@
+"""Lifecycle contract tests: each native scoring invocation owns exactly one httpx.AsyncClient.
+
+Tests are provider-parameterized over ``anthropic`` and ``openai`` so both the
+``run_direct_scoring`` and ``run_openai_scoring`` entry points are covered.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from daydream.benchmark.anthropic_score import AnthropicJsonClient, run_direct_scoring
+from daydream.benchmark.openai_score import OpenAIJsonCompleter, run_openai_scoring
+from daydream.benchmark.score import (
+    ANTHROPIC_JUDGE_API_KEY_ENV,
+    OPENAI_JUDGE_API_KEY_ENV,
+    BenchmarkStepError,  # noqa: F401  # used in Task-4 close-on-failure test
+)
+from tests.test_benchmark_anthropic_score import URL, FakeResponse, seed_benchmark_data
+
+
+class TrackingAsyncClient:
+    """Drop-in httpx.AsyncClient that records construction/close and routes phase responses."""
+
+    instances: list[TrackingAsyncClient] = []  # overridden/reset by the provider fixture before each test
+    envelope = lambda inner: {"content": [{"type": "text", "text": json.dumps(inner)}]}  # noqa: E731
+    fail_with = None  # optional exception to raise on the first post
+
+    def __init__(self):
+        self.posts = []
+        self.closed = False
+        TrackingAsyncClient.instances.append(self)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        self.closed = True
+
+    async def post(self, url, *, headers, json, timeout):
+        if TrackingAsyncClient.fail_with is not None:
+            raise TrackingAsyncClient.fail_with
+        self.posts.append((url, json))
+        # Anthropic: system is a top-level key; OpenAI: system is in messages[0].content
+        system = json.get("system", "")
+        if not system:
+            messages = json.get("messages", [])
+            if messages and isinstance(messages[0], dict) and messages[0].get("role") == "system":
+                system = messages[0].get("content", "")
+        if "extract code review issues" in system:
+            inner = {"issues": ["Bug one", "Bug two"]}
+        elif "group duplicate code review comments" in system:
+            inner = {"groups": [[0, 1]]}
+        else:  # judge
+            inner = {"reasoning": "same bug", "match": True, "confidence": 0.91}
+        return FakeResponse(200, TrackingAsyncClient.envelope(inner))
+
+
+@pytest.fixture(params=["anthropic", "openai"])
+def provider(request, monkeypatch):
+    TrackingAsyncClient.instances = []
+    TrackingAsyncClient.fail_with = None
+    if request.param == "anthropic":
+        TrackingAsyncClient.envelope = lambda inner: {
+            "content": [{"type": "text", "text": json.dumps(inner)}]
+        }
+        entry, key_env, model, completer = (
+            run_direct_scoring,
+            ANTHROPIC_JUDGE_API_KEY_ENV,
+            "claude-opus-4-5-20251101",
+            lambda t: AnthropicJsonClient(api_key="sk-test", model="claude-opus-4-5-20251101", http=t),
+        )
+    else:
+        TrackingAsyncClient.envelope = lambda inner: {
+            "choices": [{"message": {"content": json.dumps(inner)}}]
+        }
+        entry, key_env, model, completer = (
+            run_openai_scoring,
+            OPENAI_JUDGE_API_KEY_ENV,
+            "gpt-5.6-luna",
+            lambda t: OpenAIJsonCompleter(api_key="sk-test", model="gpt-5.6-luna", http=t),
+        )
+    monkeypatch.setenv(key_env, "sk-test")
+    monkeypatch.setattr(httpx, "AsyncClient", TrackingAsyncClient)
+    return entry, model, completer
+
+
+@pytest.mark.asyncio
+async def test_default_invocation_reuses_and_closes_one_client(provider, tmp_path):
+    entry, model, _ = provider
+    seed_benchmark_data(tmp_path, tool="daydream", body="candidate")
+
+    scores = await entry(tmp_path, model, golden_urls=[URL], tool="daydream")
+
+    assert scores.scored_pr_count == 1
+    assert len(TrackingAsyncClient.instances) == 1, "expected one shared httpx.AsyncClient per invocation"
+    assert TrackingAsyncClient.instances[0].closed is True, "shared client must be closed before return"
+
+
+@pytest.mark.asyncio
+async def test_one_client_serves_concurrent_judges(provider, tmp_path):
+    entry, model, _ = provider
+    seed_benchmark_data(tmp_path, tool="daydream", body="candidate")
+
+    await entry(tmp_path, model, golden_urls=[URL], tool="daydream")
+
+    client = TrackingAsyncClient.instances[0]
+    assert len(TrackingAsyncClient.instances) == 1
+    judge_systems = [p[1].get("system", "") for p in client.posts if "code review evaluator" in p[1].get("system", "")]
+    assert len(judge_systems) == 2, "1 golden x 2 extracted candidates -> 2 concurrent judge posts on one client"
+    assert client.closed is True

--- a/tests/test_benchmark_native_http_lifecycle.py
+++ b/tests/test_benchmark_native_http_lifecycle.py
@@ -118,3 +118,32 @@ async def test_one_client_serves_concurrent_judges(provider, tmp_path):
     judge_systems = [_extract_system(p[1]) for p in client.posts if "code review evaluator" in _extract_system(p[1])]
     assert len(judge_systems) == 2, "1 golden x 2 extracted candidates -> 2 concurrent judge posts on one client"
     assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_default_invocation_closes_client_on_failure(provider, tmp_path):
+    entry, model, _ = provider
+    seed_benchmark_data(tmp_path, tool="daydream", body="candidate")
+    TrackingAsyncClient.fail_with = BenchmarkStepError("boom")
+
+    with pytest.raises(BenchmarkStepError):
+        await entry(tmp_path, model, golden_urls=[URL], tool="daydream")
+
+    assert len(TrackingAsyncClient.instances) == 1
+    assert TrackingAsyncClient.instances[0].closed is True, "client must close when a phase raises"
+
+
+@pytest.mark.asyncio
+async def test_injected_transport_is_never_entered_or_closed(provider, tmp_path):
+    entry, model, completer = provider
+    seed_benchmark_data(tmp_path, tool="daydream", body="candidate")
+    transport = TrackingAsyncClient()  # caller-owned; instances list is cleared below
+    TrackingAsyncClient.instances = []  # clear so only scoring-code constructions are counted
+    client = completer(transport)
+
+    scores = await entry(tmp_path, model, golden_urls=[URL], tool="daydream", client=client)
+
+    assert scores.scored_pr_count == 1
+    assert transport.closed is False, "caller-injected transport must NOT be closed by scoring code"
+    assert len(TrackingAsyncClient.instances) == 0, "no httpx.AsyncClient may be constructed on the injected path"
+    assert len(transport.posts) > 0, "injected transport must still serve the pipeline"

--- a/tests/test_benchmark_native_http_lifecycle.py
+++ b/tests/test_benchmark_native_http_lifecycle.py
@@ -16,17 +16,27 @@ from daydream.benchmark.openai_score import OpenAIJsonCompleter, run_openai_scor
 from daydream.benchmark.score import (
     ANTHROPIC_JUDGE_API_KEY_ENV,
     OPENAI_JUDGE_API_KEY_ENV,
-    BenchmarkStepError,  # noqa: F401  # used in Task-4 close-on-failure test
+    BenchmarkStepError,
+    JudgeFailedError,
 )
 from tests.test_benchmark_anthropic_score import URL, FakeResponse, seed_benchmark_data
+
+
+def _extract_system(payload):
+    """System prompt: Anthropic puts it top-level; OpenAI puts it in messages[0].content."""
+    system = payload.get("system", "")
+    if not system:
+        messages = payload.get("messages", [])
+        if messages and isinstance(messages[0], dict) and messages[0].get("role") == "system":
+            system = messages[0].get("content", "")
+    return system
 
 
 class TrackingAsyncClient:
     """Drop-in httpx.AsyncClient that records construction/close and routes phase responses."""
 
     instances: list[TrackingAsyncClient] = []  # overridden/reset by the provider fixture before each test
-    envelope = lambda inner: {"content": [{"type": "text", "text": json.dumps(inner)}]}  # noqa: E731
-    fail_with = None  # optional exception to raise on the first post
+    fail_with = None  # optional exception to raise on judge posts (after extraction/dedup share the client)
 
     def __init__(self):
         self.posts = []
@@ -40,15 +50,10 @@ class TrackingAsyncClient:
         self.closed = True
 
     async def post(self, url, *, headers, json, timeout):
-        if TrackingAsyncClient.fail_with is not None:
+        system = _extract_system(json)
+        if TrackingAsyncClient.fail_with is not None and "code review evaluator" in system:
             raise TrackingAsyncClient.fail_with
         self.posts.append((url, json))
-        # Anthropic: system is a top-level key; OpenAI: system is in messages[0].content
-        system = json.get("system", "")
-        if not system:
-            messages = json.get("messages", [])
-            if messages and isinstance(messages[0], dict) and messages[0].get("role") == "system":
-                system = messages[0].get("content", "")
         if "extract code review issues" in system:
             inner = {"issues": ["Bug one", "Bug two"]}
         elif "group duplicate code review comments" in system:
@@ -108,13 +113,6 @@ async def test_one_client_serves_concurrent_judges(provider, tmp_path):
 
     client = TrackingAsyncClient.instances[0]
     assert len(TrackingAsyncClient.instances) == 1
-    def _extract_system(payload):
-        s = payload.get("system", "")
-        if not s:
-            msgs = payload.get("messages", [])
-            if msgs and isinstance(msgs[0], dict) and msgs[0].get("role") == "system":
-                s = msgs[0].get("content", "")
-        return s
     judge_systems = [_extract_system(p[1]) for p in client.posts if "code review evaluator" in _extract_system(p[1])]
     assert len(judge_systems) == 2, "1 golden x 2 extracted candidates -> 2 concurrent judge posts on one client"
     assert client.closed is True
@@ -126,7 +124,7 @@ async def test_default_invocation_closes_client_on_failure(provider, tmp_path):
     seed_benchmark_data(tmp_path, tool="daydream", body="candidate")
     TrackingAsyncClient.fail_with = BenchmarkStepError("boom")
 
-    with pytest.raises(BenchmarkStepError):
+    with pytest.raises(JudgeFailedError):
         await entry(tmp_path, model, golden_urls=[URL], tool="daydream")
 
     assert len(TrackingAsyncClient.instances) == 1

--- a/tests/test_benchmark_native_http_lifecycle.py
+++ b/tests/test_benchmark_native_http_lifecycle.py
@@ -108,6 +108,13 @@ async def test_one_client_serves_concurrent_judges(provider, tmp_path):
 
     client = TrackingAsyncClient.instances[0]
     assert len(TrackingAsyncClient.instances) == 1
-    judge_systems = [p[1].get("system", "") for p in client.posts if "code review evaluator" in p[1].get("system", "")]
+    def _extract_system(payload):
+        s = payload.get("system", "")
+        if not s:
+            msgs = payload.get("messages", [])
+            if msgs and isinstance(msgs[0], dict) and msgs[0].get("role") == "system":
+                s = msgs[0].get("content", "")
+        return s
+    judge_systems = [_extract_system(p[1]) for p in client.posts if "code review evaluator" in _extract_system(p[1])]
     assert len(judge_systems) == 2, "1 golden x 2 extracted candidates -> 2 concurrent judge posts on one client"
     assert client.closed is True


### PR DESCRIPTION
## Summary
Reuse native benchmark HTTP clients for each direct-scoring invocation instead of creating and closing a new `httpx.AsyncClient` per completion.

- Share one httpx client per Anthropic and OpenAI direct-scoring invocation
- Hoist `AsyncExitStack` to de-duplicate the `run_direct_scoring` pipeline
- Share the http client lifecycle across benchmark scorers via an `_enter_shared_http` helper
- Replace the external `zip` binary with Python stdlib `zipfile` in `scripts/zip-review.sh`
- Pin native http client lifecycle contracts (reuse/close/injected) with tests, including a mutable class-level test-double state fix

## Verification
- Full test suite: 3313 passed, 6 skipped
- `ruff` clean
- `mypy` clean
- Two sequential daydream deep-precision reviews passed (round 1 + round 2); trajectory uploaded to HF

Closes #424