### PR TITLE
[daydream] #456 Preserve stack-specific omissions in improve coverage reporting

### DIFF
--- a/daydream/improve/orchestrator.py
+++ b/daydream/improve/orchestrator.py
@@ -527,7 +527,7 @@ async def _step_recon(ctx: FlowContext) -> Stop | None:
     ctx.data["stacks"] = stacks
     ctx.data["partitions"] = partitions
     ctx.data["partition_groups"] = groups
-    ctx.data["partitions_not_audited"] = skipped
+    ctx.data["partition_omissions"] = skipped
     return None
 
 
@@ -1083,7 +1083,7 @@ async def _step_audit(ctx: FlowContext) -> Stop | None:
         directory,
         partitions,
         groups,
-        ctx.data["partitions_not_audited"],
+        ctx.data["partition_omissions"],
         failures=failures,
         assignments=assignments,
     )
@@ -2207,8 +2207,11 @@ def _render_report(ctx: FlowContext) -> str:
     plan_write = ctx.data["plan_write"]
     issue_publication = ctx.data.get("issue_publication")
     partitions = ctx.data["partitions"]
-    partitions_not_audited = ctx.data["partitions_not_audited"]
+    partition_omissions = ctx.data["partition_omissions"]
     groups = ctx.data["partition_groups"]
+    ledger = _coverage_ledger(partitions, groups, partition_omissions)
+    not_audited = ledger["not_audited"]
+    partially_audited = ledger["partially_audited"]
     service_lines = (
         "\n".join(f"- **{service.name}** — `{service.root.as_posix()}`" for service in services)
         or "- No service roots detected."
@@ -2227,17 +2230,24 @@ def _render_report(ctx: FlowContext) -> str:
         )
         or "- None."
     )
