### PR TITLE
build(rl): pin rollout image inputs to immutable, integrity-verified references (Closes #429)

### DIFF
--- a/rl/daydream_review_v1/README.md
+++ b/rl/daydream_review_v1/README.md
@@ -89,6 +89,23 @@ baseline against a pi-scaffold trained run moves two variables at once.
    repository name with NO tag — the tag is the task's 12-char head SHA, so one
    image is exactly one PR snapshot.
 
+   Every repository with a non-empty `setup_cmds` must satisfy four rules:
+
+   - The dependency lockfile is **committed at the head SHA** baked into the
+     image, so the image installs exactly the dependency set that commit pins.
+   - The package manager runs in a mode that **rejects lock drift** (e.g.
+     `uv sync --locked`): a lock that is missing or no longer matches fails the
+     build rather than silently resolving a different dependency set.
+   - The generated dependency environment lives **outside `/work/repo`** (e.g.
+     `UV_PROJECT_ENVIRONMENT=/opt/repo-venv`), so the baked checkout stays
+     clean and the environment survives into the image.
+   - `test_command` invokes the environment produced by that locked setup (e.g.
+     `/opt/repo-venv/bin/python -m pytest -q`), so the green-baseline gate and
+     the rollout's `fix_tests_pass` re-run both exercise the locked dependencies.
+
+   An unavailable or stale lock is an **image-build failure** — never permission
+   to **fall back to unconstrained pip**.
+
 3. **Build the images.** The last layer runs the repository's own suite at the
    head commit; a red baseline fails the build and produces nothing, because
    `fix_tests_pass` would otherwise be rewarding noise.

--- a/rl/daydream_review_v1/images/base.Dockerfile
+++ b/rl/daydream_review_v1/images/base.Dockerfile
@@ -12,6 +12,12 @@
 # contract at rollout time — DaydreamReviewHarness.setup() refuses an image whose
 # selected backend's binary is missing (daydream_review_v1/harness.py:66-79).
 
+# The uv bootstrap comes from a digest-pinned image stage, not pip: pip is the
+# last moving installer a base build could still resolve at build time, and the
+# digest names one specific multi-platform index for uv 0.11.29 that cannot
+# drift. /uv and /uvx are copied onto PATH in the python stage below.
+FROM ghcr.io/astral-sh/uv:0.11.29@sha256:eb2843a1e56fd9e30c7276ce1a52cba86e64c7b385f5e3279a0e08e02dd058fc AS uv
+
 # The base is pinned by its immutable multi-platform index digest, not a mutable
 # tag: a tag like `3.12-slim` tracks whatever `latest`-flavored manifest it
 # currently resolves to, so a base rebuilt later could silently pick up a moved
@@ -36,11 +42,11 @@ RUN apt-get update \
 
 # uv installs the daydream wheel into the system interpreter. There is no venv
 # on purpose: `daydream` must be on PATH for any process the harness starts,
-# and a rollout container hosts exactly one application. uv itself is pinned to
-# an exact version so the bootstrap tool cannot drift between builds.
-ARG UV_VERSION=0.11.29
-RUN pip install --no-cache-dir "uv==${UV_VERSION}" \
- && uv --version
+# and a rollout container hosts exactly one application. The binary came from
+# the digest-pinned uv image stage above, so the bootstrap tool cannot drift
+# between builds.
+COPY --from=uv /uv /uvx /bin/
+RUN uv --version
 
 # HOME is set before the CLI installs, not after, so the claude installer writes
 # its binary and its cache under the SAME home the harness later hands daydream

--- a/rl/daydream_review_v1/images/manifest.toml
+++ b/rl/daydream_review_v1/images/manifest.toml
@@ -25,10 +25,15 @@ setup_cmds = []
 # tests/fixtures/corpus-reference/ (PR #406, head 4bb03cd6819228f3, base
 # 4dffa1963f896a0a — the merge commit's two parents).
 #
+# Dependencies install strictly from the repository's committed uv.lock via a
+# locked sync into an environment OUTSIDE /work/repo (/opt/repo-venv), and the
+# test command runs that environment's interpreter. A lock that is missing or
+# stale fails the build (set -eu in setup.sh); there is no pip fallback.
+#
 # This is a reference, NOT the training set. Expanding to a real training-repo set
 # is data ops, tracked as its own numbered task on issue #164.
 [repos."pallets/itsdangerous"]
 clone_url = "https://github.com/pallets/itsdangerous.git"
 image = "daydream-rl/itsdangerous"
-test_command = "python -m pytest -q"
-setup_cmds = ["pip install -e .", "pip install pytest freezegun"]
+test_command = "/opt/repo-venv/bin/python -m pytest -q"
+setup_cmds = ["UV_PYTHON_DOWNLOADS=never UV_PROJECT_ENVIRONMENT=/opt/repo-venv uv sync --locked --no-default-groups --group tests"]

--- a/rl/daydream_review_v1/tests/test_images.py
+++ b/rl/daydream_review_v1/tests/test_images.py
@@ -54,6 +54,25 @@ def _tags() -> set[str]:
     return {line.strip() for line in listed.stdout.splitlines() if line.strip()}
 
 
+MANIFEST = PROJECT_ROOT / "images" / "manifest.toml"
+REFERENCE_IMAGE = "daydream-rl/itsdangerous"
+REFERENCE_TAG = f"{REFERENCE_IMAGE}:4bb03cd68192"
+REFERENCE_CORPUS = PROJECT_ROOT / "tests" / "fixtures" / "corpus-reference"
+
+
+def _build_reference(base_image: str) -> subprocess.CompletedProcess[str]:
+    """Build the reference repo image only; the ``base_image`` fixture owns the base."""
+    return subprocess.run(
+        [
+            "uv", "run", "python", "images/build_images.py",
+            "--only", "pallets/itsdangerous",
+            "--corpus", str(REFERENCE_CORPUS),
+            "--no-base", base_image,
+        ],
+        cwd=PROJECT_ROOT, capture_output=True, text=True, check=False,
+    )
+
+
 @pytest.mark.parametrize(
     "argv,expected_stderr",
     [
@@ -268,6 +287,43 @@ def test_green_baseline_builds_and_bakes_the_checkout(base_image: str) -> None:
     # origin is the in-container mirror, so daydream's terminal push stays inside
     # the container and no rollout needs a credential.
     assert "/srv/mirror.git" in probe.stdout
+
+
+def test_reference_manifest_entry_consumes_its_committed_lock() -> None:
+    """The itsdangerous entry installs strictly from its committed uv.lock."""
+    text = MANIFEST.read_text(encoding="utf-8")
+    entry = text[text.index('[repos."pallets/itsdangerous"]') :]
+    assert "uv sync --locked --no-default-groups --group tests" in entry
+    assert "UV_PROJECT_ENVIRONMENT=/opt/repo-venv" in entry
+    assert "UV_PYTHON_DOWNLOADS=never" in entry
+    assert 'test_command = "/opt/repo-venv/bin/python -m pytest -q"' in entry
+    assert "pip install" not in entry
+
+
+def test_fixture_manifest_entry_stays_dependency_free() -> None:
+    """The deterministic fixture entry is untouched: no setup, its unittest command."""
+    text = MANIFEST.read_text(encoding="utf-8")
+    head = text[: text.index('[repos."pallets/itsdangerous"]')]
+    assert 'setup_cmds = []' in head
+    assert 'test_command = "python -m unittest discover -q"' in head
+
+
+@pytest.mark.slow
+@DOCKER_REQUIRED
+def test_reference_image_builds_with_locked_dependencies(base_image: str) -> None:
+    """The reference image builds only when the locked setup + green baseline succeed."""
+    result = _build_reference(base_image)
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0, combined[-3000:]
+    assert f"built {REFERENCE_TAG}" in result.stdout, combined[-3000:]
+    # Discriminating probe: only the locked setup creates /opt/repo-venv with the
+    # test deps; a pip-based setup would leave it absent, so this fails a regression.
+    probe = subprocess.run(
+        ["docker", "run", "--rm", REFERENCE_TAG, "sh", "-c",
+         "test -x /opt/repo-venv/bin/python && /opt/repo-venv/bin/python -c 'import pytest, freezegun'"],
+        capture_output=True, text=True, check=False,
+    )
+    assert probe.returncode == 0, probe.stdout + probe.stderr
 
 
 def test_docker_required_gates_on_daemon_reachability() -> None:

--- a/rl/daydream_review_v1/tests/test_images.py
+++ b/rl/daydream_review_v1/tests/test_images.py
@@ -336,9 +336,15 @@ def test_reference_image_builds_with_locked_dependencies(base_image: str) -> Non
     assert f"built {REFERENCE_TAG}" in result.stdout, combined[-3000:]
     # Discriminating probe: only the locked setup creates /opt/repo-venv with the
     # test deps; a pip-based setup would leave it absent, so this fails a regression.
+    # It also pins the editable-install invariant: the package under test must
+    # resolve from the baked /work/repo checkout, not a venv copy, so the rollout
+    # re-run in fix_tests_pass exercises the agent's edits rather than stale code.
     probe = subprocess.run(
         ["docker", "run", "--rm", REFERENCE_TAG, "sh", "-c",
-         "test -x /opt/repo-venv/bin/python && /opt/repo-venv/bin/python -c 'import pytest, freezegun'"],
+         "test -x /opt/repo-venv/bin/python && /opt/repo-venv/bin/python -c '"
+         "import pytest, freezegun; "
+         "import itsdangerous; "
+         "assert '/work/repo' in itsdangerous.__file__, itsdangerous.__file__'"],
         capture_output=True, text=True, check=False,
     )
     assert probe.returncode == 0, probe.stdout + probe.stderr

--- a/rl/daydream_review_v1/tests/test_images.py
+++ b/rl/daydream_review_v1/tests/test_images.py
@@ -311,8 +311,14 @@ def test_docker_skip_is_per_test_not_module_wide() -> None:
             "FROM python:3.12.13-slim@sha256:229a2c5bfa27522db7815ea81f9bed70af17ccb9de9fc7ad142b1877b5830d36",
             id="python-base-index-digest",
         ),
-        pytest.param("ARG UV_VERSION=0.11.29", id="uv-pin"),
-        pytest.param('pip install --no-cache-dir "uv==${UV_VERSION}"', id="uv-exact-install"),
+        pytest.param(
+            (
+                "FROM ghcr.io/astral-sh/uv:0.11.29@"
+                "sha256:eb2843a1e56fd9e30c7276ce1a52cba86e64c7b385f5e3279a0e08e02dd058fc AS uv"
+            ),
+            id="uv-image-digest-pin",
+        ),
+        pytest.param("COPY --from=uv /uv /uvx /bin/", id="uv-copy-from-image"),
         pytest.param("ARG CLAUDE_CODE_VERSION=2.1.214", id="claude-version"),
         pytest.param(
             "release_fingerprint=31DDDE24DDFAB679F42D7BD2BAA929FF1A7ECACE",

--- a/rl/daydream_review_v1/tests/test_images.py
+++ b/rl/daydream_review_v1/tests/test_images.py
@@ -55,6 +55,7 @@ def _tags() -> set[str]:
 
 
 MANIFEST = PROJECT_ROOT / "images" / "manifest.toml"
+README = PROJECT_ROOT / "README.md"
 REFERENCE_IMAGE = "daydream-rl/itsdangerous"
 REFERENCE_TAG = f"{REFERENCE_IMAGE}:4bb03cd68192"
 REFERENCE_CORPUS = PROJECT_ROOT / "tests" / "fixtures" / "corpus-reference"
@@ -306,6 +307,23 @@ def test_fixture_manifest_entry_stays_dependency_free() -> None:
     head = text[: text.index('[repos."pallets/itsdangerous"]')]
     assert 'setup_cmds = []' in head
     assert 'test_command = "python -m unittest discover -q"' in head
+
+
+def test_readme_documents_the_locked_dependency_policy() -> None:
+    """The 'Adding a repository' section states the four mandatory setup rules."""
+    text = README.read_text(encoding="utf-8")
+    section = text[text.index("## Adding a repository") :]
+    for marker in (
+        "committed at the head SHA",            # rule 1: lockfile committed at baked head
+        "rejects lock drift",                   # rule 2: no silent drift
+        "uv sync --locked",                     # rule 2: the concrete mode
+        "outside `/work/repo`",                 # rule 3: external environment
+        "UV_PROJECT_ENVIRONMENT=/opt/repo-venv",  # rule 3: the concrete env
+        "/opt/repo-venv/bin/python -m pytest -q",  # rule 4: locked test command
+        "image-build failure",                  # no-fallback statement
+        "fall back to unconstrained pip",       # no-fallback statement
+    ):
+        assert marker in section, f"README '## Adding a repository' must state {marker!r}"
 
 
 @pytest.mark.slow

--- a/rl/daydream_review_v1/tests/test_images.py
+++ b/rl/daydream_review_v1/tests/test_images.py
@@ -344,7 +344,7 @@ def test_reference_image_builds_with_locked_dependencies(base_image: str) -> Non
          "test -x /opt/repo-venv/bin/python && /opt/repo-venv/bin/python -c '"
          "import pytest, freezegun; "
          "import itsdangerous; "
-         "assert '/work/repo' in itsdangerous.__file__, itsdangerous.__file__'"],
+         "assert \"/work/repo\" in itsdangerous.__file__, itsdangerous.__file__'"],
         capture_output=True, text=True, check=False,
     )
     assert probe.returncode == 0, probe.stdout + probe.stderr

