### PR TITLE
[daydream] Consolidate read-only Bash guard contract findings (claude.py deny-reason, prompts.py grep) (issue #565)

### DIFF
--- a/daydream/backends/claude.py
+++ b/daydream/backends/claude.py
@@ -37,9 +37,12 @@ from daydream.backends import (
     resolve_fanout_concurrency,
 )
 
-# Read-only Bash allowlist (failure summarizer): permitted only if the command
-# begins with one of these prefixes AND has no shell-chaining metacharacter that
-# could smuggle in a mutation. Mirrored in the summarizer prompt (phases.py).
+# Read-only Bash allowlist shared by every agent that runs under the read-only
+# guard (setup-investigator, failure summarizer, exploration specialists,
+# verification agent): permitted only if the command begins with one of these
+# prefixes AND has no shell-chaining metacharacter that could smuggle in a
+# mutation. Mirrored via _render_bash_allowlist() in the sibling prompts that
+# advertise it (phases.py, deep/prompts.py).
 READ_ONLY_BASH_ALLOWLIST: tuple[str, ...] = (
     "ls",
     "cat",

--- a/daydream/backends/claude.py
+++ b/daydream/backends/claude.py
@@ -196,7 +196,7 @@ def _read_only_deny(reason: str) -> HookJSONOutput:
 
 
 async def _read_only_guard(input_data: Any, tool_use_id: Any, context: Any) -> HookJSONOutput:
-    """PreToolUse hook enforcing the read-only summarizer contract.
+    """PreToolUse hook enforcing the read-only guard contract.
 
     Fires for ALL tools (matcher ``.*``). Explicitly allows only the safe set
     (Read, Grep, Glob, StructuredOutput, and allowlisted Bash commands) and
@@ -208,13 +208,13 @@ async def _read_only_guard(input_data: Any, tool_use_id: Any, context: Any) -> H
         if _is_read_only_command(command):
             return {}
         return _read_only_deny(
-            f"read-only summarizer: non-read-only Bash command blocked: {command!r}"
+            f"read-only guard: non-read-only Bash command blocked: {command!r}"
         )
     tool_name = input_data.get("tool_name") if isinstance(input_data, dict) else None
     if tool_name in _READ_ONLY_ALLOWED_TOOLS:
         return {}
     return _read_only_deny(
-        f"read-only summarizer: tool {tool_name!r} is blocked (non-mutating contract)"
+        f"read-only guard: tool {tool_name!r} is blocked (non-mutating contract)"
     )
 
 

--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -848,7 +848,7 @@ def build_verification_prompt(
 
     Hard contract:
       - Read-only tools only: Read, Grep, Glob, and Bash restricted to
-        non-mutating commands (git, cat, ls). The verifier writes nothing —
+        non-mutating commands (see `_render_bash_allowlist()`). The verifier writes nothing —
         the host persists the verdicts it returns as structured output.
       - The non-structural finding list is rendered inline below.
       - Empty issue list yields an empty verdict list (no error).

--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -23,6 +23,7 @@ from daydream.phases import (
     _confidence_and_convention_instructions,
     _dependency_impact_instructions,
     _exploration_pointer,
+    _render_bash_allowlist,
     _settled_decisions_block,
 )
 from daydream.prompt_budget import INLINE_DIFF_BUDGET_BYTES, fits_inline_diff_budget  # noqa: F401
@@ -882,7 +883,7 @@ def build_verification_prompt(
     parts.append(
         "Read-only contract (MANDATORY):\n"
         "  - Allowed tools: Read, Grep, Glob, Bash.\n"
-        "  - Bash is restricted to non-mutating commands only: `git`, `cat`, `ls`.\n"
+        f"  - Bash is restricted to non-mutating commands only: {_render_bash_allowlist()}.\n"
         "  - Do NOT write, edit, or move files. Do NOT run `git commit`, "
         "`git add`, `git checkout`, `git reset`, `git stash`, or any other "
         "state-changing command."
@@ -907,8 +908,8 @@ def build_verification_prompt(
         "  1. Locate the `impl` / interface / protocol declaration the changed "
         "code participates in. If absent, set `verdict=consistent` only if no "
         "sibling implementations exist.\n"
-        "  2. Locate every sibling implementation "
-        "(`grep -rn \"impl <Trait> for\"` / `class X(<Iface>)`).\n"
+        "  2. Locate every sibling implementation using the Grep tool "
+        "(e.g. search for `impl <Trait> for` or `class X(<Iface>)`).\n"
         "  3. Locate the trait/interface doc-comment that specifies the behavior "
         "being changed.\n"
         "  4. Compare the recommendation against those. Verdicts:\n"

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -178,8 +178,9 @@ def _render_bash_allowlist() -> str:
     """Render the read-only Bash allowlist as a comma-separated back-ticked list.
 
     Single source for the ``READ_ONLY_BASH_ALLOWLIST`` render so the setup-
-    investigator and failure-summarizer prompts stay word-for-word in sync with
-    the commands the backend guard hook actually enforces.
+    investigator, failure-summarizer, and recommendation-verifier prompts stay
+    word-for-word in sync with the commands the backend guard hook actually
+    enforces.
     """
     return ", ".join(f"`{cmd}`" for cmd in READ_ONLY_BASH_ALLOWLIST)
 

--- a/tests/test_backend_claude.py
+++ b/tests/test_backend_claude.py
@@ -2,7 +2,7 @@
 """Tests for ClaudeBackend."""
 
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -448,15 +448,21 @@ async def test_read_only_guard_deny_reason_uses_shared_guard_wording() -> None:
     'read-only summarizer'."""
     from daydream.backends.claude import _read_only_guard
 
-    deny_bash = await _read_only_guard(
-        {"tool_name": "Bash", "tool_input": {"command": "rm -rf x"}}, None, {},
+    deny_bash = cast(
+        dict[str, Any],
+        await _read_only_guard(
+            {"tool_name": "Bash", "tool_input": {"command": "rm -rf x"}}, None, {},
+        ),
     )
     bash_reason = deny_bash["hookSpecificOutput"]["permissionDecisionReason"]
     assert "read-only guard" in bash_reason
     assert "read-only summarizer" not in bash_reason
 
-    deny_tool = await _read_only_guard(
-        {"tool_name": "Write", "tool_input": {"file_path": "x", "content": "y"}}, None, {},
+    deny_tool = cast(
+        dict[str, Any],
+        await _read_only_guard(
+            {"tool_name": "Write", "tool_input": {"file_path": "x", "content": "y"}}, None, {},
+        ),
     )
     tool_reason = deny_tool["hookSpecificOutput"]["permissionDecisionReason"]
     assert "read-only guard" in tool_reason

--- a/tests/test_backend_claude.py
+++ b/tests/test_backend_claude.py
@@ -442,6 +442,28 @@ async def test_read_only_guard_denies_mutation_allows_inspection():
 
 
 @pytest.mark.asyncio
+async def test_read_only_guard_deny_reason_uses_shared_guard_wording() -> None:
+    """The guard is shared (diagnostic subagents, failure summarizer, exploration
+    specialists), so its deny reasons must say 'read-only guard', not the stale
+    'read-only summarizer'."""
+    from daydream.backends.claude import _read_only_guard
+
+    deny_bash = await _read_only_guard(
+        {"tool_name": "Bash", "tool_input": {"command": "rm -rf x"}}, None, {},
+    )
+    bash_reason = deny_bash["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "read-only guard" in bash_reason
+    assert "read-only summarizer" not in bash_reason
+
+    deny_tool = await _read_only_guard(
+        {"tool_name": "Write", "tool_input": {"file_path": "x", "content": "y"}}, None, {},
+    )
+    tool_reason = deny_tool["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "read-only guard" in tool_reason
+    assert "read-only summarizer" not in tool_reason
+
+
+@pytest.mark.asyncio
 async def test_execute_passes_agents_dict_to_options(patch_sdk):
     """Agents dict must reach ClaudeAgentOptions with original keys preserved verbatim."""
     from claude_agent_sdk.types import AgentDefinition

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -737,7 +737,6 @@ def test_verification_prompt_advertises_full_read_only_bash_allowlist(tmp_path: 
     single source — never a hand-written partial list — and must not instruct a
     shell command the read-only guard denies."""
     from daydream.deep.prompts import build_verification_prompt
-    from daydream.phases import _render_bash_allowlist
 
     items = [
         {"id": 1, "lens": "per-stack", "severity": "high", "file": "api.py",
@@ -747,8 +746,13 @@ def test_verification_prompt_advertises_full_read_only_bash_allowlist(tmp_path: 
         items=items, cwd=tmp_path, output_path=tmp_path / "verdicts.json"
     )
 
-    # Full single-source render present (a partial list would omit e.g. `git status`).
-    assert _render_bash_allowlist() in prompt
+    # Full single-source render present. Pinned literally (not via the same
+    # render function that produced the prompt) so a render or tuple regression
+    # — e.g. dropping `git status` — fails rather than passing vacuously.
+    assert (
+        "`ls`, `cat`, `git status`, `git log`, `git show`, `git blame`, `git diff`"
+        in prompt
+    )
     # The stale partial list is gone, no shell-grep step remains, and the
     # read-only clause an existing test pins survives.
     assert "`git`, `cat`, `ls`" not in prompt

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -732,6 +732,30 @@ def test_verification_prompt_has_no_schema_dump_or_write_instruction(tmp_path: P
     assert "unverified_assumptions" in prompt
 
 
+def test_verification_prompt_advertises_full_read_only_bash_allowlist(tmp_path: Path) -> None:
+    """The verifier's advertised Bash commands must be rendered from the enforced
+    single source — never a hand-written partial list — and must not instruct a
+    shell command the read-only guard denies."""
+    from daydream.deep.prompts import build_verification_prompt
+    from daydream.phases import _render_bash_allowlist
+
+    items = [
+        {"id": 1, "lens": "per-stack", "severity": "high", "file": "api.py",
+         "line": 10, "description": "x", "rationale": "y"}
+    ]
+    prompt = build_verification_prompt(
+        items=items, cwd=tmp_path, output_path=tmp_path / "verdicts.json"
+    )
+
+    # Full single-source render present (a partial list would omit e.g. `git status`).
+    assert _render_bash_allowlist() in prompt
+    # The stale partial list is gone, no shell-grep step remains, and the
+    # read-only clause an existing test pins survives.
+    assert "`git`, `cat`, `ls`" not in prompt
+    assert "grep -rn" not in prompt
+    assert "Do NOT write, edit, or move files." in prompt
+
+
 def test_verification_prompt_ignores_output_path(tmp_path: Path) -> None:
     """Two different output_path values produce byte-identical prompts."""
     from daydream.deep.prompts import build_verification_prompt


### PR DESCRIPTION
Closes #565

Consolidated: out-of-scope findings in the read-only Bash guard contract (daydream/backends/claude.py + daydream/prompts.py).

## Summary
- Generalizes the guard deny-reason wording from the stale 'read-only summarizer' to the shared 'read-only guard' (claude.py:199,211,217).
- Drops the shell grep step; renders the verifier Bash allowlist from a single source; references the allowlist render in the verification prompt.
- Docstring names the recommendation-verifier as a consumer of the shared allowlist.

## Test Plan
- [x] Daydream deep-precision review round 1
- [x] Daydream deep-precision review round 2
- [x] Branch authors verified (anderskev@gmail.com)
- [ ] CI green