### PR TITLE
[daydream] Harden fixture-contract tests via shared conftest helpers (Closes #688)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Shared pytest fixtures for the daydream test suite."""
 
 import os
+import tomllib
 from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -707,3 +708,50 @@ def fake_gh(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> FakeGh:
     everywhere, pre-push gate included.
     """
     return install_fake_gh(tmp_path / "fake-gh-state", monkeypatch)
+
+
+def improve_fixture_service(apps_dir: Path) -> str:
+    """Pick one service directory from ``apps/`` for the host-evidence record.
+
+    Only directories that look like a service (contain a ``pyproject.toml``)
+    qualify: the host evidence slices ``pyproject.toml`` line 1, so a
+    non-service directory would break the attributable-error guarantee.
+    """
+    service_entries: list[Path] = []
+    if apps_dir.is_dir():
+        service_entries = sorted(
+            p
+            for p in apps_dir.iterdir()
+            if p.is_dir() and (p / "pyproject.toml").is_file()
+        )
+    if not service_entries:
+        raise AssertionError(
+            "improve_monorepo_target fixture must contain at least one "
+            "service directory under apps/"
+        )
+    return service_entries[0].name
+
+
+def improve_fixture_test_command_anchor(pyproject: Path) -> int:
+    """Line of the ``test-command`` declaration in the root ``pyproject.toml``.
+
+    The declaration must equal ``uv run pytest`` (validated via tomllib); the
+    anchor is the line whose stripped text starts with the ``test-command``
+    key, not a substring scan that could false-positive on an earlier line
+    merely containing the text.
+    """
+    cfg = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    if cfg.get("tool", {}).get("daydream", {}).get("test-command") != "uv run pytest":
+        raise AssertionError(
+            "improve_monorepo_target fixture must declare test command "
+            "'uv run pytest' in its root pyproject.toml"
+        )
+    for line_number, line in enumerate(
+        pyproject.read_text(encoding="utf-8").splitlines(), 1
+    ):
+        if line.strip().startswith("test-command"):
+            return line_number
+    raise AssertionError(
+        "improve_monorepo_target fixture must declare test command "
+        "'uv run pytest' in its root pyproject.toml"
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -713,9 +713,11 @@ def fake_gh(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> FakeGh:
 def improve_fixture_service(apps_dir: Path) -> str:
     """Pick one service directory from ``apps/`` for the host-evidence record.
 
-    Only directories that look like a service (contain a ``pyproject.toml``)
-    qualify: the host evidence slices ``pyproject.toml`` line 1, so a
-    non-service directory would break the attributable-error guarantee.
+    Only directories that look like a service (contain a ``pyproject.toml``
+    whose line 1 is ``[project]``) qualify: the host evidence slices
+    ``pyproject.toml`` line 1 verbatim, so a non-service directory or a
+    service whose pyproject does not start with ``[project]`` would silently
+    change host evidence and break the attributable-error guarantee.
     """
     service_entries: list[Path] = []
     if apps_dir.is_dir():
@@ -729,16 +731,22 @@ def improve_fixture_service(apps_dir: Path) -> str:
             "improve_monorepo_target fixture must contain at least one "
             "service directory under apps/"
         )
-    return service_entries[0].name
+    chosen = service_entries[0]
+    if chosen.joinpath("pyproject.toml").read_text(encoding="utf-8").splitlines()[:1] != ["[project]"]:
+        raise AssertionError(
+            f"improve_monorepo_target service {chosen.name!r} must declare "
+            "'[project]' on pyproject.toml line 1 to anchor host evidence"
+        )
+    return chosen.name
 
 
 def improve_fixture_test_command_anchor(pyproject: Path) -> int:
     """Line of the ``test-command`` declaration in the root ``pyproject.toml``.
 
     The declaration must equal ``uv run pytest`` (validated via tomllib); the
-    anchor is the line whose stripped text starts with the ``test-command``
-    key, not a substring scan that could false-positive on an earlier line
-    merely containing the text.
+    anchor is the line whose stripped text is exactly the ``test-command`` key
+    (up to ``=``), not a prefix scan that could false-positive on a sibling key
+    like ``test-command-timeout`` on an earlier line.
     """
     cfg = tomllib.loads(pyproject.read_text(encoding="utf-8"))
     if cfg.get("tool", {}).get("daydream", {}).get("test-command") != "uv run pytest":
@@ -749,7 +757,7 @@ def improve_fixture_test_command_anchor(pyproject: Path) -> int:
     for line_number, line in enumerate(
         pyproject.read_text(encoding="utf-8").splitlines(), 1
     ):
-        if line.strip().startswith("test-command"):
+        if line.strip().split("=", 1)[0].strip() == "test-command":
             return line_number
     raise AssertionError(
         "improve_monorepo_target fixture must declare test command "

--- a/tests/test_command_contract.py
+++ b/tests/test_command_contract.py
@@ -344,7 +344,31 @@ async def test_host_enumeration_dedups_absolute_model_wd(
 ) -> None:
     """Must-have #1 at the entrypoint: an absolute-spelled model
     working_directory collapses against the relative host record, so the
-    host command is NOT re-admitted into recon.json."""
+    host command is NOT re-admitted into recon.json.
+
+    Fixture contract: ``improve_monorepo_target`` must remain a monorepo
+    that (a) declares the test command ``uv run pytest`` in its root
+    ``pyproject.toml`` and (b) contains at least one service directory
+    under ``apps/``. Both facts are derived from the fixture's actual
+    content below rather than hardcoded, so any layout/names that retain
+    that semantic content keep this test driving the dedup path; a future
+    editor changing the fixture must preserve those two properties or this
+    test fails with the attributable errors below."""
+    # Discover a real service directory from the fixture instead of
+    # hardcoding a name: any directory under apps/ works, because dedup
+    # collapses the absolute model wd against the relative host wd.
+    apps_dir = improve_monorepo_target / "apps"
+    service_entries = (
+        sorted(p for p in apps_dir.iterdir() if p.is_dir()) if apps_dir.is_dir() else []
+    )
+    if not service_entries:
+        raise AssertionError(
+            "improve_monorepo_target fixture must contain at least one "
+            "service directory under apps/"
+        )
+    service = service_entries[0].name
+    rel = f"apps/{service}"
+    abs_wd = f"{improve_monorepo_target}/apps/{service}"
     monkeypatch.setattr(
         "daydream.improve.orchestrator.enumerate_repository_commands",
         lambda repo, *, directories=(".",), reserved_ids=(): [
@@ -352,19 +376,19 @@ async def test_host_enumeration_dedups_absolute_model_wd(
                 "id": "make-check",
                 "purpose": "Run the repository test suite",
                 "command": "uv run pytest",
-                "working_directory": "apps/billing",
+                "working_directory": rel,
                 "expected_success": {
                     "exit_code": 0,
                     "observable_result": "exit 0 and the tests pass",
                 },
                 "applicability": {
-                    "scope": {"kind": "in-scope-paths", "paths": ["apps/billing"]},
+                    "scope": {"kind": "in-scope-paths", "paths": [rel]},
                     "preconditions": [],
-                    "rationale": "The billing service declares the test command.",
+                    "rationale": f"The {service} service declares the test command.",
                 },
                 "evidence": {
                     "kind": "host-derived",
-                    "source_path": "apps/billing/pyproject.toml",
+                    "source_path": f"{rel}/pyproject.toml",
                     "line_anchor": {"start_line": 1, "end_line": 1},
                     "verbatim_excerpt": "[project]",
                 },
@@ -398,8 +422,8 @@ async def test_host_enumeration_dedups_absolute_model_wd(
                 "purpose": "Run the repository test suite",
                 "command": "uv run pytest",
                 # Absolute spelling of the SAME directory the host enumerates
-                # relative ("apps/billing").
-                "working_directory": f"{improve_monorepo_target}/apps/billing",
+                # relative; dedup collapses the two spellings.
+                "working_directory": abs_wd,
                 "expected_success": {
                     "exit_code": 0,
                     "observable_result": "exit 0 and the tests pass",

--- a/tests/test_command_contract.py
+++ b/tests/test_command_contract.py
@@ -372,6 +372,24 @@ async def test_host_enumeration_dedups_absolute_model_wd(
         ],
     )
     stub = install_improve_stub(monkeypatch, improve_monorepo_target)
+
+    # Derive the evidence anchor from the fixture's actual content instead of
+    # hardcoding a line number: the root pyproject.toml must declare the test
+    # subject command, and the validated line is wherever that declaration
+    # lives (any layout that keeps the declaration works).
+    root_pyproject = (
+        improve_monorepo_target / "pyproject.toml"
+    ).read_text(encoding="utf-8").splitlines()
+    anchor_line = next(
+        (i for i, line in enumerate(root_pyproject, 1) if "uv run pytest" in line),
+        None,
+    )
+    if anchor_line is None:
+        raise AssertionError(
+            "improve_monorepo_target fixture must declare test command "
+            "'uv run pytest' in its root pyproject.toml"
+        )
+
     stub.recon_output_override = {
         "languages": ["python"],
         "commands": [
@@ -394,7 +412,7 @@ async def test_host_enumeration_dedups_absolute_model_wd(
                 "evidence": {
                     "kind": "literal-command",
                     "source_path": "pyproject.toml",
-                    "line_anchor": {"start_line": 5, "end_line": 5},
+                    "line_anchor": {"start_line": anchor_line, "end_line": anchor_line},
                     "verbatim_excerpt": None,
                 },
             }

--- a/tests/test_command_contract.py
+++ b/tests/test_command_contract.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import json
 import re
-import tomllib
 from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Any
@@ -29,6 +28,7 @@ from daydream.improve.command_contract import (
 )
 from daydream.repository_paths import canonicalize_working_directory
 from daydream.runner import RunConfig, run
+from tests.conftest import improve_fixture_service, improve_fixture_test_command_anchor
 from tests.harness.improve_backend import improve_artifact, install_improve_stub
 
 MakeConfig = Callable[..., RunConfig]
@@ -337,53 +337,6 @@ def test_canonicalize_working_directory_collapses_parent_traversal(tmp_path: Pat
     assert canonicalize_working_directory(tmp_path, f"{tmp_path}/sub/../sub") == "sub"
 
 
-def _fixture_service(apps_dir: Path) -> str:
-    """Pick one service directory from ``apps/`` for the host-evidence record.
-
-    Only directories that look like a service (contain a ``pyproject.toml``)
-    qualify: the host evidence slices ``pyproject.toml`` line 1, so a
-    non-service directory would break the attributable-error guarantee.
-    """
-    service_entries: list[Path] = []
-    if apps_dir.is_dir():
-        service_entries = sorted(
-            p
-            for p in apps_dir.iterdir()
-            if p.is_dir() and (p / "pyproject.toml").is_file()
-        )
-    if not service_entries:
-        raise AssertionError(
-            "improve_monorepo_target fixture must contain at least one "
-            "service directory under apps/"
-        )
-    return service_entries[0].name
-
-
-def _fixture_test_command_anchor(pyproject: Path) -> int:
-    """Line of the ``test-command`` declaration in the root ``pyproject.toml``.
-
-    The declaration must equal ``uv run pytest`` (validated via tomllib); the
-    anchor is the line whose stripped text starts with the ``test-command``
-    key, not a substring scan that could false-positive on an earlier line
-    merely containing the text.
-    """
-    cfg = tomllib.loads(pyproject.read_text(encoding="utf-8"))
-    if cfg.get("tool", {}).get("daydream", {}).get("test-command") != "uv run pytest":
-        raise AssertionError(
-            "improve_monorepo_target fixture must declare test command "
-            "'uv run pytest' in its root pyproject.toml"
-        )
-    for line_number, line in enumerate(
-        pyproject.read_text(encoding="utf-8").splitlines(), 1
-    ):
-        if line.strip().startswith("test-command"):
-            return line_number
-    raise AssertionError(
-        "improve_monorepo_target fixture must declare test command "
-        "'uv run pytest' in its root pyproject.toml"
-    )
-
-
 @pytest.mark.anyio
 async def test_host_enumeration_dedups_absolute_model_wd(
     improve_monorepo_target: Path,
@@ -405,7 +358,7 @@ async def test_host_enumeration_dedups_absolute_model_wd(
     # Discover a real service directory from the fixture instead of
     # hardcoding a name: any directory under apps/ works, because dedup
     # collapses the absolute model wd against the relative host wd.
-    service = _fixture_service(improve_monorepo_target / "apps")
+    service = improve_fixture_service(improve_monorepo_target / "apps")
     rel = f"apps/{service}"
     abs_wd = f"{improve_monorepo_target}/apps/{service}"
     monkeypatch.setattr(
@@ -440,7 +393,7 @@ async def test_host_enumeration_dedups_absolute_model_wd(
     # hardcoding a line number: the root pyproject.toml must declare the test
     # subject command, and the validated line is wherever that declaration
     # lives (any layout that keeps the declaration works).
-    anchor_line = _fixture_test_command_anchor(
+    anchor_line = improve_fixture_test_command_anchor(
         improve_monorepo_target / "pyproject.toml"
     )
 

--- a/tests/test_command_contract.py
+++ b/tests/test_command_contract.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import re
+import tomllib
 from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Any
@@ -336,6 +337,53 @@ def test_canonicalize_working_directory_collapses_parent_traversal(tmp_path: Pat
     assert canonicalize_working_directory(tmp_path, f"{tmp_path}/sub/../sub") == "sub"
 
 
+def _fixture_service(apps_dir: Path) -> str:
+    """Pick one service directory from ``apps/`` for the host-evidence record.
+
+    Only directories that look like a service (contain a ``pyproject.toml``)
+    qualify: the host evidence slices ``pyproject.toml`` line 1, so a
+    non-service directory would break the attributable-error guarantee.
+    """
+    service_entries: list[Path] = []
+    if apps_dir.is_dir():
+        service_entries = sorted(
+            p
+            for p in apps_dir.iterdir()
+            if p.is_dir() and (p / "pyproject.toml").is_file()
+        )
+    if not service_entries:
+        raise AssertionError(
+            "improve_monorepo_target fixture must contain at least one "
+            "service directory under apps/"
+        )
+    return service_entries[0].name
+
+
+def _fixture_test_command_anchor(pyproject: Path) -> int:
+    """Line of the ``test-command`` declaration in the root ``pyproject.toml``.
+
+    The declaration must equal ``uv run pytest`` (validated via tomllib); the
+    anchor is the line whose stripped text starts with the ``test-command``
+    key, not a substring scan that could false-positive on an earlier line
+    merely containing the text.
+    """
+    cfg = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    if cfg.get("tool", {}).get("daydream", {}).get("test-command") != "uv run pytest":
+        raise AssertionError(
+            "improve_monorepo_target fixture must declare test command "
+            "'uv run pytest' in its root pyproject.toml"
+        )
+    for line_number, line in enumerate(
+        pyproject.read_text(encoding="utf-8").splitlines(), 1
+    ):
+        if line.strip().startswith("test-command"):
+            return line_number
+    raise AssertionError(
+        "improve_monorepo_target fixture must declare test command "
+        "'uv run pytest' in its root pyproject.toml"
+    )
+
+
 @pytest.mark.anyio
 async def test_host_enumeration_dedups_absolute_model_wd(
     improve_monorepo_target: Path,
@@ -357,16 +405,7 @@ async def test_host_enumeration_dedups_absolute_model_wd(
     # Discover a real service directory from the fixture instead of
     # hardcoding a name: any directory under apps/ works, because dedup
     # collapses the absolute model wd against the relative host wd.
-    apps_dir = improve_monorepo_target / "apps"
-    service_entries = (
-        sorted(p for p in apps_dir.iterdir() if p.is_dir()) if apps_dir.is_dir() else []
-    )
-    if not service_entries:
-        raise AssertionError(
-            "improve_monorepo_target fixture must contain at least one "
-            "service directory under apps/"
-        )
-    service = service_entries[0].name
+    service = _fixture_service(improve_monorepo_target / "apps")
     rel = f"apps/{service}"
     abs_wd = f"{improve_monorepo_target}/apps/{service}"
     monkeypatch.setattr(
@@ -401,18 +440,9 @@ async def test_host_enumeration_dedups_absolute_model_wd(
     # hardcoding a line number: the root pyproject.toml must declare the test
     # subject command, and the validated line is wherever that declaration
     # lives (any layout that keeps the declaration works).
-    root_pyproject = (
+    anchor_line = _fixture_test_command_anchor(
         improve_monorepo_target / "pyproject.toml"
-    ).read_text(encoding="utf-8").splitlines()
-    anchor_line = next(
-        (i for i, line in enumerate(root_pyproject, 1) if "uv run pytest" in line),
-        None,
     )
-    if anchor_line is None:
-        raise AssertionError(
-            "improve_monorepo_target fixture must declare test command "
-            "'uv run pytest' in its root pyproject.toml"
-        )
 
     stub.recon_output_override = {
         "languages": ["python"],

--- a/tests/test_improve_flow.py
+++ b/tests/test_improve_flow.py
@@ -3,6 +3,7 @@ import os
 import re
 import subprocess
 import time
+import tomllib
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -1095,19 +1096,64 @@ async def test_host_enumeration_dedups_absolute_model_wd(
 ) -> None:
     """A model-cited command whose working_directory is spelled absolutely is
     deduped against the host record for the same directory (relative spelling):
-    exactly one command record, no rejection noise (issue #654)."""
+    exactly one command record, no rejection noise (issue #654).
+
+    Fixture contract (mirrors tests/test_command_contract.py): the service dir
+    and the test-command anchor are derived from the fixture's actual content
+    rather than hardcoded, so a future fixture edit surfaces as an attributable
+    error instead of a silent meaning shift.
+    """
+    # Derive a real service dir (one containing a pyproject.toml) from the
+    # fixture, and the root test-command declaration line, matching the
+    # command_contract copy's hardening.
+    service = next(
+        (
+            p.name
+            for p in sorted((improve_monorepo_target / "apps").iterdir())
+            if p.is_dir() and (p / "pyproject.toml").is_file()
+        ),
+        None,
+    )
+    if service is None:
+        raise AssertionError(
+            "improve_monorepo_target fixture must contain at least one "
+            "service directory under apps/"
+        )
+    rel = f"apps/{service}"
+    root_pyproject = improve_monorepo_target / "pyproject.toml"
+    cfg = tomllib.loads(root_pyproject.read_text(encoding="utf-8"))
+    if cfg.get("tool", {}).get("daydream", {}).get("test-command") != "uv run pytest":
+        raise AssertionError(
+            "improve_monorepo_target fixture must declare test command "
+            "'uv run pytest' in its root pyproject.toml"
+        )
+    anchor_line = next(
+        (
+            i
+            for i, line in enumerate(
+                root_pyproject.read_text(encoding="utf-8").splitlines(), 1
+            )
+            if line.strip().startswith("test-command")
+        ),
+        None,
+    )
+    if anchor_line is None:
+        raise AssertionError(
+            "improve_monorepo_target fixture must declare test command "
+            "'uv run pytest' in its root pyproject.toml"
+        )
     monkeypatch.setattr(
         "daydream.improve.orchestrator.enumerate_repository_commands",
         lambda repo, *, directories=(".",), reserved_ids=(): [
             _dedup_test_command(
                 command_id="make-check",
                 purpose="Run the repository test suite",
-                working_directory="apps/billing",
-                scope={"kind": "in-scope-paths", "paths": ["apps/billing"]},
-                rationale="The billing service declares the test command.",
+                working_directory=rel,
+                scope={"kind": "in-scope-paths", "paths": [rel]},
+                rationale=f"The {service} service declares the test command.",
                 evidence={
                     "kind": "host-derived",
-                    "source_path": "apps/billing/pyproject.toml",
+                    "source_path": f"{rel}/pyproject.toml",
                     "line_anchor": {"start_line": 1, "end_line": 1},
                     "verbatim_excerpt": "[project]",
                 },
@@ -1122,14 +1168,14 @@ async def test_host_enumeration_dedups_absolute_model_wd(
                 command_id="model-check",
                 purpose="Run the repository test suite",
                 # Absolute spelling of the SAME directory the host enumerates
-                # relative ("apps/billing").
-                working_directory=f"{improve_monorepo_target}/apps/billing",
+                # relative.
+                working_directory=f"{improve_monorepo_target}/{rel}",
                 scope={"kind": "whole-repository"},
                 rationale="The root configuration declares the test command.",
                 evidence={
                     "kind": "literal-command",
                     "source_path": "pyproject.toml",
-                    "line_anchor": {"start_line": 5, "end_line": 5},
+                    "line_anchor": {"start_line": anchor_line, "end_line": anchor_line},
                     "verbatim_excerpt": None,
                 },
             )

--- a/tests/test_improve_flow.py
+++ b/tests/test_improve_flow.py
@@ -3,7 +3,6 @@ import os
 import re
 import subprocess
 import time
-import tomllib
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -33,6 +32,7 @@ from daydream.improve.prompts import (
 )
 from daydream.improve.services import Service
 from daydream.runner import RunConfig, run
+from tests.conftest import improve_fixture_service, improve_fixture_test_command_anchor
 from tests.harness.git_helpers import commit, configure_identity, git, init_repo
 from tests.harness.improve_backend import (
     ImproveStubBackend,
@@ -1100,48 +1100,18 @@ async def test_host_enumeration_dedups_absolute_model_wd(
 
     Fixture contract (mirrors tests/test_command_contract.py): the service dir
     and the test-command anchor are derived from the fixture's actual content
-    rather than hardcoded, so a future fixture edit surfaces as an attributable
-    error instead of a silent meaning shift.
+    via the shared fixture-contract helpers rather than hardcoded, so a future
+    fixture edit surfaces as an attributable error instead of a silent meaning
+    shift.
     """
     # Derive a real service dir (one containing a pyproject.toml) from the
-    # fixture, and the root test-command declaration line, matching the
-    # command_contract copy's hardening.
-    service = next(
-        (
-            p.name
-            for p in sorted((improve_monorepo_target / "apps").iterdir())
-            if p.is_dir() and (p / "pyproject.toml").is_file()
-        ),
-        None,
-    )
-    if service is None:
-        raise AssertionError(
-            "improve_monorepo_target fixture must contain at least one "
-            "service directory under apps/"
-        )
+    # fixture, and the root test-command declaration line, via the shared
+    # fixture-contract helpers.
+    service = improve_fixture_service(improve_monorepo_target / "apps")
     rel = f"apps/{service}"
-    root_pyproject = improve_monorepo_target / "pyproject.toml"
-    cfg = tomllib.loads(root_pyproject.read_text(encoding="utf-8"))
-    if cfg.get("tool", {}).get("daydream", {}).get("test-command") != "uv run pytest":
-        raise AssertionError(
-            "improve_monorepo_target fixture must declare test command "
-            "'uv run pytest' in its root pyproject.toml"
-        )
-    anchor_line = next(
-        (
-            i
-            for i, line in enumerate(
-                root_pyproject.read_text(encoding="utf-8").splitlines(), 1
-            )
-            if line.strip().startswith("test-command")
-        ),
-        None,
+    anchor_line = improve_fixture_test_command_anchor(
+        improve_monorepo_target / "pyproject.toml"
     )
-    if anchor_line is None:
-        raise AssertionError(
-            "improve_monorepo_target fixture must declare test command "
-            "'uv run pytest' in its root pyproject.toml"
-        )
     monkeypatch.setattr(
         "daydream.improve.orchestrator.enumerate_repository_commands",
         lambda repo, *, directories=(".",), reserved_ids=(): [


### PR DESCRIPTION
## Summary
Resolves the out-of-scope finding on `tests/conftest.py` from issue #688. Hardens the fixture-contract tests so the test-command evidence anchor and service-directory discovery are derived from the fixture content itself instead of hardcoded paths, and shares the helpers via `conftest` so the duplication is eliminated.

## Changes
- **tests/conftest.py** — hoist `_fixture_service` / `_fixture_test_command_anchor` into shared helpers (addresses the unguarded `iterdir` / contract-derivation duplication).
- **tests/test_command_contract.py** — discover the service directory from the fixture instead of hardcoding `apps/billing`; derive the dedup-test evidence anchor from fixture content; enforce the exact test-command key match (not prefix) in the anchor scan.
- **tests/test_improve_flow.py** — derive the dedup-test service + anchor from the fixture; harden the monorepo fixture contract in the host enumeration test; verify the chosen service's `pyproject` line-1 is `[project]`.

## Validation
- `make check` green: 3687 passed, 6 skipped, `GATE_RC=0`.
- `ruff check` clean.
- Two sequential daydream deep-precision reviews (rounds 1 & 2) completed on fresh exe.dev VMs; all 6 findings (2 medium, 4 low) fixed; trajectories uploaded to HF.

Closes #688