### PR TITLE
fix(redaction): broaden structured credential redaction in trajectory and archive artifacts

### DIFF
--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -39,7 +39,7 @@ from daydream.backends import (
 from daydream.config import UNKNOWN_SKILL_PATTERN
 from daydream.extensions import get_registry
 from daydream.json_utils import extract_json
-from daydream.trajectory import DaydreamPhase, get_current_recorder, redact_text, redact_value
+from daydream.trajectory import DaydreamPhase, get_current_recorder, redact_structured_text, redact_text, redact_value
 from daydream.ui import (
     NEON_THEME,
     AgentTextRenderer,
@@ -370,17 +370,17 @@ def _summarize_input(input_data: dict[str, Any]) -> str:
     # string is redacted before any [:200] slice — redact-after-slice would
     # truncate a credential into an unmatchable fragment.
     if "command" in input_data:
-        return redact_text(input_data["command"])[:200]
+        return redact_structured_text(input_data["command"])[:200]
     if "path" in input_data:
         complete = f"{input_data['path']}" + (
             f" -> {input_data.get('new_path', '')}" if "new_path" in input_data else ""
         )
-        return redact_text(complete)
+        return redact_structured_text(complete)
     # Generic: first value that's a string
     for v in input_data.values():
         if isinstance(v, str):
-            return redact_text(v)[:200]
-    return redact_text(str(input_data))[:200]
+            return redact_structured_text(v)[:200]
+    return redact_structured_text(str(input_data))[:200]
 
 
 def _summarize_output(output: str) -> str:
@@ -389,7 +389,7 @@ def _summarize_output(output: str) -> str:
         return "(empty)"
     # Redact the COMPLETE output before strip/first-line/[:200] — a credential
     # straddling the summary boundary must be caught before the slice.
-    redacted = redact_text(output)
+    redacted = redact_structured_text(output)
     # Take first non-empty line or first 200 chars
     first_line = redacted.strip().split("\n")[0]
     return first_line[:200]
@@ -410,7 +410,7 @@ def _print_log(value: str) -> None:
     Phase/UI output flows through the module-level ``console``, which redacts
     string payloads in log mode via the same fail-closed boundary.
     """
-    print(redact_text(value), flush=True)
+    print(redact_structured_text(value), flush=True)
 
 
 async def run_agent(

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -105,7 +105,7 @@ def _merge_metrics(existing: "Metrics", incoming: "Metrics") -> "Metrics":
     })
 
 # Redaction patterns (REDA-01..04). Redaction composes three stages in order:
-# (1) auth-header + auth-scheme rules (Redactor._redact_structured_text) so a
+# (1) auth-header + auth-scheme rules (redact_structured_text) so a
 # shaped value under a header (e.g. `Authorization: Bearer sk-1234`) is consumed
 # whole and never double-marked; (2) the flat rules below — URL-credential before
 # bare API-key (so the captured credential isn't re-matched), PEM before env-var
@@ -170,26 +170,33 @@ def redact_text(value: str) -> str:
     return value
 
 
-def redact_value(value: Any) -> Any:
+def redact_value(value: Any, sensitive: bool = False) -> Any:
     """Recursively redact a value without mutating its argument (never raises).
 
-    ``str`` leaves and string dict keys are run through :func:`redact_text`;
-    containers are rebuilt fresh so the caller's object is never touched.
-    Non-container, non-string leaves pass through unchanged. This is the
-    canonical structured redactor for log-mode event payloads; the recursion
-    lives here so every consumer shares the same fail-closed boundary.
+    Key-aware (issue #455): ``str`` leaves under a sensitive key — their own
+    key, or inherited from a sensitive ancestor container — are replaced with
+    ``_REDACTED_CREDENTIAL``; other string leaves run through
+    :func:`redact_structured_text`. String dict keys are run through
+    :func:`redact_text` so secret-shaped keys are scrubbed too; containers
+    are rebuilt fresh so the caller's object is never touched. Non-container,
+    non-string leaves pass through unchanged. This is the canonical
+    structured redactor for log-mode event payloads and the trajectory path
+    alike; the recursion lives here so every consumer shares the same
+    fail-closed boundary.
     """
     if isinstance(value, str):
-        return redact_text(value)
+        return _REDACTED_CREDENTIAL if sensitive else redact_structured_text(value)
     if isinstance(value, dict):
         return {
-            (redact_text(k) if isinstance(k, str) else k): redact_value(v)
+            (redact_text(k) if isinstance(k, str) else k): redact_value(
+                v, sensitive or (_is_sensitive_key(k) if isinstance(k, str) else False)
+            )
             for k, v in value.items()
         }
     if isinstance(value, list):
-        return [redact_value(item) for item in value]
+        return [redact_value(item, sensitive) for item in value]
     if isinstance(value, tuple):
-        return tuple(redact_value(item) for item in value)
+        return tuple(redact_value(item, sensitive) for item in value)
     return value
 
 
@@ -353,16 +360,39 @@ _AUTHORIZATION_HEADER_PATTERN = re.compile(
 _AUTH_SCHEME_PATTERN = re.compile(r"^(Basic|Bearer|Token)\s+(\S+)")
 # Structured key<: or =>value pairs in free text (JSON, Python-repr, YAML,
 # assignment). The key may be wrapped in single or double quotes; values are
-# single/double-quoted or a bare token. A value that starts with a structural
+# single/double-quoted or a bare token, with backslash-escaped quotes honored
+# inside quoted values. A value that starts with a structural
 # open-brace does not match (the pair is skipped so the scan continues to
 # inner keys). A negative lookahead prevents re-matching a value that is
 # immediately followed by a [REDACTED_*] marker (existing env-var/API-key/
 # header redactions must not be clobbered).
 _STRUCTURED_KEY_VALUE_PATTERN = re.compile(
     r"(['\"]?)([A-Za-z_][A-Za-z0-9_.\-]*)\1([^\S\n\r]*[:=][^\S\n\r]*)"
-    r"(?:\"([^\"]*)\"|'([^']*)'|([^\s\"'\[\]{}()]++))"
+    r"(?:\"((?:\\.|[^\"\\])*)\"|'((?:\\.|[^'\\])*)'|([^\s\"'\[\]{}()]++))"
     r"(?![^\S\n\r]*\[REDACTED)",
 )
+
+
+def _redact_structured_key_value(match: re.Match[str]) -> str:
+    """Replace one sensitive ``key<: or =>value`` pair (match->str transform).
+
+    Re-emits the key's quote wrapper (group 1) and the value's surrounding
+    quotes so JSON/Python-repr text stays structurally valid: the value token
+    becomes ``_REDACTED_CREDENTIAL``, never dropped. Existing ``[REDACTED_*]``
+    markers and empty values are never re-matched.
+    """
+    key = match.group(2)
+    if not _is_sensitive_key(key):
+        return match.group(0)
+    value = match.group(4) or match.group(5) or match.group(6)
+    if value is None or value == "" or "[REDACTED" in value:
+        return match.group(0)
+    wrapped_key = f"{match.group(1)}{key}{match.group(1)}"
+    if match.group(4) is not None:
+        return f'{wrapped_key}{match.group(3)}"{_REDACTED_CREDENTIAL}"'
+    if match.group(5) is not None:
+        return f"{wrapped_key}{match.group(3)}'{_REDACTED_CREDENTIAL}'"
+    return f"{wrapped_key}{match.group(3)}{_REDACTED_CREDENTIAL}"
 
 
 def _redact_structured_key_values(text: str) -> str:
@@ -375,21 +405,41 @@ def _redact_structured_key_values(text: str) -> str:
     ``"[REDACTION_FAILED]"``.
     """
     try:
+        return _STRUCTURED_KEY_VALUE_PATTERN.sub(_redact_structured_key_value, text)
+    except Exception:  # noqa: BLE001 - fail closed at every host boundary
+        return "[REDACTION_FAILED]"
 
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(2)
-            if not _is_sensitive_key(key):
-                return match.group(0)
-            value = (
-                match.group(4)
-                if match.group(4) is not None
-                else (match.group(5) if match.group(5) is not None else match.group(6))
-            )
-            if value is None or value == "" or "[REDACTED" in value:
-                return match.group(0)
-            return f"{key}{match.group(3)}{_REDACTED_CREDENTIAL}"
 
-        return _STRUCTURED_KEY_VALUE_PATTERN.sub(_replace, text)
+def _redact_header_value(match: re.Match[str]) -> str:
+    """Replace one auth-header line's opaque credential (match->str transform).
+
+    Keeps the header name — and a ``Basic|Bearer|Token`` scheme when present —
+    replacing the trailing credential with ``_REDACTED_CREDENTIAL``.
+    """
+    name = match.group(1)
+    value = match.group(2)
+    scheme_match = _AUTH_SCHEME_PATTERN.match(value)
+    if scheme_match is not None:
+        return f"{name}: {scheme_match.group(1)} {_REDACTED_CREDENTIAL}"
+    return f"{name}: {_REDACTED_CREDENTIAL}"
+
+
+def redact_structured_text(s: str) -> str:
+    """Redact structured free-text surfaces (fail-closed).
+
+    Composes, in order: (1) auth-header + auth-scheme rules so a shaped value
+    under a header (``Authorization: Bearer sk-1234``) is consumed whole and
+    never double-marked; (2) the flat ``_REDACTION_RULES`` via
+    :func:`redact_text`; (3) structured key-value redaction
+    (``_redact_structured_key_values``), which skips existing
+    ``[REDACTED_*]`` markers so earlier stages' output is never clobbered.
+    Any exception in any stage degrades the whole field to
+    ``"[REDACTION_FAILED]"`` — never raw pass-through.
+    """
+    try:
+        s = _AUTHORIZATION_HEADER_PATTERN.sub(_redact_header_value, s)
+        s = redact_text(s)
+        return _redact_structured_key_values(s)
     except Exception:  # noqa: BLE001 - fail closed at every host boundary
         return "[REDACTION_FAILED]"
 
@@ -402,80 +452,34 @@ class Redactor:
     ``ToolCall.arguments`` value, and every ``ObservationResult.content``
     string. Tool-call arguments and other native structures are walked
     recursively with key-aware sensitive-key detection
-    (``_redact_value`` / ``_is_sensitive_key``), so credentials under
+    (``redact_value`` / ``_is_sensitive_key``), so credentials under
     lower/mixed/camel-case keys are replaced even at nested depth while the
     surrounding shape is preserved; free-text surfaces compose the flat rules
     with auth-header and structured key-value stages
-    (``_redact_structured_text``). Per REDA-05 the failure mode is
+    (``redact_structured_text``). Per REDA-05 the failure mode is
     "redact-or-omit": any internal exception replaces the offending value
     with ``"[REDACTION_FAILED]"`` rather than letting the raw value through.
     """
-
-    def _redact_text(self, s: str) -> str:
-        """Apply every flat redaction rule to *s* and return the result."""
-        return redact_text(s)
-
-    def _redact_structured_text(self, s: str) -> str:
-        """Redact structured free-text surfaces (fail-closed).
-
-        Composes, in order: (1) auth-header + auth-scheme rules so a shaped
-        value under a header (``Authorization: Bearer sk-1234``) is consumed
-        whole and never double-marked; (2) the flat ``_REDACTION_RULES`` via
-        :func:`redact_text`; (3) structured key-value redaction
-        (``_redact_structured_key_values``), which skips existing
-        ``[REDACTED_*]`` markers so earlier stages' output is never clobbered.
-        Any exception in any stage degrades the whole field to
-        ``"[REDACTION_FAILED]"`` — never raw pass-through.
-        """
-        try:
-
-            def _redact_header_value(match: re.Match[str]) -> str:
-                name = match.group(1)
-                value = match.group(2)
-                scheme_match = _AUTH_SCHEME_PATTERN.match(value)
-                if scheme_match is not None:
-                    return f"{name}: {scheme_match.group(1)} {_REDACTED_CREDENTIAL}"
-                return f"{name}: {_REDACTED_CREDENTIAL}"
-
-            s = _AUTHORIZATION_HEADER_PATTERN.sub(_redact_header_value, s)
-            s = self._redact_text(s)
-            return _redact_structured_key_values(s)
-        except Exception:  # noqa: BLE001 - fail closed at every host boundary
-            return "[REDACTION_FAILED]"
 
     def _redact_optional_text(self, value: str | None) -> str | None:
         """Redact a possibly-None text field; degrade to [REDACTION_FAILED] on error."""
         if value is None:
             return None
-        return self._redact_structured_text(value)
+        return redact_structured_text(value)
 
     def _redact_value(self, value: Any, sensitive: bool = False) -> Any:
         """Recursively redact *value*, key-aware, without mutating it.
 
-        String leaves under a sensitive key (their own key, or inherited from
-        a sensitive ancestor container) are replaced with ``_REDACTED_CREDENTIAL``;
-        other string leaves run through ``_redact_structured_text``. Dict
-        children are sensitive when the parent is sensitive OR their own key
-        is sensitive (``_is_sensitive_key``); list/tuple elements inherit the
-        container's sensitivity. Fresh containers are built at every level, so
-        the caller's object is never touched. Non-string scalars pass through
-        unchanged.
+        Delegates to the canonical module-level :func:`redact_value` so the
+        trajectory path and log-mode payload redaction share one recursion
+        (issue #455): string leaves under a sensitive key (their own key, or
+        inherited from a sensitive ancestor container) become
+        ``_REDACTED_CREDENTIAL``, other string leaves run through
+        :func:`redact_structured_text`, and string dict keys are scrubbed via
+        :func:`redact_text`. Fresh containers are built at every level, so the
+        caller's object is never touched.
         """
-        if isinstance(value, str):
-            return _REDACTED_CREDENTIAL if sensitive else self._redact_structured_text(value)
-        if isinstance(value, dict):
-            return {
-                key: self._redact_value(
-                    item,
-                    sensitive or (_is_sensitive_key(key) if isinstance(key, str) else False),
-                )
-                for key, item in value.items()
-            }
-        if isinstance(value, list):
-            return [self._redact_value(item, sensitive) for item in value]
-        if isinstance(value, tuple):
-            return tuple(self._redact_value(item, sensitive) for item in value)
-        return value
+        return redact_value(value, sensitive)
 
     def _redact_arguments(self, arguments: dict[str, Any]) -> dict[str, Any]:
         """Redact every value inside a ToolCall.arguments dict (native walk).
@@ -506,7 +510,7 @@ class Redactor:
             new_content: Any = r.content
             if isinstance(r.content, str):
                 try:
-                    new_content = self._redact_structured_text(r.content)
+                    new_content = redact_structured_text(r.content)
                 except Exception:  # noqa: BLE001 - REDA-05 redact-or-omit
                     new_content = "[REDACTION_FAILED]"
             elif isinstance(r.content, list):

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -104,10 +104,15 @@ def _merge_metrics(existing: "Metrics", incoming: "Metrics") -> "Metrics":
         "extra": merged_extra,
     })
 
-# Redaction patterns (REDA-01..04). Order in _REDACTION_RULES matters: URL-credential
-# before bare API-key (so the captured credential isn't re-matched), PEM before env-var
-# (so `VAR=<PEM>` collapses whole instead of leaking the key body), env-var before bare
-# API-key (so `OPENAI_API_KEY=sk-1234` keeps its name per D-03).
+# Redaction patterns (REDA-01..04). Redaction composes three stages in order:
+# (1) auth-header + auth-scheme rules (Redactor._redact_structured_text) so a
+# shaped value under a header (e.g. `Authorization: Bearer sk-1234`) is consumed
+# whole and never double-marked; (2) the flat rules below — URL-credential before
+# bare API-key (so the captured credential isn't re-matched), PEM before env-var
+# (so `VAR=<PEM>` collapses whole instead of leaking the key body), env-var before
+# bare API-key (so `OPENAI_API_KEY=sk-1234` keeps its name per D-03); (3) structured
+# key-value redaction (_redact_structured_key_values), which skips existing
+# [REDACTED_*] markers so earlier stages' output is never clobbered.
 _URL_CREDENTIAL_PATTERN = re.compile(r"(https?://)([^:@/\s]+):([^@/\s]+)@")
 _API_KEY_PATTERN = re.compile(
     r"\b(?:sk-[A-Za-z0-9_\-]{6,}|ghp_[A-Za-z0-9]{6,}|ghs_[A-Za-z0-9]{6,}|xoxb-[A-Za-z0-9\-]{6,}|AKIA[A-Z0-9]{16})\b"
@@ -335,6 +340,60 @@ def _is_sensitive_key(key: str) -> bool:
     return any(segment in _SENSITIVE_KEY_SUFFIXES for segment in normalized.split("_"))
 
 
+# Auth-header redaction (issue #455): case-insensitive, line-anchored. The
+# value capture is line-bounded (no DOTALL) so nothing past the end of the
+# line is ever consumed. Runs BEFORE the flat rules so a shaped value under
+# a header is consumed whole here and never double-marked downstream.
+_AUTHORIZATION_HEADER_PATTERN = re.compile(
+    r"^(Authorization|Proxy-Authorization|X-Api-Key|X-Auth-Token|Cookie|Set-Cookie):[^\S\n\r]*([^\n\r]+)$",
+    re.IGNORECASE | re.MULTILINE,
+)
+# Optional auth scheme prefix on a header value: keep the scheme + whitespace,
+# replace only the trailing opaque token.
+_AUTH_SCHEME_PATTERN = re.compile(r"^(Basic|Bearer|Token)\s+(\S+)")
+# Structured key<: or =>value pairs in free text (JSON, Python-repr, YAML,
+# assignment). The key may be wrapped in single or double quotes; values are
+# single/double-quoted or a bare token. A value that starts with a structural
+# open-brace does not match (the pair is skipped so the scan continues to
+# inner keys). A negative lookahead prevents re-matching a value that is
+# immediately followed by a [REDACTED_*] marker (existing env-var/API-key/
+# header redactions must not be clobbered).
+_STRUCTURED_KEY_VALUE_PATTERN = re.compile(
+    r"(['\"]?)([A-Za-z_][A-Za-z0-9_.\-]*)\1([^\S\n\r]*[:=][^\S\n\r]*)"
+    r"(?:\"([^\"]*)\"|'([^']*)'|([^\s\"'\[\]{}()]++))"
+    r"(?![^\S\n\r]*\[REDACTED)",
+)
+
+
+def _redact_structured_key_values(text: str) -> str:
+    """Redact values of sensitive-key assignments in free text (fail-closed).
+
+    Finds ``key<: or =>value`` pairs in JSON, Python-repr, YAML-like, and
+    assignment text. For each pair whose key ``_is_sensitive_key``, replace
+    the value token with ``_REDACTED_CREDENTIAL``. Existing ``[REDACTED_*]``
+    markers and empty values are never re-matched. Any exception degrades to
+    ``"[REDACTION_FAILED]"``.
+    """
+    try:
+
+        def _replace(match: re.Match[str]) -> str:
+            key = match.group(2)
+            if not _is_sensitive_key(key):
+                return match.group(0)
+            value = (
+                match.group(4)
+                if match.group(4) is not None
+                else (match.group(5) if match.group(5) is not None else match.group(6))
+            )
+            if value is None or value == "" or "[REDACTED" in value:
+                return match.group(0)
+            return f"{key}{match.group(3)}{_REDACTED_CREDENTIAL}"
+
+        return _STRUCTURED_KEY_VALUE_PATTERN.sub(_replace, text)
+    except Exception:  # noqa: BLE001 - fail closed at every host boundary
+        return "[REDACTION_FAILED]"
+
+
 class Redactor:
     """Regex-driven redactor (REDA-01..06).
 
@@ -359,13 +418,28 @@ class Redactor:
     def _redact_structured_text(self, s: str) -> str:
         """Redact structured free-text surfaces (fail-closed).
 
-        Task 1 delegates to the module :func:`redact_text` (preserving the
-        existing flat coverage); the auth-header and structured key-value
-        stages land in Task 2. Any exception in any stage degrades the whole
-        field to ``"[REDACTION_FAILED]"`` — never raw pass-through.
+        Composes, in order: (1) auth-header + auth-scheme rules so a shaped
+        value under a header (``Authorization: Bearer sk-1234``) is consumed
+        whole and never double-marked; (2) the flat ``_REDACTION_RULES`` via
+        :func:`redact_text`; (3) structured key-value redaction
+        (``_redact_structured_key_values``), which skips existing
+        ``[REDACTED_*]`` markers so earlier stages' output is never clobbered.
+        Any exception in any stage degrades the whole field to
+        ``"[REDACTION_FAILED]"`` — never raw pass-through.
         """
         try:
-            return redact_text(s)
+
+            def _redact_header_value(match: re.Match[str]) -> str:
+                name = match.group(1)
+                value = match.group(2)
+                scheme_match = _AUTH_SCHEME_PATTERN.match(value)
+                if scheme_match is not None:
+                    return f"{name}: {scheme_match.group(1)} {_REDACTED_CREDENTIAL}"
+                return f"{name}: {_REDACTED_CREDENTIAL}"
+
+            s = _AUTHORIZATION_HEADER_PATTERN.sub(_redact_header_value, s)
+            s = self._redact_text(s)
+            return _redact_structured_key_values(s)
         except Exception:  # noqa: BLE001 - fail closed at every host boundary
             return "[REDACTION_FAILED]"
 
@@ -432,7 +506,7 @@ class Redactor:
             new_content: Any = r.content
             if isinstance(r.content, str):
                 try:
-                    new_content = self._redact_text(r.content)
+                    new_content = self._redact_structured_text(r.content)
                 except Exception:  # noqa: BLE001 - REDA-05 redact-or-omit
                     new_content = "[REDACTION_FAILED]"
             elif isinstance(r.content, list):

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -347,52 +347,85 @@ def _is_sensitive_key(key: str) -> bool:
     return any(segment in _SENSITIVE_KEY_SUFFIXES for segment in normalized.split("_"))
 
 
-# Auth-header redaction (issue #455): case-insensitive, line-anchored. The
-# value capture is line-bounded (no DOTALL) so nothing past the end of the
-# line is ever consumed. Runs BEFORE the flat rules so a shaped value under
-# a header is consumed whole here and never double-marked downstream.
+# Auth-header redaction (issue #455): case-insensitive, matches mid-line as
+# well as line-start headers (curl -v / httpie output, YAML blocks, embedded
+# headers). A negative lookbehind keeps the match from firing inside a word
+# or a quoted JSON/YAML key; the value capture is a single token — with an
+# optional Basic|Bearer|Token scheme prefix — so nothing past the token, and
+# never past the end of the line, is ever consumed. A trailing lookahead
+# keeps prose like ``The authorization: feature is enabled now`` out of this
+# stage (the structured pair scan decides that case). Runs BEFORE the flat
+# rules so a shaped value under a header is consumed whole here and never
+# double-marked downstream.
 _AUTHORIZATION_HEADER_PATTERN = re.compile(
-    r"^(Authorization|Proxy-Authorization|X-Api-Key|X-Auth-Token|Cookie|Set-Cookie):[^\S\n\r]*([^\n\r]+)$",
-    re.IGNORECASE | re.MULTILINE,
+    r"(?<![A-Za-z0-9_\"'])(Authorization|Proxy-Authorization|X-Api-Key|X-Auth-Token|Cookie|Set-Cookie):"
+    r"[^\S\n\r]*(?:(Basic|Bearer|Token)[^\S\n\r]+)?([^\s,;\"']+)"
+    r"(?=[^\S\n\r]*[,}\]\r\n]|$)",
+    re.IGNORECASE,
 )
-# Optional auth scheme prefix on a header value: keep the scheme + whitespace,
-# replace only the trailing opaque token.
-_AUTH_SCHEME_PATTERN = re.compile(r"^(Basic|Bearer|Token)\s+(\S+)")
 # Structured key<: or =>value pairs in free text (JSON, Python-repr, YAML,
 # assignment). The key may be wrapped in single or double quotes; values are
-# single/double-quoted or a bare token, with backslash-escaped quotes honored
-# inside quoted values. A value that starts with a structural
-# open-brace does not match (the pair is skipped so the scan continues to
-# inner keys). A negative lookahead prevents re-matching a value that is
-# immediately followed by a [REDACTED_*] marker (existing env-var/API-key/
-# header redactions must not be clobbered).
+# single/double-quoted, a Bearer|Basic|Token scheme plus its opaque token, or
+# a bare token, with backslash-escaped quotes honored inside quoted values.
+# The bare-token class excludes the structural separators ',', ':' and '=' so
+# replacing a value never swallows the separator that follows it
+# ('{"token": null, "count": 3}' keeps its comma). A value that starts with
+# a structural open-brace does not match (the pair is skipped so the scan
+# continues to inner keys); block-style values are handled by the follow-up
+# _redact_structured_blocks pass. A negative lookahead prevents re-matching a
+# value that is immediately followed by a [REDACTED_*] marker (existing
+# env-var/API-key/header redactions must not be clobbered).
 _STRUCTURED_KEY_VALUE_PATTERN = re.compile(
     r"(['\"]?)([A-Za-z_][A-Za-z0-9_.\-]*)\1([^\S\n\r]*[:=][^\S\n\r]*)"
-    r"(?:\"((?:\\.|[^\"\\])*)\"|'((?:\\.|[^'\\])*)'|([^\s\"'\[\]{}()]++))"
+    r"(?:\"((?:\\.|[^\"\\])*)\"|'((?:\\.|[^'\\])*)'|(Basic|Bearer|Token)[^\S\n\r]+([^\s,;\"']+)|([^\s\"'\[\]{}():,=]++))"
     r"(?![^\S\n\r]*\[REDACTED)",
 )
 
 
-def _redact_structured_key_value(match: re.Match[str]) -> str:
+def _redact_structured_key_value(match: re.Match[str], text: str) -> str:
     """Replace one sensitive ``key<: or =>value`` pair (match->str transform).
 
-    Re-emits the key's quote wrapper (group 1) and the value's surrounding
-    quotes so JSON/Python-repr text stays structurally valid: the value token
-    becomes ``_REDACTED_CREDENTIAL``, never dropped. Existing ``[REDACTED_*]``
-    markers and empty values are never re-matched.
+    Re-emits the key's quote wrapper (group 1) and a single quote variable
+    around the value so JSON/Python-repr text stays structurally valid: the
+    value token becomes ``_REDACTED_CREDENTIAL``, never dropped. Bare-token
+    values are redacted only when the pair is an ``=`` assignment or the value
+    ends at a structural boundary, so prose like ``the token: is now
+    available`` is left intact. Existing ``[REDACTED_*]`` markers and empty
+    values are never re-matched.
     """
     key = match.group(2)
     if not _is_sensitive_key(key):
         return match.group(0)
-    value = match.group(4) or match.group(5) or match.group(6)
+    wrapped_key = f"{match.group(1)}{key}{match.group(1)}"
+    sep = match.group(3)
+    if match.group(6) is not None:
+        # Bearer|Basic|Token <opaque>: keep the scheme, replace the token.
+        token = match.group(7)
+        if token is None or token == "" or "[REDACTED" in token:
+            return match.group(0)
+        return f"{wrapped_key}{sep}{match.group(6)} {_REDACTED_CREDENTIAL}"
+    value = match.group(4) or match.group(5) or match.group(8)
     if value is None or value == "" or "[REDACTED" in value:
         return match.group(0)
-    wrapped_key = f"{match.group(1)}{key}{match.group(1)}"
-    if match.group(4) is not None:
-        return f'{wrapped_key}{match.group(3)}"{_REDACTED_CREDENTIAL}"'
-    if match.group(5) is not None:
-        return f"{wrapped_key}{match.group(3)}'{_REDACTED_CREDENTIAL}'"
-    return f"{wrapped_key}{match.group(3)}{_REDACTED_CREDENTIAL}"
+    if match.group(8) is not None and not _bare_value_redactable(sep, text, match.end()):
+        return match.group(0)
+    quote = '"' if (match.group(4) is not None or match.group(8) is not None) else "'"
+    return f"{wrapped_key}{sep}{quote}{_REDACTED_CREDENTIAL}{quote}"
+
+
+def _bare_value_redactable(sep: str, text: str, end: int) -> bool:
+    """Return True when a bare (unquoted) pair value should be redacted.
+
+    ``=`` assignments are structural by nature and always redact; a ``:``
+    value redacts only when it ends at a structural boundary — end of text,
+    end of line, or one of ``, } ]`` — so prose like ``the token: is now
+    available`` or ``The authorization: feature is enabled now`` survives
+    while YAML-ish ``token: abc, other: 1`` keeps both its redaction and its
+    separator.
+    """
+    if "=" in sep:
+        return True
+    return not text[end:] or re.match(r"[^\S\n\r]*[,}\]\r\n]", text[end:]) is not None
 
 
 def _redact_structured_key_values(text: str) -> str:
@@ -400,27 +433,146 @@ def _redact_structured_key_values(text: str) -> str:
 
     Finds ``key<: or =>value`` pairs in JSON, Python-repr, YAML-like, and
     assignment text. For each pair whose key ``_is_sensitive_key``, replace
-    the value token with ``_REDACTED_CREDENTIAL``. Existing ``[REDACTED_*]``
-    markers and empty values are never re-matched. Any exception degrades to
-    ``"[REDACTION_FAILED]"``.
+    the value token with ``_REDACTED_CREDENTIAL``; block-style values
+    (multi-line YAML, brace-wrapped JSON) are consumed wholesale by the
+    follow-up block pass. Existing ``[REDACTED_*]`` markers and empty values
+    are never re-matched. Any exception degrades to ``"[REDACTION_FAILED]"``.
     """
     try:
