### PR TITLE
feat(backends): add Osprey programmatic backend

### DIFF
--- a/daydream/backends/osprey.py
+++ b/daydream/backends/osprey.py
@@ -688,6 +688,10 @@ class OspreyBackend:
                         completion_tokens = _required_int(event, "completion_tokens")
                         cached_tokens = _optional_int(event, "cached_tokens")
                         reasoning_tokens = _optional_int(event, "thinking_tokens")
+                        if reasoning_tokens is not None and reasoning_tokens < 0:
+                            raise OspreyProtocolError(
+                                "turn_end thinking_tokens must be non-negative"
+                            )
                         cost = _parse_cost(event.get("cost_usd"), event_name=event_name)
                         turn_model = event.get("model")
                         if turn_model is not None and not isinstance(turn_model, str):
@@ -744,9 +748,17 @@ class OspreyBackend:
                 raise OspreyProtocolError("Osprey produced no session_start event")
             if not saw_session_end:
                 raise OspreyProtocolError("Osprey stream ended without session_end")
+            if terminal_exit_code is not None and terminal_exit_code != returncode:
+                raise OspreyProtocolError(
+                    "session_end exit_code does not match subprocess return code"
+                )
             if terminal_outcome not in _SUCCESS_OUTCOMES:
                 detail = failed_message or f"exit_code={terminal_exit_code!r}"
                 raise OspreyTerminalError(terminal_outcome or "unknown", detail)
+            if protocol_state.active_turn_id is not None:
+                raise OspreyProtocolError("successful session_end has an active turn")
+            if protocol_state.pending_tool_calls:
+                raise OspreyProtocolError("successful session_end has pending tool calls")
             if total_cost is not None and not saw_metric_cost:
                 yield CostEvent(
                     cost_usd=total_cost,

--- a/daydream/backends/osprey.py
+++ b/daydream/backends/osprey.py
@@ -16,6 +16,7 @@ import os
 import re
 import tempfile
 from collections.abc import AsyncGenerator, Iterable
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -180,6 +181,51 @@ def _bounded_diagnostics(lines: Iterable[str]) -> str:
     return "\n".join(cleaned)
 
 
+@dataclass(frozen=True)
+class _OspreyCommandOptions:
+    """Per-invocation inputs to the verified Osprey argv surface."""
+
+    prompt: str
+    output_schema_path: str | Path | None
+    continuation: ContinuationToken | None
+    max_turns: int | None
+    read_only: bool
+    persist_session: bool
+    tool_search_mode: str | None
+
+
+@dataclass
+class _OspreyProtocolState:
+    """Ordering and correlation state owned by one Osprey JSONL stream."""
+
+    active_turn_id: str | None = None
+    pending_tool_calls: set[str] = field(default_factory=set)
+
+    def start_turn(self, turn_id: str) -> None:
+        if self.active_turn_id is not None:
+            raise OspreyProtocolError("turn_start before prior turn_end")
+        self.active_turn_id = turn_id
+
+    def end_turn(self, turn_id: str) -> None:
+        if self.active_turn_id is None:
+            raise OspreyProtocolError("turn_end without turn_start")
+        if turn_id != self.active_turn_id:
+            raise OspreyProtocolError(
+                f"turn_end {turn_id!r} does not match active turn {self.active_turn_id!r}"
+            )
+        self.active_turn_id = None
+
+    def start_tool_call(self, call_id: str) -> None:
+        if call_id in self.pending_tool_calls:
+            raise OspreyProtocolError(f"duplicate pending tool_call_id {call_id!r}")
+        self.pending_tool_calls.add(call_id)
+
+    def finish_tool_call(self, call_id: str) -> None:
+        # Preserve unmatched results: the trajectory recorder has an explicit
+        # bucket for them. Matching calls are retired.
+        self.pending_tool_calls.discard(call_id)
+
+
 class OspreyBackend:
     """Translate ``osprey agent --events-jsonl`` into daydream events."""
 
@@ -301,7 +347,27 @@ class OspreyBackend:
         persist_session: bool = True,
         tool_search_mode: str | None = None,
     ) -> list[str]:
