### PR TITLE
[daydream] Fix CLAUDE.md retry documentation (remove stalled stream from never-retried) — Closes #568

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,7 @@ recorder are backend-agnostic.
   backend raises `MaxTurnsError`, and the fix group lands in `fix-failures.json` and is reverted, throwing
   a real fix away rather than trimming it.
 - `run_agent` retries any `retryable` backend error with exponential backoff, **20 attempts**, all backends
-  (`DAYDREAM_PI_RETRY_ATTEMPTS` overrides). Never retried: tool-supervisor veto, stalled stream,
+  (`DAYDREAM_PI_RETRY_ATTEMPTS` overrides). Never retried: tool-supervisor veto,
   non-transport logic error. A stall fires only on the *absence* of output, never on slow output.
 
 ### Config and per-phase model overrides


### PR DESCRIPTION
## Summary
Doc-only fix for the `out-of-scope finding: CLAUDE.md` issue (#460, consolidated in #568).

Removes **stalled stream** from the "Never retried" list in `CLAUDE.md`'s retry documentation. Actual behavior already retries stalled streams (`StreamStalledError` is retryable in `daydream/backends/_subprocess.py`), so the docs now match the implementation.

## Test Plan
- Doc-only change; no code behavior change.
- Verified via two sequential daydream deep-precision review rounds (no actionable findings).

Closes #568