### PR TITLE
fix(eval): coverage read-detection blind to Claude Bash/grep reads (issue #739)

### DIFF
--- a/daydream/eval/analyzer.py
+++ b/daydream/eval/analyzer.py
@@ -218,7 +218,18 @@ _RG_LONG_VALUE_OPTS = frozenset(
     }
 )
 _RG_SHORT_VALUE_OPTS = frozenset("ABCefgMmtTr")
-_GREP_LONG_VALUE_OPTS = frozenset({"context", "regexp", "file", "include", "exclude"})
+_GREP_LONG_VALUE_OPTS = frozenset(
+    {
+        "context",
+        "before-context",
+        "after-context",
+        "max-count",
+        "regexp",
+        "file",
+        "include",
+        "exclude",
+    }
+)
 _GREP_SHORT_VALUE_OPTS = frozenset("efABC")
 
 
@@ -268,26 +279,29 @@ def _rg_option_info(tok: str) -> tuple[int, bool]:
     return 1, False
 
 
-def _grep_option_info(tok: str) -> int:
-    """How many tokens a ``grep`` option occupies.
+def _grep_option_info(tok: str) -> tuple[int, bool]:
+    """How many tokens a ``grep`` option occupies, and whether it supplies the pattern.
 
     Value-taking options (``-e``/``-f``/``-A``/``-B``/``-C`` and the long
-    ``--context``/``--regexp``/``--file``/``--include``/``--exclude``) consume
-    an attached value (``-C3``, ``--context=3``) or the next token. Plain
-    flags (``-E``/``-n``/``-i``/``-r``/``-l``/``-w``/``-H`` and any other
-    short flag) consume only their own token. This is deliberately grep's own
-    table — ``_rg_option_info`` treats short ``E`` as value-taking, which
-    would swallow grep's ``-E`` flag.
+    ``--context``/``--before-context``/``--after-context``/``--max-count``/
+    ``--regexp``/``--file``/``--include``/``--exclude``) consume an attached
+    value (``-C3``, ``--context=3``) or the next token. An explicit pattern
+    flag (``-e``/``-f``/``--regexp``/``--file``) leaves the following
+    positional operand as a path, not a pattern (mirroring ``_rg_option_info``).
+    Plain flags (``-E``/``-n``/``-i``/``-r``/``-l``/``-w``/``-H`` and any
+    other short flag) consume only their own token. This is deliberately
+    grep's own table, keyed off grep's short/long value sets.
     """
     if tok.startswith("--"):
         if "=" in tok:
-            return 1
+            name = tok[2:].split("=", 1)[0]
+            return 1, name in ("regexp", "file")
         name = tok[2:]
-        return 2 if name in _GREP_LONG_VALUE_OPTS else 1
+        return 2 if name in _GREP_LONG_VALUE_OPTS else 1, name in ("regexp", "file")
     body = tok[1:]
     if body and body[0] in _GREP_SHORT_VALUE_OPTS:
-        return 1 if len(body) > 1 else 2
-    return 1
+        return (1 if len(body) > 1 else 2), body[0] in ("e", "f")
+    return 1, False
 
 
 def _read_paths_for_segment(verb: str, operands: list[str]) -> set[str]:
@@ -335,7 +349,10 @@ def _read_paths_for_segment(verb: str, operands: list[str]) -> set[str]:
                 i += 1
                 continue
             if not after_ddash and tok.startswith("-") and tok != "-":
-                i += _grep_option_info(tok)
+                skip, supplies_pattern = _grep_option_info(tok)
+                i += skip
+                if supplies_pattern:
+                    seen_pattern = True
                 continue
             if not seen_pattern:
                 seen_pattern = True

--- a/daydream/eval/analyzer.py
+++ b/daydream/eval/analyzer.py
@@ -255,53 +255,50 @@ def _tokenize_command(command: str) -> list[str]:
         return command.split()
 
 
-def _rg_option_info(tok: str) -> tuple[int, bool]:
-    """How many tokens an ``rg`` option occupies, and whether it supplies the pattern.
+def _option_info(
+    tok: str,
+    long_value_opts: frozenset[str],
+    short_value_opts: frozenset[str],
+) -> tuple[int, bool]:
+    """How many tokens a ``rg``/``grep``-family option occupies, and whether it supplies the pattern.
 
     ``-C 3`` → (2, False); ``--glob=*.py`` → (1, False) (value attached);
     ``-n`` → (1, False); ``-e PAT``/``--regexp=PAT`` → (…, True) because an
     explicit pattern leaves the next positional operand as a path, not a
     pattern. Combined short flags (``-ni``) skip only their own token; a
     value-taking short flag with an attached value (``-C3``) also consumes one.
+
+    The value sets are the verb's own — ``_RG_{LONG,SHORT}_VALUE_OPTS`` for
+    ``rg`` and ``_GREP_{LONG,SHORT}_VALUE_OPTS`` for ``grep`` — so each verb
+    consumes exactly the options that take a value in its own table. Which
+    options supply the search pattern is shared across both: ``--regexp`` and
+    ``--file`` long, ``-e`` and ``-f`` short.
     """
     if tok.startswith("--"):
         if "=" in tok:
             name = tok[2:].split("=", 1)[0]
             return 1, name in ("regexp", "file")
         name = tok[2:]
