### PR TITLE
[daydream] #443 Confine model-supplied finding paths before fix-agent dispatch

### DIFF
--- a/daydream/improve/command_contract.py
+++ b/daydream/improve/command_contract.py
@@ -7,31 +7,22 @@ import shlex
 from collections import Counter
 from collections.abc import Sequence
 from dataclasses import dataclass
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from typing import Any
 
 from jsonschema import Draft202012Validator
 
-_PATH_SEGMENT = (
-    r"(?:[A-Za-z0-9_+@$-][A-Za-z0-9._+@$-]*|"
-    r"\.[A-Za-z0-9_+@$-][A-Za-z0-9._+@$-]*|"
-    r"\.\.[A-Za-z0-9._+@$-]+)"
+from daydream.repository_paths import (
+    DIRECTORY_SCOPE_PATTERN,
+    DIRECTORY_SCOPE_SCHEMA,
+    REPOSITORY_FILE_PATH_PATTERN,
+    REPOSITORY_FILE_PATH_SCHEMA,
+    canonicalize_directory_scope,
+    path_is_confined,
+    valid_directory_scope_lexical,
+    valid_repository_file_path,
 )
-REPOSITORY_FILE_PATH_PATTERN = rf"^{_PATH_SEGMENT}(?:/{_PATH_SEGMENT})*$"
-DIRECTORY_SCOPE_PATTERN = rf"^{_PATH_SEGMENT}(?:/{_PATH_SEGMENT})*/?$"
 
-REPOSITORY_FILE_PATH_SCHEMA: dict[str, Any] = {
-    "type": "string",
-    "minLength": 1,
-    "maxLength": 512,
-    "pattern": REPOSITORY_FILE_PATH_PATTERN,
-}
-DIRECTORY_SCOPE_SCHEMA: dict[str, Any] = {
-    "type": "string",
-    "minLength": 1,
-    "maxLength": 512,
-    "pattern": DIRECTORY_SCOPE_PATTERN,
-}
 WORKING_DIRECTORY_SCHEMA: dict[str, Any] = {
     "type": "string",
     "minLength": 1,
@@ -190,8 +181,6 @@ HOST_RECON_COMMAND_SCHEMA: dict[str, Any] = {
     },
 }
 
-_REPOSITORY_FILE_PATH = re.compile(REPOSITORY_FILE_PATH_PATTERN)
-_DIRECTORY_SCOPE = re.compile(DIRECTORY_SCOPE_PATTERN)
 _COMMAND_ARROW = re.compile(
     r"[\u2190-\u21ff\u27f0-\u27ff\u2900-\u297f]|->|=>"
 )
@@ -212,53 +201,6 @@ class ContractRejection:
 
     def render(self, prefix: str) -> str:
         return f"{self.code}@{prefix}{self.pointer}"
-
-
-def valid_repository_file_path(value: str) -> bool:
-    """Return whether ``value`` has the safe repository-file grammar."""
-    return bool(_REPOSITORY_FILE_PATH.fullmatch(value))
-
-
-def valid_directory_scope_lexical(value: str) -> bool:
-    """Return whether ``value`` is a safe file-or-directory scope."""
-    return bool(_DIRECTORY_SCOPE.fullmatch(value))
-
-
-def path_is_confined(
-    repo: Path,
-    value: str,
-    *,
-    directory_scope: bool = False,
-) -> bool:
-    """Return whether a lexical repository path crosses no symlink/root edge."""
-    validator = (
-        valid_directory_scope_lexical
-        if directory_scope
-        else valid_repository_file_path
-    )
-    if value != "." and not validator(value):
-        return False
-    root = repo.resolve()
-    candidate = repo
-    if value != ".":
-        for part in PurePosixPath(value.rstrip("/")).parts:
-            candidate /= part
-            try:
-                if candidate.is_symlink():
-                    return False
-                if not candidate.exists():
-                    break
-            except OSError:
-                return False
-    try:
-        return candidate.resolve(strict=False).is_relative_to(root)
-    except OSError:
-        return False
-
-
-def canonicalize_directory_scope(value: str) -> str:
-    """Canonicalize the sole lossless scope spelling difference."""
-    return value.rstrip("/")
 
 
 def _json_pointer(parts: list[object]) -> str:

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -44,6 +44,12 @@ from daydream.generated_files import (
     related_manifest_paths,
 )
 from daydream.git_ops import BranchNotFoundError, GitError
+from daydream.improve.command_contract import (
+    REPOSITORY_FILE_PATH_SCHEMA as _REPOSITORY_FILE_PATH_SCHEMA,
+)
+from daydream.improve.command_contract import (
+    path_is_confined,
+)
 from daydream.prompt_budget import fits_inline_diff_budget
 from daydream.prompts.authorial_intent import AUTHORITATIVE_INTENT_RULE
 from daydream.prompts.grounding import UNTRUSTED_REPOSITORY_CONTENT_BOUNDARY
@@ -770,7 +776,7 @@ FEEDBACK_SCHEMA: dict[str, Any] = {
                 "properties": {
                     "id": {"type": "integer"},
                     "description": {"type": "string"},
-                    "file": {"type": "string"},
+                    "file": _REPOSITORY_FILE_PATH_SCHEMA,
                     "line": {"type": "integer"},
                     "confidence": {"type": "string", "enum": ["HIGH", "MEDIUM"]},
                     "rationale": {"type": "string"},
@@ -815,7 +821,7 @@ ALTERNATIVE_REVIEW_SCHEMA: dict[str, Any] = {
                     "description": {"type": "string"},
                     "recommendation": {"type": "string"},
                     "severity": {"type": "string", "enum": ["high", "medium", "low"]},
-                    "files": {"type": "array", "items": {"type": "string"}},
+                    "files": {"type": "array", "items": _REPOSITORY_FILE_PATH_SCHEMA},
                     "confidence": {"type": "string", "enum": ["HIGH", "MEDIUM"]},
                     "rationale": {"type": "string"},
                     "evidence": {"type": "string"},
@@ -849,7 +855,7 @@ MERGED_ITEMS_SCHEMA: dict[str, Any] = {
                 "properties": {
                     "id": {"type": "integer"},
                     "description": {"type": "string"},
-                    "file": {"type": "string"},
+                    "file": _REPOSITORY_FILE_PATH_SCHEMA,
                     "line": {"type": "integer"},
                     "confidence": {"type": "string", "enum": ["HIGH", "MEDIUM"]},
                     "rationale": {"type": "string"},

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -2031,6 +2031,15 @@ async def phase_fix_parallel(
         full success.
 
     """
+    # Preflight confinement gate: validate EVERY item's file reference before
+    # grouping, progress, prompt construction, recovery, or dispatch. An
+    # unconfined (or missing/non-string) reference raises ValueError and aborts
+    # the whole run fast, so the unsafe path never becomes a grouping key,
+    # fork name, failures entry, or checkout recovery argument. The returned
+    # refs are discarded -- per-fix calls recompute them.
+    for item in items:
+        _resolve_finding_file_ref(work.repo, item.get("file"))
+
     raw_groups = group_items_by_file(items)
     # Assign stable 1-based counters by pairing each item with its number
     # directly, avoiding fragile id()-keyed dicts whose keys are memory

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -1900,22 +1900,14 @@ async def phase_fix_batched(
         )
         return
 
-    # Items with no file cannot be meaningfully batched under a shared file
-    # header — "<no-file>" is not a real path.  Delegate each one individually
-    # to phase_fix (which already handles the unknown-file case correctly).
-    if not items[0].get("file"):
-        for item, item_num in zip(items, item_nums):
-            await phase_fix(
-                backend, work, item, item_num, total,
-                console_lock=console_lock, intent_path=intent_path,
-                changed_files=changed_files,
-            )
-        return
-
     count = len(items)
-    file_path = items[0].get("file") or "Unknown file"
-    resolved = work.repo / file_path if file_path != "Unknown file" else None
-    file_ref = str(resolved) if resolved is not None and resolved.is_file() else file_path
+    # Validate EVERY item's file reference before any progress output or prompt
+    # construction: a single unconfined (or missing/non-string) reference
+    # rejects the whole batch. All items target the same file, so the first
+    # item's canonical resolution is the group's.
+    file_ref = _resolve_finding_file_ref(work.repo, items[0].get("file"))
+    for item in items[1:]:
+        _resolve_finding_file_ref(work.repo, item.get("file"))
 
     async with (console_lock if console_lock is not None else anyio.Lock()):
         console.print()

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -44,15 +44,15 @@ from daydream.generated_files import (
     related_manifest_paths,
 )
 from daydream.git_ops import BranchNotFoundError, GitError
-from daydream.improve.command_contract import (
-    REPOSITORY_FILE_PATH_SCHEMA as _REPOSITORY_FILE_PATH_SCHEMA,
-)
-from daydream.improve.command_contract import (
-    path_is_confined,
-)
 from daydream.prompt_budget import fits_inline_diff_budget
 from daydream.prompts.authorial_intent import AUTHORITATIVE_INTENT_RULE
 from daydream.prompts.grounding import UNTRUSTED_REPOSITORY_CONTENT_BOUNDARY
+from daydream.repository_paths import (
+    REPOSITORY_FILE_PATH_SCHEMA as _REPOSITORY_FILE_PATH_SCHEMA,
+)
+from daydream.repository_paths import (
+    path_is_confined,
+)
 from daydream.trajectory import (
     DaydreamPhase,
     TrajectoryRecorder,
@@ -1774,6 +1774,21 @@ def _resolve_finding_file_ref(repo: Path, value: object) -> str:
     return value
 
 
+def _preflight_finding_file_refs(repo: Path, items: list[dict[str, Any]]) -> str:
+    """Validate every item's ``file`` ref; return the first's canonical value.
+
+    Shared preflight for the batched and parallel fix entry points: rejects
+    the whole batch when ANY item's reference is missing/non-string or
+    unconfined (fixed, non-reflective ``ValueError``), before any grouping,
+    progress output, or prompt construction. All batch items target the same
+    file, so the first item's canonical resolution is the group's.
+    """
+    file_ref = _resolve_finding_file_ref(repo, items[0].get("file"))
+    for item in items[1:]:
+        _resolve_finding_file_ref(repo, item.get("file"))
+    return file_ref
+
+
 async def phase_fix(
     backend: Backend,
     work: WorkContext,
@@ -1903,11 +1918,9 @@ async def phase_fix_batched(
     count = len(items)
     # Validate EVERY item's file reference before any progress output or prompt
     # construction: a single unconfined (or missing/non-string) reference
-    # rejects the whole batch. All items target the same file, so the first
-    # item's canonical resolution is the group's.
-    file_ref = _resolve_finding_file_ref(work.repo, items[0].get("file"))
-    for item in items[1:]:
-        _resolve_finding_file_ref(work.repo, item.get("file"))
+    # rejects the whole batch. All items target the same file, so the returned
+    # first item's canonical resolution is the group's.
+    file_ref = _preflight_finding_file_refs(work.repo, items)
 
     async with (console_lock if console_lock is not None else anyio.Lock()):
         console.print()
@@ -2037,8 +2050,7 @@ async def phase_fix_parallel(
     # the whole run fast, so the unsafe path never becomes a grouping key,
     # fork name, failures entry, or checkout recovery argument. The returned
     # refs are discarded -- per-fix calls recompute them.
-    for item in items:
-        _resolve_finding_file_ref(work.repo, item.get("file"))
+    _preflight_finding_file_refs(work.repo, items)
 
     raw_groups = group_items_by_file(items)
     # Assign stable 1-based counters by pairing each item with its number

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -1754,6 +1754,26 @@ def _build_verifier_suffix(item: dict[str, Any]) -> str:
     return out
 
 
+def _resolve_finding_file_ref(repo: Path, value: object) -> str:
+    """Resolve a finding ``file`` reference to the string used in fix prompts.
+
+    Confinement gate for every fix entry point: rejects non-string values
+    (including ``None``/absent) and any reference that escapes the repository
+    (lexical violations, absolute paths, parent traversal, or symlink escapes)
+    with a fixed, non-reflective ``ValueError``. An existing confined file
+    resolves to its canonical absolute path; a missing-but-confined path is
+    preserved unchanged (relative string).
+    """
+    if not isinstance(value, str):
+        raise ValueError("Finding file must be a confined repository-relative path")
+    if not path_is_confined(repo, value):
+        raise ValueError("Finding file must be a confined repository-relative path")
+    candidate = repo / value
+    if candidate.is_file():
+        return str(candidate.resolve())
+    return value
+
+
 async def phase_fix(
     backend: Backend,
     work: WorkContext,
@@ -1788,9 +1808,7 @@ async def phase_fix(
             prose boundary still applies.
     """
     description = item.get("description", "No description")
-    file_path = item.get("file", "Unknown file")
-    resolved = work.repo / file_path
-    file_ref = str(resolved) if resolved.is_file() else file_path
+    file_ref = _resolve_finding_file_ref(work.repo, item.get("file"))
     line = item.get("line", "Unknown")
 
     async with (console_lock if console_lock is not None else anyio.Lock()):

--- a/daydream/repository_paths.py
+++ b/daydream/repository_paths.py
@@ -1,0 +1,98 @@
+"""Canonical repository-path grammar and confinement validation (core).
+
+Model-produced ``file``/``path``/``working_directory`` fields are untrusted.
+This package-root module owns the lexical grammar (relative POSIX segments,
+no parent traversal, no absolute paths) and the filesystem confinement check
+(symlink-at-any-prefix walk plus resolved-root containment) that every
+consumer — core phases and the improve command contract — relies on. Living
+at package root keeps flow subpackages dependent on core, never the reverse.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+_PATH_SEGMENT = (
+    r"(?:[A-Za-z0-9_+@$-][A-Za-z0-9._+@$-]*|"
+    r"\.[A-Za-z0-9_+@$-][A-Za-z0-9._+@$-]*|"
+    r"\.\.[A-Za-z0-9._+@$-]+)"
+)
+REPOSITORY_FILE_PATH_PATTERN = rf"^{_PATH_SEGMENT}(?:/{_PATH_SEGMENT})*$"
+DIRECTORY_SCOPE_PATTERN = rf"^{_PATH_SEGMENT}(?:/{_PATH_SEGMENT})*/?$"
+
+REPOSITORY_FILE_PATH_SCHEMA: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "maxLength": 512,
+    "pattern": REPOSITORY_FILE_PATH_PATTERN,
+}
+DIRECTORY_SCOPE_SCHEMA: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "maxLength": 512,
+    "pattern": DIRECTORY_SCOPE_PATTERN,
+}
+
+_REPOSITORY_FILE_PATH = re.compile(REPOSITORY_FILE_PATH_PATTERN)
+_DIRECTORY_SCOPE = re.compile(DIRECTORY_SCOPE_PATTERN)
+
+
+def valid_repository_file_path(value: str) -> bool:
+    """Return whether ``value`` has the safe repository-file grammar."""
+    return bool(_REPOSITORY_FILE_PATH.fullmatch(value))
+
+
+def valid_directory_scope_lexical(value: str) -> bool:
+    """Return whether ``value`` is a safe file-or-directory scope."""
+    return bool(_DIRECTORY_SCOPE.fullmatch(value))
+
+
+def path_is_confined(
+    repo: Path,
+    value: str,
+    *,
+    directory_scope: bool = False,
+) -> bool:
+    """Return whether a lexical repository path crosses no symlink/root edge."""
+    validator = (
+        valid_directory_scope_lexical
+        if directory_scope
+        else valid_repository_file_path
+    )
+    if value != "." and not validator(value):
+        return False
+    root = repo.resolve()
+    candidate = repo
+    if value != ".":
+        for part in PurePosixPath(value.rstrip("/")).parts:
+            candidate /= part
+            try:
+                if candidate.is_symlink():
+                    return False
+                if not candidate.exists():
+                    break
+            except OSError:
+                return False
+    try:
+        return candidate.resolve(strict=False).is_relative_to(root)
+    except OSError:
+        return False
+
+
+def canonicalize_directory_scope(value: str) -> str:
+    """Canonicalize the sole lossless scope spelling difference."""
+    return value.rstrip("/")
+
+
+__all__ = [
+    "DIRECTORY_SCOPE_PATTERN",
+    "DIRECTORY_SCOPE_SCHEMA",
+    "REPOSITORY_FILE_PATH_PATTERN",
+    "REPOSITORY_FILE_PATH_SCHEMA",
+    "canonicalize_directory_scope",
+    "path_is_confined",
+    "valid_directory_scope_lexical",
+    "valid_repository_file_path",
+]

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -851,6 +851,25 @@ async def test_phase_fix_batched_includes_verifier_verdicts(tmp_path, make_work,
     assert "assumes single-threaded" in prompt
 
 
+@pytest.mark.parametrize("path_kind", ["traversal", "absolute", "symlink"])
+@pytest.mark.asyncio
+async def test_phase_fix_batched_rejects_unconfined_finding_file(tmp_path, make_work, silence_console, path_kind):
+    """A multi-item batch with any unconfined file reference rejects the whole batch."""
+    from daydream.phases import phase_fix_batched
+
+    silence_console("daydream.phases")
+    backend = ScriptedBackend()
+    hostile = _unconfined_finding_file(tmp_path, path_kind)
+    items = [
+        {"id": 1, "description": "Escape A", "file": hostile, "line": 1},
+        {"id": 2, "description": "Escape B", "file": hostile, "line": 2},
+    ]
+
+    with pytest.raises(ValueError, match="Finding file must be a confined repository-relative path"):
+        await phase_fix_batched(backend, make_work(tmp_path), items, [1, 2], 2)
+    assert backend.prompts == []
+
+
 @pytest.mark.asyncio
 async def test_phase_fix_parallel_batches_same_file_findings(monkeypatch):
     """phase_fix_parallel calls phase_fix_batched once per file-group, never falls back."""

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -33,6 +33,31 @@ def _handoff_turn(body: str) -> tuple[AgentEvent, ...]:
     return _structured_turn({"handoff_prompt": body})
 
 
+def _unconfined_finding_file(tmp_path: Path, path_kind: str) -> str:
+    """Return a finding ``file`` value that must be rejected as unconfined.
+
+    ``traversal`` escapes via parent-directory traversal; ``absolute`` points
+    outside the repo root; ``symlink`` is a repo-local path whose real file
+    lives outside the repo (crossed via a symlink the worktree contains).
+    File names are keyed to the test's unique ``tmp_path`` so parallel tests
+    never collide.
+    """
+    if path_kind == "traversal":
+        return "../outside.py"
+    if path_kind == "absolute":
+        outside = tmp_path.parent / f"{tmp_path.name}-outside.py"
+        outside.write_bytes(b"x")
+        return str(outside.resolve())
+    if path_kind == "symlink":
+        src_dir = tmp_path / "src"
+        src_dir.mkdir(parents=True, exist_ok=True)
+        target = tmp_path.parent / f"{tmp_path.name}-target.py"
+        target.write_bytes(b"x")
+        (src_dir / "handler.py").symlink_to(target)
+        return "src/handler.py"
+    raise AssertionError(f"unknown path_kind: {path_kind!r}")
+
+
 class _HealBackend(ScriptedBackend):
     """``ScriptedBackend`` plus the per-call ``read_only`` flag the heal-loop tests assert on."""
 
@@ -663,6 +688,35 @@ async def test_phase_fix_falls_back_to_relative_path_when_missing(tmp_path, make
 
     assert len(backend.prompts) == 1
     assert "File: src/nonexistent.py" in backend.prompts[0]
+
+
+@pytest.mark.parametrize("path_kind", ["traversal", "absolute", "symlink"])
+@pytest.mark.asyncio
+async def test_phase_fix_rejects_unconfined_finding_file(tmp_path, make_work, silence_console, path_kind):
+    """A finding file escaping the worktree raises ValueError and emits no prompt."""
+    from daydream.phases import phase_fix
+
+    silence_console("daydream.phases")
+    backend = ScriptedBackend()
+    item = {"id": 1, "description": "Escape", "file": _unconfined_finding_file(tmp_path, path_kind), "line": 1}
+
+    with pytest.raises(ValueError, match="Finding file must be a confined repository-relative path"):
+        await phase_fix(backend, make_work(tmp_path), item, 1, 1)
+    assert backend.prompts == []
+
+
+@pytest.mark.asyncio
+async def test_phase_fix_rejects_missing_file_reference(tmp_path, make_work, silence_console):
+    """An item with no file reference is rejected, not silently delegated."""
+    from daydream.phases import phase_fix
+
+    silence_console("daydream.phases")
+    backend = ScriptedBackend()
+    item = {"id": 1, "description": "No file", "line": 3}
+
+    with pytest.raises(ValueError, match="Finding file must be a confined repository-relative path"):
+        await phase_fix(backend, make_work(tmp_path), item, 1, 1)
+    assert backend.prompts == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -854,15 +854,19 @@ async def test_phase_fix_batched_includes_verifier_verdicts(tmp_path, make_work,
 @pytest.mark.parametrize("path_kind", ["traversal", "absolute", "symlink"])
 @pytest.mark.asyncio
 async def test_phase_fix_batched_rejects_unconfined_finding_file(tmp_path, make_work, silence_console, path_kind):
-    """A multi-item batch with any unconfined file reference rejects the whole batch."""
+    """A single unconfined reference at any position rejects the whole batch.
+
+    The hostile value lives only in the second item so the batched preflight
+    loop ``for item in items[1:]`` actually runs past index 0 before raising.
+    """
     from daydream.phases import phase_fix_batched
 
     silence_console("daydream.phases")
     backend = ScriptedBackend()
     hostile = _unconfined_finding_file(tmp_path, path_kind)
     items = [
-        {"id": 1, "description": "Escape A", "file": hostile, "line": 1},
-        {"id": 2, "description": "Escape B", "file": hostile, "line": 2},
+        {"id": 1, "description": "Confined", "file": "src/ok.py", "line": 1},
+        {"id": 2, "description": "Escape", "file": hostile, "line": 2},
     ]
 
     with pytest.raises(ValueError, match="Finding file must be a confined repository-relative path"):
@@ -938,14 +942,18 @@ async def test_phase_fix_parallel_falls_back_to_per_finding_on_batch_failure(tmp
 @pytest.mark.parametrize("path_kind", ["traversal", "absolute", "symlink"])
 @pytest.mark.asyncio
 async def test_phase_fix_parallel_rejects_unconfined_finding_file(tmp_path, make_work, silence_console, path_kind):
-    """An unconfined file reference aborts the whole parallel fix run before any dispatch."""
+    """A single unconfined reference at any position aborts the whole run.
+
+    The hostile value lives only in the second item so the parallel preflight
+    loop actually runs past index 0 before raising -- no dispatch happens.
+    """
     from daydream.phases import phase_fix_parallel
 
     silence_console("daydream.phases")
     backend = ScriptedBackend()
     hostile = _unconfined_finding_file(tmp_path, path_kind)
     items = [
-        {"id": 1, "file": hostile},
+        {"id": 1, "file": "src/ok.py"},
         {"id": 2, "file": hostile},
     ]
 

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -1460,6 +1460,26 @@ def test_feedback_schema_requires_confidence_and_rationale():
     assert confidence["enum"] == ["HIGH", "MEDIUM"]
 
 
+def test_finding_file_schema_slots_use_repository_file_path_schema():
+    """Every model-facing finding schema constrains its file slot to the shared repository-path grammar."""
+    from daydream import phases
+    from daydream.improve.command_contract import REPOSITORY_FILE_PATH_SCHEMA
+
+    # Directly-assigned slots reference the exact shared schema object.
+    feedback_file = phases.FEEDBACK_SCHEMA["properties"]["issues"]["items"]["properties"]["file"]
+    alt_files_items = phases.ALTERNATIVE_REVIEW_SCHEMA["properties"]["issues"]["items"]["properties"]["files"]["items"]
+    merged_file = phases.MERGED_ITEMS_SCHEMA["properties"]["items"]["items"]["properties"]["file"]
+    assert feedback_file is REPOSITORY_FILE_PATH_SCHEMA
+    assert alt_files_items is REPOSITORY_FILE_PATH_SCHEMA
+    assert merged_file is REPOSITORY_FILE_PATH_SCHEMA
+    # PER_STACK_RECORD_SCHEMA deep-copies FEEDBACK_SCHEMA, so its file slot is an
+    # equal copy (not the identical object) -- but it must carry the tightened
+    # grammar, not the loose `{"type":"string"}`.
+    per_stack_file = phases.PER_STACK_RECORD_SCHEMA["properties"]["issues"]["items"]["properties"]["file"]
+    assert per_stack_file == REPOSITORY_FILE_PATH_SCHEMA
+    assert per_stack_file["pattern"]
+
+
 def test_alternative_review_schema_requires_confidence_and_rationale():
     from daydream.phases import ALTERNATIVE_REVIEW_SCHEMA
 

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -875,6 +875,27 @@ async def test_phase_fix_batched_rejects_unconfined_finding_file(tmp_path, make_
 
 
 @pytest.mark.asyncio
+async def test_phase_fix_batched_rejects_missing_file_reference(tmp_path, make_work, silence_console):
+    """An item with no file reference rejects the whole batch, not just that item.
+
+    The missing ref lives in the second item so the batched preflight loop
+    ``for item in items[1:]`` actually runs past index 0 before raising.
+    """
+    from daydream.phases import phase_fix_batched
+
+    silence_console("daydream.phases")
+    backend = ScriptedBackend()
+    items = [
+        {"id": 1, "description": "Confined", "file": "src/ok.py", "line": 1},
+        {"id": 2, "description": "No file", "line": 2},
+    ]
+
+    with pytest.raises(ValueError, match="Finding file must be a confined repository-relative path"):
+        await phase_fix_batched(backend, make_work(tmp_path), items, [1, 2], 2)
+    assert backend.prompts == []
+
+
+@pytest.mark.asyncio
 async def test_phase_fix_parallel_batches_same_file_findings(tmp_path, monkeypatch, make_work):
     """phase_fix_parallel calls phase_fix_batched once per file-group, never falls back."""
     from daydream import phases
@@ -955,6 +976,27 @@ async def test_phase_fix_parallel_rejects_unconfined_finding_file(tmp_path, make
     items = [
         {"id": 1, "file": "src/ok.py"},
         {"id": 2, "file": hostile},
+    ]
+
+    with pytest.raises(ValueError, match="Finding file must be a confined repository-relative path"):
+        await phase_fix_parallel(backend, make_work(tmp_path), items)
+    assert backend.prompts == []
+
+
+@pytest.mark.asyncio
+async def test_phase_fix_parallel_rejects_missing_file_reference(tmp_path, make_work, silence_console):
+    """An item with no file reference aborts the whole run before any dispatch.
+
+    The missing ref lives in the second item so the parallel preflight loop
+    actually runs past index 0 before raising -- no grouping happens.
+    """
+    from daydream.phases import phase_fix_parallel
+
+    silence_console("daydream.phases")
+    backend = ScriptedBackend()
+    items = [
+        {"id": 1, "file": "src/ok.py"},
+        {"id": 2, "description": "No file"},
     ]
 
     with pytest.raises(ValueError, match="Finding file must be a confined repository-relative path"):

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -871,7 +871,7 @@ async def test_phase_fix_batched_rejects_unconfined_finding_file(tmp_path, make_
 
 
 @pytest.mark.asyncio
-async def test_phase_fix_parallel_batches_same_file_findings(monkeypatch):
+async def test_phase_fix_parallel_batches_same_file_findings(tmp_path, monkeypatch, make_work):
     """phase_fix_parallel calls phase_fix_batched once per file-group, never falls back."""
     from daydream import phases
 
@@ -893,7 +893,7 @@ async def test_phase_fix_parallel_batches_same_file_findings(monkeypatch):
         {"id": 5, "file": "b.py"},
     ]
 
-    failures = await phases.phase_fix_parallel(object(), object(), items)
+    failures = await phases.phase_fix_parallel(object(), make_work(tmp_path), items)
 
     assert failures == {}
     # Two file-groups -> two batched calls (NOT five per-finding calls).
@@ -903,7 +903,7 @@ async def test_phase_fix_parallel_batches_same_file_findings(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_phase_fix_parallel_falls_back_to_per_finding_on_batch_failure(monkeypatch):
+async def test_phase_fix_parallel_falls_back_to_per_finding_on_batch_failure(tmp_path, monkeypatch, make_work):
     """When the batched turn raises, the group retries each finding via phase_fix."""
     from daydream import phases
 
@@ -925,7 +925,7 @@ async def test_phase_fix_parallel_falls_back_to_per_finding_on_batch_failure(mon
         {"id": 4, "file": "boom.py"},
     ]
 
-    failures = await phases.phase_fix_parallel(object(), object(), items)
+    failures = await phases.phase_fix_parallel(object(), make_work(tmp_path), items)
 
     # Fallback ran each finding in the failing group individually...
     assert sorted(fix_calls) == [3, 4]
@@ -933,6 +933,25 @@ async def test_phase_fix_parallel_falls_back_to_per_finding_on_batch_failure(mon
     assert 1 not in fix_calls and 2 not in fix_calls
     # The fallback succeeded, so no failure was collected.
     assert failures == {}
+
+
+@pytest.mark.parametrize("path_kind", ["traversal", "absolute", "symlink"])
+@pytest.mark.asyncio
+async def test_phase_fix_parallel_rejects_unconfined_finding_file(tmp_path, make_work, silence_console, path_kind):
+    """An unconfined file reference aborts the whole parallel fix run before any dispatch."""
+    from daydream.phases import phase_fix_parallel
+
+    silence_console("daydream.phases")
+    backend = ScriptedBackend()
+    hostile = _unconfined_finding_file(tmp_path, path_kind)
+    items = [
+        {"id": 1, "file": hostile},
+        {"id": 2, "file": hostile},
+    ]
+
+    with pytest.raises(ValueError, match="Finding file must be a confined repository-relative path"):
+        await phase_fix_parallel(backend, make_work(tmp_path), items)
+    assert backend.prompts == []
 
 
 class TestBuildFixPrompt:
@@ -3199,7 +3218,7 @@ def test_group_items_by_file_preserves_order_within_and_across_groups():
     assert group_items_by_file([]) == []
 
 
-async def test_phase_fix_parallel_calls_count_serial_per_file_and_collects_failures(monkeypatch):
+async def test_phase_fix_parallel_calls_count_serial_per_file_and_collects_failures(tmp_path, monkeypatch, make_work):
     import anyio
 
     from daydream import phases
@@ -3232,7 +3251,7 @@ async def test_phase_fix_parallel_calls_count_serial_per_file_and_collects_failu
         {"id": 3, "file": "b.py"},
         {"id": 4, "file": "boom.py"},
     ]
-    failures = await phases.phase_fix_parallel(object(), object(), items)
+    failures = await phases.phase_fix_parallel(object(), make_work(tmp_path), items)
     # a.py has 2 findings -> one batched call. b.py and boom.py have 1 finding
     # each -> direct phase_fix (no batched prompt, no fallback retry).
     assert batched_calls == ["a.py"]


### PR DESCRIPTION
Confines model-supplied finding file paths to repository-path grammar before they are dispatched to the fix agent, preventing arbitrary/out-of-repo path references from reaching the fix pipeline.

Two sequential daydream deep-precision reviews (rounds 1 & 2) on fresh exe.dev VMs passed; full `make check` green (3392 passed, 6 skipped, 0 failures).

## Changes
- Constrain finding file fields to repository-path grammar (`repository_paths.py`)
- Confine single-fix, batched-fix, and parallel-fix finding file references before dispatch (`phases.py`)
- Move repository path validation to a core module
- Add regression tests for the missing-finding-file rejection path

Closes #443