### PR TITLE
fix(benchmark): preserve positional identity for duplicate comments (Closes #427)

### DIFF
--- a/daydream/benchmark/anthropic_score.py
+++ b/daydream/benchmark/anthropic_score.py
@@ -482,79 +482,64 @@ async def _evaluate_review(
     semaphore = asyncio.Semaphore(_JUDGE_CONCURRENCY)
     tasks = []
     task_meta = []
-    for golden_comment in golden:
-        for candidate in candidates:
+    for gi, golden_comment in enumerate(golden):
+        for ci, candidate in enumerate(candidates):
             tasks.append(_judge_limited(semaphore, judge, golden_comment["comment"], candidate))
-            task_meta.append(
-                {
-                    "golden": golden_comment["comment"],
-                    "golden_severity": golden_comment.get("severity"),
-                    "candidate": candidate,
-                }
-            )
+            task_meta.append((gi, ci))
 
     results = await asyncio.gather(*tasks, return_exceptions=True)
-    golden_matched = {
-        comment["comment"]: {
-            "severity": comment.get("severity"),
-            "matched": False,
-            "best_confidence": -1.0,  # sentinel: any valid confidence (including 0.0) beats this
-            "matched_candidate": None,
-        }
-        for comment in golden
-    }
-    candidate_matched = dict.fromkeys(candidates, False)
-    sibling_map = _build_sibling_map(candidates, dedup_groups)
+    # Occurrences are tracked by their zero-based list position, not their text, so
+    # equal-text comments at different positions stay structurally distinct.
+    golden_matches: list[tuple[int, JudgeVerdict] | None] = [None] * len(golden)
+    candidate_matched: list[bool] = [False] * len(candidates)
+    sibling_map = _build_sibling_map(len(candidates), dedup_groups)
     errors = []
 
-    positives: list[tuple[Any, int, str, str, JudgeVerdict]] = []
+    positives: list[tuple[float, int, int, int, JudgeVerdict]] = []
 
     for index, result in enumerate(results):
-        meta = task_meta[index]
-        golden_text = meta["golden"]
-        candidate = meta["candidate"]
+        gi, ci = task_meta[index]
         if isinstance(result, BaseException):
-            errors.append({"golden": golden_text, "candidate": candidate, "error": str(result)})
+            errors.append({"golden": golden[gi]["comment"], "candidate": candidates[ci], "error": str(result)})
             continue
 
         if result.match:
-            positives.append((-result.confidence, index, golden_text, candidate, result))
+            positives.append((-result.confidence, index, gi, ci, result))
 
     # One-to-one assignment: each candidate (with its dedup siblings) satisfies at most one golden.
     positives.sort(key=lambda item: (item[0], item[1]))
-    used_groups: set[frozenset[str]] = set()
-    for negated_confidence, _index, golden_text, candidate, result in positives:
-        info = golden_matched[golden_text]
-        siblings = sibling_map.get(candidate, set())
-        group = frozenset({candidate} | siblings)
-        if info["matched"] or group in used_groups:
+    used_groups: set[frozenset[int]] = set()
+    for _negated_confidence, _index, gi, ci, result in positives:
+        if golden_matches[gi] is not None:
+            continue
+        siblings = sibling_map.get(ci, set())
+        group = frozenset({ci} | siblings)
+        if group in used_groups:
             continue
         used_groups.add(group)
-        info["matched"] = True
-        info["best_confidence"] = -negated_confidence
-        info["matched_candidate"] = candidate
-        info["reasoning"] = result.reasoning
-        candidate_matched[candidate] = True
+        golden_matches[gi] = (ci, result)
+        candidate_matched[ci] = True
         for sibling in siblings:
             candidate_matched[sibling] = True
 
     true_positives = []
     false_negatives = []
-    for golden_text, info in golden_matched.items():
-        if info["matched"]:
+    for gi, match in enumerate(golden_matches):
+        if match is not None:
+            ci, verdict = match
             true_positives.append(
                 {
-                    "golden_comment": golden_text,
-                    "severity": info["severity"],
-                    "matched_candidate": info["matched_candidate"],
-                    "confidence": info["best_confidence"],
-                    "reasoning": info.get("reasoning"),
+                    "golden_comment": golden[gi]["comment"],
+                    "severity": golden[gi].get("severity"),
+                    "matched_candidate": candidates[ci],
+                    "confidence": verdict.confidence,
+                    "reasoning": verdict.reasoning,
                 }
             )
         else:
-            false_negatives.append({"golden_comment": golden_text, "severity": info["severity"]})
+            false_negatives.append({"golden_comment": golden[gi]["comment"], "severity": golden[gi].get("severity")})
 
-    false_positives = [{"candidate": candidate} for candidate, matched in candidate_matched.items() if not matched]
+    false_positives = [{"candidate": candidates[ci]} for ci, matched in enumerate(candidate_matched) if not matched]
     total_candidates = len(candidates)
     total_golden = len(golden)
     tp_count = len(true_positives)
@@ -587,15 +572,14 @@ async def _judge_limited(
         return await judge.same_issue(golden_comment, candidate)
 
 
-def _build_sibling_map(candidates: list[str], groups: list[list[int]] | None) -> dict[str, set[str]]:
+def _build_sibling_map(candidate_count: int, groups: list[list[int]] | None) -> dict[int, set[int]]:
     if not groups:
         return {}
-    sibling_map: dict[str, set[str]] = {}
+    sibling_map: dict[int, set[int]] = {}
     for group in groups:
-        group_texts = {candidates[index] for index in group if index < len(candidates)}
-        for index in group:
-            if index < len(candidates):
-                sibling_map[candidates[index]] = group_texts - {candidates[index]}
+        members = {idx for idx in group if 0 <= idx < candidate_count}
+        for idx in members:
+            sibling_map[idx] = members - {idx}
     return sibling_map
 
 

--- a/daydream/benchmark/anthropic_score.py
+++ b/daydream/benchmark/anthropic_score.py
@@ -490,7 +490,6 @@ async def _evaluate_review(
     results = await asyncio.gather(*tasks, return_exceptions=True)
     # Occurrences are tracked by their zero-based list position, not their text, so
     # equal-text comments at different positions stay structurally distinct.
-    golden_matches: list[tuple[int, JudgeVerdict] | None] = [None] * len(golden)
     candidate_matched: list[bool] = [False] * len(candidates)
     sibling_map = _build_sibling_map(len(candidates), dedup_groups)
     errors = []
@@ -519,36 +518,7 @@ async def _evaluate_review(
     for _negated_confidence, _index, gi, ci, result in positives:
         golden_edges[gi].append((ci, result))
 
-    # Contested candidates go to the golden with the strongest match; ties stay in golden-index
-    # order (stable sort), keeping the assignment deterministic.
-    golden_order = sorted(
-        range(len(golden)),
-        key=lambda gi: golden_edges[gi][0][1].confidence if golden_edges[gi] else -1.0,
-        reverse=True,
-    )
-
-    group_holder: dict[frozenset[int], int] = {}
-
-    def _try_assign(gi: int, seen_groups: set[frozenset[int]], visited_goldens: set[int]) -> bool:
-        """Match ``gi`` to a free candidate group, displacing other goldens along an
-        alternating path when needed. True if a (re)assignment was made."""
-        if gi in visited_goldens:
-            return False
-        visited_goldens.add(gi)
-        for ci, result in golden_edges[gi]:
-            group = group_of_candidate[ci]
-            if group in seen_groups:
-                continue
-            seen_groups.add(group)
-            holder = group_holder.get(group)
-            if holder is None or _try_assign(holder, seen_groups, visited_goldens):
-                group_holder[group] = gi
-                golden_matches[gi] = (ci, result)
-                return True
-        return False
-
-    for gi in golden_order:
-        _try_assign(gi, set(), set())
+    golden_matches = _assign_golden_matches(golden_edges, group_of_candidate)
 
     for gi, match in enumerate(golden_matches):
         if match is None:
@@ -600,6 +570,58 @@ async def _evaluate_review(
         "precision": precision,
         "recall": recall,
     }
+
+
+def _assign_golden_matches(
+    golden_edges: list[list[tuple[int, JudgeVerdict]]],
+    group_of_candidate: dict[int, frozenset[int]],
+) -> list[tuple[int, JudgeVerdict] | None]:
+    """Build a maximum-cardinality one-to-one assignment of goldens to candidate groups.
+
+    Each candidate — together with its dedup siblings (its group) — satisfies at most
+    one golden. A plain greedy pass can strand a golden whose candidate groups were all
+    taken by earlier, higher-confidence matches even when a feasible two-TP assignment
+    exists, so the assignment is grown via alternating-path augmentation (Kuhn's
+    algorithm): goldens are processed in order of their strongest match confidence, and
+    a displaced golden is re-matched to its next-best free edge. Cardinality is the
+    objective; the confidence ordering only shapes tie-breaking. Returns, per golden,
+    the assigned ``(candidate_index, verdict)`` or ``None``.
+    """
+    golden_matches: list[tuple[int, JudgeVerdict] | None] = [None] * len(golden_edges)
+    group_holder: dict[frozenset[int], int] = {}
+
+    # On the initial pass, contested candidates go to the golden with the strongest match;
+    # ties stay in golden-index order (stable sort), keeping the assignment deterministic.
+    # During augmentation a displaced golden re-matches to its next-best free edge, so the
+    # final holder of a contested group may not hold its strongest edge.
+    golden_order = sorted(
+        range(len(golden_edges)),
+        key=lambda gi: golden_edges[gi][0][1].confidence if golden_edges[gi] else -1.0,
+        reverse=True,
+    )
+
+    def _try_assign(gi: int, seen_groups: set[frozenset[int]], visited_goldens: set[int]) -> bool:
+        """Match ``gi`` to a free candidate group, displacing other goldens along an
+        alternating path when needed. True if a (re)assignment was made."""
+        if gi in visited_goldens:
+            return False
+        visited_goldens.add(gi)
+        for ci, result in golden_edges[gi]:
+            group = group_of_candidate[ci]
+            if group in seen_groups:
+                continue
+            seen_groups.add(group)
+            holder = group_holder.get(group)
+            if holder is None or _try_assign(holder, seen_groups, visited_goldens):
+                group_holder[group] = gi
+                golden_matches[gi] = (ci, result)
+                return True
+        return False
+
+    for gi in golden_order:
+        _try_assign(gi, set(), set())
+
+    return golden_matches
 
 
 async def _judge_limited(

--- a/daydream/benchmark/anthropic_score.py
+++ b/daydream/benchmark/anthropic_score.py
@@ -499,45 +499,83 @@ async def _evaluate_review(
 
     for index, result in enumerate(results):
         gi, ci = task_meta[index]
+        golden_comment = golden[gi]["comment"]
         if isinstance(result, BaseException):
-            errors.append({"golden": golden[gi]["comment"], "candidate": candidates[ci], "error": str(result)})
+            errors.append({"golden": golden_comment, "candidate": candidates[ci], "error": str(result)})
             continue
 
         if result.match:
             positives.append((-result.confidence, index, gi, ci, result))
 
     # One-to-one assignment: each candidate (with its dedup siblings) satisfies at most one golden.
+    # A plain greedy pass can strand a golden whose candidate groups were all taken by earlier,
+    # higher-confidence matches even when a feasible two-TP assignment exists, so the assignment
+    # is built as a maximum-cardinality matching via alternating-path augmentation.
     positives.sort(key=lambda item: (item[0], item[1]))
-    used_groups: set[frozenset[int]] = set()
+    group_of_candidate: dict[int, frozenset[int]] = {
+        ci: frozenset({ci} | sibling_map.get(ci, set())) for ci in range(len(candidates))
+    }
+    golden_edges: list[list[tuple[int, JudgeVerdict]]] = [[] for _ in golden]
     for _negated_confidence, _index, gi, ci, result in positives:
-        if golden_matches[gi] is not None:
+        golden_edges[gi].append((ci, result))
+
+    # Contested candidates go to the golden with the strongest match; ties stay in golden-index
+    # order (stable sort), keeping the assignment deterministic.
+    golden_order = sorted(
+        range(len(golden)),
+        key=lambda gi: golden_edges[gi][0][1].confidence if golden_edges[gi] else -1.0,
+        reverse=True,
+    )
+
+    group_holder: dict[frozenset[int], int] = {}
+
+    def _try_assign(gi: int, seen_groups: set[frozenset[int]], visited_goldens: set[int]) -> bool:
+        """Match ``gi`` to a free candidate group, displacing other goldens along an
+        alternating path when needed. True if a (re)assignment was made."""
+        if gi in visited_goldens:
+            return False
+        visited_goldens.add(gi)
+        for ci, result in golden_edges[gi]:
+            group = group_of_candidate[ci]
+            if group in seen_groups:
+                continue
+            seen_groups.add(group)
+            holder = group_holder.get(group)
+            if holder is None or _try_assign(holder, seen_groups, visited_goldens):
+                group_holder[group] = gi
+                golden_matches[gi] = (ci, result)
+                return True
+        return False
+
+    for gi in golden_order:
+        _try_assign(gi, set(), set())
+
+    for gi, match in enumerate(golden_matches):
+        if match is None:
             continue
-        siblings = sibling_map.get(ci, set())
-        group = frozenset({ci} | siblings)
-        if group in used_groups:
-            continue
-        used_groups.add(group)
-        golden_matches[gi] = (ci, result)
+        ci, _verdict = match
         candidate_matched[ci] = True
-        for sibling in siblings:
+        for sibling in sibling_map.get(ci, set()):
             candidate_matched[sibling] = True
 
     true_positives = []
     false_negatives = []
     for gi, match in enumerate(golden_matches):
+        golden_comment = golden[gi]["comment"]
+        severity = golden[gi].get("severity")
         if match is not None:
             ci, verdict = match
             true_positives.append(
                 {
-                    "golden_comment": golden[gi]["comment"],
-                    "severity": golden[gi].get("severity"),
+                    "golden_comment": golden_comment,
+                    "severity": severity,
                     "matched_candidate": candidates[ci],
                     "confidence": verdict.confidence,
                     "reasoning": verdict.reasoning,
                 }
             )
         else:
-            false_negatives.append({"golden_comment": golden[gi]["comment"], "severity": golden[gi].get("severity")})
+            false_negatives.append({"golden_comment": golden_comment, "severity": severity})
 
     false_positives = [{"candidate": candidates[ci]} for ci, matched in enumerate(candidate_matched) if not matched]
     total_candidates = len(candidates)

--- a/tests/test_benchmark_anthropic_score.py
+++ b/tests/test_benchmark_anthropic_score.py
@@ -204,6 +204,103 @@ async def test_direct_judge_does_not_reuse_one_candidate_for_two_goldens(tmp_pat
     assert [fn["golden_comment"] for fn in leaf["false_negatives"]] == ["golden one"]
 
 
+@pytest.mark.parametrize(
+    "case",
+    [
+        pytest.param(
+            {
+                "name": "duplicate-goldens",
+                "golden_comments": [
+                    {"comment": "same bug", "severity": "medium"},
+                    {"comment": "same bug", "severity": "medium"},
+                ],
+                "issues": ["same bug"],
+                "groups": [[0]],
+                "verdicts": [
+                    {"reasoning": "g0", "match": True, "confidence": 0.9},
+                    {"reasoning": "g1", "match": True, "confidence": 0.8},
+                ],
+                "expected_tp": [
+                    {"golden_comment": "same bug", "severity": "medium",
+                     "matched_candidate": "same bug", "confidence": 0.9,
+                     "reasoning": "g0"},
+                ],
+                "expected_fp": [],
+                "expected_fn": [{"golden_comment": "same bug", "severity": "medium"}],
+                "tp": 1, "fp": 0, "fn": 1,
+                "precision": 1.0, "recall": 0.5,
+                "total_tp": 1, "total_fp": 0, "total_fn": 1,
+            },
+            id="duplicate-goldens",
+        ),
+        pytest.param(
+            {
+                "name": "duplicate-candidates",
+                "golden_comments": [{"comment": "the bug", "severity": "medium"}],
+                "issues": ["the bug", "the bug"],
+                "groups": [[0], [1]],
+                "verdicts": [
+                    {"reasoning": "c0", "match": True, "confidence": 0.9},
+                    {"reasoning": "c1", "match": True, "confidence": 0.8},
+                ],
+                "expected_tp": [
+                    {"golden_comment": "the bug", "severity": "medium",
+                     "matched_candidate": "the bug", "confidence": 0.9,
+                     "reasoning": "c0"},
+                ],
+                "expected_fp": [{"candidate": "the bug"}],
+                "expected_fn": [],
+                "tp": 1, "fp": 1, "fn": 0,
+                "precision": 0.5, "recall": 1.0,
+                "total_tp": 1, "total_fp": 1, "total_fn": 0,
+            },
+            id="duplicate-candidates",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_direct_judge_tracks_duplicate_text_occurrences_by_position(tmp_path, case):
+    (tmp_path / "results").mkdir()
+    (tmp_path / "results" / "benchmark_data.json").write_text(json.dumps({
+        URL: {
+            "golden_comments": case["golden_comments"],
+            "reviews": [{"tool": "daydream", "repo_name": "repo", "pr_url": URL,
+                         "review_comments": [{"body": "the bug"}]}],
+        }
+    }))
+    seed_candidates(tmp_path, model="claude-opus-4-5-20251101", tool="daydream", texts=case["issues"])
+    seed_dedup_groups(tmp_path, model="claude-opus-4-5-20251101", tool="daydream", groups=case["groups"])
+    # Dedup only calls the completer when there are >= 2 candidates (_MIN_DEDUP_CANDIDATES);
+    # with a single candidate no groups request/response is emitted, so the queue
+    # must mirror the actual call order to keep verdicts aligned with judge tasks.
+    client_queue = [{"issues": case["issues"]}]
+    if len(case["issues"]) >= 2:
+        client_queue.append({"groups": case["groups"]})
+    client_queue += case["verdicts"]
+    client = FakeAnthropicJson(client_queue)
+
+    scores = await run_anthropic_scoring(
+        tmp_path, "claude-opus-4-5-20251101", golden_urls=[URL], tool="daydream", client=client
+    )
+
+    leaf = json.loads(
+        (model_results_dir(tmp_path, "claude-opus-4-5-20251101") / "evaluations.json").read_text()
+    )[URL]["daydream"]
+    assert leaf["true_positives"] == case["expected_tp"]
+    assert leaf["false_positives"] == case["expected_fp"]
+    assert leaf["false_negatives"] == case["expected_fn"]
+    assert (leaf["tp"], leaf["fp"], leaf["fn"]) == (case["tp"], case["fp"], case["fn"])
+    assert leaf["precision"] == pytest.approx(case["precision"])
+    assert leaf["recall"] == pytest.approx(case["recall"])
+    assert all(
+        "golden_index" not in rec and "candidate_index" not in rec
+        for rec in leaf["true_positives"] + leaf["false_positives"] + leaf["false_negatives"]
+    )
+    assert (scores.total_tp, scores.total_fp, scores.total_fn) == (
+        case["total_tp"], case["total_fp"], case["total_fn"]
+    )
+
+
 @pytest.mark.asyncio
 async def test_direct_judge_precision_counts_dedup_siblings_once(tmp_path):
     """A dedup sibling group is one logical candidate: matching it must not leave

--- a/tests/test_benchmark_anthropic_score.py
+++ b/tests/test_benchmark_anthropic_score.py
@@ -209,7 +209,6 @@ async def test_direct_judge_does_not_reuse_one_candidate_for_two_goldens(tmp_pat
     [
         pytest.param(
             {
-                "name": "duplicate-goldens",
                 "golden_comments": [
                     {"comment": "same bug", "severity": "medium"},
                     {"comment": "same bug", "severity": "medium"},
@@ -235,7 +234,6 @@ async def test_direct_judge_does_not_reuse_one_candidate_for_two_goldens(tmp_pat
         ),
         pytest.param(
             {
-                "name": "duplicate-candidates",
                 "golden_comments": [{"comment": "the bug", "severity": "medium"}],
                 "issues": ["the bug", "the bug"],
                 "groups": [[0], [1]],

--- a/tests/test_benchmark_anthropic_score.py
+++ b/tests/test_benchmark_anthropic_score.py
@@ -302,6 +302,67 @@ async def test_direct_judge_tracks_duplicate_text_occurrences_by_position(tmp_pa
 
 
 @pytest.mark.asyncio
+async def test_direct_judge_finds_two_tps_when_greedy_would_strand_one(tmp_path):
+    """A greedy one-to-one pass can strand a golden whose candidate group was taken by an
+    earlier high-confidence match even when a feasible two-TP assignment exists; the
+    maximum-cardinality matching must find both true positives."""
+    results = tmp_path / "results"
+    results.mkdir()
+    (results / "benchmark_data.json").write_text(
+        json.dumps(
+            {
+                URL: {
+                    "golden_comments": [
+                        {"comment": "bug a", "severity": "medium"},
+                        {"comment": "bug b", "severity": "medium"},
+                    ],
+                    "reviews": [
+                        {
+                            "tool": "daydream",
+                            "repo_name": "repo",
+                            "pr_url": URL,
+                            "review_comments": [{"body": "the bug"}],
+                        }
+                    ],
+                }
+            }
+        )
+    )
+    seed_candidates(tmp_path, model="claude-opus-4-5-20251101", tool="daydream", texts=["fix c", "fix d"])
+    seed_dedup_groups(tmp_path, model="claude-opus-4-5-20251101", tool="daydream", groups=[[0], [1]])
+    # Greedy would take g1c0 (0.9) first, leaving g0 unmatched even though g0c0 + g1c1
+    # is a feasible two-TP assignment. Judge tasks run in (gi, ci) order: g0c0, g0c1, g1c0, g1c1.
+    client = FakeAnthropicJson(
+        [
+            {"issues": ["fix c", "fix d"]},
+            {"groups": [[0], [1]]},
+            {"reasoning": "g0c0", "match": True, "confidence": 0.5},
+            {"reasoning": "g0c1", "match": False, "confidence": 0.0},
+            {"reasoning": "g1c0", "match": True, "confidence": 0.9},
+            {"reasoning": "g1c1", "match": True, "confidence": 0.5},
+        ]
+    )
+
+    scores = await run_anthropic_scoring(
+        tmp_path,
+        "claude-opus-4-5-20251101",
+        golden_urls=[URL],
+        tool="daydream",
+        client=client,
+    )
+
+    leaf = json.loads(
+        (model_results_dir(tmp_path, "claude-opus-4-5-20251101") / "evaluations.json").read_text()
+    )[URL]["daydream"]
+    assert [tp["golden_comment"] for tp in leaf["true_positives"]] == ["bug a", "bug b"]
+    assert leaf["false_positives"] == []
+    assert leaf["false_negatives"] == []
+    assert (leaf["tp"], leaf["fp"], leaf["fn"]) == (2, 0, 0)
+    assert leaf["precision"] == 1.0 and leaf["recall"] == 1.0
+    assert (scores.total_tp, scores.total_fp, scores.total_fn) == (2, 0, 0)
+
+
+@pytest.mark.asyncio
 async def test_direct_judge_precision_counts_dedup_siblings_once(tmp_path):
     """A dedup sibling group is one logical candidate: matching it must not leave
     its siblings inflating the precision denominator behind ``fp``'s back."""


### PR DESCRIPTION
## Summary

Fixes #427 — preserve positional identity for duplicate benchmark comments in the Anthropic scoring path.

Previously duplicate comments were tracked by their text content, so when two identical comments appeared the matching could collapse or mis-assign them. This change:

- Tracks duplicate comments by **list position**, not text (`ff664265`, `fc7711ba`)
- Assigns goldens to candidates via **max-cardinality matching** instead of a greedy text-only tie-break (`55fa6c07`)
- Extracts the golden-to-candidate assignment into a dedicated module-level helper with a corrected docstring (`bff74649`)

The max-cardinality assignment means contested candidates no longer always go to the strongest match — matching is computed correctly across all candidates.

## Test Plan

- Full test suite: **3342 passed, 6 skipped**
- Two sequential daydream deep-precision reviews (rounds 1 & 2) on fresh VMs, both clean after fixes
- Working tree clean; fix-quality gate flagged nothing

Closes #427
