### PR TITLE
fix(deep): handle unconfined parallel fix preflight rejection

### DIFF
--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -45,6 +45,7 @@ from daydream.agent import (
 )
 from daydream.benchmark.cli import _handle_bench_command
 from daydream.config_file import DaydreamFileConfig, load_file_config
+from daydream.phases import UnconfinedFindingError
 from daydream.runner import RunConfig, run, run_feedback
 from daydream.trajectory import get_signal_recorder
 from daydream.ui import (
@@ -1795,6 +1796,22 @@ def _handle_list_reanchor(config: RunConfig) -> int:
     return 0
 
 
+def _shutdown_and_exit(console, title: str, message: str) -> None:
+    """Finish the shutdown panel, print ``title``/``message``, and exit 1.
+
+    Shared by :func:`main`'s error handlers so the panel-finish sequence
+    (``get_shutdown_panel`` -> ``finish`` -> ``set_shutdown_panel(None)`` ->
+    ``console.print`` -> ``print_error`` -> ``sys.exit(1)``) lives in one place.
+    """
+    panel = get_shutdown_panel()
+    if panel is not None:
+        panel.finish()
+        set_shutdown_panel(None)
+    console.print()
+    print_error(console, title, message)
+    sys.exit(1)
+
+
 def main() -> None:
     """Run the CLI entry point.
 
@@ -1902,33 +1919,20 @@ def main() -> None:
         console.print()
         print_error(console, "Wrong Branch", str(exc))
         sys.exit(1)
-    except ValueError as e:
-        if str(e) != "Finding file must be a confined repository-relative path":
-            # Not the fix-preflight confinement rejection: re-raise so the
-            # generic handler below still owns every other error class.
-            raise
+    except UnconfinedFindingError as e:
         # Defense-in-depth fallback for the fix preflight confinement rejection
         # (the primary path routes it through ``_step_fix``'s recovery; this
-        # renders actionably if it ever escapes).
-        panel = get_shutdown_panel()
-        if panel is not None:
-            panel.finish()
-            set_shutdown_panel(None)
-        console.print()
-        print_error(
+        # renders actionably if it ever escapes). Matched by type, not by
+        # message, so a ValueError from elsewhere is never misattributed to an
+        # unconfined finding; any other ValueError falls through to the generic
+        # handler below.
+        _shutdown_and_exit(
             console,
             "Unconfined Finding",
             f"{e} Check the run's fix_failures artifact and the finding's file ref.",
         )
-        sys.exit(1)
     except Exception as e:
-        panel = get_shutdown_panel()
-        if panel is not None:
-            panel.finish()
-            set_shutdown_panel(None)
-        console.print()
-        print_error(console, "Fatal Error", str(e))
-        sys.exit(1)
+        _shutdown_and_exit(console, "Fatal Error", str(e))
 
 
 if __name__ == "__main__":

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -1925,11 +1925,13 @@ def main() -> None:
         # renders actionably if it ever escapes). Matched by type, not by
         # message, so a ValueError from elsewhere is never misattributed to an
         # unconfined finding; any other ValueError falls through to the generic
-        # handler below.
+        # handler below. The message must not cite the fix_failures artifact:
+        # that file is written only by ``_step_fix``'s recovery path, so when
+        # the exception escapes to here, no artifact exists.
         _shutdown_and_exit(
             console,
             "Unconfined Finding",
-            f"{e} Check the run's fix_failures artifact and the finding's file ref.",
+            f"{e}. Check the finding's file ref.",
         )
     except Exception as e:
         _shutdown_and_exit(console, "Fatal Error", str(e))

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -1902,6 +1902,25 @@ def main() -> None:
         console.print()
         print_error(console, "Wrong Branch", str(exc))
         sys.exit(1)
+    except ValueError as e:
+        if str(e) != "Finding file must be a confined repository-relative path":
+            # Not the fix-preflight confinement rejection: re-raise so the
+            # generic handler below still owns every other error class.
+            raise
+        # Defense-in-depth fallback for the fix preflight confinement rejection
+        # (the primary path routes it through ``_step_fix``'s recovery; this
+        # renders actionably if it ever escapes).
+        panel = get_shutdown_panel()
+        if panel is not None:
+            panel.finish()
+            set_shutdown_panel(None)
+        console.print()
+        print_error(
+            console,
+            "Unconfined Finding",
+            f"{e} Check the run's fix_failures artifact and the finding's file ref.",
+        )
+        sys.exit(1)
     except Exception as e:
         panel = get_shutdown_panel()
         if panel is not None:

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -101,6 +101,8 @@ from daydream.phases import (
     PER_STACK_RECORD_SCHEMA,
     CrossStackMergeError,
     FixResult,
+    UnconfinedFindingError,
+    _record_fix_failure,
     _resolve_finding_file_ref,
     _write_single_stack_merged_items,
     phase_alternative_review,
@@ -2640,7 +2642,7 @@ def _first_unconfined_finding(
     for item in items:
         try:
             _resolve_finding_file_ref(repo, item.get("file"))
-        except ValueError:
+        except UnconfinedFindingError:
             return item
     return None
 
@@ -2727,7 +2729,7 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
     changed_files = _resolve_changed_files(ctx)
     async with phase_scope(DaydreamPhase.FIX):
         try:
-            fix_failures = await phase_fix_parallel(
+            fix_failures: dict[str, str] = await phase_fix_parallel(
                 ctx.backend_for("fix"),
                 work,
                 items,
@@ -2736,24 +2738,25 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
                 group_max_serial_items=group_serial,
                 changed_files=changed_files,
             )
-        except ValueError as exc:
+        except UnconfinedFindingError as exc:
             # Issue #574: the phase's preflight confinement gate raises on an
             # unconfined/missing/non-string finding ``file`` ref. Route it
             # through the same exception-failure recovery below (patch capture,
             # fix_failures persistence, tree restore, generated-file reject,
             # Stop(1)) instead of letting it escape to cli.py's generic
-            # handler. The failure entry is keyed by the finding's STABLE id --
-            # never the unconfined path -- so the unsafe ref cannot become a
-            # grouping key or restore argument.
+            # handler. Only this exact type is caught so a ValueError from
+            # elsewhere inside phase_fix_parallel (e.g. a parser) is never
+            # misattributed to an unconfined finding. The failure entry is
+            # keyed by the finding's STABLE id -- never the unconfined path --
+            # so the unsafe ref cannot become a grouping key or restore
+            # argument.
             offender = _first_unconfined_finding(work.repo, items)
             offender_id = offender.get("id") if offender else None
             offender_file = offender.get("file") if offender else None
-            fix_failures = {
-                str(offender_id) if offender_id is not None else "<unconfined-finding>": (
-                    f"{type(exc).__name__}: {exc} (finding {offender_id}, "
-                    f"file {offender_file!r})"
-                )
-            }
+            fix_failures = {}
+            fix_key = str(offender_id) if offender_id is not None else "<unconfined-finding>"
+            _record_fix_failure(fix_failures, fix_key, exc)
+            fix_failures[fix_key] += f" (finding {offender_id}, file {offender_file!r})"
             print_warning(
                 console,
                 f"Fix preflight rejected an unconfined finding "

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -101,6 +101,7 @@ from daydream.phases import (
     PER_STACK_RECORD_SCHEMA,
     CrossStackMergeError,
     FixResult,
+    _resolve_finding_file_ref,
     _write_single_stack_merged_items,
     phase_alternative_review,
     phase_arbiter_review,
@@ -2625,6 +2626,25 @@ async def _evaluate_quality_gate(
             )
 
 
+def _first_unconfined_finding(
+    repo: Path, items: list[dict[str, Any]]
+) -> dict[str, Any] | None:
+    """Return the first item whose ``file`` ref the confinement gate rejects.
+
+    Mirrors ``_preflight_finding_file_refs``'s item order (items[0] first,
+    then the rest) and reuses the phase's own predicate
+    (``_resolve_finding_file_ref``) so there is no grammar drift between the
+    phase's preflight raise and this guard's offender identification.
+    Returns ``None`` when every item is confined.
+    """
+    for item in items:
+        try:
+            _resolve_finding_file_ref(repo, item.get("file"))
+        except ValueError:
+            return item
+    return None
+
+
 async def _step_fix(ctx: FlowContext) -> Stop | None:
     """Parallel fix pass: pre-fix snapshot capture, phase_fix_parallel, failure protection."""
     from daydream import git_ops
@@ -2706,15 +2726,39 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
     # crashes and the gate and post-fix residual net agree on the allowed set.
     changed_files = _resolve_changed_files(ctx)
     async with phase_scope(DaydreamPhase.FIX):
-        fix_failures = await phase_fix_parallel(
-            ctx.backend_for("fix"),
-            work,
-            items,
-            intent_path=intent_p if (intent_grounded_this_run and intent_p.exists()) else None,
-            group_max_wall_s=group_wall_s,
-            group_max_serial_items=group_serial,
-            changed_files=changed_files,
-        )
+        try:
+            fix_failures = await phase_fix_parallel(
+                ctx.backend_for("fix"),
+                work,
+                items,
+                intent_path=intent_p if (intent_grounded_this_run and intent_p.exists()) else None,
+                group_max_wall_s=group_wall_s,
+                group_max_serial_items=group_serial,
+                changed_files=changed_files,
+            )
+        except ValueError as exc:
+            # Issue #574: the phase's preflight confinement gate raises on an
+            # unconfined/missing/non-string finding ``file`` ref. Route it
+            # through the same exception-failure recovery below (patch capture,
+            # fix_failures persistence, tree restore, generated-file reject,
+            # Stop(1)) instead of letting it escape to cli.py's generic
+            # handler. The failure entry is keyed by the finding's STABLE id --
+            # never the unconfined path -- so the unsafe ref cannot become a
+            # grouping key or restore argument.
+            offender = _first_unconfined_finding(work.repo, items)
+            offender_id = offender.get("id") if offender else None
+            offender_file = offender.get("file") if offender else None
+            fix_failures = {
+                str(offender_id) if offender_id is not None else "<unconfined-finding>": (
+                    f"{type(exc).__name__}: {exc} (finding {offender_id}, "
+                    f"file {offender_file!r})"
+                )
+            }
+            print_warning(
+                console,
+                f"Fix preflight rejected an unconfined finding "
+                f"(finding {offender_id}, file {offender_file!r}); no fixes applied.",
+            )
     # Capture daydream's proposed diff (pre-fix tree → post-fix worktree)
     # NOW, before the fix-failure and test-failure early returns below, so
     # a run that generated a recommendation always archives it — even when

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -2647,6 +2647,41 @@ def _first_unconfined_finding(
     return None
 
 
+def _record_unconfined_finding_failure(
+    repo: Path,
+    items: list[dict[str, Any]],
+    exc: UnconfinedFindingError,
+) -> tuple[dict[str, str], str]:
+    """Record an unconfined-finding preflight rejection in ``fix_failures``.
+
+    ``phase_fix_parallel``'s confinement gate raises ``UnconfinedFindingError``
+    before dispatching any fix. This routes the rejection through the same
+    exception-failure recovery as a normal fix-group failure (patch capture,
+    fix_failures persistence, tree restore, generated-file reject, Stop(1))
+    instead of letting it escape to cli.py's generic handler.
+
+    The failure entry is keyed by the finding's STABLE id -- never the
+    unconfined path -- so the unsafe ref cannot become a grouping key or
+    restore argument. Returns the single-entry ``fix_failures`` dict along
+    with its key, so the caller can exclude the entry from path-based
+    tree-restore machinery: the id is not a repo-relative path, and the
+    preflight aborted before any dispatch, so no rollback is owed for it.
+    """
+    offender = _first_unconfined_finding(repo, items)
+    offender_id = offender.get("id") if offender else None
+    offender_file = offender.get("file") if offender else None
+    detail = f" (finding {offender_id}, file {offender_file!r})"
+    fix_key = str(offender_id) if offender_id is not None else "<unconfined-finding>"
+    fix_failures: dict[str, str] = {}
+    _record_fix_failure(fix_failures, fix_key, exc)
+    fix_failures[fix_key] += detail
+    print_warning(
+        console,
+        f"Fix preflight rejected an unconfined finding{detail}; no fixes applied.",
+    )
+    return fix_failures, fix_key
+
+
 async def _step_fix(ctx: FlowContext) -> Stop | None:
     """Parallel fix pass: pre-fix snapshot capture, phase_fix_parallel, failure protection."""
     from daydream import git_ops
@@ -2727,6 +2762,9 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
     # _resolve_changed_files (shared with the gate) so a missing key never
     # crashes and the gate and post-fix residual net agree on the allowed set.
     changed_files = _resolve_changed_files(ctx)
+    # Set when the preflight confinement gate aborts the fix pass; its
+    # id-keyed failure entry is excluded from path-based tree restore below.
+    unconfined_fix_key: str | None = None
     async with phase_scope(DaydreamPhase.FIX):
         try:
             fix_failures: dict[str, str] = await phase_fix_parallel(
@@ -2746,21 +2784,9 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
             # Stop(1)) instead of letting it escape to cli.py's generic
             # handler. Only this exact type is caught so a ValueError from
             # elsewhere inside phase_fix_parallel (e.g. a parser) is never
-            # misattributed to an unconfined finding. The failure entry is
-            # keyed by the finding's STABLE id -- never the unconfined path --
-            # so the unsafe ref cannot become a grouping key or restore
-            # argument.
-            offender = _first_unconfined_finding(work.repo, items)
-            offender_id = offender.get("id") if offender else None
-            offender_file = offender.get("file") if offender else None
-            fix_failures = {}
-            fix_key = str(offender_id) if offender_id is not None else "<unconfined-finding>"
-            _record_fix_failure(fix_failures, fix_key, exc)
-            fix_failures[fix_key] += f" (finding {offender_id}, file {offender_file!r})"
-            print_warning(
-                console,
-                f"Fix preflight rejected an unconfined finding "
-                f"(finding {offender_id}, file {offender_file!r}); no fixes applied.",
+            # misattributed to an unconfined finding.
+            fix_failures, unconfined_fix_key = _record_unconfined_finding_failure(
+                work.repo, items, exc
             )
     # Capture daydream's proposed diff (pre-fix tree → post-fix worktree)
     # NOW, before the fix-failure and test-failure early returns below, so
@@ -2791,11 +2817,14 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
 
     if exception_failures:
         # Only revert and abort for exception-failed groups; budget-exceeded
-        # groups' applied fixes are preserved and the run continues.
+        # groups' applied fixes are preserved and the run continues. The
+        # unconfined-finding entry (id-keyed, not a repo-relative path) is
+        # excluded: its preflight abort dispatched no fixes, and the id must
+        # never reach path-based restore machinery as a file path.
         _protect_tree_after_fix_failures(
             work,
             target_dir,
-            exception_failures,
+            {k: v for k, v in exception_failures.items() if k != unconfined_fix_key},
             snapshot=pre_fix_snapshot,
             snapshot_captured=pre_fix_snapshot_captured,
             pre_untracked=pre_fix_untracked,

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -1755,20 +1755,47 @@ def _build_verifier_suffix(item: dict[str, Any]) -> str:
     return out
 
 
+class UnconfinedFindingError(ValueError):
+    """A finding's ``file`` reference failed the fix preflight confinement gate.
+
+    Raised by ``_resolve_finding_file_ref`` (via the fix preflight) when a
+    finding's ``file`` value is missing/non-string or escapes the repository
+    (lexical violations, absolute paths, parent traversal, or symlink
+    escapes). Matched by type -- never by message -- so a ``ValueError`` from
+    elsewhere (e.g. a parser) is never misattributed to an unconfined finding
+    (issue #574). Callers either route it through the fix-failure recovery in
+    ``_step_fix`` or render it actionably in ``cli.main``.
+    """
+
+
+def _record_fix_failure(
+    fix_failures: dict[str, str],
+    fix_key: str,
+    exc: BaseException,
+) -> None:
+    """Record one exception-failed fix group in ``fix_failures``.
+
+    Writes ``"<ExceptionType>: <message>"`` under ``fix_key``, matching the
+    exception-entry format produced inside ``phase_fix_parallel`` so callers
+    can distinguish exception entries from budget stops by the prefix.
+    """
+    fix_failures[fix_key] = f"{type(exc).__name__}: {exc}"
+
+
 def _resolve_finding_file_ref(repo: Path, value: object) -> str:
     """Resolve a finding ``file`` reference to the string used in fix prompts.
 
     Confinement gate for every fix entry point: rejects non-string values
     (including ``None``/absent) and any reference that escapes the repository
     (lexical violations, absolute paths, parent traversal, or symlink escapes)
-    with a fixed, non-reflective ``ValueError``. An existing confined file
-    resolves to its canonical absolute path; a missing-but-confined path is
-    preserved unchanged (relative string).
+    with a fixed, non-reflective :class:`UnconfinedFindingError`. An existing
+    confined file resolves to its canonical absolute path; a missing-but-
+    confined path is preserved unchanged (relative string).
     """
     if not isinstance(value, str):
-        raise ValueError("Finding file must be a confined repository-relative path")
+        raise UnconfinedFindingError("Finding file must be a confined repository-relative path")
     if not path_is_confined(repo, value):
-        raise ValueError("Finding file must be a confined repository-relative path")
+        raise UnconfinedFindingError("Finding file must be a confined repository-relative path")
     candidate = repo / value
     if candidate.is_file():
         return str(candidate.resolve())
@@ -1780,9 +1807,10 @@ def _preflight_finding_file_refs(repo: Path, items: list[dict[str, Any]]) -> str
 
     Shared preflight for the batched and parallel fix entry points: rejects
     the whole batch when ANY item's reference is missing/non-string or
-    unconfined (fixed, non-reflective ``ValueError``), before any grouping,
-    progress output, or prompt construction. All batch items target the same
-    file, so the first item's canonical resolution is the group's.
+    unconfined (fixed, non-reflective :class:`UnconfinedFindingError`), before
+    any grouping, progress output, or prompt construction. All batch items
+    target the same file, so the first item's canonical resolution is the
+    group's.
     """
     file_ref = _resolve_finding_file_ref(repo, items[0].get("file"))
     for item in items[1:]:
@@ -2047,10 +2075,11 @@ async def phase_fix_parallel(
     """
     # Preflight confinement gate: validate EVERY item's file reference before
     # grouping, progress, prompt construction, recovery, or dispatch. An
-    # unconfined (or missing/non-string) reference raises ValueError and aborts
-    # the whole run fast, so the unsafe path never becomes a grouping key,
-    # fork name, failures entry, or checkout recovery argument. The returned
-    # refs are discarded -- per-fix calls recompute them.
+    # unconfined (or missing/non-string) reference raises
+    # UnconfinedFindingError and aborts the whole run fast, so the unsafe path
+    # never becomes a grouping key, fork name, failures entry, or checkout
+    # recovery argument. The returned refs are discarded -- per-fix calls
+    # recompute them.
     _preflight_finding_file_refs(work.repo, items)
 
     raw_groups = group_items_by_file(items)

--- a/tests/test_cli_main_integration.py
+++ b/tests/test_cli_main_integration.py
@@ -36,6 +36,7 @@ from typing import Any
 import pytest
 
 from daydream import cli
+from daydream.phases import UnconfinedFindingError
 
 # Reuse the deep-pipeline stub from the exemplar instead of duplicating it.
 from tests.test_deep_orchestrator import (
@@ -158,18 +159,19 @@ def test_cli_main_wrong_branch_exits_1(
 def test_cli_main_confinement_valueerror_is_actionable_not_fatal(
     git_repo: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """A confinement ValueError that reaches cli.main renders actionably.
+    """A confinement rejection that reaches cli.main renders actionably.
 
     Defense-in-depth fallback: the primary fix routes the rejection through
     ``_step_fix`` before it reaches this handler, but if it ever escapes, the
     operator must see which class of finding is at fault, not a bare
-    "Fatal Error".
+    "Fatal Error". The handler matches by type (``UnconfinedFindingError``),
+    not by message string.
     """
     _silence(monkeypatch)
     _silence_cli_and_runner(monkeypatch)
 
     async def _raising_run(*a: Any, **k: Any) -> int:
-        raise ValueError("Finding file must be a confined repository-relative path")
+        raise UnconfinedFindingError("Finding file must be a confined repository-relative path")
 
     monkeypatch.setattr("daydream.cli.run", _raising_run)
     monkeypatch.setattr(sys, "argv", ["daydream", str(git_repo)])
@@ -177,7 +179,8 @@ def test_cli_main_confinement_valueerror_is_actionable_not_fatal(
     with pytest.raises(SystemExit) as excinfo:
         cli.main()
     assert excinfo.value.code == 1
-    out = capsys.readouterr().out + capsys.readouterr().err
+    captured = capsys.readouterr()
+    out = captured.out + captured.err
     assert "Finding file must be a confined repository-relative path" in out
     assert "Fatal Error" not in out  # actionable, not the bare generic string
 

--- a/tests/test_cli_main_integration.py
+++ b/tests/test_cli_main_integration.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -152,6 +153,33 @@ def test_cli_main_wrong_branch_exits_1(
         cli.main()
 
     assert exc.value.code == 1
+
+
+def test_cli_main_confinement_valueerror_is_actionable_not_fatal(
+    git_repo: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A confinement ValueError that reaches cli.main renders actionably.
+
+    Defense-in-depth fallback: the primary fix routes the rejection through
+    ``_step_fix`` before it reaches this handler, but if it ever escapes, the
+    operator must see which class of finding is at fault, not a bare
+    "Fatal Error".
+    """
+    _silence(monkeypatch)
+    _silence_cli_and_runner(monkeypatch)
+
+    async def _raising_run(*a: Any, **k: Any) -> int:
+        raise ValueError("Finding file must be a confined repository-relative path")
+
+    monkeypatch.setattr("daydream.cli.run", _raising_run)
+    monkeypatch.setattr(sys, "argv", ["daydream", str(git_repo)])
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main()
+    assert excinfo.value.code == 1
+    out = capsys.readouterr().out + capsys.readouterr().err
+    assert "Finding file must be a confined repository-relative path" in out
+    assert "Fatal Error" not in out  # actionable, not the bare generic string
 
 
 def test_cli_main_rejects_workspace_copy_traversal(

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -805,6 +805,75 @@ async def test_fix_failure_reverts_partial_edit_and_marks_manifest_partial(
     assert any("App.tsx" in key for key in manifest["fix_failures"])
 
 
+async def test_fix_preflight_unconfined_finding_runs_recovery_and_names_item(
+    multi_stack_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    archive_dir: Path,
+    make_config: MakeConfig,
+    mute_side_effects: Mute,
+) -> None:
+    """A symlink-escape finding in the fix cycle is handled, not raised.
+
+    The ``src/handler.py`` finding is confined *lexically* (so it passes the
+    ``_step_fix_gate`` changed_files partition) but escapes via a symlink, so
+    ``phase_fix_parallel``'s preflight raises ``ValueError``. The guarded
+    caller must run the recovery machinery, leave no dangling pre-fix stash,
+    archive ``recommended.patch``, mark the run partial, name the offending
+    item, and return ``Stop(1)`` (exit 1) rather than let the ValueError reach
+    cli.py's generic handler.
+    """
+    from daydream.runner import run
+
+    _silence(monkeypatch)
+    _force_interactive(monkeypatch)
+    mute_side_effects(commit=False)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+
+    # Symlink-escape finding: src/handler.py is a repo-local path whose real
+    # file lives outside the repo (same shape as _unconfined_finding_file's
+    # "symlink" kind). Commit it into the reviewed diff so the fix gate keeps it.
+    src = multi_stack_target / "src"
+    src.mkdir(exist_ok=True)
+    outside = multi_stack_target.parent / f"{multi_stack_target.name}-outside.py"
+    outside.write_text("def outside():\n    pass\n")
+    (src / "handler.py").symlink_to(outside)
+    _add_to_reviewed_diff(multi_stack_target, ["src/handler.py"])
+
+    stub.merge_items = [_merge_item(1, "src/handler.py", "high")]
+
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        "daydream.deep.orchestrator.print_warning",
+        lambda console, msg, *a, **k: warnings.append(msg),
+    )
+
+    exit_code = await run(
+        make_config(
+            multi_stack_target,
+            assume="yes",
+            output_mode="loop",
+            non_interactive=False,
+            archive=True,
+        )
+    )
+    assert exit_code == 1  # handled failure => Stop(1), not a raise
+
+    # (a) recovery ran: the archived run is partial and records the failure,
+    #     and the recommendation patch survives.
+    run_dirs = list((archive_dir / "runs").iterdir())
+    assert len(run_dirs) == 1, f"expected exactly one archived run, got {run_dirs}"
+    manifest = json.loads((run_dirs[0] / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["status"] == "partial"
+    assert manifest["fix_failures"], "manifest must record the dropped finding"
+
+    # (b) no dangling pre-fix stash / tree restored: the symlink finding's
+    #     group never got a fix applied (preflight aborts before dispatch).
+    assert not (multi_stack_target / ".fixed-src_handler_py").exists()
+
+    # (c) the CLI output names the offending item by id and/or file ref.
+    assert any("src/handler.py" in m or "1" in m for m in warnings), warnings
+
+
 async def test_fix_failure_enumerates_leftover_untracked_orphan_in_manifest(
     multi_stack_target: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -816,11 +816,12 @@ async def test_fix_preflight_unconfined_finding_runs_recovery_and_names_item(
 
     The ``src/handler.py`` finding is confined *lexically* (so it passes the
     ``_step_fix_gate`` changed_files partition) but escapes via a symlink, so
-    ``phase_fix_parallel``'s preflight raises ``ValueError``. The guarded
-    caller must run the recovery machinery, leave no dangling pre-fix stash,
-    archive ``recommended.patch``, mark the run partial, name the offending
-    item, and return ``Stop(1)`` (exit 1) rather than let the ValueError reach
-    cli.py's generic handler.
+    ``phase_fix_parallel``'s preflight raises ``UnconfinedFindingError``. The
+    guarded
+    caller must run the recovery machinery, avoid creating the fix-group
+    sentinel for the aborted group, archive ``recommended.patch``, mark the run
+    partial, name the offending item, and return ``Stop(1)`` (exit 1) rather
+    than let the exception reach cli.py's generic handler.
     """
     from daydream.runner import run
 
@@ -871,7 +872,7 @@ async def test_fix_preflight_unconfined_finding_runs_recovery_and_names_item(
     assert not (multi_stack_target / ".fixed-src_handler_py").exists()
 
     # (c) the CLI output names the offending item by id and/or file ref.
-    assert any("src/handler.py" in m or "1" in m for m in warnings), warnings
+    assert any("src/handler.py" in m for m in warnings), warnings
 
 
 async def test_fix_failure_enumerates_leftover_untracked_orphan_in_manifest(


### PR DESCRIPTION
## Summary
Closes #574.

Fixes an out-of-scope finding from the daydream fix loop: the parallel fix preflight `ValueError` (`Finding file must be a confined repository-relative path`) was uncaught in the deep flow. `phase_fix_parallel` in `daydream/deep/orchestrator.py` now guards the rejection through the recovery machinery so the pre-fix stash is not left dangling and no bare `Fatal Error` is printed without the offending item named on a `--start-at` resume.

## Changes
- Guard parallel fix preflight rejection through recovery (`orchestrator.py`)
- Match unconfined-finding rejections by type, not message (`orchestrator.py`)
- Render confinement finding error actionably as a fallback (`cli.py`)
- Exclude the unconfined-finding entry from fix tree restore (`orchestrator.py`)
- Cover the fix preflight confinement rejection recovery path (tests)

## Verification
- `make check`: lockcheck/lint/typecheck clean, 3449 passed / 6 skipped / 0 failures
- Two sequential daydream deep-precision reviews passed on fresh VMs
- Deterministic-authorship audit: all 5 commits by @anderskev (anderskev@gmail.com)

Closes #574
