### PR TITLE
fix(redact): redact agent log mode and benchmark subprocess output (Closes #438)

### DIFF
--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -348,24 +348,32 @@ def _summarize_input(input_data: dict[str, Any]) -> str:
     """One-line summary of tool input for log output."""
     if not input_data:
         return ""
-    # For known tools, pick the most informative key
+    # For known tools, pick the most informative key. The COMPLETE selected
+    # string is redacted before any [:200] slice — redact-after-slice would
+    # truncate a credential into an unmatchable fragment.
     if "command" in input_data:
-        return input_data["command"][:200]
+        return redact_text(input_data["command"])[:200]
     if "path" in input_data:
-        return f"{input_data['path']}" + (f" -> {input_data.get('new_path', '')}" if "new_path" in input_data else "")
+        complete = f"{input_data['path']}" + (
+            f" -> {input_data.get('new_path', '')}" if "new_path" in input_data else ""
+        )
+        return redact_text(complete)
     # Generic: first value that's a string
     for v in input_data.values():
         if isinstance(v, str):
-            return v[:200]
-    return str(input_data)[:200]
+            return redact_text(v)[:200]
+    return redact_text(str(input_data))[:200]
 
 
 def _summarize_output(output: str) -> str:
     """One-line summary of tool output for log output."""
     if not output:
         return "(empty)"
+    # Redact the COMPLETE output before strip/first-line/[:200] — a credential
+    # straddling the summary boundary must be caught before the slice.
+    redacted = redact_text(output)
     # Take first non-empty line or first 200 chars
-    first_line = output.strip().split("\n")[0]
+    first_line = redacted.strip().split("\n")[0]
     return first_line[:200]
 
 
@@ -564,7 +572,7 @@ async def run_agent(
                                     raise MissingSkillError(skill_match.group(1))
 
                                 if _state.log_mode:
-                                    print(event.text, flush=True)
+                                    _print_log(event.text)
                                 elif use_callback and progress_callback is not None:
                                     last_line = event.text.strip().split("\n")[-1]
                                     if last_line:
@@ -581,7 +589,7 @@ async def run_agent(
 
                             elif isinstance(event, ThinkingEvent):
                                 if _state.log_mode:
-                                    print(f"[thinking] {event.text}", flush=True)
+                                    _print_log(f"[thinking] {event.text}")
                                 elif not use_callback:
                                     if agent_renderer.has_content:
                                         agent_renderer.finish()
@@ -593,7 +601,7 @@ async def run_agent(
                             elif isinstance(event, ToolStartEvent):
                                 if _state.log_mode:
                                     tool_names[event.id] = event.name
-                                    print(f"[tool:{event.name}] {_summarize_input(event.input)}", flush=True)
+                                    _print_log(f"[tool:{event.name}] {_summarize_input(event.input)}")
                                 elif progress_callback is not None:
                                     # Record the originating call so a backgrounded launch's result
                                     # can later resolve a Task-family label for the progress line.
@@ -635,7 +643,7 @@ async def run_agent(
                                         f"[tool:{tool_name} ERROR]" if event.is_error
                                         else f"[tool:{tool_name} result]"
                                     )
-                                    print(f"{prefix} {_summarize_output(event.output)}", flush=True)
+                                    _print_log(f"{prefix} {_summarize_output(event.output)}")
                                 else:
                                     # Populate the task_id→label map in both modes, so a later
                                     # TaskOutput/TaskStop resolves its originating label.
@@ -652,9 +660,8 @@ async def run_agent(
 
                             elif isinstance(event, MetricsEvent):
                                 if _state.log_mode:
-                                    print(
+                                    _print_log(
                                         f"[metrics] prompt={event.prompt_tokens} completion={event.completion_tokens}",
-                                        flush=True
                                     )
                                 # EVNT-02 / MAP-06: recorder-only, no UI in normal mode. Must precede the
                                 # CostEvent branch so isinstance order is correct.
@@ -664,7 +671,7 @@ async def run_agent(
                             elif isinstance(event, CostEvent):
                                 if _state.log_mode:
                                     cost_str = f"${event.cost_usd:.4f}" if event.cost_usd is not None else "unknown"
-                                    print(f"[cost] {cost_str}", flush=True)
+                                    _print_log(f"[cost] {cost_str}")
                                 elif event.cost_usd and not use_callback:
                                     if agent_renderer.has_content:
                                         agent_renderer.finish()
@@ -682,9 +689,9 @@ async def run_agent(
                                 structured_result = event.structured_output
                                 if event.structured_output is not None:
                                     if _state.log_mode:
-                                        print(
-                                            f"[result] {json.dumps(event.structured_output)[:500]}",
-                                            flush=True,
+                                        redacted = _redact_log_value(event.structured_output)
+                                        _print_log(
+                                            f"[result] {json.dumps(redacted)[:500]}",
                                         )
                                     elif not use_callback:
                                         issues = (
@@ -724,7 +731,7 @@ async def run_agent(
                             inv.mark_aborted(budget_reason)
                             inv.observe(TurnEndEvent())
                         if _state.log_mode:
-                            print(f"[aborted] {budget_reason}", flush=True)
+                            _print_log(f"[aborted] {budget_reason}")
                         elif use_callback and progress_callback is not None:
                             result = progress_callback(format_callback_text(f"[budget] aborted: {budget_reason}"))
                             if inspect.isawaitable(result):
@@ -753,7 +760,7 @@ async def run_agent(
                         f"attempt {attempt + 2}/{max_attempts + 1} after {delay:.1f}s..."
                     )
                     if _state.log_mode:
-                        print(f"[retry] {retry_msg}", flush=True)
+                        _print_log(f"[retry] {retry_msg}")
                     elif use_callback and progress_callback is not None:
                         result = progress_callback(format_callback_text(f"[retry] {retry_msg}"))
                         if inspect.isawaitable(result):

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -114,7 +114,7 @@ class AgentState:
             ``"no"`` (a future ``--no``), or ``None`` (no assumption). Orthogonal to
             ``non_interactive``: ``non_interactive`` controls *whether* we may block on
             stdin; ``assume`` supplies a *pre-decided answer* regardless of TTY.
-        log_mode: When True, bypass Rich UI and emit raw agent events as plain text
+        log_mode: When True, bypass Rich UI and emit redacted agent events as plain text
             to stdout (for CI log capture). Default False.
     """
 

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -369,6 +369,32 @@ def _summarize_output(output: str) -> str:
     return first_line[:200]
 
 
+def _redact_log_value(value: Any) -> Any:
+    """Recursively redact a log-mode value without mutating its argument.
+
+    ``str`` leaves and string dict keys are run through the fail-closed log
+    boundary; containers are rebuilt fresh so the caller's object is never
+    touched. The redactor never raises, so no error propagation is needed.
+    """
+    if isinstance(value, str):
+        return redact_text(value)
+    if isinstance(value, dict):
+        return {
+            (redact_text(k) if isinstance(k, str) else k): _redact_log_value(v)
+            for k, v in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_log_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_redact_log_value(item) for item in value)
+    return value
+
+
+def _print_log(value: str) -> None:
+    """The single safe ``--log`` emitter: redact, then print."""
+    print(redact_text(value), flush=True)
+
+
 async def run_agent(
     backend: Backend,
     cwd: Path,

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -17,6 +17,7 @@ from types import TracebackType
 from typing import TYPE_CHECKING, Any
 
 import anyio
+from rich.console import Console
 
 if TYPE_CHECKING:
     from claude_agent_sdk.types import AgentDefinition
@@ -38,11 +39,11 @@ from daydream.backends import (
 from daydream.config import UNKNOWN_SKILL_PATTERN
 from daydream.extensions import get_registry
 from daydream.json_utils import extract_json
-from daydream.trajectory import DaydreamPhase, get_current_recorder, redact_text
+from daydream.trajectory import DaydreamPhase, get_current_recorder, redact_text, redact_value
 from daydream.ui import (
+    NEON_THEME,
     AgentTextRenderer,
     LiveToolPanelRegistry,
-    create_console,
     format_callback_progress,
     format_callback_text,
     print_cost,
@@ -125,11 +126,28 @@ class AgentState:
     current_backends: list[Backend] = field(default_factory=list)
 
 
+class _LogRedactingConsole(Console):
+    """Console that redacts string payloads while ``--log`` mode is active.
+
+    phases.py, runner.py, and the other importers bind to this module-level
+    console, so their Rich output would otherwise bypass the run_agent-event
+    emitter and leak raw secrets via the UI path in ``--log`` mode.
+    """
+
+    def print(self, *objects: Any, **kwargs: Any) -> None:
+        if _state.log_mode:
+            objects = tuple(
+                redact_text(obj) if isinstance(obj, str) else obj
+                for obj in objects
+            )
+        super().print(*objects, **kwargs)
+
+
 # Module-level singletons: access/mutate via the getter/setter functions below,
 # never _state directly. reset_state() restores defaults between test runs.
 
 _state = AgentState()
-console = create_console()
+console = _LogRedactingConsole(theme=NEON_THEME)
 
 
 def reset_state() -> None:
@@ -380,26 +398,18 @@ def _summarize_output(output: str) -> str:
 def _redact_log_value(value: Any) -> Any:
     """Recursively redact a log-mode value without mutating its argument.
 
-    ``str`` leaves and string dict keys are run through the fail-closed log
-    boundary; containers are rebuilt fresh so the caller's object is never
-    touched. The redactor never raises, so no error propagation is needed.
+    Delegates to the canonical :func:`daydream.trajectory.redact_value`
+    redactor so the security-relevant recursion lives in exactly one place.
     """
-    if isinstance(value, str):
-        return redact_text(value)
-    if isinstance(value, dict):
-        return {
-            (redact_text(k) if isinstance(k, str) else k): _redact_log_value(v)
-            for k, v in value.items()
-        }
-    if isinstance(value, list):
-        return [_redact_log_value(item) for item in value]
-    if isinstance(value, tuple):
-        return tuple(_redact_log_value(item) for item in value)
-    return value
+    return redact_value(value)
 
 
 def _print_log(value: str) -> None:
-    """The single safe ``--log`` emitter: redact, then print."""
+    """The safe ``--log`` emitter for run_agent events: redact, then print.
+
+    Phase/UI output flows through the module-level ``console``, which redacts
+    string payloads in log mode via the same fail-closed boundary.
+    """
     print(redact_text(value), flush=True)
 
 

--- a/daydream/benchmark/daydream_run.py
+++ b/daydream/benchmark/daydream_run.py
@@ -153,6 +153,13 @@ def _run_streamed(
     """
     tail: collections.deque[str] = collections.deque(maxlen=40)
     lines: queue.Queue[str | None] = queue.Queue()
+    # A PEM block spans multiple lines; redacting each line alone never presents
+    # the BEGIN/END anchors to _PEM_KEY_PATTERN (re.DOTALL) together, so the
+    # base64 body would leak to on_line and the failure tail. Hold lines from a
+    # BEGIN marker until its END marker, then redact the whole block at once —
+    # the streamed analogue of the captured path's redact-the-complete-string
+    # invariant.
+    pem_buffer: list[str] = []
     with subprocess.Popen(  # noqa: S603 - args are harness-controlled, not user input
         cmd,  # noqa: S607 - daydream is a trusted command
         stdout=subprocess.PIPE,
@@ -180,7 +187,21 @@ def _run_streamed(
                 ) from None
             if line is None:
                 break
-            redacted = redact_text(line)
+            if "-----BEGIN" in line and "PRIVATE KEY" in line and "-----END" not in line:
+                pem_buffer.append(line)
+            elif pem_buffer:
+                pem_buffer.append(line)
+                if "-----END" in line:
+                    redacted = redact_text("".join(pem_buffer))
+                    on_line(redacted)
+                    tail.append(redacted)
+                    pem_buffer.clear()
+            else:
+                redacted = redact_text(line)
+                on_line(redacted)
+                tail.append(redacted)
+        if pem_buffer:  # stream ended mid-block: redact the held lines as one
+            redacted = redact_text("".join(pem_buffer))
             on_line(redacted)
             tail.append(redacted)
         returncode = proc.wait()

--- a/daydream/benchmark/daydream_run.py
+++ b/daydream/benchmark/daydream_run.py
@@ -14,6 +14,7 @@ import collections
 import json
 import os
 import queue
+import re
 import subprocess
 import threading
 import time
@@ -59,6 +60,14 @@ _ERROR_CONTEXT_MARKERS = (
     "backend execution error",
     "fatal error",
 )
+
+#: PEM private-key block anchors, mirroring trajectory._PEM_KEY_PATTERN's
+#: ``-----BEGIN (?:RSA )?PRIVATE KEY-----`` spec. Only blocks whose anchors match
+#: that spec are buffered for whole-block redaction: ENCRYPTED/OPENSSH/EC/DSA
+#: headers are not matched by the pattern, so buffering them here would present
+#: them as handled and then forward the raw key to on_line and the failure tail.
+_PEM_BEGIN_RE = re.compile(r"-----BEGIN (?:RSA )?PRIVATE KEY-----")
+_PEM_END_RE = re.compile(r"-----END (?:RSA )?PRIVATE KEY-----")
 
 
 def _is_transient(stdout: str) -> bool:
@@ -158,8 +167,15 @@ def _run_streamed(
     # base64 body would leak to on_line and the failure tail. Hold lines from a
     # BEGIN marker until its END marker, then redact the whole block at once —
     # the streamed analogue of the captured path's redact-the-complete-string
-    # invariant.
+    # invariant. Buffering is anchored to _PEM_KEY_PATTERN's spec: a block that
+    # pattern cannot match must not be treated as handled.
     pem_buffer: list[str] = []
+
+    def _emit(line: str) -> None:
+        redacted = redact_text(line)
+        on_line(redacted)
+        tail.append(redacted)
+
     with subprocess.Popen(  # noqa: S603 - args are harness-controlled, not user input
         cmd,  # noqa: S607 - daydream is a trusted command
         stdout=subprocess.PIPE,
@@ -187,23 +203,21 @@ def _run_streamed(
                 ) from None
             if line is None:
                 break
-            if "-----BEGIN" in line and "PRIVATE KEY" in line and "-----END" not in line:
+            if _PEM_BEGIN_RE.search(line) and not _PEM_END_RE.search(line):
                 pem_buffer.append(line)
             elif pem_buffer:
                 pem_buffer.append(line)
-                if "-----END" in line:
-                    redacted = redact_text("".join(pem_buffer))
-                    on_line(redacted)
-                    tail.append(redacted)
+                if _PEM_END_RE.search(line):
+                    _emit("".join(pem_buffer))
                     pem_buffer.clear()
             else:
-                redacted = redact_text(line)
-                on_line(redacted)
-                tail.append(redacted)
-        if pem_buffer:  # stream ended mid-block: redact the held lines as one
-            redacted = redact_text("".join(pem_buffer))
-            on_line(redacted)
-            tail.append(redacted)
+                _emit(line)
+        if pem_buffer:  # stream ended mid-block: no END anchor was seen, so
+            # _PEM_KEY_PATTERN cannot match the fragment; redact the held lines
+            # individually so the BEGIN-only fragment and its body never reach
+            # on_line or the failure tail raw.
+            for held in pem_buffer:
+                _emit(held)
         returncode = proc.wait()
     return returncode, "\n".join(tail)
 

--- a/daydream/benchmark/daydream_run.py
+++ b/daydream/benchmark/daydream_run.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 from daydream.agent import console
 from daydream.backends.pi import STREAM_DROP_SIGNATURES
 from daydream.github_app import APP_ID_ENV, APP_PRIVATE_KEY_ENV
+from daydream.trajectory import redact_text
 from daydream.ui import print_warning
 
 if TYPE_CHECKING:
@@ -130,8 +131,11 @@ def _run_captured(cmd: list[str], env: dict[str, str], checkout: Path) -> tuple[
             f"daydream review timed out after {_DAYDREAM_TIMEOUT}s for {checkout}"
         ) from exc
     # daydream prints its errors to stdout (Rich console), so a stderr-only
-    # message is frequently empty; surface both streams' tails.
-    tail = f"{result.stdout or ''}\n{result.stderr or ''}".strip()[-_STDERR_TAIL:]
+    # message is frequently empty; surface both streams' tails. Redact the
+    # COMPLETE combined string before the tail slice — a PEM block or credential
+    # straddling the cut must be caught before the slice, not truncated into an
+    # unmatchable fragment.
+    tail = redact_text(f"{result.stdout or ''}\n{result.stderr or ''}".strip())[-_STDERR_TAIL:]
     return result.returncode, tail
 
 
@@ -176,8 +180,9 @@ def _run_streamed(
                 ) from None
             if line is None:
                 break
-            on_line(line)
-            tail.append(line)
+            redacted = redact_text(line)
+            on_line(redacted)
+            tail.append(redacted)
         returncode = proc.wait()
     return returncode, "\n".join(tail)
 
@@ -209,14 +214,16 @@ def run_daydream_review(
             variable (never argv) when set.
         on_line: When set, the review runs via ``subprocess.Popen`` and each output
             line (stdout+stderr merged) is forwarded to this callback live instead of
-            being captured silently. When ``None`` (default), the quiet
-            ``subprocess.run`` capture path is used unchanged.
+            being captured silently. Each line is redacted (via ``redact_text``) before
+            the callback. When ``None`` (default), the quiet ``subprocess.run`` capture
+            path is used unchanged.
 
     Returns:
         Path to the canonical ``merged-items.json`` findings artifact.
 
     Raises:
-        DaydreamRunError: If the daydream process exits non-zero (includes a stderr tail).
+        DaydreamRunError: If the daydream process exits non-zero (includes a stderr tail,
+            redacted).
         DaydreamArtifactError: If the run succeeds but the artifact is absent.
     """
     cmd = [

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -742,7 +742,7 @@ def _build_main_parser(*, full_help: bool = False) -> argparse.ArgumentParser:
         action="store_true",
         default=False,
         dest="log_mode",
-        help="Bypass Rich UI and emit redacted agent events as plain text to stdout (for CI log capture)."
+        help="Bypass Rich UI and emit redacted agent events as plain text to stdout."
         if full_help else argparse.SUPPRESS,
     )
 

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -742,7 +742,7 @@ def _build_main_parser(*, full_help: bool = False) -> argparse.ArgumentParser:
         action="store_true",
         default=False,
         dest="log_mode",
-        help="Bypass Rich UI and emit raw agent events as plain text to stdout (for CI log capture)."
+        help="Bypass Rich UI and emit redacted agent events as plain text to stdout (for CI log capture)."
         if full_help else argparse.SUPPRESS,
     )
 

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -153,6 +153,29 @@ def redact_text(value: str) -> str:
     return value
 
 
+def redact_value(value: Any) -> Any:
+    """Recursively redact a value without mutating its argument (never raises).
+
+    ``str`` leaves and string dict keys are run through :func:`redact_text`;
+    containers are rebuilt fresh so the caller's object is never touched.
+    Non-container, non-string leaves pass through unchanged. This is the
+    canonical structured redactor for log-mode event payloads; the recursion
+    lives here so every consumer shares the same fail-closed boundary.
+    """
+    if isinstance(value, str):
+        return redact_text(value)
+    if isinstance(value, dict):
+        return {
+            (redact_text(k) if isinstance(k, str) else k): redact_value(v)
+            for k, v in value.items()
+        }
+    if isinstance(value, list):
+        return [redact_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(redact_value(item) for item in value)
+    return value
+
+
 def _safe_descriptor(raw: str) -> str:
     """Slugify a descriptor to filesystem-safe characters (D-06).
 

--- a/tests/test_agent_structured_render.py
+++ b/tests/test_agent_structured_render.py
@@ -23,6 +23,9 @@ from daydream.agent import run_agent
 from daydream.backends import (
     ResultEvent,
     TextEvent,
+    ThinkingEvent,
+    ToolResultEvent,
+    ToolStartEvent,
 )
 from daydream.trajectory import DaydreamPhase
 from tests.test_agent_recorder_integration import MockBackend
@@ -81,23 +84,52 @@ async def test_plain_text_still_renders(monkeypatch, tmp_path):
     assert "narration here" in rec.export_text()
 
 
-async def test_log_mode_captures_structured_output(monkeypatch, tmp_path, capsys):
-    """Under --log, the structured result must still be captured, not just printed.
-
-    Regression: the log-mode print and the structured-result capture were an
-    if/elif, so --log dropped every structured result (run_agent returned "").
-    Downstream this emptied exploration conventions/dependencies and review
-    findings across the deep pipeline.
-    """
+async def test_log_mode_emission_redacts_sentinels_on_agent_path(
+    monkeypatch, tmp_path, capsys
+):
+    """Real-path sentinel-absence check at the agent boundary (no phases.py
+    prints): every --log event type is emitted redacted — markers present, raw
+    sentinel absent — while the returned structured result stays raw."""
+    sentinel = "ghp_" + "x" * 16
+    payload = {"status": "complete", "token": sentinel}
+    backend = MockBackend(
+        [
+            TextEvent(text=f"token={sentinel}"),
+            ThinkingEvent(text=f"thinking about {sentinel}"),
+            ToolStartEvent(id="t", name="bash", input={"command": f"echo {sentinel}"}),
+            ToolResultEvent(id="t", output=f"token={sentinel}", is_error=False),
+            ResultEvent(structured_output=payload, continuation=None),
+        ]
+    )
     monkeypatch.setattr("daydream.agent._state.log_mode", True)
-    backend = MockBackend([ResultEvent(structured_output=PAYLOAD, continuation=None)])
     result, _, _ = await run_agent(
         backend, tmp_path, "scan", phase=DaydreamPhase.REVIEW, output_schema={"type": "object"}
     )
-    assert result == PAYLOAD  # captured, not discarded
+    assert result == payload          # returned object is raw/unchanged
     out = capsys.readouterr().out
-    assert "[result]" in out  # log-mode print is additive, still happens
-    assert "OpenAPI First" in out  # the serialized payload, not just the marker
+    assert "[REDACTED_API_KEY]" in out  # markers present
+    assert sentinel not in out          # no raw leak through the agent's log-mode emission
+
+
+async def test_log_mode_captures_structured_output(monkeypatch, tmp_path, capsys):
+    """Under --log, the structured result is still captured, NOT just printed —
+    and the printed projection is redacted while the returned object stays raw."""
+    sentinel = "ghp_" + "x" * 16
+    payload = {
+        "conventions": [{"name": "OpenAPI First", "description": "x", "source": "CLAUDE.md"}],
+        "token": sentinel,
+        "nested": {"path": f"/Users/{sentinel}"},
+    }
+    monkeypatch.setattr("daydream.agent._state.log_mode", True)
+    backend = MockBackend([ResultEvent(structured_output=payload, continuation=None)])
+    result, _, _ = await run_agent(
+        backend, tmp_path, "scan", phase=DaydreamPhase.REVIEW, output_schema={"type": "object"}
+    )
+    assert result == payload        # captured AND returned raw (never redacted)
+    out = capsys.readouterr().out
+    assert "[result]" in out        # log-mode print is additive, still happens
+    assert sentinel not in out      # the stdout projection is redacted
+    assert "OpenAPI First" in out   # benign content still serialized
 
 
 async def test_log_mode_structured_result_wins_over_prose_stray_json(monkeypatch, tmp_path):

--- a/tests/test_agent_structured_render.py
+++ b/tests/test_agent_structured_render.py
@@ -13,6 +13,8 @@ tests.test_agent_recorder_integration (the single canonical definition).
 
 from __future__ import annotations
 
+import copy
+import json
 from io import StringIO
 
 from rich.console import Console
@@ -27,6 +29,33 @@ from tests.test_agent_recorder_integration import MockBackend
 
 RAW = '{"conventions": [{"name": "OpenAPI First", "description": "x", "source": "CLAUDE.md"}]}'
 PAYLOAD = {"conventions": [{"name": "OpenAPI First", "description": "x", "source": "CLAUDE.md"}]}
+
+
+def test_redact_log_value_recurses_without_mutating() -> None:
+    """_redact_log_value redacts string keys AND values recursively, in fresh
+    containers, and never mutates its argument."""
+    from daydream.agent import _redact_log_value
+
+    sentinel = "ghp_" + "x" * 16
+    payload = {
+        "token": sentinel,
+        sentinel: "key-that-is-a-secret",
+        "nested": {"path": f"/Users/{sentinel}"},
+        "items": [sentinel, 42, None],
+        "flag": True,
+        1: "non-string-key",
+    }
+    original = copy.deepcopy(payload)
+    out = _redact_log_value(payload)
+
+    assert payload == original                    # argument never mutated
+    assert out is not payload                     # fresh top-level container
+    assert out["nested"] is not payload["nested"]  # fresh nested container
+    assert sentinel not in json.dumps(out)        # redacted in values AND keys
+    assert "[REDACTED" in json.dumps(out)         # a marker replaced it
+    assert out["items"] == ["[REDACTED_API_KEY]", 42, None]  # scalars preserved
+    assert out["flag"] is True
+    assert out[1] == "non-string-key"             # non-string keys untouched
 
 
 async def test_structured_output_text_is_not_rendered(monkeypatch, tmp_path):

--- a/tests/test_benchmark_daydream_run.py
+++ b/tests/test_benchmark_daydream_run.py
@@ -217,6 +217,43 @@ def test_streams_lines_and_keeps_tail_on_failure(tmp_path, monkeypatch):
     assert "[REDACTED_API_KEY]" in str(e.value)
 
 
+def test_streamed_failure_redacts_pem_block_spanning_lines(tmp_path, monkeypatch):
+    """A PEM block split across streamed lines (BEGIN/body/END on separate
+    lines) must still be redacted whole before reaching on_line and the failure
+    tail — per-line redaction would never present BEGIN and END together, so
+    the base64 body would leak raw."""
+    lines: list[str] = []
+    body = "PRIVATEKEYMATERIAL" * 20
+
+    class FakeProc:
+        def __init__(self):
+            self.stdout = iter([
+                "-----BEGIN RSA PRIVATE KEY-----\n",
+                body + "\n",
+                "-----END RSA PRIVATE KEY-----\n",
+            ])
+            self.returncode = 1
+
+        def wait(self, timeout=None):
+            return 1
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr("daydream.benchmark.daydream_run.subprocess.Popen", lambda *a, **k: FakeProc())
+    checkout = tmp_path / "co"
+    checkout.mkdir()
+    with pytest.raises(DaydreamRunError) as e:
+        run_daydream_review(checkout, base_sha="d" * 40, trajectory_path=tmp_path / "t.json", on_line=lines.append)
+    assert body not in "".join(lines)   # live echo carries no raw PEM body
+    assert "[REDACTED_PEM_KEY]" in "".join(lines)
+    assert body not in str(e.value)     # retained tail carries no raw PEM body
+    assert "[REDACTED_PEM_KEY]" in str(e.value)
+
+
 def test_captured_failure_redacts_before_tail_truncation(tmp_path, monkeypatch):
     """A PEM block whose tail would be sliced off mid-block must still be fully
     redacted before the _STDERR_TAIL cut — redact-after-slice would leave the
@@ -238,7 +275,6 @@ def test_captured_failure_redacts_before_tail_truncation(tmp_path, monkeypatch):
         run_daydream_review(checkout, base_sha="d" * 40, trajectory_path=tmp_path / "t.json")
     tail = str(e.value)
     assert "PRIVATEKEYMATERIAL" not in tail
-    assert "-----BEGIN RSA PRIVATE KEY-----" not in tail
     assert "-----END RSA PRIVATE KEY-----" not in tail
     assert "[REDACTED_PEM_KEY]" in tail
 

--- a/tests/test_benchmark_daydream_run.py
+++ b/tests/test_benchmark_daydream_run.py
@@ -191,10 +191,11 @@ def test_strips_github_app_creds_from_review_env(tmp_path, monkeypatch):
 
 def test_streams_lines_and_keeps_tail_on_failure(tmp_path, monkeypatch):
     lines: list[str] = []
+    sentinel = "ghp_" + "x" * 16
 
     class FakeProc:
         def __init__(self):
-            self.stdout = iter(["a\n", "boom\n"])
+            self.stdout = iter(["a\n", f"token={sentinel}\n"])
             self.returncode = 1
 
         def wait(self, timeout=None):
@@ -211,8 +212,35 @@ def test_streams_lines_and_keeps_tail_on_failure(tmp_path, monkeypatch):
     checkout.mkdir()
     with pytest.raises(DaydreamRunError) as e:
         run_daydream_review(checkout, base_sha="d" * 40, trajectory_path=tmp_path / "t.json", on_line=lines.append)
-    assert lines == ["a\n", "boom\n"]  # streamed live
-    assert "boom" in str(e.value)  # tail retained in the error
+    assert lines == ["a\n", "token=[REDACTED_API_KEY]\n"]  # each callback line redacted
+    assert sentinel not in str(e.value)                     # retained tail is redacted
+    assert "[REDACTED_API_KEY]" in str(e.value)
+
+
+def test_captured_failure_redacts_before_tail_truncation(tmp_path, monkeypatch):
+    """A PEM block whose tail would be sliced off mid-block must still be fully
+    redacted before the _STDERR_TAIL cut — redact-after-slice would leave the
+    raw END line (BEGIN already cut away) leaking."""
+    monkeypatch.setattr("daydream.benchmark.daydream_run._STDERR_TAIL", 80)
+    pem = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        + ("PRIVATEKEYMATERIAL" * 40)
+        + "\n-----END RSA PRIVATE KEY-----\n"
+    )
+    combined = "z" * 50 + pem  # the last-80 tail contains the END but not the BEGIN
+    monkeypatch.setattr(
+        "daydream.benchmark.daydream_run.subprocess.run",
+        lambda *a, **k: SimpleNamespace(returncode=1, stdout=combined, stderr=""),
+    )
+    checkout = tmp_path / "co"
+    checkout.mkdir()
+    with pytest.raises(DaydreamRunError) as e:
+        run_daydream_review(checkout, base_sha="d" * 40, trajectory_path=tmp_path / "t.json")
+    tail = str(e.value)
+    assert "PRIVATEKEYMATERIAL" not in tail
+    assert "-----BEGIN RSA PRIVATE KEY-----" not in tail
+    assert "-----END RSA PRIVATE KEY-----" not in tail
+    assert "[REDACTED_PEM_KEY]" in tail
 
 
 def test_streamed_timeout_kills_quiet_child_holding_stdout_open(tmp_path, monkeypatch):

--- a/tests/test_cli_help_tiers.py
+++ b/tests/test_cli_help_tiers.py
@@ -24,6 +24,9 @@ def test_help_all_shows_advanced(capsys):
     assert "--findings-out" in out and "--pr-number" in out
     assert "--precision" in out  # #232: reachable from --help-all
     assert "--approve-on-clean" in out  # #343: reachable from --help-all
+    assert "--log" in out                # #438: --log is an advanced flag
+    assert "redacted agent events" in out   # #438: exact phrase
+    assert "raw agent events" not in out    # #438: raw wording removed
 
 
 def test_advanced_flags_still_parse():

--- a/tests/test_log_mode.py
+++ b/tests/test_log_mode.py
@@ -34,6 +34,11 @@ from daydream.backends import (
 from daydream.runner import RunConfig, run
 from tests.harness.backend import ScriptedBackend
 
+# Synthetic credential-shaped sentinel: the ``{6,}`` API-key rule requires at
+# least 6 chars after the ``ghp_`` prefix, so a truncated ``ghp_yyy`` fragment
+# (only 3) is unmatchable — the discriminating boundary tests rely on this.
+REDACTION_SENTINEL = "ghp_" + "x" * 16
+
 MakeConfig = Callable[..., RunConfig]
 InstallBackend = Callable[[object], object]
 
@@ -65,24 +70,36 @@ def _capture_stdout_and_run(config: RunConfig, monkeypatch: pytest.MonkeyPatch) 
 @pytest.mark.parametrize(
     ("events", "config_overrides", "required", "forbidden"),
     [
+        # Sentinel-absence is asserted at the agent boundary in
+        # test_log_mode_emission_redacts_sentinels_on_agent_path; the deep
+        # pipeline's out-of-scope phases.py prints legitimately carry raw content,
+        # so ``forbidden`` stays empty here. Marker presence proves the agent's
+        # `_print_log` redaction runs on the real path.
         pytest.param(
-            [TextEvent("hello world")],
+            [TextEvent(f"token=hello {REDACTION_SENTINEL} world")],
             {"log_mode": True, "quiet": True, "output_mode": "review"},
-            ("hello world",),
-            ("\x1b[", "[bold]", "[dim]"),
+            ("hello", "[REDACTED_API_KEY]"),
+            (),
             id="plain-text",
+        ),
+        pytest.param(
+            [ThinkingEvent(f"thinking about {REDACTION_SENTINEL}")],
+            {"log_mode": True, "quiet": True, "output_mode": "review"},
+            ("[thinking]", "[REDACTED_API_KEY]"),
+            (),
+            id="thinking",
         ),
         pytest.param(
             [
                 ToolStartEvent(
                     id="test-id",
                     name="bash",
-                    input={"command": "echo hello", "description": "test command"},
+                    input={"command": f"echo {REDACTION_SENTINEL}"},
                 ),
-                ToolResultEvent(id="test-id", output="hello\nworld", is_error=False),
+                ToolResultEvent(id="test-id", output=f"token={REDACTION_SENTINEL}", is_error=False),
             ],
             {"log_mode": True, "quiet": True, "output_mode": "review"},
-            ("[tool:bash] echo hello", "[tool:bash result] hello"),
+            ("[tool:bash]", "[REDACTED_API_KEY]"),
             (),
             id="tool-events",
         ),
@@ -118,12 +135,12 @@ def _capture_stdout_and_run(config: RunConfig, monkeypatch: pytest.MonkeyPatch) 
         pytest.param(
             [
                 ResultEvent(
-                    structured_output={"status": "complete", "findings": ["issue1", "issue2"]},
+                    structured_output={"status": "complete", "token": REDACTION_SENTINEL},
                     continuation=None,
                 )
             ],
             {"log_mode": True, "quiet": True, "output_mode": "review"},
-            ("[result]", '"status": "complete"', '"findings"'),
+            ("[result]", "[REDACTED_API_KEY]"),
             (),
             id="result-event",
         ),
@@ -180,6 +197,31 @@ def test_log_mode_rendering(
         assert substring in output
     for substring in forbidden:
         assert substring not in output
+
+
+def test_log_mode_redacts_tool_summary_before_200_truncation() -> None:
+    """A token straddling the 200-char summary boundary is redacted, not truncated
+    into an unmatchable fragment. Redact-after-slice would leak the raw 'ghp_'."""
+    from daydream.agent import _summarize_input
+
+    # The space before the token is REQUIRED: `_API_KEY_PATTERN` anchors on `\b`,
+    # so a token glued directly after a word char is never matchable and the test
+    # would fail against BOTH implementations. With the space, redact_text matches
+    # the complete ``ghp_`` + 8 alnum token, while ``[:200]`` still cuts 9 chars
+    # into it — a redact-after implementation leaks the unmatchable ``ghp_yyyyy``
+    # fragment (the ``{6,}`` rule needs 6+ chars after the prefix).
+    command = "x" * 190 + " " + "ghp_" + "y" * 8 + "z" * 10   # [:200] cuts into the token
+    out = _summarize_input({"command": command})
+    assert "ghp_" not in out        # no raw fragment survives the 200-cut
+    assert "[REDACTED" in out       # redaction marker (even truncated) present
+
+    # Same boundary check on the output summary: a token straddling the [:200]
+    # first-line cut must be caught before strip/first-line/slice.
+    from daydream.agent import _summarize_output
+
+    out = _summarize_output("x" * 190 + " " + "ghp_" + "y" * 8 + "z" * 10)
+    assert "ghp_" not in out
+    assert "[REDACTED" in out
 
 
 def test_log_mode_trajectory_still_written(

--- a/tests/test_log_mode.py
+++ b/tests/test_log_mode.py
@@ -71,20 +71,15 @@ def _capture_stdout_and_run(config: RunConfig, monkeypatch: pytest.MonkeyPatch) 
     ("events", "config_overrides", "required", "forbidden"),
     [
         # Sentinel-absence is asserted at the agent boundary in
-        # test_log_mode_emission_redacts_sentinels_on_agent_path; the deep
-        # pipeline's out-of-scope phases.py prints legitimately carry raw content,
-        # so ``forbidden`` stays empty here. Marker presence proves the agent's
-        # `_print_log` redaction runs on the real path.
-        # Contract loss, stated explicitly: the pre-redaction version of this case
-        # asserted no Rich markup in log-mode output
-        # (``forbidden=("\x1b[", "[bold]", "[dim]")``); that assertion was dropped
-        # in the redaction rewrite and no remaining test asserts log-mode output
-        # is markup-free.
+        # test_log_mode_emission_redacts_sentinels_on_agent_path; marker presence
+        # here proves the agent's `_print_log` redaction runs on the real path.
+        # The forbidden tuples keep the log-mode markup-free invariant guarded:
+        # captured stdout on this path is plain text (no Rich escape sequences).
         pytest.param(
             [TextEvent(f"token=hello {REDACTION_SENTINEL} world")],
             {"log_mode": True, "quiet": True, "output_mode": "review"},
             ("hello", "[REDACTED_API_KEY]"),
-            (),
+            ("\x1b[", "[bold]", "[dim]"),
             id="plain-text",
         ),
         pytest.param(
@@ -227,6 +222,37 @@ def test_log_mode_redacts_tool_summary_before_200_truncation() -> None:
     out = _summarize_output("x" * 190 + " " + "ghp_" + "y" * 8 + "z" * 10)
     assert "ghp_" not in out
     assert "[REDACTED" in out
+
+
+def test_log_mode_console_redacts_string_payloads() -> None:
+    """phases.py imports agent's module-level console; in --log mode that
+    console redacts string payloads, so phase/UI output (e.g. the failure
+    handoff body) cannot bypass the log-mode redaction boundary."""
+    from daydream.agent import _LogRedactingConsole, set_log_mode
+
+    sentinel = REDACTION_SENTINEL
+    buffer = io.StringIO()
+    rec = _LogRedactingConsole(file=buffer, force_terminal=True, width=100)
+
+    set_log_mode(False)
+    try:
+        # Normal mode: raw pass-through (Rich UI is unredacted by design).
+        rec.print(f"handoff token={sentinel}")
+        assert sentinel in buffer.getvalue()
+
+        # --log mode: the same emission path is redacted at the console boundary.
+        buffer.truncate(0)
+        buffer.seek(0)
+        set_log_mode(True)
+        rec.print(f"handoff token={sentinel}")
+        out = buffer.getvalue()
+        # Rich's highlighter splits the marker's brackets into styled spans, so
+        # assert on the marker body (and the sentinel's absence) rather than the
+        # exact bracketed string.
+        assert "REDACTED_API_KEY" in out
+        assert sentinel not in out
+    finally:
+        set_log_mode(False)
 
 
 def test_log_mode_trajectory_still_written(

--- a/tests/test_log_mode.py
+++ b/tests/test_log_mode.py
@@ -75,6 +75,11 @@ def _capture_stdout_and_run(config: RunConfig, monkeypatch: pytest.MonkeyPatch) 
         # pipeline's out-of-scope phases.py prints legitimately carry raw content,
         # so ``forbidden`` stays empty here. Marker presence proves the agent's
         # `_print_log` redaction runs on the real path.
+        # Contract loss, stated explicitly: the pre-redaction version of this case
+        # asserted no Rich markup in log-mode output
+        # (``forbidden=("\x1b[", "[bold]", "[dim]")``); that assertion was dropped
+        # in the redaction rewrite and no remaining test asserts log-mode output
+        # is markup-free.
         pytest.param(
             [TextEvent(f"token=hello {REDACTION_SENTINEL} world")],
             {"log_mode": True, "quiet": True, "output_mode": "review"},
@@ -87,7 +92,7 @@ def _capture_stdout_and_run(config: RunConfig, monkeypatch: pytest.MonkeyPatch) 
             {"log_mode": True, "quiet": True, "output_mode": "review"},
             ("[thinking]", "[REDACTED_API_KEY]"),
             (),
-            id="thinking",
+            id="thinking-sentinel",
         ),
         pytest.param(
             [


### PR DESCRIPTION
## Summary

Closes #438 — **Redact agent log mode and benchmark subprocess output**

Two output boundaries could leak secrets into logs/console output and were only
partially covered by the existing `redact_text` policy:

- **`--log` agent mode**: log-mode stdout and tool summaries were truncated
  before being redacted, and phase/UI console output bypassed redaction
  entirely in `--log` mode. This adds a non-mutating log-value redactor, a
  single log emitter, and a `_LogRedactingConsole` boundary so agent log events
  are redacted without mutating the returned structured data.
- **benchmark subprocess output**: quiet/streamed child output and retained
  failure tails were not redacted; multi-line PEM blocks could be emitted
  mid-stream in a way that diverged from `_PEM_KEY_PATTERN`, leaking the base64
  body. Streamed buffering is now anchored on `_PEM_KEY_PATTERN` and flushes are
  redacted on stream-end.

### Changes
- `daydream/agent.py` — non-mutating log-value redactor + single log emitter; `_LogRedactingConsole` at the console boundary
- `daydream/cli.py` — accurate `--log` help (redacted agent events)
- `daydream/benchmark/daydream_run.py` — redact subprocess callbacks, failure tails before truncation, and streamed multi-line PEM blocks
- `daydream/trajectory.py` — centralized `redact_value`
- `tests/test_log_mode.py`, `tests/test_agent_structured_render.py`, `tests/test_cli_help_tiers.py`, `tests/test_benchmark_daydream_run.py` — regression coverage

## Test Plan
- Full suite: 3354 passed, 6 skipped, exit 0 (independently verified on review VM; the 7 `test_benchmark_cli.py` "failures" are environment-only and pass with the venv console script on PATH)
- `uv lock --check` clean

## Review
- Two sequential daydream deep-precision reviews completed (round 1 + round 2 on fresh VMs); trajectory uploaded to HF
- NO CodeRabbit
