### PR TITLE
fix(bench): rank every benchmark tool on one complete PR cohort per judge

### DIFF
--- a/bench/benchmark-report/build.py
+++ b/bench/benchmark-report/build.py
@@ -2,8 +2,9 @@
 """Benchmark report generator: daydream vs the SaaS field on the code-review-benchmark.
 
 Reads the benchmark corpus (read-only) ACROSS ALL JUDGE MODELS, recomputes every
-SaaS tool on the SAME PR subset daydream covered (per judge), synthesizes daydream
-cost from measured tokens, and emits a self-contained offline ``index.html``.
+SaaS tool on one complete PR cohort per judge — the PRs where every compared tool
+has a present (non-skipped) leaf — synthesizes daydream cost from measured tokens,
+and emits a self-contained offline ``index.html``.
 
 The judge model is NOT fixed: the generator DISCOVERS every
 ``<results>/<judge>/evaluations.json`` and normalizes the vendor prefix so the
@@ -299,7 +300,7 @@ def _build_improvements(
 
     # ── FP-burden (priority 1) ──
     anchor = next((j for j in judges_out if j.get("id") == anchor_id), None)
-    if anchor and anchor["daydream"]["fp"] > 0:
+    if anchor and anchor["daydream"] and anchor["daydream"]["fp"] > 0:
         d = anchor["daydream"]
         improvements.append({
             "priority": 1,
@@ -408,7 +409,9 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
             continue
 
         comparison_tools = saas_tools + ([dd_tool] if has_dd else [])
-        cohort = _complete_cohort(evals, comparison_tools, dd_subset)
+        # An empty comparison list would make _complete_cohort's all() vacuously
+        # true over the whole subset; treat it as having no complete common cohort.
+        cohort = _complete_cohort(evals, comparison_tools, dd_subset) if comparison_tools else set()
         if not cohort:
             skipped_judges.append(_skip(canon, b, saas_tools,
                                         "no complete common PR cohort",
@@ -440,6 +443,13 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
             "display": judge_display(canon),
             "dirs": b["dirs"],
             "subset_pr_count": len(cohort),
+            # daydream's own scored PR count (present leaves), independent of the
+            # competitor-collapsed comparison cohort (subset_pr_count <= this).
+            "daydream_pr_count": len(daydream_prs),
+            # The judge's complete cohort: every PR in it has a present leaf for
+            # every comparison tool. Per-PR scores and label slices must trace to
+            # this same set so no panel contradicts the standing aggregate.
+            "cohort": sorted(cohort),
             "has_daydream": has_dd,
             "daydream": dd_agg,
             "ranks": ranks,
@@ -459,9 +469,10 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
     anchor_judge = next((j for j in judges_out if j["id"] == anchor_judge_id), None)
     if anchor_judge is None:
         # The largest-subset judge may be panel-skipped (fails the SaaS-coverage
-        # gate), so it never reaches judges_out. Fall back to a retained judge that
-        # still carries daydream so the report-wide anchor, label slices, and
-        # priority-1 improvements don't silently vanish.
+        # gate or has no complete common PR cohort), so it never reaches judges_out.
+        # Fall back to a retained judge that still carries daydream so the
+        # report-wide anchor, label slices, and priority-1 improvements don't
+        # silently vanish.
         anchor_judge = next((j for j in judges_out if j.get("has_daydream")), None)
         if anchor_judge is not None:
             anchor_judge_id = anchor_judge["id"]
@@ -474,6 +485,14 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
                 pr for pr, t in judges_raw[anchor_judge_id]["evals"].items()
                 if _leaf_present(t.get(dd_tool))
             }
+        else:
+            # Every retained judge lacks a daydream leaf (e.g. the largest-subset
+            # judge was skipped for 'no complete common PR cohort' and no other
+            # retained judge has daydream). Point the report-wide anchor at a
+            # retained judge so meta.anchor_judge never references a skipped judge
+            # absent from judges_out; daydream panels render placeholders.
+            anchor_judge = judges_out[0]
+            anchor_judge_id = anchor_judge["id"]
     anchor_evals = judges_raw[anchor_judge_id]["evals"]
     per_pr_rows = []
     tot_prompt = tot_completion = tot_cached = 0
@@ -531,7 +550,10 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
             continue
         jev = judges_raw[j["id"]]["evals"]
         scored_prs: dict[str, dict] = {}
-        for pr in dd_subset:
+        # The judge's own complete cohort, not the report-wide daydream subset: a
+        # PR outside the cohort has no complete leaf set and must not contribute
+        # rows or scores that contradict the panel's cohort claim.
+        for pr in j["cohort"]:
             leaf = jev.get(pr, {}).get(dd_tool)
             if not _leaf_present(leaf):
                 continue
@@ -568,7 +590,9 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
     slices = []
     if anchor_judge:
         for title, dim in slice_dims:
-            rows = slice_daydream(anchor_evals, dd_subset, labels, dd_tool, dim)
+            # The anchor's complete cohort (not the report-wide dd_subset) so the
+            # label slices sum to the same PR set as the anchor's standing panel.
+            rows = slice_daydream(anchor_evals, anchor_judge["cohort"], labels, dd_tool, dim)
             if rows:
                 slices.append({"title": title, "rows": rows})
 
@@ -710,7 +734,7 @@ def main() -> None:
             print("     daydream: NOT YET SCORED under this judge (placeholder; re-judge to fill in)")
         top = j["field"][0] if j["field"] else None
         if top:
-            print(f"     field: {len(j['field'])} SaaS tools on same {j['subset_pr_count']}-PR subset; "
+            print(f"     field: {len(j['field'])} SaaS tools on one complete {j['subset_pr_count']}-PR cohort; "
                   f"best-F1 = {top['display']} (F1={top['f1']:.3f})")
         print()
     if data["skipped_judges"]:

--- a/bench/benchmark-report/build.py
+++ b/bench/benchmark-report/build.py
@@ -124,10 +124,18 @@ def _leaf_present(leaf: dict[str, Any] | None) -> TypeGuard[dict[str, Any]]:
     return leaf is not None and not leaf.get("skipped", False)
 
 
+def _complete_cohort(evals: dict[str, dict], tools: list[str], candidate_prs: set[str]) -> set[str]:
+    """Return the members of ``candidate_prs`` that have a present leaf for every tool in ``tools``."""
+    return {pr for pr in candidate_prs
+            if all(_leaf_present(evals.get(pr, {}).get(t)) for t in tools)}
+
+
 def aggregate_tool(evals: dict[str, dict], tool: str, subset: set[str]) -> dict[str, Any] | None:
     """Micro-aggregate one tool over ``subset`` PRs. Mirrors score.parse_daydream_scores.
 
