### PR TITLE
[daydream] manifest records phase-agnostic general default backend + nullable review_backend (Closes #647)

### DIFF
--- a/daydream/archive/manifest.py
+++ b/daydream/archive/manifest.py
@@ -47,11 +47,16 @@ class Manifest:
         run_flow: Run flow type (normal, ttt, pr, deep).
         skill: Review skill used (python, react, etc.).
         model: Model name (opus, sonnet, haiku).
-        backend: Backend used (claude, codex, pi, osprey).
-        review_backend: Flow's representative backend, resolved through the full
-            precedence chain (``per_stack_review`` for deep-flow runs).
-        fix_backend: Backend used for the fix phase, when the flow runs it.
-        test_backend: Backend used for the test phase, when the flow runs it.
+        backend: Phase-agnostic general default backend (claude, codex) resolved
+            from config, never a per-phase override.
+        review_backend: Review-specific backend override marker, ``None`` when
+            review ran on the general default. NOT the effective review
+            backend: a CLI ``--backend`` masks a file-config review override,
+            so review may have run on ``backend`` even when this is set.
+        fix_backend: Effective backend for the fix phase (override or general
+            default).
+        test_backend: Effective backend for the test phase (override or general
+            default).
         review_only: Whether the run was review-only.
         deep: Whether deep review mode was used.
         source_path: Absolute path to the source repository at archive time.
@@ -281,10 +286,13 @@ def build_manifest(
     )
 
     # ``backend`` records the phase-agnostic general default (config.backend →
-    # file-config global → "claude"), never a per-phase override;
-    # ``review_backend`` is stamped only when a review-specific override exists.
-    backend_used = _default_backend_name(config)
-
+    # file-config global → "claude"), never a per-phase override.
+    # ``review_backend`` is an override marker, NOT an effective value: it is
+    # stamped only when a review-specific override exists, and it can differ
+    # from the backend review actually ran on (a CLI ``--backend`` masks a
+    # file-config review override). Sibling fields ``fix_backend``/
+    # ``test_backend`` are effective per-phase values; ``review_backend`` is
+    # not.
     m = Manifest(
         session_id=recorder.session_id,
         archived_at=datetime.now(timezone.utc).isoformat(),
@@ -292,7 +300,7 @@ def build_manifest(
         run_flow=recorder.run_flow.value,
         skill=config.skill,
         model=None,
-        backend=backend_used,
+        backend=_default_backend_name(config),
         review_backend=_resolved_review_backend_name(config),
         fix_backend=_resolved_backend_name(config, "fix"),
         test_backend=_resolved_backend_name(config, "test"),

--- a/daydream/archive/manifest.py
+++ b/daydream/archive/manifest.py
@@ -281,7 +281,7 @@ def build_manifest(
     # Deferred import breaks the module-level cycle: archive.manifest → runner → (lazy) archive.
     from daydream.runner import (  # noqa: PLC0415 - deferred import avoids cycle
         _default_backend_name,
-        _resolved_backend_name,
+        _recorder_backend_names,
         _resolved_review_backend_name,
     )
 
@@ -293,6 +293,7 @@ def build_manifest(
     # file-config review override). Sibling fields ``fix_backend``/
     # ``test_backend`` are effective per-phase values; ``review_backend`` is
     # not.
+    flow_names = _recorder_backend_names(config, recorder.run_flow)
     m = Manifest(
         session_id=recorder.session_id,
         archived_at=datetime.now(timezone.utc).isoformat(),
@@ -302,8 +303,8 @@ def build_manifest(
         model=None,
         backend=_default_backend_name(config),
         review_backend=_resolved_review_backend_name(config),
-        fix_backend=_resolved_backend_name(config, "fix"),
-        test_backend=_resolved_backend_name(config, "test"),
+        fix_backend=flow_names.fix or None,
+        test_backend=flow_names.test or None,
         review_only=config.output_mode == "review",
         deep=not config.shallow,
         fix_failures=fix_failures or None,

--- a/daydream/archive/manifest.py
+++ b/daydream/archive/manifest.py
@@ -274,13 +274,16 @@ def build_manifest(
     totals = recorder._final_totals  # noqa: SLF001 - intentional access to recorder internals
 
     # Deferred import breaks the module-level cycle: archive.manifest → runner → (lazy) archive.
-    from daydream.runner import _recorder_backend_names  # noqa: PLC0415 - deferred import avoids cycle
+    from daydream.runner import (  # noqa: PLC0415 - deferred import avoids cycle
+        _default_backend_name,
+        _resolved_backend_name,
+        _resolved_review_backend_name,
+    )
 
-    # Mirror the trajectory's backend identity through the same shared resolver
-    # used by runner._open_recorder (authoritative per-flow mapping prose lives
-    # in its docstring), so the manifest and trajectory never diverge on which
-    # backend produced the run.
-    names = _recorder_backend_names(config, recorder.run_flow)
+    # ``backend`` records the phase-agnostic general default (config.backend →
+    # file-config global → "claude"), never a per-phase override;
+    # ``review_backend`` is stamped only when a review-specific override exists.
+    backend_used = _default_backend_name(config)
 
     m = Manifest(
         session_id=recorder.session_id,
@@ -289,10 +292,10 @@ def build_manifest(
         run_flow=recorder.run_flow.value,
         skill=config.skill,
         model=None,
-        backend=names.backend,
-        review_backend=names.backend,
-        fix_backend=names.fix or None,
-        test_backend=names.test or None,
+        backend=backend_used,
+        review_backend=_resolved_review_backend_name(config),
+        fix_backend=_resolved_backend_name(config, "fix"),
+        test_backend=_resolved_backend_name(config, "test"),
         review_only=config.output_mode == "review",
         deep=not config.shallow,
         fix_failures=fix_failures or None,

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -3635,8 +3635,8 @@ async def _run_review_spine(config: RunConfig, work: WorkContext, mode: str) -> 
     from daydream.git_ops import GitError, GitTimeoutError
     from daydream.phases import _git_branch, _git_log
     from daydream.runner import (
+        _default_backend_name,
         _open_recorder,
-        _resolved_backend_name,
     )
 
     # Cache one Backend instance per (backend_name, resolved_model, resolved_effort)
@@ -3689,7 +3689,7 @@ async def _run_review_spine(config: RunConfig, work: WorkContext, mode: str) -> 
         console.print()
         print_info(console, f"Target directory: {target_dir}")
         print_info(console, f"Branch: {branch}")
-        print_info(console, f"Default backend: {_resolved_backend_name(config, 'review')}")
+        print_info(console, f"Default backend: {_default_backend_name(config)}")
         # Bot logins look like ``my-app[bot]``; escape so Rich doesn't eat the brackets.
         print_info(console, f"GitHub identity: {escape_markup(config.identity)}")
         console.print()

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -487,6 +487,22 @@ def _default_backend_name(config: RunConfig) -> str:
     return config.backend or file_config.backend or "claude"
 
 
+def _resolved_review_backend_name(config: RunConfig) -> str | None:
+    """Resolve the review-specific backend override, or ``None`` when unset.
+
+    Returns the override only when a review-specific source is configured
+    (CLI ``review_backend``, then file-config review phase); ``None`` when no
+    override exists — the archive must distinguish "review used the general
+    backend" from "review was explicitly overridden", so this is never coerced
+    to a fallback string. The file-config review phase is consulted directly
+    rather than through :func:`_resolved_backend_name` because a CLI global
+    ``config.backend`` outranks the file phase there and would mask a
+    configured override.
+    """
+    file_config = _file_config_or_empty(config)
+    return config.review_backend or file_config.phase_backend("review")
+
+
 def _resolved_model(config: RunConfig, phase: str) -> str | None:
     """Resolve the model for ``phase`` across all precedence tiers.
 

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -396,16 +396,18 @@ def _resolved_backend_name(config: RunConfig, phase: str) -> str:
     """Resolve the backend kind for ``phase`` across all precedence tiers.
 
     Order (highest first): explicit per-phase ``{phase}_backend``, global
-    ``config.backend`` (``--backend``), file-config phase override, file-config
-    global, then the terminal ``"claude"`` fallback.
+    ``config.backend`` (``--backend``), file-config phase override, then the
+    phase-agnostic terminal default (:func:`_default_backend_name`). Delegating
+    the final tier is exact: it is only reached when ``config.backend`` is
+    already falsy, at which point ``_default_backend_name`` collapses to the
+    same ``file_config.backend or "claude"`` fallback.
     """
     file_config = _file_config_or_empty(config)
     return (
         getattr(config, f"{phase}_backend", None)
         or config.backend
         or file_config.phase_backend(phase)
-        or file_config.backend
-        or "claude"
+        or _default_backend_name(config)
     )
 
 

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -473,6 +473,20 @@ def _recorder_backend_names(
     return RecorderBackendNames(backend=backend, fix=fix, test=test)
 
 
+def _default_backend_name(config: RunConfig) -> str:
+    """Resolve the phase-agnostic general default backend.
+
+    Order (highest first): global ``config.backend`` (``--backend``),
+    file-config global, then the terminal ``"claude"`` fallback. Deliberately
+    phase-agnostic: it must never consult any ``{phase}_backend`` attribute, so
+    a ``review_backend`` override can never surface here — the archive's
+    general ``backend`` field and the orchestrator's "Default backend" line
+    record the true general default, not a per-phase override.
+    """
+    file_config = _file_config_or_empty(config)
+    return config.backend or file_config.backend or "claude"
+
+
 def _resolved_model(config: RunConfig, phase: str) -> str | None:
     """Resolve the model for ``phase`` across all precedence tiers.
 

--- a/rl/daydream_review_v1/tests/fixtures/rundir-golden/manifest.json
+++ b/rl/daydream_review_v1/tests/fixtures/rundir-golden/manifest.json
@@ -9,7 +9,6 @@
     "skill": null,
     "model": null,
     "backend": "claude",
-    "review_backend": "claude",
     "fix_backend": "claude",
     "test_backend": "claude",
     "review_only": false,

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -66,7 +66,7 @@ class _MockRecorder:
 @dataclass
 class _MockConfig:
     skill: str | None = "python"
-    backend: str = "claude"
+    backend: str | None = None
     review_backend: str | None = None
     fix_backend: str | None = None
     test_backend: str | None = None
@@ -157,12 +157,13 @@ def _build(
     *,
     git_ctx: GitContext | None = None,
     recorder: _MockRecorder | None = None,
+    config: Any | None = None,
     **kw: Any,
 ) -> Manifest:
     """Build a manifest from the mock recorder/config pair."""
     return build_manifest(
         recorder=cast(TrajectoryRecorder, recorder or _MockRecorder()),
-        config=cast(RunConfig, _MockConfig()),
+        config=cast(RunConfig, _MockConfig() if config is None else config),
         git_ctx=git_ctx if git_ctx is not None else GitContext(),
         status="complete",
         archive_path=tmp_path,
@@ -188,6 +189,7 @@ def test_build_manifest_basic(tmp_path: Path):
     # Per-phase models replaced config.model; build_manifest stamps model as None.
     assert m.model is None
     assert m.backend == "claude"
+    assert m.review_backend is None
     assert m.total_cost_usd == 0.05
     assert m.total_prompt_tokens == 100
     assert m.total_completion_tokens == 50
@@ -1398,6 +1400,61 @@ def test_legacy_z_valid_at_rows_are_left_untouched(tmp_path: Path):
 
     hist = label_observation_history(tmp_path, "sess-legacy")
     assert [r["valid_at"] for r in hist] == ["2026-01-01T00:00:00Z"]
+
+
+def test_manifest_backend_is_general_default_not_review_override(tmp_path: Path) -> None:
+    """#647: backend records the general default even when review differs."""
+    m = _build(tmp_path, config=_MockConfig(backend="claude", review_backend="codex"))
+    assert m.backend == "claude"
+    assert m.review_backend == "codex"
+
+
+def test_manifest_review_backend_none_when_no_override(tmp_path: Path) -> None:
+    """#647: only a general backend -> review_backend stays None."""
+    m = _build(tmp_path, config=_MockConfig(backend="codex"))
+    assert m.backend == "codex"
+    assert m.review_backend is None
+
+
+def test_manifest_backend_falls_back_to_file_config_global(tmp_path: Path) -> None:
+    """#647: no CLI backend -> backend resolves from the file-config global."""
+    m = _build(
+        tmp_path,
+        config=_MockConfig(backend=None, file_config=DaydreamFileConfig(backend="file-backend")),
+    )
+    assert m.backend == "file-backend"
+    assert m.review_backend is None
+
+
+def test_manifest_review_backend_from_file_config_phase(tmp_path: Path) -> None:
+    """#647: a file-config review-phase override stamps review_backend only."""
+    m = _build(
+        tmp_path,
+        config=_MockConfig(backend="claude", file_config=DaydreamFileConfig(phases={"review": {"backend": "codex"}})),
+    )
+    assert m.backend == "claude"
+    assert m.review_backend == "codex"
+
+
+def test_archive_run_records_general_backend_and_override(tmp_path: Path, archive_dir: Path) -> None:
+    """#647: archive_run persists the general backend + nullable review override."""
+    session_id = "abcd1234-0000-0000-0000-000000000000"
+    config = _MockConfig(backend="claude", review_backend="codex")
+    target, _, _ = _setup_bundle(tmp_path, session_id)
+    recorder = _MockRecorder(session_id=session_id)
+    archive_run(
+        recorder=cast(TrajectoryRecorder, recorder),
+        target_dir=target,
+        config=cast(RunConfig, config),
+        status="complete",
+    )
+    manifest_data = json.loads((archive_dir / "runs" / session_id / "manifest.json").read_text())
+    assert manifest_data["run"]["backend"] == "claude"
+    assert manifest_data["run"]["review_backend"] == "codex"
+    rows = query_runs(archive_dir)
+    assert len(rows) == 1
+    assert rows[0]["backend"] == "claude"
+    assert rows[0]["review_backend"] == "codex"
 
 
 async def test_build_manifest_totals_include_fork_trajectories(tmp_path: Path):

--- a/tests/test_cli_config_precedence.py
+++ b/tests/test_cli_config_precedence.py
@@ -16,6 +16,7 @@ from daydream.backends.codex import CodexBackend
 from daydream.config_file import DaydreamFileConfig
 from daydream.runner import (
     RunConfig,
+    _default_backend_name,
     _resolve_backend,
     _resolved_backend_name,
     _resolved_model,
@@ -194,6 +195,24 @@ def test_pi_native_model_is_not_replaced_by_glm_fallback(tmp_path: Path) -> None
 
     cfg.model = "custom-model"
     assert _resolved_model(cfg, "review") == "custom-model"
+
+
+def test_default_backend_is_phase_agnostic(tmp_path: Path) -> None:
+    """#647: the general default backend ignores per-phase review overrides."""
+    empty = DaydreamFileConfig()
+    # A review override must never leak into the general default.
+    cfg = RunConfig(target=str(tmp_path), backend="claude", review_backend="codex", file_config=empty)
+    assert _default_backend_name(cfg) == "claude"
+    # Global CLI --backend is the source when set.
+    cfg.backend = "codex"
+    assert _default_backend_name(cfg) == "codex"
+    # File-config global when no CLI backend.
+    cfg.backend = None
+    cfg.file_config = DaydreamFileConfig(backend="file-backend")
+    assert _default_backend_name(cfg) == "file-backend"
+    # Terminal fallback with no config.
+    cfg.file_config = empty
+    assert _default_backend_name(cfg) == "claude"
 
 
 def test_trajectory_hub_repo_flag_reaches_runconfig(tmp_path: Path) -> None:

--- a/tests/test_cli_config_precedence.py
+++ b/tests/test_cli_config_precedence.py
@@ -21,6 +21,7 @@ from daydream.runner import (
     _resolved_backend_name,
     _resolved_model,
     _resolved_reasoning_effort,
+    _resolved_review_backend_name,
 )
 
 
@@ -213,6 +214,25 @@ def test_default_backend_is_phase_agnostic(tmp_path: Path) -> None:
     # Terminal fallback with no config.
     cfg.file_config = empty
     assert _default_backend_name(cfg) == "claude"
+
+
+def test_review_backend_override_is_none_when_unset(tmp_path: Path) -> None:
+    """#647: review_backend is None unless a review-specific override is set."""
+    empty = DaydreamFileConfig()
+    # No override anywhere -> None (not the general backend).
+    bare = RunConfig(target=str(tmp_path), backend="claude", review_backend=None, file_config=empty)
+    assert _resolved_review_backend_name(bare) is None
+    # CLI review_backend override.
+    cfg = RunConfig(target=str(tmp_path), backend="claude", review_backend="codex", file_config=empty)
+    assert _resolved_review_backend_name(cfg) == "codex"
+    # File-config review-phase override.
+    fc = DaydreamFileConfig(phases={"review": {"backend": "file-codex"}})
+    cfg2 = RunConfig(target=str(tmp_path), backend="claude", review_backend=None, file_config=fc)
+    assert _resolved_review_backend_name(cfg2) == "file-codex"
+    # File-config global only (no review override) -> still None.
+    fc_global = DaydreamFileConfig(backend="codex")
+    cfg3 = RunConfig(target=str(tmp_path), backend=None, review_backend=None, file_config=fc_global)
+    assert _resolved_review_backend_name(cfg3) is None
 
 
 def test_trajectory_hub_repo_flag_reaches_runconfig(tmp_path: Path) -> None:

--- a/tests/test_deep_integration.py
+++ b/tests/test_deep_integration.py
@@ -349,6 +349,32 @@ def test_existing_tests_still_collect() -> None:
         spec.loader.exec_module(module)
 
 
+async def test_deep_default_backend_line_is_phase_agnostic(multi_stack_target: Path, monkeypatch) -> None:
+    """#647: the 'Default backend' status line never shows a review override."""
+    from daydream.deep import orchestrator
+    from daydream.exploration import ExplorationContext
+    from daydream.runner import RunConfig, run
+
+    backend = _ClaudeShape(multi_stack_target)
+    _wire_mocks(monkeypatch, backend)
+    # Capture orchestrator print_info messages (override the _silence_ui noop).
+    captured: list[str] = []
+    monkeypatch.setattr(
+        "daydream.deep.orchestrator.print_info",
+        lambda *a, **kw: captured.append(str(a[1]) if len(a) > 1 else kw.get("msg", "")),
+    )
+    config = RunConfig(
+        target=str(multi_stack_target),
+        cleanup=False,
+        exploration_context=ExplorationContext(),
+        backend="claude",
+        review_backend="codex",
+    )
+    exit_code = await run(config)
+    assert exit_code == 0, f"run returned {exit_code} (expected 0)"
+    assert "Default backend: claude" in captured, captured
+
+
 async def test_structural_meta_stack_flows_end_to_end(
     multi_stack_target: Path, monkeypatch
 ) -> None:

--- a/tests/test_deep_integration.py
+++ b/tests/test_deep_integration.py
@@ -351,7 +351,6 @@ def test_existing_tests_still_collect() -> None:
 
 async def test_deep_default_backend_line_is_phase_agnostic(multi_stack_target: Path, monkeypatch) -> None:
     """#647: the 'Default backend' status line never shows a review override."""
-    from daydream.deep import orchestrator
     from daydream.exploration import ExplorationContext
     from daydream.runner import RunConfig, run
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1441,13 +1441,15 @@ def _build_manifest(config: RunConfig, flow: DaydreamRunFlow, tmp_path: Path) ->
     )
 
 
-def test_manifest_mirrors_recorder_backend_via_per_stack_review(tmp_path: Path) -> None:
-    """The manifest resolves the representative backend via ``per_stack_review``.
+def test_manifest_backend_is_general_default_not_per_stack_review(tmp_path: Path) -> None:
+    """#647: the manifest records the phase-agnostic general default backend.
 
-    ``build_manifest`` must resolve through the same shared resolver as the
-    recorder, so a deep-flow run with a file-config ``per_stack_review``
-    override is labeled with that backend even when CLI ``review_backend`` is
-    set — the ``review`` phase only powers feedback-mode commit-push.
+    The archive manifest must NOT resolve its general ``backend`` through a
+    per-phase key (e.g. ``per_stack_review``) — that mirrored the trajectory's
+    mislabeled review identity. ``backend`` stays the general default
+    (``config.backend`` → file-config global → ``"claude"``) even when a
+    per-phase review override is set, and ``review_backend`` records only the
+    review-specific override marker.
     """
     from daydream.config_file import DaydreamFileConfig
 
@@ -1458,8 +1460,8 @@ def test_manifest_mirrors_recorder_backend_via_per_stack_review(tmp_path: Path) 
         file_config=DaydreamFileConfig(phases={"per_stack_review": {"backend": "pi"}}),
     )
     m = _build_manifest(config, DaydreamRunFlow.NORMAL, tmp_path)
-    assert m.backend == "pi"
-    assert m.review_backend == "pi"
+    assert m.backend == "claude"
+    assert m.review_backend == "codex"
 
 
 def test_manifest_normal_records_fix_and_test_backend(tmp_path: Path) -> None:
@@ -1473,7 +1475,7 @@ def test_manifest_normal_records_fix_and_test_backend(tmp_path: Path) -> None:
     )
     m = _build_manifest(config, DaydreamRunFlow.NORMAL, tmp_path)
     assert m.backend == "codex"
-    assert m.review_backend == "codex"
+    assert m.review_backend is None
     assert m.fix_backend == "pi"
     assert m.test_backend == "osprey"
     run = m.to_dict()["run"]
@@ -1491,7 +1493,7 @@ def test_manifest_review_only_omits_fix_test_backend(tmp_path: Path) -> None:
     config = RunConfig(target=str(tmp_path / "project"), run_eval=False, backend="codex")
     m = _build_manifest(config, DaydreamRunFlow.TTT, tmp_path)
     assert m.backend == "codex"
-    assert m.review_backend == "codex"
+    assert m.review_backend is None
     assert m.fix_backend is None
     assert m.test_backend is None
     run = m.to_dict()["run"]
@@ -1504,7 +1506,7 @@ def test_manifest_improve_omits_fix_test_backend(tmp_path: Path) -> None:
     config = RunConfig(target=str(tmp_path / "project"), run_eval=False, backend="codex")
     m = _build_manifest(config, DaydreamRunFlow.IMPROVE, tmp_path)
     assert m.backend == "codex"
-    assert m.review_backend == "codex"
+    assert m.review_backend is None
     assert m.fix_backend is None
     assert m.test_backend is None
     run = m.to_dict()["run"]
@@ -1522,7 +1524,7 @@ def test_manifest_feedback_records_fix_omits_test_backend(tmp_path: Path) -> Non
         target=str(tmp_path / "project"), run_eval=False, review_backend="codex",
     )
     m = _build_manifest(config, DaydreamRunFlow.PR, tmp_path)
-    assert m.backend == "codex"
+    assert m.backend == "claude"
     assert m.review_backend == "codex"
     assert m.fix_backend == "claude"
     assert m.test_backend is None
@@ -1535,6 +1537,6 @@ def test_manifest_backend_falls_back_to_claude(tmp_path: Path) -> None:
     config = RunConfig(target=str(tmp_path / "project"), run_eval=False)
     m = _build_manifest(config, DaydreamRunFlow.NORMAL, tmp_path)
     assert m.backend == "claude"
-    assert m.review_backend == "claude"
+    assert m.review_backend is None
     assert m.fix_backend == "claude"
     assert m.test_backend == "claude"


### PR DESCRIPTION
## Summary

Closes #647 — the archive manifest was resolving its general `backend` through the `review` phase key, mirroring the trajectory's mislabeled review identity.

This PR corrects the manifest's backend identity semantics:

- **`backend`** now records the phase-agnostic **general default** (`config.backend` → file-config global → `"claude"`), never a per-phase override — so a `per_stack_review`/`review` override can no longer leak into the run's general backend label.
- **`review_backend`** is now a **nullable override marker**: stamped only when a review-specific override actually exists (`None` when review ran on the general default). It is deliberately *not* the effective review backend (a CLI `--backend` masks a file-config review override).

Along the way the runner gained two focused resolvers, `_default_backend_name` (phase-agnostic) and `_resolved_review_backend_name` (nullable override), and `_resolved_backend_name` now delegates its terminal fallback to `_default_backend_name`.

Rebased onto current `main` and reconciled with #643 (PR #671): #647's general-default/nullable semantics are kept, and #643's orthogonal fix/test flow-gating is preserved via `_recorder_backend_names` (flows that never run fix/test still omit those keys).

## Verification

- `make check` green: **3618 passed, 6 skipped, 3 warnings** (ruff + mypy clean)
- Daydream deep-precision review round 2 (fresh VM) passed; trajectory uploaded to HF.

Closes #647
