### PR TITLE
Require trusted, head-bound approval before credential-bearing Daydream PR reviews

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -20,14 +20,17 @@ Codex CLI before review), then follow the canonical installation guide:
 
 | Trigger | Path | Notes |
 |---|---|---|
-| PR `opened` / `ready_for_review` | auto: Review → Post | Same-repo PRs only; disabled when `DAYDREAM_AUTO_REVIEW` is `false` |
-| `@<bot> review` PR comment | on demand: Command → Review → Post | Comment author must be OWNER / MEMBER / COLLABORATOR; bot comments are ignored |
-| Fork PRs | `@<bot> review` only by default | Auto-review is gated to same-repo PRs (fork runs get no secrets, so the reviewer cannot run) |
+| `@<bot> review` PR comment | Command → Review → Post | Comment author must be OWNER / MEMBER / COLLABORATOR; bot comments are ignored; the PR head current at comment time is bound as the approved target |
+| New commit after approval | Review rejects head drift | Comment `@<bot> review` again to approve the new head |
+| Fork PRs | Same trusted-comment path | The review remains approval-gated and checks out only the approved head |
 
-**Private-repo limitation:** on private repositories GitHub runs **no
-workflows at all** for fork PRs (the "run workflows from fork pull requests"
-policy is off by default), so fork PRs there get no auto-review of any kind —
-only the `@<bot> review` command path can serve them.
+There is no automatic PR-open trigger. A credential-bearing review runs only
+after a trusted comment explicitly approves the current head.
+
+**Private-repo limitation:** on private repositories GitHub may run no
+workflows for fork PRs when the "run workflows from fork pull requests" policy
+is disabled. Enable the applicable repository policy before using the trusted
+`@<bot> review` path for those forks.
 
 ## Security model — the privilege split
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -27,11 +27,6 @@ Codex CLI before review), then follow the canonical installation guide:
 There is no automatic PR-open trigger. A credential-bearing review runs only
 after a trusted comment explicitly approves the current head.
 
-**Private-repo limitation:** on private repositories GitHub may run no
-workflows for fork PRs when the "run workflows from fork pull requests" policy
-is disabled. Enable the applicable repository policy before using the trusted
-`@<bot> review` path for those forks.
-
 ## Security model — the privilege split
 
 No single job ever holds both PR code and the App private key:

--- a/.github/workflows/daydream-command.yml
+++ b/.github/workflows/daydream-command.yml
@@ -70,14 +70,6 @@ jobs:
           permission-actions: write
           permission-pull-requests: write
 
-      - name: Acknowledge with eyes reaction
-        if: steps.match.outputs.matched == 'true'
-        env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
-          REPO: ${{ github.repository }}
-          COMMENT_ID: ${{ github.event.comment.id }}
-        run: gh api -X POST "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" -f content=eyes
-
       # Dispatch binds the PR head (resolved at run time) plus the approving
       # comment's creation time as the comment-time anchor: the review gate
       # rejects any approved head whose commit postdates that comment, so a
@@ -99,3 +91,16 @@ jobs:
             -f pr_number="$PR_NUMBER" \
             -f approved_head_sha="$HEAD_SHA" \
             -f approved_at="$COMMENT_CREATED_AT"
+
+      # Acknowledge only after the dispatch's head resolution succeeds: the
+      # `gh api` above is fallible, and a transient error must not leave the
+      # maintainer with a 👀 reaction and no review, comment, or explanation —
+      # the failed run surfaces on the PR instead of the reaction mis-signalling
+      # success.
+      - name: Acknowledge with eyes reaction
+        if: steps.match.outputs.matched == 'true'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: gh api -X POST "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" -f content=eyes

--- a/.github/workflows/daydream-command.yml
+++ b/.github/workflows/daydream-command.yml
@@ -84,4 +84,12 @@ jobs:
           GH_TOKEN: ${{ steps.token.outputs.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
-        run: gh workflow run daydream-review.yml --repo "$REPO" -f pr_number="$PR_NUMBER"
+        run: |
+          HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq .head.sha)"
+          if [ -z "$HEAD_SHA" ]; then
+            echo "Unable to resolve the head SHA for PR #$PR_NUMBER" >&2
+            exit 1
+          fi
+          gh workflow run daydream-review.yml --repo "$REPO" \
+            -f pr_number="$PR_NUMBER" \
+            -f approved_head_sha="$HEAD_SHA"

--- a/.github/workflows/daydream-command.yml
+++ b/.github/workflows/daydream-command.yml
@@ -78,12 +78,17 @@ jobs:
           COMMENT_ID: ${{ github.event.comment.id }}
         run: gh api -X POST "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" -f content=eyes
 
+      # Dispatch binds the PR head (resolved at run time) plus the approving
+      # comment's creation time as the comment-time anchor: the review gate
+      # rejects any approved head whose commit postdates that comment, so a
+      # head pushed after the maintainer's approval is never reviewed.
       - name: Dispatch review workflow
         if: steps.match.outputs.matched == 'true'
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_CREATED_AT: ${{ github.event.comment.created_at }}
         run: |
           HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq .head.sha)"
           if [ -z "$HEAD_SHA" ]; then
@@ -92,4 +97,5 @@ jobs:
           fi
           gh workflow run daydream-review.yml --repo "$REPO" \
             -f pr_number="$PR_NUMBER" \
-            -f approved_head_sha="$HEAD_SHA"
+            -f approved_head_sha="$HEAD_SHA" \
+            -f approved_at="$COMMENT_CREATED_AT"

--- a/.github/workflows/daydream-command.yml
+++ b/.github/workflows/daydream-command.yml
@@ -94,9 +94,11 @@ jobs:
 
       # Acknowledge only after the dispatch's head resolution succeeds: the
       # `gh api` above is fallible, and a transient error must not leave the
-      # maintainer with a 👀 reaction and no review, comment, or explanation —
-      # the failed run surfaces on the PR instead of the reaction mis-signalling
-      # success.
+      # maintainer with a 👀 reaction and no review, comment, or explanation.
+      # Note: a failed dispatch does NOT surface on the PR — no Daydream Review
+      # run is created, so surface-analyze-failure (which fires on the review's
+      # workflow_run event) never triggers and the failure is visible only in
+      # this workflow's Actions tab.
       - name: Acknowledge with eyes reaction
         if: steps.match.outputs.matched == 'true'
         env:

--- a/.github/workflows/daydream-post.yml
+++ b/.github/workflows/daydream-post.yml
@@ -74,8 +74,8 @@ jobs:
           # the artifact, then trust the LIVE PR head from the API;
           # post-findings validates the artifact against it and aborts on
           # mismatch.
-          PR_NUMBER="$(jq -r '.pr_number // empty' findings/findings.json)"
-          HEAD_SHA="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq .head.sha)"
+          PR_NUMBER="$(jq -r '.pr_number // empty' findings/findings.json || true)"
+          HEAD_SHA="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq .head.sha || true)"
           if [ -z "$PR_NUMBER" ] || [ -z "$HEAD_SHA" ]; then
             echo "could not resolve a target PR for this run" >&2
             exit 1
@@ -161,10 +161,6 @@ jobs:
             exit 0
           fi
           FAILURE_MESSAGE="$(jq -r '.message // empty' findings/failure.json 2>/dev/null || true)"
-          if [ -n "$FAILURE_MESSAGE" ]; then
-            gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-              -f body="${FAILURE_MESSAGE} — see run ${RUN_URL}"
-          else
-            gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-              -f body="daydream review failed — see run ${RUN_URL}"
-          fi
+          BODY="${FAILURE_MESSAGE:-daydream review failed} — see run ${RUN_URL}"
+          gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            -f body="${BODY}"

--- a/.github/workflows/daydream-post.yml
+++ b/.github/workflows/daydream-post.yml
@@ -46,7 +46,7 @@ jobs:
         # Pinned to a release tag (not `main`) so the bot runs a known daydream
         # version: reproducible and immune to main-drift / uv-cache staleness.
         # Bump in lockstep with the package version on release (a test enforces this).
-        run: uv tool install git+https://github.com/existential-birds/daydream@v0.26.0
+        run: uv tool install git+https://github.com/existential-birds/daydream@v0.27.0
 
       - name: Mint posting token
         id: token

--- a/.github/workflows/daydream-post.yml
+++ b/.github/workflows/daydream-post.yml
@@ -7,17 +7,13 @@
 # The artifact is passive data, validated by `daydream post-findings` against a strict schema before
 # anything is posted.
 #
-# Target derivation (Task 0 spike, Step 2 — the event payload is NOT uniform):
-#   - pull_request runs: `workflow_run.head_sha` IS the PR head.
-#     `pull_requests[0].number` is populated for same-repo PRs but EMPTY for
-#     fork PRs, where the open-PR list filtered by head SHA resolves it.
-#   - workflow_dispatch runs (the `@<bot> review` path): `pull_requests` is
-#     empty and `head_sha` is the default-branch tip (useless). The PR number
-#     travels in the findings artifact; the LIVE PR fetched from the GitHub
-#     API is the trust anchor — `daydream post-findings` validates the
-#     artifact's declared head_sha against that live value and aborts on
-#     mismatch, so a forged artifact can only point at the real current head
-#     of the PR it names.
+# Target derivation: "Daydream Review" only runs via workflow_dispatch (the
+# `@<bot> review` command), so `pull_requests` is always empty and `head_sha`
+# is the default-branch tip (useless). The PR number travels in the findings
+# artifact; the LIVE PR fetched from the GitHub API is the trust anchor —
+# `daydream post-findings` validates the artifact's declared head_sha against
+# that live value and aborts on mismatch, so a forged artifact can only point
+# at the real current head of the PR it names.
 #
 # Token (footgun 3): minted via actions/create-github-app-token with exactly
 # `pull-requests: write, contents: read, metadata: read`, reaches `gh` via
@@ -73,27 +69,13 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
           REPO: ${{ github.repository }}
-          RUN_EVENT: ${{ github.event.workflow_run.event }}
-          EVENT_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          EVENT_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
         run: |
-          if [ "$RUN_EVENT" = "pull_request" ]; then
-            HEAD_SHA="$EVENT_HEAD_SHA"
-            PR_NUMBER="$EVENT_PR_NUMBER"
-            if [ -z "$PR_NUMBER" ]; then
-              # Fork PRs leave pull_requests empty (spike Shape 2); the
-              # open-PR list filtered by head SHA resolves both PR shapes.
-              PR_NUMBER="$(gh api "repos/${REPO}/pulls?state=open&per_page=100" \
-                --jq ".[] | select(.head.sha == \"${HEAD_SHA}\") | .number" | head -n 1)"
-            fi
-          else
-            # workflow_dispatch (spike Shape 3): the event cannot identify the
-            # PR — read pr_number from the artifact, then trust the LIVE PR
-            # head from the API; post-findings validates the artifact against
-            # it and aborts on mismatch.
-            PR_NUMBER="$(jq -r '.pr_number // empty' findings/findings.json)"
-            HEAD_SHA="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq .head.sha)"
-          fi
+          # The dispatch event cannot identify the PR — read pr_number from
+          # the artifact, then trust the LIVE PR head from the API;
+          # post-findings validates the artifact against it and aborts on
+          # mismatch.
+          PR_NUMBER="$(jq -r '.pr_number // empty' findings/findings.json)"
+          HEAD_SHA="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq .head.sha)"
           if [ -z "$PR_NUMBER" ] || [ -z "$HEAD_SHA" ]; then
             echo "could not resolve a target PR for this run" >&2
             exit 1
@@ -134,7 +116,10 @@ jobs:
   # An analyze failure routes here instead of silently skipping the post job.
   surface-analyze-failure:
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    permissions: {}
+    # GITHUB_TOKEN needs actions: read to download the failure-context artifact
+    # across runs; the App token carries the comment write.
+    permissions:
+      actions: read
     if: github.event.workflow_run.conclusion == 'failure'
     steps:
       - name: Mint posting token
@@ -147,25 +132,39 @@ jobs:
           permission-contents: read
           permission-metadata: read
 
+      # A workflow_dispatch run's PR is not identifiable from the event
+      # (pull_requests is empty, head_sha is the default-branch tip), so the
+      # failed analyze run's failure-context artifact resolves it. GITHUB_TOKEN's
+      # actions: read covers the cross-run download.
+      - name: Download failure context
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: daydream-findings-failure
+          path: findings
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+        # A failed run without the artifact (e.g. the runner died mid-step)
+        # falls through to the exit-0 guard below rather than failing the job.
+        continue-on-error: true
+
       - name: Comment on the PR
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
           REPO: ${{ github.repository }}
-          RUN_EVENT: ${{ github.event.workflow_run.event }}
-          EVENT_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          EVENT_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
         run: |
-          PR_NUMBER="$EVENT_PR_NUMBER"
-          if [ -z "$PR_NUMBER" ] && [ "$RUN_EVENT" = "pull_request" ]; then
-            PR_NUMBER="$(gh api "repos/${REPO}/pulls?state=open&per_page=100" \
-              --jq ".[] | select(.head.sha == \"${EVENT_HEAD_SHA}\") | .number" | head -n 1)"
-          fi
+          PR_NUMBER="$(jq -r '.pr_number // empty' findings/failure.json 2>/dev/null || true)"
           if [ -z "$PR_NUMBER" ]; then
-            # A failed dispatch run leaves no artifact and a default-branch
-            # head_sha, so there is nothing to resolve — log and stop.
+            # A failed dispatch run with no failure-context artifact — log and
+            # stop rather than posting blind.
             echo "no PR resolvable for the failed analyze run; skipping comment" >&2
             exit 0
           fi
-          gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-            -f body="daydream review failed — see run ${RUN_URL}"
+          FAILURE_MESSAGE="$(jq -r '.message // empty' findings/failure.json 2>/dev/null || true)"
+          if [ -n "$FAILURE_MESSAGE" ]; then
+            gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+              -f body="${FAILURE_MESSAGE} — see run ${RUN_URL}"
+          else
+            gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+              -f body="daydream review failed — see run ${RUN_URL}"
+          fi

--- a/.github/workflows/daydream-review.yml
+++ b/.github/workflows/daydream-review.yml
@@ -24,6 +24,10 @@ on:
         description: PR head SHA approved by the maintainer
         required: true
         type: string
+      approved_at:
+        description: ISO-8601 creation time of the approving review comment
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -48,10 +52,29 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.pr_number }}
           APPROVED_HEAD_SHA: ${{ inputs.approved_head_sha }}
+          APPROVED_AT: ${{ inputs.approved_at }}
         run: |
           LIVE_HEAD_SHA="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.sha)"
           if [ "$LIVE_HEAD_SHA" != "$APPROVED_HEAD_SHA" ]; then
             echo "PR #$PR_NUMBER head changed after approval: approved_head_sha=$APPROVED_HEAD_SHA, live=$LIVE_HEAD_SHA. Comment the review command again to approve the new head." >&2
+            # Record the failure context before exiting so the post workflow's
+            # surface-analyze-failure job can comment on the PR — the
+            # workflow_run event cannot identify a workflow_dispatch run's PR.
+            mkdir -p findings
+            printf '{"pr_number": "%s", "message": "The PR head changed after approval. Comment the review command again to approve the new head"}' "$PR_NUMBER" > findings/failure.json
+            exit 1
+          fi
+          # The dispatch resolves the head at run time; the approving comment's
+          # creation time is the comment-time anchor. A head whose commit is
+          # newer than that comment was pushed after approval, so it is not
+          # reviewable without a fresh command.
+          HEAD_COMMIT_DATE="$(gh api "repos/$GITHUB_REPOSITORY/commits/$APPROVED_HEAD_SHA" --jq .commit.committer.date)"
+          if [ -z "$HEAD_COMMIT_DATE" ]; then
+            echo "Could not resolve the commit date for approved head $APPROVED_HEAD_SHA" >&2
+            exit 1
+          fi
+          if [ "$HEAD_COMMIT_DATE" \> "$APPROVED_AT" ]; then
+            echo "PR #$PR_NUMBER approved head commit ($HEAD_COMMIT_DATE) is newer than the approving comment ($APPROVED_AT). Comment the review command again to approve the new head." >&2
             exit 1
           fi
 
@@ -109,6 +132,27 @@ jobs:
       - name: Clean up Codex auth
         if: always()
         run: rm -f "${CODEX_HOME:-$HOME/.codex}/auth.json"
+
+      # Any analyze failure (drift or otherwise) leaves the PR number where the
+      # post workflow can resolve it: the workflow_run event cannot identify a
+      # workflow_dispatch run's PR, so surface-analyze-failure reads it from
+      # this artifact instead of silently skipping the comment.
+      - name: Record failure context
+        if: failure()
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          mkdir -p findings
+          if [ ! -f findings/failure.json ]; then
+            printf '{"pr_number": "%s"}' "$PR_NUMBER" > findings/failure.json
+          fi
+
+      - name: Upload failure context
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: daydream-findings-failure
+          path: findings/failure.json
 
       - name: Upload findings artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/daydream-review.yml
+++ b/.github/workflows/daydream-review.yml
@@ -92,7 +92,7 @@ jobs:
         # Pinned to a release tag (not `main`) so the bot runs a known daydream
         # version: reproducible and immune to main-drift / uv-cache staleness.
         # Bump in lockstep with the package version on release (a test enforces this).
-        run: uv tool install git+https://github.com/existential-birds/daydream@v0.26.0
+        run: uv tool install git+https://github.com/existential-birds/daydream@v0.27.0
 
       # Codex backend: daydream spawns `codex exec` as a subprocess, so the CLI
       # must be on PATH. Pinned because the backend parses `codex exec

--- a/.github/workflows/daydream-review.yml
+++ b/.github/workflows/daydream-review.yml
@@ -7,22 +7,21 @@
 # separate privileged `daydream-post.yml` (workflow_run), per the locked
 # privilege split: no single job ever holds both PR code and the App key.
 #
-# Triggers:
-#   - pull_request (opened, ready_for_review): auto-review for same-repo PRs,
-#     unless the operator sets the repo variable DAYDREAM_AUTO_REVIEW=false.
-#   - workflow_dispatch (pr_number): on-demand review, dispatched by
-#     daydream-command.yml on `@<bot> review`. Dispatch runs sit on the
-#     default branch, so the PR head ref is fetched explicitly.
+# Triggered on demand by daydream-command.yml after a trusted maintainer
+# comments `@<bot> review`. The dispatch binds both the PR number and the
+# approved head SHA; this workflow rejects drift before checking out code.
 
 name: Daydream Review
 
 on:
-  pull_request:
-    types: [opened, ready_for_review]
   workflow_dispatch:
     inputs:
       pr_number:
         description: Number of the pull request to review
+        required: true
+        type: string
+      approved_head_sha:
+        description: PR head SHA approved by the maintainer
         required: true
         type: string
 
@@ -32,53 +31,35 @@ permissions:
 jobs:
   analyze:
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.pull_request.head.repo.full_name == github.repository &&
-      vars.DAYDREAM_AUTO_REVIEW != 'false')
+    if: github.event_name == 'workflow_dispatch'
     steps:
-      - name: Check out PR head (pull_request)
-        if: github.event_name == 'pull_request'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-
-      - name: Check out repository (workflow_dispatch)
-        if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          fetch-depth: 0
-
-      # Dispatch runs sit on the default branch and the PR number arrives as
-      # an input, so the PR head must be fetched explicitly (via env, never
-      # inline interpolation).
-      - name: Check out PR head (workflow_dispatch)
-        if: github.event_name == 'workflow_dispatch'
-        env:
-          PR_NUMBER: ${{ inputs.pr_number }}
-        run: |
-          git fetch origin "refs/pull/${PR_NUMBER}/head"
-          git checkout --detach FETCH_HEAD
-
       - name: Resolve PR number and base ref
         id: pr
         env:
           GH_TOKEN: ${{ github.token }}