+    omitted_bullets = [
+        f"  - **{entry['partition']}** — `{entry['root']}/` ({entry['file_count']} files) "
+        f"— not audited (omitted: {', '.join(entry['omitted_stacks'])})"
+        for entry in not_audited
+    ]
+    partial_bullets = [
+        f"  - **{entry['partition']}** — `{entry['root']}/` ({entry['file_count']} files) "
+        f"— partially audited (audited: {', '.join(entry['audited_stacks'])}; "
+        f"omitted: {', '.join(entry['omitted_stacks'])})"
+        for entry in partially_audited
+    ]
     not_audited_lines = (
         (
             "- Partitions not audited (reason: group-ceiling; raise "
             "`max-partition-groups` to include them):\n"
-            + "\n".join(
-                f"  - **{omission.partition.name}** — `{omission.partition.root}/` "
-                f"({len(omission.partition.files)} files)"
-                for omission in partitions_not_audited
-            )
+            + "\n".join(omitted_bullets + partial_bullets)
         )
-        if partitions_not_audited
+        if omitted_bullets or partial_bullets
         else f"- All {len(partitions)} partitions were audited."
     )
     tier_bound = {

--- a/daydream/improve/orchestrator.py
+++ b/daydream/improve/orchestrator.py
@@ -611,9 +611,14 @@ def _coverage_ledger(
     partitions: list[Partition],
     groups: list[PartitionGroup],
     omissions: list[PartitionStackOmission],
+    failed_groups: set[str] | None = None,
 ) -> dict[str, Any]:
-    """Build the coverage ledger recording what the audit did and did not cover."""
-    retained = {partition for group in groups for partition in group.partitions}
+    """Build the coverage ledger recording what the audit did and did not cover.
+
+    `failed_groups` names the groups whose audit assignments failed; their
+    stacks count as uncovered, never as audited.
+    """
+    failed_groups = failed_groups or set()
     omitted_by_partition: dict[Partition, list[str]] = {}
     for omission in omissions:
         omitted_by_partition.setdefault(omission.partition, []).append(omission.stack)
@@ -621,24 +626,38 @@ def _coverage_ledger(
     not_audited: list[dict[str, Any]] = []
     partially_audited: list[dict[str, Any]] = []
     for partition, omitted_stacks in omitted_by_partition.items():
+        retained_groups = [
+            group for group in groups if partition in group.partitions
+        ]
+        audited_stacks = sorted(
+            {
+                group.stack
+                for group in retained_groups
+                if group.name not in failed_groups and group.stack is not None
+            }
+        )
+        failed_stacks = sorted(
+            {
+                group.stack
+                for group in retained_groups
+                if group.name in failed_groups and group.stack is not None
+            }
+        )
         entry = {
             "partition": partition.name,
             "root": partition.root,
             "file_count": len(partition.files),
-            "reason": "group-ceiling",
+            "reason": (
+                "group-failed"
+                if retained_groups and not audited_stacks
+                else "group-ceiling"
+            ),
+            "omitted_stacks": sorted(set(omitted_stacks) | set(failed_stacks)),
         }
-        if partition in retained:
-            partially_audited.append(
-                {
-                    **entry,
-                    "audited_stacks": sorted(
-                        {group.stack for group in groups if partition in group.partitions}
-                    ),
-                    "omitted_stacks": sorted(omitted_stacks),
-                }
-            )
+        if audited_stacks:
+            partially_audited.append({**entry, "audited_stacks": audited_stacks})
         else:
-            not_audited.append({**entry, "omitted_stacks": sorted(omitted_stacks)})
+            not_audited.append(entry)
 
     return {
         "artifact_type": "daydream.improve-coverage",
@@ -1117,7 +1136,9 @@ def _record_audit_coverage(
         for assignment in assignments
         if assignment.key in failures
     }
-    ledger = _coverage_ledger(partitions, groups, omissions)
+    ledger = _coverage_ledger(
+        partitions, groups, omissions, failed_groups=failed_groups
+    )
     for entry in ledger["groups"]:
         entry["status"] = "failed" if entry["name"] in failed_groups else "audited"
     ledger["failed_assignments"] = dict(sorted(failures.items()))
@@ -2190,6 +2211,24 @@ def _reanchored_report_section(plans_dir: Path) -> str:
     return f"## Re-anchored plans\n\n{table}\n"
 
 
+def _coverage_bullet(entry: dict[str, Any]) -> str:
+    """Render one coverage ledger entry as a report bullet."""
+    prefix = (
+        f"  - **{entry['partition']}** — `{entry['root']}/` "
+        f"({entry['file_count']} files) "
+    )
+    if "audited_stacks" in entry:
+        return (
+            prefix
+            + f"— partially audited (audited: {', '.join(entry['audited_stacks'])}; "
+            f"omitted: {', '.join(entry['omitted_stacks'])})"
+        )
+    return (
+        prefix
+        + f"— not audited (omitted: {', '.join(entry['omitted_stacks'])})"
+    )
+
+
 def _render_report(ctx: FlowContext) -> str:
     services = ctx.data["services"]
     all_services = ctx.data["all_services"]
@@ -2209,7 +2248,11 @@ def _render_report(ctx: FlowContext) -> str:
     partitions = ctx.data["partitions"]
     partition_omissions = ctx.data["partition_omissions"]
     groups = ctx.data["partition_groups"]
-    ledger = _coverage_ledger(partitions, groups, partition_omissions)
+    failures = audit.get("failed", {})
+    failed_groups = {key.partition(":")[2] for key in failures}
+    ledger = _coverage_ledger(
+        partitions, groups, partition_omissions, failed_groups=failed_groups
+    )
     not_audited = ledger["not_audited"]
     partially_audited = ledger["partially_audited"]
     service_lines = (
@@ -2220,7 +2263,6 @@ def _render_report(ctx: FlowContext) -> str:
     cleanup_pressure_lines = _cleanup_pressure_lines(findings)
     stack_lines = "\n".join(f"- **{stack.stack_name}**" for stack in stacks) or "- No stacks detected."
     roots_by_group = {group.name: _group_roots_cell(group) for group in groups}
-    failures = audit.get("failed", {})
     failed_assignment_lines = (
         "\n".join(
             f"- **{assignment.replace(':', ' / ')}** "
@@ -2230,27 +2272,10 @@ def _render_report(ctx: FlowContext) -> str:
         )
         or "- None."
     )
-    def _coverage_bullet(entry: dict[str, Any]) -> str:
-        """Render one coverage ledger entry as a report bullet."""
-        prefix = (
-            f"  - **{entry['partition']}** — `{entry['root']}/` "
-            f"({entry['file_count']} files) "
-        )
-        if "audited_stacks" in entry:
-            return (
-                prefix
-                + f"— partially audited (audited: {', '.join(entry['audited_stacks'])}; "
-                f"omitted: {', '.join(entry['omitted_stacks'])})"
-            )
-        return (
-            prefix
-            + f"— not audited (omitted: {', '.join(entry['omitted_stacks'])})"
-        )
-
     coverage_bullets = [
         _coverage_bullet(entry) for entry in not_audited + partially_audited
     ]
-    not_audited_lines = (
+    coverage_lines = (
         (
             "- Partitions not fully audited (reason: group-ceiling; raise "
             "`max-partition-groups` to include them):\n"
@@ -2318,7 +2343,7 @@ def _render_report(ctx: FlowContext) -> str:
         "## What was not audited\n\n"
         f"- {tier_bound}\n"
         f"- {scope_statement}\n\n"
-        f"{not_audited_lines}\n\n"
+        f"{coverage_lines}\n\n"
         "### Failed audit assignments\n\n"
         f"{failed_assignment_lines}\n\n"
         "## Audit filtering\n\n"

--- a/daydream/improve/orchestrator.py
+++ b/daydream/improve/orchestrator.py
@@ -392,7 +392,7 @@ async def _step_recon(ctx: FlowContext) -> Stop | None:
     stacks: list[StackAssignment] = []
     partitions: list[Partition] = []
     groups: list[PartitionGroup] = []
-    skipped: list[PartitionStackOmission] = []
+    omissions: list[PartitionStackOmission] = []
     if not description_mode:
         # Availability is resolved once in runner.run and threaded via config;
         # None flows through to detect_stacks' optimistic default.
@@ -405,7 +405,7 @@ async def _step_recon(ctx: FlowContext) -> Stop | None:
         if ctx.config.improve_scope:
             stacks = _stacks_for_services(stacks, services)
             tracked = sorted({path for stack in stacks for path in stack.files})
-        partitions, groups, skipped = _partition_repository(
+        partitions, groups, omissions = _partition_repository(
             ctx,
             tracked,
             services,
@@ -415,7 +415,7 @@ async def _step_recon(ctx: FlowContext) -> Stop | None:
         coverage_path(directory).write_text(
             json.dumps(
                 _with_artifact_provenance(
-                    _coverage_ledger(partitions, groups, skipped),
+                    _coverage_ledger(partitions, groups, omissions),
                     phase=DaydreamPhase.RECON,
                 ),
                 indent=2,
@@ -527,7 +527,7 @@ async def _step_recon(ctx: FlowContext) -> Stop | None:
     ctx.data["stacks"] = stacks
     ctx.data["partitions"] = partitions
     ctx.data["partition_groups"] = groups
-    ctx.data["partition_omissions"] = skipped
+    ctx.data["partition_omissions"] = omissions
     return None
 
 
@@ -564,13 +564,13 @@ def _partition_repository(
         return [whole], [_whole_surface_group(whole, stack_of)], []
 
     partitions = build_partitions(tracked, services, max_files=max_files)
-    groups, skipped = group_partitions(
+    groups, omissions = group_partitions(
         partitions,
         stack_of,
         max_files=max_files,
         max_groups=max_groups,
     )
-    return partitions, groups, skipped
+    return partitions, groups, omissions
 
 
 def _whole_surface_group(
@@ -610,12 +610,12 @@ def _group_dict(group: PartitionGroup) -> dict[str, Any]:
 def _coverage_ledger(
     partitions: list[Partition],
     groups: list[PartitionGroup],
-    skipped: list[PartitionStackOmission],
+    omissions: list[PartitionStackOmission],
 ) -> dict[str, Any]:
     """Build the coverage ledger recording what the audit did and did not cover."""
     retained = {partition for group in groups for partition in group.partitions}
     omitted_by_partition: dict[Partition, list[str]] = {}
-    for omission in skipped:
+    for omission in omissions:
         omitted_by_partition.setdefault(omission.partition, []).append(omission.stack)
 
     not_audited: list[dict[str, Any]] = []
@@ -1106,7 +1106,7 @@ def _record_audit_coverage(
     directory: Path,
     partitions: list[Partition],
     groups: list[PartitionGroup],
-    skipped: list[PartitionStackOmission],
+    omissions: list[PartitionStackOmission],
     *,
     failures: dict[str, str],
     assignments: list[_AuditAssignment],
@@ -1117,7 +1117,7 @@ def _record_audit_coverage(
         for assignment in assignments
         if assignment.key in failures
     }
-    ledger = _coverage_ledger(partitions, groups, skipped)
+    ledger = _coverage_ledger(partitions, groups, omissions)
     for entry in ledger["groups"]:
         entry["status"] = "failed" if entry["name"] in failed_groups else "audited"
     ledger["failed_assignments"] = dict(sorted(failures.items()))
@@ -2230,24 +2230,33 @@ def _render_report(ctx: FlowContext) -> str:
         )
         or "- None."
     )
-    omitted_bullets = [
-        f"  - **{entry['partition']}** — `{entry['root']}/` ({entry['file_count']} files) "
-        f"— not audited (omitted: {', '.join(entry['omitted_stacks'])})"
-        for entry in not_audited
-    ]
-    partial_bullets = [
-        f"  - **{entry['partition']}** — `{entry['root']}/` ({entry['file_count']} files) "
-        f"— partially audited (audited: {', '.join(entry['audited_stacks'])}; "
-        f"omitted: {', '.join(entry['omitted_stacks'])})"
-        for entry in partially_audited
+    def _coverage_bullet(entry: dict[str, Any]) -> str:
+        """Render one coverage ledger entry as a report bullet."""
+        prefix = (
+            f"  - **{entry['partition']}** — `{entry['root']}/` "
+            f"({entry['file_count']} files) "
+        )
+        if "audited_stacks" in entry:
+            return (
+                prefix
+                + f"— partially audited (audited: {', '.join(entry['audited_stacks'])}; "
+                f"omitted: {', '.join(entry['omitted_stacks'])})"
+            )
+        return (
+            prefix
+            + f"— not audited (omitted: {', '.join(entry['omitted_stacks'])})"
+        )
+
+    coverage_bullets = [
+        _coverage_bullet(entry) for entry in not_audited + partially_audited
     ]
     not_audited_lines = (
         (
-            "- Partitions not audited (reason: group-ceiling; raise "
+            "- Partitions not fully audited (reason: group-ceiling; raise "
             "`max-partition-groups` to include them):\n"
-            + "\n".join(omitted_bullets + partial_bullets)
+            + "\n".join(coverage_bullets)
         )
-        if omitted_bullets or partial_bullets
+        if coverage_bullets
         else f"- All {len(partitions)} partitions were audited."
     )
     tier_bound = {

--- a/daydream/improve/orchestrator.py
+++ b/daydream/improve/orchestrator.py
@@ -52,6 +52,7 @@ from daydream.improve.partition import (
     PARTITION_MAX_FILES,
     Partition,
     PartitionGroup,
+    PartitionStackOmission,
     build_partitions,
     group_partitions,
     stack_by_path,
@@ -391,7 +392,7 @@ async def _step_recon(ctx: FlowContext) -> Stop | None:
     stacks: list[StackAssignment] = []
     partitions: list[Partition] = []
     groups: list[PartitionGroup] = []
-    skipped: list[Partition] = []
+    skipped: list[PartitionStackOmission] = []
     if not description_mode:
         # Availability is resolved once in runner.run and threaded via config;
         # None flows through to detect_stacks' optimistic default.
@@ -537,7 +538,7 @@ def _partition_repository(
     stacks: list[StackAssignment],
     *,
     branch_focus: bool,
-) -> tuple[list[Partition], list[PartitionGroup], list[Partition]]:
+) -> tuple[list[Partition], list[PartitionGroup], list[PartitionStackOmission]]:
     """Cover the audited surface with partitions and pack them into groups.
 
     Branch focus and the ``quick`` tier bypass partitioning: both audit one
@@ -609,7 +610,7 @@ def _group_dict(group: PartitionGroup) -> dict[str, Any]:
 def _coverage_ledger(
     partitions: list[Partition],
     groups: list[PartitionGroup],
-    skipped: list[Partition],
+    skipped: list[PartitionStackOmission],
 ) -> dict[str, Any]:
     """Build the coverage ledger recording what the audit did and did not cover."""
     return {
@@ -631,12 +632,12 @@ def _coverage_ledger(
         ],
         "not_audited": [
             {
-                "partition": partition.name,
-                "root": partition.root,
-                "file_count": len(partition.files),
+                "partition": omission.partition.name,
+                "root": omission.partition.root,
+                "file_count": len(omission.partition.files),
                 "reason": "group-ceiling",
             }
-            for partition in skipped
+            for omission in skipped
         ],
     }
 
@@ -1085,7 +1086,7 @@ def _record_audit_coverage(
     directory: Path,
     partitions: list[Partition],
     groups: list[PartitionGroup],
-    skipped: list[Partition],
+    skipped: list[PartitionStackOmission],
     *,
     failures: dict[str, str],
     assignments: list[_AuditAssignment],
@@ -2211,9 +2212,9 @@ def _render_report(ctx: FlowContext) -> str:
             "- Partitions not audited (reason: group-ceiling; raise "
             "`max-partition-groups` to include them):\n"
             + "\n".join(
-                f"  - **{partition.name}** — `{partition.root}/` "
-                f"({len(partition.files)} files)"
-                for partition in partitions_not_audited
+                f"  - **{omission.partition.name}** — `{omission.partition.root}/` "
+                f"({len(omission.partition.files)} files)"
+                for omission in partitions_not_audited
             )
         )
         if partitions_not_audited

--- a/daydream/improve/orchestrator.py
+++ b/daydream/improve/orchestrator.py
@@ -613,6 +613,33 @@ def _coverage_ledger(
     skipped: list[PartitionStackOmission],
 ) -> dict[str, Any]:
     """Build the coverage ledger recording what the audit did and did not cover."""
+    retained = {partition for group in groups for partition in group.partitions}
+    omitted_by_partition: dict[Partition, list[str]] = {}
+    for omission in skipped:
+        omitted_by_partition.setdefault(omission.partition, []).append(omission.stack)
+
+    not_audited: list[dict[str, Any]] = []
+    partially_audited: list[dict[str, Any]] = []
+    for partition, omitted_stacks in omitted_by_partition.items():
+        entry = {
+            "partition": partition.name,
+            "root": partition.root,
+            "file_count": len(partition.files),
+            "reason": "group-ceiling",
+        }
+        if partition in retained:
+            partially_audited.append(
+                {
+                    **entry,
+                    "audited_stacks": sorted(
+                        {group.stack for group in groups if partition in group.partitions}
+                    ),
+                    "omitted_stacks": sorted(omitted_stacks),
+                }
+            )
+        else:
+            not_audited.append({**entry, "omitted_stacks": sorted(omitted_stacks)})
+
     return {
         "artifact_type": "daydream.improve-coverage",
         "partitions": [
@@ -630,15 +657,8 @@ def _coverage_ledger(
             }
             for group in groups
         ],
-        "not_audited": [
-            {
-                "partition": omission.partition.name,
-                "root": omission.partition.root,
-                "file_count": len(omission.partition.files),
-                "reason": "group-ceiling",
-            }
-            for omission in skipped
-        ],
+        "not_audited": not_audited,
+        "partially_audited": partially_audited,
     }
 
 

--- a/daydream/improve/partition.py
+++ b/daydream/improve/partition.py
@@ -62,7 +62,12 @@ class PartitionGroup:
 
 @dataclass(frozen=True)
 class PartitionStackOmission:
-    """One partition pass omitted from a stack-specific audit group."""
+    """One partition pass omitted from a stack-specific audit group.
+
+    Attributes:
+        partition: The partition whose pass was dropped.
+        stack: The stack-specific group the pass was omitted from.
+    """
 
     partition: Partition
     stack: str

--- a/daydream/improve/partition.py
+++ b/daydream/improve/partition.py
@@ -60,6 +60,14 @@ class PartitionGroup:
         return tuple(sorted(partition.root for partition in self.partitions))
 
 
+@dataclass(frozen=True)
+class PartitionStackOmission:
+    """One partition pass omitted from a stack-specific audit group."""
+
+    partition: Partition
+    stack: str
+
+
 def build_partitions(
     files: Sequence[str],
     services: Sequence[Service],
@@ -150,12 +158,12 @@ def group_partitions(
     *,
     max_files: int = PARTITION_MAX_FILES,
     max_groups: int | None = None,
-) -> tuple[list[PartitionGroup], list[Partition]]:
+) -> tuple[list[PartitionGroup], list[PartitionStackOmission]]:
     """Pack partitions into stack-homogeneous groups bounded by ``max_files``.
 
     Returns:
         The kept groups (renamed ``group-01``..) and, when ``max_groups`` binds,
-        every partition belonging to a dropped group — the not-audited list.
+        one ``PartitionStackOmission`` per dropped pass.
     """
     buckets: dict[str, list[Partition]] = defaultdict(list)
     for partition in partitions:
@@ -169,13 +177,18 @@ def group_partitions(
 
     bins.sort(key=lambda entry: (entry[0], entry[1][0].name))
 
-    skipped: list[Partition] = []
+    omissions: list[PartitionStackOmission] = []
     if max_groups is not None and len(bins) > max_groups:
         ranked = sorted(bins, key=lambda entry: (-sum(len(p.files) for p in entry[1]), entry[1][0].name))
         kept = {id(entry) for entry in ranked[:max_groups]}
-        skipped = sorted(
-            (partition for entry in bins if id(entry) not in kept for partition in entry[1]),
-            key=lambda partition: partition.root,
+        omissions = sorted(
+            (
+                PartitionStackOmission(partition=partition, stack=entry[0])
+                for entry in bins
+                if id(entry) not in kept
+                for partition in entry[1]
+            ),
+            key=lambda omission: (omission.partition.root, omission.partition.name, omission.stack),
         )
         bins = [entry for entry in bins if id(entry) in kept]
 
@@ -183,7 +196,7 @@ def group_partitions(
         PartitionGroup(name=f"group-{index:02d}", stack=stack, partitions=tuple(members))
         for index, (stack, members) in enumerate(bins, start=1)
     ]
-    return groups, skipped
+    return groups, omissions
 
 
 def _owning_service(path: str, ordered_services: Sequence[Service]) -> Service | None:

--- a/tests/test_improve_flow.py
+++ b/tests/test_improve_flow.py
@@ -566,7 +566,7 @@ async def test_partition_bound_splits_oversized_trees_via_config(
 
 
 @pytest.mark.anyio
-async def test_group_ceiling_skips_smallest_groups_and_reports_them(
+async def test_group_ceiling_reports_full_and_partial_stack_coverage(
     improve_scaled_monorepo_target: Path,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -593,8 +593,15 @@ async def test_group_ceiling_skips_smallest_groups_and_reports_them(
     assert len(audit_calls) == len(AUDIT_CATEGORIES)
     assert {group_scope(call["prompt"])[0] for call in audit_calls} == {"group-01"}
     coverage = json.loads(improve_artifact(improve_scaled_monorepo_target, "coverage.json").read_text())
-    skipped = {entry["partition"]: entry["reason"] for entry in coverage["not_audited"]}
-    assert skipped == {"frontend": "group-ceiling", "residue": "group-ceiling"}
+    not_audited = {entry["partition"]: entry for entry in coverage["not_audited"]}
+    assert set(not_audited) == {"frontend"}
+    assert not_audited["frontend"]["reason"] == "group-ceiling"
+    assert not_audited["frontend"]["omitted_stacks"] == ["react"]
+    partially = {entry["partition"]: entry for entry in coverage["partially_audited"]}
+    assert set(partially) == {"residue"}
+    assert partially["residue"]["reason"] == "group-ceiling"
+    assert partially["residue"]["audited_stacks"] == ["python"]
+    assert partially["residue"]["omitted_stacks"] == ["generic"]
 
 
 @pytest.mark.anyio

--- a/tests/test_improve_flow.py
+++ b/tests/test_improve_flow.py
@@ -707,18 +707,24 @@ async def test_report_names_unaudited_partitions_and_failed_groups(
     # Every ceiling-skipped partition is named with its root and reason.
     assert "**frontend**" in section and "group-ceiling" in section
     assert "`frontend/`" in section
-    # A partially-audited partition is a distinct bullet naming both stacks.
+    # residue's only retained group (group-01) failed its docs audit, so the
+    # python stack is not counted as audited: the partition is reported as not
+    # audited, naming both the ceiling-omitted and the failed stacks.
     assert "**residue**" in section
-    assert "partially audited" in section
-    assert "audited: python" in section
-    assert "omitted: generic" in section
+    assert "not audited" in section
+    assert "omitted: generic, python" in section
+    assert "partially audited" not in section
     failed = report.split("### Failed audit assignments")[1].split("## ")[0]
     # The failed assignment resolves to its group's roots, not just a key.
     assert "**docs / group-01**" in failed and "apps/svc00/" in failed
     coverage = json.loads(
         improve_artifact(improve_scaled_monorepo_target, "coverage.json").read_text()
     )
-    assert {entry["reason"] for entry in coverage["not_audited"]} == {"group-ceiling"}
+    assert {entry["reason"] for entry in coverage["not_audited"]} == {
+        "group-ceiling",
+        "group-failed",
+    }
+    assert coverage["partially_audited"] == []
     assert coverage["groups"] and coverage["partitions"]
     assert [entry["status"] for entry in coverage["groups"]] == ["failed"]
     assert "docs:group-01" in coverage["failed_assignments"]

--- a/tests/test_improve_flow.py
+++ b/tests/test_improve_flow.py
@@ -707,6 +707,11 @@ async def test_report_names_unaudited_partitions_and_failed_groups(
     # Every ceiling-skipped partition is named with its root and reason.
     assert "**frontend**" in section and "group-ceiling" in section
     assert "`frontend/`" in section
+    # A partially-audited partition is a distinct bullet naming both stacks.
+    assert "**residue**" in section
+    assert "partially audited" in section
+    assert "audited: python" in section
+    assert "omitted: generic" in section
     failed = report.split("### Failed audit assignments")[1].split("## ")[0]
     # The failed assignment resolves to its group's roots, not just a key.
     assert "**docs / group-01**" in failed and "apps/svc00/" in failed

--- a/tests/test_improve_partition.py
+++ b/tests/test_improve_partition.py
@@ -8,6 +8,7 @@ from daydream.improve.partition import (
     PARTITION_MAX_FILES,
     Partition,
     PartitionGroup,
+    PartitionStackOmission,
     build_partitions,
     group_partitions,
     stack_by_path,
@@ -110,8 +111,8 @@ def test_grouping_is_stack_homogeneous_and_bounded() -> None:
         ],
     )
     stack_of = {"apps/s1/a.py": "python", "apps/s2/b.py": "python", "web/c.tsx": "react"}
-    groups, skipped = group_partitions(parts, stack_of, max_files=10, max_groups=None)
-    assert skipped == []
+    groups, omissions = group_partitions(parts, stack_of, max_files=10, max_groups=None)
+    assert omissions == []
     assert [(g.name, g.stack, tuple(p.name for p in g.partitions)) for g in groups] == [
         ("group-01", "generic", ("residue",)),
         ("group-02", "python", ("s1", "s2")),
@@ -128,25 +129,51 @@ def test_mixed_stack_partition_is_routed_to_each_stack_specialist() -> None:
         files=("app/main.py", "app/view.tsx"),
     )
 
-    groups, skipped = group_partitions(
+    groups, omissions = group_partitions(
         [partition],
         {"app/main.py": "python", "app/view.tsx": "react"},
     )
 
-    assert skipped == []
+    assert omissions == []
     assert [(group.stack, group.partitions) for group in groups] == [
         ("python", (partition,)),
         ("react", (partition,)),
     ]
 
 
+def test_group_ceiling_preserves_stack_for_partially_retained_partition() -> None:
+    app = Partition(
+        name="app",
+        root="app",
+        source="directory",
+        service=None,
+        files=("app/main.py", "app/view.tsx"),
+    )
+    web = Partition(
+        name="web",
+        root="web",
+        source="directory",
+        service=None,
+        files=("web/index.tsx",),
+    )
+    stack_of = {"app/main.py": "python", "app/view.tsx": "react", "web/index.tsx": "react"}
+
+    groups, omissions = group_partitions([app, web], stack_of, max_groups=1)
+
+    assert len(omissions) == 1
+    assert omissions[0].partition == app
+    assert omissions[0].stack == "python"
+    assert {g.stack for g in groups} == {"react"}
+    assert app in groups[0].partitions
+
+
 def test_group_ceiling_keeps_largest_groups_and_reports_the_rest() -> None:
     parts = build_partitions([f"apps/s{i}/f{j}.py" for i in range(3) for j in range(i + 1)], [], max_files=2)
     stack_of = {f: "python" for p in parts for f in p.files}
-    groups, skipped = group_partitions(parts, stack_of, max_files=2, max_groups=1)
+    groups, omissions = group_partitions(parts, stack_of, max_files=2, max_groups=1)
     assert len(groups) == 1
     assert groups[0].file_count == max(2, groups[0].file_count)  # largest kept
-    assert {p.name for p in skipped} and all(isinstance(p, Partition) for p in skipped)
+    assert omissions and all(isinstance(o, PartitionStackOmission) for o in omissions)
 
 
 def test_empty_and_single_file_repos() -> None:
@@ -161,8 +188,8 @@ def test_sibling_partitions_stay_in_one_group() -> None:
     files += [f"lib/f{i}.ts" for i in range(6)]
     partitions = build_partitions(files, [], max_files=6)
     stack_of = dict.fromkeys(files, "ts")
-    groups, skipped = group_partitions(partitions, stack_of, max_files=8, max_groups=None)
-    assert skipped == []
+    groups, omissions = group_partitions(partitions, stack_of, max_files=8, max_groups=None)
+    assert omissions == []
     by_group = {group.name: set(group.roots) for group in groups}
     # Packing by size alone would fill the first bin with lib + two web children
     # and strand the rest; the siblings must travel together instead.


### PR DESCRIPTION
## Summary

Addresses #456: **Preserve stack-specific omissions in improve coverage reporting.**

The improve coverage ledger now distinguishes wholly-audited, partially-audited (stack-specific omissions), and failed-group stacks instead of collapsing them. Failed-group stacks are counted as uncovered (with a distinct `group-failed` reason) rather than reported as audited, so coverage is no longer overstated.

### Changes
- `daydream/improve/orchestrator.py` — carry stack with group-ceiling omissions; report partial stack coverage; split coverage into wholly/partially audited; count failed-group stacks as uncovered
- `daydream/improve/partition.py` — partition adjustments for stack-specific omission tracking
- `tests/test_improve_flow.py`, `tests/test_improve_partition.py` — updated coverage assertions

## Verification
- Two sequential daydream deep-precision reviews on fresh exe.dev VMs (rounds 1 and 2), both genuine runs (coverage 1.0, no per-stack failures)
- Full repo gate: `make check` passes — lockcheck + lint + typecheck + 3439 tests, 6 skipped, `GATE_RC=0`
- Clean merge into main (no conflicts)

Closes #456
