### PR TITLE
docs: point PR checklist at make check and CI actionlint gates (Closes #433)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,9 +34,8 @@
 
 <!-- Verify before requesting review. -->
 
-- [ ] Tests pass locally (`uv run pytest`)
-- [ ] Linting passes (`uv run ruff check`)
-- [ ] Type checking passes (`uv run mypy daydream`)
+- [ ] Repository checks pass locally (`make check`)
+- [ ] Actionlint passes for workflow YAML changes (if applicable): `docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:1.7.7 -color .github/workflows/*.yml daydream/templates/workflows/*.yml daydream/templates/workflows/single/*.yml`
 - [ ] Documentation updated (if applicable)
 
 ## Additional Context


### PR DESCRIPTION
## Summary

Point the pull-request checklist at the canonical verification gates.

Closes #433