### PR TITLE
[daydream] #562 Consolidate out-of-scope findings in daydream/phases.py (raw --log output, untracked files in commit)

### DIFF
--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -20,7 +20,7 @@ import os
 import shutil
 from dataclasses import asdict
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Awaitable
 
 import anyio
 from rich.markup import escape as escape_markup
@@ -2878,22 +2878,35 @@ async def _step_test(ctx: FlowContext) -> Stop | None:
     return None
 
 
+async def _commit_push_or_stop(coro: Awaitable[None]) -> Stop | None:
+    """Await a commit/push phase, mapping failure to a clean Stop(1).
+
+    Shared by _step_commit and _step_commit_push so the try/except ->
+    print_error("Commit/Push Failed") -> Stop(1) guard lives in one place.
+    The phase coroutine is created by the caller but only awaited here, so a
+    synchronous GitError from staging still surfaces inside the guard.
+    """
+    try:
+        await coro
+    except Exception as e:
+        print_error(console, "Commit/Push Failed", str(e))
+        return Stop(1)
+    return None
+
+
 async def _step_commit(ctx: FlowContext) -> Stop | None:
     """Commit-and-push the applied fixes."""
     # phase_commit_push runs as part of the fix/commit cycle — reuse
     # the fix backend (no separate "commit" phase identifier).
     # stage_paths can raise GitError synchronously before the agent turn;
-    # mirror _step_commit_push so that surfaces as a clean Stop(1) instead of
+    # _commit_push_or_stop surfaces that as a clean Stop(1) instead of
     # an unhandled traceback terminating the deep run.
