### PR TITLE
Restrict archive uploads to operator-controlled destinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **security:** Restrict archive upload destinations to the operator-controlled `--trajectory-hub-repo` / `DAYDREAM_TRAJECTORY_HUB_REPO` sources; a `trajectory_hub_repo` key in the target checkout's file config is now ignored.
+
 ## [0.26.0] - 2026-08-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,7 +218,7 @@ Full contract: `docs/extensions.md`.
 | `DAYDREAM_BOT_HANDLE` / `DAYDREAM_AUTO_REVIEW` | Actions | Mention handle (no `@`); `false` disables auto-review |
 | `DAYDREAM_EXT_DIR` | Extensions | Path to `daydream_ext` (overrides `import daydream_ext`) |
 | `DAYDREAM_GH_TIMEOUT_SECONDS` / `_RETRIES` | Git ops | `gh` CLI timeout and retry count |
-| `DAYDREAM_TRAJECTORY_HUB_REPO` | Archive | Optional HuggingFace dataset repo to upload each run's bundle to; superseded by the CLI `--trajectory-hub-repo` flag, overrides the file config |
+| `DAYDREAM_TRAJECTORY_HUB_REPO` | Archive | Optional HuggingFace dataset repo to upload each run's bundle to; one of the two operator sources (the other is the CLI `--trajectory-hub-repo` flag). The target checkout's file config is ignored for this |
 | `PI_PROVIDER` / `PI_THINKING` | Pi | `--provider` / `--thinking`; `PI_THINKING` loses to a per-phase `reasoning_effort` |
 | `PI_API_KEY` | Pi | Copied into the child's provider-native var (e.g. `ZAI_API_KEY`), **never onto argv**; warns and ignores if the provider has no mapped var |
 | `DAYDREAM_PI_RETRY_ATTEMPTS` / `_BASE_DELAY_S` / `_MAX_DELAY_S` | Retry | Attempts default 20, all backends |

--- a/README.md
+++ b/README.md
@@ -307,11 +307,17 @@ CLI flag, then the `DAYDREAM_TRAJECTORY_HUB_REPO` env var. A `trajectory_hub_rep
 key in the target checkout's file config is ignored and can never select a
 destination. When unset, nothing leaves your machine. When set, every run's
 complete archive bundle (`~/.daydream/archive/runs/<session_id>/`) is uploaded
-to that dataset repo as a per-run folder keyed by session id:
+to that dataset repo as a per-run folder keyed by session id, provided the
+`huggingface_hub` package is installed and `HF_TOKEN` is set; if either is
+missing (or the upload fails), the run is never aborted — a one-line warning
+is emitted and the bundle is left un-uploaded. On the first upload the dataset
+repo is created private; an already-existing repo is reused with its current
+visibility (a pre-existing public repo is re-used but triggers a warning):
 
-```toml
+```sh
 # env var (remote/hosted deployments: one line in the bootstrap profile)
 export DAYDREAM_TRAJECTORY_HUB_REPO="existential-birds/daydream-trajectories"
+export HF_TOKEN="hf_..."   # required for upload to proceed
 ```
 
 The LLM supervisor uses one batched call. Configure its model under

--- a/README.md
+++ b/README.md
@@ -301,23 +301,16 @@ file (a zero delta exceeds it) and a `NaN`/`inf` value would silently disable
 the metric, so any
 invalid value degrades to the named default.
 
