### PR TITLE
fix(backends): Claude completion tokens under-counted 15-20x; correct total emitted then discarded

### DIFF
--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -745,6 +745,17 @@ async def run_agent(
                                 if inv is not None:
                                     inv.observe(event)
 
+                            elif isinstance(event, TurnEndEvent):
+                                # Per-turn close (issue #747): forward the
+                                # turn boundary so each turn's already-emitted
+                                # MetricsEvent lands on its own Step instead of
+                                # collapsing into one. Pure recorder
+                                # forwarding — no UI, no logging. The recorder's
+                                # no-open-step no-op guard prevents empty-step
+                                # invention.
+                                if inv is not None:
+                                    inv.observe(event)
+
                             elif isinstance(event, ResultEvent):
                                 # Capture the structured result unconditionally: the log-mode
                                 # print is an additive side effect, never a substitute for

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -1046,12 +1046,12 @@ class Invocation:
             # under-count; codex/pi re-state totals equal to the per-message
             # sum -> delta 0, so the restatement never double-counts. Never
             # negative, never subtraction.
-            delta = {
-                "prompt": max(0, (event.input_tokens or 0) - self._inv_metrics_sum["prompt"]),
-                "completion": max(0, (event.output_tokens or 0) - self._inv_metrics_sum["completion"]),
-                "cached": max(0, (event.cached_tokens or 0) - self._inv_metrics_sum["cached"]),
-                "cost": max(0.0, (event.cost_usd or 0.0) - self._inv_metrics_sum["cost"]),
-            }
+            delta_prompt = max(0, (event.input_tokens or 0) - int(self._inv_metrics_sum["prompt"]))
+            delta_completion = max(
+                0, (event.output_tokens or 0) - int(self._inv_metrics_sum["completion"])
+            )
+            delta_cached = max(0, (event.cached_tokens or 0) - int(self._inv_metrics_sum["cached"]))
+            delta_cost = max(0.0, (event.cost_usd or 0.0) - float(self._inv_metrics_sum["cost"]))
             self._ensure_open_step()
             assert self._open_step_dict is not None
             target = self._open_step_dict
@@ -1067,14 +1067,14 @@ class Invocation:
                 reasoning = None
                 if (
                     event.reasoning_tokens is not None
-                    and event.reasoning_tokens <= delta["completion"]
+                    and event.reasoning_tokens <= delta_completion
                 ):
                     reasoning = _reasoning_extra(event.reasoning_tokens)
                 target["_metrics"] = Metrics(
-                    prompt_tokens=delta["prompt"],
-                    completion_tokens=delta["completion"],
-                    cached_tokens=delta["cached"],
-                    cost_usd=None if event.cost_usd is None else delta["cost"],
+                    prompt_tokens=delta_prompt,
+                    completion_tokens=delta_completion,
+                    cached_tokens=delta_cached,
+                    cost_usd=None if event.cost_usd is None else delta_cost,
                     extra=reasoning,
                 )
             else:
@@ -1104,10 +1104,10 @@ class Invocation:
             # total should sum). A CostEvent-only backend (no MetricsEvents at
             # all) still accumulates its full totals via the delta.
             self.recorder._accumulate_metrics(
-                prompt_tokens=delta["prompt"],
-                completion_tokens=delta["completion"],
-                cached_tokens=delta["cached"],
-                cost_usd=None if event.cost_usd is None else delta["cost"],
+                prompt_tokens=delta_prompt,
+                completion_tokens=delta_completion,
+                cached_tokens=delta_cached,
+                cost_usd=None if event.cost_usd is None else delta_cost,
             )
         elif isinstance(event, ResultEvent):
             self._close_open_step()

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -996,6 +996,85 @@ class Invocation:
             reasoning=event.reasoning_tokens,
         )
 
+    def _fold_cost_event(self, event: CostEvent) -> None:
+        """Fold a ``CostEvent``'s residual onto a step and aggregate totals.
+
+        End-of-call signal — fold per-step metrics onto the open Step so the
+        renderer's per-step rollup sees real cost / tokens (Bug C: previously
+        CostEvent only updated _final_totals).
+
+        Per-dimension take-max delta (issue #747): the amount by which this
+        CostEvent's total EXCEEDS the invocation's per-message sum. Claude's
+        authoritative session total exceeds the collapsed per-message single
+        digits -> positive delta repairs the under-count; codex/pi re-state
+        totals equal to the per-message sum -> delta 0, so the restatement never
+        double-counts. Never negative, never subtraction.
+        """
+        delta = self._reconcile_cost_delta(event)
+        existing = (
+            self._open_step_dict["_metrics"] if self._open_step_dict is not None else None
+        )
+        if existing is not None:
+            # A MetricsEvent already populated this step. Fold the residual
+            # delta onto it (previously only the recorder-level tally absorbed
+            # it, so the Step's rollup dropped the magnitude and ``Sigma steps <
+            # final``). Then backfill cost_usd / reasoning the per-message path
+            # didn't surface. ``Sigma steps == final`` holds here too (issue
+            # #747).
+            if delta.nonzero:
+                existing = _merge_metrics(
+                    existing,
+                    delta.residual_metrics(
+                        cost_usd=event.cost_usd, include_reasoning=False
+                    ),
+                )
+            updates: dict[str, Any] = {}
+            if existing.cost_usd is None and event.cost_usd is not None:
+                updates["cost_usd"] = event.cost_usd
+            # #192: backfill reasoning_tokens via Metrics.extra when the
+            # MetricsEvent path didn't carry it (mirrors cost_usd backfill).
+            if (
+                event.reasoning_tokens is not None
+                and (existing.extra is None or "reasoning_tokens" not in existing.extra)
+            ):
+                merged_extra = dict(existing.extra or {})
+                merged_extra["reasoning_tokens"] = event.reasoning_tokens
+                updates["extra"] = merged_extra
+            if updates:
+                existing = existing.model_copy(update=updates)
+            assert self._open_step_dict is not None
+            self._open_step_dict["_metrics"] = existing
+        elif delta.nonzero:
+            # No metrics-bearing step is open and the residual is non-zero: mint
+            # a fresh residual Step holding exactly the delta this CostEvent
+            # adds beyond the invocation's per-message sum, so ``Sigma steps ==
+            # recorder total`` holds (issue #747). reasoning_tokens (#192) is a
+            # subset of completion_tokens and rides in Metrics.extra (D-03).
+            self._ensure_open_step()
+            assert self._open_step_dict is not None
+            self._open_step_dict["_metrics"] = delta.residual_metrics(
+                cost_usd=event.cost_usd, include_reasoning=True
+            )
+        # else: a delta-0 restatement (codex/pi) with no metrics-bearing step
+        # open has nothing to fold — do NOT mint a phantom all-zero Metrics Step
+        # that would inflate total_steps and per-step lists in archived
+        # trajectories and rendered reports (issue #747).
+        if event.model_name:
+            if self._open_step_dict is not None:
+                self._open_step_dict["_model_name"] = event.model_name
+            self.recorder._upgrade_model_name(event.model_name)
+        # Aggregate the delta into recorder-level totals: per-dimension take-max
+        # at the per-invocation level, summed across invocations (a multi-phase
+        # run shares one recorder, so each phase's session total should sum). A
+        # CostEvent-only backend (no MetricsEvents at all) still totals by the
+        # full delta.
+        self.recorder._accumulate_metrics(
+            prompt_tokens=delta.prompt,
+            completion_tokens=delta.completion,
+            cached_tokens=delta.cached,
+            cost_usd=None if event.cost_usd is None else delta.cost,
+        )
+
     def _dispatch(self, event: Any) -> None:
         # Function-local imports avoid load-order cycles with daydream.backends.
         from daydream.backends import (
@@ -1133,80 +1212,13 @@ class Invocation:
                 cost_usd=event.cost_usd,
             )
         elif isinstance(event, CostEvent):
-            # End-of-call signal — also fold per-step metrics onto the open
-            # Step so the renderer's per-step rollup sees real cost / tokens
-            # (Bug C: previously CostEvent only updated _final_totals).
-            #
-            # Per-dimension take-max delta (issue #747): the amount by which
-            # this CostEvent's total EXCEEDS the invocation's per-message sum.
-            # Claude's authoritative session total exceeds the collapsed
-            # per-message single digits -> positive delta repairs the
-            # under-count; codex/pi re-state totals equal to the per-message
-            # sum -> delta 0, so the restatement never double-counts. Never
-            # negative, never subtraction.
-            delta = self._reconcile_cost_delta(event)
-            existing = self._open_step_dict["_metrics"] if self._open_step_dict is not None else None
-            if existing is not None:
-                # A MetricsEvent already populated this step. Fold the residual
-                # delta onto it (previously only the recorder-level tally
-                # absorbed it, so the Step's rollup dropped the magnitude and
-                # ``Σ steps < final``). Then backfill cost_usd / reasoning the
-                # per-message path didn't surface. ``Σ steps == final`` holds
-                # here too (issue #747).
-                if delta.nonzero:
-                    existing = _merge_metrics(
-                        existing,
-                        delta.residual_metrics(
-                            cost_usd=event.cost_usd, include_reasoning=False
-                        ),
-                    )
-                updates: dict[str, Any] = {}
-                if existing.cost_usd is None and event.cost_usd is not None:
-                    updates["cost_usd"] = event.cost_usd
-                # #192: backfill reasoning_tokens via Metrics.extra when the
-                # MetricsEvent path didn't carry it (mirrors cost_usd backfill).
-                if (
-                    event.reasoning_tokens is not None
-                    and (existing.extra is None or "reasoning_tokens" not in existing.extra)
-                ):
-                    merged_extra = dict(existing.extra or {})
-                    merged_extra["reasoning_tokens"] = event.reasoning_tokens
-                    updates["extra"] = merged_extra
-                if updates:
-                    existing = existing.model_copy(update=updates)
-                assert self._open_step_dict is not None
-                self._open_step_dict["_metrics"] = existing
-            elif delta.nonzero:
-                # No metrics-bearing step is open and the residual is non-zero:
-                # mint a fresh residual Step holding exactly the delta this
-                # CostEvent adds beyond the invocation's per-message sum, so
-                # ``Σ steps == recorder total`` holds (issue #747).
-                # reasoning_tokens (#192) is a subset of completion_tokens and
-                # rides in Metrics.extra (D-03).
-                self._ensure_open_step()
-                assert self._open_step_dict is not None
-                self._open_step_dict["_metrics"] = delta.residual_metrics(
-                    cost_usd=event.cost_usd, include_reasoning=True
-                )
-            # else: a delta-0 restatement (codex/pi) with no metrics-bearing
-            # step open has nothing to fold — do NOT mint a phantom all-zero
-            # Metrics Step that would inflate total_steps and per-step lists
-            # in archived trajectories and rendered reports (issue #747).
-            if event.model_name:
-                if self._open_step_dict is not None:
-                    self._open_step_dict["_model_name"] = event.model_name
-                self.recorder._upgrade_model_name(event.model_name)
-            # Aggregate the delta into recorder-level totals: per-dimension
-            # take-max at the per-invocation level, summed across invocations
-            # (a multi-phase run shares one recorder, so each phase's session
-            # total should sum). A CostEvent-only backend (no MetricsEvents at
-            # all) still totals by the full delta.
-            self.recorder._accumulate_metrics(
-                prompt_tokens=delta.prompt,
-                completion_tokens=delta.completion,
-                cached_tokens=delta.cached,
-                cost_usd=None if event.cost_usd is None else delta.cost,
-            )
+            # End-of-call signal — fold the CostEvent's per-dimension
+            # take-max residual delta onto the open/metrics step (or mint a
+            # residual step) and aggregate it into recorder totals. Isolated
+            # in _fold_cost_event so the CostEvent merge/backfill wiring is
+            # not inlined inside _dispatch (cuts the dispatch complexity
+            # concentration; issue #747).
+            self._fold_cost_event(event)
         elif isinstance(event, ResultEvent):
             self._close_open_step()
         elif isinstance(event, TurnEndEvent):
