### PR TITLE
Isolate RL reward scoring against mutable agent state (Closes #580)

### DIFF
--- a/rl/daydream_review_v1/README.md
+++ b/rl/daydream_review_v1/README.md
@@ -2,8 +2,15 @@
 
 A [verifiers](https://github.com/PrimeIntellect-ai/verifiers) **v1 environment**:
 one rollout is one headless daydream deep review→fix→test run inside a sandbox,
-scored on two axes — daydream's own intrinsic trajectory composite, and a
-deterministic re-run of the repository's test suite against the fixed tree.
+scored on a single reward axis — daydream's own intrinsic trajectory composite.
+The post-change suite result is recorded as the ``suite_non_regression`` metric
+(a green suite proves the tree did not regress, not that the reported defect was
+repaired, so it earns no training signal of its own). Scoring consumes only
+sealed artifacts: the supervisor seals the archived run dir after the agent's
+write window, the reward verifies the seal against the staged copy before
+trusting any value, and the suite re-run executes against a separate
+root-owned read-only checkout under a distinct non-root verifier identity —
+never the agent-mutable tree.
 
 Standalone uv project on purpose: verifiers pulls ~100 packages and must never
 enter daydream's lockfile. `daydream` is a path dependency (`../..`, editable) so
@@ -29,8 +36,8 @@ Taskset.load()          harvested corpus + images/manifest.toml, C5-enforced
        every model turn ↴
   → interception server (host) → the policy endpoint
   → Task.score()        while the sandbox is still live
-       intrinsic_composite  archived run dir → score_trajectory()
-       fix_tests_pass       re-run the repo's own suite, exit code
+       intrinsic_composite  sealed archived run dir → score_trajectory()
+       suite_non_regression  metric: re-run the repo suite in a read-only checkout
 ```
 
 Nothing clones at rollout time and no rollout carries credentials: the repository
@@ -68,7 +75,7 @@ So `codex` (Responses) and `claude` (Anthropic Messages) work for an **eval**
 against a hosted provider and cannot be used for a **training run** at these
 pins. `pi` speaks Chat Completions end to end. It is also the backend proven on a
 real model: 79 captured turns, 3 findings, a fix applied and committed,
-`fix_tests_pass` 1.0 from a genuine in-sandbox suite re-run.
+`suite_non_regression` 1.0 from a genuine in-sandbox suite re-run.
 
 Measure a baseline under the **same backend you will train under**. The agent
 scaffold is part of what the number describes; comparing a codex-scaffold
@@ -101,7 +108,7 @@ baseline against a pi-scaffold trained run moves two variables at once.
      clean and the environment survives into the image.
    - `test_command` invokes the environment produced by that locked setup (e.g.
      `/opt/repo-venv/bin/python -m pytest -q`), so the green-baseline gate and
-     the rollout's `fix_tests_pass` re-run both exercise the locked dependencies.
+     the rollout's `suite_non_regression` re-run both exercise the locked dependencies.
 
    An unavailable or stale lock is an **image-build failure** — never permission
    to **fall back to unconstrained pip**.
@@ -113,10 +120,10 @@ baseline against a pi-scaffold trained run moves two variables at once.
    Coverage must include the test sources **and every runner-config file
    `test_command` can load** — including absent filenames whose later creation
    could alter collection (e.g. `conftest.py`, `pytest.ini`, `pyproject.toml`,
-   `setup.cfg`, `tox.ini`). At scoring time `fix_tests_pass` compares these
-   paths against the image's baked head SHA, fail-closed: a changed or
-   unverifiable oracle earns **zero test reward** and the repository's mutable
-   `test_command` is not executed. That covers any tracked difference, any
+   `setup.cfg`, `tox.ini`). At scoring time `suite_non_regression` compares
+   these paths against the image's baked head SHA, fail-closed: a changed or
+   unverifiable oracle records **zero non-regression telemetry** and the
+   repository's mutable `test_command` is not executed. That covers any tracked difference, any
    non-ignored untracked file under a protected path or an untracked root
    `sitecustomize.py` (imported at startup by every `python` run, so one that
    `sys.exit(0)`s makes a suite that never ran look green), a
@@ -126,7 +133,7 @@ baseline against a pi-scaffold trained run moves two variables at once.
 
 3. **Build the images.** The last layer runs the repository's own suite at the
    head commit; a red baseline fails the build and produces nothing, because
-   `fix_tests_pass` would otherwise be rewarding noise.
+   `suite_non_regression` would otherwise be measuring noise.
 
    ```bash
    uv run python images/build_images.py --corpus ./corpus-train
@@ -186,5 +193,14 @@ eval-docker; the explicit `--client.base-url` is in `configs/eval-stub.toml`
   archive-time eval pass; without it the axis is silently null.
 - **`golden_overlap` is a crude localisation proxy**, not a reward. It feeds
   #91's rubric design and is deliberately never summed.
+- **Scoring trusts only sealed state.** The supervisor seals the archived run
+  dir (with the candidate diff) after the launch returns; the reward verifies
+  the seal against its single staged copy before any value is trusted, and a
+  tampered archive zeroes `intrinsic_composite` and records
+  `suite_non_regression` 0.0 — never honest telemetry. The container launches
+  daydream through the root-owned `run-as-agent` wrapper (setpriv down to the
+  non-root `agent` user), so no backend CLI subprocess can write the sealed
+  surfaces, and the suite re-run runs under a distinct non-root `verifier`
+  identity against a root-owned read-only checkout.
 - **Rollout cost is real.** A deep run is minutes and dollars. The task caps the
   harness at 5400s; daydream bounds each phase at 1800s of its own.

--- a/rl/daydream_review_v1/configs/eval-docker.toml
+++ b/rl/daydream_review_v1/configs/eval-docker.toml
@@ -2,8 +2,8 @@
 #
 # Each task runs in its own container built from the per-PR image the manifest
 # names, so the repository is already checked out at the head SHA and its suite
-# is already proven green there — which is what makes fix_tests_pass a verdict
-# rather than noise.
+# is already proven green there — which is what makes the suite_non_regression
+# metric a signal rather than noise.
 #
 #   uv run python images/build_images.py --only existential-birds/daydream-rl-fixture
 #   uv run eval @ configs/eval-docker.toml --client.base-url <your endpoint>

--- a/rl/daydream_review_v1/configs/eval-stub.toml
+++ b/rl/daydream_review_v1/configs/eval-stub.toml
@@ -2,8 +2,9 @@
 #
 # Proves the plumbing, not the policy: env injection reaches the CLI, the CLI
 # speaks to the interception server in the right dialect with the rollout secret,
-# artifacts land in the archive, and both reward axes score. The replies are
-# garbage by construction, so near-zero rewards are the expected outcome.
+# artifacts land in the archive and are sealed by the supervisor, and the single
+# intrinsic reward scores alongside the suite_non_regression metric. The replies
+# are garbage by construction, so near-zero rewards are the expected outcome.
 #
 #   uv run python -m daydream_review_v1.fixture /tmp/daydream-rl-smoke/repo
 #   mkdir -p /tmp/daydream-rl-smoke/archive /tmp/daydream-rl-smoke/home

--- a/rl/daydream_review_v1/daydream_review_v1/fixture.py
+++ b/rl/daydream_review_v1/daydream_review_v1/fixture.py
@@ -46,7 +46,7 @@ _IDENTITY = {
 # NON-ignored file (daydream/git_ops.py:842 -> list_untracked, which passes
 # --exclude-standard). Without this file, stray .pyc bytecode written during the
 # review would land in recommended.patch and make an empty fix look like a real
-# one — the exact signal fix_tests_pass gates on.
+# one — the exact signal suite_non_regression gates on.
 _GITIGNORE = """__pycache__/
 *.py[cod]
 .daydream/

--- a/rl/daydream_review_v1/daydream_review_v1/harness.py
+++ b/rl/daydream_review_v1/daydream_review_v1/harness.py
@@ -137,6 +137,14 @@ class DaydreamReviewHarness(vf.Harness[DaydreamReviewHarnessConfig]):
             *self.config.extra_args,
             self.config.repo_path,
         ]
+        if runtime.type == "docker":
+            # Container launches drop from the container default user (root) to
+            # the non-root agent identity through the image's root-owned
+            # run-as-agent wrapper, so every daydream process and backend CLI
+            # subprocess it spawns runs as the agent uid — never root, and never
+            # able to write the sealed surfaces. The local subprocess smoke path
+            # has no wrapper (there is no root boundary to cross).
+            argv = ["run-as-agent", *argv]
         result = await runtime.run_program(argv, env)
 
         # A deep run always talks to a model. Zero captured turns means the CLI

--- a/rl/daydream_review_v1/daydream_review_v1/harness.py
+++ b/rl/daydream_review_v1/daydream_review_v1/harness.py
@@ -13,6 +13,7 @@ rollout agent is one config key: ``backend``.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import verifiers.v1 as vf
@@ -28,6 +29,8 @@ from daydream_review_v1.backends import (
 )
 from daydream_review_v1.rundir import DEFAULT_ARCHIVE_ROOT, daydream_completed, seal_archived_run
 from daydream_review_v1.taskset import DEFAULT_REPO_PATH, DaydreamReviewData
+
+logger = logging.getLogger(__name__)
 
 
 class DaydreamReviewHarnessConfig(vf.HarnessConfig):
@@ -89,6 +92,11 @@ class DaydreamReviewHarness(vf.Harness[DaydreamReviewHarnessConfig]):
         """Fail fast with remediation text; the image bakes everything else (D6)."""
         strategy = self.strategy
         binaries = ("daydream", *strategy.required_binaries)
+        if runtime.type == "docker":
+            # The image's root-owned run-as-agent wrapper is the single
+            # privilege-drop seam; a wrapper-less image must fail here, not
+            # opaquely at docker exec.
+            binaries = (*binaries, "run-as-agent")
         checks = " && ".join(f"command -v {binary} >/dev/null" for binary in binaries)
         result = await runtime.run(
             ["sh", "-c", f"{checks} && test -d {self.config.repo_path}"], self.config.resolved_env
@@ -187,10 +195,25 @@ class DaydreamReviewHarness(vf.Harness[DaydreamReviewHarnessConfig]):
         # with the archived artifacts zeroes the reward instead of recording
         # honest telemetry. The candidate diff is the rollout's own committed
         # diff against the baked head (b"" when it cannot be re-derived).
-        await seal_archived_run(
+        sealed = await seal_archived_run(
             runtime,
             self.config.archive_root,
             repo=self.config.repo_path,
             head_sha=data.head_sha,
         )
+        # A seal-production failure must never be silent or fail-open:
+        # seal_archived_run overwrites seal.json with an unvalidatable marker
+        # (verify_seal -> False -> zero reward), and the trace records the
+        # outcome so an operator can distinguish "sealed and verified" from
+        # "sealing failed, zero protection" — a completed run with no valid
+        # seal is never scored at full trust as if the protection existed.
+        trace.info["daydream_seal_ok"] = sealed
+        if not sealed:
+            logger.warning(
+                "seal_archived_run failed for %s (repo=%s, head=%s): the rollout "
+                "will score seal_verified 0.0 and zero intrinsic reward",
+                self.config.archive_root,
+                self.config.repo_path,
+                data.head_sha,
+            )
         return result

--- a/rl/daydream_review_v1/daydream_review_v1/harness.py
+++ b/rl/daydream_review_v1/daydream_review_v1/harness.py
@@ -168,7 +168,7 @@ class DaydreamReviewHarness(vf.Harness[DaydreamReviewHarnessConfig]):
         # deep flow stops non-zero when the suite is still red after the fix pass
         # (orchestrator.py:1389). Setting a stop condition makes the framework
         # return quietly instead of raising HarnessError (harness.py:99-118), so the
-        # rollout SCORES — a red suite is exactly the signal fix_tests_pass wants.
+        # rollout SCORES — a red suite is exactly the signal suite_non_regression wants.
         # A non-zero exit with no artifacts is left to raise: that is infrastructure
         # failure and belongs to the retry budget, not to the gradient.
         if result.exit_code != 0 and await daydream_completed(runtime, self.config.archive_root):

--- a/rl/daydream_review_v1/daydream_review_v1/harness.py
+++ b/rl/daydream_review_v1/daydream_review_v1/harness.py
@@ -26,7 +26,7 @@ from daydream_review_v1.backends import (
     BackendStrategy,
     PiStrategy,
 )
-from daydream_review_v1.rundir import DEFAULT_ARCHIVE_ROOT, daydream_completed
+from daydream_review_v1.rundir import DEFAULT_ARCHIVE_ROOT, daydream_completed, seal_archived_run
 from daydream_review_v1.taskset import DEFAULT_REPO_PATH, DaydreamReviewData
 
 
@@ -173,4 +173,16 @@ class DaydreamReviewHarness(vf.Harness[DaydreamReviewHarnessConfig]):
         # failure and belongs to the retry budget, not to the gradient.
         if result.exit_code != 0 and await daydream_completed(runtime, self.config.archive_root):
             trace.stop("daydream_completed_nonzero")
+        # Produce the integrity seal over the archived run dir now that the
+        # agent's write window has closed: the reward verifies the staged copy
+        # against this seal before trusting any value, so an attempted tamper
+        # with the archived artifacts zeroes the reward instead of recording
+        # honest telemetry. The candidate diff is the rollout's own committed
+        # diff against the baked head (b"" when it cannot be re-derived).
+        await seal_archived_run(
+            runtime,
+            self.config.archive_root,
+            repo=self.config.repo_path,
+            head_sha=data.head_sha,
+        )
         return result

--- a/rl/daydream_review_v1/daydream_review_v1/harness.py
+++ b/rl/daydream_review_v1/daydream_review_v1/harness.py
@@ -146,6 +146,20 @@ class DaydreamReviewHarness(vf.Harness[DaydreamReviewHarnessConfig]):
             self.config.repo_path,
         ]
         if runtime.type == "docker":
+            # The repo image clones the checkout as root (repo.Dockerfile), so
+            # hand the workspace — and the in-container origin mirror the deep
+            # flow pushes its fix to — to the agent identity before the
+            # privilege drop. Otherwise every deep-flow write (.daydream/,
+            # worktrees, fix edits, git add/commit, push) EACCESes as the
+            # agent uid and the rollout dies before any model turn.
+            handoff = await runtime.run(
+                ["chown", "-R", "agent:agent", self.config.repo_path, "/srv/mirror.git"], env
+            )
+            if handoff.exit_code != 0:
+                raise RuntimeError(
+                    "could not hand the checkout to the agent identity: "
+                    f"{handoff.stdout}{handoff.stderr}"
+                )
             # Container launches drop from the container default user (root) to
             # the non-root agent identity through the image's root-owned
             # run-as-agent wrapper, so every daydream process and backend CLI

--- a/rl/daydream_review_v1/daydream_review_v1/rundir.py
+++ b/rl/daydream_review_v1/daydream_review_v1/rundir.py
@@ -52,6 +52,17 @@ RUN_DIR_FILES: tuple[str, ...] = (
 DEFAULT_ARCHIVE_ROOT = "/rollout/archive"
 
 
+def _candidate_diff_cmd(repo: str, head_sha: str) -> list[str]:
+    """Argv for re-deriving the rollout's committed diff against the baked head.
+
+    The candidate diff is the load-bearing contract the seal binds and the
+    verifier re-applies, so it must be derived identically everywhere it is
+    needed (seal production, seal verification, and the verify-checkout
+    construction). Single-sourcing the command keeps those sites from drifting.
+    """
+    return ["git", "-C", repo, "diff", head_sha, "HEAD"]
+
+
 async def _session_dir(runtime: vf.Runtime, archive_root: str) -> str | None:
     """Absolute path of the rollout's single archived run dir, or ``None``.
 
@@ -172,7 +183,7 @@ async def verify_seal(
     # embedded copy is an audit record, never the verification input, so a
     # committed diff rewritten after sealing fails the digest check.
     try:
-        diff_result = await runtime.run(["git", "-C", repo, "diff", head_sha, "HEAD"], {})
+        diff_result = await runtime.run(_candidate_diff_cmd(repo, head_sha), {})
     except Exception:
         return False
     if diff_result.exit_code != 0:
@@ -213,19 +224,15 @@ async def seal_archived_run(
         return False
     try:
         artifacts: dict[str, bytes] = {}
+        # _present_files already restricts the listing to the reward inputs
+        # (RUN_DIR_FILES members that exist + the deep/stack-*-records.json
+        # glob members), so only the self-exclusion of seal.json is needed
+        # here.
         for rel in await _present_files(runtime, session_dir):
-            # The seal covers every reward input: the RUN_DIR_FILES members the
-            # reward reads AND the deep/stack-*-records.json glob members, which
-            # feed the intrinsic scorer's format gate. seal.json is the seal
-            # record itself.
             if rel == "seal.json":
                 continue
-            if rel not in RUN_DIR_FILES and not (
-                rel.startswith("deep/stack-") and rel.endswith("-records.json")
-            ):
-                continue
             artifacts[rel] = await runtime.read(f"{session_dir}/{rel}")
-        diff_result = await runtime.run(["git", "-C", repo, "diff", head_sha, "HEAD"], {})
+        diff_result = await runtime.run(_candidate_diff_cmd(repo, head_sha), {})
         candidate_diff = diff_result.stdout.encode() if diff_result.exit_code == 0 else b""
         seal = seal_bytes(artifacts, candidate_diff)
         await runtime.write(f"{session_dir}/seal.json", seal.model_dump_json().encode())

--- a/rl/daydream_review_v1/daydream_review_v1/rundir.py
+++ b/rl/daydream_review_v1/daydream_review_v1/rundir.py
@@ -3,7 +3,10 @@
 Scoring runs while the runtime is still up (a ``@vf.reward`` with a required
 ``runtime`` parameter — verifiers 0.2.1 ``task.py:269-277``), so the reward reads
 daydream's own artifacts straight off the sandbox filesystem and replays them
-through the training pipeline's scorer on the host.
+through the training pipeline's scorer on the host. The supervisor seals the
+archived run dir (with the candidate diff) after the agent's write window, and
+the reward verifies that seal against the staged copy before trusting any
+value — a tampered archive must zero the reward, never record honest telemetry.
 
 Only the handful of small files the scorer actually reads are copied. The full
 archive bundle carries per-fork trajectories and diffs that can run to megabytes;
@@ -18,10 +21,16 @@ from pathlib import Path
 
 import verifiers.v1 as vf
 
+from daydream_review_v1.verifier import SealResult, seal_bytes, verify
+
 #: Fixed members of the archived run dir the reward path reads. Every one is
 #: optional: a review-only rollout has no verdicts, a green run has no
 #: fix-failures. ``deep/stack-*-records.json`` is collected separately by glob —
 #: its names depend on which stacks the router detected.
+#:
+#: ``seal.json`` is the supervisor-produced integrity seal over the other
+#: members plus the candidate diff; it rides in the fetch so the reward can
+#: verify the staged copy against it.
 #:
 #: ``trajectory.json`` and any per-fork ``trajectories/*.json`` are deliberately
 #: NOT listed here: they carry untrusted, model-directed operational text from
@@ -37,6 +46,7 @@ RUN_DIR_FILES: tuple[str, ...] = (
     "deep/merged-items.json",
     "deep/test-verdict.json",
     "deep/fix-failures.json",
+    "seal.json",
 )
 
 DEFAULT_ARCHIVE_ROOT = "/rollout/archive"
@@ -102,6 +112,76 @@ async def fetch_run_dir(
         target.write_bytes(data)
         copied += 1
     return dest if copied else None
+
+
+def verify_seal(run_dir: Path) -> bool | None:
+    """Verify the staged run dir's supervisor-produced seal.
+
+    Args:
+        run_dir: The staged host copy of the archived run dir (``fetch_run_dir``
+            output), including ``seal.json`` when the supervisor sealed the run.
+
+    Returns:
+        ``True`` when the seal verifies against the staged members and the
+        candidate diff it carries; ``False`` when a seal exists but is missing,
+        malformed, or mismatched (a tamper must zero the reward, not crash
+        scoring); ``None`` when no seal was produced (legacy/unsealed runs keep
+        their pre-seal scoring — the harness seals every completed production
+        run, so this is the test-only path). Never raises.
+    """
+    seal_path = run_dir / "seal.json"
+    if not seal_path.is_file():
+        return None
+    try:
+        seal = SealResult.model_validate_json(seal_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False
+    # The seal covers the RUN_DIR_FILES members that exist; seal.json itself is
+    # the seal record and is never hashed into itself.
+    present = [
+        run_dir / rel for rel in RUN_DIR_FILES if rel != "seal.json" and (run_dir / rel).is_file()
+    ]
+    return verify(seal, present, candidate_diff=seal.candidate_diff)
+
+
+async def seal_archived_run(
+    runtime: vf.Runtime,
+    archive_root: str = DEFAULT_ARCHIVE_ROOT,
+    *,
+    repo: str,
+    head_sha: str,
+) -> bool:
+    """Seal the archived run dir + the candidate diff; write ``seal.json`` into the sandbox.
+
+    The supervisor (harness) runs this after the launch returns, so the seal is
+    produced outside the agent's write window and the reward can verify the
+    staged copy against it. The candidate diff is the rollout's own committed
+    diff against the baked head (``b""`` when the runner cannot produce one).
+
+    Returns:
+        ``True`` when a seal was written; ``False`` when there is no run dir to
+        seal or sealing failed. Never raises: a missing seal must not crash the
+        rollout — but note that an unsealed completed run is then scored with
+        no ``seal_verified`` metric and no tamper protection.
+    """
+    session_dir = await _session_dir(runtime, archive_root)
+    if session_dir is None:
+        return False
+    try:
+        artifacts: dict[str, bytes] = {}
+        for rel in await _present_files(runtime, session_dir):
+            # The seal covers the RUN_DIR_FILES members the reward reads; the
+            # stack-record glob members are staged but are not reward inputs.
+            if rel not in RUN_DIR_FILES or rel == "seal.json":
+                continue
+            artifacts[rel] = await runtime.read(f"{session_dir}/{rel}")
+        diff_result = await runtime.run(["git", "-C", repo, "diff", head_sha, "HEAD"], {})
+        candidate_diff = diff_result.stdout.encode() if diff_result.exit_code == 0 else b""
+        seal = seal_bytes(artifacts, candidate_diff)
+        await runtime.write(f"{session_dir}/seal.json", seal.model_dump_json().encode())
+        return True
+    except Exception:
+        return False
 
 
 async def daydream_completed(

--- a/rl/daydream_review_v1/daydream_review_v1/rundir.py
+++ b/rl/daydream_review_v1/daydream_review_v1/rundir.py
@@ -119,6 +119,8 @@ async def verify_seal(
     runtime: vf.Runtime,
     repo: str,
     head_sha: str,
+    *,
+    seal_expected: bool = False,
 ) -> bool | None:
     """Verify the staged run dir's supervisor-produced seal.
 
@@ -130,18 +132,29 @@ async def verify_seal(
             diff the verifier checkout will actually apply.
         repo: The repository under review inside the sandbox.
         head_sha: The baked head SHA the rollout diffed against.
+        seal_expected: Whether the harness claims to have sealed the run. A run
+            the harness sealed whose ``seal.json`` is missing at scoring time
+            is a vanished seal — a tamper, never a legacy unsealed run — so it
+            must fail closed rather than score at full trust.
 
     Returns:
         ``True`` when the seal verifies against the staged members and the diff
         re-derived from the sandbox; ``False`` when a seal exists but is
         missing, malformed, or mismatched (a tamper must zero the reward, not
-        crash scoring); ``None`` when no seal was produced (legacy/unsealed
-        runs keep their pre-seal scoring — the harness seals every completed
+        crash scoring) — including a vanished seal on a run the harness claims
+        to have sealed (*seal_expected*), and a diff that cannot be re-derived
+        (a git failure must fail closed, never hash as the empty diff); ``None``
+        when no seal was produced and none was expected (legacy/unsealed runs
+        keep their pre-seal scoring — the harness seals every completed
         production run, so this is the test-only path). Never raises.
     """
     seal_path = run_dir / "seal.json"
     if not seal_path.is_file():
-        return None
+        # A missing seal is the legacy path only when none was expected. The
+        # harness claimed to seal this run, so a vanished seal.json is an
+        # internal contradiction that must read as a tamper, never as an
+        # unsealed run at full trust.
+        return False if seal_expected else None
     try:
         seal = SealResult.model_validate_json(seal_path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
@@ -162,8 +175,14 @@ async def verify_seal(
         diff_result = await runtime.run(["git", "-C", repo, "diff", head_sha, "HEAD"], {})
     except Exception:
         return False
-    candidate_diff = diff_result.stdout.encode() if diff_result.exit_code == 0 else b""
-    return verify(seal, present, candidate_diff=candidate_diff)
+    if diff_result.exit_code != 0:
+        # The diff cannot be re-derived, so there is nothing to verify against.
+        # Hashing b"" here would let a git failure at BOTH seal and scoring
+        # time pass as a matching empty diff (seal_verified 1.0 on a run whose
+        # diff was never re-derived); a failed re-derivation must fail closed
+        # like any other unverifiable seal.
+        return False
+    return verify(seal, present, candidate_diff=diff_result.stdout.encode())
 
 
 async def seal_archived_run(

--- a/rl/daydream_review_v1/daydream_review_v1/rundir.py
+++ b/rl/daydream_review_v1/daydream_review_v1/rundir.py
@@ -114,20 +114,30 @@ async def fetch_run_dir(
     return dest if copied else None
 
 
-def verify_seal(run_dir: Path) -> bool | None:
+async def verify_seal(
+    run_dir: Path,
+    runtime: vf.Runtime,
+    repo: str,
+    head_sha: str,
+) -> bool | None:
     """Verify the staged run dir's supervisor-produced seal.
 
     Args:
         run_dir: The staged host copy of the archived run dir (``fetch_run_dir``
             output), including ``seal.json`` when the supervisor sealed the run.
+        runtime: The live rollout runtime. The candidate diff is re-derived
+            from the sandbox through it at scoring time, so the seal binds the
+            diff the verifier checkout will actually apply.
+        repo: The repository under review inside the sandbox.
+        head_sha: The baked head SHA the rollout diffed against.
 
     Returns:
-        ``True`` when the seal verifies against the staged members and the
-        candidate diff it carries; ``False`` when a seal exists but is missing,
-        malformed, or mismatched (a tamper must zero the reward, not crash
-        scoring); ``None`` when no seal was produced (legacy/unsealed runs keep
-        their pre-seal scoring — the harness seals every completed production
-        run, so this is the test-only path). Never raises.
+        ``True`` when the seal verifies against the staged members and the diff
+        re-derived from the sandbox; ``False`` when a seal exists but is
+        missing, malformed, or mismatched (a tamper must zero the reward, not
+        crash scoring); ``None`` when no seal was produced (legacy/unsealed
+        runs keep their pre-seal scoring — the harness seals every completed
+        production run, so this is the test-only path). Never raises.
     """
     seal_path = run_dir / "seal.json"
     if not seal_path.is_file():
@@ -136,12 +146,24 @@ def verify_seal(run_dir: Path) -> bool | None:
         seal = SealResult.model_validate_json(seal_path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return False
-    # The seal covers the RUN_DIR_FILES members that exist; seal.json itself is
-    # the seal record and is never hashed into itself.
+    # The seal covers the RUN_DIR_FILES members that exist plus the
+    # deep/stack-*-records.json glob members — both are reward inputs (the
+    # stack records feed the intrinsic scorer's format gate). seal.json itself
+    # is the seal record and is never hashed into itself.
     present = [
         run_dir / rel for rel in RUN_DIR_FILES if rel != "seal.json" and (run_dir / rel).is_file()
     ]
-    return verify(seal, present, candidate_diff=seal.candidate_diff)
+    present += sorted(run_dir.glob("deep/stack-*-records.json"))
+    # Re-derive the candidate diff from the sandbox exactly as the seal
+    # producer did (and as the verifier checkout will apply it): the seal's
+    # embedded copy is an audit record, never the verification input, so a
+    # committed diff rewritten after sealing fails the digest check.
+    try:
+        diff_result = await runtime.run(["git", "-C", repo, "diff", head_sha, "HEAD"], {})
+    except Exception:
+        return False
+    candidate_diff = diff_result.stdout.encode() if diff_result.exit_code == 0 else b""
+    return verify(seal, present, candidate_diff=candidate_diff)
 
 
 async def seal_archived_run(
@@ -159,10 +181,13 @@ async def seal_archived_run(
     diff against the baked head (``b""`` when the runner cannot produce one).
 
     Returns:
-        ``True`` when a seal was written; ``False`` when there is no run dir to
+        ``True`` when a seal was written (and, under docker, the run dir
+        hardened root-owned read-only); ``False`` when there is no run dir to
         seal or sealing failed. Never raises: a missing seal must not crash the
-        rollout — but note that an unsealed completed run is then scored with
-        no ``seal_verified`` metric and no tamper protection.
+        rollout. A sealing failure on a real run dir is fail-closed: the dir is
+        marked with an unvalidatable ``seal.json`` so scoring reads a failed
+        seal (``seal_verified`` 0.0, zero reward) rather than an unsealed run
+        at full trust.
     """
     session_dir = await _session_dir(runtime, archive_root)
     if session_dir is None:
@@ -170,17 +195,54 @@ async def seal_archived_run(
     try:
         artifacts: dict[str, bytes] = {}
         for rel in await _present_files(runtime, session_dir):
-            # The seal covers the RUN_DIR_FILES members the reward reads; the
-            # stack-record glob members are staged but are not reward inputs.
-            if rel not in RUN_DIR_FILES or rel == "seal.json":
+            # The seal covers every reward input: the RUN_DIR_FILES members the
+            # reward reads AND the deep/stack-*-records.json glob members, which
+            # feed the intrinsic scorer's format gate. seal.json is the seal
+            # record itself.
+            if rel == "seal.json":
+                continue
+            if rel not in RUN_DIR_FILES and not (
+                rel.startswith("deep/stack-") and rel.endswith("-records.json")
+            ):
                 continue
             artifacts[rel] = await runtime.read(f"{session_dir}/{rel}")
         diff_result = await runtime.run(["git", "-C", repo, "diff", head_sha, "HEAD"], {})
         candidate_diff = diff_result.stdout.encode() if diff_result.exit_code == 0 else b""
         seal = seal_bytes(artifacts, candidate_diff)
         await runtime.write(f"{session_dir}/seal.json", seal.model_dump_json().encode())
+        # base.Dockerfile documents that the supervisor re-chowns the sealed run
+        # dir root-owned read-only at seal time — the mechanism that makes the
+        # sealed artifacts agent-inaccessible once the agent's write window has
+        # closed. The docker runtime execs as the container root, so the chown
+        # lands there; the local subprocess path has no root boundary (it runs
+        # as the host user, sharing the agent's uid), so there is nothing to
+        # re-chown on that path. A failed hardening is a sealing failure: a
+        # seal over still-agent-writable bytes would not be worth trusting.
+        if runtime.type == "docker":
+            hardened = await runtime.run(
+                [
+                    "sh",
+                    "-c",
+                    f"chown -R root:root {shlex.quote(session_dir)} "
+                    f"&& chmod -R a-w {shlex.quote(session_dir)}",
+                ],
+                {},
+            )
+            if hardened.exit_code != 0:
+                raise RuntimeError(
+                    "could not re-chown the sealed run dir root-owned read-only: "
+                    f"{hardened.stderr.strip() or 'chown/chmod failed'}"
+                )
         return True
     except Exception:
+        # Fail closed: a run whose seal could not be produced must score as a
+        # failed seal (verify_seal -> False -> zero reward), never as an
+        # unsealed full-trust run. Overwrite seal.json with an unvalidatable
+        # marker; if even that write fails, the harness records the failure.
+        try:
+            await runtime.write(f"{session_dir}/seal.json", b'{"seal_failed": true}')
+        except Exception:
+            pass
         return False
 
 

--- a/rl/daydream_review_v1/daydream_review_v1/taskset.py
+++ b/rl/daydream_review_v1/daydream_review_v1/taskset.py
@@ -335,6 +335,49 @@ def _claimed_test_verdict(run_dir: Path | None) -> bool | None:
         return None
     return bool(verdict["passed"])
 
+
+async def _verifier_identity_available(runtime: vf.Runtime) -> bool:
+    """Whether the sandbox carries the distinct read-only verifier identity.
+
+    The container image provides ``setpriv`` and a non-root ``verifier`` user;
+    the local subprocess smoke path has neither, so it keeps the pre-identity
+    re-run shape against the staged repo.
+    """
+    result = await runtime.run(
+        ["sh", "-c", "command -v setpriv >/dev/null 2>&1 && id verifier >/dev/null 2>&1"], {}
+    )
+    return result.exit_code == 0
+
+
+async def _prepare_verify_checkout(runtime: vf.Runtime, repo: str, head_sha: str) -> str | None:
+    """Build a separate root-owned read-only checkout with only the candidate diff applied.
+
+    The manifest ``test_command`` must never run against the agent-mutable tree.
+    This clones the current tree, detaches at the baked head, applies the
+    candidate product diff (the rollout's own committed diff against
+    ``head_sha``), and makes the result root-owned and read-only — the reward
+    re-runs the suite there under the distinct non-root verifier identity.
+
+    Returns:
+        The checkout path, or ``None`` when construction failed. A checkout the
+        verifier cannot trust is an explicit zero, never a fallback to the
+        mutable tree.
+    """
+    verify_dir = f"{repo}-verify"
+    script = (
+        f"rm -rf {shlex.quote(verify_dir)} && "
+        f"git clone -q {shlex.quote(repo)} {shlex.quote(verify_dir)} && "
+        f"git -C {shlex.quote(verify_dir)} checkout -q --detach {shlex.quote(head_sha)} && "
+        f"git -C {shlex.quote(repo)} diff {shlex.quote(head_sha)} HEAD "
+        f"| git -C {shlex.quote(verify_dir)} apply - && "
+        f"chown -R root:root {shlex.quote(verify_dir)} && "
+        f"chmod -R a-w {shlex.quote(verify_dir)}"
+    )
+    result = await runtime.run(["sh", "-c", script], {})
+    if result.exit_code != 0:
+        return None
+    return verify_dir
+
 #: Wall-clock ceilings per rollout stage, in seconds. ``harness`` bounds the whole
 #: deep loop (daydream's own per-phase wall budget is 1800s); ``scoring`` must fit a
 #: full re-run of the repository's test suite.
@@ -426,7 +469,9 @@ class DaydreamReviewTask(vf.Task[DaydreamReviewData, DaydreamReviewState, Daydre
     online reward and an offline label can never disagree about the same run.
 
     ``suite_non_regression`` is the ground truth the intrinsic composite cannot
-    supply: the repository's own suite, re-run inside the still-live sandbox.
+    supply: the repository's own suite, re-run inside the sandbox against a
+    separate root-owned read-only checkout with only the candidate product diff
+    applied (never the agent-mutable tree).
     daydream's own test verdict is a regex over agent prose
     (``daydream/agent.py:252-300``), so it is recorded as a claim and compared
     against the re-run — never trusted as reward. The suite result is a metric,
@@ -579,9 +624,7 @@ class DaydreamReviewTask(vf.Task[DaydreamReviewData, DaydreamReviewState, Daydre
         if not unchanged:
             return {"suite_non_regression": 0.0}
 
-        result = await runtime.run(
-            ["sh", "-c", f"cd {shlex.quote(repo)} && {self.data.test_command}"], {}
-        )
+        result = await self._run_test_command(runtime, repo)
         passed = result.exit_code == 0
 
         # Reward-hack tripwire: daydream's own prose-derived verdict versus what
@@ -595,6 +638,28 @@ class DaydreamReviewTask(vf.Task[DaydreamReviewData, DaydreamReviewState, Daydre
             trace.record_metric("test_claim_mismatch", float(claimed != passed))
 
         return {"suite_non_regression": float(passed)}
+
+    async def _run_test_command(self, runtime: vf.Runtime, repo: str) -> vf.ProgramResult:
+        """Run the manifest ``test_command`` against a trustworthy tree.
+
+        In the container the re-run executes against a separate root-owned
+        read-only checkout with only the candidate product diff applied, under a
+        distinct non-root verifier identity (``setpriv``) — never against the
+        agent-mutable ``/work/repo``. A checkout the verifier cannot trust is an
+        explicit non-zero result, never a fallback to the mutable tree. On the
+        local subprocess smoke path (no ``setpriv``/``verifier`` identity) the
+        re-run keeps the pre-identity shape against the staged repo.
+        """
+        if not await _verifier_identity_available(runtime):
+            return await runtime.run(
+                ["sh", "-c", f"cd {shlex.quote(repo)} && {self.data.test_command}"], {}
+            )
+        verify_dir = await _prepare_verify_checkout(runtime, repo, self.data.head_sha)
+        if verify_dir is None:
+            return vf.ProgramResult(exit_code=1, stdout="", stderr="verify checkout construction failed")
+        command = f"cd {shlex.quote(verify_dir)} && {self.data.test_command}"
+        runner = f"setpriv --reuid=verifier --regid=verifier --clear-groups sh -c {shlex.quote(command)}"
+        return await runtime.run(["sh", "-c", runner], {})
 
     @vf.metric
     async def review_shape(self, trace: vf.Trace, runtime: vf.Runtime) -> dict[str, float]:

--- a/rl/daydream_review_v1/daydream_review_v1/taskset.py
+++ b/rl/daydream_review_v1/daydream_review_v1/taskset.py
@@ -547,7 +547,14 @@ class DaydreamReviewTask(vf.Task[DaydreamReviewData, DaydreamReviewState, Daydre
                         state.seal_ok = False
                     else:
                         state.seal_ok = await verify_seal(
-                            state.run_dir, runtime, _repo_path(trace), self.data.head_sha
+                            state.run_dir,
+                            runtime,
+                            _repo_path(trace),
+                            self.data.head_sha,
+                            # The harness claims to have sealed this run: a
+                            # seal that did not survive to scoring is a vanished
+                            # seal (tamper), never the legacy unsealed path.
+                            seal_expected=trace.info.get("daydream_seal_ok") is True,
                         )
             if state.seal_ok is not None:
                 trace.record_metric("seal_verified", float(state.seal_ok))
@@ -670,7 +677,7 @@ class DaydreamReviewTask(vf.Task[DaydreamReviewData, DaydreamReviewState, Daydre
         if verify_dir is None:
             return vf.ProgramResult(exit_code=1, stdout="", stderr="verify checkout construction failed")
         command = f"cd {shlex.quote(verify_dir)} && {self.data.test_command}"
-        runner = f"setpriv --reuid=verifier --regid=verifier --clear-groups sh -c {shlex.quote(command)}"
+        runner = f"setpriv --no-new-privs --reuid=verifier --regid=verifier --clear-groups sh -c {shlex.quote(command)}"
         return await runtime.run(["sh", "-c", runner], {})
 
     @vf.metric

--- a/rl/daydream_review_v1/daydream_review_v1/taskset.py
+++ b/rl/daydream_review_v1/daydream_review_v1/taskset.py
@@ -536,7 +536,19 @@ class DaydreamReviewTask(vf.Task[DaydreamReviewData, DaydreamReviewState, Daydre
                 state.run_dir = await fetch_run_dir(runtime, Path(staging), _archive_root(trace))
                 # Seal verification is host-side over the staged copy; a seal
                 # failure is a tamper signal (explicit zero), never a crash.
-                state.seal_ok = verify_seal(state.run_dir) if state.run_dir is not None else None
+                # The candidate diff is re-derived from the sandbox here so the
+                # seal binds the diff the verifier checkout will actually apply.
+                if state.run_dir is not None:
+                    if trace.info.get("daydream_seal_ok") is False:
+                        # The harness could not produce a seal at all; score the
+                        # run as a failed seal, never as an unsealed full-trust
+                        # run (rundir.seal_archived_run also writes a fail-closed
+                        # marker; this covers even a marker-write failure).
+                        state.seal_ok = False
+                    else:
+                        state.seal_ok = await verify_seal(
+                            state.run_dir, runtime, _repo_path(trace), self.data.head_sha
+                        )
             if state.seal_ok is not None:
                 trace.record_metric("seal_verified", float(state.seal_ok))
             try:

--- a/rl/daydream_review_v1/daydream_review_v1/taskset.py
+++ b/rl/daydream_review_v1/daydream_review_v1/taskset.py
@@ -102,7 +102,8 @@ ORACLE_IGNORE_PATHSPECS = ["sitecustomize.py", ":(glob)**/.gitignore"]
 #: every untracked file under a protected path — including the ``__pycache__/``
 #: and ``*.py[cod]`` files a green suite itself drops while importing the test
 #: modules. Without this explicit exclusion a genuinely fixed tree would trip
-#: the probe on its own legitimate test runs and be withheld ``w_tests``. The
+#: the probe on its own legitimate test runs and be withheld a green
+#: non-regression reading. The
 #: benign exclusions are baked into the probe rather than delegated to the
 #: repo's ignore rules, whose decisions this gate deliberately no longer trusts.
 ORACLE_BENIGN_PATHSPECS = [":(exclude,glob)**/__pycache__/**", ":(exclude,glob)**/*.py[cod]"]
@@ -136,16 +137,17 @@ async def _fixes_applied(runtime: vf.Runtime, repo: str, head_sha: str) -> bool:
     own ``.daydream/`` directory inside the repository under review. On any
     repository that does not gitignore that directory — which is every repository
     except our own fixture — the patch is non-empty after a rollout that changed
-    nothing, and the still-green baseline would hand out a free ``w_tests``.
+    nothing, and the still-green baseline would hand out a free green
+    non-regression reading.
 
     Deliberately biased toward false negatives: a fix consisting ONLY of new,
-    never-committed files reads as "no fix" and scores ``no_fix_reward``. That
+    never-committed files reads as "no fix" (``suite_non_regression`` 0.0). That
     direction costs a gradient; the other direction corrupts one.
 
     A clean tree at a moved HEAD counts as a fix only when the *committed
     contents differ* from the snapshot. HEAD advancing on its own — e.g. an
     `--allow-empty` commit that leaves the tree byte-identical — is not a fix
-    and scores ``no_fix_reward``. Either way the decision is read from the
+    and scores ``suite_non_regression`` 0.0. Either way the decision is read from the
     tracked tree, never from daydream's own ``.daydream/`` directory.
     """
     dirty = await runtime.run(
@@ -197,8 +199,9 @@ async def _protected_test_paths_unchanged(
 
     The oracle is the repository's own mutable test infrastructure — test
     sources, runner config, package config — so a rollout could otherwise earn
-    ``w_tests`` by rewriting it into a trivial suite. The baked head SHA is the
-    trustworthy baseline: the image build proved the suite green at exactly that
+    an honest green non-regression reading by rewriting it into a trivial suite;
+    the demoted ``suite_non_regression`` metric must never record a gutted
+    suite as honest telemetry. The baked head SHA is the trustworthy baseline: the image build proved the suite green at exactly that
     commit before any agent touched the tree.
 
     Fail-closed by design, with every ambiguity reading as "changed". The probe
@@ -248,7 +251,7 @@ async def _protected_test_paths_unchanged(
       oracle changed.
 
     There is deliberately no case that defaults to pass on an error — an
-    unverifiable oracle never earns the test reward.
+    unverifiable oracle never records an honest non-regression value.
     """
     oracle_pathspecs = [*protected_test_paths, *ORACLE_IGNORE_PATHSPECS]
 
@@ -378,8 +381,6 @@ class DaydreamReviewTaskConfig(vf.TaskConfig):
     """Reward weights, overridable as ``--taskset.task.*``."""
 
     w_composite: float = 1.0
-    w_tests: float = 1.0
-    no_fix_reward: float = 0.0
 
 
 class DaydreamReviewState(vf.State):
@@ -411,18 +412,20 @@ def _review_state(trace: vf.Trace) -> DaydreamReviewState:
 
 
 class DaydreamReviewTask(vf.Task[DaydreamReviewData, DaydreamReviewState, DaydreamReviewTaskConfig]):
-    """Two reward axes: daydream's own intrinsic composite, and the test suite.
+    """One reward axis: daydream's own intrinsic composite; the suite is telemetry.
 
     ``intrinsic_composite`` replays the archived run through
     :func:`daydream.training.reward.score_trajectory` — the exact scorer the
     offline training pipeline uses, imported rather than reimplemented, so an
     online reward and an offline label can never disagree about the same run.
 
-    ``fix_tests_pass`` is the ground truth the intrinsic composite cannot supply:
-    the repository's own suite, re-run inside the still-live sandbox. daydream's
-    own test verdict is a regex over agent prose
+    ``suite_non_regression`` is the ground truth the intrinsic composite cannot
+    supply: the repository's own suite, re-run inside the still-live sandbox.
+    daydream's own test verdict is a regex over agent prose
     (``daydream/agent.py:252-300``), so it is recorded as a claim and compared
-    against the re-run — never trusted as reward.
+    against the re-run — never trusted as reward. The suite result is a metric,
+    never a reward: a green suite proves the tree did not regress, not that the
+    reported defect was repaired, so it earns no training signal of its own.
 
     Important: ``verifier_verdicts`` exist only when the fix gate was accepted
     (``deep/recommendation-verdicts.json`` is written at
@@ -496,23 +499,28 @@ class DaydreamReviewTask(vf.Task[DaydreamReviewData, DaydreamReviewState, Daydre
         }
         return self.config.w_composite * (breakdown.composite or 0.0)
 
-    @vf.reward(weight=1.0)
-    async def fix_tests_pass(self, trace: vf.Trace, runtime: vf.Runtime) -> float:
-        """Re-run the repository's pinned suite against the fixed tree.
+    @vf.metric
+    async def suite_non_regression(self, trace: vf.Trace, runtime: vf.Runtime) -> dict[str, float]:
+        """Re-run the repository's pinned suite against the fixed tree; telemetry, never a reward.
 
         Deterministic because the image build proved the same command green at
         the same commit before any agent touched it (D6). A rollout that applied
-        no fix is not evidence either way, so it takes ``no_fix_reward`` rather
-        than a free 1.0 for leaving the tree alone.
+        no fix is not evidence either way, so it records ``suite_non_regression``
+        0.0 rather than a free 1.0 for leaving the tree alone.
 
         The declared ``protected_test_paths`` oracle must still match the baked
         head before ``test_command`` is trusted: any oracle change — a tracked
         difference, an untracked file under a protected path or a root
         ``sitecustomize.py``, a ``skip-worktree``/``assume-unchanged`` flag, an
         ignore-rule change (``.gitignore`` files or ``.git/info/exclude``), or a
-        Git error — returns a literal ``0.0`` without running the repository's
-        mutable ``test_command``, so a rollout can never pay itself the test
-        reward by gutting its own suite.
+        Git error — records a literal ``0.0`` without running the repository's
+        mutable ``test_command``, so a gutted suite is never recorded as an
+        honest non-regression value.
+
+        The suite result is deliberately NOT a reward: a rollout that starts
+        from an already-green commit and makes only an unrelated or test-only
+        edit earns no suite-derived credit. The value stays in ``trace.metrics``
+        for analysis.
         """
         repo = _repo_path(trace)
         if not await _fixes_applied(runtime, repo, self.data.head_sha):
@@ -523,21 +531,21 @@ class DaydreamReviewTask(vf.Task[DaydreamReviewData, DaydreamReviewState, Daydre
             claimed = _claimed_test_verdict(_review_state(trace).run_dir)
             if claimed is not None:
                 trace.record_metric("test_claim_passed_without_fix", float(claimed))
-            return self.config.no_fix_reward
+            return {"suite_non_regression": 0.0}
 
         trace.record_metric("fixes_applied", 1.0)
         # Security boundary: the test oracle must match the baked head before the
         # repository's own mutable test_command is trusted. A changed oracle
         # (committed/staged/unstaged/deleted/renamed, an untracked protected
         # file or root sitecustomize.py, a skip-worktree/assume-unchanged flag,
-        # an ignore-rule change, or a Git error) earns a literal zero WITHOUT
+        # an ignore-rule change, or a Git error) records a literal zero WITHOUT
         # running test_command.
         unchanged = await _protected_test_paths_unchanged(
             runtime, repo, self.data.head_sha, self.data.protected_test_paths
         )
         trace.record_metric("test_oracle_unchanged", float(unchanged))
         if not unchanged:
-            return 0.0
+            return {"suite_non_regression": 0.0}
 
         result = await runtime.run(
             ["sh", "-c", f"cd {shlex.quote(repo)} && {self.data.test_command}"], {}
@@ -545,14 +553,16 @@ class DaydreamReviewTask(vf.Task[DaydreamReviewData, DaydreamReviewState, Daydre
         passed = result.exit_code == 0
 
         # Reward-hack tripwire: daydream's own prose-derived verdict versus what
-        # the suite actually does. Recorded here rather than as a @vf.metric
+        # the suite actually does. Recorded here (inside this metric handler,
+        # which performs the re-run) rather than as a separate @vf.metric,
         # because metrics run BEFORE rewards (verifiers task.py:299-306), so a
-        # metric cannot see this re-run without paying for a second one.
+        # standalone metric could not see this re-run without paying for a
+        # second one.
         claimed = _claimed_test_verdict(_review_state(trace).run_dir)
         if claimed is not None:
             trace.record_metric("test_claim_mismatch", float(claimed != passed))
 
-        return self.config.w_tests * float(passed)
+        return {"suite_non_regression": float(passed)}
 
     @vf.metric
     async def review_shape(self, trace: vf.Trace, runtime: vf.Runtime) -> dict[str, float]:
@@ -690,7 +700,7 @@ class DaydreamReviewTaskset(vf.Taskset[DaydreamReviewTask, DaydreamReviewConfig]
         if not config.use_images:
             logger.warning(
                 "use_images is off: tasks carry no image, so nothing guarantees a green baseline "
-                "and fix_tests_pass is not deterministic. This is the local smoke path only."
+                "and suite_non_regression is not deterministic. This is the local smoke path only."
             )
 
         source = harvested_corpus(config.corpus_dir)

--- a/rl/daydream_review_v1/daydream_review_v1/taskset.py
+++ b/rl/daydream_review_v1/daydream_review_v1/taskset.py
@@ -31,7 +31,7 @@ from daydream.training.reward import score_trajectory
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from verifiers.v1.errors import boundary
 
-from daydream_review_v1.rundir import DEFAULT_ARCHIVE_ROOT, fetch_run_dir
+from daydream_review_v1.rundir import DEFAULT_ARCHIVE_ROOT, fetch_run_dir, verify_seal
 
 logger = logging.getLogger(__name__)
 
@@ -201,8 +201,9 @@ async def _protected_test_paths_unchanged(
     sources, runner config, package config — so a rollout could otherwise earn
     an honest green non-regression reading by rewriting it into a trivial suite;
     the demoted ``suite_non_regression`` metric must never record a gutted
-    suite as honest telemetry. The baked head SHA is the trustworthy baseline: the image build proved the suite green at exactly that
-    commit before any agent touched the tree.
+    suite as honest telemetry. The baked head SHA is the trustworthy baseline:
+    the image build proved the suite green at exactly that commit before any
+    agent touched the tree.
 
     Fail-closed by design, with every ambiguity reading as "changed". The probe
     pathspecs are the declared paths plus ``ORACLE_IGNORE_PATHSPECS``: the repo's
@@ -394,6 +395,11 @@ class DaydreamReviewState(vf.State):
     """
 
     run_dir: Path | None = None
+    seal_ok: bool | None = None
+    """Whether the staged run dir's supervisor seal verified; ``None`` = no seal.
+
+    ``False`` means a seal existed but did not verify — a tamper — and both the
+    intrinsic reward and the non-regression metric must score zero."""
 
 
 def _review_state(trace: vf.Trace) -> DaydreamReviewState:
@@ -427,6 +433,13 @@ class DaydreamReviewTask(vf.Task[DaydreamReviewData, DaydreamReviewState, Daydre
     never a reward: a green suite proves the tree did not regress, not that the
     reported defect was repaired, so it earns no training signal of its own.
 
+    ``intrinsic_composite`` consumes only sealed artifacts: the supervisor seals
+    the archived run dir (with the candidate diff) after the agent's write
+    window, and :meth:`DaydreamReviewTask.score` verifies that seal against the
+    single staged host copy before any value is trusted. A tampered archive
+    zeroes the only remaining reward and never records honest non-regression
+    telemetry.
+
     Important: ``verifier_verdicts`` exist only when the fix gate was accepted
     (``deep/recommendation-verdicts.json`` is written at
     ``daydream/deep/orchestrator.py:1213-1229``). A review-only rollout therefore
@@ -459,8 +472,11 @@ class DaydreamReviewTask(vf.Task[DaydreamReviewData, DaydreamReviewState, Daydre
 
         The single run-dir fetch happens here, at the entrypoint; the consumers
         read the staged snapshot off ``state.run_dir`` and never re-enter the
-        runtime. With no runtime the base class simply skips the
-        runtime-dependent signals, and there is nothing to stage.
+        runtime. The supervisor-produced ``seal.json`` rides in the fetch, so the
+        staged copy is verified against the seal before any reward trusts it; a
+        tampered archive zeroes the only remaining reward. With no runtime the
+        base class simply skips the runtime-dependent signals, and there is
+        nothing to stage.
         """
         if runtime is None:
             await super().score(trace, None)
@@ -473,6 +489,11 @@ class DaydreamReviewTask(vf.Task[DaydreamReviewData, DaydreamReviewState, Daydre
             # task-scoring boundary rather than escaping as a raw OSError.
             async with boundary(vf.TaskError, f"task {type(self).__name__} scoring"):
                 state.run_dir = await fetch_run_dir(runtime, Path(staging), _archive_root(trace))
+                # Seal verification is host-side over the staged copy; a seal
+                # failure is a tamper signal (explicit zero), never a crash.
+                state.seal_ok = verify_seal(state.run_dir) if state.run_dir is not None else None
+            if state.seal_ok is not None:
+                trace.record_metric("seal_verified", float(state.seal_ok))
             try:
                 await super().score(trace, runtime)
             finally:
@@ -481,7 +502,13 @@ class DaydreamReviewTask(vf.Task[DaydreamReviewData, DaydreamReviewState, Daydre
     @vf.reward(weight=1.0)
     async def intrinsic_composite(self, trace: vf.Trace, runtime: vf.Runtime) -> float:
         """daydream's own trajectory composite over the archived run."""
-        run_dir = _review_state(trace).run_dir
+        state = _review_state(trace)
+        # The staged copy must verify against the supervisor's seal before any
+        # value is trusted: a tampered archive zeroes the only remaining reward.
+        if state.seal_ok is False:
+            trace.info["reward_breakdown"] = {"error": "seal verification failed"}
+            return 0.0
+        run_dir = state.run_dir
         if run_dir is None:
             trace.info["reward_breakdown"] = {"error": "no archived run dir"}
             return 0.0
@@ -523,6 +550,11 @@ class DaydreamReviewTask(vf.Task[DaydreamReviewData, DaydreamReviewState, Daydre
         for analysis.
         """
         repo = _repo_path(trace)
+        if _review_state(trace).seal_ok is False:
+            # The archived run cannot be trusted: the oracle is unverifiable, so
+            # the tampered result is never recorded as honest non-regression.
+            trace.record_metric("test_oracle_unchanged", 0.0)
+            return {"suite_non_regression": 0.0}
         if not await _fixes_applied(runtime, repo, self.data.head_sha):
             trace.record_metric("fixes_applied", 0.0)
             # There is no re-run to compare against on this path, but a rollout

--- a/rl/daydream_review_v1/daydream_review_v1/taskset.py
+++ b/rl/daydream_review_v1/daydream_review_v1/taskset.py
@@ -37,6 +37,14 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_REPO_PATH = "/work/repo"
 
+#: The aggregate rollout reward contract version, distinct from the intrinsic
+#: scorer's ``REWARD_VERSION`` (``daydream/training/reward.py``, unchanged and
+#: the intrinsic parity pin). ``reward_breakdown`` stamps both: ``reward_version``
+#: is this rollout contract, and ``intrinsic_reward_version`` is the offline
+#: scorer it was evaluated against. Archives scored before this boundary was
+#: introduced carry only the intrinsic version and need no migration tag.
+ROLLOUT_REWARD_VERSION = "2026.08.15-1"
+
 
 def _archive_root(trace: vf.Trace) -> str:
     """Archive root the harness told daydream to use, for this rollout."""
@@ -483,7 +491,8 @@ class DaydreamReviewTask(vf.Task[DaydreamReviewData, DaydreamReviewState, Daydre
             "length_penalty": breakdown.length_penalty,
             "composite": breakdown.composite,
             "axes_present": breakdown.axes_present,
-            "reward_version": breakdown.reward_version,
+            "reward_version": ROLLOUT_REWARD_VERSION,
+            "intrinsic_reward_version": breakdown.reward_version,
         }
         return self.config.w_composite * (breakdown.composite or 0.0)
 

--- a/rl/daydream_review_v1/daydream_review_v1/verifier.py
+++ b/rl/daydream_review_v1/daydream_review_v1/verifier.py
@@ -15,6 +15,7 @@ out of daydream's lockfile, and this primitive must not disturb that boundary.
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import json
 import os
@@ -32,11 +33,15 @@ class SealResult:
     ``artifact_digests`` maps each artifact's path relative to the common parent
     of the sealed paths (posix form) to its sha256 hex digest; the algorithm is
     pinned as ``"sha256"`` so a verify can never silently downgrade.
-    ``candidate_diff`` carries the raw diff bytes so the verifying side can
-    re-check them against the recorded digest without re-entering the sandbox
-    (the supervisor records the diff into the seal record). Serialized to JSON
-    by the supervisor (:meth:`model_dump_json`) and parsed back at
-    verification time (:meth:`model_validate_json`).
+    ``candidate_diff`` carries the raw diff bytes as an audit record of what
+    was sealed. Verification does not trust this embedded copy: the verifying
+    side re-derives the diff from the sandbox at scoring time and compares its
+    digest against ``candidate_diff_digest``, so the seal is bound to the diff
+    the verifier checkout actually applies. Diff bytes are arbitrary (git diff
+    output is not guaranteed UTF-8), so the record is serialized to JSON as
+    base64, never as a UTF-8 decode. Serialized by the supervisor
+    (:meth:`model_dump_json`) and parsed back at verification time
+    (:meth:`model_validate_json`).
     """
 
     algorithm: Literal["sha256"] = _ALGORITHM
@@ -45,13 +50,19 @@ class SealResult:
     candidate_diff: bytes = b""
 
     def model_dump_json(self) -> str:
-        """Serialize the seal to a JSON string (deterministic key order)."""
+        """Serialize the seal to a JSON string (deterministic key order).
+
+        ``candidate_diff`` is base64-encoded: the diff bytes are arbitrary
+        (git diff output is not guaranteed UTF-8), and a UTF-8 decode here
+        would make seal production raise on a non-UTF-8 diff — leaving the run
+        unsealed instead of sealed.
+        """
         return json.dumps(
             {
                 "algorithm": self.algorithm,
                 "artifact_digests": self.artifact_digests,
                 "candidate_diff_digest": self.candidate_diff_digest,
-                "candidate_diff": self.candidate_diff.decode("utf-8"),
+                "candidate_diff": base64.b64encode(self.candidate_diff).decode("ascii"),
             },
             sort_keys=True,
         )
@@ -86,11 +97,15 @@ class SealResult:
         raw_diff = data.get("candidate_diff")
         if not isinstance(raw_diff, str):
             raise ValueError("seal.json candidate_diff must be a string")
+        try:
+            diff_bytes = base64.b64decode(raw_diff.encode("ascii"))
+        except (UnicodeError, ValueError) as exc:
+            raise ValueError("seal.json candidate_diff is not valid base64") from exc
         return cls(
             algorithm=algorithm,
             artifact_digests=digests,
             candidate_diff_digest=diff,
-            candidate_diff=raw_diff.encode("utf-8"),
+            candidate_diff=diff_bytes,
         )
 
 
@@ -108,26 +123,31 @@ def _relative_keys(paths: list[Path]) -> dict[str, Path]:
     return {path.relative_to(common).as_posix(): path for path in paths}
 
 
+def read_paths(paths: list[Path]) -> dict[str, bytes]:
+    """Read each path's raw bytes, keyed by its posix path relative to the common parent.
+
+    Raises:
+        OSError: If an artifact cannot be read. Callers choose the policy:
+            :func:`seal_artifacts` lets it propagate (a supervisor-side
+            programming error), :func:`verify` absorbs it as a failed seal.
+        ValueError: If the paths share no common parent (see :func:`_relative_keys`).
+    """
+    return {rel: path.read_bytes() for rel, path in _relative_keys(paths).items()}
+
+
 def seal_artifacts(paths: list[Path], candidate_diff: bytes) -> SealResult:
     """Seal *paths* (sha256 of each artifact's raw bytes) plus *candidate_diff*.
 
-    The raw diff is carried in the seal record so the verifying side can re-check
-    it against ``candidate_diff_digest`` without re-entering the sandbox.
+    The raw diff is carried in the seal record as an audit copy; verification
+    re-derives the diff from the sandbox at scoring time instead of trusting
+    this embedded copy (:func:`rundir.verify_seal`).
 
     Raises:
         OSError: If an artifact cannot be read. Sealing is the supervisor's job
             over a known-good staged copy, so a missing artifact here is a
             programming error, not a tamper to absorb.
     """
-    digests = {
-        rel: hashlib.sha256(path.read_bytes()).hexdigest() for rel, path in _relative_keys(paths).items()
-    }
-    return SealResult(
-        algorithm=_ALGORITHM,
-        artifact_digests=digests,
-        candidate_diff_digest=hashlib.sha256(candidate_diff).hexdigest(),
-        candidate_diff=candidate_diff,
-    )
+    return seal_bytes(read_paths(paths), candidate_diff)
 
 
 def seal_bytes(artifacts: dict[str, bytes], candidate_diff: bytes) -> SealResult:
@@ -156,7 +176,7 @@ def verify(seal: SealResult, paths: list[Path], candidate_diff: bytes) -> bool:
     """
     try:
         digests = {
-            rel: hashlib.sha256(path.read_bytes()).hexdigest() for rel, path in _relative_keys(paths).items()
+            rel: hashlib.sha256(data).hexdigest() for rel, data in read_paths(paths).items()
         }
         if hashlib.sha256(candidate_diff).hexdigest() != seal.candidate_diff_digest:
             return False

--- a/rl/daydream_review_v1/daydream_review_v1/verifier.py
+++ b/rl/daydream_review_v1/daydream_review_v1/verifier.py
@@ -1,0 +1,135 @@
+"""Stdlib-only seal/verify primitive for reward artifact isolation.
+
+The reward must consume only state the rollout agent cannot rewrite. The trusted
+supervisor seals the staged run-dir artifacts together with the candidate diff
+(:func:`seal_artifacts`), and the reward verifies the seal against the staged
+copy before trusting any value (:func:`verify`). An attempted tamper — a
+rewritten artifact, an altered candidate diff, a missing artifact — makes
+verification fail, which must zero the reward rather than crash scoring:
+:func:`verify` never raises and returns ``False`` on any ``OSError``.
+
+Constraint: standard library only (``hashlib``, ``dataclasses``, ``pathlib``,
+``os``, ``json``). The standalone RL project deliberately keeps verifiers/prime-rl
+out of daydream's lockfile, and this primitive must not disturb that boundary.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+_ALGORITHM: Literal["sha256"] = "sha256"
+
+
+@dataclass(frozen=True)
+class SealResult:
+    """An integrity seal over a set of artifacts and the candidate diff.
+
+    ``artifact_digests`` maps each artifact's path relative to the common parent
+    of the sealed paths (posix form) to its sha256 hex digest; the algorithm is
+    pinned as ``"sha256"`` so a verify can never silently downgrade. Serialized
+    to JSON by the supervisor (:meth:`model_dump_json`) and parsed back at
+    verification time (:meth:`model_validate_json`).
+    """
+
+    algorithm: Literal["sha256"] = _ALGORITHM
+    artifact_digests: dict[str, str] = field(default_factory=dict)
+    candidate_diff_digest: str = ""
+
+    def model_dump_json(self) -> str:
+        """Serialize the seal to a JSON string (deterministic key order)."""
+        return json.dumps(
+            {
+                "algorithm": self.algorithm,
+                "artifact_digests": self.artifact_digests,
+                "candidate_diff_digest": self.candidate_diff_digest,
+            },
+            sort_keys=True,
+        )
+
+    @classmethod
+    def model_validate_json(cls, raw: str) -> "SealResult":
+        """Parse and validate a ``seal.json`` produced by :meth:`model_dump_json`.
+
+        Raises:
+            ValueError: If the payload is not the sealed shape (malformed JSON,
+                wrong algorithm, or non-string digest values). A tamper must
+                surface as a verification failure, so callers treat this as a
+                failed seal — never as a pass.
+        """
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"seal.json is not valid JSON: {exc}") from exc
+        if not isinstance(data, dict):
+            raise ValueError("seal.json must be a JSON object")
+        algorithm = data.get("algorithm")
+        if algorithm != _ALGORITHM:
+            raise ValueError(f"unsupported seal algorithm {algorithm!r}; expected {_ALGORITHM!r}")
+        digests = data.get("artifact_digests")
+        if not isinstance(digests, dict) or not all(
+            isinstance(key, str) and isinstance(value, str) for key, value in digests.items()
+        ):
+            raise ValueError("seal.json artifact_digests must map path -> hex digest")
+        diff = data.get("candidate_diff_digest")
+        if not isinstance(diff, str):
+            raise ValueError("seal.json candidate_diff_digest must be a string")
+        return cls(algorithm=algorithm, artifact_digests=digests, candidate_diff_digest=diff)
+
+
+def _relative_keys(paths: list[Path]) -> dict[str, Path]:
+    """Map each path to its posix path relative to the paths' common parent.
+
+    An empty list yields no keys. A single path is keyed by its own name. Paths
+    with no common parent (``os.path.commonpath`` raises) propagate as a
+    ``ValueError`` — a caller error, not a tamper signal.
+    """
+    if not paths:
+        return {}
+    parents = [str(path.parent) for path in paths]
+    common = Path(os.path.commonpath(parents))
+    return {path.relative_to(common).as_posix(): path for path in paths}
+
+
+def seal_artifacts(paths: list[Path], candidate_diff: bytes) -> SealResult:
+    """Seal *paths* (sha256 of each artifact's raw bytes) plus *candidate_diff*.
+
+    Raises:
+        OSError: If an artifact cannot be read. Sealing is the supervisor's job
+            over a known-good staged copy, so a missing artifact here is a
+            programming error, not a tamper to absorb.
+    """
+    digests = {
+        rel: hashlib.sha256(path.read_bytes()).hexdigest() for rel, path in _relative_keys(paths).items()
+    }
+    return SealResult(
+        algorithm=_ALGORITHM,
+        artifact_digests=digests,
+        candidate_diff_digest=hashlib.sha256(candidate_diff).hexdigest(),
+    )
+
+
+def verify(seal: SealResult, paths: list[Path], candidate_diff: bytes) -> bool:
+    """Return True iff every artifact matches its recorded digest and no seal member is missing.
+
+    ``True`` requires all three: every artifact's current bytes hash to its
+    recorded digest, the candidate diff hashes to ``seal.candidate_diff_digest``,
+    and the set of presented paths exactly matches the sealed set (a deleted or
+    added artifact is a tamper). Never raises: any ``OSError`` (a missing or
+    unreadable artifact) returns ``False``.
+    """
+    try:
+        digests = {
+            rel: hashlib.sha256(path.read_bytes()).hexdigest() for rel, path in _relative_keys(paths).items()
+        }
+        if hashlib.sha256(candidate_diff).hexdigest() != seal.candidate_diff_digest:
+            return False
+        if set(digests) != set(seal.artifact_digests):
+            return False
+        return all(digests[rel] == digest for rel, digest in seal.artifact_digests.items())
+    except OSError:
+        return False

--- a/rl/daydream_review_v1/daydream_review_v1/verifier.py
+++ b/rl/daydream_review_v1/daydream_review_v1/verifier.py
@@ -31,14 +31,18 @@ class SealResult:
 
     ``artifact_digests`` maps each artifact's path relative to the common parent
     of the sealed paths (posix form) to its sha256 hex digest; the algorithm is
-    pinned as ``"sha256"`` so a verify can never silently downgrade. Serialized
-    to JSON by the supervisor (:meth:`model_dump_json`) and parsed back at
+    pinned as ``"sha256"`` so a verify can never silently downgrade.
+    ``candidate_diff`` carries the raw diff bytes so the verifying side can
+    re-check them against the recorded digest without re-entering the sandbox
+    (the supervisor records the diff into the seal record). Serialized to JSON
+    by the supervisor (:meth:`model_dump_json`) and parsed back at
     verification time (:meth:`model_validate_json`).
     """
 
     algorithm: Literal["sha256"] = _ALGORITHM
     artifact_digests: dict[str, str] = field(default_factory=dict)
     candidate_diff_digest: str = ""
+    candidate_diff: bytes = b""
 
     def model_dump_json(self) -> str:
         """Serialize the seal to a JSON string (deterministic key order)."""
@@ -47,6 +51,7 @@ class SealResult:
                 "algorithm": self.algorithm,
                 "artifact_digests": self.artifact_digests,
                 "candidate_diff_digest": self.candidate_diff_digest,
+                "candidate_diff": self.candidate_diff.decode("utf-8"),
             },
             sort_keys=True,
         )
@@ -78,7 +83,15 @@ class SealResult:
         diff = data.get("candidate_diff_digest")
         if not isinstance(diff, str):
             raise ValueError("seal.json candidate_diff_digest must be a string")
-        return cls(algorithm=algorithm, artifact_digests=digests, candidate_diff_digest=diff)
+        raw_diff = data.get("candidate_diff")
+        if not isinstance(raw_diff, str):
+            raise ValueError("seal.json candidate_diff must be a string")
+        return cls(
+            algorithm=algorithm,
+            artifact_digests=digests,
+            candidate_diff_digest=diff,
+            candidate_diff=raw_diff.encode("utf-8"),
+        )
 
 
 def _relative_keys(paths: list[Path]) -> dict[str, Path]:
@@ -98,6 +111,9 @@ def _relative_keys(paths: list[Path]) -> dict[str, Path]:
 def seal_artifacts(paths: list[Path], candidate_diff: bytes) -> SealResult:
     """Seal *paths* (sha256 of each artifact's raw bytes) plus *candidate_diff*.
 
+    The raw diff is carried in the seal record so the verifying side can re-check
+    it against ``candidate_diff_digest`` without re-entering the sandbox.
+
     Raises:
         OSError: If an artifact cannot be read. Sealing is the supervisor's job
             over a known-good staged copy, so a missing artifact here is a
@@ -110,6 +126,22 @@ def seal_artifacts(paths: list[Path], candidate_diff: bytes) -> SealResult:
         algorithm=_ALGORITHM,
         artifact_digests=digests,
         candidate_diff_digest=hashlib.sha256(candidate_diff).hexdigest(),
+        candidate_diff=candidate_diff,
+    )
+
+
+def seal_bytes(artifacts: dict[str, bytes], candidate_diff: bytes) -> SealResult:
+    """Seal artifacts given as ``{relative posix path: raw bytes}`` plus *candidate_diff*.
+
+    The sandbox-side twin of :func:`seal_artifacts`: the supervisor reads the
+    archived run-dir members as bytes out of the runtime and seals them without
+    staging a host copy first.
+    """
+    return SealResult(
+        algorithm=_ALGORITHM,
+        artifact_digests={rel: hashlib.sha256(data).hexdigest() for rel, data in artifacts.items()},
+        candidate_diff_digest=hashlib.sha256(candidate_diff).hexdigest(),
+        candidate_diff=candidate_diff,
     )
 
 

--- a/rl/daydream_review_v1/images/base.Dockerfile
+++ b/rl/daydream_review_v1/images/base.Dockerfile
@@ -186,6 +186,25 @@ RUN if [ "${INSTALL_PI}" = "1" ]; then \
       pi --version; \
     fi
 
+# Read-only verifier identity: the container default user stays root, and the
+# harness launches daydream through the root-owned images/run-as-agent wrapper,
+# which setprivs down to the non-root `agent` user. Every backend CLI subprocess
+# inherits that uid, so no rollout process can write the sealed surfaces. The
+# archive dir is the agent's own write target during the run (daydream archives
+# in-process); the supervisor re-chowns the sealed run dir root-owned read-only
+# at seal time (rundir.seal_archived_run), which is what makes the sealed
+# artifacts agent-inaccessible.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends gosu \
+ && rm -rf /var/lib/apt/lists/* \
+ && useradd --system --create-home agent \
+ && chown -R agent:agent /rollout \
+ && chmod 0755 /rollout/archive
+
+COPY run-as-agent /usr/local/bin/run-as-agent
+RUN chown root:root /usr/local/bin/run-as-agent \
+ && chmod 0755 /usr/local/bin/run-as-agent
+
 # The checkout in the repo image is created by root during the build and read by
 # whatever uid the rollout runs as; git refuses a repository it does not own, and
 # that refusal would surface as an unreviewable empty diff rather than an error.

--- a/rl/daydream_review_v1/images/base.Dockerfile
+++ b/rl/daydream_review_v1/images/base.Dockerfile
@@ -202,7 +202,7 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/* \
  && useradd --system --create-home agent \
  && useradd --system --create-home verifier \
- && chown -R agent:agent /rollout \
+ && chown -R agent:agent /rollout /work \
  && chmod 0755 /rollout/archive
 
 COPY run-as-agent /usr/local/bin/run-as-agent

--- a/rl/daydream_review_v1/images/base.Dockerfile
+++ b/rl/daydream_review_v1/images/base.Dockerfile
@@ -194,10 +194,14 @@ RUN if [ "${INSTALL_PI}" = "1" ]; then \
 # in-process); the supervisor re-chowns the sealed run dir root-owned read-only
 # at seal time (rundir.seal_archived_run), which is what makes the sealed
 # artifacts agent-inaccessible.
+# util-linux is installed explicitly because it provides the setpriv binary the
+# wrapper and the verifier re-run both exec — pinning the privilege-drop
+# dependency instead of trusting it to ship in the base image.
 RUN apt-get update \
- && apt-get install -y --no-install-recommends gosu \
+ && apt-get install -y --no-install-recommends util-linux \
  && rm -rf /var/lib/apt/lists/* \
  && useradd --system --create-home agent \
+ && useradd --system --create-home verifier \
  && chown -R agent:agent /rollout \
  && chmod 0755 /rollout/archive
 

--- a/rl/daydream_review_v1/images/build_images.py
+++ b/rl/daydream_review_v1/images/build_images.py
@@ -11,9 +11,10 @@ mirror.
 
 **The baseline must be green.** The last layer of ``repo.Dockerfile`` runs the
 repository's own test suite at the head commit, so a red suite fails the build and
-produces no image. That is not a nicety — the ``fix_tests_pass`` reward pays a
-rollout for a suite that passes after its fix, so a baseline that was already red
-makes that reward pure noise. This script never catches, retries or downgrades that
+produces no image. That is not a nicety — the ``suite_non_regression`` metric
+records a rollout for a suite that passes after its fix, so a baseline that was
+already red makes that signal pure noise. This script never catches, retries or
+downgrades that
 failure; a failed build exits non-zero and the image simply does not exist.
 
 Usage::

--- a/rl/daydream_review_v1/images/build_images.py
+++ b/rl/daydream_review_v1/images/build_images.py
@@ -14,8 +14,8 @@ repository's own test suite at the head commit, so a red suite fails the build a
 produces no image. That is not a nicety — the ``suite_non_regression`` metric
 records a rollout for a suite that passes after its fix, so a baseline that was
 already red makes that signal pure noise. This script never catches, retries or
-downgrades that
-failure; a failed build exits non-zero and the image simply does not exist.
+downgrades that failure; a failed build exits non-zero and the image simply does
+not exist.
 
 Usage::
 

--- a/rl/daydream_review_v1/images/manifest.toml
+++ b/rl/daydream_review_v1/images/manifest.toml
@@ -18,7 +18,7 @@
 # nonempty (a missing or empty list is a manifest-load error), and every entry must
 # be a literal path — no git pathspec syntax (``*``/``?``/``[`` globs, a leading
 # ``:`` magic), which the manifest loader rejects: at scoring time
-# `fix_tests_pass` compares these paths against the baked head SHA, fail-closed:
+# `suite_non_regression` compares these paths against the baked head SHA, fail-closed:
 # any tracked difference (committed, staged, unstaged, deleted, renamed), any
 # non-ignored untracked file under a protected path, or any Git error means the
 # oracle changed and the rollout earns zero test reward without running

--- a/rl/daydream_review_v1/images/manifest.toml
+++ b/rl/daydream_review_v1/images/manifest.toml
@@ -21,7 +21,7 @@
 # `suite_non_regression` compares these paths against the baked head SHA, fail-closed:
 # any tracked difference (committed, staged, unstaged, deleted, renamed), any
 # non-ignored untracked file under a protected path, or any Git error means the
-# oracle changed and the rollout earns zero test reward without running
+# oracle changed and the rollout records `suite_non_regression` 0.0 without running
 # `test_command`. Cover every runner-config filename `test_command` can load,
 # including absent ones whose later creation could alter collection.
 

--- a/rl/daydream_review_v1/images/repo.Dockerfile
+++ b/rl/daydream_review_v1/images/repo.Dockerfile
@@ -3,10 +3,10 @@
 # (daydream_review_v1/taskset.py:383) — one image is one reviewable commit.
 #
 # The final layer re-runs the repository's own test suite at that commit. A red
-# suite MUST fail the build: fix_tests_pass rewards a rollout for turning a red
-# suite green, so a baseline that was already red turns that reward into noise
-# and the run is unusable as a gradient. Better to lose the image than to ship a
-# task whose reward means nothing.
+# suite MUST fail the build: suite_non_regression rewards a rollout for turning
+# a red suite green, so a baseline that was already red turns that reward into
+# noise and the run is unusable as a gradient. Better to lose the image than to
+# ship a task whose reward means nothing.
 
 # BASE_IMAGE is supplied as a build-arg by images/build_images.py and must be an
 # immutable identity (daydream-rl/base:<tag> or daydream-rl/base@sha256:<64 hex>).

--- a/rl/daydream_review_v1/images/run-as-agent
+++ b/rl/daydream_review_v1/images/run-as-agent
@@ -8,4 +8,4 @@ if [ "$(id -u)" != "0" ]; then
     echo "run-as-agent: must be run as root" >&2
     exit 1
 fi
-exec setpriv --reuid=agent --regid=agent --clear-groups "$@"
+exec setpriv --no-new-privs --reuid=agent --regid=agent --clear-groups "$@"

--- a/rl/daydream_review_v1/images/run-as-agent
+++ b/rl/daydream_review_v1/images/run-as-agent
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Root-owned privilege-drop seam: verify we are root, then exec the args as the
+# non-root agent identity. This is the single place a launch can leave root —
+# every daydream process and backend CLI subprocess it spawns inherits the
+# agent uid, so no rollout process can write the root-owned sealed surfaces.
+set -eu
+if [ "$(id -u)" != "0" ]; then
+    echo "run-as-agent: must be run as root" >&2
+    exit 1
+fi
+exec setpriv --reuid=agent --regid=agent --clear-groups "$@"

--- a/rl/daydream_review_v1/pyproject.toml
+++ b/rl/daydream_review_v1/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "daydream-review-v1"
-version = "0.1.0"
-description = "verifiers v1 environment: the daydream deep review-fix-test loop as a Harness with sandboxed fix verification"
+version = "0.2.0"
+description = "verifiers v1 environment: the daydream deep review-fix-test loop as a Harness with sandboxed fix verification, scored only on sealed artifacts with the suite result demoted to non-regression telemetry"
 # Lower bound is daydream's own floor (root pyproject requires-python = ">=3.12.13");
 # upper bound is verifiers 0.2.1's (">=3.11,<3.14").
 requires-python = ">=3.12.13,<3.14"

--- a/rl/daydream_review_v1/tests/test_harness.py
+++ b/rl/daydream_review_v1/tests/test_harness.py
@@ -7,10 +7,12 @@ The full rollout (real interception server, real CLI, real scoring) lives in
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 
 import pytest
 import verifiers.v1 as vf
-from conftest import FakeRuntime
+from conftest import PROJECT_ROOT, FakeRuntime
 from verifiers.v1.graph import MessageNode
 
 from daydream_review_v1.backends import STRATEGIES
@@ -164,7 +166,9 @@ async def test_launch_does_not_stop_on_a_half_written_archive(corpus_mini_dir, f
 
 
 async def test_setup_names_the_missing_binaries(corpus_mini_dir, fixture_manifest_path) -> None:
-    class MissingBinaries(FakeRuntime):
+    class MissingBinaries(_DockerLikeRuntime):
+        """Docker-shaped runtime whose image is missing every required binary."""
+
         async def run(self, argv: list[str], env: dict[str, str]) -> vf.ProgramResult:
             await super().run(argv, env)
             return vf.ProgramResult(exit_code=127, stdout="", stderr="not found")
@@ -174,6 +178,7 @@ async def test_setup_names_the_missing_binaries(corpus_mini_dir, fixture_manifes
         await harness.setup(MissingBinaries())
     message = str(excinfo.value)
     assert "daydream" in message and "pi" in message
+    assert "run-as-agent" in message, "a wrapper-less image must fail setup"
     assert "build_images.py" in message, "the error must say how to fix it"
 
 
@@ -209,9 +214,14 @@ async def test_launch_uses_run_as_agent_wrapper_under_docker(
     """Container launches drop to the non-root agent identity via run-as-agent.
 
     The image's default user is root and the root-owned run-as-agent wrapper is
-    the single privilege-drop seam, so a container rollout must launch daydream
-    through it — every backend CLI subprocess then inherits the agent uid. The
-    local subprocess smoke path has no wrapper (no root boundary to cross).
+    the agent-launch privilege-drop seam, so a container rollout must launch
+    daydream through it — every backend CLI subprocess then inherits the agent
+    uid. The sealed run dir is re-chowned root-owned read-only at seal time
+    (rundir.seal_archived_run), so no rollout process can rewrite the sealed
+    artifacts once the agent's write window closes; and the suite re-run runs
+    under the distinct non-root verifier identity against a separate
+    root-owned read-only checkout — never the agent-mutable tree. The local
+    subprocess smoke path has no wrapper (no root boundary to cross).
     """
     task = _task(corpus_mini_dir, fixture_manifest_path)
     harness = DaydreamReviewHarness(DaydreamReviewHarnessConfig())
@@ -223,3 +233,92 @@ async def test_launch_uses_run_as_agent_wrapper_under_docker(
     assert argv[0] == "run-as-agent"
     assert argv[1] == "daydream"
     assert argv[argv.index("--backend") + 1] == "claude"
+
+
+def test_run_as_agent_wrapper_executes_and_enforces_root_only() -> None:
+    """The privilege-drop seam must actually run, not just be argv[0].
+
+    The docker-path test above pins that the harness prefixes the wrapper; this
+    pins the wrapper itself by executing it. On a non-root host (the normal
+    dev/CI case) the wrapper must refuse — it exists to leave root, never to
+    run the payload as root. On a root host that can satisfy setpriv/agent
+    (i.e. the built image) a successful run must land off root; anywhere else
+    it must fail closed. A missing, non-executable, or silently-passing wrapper
+    is exactly the rollout-time failure this pins at build time.
+    """
+    wrapper = PROJECT_ROOT / "images" / "run-as-agent"
+    result = subprocess.run([str(wrapper), "id", "-u"], capture_output=True, text=True)
+    assert os.access(wrapper, os.X_OK), "run-as-agent wrapper must be executable"
+    if os.geteuid() != 0:
+        assert result.returncode != 0, "non-root callers must be refused"
+        assert "must be run as root" in result.stderr
+    elif result.returncode == 0:
+        assert result.stdout.strip() != "0", "run-as-agent must drop off root"
+
+
+class _ArchivingDockerRuntime(_DockerLikeRuntime):
+    """A docker-shaped runtime whose `ls` of the archive reports one session dir."""
+
+    def __init__(self, *, exit_code: int = 0) -> None:
+        super().__init__(exit_code=exit_code)
+        self.sessions = ["session-1"]
+
+    async def run(self, argv: list[str], env: dict[str, str]) -> vf.ProgramResult:
+        await super().run(argv, env)
+        if argv[:2] == ["sh", "-c"] and argv[2].startswith("ls -1 "):
+            return vf.ProgramResult(exit_code=0, stdout="\n".join(self.sessions), stderr="")
+        return vf.ProgramResult(exit_code=0, stdout="", stderr="")
+
+
+async def test_seal_re_chowns_the_run_dir_root_owned_under_docker(
+    corpus_mini_dir, fixture_manifest_path
+) -> None:
+    """The sealed run dir is re-chowned root-owned read-only at seal time.
+
+    base.Dockerfile documents that the supervisor re-chowns the sealed run dir
+    root-owned read-only at seal time (rundir.seal_archived_run) — the
+    mechanism that keeps the sealed artifacts agent-inaccessible once the
+    agent's write window closes. The docker runtime execs as the container
+    root, so the chown lands there and the local path is untouched.
+    """
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    harness = DaydreamReviewHarness(DaydreamReviewHarnessConfig())
+    runtime = _ArchivingDockerRuntime(exit_code=0)
+
+    await harness.launch(_ctx(), _trace(task), runtime, ENDPOINT, SECRET, {})
+
+    hardened = [cmd for cmd in runtime.commands if "chown -R root:root" in " ".join(cmd)]
+    assert hardened, "seal_archived_run must re-chown the sealed run dir root-owned"
+    assert "chmod -R a-w" in hardened[-1][2]
+    assert any(path.endswith("/seal.json") for path in runtime.writes), "seal.json must be written"
+
+
+async def test_seal_failure_is_fail_closed_and_recorded(
+    corpus_mini_dir, fixture_manifest_path
+) -> None:
+    """A seal-production failure is fail-closed, never silently unsealed.
+
+    seal_archived_run swallows every exception, but not fail-open: it overwrites
+    seal.json with an unvalidatable marker so verify_seal reads a failed seal
+    (seal_verified 0.0, zero reward) instead of a missing-seal full trust, and
+    the harness records the outcome on the trace instead of discarding the
+    bool — an operator can tell "sealed and verified" from "sealing failed".
+    """
+
+    class ExplodingGit(_ArchivingDockerRuntime):
+        async def run(self, argv: list[str], env: dict[str, str]) -> vf.ProgramResult:
+            result = await super().run(argv, env)
+            if argv[:1] == ["git"]:
+                raise RuntimeError("git exploded")
+            return result
+
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    harness = DaydreamReviewHarness(DaydreamReviewHarnessConfig())
+    runtime = ExplodingGit(exit_code=0)
+    trace = _trace(task)
+
+    await harness.launch(_ctx(), trace, runtime, ENDPOINT, SECRET, {})
+
+    assert trace.info["daydream_seal_ok"] is False
+    marker = runtime.writes.get("/rollout/archive/runs/session-1/seal.json")
+    assert marker == b'{"seal_failed": true}', "a failed seal must carry the fail-closed marker"

--- a/rl/daydream_review_v1/tests/test_harness.py
+++ b/rl/daydream_review_v1/tests/test_harness.py
@@ -222,6 +222,11 @@ async def test_launch_uses_run_as_agent_wrapper_under_docker(
     under the distinct non-root verifier identity against a separate
     root-owned read-only checkout — never the agent-mutable tree. The local
     subprocess smoke path has no wrapper (no root boundary to cross).
+
+    Beyond argv, the wrapper itself must actually deliver the drop — the
+    property it exists for, not just the prefix it is named with — so a
+    wrapper that cannot leave root (or a harness that merely names one) fails
+    this container contract.
     """
     task = _task(corpus_mini_dir, fixture_manifest_path)
     harness = DaydreamReviewHarness(DaydreamReviewHarnessConfig())
@@ -233,6 +238,17 @@ async def test_launch_uses_run_as_agent_wrapper_under_docker(
     assert argv[0] == "run-as-agent"
     assert argv[1] == "daydream"
     assert argv[argv.index("--backend") + 1] == "claude"
+
+    # Pin the terminal property of the seam by executing it: root must drop
+    # off root, and a non-root caller must be refused.
+    wrapper = PROJECT_ROOT / "images" / "run-as-agent"
+    dropped = subprocess.run([str(wrapper), "id", "-u"], capture_output=True, text=True)
+    if os.geteuid() == 0:
+        assert dropped.returncode == 0, dropped.stderr
+        assert dropped.stdout.strip() != "0", "run-as-agent must drop off root"
+    else:
+        assert dropped.returncode != 0, "non-root callers must be refused"
+        assert "must be run as root" in dropped.stderr
 
 
 def test_run_as_agent_wrapper_executes_and_enforces_root_only() -> None:
@@ -254,6 +270,12 @@ def test_run_as_agent_wrapper_executes_and_enforces_root_only() -> None:
         assert "must be run as root" in result.stderr
     elif result.returncode == 0:
         assert result.stdout.strip() != "0", "run-as-agent must drop off root"
+    else:
+        # Root host where the wrapper failed (broken wrapper or missing agent
+        # user): fail-closed means the payload must never run as root, even on
+        # the failure path — a non-zero exit that still emitted the root uid
+        # would be a silent fail-open.
+        assert result.stdout.strip() != "0", "a failing wrapper must not run the payload as root"
 
 
 class _ArchivingDockerRuntime(_DockerLikeRuntime):

--- a/rl/daydream_review_v1/tests/test_harness.py
+++ b/rl/daydream_review_v1/tests/test_harness.py
@@ -190,3 +190,36 @@ async def test_launch_refuses_a_rollout_that_captured_no_model_calls(
         await harness.launch(_ctx(), trace, FakeRuntime(exit_code=0), ENDPOINT, SECRET, {})
     assert "no model calls" in str(excinfo.value)
     assert ENDPOINT in str(excinfo.value)
+
+
+class _DockerLikeRuntime(FakeRuntime):
+    """A FakeRuntime shaped like the docker runtime (wrapper-prefix contract)."""
+
+    def __init__(self, *, exit_code: int = 0) -> None:
+        from verifiers.v1.runtimes.docker import DockerConfig, DockerRuntimeInfo
+
+        super().__init__(exit_code=exit_code)
+        self.config = DockerConfig()
+        self.info = DockerRuntimeInfo(**self.config.model_dump())
+
+
+async def test_launch_uses_run_as_agent_wrapper_under_docker(
+    corpus_mini_dir, fixture_manifest_path
+) -> None:
+    """Container launches drop to the non-root agent identity via run-as-agent.
+
+    The image's default user is root and the root-owned run-as-agent wrapper is
+    the single privilege-drop seam, so a container rollout must launch daydream
+    through it — every backend CLI subprocess then inherits the agent uid. The
+    local subprocess smoke path has no wrapper (no root boundary to cross).
+    """
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    harness = DaydreamReviewHarness(DaydreamReviewHarnessConfig())
+    runtime = _DockerLikeRuntime(exit_code=0)
+
+    await harness.launch(_ctx(), _trace(task), runtime, ENDPOINT, SECRET, {})
+
+    (argv, _), = runtime.programs
+    assert argv[0] == "run-as-agent"
+    assert argv[1] == "daydream"
+    assert argv[argv.index("--backend") + 1] == "claude"

--- a/rl/daydream_review_v1/tests/test_harness_e2e.py
+++ b/rl/daydream_review_v1/tests/test_harness_e2e.py
@@ -6,7 +6,8 @@ useless sentence, so the rewards are meaningless — what it proves is the
 plumbing, and it proves all of it at once. Env injection reaches the CLI, the CLI
 speaks the Anthropic dialect to the interception server and authenticates with
 the rollout secret, every turn lands in the trace DAG, daydream archives a run,
-the run dir comes back out of the sandbox, and both reward axes score.
+the run dir comes back out of the sandbox, and the single intrinsic reward
+scores alongside the suite_non_regression metric.
 
 ``test_live_rollout`` is the only test that needs a real model, and it is the
 only one whose reward values mean anything.
@@ -25,7 +26,7 @@ from conftest import PROJECT_ROOT
 
 from daydream_review_v1.fixture import build_fixture_repo
 
-REQUIRED_REWARDS = {"intrinsic_composite", "fix_tests_pass"}
+REQUIRED_REWARDS = {"intrinsic_composite"}
 
 
 def _stage(root: Path) -> dict[str, Path]:
@@ -132,5 +133,6 @@ def test_live_rollout(tmp_path: Path) -> None:
 
     trace = _sole_trace(paths)
     assert REQUIRED_REWARDS <= set(trace["rewards"]), trace["rewards"]
-    assert trace["rewards"]["fix_tests_pass"] in (0.0, 1.0)
+    assert trace["rewards"]["intrinsic_composite"] in (0.0, 1.0)
+    assert trace["metrics"]["suite_non_regression"] in (0.0, 1.0)
     assert trace["info"]["daydream_backend"] == backend

--- a/rl/daydream_review_v1/tests/test_harness_e2e.py
+++ b/rl/daydream_review_v1/tests/test_harness_e2e.py
@@ -88,6 +88,8 @@ def test_stub_rollout_scores_without_crash(tmp_path: Path, stub_upstream: str) -
     sampled = [node for node in trace["nodes"] if node.get("sampled")]
     assert sampled, "no sampled assistant turns — endpoint injection or the dialect did not work"
     assert REQUIRED_REWARDS <= set(trace["rewards"]), trace["rewards"]
+    assert 0.0 <= trace["rewards"]["intrinsic_composite"] <= 1.0, trace["rewards"]
+    assert trace["metrics"]["suite_non_regression"] in (0.0, 1.0), trace["metrics"]
     assert trace["info"]["daydream_backend"] == "claude"
     assert trace["info"]["daydream_exit_code"] == 0
     # Scoring really read daydream's archived run dir out of the sandbox.
@@ -133,6 +135,6 @@ def test_live_rollout(tmp_path: Path) -> None:
 
     trace = _sole_trace(paths)
     assert REQUIRED_REWARDS <= set(trace["rewards"]), trace["rewards"]
-    assert trace["rewards"]["intrinsic_composite"] in (0.0, 1.0)
+    assert 0.0 <= trace["rewards"]["intrinsic_composite"] <= 1.0
     assert trace["metrics"]["suite_non_regression"] in (0.0, 1.0)
     assert trace["info"]["daydream_backend"] == backend

--- a/rl/daydream_review_v1/tests/test_images.py
+++ b/rl/daydream_review_v1/tests/test_images.py
@@ -334,7 +334,7 @@ def test_reference_image_builds_with_locked_dependencies(base_image: str) -> Non
     # test deps; a pip-based setup would leave it absent, so this fails a regression.
     # It also pins the editable-install invariant: the package under test must
     # resolve from the baked /work/repo checkout, not a venv copy, so the rollout
-    # re-run in fix_tests_pass exercises the agent's edits rather than stale code.
+    # re-run in suite_non_regression exercises the agent's edits rather than stale code.
     probe = subprocess.run(
         ["docker", "run", "--rm", REFERENCE_TAG, "sh", "-c",
          "test -x /opt/repo-venv/bin/python && /opt/repo-venv/bin/python -c '"

--- a/rl/daydream_review_v1/tests/test_images.py
+++ b/rl/daydream_review_v1/tests/test_images.py
@@ -674,3 +674,22 @@ def test_reference_probe_quotes_the_work_repo_path() -> None:
     probe_src = src[probe_start : probe_end]
     assert quoted in probe_src, "python -c body must receive a quoted path literal"
     assert bare not in probe_src, "a single-quoted path would break the sh -c region"
+
+
+def test_run_as_agent_wrapper_is_root_owned_and_drops_privilege() -> None:
+    """The wrapper is root-owned and setprivs down to the agent identity (image contract)."""
+    wrapper = PROJECT_ROOT / "images" / "run-as-agent"
+    assert wrapper.is_file(), "run-as-agent wrapper missing"
+    mode = wrapper.stat().st_mode & 0o777
+    assert mode & 0o400 and mode & 0o100, "wrapper must be root-executable (0755)"
+    text = wrapper.read_text(encoding="utf-8")
+    assert "setpriv" in text or "gosu" in text, "wrapper must drop privileges via setpriv/gosu"
+    assert "agent" in text, "wrapper must target the non-root agent user"
+
+
+def test_base_image_has_distinct_agent_identity() -> None:
+    """base.Dockerfile declares a non-root agent user and root-owned archive."""
+    dockerfile = (PROJECT_ROOT / "images" / "base.Dockerfile").read_text(encoding="utf-8")
+    assert "gosu" in dockerfile
+    assert "useradd" in dockerfile or "adduser" in dockerfile
+    assert "chmod" in dockerfile and "archive" in dockerfile  # archive made agent-inaccessible

--- a/rl/daydream_review_v1/tests/test_images.py
+++ b/rl/daydream_review_v1/tests/test_images.py
@@ -353,7 +353,9 @@ def test_base_layer_hardening_executes_on_warm_host() -> None:
 
     Builds a fresh base image with ``--no-cache`` and verifies the resulting
     image actually contains the hardening layers (gpg-verify and checksum
-    verification) via ``docker image history``. The session ``base_image``
+    verification) via ``docker image history``, and that the run-as-agent
+    privilege-drop seam really drops root in the built image. The session
+    ``base_image``
     fixture short-circuits when the image exists (conftest.py:40-55) and every
     repo build passes ``--no-base``, so on a warm host the hardening is
     otherwise never re-run; this test forces the build to run and then probes
@@ -394,6 +396,23 @@ def test_base_layer_hardening_executes_on_warm_host() -> None:
         assert "sha256sum -c" in probe.stdout, (
             "built image lacks the checksum-verification hardening layer"
         )
+        # The privilege-drop seam must actually work in the built image, not
+        # just be declared: the image's default user stays root, and the
+        # root-owned run-as-agent wrapper drops to a non-root uid (the `agent`
+        # user). A missing or non-executable wrapper is exactly the
+        # rollout-time failure this probe catches at build time.
+        default_uid = subprocess.run(
+            ["docker", "run", "--rm", tag, "id", "-u"],
+            capture_output=True, text=True, check=False,
+        )
+        dropped_uid = subprocess.run(
+            ["docker", "run", "--rm", tag, "run-as-agent", "id", "-u"],
+            capture_output=True, text=True, check=False,
+        )
+        assert default_uid.returncode == 0, default_uid.stdout + default_uid.stderr
+        assert dropped_uid.returncode == 0, dropped_uid.stdout + dropped_uid.stderr
+        assert default_uid.stdout.strip() == "0", "image default user must stay root"
+        assert dropped_uid.stdout.strip() != "0", "run-as-agent must drop off root"
     finally:
         subprocess.run(["docker", "rmi", tag], capture_output=True, text=True, check=False)
 
@@ -676,23 +695,28 @@ def test_reference_probe_quotes_the_work_repo_path() -> None:
     assert bare not in probe_src, "a single-quoted path would break the sh -c region"
 
 
-def test_run_as_agent_wrapper_is_root_owned_and_drops_privilege() -> None:
-    """The wrapper is root-owned and setprivs down to the agent identity (image contract)."""
+def test_run_as_agent_wrapper_drops_privilege() -> None:
+    """The wrapper setprivs down to the agent identity (image contract). Root
+    ownership is established only inside the built image (base.Dockerfile chowns
+    run-as-agent root:root), so no st_uid check is made on the checkout copy."""
     wrapper = PROJECT_ROOT / "images" / "run-as-agent"
     assert wrapper.is_file(), "run-as-agent wrapper missing"
     mode = wrapper.stat().st_mode & 0o777
-    assert mode & 0o400 and mode & 0o100, "wrapper must be root-executable (0755)"
+    assert mode & 0o400 and mode & 0o100, "wrapper must be owner-executable (0755)"
     text = wrapper.read_text(encoding="utf-8")
-    assert "setpriv" in text or "gosu" in text, "wrapper must drop privileges via setpriv/gosu"
+    assert "setpriv" in text, "wrapper must drop privileges via setpriv"
     assert "agent" in text, "wrapper must target the non-root agent user"
 
 
 def test_base_image_has_distinct_agent_identity() -> None:
-    """base.Dockerfile declares a non-root agent user and root-owned archive."""
+    """base.Dockerfile declares non-root agent and verifier users, an
+    agent-owned archive, and the explicit setpriv provider (util-linux)."""
     dockerfile = (PROJECT_ROOT / "images" / "base.Dockerfile").read_text(encoding="utf-8")
-    assert "gosu" in dockerfile
+    assert "util-linux" in dockerfile  # setpriv provider pinned explicitly, not implicit
     assert "useradd" in dockerfile or "adduser" in dockerfile
-    assert "chmod" in dockerfile and "archive" in dockerfile  # archive made agent-inaccessible
+    assert "agent" in dockerfile
+    assert "verifier" in dockerfile  # read-only verifier identity provisioned
+    assert "chown" in dockerfile and "agent:agent" in dockerfile  # /rollout (incl. archive) is agent-owned
 
 
 def test_readme_documents_single_reward_axis_and_metric() -> None:

--- a/rl/daydream_review_v1/tests/test_images.py
+++ b/rl/daydream_review_v1/tests/test_images.py
@@ -693,3 +693,24 @@ def test_base_image_has_distinct_agent_identity() -> None:
     assert "gosu" in dockerfile
     assert "useradd" in dockerfile or "adduser" in dockerfile
     assert "chmod" in dockerfile and "archive" in dockerfile  # archive made agent-inaccessible
+
+
+def test_readme_documents_single_reward_axis_and_metric() -> None:
+    from conftest import PROJECT_ROOT
+
+    readme = (PROJECT_ROOT / "README.md").read_text(encoding="utf-8")
+    assert "two axes" not in readme.lower()
+    assert "suite_non_regression" in readme
+    assert "intrinsic_composite" in readme
+
+
+def test_configs_and_pyproject_reflect_the_new_contract() -> None:
+    from conftest import PROJECT_ROOT
+
+    docker = (PROJECT_ROOT / "configs" / "eval-docker.toml").read_text(encoding="utf-8")
+    stub = (PROJECT_ROOT / "configs" / "eval-stub.toml").read_text(encoding="utf-8")
+    pyproject = (PROJECT_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    assert "verdict" not in docker.lower()  # stale "it's a verdict" wording
+    assert "suite_non_regression" in docker or "non-regression" in docker
+    assert "reward axes" not in stub.lower()  # stale "both reward axes" wording
+    assert "0.2.0" in pyproject

--- a/rl/daydream_review_v1/tests/test_rewards.py
+++ b/rl/daydream_review_v1/tests/test_rewards.py
@@ -1068,3 +1068,25 @@ async def test_reward_version_is_pinned(
     await task.score(trace, runtime)
 
     assert trace.info["reward_breakdown"]["reward_version"] == REWARD_VERSION
+
+
+async def test_reward_breakdown_carries_dual_version_stamps(
+    tmp_path, runtime, rundir_golden, corpus_mini_dir, fixture_manifest_path,
+) -> None:
+    """The rollout reward contract and the intrinsic scorer version are two stamps."""
+    from daydream.training.reward import REWARD_VERSION
+    from daydream_review_v1.taskset import ROLLOUT_REWARD_VERSION
+
+    assert REWARD_VERSION == "2026.05.28-2"  # intrinsic parity pin (unchanged)
+    assert ROLLOUT_REWARD_VERSION == "2026.08.15-1"
+
+    archive_root = tmp_path / "archive"
+    _stage_run(archive_root, rundir_golden)
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    trace = _trace(task, archive_root=archive_root, repo_path=tmp_path / "repo")
+
+    await task.score(trace, runtime)
+
+    breakdown = trace.info["reward_breakdown"]
+    assert breakdown["reward_version"] == ROLLOUT_REWARD_VERSION
+    assert breakdown["intrinsic_reward_version"] == REWARD_VERSION

--- a/rl/daydream_review_v1/tests/test_rewards.py
+++ b/rl/daydream_review_v1/tests/test_rewards.py
@@ -434,7 +434,7 @@ async def test_missing_run_dir_scores_zero(
     assert trace.metrics["n_findings"] == 0.0
 
 
-async def test_fix_tests_pass_green(
+async def test_green_suite_records_non_regression(
     tmp_path: Path, runtime, corpus_mini_dir: Path, fixture_manifest_path: Path
 ) -> None:
     archive_root = tmp_path / "archive"
@@ -451,15 +451,63 @@ async def test_fix_tests_pass_green(
     assert trace.metrics["test_oracle_unchanged"] == 1.0
 
 
-async def test_green_unrelated_edit_gets_no_suite_reward(
-    tmp_path, runtime, corpus_mini_dir, fixture_manifest_path,
+async def test_verifier_identity_branch_executes_and_fails_closed(
+    tmp_path: Path,
+    runtime,
+    corpus_mini_dir: Path,
+    fixture_manifest_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Starting green and making an unrelated/test-only edit earns no suite credit."""
+    """The verifier identity branch is reachable and fail-closed on the real runtime.
+
+    The image provisions the distinct non-root verifier identity
+    (``base.Dockerfile``); the host subprocess smoke path does not, so force the
+    identity probe to simulate the container. The real checkout construction
+    then executes (git clone/detach/apply against the staged repo), and the
+    root-owned ``chown`` cannot succeed as an unprivileged host user — so
+    construction fails and the re-run must be an explicit zero, never a fallback
+    to the agent-mutable tree, whose suite here is green (contrast
+    ``test_green_suite_records_non_regression``, which scores 1.0 on exactly the
+    mutable-tree fallback shape).
+    """
+    from daydream_review_v1 import taskset
+
+    archive_root = tmp_path / "archive"
+    (archive_root / "runs").mkdir(parents=True)
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    # The fix is COMMITTED: the verifier checkout's candidate diff is
+    # ``git diff <head_sha> HEAD``, i.e. the committed contents, never the
+    # working tree.
+    repo = _stage_repo(tmp_path / "repo", task.data.head_sha, edit=_CALC_FIXED, commit=True)
+    trace = _trace(task, archive_root=archive_root, repo_path=repo)
+
+    async def _identity_available(_runtime: vf.Runtime) -> bool:
+        return True  # container shape: setpriv + verifier user provisioned
+
+    monkeypatch.setattr(taskset, "_verifier_identity_available", _identity_available)
+
+    await task.score(trace, runtime)
+
+    # The oracle gate passed: the zero below comes from the verifier branch's
+    # fail-closed checkout construction, not from a changed test oracle.
+    assert trace.metrics["test_oracle_unchanged"] == 1.0
+    assert trace.metrics["suite_non_regression"] == 0.0
+    # _prepare_verify_checkout really executed its git steps: the verify clone
+    # exists and carries the applied candidate diff (it is left on disk by the
+    # failed construction rather than silently skipped).
+    verify_dir = tmp_path / "repo-verify"
+    assert (verify_dir / "calc.py").read_text(encoding="utf-8") == _CALC_FIXED
+
+
+async def test_green_unrelated_edit_gets_no_suite_reward(
+    tmp_path: Path, runtime, corpus_mini_dir: Path, fixture_manifest_path: Path,
+) -> None:
+    """Starting green and making an unrelated edit earns no suite credit."""
     archive_root = tmp_path / "archive"
     (archive_root / "runs").mkdir(parents=True)
     task = _task(corpus_mini_dir, fixture_manifest_path)
     # The baked head is already green; the agent only touches README (unrelated)
-    # and a test comment (test-only) — the suite stays green.
+    # — the suite stays green.
     repo = _stage_repo(tmp_path / "repo", task.data.head_sha, patch=_REAL_PATCH)
     (repo / "README.md").write_text("# changed\n", encoding="utf-8")
     trace = _trace(task, archive_root=archive_root, repo_path=repo)
@@ -473,7 +521,7 @@ async def test_green_unrelated_edit_gets_no_suite_reward(
     assert trace.metrics["suite_non_regression"] == 1.0
 
 
-async def test_fix_tests_pass_red(
+async def test_red_suite_records_no_non_regression(
     tmp_path: Path, runtime, corpus_mini_dir: Path, fixture_manifest_path: Path
 ) -> None:
     archive_root = tmp_path / "archive"
@@ -489,7 +537,7 @@ async def test_fix_tests_pass_red(
 
 
 async def test_suite_result_is_telemetry_not_reward(
-    tmp_path, runtime, corpus_mini_dir, fixture_manifest_path,
+    tmp_path: Path, runtime, corpus_mini_dir: Path, fixture_manifest_path: Path,
 ) -> None:
     """A green suite no longer sums into the reward: only intrinsic_composite remains."""
     archive_root = tmp_path / "archive"
@@ -508,7 +556,7 @@ async def test_suite_result_is_telemetry_not_reward(
 
 
 async def test_tampered_suite_never_records_honest_non_regression(
-    tmp_path, runtime, rundir_golden, corpus_mini_dir, fixture_manifest_path,
+    tmp_path: Path, runtime, rundir_golden: Path, corpus_mini_dir: Path, fixture_manifest_path: Path,
 ) -> None:
     """A gutted test oracle records suite_non_regression 0.0 and no suite reward."""
     archive_root = tmp_path / "archive"
@@ -538,7 +586,7 @@ async def test_tampered_suite_never_records_honest_non_regression(
     ],
     ids=["test-source-tamper", "test-package-config-tamper", "untracked-oracle-file"],
 )
-async def test_fix_tests_pass_rejects_protected_test_path_changes(
+async def test_suite_rejects_protected_test_path_changes(
     edit: str | None,
     tamper_rel: str,
     tamper_content: str,
@@ -797,7 +845,7 @@ async def test_oracle_gate_rejects_root_sitecustomize(
     ],
     ids=["no-patch-file", "empty-patch", "non-empty-patch-but-untouched-tree", "empty-commit"],
 )
-async def test_no_fixes_returns_no_fix_reward(
+async def test_no_fixes_records_no_non_regression(
     patch: str | None, commit: bool, tmp_path: Path, runtime, corpus_mini_dir: Path, fixture_manifest_path: Path
 ) -> None:
     """An untouched tree records suite_non_regression 0.0 however recommended.patch looks.
@@ -1140,48 +1188,35 @@ async def test_reward_version_is_pinned(
     assert breakdown["intrinsic_reward_version"] == REWARD_VERSION
 
 
-async def test_reward_breakdown_carries_dual_version_stamps(
-    tmp_path, runtime, rundir_golden, corpus_mini_dir, fixture_manifest_path,
-) -> None:
-    """The rollout reward contract and the intrinsic scorer version are two stamps."""
-    from daydream.training.reward import REWARD_VERSION
-
-    from daydream_review_v1.taskset import ROLLOUT_REWARD_VERSION
-
-    assert REWARD_VERSION == "2026.05.28-2"  # intrinsic parity pin (unchanged)
-    assert ROLLOUT_REWARD_VERSION == "2026.08.15-1"
-
-    archive_root = tmp_path / "archive"
-    _stage_run(archive_root, rundir_golden)
-    task = _task(corpus_mini_dir, fixture_manifest_path)
-    trace = _trace(task, archive_root=archive_root, repo_path=tmp_path / "repo")
-
-    await task.score(trace, runtime)
-
-    breakdown = trace.info["reward_breakdown"]
-    assert breakdown["reward_version"] == ROLLOUT_REWARD_VERSION
-    assert breakdown["intrinsic_reward_version"] == REWARD_VERSION
-
-
 async def test_tampered_sealed_artifact_zeroes_intrinsic_and_non_regression(
     tmp_path, runtime, rundir_golden, corpus_mini_dir, fixture_manifest_path,
 ) -> None:
     """A tampered sealed artifact makes the only reward zero and non-regression dishonest."""
     archive_root = tmp_path / "archive"
     run_dir = _stage_run(archive_root, rundir_golden)
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    # The seal binds the committed diff re-derived at verify time; stage a real
+    # repo with a committed fix so the tamper below is the ONLY mismatch.
+    repo = _stage_repo(tmp_path / "repo", task.data.head_sha, edit=_CALC_FIXED, commit=True)
+    diff = subprocess.run(
+        ["git", "-C", str(repo), "diff", task.data.head_sha, "HEAD"],
+        capture_output=True,
+        check=True,
+    ).stdout
     # Harness produced the seal; the agent then rewrote an archived artifact.
     from daydream_review_v1.rundir import RUN_DIR_FILES
     from daydream_review_v1.verifier import seal_artifacts
 
-    present = [run_dir / rel for rel in RUN_DIR_FILES if (run_dir / rel).is_file()]
-    seal = seal_artifacts(present, candidate_diff=b"candidate-diff")
+    present = [
+        run_dir / rel for rel in RUN_DIR_FILES if (run_dir / rel).is_file()
+    ] + sorted(run_dir.glob("deep/stack-*-records.json"))
+    seal = seal_artifacts(present, candidate_diff=diff)
     (run_dir / "seal.json").write_text(seal.model_dump_json(), encoding="utf-8")
     (run_dir / "deep" / "merged-items.json").write_text(
         json.dumps({"items": []}), encoding="utf-8"
     )  # tamper after sealing
 
-    task = _task(corpus_mini_dir, fixture_manifest_path)
-    trace = _trace(task, archive_root=archive_root, repo_path=tmp_path / "repo")
+    trace = _trace(task, archive_root=archive_root, repo_path=repo)
 
     await task.score(trace, runtime)
 
@@ -1196,15 +1231,25 @@ async def test_untampered_sealed_run_scores_normally(
     """An intact seal leaves scoring unchanged."""
     archive_root = tmp_path / "archive"
     run_dir = _stage_run(archive_root, rundir_golden)
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    # The seal must match the committed diff the verifier re-derives at scoring
+    # time from the live repo: stage a real repo with a committed fix.
+    repo = _stage_repo(tmp_path / "repo", task.data.head_sha, edit=_CALC_FIXED, commit=True)
+    diff = subprocess.run(
+        ["git", "-C", str(repo), "diff", task.data.head_sha, "HEAD"],
+        capture_output=True,
+        check=True,
+    ).stdout
     from daydream_review_v1.rundir import RUN_DIR_FILES
     from daydream_review_v1.verifier import seal_artifacts
 
-    present = [run_dir / rel for rel in RUN_DIR_FILES if (run_dir / rel).is_file()]
-    seal = seal_artifacts(present, candidate_diff=b"candidate-diff")
+    present = [
+        run_dir / rel for rel in RUN_DIR_FILES if (run_dir / rel).is_file()
+    ] + sorted(run_dir.glob("deep/stack-*-records.json"))
+    seal = seal_artifacts(present, candidate_diff=diff)
     (run_dir / "seal.json").write_text(seal.model_dump_json(), encoding="utf-8")
 
-    task = _task(corpus_mini_dir, fixture_manifest_path)
-    trace = _trace(task, archive_root=archive_root, repo_path=tmp_path / "repo")
+    trace = _trace(task, archive_root=archive_root, repo_path=repo)
 
     await task.score(trace, runtime)
 
@@ -1214,3 +1259,44 @@ async def test_untampered_sealed_run_scores_normally(
             assemble_scoring_inputs(rundir_golden, _manifest_row_like_production(rundir_golden))
         ).composite
     )
+
+
+async def test_seal_detects_committed_diff_changed_after_sealing(
+    tmp_path, runtime, rundir_golden, corpus_mini_dir, fixture_manifest_path,
+) -> None:
+    """The seal binds the diff applied at scoring time, not a self-consistent record.
+
+    verify_seal re-derives the candidate diff from the live repo, so a commit
+    made after sealing (a tampered committed diff — exactly what the verifier
+    checkout would apply) fails verification. The old tautology — re-hashing
+    the seal's own embedded copy of the diff — could never fail on this.
+    """
+    archive_root = tmp_path / "archive"
+    run_dir = _stage_run(archive_root, rundir_golden)
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    repo = _stage_repo(tmp_path / "repo", task.data.head_sha, edit=_CALC_FIXED, commit=True)
+    diff = subprocess.run(
+        ["git", "-C", str(repo), "diff", task.data.head_sha, "HEAD"],
+        capture_output=True,
+        check=True,
+    ).stdout
+    from daydream_review_v1.rundir import RUN_DIR_FILES
+    from daydream_review_v1.verifier import seal_artifacts
+
+    present = [
+        run_dir / rel for rel in RUN_DIR_FILES if (run_dir / rel).is_file()
+    ] + sorted(run_dir.glob("deep/stack-*-records.json"))
+    seal = seal_artifacts(present, candidate_diff=diff)
+    (run_dir / "seal.json").write_text(seal.model_dump_json(), encoding="utf-8")
+
+    # The committed diff changes after sealing: a second commit past the fix.
+    (repo / "README.md").write_text("# changed\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "-A"], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "--quiet", "-m", "tamper"], check=True)
+
+    trace = _trace(task, archive_root=archive_root, repo_path=repo)
+
+    await task.score(trace, runtime)
+
+    assert trace.metrics["seal_verified"] == 0.0
+    assert trace.rewards["intrinsic_composite"] == 0.0

--- a/rl/daydream_review_v1/tests/test_rewards.py
+++ b/rl/daydream_review_v1/tests/test_rewards.py
@@ -451,6 +451,28 @@ async def test_fix_tests_pass_green(
     assert trace.metrics["test_oracle_unchanged"] == 1.0
 
 
+async def test_green_unrelated_edit_gets_no_suite_reward(
+    tmp_path, runtime, corpus_mini_dir, fixture_manifest_path,
+) -> None:
+    """Starting green and making an unrelated/test-only edit earns no suite credit."""
+    archive_root = tmp_path / "archive"
+    (archive_root / "runs").mkdir(parents=True)
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    # The baked head is already green; the agent only touches README (unrelated)
+    # and a test comment (test-only) — the suite stays green.
+    repo = _stage_repo(tmp_path / "repo", task.data.head_sha, patch=_REAL_PATCH)
+    (repo / "README.md").write_text("# changed\n", encoding="utf-8")
+    trace = _trace(task, archive_root=archive_root, repo_path=repo)
+
+    await task.score(trace, runtime)
+
+    # Suite green is telemetry, never a reward axis.
+    assert set(trace.rewards) == {"intrinsic_composite"}
+    assert trace.metrics["fixes_applied"] == 1.0
+    assert trace.metrics["test_oracle_unchanged"] == 1.0
+    assert trace.metrics["suite_non_regression"] == 1.0
+
+
 async def test_fix_tests_pass_red(
     tmp_path: Path, runtime, corpus_mini_dir: Path, fixture_manifest_path: Path
 ) -> None:
@@ -1095,6 +1117,7 @@ async def test_reward_version_is_pinned(
     intrinsic scorer it was evaluated against (``intrinsic_reward_version``).
     """
     from daydream.training.reward import REWARD_VERSION
+
     from daydream_review_v1.taskset import ROLLOUT_REWARD_VERSION
 
     assert REWARD_VERSION == "2026.05.28-2", (
@@ -1122,6 +1145,7 @@ async def test_reward_breakdown_carries_dual_version_stamps(
 ) -> None:
     """The rollout reward contract and the intrinsic scorer version are two stamps."""
     from daydream.training.reward import REWARD_VERSION
+
     from daydream_review_v1.taskset import ROLLOUT_REWARD_VERSION
 
     assert REWARD_VERSION == "2026.05.28-2"  # intrinsic parity pin (unchanged)

--- a/rl/daydream_review_v1/tests/test_rewards.py
+++ b/rl/daydream_review_v1/tests/test_rewards.py
@@ -1161,3 +1161,56 @@ async def test_reward_breakdown_carries_dual_version_stamps(
     breakdown = trace.info["reward_breakdown"]
     assert breakdown["reward_version"] == ROLLOUT_REWARD_VERSION
     assert breakdown["intrinsic_reward_version"] == REWARD_VERSION
+
+
+async def test_tampered_sealed_artifact_zeroes_intrinsic_and_non_regression(
+    tmp_path, runtime, rundir_golden, corpus_mini_dir, fixture_manifest_path,
+) -> None:
+    """A tampered sealed artifact makes the only reward zero and non-regression dishonest."""
+    archive_root = tmp_path / "archive"
+    run_dir = _stage_run(archive_root, rundir_golden)
+    # Harness produced the seal; the agent then rewrote an archived artifact.
+    from daydream_review_v1.rundir import RUN_DIR_FILES
+    from daydream_review_v1.verifier import seal_artifacts
+
+    present = [run_dir / rel for rel in RUN_DIR_FILES if (run_dir / rel).is_file()]
+    seal = seal_artifacts(present, candidate_diff=b"candidate-diff")
+    (run_dir / "seal.json").write_text(seal.model_dump_json(), encoding="utf-8")
+    (run_dir / "deep" / "merged-items.json").write_text(
+        json.dumps({"items": []}), encoding="utf-8"
+    )  # tamper after sealing
+
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    trace = _trace(task, archive_root=archive_root, repo_path=tmp_path / "repo")
+
+    await task.score(trace, runtime)
+
+    assert trace.metrics["seal_verified"] == 0.0
+    assert trace.rewards["intrinsic_composite"] == 0.0
+    assert trace.metrics["suite_non_regression"] == 0.0
+
+
+async def test_untampered_sealed_run_scores_normally(
+    tmp_path, runtime, rundir_golden, corpus_mini_dir, fixture_manifest_path,
+) -> None:
+    """An intact seal leaves scoring unchanged."""
+    archive_root = tmp_path / "archive"
+    run_dir = _stage_run(archive_root, rundir_golden)
+    from daydream_review_v1.rundir import RUN_DIR_FILES
+    from daydream_review_v1.verifier import seal_artifacts
+
+    present = [run_dir / rel for rel in RUN_DIR_FILES if (run_dir / rel).is_file()]
+    seal = seal_artifacts(present, candidate_diff=b"candidate-diff")
+    (run_dir / "seal.json").write_text(seal.model_dump_json(), encoding="utf-8")
+
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    trace = _trace(task, archive_root=archive_root, repo_path=tmp_path / "repo")
+
+    await task.score(trace, runtime)
+
+    assert trace.metrics["seal_verified"] == 1.0
+    assert trace.rewards["intrinsic_composite"] == (
+        score_trajectory(
+            assemble_scoring_inputs(rundir_golden, _manifest_row_like_production(rundir_golden))
+        ).composite
+    )

--- a/rl/daydream_review_v1/tests/test_rewards.py
+++ b/rl/daydream_review_v1/tests/test_rewards.py
@@ -73,7 +73,7 @@ def _trace(task: DaydreamReviewTask, *, archive_root: Path, repo_path: Path) -> 
 
 
 def _assert_gate_held(trace: vf.Trace) -> None:
-    """A test-oracle change must earn a literal zero, never the w_tests reward.
+    """A test-oracle change must zero suite_non_regression, never pay a reward.
 
     The staged ``deep/test-verdict.json`` claim (passed=True) makes the tripwire
     load-bearing: any execution of test_command records ``test_claim_mismatch``,
@@ -82,7 +82,8 @@ def _assert_gate_held(trace: vf.Trace) -> None:
     """
     assert trace.metrics["fixes_applied"] == 1.0
     assert trace.metrics["test_oracle_unchanged"] == 0.0
-    assert trace.rewards["fix_tests_pass"] == 0.0
+    assert trace.metrics["suite_non_regression"] == 0.0
+    assert "fix_tests_pass" not in trace.rewards
     assert "test_claim_mismatch" not in trace.metrics
 
 
@@ -446,7 +447,7 @@ async def test_fix_tests_pass_green(
     await task.score(trace, runtime)
 
     assert trace.metrics["fixes_applied"] == 1.0
-    assert trace.rewards["fix_tests_pass"] == 1.0
+    assert trace.metrics["suite_non_regression"] == 1.0
     assert trace.metrics["test_oracle_unchanged"] == 1.0
 
 
@@ -462,7 +463,44 @@ async def test_fix_tests_pass_red(
     await task.score(trace, runtime)
 
     assert trace.metrics["fixes_applied"] == 1.0
-    assert trace.rewards["fix_tests_pass"] == 0.0
+    assert trace.metrics["suite_non_regression"] == 0.0
+
+
+async def test_suite_result_is_telemetry_not_reward(
+    tmp_path, runtime, corpus_mini_dir, fixture_manifest_path,
+) -> None:
+    """A green suite no longer sums into the reward: only intrinsic_composite remains."""
+    archive_root = tmp_path / "archive"
+    (archive_root / "runs").mkdir(parents=True)
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    repo = _stage_repo(tmp_path / "repo", task.data.head_sha, edit=_CALC_FIXED, patch=_REAL_PATCH)
+    trace = _trace(task, archive_root=archive_root, repo_path=repo)
+
+    await task.score(trace, runtime)
+
+    assert set(trace.rewards) == {"intrinsic_composite"}
+    assert "fix_tests_pass" not in trace.rewards
+    assert trace.metrics["fixes_applied"] == 1.0
+    assert trace.metrics["test_oracle_unchanged"] == 1.0
+    assert trace.metrics["suite_non_regression"] == 1.0
+
+
+async def test_tampered_suite_never_records_honest_non_regression(
+    tmp_path, runtime, rundir_golden, corpus_mini_dir, fixture_manifest_path,
+) -> None:
+    """A gutted test oracle records suite_non_regression 0.0 and no suite reward."""
+    archive_root = tmp_path / "archive"
+    _stage_run(archive_root, rundir_golden)
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    repo = _stage_repo(tmp_path / "repo", task.data.head_sha, edit=_CALC_FIXED)
+    (repo / "tests/test_calc.py").write_text(_TAMPER_PASSING, encoding="utf-8")
+    trace = _trace(task, archive_root=archive_root, repo_path=repo)
+
+    await task.score(trace, runtime)
+
+    assert "fix_tests_pass" not in trace.rewards
+    assert trace.metrics["test_oracle_unchanged"] == 0.0
+    assert trace.metrics["suite_non_regression"] == 0.0
 
 
 @pytest.mark.parametrize(
@@ -488,7 +526,7 @@ async def test_fix_tests_pass_rejects_protected_test_path_changes(
     corpus_mini_dir: Path,
     fixture_manifest_path: Path,
 ) -> None:
-    """A changed test oracle earns a literal zero, never the w_tests reward.
+    """A changed test oracle records suite_non_regression 0.0, never an honest reading.
 
     Every tamper row is deliberately green-if-run: a vulnerable impl that
     executes the tampered oracle gets exit 0 -> reward 1.0. The gate must
@@ -563,7 +601,7 @@ async def test_oracle_gate_rejects_flag_tampered_tracked_file(
     _stage_run(archive_root, rundir_golden)
     task = _task(corpus_mini_dir, fixture_manifest_path)
     # A real fix (calc.py) plus a flagged, gutted tracked test: diff is fooled,
-    # so only the flag probe stands between this and a free w_tests.
+    # so only the flag probe stands between this and a free green reading.
     repo = _stage_repo(tmp_path / "repo", task.data.head_sha, edit=_CALC_FIXED)
     (repo / "tests/test_calc.py").write_text(_TAMPER_PASSING, encoding="utf-8")
     subprocess.run(
@@ -680,7 +718,7 @@ async def test_oracle_gate_green_despite_suite_bytecode_artifacts(
     The untracked probe lists every untracked file under a protected path (no
     ``--exclude-standard``), so the ``__pycache__/`` and ``*.py[cod]`` files a
     legitimate test run drops while importing ``tests/`` would otherwise read as
-    an oracle change and withhold ``w_tests`` from a genuinely fixed tree. Those
+    an oracle change and withhold a green non-regression reading from a genuinely fixed tree. Those
     artifacts are excluded explicitly via ``ORACLE_BENIGN_PATHSPECS`` — never
     loaded by the runner, so excluding them cannot hide a real oracle file.
     """
@@ -698,7 +736,7 @@ async def test_oracle_gate_green_despite_suite_bytecode_artifacts(
 
     assert trace.metrics["fixes_applied"] == 1.0
     assert trace.metrics["test_oracle_unchanged"] == 1.0
-    assert trace.rewards["fix_tests_pass"] == 1.0
+    assert trace.metrics["suite_non_regression"] == 1.0
 
 
 async def test_oracle_gate_rejects_root_sitecustomize(
@@ -740,14 +778,14 @@ async def test_oracle_gate_rejects_root_sitecustomize(
 async def test_no_fixes_returns_no_fix_reward(
     patch: str | None, commit: bool, tmp_path: Path, runtime, corpus_mini_dir: Path, fixture_manifest_path: Path
 ) -> None:
-    """An untouched tree earns no_fix_reward however recommended.patch looks.
+    """An untouched tree records suite_non_regression 0.0 however recommended.patch looks.
 
     The third case is the one that matters. daydream writes `.daydream/` INTO the
     repository under review, and `capture_recommended_patch` appends a creation
     hunk for every untracked non-ignored file — so on any repository that does not
     gitignore that directory (i.e. every real repository), the patch is non-empty
     after a rollout that changed nothing. Reading it as "a fix landed" would hand
-    out the full w_tests off the still-green baseline, for free, forever.
+    out a free green non-regression reading off the still-green baseline, for free, forever.
     """
     archive_root = tmp_path / "archive"
     (archive_root / "runs").mkdir(parents=True)
@@ -758,7 +796,7 @@ async def test_no_fixes_returns_no_fix_reward(
     await task.score(trace, runtime)
 
     assert trace.metrics["fixes_applied"] == 0.0
-    assert trace.rewards["fix_tests_pass"] == task.config.no_fix_reward
+    assert trace.metrics["suite_non_regression"] == 0.0
     assert "test_claim_mismatch" not in trace.metrics
     # No archived run at all, so there is no claim to record either.
     assert "test_claim_passed_without_fix" not in trace.metrics
@@ -773,7 +811,7 @@ async def test_unresolvable_head_sha_scores_no_fix(
     `git diff --quiet <head_sha> HEAD` exits 128 when the head object is absent
     from the object store (the documented `exit_code != 1` branch in
     `_fixes_applied`). Unlike a string comparison on `rev-parse`, that must not
-    be scored as a fix: every non-1 exit is `no_fix_reward`, honoring the
+    be scored as a fix: every non-1 exit records suite_non_regression 0.0, honoring the
     deliberate false-negative bias.
     """
     archive_root = tmp_path / "archive"
@@ -788,7 +826,7 @@ async def test_unresolvable_head_sha_scores_no_fix(
     await task.score(trace, runtime)
 
     assert trace.metrics["fixes_applied"] == 0.0
-    assert trace.rewards["fix_tests_pass"] == task.config.no_fix_reward
+    assert trace.metrics["suite_non_regression"] == 0.0
 
 
 @pytest.mark.parametrize("claimed", [True, False], ids=["claimed-green", "claimed-red"])
@@ -820,7 +858,7 @@ async def test_no_fixes_still_records_the_test_claim(
     await task.score(trace, runtime)
 
     assert trace.metrics["fixes_applied"] == 0.0
-    assert trace.rewards["fix_tests_pass"] == task.config.no_fix_reward
+    assert trace.metrics["suite_non_regression"] == 0.0
     assert trace.metrics["test_claim_passed_without_fix"] == float(claimed)
     # Observability only: recording the claim must not invent a verdict comparison.
     assert "test_claim_mismatch" not in trace.metrics
@@ -904,7 +942,7 @@ async def test_metric_claim_mismatch_fires(
     await task.score(trace, runtime)
 
     assert trace.metrics["fixes_applied"] == 1.0
-    assert trace.rewards["fix_tests_pass"] == (0.0 if red else 1.0)
+    assert trace.metrics["suite_non_regression"] == (0.0 if red else 1.0)
     assert trace.metrics["test_claim_mismatch"] == expected
 
 
@@ -978,7 +1016,7 @@ async def test_committed_fix_counts_even_with_a_clean_tree(
     await task.score(trace, runtime)
 
     assert trace.metrics["fixes_applied"] == 1.0
-    assert trace.rewards["fix_tests_pass"] == 1.0
+    assert trace.metrics["suite_non_regression"] == 1.0
     assert trace.metrics["test_oracle_unchanged"] == 1.0
 
 
@@ -991,9 +1029,9 @@ async def test_committed_daydream_artifacts_not_a_fix(
     ``.daydream/`` (only the fixture does), so a no-fix rollout whose agent
     commits daydream's own untracked artifacts produces a tree that differs from
     the baked snapshot — which ``git diff --quiet <head_sha> HEAD`` would read as
-    a fix and pay the full ``w_tests`` off a still-green baseline. Committing the
-    artifacts (force-added, since the fixture ignores them) must score
-    ``no_fix_reward``.
+    a fix and pay a free green non-regression reading off a still-green baseline. Committing the
+    artifacts (force-added, since the fixture ignores them) must record
+    ``suite_non_regression`` 0.0.
     """
     archive_root = tmp_path / "archive"
     (archive_root / "runs").mkdir(parents=True)
@@ -1006,7 +1044,7 @@ async def test_committed_daydream_artifacts_not_a_fix(
     await task.score(trace, runtime)
 
     assert trace.metrics["fixes_applied"] == 0.0
-    assert trace.rewards["fix_tests_pass"] == task.config.no_fix_reward
+    assert trace.metrics["suite_non_regression"] == 0.0
     assert "test_claim_mismatch" not in trace.metrics
 
 
@@ -1015,11 +1053,11 @@ async def test_unresolvable_snapshot_sha_reads_as_no_fix(
 ) -> None:
     """A fix signal that cannot be evaluated reads as no-fix, not a free win.
 
-    ``fix_tests_pass`` stays deliberately false-negative biased: any ``git diff
+    ``suite_non_regression`` stays deliberately false-negative biased: any ``git diff
     --quiet`` exit other than 1 (0 = identical trees, 128 = unresolvable baked
     SHA, 127 = missing sh/git) means "no fix found". Here the baked snapshot SHA
     is not present in the repository at all, so the diff exits 128 — the reward
-    must be ``no_fix_reward``, never the full ``w_tests`` for nothing.
+    must record ``suite_non_regression`` 0.0, never a free green reading for nothing.
     """
     archive_root = tmp_path / "archive"
     (archive_root / "runs").mkdir(parents=True)
@@ -1040,24 +1078,31 @@ async def test_unresolvable_snapshot_sha_reads_as_no_fix(
     await task.score(trace, runtime)
 
     assert trace.metrics["fixes_applied"] == 0.0
-    assert trace.rewards["fix_tests_pass"] == task.config.no_fix_reward
+    assert trace.metrics["suite_non_regression"] == 0.0
 
 
 async def test_reward_version_is_pinned(
     tmp_path: Path, runtime, rundir_golden: Path, corpus_mini_dir: Path, fixture_manifest_path: Path
 ) -> None:
-    """AC-3: pin the scorer version the parity test cannot see move.
+    """AC-3: pin the scorer version the parity test cannot see move — both stamps.
 
     `test_intrinsic_composite_parity` runs the same `score_trajectory` on both
     sides, so a REWARD_VERSION bump moves expectation and actual together and the
     parity assertion stays green through a semantic change. This is the assertion
-    that actually fails when the offline scorer changes under us.
+    that actually fails when the offline scorer changes under us. Since the
+    demotion, the aggregate rollout contract carries its own version: the
+    breakdown stamps both the rollout boundary (``reward_version``) and the
+    intrinsic scorer it was evaluated against (``intrinsic_reward_version``).
     """
     from daydream.training.reward import REWARD_VERSION
+    from daydream_review_v1.taskset import ROLLOUT_REWARD_VERSION
 
     assert REWARD_VERSION == "2026.05.28-2", (
         f"the training pipeline's reward version moved to {REWARD_VERSION!r}. Re-derive the "
         "rollout reward's expected values before trusting any run scored across the boundary."
+    )
+    assert ROLLOUT_REWARD_VERSION == "2026.08.15-1", (
+        f"the rollout reward contract version moved to {ROLLOUT_REWARD_VERSION!r}"
     )
 
     archive_root = tmp_path / "archive"
@@ -1067,7 +1112,9 @@ async def test_reward_version_is_pinned(
 
     await task.score(trace, runtime)
 
-    assert trace.info["reward_breakdown"]["reward_version"] == REWARD_VERSION
+    breakdown = trace.info["reward_breakdown"]
+    assert breakdown["reward_version"] == ROLLOUT_REWARD_VERSION
+    assert breakdown["intrinsic_reward_version"] == REWARD_VERSION
 
 
 async def test_reward_breakdown_carries_dual_version_stamps(

--- a/rl/daydream_review_v1/tests/test_rewards.py
+++ b/rl/daydream_review_v1/tests/test_rewards.py
@@ -11,6 +11,7 @@ in ``trace.info`` makes the reward path run real ``sh`` and real reads.
 from __future__ import annotations
 
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -291,6 +292,32 @@ _REAL_PATCH = "diff --git a/tests/test_calc.py b/tests/test_calc.py\n@@ -1 +1 @@
 
 _CALC_FIXED = _CALC_BROKEN.replace("return a + b + 1", "return a + b")
 
+
+def _seal_run(run_dir: Path, task: DaydreamReviewTask, repo_path: Path) -> Path:
+    """Harness-side seal production over a staged committed-fix repo.
+
+    Stages the fixture repo with the fix COMMITTED (the seal binds the committed
+    diff the verifier re-derives at scoring time, never the working tree),
+    hashes the archive members the harness recorded, and writes ``seal.json``
+    into *run_dir*. Returns the staged repo path.
+    """
+    from daydream_review_v1.rundir import RUN_DIR_FILES
+    from daydream_review_v1.verifier import seal_artifacts
+
+    repo = _stage_repo(repo_path, task.data.head_sha, edit=_CALC_FIXED, commit=True)
+    diff = subprocess.run(
+        ["git", "-C", str(repo), "diff", task.data.head_sha, "HEAD"],
+        capture_output=True,
+        check=True,
+    ).stdout
+    present = [
+        run_dir / rel for rel in RUN_DIR_FILES if (run_dir / rel).is_file()
+    ] + sorted(run_dir.glob("deep/stack-*-records.json"))
+    seal = seal_artifacts(present, candidate_diff=diff)
+    (run_dir / "seal.json").write_text(seal.model_dump_json(), encoding="utf-8")
+    return repo
+
+
 # A gutted suite that PASSES if run: a vulnerable impl that executes the
 # tampered oracle gets exit 0 -> reward 1.0. The gate must return 0.0 instead.
 _TAMPER_PASSING = (
@@ -458,17 +485,20 @@ async def test_verifier_identity_branch_executes_and_fails_closed(
     fixture_manifest_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The verifier identity branch is reachable and fail-closed on the real runtime.
+    """The verifier identity branch is reachable and never falls back to the mutable tree.
 
     The image provisions the distinct non-root verifier identity
     (``base.Dockerfile``); the host subprocess smoke path does not, so force the
     identity probe to simulate the container. The real checkout construction
-    then executes (git clone/detach/apply against the staged repo), and the
-    root-owned ``chown`` cannot succeed as an unprivileged host user — so
-    construction fails and the re-run must be an explicit zero, never a fallback
-    to the agent-mutable tree, whose suite here is green (contrast
-    ``test_green_suite_records_non_regression``, which scores 1.0 on exactly the
-    mutable-tree fallback shape).
+    then executes (git clone/detach/apply against the staged repo). On an
+    unprivileged host the root-owned ``chown`` cannot succeed, so construction
+    fails and the re-run must be an explicit zero — fail-closed, never a
+    fallback to the agent-mutable tree, whose suite here is green (contrast
+    ``test_green_suite_records_non_regression``, which scores 1.0 on exactly
+    the mutable-tree fallback shape). On a root host with the verifier identity
+    (the production container shape) the ``chown`` succeeds and the suite
+    re-runs green under the verifier identity instead; the expected reading
+    follows the host shape either way.
     """
     from daydream_review_v1 import taskset
 
@@ -481,6 +511,11 @@ async def test_verifier_identity_branch_executes_and_fails_closed(
     repo = _stage_repo(tmp_path / "repo", task.data.head_sha, edit=_CALC_FIXED, commit=True)
     trace = _trace(task, archive_root=archive_root, repo_path=repo)
 
+    # Keep the real host probe (setpriv + verifier user) before it is replaced:
+    # the assertion below must know whether the host can actually complete the
+    # verifier re-run, not just whether the branch was forced on.
+    real_identity_available = taskset._verifier_identity_available
+
     async def _identity_available(_runtime: vf.Runtime) -> bool:
         return True  # container shape: setpriv + verifier user provisioned
 
@@ -488,10 +523,16 @@ async def test_verifier_identity_branch_executes_and_fails_closed(
 
     await task.score(trace, runtime)
 
-    # The oracle gate passed: the zero below comes from the verifier branch's
-    # fail-closed checkout construction, not from a changed test oracle.
+    # The oracle gate passed: the reading below comes from the verifier branch,
+    # not from a changed test oracle.
     assert trace.metrics["test_oracle_unchanged"] == 1.0
-    assert trace.metrics["suite_non_regression"] == 0.0
+    # The expected suite reading follows the host shape: the root-owned chown
+    # only fails on an unprivileged host, so there construction fails closed to
+    # an explicit zero; on a root host with the verifier identity the checkout
+    # is built and the suite re-runs green under the verifier identity. Both
+    # shapes prove the re-run never fell back to the agent-mutable tree.
+    verifier_rerun_succeeds = os.geteuid() == 0 and await real_identity_available(runtime)
+    assert trace.metrics["suite_non_regression"] == (1.0 if verifier_rerun_succeeds else 0.0)
     # _prepare_verify_checkout really executed its git steps: the verify clone
     # exists and carries the applied candidate diff (it is left on disk by the
     # failed construction rather than silently skipped).
@@ -1195,23 +1236,8 @@ async def test_tampered_sealed_artifact_zeroes_intrinsic_and_non_regression(
     archive_root = tmp_path / "archive"
     run_dir = _stage_run(archive_root, rundir_golden)
     task = _task(corpus_mini_dir, fixture_manifest_path)
-    # The seal binds the committed diff re-derived at verify time; stage a real
-    # repo with a committed fix so the tamper below is the ONLY mismatch.
-    repo = _stage_repo(tmp_path / "repo", task.data.head_sha, edit=_CALC_FIXED, commit=True)
-    diff = subprocess.run(
-        ["git", "-C", str(repo), "diff", task.data.head_sha, "HEAD"],
-        capture_output=True,
-        check=True,
-    ).stdout
     # Harness produced the seal; the agent then rewrote an archived artifact.
-    from daydream_review_v1.rundir import RUN_DIR_FILES
-    from daydream_review_v1.verifier import seal_artifacts
-
-    present = [
-        run_dir / rel for rel in RUN_DIR_FILES if (run_dir / rel).is_file()
-    ] + sorted(run_dir.glob("deep/stack-*-records.json"))
-    seal = seal_artifacts(present, candidate_diff=diff)
-    (run_dir / "seal.json").write_text(seal.model_dump_json(), encoding="utf-8")
+    repo = _seal_run(run_dir, task, tmp_path / "repo")
     (run_dir / "deep" / "merged-items.json").write_text(
         json.dumps({"items": []}), encoding="utf-8"
     )  # tamper after sealing
@@ -1232,22 +1258,7 @@ async def test_untampered_sealed_run_scores_normally(
     archive_root = tmp_path / "archive"
     run_dir = _stage_run(archive_root, rundir_golden)
     task = _task(corpus_mini_dir, fixture_manifest_path)
-    # The seal must match the committed diff the verifier re-derives at scoring
-    # time from the live repo: stage a real repo with a committed fix.
-    repo = _stage_repo(tmp_path / "repo", task.data.head_sha, edit=_CALC_FIXED, commit=True)
-    diff = subprocess.run(
-        ["git", "-C", str(repo), "diff", task.data.head_sha, "HEAD"],
-        capture_output=True,
-        check=True,
-    ).stdout
-    from daydream_review_v1.rundir import RUN_DIR_FILES
-    from daydream_review_v1.verifier import seal_artifacts
-
-    present = [
-        run_dir / rel for rel in RUN_DIR_FILES if (run_dir / rel).is_file()
-    ] + sorted(run_dir.glob("deep/stack-*-records.json"))
-    seal = seal_artifacts(present, candidate_diff=diff)
-    (run_dir / "seal.json").write_text(seal.model_dump_json(), encoding="utf-8")
+    repo = _seal_run(run_dir, task, tmp_path / "repo")
 
     trace = _trace(task, archive_root=archive_root, repo_path=repo)
 
@@ -1274,20 +1285,7 @@ async def test_seal_detects_committed_diff_changed_after_sealing(
     archive_root = tmp_path / "archive"
     run_dir = _stage_run(archive_root, rundir_golden)
     task = _task(corpus_mini_dir, fixture_manifest_path)
-    repo = _stage_repo(tmp_path / "repo", task.data.head_sha, edit=_CALC_FIXED, commit=True)
-    diff = subprocess.run(
-        ["git", "-C", str(repo), "diff", task.data.head_sha, "HEAD"],
-        capture_output=True,
-        check=True,
-    ).stdout
-    from daydream_review_v1.rundir import RUN_DIR_FILES
-    from daydream_review_v1.verifier import seal_artifacts
-
-    present = [
-        run_dir / rel for rel in RUN_DIR_FILES if (run_dir / rel).is_file()
-    ] + sorted(run_dir.glob("deep/stack-*-records.json"))
-    seal = seal_artifacts(present, candidate_diff=diff)
-    (run_dir / "seal.json").write_text(seal.model_dump_json(), encoding="utf-8")
+    repo = _seal_run(run_dir, task, tmp_path / "repo")
 
     # The committed diff changes after sealing: a second commit past the fix.
     (repo / "README.md").write_text("# changed\n", encoding="utf-8")
@@ -1300,3 +1298,64 @@ async def test_seal_detects_committed_diff_changed_after_sealing(
 
     assert trace.metrics["seal_verified"] == 0.0
     assert trace.rewards["intrinsic_composite"] == 0.0
+
+
+async def test_vanished_seal_on_a_harness_sealed_run_is_a_tamper(
+    tmp_path, runtime, rundir_golden, corpus_mini_dir, fixture_manifest_path,
+) -> None:
+    """A harness-sealed run whose seal vanished is a tamper, never legacy unsealed.
+
+    verify_seal's ``None`` is the legacy path only when no seal was expected:
+    the harness recorded ``daydream_seal_ok=True``, so a missing ``seal.json``
+    at scoring time is an internal contradiction and must fail closed
+    (``seal_verified`` 0.0, zero intrinsic, no honest non-regression) instead
+    of scoring the run at full trust.
+    """
+    archive_root = tmp_path / "archive"
+    _stage_run(archive_root, rundir_golden)  # staged copy carries no seal.json
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    repo = _stage_repo(tmp_path / "repo", task.data.head_sha, edit=_CALC_FIXED, commit=True)
+    trace = _trace(task, archive_root=archive_root, repo_path=repo)
+    trace.info["daydream_seal_ok"] = True  # the harness claims it sealed the run
+
+    await task.score(trace, runtime)
+
+    assert trace.metrics["seal_verified"] == 0.0
+    assert trace.rewards["intrinsic_composite"] == 0.0
+    assert trace.metrics["suite_non_regression"] == 0.0
+
+
+async def test_git_failure_at_verify_time_fails_closed(
+    tmp_path, runtime, rundir_golden, corpus_mini_dir, fixture_manifest_path,
+) -> None:
+    """A scoring-time diff re-derivation failure must not hash as the empty diff.
+
+    seal_archived_run records ``b""`` when git fails at seal time; if
+    verify_seal mapped a scoring-time git failure to ``b""`` too, a git failure
+    at BOTH times would yield matching sha256(b"") digests and verify True
+    (``seal_verified`` 1.0) on a run whose diff was never re-derived. A failed
+    re-derivation must fail closed like any other unverifiable seal.
+    """
+    archive_root = tmp_path / "archive"
+    run_dir = _stage_run(archive_root, rundir_golden)
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    from daydream_review_v1.rundir import RUN_DIR_FILES
+    from daydream_review_v1.verifier import seal_artifacts
+
+    present = [
+        run_dir / rel for rel in RUN_DIR_FILES if (run_dir / rel).is_file()
+    ] + sorted(run_dir.glob("deep/stack-*-records.json"))
+    # A seal produced while git failed at seal time seals the empty diff.
+    seal = seal_artifacts(present, candidate_diff=b"")
+    (run_dir / "seal.json").write_text(seal.model_dump_json(), encoding="utf-8")
+
+    # The repo under review is not a git repository: ``git diff`` fails at
+    # scoring time with a non-zero exit, exactly the empty-diff collision.
+    trace = _trace(task, archive_root=archive_root, repo_path=tmp_path / "not-a-repo")
+    trace.info["daydream_seal_ok"] = True
+
+    await task.score(trace, runtime)
+
+    assert trace.metrics["seal_verified"] == 0.0
+    assert trace.rewards["intrinsic_composite"] == 0.0
+    assert trace.metrics["suite_non_regression"] == 0.0

--- a/rl/daydream_review_v1/tests/test_verifier.py
+++ b/rl/daydream_review_v1/tests/test_verifier.py
@@ -71,3 +71,33 @@ def test_seal_json_roundtrip(tmp_path):
     assert parsed == seal
     assert json.loads(raw)["algorithm"] == "sha256"
     assert verify(parsed, [a], candidate_diff=b"candidate-diff") is True
+
+
+def test_validate_rejects_unsupported_algorithm():
+    """A seal.json with a downgraded algorithm (e.g. md5) must fail closed."""
+    import pytest
+
+    from daydream_review_v1.verifier import SealResult
+
+    raw = json.dumps(
+        {
+            "algorithm": "md5",
+            "artifact_digests": {"a.json": "0" * 32},
+            "candidate_diff_digest": "0" * 64,
+            "candidate_diff": "",
+        }
+    )
+    with pytest.raises(ValueError, match="unsupported seal algorithm"):
+        SealResult.model_validate_json(raw)
+
+
+def test_validate_rejects_malformed_json():
+    """Garbage seal.json content must fail closed as a verification failure."""
+    import pytest
+
+    from daydream_review_v1.verifier import SealResult
+
+    with pytest.raises(ValueError, match="not valid JSON"):
+        SealResult.model_validate_json("this is not json{")
+    with pytest.raises(ValueError, match="must be a JSON object"):
+        SealResult.model_validate_json('["not", "an", "object"]')

--- a/rl/daydream_review_v1/tests/test_verifier.py
+++ b/rl/daydream_review_v1/tests/test_verifier.py
@@ -1,0 +1,73 @@
+"""Seal/verify primitive for reward artifact isolation — stdlib only.
+
+The reward must consume only state the rollout agent cannot rewrite. The
+supervisor seals the staged run-dir artifacts (with the candidate diff) and the
+reward verifies the seal before trusting any value; an attempted tamper must
+make verification fail. These tests pin the round-trip and every tamper shape.
+"""
+
+from __future__ import annotations
+
+import json
+
+
+def test_seal_verify_roundtrip(tmp_path):
+    from daydream_review_v1.verifier import seal_artifacts, verify
+
+    a = tmp_path / "a.json"
+    a.write_text('{"x": 1}', encoding="utf-8")
+    d = tmp_path / "deep"
+    d.mkdir()
+    b = d / "b.json"
+    b.write_text('{"y": 2}', encoding="utf-8")
+    diff = b"diff --git a/a b/a"
+
+    seal = seal_artifacts([a, b], candidate_diff=diff)
+    assert verify(seal, [a, b], candidate_diff=diff) is True
+
+
+def test_verify_detects_tampered_artifact(tmp_path):
+    from daydream_review_v1.verifier import seal_artifacts, verify
+
+    a = tmp_path / "a.json"
+    a.write_text('{"x": 1}', encoding="utf-8")
+    seal = seal_artifacts([a], candidate_diff=b"")
+    a.write_text('{"x": 999}', encoding="utf-8")  # agent rewrote it
+
+    assert verify(seal, [a], candidate_diff=b"") is False
+
+
+def test_verify_detects_altered_candidate_diff(tmp_path):
+    from daydream_review_v1.verifier import seal_artifacts, verify
+
+    a = tmp_path / "a.json"
+    a.write_text('{"x": 1}', encoding="utf-8")
+    seal = seal_artifacts([a], candidate_diff=b"patch-v1")
+
+    assert verify(seal, [a], candidate_diff=b"patch-v2") is False
+
+
+def test_verify_detects_missing_artifact(tmp_path):
+    from daydream_review_v1.verifier import seal_artifacts, verify
+
+    a = tmp_path / "a.json"
+    a.write_text('{"x": 1}', encoding="utf-8")
+    seal = seal_artifacts([a], candidate_diff=b"")
+    a.unlink()
+
+    assert verify(seal, [a], candidate_diff=b"") is False
+
+
+def test_seal_json_roundtrip(tmp_path):
+    """The seal serializes to JSON and parses back to the same verification result."""
+    from daydream_review_v1.verifier import SealResult, seal_artifacts, verify
+
+    a = tmp_path / "a.json"
+    a.write_text('{"x": 1}', encoding="utf-8")
+    seal = seal_artifacts([a], candidate_diff=b"candidate-diff")
+
+    raw = seal.model_dump_json()
+    parsed = SealResult.model_validate_json(raw)
+    assert parsed == seal
+    assert json.loads(raw)["algorithm"] == "sha256"
+    assert verify(parsed, [a], candidate_diff=b"candidate-diff") is True

--- a/rl/daydream_review_v1/uv.lock
+++ b/rl/daydream_review_v1/uv.lock
@@ -446,7 +446,7 @@ dev = [
 
 [[package]]
 name = "daydream-review-v1"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "daydream" },


### PR DESCRIPTION
## Summary

- Isolates RL reward scoring against mutable agent state for the daydream_review_v1 harness
- Adds a stdlib-only seal/verify primitive and a read-only verifier identity (run-as-agent wrapper with user separation) so the reward artifact cannot be tampered with between staging and scoring
- Consolidates issues #450, #452, #453

## Motivation

Reward scoring was reading mutable agent state, so an agent (or a compromised run) could influence its own reward. This makes the reward derivation deterministic and tamper-evident: the artifact is sealed at the staging seam and fails closed if the seal is ever lost or altered.

Closes #580

## Changes

- `feat(reward)`: add `ROLLOUT_REWARD_VERSION` and dual-version `reward_breakdown` stamp
- `refactor(reward)`: demote suite result to `suite_non_regression` telemetry, drop `w_tests`/`no_fix_reward`
- `test(reward)`: negative-control green baseline earns no suite-derived reward
- `feat(verifier)`: stdlib-only seal/verify primitive for reward artifact isolation
- `feat(reward)`: verify artifact seal at staging seam; tamper zeroes the reward
- `feat(image)`: read-only verifier identity via run-as-agent wrapper and user separation
- `docs(reward)`: single reward axis + `suite_non_regression` metric + sealed/read-only model
- `fix(rl)`: bind seal to re-derived diff and fail closed on seal failures
- `fix(rl)`: fail closed on seal loss and harden privilege-drop wrappers
- `fix(rl)`: single-source candidate-diff derivation, drop dead seal guard, refresh stale reward comment

## Test Plan

- [x] Full suite green: 143 passed, 1 skipped
- [x] `ruff check` clean
- [x] `mypy` clean (8 source files)
- [x] Two sequential daydream deep-precision reviews (rounds 1 & 2) on fresh VMs, all findings addressed, trajectory uploaded to HF
- [x] Clean merge into `main` verified locally

## Notes for Reviewers

No CodeRabbit in this org — the merge gate is the two sequential daydream deep-precision reviews, both of which passed. Review threads from other bots/humans are handled via the standard thread-resolution flow.
