### PR TITLE
[daydream] #566 Consolidate out-of-scope findings in daydream/improve/ (command_contract abs paths, shared prune)

### DIFF
--- a/daydream/benchmark/anthropic_score.py
+++ b/daydream/benchmark/anthropic_score.py
@@ -685,24 +685,32 @@ async def run_bounded(
     """
     semaphore = asyncio.Semaphore(_JUDGE_CONCURRENCY)
 
-    async def _bounded(call: Callable[[], Awaitable[Any]]) -> Any:
-        async with semaphore:
-            return await call()
+    async def _bounded(meta: Any, call: Callable[[], Awaitable[Any]]) -> tuple[Any, Any]:
+        # The slot is held until the run loop has delivered the result to ``handle``.
+        # Releasing at call-completion would let a finished-but-unhandled success
+        # admit a waiting job in the window before a failure is observed, so a
+        # fail-fast abort could still start extra paid calls under load.
+        await semaphore.acquire()
+        try:
+            result: Any = await call()
+        except asyncio.CancelledError:
+            raise
+        except BaseException as exc:
+            result = exc
+        return meta, result
 
-    tasks = [asyncio.create_task(_bounded(call)) for _, call in jobs]
-    metas = [meta for meta, _ in jobs]
-    task_index = {task: i for i, task in enumerate(tasks)}
+    tasks = [asyncio.create_task(_bounded(meta, call)) for meta, call in jobs]
     pending = set(tasks)
     try:
         while pending:
             done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
-            for task in done:
-                index = task_index[task]
-                try:
-                    result = task.result()
-                except BaseException as exc:
-                    result = exc
-                handle(metas[index], result)
+            # Failures first within one completion batch: a fail-fast abort must
+            # cancel the waiting jobs before a success below frees its slot.
+            batch = [(task, *task.result()) for task in done]
+            batch.sort(key=lambda item: 0 if isinstance(item[2], BaseException) else 1)
+            for _, meta, result in batch:
+                handle(meta, result)  # raising aborts: no slot is freed, pending jobs are cancelled
+                semaphore.release()
     except BaseException:
         for task in pending:
             task.cancel()

--- a/daydream/improve/command_contract.py
+++ b/daydream/improve/command_contract.py
@@ -36,7 +36,7 @@ WORKING_DIRECTORY_SCHEMA: dict[str, Any] = {
     "type": "string",
     "minLength": 1,
     "maxLength": 512,
-    "pattern": rf"^(?:\.|{REPOSITORY_FILE_PATH_PATTERN[1:-1]})$",
+    "pattern": rf"^(?:\.|{REPOSITORY_FILE_PATH_PATTERN[1:-1]}|/{REPOSITORY_FILE_PATH_PATTERN[1:-1]})$",
 }
 LINE_ANCHOR_SCHEMA: dict[str, Any] = {
     "type": "object",

--- a/daydream/improve/command_contract.py
+++ b/daydream/improve/command_contract.py
@@ -224,6 +224,34 @@ def valid_directory_scope_lexical(value: str) -> bool:
     return bool(_DIRECTORY_SCOPE.fullmatch(value))
 
 
+def _strip_prefix(
+    parts: tuple[str, ...], base: tuple[str, ...]
+) -> tuple[str, ...] | None:
+    """Return ``parts`` with a leading ``base`` removed, else None."""
+    if parts[: len(base)] == base:
+        return parts[len(base) :]
+    return None
+
+
+def _walk_components(candidate: Path, parts: Sequence[str]) -> Path | None:
+    """Return ``candidate`` advanced through ``parts``, or None on a crossing.
+
+    Stops at the first component that does not exist (the containment check
+    below settles it). None when a component is a symlink or cannot be
+    inspected — both are treated as an escape.
+    """
+    for part in parts:
+        candidate /= part
+        try:
+            if candidate.is_symlink():
+                return None
+            if not candidate.exists():
+                break
+        except OSError:
+            return None
+    return candidate
+
+
 def path_is_confined(
     repo: Path,
     value: str,
@@ -267,22 +295,17 @@ def path_is_confined(
             # are adjudicated by the containment check below; walk only the
             # components at or below the repo root, exactly like the relative
             # form does.
-            base = PurePosixPath(repo).parts
-            if parts[: len(base)] == base:
-                parts = parts[len(base) :]
-            else:
-                resolved_base = PurePosixPath(str(root)).parts
-                if parts[: len(resolved_base)] == resolved_base:
-                    parts = parts[len(resolved_base) :]
-        for part in parts:
-            candidate /= part
-            try:
-                if candidate.is_symlink():
-                    return False
-                if not candidate.exists():
-                    break
-            except OSError:
-                return False
+            stripped = _strip_prefix(parts, PurePosixPath(repo).parts)
+            if stripped is None:
+                stripped = _strip_prefix(
+                    parts, PurePosixPath(str(root)).parts
+                )
+            if stripped is not None:
+                parts = stripped
+        walked = _walk_components(candidate, parts)
+        if walked is None:
+            return False
+        candidate = walked
     try:
         return candidate.resolve(strict=False).is_relative_to(root)
     except OSError:

--- a/daydream/improve/command_contract.py
+++ b/daydream/improve/command_contract.py
@@ -234,10 +234,14 @@ def path_is_confined(
     """Return whether a repository path crosses no symlink/root edge.
 
     When ``allow_absolute`` is set and ``value`` starts with ``"/"``, the
-    relative-lexical gate is skipped and the confinement loop alone decides
-    (it already resolves absolute paths against the repo root). Relative
-    paths and the default ``allow_absolute=False`` keep today's exact
-    behavior.
+    relative-lexical gate is skipped and the confinement loop alone decides:
+    it walks the components at or below the repo root and settles containment
+    with the final ``is_relative_to`` check against the resolved repo root.
+    Components above the repo root are deliberately not symlink-tested — a
+    symlinked ancestor of the repo (e.g. ``/tmp`` on macOS) would otherwise
+    reject the absolute spelling of a path the identical relative spelling
+    accepts, and skipping that test cannot escape containment. Relative paths
+    and the default ``allow_absolute=False`` keep today's exact behavior.
     """
     validator = (
         valid_directory_scope_lexical
@@ -253,7 +257,24 @@ def path_is_confined(
     root = repo.resolve()
     candidate = repo
     if value != ".":
-        for part in PurePosixPath(value.rstrip("/")).parts:
+        parts = PurePosixPath(value.rstrip("/")).parts
+        if allow_absolute and value.startswith("/"):
+            # PurePosixPath.parts begins with "/", so a bare component-wise
+            # division would reset candidate to the filesystem root and
+            # re-descend the repo's own ancestors — symlink-testing each one
+            # and rejecting the absolute spelling of an in-repo path whenever
+            # an ancestor is a symlink (e.g. /tmp -> /private/tmp). Ancestors
+            # are adjudicated by the containment check below; walk only the
+            # components at or below the repo root, exactly like the relative
+            # form does.
+            base = PurePosixPath(repo).parts
+            if parts[: len(base)] == base:
+                parts = parts[len(base) :]
+            else:
+                resolved_base = PurePosixPath(str(root)).parts
+                if parts[: len(resolved_base)] == resolved_base:
+                    parts = parts[len(resolved_base) :]
+        for part in parts:
             candidate /= part
             try:
                 if candidate.is_symlink():

--- a/daydream/improve/command_contract.py
+++ b/daydream/improve/command_contract.py
@@ -229,14 +229,26 @@ def path_is_confined(
     value: str,
     *,
     directory_scope: bool = False,
+    allow_absolute: bool = False,
 ) -> bool:
-    """Return whether a lexical repository path crosses no symlink/root edge."""
+    """Return whether a repository path crosses no symlink/root edge.
+
+    When ``allow_absolute`` is set and ``value`` starts with ``"/"``, the
+    relative-lexical gate is skipped and the confinement loop alone decides
+    (it already resolves absolute paths against the repo root). Relative
+    paths and the default ``allow_absolute=False`` keep today's exact
+    behavior.
+    """
     validator = (
         valid_directory_scope_lexical
         if directory_scope
         else valid_repository_file_path
     )
-    if value != "." and not validator(value):
+    if (
+        value != "."
+        and not (allow_absolute and value.startswith("/"))
+        and not validator(value)
+    ):
         return False
     root = repo.resolve()
     candidate = repo
@@ -593,12 +605,16 @@ def _validate_command_records(
             )
             continue
         working_directory = command["working_directory"]
+        is_absolute = working_directory.startswith("/")
         if (
             (
                 working_directory != "."
+                and not is_absolute
                 and not valid_repository_file_path(working_directory)
             )
-            or not path_is_confined(repo, working_directory)
+            or not path_is_confined(
+                repo, working_directory, allow_absolute=is_absolute
+            )
             or not (repo / working_directory).is_dir()
         ):
             reject(

--- a/daydream/improve/plans.py
+++ b/daydream/improve/plans.py
@@ -6,7 +6,6 @@ import hashlib
 import json
 import re
 import subprocess
-import time
 from collections import Counter
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, replace
@@ -23,6 +22,7 @@ from daydream.improve.render import (
     render_plan,
 )
 from daydream.trajectory import redact_text
+from daydream.workspace import _prune_stale_locked_worktrees
 
 REJECTIONS_SCHEMA_VERSION = 1
 PLAN_WRITE_DIAGNOSTICS_SCHEMA_VERSION = 1
@@ -708,30 +708,17 @@ def prune_stale_reanchor_worktrees(repo: Path) -> int:
     the directory does not grow unboundedly. Individual failures are tolerated
     so one stale worktree never blocks a plan run.
 
-    The prune is lock-aware: a live re-anchor worktree (locked at creation, age
-    near zero) is skipped without any removal attempt, so a concurrent run
-    mid-write is never destroyed. A worktree whose lock is older than
-    ``_REANCHOR_LOCK_STALE_AFTER_S`` is a crashed session's leftover: it is
-    reclaimed via ``git_ops.worktree_remove_unlocked`` (unlock, then
-    force-remove) rather than wedged forever. Unlocked worktrees are removed
-    the same way, the unlock being a no-op for them.
+    The prune is lock-aware and delegates its policy to
+    :func:`daydream.workspace._prune_stale_locked_worktrees` — the same shared
+    body the audit prune uses — so the staleness window, live-lock skip rule,
+    and unlock-before-remove ordering live in one place and cannot silently
+    drift between the two modules.
     """
-    removed = 0
-    for path in _iter_reanchor_worktrees(repo):
-        try:
-            locked_at = git_ops.worktree_lock_mtime(repo, path)
-            if (
-                locked_at is not None
-                and time.time() - locked_at <= _REANCHOR_LOCK_STALE_AFTER_S
-            ):
-                # Live re-anchor worktree (lock age near zero): never unlock or
-                # remove it, so a concurrent run mid-write is not destroyed.
-                continue
-            git_ops.worktree_remove_unlocked(repo, path)
-        except git_ops.GitError:
-            continue
-        removed += 1
-    return removed
+    return _prune_stale_locked_worktrees(
+        repo,
+        _iter_reanchor_worktrees(repo),
+        stale_after_s=_REANCHOR_LOCK_STALE_AFTER_S,
+    )
 
 
 # Verdicts for a named prune of a single re-anchor worktree. Distinct outcomes

--- a/tests/test_command_contract.py
+++ b/tests/test_command_contract.py
@@ -141,6 +141,50 @@ def test_path_is_confined_allow_absolute(tmp_path: Path) -> None:
     assert not path_is_confined(repo, abs_under)
 
 
+def test_path_is_confined_allow_absolute_symlinked_ancestor(
+    tmp_path: Path,
+) -> None:
+    """A symlinked ancestor of the repo must not reject the absolute spelling.
+
+    Regression pin for the macOS ``/tmp`` -> ``/private/tmp`` case: with
+    ``allow_absolute=True`` the ancestor-skip strips the repo-root prefix from
+    the walk, so an absolute value spelled through a symlinked ancestor of the
+    repo is accepted exactly like the identical relative spelling.
+    """
+    real = tmp_path / "real"
+    (real / "repo" / "improve").mkdir(parents=True)
+    alias = tmp_path / "alias"
+    alias.symlink_to(real, target_is_directory=True)
+    repo = alias / "repo"
+    abs_under = (repo / "improve").as_posix()
+    assert path_is_confined(repo, abs_under, allow_absolute=True)
+    # Baseline: the identical relative spelling is confined either way.
+    assert path_is_confined(repo, "improve")
+    # The resolved spelling of the same path is confined too.
+    assert path_is_confined(repo, (real / "repo" / "improve").as_posix(), allow_absolute=True)
+
+
+def test_path_is_confined_allow_absolute_cannot_escape_via_ancestor_skip(
+    tmp_path: Path,
+) -> None:
+    """The ancestor-skip must not enable a symlink escape from containment.
+
+    Regression pin for the claim that skipping symlink tests on components
+    above the repo root cannot escape containment: a symlink at or below the
+    repo root that points outside the repo is still rejected even with
+    ``allow_absolute=True``.
+    """
+    repo = tmp_path / "repo"
+    (repo / "improve").mkdir(parents=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (repo / "improve" / "escape").symlink_to(outside, target_is_directory=True)
+    abs_escape = (repo / "improve" / "escape").as_posix()
+    assert not path_is_confined(repo, abs_escape, allow_absolute=True)
+    # A direct absolute path to the outside directory is rejected as well.
+    assert not path_is_confined(repo, outside.as_posix(), allow_absolute=True)
+
+
 def _iter_schema_patterns(schema: Any) -> Iterator[str]:
     """Yield the string value of every ``pattern`` key in a schema tree."""
     if isinstance(schema, dict):

--- a/tests/test_command_contract.py
+++ b/tests/test_command_contract.py
@@ -106,7 +106,13 @@ def test_working_directory_accepts_cwd() -> None:
     regex = re.compile(WORKING_DIRECTORY_SCHEMA["pattern"])
     assert regex.match(".")
     assert regex.match("src/main.rs")
-    assert not regex.match("/abs/path")
+    # A well-formed absolute path is lexically acceptable (confinement is
+    # enforced by path_is_confined + the host check, not this pattern).
+    assert regex.match("/abs/path")
+    assert Draft202012Validator(WORKING_DIRECTORY_SCHEMA).is_valid("/abs/path")
+    # Absolute form still requires a non-empty segment after the slash.
+    assert not regex.match("/")
+    assert not regex.match("//double-slash")
 
 
 @pytest.mark.parametrize("value", MULTI_DOT_PATHS)

--- a/tests/test_command_contract.py
+++ b/tests/test_command_contract.py
@@ -128,6 +128,19 @@ def test_multi_dot_paths_are_accepted_by_schemas_and_validators(
     assert path_is_confined(tmp_path, value, directory_scope=True)
 
 
+def test_path_is_confined_allow_absolute(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / "improve").mkdir(parents=True)
+    abs_under = (repo / "improve").as_posix()
+    abs_outside = (repo.parent / "outside").as_posix()
+    # allow_absolute=True: confined absolute accepted, outside rejected.
+    assert path_is_confined(repo, abs_under, allow_absolute=True)
+    assert not path_is_confined(repo, abs_outside, allow_absolute=True)
+    # default (allow_absolute=False) must still reject absolute — this is what
+    # keeps evidence source_path / applicability scope paths unchanged.
+    assert not path_is_confined(repo, abs_under)
+
+
 def _iter_schema_patterns(schema: Any) -> Iterator[str]:
     """Yield the string value of every ``pattern`` key in a schema tree."""
     if isinstance(schema, dict):

--- a/tests/test_improve_plans.py
+++ b/tests/test_improve_plans.py
@@ -189,6 +189,32 @@ def test_recon_validation_retains_valid_siblings_when_one_is_invalid(repo: Path)
     ]
 
 
+def test_recon_working_directory_accepts_confined_absolute_and_rejects_outside(
+    repo: Path, tmp_path: Path
+) -> None:
+    abs_under = (repo / "apps" / "catalog").as_posix()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    abs_outside = outside.as_posix()
+    # Reuse the module's already-valid recon record (valid evidence, Makefile
+    # line 2 anchor) and only override working_directory.
+    base = deepcopy(_recon_commands()[0])
+
+    under = deepcopy(base)
+    under["working_directory"] = abs_under
+    accepted, errors = validate_recon_commands({"commands": [under]}, repo=repo)
+    assert errors == []
+    assert [c["id"] for c in accepted] == ["test-suite"]
+
+    rejected = deepcopy(base)
+    rejected["working_directory"] = abs_outside
+    accepted, errors = validate_recon_commands({"commands": [rejected]}, repo=repo)
+    assert accepted == []
+    assert errors == [
+        "RECON_WORKING_DIRECTORY_INVALID@/commands/0/working_directory"
+    ]
+
+
 @pytest.mark.parametrize(
     "model_excerpt",
     [


### PR DESCRIPTION
Consolidates out-of-scope findings in `daydream/improve/` (command_contract absolute-path validation, shared stale-worktree prune; originals #556, #557).

Two sequential daydream deep-precision reviews (rounds 1 & 2) on fresh exe.dev VMs passed; full test suites green.

## Changes
- `command_contract.py`: accept absolute audit-worktree paths via symlinked repo ancestors; extract `_strip_prefix`/`_walk_components` helpers to reduce `path_is_confined` complexity/duplication; pin symlink-escape rejection
- `plans.py`: delegate `prune_stale_reanchor_worktrees` to the shared stale-locked-worktree prune (dedup staleness window, live-lock skip, unlock-before-remove ordering); drop unused `import time`
- `anthropic_score.py`: fix `run_bounded` semaphore-slot handling to avoid extra paid judge calls under fail-fast load
- Regression tests pinning symlink-ancestor acceptance and escape rejection (36 command_contract + 215 improve_plans + 17 anthropic_score tests pass)

Closes #566