-        if name in _RG_LONG_VALUE_OPTS:
-            return 2, name in ("regexp", "file")
-        return 1, False
+        return (2 if name in long_value_opts else 1), name in ("regexp", "file")
     body = tok[1:]
-    if body and body[0] in _RG_SHORT_VALUE_OPTS:
-        value_attached = len(body) > 1
-        return (1 if value_attached else 2), body[0] in ("e", "f")
+    if body and body[0] in short_value_opts:
+        return (1 if len(body) > 1 else 2), body[0] in ("e", "f")
     return 1, False
+
+
+def _rg_option_info(tok: str) -> tuple[int, bool]:
+    """How many tokens an ``rg`` option occupies, and whether it supplies the pattern."""
+    return _option_info(tok, _RG_LONG_VALUE_OPTS, _RG_SHORT_VALUE_OPTS)
 
 
 def _grep_option_info(tok: str) -> tuple[int, bool]:
     """How many tokens a ``grep`` option occupies, and whether it supplies the pattern.
 
-    Value-taking options (``-e``/``-f``/``-A``/``-B``/``-C`` and the long
-    ``--context``/``--before-context``/``--after-context``/``--max-count``/
-    ``--regexp``/``--file``/``--include``/``--exclude``) consume an attached
-    value (``-C3``, ``--context=3``) or the next token. An explicit pattern
-    flag (``-e``/``-f``/``--regexp``/``--file``) leaves the following
-    positional operand as a path, not a pattern (mirroring ``_rg_option_info``).
-    Plain flags (``-E``/``-n``/``-i``/``-r``/``-l``/``-w``/``-H`` and any
-    other short flag) consume only their own token. This is deliberately
-    grep's own table, keyed off grep's short/long value sets.
+    Uses grep's own value sets (``--context``/``--before-context``/``--max-count``/…
+    long; ``-e``/``-f``/``-A``/``-B``/``-C`` short) so only grep's value-taking
+    options consume a following token.
     """
-    if tok.startswith("--"):
-        if "=" in tok:
-            name = tok[2:].split("=", 1)[0]
-            return 1, name in ("regexp", "file")
-        name = tok[2:]
-        return 2 if name in _GREP_LONG_VALUE_OPTS else 1, name in ("regexp", "file")
-    body = tok[1:]
-    if body and body[0] in _GREP_SHORT_VALUE_OPTS:
-        return (1 if len(body) > 1 else 2), body[0] in ("e", "f")
-    return 1, False
+    return _option_info(tok, _GREP_LONG_VALUE_OPTS, _GREP_SHORT_VALUE_OPTS)
 
 
 def _read_paths_for_segment(verb: str, operands: list[str]) -> set[str]:
@@ -310,9 +307,10 @@ def _read_paths_for_segment(verb: str, operands: list[str]) -> set[str]:
     Redirection operators are consumed together with their targets (separated
     ``> target`` or attached ``2>/dev/null``) so a redirect target is never
     recorded as a read. Sed address ranges and flags are filtered, ``rg``
-    skips option values plus the search pattern, and the new inspection verbs
+    skips option values plus the search pattern, and the inspection verbs
     behave likewise: ``grep`` skips option values and its first positional