-          EVENT_NAME: ${{ github.event_name }}
-          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
-          EVENT_BASE_REF: ${{ github.event.pull_request.base.ref }}
-          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+          PR_NUMBER: ${{ inputs.pr_number }}
         run: |
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            PR_NUMBER="$INPUT_PR_NUMBER"
-            BASE_REF="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json baseRefName --jq .baseRefName)"
-          else
-            PR_NUMBER="$EVENT_PR_NUMBER"
-            BASE_REF="$EVENT_BASE_REF"
-          fi
+          BASE_REF="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json baseRefName --jq .baseRefName)"
           echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
           echo "base_ref=${BASE_REF}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify approved PR head
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          APPROVED_HEAD_SHA: ${{ inputs.approved_head_sha }}
+        run: |
+          LIVE_HEAD_SHA="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.sha)"
+          if [ "$LIVE_HEAD_SHA" != "$APPROVED_HEAD_SHA" ]; then
+            echo "PR #$PR_NUMBER head changed after approval: approved_head_sha=$APPROVED_HEAD_SHA, live=$LIVE_HEAD_SHA. Comment the review command again to approve the new head." >&2
+            exit 1
+          fi
+
+      - name: Check out approved PR head
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.approved_head_sha }}
+          fetch-depth: 0
 
       - name: Fetch base ref
         env:
@@ -118,10 +99,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           BASE_REF: ${{ steps.pr.outputs.base_ref }}
+          APPROVED_HEAD_SHA: ${{ inputs.approved_head_sha }}
         run: |
           mkdir -p findings
           daydream --review --backend codex --non-interactive --pr-number "$PR_NUMBER" \
+            --approved-head-sha "$APPROVED_HEAD_SHA" \
             --findings-out findings/findings.json --base "origin/$BASE_REF" .
+
+      - name: Clean up Codex auth
+        if: always()
+        run: rm -f "${CODEX_HOME:-$HOME/.codex}/auth.json"
 
       - name: Upload findings artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/daydream-review.yml
+++ b/.github/workflows/daydream-review.yml
@@ -65,16 +65,28 @@ jobs:
             exit 1
           fi
           # The dispatch resolves the head at run time; the approving comment's
-          # creation time is the comment-time anchor. A head whose commit is
-          # newer than that comment was pushed after approval, so it is not
-          # reviewable without a fresh command.
-          HEAD_COMMIT_DATE="$(gh api "repos/$GITHUB_REPOSITORY/commits/$APPROVED_HEAD_SHA" --jq .commit.committer.date)"
-          if [ -z "$HEAD_COMMIT_DATE" ]; then
-            echo "Could not resolve the commit date for approved head $APPROVED_HEAD_SHA" >&2
+          # creation time is the comment-time anchor. The head repository's
+          # pushed_at is server-set by GitHub when a push is received, so it
+          # cannot be backdated like commit.committer.date; a head pushed after
+          # the comment has pushed_at newer than it and is not reviewable
+          # without a fresh command.
+          HEAD_PUSHED_AT="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.repo.pushed_at)"
+          if [ -z "$HEAD_PUSHED_AT" ]; then
+            echo "Could not resolve the head repository push time for approved head $APPROVED_HEAD_SHA" >&2
+            # Record the failure context before exiting, like the head-change
+            # branch, so the rejection surfaces on the PR with the instructive
+            # message (issue #336).
+            mkdir -p findings
+            printf '{"pr_number": "%s", "message": "Could not verify the approved head push time. Comment the review command again to approve the new head"}' "$PR_NUMBER" > findings/failure.json
             exit 1
           fi
-          if [ "$HEAD_COMMIT_DATE" \> "$APPROVED_AT" ]; then
-            echo "PR #$PR_NUMBER approved head commit ($HEAD_COMMIT_DATE) is newer than the approving comment ($APPROVED_AT). Comment the review command again to approve the new head." >&2
+          if [ "$HEAD_PUSHED_AT" \> "$APPROVED_AT" ]; then
+            echo "PR #$PR_NUMBER head repository was pushed ($HEAD_PUSHED_AT) after the approving comment ($APPROVED_AT). Comment the review command again to approve the new head." >&2
+            # Record the failure context before exiting, like the head-change
+            # branch, so the rejection surfaces on the PR with the instructive
+            # message (issue #336).
+            mkdir -p findings
+            printf '{"pr_number": "%s", "message": "The approved head was pushed after the approving comment. Comment the review command again to approve the new head"}' "$PR_NUMBER" > findings/failure.json
             exit 1
           fi
 

--- a/.github/workflows/daydream-review.yml
+++ b/.github/workflows/daydream-review.yml
@@ -54,40 +54,52 @@ jobs:
           APPROVED_HEAD_SHA: ${{ inputs.approved_head_sha }}
           APPROVED_AT: ${{ inputs.approved_at }}
         run: |
-          LIVE_HEAD_SHA="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.sha)"
-          if [ "$LIVE_HEAD_SHA" != "$APPROVED_HEAD_SHA" ]; then
-            echo "PR #$PR_NUMBER head changed after approval: approved_head_sha=$APPROVED_HEAD_SHA, live=$LIVE_HEAD_SHA. Comment the review command again to approve the new head." >&2
-            # Record the failure context before exiting so the post workflow's
-            # surface-analyze-failure job can comment on the PR — the
-            # workflow_run event cannot identify a workflow_dispatch run's PR.
+          # Every drift rejection funnels through this helper: it records the
+          # failure context (pr_number + the instructive message) before exiting
+          # so the post workflow's surface-analyze-failure job can comment on
+          # the PR — the workflow_run event cannot identify a workflow_dispatch
+          # run's PR (issue #336). The console message carries the details for
+          # the log; the record message is the shorter text posted on the PR.
+          reject() {
+            local console_message="$1"
+            local record_message="$2"
+            echo "$console_message" >&2
             mkdir -p findings
-            printf '{"pr_number": "%s", "message": "The PR head changed after approval. Comment the review command again to approve the new head"}' "$PR_NUMBER" > findings/failure.json
+            printf '{"pr_number": "%s", "message": "%s"}' "$PR_NUMBER" "$record_message" > findings/failure.json
             exit 1
+          }
+          HEAD_INFO="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '{sha: .head.sha, ref: .head.ref, repo: (.head.repo.full_name? // "")}')"
+          LIVE_HEAD_SHA="$(printf '%s' "$HEAD_INFO" | jq -r .sha)"
+          HEAD_REF="$(printf '%s' "$HEAD_INFO" | jq -r .ref)"
+          HEAD_REPO="$(printf '%s' "$HEAD_INFO" | jq -r .repo)"
+          if [ "$LIVE_HEAD_SHA" != "$APPROVED_HEAD_SHA" ]; then
+            reject "PR #$PR_NUMBER head changed after approval: approved_head_sha=$APPROVED_HEAD_SHA, live=$LIVE_HEAD_SHA. Comment the review command again to approve the new head." \
+              "The PR head changed after approval. Comment the review command again to approve the new head"
           fi
           # The dispatch resolves the head at run time; the approving comment's
