### PR TITLE
fix(rl): withhold fix-test reward when protected test-oracle paths change (Closes #440)

### DIFF
--- a/rl/daydream_review_v1/README.md
+++ b/rl/daydream_review_v1/README.md
@@ -106,6 +106,19 @@ baseline against a pi-scaffold trained run moves two variables at once.
    An unavailable or stale lock is an **image-build failure** — never permission
    to **fall back to unconstrained pip**.
 
+   Every manifest entry must also declare a **required, nonempty
+   `protected_test_paths`** array: the literal repository-relative files or
+   directories that constitute the repository's test oracle. A missing or empty
+   inventory is a manifest-load error, never a silently unprotected task.
+   Coverage must include the test sources **and every runner-config file
+   `test_command` can load** — including absent filenames whose later creation
+   could alter collection (e.g. `conftest.py`, `pytest.ini`, `pyproject.toml`,
+   `setup.cfg`, `tox.ini`). At scoring time `fix_tests_pass` compares these
+   paths against the image's baked head SHA, fail-closed: a changed or
+   unverifiable oracle (any tracked difference, any non-ignored untracked file
+   under a protected path, or a Git error) earns **zero test reward** and the
+   repository's mutable `test_command` is not executed.
+
 3. **Build the images.** The last layer runs the repository's own suite at the
    head commit; a red baseline fails the build and produces nothing, because
    `fix_tests_pass` would otherwise be rewarding noise.

--- a/rl/daydream_review_v1/README.md
+++ b/rl/daydream_review_v1/README.md
@@ -115,9 +115,14 @@ baseline against a pi-scaffold trained run moves two variables at once.
    could alter collection (e.g. `conftest.py`, `pytest.ini`, `pyproject.toml`,
    `setup.cfg`, `tox.ini`). At scoring time `fix_tests_pass` compares these
    paths against the image's baked head SHA, fail-closed: a changed or
-   unverifiable oracle (any tracked difference, any non-ignored untracked file
-   under a protected path, or a Git error) earns **zero test reward** and the
-   repository's mutable `test_command` is not executed.
+   unverifiable oracle earns **zero test reward** and the repository's mutable
+   `test_command` is not executed. That covers any tracked difference, any
+   non-ignored untracked file under a protected path or an untracked root
+   `sitecustomize.py` (imported at startup by every `python` run, so one that
+   `sys.exit(0)`s makes a suite that never ran look green), a
+   `skip-worktree`/`assume-unchanged` flag on a protected file, any change to
+   the ignore rules the probes honor (tracked or new untracked `.gitignore`
+   files, or a rule written to `.git/info/exclude`), or a Git error.
 
 3. **Build the images.** The last layer runs the repository's own suite at the
    head commit; a red baseline fails the build and produces nothing, because

--- a/rl/daydream_review_v1/daydream_review_v1/taskset.py
+++ b/rl/daydream_review_v1/daydream_review_v1/taskset.py
@@ -27,7 +27,7 @@ from daydream.benchmark.corpus import harvested_corpus
 from daydream.training.exclusion import load_exclusion_list
 from daydream.training.harvest import assemble_scoring_inputs
 from daydream.training.reward import score_trajectory
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from verifiers.v1.errors import boundary
 
 from daydream_review_v1.rundir import DEFAULT_ARCHIVE_ROOT, fetch_run_dir
@@ -76,6 +76,16 @@ def _manifest_row(run_dir: Path) -> dict[str, Any]:
 #: Shared by both dirty-tree and moved-HEAD probes so the exclusion set only
 #: drifts by intentional edit, never by one string falling out of sync.
 DAYDREAM_EXCLUDE = ":(exclude).daydream"
+
+#: Extra pathspecs the oracle probes treat as part of the oracle itself.
+#: ``git ls-files --exclude-standard`` honors ignore rules, so a rollout that
+#: edits the tracked ``.gitignore`` (or drops a new untracked one) can mask a
+#: tampered untracked oracle file from the probes — the ignore files are
+#: therefore probed too. ``sitecustomize.py`` is imported from the repository
+#: root by every ``python`` invocation ``test_command`` runs (cwd is on
+#: ``sys.path``), so an untracked one that ``sys.exit(0)``s makes a suite that
+#: never ran look green.
+ORACLE_IGNORE_PATHSPECS = ["sitecustomize.py", ":(glob)**/.gitignore"]
 
 
 async def _fixes_applied(runtime: vf.Runtime, repo: str, head_sha: str) -> bool:
@@ -154,33 +164,99 @@ async def _protected_test_paths_unchanged(
     trustworthy baseline: the image build proved the suite green at exactly that
     commit before any agent touched the tree.
 
-    Fail-closed by design, with every ambiguity reading as "changed":
+    Fail-closed by design, with every ambiguity reading as "changed". The probe
+    pathspecs are the declared paths plus ``ORACLE_IGNORE_PATHSPECS``: the repo's
+    own ignore files (which gate what the untracked probe sees) and the
+    interpreter-startup hook.
 
     - ``git diff --quiet <head_sha> -- <paths>`` compares the baked head against
       the WORKING TREE (no ``HEAD`` argument — that form would miss uncommitted
       tampering, the exact attack). Exit 0 means no tracked difference
       (committed, staged, unstaged, deleted, or renamed); any other exit — a
       tracked diff (1) or a Git error such as 128 for an unresolvable baked SHA —
+      means the oracle changed. A tracked ``.gitignore`` edit is itself a
+      tracked difference here: without it, the edit could mask a new untracked
+      oracle file from the untracked probe.
+    - ``git ls-files -v`` rejects any protected or ignore file carrying the
+      ``skip-worktree``/``assume-unchanged`` flag (tag ``S`` or a lowercase
+      letter): git then reads the INDEX instead of the worktree, so the diff
+      probe above would stay clean against a tampered tracked file with the
+      flag set.
+    - ``git ls-files --others --exclude-standard -- <paths>`` catches a
+      non-ignored untracked file under a protected path (e.g. a new
+      ``pytest.ini`` or ``conftest.py``), an untracked root ``sitecustomize.py``
+      (imported at startup by every ``python`` ``test_command`` runs, so one
+      that ``sys.exit(0)``s makes a suite that never ran look green), or a new
+      untracked ``.gitignore`` (the ignore-rule attack): any listing or error
       means the oracle changed.
-    - When the diff is clean, ``git ls-files --others --exclude-standard --
-      <paths>`` catches a non-ignored untracked file under a protected path
-      (e.g. a new ``pytest.ini`` or ``conftest.py``): any listing or error
-      means the oracle changed.
+    - ``git ls-files --others --ignored ... -- ':(glob)**/.gitignore'`` catches
+      a ``.gitignore`` that ignores itself (e.g. a bare ``*``), which hides from
+      the listing above.
+    - ``cat .git/info/exclude`` verifies the rollout-controlled per-repo ignore
+      file: ``--exclude-standard`` reads it, so a rule written there can mask
+      untracked oracle files with zero tracked changes. A fresh clone's file is
+      comments-only; any real rule means the oracle changed.
 
     There is deliberately no case that defaults to pass on an error — an
     unverifiable oracle never earns the test reward.
     """
+    oracle_pathspecs = [*protected_test_paths, *ORACLE_IGNORE_PATHSPECS]
+
     diff = await runtime.run(
-        ["git", "-C", repo, "diff", "--quiet", head_sha, "--", *protected_test_paths],
+        ["git", "-C", repo, "diff", "--quiet", head_sha, "--", *oracle_pathspecs],
         {},
     )
     if diff.exit_code != 0:
         return False
-    untracked = await runtime.run(
-        ["git", "-C", repo, "ls-files", "--others", "--exclude-standard", "--", *protected_test_paths],
+    flags = await runtime.run(
+        ["git", "-C", repo, "ls-files", "-v", "--", *oracle_pathspecs],
         {},
     )
-    return untracked.exit_code == 0 and not untracked.stdout.strip()
+    if flags.exit_code != 0 or any(
+        line[:1] == "S" or line[:1].islower() for line in flags.stdout.splitlines()
+    ):
+        return False
+    untracked = await runtime.run(
+        [
+            "git",
+            "-C",
+            repo,
+            "ls-files",
+            "--others",
+            "--exclude-standard",
+            "--",
+            *oracle_pathspecs,
+        ],
+        {},
+    )
+    if untracked.exit_code != 0 or untracked.stdout.strip():
+        return False
+    ignored_ignores = await runtime.run(
+        [
+            "git",
+            "-C",
+            repo,
+            "ls-files",
+            "--others",
+            "--ignored",
+            "--exclude-standard",
+            "--",
+            ":(glob)**/.gitignore",
+        ],
+        {},
+    )
+    if ignored_ignores.exit_code != 0 or ignored_ignores.stdout.strip():
+        return False
+    info_exclude = await runtime.run(
+        ["cat", f"{repo}/.git/info/exclude"],
+        {},
+    )
+    if info_exclude.exit_code != 0 or any(
+        line.strip() and not line.lstrip().startswith("#")
+        for line in info_exclude.stdout.splitlines()
+    ):
+        return False
+    return True
 
 
 def _claimed_test_verdict(run_dir: Path | None) -> bool | None:
@@ -366,10 +442,13 @@ class DaydreamReviewTask(vf.Task[DaydreamReviewData, DaydreamReviewState, Daydre
         than a free 1.0 for leaving the tree alone.
 
         The declared ``protected_test_paths`` oracle must still match the baked
-        head before ``test_command`` is trusted: any oracle change (tracked,
-        untracked, or a Git error) returns a literal ``0.0`` without running the
-        repository's mutable ``test_command``, so a rollout can never pay itself
-        the test reward by gutting its own suite.
+        head before ``test_command`` is trusted: any oracle change — a tracked
+        difference, an untracked file under a protected path or a root
+        ``sitecustomize.py``, a ``skip-worktree``/``assume-unchanged`` flag, an
+        ignore-rule change (``.gitignore`` files or ``.git/info/exclude``), or a
+        Git error — returns a literal ``0.0`` without running the repository's
+        mutable ``test_command``, so a rollout can never pay itself the test
+        reward by gutting its own suite.
         """
         repo = _repo_path(trace)
         if not await _fixes_applied(runtime, repo, self.data.head_sha):
@@ -386,7 +465,9 @@ class DaydreamReviewTask(vf.Task[DaydreamReviewData, DaydreamReviewState, Daydre
         # Security boundary: the test oracle must match the baked head before the
         # repository's own mutable test_command is trusted. A changed oracle
         # (committed/staged/unstaged/deleted/renamed, an untracked protected
-        # file, or a Git error) earns a literal zero WITHOUT running test_command.
+        # file or root sitecustomize.py, a skip-worktree/assume-unchanged flag,
+        # an ignore-rule change, or a Git error) earns a literal zero WITHOUT
+        # running test_command.
         unchanged = await _protected_test_paths_unchanged(
             runtime, repo, self.data.head_sha, self.data.protected_test_paths
         )
@@ -463,6 +544,28 @@ class _ManifestEntry(BaseModel):
     test_command: str
     protected_test_paths: list[str] = Field(min_length=1)
     setup_cmds: list[str] = []
+
+    @field_validator("protected_test_paths")
+    @classmethod
+    def _require_literal_paths(cls, paths: list[str]) -> list[str]:
+        """Reject entries git would re-interpret instead of matching byte-for-byte.
+
+        The manifest promises LITERAL repository-relative paths, but the scoring
+        gate passes each entry to git as a bare pathspec (``_protected_test_paths_unchanged``),
+        where ``*``, ``?`` and ``[`` are glob metacharacters and a leading ``:``
+        is pathspec magic. A glob-shaped entry that matches nothing would read as
+        a clean diff and an empty ``ls-files`` list, letting ``test_command`` run
+        against an unprotected oracle — so such entries must fail the load rather
+        than ship a silently-inert protection.
+        """
+        for path in paths:
+            if not path or path[0] == ":" or any(ch in path for ch in "*?["):
+                raise ValueError(
+                    "protected_test_paths must be LITERAL repository-relative paths "
+                    "(nonempty, no leading ':', no '*', '?' or '['); got "
+                    f"{path!r}"
+                )
+        return paths
 
 
 def load_manifest(path: Path) -> dict[str, _ManifestEntry]:

--- a/rl/daydream_review_v1/daydream_review_v1/taskset.py
+++ b/rl/daydream_review_v1/daydream_review_v1/taskset.py
@@ -143,6 +143,46 @@ async def _fixes_applied(runtime: vf.Runtime, repo: str, head_sha: str) -> bool:
     return diff.exit_code == 1
 
 
+async def _protected_test_paths_unchanged(
+    runtime: vf.Runtime, repo: str, head_sha: str, protected_test_paths: list[str]
+) -> bool:
+    """Whether the declared test-oracle paths still match the baked head.
+
+    The oracle is the repository's own mutable test infrastructure — test
+    sources, runner config, package config — so a rollout could otherwise earn
+    ``w_tests`` by rewriting it into a trivial suite. The baked head SHA is the
+    trustworthy baseline: the image build proved the suite green at exactly that
+    commit before any agent touched the tree.
+
+    Fail-closed by design, with every ambiguity reading as "changed":
+
+    - ``git diff --quiet <head_sha> -- <paths>`` compares the baked head against
+      the WORKING TREE (no ``HEAD`` argument — that form would miss uncommitted
+      tampering, the exact attack). Exit 0 means no tracked difference
+      (committed, staged, unstaged, deleted, or renamed); any other exit — a
+      tracked diff (1) or a Git error such as 128 for an unresolvable baked SHA —
+      means the oracle changed.
+    - When the diff is clean, ``git ls-files --others --exclude-standard --
+      <paths>`` catches a non-ignored untracked file under a protected path
+      (e.g. a new ``pytest.ini`` or ``conftest.py``): any listing or error
+      means the oracle changed.
+
+    There is deliberately no case that defaults to pass on an error — an
+    unverifiable oracle never earns the test reward.
+    """
+    diff = await runtime.run(
+        ["git", "-C", repo, "diff", "--quiet", head_sha, "--", *protected_test_paths],
+        {},
+    )
+    if diff.exit_code != 0:
+        return False
+    untracked = await runtime.run(
+        ["git", "-C", repo, "ls-files", "--others", "--exclude-standard", "--", *protected_test_paths],
+        {},
+    )
+    return untracked.exit_code == 0 and not untracked.stdout.strip()
+
+
 def _claimed_test_verdict(run_dir: Path | None) -> bool | None:
     """daydream's own ``deep/test-verdict.json`` claim, or ``None`` if absent."""
     if run_dir is None:
@@ -324,6 +364,12 @@ class DaydreamReviewTask(vf.Task[DaydreamReviewData, DaydreamReviewState, Daydre
         the same commit before any agent touched it (D6). A rollout that applied
         no fix is not evidence either way, so it takes ``no_fix_reward`` rather
         than a free 1.0 for leaving the tree alone.
+
+        The declared ``protected_test_paths`` oracle must still match the baked
+        head before ``test_command`` is trusted: any oracle change (tracked,
+        untracked, or a Git error) returns a literal ``0.0`` without running the
+        repository's mutable ``test_command``, so a rollout can never pay itself
+        the test reward by gutting its own suite.
         """
         repo = _repo_path(trace)
         if not await _fixes_applied(runtime, repo, self.data.head_sha):
@@ -337,6 +383,17 @@ class DaydreamReviewTask(vf.Task[DaydreamReviewData, DaydreamReviewState, Daydre
             return self.config.no_fix_reward
 
         trace.record_metric("fixes_applied", 1.0)
+        # Security boundary: the test oracle must match the baked head before the
+        # repository's own mutable test_command is trusted. A changed oracle
+        # (committed/staged/unstaged/deleted/renamed, an untracked protected
+        # file, or a Git error) earns a literal zero WITHOUT running test_command.
+        unchanged = await _protected_test_paths_unchanged(
+            runtime, repo, self.data.head_sha, self.data.protected_test_paths
+        )
+        trace.record_metric("test_oracle_unchanged", float(unchanged))
+        if not unchanged:
+            return 0.0
+
         result = await runtime.run(
             ["sh", "-c", f"cd {shlex.quote(repo)} && {self.data.test_command}"], {}
         )

--- a/rl/daydream_review_v1/daydream_review_v1/taskset.py
+++ b/rl/daydream_review_v1/daydream_review_v1/taskset.py
@@ -19,6 +19,7 @@ import logging
 import shlex
 import tempfile
 import tomllib
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -86,6 +87,34 @@ DAYDREAM_EXCLUDE = ":(exclude).daydream"
 #: ``sys.path``), so an untracked one that ``sys.exit(0)``s makes a suite that
 #: never ran look green.
 ORACLE_IGNORE_PATHSPECS = ["sitecustomize.py", ":(glob)**/.gitignore"]
+
+#: Pathspecs excluding the suite's own bytecode artifacts from the untracked
+#: probe. That probe deliberately runs ``git ls-files --others`` WITHOUT
+#: ``--exclude-standard`` (see ``_protected_test_paths_unchanged``), so it lists
+#: every untracked file under a protected path — including the ``__pycache__/``
+#: and ``*.py[cod]`` files a green suite itself drops while importing the test
+#: modules. Without this explicit exclusion a genuinely fixed tree would trip
+#: the probe on its own legitimate test runs and be withheld ``w_tests``. The
+#: benign exclusions are baked into the probe rather than delegated to the
+#: repo's ignore rules, whose decisions this gate deliberately no longer trusts.
+ORACLE_BENIGN_PATHSPECS = [":(exclude,glob)**/__pycache__/**", ":(exclude,glob)**/*.py[cod]"]
+
+
+async def _probe(
+    runtime: vf.Runtime,
+    argv: list[str],
+    changed: Callable[[vf.ProgramResult], bool],
+) -> bool:
+    """Run one oracle probe; return True iff the oracle is unchanged.
+
+    Every probe shares the same fail-closed run -> check shape: run one command
+    against the mutable tree and let the ``changed`` predicate decide — anything
+    it flags, including an unusual exit code, reads as an oracle change, never
+    as a pass. The predicate is the single place each probe's semantics live, so
+    the probe list in :func:`_protected_test_paths_unchanged` reads as a table
+    of ``(argv, changed-verdict)`` pairs.
+    """
+    return not changed(await runtime.run(argv, {}))
 
 
 async def _fixes_applied(runtime: vf.Runtime, repo: str, head_sha: str) -> bool:
@@ -166,8 +195,9 @@ async def _protected_test_paths_unchanged(
 
     Fail-closed by design, with every ambiguity reading as "changed". The probe
     pathspecs are the declared paths plus ``ORACLE_IGNORE_PATHSPECS``: the repo's
-    own ignore files (which gate what the untracked probe sees) and the
-    interpreter-startup hook.
+    own ignore files and the interpreter-startup hook. The five probes share one
+    run -> fail-closed-check shape, expressed as a table of ``(argv, changed)``
+    pairs over :func:`_probe`.
 
     - ``git diff --quiet <head_sha> -- <paths>`` compares the baked head against
       the WORKING TREE (no ``HEAD`` argument — that form would miss uncommitted
@@ -182,80 +212,105 @@ async def _protected_test_paths_unchanged(
       letter): git then reads the INDEX instead of the worktree, so the diff
       probe above would stay clean against a tampered tracked file with the
       flag set.
-    - ``git ls-files --others --exclude-standard -- <paths>`` catches a
-      non-ignored untracked file under a protected path (e.g. a new
-      ``pytest.ini`` or ``conftest.py``), an untracked root ``sitecustomize.py``
-      (imported at startup by every ``python`` ``test_command`` runs, so one
-      that ``sys.exit(0)``s makes a suite that never ran look green), or a new
-      untracked ``.gitignore`` (the ignore-rule attack): any listing or error
-      means the oracle changed.
-    - ``git ls-files --others --ignored ... -- ':(glob)**/.gitignore'`` catches
-      a ``.gitignore`` that ignores itself (e.g. a bare ``*``), which hides from
-      the listing above.
+    - ``git -c core.excludesFile= ls-files --others -- <paths>`` lists EVERY
+      untracked file under a protected path — e.g. a new ``pytest.ini`` or
+      ``conftest.py``, an untracked root ``sitecustomize.py`` (imported at
+      startup by every ``python`` ``test_command`` runs, so one that
+      ``sys.exit(0)``s makes a suite that never ran look green), or a new
+      untracked ``.gitignore`` (the ignore-rule attack). It deliberately does
+      NOT pass ``--exclude-standard``: a protected path the baked tree's own
+      ignore rules already cover would otherwise ship inert protection, and a
+      freshly planted ignore rule could hide the file. Listing everything makes
+      the baked tree's ignore decisions irrelevant to the probe; the suite's
+      own runtime byproducts (``__pycache__/`` and ``*.py[cod]``) are excluded
+      explicitly via ``ORACLE_BENIGN_PATHSPECS`` instead.
+    - The ``core.excludesFile=`` override above also neutralizes the two ignore
+      sources ``--exclude-standard`` would otherwise honor with no probe here to
+      vouch for them: the repo-local ``core.excludesFile`` set in ``.git/config``
+      and the global excludes file (default ``$HOME/.config/git/ignore``). Both
+      are agent-writable, so without this a rollout could mask an untracked
+      oracle file behind either and pass every probe. An empty value loads
+      neither — the default-path fallback only applies when the key is unset —
+      so the same override rides on the ``--ignored`` probe below.
+    - ``git -c core.excludesFile= ls-files --others --ignored ... --
+      ':(glob)**/.gitignore'`` catches a ``.gitignore`` that ignores itself
+      (e.g. a bare ``*``), which hides from the listing above.
     - ``cat .git/info/exclude`` verifies the rollout-controlled per-repo ignore
-      file: ``--exclude-standard`` reads it, so a rule written there can mask
-      untracked oracle files with zero tracked changes. A fresh clone's file is
-      comments-only; any real rule means the oracle changed.
+      file. A fresh clone's file is comments-only; any real rule means the
+      oracle changed.
 
     There is deliberately no case that defaults to pass on an error — an
     unverifiable oracle never earns the test reward.
     """
     oracle_pathspecs = [*protected_test_paths, *ORACLE_IGNORE_PATHSPECS]
 
-    diff = await runtime.run(
-        ["git", "-C", repo, "diff", "--quiet", head_sha, "--", *oracle_pathspecs],
-        {},
-    )
-    if diff.exit_code != 0:
-        return False
-    flags = await runtime.run(
-        ["git", "-C", repo, "ls-files", "-v", "--", *oracle_pathspecs],
-        {},
-    )
-    if flags.exit_code != 0 or any(
-        line[:1] == "S" or line[:1].islower() for line in flags.stdout.splitlines()
-    ):
-        return False
-    untracked = await runtime.run(
-        [
-            "git",
-            "-C",
-            repo,
-            "ls-files",
-            "--others",
-            "--exclude-standard",
-            "--",
-            *oracle_pathspecs,
-        ],
-        {},
-    )
-    if untracked.exit_code != 0 or untracked.stdout.strip():
-        return False
-    ignored_ignores = await runtime.run(
-        [
-            "git",
-            "-C",
-            repo,
-            "ls-files",
-            "--others",
-            "--ignored",
-            "--exclude-standard",
-            "--",
-            ":(glob)**/.gitignore",
-        ],
-        {},
-    )
-    if ignored_ignores.exit_code != 0 or ignored_ignores.stdout.strip():
-        return False
-    info_exclude = await runtime.run(
-        ["cat", f"{repo}/.git/info/exclude"],
-        {},
-    )
-    if info_exclude.exit_code != 0 or any(
-        line.strip() and not line.lstrip().startswith("#")
-        for line in info_exclude.stdout.splitlines()
-    ):
-        return False
+    def diff_changed(result: vf.ProgramResult) -> bool:
+        return result.exit_code != 0
+
+    def flags_changed(result: vf.ProgramResult) -> bool:
+        return result.exit_code != 0 or any(
+            line[:1] == "S" or line[:1].islower()
+            for line in result.stdout.splitlines()
+        )
+
+    def nonempty_changed(result: vf.ProgramResult) -> bool:
+        # Any listed file — or any probe error — means the oracle changed.
+        return result.exit_code != 0 or bool(result.stdout.strip())
+
+    def info_exclude_changed(result: vf.ProgramResult) -> bool:
+        return result.exit_code != 0 or any(
+            line.strip() and not line.lstrip().startswith("#")
+            for line in result.stdout.splitlines()
+        )
+
+    probes = [
+        (
+            ["git", "-C", repo, "diff", "--quiet", head_sha, "--", *oracle_pathspecs],
+            diff_changed,
+        ),
+        (
+            ["git", "-C", repo, "ls-files", "-v", "--", *oracle_pathspecs],
+            flags_changed,
+        ),
+        (
+            [
+                "git",
+                "-C",
+                repo,
+                "-c",
+                "core.excludesFile=",
+                "ls-files",
+                "--others",
+                "--",
+                *oracle_pathspecs,
+                *ORACLE_BENIGN_PATHSPECS,
+            ],
+            nonempty_changed,
+        ),
+        (
+            [
+                "git",
+                "-C",
+                repo,
+                "-c",
+                "core.excludesFile=",
+                "ls-files",
+                "--others",
+                "--ignored",
+                "--exclude-standard",
+                "--",
+                ":(glob)**/.gitignore",
+            ],
+            nonempty_changed,
+        ),
+        (
+            ["cat", f"{repo}/.git/info/exclude"],
+            info_exclude_changed,
+        ),
+    ]
+    for argv, changed in probes:
+        if not await _probe(runtime, argv, changed):
+            return False
     return True
 
 

--- a/rl/daydream_review_v1/daydream_review_v1/taskset.py
+++ b/rl/daydream_review_v1/daydream_review_v1/taskset.py
@@ -27,7 +27,7 @@ from daydream.benchmark.corpus import harvested_corpus
 from daydream.training.exclusion import load_exclusion_list
 from daydream.training.harvest import assemble_scoring_inputs
 from daydream.training.reward import score_trajectory
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from verifiers.v1.errors import boundary
 
 from daydream_review_v1.rundir import DEFAULT_ARCHIVE_ROOT, fetch_run_dir
@@ -191,6 +191,7 @@ class DaydreamReviewData(vf.TaskData):
     head_sha: str
     base_ref: str | None = None
     test_command: str
+    protected_test_paths: list[str]
     golden_comments: list[GoldenComment] = []
 
 
@@ -403,6 +404,7 @@ class _ManifestEntry(BaseModel):
     clone_url: str
     image: str
     test_command: str
+    protected_test_paths: list[str] = Field(min_length=1)
     setup_cmds: list[str] = []
 
 
@@ -534,6 +536,7 @@ class DaydreamReviewTaskset(vf.Taskset[DaydreamReviewTask, DaydreamReviewConfig]
                 head_sha=pr.head_sha,
                 base_ref=pr.base_ref,
                 test_command=entry.test_command,
+                protected_test_paths=entry.protected_test_paths,
                 golden_comments=golden.get(pr.golden_url, []),
             )
             tasks.append(DaydreamReviewTask(data, config.task))

--- a/rl/daydream_review_v1/images/manifest.toml
+++ b/rl/daydream_review_v1/images/manifest.toml
@@ -12,12 +12,23 @@
 # `clone_url` is what `images/repo.Dockerfile` mirror-clones. The sentinel
 # `fixture://daydream-rl-fixture` tells `build_images.py` to materialize the
 # deterministic fixture repository from `daydream_review_v1.fixture` instead of cloning.
+#
+# `protected_test_paths` is the test oracle inventory: LITERAL repository-relative
+# files/directories that constitute the repo's test oracle. It is required and
+# nonempty (a missing or empty list is a manifest-load error). At scoring time
+# `fix_tests_pass` compares these paths against the baked head SHA, fail-closed:
+# any tracked difference (committed, staged, unstaged, deleted, renamed), any
+# non-ignored untracked file under a protected path, or any Git error means the
+# oracle changed and the rollout earns zero test reward without running
+# `test_command`. Cover every runner-config filename `test_command` can load,
+# including absent ones whose later creation could alter collection.
 
 [repos."existential-birds/daydream-rl-fixture"]
 clone_url = "fixture://daydream-rl-fixture"
 image = "daydream-rl/fixture"
 test_command = "python -m unittest discover -q"
 setup_cmds = []
+protected_test_paths = ["tests"]
 
 # Reference entry: real upstream history, proving the tooling on something other
 # than a synthetic repo. BSD-3-Clause, not on the C5 exclusion list, and its whole
@@ -37,3 +48,4 @@ clone_url = "https://github.com/pallets/itsdangerous.git"
 image = "daydream-rl/itsdangerous"
 test_command = "/opt/repo-venv/bin/python -m pytest -q"
 setup_cmds = ["UV_PYTHON_DOWNLOADS=never UV_PROJECT_ENVIRONMENT=/opt/repo-venv uv sync --locked --no-default-groups --group tests"]
+protected_test_paths = ["tests", "conftest.py", ".pytest.ini", "pytest.ini", "pyproject.toml", "setup.cfg", "tox.ini"]

--- a/rl/daydream_review_v1/images/manifest.toml
+++ b/rl/daydream_review_v1/images/manifest.toml
@@ -15,7 +15,9 @@
 #
 # `protected_test_paths` is the test oracle inventory: LITERAL repository-relative
 # files/directories that constitute the repo's test oracle. It is required and
-# nonempty (a missing or empty list is a manifest-load error). At scoring time
+# nonempty (a missing or empty list is a manifest-load error), and every entry must
+# be a literal path — no git pathspec syntax (``*``/``?``/``[`` globs, a leading
+# ``:`` magic), which the manifest loader rejects: at scoring time
 # `fix_tests_pass` compares these paths against the baked head SHA, fail-closed:
 # any tracked difference (committed, staged, unstaged, deleted, renamed), any
 # non-ignored untracked file under a protected path, or any Git error means the

--- a/rl/daydream_review_v1/tests/test_rewards.py
+++ b/rl/daydream_review_v1/tests/test_rewards.py
@@ -558,6 +558,76 @@ async def test_oracle_gate_rejects_info_exclude_rule(
     assert "test_claim_mismatch" not in trace.metrics
 
 
+async def test_oracle_gate_rejects_untracked_hidden_by_core_excludesfile(
+    tmp_path: Path,
+    runtime,
+    rundir_golden: Path,
+    corpus_mini_dir: Path,
+    fixture_manifest_path: Path,
+) -> None:
+    """A core.excludesFile rule masking an untracked oracle file must fail closed.
+
+    ``git ls-files --exclude-standard`` honors the repo-local ``core.excludesFile``
+    set in the untracked ``.git/config`` — a file the gate never probes — so a
+    rollout could otherwise hide an untracked tests/pytest.ini behind it and pass
+    every probe. The untracked probe runs with ``-c core.excludesFile=``, which
+    also neutralizes the global excludes file (``$HOME/.config/git/ignore``), so
+    the file is listed and the oracle reads as changed.
+    """
+    archive_root = tmp_path / "archive"
+    _stage_run(archive_root, rundir_golden)
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    repo = _stage_repo(tmp_path / "repo", task.data.head_sha, edit=_CALC_FIXED)
+    ignores = repo.parent / "excludes"
+    ignores.write_text("tests/pytest.ini\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "core.excludesFile", str(ignores)],
+        check=True,
+    )
+    (repo / "tests/pytest.ini").write_text("[pytest]\n", encoding="utf-8")
+    trace = _trace(task, archive_root=archive_root, repo_path=repo)
+
+    await task.score(trace, runtime)
+
+    assert trace.metrics["fixes_applied"] == 1.0
+    assert trace.metrics["test_oracle_unchanged"] == 0.0
+    assert trace.rewards["fix_tests_pass"] == 0.0
+    assert "test_claim_mismatch" not in trace.metrics
+
+
+async def test_oracle_gate_green_despite_suite_bytecode_artifacts(
+    tmp_path: Path,
+    runtime,
+    rundir_golden: Path,
+    corpus_mini_dir: Path,
+    fixture_manifest_path: Path,
+) -> None:
+    """A green suite's own bytecode under protected paths must not trip the gate.
+
+    The untracked probe lists every untracked file under a protected path (no
+    ``--exclude-standard``), so the ``__pycache__/`` and ``*.py[cod]`` files a
+    legitimate test run drops while importing ``tests/`` would otherwise read as
+    an oracle change and withhold ``w_tests`` from a genuinely fixed tree. Those
+    artifacts are excluded explicitly via ``ORACLE_BENIGN_PATHSPECS`` — never
+    loaded by the runner, so excluding them cannot hide a real oracle file.
+    """
+    archive_root = tmp_path / "archive"
+    _stage_run(archive_root, rundir_golden)
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    repo = _stage_repo(tmp_path / "repo", task.data.head_sha, edit=_CALC_FIXED)
+    pycache = repo / "tests" / "__pycache__"
+    pycache.mkdir()
+    (pycache / "test_calc.cpython-312.pyc").write_bytes(b"x")
+    (repo / "tests" / "test_calc.pyc").write_bytes(b"x")
+    trace = _trace(task, archive_root=archive_root, repo_path=repo)
+
+    await task.score(trace, runtime)
+
+    assert trace.metrics["fixes_applied"] == 1.0
+    assert trace.metrics["test_oracle_unchanged"] == 1.0
+    assert trace.rewards["fix_tests_pass"] == 1.0
+
+
 async def test_oracle_gate_rejects_root_sitecustomize(
     tmp_path: Path,
     runtime,

--- a/rl/daydream_review_v1/tests/test_rewards.py
+++ b/rl/daydream_review_v1/tests/test_rewards.py
@@ -391,6 +391,7 @@ async def test_fix_tests_pass_rejects_protected_test_path_changes(
     tamper_content: str,
     tmp_path: Path,
     runtime,
+    rundir_golden: Path,
     corpus_mini_dir: Path,
     fixture_manifest_path: Path,
 ) -> None:
@@ -398,11 +399,14 @@ async def test_fix_tests_pass_rejects_protected_test_path_changes(
 
     Every tamper row is deliberately green-if-run: a vulnerable impl that
     executes the tampered oracle gets exit 0 -> reward 1.0. The gate must
-    return 0.0 without running test_command, so the claim-mismatch tripwire
-    never fires either.
+    return 0.0 without running test_command. Staging a real
+    ``deep/test-verdict.json`` claim makes the tripwire load-bearing: any
+    execution of test_command records ``test_claim_mismatch`` (0.0 on this
+    green tampered suite, 1.0 if it ran red), so its absence below proves the
+    gate held rather than passing vacuously over an empty archive.
     """
     archive_root = tmp_path / "archive"
-    (archive_root / "runs").mkdir(parents=True)
+    _stage_run(archive_root, rundir_golden)
     task = _task(corpus_mini_dir, fixture_manifest_path)
     repo = _stage_repo(tmp_path / "repo", task.data.head_sha, edit=edit)
     (repo / tamper_rel).write_text(tamper_content, encoding="utf-8")
@@ -413,22 +417,166 @@ async def test_fix_tests_pass_rejects_protected_test_path_changes(
     assert trace.metrics["fixes_applied"] == 1.0
     assert trace.metrics["test_oracle_unchanged"] == 0.0
     assert trace.rewards["fix_tests_pass"] == 0.0
-    # test_command must NOT have run, so the claim-mismatch tripwire never fires.
+    # The staged claim (passed=True) means ANY test_command execution would
+    # record test_claim_mismatch; its absence proves the gate held.
     assert "test_claim_mismatch" not in trace.metrics
 
 
 async def test_oracle_gate_fails_closed_on_git_error(
-    tmp_path: Path, runtime, corpus_mini_dir: Path, fixture_manifest_path: Path
+    tmp_path: Path,
+    runtime,
+    rundir_golden: Path,
+    corpus_mini_dir: Path,
+    fixture_manifest_path: Path,
 ) -> None:
-    """A Git error in the oracle comparison must read as 'changed' (zero reward)."""
+    """A Git error in the oracle comparison must read as 'changed' (zero reward).
+
+    The staged ``deep/test-verdict.json`` claim makes the tripwire assertion
+    load-bearing: a gate that ran test_command (on this green fixed repo) would
+    record ``test_claim_mismatch``, so its absence proves the fail-closed branch
+    returned 0.0 without running the suite.
+    """
     archive_root = tmp_path / "archive"
-    (archive_root / "runs").mkdir(parents=True)
+    _stage_run(archive_root, rundir_golden)
     task = _task(corpus_mini_dir, fixture_manifest_path)
     repo = _stage_repo(tmp_path / "repo", task.data.head_sha, edit=_CALC_FIXED)
     # The uncommitted calc.py fix makes _fixes_applied return True via the
     # dirty-tree check (no head_sha resolution); the gate then diff's an
     # unresolvable baked SHA -> exit 128 -> fail closed.
     task.data = task.data.model_copy(update={"head_sha": "0" * 40})
+    trace = _trace(task, archive_root=archive_root, repo_path=repo)
+
+    await task.score(trace, runtime)
+
+    assert trace.metrics["fixes_applied"] == 1.0
+    assert trace.metrics["test_oracle_unchanged"] == 0.0
+    assert trace.rewards["fix_tests_pass"] == 0.0
+    assert "test_claim_mismatch" not in trace.metrics
+
+
+@pytest.mark.parametrize(
+    "flag",
+    ["--skip-worktree", "--assume-unchanged"],
+    ids=["skip-worktree", "assume-unchanged"],
+)
+async def test_oracle_gate_rejects_flag_tampered_tracked_file(
+    flag: str,
+    tmp_path: Path,
+    runtime,
+    rundir_golden: Path,
+    corpus_mini_dir: Path,
+    fixture_manifest_path: Path,
+) -> None:
+    """A skip-worktree/assume-unchanged flag hides tamper from the diff probe.
+
+    git reads a file carrying either flag from the INDEX, not the worktree, so a
+    tampered tracked protected file reads as clean to ``git diff`` (exit 0). The
+    flag probe (``git ls-files -v``) must fail closed: setting the flag on any
+    protected file is itself tampering with the oracle's verifiability.
+    """
+    archive_root = tmp_path / "archive"
+    _stage_run(archive_root, rundir_golden)
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    # A real fix (calc.py) plus a flagged, gutted tracked test: diff is fooled,
+    # so only the flag probe stands between this and a free w_tests.
+    repo = _stage_repo(tmp_path / "repo", task.data.head_sha, edit=_CALC_FIXED)
+    (repo / "tests/test_calc.py").write_text(_TAMPER_PASSING, encoding="utf-8")
+    subprocess.run(
+        ["git", "-C", str(repo), "update-index", flag, "tests/test_calc.py"],
+        check=True,
+    )
+    trace = _trace(task, archive_root=archive_root, repo_path=repo)
+
+    await task.score(trace, runtime)
+
+    assert trace.metrics["fixes_applied"] == 1.0
+    assert trace.metrics["test_oracle_unchanged"] == 0.0
+    assert trace.rewards["fix_tests_pass"] == 0.0
+    assert "test_claim_mismatch" not in trace.metrics
+
+
+async def test_oracle_gate_rejects_tracked_gitignore_edit(
+    tmp_path: Path,
+    runtime,
+    rundir_golden: Path,
+    corpus_mini_dir: Path,
+    fixture_manifest_path: Path,
+) -> None:
+    """A tracked .gitignore edit masking a new oracle file must fail closed.
+
+    ``git ls-files --exclude-standard`` honors the repo's own ignore rules, so a
+    rollout that edits the tracked ``.gitignore`` to ignore a new untracked
+    tests/pytest.ini hides that file from the untracked probe. The diff probe
+    covers those ignore files (``:(glob)**/.gitignore``), so the edit itself
+    must read as an oracle change.
+    """
+    archive_root = tmp_path / "archive"
+    _stage_run(archive_root, rundir_golden)
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    repo = _stage_repo(tmp_path / "repo", task.data.head_sha, edit=_CALC_FIXED)
+    gitignore = repo / ".gitignore"
+    gitignore.write_text(gitignore.read_text(encoding="utf-8") + "tests/pytest.ini\n", encoding="utf-8")
+    (repo / "tests/pytest.ini").write_text("[pytest]\n", encoding="utf-8")
+    trace = _trace(task, archive_root=archive_root, repo_path=repo)
+
+    await task.score(trace, runtime)
+
+    assert trace.metrics["fixes_applied"] == 1.0
+    assert trace.metrics["test_oracle_unchanged"] == 0.0
+    assert trace.rewards["fix_tests_pass"] == 0.0
+    assert "test_claim_mismatch" not in trace.metrics
+
+
+async def test_oracle_gate_rejects_info_exclude_rule(
+    tmp_path: Path,
+    runtime,
+    rundir_golden: Path,
+    corpus_mini_dir: Path,
+    fixture_manifest_path: Path,
+) -> None:
+    """A rule written to .git/info/exclude must fail closed.
+
+    ``--exclude-standard`` reads the rollout-controlled ``.git/info/exclude``,
+    so a rule written there can mask an untracked oracle file with zero tracked
+    changes. A fresh clone's file is comments-only; any real rule means the
+    oracle changed.
+    """
+    archive_root = tmp_path / "archive"
+    _stage_run(archive_root, rundir_golden)
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    repo = _stage_repo(tmp_path / "repo", task.data.head_sha, edit=_CALC_FIXED)
+    info_exclude = repo / ".git/info/exclude"
+    info_exclude.write_text(info_exclude.read_text(encoding="utf-8") + "tests/conftest.py\n", encoding="utf-8")
+    (repo / "tests/conftest.py").write_text("", encoding="utf-8")
+    trace = _trace(task, archive_root=archive_root, repo_path=repo)
+
+    await task.score(trace, runtime)
+
+    assert trace.metrics["fixes_applied"] == 1.0
+    assert trace.metrics["test_oracle_unchanged"] == 0.0
+    assert trace.rewards["fix_tests_pass"] == 0.0
+    assert "test_claim_mismatch" not in trace.metrics
+
+
+async def test_oracle_gate_rejects_root_sitecustomize(
+    tmp_path: Path,
+    runtime,
+    rundir_golden: Path,
+    corpus_mini_dir: Path,
+    fixture_manifest_path: Path,
+) -> None:
+    """An untracked root sitecustomize.py that exits 0 must fail closed.
+
+    ``sitecustomize.py`` is imported from the repository root by every ``python``
+    invocation ``test_command`` runs (cwd is on ``sys.path``), so one that calls
+    ``sys.exit(0)`` makes a suite that never ran look green. It sits outside the
+    declared protected paths, so the untracked probe must cover it explicitly.
+    """
+    archive_root = tmp_path / "archive"
+    _stage_run(archive_root, rundir_golden)
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    repo = _stage_repo(tmp_path / "repo", task.data.head_sha, edit=_CALC_FIXED)
+    (repo / "sitecustomize.py").write_text("import sys\nsys.exit(0)\n", encoding="utf-8")
     trace = _trace(task, archive_root=archive_root, repo_path=repo)
 
     await task.score(trace, runtime)

--- a/rl/daydream_review_v1/tests/test_rewards.py
+++ b/rl/daydream_review_v1/tests/test_rewards.py
@@ -197,6 +197,18 @@ _REAL_PATCH = "diff --git a/tests/test_calc.py b/tests/test_calc.py\n@@ -1 +1 @@
 
 _CALC_FIXED = _CALC_BROKEN.replace("return a + b + 1", "return a + b")
 
+# A gutted suite that PASSES if run: a vulnerable impl that executes the
+# tampered oracle gets exit 0 -> reward 1.0. The gate must return 0.0 instead.
+_TAMPER_PASSING = (
+    "import unittest\n\n"
+    "class TestCalc(unittest.TestCase):\n"
+    "    def test_placeholder(self) -> None:\n"
+    "        pass\n"
+)
+
+# Overwriting the tracked tests/__init__.py to skip discovery: suite still exits 0.
+_TAMPER_SKIPALL = 'import unittest\nraise unittest.SkipTest("gutted")\n'
+
 
 def test_rundir_golden_user_messages_are_inert(rundir_golden: Path) -> None:
     """Defensive regression guard only: every user-authored step in the
@@ -342,6 +354,7 @@ async def test_fix_tests_pass_green(
 
     assert trace.metrics["fixes_applied"] == 1.0
     assert trace.rewards["fix_tests_pass"] == 1.0
+    assert trace.metrics["test_oracle_unchanged"] == 1.0
 
 
 async def test_fix_tests_pass_red(
@@ -357,6 +370,73 @@ async def test_fix_tests_pass_red(
 
     assert trace.metrics["fixes_applied"] == 1.0
     assert trace.rewards["fix_tests_pass"] == 0.0
+
+
+@pytest.mark.parametrize(
+    ("edit", "tamper_rel", "tamper_content"),
+    [
+        # test-source-tamper: overwrite a tracked test with a passing suite
+        (None, "tests/test_calc.py", _TAMPER_PASSING),
+        # test-package-config: overwrite tracked tests/__init__.py to skip discovery
+        (None, "tests/__init__.py", _TAMPER_SKIPALL),
+        # untracked oracle file: a real fix (calc.py) plus a NEW non-ignored
+        # tests/pytest.ini — ls-files --others must catch it
+        (_CALC_FIXED, "tests/pytest.ini", "[pytest]\n"),
+    ],
+    ids=["test-source-tamper", "test-package-config-tamper", "untracked-oracle-file"],
+)
+async def test_fix_tests_pass_rejects_protected_test_path_changes(
+    edit: str | None,
+    tamper_rel: str,
+    tamper_content: str,
+    tmp_path: Path,
+    runtime,
+    corpus_mini_dir: Path,
+    fixture_manifest_path: Path,
+) -> None:
+    """A changed test oracle earns a literal zero, never the w_tests reward.
+
+    Every tamper row is deliberately green-if-run: a vulnerable impl that
+    executes the tampered oracle gets exit 0 -> reward 1.0. The gate must
+    return 0.0 without running test_command, so the claim-mismatch tripwire
+    never fires either.
+    """
+    archive_root = tmp_path / "archive"
+    (archive_root / "runs").mkdir(parents=True)
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    repo = _stage_repo(tmp_path / "repo", task.data.head_sha, edit=edit)
+    (repo / tamper_rel).write_text(tamper_content, encoding="utf-8")
+    trace = _trace(task, archive_root=archive_root, repo_path=repo)
+
+    await task.score(trace, runtime)
+
+    assert trace.metrics["fixes_applied"] == 1.0
+    assert trace.metrics["test_oracle_unchanged"] == 0.0
+    assert trace.rewards["fix_tests_pass"] == 0.0
+    # test_command must NOT have run, so the claim-mismatch tripwire never fires.
+    assert "test_claim_mismatch" not in trace.metrics
+
+
+async def test_oracle_gate_fails_closed_on_git_error(
+    tmp_path: Path, runtime, corpus_mini_dir: Path, fixture_manifest_path: Path
+) -> None:
+    """A Git error in the oracle comparison must read as 'changed' (zero reward)."""
+    archive_root = tmp_path / "archive"
+    (archive_root / "runs").mkdir(parents=True)
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    repo = _stage_repo(tmp_path / "repo", task.data.head_sha, edit=_CALC_FIXED)
+    # The uncommitted calc.py fix makes _fixes_applied return True via the
+    # dirty-tree check (no head_sha resolution); the gate then diff's an
+    # unresolvable baked SHA -> exit 128 -> fail closed.
+    task.data = task.data.model_copy(update={"head_sha": "0" * 40})
+    trace = _trace(task, archive_root=archive_root, repo_path=repo)
+
+    await task.score(trace, runtime)
+
+    assert trace.metrics["fixes_applied"] == 1.0
+    assert trace.metrics["test_oracle_unchanged"] == 0.0
+    assert trace.rewards["fix_tests_pass"] == 0.0
+    assert "test_claim_mismatch" not in trace.metrics
 
 
 @pytest.mark.parametrize(
@@ -611,6 +691,7 @@ async def test_committed_fix_counts_even_with_a_clean_tree(
 
     assert trace.metrics["fixes_applied"] == 1.0
     assert trace.rewards["fix_tests_pass"] == 1.0
+    assert trace.metrics["test_oracle_unchanged"] == 1.0
 
 
 async def test_committed_daydream_artifacts_not_a_fix(

--- a/rl/daydream_review_v1/tests/test_taskset.py
+++ b/rl/daydream_review_v1/tests/test_taskset.py
@@ -62,6 +62,7 @@ def _write_manifest(path: Path, slugs: list[str]) -> Path:
         f'image = "daydream-rl/{slug.split("/")[-1]}"\n'
         f'test_command = "pytest -q"\n'
         "setup_cmds = []\n"
+        f'protected_test_paths = {json.dumps(["tests"])}\n'
         for slug in slugs
     )
     path.write_text(body, encoding="utf-8")
@@ -165,6 +166,7 @@ def test_load_builds_tasks_from_fixture_corpus(corpus_mini_dir: Path, fixture_ma
     assert pr1.head_sha == FIXTURE_PR1_HEAD_SHA
     assert pr1.base_ref == "main"
     assert pr1.test_command == FIXTURE_TEST_COMMAND
+    assert pr1.protected_test_paths == ["tests"]
     assert pr1.clone_url == f"https://github.com/{FIXTURE_SLUG}"
     assert pr1.image == f"daydream-rl/fixture:{FIXTURE_PR1_HEAD_SHA[:12]}"
     assert pr1.name == f"{FIXTURE_SLUG}#1"
@@ -266,6 +268,47 @@ def test_load_manifest_rejects_unknown_key(tmp_path: Path) -> None:
     ]
 
 
+@pytest.mark.parametrize(
+    "block, error_type",
+    [
+        (  # missing field entirely
+            '[repos."acme/widgets"]\n'
+            'clone_url = "https://github.com/acme/widgets"\n'
+            'image = "daydream-rl/widgets"\n'
+            'test_command = "pytest -q"\n'
+            "setup_cmds = []\n",
+            "missing",
+        ),
+        (  # present but empty
+            '[repos."acme/widgets"]\n'
+            'clone_url = "https://github.com/acme/widgets"\n'
+            'image = "daydream-rl/widgets"\n'
+            'test_command = "pytest -q"\n'
+            "setup_cmds = []\n"
+            "protected_test_paths = []\n",
+            "too_short",
+        ),
+    ],
+    ids=["missing", "empty"],
+)
+def test_load_manifest_rejects_missing_or_empty_protected_test_paths(
+    tmp_path: Path, block: str, error_type: str
+) -> None:
+    """A missing or empty protected_test_paths inventory is a load error.
+
+    The security boundary is structural: an entry that ships without a
+    protected-path inventory must never silently load into an unprotected task.
+    """
+    manifest = tmp_path / "manifest.toml"
+    manifest.write_text(block, encoding="utf-8")
+
+    with pytest.raises(ValidationError) as excinfo:
+        load_manifest(manifest)
+    assert (error_type, ("protected_test_paths",)) in [
+        (err["type"], err["loc"]) for err in excinfo.value.errors()
+    ]
+
+
 def test_golden_comment_rejects_unknown_key() -> None:
     """A misspelled/extra key in benchmark_data.json must not be silently dropped.
 
@@ -351,4 +394,13 @@ def test_reference_corpus_loads_against_the_manifest(fixture_manifest_path: Path
     assert task.data.head_sha == "4bb03cd6819228f30079885297299fe568a62863"
     assert task.data.base_sha == "4dffa1963f896a0a311dec3c14f003a5f382c446"
     assert task.data.test_command == "/opt/repo-venv/bin/python -m pytest -q"
+    assert task.data.protected_test_paths == [
+        "tests",
+        "conftest.py",
+        ".pytest.ini",
+        "pytest.ini",
+        "pyproject.toml",
+        "setup.cfg",
+        "tox.ini",
+    ]
     assert task.data.image == "daydream-rl/itsdangerous:4bb03cd68192"

--- a/rl/daydream_review_v1/tests/test_taskset.py
+++ b/rl/daydream_review_v1/tests/test_taskset.py
@@ -309,6 +309,41 @@ def test_load_manifest_rejects_missing_or_empty_protected_test_paths(
     ]
 
 
+@pytest.mark.parametrize(
+    "entry",
+    ["", ":(exclude)tests", "tests/*", "tests/?", "tests/[x]"],
+    ids=["empty", "leading-colon-magic", "glob-star", "glob-question", "glob-bracket"],
+)
+def test_load_manifest_rejects_non_literal_protected_test_paths(
+    tmp_path: Path, entry: str
+) -> None:
+    """A protected_test_paths entry with git pathspec syntax is a load error.
+
+    The manifest promises LITERAL repository-relative paths, but the scoring gate
+    passes each entry to git as a bare pathspec, where ``*``/``?``/``[`` are glob
+    metacharacters and a leading ``:`` is pathspec magic. A glob-shaped entry that
+    matches nothing would read as a clean diff and an empty ls-files list, letting
+    test_command run against an unprotected oracle — so such entries must never
+    load, exactly like a missing or empty inventory.
+    """
+    manifest = tmp_path / "manifest.toml"
+    manifest.write_text(
+        '[repos."acme/widgets"]\n'
+        'clone_url = "https://github.com/acme/widgets"\n'
+        'image = "daydream-rl/widgets"\n'
+        'test_command = "pytest -q"\n'
+        "setup_cmds = []\n"
+        f"protected_test_paths = {json.dumps([entry])}\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValidationError) as excinfo:
+        load_manifest(manifest)
+    assert ("value_error", ("protected_test_paths",)) in [
+        (err["type"], err["loc"]) for err in excinfo.value.errors()
+    ]
+
+
 def test_golden_comment_rejects_unknown_key() -> None:
     """A misspelled/extra key in benchmark_data.json must not be silently dropped.
 


### PR DESCRIPTION
## Summary

Closes #440 — **withhold the fix-test reward when protected test-oracle paths change**.

This is a daydream-improve ticket (critical/improve). The embedded plan was treated as guidance only; the full pipeline (explore → spec → plan → implement → 2× daydream deep-precision review) ran against current `main`.

### What changed
- **Require a protected test-oracle path inventory** in image manifests (`protected_test_paths`), enforced by the gate when a repository is added.
- **Withhold the fix reward** when any protected test-oracle path changes during a run (the core issue).
- **Close remaining test-oracle bypass vectors** in the gate, including a **fail-open `core.excludesFile` / global-excludes bypass** in the untracked-oracle probe (high severity, found by round-2 review): the five probes were refactored into a fail-closed (argv, changed-predicate) table over a shared `_probe` helper; the untracked probe now runs with `-c core.excludesFile=` and without `--exclude-standard`; the suite's own `__pycache__/*.py[cod]` byproducts are explicitly excluded via `ORACLE_BENIGN_PATHSPECS`.

### Files changed
- `rl/daydream_review_v1/README.md`
- `rl/daydream_review_v1/daydream_review_v1/taskset.py`
- `rl/daydream_review_v1/images/manifest.toml`
- `rl/daydream_review_v1/tests/test_rewards.py`
- `rl/daydream_review_v1/tests/test_taskset.py`

### Verification
- Two sequential daydream deep-precision reviews (rounds 1 & 2), each on a fresh VM; trajectories uploaded to HF.
- Round-2 review: full suite **114 passed / 1 skipped**, ruff clean, tree clean.
- Author gate: all 5 commits authored by anderskev@gmail.com.

### Test Plan
- [x] `uv run pytest` (full standalone suite) green
- [x] `uv run ruff check .` clean
- [x] Author gate `AUTHORS_OK`

_Reviewed by Hermes Agent — ship pipeline (no CodeRabbit)._