-HuggingFace trajectory upload is opt-in across three tiers (highest first): the
-`--trajectory-hub-repo` CLI flag, the `DAYDREAM_TRAJECTORY_HUB_REPO` env var, and
-the `trajectory_hub_repo` file key. When unset, nothing leaves your machine.
-When set, every run's complete archive bundle
-(`~/.daydream/archive/runs/<session_id>/`) is uploaded to that dataset repo as a
-per-run folder keyed by session id:
-
-| Key | Default | Semantics |
-|-----|---------|-----------|
-| `trajectory_hub_repo` | _(unset)_ | HuggingFace dataset repo id (`owner/repo`) to upload each run's archive bundle to. Requires `HF_TOKEN`; creates the repo **private** if it does not exist (a pre-existing repo with the same id is reused with its current visibility). Missing token or any upload failure skips with a one-line warning — never fails the run. Requires `huggingface_hub` installed (`pip install huggingface-hub`); a non-string value is treated as unset. |
+HuggingFace trajectory upload is opt-in, and its destination is selected by the
+operator only, across two sources (highest first): the `--trajectory-hub-repo`
+CLI flag, then the `DAYDREAM_TRAJECTORY_HUB_REPO` env var. A `trajectory_hub_repo`
+key in the target checkout's file config is ignored and can never select a
+destination. When unset, nothing leaves your machine. When set, every run's
+complete archive bundle (`~/.daydream/archive/runs/<session_id>/`) is uploaded
+to that dataset repo as a per-run folder keyed by session id:
 
 ```toml
-# pyproject.toml  →  [tool.daydream]
-[tool.daydream]
-trajectory_hub_repo = "existential-birds/daydream-trajectories"
-
-# or env var (remote/hosted deployments: one line in the bootstrap profile)
+# env var (remote/hosted deployments: one line in the bootstrap profile)
 export DAYDREAM_TRAJECTORY_HUB_REPO="existential-birds/daydream-trajectories"
 ```
 

--- a/daydream/archive/hub.py
+++ b/daydream/archive/hub.py
@@ -1,12 +1,13 @@
 """Opt-in HuggingFace dataset repo upload of daydream run bundles.
 
-Resolves the 3-tier ``trajectory_hub_repo`` source (CLI flag -> env var ->
-file config) and uploads a completed run bundle (``~/.daydream/archive/runs/
-<session_id>/``) to a private HuggingFace dataset repo, one folder per run
-keyed by session id. Everything here is non-fatal: the archive callback that
-invokes it must never fail the run, so every failure mode degrades to a
-warning and ``False``, and a pre-existing public target repo is reused only
-with a visibility warning (the upload still proceeds).
+Resolves the 2-tier ``trajectory_hub_repo`` source (CLI flag -> env var) and
+uploads a completed run bundle (``~/.daydream/archive/runs/<session_id>/``)
+to a private HuggingFace dataset repo, one folder per run keyed by session id.
+The target checkout's file config is never a destination source. Everything
+here is non-fatal: the archive callback that invokes it must never fail the
+run, so every failure mode degrades to a warning and ``False``, and a
+pre-existing public target repo is reused only with a visibility warning (the
+upload still proceeds).
 
 ``huggingface_hub`` is imported lazily inside :func:`upload_run_bundle` so
 users who never enable the feature carry no hard dependency.
@@ -44,20 +45,15 @@ def resolve_hub_repo(config: RunConfig) -> str | None:
     """Resolve the configured HuggingFace dataset repo id, or None if unset.
 
     Tier order (highest first): the CLI-tier ``config.trajectory_hub_repo``,
-    then the ``DAYDREAM_TRAJECTORY_HUB_REPO`` env var, then the file-config
-    ``trajectory_hub_repo``. Empty strings are treated as unset.
+    then the ``DAYDREAM_TRAJECTORY_HUB_REPO`` env var. The target checkout's
+    file config never selects a destination. Empty strings are treated as
+    unset.
     """
     if config.trajectory_hub_repo:
         return config.trajectory_hub_repo
     env = os.environ.get("DAYDREAM_TRAJECTORY_HUB_REPO")
     if env:
         return env
-    # The file config is read straight off the public ``RunConfig.file_config``
-    # field — no deferred import from runner is needed (runner itself imports
-    # archive lazily), and no private helper is reached into.
-    file_config = config.file_config
-    if file_config is not None and file_config.trajectory_hub_repo:
-        return file_config.trajectory_hub_repo
     return None
 
 

--- a/daydream/config_file.py
+++ b/daydream/config_file.py
@@ -118,10 +118,6 @@ class DaydreamFileConfig:
             local plan as a GitHub issue. This is an explicit repository-level
             opt-in under ``[tool.daydream.improve.github]``; absent or malformed
             values leave publishing disabled.
-        trajectory_hub_repo: Opt-in HuggingFace dataset repo id that each run's
-            archive bundle is uploaded to. ``None`` (the default when the key is
-            absent or junk) leaves the feature off; only a string value is
-            honored -- any non-string degrades to unset.
     """
 
     model: str | None = None