-    Returns None when the tool has no present leaf anywhere in the subset.
+    Returns None when the tool has no present leaf anywhere in the subset. Absent and
+    skipped leaves are skipped, not counted as zero; comparison callers that need equal
+    PR membership across tools must pass a cohort produced by :func:`_complete_cohort`.
     """
     tp = fp = fn = errors = comparisons = 0
     n = 0
@@ -382,28 +390,37 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
         all_tools: set[str] = set()
         for t in evals.values():
             all_tools.update(t.keys())
-        saas_tools = sorted(t for t in all_tools if t != dd_tool)
+        daydream_prs = {pr for pr in dd_subset if _leaf_present(evals.get(pr, {}).get(dd_tool))}
+        has_dd = bool(daydream_prs)
+        saas_tools = sorted(
+            t for t in all_tools if t != dd_tool
+            and any(_leaf_present(evals.get(pr, {}).get(t)) for pr in dd_subset)
+        )
         if len(saas_tools) < _MIN_SAAS_TOOLS_FOR_PANEL:
             # Verify daydream-subset overlap so future re-judges still anchor cleanly.
-            overlap_count = len(dd_subset & set(evals.keys()))
             skipped_judges.append({"id": canon, "dirs": b["dirs"], "saas_tools": len(saas_tools),
                                    "reason": "no SaaS field (superseded or partial run)",
-                                   "daydream_overlap": overlap_count})
+                                   "daydream_overlap": len(daydream_prs)})
             continue
 
-        overlap = dd_subset & set(evals.keys())
-        has_dd = bool({pr for pr in dd_subset if _leaf_present(evals.get(pr, {}).get(dd_tool))})
+        comparison_tools = saas_tools + ([dd_tool] if has_dd else [])
+        cohort = _complete_cohort(evals, comparison_tools, dd_subset)
+        if not cohort:
+            skipped_judges.append({"id": canon, "dirs": b["dirs"], "saas_tools": len(saas_tools),
+                                   "reason": "no complete common PR cohort",
+                                   "daydream_overlap": len(daydream_prs)})
+            continue
 
         field = []
         for tool in saas_tools:
-            agg = aggregate_tool(evals, tool, dd_subset)
-            if agg is None or agg["n_prs"] != len(overlap):
+            agg = aggregate_tool(evals, tool, cohort)
+            if agg is None or agg["n_prs"] != len(cohort):
                 continue
             agg["display"] = display_names.get(tool, tool)
             agg["color"] = tool_colors.get(tool, "#5B7C99")
             field.append(agg)
 
-        dd_agg = aggregate_tool(evals, dd_tool, dd_subset) if has_dd else None
+        dd_agg = aggregate_tool(evals, dd_tool, cohort) if has_dd else None
         ranks = {}
         if dd_agg:
             dd_agg["display"] = daydream_display(dd_tool)
@@ -419,7 +436,7 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
             "id": canon,
             "display": judge_display(canon),
             "dirs": b["dirs"],
-            "subset_pr_count": len(overlap),
+            "subset_pr_count": len(cohort),
             "has_daydream": has_dd,
             "daydream": dd_agg,
             "ranks": ranks,
@@ -693,7 +710,7 @@ def main() -> None:
                   f"best-F1 = {top['display']} (F1={top['f1']:.3f})")
         print()
     if data["skipped_judges"]:
-        print("── discovered but skipped (no SaaS field):")
+        print("── discovered but skipped:")
         for s in data["skipped_judges"]:
             print(f"     {s['id']}  ({s['saas_tools']} saas tools, "
                   f"daydream_overlap={s['daydream_overlap']})  — {s['reason']}")

--- a/bench/benchmark-report/build.py
+++ b/bench/benchmark-report/build.py
@@ -130,6 +130,12 @@ def _complete_cohort(evals: dict[str, dict], tools: list[str], candidate_prs: se
             if all(_leaf_present(evals.get(pr, {}).get(t)) for t in tools)}
 
 
+def _skip(canon: str, b: dict[str, Any], saas_tools: list[str], reason: str, daydream_overlap: int) -> dict[str, Any]:
+    """Record one skipped judge; both skip paths share this single dict shape."""
+    return {"id": canon, "dirs": b["dirs"], "saas_tools": len(saas_tools),
+            "reason": reason, "daydream_overlap": daydream_overlap}
+
+
 def aggregate_tool(evals: dict[str, dict], tool: str, subset: set[str]) -> dict[str, Any] | None:
     """Micro-aggregate one tool over ``subset`` PRs. Mirrors score.parse_daydream_scores.
 
@@ -390,32 +396,29 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
         all_tools: set[str] = set()
         for t in evals.values():
             all_tools.update(t.keys())
-        daydream_prs = {pr for pr in dd_subset if _leaf_present(evals.get(pr, {}).get(dd_tool))}
+        daydream_prs = _complete_cohort(evals, [dd_tool], dd_subset)
         has_dd = bool(daydream_prs)