@@ -1348,6 +1360,16 @@ class Invocation:
                 step.model_copy(update=updates)
             )
             return
+        # No closed agent Step exists to fold onto (self.steps is non-empty but
+        # every step is non-agent, e.g. only user/context steps recorded). Mint a
+        # metrics-bearing agent Step so the recorder-level tally still sums to
+        # final (Sigma steps == final) instead of silently dropping the metrics
+        # while final_metrics keeps them (issue #747).
+        self._ensure_open_step()
+        assert self._open_step_dict is not None
+        self._open_step_dict["_metrics"] = incoming
+        if event.model_name:
+            self._open_step_dict["_model_name"] = event.model_name
 
     def snapshot_steps(self, *, snapshot_step_id: int | None = None) -> list[Step]:
         """Return steps including a materialized copy of any open step (signal-safe, non-mutating).

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -838,16 +838,6 @@ class Invocation:
     _inv_metrics_sum: dict[str, float | int] = field(
         default_factory=lambda: {"prompt": 0, "completion": 0, "cached": 0, "cost": 0.0}
     )
-    # Set-once per invocation: did any MetricsEvent already carry tokens / cost?
-    # A trailing CostEvent that re-states what MetricsEvents reported must not
-    # accumulate again (codex re-states per turn, pi re-states the summed
-    # totals). Each retry attempt mints a fresh Invocation (agent.py opens
-    # `recorder.invocation(...)` inside the attempt loop), so these flags start
-    # False per attempt and each attempt's MetricsEvent/CostEvent de-dupe
-    # independently while the recorder-level tally still sums every billed
-    # attempt.
-    _tokens_from_metrics: bool = False
-    _cost_from_metrics: bool = False
 
     def observe_user_step(self, prompt: str) -> None:
         """Append a user Step at invocation start (MAP-01, Pitfall 4).
@@ -1030,9 +1020,6 @@ class Invocation:
             # Aggregate into recorder-level totals for FinalMetrics (MAP-07),
             # and into the invocation-level sum the CostEvent delta reconciles
             # against (issue #747).
-            self._tokens_from_metrics = True
-            if event.cost_usd is not None:
-                self._cost_from_metrics = True
             if event.prompt_tokens is not None:
                 self._inv_metrics_sum["prompt"] += event.prompt_tokens
             if event.completion_tokens is not None:
@@ -1071,13 +1058,24 @@ class Invocation:
             existing = target["_metrics"]
             if existing is None:
                 # #192: reasoning_tokens (subset of completion_tokens) via
-                # Metrics.extra — vendored Metrics has no field (D-03).
+                # Metrics.extra — vendored Metrics has no field (D-03). The
+                # fresh step E holds only the residual delta this CostEvent
+                # adds beyond the invocation's per-message sum, so
+                # ``Σ steps == recorder total`` holds (issue #747). Reasoning
+                # stays a subset: only carried when it does not exceed the
+                # step's completion.
+                reasoning = None
+                if (
+                    event.reasoning_tokens is not None
+                    and event.reasoning_tokens <= delta["completion"]
+                ):
+                    reasoning = _reasoning_extra(event.reasoning_tokens)
                 target["_metrics"] = Metrics(
-                    prompt_tokens=event.input_tokens,
-                    completion_tokens=event.output_tokens,
-                    cached_tokens=event.cached_tokens,
-                    cost_usd=event.cost_usd,
-                    extra=_reasoning_extra(event.reasoning_tokens),
+                    prompt_tokens=delta["prompt"],
+                    completion_tokens=delta["completion"],
+                    cached_tokens=delta["cached"],
+                    cost_usd=None if event.cost_usd is None else delta["cost"],
+                    extra=reasoning,
                 )
             else:
                 # MetricsEvent already populated this step. Prefer the

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -27,7 +27,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, TypedDict
 
 import daydream
 from daydream.atif import (
@@ -53,7 +53,7 @@ _TRAJECTORIES_SUBDIR = "trajectories"
 _DAYDREAM_DIRNAME = ".daydream"
 
 if TYPE_CHECKING:
-    from daydream.backends import AgentEvent
+    from daydream.backends import AgentEvent, CostEvent
 
 _console = create_console()
 _INITIAL_TOTALS: dict[str, Any] = {"prompt": 0, "completion": 0, "cached": 0, "cost": 0.0, "any_cost_seen": False}  # noqa: E501 - module-level constant cloned via dict.copy() at recorder init
@@ -103,6 +103,66 @@ def _merge_metrics(existing: "Metrics", incoming: "Metrics") -> "Metrics":
         "cost_usd": _add(existing.cost_usd, incoming.cost_usd),
         "extra": merged_extra,
     })
+
+
+class _InvMetricsSum(TypedDict):
+    """Per-message MetricsEvent totals for one invocation (issue #747).
+
+    prompt/completion are always int, cached is int-or-absent, and only cost is
+    fractional. Precise member types let the CostEvent reconcile subtract these
+    values without the ``int()``/``float()`` coercions that a broad
+    ``dict[str, float | int]`` annotation forced on every delta computation.
+    """
+
+    prompt: int
+    completion: int
+    cached: int
+    cost: float
+
+
+@dataclass(frozen=True)
+class _CostDelta:
+    """Per-dimension take-max residual of a CostEvent over per-event metrics.
+
+    ``max(0, CostEvent.total - _inv_metrics_sum)`` (issue #747): Claude's
+    authoritative session total exceeds the collapsed per-message single digits
+    so the delta is the true repair magnitude; codex/pi re-state the already
+    summed totals so every delta is 0 and the restatement never double-counts.
+    Never negative, never subtraction.
+    """
+
+    prompt: int
+    completion: int
+    cached: int
+    cost: float
+    reasoning: int | None
+
+    @property
+    def nonzero(self) -> bool:
+        """True when any residual dimension exists (delta-0 restatement folds nothing)."""
+        return self.prompt != 0 or self.completion != 0 or self.cached != 0 or self.cost != 0.0
+
+    def residual_metrics(self, *, cost_usd: float | None, include_reasoning: bool) -> Metrics:
+        """Residual Metrics for this delta (the CostEvent residual-step mapping).
+
+        ``reasoning_tokens`` (#192) is a subset of ``completion_tokens``, so it is
+        carried only when it does not exceed this step's completion.
+        """
+        reasoning = None
+        if (
+            include_reasoning
+            and self.reasoning is not None
+            and self.reasoning <= self.completion
+        ):
+            reasoning = _reasoning_extra(self.reasoning)
+        return Metrics(
+            prompt_tokens=self.prompt,
+            completion_tokens=self.completion,
+            cached_tokens=self.cached,
+            cost_usd=None if cost_usd is None else self.cost,
+            extra=reasoning,
+        )
+
 
 # Redaction patterns (REDA-01..04). Redaction composes three stages in order:
 # (1) auth-header + auth-scheme rules (redact_structured_text) so a
@@ -835,8 +895,8 @@ class Invocation:
     # #747). The CostEvent handler reconciles each CostEvent's totals against
     # this sum (per-dimension take-max delta) instead of trusting the collapsed
     # per-message digits or blindly re-accumulating restated totals.
-    _inv_metrics_sum: dict[str, float | int] = field(
-        default_factory=lambda: {"prompt": 0, "completion": 0, "cached": 0, "cost": 0.0}
+    _inv_metrics_sum: _InvMetricsSum = field(
+        default_factory=lambda: _InvMetricsSum(prompt=0, completion=0, cached=0, cost=0.0)
     )
 
     def observe_user_step(self, prompt: str) -> None:
@@ -914,6 +974,27 @@ class Invocation:
             self._dispatch(event)
         except Exception as exc:  # noqa: BLE001 - recording must never crash a run (Architecture Q7)
             print_warning(_console, f"Trajectory recording: {type(exc).__name__}: {exc}")
+
+    def _reconcile_cost_delta(self, event: CostEvent) -> _CostDelta:
+        """Compute the per-dimension take-max CostEvent residual (issue #747).
+
+        The amount by which this CostEvent's total EXCEEDS the invocation's
+        per-message MetricsEvent sum (``max(0, total - sum)``). Claude's
+        authoritative session total exceeds the collapsed per-message single
+        digits, so a positive delta is the true repair magnitude; codex/pi
+        re-state the already summed totals, so delta 0 and the restatement
+        never double-counts. Isolated here so the delta semantics are
+        unit-testable independently of the observe() dispatch ladder.
+        """
+        return _CostDelta(
+            prompt=max(0, (event.input_tokens or 0) - self._inv_metrics_sum["prompt"]),
+            completion=max(
+                0, (event.output_tokens or 0) - self._inv_metrics_sum["completion"]
+            ),
+            cached=max(0, (event.cached_tokens or 0) - self._inv_metrics_sum["cached"]),
+            cost=max(0.0, (event.cost_usd or 0.0) - self._inv_metrics_sum["cost"]),
+            reasoning=event.reasoning_tokens,
+        )
 
     def _dispatch(self, event: Any) -> None:
         # Function-local imports avoid load-order cycles with daydream.backends.
@@ -993,10 +1074,12 @@ class Invocation:
             # tests/contract/test_backend_codex_trajectory.py); it is not a
             # silent coarsening.
             target = self._open_step_dict
-            if target is None:
+            if target is None and not self.steps:
+                # No open Step and no prior agent Step to attach to: mint a
+                # fresh one (a metrics-only backend with no Text/TurnEnd ever
+                # reaching the recorder).
                 self._ensure_open_step()
                 target = self._open_step_dict
-            assert target is not None
             # #192: reasoning_tokens is a SUBSET of completion_tokens (not
             # additive). Vendored Metrics has no dedicated field (D-03), so
             # carry it via the documented extension carrier ``extra``.
@@ -1012,10 +1095,25 @@ class Invocation:
                 cost_usd=event.cost_usd,
                 extra=_reasoning_extra(event.reasoning_tokens),
             )