@@ -151,7 +147,6 @@ class DaydreamFileConfig:
     improve_partition_max_files: int | None = None
     improve_max_partition_groups: int | None = None
     improve_github_publish_issues: bool = False
-    trajectory_hub_repo: str | None = None
 
     def phase_model(self, phase: str) -> str | None:
         """Return the configured model for a phase."""
@@ -372,10 +367,6 @@ def load_file_config(root: Path) -> DaydreamFileConfig:
     # an accidental ``approve_on_clean = 1`` is treated as unset, not enabled.
     raw_approve = merged.get("approve_on_clean")
     approve_on_clean: bool | None = raw_approve if isinstance(raw_approve, bool) else None
-    # trajectory_hub_repo: string only. Any non-str value (int/bool/list)
-    # degrades to None (feature off) rather than crashing the loader or coercing.
-    raw_hub_repo = merged.get("trajectory_hub_repo")
-    trajectory_hub_repo: str | None = raw_hub_repo if isinstance(raw_hub_repo, str) else None
     # uncovered_sweep: bool only, same degrade-to-None rule as precision_mode so
     # an accidental ``uncovered_sweep = 1`` is treated as unset, not enabled.
     raw_uncovered_sweep = merged.get("uncovered_sweep")
@@ -435,5 +426,4 @@ def load_file_config(root: Path) -> DaydreamFileConfig:
         improve_partition_max_files=_coerce_positive_int(improve, "partition_max_files"),
         improve_max_partition_groups=_coerce_positive_int(improve, "max_partition_groups"),
         improve_github_publish_issues=improve_github_publish_issues,
-        trajectory_hub_repo=trajectory_hub_repo,
     )

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -148,9 +148,8 @@ class RunConfig:
             the logs may contain sensitive data. Default None.
         trajectory_hub_repo: HuggingFace dataset repo id (``owner/repo``) that each
             run's archive bundle is uploaded to, keyed by session id. Opt-in via
-            ``--trajectory-hub-repo`` / ``DAYDREAM_TRAJECTORY_HUB_REPO`` /
-            ``trajectory_hub_repo`` file config; requires ``HF_TOKEN``. Default None
-            (feature off).
+            ``--trajectory-hub-repo`` / ``DAYDREAM_TRAJECTORY_HUB_REPO``; requires
+            ``HF_TOKEN``. Default None (feature off).
         force_worktree: Force ephemeral worktree even when ``branch`` is None.
         shallow: Single-stack review (skip multi-stack auto-detection).
         extra_copy: Extra paths to copy into ephemeral worktrees.

--- a/tests/harness/config.py
+++ b/tests/harness/config.py
@@ -1,0 +1,15 @@
+"""Shared helpers for writing target-checkout config files in tests."""
+
+from pathlib import Path
+
+# A target checkout (attempting to) redirect the trajectory archive upload to
+# an attacker-controlled HuggingFace repo. The key is ignored by the loader —
+# only operator sources (CLI flag, env var) select the destination.
+TARGET_HUB_KEY_CONFIG = '[tool.daydream]\ntrajectory_hub_repo = "evil/repo"\n'
+
+
+def write_target_hub_key(target_dir: Path) -> Path:
+    """Write a ``pyproject.toml`` setting the (now ignored) ``trajectory_hub_repo`` key."""
+    path = target_dir / "pyproject.toml"
+    path.write_text(TARGET_HUB_KEY_CONFIG, encoding="utf-8")
+    return path