-        saas_tools = sorted(
-            t for t in all_tools if t != dd_tool
-            and any(_leaf_present(evals.get(pr, {}).get(t)) for pr in dd_subset)
-        )
-        if len(saas_tools) < _MIN_SAAS_TOOLS_FOR_PANEL:
+        raw_saas_tools = sorted(t for t in all_tools if t != dd_tool)
+        saas_tools = [t for t in raw_saas_tools if bool(_complete_cohort(evals, [t], dd_subset))]
+        if len(raw_saas_tools) < _MIN_SAAS_TOOLS_FOR_PANEL:
             # Verify daydream-subset overlap so future re-judges still anchor cleanly.
-            skipped_judges.append({"id": canon, "dirs": b["dirs"], "saas_tools": len(saas_tools),
-                                   "reason": "no SaaS field (superseded or partial run)",
-                                   "daydream_overlap": len(daydream_prs)})
+            skipped_judges.append(_skip(canon, b, raw_saas_tools,
+                                        "no SaaS field (superseded or partial run)",
+                                        len(daydream_prs)))
             continue
 
         comparison_tools = saas_tools + ([dd_tool] if has_dd else [])
         cohort = _complete_cohort(evals, comparison_tools, dd_subset)
         if not cohort:
-            skipped_judges.append({"id": canon, "dirs": b["dirs"], "saas_tools": len(saas_tools),
-                                   "reason": "no complete common PR cohort",
-                                   "daydream_overlap": len(daydream_prs)})
+            skipped_judges.append(_skip(canon, b, saas_tools,
+                                        "no complete common PR cohort",
+                                        len(daydream_prs)))
             continue
 
         field = []
         for tool in saas_tools:
             agg = aggregate_tool(evals, tool, cohort)
-            if agg is None or agg["n_prs"] != len(cohort):
-                continue
+            assert agg is not None  # cohort guarantees a present leaf for every comparison tool
             agg["display"] = display_names.get(tool, tool)
             agg["color"] = tool_colors.get(tool, "#5B7C99")
             field.append(agg)
@@ -445,7 +448,8 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
 
     if not judges_out:
         lines = [
-            f"no eligible judge panel: every judge lacks a {_MIN_SAAS_TOOLS_FOR_PANEL}-SaaS-tool comparison field",
+            f"no eligible judge panel: every judge lacks a {_MIN_SAAS_TOOLS_FOR_PANEL}-SaaS-tool "
+            "comparison field or a complete common PR cohort",
         ]
         for s in skipped_judges:
             lines.append(f"  - {s['id']} ({s['saas_tools']} saas tools): {s['reason']}")

--- a/bench/benchmark-report/template.html
+++ b/bench/benchmark-report/template.html
@@ -169,7 +169,7 @@ svg{display:block;width:100%;height:auto;overflow:visible;}
 
   <section class="section" id="sec-kpi" data-nav="Standing">
     <div class="h2"><span class="glyph">◇</span>STANDING<span class="n" id="kpi-judgetag"></span></div>
-    <p class="subhead">Micro-averaged on the same PR subset daydream covered under the selected judge. Rank is among the SaaS field whose judge calls did not exceed the 50% error guard.</p>
+    <p class="subhead">Micro-averaged on one complete PR cohort for the selected judge. Every ranked row has a present leaf for every PR in that cohort. Rank is among the SaaS field whose judge calls did not exceed the 50% error guard.</p>
     <div class="kpis" id="kpis"></div>
   </section>
 
@@ -187,8 +187,8 @@ svg{display:block;width:100%;height:auto;overflow:visible;}
   </section>
 
   <section class="section" id="sec-lb" data-nav="Leaderboards">
-    <div class="h2"><span class="glyph">◇</span>PER-AXIS LEADERBOARDS<span class="n">same-subset · daydream row marked</span></div>
-    <p class="subhead">Top of each axis on the daydream subset for the selected judge. daydream's row is highlighted and pinned in view even when outside the top 8.</p>
+    <div class="h2"><span class="glyph">◇</span>PER-AXIS LEADERBOARDS<span class="n">complete-cohort · daydream row marked</span></div>
+    <p class="subhead">Top of each axis on the selected judge's complete PR cohort. daydream's row is highlighted and pinned in view even when outside the top 8.</p>
     <div class="grid3" id="leaderboards"></div>
   </section>
 
@@ -298,14 +298,14 @@ function renderLead(){
   const anchor=anchorJudge();
   const d=anchor?anchor.daydream:null;const rk=anchor?anchor.ranks:null;
   $("#leadcopy").innerHTML=d?
-    `On <b>${DATA.meta.subset_pr_count} PRs</b> (of ${DATA.meta.total_daydream_attempts} attempted) judged by <b>${esc(anchor.display)}</b>, daydream lands <b class="mint">recall ${pct(d.recall)}%</b> (#${rk.recall[0]} of ${rk.recall[1]}) but <b>precision ${pct(d.precision)}%</b> (#${rk.precision[0]} of ${rk.precision[1]}) — <b>top-class recall, bottom-class precision</b>. The story is <b>${d.fp} false positives against ${d.tp} true positives</b>. Every SaaS competitor is recomputed on this exact subset; cost is synthesized from daydream's measured tokens.`
+    `On <b>${anchor.subset_pr_count} PRs</b> (of ${DATA.meta.total_daydream_attempts} attempted) judged by <b>${esc(anchor.display)}</b>, daydream lands <b class="mint">recall ${pct(d.recall)}%</b> (#${rk.recall[0]} of ${rk.recall[1]}) but <b>precision ${pct(d.precision)}%</b> (#${rk.precision[0]} of ${rk.precision[1]}) — <b>top-class recall, bottom-class precision</b>. The story is <b>${d.fp} false positives against ${d.tp} true positives</b>. Every SaaS competitor is recomputed on this exact cohort, drawn from daydream's ${DATA.meta.subset_pr_count}-PR anchor; cost is synthesized from daydream's measured tokens.`
     :"daydream has not been scored under any discovered judge.";
 }
 function renderJudgeNote(){
   const j=curJudge();
   $("#judgenote").textContent=j.has_daydream
-    ? `Selected judge ${j.display} scored daydream on ${j.subset_pr_count} PRs. Field of ${j.field.length} SaaS tools recomputed on the same subset.`
-    : `Selected judge ${j.display} has NOT yet scored daydream — the field of ${j.field.length} SaaS tools is shown on the daydream PR subset; daydream panels render a placeholder until it is re-judged.`;
+    ? `Selected judge ${j.display} scored daydream on ${j.subset_pr_count} PRs. daydream is compared with ${j.field.length} SaaS tools on one complete ${j.subset_pr_count}-PR cohort.`
+    : `Selected judge ${j.display} has NOT yet scored daydream — the field of ${j.field.length} SaaS tools shares one complete ${j.subset_pr_count}-PR cohort drawn from the daydream anchor set; daydream panels render a placeholder until it is re-judged.`;
 }
 
 function rankClass(r,n){if(!r)return"";if(r<=Math.ceil(n*0.34))return"good";return"";}
