### PR TITLE
[daydream] Gate fix/test backend labels on executed pipeline (Closes #648)

### DIFF
--- a/daydream/archive/manifest.py
+++ b/daydream/archive/manifest.py
@@ -19,6 +19,8 @@ from typing import TYPE_CHECKING, Any
 
 from daydream.archive.git_context import GitContext
 from daydream.config import DEFAULT_PI_MODEL
+from daydream.extensions import UnresolvedExtensionError, get_registry
+from daydream.trajectory import DaydreamRunFlow
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -27,6 +29,76 @@ if TYPE_CHECKING:
     from daydream.trajectory import TrajectoryRecorder
 
 MANIFEST_SCHEMA_VERSION = "1.0"
+
+
+def _runtime_flow_name(flow: DaydreamRunFlow, flow_name: str | None) -> str | None:
+    """Return the registered flow name ``run_flow`` resolved for this label.
+
+    The deep family (NORMAL/DEEP/TTT/PR — four mode labels of the single
+    registered ``deep`` flow, #330) always resolves to ``"deep"`` regardless
+    of ``config.flow_name``; ``IMPROVE`` resolves ``"improve"``; ``CUSTOM`` is
+    the literal ``--flow`` name. Builtins are seeded before the session's
+    registry loads, so a fork registering a built-in name is resolved exactly
+    as it runs (issue #648).
+    """
+    if flow is DaydreamRunFlow.IMPROVE:
+        return "improve"
+    if flow is DaydreamRunFlow.CUSTOM:
+        return flow_name
+    return "deep"
+
+
+def _flow_phase_steps(flow_name: str | None) -> set[str]:
+    """Return the set of phase steps in the registered flow's pipeline.
+
+    Introspects the per-run registry (builtins are seeded before extension
+    load) — the same source ``run_flow`` resolves — so a fork flow composing
+    the built-in ``fix``/``test`` phases is detected exactly as it runs them.
+    An unknown/absent flow yields an empty set: we record no backend rather
+    than invent one for phases that never ran (#648).
+    """
+    if not flow_name:
+        return set()
+    try:
+        entries = get_registry().flow(flow_name)
+    except UnresolvedExtensionError:
+        return set()
+    step_names: set[str] = set()
+    for entry in entries:
+        if isinstance(entry, str):
+            step_names.add(entry)
+        else:
+            step_names.update(entry.steps)
+    return step_names
+
+
+def _flow_fix_test_steps(flow: DaydreamRunFlow, flow_name: str | None) -> tuple[bool, bool]:
+    """Return ``(runs_fix, runs_test)`` for the pipeline ``run_flow`` executes.
+
+    Issue #648 gates the manifest's fix/test backend labels on the step
+    pipeline ``run_flow`` actually executes, resolved from the per-run registry
+    for every label — not just ``CUSTOM`` — because ``Registry.set_flow`` has no
+    built-in-name guard: a fork overriding ``deep`` or ``improve`` runs its own
+    pipeline while the label would suggest the built-in. Two labels are fixed
+    by runtime mode, not the registry:
+
+    - Review/comment (``TTT``) stops after ``post-review`` (``_review_only_mode``)
+      and never runs the fix cycle, so it records neither backend.
+    - Feedback (``PR``) runs its own ``fix-items`` phase (``_step_fix_items``,
+      ``backend_for("fix")``) but never the ``test`` step, so it records a fix
+      backend only — matching the trajectory's ``_recorder_backend_names``.
+
+    ``NORMAL``/``DEEP``/``IMPROVE``/``CUSTOM`` are classified by the registered
+    pipeline (``NORMAL``/``DEEP`` → the ``deep`` flow; ``IMPROVE`` → ``improve``;
+    ``CUSTOM`` → the literal ``--flow`` name).
+    """
+    if flow is DaydreamRunFlow.TTT:
+        return False, False
+    if flow is DaydreamRunFlow.PR:
+        # Feedback runs the fix phase (fix-items) but never the test phase.
+        return True, False
+    steps = _flow_phase_steps(_runtime_flow_name(flow, flow_name))
+    return ("fix" in steps, "test" in steps)
 
 
 def _omit_falsy(**fields: Any) -> dict[str, Any]:
@@ -65,9 +137,13 @@ class Manifest:
             backend: a CLI ``--backend`` masks a file-config review override,
             so review may have run on ``backend`` even when this is set.
         fix_backend: Effective backend for the fix phase (override or general
-            default).
+            default), or ``None`` for flows whose executed step pipeline has no
+            fix phase (improve, custom flows without fix, and TTT whose fix/test
+            steps are gated off at runtime; #648).
         test_backend: Effective backend for the test phase (override or general
-            default).
+            default), or ``None`` for flows whose executed step pipeline has no
+            test phase (improve, custom flows without test, and TTT/PR which
+            never run the test step; #648).
         per_stack_review_backend: Per-stack review tier backend for runs that
             execute per-stack reviews (issue #646), resolved from the
             ``per_stack_review`` phase key — the key that actually drives
@@ -323,7 +399,6 @@ def build_manifest(
     from daydream.runner import (  # noqa: PLC0415 - deferred import avoids cycle
         _DEEP_FLOW_ALIASES,
         _default_backend_name,
-        _recorder_backend_names,
         _resolved_backend_name,
         _resolved_model,
         _resolved_review_backend_name,
@@ -337,7 +412,6 @@ def build_manifest(
     # file-config review override). Sibling fields ``fix_backend``/
     # ``test_backend`` are effective per-phase values; ``review_backend`` is
     # not.
-    flow_names = _recorder_backend_names(config, recorder.run_flow)
 
     # Per-stack reviewers (issue #646) execute on the "per_stack_review" phase key —
     # NOT the "review" tier — so archives record that tier's resolved backend and
@@ -376,6 +450,17 @@ def build_manifest(
                 _configured_pi_model(Path(cwd)) if cwd else None
             ) or DEFAULT_PI_MODEL
 
+    # Gate fix/test backend labels on whether this flow's step pipeline actually
+    # includes those phases (issue #648): improve never reaches the fix/test
+    # STEPS, TTT (review/comment) gates them off at runtime (_fix_cycle_enabled
+    # is loop/shallow only), PR (feedback) runs its own fix-items phase but
+    # never test, and custom flows are classified from their registered pipeline
+    # (every ``--flow`` run is stamped CUSTOM regardless of step composition), so
+    # a fork composing the built-in fix/test steps records backends like the deep
+    # family. Registry-resolved for every label so fork overrides of built-in
+    # ``deep``/``improve`` are classified by the pipeline actually executed.
+    runs_fix, runs_test = _flow_fix_test_steps(recorder.run_flow, config.flow_name)
+
     m = Manifest(
         session_id=recorder.session_id,
         archived_at=datetime.now(timezone.utc).isoformat(),
@@ -385,8 +470,8 @@ def build_manifest(
         model=None,
         backend=_default_backend_name(config),
         review_backend=_resolved_review_backend_name(config),
-        fix_backend=flow_names.fix or None,
-        test_backend=flow_names.test or None,
+        fix_backend=_resolved_backend_name(config, "fix") if runs_fix else None,
+        test_backend=_resolved_backend_name(config, "test") if runs_test else None,
         per_stack_review_backend=per_stack_review_backend,
         per_stack_review_model=per_stack_review_model,
         review_only=config.output_mode == "review",

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -7,6 +7,7 @@ Covers git_context, manifest, index, and the top-level archive_run flow.
 import json
 import sqlite3
 import subprocess
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, cast
@@ -35,6 +36,9 @@ from daydream.config_file import DaydreamFileConfig
 from daydream.runner import RunConfig
 from daydream.trajectory import DaydreamRunFlow, TrajectoryRecorder
 from tests.harness.trajectory import make_manifest
+
+MakeConfig = Callable[..., RunConfig]
+InstallBackend = Callable[[object], object]
 
 
 @dataclass
@@ -199,6 +203,232 @@ def test_build_manifest_basic(tmp_path: Path):
     assert m.total_cached_tokens == 20
     assert m.repo_slug == "org/repo"
     assert m.head_sha == "a" * 40
+
+
+@pytest.mark.parametrize(
+    "flow",
+    list(DaydreamRunFlow),
+    ids=[f.value for f in DaydreamRunFlow],
+)
+def test_build_manifest_fix_test_backend_gated_per_flow(
+    tmp_path: Path, flow: DaydreamRunFlow,
+) -> None:
+    """Issue #648: backend labels track the executed step pipeline.
+
+    Driven over every ``DaydreamRunFlow`` member: the deep family's
+    fix-bearing mode labels (NORMAL for shallow, DEEP for loop) resolve
+    fix/test backends exactly as today, while TTT (review/comment) gates the
+    fix/test STEPS off at runtime (``_fix_cycle_enabled`` is loop/shallow
+    only) and drops both labels. PR (feedback) runs its own ``fix-items``
+    phase (``_step_fix_items``, ``backend_for("fix")``) but never the ``test``
+    step, so it keeps a fix backend and drops only test. IMPROVE's built-in
+    pipeline defines no fix/test phase, so it drops both. CUSTOM is classified
+    by its registered pipeline; with no fork flow configured here it cannot
+    prove a fix/test phase, so it drops both.
+    """
+    recorder = _MockRecorder(run_flow=flow)
+    config = _MockConfig(fix_backend="codex", test_backend="codex")
+    m = _build(tmp_path, recorder=recorder, config=config)
+    run = m.to_dict()["run"]
+    if flow is DaydreamRunFlow.PR:
+        # Feedback runs fix-items but never the test step.
+        assert m.fix_backend == "codex"
+        assert m.test_backend is None
+        assert run["fix_backend"] == "codex"
+        assert "test_backend" not in run
+    elif flow in (
+        DaydreamRunFlow.IMPROVE,
+        DaydreamRunFlow.TTT,
+        DaydreamRunFlow.CUSTOM,
+    ):
+        assert m.fix_backend is None
+        assert m.test_backend is None
+        assert "fix_backend" not in run
+        assert "test_backend" not in run
+    else:
+        assert m.fix_backend == "codex"
+        assert m.test_backend == "codex"
+        assert run["fix_backend"] == "codex"
+        assert run["test_backend"] == "codex"
+
+
+def test_build_manifest_classifies_custom_flow_by_registered_pipeline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every ``--flow`` run is stamped CUSTOM regardless of step composition, so
+    a fork flow is classified from its registered pipeline, not its label: one
+    composing the built-in fix/test steps records backends, one without them
+    records none.
+    """
+    from daydream.extensions import build_registry
+
+    registry = build_registry()
+    registry.set_flow("fix-cycle-fork", ["exploration", "intent", "fix", "test", "commit"])
+    registry.set_flow("review-only-fork", ["exploration", "intent"])
+    monkeypatch.setattr("daydream.archive.manifest.get_registry", lambda: registry)
+
+    for flow_name, fix_backend, test_backend in (
+        ("fix-cycle-fork", "codex", "codex"),
+        ("review-only-fork", None, None),
+    ):
+        recorder = _MockRecorder(run_flow=DaydreamRunFlow.CUSTOM)
+        config = _MockConfig(
+            fix_backend="codex", test_backend="codex", flow_name=flow_name,
+        )
+        m = _build(tmp_path, recorder=recorder, config=config)
+        assert m.fix_backend == fix_backend
+        assert m.test_backend == test_backend
+        run = m.to_dict()["run"]
+        assert ("fix_backend" in run) == (fix_backend is not None)
+        assert ("test_backend" in run) == (test_backend is not None)
+
+
+def test_build_manifest_classifies_fork_override_of_builtin_flow(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #648: fork overrides of built-in flow names are classified by
+    the registry pipeline actually executed by ``run_flow``, not by the label.
+
+    ``Registry.set_flow`` has no built-in-name guard, so a fork overriding
+    ``deep`` (dropping fix/test) or ``improve`` (adding fix/test) runs its own
+    pipeline while the recorder label still suggests the built-in. The manifest
+    must follow the registry in both directions.
+    """
+    from daydream.extensions import build_registry
+
+    registry = build_registry()
+    # Override built-ins after seeding, exactly as an extension would.
+    registry.set_flow("deep", ["exploration", "intent"])
+    registry.set_flow("improve", ["exploration", "fix", "test"])
+    monkeypatch.setattr("daydream.archive.manifest.get_registry", lambda: registry)
+
+    for flow, flow_name, fix_backend, test_backend in (
+        (DaydreamRunFlow.DEEP, None, None, None),
+        (DaydreamRunFlow.NORMAL, None, None, None),
+        (DaydreamRunFlow.IMPROVE, None, "codex", "codex"),
+    ):
+        recorder = _MockRecorder(run_flow=flow)
+        config = _MockConfig(
+            fix_backend="codex", test_backend="codex", flow_name=flow_name,
+        )
+        m = _build(tmp_path, recorder=recorder, config=config)
+        assert m.fix_backend == fix_backend
+        assert m.test_backend == test_backend
+
+
+def test_fix_cycle_classification_covers_every_run_flow() -> None:
+    """Every ``DaydreamRunFlow`` member is explicitly classified: TTT
+    (review/comment) is mode-gated never to reach the fix cycle, PR (feedback)
+    runs its own fix-items phase (fix yes, test no), and every other label is
+    classified by its registered pipeline (issue #648). A future enum member
+    fails this exhaustiveness check instead of silently changing which backend
+    fields the manifest emits.
+    """
+    mode_gated_labels = {DaydreamRunFlow.TTT}
+    fix_only_labels = {DaydreamRunFlow.PR}
+    fix_cycle_builtins = {
+        DaydreamRunFlow.NORMAL,
+        DaydreamRunFlow.DEEP,
+    }
+    assert set(DaydreamRunFlow) == (
+        mode_gated_labels
+        | fix_only_labels
+        | fix_cycle_builtins
+        | {DaydreamRunFlow.IMPROVE, DaydreamRunFlow.CUSTOM}
+    )
+
+
+def _assert_archive_omits_fix_test_backend(archive_dir: Path, flow: str) -> None:
+    """Issue #648 observable outcomes: manifest + SQLite carry no fix/test backend."""
+    manifests = list((archive_dir / "runs").glob("*/manifest.json"))
+    assert len(manifests) == 1, f"expected exactly one archived run, found {len(manifests)}"
+    manifest = json.loads(manifests[0].read_text(encoding="utf-8"))
+    assert manifest["run"]["flow"] == flow
+    assert "fix_backend" not in manifest["run"]
+    assert "test_backend" not in manifest["run"]
+    rows = query_runs(archive_dir)
+    assert len(rows) == 1
+    assert rows[0]["fix_backend"] is None
+    assert rows[0]["test_backend"] is None
+
+
+async def test_improve_archive_real_path_omits_fix_test_backend(
+    improve_monorepo_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    archive_dir: Path,
+    make_config: MakeConfig,
+) -> None:
+    """Issue #648 real-path: an improve run archives no fix/test backend.
+
+    Enters from the production entrypoint (``runner.run``) with a real temp git
+    worktree, real recorder, and real event loop; only the network backend is
+    mocked via the ``create_backend`` seam. The archived manifest drops
+    ``fix_backend``/``test_backend`` and the SQLite runs row stores NULL.
+    """
+    from daydream.runner import run
+    from tests.harness.improve_backend import install_improve_stub
+
+    monkeypatch.delenv("DAYDREAM_TRAJECTORY_HUB_REPO", raising=False)
+    install_improve_stub(monkeypatch, improve_monorepo_target)
+
+    rc = await run(
+        make_config(
+            improve_monorepo_target, flow_name="improve", archive=True, run_eval=False,
+        )
+    )
+
+    assert rc == 0
+    _assert_archive_omits_fix_test_backend(archive_dir, "improve")
+
+
+async def test_custom_flow_archive_real_path_omits_fix_test_backend(
+    ext_dir: Any,
+    multi_stack_target: Path,
+    install_backend: InstallBackend,
+    monkeypatch: pytest.MonkeyPatch,
+    archive_dir: Path,
+    make_config: MakeConfig,
+) -> None:
+    """Issue #648 real-path: a fork-registered custom flow archives no fix/test backend.
+
+    Same production entry (``runner.run``) with a real git worktree and
+    recorder; only the backend is mocked. The custom flow is extension-defined,
+    so its pipeline has no fix/test step and the archive must not invent labels.
+    """
+    from daydream.backends import ResultEvent, TextEvent
+    from daydream.runner import run
+    from tests.harness.backend import ScriptedBackend
+
+    monkeypatch.delenv("DAYDREAM_TRAJECTORY_HUB_REPO", raising=False)
+    ext_dir.write_module(
+        "from daydream.extensions import FlowStep\n"
+        "async def _audit(ctx):\n"
+        "    from daydream.agent import run_agent\n"
+        "    from daydream.trajectory import DaydreamPhase\n"
+        "    await run_agent(ctx.backend_for('ro_audit'), ctx.work.repo, 'CUSTOM-FLOW-PROMPT',\n"
+        "                    phase=DaydreamPhase.REVIEW)\n"
+        "def register(r):\n"
+        "    r.register_phase(FlowStep(name='ro_audit', run=_audit))\n"
+        "    r.set_flow('ro-audit', ['ro_audit'])\n"
+    )
+    install_backend(
+        ScriptedBackend(
+            events=(
+                TextEvent(text=""),
+                ResultEvent(structured_output=None, continuation=None),
+            ),
+            model="mock-model",
+        )
+    )
+
+    rc = await run(
+        make_config(
+            multi_stack_target, flow_name="ro-audit", archive=True, run_eval=False,
+        )
+    )
+
+    assert rc == 0
+    _assert_archive_omits_fix_test_backend(archive_dir, "custom")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
Fixes out-of-scope finding #648: the archive manifest recorded `fix_backend`/`test_backend` labels for flows whose step pipeline never runs those phases (improve, review/comment TTT, and custom forks).

## What changed
- `daydream/archive/manifest.py` — gate fix/test backend labels on the step pipeline `run_flow` actually executes, resolved from the per-run extension registry for every label (not just CUSTOM):
  - IMPROVE never reaches fix/test STEPS → no labels.
  - TTT (review/comment) gates the fix/test STEPS off at runtime (`_fix_cycle_enabled` is loop/shallow only) → no labels.
  - PR (feedback) runs its own `fix-items` phase but never the `test` step → keeps a fix backend, drops test.
  - CUSTOM and fork-overrides of built-in `deep`/`improve` are classified by the registered pipeline (`Registry.set_flow` has no built-in-name guard), so a fork composing the built-in fix/test steps records backends like the deep family.
- Preserves merged #643/#646/#647 semantics: `backend` is the phase-agnostic general default, `review_backend` a nullable override marker, and per-stack review identity is recorded.
- `tests/test_archive.py` — per-flow gating, custom-pipeline classification, fork-override-of-builtin, exhaustiveness, and two real-path archive tests (improve, custom fork).

## Test Plan
- Full `make check` gate green: **3653 passed / 6 skipped / 0 failures** (~3.5 min), ruff + mypy clean.

Closes #648
