### PR TITLE
test(improve): pin working_directory spelling dedup at improve entrypoint (Closes #654)

### DIFF
--- a/tests/test_improve_flow.py
+++ b/tests/test_improve_flow.py
@@ -1054,6 +1054,39 @@ async def test_makefile_and_manifest_gate_plans_when_the_model_cites_nothing(
     assert _git_status_porcelain(improve_monorepo_target) == ""
 
 
+def _dedup_test_command(
+    *,
+    command_id: str,
+    purpose: str,
+    working_directory: str,
+    scope: dict[str, Any],
+    rationale: str,
+    evidence: dict[str, Any],
+) -> dict[str, Any]:
+    """Build one recon command record for the absolute-wd dedup fixture.
+
+    The host-enumerated and model-cited sides of the dedup share the same
+    command, expected-success block, and applicability skeleton; only the id,
+    working-directory spelling, scope, rationale, and evidence differ.
+    """
+    return {
+        "id": command_id,
+        "purpose": purpose,
+        "command": "uv run pytest",
+        "working_directory": working_directory,
+        "expected_success": {
+            "exit_code": 0,
+            "observable_result": "exit 0 and the tests pass",
+        },
+        "applicability": {
+            "scope": scope,
+            "preconditions": [],
+            "rationale": rationale,
+        },
+        "evidence": evidence,
+    }
+
+
 @pytest.mark.anyio
 async def test_host_enumeration_dedups_absolute_model_wd(
     improve_monorepo_target: Path,
@@ -1066,56 +1099,40 @@ async def test_host_enumeration_dedups_absolute_model_wd(
     monkeypatch.setattr(
         "daydream.improve.orchestrator.enumerate_repository_commands",
         lambda repo, *, directories=(".",), reserved_ids=(): [
-            {
-                "id": "make-check",
-                "purpose": "Run the repository test suite",
-                "command": "uv run pytest",
-                "working_directory": "apps/billing",
-                "expected_success": {
-                    "exit_code": 0,
-                    "observable_result": "exit 0 and the tests pass",
-                },
-                "applicability": {
-                    "scope": {"kind": "in-scope-paths", "paths": ["apps/billing"]},
-                    "preconditions": [],
-                    "rationale": "The billing service declares the test command.",
-                },
-                "evidence": {
+            _dedup_test_command(
+                command_id="make-check",
+                purpose="Run the repository test suite",
+                working_directory="apps/billing",
+                scope={"kind": "in-scope-paths", "paths": ["apps/billing"]},
+                rationale="The billing service declares the test command.",
+                evidence={
                     "kind": "host-derived",
                     "source_path": "apps/billing/pyproject.toml",
                     "line_anchor": {"start_line": 1, "end_line": 1},
                     "verbatim_excerpt": "[project]",
                 },
-            }
+            )
         ],
     )
     stub = install_improve_stub(monkeypatch, improve_monorepo_target)
     stub.recon_output_override = {
         "languages": ["python"],
         "commands": [
-            {
-                "id": "model-check",
-                "purpose": "Run the repository test suite",
-                "command": "uv run pytest",
+            _dedup_test_command(
+                command_id="model-check",
+                purpose="Run the repository test suite",
                 # Absolute spelling of the SAME directory the host enumerates
                 # relative ("apps/billing").
-                "working_directory": f"{improve_monorepo_target}/apps/billing",
-                "expected_success": {
-                    "exit_code": 0,
-                    "observable_result": "exit 0 and the tests pass",
-                },
-                "applicability": {
-                    "scope": {"kind": "whole-repository"},
-                    "preconditions": [],
-                    "rationale": "The root configuration declares the test command.",
-                },
-                "evidence": {
+                working_directory=f"{improve_monorepo_target}/apps/billing",
+                scope={"kind": "whole-repository"},
+                rationale="The root configuration declares the test command.",
+                evidence={
                     "kind": "literal-command",
                     "source_path": "pyproject.toml",
                     "line_anchor": {"start_line": 5, "end_line": 5},
                     "verbatim_excerpt": None,
                 },
-            }
+            )
         ],
         "conventions": ["OpenAPI First"],
         "intent_docs": ["README.md"],

--- a/tests/test_improve_flow.py
+++ b/tests/test_improve_flow.py
@@ -1055,6 +1055,86 @@ async def test_makefile_and_manifest_gate_plans_when_the_model_cites_nothing(
 
 
 @pytest.mark.anyio
+async def test_host_enumeration_dedups_absolute_model_wd(
+    improve_monorepo_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+) -> None:
+    """A model-cited command whose working_directory is spelled absolutely is
+    deduped against the host record for the same directory (relative spelling):
+    exactly one command record, no rejection noise (issue #654)."""
+    monkeypatch.setattr(
+        "daydream.improve.orchestrator.enumerate_repository_commands",
+        lambda repo, *, directories=(".",), reserved_ids=(): [
+            {
+                "id": "make-check",
+                "purpose": "Run the repository test suite",
+                "command": "uv run pytest",
+                "working_directory": "apps/billing",
+                "expected_success": {
+                    "exit_code": 0,
+                    "observable_result": "exit 0 and the tests pass",
+                },
+                "applicability": {
+                    "scope": {"kind": "in-scope-paths", "paths": ["apps/billing"]},
+                    "preconditions": [],
+                    "rationale": "The billing service declares the test command.",
+                },
+                "evidence": {
+                    "kind": "host-derived",
+                    "source_path": "apps/billing/pyproject.toml",
+                    "line_anchor": {"start_line": 1, "end_line": 1},
+                    "verbatim_excerpt": "[project]",
+                },
+            }
+        ],
+    )
+    stub = install_improve_stub(monkeypatch, improve_monorepo_target)
+    stub.recon_output_override = {
+        "languages": ["python"],
+        "commands": [
+            {
+                "id": "model-check",
+                "purpose": "Run the repository test suite",
+                "command": "uv run pytest",
+                # Absolute spelling of the SAME directory the host enumerates
+                # relative ("apps/billing").
+                "working_directory": f"{improve_monorepo_target}/apps/billing",
+                "expected_success": {
+                    "exit_code": 0,
+                    "observable_result": "exit 0 and the tests pass",
+                },
+                "applicability": {
+                    "scope": {"kind": "whole-repository"},
+                    "preconditions": [],
+                    "rationale": "The root configuration declares the test command.",
+                },
+                "evidence": {
+                    "kind": "literal-command",
+                    "source_path": "pyproject.toml",
+                    "line_anchor": {"start_line": 5, "end_line": 5},
+                    "verbatim_excerpt": None,
+                },
+            }
+        ],
+        "conventions": ["OpenAPI First"],
+        "intent_docs": ["README.md"],
+    }
+    stub.plan_gate_on_first_menu_id = True
+
+    code = await run(make_config(improve_monorepo_target, flow_name="improve"))
+
+    assert code == 0
+    recon = json.loads(
+        improve_artifact(improve_monorepo_target, "recon.json").read_text(encoding="utf-8")
+    )
+    # The host command was deduped against the absolute model wd: no
+    # re-admitted make-check record, no rejection noise.
+    assert [command["id"] for command in recon["commands"]] == ["model-check"]
+    assert recon["command_rejections"] == []
+
+
+@pytest.mark.anyio
 async def test_host_enumeration_failure_is_visible_and_keeps_model_commands(
     improve_monorepo_target: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_improve_flow.py
+++ b/tests/test_improve_flow.py
@@ -1125,9 +1125,7 @@ async def test_host_enumeration_dedups_absolute_model_wd(
     code = await run(make_config(improve_monorepo_target, flow_name="improve"))
 
     assert code == 0
-    recon = json.loads(
-        improve_artifact(improve_monorepo_target, "recon.json").read_text(encoding="utf-8")
-    )
+    recon = _load_improve_json(improve_monorepo_target, "recon.json")
     # The host command was deduped against the absolute model wd: no
     # re-admitted make-check record, no rejection noise.
     assert [command["id"] for command in recon["commands"]] == ["model-check"]


### PR DESCRIPTION
## Summary

Pins the working-directory spelling dedup regression from issue #654 at the `improve` entrypoint.

A model-cited recon command whose `working_directory` is spelled **absolutely** (e.g. `/repo/apps/billing`) is deduped against the host-enumerated record for the **same** directory spelled relatively (`apps/billing`). Result: exactly one command record and no rejection noise.

### Changes
- `tests/test_improve_flow.py`
  - Add `_dedup_test_command()` fixture helper to build a single recon command record (shared by both sides of the dedup).
  - Add `test_host_enumeration_dedups_absolute_model_wd` asserting the absolute-vs-relative working_directory dedup collapses to one `model-check` command with `command_rejections == []`.

## Test Plan
- [x] Targeted: `tests/test_improve_flow.py` — 110 passed
- [x] Full gate: `make check` — 3654 passed, 6 skipped

## Verification
- Round-2 daydream deep-precision review (fresh VM) run on this branch; both stacks clean, findings addressed. Trajectory uploaded to HF.

Closes #654