-        return _STRUCTURED_KEY_VALUE_PATTERN.sub(_redact_structured_key_value, text)
+        return _redact_structured_blocks(_redact_structured_pairs(text))
     except Exception:  # noqa: BLE001 - fail closed at every host boundary
         return "[REDACTION_FAILED]"
 
 
+def _redact_structured_pairs(text: str) -> str:
+    """Redact line-scoped ``key<: or =>value`` pairs, re-scanning every value.
+
+    A plain ``re.sub`` resumes after each consumed match, so a sensitive pair
+    nested inside a non-sensitive pair's value (``text: apiKey: opaque``,
+    ``config: token=opaque``, ``{\"description\": \"use token=opaque here\"}``)
+    would never be visited. The scan instead advances one character past any
+    pair whose key is not sensitive, so nested pairs inside its value are
+    still found and redacted.
+    """
+    out: list[str] = []
+    pos = 0
+    while True:
+        match = _STRUCTURED_KEY_VALUE_PATTERN.search(text, pos)
+        if match is None:
+            break
+        if _is_sensitive_key(match.group(2)):
+            out.append(text[pos:match.start()])
+            out.append(_redact_structured_key_value(match, text))
+            pos = match.end()
+        else:
+            out.append(text[pos:match.start() + 1])
+            pos = match.start() + 1
+    out.append(text[pos:])
+    return "".join(out)
+
+
+_BLOCK_VALUE_PATTERN = re.compile(
+    r"(['\"]?)([A-Za-z_][A-Za-z0-9_.\-]*)\1([^\S\n\r]*[:=][^\S\n\r]*)"
+    r"(?=[\[{](?!REDACTED)|\n)"
+)
+
+
+def _redact_structured_blocks(text: str) -> str:
+    """Redact block-style values under sensitive keys (fail-closed).
+
+    Handles what the line-scoped pair scan cannot: block-style YAML
+    (``apiKey:\\n  nested: <opaque>``) and brace-wrapped JSON
+    (``\"apiKey\": {\\n  \"nested\": ...\\n}``) where the sensitive value
+    spans lines. Each matched block is replaced wholesale with a quoted
+    ``_REDACTED_CREDENTIAL`` marker so the output stays structurally valid.
+    """
+    try:
+        out: list[str] = []
+        pos = 0
+        while True:
+            match = _BLOCK_VALUE_PATTERN.search(text, pos)
+            if match is None:
+                break
+            key = match.group(2)
+            if not _is_sensitive_key(key):
+                out.append(text[pos:match.start() + 1])
+                pos = match.start() + 1
+                continue
+            block_end = _block_value_end(text, match.end())
+            if block_end == match.end():
+                # no indented block follows (empty value): skip and re-scan
+                out.append(text[pos:match.start() + 1])
+                pos = match.start() + 1
+                continue
+            out.append(text[pos:match.start()])
+            quote = match.group(1) or ""
+            out.append(f"{quote}{key}{quote}{match.group(3)}\"{_REDACTED_CREDENTIAL}\"")
+            pos = block_end
+        out.append(text[pos:])
+        return "".join(out)
+    except Exception:  # noqa: BLE001 - fail closed at every host boundary
+        return "[REDACTION_FAILED]"
+
+
+def _block_value_end(text: str, start: int) -> int:
+    """Return the index just past the block opened at *start*.
+
+    Brace/bracket blocks are consumed to their matching close (quote-aware);
+    an unbalanced opener consumes to the end of the text (fail-safe).
+    YAML-style blocks consume every following indented line, stopping at the
+    first line that outdents back to the key's level — or return *start*
+    unchanged when nothing is indented.
+    """
+    if start >= len(text):
+        return start
+    if text[start] in "[{":
+        opener = text[start]
+        closer = "}" if opener == "{" else "]"
+        depth = 0
+        quote: str | None = None
+        i = start
+        while i < len(text):
+            ch = text[i]
+            if quote is not None:
+                if ch == "\\":
+                    i += 2
+                    continue
+                if ch == quote:
+                    quote = None
+            elif ch in "\"'":
+                quote = ch
+            elif ch == opener:
+                depth += 1
+            elif ch == closer:
+                depth -= 1
+                if depth == 0:
+                    return i + 1
+            i += 1
+        return len(text)
+    # text[start] is the newline ending the key's line.
+    prev = start
+    i = start
+    while i <= len(text):
+        line_end = text.find("\n", i)
+        if line_end == -1:
+            line_end = len(text)
+        line = text[i:line_end]
+        if line and not line[0].isspace():
+            break
+        prev = line_end
+        i = line_end + 1
+    return prev
+
+
 def _redact_header_value(match: re.Match[str]) -> str:
-    """Replace one auth-header line's opaque credential (match->str transform).
+    """Replace one auth-header credential (match->str transform).
 
     Keeps the header name — and a ``Basic|Bearer|Token`` scheme when present —
-    replacing the trailing credential with ``_REDACTED_CREDENTIAL``.
+    replacing the trailing opaque token with ``_REDACTED_CREDENTIAL``.
     """
     name = match.group(1)
-    value = match.group(2)
-    scheme_match = _AUTH_SCHEME_PATTERN.match(value)
-    if scheme_match is not None:
-        return f"{name}: {scheme_match.group(1)} {_REDACTED_CREDENTIAL}"
+    if match.group(2) is not None:
+        return f"{name}: {match.group(2)} {_REDACTED_CREDENTIAL}"
     return f"{name}: {_REDACTED_CREDENTIAL}"
 
 
@@ -467,25 +619,11 @@ class Redactor:
             return None
         return redact_structured_text(value)
 
-    def _redact_value(self, value: Any, sensitive: bool = False) -> Any:
-        """Recursively redact *value*, key-aware, without mutating it.
-
-        Delegates to the canonical module-level :func:`redact_value` so the
-        trajectory path and log-mode payload redaction share one recursion
-        (issue #455): string leaves under a sensitive key (their own key, or
-        inherited from a sensitive ancestor container) become
-        ``_REDACTED_CREDENTIAL``, other string leaves run through
-        :func:`redact_structured_text`, and string dict keys are scrubbed via
-        :func:`redact_text`. Fresh containers are built at every level, so the
-        caller's object is never touched.
-        """
-        return redact_value(value, sensitive)
-
     def _redact_arguments(self, arguments: dict[str, Any]) -> dict[str, Any]:
         """Redact every value inside a ToolCall.arguments dict (native walk).
 
         Each value is walked recursively with key-aware sensitive-key