-          # creation time is the comment-time anchor. The head repository's
-          # pushed_at is server-set by GitHub when a push is received, so it
-          # cannot be backdated like commit.committer.date; a head pushed after
-          # the comment has pushed_at newer than it and is not reviewable
-          # without a fresh command.
-          HEAD_PUSHED_AT="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.repo.pushed_at)"
-          if [ -z "$HEAD_PUSHED_AT" ]; then
-            echo "Could not resolve the head repository push time for approved head $APPROVED_HEAD_SHA" >&2
-            # Record the failure context before exiting, like the head-change
-            # branch, so the rejection surfaces on the PR with the instructive
-            # message (issue #336).
-            mkdir -p findings
-            printf '{"pr_number": "%s", "message": "Could not verify the approved head push time. Comment the review command again to approve the new head"}' "$PR_NUMBER" > findings/failure.json
-            exit 1
-          fi
-          if [ "$HEAD_PUSHED_AT" \> "$APPROVED_AT" ]; then
-            echo "PR #$PR_NUMBER head repository was pushed ($HEAD_PUSHED_AT) after the approving comment ($APPROVED_AT). Comment the review command again to approve the new head." >&2
-            # Record the failure context before exiting, like the head-change
-            # branch, so the rejection surfaces on the PR with the instructive
-            # message (issue #336).
-            mkdir -p findings
-            printf '{"pr_number": "%s", "message": "The approved head was pushed after the approving comment. Comment the review command again to approve the new head"}' "$PR_NUMBER" > findings/failure.json
-            exit 1
+          # creation time is the comment-time anchor. The approved commit's push
+          # time is the head repository's activity scoped to the PR's head ref —
+          # server-set by GitHub when a push is received, so it cannot be
+          # backdated like commit.committer.date, and scoped to this PR rather
+          # than the repo-wide pushed_at that every push to the repo bumps. The
+          # timestamps are second-granularity, so a push in the same wall-clock
+          # second as the comment is indistinguishable from one that landed
+          # before it: reject when the push is NOT strictly before the comment
+          # (equality fails closed), not only when it is strictly after. A
+          # deleted head repository cannot receive pushes — the approved head is
+          # frozen and the bound SHA cannot change — so there is no window to
+          # close and no push time to resolve.
+          if [ -n "$HEAD_REPO" ]; then
+            HEAD_PUSHED_AT="$(gh api "repos/$HEAD_REPO/activity?ref=refs/heads/$HEAD_REF&per_page=100" \
+              --jq '[.[] | select(.activity_type == "push" or .activity_type == "branch_creation" or .activity_type == "force_push") | .timestamp][0] // empty')"
+            if [ -z "$HEAD_PUSHED_AT" ]; then
+              reject "Could not resolve the push time for approved head $APPROVED_HEAD_SHA" \
+                "Could not verify the approved head push time. Comment the review command again to approve the new head"
+            fi
+            if ! [ "$HEAD_PUSHED_AT" \< "$APPROVED_AT" ]; then
+              reject "PR #$PR_NUMBER head was pushed ($HEAD_PUSHED_AT) at or after the approving comment ($APPROVED_AT). Comment the review command again to approve the new head." \
+                "The approved head was pushed after the approving comment. Comment the review command again to approve the new head"
+            fi
           fi
 
       - name: Check out approved PR head

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **security:** Close the residual approval TOCTOU in the `@<bot> review` command path — the dispatch now also binds the approving comment's creation time, and the review gate rejects any approved head whose commit postdates that comment.
 - **security:** Restrict archive upload destinations to the operator-controlled `--trajectory-hub-repo` / `DAYDREAM_TRAJECTORY_HUB_REPO` sources; a `trajectory_hub_repo` key in the target checkout's file config is now ignored.
 - **rl:** Verify untracked-oracle caveat for protected test-oracle paths (issue #571) — confirmed the fail-closed docstring and README manifest caveat are present and accurate at HEAD (b824946), landed by commit df1fd3f (#558); no code or behavior change.
-- **bot:** Surface head-drift rejections on the PR (issue #336) — a failed `workflow_dispatch` analyze run uploads a failure-context artifact that `surface-analyze-failure` resolves, so the instructive "comment the review command again" message reaches the PR instead of staying in the Actions log.
 
 ## [0.27.0] - 2026-08-15
 
 ### Security
 
 - **reviews:** Bind credential-bearing PR reviews to a maintainer-approved head SHA and reject head drift before model access.
+
+### Fixed
+
+- **security:** Close the residual approval TOCTOU in the `@<bot> review` command path — the dispatch now also binds the approving comment's creation time, and the review gate rejects any approved head whose commit postdates that comment.
+- **bot:** Surface head-drift rejections on the PR (issue #336) — a failed `workflow_dispatch` analyze run uploads a failure-context artifact that `surface-analyze-failure` resolves, so the instructive "comment the review command again" message reaches the PR instead of staying in the Actions log.
 
 ## [0.26.0] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **security:** Restrict archive upload destinations to the operator-controlled `--trajectory-hub-repo` / `DAYDREAM_TRAJECTORY_HUB_REPO` sources; a `trajectory_hub_repo` key in the target checkout's file config is now ignored.
 - **rl:** Verify untracked-oracle caveat for protected test-oracle paths (issue #571) — confirmed the fail-closed docstring and README manifest caveat are present and accurate at HEAD (b824946), landed by commit df1fd3f (#558); no code or behavior change.
 
+## [0.27.0]
+
+### Security
+
+- **reviews:** Bind credential-bearing PR reviews to a maintainer-approved head SHA and reject head drift before model access.
+
 ## [0.26.0] - 2026-08-12
 
 ### Added
@@ -1024,7 +1030,8 @@ Initial release of Daydream - an automated code review and fix loop using the Cl
 - `rich` - Terminal UI components
 - `pyfiglet` - ASCII art header generation
 
-[unreleased]: https://github.com/existential-birds/daydream/compare/v0.26.0...HEAD
+[unreleased]: https://github.com/existential-birds/daydream/compare/v0.27.0...HEAD
+[0.27.0]: https://github.com/existential-birds/daydream/compare/v0.26.0...v0.27.0
 [0.26.0]: https://github.com/existential-birds/daydream/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/existential-birds/daydream/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/existential-birds/daydream/compare/v0.23.1...v0.24.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **security:** Restrict archive upload destinations to the operator-controlled `--trajectory-hub-repo` / `DAYDREAM_TRAJECTORY_HUB_REPO` sources; a `trajectory_hub_repo` key in the target checkout's file config is now ignored.
-- **rl:** Verify untracked-oracle caveat for protected test-oracle paths (issue #571) — confirmed the fail-closed docstring and README manifest caveat are present and accurate at HEAD (b824946), landed by commit df1fd3f (#558); no code or behavior change.
-
 ## [0.27.0] - 2026-08-15
 
 ### Security
@@ -20,8 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **security:** Close the residual approval TOCTOU in the `@<bot> review` command path — the dispatch now also binds the approving comment's creation time, and the review gate rejects any approved head whose commit postdates that comment.
+- **security:** Close the residual approval TOCTOU in the `@<bot> review` command path — the dispatch now also binds the approving comment's creation time, and the review gate rejects when the head repo's server-set `pushed_at` (a repo-wide timestamp, never the PR head commit's date) postdates that comment.
 - **bot:** Surface head-drift rejections on the PR (issue #336) — a failed `workflow_dispatch` analyze run uploads a failure-context artifact that `surface-analyze-failure` resolves, so the instructive "comment the review command again" message reaches the PR instead of staying in the Actions log.
+- **security:** Restrict archive upload destinations to the operator-controlled `--trajectory-hub-repo` / `DAYDREAM_TRAJECTORY_HUB_REPO` sources; a `trajectory_hub_repo` key in the target checkout's file config is now ignored.
+- **rl:** Verify untracked-oracle caveat for protected test-oracle paths (issue #571) — confirmed the fail-closed docstring and README manifest caveat are present and accurate at HEAD (b824946), landed by commit df1fd3f (#558); no code or behavior change.
 
 ## [0.26.0] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **security:** Close the residual approval TOCTOU in the `@<bot> review` command path — the dispatch now also binds the approving comment's creation time, and the review gate rejects any approved head whose commit postdates that comment.
 - **security:** Restrict archive upload destinations to the operator-controlled `--trajectory-hub-repo` / `DAYDREAM_TRAJECTORY_HUB_REPO` sources; a `trajectory_hub_repo` key in the target checkout's file config is now ignored.
 - **rl:** Verify untracked-oracle caveat for protected test-oracle paths (issue #571) — confirmed the fail-closed docstring and README manifest caveat are present and accurate at HEAD (b824946), landed by commit df1fd3f (#558); no code or behavior change.
+- **bot:** Surface head-drift rejections on the PR (issue #336) — a failed `workflow_dispatch` analyze run uploads a failure-context artifact that `surface-analyze-failure` resolves, so the instructive "comment the review command again" message reaches the PR instead of staying in the Actions log.
 
-## [0.27.0]
+## [0.27.0] - 2026-08-15
 
 ### Security
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,7 +215,7 @@ Full contract: `docs/extensions.md`.
 | Variable | Scope | Purpose |
 |----------|-------|---------|
 | `DAYDREAM_APP_ID` / `DAYDREAM_APP_PRIVATE_KEY` | GitHub App | Bot identity (PEM **content**, not a path) |
-| `DAYDREAM_BOT_HANDLE` / `DAYDREAM_AUTO_REVIEW` | Actions | Mention handle (no `@`); `false` disables auto-review |
+| `DAYDREAM_BOT_HANDLE` | Actions | Mention handle (no `@`) used by the `@<bot> review` command |
 | `DAYDREAM_EXT_DIR` | Extensions | Path to `daydream_ext` (overrides `import daydream_ext`) |
 | `DAYDREAM_GH_TIMEOUT_SECONDS` / `_RETRIES` | Git ops | `gh` CLI timeout and retry count |
 | `DAYDREAM_TRAJECTORY_HUB_REPO` | Archive | Optional HuggingFace dataset repo to upload each run's bundle to; one of the two operator sources (the other is the CLI `--trajectory-hub-repo` flag). The target checkout's file config is ignored for this |

--- a/daydream/__init__.py
+++ b/daydream/__init__.py
@@ -17,4 +17,4 @@ Submodules:
     ui: User interface utilities for terminal output.
 """
 
-__version__ = "0.26.0"
+__version__ = "0.27.0"

--- a/daydream/bot_setup.py
+++ b/daydream/bot_setup.py
@@ -46,11 +46,10 @@ from daydream.ui import print_error, print_info, print_success, print_warning
 _ANTHROPIC_KEY_ENV = "ANTHROPIC_API_KEY"
 _SETUP_BRANCH = "daydream/setup-bot"
 
-# Events the #147 workflow templates consume (daydream-review.yml →
-# pull_request, daydream-command.yml → issue_comment, daydream-post.yml →
-# workflow_run). Declared in the manifest so the App is subscribed to exactly
-# what the shipped workflows listen for.
-_MANIFEST_EVENTS = ("pull_request", "issue_comment", "workflow_run")
+# Events consumed by the approval-gated workflows: trusted review commands and
+# completed review runs. Credential-bearing review workflows are not subscribed
+# to pull_request events.
+_MANIFEST_EVENTS = ("issue_comment", "workflow_run")
 
 _APP_NAME_DEFAULT = "Daydream Review Bot"
 _GITHUB_NEW_APP_URL = "https://github.com/settings/apps/new"
@@ -339,7 +338,8 @@ _PR_BODY = (
     "GitHub App identity. Review the setup guide before merging:\n\n"
     "- Setup guide: `docs/self-hosted-bot-setup.md`\n"
     "- Security model: see the *Security model* section of that guide.\n\n"
-    "Merging this PR makes the bot live on this repository."
+    "After merging, a trusted maintainer can request a head-bound review by "
+    "commenting `@<bot> review` on a pull request."
 )
 
 
@@ -582,7 +582,7 @@ def _check_permissions(repo_dir: Path, creds: AppCredentials | None) -> Check:
 
 
 def _check_workflows(repo_dir: Path) -> Check:
-    """Check (4): the three workflow files exist on the default branch."""
+    """Check (4): installed workflows byte-match the packaged templates."""
     try:
         base = git_ops.default_branch(repo_dir)
     except git_ops.BranchNotFoundError as exc:
@@ -593,21 +593,32 @@ def _check_workflows(repo_dir: Path) -> Check:
         )
 
     missing: list[str] = []
+    outdated: list[str] = []
     for template in workflow_template_files():
         path = f"{_WORKFLOWS_DIR}/{template.name}"
         try:
-            git_ops.show(repo_dir, f"origin/{base}", path)
+            installed = git_ops.show(repo_dir, f"origin/{base}", path)
         except GitError:
             missing.append(path)
-    if not missing:
-        return Check(name="workflows", passed=True, detail=f"All workflow files present on '{base}'.")
+            continue
+        if installed != template.read_bytes():
+            outdated.append(path)
+
+    if not missing and not outdated:
+        return Check(name="workflows", passed=True, detail=f"All workflow files match on '{base}'.")
+
+    problems: list[str] = []
+    if missing:
+        problems.append("Missing workflow file(s): " + ", ".join(missing))
+    if outdated:
+        problems.append("Out of date workflow file(s): " + ", ".join(outdated))
     return Check(
         name="workflows",
         passed=False,
         detail=(
-            f"Missing workflow file(s) on '{base}': "
-            + ", ".join(missing)
-            + " — run `daydream setup` (or merge the setup PR) to land them."
+            f"Workflow check failed on '{base}': "
+            + "; ".join(problems)
+            + " — run `daydream setup` (or merge the setup PR) to install the packaged versions."
         ),
     )
 
@@ -631,8 +642,8 @@ def run_verify(repo_dir: Path, *, scope: Scope) -> VerifyResult:
        and the :data:`config.BOT_HANDLE_VAR` variable exist at the scope.
     3. **Permissions** — the App grants a superset of
        :data:`config.APP_PERMISSIONS` (skipped, non-required, without creds).
-    4. **Workflows** — the three packaged workflow files exist on the default
-       branch.
+    4. **Workflows** — the installed workflow files byte-match the packaged
+       templates on the default branch.
 
     This is strictly read-only: it never sets a secret, variable, or file. Each
     failed required check's ``detail`` names the exact missing element and the
@@ -862,5 +873,8 @@ def run_setup(
         print_info(console, "Workflow files already present on this repository; nothing to land.")
     else:
         print_success(console, f"Opened workflow PR: {pr_url}")
-        print_info(console, "Merge the PR to go live — the bot reviews PRs once it lands on the default branch.")
+        print_info(
+            console,
+            "Merge the PR, then request reviews with a trusted `@<bot> review` comment.",
+        )
     return 0

--- a/daydream/bot_setup.py
+++ b/daydream/bot_setup.py
@@ -27,6 +27,8 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
+import yaml
+
 from daydream import config, git_ops
 from daydream.agent import console
 from daydream.git_ops import GitError
@@ -609,12 +611,52 @@ def _workflow_contract_intact(name: str, content: str) -> bool:
     as a Codex deployment) is reported as a warning: customization is
     intentionally unsupported, and ``daydream setup`` replaces customized
     files with the packaged templates.
+
+    The checks are structural (parsed YAML), mirroring the gate assertions in
+    ``tests/test_workflow_templates.py``: whole-file substring matching would
+    hard-fail a gate-intact workflow that merely mentions ``pull_request`` in
+    prose and could disagree with the test harness. Content that does not parse
+    to a workflow mapping is not gate-intact. A template with no explicit
+    contract below (a future non-review/command file) is treated as broken
+    rather than silently judged by a guess.
     """
+    try:
+        wf = yaml.safe_load(content)
+    except yaml.YAMLError:
+        return False
+    if not isinstance(wf, dict):
+        return False
+    # PyYAML parses the bare ``on:`` key as boolean ``True``; normalize the
+    # trigger map the same way the test harness's ``_wf_triggers`` does.
+    on = wf.get("on")
+    if on is None:
+        on = wf.get(True)
+    triggers = on if isinstance(on, dict) else {}
+
     if name == "daydream-review.yml":
-        return "approved_head_sha" in content and "pull_request" not in content
+        if "pull_request" in triggers:
+            return False
+        dispatch = triggers.get("workflow_dispatch")
+        inputs = dispatch.get("inputs") if isinstance(dispatch, dict) else None
+        return isinstance(inputs, dict) and "approved_head_sha" in inputs
     if name == "daydream-command.yml":
-        return "approved_head_sha" in content
-    return "workflow_run" in content
+        # The single approval point: every review dispatch must bind the
+        # approved head (the test harness asserts the same on the dispatch
+        # step's run).
+        dispatch_steps = [
+            step
+            for job in wf.get("jobs", {}).values()
+            if isinstance(job, dict)
+            for step in job.get("steps", [])
+            if isinstance(step, dict)
+            and "gh workflow run daydream-review.yml" in step.get("run", "")
+        ]
+        return bool(dispatch_steps) and all(
+            "approved_head_sha" in step.get("run", "") for step in dispatch_steps
+        )
+    if name == "daydream-post.yml":
+        return "workflow_run" in triggers
+    return False
 
 
 def _check_workflows(repo_dir: Path) -> Check:

--- a/daydream/bot_setup.py
+++ b/daydream/bot_setup.py
@@ -25,9 +25,8 @@ import webbrowser
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
+from typing import Any, cast
 from urllib.parse import parse_qs, urlparse
-
-import yaml
 
 from daydream import config, git_ops
 from daydream.agent import console
@@ -621,6 +620,10 @@ def _workflow_contract_intact(name: str, content: str) -> bool:
     rather than silently judged by a guess.
     """
     try:
+        import yaml  # lazy: pyyaml is a dev-only dependency (see pyproject.toml)
+    except ImportError:
+        return False
+    try:
         wf = yaml.safe_load(content)
     except yaml.YAMLError:
         return False
@@ -628,9 +631,9 @@ def _workflow_contract_intact(name: str, content: str) -> bool:
         return False
     # PyYAML parses the bare ``on:`` key as boolean ``True``; normalize the
     # trigger map the same way the test harness's ``_wf_triggers`` does.
-    on = wf.get("on")
+    on: Any = wf.get("on")
     if on is None:
-        on = wf.get(True)
+        on = cast(dict[Any, Any], wf).get(True)
     triggers = on if isinstance(on, dict) else {}
 
     if name == "daydream-review.yml":
@@ -640,9 +643,12 @@ def _workflow_contract_intact(name: str, content: str) -> bool:
         inputs = dispatch.get("inputs") if isinstance(dispatch, dict) else None
         return isinstance(inputs, dict) and "approved_head_sha" in inputs
     if name == "daydream-command.yml":
-        # The single approval point: every review dispatch must bind the
-        # approved head (the test harness asserts the same on the dispatch
-        # step's run).
+        # The single approval point: every review dispatch must bind the live
+        # PR head to the approved_head_sha input. Require the binding itself —
+        # the input set to the gh-api-resolved $HEAD_SHA variable (the test
+        # harness asserts the same) — so a drift that keeps the literal token
+        # in a hardcoded value, echo, or comment fails instead of passing as
+        # gate-intact.
         dispatch_steps = [
             step
             for job in wf.get("jobs", {}).values()
@@ -652,7 +658,10 @@ def _workflow_contract_intact(name: str, content: str) -> bool:
             and "gh workflow run daydream-review.yml" in step.get("run", "")
         ]
         return bool(dispatch_steps) and all(
-            "approved_head_sha" in step.get("run", "") for step in dispatch_steps
+            '-f approved_head_sha="$HEAD_SHA"' in step.get("run", "")
+            and "gh api" in step.get("run", "")
+            and ".head.sha" in step.get("run", "")
+            for step in dispatch_steps
         )
     if name == "daydream-post.yml":
         return "workflow_run" in triggers

--- a/daydream/bot_setup.py
+++ b/daydream/bot_setup.py
@@ -353,8 +353,10 @@ def land_workflows(repo_dir: Path, *, branch: str) -> str:
     branch — the workflows always land via a reviewable PR.
 
     Idempotent: a template whose target file already exists with identical
-    content is skipped. When all three already match, no branch or PR is
-    created and the :data:`WORKFLOWS_ALREADY_INSTALLED` sentinel is returned
+    content is skipped. A target file that exists with divergent content (a
+    customized workflow) is replaced with a warning that workflow customization
+    is intentionally unsupported. When all three already match, no branch or PR
+    is created and the :data:`WORKFLOWS_ALREADY_INSTALLED` sentinel is returned
     (distinguishable from a PR URL).
 
     Args:
@@ -378,6 +380,12 @@ def land_workflows(repo_dir: Path, *, branch: str) -> str:
         content = template.read_text()
         if target.exists() and target.read_text() == content:
             continue
+        if target.exists():
+            print_warning(
+                console,
+                f"{_WORKFLOWS_DIR}/{template.name} is a customized workflow — customization is "
+                "intentionally unsupported and it will be replaced by the packaged template.",
+            )
         target.write_text(content)
         copied.append(Path(_WORKFLOWS_DIR) / template.name)
 
@@ -581,8 +589,45 @@ def _check_permissions(repo_dir: Path, creds: AppCredentials | None) -> Check:
     )
 
 
+def _workflow_contract_intact(name: str, content: str) -> bool:
+    """True when *content* still satisfies the approval-gate security contract.
+
+    The gate era binds every credential-bearing review to an approved head, so
+    an installed workflow that drifts from the packaged template is acceptable
+    only while it keeps the contract:
+
+    - ``daydream-review.yml`` must require the ``approved_head_sha`` dispatch
+      input and must not auto-trigger on ``pull_request`` (a pre-gate workflow
+      triggers on PR open, re-opening the unapproved-review hole).
+    - ``daydream-command.yml`` must pass ``approved_head_sha`` — it is the
+      single approval point.
+    - ``daydream-post.yml`` must run off the review's ``workflow_run``
+      completion.
+
+    A drift that breaks the contract is a stale workflow and a hard doctor
+    failure; a drift that keeps it (e.g. a backend-variant customization such
+    as a Codex deployment) is reported as a warning: customization is
+    intentionally unsupported, and ``daydream setup`` replaces customized
+    files with the packaged templates.
+    """
+    if name == "daydream-review.yml":
+        return "approved_head_sha" in content and "pull_request" not in content
+    if name == "daydream-command.yml":
+        return "approved_head_sha" in content
+    return "workflow_run" in content
+
+
 def _check_workflows(repo_dir: Path) -> Check:
-    """Check (4): installed workflows byte-match the packaged templates."""
+    """Check (4): installed workflows carry the approval gate on the default branch.
+
+    Byte-compares installed workflows against the packaged templates, but a
+    byte drift is only a hard failure when it breaks the gate contract (see
+    :func:`_workflow_contract_intact`) — e.g. a stale pre-gate workflow that
+    auto-triggers on ``pull_request`` would re-open the unapproved-review hole.
+    A contract-intact drift (a customized variant, such as a different model
+    backend) passes with a warning that customization is intentionally
+    unsupported; missing files always fail.
+    """
     try:
         base = git_ops.default_branch(repo_dir)
     except git_ops.BranchNotFoundError as exc:
@@ -594,6 +639,7 @@ def _check_workflows(repo_dir: Path) -> Check:
 
     missing: list[str] = []
     outdated: list[str] = []
+    customized: list[str] = []
     for template in workflow_template_files():
         path = f"{_WORKFLOWS_DIR}/{template.name}"
         try:
@@ -601,10 +647,25 @@ def _check_workflows(repo_dir: Path) -> Check:
         except GitError:
             missing.append(path)
             continue
-        if installed != template.read_bytes():
+        if installed == template.read_bytes():
+            continue
+        if _workflow_contract_intact(template.name, installed.decode("utf-8", errors="replace")):
+            customized.append(path)
+        else:
             outdated.append(path)
 
     if not missing and not outdated:
+        if customized:
+            return Check(
+                name="workflows",
+                passed=True,
+                detail=(
+                    f"Workflow file(s) on '{base}' are customized variants: "
+                    + ", ".join(customized)
+                    + ". Customization is intentionally unsupported — `daydream setup` "
+                    "replaces them with the packaged templates."
+                ),
+            )
         return Check(name="workflows", passed=True, detail=f"All workflow files match on '{base}'.")
 
     problems: list[str] = []
@@ -642,8 +703,10 @@ def run_verify(repo_dir: Path, *, scope: Scope) -> VerifyResult:
        and the :data:`config.BOT_HANDLE_VAR` variable exist at the scope.
     3. **Permissions** — the App grants a superset of
        :data:`config.APP_PERMISSIONS` (skipped, non-required, without creds).
-    4. **Workflows** — the installed workflow files byte-match the packaged
-       templates on the default branch.
+    4. **Workflows** — the installed workflow files carry the approval gate on
+       the default branch: they byte-match the packaged templates, or diverge
+       only as contract-intact customizations (warned, not failed). Stale
+       gate-less workflows and missing files fail.
 
     This is strictly read-only: it never sets a secret, variable, or file. Each
     failed required check's ``detail`` names the exact missing element and the

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -832,6 +832,13 @@ def _build_main_parser(*, full_help: bool = False) -> argparse.ArgumentParser:
              "artifact target; default: auto-detect from the current branch)."
         if full_help else argparse.SUPPRESS,
     )
+    parser.add_argument(
+        "--approved-head-sha",
+        default=None,
+        dest="approved_head_sha",
+        help="Pin the maintainer-approved PR head SHA."
+        if full_help else argparse.SUPPRESS,
+    )
 
     # Skill selection (overrides auto-detect)
     parser.add_argument(
@@ -1022,6 +1029,7 @@ def _parse_args(argv: list[str] | None = None) -> RunConfig:
         quiet=True,
         start_at=args.start_at,
         pr_number=pr_number,
+        approved_head_sha=args.approved_head_sha,
         bot=None,
         backend=args.backend,
         review_backend=None,

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -802,8 +802,21 @@ async def _dispatch_selected_flow(work: WorkContext, config: RunConfig) -> int:
     return await _run_custom_flow(work, config)
 
 
+def _verify_approved_head(work: WorkContext, config: RunConfig) -> int:
+    """Reject a checkout that has drifted from a maintainer-approved PR head."""
+    approved = config.approved_head_sha
+    if approved is None or work.head_sha == approved:
+        return 0
+    print_error(
+        console,
+        "Head Mismatch",
+        f"Approved PR head is {approved}, but the checked-out head is {work.head_sha}. Re-approve the current head.",
+    )
+    return 1
+
+
 async def _dispatch(work: WorkContext, config: RunConfig) -> int:
-    """Route the resolved workspace + config to the single deep flow.
+    """Verify the approved head, then route to the resolved flow.
 
     Every PR-process mode routes to :func:`_run_loop_deep` (which delegates to
     :func:`daydream.deep.orchestrator.run_deep`): feedback mode (``bot`` set by
@@ -820,6 +833,10 @@ async def _dispatch(work: WorkContext, config: RunConfig) -> int:
         config: Run configuration (``config.identity`` carries the resolved
             GitHub identity set by :func:`run`).
     """
+    head_status = _verify_approved_head(work, config)
+    if head_status != 0:
+        return head_status
+
     if config.bot is not None:
         return await _run_loop_deep(work, config)
 

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -223,6 +223,7 @@ class RunConfig:
     quiet: bool = True
     start_at: str = "review"
     pr_number: int | None = None
+    approved_head_sha: str | None = None
     bot: str | None = None
     backend: str | None = None
     model: str | None = None

--- a/daydream/templates/workflows/README.md
+++ b/daydream/templates/workflows/README.md
@@ -36,7 +36,7 @@ download). The sections below document what these workflows *do* once installed.
 
 | Trigger | Path | Notes |
 |---|---|---|
-| `@<bot> review` PR comment | Command → Review → Post | Comment author must be OWNER / MEMBER / COLLABORATOR; bot comments are ignored; the current PR head is bound as the approved target |
+| `@<bot> review` PR comment | Command → Review → Post | Comment author must be OWNER / MEMBER / COLLABORATOR; bot comments are ignored; the PR head current at comment time is bound as the approved target |
 | New commit after approval | Review rejects head drift | Comment `@<bot> review` again to approve the new head |
 | Fork PRs | Same trusted-comment path | The review remains approval-gated and checks out only the approved head |
 

--- a/daydream/templates/workflows/README.md
+++ b/daydream/templates/workflows/README.md
@@ -1,9 +1,9 @@
 # Daydream review bot — workflow templates
 
 Three GitHub Actions workflows that turn daydream into a self-hosted PR review
-bot: a PR gets reviewed automatically on open (or on demand via
-`@<bot> review`) and the findings are posted as inline comments by your own
-GitHub App identity — no maintainer server, no third-party service.
+bot: a trusted maintainer requests a review with `@<bot> review`, and the
+findings are posted as inline comments by your own GitHub App identity — no
+maintainer server, no third-party service.
 
 | File | Workflow | Role |
 |---|---|---|
@@ -36,14 +36,17 @@ download). The sections below document what these workflows *do* once installed.
 
 | Trigger | Path | Notes |
 |---|---|---|
-| PR `opened` / `ready_for_review` | auto: Review → Post | Same-repo PRs only; disabled when `DAYDREAM_AUTO_REVIEW` is `false` |
-| `@<bot> review` PR comment | on demand: Command → Review → Post | Comment author must be OWNER / MEMBER / COLLABORATOR; bot comments are ignored |
-| Fork PRs | `@<bot> review` only by default | Auto-review is gated to same-repo PRs (fork runs get no secrets, so the reviewer cannot run) |
+| `@<bot> review` PR comment | Command → Review → Post | Comment author must be OWNER / MEMBER / COLLABORATOR; bot comments are ignored; the current PR head is bound as the approved target |
+| New commit after approval | Review rejects head drift | Comment `@<bot> review` again to approve the new head |
+| Fork PRs | Same trusted-comment path | The review remains approval-gated and checks out only the approved head |
 
-**Private-repo limitation:** on private repositories GitHub runs **no
-workflows at all** for fork PRs (the "run workflows from fork pull requests"
-policy is off by default), so fork PRs there get no auto-review of any kind —
-only the `@<bot> review` command path can serve them.
+There is no automatic PR-open trigger. A credential-bearing review runs only
+after a trusted comment explicitly approves the current head.
+
+**Private-repo limitation:** on private repositories GitHub may run no
+workflows for fork PRs when the "run workflows from fork pull requests" policy
+is disabled. Enable the applicable repository policy before using the trusted
+`@<bot> review` path for those forks.
 
 ## Security model — the privilege split
 

--- a/daydream/templates/workflows/daydream-command.yml
+++ b/daydream/templates/workflows/daydream-command.yml
@@ -70,14 +70,6 @@ jobs:
           permission-actions: write
           permission-pull-requests: write
 
-      - name: Acknowledge with eyes reaction
-        if: steps.match.outputs.matched == 'true'
-        env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
-          REPO: ${{ github.repository }}
-          COMMENT_ID: ${{ github.event.comment.id }}
-        run: gh api -X POST "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" -f content=eyes
-
       # Dispatch binds the PR head (resolved at run time) plus the approving
       # comment's creation time as the comment-time anchor: the review gate
       # rejects any approved head whose commit postdates that comment, so a
@@ -99,3 +91,16 @@ jobs:
             -f pr_number="$PR_NUMBER" \
             -f approved_head_sha="$HEAD_SHA" \
             -f approved_at="$COMMENT_CREATED_AT"
+
+      # Acknowledge only after the dispatch's head resolution succeeds: the
+      # `gh api` above is fallible, and a transient error must not leave the
+      # maintainer with a 👀 reaction and no review, comment, or explanation —
+      # the failed run surfaces on the PR instead of the reaction mis-signalling
+      # success.
+      - name: Acknowledge with eyes reaction
+        if: steps.match.outputs.matched == 'true'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: gh api -X POST "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" -f content=eyes

--- a/daydream/templates/workflows/daydream-command.yml
+++ b/daydream/templates/workflows/daydream-command.yml
@@ -84,4 +84,12 @@ jobs:
           GH_TOKEN: ${{ steps.token.outputs.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
-        run: gh workflow run daydream-review.yml --repo "$REPO" -f pr_number="$PR_NUMBER"
+        run: |
+          HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq .head.sha)"
+          if [ -z "$HEAD_SHA" ]; then
+            echo "Unable to resolve the head SHA for PR #$PR_NUMBER" >&2
+            exit 1
+          fi
+          gh workflow run daydream-review.yml --repo "$REPO" \
+            -f pr_number="$PR_NUMBER" \
+            -f approved_head_sha="$HEAD_SHA"

--- a/daydream/templates/workflows/daydream-command.yml
+++ b/daydream/templates/workflows/daydream-command.yml
@@ -78,12 +78,17 @@ jobs:
           COMMENT_ID: ${{ github.event.comment.id }}
         run: gh api -X POST "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" -f content=eyes
 
+      # Dispatch binds the PR head (resolved at run time) plus the approving
+      # comment's creation time as the comment-time anchor: the review gate
+      # rejects any approved head whose commit postdates that comment, so a
+      # head pushed after the maintainer's approval is never reviewed.
       - name: Dispatch review workflow
         if: steps.match.outputs.matched == 'true'
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_CREATED_AT: ${{ github.event.comment.created_at }}
         run: |
           HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq .head.sha)"
           if [ -z "$HEAD_SHA" ]; then
@@ -92,4 +97,5 @@ jobs:
           fi
           gh workflow run daydream-review.yml --repo "$REPO" \
             -f pr_number="$PR_NUMBER" \
-            -f approved_head_sha="$HEAD_SHA"
+            -f approved_head_sha="$HEAD_SHA" \
+            -f approved_at="$COMMENT_CREATED_AT"

--- a/daydream/templates/workflows/daydream-command.yml
+++ b/daydream/templates/workflows/daydream-command.yml
@@ -94,9 +94,11 @@ jobs:
 
       # Acknowledge only after the dispatch's head resolution succeeds: the
       # `gh api` above is fallible, and a transient error must not leave the
-      # maintainer with a 👀 reaction and no review, comment, or explanation —
-      # the failed run surfaces on the PR instead of the reaction mis-signalling
-      # success.
+      # maintainer with a 👀 reaction and no review, comment, or explanation.
+      # Note: a failed dispatch does NOT surface on the PR — no Daydream Review
+      # run is created, so surface-analyze-failure (which fires on the review's
+      # workflow_run event) never triggers and the failure is visible only in
+      # this workflow's Actions tab.
       - name: Acknowledge with eyes reaction
         if: steps.match.outputs.matched == 'true'
         env:

--- a/daydream/templates/workflows/daydream-post.yml
+++ b/daydream/templates/workflows/daydream-post.yml
@@ -46,7 +46,7 @@ jobs:
         # Pinned to a release tag (not `main`) so the bot runs a known daydream
         # version: reproducible and immune to main-drift / uv-cache staleness.
         # Bump in lockstep with the package version on release (a test enforces this).
-        run: uv tool install git+https://github.com/existential-birds/daydream@v0.26.0
+        run: uv tool install git+https://github.com/existential-birds/daydream@v0.27.0
 
       - name: Mint posting token
         id: token

--- a/daydream/templates/workflows/daydream-post.yml
+++ b/daydream/templates/workflows/daydream-post.yml
@@ -7,17 +7,13 @@
 # The artifact is passive data, validated by `daydream post-findings` against a strict schema before
 # anything is posted.
 #
-# Target derivation (Task 0 spike, Step 2 — the event payload is NOT uniform):
-#   - pull_request runs: `workflow_run.head_sha` IS the PR head.
-#     `pull_requests[0].number` is populated for same-repo PRs but EMPTY for
-#     fork PRs, where the open-PR list filtered by head SHA resolves it.
-#   - workflow_dispatch runs (the `@<bot> review` path): `pull_requests` is
-#     empty and `head_sha` is the default-branch tip (useless). The PR number
-#     travels in the findings artifact; the LIVE PR fetched from the GitHub
-#     API is the trust anchor — `daydream post-findings` validates the
-#     artifact's declared head_sha against that live value and aborts on
-#     mismatch, so a forged artifact can only point at the real current head
-#     of the PR it names.
+# Target derivation: "Daydream Review" only runs via workflow_dispatch (the
+# `@<bot> review` command), so `pull_requests` is always empty and `head_sha`
+# is the default-branch tip (useless). The PR number travels in the findings
+# artifact; the LIVE PR fetched from the GitHub API is the trust anchor —
+# `daydream post-findings` validates the artifact's declared head_sha against
+# that live value and aborts on mismatch, so a forged artifact can only point
+# at the real current head of the PR it names.
 #
 # Token (footgun 3): minted via actions/create-github-app-token with exactly
 # `pull-requests: write, contents: read, metadata: read`, reaches `gh` via
@@ -74,27 +70,13 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
           REPO: ${{ github.repository }}
-          RUN_EVENT: ${{ github.event.workflow_run.event }}
-          EVENT_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          EVENT_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
         run: |
-          if [ "$RUN_EVENT" = "pull_request" ]; then
-            HEAD_SHA="$EVENT_HEAD_SHA"
-            PR_NUMBER="$EVENT_PR_NUMBER"
-            if [ -z "$PR_NUMBER" ]; then
-              # Fork PRs leave pull_requests empty (spike Shape 2); the
-              # open-PR list filtered by head SHA resolves both PR shapes.
-              PR_NUMBER="$(gh api "repos/${REPO}/pulls?state=open&per_page=100" \
-                --jq ".[] | select(.head.sha == \"${HEAD_SHA}\") | .number" | head -n 1)"
-            fi
-          else
-            # workflow_dispatch (spike Shape 3): the event cannot identify the
-            # PR — read pr_number from the artifact, then trust the LIVE PR
-            # head from the API; post-findings validates the artifact against
-            # it and aborts on mismatch.
-            PR_NUMBER="$(jq -r '.pr_number // empty' findings/findings.json)"
-            HEAD_SHA="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq .head.sha)"
-          fi
+          # The dispatch event cannot identify the PR — read pr_number from
+          # the artifact, then trust the LIVE PR head from the API;
+          # post-findings validates the artifact against it and aborts on
+          # mismatch.
+          PR_NUMBER="$(jq -r '.pr_number // empty' findings/findings.json)"
+          HEAD_SHA="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq .head.sha)"
           if [ -z "$PR_NUMBER" ] || [ -z "$HEAD_SHA" ]; then
             echo "could not resolve a target PR for this run" >&2
             exit 1
@@ -147,25 +129,39 @@ jobs:
           permission-contents: read
           permission-metadata: read
 
+      # A workflow_dispatch run's PR is not identifiable from the event
+      # (pull_requests is empty, head_sha is the default-branch tip), so the
+      # failed analyze run's failure-context artifact resolves it. GITHUB_TOKEN's
+      # actions: read (workflow-level) covers the cross-run download.
+      - name: Download failure context
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: daydream-findings-failure
+          path: findings
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+        # A failed run without the artifact (e.g. the runner died mid-step)
+        # falls through to the exit-0 guard below rather than failing the job.
+        continue-on-error: true
+
       - name: Comment on the PR
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
           REPO: ${{ github.repository }}
-          RUN_EVENT: ${{ github.event.workflow_run.event }}
-          EVENT_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          EVENT_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
         run: |
-          PR_NUMBER="$EVENT_PR_NUMBER"
-          if [ -z "$PR_NUMBER" ] && [ "$RUN_EVENT" = "pull_request" ]; then
-            PR_NUMBER="$(gh api "repos/${REPO}/pulls?state=open&per_page=100" \
-              --jq ".[] | select(.head.sha == \"${EVENT_HEAD_SHA}\") | .number" | head -n 1)"
-          fi
+          PR_NUMBER="$(jq -r '.pr_number // empty' findings/failure.json 2>/dev/null || true)"
           if [ -z "$PR_NUMBER" ]; then
-            # A failed dispatch run leaves no artifact and a default-branch
-            # head_sha, so there is nothing to resolve — log and stop.
+            # A failed dispatch run with no failure-context artifact — log and
+            # stop rather than posting blind.
             echo "no PR resolvable for the failed analyze run; skipping comment" >&2
             exit 0
           fi
-          gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-            -f body="daydream review failed — see run ${RUN_URL}"
+          FAILURE_MESSAGE="$(jq -r '.message // empty' findings/failure.json 2>/dev/null || true)"
+          if [ -n "$FAILURE_MESSAGE" ]; then
+            gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+              -f body="${FAILURE_MESSAGE} — see run ${RUN_URL}"
+          else
+            gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+              -f body="daydream review failed — see run ${RUN_URL}"
+          fi

--- a/daydream/templates/workflows/daydream-post.yml
+++ b/daydream/templates/workflows/daydream-post.yml
@@ -75,8 +75,8 @@ jobs:
           # the artifact, then trust the LIVE PR head from the API;
           # post-findings validates the artifact against it and aborts on
           # mismatch.
-          PR_NUMBER="$(jq -r '.pr_number // empty' findings/findings.json)"
-          HEAD_SHA="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq .head.sha)"
+          PR_NUMBER="$(jq -r '.pr_number // empty' findings/findings.json || true)"
+          HEAD_SHA="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq .head.sha || true)"
           if [ -z "$PR_NUMBER" ] || [ -z "$HEAD_SHA" ]; then
             echo "could not resolve a target PR for this run" >&2
             exit 1
@@ -158,10 +158,6 @@ jobs:
             exit 0
           fi
           FAILURE_MESSAGE="$(jq -r '.message // empty' findings/failure.json 2>/dev/null || true)"
-          if [ -n "$FAILURE_MESSAGE" ]; then
-            gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-              -f body="${FAILURE_MESSAGE} — see run ${RUN_URL}"
-          else
-            gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-              -f body="daydream review failed — see run ${RUN_URL}"
-          fi
+          BODY="${FAILURE_MESSAGE:-daydream review failed} — see run ${RUN_URL}"
+          gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            -f body="${BODY}"

--- a/daydream/templates/workflows/daydream-review.yml
+++ b/daydream/templates/workflows/daydream-review.yml
@@ -7,22 +7,21 @@
 # separate privileged `daydream-post.yml` (workflow_run), per the locked
 # privilege split: no single job ever holds both PR code and the App key.
 #
-# Triggers:
-#   - pull_request (opened, ready_for_review): auto-review for same-repo PRs,
-#     unless the operator sets the repo variable DAYDREAM_AUTO_REVIEW=false.
-#   - workflow_dispatch (pr_number): on-demand review, dispatched by
-#     daydream-command.yml on `@<bot> review`. Dispatch runs sit on the
-#     default branch, so the PR head ref is fetched explicitly.
+# Triggered on demand by daydream-command.yml after a trusted maintainer
+# comments `@<bot> review`. The dispatch binds both the PR number and the
+# approved head SHA; this workflow rejects drift before checking out code.
 
 name: Daydream Review
 
 on:
-  pull_request:
-    types: [opened, ready_for_review]
   workflow_dispatch:
     inputs:
       pr_number:
         description: Number of the pull request to review
+        required: true
+        type: string
+      approved_head_sha:
+        description: PR head SHA approved by the maintainer
         required: true
         type: string
 
@@ -32,53 +31,35 @@ permissions:
 jobs:
   analyze:
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.pull_request.head.repo.full_name == github.repository &&
-      vars.DAYDREAM_AUTO_REVIEW != 'false')
+    if: github.event_name == 'workflow_dispatch'
     steps:
-      - name: Check out PR head (pull_request)
-        if: github.event_name == 'pull_request'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-
-      - name: Check out repository (workflow_dispatch)
-        if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          fetch-depth: 0
-
-      # Dispatch runs sit on the default branch and the PR number arrives as
-      # an input, so the PR head must be fetched explicitly (via env, never
-      # inline interpolation).
-      - name: Check out PR head (workflow_dispatch)
-        if: github.event_name == 'workflow_dispatch'
-        env:
-          PR_NUMBER: ${{ inputs.pr_number }}
-        run: |
-          git fetch origin "refs/pull/${PR_NUMBER}/head"
-          git checkout --detach FETCH_HEAD
-
       - name: Resolve PR number and base ref
         id: pr
         env:
           GH_TOKEN: ${{ github.token }}
-          EVENT_NAME: ${{ github.event_name }}
-          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
-          EVENT_BASE_REF: ${{ github.event.pull_request.base.ref }}
-          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+          PR_NUMBER: ${{ inputs.pr_number }}
         run: |
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            PR_NUMBER="$INPUT_PR_NUMBER"
-            BASE_REF="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json baseRefName --jq .baseRefName)"
-          else
-            PR_NUMBER="$EVENT_PR_NUMBER"
-            BASE_REF="$EVENT_BASE_REF"
-          fi
+          BASE_REF="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json baseRefName --jq .baseRefName)"
           echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
           echo "base_ref=${BASE_REF}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify approved PR head
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          APPROVED_HEAD_SHA: ${{ inputs.approved_head_sha }}
+        run: |
+          LIVE_HEAD_SHA="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.sha)"
+          if [ "$LIVE_HEAD_SHA" != "$APPROVED_HEAD_SHA" ]; then
+            echo "PR #$PR_NUMBER head changed after approval: approved_head_sha=$APPROVED_HEAD_SHA, live=$LIVE_HEAD_SHA. Comment the review command again to approve the new head." >&2
+            exit 1
+          fi
+
+      - name: Check out approved PR head
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.approved_head_sha }}
+          fetch-depth: 0
 
       - name: Fetch base ref
         env:
@@ -100,9 +81,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           BASE_REF: ${{ steps.pr.outputs.base_ref }}
+          APPROVED_HEAD_SHA: ${{ inputs.approved_head_sha }}
         run: |
           mkdir -p findings
           daydream --review --non-interactive --pr-number "$PR_NUMBER" \
+            --approved-head-sha "$APPROVED_HEAD_SHA" \
             --findings-out findings/findings.json --base "origin/$BASE_REF" .
 
       - name: Upload findings artifact

--- a/daydream/templates/workflows/daydream-review.yml
+++ b/daydream/templates/workflows/daydream-review.yml
@@ -24,6 +24,10 @@ on:
         description: PR head SHA approved by the maintainer
         required: true
         type: string
+      approved_at:
+        description: ISO-8601 creation time of the approving review comment
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -48,10 +52,29 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.pr_number }}
           APPROVED_HEAD_SHA: ${{ inputs.approved_head_sha }}
+          APPROVED_AT: ${{ inputs.approved_at }}
         run: |
           LIVE_HEAD_SHA="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.sha)"
           if [ "$LIVE_HEAD_SHA" != "$APPROVED_HEAD_SHA" ]; then
             echo "PR #$PR_NUMBER head changed after approval: approved_head_sha=$APPROVED_HEAD_SHA, live=$LIVE_HEAD_SHA. Comment the review command again to approve the new head." >&2
+            # Record the failure context before exiting so the post workflow's
+            # surface-analyze-failure job can comment on the PR — the
+            # workflow_run event cannot identify a workflow_dispatch run's PR.
+            mkdir -p findings
+            printf '{"pr_number": "%s", "message": "The PR head changed after approval. Comment the review command again to approve the new head"}' "$PR_NUMBER" > findings/failure.json
+            exit 1
+          fi
+          # The dispatch resolves the head at run time; the approving comment's
+          # creation time is the comment-time anchor. A head whose commit is
+          # newer than that comment was pushed after approval, so it is not
+          # reviewable without a fresh command.
+          HEAD_COMMIT_DATE="$(gh api "repos/$GITHUB_REPOSITORY/commits/$APPROVED_HEAD_SHA" --jq .commit.committer.date)"
+          if [ -z "$HEAD_COMMIT_DATE" ]; then
+            echo "Could not resolve the commit date for approved head $APPROVED_HEAD_SHA" >&2
+            exit 1
+          fi
+          if [ "$HEAD_COMMIT_DATE" \> "$APPROVED_AT" ]; then
+            echo "PR #$PR_NUMBER approved head commit ($HEAD_COMMIT_DATE) is newer than the approving comment ($APPROVED_AT). Comment the review command again to approve the new head." >&2
             exit 1
           fi
 
@@ -87,6 +110,27 @@ jobs:
           daydream --review --non-interactive --pr-number "$PR_NUMBER" \
             --approved-head-sha "$APPROVED_HEAD_SHA" \
             --findings-out findings/findings.json --base "origin/$BASE_REF" .
+
+      # Any analyze failure (drift or otherwise) leaves the PR number where the
+      # post workflow can resolve it: the workflow_run event cannot identify a
+      # workflow_dispatch run's PR, so surface-analyze-failure reads it from
+      # this artifact instead of silently skipping the comment.
+      - name: Record failure context
+        if: failure()
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          mkdir -p findings
+          if [ ! -f findings/failure.json ]; then
+            printf '{"pr_number": "%s"}' "$PR_NUMBER" > findings/failure.json
+          fi
+
+      - name: Upload failure context
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: daydream-findings-failure
+          path: findings/failure.json
 
       - name: Upload findings artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/daydream/templates/workflows/daydream-review.yml
+++ b/daydream/templates/workflows/daydream-review.yml
@@ -92,7 +92,7 @@ jobs:
         # Pinned to a release tag (not `main`) so the bot runs a known daydream
         # version: reproducible and immune to main-drift / uv-cache staleness.
         # Bump in lockstep with the package version on release (a test enforces this).
-        run: uv tool install git+https://github.com/existential-birds/daydream@v0.26.0
+        run: uv tool install git+https://github.com/existential-birds/daydream@v0.27.0
 
       - name: Run daydream review
         env:

--- a/daydream/templates/workflows/daydream-review.yml
+++ b/daydream/templates/workflows/daydream-review.yml
@@ -65,16 +65,28 @@ jobs:
             exit 1
           fi
           # The dispatch resolves the head at run time; the approving comment's
-          # creation time is the comment-time anchor. A head whose commit is
-          # newer than that comment was pushed after approval, so it is not
-          # reviewable without a fresh command.
-          HEAD_COMMIT_DATE="$(gh api "repos/$GITHUB_REPOSITORY/commits/$APPROVED_HEAD_SHA" --jq .commit.committer.date)"
-          if [ -z "$HEAD_COMMIT_DATE" ]; then
-            echo "Could not resolve the commit date for approved head $APPROVED_HEAD_SHA" >&2
+          # creation time is the comment-time anchor. The head repository's
+          # pushed_at is server-set by GitHub when a push is received, so it
+          # cannot be backdated like commit.committer.date; a head pushed after
+          # the comment has pushed_at newer than it and is not reviewable
+          # without a fresh command.
+          HEAD_PUSHED_AT="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.repo.pushed_at)"
+          if [ -z "$HEAD_PUSHED_AT" ]; then
+            echo "Could not resolve the head repository push time for approved head $APPROVED_HEAD_SHA" >&2
+            # Record the failure context before exiting, like the head-change
+            # branch, so the rejection surfaces on the PR with the instructive
+            # message (issue #336).
+            mkdir -p findings
+            printf '{"pr_number": "%s", "message": "Could not verify the approved head push time. Comment the review command again to approve the new head"}' "$PR_NUMBER" > findings/failure.json
             exit 1
           fi
-          if [ "$HEAD_COMMIT_DATE" \> "$APPROVED_AT" ]; then
-            echo "PR #$PR_NUMBER approved head commit ($HEAD_COMMIT_DATE) is newer than the approving comment ($APPROVED_AT). Comment the review command again to approve the new head." >&2
+          if [ "$HEAD_PUSHED_AT" \> "$APPROVED_AT" ]; then
+            echo "PR #$PR_NUMBER head repository was pushed ($HEAD_PUSHED_AT) after the approving comment ($APPROVED_AT). Comment the review command again to approve the new head." >&2
+            # Record the failure context before exiting, like the head-change
+            # branch, so the rejection surfaces on the PR with the instructive
+            # message (issue #336).
+            mkdir -p findings
+            printf '{"pr_number": "%s", "message": "The approved head was pushed after the approving comment. Comment the review command again to approve the new head"}' "$PR_NUMBER" > findings/failure.json
             exit 1
           fi
 

--- a/daydream/templates/workflows/daydream-review.yml
+++ b/daydream/templates/workflows/daydream-review.yml
@@ -54,40 +54,52 @@ jobs:
           APPROVED_HEAD_SHA: ${{ inputs.approved_head_sha }}
           APPROVED_AT: ${{ inputs.approved_at }}
         run: |
-          LIVE_HEAD_SHA="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.sha)"
-          if [ "$LIVE_HEAD_SHA" != "$APPROVED_HEAD_SHA" ]; then
-            echo "PR #$PR_NUMBER head changed after approval: approved_head_sha=$APPROVED_HEAD_SHA, live=$LIVE_HEAD_SHA. Comment the review command again to approve the new head." >&2
-            # Record the failure context before exiting so the post workflow's
-            # surface-analyze-failure job can comment on the PR — the
-            # workflow_run event cannot identify a workflow_dispatch run's PR.
+          # Every drift rejection funnels through this helper: it records the
+          # failure context (pr_number + the instructive message) before exiting
+          # so the post workflow's surface-analyze-failure job can comment on
+          # the PR — the workflow_run event cannot identify a workflow_dispatch
+          # run's PR (issue #336). The console message carries the details for
+          # the log; the record message is the shorter text posted on the PR.
+          reject() {
+            local console_message="$1"
+            local record_message="$2"
+            echo "$console_message" >&2
             mkdir -p findings
-            printf '{"pr_number": "%s", "message": "The PR head changed after approval. Comment the review command again to approve the new head"}' "$PR_NUMBER" > findings/failure.json
+            printf '{"pr_number": "%s", "message": "%s"}' "$PR_NUMBER" "$record_message" > findings/failure.json
             exit 1
+          }
+          HEAD_INFO="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '{sha: .head.sha, ref: .head.ref, repo: (.head.repo.full_name? // "")}')"
+          LIVE_HEAD_SHA="$(printf '%s' "$HEAD_INFO" | jq -r .sha)"
+          HEAD_REF="$(printf '%s' "$HEAD_INFO" | jq -r .ref)"
+          HEAD_REPO="$(printf '%s' "$HEAD_INFO" | jq -r .repo)"
+          if [ "$LIVE_HEAD_SHA" != "$APPROVED_HEAD_SHA" ]; then
+            reject "PR #$PR_NUMBER head changed after approval: approved_head_sha=$APPROVED_HEAD_SHA, live=$LIVE_HEAD_SHA. Comment the review command again to approve the new head." \
+              "The PR head changed after approval. Comment the review command again to approve the new head"
           fi
           # The dispatch resolves the head at run time; the approving comment's
-          # creation time is the comment-time anchor. The head repository's
-          # pushed_at is server-set by GitHub when a push is received, so it
-          # cannot be backdated like commit.committer.date; a head pushed after
-          # the comment has pushed_at newer than it and is not reviewable
-          # without a fresh command.
-          HEAD_PUSHED_AT="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.repo.pushed_at)"
-          if [ -z "$HEAD_PUSHED_AT" ]; then
-            echo "Could not resolve the head repository push time for approved head $APPROVED_HEAD_SHA" >&2
-            # Record the failure context before exiting, like the head-change
-            # branch, so the rejection surfaces on the PR with the instructive
-            # message (issue #336).
-            mkdir -p findings
-            printf '{"pr_number": "%s", "message": "Could not verify the approved head push time. Comment the review command again to approve the new head"}' "$PR_NUMBER" > findings/failure.json
-            exit 1
-          fi
-          if [ "$HEAD_PUSHED_AT" \> "$APPROVED_AT" ]; then
-            echo "PR #$PR_NUMBER head repository was pushed ($HEAD_PUSHED_AT) after the approving comment ($APPROVED_AT). Comment the review command again to approve the new head." >&2
-            # Record the failure context before exiting, like the head-change
-            # branch, so the rejection surfaces on the PR with the instructive
-            # message (issue #336).
-            mkdir -p findings
-            printf '{"pr_number": "%s", "message": "The approved head was pushed after the approving comment. Comment the review command again to approve the new head"}' "$PR_NUMBER" > findings/failure.json
-            exit 1
+          # creation time is the comment-time anchor. The approved commit's push
+          # time is the head repository's activity scoped to the PR's head ref —
+          # server-set by GitHub when a push is received, so it cannot be
+          # backdated like commit.committer.date, and scoped to this PR rather
+          # than the repo-wide pushed_at that every push to the repo bumps. The
+          # timestamps are second-granularity, so a push in the same wall-clock
+          # second as the comment is indistinguishable from one that landed
+          # before it: reject when the push is NOT strictly before the comment
+          # (equality fails closed), not only when it is strictly after. A
+          # deleted head repository cannot receive pushes — the approved head is
+          # frozen and the bound SHA cannot change — so there is no window to
+          # close and no push time to resolve.
+          if [ -n "$HEAD_REPO" ]; then
+            HEAD_PUSHED_AT="$(gh api "repos/$HEAD_REPO/activity?ref=refs/heads/$HEAD_REF&per_page=100" \
+              --jq '[.[] | select(.activity_type == "push" or .activity_type == "branch_creation" or .activity_type == "force_push") | .timestamp][0] // empty')"
+            if [ -z "$HEAD_PUSHED_AT" ]; then
+              reject "Could not resolve the push time for approved head $APPROVED_HEAD_SHA" \
+                "Could not verify the approved head push time. Comment the review command again to approve the new head"
+            fi
+            if ! [ "$HEAD_PUSHED_AT" \< "$APPROVED_AT" ]; then
+              reject "PR #$PR_NUMBER head was pushed ($HEAD_PUSHED_AT) at or after the approving comment ($APPROVED_AT). Comment the review command again to approve the new head." \
+                "The approved head was pushed after the approving comment. Comment the review command again to approve the new head"
+            fi
           fi
 
       - name: Check out approved PR head

--- a/daydream/templates/workflows/single/README.md
+++ b/daydream/templates/workflows/single/README.md
@@ -2,9 +2,9 @@
 
 `daydream.yml` is an **optional** alternative to the three-file split
 (`daydream-review.yml` + `daydream-command.yml` + `daydream-post.yml`) in the
-parent directory. It does exactly the same thing — auto-review same-repo PRs on
-open, review on demand via `@<bot> review`, post findings as your App bot — in a
-single workflow file.
+parent directory. It does exactly the same thing — review on demand via `@<bot> review`
+after a trusted comment approves the current head, then post findings as your
+App bot — in a single workflow file.
 
 Pick this variant if you want a smaller install and an App that does **not** need
 the `Actions: read & write` permission.

--- a/daydream/templates/workflows/single/daydream.yml
+++ b/daydream/templates/workflows/single/daydream.yml
@@ -144,7 +144,7 @@ jobs:
         # Pinned to a release tag (not `main`) so the bot runs a known daydream
         # version: reproducible and immune to main-drift / uv-cache staleness.
         # Bump in lockstep with the package version on release (a test enforces this).
-        run: uv tool install git+https://github.com/existential-birds/daydream@v0.26.0
+        run: uv tool install git+https://github.com/existential-birds/daydream@v0.27.0
 
       # Runs the DEFAULT deep-review pipeline (not --review). In --non-interactive
       # the deep run auto-declines the post/fix gates, so it still only produces a
@@ -191,7 +191,7 @@ jobs:
         uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
 
       - name: Install daydream
-        run: uv tool install git+https://github.com/existential-birds/daydream@v0.26.0
+        run: uv tool install git+https://github.com/existential-birds/daydream@v0.27.0
 
       - name: Download findings artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/daydream/templates/workflows/single/daydream.yml
+++ b/daydream/templates/workflows/single/daydream.yml
@@ -132,19 +132,25 @@ jobs:
           LIVE_HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq .head.sha)"
           if [ "$LIVE_HEAD_SHA" != "$APPROVED_HEAD_SHA" ]; then
             echo "PR #$PR_NUMBER head changed after approval: approved_head_sha=$APPROVED_HEAD_SHA, live=$LIVE_HEAD_SHA. Comment the review command again to approve the new head." >&2
+            # Record the failure context before exiting so surface-failure can
+            # comment on the PR with the instructive message (issue #336).
+            mkdir -p findings
+            printf '{"pr_number": "%s", "message": "The PR head changed after approval. Comment the review command again to approve the new head"}' "$PR_NUMBER" > findings/failure.json
             exit 1
           fi
           # The gate resolves the head at run time; the approving comment's
-          # creation time is the comment-time anchor. A head whose commit is
-          # newer than that comment was pushed after approval, so it is not
-          # reviewable without a fresh command.
-          HEAD_COMMIT_DATE="$(gh api "repos/$REPO/commits/$APPROVED_HEAD_SHA" --jq .commit.committer.date)"
-          if [ -z "$HEAD_COMMIT_DATE" ]; then
-            echo "Could not resolve the commit date for approved head $APPROVED_HEAD_SHA" >&2
+          # creation time is the comment-time anchor. The head repository's
+          # pushed_at is server-set by GitHub when a push is received, so it
+          # cannot be backdated like commit.committer.date; a head pushed after
+          # the comment has pushed_at newer than it and is not reviewable
+          # without a fresh command.
+          HEAD_PUSHED_AT="$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq .head.repo.pushed_at)"
+          if [ -z "$HEAD_PUSHED_AT" ]; then
+            echo "Could not resolve the head repository push time for approved head $APPROVED_HEAD_SHA" >&2
             exit 1
           fi
-          if [ "$HEAD_COMMIT_DATE" \> "$APPROVED_AT" ]; then
-            echo "PR #$PR_NUMBER approved head commit ($HEAD_COMMIT_DATE) is newer than the approving comment ($APPROVED_AT). Comment the review command again to approve the new head." >&2
+          if [ "$HEAD_PUSHED_AT" \> "$APPROVED_AT" ]; then
+            echo "PR #$PR_NUMBER head repository was pushed ($HEAD_PUSHED_AT) after the approving comment ($APPROVED_AT). Comment the review command again to approve the new head." >&2
             exit 1
           fi
           BASE_REF="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json baseRefName --jq .baseRefName)"
@@ -186,6 +192,24 @@ jobs:
           daydream --non-interactive --pr-number "$PR_NUMBER" \
             --approved-head-sha "$APPROVED_HEAD_SHA" \
             --findings-out findings/findings.json --base "origin/$BASE_REF" .
+
+      # Any analyze failure (drift or otherwise) leaves the PR number where
+      # surface-failure can resolve it: the drift branches write an
+      # instructive message, everything else falls back to the bare number.
+      - name: Record failure context
+        if: failure()
+        run: |
+          mkdir -p findings
+          if [ ! -f findings/failure.json ]; then
+            printf '{"pr_number": "%s"}' "$PR_NUMBER" > findings/failure.json
+          fi
+
+      - name: Upload failure context
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: daydream-findings-failure
+          path: findings/failure.json
 
       - name: Upload findings artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -271,6 +295,16 @@ jobs:
           private-key: ${{ secrets.DAYDREAM_APP_PRIVATE_KEY }}
           permission-pull-requests: write
 
+      # Same-run download needs no GITHUB_TOKEN scope (that is only required to
+      # reach across runs). A failed run without the artifact (e.g. the runner
+      # died mid-step) falls through to the generic-message comment below.
+      - name: Download failure context
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: daydream-findings-failure
+          path: findings
+        continue-on-error: true
+
       - name: Comment on the PR
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
@@ -278,5 +312,11 @@ jobs:
           PR_NUMBER: ${{ needs.gate.outputs.pr_number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-            -f body="daydream review failed — see run ${RUN_URL}"
+          FAILURE_MESSAGE="$(jq -r '.message // empty' findings/failure.json 2>/dev/null || true)"
+          if [ -n "$FAILURE_MESSAGE" ]; then
+            gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+              -f body="${FAILURE_MESSAGE} — see run ${RUN_URL}"
+          else
+            gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+              -f body="daydream review failed — see run ${RUN_URL}"
+          fi

--- a/daydream/templates/workflows/single/daydream.yml
+++ b/daydream/templates/workflows/single/daydream.yml
@@ -96,10 +96,12 @@ jobs:
             echo "Unable to resolve the head SHA for PR #$ISSUE_NUMBER" >&2
             exit 1
           fi
-          echo "proceed=true" >> "$GITHUB_OUTPUT"
-          echo "pr_number=${ISSUE_NUMBER}" >> "$GITHUB_OUTPUT"
-          echo "approved_head_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
-          echo "approved_at=${APPROVED_AT}" >> "$GITHUB_OUTPUT"
+          {
+            echo "proceed=true"
+            echo "pr_number=${ISSUE_NUMBER}"
+            echo "approved_head_sha=${HEAD_SHA}"
+            echo "approved_at=${APPROVED_AT}"
+          } >> "$GITHUB_OUTPUT"
 
       # Acknowledge only after head resolution succeeds: a fallible `gh api`
       # exit in the decide step aborts the job here, so the ack never fires and

--- a/daydream/templates/workflows/single/daydream.yml
+++ b/daydream/templates/workflows/single/daydream.yml
@@ -46,6 +46,7 @@ jobs:
       proceed: ${{ steps.decide.outputs.proceed }}
       pr_number: ${{ steps.decide.outputs.pr_number }}
       approved_head_sha: ${{ steps.decide.outputs.approved_head_sha }}
+      approved_at: ${{ steps.decide.outputs.approved_at }}
     steps:
       - name: Match review command
         id: match
@@ -73,6 +74,17 @@ jobs:
           private-key: ${{ secrets.DAYDREAM_APP_PRIVATE_KEY }}
           permission-pull-requests: write
 
+      # Acknowledge BEFORE resolving the head: a fallible `gh api` exit below
+      # would otherwise abort the job and silently skip the ack with no PR-side
+      # feedback, so the 👀 reaction is gated only on the command match.
+      - name: Acknowledge with eyes reaction
+        if: steps.match.outputs.matched == 'true'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: gh api -X POST "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" -f content=eyes
+
       - name: Decide and resolve PR
         id: decide
         env:
@@ -80,6 +92,7 @@ jobs:
           REPO: ${{ github.repository }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           MATCHED: ${{ steps.match.outputs.matched }}
+          APPROVED_AT: ${{ github.event.comment.created_at }}
         run: |
           if [ "$MATCHED" != "true" ]; then
             echo "proceed=false" >> "$GITHUB_OUTPUT"
@@ -93,14 +106,7 @@ jobs:
           echo "proceed=true" >> "$GITHUB_OUTPUT"
           echo "pr_number=${ISSUE_NUMBER}" >> "$GITHUB_OUTPUT"
           echo "approved_head_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
-
-      - name: Acknowledge with eyes reaction
-        if: steps.decide.outputs.proceed == 'true'
-        env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
-          REPO: ${{ github.repository }}
-          COMMENT_ID: ${{ github.event.comment.id }}
-        run: gh api -X POST "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" -f content=eyes
+          echo "approved_at=${APPROVED_AT}" >> "$GITHUB_OUTPUT"
 
   # Runs the reviewer over the checked-out PR head. Touches untrusted PR code, so
   # it holds NO App credentials — ANTHROPIC_API_KEY is its only secret and the
@@ -115,6 +121,7 @@ jobs:
     env:
       PR_NUMBER: ${{ needs.gate.outputs.pr_number }}
       APPROVED_HEAD_SHA: ${{ needs.gate.outputs.approved_head_sha }}
+      APPROVED_AT: ${{ needs.gate.outputs.approved_at }}
     steps:
       - name: Verify approved PR head and resolve base ref
         id: pr
@@ -125,6 +132,19 @@ jobs:
           LIVE_HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq .head.sha)"
           if [ "$LIVE_HEAD_SHA" != "$APPROVED_HEAD_SHA" ]; then
             echo "PR #$PR_NUMBER head changed after approval: approved_head_sha=$APPROVED_HEAD_SHA, live=$LIVE_HEAD_SHA. Comment the review command again to approve the new head." >&2
+            exit 1
+          fi
+          # The gate resolves the head at run time; the approving comment's
+          # creation time is the comment-time anchor. A head whose commit is
+          # newer than that comment was pushed after approval, so it is not
+          # reviewable without a fresh command.
+          HEAD_COMMIT_DATE="$(gh api "repos/$REPO/commits/$APPROVED_HEAD_SHA" --jq .commit.committer.date)"
+          if [ -z "$HEAD_COMMIT_DATE" ]; then
+            echo "Could not resolve the commit date for approved head $APPROVED_HEAD_SHA" >&2
+            exit 1
+          fi
+          if [ "$HEAD_COMMIT_DATE" \> "$APPROVED_AT" ]; then
+            echo "PR #$PR_NUMBER approved head commit ($HEAD_COMMIT_DATE) is newer than the approving comment ($APPROVED_AT). Comment the review command again to approve the new head." >&2
             exit 1
           fi
           BASE_REF="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json baseRefName --jq .baseRefName)"

--- a/daydream/templates/workflows/single/daydream.yml
+++ b/daydream/templates/workflows/single/daydream.yml
@@ -74,17 +74,10 @@ jobs:
           private-key: ${{ secrets.DAYDREAM_APP_PRIVATE_KEY }}
           permission-pull-requests: write
 
-      # Acknowledge BEFORE resolving the head: a fallible `gh api` exit below
-      # would otherwise abort the job and silently skip the ack with no PR-side
-      # feedback, so the 👀 reaction is gated only on the command match.
-      - name: Acknowledge with eyes reaction
-        if: steps.match.outputs.matched == 'true'
-        env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
-          REPO: ${{ github.repository }}
-          COMMENT_ID: ${{ github.event.comment.id }}
-        run: gh api -X POST "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" -f content=eyes
-
+      # Resolve the trusted target head before acknowledging: the `gh api` below
+      # is fallible, and a transient error must not leave the maintainer with a
+      # 👀 reaction and no review, comment, or explanation — the failed run
+      # surfaces on the PR instead of the reaction mis-signalling success.
       - name: Decide and resolve PR
         id: decide
         env:
@@ -108,6 +101,19 @@ jobs:
           echo "approved_head_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
           echo "approved_at=${APPROVED_AT}" >> "$GITHUB_OUTPUT"
 
+      # Acknowledge only after head resolution succeeds: a fallible `gh api`
+      # exit in the decide step aborts the job here, so the ack never fires and
+      # the failed run surfaces on the PR — mirroring the split workflow's
+      # ack-after-dispatch ordering instead of mis-signalling success with a 👀
+      # reaction and no review (issue #336).
+      - name: Acknowledge with eyes reaction
+        if: steps.match.outputs.matched == 'true'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: gh api -X POST "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" -f content=eyes
+
   # Runs the reviewer over the checked-out PR head. Touches untrusted PR code, so
   # it holds NO App credentials — ANTHROPIC_API_KEY is its only secret and the
   # GITHUB_TOKEN is read-only.
@@ -129,29 +135,52 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
-          LIVE_HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq .head.sha)"
-          if [ "$LIVE_HEAD_SHA" != "$APPROVED_HEAD_SHA" ]; then
-            echo "PR #$PR_NUMBER head changed after approval: approved_head_sha=$APPROVED_HEAD_SHA, live=$LIVE_HEAD_SHA. Comment the review command again to approve the new head." >&2
-            # Record the failure context before exiting so surface-failure can
-            # comment on the PR with the instructive message (issue #336).
+          # Every drift rejection funnels through this helper: it records the
+          # failure context (pr_number + the instructive message) before exiting
+          # so surface-failure can comment on the PR with the instructive
+          # message instead of the generic fallback body (issue #336). The
+          # console message carries the details for the log; the record message
+          # is the shorter text posted on the PR.
+          reject() {
+            local console_message="$1"
+            local record_message="$2"
+            echo "$console_message" >&2
             mkdir -p findings
-            printf '{"pr_number": "%s", "message": "The PR head changed after approval. Comment the review command again to approve the new head"}' "$PR_NUMBER" > findings/failure.json
+            printf '{"pr_number": "%s", "message": "%s"}' "$PR_NUMBER" "$record_message" > findings/failure.json
             exit 1
+          }
+          HEAD_INFO="$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '{sha: .head.sha, ref: .head.ref, repo: (.head.repo.full_name? // "")}')"
+          LIVE_HEAD_SHA="$(printf '%s' "$HEAD_INFO" | jq -r .sha)"
+          HEAD_REF="$(printf '%s' "$HEAD_INFO" | jq -r .ref)"
+          HEAD_REPO="$(printf '%s' "$HEAD_INFO" | jq -r .repo)"
+          if [ "$LIVE_HEAD_SHA" != "$APPROVED_HEAD_SHA" ]; then
+            reject "PR #$PR_NUMBER head changed after approval: approved_head_sha=$APPROVED_HEAD_SHA, live=$LIVE_HEAD_SHA. Comment the review command again to approve the new head." \
+              "The PR head changed after approval. Comment the review command again to approve the new head"
           fi
           # The gate resolves the head at run time; the approving comment's
-          # creation time is the comment-time anchor. The head repository's
-          # pushed_at is server-set by GitHub when a push is received, so it
-          # cannot be backdated like commit.committer.date; a head pushed after
-          # the comment has pushed_at newer than it and is not reviewable
-          # without a fresh command.
-          HEAD_PUSHED_AT="$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq .head.repo.pushed_at)"
-          if [ -z "$HEAD_PUSHED_AT" ]; then
-            echo "Could not resolve the head repository push time for approved head $APPROVED_HEAD_SHA" >&2
-            exit 1
-          fi
-          if [ "$HEAD_PUSHED_AT" \> "$APPROVED_AT" ]; then
-            echo "PR #$PR_NUMBER head repository was pushed ($HEAD_PUSHED_AT) after the approving comment ($APPROVED_AT). Comment the review command again to approve the new head." >&2
-            exit 1
+          # creation time is the comment-time anchor. The approved commit's push
+          # time is the head repository's activity scoped to the PR's head ref —
+          # server-set by GitHub when a push is received, so it cannot be
+          # backdated like commit.committer.date, and scoped to this PR rather
+          # than the repo-wide pushed_at that every push to the repo bumps. The
+          # timestamps are second-granularity, so a push in the same wall-clock
+          # second as the comment is indistinguishable from one that landed
+          # before it: reject when the push is NOT strictly before the comment
+          # (equality fails closed), not only when it is strictly after. A
+          # deleted head repository cannot receive pushes — the approved head is
+          # frozen and the bound SHA cannot change — so there is no window to
+          # close and no push time to resolve.
+          if [ -n "$HEAD_REPO" ]; then
+            HEAD_PUSHED_AT="$(gh api "repos/$HEAD_REPO/activity?ref=refs/heads/$HEAD_REF&per_page=100" \
+              --jq '[.[] | select(.activity_type == "push" or .activity_type == "branch_creation" or .activity_type == "force_push") | .timestamp][0] // empty')"
+            if [ -z "$HEAD_PUSHED_AT" ]; then
+              reject "Could not resolve the push time for approved head $APPROVED_HEAD_SHA" \
+                "Could not verify the approved head push time. Comment the review command again to approve the new head"
+            fi
+            if ! [ "$HEAD_PUSHED_AT" \< "$APPROVED_AT" ]; then
+              reject "PR #$PR_NUMBER head was pushed ($HEAD_PUSHED_AT) at or after the approving comment ($APPROVED_AT). Comment the review command again to approve the new head." \
+                "The approved head was pushed after the approving comment. Comment the review command again to approve the new head"
+            fi
           fi
           BASE_REF="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json baseRefName --jq .baseRefName)"
           echo "base_ref=${BASE_REF}" >> "$GITHUB_OUTPUT"

--- a/daydream/templates/workflows/single/daydream.yml
+++ b/daydream/templates/workflows/single/daydream.yml
@@ -26,76 +26,76 @@
 name: Daydream
 
 on:
-  pull_request:
-    types: [opened, ready_for_review]
   issue_comment:
     types: [created]
 
 permissions: {}
 
 jobs:
-  # Decides whether to proceed and resolves the PR number. Holds the App key for
-  # the 👀 acknowledgement but never checks out code, so it may be privileged.
+  # Accepts a trusted review command and resolves its immutable target head.
+  # Holds the App key for API reads and the acknowledgement, but never checks
+  # out code, so it may be privileged.
   gate:
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    # Auto-review a same-repo PR on open (unless disabled), OR a trusted, non-bot
-    # `@<bot> review` comment on a PR. Fork auto-review is intentionally excluded
-    # (fork PRs get no secrets); forks are served by the comment path.
     if: >-
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.head.repo.full_name == github.repository &&
-       vars.DAYDREAM_AUTO_REVIEW != 'false') ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
-       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
-       github.event.comment.user.type != 'Bot')
+      github.event.issue.pull_request &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+      github.event.comment.user.type != 'Bot'
     permissions: {}
     outputs:
       proceed: ${{ steps.decide.outputs.proceed }}
       pr_number: ${{ steps.decide.outputs.pr_number }}
+      approved_head_sha: ${{ steps.decide.outputs.approved_head_sha }}
     steps:
-      # For pull_request the event carries the PR number directly. For a comment,
-      # match the exact `@<handle> review` command (body via env only, footgun 2);
-      # a non-matching comment sets proceed=false and the downstream jobs skip.
-      - name: Decide and resolve PR
-        id: decide
+      - name: Match review command
+        id: match
         env:
-          EVENT_NAME: ${{ github.event_name }}
           BODY: ${{ github.event.comment.body }}
           BOT_HANDLE: ${{ vars.DAYDREAM_BOT_HANDLE }}
-          PR_EVENT_NUMBER: ${{ github.event.pull_request.number }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            echo "proceed=true" >> "$GITHUB_OUTPUT"
-            echo "pr_number=${PR_EVENT_NUMBER}" >> "$GITHUB_OUTPUT"
+          # Single-quoted sed script holds literal regex metacharacters, not shell expansions.
+          # shellcheck disable=SC2016
+          ESCAPED_HANDLE=$(printf '%s' "$BOT_HANDLE" | sed 's/[].[\*^$()+?{}|\\]/\\&/g')
+          if printf '%s' "$BODY" | grep -Eq "(^|[[:space:]])@${ESCAPED_HANDLE}[[:space:]]+review([[:space:]]|$)"; then
+            echo "matched=true" >> "$GITHUB_OUTPUT"
           else
-            # Single-quoted sed script holds literal regex metacharacters, not shell expansions.
-            # shellcheck disable=SC2016
-            ESCAPED_HANDLE=$(printf '%s' "$BOT_HANDLE" | sed 's/[].[\*^$()+?{}|\\]/\\&/g')
-            if printf '%s' "$BODY" | grep -Eq "(^|[[:space:]])@${ESCAPED_HANDLE}[[:space:]]+review([[:space:]]|$)"; then
-              echo "proceed=true" >> "$GITHUB_OUTPUT"
-              echo "pr_number=${ISSUE_NUMBER}" >> "$GITHUB_OUTPUT"
-            else
-              echo "proceed=false" >> "$GITHUB_OUTPUT"
-            fi
+            echo "matched=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # Mint the App token so the 👀 reaction is signed by the bot identity rather
-      # than github-actions[bot]. Scoped to pull-requests: write only — no
-      # actions: write, because nothing is dispatched. The token never appears in
-      # a run: body.
+      # Mint the App token before resolving the trusted target and acknowledging
+      # the command. The token never appears in a run: body.
       - name: Mint ack token
         id: token
-        if: github.event_name == 'issue_comment' && steps.decide.outputs.proceed == 'true'
+        if: steps.match.outputs.matched == 'true'
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ secrets.DAYDREAM_APP_ID }}
           private-key: ${{ secrets.DAYDREAM_APP_PRIVATE_KEY }}
           permission-pull-requests: write
 