-            prior = target["_metrics"]
-            target["_metrics"] = incoming if prior is None else _merge_metrics(prior, incoming)
+            if target is not None:
+                # Open Step still in flight (Claude/Pi — usage arrives while the
+                # turn Step is open). Fold the per-turn metrics onto it.
+                prior = target["_metrics"]
+                target["_metrics"] = (
+                    incoming if prior is None else _merge_metrics(prior, incoming)
+                )
+                if event.model_name:
+                    target["_model_name"] = event.model_name
+            else:
+                # Closed-Step fallback (Codex D-04): the turn's usage arrives on
+                # ``turn.completed`` AFTER its content Step was closed by the
+                # ``TurnEndEvent``. Fold onto the most recently closed agent Step
+                # so each turn keeps ONE metrics-bearing Step — matching Claude,
+                # which folds onto its still-open final turn Step — instead of
+                # minting a phantom empty-message Step that splits Codex/Claude
+                # Step parity (test_backend_step_parity.py, issue #747).
+                self._fold_metrics_into_closed_last_step(event, incoming)
             if event.model_name:
-                target["_model_name"] = event.model_name
                 self.recorder._upgrade_model_name(event.model_name)
             # Aggregate into recorder-level totals for FinalMetrics (MAP-07),
             # and into the invocation-level sum the CostEvent delta reconciles
@@ -1046,41 +1144,22 @@ class Invocation:
             # under-count; codex/pi re-state totals equal to the per-message
             # sum -> delta 0, so the restatement never double-counts. Never
             # negative, never subtraction.
-            delta_prompt = max(0, (event.input_tokens or 0) - int(self._inv_metrics_sum["prompt"]))
-            delta_completion = max(
-                0, (event.output_tokens or 0) - int(self._inv_metrics_sum["completion"])
-            )
-            delta_cached = max(0, (event.cached_tokens or 0) - int(self._inv_metrics_sum["cached"]))
-            delta_cost = max(0.0, (event.cost_usd or 0.0) - float(self._inv_metrics_sum["cost"]))
-            self._ensure_open_step()
-            assert self._open_step_dict is not None
-            target = self._open_step_dict
-            existing = target["_metrics"]
-            if existing is None:
-                # #192: reasoning_tokens (subset of completion_tokens) via
-                # Metrics.extra — vendored Metrics has no field (D-03). The
-                # fresh step E holds only the residual delta this CostEvent
-                # adds beyond the invocation's per-message sum, so
-                # ``Σ steps == recorder total`` holds (issue #747). Reasoning
-                # stays a subset: only carried when it does not exceed the
-                # step's completion.
-                reasoning = None
-                if (
-                    event.reasoning_tokens is not None
-                    and event.reasoning_tokens <= delta_completion
-                ):
-                    reasoning = _reasoning_extra(event.reasoning_tokens)
-                target["_metrics"] = Metrics(
-                    prompt_tokens=delta_prompt,
-                    completion_tokens=delta_completion,
-                    cached_tokens=delta_cached,
-                    cost_usd=None if event.cost_usd is None else delta_cost,
-                    extra=reasoning,
-                )
-            else:
-                # MetricsEvent already populated this step. Prefer the
-                # existing token counts but backfill cost_usd if it wasn't
-                # surfaced per-message.
+            delta = self._reconcile_cost_delta(event)
+            existing = self._open_step_dict["_metrics"] if self._open_step_dict is not None else None
+            if existing is not None:
+                # A MetricsEvent already populated this step. Fold the residual
+                # delta onto it (previously only the recorder-level tally
+                # absorbed it, so the Step's rollup dropped the magnitude and
+                # ``Σ steps < final``). Then backfill cost_usd / reasoning the
+                # per-message path didn't surface. ``Σ steps == final`` holds
+                # here too (issue #747).
+                if delta.nonzero:
+                    existing = _merge_metrics(
+                        existing,
+                        delta.residual_metrics(
+                            cost_usd=event.cost_usd, include_reasoning=False
+                        ),
+                    )
                 updates: dict[str, Any] = {}
                 if existing.cost_usd is None and event.cost_usd is not None:
                     updates["cost_usd"] = event.cost_usd
@@ -1094,20 +1173,39 @@ class Invocation:
                     merged_extra["reasoning_tokens"] = event.reasoning_tokens
                     updates["extra"] = merged_extra
                 if updates:
-                    target["_metrics"] = existing.model_copy(update=updates)
+                    existing = existing.model_copy(update=updates)
+                assert self._open_step_dict is not None
+                self._open_step_dict["_metrics"] = existing
+            elif delta.nonzero:
+                # No metrics-bearing step is open and the residual is non-zero:
+                # mint a fresh residual Step holding exactly the delta this
+                # CostEvent adds beyond the invocation's per-message sum, so
+                # ``Σ steps == recorder total`` holds (issue #747).
+                # reasoning_tokens (#192) is a subset of completion_tokens and
+                # rides in Metrics.extra (D-03).
+                self._ensure_open_step()
+                assert self._open_step_dict is not None
+                self._open_step_dict["_metrics"] = delta.residual_metrics(
+                    cost_usd=event.cost_usd, include_reasoning=True
+                )
+            # else: a delta-0 restatement (codex/pi) with no metrics-bearing
+            # step open has nothing to fold — do NOT mint a phantom all-zero
+            # Metrics Step that would inflate total_steps and per-step lists
+            # in archived trajectories and rendered reports (issue #747).
             if event.model_name:
-                target["_model_name"] = event.model_name
+                if self._open_step_dict is not None:
+                    self._open_step_dict["_model_name"] = event.model_name
                 self.recorder._upgrade_model_name(event.model_name)
             # Aggregate the delta into recorder-level totals: per-dimension
             # take-max at the per-invocation level, summed across invocations
             # (a multi-phase run shares one recorder, so each phase's session
             # total should sum). A CostEvent-only backend (no MetricsEvents at
-            # all) still accumulates its full totals via the delta.
+            # all) still totals by the full delta.
             self.recorder._accumulate_metrics(
-                prompt_tokens=delta_prompt,
-                completion_tokens=delta_completion,
-                cached_tokens=delta_cached,
-                cost_usd=None if event.cost_usd is None else delta_cost,
+                prompt_tokens=delta.prompt,
+                completion_tokens=delta.completion,
+                cached_tokens=delta.cached,
+                cost_usd=None if event.cost_usd is None else delta.cost,
             )
         elif isinstance(event, ResultEvent):
             self._close_open_step()
@@ -1218,6 +1316,38 @@ class Invocation:
             )
         updated = existing.model_copy(update={"observation": new_observation})
         self.steps[closed_index] = self.recorder.redactor.redact_step(updated)