--- a/rl/daydream_review_v1/tests/test_taskset.py
+++ b/rl/daydream_review_v1/tests/test_taskset.py
@@ -350,5 +350,5 @@ def test_reference_corpus_loads_against_the_manifest(fixture_manifest_path: Path
     assert task.data.pr_number == 406
     assert task.data.head_sha == "4bb03cd6819228f30079885297299fe568a62863"
     assert task.data.base_sha == "4dffa1963f896a0a311dec3c14f003a5f382c446"
-    assert task.data.test_command == "python -m pytest -q"
+    assert task.data.test_command == "/opt/repo-venv/bin/python -m pytest -q"
     assert task.data.image == "daydream-rl/itsdangerous:4bb03cd68192"


### PR DESCRIPTION
## Summary

- Make the rollout base image inputs immutable: the uv bootstrap now comes from a digest-pinned `ghcr.io/astral-sh/uv` image stage (`COPY --from=uv /uv /uvx /bin/`) instead of a versioned pip install.
- Install the reference repository's test dependencies strictly from its committed `uv.lock` via `uv sync --locked` into an environment outside `/work/repo` (`/opt/repo-venv`), and run the green-baseline gate through that environment's interpreter. A missing or stale lock is an image-build failure — no pip fallback.
- Document the locked-dependency policy in the repo-adding workflow, and add static tests asserting the digest pins, verify-before-install ordering, and the locked manifest entry.

## Motivation

The rollout base previously resolved a floating pip-installed uv and installed reference-repo dependencies without consuming its committed lock. Two builds of the same PR snapshot could contain different tools or dependencies, so a previously green baseline could change independently of the reviewed commit and make training rewards incomparable.

Closes #429

## Changes

- `rl/daydream_review_v1/images/base.Dockerfile` — digest-pin the uv bootstrap stage; remove the pip-based uv install.
- `rl/daydream_review_v1/images/manifest.toml` — ItsDangerous reference entry installs from the committed lock into `/opt/repo-venv` and runs pytest through that interpreter.
- `rl/daydream_review_v1/README.md` — document the four mandatory locked-dependency rules for non-empty `setup_cmds`.
- `rl/daydream_review_v1/tests/test_images.py` — add static digest-pin, verify-before-install, and locked-manifest tests.
- `rl/daydream_review_v1/tests/test_taskset.py` — adjust to the locked manifest entry.

## Test Plan

- [x] `uv run pytest` in `rl/daydream_review_v1` (CI `rl-check` job, incl. Docker-backed reference build)
- [x] `uv run pytest -n auto`, `ruff check`, `mypy` (CI `check` job)
- [x] Two sequential daydream deep-precision review rounds (deep-python + deep-structure), test verdict passed, fix-quality-gate clean.

## Notes for Reviewers

Merge gate is two sequential daydream reviews (no CodeRabbit in this org). Deterministic-authorship gate run: all commits authored by the token owner.