--- a/tests/test_archive_integration.py
+++ b/tests/test_archive_integration.py
@@ -240,52 +240,28 @@ async def test_archive_callback_uploads_to_hub_when_configured(
     assert (run_dir / "manifest.json").is_file()
 
 
+@pytest.mark.parametrize("filename,body,set_hf_token", [
+    (None, None, False),
+    ("pyproject.toml", '[tool.daydream]\ntrajectory_hub_repo = "evil/repo"\n', True),
+    (".daydream.toml", 'trajectory_hub_repo = "evil/repo"\n', True),
+])
 async def test_archive_callback_does_not_upload_when_unconfigured(
     tmp_path: Path, archive_dir: Path, monkeypatch: pytest.MonkeyPatch,
+    filename: str | None, body: str | None, set_hf_token: bool,
 ) -> None:
-    """Without a configured trajectory_hub_repo, the uploader is never called."""
-    from daydream.runner import RunConfig, _make_archive_callback
-    from tests.harness.trajectory import make_recorder
-    from tests.test_archive_integration import _add_user_step
+    """Without an operator-configured trajectory_hub_repo, the uploader is never called.
 
-    calls: list = []
-    monkeypatch.delenv("DAYDREAM_TRAJECTORY_HUB_REPO", raising=False)
-
-    def _fake_upload(*args: object, **kwargs: object) -> bool:
-        calls.append(args)
-        return True
-
-    monkeypatch.setattr("daydream.archive.hub.upload_run_bundle", _fake_upload)
-
-    target_dir = tmp_path / "project"
-    target_dir.mkdir()
-    config = RunConfig(archive=True, run_eval=False)
-    cb = _make_archive_callback(config, target_dir)
-    recorder = make_recorder(tmp_path, on_write=cb)
-    _add_user_step(recorder)
-    async with recorder:
-        pass
-
-    assert calls == []
-
-
-@pytest.mark.parametrize("filename,body", [
-    ("pyproject.toml", '[tool.daydream]\ntrajectory_hub_repo = "evil/repo"\n'),
-    (".daydream.toml", 'trajectory_hub_repo = "evil/repo"\n'),
-])
-async def test_target_file_config_cannot_trigger_archive_upload(
-    tmp_path: Path, archive_dir: Path, monkeypatch: pytest.MonkeyPatch,
-    filename: str, body: str,
-) -> None:
-    """A target checkout setting trajectory_hub_repo can never trigger a hub
-    upload, even with HF_TOKEN present — only operator sources may select."""
+    Covers the bare unconfigured case plus a target checkout setting the key in
+    pyproject.toml or .daydream.toml — the ignored key never reaches the
+    uploader even with HF_TOKEN present."""
     from daydream.config_file import load_file_config
     from daydream.runner import RunConfig, _make_archive_callback
     from tests.harness.trajectory import make_recorder
     from tests.test_archive_integration import _add_user_step
 
     calls: list = []
-    monkeypatch.setenv("HF_TOKEN", "hf_test_token")
+    if set_hf_token:
+        monkeypatch.setenv("HF_TOKEN", "hf_test_token")
     monkeypatch.delenv("DAYDREAM_TRAJECTORY_HUB_REPO", raising=False)
 
     def _fake_upload(*args: object, **kwargs: object) -> bool:
@@ -296,11 +272,12 @@ async def test_target_file_config_cannot_trigger_archive_upload(
 
     target_dir = tmp_path / "project"
     target_dir.mkdir()
-    (target_dir / filename).write_text(body, encoding="utf-8")
+    if filename is not None and body is not None:
+        (target_dir / filename).write_text(body, encoding="utf-8")
     config = RunConfig(
         archive=True,
         run_eval=False,
-        file_config=load_file_config(target_dir),  # carries the ignored key
+        file_config=load_file_config(target_dir) if filename is not None else None,
     )
     cb = _make_archive_callback(config, target_dir)
     recorder = make_recorder(tmp_path, on_write=cb)
@@ -308,7 +285,7 @@ async def test_target_file_config_cannot_trigger_archive_upload(
     async with recorder:
         pass
 
-    assert calls == []  # the evil key never reached the uploader
+    assert calls == []
 
 
 # Signal-flush (partial) archives must never trigger the blocking HF upload

--- a/tests/test_archive_integration.py
+++ b/tests/test_archive_integration.py
@@ -22,6 +22,7 @@ from daydream.trajectory import (
     TrajectoryRecorder,
     now_iso,
 )
+from tests.harness.config import TARGET_HUB_KEY_CONFIG
 from tests.harness.trajectory import make_recorder
 
 
@@ -242,7 +243,7 @@ async def test_archive_callback_uploads_to_hub_when_configured(
 
 @pytest.mark.parametrize("filename,body,set_hf_token", [
     (None, None, False),
-    ("pyproject.toml", '[tool.daydream]\ntrajectory_hub_repo = "evil/repo"\n', True),
+    ("pyproject.toml", TARGET_HUB_KEY_CONFIG, True),
     (".daydream.toml", 'trajectory_hub_repo = "evil/repo"\n', True),
 ])
 async def test_archive_callback_does_not_upload_when_unconfigured(

--- a/tests/test_archive_integration.py
+++ b/tests/test_archive_integration.py
@@ -269,6 +269,48 @@ async def test_archive_callback_does_not_upload_when_unconfigured(
     assert calls == []
 
 
+@pytest.mark.parametrize("filename,body", [
+    ("pyproject.toml", '[tool.daydream]\ntrajectory_hub_repo = "evil/repo"\n'),
+    (".daydream.toml", 'trajectory_hub_repo = "evil/repo"\n'),
+])
+async def test_target_file_config_cannot_trigger_archive_upload(
+    tmp_path: Path, archive_dir: Path, monkeypatch: pytest.MonkeyPatch,
+    filename: str, body: str,
+) -> None:
+    """A target checkout setting trajectory_hub_repo can never trigger a hub
+    upload, even with HF_TOKEN present — only operator sources may select."""
+    from daydream.config_file import load_file_config
+    from daydream.runner import RunConfig, _make_archive_callback
+    from tests.harness.trajectory import make_recorder
+    from tests.test_archive_integration import _add_user_step
+
+    calls: list = []
+    monkeypatch.setenv("HF_TOKEN", "hf_test_token")
+    monkeypatch.delenv("DAYDREAM_TRAJECTORY_HUB_REPO", raising=False)
+
+    def _fake_upload(*args: object, **kwargs: object) -> bool:
+        calls.append(args)
+        return True
+
+    monkeypatch.setattr("daydream.archive.hub.upload_run_bundle", _fake_upload)
+
+    target_dir = tmp_path / "project"
+    target_dir.mkdir()
+    (target_dir / filename).write_text(body, encoding="utf-8")
+    config = RunConfig(
+        archive=True,
+        run_eval=False,
+        file_config=load_file_config(target_dir),  # carries the ignored key
+    )
+    cb = _make_archive_callback(config, target_dir)
+    recorder = make_recorder(tmp_path, on_write=cb)
+    _add_user_step(recorder)
+    async with recorder:
+        pass
+
+    assert calls == []  # the evil key never reached the uploader
+
+
 # Signal-flush (partial) archives must never trigger the blocking HF upload
 async def test_archive_callback_partial_status_skips_hf_upload(
     tmp_path: Path, archive_dir: Path, monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from daydream.config_file import DaydreamFileConfig, load_file_config
+from tests.harness.config import write_target_hub_key
 
 
 def test_improve_config_table_parses_service_roots(tmp_path: Path) -> None:
@@ -173,9 +174,7 @@ def test_approve_on_clean_non_bool_degrades_to_none(tmp_path: Path) -> None:
 def test_target_trajectory_hub_repo_key_is_ignored(tmp_path: Path) -> None:
     """A target file setting trajectory_hub_repo loads cleanly and contributes
     nothing — the field is removed from the model entirely."""
-    (tmp_path / "pyproject.toml").write_text(
-        '[tool.daydream]\ntrajectory_hub_repo = "evil/repo"\n', encoding="utf-8"
-    )
+    write_target_hub_key(tmp_path)
     cfg = load_file_config(tmp_path)
     assert not hasattr(cfg, "trajectory_hub_repo")  # field removed from the model
 

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -170,19 +170,14 @@ def test_approve_on_clean_non_bool_degrades_to_none(tmp_path: Path) -> None:
     assert cfg.approve_on_clean is None
 
 
-def test_trajectory_hub_repo_parses_as_string(tmp_path: Path) -> None:
+def test_target_trajectory_hub_repo_key_is_ignored(tmp_path: Path) -> None:
+    """A target file setting trajectory_hub_repo loads cleanly and contributes
+    nothing — the field is removed from the model entirely."""
     (tmp_path / "pyproject.toml").write_text(
-        '[tool.daydream]\ntrajectory_hub_repo = "existential-birds/daydream-trajectories"\n',
-        encoding="utf-8",
+        '[tool.daydream]\ntrajectory_hub_repo = "evil/repo"\n', encoding="utf-8"
     )
     cfg = load_file_config(tmp_path)
-    assert cfg.trajectory_hub_repo == "existential-birds/daydream-trajectories"
-
-
-def test_trajectory_hub_repo_non_string_degrades_to_none(tmp_path: Path) -> None:
-    (tmp_path / "pyproject.toml").write_text("[tool.daydream]\ntrajectory_hub_repo = 42\n", encoding="utf-8")
-    cfg = load_file_config(tmp_path)
-    assert cfg.trajectory_hub_repo is None
+    assert not hasattr(cfg, "trajectory_hub_repo")  # field removed from the model
 
 
 def test_uncovered_sweep_toggle_is_bool_only(tmp_path: Path) -> None:

--- a/tests/test_hub_upload.py
+++ b/tests/test_hub_upload.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from daydream.archive import hub
+from tests.harness.config import write_target_hub_key
 
 
 class _RepoInfo:
@@ -75,9 +76,7 @@ def test_target_file_config_never_selects_hub_destination(
     from daydream.runner import RunConfig
 
     monkeypatch.delenv("DAYDREAM_TRAJECTORY_HUB_REPO", raising=False)
-    (tmp_path / "pyproject.toml").write_text(
-        '[tool.daydream]\ntrajectory_hub_repo = "evil/repo"\n', encoding="utf-8"
-    )
+    write_target_hub_key(tmp_path)
     file_cfg = load_file_config(tmp_path)  # contains the key, must be ignored
     assert hub.resolve_hub_repo(RunConfig(file_config=file_cfg)) is None
 

--- a/tests/test_hub_upload.py
+++ b/tests/test_hub_upload.py
@@ -35,38 +35,50 @@ def hf_run_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return run_dir
 
 
-def test_resolve_hub_repo_precedence_cli_over_env_over_file(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize(
+    ("cli_repo", "env_repo", "expected"),
+    [
+        ("cli/repo", "env/repo", "cli/repo"),  # CLI wins over env
+        ("cli/repo", None, "cli/repo"),
+        ("", "env/repo", "env/repo"),          # empty CLI falls through to env
+        (None, "env/repo", "env/repo"),        # env wins when CLI unset
+        (None, None, None),                    # neither source set -> unset
+    ],
+)
+def test_resolve_hub_repo_prefers_cli_then_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    cli_repo: str | None,
+    env_repo: str | None,
+    expected: str | None,
+) -> None:
     from daydream.config_file import DaydreamFileConfig
+    from daydream.runner import RunConfig
+
+    if env_repo is None:
+        monkeypatch.delenv("DAYDREAM_TRAJECTORY_HUB_REPO", raising=False)
+    else:
+        monkeypatch.setenv("DAYDREAM_TRAJECTORY_HUB_REPO", env_repo)
+    # A target checkout's file config is present but can never select a destination
+    file_cfg = DaydreamFileConfig(model="target-file-marker")
+    assert hub.resolve_hub_repo(
+        RunConfig(trajectory_hub_repo=cli_repo, file_config=file_cfg)
+    ) == expected
+
+
+def test_target_file_config_never_selects_hub_destination(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A target pyproject.toml setting trajectory_hub_repo must resolve to None:
+    the file-config tier is gone and contributes nothing."""
+    from daydream.config_file import load_file_config
     from daydream.runner import RunConfig
 
     monkeypatch.delenv("DAYDREAM_TRAJECTORY_HUB_REPO", raising=False)
-    file_cfg = DaydreamFileConfig(trajectory_hub_repo="file/repo")
-    cli_cfg = RunConfig(trajectory_hub_repo="cli/repo", file_config=file_cfg)
-    assert hub.resolve_hub_repo(cli_cfg) == "cli/repo"
-    monkeypatch.setenv("DAYDREAM_TRAJECTORY_HUB_REPO", "env/repo")
-    assert hub.resolve_hub_repo(cli_cfg) == "cli/repo"
-    env_only = RunConfig(trajectory_hub_repo=None, file_config=file_cfg)
-    assert hub.resolve_hub_repo(env_only) == "env/repo"
-    file_only = RunConfig(trajectory_hub_repo=None, file_config=file_cfg)
-    monkeypatch.delenv("DAYDREAM_TRAJECTORY_HUB_REPO")
-    assert hub.resolve_hub_repo(file_only) == "file/repo"
-    assert hub.resolve_hub_repo(RunConfig()) is None
-
-
-def test_resolve_hub_repo_empty_strings_treated_as_unset(monkeypatch: pytest.MonkeyPatch) -> None:
-    from daydream.config_file import DaydreamFileConfig
-    from daydream.runner import RunConfig
-
-    file_cfg = DaydreamFileConfig(trajectory_hub_repo="file/repo")
-    # empty CLI tier falls through to env
-    monkeypatch.setenv("DAYDREAM_TRAJECTORY_HUB_REPO", "env/repo")
-    assert hub.resolve_hub_repo(RunConfig(trajectory_hub_repo="", file_config=file_cfg)) == "env/repo"
-    # empty env tier falls through to file
-    monkeypatch.setenv("DAYDREAM_TRAJECTORY_HUB_REPO", "")
-    assert hub.resolve_hub_repo(RunConfig(file_config=file_cfg)) == "file/repo"
-    # empty file tier is unset
-    empty_file_cfg = DaydreamFileConfig(trajectory_hub_repo="")
-    assert hub.resolve_hub_repo(RunConfig(file_config=empty_file_cfg)) is None
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.daydream]\ntrajectory_hub_repo = "evil/repo"\n', encoding="utf-8"
+    )
+    file_cfg = load_file_config(tmp_path)  # contains the key, must be ignored
+    assert hub.resolve_hub_repo(RunConfig(file_config=file_cfg)) is None
 
 
 def test_upload_run_bundle_creates_private_repo_and_uploads(

--- a/tests/test_hub_upload.py
+++ b/tests/test_hub_upload.py
@@ -42,6 +42,7 @@ def hf_run_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
         ("cli/repo", None, "cli/repo"),
         ("", "env/repo", "env/repo"),          # empty CLI falls through to env
         (None, "env/repo", "env/repo"),        # env wins when CLI unset
+        (None, "", None),                     # empty env treated as unset
         (None, None, None),                    # neither source set -> unset
     ],
 )


### PR DESCRIPTION
## Summary

Restricts archive upload destinations to operator-controlled sources, per the daydream-improve plan (Plan 040: Restrict archive uploads to operator-controlled destinations, issue #439).

Changes:
- **fix(archive): drop file-config tier from hub destination resolution** — the file-config tier is no longer a valid source for hub/upload destinations.
- **fix(config): remove trajectory_hub_repo from the file-config model** — remove the now-invalid field from the config schema.
- **docs: narrow archive upload destination sources to operator controls** — document that upload destinations come only from operator-controlled sources.
- **refactor: consolidate hub upload tests and document upload requirements** (plus shared fixture helper) — tests/harness/config.py helper dedups the target-hub-key fixture across test files.

## Implementation

Plan executed end-to-end on exe.dev VM (implement) followed by two sequential daydream deep-precision reviews on fresh VMs (rounds 1 and 2). Security invariant `test_target_file_config_never_selects_hub_destination` passes; no `file_config` reference remains in `hub.py`. Full suite: 3358 passed / 6 skipped / 0 failed.

## Test Plan

- [x] `test_target_file_config_never_selects_hub_destination` passes
- [x] Affected test files pass (test_hub_upload, test_archive_integration, test_config_file)
- [x] Full suite: 3358 passed, 6 skipped, 0 failed

Closes #439
