### PR TITLE
[daydream] Bound the deep-flow diff size (#625) (Closes #644)

### DIFF
--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -941,7 +941,25 @@ async def _step_exploration(ctx: FlowContext) -> None:
     config = ctx.config
     target_dir = ctx.work.repo
     daydream_dir = target_dir / ".daydream"
+    # Issue #644 — the pre-scan must be grounded in the FULL diff, never the
+    # bounded in-memory ``ctx.data["diff"]``: ``detect_affected_files`` seeds a
+    # specialist per affected file, so a dropped-block file would otherwise get
+    # zero exploration context, and the exact-match cache key would cover only
+    # the retained blocks (a change confined to a dropped-block region could
+    # then hit the cache). ``diff_path`` is always written full at gather; a
+    # read failure degrades to the bounded text with a warning rather than
+    # failing the run — exploration is fail-open by design.
     diff = ctx.data["diff"]
+    diff_path = ctx.data.get("diff_path")
+    if diff_path is not None:
+        try:
+            diff = diff_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            print_warning(
+                console,
+                f"Could not read the full diff for the exploration pre-scan "
+                f"({exc}); falling back to the bounded in-memory diff",
+            )
     tier = ctx.data["tier"]
     exploration_path = daydream_dir / "exploration"
 
@@ -1002,6 +1020,45 @@ async def _step_exploration(ctx: FlowContext) -> None:
     ctx.data["exploration_dir"] = exploration_dir
 
 
+def _ttt_diff_text(ctx: FlowContext) -> str | None:
+    """The diff text handed to the TTT phases (intent/wonder).
+
+    Issue #644 — the gather-time bound shrinks an over-budget diff to whole
+    retained blocks so ``ctx.data["diff"]`` fits the inline prompt budget, but
+    the inline prompts promise "the complete diff is inlined below (do NOT
+    re-Read ``diff.patch``)". Inlining the bounded text would make that claim
+    over a truncated diff with no path to the dropped blocks, so when the diff
+    WAS truncated the FULL on-disk diff (``ctx.data["diff_path"]``, always
+    written full at gather) is handed over instead: it never fits the inline
+    budget, so worktree-cwd backends keep the ``diff.patch`` pointer and
+    disposable-clone read-only backends keep their documented truncated-inline
+    fallback. The bounded text is therefore only ever inlined when it genuinely
+    IS the complete diff. A full-diff read failure degrades to the bounded text
+    with a warning (defensive only — ``diff.patch`` was written this run).
+    """
+    if not ctx.data.get("diff_truncated"):
+        return ctx.data["diff"]
+    diff_path = ctx.data.get("diff_path")
+    if diff_path is not None:
+        try:
+            return diff_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            truncation = ctx.data.get("diff_truncation")
+            detail = (
+                f" ({truncation.retained_bytes}/{truncation.original_bytes} "
+                f"bytes, {truncation.retained_blocks}/{truncation.total_blocks} "
+                "blocks retained)"
+                if truncation is not None
+                else ""
+            )
+            print_warning(
+                console,
+                f"Could not read the full diff for the intent/wonder phases "
+                f"({exc}); falling back to the bounded in-memory diff{detail}",
+            )
+    return ctx.data["diff"]
+
+
 async def _step_intent(ctx: FlowContext) -> None:
     """TTT intent analysis, grounded by the PR description when it is fresh.
 
@@ -1052,7 +1109,7 @@ async def _step_intent(ctx: FlowContext) -> None:
             ctx.data["branch"],
             exploration_dir=ctx.data["exploration_dir"],
             pr_description=pr_description,
-            diff_text=ctx.data["diff"],
+            diff_text=_ttt_diff_text(ctx),
         )
     # Each TTT step persists its own half, so a later step's failure cannot
     # discard an artifact this one already produced.
@@ -1077,7 +1134,7 @@ async def _wonder(ctx: FlowContext) -> None:
                 ctx.data["diff_path"],
                 intent_summary,
                 exploration_dir=ctx.data["exploration_dir"],
-                diff_text=ctx.data["diff"],
+                diff_text=_ttt_diff_text(ctx),
             )
 
     alts_p = _alternatives_path(ctx.data["dd"])
@@ -3703,7 +3760,9 @@ async def _run_review_spine(config: RunConfig, work: WorkContext, mode: str) -> 
         # ``INLINE_DIFF_BUDGET_BYTES`` via whole-block retention (``diff.patch``
         # above stays FULL on disk for the archival/coverage/eval/training
         # consumers; tiering / ``diff_key`` / ``changed_files`` above already
-        # ran on the full ``diff``). ``bound_deep_diff`` is infallible and runs
+        # ran on the full ``diff``; the exploration pre-scan and the uncovered
+        # sweep read the FULL on-disk patch at step time, never this bounded
+        # value). ``bound_deep_diff`` is infallible and runs
         # after the full diff is persisted, so the disk copy is never bounded.
         bounded_diff, bound_info = bound_deep_diff(diff)
         if bound_info.truncated:

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -171,6 +171,7 @@ except ImportError:  # pragma: no cover -- only hit when Phases 1-4 absent
 from daydream.deep.prompts import (
     _DIFF_BLOCK_SPLIT,
     _diff_block_path,
+    bound_deep_diff,
 )
 
 # User-visible pipeline stages (exploration is a pre-stage banner, not counted).
@@ -3680,13 +3681,27 @@ async def _run_review_spine(config: RunConfig, work: WorkContext, mode: str) -> 
 
         # Flow context (steps communicate through ctx.data); ctx shares
         # run_deep's backend cache so instance-sharing semantics are unchanged.
+        # Issue #644 — the in-memory diff is bounded at gather time to
+        # ``INLINE_DIFF_BUDGET_BYTES`` via whole-block retention (``diff.patch``
+        # above stays FULL on disk for the archival/coverage/eval/training
+        # consumers; tiering / ``diff_key`` / ``changed_files`` above already
+        # ran on the full ``diff``). ``bound_deep_diff`` is infallible and runs
+        # after the full diff is persisted, so the disk copy is never bounded.
+        bounded_diff, bound_info = bound_deep_diff(diff)
+        if bound_info.truncated:
+            print_warning(
+                console,
+                f"Deep diff truncated: {bound_info.original_bytes} -> "
+                f"{bound_info.retained_bytes} bytes "
+                f"({bound_info.retained_blocks}/{bound_info.total_blocks} blocks retained)",
+            )
         ctx = FlowContext(
             config=config,
             work=work,
             registry=get_registry(),
             data={
                 "mode": mode,
-                "diff": diff,
+                "diff": bounded_diff,
                 # Issue #336 — fix-loop scope bound. The reviewed diff's file
                 # set threads through ctx.data so the fix gate can partition
                 # out-of-scope findings (Task 3) and the fix step can both
@@ -3695,6 +3710,8 @@ async def _run_review_spine(config: RunConfig, work: WorkContext, mode: str) -> 
                 # ``_diff_changed_files``; a missing key never crashes.
                 "changed_files": set(changed_files),
                 "diff_path": diff_path,
+                "diff_truncated": bound_info.truncated,
+                "diff_truncation": bound_info,
                 "tier": tier,
                 "dd": dd,
                 "stacks": stacks,

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -1403,9 +1403,27 @@ async def _run_uncovered_sweep(ctx: FlowContext) -> None:
 
     uncovered_files, coverage_stats = compute_uncovered_files(dd.parent, session_id)
 
+    # Issue #644 — the sweep's block extraction must source the FULL on-disk
+    # diff (``ctx.data["diff_path"]``, always written full at gather) because
+    # the coverage file set above derives from the same full ``diff.patch``:
+    # a bounded in-memory ``ctx.data["diff"]`` would silently route a
+    # truncated-away file into ``skipped_small`` (block lookup -> None) and it
+    # would never be swept. A read error here propagates to the step's
+    # fail-open wrapper (the sweep must NEVER fail the run); it is not
+    # swallowed with a silent empty-diff fallback.
+    full_diff: str
+    diff_path = ctx.data.get("diff_path")
+    if diff_path is not None:
+        full_diff = diff_path.read_text(encoding="utf-8")
+    else:
+        # Defensive legacy fallback only (never the default): a ctx built
+        # without ``diff_path`` degrades to the in-memory diff rather than
+        # crashing the sweep.
+        full_diff = ctx.data["diff"]
+
     swept_files, skipped_small_files, skipped_capacity_files = filter_sweepable_files(
         uncovered_files,
-        ctx.data["diff"],
+        full_diff,
         min_hunk_lines=_uncovered_sweep_min_hunk_lines(config),
         max_files=_uncovered_sweep_max_files(config),
     )
@@ -1463,7 +1481,7 @@ async def _run_uncovered_sweep(ctx: FlowContext) -> None:
             output_path = dd / f"uncovered-{n}-review.md"
             prompt = build_uncovered_sweep_prompt(
                 file=file,
-                hunks=diff_block_for_file(ctx.data["diff"], file) or "",
+                hunks=diff_block_for_file(full_diff, file) or "",
                 intent_path=ctx.data["intent_path"],
                 cwd=ctx.work.repo,
                 output_path=output_path,

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -933,6 +933,28 @@ def _has_non_daydream_worktree_changes(status: str) -> bool:
     return False
 
 
+def _read_full_diff(ctx: FlowContext) -> str:
+    """Read the full on-disk PR diff (``ctx.data["diff_path"]``).
+
+    Issue #644 — the gather-time bound shrinks the in-memory
+    ``ctx.data["diff"]`` to ``INLINE_DIFF_BUDGET_BYTES`` via whole-block
+    retention, so consumers that need the COMPLETE diff (the exploration
+    pre-scan, the intent/wonder TTT phases, and the uncovered sweep) must
+    re-read ``diff_path``, which is always written full at gather. This is
+    that single re-read site.
+
+    Raises ``OSError`` on a failed read so each caller keeps its own
+    degradation shape (warn-and-fallback for exploration / TTT,
+    propagate-to-the-fail-open-wrapper for the sweep). When the ctx carries no
+    ``diff_path`` (defensive legacy fallback only, never the default), the
+    bounded in-memory ``ctx.data["diff"]`` is returned instead of crashing.
+    """
+    diff_path = ctx.data.get("diff_path")
+    if diff_path is None:
+        return ctx.data["diff"]
+    return diff_path.read_text(encoding="utf-8")
+
+
 async def _step_exploration(ctx: FlowContext) -> None:
     """Exploration pre-scan (D-43), reused on an exact key match."""
     from daydream.exploration import cache_key_path, exploration_cache_key, read_cache_key
@@ -950,16 +972,14 @@ async def _step_exploration(ctx: FlowContext) -> None:
     # read failure degrades to the bounded text with a warning rather than
     # failing the run — exploration is fail-open by design.
     diff = ctx.data["diff"]
-    diff_path = ctx.data.get("diff_path")
-    if diff_path is not None:
-        try:
-            diff = diff_path.read_text(encoding="utf-8")
-        except OSError as exc:
-            print_warning(
-                console,
-                f"Could not read the full diff for the exploration pre-scan "
-                f"({exc}); falling back to the bounded in-memory diff",
-            )
+    try:
+        diff = _read_full_diff(ctx)
+    except OSError as exc:
+        print_warning(
+            console,
+            f"Could not read the full diff for the exploration pre-scan "
+            f"({exc}); falling back to the bounded in-memory diff",
+        )
     tier = ctx.data["tier"]
     exploration_path = daydream_dir / "exploration"
 
@@ -1038,24 +1058,20 @@ def _ttt_diff_text(ctx: FlowContext) -> str | None:
     """
     if not ctx.data.get("diff_truncated"):
         return ctx.data["diff"]
-    diff_path = ctx.data.get("diff_path")
-    if diff_path is not None:
-        try:
-            return diff_path.read_text(encoding="utf-8")
-        except OSError as exc:
-            truncation = ctx.data.get("diff_truncation")
-            detail = (
-                f" ({truncation.retained_bytes}/{truncation.original_bytes} "
-                f"bytes, {truncation.retained_blocks}/{truncation.total_blocks} "
-                "blocks retained)"
-                if truncation is not None
-                else ""
-            )
-            print_warning(
-                console,
-                f"Could not read the full diff for the intent/wonder phases "
-                f"({exc}); falling back to the bounded in-memory diff{detail}",
-            )
+    try:
+        return _read_full_diff(ctx)
+    except OSError as exc:
+        truncation = ctx.data.get("diff_truncation")
+        detail = (
+            f" ({truncation.marker.strip()})"
+            if truncation is not None and truncation.marker is not None
+            else ""
+        )
+        print_warning(
+            console,
+            f"Could not read the full diff for the intent/wonder phases "
+            f"({exc}); falling back to the bounded in-memory diff{detail}",
+        )
     return ctx.data["diff"]
 
 
@@ -1465,18 +1481,12 @@ async def _run_uncovered_sweep(ctx: FlowContext) -> None:
     # the coverage file set above derives from the same full ``diff.patch``:
     # a bounded in-memory ``ctx.data["diff"]`` would silently route a
     # truncated-away file into ``skipped_small`` (block lookup -> None) and it
-    # would never be swept. A read error here propagates to the step's
+    # would never be swept. A read error propagates to the step's
     # fail-open wrapper (the sweep must NEVER fail the run); it is not
-    # swallowed with a silent empty-diff fallback.
-    full_diff: str
-    diff_path = ctx.data.get("diff_path")
-    if diff_path is not None:
-        full_diff = diff_path.read_text(encoding="utf-8")
-    else:
-        # Defensive legacy fallback only (never the default): a ctx built
-        # without ``diff_path`` degrades to the in-memory diff rather than
-        # crashing the sweep.
-        full_diff = ctx.data["diff"]
+    # swallowed with a silent empty-diff fallback. A ctx built without
+    # ``diff_path`` (defensive legacy fallback only, never the default)
+    # degrades to the in-memory diff rather than crashing the sweep.
+    full_diff = _read_full_diff(ctx)
 
     swept_files, skipped_small_files, skipped_capacity_files = filter_sweepable_files(
         uncovered_files,
@@ -3766,11 +3776,22 @@ async def _run_review_spine(config: RunConfig, work: WorkContext, mode: str) -> 
         # after the full diff is persisted, so the disk copy is never bounded.
         bounded_diff, bound_info = bound_deep_diff(diff)
         if bound_info.truncated:
+            dropped = (
+                f"; dropped blocks: {', '.join(bound_info.dropped_paths)}"
+                if bound_info.dropped_paths
+                else ""
+            )
+            oversize = (
+                f"; oversized block kept whole: {', '.join(bound_info.oversize_paths)}"
+                if bound_info.oversize_paths
+                else ""
+            )
             print_warning(
                 console,
                 f"Deep diff truncated: {bound_info.original_bytes} -> "
                 f"{bound_info.retained_bytes} bytes "
-                f"({bound_info.retained_blocks}/{bound_info.total_blocks} blocks retained)",
+                f"({bound_info.retained_blocks}/{bound_info.total_blocks} blocks retained"
+                f"{dropped}{oversize})",
             )
         ctx = FlowContext(
             config=config,

--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -325,8 +325,10 @@ class DeepDiffBoundInfo:
     """Truncation statistics for one ``bound_deep_diff`` call.
 
     ``retained_bytes`` excludes the marker line; ``oversize_paths`` names the
-    files whose single block exceeded the cap and was kept whole (block
-    integrity outranks the soft byte bound).
+    files whose single block exceeded the cap and was kept whole. Only a
+    LEADING oversize block (one that arrives before any retained block) is
+    kept whole and recorded; an oversize block arriving after a retained
+    block is dropped whole and absent from ``oversize_paths``.
     """
 
     truncated: bool
@@ -352,8 +354,11 @@ def bound_deep_diff(diff: str, budget: int = INLINE_DIFF_BUDGET_BYTES) -> tuple[
     (byte-for-byte identical to today, Must-have #4). Over ``budget`` whole
     blocks are retained while ``retained_bytes + block_bytes <= budget``; a
     single block that alone exceeds the cap is kept whole with its path
-    recorded in ``oversize_paths`` (block integrity outranks the soft bound;
-    the prompt-inline budget already keeps it out of an oversized prompt). The
+    recorded in ``oversize_paths`` -- but only when it is the leading block
+    (no retained block yet). An oversize block arriving after a retained
+    block is dropped whole and omitted from ``oversize_paths`` (block
+    integrity outranks the soft bound; the prompt-inline budget already keeps
+    it out of an oversized prompt). The
     returned value carries a leading ``# daydream: deep diff truncated:``
     marker line only when truncated; ``retained_bytes`` excludes the marker.
 
@@ -373,7 +378,8 @@ def bound_deep_diff(diff: str, budget: int = INLINE_DIFF_BUDGET_BYTES) -> tuple[
     total_blocks = 0
     oversize_paths: list[str] = []
     for block in _DIFF_BLOCK_SPLIT.split(diff):
-        if _diff_block_path(block) is None:
+        block_path = _diff_block_path(block)
+        if block_path is None:
             # Leading empty fragment / non-``diff --git`` element: never a block.
             continue
         total_blocks += 1
@@ -387,7 +393,7 @@ def bound_deep_diff(diff: str, budget: int = INLINE_DIFF_BUDGET_BYTES) -> tuple[
             # budget keeps it out of an oversized prompt.
             retained.append(block)
             retained_bytes += block_bytes
-            oversize_paths.append(_diff_block_path(block) or "")
+            oversize_paths.append(block_path)
         # else: block dropped whole; never split mid-stream.
 
     marker = (

--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -16,6 +16,7 @@ Public builders:
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -317,6 +318,92 @@ def _diff_blocks_for_files(diff: str, files: list[str]) -> str | None:
     if not fits_inline_diff_budget(result):
         return None
     return result
+
+
+@dataclass
+class DeepDiffBoundInfo:
+    """Truncation statistics for one ``bound_deep_diff`` call.
+
+    ``retained_bytes`` excludes the marker line; ``oversize_paths`` names the
+    files whose single block exceeded the cap and was kept whole (block
+    integrity outranks the soft byte bound).
+    """
+
+    truncated: bool
+    original_bytes: int = 0
+    retained_bytes: int = 0
+    total_blocks: int = 0
+    retained_blocks: int = 0
+    oversize_paths: list[str] = field(default_factory=list)
+    marker: str | None = None
+
+
+def bound_deep_diff(diff: str, budget: int = INLINE_DIFF_BUDGET_BYTES) -> tuple[str, DeepDiffBoundInfo]:
+    """Bound ``diff`` to ``budget`` bytes using whole ``diff --git``-block retention.
+
+    Issue #644: the deep-flow gather stores this bounded value in
+    ``ctx.data["diff"]`` so a pathological PR never feeds an oversized
+    in-memory diff into the prompt pipeline. Reuses the shared
+    ``_DIFF_BLOCK_SPLIT`` / ``_diff_block_path`` parse contract -- a retained
+    block is byte-identical to its source block and no block is ever split
+    mid-stream.
+
+    At/under ``budget`` the input is returned unchanged with no marker
+    (byte-for-byte identical to today, Must-have #4). Over ``budget`` whole
+    blocks are retained while ``retained_bytes + block_bytes <= budget``; a
+    single block that alone exceeds the cap is kept whole with its path
+    recorded in ``oversize_paths`` (block integrity outranks the soft bound;
+    the prompt-inline budget already keeps it out of an oversized prompt). The
+    returned value carries a leading ``# daydream: deep diff truncated:``
+    marker line only when truncated; ``retained_bytes`` excludes the marker.
+
+    Blocks that fail to resolve a path via ``_diff_block_path`` (the leading
+    empty split fragment, non-``diff --git`` elements) are skipped exactly as
+    ``_diff_changed_files`` / ``_diff_blocks_for_files`` do.
+
+    Returns:
+        ``(bounded_diff, DeepDiffBoundInfo)``.
+    """
+    original_bytes = len(diff.encode("utf-8"))
+    if original_bytes <= budget:
+        return diff, DeepDiffBoundInfo(truncated=False, original_bytes=original_bytes, marker=None)
+
+    retained: list[str] = []
+    retained_bytes = 0
+    total_blocks = 0
+    oversize_paths: list[str] = []
+    for block in _DIFF_BLOCK_SPLIT.split(diff):
+        if _diff_block_path(block) is None:
+            # Leading empty fragment / non-``diff --git`` element: never a block.
+            continue
+        total_blocks += 1
+        block_bytes = len(block.encode("utf-8"))
+        if retained_bytes + block_bytes <= budget:
+            retained.append(block)
+            retained_bytes += block_bytes
+        elif not retained:
+            # A single block larger than the cap is kept whole (block
+            # integrity outranks the soft byte bound); the prompt-inline
+            # budget keeps it out of an oversized prompt.
+            retained.append(block)
+            retained_bytes += block_bytes
+            oversize_paths.append(_diff_block_path(block) or "")
+        # else: block dropped whole; never split mid-stream.
+
+    marker = (
+        f"# daydream: deep diff truncated: {original_bytes} -> {retained_bytes} bytes "
+        f"({len(retained)}/{total_blocks} blocks retained)\n"
+    )
+    bounded = marker + "".join(retained)
+    return bounded, DeepDiffBoundInfo(
+        truncated=True,
+        original_bytes=original_bytes,
+        retained_bytes=retained_bytes,
+        total_blocks=total_blocks,
+        retained_blocks=len(retained),
+        oversize_paths=oversize_paths,
+        marker=marker,
+    )
 
 
 def _full_diff_pointer(diff_path: Path) -> str:

--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -245,6 +245,16 @@ _DIFF_PLUS_HEADER = re.compile(r"^\+\+\+ (.+)$", re.MULTILINE)
 _DIFF_MINUS_HEADER = re.compile(r"^--- (.+)$", re.MULTILINE)
 # Fallback header for binary / mode-only diffs that lack `--- / +++`.
 _DIFF_GIT_HEADER = re.compile(r"^diff --git a/(\S+) b/(\S+)")
+# Truncation marker emitted by ``bound_deep_diff``; carries the same dropped
+# names as ``DeepDiffBoundInfo.dropped_paths`` so consumers of the bounded text
+# alone (``_diff_blocks_for_files``) can tell a dropped block from a file
+# simply absent from the diff. Parse-safe for every block consumer: the line
+# carries no ``diff --git`` / ``---`` / ``+++`` header, so ``_diff_block_path``
+# returns None and the block splitters skip it.
+_DIFF_TRUNCATION_MARKER = re.compile(
+    r"^# daydream: deep diff truncated: \d+ -> \d+ bytes "
+    r"\(\d+/\d+ blocks retained(?:; dropped: (?P<dropped>[^)]+))?\)\n"
+)
 
 
 def _diff_block_path(block: str) -> str | None:
@@ -301,11 +311,25 @@ def _diff_blocks_for_files(diff: str, files: list[str]) -> str | None:
 
     Returns:
         The concatenated diff blocks (with a trailing newline), or ``None``
-        when the result would exceed the byte budget or no blocks match.
+        when the result would exceed the byte budget, no blocks match, or the
+        ``diff`` is a bounded value whose truncation marker names one of
+        ``files`` as dropped whole (a stack that mixes retained and dropped
+        blocks must fall back to the diff_path pointer rather than inline a
+        silently partial hunk set).
     """
     wanted = set(files)
     if not wanted:
         return None
+
+    # Issue #644 follow-up: ``bound_deep_diff`` drops whole blocks over budget
+    # and names them in the leading truncation marker. A wanted file absent
+    # from the bounded text is only a problem when the marker names it as
+    # dropped -- a scope file never changed in this PR has no hunks to inline.
+    marker = _DIFF_TRUNCATION_MARKER.match(diff)
+    if marker is not None and marker.group("dropped") is not None:
+        dropped = {p.strip() for p in marker.group("dropped").split(",") if p.strip()}
+        if wanted & dropped:
+            return None
 
     selected: list[str] = []
     for block in _DIFF_BLOCK_SPLIT.split(diff):
@@ -325,10 +349,15 @@ class DeepDiffBoundInfo:
     """Truncation statistics for one ``bound_deep_diff`` call.
 
     ``retained_bytes`` excludes the marker line; ``oversize_paths`` names the
-    files whose single block exceeded the cap and was kept whole. Only a
-    LEADING oversize block (one that arrives before any retained block) is
-    kept whole and recorded; an oversize block arriving after a retained
-    block is dropped whole and absent from ``oversize_paths``.
+    files whose single block exceeded the cap and was kept whole;
+    ``dropped_paths`` names the files whose blocks were dropped whole by the
+    bound (``marker`` carries the same names inline, so a consumer of the
+    bounded text alone -- e.g. ``_diff_blocks_for_files`` -- can tell a
+    dropped block from a file simply absent from the diff). Only a LEADING
+    oversize block (one that arrives before any retained block) is kept
+    whole and recorded; an oversize block arriving after a retained block is
+    dropped whole, so it is absent from ``oversize_paths`` but present in
+    ``dropped_paths``.
     """
 
     truncated: bool
@@ -337,6 +366,7 @@ class DeepDiffBoundInfo:
     total_blocks: int = 0
     retained_blocks: int = 0
     oversize_paths: list[str] = field(default_factory=list)
+    dropped_paths: list[str] = field(default_factory=list)
     marker: str | None = None
 
 
@@ -361,6 +391,8 @@ def bound_deep_diff(diff: str, budget: int = INLINE_DIFF_BUDGET_BYTES) -> tuple[
     it out of an oversized prompt). The
     returned value carries a leading ``# daydream: deep diff truncated:``
     marker line only when truncated; ``retained_bytes`` excludes the marker.
+    When blocks were dropped the marker names them (``; dropped: <paths>``),
+    mirroring ``dropped_paths`` in the info object.
 
     Blocks that fail to resolve a path via ``_diff_block_path`` (the leading
     empty split fragment, non-``diff --git`` elements) are skipped exactly as
@@ -377,6 +409,7 @@ def bound_deep_diff(diff: str, budget: int = INLINE_DIFF_BUDGET_BYTES) -> tuple[
     retained_bytes = 0
     total_blocks = 0
     oversize_paths: list[str] = []
+    dropped_paths: list[str] = []
     for block in _DIFF_BLOCK_SPLIT.split(diff):
         block_path = _diff_block_path(block)
         if block_path is None:
@@ -394,11 +427,16 @@ def bound_deep_diff(diff: str, budget: int = INLINE_DIFF_BUDGET_BYTES) -> tuple[
             retained.append(block)
             retained_bytes += block_bytes
             oversize_paths.append(block_path)
-        # else: block dropped whole; never split mid-stream.
+        else:
+            # Block dropped whole; never split mid-stream. The path is
+            # recorded so per-stack extraction can refuse a silently partial
+            # inline when a stack mixes retained and dropped blocks.
+            dropped_paths.append(block_path)
 
+    dropped_clause = f"; dropped: {', '.join(dropped_paths)}" if dropped_paths else ""
     marker = (
         f"# daydream: deep diff truncated: {original_bytes} -> {retained_bytes} bytes "
-        f"({len(retained)}/{total_blocks} blocks retained)\n"
+        f"({len(retained)}/{total_blocks} blocks retained{dropped_clause})\n"
     )
     bounded = marker + "".join(retained)
     return bounded, DeepDiffBoundInfo(
@@ -408,6 +446,7 @@ def bound_deep_diff(diff: str, budget: int = INLINE_DIFF_BUDGET_BYTES) -> tuple[
         total_blocks=total_blocks,
         retained_blocks=len(retained),
         oversize_paths=oversize_paths,
+        dropped_paths=dropped_paths,
         marker=marker,
     )
 

--- a/daydream/deep/scope_issues.py
+++ b/daydream/deep/scope_issues.py
@@ -269,11 +269,19 @@ def _resolve_changed_files(ctx: FlowContext) -> set[str] | None:
     set — a divergence left the residual net strictly weaker than the gate on
     the resume path.
     """
-    from daydream.deep.orchestrator import _diff_changed_files
+    from daydream.deep.orchestrator import _diff_changed_files, _read_full_diff
 
     changed_files: set[str] | None = ctx.data.get("changed_files")
     if changed_files is None:
-        diff_str = ctx.data.get("diff") or ""
+        # Issue #644 — ctx.data["diff"] is the gather-time BOUNDED diff; the
+        # resume path must resolve the scope from the FULL diff.patch (via
+        # diff_path) so a truncated-away file is not silently excluded from
+        # the auto-fix scope. Fall back to the bounded text only when the ctx
+        # carries no diff_path (defensive legacy path).
+        try:
+            diff_str = _read_full_diff(ctx) or ""
+        except OSError:
+            diff_str = ctx.data.get("diff") or ""
         if diff_str:
             changed_files = set(_diff_changed_files(diff_str))
     return changed_files

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -6831,6 +6831,29 @@ async def test_deep_run_keeps_pointer_when_trailing_block_dropped(
         assert "SMALL_RETAINED_MARKER" not in prompt, f"{name} inlined the bounded diff"
         assert "line 500 of filler content" not in prompt, f"{name} inlined an over-budget diff"
 
+    # The python stack owns aaa.py (retained by the bound) AND zzz.py (dropped
+    # whole by the bound): the truncation marker names zzz.py as dropped, so
+    # ``_diff_blocks_for_files`` refuses a partial inline and the python
+    # per-stack prompt falls back to the diff.patch pointer instead of silently
+    # inlining aaa.py's hunk with zzz.py's hunks unreachable. The react stack
+    # (App.tsx only, fully retained) keeps its inline.
+    python_prompt = next(
+        c["prompt"] for c in stub.calls
+        if "you are reviewing the python stack" in c["prompt"].lower()
+    )
+    assert "Read it directly" in python_prompt, (
+        "a stack mixing retained and dropped blocks must fall back to the "
+        "full diff.patch pointer"
+    )
+    assert "SMALL_RETAINED_MARKER" not in python_prompt, (
+        "must not inline the retained block while the dropped block is missing"
+    )
+    react_prompt = next(
+        c["prompt"] for c in stub.calls
+        if "you are reviewing the react stack" in c["prompt"].lower()
+    )
+    assert "diff --git" in react_prompt, "a fully-retained stack must keep its inline hunks"
+
 
 async def test_deep_run_bounds_in_memory_diff_but_keeps_diff_patch_full(
     multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
@@ -6872,14 +6895,15 @@ async def test_deep_run_bounds_in_memory_diff_but_keeps_diff_patch_full(
     # (c) the helper's BOUNDED result -- not the full diff -- reaches
     # ctx.data['diff'] and the prompt pipeline. The TTT (intent/wonder) phases
     # deliberately re-read the FULL on-disk diff when truncation happened
-    # (``_ttt_diff_text``), so the only prompt consumer of the bounded value is
-    # the per-stack reviewer: big.py's block sorts LAST in git's byte-ordered
-    # diff, so the bound drops it and the python stack's combined blocks (api.py
-    # only) fit the inline budget -- the python per-stack prompt inlines api.py's
-    # hunk and carries neither big.py's dropped content nor the diff_path
-    # pointer. A gather bug that invokes the helper and discards the result
-    # (storing the full diff) would push the python stack's combined blocks over
-    # the budget, dropping the inline for the pointer.
+    # (``_ttt_diff_text``), so the per-stack reviewer is the bounded value's
+    # prompt consumer: big.py's block sorts LAST in git's byte-ordered diff,
+    # so the bound drops it. The python stack owns api.py AND big.py, so its
+    # wanted files span retained and dropped blocks: ``_diff_blocks_for_files``
+    # reads the truncation marker's dropped names, refuses the partial inline,
+    # and the python per-stack prompt carries the diff_path pointer instead of
+    # api.py's hunk alone. A gather bug that invokes the helper and discards
+    # the result (storing the full diff) would carry no marker and no dropped
+    # names -- the mixing guard could not fire.
     assert len(bounded_results) == 1
     assert "# daydream: deep diff truncated:" in bounded_results[0]
     assert "line 50 of filler content" not in bounded_results[0]
@@ -6887,10 +6911,20 @@ async def test_deep_run_bounds_in_memory_diff_but_keeps_diff_patch_full(
         c["prompt"] for c in stub.calls
         if "you are reviewing the python stack" in c["prompt"].lower()
     )
-    assert "diff --git" in per_stack_prompt, (
-        "the bounded diff must be inlined into the python per-stack prompt"
+    assert "Read it directly" in per_stack_prompt, (
+        "the python stack mixes retained (api.py) and dropped (big.py) blocks; "
+        "it must fall back to the full diff.patch pointer, never inline a "
+        "silent partial subset"
     )
+    assert "diff --git" not in per_stack_prompt
     assert "line 50 of filler content" not in per_stack_prompt
+    react_prompt = next(
+        c["prompt"] for c in stub.calls
+        if "you are reviewing the react stack" in c["prompt"].lower()
+    )
+    assert "diff --git" in react_prompt, (
+        "a fully-retained stack must keep its inline hunks"
+    )
 
 
 async def test_uncovered_sweep_reads_full_diff_for_block_extraction(

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -6729,9 +6729,12 @@ async def test_deep_run_keeps_pointer_when_diff_exceeds_budget(
     rule) and the bounded in-memory diff is STILL over the inline budget — the
     pointer fallback is genuinely exercised rather than replaced by an inline
     of the small retained blocks. A multi-file over-budget diff whose trailing
-    block is dropped instead yields a small bounded diff that is inlined
-    (``test_deep_run_bounds_in_memory_diff_but_keeps_diff_patch_full``).
+    block is dropped instead yields a bounded diff that WOULD fit the inline
+    budget; it must still fall back to the pointer so the "complete diff"
+    claim never covers a truncated diff
+    (``test_deep_run_keeps_pointer_when_trailing_block_dropped``).
     """
+    import daydream.deep.orchestrator as orch_mod
     from daydream.deep.prompts import INLINE_DIFF_BUDGET_BYTES
 
     # Push the diff over the byte budget with a large committed file.
@@ -6739,6 +6742,76 @@ async def test_deep_run_keeps_pointer_when_diff_exceeds_budget(
     (multi_stack_target / "0big.py").write_text(big + "\n")
     _git(multi_stack_target, "add", "0big.py")
     _git(multi_stack_target, "commit", "-m", "add big file")
+
+    bounded_results: list[str] = []
+    real = orch_mod.bound_deep_diff
+
+    def spy(diff: str, budget: int = INLINE_DIFF_BUDGET_BYTES):
+        result = real(diff, budget)
+        bounded_results.append(result[0])
+        return result
+
+    monkeypatch.setattr(orch_mod, "bound_deep_diff", spy)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    assert await _run_deep(multi_stack_target) == 0
+
+    # The pointer fallback only discriminates when 0big.py's block really sorts
+    # FIRST in git's byte-ordered diff AND the bound keeps it whole (leading
+    # oversize rule): verify both, so the "not inlined" assertions below cannot
+    # pass via an inline of small retained blocks instead of the pointer.
+    patch = (multi_stack_target / ".daydream" / "diff.patch").read_text()
+    assert patch.startswith("diff --git a/0big.py b/0big.py"), (
+        "0big.py must be the FIRST block in git's byte-ordered diff, "
+        f"got {patch.splitlines()[0] if patch else '<empty patch>'!r}"
+    )
+    assert len(bounded_results) == 1, "gather must bound the diff exactly once"
+    assert "line 500 of filler content" in bounded_results[0], (
+        "the bound must keep 0big.py's oversize block whole"
+    )
+    assert len(bounded_results[0].encode("utf-8")) > INLINE_DIFF_BUDGET_BYTES, (
+        "the bounded diff must stay over the inline budget so the pointer fallback is exercised"
+    )
+
+    intent_prompt = next(
+        c["prompt"] for c in stub.calls
+        if "understand the intent of these changes" in c["prompt"].lower()
+    )
+    wonder_prompt = next(
+        c["prompt"] for c in stub.calls
+        if "evaluate the implementation" in c["prompt"].lower()
+    )
+
+    assert "Read the diff file at" in intent_prompt
+    # The wonder pointer clause is "in the diff at {diff_path}"; the inline
+    # clause ("do NOT re-Read {diff_path}") embeds the path too, so the bare
+    # "diff.patch" substring is not discriminating.
+    assert "in the diff at " in wonder_prompt
+    for name, prompt in (("intent", intent_prompt), ("wonder", wonder_prompt)):
+        assert "line 500 of filler content" not in prompt, f"{name} inlined an over-budget diff"
+
+
+async def test_deep_run_keeps_pointer_when_trailing_block_dropped(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A multi-file over-budget diff whose trailing block is dropped keeps the
+    diff.patch pointer in the intent/wonder prompts.
+
+    Discriminating: the gather bound keeps the small leading block and drops
+    the huge trailing block whole, leaving a bounded in-memory diff that FITS
+    the inline budget. Inlining it would tell the agent "the complete diff is
+    inlined below (do NOT re-Read diff.patch)" over a truncated diff whose
+    dropped block is nowhere reachable — the pointer must be restored instead.
+    """
+    from daydream.deep.prompts import INLINE_DIFF_BUDGET_BYTES
+
+    # aaa.py sorts FIRST in the byte-ordered git diff and its block is
+    # retained; zzz.py's block alone exceeds the budget and arrives after a
+    # retained block, so it is dropped whole.
+    (multi_stack_target / "aaa.py").write_text("SMALL_RETAINED_MARKER = 1\n")
+    big = "\n".join(f"line {i} of filler content" for i in range(INLINE_DIFF_BUDGET_BYTES // 10))
+    (multi_stack_target / "zzz.py").write_text(big + "\n")
+    _git(multi_stack_target, "add", "aaa.py", "zzz.py")
+    _git(multi_stack_target, "commit", "-m", "add small and big files")
 
     stub = _install_stub_backend(monkeypatch, multi_stack_target)
     assert await _run_deep(multi_stack_target) == 0
@@ -6755,6 +6828,7 @@ async def test_deep_run_keeps_pointer_when_diff_exceeds_budget(
     assert "Read the diff file at" in intent_prompt
     assert "diff.patch" in wonder_prompt
     for name, prompt in (("intent", intent_prompt), ("wonder", wonder_prompt)):
+        assert "SMALL_RETAINED_MARKER" not in prompt, f"{name} inlined the bounded diff"
         assert "line 500 of filler content" not in prompt, f"{name} inlined an over-budget diff"
 
 
@@ -6776,15 +6850,18 @@ async def test_deep_run_bounds_in_memory_diff_but_keeps_diff_patch_full(
     _git(multi_stack_target, "commit", "-m", "add big file")
 
     called_with: list[str] = []
+    bounded_results: list[str] = []
     real = orch_mod.bound_deep_diff
 
     def spy(diff: str, budget: int = INLINE_DIFF_BUDGET_BYTES):
         called_with.append(diff)
-        return real(diff, budget)
+        result = real(diff, budget)
+        bounded_results.append(result[0])
+        return result
 
     monkeypatch.setattr(orch_mod, "bound_deep_diff", spy)
     _silence(monkeypatch)
-    _install_stub_backend(monkeypatch, multi_stack_target)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
     assert await _run_deep(multi_stack_target) == 0
 
     # (a) the helper was invoked at gather with the full diff (gather wiring).
@@ -6792,6 +6869,28 @@ async def test_deep_run_bounds_in_memory_diff_but_keeps_diff_patch_full(
     # (b) diff.patch on disk is FULL: the big committed file's content survives.
     patch = (multi_stack_target / ".daydream" / "diff.patch").read_text()
     assert "line 50 of filler content" in patch  # a line far into big.py is present
+    # (c) the helper's BOUNDED result -- not the full diff -- reaches
+    # ctx.data['diff'] and the prompt pipeline. The TTT (intent/wonder) phases
+    # deliberately re-read the FULL on-disk diff when truncation happened
+    # (``_ttt_diff_text``), so the only prompt consumer of the bounded value is
+    # the per-stack reviewer: big.py's block sorts LAST in git's byte-ordered
+    # diff, so the bound drops it and the python stack's combined blocks (api.py
+    # only) fit the inline budget -- the python per-stack prompt inlines api.py's
+    # hunk and carries neither big.py's dropped content nor the diff_path
+    # pointer. A gather bug that invokes the helper and discards the result
+    # (storing the full diff) would push the python stack's combined blocks over
+    # the budget, dropping the inline for the pointer.
+    assert len(bounded_results) == 1
+    assert "# daydream: deep diff truncated:" in bounded_results[0]
+    assert "line 50 of filler content" not in bounded_results[0]
+    per_stack_prompt = next(
+        c["prompt"] for c in stub.calls
+        if "you are reviewing the python stack" in c["prompt"].lower()
+    )
+    assert "diff --git" in per_stack_prompt, (
+        "the bounded diff must be inlined into the python per-stack prompt"
+    )
+    assert "line 50 of filler content" not in per_stack_prompt
 
 
 async def test_uncovered_sweep_reads_full_diff_for_block_extraction(
@@ -6804,34 +6903,55 @@ async def test_uncovered_sweep_reads_full_diff_for_block_extraction(
     block was truncated away would land in skipped_small (diff_block_for_file ->
     None) instead of being swept.
     """
-    import inspect
+    import daydream.deep.orchestrator as orch_mod
+    from daydream.deep.prompts import INLINE_DIFF_BUDGET_BYTES
 
-    from daydream.deep.orchestrator import _run_uncovered_sweep
+    # Push the in-memory diff over the budget with a file that sorts FIRST in
+    # git's byte-ordered diff: its oversize block is kept whole by the bound,
+    # so every later block -- including the small uncovered file below -- is
+    # dropped from ctx.data['diff'] but survives in the on-disk diff.patch.
+    big = "\n".join(f"line {i} of filler content" for i in range((INLINE_DIFF_BUDGET_BYTES // 10) + 50))
+    (multi_stack_target / "0big.py").write_text(big + "\n")
+    (multi_stack_target / "zzuncovered.py").write_text(
+        "".join(f"content line {i}\n" for i in range(6))
+    )
+    _git(multi_stack_target, "add", "0big.py", "zzuncovered.py")
+    _git(multi_stack_target, "commit", "-m", "add big file and an uncovered file")
 
+    bounded_results: list[str] = []
+    real = orch_mod.bound_deep_diff
+
+    def spy(diff: str, budget: int = INLINE_DIFF_BUDGET_BYTES):
+        result = real(diff, budget)
+        bounded_results.append(result[0])
+        return result
+
+    monkeypatch.setattr(orch_mod, "bound_deep_diff", spy)
     _silence(monkeypatch)
-    _install_stub_backend(monkeypatch, multi_stack_target)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    # Per-stack reviewers read their scope files; zzuncovered.py is deliberately
+    # unread so it is the sweep's single uncovered target.
+    stub.per_stack_emit_reads = True
+    stub.per_stack_unread = frozenset({"zzuncovered.py"})
+
     assert await _run_deep(multi_stack_target, uncovered_sweep=True) == 0
 
-    # The sweep's two block-extraction call sites must source their diff from
-    # the FULL on-disk patch (ctx.data['diff_path']), never the bounded
-    # ctx.data['diff']. Read the step body and assert each call's diff argument
-    # is a diff_path-derived variable, and that the bounded key is not the
-    # block source inside this function.
-    body = inspect.getsource(_run_uncovered_sweep)
-    func_src = body[body.index("def "):]
-    # The block source variable must be read from the full on-disk patch.
-    assert "diff_path" in func_src, "sweep must source blocks from diff_path (full diff.patch)"
-    # The bounded in-memory key must NOT be the diff argument to the two call sites.
-    # (It may still appear as a comment/other key; the guard is the block feed.)
+    # Prove the discriminating setup actually held: the bounded in-memory diff
+    # dropped zzuncovered.py's block (truncation marker present, the file's
+    # content absent) while the full on-disk diff.patch kept it. A sweep that
+    # sourced ctx.data['diff'] would then find no block for the file and route
+    # it into skipped_small; the fixed sweep sources diff.patch and sweeps it.
+    assert len(bounded_results) == 1
+    assert "# daydream: deep diff truncated:" in bounded_results[0]
+    assert "content line 3" not in bounded_results[0]
+    patch = (multi_stack_target / ".daydream" / "diff.patch").read_text()
+    assert "content line 3" in patch
 
-    def _call_slice(name: str) -> str:
-        start = func_src.index(name)
-        return func_src[start : func_src.index(")\n", start)]
-
-    sweep_call = _call_slice("filter_sweepable_files")
-    block_call = _call_slice("diff_block_for_file")
-    assert 'ctx.data["diff"]' not in sweep_call
-    assert 'ctx.data["diff"]' not in block_call
+    stats = json.loads(
+        (multi_stack_target / ".daydream" / "deep" / "coverage-stats.json").read_text()
+    )
+    assert "zzuncovered.py" in stats["attempted_files"]
+    assert "zzuncovered.py" not in stats["sweep_skipped_small_hunks_files"]
 
 
 async def test_intent_artifact_survives_wonder_failure(

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -6721,13 +6721,23 @@ async def test_deep_run_inlines_small_diff_into_intent_and_wonder(
 async def test_deep_run_keeps_pointer_when_diff_exceeds_budget(
     multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """An over-budget diff falls back to today's diff.patch pointer in both prompts."""
+    """An over-budget diff falls back to today's diff.patch pointer in both prompts.
+
+    The committed file is named ``0big.py`` so it sorts FIRST in the git diff
+    (``git diff`` emits paths in byte order): its single block alone exceeds
+    ``INLINE_DIFF_BUDGET_BYTES``, so the gather bound keeps it whole (oversize
+    rule) and the bounded in-memory diff is STILL over the inline budget — the
+    pointer fallback is genuinely exercised rather than replaced by an inline
+    of the small retained blocks. A multi-file over-budget diff whose trailing
+    block is dropped instead yields a small bounded diff that is inlined
+    (``test_deep_run_bounds_in_memory_diff_but_keeps_diff_patch_full``).
+    """
     from daydream.deep.prompts import INLINE_DIFF_BUDGET_BYTES
 
     # Push the diff over the byte budget with a large committed file.
     big = "\n".join(f"line {i} of filler content" for i in range(INLINE_DIFF_BUDGET_BYTES // 10))
-    (multi_stack_target / "big.py").write_text(big + "\n")
-    _git(multi_stack_target, "add", "big.py")
+    (multi_stack_target / "0big.py").write_text(big + "\n")
+    _git(multi_stack_target, "add", "0big.py")
     _git(multi_stack_target, "commit", "-m", "add big file")
 
     stub = _install_stub_backend(monkeypatch, multi_stack_target)
@@ -6746,6 +6756,42 @@ async def test_deep_run_keeps_pointer_when_diff_exceeds_budget(
     assert "diff.patch" in wonder_prompt
     for name, prompt in (("intent", intent_prompt), ("wonder", wonder_prompt)):
         assert "line 500 of filler content" not in prompt, f"{name} inlined an over-budget diff"
+
+
+async def test_deep_run_bounds_in_memory_diff_but_keeps_diff_patch_full(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Gather stores the BOUNDED diff in ctx.data; diff.patch on disk stays FULL.
+
+    Discriminating: a wiring bug either (a) fails to bound ctx.data['diff']
+    (helper never invoked), or (b) bounds the on-disk diff.patch (disk write
+    loses the truncated block). Both must be caught.
+    """
+    import daydream.deep.orchestrator as orch_mod
+    from daydream.deep.prompts import INLINE_DIFF_BUDGET_BYTES
+
+    big = "\n".join(f"line {i} of filler content" for i in range((INLINE_DIFF_BUDGET_BYTES // 10) + 50))
+    (multi_stack_target / "big.py").write_text(big + "\n")
+    _git(multi_stack_target, "add", "big.py")
+    _git(multi_stack_target, "commit", "-m", "add big file")
+
+    called_with: list[str] = []
+    real = orch_mod.bound_deep_diff
+
+    def spy(diff: str, budget: int = INLINE_DIFF_BUDGET_BYTES):
+        called_with.append(diff)
+        return real(diff, budget)
+
+    monkeypatch.setattr(orch_mod, "bound_deep_diff", spy)
+    _silence(monkeypatch)
+    _install_stub_backend(monkeypatch, multi_stack_target)
+    assert await _run_deep(multi_stack_target) == 0
+
+    # (a) the helper was invoked at gather with the full diff (gather wiring).
+    assert len(called_with) == 1 and called_with[0] == (multi_stack_target / ".daydream" / "diff.patch").read_text()
+    # (b) diff.patch on disk is FULL: the big committed file's content survives.
+    patch = (multi_stack_target / ".daydream" / "diff.patch").read_text()
+    assert "line 50 of filler content" in patch  # a line far into big.py is present
 
 
 # --- Task 12b: each TTT step writes its own artifact -------------------------

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -6794,7 +6794,44 @@ async def test_deep_run_bounds_in_memory_diff_but_keeps_diff_patch_full(
     assert "line 50 of filler content" in patch  # a line far into big.py is present
 
 
-# --- Task 12b: each TTT step writes its own artifact -------------------------
+async def test_uncovered_sweep_reads_full_diff_for_block_extraction(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The sweep extracts blocks from the FULL diff.patch, not the bounded
+    ctx.data['diff'], so sweep targets cannot diverge from the coverage set.
+
+    Discriminating: if the sweep used the bounded ctx.data['diff'], a file whose
+    block was truncated away would land in skipped_small (diff_block_for_file ->
+    None) instead of being swept.
+    """
+    import inspect
+
+    from daydream.deep.orchestrator import _run_uncovered_sweep
+
+    _silence(monkeypatch)
+    _install_stub_backend(monkeypatch, multi_stack_target)
+    assert await _run_deep(multi_stack_target, uncovered_sweep=True) == 0
+
+    # The sweep's two block-extraction call sites must source their diff from
+    # the FULL on-disk patch (ctx.data['diff_path']), never the bounded
+    # ctx.data['diff']. Read the step body and assert each call's diff argument
+    # is a diff_path-derived variable, and that the bounded key is not the
+    # block source inside this function.
+    body = inspect.getsource(_run_uncovered_sweep)
+    func_src = body[body.index("def "):]
+    # The block source variable must be read from the full on-disk patch.
+    assert "diff_path" in func_src, "sweep must source blocks from diff_path (full diff.patch)"
+    # The bounded in-memory key must NOT be the diff argument to the two call sites.
+    # (It may still appear as a comment/other key; the guard is the block feed.)
+
+    def _call_slice(name: str) -> str:
+        start = func_src.index(name)
+        return func_src[start : func_src.index(")\n", start)]
+
+    sweep_call = _call_slice("filter_sweepable_files")
+    block_call = _call_slice("diff_block_for_file")
+    assert 'ctx.data["diff"]' not in sweep_call
+    assert 'ctx.data["diff"]' not in block_call
 
 
 async def test_intent_artifact_survives_wonder_failure(

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -9,8 +9,10 @@ from daydream.deep.prompts import (
     CONFIG_FLOW_TRACE_INSTRUCTION,
     CROSS_FILE_SYMBOL_EXISTENCE_INSTRUCTION,
     DOC_REVIEW_NOTICE,
+    INLINE_DIFF_BUDGET_BYTES,
     TEST_QUALITY_RUBRIC_INSTRUCTION,
     TRUST_MODEL_INSTRUCTION,
+    bound_deep_diff,
     build_arbiter_prompt,
     build_generic_fallback_prompt,
     build_merge_prompt,
@@ -413,6 +415,74 @@ _DIFF_TWO_FILES = (
     "-export const App = () => <div>hello</div>;\n"
     "+export const App = () => <div>universe</div>;\n"
 )
+
+
+# =============================================================================
+# Issue #644 — bound the deep-flow diff at gather time (whole-block retention)
+# =============================================================================
+
+
+def _blk(path: str, body: str) -> str:
+    return (
+        f"diff --git a/{path} b/{path}\n"
+        f"+++ b/{path}\n"
+        "@@ -1 +1 @@\n"
+        f"-{body}\n"
+        f"+{body.upper()}\n"
+    )
+
+
+def test_bound_deep_diff_under_budget_is_byte_identical() -> None:
+    """Must-have #4: at/under cap → identical value, no marker, no truncation."""
+    out, info = bound_deep_diff(_DIFF_TWO_FILES)
+    assert out == _DIFF_TWO_FILES
+    assert not info.truncated
+    assert info.marker is None
+
+
+def test_bound_deep_diff_keeps_whole_blocks_up_to_budget() -> None:
+    """Must-have #2: over cap → only whole blocks retained; each byte-identical."""
+    from daydream.deep.coverage import diff_block_for_file
+
+    diff = _blk("a.py", "x" * 3000) + _blk("b.py", "y" * 3000) + _blk("c.py", "z" * 3000)
+    out, info = bound_deep_diff(diff)
+    assert info.truncated
+    assert "diff --git a/a.py b/a.py" in out
+    assert "diff --git a/b.py b/b.py" in out
+    # c.py's block is dropped whole (never split mid-stream).
+    assert "diff --git a/c.py b/c.py" not in out
+    assert "-" + "x" * 3000 in out  # a retained block's hunk body is present, unchanged
+    # Every retained block is byte-identical to its source block.
+    assert diff_block_for_file(out, "a.py") == diff_block_for_file(diff, "a.py")
+    assert diff_block_for_file(out, "b.py") == diff_block_for_file(diff, "b.py")
+    assert info.original_bytes == len(diff.encode("utf-8"))
+    assert info.retained_bytes == len(out.encode("utf-8")) - len((info.marker or "").encode("utf-8"))
+    assert info.retained_blocks < info.total_blocks
+
+
+def test_bound_deep_diff_oversize_single_block_kept_whole() -> None:
+    """Must-have #5: a single block larger than the cap is kept whole + oversize marker."""
+    diff = _blk("huge.py", "y" * (INLINE_DIFF_BUDGET_BYTES + 256))
+    out, info = bound_deep_diff(diff)
+    assert info.truncated
+    assert "diff --git a/huge.py b/huge.py" in out
+    assert "huge.py" in info.oversize_paths
+    assert info.retained_blocks == 1
+
+
+def test_bound_deep_diff_marker_is_parse_safe() -> None:
+    """Must-have #3 + spike: marker element is skipped by every block consumer."""
+    diff = _blk("a.py", "x" * 3000) + _blk("b.py", "y" * 3000) + _blk("c.py", "z" * 3000)
+    out, info = bound_deep_diff(diff)
+    assert info.marker is not None
+    assert out.startswith("# daydream: deep diff truncated:")
+    # count_changed_files / _diff_changed_files / diff_block_for_file ignore the marker.
+    from daydream.deep.coverage import diff_block_for_file
+    from daydream.exploration_runner import count_changed_files
+
+    assert count_changed_files(out) == 2
+    assert diff_block_for_file(out, "a.py") == diff_block_for_file(diff, "a.py")
+    assert diff_block_for_file(out, "c.py") is None
 
 
 def test_diff_blocks_for_files_selects_relevant_hunks() -> None:

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -444,14 +444,15 @@ def test_bound_deep_diff_keeps_whole_blocks_up_to_budget() -> None:
     """Must-have #2: over cap → only whole blocks retained; each byte-identical."""
     from daydream.deep.coverage import diff_block_for_file
 
-    diff = _blk("a.py", "x" * 3000) + _blk("b.py", "y" * 3000) + _blk("c.py", "z" * 3000)
+    body = INLINE_DIFF_BUDGET_BYTES // 5  # three whole blocks; exactly two fit under the cap
+    diff = _blk("a.py", "x" * body) + _blk("b.py", "y" * body) + _blk("c.py", "z" * body)
     out, info = bound_deep_diff(diff)
     assert info.truncated
     assert "diff --git a/a.py b/a.py" in out
     assert "diff --git a/b.py b/b.py" in out
     # c.py's block is dropped whole (never split mid-stream).
     assert "diff --git a/c.py b/c.py" not in out
-    assert "-" + "x" * 3000 in out  # a retained block's hunk body is present, unchanged
+    assert "-" + "x" * body in out  # a retained block's hunk body is present, unchanged
     # Every retained block is byte-identical to its source block.
     assert diff_block_for_file(out, "a.py") == diff_block_for_file(diff, "a.py")
     assert diff_block_for_file(out, "b.py") == diff_block_for_file(diff, "b.py")

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -459,6 +459,8 @@ def test_bound_deep_diff_keeps_whole_blocks_up_to_budget() -> None:
     assert info.original_bytes == len(diff.encode("utf-8"))
     assert info.retained_bytes == len(out.encode("utf-8")) - len((info.marker or "").encode("utf-8"))
     assert info.retained_blocks < info.total_blocks
+    assert info.dropped_paths == ["c.py"]
+    assert "dropped: c.py" in (info.marker or "")
 
 
 def test_bound_deep_diff_oversize_single_block_kept_whole() -> None:
@@ -469,6 +471,7 @@ def test_bound_deep_diff_oversize_single_block_kept_whole() -> None:
     assert "diff --git a/huge.py b/huge.py" in out
     assert "huge.py" in info.oversize_paths
     assert info.retained_blocks == 1
+    assert info.dropped_paths == []  # nothing follows the kept-whole oversize block
 
 
 def test_bound_deep_diff_marker_is_parse_safe() -> None:
@@ -503,6 +506,36 @@ def test_diff_blocks_for_files_selects_relevant_hunks() -> None:
     assert both is not None
     assert "def hello(): return 'universe'" in both
     assert "<div>universe</div>" in both
+
+
+def test_diff_blocks_for_files_refuses_partial_inline_for_mixed_stack() -> None:
+    """A stack that mixes retained and dropped blocks falls back to the pointer.
+
+    ``bound_deep_diff`` keeps whole blocks up to the cap and names the dropped
+    ones in the truncation marker; ``_diff_blocks_for_files`` must refuse to
+    inline only the retained hunks of a stack whose other files' blocks were
+    dropped -- the caller then falls back to the diff_path pointer so the
+    reviewer never silently reviews a partial hunk set.
+    """
+    from daydream.deep.prompts import _diff_blocks_for_files
+
+    body = INLINE_DIFF_BUDGET_BYTES // 5  # three whole blocks; exactly two fit under the cap
+    diff = _blk("a.py", "x" * body) + _blk("b.py", "y" * body) + _blk("c.py", "z" * body)
+    bounded, info = bound_deep_diff(diff)
+    assert info.truncated
+    assert info.dropped_paths == ["c.py"]
+
+    # Fully-retained stack still inlines its complete hunks.
+    kept = _diff_blocks_for_files(bounded, ["a.py", "b.py"])
+    assert kept is not None
+    assert "diff --git a/a.py b/a.py" in kept
+    assert "diff --git a/b.py b/b.py" in kept
+    # Fully-dropped stack falls back (no blocks present in the bounded text).
+    assert _diff_blocks_for_files(bounded, ["c.py"]) is None
+    # Mixed stack must NOT get a partial inline of a.py alone.
+    assert _diff_blocks_for_files(bounded, ["a.py", "c.py"]) is None
+    # A scope file never changed in this PR is not mistaken for a dropped block.
+    assert _diff_blocks_for_files(bounded, ["a.py", "never.py"]) is not None
 
 
 def test_diff_blocks_for_files_returns_none_above_byte_budget() -> None:

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -476,7 +476,11 @@ def test_bound_deep_diff_oversize_single_block_kept_whole() -> None:
 
 def test_bound_deep_diff_marker_is_parse_safe() -> None:
     """Must-have #3 + spike: marker element is skipped by every block consumer."""
-    diff = _blk("a.py", "x" * 3000) + _blk("b.py", "y" * 3000) + _blk("c.py", "z" * 3000)
+    # Derive the block body from the budget (not a magic size) so the test stays
+    # valid if INLINE_DIFF_BUDGET_BYTES changes: three whole blocks, exactly two
+    # fit under the cap, so the marker-skip assertions exercise a dropped block.
+    body = INLINE_DIFF_BUDGET_BYTES // 5
+    diff = _blk("a.py", "x" * body) + _blk("b.py", "y" * body) + _blk("c.py", "z" * body)
     out, info = bound_deep_diff(diff)
     assert info.marker is not None
     assert out.startswith("# daydream: deep diff truncated:")


### PR DESCRIPTION
Closes #644

Bound the deep-flow diff size with whole-block retention: keep the full diff reachable for exploration, TTT, and sweep (diff.patch stays full), while the ctx.data diff is bounded at gather to avoid oversized inline prompts. On `--start-at` fix resume, the fix-loop scope re-reads the full diff.patch so a truncated-away file isn't silently dropped from the auto-fix scope.

Two sequential daydream deep-precision reviews completed (trajectories uploaded to HF).

## Test Plan
- [x] `make check` (3586 passed, 6 skipped): lockcheck + lint + typecheck + full pytest

Branches rebased onto current main.