### PR TITLE
[daydream] Consolidated: backend identity in trajectory metadata (#623) (Closes #643)

### DIFF
--- a/daydream/archive/manifest.py
+++ b/daydream/archive/manifest.py
@@ -273,12 +273,14 @@ def build_manifest(
     totals = recorder._final_totals  # noqa: SLF001 - intentional access to recorder internals
 
     # Deferred import breaks the module-level cycle: archive.manifest → runner → (lazy) archive.
-    from daydream.runner import _resolved_backend_name  # noqa: PLC0415 - deferred import avoids cycle
+    from daydream.runner import _recorder_backend_names  # noqa: PLC0415 - deferred import avoids cycle
 
-    # Resolve the effective backend through the full precedence chain so the manifest
-    # records what was actually used (raw config.backend is None when set via file-config);
-    # "review" is the representative phase the orchestrator also prints as the default.
-    backend_used = _resolved_backend_name(config, "review")
+    # Mirror the trajectory's backend identity through the same shared resolver
+    # used by runner._open_recorder, so the manifest and trajectory never diverge
+    # on which backend produced the run. Deep-flow runs resolve the representative
+    # backend via ``per_stack_review`` (the phase that actually drives their review
+    # fan-out); fix/test are recorded only for flows that run those phases.
+    backend_used, fix_backend, test_backend = _recorder_backend_names(config, recorder.run_flow)
 
     m = Manifest(
         session_id=recorder.session_id,
@@ -289,8 +291,8 @@ def build_manifest(
         model=None,
         backend=backend_used,
         review_backend=backend_used,
-        fix_backend=_resolved_backend_name(config, "fix"),
-        test_backend=_resolved_backend_name(config, "test"),
+        fix_backend=fix_backend or None,
+        test_backend=test_backend or None,
         review_only=config.output_mode == "review",
         deep=not config.shallow,
         fix_failures=fix_failures or None,

--- a/daydream/archive/manifest.py
+++ b/daydream/archive/manifest.py
@@ -47,10 +47,11 @@ class Manifest:
         run_flow: Run flow type (normal, ttt, pr, deep).
         skill: Review skill used (python, react, etc.).
         model: Model name (opus, sonnet, haiku).
-        backend: Backend used (claude, codex).
-        review_backend: Per-phase backend override for review, if set.
-        fix_backend: Per-phase backend override for fix, if set.
-        test_backend: Per-phase backend override for test, if set.
+        backend: Backend used (claude, codex, pi, osprey).
+        review_backend: Flow's representative backend, resolved through the full
+            precedence chain (``per_stack_review`` for deep-flow runs).
+        fix_backend: Backend used for the fix phase, when the flow runs it.
+        test_backend: Backend used for the test phase, when the flow runs it.
         review_only: Whether the run was review-only.
         deep: Whether deep review mode was used.
         source_path: Absolute path to the source repository at archive time.
@@ -276,11 +277,10 @@ def build_manifest(
     from daydream.runner import _recorder_backend_names  # noqa: PLC0415 - deferred import avoids cycle
 
     # Mirror the trajectory's backend identity through the same shared resolver
-    # used by runner._open_recorder, so the manifest and trajectory never diverge
-    # on which backend produced the run. Deep-flow runs resolve the representative
-    # backend via ``per_stack_review`` (the phase that actually drives their review
-    # fan-out); fix/test are recorded only for flows that run those phases.
-    backend_used, fix_backend, test_backend = _recorder_backend_names(config, recorder.run_flow)
+    # used by runner._open_recorder (authoritative per-flow mapping prose lives
+    # in its docstring), so the manifest and trajectory never diverge on which
+    # backend produced the run.
+    names = _recorder_backend_names(config, recorder.run_flow)
 
     m = Manifest(
         session_id=recorder.session_id,
@@ -289,10 +289,10 @@ def build_manifest(
         run_flow=recorder.run_flow.value,
         skill=config.skill,
         model=None,
-        backend=backend_used,
-        review_backend=backend_used,
-        fix_backend=fix_backend or None,
-        test_backend=test_backend or None,
+        backend=names.backend,
+        review_backend=names.backend,
+        fix_backend=names.fix or None,
+        test_backend=names.test or None,
         review_only=config.output_mode == "review",
         deep=not config.shallow,
         fix_failures=fix_failures or None,

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -33,7 +33,7 @@ import uuid
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 
 from rich.markup import escape as escape_markup
 
@@ -361,18 +361,11 @@ def _open_recorder(
     """
     session_id = str(uuid.uuid4())
     trajectory_path = config.trajectory_path or default_trajectory_path(target_dir, session_id)
-    # Backend identity mirrors archive/manifest.py, but the representative
-    # backend resolves through the phase that actually governs the flow's
-    # review: the deep flow's review fan-out runs on ``per_stack_review``
-    # (loop/shallow/review/comment modes), while ``review`` only powers
-    # feedback-mode commit-push and the PR-feedback banner — so resolving via
-    # "review" would mislabel deep-flow runs under per-phase backend overrides.
-    # Per-phase fix/test resolutions are recorded only for flows that run those
-    # phases: review-only (TTT) and improve flows stop before the fix cycle,
-    # and feedback (PR) runs fix but never test, so their keys stay omitted.
-    backend_name, fix_backend_name, test_backend_name = _recorder_backend_names(
-        config, flow_kind,
-    )
+    # Backend identity is resolved in exactly one place,
+    # ``_recorder_backend_names`` — see its docstring for the authoritative
+    # per-flow phase mapping. Keep the mapping prose there so it cannot drift
+    # between call sites (runner, archive manifest).
+    names = _recorder_backend_names(config, flow_kind)
     return TrajectoryRecorder(
         path=trajectory_path,
         run_flow=flow_kind,
@@ -382,10 +375,10 @@ def _open_recorder(
         explicit_path=config.trajectory_path is not None,
         pr_number=config.pr_number,
         pr_repo=config.pr_repo,
-        backend_name=backend_name,
-        review_backend_name=backend_name,
-        fix_backend_name=fix_backend_name,
-        test_backend_name=test_backend_name,
+        backend_name=names.backend,
+        review_backend_name=names.backend,
+        fix_backend_name=names.fix,
+        test_backend_name=names.test,
         on_write=_make_archive_callback(config, target_dir, work),
     )
 
@@ -416,38 +409,68 @@ def _resolved_backend_name(config: RunConfig, phase: str) -> str:
     )
 
 
+class RecorderBackendNames(NamedTuple):
+    """Resolved backend identities for a run's trajectory and manifest.
+
+    Attributes:
+        backend: Representative backend kind for the run, resolved through the
+            phase that actually governs the flow (see
+            :func:`_recorder_backend_names`).
+        fix: Backend kind for the fix phase, or ``""`` when the flow never
+            runs fix (the key is omitted on serialization).
+        test: Backend kind for the test phase, or ``""`` when the flow never
+            runs test (the key is omitted on serialization).
+    """
+
+    backend: str
+    fix: str
+    test: str
+
+
 def _recorder_backend_names(
     config: RunConfig, flow_kind: DaydreamRunFlow
-) -> tuple[str, str, str]:
-    """Resolve the backend identity ``(backend, fix, test)`` for the run recorder.
+) -> RecorderBackendNames:
+    """Resolve the backend identities for the run's trajectory and manifest.
 
-    Shared by :func:`_open_recorder` and the archive manifest so the trajectory
-    and manifest never diverge on which backend produced the run. The
-    representative backend resolves through the phase that actually governs the
-    flow's review: deep-flow runs (DEEP/NORMAL/TTT) fan out on
-    ``per_stack_review``, while ``review`` only powers feedback-mode commit-push
-    and the PR-feedback banner. Per-phase fix/test are recorded only for flows
-    that run those phases (improve/TTT never run fix/test; PR runs fix but never
-    test), so a flow that skips a phase yields an empty name (the key is omitted
-    on serialization) rather than a misleading label.
+    Single authoritative source for the per-flow backend mapping, shared by
+    :func:`_open_recorder` and ``archive.manifest.build_manifest`` so the
+    trajectory and manifest never diverge on which backend produced the run.
+    The representative backend resolves through the phase that actually governs
+    the flow: deep-flow runs (DEEP/NORMAL/TTT) fan out on ``per_stack_review``;
+    improve runs on its advisory phases with ``recon`` first; ``review`` only
+    powers feedback-mode commit-push and the PR-feedback banner, so PR/CUSTOM
+    fall back to it. Per-phase fix/test are recorded only for flows that
+    statically run those phases: improve/TTT never run fix/test; PR runs fix
+    but never test; CUSTOM composition is fork-defined and unknowable at
+    recorder-open time, so labeling it unconditionally would mislabel
+    review-only forks. A flow that skips a phase yields an empty name (the key
+    is omitted on serialization) rather than a misleading label.
     """
-    review_phase = (
-        "per_stack_review"
-        if flow_kind in (DaydreamRunFlow.DEEP, DaydreamRunFlow.NORMAL, DaydreamRunFlow.TTT)
-        else "review"
-    )
-    backend = _resolved_backend_name(config, review_phase)
+    if flow_kind in (DaydreamRunFlow.DEEP, DaydreamRunFlow.NORMAL, DaydreamRunFlow.TTT):
+        representative_phase = "per_stack_review"
+    elif flow_kind == DaydreamRunFlow.IMPROVE:
+        representative_phase = "recon"
+    else:
+        representative_phase = "review"
+    backend = _resolved_backend_name(config, representative_phase)
     fix = (
         _resolved_backend_name(config, "fix")
-        if flow_kind not in (DaydreamRunFlow.TTT, DaydreamRunFlow.IMPROVE)
+        if flow_kind
+        not in (DaydreamRunFlow.TTT, DaydreamRunFlow.IMPROVE, DaydreamRunFlow.CUSTOM)
         else ""
     )
     test = (
         _resolved_backend_name(config, "test")
-        if flow_kind not in (DaydreamRunFlow.TTT, DaydreamRunFlow.PR, DaydreamRunFlow.IMPROVE)
+        if flow_kind
+        not in (
+            DaydreamRunFlow.TTT,
+            DaydreamRunFlow.PR,
+            DaydreamRunFlow.IMPROVE,
+            DaydreamRunFlow.CUSTOM,
+        )
         else ""
     )
-    return backend, fix, test
+    return RecorderBackendNames(backend=backend, fix=fix, test=test)
 
 
 def _resolved_model(config: RunConfig, phase: str) -> str | None:

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -361,6 +361,10 @@ def _open_recorder(
     """
     session_id = str(uuid.uuid4())
     trajectory_path = config.trajectory_path or default_trajectory_path(target_dir, session_id)
+    # Backend identity mirrors archive/manifest.py: the representative backend is
+    # resolved via the review phase, plus per-phase fix/test resolutions, all
+    # resolved here in the single construction site.
+    backend_name = _resolved_backend_name(config, "review")
     return TrajectoryRecorder(
         path=trajectory_path,
         run_flow=flow_kind,
@@ -370,6 +374,10 @@ def _open_recorder(
         explicit_path=config.trajectory_path is not None,
         pr_number=config.pr_number,
         pr_repo=config.pr_repo,
+        backend_name=backend_name,
+        review_backend_name=backend_name,
+        fix_backend_name=_resolved_backend_name(config, "fix"),
+        test_backend_name=_resolved_backend_name(config, "test"),
         on_write=_make_archive_callback(config, target_dir, work),
     )
 

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -370,18 +370,9 @@ def _open_recorder(
     # Per-phase fix/test resolutions are recorded only for flows that run those
     # phases: review-only (TTT) and improve flows stop before the fix cycle,
     # and feedback (PR) runs fix but never test, so their keys stay omitted.
-    review_phase = (
-        "per_stack_review"
-        if flow_kind in (DaydreamRunFlow.DEEP, DaydreamRunFlow.NORMAL, DaydreamRunFlow.TTT)
-        else "review"
+    backend_name, fix_backend_name, test_backend_name = _recorder_backend_names(
+        config, flow_kind,
     )
-    backend_name = _resolved_backend_name(config, review_phase)
-    fix_backend_name = _resolved_backend_name(config, "fix") if flow_kind not in (
-        DaydreamRunFlow.TTT, DaydreamRunFlow.IMPROVE,
-    ) else ""
-    test_backend_name = _resolved_backend_name(config, "test") if flow_kind not in (
-        DaydreamRunFlow.TTT, DaydreamRunFlow.PR, DaydreamRunFlow.IMPROVE,
-    ) else ""
     return TrajectoryRecorder(
         path=trajectory_path,
         run_flow=flow_kind,
@@ -423,6 +414,40 @@ def _resolved_backend_name(config: RunConfig, phase: str) -> str:
         or file_config.backend
         or "claude"
     )
+
+
+def _recorder_backend_names(
+    config: RunConfig, flow_kind: DaydreamRunFlow
+) -> tuple[str, str, str]:
+    """Resolve the backend identity ``(backend, fix, test)`` for the run recorder.
+
+    Shared by :func:`_open_recorder` and the archive manifest so the trajectory
+    and manifest never diverge on which backend produced the run. The
+    representative backend resolves through the phase that actually governs the
+    flow's review: deep-flow runs (DEEP/NORMAL/TTT) fan out on
+    ``per_stack_review``, while ``review`` only powers feedback-mode commit-push
+    and the PR-feedback banner. Per-phase fix/test are recorded only for flows
+    that run those phases (improve/TTT never run fix/test; PR runs fix but never
+    test), so a flow that skips a phase yields an empty name (the key is omitted
+    on serialization) rather than a misleading label.
+    """
+    review_phase = (
+        "per_stack_review"
+        if flow_kind in (DaydreamRunFlow.DEEP, DaydreamRunFlow.NORMAL, DaydreamRunFlow.TTT)
+        else "review"
+    )
+    backend = _resolved_backend_name(config, review_phase)
+    fix = (
+        _resolved_backend_name(config, "fix")
+        if flow_kind not in (DaydreamRunFlow.TTT, DaydreamRunFlow.IMPROVE)
+        else ""
+    )
+    test = (
+        _resolved_backend_name(config, "test")
+        if flow_kind not in (DaydreamRunFlow.TTT, DaydreamRunFlow.PR, DaydreamRunFlow.IMPROVE)
+        else ""
+    )
+    return backend, fix, test
 
 
 def _resolved_model(config: RunConfig, phase: str) -> str | None:

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -361,10 +361,27 @@ def _open_recorder(
     """
     session_id = str(uuid.uuid4())
     trajectory_path = config.trajectory_path or default_trajectory_path(target_dir, session_id)
-    # Backend identity mirrors archive/manifest.py: the representative backend is
-    # resolved via the review phase, plus per-phase fix/test resolutions, all
-    # resolved here in the single construction site.
-    backend_name = _resolved_backend_name(config, "review")
+    # Backend identity mirrors archive/manifest.py, but the representative
+    # backend resolves through the phase that actually governs the flow's
+    # review: the deep flow's review fan-out runs on ``per_stack_review``
+    # (loop/shallow/review/comment modes), while ``review`` only powers
+    # feedback-mode commit-push and the PR-feedback banner — so resolving via
+    # "review" would mislabel deep-flow runs under per-phase backend overrides.
+    # Per-phase fix/test resolutions are recorded only for flows that run those
+    # phases: review-only (TTT) and improve flows stop before the fix cycle,
+    # and feedback (PR) runs fix but never test, so their keys stay omitted.
+    review_phase = (
+        "per_stack_review"
+        if flow_kind in (DaydreamRunFlow.DEEP, DaydreamRunFlow.NORMAL, DaydreamRunFlow.TTT)
+        else "review"
+    )
+    backend_name = _resolved_backend_name(config, review_phase)
+    fix_backend_name = _resolved_backend_name(config, "fix") if flow_kind not in (
+        DaydreamRunFlow.TTT, DaydreamRunFlow.IMPROVE,
+    ) else ""
+    test_backend_name = _resolved_backend_name(config, "test") if flow_kind not in (
+        DaydreamRunFlow.TTT, DaydreamRunFlow.PR, DaydreamRunFlow.IMPROVE,
+    ) else ""
     return TrajectoryRecorder(
         path=trajectory_path,
         run_flow=flow_kind,
@@ -376,8 +393,8 @@ def _open_recorder(
         pr_repo=config.pr_repo,
         backend_name=backend_name,
         review_backend_name=backend_name,
-        fix_backend_name=_resolved_backend_name(config, "fix"),
-        test_backend_name=_resolved_backend_name(config, "test"),
+        fix_backend_name=fix_backend_name,
+        test_backend_name=test_backend_name,
         on_write=_make_archive_callback(config, target_dir, work),
     )
 

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -1287,14 +1287,20 @@ class TrajectoryRecorder:
         pr_number: GitHub PR number if reviewing a PR. Stored in trajectory extra.
         pr_repo: GitHub repo (``owner/repo``) if reviewing a PR. Stored in trajectory extra.
         backend_name: Resolved backend kind (claude/codex/pi/osprey) for the run,
-            resolved via the review phase by ``_open_recorder``. Stored in
+            resolved by ``_open_recorder`` via the ``per_stack_review`` phase for
+            deep-flow runs (the phase that governs the deep flow's actual review
+            fan-out) and via the ``review`` phase otherwise. Stored in
             trajectory extra as ``backend`` when non-empty.
         review_backend_name: Resolved backend kind for the review phase. Stored in
-            trajectory extra as ``review_backend`` when ``backend_name`` is set.
+            trajectory extra as ``review_backend`` when set.
         fix_backend_name: Resolved backend kind for the fix phase. Stored in
-            trajectory extra as ``fix_backend`` when ``backend_name`` is set.
+            trajectory extra as ``fix_backend`` when set; left empty by
+            ``_open_recorder`` for flows that never run fix (e.g. improve), so
+            the key is omitted from their trajectories.
         test_backend_name: Resolved backend kind for the test phase. Stored in
-            trajectory extra as ``test_backend`` when ``backend_name`` is set.
+            trajectory extra as ``test_backend`` when set; left empty by
+            ``_open_recorder`` for flows that never run test (e.g. improve), so
+            the key is omitted from their trajectories.
         _step_id_counter: Monotonic; never decreases (Pitfall 1).
         _final_totals: Running tally for FinalMetrics aggregation (MAP-07).
         _previous_token: ContextVar reset token; used by __aexit__ to restore.
@@ -1748,13 +1754,18 @@ class TrajectoryRecorder:
         extra: dict[str, Any] = {"target_dir": str(self.target_dir)}
         if self.backend_name:
             # Backend identity mirrors archive/manifest.py's record: a
-            # representative ``backend`` (resolved via the review phase) plus
-            # always-present per-phase keys. Empty ``backend_name`` (direct
-            # construction outside the factory) serializes no backend keys.
+            # representative ``backend`` (resolved via the phase that governs the
+            # deep flow's review fan-out) plus per-phase keys, each serialized
+            # only when set — a flow that never runs a phase (improve never runs
+            # fix/test) omits that phase's key entirely. Empty ``backend_name``
+            # (direct construction outside the factory) serializes no backend keys.
             extra["backend"] = self.backend_name
-            extra["review_backend"] = self.review_backend_name
-            extra["fix_backend"] = self.fix_backend_name
-            extra["test_backend"] = self.test_backend_name
+            if self.review_backend_name:
+                extra["review_backend"] = self.review_backend_name
+            if self.fix_backend_name:
+                extra["fix_backend"] = self.fix_backend_name
+            if self.test_backend_name:
+                extra["test_backend"] = self.test_backend_name
         if self.pr_number is not None:
             extra["pr_number"] = self.pr_number
         if self.pr_repo is not None:

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -1286,6 +1286,15 @@ class TrajectoryRecorder:
         steps: Sequential Steps from every Invocation, step_id 1..N.
         pr_number: GitHub PR number if reviewing a PR. Stored in trajectory extra.
         pr_repo: GitHub repo (``owner/repo``) if reviewing a PR. Stored in trajectory extra.
+        backend_name: Resolved backend kind (claude/codex/pi/osprey) for the run,
+            resolved via the review phase by ``_open_recorder``. Stored in
+            trajectory extra as ``backend`` when non-empty.
+        review_backend_name: Resolved backend kind for the review phase. Stored in
+            trajectory extra as ``review_backend`` when ``backend_name`` is set.
+        fix_backend_name: Resolved backend kind for the fix phase. Stored in
+            trajectory extra as ``fix_backend`` when ``backend_name`` is set.
+        test_backend_name: Resolved backend kind for the test phase. Stored in
+            trajectory extra as ``test_backend`` when ``backend_name`` is set.
         _step_id_counter: Monotonic; never decreases (Pitfall 1).
         _final_totals: Running tally for FinalMetrics aggregation (MAP-07).
         _previous_token: ContextVar reset token; used by __aexit__ to restore.
@@ -1303,6 +1312,10 @@ class TrajectoryRecorder:
     explicit_path: bool = False
     pr_number: int | None = None
     pr_repo: str | None = None
+    backend_name: str = ""
+    review_backend_name: str = ""
+    fix_backend_name: str = ""
+    test_backend_name: str = ""
     _step_id_counter: int = 0
     _final_totals: dict[str, Any] = field(default_factory=lambda: _INITIAL_TOTALS.copy())
     _folded_fork_totals: bool = False
@@ -1733,6 +1746,15 @@ class TrajectoryRecorder:
             extra=final_metrics_extra,
         )
         extra: dict[str, Any] = {"target_dir": str(self.target_dir)}
+        if self.backend_name:
+            # Backend identity mirrors archive/manifest.py's record: a
+            # representative ``backend`` (resolved via the review phase) plus
+            # always-present per-phase keys. Empty ``backend_name`` (direct
+            # construction outside the factory) serializes no backend keys.
+            extra["backend"] = self.backend_name
+            extra["review_backend"] = self.review_backend_name
+            extra["fix_backend"] = self.fix_backend_name
+            extra["test_backend"] = self.test_backend_name
         if self.pr_number is not None:
             extra["pr_number"] = self.pr_number
         if self.pr_repo is not None:

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -1878,6 +1878,10 @@ class _ForkCM:
             session_id=self._parent.session_id,
             pr_number=self._parent.pr_number,
             pr_repo=self._parent.pr_repo,
+            backend_name=self._parent.backend_name,
+            review_backend_name=self._parent.review_backend_name,
+            fix_backend_name=self._parent.fix_backend_name,
+            test_backend_name=self._parent.test_backend_name,
         )
         child.parent = self._parent
         child.descriptor = self._descriptor

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -33,7 +33,7 @@ from daydream.archive.index import (
 from daydream.archive.manifest import Manifest, build_manifest
 from daydream.config_file import DaydreamFileConfig
 from daydream.runner import RunConfig
-from daydream.trajectory import TrajectoryRecorder
+from daydream.trajectory import DaydreamRunFlow, TrajectoryRecorder
 from tests.harness.trajectory import make_manifest
 
 
@@ -41,7 +41,7 @@ from tests.harness.trajectory import make_manifest
 class _MockRecorder:
     session_id: str = "abcd1234-0000-0000-0000-000000000000"
     path: Path = field(default_factory=lambda: Path("/nonexistent/trajectory.json"))
-    run_flow: MagicMock = field(default_factory=lambda: MagicMock(value="normal"))
+    run_flow: DaydreamRunFlow = DaydreamRunFlow.NORMAL
     explicit_path: bool = False
     pr_number: int | None = None
     pr_repo: str | None = None

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -10,18 +10,21 @@ import threading
 import time
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import anyio
 import pytest
 
 from daydream import git_ops, runner
+from daydream.archive.git_context import GitContext
+from daydream.archive.manifest import Manifest, build_manifest
 from daydream.backends import AgentEvent, ResultEvent, TextEvent
 from daydream.exploration import ExplorationContext
 from daydream.runner import RunConfig
-from daydream.trajectory import DaydreamRunFlow
+from daydream.trajectory import DaydreamRunFlow, TrajectoryRecorder
 from daydream.workspace import WorkContext
 from tests.harness.backend import ScriptedBackend, Turn
 from tests.harness.git_helpers import commit as _commit
@@ -1314,6 +1317,54 @@ def test_open_recorder_review_only_omits_fix_test_backend(tmp_path: Path) -> Non
     assert recorder.test_backend_name == ""
 
 
+def test_open_recorder_custom_omits_fix_test_backend(tmp_path: Path) -> None:
+    """Custom (fork) flows carry no fix/test backend identity.
+
+    A fork-defined CUSTOM flow's composition is unknowable at recorder-open
+    time — review-only forks are explicitly supported — so labeling it
+    unconditionally would mislabel runs that never run the fix/test phases.
+    Even an explicit ``fix_backend`` must not leak onto a CUSTOM run.
+    """
+    from daydream.runner import _open_recorder
+    target_dir = tmp_path / "project"
+    target_dir.mkdir()
+    config = RunConfig(target=str(target_dir), backend="codex", fix_backend="pi", run_eval=False)
+    recorder = _open_recorder(
+        config=config, target_dir=target_dir, work=None, flow_kind=DaydreamRunFlow.CUSTOM,
+    )
+    assert recorder.backend_name == "codex"
+    assert recorder.review_backend_name == "codex"
+    assert recorder.fix_backend_name == ""
+    assert recorder.test_backend_name == ""
+
+
+def test_open_recorder_improve_resolves_backend_via_recon(tmp_path: Path) -> None:
+    """The improve flow's representative backend follows its advisory phases.
+
+    The improve flow runs exclusively on recon/audit/vet/plan_write steps (no
+    review step), so a file-config override on ``recon`` — its first advisory
+    phase — must win for the run's backend identity instead of the never-run
+    ``review`` phase.
+    """
+    from daydream.config_file import DaydreamFileConfig
+    from daydream.runner import _open_recorder
+    target_dir = tmp_path / "project"
+    target_dir.mkdir()
+    config = RunConfig(
+        target=str(target_dir),
+        run_eval=False,
+        review_backend="codex",
+        file_config=DaydreamFileConfig(phases={"recon": {"backend": "pi"}}),
+    )
+    recorder = _open_recorder(
+        config=config, target_dir=target_dir, work=None, flow_kind=DaydreamRunFlow.IMPROVE,
+    )
+    assert recorder.backend_name == "pi"
+    assert recorder.review_backend_name == "pi"
+    assert recorder.fix_backend_name == ""
+    assert recorder.test_backend_name == ""
+
+
 def test_open_recorder_feedback_resolves_fix_omits_test(tmp_path: Path) -> None:
     """Feedback (PR) flow records the fix backend but omits the test backend.
 
@@ -1347,3 +1398,143 @@ def test_open_recorder_backend_falls_back_to_claude(tmp_path: Path) -> None:
     assert recorder.review_backend_name == "claude"
     assert recorder.fix_backend_name == "claude"
     assert recorder.test_backend_name == "claude"
+
+
+@dataclass
+class _MockManifestRecorder:
+    """Minimal recorder surface consumed by ``build_manifest``.
+
+    Mirrors tests/test_archive.py's ``_MockRecorder``: ``build_manifest`` reads
+    the identity fields, ``run_flow``, and ``_final_totals``, and calls the two
+    timing methods.
+    """
+
+    session_id: str = "abcd1234-0000-0000-0000-000000000000"
+    run_flow: DaydreamRunFlow = DaydreamRunFlow.NORMAL
+    pr_number: int | None = None
+    pr_repo: str | None = None
+    _final_totals: dict[str, Any] = field(
+        default_factory=lambda: {
+            "prompt": 0,
+            "completion": 0,
+            "cached": 0,
+            "cost": 0.0,
+            "any_cost_seen": False,
+        },
+    )
+
+    def compute_wall_clock_seconds(self) -> float | None:
+        return None
+
+    def compute_phase_timings(self) -> dict[str, Any] | None:
+        return None
+
+
+def _build_manifest(config: RunConfig, flow: DaydreamRunFlow, tmp_path: Path) -> Manifest:
+    """Build a manifest for ``config``/``flow`` from a mock recorder."""
+    return build_manifest(
+        recorder=cast(TrajectoryRecorder, _MockManifestRecorder(run_flow=flow)),
+        config=config,
+        git_ctx=GitContext(),
+        status="complete",
+        archive_path=tmp_path,
+    )
+
+
+def test_manifest_mirrors_recorder_backend_via_per_stack_review(tmp_path: Path) -> None:
+    """The manifest resolves the representative backend via ``per_stack_review``.
+
+    ``build_manifest`` must resolve through the same shared resolver as the
+    recorder, so a deep-flow run with a file-config ``per_stack_review``
+    override is labeled with that backend even when CLI ``review_backend`` is
+    set — the ``review`` phase only powers feedback-mode commit-push.
+    """
+    from daydream.config_file import DaydreamFileConfig
+
+    config = RunConfig(
+        target=str(tmp_path / "project"),
+        run_eval=False,
+        review_backend="codex",
+        file_config=DaydreamFileConfig(phases={"per_stack_review": {"backend": "pi"}}),
+    )
+    m = _build_manifest(config, DaydreamRunFlow.NORMAL, tmp_path)
+    assert m.backend == "pi"
+    assert m.review_backend == "pi"
+
+
+def test_manifest_normal_records_fix_and_test_backend(tmp_path: Path) -> None:
+    """A deep-flow run records per-phase fix/test backends on the manifest."""
+    config = RunConfig(
+        target=str(tmp_path / "project"),
+        run_eval=False,
+        backend="codex",
+        fix_backend="pi",
+        test_backend="osprey",
+    )
+    m = _build_manifest(config, DaydreamRunFlow.NORMAL, tmp_path)
+    assert m.backend == "codex"
+    assert m.review_backend == "codex"
+    assert m.fix_backend == "pi"
+    assert m.test_backend == "osprey"
+    run = m.to_dict()["run"]
+    assert run["fix_backend"] == "pi"
+    assert run["test_backend"] == "osprey"
+
+
+def test_manifest_review_only_omits_fix_test_backend(tmp_path: Path) -> None:
+    """Review-only (TTT) manifests omit fix/test backend keys entirely.
+
+    ``--review``/``--comment`` never run the fix or test phases, so
+    ``fix_backend``/``test_backend`` resolve empty and the ``or None`` omission
+    in ``build_manifest`` drops the keys rather than mislabeling the run.
+    """
+    config = RunConfig(target=str(tmp_path / "project"), run_eval=False, backend="codex")
+    m = _build_manifest(config, DaydreamRunFlow.TTT, tmp_path)
+    assert m.backend == "codex"
+    assert m.review_backend == "codex"
+    assert m.fix_backend is None
+    assert m.test_backend is None
+    run = m.to_dict()["run"]
+    assert "fix_backend" not in run
+    assert "test_backend" not in run
+
+
+def test_manifest_improve_omits_fix_test_backend(tmp_path: Path) -> None:
+    """Improve manifests omit fix/test backend keys (those phases never run)."""
+    config = RunConfig(target=str(tmp_path / "project"), run_eval=False, backend="codex")
+    m = _build_manifest(config, DaydreamRunFlow.IMPROVE, tmp_path)
+    assert m.backend == "codex"
+    assert m.review_backend == "codex"
+    assert m.fix_backend is None
+    assert m.test_backend is None
+    run = m.to_dict()["run"]
+    assert "fix_backend" not in run
+    assert "test_backend" not in run
+
+
+def test_manifest_feedback_records_fix_omits_test_backend(tmp_path: Path) -> None:
+    """Feedback (PR) manifests keep ``fix_backend`` but omit ``test_backend``.
+
+    ``daydream feedback`` runs the fix phase but never the test phase, and its
+    representative backend follows the ``review`` phase.
+    """
+    config = RunConfig(
+        target=str(tmp_path / "project"), run_eval=False, review_backend="codex",
+    )
+    m = _build_manifest(config, DaydreamRunFlow.PR, tmp_path)
+    assert m.backend == "codex"
+    assert m.review_backend == "codex"
+    assert m.fix_backend == "claude"
+    assert m.test_backend is None
+    run = m.to_dict()["run"]
+    assert "test_backend" not in run
+
+
+def test_manifest_backend_falls_back_to_claude(tmp_path: Path) -> None:
+    """With no backend configured anywhere, the manifest defaults to claude."""
+    config = RunConfig(target=str(tmp_path / "project"), run_eval=False)
+    m = _build_manifest(config, DaydreamRunFlow.NORMAL, tmp_path)
+    assert m.backend == "claude"
+    assert m.review_backend == "claude"
+    assert m.fix_backend == "claude"
+    assert m.test_backend == "claude"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -21,6 +21,7 @@ from daydream import git_ops, runner
 from daydream.backends import AgentEvent, ResultEvent, TextEvent
 from daydream.exploration import ExplorationContext
 from daydream.runner import RunConfig
+from daydream.trajectory import DaydreamRunFlow
 from daydream.workspace import WorkContext
 from tests.harness.backend import ScriptedBackend, Turn
 from tests.harness.git_helpers import commit as _commit
@@ -1236,3 +1237,31 @@ async def test_fix_cycle_failing_tests_bounded_fix_then_handoff(
     assert test_backend.read_only_calls == [False, False, False, True], (
         test_backend.read_only_calls
     )
+
+
+def test_open_recorder_resolves_backend_identity(tmp_path: Path) -> None:
+    from daydream.runner import RunConfig, _open_recorder
+    target_dir = tmp_path / "project"
+    target_dir.mkdir()
+    config = RunConfig(target=str(target_dir), backend="codex", fix_backend="pi", run_eval=False)
+    recorder = _open_recorder(
+        config=config, target_dir=target_dir, work=None, flow_kind=DaydreamRunFlow.NORMAL,
+    )
+    assert recorder.backend_name == "codex"
+    assert recorder.review_backend_name == "codex"
+    assert recorder.fix_backend_name == "pi"
+    assert recorder.test_backend_name == "codex"
+
+
+def test_open_recorder_backend_falls_back_to_claude(tmp_path: Path) -> None:
+    from daydream.runner import RunConfig, _open_recorder
+    target_dir = tmp_path / "project"
+    target_dir.mkdir()
+    config = RunConfig(target=str(target_dir), run_eval=False)
+    recorder = _open_recorder(
+        config=config, target_dir=target_dir, work=None, flow_kind=DaydreamRunFlow.NORMAL,
+    )
+    assert recorder.backend_name == "claude"
+    assert recorder.review_backend_name == "claude"
+    assert recorder.fix_backend_name == "claude"
+    assert recorder.test_backend_name == "claude"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1240,7 +1240,7 @@ async def test_fix_cycle_failing_tests_bounded_fix_then_handoff(
 
 
 def test_open_recorder_resolves_backend_identity(tmp_path: Path) -> None:
-    from daydream.runner import RunConfig, _open_recorder
+    from daydream.runner import _open_recorder
     target_dir = tmp_path / "project"
     target_dir.mkdir()
     config = RunConfig(target=str(target_dir), backend="codex", fix_backend="pi", run_eval=False)
@@ -1253,8 +1253,90 @@ def test_open_recorder_resolves_backend_identity(tmp_path: Path) -> None:
     assert recorder.test_backend_name == "codex"
 
 
+def test_open_recorder_resolves_backend_via_per_stack_review(tmp_path: Path) -> None:
+    """The representative backend follows per_stack_review, not the review phase.
+
+    The deep flow's actual review fan-out runs on ``per_stack_review``; the
+    ``review`` phase only powers feedback-mode commit-push, so a per-phase
+    override on ``per_stack_review`` must win for the run's backend identity.
+    """
+    from daydream.config_file import DaydreamFileConfig
+    from daydream.runner import _open_recorder
+    target_dir = tmp_path / "project"
+    target_dir.mkdir()
+    config = RunConfig(
+        target=str(target_dir),
+        run_eval=False,
+        review_backend="codex",
+        file_config=DaydreamFileConfig(phases={"per_stack_review": {"backend": "pi"}}),
+    )
+    recorder = _open_recorder(
+        config=config, target_dir=target_dir, work=None, flow_kind=DaydreamRunFlow.NORMAL,
+    )
+    assert recorder.backend_name == "pi"
+    assert recorder.review_backend_name == "pi"
+    assert recorder.fix_backend_name == "claude"
+    assert recorder.test_backend_name == "claude"
+
+
+def test_open_recorder_improve_omits_fix_test_backend(tmp_path: Path) -> None:
+    """Improve trajectories carry no fix/test backend identity: the improve flow
+    never runs those phases, so serializing them would mislabel the run."""
+    from daydream.runner import _open_recorder
+    target_dir = tmp_path / "project"
+    target_dir.mkdir()
+    config = RunConfig(target=str(target_dir), backend="codex", run_eval=False)
+    recorder = _open_recorder(
+        config=config, target_dir=target_dir, work=None, flow_kind=DaydreamRunFlow.IMPROVE,
+    )
+    assert recorder.backend_name == "codex"
+    assert recorder.review_backend_name == "codex"
+    assert recorder.fix_backend_name == ""
+    assert recorder.test_backend_name == ""
+
+
+def test_open_recorder_review_only_omits_fix_test_backend(tmp_path: Path) -> None:
+    """Review-only (TTT) trajectories carry no fix/test backend identity.
+
+    ``--review``/``--comment`` stop the deep spine after post-review, so their
+    flow never runs the fix cycle; emitting fix/test labels would mislabel them.
+    """
+    from daydream.runner import _open_recorder
+    target_dir = tmp_path / "project"
+    target_dir.mkdir()
+    config = RunConfig(target=str(target_dir), backend="codex", run_eval=False)
+    recorder = _open_recorder(
+        config=config, target_dir=target_dir, work=None, flow_kind=DaydreamRunFlow.TTT,
+    )
+    assert recorder.backend_name == "codex"
+    assert recorder.review_backend_name == "codex"
+    assert recorder.fix_backend_name == ""
+    assert recorder.test_backend_name == ""
+
+
+def test_open_recorder_feedback_resolves_fix_omits_test(tmp_path: Path) -> None:
+    """Feedback (PR) flow records the fix backend but omits the test backend.
+
+    ``daydream feedback`` fixes items (fix phase) but never runs the test
+    phase, and its commit-push step uses the ``review`` backend — so the
+    representative follows the ``review`` phase and only ``fix_backend`` is
+    recorded.
+    """
+    from daydream.runner import _open_recorder
+    target_dir = tmp_path / "project"
+    target_dir.mkdir()
+    config = RunConfig(target=str(target_dir), review_backend="codex", run_eval=False)
+    recorder = _open_recorder(
+        config=config, target_dir=target_dir, work=None, flow_kind=DaydreamRunFlow.PR,
+    )
+    assert recorder.backend_name == "codex"
+    assert recorder.review_backend_name == "codex"
+    assert recorder.fix_backend_name == "claude"
+    assert recorder.test_backend_name == ""
+
+
 def test_open_recorder_backend_falls_back_to_claude(tmp_path: Path) -> None:
-    from daydream.runner import RunConfig, _open_recorder
+    from daydream.runner import _open_recorder
     target_dir = tmp_path / "project"
     target_dir.mkdir()
     config = RunConfig(target=str(target_dir), run_eval=False)

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -1429,6 +1429,30 @@ async def test_build_trajectory_omits_backend_when_unset(tmp_path: Path) -> None
     assert "test_backend" not in extra
 
 
+async def test_build_trajectory_omits_empty_per_phase_backend_keys(tmp_path: Path) -> None:
+    """Per-phase backend keys are omitted when their name is empty (improve flow)."""
+    recorder = TrajectoryRecorder(
+        path=tmp_path / ".daydream" / "trajectory.json",
+        run_flow=DaydreamRunFlow.IMPROVE,
+        target_dir=tmp_path,
+        agent_model_name="opus",
+        session_id="test",
+        backend_name="codex",
+        review_backend_name="codex",
+        fix_backend_name="",
+        test_backend_name="",
+    )
+    async with recorder:
+        async with recorder.invocation(phase=DaydreamPhase.REVIEW) as inv:
+            inv.observe(TextEvent(text="hello"))
+            inv.observe(ResultEvent(structured_output=None, continuation=None))
+    extra = read_trajectory(recorder.path)["extra"]
+    assert extra["backend"] == "codex"
+    assert extra["review_backend"] == "codex"
+    assert "fix_backend" not in extra
+    assert "test_backend" not in extra
+
+
 async def test_fork_child_inherits_backend_identity(tmp_path: Path) -> None:
     parent = TrajectoryRecorder(
         path=tmp_path / ".daydream" / "trajectory.json",

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -1384,3 +1384,46 @@ async def test_analyze_costs_total_comes_from_root_only(tmp_path: Path) -> None:
     assert len(by_agent) == 2
     assert any(a["cost_usd"] == pytest.approx(0.5) for a in costs["by_agent"])
     assert sum(a["cost_usd"] for a in costs["by_agent"]) == pytest.approx(costs["total_cost_usd"])
+
+
+async def test_build_trajectory_extra_records_backend_identity(tmp_path: Path) -> None:
+    recorder = TrajectoryRecorder(
+        path=tmp_path / ".daydream" / "trajectory.json",
+        run_flow=DaydreamRunFlow.NORMAL,
+        target_dir=tmp_path,
+        agent_model_name="opus",
+        session_id="test",
+        backend_name="codex",
+        review_backend_name="pi",
+        fix_backend_name="claude",
+        test_backend_name="osprey",
+    )
+    async with recorder:
+        async with recorder.invocation(phase=DaydreamPhase.REVIEW) as inv:
+            inv.observe(TextEvent(text="hello"))
+            inv.observe(ResultEvent(structured_output=None, continuation=None))
+    extra = read_trajectory(recorder.path)["extra"]
+    assert extra["backend"] == "codex"
+    assert extra["review_backend"] == "pi"
+    assert extra["fix_backend"] == "claude"
+    assert extra["test_backend"] == "osprey"
+    assert extra["target_dir"] == str(tmp_path)
+
+
+async def test_build_trajectory_omits_backend_when_unset(tmp_path: Path) -> None:
+    recorder = TrajectoryRecorder(
+        path=tmp_path / ".daydream" / "trajectory.json",
+        run_flow=DaydreamRunFlow.NORMAL,
+        target_dir=tmp_path,
+        agent_model_name="opus",
+        session_id="test",
+    )
+    async with recorder:
+        async with recorder.invocation(phase=DaydreamPhase.REVIEW) as inv:
+            inv.observe(TextEvent(text="hello"))
+            inv.observe(ResultEvent(structured_output=None, continuation=None))
+    extra = read_trajectory(recorder.path)["extra"]
+    assert "backend" not in extra
+    assert "review_backend" not in extra
+    assert "fix_backend" not in extra
+    assert "test_backend" not in extra

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -1427,3 +1427,30 @@ async def test_build_trajectory_omits_backend_when_unset(tmp_path: Path) -> None
     assert "review_backend" not in extra
     assert "fix_backend" not in extra
     assert "test_backend" not in extra
+
+
+async def test_fork_child_inherits_backend_identity(tmp_path: Path) -> None:
+    parent = TrajectoryRecorder(
+        path=tmp_path / ".daydream" / "trajectory.json",
+        run_flow=DaydreamRunFlow.NORMAL,
+        target_dir=tmp_path,
+        agent_model_name="opus",
+        session_id="test",
+        backend_name="codex",
+        review_backend_name="codex",
+        fix_backend_name="pi",
+        test_backend_name="codex",
+    )
+    async with parent:
+        async with parent.invocation(phase=DaydreamPhase.REVIEW) as inv:
+            inv.observe(TextEvent(text="parent"))
+            inv.observe(ResultEvent(structured_output=None, continuation=None))
+        async with parent.fork("deep") as child:
+            async with child.invocation(phase=DaydreamPhase.DEEP) as cinv:
+                cinv.observe(TextEvent(text="child"))
+                cinv.observe(ResultEvent(structured_output=None, continuation=None))
+    child_extra = read_trajectory(child.path)["extra"]
+    assert child_extra["backend"] == "codex"
+    assert child_extra["review_backend"] == "codex"
+    assert child_extra["fix_backend"] == "pi"
+    assert child_extra["test_backend"] == "codex"


### PR DESCRIPTION
Closes #643

Backend identity recording in trajectory extra metadata, forked child trajectories, and the recorder factory — with per-flow resolution for deep, improve, and custom flows. Two sequential daydream deep-precision reviews completed (trajectories uploaded to HF).

## Test Plan
- [x] `make check` (3596 passed, 6 skipped): lockcheck + lint + typecheck + full pytest

Branches rebased onto current main.