### PR TITLE
perf(rl): reuse one archived run snapshot across rollout scoring (Closes #435)

### DIFF
--- a/rl/daydream_review_v1/daydream_review_v1/taskset.py
+++ b/rl/daydream_review_v1/daydream_review_v1/taskset.py
@@ -142,13 +142,11 @@ async def _fixes_applied(runtime: vf.Runtime, repo: str, head_sha: str) -> bool:
     return diff.exit_code == 1
 
 
-async def _claimed_test_verdict(runtime: vf.Runtime, archive_root: str) -> bool | None:
+def _claimed_test_verdict(run_dir: Path | None) -> bool | None:
     """daydream's own ``deep/test-verdict.json`` claim, or ``None`` if absent."""
-    with tempfile.TemporaryDirectory(prefix="daydream-verdict-") as staging:
-        run_dir = await fetch_run_dir(runtime, Path(staging), archive_root)
-        if run_dir is None:
-            return None
-        verdict = _read_json(run_dir / "deep" / "test-verdict.json", default=None)
+    if run_dir is None:
+        return None
+    verdict = _read_json(run_dir / "deep" / "test-verdict.json", default=None)
     if not isinstance(verdict, dict) or not isinstance(verdict.get("passed"), bool):
         return None
     return bool(verdict["passed"])
@@ -275,10 +273,10 @@ class DaydreamReviewTask(vf.Task[DaydreamReviewData, DaydreamReviewState, Daydre
     async def score(self, trace: vf.Trace, runtime: vf.Runtime | None = None) -> None:
         """Score *trace*, staging the archived run dir into the state exactly once.
 
-        The single :func:`fetch_run_dir` call per score happens here, at the
-        entrypoint; the consumers read the staged snapshot off ``state.run_dir``
-        and never re-enter the runtime. With no runtime the base class simply
-        skips the runtime-dependent signals, and there is nothing to stage.
+        The single run-dir fetch happens here, at the entrypoint; the consumers
+        read the staged snapshot off ``state.run_dir`` and never re-enter the
+        runtime. With no runtime the base class simply skips the
+        runtime-dependent signals, and there is nothing to stage.
         """
         if runtime is None:
             await super().score(trace, None)
@@ -295,12 +293,11 @@ class DaydreamReviewTask(vf.Task[DaydreamReviewData, DaydreamReviewState, Daydre
     @vf.reward(weight=1.0)
     async def intrinsic_composite(self, trace: vf.Trace, runtime: vf.Runtime) -> float:
         """daydream's own trajectory composite over the archived run."""
-        with tempfile.TemporaryDirectory(prefix="daydream-rundir-") as staging:
-            run_dir = await fetch_run_dir(runtime, Path(staging), _archive_root(trace))
-            if run_dir is None:
-                trace.info["reward_breakdown"] = {"error": "no archived run dir"}
-                return 0.0
-            breakdown = score_trajectory(assemble_scoring_inputs(run_dir, _manifest_row(run_dir)))
+        run_dir = _review_state(trace).run_dir
+        if run_dir is None:
+            trace.info["reward_breakdown"] = {"error": "no archived run dir"}
+            return 0.0
+        breakdown = score_trajectory(assemble_scoring_inputs(run_dir, _manifest_row(run_dir)))
 
         trace.info["reward_breakdown"] = {
             "correctness_per_finding": breakdown.correctness_per_finding,
@@ -328,7 +325,7 @@ class DaydreamReviewTask(vf.Task[DaydreamReviewData, DaydreamReviewState, Daydre
             # There is no re-run to compare against on this path, but a rollout
             # that changed nothing and still wrote a green test-verdict is the
             # sharpest hack shape there is, so record the bare claim.
-            claimed = await _claimed_test_verdict(runtime, _archive_root(trace))
+            claimed = _claimed_test_verdict(_review_state(trace).run_dir)
             if claimed is not None:
                 trace.record_metric("test_claim_passed_without_fix", float(claimed))
             return self.config.no_fix_reward
@@ -343,7 +340,7 @@ class DaydreamReviewTask(vf.Task[DaydreamReviewData, DaydreamReviewState, Daydre
         # the suite actually does. Recorded here rather than as a @vf.metric
         # because metrics run BEFORE rewards (verifiers task.py:299-306), so a
         # metric cannot see this re-run without paying for a second one.
-        claimed = await _claimed_test_verdict(runtime, _archive_root(trace))
+        claimed = _claimed_test_verdict(_review_state(trace).run_dir)
         if claimed is not None:
             trace.record_metric("test_claim_mismatch", float(claimed != passed))
 
@@ -357,13 +354,12 @@ class DaydreamReviewTask(vf.Task[DaydreamReviewData, DaydreamReviewState, Daydre
         the bot's golden comments whose file appears among daydream's merged
         findings. It exists to inform #91's rubric design, not to grade a rollout.
         """
-        with tempfile.TemporaryDirectory(prefix="daydream-shape-") as staging:
-            run_dir = await fetch_run_dir(runtime, Path(staging), _archive_root(trace))
-            items: list[dict[str, Any]] = []
-            if run_dir is not None:
-                merged = _read_json(run_dir / "deep" / "merged-items.json", default={})
-                if isinstance(merged, dict):
-                    items = merged.get("items") or []
+        run_dir = _review_state(trace).run_dir
+        items: list[dict[str, Any]] = []
+        if run_dir is not None:
+            merged = _read_json(run_dir / "deep" / "merged-items.json", default={})
+            if isinstance(merged, dict):
+                items = merged.get("items") or []
 
         found_files = {item.get("file") for item in items if isinstance(item, dict)}
         golden_paths = [c.path for c in self.data.golden_comments if c.path]

--- a/rl/daydream_review_v1/daydream_review_v1/taskset.py
+++ b/rl/daydream_review_v1/daydream_review_v1/taskset.py
@@ -203,7 +203,35 @@ class DaydreamReviewTaskConfig(vf.TaskConfig):
     no_fix_reward: float = 0.0
 
 
-class DaydreamReviewTask(vf.Task[DaydreamReviewData, vf.State, DaydreamReviewTaskConfig]):
+class DaydreamReviewState(vf.State):
+    """Mutable per-rollout scoring state, living on the trace.
+
+    Production traces carry one automatically — the rollout resolves the task's
+    ``StateT`` through the MRO (``verifiers/v1/rollout.py:112-116``) — and the
+    overridden :meth:`DaydreamReviewTask.score` holds the single host-side
+    snapshot of the archived run dir here, so every reward/metric reads the
+    same copy instead of re-fetching one.
+    """
+
+    run_dir: Path | None = None
+
+
+def _review_state(trace: vf.Trace) -> DaydreamReviewState:
+    """The trace's scoring state, or a loud error for a base ``State``.
+
+    A test helper or consumer that scores without a ``DaydreamReviewState``
+    (e.g. by constructing a bare ``vf.Trace``) would otherwise silently
+    dereference a missing ``run_dir``. Fail loudly instead.
+    """
+    state = trace.state
+    if not isinstance(state, DaydreamReviewState):
+        raise TypeError(
+            f"scoring state must be a DaydreamReviewState, got {type(state).__name__}"
+        )
+    return state
+
+
+class DaydreamReviewTask(vf.Task[DaydreamReviewData, DaydreamReviewState, DaydreamReviewTaskConfig]):
     """Two reward axes: daydream's own intrinsic composite, and the test suite.
 
     ``intrinsic_composite`` replays the archived run through
@@ -243,6 +271,26 @@ class DaydreamReviewTask(vf.Task[DaydreamReviewData, vf.State, DaydreamReviewTas
     the reward regardless: reward climbing while ``n_findings`` falls is still
     the signal that the policy is learning to say nothing.
     """
+
+    async def score(self, trace: vf.Trace, runtime: vf.Runtime | None = None) -> None:
+        """Score *trace*, staging the archived run dir into the state exactly once.
+
+        The single :func:`fetch_run_dir` call per score happens here, at the
+        entrypoint; the consumers read the staged snapshot off ``state.run_dir``
+        and never re-enter the runtime. With no runtime the base class simply
+        skips the runtime-dependent signals, and there is nothing to stage.
+        """
+        if runtime is None:
+            await super().score(trace, None)
+            return
+        state = _review_state(trace)
+        with tempfile.TemporaryDirectory(prefix="daydream-rundir-") as staging:
+            state.run_dir = await fetch_run_dir(runtime, Path(staging), _archive_root(trace))
+            try:
+                await super().score(trace, runtime)
+            finally:
+                state.run_dir = None
+
 
     @vf.reward(weight=1.0)
     async def intrinsic_composite(self, trace: vf.Trace, runtime: vf.Runtime) -> float:

--- a/rl/daydream_review_v1/daydream_review_v1/taskset.py
+++ b/rl/daydream_review_v1/daydream_review_v1/taskset.py
@@ -28,6 +28,7 @@ from daydream.training.exclusion import load_exclusion_list
 from daydream.training.harvest import assemble_scoring_inputs
 from daydream.training.reward import score_trajectory
 from pydantic import BaseModel, ConfigDict
+from verifiers.v1.errors import boundary
 
 from daydream_review_v1.rundir import DEFAULT_ARCHIVE_ROOT, fetch_run_dir
 
@@ -283,7 +284,12 @@ class DaydreamReviewTask(vf.Task[DaydreamReviewData, DaydreamReviewState, Daydre
             return
         state = _review_state(trace)
         with tempfile.TemporaryDirectory(prefix="daydream-rundir-") as staging:
-            state.run_dir = await fetch_run_dir(runtime, Path(staging), _archive_root(trace))
+            # The run-dir fetch is scoring work: it runs inside the same
+            # TaskError boundary the base class draws around signal evaluation,
+            # so a fetch failure (e.g. a missing artifact) is attributed to the
+            # task-scoring boundary rather than escaping as a raw OSError.
+            async with boundary(vf.TaskError, f"task {type(self).__name__} scoring"):
+                state.run_dir = await fetch_run_dir(runtime, Path(staging), _archive_root(trace))
             try:
                 await super().score(trace, runtime)
             finally:

--- a/rl/daydream_review_v1/daydream_review_v1/taskset.py
+++ b/rl/daydream_review_v1/daydream_review_v1/taskset.py
@@ -289,7 +289,6 @@ class DaydreamReviewTask(vf.Task[DaydreamReviewData, DaydreamReviewState, Daydre
             finally:
                 state.run_dir = None
 
-
     @vf.reward(weight=1.0)
     async def intrinsic_composite(self, trace: vf.Trace, runtime: vf.Runtime) -> float:
         """daydream's own trajectory composite over the archived run."""

--- a/rl/daydream_review_v1/tests/test_rewards.py
+++ b/rl/daydream_review_v1/tests/test_rewards.py
@@ -90,6 +90,30 @@ def test_review_state_guard_rejects_base_state(
     assert _review_state(good_trace).run_dir is None
 
 
+async def test_score_without_runtime_records_nothing(
+    corpus_mini_dir: Path, fixture_manifest_path: Path
+) -> None:
+    """The offline replay path — ``score(trace, None)`` — completes and records nothing.
+
+    The verifiers replay CLI scores archived traces with no runtime; the base
+    then skips every runtime-dependent signal (all three handlers here require
+    ``runtime``) and this task stages no run dir. The trace deliberately carries
+    the base ``State`` — the load-bearing shape from the replay path — so
+    reaching ``_review_state`` would raise TypeError. Completing, with no
+    rewards/metrics recorded, is the proof the offline branch never touches the
+    state guard, the run-dir fetch, or the runtime.
+    """
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    trace = vf.Trace(task=vf.TraceTask(type=type(task).__name__, data=task.data))
+    trace.info["daydream_archive_root"] = "/does/not/exist"
+    trace.info["daydream_repo_path"] = "/does/not/exist"
+
+    await task.score(trace)  # runtime defaults to None — the offline replay path
+
+    assert trace.rewards == {}
+    assert trace.metrics == {}
+
+
 def _stage_run(archive_root: Path, source: Path, *, session_id: str = SESSION_ID) -> Path:
     """Copy an archived run dir to ``<archive_root>/runs/<session_id>``."""
     dest = archive_root / "runs" / session_id

--- a/rl/daydream_review_v1/tests/test_rewards.py
+++ b/rl/daydream_review_v1/tests/test_rewards.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 import shutil
 import subprocess
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 
 import pytest
@@ -431,6 +432,56 @@ async def test_no_fixes_still_records_the_test_claim(
     assert trace.metrics["test_claim_passed_without_fix"] == float(claimed)
     # Observability only: recording the claim must not invent a verdict comparison.
     assert "test_claim_mismatch" not in trace.metrics
+
+
+async def test_score_reuses_one_archived_run_snapshot(
+    tmp_path: Path,
+    runtime,
+    rundir_golden: Path,
+    corpus_mini_dir: Path,
+    fixture_manifest_path: Path,
+    monkeypatch,
+) -> None:
+    """One score call fetches the archived run dir exactly once; all consumers share it.
+
+    A read-once wrapper over the real subprocess runtime rejects any repeated
+    ``runtime.read`` of an artifact path — the exact seam the refactor
+    consolidates. After the single score-level fetch, the three consumers must
+    read the shared host snapshot (via ``_read_json``), never re-enter the
+    runtime; ``trace.state.run_dir`` must be cleared once scoring returns.
+    """
+    archive_root = tmp_path / "archive"
+    _stage_run(archive_root, rundir_golden)
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    repo = _stage_repo(tmp_path / "repo", task.data.head_sha, patch=_REAL_PATCH)
+    trace = _trace(task, archive_root=archive_root, repo_path=repo)
+
+    class ReadOnce:
+        def __init__(self, real: Callable[[str], Awaitable[bytes]]) -> None:
+            self._real = real
+            self._seen: set[str] = set()
+
+        async def __call__(self, path: str) -> bytes:
+            if path in self._seen:
+                raise AssertionError(
+                    f"archived artifact {path} read more than once in a single score call"
+                )
+            self._seen.add(path)
+            return await self._real(path)
+
+    real_read = runtime.read
+    monkeypatch.setattr(runtime, "read", ReadOnce(real_read))
+
+    await task.score(trace, runtime)
+
+    expected = score_trajectory(
+        assemble_scoring_inputs(rundir_golden, _manifest_row_like_production(rundir_golden))
+    ).composite
+    assert expected is not None
+    assert trace.rewards["intrinsic_composite"] == expected
+    assert trace.metrics["test_claim_passed_without_fix"] == 1.0
+    assert trace.metrics["n_findings"] == 1.0
+    assert trace.state.run_dir is None
 
 
 @pytest.mark.parametrize("red, expected", [(True, 1.0), (False, 0.0)], ids=["mismatch", "agrees"])

--- a/rl/daydream_review_v1/tests/test_rewards.py
+++ b/rl/daydream_review_v1/tests/test_rewards.py
@@ -23,8 +23,10 @@ from daydream.training.reward import score_trajectory
 from daydream_review_v1.fixture import build_fixture_repo
 from daydream_review_v1.taskset import (
     DaydreamReviewConfig,
+    DaydreamReviewState,
     DaydreamReviewTask,
     DaydreamReviewTaskset,
+    _review_state,
 )
 
 SESSION_ID = "9b36227a-9f80-41e5-a419-5cfed5a34b5b"
@@ -58,10 +60,33 @@ def _task(corpus_mini_dir: Path, fixture_manifest_path: Path, *, pr_number: int 
 
 
 def _trace(task: DaydreamReviewTask, *, archive_root: Path, repo_path: Path) -> vf.Trace:
-    trace: vf.Trace = vf.Trace(task=vf.TraceTask(type=type(task).__name__, data=task.data))
+    trace: vf.Trace = vf.Trace(
+        task=vf.TraceTask(type=type(task).__name__, data=task.data), state=DaydreamReviewState()
+    )
     trace.info["daydream_archive_root"] = str(archive_root)
     trace.info["daydream_repo_path"] = str(repo_path)
     return trace
+
+
+def test_review_state_guard_rejects_base_state(
+    corpus_mini_dir: Path, fixture_manifest_path: Path
+) -> None:
+    """Scoring state must be a DaydreamReviewState, never the base State.
+
+    Production traces carry a DaydreamReviewState automatically (the rollout
+    resolves the task's StateT through the MRO); test helpers that score must
+    pass one explicitly. A base State must fail loudly rather than silently
+    dereference a missing run_dir.
+    """
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    base_trace = vf.Trace(task=vf.TraceTask(type=type(task).__name__, data=task.data))
+    with pytest.raises(TypeError):
+        _review_state(base_trace)
+    good_trace = vf.Trace(
+        task=vf.TraceTask(type=type(task).__name__, data=task.data),
+        state=DaydreamReviewState(),
+    )
+    assert _review_state(good_trace).run_dir is None
 
 
 def _stage_run(archive_root: Path, source: Path, *, session_id: str = SESSION_ID) -> Path:


### PR DESCRIPTION
## Summary
Consolidate archived-run snapshot fetching in the RL daydream-review verifier so one `DaydreamReviewTask.score` call transfers the archived rollout exactly once instead of up to three times.

## Changes
- Add `DaydreamReviewState` (trace-scoped `run_dir`) and override `DaydreamReviewTask.score` to fetch/materialize a single temporary snapshot, shared by `intrinsic_composite`, `fix_tests_pass`, and `review_shape`; clean up in `finally`.
- `_claimed_test_verdict` now reads only from the supplied snapshot (no per-consumer fetch).
- `taskset.py` now contains exactly one `fetch_run_dir(...)` call, inside `score`.
- Add `test_score_reuses_one_archived_run_snapshot`: real subprocess runtime, read-once boundary rejecting a repeated artifact transfer, asserts intrinsic reward, claimed-verdict metric, finding count, and `trace.state.run_dir is None` after scoring.

## Test Plan
- `uv run pytest tests/test_rewards.py` (26 passed) and full RL suite (96 passed / 1 skipped) verified green.
- Two sequential daydream deep-precision reviews passed; round-2 findings (run-dir fetch outside `TaskError` boundary + offline-replay test coverage) fixed in f883985.

Closes #435