@@ -314,7 +314,7 @@ function renderKPIs(){
   const host=$("#kpis");host.innerHTML="";
   if(!j.has_daydream||!j.daydream){
     host.innerHTML=`<div class="placeholder" style="grid-column:1/-1"><div class="big">daydream not yet scored under ${esc(j.display)}</div>
-      The ${j.field.length}-tool SaaS field below is computed on the ${DATA.meta.subset_pr_count}-PR daydream subset. Re-judge daydream under this model and the same generator fills these KPIs in — no code change.</div>`;
+      The ${j.field.length}-tool SaaS field below is computed on its complete ${j.subset_pr_count}-PR cohort within the daydream anchor set. Re-judge daydream under this model and the same generator fills these KPIs in — no code change.</div>`;
     return;
   }
   const d=j.daydream,rk=j.ranks;
@@ -336,8 +336,8 @@ function renderKPIs(){
 
 function renderScatter(){
   const j=curJudge();
-  $("#scatter-sub").textContent=`Recall (x) vs precision (y) for ${j.field.length} SaaS tools${j.has_daydream?" + daydream":""}, ${j.display}, on the ${DATA.meta.subset_pr_count}-PR daydream subset.`;
-  $("#scatter-title").textContent=`${j.display} · same-subset precision–recall`;
+  $("#scatter-sub").textContent=`Recall (x) vs precision (y) for ${j.field.length} SaaS tools${j.has_daydream?" + daydream":""}, ${j.display}, on a ${j.subset_pr_count}-PR complete cohort.`;
+  $("#scatter-title").textContent=`${j.display} · complete-cohort precision–recall`;
   const W=860,H=440,m={l:54,r:18,t:18,b:46};
   const iw=W-m.l-m.r,ih=H-m.t-m.b;
   const svg=el("svg",{viewBox:`0 0 ${W} ${H}`});
@@ -610,7 +610,7 @@ function renderImprovements(){
 
 function renderFoot(){
   const m=DATA.meta;
-  $("#foot").innerHTML=`<b>METHODOLOGY.</b> ${esc(m.metric_def)}. Daydream covers ${m.subset_pr_count} PRs (of ${m.total_daydream_attempts} attempted; ${m.total_daydream_attempts-m.subset_pr_count} failed runs absent). Every SaaS tool is recomputed on this exact subset per judge — never daydream's ${m.subset_pr_count}-PR numbers against a 50-PR field aggregate. Judges with &gt;${(m.judge_error_ratio_threshold*100)}% failed comparisons are flagged ⚠ERR and excluded from rank (guard from daydream/benchmark/score.py). Stale <b>${esc(m.excluded_tool)}</b> rows excluded. Cost synthesized from measured ATIF tokens @ ${esc(DATA.economy.price_model)} price card (${esc(m.price_source)}); the backend's $0 field is not used. SaaS latency shown only when a speed_analysis.json is supplied. <br><br>
+  $("#foot").innerHTML=`<b>METHODOLOGY.</b> ${esc(m.metric_def)}. The daydream anchor set contains ${m.subset_pr_count} scored PRs (of ${m.total_daydream_attempts} attempted; ${m.total_daydream_attempts-m.subset_pr_count} failed runs absent). Each judge panel intersects that anchor with the PRs having a present leaf for every ranked row, and every row in a panel is recomputed on that panel's complete cohort — no rank compares different PR counts. Judges with &gt;${(m.judge_error_ratio_threshold*100)}% failed comparisons are flagged ⚠ERR and excluded from rank (guard from daydream/benchmark/score.py). Stale <b>${esc(m.excluded_tool)}</b> rows excluded. Cost synthesized from measured ATIF tokens @ ${esc(DATA.economy.price_model)} price card (${esc(m.price_source)}); the backend's $0 field is not used. SaaS latency shown only when a speed_analysis.json is supplied. <br><br>
   <b>SOURCES.</b> aggregates: ${esc(m.generated_from)} (auto-discovered ${DATA.judges.length} judge panels + ${DATA.skipped_judges.length} skipped). labels: results/pr_labels.json. tokens/wall: .daydream-bench/trajectories/*.json. tool names/colors: analysis/benchmark_dashboard.json. Generated by bench/benchmark-report/build.py — re-run against any corpus, judge, or price card.`;
 }
 

--- a/bench/benchmark-report/template.html
+++ b/bench/benchmark-report/template.html
@@ -239,7 +239,7 @@ svg{display:block;width:100%;height:auto;overflow:visible;}
 
   <section class="section" id="sec-table" data-nav="Per-PR">
     <div class="h2"><span class="glyph">◆</span>PER-PR LOG<span class="n" id="table-judgetag"></span></div>
-    <p class="subhead">Every scored PR for the selected judge. Click a header to sort. tp/fp/fn and golden counts are from the judge leaf; $ and wall are daydream's measured trajectory (judge-independent).</p>
+    <p class="subhead">Every daydream-scored PR in the anchor set (judge leaf columns fill where the selected judge has a present leaf on its complete cohort, '—' elsewhere). Click a header to sort. tp/fp/fn and golden counts are from the judge leaf; $ and wall are daydream's measured trajectory (judge-independent).</p>
     <div class="card" style="overflow-x:auto"><table class="tbl" id="prtable"></table></div>
   </section>
 
@@ -298,13 +298,13 @@ function renderLead(){
   const anchor=anchorJudge();
   const d=anchor?anchor.daydream:null;const rk=anchor?anchor.ranks:null;
   $("#leadcopy").innerHTML=d?
-    `On <b>${anchor.subset_pr_count} PRs</b> (of ${DATA.meta.total_daydream_attempts} attempted) judged by <b>${esc(anchor.display)}</b>, daydream lands <b class="mint">recall ${pct(d.recall)}%</b> (#${rk.recall[0]} of ${rk.recall[1]}) but <b>precision ${pct(d.precision)}%</b> (#${rk.precision[0]} of ${rk.precision[1]}) — <b>top-class recall, bottom-class precision</b>. The story is <b>${d.fp} false positives against ${d.tp} true positives</b>. Every SaaS competitor is recomputed on this exact cohort, drawn from daydream's ${DATA.meta.subset_pr_count}-PR anchor; cost is synthesized from daydream's measured tokens.`
-    :"daydream has not been scored under any discovered judge.";
+    `daydream was scored on <b>${anchor.daydream_pr_count} PRs</b> (of ${DATA.meta.total_daydream_attempts} attempted); on the ${anchor.subset_pr_count}-PR complete cohort judged by <b>${esc(anchor.display)}</b>, daydream lands <b class="mint">recall ${pct(d.recall)}%</b> (#${rk.recall[0]} of ${rk.recall[1]}) but <b>precision ${pct(d.precision)}%</b> (#${rk.precision[0]} of ${rk.precision[1]}) — <b>top-class recall, bottom-class precision</b>. The story is <b>${d.fp} false positives against ${d.tp} true positives</b>. Every SaaS competitor is recomputed on this exact cohort, drawn from daydream's ${DATA.meta.subset_pr_count}-PR anchor; cost is synthesized from daydream's measured tokens.`
+    :`daydream was scored, but not under any retained judge panel — every judge that scored it was skipped (${DATA.skipped_judges.length} for an incomplete SaaS field or no complete common PR cohort), so the report-wide anchor is a retained panel without daydream. daydream's ${DATA.meta.subset_pr_count}-PR scored set is preserved in the per-PR log; cost is synthesized from daydream's measured tokens.`;
 }
 function renderJudgeNote(){
   const j=curJudge();
   $("#judgenote").textContent=j.has_daydream
-    ? `Selected judge ${j.display} scored daydream on ${j.subset_pr_count} PRs. daydream is compared with ${j.field.length} SaaS tools on one complete ${j.subset_pr_count}-PR cohort.`
+    ? `Selected judge ${j.display} scored daydream on ${j.daydream_pr_count} PRs; the compared field runs on the ${j.subset_pr_count}-PR complete cohort where every ranked tool has a present leaf.`
     : `Selected judge ${j.display} has NOT yet scored daydream — the field of ${j.field.length} SaaS tools shares one complete ${j.subset_pr_count}-PR cohort drawn from the daydream anchor set; daydream panels render a placeholder until it is re-judged.`;
 }
 
@@ -504,11 +504,11 @@ function renderCost(){
   const e=DATA.economy;
   $("#cost-sub").innerHTML=`Computed from measured tokens @ <b>${esc(e.price_model)}</b> price card (in $${e.price_card.input} / cached $${e.price_card.cached} / out $${e.price_card.output} per 1M; counters disjoint). Backend records $0 (GLM via z.ai) — this is synthesized, not read. ${e.n_with_trajectory} of ${e.n_prs} PRs have a trajectory.`;
   const host=$("#cost-kpis");host.innerHTML="";
-  const ddtp=(anchorJudge()||{daydream:{tp:1}}).daydream.tp||1;
+  const ddtp=(anchorJudge()||{daydream:{tp:null}}).daydream?.tp;
   const cards=[
     {label:"Total cost",val:fmtUSD(e.total_cost_usd),sub:`${e.n_with_trajectory} PRs`},
     {label:"Cost / PR",val:fmtUSD(e.cost_per_pr),sub:"mean over scored PRs"},
-    {label:"Cost / true positive",val:"$"+(e.total_cost_usd/ddtp).toFixed(3),sub:"total $ ÷ TP"},
+    {label:"Cost / true positive",val:ddtp?"$"+(e.total_cost_usd/ddtp).toFixed(3):"—",sub:"total $ ÷ TP"},
   ];
   cards.forEach((c,i)=>{const d=document.createElement("div");d.className="kpi "+(i===1?"mint":i===2?"steel":"");
     d.innerHTML=`<div class="label">${c.label}</div><div class="val">${c.val}</div><div class="sub">${c.sub}</div>`;host.appendChild(d);});

--- a/tests/test_benchmark_report_build.py
+++ b/tests/test_benchmark_report_build.py
@@ -305,14 +305,22 @@ def test_generated_report_ranks_one_complete_cohort(
     assert judge["daydream"] is not None
     assert len(judge["field"]) == 5
     assert judge["subset_pr_count"] == 2
+    # daydream's own scored count is independent of the competitor-collapsed cohort:
+    # the anchor scored daydream on all 3 PRs; only the comparison cohort is 2.
+    assert judge["daydream_pr_count"] == (2 if missing_tool == "daydream-owl-alpha" else 3)
     rows = [judge["daydream"]] + judge["field"]
     assert {r["n_prs"] for r in rows} == {2}
     # The third PR's tp=4 leaf must NOT be counted; every row sums tp 1+2 = 3.
     assert {r["tp"] for r in rows} == {3}
     assert all(rk[1] == 6 for rk in judge["ranks"].values())
+    # The excluded PR must not leak into the per-PR log either: per-PR scores trace
+    # to the judge's complete cohort, not the full report-wide anchor set.
+    assert set(data["per_pr_scores"][judge["id"]]) == {PR_URL, SECOND_PR_URL}
+    assert THIRD_PR_URL not in data["per_pr_scores"][judge["id"]]
 
     html = (out_dir / "index.html").read_text()
-    assert "On <b>${anchor.subset_pr_count} PRs</b>" in html
+    # Lead distinguishes daydream's own scored PR count from the collapsed cohort.
+    assert "daydream was scored on <b>${anchor.daydream_pr_count} PRs</b>" in html
     assert "present leaf for every ranked row" in html
     assert "Every SaaS tool is recomputed on this exact subset per judge" not in html
 
@@ -372,6 +380,9 @@ def test_build_collapses_field_to_complete_cohort_when_tool_incomplete(
     assert judge["daydream"] is not None and judge["daydream"]["n_prs"] == 1
     assert judge["ranks"]["f1"][1] == 7          # 6 SaaS + daydream
     assert report["meta"]["subset_pr_count"] == 2  # global anchor unchanged
+    # The collapsed cohort (PR 1 only) is the per-PR log's daydream scope too: the
+    # PR whose competitor leaf is missing must not show daydream scores.
+    assert set(report["per_pr_scores"][judge["id"]]) == {PR_URL}
 
 
 def test_build_skips_judge_with_no_complete_common_cohort(
@@ -396,6 +407,52 @@ def test_build_skips_judge_with_no_complete_common_cohort(
     assert "gpt-5.2" in skipped
     assert skipped["gpt-5.2"]["reason"] == "no complete common PR cohort"
     assert all(j["id"] != "gpt-5.2" for j in report["judges"])
+
+
+def test_report_anchor_falls_back_to_retained_judge_when_none_have_daydream(
+    build_mod: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Anchor-orphan corner: the largest daydream-subset judge is panel-skipped AND no
+    retained judge carries any daydream leaf, so the has_daydream fallback finds
+    nothing. The anchor must still resolve to a retained judge so meta.anchor_judge
+    never references a skipped judge absent from judges_out; label slices stay empty
+    and the priority-3 re-judge improvement names the retained daydream-less judges."""
+    monkeypatch.setenv("DAYDREAM_PRICES_FILE", str(tmp_path / "absent.toml"))
+    saas5 = {f"saas-{i}": _leaf(tp=1, fp=0) for i in range(5)}
+    skip_anchor = {"saas-0": _leaf(tp=1, fp=0), "saas-1": _leaf(tp=1, fp=0)}
+    evals = {
+        # Largest daydream subset (2 PRs) but only 2 SaaS tools -> SaaS-coverage skip.
+        "a-skip-anchor": {
+            PR_URL: {**skip_anchor, "daydream-owl-alpha": _leaf(tp=1, fp=2, fn=1)},
+            SECOND_PR_URL: {**skip_anchor, "daydream-owl-alpha": _leaf(tp=2, fp=1, fn=1)},
+        },
+        # Retained judge (5 SaaS tools) with NO daydream leaf on either PR.
+        "z-retained": {
+            PR_URL: dict(saas5),
+            SECOND_PR_URL: dict(saas5),
+        },
+    }
+    report: dict[str, Any] = build_mod.build(_anchor_corpus(tmp_path, evals))
+
+    # The skipped judge is not retained and no retained judge carries daydream, so
+    # the anchor falls back to a retained judge (never a skipped id).
+    assert [j["id"] for j in report["judges"]] == ["z-retained"]
+    assert [s["id"] for s in report["skipped_judges"]] == ["a-skip-anchor"]
+    assert report["judges"][0]["has_daydream"] is False
+    assert report["meta"]["anchor_judge"] == "z-retained"
+    assert "a-skip-anchor" not in {j["id"] for j in report["judges"]}
+
+    # No retained daydream -> no label slices; the economy still traces to the
+    # skipped judge's daydream subset (the fixed cross-judge anchor).
+    assert report["slices"] == []
+    assert report["meta"]["subset_pr_count"] == 2
+    assert report["economy"]["n_prs"] == 2
+
+    # No priority-1 (no retained anchor FP to cite); priority-3 names the retained
+    # daydream-less judge.
+    assert all(im["priority"] != 1 for im in report["improvements"])
+    p3 = next(im for im in report["improvements"] if im["priority"] == 3)
+    assert "z-retained" in p3["heading"]
 
 
 def test_complete_cohort_requires_present_leaf_across_all_tools(build_mod: ModuleType) -> None:
@@ -748,7 +805,7 @@ def test_template_consumers_resolve_anchor_judge_by_id(tmp_path: Path) -> None:
 
     assert "function anchorJudge(){return DATA.judges.find(j=>j.id===DATA.meta.anchor_judge);}" in template
     assert template.count("const anchor=anchorJudge();") == 2  # renderLead, renderSlices
-    assert "const ddtp=(anchorJudge()||{daydream:{tp:1}})" in template  # renderCost
+    assert "const ddtp=(anchorJudge()||{daydream:{tp:null}}).daydream?.tp;" in template  # renderCost
     assert "DATA.judges.find(j=>j.has_daydream)" not in template
 
 

--- a/tests/test_benchmark_report_build.py
+++ b/tests/test_benchmark_report_build.py
@@ -32,7 +32,6 @@ PR_URL = "https://github.com/calcom/cal.com/pull/10600"
 
 SECOND_PR_URL = "https://github.com/calcom/cal.com/pull/10601"
 THIRD_PR_URL = "https://github.com/calcom/cal.com/pull/10602"
-PR_URLS = (PR_URL, SECOND_PR_URL, THIRD_PR_URL)
 _COMPLETE_SAAS_TOOLS = ("saas-alpha", "saas-beta", "saas-delta", "saas-gamma", "saas-zeta")
 _JUDGE_DIRNAME = "anthropic_claude-opus-4-5-20251101"
 

--- a/tests/test_benchmark_report_build.py
+++ b/tests/test_benchmark_report_build.py
@@ -1,4 +1,4 @@
-"""Tests for the offline benchmark report generator in bench/benchmark-report/build.py."""
+"""Regression coverage for the offline benchmark report generator (bench/benchmark-report/build.py)."""
 
 from __future__ import annotations
 
@@ -31,6 +31,8 @@ def build_mod() -> ModuleType:
 PR_URL = "https://github.com/calcom/cal.com/pull/10600"
 
 SECOND_PR_URL = "https://github.com/calcom/cal.com/pull/10601"
+THIRD_PR_URL = "https://github.com/calcom/cal.com/pull/10602"
+PR_URLS = (PR_URL, SECOND_PR_URL, THIRD_PR_URL)
 _COMPLETE_SAAS_TOOLS = ("saas-alpha", "saas-beta", "saas-delta", "saas-gamma", "saas-zeta")
 _JUDGE_DIRNAME = "anthropic_claude-opus-4-5-20251101"
 
@@ -133,6 +135,45 @@ def _comparison_corpus(root: Path, incomplete_leaf: dict[str, Any] | None) -> ar
         pr2["saas-incomplete"] = incomplete_leaf
     judge = root / "results" / _JUDGE_DIRNAME
     (judge / "evaluations.json").write_text(json.dumps({PR_URL: pr1, SECOND_PR_URL: pr2}))
+    return args
+
+
+def _partial_matrix_corpus(root: Path, missing_tool: str) -> argparse.Namespace:
+    """Three-PR corpus with one comparison tool's leaf absent on the third PR.
+
+    The anthropic judge is a daydream-only 3-PR global anchor (no SaaS rows, so it
+    is SaaS-skipped). The gpt-5.2 panel judge carries daydream + every complete SaaS
+    tool on all three PRs, then ``missing_tool`` is deleted from the third PR — the
+    partial matrix that must collapse to the two-PR complete cohort. Reuses _corpus
+    for the judge dir + trajectories, then overwrites/creates evaluations.json."""
+    args = _corpus(
+        root,
+        pr_trajectories={
+            PR_URL: ("cal.com-10600.json", None, 1_000_000, 1_000_000, 1_000_000, 3, None),
+            SECOND_PR_URL: ("cal.com-10601.json", None, 1_000_000, 1_000_000, 1_000_000, 3, None),
+            THIRD_PR_URL: ("cal.com-10602.json", None, 1_000_000, 1_000_000, 1_000_000, 3, None),
+        },
+    )
+    results = root / "results"
+    # 3-PR global anchor: daydream only, no SaaS rows -> SaaS-skipped judge.
+    anchor_evals = {
+        PR_URL: {"daydream-owl-alpha": _leaf(tp=1)},
+        SECOND_PR_URL: {"daydream-owl-alpha": _leaf(tp=2)},
+        THIRD_PR_URL: {"daydream-owl-alpha": _leaf(tp=4)},
+    }
+    (results / _JUDGE_DIRNAME / "evaluations.json").write_text(json.dumps(anchor_evals))
+    # Panel judge: daydream + every complete SaaS tool on all three PRs, minus
+    # missing_tool's third-PR leaf (the partial matrix).
+    panel_evals = {}
+    for pr, tp in ((PR_URL, 1), (SECOND_PR_URL, 2), (THIRD_PR_URL, 4)):
+        tools = {"daydream-owl-alpha": _leaf(tp=tp)}
+        for tool in _COMPLETE_SAAS_TOOLS:
+            tools[tool] = _leaf(tp=tp)
+        panel_evals[pr] = tools
+    del panel_evals[THIRD_PR_URL][missing_tool]
+    jdir = results / "openai_gpt-5.2"
+    jdir.mkdir(parents=True, exist_ok=True)
+    (jdir / "evaluations.json").write_text(json.dumps(panel_evals))
     return args
 
 
@@ -239,6 +280,44 @@ def test_unknown_price_model_is_rejected(
         build_mod.build(args)
 
 
+@pytest.mark.parametrize("missing_tool", ["daydream-owl-alpha", _COMPLETE_SAAS_TOOLS[0]],
+                         ids=["missing-daydream", "missing-saas"])
+def test_generated_report_ranks_one_complete_cohort(
+    build_mod: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    missing_tool: str,
+) -> None:
+    """A partial matrix (one comparison tool's leaf absent on one PR) still ranks all six
+    rows on the SAME complete cohort: n_prs identical, the excluded PR's score not counted.
+    Drives the real entrypoint (main) and inspects the generated report + HTML."""
+    monkeypatch.setenv("DAYDREAM_PRICES_FILE", str(tmp_path / "absent.toml"))
+    args = _partial_matrix_corpus(tmp_path, missing_tool)
+    out_dir = tmp_path / "report"
+    monkeypatch.setattr(sys, "argv", [
+        "build.py", str(args.results_root),
+        "--daydream-tool", args.daydream_tool, "--price-model", args.price_model,
+        "--trajectories", args.trajectories, "--out", str(out_dir),
+    ])
+    build_mod.main()
+    data = json.loads((out_dir / "data.json").read_text())
+
+    assert len(data["judges"]) == 1          # anthropic anchor is SaaS-skipped
+    judge = data["judges"][0]
+    assert judge["id"] == "gpt-5.2"
+    assert judge["daydream"] is not None
+    assert len(judge["field"]) == 5
+    assert judge["subset_pr_count"] == 2
+    rows = [judge["daydream"]] + judge["field"]
+    assert {r["n_prs"] for r in rows} == {2}
+    # The third PR's tp=4 leaf must NOT be counted; every row sums tp 1+2 = 3.
+    assert {r["tp"] for r in rows} == {3}
+    assert all(rk[1] == 6 for rk in judge["ranks"].values())
+
+    html = (out_dir / "index.html").read_text()
+    assert "On <b>${anchor.subset_pr_count} PRs</b>" in html
+    assert "present leaf for every ranked row" in html
+    assert "Every SaaS tool is recomputed on this exact subset per judge" not in html
+
+
 def test_malformed_phase_event_timestamp_preserves_trajectory_metrics(
     build_mod: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -275,23 +354,59 @@ def test_malformed_phase_event_timestamp_preserves_trajectory_metrics(
 
 
 @pytest.mark.parametrize("incomplete_leaf", [None, {"skipped": True}], ids=["missing", "skipped"])
-def test_build_excludes_incomplete_saas_tools_from_field_and_rank(
+def test_build_collapses_field_to_complete_cohort_when_tool_incomplete(
     build_mod: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
     incomplete_leaf: dict[str, Any] | None,
 ) -> None:
-    """A SaaS tool measured on fewer than the full daydream subset is omitted from the
-    field and rank denominator; every admitted tool is fully covered. Regression for #382."""
+    """A tool with a missing/skipped leaf on one PR collapses the judge's panel to the
+    complete common cohort (the PRs where every compared tool has a present leaf); the
+    once-incomplete tool is RETAINED on that cohort, not dropped. Reconciles the old
+    #382 per-tool-drop behavior to Plan 089's complete-cohort semantics."""
     monkeypatch.setenv("DAYDREAM_PRICES_FILE", str(tmp_path / "absent.toml"))
     report: dict[str, Any] = build_mod.build(_comparison_corpus(tmp_path, incomplete_leaf))
 
     judge = next(j for j in report["judges"] if j["id"] == "claude-opus-4-5-20251101")
     field_tools = {r["tool"] for r in judge["field"]}
-    assert field_tools == set(_COMPLETE_SAAS_TOOLS)
-    assert "saas-incomplete" not in field_tools
-    assert {r["n_prs"] for r in judge["field"]} == {2}
-    assert judge["subset_pr_count"] == 2
-    assert judge["ranks"]["f1"] == (1, 6)
-    assert report["meta"]["subset_pr_count"] == 2
+    assert field_tools == set(_COMPLETE_SAAS_TOOLS) | {"saas-incomplete"}
+    assert {r["n_prs"] for r in judge["field"]} == {1}
+    assert judge["subset_pr_count"] == 1
+    assert judge["daydream"] is not None and judge["daydream"]["n_prs"] == 1
+    assert judge["ranks"]["f1"][1] == 7          # 6 SaaS + daydream
+    assert report["meta"]["subset_pr_count"] == 2  # global anchor unchanged
+
+
+def test_build_skips_judge_with_no_complete_common_cohort(
+    build_mod: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A judge whose comparison tools never co-occur on any PR passes the SaaS-count gate
+    but has an EMPTY complete cohort; it is skipped (never ranked) with the dedicated reason."""
+    monkeypatch.setenv("DAYDREAM_PRICES_FILE", str(tmp_path / "absent.toml"))
+    saas5 = {f"saas-{i}": _leaf(tp=1) for i in range(5)}
+    evals = {
+        _ANCHOR: {
+            PR_URL: {**saas5, "daydream-owl-alpha": _leaf(tp=1)},
+            SECOND_PR_URL: {**saas5, "daydream-owl-alpha": _leaf(tp=1)},
+        },
+        "openai_gpt-5.2": {
+            PR_URL: dict(saas5),                                # SaaS only, no daydream
+            SECOND_PR_URL: {"daydream-owl-alpha": _leaf(tp=1)},  # daydream only, no SaaS
+        },
+    }
+    report: dict[str, Any] = build_mod.build(_anchor_corpus(tmp_path, evals))
+    skipped = {s["id"]: s for s in report["skipped_judges"]}
+    assert "gpt-5.2" in skipped
+    assert skipped["gpt-5.2"]["reason"] == "no complete common PR cohort"
+    assert all(j["id"] != "gpt-5.2" for j in report["judges"])
+
+
+def test_complete_cohort_requires_present_leaf_across_all_tools(build_mod: ModuleType) -> None:
+    evals = {
+        "pr1": {"a": _leaf(tp=1), "b": _leaf(tp=1)},
+        "pr2": {"a": _leaf(tp=1), "b": {"skipped": True}},
+        "pr3": {"a": _leaf(tp=1)},                     # b absent
+    }
+    assert build_mod._complete_cohort(evals, ["a", "b"], {"pr1", "pr2", "pr3"}) == {"pr1"}
+    assert build_mod._complete_cohort(evals, ["a"], {"pr1", "pr2", "pr3"}) == {"pr1", "pr2", "pr3"}
 
 
 def test_report_joins_trajectories_by_full_repository_identity(


### PR DESCRIPTION
## Summary
Closes #428

Rank every benchmark tool (daydream + each SaaS competitor) on **one complete PR cohort per judge**.

The report previously started from one global daydream PR set, but `aggregate_tool` skipped missing or skipped leaves independently per tool. A partially rescored judge could therefore rank rows whose `n_prs` values and underlying PR identities differed — readers could compare unequal samples.

### What changed
- **`bench/benchmark-report/build.py`** — added `_complete_cohort()`, which derives, for each retained judge panel, the set of PRs with a present leaf for every compared tool. Every field row and the optional daydream row are now aggregated over that same cohort; `subset_pr_count` is its length. Judges with no nonempty common cohort are recorded in `skipped_judges` (reason `no complete common PR cohort`).
- **`bench/benchmark-report/template.html`** — ranking/leaderboard/scatter/footer wording now describe each panel's complete cohort and per-judge cohort size, replacing the exact-global-subset claim.
- **`tests/test_benchmark_report_build.py`** — parameterized acceptance test `test_generated_report_ranks_one_complete_cohort` proves partial daydream and partial SaaS matrices each yield six ranked rows on the same two PRs with aggregate `tp` equal to 3.

### Verification
- `uv lock --check` — no lockfile drift
- Focused pytest on the new acceptance test — both params pass
- `make check` — lock, ruff, mypy, and full parallel pytest gates green

Authored by Kevin Anderson. Reviewed by two sequential daydream deep-precision review rounds (round-1 and round-2 on fresh exe.dev VMs); round-2 verified 29 tests in `tests/test_benchmark_report_build.py` including the new anchor-orphan test.