### PR TITLE
[daydream] #561 Consolidate out-of-scope findings in daydream/trajectory.py (PEM redaction variants, redact_value helper)

### DIFF
--- a/daydream/benchmark/daydream_run.py
+++ b/daydream/benchmark/daydream_run.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING
 from daydream.agent import console
 from daydream.backends.pi import STREAM_DROP_SIGNATURES
 from daydream.github_app import APP_ID_ENV, APP_PRIVATE_KEY_ENV
-from daydream.trajectory import _PEM_HEADER, redact_text
+from daydream.trajectory import _PEM_HEADER, _PEM_KEY_REDACTED_MARKER, redact_text
 from daydream.ui import print_warning
 
 if TYPE_CHECKING:
@@ -67,8 +67,11 @@ _ERROR_CONTEXT_MARKERS = (
 #: every variant the pattern can redact is held until its END anchor and
 #: redacted whole before reaching on_line or the failure tail. A block the
 #: pattern cannot match (e.g. CERTIFICATE) must not be treated as handled.
-_PEM_BEGIN_RE = re.compile(rf"-----BEGIN {_PEM_HEADER}-----")
-_PEM_END_RE = re.compile(rf"-----END {_PEM_HEADER}-----")
+#: The captured group holds the exact header variant, so a flush is gated on
+#: the END anchor pairing with the SAME variant that opened the buffer (the
+#: sibling _PEM_KEY_PATTERN pairs the same header fragment on both anchors).
+_PEM_BEGIN_RE = re.compile(rf"-----BEGIN ({_PEM_HEADER})-----")
+_PEM_END_RE = re.compile(rf"-----END ({_PEM_HEADER})-----")
 #: A BEGIN anchor plus everything to end-of-text: matches the held fragment
 #: when the stream dies mid-block, where no END anchor exists to pair with
 #: _PEM_KEY_PATTERN. Shares _PEM_HEADER so the six-variant spec stays in sync
@@ -149,8 +152,13 @@ def _run_captured(cmd: list[str], env: dict[str, str], checkout: Path) -> tuple[
     # message is frequently empty; surface both streams' tails. Redact the
     # COMPLETE combined string before the tail slice — a PEM block or credential
     # straddling the cut must be caught before the slice, not truncated into an
-    # unmatchable fragment.
-    tail = redact_text(f"{result.stdout or ''}\n{result.stderr or ''}".strip())[-_STDERR_TAIL:]
+    # unmatchable fragment. A stream that ends mid-PEM-block (BEGIN+body, no END
+    # anchor) cannot match _PEM_KEY_PATTERN either, so collapse the trailing
+    # fragment the same way the streamed path's EOF flush does — the captured
+    # analogue of that invariant.
+    combined = f"{result.stdout or ''}\n{result.stderr or ''}".strip()
+    redacted = redact_text(combined)
+    tail = _PEM_FRAGMENT_RE.sub(_PEM_KEY_REDACTED_MARKER, redacted)[-_STDERR_TAIL:]
     return result.returncode, tail
 
 
@@ -176,6 +184,11 @@ def _run_streamed(
     # invariant. Buffering is anchored to _PEM_KEY_PATTERN's spec: a block that
     # pattern cannot match must not be treated as handled.
     pem_buffer: list[str] = []
+    # The variant of the BEGIN anchor that opened pem_buffer. A flush happens
+    # only when the END anchor pairs with the SAME variant, mirroring how
+    # _PEM_KEY_PATTERN pairs one header fragment on both anchors — a stray END
+    # of another variant neither closes the block early nor leaks its body.
+    pem_variant: str | None = None
 
     def _emit(line: str) -> None:
         redacted = redact_text(line)
@@ -209,13 +222,17 @@ def _run_streamed(
                 ) from None
             if line is None:
                 break
-            if _PEM_BEGIN_RE.search(line) and not _PEM_END_RE.search(line):
+            begin = _PEM_BEGIN_RE.search(line)
+            if begin and not _PEM_END_RE.search(line):
                 pem_buffer.append(line)
+                pem_variant = begin.group(1)
             elif pem_buffer:
                 pem_buffer.append(line)
-                if _PEM_END_RE.search(line):
+                end = _PEM_END_RE.search(line)
+                if end is not None and end.group(1) == pem_variant:
                     _emit("".join(pem_buffer))
                     pem_buffer.clear()
+                    pem_variant = None
             else:
                 _emit(line)
         if pem_buffer:  # stream ended mid-block: no END anchor was seen, so
@@ -223,7 +240,7 @@ def _run_streamed(
             # anchors); redact the whole held fragment at once — BEGIN marker
             # through end of stream — so the BEGIN-only fragment and its body
             # never reach on_line or the failure tail raw.
-            _emit(_PEM_FRAGMENT_RE.sub("[REDACTED_PEM_KEY]", "".join(pem_buffer)))
+            _emit(_PEM_FRAGMENT_RE.sub(_PEM_KEY_REDACTED_MARKER, "".join(pem_buffer)))
         returncode = proc.wait()
     return returncode, "\n".join(tail)
 

--- a/daydream/benchmark/daydream_run.py
+++ b/daydream/benchmark/daydream_run.py
@@ -62,12 +62,13 @@ _ERROR_CONTEXT_MARKERS = (
 )
 
 #: PEM private-key block anchors, mirroring trajectory._PEM_KEY_PATTERN's
-#: ``-----BEGIN (?:RSA )?PRIVATE KEY-----`` spec. Only blocks whose anchors match
-#: that spec are buffered for whole-block redaction: ENCRYPTED/OPENSSH/EC/DSA
-#: headers are not matched by the pattern, so buffering them here would present
-#: them as handled and then forward the raw key to on_line and the failure tail.
-_PEM_BEGIN_RE = re.compile(r"-----BEGIN (?:RSA )?PRIVATE KEY-----")
-_PEM_END_RE = re.compile(r"-----END (?:RSA )?PRIVATE KEY-----")
+#: six-variant spec (RSA, PKCS8, ENCRYPTED, OPENSSH, EC, DSA). Only blocks
+#: whose anchors match that spec are buffered for whole-block redaction, so
+#: every variant the pattern can redact is held until its END anchor and
+#: redacted whole before reaching on_line or the failure tail. A block the
+#: pattern cannot match (e.g. CERTIFICATE) must not be treated as handled.
+_PEM_BEGIN_RE = re.compile(r"-----BEGIN (?:RSA |EC |DSA |OPENSSH |ENCRYPTED )?PRIVATE KEY-----")
+_PEM_END_RE = re.compile(r"-----END (?:RSA |EC |DSA |OPENSSH |ENCRYPTED )?PRIVATE KEY-----")
 
 
 def _is_transient(stdout: str) -> bool:

--- a/daydream/benchmark/daydream_run.py
+++ b/daydream/benchmark/daydream_run.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING
 from daydream.agent import console
 from daydream.backends.pi import STREAM_DROP_SIGNATURES
 from daydream.github_app import APP_ID_ENV, APP_PRIVATE_KEY_ENV
-from daydream.trajectory import redact_text
+from daydream.trajectory import _PEM_HEADER, redact_text
 from daydream.ui import print_warning
 
 if TYPE_CHECKING:
@@ -61,14 +61,19 @@ _ERROR_CONTEXT_MARKERS = (
     "fatal error",
 )
 
-#: PEM private-key block anchors, mirroring trajectory._PEM_KEY_PATTERN's
+#: PEM private-key block anchors, sharing trajectory._PEM_HEADER's
 #: six-variant spec (RSA, PKCS8, ENCRYPTED, OPENSSH, EC, DSA). Only blocks
 #: whose anchors match that spec are buffered for whole-block redaction, so
 #: every variant the pattern can redact is held until its END anchor and
 #: redacted whole before reaching on_line or the failure tail. A block the
 #: pattern cannot match (e.g. CERTIFICATE) must not be treated as handled.
-_PEM_BEGIN_RE = re.compile(r"-----BEGIN (?:RSA |EC |DSA |OPENSSH |ENCRYPTED )?PRIVATE KEY-----")
-_PEM_END_RE = re.compile(r"-----END (?:RSA |EC |DSA |OPENSSH |ENCRYPTED )?PRIVATE KEY-----")
+_PEM_BEGIN_RE = re.compile(rf"-----BEGIN {_PEM_HEADER}-----")
+_PEM_END_RE = re.compile(rf"-----END {_PEM_HEADER}-----")
+#: A BEGIN anchor plus everything to end-of-text: matches the held fragment
+#: when the stream dies mid-block, where no END anchor exists to pair with
+#: _PEM_KEY_PATTERN. Shares _PEM_HEADER so the six-variant spec stays in sync
+#: with the buffering anchors.
+_PEM_FRAGMENT_RE = re.compile(rf"-----BEGIN {_PEM_HEADER}-----.*", re.DOTALL)
 
 
 def _is_transient(stdout: str) -> bool:
@@ -214,11 +219,11 @@ def _run_streamed(
             else:
                 _emit(line)
         if pem_buffer:  # stream ended mid-block: no END anchor was seen, so
-            # _PEM_KEY_PATTERN cannot match the fragment; redact the held lines
-            # individually so the BEGIN-only fragment and its body never reach
-            # on_line or the failure tail raw.
-            for held in pem_buffer:
-                _emit(held)
+            # _PEM_KEY_PATTERN cannot match the fragment (it needs both
+            # anchors); redact the whole held fragment at once — BEGIN marker
+            # through end of stream — so the BEGIN-only fragment and its body
+            # never reach on_line or the failure tail raw.
+            _emit(_PEM_FRAGMENT_RE.sub("[REDACTED_PEM_KEY]", "".join(pem_buffer)))
         returncode = proc.wait()
     return returncode, "\n".join(tail)
 

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -116,10 +116,12 @@ _JWT_PATTERN = re.compile(
     r"\beyJ[A-Za-z0-9_\-]{4,}\.[A-Za-z0-9_\-]{4,}\.[A-Za-z0-9_\-]{4,}\b"
 )
 _USERNAME_PATH_PATTERN = re.compile(r"(/Users/|/home/|[A-Z]:\\Users\\)([^/\\\s]+)")
-# PEM private-key blocks (PKCS1 and PKCS8). Multi-line body collapsed before the
-# bare API-key rule scans it. CERTIFICATE blocks are public material — not matched.
+# PEM private-key blocks (PKCS1/RSA, PKCS8, ENCRYPTED, OPENSSH, EC, DSA).
+# Multi-line body collapsed before the bare API-key rule scans it. CERTIFICATE
+# blocks are public material — not matched.
 _PEM_KEY_PATTERN = re.compile(
-    r"-----BEGIN (?:RSA )?PRIVATE KEY-----.*?-----END (?:RSA )?PRIVATE KEY-----",
+    r"-----BEGIN (?:RSA |EC |DSA |OPENSSH |ENCRYPTED )?PRIVATE KEY-----"
+    r".*?-----END (?:RSA |EC |DSA |OPENSSH |ENCRYPTED )?PRIVATE KEY-----",
     re.DOTALL,
 )
 # Match env-var assignment where one of the underscore-separated SEGMENTS of

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -119,9 +119,12 @@ _USERNAME_PATH_PATTERN = re.compile(r"(/Users/|/home/|[A-Z]:\\Users\\)([^/\\\s]+
 # PEM private-key blocks (PKCS1/RSA, PKCS8, ENCRYPTED, OPENSSH, EC, DSA).
 # Multi-line body collapsed before the bare API-key rule scans it. CERTIFICATE
 # blocks are public material — not matched.
+# The header fragment is shared (imported) by the benchmark's buffering
+# anchors, so a variant addition needs one edit here, not four.
+_PEM_HEADER = r"(?:RSA |EC |DSA |OPENSSH |ENCRYPTED )?PRIVATE KEY"
 _PEM_KEY_PATTERN = re.compile(
-    r"-----BEGIN (?:RSA |EC |DSA |OPENSSH |ENCRYPTED )?PRIVATE KEY-----"
-    r".*?-----END (?:RSA |EC |DSA |OPENSSH |ENCRYPTED )?PRIVATE KEY-----",
+    rf"-----BEGIN {_PEM_HEADER}-----"
+    rf".*?-----END {_PEM_HEADER}-----",
     re.DOTALL,
 )
 # Match env-var assignment where one of the underscore-separated SEGMENTS of

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -127,6 +127,9 @@ _PEM_KEY_PATTERN = re.compile(
     rf".*?-----END {_PEM_HEADER}-----",
     re.DOTALL,
 )
+#: Replacement marker for PEM private-key blocks. Shared (imported) by the
+#: benchmark's buffering anchors so every redaction site emits one marker.
+_PEM_KEY_REDACTED_MARKER = "[REDACTED_PEM_KEY]"
 # Match env-var assignment where one of the underscore-separated SEGMENTS of
 # the var name is a secret keyword. Substring matching (the original) over-
 # redacted MONKEY_PATCH/KEYBOARD_LAYOUT/AUTHOR/TOKENIZED — segment-aware
@@ -140,7 +143,7 @@ _ENV_VAR_PATTERN = re.compile(
 )
 _REDACTION_RULES: tuple[tuple[Any, str], ...] = (
     (_URL_CREDENTIAL_PATTERN, r"\1[REDACTED_USER]:[REDACTED_API_KEY]@"),
-    (_PEM_KEY_PATTERN, "[REDACTED_PEM_KEY]"),
+    (_PEM_KEY_PATTERN, _PEM_KEY_REDACTED_MARKER),
     (_ENV_VAR_PATTERN, r"\1=[REDACTED_ENV_VAR]"),
     (_API_KEY_PATTERN, "[REDACTED_API_KEY]"),
     (_JWT_PATTERN, "[REDACTED_JWT]"),

--- a/tests/test_benchmark_daydream_run.py
+++ b/tests/test_benchmark_daydream_run.py
@@ -217,20 +217,47 @@ def test_streams_lines_and_keeps_tail_on_failure(tmp_path, monkeypatch):
     assert "[REDACTED_API_KEY]" in str(e.value)
 
 
-def test_streamed_failure_redacts_pem_block_spanning_lines(tmp_path, monkeypatch):
+@pytest.mark.parametrize(
+    ("begin_line", "end_line", "body"),
+    [
+        (
+            "-----BEGIN RSA PRIVATE KEY-----\n",
+            "-----END RSA PRIVATE KEY-----\n",
+            "PRIVATEKEYMATERIAL" * 20,
+        ),
+        ("-----BEGIN PRIVATE KEY-----\n", "-----END PRIVATE KEY-----\n", "PKCS8KEYMATERIAL" * 20),
+        (
+            "-----BEGIN ENCRYPTED PRIVATE KEY-----\n",
+            "-----END ENCRYPTED PRIVATE KEY-----\n",
+            "ENCRYPTEDKEYMATERIAL" * 20,
+        ),
+        (
+            "-----BEGIN OPENSSH PRIVATE KEY-----\n",
+            "-----END OPENSSH PRIVATE KEY-----\n",
+            "OPENSSHKEYMATERIAL" * 20,
+        ),
+        ("-----BEGIN EC PRIVATE KEY-----\n", "-----END EC PRIVATE KEY-----\n", "ECKEYMATERIAL" * 20),
+        ("-----BEGIN DSA PRIVATE KEY-----\n", "-----END DSA PRIVATE KEY-----\n", "DSAKEYMATERIAL" * 20),
+    ],
+    ids=["pkcs1", "pkcs8", "encrypted", "openssh", "ec", "dsa"],
+)
+def test_streamed_failure_redacts_pem_block_spanning_lines(
+    tmp_path, monkeypatch, begin_line: str, end_line: str, body: str
+):
     """A PEM block split across streamed lines (BEGIN/body/END on separate
     lines) must still be redacted whole before reaching on_line and the failure
     tail — per-line redaction would never present BEGIN and END together, so
-    the base64 body would leak raw."""
+    the base64 body would leak raw. Parametrized over every variant the
+    buffering anchors recognize, so EC/DSA/ENCRYPTED/PKCS8 blocks get the same
+    streamed coverage as RSA/OPENSSH."""
     lines: list[str] = []
-    body = "PRIVATEKEYMATERIAL" * 20
 
     class FakeProc:
         def __init__(self):
             self.stdout = iter([
-                "-----BEGIN RSA PRIVATE KEY-----\n",
+                begin_line,
                 body + "\n",
-                "-----END RSA PRIVATE KEY-----\n",
+                end_line,
             ])
             self.returncode = 1
 
@@ -254,11 +281,11 @@ def test_streamed_failure_redacts_pem_block_spanning_lines(tmp_path, monkeypatch
     assert "[REDACTED_PEM_KEY]" in str(e.value)
 
 
-def test_streamed_failure_redacts_openssh_pem_block_spanning_lines(tmp_path, monkeypatch):
-    """An OPENSSH PEM block split across streamed lines (BEGIN/body/END on
-    separate lines) must also be buffered and redacted whole before reaching
-    on_line and the failure tail — the BEGIN anchor must recognize the
-    OPENSSH variant or the base64 body leaks raw."""
+def test_streamed_failure_redacts_pem_block_truncated_at_eof(tmp_path, monkeypatch):
+    """A stream that ends mid-PEM-block (BEGIN/body seen, END never arrives)
+    must still redact the held fragment before it reaches on_line and the
+    failure tail — per-line redaction could never match _PEM_KEY_PATTERN's
+    BEGIN+END anchors, so the buffered fragment must be redacted whole."""
     lines: list[str] = []
     body = "OPENSSHKEYMATERIAL" * 20
 
@@ -267,7 +294,6 @@ def test_streamed_failure_redacts_openssh_pem_block_spanning_lines(tmp_path, mon
             self.stdout = iter([
                 "-----BEGIN OPENSSH PRIVATE KEY-----\n",
                 body + "\n",
-                "-----END OPENSSH PRIVATE KEY-----\n",
             ])
             self.returncode = 1
 
@@ -285,9 +311,9 @@ def test_streamed_failure_redacts_openssh_pem_block_spanning_lines(tmp_path, mon
     checkout.mkdir()
     with pytest.raises(DaydreamRunError) as e:
         run_daydream_review(checkout, base_sha="d" * 40, trajectory_path=tmp_path / "t.json", on_line=lines.append)
-    assert body not in "".join(lines)   # live echo carries no raw OPENSSH body
+    assert body not in "".join(lines)   # live echo carries no raw PEM body
     assert "[REDACTED_PEM_KEY]" in "".join(lines)
-    assert body not in str(e.value)     # retained tail carries no raw body
+    assert body not in str(e.value)     # retained tail carries no raw PEM body
     assert "[REDACTED_PEM_KEY]" in str(e.value)
 
 

--- a/tests/test_benchmark_daydream_run.py
+++ b/tests/test_benchmark_daydream_run.py
@@ -17,6 +17,7 @@ from daydream.benchmark.daydream_run import (
     _review_complete,
     run_daydream_review,
 )
+from daydream.trajectory import _PEM_KEY_REDACTED_MARKER
 
 # A real `PiError: terminated` Backend-Execution-Error panel as captured in
 # daydream's stdout when the z.ai/GLM provider drops the streaming connection.
@@ -276,9 +277,9 @@ def test_streamed_failure_redacts_pem_block_spanning_lines(
     with pytest.raises(DaydreamRunError) as e:
         run_daydream_review(checkout, base_sha="d" * 40, trajectory_path=tmp_path / "t.json", on_line=lines.append)
     assert body not in "".join(lines)   # live echo carries no raw PEM body
-    assert "[REDACTED_PEM_KEY]" in "".join(lines)
+    assert _PEM_KEY_REDACTED_MARKER in "".join(lines)
     assert body not in str(e.value)     # retained tail carries no raw PEM body
-    assert "[REDACTED_PEM_KEY]" in str(e.value)
+    assert _PEM_KEY_REDACTED_MARKER in str(e.value)
 
 
 def test_streamed_failure_redacts_pem_block_truncated_at_eof(tmp_path, monkeypatch):
@@ -312,9 +313,71 @@ def test_streamed_failure_redacts_pem_block_truncated_at_eof(tmp_path, monkeypat
     with pytest.raises(DaydreamRunError) as e:
         run_daydream_review(checkout, base_sha="d" * 40, trajectory_path=tmp_path / "t.json", on_line=lines.append)
     assert body not in "".join(lines)   # live echo carries no raw PEM body
-    assert "[REDACTED_PEM_KEY]" in "".join(lines)
+    assert _PEM_KEY_REDACTED_MARKER in "".join(lines)
     assert body not in str(e.value)     # retained tail carries no raw PEM body
-    assert "[REDACTED_PEM_KEY]" in str(e.value)
+    assert _PEM_KEY_REDACTED_MARKER in str(e.value)
+
+
+def test_streamed_certificate_block_is_not_buffered(tmp_path, monkeypatch):
+    """A CERTIFICATE block (public material, not matched by the six-variant
+    _PEM_HEADER spec) must NOT be treated as handled by the streamed buffering:
+    every line passes through on_line individually and unredacted, and the
+    failure tail carries the raw body — buffering is anchored to what
+    _PEM_KEY_PATTERN can redact, nothing more."""
+    lines: list[str] = []
+    body = "CERTIFICATEBODY" * 20
+
+    class FakeProc:
+        def __init__(self):
+            self.stdout = iter([
+                "-----BEGIN CERTIFICATE-----\n",
+                body + "\n",
+                "-----END CERTIFICATE-----\n",
+            ])
+            self.returncode = 1
+
+        def wait(self, timeout=None):
+            return 1
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr("daydream.benchmark.daydream_run.subprocess.Popen", lambda *a, **k: FakeProc())
+    checkout = tmp_path / "co"
+    checkout.mkdir()
+    with pytest.raises(DaydreamRunError) as e:
+        run_daydream_review(checkout, base_sha="d" * 40, trajectory_path=tmp_path / "t.json", on_line=lines.append)
+    # Emitted line-by-line, never buffered or collapsed: public material.
+    assert lines == [
+        "-----BEGIN CERTIFICATE-----\n",
+        body + "\n",
+        "-----END CERTIFICATE-----\n",
+    ]
+    assert _PEM_KEY_REDACTED_MARKER not in "".join(lines)
+    assert body in str(e.value)  # failure tail carries the raw cert body
+
+
+def test_captured_failure_redacts_pem_block_truncated_at_eof(tmp_path, monkeypatch):
+    """A captured stream that ends mid-PEM-block (BEGIN+body, no END anchor)
+    must not leak the truncated body to the failure tail — _PEM_KEY_PATTERN
+    needs both anchors, so the trailing fragment is collapsed by the same
+    fragment rule the streamed path's EOF flush uses."""
+    body = "PKCS8KEYMATERIAL" * 20
+    combined = "-----BEGIN PRIVATE KEY-----\n" + body  # BEGIN+body, no END
+    monkeypatch.setattr(
+        "daydream.benchmark.daydream_run.subprocess.run",
+        lambda *a, **k: SimpleNamespace(returncode=1, stdout=combined, stderr=""),
+    )
+    checkout = tmp_path / "co"
+    checkout.mkdir()
+    with pytest.raises(DaydreamRunError) as e:
+        run_daydream_review(checkout, base_sha="d" * 40, trajectory_path=tmp_path / "t.json")
+    tail = str(e.value)
+    assert body not in tail
+    assert _PEM_KEY_REDACTED_MARKER in tail
 
 
 def test_captured_failure_redacts_before_tail_truncation(tmp_path, monkeypatch):
@@ -339,7 +402,7 @@ def test_captured_failure_redacts_before_tail_truncation(tmp_path, monkeypatch):
     tail = str(e.value)
     assert "PRIVATEKEYMATERIAL" not in tail
     assert "-----END RSA PRIVATE KEY-----" not in tail
-    assert "[REDACTED_PEM_KEY]" in tail
+    assert _PEM_KEY_REDACTED_MARKER in tail
 
 
 def test_streamed_timeout_kills_quiet_child_holding_stdout_open(tmp_path, monkeypatch):

--- a/tests/test_benchmark_daydream_run.py
+++ b/tests/test_benchmark_daydream_run.py
@@ -254,6 +254,43 @@ def test_streamed_failure_redacts_pem_block_spanning_lines(tmp_path, monkeypatch
     assert "[REDACTED_PEM_KEY]" in str(e.value)
 
 
+def test_streamed_failure_redacts_openssh_pem_block_spanning_lines(tmp_path, monkeypatch):
+    """An OPENSSH PEM block split across streamed lines (BEGIN/body/END on
+    separate lines) must also be buffered and redacted whole before reaching
+    on_line and the failure tail — the BEGIN anchor must recognize the
+    OPENSSH variant or the base64 body leaks raw."""
+    lines: list[str] = []
+    body = "OPENSSHKEYMATERIAL" * 20
+
+    class FakeProc:
+        def __init__(self):
+            self.stdout = iter([
+                "-----BEGIN OPENSSH PRIVATE KEY-----\n",
+                body + "\n",
+                "-----END OPENSSH PRIVATE KEY-----\n",
+            ])
+            self.returncode = 1
+
+        def wait(self, timeout=None):
+            return 1
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr("daydream.benchmark.daydream_run.subprocess.Popen", lambda *a, **k: FakeProc())
+    checkout = tmp_path / "co"
+    checkout.mkdir()
+    with pytest.raises(DaydreamRunError) as e:
+        run_daydream_review(checkout, base_sha="d" * 40, trajectory_path=tmp_path / "t.json", on_line=lines.append)
+    assert body not in "".join(lines)   # live echo carries no raw OPENSSH body
+    assert "[REDACTED_PEM_KEY]" in "".join(lines)
+    assert body not in str(e.value)     # retained tail carries no raw body
+    assert "[REDACTED_PEM_KEY]" in str(e.value)
+
+
 def test_captured_failure_redacts_before_tail_truncation(tmp_path, monkeypatch):
     """A PEM block whose tail would be sliced off mid-block must still be fully
     redacted before the _STDERR_TAIL cut — redact-after-slice would leave the

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -8,10 +8,13 @@ REDA-05 fail-safe.
 
 from __future__ import annotations
 
+import copy
+import json
+
 import pytest
 
 from daydream.atif import ContentPart, Observation, ObservationResult, Step, ToolCall
-from daydream.trajectory import Redactor, now_iso
+from daydream.trajectory import Redactor, now_iso, redact_value
 
 
 def _user_step(message: str) -> Step:
@@ -524,3 +527,26 @@ def test_redactor_preserves_certificate_block() -> None:
     assert isinstance(out.message, str)
     assert "[REDACTED_PEM_KEY]" not in out.message
     assert "BEGIN CERTIFICATE" in out.message
+
+
+def test_redact_value_recurses_redacts_keys_and_values_without_mutating() -> None:
+    """redact_value redacts string leaves AND string dict keys recursively, in
+    fresh containers, and never mutates its argument."""
+    sentinel = "ghp_" + "x" * 16
+    payload = {
+        "token": sentinel,
+        sentinel: "key-secret",
+        "nested": {"path": f"/Users/{sentinel}"},
+        "items": [sentinel, 42, None],
+        "flag": True,
+        1: "non-string-key",
+    }
+    original = copy.deepcopy(payload)
+    out = redact_value(payload)
+
+    assert payload == original                      # never mutates the argument
+    assert out is not payload and out["nested"] is not payload["nested"]  # fresh containers
+    assert sentinel not in json.dumps(out)          # redacted in values AND keys
+    assert "[REDACTED" in json.dumps(out)           # a marker replaced it
+    assert out["items"] == ["[REDACTED_API_KEY]", 42, None]  # scalars preserved
+    assert out["flag"] is True and out[1] == "non-string-key"  # non-string keys untouched

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -489,7 +489,7 @@ _DSA_PEM = (
     ids=["pkcs1", "pkcs8", "encrypted", "openssh", "ec", "dsa"],
 )
 def test_redactor_scrubs_private_key_block(pem: str, body: str) -> None:
-    """-----BEGIN (RSA )PRIVATE KEY----- blocks replaced with [REDACTED_PEM_KEY]."""
+    """PEM private-key blocks (PKCS1/RSA, PKCS8, ENCRYPTED, OPENSSH, EC, DSA) replaced with [REDACTED_PEM_KEY]."""
     out = Redactor().redact_step(_user_step(f"key is {pem} ok"))
     assert isinstance(out.message, str)
     assert body not in out.message

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -451,12 +451,39 @@ _PKCS8_PEM = (
     "MIIEvgIBADANBgkqhkiG9w0BAQEFAASC\n"
     "-----END PRIVATE KEY-----"
 )
+_ENCRYPTED_PEM = (
+    "-----BEGIN ENCRYPTED PRIVATE KEY-----\n"
+    "MIIFCTBHBgkqhkiG9w0BBQ0wOjANBglghkgBZQMEAwEFENCRYPTEDKEYBODY\n"
+    "-----END ENCRYPTED PRIVATE KEY-----"
+)
+_OPENSSH_PEM = (
+    "-----BEGIN OPENSSH PRIVATE KEY-----\n"
+    "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAEAAABlOPENSSHKEYBODY\n"
+    "-----END OPENSSH PRIVATE KEY-----"
+)
+_EC_PEM = (
+    "-----BEGIN EC PRIVATE KEY-----\n"
+    "MHcCAQEEIBF8XZQ6ECKEYBODYwJ5fWx8+1FcQ2rY=\n"
+    "-----END EC PRIVATE KEY-----"
+)
+_DSA_PEM = (
+    "-----BEGIN DSA PRIVATE KEY-----\n"
+    "MIH3AgEAAkEA8qWq6Q2DSAKEYBODYB5QhJ9zQ2nLr3U=\n"
+    "-----END DSA PRIVATE KEY-----"
+)
 
 
 @pytest.mark.parametrize(
     ("pem", "body"),
-    [(_PKCS1_PEM, "MIIEpAIBAAKCAQEA0Z3VS5JJcds3xfn"), (_PKCS8_PEM, "MIIEvgIBADANBgkqhkiG9w0BAQEFAASC")],
-    ids=["pkcs1", "pkcs8"],
+    [
+        (_PKCS1_PEM, "MIIEpAIBAAKCAQEA0Z3VS5JJcds3xfn"),
+        (_PKCS8_PEM, "MIIEvgIBADANBgkqhkiG9w0BAQEFAASC"),
+        (_ENCRYPTED_PEM, "ENCRYPTEDKEYBODY"),
+        (_OPENSSH_PEM, "OPENSSHKEYBODY"),
+        (_EC_PEM, "ECKEYBODY"),
+        (_DSA_PEM, "DSAKEYBODY"),
+    ],
+    ids=["pkcs1", "pkcs8", "encrypted", "openssh", "ec", "dsa"],
 )
 def test_redactor_scrubs_private_key_block(pem: str, body: str) -> None:
     """-----BEGIN (RSA )PRIVATE KEY----- blocks replaced with [REDACTED_PEM_KEY]."""
@@ -468,8 +495,15 @@ def test_redactor_scrubs_private_key_block(pem: str, body: str) -> None:
 
 @pytest.mark.parametrize(
     ("pem", "body"),
-    [(_PKCS1_PEM, "MIIEpAIBAAKCAQEA0Z3VS5JJcds3xfn"), (_PKCS8_PEM, "MIIEvgIBADANBgkqhkiG9w0BAQEFAASC")],
-    ids=["pkcs1", "pkcs8"],
+    [
+        (_PKCS1_PEM, "MIIEpAIBAAKCAQEA0Z3VS5JJcds3xfn"),
+        (_PKCS8_PEM, "MIIEvgIBADANBgkqhkiG9w0BAQEFAASC"),
+        (_ENCRYPTED_PEM, "ENCRYPTEDKEYBODY"),
+        (_OPENSSH_PEM, "OPENSSHKEYBODY"),
+        (_EC_PEM, "ECKEYBODY"),
+        (_DSA_PEM, "DSAKEYBODY"),
+    ],
+    ids=["pkcs1", "pkcs8", "encrypted", "openssh", "ec", "dsa"],
 )
 def test_redactor_scrubs_private_key_in_env_assignment(pem: str, body: str) -> None:
     """VAR=<PEM> redacts fully — PEM rule must run before the env-var rule, no base64 body survives."""

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -475,18 +475,23 @@ _DSA_PEM = (
     "-----END DSA PRIVATE KEY-----"
 )
 
+# Shared by the block and env-assignment redaction tests — one spec for the six
+# PEM variants so the parametrize lists cannot drift out of sync.
+_PEM_KEY_CASES: list[tuple[str, str]] = [
+    (_PKCS1_PEM, "MIIEpAIBAAKCAQEA0Z3VS5JJcds3xfn"),
+    (_PKCS8_PEM, "MIIEvgIBADANBgkqhkiG9w0BAQEFAASC"),
+    (_ENCRYPTED_PEM, "ENCRYPTEDKEYBODY"),
+    (_OPENSSH_PEM, "OPENSSHKEYBODY"),
+    (_EC_PEM, "ECKEYBODY"),
+    (_DSA_PEM, "DSAKEYBODY"),
+]
+_PEM_KEY_IDS = ["pkcs1", "pkcs8", "encrypted", "openssh", "ec", "dsa"]
+
 
 @pytest.mark.parametrize(
     ("pem", "body"),
-    [
-        (_PKCS1_PEM, "MIIEpAIBAAKCAQEA0Z3VS5JJcds3xfn"),
-        (_PKCS8_PEM, "MIIEvgIBADANBgkqhkiG9w0BAQEFAASC"),
-        (_ENCRYPTED_PEM, "ENCRYPTEDKEYBODY"),
-        (_OPENSSH_PEM, "OPENSSHKEYBODY"),
-        (_EC_PEM, "ECKEYBODY"),
-        (_DSA_PEM, "DSAKEYBODY"),
-    ],
-    ids=["pkcs1", "pkcs8", "encrypted", "openssh", "ec", "dsa"],
+    _PEM_KEY_CASES,
+    ids=_PEM_KEY_IDS,
 )
 def test_redactor_scrubs_private_key_block(pem: str, body: str) -> None:
     """PEM private-key blocks (PKCS1/RSA, PKCS8, ENCRYPTED, OPENSSH, EC, DSA) replaced with [REDACTED_PEM_KEY]."""
@@ -496,18 +501,7 @@ def test_redactor_scrubs_private_key_block(pem: str, body: str) -> None:
     assert "[REDACTED_PEM_KEY]" in out.message
 
 
-@pytest.mark.parametrize(
-    ("pem", "body"),
-    [
-        (_PKCS1_PEM, "MIIEpAIBAAKCAQEA0Z3VS5JJcds3xfn"),
-        (_PKCS8_PEM, "MIIEvgIBADANBgkqhkiG9w0BAQEFAASC"),
-        (_ENCRYPTED_PEM, "ENCRYPTEDKEYBODY"),
-        (_OPENSSH_PEM, "OPENSSHKEYBODY"),
-        (_EC_PEM, "ECKEYBODY"),
-        (_DSA_PEM, "DSAKEYBODY"),
-    ],
-    ids=["pkcs1", "pkcs8", "encrypted", "openssh", "ec", "dsa"],
-)
+@pytest.mark.parametrize(("pem", "body"), _PEM_KEY_CASES, ids=_PEM_KEY_IDS)
 def test_redactor_scrubs_private_key_in_env_assignment(pem: str, body: str) -> None:
     """VAR=<PEM> redacts fully — PEM rule must run before the env-var rule, no base64 body survives."""
     out = Redactor().redact_step(_user_step(f"DAYDREAM_APP_PRIVATE_KEY={pem}"))


### PR DESCRIPTION
Consolidates out-of-scope findings in `daydream/trajectory.py` (PEM redaction variants, redact_value helper).

Two sequential daydream deep-precision reviews (rounds 1 & 2) on fresh exe.dev VMs passed; full `make check` green (3407 passed, 0 failures).

## Changes
- Broaden PEM key redaction pattern to all six header variants
- Buffer all six PEM key variants for whole-block redaction
- Redact PEM key fragments when stream dies mid-block
- Redact truncated PEM keys in captured benchmark tail
- Pin redact_value recursion contract directly

Closes #561