### PR TITLE
Bound benchmark extraction and deduplication concurrency deterministically (issue #432)

### DIFF
--- a/daydream/benchmark/anthropic_score.py
+++ b/daydream/benchmark/anthropic_score.py
@@ -10,9 +10,10 @@ entry both in-process judge routes drive.
 from __future__ import annotations
 
 import asyncio
+import functools
 import json
 import os
-from collections.abc import Callable, Collection
+from collections.abc import Awaitable, Callable, Collection
 from contextlib import AsyncExitStack
 from dataclasses import dataclass
 from pathlib import Path
@@ -194,9 +195,8 @@ async def run_anthropic_extraction(
     all_candidates = _load_json_dict(candidates_file, required=False)
 
     selected = _make_selection(golden_urls)
-    semaphore = asyncio.Semaphore(_JUDGE_CONCURRENCY)
-    tasks = []
-    meta = []
+    jobs: list[tuple[tuple[int, str], Callable[[], Awaitable[Any]]]] = []
+    last_review_index: dict[str, int] = {}
     for golden_url, entry in data.items():
         if selected is not None and golden_url not in selected:
             continue
@@ -209,25 +209,38 @@ async def run_anthropic_extraction(
             if not all_text.strip():
                 continue
 
-            tasks.append(
-                _complete_json_limited(
-                    semaphore,
-                    client,
-                    system=_EXTRACTION_SYSTEM,
-                    user=_EXTRACTION_PROMPT.format(comment=all_text),
-                    max_tokens=_MAX_EXTRACTION_TOKENS,
+            job_index = len(jobs)
+            jobs.append(
+                (
+                    (job_index, golden_url),
+                    functools.partial(
+                        client.complete_json,
+                        system=_EXTRACTION_SYSTEM,
+                        user=_EXTRACTION_PROMPT.format(comment=all_text),
+                        max_tokens=_MAX_EXTRACTION_TOKENS,
+                    ),
                 )
             )
-            meta.append(golden_url)
+            # Reserve the URL key up front so candidates.json keeps source order
+            # regardless of completion order.
+            all_candidates.setdefault(golden_url, {})
+            last_review_index[golden_url] = job_index
 
-    results = await asyncio.gather(*tasks, return_exceptions=True)
-    for golden_url, result in zip(meta, results, strict=True):
+    def _handle(meta: tuple[int, str], result: Any) -> None:
+        job_index, golden_url = meta
+        # Extraction is fail-fast: any permanent failure (5xx after retries, or a
+        # malformed response) aborts the run before the remaining paid calls finish.
         if isinstance(result, BaseException):
             raise result
         issues = _extract_issues(result)
-        all_candidates.setdefault(golden_url, {})[tool] = [
-            {"text": issue, "path": None, "line": None, "source": "extracted"} for issue in issues
-        ]
+        # A URL with several reviews keeps only its last review's issues; committing
+        # by completion order would make the winner nondeterministic.
+        if job_index == last_review_index[golden_url]:
+            all_candidates.setdefault(golden_url, {})[tool] = [
+                {"text": issue, "path": None, "line": None, "source": "extracted"} for issue in issues
+            ]
+
+    await run_bounded(jobs, handle=_handle)
 
     candidates_file.write_text(json.dumps(all_candidates, indent=2))
 
@@ -256,9 +269,7 @@ async def run_anthropic_dedup(
     all_groups = _load_json_dict(groups_file, required=False)
 
     selected = _make_selection(golden_urls)
-    semaphore = asyncio.Semaphore(_JUDGE_CONCURRENCY)
-    tasks = []
-    meta = []
+    jobs: list[tuple[tuple[str, int], Callable[[], Awaitable[Any]]]] = []
     for golden_url, tools in all_candidates.items():
         if selected is not None and golden_url not in selected:
             continue
@@ -272,25 +283,30 @@ async def run_anthropic_dedup(
         if len(texts) < _MIN_DEDUP_CANDIDATES:
             continue
 
-        tasks.append(
-            _complete_json_limited(
-                semaphore,
-                client,
-                system=_DEDUP_SYSTEM,
-                user=_DEDUP_PROMPT.format(candidates=_numbered_candidates(texts)),
-                max_tokens=_MAX_DEDUP_TOKENS,
+        jobs.append(
+            (
+                (golden_url, len(texts)),
+                functools.partial(
+                    client.complete_json,
+                    system=_DEDUP_SYSTEM,
+                    user=_DEDUP_PROMPT.format(candidates=_numbered_candidates(texts)),
+                    max_tokens=_MAX_DEDUP_TOKENS,
+                ),
             )
         )
-        meta.append((golden_url, len(texts)))
+        # Reserve the URL key up front so dedup_groups.json keeps source order.
+        all_groups.setdefault(golden_url, {})
 
-    results = await asyncio.gather(*tasks, return_exceptions=True)
-    for (golden_url, n_texts), result in zip(meta, results, strict=True):
+    def _handle(meta: tuple[str, int], result: Any) -> None:
+        golden_url, n_texts = meta
         if isinstance(result, BaseException) and not isinstance(result, Exception):
             raise result
         groups = _extract_dedup_groups(result, n_texts) if isinstance(result, dict) else None
         if groups is None:
             groups = _singleton_groups(n_texts)
         all_groups.setdefault(golden_url, {})[tool] = groups
+
+    await run_bounded(jobs, handle=_handle)
 
     groups_file.write_text(json.dumps(all_groups, indent=2))
 
@@ -502,32 +518,36 @@ async def _evaluate_review(
             "recall": 0.0,
         }
 
-    semaphore = asyncio.Semaphore(_JUDGE_CONCURRENCY)
-    tasks = []
-    task_meta = []
+    jobs: list[tuple[tuple[int, int, int], Callable[[], Awaitable[JudgeVerdict]]]] = []
     for gi, golden_comment in enumerate(golden):
         for ci, candidate in enumerate(candidates):
-            tasks.append(_judge_limited(semaphore, judge, golden_comment["comment"], candidate))
-            task_meta.append((gi, ci))
+            jobs.append(
+                (
+                    (len(jobs), gi, ci),
+                    functools.partial(judge.same_issue, golden_comment["comment"], candidate),
+                )
+            )
 
-    results = await asyncio.gather(*tasks, return_exceptions=True)
     # Occurrences are tracked by their zero-based list position, not their text, so
     # equal-text comments at different positions stay structurally distinct.
     candidate_matched: list[bool] = [False] * len(candidates)
     sibling_map = _build_sibling_map(len(candidates), dedup_groups)
-    errors = []
+    # Keyed by source index so the persisted error list stays in source order.
+    errors_by_index: dict[int, dict[str, str]] = {}
 
     positives: list[tuple[float, int, int, int, JudgeVerdict]] = []
 
-    for index, result in enumerate(results):
-        gi, ci = task_meta[index]
+    def _handle(meta: tuple[int, int, int], result: Any) -> None:
+        index, gi, ci = meta
         golden_comment = golden[gi]["comment"]
         if isinstance(result, BaseException):
-            errors.append({"golden": golden_comment, "candidate": candidates[ci], "error": str(result)})
-            continue
+            errors_by_index[index] = {"golden": golden_comment, "candidate": candidates[ci], "error": str(result)}
+            return
 
         if result.match:
             positives.append((-result.confidence, index, gi, ci, result))
+
+    await run_bounded(jobs, handle=_handle)
 
     # One-to-one assignment: each candidate (with its dedup siblings) satisfies at most one golden.
     # A plain greedy pass can strand a golden whose candidate groups were all taken by earlier,
@@ -577,6 +597,8 @@ async def _evaluate_review(
     predicted_count = tp_count + len(false_positives)
     precision = tp_count / predicted_count if predicted_count > 0 else 0.0
     recall = tp_count / total_golden if total_golden > 0 else 0.0
+
+    errors = [errors_by_index[index] for index in sorted(errors_by_index)]
 
     return {
         "skipped": False,
@@ -647,20 +669,44 @@ def _assign_golden_matches(
     return golden_matches
 
 
-async def _complete_json_limited(
-    semaphore: asyncio.Semaphore, client: _AnthropicJsonCompleter, *, system: str, user: str, max_tokens: int
-) -> dict[str, Any]:
-    """Bound one ``complete_json`` model call under *semaphore*."""
-    async with semaphore:
-        return await client.complete_json(system=system, user=user, max_tokens=max_tokens)
+async def run_bounded(
+    jobs: list[tuple[Any, Callable[[], Awaitable[Any]]]],
+    *,
+    handle: Callable[[Any, Any], None],
+) -> None:
+    """Run ``(meta, call)`` jobs under one shared ``_JUDGE_CONCURRENCY`` semaphore.
 
+    ``handle(meta, result)`` fires as each job completes (completion order); a
+    failed job is delivered as the exception instance for the caller's policy
+    (abort, fall back, or record). If ``handle`` raises — a fail-fast policy —
+    every still-pending job is cancelled before the exception propagates, so no
+    further paid model calls start after an abort. Callers that need deterministic
+    output order key their own state by ``meta``.
+    """
+    semaphore = asyncio.Semaphore(_JUDGE_CONCURRENCY)
 
-async def _judge_limited(
-    semaphore: asyncio.Semaphore, judge: FindingJudge, golden_comment: str, candidate: str
-) -> JudgeVerdict:
-    """Bound judge concurrency; `JudgeError` propagates to the per-pair error record."""
-    async with semaphore:
-        return await judge.same_issue(golden_comment, candidate)
+    async def _bounded(call: Callable[[], Awaitable[Any]]) -> Any:
+        async with semaphore:
+            return await call()
+
+    tasks = [asyncio.create_task(_bounded(call)) for _, call in jobs]
+    metas = [meta for meta, _ in jobs]
+    pending = set(tasks)
+    try:
+        while pending:
+            done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
+            for task in done:
+                index = tasks.index(task)
+                try:
+                    result = task.result()
+                except BaseException as exc:
+                    result = exc
+                handle(metas[index], result)
+    except BaseException:
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+        raise
 
 
 def _build_sibling_map(candidate_count: int, groups: list[list[int]] | None) -> dict[int, set[int]]:

--- a/daydream/benchmark/anthropic_score.py
+++ b/daydream/benchmark/anthropic_score.py
@@ -42,7 +42,7 @@ _MAX_RETRIES = 3
 _MAX_EXTRACTION_TOKENS = 4096
 _MAX_DEDUP_TOKENS = 4096
 _MIN_DEDUP_CANDIDATES = 2
-_JUDGE_CONCURRENCY = 10  # max parallel judge calls; mirrors CapacityLimiter convention in phases.py
+_JUDGE_CONCURRENCY = 10  # caps parallel model calls across extraction/dedup/judging; mirrors phases.py CapacityLimiter
 _TOOL = "daydream"
 
 _EXTRACTION_SYSTEM = "You extract code review issues from comments. Always respond with valid JSON."
@@ -194,6 +194,9 @@ async def run_anthropic_extraction(
     all_candidates = _load_json_dict(candidates_file, required=False)
 
     selected = _make_selection(golden_urls)
+    semaphore = asyncio.Semaphore(_JUDGE_CONCURRENCY)
+    tasks = []
+    meta = []
     for golden_url, entry in data.items():
         if selected is not None and golden_url not in selected:
             continue
@@ -206,15 +209,25 @@ async def run_anthropic_extraction(
             if not all_text.strip():
                 continue
 
-            response = await client.complete_json(
-                system=_EXTRACTION_SYSTEM,
-                user=_EXTRACTION_PROMPT.format(comment=all_text),
-                max_tokens=_MAX_EXTRACTION_TOKENS,
+            tasks.append(
+                _complete_json_limited(
+                    semaphore,
+                    client,
+                    system=_EXTRACTION_SYSTEM,
+                    user=_EXTRACTION_PROMPT.format(comment=all_text),
+                    max_tokens=_MAX_EXTRACTION_TOKENS,
+                )
             )
-            issues = _extract_issues(response)
-            all_candidates.setdefault(golden_url, {})[tool] = [
-                {"text": issue, "path": None, "line": None, "source": "extracted"} for issue in issues
-            ]
+            meta.append(golden_url)
+
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    for golden_url, result in zip(meta, results, strict=True):
+        if isinstance(result, BaseException):
+            raise result
+        issues = _extract_issues(result)
+        all_candidates.setdefault(golden_url, {})[tool] = [
+            {"text": issue, "path": None, "line": None, "source": "extracted"} for issue in issues
+        ]
 
     candidates_file.write_text(json.dumps(all_candidates, indent=2))
 
@@ -243,6 +256,9 @@ async def run_anthropic_dedup(
     all_groups = _load_json_dict(groups_file, required=False)
 
     selected = _make_selection(golden_urls)
+    semaphore = asyncio.Semaphore(_JUDGE_CONCURRENCY)
+    tasks = []
+    meta = []
     for golden_url, tools in all_candidates.items():
         if selected is not None and golden_url not in selected:
             continue
@@ -256,17 +272,24 @@ async def run_anthropic_dedup(
         if len(texts) < _MIN_DEDUP_CANDIDATES:
             continue
 
-        try:
-            response = await client.complete_json(
+        tasks.append(
+            _complete_json_limited(
+                semaphore,
+                client,
                 system=_DEDUP_SYSTEM,
                 user=_DEDUP_PROMPT.format(candidates=_numbered_candidates(texts)),
                 max_tokens=_MAX_DEDUP_TOKENS,
             )
-        except Exception:
-            response = None
-        groups = _extract_dedup_groups(response, len(texts)) if isinstance(response, dict) else None
+        )
+        meta.append((golden_url, len(texts)))
+
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    for (golden_url, n_texts), result in zip(meta, results, strict=True):
+        if isinstance(result, BaseException) and not isinstance(result, Exception):
+            raise result
+        groups = _extract_dedup_groups(result, n_texts) if isinstance(result, dict) else None
         if groups is None:
-            groups = _singleton_groups(len(texts))
+            groups = _singleton_groups(n_texts)
         all_groups.setdefault(golden_url, {})[tool] = groups
 
     groups_file.write_text(json.dumps(all_groups, indent=2))
@@ -622,6 +645,14 @@ def _assign_golden_matches(
         _try_assign(gi, set(), set())
 
     return golden_matches
+
+
+async def _complete_json_limited(
+    semaphore: asyncio.Semaphore, client: _AnthropicJsonCompleter, *, system: str, user: str, max_tokens: int
+) -> dict[str, Any]:
+    """Bound one ``complete_json`` model call under *semaphore*."""
+    async with semaphore:
+        return await client.complete_json(system=system, user=user, max_tokens=max_tokens)
 
 
 async def _judge_limited(

--- a/daydream/benchmark/anthropic_score.py
+++ b/daydream/benchmark/anthropic_score.py
@@ -691,12 +691,13 @@ async def run_bounded(
 
     tasks = [asyncio.create_task(_bounded(call)) for _, call in jobs]
     metas = [meta for meta, _ in jobs]
+    task_index = {task: i for i, task in enumerate(tasks)}
     pending = set(tasks)
     try:
         while pending:
             done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
             for task in done:
-                index = tasks.index(task)
+                index = task_index[task]
                 try:
                     result = task.result()
                 except BaseException as exc:

--- a/tests/test_benchmark_anthropic_score.py
+++ b/tests/test_benchmark_anthropic_score.py
@@ -589,3 +589,47 @@ async def test_direct_scoring_filters_extraction_and_dedup_to_selected_urls(tmp_
     # Selected-only scoring.
     assert scores.scored_pr_count == 1
     assert scores.total_tp == 1
+
+
+class FailFastAnthropicJson:
+    """Like FakeAnthropicJson but with real I/O-style awaits so pending semaphore
+    jobs stay cancellable; tracks how many calls actually started."""
+
+    def __init__(self, responses, fail_index=None):
+        self._responses = list(responses)
+        self._fail_index = fail_index
+        self._next = 0
+        self.started = 0
+
+    async def complete_json(self, *, system, user, max_tokens):
+        idx = self._next
+        self._next += 1
+        self.started += 1
+        if self._fail_index is not None and idx == self._fail_index:
+            await asyncio.sleep(0.001)
+            raise RuntimeError("permanent 5xx")
+        await asyncio.sleep(0.02)
+        return self._responses[idx]
+
+
+@pytest.mark.asyncio
+async def test_direct_extraction_fails_fast_and_cancels_pending(tmp_path):
+    """Extraction is fail-fast: a permanent failure aborts and cancels pending
+    jobs so no further paid calls start after the abort (nothing is written)."""
+    urls = [f"https://x/pull/{i}" for i in range(1, 13)]  # 12 URLs
+    reviews_by_url = {url: [f"review for {url}"] for url in urls}
+    seed_parallel_benchmark_data(tmp_path, tool="daydream", reviews_by_url=reviews_by_url)
+
+    responses = [{"issues": [f"ok {i}"]} for i in range(12)]
+    client = FailFastAnthropicJson(responses, fail_index=5)  # 6th job fails
+
+    with pytest.raises(RuntimeError):
+        await run_anthropic_extraction(
+            tmp_path, "claude-opus-4-5-20251101", tool="daydream", client=client
+        )
+
+    # A permanent failure must not schedule every remaining paid call.
+    assert client.started < len(urls), f"fail-fast broken: started {client.started}/{len(urls)}"
+    # Nothing is persisted after an abort.
+    cand = model_results_dir(tmp_path, "claude-opus-4-5-20251101") / "candidates.json"
+    assert not cand.exists(), "fail-fast abort must not write candidates.json"

--- a/tests/test_benchmark_anthropic_score.py
+++ b/tests/test_benchmark_anthropic_score.py
@@ -1,8 +1,10 @@
+import asyncio
 import json
 
 import pytest
 
 from daydream.benchmark.anthropic_score import (
+    _JUDGE_CONCURRENCY,
     AnthropicJsonClient,
     run_anthropic_dedup,
     run_anthropic_extraction,
@@ -23,6 +25,32 @@ class FakeAnthropicJson:
     async def complete_json(self, *, system, user, max_tokens):
         self.requests.append((system, user, max_tokens))
         return self._responses.pop(0)
+
+
+class OutOfOrderAnthropicJson:
+    """Completes later-scheduled requests first; tracks concurrent overlap."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self._next_index = 0
+        self.active = 0
+        self.peak_active = 0
+
+    async def complete_json(self, *, system, user, max_tokens):
+        index = self._next_index
+        self._next_index += 1
+        self.active += 1
+        self.peak_active = max(self.peak_active, self.active)
+        try:
+            # Earlier indices yield more event-loop turns, so they finish last.
+            for _ in range(len(self._responses) - index):
+                await asyncio.sleep(0)
+            response = self._responses[index]
+            if isinstance(response, Exception):
+                raise response
+            return response
+        finally:
+            self.active -= 1
 
 
 def seed_benchmark_data(tmp_path, *, tool, body):
@@ -47,12 +75,42 @@ def seed_benchmark_data(tmp_path, *, tool, body):
     )
 
 
+def seed_parallel_benchmark_data(tmp_path, *, tool, reviews_by_url):
+    """Write results/benchmark_data.json from an ordered {url: [bodies]} map."""
+    (tmp_path / "results").mkdir()
+    data = {}
+    for golden_url, bodies in reviews_by_url.items():
+        data[golden_url] = {
+            "golden_comments": [{"comment": bodies[-1], "severity": "medium"}],
+            "reviews": [
+                {
+                    "tool": tool,
+                    "repo_name": "repo",
+                    "pr_url": golden_url,
+                    "review_comments": [{"body": body}],
+                }
+                for body in bodies
+            ],
+        }
+    (tmp_path / "results" / "benchmark_data.json").write_text(json.dumps(data))
+
+
 def seed_candidates(tmp_path, *, model, tool, texts):
     scores_dir = model_results_dir(tmp_path, model)
     scores_dir.mkdir(parents=True)
     (scores_dir / "candidates.json").write_text(
         json.dumps({URL: {tool: [{"text": text, "path": None, "line": None} for text in texts]}})
     )
+
+
+def seed_parallel_candidates(tmp_path, *, model, tool, texts_by_url):
+    """Write an ordered multi-URL candidates.json using the current field shape."""
+    scores_dir = model_results_dir(tmp_path, model)
+    scores_dir.mkdir(parents=True)
+    (scores_dir / "candidates.json").write_text(json.dumps({
+        url: {tool: [{"text": text, "path": None, "line": None} for text in texts]}
+        for url, texts in texts_by_url.items()
+    }))
 
 
 def seed_dedup_groups(tmp_path, *, model, tool, groups):
@@ -103,6 +161,30 @@ async def test_direct_extraction_writes_martian_candidates(tmp_path):
     assert all(c["source"] == "extracted" and c["path"] is None and c["line"] is None for c in leaf)
 
 
+@pytest.mark.asyncio
+async def test_direct_extraction_bounds_concurrency_and_preserves_source_order(tmp_path):
+    urls = [f"https://x/pull/{i}" for i in range(1, 12)]  # 11 URLs
+    reviews_by_url = {urls[0]: ["first review", "replacement review"]}
+    for url in urls[1:]:
+        reviews_by_url[url] = [f"review for {url}"]
+    seed_parallel_benchmark_data(tmp_path, tool="daydream", reviews_by_url=reviews_by_url)
+
+    responses = [{"issues": ["first issue"]}, {"issues": ["replacement issue"]}]
+    responses += [{"issues": [f"issue for {url}"]} for url in urls[1:]]
+    client = OutOfOrderAnthropicJson(responses)  # 12 requests
+
+    await run_anthropic_extraction(tmp_path, "claude-opus-4-5-20251101", tool="daydream", client=client)
+
+    assert client.peak_active == _JUDGE_CONCURRENCY, f"peak={client.peak_active}"
+    candidates = json.loads(
+        (model_results_dir(tmp_path, "claude-opus-4-5-20251101") / "candidates.json").read_text()
+    )
+    assert list(candidates.keys()) == urls
+    assert [c["text"] for c in candidates[urls[0]]["daydream"]] == ["replacement issue"]
+    for url in urls[1:]:
+        assert [c["text"] for c in candidates[url]["daydream"]] == [f"issue for {url}"]
+
+
 @pytest.mark.parametrize(
     ("texts", "response", "expected"),
     [
@@ -121,6 +203,28 @@ async def test_direct_dedup_writes_groups_or_singletons(tmp_path, texts, respons
 
     groups = json.loads((model_results_dir(tmp_path, "claude-opus-4-5-20251101") / "dedup_groups.json").read_text())
     assert groups[URL]["daydream"] == expected
+
+
+@pytest.mark.asyncio
+async def test_direct_dedup_bounds_concurrency_preserves_order_and_falls_back_per_entry(tmp_path):
+    urls = [f"https://x/pull/{i}" for i in range(1, 13)]  # 12 URLs
+    texts_by_url = {url: [f"text a for {url}", f"text b for {url}"] for url in urls}
+    seed_parallel_candidates(tmp_path, model="claude-opus-4-5-20251101", tool="daydream",
+                             texts_by_url=texts_by_url)
+
+    responses = [{"groups": [[0, 1]]} for _ in urls]
+    responses[4] = RuntimeError("dedup request failed")  # 5th entry fails
+    client = OutOfOrderAnthropicJson(responses)
+
+    await run_anthropic_dedup(tmp_path, "claude-opus-4-5-20251101", tool="daydream", client=client)
+
+    assert client.peak_active == _JUDGE_CONCURRENCY, f"peak={client.peak_active}"
+    groups = json.loads(
+        (model_results_dir(tmp_path, "claude-opus-4-5-20251101") / "dedup_groups.json").read_text()
+    )
+    assert list(groups.keys()) == urls
+    expected = [[[0, 1]] if i != 4 else [[0], [1]] for i in range(12)]
+    assert [groups[url]["daydream"] for url in urls] == expected
 
 
 @pytest.mark.asyncio

--- a/tests/test_benchmark_anthropic_score.py
+++ b/tests/test_benchmark_anthropic_score.py
@@ -54,25 +54,7 @@ class OutOfOrderAnthropicJson:
 
 
 def seed_benchmark_data(tmp_path, *, tool, body):
-    results = tmp_path / "results"
-    results.mkdir()
-    (results / "benchmark_data.json").write_text(
-        json.dumps(
-            {
-                URL: {
-                    "golden_comments": [{"comment": body, "severity": "medium"}],
-                    "reviews": [
-                        {
-                            "tool": tool,
-                            "repo_name": "repo",
-                            "pr_url": URL,
-                            "review_comments": [{"body": body}],
-                        }
-                    ]
-                }
-            }
-        )
-    )
+    seed_parallel_benchmark_data(tmp_path, tool=tool, reviews_by_url={URL: [body]})
 
 
 def seed_parallel_benchmark_data(tmp_path, *, tool, reviews_by_url):
@@ -96,11 +78,7 @@ def seed_parallel_benchmark_data(tmp_path, *, tool, reviews_by_url):
 
 
 def seed_candidates(tmp_path, *, model, tool, texts):
-    scores_dir = model_results_dir(tmp_path, model)
-    scores_dir.mkdir(parents=True)
-    (scores_dir / "candidates.json").write_text(
-        json.dumps({URL: {tool: [{"text": text, "path": None, "line": None} for text in texts]}})
-    )
+    seed_parallel_candidates(tmp_path, model=model, tool=tool, texts_by_url={URL: texts})
 
 
 def seed_parallel_candidates(tmp_path, *, model, tool, texts_by_url):

--- a/tests/test_benchmark_anthropic_score.py
+++ b/tests/test_benchmark_anthropic_score.py
@@ -286,6 +286,77 @@ async def test_direct_judge_does_not_reuse_one_candidate_for_two_goldens(tmp_pat
     assert [fn["golden_comment"] for fn in leaf["false_negatives"]] == ["golden one"]
 
 
+@pytest.mark.asyncio
+async def test_direct_judge_records_per_pair_errors_in_source_order(tmp_path):
+    """Judge failures are recorded per golden-candidate pair and re-emitted in
+    source index order regardless of completion order; each errors entry carries
+    the verbatim golden/candidate/error for its own pair."""
+    (tmp_path / "results").mkdir()
+    (tmp_path / "results" / "benchmark_data.json").write_text(
+        json.dumps(
+            {
+                URL: {
+                    "golden_comments": [
+                        {"comment": "golden a", "severity": "medium"},
+                        {"comment": "golden b", "severity": "medium"},
+                    ],
+                    "reviews": [
+                        {
+                            "tool": "daydream",
+                            "repo_name": "repo",
+                            "pr_url": URL,
+                            "review_comments": [{"body": "the bug"}],
+                        }
+                    ],
+                }
+            }
+        )
+    )
+    seed_candidates(tmp_path, model="claude-opus-4-5-20251101", tool="daydream",
+                    texts=["cand a", "cand b", "cand c"])
+    seed_dedup_groups(tmp_path, model="claude-opus-4-5-20251101", tool="daydream",
+                      groups=[[0], [1], [2]])
+    # Judge tasks run in (gi, ci) order: (0,0) ok, (0,1) fails, (0,2) ok,
+    # (1,0) fails, (1,1) ok, (1,2) ok. OutOfOrderAnthropicJson completes them
+    # in reverse, so the recorded errors must be re-sorted by source index when
+    # persisted (2 errors / 6 comparisons stays under JUDGE_ERROR_RATIO_THRESHOLD).
+    client = OutOfOrderAnthropicJson(
+        [
+            {"issues": ["cand a", "cand b", "cand c"]},
+            {"groups": [[0], [1], [2]]},
+            {"reasoning": "a0", "match": True, "confidence": 0.9},
+            RuntimeError("judge failed for golden a x cand b"),
+            {"reasoning": "a2", "match": True, "confidence": 0.7},
+            RuntimeError("judge failed for golden b x cand a"),
+            {"reasoning": "b1", "match": True, "confidence": 0.8},
+            {"reasoning": "b2", "match": True, "confidence": 0.6},
+        ]
+    )
+
+    scores = await run_anthropic_scoring(
+        tmp_path,
+        "claude-opus-4-5-20251101",
+        golden_urls=[URL],
+        tool="daydream",
+        client=client,
+    )
+
+    leaf = json.loads(
+        (model_results_dir(tmp_path, "claude-opus-4-5-20251101") / "evaluations.json").read_text()
+    )[URL]["daydream"]
+    # Each failure is keyed to its own pair and re-emitted in source order.
+    assert leaf["errors"] == [
+        {"golden": "golden a", "candidate": "cand b", "error": "judge failed for golden a x cand b"},
+        {"golden": "golden b", "candidate": "cand a", "error": "judge failed for golden b x cand a"},
+    ]
+    assert leaf["errors_count"] == 2
+    # Failed pairs only record errors; successful pairs still count.
+    assert (leaf["tp"], leaf["fp"], leaf["fn"]) == (2, 1, 0)
+    assert [tp["golden_comment"] for tp in leaf["true_positives"]] == ["golden a", "golden b"]
+    assert leaf["false_positives"] == [{"candidate": "cand c"}]
+    assert scores.total_tp == 2
+
+
 @pytest.mark.parametrize(
     "case",
     [


### PR DESCRIPTION
## Summary

Bounds benchmark extraction and deduplication concurrency deterministically. Four commits on `eb/daydream/issue-432`:

- **perf(benchmark):** bound extraction and dedup requests
- **refactor(benchmark):** unify bounded judge concurrency via `run_bounded`
- **test(benchmark):** pin fail-fast extraction cancellation and no-partial-write behavior
- **perf(benchmark):** use dict for task-index lookup in bounded judge (O(1) `task_index` dict)

## Verification

Two sequential daydream deep-precision reviews passed (round 1 + round 2 on fresh VMs). Round-2 findings (O(n²) `tasks.index()` scan + missing regression test) fixed and pushed at `78ccbb8`. 17/17 module tests pass (`tests/test_benchmark_anthropic_score.py`). Branch authorship gate `verify-branch-authors.sh` passed (all commits authored by anderskev@gmail.com, no rewrite). Trajectories uploaded to `existentialbirds/daydream-trajectories`.

Closes #432