-    try:
-        await phase_commit_push(
+    return await _commit_push_or_stop(
+        phase_commit_push(
             ctx.backend_for("fix"), ctx.work,
             preexisting_untracked=ctx.data.get("pre_fix_untracked"),
         )
-    except Exception as e:
-        print_error(console, "Commit/Push Failed", str(e))
-        return Stop(1)
-    return None
+    )
 
 
 async def _perform_cleanup(ctx: FlowContext) -> None:
@@ -3001,16 +3014,13 @@ async def _step_fix_items(ctx: FlowContext) -> Stop | None:
 async def _step_commit_push(ctx: FlowContext) -> Stop | None:
     """Commit and push the applied fixes (feedback mode)."""
     results: list[FixResult] = ctx.data["results"]
-    try:
-        await phase_commit_push_auto(
+    return await _commit_push_or_stop(
+        phase_commit_push_auto(
             ctx.backend_for("review"), ctx.work,
             items=[item for item, _ok, _err in results if _ok],
             preexisting_untracked=ctx.data.get("pre_fix_untracked"),
         )
-    except Exception as e:
-        print_error(console, "Commit/Push Failed", str(e))
-        return Stop(1)
-    return None
+    )
 
 
 async def _step_respond_feedback(ctx: FlowContext) -> Stop:

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -2658,6 +2658,10 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
         pre_fix_snapshot_captured = False
     else:
         pre_fix_snapshot_captured = True
+    # Issue #543: thread the pre-fix untracked snapshot into the commit steps so
+    # _do_commit can exclude user scratch files from the daydream commit instead
+    # of sweeping them in via the commit agent's ``git add --all``.
+    ctx.data["pre_fix_untracked"] = pre_fix_untracked
     # Pre-fix HEAD is the recommended-patch base only when the tree was
     # clean (stash_create returns None then) -- otherwise the snapshot is
     # the base and HEAD is unused, so skip the rev-parse. Captured now
@@ -2878,7 +2882,10 @@ async def _step_commit(ctx: FlowContext) -> None:
     """Commit-and-push the applied fixes."""
     # phase_commit_push runs as part of the fix/commit cycle — reuse
     # the fix backend (no separate "commit" phase identifier).
-    await phase_commit_push(ctx.backend_for("fix"), ctx.work)
+    await phase_commit_push(
+        ctx.backend_for("fix"), ctx.work,
+        preexisting_untracked=ctx.data.get("pre_fix_untracked"),
+    )
 
 
 async def _perform_cleanup(ctx: FlowContext) -> None:
@@ -2943,8 +2950,19 @@ async def _step_parse_feedback(ctx: FlowContext) -> Stop | None:
 
 async def _step_fix_items(ctx: FlowContext) -> Stop | None:
     """Apply a fix per feedback item; abort before commit when all fail."""
+    from daydream import git_ops
+
     feedback_items = ctx.data["feedback_items"]
     fix_backend = ctx.backend_for("fix")
+
+    # Issue #543: snapshot the pre-fix untracked set so the feedback commit step
+    # can exclude user scratch files from the daydream commit. Fail-open to an
+    # empty snapshot (deterministic stage = all untracked), mirroring _step_fix.
+    try:
+        pre_fix_untracked = set(git_ops.list_untracked(ctx.work.repo))
+    except git_ops.GitError:
+        pre_fix_untracked = set()
+    ctx.data["pre_fix_untracked"] = pre_fix_untracked
 
     # Fix sequentially to avoid concurrent access to one mutable backend.
     results: list[FixResult] = []
@@ -2979,7 +2997,9 @@ async def _step_commit_push(ctx: FlowContext) -> Stop | None:
     results: list[FixResult] = ctx.data["results"]
     try:
         await phase_commit_push_auto(
-            ctx.backend_for("review"), ctx.work, items=[item for item, _ok, _err in results if _ok],
+            ctx.backend_for("review"), ctx.work,
+            items=[item for item, _ok, _err in results if _ok],
+            preexisting_untracked=ctx.data.get("pre_fix_untracked"),
         )
     except Exception as e:
         print_error(console, "Commit/Push Failed", str(e))

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -2878,14 +2878,22 @@ async def _step_test(ctx: FlowContext) -> Stop | None:
     return None
 
 
-async def _step_commit(ctx: FlowContext) -> None:
+async def _step_commit(ctx: FlowContext) -> Stop | None:
     """Commit-and-push the applied fixes."""
     # phase_commit_push runs as part of the fix/commit cycle — reuse
     # the fix backend (no separate "commit" phase identifier).
-    await phase_commit_push(
-        ctx.backend_for("fix"), ctx.work,
-        preexisting_untracked=ctx.data.get("pre_fix_untracked"),
-    )
+    # stage_paths can raise GitError synchronously before the agent turn;
+    # mirror _step_commit_push so that surfaces as a clean Stop(1) instead of
+    # an unhandled traceback terminating the deep run.
+    try:
+        await phase_commit_push(
+            ctx.backend_for("fix"), ctx.work,
+            preexisting_untracked=ctx.data.get("pre_fix_untracked"),
+        )
+    except Exception as e:
+        print_error(console, "Commit/Push Failed", str(e))
+        return Stop(1)
+    return None
 
 
 async def _perform_cleanup(ctx: FlowContext) -> None:
@@ -2956,12 +2964,10 @@ async def _step_fix_items(ctx: FlowContext) -> Stop | None:
     fix_backend = ctx.backend_for("fix")
 
     # Issue #543: snapshot the pre-fix untracked set so the feedback commit step
-    # can exclude user scratch files from the daydream commit. Fail-open to an
-    # empty snapshot (deterministic stage = all untracked), mirroring _step_fix.
-    try:
-        pre_fix_untracked = set(git_ops.list_untracked(ctx.work.repo))
-    except git_ops.GitError:
-        pre_fix_untracked = set()
+    # can exclude user scratch files from the daydream commit. list_untracked
+    # soft-fails to [] on GitError, so set(...) is already the fail-open empty
+    # snapshot (deterministic stage = all untracked), mirroring _step_fix.
+    pre_fix_untracked = set(git_ops.list_untracked(ctx.work.repo))
     ctx.data["pre_fix_untracked"] = pre_fix_untracked
 
     # Fix sequentially to avoid concurrent access to one mutable backend.

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -1760,6 +1760,26 @@ def checkout_branch(repo: Path, name: str) -> None:
         raise GitError(f"git checkout {name} failed in {repo}: {proc.stderr.strip()}")
 
 
+def stage_paths(repo: Path, paths: list[Path]) -> None:
+    """Stage exactly *paths* into the index — never ``-A`` / ``--all``.
+
+    Runs ``git add <paths…>`` so only the named files enter the index; any
+    other working-tree changes (including pre-existing untracked files) stay
+    unstaged.
+
+    Args:
+        paths: Repo-relative paths to stage. Must be non-empty.
+
+    Raises:
+        GitError: If *paths* is empty, or the ``git add`` call fails.
+    """
+    if not paths:
+        raise GitError("stage_paths requires at least one path")
+    add = _run_git(repo, ["add", "--", *(str(p) for p in paths)], timeout=30, retries=0)
+    if add.returncode != 0:
+        raise GitError(f"git add {paths} failed in {repo}: {add.stderr.strip()}")
+
+
 def commit_paths(repo: Path, paths: list[Path], message: str) -> None:
     """Stage only *paths* and commit them with *message*.
 
@@ -1776,9 +1796,7 @@ def commit_paths(repo: Path, paths: list[Path], message: str) -> None:
     """
     if not paths:
         raise GitError("commit_paths requires at least one path")
-    add = _run_git(repo, ["add", "--", *(str(p) for p in paths)], timeout=30, retries=0)
-    if add.returncode != 0:
-        raise GitError(f"git add {paths} failed in {repo}: {add.stderr.strip()}")
+    stage_paths(repo, paths)
     # git commit fails "Author identity unknown" with no user.email/user.name
     # (common in fresh CI). Inject fallback values via -c only when none is set.
     identity_ok = (

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -1355,6 +1355,27 @@ def changed_files_against(
     return names
 
 
+def diff_name_only_strict(repo: Path, from_ref: str, to_ref: str) -> list[str]:
+    """Return repo-relative paths that differ between two refs' trees.
+
+    Strict counterpart to :func:`diff_name_only` (which soft-fails to an empty
+    list) for post-commit tree checks: ``git diff --name-only <from_ref>
+    <to_ref>`` over the two commit trees. Raises :class:`GitError` when the
+    diff cannot be computed, so callers can distinguish "no differences" from
+    "unknown" (e.g. when verifying that a commit agent did not broaden a
+    commit beyond the pre-staged set).
+
+    Returns:
+        List of repo-relative path strings (unique, as emitted by git).
+    """
+    proc = _run_git(repo, ["diff", "--name-only", from_ref, to_ref], timeout=10)
+    if proc.returncode != 0:
+        raise GitError(
+            f"git diff --name-only {from_ref} {to_ref} failed in {repo}: {proc.stderr.strip()}"
+        )
+    return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+
+
 def list_untracked(repo: Path) -> list[str]:
     """Return repo-relative paths of untracked, non-ignored files.
 
@@ -1794,8 +1815,7 @@ def commit_paths(repo: Path, paths: list[Path], message: str) -> None:
         GitError: If *paths* is empty, or the ``git add`` / ``git commit`` call
             fails.
     """
-    if not paths:
-        raise GitError("commit_paths requires at least one path")
+    # Empty-path guard lives in stage_paths (identical GitError).
     stage_paths(repo, paths)
     # git commit fails "Author identity unknown" with no user.email/user.name
     # (common in fresh CI). Inject fallback values via -c only when none is set.

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -2595,6 +2595,22 @@ async def _do_commit(
 
     push_line = "Then push to the remote." if push else "Do NOT push. Only commit."
 
+    if preexisting_untracked is not None:
+        # Deterministic staging (issue #562/#543): the index already holds
+        # exactly the daydream changes, so the agent commits the pre-staged
+        # index only and must not re-stage anything.
+        staging_instruction = (
+            "The daydream changes are already staged. Review the staged diff "
+            "(git diff --cached) and commit using a conventional commit message. "
+            "Do NOT run git add or stage anything — the index is complete. "
+        )
+    else:
+        # Legacy path: no pre-run untracked snapshot — the agent stages and
+        # commits as before (the documented None contract).
+        staging_instruction = (
+            "Stage all changes and commit using a conventional commit message. "
+        )
+
     if items:
         summaries = "\n".join(
             f"- {it.get('file', 'unknown')}: {it.get('description', 'no description')}"
@@ -2608,8 +2624,7 @@ async def _do_commit(
         items_context = ""
 
     prompt = (
-        "The daydream changes are already staged. Review the staged diff "
-        "(git diff --cached) and commit using a conventional commit message. "
+        f"{staging_instruction}"
         "Review the diff to write a meaningful summary of what was fixed or changed. "
         "Use the format: <type>: <concise summary of changes>\n\n"
         f"{items_context}"
@@ -2665,6 +2680,24 @@ async def _do_commit(
             git_ops.amend_trailers(work.repo, missing, message=msg)
         except GitError as exc:
             print_warning(console, f"Failed to amend trailers: {exc}")
+
+    if preexisting_untracked is not None:
+        # Issue #562: prompt compliance alone is not enforcement — a commit
+        # agent that re-runs ``git add -A`` would sweep pre-existing untracked
+        # files into the commit. Verify the committed tree against the
+        # pre-staged set and surface any scope creep to the operator.
+        try:
+            committed = set(git_ops.diff_name_only_strict(work.repo, sha_before, "HEAD"))
+        except GitError as exc:
+            print_warning(console, f"Could not verify committed tree: {exc}")
+        else:
+            extras = sorted(committed - set(stage))
+            if extras:
+                print_warning(
+                    console,
+                    "Commit contains files outside the pre-staged daydream set "
+                    f"(scope creep): {', '.join(extras)}",
+                )
 
     return True
 
@@ -2724,11 +2757,17 @@ async def phase_commit_push_auto(
     """
     console.print()
     print_info(console, "Committing and pushing changes...")
-    await _do_commit(
+    committed = await _do_commit(
         backend, work, push=True, items=items,
         preexisting_untracked=preexisting_untracked,
     )
-    print_success(console, "Commit and push complete")
+    # Only claim success when a commit was actually created: on the
+    # deterministic path a git failure makes changed_files soft-fail to an
+    # empty set, so _do_commit prints "Nothing to commit" and returns False —
+    # a success banner there would mislead the operator into believing the
+    # fixes were committed.
+    if committed:
+        print_success(console, "Commit and push complete")
 
 
 async def phase_respond_pr_feedback(

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -2537,6 +2537,80 @@ async def phase_test_and_heal(
             return False, retries_used, False
 
 
+def _stage_deterministic(
+    work: WorkContext, preexisting_untracked: set[str],
+) -> set[str] | None:
+    """Pre-stage exactly the daydream changes, excluding run artifacts.
+
+    Deterministic staging (issue #562/#543): everything changed from HEAD
+    minus the pre-run untracked snapshot is staged via ``stage_paths`` (never
+    ``git add --all``), so a user's pre-run scratch files can never be swept
+    into the daydream commit. Daydream's own mid-run artifacts under
+    ``.daydream/`` (recommended.patch, fix-failures, quality-gate/test
+    verdicts) are created after the snapshot and would otherwise be staged
+    and pushed alongside the fixes — they are run state, not user changes,
+    so they are excluded.
+
+    Returns:
+        The staged path set, or ``None`` when there is nothing to commit.
+
+    Raises:
+        GitError: If the changed-file enumeration or staging fails — the
+            strict enumerator must not silently degrade to an empty stage
+            (that would leave tracked fixes uncommitted behind a green
+            "Commit and push complete").
+    """
+    stage = set(
+        git_ops.changed_files_against(
+            work.repo, "HEAD", preexisting_untracked=preexisting_untracked,
+        )
+    )
+    stage = {
+        p for p in stage if p != ".daydream" and not p.startswith(".daydream/")
+    }
+    if not stage:
+        print_info(console, "Nothing to commit — no daydream changes")
+        return None
+    git_ops.stage_paths(work.repo, [Path(p) for p in sorted(stage)])
+    return stage
+
+
+def _verify_commit_scope(
+    work: WorkContext, sha_before: str, stage: set[str],
+) -> None:
+    """Verify the committed tree matches the pre-staged daydream set.
+
+    Issue #562: prompt compliance alone is not enforcement — a commit agent
+    that re-runs ``git add -A`` would sweep pre-existing untracked files into
+    the commit. Enforcement checks both directions:
+
+    - extras (committed beyond the pre-staged set) surfaces scope creep;
+    - missing (pre-staged files absent from the committed tree) surfaces an
+      under-commit, so a tracked fix dropped from the commit (e.g. by a
+      partial commit) is never hidden behind a green "Commit and push
+      complete".
+    """
+    try:
+        committed = set(git_ops.diff_name_only_strict(work.repo, sha_before, "HEAD"))
+    except GitError as exc:
+        print_warning(console, f"Could not verify committed tree: {exc}")
+        return
+    extras = sorted(committed - stage)
+    if extras:
+        print_warning(
+            console,
+            "Commit contains files outside the pre-staged daydream set "
+            f"(scope creep): {', '.join(extras)}",
+        )
+    missing = sorted(stage - committed)
+    if missing:
+        print_warning(
+            console,
+            "Commit is missing pre-staged daydream files (under-commit): "
+            f"{', '.join(missing)}",
+        )
+
+
 async def _do_commit(
     backend: Backend,
     work: WorkContext,
@@ -2587,11 +2661,9 @@ async def _do_commit(
             return False
 
     if preexisting_untracked is not None:
-        stage = git_ops.changed_files(work.repo, preexisting_untracked=preexisting_untracked)
-        if not stage:
-            print_info(console, "Nothing to commit — no daydream changes")
+        stage = _stage_deterministic(work, preexisting_untracked)
+        if stage is None:
             return False
-        git_ops.stage_paths(work.repo, [Path(p) for p in stage])
 
     push_line = "Then push to the remote." if push else "Do NOT push. Only commit."
 
@@ -2681,23 +2753,11 @@ async def _do_commit(
         except GitError as exc:
             print_warning(console, f"Failed to amend trailers: {exc}")
 
-    if preexisting_untracked is not None:
-        # Issue #562: prompt compliance alone is not enforcement — a commit
-        # agent that re-runs ``git add -A`` would sweep pre-existing untracked
-        # files into the commit. Verify the committed tree against the
-        # pre-staged set and surface any scope creep to the operator.
-        try:
-            committed = set(git_ops.diff_name_only_strict(work.repo, sha_before, "HEAD"))
-        except GitError as exc:
-            print_warning(console, f"Could not verify committed tree: {exc}")
-        else:
-            extras = sorted(committed - set(stage))
-            if extras:
-                print_warning(
-                    console,
-                    "Commit contains files outside the pre-staged daydream set "
-                    f"(scope creep): {', '.join(extras)}",
-                )
+    # stage is only ever set on the deterministic path (and non-None there,
+    # since _stage_deterministic returned early on an empty stage); the
+    # ``is not None`` narrow lets mypy prove the set type.
+    if preexisting_untracked is not None and stage is not None:
+        _verify_commit_scope(work, sha_before, stage)
 
     return True
 
@@ -2761,11 +2821,11 @@ async def phase_commit_push_auto(
         backend, work, push=True, items=items,
         preexisting_untracked=preexisting_untracked,
     )
-    # Only claim success when a commit was actually created: on the
-    # deterministic path a git failure makes changed_files soft-fail to an
-    # empty set, so _do_commit prints "Nothing to commit" and returns False —
-    # a success banner there would mislead the operator into believing the
-    # fixes were committed.
+    # Only claim success when a commit was actually created: the deterministic
+    # path uses the strict changed_files_against enumerator (a git failure
+    # surfaces as Stop(1), never an empty stage), so _do_commit returns False
+    # only for a genuinely empty daydream change set — a success banner on
+    # either would mislead the operator into believing the fixes were committed.
     if committed:
         print_success(console, "Commit and push complete")
 

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -2544,6 +2544,7 @@ async def _do_commit(
     push: bool = False,
     interactive: bool = False,
     items: list[dict[str, Any]] | None = None,
+    preexisting_untracked: set[str] | None = None,
 ) -> bool:
     """Stage, commit, and optionally push with daydream trailers.
 
@@ -2556,6 +2557,13 @@ async def _do_commit(
         items: Optional list of fix dicts (with ``file`` and ``description``
             keys) summarising changes applied in this run; included in the
             agent prompt so the commit message is accurate.
+        preexisting_untracked: Optional set of repo-relative paths that were
+            untracked before the daydream run started. When supplied, staging
+            is deterministic: exactly ``changed_files(...) - preexisting`` is
+            pre-staged (never ``git add --all``) so a user's pre-run scratch
+            files can never be swept into the daydream commit (issue #543).
+            The commit agent then commits the already-staged index only. When
+            ``None`` (legacy callers), the agent stages as before.
 
     Returns:
         True if a commit was performed, False if the user declined.
@@ -2578,6 +2586,13 @@ async def _do_commit(
             print_dim(console, "Skipping commit and push")
             return False
 
+    if preexisting_untracked is not None:
+        stage = git_ops.changed_files(work.repo, preexisting_untracked=preexisting_untracked)
+        if not stage:
+            print_info(console, "Nothing to commit — no daydream changes")
+            return False
+        git_ops.stage_paths(work.repo, [Path(p) for p in stage])
+
     push_line = "Then push to the remote." if push else "Do NOT push. Only commit."
 
     if items:
@@ -2593,7 +2608,8 @@ async def _do_commit(
         items_context = ""
 
     prompt = (
-        "Stage all changes and commit using a conventional commit message. "
+        "The daydream changes are already staged. Review the staged diff "
+        "(git diff --cached) and commit using a conventional commit message. "
         "Review the diff to write a meaningful summary of what was fixed or changed. "
         "Use the format: <type>: <concise summary of changes>\n\n"
         f"{items_context}"
@@ -2653,11 +2669,16 @@ async def _do_commit(
     return True
 
 
-async def phase_commit_push(backend: Backend, work: WorkContext) -> None:
+async def phase_commit_push(
+    backend: Backend, work: WorkContext, *, preexisting_untracked: set[str] | None = None,
+) -> None:
     """Prompt user to commit and push changes."""
     console.print()
     print_info(console, "Committing and pushing changes...")
-    committed = await _do_commit(backend, work, push=True, interactive=True)
+    committed = await _do_commit(
+        backend, work, push=True, interactive=True,
+        preexisting_untracked=preexisting_untracked,
+    )
     if committed:
         print_success(console, "Commit and push complete")
 
@@ -2687,17 +2708,26 @@ async def phase_fetch_pr_feedback(
 
 
 async def phase_commit_push_auto(
-    backend: Backend, work: WorkContext, *, items: list[dict[str, Any]] | None = None,
+    backend: Backend,
+    work: WorkContext,
+    *,
+    items: list[dict[str, Any]] | None = None,
+    preexisting_untracked: set[str] | None = None,
 ) -> None:
     """Automatically commit and push changes without user prompt.
 
     Args:
         items: Optional fix items applied this run; forwarded to the commit
             agent so it can craft an accurate commit message.
+        preexisting_untracked: Optional pre-run untracked snapshot; forwarded
+            to ``_do_commit`` for deterministic pre-staging (issue #543).
     """
     console.print()
     print_info(console, "Committing and pushing changes...")
-    await _do_commit(backend, work, push=True, items=items)
+    await _do_commit(
+        backend, work, push=True, items=items,
+        preexisting_untracked=preexisting_untracked,
+    )
     print_success(console, "Commit and push complete")
 
 

--- a/tests/harness/phase_backend.py
+++ b/tests/harness/phase_backend.py
@@ -144,7 +144,7 @@ class PhaseDispatchBackend:
             else:
                 yield TextEvent(text="1 test failed.")
             yield ResultEvent(structured_output=None, continuation=None)
-        elif "stage all changes and commit" in prompt_lower and "do not push" in prompt_lower:
+        elif "the daydream changes are already staged" in prompt_lower and "do not push" in prompt_lower:
             self.commit_calls.append(prompt_lower)
             yield TextEvent(text="Committed iteration changes.")
             yield ResultEvent(structured_output=None, continuation=None)

--- a/tests/test_archive_data_capture.py
+++ b/tests/test_archive_data_capture.py
@@ -53,10 +53,11 @@ class _ArchiveCaptureBackend(StubBackend):
         max_turns=None,
         read_only=False,
     ):
-        if prompt.startswith("Stage all changes and commit"):
+        if prompt.startswith("The daydream changes are already staged"):
             run_id = prompt.split("Daydream-Run: ", 1)[1].splitlines()[0]
             version = prompt.split("Daydream-Version: ", 1)[1].splitlines()[0]
-            git(cwd, "add", "--all")
+            # The index is pre-staged by _do_commit (deterministic staging,
+            # issue #543) — commit it as-is, never `git add --all`.
             git(
                 cwd,
                 "commit",
@@ -197,6 +198,35 @@ async def test_deep_archive_recommended_patch_excludes_preexisting_untracked_fil
     recommended = (run_dir / "recommended.patch").read_text()
     assert "migrations/0002_add_x.sql" in recommended  # fix-created file present
     assert "notes.txt" not in recommended              # pre-existing file excluded
+
+
+async def test_deep_archive_commit_excludes_preexisting_untracked_files(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch, archive_dir: Path
+) -> None:
+    """A pre-existing untracked file (before the run) is absent from the daydream
+    commit's tree; a fix-created untracked file is present (issue #543)."""
+    remote = bare_remote(archive_dir.parent / "origin.git")
+    git(multi_stack_target, "remote", "add", "archive", str(remote))
+    stub = _install_deep_capture_backend(
+        multi_stack_target, monkeypatch, real_internal_phases=True
+    )
+    stub.fix_edit_line = "# daydream recommended change\n"
+    stub.fix_new_generated = "migrations/0002_add_x.sql"  # fix-created, untracked
+    (multi_stack_target / "notes.txt").write_text("pre-existing\n")  # pre-fix, untracked
+
+    exit_code = await run(
+        RunConfig(target=str(multi_stack_target), assume="yes", output_mode="loop", cleanup=False)
+    )
+    assert exit_code == 0
+
+    # The pushed branch's HEAD tree excludes notes.txt but includes the fix-created
+    # file (the stub pushes the current branch, so query that ref on the remote).
+    branch = git(multi_stack_target, "branch", "--show-current")
+    committed = git(remote, "ls-tree", "-r", "--name-only", branch).splitlines()
+    assert "migrations/0002_add_x.sql" in committed
+    assert "notes.txt" not in committed
+    # notes.txt still untracked in the working tree.
+    assert "notes.txt" in git(multi_stack_target, "status", "--porcelain")
 
 
 async def test_deep_run_with_unbalanced_quote_shell_command_still_archives_evaluation(

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -719,7 +719,7 @@ async def test_parallel_fix_failure_isolated_returns_nonzero(
     )
     commit_calls: list[int] = []
 
-    async def _spy_commit(backend: Any, work: Any) -> None:
+    async def _spy_commit(backend: Any, work: Any, **kwargs: Any) -> None:
         commit_calls.append(1)
 
     monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _spy_commit)
@@ -1035,9 +1035,10 @@ class _ScopeCreepBackend(_StubBackend):
     reviewed diff. This is the issue #336 post-fix residual shape: without the
     residual check the creep edit would be committed alongside the fix.
 
-    The commit prompt is answered with a REAL ``git add -u`` + ``git commit``
-    (tracked changes only — the stub's untracked sentinels must not leak into
-    the committed tree), so the test can assert the commit step's actual output.
+    The commit agent now commits the index that ``_do_commit`` deterministically
+    pre-staged (issue #543) — it only commits, never re-stages — so this stub
+    commits the already-staged index and lets the test assert the commit step's
+    actual output.
     """
 
     def __init__(self, target: Path, creep: Path, creep_edit: str) -> None:
@@ -1055,7 +1056,7 @@ class _ScopeCreepBackend(_StubBackend):
         max_turns: Any = None,
         read_only: bool = False,
     ):
-        if prompt.startswith("Stage all changes and commit"):
+        if prompt.startswith("The daydream changes are already staged"):
             run_id = re.search(r"^Daydream-Run: (.+)$", prompt, re.MULTILINE)
             version = re.search(r"^Daydream-Version: (.+)$", prompt, re.MULTILINE)
             assert run_id is not None
@@ -1065,7 +1066,6 @@ class _ScopeCreepBackend(_StubBackend):
                 f"Daydream-Run: {run_id.group(1)}\n"
                 f"Daydream-Version: {version.group(1)}"
             )
-            _git(cwd, "add", "-u")
             _git(cwd, "commit", "-m", message)
             yield TextEvent(text="Committed.")
             yield ResultEvent(structured_output=None, continuation=None)
@@ -1855,7 +1855,7 @@ async def test_parallel_fix_commit_runs_once_after_all(
     stub.merge_items = [_merge_item(i + 1, f, "high") for i, f in enumerate(files)]
     seen_at_commit: list[bool] = []
 
-    async def _spy_commit(backend: Any, work: Any) -> None:
+    async def _spy_commit(backend: Any, work: Any, **kwargs: Any) -> None:
         seen_at_commit.append(
             all((multi_stack_target / f".fixed-{f.replace('.', '_')}").exists() for f in files)
         )
@@ -1884,7 +1884,8 @@ async def test_fix_reverts_post_fix_edit_outside_reviewed_diff(
 
       1. unrelated.py is reverted to its pre-fix content (git shows no change);
       2. ``gh_issue_create`` was called with unrelated.py in the body;
-      3. the commit step lands a commit whose tree contains ONLY api.py;
+      3. the commit step lands a commit whose tree contains the fix (api.py)
+         and NOT unrelated.py;
       4. the committed tree contains zero files outside ``changed_files``.
 
     Discriminating: without the residual check, unrelated.py's edit survives to
@@ -1899,7 +1900,7 @@ async def test_fix_reverts_post_fix_edit_outside_reviewed_diff(
     _silence(monkeypatch)
     _force_interactive(monkeypatch)
     # Commit runs for real (the scope-creep backend answers the commit prompt
-    # with a real `git add -u` + commit); heal is stubbed to pass.
+    # with a real commit of the pre-staged index); heal is stubbed to pass.
     mute_side_effects(commit=False)
     stub = _ScopeCreepBackend(target, target / "unrelated.py", "\n# scope creep\n")
     stub.fix_edit_line = "\n# daydream fix\n"
@@ -1936,9 +1937,14 @@ async def test_fix_reverts_post_fix_edit_outside_reviewed_diff(
     assert len(issues) == 1, f"expected 1 issue, got {issues!r}"
     assert "unrelated.py" in issues[0][2]
 
-    # 3/4. The commit's tree contains zero files outside the reviewed diff.
+    # 3/4. The commit's tree contains the fix but zero out-of-scope files: the
+    # creep edit to unrelated.py must never survive. The commit tree may carry
+    # test-stub sentinels and .daydream/ artifacts (untracked files created
+    # mid-run, pre-staged by _do_commit deterministically), so the invariant is
+    # inclusion + absence, not exact equality.
     committed_paths = _git(target, "show", "--name-only", "--format=", "HEAD").split()
-    assert committed_paths == ["api.py"], (
+    assert "api.py" in committed_paths
+    assert "unrelated.py" not in committed_paths, (
         f"commit tree leaks out-of-scope files: {committed_paths}"
     )
     # The fix itself landed (api.py carries the daydream edit).
@@ -6235,8 +6241,7 @@ class _CommittingStubBackend(_StubBackend):
         max_turns: Any = None,
         read_only: bool = False,
     ) -> Any:
-        if prompt.startswith("Stage all changes and commit"):
-            _git(cwd, "add", "--all")
+        if prompt.startswith("The daydream changes are already staged"):
             _git(cwd, "commit", "-m", "fix: align greeting copy")
             yield TextEvent(text="Committed.")
             yield ResultEvent(structured_output=None, continuation=None)
@@ -6267,7 +6272,7 @@ class _PushingCommittingStubBackend(_StubBackend):
         max_turns: Any = None,
         read_only: bool = False,
     ) -> Any:
-        if prompt.startswith("Stage all changes and commit"):
+        if prompt.startswith("The daydream changes are already staged"):
             run_id = re.search(r"^Daydream-Run: (.+)$", prompt, re.MULTILINE)
             version = re.search(r"^Daydream-Version: (.+)$", prompt, re.MULTILINE)
             assert run_id is not None
@@ -6277,7 +6282,6 @@ class _PushingCommittingStubBackend(_StubBackend):
                 f"Daydream-Run: {run_id.group(1)}\n"
                 f"Daydream-Version: {version.group(1)}"
             )
-            _git(cwd, "add", "--all")
             _git(cwd, "commit", "-m", message)
             branch = _git(cwd, "branch", "--show-current")
             _git(cwd, "push", "-u", "origin", branch)

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -722,6 +722,18 @@ def test_commit_paths_commits_only_named_paths(repo_with_origin: Path) -> None:
     assert "untouched.txt" in _git(repo_with_origin, "status", "--porcelain")
 
 
+def test_stage_paths_stages_only_named_paths(repo_with_origin: Path) -> None:
+    """stage_paths stages exactly the named files into the index — never -A."""
+    git_ops.create_branch(repo_with_origin, "daydream/stage")
+    (repo_with_origin / "a.txt").write_text("a\n")
+    (repo_with_origin / "b.txt").write_text("b\n")
+    git_ops.stage_paths(repo_with_origin, [Path("a.txt")])
+    staged = _git(repo_with_origin, "diff", "--cached", "--name-only").split()
+    assert staged == ["a.txt"]
+    # b.txt remains unstaged + untracked.
+    assert "b.txt" in _git(repo_with_origin, "status", "--porcelain")
+
+
 def test_push_branch_failure_raises_git_error(git_repo: Path) -> None:
     """push_branch propagates a push failure (no ``origin`` remote) as GitError."""
     git_ops.create_branch(git_repo, "daydream/no-remote")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -233,10 +233,10 @@ class _WorktreeMutatingBackend(PhaseDispatchBackend):
     ):
         if prompt.startswith("Fix this issue") or prompt.startswith("Fix these"):
             (cwd / "main.py").write_text("def hello() -> str:\n    return 'world'\n")
-        elif prompt.startswith("Stage all changes and commit"):
+        elif prompt.startswith("The daydream changes are already staged"):
             run_id = prompt.split("Daydream-Run: ", 1)[1].splitlines()[0]
             version = prompt.split("Daydream-Version: ", 1)[1].splitlines()[0]
-            _git(cwd, "add", "main.py")
+            # The index is pre-staged by _do_commit (issue #543) — commit it.
             _commit(
                 cwd,
                 f"fix: add type hints\n\nDaydream-Run: {run_id}\nDaydream-Version: {version}",

--- a/tests/test_log_mode.py
+++ b/tests/test_log_mode.py
@@ -16,15 +16,13 @@ from __future__ import annotations
 
 import io
 import sys
-from collections.abc import AsyncGenerator, Callable
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any
 
 import pytest
 
 from daydream.backends import (
     AgentEvent,
-    ContinuationToken,
     CostEvent,
     MetricsEvent,
     ResultEvent,
@@ -257,43 +255,25 @@ def test_log_mode_console_redacts_string_payloads() -> None:
         set_log_mode(False)
 
 
-class _CredentialSummarizerBackend:
+class _CredentialSummarizerBackend(ScriptedBackend):
     """Failure-summarizer stub: yields the credential-bearing handoff_prompt.
 
     Mirrors the real summarizer contract (``FAILURE_SUMMARIZER_SCHEMA`` in
     phases.py: structured ``handoff_prompt`` in the ResultEvent) so the REAL
-    ``run_agent`` + ``_run_failure_summarizer`` path consumes it.
+    ``run_agent`` + ``_run_failure_summarizer`` path consumes it. Reuses
+    ``ScriptedBackend``'s shared four-member Backend surface; only the script
+    differs (one turn: blank text, then the credential-bearing ResultEvent).
     """
 
-    model = "test-model"
-
     def __init__(self, body: str) -> None:
-        self._body = body
-
-    def execute(
-        self,
-        cwd: Path,
-        prompt: str,
-        output_schema: dict[str, Any] | None = None,
-        continuation: ContinuationToken | None = None,
-        agents: dict[str, Any] | None = None,
-        max_turns: int | None = None,
-        read_only: bool = False,
-        persist_session: bool = True,
-    ) -> AsyncGenerator[AgentEvent, None]:
-        async def _gen() -> AsyncGenerator[AgentEvent, None]:
-            yield TextEvent(text="")
-            yield ResultEvent(
-                structured_output={"handoff_prompt": self._body}, continuation=None
-            )
-
-        return _gen()
-
-    async def cancel(self) -> None:
-        pass
-
-    def format_skill_invocation(self, skill_key: str, args: str = "") -> str:
-        return f"/{skill_key}"
+        super().__init__(
+            events=[
+                TextEvent(text=""),
+                ResultEvent(
+                    structured_output={"handoff_prompt": body}, continuation=None
+                ),
+            ]
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_log_mode.py
+++ b/tests/test_log_mode.py
@@ -255,6 +255,76 @@ def test_log_mode_console_redacts_string_payloads() -> None:
         set_log_mode(False)
 
 
+class _CredentialSummarizerBackend:
+    """Failure-summarizer stub: yields the credential-bearing handoff_prompt.
+
+    Mirrors the real summarizer contract (``FAILURE_SUMMARIZER_SCHEMA`` in
+    phases.py: structured ``handoff_prompt`` in the ResultEvent) so the REAL
+    ``run_agent`` + ``_run_failure_summarizer`` path consumes it.
+    """
+
+    model = "test-model"
+
+    def __init__(self, body: str) -> None:
+        self._body = body
+
+    async def execute(
+        self,
+        cwd,
+        prompt,
+        output_schema=None,
+        continuation=None,
+        agents=None,
+        max_turns=None,
+        read_only=False,
+    ):
+        yield TextEvent(text="")
+        yield ResultEvent(structured_output={"handoff_prompt": self._body}, continuation=None)
+
+    async def cancel(self) -> None:
+        pass
+
+    def format_skill_invocation(self, skill_key: str, args: str = "") -> str:
+        return f"/{skill_key}"
+
+
+@pytest.mark.asyncio
+async def test_log_mode_failure_handoff_redacts_credential_body(
+    git_repo: Path, make_work, capsys, monkeypatch,
+) -> None:
+    """Integration regression (issue #547): driving the REAL _emit_failure_handoff
+    with a credential-bearing summarizer body under --log mode must not leak the
+    raw token to stdout. The console-level _LogRedactingConsole boundary is the
+    mechanism (RD-1); this proves it on the real handoff path."""
+    from daydream.agent import set_log_mode
+    from daydream.phases import _emit_failure_handoff, console as phases_console
+
+    # False-pass trap: the module console phases.py binds MUST be the redacting
+    # console, otherwise a passing test would mean nothing.
+    assert type(phases_console).__name__ == "_LogRedactingConsole", (
+        "phases.py no longer binds the log-redacting console — the redaction "
+        "boundary for issue #547 is broken"
+    )
+
+    sentinel = "ghp_" + "A" * 12   # matches _API_KEY_PATTERN (ghp_ + >=6 alnum)
+    work = make_work(git_repo)
+    # Stub backend returns the credential-bearing summarizer body as structured
+    # handoff_prompt (real run_agent path, backend mocked only).
+    backend = _CredentialSummarizerBackend(f"token {sentinel}")
+
+    set_log_mode(True)
+    try:
+        await _emit_failure_handoff(
+            backend, work, "failing test output", offer_clipboard=False,
+        )
+        captured = capsys.readouterr()
+        out = captured.out + captured.err
+        assert sentinel not in out   # raw token never reaches stdout
+        assert "REDACTED" in out     # redaction marker present
+    finally:
+        set_log_mode(False)
+
+
 def test_log_mode_trajectory_still_written(
     tiny_diff_target: Path,
     make_config: MakeConfig,

--- a/tests/test_log_mode.py
+++ b/tests/test_log_mode.py
@@ -16,13 +16,15 @@ from __future__ import annotations
 
 import io
 import sys
-from collections.abc import Callable
+from collections.abc import AsyncGenerator, Callable
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from daydream.backends import (
     AgentEvent,
+    ContinuationToken,
     CostEvent,
     MetricsEvent,
     ResultEvent,
@@ -268,18 +270,24 @@ class _CredentialSummarizerBackend:
     def __init__(self, body: str) -> None:
         self._body = body
 
-    async def execute(
+    def execute(
         self,
-        cwd,
-        prompt,
-        output_schema=None,
-        continuation=None,
-        agents=None,
-        max_turns=None,
-        read_only=False,
-    ):
-        yield TextEvent(text="")
-        yield ResultEvent(structured_output={"handoff_prompt": self._body}, continuation=None)
+        cwd: Path,
+        prompt: str,
+        output_schema: dict[str, Any] | None = None,
+        continuation: ContinuationToken | None = None,
+        agents: dict[str, Any] | None = None,
+        max_turns: int | None = None,
+        read_only: bool = False,
+        persist_session: bool = True,
+    ) -> AsyncGenerator[AgentEvent, None]:
+        async def _gen() -> AsyncGenerator[AgentEvent, None]:
+            yield TextEvent(text="")
+            yield ResultEvent(
+                structured_output={"handoff_prompt": self._body}, continuation=None
+            )
+
+        return _gen()
 
     async def cancel(self) -> None:
         pass
@@ -297,7 +305,8 @@ async def test_log_mode_failure_handoff_redacts_credential_body(
     raw token to stdout. The console-level _LogRedactingConsole boundary is the
     mechanism (RD-1); this proves it on the real handoff path."""
     from daydream.agent import set_log_mode
-    from daydream.phases import _emit_failure_handoff, console as phases_console
+    from daydream.phases import _emit_failure_handoff
+    from daydream.phases import console as phases_console
 
     # False-pass trap: the module console phases.py binds MUST be the redacting
     # console, otherwise a passing test would mean nothing.

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -308,6 +308,98 @@ class _StagedCommitBackend(StubBackend):
             yield event
 
 
+class _ReStageCommitBackend(StubBackend):
+    """Commit-agent stub that IGNORES the staging instruction and re-runs
+    ``git add -A`` — the issue #562 failure mode the post-commit verification
+    must surface. Sweeps a pre-existing untracked file into the commit that
+    ``_do_commit`` deliberately left out of the pre-staged index.
+    """
+
+    async def execute(
+        self,
+        cwd: Path,
+        prompt: str,
+        output_schema: Any = None,
+        continuation: Any = None,
+        agents: Any = None,
+        max_turns: Any = None,
+        read_only: bool = False,
+        persist_session: bool = True,
+    ) -> AsyncGenerator[AgentEvent, None]:
+        if prompt.startswith("The daydream changes are already staged"):
+            run_id = prompt.split("Daydream-Run: ", 1)[1].splitlines()[0]
+            version = prompt.split("Daydream-Version: ", 1)[1].splitlines()[0]
+            git(cwd, "add", "-A")
+            git(
+                cwd,
+                "commit",
+                "-m",
+                f"fix: apply daydream changes\n\n"
+                f"Daydream-Run: {run_id}\nDaydream-Version: {version}",
+            )
+            yield TextEvent(text="Committed the staged changes.")
+            yield ResultEvent(structured_output=None, continuation=None)
+            return
+
+        async for event in super().execute(
+            cwd,
+            prompt,
+            output_schema=output_schema,
+            continuation=continuation,
+            agents=agents,
+            max_turns=max_turns,
+            read_only=read_only,
+        ):
+            yield event
+
+
+class _PartialCommitBackend(StubBackend):
+    """Commit-agent stub that commits only a subset of the pre-staged index
+    (``git commit -- <one path>``), leaving the other staged fix uncommitted —
+    the under-commit direction the verification must surface.
+    """
+
+    async def execute(
+        self,
+        cwd: Path,
+        prompt: str,
+        output_schema: Any = None,
+        continuation: Any = None,
+        agents: Any = None,
+        max_turns: Any = None,
+        read_only: bool = False,
+        persist_session: bool = True,
+    ) -> AsyncGenerator[AgentEvent, None]:
+        if prompt.startswith("The daydream changes are already staged"):
+            run_id = prompt.split("Daydream-Run: ", 1)[1].splitlines()[0]
+            version = prompt.split("Daydream-Version: ", 1)[1].splitlines()[0]
+            # Partial commit: only app.py enters the committed tree; helper.py
+            # stays staged and must be surfaced as an under-commit.
+            git(
+                cwd,
+                "commit",
+                "-m",
+                f"fix: apply daydream changes\n\n"
+                f"Daydream-Run: {run_id}\nDaydream-Version: {version}",
+                "--",
+                "app.py",
+            )
+            yield TextEvent(text="Committed one path.")
+            yield ResultEvent(structured_output=None, continuation=None)
+            return
+
+        async for event in super().execute(
+            cwd,
+            prompt,
+            output_schema=output_schema,
+            continuation=continuation,
+            agents=agents,
+            max_turns=max_turns,
+            read_only=read_only,
+        ):
+            yield event
+
+
 @pytest.mark.asyncio
 async def test_do_commit_excludes_preexisting_untracked_from_tree(
     git_repo: Path, make_work, capsys,
@@ -337,6 +429,101 @@ async def test_do_commit_excludes_preexisting_untracked_from_tree(
     assert "notes.txt" in git(git_repo, "status", "--porcelain")
     # Daydream-Run trailer still applied (existing flow preserved).
     assert "Daydream-Run:" in git(git_repo, "log", "-1", "--format=%B")
+
+
+@pytest.mark.asyncio
+async def test_do_commit_warns_on_scope_creep_beyond_prestaged_set(
+    git_repo: Path, make_work, capsys,
+) -> None:
+    """#562 enforcement is not prompt-only: a commit agent that re-runs
+    ``git add -A`` sweeps a pre-existing untracked file into the commit, and
+    the post-commit verification must warn — the committed tree exceeds the
+    pre-staged daydream set."""
+    from daydream.phases import _do_commit
+
+    work = make_work(git_repo)
+    (git_repo / "app.py").write_text("x = 0\n")            # tracked baseline
+    git(git_repo, "add", "app.py")
+    git_commit(git_repo, "baseline app.py")
+    (git_repo / "app.py").write_text("x = 1\n")            # daydream change (tracked)
+    (git_repo / "notes.txt").write_text("user scratch\n")  # pre-existing untracked
+    backend = _ReStageCommitBackend(git_repo)
+
+    ok = await _do_commit(
+        backend, work, push=False, preexisting_untracked={"notes.txt"},
+    )
+    assert ok is True
+    committed = git(git_repo, "show", "--name-only", "--format=", "HEAD").split()
+    assert "app.py" in committed
+    assert "notes.txt" in committed  # the bad agent swept it in
+    out = capsys.readouterr().out
+    assert "scope creep" in out
+    assert "notes.txt" in out
+
+
+@pytest.mark.asyncio
+async def test_do_commit_warns_on_under_commit_missing_prestaged_files(
+    git_repo: Path, make_work, capsys,
+) -> None:
+    """A commit agent that commits only part of the pre-staged index drops the
+    remaining tracked fixes — the verification surfaces the under-commit
+    instead of reporting a clean pass."""
+    from daydream.phases import _do_commit
+
+    work = make_work(git_repo)
+    (git_repo / "app.py").write_text("x = 0\n")
+    (git_repo / "helper.py").write_text("h = 0\n")
+    git(git_repo, "add", "app.py", "helper.py")
+    git_commit(git_repo, "baseline")
+    (git_repo / "app.py").write_text("x = 1\n")    # daydream change
+    (git_repo / "helper.py").write_text("h = 1\n")  # daydream change
+    backend = _PartialCommitBackend(git_repo)
+
+    ok = await _do_commit(
+        backend, work, push=False, preexisting_untracked=set(),
+    )
+    assert ok is True
+    committed = git(git_repo, "show", "--name-only", "--format=", "HEAD").split()
+    assert "app.py" in committed
+    assert "helper.py" not in committed  # dropped by the partial commit
+    out = capsys.readouterr().out
+    assert "under-commit" in out
+    assert "helper.py" in out
+
+
+@pytest.mark.asyncio
+async def test_do_commit_excludes_daydream_run_artifacts_from_tree(
+    git_repo: Path, make_work, capsys,
+) -> None:
+    """Daydream's own mid-run artifacts under .daydream/ (recommended.patch,
+    fix-failures.json, quality-gate verdicts) are excluded from the
+    deterministic stage: they must not land in the daydream commit and get
+    pushed even when the repo does not ignore .daydream/."""
+    from daydream.phases import _do_commit
+
+    work = make_work(git_repo)
+    (git_repo / "app.py").write_text("x = 0\n")
+    git(git_repo, "add", "app.py")
+    git_commit(git_repo, "baseline app.py")
+    (git_repo / "app.py").write_text("x = 1\n")  # daydream change (tracked)
+    # Mid-run artifacts created after the pre-run untracked snapshot.
+    dd = git_repo / ".daydream"
+    dd.mkdir()
+    (dd / "recommended.patch").write_text("--- a/app.py\n")
+    (dd / "fix-failures.json").write_text("[]\n")
+    (dd / "deep").mkdir(parents=True)
+    (dd / "deep" / "fix-quality-gate.json").write_text("{}\n")
+    backend = _StagedCommitBackend(git_repo)
+
+    ok = await _do_commit(
+        backend, work, push=False, preexisting_untracked=set(),
+    )
+    assert ok is True
+    committed = git(git_repo, "show", "--name-only", "--format=", "HEAD").split()
+    assert "app.py" in committed
+    assert not any(p.startswith(".daydream/") for p in committed), (
+        f"commit tree carries .daydream/ artifacts: {committed}"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -18,6 +18,7 @@ from daydream.config import REVIEW_OUTPUT_FILE
 from tests.harness.backend import ScriptedBackend
 from tests.harness.git_helpers import commit as git_commit
 from tests.harness.git_helpers import git, init_repo
+from tests.harness.stub_backend import StubBackend
 
 _RESULT = ResultEvent(structured_output=None, continuation=None)
 _FAIL_TURN: tuple[AgentEvent, ...] = (TextEvent(text="1 failed, 0 passed"), _RESULT)
@@ -259,6 +260,78 @@ def test_test_healing_guard_preserves_untouched_preexisting_untracked_bytes(tmp_
 
     assert violations == []
     assert migration.read_bytes() == original
+
+
+class _StagedCommitBackend(StubBackend):
+    """Commit-agent stub: commits the ALREADY-STAGED index with daydream trailers.
+
+    Never runs ``git add`` — the deterministic pre-staging in ``_do_commit``
+    (issue #562/#543) has staged exactly the intended files, so re-staging with
+    ``--all`` would sweep pre-existing untracked files back into the commit.
+    """
+
+    async def execute(
+        self,
+        cwd: Path,
+        prompt: str,
+        output_schema: Any = None,
+        continuation: Any = None,
+        agents: Any = None,
+        max_turns: Any = None,
+        read_only: bool = False,
+    ):
+        if prompt.startswith("The daydream changes are already staged"):
+            run_id = prompt.split("Daydream-Run: ", 1)[1].splitlines()[0]
+            version = prompt.split("Daydream-Version: ", 1)[1].splitlines()[0]
+            git(
+                cwd,
+                "commit",
+                "-m",
+                f"fix: apply daydream changes\n\n"
+                f"Daydream-Run: {run_id}\nDaydream-Version: {version}",
+            )
+            yield TextEvent(text="Committed the staged changes.")
+            yield ResultEvent(structured_output=None, continuation=None)
+            return
+
+        async for event in super().execute(
+            cwd,
+            prompt,
+            output_schema=output_schema,
+            continuation=continuation,
+            agents=agents,
+            max_turns=max_turns,
+            read_only=read_only,
+        ):
+            yield event
+
+
+@pytest.mark.asyncio
+async def test_do_commit_excludes_preexisting_untracked_from_tree(
+    git_repo: Path, make_work, capsys,
+) -> None:
+    """_do_commit stages only (daydream changes + new untracked) - (pre-existing
+    untracked): a pre-existing file never enters the commit tree; a fix-created
+    file does."""
+    from daydream.phases import _do_commit
+
+    work = make_work(git_repo)
+    (git_repo / "app.py").write_text("x = 1\n")            # daydream change
+    (git_repo / "notes.txt").write_text("user scratch\n")  # pre-existing untracked
+    backend = _StagedCommitBackend(git_repo)
+
+    ok = await _do_commit(
+        backend, work, push=False, preexisting_untracked={"notes.txt"},
+    )
+    assert ok is True
+    # The commit exists and its tree has the daydream change but NOT notes.txt.
+    committed = git(git_repo, "show", "--name-only", "--format=", "HEAD").split()
+    assert "app.py" in committed
+    assert "notes.txt" not in committed
+    # notes.txt is still an uncommitted untracked file on disk.
+    assert "notes.txt" in git(git_repo, "status", "--porcelain")
+    # Daydream-Run trailer still applied (existing flow preserved).
+    assert "Daydream-Run:" in git(git_repo, "log", "-1", "--format=%B")
 
 
 @pytest.mark.asyncio

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -2,6 +2,7 @@
 """Tests for phase functions with backend abstraction."""
 
 import json
+from collections.abc import AsyncGenerator
 from io import StringIO
 from pathlib import Path
 from typing import Any
@@ -279,7 +280,8 @@ class _StagedCommitBackend(StubBackend):
         agents: Any = None,
         max_turns: Any = None,
         read_only: bool = False,
-    ):
+        persist_session: bool = True,
+    ) -> AsyncGenerator[AgentEvent, None]:
         if prompt.startswith("The daydream changes are already staged"):
             run_id = prompt.split("Daydream-Run: ", 1)[1].splitlines()[0]
             version = prompt.split("Daydream-Version: ", 1)[1].splitlines()[0]

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -318,7 +318,10 @@ async def test_do_commit_excludes_preexisting_untracked_from_tree(
     from daydream.phases import _do_commit
 
     work = make_work(git_repo)
-    (git_repo / "app.py").write_text("x = 1\n")            # daydream change
+    (git_repo / "app.py").write_text("x = 0\n")  # tracked baseline
+    git(git_repo, "add", "app.py")
+    git_commit(git_repo, "baseline app.py")
+    (git_repo / "app.py").write_text("x = 1\n")            # daydream change (tracked modification)
     (git_repo / "notes.txt").write_text("user scratch\n")  # pre-existing untracked
     backend = _StagedCommitBackend(git_repo)
 

--- a/tests/test_pr_feedback_integration.py
+++ b/tests/test_pr_feedback_integration.py
@@ -9,10 +9,11 @@ the seam used by the deep-orchestrator exemplar in ``test_deep_orchestrator.py``
 
 The mock backend dispatches on prompt content to behave like the skill agents
 would: it writes ``.review-output.md``, returns parsed issues, applies a REAL
-edit to ``api.py``, runs REAL ``git add``/``git commit``, and records the
-respond-pr-feedback invocation. Assertions are on observable outcomes only:
-exit code, the marker written into the real file, a new git commit carrying the
-Daydream trailer, and the recorded respond invocation carrying the right pr/bot.
+edit to ``api.py``, commits the index ``_do_commit`` pre-staged (REAL
+``git commit``, no re-staging), and records the respond-pr-feedback invocation.
+Assertions are on observable outcomes only: exit code, the marker written into
+the real file, a new git commit carrying the Daydream trailer, and the recorded
+respond invocation carrying the right pr/bot.
 """
 
 from __future__ import annotations
@@ -102,11 +103,11 @@ class _PRFeedbackStubBackend:
 
         # Phase 4: commit -> run REAL git in cwd. Include the two Daydream
         # trailers so the prompt's amend path is not exercised (we assert on
-        # what the agent itself committed).
-        if "stage all changes and commit" in pl:
+        # what the agent itself committed). The index is pre-staged by
+        # _do_commit (deterministic staging, issue #543) — commit it as-is.
+        if "the daydream changes are already staged" in pl:
             run_id = self._extract_trailer(prompt, "Daydream-Run")
             version = self._extract_trailer(prompt, "Daydream-Version")
-            _git(cwd, "add", "-A")
             _git(
                 cwd,
                 "commit",

--- a/tests/test_pr_feedback_integration.py
+++ b/tests/test_pr_feedback_integration.py
@@ -134,7 +134,15 @@ class _PRFeedbackStubBackend:
     @staticmethod
     def _extract_trailer(prompt: str, key: str) -> str:
         m = re.search(rf"{re.escape(key)}:\s*(\S+)", prompt)
-        return m.group(1) if m else "unknown"
+        if m is None:
+            # Fail closed: if the production prompt ever drops the trailer
+            # lines while keeping the "already staged" phrase, committing
+            # "Daydream-Run: unknown" would still satisfy the substring
+            # assert — raise instead so the regression surfaces.
+            raise AssertionError(
+                f"commit prompt dropped the {key} trailer line"
+            )
+        return m.group(1)
 
     async def cancel(self) -> None:
         pass
@@ -185,6 +193,12 @@ async def test_pr_feedback_real_path(
     assert head_after != head_before
     commit_msg = _git(multi_stack_target, "log", "-1", "--format=%B")
     assert "Daydream-Run:" in commit_msg
+
+    # Observable 3b: the committed TREE carries the api.py fix, not just the
+    # working tree. A staging regression that commits wrong paths while
+    # omitting api.py must fail here.
+    committed_api = _git(multi_stack_target, "show", "HEAD:api.py")
+    assert FIX_MARKER.strip() in committed_api
 
     # Observable 4: the reply path ran with the right pr/bot.
     assert len(stub.respond_calls) == 1

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -778,7 +778,7 @@ class _CommitWritingBackend:
             yield TextEvent(text="All 1 tests passed. 0 failed.")
             yield ResultEvent(structured_output=None, continuation=None)
             return
-        if "stage all changes and commit" in pl:
+        if "the daydream changes are already staged" in pl:
             self.commit_prompts.append(prompt)
             run_id = re.search(r"Daydream-Run: (\S+)", prompt)
             version = re.search(r"Daydream-Version: (\S+)", prompt)
@@ -787,7 +787,6 @@ class _CommitWritingBackend:
                 f"Daydream-Run: {run_id.group(1) if run_id else 'unknown'}\n"
                 f"Daydream-Version: {version.group(1) if version else 'unknown'}\n"
             )
-            _git(cwd, "add", "-A")
             _git(cwd, "commit", "-m", message)
             yield TextEvent(text="Committed.")
             yield ResultEvent(structured_output=None, continuation=None)


### PR DESCRIPTION
## Summary
Closes #562

Consolidates out-of-scope findings handling in daydream/phases.py — the raw `--log` output and untracked files in the commit. Rounds 1 and 2 of daydream deep-precision review completed; round-2 commit 3a9c92b added under-commit detection (`_verify_commit_scope`), strict `changed_files_against` enumeration, and exclusion of `.daydream/` run artifacts. Branch merged cleanly with main (resolved `list_untracked` strict-param conflict).

## Verification
- verify-branch-authors: AUTHORS_OK (all 11 commits by anderskev@gmail.com)
- make check: PASS (3445 passed, 6 skipped)
- Two sequential daydream deep-precision reviews passed (trajectories uploaded to HF)