### PR TITLE
feat(cli): support osprey backend selection (#642)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ claude plugin marketplace add https://github.com/existential-birds/beagle
 claude plugin install beagle
 ```
 
-Optional: [GitHub CLI](https://cli.github.com/) (`gh`) for PR feedback and `--comment` mode. [Codex CLI](https://openai.com/codex) for `--backend codex`. [Pi CLI](https://pi.dev) for `--backend pi` (Nous Research DeepSeek models). [Osprey CLI](https://github.com/existential-birds/osprey) for `--backend osprey`.
+Optional: [GitHub CLI](https://cli.github.com/) (`gh`) for PR feedback and `--comment` mode. [Codex CLI](https://openai.com/codex) for `--backend codex`. [Pi CLI](https://pi.dev) for `--backend pi` (Nous Research DeepSeek models). Osprey CLI for `--backend osprey`.
 
 ### Golden paths
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ daydream corpus label <session_id> --outcome accepted  # manual outcome label ov
 
 ```bash
 daydream -s python /path/to/project           # force a specific Beagle skill
-daydream --backend codex /path/to/project     # override backend (claude, codex, pi)
+daydream --backend codex /path/to/project     # override backend (claude, codex, pi, osprey)
 daydream --model claude-haiku-4-5 /path/to/project  # overrides ALL phases (beats config-file overrides)
 daydream --yes /path/to/project               # auto-apply fixes without prompting
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ claude plugin marketplace add https://github.com/existential-birds/beagle
 claude plugin install beagle
 ```
 
-Optional: [GitHub CLI](https://cli.github.com/) (`gh`) for PR feedback and `--comment` mode. [Codex CLI](https://openai.com/codex) for `--backend codex`. [Pi CLI](https://pi.dev) for `--backend pi` (Nous Research DeepSeek models).
+Optional: [GitHub CLI](https://cli.github.com/) (`gh`) for PR feedback and `--comment` mode. [Codex CLI](https://openai.com/codex) for `--backend codex`. [Pi CLI](https://pi.dev) for `--backend pi` (Nous Research DeepSeek models). [Osprey CLI](https://github.com/existential-birds/osprey) for `--backend osprey`.
 
 ### Golden paths
 

--- a/daydream/benchmark/cli.py
+++ b/daydream/benchmark/cli.py
@@ -124,7 +124,7 @@ def _build_bench_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--reviewer-backend",
         type=str,
-        choices=["claude", "codex", "pi"],
+        choices=["claude", "codex", "pi", "osprey"],
         default=None,
         dest="reviewer_backend",
         help="Backend for the reviewer under test (default: daydream's built-in default)",

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -261,9 +261,9 @@ def _add_shared_arguments(parser: argparse.ArgumentParser, *, full_help: bool = 
     )
     parser.add_argument(
         "--backend", "-b",
-        choices=["claude", "codex", "pi"],
+        choices=["claude", "codex", "pi", "osprey"],
         default=None,
-        help="Agent backend: claude, codex, or pi "
+        help="Agent backend: claude, codex, pi, or osprey "
              "(default: config file, then claude)",
     )
     parser.add_argument(

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -79,6 +79,20 @@ def test_reviewer_flags_reach_config(tmp_path, monkeypatch):
         == ("pi", "glm-5.2", "openrouter", "daydream-glm")
 
 
+# --reviewer-backend must accept every backend the main CLI accepts (incl. osprey).
+REVIEWER_BACKENDS = ["claude", "codex", "pi", "osprey"]
+
+
+@pytest.mark.parametrize("backend", REVIEWER_BACKENDS, ids=lambda name: name)
+def test_reviewer_backend_accepts_all_cli_backends(tmp_path, monkeypatch, backend):
+    monkeypatch.chdir(tmp_path)
+    cfg = _bench_config_from_argv([
+        "--benchmark-repo", "/b", "--no-score",
+        "--reviewer-backend", backend, "--tool-label", "daydream-x",
+    ])
+    assert cfg.reviewer_backend == backend
+
+
 def test_config_supplies_benchmark_repo_when_flag_omitted(tmp_path, monkeypatch):
     (tmp_path / "pyproject.toml").write_text('[tool.daydream.bench]\nbenchmark-repo = "/from/config"\n')
     monkeypatch.chdir(tmp_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,6 +43,14 @@ def test_backend_flag_codex(monkeypatch, flag):
     assert config.backend == "codex"
 
 
+@pytest.mark.parametrize("flag", ["--backend", "-b"], ids=["long", "short"])
+def test_backend_flag_osprey(monkeypatch, flag):
+    """Accept each backend flag spelling and select the Osprey backend."""
+    monkeypatch.setattr(sys, "argv", ["daydream", "/tmp/project", flag, "osprey"])
+    config = _parse_args()
+    assert config.backend == "osprey"
+
+
 def test_invalid_backend_rejected(monkeypatch):
     monkeypatch.setattr(sys, "argv", ["daydream", "/tmp/project", "--backend", "invalid"])
     with pytest.raises(SystemExit):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,20 +35,17 @@ def test_default_backend_is_none_and_resolves_to_claude(monkeypatch):
     assert _resolved_backend_name(config, "review") == "claude"
 
 
-@pytest.mark.parametrize("flag", ["--backend", "-b"], ids=["long", "short"])
-def test_backend_flag_codex(monkeypatch, flag):
-    """Accept each backend flag spelling and select the Codex backend."""
-    monkeypatch.setattr(sys, "argv", ["daydream", "/tmp/project", flag, "codex"])
-    config = _parse_args()
-    assert config.backend == "codex"
+# Backend names selectable via --backend/-b.
+BACKEND_NAMES = ["codex", "osprey"]
 
 
 @pytest.mark.parametrize("flag", ["--backend", "-b"], ids=["long", "short"])
-def test_backend_flag_osprey(monkeypatch, flag):
-    """Accept each backend flag spelling and select the Osprey backend."""
-    monkeypatch.setattr(sys, "argv", ["daydream", "/tmp/project", flag, "osprey"])
+@pytest.mark.parametrize("backend", BACKEND_NAMES, ids=lambda name: name)
+def test_backend_flag(monkeypatch, flag, backend):
+    """Accept each backend flag spelling and select the named backend."""
+    monkeypatch.setattr(sys, "argv", ["daydream", "/tmp/project", flag, backend])
     config = _parse_args()
-    assert config.backend == "osprey"
+    assert config.backend == backend
 
 
 def test_invalid_backend_rejected(monkeypatch):


### PR DESCRIPTION
## Summary
Consolidated Osprey backend CLI selection + coverage (#621, #622, closes #642).

- feat(cli): add `osprey` to `--backend` (and short-flag) choices, resolving to `OspreyBackend` via the factory
- docs(readme): list osprey in `--backend` options
- refactor(test_cli): parametrize backend flag tests
- fix(readme): drop broken osprey CLI link (404)
- fix(bench): accept osprey as `--reviewer-backend` choice (closes out-of-scope gap from round-2 review)

## Test Plan
- `make check` gate green (3584 passed / 6 skipped / 0 failures)
- Parametrized backend parsing test covers long + short forms incl. osprey

Closes #642