-        detection (``_redact_value``) so nested credentials under
+        detection (:func:`redact_value`) so nested credentials under
         lower/mixed/camel-case keys are replaced without a JSON round-trip;
         the output keeps its declared ``dict[str, Any]`` shape and preserves
         nested structure (CR-01). A failure on any one key degrades only that
@@ -494,7 +632,7 @@ class Redactor:
         out: dict[str, Any] = {}
         for key, val in arguments.items():
             try:
-                out[key] = self._redact_value(
+                out[key] = redact_value(
                     val, _is_sensitive_key(key) if isinstance(key, str) else False
                 )
             except Exception:  # noqa: BLE001 - REDA-05 redact-or-omit

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -130,6 +130,10 @@ _PEM_KEY_PATTERN = re.compile(
 #: Replacement marker for PEM private-key blocks. Shared (imported) by the
 #: benchmark's buffering anchors so every redaction site emits one marker.
 _PEM_KEY_REDACTED_MARKER = "[REDACTED_PEM_KEY]"
+#: Replacement marker for credential values under sensitive keys (issue #455).
+#: Distinct from every existing [REDACTED_*] marker so consumers can tell a
+#: key-aware credential redaction from a flat regex hit.
+_REDACTED_CREDENTIAL = "[REDACTED_CREDENTIAL]"
 # Match env-var assignment where one of the underscore-separated SEGMENTS of
 # the var name is a secret keyword. Substring matching (the original) over-
 # redacted MONKEY_PATCH/KEYBOARD_LAYOUT/AUTHOR/TOKENIZED — segment-aware
@@ -277,47 +281,144 @@ class DaydreamRunFlow(str, Enum):
     IMPROVE = "improve"
 
 
+# Sensitive-key detection (issue #455): segment-aware, casing-agnostic.
+# A key is sensitive when the whole normalized key is a member of
+# _SENSITIVE_KEY_SUFFIXES, when it ends with "_" + member (compound members
+# like private_key / secret_access_key), or when any underscore-separated
+# segment is a member. Bare `key` is deliberately absent so keyStore/key_store
+# stay clean (WR-03), and a secret term must appear as a full segment — never
+# as a substring (tokenizer/passwordless pass through).
+_SENSITIVE_KEY_SUFFIXES: frozenset[str] = frozenset({
+    "api_key", "apikey", "auth", "authorization", "client_secret", "cookie",
+    "credential", "credentials", "password", "passwd", "private_key",
+    "secret", "secret_access_key", "set_cookie", "token",
+})
+# Insert a separator before an uppercase letter that follows a lowercase/digit
+# (camelCase → snake_case boundary): apiKey → api_Key, dbPassword → db_Password.
+_CAMEL_CASE_BOUNDARY_PATTERN = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+# Collapse any run of non-alphanumerics to a single underscore:
+# client-secret → client_secret, Access_Token → Access_Token.
+_NON_ALPHANUMERIC_KEY_PATTERN = re.compile(r"[^A-Za-z0-9]+")
+
+
+def _normalize_sensitive_key(key: str) -> str:
+    """Normalize *key* for sensitive-key matching (snake_case, lowercase).
+
+    Insert camelCase boundaries, lowercase, collapse non-alphanumeric runs to
+    ``_``, and strip edge separators: ``apiKey`` → ``api_key``,
+    ``client-secret`` → ``client_secret``, ``Access_Token`` → ``access_token``,
+    ``dbPassword`` → ``db_password``, ``AUTHORIZATION`` → ``authorization``,
+    ``awsSecretAccessKey`` → ``aws_secret_access_key``.
+    """
+    return (
+        _NON_ALPHANUMERIC_KEY_PATTERN.sub("_", _CAMEL_CASE_BOUNDARY_PATTERN.sub("_", key))
+        .lower()
+        .strip("_")
+    )
+
+
+def _is_sensitive_key(key: str) -> bool:
+    """Return True when *key* names a credential-bearing value (issue #455).
+
+    Segment-aware, casing-agnostic: True when the normalized key exactly
+    equals a ``_SENSITIVE_KEY_SUFFIXES`` member, ends with ``_<member>``, or
+    has some underscore-separated segment that is a member. The five WR-03
+    negatives (``tokenizer``, ``passwordless``, ``monkeyPatch``, ``keyStore``,
+    ``max_tokens``) all stay False — a secret term must appear as a full
+    segment, never as a substring.
+    """
+    normalized = _normalize_sensitive_key(key)
+    if normalized in _SENSITIVE_KEY_SUFFIXES:
+        return True
+    if any(normalized.endswith(f"_{member}") for member in _SENSITIVE_KEY_SUFFIXES):
+        return True
+    return any(segment in _SENSITIVE_KEY_SUFFIXES for segment in normalized.split("_"))
+
+
 class Redactor:
     """Regex-driven redactor (REDA-01..06).
 
     Applies ``_REDACTION_RULES`` uniformly to all four ATIF text surfaces:
     ``Step.message``, ``Step.reasoning_content``, every
     ``ToolCall.arguments`` value, and every ``ObservationResult.content``
-    string. Per D-04 the dispatch is flat regex on serialized text — no
-    JSON-aware deep walk. Per REDA-05 the failure mode is "redact-or-omit":
-    any internal exception replaces the offending value with
-    ``"[REDACTION_FAILED]"`` rather than letting the raw value through.
+    string. Tool-call arguments and other native structures are walked
+    recursively with key-aware sensitive-key detection
+    (``_redact_value`` / ``_is_sensitive_key``), so credentials under
+    lower/mixed/camel-case keys are replaced even at nested depth while the
+    surrounding shape is preserved; free-text surfaces compose the flat rules
+    with auth-header and structured key-value stages
+    (``_redact_structured_text``). Per REDA-05 the failure mode is
+    "redact-or-omit": any internal exception replaces the offending value
+    with ``"[REDACTION_FAILED]"`` rather than letting the raw value through.
     """
 
     def _redact_text(self, s: str) -> str:
-        """Apply every redaction rule to *s* and return the result."""
+        """Apply every flat redaction rule to *s* and return the result."""
         return redact_text(s)
+
+    def _redact_structured_text(self, s: str) -> str:
+        """Redact structured free-text surfaces (fail-closed).
+
+        Task 1 delegates to the module :func:`redact_text` (preserving the
+        existing flat coverage); the auth-header and structured key-value
+        stages land in Task 2. Any exception in any stage degrades the whole
+        field to ``"[REDACTION_FAILED]"`` — never raw pass-through.
+        """
+        try:
+            return redact_text(s)
+        except Exception:  # noqa: BLE001 - fail closed at every host boundary
+            return "[REDACTION_FAILED]"
 
     def _redact_optional_text(self, value: str | None) -> str | None:
         """Redact a possibly-None text field; degrade to [REDACTION_FAILED] on error."""
         if value is None:
             return None
-        return redact_text(value)
+        return self._redact_structured_text(value)
+
+    def _redact_value(self, value: Any, sensitive: bool = False) -> Any:
+        """Recursively redact *value*, key-aware, without mutating it.
+
+        String leaves under a sensitive key (their own key, or inherited from
+        a sensitive ancestor container) are replaced with ``_REDACTED_CREDENTIAL``;
+        other string leaves run through ``_redact_structured_text``. Dict
+        children are sensitive when the parent is sensitive OR their own key
+        is sensitive (``_is_sensitive_key``); list/tuple elements inherit the
+        container's sensitivity. Fresh containers are built at every level, so
+        the caller's object is never touched. Non-string scalars pass through
+        unchanged.
+        """
+        if isinstance(value, str):
+            return _REDACTED_CREDENTIAL if sensitive else self._redact_structured_text(value)
+        if isinstance(value, dict):
+            return {
+                key: self._redact_value(
+                    item,
+                    sensitive or (_is_sensitive_key(key) if isinstance(key, str) else False),
+                )
+                for key, item in value.items()
+            }
+        if isinstance(value, list):
+            return [self._redact_value(item, sensitive) for item in value]
+        if isinstance(value, tuple):
+            return tuple(self._redact_value(item, sensitive) for item in value)
+        return value
 
     def _redact_arguments(self, arguments: dict[str, Any]) -> dict[str, Any]:
-        """Redact every value inside a ToolCall.arguments dict.
+        """Redact every value inside a ToolCall.arguments dict (native walk).
 
-        Per D-04 the dispatch is flat regex on the serialized form of each
-        value. String values are redacted directly. Non-string values are
-        ``json.dumps``'d, redacted, then re-parsed back to their Python
-        structure so ``ToolCall.arguments`` keeps its declared shape. If
-        re-parse fails (regex broke JSON syntax) the value is replaced with
-        ``"[REDACTION_FAILED]"`` per REDA-05.
+        Each value is walked recursively with key-aware sensitive-key
+        detection (``_redact_value``) so nested credentials under
+        lower/mixed/camel-case keys are replaced without a JSON round-trip;
+        the output keeps its declared ``dict[str, Any]`` shape and preserves
+        nested structure (CR-01). A failure on any one key degrades only that
+        key to ``"[REDACTION_FAILED]"`` per REDA-05.
         """
         out: dict[str, Any] = {}
         for key, val in arguments.items():
             try:
-                if isinstance(val, str):
-                    out[key] = self._redact_text(val)
-                else:
-                    serialized = json.dumps(val)
-                    redacted = self._redact_text(serialized)
-                    out[key] = json.loads(redacted)
+                out[key] = self._redact_value(
+                    val, _is_sensitive_key(key) if isinstance(key, str) else False
+                )
             except Exception:  # noqa: BLE001 - REDA-05 redact-or-omit
                 out[key] = "[REDACTION_FAILED]"
         return out

--- a/tests/test_archive_integration.py
+++ b/tests/test_archive_integration.py
@@ -381,3 +381,52 @@ async def test_archive_callback_no_archive_dump_artifacts_skips_upload(
     # the dump dir even though centralized archiving + the HF upload are off.
     assert (dump_dir / "manifest.json").is_file()
     assert (dump_dir / "review-output.md").is_file()
+
+
+# Recorder → archive redaction parity (issue #455, Task 3)
+async def test_runner_archive_round_trip_redacts_structured_tool_credentials(
+    tmp_path: Path, archive_dir: Path,
+) -> None:
+    """A structured tool call under a sensitive key is redacted identically in the
+    live trajectory and the archived copy; both pass the ATIF validator."""
+    from daydream.agent import run_agent
+    from daydream.atif import validate as atif_validate
+    from daydream.backends import ResultEvent, ToolResultEvent, ToolStartEvent
+    from daydream.runner import RunConfig, _open_recorder
+    from tests.harness.backend import ScriptedBackend
+
+    sentinel = "opaque-test-only-sentinel"
+    target_dir = tmp_path / "project"
+    target_dir.mkdir()
+
+    backend = ScriptedBackend(events=(
+        ToolStartEvent(
+            id="t1", name="ListDir",
+            input={"dir": "/tmp", "apiKey": {"nested": sentinel}, "displayName": "visible"},
+        ),
+        ToolResultEvent(
+            id="t1",
+            output='{"status": "ok", "token": "opaque-test-only-sentinel"}',
+            is_error=False,
+        ),
+        ResultEvent(structured_output=None, continuation=None),
+    ))
+
+    config = RunConfig(target=str(target_dir), archive=True, run_eval=False)
+    recorder = _open_recorder(
+        config=config, target_dir=target_dir, work=None, flow_kind=DaydreamRunFlow.NORMAL,
+    )
+
+    async with recorder:
+        await run_agent(backend, target_dir, "inspect configuration", phase=DaydreamPhase.REVIEW)
+
+    live = json.loads(recorder.path.read_text(encoding="utf-8"))
+    run_dir = archive_dir / "runs" / recorder.session_id
+    archived = json.loads((run_dir / "trajectory.json").read_text(encoding="utf-8"))
+
+    assert live == archived
+    assert atif_validate(live) is True
+    blob = json.dumps(live)
+    assert sentinel not in blob
+    assert "[REDACTED_CREDENTIAL]" in blob
+    assert "visible" in blob

--- a/tests/test_log_mode.py
+++ b/tests/test_log_mode.py
@@ -140,7 +140,7 @@ def _capture_stdout_and_run(config: RunConfig, monkeypatch: pytest.MonkeyPatch) 
                 )
             ],
             {"log_mode": True, "quiet": True, "output_mode": "review"},
-            ("[result]", "[REDACTED_API_KEY]"),
+            ("[result]", "[REDACTED_CREDENTIAL]"),
             (),
             id="result-event",
         ),

--- a/tests/test_log_mode.py
+++ b/tests/test_log_mode.py
@@ -224,6 +224,39 @@ def test_log_mode_redacts_tool_summary_before_200_truncation() -> None:
     assert "[REDACTED" in out
 
 
+def test_log_mode_summaries_redact_structured_credentials() -> None:
+    """Log-mode summaries must use the structured redactor, not the flat one.
+
+    Issue #455 broadens structured credential redaction. Flat ``redact_text``
+    leaks structured credentials that ``redact_structured_text`` catches -- e.g.
+    a nested ``key=value`` assignment (``token=opaque-test-12345``) and a Basic
+    auth header's base64 credential. These flow through the real agent summary
+    paths (``_summarize_input`` / ``_summarize_output`` / ``_print_log``), so a
+    flat-only redactor would print the secret in --log mode.
+    """
+    from daydream.agent import _print_log, _summarize_input, _summarize_output
+
+    # Nested assignment under a sensitive key: flat redaction leaks the token.
+    out = _summarize_input({"command": "the config: token=opaque-test-12345"})
+    assert "opaque-test-12345" not in out
+    assert "[REDACTED" in out
+
+    # Basic auth header value (base64): flat redaction leaks it.
+    out = _summarize_output("Authorization: Basic dXNlcjpwYXNzd29yZA== more")
+    assert "dXNlcjpwYXNzd29yZA==" not in out
+    assert "[REDACTED" in out
+
+    # And the direct _print_log emitter on a command with a structured pair.
+    import io
+    from contextlib import redirect_stdout
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        _print_log("run: token=opaque-test-12345 done")
+    assert "opaque-test-12345" not in buf.getvalue()
+    assert "[REDACTED" in buf.getvalue()
+
+
 def test_log_mode_console_redacts_string_payloads() -> None:
     """phases.py imports agent's module-level console; in --log mode that
     console redacts string payloads, so phase/UI output (e.g. the failure

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -584,3 +584,45 @@ def test_redactor_preserves_non_sensitive_structured_keys(non_secret_key: str) -
     args = out.tool_calls[0].arguments
     assert args[non_secret_key] == "opaque-test-only-sentinel"
     assert "[REDACTED_CREDENTIAL]" not in json.dumps(args)
+
+
+# ---- Structured key-value text + auth headers (issue #455, Task 2) ----
+
+
+@pytest.mark.parametrize("text", [
+    '{"credentials": {"apiKey": "opaque-test-only-sentinel"}}',
+    "{'client_secret': 'opaque-test-only-sentinel'}",
+    "apiKey: opaque-test-only-sentinel",
+    "client-secret = opaque-test-only-sentinel",
+])
+def test_redactor_scrubs_sensitive_key_value_text_formats(text: str) -> None:
+    """The same leak is caught in JSON, Python-repr, YAML-like, and assignment text."""
+    out = Redactor().redact_step(_user_step(text))
+    assert isinstance(out.message, str)
+    assert "opaque-test-only-sentinel" not in out.message
+    assert "[REDACTED_CREDENTIAL]" in out.message
+
+
+@pytest.mark.parametrize(("header", "value", "scheme"), [
+    ("Authorization", "opaque-test-only-sentinel", None),
+    ("authorization", "Bearer opaque-test-only-sentinel", "Bearer"),
+    ("Proxy-Authorization", "opaque-test-only-sentinel", None),
+    ("X-Api-Key", "opaque-test-only-sentinel", None),
+    ("X-Auth-Token", "opaque-test-only-sentinel", None),
+    ("Cookie", "session=opaque-test-only-sentinel", None),
+    ("Set-Cookie", "opaque-test-only-sentinel", None),
+])
+def test_redactor_scrubs_authorization_header_values(
+    header: str, value: str, scheme: str | None,
+) -> None:
+    """Auth header values are redacted case-insensitively; name + scheme preserved;
+    nothing past end of line consumed."""
+    line = f"{header}: {value}\nnext line stays"
+    out = Redactor().redact_step(_user_step(line))
+    assert isinstance(out.message, str)
+    assert "opaque-test-only-sentinel" not in out.message
+    assert "[REDACTED_CREDENTIAL]" in out.message
+    assert f"{header}: " in out.message
+    assert "next line stays" in out.message
+    if scheme is not None:
+        assert f"{header}: {scheme} " in out.message

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -290,23 +290,17 @@ def test_redact_arguments_passthrough_when_no_secret() -> None:
     assert out["config"] == {"x": 1, "y": [1, 2, 3]}
 
 
-def test_redact_arguments_invalid_json_falls_back_to_redaction_failed() -> None:
-    """When regex breaks JSON syntax, value falls back to [REDACTION_FAILED]."""
+def test_redact_arguments_recursive_failure_falls_back_to_redaction_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the recursive native walk raises, that key falls back to [REDACTION_FAILED]."""
 
-    class _PoisonPattern:
-        def sub(self, _repl: object, s: str) -> str:
-            return "{not valid json"
+    def _boom(self: object, value: object, sensitive: bool = False) -> object:
+        raise RuntimeError("boom")
 
-    from daydream import trajectory as traj_mod
-
-    original_rules = traj_mod._REDACTION_RULES
-    poison_rules = ((_PoisonPattern(), "ignored"), *original_rules[:0])
-    try:
-        traj_mod._REDACTION_RULES = poison_rules
-        out = Redactor()._redact_arguments({"edits": [{"x": 1}]})
-        assert out["edits"] == "[REDACTION_FAILED]"
-    finally:
-        traj_mod._REDACTION_RULES = original_rules
+    monkeypatch.setattr(Redactor, "_redact_value", _boom, raising=True)
+    out = Redactor()._redact_arguments({"edits": [{"x": 1}]})
+    assert out["edits"] == "[REDACTION_FAILED]"
 
 
 # ---- Regression: WR-03 (env-var pattern over-redacted via substring match) ----
@@ -544,3 +538,49 @@ def test_redact_value_recurses_redacts_keys_and_values_without_mutating() -> Non
     assert "[REDACTED" in json.dumps(out)           # a marker replaced it
     assert out["items"] == ["[REDACTED_API_KEY]", 42, None]  # scalars preserved
     assert out["flag"] is True and out[1] == "non-string-key"  # non-string keys untouched
+
+
+# ---- Recursive sensitive-key redaction (issue #455, Task 1) ----
+
+
+@pytest.mark.parametrize("sensitive_key", [
+    "apiKey",
+    "client-secret",
+    "Access_Token",
+    "dbPassword",
+    "AUTHORIZATION",
+    "awsSecretAccessKey",
+])
+def test_redactor_scrubs_sensitive_keys_recursively(sensitive_key: str) -> None:
+    """Sensitive-key values are replaced with [REDACTED_CREDENTIAL] at nested depth;
+    clean siblings survive."""
+    sentinel = "opaque-test-only-sentinel"
+    call = ToolCall(
+        tool_call_id="t1",
+        function_name="Bash",
+        arguments={sensitive_key: {"nested": {"token": sentinel}}, "displayName": "visible"},
+    )
+    out = Redactor().redact_step(_agent_step(tool_calls=[call]))
+    assert out.tool_calls is not None
+    args = out.tool_calls[0].arguments
+    blob = json.dumps(args)
+    assert sentinel not in blob
+    assert "[REDACTED_CREDENTIAL]" in blob
+    assert args["displayName"] == "visible"
+
+
+@pytest.mark.parametrize("non_secret_key", [
+    "tokenizer", "passwordless", "monkeyPatch", "keyStore", "max_tokens",
+])
+def test_redactor_preserves_non_sensitive_structured_keys(non_secret_key: str) -> None:
+    """WR-03 guard: keys that merely contain a secret term as a substring are untouched."""
+    call = ToolCall(
+        tool_call_id="t1",
+        function_name="Bash",
+        arguments={non_secret_key: "opaque-test-only-sentinel"},
+    )
+    out = Redactor().redact_step(_agent_step(tool_calls=[call]))
+    assert out.tool_calls is not None
+    args = out.tool_calls[0].arguments
+    assert args[non_secret_key] == "opaque-test-only-sentinel"
+    assert "[REDACTED_CREDENTIAL]" not in json.dumps(args)

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -14,7 +14,7 @@ import json
 import pytest
 
 from daydream.atif import ContentPart, Observation, ObservationResult, Step, ToolCall
-from daydream.trajectory import Redactor, now_iso, redact_value
+from daydream.trajectory import Redactor, now_iso, redact_structured_text, redact_value
 
 
 def _user_step(message: str) -> Step:
@@ -234,7 +234,7 @@ def test_redactor_failure_mode_replaces_with_redaction_failed(
         def sub(self, *_args: object, **_kwargs: object) -> str:
             raise RuntimeError("boom")
 
-    # Replace the first rule so _redact_text raises on the first call.
+    # Replace the first rule so redact_structured_text raises on the first call.
     original_rules = traj_mod._REDACTION_RULES
     boom_rules = ((_BoomPattern(), "[REDACTED_API_KEY]"), *original_rules[1:])
     monkeypatch.setattr(traj_mod, "_REDACTION_RULES", boom_rules)
@@ -294,11 +294,12 @@ def test_redact_arguments_recursive_failure_falls_back_to_redaction_failed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """When the recursive native walk raises, that key falls back to [REDACTION_FAILED]."""
+    from daydream import trajectory as traj_mod
 
-    def _boom(self: object, value: object, sensitive: bool = False) -> object:
+    def _boom(value: object, sensitive: bool = False) -> object:
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(Redactor, "_redact_value", _boom, raising=True)
+    monkeypatch.setattr(traj_mod, "redact_value", _boom, raising=True)
     out = Redactor()._redact_arguments({"edits": [{"x": 1}]})
     assert out["edits"] == "[REDACTION_FAILED]"
 
@@ -626,3 +627,91 @@ def test_redactor_scrubs_authorization_header_values(
     assert "next line stays" in out.message
     if scheme is not None:
         assert f"{header}: {scheme} " in out.message
+
+
+# ---- Follow-up regressions (mid-line headers, nested pairs, prose) ----
+
+
+def test_redactor_scrubs_mid_line_authorization_header() -> None:
+    """A header embedded mid-line (curl -H, tool output) redacts the whole token,
+    not just the Bearer scheme word."""
+    text = 'curl -H "Authorization: Bearer opaque-token-xyz" https://api'
+    out = Redactor().redact_step(_user_step(text))
+    assert isinstance(out.message, str)
+    assert "opaque-token-xyz" not in out.message
+    assert "Authorization: Bearer [REDACTED_CREDENTIAL]" in out.message
+
+
+def test_redactor_scrubs_indented_and_embedded_headers() -> None:
+    """Indented (curl -v / httpie / YAML) and prose-embedded headers fire the
+    header stage instead of leaking the opaque token after the scheme word."""
+    indented = "  authorization: Bearer opaque-token-xyz"
+    embedded = "saw Authorization: Bearer opaque-token-xyz in the log"
+    for text in (indented, embedded):
+        out = Redactor().redact_step(_user_step(text))
+        assert isinstance(out.message, str)
+        assert "opaque-token-xyz" not in out.message
+        assert "Bearer [REDACTED_CREDENTIAL]" in out.message
+
+
+@pytest.mark.parametrize("text", [
+    "apiKey:\n  nested: opaque-test-only-sentinel",
+    '{\n  "apiKey": {\n    "nested": "opaque-test-only-sentinel"\n  }\n}',
+    '{"apiKey": {"nested": "opaque-test-only-sentinel"}}',
+])
+def test_redactor_scrubs_multi_line_block_values(text: str) -> None:
+    """Block-style YAML and pretty-printed JSON under a sensitive key are consumed
+    wholesale instead of passing through the line-scoped scan unredacted."""
+    out = redact_structured_text(text)
+    assert "opaque-test-only-sentinel" not in out
+    assert "[REDACTED_CREDENTIAL]" in out
+
+
+@pytest.mark.parametrize("text", [
+    "text: apiKey: opaque-test-only-sentinel",
+    "config: token=opaque-test-only-sentinel",
+    '{"description": "use token=opaque-test-only-sentinel here"}',
+])
+def test_redactor_scrubs_pairs_nested_inside_non_sensitive_values(text: str) -> None:
+    """A sensitive pair embedded in a non-sensitive pair's value is re-scanned
+    and redacted rather than skipped when the outer pair is consumed."""
+    out = redact_structured_text(text)
+    assert "opaque-test-only-sentinel" not in out
+    assert "[REDACTED_CREDENTIAL]" in out
+
+
+def test_redactor_preserves_structural_separator_after_bare_value() -> None:
+    """Redacting a bare value must not swallow the following ',' — the JSON
+    keeps its structure (issue: '{"token": null, "count": 3}' lost its comma)."""
+    out = redact_structured_text('{"token": null, "count": 3}')
+    assert out == '{"token": "[REDACTED_CREDENTIAL]", "count": 3}'
+    import json as _json
+
+    assert _json.loads(out)  # still parseable as JSON
+
+
+@pytest.mark.parametrize("text", [
+    "the token: is now available",
+    "The authorization: feature is enabled now",
+])
+def test_redactor_preserves_prose_with_sensitive_word_colon(text: str) -> None:
+    """A sensitive word followed by a colon in ordinary prose is not a key-value
+    pair — the following prose word is left untouched."""
+    out = redact_structured_text(text)
+    assert out == text
+    assert "[REDACTED_CREDENTIAL]" not in out
+
+
+def test_redactor_keeps_comma_in_bare_yaml_pair() -> None:
+    """'token: abc, other: 1' keeps its comma: the bare value stops at the
+    separator instead of swallowing it and merging the next pair."""
+    out = redact_structured_text("token: abc, other: 1")
+    assert out == 'token: "[REDACTED_CREDENTIAL]", other: 1'
+
+
+def test_redactor_scrubs_scheme_pair_under_sensitive_key() -> None:
+    """A bare 'Bearer|Basic|Token <opaque>' pair under a sensitive key redacts
+    the opaque token, not just the scheme word."""
+    out = redact_structured_text("token: Bearer opaque-token-xyz")
+    assert "opaque-token-xyz" not in out
+    assert "token: Bearer [REDACTED_CREDENTIAL]" in out


### PR DESCRIPTION
## Summary
Broadens structured credential redaction in trajectory and archive artifacts so sensitive values no longer leak through log-mode summaries and structured key-value payloads.

- Redact auth headers and structured key=value text in log-mode summaries
- Route _summarize_input/_summarize_output/_print_log through the structured redactor instead of flat redact_text
- Close block-value and nested-pair redaction gaps
- Pin recorder-to-archive redaction parity and recursive sensitive-key redaction in tests

## Test Plan
- Full suite: 3468 passed, 6 skipped, 7 failed (7 pre-existing environmental test_benchmark_cli.py compiled-entrypoint failures, unrelated)
- test_log_mode.py + test_redaction.py: 100 passed
- ruff lint clean, mypy clean

Two sequential daydream deep-precision reviews (rounds 1 and 2) passed on fresh exe.dev VMs. No CodeRabbit.

Closes #455
