### PR TITLE
[daydream] Persist per-stack review identity in archive index (Closes #646)

### DIFF
--- a/daydream/archive/__init__.py
+++ b/daydream/archive/__init__.py
@@ -165,6 +165,7 @@ def _archive_run_inner(
         archive_path=run_dir,
         evaluation=evaluation,
         source_path=source_path,
+        cwd=str(work.repo) if work is not None else None,
         fix_failures=fix_failures,
         fix_leftover_untracked=fix_leftover_untracked,
         fix_quality_gate=fix_quality_gate,

--- a/daydream/archive/_schema.py
+++ b/daydream/archive/_schema.py
@@ -42,6 +42,8 @@ CREATE TABLE IF NOT EXISTS runs (
     review_backend TEXT,
     fix_backend TEXT,
     test_backend TEXT,
+    per_stack_review_backend TEXT,
+    per_stack_review_model TEXT,
     review_only INTEGER NOT NULL DEFAULT 0,
     deep INTEGER NOT NULL DEFAULT 0,
     remote_url TEXT,
@@ -124,7 +126,7 @@ _CREATE_INDEXES = [
 _UPSERT_SQL = """
 INSERT OR REPLACE INTO runs (
     session_id, archived_at, status, run_flow, skill, model, backend,
-    review_backend, fix_backend, test_backend,
+    review_backend, fix_backend, test_backend, per_stack_review_backend, per_stack_review_model,
     review_only, deep, remote_url, repo_slug, source_path, branch, base_branch,
     head_sha, base_sha, changed_files, pr_number, pr_repo, total_cost_usd, total_findings,
     grounding_rate, coverage_ratio, cost_per_finding_usd, wall_clock_seconds,
@@ -133,7 +135,7 @@ INSERT OR REPLACE INTO runs (
     outcome_labels, labeled_at, composite_reward, archive_path, schema_version
 ) VALUES (
     :session_id, :archived_at, :status, :run_flow, :skill, :model, :backend,
-    :review_backend, :fix_backend, :test_backend,
+    :review_backend, :fix_backend, :test_backend, :per_stack_review_backend, :per_stack_review_model,
     :review_only, :deep, :remote_url, :repo_slug, :source_path, :branch, :base_branch,
     :head_sha, :base_sha, :changed_files, :pr_number, :pr_repo, :total_cost_usd, :total_findings,
     :grounding_rate, :coverage_ratio, :cost_per_finding_usd, :wall_clock_seconds,
@@ -175,6 +177,8 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
             ("review_backend", "TEXT"),
             ("fix_backend", "TEXT"),
             ("test_backend", "TEXT"),
+            ("per_stack_review_backend", "TEXT"),
+            ("per_stack_review_model", "TEXT"),
             ("rubric_json", "TEXT"),
             ("base_sha", "TEXT"),
             ("changed_files", "TEXT"),

--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -207,6 +207,8 @@ def upsert_run(archive_dir: Path, manifest: Manifest) -> None:
                 "review_backend": manifest.review_backend,
                 "fix_backend": manifest.fix_backend,
                 "test_backend": manifest.test_backend,
+                "per_stack_review_backend": manifest.per_stack_review_backend,
+                "per_stack_review_model": manifest.per_stack_review_model,
                 "review_only": int(manifest.review_only),
                 "deep": int(manifest.deep),
                 "remote_url": manifest.remote_url,

--- a/daydream/archive/manifest.py
+++ b/daydream/archive/manifest.py
@@ -18,6 +18,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 from daydream.archive.git_context import GitContext
+from daydream.config import DEFAULT_PI_MODEL
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -26,6 +27,16 @@ if TYPE_CHECKING:
     from daydream.trajectory import TrajectoryRecorder
 
 MANIFEST_SCHEMA_VERSION = "1.0"
+
+
+def _omit_falsy(**fields: Any) -> dict[str, Any]:
+    """Return only the fields whose values are truthy.
+
+    Collapses the repeated ``**({k: v} if v else {})`` conditional-splat guard
+    used for optional manifest fields: ``None`` (and any other falsy value)
+    drops the key entirely, mirroring the old inline pattern exactly.
+    """
+    return {k: v for k, v in fields.items() if v}
 
 
 @dataclass
@@ -51,18 +62,27 @@ class Manifest:
         review_backend: Per-phase backend override for review, if set.
         fix_backend: Per-phase backend override for fix, if set.
         test_backend: Per-phase backend override for test, if set.
-        per_stack_review_backend: Per-stack review tier backend for deep runs
-            (issue #646), resolved from the ``per_stack_review`` phase key —
-            the key that actually drives per-stack execution — kept distinct
-            from ``review_backend`` so "who reviewed" is never a misstatement.
-            ``None`` (and omitted from ``to_dict()``) for shallow/non-deep runs,
-            which have no per-stack fan-out.
-        per_stack_review_model: Per-stack review tier model for deep runs
-            (issue #646), resolved from the ``per_stack_review`` phase key. The
-            model is the load-bearing part of the identity: per-stack defaults
-            to Sonnet vs the ``review`` tier's Opus, which a pure backend name
-            cannot distinguish. ``None`` (and omitted from ``to_dict()``) for
-            shallow/non-deep runs.
+        per_stack_review_backend: Per-stack review tier backend for runs that
+            execute per-stack reviews (issue #646), resolved from the
+            ``per_stack_review`` phase key — the key that actually drives
+            per-stack execution — kept distinct from ``review_backend`` so
+            "who reviewed" is never a misstatement. Every deep-flow mode
+            executes per-stack reviews — loop, shallow (single collapsed
+            stack), review, and comment; only feedback mode (the review spine
+            is skipped entirely) and improve/custom flows (which never invoke
+            the deep orchestrator) have no per-stack fan-out and leave this
+            ``None`` (omitted from ``to_dict()``).
+        per_stack_review_model: Per-stack review tier model for runs that
+            execute per-stack reviews (issue #646), resolved from the
+            ``per_stack_review`` phase key. The model is the load-bearing part
+            of the identity: per-stack defaults to Sonnet vs the ``review``
+            tier's Opus, which a pure backend name cannot distinguish. ``None``
+            (and omitted from ``to_dict()``) only for runs that never execute
+            per-stack reviews (feedback / improve / custom flows). For a Pi run
+            with no explicit override the backend default (``DEFAULT_PI_MODEL``)
+            is recorded: Pi's default intentionally lives outside
+            ``PHASE_DEFAULT_MODELS``, so ``_resolved_model`` alone would leave
+            the load-bearing model NULL.
         review_only: Whether the run was review-only.
         deep: Whether deep review mode was used.
         source_path: Absolute path to the source repository at archive time.
@@ -199,13 +219,13 @@ class Manifest:
                 "skill": self.skill,
                 "model": self.model,
                 "backend": self.backend,
-                **({"review_backend": self.review_backend} if self.review_backend else {}),
-                **({"fix_backend": self.fix_backend} if self.fix_backend else {}),
-                **({"test_backend": self.test_backend} if self.test_backend else {}),
-                **({"per_stack_review_backend": self.per_stack_review_backend}
-                  if self.per_stack_review_backend else {}),
-                **({"per_stack_review_model": self.per_stack_review_model}
-                  if self.per_stack_review_model else {}),
+                **_omit_falsy(
+                    review_backend=self.review_backend,
+                    fix_backend=self.fix_backend,
+                    test_backend=self.test_backend,
+                    per_stack_review_backend=self.per_stack_review_backend,
+                    per_stack_review_model=self.per_stack_review_model,
+                ),
                 "review_only": self.review_only,
                 "deep": self.deep,
             },
@@ -299,14 +319,29 @@ def build_manifest(
     backend_used = _resolved_backend_name(config, "review")
 
     # Per-stack reviewers (issue #646) execute on the "per_stack_review" phase key —
-    # NOT the "review" tier — so a deep archive records that tier's resolved backend
-    # and model from its own key. Per-stack fan-out does not exist outside deep mode,
-    # so shallow/non-deep runs leave both fields None (and to_dict() omits them).
+    # NOT the "review" tier — so archives record that tier's resolved backend and
+    # model from its own key. The per-stack-reviews step runs in every deep-flow
+    # mode (loop, shallow, review, comment); shallow is NOT excluded — a collapsed
+    # single stack is still reviewed through phase_per_stack_reviews. Only feedback
+    # mode (config.bot set — the review spine is skipped entirely) and improve/custom
+    # flows (which never invoke the deep orchestrator) have no per-stack fan-out, so
+    # those runs leave both fields None (and to_dict() omits them).
+    per_stack_reviews_ran = (
+        config.bot is None
+        and (config.flow_name is None or config.flow_name in ("review", "shallow", "deep"))
+    )
     per_stack_review_backend: str | None = None
     per_stack_review_model: str | None = None
-    if not config.shallow:
+    if per_stack_reviews_ran:
         per_stack_review_backend = _resolved_backend_name(config, "per_stack_review")
         per_stack_review_model = _resolved_model(config, "per_stack_review")
+        if per_stack_review_model is None and per_stack_review_backend == "pi":
+            # Pi's default is a backend fallback (resolved by PiBackend from cwd)
+            # that intentionally never appears in PHASE_DEFAULT_MODELS, so
+            # _resolved_model returns None here even though the per-stack reviewers
+            # ran on a concrete model. Surface the backend default instead of
+            # dropping the load-bearing half of the identity.
+            per_stack_review_model = DEFAULT_PI_MODEL
 
     m = Manifest(
         session_id=recorder.session_id,

--- a/daydream/archive/manifest.py
+++ b/daydream/archive/manifest.py
@@ -283,6 +283,7 @@ def build_manifest(
     archive_path: Path,
     evaluation: dict[str, Any] | None = None,
     source_path: str | None = None,
+    cwd: str | None = None,
     fix_failures: dict[str, str] | None = None,
     fix_leftover_untracked: list[str] | None = None,
     fix_quality_gate: dict[str, Any] | None = None,
@@ -297,6 +298,8 @@ def build_manifest(
         archive_path: Absolute path to the archive directory for this run.
         evaluation: Optional ``analyze_session()`` result dict.
         source_path: Absolute path to the source repository at archive time.
+        cwd: The repository directory daydream operated on (``work.repo``), used
+            to mirror PiBackend's cwd-configured default model resolution.
         fix_failures: Map of dropped fix file-group -> reason, or ``None`` when
             every fix applied. Recorded verbatim on the manifest.
         fix_leftover_untracked: Sorted list of untracked paths left behind by a
@@ -311,7 +314,11 @@ def build_manifest(
     totals = recorder._final_totals  # noqa: SLF001 - intentional access to recorder internals
 
     # Deferred import breaks the module-level cycle: archive.manifest → runner → (lazy) archive.
-    from daydream.runner import _resolved_backend_name, _resolved_model  # noqa: PLC0415 - deferred import avoids cycle
+    from daydream.runner import (  # noqa: PLC0415 - deferred import avoids cycle
+        _DEEP_FLOW_ALIASES,
+        _resolved_backend_name,
+        _resolved_model,
+    )
 
     # Resolve the effective backend through the full precedence chain so the manifest
     # records what was actually used (raw config.backend is None when set via file-config);
@@ -325,10 +332,16 @@ def build_manifest(
     # single stack is still reviewed through phase_per_stack_reviews. Only feedback
     # mode (config.bot set — the review spine is skipped entirely) and improve/custom
     # flows (which never invoke the deep orchestrator) have no per-stack fan-out, so
-    # those runs leave both fields None (and to_dict() omits them).
+    # those runs leave both fields None (and to_dict() omits them). The deep-flow
+    # alias set is runner._DEEP_FLOW_ALIASES — the same list _dispatch_selected_flow
+    # routes — so the gate cannot drift from the actual flow routing.
+    # start_at defaults to "review" on the real RunConfig; getattr keeps the
+    # gate robust to lighter config fakes that omit the field.
+    _start_at = getattr(config, "start_at", "review")
     per_stack_reviews_ran = (
         config.bot is None
-        and (config.flow_name is None or config.flow_name in ("review", "shallow", "deep"))
+        and (config.flow_name is None or config.flow_name in _DEEP_FLOW_ALIASES)
+        and _start_at not in ("merge", "fix")
     )
     per_stack_review_backend: str | None = None
     per_stack_review_model: str | None = None
@@ -339,9 +352,15 @@ def build_manifest(
             # Pi's default is a backend fallback (resolved by PiBackend from cwd)
             # that intentionally never appears in PHASE_DEFAULT_MODELS, so
             # _resolved_model returns None here even though the per-stack reviewers
-            # ran on a concrete model. Surface the backend default instead of
-            # dropping the load-bearing half of the identity.
-            per_stack_review_model = DEFAULT_PI_MODEL
+            # ran on a concrete model. Mirror PiBackend's own precedence — a
+            # cwd-configured default first, then DEFAULT_PI_MODEL — so the archived
+            # identity matches what actually ran (#646 finding 1).
+            from pathlib import Path
+
+            from daydream.backends.pi import _configured_pi_model
+            per_stack_review_model = (
+                _configured_pi_model(Path(cwd)) if cwd else None
+            ) or DEFAULT_PI_MODEL
 
     m = Manifest(
         session_id=recorder.session_id,

--- a/daydream/archive/manifest.py
+++ b/daydream/archive/manifest.py
@@ -51,6 +51,18 @@ class Manifest:
         review_backend: Per-phase backend override for review, if set.
         fix_backend: Per-phase backend override for fix, if set.
         test_backend: Per-phase backend override for test, if set.
+        per_stack_review_backend: Per-stack review tier backend for deep runs
+            (issue #646), resolved from the ``per_stack_review`` phase key —
+            the key that actually drives per-stack execution — kept distinct
+            from ``review_backend`` so "who reviewed" is never a misstatement.
+            ``None`` (and omitted from ``to_dict()``) for shallow/non-deep runs,
+            which have no per-stack fan-out.
+        per_stack_review_model: Per-stack review tier model for deep runs
+            (issue #646), resolved from the ``per_stack_review`` phase key. The
+            model is the load-bearing part of the identity: per-stack defaults
+            to Sonnet vs the ``review`` tier's Opus, which a pure backend name
+            cannot distinguish. ``None`` (and omitted from ``to_dict()``) for
+            shallow/non-deep runs.
         review_only: Whether the run was review-only.
         deep: Whether deep review mode was used.
         source_path: Absolute path to the source repository at archive time.
@@ -126,6 +138,8 @@ class Manifest:
     review_backend: str | None = None
     fix_backend: str | None = None
     test_backend: str | None = None
+    per_stack_review_backend: str | None = None
+    per_stack_review_model: str | None = None
     review_only: bool = False
     deep: bool = False
     fix_failures: dict[str, str] | None = None
@@ -188,6 +202,10 @@ class Manifest:
                 **({"review_backend": self.review_backend} if self.review_backend else {}),
                 **({"fix_backend": self.fix_backend} if self.fix_backend else {}),
                 **({"test_backend": self.test_backend} if self.test_backend else {}),
+                **({"per_stack_review_backend": self.per_stack_review_backend}
+                  if self.per_stack_review_backend else {}),
+                **({"per_stack_review_model": self.per_stack_review_model}
+                  if self.per_stack_review_model else {}),
                 "review_only": self.review_only,
                 "deep": self.deep,
             },
@@ -273,12 +291,22 @@ def build_manifest(
     totals = recorder._final_totals  # noqa: SLF001 - intentional access to recorder internals
 
     # Deferred import breaks the module-level cycle: archive.manifest → runner → (lazy) archive.
-    from daydream.runner import _resolved_backend_name  # noqa: PLC0415 - deferred import avoids cycle
+    from daydream.runner import _resolved_backend_name, _resolved_model  # noqa: PLC0415 - deferred import avoids cycle
 
     # Resolve the effective backend through the full precedence chain so the manifest
     # records what was actually used (raw config.backend is None when set via file-config);
     # "review" is the representative phase the orchestrator also prints as the default.
     backend_used = _resolved_backend_name(config, "review")
+
+    # Per-stack reviewers (issue #646) execute on the "per_stack_review" phase key —
+    # NOT the "review" tier — so a deep archive records that tier's resolved backend
+    # and model from its own key. Per-stack fan-out does not exist outside deep mode,
+    # so shallow/non-deep runs leave both fields None (and to_dict() omits them).
+    per_stack_review_backend: str | None = None
+    per_stack_review_model: str | None = None
+    if not config.shallow:
+        per_stack_review_backend = _resolved_backend_name(config, "per_stack_review")
+        per_stack_review_model = _resolved_model(config, "per_stack_review")
 
     m = Manifest(
         session_id=recorder.session_id,
@@ -291,6 +319,8 @@ def build_manifest(
         review_backend=backend_used,
         fix_backend=_resolved_backend_name(config, "fix"),
         test_backend=_resolved_backend_name(config, "test"),
+        per_stack_review_backend=per_stack_review_backend,
+        per_stack_review_model=per_stack_review_model,
         review_only=config.output_mode == "review",
         deep=not config.shallow,
         fix_failures=fix_failures or None,

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -773,6 +773,12 @@ def _require_reviewable_branch(work: WorkContext, config: RunConfig) -> None:
         )
 
 
+# Built-in deep-flow mode aliases (review / shallow / deep all route to the
+# single deep flow in different modes, #330). Kept as a module constant so
+# downstream consumers (e.g. archive manifest tier gate) share the same list.
+_DEEP_FLOW_ALIASES = ("review", "shallow", "deep")
+
+
 async def _dispatch_selected_flow(work: WorkContext, config: RunConfig) -> int:
     """Route an explicit ``--flow <name>`` selection.
 
@@ -789,7 +795,7 @@ async def _dispatch_selected_flow(work: WorkContext, config: RunConfig) -> int:
 
     # Built-in mode aliases: resolve before the registry lookup so the deep
     # routing wins over the "not registered" error.
-    if name in ("review", "shallow", "deep"):
+    if name in _DEEP_FLOW_ALIASES:
         if name in ("shallow", "deep"):
             _require_reviewable_branch(work, config)
         return await _run_loop_deep(work, config)

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -202,11 +202,11 @@ def test_build_manifest_basic(tmp_path: Path):
 @pytest.mark.parametrize(
     ("flow_name", "shallow"),
     [
-        (None, False),      # default deep loop
-        (None, True),       # --shallow single-stack
-        ("deep", False),   # --flow deep
-        ("shallow", False),  # --flow shallow
-        ("review", False),   # --flow review
+        pytest.param(None, False, id="default-deep-loop"),
+        pytest.param(None, True, id="shallow-single-stack"),
+        pytest.param("deep", False, id="flow-deep"),
+        pytest.param("shallow", False, id="flow-shallow"),
+        pytest.param("review", False, id="flow-review"),
     ],
 )
 def test_build_manifest_per_stack_review_tier(
@@ -237,6 +237,26 @@ def test_build_manifest_per_stack_review_tier(
     assert run["per_stack_review_backend"] == "codex"
     assert run["per_stack_review_model"] == "gpt-psr"
     assert run["review_backend"] == "claude"
+
+
+def test_build_manifest_per_stack_review_gate_tracks_runner_aliases(tmp_path: Path) -> None:
+    """Issue #646 finding 3: the per-stack gate derives from the same alias list
+    ``runner._dispatch_selected_flow`` routes (no third inline copy), so adding
+    or renaming a deep-flow alias surfaces here instead of silently misstating
+    "who reviewed" in archived runs."""
+    from daydream.runner import _DEEP_FLOW_ALIASES
+
+    assert _DEEP_FLOW_ALIASES  # non-empty; every alias must record the identity
+    for flow_name in _DEEP_FLOW_ALIASES:
+        m = build_manifest(
+            recorder=cast(TrajectoryRecorder, _MockRecorder()),
+            config=RunConfig(target=str(tmp_path), backend=None, model=None, flow_name=flow_name),
+            git_ctx=GitContext(),
+            status="complete", archive_path=tmp_path,
+        )
+        assert m.per_stack_review_backend is not None
+        assert m.per_stack_review_model is not None
+        assert "per_stack_review_backend" in m.to_dict()["run"]
 
 
 def test_build_manifest_omits_per_stack_review_without_spine(tmp_path: Path) -> None:
@@ -1570,3 +1590,68 @@ async def test_build_manifest_totals_include_fork_trajectories(tmp_path: Path):
     assert m.total_completion_tokens == 75
     assert m.total_cached_tokens == 25
     assert m.total_cost_usd == pytest.approx(0.25)
+
+
+def test_build_manifest_pi_records_cwd_configured_default_model(tmp_path: Path) -> None:
+    """Issue #646 finding 1: a Pi deep run with no explicit override records the
+    model PiBackend actually resolved — the cwd-configured default from
+    ``<repo>/.pi/settings.json``, not DEFAULT_PI_MODEL — so the archived
+    'who reviewed' identity matches what ran."""
+    from daydream.backends.pi import _configured_pi_model
+    from daydream.config import DEFAULT_PI_MODEL
+
+    # Configure a Pi default in the repo cwd (the same seam PiBackend reads).
+    pi_dir = tmp_path / ".pi"
+    pi_dir.mkdir()
+    (pi_dir / "settings.json").write_text(
+        json.dumps({"defaultModel": "gpt-psr-configured"}), encoding="utf-8"
+    )
+    assert _configured_pi_model(tmp_path) == "gpt-psr-configured"
+
+    m = build_manifest(
+        recorder=cast(TrajectoryRecorder, _MockRecorder()),
+        config=RunConfig(target=str(tmp_path), backend="pi", model=None),
+        git_ctx=GitContext(),
+        status="complete", archive_path=tmp_path,
+        cwd=str(tmp_path),
+    )
+    assert m.per_stack_review_backend == "pi"
+    assert m.per_stack_review_model == "gpt-psr-configured"
+    assert m.per_stack_review_model != DEFAULT_PI_MODEL
+    assert m.to_dict()["run"]["per_stack_review_model"] == "gpt-psr-configured"
+
+
+def test_build_manifest_pi_falls_back_to_default_when_no_cwd_config(tmp_path: Path) -> None:
+    """Issue #646 finding 1: with no cwd-configured Pi default (and no cwd passed),
+    the manifest records DEFAULT_PI_MODEL as before — the fallback path is intact."""
+    from daydream.config import DEFAULT_PI_MODEL
+
+    m = build_manifest(
+        recorder=cast(TrajectoryRecorder, _MockRecorder()),
+        config=RunConfig(target=str(tmp_path), backend="pi", model=None),
+        git_ctx=GitContext(),
+        status="complete", archive_path=tmp_path,
+    )
+    assert m.per_stack_review_backend == "pi"
+    assert m.per_stack_review_model == DEFAULT_PI_MODEL
+
+
+def test_build_manifest_omits_per_stack_review_on_merge_fix_resume(tmp_path: Path) -> None:
+    """Issue #646 finding 2: a --start-at merge/fix resume skips
+    phase_per_stack_reviews (orchestrator.py:1132), so the manifest must not
+    attribute the resume config's per-stack tier to the prior run's artifacts."""
+    for start_at in ("merge", "fix"):
+        config = RunConfig(
+            target=str(tmp_path), backend=None, model=None,
+            flow_name="deep", start_at=start_at,
+        )
+        m = build_manifest(
+            recorder=cast(TrajectoryRecorder, _MockRecorder()),
+            config=config, git_ctx=GitContext(),
+            status="complete", archive_path=tmp_path,
+        )
+        run = m.to_dict()["run"]
+        assert m.per_stack_review_backend is None, f"start_at={start_at}"
+        assert m.per_stack_review_model is None, f"start_at={start_at}"
+        assert "per_stack_review_backend" not in run, f"start_at={start_at}"
+        assert "per_stack_review_model" not in run, f"start_at={start_at}"

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -479,6 +479,50 @@ def test_runs_erosion_verbosity_columns_migrate_existing_db(tmp_path: Path):
     assert row["verbosity"] == pytest.approx(0.08)
 
 
+def test_upsert_run_persists_per_stack_review_identity(tmp_path: Path) -> None:
+    """Issue #646: per-stack review identity round-trips through the index."""
+    m = make_manifest(
+        session_id="s-psr",
+        per_stack_review_backend="codex",
+        per_stack_review_model="gpt-psr",
+        review_backend="claude",
+    )
+    upsert_run(tmp_path, m)
+    row = query_runs(tmp_path, where="session_id = ?", params=("s-psr",))[0]
+    assert row["per_stack_review_backend"] == "codex"
+    assert row["per_stack_review_model"] == "gpt-psr"
+    assert row["review_backend"] == "claude"
+
+
+def test_runs_per_stack_review_columns_migrate_existing_db(tmp_path: Path) -> None:
+    """A legacy index.db gains per_stack_review_* via ALTER-ADD, rows preserved."""
+    from daydream.archive.index import _CREATE_TABLE
+
+    legacy_ddl = _CREATE_TABLE.replace(
+        "    per_stack_review_backend TEXT,\n    per_stack_review_model TEXT,\n", ""
+    )
+    assert "per_stack_review_backend" not in legacy_ddl
+    conn = sqlite3.connect(str(tmp_path / "index.db"))
+    conn.execute(legacy_ddl)
+    conn.execute(
+        "INSERT INTO runs (session_id, archived_at, run_flow, archive_path) VALUES (?, ?, ?, ?)",
+        ("legacy-psr", "2026-01-01T00:00:00Z", "normal", str(tmp_path / "legacy-psr")),
+    )
+    conn.commit()
+    conn.close()
+
+    upsert_run(
+        tmp_path,
+        make_manifest(session_id="s-psr-mig", per_stack_review_backend="codex",
+                      per_stack_review_model="gpt-psr"),
+    )
+    legacy = query_runs(tmp_path, where="session_id = ?", params=("legacy-psr",))[0]
+    assert legacy["per_stack_review_backend"] is None   # pre-existing row preserved, nullable
+    row = query_runs(tmp_path, where="session_id = ?", params=("s-psr-mig",))[0]
+    assert row["per_stack_review_backend"] == "codex"
+    assert row["per_stack_review_model"] == "gpt-psr"
+
+
 def test_build_manifest_carries_fix_quality_gate(tmp_path: Path):
     """Issue #315: the fix-phase quality-gate verdict round-trips on the manifest."""
     gate = {

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -73,6 +73,8 @@ class _MockConfig:
     test_backend: str | None = None
     output_mode: str = "loop"
     shallow: bool = False
+    bot: str | None = None
+    flow_name: str | None = None
     loop: bool = False
     archive: bool = True
     run_eval: bool = False
@@ -197,52 +199,86 @@ def test_build_manifest_basic(tmp_path: Path):
     assert m.head_sha == "a" * 40
 
 
-def test_build_manifest_deep_records_per_stack_review_tier(tmp_path: Path) -> None:
-    """Issue #646: a deep manifest records the per-stack tier, distinct from review."""
+@pytest.mark.parametrize(
+    ("flow_name", "shallow"),
+    [
+        (None, False),      # default deep loop
+        (None, True),       # --shallow single-stack
+        ("deep", False),   # --flow deep
+        ("shallow", False),  # --flow shallow
+        ("review", False),   # --flow review
+    ],
+)
+def test_build_manifest_per_stack_review_tier(
+    tmp_path: Path, flow_name: str | None, shallow: bool
+) -> None:
+    """Issue #646: every deep-flow mode that executes per-stack reviews records the
+    per-stack tier resolved from its own key — including shallow, whose collapsed
+    single stack is still reviewed by ``phase_per_stack_reviews`` on the
+    ``per_stack_review`` tier."""
     fc = DaydreamFileConfig(
         model=None, backend=None,
         phases={"per_stack_review": {"backend": "codex", "model": "gpt-psr"}},
     )
     config = RunConfig(
         target=str(tmp_path), backend=None, model=None,
-        file_config=fc, review_backend="claude", shallow=False,
+        file_config=fc, shallow=shallow, flow_name=flow_name,
+        review_backend="claude",
     )
     m = build_manifest(
         recorder=cast(TrajectoryRecorder, _MockRecorder()),
         config=config, git_ctx=GitContext(),
         status="complete", archive_path=tmp_path,
     )
-    assert m.deep is True
-    assert m.per_stack_review_backend == "codex"     # per-stack tier resolved from its own key
-    assert m.per_stack_review_model == "gpt-psr"
-    assert m.review_backend == "claude"              # review tier unchanged, distinct
     run = m.to_dict()["run"]
+    assert m.per_stack_review_backend == "codex"  # per-stack tier resolved from its own key
+    assert m.per_stack_review_model == "gpt-psr"
+    assert m.review_backend == "claude"           # review tier unchanged, distinct
     assert run["per_stack_review_backend"] == "codex"
     assert run["per_stack_review_model"] == "gpt-psr"
     assert run["review_backend"] == "claude"
 
 
-def test_build_manifest_shallow_omits_per_stack_review(tmp_path: Path) -> None:
-    """Issue #646: shallow/non-deep manifests are byte-for-byte unchanged."""
-    fc = DaydreamFileConfig(
-        model=None, backend=None,
-        phases={"per_stack_review": {"backend": "codex", "model": "gpt-psr"}},
-    )
-    config = RunConfig(
-        target=str(tmp_path), backend=None, model=None,
-        file_config=fc, shallow=True,
-    )
+def test_build_manifest_omits_per_stack_review_without_spine(tmp_path: Path) -> None:
+    """Issue #646: runs that never execute per-stack reviews record no identity —
+    feedback mode (the review spine is skipped entirely) and improve/custom flows
+    (which never invoke the deep orchestrator's per-stack-reviews step)."""
+    for config in (
+        RunConfig(target=str(tmp_path), backend=None, model=None,
+                  bot="myapp[bot]", pr_number=42),        # feedback mode
+        RunConfig(target=str(tmp_path), backend=None, model=None,
+                  flow_name="improve"),                   # improve flow
+        RunConfig(target=str(tmp_path), backend=None, model=None,
+                  flow_name="custom-flow"),               # custom flow
+    ):
+        m = build_manifest(
+            recorder=cast(TrajectoryRecorder, _MockRecorder()),
+            config=config, git_ctx=GitContext(),
+            status="complete", archive_path=tmp_path,
+        )
+        run = m.to_dict()["run"]
+        assert m.per_stack_review_backend is None
+        assert m.per_stack_review_model is None
+        assert "per_stack_review_backend" not in run
+        assert "per_stack_review_model" not in run
+
+
+def test_build_manifest_pi_deep_records_backend_default_model(tmp_path: Path) -> None:
+    """Issue #646: a Pi deep run with no explicit model override records Pi's
+    backend default. Pi's default intentionally lives outside PHASE_DEFAULT_MODELS
+    (it is a backend fallback), so _resolved_model alone leaves the load-bearing
+    model NULL; the manifest surfaces the backend default instead."""
+    from daydream.config import DEFAULT_PI_MODEL
+
     m = build_manifest(
         recorder=cast(TrajectoryRecorder, _MockRecorder()),
-        config=config, git_ctx=GitContext(),
+        config=RunConfig(target=str(tmp_path), backend="pi", model=None),
+        git_ctx=GitContext(),
         status="complete", archive_path=tmp_path,
     )
-    assert m.deep is False
-    assert m.per_stack_review_backend is None
-    assert m.per_stack_review_model is None
-    run = m.to_dict()["run"]
-    assert "per_stack_review_backend" not in run
-    assert "per_stack_review_model" not in run
+    assert m.per_stack_review_backend == "pi"
+    assert m.per_stack_review_model == DEFAULT_PI_MODEL
+    assert m.to_dict()["run"]["per_stack_review_model"] == DEFAULT_PI_MODEL
 
 
 def test_manifest_to_dict_structure(tmp_path: Path):

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -67,6 +67,7 @@ class _MockRecorder:
 class _MockConfig:
     skill: str | None = "python"
     backend: str = "claude"
+    model: str | None = None
     review_backend: str | None = None
     fix_backend: str | None = None
     test_backend: str | None = None
@@ -194,6 +195,54 @@ def test_build_manifest_basic(tmp_path: Path):
     assert m.total_cached_tokens == 20
     assert m.repo_slug == "org/repo"
     assert m.head_sha == "a" * 40
+
+
+def test_build_manifest_deep_records_per_stack_review_tier(tmp_path: Path) -> None:
+    """Issue #646: a deep manifest records the per-stack tier, distinct from review."""
+    fc = DaydreamFileConfig(
+        model=None, backend=None,
+        phases={"per_stack_review": {"backend": "codex", "model": "gpt-psr"}},
+    )
+    config = RunConfig(
+        target=str(tmp_path), backend=None, model=None,
+        file_config=fc, review_backend="claude", shallow=False,
+    )
+    m = build_manifest(
+        recorder=cast(TrajectoryRecorder, _MockRecorder()),
+        config=config, git_ctx=GitContext(),
+        status="complete", archive_path=tmp_path,
+    )
+    assert m.deep is True
+    assert m.per_stack_review_backend == "codex"     # per-stack tier resolved from its own key
+    assert m.per_stack_review_model == "gpt-psr"
+    assert m.review_backend == "claude"              # review tier unchanged, distinct
+    run = m.to_dict()["run"]
+    assert run["per_stack_review_backend"] == "codex"
+    assert run["per_stack_review_model"] == "gpt-psr"
+    assert run["review_backend"] == "claude"
+
+
+def test_build_manifest_shallow_omits_per_stack_review(tmp_path: Path) -> None:
+    """Issue #646: shallow/non-deep manifests are byte-for-byte unchanged."""
+    fc = DaydreamFileConfig(
+        model=None, backend=None,
+        phases={"per_stack_review": {"backend": "codex", "model": "gpt-psr"}},
+    )
+    config = RunConfig(
+        target=str(tmp_path), backend=None, model=None,
+        file_config=fc, shallow=True,
+    )
+    m = build_manifest(
+        recorder=cast(TrajectoryRecorder, _MockRecorder()),
+        config=config, git_ctx=GitContext(),
+        status="complete", archive_path=tmp_path,
+    )
+    assert m.deep is False
+    assert m.per_stack_review_backend is None
+    assert m.per_stack_review_model is None
+    run = m.to_dict()["run"]
+    assert "per_stack_review_backend" not in run
+    assert "per_stack_review_model" not in run
 
 
 def test_manifest_to_dict_structure(tmp_path: Path):


### PR DESCRIPTION
## Summary
Fixes #646 — the out-of-scope finding that per-stack review identity was not persisted to the archive index.

Adds `per_stack_review_backend` / `per_stack_review_model` to the run manifest and SQLite index (runs table + migration), resolved from the `per_stack_review` phase key — the key that actually drives per-stack execution — so "who reviewed" is never a misstatement. The model is the load-bearing part: per-stack defaults to Sonnet vs the `review` tier's Opus, which a backend name alone cannot distinguish.

- `_DEEP_FLOW_ALIASES` module constant in runner, shared by the deep-flow gate so it cannot drift from `_dispatch_selected_flow` routing.
- Deep-flow modes (loop / shallow / review / comment) record the per-stack tier; feedback / improve / custom flows omit it.
- Pi deep runs with no explicit override record Pi's backend default (`DEFAULT_PI_MODEL`), mirroring PiBackend cwd-configured precedence.
- Rebased onto current `main` (resolved conflict with #643 consolidated backend identity — the manifest keeps the shared `_recorder_backend_names` resolver for the base backend/review/fix/test fields, with the per-stack identity added on top).

## Test Plan
- `make check` green: 3623 passed, 6 skipped (ruff + mypy clean, 328 files).
- New regression tests in `tests/test_archive.py`: per-stack tier resolution, gate tracking runner aliases, omission without spine, Pi default model, upsert persistence, schema migration.

Closes #646