+
+    def _fold_metrics_into_closed_last_step(
+        self, event: Any, incoming: Metrics
+    ) -> None:
+        """Fold a terminal ``MetricsEvent`` onto the last closed agent Step.
+
+        Codex emits each turn's usage on ``turn.completed``, which arrives AFTER
+        that turn's content Step was closed by its ``TurnEndEvent`` (D-04).
+        Rather than mint a phantom empty-message Step — which would make Codex's
+        agent Step stream one longer than Claude's, where the same usage lands on
+        the still-open final turn Step — fold the usage into the most recently
+        closed agent Step so both backends emit identical Step shapes (the parity
+        gate in ``tests/contract/test_backend_step_parity.py``). ``Σ steps ==
+        final`` is preserved because the metrics still accumulate on a Step
+        (issue #747).
+        """
+        for idx in range(len(self.steps) - 1, -1, -1):
+            step = self.steps[idx]
+            if step.source != "agent":
+                continue
+            metrics = (
+                incoming
+                if step.metrics is None
+                else _merge_metrics(step.metrics, incoming)
+            )
+            updates: dict[str, Any] = {"metrics": metrics}
+            if event.model_name:
+                updates["model_name"] = event.model_name
+            self.steps[idx] = self.recorder.redactor.redact_step(
+                step.model_copy(update=updates)
+            )
+            return
 
     def snapshot_steps(self, *, snapshot_step_id: int | None = None) -> list[Step]:
         """Return steps including a materialized copy of any open step (signal-safe, non-mutating).

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -831,6 +831,13 @@ class Invocation:
     _in_flight_tools: dict[str, dict[str, Any]] = field(default_factory=dict)
     _stop_reason: str | None = None
     _error_subtype: str | None = None
+    # Per-invocation sum of the MetricsEvent values observed so far (issue
+    # #747). The CostEvent handler reconciles each CostEvent's totals against
+    # this sum (per-dimension take-max delta) instead of trusting the collapsed
+    # per-message digits or blindly re-accumulating restated totals.
+    _inv_metrics_sum: dict[str, float | int] = field(
+        default_factory=lambda: {"prompt": 0, "completion": 0, "cached": 0, "cost": 0.0}
+    )
     # Set-once per invocation: did any MetricsEvent already carry tokens / cost?
     # A trailing CostEvent that re-states what MetricsEvents reported must not
     # accumulate again (codex re-states per turn, pi re-states the summed
@@ -1020,10 +1027,20 @@ class Invocation:
             if event.model_name:
                 target["_model_name"] = event.model_name
                 self.recorder._upgrade_model_name(event.model_name)
-            # Aggregate into recorder-level totals for FinalMetrics (MAP-07).
+            # Aggregate into recorder-level totals for FinalMetrics (MAP-07),
+            # and into the invocation-level sum the CostEvent delta reconciles
+            # against (issue #747).
             self._tokens_from_metrics = True
             if event.cost_usd is not None:
                 self._cost_from_metrics = True
+            if event.prompt_tokens is not None:
+                self._inv_metrics_sum["prompt"] += event.prompt_tokens
+            if event.completion_tokens is not None:
+                self._inv_metrics_sum["completion"] += event.completion_tokens
+            if event.cached_tokens is not None:
+                self._inv_metrics_sum["cached"] += event.cached_tokens
+            if event.cost_usd is not None:
+                self._inv_metrics_sum["cost"] += event.cost_usd
             self.recorder._accumulate_metrics(
                 prompt_tokens=event.prompt_tokens,
                 completion_tokens=event.completion_tokens,
@@ -1034,6 +1051,20 @@ class Invocation:
             # End-of-call signal — also fold per-step metrics onto the open
             # Step so the renderer's per-step rollup sees real cost / tokens
             # (Bug C: previously CostEvent only updated _final_totals).
+            #
+            # Per-dimension take-max delta (issue #747): the amount by which
+            # this CostEvent's total EXCEEDS the invocation's per-message sum.
+            # Claude's authoritative session total exceeds the collapsed
+            # per-message single digits -> positive delta repairs the
+            # under-count; codex/pi re-state totals equal to the per-message
+            # sum -> delta 0, so the restatement never double-counts. Never
+            # negative, never subtraction.
+            delta = {
+                "prompt": max(0, (event.input_tokens or 0) - self._inv_metrics_sum["prompt"]),
+                "completion": max(0, (event.output_tokens or 0) - self._inv_metrics_sum["completion"]),
+                "cached": max(0, (event.cached_tokens or 0) - self._inv_metrics_sum["cached"]),
+                "cost": max(0.0, (event.cost_usd or 0.0) - self._inv_metrics_sum["cost"]),
+            }
             self._ensure_open_step()
             assert self._open_step_dict is not None
             target = self._open_step_dict
@@ -1069,16 +1100,16 @@ class Invocation:
             if event.model_name:
                 target["_model_name"] = event.model_name
                 self.recorder._upgrade_model_name(event.model_name)
-            # Aggregate into recorder-level totals, but only for the dimensions
-            # no MetricsEvent already reported this invocation — codex re-states
-            # each turn's tokens/cost here and pi re-states the summed totals,
-            # so unconditional accumulation double-counts. A CostEvent-only
-            # backend still accumulates fully.
+            # Aggregate the delta into recorder-level totals: per-dimension
+            # take-max at the per-invocation level, summed across invocations
+            # (a multi-phase run shares one recorder, so each phase's session
+            # total should sum). A CostEvent-only backend (no MetricsEvents at
+            # all) still accumulates its full totals via the delta.
             self.recorder._accumulate_metrics(
-                prompt_tokens=None if self._tokens_from_metrics else event.input_tokens,
-                completion_tokens=None if self._tokens_from_metrics else event.output_tokens,
-                cached_tokens=None if self._tokens_from_metrics else event.cached_tokens,
-                cost_usd=None if self._cost_from_metrics else event.cost_usd,
+                prompt_tokens=delta["prompt"],
+                completion_tokens=delta["completion"],
+                cached_tokens=delta["cached"],
+                cost_usd=None if event.cost_usd is None else delta["cost"],
             )
         elif isinstance(event, ResultEvent):
             self._close_open_step()

--- a/tests/harness/trajectory.py
+++ b/tests/harness/trajectory.py
@@ -43,6 +43,22 @@ def read_trajectory(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def step_token_sum(traj: dict[str, Any], key: str) -> int:
+    """Sum ``metrics[key]`` across agent steps that carry it.
+
+    Reconciliation invariant: the step-level rollup's per-dimension sum must
+    equal the recorder's final_metrics total (``Σ steps == final``). Steps
+    whose ``metrics`` block is absent, or which lack the requested key, are
+    skipped so a phantom all-zero residual step can never contribute a zero
+    line item to the sum.
+    """
+    return sum(
+        s["metrics"][key]
+        for s in traj["steps"]
+        if s.get("metrics") and s["metrics"].get(key)
+    )
+
+
 def observe_text_and_result(inv: Invocation, text: str = "output") -> None:
     """Observe a TextEvent + ResultEvent to produce a minimal agent step."""
     inv.observe(TextEvent(text=text))

--- a/tests/harness/trajectory.py
+++ b/tests/harness/trajectory.py
@@ -12,7 +12,13 @@ from pathlib import Path
 from typing import Any
 
 from daydream.archive.manifest import Manifest
-from daydream.backends import ResultEvent, TextEvent
+from daydream.backends import (
+    CostEvent,
+    MetricsEvent,
+    ResultEvent,
+    TextEvent,
+    TurnEndEvent,
+)
 from daydream.trajectory import (
     DaydreamRunFlow,
     Invocation,
@@ -57,6 +63,29 @@ def step_token_sum(traj: dict[str, Any], key: str) -> int:
         for s in traj["steps"]
         if s.get("metrics") and s["metrics"].get(key)
     )
+
+
+def observe_claude_shape(inv: Invocation) -> None:
+    """Observe a Claude-shaped stream: 5 per-message single-digit MetricsEvents
+    (one per turn) + the authoritative session-total CostEvent + ResultEvent.
+
+    Shared by the token-reconciliation and renderer tests so a future token
+    dimension is added in exactly one place (issue #747). The per-message
+    completion is a near-constant single digit (SDK bug shape) while the
+    CostEvent carries the authoritative whole-call session total — the exact
+    shape that exercises the reconciliation delta.
+    """
+    for i, c in enumerate((12, 9, 11, 8, 10)):
+        inv.observe(TextEvent(text=f"turn {i}"))
+        inv.observe(
+            MetricsEvent(message_id=f"m{i}", prompt_tokens=100,
+                         completion_tokens=c, cached_tokens=None,
+                         cost_usd=None)
+        )
+        inv.observe(TurnEndEvent(message_id=f"m{i}"))
+    inv.observe(CostEvent(cost_usd=0.5, input_tokens=600,
+                          output_tokens=66_737, cached_tokens=None))
+    inv.observe(ResultEvent(structured_output=None, continuation=None))
 
 
 def observe_text_and_result(inv: Invocation, text: str = "output") -> None:

--- a/tests/test_multi_turn_tokens.py
+++ b/tests/test_multi_turn_tokens.py
@@ -31,7 +31,6 @@ from daydream.backends import (
 from daydream.trajectory import DaydreamPhase
 from tests.harness.trajectory import make_recorder, read_trajectory
 
-
 # -- Per-phase session totals (one run_agent call per phase) -----------------
 # Claude-shaped stream: near-constant single-digit completion_tokens per
 # message, with the authoritative whole-call session total on the CostEvent.

--- a/tests/test_multi_turn_tokens.py
+++ b/tests/test_multi_turn_tokens.py
@@ -29,7 +29,7 @@ from daydream.backends import (
     TurnEndEvent,
 )
 from daydream.trajectory import DaydreamPhase
-from tests.harness.trajectory import make_recorder, read_trajectory
+from tests.harness.trajectory import make_recorder, read_trajectory, step_token_sum
 
 # -- Per-phase session totals (one run_agent call per phase) -----------------
 # Claude-shaped stream: near-constant single-digit completion_tokens per
@@ -132,8 +132,7 @@ async def test_reconciled_totals_not_per_message_collapse(tmp_path: Path) -> Non
 
     final = traj["final_metrics"]
     assert final["total_completion_tokens"] == sum(_PHASE_SESSION_TOTALS)
-    step_sum = sum(s["metrics"]["completion_tokens"] for s in traj["steps"]
-                   if s.get("metrics") and s["metrics"].get("completion_tokens"))
+    step_sum = step_token_sum(traj, "completion_tokens")
     assert final["total_completion_tokens"] == step_sum
 
 
@@ -145,8 +144,7 @@ async def test_final_metrics_sum_matches_per_step_totals(tmp_path: Path) -> None
 
     final = traj["final_metrics"]
     assert final["total_completion_tokens"] == sum(_PHASE_SESSION_TOTALS)  # 181_737
-    step_sum = sum(s["metrics"]["completion_tokens"] for s in traj["steps"]
-                   if s.get("metrics") and s["metrics"].get("completion_tokens"))
+    step_sum = step_token_sum(traj, "completion_tokens")
     assert final["total_completion_tokens"] == step_sum
     # Prompt: per-call authoritative CostEvent total (600) per phase.
     assert final["total_prompt_tokens"] == 600 * 3  # 1800
@@ -412,11 +410,7 @@ async def test_step_metrics_sum_equals_final_metrics(tmp_path: Path) -> None:
     """The ``final == Σ steps`` invariant holds once steps accumulate."""
     traj = await _drive_one(tmp_path, _MetricsOnlyBackend(turns=3, in_tok=100, out_tok=10))
 
-    step_sum = sum(
-        s["metrics"]["prompt_tokens"]
-        for s in traj["steps"]
-        if s.get("metrics") and s["metrics"].get("prompt_tokens")
-    )
+    step_sum = step_token_sum(traj, "prompt_tokens")
     assert traj["final_metrics"]["total_prompt_tokens"] == step_sum == 300
 
 

--- a/tests/test_multi_turn_tokens.py
+++ b/tests/test_multi_turn_tokens.py
@@ -1,13 +1,11 @@
-"""TEST-06: Empirical multi-turn fixture verifying per-call token semantics.
+"""TEST-06: Empirical multi-turn fixture verifying session total reconciliation.
 
 Drives 3 sequential run_agent() calls through a MockBackend with known token
-values. Asserts each agent step's Metrics.prompt_tokens matches the per-call
-value (not cumulative). This is a gate test -- it passes or fails. No
-conditional delta-subtraction logic.
-
-Per Phase 2 D-14, we trust per-call semantics for claude-agent-sdk==0.1.52.
-If this test fails, the token extraction in backends/claude.py needs a
-last_seen_cumulative subtract step.
+values. Asserts the recorded final metrics reflect the authoritative per-call
+session totals (reconciled via per-dimension take-max delta, issue #747), NOT
+the collapsed per-message single digits — the under-count is caught, not
+blessed. This is a gate test -- it passes or fails. No conditional
+delta-subtraction logic.
 """
 
 from __future__ import annotations
@@ -15,7 +13,7 @@ from __future__ import annotations
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, TypedDict
+from typing import Any
 
 import pytest
 
@@ -34,18 +32,10 @@ from daydream.trajectory import DaydreamPhase
 from tests.harness.trajectory import make_recorder, read_trajectory
 
 
-# -- Token value constants for the 3-turn sequence --------------------------
-class _TurnTokens(TypedDict):
-    prompt_tokens: int
-    completion_tokens: int
-    cached_tokens: int
-    cost_usd: float
-
-
-TURN_1: _TurnTokens = {"prompt_tokens": 100, "completion_tokens": 20, "cached_tokens": 5, "cost_usd": 0.001}
-TURN_2: _TurnTokens = {"prompt_tokens": 150, "completion_tokens": 30, "cached_tokens": 10, "cost_usd": 0.002}
-TURN_3: _TurnTokens = {"prompt_tokens": 200, "completion_tokens": 40, "cached_tokens": 15, "cost_usd": 0.003}
-TURNS: list[_TurnTokens] = [TURN_1, TURN_2, TURN_3]
+# -- Per-phase session totals (one run_agent call per phase) -----------------
+# Claude-shaped stream: near-constant single-digit completion_tokens per
+# message, with the authoritative whole-call session total on the CostEvent.
+_PHASE_SESSION_TOTALS: list[int] = [66_737, 60_000, 55_000]
 PHASES = [DaydreamPhase.REVIEW, DaydreamPhase.FIX, DaydreamPhase.TEST]
 
 
@@ -84,17 +74,22 @@ class MockBackend:
 
 
 def _make_backend(turn_idx: int) -> MockBackend:
-    """Build a MockBackend for the given turn index (0, 1, 2)."""
-    t = TURNS[turn_idx]
+    """Claude-shaped mock: completion is a near-constant single digit per
+    message (SDK bug shape); the authoritative whole-call session total rides
+    the per-call CostEvent (mirrors the real claude-agent-sdk emission order:
+    MetricsEvent per message, then CostEvent)."""
     return MockBackend([
         TextEvent(text=f"turn {turn_idx + 1} output"),
         MetricsEvent(
-            message_id=f"msg_{turn_idx + 1:02d}",
-            prompt_tokens=t["prompt_tokens"],
-            completion_tokens=t["completion_tokens"],
-            cached_tokens=t["cached_tokens"],
-            cost_usd=t["cost_usd"],
+            message_id=f"msg_{turn_idx:02d}",
+            prompt_tokens=[100, 150, 200][turn_idx],
+            completion_tokens=12,   # near-constant single digit (SDK bug shape)
+            cached_tokens=None,
+            cost_usd=None,
         ),
+        TurnEndEvent(message_id=f"msg_{turn_idx:02d}"),
+        CostEvent(cost_usd=0.5, input_tokens=600,
+                  output_tokens=_PHASE_SESSION_TOTALS[turn_idx], cached_tokens=None),
         ResultEvent(structured_output=None, continuation=None),
     ])
 
@@ -110,37 +105,54 @@ async def _run_three_turns(tmp_path: Path) -> dict[str, Any]:
 
 
 async def test_per_call_token_values_not_cumulative(tmp_path: Path) -> None:
-    """SDK #112 gate: per-step prompt_tokens matches per-call value, not cumulative."""
+    """SDK #112 gate: per-turn step prompt_tokens matches the per-call value,
+    not cumulative (100, 250, 450)."""
     traj = await _run_three_turns(tmp_path)
     assert atif_validate(traj) is True
 
     agent_steps = [s for s in traj["steps"] if s["source"] == "agent"]
-    assert len(agent_steps) == 3
 
-    # Per-call values -- NOT cumulative (100, 250, 450)
-    assert agent_steps[0]["metrics"]["prompt_tokens"] == 100
-    assert agent_steps[1]["metrics"]["prompt_tokens"] == 150
-    assert agent_steps[2]["metrics"]["prompt_tokens"] == 200
-
-    assert agent_steps[0]["metrics"]["completion_tokens"] == 20
-    assert agent_steps[1]["metrics"]["completion_tokens"] == 30
-    assert agent_steps[2]["metrics"]["completion_tokens"] == 40
-
-    assert agent_steps[0]["metrics"]["cached_tokens"] == 5
-    assert agent_steps[1]["metrics"]["cached_tokens"] == 10
-    assert agent_steps[2]["metrics"]["cached_tokens"] == 15
+    # Per-call values -- NOT cumulative. Read off the per-turn steps only
+    # (completion == the near-constant single digit 12 distinguishes them from
+    # the residual CostEvent steps; do not index agent_steps[i], the residual
+    # steps shift indices).
+    turn_steps = [
+        s for s in agent_steps
+        if s.get("metrics")
+        and s["metrics"].get("prompt_tokens")
+        and s["metrics"].get("completion_tokens") == 12
+    ]
+    assert [s["metrics"]["prompt_tokens"] for s in turn_steps] == [100, 150, 200]
 
 
-async def test_final_metrics_sum_matches_per_step_totals(tmp_path: Path) -> None:
-    """FinalMetrics totals are the sum of per-step values across all 3 turns."""
+async def test_reconciled_totals_not_per_message_collapse(tmp_path: Path) -> None:
+    """The 3-phase run's final completion == Σ session totals (NOT Σ per-message
+    single digits), and final == Σ steps — the under-count is caught, not blessed."""
     traj = await _run_three_turns(tmp_path)
     assert atif_validate(traj) is True
 
     final = traj["final_metrics"]
-    assert final["total_prompt_tokens"] == 100 + 150 + 200  # 450
-    assert final["total_completion_tokens"] == 20 + 30 + 40  # 90
-    assert final["total_cached_tokens"] == 5 + 10 + 15  # 30
-    assert final["total_cost_usd"] == pytest.approx(0.001 + 0.002 + 0.003)  # 0.006
+    assert final["total_completion_tokens"] == sum(_PHASE_SESSION_TOTALS)
+    step_sum = sum(s["metrics"]["completion_tokens"] for s in traj["steps"]
+                   if s.get("metrics") and s["metrics"].get("completion_tokens"))
+    assert final["total_completion_tokens"] == step_sum
+
+
+async def test_final_metrics_sum_matches_per_step_totals(tmp_path: Path) -> None:
+    """FinalMetrics totals are the sum of per-step values across all 3 phases,
+    matching the reconciled session totals (not the collapsed single digits)."""
+    traj = await _run_three_turns(tmp_path)
+    assert atif_validate(traj) is True
+
+    final = traj["final_metrics"]
+    assert final["total_completion_tokens"] == sum(_PHASE_SESSION_TOTALS)  # 181_737
+    step_sum = sum(s["metrics"]["completion_tokens"] for s in traj["steps"]
+                   if s.get("metrics") and s["metrics"].get("completion_tokens"))
+    assert final["total_completion_tokens"] == step_sum
+    # Prompt: per-call authoritative CostEvent total (600) per phase.
+    assert final["total_prompt_tokens"] == 600 * 3  # 1800
+    # Cost: one CostEvent per phase.
+    assert final["total_cost_usd"] == pytest.approx(0.5 * 3)  # 1.5
 
 
 async def test_each_step_carries_correct_phase_label(tmp_path: Path) -> None:
@@ -149,11 +161,9 @@ async def test_each_step_carries_correct_phase_label(tmp_path: Path) -> None:
     assert atif_validate(traj) is True
 
     agent_steps = [s for s in traj["steps"] if s["source"] == "agent"]
-    assert len(agent_steps) == 3
-
-    assert agent_steps[0]["extra"]["daydream_phase"] == "review"
-    assert agent_steps[1]["extra"]["daydream_phase"] == "fix"
-    assert agent_steps[2]["extra"]["daydream_phase"] == "test"
+    # 2 metric-bearing steps per phase (per-turn step + residual CostEvent step).
+    phases = [s["extra"]["daydream_phase"] for s in agent_steps]
+    assert phases == ["review", "review", "fix", "fix", "test", "test"]
 
 
 # -- CostEvent must not re-count what MetricsEvents already reported ---------

--- a/tests/test_pr_comment_renderer.py
+++ b/tests/test_pr_comment_renderer.py
@@ -7,6 +7,7 @@ called out in S2.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import re
 from pathlib import Path
@@ -14,8 +15,16 @@ from typing import Any
 
 import pytest
 
+from daydream.backends import (
+    CostEvent,
+    MetricsEvent,
+    ResultEvent,
+    TextEvent,
+    TurnEndEvent,
+)
 from daydream.pr_comment_renderer import _PHASE_LABELS, _format_duration, render_run_info_block
 from daydream.trajectory import DaydreamPhase
+from tests.harness.trajectory import make_recorder
 
 # Committed fixtures cover Claude (cost_usd present) and Codex (cost_usd null,
 # synthesized via pricing). Tests needing a specific shape build inline via _write_trajectory.
@@ -689,3 +698,44 @@ def test_phase_labels_covers_all_daydream_phases() -> None:
         assert phase.value in _PHASE_LABELS, (
             f"DaydreamPhase.{phase.name} (value={phase.value!r}) is missing from _PHASE_LABELS"
         )
+
+
+# -- Reconciled per-step metrics feed the per-phase rollup (issue #747) ------
+def _write_reconciled_trajectory(tmp_path: Path) -> Path:
+    """Build a trajectory through the real recorder whose per-step metrics were
+    reconciled (Σ steps == session total): per-turn single-digit MetricsEvents
+    + TurnEndEvent + a final CostEvent carrying the authoritative session total.
+    Includes the leading user step (step_id 1) the renderer/validator expects.
+    Returns the written trajectory path.
+    """
+
+    async def _build() -> Path:
+        recorder = make_recorder(tmp_path)
+        async with recorder:
+            async with recorder.invocation(phase=DaydreamPhase.REVIEW) as inv:
+                inv.observe_user_step(prompt="go")
+                for i, c in enumerate((12, 9, 11, 8, 10)):
+                    inv.observe(TextEvent(text=f"turn {i}"))
+                    inv.observe(MetricsEvent(
+                        message_id=f"m{i}", prompt_tokens=100,
+                        completion_tokens=c, cached_tokens=None, cost_usd=None,
+                    ))
+                    inv.observe(TurnEndEvent(message_id=f"m{i}"))
+                inv.observe(CostEvent(cost_usd=0.5, input_tokens=600,
+                                      output_tokens=66_737, cached_tokens=None))
+                inv.observe(ResultEvent(structured_output=None, continuation=None))
+        return recorder.path
+
+    return asyncio.run(_build())
+
+
+def test_reconciled_phase_output_consistent_with_session_total(tmp_path: Path) -> None:
+    """A trajectory whose per-step metrics were reconciled (Σ == session total)
+    renders per-phase output tokens consistent with the session total, not the
+    collapsed per-message sum."""
+    path = _write_reconciled_trajectory(tmp_path)
+    rendered = render_run_info_block([path])
+    # The reconciled session total (rendered with thousand separators), not the
+    # collapsed per-message sum (~50).
+    assert "66,737 out" in rendered
+    assert "50 out" not in rendered   # no collapsed value leaks

--- a/tests/test_pr_comment_renderer.py
+++ b/tests/test_pr_comment_renderer.py
@@ -15,16 +15,9 @@ from typing import Any
 
 import pytest
 
-from daydream.backends import (
-    CostEvent,
-    MetricsEvent,
-    ResultEvent,
-    TextEvent,
-    TurnEndEvent,
-)
 from daydream.pr_comment_renderer import _PHASE_LABELS, _format_duration, render_run_info_block
 from daydream.trajectory import DaydreamPhase
-from tests.harness.trajectory import make_recorder
+from tests.harness.trajectory import make_recorder, observe_claude_shape
 
 # Committed fixtures cover Claude (cost_usd present) and Codex (cost_usd null,
 # synthesized via pricing). Tests needing a specific shape build inline via _write_trajectory.
@@ -710,20 +703,15 @@ def _write_reconciled_trajectory(tmp_path: Path) -> Path:
     """
 
     async def _build() -> Path:
-        recorder = make_recorder(tmp_path)
+        # Price the fixture model (claude-sonnet-5 is a MODEL_PRICES key) so the
+        # cost-reconciliation half of the invariant is exercised: with the default
+        # unpriced 'opus' model, cost synthesis can never run, phase.cost_unknown
+        # flips True and the cost cell degrades to '—' (issue #747).
+        recorder = make_recorder(tmp_path, agent_model_name="claude-sonnet-5")
         async with recorder:
             async with recorder.invocation(phase=DaydreamPhase.REVIEW) as inv:
                 inv.observe_user_step(prompt="go")
-                for i, c in enumerate((12, 9, 11, 8, 10)):
-                    inv.observe(TextEvent(text=f"turn {i}"))
-                    inv.observe(MetricsEvent(
-                        message_id=f"m{i}", prompt_tokens=100,
-                        completion_tokens=c, cached_tokens=None, cost_usd=None,
-                    ))
-                    inv.observe(TurnEndEvent(message_id=f"m{i}"))
-                inv.observe(CostEvent(cost_usd=0.5, input_tokens=600,
-                                      output_tokens=66_737, cached_tokens=None))
-                inv.observe(ResultEvent(structured_output=None, continuation=None))
+                observe_claude_shape(inv)
         return recorder.path
 
     return asyncio.run(_build())
@@ -739,3 +727,8 @@ def test_reconciled_phase_output_consistent_with_session_total(tmp_path: Path) -
     # collapsed per-message sum (~50).
     assert "66,737 out" in rendered
     assert "50 out" not in rendered   # no collapsed value leaks
+    # The priced fixture model lets cost synthesis run: the authoritative
+    # session cost_usd=0.5 renders (not '—'), so the cost-reconciliation half of
+    # the "consistent with session total" invariant is actually exercised.
+    assert "$0.50" in rendered
+    assert "Cost unavailable" not in rendered

--- a/tests/test_token_reconciliation.py
+++ b/tests/test_token_reconciliation.py
@@ -215,3 +215,41 @@ async def test_16kb_write_reports_real_completion(tmp_path):
     traj = await _run_write_agent(tmp_path, content="x" * 16_000)
     completion = traj["final_metrics"]["total_completion_tokens"]
     assert completion >= 1_000   # right order of magnitude; pre-fix it was ~50
+
+
+def _tool_argument_floor(traj):
+    """floor = SUM(len(json.dumps(tool_call['arguments'])) / 4) over recorded calls."""
+    total = 0
+    for s in traj["steps"]:
+        for tc in s.get("tool_calls") or []:
+            total += len(json.dumps(tc["arguments"]))
+    return total // 4
+
+
+@pytest.mark.asyncio
+async def test_tool_argument_invariant_holds_real_path(tmp_path):
+    """total_completion_tokens >= floor on a real-path Write-heavy run (passes post-fix)."""
+    traj = await _run_write_agent(tmp_path, content="y" * 16_000)
+    assert traj["final_metrics"]["total_completion_tokens"] >= _tool_argument_floor(traj)
+
+
+def test_tool_argument_invariant_fails_pre_fix_bundle():
+    """The gate is non-trivial: a hand-built pre-fix bundle (collapsed total) FAILS it."""
+    traj = _pre_fix_bundle()   # total_completion_tokens=50, one Write call with 16KB args
+    completion = traj["final_metrics"]["total_completion_tokens"]
+    assert completion < _tool_argument_floor(traj)
+
+
+def _pre_fix_bundle() -> dict[str, Any]:
+    """Minimal ATIF-shaped dict with a collapsed pre-fix completion total."""
+    return {
+        "final_metrics": {"total_completion_tokens": 50},
+        "steps": [{
+            "source": "agent",
+            "tool_calls": [{
+                "tool_call_id": "w1",
+                "function_name": "Write",
+                "arguments": {"file_path": "/tmp/f", "content": "z" * 16_000},
+            }],
+        }],
+    }

--- a/tests/test_token_reconciliation.py
+++ b/tests/test_token_reconciliation.py
@@ -13,6 +13,7 @@ emitted MetricsEvent lands on its own Step.
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -32,6 +33,72 @@ from daydream.backends import (
 )
 from daydream.trajectory import DaydreamPhase
 from tests.harness.trajectory import make_recorder, read_trajectory
+
+
+@dataclass
+class _MockBackend:
+    """Minimal Backend replaying a canned event list (mirrors the MockBackend
+    in tests/test_multi_turn_tokens.py)."""
+
+    model = "mock-model"
+    fanout_concurrency = 4
+    events: list[AgentEvent]
+
+    def execute(
+        self,
+        cwd: Path,
+        prompt: str,
+        output_schema: dict[str, Any] | None = None,
+        continuation: ContinuationToken | None = None,
+        agents: dict[str, Any] | None = None,
+        max_turns: int | None = None,
+        read_only: bool = False,
+        persist_session: bool = True,
+    ) -> Any:
+        events = self.events
+
+        async def _gen() -> Any:
+            for event in events:
+                yield event
+
+        return _gen()
+
+    async def cancel(self) -> None:
+        return None
+
+    def format_skill_invocation(self, skill_key: str, args: str = "") -> str:
+        return f"/{skill_key}"
+
+
+async def _run_tool_agent(
+    tmp_path: Path, *, turns: int, tools_per_turn: int
+) -> dict[str, Any]:
+    """Real-path run_agent: per turn a TextEvent, tools_per_turn tool pairs, a
+    MetricsEvent (single-digit completion), and a TurnEndEvent; then a CostEvent
+    carrying the authoritative session total and a ResultEvent."""
+    events: list[AgentEvent] = []
+    for turn in range(turns):
+        events.append(TextEvent(text=f"turn {turn}"))
+        for j in range(tools_per_turn):
+            events.append(ToolStartEvent(
+                id=f"t{turn}-{j}", name="Bash", input={"command": "x"}
+            ))
+            events.append(ToolResultEvent(id=f"t{turn}-{j}", output="ok", is_error=False))
+        events.append(MetricsEvent(
+            message_id=f"m{turn}", prompt_tokens=100, completion_tokens=10,
+            cached_tokens=None, cost_usd=None,
+        ))
+        events.append(TurnEndEvent(message_id=f"m{turn}"))
+    events.append(CostEvent(cost_usd=0.5, input_tokens=600,
+                            output_tokens=66_737, cached_tokens=None))
+    events.append(ResultEvent(structured_output=None, continuation=None))
+    recorder = make_recorder(tmp_path)
+    async with recorder:
+        await run_agent(
+            _MockBackend(events=events), tmp_path, "prompt", phase=DaydreamPhase.REVIEW
+        )
+    return read_trajectory(recorder.path)
+
 
 
 @pytest.mark.asyncio
@@ -77,6 +144,17 @@ async def test_claude_shape_step_sum_equals_final(tmp_path):
                    if s.get("metrics") and s["metrics"].get("completion_tokens"))
     assert step_sum == 66_737
     assert final["total_completion_tokens"] == step_sum
+
+
+@pytest.mark.asyncio
+async def test_multi_turn_turns_each_own_step(tmp_path):
+    """run_agent forwards TurnEndEvent (fix B): a 24-tool-call, 3-turn agent
+    records >2 steps and one metrics-bearing step per turn (not one collapsed)."""
+    traj = await _run_tool_agent(tmp_path, turns=3, tools_per_turn=8)
+    assert traj["final_metrics"]["total_steps"] > 2
+    metric_steps = [s for s in traj["steps"]
+                    if s["source"] == "agent" and s.get("metrics")]
+    assert len(metric_steps) >= 3   # one per turn, not collapsed to 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_token_reconciliation.py
+++ b/tests/test_token_reconciliation.py
@@ -53,3 +53,55 @@ async def test_claude_shape_final_reflects_session_total(tmp_path):
             inv.observe(ResultEvent(structured_output=None, continuation=None))
     traj = read_trajectory(recorder.path)
     assert traj["final_metrics"]["total_completion_tokens"] == 66_737
+
+
+@pytest.mark.asyncio
+async def test_claude_shape_step_sum_equals_final(tmp_path):
+    """The whole-run session total is distributed so SUM(steps) == final, keeping
+    the final == Σ steps invariant after per-turn steps + reconciliation."""
+    recorder = make_recorder(tmp_path)
+    async with recorder:
+        async with recorder.invocation(phase=DaydreamPhase.REVIEW) as inv:
+            for i, c in enumerate((12, 9, 11, 8, 10)):
+                inv.observe(TextEvent(text=f"turn {i}"))
+                inv.observe(MetricsEvent(message_id=f"m{i}", prompt_tokens=100,
+                                         completion_tokens=c, cached_tokens=None,
+                                         cost_usd=None))
+                inv.observe(TurnEndEvent(message_id=f"m{i}"))
+            inv.observe(CostEvent(cost_usd=0.5, input_tokens=600,
+                                  output_tokens=66_737, cached_tokens=None))
+            inv.observe(ResultEvent(structured_output=None, continuation=None))
+    traj = read_trajectory(recorder.path)
+    final = traj["final_metrics"]
+    step_sum = sum(s["metrics"]["completion_tokens"] for s in traj["steps"]
+                   if s.get("metrics") and s["metrics"].get("completion_tokens"))
+    assert step_sum == 66_737
+    assert final["total_completion_tokens"] == step_sum
+
+
+@pytest.mark.asyncio
+async def test_pi_shape_no_step_level_double_count(tmp_path):
+    """Pi-shaped stream (per-turn MetricsEvent w/ cost + restated final CostEvent)
+    must not double-count at the step level once per-turn steps are enabled."""
+    recorder = make_recorder(tmp_path)
+    async with recorder:
+        async with recorder.invocation(phase=DaydreamPhase.REVIEW) as inv:
+            for i in range(3):
+                inv.observe(TextEvent(text=f"turn {i}"))
+                inv.observe(MetricsEvent(message_id="", prompt_tokens=100,
+                                         completion_tokens=10, cached_tokens=None,
+                                         cost_usd=0.25))
+                inv.observe(TurnEndEvent(message_id=""))
+            inv.observe(CostEvent(cost_usd=0.75, input_tokens=300,
+                                  output_tokens=30, cached_tokens=None))
+            inv.observe(ResultEvent(structured_output=None, continuation=None))
+    traj = read_trajectory(recorder.path)
+    final = traj["final_metrics"]
+    step_sum = sum(s["metrics"]["completion_tokens"] for s in traj["steps"]
+                   if s.get("metrics") and s["metrics"].get("completion_tokens"))
+    step_cost = sum(s["metrics"].get("cost_usd") or 0 for s in traj["steps"]
+                    if s.get("metrics"))
+    assert final["total_completion_tokens"] == 30
+    assert step_sum == 30               # not 60
+    assert final["total_cost_usd"] == pytest.approx(0.75)
+    assert step_cost == pytest.approx(0.75)  # not 1.5

--- a/tests/test_token_reconciliation.py
+++ b/tests/test_token_reconciliation.py
@@ -31,8 +31,8 @@ from daydream.backends import (
     ToolStartEvent,
     TurnEndEvent,
 )
-from daydream.trajectory import DaydreamPhase
-from tests.harness.trajectory import make_recorder, read_trajectory
+from daydream.trajectory import DaydreamPhase, Invocation
+from tests.harness.trajectory import make_recorder, read_trajectory, step_token_sum
 
 
 @dataclass
@@ -124,6 +124,22 @@ async def _run_tool_agent(
 
 
 
+def _observe_claude_shape(inv: Invocation) -> None:
+    """Shared Claude-shaped observe() body: 5 per-message single-digit
+    MetricsEvents (one per turn) + the authoritative session-total CostEvent
+    + ResultEvent. Both claude-shape tests replay this so a future token
+    dimension is added in exactly one place."""
+    for i, c in enumerate((12, 9, 11, 8, 10)):
+        inv.observe(TextEvent(text=f"turn {i}"))
+        inv.observe(MetricsEvent(message_id=f"m{i}", prompt_tokens=100,
+                                 completion_tokens=c, cached_tokens=None,
+                                 cost_usd=None))
+        inv.observe(TurnEndEvent(message_id=f"m{i}"))
+    inv.observe(CostEvent(cost_usd=0.5, input_tokens=600,
+                          output_tokens=66_737, cached_tokens=None))
+    inv.observe(ResultEvent(structured_output=None, continuation=None))
+
+
 @pytest.mark.asyncio
 async def test_claude_shape_final_reflects_session_total(tmp_path):
     """Claude-shaped stream: per-message single-digit completion + authoritative
@@ -132,15 +148,7 @@ async def test_claude_shape_final_reflects_session_total(tmp_path):
     recorder = make_recorder(tmp_path)
     async with recorder:
         async with recorder.invocation(phase=DaydreamPhase.REVIEW) as inv:
-            for i, c in enumerate((12, 9, 11, 8, 10)):
-                inv.observe(TextEvent(text=f"turn {i}"))
-                inv.observe(MetricsEvent(message_id=f"m{i}", prompt_tokens=100,
-                                         completion_tokens=c, cached_tokens=None,
-                                         cost_usd=None))
-                inv.observe(TurnEndEvent(message_id=f"m{i}"))
-            inv.observe(CostEvent(cost_usd=0.5, input_tokens=600,
-                                  output_tokens=66_737, cached_tokens=None))
-            inv.observe(ResultEvent(structured_output=None, continuation=None))
+            _observe_claude_shape(inv)
     traj = read_trajectory(recorder.path)
     assert traj["final_metrics"]["total_completion_tokens"] == 66_737
 
@@ -152,19 +160,10 @@ async def test_claude_shape_step_sum_equals_final(tmp_path):
     recorder = make_recorder(tmp_path)
     async with recorder:
         async with recorder.invocation(phase=DaydreamPhase.REVIEW) as inv:
-            for i, c in enumerate((12, 9, 11, 8, 10)):
-                inv.observe(TextEvent(text=f"turn {i}"))
-                inv.observe(MetricsEvent(message_id=f"m{i}", prompt_tokens=100,
-                                         completion_tokens=c, cached_tokens=None,
-                                         cost_usd=None))
-                inv.observe(TurnEndEvent(message_id=f"m{i}"))
-            inv.observe(CostEvent(cost_usd=0.5, input_tokens=600,
-                                  output_tokens=66_737, cached_tokens=None))
-            inv.observe(ResultEvent(structured_output=None, continuation=None))
+            _observe_claude_shape(inv)
     traj = read_trajectory(recorder.path)
     final = traj["final_metrics"]
-    step_sum = sum(s["metrics"]["completion_tokens"] for s in traj["steps"]
-                   if s.get("metrics") and s["metrics"].get("completion_tokens"))
+    step_sum = step_token_sum(traj, "completion_tokens")
     assert step_sum == 66_737
     assert final["total_completion_tokens"] == step_sum
 
@@ -175,9 +174,13 @@ async def test_multi_turn_turns_each_own_step(tmp_path):
     records >2 steps and one metrics-bearing step per turn (not one collapsed)."""
     traj = await _run_tool_agent(tmp_path, turns=3, tools_per_turn=8)
     assert traj["final_metrics"]["total_steps"] > 2
-    metric_steps = [s for s in traj["steps"]
-                    if s["source"] == "agent" and s.get("metrics")]
-    assert len(metric_steps) >= 3   # one per turn, not collapsed to 1
+    # One metrics-bearing step per turn: the per-message single-digit (10)
+    # steps are the per-turn MetricsEvents; the CostEvent residual step
+    # (completion 66707) is reconciliation, not a turn, so it is excluded.
+    turn_steps = [s for s in traj["steps"]
+                  if s["source"] == "agent" and s.get("metrics")
+                  and s["metrics"].get("completion_tokens") == 10]
+    assert len(turn_steps) == 3   # exactly one per turn, not collapsed
 
 
 @pytest.mark.asyncio
@@ -198,8 +201,7 @@ async def test_pi_shape_no_step_level_double_count(tmp_path):
             inv.observe(ResultEvent(structured_output=None, continuation=None))
     traj = read_trajectory(recorder.path)
     final = traj["final_metrics"]
-    step_sum = sum(s["metrics"]["completion_tokens"] for s in traj["steps"]
-                   if s.get("metrics") and s["metrics"].get("completion_tokens"))
+    step_sum = step_token_sum(traj, "completion_tokens")
     step_cost = sum(s["metrics"].get("cost_usd") or 0 for s in traj["steps"]
                     if s.get("metrics"))
     assert final["total_completion_tokens"] == 30

--- a/tests/test_token_reconciliation.py
+++ b/tests/test_token_reconciliation.py
@@ -70,6 +70,29 @@ class _MockBackend:
         return f"/{skill_key}"
 
 
+async def _run_write_agent(tmp_path: Path, *, content: str) -> dict[str, Any]:
+    """Real-path run_agent with a Write-heavy tool call: a 16 KB content payload
+    in the tool arguments (like _run_tool_agent, one turn)."""
+    events: list[AgentEvent] = [
+        TextEvent(text="turn 0"),
+        ToolStartEvent(id="w1", name="Write",
+                       input={"file_path": "/tmp/f.txt", "content": content}),
+        ToolResultEvent(id="w1", output="ok", is_error=False),
+        MetricsEvent(message_id="m0", prompt_tokens=100, completion_tokens=10,
+                     cached_tokens=None, cost_usd=None),
+        TurnEndEvent(message_id="m0"),
+        CostEvent(cost_usd=0.5, input_tokens=600,
+                  output_tokens=66_737, cached_tokens=None),
+        ResultEvent(structured_output=None, continuation=None),
+    ]
+    recorder = make_recorder(tmp_path)
+    async with recorder:
+        await run_agent(
+            _MockBackend(events=events), tmp_path, "prompt", phase=DaydreamPhase.REVIEW
+        )
+    return read_trajectory(recorder.path)
+
+
 async def _run_tool_agent(
     tmp_path: Path, *, turns: int, tools_per_turn: int
 ) -> dict[str, Any]:
@@ -183,3 +206,12 @@ async def test_pi_shape_no_step_level_double_count(tmp_path):
     assert step_sum == 30               # not 60
     assert final["total_cost_usd"] == pytest.approx(0.75)
     assert step_cost == pytest.approx(0.75)  # not 1.5
+
+
+@pytest.mark.asyncio
+async def test_16kb_write_reports_real_completion(tmp_path):
+    """A Write-heavy agent (16 KB content in tool arguments) reports a real
+    total_completion_tokens magnitude, not double digits (the pre-fix bug)."""
+    traj = await _run_write_agent(tmp_path, content="x" * 16_000)
+    completion = traj["final_metrics"]["total_completion_tokens"]
+    assert completion >= 1_000   # right order of magnitude; pre-fix it was ~50

--- a/tests/test_token_reconciliation.py
+++ b/tests/test_token_reconciliation.py
@@ -1,0 +1,55 @@
+"""Correct completion-token accounting & real turn granularity (issue #747).
+
+Fix A: the recorder reconciles each CostEvent's totals against the
+invocation's per-message sum (per-dimension take-max delta), so the recorded
+final metrics reflect the authoritative session value instead of the
+collapsed per-message single digits, and fresh CostEvent steps carry only the
+residual so ``Σ steps == final`` holds.
+
+Fix B: run_agent's normal loop forwards TurnEndEvent so each turn's already-
+emitted MetricsEvent lands on its own Step.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from daydream.agent import run_agent
+from daydream.backends import (
+    AgentEvent,
+    ContinuationToken,
+    CostEvent,
+    MetricsEvent,
+    ResultEvent,
+    TextEvent,
+    ToolResultEvent,
+    ToolStartEvent,
+    TurnEndEvent,
+)
+from daydream.trajectory import DaydreamPhase
+from tests.harness.trajectory import make_recorder, read_trajectory
+
+
+@pytest.mark.asyncio
+async def test_claude_shape_final_reflects_session_total(tmp_path):
+    """Claude-shaped stream: per-message single-digit completion + authoritative
+    CostEvent session total -> final.total_completion_tokens == session total,
+    not the collapsed sum of per-message digits."""
+    recorder = make_recorder(tmp_path)
+    async with recorder:
+        async with recorder.invocation(phase=DaydreamPhase.REVIEW) as inv:
+            for i, c in enumerate((12, 9, 11, 8, 10)):
+                inv.observe(TextEvent(text=f"turn {i}"))
+                inv.observe(MetricsEvent(message_id=f"m{i}", prompt_tokens=100,
+                                         completion_tokens=c, cached_tokens=None,
+                                         cost_usd=None))
+                inv.observe(TurnEndEvent(message_id=f"m{i}"))
+            inv.observe(CostEvent(cost_usd=0.5, input_tokens=600,
+                                  output_tokens=66_737, cached_tokens=None))
+            inv.observe(ResultEvent(structured_output=None, continuation=None))
+    traj = read_trajectory(recorder.path)
+    assert traj["final_metrics"]["total_completion_tokens"] == 66_737

--- a/tests/test_token_reconciliation.py
+++ b/tests/test_token_reconciliation.py
@@ -13,7 +13,6 @@ emitted MetricsEvent lands on its own Step.
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -22,7 +21,6 @@ import pytest
 from daydream.agent import run_agent
 from daydream.backends import (
     AgentEvent,
-    ContinuationToken,
     CostEvent,
     MetricsEvent,
     ResultEvent,
@@ -31,43 +29,14 @@ from daydream.backends import (
     ToolStartEvent,
     TurnEndEvent,
 )
-from daydream.trajectory import DaydreamPhase, Invocation
-from tests.harness.trajectory import make_recorder, read_trajectory, step_token_sum
-
-
-@dataclass
-class _MockBackend:
-    """Minimal Backend replaying a canned event list (mirrors the MockBackend
-    in tests/test_multi_turn_tokens.py)."""
-
-    model = "mock-model"
-    fanout_concurrency = 4
-    events: list[AgentEvent]
-
-    def execute(
-        self,
-        cwd: Path,
-        prompt: str,
-        output_schema: dict[str, Any] | None = None,
-        continuation: ContinuationToken | None = None,
-        agents: dict[str, Any] | None = None,
-        max_turns: int | None = None,
-        read_only: bool = False,
-        persist_session: bool = True,
-    ) -> Any:
-        events = self.events
-
-        async def _gen() -> Any:
-            for event in events:
-                yield event
-
-        return _gen()
-
-    async def cancel(self) -> None:
-        return None
-
-    def format_skill_invocation(self, skill_key: str, args: str = "") -> str:
-        return f"/{skill_key}"
+from daydream.trajectory import DaydreamPhase
+from tests.harness.backend import ScriptedBackend
+from tests.harness.trajectory import (
+    make_recorder,
+    observe_claude_shape,
+    read_trajectory,
+    step_token_sum,
+)
 
 
 async def _run_write_agent(tmp_path: Path, *, content: str) -> dict[str, Any]:
@@ -88,7 +57,7 @@ async def _run_write_agent(tmp_path: Path, *, content: str) -> dict[str, Any]:
     recorder = make_recorder(tmp_path)
     async with recorder:
         await run_agent(
-            _MockBackend(events=events), tmp_path, "prompt", phase=DaydreamPhase.REVIEW
+            ScriptedBackend(events=events, model="mock-model"), tmp_path, "prompt", phase=DaydreamPhase.REVIEW
         )
     return read_trajectory(recorder.path)
 
@@ -118,26 +87,10 @@ async def _run_tool_agent(
     recorder = make_recorder(tmp_path)
     async with recorder:
         await run_agent(
-            _MockBackend(events=events), tmp_path, "prompt", phase=DaydreamPhase.REVIEW
+            ScriptedBackend(events=events, model="mock-model"), tmp_path, "prompt", phase=DaydreamPhase.REVIEW
         )
     return read_trajectory(recorder.path)
 
-
-
-def _observe_claude_shape(inv: Invocation) -> None:
-    """Shared Claude-shaped observe() body: 5 per-message single-digit
-    MetricsEvents (one per turn) + the authoritative session-total CostEvent
-    + ResultEvent. Both claude-shape tests replay this so a future token
-    dimension is added in exactly one place."""
-    for i, c in enumerate((12, 9, 11, 8, 10)):
-        inv.observe(TextEvent(text=f"turn {i}"))
-        inv.observe(MetricsEvent(message_id=f"m{i}", prompt_tokens=100,
-                                 completion_tokens=c, cached_tokens=None,
-                                 cost_usd=None))
-        inv.observe(TurnEndEvent(message_id=f"m{i}"))
-    inv.observe(CostEvent(cost_usd=0.5, input_tokens=600,
-                          output_tokens=66_737, cached_tokens=None))
-    inv.observe(ResultEvent(structured_output=None, continuation=None))
 
 
 @pytest.mark.asyncio
@@ -148,7 +101,7 @@ async def test_claude_shape_final_reflects_session_total(tmp_path):
     recorder = make_recorder(tmp_path)
     async with recorder:
         async with recorder.invocation(phase=DaydreamPhase.REVIEW) as inv:
-            _observe_claude_shape(inv)
+            observe_claude_shape(inv)
     traj = read_trajectory(recorder.path)
     assert traj["final_metrics"]["total_completion_tokens"] == 66_737
 
@@ -160,7 +113,7 @@ async def test_claude_shape_step_sum_equals_final(tmp_path):
     recorder = make_recorder(tmp_path)
     async with recorder:
         async with recorder.invocation(phase=DaydreamPhase.REVIEW) as inv:
-            _observe_claude_shape(inv)
+            observe_claude_shape(inv)
     traj = read_trajectory(recorder.path)
     final = traj["final_metrics"]
     step_sum = step_token_sum(traj, "completion_tokens")
@@ -255,3 +208,24 @@ def _pre_fix_bundle() -> dict[str, Any]:
             }],
         }],
     }