+      - name: Decide and resolve PR
+        id: decide
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          MATCHED: ${{ steps.match.outputs.matched }}
+        run: |
+          if [ "$MATCHED" != "true" ]; then
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          HEAD_SHA="$(gh api "repos/$REPO/pulls/$ISSUE_NUMBER" --jq .head.sha)"
+          if [ -z "$HEAD_SHA" ]; then
+            echo "Unable to resolve the head SHA for PR #$ISSUE_NUMBER" >&2
+            exit 1
+          fi
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+          echo "pr_number=${ISSUE_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "approved_head_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
+
       - name: Acknowledge with eyes reaction
-        if: github.event_name == 'issue_comment' && steps.decide.outputs.proceed == 'true'
+        if: steps.decide.outputs.proceed == 'true'
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
           REPO: ${{ github.repository }}
@@ -114,28 +114,34 @@ jobs:
       pull-requests: read
     env:
       PR_NUMBER: ${{ needs.gate.outputs.pr_number }}
+      APPROVED_HEAD_SHA: ${{ needs.gate.outputs.approved_head_sha }}
     steps:
-      - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          fetch-depth: 0
-          # This job handles untrusted PR code; don't leave the GITHUB_TOKEN in .git/config.
-          persist-credentials: false
-
-      # Resolve the base ref, then fetch and detach the PR head. `refs/pull/N/head`
-      # resolves the same for same-repo and fork PRs. PR number via env, never
-      # inline interpolation (footgun 2).
-      - name: Fetch PR head and base ref
+      - name: Verify approved PR head and resolve base ref
         id: pr
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
+          LIVE_HEAD_SHA="$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq .head.sha)"
+          if [ "$LIVE_HEAD_SHA" != "$APPROVED_HEAD_SHA" ]; then
+            echo "PR #$PR_NUMBER head changed after approval: approved_head_sha=$APPROVED_HEAD_SHA, live=$LIVE_HEAD_SHA. Comment the review command again to approve the new head." >&2
+            exit 1
+          fi
           BASE_REF="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json baseRefName --jq .baseRefName)"
