### PR TITLE
[daydream] Consolidated: daydream input-handling hardening (host-command dedup + structured-output schema) (Closes #649)

### DIFF
--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -59,6 +59,7 @@ _logger = logging.getLogger(__name__)
 
 class MissingSkillError(Exception):
     """Raised when a required skill is not available."""
+
     def __init__(self, skill_name: str):
         self.skill_name = skill_name
         super().__init__(f"Skill '{skill_name}' is not available")
@@ -400,6 +401,40 @@ def _validates_schema(value: Any, schema: dict[str, Any]) -> bool:
     return not any(Draft202012Validator(schema).iter_errors(value))
 
 
+def _salvageable(value: Any, schema: dict[str, Any]) -> bool:
+    """Return whether ``value`` is usable by a salvage-tolerant consumer.
+
+    Full validation is the baseline, but the fallback gate must not be
+    all-or-nothing: the per-stack parse, the recommendation verifier, and the
+    cross-stack merge all normalize partial agent output (dropping invalid
+    records rather than losing the whole payload, or accepting a bare item
+    array), so a dict whose required top-level fields are present — with
+    array-typed fields holding actual lists — is still returned for them to
+    salvage, and so is a bare JSON array, which ``phase_cross_stack_merge``
+    normalizes to its item list (a bare array can never validate against the
+    object-typed ``MERGED_ITEMS_SCHEMA``). Nested item validity is deliberately
+    not checked here: that is the consumers' salvage domain.
+    """
+    if _validates_schema(value, schema):
+        return True
+    if isinstance(value, list):
+        return True
+    if not isinstance(value, dict):
+        return False
+    required = schema.get("required")
+    if not isinstance(required, list):
+        return False
+    properties = schema.get("properties", {})
+    for key in required:
+        if key not in value:
+            return False
+        prop = properties.get(key)
+        if isinstance(prop, dict) and prop.get("type") == "array":
+            if not isinstance(value[key], list):
+                return False
+    return True
+
+
 def _redact_log_value(value: Any) -> Any:
     """Recursively redact a log-mode value without mutating its argument.
 
@@ -433,6 +468,7 @@ async def run_agent(
     persist_session: bool = True,
     wall_budget_s: float | None = None,
     tool_call_budget: int | None = None,
+    validate_fallback_schema: bool = True,
 ) -> tuple[str | Any, ContinuationToken | None, str | None]:
     """Run agent with the given prompt and return output plus continuation token.
 
@@ -478,6 +514,12 @@ async def run_agent(
         tool_call_budget: Opt-in ceiling on ToolStartEvents in this turn. When
             exceeded the loop breaks with the same abort/partial-return path.
             ``None`` (the default) means no tool-call ceiling.
+        validate_fallback_schema: When True (default), the structured-output
+            extraction fallback only returns parsed JSON whose shape is usable
+            by downstream consumers (see ``_salvageable``). Set False for call
+            sites that re-validate or salvage wholesale downstream — the
+            improve recon, whose all-or-nothing top-level schema is
+            re-validated per-command by ``validate_recon_commands``.
 
     Returns:
         Tuple of (output, continuation_token, budget_reason). Output is text
@@ -826,17 +868,24 @@ async def run_agent(
         # Fallback: extract JSON from the raw text when structured output
         # failed. Uses robust extraction (handles prose-wrapped JSON and
         # markdown code fences — common with GLM and other OpenAI-compat models).
-        # The parsed result must also validate against the requested schema —
-        # an unvalidated fallback would be asymmetric with the success path.
-        # RECON is the exception: its top-level schema is all-or-nothing but the
-        # orchestrator salvages per-command records downstream (validate_recon_commands),
-        # so an all-or-nothing gate here would preempt that salvage. The downstream
-        # validator remains the fail-closed enforcement point for RECON.
+        # The parsed result must also pass the fallback gate — an unvalidated
+        # fallback would be asymmetric with the success path. The gate is
+        # salvage-tolerant, not all-or-nothing (see _salvageable): consumers
+        # like the per-stack parse, the recommendation verifier, and the
+        # cross-stack merge normalize partial output (dropping invalid records
+        # rather than losing the whole payload, or accepting a bare item
+        # array), so salvageable structures still reach them. Only output that
+        # is unusable in any shape falls through to the plain-text return.
+        # Callers that salvage wholesale downstream (the improve recon, whose
+        # top-level schema is all-or-nothing but which re-validates per-command
+        # records via validate_recon_commands) opt out with
+        # validate_fallback_schema=False; the downstream validator remains the
+        # fail-closed enforcement point for those call sites.
         if raw.strip():
             parsed = extract_json(raw)
             if parsed is not None and (
-                phase is DaydreamPhase.RECON
-                or _validates_schema(parsed, output_schema)
+                not validate_fallback_schema
+                or _salvageable(parsed, output_schema)
             ):
                 return parsed, result_continuation, aborted_reason
     return "".join(output_parts), result_continuation, aborted_reason

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -828,8 +828,15 @@ async def run_agent(
         # markdown code fences — common with GLM and other OpenAI-compat models).
         # The parsed result must also validate against the requested schema —
         # an unvalidated fallback would be asymmetric with the success path.
+        # RECON is the exception: its top-level schema is all-or-nothing but the
+        # orchestrator salvages per-command records downstream (validate_recon_commands),
+        # so an all-or-nothing gate here would preempt that salvage. The downstream
+        # validator remains the fail-closed enforcement point for RECON.
         if raw.strip():
             parsed = extract_json(raw)
-            if parsed is not None and _validates_schema(parsed, output_schema):
+            if parsed is not None and (
+                phase is DaydreamPhase.RECON
+                or _validates_schema(parsed, output_schema)
+            ):
                 return parsed, result_continuation, aborted_reason
     return "".join(output_parts), result_continuation, aborted_reason

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -17,6 +17,7 @@ from types import TracebackType
 from typing import TYPE_CHECKING, Any
 
 import anyio
+from jsonschema import Draft202012Validator
 from rich.console import Console
 
 if TYPE_CHECKING:
@@ -58,7 +59,6 @@ _logger = logging.getLogger(__name__)
 
 class MissingSkillError(Exception):
     """Raised when a required skill is not available."""
-
     def __init__(self, skill_name: str):
         self.skill_name = skill_name
         super().__init__(f"Skill '{skill_name}' is not available")
@@ -393,6 +393,11 @@ def _summarize_output(output: str) -> str:
     # Take first non-empty line or first 200 chars
     first_line = redacted.strip().split("\n")[0]
     return first_line[:200]
+
+
+def _validates_schema(value: Any, schema: dict[str, Any]) -> bool:
+    """Return whether ``value`` validates against ``schema`` (shape + required)."""
+    return not any(Draft202012Validator(schema).iter_errors(value))
 
 
 def _redact_log_value(value: Any) -> Any:
@@ -821,8 +826,10 @@ async def run_agent(
         # Fallback: extract JSON from the raw text when structured output
         # failed. Uses robust extraction (handles prose-wrapped JSON and
         # markdown code fences — common with GLM and other OpenAI-compat models).
+        # The parsed result must also validate against the requested schema —
+        # an unvalidated fallback would be asymmetric with the success path.
         if raw.strip():
             parsed = extract_json(raw)
-            if parsed is not None:
+            if parsed is not None and _validates_schema(parsed, output_schema):
                 return parsed, result_continuation, aborted_reason
     return "".join(output_parts), result_continuation, aborted_reason

--- a/daydream/improve/orchestrator.py
+++ b/daydream/improve/orchestrator.py
@@ -447,6 +447,7 @@ async def _step_recon(ctx: FlowContext) -> Stop | None:
             output_schema=RECON_SCHEMA,
             read_only=True,
             persist_session=False,
+            validate_fallback_schema=False,
         )
 
     total_candidates = 0

--- a/daydream/improve/orchestrator.py
+++ b/daydream/improve/orchestrator.py
@@ -87,6 +87,7 @@ from daydream.improve.repo_commands import enumerate_repository_commands
 from daydream.improve.services import Service, enumerate_services, filter_scope
 from daydream.pr_review import compute_fingerprint
 from daydream.prompts.grounding import UNTRUSTED_REPOSITORY_CONTENT_BOUNDARY
+from daydream.repository_paths import canonicalize_working_directory
 from daydream.trajectory import (
     DaydreamPhase,
     get_current_recorder,
@@ -315,13 +316,20 @@ def _host_enumerated_commands(
         )
         return 0, [], ["HOST_COMMAND_ENUMERATION_FAILED@/host_commands"]
     already_cited = {
-        (command["command"], command["working_directory"])
+        (
+            command["command"],
+            canonicalize_working_directory(repo, command["working_directory"]),
+        )
         for command in model_commands
     }
     candidates = [
         command
         for command in enumerated
-        if (command["command"], command["working_directory"]) not in already_cited
+        if (
+            command["command"],
+            canonicalize_working_directory(repo, command["working_directory"]),
+        )
+        not in already_cited
     ]
     validated, errors = validate_host_commands(candidates, repo=repo)
     return len(candidates), validated, errors

--- a/daydream/improve/orchestrator.py
+++ b/daydream/improve/orchestrator.py
@@ -315,21 +315,23 @@ def _host_enumerated_commands(
             f"{type(exc).__name__}: {exc}",
         )
         return 0, [], ["HOST_COMMAND_ENUMERATION_FAILED@/host_commands"]
-    already_cited = {
-        (
+    def _dedup_key(
+        command: dict[str, Any],
+    ) -> tuple[str, str]:
+        """Collapse a model command to the host-enumeration dedup key.
+
+        Both the already-cited set and the candidate filter must use the exact
+        same key (command + canonical working_directory) so an absolute-spelled
+        working_directory collapses against the relative host record.
+        """
+        return (
             command["command"],
             canonicalize_working_directory(repo, command["working_directory"]),
         )
-        for command in model_commands
-    }
+
+    already_cited = {_dedup_key(command) for command in model_commands}
     candidates = [
-        command
-        for command in enumerated
-        if (
-            command["command"],
-            canonicalize_working_directory(repo, command["working_directory"]),
-        )
-        not in already_cited
+        command for command in enumerated if _dedup_key(command) not in already_cited
     ]
     validated, errors = validate_host_commands(candidates, repo=repo)
     return len(candidates), validated, errors

--- a/daydream/repository_paths.py
+++ b/daydream/repository_paths.py
@@ -10,6 +10,7 @@ at package root keeps flow subpackages dependent on core, never the reverse.
 
 from __future__ import annotations
 
+import posixpath
 import re
 from collections.abc import Sequence
 from pathlib import Path, PurePosixPath
@@ -77,6 +78,22 @@ def _strip_prefix(
     return None
 
 
+def _repo_relative_parts(
+    parts: tuple[str, ...], repo: Path, root: Path
+) -> tuple[str, ...] | None:
+    """Return ``parts`` minus the repo prefix, trying unresolved then resolved.
+
+    ``root`` is ``repo.resolve()``; the second base strips absolute spellings
+    of a symlinked repo against its resolved spelling. None when neither base
+    prefixes ``parts``.
+    """
+    for base in (PurePosixPath(repo).parts, PurePosixPath(str(root)).parts):
+        remainder = _strip_prefix(parts, base)
+        if remainder is not None:
+            return remainder
+    return None
+
+
 def _walk_components(candidate: Path, parts: Sequence[str]) -> Path | None:
     """Return ``candidate`` advanced through ``parts``, or None on a crossing.
 
@@ -139,11 +156,7 @@ def path_is_confined(
             # are adjudicated by the containment check below; walk only the
             # components at or below the repo root, exactly like the relative
             # form does.
-            stripped = _strip_prefix(parts, PurePosixPath(repo).parts)
-            if stripped is None:
-                stripped = _strip_prefix(
-                    parts, PurePosixPath(str(root)).parts
-                )
+            stripped = _repo_relative_parts(parts, repo, root)
             if stripped is not None:
                 parts = stripped
         walked = _walk_components(candidate, parts)
@@ -173,13 +186,13 @@ def canonicalize_working_directory(repo: Path, value: str) -> str:
     """
     if value.startswith("/"):
         parts = PurePosixPath(value.rstrip("/")).parts
-        for base in (
-            PurePosixPath(repo).parts,
-            PurePosixPath(str(repo.resolve())).parts,
-        ):
-            remainder = _strip_prefix(parts, base)
-            if remainder is not None:
-                return "/".join(remainder) or "."
+        remainder = _repo_relative_parts(parts, repo, repo.resolve())
+        if remainder is not None:
+            # Parent-traversal segments name an in-repo directory for
+            # confinement-checked values (the walk resolves each ``..``
+            # against a real in-repo dir), so collapse them lexically to keep
+            # "sub/../sub" and "sub" on one dedup key.
+            return posixpath.normpath("/".join(remainder)) or "."
         # Not-under-repo absolute spellings are unreachable for
         # confinement-checked callers; return unchanged as a defensive identity.
         return value

--- a/daydream/repository_paths.py
+++ b/daydream/repository_paths.py
@@ -164,6 +164,28 @@ def canonicalize_directory_scope(value: str) -> str:
     return stripped
 
 
+def canonicalize_working_directory(repo: Path, value: str) -> str:
+    """Return ``value`` as the repo-relative posix form (``"."`` for the root).
+
+    Absolute, ``./``-prefixed, and plain relative spellings of the same
+    directory collapse to one repo-relative key. Accepted values are already
+    confinement-checked (``path_is_confined``), so the transform is lossless.
+    """
+    if value.startswith("/"):
+        parts = PurePosixPath(value.rstrip("/")).parts
+        for base in (
+            PurePosixPath(repo).parts,
+            PurePosixPath(str(repo.resolve())).parts,
+        ):
+            remainder = _strip_prefix(parts, base)
+            if remainder is not None:
+                return "/".join(remainder) or "."
+        # Not-under-repo absolute spellings are unreachable for
+        # confinement-checked callers; return unchanged as a defensive identity.
+        return value
+    return canonicalize_directory_scope(value)
+
+
 __all__ = [
     "DIRECTORY_SCOPE_PATTERN",
     "DIRECTORY_SCOPE_SCHEMA",
@@ -171,6 +193,7 @@ __all__ = [
     "REPOSITORY_FILE_PATH_SCHEMA",
     "REPOSITORY_FILE_PATH_SEGMENTS",
     "canonicalize_directory_scope",
+    "canonicalize_working_directory",
     "path_is_confined",
     "valid_directory_scope_lexical",
     "valid_repository_file_path",

--- a/docs/issue-649-should-have.md
+++ b/docs/issue-649-should-have.md
@@ -1,0 +1,3 @@
+# Issue #649 — Should-have audit note
+
+Should-have audit: grepped `daydream/improve/` for other `working_directory`-keyed dedup/lookup constructions; the only raw-spelling dedup site was `_host_enumerated_commands` (fixed in this PR). All other `working_directory` uses are schema/pass-through/render/host-emission and need no normalization.

--- a/tests/test_agent_structured_render.py
+++ b/tests/test_agent_structured_render.py
@@ -160,3 +160,39 @@ async def test_log_mode_structured_result_wins_over_prose_stray_json(monkeypatch
     )
     assert result == payload  # the captured dict, NOT the stray [] scraped from prose
     assert isinstance(result, dict)  # the exact type the merge phase gate requires
+
+
+async def test_structured_fallback_validates_against_output_schema(
+    monkeypatch, tmp_path
+) -> None:
+    """Must-haves #4/#5: with output_schema set and structured output failing,
+    (a) valid-schema JSON is returned as structured output, and (b) invalid-
+    schema JSON falls through to the plain-text return."""
+    rec = Console(file=StringIO(), record=True, force_terminal=True, width=100)
+    monkeypatch.setattr("daydream.agent.console", rec)
+    schema = {
+        "type": "object",
+        "required": ["file"],
+        "properties": {"file": {"type": "string"}},
+    }
+
+    # (a) valid-schema raw JSON -> returned as structured output
+    valid_backend = MockBackend([
+        TextEvent(text='{"file": "src/a.py"}'),
+        ResultEvent(structured_output=None, continuation=None),
+    ])
+    result, _, _ = await run_agent(
+        valid_backend, tmp_path, "go", phase=DaydreamPhase.REVIEW, output_schema=schema
+    )
+    assert result == {"file": "src/a.py"}
+
+    # (b) invalid-schema raw JSON (missing required "file") -> plain-text fallthrough
+    invalid_backend = MockBackend([
+        TextEvent(text='{"line": 3}'),
+        ResultEvent(structured_output=None, continuation=None),
+    ])
+    result2, _, _ = await run_agent(
+        invalid_backend, tmp_path, "go", phase=DaydreamPhase.REVIEW, output_schema=schema
+    )
+    assert result2 == '{"line": 3}'
+    assert isinstance(result2, str)

--- a/tests/test_agent_structured_render.py
+++ b/tests/test_agent_structured_render.py
@@ -201,13 +201,15 @@ async def test_structured_fallback_validates_against_output_schema(
 async def test_structured_fallback_recon_not_gated_all_or_nothing(
     monkeypatch, tmp_path
 ) -> None:
-    """RECON's fallback skips the all-or-nothing schema gate: the top-level
-    RECON schema requires languages/commands/conventions/intent_docs, but the
-    orchestrator salvages per-command records downstream via
+    """RECON's fallback skips the fallback schema gate via the caller-declared
+    ``validate_fallback_schema=False`` kwarg (not a phase carve-out): the
+    top-level RECON schema requires languages/commands/conventions/intent_docs,
+    but the orchestrator salvages per-command records downstream via
     validate_recon_commands() and defaults missing model fields to []. An
     extracted response with a valid commands list but a missing top-level field
     must still reach that salvage path instead of falling through to plain text.
-    Non-RECON phases keep the gate (see the REVIEW assertions above)."""
+    Callers that do not opt out keep the gate (see the REVIEW assertions
+    above)."""
     rec = Console(file=StringIO(), record=True, force_terminal=True, width=100)
     monkeypatch.setattr("daydream.agent.console", rec)
     schema = {
@@ -225,7 +227,80 @@ async def test_structured_fallback_recon_not_gated_all_or_nothing(
         ResultEvent(structured_output=None, continuation=None),
     ])
     result, _, _ = await run_agent(
-        backend, tmp_path, "go", phase=DaydreamPhase.RECON, output_schema=schema
+        backend, tmp_path, "go", phase=DaydreamPhase.RECON, output_schema=schema,
+        validate_fallback_schema=False,
     )
     assert result == {"commands": [{"command": "make test"}]}
     assert isinstance(result, dict)
+
+
+async def test_structured_fallback_salvages_partial_dict(
+    monkeypatch, tmp_path
+) -> None:
+    """The fallback gate is salvage-tolerant, not all-or-nothing: a dict whose
+    required top-level field is present but whose nested records contain one
+    schema-invalid item still reaches the consumer. The recommendation verifier
+    (and the per-stack parse) drop invalid records rather than losing the whole
+    payload, so an all-or-nothing gate here would starve every valid record."""
+    rec = Console(file=StringIO(), record=True, force_terminal=True, width=100)
+    monkeypatch.setattr("daydream.agent.console", rec)
+    schema = {
+        "type": "object",
+        "required": ["verdicts"],
+        "properties": {
+            "verdicts": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["issue_id", "verdict", "evidence"],
+                    "properties": {
+                        "issue_id": {"type": "integer"},
+                        "verdict": {"type": "string"},
+                        "evidence": {"type": "string"},
+                    },
+                },
+            }
+        },
+    }
+    partial = {
+        "verdicts": [
+            {"issue_id": 1, "verdict": "consistent", "evidence": "matches"},
+            {"issue_id": 2, "verdict": "bogus"},  # missing required "evidence"
+        ]
+    }
+    backend = MockBackend([
+        TextEvent(text=json.dumps(partial)),
+        ResultEvent(structured_output=None, continuation=None),
+    ])
+    result, _, _ = await run_agent(
+        backend, tmp_path, "go", phase=DaydreamPhase.VERIFY, output_schema=schema
+    )
+    assert result == partial  # the partial dict reaches the salvage path
+    assert isinstance(result, dict)
+
+
+async def test_structured_fallback_bare_array_reaches_merge_shape(
+    monkeypatch, tmp_path
+) -> None:
+    """A bare JSON array can never validate against an object-typed schema
+    (MERGED_ITEMS_SCHEMA is ``type: object``), but phase_cross_stack_merge
+    normalizes a bare array to its item list. The gate must let it through
+    instead of falling back to plain text, which would raise
+    CrossStackMergeError downstream and abort the run."""
+    rec = Console(file=StringIO(), record=True, force_terminal=True, width=100)
+    monkeypatch.setattr("daydream.agent.console", rec)
+    schema = {
+        "type": "object",
+        "required": ["items"],
+        "properties": {"items": {"type": "array", "items": {"type": "object"}}},
+    }
+    items = [{"id": 1, "description": "x"}]
+    backend = MockBackend([
+        TextEvent(text=json.dumps(items)),
+        ResultEvent(structured_output=None, continuation=None),
+    ])
+    result, _, _ = await run_agent(
+        backend, tmp_path, "merge", phase=DaydreamPhase.DEEP, output_schema=schema
+    )
+    assert result == items
+    assert isinstance(result, list)

--- a/tests/test_agent_structured_render.py
+++ b/tests/test_agent_structured_render.py
@@ -196,3 +196,36 @@ async def test_structured_fallback_validates_against_output_schema(
     )
     assert result2 == '{"line": 3}'
     assert isinstance(result2, str)
+
+
+async def test_structured_fallback_recon_not_gated_all_or_nothing(
+    monkeypatch, tmp_path
+) -> None:
+    """RECON's fallback skips the all-or-nothing schema gate: the top-level
+    RECON schema requires languages/commands/conventions/intent_docs, but the
+    orchestrator salvages per-command records downstream via
+    validate_recon_commands() and defaults missing model fields to []. An
+    extracted response with a valid commands list but a missing top-level field
+    must still reach that salvage path instead of falling through to plain text.
+    Non-RECON phases keep the gate (see the REVIEW assertions above)."""
+    rec = Console(file=StringIO(), record=True, force_terminal=True, width=100)
+    monkeypatch.setattr("daydream.agent.console", rec)
+    schema = {
+        "type": "object",
+        "required": ["languages", "commands", "conventions", "intent_docs"],
+        "properties": {
+            "languages": {"type": "array", "items": {"type": "string"}},
+            "commands": {"type": "array", "items": {"type": "object"}},
+            "conventions": {"type": "array", "items": {"type": "string"}},
+            "intent_docs": {"type": "array", "items": {"type": "string"}},
+        },
+    }
+    backend = MockBackend([
+        TextEvent(text='{"commands": [{"command": "make test"}]}'),
+        ResultEvent(structured_output=None, continuation=None),
+    ])
+    result, _, _ = await run_agent(
+        backend, tmp_path, "go", phase=DaydreamPhase.RECON, output_schema=schema
+    )
+    assert result == {"commands": [{"command": "make test"}]}
+    assert isinstance(result, dict)

--- a/tests/test_command_contract.py
+++ b/tests/test_command_contract.py
@@ -317,6 +317,25 @@ def test_canonicalize_working_directory_all_spellings_share_one_key(tmp_path: Pa
     assert spelled == {"sub"}
 
 
+def test_canonicalize_working_directory_resolved_repo_spelling(tmp_path: Path) -> None:
+    """The repo.resolve() fallback base: a symlinked repo strips a value
+    spelled with its RESOLVED path, which the literal prefix cannot match."""
+    real = tmp_path / "real"
+    real.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(real, target_is_directory=True)
+    # Literal spelling strips on the first (unresolved) base.
+    assert canonicalize_working_directory(link, f"{link}/sub") == "sub"
+    # Resolved spelling matches only the repo.resolve() base.
+    assert canonicalize_working_directory(link, f"{link.resolve()}/sub") == "sub"
+
+
+def test_canonicalize_working_directory_collapses_parent_traversal(tmp_path: Path) -> None:
+    """A ``..``-containing absolute spelling of an in-repo directory yields the
+    same key as its plain spelling (the issue #649 dedup miss)."""
+    assert canonicalize_working_directory(tmp_path, f"{tmp_path}/sub/../sub") == "sub"
+
+
 @pytest.mark.anyio
 async def test_host_enumeration_dedups_absolute_model_wd(
     improve_monorepo_target: Path,

--- a/tests/test_command_contract.py
+++ b/tests/test_command_contract.py
@@ -7,6 +7,7 @@ preserving the accept/reject grammar.
 
 from __future__ import annotations
 
+import json
 import re
 from collections.abc import Callable, Iterator
 from pathlib import Path
@@ -27,7 +28,7 @@ from daydream.improve.command_contract import (
 )
 from daydream.repository_paths import canonicalize_working_directory
 from daydream.runner import RunConfig, run
-from tests.harness.improve_backend import install_improve_stub
+from tests.harness.improve_backend import improve_artifact, install_improve_stub
 
 MakeConfig = Callable[..., RunConfig]
 
@@ -316,31 +317,84 @@ def test_canonicalize_working_directory_all_spellings_share_one_key(tmp_path: Pa
     assert spelled == {"sub"}
 
 
-def test_host_enumeration_dedups_absolute_model_wd(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+@pytest.mark.anyio
+async def test_host_enumeration_dedups_absolute_model_wd(
+    improve_monorepo_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
 ) -> None:
-    """Must-have #1: an absolute-spelled model working_directory collapses
-    against the relative host record, so the host command is NOT re-admitted."""
-    from daydream.improve import orchestrator as orch
-
-    host_record = {
-        "id": "make-check",
-        "command": "make check",
-        "working_directory": "sub",
-    }
+    """Must-have #1 at the entrypoint: an absolute-spelled model
+    working_directory collapses against the relative host record, so the
+    host command is NOT re-admitted into recon.json."""
     monkeypatch.setattr(
-        orch, "enumerate_repository_commands", lambda *a, **k: [host_record]
+        "daydream.improve.orchestrator.enumerate_repository_commands",
+        lambda repo, *, directories=(".",), reserved_ids=(): [
+            {
+                "id": "make-check",
+                "purpose": "Run the repository test suite",
+                "command": "uv run pytest",
+                "working_directory": "apps/billing",
+                "expected_success": {
+                    "exit_code": 0,
+                    "observable_result": "exit 0 and the tests pass",
+                },
+                "applicability": {
+                    "scope": {"kind": "in-scope-paths", "paths": ["apps/billing"]},
+                    "preconditions": [],
+                    "rationale": "The billing service declares the test command.",
+                },
+                "evidence": {
+                    "kind": "host-derived",
+                    "source_path": "apps/billing/pyproject.toml",
+                    "line_anchor": {"start_line": 1, "end_line": 1},
+                    "verbatim_excerpt": "[project]",
+                },
+            }
+        ],
     )
-    model = [{
-        "id": "m1",
-        "command": "make check",
-        "working_directory": f"{tmp_path}/sub",
-    }]
-    count, validated, _ = orch._host_enumerated_commands(
-        tmp_path, [], [], model_commands=model
+    stub = install_improve_stub(monkeypatch, improve_monorepo_target)
+    stub.recon_output_override = {
+        "languages": ["python"],
+        "commands": [
+            {
+                "id": "model-check",
+                "purpose": "Run the repository test suite",
+                "command": "uv run pytest",
+                # Absolute spelling of the SAME directory the host enumerates
+                # relative ("apps/billing").
+                "working_directory": f"{improve_monorepo_target}/apps/billing",
+                "expected_success": {
+                    "exit_code": 0,
+                    "observable_result": "exit 0 and the tests pass",
+                },
+                "applicability": {
+                    "scope": {"kind": "whole-repository"},
+                    "preconditions": [],
+                    "rationale": "The root configuration declares the test command.",
+                },
+                "evidence": {
+                    "kind": "literal-command",
+                    "source_path": "pyproject.toml",
+                    "line_anchor": {"start_line": 5, "end_line": 5},
+                    "verbatim_excerpt": None,
+                },
+            }
+        ],
+        "conventions": ["OpenAPI First"],
+        "intent_docs": ["README.md"],
+    }
+    stub.plan_gate_on_first_menu_id = True
+
+    code = await run(make_config(improve_monorepo_target, flow_name="improve"))
+
+    assert code == 0
+    recon = json.loads(
+        improve_artifact(improve_monorepo_target, "recon.json").read_text(encoding="utf-8")
     )
-    assert count == 0  # host command deduped against the absolute model wd
-    assert validated == []
+    # The host command was deduped against the absolute model wd: no
+    # re-admitted make-check record, no rejection noise.
+    assert [command["id"] for command in recon["commands"]] == ["model-check"]
+    assert recon["command_rejections"] == []
 
 
 def test_host_enumeration_does_not_dedup_different_directory(

--- a/tests/test_command_contract.py
+++ b/tests/test_command_contract.py
@@ -25,6 +25,7 @@ from daydream.improve.command_contract import (
     valid_repository_file_path,
     validate_applicability,
 )
+from daydream.repository_paths import canonicalize_working_directory
 from daydream.runner import RunConfig, run
 from tests.harness.improve_backend import install_improve_stub
 
@@ -290,6 +291,29 @@ def test_path_is_confined_allow_absolute_symlinked_ancestor(
     assert path_is_confined(repo, "improve")
     # The resolved spelling of the same path is confined too.
     assert path_is_confined(repo, (real / "repo" / "improve").as_posix(), allow_absolute=True)
+
+
+def test_canonicalize_working_directory_relative_and_dot(tmp_path: Path) -> None:
+    """Must-have #2: relative / ./ / trailing-slash / root spellings collapse."""
+    assert canonicalize_working_directory(tmp_path, ".") == "."
+    assert canonicalize_working_directory(tmp_path, "sub") == "sub"
+    assert canonicalize_working_directory(tmp_path, "./sub") == "sub"
+    assert canonicalize_working_directory(tmp_path, "sub/") == "sub"
+
+
+def test_canonicalize_working_directory_absolute_collapses_to_relative(tmp_path: Path) -> None:
+    """Must-have #1: an absolute in-repo spelling maps to its repo-relative form."""
+    assert canonicalize_working_directory(tmp_path, f"{tmp_path}/sub") == "sub"
+    assert canonicalize_working_directory(tmp_path, f"{tmp_path}") == "."
+
+
+def test_canonicalize_working_directory_all_spellings_share_one_key(tmp_path: Path) -> None:
+    """Discriminating: the SAME directory in every accepted spelling yields ONE key."""
+    spelled = {
+        canonicalize_working_directory(tmp_path, wd)
+        for wd in ("sub", "./sub", "sub/", f"{tmp_path}/sub")
+    }
+    assert spelled == {"sub"}
 
 
 def test_path_is_confined_allow_absolute_cannot_escape_via_ancestor_skip(

--- a/tests/test_command_contract.py
+++ b/tests/test_command_contract.py
@@ -316,6 +316,59 @@ def test_canonicalize_working_directory_all_spellings_share_one_key(tmp_path: Pa
     assert spelled == {"sub"}
 
 
+def test_host_enumeration_dedups_absolute_model_wd(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Must-have #1: an absolute-spelled model working_directory collapses
+    against the relative host record, so the host command is NOT re-admitted."""
+    from daydream.improve import orchestrator as orch
+
+    host_record = {
+        "id": "make-check",
+        "command": "make check",
+        "working_directory": "sub",
+    }
+    monkeypatch.setattr(
+        orch, "enumerate_repository_commands", lambda *a, **k: [host_record]
+    )
+    model = [{
+        "id": "m1",
+        "command": "make check",
+        "working_directory": f"{tmp_path}/sub",
+    }]
+    count, validated, _ = orch._host_enumerated_commands(
+        tmp_path, [], [], model_commands=model
+    )
+    assert count == 0  # host command deduped against the absolute model wd
+    assert validated == []
+
+
+def test_host_enumeration_does_not_dedup_different_directory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Discriminating: a genuinely different directory is NOT collapsed —
+    normalization must not widen dedup to 'same command anywhere'."""
+    from daydream.improve import orchestrator as orch
+
+    host_record = {
+        "id": "make-check",
+        "command": "make check",
+        "working_directory": "sub",
+    }
+    monkeypatch.setattr(
+        orch, "enumerate_repository_commands", lambda *a, **k: [host_record]
+    )
+    model = [{
+        "id": "m1",
+        "command": "make check",
+        "working_directory": f"{tmp_path}/other",
+    }]
+    count, _, _ = orch._host_enumerated_commands(
+        tmp_path, [], [], model_commands=model
+    )
+    assert count == 1  # different directory stays a separate candidate
+
+
 def test_path_is_confined_allow_absolute_cannot_escape_via_ancestor_skip(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
Closes #649

Consolidated hardening of daydream input handling, addressing the work in #594 and #598:
- **Host-command dedup**: canonicalize `working_directory` spellings (repo-relative + symlink + `..` collapse) and dedup host commands against canonical working directories, with the dedup-key logic extracted to a single helper.
- **Structured-output schema hardening**: schema-validate structured-output extraction fallbacks, let RECON bypass the all-or-nothing schema gate via a caller-declared `validate_fallback_schema` kwarg, and salvage partial structured output (partial dicts + bare arrays) so they reach downstream PARSE/verifier/merge normalization instead of falling through to plain text.

## Test Plan
- [x] `make check` (lockcheck + lint + typecheck + full pytest): 3589 passed, 6 skipped, 0 failures
- [x] Two sequential daydream deep-precision review rounds (each on a fresh VM) — all findings resolved; round-2 auto-fix `76168fb` cleared 10 findings (5 medium, 5 low)

## Review
Reviewed by two sequential daydream deep-precision passes (per EB merge workflow). No CodeRabbit.