+        return self._build_command(
+            _OspreyCommandOptions(
+                prompt=prompt,
+                output_schema_path=output_schema_path,
+                continuation=continuation,
+                max_turns=max_turns,
+                read_only=read_only,
+                persist_session=persist_session,
+                tool_search_mode=tool_search_mode,
+            )
+        )
+
+    def _build_command(self, options: _OspreyCommandOptions) -> list[str]:
         """Build only flags verified against the current Osprey CLI source."""
+        prompt = options.prompt
+        output_schema_path = options.output_schema_path
+        continuation = options.continuation
+        max_turns = options.max_turns
+        read_only = options.read_only
+        persist_session = options.persist_session
+        tool_search_mode = options.tool_search_mode
         selected_tool_search = (
             tool_search_mode if tool_search_mode is not None else self.tool_search_mode
         )
@@ -420,42 +486,20 @@ class OspreyBackend:
         handle = tempfile.NamedTemporaryFile(
             mode="w", encoding="utf-8", suffix=".json", prefix="daydream-osprey-schema-", delete=False
         )
+        completed = False
         try:
             json.dump(schema, handle, separators=(",", ":"))
             handle.write("\n")
+            completed = True
             return handle.name
         finally:
-            handle.close()
-
-    @staticmethod
-    def _record_identity(
-        *,
-        session_id: str,
-        model: str,
-        provider: str,
-        outcome: str | None = None,
-        exit_code: int | None = None,
-        turn_durations_ms: list[int] | None = None,
-    ) -> None:
-        # Recording is deliberately best-effort, matching the existing
-        # trajectory boundary: a recorder problem must not change execution.
-        try:
-            from daydream.trajectory import get_current_recorder
-
-            recorder = get_current_recorder()
-            record_identity = getattr(recorder, "record_backend_identity", None)
-            if callable(record_identity):
-                record_identity(
-                    backend="osprey",
-                    model=model,
-                    provider=provider,
-                    session_id=session_id,
-                    outcome=outcome,
-                    exit_code=exit_code,
-                    turn_durations_ms=turn_durations_ms,
-                )
-        except Exception:  # noqa: BLE001 - telemetry must never mask the run
-            logger.warning("failed to record Osprey identity", exc_info=True)
+            try:
+                handle.close()
+            finally:
+                if not completed:
+                    # delete=False lets Osprey reopen this path, so remove the file
+                    # ourselves if serialization or writing does not complete.
+                    Path(handle.name).unlink(missing_ok=True)
 
     async def execute(
         self,
@@ -493,6 +537,7 @@ class OspreyBackend:
         terminal_exit_code: int | None = None
         terminal_structured_output: Any = None
         turn_text_emitted = False
+        protocol_state = _OspreyProtocolState()
 
         try:
             command = self.build_command(
@@ -563,11 +608,6 @@ class OspreyBackend:
                     session_model = _required_string(event, "model")
                     provider = _required_string(event, "provider")
                     saw_session_start = True
-                    self._record_identity(
-                        session_id=session_id,
-                        model=session_model,
-                        provider=provider,
-                    )
                     continue
                 if saw_session_end:
                     raise OspreyProtocolError("JSONL event appeared after session_end")
@@ -583,14 +623,6 @@ class OspreyBackend:
                     terminal_exit_code = exit_code
                     terminal_structured_output = event.get("structured_output")
                     saw_session_end = True
-                    self._record_identity(
-                        session_id=session_id,
-                        model=session_model or self.model,
-                        provider=provider or "unknown",
-                        outcome=outcome,
-                        exit_code=exit_code,
-                        turn_durations_ms=turn_durations_ms,
-                    )
                     final_cost = _parse_cost(event.get("total_cost_usd"), event_name=event_name)
                     if final_cost is not None and not saw_metric_cost:
                         total_cost = final_cost
@@ -615,6 +647,7 @@ class OspreyBackend:
                     arguments = event.get("arguments")
                     if not isinstance(arguments, dict):
                         raise OspreyProtocolError("tool_call requires object arguments")
+                    protocol_state.start_tool_call(call_id)
                     yield ToolStartEvent(call_id, tool_name, arguments)
                 elif event_name == "tool_result":
                     call_id = _required_string(event, "tool_call_id")
@@ -626,29 +659,35 @@ class OspreyBackend:
                     if not isinstance(content, str):
                         raise OspreyProtocolError("tool_result requires string content")
                     _required_int(event, "duration_ms")
+                    protocol_state.finish_tool_call(call_id)
                     yield ToolResultEvent(call_id, content, status == "error")
                 elif event_name == "tool_update":
                     _required_string(event, "tool_call_id")
                     if not isinstance(event.get("content"), str):
                         raise OspreyProtocolError("tool_update requires string content")
                 elif event_name == "turn_start":
-                    _required_string(event, "turn_id")
+                    turn_id = _required_string(event, "turn_id")
                     _required_string(event, "timestamp")
+                    protocol_state.start_turn(turn_id)
                     turn_text_emitted = False
                 elif event_name == "turn_end":
                     turn_id = _required_string(event, "turn_id")
-                    _required_int(event, "prompt_tokens")
-                    _required_int(event, "completion_tokens")
+                    protocol_state.end_turn(turn_id)
                     usage_reported = event.get("usage_reported")
                     if not isinstance(usage_reported, bool):
                         raise OspreyProtocolError("turn_end requires boolean usage_reported")
-                    duration = _required_int(event, "duration_ms")
+                    duration = (
+                        _required_int(event, "duration_ms")
+                        if usage_reported
+                        else _optional_int(event, "duration_ms")
+                    )
                     if duration is not None:
                         turn_durations_ms.append(duration)
                     if usage_reported:
                         prompt_tokens = _required_int(event, "prompt_tokens")
                         completion_tokens = _required_int(event, "completion_tokens")
                         cached_tokens = _optional_int(event, "cached_tokens")
+                        reasoning_tokens = _optional_int(event, "thinking_tokens")
                         cost = _parse_cost(event.get("cost_usd"), event_name=event_name)
                         turn_model = event.get("model")
                         if turn_model is not None and not isinstance(turn_model, str):
@@ -662,6 +701,7 @@ class OspreyBackend:
                             completion_tokens=completion_tokens,
                             cached_tokens=cached_tokens,
                             cost_usd=cost,
+                            reasoning_tokens=reasoning_tokens,
                             model_name=turn_model or session_model,
                         )
                     yield TurnEndEvent(message_id=turn_id)

--- a/docs/backends/osprey.md
+++ b/docs/backends/osprey.md
@@ -11,8 +11,9 @@ The adapter consumes JSONL protocol version 2 and translates the producer’s
 text, thinking, tool, usage, turn, and terminal records into Daydream’s
 existing backend event union. Osprey remains the only agent loop and the owner
 of tool execution, Tool Search, MCP transport/lifecycle, hooks, approvals,
-posture, result caps/spill, persistence, telemetry, and cancellation policy.
-Daydream does not add an MCP catalog or eager deferred-tool schemas.
+posture, result caps/spill, persistence, and telemetry. Daydream owns
+cancellation of its child subprocesses. It does not add an MCP catalog or eager
+deferred-tool schemas.
 
 ## Configuration boundary
 
@@ -41,7 +42,7 @@ or policy settings.
 
 ## Stream and terminal semantics
 
-The first line must be `{"event":"protocol","version":2}` followed by one
+The first nonblank line must be `{"event":"protocol","version":2}` followed by one
 `session_start`. A successful stream ends with `session_end.outcome` equal to
 `completed` or `terminal_tool`, then a Daydream `ResultEvent`. Usage is emitted
 only when Osprey reports `usage_reported: true`; absent tokens, costs, cache
@@ -49,9 +50,10 @@ counts, and durations remain absent rather than becoming fabricated zeroes.
 
 Other terminal outcomes (`failed`, `cancelled`, `max_continuations`,
 `budget_expired`, and `actionless_timeout`) raise `OspreyTerminalError` with the
-producer’s outcome. Missing headers, malformed required fields, unknown event
-names, truncated streams, and non-zero process exits are explicit bounded
-backend failures.
+producer’s outcome when the subprocess exits successfully. A non-zero subprocess
+exit is a backend failure even if the stream reported a terminal outcome. Missing
+headers, malformed required fields, unknown event names, and truncated streams
+are also explicit bounded backend failures.
 
 ## Identity and tool calls
 

--- a/rl/daydream_review_v1/uv.lock
+++ b/rl/daydream_review_v1/uv.lock
@@ -396,7 +396,7 @@ wheels = [
 
 [[package]]
 name = "daydream"
-version = "0.26.0"
+version = "0.27.0"
 source = { editable = "../../" }
 dependencies = [
     { name = "anyio" },

--- a/tests/test_backend_osprey.py
+++ b/tests/test_backend_osprey.py
@@ -22,6 +22,7 @@ from daydream.backends import (
 )
 from daydream.backends.osprey import (
     OspreyBackend,
+    OspreyError,
     OspreyTerminalError,
     OspreyUnsupportedOption,
 )
@@ -142,6 +143,7 @@ def test_factory_builds_verified_osprey_jsonl_command() -> None:
 @pytest.mark.asyncio
 async def test_translates_text_thinking_tool_identity_metrics_and_result() -> None:
     lines, _ = _stream(
+        {"event": "turn_start", "turn_id": "t-1", "timestamp": "now"},
         {"event": "thinking_delta", "content": "checking"},
         {"event": "text_delta", "content": "done"},
         {
@@ -203,7 +205,7 @@ async def test_usage_and_structured_output_preserve_optional_metrics() -> None:
             "provider": "openai-compatible",
             "model": "custom-model",
             "duration_ms": 0,
-            "thinking_tokens": 0,
+            "thinking_tokens": 3,
             "tool_calls": 0,
             "cost_usd": "0.125",
         },
@@ -215,11 +217,36 @@ async def test_usage_and_structured_output_preserve_optional_metrics() -> None:
 
     assert metrics.prompt_tokens == 12
     assert metrics.completion_tokens == 7
+    assert metrics.reasoning_tokens == 3
     assert metrics.cached_tokens is None
     assert metrics.cost_usd == pytest.approx(0.125)
     assert result.structured_output == {"ok": True}
     assert result.continuation is not None
     assert result.continuation.data["session_id"] == "s-137"
+    assert result.continuation.data == {
+        "session_id": "s-137",
+        "provider": "openai-compatible",
+        "model": "custom-model",
+        "outcome": "completed",
+        "exit_code": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_unreported_usage_permits_omitted_optional_telemetry() -> None:
+    lines, _ = _stream(
+        {"event": "turn_start", "turn_id": "t-1", "timestamp": "now"},
+        {
+            "event": "turn_end",
+            "turn_id": "t-1",
+            "usage_reported": False,
+        },
+    )
+
+    events, _ = await _collect(OspreyBackend(osprey_binary="fake"), lines)
+
+    assert [event.message_id for event in events if isinstance(event, TurnEndEvent)] == ["t-1"]
+    assert not any(isinstance(event, MetricsEvent) for event in events)
 
 
 @pytest.mark.asyncio
@@ -300,6 +327,21 @@ async def test_output_schema_is_temp_file_forwarded_and_cleaned(tmp_path: Path) 
     assert not schema_path.exists()
 
 
+@pytest.mark.asyncio
+async def test_output_schema_temp_file_is_cleaned_when_serialization_fails(tmp_path: Path) -> None:
+    schema_path = tmp_path / "schema.json"
+    schema_path.touch()
+    handle = MagicMock()
+    handle.name = str(schema_path)
+    with (
+        patch("daydream.backends.osprey.tempfile.NamedTemporaryFile", return_value=handle),
+        patch("daydream.backends.osprey.json.dump", side_effect=TypeError("not serializable")),
+        pytest.raises(TypeError, match="not serializable"),
+    ):
+        await _collect(OspreyBackend(osprey_binary="fake"), [], output_schema={"type": object})
+    assert not schema_path.exists()
+
+
 def test_unsupported_policy_and_tool_search_options_fail_closed() -> None:
     with pytest.raises(OspreyUnsupportedOption, match="interactive approver"):
         OspreyBackend(approval="on-request").build_command("prompt")
@@ -316,6 +358,49 @@ async def test_non_success_terminal_outcome_is_not_reported_as_success() -> None
     with pytest.raises(OspreyTerminalError, match="budget_expired") as exc_info:
         await _collect(OspreyBackend(osprey_binary="fake"), lines)
     assert exc_info.value.outcome == "budget_expired"
+
+
+@pytest.mark.asyncio
+async def test_non_success_terminal_outcome_with_nonzero_process_exit_is_process_failure() -> None:
+    lines, _ = _stream()
+    lines[-1]["outcome"] = "budget_expired"
+    with pytest.raises(OspreyError, match="return code 1") as exc_info:
+        await _collect(OspreyBackend(osprey_binary="fake"), lines, returncode=1)
+    assert exc_info.value.category == "PROCESS_EXIT"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "events, message",
+    [
+        (
+            [
+                {
+                    "event": "turn_end",
+                    "turn_id": "t-1",
+                    "prompt_tokens": 0,
+                    "completion_tokens": 0,
+                    "usage_reported": False,
+                    "duration_ms": 0,
+                }
+            ],
+            "turn_end without turn_start",
+        ),
+        (
+            [
+                {"event": "turn_start", "turn_id": "t-1", "timestamp": "now"},
+                {"event": "turn_start", "turn_id": "t-2", "timestamp": "now"},
+            ],
+            "turn_start before prior turn_end",
+        ),
+    ],
+)
+async def test_invalid_turn_event_order_fails_closed(
+    events: list[dict[str, object]], message: str
+) -> None:
+    lines, _ = _stream(*events)
+    with pytest.raises(Exception, match=message):
+        await _collect(OspreyBackend(osprey_binary="fake"), lines)
 
 
 @pytest.mark.asyncio

--- a/tests/test_backend_osprey.py
+++ b/tests/test_backend_osprey.py
@@ -374,6 +374,64 @@ async def test_non_success_terminal_outcome_with_nonzero_process_exit_is_process
     "events, message",
     [
         (
+            [{"event": "turn_start", "turn_id": "t-1", "timestamp": "now"}],
+            "active turn",
+        ),
+        (
+            [
+                {
+                    "event": "tool_call",
+                    "tool_call_id": "c-1",
+                    "tool_name": "tool_search",
+                    "arguments": {},
+                }
+            ],
+            "pending tool calls",
+        ),
+    ],
+)
+async def test_successful_session_end_requires_a_quiescent_stream(
+    events: list[dict[str, object]], message: str
+) -> None:
+    lines, _ = _stream(*events)
+
+    with pytest.raises(OspreyError, match=message):
+        await _collect(OspreyBackend(osprey_binary="fake"), lines)
+
+
+@pytest.mark.asyncio
+async def test_terminal_exit_code_must_match_process_status() -> None:
+    lines, _ = _stream()
+    lines[-1]["exit_code"] = 1
+
+    with pytest.raises(OspreyError, match="exit_code"):
+        await _collect(OspreyBackend(osprey_binary="fake"), lines)
+
+
+@pytest.mark.asyncio
+async def test_negative_thinking_tokens_are_rejected() -> None:
+    lines, _ = _stream(
+        {"event": "turn_start", "turn_id": "t-1", "timestamp": "now"},
+        {
+            "event": "turn_end",
+            "turn_id": "t-1",
+            "usage_reported": True,
+            "duration_ms": 0,
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "thinking_tokens": -1,
+        },
+    )
+
+    with pytest.raises(OspreyError, match="thinking_tokens"):
+        await _collect(OspreyBackend(osprey_binary="fake"), lines)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "events, message",
+    [
+        (
             [
                 {
                     "event": "turn_end",


### PR DESCRIPTION
## Summary

Adds the Osprey headless JSONL subprocess adapter as a first-class Daydream backend. Osprey remains the owner of its agent loop, Tool Search catalog (including MCPs), approvals, hooks, cancellation, caps, telemetry, and ATIF semantics; Daydream translates the versioned event stream into its existing backend event union.

## Review and verification

- Review-1 and review-2 completed with the canonical deep precision Daydream/Codex workflow.
- Review fixes are on `35ee43e5fe10d3ad8bcffe05077583c2dc2581c4`.
- Focused backend tests: 20 passed.
- Full suite: 3460 passed, 6 skipped.
- Ruff and mypy passed.

## Residual risk

The Daydream trajectory service recorded uploads for both review rounds, but direct Hugging Face retrieval of the run path was inconclusive with the available CLI. The implementation itself is limited to the reviewed backend adapter, documentation, and tests.

Closes existential-birds/osprey#137
