### PR TITLE
[daydream] Gate primary structured output through the salvage check (Closes #669)

### DIFF
--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -871,7 +871,9 @@ async def run_agent(
         return paths: either this call site opted out of validation, or the
         value is salvageable (see ``_salvageable``).
         """
-        return not validate_structured_output or _salvageable(value, output_schema)
+        return not validate_structured_output or (
+            output_schema is not None and _salvageable(value, output_schema)
+        )
 
     if output_schema is not None and structured_result is not None and _usable(structured_result):
         return structured_result, result_continuation, aborted_reason

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -404,16 +404,18 @@ def _validates_schema(value: Any, schema: dict[str, Any]) -> bool:
 def _salvageable(value: Any, schema: dict[str, Any]) -> bool:
     """Return whether ``value`` is usable by a salvage-tolerant consumer.
 
-    Full validation is the baseline, but the fallback gate must not be
-    all-or-nothing: the per-stack parse, the recommendation verifier, and the
-    cross-stack merge all normalize partial agent output (dropping invalid
-    records rather than losing the whole payload, or accepting a bare item
-    array), so a dict whose required top-level fields are present — with
-    array-typed fields holding actual lists — is still returned for them to
-    salvage, and so is a bare JSON array, which ``phase_cross_stack_merge``
-    normalizes to its item list (a bare array can never validate against the
-    object-typed ``MERGED_ITEMS_SCHEMA``). Nested item validity is deliberately
-    not checked here: that is the consumers' salvage domain.
+    Full validation is the baseline, but the structured-output gate must not
+    be all-or-nothing: it guards the backend-supplied primary result and the
+    extraction fallback alike, and the per-stack parse, the recommendation
+    verifier, and the cross-stack merge all normalize partial agent output
+    (dropping invalid records rather than losing the whole payload, or
+    accepting a bare item array), so a dict whose required top-level fields
+    are present — with array-typed fields holding actual lists — is still
+    returned for them to salvage, and so is a bare JSON array, which
+    ``phase_cross_stack_merge`` normalizes to its item list (a bare array can
+    never validate against the object-typed ``MERGED_ITEMS_SCHEMA``). Nested
+    item validity is deliberately not checked here: that is the consumers'
+    salvage domain.
     """
     if _validates_schema(value, schema):
         return True
@@ -468,7 +470,7 @@ async def run_agent(
     persist_session: bool = True,
     wall_budget_s: float | None = None,
     tool_call_budget: int | None = None,
-    validate_fallback_schema: bool = True,
+    validate_structured_output: bool = True,
 ) -> tuple[str | Any, ContinuationToken | None, str | None]:
     """Run agent with the given prompt and return output plus continuation token.
 
@@ -514,9 +516,9 @@ async def run_agent(
         tool_call_budget: Opt-in ceiling on ToolStartEvents in this turn. When
             exceeded the loop breaks with the same abort/partial-return path.
             ``None`` (the default) means no tool-call ceiling.
-        validate_fallback_schema: When True (default), structured output — the
-            backend-supplied primary result and the extraction fallback alike —
-            is returned only when its shape is usable by downstream consumers
+        validate_structured_output: When True (default), structured output —
+            the backend-supplied primary result and the extraction fallback alike
+            — is returned only when its shape is usable by downstream consumers
             (see ``_salvageable``). Set False for call sites that re-validate
             or salvage wholesale downstream — the improve recon and plan
             author, whose downstream validators (``validate_recon_commands`` /
@@ -862,10 +864,16 @@ async def run_agent(
     finally:
         _state.current_backends.remove(backend)
 
-    if output_schema is not None and structured_result is not None and (
-        not validate_fallback_schema
-        or _salvageable(structured_result, output_schema)
-    ):
+    def _usable(value: Any) -> bool:
+        """Whether ``value`` passes the structured-output gate.
+
+        One predicate shared by the primary-result and extraction-fallback
+        return paths: either this call site opted out of validation, or the
+        value is salvageable (see ``_salvageable``).
+        """
+        return not validate_structured_output or _salvageable(value, output_schema)
+
+    if output_schema is not None and structured_result is not None and _usable(structured_result):
         return structured_result, result_continuation, aborted_reason
     if output_schema is not None:
         raw = "".join(output_parts)
@@ -880,16 +888,13 @@ async def run_agent(
         # rather than losing the whole payload, or accepting a bare item
         # array), so salvageable structures still reach them. Only output that
         # is unusable in any shape falls through to the plain-text return.
-        # Callers that salvage wholesale downstream (the improve recon, whose
-        # top-level schema is all-or-nothing but which re-validates per-command
-        # records via validate_recon_commands) opt out with
-        # validate_fallback_schema=False; the downstream validator remains the
-        # fail-closed enforcement point for those call sites.
+        # Callers that salvage wholesale downstream — the improve recon and
+        # the plan author, whose downstream validators (validate_recon_commands
+        # / assemble_plan) are the fail-closed enforcement point — opt out
+        # with validate_structured_output=False; the downstream validator
+        # remains the fail-closed enforcement point for those call sites.
         if raw.strip():
             parsed = extract_json(raw)
-            if parsed is not None and (
-                not validate_fallback_schema
-                or _salvageable(parsed, output_schema)
-            ):
+            if parsed is not None and _usable(parsed):
                 return parsed, result_continuation, aborted_reason
     return "".join(output_parts), result_continuation, aborted_reason

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -514,12 +514,13 @@ async def run_agent(
         tool_call_budget: Opt-in ceiling on ToolStartEvents in this turn. When
             exceeded the loop breaks with the same abort/partial-return path.
             ``None`` (the default) means no tool-call ceiling.
-        validate_fallback_schema: When True (default), the structured-output
-            extraction fallback only returns parsed JSON whose shape is usable
-            by downstream consumers (see ``_salvageable``). Set False for call
-            sites that re-validate or salvage wholesale downstream — the
-            improve recon, whose all-or-nothing top-level schema is
-            re-validated per-command by ``validate_recon_commands``.
+        validate_fallback_schema: When True (default), structured output — the
+            backend-supplied primary result and the extraction fallback alike —
+            is returned only when its shape is usable by downstream consumers
+            (see ``_salvageable``). Set False for call sites that re-validate
+            or salvage wholesale downstream — the improve recon and plan
+            author, whose downstream validators (``validate_recon_commands`` /
+            ``assemble_plan``) are the fail-closed enforcement point.
 
     Returns:
         Tuple of (output, continuation_token, budget_reason). Output is text

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -861,7 +861,10 @@ async def run_agent(
     finally:
         _state.current_backends.remove(backend)
 
-    if output_schema is not None and structured_result is not None:
+    if output_schema is not None and structured_result is not None and (
+        not validate_fallback_schema
+        or _salvageable(structured_result, output_schema)
+    ):
         return structured_result, result_continuation, aborted_reason
     if output_schema is not None:
         raw = "".join(output_parts)

--- a/daydream/backends/__init__.py
+++ b/daydream/backends/__init__.py
@@ -228,7 +228,9 @@ class ResultEvent:
     """Final event in the stream. Carries structured output and continuation token.
 
     Attributes:
-        structured_output: Schema-validated structured result, or None.
+        structured_output: Structured result as emitted by the backend,
+            schema-validated (or salvage-checked) at the run_agent return
+            path, or None.
         continuation: Optional continuation token for multi-turn flows.
         timestamp: ISO 8601 UTC timestamp populated at backend yield time.
     """

--- a/daydream/backends/__init__.py
+++ b/daydream/backends/__init__.py
@@ -230,7 +230,9 @@ class ResultEvent:
     Attributes:
         structured_output: Structured result as emitted by the backend,
             schema-validated (or salvage-checked) at the run_agent return
-            path, or None.
+            path when the caller opts in (``validate_structured_output``
+            True), or None. Callers that pass
+            ``validate_structured_output=False`` re-validate downstream.
         continuation: Optional continuation token for multi-turn flows.
         timestamp: ISO 8601 UTC timestamp populated at backend yield time.
     """

--- a/daydream/improve/orchestrator.py
+++ b/daydream/improve/orchestrator.py
@@ -1724,6 +1724,12 @@ async def _step_write_plans(ctx: FlowContext) -> None:
                     generation_prompt: str,
                 ) -> tuple[Any, str | None]:
                     async with phase_scope(DaydreamPhase.PLAN_WRITE):
+                        # assemble_plan re-validates the authored plan against
+                        # PLAN_AUTHOR_SCHEMA downstream and reports
+                        # AUTHOR_SCHEMA_INVALID (with a repair pass), so the
+                        # schema-violating structured result must reach it
+                        # un-gated — the downstream validator is the fail-closed
+                        # enforcement point, mirroring the recon.
                         output, _, aborted_reason = await run_agent(
                             backend,
                             _audit_repo(ctx),
@@ -1732,6 +1738,7 @@ async def _step_write_plans(ctx: FlowContext) -> None:
                             output_schema=PLAN_AUTHOR_SCHEMA,
                             read_only=True,
                             persist_session=False,
+                            validate_fallback_schema=False,
                         )
                     return output, aborted_reason
 

--- a/daydream/improve/orchestrator.py
+++ b/daydream/improve/orchestrator.py
@@ -447,7 +447,7 @@ async def _step_recon(ctx: FlowContext) -> Stop | None:
             output_schema=RECON_SCHEMA,
             read_only=True,
             persist_session=False,
-            validate_fallback_schema=False,
+            validate_structured_output=False,
         )
 
     total_candidates = 0
@@ -1738,7 +1738,7 @@ async def _step_write_plans(ctx: FlowContext) -> None:
                             output_schema=PLAN_AUTHOR_SCHEMA,
                             read_only=True,
                             persist_session=False,
-                            validate_fallback_schema=False,
+                            validate_structured_output=False,
                         )
                     return output, aborted_reason
 

--- a/tests/test_agent_structured_primary_validation.py
+++ b/tests/test_agent_structured_primary_validation.py
@@ -2,7 +2,8 @@
 gate the backend-supplied result through the same ``_salvageable`` check the
 extraction fallback applies (honoring ``validate_structured_output``).
 
-Pins the agent.py:864 asymmetry: before this module, the primary path returned
+Pins the agent.py:878 asymmetry (the primary gate; ``_usable`` lives at 867):
+before this module, the primary path returned
 ``structured_result`` unvalidated whenever ``output_schema`` was set and the
 backend supplied a non-None result — so a codex/pi payload that was valid JSON
 but violated ``output_schema`` leaked out unvalidated. These tests drive
@@ -44,7 +45,7 @@ async def test_primary_path_schema_violation_degrades_to_fallback(tmp_path) -> N
 
 async def test_primary_path_unusable_text_and_structured_degrade_to_plain_text(tmp_path) -> None:
     # The reachable codex/pi route: structured output is parsed from the agent
-    # text itself (codex.py:647-648, pi.py:910), so text and structured carry
+    # text itself (codex.py:641, pi.py:910), so text and structured carry
     # the same payload. When that payload violates output_schema, both gates
     # reject and run_agent degrades to the plain-text string — not the
     # unvalidated dict that leaked out before the primary gate existed.

--- a/tests/test_agent_structured_primary_validation.py
+++ b/tests/test_agent_structured_primary_validation.py
@@ -1,6 +1,6 @@
 """Real-path tests: the run_agent primary structured-output return path must
 gate the backend-supplied result through the same ``_salvageable`` check the
-extraction fallback applies (honoring ``validate_fallback_schema``).
+extraction fallback applies (honoring ``validate_structured_output``).
 
 Pins the agent.py:864 asymmetry: before this module, the primary path returned
 ``structured_result`` unvalidated whenever ``output_schema`` was set and the
@@ -42,6 +42,21 @@ async def test_primary_path_schema_violation_degrades_to_fallback(tmp_path) -> N
     assert isinstance(result, dict)
 
 
+async def test_primary_path_unusable_text_and_structured_degrade_to_plain_text(tmp_path) -> None:
+    # The reachable codex/pi route: structured output is parsed from the agent
+    # text itself (codex.py:647-648, pi.py:910), so text and structured carry
+    # the same payload. When that payload violates output_schema, both gates
+    # reject and run_agent degrades to the plain-text string — not the
+    # unvalidated dict that leaked out before the primary gate existed.
+    payload = {"line": 3}
+    backend = MockBackend([TextEvent(text=json.dumps(payload)),
+                           ResultEvent(structured_output=payload, continuation=None)])
+    result, _, _ = await run_agent(
+        backend, tmp_path, "go", phase=DaydreamPhase.REVIEW, output_schema=_FILE_SCHEMA)
+    assert result == '{"line": 3}'   # identical invalid JSON in text and structured
+    assert isinstance(result, str)
+
+
 async def test_primary_path_salvages_partial_dict(tmp_path) -> None:
     schema = {"type": "object", "required": ["verdicts"], "properties": {
         "verdicts": {"type": "array", "items": {
@@ -50,8 +65,10 @@ async def test_primary_path_salvages_partial_dict(tmp_path) -> None:
         {"issue_id": 1, "verdict": "consistent", "evidence": "matches"},
         {"issue_id": 2, "verdict": "bogus"},  # nested item missing "evidence"
     ]}
-    backend = MockBackend([TextEvent(text=json.dumps(partial)),
-                           ResultEvent(structured_output=partial, continuation=None)])
+    # No TextEvent: a mirrored text would let the fallback re-extract the same
+    # value, so this would pass even without the primary gate. Only the primary
+    # return path can yield ``partial`` here.
+    backend = MockBackend([ResultEvent(structured_output=partial, continuation=None)])
     result, _, _ = await run_agent(
         backend, tmp_path, "go", phase=DaydreamPhase.VERIFY, output_schema=schema)
     assert result == partial          # salvage-tolerant: nested validity not gated
@@ -62,19 +79,21 @@ async def test_primary_path_bare_array_reaches_merge_shape(tmp_path) -> None:
     schema = {"type": "object", "required": ["items"], "properties": {
         "items": {"type": "array", "items": {"type": "object"}}}}
     items = [{"id": 1, "description": "x"}]
-    backend = MockBackend([TextEvent(text=json.dumps(items)),
-                           ResultEvent(structured_output=items, continuation=None)])
+    # No TextEvent: a mirrored text would let the fallback re-extract the same
+    # value, so this would pass even without the primary gate. Only the primary
+    # return path can yield ``items`` here.
+    backend = MockBackend([ResultEvent(structured_output=items, continuation=None)])
     result, _, _ = await run_agent(
         backend, tmp_path, "merge", phase=DaydreamPhase.DEEP, output_schema=schema)
     assert result == items            # bare array is a salvageable form
     assert isinstance(result, list)
 
 
-async def test_primary_path_respects_validate_fallback_schema_false(tmp_path) -> None:
+async def test_primary_path_respects_validate_structured_output_false(tmp_path) -> None:
     backend = MockBackend([ResultEvent(structured_output={"line": 3}, continuation=None)])
     result, _, _ = await run_agent(
         backend, tmp_path, "go", phase=DaydreamPhase.RECON,
-        output_schema=_FILE_SCHEMA, validate_fallback_schema=False)
+        output_schema=_FILE_SCHEMA, validate_structured_output=False)
     assert result == {"line": 3}      # opt-out passes through unvalidated, as today
     assert isinstance(result, dict)
 

--- a/tests/test_agent_structured_primary_validation.py
+++ b/tests/test_agent_structured_primary_validation.py
@@ -1,0 +1,88 @@
+"""Real-path tests: the run_agent primary structured-output return path must
+gate the backend-supplied result through the same ``_salvageable`` check the
+extraction fallback applies (honoring ``validate_fallback_schema``).
+
+Pins the agent.py:864 asymmetry: before this module, the primary path returned
+``structured_result`` unvalidated whenever ``output_schema`` was set and the
+backend supplied a non-None result — so a codex/pi payload that was valid JSON
+but violated ``output_schema`` leaked out unvalidated. These tests drive
+``run_agent`` (the single-agent production entrypoint) with the shared
+``MockBackend``, mocking only the ``Backend`` protocol seam — the established
+real-path pattern in ``test_agent_structured_render.py`` /
+``test_agent_recorder_integration.py``.
+"""
+
+from __future__ import annotations
+
+import json
+
+from daydream.agent import run_agent
+from daydream.backends import ResultEvent, TextEvent
+from daydream.trajectory import DaydreamPhase
+from tests.test_agent_recorder_integration import MockBackend
+
+_FILE_SCHEMA = {
+    "type": "object",
+    "required": ["file"],
+    "properties": {"file": {"type": "string"}},
+}
+
+
+async def test_primary_path_schema_violation_degrades_to_fallback(tmp_path) -> None:
+    backend = MockBackend([
+        TextEvent(text='{"file": "src/a.py"}'),
+        ResultEvent(structured_output={"line": 3}, continuation=None),
+    ])
+    result, _, _ = await run_agent(
+        backend, tmp_path, "go", phase=DaydreamPhase.REVIEW, output_schema=_FILE_SCHEMA
+    )
+    # {"line": 3} is missing required "file" -> rejected; the fallback
+    # re-extracts the valid {"file": "src/a.py"} from the agent text.
+    assert result == {"file": "src/a.py"}
+    assert isinstance(result, dict)
+
+
+async def test_primary_path_salvages_partial_dict(tmp_path) -> None:
+    schema = {"type": "object", "required": ["verdicts"], "properties": {
+        "verdicts": {"type": "array", "items": {
+            "type": "object", "required": ["issue_id", "verdict", "evidence"]}}}}
+    partial = {"verdicts": [
+        {"issue_id": 1, "verdict": "consistent", "evidence": "matches"},
+        {"issue_id": 2, "verdict": "bogus"},  # nested item missing "evidence"
+    ]}
+    backend = MockBackend([TextEvent(text=json.dumps(partial)),
+                           ResultEvent(structured_output=partial, continuation=None)])
+    result, _, _ = await run_agent(
+        backend, tmp_path, "go", phase=DaydreamPhase.VERIFY, output_schema=schema)
+    assert result == partial          # salvage-tolerant: nested validity not gated
+    assert isinstance(result, dict)
+
+
+async def test_primary_path_bare_array_reaches_merge_shape(tmp_path) -> None:
+    schema = {"type": "object", "required": ["items"], "properties": {
+        "items": {"type": "array", "items": {"type": "object"}}}}
+    items = [{"id": 1, "description": "x"}]
+    backend = MockBackend([TextEvent(text=json.dumps(items)),
+                           ResultEvent(structured_output=items, continuation=None)])
+    result, _, _ = await run_agent(
+        backend, tmp_path, "merge", phase=DaydreamPhase.DEEP, output_schema=schema)
+    assert result == items            # bare array is a salvageable form
+    assert isinstance(result, list)
+
+
+async def test_primary_path_respects_validate_fallback_schema_false(tmp_path) -> None:
+    backend = MockBackend([ResultEvent(structured_output={"line": 3}, continuation=None)])
+    result, _, _ = await run_agent(
+        backend, tmp_path, "go", phase=DaydreamPhase.RECON,
+        output_schema=_FILE_SCHEMA, validate_fallback_schema=False)
+    assert result == {"line": 3}      # opt-out passes through unvalidated, as today
+    assert isinstance(result, dict)
+
+
+async def test_primary_path_valid_structured_output_returned(tmp_path) -> None:
+    schema = {"type": "object", "required": ["issues"], "properties": {"issues": {"type": "array"}}}
+    payload = {"issues": [{"id": 1, "description": "Fix type hints", "file": "app.py", "line": 5}]}
+    backend = MockBackend([ResultEvent(structured_output=payload, continuation=None)])
+    result, _, _ = await run_agent(
+        backend, tmp_path, "Parse", phase=DaydreamPhase.REVIEW, output_schema=schema)
+    assert result == payload          # valid codex-shaped output returned unchanged

--- a/tests/test_agent_structured_render.py
+++ b/tests/test_agent_structured_render.py
@@ -201,8 +201,8 @@ async def test_structured_fallback_validates_against_output_schema(
 async def test_structured_fallback_recon_not_gated_all_or_nothing(
     monkeypatch, tmp_path
 ) -> None:
-    """RECON's fallback skips the fallback schema gate via the caller-declared
-    ``validate_fallback_schema=False`` kwarg (not a phase carve-out): the
+    """RECON's fallback skips the structured-output gate via the caller-declared
+    ``validate_structured_output=False`` kwarg (not a phase carve-out): the
     top-level RECON schema requires languages/commands/conventions/intent_docs,
     but the orchestrator salvages per-command records downstream via
     validate_recon_commands() and defaults missing model fields to []. An
@@ -228,7 +228,7 @@ async def test_structured_fallback_recon_not_gated_all_or_nothing(
     ])
     result, _, _ = await run_agent(
         backend, tmp_path, "go", phase=DaydreamPhase.RECON, output_schema=schema,
-        validate_fallback_schema=False,
+        validate_structured_output=False,
     )
     assert result == {"commands": [{"command": "make test"}]}
     assert isinstance(result, dict)


### PR DESCRIPTION
## Summary

Addresses out-of-scope finding in `daydream/backends/codex.py` (issue #669): the codex backend populates `ResultEvent.structured_output` from `json.loads` of raw model text with no schema check, feeding schema-violating dicts to `run_agent`'s unvalidated primary return path.

This PR unifies the structured-output gate behind a shared predicate and routes the primary return path through it, so schema validation runs when the caller opts in via `validate_structured_output`.

## Changes
- `daydream/agent.py` — gate primary structured output through the salvage check; unify the structured-output gate via a shared predicate; narrow `output_schema` in the `_usable` closure for typecheck; reconcile structured-output validation docstrings
- `daydream/backends/__init__.py` — clarify that `ResultEvent.structured_output` validation only runs when the caller opts in via `validate_structured_output`
- `daydream/improve/orchestrator.py` — let the plan author validate its schema downstream
- `tests/test_agent_structured_primary_validation.py` — add real-path primary-validation coverage
- `tests/test_agent_structured_render.py` — update for the unified predicate

## Test Plan
- [x] Full gate (`make check`): ruff + mypy + 3660 passed / 6 skipped / 0 failed (exit 0)

## Reviews
- Two sequential daydream deep-precision reviews on fresh exe.dev VMs (rounds 1 & 2) — all findings addressed.

Closes #669