### PR TITLE
test: reuse shared install_backend fixture at fixed-backend integration sites

### DIFF
--- a/tests/test_deep_parse_concurrency.py
+++ b/tests/test_deep_parse_concurrency.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import re
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -56,16 +57,22 @@ class _RendezvousParseStub(StubBackend):
             yield event
 
 
-def _install_raw(monkeypatch: pytest.MonkeyPatch, stub: StubBackend) -> None:
-    monkeypatch.setattr("daydream.runner.create_backend", lambda name, model=None, **kw: stub)
+def _install_raw(
+    monkeypatch: pytest.MonkeyPatch, stub: StubBackend,
+    install_backend: Callable[[object], object],
+) -> None:
+    install_backend(stub)
     monkeypatch.setattr("daydream.deep.orchestrator.get_installed_skills", lambda: None)
     monkeypatch.setattr("daydream.deep.orchestrator.EXPLORATION_AVAILABLE", False)
 
 
-async def test_parse_runs_concurrently(multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_parse_runs_concurrently(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch,
+    install_backend: Callable[[object], object],
+) -> None:
     """The N per-stack parse calls overlap; every stack's records land on disk."""
     stub = _RendezvousParseStub(multi_stack_target)
-    _install_raw(monkeypatch, stub)
+    _install_raw(monkeypatch, stub, install_backend)
 
     with anyio.fail_after(15):
         exit_code = await _run_deep(multi_stack_target)
@@ -104,11 +111,12 @@ class _FailingParseStub(StubBackend):
 
 
 async def test_parse_failure_propagates_original_exception_type(
-    multi_stack_target: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, make_config
+    multi_stack_target: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    make_config, install_backend: Callable[[object], object],
 ) -> None:
     """One stack's parse failure fails the run with its own exception type."""
     stub = _FailingParseStub(multi_stack_target, failing_stack="python")
-    _install_raw(monkeypatch, stub)
+    _install_raw(monkeypatch, stub, install_backend)
     from daydream.runner import run
 
     trajectory_path = tmp_path / "trajectory.json"

--- a/tests/test_deep_parse_concurrency.py
+++ b/tests/test_deep_parse_concurrency.py
@@ -61,6 +61,16 @@ def _install_raw(
     monkeypatch: pytest.MonkeyPatch, stub: StubBackend,
     install_backend: Callable[[object], object],
 ) -> None:
+    """Install a *caller-supplied custom* stub backend via the shared
+    ``install_backend`` fixture, then pin skill availability.
+
+    Unlike ``install_stub_backend`` (which builds its own ``StubBackend`` from a
+    target), this installs a custom stub (e.g. a rendezvous or failing stub) at
+    the ``create_backend`` seam so tests can observe parse concurrency / failure
+    behavior. The two skill-availability pins are identical to
+    ``install_stub_backend``'s defaults and keep the test off the local Beagle
+    plugin registry.
+    """
     install_backend(stub)
     monkeypatch.setattr("daydream.deep.orchestrator.get_installed_skills", lambda: None)
     monkeypatch.setattr("daydream.deep.orchestrator.EXPLORATION_AVAILABLE", False)

--- a/tests/test_feedback_subcommand_integration.py
+++ b/tests/test_feedback_subcommand_integration.py
@@ -16,6 +16,7 @@ its prompt-dispatching stub — there is exactly one stub, no parallel copy.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -31,7 +32,8 @@ from tests.test_pr_feedback_integration import (
 
 
 async def test_feedback_subcommand_argv_to_body(
-    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch,
+    install_backend: Callable[[object], object],
 ) -> None:
     """Real-path: argv -> _parse_args(feedback) -> run_feedback -> full body.
 
@@ -54,7 +56,7 @@ async def test_feedback_subcommand_argv_to_body(
 
     _silence(monkeypatch)
     stub = _PRFeedbackStubBackend()
-    monkeypatch.setattr("daydream.runner.create_backend", lambda name, model=None, **kwargs: stub)
+    install_backend(stub)
 
     head_before = _git(multi_stack_target, "rev-parse", "HEAD")
 
@@ -78,7 +80,8 @@ async def test_feedback_subcommand_argv_to_body(
 
 
 async def test_feedback_subcommand_non_interactive_argv_to_body(
-    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    install_backend: Callable[[object], object],
 ) -> None:
     """Real-path: ``daydream feedback ... --non-interactive`` parses AND runs.
 
@@ -115,7 +118,7 @@ async def test_feedback_subcommand_non_interactive_argv_to_body(
 
     # No _silence — stdin must never be touched.
     stub = _PRFeedbackStubBackend()
-    monkeypatch.setattr("daydream.runner.create_backend", lambda name, model=None, **kwargs: stub)
+    install_backend(stub)
 
     def _forbidden_input(*_a: object, **_kw: object) -> str:
         raise AssertionError("input() was called -- feedback path must not touch stdin")


### PR DESCRIPTION
## Summary

Reuses the shared `install_backend` test fixture at the three evidenced
fixed-backend integration sites instead of hand-rolling `create_backend`
monkeypatch stubs (Closes #434).

### Changes
- **tests/test_feedback_subcommand_integration.py** — `feedback` subcommand
  tests now install their stub backend via the shared `install_backend` fixture
  (both argv and `--non-interactive` paths).
- **tests/test_deep_parse_concurrency.py** — deep parse concurrency tests
  (rendezvous + failing stubs) now route through `install_backend` via a
  caller-supplied custom-stub helper `_install_raw`, which documents its
  custom-stub role (it cannot use `install_stub_backend`, which builds its own
  `StubBackend` from a target).

### Verification
- Full test suite green: 3347 passed, 6 skipped, 0 failed
- ruff clean

### Plan
Covered finding fingerprint `f1068c44968a44f714356a0f870e32bd14e13b9ce28675c51bfe7953987cce0b`

Closes #434