### PR TITLE
fix(archive): prevent pre-existing untracked files from entering recommended patch archives (#436)

### DIFF
--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -2716,7 +2716,11 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
     # a run that generated a recommendation always archives it — even when
     # tests fail or a fix group is reverted. Best-effort; never raises.
     git_ops.capture_recommended_patch_with_base(
-        work.repo, pre_fix_snapshot, pre_fix_head, daydream_dir / "recommended.patch"
+        work.repo,
+        pre_fix_snapshot,
+        pre_fix_head,
+        daydream_dir / "recommended.patch",
+        preexisting_untracked=pre_fix_untracked,
     )
     fix_failures_p = fix_failures_path(dd)
     # Partition failures: budget-exceeded groups have their already-applied fixes

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -879,7 +879,9 @@ def diff_worktree_against(repo: Path, ref: str, paths: list[str]) -> str:
     return proc.stdout
 
 
-def capture_recommended_patch(repo: Path, base_ref: str | None, out_path: Path) -> bool:
+def capture_recommended_patch(
+    repo: Path, base_ref: str | None, out_path: Path, *, preexisting_untracked: set[str] | None = None
+) -> bool:
     """Write daydream's proposed diff (``base_ref`` → working tree) to *out_path*.
 
     Captures the *recommended-change patch*: the difference between the pre-fix
@@ -904,6 +906,11 @@ def capture_recommended_patch(repo: Path, base_ref: str | None, out_path: Path) 
     Args:
         base_ref: Pre-fix base ref (a ``stash create`` SHA or a ``HEAD`` SHA),
             or ``None`` when no pre-fix snapshot could be taken.
+        preexisting_untracked: Set of repo-relative paths that were untracked
+            BEFORE the fix ran. Matching untracked files contribute no creation
+            hunk (they are not daydream's changes); files absent from the set
+            still do. Order follows :func:`list_untracked`, never re-sorted.
+            ``None`` (default) excludes nothing, preserving legacy behavior.
 
     Returns:
         ``True`` when a non-empty patch was written, else ``False``.
@@ -917,8 +924,13 @@ def capture_recommended_patch(repo: Path, base_ref: str | None, out_path: Path) 
     # `git diff <base_ref>` only reports tracked-file changes, so new files the
     # fix phase created are absent. Append a creation hunk for each via
     # `git diff --no-index /dev/null <file>` (exit 1 = "files differ", expected).
+    # Pre-fix untracked files (preexisting_untracked) are filtered out first so
+    # files that were already untracked before the run never enter the patch.
     try:
-        for rel in list_untracked(repo):
+        untracked = list_untracked(repo)
+        if preexisting_untracked is not None:
+            untracked = [path for path in untracked if path not in preexisting_untracked]
+        for rel in untracked:
             proc = _run_git(repo, ["diff", "--no-index", "/dev/null", rel], timeout=30, retries=0)
             if proc.returncode in (0, 1):
                 recommended += proc.stdout
@@ -941,6 +953,8 @@ def capture_recommended_patch_with_base(
     pre_fix_snapshot: str | None,
     pre_fix_head: str | None,
     out_path: Path,
+    *,
+    preexisting_untracked: set[str] | None = None,
 ) -> bool:
     """Capture the recommended patch, resolving the pre-fix base centrally.
 
@@ -963,12 +977,18 @@ def capture_recommended_patch_with_base(
             clean or the snapshot failed.
         pre_fix_head: Pre-fix ``HEAD`` SHA, or ``None``. Used only when
             *pre_fix_snapshot* is ``None``.
+        preexisting_untracked: Set of repo-relative paths that were untracked
+            BEFORE the fix ran, forwarded to
+            :func:`capture_recommended_patch` so they contribute no creation
+            hunk. ``None`` (default) excludes nothing.
 
     Returns:
         ``True`` when a non-empty patch was written, else ``False``.
     """
     base_ref = pre_fix_snapshot or pre_fix_head
-    return capture_recommended_patch(repo, base_ref, out_path)
+    return capture_recommended_patch(
+        repo, base_ref, out_path, preexisting_untracked=preexisting_untracked
+    )
 
 
 def log(repo: Path, base: str, head: str = "HEAD") -> str:

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -927,9 +927,7 @@ def capture_recommended_patch(
     # Pre-fix untracked files (preexisting_untracked) are filtered out first so
     # files that were already untracked before the run never enter the patch.
     try:
-        untracked = list_untracked(repo)
-        if preexisting_untracked is not None:
-            untracked = [path for path in untracked if path not in preexisting_untracked]
+        untracked = _filter_preexisting_untracked(list_untracked(repo), preexisting_untracked)
         for rel in untracked:
             proc = _run_git(repo, ["diff", "--no-index", "/dev/null", rel], timeout=30, retries=0)
             if proc.returncode in (0, 1):
@@ -1315,9 +1313,7 @@ def changed_files(repo: Path, *, preexisting_untracked: set[str] | None = None) 
         tracked = proc.stdout.splitlines() if proc.returncode == 0 else []
     except GitError:
         tracked = []
-    untracked = list_untracked(repo)
-    if preexisting_untracked is not None:
-        untracked = [path for path in untracked if path not in preexisting_untracked]
+    untracked = _filter_preexisting_untracked(list_untracked(repo), preexisting_untracked)
     for line in [*tracked, *untracked]:
         name = line.strip()
         if name and name not in seen:
@@ -1350,8 +1346,7 @@ def changed_files_against(
     names: list[str] = []
     seen: set[str] = set()
     untracked = [line.strip() for line in untracked_proc.stdout.splitlines() if line.strip()]
-    if preexisting_untracked is not None:
-        untracked = [path for path in untracked if path not in preexisting_untracked]
+    untracked = _filter_preexisting_untracked(untracked, preexisting_untracked)
     for line in [*proc.stdout.splitlines(), *untracked]:
         name = line.strip()
         if name and name not in seen:
@@ -1374,6 +1369,22 @@ def list_untracked(repo: Path) -> list[str]:
     if proc.returncode != 0:
         return []
     return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+
+
+def _filter_preexisting_untracked(
+    untracked: list[str], preexisting_untracked: set[str] | None
+) -> list[str]:
+    """Drop paths that were already untracked before a fix ran.
+
+    Filters *untracked* against the *preexisting_untracked* snapshot so files
+    that existed before the run (e.g. a user's scratch file) are never
+    misattributed to daydream. ``None`` passes the list through unchanged,
+    preserving legacy behavior. Order of *untracked* is preserved, never
+    re-sorted.
+    """
+    if preexisting_untracked is None:
+        return untracked
+    return [path for path in untracked if path not in preexisting_untracked]
 
 
 def ls_files(repo: Path) -> list[str]:

--- a/tests/test_archive_data_capture.py
+++ b/tests/test_archive_data_capture.py
@@ -447,6 +447,32 @@ def test_capture_recommended_patch_clean_tree_uses_head_base(tmp_path: Path) -> 
     assert "+y = 2" in out.read_text()
 
 
+def test_capture_recommended_patch_excludes_only_preexisting_untracked_files(tmp_path: Path) -> None:
+    """R1-R4: a pre-existing untracked file (in preexisting_untracked) contributes
+    no creation hunk; a fix-created untracked file still does; tracked edits
+    serialize as today; omitting the snapshot keeps pre-existing files."""
+    repo = _init_repo_with_commit(tmp_path)
+    base = git_ops.head_sha(repo)                       # captured before the "fix"
+    (repo / "a.py").write_text("x = 1\ny = 2\n")        # tracked fix edit
+    (repo / "notes.txt").write_text("pre-existing\n")   # in the snapshot (pre-fix)
+    (repo / "new.py").write_text("fix = 1\n")           # created during the fix
+
+    out = repo / ".daydream" / "recommended.patch"
+    wrote = git_ops.capture_recommended_patch(
+        repo, base, out, preexisting_untracked={"notes.txt"}
+    )
+    assert wrote is True
+    text = out.read_text()
+    assert "new.py" in text            # fix-created untracked file captured
+    assert "notes.txt" not in text     # pre-existing untracked file excluded
+    assert "+y = 2" in text            # tracked diff unaffected
+
+    # R4 backward-compat: no snapshot -> the pre-existing file IS captured.
+    out2 = repo / ".daydream" / "recommended2.patch"
+    git_ops.capture_recommended_patch(repo, base, out2)
+    assert "notes.txt" in out2.read_text()
+
+
 def test_capture_recommended_patch_none_base_writes_nothing(tmp_path: Path) -> None:
     """A None base (no pre-fix snapshot could be taken) is a no-op."""
     repo = _init_repo_with_commit(tmp_path)

--- a/tests/test_archive_data_capture.py
+++ b/tests/test_archive_data_capture.py
@@ -174,6 +174,31 @@ async def test_default_deep_run_populates_eval_and_captures_recommended_patch(
     assert "# daydream recommended change" not in diff_text
 
 
+async def test_deep_archive_recommended_patch_excludes_preexisting_untracked_files(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch, archive_dir: Path
+) -> None:
+    """A pre-existing untracked file (present before the run) is absent from the
+    archived recommended.patch while a fix-created untracked file is present."""
+    remote = bare_remote(archive_dir.parent / "origin.git")
+    git(multi_stack_target, "remote", "add", "archive", str(remote))
+    stub = _install_deep_capture_backend(
+        multi_stack_target, monkeypatch, real_internal_phases=True
+    )
+    stub.fix_edit_line = "# daydream recommended change\n"
+    stub.fix_new_generated = "migrations/0002_add_x.sql"  # fix-created, untracked
+    (multi_stack_target / "notes.txt").write_text("pre-existing\n")  # pre-fix, untracked
+
+    exit_code = await run(
+        RunConfig(target=str(multi_stack_target), assume="yes", output_mode="loop", cleanup=False)
+    )
+    assert exit_code == 0
+
+    run_dir = _only_archived_run(archive_dir)
+    recommended = (run_dir / "recommended.patch").read_text()
+    assert "migrations/0002_add_x.sql" in recommended  # fix-created file present
+    assert "notes.txt" not in recommended              # pre-existing file excluded
+
+
 async def test_deep_run_with_unbalanced_quote_shell_command_still_archives_evaluation(
     multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch, archive_dir: Path
 ) -> None:


### PR DESCRIPTION
## Summary
- Prevents pre-existing untracked files from being serialized into `.daydream/recommended.patch` and from there into run archives / artifact dumps / bundle uploads.
- Threads the pre-fix untracked-path snapshot through to patch capture, so only files first created during the fix are emitted as creation hunks.

## Motivation
`_step_fix` recorded the untracked paths present before fixing, but `capture_recommended_patch` ignored that snapshot and emitted creation hunks for every untracked path still present after fixing. An unrelated local file could be serialized into the recommended patch, contaminating downstream evaluation or training evidence.

Closes #436

## Changes
- `daydream/git_ops.py`: extract a reusable preexisting-untracked filter helper; capture a pre-fix untracked snapshot and exclude those exact members from recommended-patch creation hunks.
- `daydream/deep/orchestrator.py`: thread the pre-fix untracked snapshot into patch capture.
- Retains tracked-diff, empty-marker, ordering, and failure behavior.

## Test Plan
- [x] Full suite green (3349 passed / 6 skipped, round-1 review)
- [x] Two sequential daydream deep-precision reviews (rounds 1 & 2) on fresh VMs — clean verdict on round 2
- [x] Authorship gate (verify-branch-authors.sh) — AUTHORS_OK, no rewrite

## Notes for Reviewers
- Round-2 review surfaced one pre-existing out-of-scope concern (commit agent's `git add --all` can stage pre-existing untracked files), tracked as issue #543.