### PR TITLE
[daydream] Document format version in exploration cache-key contract (issue #569)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,7 @@ exploration pre-scan (cached across runs)
   else the `diff.patch` pointer. Small diffs skip the fan-out entirely.
 - Merge resumes the arbiter's session when both phases resolve to the same backend instance; the resumed
   prompt forces a re-read of the per-stack record files, rewritten after arbitration.
-- `.daydream/exploration/` survives the run, reused only on an **exact** key match (head SHA + diff + tier +
+- `.daydream/exploration/` survives the run, reused only on an **exact** key match (format version + head SHA + diff + tier +
   depth, in a sibling `cache-key` file) — a near-match hit would misground every prompt. Uncommitted edits
   are not in the key, so an exact hit on a dirty tree can serve pre-edit exploration. `--shallow`/`--review`
   delete the directory, so alternating flows always misses.

--- a/README.md
+++ b/README.md
@@ -519,14 +519,14 @@ Daydream can run as a self-hosted PR review bot in your own repository's GitHub 
 | `.daydream/diff.patch` | Unified diff captured at run start |
 | `.daydream/deep/` | Deep pipeline artifacts: intent, per-stack reviews, merged report |
 | `.daydream/exploration/` | Cached pre-scan grounding; survives the run and is reused by the next one |
-| `.daydream/exploration/cache-key` | Key the cached pre-scan was produced from (head SHA + diff + tier + depth) |
+| `.daydream/exploration/cache-key` | Key the cached pre-scan was produced from (format version + head SHA + diff + tier + depth) |
 | `.review-output.md` | Review findings (removed with `--cleanup`) |
 | `~/.daydream/archive/runs/<id>/` | Archived run: manifest, trajectory, review output, evaluation, deep artifacts |
 | `~/.daydream/archive/index.db` | SQLite index for cross-project querying |
 
 `.daydream/exploration/` is reused on an **exact** key match regardless of
 uncommitted worktree edits: the key intentionally excludes uncommitted edits
-(head SHA + diff + tier + depth), so an exact-key hit on a dirty tree serves
+(format version + head SHA + diff + tier + depth), so an exact-key hit on a dirty tree serves
 exploration computed before those edits. Near-matches never count — a stale hit
 would misground every review prompt. The `--shallow` and `--review` flows still
 delete the directory, so alternating flows degrades to a cache miss (never to

--- a/daydream/exploration.py
+++ b/daydream/exploration.py
@@ -334,9 +334,10 @@ def exploration_cache_key(head_sha: str, diff: str, tier: str, depth: int | str)
 
     An exact key match is reused even with uncommitted worktree edits: the key
     intentionally excludes uncommitted edits because reuse is exact-match-only
-    on head SHA + diff + tier + depth. The generating code is versioned into the
-    key too, so an upgrade that changes artifact rendering (``_CACHE_VERSION``)
-    never serves stale pre-upgrade artifacts on an exact match.
+    on format version + head SHA + diff + tier + depth. The generating code is
+    versioned into the key too, so an upgrade that changes artifact rendering
+    (``_CACHE_VERSION``) never serves stale pre-upgrade artifacts on an exact
+    match.
     """
     payload = f"{_CACHE_VERSION}\n{head_sha}\n{diff}\n{tier}\n{depth}"
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/tests/test_exploration_cache.py
+++ b/tests/test_exploration_cache.py
@@ -211,8 +211,11 @@ async def test_failed_exploration_is_not_durably_cached(
     assert not (exploration / "cache-key").exists()
 
 
-def test_cache_key_is_sensitive_to_every_component() -> None:
-    """Each of head, diff, tier, depth changes the key."""
+def test_cache_key_is_sensitive_to_every_component(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each of head, diff, tier, depth, and the format version changes the key."""
+    from daydream import exploration as exploration_mod
     from daydream.exploration import exploration_cache_key
 
     base = exploration_cache_key("sha1", "diff", "standard", 2)
@@ -221,6 +224,12 @@ def test_cache_key_is_sensitive_to_every_component() -> None:
     assert base != exploration_cache_key("sha1", "other", "standard", 2)
     assert base != exploration_cache_key("sha1", "diff", "deep", 2)
     assert base != exploration_cache_key("sha1", "diff", "standard", 3)
+
+    # The format version is part of the key: a bump must change it. The override
+    # value is arbitrary (never assert the production value), so a legitimate
+    # upgrade stays green while a removal from the payload goes red.
+    monkeypatch.setattr(exploration_mod, "_CACHE_VERSION", 999)
+    assert base != exploration_cache_key("sha1", "diff", "standard", 2)
 
 
 def test_cache_key_components_cannot_be_confused_by_delimiters() -> None:

--- a/tests/test_exploration_cache.py
+++ b/tests/test_exploration_cache.py
@@ -1,7 +1,8 @@
 """Cross-run reuse of the deep pipeline's exploration pre-scan.
 
 ``.daydream/exploration/`` now survives a run and is keyed by
-``head sha + diff + tier + depth`` (``daydream.exploration.exploration_cache_key``).
+``head sha + diff + tier + depth + format version``
+(``daydream.exploration.exploration_cache_key``).
 A second run with an identical key reuses the directory verbatim and fires zero
 specialist agents; any key change re-runs the pre-scan and rewrites the files.
 


### PR DESCRIPTION
## Summary
Documents that the deep-flow exploration cache key includes a **format version** component (`_CACHE_VERSION`) alongside head SHA + diff + tier + depth, per the consolidated finding in #569. The generating code was already versioned into the key — the source docstring, README, CLAUDE, and tests just didn't all say so, and one site (the owning function's docstring) still enumerated the old component set after earlier rounds.

## Changes
- `daydream/exploration.py` — `exploration_cache_key` docstring now enumerates "format version + head SHA + diff + tier + depth" (matches the actual payload and all other doc sites).
- `README.md` / `CLAUDE.md` — `.daydream/exploration/cache-key` descriptions updated to the same component list.
- `tests/test_exploration_cache.py` — extended the cache-key sensitivity test to assert the key changes when `_CACHE_VERSION` is bumped (regression guard that the version stays part of the key).

## Test Plan
- `tests/test_exploration_cache.py` → 10 passed.

Closes #569