-          git fetch origin "refs/pull/${PR_NUMBER}/head"
-          git checkout --detach FETCH_HEAD
-          git fetch origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
           echo "base_ref=${BASE_REF}" >> "$GITHUB_OUTPUT"
+
+      - name: Check out approved PR head
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ needs.gate.outputs.approved_head_sha }}
+          fetch-depth: 0
+          # This job handles untrusted PR code; don't leave the GITHUB_TOKEN in .git/config.
+          persist-credentials: false
+
+      - name: Fetch base ref
+        env:
+          BASE_REF: ${{ steps.pr.outputs.base_ref }}
+        run: git fetch origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
 
       - name: Set up uv
         uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
@@ -154,9 +160,11 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ github.token }}
           BASE_REF: ${{ steps.pr.outputs.base_ref }}
+          APPROVED_HEAD_SHA: ${{ needs.gate.outputs.approved_head_sha }}
         run: |
           mkdir -p findings
           daydream --non-interactive --pr-number "$PR_NUMBER" \
+            --approved-head-sha "$APPROVED_HEAD_SHA" \
             --findings-out findings/findings.json --base "origin/$BASE_REF" .
 
       - name: Upload findings artifact

--- a/docs/self-hosted-bot-setup.md
+++ b/docs/self-hosted-bot-setup.md
@@ -152,8 +152,6 @@ In the same area, switch to the **Variables** tab → **New repository variable*
 - `DAYDREAM_BOT_HANDLE` — the mention handle the command workflow matches,
   **without** the `@` (e.g. `daydream-review`, so `@daydream-review review`
   triggers it).
