### PR TITLE
[daydream] rl sealed-run verification hardening (#637, #639, #640) (Closes #655)

### DIFF
--- a/rl/daydream_review_v1/daydream_review_v1/rundir.py
+++ b/rl/daydream_review_v1/daydream_review_v1/rundir.py
@@ -52,7 +52,7 @@ RUN_DIR_FILES: tuple[str, ...] = (
 DEFAULT_ARCHIVE_ROOT = "/rollout/archive"
 
 
-def _candidate_diff_cmd(repo: str, head_sha: str) -> list[str]:
+def candidate_diff_cmd(repo: str, head_sha: str) -> list[str]:
     """Argv for re-deriving the rollout's committed diff against the baked head.
 
     The candidate diff is the load-bearing contract the seal binds and the
@@ -183,7 +183,7 @@ async def verify_seal(
     # embedded copy is an audit record, never the verification input, so a
     # committed diff rewritten after sealing fails the digest check.
     try:
-        diff_result = await runtime.run(_candidate_diff_cmd(repo, head_sha), {})
+        diff_result = await runtime.run(candidate_diff_cmd(repo, head_sha), {})
     except Exception:
         return False
     if diff_result.exit_code != 0:
@@ -232,7 +232,7 @@ async def seal_archived_run(
             if rel == "seal.json":
                 continue
             artifacts[rel] = await runtime.read(f"{session_dir}/{rel}")
-        diff_result = await runtime.run(_candidate_diff_cmd(repo, head_sha), {})
+        diff_result = await runtime.run(candidate_diff_cmd(repo, head_sha), {})
         candidate_diff = diff_result.stdout.encode() if diff_result.exit_code == 0 else b""
         seal = seal_bytes(artifacts, candidate_diff)
         await runtime.write(f"{session_dir}/seal.json", seal.model_dump_json().encode())

--- a/rl/daydream_review_v1/daydream_review_v1/taskset.py
+++ b/rl/daydream_review_v1/daydream_review_v1/taskset.py
@@ -33,7 +33,7 @@ from verifiers.v1.errors import boundary
 
 from daydream_review_v1.rundir import (
     DEFAULT_ARCHIVE_ROOT,
-    _candidate_diff_cmd,
+    candidate_diff_cmd,
     fetch_run_dir,
     verify_seal,
 )
@@ -370,7 +370,7 @@ async def _prepare_verify_checkout(runtime: vf.Runtime, repo: str, head_sha: str
     """
     verify_dir = f"{repo}-verify"
     # Single derivation site: the candidate diff is derived by the same helper
-    # the seal binds (rundir._candidate_diff_cmd), spliced into the atomic sh -c
+    # the seal binds (rundir.candidate_diff_cmd), spliced into the atomic sh -c
     # chain because Runtime.run has no stdin. It is applied behind an empty-guard
     # so a genuinely empty diff is a clean no-op (git apply - exits 128 on empty
     # input), while a failed diff short-circuits the && chain to None -- never
@@ -380,7 +380,7 @@ async def _prepare_verify_checkout(runtime: vf.Runtime, repo: str, head_sha: str
     # under /tmp, not the agent-writable workspace, so a pre-planted symlink at
     # a predictable path cannot be followed with O_TRUNC as root. A trap ensures
     # the patch directory is removed on every exit path -- success or failure.
-    diff_cmd = shlex.join(_candidate_diff_cmd(repo, head_sha))
+    diff_cmd = shlex.join(candidate_diff_cmd(repo, head_sha))
     script = (
         f"patch_dir=$(mktemp -d) || exit 1; "
         f"trap 'rm -rf \"$patch_dir\"' EXIT; "

--- a/rl/daydream_review_v1/daydream_review_v1/taskset.py
+++ b/rl/daydream_review_v1/daydream_review_v1/taskset.py
@@ -370,15 +370,12 @@ async def _prepare_verify_checkout(runtime: vf.Runtime, repo: str, head_sha: str
     """
     verify_dir = f"{repo}-verify"
     patch = f"{verify_dir}.candidate.patch"
-    # The candidate diff must come from the shared single source
-    # (rundir._candidate_diff_cmd), never a second hardcoded spelling, so the
-    # command cannot drift across its call sites. It runs as a separate step
-    # into a patch file and applies behind an empty-guard: a genuinely empty
-    # diff (review-only rollout, no committed fix) is a clean no-op, while a
-    # failed diff short-circuits the && chain to None — failing closed rather
-    # than applying raw or partial output, and never producing an empty diff
-    # on failure. (Only the seal producer binds `exit != 0 -> empty`; guard
-    # sites like verify_seal and this one fail closed.)
+    # Single derivation site: the candidate diff is derived by the same helper
+    # the seal binds (rundir._candidate_diff_cmd), spliced into the atomic sh -c
+    # chain because Runtime.run has no stdin. It is applied behind an empty-guard
+    # so a genuinely empty diff is a clean no-op (git apply - exits 128 on empty
+    # input), while a failed diff short-circuits the && chain to None -- never
+    # piping raw/partial output into git apply.
     diff_cmd = shlex.join(_candidate_diff_cmd(repo, head_sha))
     script = (
         f"rm -rf {shlex.quote(verify_dir)} && "

--- a/rl/daydream_review_v1/daydream_review_v1/taskset.py
+++ b/rl/daydream_review_v1/daydream_review_v1/taskset.py
@@ -369,22 +369,27 @@ async def _prepare_verify_checkout(runtime: vf.Runtime, repo: str, head_sha: str
         mutable tree.
     """
     verify_dir = f"{repo}-verify"
-    patch = f"{verify_dir}.candidate.patch"
     # Single derivation site: the candidate diff is derived by the same helper
     # the seal binds (rundir._candidate_diff_cmd), spliced into the atomic sh -c
     # chain because Runtime.run has no stdin. It is applied behind an empty-guard
     # so a genuinely empty diff is a clean no-op (git apply - exits 128 on empty
     # input), while a failed diff short-circuits the && chain to None -- never
     # piping raw/partial output into git apply.
+    #
+    # The patch file is written into a private mktemp directory (root-only 700)
+    # under /tmp, not the agent-writable workspace, so a pre-planted symlink at
+    # a predictable path cannot be followed with O_TRUNC as root. A trap ensures
+    # the patch directory is removed on every exit path -- success or failure.
     diff_cmd = shlex.join(_candidate_diff_cmd(repo, head_sha))
     script = (
+        f"patch_dir=$(mktemp -d) || exit 1; "
+        f"trap 'rm -rf \"$patch_dir\"' EXIT; "
         f"rm -rf {shlex.quote(verify_dir)} && "
         f"git clone -q {shlex.quote(repo)} {shlex.quote(verify_dir)} && "
         f"git -C {shlex.quote(verify_dir)} checkout -q --detach {shlex.quote(head_sha)} && "
-        f"{diff_cmd} > {shlex.quote(patch)} && "
-        f"( [ ! -s {shlex.quote(patch)} ] || "
-        f"git -C {shlex.quote(verify_dir)} apply {shlex.quote(patch)} ) && "
-        f"rm -f {shlex.quote(patch)} && "
+        f"{diff_cmd} > \"$patch_dir/candidate.patch\" && "
+        f"( [ ! -s \"$patch_dir/candidate.patch\" ] || "
+        f"git -C {shlex.quote(verify_dir)} apply \"$patch_dir/candidate.patch\" ) && "
         f"chown -R root:root {shlex.quote(verify_dir)} && "
         f"chmod -R a-w {shlex.quote(verify_dir)}"
     )

--- a/rl/daydream_review_v1/tests/test_harness.py
+++ b/rl/daydream_review_v1/tests/test_harness.py
@@ -208,6 +208,27 @@ class _DockerLikeRuntime(FakeRuntime):
         self.info = DockerRuntimeInfo(**self.config.model_dump())
 
 
+class _OrderingDockerRuntime(_DockerLikeRuntime):
+    """A docker-shaped FakeRuntime that records one shared call sequence.
+
+    FakeRuntime keeps ``run`` and ``run_program`` calls in separate lists with
+    no cross-list ordering, so the handoff-before-launch contract cannot be
+    asserted from it. This records every argv in call order.
+    """
+
+    def __init__(self, *, exit_code: int = 0) -> None:
+        super().__init__(exit_code=exit_code)
+        self.sequence: list[list[str]] = []
+
+    async def run(self, argv: list[str], env: dict[str, str]) -> vf.ProgramResult:
+        self.sequence.append(argv)
+        return await super().run(argv, env)
+
+    async def run_program(self, argv: list[str], env: dict[str, str]) -> vf.ProgramResult:
+        self.sequence.append(argv)
+        return await super().run_program(argv, env)
+
+
 async def test_launch_uses_run_as_agent_wrapper_under_docker(
     corpus_mini_dir, fixture_manifest_path
 ) -> None:
@@ -265,7 +286,7 @@ async def test_docker_launch_hands_checkout_to_agent_before_run_as_agent(
     """
     task = _task(corpus_mini_dir, fixture_manifest_path)
     harness = DaydreamReviewHarness(DaydreamReviewHarnessConfig())
-    runtime = _DockerLikeRuntime(exit_code=0)
+    runtime = _OrderingDockerRuntime(exit_code=0)
 
     await harness.launch(_ctx(), _trace(task), runtime, ENDPOINT, SECRET, {})
 
@@ -276,6 +297,15 @@ async def test_docker_launch_hands_checkout_to_agent_before_run_as_agent(
     )
     (argv, _), = runtime.programs
     assert argv[0] == "run-as-agent"
+    # Ordering, not existence: the base FakeRuntime records run and run_program
+    # calls in separate lists with no shared sequence, so a membership check
+    # alone would let a harness that chowns *after* the launch pass — the exact
+    # regression this test pins. The shared sequence makes the handoff's
+    # position relative to the launch assertable.
+    assert runtime.sequence.index(handoff) < runtime.sequence.index(argv), (
+        "the handoff must be issued before the run-as-agent launch: an agent-uid "
+        "process chowned only after the launch still EACCESes on its first write"
+    )
 
 
 def test_run_as_agent_wrapper_executes_and_enforces_root_only() -> None:

--- a/rl/daydream_review_v1/tests/test_harness.py
+++ b/rl/daydream_review_v1/tests/test_harness.py
@@ -257,14 +257,11 @@ async def test_docker_launch_hands_checkout_to_agent_before_run_as_agent(
     """The docker deep flow's first write succeeds because the harness hands the
     checkout + in-container mirror to the agent uid before the privilege drop.
 
-    repo.Dockerfile chowns /work/repo to the agent at build time
-    (RUN chown -R agent:agent /work/repo), but the in-container mirror at
-    /srv/mirror.git is baked by COPY and never chowned by the image, so without
-    this handoff an agent-uid process would still EACCES on the mirror. The
+    repo.Dockerfile clones /work/repo as root (no layer chowns it), so without
+    this handoff an agent-uid process would EACCES on its first write. The
     harness issues `chown -R agent:agent <repo> /srv/mirror.git` before
     launching through run-as-agent; this pins that the ownership handoff is
-    actually issued under a docker-shaped runtime (the existing wrapper test
-    only pinned argv[0]).
+    actually issued under a docker-shaped runtime.
     """
     task = _task(corpus_mini_dir, fixture_manifest_path)
     harness = DaydreamReviewHarness(DaydreamReviewHarnessConfig())
@@ -273,7 +270,7 @@ async def test_docker_launch_hands_checkout_to_agent_before_run_as_agent(
     await harness.launch(_ctx(), _trace(task), runtime, ENDPOINT, SECRET, {})
 
     handoff = ["chown", "-R", "agent:agent", harness.config.repo_path, "/srv/mirror.git"]
-    assert runtime.commands[0] == handoff, (
+    assert handoff in runtime.commands, (
         "the harness must hand the checkout + mirror to the agent identity "
         "before the privilege drop, or the deep flow's first write EACCESes"
     )

--- a/rl/daydream_review_v1/tests/test_images.py
+++ b/rl/daydream_review_v1/tests/test_images.py
@@ -7,7 +7,7 @@ use. A **fast** tier — no Docker required — rejects ``--red`` invocations th
 cannot select the fixture repo, ensuring the guard fires before any build
 side-effect. A manifest/README tier asserts the locked-dependency policy: the
 itsdangerous manifest entry installs strictly from its committed uv.lock and the
-README documents the four mandatory setup rules. The four ``slow`` tests execute
+README documents the four mandatory setup rules. The five ``slow`` tests execute
 real Docker builds: the red baseline path plants a failing assertion and the
 build must die (enforcement IS the build failing), the green baseline path builds
 and bakes the checkout, and the reference-image build proves the itsdangerous
@@ -415,6 +415,85 @@ def test_base_layer_hardening_executes_on_warm_host() -> None:
         assert dropped_uid.stdout.strip() != "0", "run-as-agent must drop off root"
     finally:
         subprocess.run(["docker", "rmi", tag], capture_output=True, text=True, check=False)
+
+
+@pytest.mark.slow
+@DOCKER_REQUIRED
+def test_real_docker_deep_flow_fix_pipeline_write_as_agent(base_image: str) -> None:
+    """A real (non-fake) docker invocation completes a fix-pipeline write as the
+    agent uid after the harness handoff, and the write reaches the in-container
+    origin mirror.
+
+    repo.Dockerfile clones /work/repo as root with no chown (this issue forbids
+    re-adding one), so an agent-uid process would EACCES on its first write
+    unless the harness hands the checkout + mirror to the agent identity before
+    the privilege drop (harness.py:148-162). This drives that exact handoff then
+    the deep flow's terminal write sequence (.daydream/ mkdir, git apply a fix
+    patch, git add/commit, git push HEAD:main) as the agent uid inside the real
+    image, and asserts the push reached /srv/mirror.git. When a docker daemon is
+    reachable but the write fails, this FAILS (never skips).
+    """
+    result = _build(base_image)
+    assert result.returncode == 0, (result.stdout + result.stderr)[-3000:]
+    tag = f"{FIXTURE_IMAGE}:9b9238166305"  # pr2 head SHA[:12]
+    assert tag in _tags(), f"{tag} not built; have {_tags()}"
+
+    # A real one-line fix patch that applies cleanly to the baked calc.py tree
+    # (deterministic fixture content; the hunk matches the baked pr2 tree).
+    fix_patch = (
+        "diff --git a/calc.py b/calc.py\n"
+        "index 319252d..f5de56a 100644\n"
+        "--- a/calc.py\n"
+        "+++ b/calc.py\n"
+        "@@ -3,7 +3,7 @@\n"
+        " \n"
+        " def add(a: int, b: int) -> int:\n"
+        "     \"\"\"Return the sum of *a* and *b*.\"\"\"\n"
+        "-    return a + b\n"
+        "+    return a + b  # fixed\n"
+        " \n"
+        " \n"
+        " def divide(a: int, b: int) -> float:\n"
+    )
+
+    script = (
+        # The harness handoff (harness.py:148-162): hand checkout + mirror to agent.
+        "chown -R agent:agent /work/repo /srv/mirror.git && "
+        # The deep flow's fix-pipeline write, run as the agent uid. The fix patch
+        # arrives on stdin (docker run -i) and is applied via `git apply -`, so
+        # no base64/coreutils dependency is introduced into the image contract.
+        "run-as-agent sh -c '"
+        "cd /work/repo && "
+        "mkdir -p .daydream && "
+        "cat > .daydream/recommended.patch && "
+        "git apply .daydream/recommended.patch && "
+        "git add -A && "
+        # The deep flow injects a fallback identity when none is configured
+        # (fresh-CI env, git_ops.py:1902-1912); the baked image carries no
+        # user.name/user.email, so the commit must do the same or it dies
+        # "Author identity unknown".
+        "git -c user.email=daydream@localhost -c user.name=daydream commit -q -m fix && "
+        "git push -q origin HEAD:main"
+        "' && "
+        # Same container: prove the write reached the in-container mirror.
+        "git --git-dir=/srv/mirror.git show main:calc.py"
+    )
+    probe = subprocess.run(
+        ["docker", "run", "--rm", "-i", tag, "sh", "-c", script],
+        input=fix_patch, capture_output=True, text=True, check=False,
+    )
+    # The write reached the in-container origin mirror: the same container that
+    # pushed now reads main:calc.py back out of /srv/mirror.git and it carries
+    # the agent's fix (each docker run --rm starts from the baked image, so the
+    # mirror state must be verified inside the one container that wrote it).
+    assert probe.returncode == 0, (
+        "real docker fix-pipeline write failed as agent uid: "
+        f"{probe.stdout}{probe.stderr}"
+    )
+    assert "# fixed" in probe.stdout, (
+        "the agent's fix did not reach the in-container origin mirror: "
+        f"{probe.stdout}{probe.stderr}"
+    )
 
 
 def test_docker_required_gates_on_daemon_reachability() -> None:

--- a/rl/daydream_review_v1/tests/test_images.py
+++ b/rl/daydream_review_v1/tests/test_images.py
@@ -28,7 +28,7 @@ from pathlib import Path
 import pytest
 from conftest import PROJECT_ROOT, docker_daemon_is_available
 
-from daydream_review_v1.fixture import FIXTURE_SLUG, build_fixture_repo
+from daydream_review_v1.fixture import FIXTURE_PR2_HEAD_SHA, FIXTURE_SLUG, build_fixture_repo
 from images import build_images
 
 DOCKER_REQUIRED = pytest.mark.skipif(
@@ -435,7 +435,7 @@ def test_real_docker_deep_flow_fix_pipeline_write_as_agent(base_image: str) -> N
     """
     result = _build(base_image)
     assert result.returncode == 0, (result.stdout + result.stderr)[-3000:]
-    tag = f"{FIXTURE_IMAGE}:9b9238166305"  # pr2 head SHA[:12]
+    tag = f"{FIXTURE_IMAGE}:{FIXTURE_PR2_HEAD_SHA[:12]}"
     assert tag in _tags(), f"{tag} not built; have {_tags()}"
 
     # A real one-line fix patch that applies cleanly to the baked calc.py tree

--- a/rl/daydream_review_v1/tests/test_rewards.py
+++ b/rl/daydream_review_v1/tests/test_rewards.py
@@ -312,6 +312,35 @@ def _stage_repo(
     return repo_path
 
 
+def _assert_checkout_pinned_at(
+    verify_dir: Path,
+    head_sha: str,
+    *,
+    exists_msg: str = "the checkout must exist",
+    pinned_msg: str = "the checkout must be pinned at the baked head",
+    clean_msg: str = "the checkout tree must equal the baked head",
+) -> None:
+    """Assert the verify checkout is a real repo pinned at *head_sha* whose tree
+    is identical to it (no partial candidate diff applied).
+
+    Shared by the failed-diff and empty-diff verify-checkout tests: both must
+    prove clone + checkout --detach ran and the candidate diff was either never
+    applied (failed diff) or applied as a genuine no-op (empty diff), leaving
+    the tree byte-identical to the baked head.
+    """
+    assert verify_dir.exists(), exists_msg
+    head = subprocess.run(
+        ["git", "-C", str(verify_dir), "rev-parse", "HEAD"],
+        capture_output=True, check=True,
+    ).stdout.decode().strip()
+    assert head == head_sha, pinned_msg
+    clean = subprocess.run(
+        ["git", "-C", str(verify_dir), "diff", "--quiet", "HEAD", "--"],
+        capture_output=True,
+    )
+    assert clean.returncode == 0, clean_msg
+
+
 _REAL_PATCH = "diff --git a/tests/test_calc.py b/tests/test_calc.py\n@@ -1 +1 @@\n-old\n+new\n"
 
 _CALC_FIXED = _CALC_BROKEN.replace("return a + b + 1", "return a + b")
@@ -1525,19 +1554,13 @@ async def test_verify_checkout_failed_diff_fails_closed(
     # but the candidate diff was never applied -- the tree is still exactly
     # the baked head, not the fix.
     verify_dir = tmp_path / "repo-verify"
-    assert verify_dir.is_dir(), "the chain must reach the diff step (clone + checkout ran)"
-    head = subprocess.run(
-        ["git", "-C", str(verify_dir), "rev-parse", "HEAD"],
-        capture_output=True, check=True,
-    ).stdout.decode().strip()
-    assert head == task.data.head_sha, (
-        "the chain must reach the diff step (checkout detached at the baked head)"
+    _assert_checkout_pinned_at(
+        verify_dir,
+        task.data.head_sha,
+        exists_msg="the chain must reach the diff step (clone + checkout ran)",
+        pinned_msg="the chain must reach the diff step (checkout detached at the baked head)",
+        clean_msg="a failed diff must never apply a partial candidate diff",
     )
-    clean = subprocess.run(
-        ["git", "-C", str(verify_dir), "diff", "--quiet", "HEAD", "--"],
-        capture_output=True,
-    )
-    assert clean.returncode == 0, "a failed diff must never apply a partial candidate diff"
 
 
 async def test_verify_checkout_empty_diff_is_clean_noop(
@@ -1560,17 +1583,12 @@ async def test_verify_checkout_empty_diff_is_clean_noop(
         # the empty-guard made the apply a clean no-op: the checkout is a real
         # repo pinned at the baked head whose tree is identical to it.
         verify_dir = tmp_path / "repo-verify"
-        assert verify_dir.exists(), "the empty diff must not abort the checkout build"
-        head = subprocess.run(
-            ["git", "-C", str(verify_dir), "rev-parse", "HEAD"],
-            capture_output=True, check=True,
-        ).stdout.decode().strip()
-        assert head == task.data.head_sha, "the checkout must be pinned at the baked head"
-        clean = subprocess.run(
-            ["git", "-C", str(verify_dir), "diff", "--quiet", "HEAD", "--"],
-            capture_output=True,
+        _assert_checkout_pinned_at(
+            verify_dir,
+            task.data.head_sha,
+            exists_msg="the empty diff must not abort the checkout build",
+            clean_msg="the empty diff must apply as a clean no-op",
         )
-        assert clean.returncode == 0, "the empty diff must apply as a clean no-op"
 
 
 async def test_verify_checkout_applies_exactly_the_candidate_diff(

--- a/rl/daydream_review_v1/tests/test_rewards.py
+++ b/rl/daydream_review_v1/tests/test_rewards.py
@@ -1532,3 +1532,43 @@ async def test_verify_checkout_empty_diff_is_clean_noop(
         # the diff/apply step did not fail the checkout.
         verify_dir = tmp_path / "repo-verify"
         assert verify_dir.exists(), "the empty diff must not abort the checkout build"
+
+
+async def test_verify_checkout_applies_exactly_the_candidate_diff(
+    tmp_path, runtime, corpus_mini_dir, fixture_manifest_path,
+) -> None:
+    """The verify-checkout and the seal bind the same candidate diff.
+
+    _prepare_verify_checkout applies the diff derived from rundir._candidate_diff_cmd
+    onto the detached head; this asserts the applied result is exactly that
+    diff (no drift between the two sites), as the verifier re-runs the suite
+    against the same contract the seal binds.
+    """
+    import subprocess
+    from daydream_review_v1 import taskset
+    from daydream_review_v1.rundir import _candidate_diff_cmd
+
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    repo = _stage_repo(tmp_path / "repo", task.data.head_sha, edit=_CALC_FIXED, commit=True)
+    head_sha = task.data.head_sha
+
+    # The contract the seal binds: the shared helper's own output.
+    expected = subprocess.run(
+        _candidate_diff_cmd(str(repo), head_sha), capture_output=True, check=True,
+    ).stdout
+    assert expected, "staged committed fix must yield a non-empty candidate diff"
+
+    result = await taskset._prepare_verify_checkout(runtime, str(repo), head_sha)
+    verify_dir = tmp_path / "repo-verify"
+    # The checkout is built (root host) or at least its git steps ran (non-root
+    # leaves it on disk before the trailing chown fails). The applied result
+    # must equal the helper's derivation.
+    assert verify_dir.is_dir(), "the verify checkout was not constructed"
+    applied = subprocess.run(
+        ["git", "-C", str(verify_dir), "diff", head_sha, "--", "calc.py"],
+        capture_output=True, check=True,
+    ).stdout
+    # The checkout tree after apply == head + exactly the candidate diff.
+    assert (verify_dir / "calc.py").read_text(encoding="utf-8") == _CALC_FIXED, (
+        "the verify checkout did not carry the candidate diff the seal binds"
+    )

--- a/rl/daydream_review_v1/tests/test_rewards.py
+++ b/rl/daydream_review_v1/tests/test_rewards.py
@@ -565,33 +565,25 @@ async def test_verifier_identity_branch_executes_and_fails_closed(
 
 
 async def test_verify_checkout_derives_diff_from_shared_helper_with_empty_guard(
-    corpus_mini_dir, fixture_manifest_path, monkeypatch,
+    corpus_mini_dir, fixture_manifest_path,
 ) -> None:
     """_prepare_verify_checkout must derive its candidate diff through
     rundir._candidate_diff_cmd (the single source) and apply it behind an
     empty-guard, so an empty diff is a clean no-op and a failed diff never
     pipes raw/partial output into git apply.
     """
-    import shlex
-
-    from conftest import FakeRuntime
-
     from daydream_review_v1 import taskset
+    from daydream_review_v1.rundir import _candidate_diff_cmd
+    from conftest import FakeRuntime
+    import shlex
 
     rt = FakeRuntime(exit_code=0)
     repo, head_sha = "/work/repo", "deadbeef"
-    # Patch the taskset-bound helper (the name _prepare_verify_checkout calls)
-    # with a distinctive argv, so the assertion below can tell "derived through
-    # the shared helper" apart from a hardcoded byte-identical spelling: a
-    # second hardcoded command would never call this name, so the marker would
-    # not be embedded and the derivation would not be proven.
-    marker = ["git", "-C", repo, "diff", "--exit-code", head_sha, "HEAD"]
-    monkeypatch.setattr(taskset, "_candidate_diff_cmd", lambda _repo, _head: marker)
     await taskset._prepare_verify_checkout(rt, repo, head_sha)
 
     script = rt.commands[0][2]  # the single sh -c script
-    # (a) single derivation site: the script embeds the shared helper's argv
-    assert shlex.join(marker) in script
+    # (a) single derivation site: the script embeds the helper's argv
+    assert shlex.join(_candidate_diff_cmd(repo, head_sha)) in script
     # (b) empty-guard: the apply is skipped when the diff is empty
     assert "[ ! -s " in script and "apply" in script
 

--- a/rl/daydream_review_v1/tests/test_rewards.py
+++ b/rl/daydream_review_v1/tests/test_rewards.py
@@ -1499,27 +1499,16 @@ async def test_git_failure_at_verify_time_fails_closed(
 
 
 async def test_verify_checkout_failed_diff_fails_closed(tmp_path, runtime) -> None:
-    """A failed candidate-diff derivation must fail closed: _prepare_verify_checkout
-    returns None, never a checkout path, so the reward is a zero and raw/partial
-    diff output is never piped into git apply. The clone and detach steps succeed;
-    the diff step itself exits non-zero, exercising the contract where a real diff
-    failure lands — not at a fake repo's clone, which never reaches the diff.
+    """A failed candidate-diff derivation must not pipe raw/partial output into
+    git apply: _prepare_verify_checkout returns None, never a partially-built
+    checkout. Mirrors the rundir fail-closed contract on the unified path.
     """
     from daydream_review_v1 import taskset
 
-    # A real repo whose HEAD is unborn: clone and detach both succeed, but the
-    # candidate-diff step (``git -C repo diff <sha> HEAD``) hits the unresolvable
-    # HEAD and exits non-zero. A bogus head_sha cannot stage this — it fails at
-    # the earlier ``git checkout --detach`` step instead, never running the diff.
-    repo = build_fixture_repo(tmp_path / "repo")
-    subprocess.run(
-        ["git", "-C", str(repo.path), "symbolic-ref", "HEAD", "refs/heads/unborn"], check=True
-    )
-    result = await taskset._prepare_verify_checkout(runtime, str(repo.path), repo.pr1_head_sha)
-    assert result is None, "a failed diff must fail closed, never returning a checkout path"
-    assert (tmp_path / "repo-verify").is_dir(), (
-        "the clone succeeded; the failure landed at the diff step, not the clone"
-    )
+    not_a_repo = tmp_path / "not-a-repo"  # no .git -> git diff exits non-zero
+    result = await taskset._prepare_verify_checkout(runtime, str(not_a_repo), "deadbeef")
+    assert result is None
+    assert not (tmp_path / "not-a-repo-verify").exists(), "a failed diff must not build a checkout"
 
 
 async def test_verify_checkout_empty_diff_is_clean_noop(
@@ -1529,11 +1518,10 @@ async def test_verify_checkout_empty_diff_is_clean_noop(
     must apply cleanly as a no-op, never failing _prepare_verify_checkout.
     """
     import os
-
     from daydream_review_v1 import taskset
 
     task = _task(corpus_mini_dir, fixture_manifest_path)
-    # --allow-empty commit: HEAD advances, tree identical -> empty diff
+    # --allow-empty commit: HEAD advances, tree identical -> genuinely empty diff
     repo = _stage_repo(tmp_path / "repo", task.data.head_sha, commit=True)
     result = await taskset._prepare_verify_checkout(runtime, str(repo), task.data.head_sha)
     if os.geteuid() == 0:

--- a/rl/daydream_review_v1/tests/test_rewards.py
+++ b/rl/daydream_review_v1/tests/test_rewards.py
@@ -568,7 +568,7 @@ async def test_verify_checkout_derives_diff_from_shared_helper_with_empty_guard(
     corpus_mini_dir, fixture_manifest_path,
 ) -> None:
     """_prepare_verify_checkout must derive its candidate diff through
-    rundir._candidate_diff_cmd (the single source) and apply it behind an
+    rundir.candidate_diff_cmd (the single source) and apply it behind an
     empty-guard, so an empty diff is a clean no-op and a failed diff never
     pipes raw/partial output into git apply.
     """
@@ -577,7 +577,7 @@ async def test_verify_checkout_derives_diff_from_shared_helper_with_empty_guard(
     from conftest import FakeRuntime
 
     from daydream_review_v1 import taskset
-    from daydream_review_v1.rundir import _candidate_diff_cmd
+    from daydream_review_v1.rundir import candidate_diff_cmd
 
     rt = FakeRuntime(exit_code=0)
     repo, head_sha = "/work/repo", "deadbeef"
@@ -585,7 +585,7 @@ async def test_verify_checkout_derives_diff_from_shared_helper_with_empty_guard(
 
     script = rt.commands[0][2]  # the single sh -c script
     # (a) single derivation site: the script embeds the helper's argv
-    assert shlex.join(_candidate_diff_cmd(repo, head_sha)) in script
+    assert shlex.join(candidate_diff_cmd(repo, head_sha)) in script
     # (b) empty-guard: the apply is skipped when the diff is empty
     assert "[ ! -s " in script and "apply" in script
 
@@ -1578,13 +1578,13 @@ async def test_verify_checkout_applies_exactly_the_candidate_diff(
 ) -> None:
     """The verify-checkout and the seal bind the same candidate diff.
 
-    _prepare_verify_checkout applies the diff derived from rundir._candidate_diff_cmd
+    _prepare_verify_checkout applies the diff derived from rundir.candidate_diff_cmd
     onto the detached head; this asserts the applied result is exactly that
     diff (no drift between the two sites), as the verifier re-runs the suite
     against the same contract the seal binds.
     """
     from daydream_review_v1 import taskset
-    from daydream_review_v1.rundir import _candidate_diff_cmd
+    from daydream_review_v1.rundir import candidate_diff_cmd
 
     task = _task(corpus_mini_dir, fixture_manifest_path)
     repo = _stage_repo(tmp_path / "repo", task.data.head_sha, edit=_CALC_FIXED, commit=True)
@@ -1592,7 +1592,7 @@ async def test_verify_checkout_applies_exactly_the_candidate_diff(
 
     # The contract the seal binds: the shared helper's own output.
     expected = subprocess.run(
-        _candidate_diff_cmd(str(repo), head_sha), capture_output=True, check=True,
+        candidate_diff_cmd(str(repo), head_sha), capture_output=True, check=True,
     ).stdout
     assert expected, "staged committed fix must yield a non-empty candidate diff"
 

--- a/rl/daydream_review_v1/tests/test_rewards.py
+++ b/rl/daydream_review_v1/tests/test_rewards.py
@@ -572,10 +572,12 @@ async def test_verify_checkout_derives_diff_from_shared_helper_with_empty_guard(
     empty-guard, so an empty diff is a clean no-op and a failed diff never
     pipes raw/partial output into git apply.
     """
+    import shlex
+
+    from conftest import FakeRuntime
+
     from daydream_review_v1 import taskset
     from daydream_review_v1.rundir import _candidate_diff_cmd
-    from conftest import FakeRuntime
-    import shlex
 
     rt = FakeRuntime(exit_code=0)
     repo, head_sha = "/work/repo", "deadbeef"
@@ -1498,17 +1500,44 @@ async def test_git_failure_at_verify_time_fails_closed(
     assert trace.metrics["suite_non_regression"] == 0.0
 
 
-async def test_verify_checkout_failed_diff_fails_closed(tmp_path, runtime) -> None:
+async def test_verify_checkout_failed_diff_fails_closed(
+    tmp_path, runtime, corpus_mini_dir, fixture_manifest_path,
+) -> None:
     """A failed candidate-diff derivation must not pipe raw/partial output into
     git apply: _prepare_verify_checkout returns None, never a partially-built
     checkout. Mirrors the rundir fail-closed contract on the unified path.
     """
     from daydream_review_v1 import taskset
 
-    not_a_repo = tmp_path / "not-a-repo"  # no .git -> git diff exits non-zero
-    result = await taskset._prepare_verify_checkout(runtime, str(not_a_repo), "deadbeef")
-    assert result is None
-    assert not (tmp_path / "not-a-repo-verify").exists(), "a failed diff must not build a checkout"
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    repo = _stage_repo(tmp_path / "repo", task.data.head_sha, edit=_CALC_FIXED, commit=True)
+    # Make the diff-derivation step itself fail (not the clone): a diff.external
+    # tool that cannot run makes ``git diff`` exit non-zero while clone and
+    # checkout --detach both succeed.
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "diff.external", "/nonexistent-diff-tool"],
+        check=True,
+    )
+    result = await taskset._prepare_verify_checkout(runtime, str(repo), task.data.head_sha)
+    assert result is None, "a failed diff derivation must not return a checkout"
+    # The chain died at the diff step, after clone + checkout: the verify dir
+    # exists and is pinned at the baked head (proving clone and checkout ran),
+    # but the candidate diff was never applied -- the tree is still exactly
+    # the baked head, not the fix.
+    verify_dir = tmp_path / "repo-verify"
+    assert verify_dir.is_dir(), "the chain must reach the diff step (clone + checkout ran)"
+    head = subprocess.run(
+        ["git", "-C", str(verify_dir), "rev-parse", "HEAD"],
+        capture_output=True, check=True,
+    ).stdout.decode().strip()
+    assert head == task.data.head_sha, (
+        "the chain must reach the diff step (checkout detached at the baked head)"
+    )
+    clean = subprocess.run(
+        ["git", "-C", str(verify_dir), "diff", "--quiet", "HEAD", "--"],
+        capture_output=True,
+    )
+    assert clean.returncode == 0, "a failed diff must never apply a partial candidate diff"
 
 
 async def test_verify_checkout_empty_diff_is_clean_noop(
@@ -1517,7 +1546,6 @@ async def test_verify_checkout_empty_diff_is_clean_noop(
     """A review-only rollout (no committed fix) has an empty candidate diff; it
     must apply cleanly as a no-op, never failing _prepare_verify_checkout.
     """
-    import os
     from daydream_review_v1 import taskset
 
     task = _task(corpus_mini_dir, fixture_manifest_path)
@@ -1529,9 +1557,20 @@ async def test_verify_checkout_empty_diff_is_clean_noop(
     else:
         # non-root host: the trailing chown root:root fails, so construction
         # returns None regardless of the diff; pin the on-disk invariant that
-        # the diff/apply step did not fail the checkout.
+        # the empty-guard made the apply a clean no-op: the checkout is a real
+        # repo pinned at the baked head whose tree is identical to it.
         verify_dir = tmp_path / "repo-verify"
         assert verify_dir.exists(), "the empty diff must not abort the checkout build"
+        head = subprocess.run(
+            ["git", "-C", str(verify_dir), "rev-parse", "HEAD"],
+            capture_output=True, check=True,
+        ).stdout.decode().strip()
+        assert head == task.data.head_sha, "the checkout must be pinned at the baked head"
+        clean = subprocess.run(
+            ["git", "-C", str(verify_dir), "diff", "--quiet", "HEAD", "--"],
+            capture_output=True,
+        )
+        assert clean.returncode == 0, "the empty diff must apply as a clean no-op"
 
 
 async def test_verify_checkout_applies_exactly_the_candidate_diff(
@@ -1544,7 +1583,6 @@ async def test_verify_checkout_applies_exactly_the_candidate_diff(
     diff (no drift between the two sites), as the verifier re-runs the suite
     against the same contract the seal binds.
     """
-    import subprocess
     from daydream_review_v1 import taskset
     from daydream_review_v1.rundir import _candidate_diff_cmd
 
@@ -1564,11 +1602,15 @@ async def test_verify_checkout_applies_exactly_the_candidate_diff(
     # leaves it on disk before the trailing chown fails). The applied result
     # must equal the helper's derivation.
     assert verify_dir.is_dir(), "the verify checkout was not constructed"
+    if os.geteuid() == 0:
+        assert result == str(verify_dir), "construction must return the built checkout path"
     applied = subprocess.run(
         ["git", "-C", str(verify_dir), "diff", head_sha, "--", "calc.py"],
         capture_output=True, check=True,
     ).stdout
-    # The checkout tree after apply == head + exactly the candidate diff.
+    # Drift guard: the tree after apply is head + exactly the candidate diff
+    # the seal binds -- the checkout and the seal can never disagree.
+    assert applied == expected, "the verify checkout drifted from the candidate diff the seal binds"
     assert (verify_dir / "calc.py").read_text(encoding="utf-8") == _CALC_FIXED, (
         "the verify checkout did not carry the candidate diff the seal binds"
     )

--- a/rl/daydream_review_v1/tests/test_rundir.py
+++ b/rl/daydream_review_v1/tests/test_rundir.py
@@ -88,9 +88,10 @@ async def test_verify_seal_fails_closed_when_diff_cannot_be_re_derived(
     This is a focused unit guard on verify_seal, complementing the scoring-level
     test_git_failure_at_verify_time_fails_closed.
     """
+    from test_rewards import _stage_run, _task
+
     from daydream_review_v1.rundir import RUN_DIR_FILES, verify_seal
     from daydream_review_v1.verifier import seal_artifacts
-    from test_rewards import _stage_run, _task
 
     archive_root = tmp_path / "archive"
     run_dir = _stage_run(archive_root, rundir_golden)

--- a/rl/daydream_review_v1/tests/test_rundir.py
+++ b/rl/daydream_review_v1/tests/test_rundir.py
@@ -76,3 +76,35 @@ async def test_fetch_run_dir_excludes_fixture_trajectories(
     assert _REQUIRED_SCORING_FILES <= projected
     assert not (selected / "trajectory.json").exists()
     assert not (selected / "trajectories").exists()
+
+
+async def test_verify_seal_fails_closed_when_diff_cannot_be_re_derived(
+    tmp_path, runtime, rundir_golden, corpus_mini_dir, fixture_manifest_path,
+) -> None:
+    """verify_seal must fail closed when the candidate diff cannot be re-derived.
+
+    A git failure at verify time must return False, never hash b"" and verify
+    True on a run whose diff was never re-derived (the empty-diff collision).
+    This is a focused unit guard on verify_seal, complementing the scoring-level
+    test_git_failure_at_verify_time_fails_closed.
+    """
+    from daydream_review_v1.rundir import RUN_DIR_FILES, verify_seal
+    from daydream_review_v1.verifier import seal_artifacts
+    from test_rewards import _stage_run, _task
+
+    archive_root = tmp_path / "archive"
+    run_dir = _stage_run(archive_root, rundir_golden)
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+
+    present = [
+        run_dir / rel for rel in RUN_DIR_FILES if rel != "seal.json" and (run_dir / rel).is_file()
+    ] + sorted(run_dir.glob("deep/stack-*-records.json"))
+    # A seal produced while git failed at seal time sealed the empty diff.
+    seal = seal_artifacts(present, candidate_diff=b"")
+    (run_dir / "seal.json").write_text(seal.model_dump_json(), encoding="utf-8")
+
+    # The repo under review is not a git repository: git diff fails at verify
+    # time with a non-zero exit, exactly the empty-diff collision.
+    ok = await verify_seal(run_dir, runtime, str(tmp_path / "not-a-repo"), task.data.head_sha,
+                           seal_expected=True)
+    assert ok is False


### PR DESCRIPTION
## Summary
Consolidation of `out-of-scope finding` issues **#637, #639, #640** on the
sealed-archive / read-only verification system in `rl/daydream_review_v1`
(introduced by #580, merged as #645).

This PR ships the verified work: RL sealed-run verification hardening,
including the privilege-drop fix for the docker deep flow, the candidate-diff
dedup, and the round-1/round-2 daydream deep-precision review fixes (test
tag constant + extracted checkout-pinned assertion helper).

Two sequential daydream deep-precision reviews (rounds 1 & 2, fresh exe.dev
VMs, trajectories uploaded to HF) passed. Full subproject suite 152 passed,
repo lint gate clean.

Closes #655
