### PR TITLE
[daydream] Preserve ASCII quotes in the pi fix-apply step (Closes #687)

### DIFF
--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -3224,7 +3224,7 @@ async def _step_test(ctx: FlowContext) -> Stop | None:
         ctx.work,
         ref=ctx.data.get("pre_fix_ref") or "HEAD",
         preexisting_untracked=ctx.data.get("pre_fix_untracked"),
-        trustworthy=bool(ctx.data.get("pre_fix_snapshot_captured", True)),
+        trustworthy=bool(ctx.data.get("pre_fix_snapshot_captured", False)),
         skip_reason=(
             "Smart-quote scrub skipped after test healing: no trustworthy "
             "pre-fix snapshot; HEAD may include edits present before the fix pass."
@@ -3332,10 +3332,29 @@ async def _step_fix_items(ctx: FlowContext) -> Stop | None:
     fix_backend = ctx.backend_for("fix")
 
     # Issue #543: snapshot the pre-fix untracked set so the feedback commit step
-    # can exclude user scratch files from the daydream commit. list_untracked
-    # soft-fails to [] on GitError, so set(...) is already the fail-open empty
-    # snapshot (deterministic stage = all untracked), mirroring _step_fix.
-    pre_fix_untracked = set(git_ops.list_untracked(ctx.work.repo))
+    # can exclude user scratch files from the daydream commit, and (Issue #687)
+    # snapshot the tracked tree too so the smart-quote scrub below can
+    # attribute agent-added lines against the pre-fix state instead of bare
+    # HEAD. Feedback mode runs in-place on the user's checkout, so HEAD may
+    # include uncommitted tracked user edits; without the snapshot the scrub
+    # would diff-attribute those user smart-quote lines as agent-added and
+    # rewrite them. Mirrors _step_fix. list_untracked soft-fails to [] on
+    # GitError, so set(...) is already the fail-open empty snapshot.
+    try:
+        pre_fix_snapshot = git_ops.stash_create(ctx.work.repo)
+        pre_fix_untracked = set(git_ops.list_untracked(ctx.work.repo))
+    except (git_ops.GitError, OSError) as exc:
+        print_warning(
+            console,
+            f"Could not snapshot tree before feedback fixes: {exc}",
+        )
+        pre_fix_snapshot = None
+        pre_fix_untracked = set()
+        pre_fix_snapshot_captured = False
+    else:
+        pre_fix_snapshot_captured = True
+    pre_fix_ref = pre_fix_snapshot or "HEAD"
+    ctx.data["pre_fix_ref"] = pre_fix_ref
     ctx.data["pre_fix_untracked"] = pre_fix_untracked
 
     # Fix sequentially to avoid concurrent access to one mutable backend.
@@ -3367,7 +3386,13 @@ async def _step_fix_items(ctx: FlowContext) -> Stop | None:
     # deep fix pass applies.
     _scrub_smart_quotes(
         ctx.work,
+        ref=pre_fix_ref,
         preexisting_untracked=pre_fix_untracked,
+        trustworthy=pre_fix_snapshot_captured,
+        skip_reason=(
+            "Smart-quote scrub skipped after feedback fix: no trustworthy "
+            "pre-fix snapshot; HEAD may include user edits present before the fix pass."
+        ),
     )
 
     ctx.data["results"] = results

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -2822,6 +2822,62 @@ def _record_unconfined_finding_failure(
     return fix_failures, fix_key
 
 
+def _scrub_smart_quotes(
+    work: WorkContext,
+    *,
+    changed_files: list[str] | None = None,
+    ref: str = "HEAD",
+    preexisting_untracked: set[str] | None = None,
+    trustworthy: bool = True,
+    skip_reason: str = "Smart-quote scrub skipped: no trustworthy pre-fix snapshot.",
+) -> None:
+    """Best-effort ASCII-quote scrub of changed files about to be committed (#687).
+
+    Rewrites typographic smart quotes (U+201C/U+201D/U+2018/U+2019) back to ASCII
+    straight quotes in the given ``changed_files`` set, or — when ``changed_files``
+    is None — in the set freshly enumerated against ``ref`` with
+    ``preexisting_untracked`` filtered out. The driver attributes the agent-added
+    lines against ``ref`` (only those lines are rewritten; pre-existing smart
+    quotes in baseline content are preserved). Shared by every
+    agent-write-then-commit path: the deep fix pass, the deep test-heal pass, and
+    the pr-feedback fix step.
+
+    Fail-open by design, never a gate: a missing, binary, or generated file is
+    skipped by the driver, an enumeration or attribution ``GitError`` degrades to
+    a warning, and an untrustworthy pre-fix base (``trustworthy=False``) skips
+    with ``skip_reason``. The scrub must never abort a run or block a commit.
+    """
+    from daydream import git_ops
+
+    if not trustworthy:
+        print_warning(console, skip_reason)
+        return
+    if changed_files is None:
+        try:
+            changed_files = git_ops.changed_files_against(
+                work.repo, ref, preexisting_untracked=preexisting_untracked,
+            )
+        except git_ops.GitError as exc:
+            print_warning(
+                console,
+                f"Could not enumerate changed files for smart-quote scrub: {exc}",
+            )
+            return
+    try:
+        scrubbed = scrub_smart_quotes_changed_files(
+            work.repo, changed_files, pre_fix_ref=ref,
+        )
+    except git_ops.GitError as exc:
+        # Attribution diff could not be computed: fail-open, never abort.
+        print_warning(console, f"Could not scrub smart quotes in changed files: {exc}")
+        return
+    if scrubbed:
+        print_warning(
+            console,
+            "Normalized smart quotes to ASCII in: " + ", ".join(sorted(scrubbed)),
+        )
+
+
 async def _step_fix(ctx: FlowContext) -> Stop | None:
     """Parallel fix pass: pre-fix snapshot capture, phase_fix_parallel, failure protection."""
     from daydream import git_ops
@@ -3037,6 +3093,10 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
     # double-revert) and BEFORE the quality gate (which then measures the
     # now-scoped edited set).
     pre_fix_ref = pre_fix_snapshot or "HEAD"
+    # Thread the pre-fix base + snapshot trust into the test-heal scrub
+    # (_step_test) so it measures the same base on the same trust gate.
+    ctx.data["pre_fix_ref"] = pre_fix_ref
+    ctx.data["pre_fix_snapshot_captured"] = pre_fix_snapshot_captured
     residual_guard_result = _revert_out_of_scope_edits(
         work,
         pre_fix_ref=pre_fix_ref,
@@ -3055,24 +3115,38 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
     # typographic finding on every re-review. Scrub the same changed-file set
     # the residual net and quality gate use (pre_fix_ref base) back to ASCII
     # straight quotes BEFORE the quality gate measures the tree, so the gate
-    # and the commit stage the final scrubbed bytes. Best-effort, never a
-    # gate: a missing, binary, or generated file is skipped, and a changed-
-    # file enumeration failure degrades to a warning rather than aborting the
-    # run or blocking the commit.
+    # and the commit stage the final scrubbed bytes. Only the lines the fix
+    # pass added are normalized (attributed from the working-tree diff against
+    # the same base), so pre-existing smart quotes in baseline content are
+    # never rewritten. Best-effort, never a gate: a missing, binary, or
+    # generated file is skipped, a write failure degrades to a warning, and a
+    # changed-file enumeration failure degrades to a warning rather than
+    # aborting the run or blocking the commit. The scrub and the quality gate
+    # below both enumerate the same post-residual tree with no mutation between
+    # them, so enumerate the changed-file set ONCE (Issue #336): one two-
+    # subprocess enumeration per fix run instead of two byte-identical ones,
+    # collapsing the repeated try/except -> warn/None shape.
     try:
-        scrubbed = scrub_smart_quotes_changed_files(
-            work.repo,
-            git_ops.changed_files_against(
-                work.repo, pre_fix_ref, preexisting_untracked=pre_fix_untracked
-            ),
+        changed_after_fix = git_ops.changed_files_against(
+            work.repo, pre_fix_ref, preexisting_untracked=pre_fix_untracked
         )
     except git_ops.GitError as exc:
-        print_warning(console, f"Could not scrub smart quotes in changed files: {exc}")
-        scrubbed = []
-    if scrubbed:
-        print_warning(
-            console,
-            "Normalized smart quotes to ASCII in: " + ", ".join(sorted(scrubbed)),
+        print_warning(console, f"Could not enumerate changed files after fix: {exc}")
+        changed_after_fix = None
+    # Trust gate: when the pre-fix snapshot could not be captured, pre_fix_ref
+    # falls back to HEAD, which may include user edits present before the fix
+    # pass — scrubbing them would rewrite the user's in-progress work. Match the
+    # sibling guards: fail-open, skip with a warning.
+    if changed_after_fix is not None:
+        _scrub_smart_quotes(
+            work,
+            changed_files=changed_after_fix,
+            ref=pre_fix_ref,
+            trustworthy=pre_fix_snapshot_captured,
+            skip_reason=(
+                "Smart-quote scrub skipped: no trustworthy pre-fix snapshot; "
+                "HEAD may include edits present before the fix pass."
+            ),
         )
     # Issue #315: post-fix anti-degradation gate over the files the fix phase
     # edited. Tree is post-fix here (every applied or budget-preserved fix is
@@ -3098,15 +3172,15 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
     # flagged missing-baseline entries rather than computing an undefined delta.
     quality_candidates: set[str] | None
     if quality_gate_enabled:
-        try:
-            changed_after_fix = git_ops.changed_files_against(
-                work.repo, pre_fix_ref, preexisting_untracked=pre_fix_untracked
-            )
+        if changed_after_fix is not None:
             quality_candidates = _py_only(changed_after_fix)
             quality_candidates |= _py_only(
                 item["file"] for item in ctx.data["items"] if item.get("file")
             )
-        except git_ops.GitError:
+        else:
+            # Enumeration failed: gate records an explicit ``unavailable`` verdict
+            # rather than gating on a partial candidate set (same fail-open
+            # contract as before).
             quality_candidates = None
     else:
         quality_candidates = set()
@@ -3141,6 +3215,21 @@ async def _step_test(ctx: FlowContext) -> Stop | None:
     if not proceed:
         print_warning(console, "Tests failed after fix attempt.")
         return Stop(1)
+    # Issue #687: test healing (phase_test_and_heal) writes agent edits after
+    # _step_fix's scrub, so re-scrub the tree about to be committed on the same
+    # pre_fix_ref base and trust gate (skip with a warning when the pre-fix
+    # snapshot could not be captured). Idempotent for the already-scrubbed fix
+    # edits; catches the test-heal edits before _step_commit stages the tree.
+    _scrub_smart_quotes(
+        ctx.work,
+        ref=ctx.data.get("pre_fix_ref") or "HEAD",
+        preexisting_untracked=ctx.data.get("pre_fix_untracked"),
+        trustworthy=bool(ctx.data.get("pre_fix_snapshot_captured", True)),
+        skip_reason=(
+            "Smart-quote scrub skipped after test healing: no trustworthy "
+            "pre-fix snapshot; HEAD may include edits present before the fix pass."
+        ),
+    )
     return None
 
 
@@ -3270,6 +3359,16 @@ async def _step_fix_items(ctx: FlowContext) -> Stop | None:
             f"All {len(failed)} fix(es) failed. Aborting before commit.",
         )
         return Stop(1)
+
+    # Issue #687: the pr-feedback fix path (phase_fix) writes agent edits that
+    # _step_commit_push stages and pushes with no deterministic scrub. Scrub the
+    # changed files (vs HEAD, with pre-fix untracked filtered out) back to ASCII
+    # straight quotes before the commit — same best-effort, never-a-gate guard the
+    # deep fix pass applies.
+    _scrub_smart_quotes(
+        ctx.work,
+        preexisting_untracked=pre_fix_untracked,
+    )
 
     ctx.data["results"] = results
     ctx.data["successful"] = successful

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -123,6 +123,7 @@ from daydream.phases import (
     phase_verify_recommendations,
     severity_sorted,
 )
+from daydream.quote_scrub import scrub_smart_quotes_changed_files
 from daydream.supervision import (
     RuleBasedSupervisor,
     apply_findings_verdicts,
@@ -3048,6 +3049,31 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
         # Fail-close to match the generated-file guard: an unreverted
         # out-of-scope edit must never reach the commit step.
         return Stop(1)
+    # Issue #687: ASCII-quote normalization on the fix path. A fix agent that
+    # writes typographic smart quotes (U+201C/U+201D/U+2018/U+2019) into a
+    # changed file would otherwise commit those bytes and re-trigger the same
+    # typographic finding on every re-review. Scrub the same changed-file set
+    # the residual net and quality gate use (pre_fix_ref base) back to ASCII
+    # straight quotes BEFORE the quality gate measures the tree, so the gate
+    # and the commit stage the final scrubbed bytes. Best-effort, never a
+    # gate: a missing, binary, or generated file is skipped, and a changed-
+    # file enumeration failure degrades to a warning rather than aborting the
+    # run or blocking the commit.
+    try:
+        scrubbed = scrub_smart_quotes_changed_files(
+            work.repo,
+            git_ops.changed_files_against(
+                work.repo, pre_fix_ref, preexisting_untracked=pre_fix_untracked
+            ),
+        )
+    except git_ops.GitError as exc:
+        print_warning(console, f"Could not scrub smart quotes in changed files: {exc}")
+        scrubbed = []
+    if scrubbed:
+        print_warning(
+            console,
+            "Normalized smart quotes to ASCII in: " + ", ".join(sorted(scrubbed)),
+        )
     # Issue #315: post-fix anti-degradation gate over the files the fix phase
     # edited. Tree is post-fix here (every applied or budget-preserved fix is
     # intact); a regression is flagged and surfaced, never fatal.

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -1689,6 +1689,12 @@ confirmed author intent below overrides it). Do not override documented intent
 to satisfy the finding; stop and report the conflict rather than overriding
 documented intent. Treat low/medium-confidence findings with extra skepticism
 here.
+
+Preserve ASCII quotes verbatim in code and comments. Never convert existing
+ASCII ``''`` / ``""`` into typographic smart quotes (``”`` ``“`` ``’`` ``‘``),
+and never introduce smart quotes when writing new code or comments — use plain
+ASCII straight quotes so the committed tree stays byte-clean and re-reviews do
+not re-surface a typographic finding.
 """
     + GENERATED_FILES_PROMPT_RULE
     + "\n"

--- a/daydream/quote_scrub.py
+++ b/daydream/quote_scrub.py
@@ -16,7 +16,7 @@ from collections.abc import Iterable
 from pathlib import Path
 
 from daydream.generated_files import is_generated_file
-from daydream.git_ops import diff_worktree_against
+from daydream.git_ops import GitError, diff_worktree_against
 
 # U+201C LEFT DOUBLE QUOTATION MARK / U+201D RIGHT DOUBLE QUOTATION MARK -> "
 # U+2018 LEFT SINGLE QUOTATION MARK / U+2019 RIGHT SINGLE QUOTATION MARK -> '
@@ -24,6 +24,28 @@ _SMART_QUOTE_TABLE = str.maketrans({"\u201c": '"', "\u201d": '"', "\u2018": "'",
 
 # Unified-diff hunk header: @@ -<old_start>[,<old_count>] +<new_start>[,<new_count>] @@
 _HUNK_HEADER = re.compile(r"^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@")
+
+# Extended header lines git emits in place of hunks (binary/rename/mode-only
+# diffs). Their presence marks the output as git-structured even without ``+++``
+# file headers; anything else in a header-less diff is an external diff driver's
+# output, which cannot be attributed.
+_NON_HUNK_DIFF_LINES = (
+    "diff --git ",
+    "index ",
+    "Binary files ",
+    "--- ",
+    '--- "',
+    "similarity index ",
+    "rename from ",
+    "rename to ",
+    "copy from ",
+    "copy to ",
+    "old mode ",
+    "new mode ",
+    "deleted file mode ",
+    "new file mode ",
+    "\\ No newline at end of file",
+)
 
 
 def normalize_smart_quotes(text: str) -> str:
@@ -36,28 +58,85 @@ def normalize_smart_quotes(text: str) -> str:
     return text.translate(_SMART_QUOTE_TABLE)
 
 
+def _header_path(raw: str) -> str | None:
+    """Extract the repo-relative path from a ``+++`` file-header line.
+
+    Handles the plain ``+++ b/rel/path`` form, git's ``core.quotepath`` quoted
+    form (``+++ "b/caf\\303\\251.go"``), and ``diff.noprefix`` output (``+++
+    rel/path`` with no ``b/`` prefix). A trailing tab — git appends one after
+    space-containing paths — is stripped first, or the extracted key would not
+    match the caller's path and the file would silently fall through to the
+    whole-file normalization branch. Returns None for the ``+++ /dev/null``
+    deletion header.
+    """
+    if not raw.startswith("+++ "):
+        return None
+    tail = raw[4:].rstrip("\t")
+    if tail.startswith('"') and tail.endswith('"'):
+        tail = _unquote_git_path(tail)
+    if tail.startswith("b/"):
+        return tail[2:]
+    if tail == "/dev/null":
+        return None
+    return tail
+
+
+def _attribution_unusable(diff_text: str) -> bool:
+    """True when a non-empty *diff_text* carries no parseable unified-diff structure.
+
+    A working-tree diff restricted to real paths must contain ``+++`` file
+    headers; their absence means the text came from an external diff driver
+    rather than git's unified format, so added-line attribution is impossible —
+    and falling back to whole-file normalization would rewrite baseline smart
+    quotes in tracked files. Binary-only, rename-only, and mode-change-only
+    diffs (git's extended header lines, no hunks) are exempt: their files fail
+    UTF-8 decoding or carry no added lines, and untracked siblings still
+    normalize whole-file.
+    """
+    lines = diff_text.splitlines()
+    if not any(line.strip() for line in lines):
+        return False
+    if any(line.startswith("+++") for line in lines):
+        return False
+    return not all(not line or line.startswith(_NON_HUNK_DIFF_LINES) for line in lines)
+
+
 def _added_line_numbers(diff_text: str) -> dict[str, set[int]]:
     """Map repo-relative paths in a working-tree diff to the new-file line
     numbers the diff adds.
 
-    Parses ``git diff <ref>`` unified-diff output: within each ``+++ b/`` file
+    Parses ``git diff <ref>`` unified-diff output: within each ``+++`` file
     section it tracks the new-file line counter and records every ``+`` line.
     Context lines advance the counter; deletions (``-``) and header lines do
     not, matching how git numbers the new file. Every file present in the diff
     is a key (mapping to the possibly-empty set of added lines); files absent
     from the diff (untracked new files) are not keys at all.
+
+    A ``+++`` line is treated as a file header only when the previous line was
+    its ``--- `` counterpart (git always emits the pair adjacently), so an added
+    line whose content starts with ``++ b/`` — rendered identically to a header
+    — is parsed as content and cannot re-key the current file.
     """
     added: dict[str, set[int]] = {}
     current: str | None = None
     new_line = 0
+    prev_old_header = False
     for raw in diff_text.splitlines():
-        if raw.startswith("+++ b/"):
-            current = raw[6:]
-            added.setdefault(current, set())
-            new_line = 0
-        elif current is None:
+        if raw.startswith(("--- ", '--- "')):
+            prev_old_header = True
             continue
-        elif raw.startswith("@@"):
+        if raw.startswith("+++ ") and prev_old_header:
+            prev_old_header = False
+            path = _header_path(raw)
+            if path is not None:
+                current = path
+                added.setdefault(current, set())
+                new_line = 0
+            continue
+        prev_old_header = False
+        if current is None:
+            continue
+        if raw.startswith("@@"):
             match = _HUNK_HEADER.match(raw)
             if match:
                 new_line = int(match.group(2))
@@ -68,6 +147,46 @@ def _added_line_numbers(diff_text: str) -> dict[str, set[int]]:
             new_line += 1
         # "-" deletions and mode/header lines advance no new-file counter.
     return added
+
+
+def _unquote_git_path(quoted: str) -> str:
+    """Unquote a ``core.quotepath``-quoted path from ``git diff`` output.
+
+    Git quotes non-ASCII path names as C-style string literals, e.g.
+    ``"b/caf\303\251.go"`` (octal escapes of the raw UTF-8 bytes). Strips the
+    surrounding quotes, decodes the escapes back to bytes, and decodes those as
+    UTF-8. Non-quoted input passes through unchanged.
+    """
+    if not (quoted.startswith('"') and quoted.endswith('"')):
+        return quoted
+    inner = quoted[1:-1]
+    out = bytearray()
+    i = 0
+    while i < len(inner):
+        ch = inner[i]
+        if ch == "\\" and i + 1 < len(inner):
+            nxt = inner[i + 1]
+            if nxt == "\\":
+                out.append(ord("\\"))
+                i += 2
+            elif nxt == '"':
+                out.append(ord('"'))
+                i += 2
+            elif nxt in "01234567":
+                val = 0
+                j = i + 1
+                while j < len(inner) and j < i + 4 and inner[j] in "01234567":
+                    val = val * 8 + int(inner[j])
+                    j += 1
+                out.append(val)
+                i = j
+            else:
+                out.append(ord("\\"))
+                i += 1
+        else:
+            out.extend(ch.encode("utf-8"))
+            i += 1
+    return out.decode("utf-8")
 
 
 def _normalize_added_lines(text: str, added: set[int]) -> str:
@@ -94,6 +213,11 @@ def _atomic_write_bytes(path: Path, data: bytes) -> None:
     Raises:
         OSError: On any write failure (after cleaning up the temp file).
     """
+    if path.is_symlink():
+        # The driver reads through the link (read_bytes/stat follow it), so
+        # os.replace here would swap the link's directory entry for a regular
+        # file and destroy the symlink. Write to the link target instead.
+        path = path.resolve()
     fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=path.name + ".", suffix=".tmp")
     try:
         try:
@@ -102,6 +226,8 @@ def _atomic_write_bytes(path: Path, data: bytes) -> None:
             mode = None
         with os.fdopen(fd, "wb") as tmp:
             tmp.write(data)
+            tmp.flush()
+            os.fsync(tmp.fileno())
         if mode is not None:
             os.chmod(tmp_name, mode)
         os.replace(tmp_name, path)
@@ -150,14 +276,34 @@ def scrub_smart_quotes_changed_files(
         caller's responsibility; order here follows the input order).
 
     Raises:
-        GitError: If the attribution diff cannot be computed; callers treat
-            this as fail-open (degrade to a warning, never abort a run).
+        GitError: If the attribution diff cannot be computed — including when
+            the diff output contains non-UTF-8 bytes (a changed file with
+            binary/latin-1 content) and cannot be decoded; callers treat this
+            as fail-open (degrade to a warning, never abort a run).
     """
     changed = list(changed_files)
     if pre_fix_ref is None:
         added_lines: dict[str, set[int]] | None = None
     else:
-        added_lines = _added_line_numbers(diff_worktree_against(repo, pre_fix_ref, changed))
+        try:
+            diff_text = diff_worktree_against(repo, pre_fix_ref, changed)
+        except UnicodeDecodeError as exc:
+            # A changed file with non-UTF-8 content makes the attribution diff
+            # undecodable. The diff cannot be computed: degrade to the
+            # documented GitError fail-open path instead of crashing the run.
+            raise GitError(
+                f"attribution diff against {pre_fix_ref} is not valid UTF-8: {exc}"
+            ) from exc
+        if _attribution_unusable(diff_text):
+            # Not unified-diff output (external diff driver, ...): attribution
+            # is impossible, and whole-file normalization would rewrite baseline
+            # smart quotes in tracked files. Fail open through the caller's
+            # GitError guard instead.
+            raise GitError(
+                "attribution diff for smart-quote scrub is not unified-diff output "
+                f"(external diff driver?): {diff_text[:120]!r}"
+            )
+        added_lines = _added_line_numbers(diff_text)
     scrubbed: list[str] = []
     for path in changed:
         if path.startswith(".daydream/"):

--- a/daydream/quote_scrub.py
+++ b/daydream/quote_scrub.py
@@ -5,19 +5,25 @@ into code comments and string literals. Left alone, those bytes land in the
 committed tree and every later review re-surfaces the same typographic finding.
 This module provides a deterministic, backend-agnostic scrub: a pure
 ``str.translate`` transform over the four smart-quote code points plus a
-changed-file driver that rewrites only the changed-file set in place.
+changed-file driver that rewrites only the lines the fix pass added, in place.
 """
 
+import os
+import re
+import stat
+import tempfile
 from collections.abc import Iterable
 from pathlib import Path
 
 from daydream.generated_files import is_generated_file
+from daydream.git_ops import diff_worktree_against
 
 # U+201C LEFT DOUBLE QUOTATION MARK / U+201D RIGHT DOUBLE QUOTATION MARK -> "
 # U+2018 LEFT SINGLE QUOTATION MARK / U+2019 RIGHT SINGLE QUOTATION MARK -> '
-_SMART_QUOTE_TABLE = str.maketrans(
-    {"\u201C": '"', "\u201D": '"', "\u2018": "'", "\u2019": "'"}
-)
+_SMART_QUOTE_TABLE = str.maketrans({"\u201c": '"', "\u201d": '"', "\u2018": "'", "\u2019": "'"})
+
+# Unified-diff hunk header: @@ -<old_start>[,<old_count>] +<new_start>[,<new_count>] @@
+_HUNK_HEADER = re.compile(r"^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@")
 
 
 def normalize_smart_quotes(text: str) -> str:
@@ -30,26 +36,130 @@ def normalize_smart_quotes(text: str) -> str:
     return text.translate(_SMART_QUOTE_TABLE)
 
 
-def scrub_smart_quotes_changed_files(repo: Path, changed_files: Iterable[str]) -> list[str]:
-    """Rewrite smart quotes to ASCII in every changed, non-generated text file.
+def _added_line_numbers(diff_text: str) -> dict[str, set[int]]:
+    """Map repo-relative paths in a working-tree diff to the new-file line
+    numbers the diff adds.
 
-    Best-effort normalization, never a gate: a missing file, a read failure
-    (``OSError``), or a non-UTF-8 (binary/undecodable) file skips that file and
-    the scrub continues — it must never abort a run or block a commit. Files
-    ``is_generated_file`` classifies as generated (glob patterns plus
+    Parses ``git diff <ref>`` unified-diff output: within each ``+++ b/`` file
+    section it tracks the new-file line counter and records every ``+`` line.
+    Context lines advance the counter; deletions (``-``) and header lines do
+    not, matching how git numbers the new file. Every file present in the diff
+    is a key (mapping to the possibly-empty set of added lines); files absent
+    from the diff (untracked new files) are not keys at all.
+    """
+    added: dict[str, set[int]] = {}
+    current: str | None = None
+    new_line = 0
+    for raw in diff_text.splitlines():
+        if raw.startswith("+++ b/"):
+            current = raw[6:]
+            added.setdefault(current, set())
+            new_line = 0
+        elif current is None:
+            continue
+        elif raw.startswith("@@"):
+            match = _HUNK_HEADER.match(raw)
+            if match:
+                new_line = int(match.group(2))
+        elif raw.startswith("+"):
+            added[current].add(new_line)
+            new_line += 1
+        elif raw.startswith(" "):
+            new_line += 1
+        # "-" deletions and mode/header lines advance no new-file counter.
+    return added
+
+
+def _normalize_added_lines(text: str, added: set[int]) -> str:
+    """Normalize smart quotes only on the 1-based new-file lines in *added*.
+
+    Splits on ``\\n`` (matching git's line accounting; a trailing ``\\r`` in
+    CRLF files rides along as line content) and rejoins unchanged, so every
+    byte outside an added line is preserved exactly.
+    """
+    parts = text.split("\n")
+    return "\n".join(normalize_smart_quotes(part) if idx in added else part for idx, part in enumerate(parts, start=1))
+
+
+def _atomic_write_bytes(path: Path, data: bytes) -> None:
+    """Write *data* to *path* without ever exposing a truncated file.
+
+    ``Path.write_bytes`` opens ``wb`` (truncate-then-write), so a mid-write
+    failure (ENOSPC, ...) leaves the source file truncated. Instead, write to
+    a sibling temp file, preserve the original file's permission bits, and
+    ``os.replace`` it into place — the original bytes survive any write
+    failure and the final swap is atomic. The temp file is cleaned up on any
+    failure.
+
+    Raises:
+        OSError: On any write failure (after cleaning up the temp file).
+    """
+    fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=path.name + ".", suffix=".tmp")
+    try:
+        try:
+            mode = stat.S_IMODE(path.stat().st_mode)
+        except OSError:
+            mode = None
+        with os.fdopen(fd, "wb") as tmp:
+            tmp.write(data)
+        if mode is not None:
+            os.chmod(tmp_name, mode)
+        os.replace(tmp_name, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def scrub_smart_quotes_changed_files(
+    repo: Path,
+    changed_files: Iterable[str],
+    *,
+    pre_fix_ref: str | None = None,
+) -> list[str]:
+    """Rewrite agent-written smart quotes to ASCII in changed, non-generated files.
+
+    Best-effort normalization, never a gate: a missing file, a read or write
+    failure (``OSError``), or a non-UTF-8 (binary/undecodable) file skips that
+    file and the scrub continues — it must never abort a run or block a commit.
+    Files ``is_generated_file`` classifies as generated (glob patterns plus
     ``@generated`` / ``DO NOT EDIT`` header markers) and anything under
     ``.daydream/`` are excluded.
+
+    Only lines the fix pass added are rewritten, attributed from the working-
+    tree diff against *pre_fix_ref*: pre-existing smart quotes in baseline
+    string literals, doc examples, or fixture data are never touched, and the
+    rewrite can never turn an untouched single-quoted literal into a syntax
+    error. A path absent from that diff is a newly created (untracked) file,
+    every line of which is agent-authored, so it is normalized in full. When
+    *pre_fix_ref* is None no attribution is attempted and the whole file is
+    normalized — production callers always pass it. Writes are atomic (sibling
+    temp file + ``os.replace``) so a mid-write failure can never leave a
+    truncated source file.
 
     Args:
         repo: The git working directory (repo-relative paths resolve against it).
         changed_files: Repo-relative paths the fix pass edited.
+        pre_fix_ref: Base ref the fix pass edited against; the working-tree
+            diff against it attributes the agent-added lines.
 
     Returns:
         The repo-relative paths whose bytes were rewritten (sorted by the
         caller's responsibility; order here follows the input order).
+
+    Raises:
+        GitError: If the attribution diff cannot be computed; callers treat
+            this as fail-open (degrade to a warning, never abort a run).
     """
+    changed = list(changed_files)
+    if pre_fix_ref is None:
+        added_lines: dict[str, set[int]] | None = None
+    else:
+        added_lines = _added_line_numbers(diff_worktree_against(repo, pre_fix_ref, changed))
     scrubbed: list[str] = []
-    for path in changed_files:
+    for path in changed:
         if path.startswith(".daydream/"):
             continue
         file_path = repo / path
@@ -65,8 +175,22 @@ def scrub_smart_quotes_changed_files(repo: Path, changed_files: Iterable[str]) -
             continue
         if is_generated_file(path, decoded):
             continue
-        normalized = normalize_smart_quotes(decoded)
+        if added_lines is None:
+            normalized = normalize_smart_quotes(decoded)
+        else:
+            added = added_lines.get(path)
+            if added is None:
+                # Absent from the attribution diff: a newly created (untracked)
+                # file, so every line is agent-authored.
+                normalized = normalize_smart_quotes(decoded)
+            else:
+                normalized = _normalize_added_lines(decoded, added)
         if normalized != decoded:
-            file_path.write_bytes(normalized.encode("utf-8"))
+            try:
+                _atomic_write_bytes(file_path, normalized.encode("utf-8"))
+            except OSError:
+                # Write failure (read-only fs, ENOSPC, permissions, ...): skip
+                # and continue — never abort the run.
+                continue
             scrubbed.append(path)
     return scrubbed

--- a/daydream/quote_scrub.py
+++ b/daydream/quote_scrub.py
@@ -1,0 +1,72 @@
+"""ASCII normalization for smart quotes on the fix-apply path (#687).
+
+Fix agents sometimes write typographic smart quotes (``”`` ``“`` ``’`` ``‘``)
+into code comments and string literals. Left alone, those bytes land in the
+committed tree and every later review re-surfaces the same typographic finding.
+This module provides a deterministic, backend-agnostic scrub: a pure
+``str.translate`` transform over the four smart-quote code points plus a
+changed-file driver that rewrites only the changed-file set in place.
+"""
+
+from collections.abc import Iterable
+from pathlib import Path
+
+from daydream.generated_files import is_generated_file
+
+# U+201C LEFT DOUBLE QUOTATION MARK / U+201D RIGHT DOUBLE QUOTATION MARK -> "
+# U+2018 LEFT SINGLE QUOTATION MARK / U+2019 RIGHT SINGLE QUOTATION MARK -> '
+_SMART_QUOTE_TABLE = str.maketrans(
+    {"\u201C": '"', "\u201D": '"', "\u2018": "'", "\u2019": "'"}
+)
+
+
+def normalize_smart_quotes(text: str) -> str:
+    """Replace the four smart-quote code points with ASCII straight quotes.
+
+    Pure transform: ``str.translate`` over a fixed mapping, byte-identical for
+    any input that already contains none of the four code points. Never
+    reformats or reflows the text.
+    """
+    return text.translate(_SMART_QUOTE_TABLE)
+
+
+def scrub_smart_quotes_changed_files(repo: Path, changed_files: Iterable[str]) -> list[str]:
+    """Rewrite smart quotes to ASCII in every changed, non-generated text file.
+
+    Best-effort normalization, never a gate: a missing file, a read failure
+    (``OSError``), or a non-UTF-8 (binary/undecodable) file skips that file and
+    the scrub continues — it must never abort a run or block a commit. Files
+    ``is_generated_file`` classifies as generated (glob patterns plus
+    ``@generated`` / ``DO NOT EDIT`` header markers) and anything under
+    ``.daydream/`` are excluded.
+
+    Args:
+        repo: The git working directory (repo-relative paths resolve against it).
+        changed_files: Repo-relative paths the fix pass edited.
+
+    Returns:
+        The repo-relative paths whose bytes were rewritten (sorted by the
+        caller's responsibility; order here follows the input order).
+    """
+    scrubbed: list[str] = []
+    for path in changed_files:
+        if path.startswith(".daydream/"):
+            continue
+        file_path = repo / path
+        try:
+            content = file_path.read_bytes()
+        except OSError:
+            # Missing or unreadable: skip and continue.
+            continue
+        try:
+            decoded = content.decode("utf-8")
+        except UnicodeDecodeError:
+            # Binary / non-UTF-8 file: skip and continue.
+            continue
+        if is_generated_file(path, decoded):
+            continue
+        normalized = normalize_smart_quotes(decoded)
+        if normalized != decoded:
+            file_path.write_bytes(normalized.encode("utf-8"))
+            scrubbed.append(path)
+    return scrubbed

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -171,6 +171,24 @@ def _migration_project(tmp_path: Path, name: str) -> tuple[Path, Path]:
     return project, migration
 
 
+def _go_quote_project(tmp_path: Path) -> Path:
+    """Build a feature-branch fixture whose reviewed diff is a single Go file."""
+    project = tmp_path / "go_quote_repo"
+    project.mkdir()
+    (project / "main.go").write_text("package main\n\n// doc\n")
+    (project / "notes.md").write_text("# Notes\n")
+    _init_repo(project)
+    _git(project, "add", "main.go", "notes.md")
+    _commit(project, "test: initialize go fixture")
+    _git(project, "checkout", "-b", "feature")
+    # Only main.go changes in the feature-branch commit: it is the sole
+    # reviewed-diff file, so a fix to it is the only edit the run commits.
+    (project / "main.go").write_text("package main\n\n// doc updated\n")
+    _git(project, "add", "main.go")
+    _commit(project, "test: change the go source")
+    return project
+
+
 def _record(**overrides: Any) -> dict[str, Any]:
     """Build one on-disk per-stack record (the shape a merge resume reads back)."""
     record: dict[str, Any] = {"id": 1, "description": "issue", "file": "api.py", "line": 1}
@@ -1955,6 +1973,57 @@ async def test_fix_guard_reverts_generated_migration_edit(
     assert "Daydream-Run: " in commit_message
     assert f"Daydream-Version: {daydream.__version__}" in commit_message
     assert head_after in _git(project, "ls-remote", "--heads", "origin", "feature")
+
+
+async def test_fix_scrub_normalizes_smart_quote_in_changed_go_comment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+    mute_side_effects: Mute,
+) -> None:
+    """Real path: a fix writing U+201D into a changed .go comment is scrubbed pre-commit.
+
+    Drives ``runner.run`` through the deep flow with a stub backend whose fix
+    turn appends a smart-quote comment line to ``main.go`` — the sole reviewed
+    diff file. The scrub must normalize U+201D to an ASCII straight quote
+    before the quality gate measures the tree and before the commit stages it,
+    so the committed tree never carries the smart quote and the non-changed
+    ``notes.md`` stays byte-identical.
+    """
+    from daydream.runner import run
+
+    project = _go_quote_project(tmp_path)
+    bare = _bare_remote(tmp_path / "remote.git")
+    _git(project, "remote", "add", "origin", str(bare))
+    notes_before = (project / "notes.md").read_bytes()
+    head_before = _git(project, "rev-parse", "HEAD")
+    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
+    mute_side_effects(heal=False, commit=False)
+    stub = _PushingCommittingStubBackend(project)
+    monkeypatch.setattr("daydream.runner.create_backend", lambda name, model=None, **kwargs: stub)
+    # A one-file diff collapses to single-stack mode (no cross-stack merge
+    # agent), so the finding is driven through the per-stack parse: the go
+    # review's record points at the sole reviewed file, main.go.
+    stub.parse_by_stack = {
+        "go": {
+            "severity": "high",
+            "confidence": "HIGH",
+            "file": "main.go",
+            "line": 1,
+            "description": "comment doc fix",
+        }
+    }
+    stub.fix_edit_line = "\n// not \u201D\n"  # fix agent writes U+201D into the changed .go comment
+    exit_code = await run(make_config(
+        project, assume="yes", output_mode="loop", non_interactive=False,
+        archive=False, skill_availability=frozenset(SKILL_MAP),
+    ))
+    assert exit_code == 0
+    go_src = (project / "main.go").read_text()
+    assert "not \u201D" not in go_src      # U+201D never lands in the committed tree
+    assert '// not "' in go_src            # normalized to ASCII straight quote
+    assert (project / "notes.md").read_bytes() == notes_before  # non-changed file untouched
+    assert _git(project, "rev-parse", "HEAD") != head_before
 
 
 async def test_test_healing_guard_reverts_generated_migration_edit(

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -2026,6 +2026,60 @@ async def test_fix_scrub_normalizes_smart_quote_in_changed_go_comment(
     assert _git(project, "rev-parse", "HEAD") != head_before
 
 
+async def test_feedback_scrub_trust_gate_preserves_user_edits(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+    mute_side_effects: Mute,
+) -> None:
+    """Real path: the pr-feedback scrub never rewrites uncommitted tracked user edits.
+
+    Feedback mode runs in-place on the user's checkout with no pre-fix snapshot
+    mechanism, so the scrub used to attribute the user's uncommitted tracked
+    smart-quote lines against bare HEAD as if the fix agent added them, and
+    rewrote them to ASCII. The trust gate captures a pre-fix stash snapshot
+    (mirroring ``_step_fix``) and attributes agent-added lines against it, so
+    the user's smart quotes survive the run byte-identical while the fix
+    agent's own smart-quote line is still normalized before commit.
+
+    Drives ``runner.run`` through feedback mode (``pr_number`` + ``bot``) with a
+    stub backend as the only mocked seam; the commit and push are real.
+    """
+    from daydream.runner import run
+
+    project = tmp_path / "fb_quote_repo"
+    project.mkdir()
+    (project / "main.go").write_text("package main\n\n// doc\n")
+    _init_repo(project)
+    _git(project, "add", "main.go")
+    _commit(project, "test: initialize feedback fixture")
+    bare = _bare_remote(tmp_path / "remote.git")
+    _git(project, "remote", "add", "origin", str(bare))
+
+    # User's uncommitted tracked edit in the in-place checkout carries smart quotes.
+    user_line = "// user \u201Cedit\u201D\n"
+    (project / "main.go").write_text((project / "main.go").read_text() + user_line)
+
+    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
+    mute_side_effects(heal=False, commit=False)
+    stub = _FeedbackQuoteScrubBackend(project)
+    # The fix agent writes U+201D into the changed .go comment; the user's own
+    # smart-quote line is baseline content the scrub must not touch.
+    stub.fix_edit_line = "\n// agent \u201D\n"
+    monkeypatch.setattr("daydream.runner.create_backend", lambda name, model=None, **kwargs: stub)
+
+    exit_code = await run(make_config(
+        project, pr_number=7, bot="my-app[bot]", assume="yes",
+        output_mode="loop", non_interactive=False, archive=False,
+        skill_availability=frozenset(SKILL_MAP),
+    ))
+    assert exit_code == 0
+    go_src = (project / "main.go").read_text()
+    assert user_line in go_src             # user's smart-quote line NOT rewritten
+    assert "// agent \u201D" not in go_src  # fix agent's U+201D never lands in the tree
+    assert '// agent "' in go_src          # ... it is normalized to ASCII straight quote
+
+
 async def test_test_healing_guard_reverts_generated_migration_edit(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -6690,6 +6744,56 @@ class _PushingCommittingStubBackend(_StubBackend):
             yield ResultEvent(structured_output=None, continuation=None)
             return
 
+        async for event in super().execute(
+            cwd,
+            prompt,
+            output_schema=output_schema,
+            continuation=continuation,
+            agents=agents,
+            max_turns=max_turns,
+            read_only=read_only,
+        ):
+            yield event
+
+
+class _FeedbackQuoteScrubBackend(_PushingCommittingStubBackend):
+    """Feedback-mode stub: parse-feedback yields one ``main.go`` issue; the rest delegate.
+
+    ``_PushingCommittingStubBackend`` already handles the fix turn (appending
+    ``fix_edit_line`` to the fixed file) and the commit/push turn. Feedback mode
+    additionally runs fetch-feedback (skill invocation, default empty branch)
+    and parse-feedback, whose prompt asks the agent to read the review output
+    file — the stub answers with a single actionable issue on ``main.go``.
+    """
+
+    async def execute(
+        self,
+        cwd: Path,
+        prompt: str,
+        output_schema: Any = None,
+        continuation: Any = None,
+        agents: Any = None,
+        max_turns: Any = None,
+        read_only: bool = False,
+    ) -> Any:
+        if prompt.startswith("Read the review output file"):
+            yield TextEvent(text="")
+            yield ResultEvent(
+                structured_output={
+                    "issues": [
+                        {
+                            "id": 1,
+                            "description": "doc comment fix",
+                            "file": "main.go",
+                            "line": 1,
+                            "confidence": "HIGH",
+                            "evidence": "main.go:1",
+                        }
+                    ]
+                },
+                continuation=None,
+            )
+            return
         async for event in super().execute(
             cwd,
             prompt,

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -937,6 +937,13 @@ def test_fix_guardrails_forbid_generated_file_edits():
     assert "migration" in _FIX_GUARDRAILS.lower()
 
 
+def test_fix_guardrails_preserve_ascii_quotes():
+    from daydream.phases import _FIX_GUARDRAILS
+
+    assert "ascii" in _FIX_GUARDRAILS.lower()
+    assert "smart quote" in _FIX_GUARDRAILS.lower()
+
+
 def test_build_fix_prompt_carries_generated_file_rule():
     from daydream.phases import _build_fix_prompt
 

--- a/tests/test_quote_scrub.py
+++ b/tests/test_quote_scrub.py
@@ -1,3 +1,6 @@
+import pytest
+
+from daydream.git_ops import GitError
 from daydream.quote_scrub import (
     _added_line_numbers,
     normalize_smart_quotes,
@@ -114,6 +117,80 @@ def test_scrub_driver_atomic_write_leaves_original_intact_on_failure(tmp_path, m
     assert not [p for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
 
 
+def test_scrub_driver_raises_git_error_on_attribution_diff_failure(tmp_path, monkeypatch):
+    """When the attribution diff cannot be computed the driver raises the
+    documented GitError (finding 3): the orchestrator's fail-open guard turns
+    that into a warning and continues — never an abort."""
+    repo = tmp_path / "repo"
+    init_repo(repo)
+    src = repo / "main.go"
+    src.write_text("x\n", encoding="utf-8")
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", "baseline")
+    src.write_text("// \u201d\n", encoding="utf-8")
+
+    def _fail_diff(repo, ref, paths):
+        raise GitError("git diff failed")
+
+    monkeypatch.setattr("daydream.quote_scrub.diff_worktree_against", _fail_diff)
+    with pytest.raises(GitError):
+        scrub_smart_quotes_changed_files(repo, ["main.go"], pre_fix_ref="HEAD")
+
+
+def test_scrub_driver_with_non_utf8_diff_content_raises_git_error(tmp_path):
+    """A changed file whose content is not valid UTF-8 (latin-1) makes the
+    attribution diff undecodable; the driver must raise the documented GitError
+    (degrading to the caller's warn-and-continue) instead of crashing with a
+    raw UnicodeDecodeError (finding 1, F1)."""
+    repo = tmp_path / "repo"
+    init_repo(repo)
+    src = repo / "latin.go"
+    src.write_bytes(b"// caf\xe9\n")
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", "baseline")
+    src.write_bytes(b"// caf\xe9\n// \xe2\x80\x9cadded\xe2\x80\x9d\n")
+    with pytest.raises(GitError):
+        scrub_smart_quotes_changed_files(repo, ["latin.go"], pre_fix_ref="HEAD")
+
+
+def test_scrub_driver_with_quotepath_non_ascii_path_preserves_attribution(tmp_path):
+    """git's default core.quotepath quotes non-ASCII paths in diff output
+    (``+++ \"b/caf\\303\\251.go\"``); the added-line parser must unquote them so
+    the file stays line-targeted instead of falling through to whole-file
+    normalization, which would rewrite baseline quotes (finding 1, F2)."""
+    repo = tmp_path / "repo"
+    init_repo(repo)
+    src = repo / "caf\u00e9.go"
+    src.write_text("package main\n\n// baseline \u201d quote\n", encoding="utf-8")
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", "baseline")
+    src.write_text(
+        "package main\n\n// baseline \u201d quote\n// added \u201cquote\u201d\n",
+        encoding="utf-8",
+    )
+    scrubbed = scrub_smart_quotes_changed_files(repo, ["caf\u00e9.go"], pre_fix_ref="HEAD")
+    assert scrubbed == ["caf\u00e9.go"]
+    assert src.read_text(encoding="utf-8") == (
+        'package main\n\n// baseline \u201d quote\n// added "quote"\n'
+    )
+
+
+def test_scrub_driver_normalizes_untracked_new_file_in_full(tmp_path):
+    """An untracked new file is absent from the attribution diff, so every line
+    is agent-authored and normalized in full (finding 2) — the whole-file
+    branch for ``added is None`` on a per-path lookup."""
+    repo = tmp_path / "repo"
+    init_repo(repo)
+    (repo / "base.go").write_text("x\n", encoding="utf-8")
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", "baseline")
+    new_file = repo / "new.go"
+    new_file.write_text("// \u201cnew file\u201d\n", encoding="utf-8")
+    scrubbed = scrub_smart_quotes_changed_files(repo, ["new.go"], pre_fix_ref="HEAD")
+    assert scrubbed == ["new.go"]
+    assert new_file.read_text(encoding="utf-8") == '// "new file"\n'
+
+
 def test_added_line_numbers_parses_unified_diff():
     diff = (
         "diff --git a/main.go b/main.go\n"
@@ -134,3 +211,121 @@ def test_added_line_numbers_parses_unified_diff():
         "+new\n"
     )
     assert _added_line_numbers(diff) == {"main.go": {3, 12, 13}, "other.py": {5}}
+
+
+def test_added_line_numbers_added_line_looking_like_header_is_content(tmp_path):
+    """An added line whose content starts with ``++ b/`` renders as ``+++ b/...``
+    and must be parsed as an added line, not a file header re-keying the current
+    file (findings 4/6): later added smart quotes stay attributed to the real
+    path."""
+    diff = (
+        "--- a/main.go\n"
+        "+++ b/main.go\n"
+        "@@ -1,2 +1,4 @@\n"
+        " package main\n"
+        " \n"
+        "++ b/not-a-header\n"
+        "+// \u201cquote\u201d\n"
+        "--- a/other.go\n"
+        "+++ b/other.go\n"
+        "@@ -1 +1 @@\n"
+        "-old\n"
+        "+new\n"
+    )
+    assert _added_line_numbers(diff) == {"main.go": {3, 4}, "other.go": {1}}
+
+
+def test_added_line_numbers_noprefix_and_space_paths():
+    """diff.noprefix=true drops the a//b/ prefixes (``+++ main.go``), and git
+    appends a trailing tab after space-containing paths (``+++ b/has space.py\t``);
+    both must still key the real repo-relative path (finding 5, finding 2 tab
+    separator)."""
+    diff = (
+        "diff --git main.go main.go\n"
+        "--- main.go\n"
+        "+++ main.go\n"
+        "@@ -1 +1,2 @@\n"
+        " package main\n"
+        "+// \u201cquote\u201d\n"
+        "diff --git a/has space.py b/has space.py\n"
+        "--- a/has space.py\t\n"
+        "+++ b/has space.py\t\n"
+        "@@ -0,0 +1 @@\n"
+        "+x = 1\n"
+    )
+    assert _added_line_numbers(diff) == {"main.go": {2}, "has space.py": {1}}
+
+
+def test_added_line_numbers_quoted_path_with_space():
+    """A quotepath-quoted path that also contains a space gets the trailing tab
+    separator after the closing quote (``+++ \"b/na\\303\\257ve ve.py\"\t``); the
+    unquoted key must match the real path (finding 2)."""
+    diff = (
+        "--- \"a/na\\303\\257ve ve.py\"\n"
+        "+++ \"b/na\\303\\257ve ve.py\"\t\n"
+        "@@ -0,0 +1 @@\n"
+        "+x = 1\n"
+    )
+    assert _added_line_numbers(diff) == {"na\u00efve ve.py": {1}}
+
+
+def test_scrub_driver_raises_git_error_on_external_driver_diff(tmp_path, monkeypatch):
+    """A non-unified attribution diff (external diff driver output) cannot be
+    attributed; the driver raises the documented GitError so the caller's
+    fail-open guard skips instead of silently whole-file normalizing baseline
+    smart quotes in tracked files (finding 5)."""
+    repo = tmp_path / "repo"
+    init_repo(repo)
+    src = repo / "main.go"
+    src.write_text("// baseline \u201d quote\n", encoding="utf-8")
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", "baseline")
+    src.write_text("// baseline \u201d quote\n// added \u201cquote\u201d\n", encoding="utf-8")
+
+    def _garbage_diff(repo, ref, paths):
+        return "raw external-driver output without unified-diff structure\n"
+
+    monkeypatch.setattr("daydream.quote_scrub.diff_worktree_against", _garbage_diff)
+    with pytest.raises(GitError):
+        scrub_smart_quotes_changed_files(repo, ["main.go"], pre_fix_ref="HEAD")
+    # Fail-open: nothing was rewritten.
+    assert src.read_text(encoding="utf-8") == "// baseline \u201d quote\n// added \u201cquote\u201d\n"
+
+
+def test_scrub_driver_binary_only_diff_does_not_raise(tmp_path):
+    """A binary-only diff (``Binary files ... differ``) is legitimate git
+    output: the binary file is skipped as undecodable and an untracked sibling
+    still normalizes whole-file, without tripping the external-driver check
+    (finding 5)."""
+    repo = tmp_path / "repo"
+    init_repo(repo)
+    blob = repo / "blob.bin"
+    blob.write_bytes(b"\x00\x01")
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", "baseline")
+    blob.write_bytes(b"\x00\x02")
+    new_file = repo / "new.go"
+    new_file.write_text("// \u201cnew\u201d\n", encoding="utf-8")
+    scrubbed = scrub_smart_quotes_changed_files(
+        repo, ["blob.bin", "new.go"], pre_fix_ref="HEAD",
+    )
+    assert scrubbed == ["new.go"]
+    assert new_file.read_text(encoding="utf-8") == '// "new"\n'
+
+
+def test_scrub_driver_preserves_symlink_on_rewrite(tmp_path):
+    """A tracked symlink must survive the scrub: the normalized bytes land in
+    the link target, and the directory entry stays a symlink (finding 7)."""
+    repo = tmp_path / "repo"
+    init_repo(repo)
+    target = repo / "real.go"
+    target.write_text("// baseline\n", encoding="utf-8")
+    link = repo / "link.go"
+    link.symlink_to(target.name)
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", "baseline")
+    target.write_text("// baseline\n// added \u201cquote\u201d\n", encoding="utf-8")
+    scrubbed = scrub_smart_quotes_changed_files(repo, ["link.go"], pre_fix_ref="HEAD")
+    assert scrubbed == ["link.go"]
+    assert link.is_symlink()
+    assert target.read_text(encoding="utf-8") == '// baseline\n// added "quote"\n'

--- a/tests/test_quote_scrub.py
+++ b/tests/test_quote_scrub.py
@@ -1,9 +1,14 @@
-from daydream.quote_scrub import normalize_smart_quotes, scrub_smart_quotes_changed_files
+from daydream.quote_scrub import (
+    _added_line_numbers,
+    normalize_smart_quotes,
+    scrub_smart_quotes_changed_files,
+)
+from tests.harness.git_helpers import git, init_repo
 
 
 def test_normalize_smart_quotes_maps_all_four_code_points_to_ascii():
-    assert normalize_smart_quotes("\u201Cleft\u201D \u2018single\u2019") == '"left" \'single\''
-    assert normalize_smart_quotes("not \u201D") == 'not "'
+    assert normalize_smart_quotes("\u201cleft\u201d \u2018single\u2019") == "\"left\" 'single'"
+    assert normalize_smart_quotes("not \u201d") == 'not "'
 
 
 def test_normalize_smart_quotes_identity_on_ascii():
@@ -14,7 +19,7 @@ def test_normalize_smart_quotes_identity_on_ascii():
 
 
 def test_scrub_driver_rewrites_and_reports_changed_files(tmp_path):
-    (tmp_path / "main.go").write_text("package main\n\n// not \u201D\n")
+    (tmp_path / "main.go").write_text("package main\n\n// not \u201d\n")
     (tmp_path / "keep.py").write_text("x = 1\n")
     scrubbed = scrub_smart_quotes_changed_files(tmp_path, ["main.go", "keep.py"])
     assert scrubbed == ["main.go"]
@@ -24,16 +29,108 @@ def test_scrub_driver_rewrites_and_reports_changed_files(tmp_path):
 
 def test_scrub_driver_skips_generated_binary_and_out_of_scope(tmp_path):
     gen = tmp_path / "models_generated.go"
-    gen.write_text("// generated \u201D\n")
+    gen.write_text("// generated \u201d\n")
     binary = tmp_path / "blob.bin"
     binary.write_bytes(b"\x00\xff\xfe smart \x80")  # invalid UTF-8
     outside = tmp_path / "outside.txt"
-    outside.write_text("\u201Doutside\u201D")
+    outside.write_text("\u201doutside\u201d")
     assert scrub_smart_quotes_changed_files(tmp_path, ["models_generated.go", "blob.bin"]) == []
-    assert gen.read_text() == "// generated \u201D\n"
+    assert gen.read_text() == "// generated \u201d\n"
     assert binary.read_bytes() == b"\x00\xff\xfe smart \x80"
-    assert outside.read_text() == "\u201Doutside\u201D"  # not in changed set → untouched
+    assert outside.read_text() == "\u201doutside\u201d"  # not in changed set → untouched
 
 
 def test_scrub_driver_skips_missing_file(tmp_path):
     assert scrub_smart_quotes_changed_files(tmp_path, ["gone.go"]) == []
+
+
+def test_scrub_driver_normalizes_only_added_lines(tmp_path):
+    """Real git repo: pre-existing baseline smart quotes stay untouched; only
+    lines the fix pass added are normalized (issue #687 finding 1)."""
+    repo = tmp_path / "repo"
+    init_repo(repo)
+    src = repo / "main.go"
+    src.write_text("package main\n\n// baseline \u201d quote\n", encoding="utf-8")
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", "baseline")
+    # The fix pass adds a smart quote on a new line only.
+    src.write_text(
+        "package main\n\n// baseline \u201d quote\n// added \u201cquote\u201d\n",
+        encoding="utf-8",
+    )
+    scrubbed = scrub_smart_quotes_changed_files(repo, ["main.go"], pre_fix_ref="HEAD")
+    assert scrubbed == ["main.go"]
+    assert src.read_text(encoding="utf-8") == ('package main\n\n// baseline \u201d quote\n// added "quote"\n')
+
+
+def test_scrub_driver_never_rewrites_baseline_smart_quotes_in_literals(tmp_path):
+    """A baseline single-quoted literal containing U+2019 (which whole-file
+    normalization would turn into a syntax error) survives byte-identical; an
+    added line is still scrubbed."""
+    repo = tmp_path / "repo"
+    init_repo(repo)
+    src = repo / "main.go"
+    src.write_text("package main\n\nconst s = 'it\u2019s'\n\n", encoding="utf-8")
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", "baseline")
+    src.write_text(
+        "package main\n\nconst s = 'it\u2019s'\n\n// \u201cadded\u201d\n",
+        encoding="utf-8",
+    )
+    scrubbed = scrub_smart_quotes_changed_files(repo, ["main.go"], pre_fix_ref="HEAD")
+    assert scrubbed == ["main.go"]
+    assert src.read_text(encoding="utf-8") == ("package main\n\nconst s = 'it\u2019s'\n\n// \"added\"\n")
+
+
+def test_scrub_driver_guards_write_failure(tmp_path, monkeypatch):
+    """A write failure (read-only fs, ENOSPC) skips the file instead of
+    propagating an OSError past the caller's GitError-only guard (findings 2/3)."""
+    src = tmp_path / "main.go"
+    src.write_text("// not \u201d\n", encoding="utf-8")
+
+    def _fail_write(path, data):
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr("daydream.quote_scrub._atomic_write_bytes", _fail_write)
+    assert scrub_smart_quotes_changed_files(tmp_path, ["main.go"]) == []
+    assert src.read_text(encoding="utf-8") == "// not \u201d\n"
+
+
+def test_scrub_driver_atomic_write_leaves_original_intact_on_failure(tmp_path, monkeypatch):
+    """A mid-write failure must not truncate the source file: the original
+    bytes survive and no temp files are left behind (finding 3)."""
+    import os
+
+    src = tmp_path / "main.go"
+    src.write_text("// not \u201d\n", encoding="utf-8")
+
+    def _failing_replace(tmp, dst):
+        raise OSError("No space left on device")
+
+    monkeypatch.setattr(os, "replace", _failing_replace)
+    assert scrub_smart_quotes_changed_files(tmp_path, ["main.go"]) == []
+    assert src.read_text(encoding="utf-8") == "// not \u201d\n"
+    # No sibling temp file is left behind by the failed atomic write.
+    assert not [p for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+
+
+def test_added_line_numbers_parses_unified_diff():
+    diff = (
+        "diff --git a/main.go b/main.go\n"
+        "index 422c2b7..63da0a2 100644\n"
+        "--- a/main.go\n"
+        "+++ b/main.go\n"
+        "@@ -1,2 +1,3 @@\n"
+        " package main\n"
+        " \n"
+        "+// \u201cquote\u201d\n"
+        "@@ -10,0 +12,2 @@\n"
+        "+\n"
+        "+b\n"
+        "--- a/other.py\n"
+        "+++ b/other.py\n"
+        "@@ -5 +5 @@\n"
+        "-old\n"
+        "+new\n"
+    )
+    assert _added_line_numbers(diff) == {"main.go": {3, 12, 13}, "other.py": {5}}

--- a/tests/test_quote_scrub.py
+++ b/tests/test_quote_scrub.py
@@ -1,0 +1,39 @@
+from daydream.quote_scrub import normalize_smart_quotes, scrub_smart_quotes_changed_files
+
+
+def test_normalize_smart_quotes_maps_all_four_code_points_to_ascii():
+    assert normalize_smart_quotes("\u201Cleft\u201D \u2018single\u2019") == '"left" \'single\''
+    assert normalize_smart_quotes("not \u201D") == 'not "'
+
+
+def test_normalize_smart_quotes_identity_on_ascii():
+    # Legitimate ASCII code/strings are byte-identical.
+    assert normalize_smart_quotes('fmt.Println("x")') == 'fmt.Println("x")'
+    # The empty-string literal in a Go comment is already ASCII — untouched.
+    assert normalize_smart_quotes("// not ''") == "// not ''"
+
+
+def test_scrub_driver_rewrites_and_reports_changed_files(tmp_path):
+    (tmp_path / "main.go").write_text("package main\n\n// not \u201D\n")
+    (tmp_path / "keep.py").write_text("x = 1\n")
+    scrubbed = scrub_smart_quotes_changed_files(tmp_path, ["main.go", "keep.py"])
+    assert scrubbed == ["main.go"]
+    assert (tmp_path / "main.go").read_text() == 'package main\n\n// not "\n'
+    assert (tmp_path / "keep.py").read_text() == "x = 1\n"
+
+
+def test_scrub_driver_skips_generated_binary_and_out_of_scope(tmp_path):
+    gen = tmp_path / "models_generated.go"
+    gen.write_text("// generated \u201D\n")
+    binary = tmp_path / "blob.bin"
+    binary.write_bytes(b"\x00\xff\xfe smart \x80")  # invalid UTF-8
+    outside = tmp_path / "outside.txt"
+    outside.write_text("\u201Doutside\u201D")
+    assert scrub_smart_quotes_changed_files(tmp_path, ["models_generated.go", "blob.bin"]) == []
+    assert gen.read_text() == "// generated \u201D\n"
+    assert binary.read_bytes() == b"\x00\xff\xfe smart \x80"
+    assert outside.read_text() == "\u201Doutside\u201D"  # not in changed set → untouched
+
+
+def test_scrub_driver_skips_missing_file(tmp_path):
+    assert scrub_smart_quotes_changed_files(tmp_path, ["gone.go"]) == []


### PR DESCRIPTION
## Summary

Fixes daydream issue #687: the deep-precision fix loop (backend `pi`) was mangling ASCII `''` (empty-string literal) into U+201D (RIGHT DOUBLE QUOTATION MARK) inside Go comment literals when rewriting source through the coding agent.

## Changes

- **feat(quote-scrub):** add a deterministic smart-quote → ASCII normalization pass for the fix path
- **fix(deep):** scrub smart quotes in changed files before commit
- **feat(fix):** guardrail to preserve ASCII quotes in fix prompts
- **fix(quote-scrub):** rewrite only agent-added lines, atomic writes
- **fix(quote-scrub):** trust gate for feedback scrub, fail-closed test heal, parser hardening

## Verification

- Full gate `make check` GREEN: 3678 passed, 6 skipped; ruff + mypy clean
- Two sequential daydream deep-precision reviews on fresh VMs (round 1 + round 2), all 12 findings addressed

Closes #687