+
+@pytest.mark.asyncio
+async def test_metrics_no_agent_step_folds_to_minted_step(tmp_path):
+    """Round-2 #747: a MetricsEvent arriving with no open Step and no existing
+    agent Step (self.steps contains only a user/context step) must fold onto a
+    minted agent Step so the recorder-level tally still sums to final
+    (Sigma steps == final), instead of silently dropping the metrics."""
+    recorder = make_recorder(tmp_path)
+    async with recorder:
+        async with recorder.invocation(phase=DaydreamPhase.REVIEW) as inv:
+            inv.observe_user_step(prompt="go")  # non-agent user step only
+            # No TextEvent/TurnEnd: self.steps non-empty but no agent step.
+            inv.observe(MetricsEvent(message_id="m0", prompt_tokens=100,
+                                     completion_tokens=25, cached_tokens=None,
+                                     cost_usd=0.01))
+            inv.observe(ResultEvent(structured_output=None, continuation=None))
+    traj = read_trajectory(recorder.path)
+    final = traj["final_metrics"]
+    step_sum = step_token_sum(traj, "completion_tokens")
+    assert final.get("total_completion_tokens") == 25
+    assert step_sum == 25


### PR DESCRIPTION
## Summary

Fixes issue #747: Claude backend completion tokens were under-counted 15-20x (the correct session total is emitted on `CostEvent` but discarded by a de-dupe guard written for codex/pi), and all turns of an invocation collapsed into a single ATIF Step, making per-turn granularity unrecoverable from archived trajectories.

## Changes

- **`daydream/trajectory.py`**
  - Reconcile per-step completion to the session total via per-dimension take-max delta, keeping `sum == final`.
  - Reconcile cost deltas so step metrics sum to the final total.
  - Preserve `Sigma-steps == final` even when no `source == 'agent'` step exists (mint a metrics-bearing agent step).
  - Forward `TurnEndEvent` to close per-turn steps in the normal loop.
  - Type delta reconciliation values as int/float locals.
- **`daydream/agent.py`** — forward `TurnEndEvent` to close per-turn steps.
- **Tests** — new regression gates: 16KB Write fixture asserting real completion magnitude; tool-argument floor invariant; renderer reconciled-output assertion; claude-path fixture reworked to mirror real SDK token shape; per-step completion reconciliation.

## Test Plan

- `make check`: 3743 passed, 6 skipped, exit 0
- `ruff check`: clean
- Two sequential daydream deep-precision review rounds (on fresh exe.dev VMs) completed; all 5 round-2 findings addressed.

Closes #747