-    (the pattern), ``awk`` skips options and its first positional (the
+    (the pattern) and credits no operand when that pattern is import-only
+    (issue #739), ``awk`` skips options and its first positional (the
     program), ``head``/``tail`` skip options and their ``-n``/``-c`` values,
     and ``wc`` skips options. ``cat`` operands pass through verbatim.
     """
@@ -328,34 +326,31 @@ def _read_paths_for_segment(verb: str, operands: list[str]) -> set[str]:
         if m:
             i += 1 if m.group(3) else 2
             continue
-        if verb == "rg":
+        # ``rg`` and ``grep`` share the same shape: ``--`` flips to literal
+        # operand parsing, a leading ``-`` (unless ``-`` itself) is an option
+        # whose consumed tokens + pattern-supplying status come from the verb's
+        # own option table, and the first remaining positional is the pattern.
+        if verb in ("rg", "grep"):
+            option_info = _rg_option_info if verb == "rg" else _grep_option_info
             if tok == "--":
                 after_ddash = True
                 i += 1
                 continue
             if not after_ddash and tok.startswith("-") and tok != "-":
-                skip, supplies_pattern = _rg_option_info(tok)
+                skip, supplies_pattern = option_info(tok)
                 i += skip
                 if supplies_pattern:
                     seen_pattern = True
                 continue
             if not seen_pattern:
                 seen_pattern = True
-                i += 1
-                continue
-        elif verb == "grep":
-            if tok == "--":
-                after_ddash = True
-                i += 1
-                continue
-            if not after_ddash and tok.startswith("-") and tok != "-":
-                skip, supplies_pattern = _grep_option_info(tok)
-                i += skip
-                if supplies_pattern:
-                    seen_pattern = True
-                continue
-            if not seen_pattern:
-                seen_pattern = True
+                if verb == "grep" and _is_import_only_pattern(tok):
+                    # A grep whose pattern is only an import anchor is a
+                    # module-import scan, not a content read (issue #739):
+                    # crediting its operands as read paths would mis-credit
+                    # AC2/AC3 import coverage, exactly like the Grep-tool
+                    # branch's carve-out on the same shared seam.
+                    return paths
                 i += 1
                 continue
         elif verb in ("head", "tail"):

--- a/daydream/eval/analyzer.py
+++ b/daydream/eval/analyzer.py
@@ -707,7 +707,14 @@ def analyze_grounding(trajectories: dict, findings: list[dict]) -> dict:
 
 
 def analyze_exploration_utilization(trajectories: dict) -> dict:
-    """Check whether review agents read the deterministic ``affected_files.md`` artifact."""
+    """Check whether review agents read the exploration-path artifacts.
+
+    Any tool call contributing a read path beneath an ``exploration/`` directory
+    (e.g. the deterministic ``affected_files.md`` index, ``summary.md``, or
+    ``conventions.md``) counts as exploration utilization, whichever backend
+    performed the read — ``Read``/``Grep`` tool calls and ``shell``/``bash``
+    commands alike route through ``_read_paths_for_call``.
+    """
     results: list[dict] = []
 
     for traj in trajectories["forked"]:
@@ -725,7 +732,7 @@ def analyze_exploration_utilization(trajectories: dict) -> dict:
                 continue
             total_reads += 1
             for path in read_paths:
-                if "affected_files.md" in path:
+                if "/exploration/" in path:
                     exploration_refs.append(path)
 
         results.append({

--- a/daydream/eval/analyzer.py
+++ b/daydream/eval/analyzer.py
@@ -333,19 +333,21 @@ def _paths_from_command(command: str) -> set[str]:
 def _read_paths_for_call(tc: dict) -> list[str]:
     """All file paths a single tool call reads, across backends.
 
+    ``function_name`` is case-folded so ``Bash`` (Claude) / ``bash`` (pi) /
+    ``shell`` (codex) all route to the shell-command parser, and Claude's
+    ``Read`` / pi's ``read`` collapse into one branch that accepts either the
+    ``file_path`` or ``path`` argument key.
+
     - claude: ``Read`` → ``arguments.file_path``; ``Grep`` → ``arguments.path``
     - pi:     lowercase ``read`` → ``arguments.path``
     - codex/pi: ``shell``/``bash`` → paths embedded in ``arguments.command``
     """
-    fn = tc["function_name"]
+    fn = tc["function_name"].lower()
     args = tc["arguments"]
-    if fn == "Read":
-        p = args.get("file_path", "")
-        return [p] if p else []
-    if fn == "Grep":
-        p = args.get("path", "")
-        return [p] if p else []
     if fn == "read":
+        p = args.get("file_path") or args.get("path", "")
+        return [p] if p else []
+    if fn == "grep":
         p = args.get("path", "")
         return [p] if p else []
     if fn in ("shell", "bash"):

--- a/daydream/eval/analyzer.py
+++ b/daydream/eval/analyzer.py
@@ -168,7 +168,7 @@ def _files_from_diff(diff_path: Path) -> list[str]:
     return sorted(files)
 
 
-_READ_VERBS = ("sed", "nl", "cat", "rg")
+_READ_VERBS = ("sed", "nl", "cat", "rg", "grep", "head", "tail", "awk", "wc")
 _SED_RANGE_RE = re.compile(r"^\d+(?:,\d*)?\$?p$")
 _REDIRECT_RE = re.compile(r"^(\d*)([<>]+|&>)(.*)$")
 _SEGMENT_SEPARATORS = frozenset(("&&", ";", "&"))
@@ -197,6 +197,8 @@ _RG_LONG_VALUE_OPTS = frozenset(
     }
 )
 _RG_SHORT_VALUE_OPTS = frozenset("ABCefgMmtTr")
+_GREP_LONG_VALUE_OPTS = frozenset({"context", "regexp", "file", "include", "exclude"})
+_GREP_SHORT_VALUE_OPTS = frozenset("efABC")
 
 
 def _tokenize_command(command: str) -> list[str]:
@@ -245,19 +247,45 @@ def _rg_option_info(tok: str) -> tuple[int, bool]:
     return 1, False
 
 
+def _grep_option_info(tok: str) -> int:
+    """How many tokens a ``grep`` option occupies.
+
+    Value-taking options (``-e``/``-f``/``-A``/``-B``/``-C`` and the long
+    ``--context``/``--regexp``/``--file``/``--include``/``--exclude``) consume
+    an attached value (``-C3``, ``--context=3``) or the next token. Plain
+    flags (``-E``/``-n``/``-i``/``-r``/``-l``/``-w``/``-H`` and any other
+    short flag) consume only their own token. This is deliberately grep's own
+    table — ``_rg_option_info`` treats short ``E`` as value-taking, which
+    would swallow grep's ``-E`` flag.
+    """
+    if tok.startswith("--"):
+        if "=" in tok:
+            return 1
+        name = tok[2:]
+        return 2 if name in _GREP_LONG_VALUE_OPTS else 1
+    body = tok[1:]
+    if body and body[0] in _GREP_SHORT_VALUE_OPTS:
+        return 1 if len(body) > 1 else 2
+    return 1
+
+
 def _read_paths_for_segment(verb: str, operands: list[str]) -> set[str]:
     """File-path operands of one command segment for a given read verb.
 
     Redirection operators are consumed together with their targets (separated
     ``> target`` or attached ``2>/dev/null``) so a redirect target is never
-    recorded as a read. Sed address ranges and flags are filtered, and ``rg``
-    skips option values plus the search pattern. ``cat`` operands pass through
-    verbatim.
+    recorded as a read. Sed address ranges and flags are filtered, ``rg``
+    skips option values plus the search pattern, and the new inspection verbs
+    behave likewise: ``grep`` skips option values and its first positional
+    (the pattern), ``awk`` skips options and its first positional (the
+    program), ``head``/``tail`` skip options and their ``-n``/``-c`` values,
+    and ``wc`` skips options. ``cat`` operands pass through verbatim.
     """
     paths: set[str] = set()
     i = 0
     n = len(operands)
     seen_pattern = False
+    seen_program = False
     after_ddash = False
     while i < n:
         tok = operands[i]
@@ -280,6 +308,34 @@ def _read_paths_for_segment(verb: str, operands: list[str]) -> set[str]:
                 seen_pattern = True
                 i += 1
                 continue
+        elif verb == "grep":
+            if tok == "--":
+                after_ddash = True
+                i += 1
+                continue
+            if not after_ddash and tok.startswith("-") and tok != "-":
+                i += _grep_option_info(tok)
+                continue
+            if not seen_pattern:
+                seen_pattern = True
+                i += 1
+                continue
+        elif verb in ("head", "tail"):
+            if tok.startswith("-"):
+                body = tok[1:]
+                if body and body[0] in ("n", "c"):
+                    i += 1 if len(body) > 1 else 2
+                else:
+                    i += 1
+                continue
+        elif verb in ("awk", "wc"):
+            if tok.startswith("-"):
+                i += 1
+                continue
+            if verb == "awk" and not seen_program:
+                seen_program = True
+                i += 1
+                continue
         elif verb in ("sed", "nl", "cat"):
             if tok.startswith("-"):
                 i += 1
@@ -296,13 +352,15 @@ def _paths_from_command(command: str) -> set[str]:
     """Extract file-path operands from a codex ``shell`` / pi ``bash`` command.
 
     Reviewers read files through these verbs: ``sed -n '1,240p'``, ``nl -ba``,
-    ``cat``, and ``rg``. Commands may chain segments with ``&&``/``;`` and
-    redirect with ``2>/dev/null``. Tokenization is shell-aware: quoted paths
-    survive, redirection targets are consumed with their operator, and ``rg``
-    option values and the search pattern are filtered. Extraction is
-    deliberately permissive — ``_path_matches`` matches by ``endswith``, so a
-    stray operand simply never matches a diff file — but flags, redirect
-    targets, sed address ranges, and the ``rg`` search pattern are filtered.
+    ``cat``, ``rg``, ``grep``, ``head``, ``tail``, ``awk``, and ``wc``.
+    Commands may chain segments with ``&&``/``;`` and redirect with
+    ``2>/dev/null``. Tokenization is shell-aware: quoted paths survive,
+    redirection targets are consumed with their operator, and option values
+    plus the ``rg``/``grep`` search pattern and the ``awk`` program are
+    filtered. Extraction is deliberately permissive — ``_path_matches``
+    matches by ``endswith``, so a stray operand simply never matches a diff
+    file — but options, redirect targets, sed address ranges, and the
+    ``rg``/``grep`` search patterns are filtered.
     """
     paths: set[str] = set()
     tokens = _tokenize_command(command)

--- a/daydream/eval/analyzer.py
+++ b/daydream/eval/analyzer.py
@@ -169,6 +169,27 @@ def _files_from_diff(diff_path: Path) -> list[str]:
 
 
 _READ_VERBS = ("sed", "nl", "cat", "rg", "grep", "head", "tail", "awk", "wc")
+_IMPORT_ONLY_ALTERNATIVE_RE = re.compile(r"^\^?(?:from\b|import\b)")
+
+
+def _is_import_only_pattern(pattern: str) -> bool:
+    """Whether a ``Grep`` pattern references only module imports, no content.
+
+    Returns ``False`` for an empty/absent pattern (an import-only rule must
+    never gate a pathless Grep call). Otherwise ``True`` iff every ``|``-
+    separated alternative, stripped, matches the anchor-or-bare ``from`` /
+    ``import`` predicate — so ``^from|^import`` and ``from |import `` qualify,
+    while any alternative naming content (a ``class ``/``def `` body or a
+    symbol) makes it ``False``.
+    """
+    if not pattern:
+        return False
+    return all(
+        _IMPORT_ONLY_ALTERNATIVE_RE.match(alt.strip())
+        for alt in pattern.split("|")
+    )
+
+
 _SED_RANGE_RE = re.compile(r"^\d+(?:,\d*)?\$?p$")
 _REDIRECT_RE = re.compile(r"^(\d*)([<>]+|&>)(.*)$")
 _SEGMENT_SEPARATORS = frozenset(("&&", ";", "&"))
@@ -397,6 +418,7 @@ def _read_paths_for_call(tc: dict) -> list[str]:
     ``file_path`` or ``path`` argument key.
 
     - claude: ``Read`` → ``arguments.file_path``; ``Grep`` → ``arguments.path``
+      (credited only when the pattern is not import-only)
     - pi:     lowercase ``read`` → ``arguments.path``
     - codex/pi: ``shell``/``bash`` → paths embedded in ``arguments.command``
     """
@@ -407,7 +429,12 @@ def _read_paths_for_call(tc: dict) -> list[str]:
         return [p] if p else []
     if fn == "grep":
         p = args.get("path", "")
-        return [p] if p else []
+        if not p:
+            return []
+        pattern = args.get("pattern", "")
+        if pattern and _is_import_only_pattern(pattern):
+            return []
+        return [p]
     if fn in ("shell", "bash"):
         return sorted(_paths_from_command(args.get("command", "")))
     return []

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -322,6 +322,29 @@ def test_files_read_skips_rg_option_values():
     assert "needle" not in paths
 
 
+def test_files_read_extracts_claude_inspection_verbs():
+    calls = [{"function_name": "Bash", "arguments": {"command": (
+        "grep -n '^from|^import' daydream/config.py && "
+        "head -n 20 tests/test_config.py; "
+        "tail -n 5 README.md; "
+        "wc -l daydream/timeutil.py; "
+        "awk '{print $1}' docs/guide.md"
+    )}}]
+
+    paths = _files_read(calls)
+
+    assert "daydream/config.py" in paths
+    assert "tests/test_config.py" in paths
+    assert "README.md" in paths
+    assert "daydream/timeutil.py" in paths
+    assert "docs/guide.md" in paths
+    assert "^from|^import" not in paths   # grep pattern is not a path
+    assert "20" not in paths              # head -n value is not a path
+    assert "5" not in paths               # tail -n value is not a path
+    assert "{print $1}" not in paths      # awk program is not a path
+    assert "1" not in paths               # wc -l flag not a path
+
+
 def test_files_read_claude_read_and_grep_unchanged():
     calls = [
         {"function_name": "Read", "arguments": {"file_path": "/repo/api.py"}},

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -195,7 +195,7 @@ def _read_traj(source_file: str, *read_paths: str, pi_style: bool = False) -> di
     return {"_source_file": source_file, "steps": steps}
 
 
-def test_exploration_utilization_counts_only_deterministic_artifact():
+def test_exploration_utilization_counts_reads_beneath_exploration_dir():
     from daydream.eval.analyzer import analyze_exploration_utilization
 
     trajectories = {
@@ -207,15 +207,42 @@ def test_exploration_utilization_counts_only_deterministic_artifact():
             _read_traj(
                 "deep-c.json", "/repo/.daydream/exploration/affected_files.md", pi_style=True
             ),
+            _read_traj("deep-go.json", "/repo/src/main.go"),
         ],
     }
     result = analyze_exploration_utilization(trajectories)
     by_agent = {agent["agent"]: agent for agent in result["by_agent"]}
-    assert by_agent["deep-python"]["utilized"] is False
+    assert by_agent["deep-python"]["utilized"] is True
     assert by_agent["deep-ts"]["utilized"] is True
-    assert by_agent["deep-rust"]["utilized"] is False
+    assert by_agent["deep-rust"]["utilized"] is True
     assert by_agent["deep-c"]["utilized"] is True
-    assert result["reviewers_utilizing_exploration"] == 2
+    assert by_agent["deep-go"]["utilized"] is False  # outside exploration/ -> not counted
+    assert result["reviewers_utilizing_exploration"] == 4
+
+
+def test_exploration_utilization_counts_bash_mediated_reads():
+    from daydream.eval.analyzer import analyze_exploration_utilization
+
+    trajectories = {
+        "main": None,
+        "forked": [
+            {
+                "_source_file": "deep-python.json",
+                "steps": [
+                    {"step_id": "s0", "tool_calls": [
+                        {"function_name": "Bash", "arguments": {"command": "cat .daydream/exploration/summary.md"}},
+                    ]},
+                ],
+            }
+        ],
+    }
+
+    result = analyze_exploration_utilization(trajectories)
+
+    entry = result["by_agent"][0]
+    assert entry["exploration_reads"] == 1
+    assert entry["utilized"] is True
+    assert result["reviewers_utilizing_exploration"] == 1
 
 
 def test_grounding_rate_is_undefined_with_zero_findings():

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -399,6 +399,24 @@ def test_files_read_grep_content_pattern_credits_path():
     assert paths == {"daydream/config.py"}
 
 
+def test_files_read_grep_pattern_flag_keeps_file_operand():
+    # -e/-f/--regexp/--file are pattern-supplying options: the following token
+    # is the pattern, so the trailing file operand must still be credited as a
+    # read path (issue #739). Before the fix these dropped the operand entirely.
+    assert _shell_reads("grep -e 'def validate' daydream/config.py") == {"daydream/config.py"}
+    assert _shell_reads("grep --regexp 'def validate' daydream/config.py") == {"daydream/config.py"}
+    assert _shell_reads("grep --regexp='def validate' daydream/config.py") == {"daydream/config.py"}
+    assert _shell_reads("grep -f /tmp/patterns.txt daydream/config.py") == {"daydream/config.py"}
+
+
+def test_files_read_grep_context_options_do_not_eat_operand():
+    # --before-context/--after-context/--max-count take a value; their numeric
+    # value must not be misread as the pattern (issue #739).
+    assert _shell_reads("grep --before-context 3 'def validate' daydream/config.py") == {"daydream/config.py"}
+    assert _shell_reads("grep --after-context 5 'def validate' daydream/config.py") == {"daydream/config.py"}
+    assert _shell_reads("grep --max-count 2 'def validate' daydream/config.py") == {"daydream/config.py"}
+
+
 # --- unbalanced-quote tokenization (issue #327) ---
 
 

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -278,6 +278,15 @@ def test_files_read_extracts_pi_read_and_bash_paths():
     assert "core/osprey-cli" in paths
 
 
+def test_files_read_counts_claude_bash_shell_reads():
+    calls = [{"function_name": "Bash", "arguments": {"command": "sed -n '1,60p' daydream/config.py"}}]
+
+    paths = _files_read(calls)
+
+    assert paths == {"daydream/config.py"}
+    assert "1,60p" not in paths
+
+
 def _shell_reads(command: str) -> set[str]:
     """Extract read paths from a single codex ``shell`` call."""
     return _files_read([{"function_name": "shell", "arguments": {"command": command}}])

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -356,6 +356,22 @@ def test_files_read_claude_read_and_grep_unchanged():
     assert paths == {"/repo/api.py", "src/"}
 
 
+def test_files_read_grep_import_only_pattern_does_not_credit():
+    calls = [{"function_name": "Grep", "arguments": {"pattern": "^from|^import", "path": "daydream/config.py"}}]
+
+    paths = _files_read(calls)
+
+    assert paths == set()
+
+
+def test_files_read_grep_content_pattern_credits_path():
+    calls = [{"function_name": "Grep", "arguments": {"pattern": "def validate", "path": "daydream/config.py"}}]
+
+    paths = _files_read(calls)
+
+    assert paths == {"daydream/config.py"}
+
+
 # --- unbalanced-quote tokenization (issue #327) ---
 
 

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -351,7 +351,7 @@ def test_files_read_skips_rg_option_values():
 
 def test_files_read_extracts_claude_inspection_verbs():
     calls = [{"function_name": "Bash", "arguments": {"command": (
-        "grep -n '^from|^import' daydream/config.py && "
+        "grep -n 'def validate' daydream/config.py && "
         "head -n 20 tests/test_config.py; "
         "tail -n 5 README.md; "
         "wc -l daydream/timeutil.py; "
@@ -365,11 +365,21 @@ def test_files_read_extracts_claude_inspection_verbs():
     assert "README.md" in paths
     assert "daydream/timeutil.py" in paths
     assert "docs/guide.md" in paths
-    assert "^from|^import" not in paths   # grep pattern is not a path
+    assert "def validate" not in paths    # grep pattern is not a path
     assert "20" not in paths              # head -n value is not a path
     assert "5" not in paths               # tail -n value is not a path
     assert "{print $1}" not in paths      # awk program is not a path
     assert "1" not in paths               # wc -l flag not a path
+
+
+def test_files_read_bash_import_only_grep_does_not_credit():
+    # The import-only carve-out spans the shared seam: a Bash/shell ``grep``
+    # whose pattern references only module imports credits no read path,
+    # matching the Grep-tool branch (issue #739).
+    assert _shell_reads("grep -n '^from|^import' daydream/config.py") == set()
+    assert _shell_reads("grep 'import ' a.py b.py") == set()
+    # A content grep still credits its file operands.
+    assert _shell_reads("grep -n 'def validate' daydream/config.py") == {"daydream/config.py"}
 
 
 def test_files_read_claude_read_and_grep_unchanged():

--- a/tests/test_deep_coverage.py
+++ b/tests/test_deep_coverage.py
@@ -40,52 +40,12 @@ _DIFF = (
 )
 
 
-def _write_fork(run_dir: Path, name: str, read_paths: list[str]) -> None:
-    """Write one sibling trajectory whose *completed* reads cover *read_paths*.
+def _write_fork_calls(run_dir: Path, name: str, calls: list[dict]) -> None:
+    """Write one completed sibling step whose tool calls are all completed.
 
-    Each read tool call carries a matching ``observation.results[].source_call_id``
-    so the sweep counts it as coverage (a read without a ToolResult observation
+    Each tool call carries a matching ``observation.results[].source_call_id``
+    so the sweep counts it as coverage (a call without a ToolResult observation
     is treated as interrupted and does NOT cover the file).
-    """
-    trajectories_dir = run_dir / "trajectories"
-    trajectories_dir.mkdir(parents=True, exist_ok=True)
-    tool_calls = []
-    results = []
-    for i, path in enumerate(read_paths):
-        call_id = f"read-{i}"
-        tool_calls.append(
-            {
-                "tool_call_id": call_id,
-                "function_name": "Read",
-                "arguments": {"file_path": path},
-            }
-        )
-        results.append({"source_call_id": call_id, "content": "file content"})
-    (trajectories_dir / name).write_text(
-        json.dumps(
-            {
-                "session_id": run_dir.name,
-                "steps": [
-                    {
-                        "step_id": "s0",
-                        "tool_calls": tool_calls,
-                        "observation": {"results": results},
-                    }
-                ],
-            }
-        )
-    )
-
-
-def _write_claude_fork(run_dir: Path, name: str, calls: list[dict]) -> None:
-    """Write one completed sibling trajectory with arbitrary Claude-spelled calls.
-
-    ``_write_fork`` is hardcoded to emit ``function_name: "Read"`` with
-    ``arguments.file_path``, so it cannot exercise the ``Bash``/``Grep``
-    spellings that Issue #739 routes through the live sweep. This helper writes
-    a single completed step whose calls carry matching
-    ``observation.results[].source_call_id``s (so they count as coverage) for
-    caller-supplied ``{"function_name", "arguments"}`` dicts.
     """
     trajectories_dir = run_dir / "trajectories"
     trajectories_dir.mkdir(parents=True, exist_ok=True)
@@ -115,6 +75,35 @@ def _write_claude_fork(run_dir: Path, name: str, calls: list[dict]) -> None:
             }
         )
     )
+
+
+def _write_fork(run_dir: Path, name: str, read_paths: list[str]) -> None:
+    """Write one completed sibling trajectory whose *completed* reads cover *read_paths*.
+
+    Re-expresses the shared envelope as ``Read`` calls carrying
+    ``arguments.file_path``.
+    """
+    _write_fork_calls(
+        run_dir,
+        name,
+        [
+            {"function_name": "Read", "arguments": {"file_path": path}}
+            for path in read_paths
+        ],
+    )
+
+
+def _write_claude_fork(run_dir: Path, name: str, calls: list[dict]) -> None:
+    """Write one completed sibling trajectory with arbitrary Claude-spelled calls.
+
+    ``_write_fork`` is hardcoded to emit ``function_name: "Read"`` with
+    ``arguments.file_path``, so it cannot exercise the ``Bash``/``Grep``
+    spellings that Issue #739 routes through the live sweep. This helper writes
+    a single completed step whose calls carry matching
+    ``observation.results[].source_call_id``s (so they count as coverage) for
+    caller-supplied ``{"function_name", "arguments"}`` dicts.
+    """
+    _write_fork_calls(run_dir, name, calls)
 
 
 def _write_interrupted_read_fork(run_dir: Path, name: str, read_paths: list[str]) -> None:
@@ -648,6 +637,29 @@ def test_omitted_assigned_file_is_still_swept(tmp_path: Path) -> None:
     uncovered, _ = compute_uncovered_files(daydream_dir, "sess-d", receipts=receipts)
     assert "notes.txt" in uncovered    # omitted by the reviewer -> swept, never skipped
     assert "api.py" not in uncovered   # reviewed inline -> not swept
+
+
+def test_compute_uncovered_files_bash_import_only_grep_does_not_cover(tmp_path: Path) -> None:
+    """An import-only Bash grep shares the Grep-tool carve-out (issue #739)."""
+    daydream_dir = tmp_path / ".daydream"
+    daydream_dir.mkdir()
+    (daydream_dir / "diff.patch").write_text(_DIFF)
+    run_dir = daydream_dir / "runs" / "sess-bashgrep"
+    run_dir.mkdir(parents=True)
+    _write_main(run_dir)
+    _write_claude_fork(run_dir, "deep-python.json", [
+        {"function_name": "Bash", "arguments": {
+            "command": "grep -n '^from|^import' /repo/api.py"
+        }},
+    ])
+    _write_fork(run_dir, "deep-generic.json", ["/repo/notes.txt"])
+
+    uncovered, stats = compute_uncovered_files(daydream_dir, "sess-bashgrep")
+
+    assert "api.py" in uncovered  # the import-only Bash grep covers nothing
+    assert stats["files_read_by_reviewers"] == 1  # only notes.txt via Read
+    swept, _, _ = filter_sweepable_files(uncovered, _DIFF, min_hunk_lines=1, max_files=10)
+    assert "api.py" in swept  # the file is swept, never silently skipped
 
 
 def test_compute_uncovered_files_counts_claude_bash_reads(tmp_path: Path) -> None:

--- a/tests/test_deep_coverage.py
+++ b/tests/test_deep_coverage.py
@@ -77,6 +77,46 @@ def _write_fork(run_dir: Path, name: str, read_paths: list[str]) -> None:
     )
 
 
+def _write_claude_fork(run_dir: Path, name: str, calls: list[dict]) -> None:
+    """Write one completed sibling trajectory with arbitrary Claude-spelled calls.
+
+    ``_write_fork`` is hardcoded to emit ``function_name: "Read"`` with
+    ``arguments.file_path``, so it cannot exercise the ``Bash``/``Grep``
+    spellings that Issue #739 routes through the live sweep. This helper writes
+    a single completed step whose calls carry matching
+    ``observation.results[].source_call_id``s (so they count as coverage) for
+    caller-supplied ``{"function_name", "arguments"}`` dicts.
+    """
+    trajectories_dir = run_dir / "trajectories"
+    trajectories_dir.mkdir(parents=True, exist_ok=True)
+    tool_calls = []
+    results = []
+    for i, call in enumerate(calls):
+        call_id = f"read-{i}"
+        tool_calls.append(
+            {
+                "tool_call_id": call_id,
+                "function_name": call["function_name"],
+                "arguments": call.get("arguments", {}),
+            }
+        )
+        results.append({"source_call_id": call_id, "content": "file content"})
+    (trajectories_dir / name).write_text(
+        json.dumps(
+            {
+                "session_id": run_dir.name,
+                "steps": [
+                    {
+                        "step_id": "s0",
+                        "tool_calls": tool_calls,
+                        "observation": {"results": results},
+                    }
+                ],
+            }
+        )
+    )
+
+
 def _write_interrupted_read_fork(run_dir: Path, name: str, read_paths: list[str]) -> None:
     """Write a sibling trajectory whose reads carry NO ToolResult observation.
 
@@ -608,3 +648,43 @@ def test_omitted_assigned_file_is_still_swept(tmp_path: Path) -> None:
     uncovered, _ = compute_uncovered_files(daydream_dir, "sess-d", receipts=receipts)
     assert "notes.txt" in uncovered    # omitted by the reviewer -> swept, never skipped
     assert "api.py" not in uncovered   # reviewed inline -> not swept
+
+
+def test_compute_uncovered_files_counts_claude_bash_reads(tmp_path: Path) -> None:
+    """A Claude-spelled Bash sed read covers a diff file (AC3)."""
+    daydream_dir = tmp_path / ".daydream"
+    daydream_dir.mkdir()
+    (daydream_dir / "diff.patch").write_text(_DIFF)
+    run_dir = daydream_dir / "runs" / "sess-claude"
+    run_dir.mkdir(parents=True)
+    _write_main(run_dir)
+    _write_claude_fork(run_dir, "deep-python.json", [
+        {"function_name": "Bash", "arguments": {"command": "sed -n '1,60p' /repo/api.py"}},
+    ])
+
+    uncovered, stats = compute_uncovered_files(daydream_dir, "sess-claude")
+
+    assert uncovered == ["notes.txt"]  # api.py read via Bash sed is covered, not swept
+    assert stats["files_read_by_reviewers"] == 1
+    assert stats["coverage_ratio"] == 0.5
+
+
+def test_compute_uncovered_files_import_only_grep_does_not_cover(tmp_path: Path) -> None:
+    """An import-only Grep does not, on its own, mark a file covered (AC2/AC3)."""
+    daydream_dir = tmp_path / ".daydream"
+    daydream_dir.mkdir()
+    (daydream_dir / "diff.patch").write_text(_DIFF)
+    run_dir = daydream_dir / "runs" / "sess-grep"
+    run_dir.mkdir(parents=True)
+    _write_main(run_dir)
+    _write_claude_fork(run_dir, "deep-python.json", [
+        {"function_name": "Grep", "arguments": {"pattern": "^from|^import", "path": "/repo/api.py"}},
+    ])
+    _write_fork(run_dir, "deep-generic.json", ["/repo/notes.txt"])
+
+    uncovered, stats = compute_uncovered_files(daydream_dir, "sess-grep")
+
+    assert "api.py" in uncovered  # the import-only grep covers nothing
+    assert stats["files_read_by_reviewers"] == 1  # only notes.txt via Read
+    swept, _, _ = filter_sweepable_files(uncovered, _DIFF, min_hunk_lines=1, max_files=10)
+    assert "api.py" in swept  # the file is swept, never silently skipped


### PR DESCRIPTION
Fixes #739

## Summary
`daydream/eval/analyzer.py`'s read-detection helpers were blind to the Claude backend's tool names (`Bash`, `Grep`) and its dominant inspection verbs (`grep`, `head`, `tail`, `awk`, `wc`). Because `daydream/deep/coverage.py:33` imports `_read_paths_for_call` from the evaluator, this was not only a metrics defect — it corrupted the live uncovered-sweep dispatch decision, spawning review agents for files that were already reviewed.

## Changes
- **AC1:** Case-fold tool-name dispatch so Claude `Bash` reads count; recognize `grep`/`head`/`tail`/`awk`/`wc` read verbs
- **AC2:** Import-only `Grep` no longer credits its path as a read
- **AC3:** `compute_uncovered_files` covers Claude Bash/Grep spellings
- Should-have: exploration utilization counts Bash-mediated reads
- Refactor: unified `rg`/`grep` option parsing (shared `_option_info` helper), applied import-only carve-out to Bash grep; deduped test helpers

## Verification
- Full `make check` gate green (3770 passed / 6 skipped)
- Two sequential daydream deep-precision reviews on fresh VMs (no CodeRabbit); all findings auto-fixed on branch tip `eb47505`