-- _Optional:_ `DAYDREAM_AUTO_REVIEW` — set to `false` to disable auto-review on
-  PR open; the `@<bot> review` command keeps working.
 
 ### 6. Add the three workflow files
 
@@ -180,12 +178,21 @@ roles, trigger matrix, and security model are documented in that directory's
 > setup` always lands the three-file split, so this variant is browser/manual
 > only.
 
-### 7. Confirm
+### 7. Confirm and approve a review
 
-Open a pull request in the repo. With auto-review on, the bot reviews it and
-posts inline comments as `<your-app>[bot]`; otherwise comment `@<bot> review`.
+Open a pull request in the repo, then have a trusted maintainer (an OWNER,
+MEMBER, or COLLABORATOR) comment `@<bot> review`. The command workflow records
+the PR's current head SHA as the approved target and starts the unprivileged
+review workflow. Findings are posted as `<your-app>[bot]`.
+
+The approval is bound to that exact commit. If a commit is pushed after the
+comment, the review fails loudly before checkout rather than running with model
+credentials against code that was never approved. Comment `@<bot> review`
+again to approve and review the new head.
+
 If you have a terminal available, run the `--verify` command shown at the top of
-this guide to audit the install component-by-component.
+this guide to audit the install component-by-component, including that the
+installed workflows exactly match the packaged approval-gated versions.
 
 ---
 

--- a/docs/self-hosted-bot-setup.md
+++ b/docs/self-hosted-bot-setup.md
@@ -192,7 +192,9 @@ again to approve and review the new head.
 
 If you have a terminal available, run the `--verify` command shown at the top of
 this guide to audit the install component-by-component, including that the
-installed workflows exactly match the packaged approval-gated versions.
+installed workflows still satisfy the approval-gate contract of the packaged
+versions (contract-intact customizations, such as a different model backend,
+pass with a warning; only drift that breaks the gate is a hard failure).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "daydream"
-version = "0.26.0"
+version = "0.27.0"
 description = "Automated code review and fix loop using Claude"
 requires-python = ">=3.12.13"
 dependencies = [

--- a/tests/test_bot_setup_integration.py
+++ b/tests/test_bot_setup_integration.py
@@ -198,7 +198,7 @@ def test_verify_healthy_install_passes_all_checks(
 
 
 def test_verify_rejects_outdated_workflow_file(fake_gh: FakeGh, repo_with_origin: Path) -> None:
-    """A present but stale workflow fails the doctor byte comparison."""
+    """A present but stale workflow — one that lost the approval gate — fails the doctor."""
     from daydream.templates import workflow_template_files
     from tests.conftest import _commit, _git
 
@@ -207,7 +207,13 @@ def test_verify_rejects_outdated_workflow_file(fake_gh: FakeGh, repo_with_origin
     for template in workflow_template_files():
         content = template.read_text()
         if template.name == "daydream-review.yml":
-            content += "\n# stale installed copy\n"
+            # Pre-gate shape: auto-triggers on PR open instead of binding an
+            # approved head, re-opening the unapproved-review hole.
+            content = content.replace(
+                "on:\n  workflow_dispatch:",
+                "on:\n  pull_request:\n    types: [opened, ready_for_review]\n  workflow_dispatch:",
+                1,
+            )
         (workflows_dir / template.name).write_text(content)
     _git(repo_with_origin, "add", ".github/workflows")
     _commit(repo_with_origin, "add stale workflows")
@@ -218,6 +224,67 @@ def test_verify_rejects_outdated_workflow_file(fake_gh: FakeGh, repo_with_origin
     assert result.ok is False
     assert workflows_check.passed is False
     assert "daydream-review.yml" in workflows_check.detail
+
+
+def test_verify_accepts_customized_workflow_with_intact_gate(
+    fake_gh: FakeGh, repo_with_origin: Path
+) -> None:
+    """A divergent-but-gated workflow (e.g. a different backend) passes with a warning."""
+    fake_gh.serve_secret_list(list(config.SETUP_SECRET_NAMES))
+    fake_gh.serve_variable_list([config.BOT_HANDLE_VAR])
+    from daydream.templates import workflow_template_files
+    from tests.conftest import _commit, _git
+
+    workflows_dir = repo_with_origin / ".github/workflows"
+    workflows_dir.mkdir(parents=True)
+    for template in workflow_template_files():
+        content = template.read_text()
+        if template.name == "daydream-review.yml":
+            # Backend-variant customization: the gate (approved_head_sha input,
+            # no pull_request trigger) is intact, credential/backend swapped.
+            content = content.replace("ANTHROPIC_API_KEY", "OPENAI_API_KEY")
+        (workflows_dir / template.name).write_text(content)
+    _git(repo_with_origin, "add", ".github/workflows")
+    _commit(repo_with_origin, "add customized workflows")
+    _git(repo_with_origin, "push", "origin", "main")
+
+    result = bot_setup.run_verify(repo_with_origin, scope=bot_setup.Scope(repo="o/r"))
+    workflows_check = next(check for check in result.checks if check.name == "workflows")
+    assert result.ok is True
+    assert workflows_check.passed is True
+    assert "daydream-review.yml" in workflows_check.detail
+    assert "intentionally unsupported" in workflows_check.detail
+
+
+def test_land_workflows_warns_before_overwriting_customized_workflow(
+    fake_gh: FakeGh, repo_with_origin: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """land_workflows warns that customization is unsupported before replacing it."""
+    from daydream.templates import workflow_template_files
+    from tests.conftest import _commit, _git
+
+    workflows_dir = repo_with_origin / ".github/workflows"
+    workflows_dir.mkdir(parents=True)
+    for template in workflow_template_files():
+        content = template.read_text()
+        if template.name == "daydream-review.yml":
+            content = content.replace("ANTHROPIC_API_KEY", "OPENAI_API_KEY")
+        (workflows_dir / template.name).write_text(content)
+    _git(repo_with_origin, "add", ".github/workflows")
+    _commit(repo_with_origin, "add customized workflows")
+
+    warnings: list[str] = []
+    monkeypatch.setattr("daydream.bot_setup.print_warning", lambda console, msg: warnings.append(msg))
+    fake_gh.set_response("pr-create", value="https://github.com/o/r/pull/5")
+    fake_gh.set_response("pr-list", value=[])
+
+    review_template = next(t for t in workflow_template_files() if t.name == "daydream-review.yml")
+    url = bot_setup.land_workflows(repo_with_origin, branch="daydream/setup-bot")
+
+    assert url != bot_setup.WORKFLOWS_ALREADY_INSTALLED
+    assert any("daydream-review.yml" in w and "intentionally unsupported" in w for w in warnings)
+    # The customization was replaced by the packaged template on the branch.
+    assert (workflows_dir / "daydream-review.yml").read_text() == review_template.read_text()
 
 
 # --- Task 9: CLI `setup` verb + run_setup orchestrator ----------------------

--- a/tests/test_bot_setup_integration.py
+++ b/tests/test_bot_setup_integration.py
@@ -42,6 +42,11 @@ def test_callback_listener_captures_code_then_exchanges(monkeypatch):
     assert slug == "acme-bot"
 
 
+def test_manifest_events_exclude_pull_request() -> None:
+    """The App subscribes only to events consumed by approval-gated workflows."""
+    assert bot_setup._MANIFEST_EVENTS == ("issue_comment", "workflow_run")
+
+
 def test_app_manifest_requests_issue_write_for_improve_publication() -> None:
     manifest = bot_setup._manifest_payload(
         redirect_url="http://localhost:8080/callback",
@@ -190,6 +195,29 @@ def test_verify_healthy_install_passes_all_checks(
     assert all(c.passed for c in result.checks)
     # The App-installed check actually consulted the installations endpoint.
     assert fake_gh.calls("GET", "/app/installations")
+
+
+def test_verify_rejects_outdated_workflow_file(fake_gh: FakeGh, repo_with_origin: Path) -> None:
+    """A present but stale workflow fails the doctor byte comparison."""
+    from daydream.templates import workflow_template_files
+    from tests.conftest import _commit, _git
+
+    workflows_dir = repo_with_origin / ".github/workflows"
+    workflows_dir.mkdir(parents=True)
+    for template in workflow_template_files():
+        content = template.read_text()
+        if template.name == "daydream-review.yml":
+            content += "\n# stale installed copy\n"
+        (workflows_dir / template.name).write_text(content)
+    _git(repo_with_origin, "add", ".github/workflows")
+    _commit(repo_with_origin, "add stale workflows")
+    _git(repo_with_origin, "push", "origin", "main")
+
+    result = bot_setup.run_verify(repo_with_origin, scope=bot_setup.Scope(repo="o/r"))
+    workflows_check = next(check for check in result.checks if check.name == "workflows")
+    assert result.ok is False
+    assert workflows_check.passed is False
+    assert "daydream-review.yml" in workflows_check.detail
 
 
 # --- Task 9: CLI `setup` verb + run_setup orchestrator ----------------------

--- a/tests/test_bot_setup_integration.py
+++ b/tests/test_bot_setup_integration.py
@@ -223,7 +223,11 @@ def test_verify_rejects_outdated_workflow_file(fake_gh: FakeGh, repo_with_origin
     workflows_check = next(check for check in result.checks if check.name == "workflows")
     assert result.ok is False
     assert workflows_check.passed is False
-    assert "daydream-review.yml" in workflows_check.detail
+    # Pin the *outdated* failure mode: the file is present but stale, so the
+    # detail must name it under "Out of date" — not under "Missing" (which
+    # would also contain the filename and pass these assertions otherwise).
+    assert "Out of date workflow file(s): .github/workflows/daydream-review.yml" in workflows_check.detail
+    assert "Missing workflow file(s)" not in workflows_check.detail
 
 
 def test_verify_accepts_customized_workflow_with_intact_gate(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,18 @@ from daydream.config_file import DaydreamFileConfig
 from daydream.runner import RunConfig, _resolved_backend_name, _resolved_model
 
 
+def test_approved_head_sha_flag_populates_config(monkeypatch):
+    """--approved-head-sha pins config.approved_head_sha (no normalization)."""
+    monkeypatch.setattr(sys, "argv", ["daydream", "--review", "--approved-head-sha", "a" * 40, "/tmp/repo"])
+    config = _parse_args()
+    assert config.approved_head_sha == "a" * 40
+
+
+def test_approved_head_sha_defaults_none(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["daydream", "--review", "/tmp/repo"])
+    assert _parse_args().approved_head_sha is None
+
+
 def test_default_backend_is_none_and_resolves_to_claude(monkeypatch):
     # --backend default is now None so the config file can supply it; the
     # terminal fallback in _resolved_backend_name is "claude".

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -212,6 +212,52 @@ async def test_run_dispatches_to_expected_flow(
 
 
 @pytest.mark.asyncio
+async def test_run_rejects_head_mismatch_before_dispatch(
+    monkeypatch, patch_workspace, silence_runner_ui, tmp_path, make_config,
+):
+    """Head drift: run() returns 1 and no flow is dispatched."""
+    called: list[str] = []
+
+    def _record(name: str):
+        async def stub(work, config):
+            called.append(name)
+            return 0
+
+        return stub
+
+    for name in _DISPATCH_TARGETS:
+        monkeypatch.setattr(f"daydream.runner.{name}", _record(name))
+
+    config = make_config(tmp_path, approved_head_sha="DEADBEEF")
+    exit_code = await runner.run(config)
+    assert exit_code == 1
+    assert called == []
+
+
+@pytest.mark.asyncio
+async def test_run_allows_matching_approved_head(
+    monkeypatch, patch_workspace, silence_runner_ui, tmp_path, make_config,
+):
+    """Matching approved head: run() proceeds to the expected flow."""
+    called: list[str] = []
+
+    def _record(name: str):
+        async def stub(work, config):
+            called.append(name)
+            return 0
+
+        return stub
+
+    for name in _DISPATCH_TARGETS:
+        monkeypatch.setattr(f"daydream.runner.{name}", _record(name))
+
+    config = make_config(tmp_path, approved_head_sha="CAFEBABE")
+    exit_code = await runner.run(config)
+    assert exit_code == 0
+    assert called == ["_run_loop_deep"]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("flow_name", [None, "deep"], ids=["default_deep", "explicit_deep"])
 async def test_deep_run_mints_app_identity_before_posting_path(
     flow_name: str | None,

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -258,6 +258,68 @@ async def test_run_allows_matching_approved_head(
 
 
 @pytest.mark.asyncio
+async def test_run_rejects_head_mismatch_on_real_worktree(
+    monkeypatch, silence_runner_ui, deep_target, make_config,
+):
+    """Head drift on a real checkout: run() returns 1 and no flow is dispatched.
+
+    Unlike the stub-based gate tests above (``patch_workspace`` yields a
+    synthetic ``WorkContext`` with a hardcoded fake ``head_sha``), this drives
+    ``open_workspace`` -> ``git_ops.head_sha`` for real, so a regression in
+    the workspace plumbing surfaces as a failing gate instead of a silent
+    no-op on real checkouts.
+    """
+    called: list[str] = []
+
+    def _record(name: str):
+        async def stub(work, config):
+            called.append(name)
+            return 0
+
+        return stub
+
+    for name in _DISPATCH_TARGETS:
+        monkeypatch.setattr(f"daydream.runner.{name}", _record(name))
+
+    config = make_config(deep_target, approved_head_sha="DEADBEEF")
+    exit_code = await runner.run(config)
+    assert exit_code == 1
+    assert called == []
+
+
+@pytest.mark.asyncio
+async def test_run_allows_matching_approved_head_on_real_worktree(
+    monkeypatch, silence_runner_ui, deep_target, make_config,
+):
+    """Matching approved head on a real checkout: run() proceeds to the flow.
+
+    The dispatch stub records the ``WorkContext`` the real ``open_workspace``
+    built, proving ``work.head_sha`` came from ``git rev-parse HEAD`` on the
+    actual repo and not from a synthetic context.
+    """
+    called: list[str] = []
+    head_shas: list[str] = []
+
+    def _record(name: str):
+        async def stub(work, config):
+            called.append(name)
+            head_shas.append(work.head_sha)
+            return 0
+
+        return stub
+
+    for name in _DISPATCH_TARGETS:
+        monkeypatch.setattr(f"daydream.runner.{name}", _record(name))
+
+    real_head = _git(deep_target, "rev-parse", "HEAD").strip()
+    config = make_config(deep_target, approved_head_sha=real_head)
+    exit_code = await runner.run(config)
+    assert exit_code == 0
+    assert called == ["_run_loop_deep"]
+    assert head_shas == [real_head]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("flow_name", [None, "deep"], ids=["default_deep", "explicit_deep"])
 async def test_deep_run_mints_app_identity_before_posting_path(
     flow_name: str | None,

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -171,6 +171,50 @@ def test_template_command_workflow_dispatches_approved_head() -> None:
 
 @pytest.mark.parametrize(
     "wf_path",
+    [TEMPLATES_DIR / "daydream-command.yml", REPO_WORKFLOWS_DIR / "daydream-command.yml"],
+    ids=["template", "live"],
+)
+def test_command_workflow_acknowledges_only_after_successful_dispatch(wf_path: Path) -> None:
+    """The 👀 acknowledgement must come after the dispatch step and stay gated
+    on its success. A failed dispatch (unresolvable head SHA or a `gh workflow
+    run` error) creates no Daydream Review run, so surface-analyze-failure
+    never fires and nothing surfaces on the PR — a reaction posted before or
+    regardless of the dispatch outcome would mis-signal success. The step
+    ordering IS the mechanism, so a reordering that moves the ack above the
+    dispatch (or drops its success gate) must fail here.
+    """
+    wf = load_workflow(wf_path)
+    steps = job_steps(wf, "dispatch")
+    dispatch = next(
+        step
+        for step in steps
+        if "gh workflow run daydream-review.yml" in step.get("run", "")
+    )
+    ack = next(step for step in steps if step.get("name") == "Acknowledge with eyes reaction")
+
+    # The ack must follow the dispatch in step order.
+    assert steps.index(dispatch) < steps.index(ack), (
+        f"{wf_path.name}: the 👀 acknowledgement must come after the dispatch step "
+        "so a dispatch failure never mis-signals success"
+    )
+
+    # The ack's if: must keep GitHub's implicit success() gate — no status
+    # function (always()/failure()/cancelled()) may let it run after a failed
+    # dispatch, and the dispatch step may not continue-on-error (which would
+    # keep the job alive past its failure and still post the reaction).
+    ack_if = ack.get("if", "")
+    assert not any(fn in ack_if for fn in ("always()", "failure()", "cancelled()")), (
+        f"{wf_path.name}: the acknowledgement must stay gated on dispatch success "
+        "(its if: must keep GitHub's implicit success())"
+    )
+    assert "continue-on-error" not in dispatch, (
+        f"{wf_path.name}: the dispatch step must not continue-on-error, or a failed "
+        "dispatch would still post the 👀 reaction"
+    )
+
+
+@pytest.mark.parametrize(
+    "wf_path",
     [TEMPLATES_DIR / "daydream-review.yml", REPO_WORKFLOWS_DIR / "daydream-review.yml"],
     ids=["template", "live"],
 )
@@ -193,7 +237,14 @@ def test_review_workflow_head_bound_gate(wf_path: Path) -> None:
         for step in steps
         if "approved_head_sha" in step.get("run", "") and "exit 1" in step.get("run", "")
     )
-    assert "head.repo.pushed_at" in verify["run"]
+    # The drift gate anchors on the approved commit's push time scoped to the
+    # PR's head ref (the head repository's activity feed), not the repo-wide
+    # head.repo.pushed_at, and rejects a push at-or-after the comment: the
+    # second-granularity timestamps cannot distinguish a same-second push, so
+    # equality must fail closed (\< strict-before guard) rather than pass.
+    assert ".head.ref" in verify["run"]
+    assert "activity" in verify["run"]
+    assert r'\< "$APPROVED_AT"' in verify["run"]
     assert "APPROVED_AT" in verify["env"]
     checkout_idx = next(i for i, step in enumerate(steps) if "actions/checkout" in step.get("uses", ""))
     assert steps.index(verify) < checkout_idx
@@ -236,12 +287,14 @@ def test_review_workflow_persists_failure_context(wf_path: Path) -> None:
     wf = load_workflow(wf_path)
     steps = job_steps(wf, "analyze")
 
-    # The drift gate records the failure context (pr_number + the instructive
-    # message) before exiting in EVERY rejection branch — head changed,
-    # unresolvable commit date, commit newer than the approving comment — so
-    # surface-analyze-failure comments the instructive message on the PR
-    # (issue #336). A rejection that exits without the write would degrade the
-    # comment to the generic fallback body.
+    # The drift gate funnels every rejection through one helper that records
+    # the failure context (pr_number + the instructive message) before exiting
+    # — head changed, unresolvable push time, push at-or-after the approving
+    # comment — so surface-analyze-failure comments the instructive message on
+    # the PR (issue #336). A rejection that exits without the write would
+    # degrade the comment to the generic fallback body. The single write/exit
+    # point lives in the helper, so a new rejection branch only has to call it
+    # (rather than re-triplicating the mkdir/printf/exit skeleton).
     verify = next(
         step
         for step in steps
@@ -250,20 +303,21 @@ def test_review_workflow_persists_failure_context(wf_path: Path) -> None:
     lines = verify["run"].splitlines()
     write_idx = [i for i, ln in enumerate(lines) if "> findings/failure.json" in ln]
     exit_idx = [i for i, ln in enumerate(lines) if ln.strip() == "exit 1"]
-    assert len(exit_idx) >= 3, (
-        f"{wf_path.name}: drift gate must reject head changes, unresolvable "
-        "commit dates, and commits newer than the approving comment"
+    reject_calls = [i for i, ln in enumerate(lines) if re.match(r"reject \"", ln.strip())]
+    assert len(write_idx) == 1 and len(exit_idx) == 1, (
+        f"{wf_path.name}: every drift rejection must funnel through the single "
+        "failure-context helper (one write, one exit) (issue #336)"
     )
-    assert len(write_idx) == len(exit_idx), (
-        f"{wf_path.name}: every drift-rejection branch must record the failure "
-        "context before exiting (issue #336)"
+    assert write_idx[0] < exit_idx[0], (
+        f"{wf_path.name}: the helper must record the failure context before exiting"
     )
-    assert all('"message"' in lines[i] for i in write_idx), (
-        f"{wf_path.name}: each recorded failure context must carry the "
+    assert '"message"' in lines[write_idx[0]], (
+        f"{wf_path.name}: the recorded failure context must carry the "
         "instructive message (issue #336)"
     )
-    assert all(wi < ei for wi, ei in zip(write_idx, exit_idx)), (
-        f"{wf_path.name}: the failure context must be recorded before the branch exits"
+    assert len(reject_calls) >= 3, (
+        f"{wf_path.name}: the drift gate must reject head changes, unresolvable "
+        "push times, and pushes at/after the approving comment"
     )
 
     # Any other failure still records the PR number via the job-level handler.
@@ -330,14 +384,43 @@ def test_single_workflow_head_bound_gate() -> None:
     assert "approved_head_sha" in decide.get("outputs", {}) or "head.sha" in decide.get("run", "")
     assert "approved_at" in decide.get("outputs", {}) or "approved_at=" in decide.get("run", "")
 
+    # Acknowledge only AFTER head resolution succeeds (mirroring the split
+    # workflow's ack-after-dispatch ordering): a fallible gh api exit in the
+    # decide step must abort the job before the ack, so a transient
+    # head-resolution failure surfaces as a failed run rather than a 👀 with no
+    # review or comment (issue #336).
+    ack = next(step for step in gate["steps"] if step.get("name") == "Acknowledge with eyes reaction")
+    assert gate["steps"].index(ack) > gate["steps"].index(decide)
+
     steps = wf["jobs"]["analyze"]["steps"]
     verify = next(
         step
         for step in steps
         if "approved_head_sha" in step.get("run", "") and "exit 1" in step.get("run", "")
     )
-    assert "head.repo.pushed_at" in verify["run"]
+    assert ".head.ref" in verify["run"]
+    assert "activity" in verify["run"]
+    assert r'\< "$APPROVED_AT"' in verify["run"]
     assert "APPROVED_AT" in wf["jobs"]["analyze"]["env"]
+
+    # The drift gate funnels every rejection through one helper that records
+    # the failure context (pr_number + the instructive message) before exiting
+    # — head changed, unresolvable push time, push at-or-after the approving
+    # comment — so surface-failure comments the instructive message instead of
+    # the generic fallback body (issue #336). The single write/exit point lives
+    # in the helper, so a new rejection branch only has to call it.
+    lines = verify["run"].splitlines()
+    write_idx = [i for i, ln in enumerate(lines) if "> findings/failure.json" in ln]
+    exit_idx = [i for i, ln in enumerate(lines) if ln.strip() == "exit 1"]
+    reject_calls = [i for i, ln in enumerate(lines) if re.match(r"reject \"", ln.strip())]
+    assert len(write_idx) == 1 and len(exit_idx) == 1, (
+        "single/daydream.yml: every drift rejection must funnel through the "
+        "single failure-context helper (one write, one exit) (issue #336)"
+    )
+    assert write_idx[0] < exit_idx[0]
+    assert '"message"' in lines[write_idx[0]]
+    assert len(reject_calls) >= 3
+
     checkout_idx = next(i for i, step in enumerate(steps) if "actions/checkout" in step.get("uses", ""))
     assert steps.index(verify) < checkout_idx
     review = next(

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -223,6 +223,34 @@ def test_template_review_workflow_head_bound_gate() -> None:
     assert set(_SECRET_REF_RE.findall(text)) == {"ANTHROPIC_API_KEY"}
 
 
+def test_single_workflow_head_bound_gate() -> None:
+    """The single-file setup is comment-only and enforces the approved head."""
+    path = TEMPLATES_DIR / "single" / "daydream.yml"
+    wf = load_workflow(path)
+
+    assert "pull_request" not in _wf_triggers(wf)
+
+    gate = wf["jobs"]["gate"]
+    assert "approved_head_sha" in gate["outputs"]
+    decide = next(step for step in gate["steps"] if step.get("name") == "Decide and resolve PR")
+    assert "approved_head_sha" in decide.get("outputs", {}) or "head.sha" in decide.get("run", "")
+
+    steps = wf["jobs"]["analyze"]["steps"]
+    verify = next(
+        step
+        for step in steps
+        if "approved_head_sha" in step.get("run", "") and "exit 1" in step.get("run", "")
+    )
+    checkout_idx = next(i for i, step in enumerate(steps) if "actions/checkout" in step.get("uses", ""))
+    assert steps.index(verify) < checkout_idx
+    review = next(
+        step
+        for step in steps
+        if "daydream" in step.get("run", "") and "--approved-head-sha" in step.get("run", "")
+    )
+    assert "APPROVED_HEAD_SHA" in review["env"]
+
+
 @pytest.mark.parametrize("wf_path", sorted(TEMPLATES_DIR.rglob("*.yml")), ids=lambda p: p.name)
 def test_no_event_data_interpolated_into_run_steps(wf_path: Path) -> None:
     wf = load_workflow(wf_path)

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -59,6 +59,14 @@ def job_steps(wf: dict[str, Any], job: str) -> list[dict[str, Any]]:
     return steps
 
 
+def _wf_triggers(wf: dict[str, Any]) -> dict[str, Any]:
+    """Return the ``on:`` trigger map, normalizing PyYAML's boolean key."""
+    on = wf.get("on")
+    if on is None and True in wf and isinstance(wf[True], dict):
+        on = wf[True]
+    return on if isinstance(on, dict) else {}
+
+
 def has_checkout(job: dict[str, Any]) -> bool:
     return any("actions/checkout" in s.get("uses", "") for s in job["steps"])
 
@@ -121,6 +129,25 @@ def _action_references(wf: dict[str, Any]) -> list[str]:
 # shell.
 
 _EVENT_INTERP = re.compile(r"\$\{\{[^}]*github\.event\.(comment|issue|pull_request|workflow_run|review)[^}]*\}\}")
+
+
+def test_command_workflows_dispatch_approved_head() -> None:
+    """The live trusted command workflow binds the PR head at approval time."""
+    path = REPO_WORKFLOWS_DIR / "daydream-command.yml"
+    wf = load_workflow(path)
+    dispatch = next(
+        step
+        for step in job_steps(wf, "dispatch")
+        if "gh workflow run daydream-review.yml" in step.get("run", "")
+    )
+
+    assert "gh api" in dispatch["run"] and ".head.sha" in dispatch["run"]
+    assert '-f approved_head_sha="$HEAD_SHA"' in dispatch["run"]
+    assert "PR_NUMBER" in dispatch["env"]
+    assert not any(
+        _EVENT_INTERP.search(step.get("run", ""))
+        for step in job_steps(wf, "dispatch")
+    )
 
 
 @pytest.mark.parametrize("wf_path", sorted(TEMPLATES_DIR.rglob("*.yml")), ids=lambda p: p.name)

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -143,7 +143,9 @@ def test_command_workflows_dispatch_approved_head() -> None:
 
     assert "gh api" in dispatch["run"] and ".head.sha" in dispatch["run"]
     assert '-f approved_head_sha="$HEAD_SHA"' in dispatch["run"]
+    assert '-f approved_at="$COMMENT_CREATED_AT"' in dispatch["run"]
     assert "PR_NUMBER" in dispatch["env"]
+    assert "COMMENT_CREATED_AT" in dispatch["env"]
     assert not any(
         _EVENT_INTERP.search(step.get("run", ""))
         for step in job_steps(wf, "dispatch")
@@ -160,8 +162,10 @@ def test_template_command_workflow_dispatches_approved_head() -> None:
         if "gh workflow run daydream-review.yml" in step.get("run", "")
     )
     assert "approved_head_sha" in dispatch["run"]
+    assert "approved_at" in dispatch["run"]
     assert "gh api" in dispatch["run"] and ".head.sha" in dispatch["run"]
     assert "PR_NUMBER" in dispatch["env"]
+    assert "COMMENT_CREATED_AT" in dispatch["env"]
     assert "actions/checkout" not in path.read_text(encoding="utf-8")
 
 
@@ -172,6 +176,7 @@ def test_review_workflow_head_bound_gate() -> None:
     assert "pull_request" not in _wf_triggers(wf)
     inputs = _wf_triggers(wf)["workflow_dispatch"]["inputs"]
     assert "approved_head_sha" in inputs
+    assert "approved_at" in inputs
 
     steps = job_steps(wf, "analyze")
     verify = next(
@@ -179,6 +184,8 @@ def test_review_workflow_head_bound_gate() -> None:
         for step in steps
         if "approved_head_sha" in step.get("run", "") and "exit 1" in step.get("run", "")
     )
+    assert "commit.committer.date" in verify["run"]
+    assert "APPROVED_AT" in verify["env"]
     checkout_idx = next(i for i, step in enumerate(steps) if "actions/checkout" in step.get("uses", ""))
     assert steps.index(verify) < checkout_idx
 
@@ -206,6 +213,7 @@ def test_template_review_workflow_head_bound_gate() -> None:
     assert "pull_request" not in _wf_triggers(wf)
     inputs = _wf_triggers(wf)["workflow_dispatch"]["inputs"]
     assert "approved_head_sha" in inputs
+    assert "approved_at" in inputs
 
     steps = job_steps(wf, "analyze")
     verify = next(
@@ -213,6 +221,8 @@ def test_template_review_workflow_head_bound_gate() -> None:
         for step in steps
         if "approved_head_sha" in step.get("run", "") and "exit 1" in step.get("run", "")
     )
+    assert "commit.committer.date" in verify["run"]
+    assert "APPROVED_AT" in verify["env"]
     checkout_idx = next(i for i, step in enumerate(steps) if "actions/checkout" in step.get("uses", ""))
     assert steps.index(verify) < checkout_idx
 
@@ -221,6 +231,81 @@ def test_template_review_workflow_head_bound_gate() -> None:
     assert "APPROVED_HEAD_SHA" in review["env"]
     assert not any("auth.json" in step.get("run", "") for step in steps)
     assert set(_SECRET_REF_RE.findall(text)) == {"ANTHROPIC_API_KEY"}
+
+
+@pytest.mark.parametrize(
+    "wf_path",
+    [TEMPLATES_DIR / "daydream-review.yml", REPO_WORKFLOWS_DIR / "daydream-review.yml"],
+    ids=["template", "live"],
+)
+def test_review_workflow_persists_failure_context(wf_path: Path) -> None:
+    """A failed analyze run must leave the PR number where the post workflow can
+    resolve it: on any failure the analyze job records ``failure.json`` and
+    uploads it as ``daydream-findings-failure``, so surface-analyze-failure can
+    comment on the PR even though the workflow_run event cannot identify a
+    workflow_dispatch run's PR (issue #336).
+    """
+    wf = load_workflow(wf_path)
+    steps = job_steps(wf, "analyze")
+
+    # The drift gate records the failure context (pr_number + the instructive
+    # message) before exiting, so the rejection can be surfaced on the PR.
+    verify = next(
+        step
+        for step in steps
+        if "approved_head_sha" in step.get("run", "") and "exit 1" in step.get("run", "")
+    )
+    assert "failure.json" in verify["run"]
+    assert "message" in verify["run"]
+
+    # Any other failure still records the PR number via the job-level handler.
+    record = next(step for step in steps if step.get("name") == "Record failure context")
+    assert record.get("if", "") == "failure()"
+    assert "failure.json" in record["run"]
+
+    upload = next(step for step in steps if step.get("name") == "Upload failure context")
+    assert upload.get("if", "") == "failure()"
+    assert upload["uses"].startswith("actions/upload-artifact@")
+    assert upload["with"]["name"] == "daydream-findings-failure"
+    assert upload["with"]["path"] == "findings/failure.json"
+
+
+@pytest.mark.parametrize(
+    "wf_path",
+    [TEMPLATES_DIR / "daydream-post.yml", REPO_WORKFLOWS_DIR / "daydream-post.yml"],
+    ids=["template", "live"],
+)
+def test_surface_analyze_failure_resolves_dispatch_run_pr(wf_path: Path) -> None:
+    """surface-analyze-failure must resolve the PR of a failed workflow_dispatch
+    run from the failure-context artifact (the event cannot identify it) and
+    post the recorded message on the PR; an unresolvable run keeps the
+    warn-and-continue guard (issue #336).
+    """
+    wf = load_workflow(wf_path)
+    job = wf["jobs"]["surface-analyze-failure"]
+    steps = job["steps"]
+
+    # GITHUB_TOKEN needs actions: read for the cross-run artifact download
+    # (the App token carries the comment write).
+    effective_perms = job.get("permissions", wf.get("permissions", {}))
+    assert effective_perms == {"actions": "read"}
+
+    download = next(step for step in steps if step.get("name") == "Download failure context")
+    assert download["uses"].startswith("actions/download-artifact@")
+    assert download["with"]["name"] == "daydream-findings-failure"
+    assert "run-id" in download["with"]
+    assert "github-token" in download["with"]
+    assert download.get("continue-on-error") is True
+
+    comment = next(step for step in steps if step.get("name") == "Comment on the PR")
+    run = comment["run"]
+    assert "findings/failure.json" in run
+    assert ".pr_number // empty" in run
+    assert ".message // empty" in run
+    guard = 'echo "no PR resolvable for the failed analyze run; skipping comment" >&2'
+    assert guard in run
+    assert "exit 0" in run
+    assert run.index(guard) < run.index("exit 0")
 
 
 def test_single_workflow_head_bound_gate() -> None:
@@ -232,8 +317,10 @@ def test_single_workflow_head_bound_gate() -> None:
 
     gate = wf["jobs"]["gate"]
     assert "approved_head_sha" in gate["outputs"]
+    assert "approved_at" in gate["outputs"]
     decide = next(step for step in gate["steps"] if step.get("name") == "Decide and resolve PR")
     assert "approved_head_sha" in decide.get("outputs", {}) or "head.sha" in decide.get("run", "")
+    assert "approved_at" in decide.get("outputs", {}) or "approved_at=" in decide.get("run", "")
 
     steps = wf["jobs"]["analyze"]["steps"]
     verify = next(
@@ -241,6 +328,8 @@ def test_single_workflow_head_bound_gate() -> None:
         for step in steps
         if "approved_head_sha" in step.get("run", "") and "exit 1" in step.get("run", "")
     )
+    assert "commit.committer.date" in verify["run"]
+    assert "APPROVED_AT" in wf["jobs"]["analyze"]["env"]
     checkout_idx = next(i for i, step in enumerate(steps) if "actions/checkout" in step.get("uses", ""))
     assert steps.index(verify) < checkout_idx
     review = next(

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -169,9 +169,18 @@ def test_template_command_workflow_dispatches_approved_head() -> None:
     assert "actions/checkout" not in path.read_text(encoding="utf-8")
 
 
-def test_review_workflow_head_bound_gate() -> None:
-    """The live Codex review workflow requires an approved head and cleans up auth."""
-    wf = load_workflow(REPO_WORKFLOWS_DIR / "daydream-review.yml")
+@pytest.mark.parametrize(
+    "wf_path",
+    [TEMPLATES_DIR / "daydream-review.yml", REPO_WORKFLOWS_DIR / "daydream-review.yml"],
+    ids=["template", "live"],
+)
+def test_review_workflow_head_bound_gate(wf_path: Path) -> None:
+    """The review workflow is comment-only and enforces the approved head;
+    backend-specific auth handling differs between the packaged Anthropic
+    template and the repo's live Codex workflow.
+    """
+    wf = load_workflow(wf_path)
+    text = wf_path.read_text(encoding="utf-8")
 
     assert "pull_request" not in _wf_triggers(wf)
     inputs = _wf_triggers(wf)["workflow_dispatch"]["inputs"]
@@ -184,7 +193,7 @@ def test_review_workflow_head_bound_gate() -> None:
         for step in steps
         if "approved_head_sha" in step.get("run", "") and "exit 1" in step.get("run", "")
     )
-    assert "commit.committer.date" in verify["run"]
+    assert "head.repo.pushed_at" in verify["run"]
     assert "APPROVED_AT" in verify["env"]
     checkout_idx = next(i for i, step in enumerate(steps) if "actions/checkout" in step.get("uses", ""))
     assert steps.index(verify) < checkout_idx
@@ -193,44 +202,23 @@ def test_review_workflow_head_bound_gate() -> None:
     assert "--approved-head-sha" in review["run"]
     assert "APPROVED_HEAD_SHA" in review["env"]
 
-    cleanup = next(step for step in steps if "auth.json" in step.get("run", ""))
-    assert steps.index(review) < steps.index(cleanup)
-    assert cleanup.get("if", "") == "always()"
+    if wf_path == REPO_WORKFLOWS_DIR / "daydream-review.yml":
+        # Live Codex workflow: persisted codex auth is cleaned up after the review.
+        cleanup = next(step for step in steps if "auth.json" in step.get("run", ""))
+        assert steps.index(review) < steps.index(cleanup)
+        assert cleanup.get("if", "") == "always()"
+        assert set(_SECRET_REF_RE.findall(text)) == {"OPENAI_API_KEY"}
+    else:
+        # Packaged template: nothing persists auth, and the model credential is
+        # the only secret.
+        assert not any("auth.json" in step.get("run", "") for step in steps)
+        assert set(_SECRET_REF_RE.findall(text)) == {"ANTHROPIC_API_KEY"}
 
 
 def test_review_workflow_uses_only_model_credential() -> None:
     """The live review gate adds no secret beyond the model credential."""
     text = (REPO_WORKFLOWS_DIR / "daydream-review.yml").read_text(encoding="utf-8")
     assert set(_SECRET_REF_RE.findall(text)) == {"OPENAI_API_KEY"}
-
-
-def test_template_review_workflow_head_bound_gate() -> None:
-    """The packaged Anthropic review workflow enforces the head-bound gate."""
-    path = TEMPLATES_DIR / "daydream-review.yml"
-    wf = load_workflow(path)
-    text = path.read_text(encoding="utf-8")
-
-    assert "pull_request" not in _wf_triggers(wf)
-    inputs = _wf_triggers(wf)["workflow_dispatch"]["inputs"]
-    assert "approved_head_sha" in inputs
-    assert "approved_at" in inputs
-
-    steps = job_steps(wf, "analyze")
-    verify = next(
-        step
-        for step in steps
-        if "approved_head_sha" in step.get("run", "") and "exit 1" in step.get("run", "")
-    )
-    assert "commit.committer.date" in verify["run"]
-    assert "APPROVED_AT" in verify["env"]
-    checkout_idx = next(i for i, step in enumerate(steps) if "actions/checkout" in step.get("uses", ""))
-    assert steps.index(verify) < checkout_idx
-
-    review = next(step for step in steps if "daydream --review" in step.get("run", ""))
-    assert "--approved-head-sha" in review["run"]
-    assert "APPROVED_HEAD_SHA" in review["env"]
-    assert not any("auth.json" in step.get("run", "") for step in steps)
-    assert set(_SECRET_REF_RE.findall(text)) == {"ANTHROPIC_API_KEY"}
 
 
 @pytest.mark.parametrize(
@@ -249,14 +237,34 @@ def test_review_workflow_persists_failure_context(wf_path: Path) -> None:
     steps = job_steps(wf, "analyze")
 
     # The drift gate records the failure context (pr_number + the instructive
-    # message) before exiting, so the rejection can be surfaced on the PR.
+    # message) before exiting in EVERY rejection branch — head changed,
+    # unresolvable commit date, commit newer than the approving comment — so
+    # surface-analyze-failure comments the instructive message on the PR
+    # (issue #336). A rejection that exits without the write would degrade the
+    # comment to the generic fallback body.
     verify = next(
         step
         for step in steps
         if "approved_head_sha" in step.get("run", "") and "exit 1" in step.get("run", "")
     )
-    assert "failure.json" in verify["run"]
-    assert "message" in verify["run"]
+    lines = verify["run"].splitlines()
+    write_idx = [i for i, ln in enumerate(lines) if "> findings/failure.json" in ln]
+    exit_idx = [i for i, ln in enumerate(lines) if ln.strip() == "exit 1"]
+    assert len(exit_idx) >= 3, (
+        f"{wf_path.name}: drift gate must reject head changes, unresolvable "
+        "commit dates, and commits newer than the approving comment"
+    )
+    assert len(write_idx) == len(exit_idx), (
+        f"{wf_path.name}: every drift-rejection branch must record the failure "
+        "context before exiting (issue #336)"
+    )
+    assert all('"message"' in lines[i] for i in write_idx), (
+        f"{wf_path.name}: each recorded failure context must carry the "
+        "instructive message (issue #336)"
+    )
+    assert all(wi < ei for wi, ei in zip(write_idx, exit_idx)), (
+        f"{wf_path.name}: the failure context must be recorded before the branch exits"
+    )
 
     # Any other failure still records the PR number via the job-level handler.
     record = next(step for step in steps if step.get("name") == "Record failure context")
@@ -328,7 +336,7 @@ def test_single_workflow_head_bound_gate() -> None:
         for step in steps
         if "approved_head_sha" in step.get("run", "") and "exit 1" in step.get("run", "")
     )
-    assert "commit.committer.date" in verify["run"]
+    assert "head.repo.pushed_at" in verify["run"]
     assert "APPROVED_AT" in wf["jobs"]["analyze"]["env"]
     checkout_idx = next(i for i, step in enumerate(steps) if "actions/checkout" in step.get("uses", ""))
     assert steps.index(verify) < checkout_idx

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -182,6 +182,32 @@ def test_review_workflow_uses_only_model_credential() -> None:
     assert set(_SECRET_REF_RE.findall(text)) == {"OPENAI_API_KEY"}
 
 
+def test_template_review_workflow_head_bound_gate() -> None:
+    """The packaged Anthropic review workflow enforces the head-bound gate."""
+    path = TEMPLATES_DIR / "daydream-review.yml"
+    wf = load_workflow(path)
+    text = path.read_text(encoding="utf-8")
+
+    assert "pull_request" not in _wf_triggers(wf)
+    inputs = _wf_triggers(wf)["workflow_dispatch"]["inputs"]
+    assert "approved_head_sha" in inputs
+
+    steps = job_steps(wf, "analyze")
+    verify = next(
+        step
+        for step in steps
+        if "approved_head_sha" in step.get("run", "") and "exit 1" in step.get("run", "")
+    )
+    checkout_idx = next(i for i, step in enumerate(steps) if "actions/checkout" in step.get("uses", ""))
+    assert steps.index(verify) < checkout_idx
+
+    review = next(step for step in steps if "daydream --review" in step.get("run", ""))
+    assert "--approved-head-sha" in review["run"]
+    assert "APPROVED_HEAD_SHA" in review["env"]
+    assert not any("auth.json" in step.get("run", "") for step in steps)
+    assert set(_SECRET_REF_RE.findall(text)) == {"ANTHROPIC_API_KEY"}
+
+
 @pytest.mark.parametrize("wf_path", sorted(TEMPLATES_DIR.rglob("*.yml")), ids=lambda p: p.name)
 def test_no_event_data_interpolated_into_run_steps(wf_path: Path) -> None:
     wf = load_workflow(wf_path)

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -150,6 +150,21 @@ def test_command_workflows_dispatch_approved_head() -> None:
     )
 
 
+def test_template_command_workflow_dispatches_approved_head() -> None:
+    """The packaged command template binds the PR head at approval time."""
+    path = TEMPLATES_DIR / "daydream-command.yml"
+    wf = load_workflow(path)
+    dispatch = next(
+        step
+        for step in job_steps(wf, "dispatch")
+        if "gh workflow run daydream-review.yml" in step.get("run", "")
+    )
+    assert "approved_head_sha" in dispatch["run"]
+    assert "gh api" in dispatch["run"] and ".head.sha" in dispatch["run"]
+    assert "PR_NUMBER" in dispatch["env"]
+    assert "actions/checkout" not in path.read_text(encoding="utf-8")
+
+
 def test_review_workflow_head_bound_gate() -> None:
     """The live Codex review workflow requires an approved head and cleans up auth."""
     wf = load_workflow(REPO_WORKFLOWS_DIR / "daydream-review.yml")

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -150,6 +150,38 @@ def test_command_workflows_dispatch_approved_head() -> None:
     )
 
 
+def test_review_workflow_head_bound_gate() -> None:
+    """The live Codex review workflow requires an approved head and cleans up auth."""
+    wf = load_workflow(REPO_WORKFLOWS_DIR / "daydream-review.yml")
+
+    assert "pull_request" not in _wf_triggers(wf)
+    inputs = _wf_triggers(wf)["workflow_dispatch"]["inputs"]
+    assert "approved_head_sha" in inputs
+
+    steps = job_steps(wf, "analyze")
+    verify = next(
+        step
+        for step in steps
+        if "approved_head_sha" in step.get("run", "") and "exit 1" in step.get("run", "")
+    )
+    checkout_idx = next(i for i, step in enumerate(steps) if "actions/checkout" in step.get("uses", ""))
+    assert steps.index(verify) < checkout_idx
+
+    review = next(step for step in steps if "daydream --review" in step.get("run", ""))
+    assert "--approved-head-sha" in review["run"]
+    assert "APPROVED_HEAD_SHA" in review["env"]
+
+    cleanup = next(step for step in steps if "auth.json" in step.get("run", ""))
+    assert steps.index(review) < steps.index(cleanup)
+    assert cleanup.get("if", "") == "always()"
+
+
+def test_review_workflow_uses_only_model_credential() -> None:
+    """The live review gate adds no secret beyond the model credential."""
+    text = (REPO_WORKFLOWS_DIR / "daydream-review.yml").read_text(encoding="utf-8")
+    assert set(_SECRET_REF_RE.findall(text)) == {"OPENAI_API_KEY"}
+
+
 @pytest.mark.parametrize("wf_path", sorted(TEMPLATES_DIR.rglob("*.yml")), ids=lambda p: p.name)
 def test_no_event_data_interpolated_into_run_steps(wf_path: Path) -> None:
     wf = load_workflow(wf_path)

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 import re
 import tomllib
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 import yaml
@@ -61,9 +61,9 @@ def job_steps(wf: dict[str, Any], job: str) -> list[dict[str, Any]]:
 
 def _wf_triggers(wf: dict[str, Any]) -> dict[str, Any]:
     """Return the ``on:`` trigger map, normalizing PyYAML's boolean key."""
-    on = wf.get("on")
-    if on is None and True in wf and isinstance(wf[True], dict):
-        on = wf[True]
+    on: Any = wf.get("on")
+    if on is None:
+        on = cast(dict[Any, Any], wf).get(True)
     return on if isinstance(on, dict) else {}
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -196,7 +196,7 @@ wheels = [
 
 [[package]]
 name = "daydream"
-version = "0.26.0"
+version = "0.27.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary
Requires trusted, head-bound approval before credential-bearing Daydream PR reviews, closing the approval-time TOCTOU gap so a same-repo PR head cannot drift after an OWNER/MEMBER/COLLABORATOR approves it.

- Scope the approval push-time gate to the PR head ref (not repo-wide pushed_at)
- Strict-before (`<`) guard so a same-second push fails closed
- Single `reject()` failure-context helper records an instructive PR message in every drift branch
- Ack (eyes) after head resolution; contract check requires a live `$HEAD_SHA` binding
- Lazy `pyyaml` import so bot setup works on dev-dep-free installs
- Update the single-file and packaged command/review/Anthropic workflows, runner gate, and CLI flag
- Docs/CHANGELOG corrections (private-repo caveat, 0.27.0 entries, --verify wording) and real-worktree runner gate tests

## Test Plan
- `make check` green on final tree: 3460 passed, 6 skipped, exit 0 (lockcheck + lint + typecheck + test)
- Quality gate clean (no flagged files)

Two sequential daydream deep-precision reviews (rounds 1 and 2) passed on fresh exe.dev VMs. No CodeRabbit.

Closes #451
