### PR TITLE
chore: add .zenodo.json with Existential Birds affiliation

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,8 @@
+{
+  "creators": [
+    {
+      "name": "Kevin Anderson",
+      "affiliation": "Existential Birds"
+    }
+  ]
+}


### PR DESCRIPTION
Adds an explicit `.zenodo.json` so Zenodo GitHub-integration deposits record the creator affiliation as **Existential Birds** instead of defaulting to the GitHub profile's affiliation field (which currently shows a stale/incorrect value).

Without this file, Zenodo falls back to the connected GitHub account's profile affiliation for the creator. This makes the affiliation explicit and version-controlled for all future releases.