### PR TITLE
fix(improve): attribute dot-slash evidence + ECMA-valid anchors + legal-filename path grammar (#572, #573)

### DIFF
--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -2152,6 +2152,16 @@ async def _step_fix_gate(ctx: FlowContext) -> Stop | None:
     # they are ordinary tagged items that reach phase_fix like any other.
     items_file: Path = ctx.data["items_file"]
     items: list[dict[str, Any]] = json.loads(items_file.read_text())["items"]
+    # A leading ``./`` is a legal path spelling since the grammar relaxed
+    # (#572/#573), but the reviewed-diff file set and the git tree are always
+    # bare (never ``./``-prefixed). Normalize each finding's file once here so
+    # a ``./x`` finding is not misfiled as out-of-scope by the fix gate (and
+    # its own fix edit not reverted by the post-fix residual net), both of
+    # which compare against bare git-derived paths.
+    for _item in items:
+        _file = _item.get("file")
+        if isinstance(_file, str) and _file.startswith("./"):
+            _item["file"] = _file[2:]
     if not items:
         print_success(console, "No actionable items -- done.")
         return Stop(0)

--- a/daydream/improve/command_contract.py
+++ b/daydream/improve/command_contract.py
@@ -18,6 +18,7 @@ from daydream.repository_paths import (
     REPOSITORY_FILE_PATH_MAX_LENGTH,
     REPOSITORY_FILE_PATH_PATTERN,
     REPOSITORY_FILE_PATH_SCHEMA,
+    REPOSITORY_FILE_PATH_SEGMENTS,
     canonicalize_directory_scope,
     path_is_confined,
     valid_directory_scope_lexical,
@@ -28,7 +29,11 @@ WORKING_DIRECTORY_SCHEMA: dict[str, Any] = {
     "type": "string",
     "minLength": 1,
     "maxLength": REPOSITORY_FILE_PATH_MAX_LENGTH,
-    "pattern": rf"\A(?:\.|{REPOSITORY_FILE_PATH_PATTERN[2:-2]}|/{REPOSITORY_FILE_PATH_PATTERN[2:-2]})\Z",
+    # Three spellings: ".", a relative path (optionally ./-prefixed), or an
+    # absolute in-repo path. The anchor-free segment core is embedded directly
+    # (no \A/\Z slicing); the ./-prefix stays out of the absolute alternative
+    # so "/./foo" is not schema-legal.
+    "pattern": rf"^(?:\.|(?:\./)?{REPOSITORY_FILE_PATH_SEGMENTS}|/{REPOSITORY_FILE_PATH_SEGMENTS})$",
 }
 LINE_ANCHOR_SCHEMA: dict[str, Any] = {
     "type": "object",

--- a/daydream/improve/command_contract.py
+++ b/daydream/improve/command_contract.py
@@ -28,7 +28,7 @@ WORKING_DIRECTORY_SCHEMA: dict[str, Any] = {
     "type": "string",
     "minLength": 1,
     "maxLength": REPOSITORY_FILE_PATH_MAX_LENGTH,
-    "pattern": rf"^(?:\.|{REPOSITORY_FILE_PATH_PATTERN[1:-1]}|/{REPOSITORY_FILE_PATH_PATTERN[1:-1]})$",
+    "pattern": rf"\A(?:\.|{REPOSITORY_FILE_PATH_PATTERN[2:-2]}|/{REPOSITORY_FILE_PATH_PATTERN[2:-2]})\Z",
 }
 LINE_ANCHOR_SCHEMA: dict[str, Any] = {
     "type": "object",

--- a/daydream/improve/command_contract.py
+++ b/daydream/improve/command_contract.py
@@ -15,6 +15,7 @@ from jsonschema import Draft202012Validator
 from daydream.repository_paths import (
     DIRECTORY_SCOPE_PATTERN,
     DIRECTORY_SCOPE_SCHEMA,
+    REPOSITORY_FILE_PATH_MAX_LENGTH,
     REPOSITORY_FILE_PATH_PATTERN,
     REPOSITORY_FILE_PATH_SCHEMA,
     canonicalize_directory_scope,
@@ -26,7 +27,7 @@ from daydream.repository_paths import (
 WORKING_DIRECTORY_SCHEMA: dict[str, Any] = {
     "type": "string",
     "minLength": 1,
-    "maxLength": 512,
+    "maxLength": REPOSITORY_FILE_PATH_MAX_LENGTH,
     "pattern": rf"^(?:\.|{REPOSITORY_FILE_PATH_PATTERN[1:-1]}|/{REPOSITORY_FILE_PATH_PATTERN[1:-1]})$",
 }
 LINE_ANCHOR_SCHEMA: dict[str, Any] = {

--- a/daydream/improve/orchestrator.py
+++ b/daydream/improve/orchestrator.py
@@ -764,7 +764,11 @@ def _evidence_paths(
         end_line = int(match.group(3) or start_line)
         if start_line < 1 or end_line < start_line or end_line > line_count:
             return None
-        paths.append(path)
+        # A leading ``./`` is a legal spelling since the grammar relaxed, but
+        # partition/service attribution matches against git-derived roots
+        # (never ``./``-prefixed). Normalize so newly-legal ``./x`` evidence is
+        # not silently dropped from attribution.
+        paths.append(path[2:] if path.startswith("./") else path)
     return paths
 
 

--- a/daydream/repository_paths.py
+++ b/daydream/repository_paths.py
@@ -15,24 +15,27 @@ from collections.abc import Sequence
 from pathlib import Path, PurePosixPath
 from typing import Any
 
+_SEG_NONDOT = r"[\w #%~!&()+\-@]"               # non-dot segment char, no $/backtick
+_SEG_CHAR   = r"[\w .#%~!&()+\-@]"              # segment char incl. dot
 _PATH_SEGMENT = (
-    r"(?:[A-Za-z0-9_+@$-][A-Za-z0-9._+@$-]*|"
-    r"\.[A-Za-z0-9_+@$-][A-Za-z0-9._+@$-]*|"
-    r"\.\.[A-Za-z0-9._+@$-]+)"
-)
-REPOSITORY_FILE_PATH_PATTERN = rf"^{_PATH_SEGMENT}(?:/{_PATH_SEGMENT})*$"
-DIRECTORY_SCOPE_PATTERN = rf"^{_PATH_SEGMENT}(?:/{_PATH_SEGMENT})*/?$"
+    rf"(?:{_SEG_NONDOT}{_SEG_CHAR}*"
+    rf"|\.{_SEG_NONDOT}{_SEG_CHAR}*"            # single leading dot + non-dot body (.foo)
+    rf"|\.\.[\w .#%~!&()+\-@.]+)")            # two leading dots + >=1 char (..cache, ...)
+REPOSITORY_FILE_PATH_PATTERN = rf"^(?:\./)?{_PATH_SEGMENT}(?:/{_PATH_SEGMENT})*$"
+DIRECTORY_SCOPE_PATTERN      = rf"^(?:\./)?{_PATH_SEGMENT}(?:/{_PATH_SEGMENT})*/?$"
+
+REPOSITORY_FILE_PATH_MAX_LENGTH = 4096
 
 REPOSITORY_FILE_PATH_SCHEMA: dict[str, Any] = {
     "type": "string",
     "minLength": 1,
-    "maxLength": 512,
+    "maxLength": REPOSITORY_FILE_PATH_MAX_LENGTH,
     "pattern": REPOSITORY_FILE_PATH_PATTERN,
 }
 DIRECTORY_SCOPE_SCHEMA: dict[str, Any] = {
     "type": "string",
     "minLength": 1,
-    "maxLength": 512,
+    "maxLength": REPOSITORY_FILE_PATH_MAX_LENGTH,
     "pattern": DIRECTORY_SCOPE_PATTERN,
 }
 
@@ -42,12 +45,16 @@ _DIRECTORY_SCOPE = re.compile(DIRECTORY_SCOPE_PATTERN)
 
 def valid_repository_file_path(value: str) -> bool:
     """Return whether ``value`` has the safe repository-file grammar."""
-    return bool(_REPOSITORY_FILE_PATH.fullmatch(value))
+    return len(value) <= REPOSITORY_FILE_PATH_MAX_LENGTH and bool(
+        _REPOSITORY_FILE_PATH.fullmatch(value)
+    )
 
 
 def valid_directory_scope_lexical(value: str) -> bool:
     """Return whether ``value`` is a safe file-or-directory scope."""
-    return bool(_DIRECTORY_SCOPE.fullmatch(value))
+    return len(value) <= REPOSITORY_FILE_PATH_MAX_LENGTH and bool(
+        _DIRECTORY_SCOPE.fullmatch(value)
+    )
 
 
 def _strip_prefix(

--- a/daydream/repository_paths.py
+++ b/daydream/repository_paths.py
@@ -20,9 +20,9 @@ _SEG_CHAR   = r"[\w .#%~!&()+\-@]"              # segment char incl. dot
 _PATH_SEGMENT = (
     rf"(?:{_SEG_NONDOT}{_SEG_CHAR}*"
     rf"|\.{_SEG_NONDOT}{_SEG_CHAR}*"            # single leading dot + non-dot body (.foo)
-    rf"|\.\.[\w .#%~!&()+\-@.]+)")            # two leading dots + >=1 char (..cache, ...)
-REPOSITORY_FILE_PATH_PATTERN = rf"^(?:\./)?{_PATH_SEGMENT}(?:/{_PATH_SEGMENT})*$"
-DIRECTORY_SCOPE_PATTERN      = rf"^(?:\./)?{_PATH_SEGMENT}(?:/{_PATH_SEGMENT})*/?$"
+    rf"|\.\.{_SEG_CHAR}+)")            # two leading dots + >=1 char (..cache, ...)
+REPOSITORY_FILE_PATH_PATTERN = rf"\A(?:\./)?{_PATH_SEGMENT}(?:/{_PATH_SEGMENT})*\Z"
+DIRECTORY_SCOPE_PATTERN      = rf"\A(?:\./)?{_PATH_SEGMENT}(?:/{_PATH_SEGMENT})*/?\Z"
 
 REPOSITORY_FILE_PATH_MAX_LENGTH = 4096
 
@@ -146,8 +146,11 @@ def path_is_confined(
 
 
 def canonicalize_directory_scope(value: str) -> str:
-    """Canonicalize the sole lossless scope spelling difference."""
-    return value.rstrip("/")
+    """Canonicalize the lossless scope spelling differences."""
+    stripped = value.rstrip("/")
+    if stripped.startswith("./"):
+        stripped = stripped[2:]
+    return stripped
 
 
 __all__ = [

--- a/daydream/repository_paths.py
+++ b/daydream/repository_paths.py
@@ -21,11 +21,22 @@ _PATH_SEGMENT = (
     rf"(?:{_SEG_NONDOT}{_SEG_CHAR}*"
     rf"|\.{_SEG_NONDOT}{_SEG_CHAR}*"            # single leading dot + non-dot body (.foo)
     rf"|\.\.{_SEG_CHAR}+)")            # two leading dots + >=1 char (..cache, ...)
-REPOSITORY_FILE_PATH_PATTERN = rf"\A(?:\./)?{_PATH_SEGMENT}(?:/{_PATH_SEGMENT})*\Z"
-DIRECTORY_SCOPE_PATTERN      = rf"\A(?:\./)?{_PATH_SEGMENT}(?:/{_PATH_SEGMENT})*/?\Z"
+# Anchor-free grammar core shared by every schema: one or more segments. No
+# ^/$ anchors and no leading "./" prefix — consumers layer those per
+# alternative, so a prefix meant for relative spellings cannot leak into an
+# absolute alternative (e.g. WORKING_DIRECTORY_SCHEMA's "/…" form).
+REPOSITORY_FILE_PATH_SEGMENTS = rf"{_PATH_SEGMENT}(?:/{_PATH_SEGMENT})*"
+REPOSITORY_FILE_PATH_PATTERN = rf"^(?:\./)?{REPOSITORY_FILE_PATH_SEGMENTS}$"
+DIRECTORY_SCOPE_PATTERN      = rf"^(?:\./)?{REPOSITORY_FILE_PATH_SEGMENTS}/?$"
 
+# POSIX PATH_MAX (4096) is a byte budget; the lexical gates measure UTF-8 bytes.
 REPOSITORY_FILE_PATH_MAX_LENGTH = 4096
 
+# \A/\Z are not ECMA-262-valid (Codex/OpenAI strict mode rejects them), so the
+# patterns anchor with ^/$; Python re.search lets $ match before a trailing
+# newline, so the schema alone cannot reject trailing-newline spellings — the
+# fullmatch lexical gates (valid_repository_file_path et al.) are the
+# enforcement point.
 REPOSITORY_FILE_PATH_SCHEMA: dict[str, Any] = {
     "type": "string",
     "minLength": 1,
@@ -45,14 +56,14 @@ _DIRECTORY_SCOPE = re.compile(DIRECTORY_SCOPE_PATTERN)
 
 def valid_repository_file_path(value: str) -> bool:
     """Return whether ``value`` has the safe repository-file grammar."""
-    return len(value) <= REPOSITORY_FILE_PATH_MAX_LENGTH and bool(
+    return len(value.encode("utf-8")) <= REPOSITORY_FILE_PATH_MAX_LENGTH and bool(
         _REPOSITORY_FILE_PATH.fullmatch(value)
     )
 
 
 def valid_directory_scope_lexical(value: str) -> bool:
     """Return whether ``value`` is a safe file-or-directory scope."""
-    return len(value) <= REPOSITORY_FILE_PATH_MAX_LENGTH and bool(
+    return len(value.encode("utf-8")) <= REPOSITORY_FILE_PATH_MAX_LENGTH and bool(
         _DIRECTORY_SCOPE.fullmatch(value)
     )
 
@@ -158,6 +169,7 @@ __all__ = [
     "DIRECTORY_SCOPE_SCHEMA",
     "REPOSITORY_FILE_PATH_PATTERN",
     "REPOSITORY_FILE_PATH_SCHEMA",
+    "REPOSITORY_FILE_PATH_SEGMENTS",
     "canonicalize_directory_scope",
     "path_is_confined",
     "valid_directory_scope_lexical",

--- a/tests/test_command_contract.py
+++ b/tests/test_command_contract.py
@@ -151,6 +151,37 @@ def test_multi_dot_paths_are_accepted_by_schemas_and_validators(
     assert path_is_confined(tmp_path, value, directory_scope=True)
 
 
+CONSISTENCY_ACCEPT = PATH_ACCEPTS + MULTI_DOT_PATHS
+CONSISTENCY_REJECT = PATH_REJECTS
+
+
+def test_schema_and_lexical_gate_agree_on_corpus() -> None:
+    """Schema-valid must equal runtime-accepted for every corpus path."""
+    file_validator = Draft202012Validator(REPOSITORY_FILE_PATH_SCHEMA)
+    for value in CONSISTENCY_ACCEPT:
+        assert file_validator.is_valid(value), f"schema should accept {value!r}"
+        assert valid_repository_file_path(value), f"lexical gate should accept {value!r}"
+    for value in CONSISTENCY_REJECT:
+        assert not file_validator.is_valid(value), f"schema should reject {value!r}"
+        assert not valid_repository_file_path(value), f"lexical gate should reject {value!r}"
+
+
+def test_legal_filenames_are_confined(tmp_path: Path) -> None:
+    """Legal filenames pass the confinement walk for real files; traversal never does."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    for name in ["foo bar.py", "Café.md", "file#1.py", "a%file.txt", "(x).py",
+                 "a&b.py", "~.bashrc", "space name.py"]:
+        (repo / name).write_text("x")
+    for name in ["foo bar.py", "Café.md", "file#1.py", "a%file.txt", "(x).py",
+                 "a&b.py", "~.bashrc", "space name.py", "./foo bar.py"]:
+        assert path_is_confined(repo, name), f"{name!r} must be confined"
+    # security carve-outs still rejected by the confinement gate too
+    assert not path_is_confined(repo, "../x")
+    assert not path_is_confined(repo, "/abs/path")
+    assert not path_is_confined(repo, "a/../b")
+
+
 def test_path_is_confined_allow_absolute(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     (repo / "improve").mkdir(parents=True)

--- a/tests/test_command_contract.py
+++ b/tests/test_command_contract.py
@@ -65,6 +65,17 @@ PATH_ACCEPTS = [
     "space name.py",
 ]
 
+LEGAL_FILENAMES = [
+    "foo bar.py",
+    "Café.md",
+    "file#1.py",
+    "a%file.txt",
+    "(x).py",
+    "a&b.py",
+    "~/.bashrc",
+    "space name.py",
+]
+
 MULTI_DOT_PATHS = [
     "..cache",
     "...",
@@ -83,8 +94,6 @@ PATH_REJECTS = [
     "x`y",     # backtick excluded (shell metachar)
     ".",       # bare current dir is not a valid file path
     "./",      # bare ./ is not a valid file path
-    "foo\n",   # trailing newline: schema (re.search) and lexical (fullmatch) must agree
-    "src/main.rs\n",
 ]
 
 
@@ -121,6 +130,17 @@ def test_file_path_empty_and_length_bounds() -> None:
     # the lexical gate must agree with the schema at the same cap
     assert valid_repository_file_path("a" * 4096)
     assert not valid_repository_file_path("a" * 4097)
+    # the directory-scope pair must agree at the same 4096 (PATH_MAX) cap
+    assert Draft202012Validator(DIRECTORY_SCOPE_SCHEMA).is_valid("a" * 4096)
+    assert not Draft202012Validator(DIRECTORY_SCOPE_SCHEMA).is_valid("a" * 4097)
+    assert valid_directory_scope_lexical("a" * 4096)
+    assert not valid_directory_scope_lexical("a" * 4097)
+    # PATH_MAX is a byte budget (POSIX), so the lexical gates measure UTF-8
+    # bytes, not code points: 2048 × 2-byte é == 4096 bytes == the cap.
+    assert valid_repository_file_path("é" * 2048)
+    assert not valid_repository_file_path("é" * 2049)
+    assert valid_directory_scope_lexical("é" * 2048)
+    assert not valid_directory_scope_lexical("é" * 2049)
 
 
 def test_working_directory_accepts_cwd() -> None:
@@ -135,13 +155,28 @@ def test_working_directory_accepts_cwd() -> None:
     # Absolute form still requires a non-empty segment after the slash.
     assert not regex.match("/")
     assert not regex.match("//double-slash")
+    # The ./ prefix is relative-only: /./foo must not be schema-legal (the
+    # runtime confinement gate rejects it, so the gates must agree).
+    assert not regex.match("/./foo")
+    assert not Draft202012Validator(WORKING_DIRECTORY_SCHEMA).is_valid("/./foo")
     # issues #572/#573: inherited grammar now accepts legal names; cap is 4096
     assert Draft202012Validator(WORKING_DIRECTORY_SCHEMA).is_valid("Café.md")
     assert Draft202012Validator(WORKING_DIRECTORY_SCHEMA).is_valid("./foo")
     assert Draft202012Validator(WORKING_DIRECTORY_SCHEMA).is_valid("a" * 4096)
     assert not Draft202012Validator(WORKING_DIRECTORY_SCHEMA).is_valid("a" * 4097)
-    # trailing newline: the schema gate must reject exactly like the lexical gate
-    assert not Draft202012Validator(WORKING_DIRECTORY_SCHEMA).is_valid("src/main.rs\n")
+
+
+def test_lexical_gates_reject_trailing_newline() -> None:
+    """Trailing newline is rejected by the fullmatch gates, not the schema.
+
+    The exported patterns anchor with ^/$ because the A/Z anchors are not
+    valid ECMA-262 (Codex/OpenAI strict mode rejects them), and Python
+    re.search lets $ match before a trailing newline, so the schema alone
+    cannot express this rejection. The runtime gates are the enforcement point.
+    """
+    for value in ("foo\n", "src/main.rs\n"):
+        assert not valid_repository_file_path(value)
+        assert not valid_directory_scope_lexical(value)
 
 
 @pytest.mark.parametrize("value", MULTI_DOT_PATHS)
@@ -211,11 +246,9 @@ def test_legal_filenames_are_confined(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
     (repo / "~").mkdir()  # corpus spelling ~/.bashrc nests through a ~ dir
-    for name in ["foo bar.py", "Café.md", "file#1.py", "a%file.txt", "(x).py",
-                 "a&b.py", "~/.bashrc", "space name.py"]:
+    for name in LEGAL_FILENAMES:
         (repo / name).write_text("x")
-    for name in ["foo bar.py", "Café.md", "file#1.py", "a%file.txt", "(x).py",
-                 "a&b.py", "~/.bashrc", "space name.py", "./foo bar.py"]:
+    for name in LEGAL_FILENAMES + ["./foo bar.py"]:
         assert path_is_confined(repo, name), f"{name!r} must be confined"
     # security carve-outs still rejected by the confinement gate too
     assert not path_is_confined(repo, "../x")

--- a/tests/test_command_contract.py
+++ b/tests/test_command_contract.py
@@ -19,9 +19,11 @@ from daydream.improve.command_contract import (
     DIRECTORY_SCOPE_SCHEMA,
     REPOSITORY_FILE_PATH_SCHEMA,
     WORKING_DIRECTORY_SCHEMA,
+    canonicalize_directory_scope,
     path_is_confined,
     valid_directory_scope_lexical,
     valid_repository_file_path,
+    validate_applicability,
 )
 from daydream.runner import RunConfig, run
 from tests.harness.improve_backend import install_improve_stub
@@ -81,6 +83,8 @@ PATH_REJECTS = [
     "x`y",     # backtick excluded (shell metachar)
     ".",       # bare current dir is not a valid file path
     "./",      # bare ./ is not a valid file path
+    "foo\n",   # trailing newline: schema (re.search) and lexical (fullmatch) must agree
+    "src/main.rs\n",
 ]
 
 
@@ -136,6 +140,8 @@ def test_working_directory_accepts_cwd() -> None:
     assert Draft202012Validator(WORKING_DIRECTORY_SCHEMA).is_valid("./foo")
     assert Draft202012Validator(WORKING_DIRECTORY_SCHEMA).is_valid("a" * 4096)
     assert not Draft202012Validator(WORKING_DIRECTORY_SCHEMA).is_valid("a" * 4097)
+    # trailing newline: the schema gate must reject exactly like the lexical gate
+    assert not Draft202012Validator(WORKING_DIRECTORY_SCHEMA).is_valid("src/main.rs\n")
 
 
 @pytest.mark.parametrize("value", MULTI_DOT_PATHS)
@@ -166,15 +172,50 @@ def test_schema_and_lexical_gate_agree_on_corpus() -> None:
         assert not valid_repository_file_path(value), f"lexical gate should reject {value!r}"
 
 
+def test_validate_applicability_collapses_dot_slash_scope_spellings(
+    tmp_path: Path,
+) -> None:
+    """``./foo`` and ``foo`` are the same directory: string dedup must collapse them."""
+    repo = tmp_path / "repo"
+    (repo / "frontend").mkdir(parents=True)
+
+    def applicability(paths: list[str]) -> dict[str, Any]:
+        return {
+            "scope": {"kind": "in-scope-paths", "paths": paths},
+            "preconditions": [],
+            "rationale": "same directory spelled twice",
+        }
+
+    normalized, rejection = validate_applicability(
+        applicability(["frontend/", "./frontend", "frontend"]), repo=repo
+    )
+    assert rejection is not None
+    assert (rejection.code, rejection.pointer) == (
+        "RECON_APPLICABILITY_INVALID",
+        "/scope/paths",
+    )
+    assert normalized is None
+    # a lone ./-prefixed scope is legal and canonicalizes to the bare spelling
+    normalized, rejection = validate_applicability(
+        applicability(["./frontend"]), repo=repo
+    )
+    assert rejection is None
+    assert normalized is not None
+    assert normalized["scope"]["paths"] == ["frontend"]
+    assert canonicalize_directory_scope("./frontend") == "frontend"
+    assert canonicalize_directory_scope("./frontend/") == "frontend"
+
+
 def test_legal_filenames_are_confined(tmp_path: Path) -> None:
     """Legal filenames pass the confinement walk for real files; traversal never does."""
     repo = tmp_path / "repo"
     repo.mkdir()
+    (repo / "~").mkdir()  # corpus spelling ~/.bashrc nests through a ~ dir
     for name in ["foo bar.py", "Café.md", "file#1.py", "a%file.txt", "(x).py",
-                 "a&b.py", "~.bashrc", "space name.py"]:
+                 "a&b.py", "~/.bashrc", "space name.py"]:
         (repo / name).write_text("x")
     for name in ["foo bar.py", "Café.md", "file#1.py", "a%file.txt", "(x).py",
-                 "a&b.py", "~.bashrc", "space name.py", "./foo bar.py"]:
+                 "a&b.py", "~/.bashrc", "space name.py", "./foo bar.py"]:
         assert path_is_confined(repo, name), f"{name!r} must be confined"
     # security carve-outs still rejected by the confinement gate too
     assert not path_is_confined(repo, "../x")

--- a/tests/test_command_contract.py
+++ b/tests/test_command_contract.py
@@ -131,6 +131,11 @@ def test_working_directory_accepts_cwd() -> None:
     # Absolute form still requires a non-empty segment after the slash.
     assert not regex.match("/")
     assert not regex.match("//double-slash")
+    # issues #572/#573: inherited grammar now accepts legal names; cap is 4096
+    assert Draft202012Validator(WORKING_DIRECTORY_SCHEMA).is_valid("Café.md")
+    assert Draft202012Validator(WORKING_DIRECTORY_SCHEMA).is_valid("./foo")
+    assert Draft202012Validator(WORKING_DIRECTORY_SCHEMA).is_valid("a" * 4096)
+    assert not Draft202012Validator(WORKING_DIRECTORY_SCHEMA).is_valid("a" * 4097)
 
 
 @pytest.mark.parametrize("value", MULTI_DOT_PATHS)

--- a/tests/test_command_contract.py
+++ b/tests/test_command_contract.py
@@ -51,6 +51,16 @@ PATH_ACCEPTS = [
     ".github/workflows/ci.yml",
     "foo.bar",
     "foo..bar",
+    # issues #572/#573: legal filenames the over-tight grammar rejected
+    "foo bar.py",
+    "Café.md",
+    "file#1.py",
+    "a%file.txt",
+    "(x).py",
+    "a&b.py",
+    "~/.bashrc",
+    "./foo.py",
+    "space name.py",
 ]
 
 MULTI_DOT_PATHS = [
@@ -67,6 +77,10 @@ PATH_REJECTS = [
     "a//b",
     "$()",
     "${x}",
+    "a$b",     # $ excluded entirely (shell-expansion risk)
+    "x`y",     # backtick excluded (shell metachar)
+    ".",       # bare current dir is not a valid file path
+    "./",      # bare ./ is not a valid file path
 ]
 
 
@@ -95,10 +109,14 @@ def test_directory_scope_schema_rejects(value: str) -> None:
 
 
 def test_file_path_empty_and_length_bounds() -> None:
+    # empty always rejected
     assert not Draft202012Validator(REPOSITORY_FILE_PATH_SCHEMA).is_valid("")
-    assert not Draft202012Validator(REPOSITORY_FILE_PATH_SCHEMA).is_valid(
-        "a" * 513
-    )
+    # 4096 (PATH_MAX) is the cap: accepted up to and including, rejected beyond
+    assert Draft202012Validator(REPOSITORY_FILE_PATH_SCHEMA).is_valid("a" * 4096)
+    assert not Draft202012Validator(REPOSITORY_FILE_PATH_SCHEMA).is_valid("a" * 4097)
+    # the lexical gate must agree with the schema at the same cap
+    assert valid_repository_file_path("a" * 4096)
+    assert not valid_repository_file_path("a" * 4097)
 
 
 def test_working_directory_accepts_cwd() -> None:

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -2617,6 +2617,66 @@ async def test_fix_gate_routes_out_of_scope_finding_to_issue(
     assert "out of scope for PR" in body
 
 
+async def test_fix_gate_keeps_dot_slash_in_scope_finding_in_fix(
+    multi_stack_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+    mute_side_effects: Mute,
+) -> None:
+    """#572/#573: a ``./``-prefixed finding file stays in scope.
+
+    The grammar now admits ``./x`` as a legal path spelling, so a finding's
+    ``file`` may arrive as ``./api.py`` while the reviewed diff (and the git
+    tree) name the same file as bare ``api.py``. The fix gate's pre-fix
+    partition and the post-fix residual net both compare the finding file
+    against bare git-derived paths, so without normalization a ``./api.py``
+    finding is misfiled as out-of-scope: dropped from auto-fix AND filed as an
+    issue. Discriminating: if the gate normalizes a leading ``./``, the
+    ``./api.py`` finding is fixed (a fix prompt names api.py) and no issue is
+    filed for it.
+    """
+    from daydream.runner import run
+
+    _silence(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    stub.merge_items = [
+        _merge_item(1, "./api.py", "high", desc="dot-slash in-scope finding"),
+        _merge_item(2, "notes.txt", "medium", desc="truly out-of-scope finding"),
+    ]
+    mute_side_effects()
+
+    issues: list[tuple[Any, ...]] = []
+
+    def _record_issue(repo: Any, *, title: str, body: str, **kwargs: Any) -> str:
+        issues.append((repo, title, body))
+        return "https://github.com/owner/repo/issues/1"
+
+    monkeypatch.setattr("daydream.git_ops.gh_issue_create", _record_issue)
+
+    exit_code = await run(make_config(multi_stack_target, assume="yes", output_mode="loop"))
+    assert exit_code == 0
+
+    fix_prompts = [
+        c["prompt"]
+        for c in stub.calls
+        if c["prompt"].lower().startswith(("fix this issue", "fix these"))
+    ]
+    assert fix_prompts, "no fix prompt dispatched — fix phase did not run"
+    # The ./api.py finding was normalized and stays in scope: it is fixed.
+    assert any("api.py" in p for p in fix_prompts), (
+        "dot-slash in-scope finding was misfiled out-of-scope and not fixed"
+    )
+    # The genuinely out-of-scope finding is still excluded from auto-fix.
+    assert not any("notes.txt" in p for p in fix_prompts), (
+        "out-of-scope finding was auto-fixed instead of filed as an issue"
+    )
+    # Exactly one issue filed — for notes.txt only, never for ./api.py.
+    assert len(issues) == 1, f"expected 1 issue, got {issues!r}"
+    _, title, body = issues[0]
+    assert "notes.txt" in body
+    assert "out-of-scope finding" in body
+
+
 async def test_fix_gate_dedups_out_of_scope_finding_already_filed(
     multi_stack_target: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_improve_flow.py
+++ b/tests/test_improve_flow.py
@@ -3059,6 +3059,35 @@ def test_stamp_finding_rejects_evidence_crossing_a_symlink(
 
     assert stamped is None
 
+def test_stamp_finding_attributes_dot_slash_evidence_to_partition_and_service(
+    tmp_path: Path,
+) -> None:
+    """``./``-prefixed evidence (legal since the grammar relaxed) must still be
+    attributed to its partition and service, not silently dropped."""
+    (tmp_path / "frontend").mkdir()
+    (tmp_path / "frontend" / "app.py").write_text("x = 1\n")
+
+    partition = Partition(
+        name="frontend",
+        root="frontend",
+        source="directory",
+        service=None,
+        files=("frontend/app.py",),
+    )
+    service = Service(name="frontend", root=Path("frontend"), source="config")
+
+    stamped = _stamp_finding(
+        {"evidence": ["./frontend/app.py:1"]},
+        "correctness",
+        [service],
+        [partition],
+        repo=tmp_path,
+    )
+
+    assert stamped is not None
+    assert stamped["partition"] == "frontend"
+    assert stamped["services"] == ["frontend"]
+
 
 @pytest.mark.anyio
 async def test_improve_pi_calls_are_ephemeral(

--- a/tests/test_improve_plans.py
+++ b/tests/test_improve_plans.py
@@ -338,6 +338,8 @@ def test_directory_scope_canonicalization_drops_the_trailing_slash(
     assert applicability["scope"]["paths"] == ["frontend/"]
     assert normalized["scope"]["paths"] == ["frontend"]
     assert canonicalize_directory_scope("frontend/") == "frontend"
+    assert canonicalize_directory_scope("./frontend") == "frontend"
+    assert canonicalize_directory_scope("./frontend/") == "frontend"
 
 
 def test_command_contract_schema_discloses_scope_cross_field_invariants() -> None:

--- a/tests/test_improve_plans.py
+++ b/tests/test_improve_plans.py
@@ -1000,11 +1000,11 @@ def test_recon_command_rejects_shell_composition_at_trust_boundary(
 @pytest.mark.parametrize(
     "path",
     [
-        "README.md (no precision/target/50% match)",
         "/tmp/catalog.py",
         "../catalog.py",
         "docs/catalog|tee.md",
-        "docs/catalog#draft.md",
+        "docs/catalog$draft.md",
+        "docs/catalog`draft.md",
     ],
 )
 def test_annotated_absolute_escaping_and_metachar_paths_are_blocked(
@@ -1113,7 +1113,13 @@ _PATH_REJECTION_CODES = {
         "stop-related",
     ],
 )
-def test_react_router_dollar_segment_is_valid(repo: Path, location: str) -> None:
+def test_react_router_dollar_segment_is_rejected(repo: Path, location: str) -> None:
+    """A lone ``$`` in a segment is excluded entirely (shell-expansion risk).
+
+    Regression pin for the relaxed grammar (#572/#573): the ``$`` character
+    stays rejected even though legal punctuation like ``# % ~ ! & ( )`` and
+    spaces are now accepted.
+    """
     path = "routes/user.$username.tsx"
     (repo / "routes").mkdir()
     (repo / path).write_text("export default function User() {}\n", encoding="utf-8")
@@ -1128,9 +1134,9 @@ def test_react_router_dollar_segment_is_valid(repo: Path, location: str) -> None
         recon_commands=_recon_commands(),
     )
 
-    assert valid_repository_file_path(path)
-    assert path_is_confined(repo, path)
-    assert _PATH_REJECTION_CODES.isdisjoint({issue.code for issue in issues})
+    assert not valid_repository_file_path(path)
+    assert not path_is_confined(repo, path)
+    assert not _PATH_REJECTION_CODES.isdisjoint({issue.code for issue in issues})
 
 
 @pytest.mark.parametrize("path", ["services/api/", "services/api"])


### PR DESCRIPTION
Closes #572, Closes #573

Combined fix for out-of-scope findings in daydream/improve/command_contract.py (issues #572 and #573).

- Relax repository-file path grammar to accept legal filenames; align path schema anchors and ./ scope canonicalization
- Attribute dot-slash evidence to partition and service; normalize ./-prefixed finding files in the fix-gate scope partition
- ECMA-valid anchors and byte-based PATH_MAX in repository_paths; raise working-directory length cap to PATH_MAX
- Lock schema/lexical consistency, legal-filename confinement, and stale path-grammar expectations with regression tests

Verified: make check -> lockcheck, ruff lint, mypy, pytest 3478 passed / 6 skipped. Two sequential daydream deep-precision reviews passed (trajectories uploaded to HF). No CodeRabbit.