### PR TITLE
fix(deep): per-stack reviewers lack the anti-confabulation gate and cleared a file they never read

### DIFF
--- a/daydream/deep/coverage.py
+++ b/daydream/deep/coverage.py
@@ -124,10 +124,11 @@ def _parsed_finding_files(records_path: Path) -> set[str] | None:
     except (OSError, ValueError):
         return None
     if isinstance(records, dict):
+        # Issue #742: fresh-run per-stack records carry the dict shape
+        # {"issues": [...], "verdicts": [...]}; the issues list is the
+        # findings evidence either way (legacy bare lists pass through).
         findings = records.get("issues")
     elif isinstance(records, list):
-        # Production per-stack records are a bare JSON list (the raw parse
-        # output); the dict-with-"issues" shape is the legacy/unit-test form.
         findings = records
     else:
         findings = None
@@ -189,6 +190,83 @@ def _receipt_covered_files(
                     covered_by_type[evidence_key].add(f)
     counts = {key: len(files) for key, files in covered_by_type.items()}
     return covered, counts
+
+
+def resolve_per_stack_verdicts(
+    *,
+    assigned_files: list[str],
+    declared_verdicts: list[dict[str, Any]],
+    completed_read_paths: set[str],
+    finding_files: set[str],
+) -> list[dict[str, Any]]:
+    """Reconcile declared per-file verdicts against completed-read evidence (issue #742).
+
+    A per-stack reviewer's declared verdict is NOT the recorded truth: a
+    ``clean`` verdict for an assigned file with no completed read of that file
+    in the same review is downgraded to ``not_reviewed`` (routing the file to
+    the uncovered sweep), never recorded as a pass. The gate reads evidence
+    (``_completed_read_paths`` output + parsed finding files), never reviewer
+    self-report.
+
+    The final verdict per assigned file is resolved by evidence, in order:
+    a parsed finding that path-component-matches the file wins (``has_findings``
+    beats a read, beats ``clean``); otherwise a completed read that
+    path-component-matches the file yields ``clean``; otherwise the file is
+    ``not_reviewed``. This mirrors the read-detection the sweep already uses
+    (``_path_component_matches``), so a clean shard that read its file is
+    covered regardless of findings and an unread file is never recorded clean.
+
+    Args:
+        assigned_files: The stack's assigned files, in order.
+        declared_verdicts: The reviewer-declared per-file verdict entries
+            (``path`` / ``lines_read`` / ``verdict``), surfaced through the
+            per-stack parse; evidence, not authority.
+        completed_read_paths: Completed-read paths from the stack's own fork
+            trajectory (``_completed_read_paths``).
+        finding_files: ``file`` fields from the stack's parsed issues.
+
+    Returns:
+        Exactly one verdict dict per ``assigned_files`` path, in the given
+        order: ``{"path", "lines_read", "verdict"}``, plus ``n_findings``
+        when the verdict is ``has_findings``. The declared ``lines_read`` is
+        preserved even when the verdict is downgraded to ``not_reviewed`` (the
+        reviewer said it read N lines; the gate records it was not read). Pure
+        and total: a declared verdict whose path is not in ``assigned_files``
+        is ignored (never fabricated), and missing keys default safely.
+    """
+    declared_by_path: dict[str, dict[str, Any]] = {}
+    for entry in declared_verdicts:
+        if not isinstance(entry, dict):
+            continue
+        path = entry.get("path")
+        if not isinstance(path, str) or path not in assigned_files:
+            continue  # non-assigned declared paths are ignored, never fabricated
+        declared_by_path[path] = entry
+
+    out: list[dict[str, Any]] = []
+    for path in assigned_files:
+        declared = declared_by_path.get(path, {})
+        lines_read = declared.get("lines_read", 0)
+        matching_findings = [
+            ff for ff in finding_files if _path_component_matches(ff, path)
+        ]
+        if matching_findings:
+            # A finding beats a read and beats a declared clean.
+            out.append(
+                {
+                    "path": path,
+                    "lines_read": lines_read,
+                    "verdict": "has_findings",
+                    "n_findings": len(matching_findings),
+                }
+            )
+        elif any(_path_component_matches(r, path) for r in completed_read_paths):
+            out.append({"path": path, "lines_read": lines_read, "verdict": "clean"})
+        else:
+            out.append(
+                {"path": path, "lines_read": lines_read, "verdict": "not_reviewed"}
+            )
+    return out
 
 
 def compute_uncovered_files(

--- a/daydream/deep/coverage.py
+++ b/daydream/deep/coverage.py
@@ -31,6 +31,7 @@ from daydream.eval.analyzer import (
     _agent_label,
     _files_from_diff,
     _read_paths_for_call,
+    _records_issues,
     load_trajectories,
 )
 from daydream.phases import (
@@ -112,6 +113,27 @@ def _completed_read_paths(
     return paths
 
 
+def _finding_files_from_records(findings: list[Any]) -> set[str]:
+    """Normalized ``file`` fields across parsed finding records (issue #742).
+
+    Shared between :func:`_parsed_finding_files` (disk-backed) and the per-stack
+    verdict reconciliation in the orchestrator (in-memory parsed records) so the
+    ``./`` strip lives in one place: a leading ``./`` is a legal path spelling
+    since the grammar relaxed (#572/#573), and the reviewed-diff file set and
+    the receipt lists are always bare, so normalizing once keeps a ``./x``
+    finding matching its assigned file rather than failing every path-component
+    match and getting swept.
+    """
+    files: set[str] = set()
+    for finding in findings:
+        if isinstance(finding, dict) and isinstance(finding.get("file"), str):
+            file = finding["file"]
+            if file.startswith("./"):
+                file = file[2:]
+            files.add(file)
+    return files
+
+
 def _parsed_finding_files(records_path: Path) -> set[str] | None:
     """Set of ``file`` fields across a completed shard's parsed records.
 
@@ -123,31 +145,10 @@ def _parsed_finding_files(records_path: Path) -> set[str] | None:
         records = json.loads(records_path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return None
-    if isinstance(records, dict):
-        # Issue #742: fresh-run per-stack records carry the dict shape
-        # {"issues": [...], "verdicts": [...]}; the issues list is the
-        # findings evidence either way (legacy bare lists pass through).
-        findings = records.get("issues")
-    elif isinstance(records, list):
-        findings = records
-    else:
-        findings = None
-    if not isinstance(findings, list):
+    findings = _records_issues(records)
+    if findings is None:
         return None
-    files: set[str] = set()
-    for finding in findings:
-        if isinstance(finding, dict) and isinstance(finding.get("file"), str):
-            file = finding["file"]
-            # A leading ``./`` is a legal path spelling since the grammar
-            # relaxed (#572/#573); the reviewed-diff file set and the receipt
-            # lists are always bare. Normalize once here (mirroring the fix
-            # gate at orchestrator.py) so a ``./x`` finding contributes
-            # inline/frontier evidence instead of failing every path-component
-            # match and getting swept.
-            if file.startswith("./"):
-                file = file[2:]
-            files.add(file)
-    return files
+    return _finding_files_from_records(findings)
 
 
 def _receipt_covered_files(
@@ -227,12 +228,15 @@ def resolve_per_stack_verdicts(
 
     Returns:
         Exactly one verdict dict per ``assigned_files`` path, in the given
-        order: ``{"path", "lines_read", "verdict"}``, plus ``n_findings``
-        when the verdict is ``has_findings``. The declared ``lines_read`` is
-        preserved even when the verdict is downgraded to ``not_reviewed`` (the
-        reviewer said it read N lines; the gate records it was not read). Pure
-        and total: a declared verdict whose path is not in ``assigned_files``
-        is ignored (never fabricated), and missing keys default safely.
+        order: ``{"path", "lines_read", "verdict", "n_findings"}``. ``n_findings``
+        is the count of parsed findings matching the path (0 for ``clean`` /
+        ``not_reviewed``), so every recorded verdict conforms to
+        ``PER_STACK_RECORD_SCHEMA``'s required ``n_findings`` key. The declared
+        ``lines_read`` is preserved even when the verdict is downgraded to
+        ``not_reviewed`` (the reviewer said it did read N lines; the gate
+        records it was not read). Pure and total: a declared verdict whose path
+        is not in ``assigned_files`` is ignored (never fabricated), and missing
+        keys default safely.
     """
     declared_by_path: dict[str, dict[str, Any]] = {}
     for entry in declared_verdicts:
@@ -261,10 +265,17 @@ def resolve_per_stack_verdicts(
                 }
             )
         elif any(_path_component_matches(r, path) for r in completed_read_paths):
-            out.append({"path": path, "lines_read": lines_read, "verdict": "clean"})
+            out.append(
+                {"path": path, "lines_read": lines_read, "verdict": "clean", "n_findings": 0}
+            )
         else:
             out.append(
-                {"path": path, "lines_read": lines_read, "verdict": "not_reviewed"}
+                {
+                    "path": path,
+                    "lines_read": lines_read,
+                    "verdict": "not_reviewed",
+                    "n_findings": 0,
+                }
             )
     return out
 

--- a/daydream/deep/coverage.py
+++ b/daydream/deep/coverage.py
@@ -54,6 +54,20 @@ def _path_component_matches(absolute: str, relative: str) -> bool:
     return absolute == relative or absolute.endswith("/" + relative)
 
 
+def _same_repo_relative(a: str, b: str) -> bool:
+    """Exact dir-aware match between two repo-relative paths.
+
+    ``_path_component_matches`` pairs an absolute read path (from a tool call)
+    with a repo-relative diff file, where a basename-boundary fallback is
+    needed. When BOTH operands are repo-relative (a parsed finding ``file`` vs
+    an assigned or receipt file), that one-directional basename fallback
+    misattributes: ``lib/util.py`` ``endswith("/util.py")`` matches the
+    assigned top-level ``util.py``. Repo-relative operands share the same
+    normalization, so exact equality is the only correct comparison.
+    """
+    return a == b
+
+
 def coverage_receipt_path(deep_dir: Path) -> Path:
     """Path to the run's structured coverage receipts (issue #731).
 
@@ -158,7 +172,7 @@ def _receipt_covered_files(
 
     A diff file is ``inline_hunk_reviewed``-covered when it is in a shard's
     ``inline_files`` AND that shard's parsed records exist AND at least one
-    parsed finding ``_path_component_matches`` it. ``dependency_frontier_read``
+    parsed finding ``_same_repo_relative`` it. ``dependency_frontier_read``
     is the same check over the shard's ``frontier_files``. Assignment/grounding
     alone never counts; a shard without a records file contributes zero.
 
@@ -185,12 +199,28 @@ def _receipt_covered_files(
         ):
             for f in receipt.get(files_key, []) or []:
                 if f in diff_set and any(
-                    _path_component_matches(ff, f) for ff in finding_files
+                    _same_repo_relative(ff, f) for ff in finding_files
                 ):
                     covered.add(f)
                     covered_by_type[evidence_key].add(f)
     counts = {key: len(files) for key, files in covered_by_type.items()}
     return covered, counts
+
+
+def _verdict(path: str, lines_read: int, verdict: str, n_findings: int) -> dict[str, Any]:
+    """Build one conformant per-file verdict dict (issue #742).
+
+    Collapses the three near-identical ``out.append({...})`` blocks in
+    :func:`resolve_per_stack_verdicts`, which differ only in ``verdict`` and
+    ``n_findings``. Every returned dict conforms to ``PER_STACK_RECORD_SCHEMA``'s
+    required ``path`` / ``lines_read`` / ``verdict`` / ``n_findings`` keys.
+    """
+    return {
+        "path": path,
+        "lines_read": lines_read,
+        "verdict": verdict,
+        "n_findings": n_findings,
+    }
 
 
 def resolve_per_stack_verdicts(
@@ -210,7 +240,7 @@ def resolve_per_stack_verdicts(
     self-report.
 
     The final verdict per assigned file is resolved by evidence, in order:
-    a parsed finding that path-component-matches the file wins (``has_findings``
+    a parsed finding that exactly matches the file (``_same_repo_relative``) wins (``has_findings``
     beats a read, beats ``clean``); otherwise a completed read that
     path-component-matches the file yields ``clean``; otherwise the file is
     ``not_reviewed``. This mirrors the read-detection the sweep already uses
@@ -252,31 +282,17 @@ def resolve_per_stack_verdicts(
         declared = declared_by_path.get(path, {})
         lines_read = declared.get("lines_read", 0)
         matching_findings = [
-            ff for ff in finding_files if _path_component_matches(ff, path)
+            ff for ff in finding_files if _same_repo_relative(ff, path)
         ]
         if matching_findings:
             # A finding beats a read and beats a declared clean.
-            out.append(
-                {
-                    "path": path,
-                    "lines_read": lines_read,
-                    "verdict": "has_findings",
-                    "n_findings": len(matching_findings),
-                }
-            )
+            out.append(_verdict(path, lines_read, "has_findings", len(matching_findings)))
         elif any(_path_component_matches(r, path) for r in completed_read_paths):
-            out.append(
-                {"path": path, "lines_read": lines_read, "verdict": "clean", "n_findings": 0}
-            )
+            # A completed read that matches the file yields clean.
+            out.append(_verdict(path, lines_read, "clean", 0))
         else:
-            out.append(
-                {
-                    "path": path,
-                    "lines_read": lines_read,
-                    "verdict": "not_reviewed",
-                    "n_findings": 0,
-                }
-            )
+            # No finding and no completed read: never recorded as a pass.
+            out.append(_verdict(path, lines_read, "not_reviewed", 0))
     return out
 
 

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -99,7 +99,7 @@ from daydream.deep.scope_issues import (
     _revert_out_of_scope_edits,
 )
 from daydream.deep.sharding import shard_stacks
-from daydream.eval.analyzer import _agent_label, _records_issues, load_trajectories
+from daydream.eval.analyzer import _agent_label, _records_issues_or_empty, load_trajectories
 from daydream.extensions import get_registry
 from daydream.extensions.api import FlowStep, Stop
 from daydream.flows.engine import FlowContext, run_flow
@@ -146,6 +146,7 @@ from daydream.supervision import (
 from daydream.trajectory import (
     DaydreamPhase,
     DaydreamRunFlow,
+    _safe_descriptor,
     get_current_recorder,
     maybe_fork,
     phase_scope,
@@ -772,8 +773,9 @@ def _rewrite_stack_records(
 
     The cross-stack merge reads per-stack records by path, so arbitration must
     be reflected on disk, not just in memory. Every language stack file is
-    rewritten with its surviving records (an emptied stack becomes ``[]`` rather
-    than retaining stale pre-arbitration content).
+    rewritten with its surviving records (an emptied stack becomes
+    ``{"issues": [], "verdicts": [...]}`` rather than retaining stale
+    pre-arbitration content).
     """
     by_stack: dict[Path, list[dict[str, Any]]] = {path: [] for path in stack_record_paths}
     for record, source in zip(records, sources, strict=True):
@@ -787,7 +789,25 @@ def _rewrite_stack_records(
         if dest in by_stack:
             by_stack[dest].append(record)
     for dest_path, stack_records in by_stack.items():
-        dest_path.write_text(json.dumps(stack_records, indent=2))
+        # Issue #742: per-stack records files carry the dict shape
+        # ``{"issues": [...], "verdicts": [...]}``. Preserve the verdicts from
+        # the on-disk file (if a dict-shaped file is present) so arbitration
+        # does not silently drop them; the dict shape is written back
+        # regardless so every worker -- merge resume, the coverage evidence
+        # path -- reads the same shape whether or not arbitration fired.
+        verdicts: list[Any] = []
+        if dest_path.is_file():
+            try:
+                existing = json.loads(dest_path.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                existing = None
+            if isinstance(existing, dict):
+                existing_verdicts = existing.get("verdicts", [])
+                if isinstance(existing_verdicts, list):
+                    verdicts = existing_verdicts
+        dest_path.write_text(
+            json.dumps({"issues": stack_records, "verdicts": verdicts}, indent=2)
+        )
 
 
 def _protect_tree_after_fix_failures(
@@ -1375,9 +1395,7 @@ async def _step_per_stack_parse(ctx: FlowContext) -> Stop | None:
             # verdicts surfaced through the parse). Merge consumes a bare
             # issues list, so normalize the dict shape here; legacy bare-list
             # records pass through unchanged.
-            records = _records_issues(loaded)
-            if records is None:
-                records = [] if isinstance(loaded, dict) else loaded
+            records = _records_issues_or_empty(loaded)
             per_stack_records_paths.append(records_path)
             source_name = records_path.name
             all_records.extend(records)
@@ -2611,8 +2629,12 @@ def _stack_review_reads(
     """
     if recorder is None:
         return set()
+    # A sharded stack is named ``deep-<stack>#<n>`` but its fork is
+    # filesystem-slugified (``_safe_descriptor``) to ``deep-<stack>-<n>`` on
+    # disk, so match the slug -- not the raw descriptor (#742 finding 1).
+    lookup = _safe_descriptor(f"deep-{stack_name}")
     for fork in _loaded_review_forks(daydream_dir, recorder.session_id):
-        if _agent_label(fork["_source_file"]) == f"deep-{stack_name}":
+        if _agent_label(fork["_source_file"]) == lookup:
             return _completed_read_paths(fork)
     return set()
 

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -19,6 +19,7 @@ import json
 import os
 import shutil
 from dataclasses import asdict
+from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Awaitable, Iterable
 
@@ -75,6 +76,7 @@ from daydream.deep.artifacts import (
 )
 from daydream.deep.coverage import (
     _completed_read_paths,
+    _finding_files_from_records,
     build_uncovered_sweep_prompt,
     compute_uncovered_files,
     coverage_receipt_path,
@@ -97,7 +99,7 @@ from daydream.deep.scope_issues import (
     _revert_out_of_scope_edits,
 )
 from daydream.deep.sharding import shard_stacks
-from daydream.eval.analyzer import _agent_label, load_trajectories
+from daydream.eval.analyzer import _agent_label, _records_issues, load_trajectories
 from daydream.extensions import get_registry
 from daydream.extensions.api import FlowStep, Stop
 from daydream.flows.engine import FlowContext, run_flow
@@ -110,6 +112,7 @@ from daydream.generated_files import (
 )
 from daydream.phases import (
     PER_STACK_RECORD_SCHEMA,
+    UNCOVERED_SWEEP_SCHEMA,
     CrossStackMergeError,
     FixResult,
     UnconfinedFindingError,
@@ -1372,11 +1375,9 @@ async def _step_per_stack_parse(ctx: FlowContext) -> Stop | None:
             # verdicts surfaced through the parse). Merge consumes a bare
             # issues list, so normalize the dict shape here; legacy bare-list
             # records pass through unchanged.
-            if isinstance(loaded, dict):
-                records = loaded.get("issues")
-                records = records if isinstance(records, list) else []
-            else:
-                records = loaded
+            records = _records_issues(loaded)
+            if records is None:
+                records = [] if isinstance(loaded, dict) else loaded
             per_stack_records_paths.append(records_path)
             source_name = records_path.name
             all_records.extend(records)
@@ -1434,32 +1435,20 @@ async def _step_per_stack_parse(ctx: FlowContext) -> Stop | None:
                                 except Exception as exc:  # noqa: BLE001 -- captured so one failure cannot cancel siblings mid-write
                                     parse_failures[stack_name] = exc
                                     return
-                                # Issue #742: reconcile the reviewer's declared
-                                # per-file verdicts against completed-read
-                                # evidence from its own deep-<stack> fork. The
-                                # gate is fail-open (never fails the run, never
-                                # records an unread file clean): a missing fork
-                                # degrades to ``verdicts: []``.
-                                try:
-                                    stack_reads = _stack_review_reads(
-                                        dd.parent, recorder, stack_name
-                                    )
-                                    finding_files = {
-                                        f["file"][2:]
-                                        if f["file"].startswith("./")
-                                        else f["file"]
-                                        for f in records
-                                        if isinstance(f, dict)
-                                        and isinstance(f.get("file"), str)
-                                    }
-                                    verdicts = resolve_per_stack_verdicts(
-                                        assigned_files=assigned_files,
-                                        declared_verdicts=declared_verdicts,
-                                        completed_read_paths=stack_reads,
-                                        finding_files=finding_files,
-                                    )
-                                except Exception:  # noqa: BLE001 -- fail-open: never fail the run on a missing fork
-                                    verdicts = []
+                                # Issue #742: reconcile the declared per-file
+                                # verdicts against completed-read evidence from
+                                # the stack's own deep-<stack> fork. Fail-open
+                                # (a missing fork degrades to ``verdicts: []``)
+                                # so the stack's records still land on disk and its
+                                # unread files are swept.
+                                verdicts = _reconcile_stack_verdicts(
+                                    dd.parent,
+                                    recorder,
+                                    stack_name,
+                                    assigned_files=assigned_files,
+                                    declared_verdicts=declared_verdicts,
+                                    parsed_records=records,
+                                )
                                 # Written per task, not after the join, so a
                                 # sibling's failure cannot discard records that
                                 # already succeeded (they survive for --start-at).
@@ -1732,10 +1721,15 @@ async def _run_uncovered_sweep(ctx: FlowContext) -> None:
     if recorder is not None:
         recorder.create_dispatch_step(phase=DaydreamPhase.DEEP)
 
-    # Parse each sweep review into PER_STACK_RECORD_SCHEMA records (fail-open:
-    # unparseable or failed parses are dropped, never fatal). Parse failures are
-    # tracked BY FILENAME into `sweep_failures`, not just the `parse_dropped`
-    # count, so coverage-stats.json names exactly which file's parse failed.
+    # Parse each sweep review with the uncovered-sweep schema (issue #742
+    # finding 2): it carries severity but NOT the per-file verdicts array. The
+    # sweep parse runs with ``include_verdicts=False`` and the prompt never
+    # teaches the verdicts shape, so PER_STACK_RECORD_SCHEMA's required
+    # ``verdicts`` field would be an untaught ask; UNCOVERED_SWEEP_SCHEMA drops
+    # only that requirement/property (severity is preserved so sweep records
+    # enter the arbiter/merge pool undifferentiated). Fail-open: unparseable or
+    # failed parses are dropped, never fatal; failures are tracked BY FILENAME
+    # into `sweep_failures`, not just the `parse_dropped` count.
     parse_results: dict[str, list[dict[str, Any]]] = {}
     parse_dropped = 0
     parse_failures: dict[str, str] = {}
@@ -1757,7 +1751,7 @@ async def _run_uncovered_sweep(ctx: FlowContext) -> None:
                                     parse_backend,
                                     ctx.work,
                                     input_path=input_path,
-                                    output_schema=PER_STACK_RECORD_SCHEMA,
+                                    output_schema=UNCOVERED_SWEEP_SCHEMA,
                                 )
                                 parse_results[file] = records
                             except Exception as exc:  # noqa: BLE001 -- fail-open drop
@@ -2585,6 +2579,21 @@ def _current_session_id() -> str | None:
     return recorder.session_id if recorder is not None else None
 
 
+@lru_cache(maxsize=None)
+def _loaded_review_forks(daydream_dir: Path, session_id: str) -> tuple[dict[str, Any], ...]:
+    """Trajectory forks for a session, parsed once (issue #742 finding 4).
+
+    ``load_trajectories`` re-parses every JSON file under
+    ``runs/<session>/trajectories/`` on every call; the per-stack parse task
+    group fans ``_stack_review_reads`` out once per stack concurrently, so cache
+    the parsed fork set per ``(daydream_dir, session_id)`` and reap a single
+    parse. The gate only consumes the ``forked`` list; the parsed dicts are
+    read-only for the run, so caching is safe. ``Path`` and ``str`` are
+    hashable, satisfying ``functools.lru_cache``'s key contract.
+    """
+    return tuple(load_trajectories(daydream_dir, session_id).get("forked", []))
+
+
 def _stack_review_reads(
     daydream_dir: Path, recorder: TrajectoryRecorder | None, stack_name: str
 ) -> set[str]:
@@ -2593,17 +2602,51 @@ def _stack_review_reads(
     The clean-verdict gate consumes evidence, never reviewer self-report: the
     reads that count are the ones the per-stack review agent actually completed
     in its own fork trajectory (``deep-<stack_name>.json``, written when the
-    review fork exits — always before parse starts). A ``None`` recorder (no
-    trajectory recording this run) or an absent fork yields the empty set
-    (fail-open: every assigned file without a finding resolves to
-    ``not_reviewed`` and is swept, never recorded clean).
+    review fork exits — always before parse starts). The fork set is loaded once
+    and cached (``_loaded_review_forks``) so N concurrent per-stack parse tasks
+    do not re-parse the session's trajectories on every call (finding 4). A
+    ``None`` recorder (no trajectory recording this run) or an absent fork
+    yields the empty set (fail-open: every assigned file without a finding
+    resolves to ``not_reviewed`` and is swept, never recorded clean).
     """
     if recorder is None:
         return set()
-    for fork in load_trajectories(daydream_dir, recorder.session_id)["forked"]:
+    for fork in _loaded_review_forks(daydream_dir, recorder.session_id):
         if _agent_label(fork["_source_file"]) == f"deep-{stack_name}":
             return _completed_read_paths(fork)
     return set()
+
+
+def _reconcile_stack_verdicts(
+    daydream_dir: Path,
+    recorder: TrajectoryRecorder | None,
+    stack_name: str,
+    *,
+    assigned_files: list[str],
+    declared_verdicts: list[dict[str, Any]],
+    parsed_records: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Fail-open per-file verdict reconciliation for one stack (issue #742).
+
+    Collects the evidence-gathering glue the per-stack parse needs: the stack's
+    own ``deep-<stack>`` review-fork completed reads plus the parse's
+    normalized finding files, then resolves the evidence-gated verdict for each
+    assigned file. Fail-open (never fails the run, never records an unread file
+    clean): any failure (e.g. a missing fork) yields ``[]`` so the stack's
+    records stay writable and its unread files resolve to ``not_reviewed``
+    instead of a pass.
+    """
+    try:
+        stack_reads = _stack_review_reads(daydream_dir, recorder, stack_name)
+        finding_files = _finding_files_from_records(parsed_records)
+        return resolve_per_stack_verdicts(
+            assigned_files=assigned_files,
+            declared_verdicts=declared_verdicts,
+            completed_read_paths=stack_reads,
+            finding_files=finding_files,
+        )
+    except Exception:  # noqa: BLE001 -- fail-open: never fail the run on a missing fork
+        return []
 
 
 def _load_quality_gate_rounds(gate_p: Path, session_id: str | None) -> list[dict[str, Any]]:

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -74,11 +74,13 @@ from daydream.deep.artifacts import (
     intent_path as _intent_path,
 )
 from daydream.deep.coverage import (
+    _completed_read_paths,
     build_uncovered_sweep_prompt,
     compute_uncovered_files,
     coverage_receipt_path,
     diff_block_for_file,
     filter_sweepable_files,
+    resolve_per_stack_verdicts,
 )
 from daydream.deep.dedup import (
     CandidatePair,
@@ -95,6 +97,7 @@ from daydream.deep.scope_issues import (
     _revert_out_of_scope_edits,
 )
 from daydream.deep.sharding import shard_stacks
+from daydream.eval.analyzer import _agent_label, load_trajectories
 from daydream.extensions import get_registry
 from daydream.extensions.api import FlowStep, Stop
 from daydream.flows.engine import FlowContext, run_flow
@@ -162,6 +165,7 @@ from daydream.workspace import WorkContext
 
 if TYPE_CHECKING:
     from daydream.runner import RunConfig
+    from daydream.trajectory import TrajectoryRecorder
 
 # Exploration infrastructure import guard. When Phases 1-4 are not yet
 # installed, deep mode still runs -- just without grounding context.
@@ -1362,7 +1366,17 @@ async def _step_per_stack_parse(ctx: FlowContext) -> Stop | None:
         if sweep_path.is_file():
             expected_paths.append(sweep_path)
         for records_path in sorted(expected_paths):
-            records = json.loads(records_path.read_text())
+            loaded = json.loads(records_path.read_text())
+            # Issue #742: fresh-run per-stack records files now carry the dict
+            # shape ``{"issues": [...], "verdicts": [...]}`` (the per-file
+            # verdicts surfaced through the parse). Merge consumes a bare
+            # issues list, so normalize the dict shape here; legacy bare-list
+            # records pass through unchanged.
+            if isinstance(loaded, dict):
+                records = loaded.get("issues")
+                records = records if isinstance(records, list) else []
+            else:
+                records = loaded
             per_stack_records_paths.append(records_path)
             source_name = records_path.name
             all_records.extend(records)
@@ -1375,6 +1389,12 @@ async def _step_per_stack_parse(ctx: FlowContext) -> Stop | None:
         parse_backend = ctx.backend_for("parse")
         limiter = anyio.CapacityLimiter(effective_fanout_concurrency(10, parse_backend))
         recorder = get_current_recorder()
+        # Issue #742: the verdict gate reconciles each stack's declared per-file
+        # verdicts against its own assigned files. Default-arg captured per
+        # closure so the gate cannot read the wrong stack's file list.
+        stack_files: dict[str, list[str]] = {
+            s.stack_name: list(s.files) for s in stacks
+        }
         parse_results: dict[str, list[dict[str, Any]]] = {}
         parse_failures: dict[str, BaseException] = {}
 
@@ -1398,24 +1418,61 @@ async def _step_per_stack_parse(ctx: FlowContext) -> Stop | None:
                         stack_name: str = stack_name,
                         input_path: Path = output_path,
                         schema: dict[str, Any] = record_schema,
+                        assigned_files: list[str] = stack_files[stack_name],
                     ) -> None:
                         async with limiter:
                             async with maybe_fork(recorder, f"parse-{stack_name}"):
                                 try:
-                                    records = await phase_parse_feedback(
+                                    parsed = await phase_parse_feedback(
                                         parse_backend,
                                         ctx.work,
                                         input_path=input_path,
                                         output_schema=schema,
+                                        include_verdicts=True,
                                     )
+                                    records, declared_verdicts = parsed
                                 except Exception as exc:  # noqa: BLE001 -- captured so one failure cannot cancel siblings mid-write
                                     parse_failures[stack_name] = exc
                                     return
+                                # Issue #742: reconcile the reviewer's declared
+                                # per-file verdicts against completed-read
+                                # evidence from its own deep-<stack> fork. The
+                                # gate is fail-open (never fails the run, never
+                                # records an unread file clean): a missing fork
+                                # degrades to ``verdicts: []``.
+                                try:
+                                    stack_reads = _stack_review_reads(
+                                        dd.parent, recorder, stack_name
+                                    )
+                                    finding_files = {
+                                        f["file"][2:]
+                                        if f["file"].startswith("./")
+                                        else f["file"]
+                                        for f in records
+                                        if isinstance(f, dict)
+                                        and isinstance(f.get("file"), str)
+                                    }
+                                    verdicts = resolve_per_stack_verdicts(
+                                        assigned_files=assigned_files,
+                                        declared_verdicts=declared_verdicts,
+                                        completed_read_paths=stack_reads,
+                                        finding_files=finding_files,
+                                    )
+                                except Exception:  # noqa: BLE001 -- fail-open: never fail the run on a missing fork
+                                    verdicts = []
                                 # Written per task, not after the join, so a
                                 # sibling's failure cannot discard records that
                                 # already succeeded (they survive for --start-at).
+                                # Issue #742: the record also carries the
+                                # reconciled per-file verdicts (PER_STACK_RECORD_SCHEMA
+                                # shape); merge consumers normalize dict ->
+                                # issues and the coverage evidence path already
+                                # tolerates both shapes.
                                 per_stack_records_path(dd, stack_name).write_text(
-                                    json.dumps(records, indent=2)
+                                    json.dumps(
+                                        {"issues": records, "verdicts": verdicts},
+                                        indent=2,
+                                    )
                                 )
                                 parse_results[stack_name] = records
 
@@ -2526,6 +2583,27 @@ def _current_session_id() -> str | None:
     """Session id binding the quality-gate artifact to the current run."""
     recorder = get_current_recorder()
     return recorder.session_id if recorder is not None else None
+
+
+def _stack_review_reads(
+    daydream_dir: Path, recorder: TrajectoryRecorder | None, stack_name: str
+) -> set[str]:
+    """Completed reads from the ``deep-<stack>`` review fork (issue #742).
+
+    The clean-verdict gate consumes evidence, never reviewer self-report: the
+    reads that count are the ones the per-stack review agent actually completed
+    in its own fork trajectory (``deep-<stack_name>.json``, written when the
+    review fork exits — always before parse starts). A ``None`` recorder (no
+    trajectory recording this run) or an absent fork yields the empty set
+    (fail-open: every assigned file without a finding resolves to
+    ``not_reviewed`` and is swept, never recorded clean).
+    """
+    if recorder is None:
+        return set()
+    for fork in load_trajectories(daydream_dir, recorder.session_id)["forked"]:
+        if _agent_label(fork["_source_file"]) == f"deep-{stack_name}":
+            return _completed_read_paths(fork)
+    return set()
 
 
 def _load_quality_gate_rounds(gate_p: Path, session_id: str | None) -> list[dict[str, Any]]:

--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -120,6 +120,8 @@ VERIFICATION_PROTOCOL_INSTRUCTION = (
     "not recalled. The source is the only truth; never infer a finding from the "
     "branch name, cwd, or memory. A finding without a same-turn echo of its "
     "target is INVALID.\n"
+    "  A `clean` verdict for a file also requires a same-turn read of that file: "
+    "absent the read, mark the file `not reviewed`, never `clean`.\n"
     "  Gate 1 (anchor): read the full enclosing symbol/module, not just the diff "
     "hunk; state the file path and line range you are judging.\n"
     "  Gate 2 (evidence): produce an artifact for the finding's type — pasted "

--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -233,10 +233,16 @@ def _context_pointers(
 def _stack_scope_instruction(stack_name: str, files: list[str]) -> str:
     joined = ", ".join(files)
     return (
-        f"You are reviewing the {stack_name} stack. Focus ONLY on these files:\n"
-        f"  {joined}\n"
+        f"You are reviewing the {stack_name} stack. Your assigned files are an "
+        f"inclusion obligation: read and review EACH one in full -- a file you "
+        f"did not read is not covered by this review.\n"
+        f"  Assigned files: {joined}\n"
         f"Do NOT review files from other stacks -- their reviews are running in "
-        f"parallel and will be merged afterwards."
+        f"parallel and will be merged afterwards.\n"
+        f"After the review, output ONE verdict line per assigned file, as: "
+        f"`<path>` | `<lines read>` | `clean | has_findings | not_reviewed`. "
+        f"A file you did not read in this same review must be marked "
+        f"`not_reviewed`, never `clean`."
     )
 
 

--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -594,6 +594,7 @@ def build_per_stack_prompt(
     parts.append(skill_invocation)
     parts.append(TEST_QUALITY_RUBRIC_INSTRUCTION)
     parts.append(ANTI_SLOP_RUBRIC_INSTRUCTION)
+    parts.append(VERIFICATION_PROTOCOL_INSTRUCTION)
     parts.append(CONFIG_FLOW_TRACE_INSTRUCTION)
     parts.append(TRUST_MODEL_INSTRUCTION)
     if stack_name == "rust":

--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -507,8 +507,9 @@ def _diff_instruction(
             "Relevant diff hunks for your stack (inlined; do NOT re-Read "
             "diff.patch for these — the hunks are already here):\n\n"
             f"{inline_diff.rstrip()}\n\n"
-            "Focus on hunks that touch your stack's files. For whole-file "
-            "context beyond these hunks you MAY Read the source files directly."
+            "Focus on hunks that touch your stack's files. Read the source file "
+            "FIRST; you may only comment on hunks you have read. The inlined "
+            "hunks are not a substitute for reading the file."
         )
     joined = ", ".join(files)
     # Point agents at diff_path directly. A bare `git diff -- <files>` command

--- a/daydream/eval/analyzer.py
+++ b/daydream/eval/analyzer.py
@@ -626,6 +626,22 @@ def _records_issues(records: Any) -> list[Any] | None:
     return records if isinstance(records, list) else None
 
 
+def _records_issues_or_empty(records: Any) -> list[Any]:
+    """Normalize a loaded per-stack records file to a bare issues list.
+
+    Collapses the ``None`` -> ``[]`` fallback idiom that every per-stack
+    records reader previously re-implemented verbatim (orchestrator merge
+    resume, analyzer findings, and the test harness). A non-list load yields
+    the same degenerate value as the callers' explicit fallback
+    (``[]`` for a dict, otherwise the raw load), preserving prior
+    warn-and-continue semantics exactly.
+    """
+    issues = _records_issues(records)
+    if issues is None:
+        return [] if isinstance(records, dict) else records  # type: ignore[return-value]
+    return issues
+
+
 def analyze_findings(daydream_dir: Path) -> dict:
     """Parse per-stack records, dedup stats, and merged review."""
     deep_dir = daydream_dir / "deep"
@@ -648,9 +664,7 @@ def analyze_findings(daydream_dir: Path) -> dict:
         # Issue #742: fresh-run per-stack records files carry the dict shape
         # {"issues": [...], "verdicts": [...]}; findings are the issues list
         # either way (legacy bare lists pass through).
-        records = _records_issues(loaded)
-        if records is None:
-            records = [] if isinstance(loaded, dict) else loaded
+        records = _records_issues_or_empty(loaded)
         stacks.append({"name": stack_name, "finding_count": len(records)})
         for r in records:
             r["_stack"] = stack_name

--- a/daydream/eval/analyzer.py
+++ b/daydream/eval/analyzer.py
@@ -626,7 +626,15 @@ def analyze_findings(daydream_dir: Path) -> dict:
 
     for f in sorted(deep_dir.glob("stack-*-records.json")):
         stack_name = f.stem.replace("stack-", "").replace("-records", "")
-        records = json.loads(f.read_text())
+        loaded = json.loads(f.read_text())
+        # Issue #742: fresh-run per-stack records files carry the dict shape
+        # {"issues": [...], "verdicts": [...]}; findings are the issues list
+        # either way (legacy bare lists pass through).
+        if isinstance(loaded, dict):
+            issues = loaded.get("issues")
+            records = issues if isinstance(issues, list) else []
+        else:
+            records = loaded
         stacks.append({"name": stack_name, "finding_count": len(records)})
         for r in records:
             r["_stack"] = stack_name

--- a/daydream/eval/analyzer.py
+++ b/daydream/eval/analyzer.py
@@ -608,6 +608,24 @@ def analyze_coverage(trajectories: dict, daydream_dir: Path) -> dict:
     }
 
 
+def _records_issues(records: Any) -> list[Any] | None:
+    """Normalize a loaded per-stack records file to its bare issues list.
+
+    Issue #742: fresh-run per-stack records files carry the dict shape
+    ``{"issues": [...], "verdicts": [...]}``; legacy and primed fixtures use
+    the bare list. Returns the issues list when ``records`` is a bare list or
+    a dict whose ``issues`` is a list; ``None`` when it is neither (callers
+    keep their own fail-open / warn-and-continue handling for non-list
+    shapes). This is the canonical records-shape normalization shared by
+    every per-stack records reader (coverage sweep, merge resume, analyzer,
+    phases, and the test harness); a future shape change lands here only.
+    """
+    if isinstance(records, dict):
+        issues = records.get("issues")
+        return issues if isinstance(issues, list) else None
+    return records if isinstance(records, list) else None
+
+
 def analyze_findings(daydream_dir: Path) -> dict:
     """Parse per-stack records, dedup stats, and merged review."""
     deep_dir = daydream_dir / "deep"
@@ -630,11 +648,9 @@ def analyze_findings(daydream_dir: Path) -> dict:
         # Issue #742: fresh-run per-stack records files carry the dict shape
         # {"issues": [...], "verdicts": [...]}; findings are the issues list
         # either way (legacy bare lists pass through).
-        if isinstance(loaded, dict):
-            issues = loaded.get("issues")
-            records = issues if isinstance(issues, list) else []
-        else:
-            records = loaded
+        records = _records_issues(loaded)
+        if records is None:
+            records = [] if isinstance(loaded, dict) else loaded
         stacks.append({"name": stack_name, "finding_count": len(records)})
         for r in records:
             r["_stack"] = stack_name

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -819,9 +819,13 @@ PER_STACK_RECORD_SCHEMA["properties"]["issues"]["items"]["properties"]["severity
 PER_STACK_RECORD_SCHEMA["properties"]["issues"]["items"]["required"] = [
     "id", "description", "file", "line", "severity", "confidence", "rationale", "evidence"
 ]
-# Per-file verdicts (issue #742). Fail-open: NOT in ``required``, so records
-# written before this field existed (or a sweep record that never emits
-# verdicts) still parse.
+# Per-file verdicts (issue #742). ``verdicts`` sits in ``required`` (like
+# every property of every Codex-routed output schema -- the strict-mode
+# validator rejects optional properties, see test_output_schema_strict.py), so
+# the parse model must emit a (possibly empty) verdicts array; the sweep parse
+# still ignores it (``include_verdicts=False``) and records written before this
+# field existed remain parseable on resume (loading is schema-free).
+PER_STACK_RECORD_SCHEMA["required"] = ["issues", "verdicts"]
 PER_STACK_RECORD_SCHEMA["properties"]["verdicts"] = {
     "type": "array",
     "items": {
@@ -832,7 +836,7 @@ PER_STACK_RECORD_SCHEMA["properties"]["verdicts"] = {
             "verdict": {"type": "string", "enum": ["clean", "has_findings", "not_reviewed"]},
             "n_findings": {"type": "integer"},
         },
-        "required": ["path", "lines_read", "verdict"],
+        "required": ["path", "lines_read", "verdict", "n_findings"],
         "additionalProperties": False,
     },
 }

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -1561,6 +1561,34 @@ async def phase_parse_feedback(
         else ""
     )
 
+    # Per-file verdict surface (issue #742). Deep-mode's per-stack parse emits
+    # the schema-required ``verdicts`` array, so the prompt must teach the
+    # verdict-line shape and its sub-fields; otherwise the strict-mode model
+    # emits ``[]``/``lines_read: 0`` in production. Shallow / PR-feedback /
+    # sweep callers pass ``include_verdicts=False`` and get no verdict
+    # instruction, keeping their prompt byte-identical to prior behavior.
+    verdict_line = (
+        '{"path": "path/to/file.py", "lines_read": 42, '
+        '"verdict": "clean|has_findings|not_reviewed", "n_findings": 0}'
+    )
+    verdicts_hint = (
+        "\nEmit a `verdicts` array, one entry per file the review examined, so a "
+        "file marked `clean` stays distinguishable from one never reviewed. Each "
+        f"entry is: {verdict_line}. "
+        "Use `clean` for a file read with no findings, `has_findings` for a file "
+        "the review flagged, and `not_reviewed` for a file never read. Set "
+        "`lines_read` to the real number of lines read and `n_findings` to that "
+        "file's issue count (0 if none).\n"
+        if include_verdicts
+        else ""
+    )
+    verdicts_example = (
+        f', "verdicts": [{verdict_line}]'
+        if include_verdicts
+        else ""
+    )
+    verdicts_empty = ', "verdicts": []' if include_verdicts else ""
+
     # Use absolute path to prevent model hallucination of paths from training data
     review_output_path = input_path if input_path is not None else work.repo / REVIEW_OUTPUT_FILE
     prompt = f"""Read the review output file at {review_output_path}.
@@ -1569,13 +1597,13 @@ Extract ONLY actionable issues that need fixing. Skip these sections entirely:
 - "Good Patterns" or "Strengths"
 - "Summary" sections
 - Any positive observations
-{severity_hint}
+{severity_hint}{verdicts_hint}
 For each issue found, return a JSON object with this structure:
 {{"issues": [
   {{"id": 1, "description": "Brief description of the issue", "file": "path/to/file.py", "line": 42{severity_field}}}
-]}}
+]{verdicts_example}}}
 
-If there are no actionable issues, return: {{"issues": []}}
+If there are no actionable issues, return: {{"issues": []{verdicts_empty}}}
 """
 
     result, _, budget_reason = await run_agent(

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -802,12 +802,15 @@ FEEDBACK_SCHEMA: dict[str, Any] = {
 
 # Per-stack parse schema (issue #168). Identical to FEEDBACK_SCHEMA but carries a
 # required ``severity`` so the scoped Opus arbiter can select high-severity /
-# contested findings *before* the merge. The shared FEEDBACK_SCHEMA stays
+# contested findings *before* the merge, plus a per-file ``verdicts`` array
+# (issue #742) so a file marked ``clean`` in the review is distinguishable from
+# one never reviewed (``not_reviewed``). The shared FEEDBACK_SCHEMA stays
 # severity-free (the shallow loop and PR-feedback parse paths never need it);
 # only deep-mode's pre-merge per-stack parse opts into this richer record shape.
 #
 # Derived from FEEDBACK_SCHEMA to avoid silent drift: we deep-copy the base
-# schema and inject the extra ``severity`` field into the items sub-schema.
+# schema and inject the extra ``severity`` field into the items sub-schema and
+# the top-level ``verdicts`` array.
 PER_STACK_RECORD_SCHEMA: dict[str, Any] = copy.deepcopy(FEEDBACK_SCHEMA)
 PER_STACK_RECORD_SCHEMA["properties"]["issues"]["items"]["properties"]["severity"] = {
     "type": "string",
@@ -816,6 +819,23 @@ PER_STACK_RECORD_SCHEMA["properties"]["issues"]["items"]["properties"]["severity
 PER_STACK_RECORD_SCHEMA["properties"]["issues"]["items"]["required"] = [
     "id", "description", "file", "line", "severity", "confidence", "rationale", "evidence"
 ]
+# Per-file verdicts (issue #742). Fail-open: NOT in ``required``, so records
+# written before this field existed (or a sweep record that never emits
+# verdicts) still parse.
+PER_STACK_RECORD_SCHEMA["properties"]["verdicts"] = {
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "path": _REPOSITORY_FILE_PATH_SCHEMA,
+            "lines_read": {"type": "integer"},
+            "verdict": {"type": "string", "enum": ["clean", "has_findings", "not_reviewed"]},
+            "n_findings": {"type": "integer"},
+        },
+        "required": ["path", "lines_read", "verdict"],
+        "additionalProperties": False,
+    },
+}
 
 ALTERNATIVE_REVIEW_SCHEMA: dict[str, Any] = {
     "type": "object",
@@ -1440,7 +1460,8 @@ async def phase_parse_feedback(
     *,
     input_path: Path | None = None,
     output_schema: dict[str, Any] | None = None,
-) -> list[dict[str, Any]]:
+    include_verdicts: bool = False,
+) -> list[dict[str, Any]] | tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """Phase 2: Parse feedback from review output and return validated items.
 
     Args:
@@ -1460,9 +1481,18 @@ async def phase_parse_feedback(
             parses with the same schema so its anti-slop severity calibration
             survives merge (issue #314). When the schema requires a
             ``severity`` field, the prompt instructs the agent to extract it.
+        include_verdicts: When True (deep-mode's per-stack parse only, issue
+            #742), the declared per-file verdicts from the parse output are
+            surfaced alongside the issues list and the return is a
+            ``(feedback_items, verdicts)`` tuple; a malformed ``verdicts``
+            value (non-list / non-dict entries) is coerced to ``[]``
+            (fail-open, never raises, never fabricates verdicts). When False
+            (default), the return is the bare issues list, byte-identical to
+            today — shallow / PR-feedback / sweep callers are untouched.
 
     Returns:
         List of validated feedback items with id, description, file, line
+        — or, with ``include_verdicts=True``, a ``(items, verdicts)`` tuple.
 
     Note:
         Unparseable agent output degrades gracefully: an empty response, prose
@@ -1532,6 +1562,8 @@ If there are no actionable issues, return: {{"issues": []}}
             f"Agent returned no parseable issues (got {type(result).__name__}); "
             f"treating as no actionable issues. Preview: {preview}",
         )
+        if include_verdicts:
+            return [], []
         return []
 
     feedback_items = result["issues"]
@@ -1562,7 +1594,16 @@ If there are no actionable issues, return: {{"issues": []}}
     print_info(console, f"Found {issue_count} actionable {'issue' if issue_count == 1 else 'issues'}")
     if feedback_items:
         print_feedback_table(console, feedback_items)
-    return feedback_items
+    if not include_verdicts:
+        return feedback_items
+    # Per-file verdict surfacing (issue #742). Fail-open: a malformed
+    # ``verdicts`` value (non-list, or non-dict entries) coerces to ``[]`` —
+    # never raises, never fabricates verdicts.
+    declared = result.get("verdicts", [])
+    if not isinstance(declared, list):
+        declared = []
+    verdicts = [v for v in declared if isinstance(v, dict)]
+    return feedback_items, verdicts
 
 
 def _coerce_verdicts_payload(value: Any) -> dict[str, Any]:

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -1162,8 +1162,9 @@ def _exploration_pointer(exploration_dir: Path | None, *, fixer: bool = False) -
         f"Read {exploration_dir}/affected_files.md for the deterministic index of files relevant to this review "
         f"(paths, roles, import relationships).\n"
         f"{exploration_dir}/summary.md is a counts-only index; reference individual exploration files as needed.\n"
-        f"Reference files as needed; do NOT read them all up front under {exploration_dir}/ — "
-        f"but you MUST read in full all assigned source files.\n"
+        f"Reference exploration files as needed; do NOT read them all up front under {exploration_dir}/ — "
+        f"that no-up-front-read rule applies ONLY to exploration artifacts."
+        f"\nAssigned source files are different: you MUST read in full all assigned source files.\n"
     )
 
 

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -8,7 +8,7 @@ import re
 from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 import anyio
 from rich.text import Text
@@ -1452,6 +1452,28 @@ Expected: {review_output_path}
 Run a full review first:
   daydream {target_dir}"""
         raise FileNotFoundError(msg)
+
+
+@overload
+async def phase_parse_feedback(
+    backend: Backend,
+    work: WorkContext,
+    *,
+    input_path: Path | None = None,
+    output_schema: dict[str, Any] | None = None,
+    include_verdicts: Literal[False] = False,
+) -> list[dict[str, Any]]: ...
+
+
+@overload
+async def phase_parse_feedback(
+    backend: Backend,
+    work: WorkContext,
+    *,
+    input_path: Path | None = None,
+    output_schema: dict[str, Any] | None = None,
+    include_verdicts: Literal[True],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]: ...
 
 
 async def phase_parse_feedback(
@@ -3997,6 +4019,11 @@ def _append_structural_and_write_merged(
             # malformed output; degrade to none rather than crash the merge.
             print_warning(console, f"Skipping malformed structural records: {type(exc).__name__}: {exc}")
             structural_records = []
+        # Issue #742: fresh-run per-stack records files carry the dict shape
+        # ``{"issues": [...], "verdicts": [...]}``; the structural records are
+        # the issues list either way. Legacy bare-list files pass through.
+        if isinstance(structural_records, dict):
+            structural_records = structural_records.get("issues")
         if not isinstance(structural_records, list):
             print_warning(console, "Skipping non-list structural records; expected a list")
             structural_records = []

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -33,6 +33,7 @@ from daydream.backends import (
 )
 from daydream.backends.claude import READ_ONLY_BASH_ALLOWLIST
 from daydream.clipboard import clipboard_available, copy_to_clipboard
+from daydream.eval.analyzer import _records_issues
 from daydream.extensions import get_registry
 from daydream.file_group_budget import FileGroupBudget
 from daydream.generated_files import (
@@ -822,9 +823,11 @@ PER_STACK_RECORD_SCHEMA["properties"]["issues"]["items"]["required"] = [
 # Per-file verdicts (issue #742). ``verdicts`` sits in ``required`` (like
 # every property of every Codex-routed output schema -- the strict-mode
 # validator rejects optional properties, see test_output_schema_strict.py), so
-# the parse model must emit a (possibly empty) verdicts array; the sweep parse
-# still ignores it (``include_verdicts=False``) and records written before this
-# field existed remain parseable on resume (loading is schema-free).
+# the deep per-stack parse model must emit a (possibly empty) verdicts array.
+# The uncovered sweep parses with UNCOVERED_SWEEP_SCHEMA instead (it never
+# teaches the verdicts shape, so it must not ask for that field), and records
+# written before this field existed remain parseable on resume (loading is
+# schema-free).
 PER_STACK_RECORD_SCHEMA["required"] = ["issues", "verdicts"]
 PER_STACK_RECORD_SCHEMA["properties"]["verdicts"] = {
     "type": "array",
@@ -840,6 +843,19 @@ PER_STACK_RECORD_SCHEMA["properties"]["verdicts"] = {
         "additionalProperties": False,
     },
 }
+
+# Uncovered-sweep parse schema (issue #742 finding 2). The sweep re-runs a
+# bare per-file review that never declares a per-file verdict surface, so its
+# parse must NOT force a required ``verdicts`` array: the sweep parse runs with
+# ``include_verdicts=False`` and the phase_parse_feedback prompt never teaches
+# the verdicts shape, so requiring it would ask the model to emit an untaught
+# field. It keeps ``severity`` (the sweep's records enter the same arbiter/merge
+# pool as per-stack records, where severity selects the scoped Opus pass).
+# Derived from PER_STACK_RECORD_SCHEMA and stripped of only the verdicts
+# property and requirement, so it stays strict-mode conformant either way.
+UNCOVERED_SWEEP_SCHEMA: dict[str, Any] = copy.deepcopy(PER_STACK_RECORD_SCHEMA)
+UNCOVERED_SWEEP_SCHEMA["required"] = ["issues"]
+UNCOVERED_SWEEP_SCHEMA["properties"].pop("verdicts", None)
 
 ALTERNATIVE_REVIEW_SCHEMA: dict[str, Any] = {
     "type": "object",
@@ -4026,9 +4042,8 @@ def _append_structural_and_write_merged(
         # Issue #742: fresh-run per-stack records files carry the dict shape
         # ``{"issues": [...], "verdicts": [...]}``; the structural records are
         # the issues list either way. Legacy bare-list files pass through.
-        if isinstance(structural_records, dict):
-            structural_records = structural_records.get("issues")
-        if not isinstance(structural_records, list):
+        structural_records = _records_issues(structural_records)
+        if structural_records is None:
             print_warning(console, "Skipping non-list structural records; expected a list")
             structural_records = []
         for rec in structural_records:

--- a/tests/harness/phase_backend.py
+++ b/tests/harness/phase_backend.py
@@ -134,7 +134,12 @@ class PhaseDispatchBackend:
                 for it in issues
             ]
             yield TextEvent(text="Parsed.")
-            yield ResultEvent(structured_output={"issues": issues}, continuation=None)
+            # Issue #742: the deep per-stack parse schema requires a
+            # ``verdicts`` property (Codex strict-mode output), so the parse
+            # payload always carries it (empty when not exercised).
+            yield ResultEvent(
+                structured_output={"issues": issues, "verdicts": []}, continuation=None
+            )
         elif "fix this issue" in prompt_lower or prompt_lower.startswith("fix these"):
             yield TextEvent(text="Fixed.")
             yield ResultEvent(structured_output=None, continuation=None)

--- a/tests/harness/stub_backend.py
+++ b/tests/harness/stub_backend.py
@@ -203,6 +203,14 @@ class StubBackend:
         # per_stack_emit_reads is on (the uncovered-file-sweep test uses this to
         # leave one diff file unread by every reviewer).
         self.per_stack_unread: frozenset[str] = frozenset()
+        # Issue #742: when set, the per-stack parse branch emits these as the
+        # declared per-file verdicts in its structured_output
+        # (``{"issues": issues, "verdicts": self.parse_declared_verdicts}``),
+        # so the orchestrator's ``include_verdicts=True`` parse surfaces them
+        # and the clean-verdict gate reconciles them against completed reads.
+        # Default ``None`` keeps the existing parse output (no ``verdicts``
+        # key), so all current tests are unchanged.
+        self.parse_declared_verdicts: list[dict[str, Any]] | None = None
         # When set, the sweep parse branch emits its finding for this file
         # (instead of the default api.py), so stack-uncovered-records.json names
         # the swept file.
@@ -510,7 +518,10 @@ class StubBackend:
                             }
                         )
             yield TextEvent(text="")
-            yield ResultEvent(structured_output={"issues": issues}, continuation=None)
+            payload: dict[str, Any] = {"issues": issues}
+            if self.parse_declared_verdicts is not None:
+                payload["verdicts"] = self.parse_declared_verdicts
+            yield ResultEvent(structured_output=payload, continuation=None)
             return
 
         # Scoped Opus arbiter (#168). Reads the arbiter-input.json path the prompt

--- a/tests/harness/stub_backend.py
+++ b/tests/harness/stub_backend.py
@@ -37,7 +37,7 @@ from daydream.backends import (
     ToolResultEvent,
     ToolStartEvent,
 )
-from daydream.eval.analyzer import _records_issues
+from daydream.eval.analyzer import _records_issues_or_empty
 
 PARTIAL_FIX_MARKER = "// PARTIAL BROKEN EDIT -- max turns exhausted mid-fix\n"
 
@@ -611,9 +611,7 @@ class StubBackend:
                 next_id = 1
                 for path_str in re.findall(r"  - (\S+-records\.json)", prompt):
                     loaded = json.loads(Path(path_str).read_text())
-                    recs = _records_issues(loaded)
-                    if recs is None:
-                        recs = [] if isinstance(loaded, dict) else loaded
+                    recs = _records_issues_or_empty(loaded)
                     for rec in recs:
                         echoed.append(
                             {

--- a/tests/harness/stub_backend.py
+++ b/tests/harness/stub_backend.py
@@ -587,10 +587,19 @@ class StubBackend:
             if self.merge_echo_records:
                 # Echo the on-disk per-stack records as merged items so the
                 # rendered artifact reflects any arbiter revisions (#168).
+                # Issue #742: fresh-run records files carry the dict shape
+                # {"issues": [...], "verdicts": [...]}; normalize to the
+                # bare issues list (legacy files stay bare lists).
                 echoed: list[dict[str, Any]] = []
                 next_id = 1
                 for path_str in re.findall(r"  - (\S+-records\.json)", prompt):
-                    for rec in json.loads(Path(path_str).read_text()):
+                    loaded = json.loads(Path(path_str).read_text())
+                    if isinstance(loaded, dict):
+                        issues = loaded.get("issues")
+                        records = issues if isinstance(issues, list) else []
+                    else:
+                        records = loaded
+                    for rec in records:
                         echoed.append(
                             {
                                 "id": next_id,

--- a/tests/harness/stub_backend.py
+++ b/tests/harness/stub_backend.py
@@ -225,10 +225,11 @@ class StubBackend:
     def _stack_scope_files(prompt: str) -> list[str]:
         """Extract the file list from a per-stack/generic scope instruction.
 
-        ``_stack_scope_instruction`` renders the files comma-joined on a single
-        line (``  api.py, README.md``), so the single line is split on commas.
+        ``_stack_scope_instruction`` renders the files comma-joined on the
+        ``Assigned files:`` marker line (``  Assigned files: api.py, README.md``),
+        so the single line is split on commas.
         """
-        m = re.search(r"Focus ONLY on these files:\n\s*([^\n]+)", prompt)
+        m = re.search(r"Assigned files:\s*([^\n]+)", prompt)
         if m is None:
             return []
         return [part.strip() for part in m.group(1).split(",") if part.strip()]

--- a/tests/harness/stub_backend.py
+++ b/tests/harness/stub_backend.py
@@ -518,10 +518,15 @@ class StubBackend:
                             }
                         )
             yield TextEvent(text="")
-            payload: dict[str, Any] = {"issues": issues}
-            if self.parse_declared_verdicts is not None:
-                payload["verdicts"] = self.parse_declared_verdicts
-            yield ResultEvent(structured_output=payload, continuation=None)
+            # Issue #742: PER_STACK_RECORD_SCHEMA requires a ``verdicts``
+            # property (Codex strict-mode output schemas list every key in
+            # ``required``), so the parse payload always carries the key --
+            # declared per-file verdicts when the knob is set, else empty.
+            parse_payload: dict[str, Any] = {
+                "issues": issues,
+                "verdicts": self.parse_declared_verdicts or [],
+            }
+            yield ResultEvent(structured_output=parse_payload, continuation=None)
             return
 
         # Scoped Opus arbiter (#168). Reads the arbiter-input.json path the prompt
@@ -606,11 +611,11 @@ class StubBackend:
                 for path_str in re.findall(r"  - (\S+-records\.json)", prompt):
                     loaded = json.loads(Path(path_str).read_text())
                     if isinstance(loaded, dict):
-                        issues = loaded.get("issues")
-                        records = issues if isinstance(issues, list) else []
+                        loaded_issues = loaded.get("issues")
+                        recs = loaded_issues if isinstance(loaded_issues, list) else []
                     else:
-                        records = loaded
-                    for rec in records:
+                        recs = loaded
+                    for rec in recs:
                         echoed.append(
                             {
                                 "id": next_id,

--- a/tests/harness/stub_backend.py
+++ b/tests/harness/stub_backend.py
@@ -37,6 +37,7 @@ from daydream.backends import (
     ToolResultEvent,
     ToolStartEvent,
 )
+from daydream.eval.analyzer import _records_issues
 
 PARTIAL_FIX_MARKER = "// PARTIAL BROKEN EDIT -- max turns exhausted mid-fix\n"
 
@@ -610,11 +611,9 @@ class StubBackend:
                 next_id = 1
                 for path_str in re.findall(r"  - (\S+-records\.json)", prompt):
                     loaded = json.loads(Path(path_str).read_text())
-                    if isinstance(loaded, dict):
-                        loaded_issues = loaded.get("issues")
-                        recs = loaded_issues if isinstance(loaded_issues, list) else []
-                    else:
-                        recs = loaded
+                    recs = _records_issues(loaded)
+                    if recs is None:
+                        recs = [] if isinstance(loaded, dict) else loaded
                     for rec in recs:
                         echoed.append(
                             {

--- a/tests/test_archive_data_capture.py
+++ b/tests/test_archive_data_capture.py
@@ -406,7 +406,11 @@ class _FixEditingBackend:
                             "rationale": "guard missing",
                             "evidence": "main.py:1",
                         }
-                    ]
+                    ],
+                    # Issue #742: the deep per-stack parse schema requires a
+                    # ``verdicts`` property (Codex strict-mode output), so the
+                    # parse payload must carry it (empty when not exercised).
+                    "verdicts": [],
                 },
                 continuation=None,
             )

--- a/tests/test_capture_loop.py
+++ b/tests/test_capture_loop.py
@@ -124,7 +124,12 @@ async def test_unanchorable_finding_on_changed_file_is_placed_file_level(
     backend = PhaseDispatchBackend(
         events=[
             TextEvent(text="Review complete."),
-            ResultEvent(structured_output={"issues": [issue]}, continuation=None),
+            # Issue #742: the deep per-stack parse schema requires a
+            # ``verdicts`` property (Codex strict-mode output).
+            ResultEvent(
+                structured_output={"issues": [issue], "verdicts": []},
+                continuation=None,
+            ),
         ]
     )
     with _review_run_env(feature_branch_repo, monkeypatch, out, backend, fake_gh) as config:

--- a/tests/test_deep_coverage.py
+++ b/tests/test_deep_coverage.py
@@ -700,3 +700,39 @@ def test_compute_uncovered_files_import_only_grep_does_not_cover(tmp_path: Path)
     assert stats["files_read_by_reviewers"] == 1  # only notes.txt via Read
     swept, _, _ = filter_sweepable_files(uncovered, _DIFF, min_hunk_lines=1, max_files=10)
     assert "api.py" in swept  # the file is swept, never silently skipped
+
+
+def test_resolve_per_stack_verdicts_downgrades_clean_without_read() -> None:
+    """AC2: a clean verdict for a file with no completed read becomes not_reviewed."""
+    from daydream.deep.coverage import resolve_per_stack_verdicts
+
+    declared = [
+        {"path": "api.py", "lines_read": 10, "verdict": "clean"},
+        {"path": "notes.txt", "lines_read": 5, "verdict": "has_findings"},
+    ]
+    reads = {"/repo/api.py"}  # api.py read, notes.txt not
+    findings = {"notes.txt"}  # notes.txt has a finding
+    out = resolve_per_stack_verdicts(
+        assigned_files=["api.py", "notes.txt", "lib/util.py"],
+        declared_verdicts=declared,
+        completed_read_paths=reads,
+        finding_files=findings,
+    )
+    by_path = {v["path"]: v["verdict"] for v in out}
+    assert by_path["api.py"] == "clean"  # read + no finding -> clean stays
+    assert by_path["notes.txt"] == "has_findings"  # finding beats read
+    # an assigned file with no declaration, no read -> not_reviewed
+    assert by_path["lib/util.py"] == "not_reviewed"
+
+
+def test_resolve_per_stack_verdicts_clean_shard_read_is_clean() -> None:
+    """Spike: a clean shard that read its file stays clean (read-detection is findings-independent)."""
+    from daydream.deep.coverage import resolve_per_stack_verdicts
+
+    out = resolve_per_stack_verdicts(
+        assigned_files=["api.py"],
+        declared_verdicts=[{"path": "api.py", "lines_read": 10, "verdict": "clean"}],
+        completed_read_paths={"/repo/api.py"},
+        finding_files=set(),
+    )
+    assert out[0]["verdict"] == "clean"

--- a/tests/test_deep_coverage.py
+++ b/tests/test_deep_coverage.py
@@ -709,8 +709,9 @@ def test_resolve_per_stack_verdicts_downgrades_clean_without_read() -> None:
     declared = [
         {"path": "api.py", "lines_read": 10, "verdict": "clean"},
         {"path": "notes.txt", "lines_read": 5, "verdict": "has_findings"},
+        {"path": "lib/util.py", "lines_read": 12, "verdict": "clean"},
     ]
-    reads = {"/repo/api.py"}  # api.py read, notes.txt not
+    reads = {"/repo/api.py"}  # api.py read, notes.txt and lib/util.py not
     findings = {"notes.txt"}  # notes.txt has a finding
     out = resolve_per_stack_verdicts(
         assigned_files=["api.py", "notes.txt", "lib/util.py"],
@@ -721,7 +722,7 @@ def test_resolve_per_stack_verdicts_downgrades_clean_without_read() -> None:
     by_path = {v["path"]: v["verdict"] for v in out}
     assert by_path["api.py"] == "clean"  # read + no finding -> clean stays
     assert by_path["notes.txt"] == "has_findings"  # finding beats read
-    # an assigned file with no declaration, no read -> not_reviewed
+    # declared clean + no read -> downgraded to not_reviewed
     assert by_path["lib/util.py"] == "not_reviewed"
 
 

--- a/tests/test_deep_integration.py
+++ b/tests/test_deep_integration.py
@@ -101,6 +101,7 @@ class _DeepMockBackend:
             yield TextEvent(text="")
             # Parsing the structural review yields a finding (tagged lens="structural"
             # in merge, rendering the ## Structural Review section); other stacks yield none.
+            # Issue #742: the per-stack parse schema requires a ``verdicts`` property.
             if "stack-structure-review.md" in prompt:
                 yield ResultEvent(
                     structured_output={
@@ -112,12 +113,16 @@ class _DeepMockBackend:
                                 "line": 1,
                                 "evidence": "api.py:1",
                             }
-                        ]
+                        ],
+                        "verdicts": [],
                     },
                     continuation=None,
                 )
             else:
-                yield ResultEvent(structured_output={"issues": []}, continuation=None)
+                yield ResultEvent(
+                    structured_output={"issues": [], "verdicts": []},
+                    continuation=None,
+                )
             return
 
         # Merge: return an empty item list (no language-stack issues in this fixture),

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -211,6 +211,20 @@ def _write_matching_diff_key(target: Path, deep: Path) -> None:
     diff_key_path(deep).write_text(diff_key(diff or ""), encoding="utf-8")
 
 
+def _record_issues(loaded: Any) -> list[dict[str, Any]]:
+    """Normalize a per-stack records file to its bare issues list.
+
+    Issue #742: fresh-run per-stack records files carry the dict shape
+    ``{"issues": [...], "verdicts": [...]}``; legacy and primed fixtures use
+    the bare list. Consumers reading the file return the issues list either
+    way.
+    """
+    if isinstance(loaded, dict):
+        issues = loaded.get("issues")
+        return issues if isinstance(issues, list) else []
+    return loaded if isinstance(loaded, list) else []
+
+
 def _prime_merge_resume(
     target: Path,
     *,
@@ -4798,7 +4812,7 @@ async def test_arbiter_missing_verdict_retains_high_severity_finding(
     records = [
         rec
         for path in deep_dir.glob("stack-*-records.json")
-        for rec in json.loads(path.read_text())
+        for rec in _record_issues(json.loads(path.read_text()))
     ]
     assert any(r.get("severity") == "high" for r in records), (
         f"high-severity record must survive a missing arbiter verdict:\n{records}"

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -2575,9 +2575,9 @@ async def test_pipeline_order(multi_stack_target: Path, monkeypatch: pytest.Monk
     )
     assert python_prompt is not None
     assert react_prompt is not None
-    # The scope instruction's file-list line (right after the "Focus ONLY on these files:" header)
+    # The scope instruction's file-list line (right after the "Assigned files:" marker)
     # must not embed React files in the Python stack prompt.
-    python_scope_files_line = python_prompt.split("Focus ONLY on these files:")[1].split("\n", 2)[1]
+    python_scope_files_line = python_prompt.split("Assigned files:")[1].split("\n", 1)[0]
     assert "App.tsx" not in python_scope_files_line
 
     # Every execute call must have agents=None per D-38.

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -8175,3 +8175,64 @@ async def test_deep_forensic_mode_keeps_single_agent_per_stack(
     assert rc == 0
     deep = shard_many_python_target / ".daydream" / "deep"
     assert not list(deep.glob("stack-python#*-review.md"))  # exactly one agent per stack, as today
+
+
+async def test_clean_verdict_on_unread_file_is_not_reviewed_not_pass(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig, mute_side_effects: Mute,
+) -> None:
+    """AC4: per-stack reviewer declares clean for an assigned file it never
+    Read -> that file is recorded not_reviewed, never a pass; the assigned
+    and Read file stays clean.
+
+    Real path: drives runner.run; mocks only the backend. The stub emits a
+    Read for one assigned file and declares a clean verdict for BOTH assigned
+    files, so the unread file's clean verdict must be downgraded to
+    not_reviewed (read-gated, never a pass) while the read file's clean
+    verdict survives (payload preservation).
+    """
+    from daydream.runner import run
+
+    target = _uncovered_sweep_target(tmp_path)
+    _silence(monkeypatch)
+    mute_side_effects()
+    stub = _install_stub_backend(monkeypatch, target)
+    # Emit reads for one file, and a parse that declares clean verdicts for
+    # two files (one of which is never Read).
+    stub.per_stack_emit_reads = True
+    stub.per_stack_unread = frozenset({"notes.txt"})       # notes.txt is never Read
+    stub.parse_declared_verdicts = [
+        {"path": "api.py", "lines_read": 10, "verdict": "clean"},
+        {"path": "notes.txt", "lines_read": 8, "verdict": "clean"},
+    ]
+    # The stub's default parse emits an api.py finding for every stack; the
+    # gate's ordering is finding-beats-read, so a python-stack api.py finding
+    # would make the api.py verdict has_findings and mask the read-clean
+    # assertion under test. Route the python parse's finding off api.py so the
+    # read+clean verdict for api.py is observable.
+    stub.parse_by_stack = {
+        "python": {
+            "severity": "medium",
+            "confidence": "MEDIUM",
+            "file": "App.tsx",
+            "description": "python-stack finding routed off api.py",
+        },
+    }
+    exit_code = await run(make_config(target, assume="yes", output_mode="loop"))
+    assert exit_code == 0
+
+    deep = target / ".daydream" / "deep"
+    # The reconciled per-stack record must not record notes.txt as clean.
+    rec = json.loads((deep / "stack-python-records.json").read_text())
+    verdicts = {v["path"]: v for v in rec.get("verdicts", [])}
+    assert verdicts["api.py"]["verdict"] == "clean"  # the read file stays clean
+    assert verdicts["api.py"]["lines_read"] == 10  # declared payload survived reconciliation
+    # notes.txt lives in the generic stack's scope; it was declared clean but
+    # never Read, so the gate must downgrade it to not_reviewed -- and the
+    # declared lines_read payload is preserved on the downgraded entry (the
+    # reviewer said it read 8 lines; the gate records it was not read).
+    rec_generic = json.loads((deep / "stack-generic-records.json").read_text())
+    verdicts_generic = {v["path"]: v for v in rec_generic.get("verdicts", [])}
+    assert verdicts_generic["notes.txt"]["verdict"] == "not_reviewed"  # read-gated, never clean
+    assert verdicts_generic["notes.txt"]["lines_read"] == 8
+    assert verdicts_generic["README.md"]["verdict"] == "clean"  # read, though not declared

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -28,6 +28,7 @@ import pytest
 
 from daydream.backends import ResultEvent, TextEvent
 from daydream.config import SKILL_MAP
+from daydream.eval.analyzer import _records_issues
 from daydream.prompts.authorial_intent import AUTHORITATIVE_INTENT_RULE
 from tests.harness.git_helpers import bare_remote as _bare_remote
 from tests.harness.git_helpers import commit as _commit
@@ -214,15 +215,11 @@ def _write_matching_diff_key(target: Path, deep: Path) -> None:
 def _record_issues(loaded: Any) -> list[dict[str, Any]]:
     """Normalize a per-stack records file to its bare issues list.
 
-    Issue #742: fresh-run per-stack records files carry the dict shape
-    ``{"issues": [...], "verdicts": [...]}``; legacy and primed fixtures use
-    the bare list. Consumers reading the file return the issues list either
-    way.
+    Delegates to ``analyzer._records_issues`` (the canonical records-shape
+    normalization); non-list shapes (malformed fixtures) degrade to ``[]``.
     """
-    if isinstance(loaded, dict):
-        issues = loaded.get("issues")
-        return issues if isinstance(issues, list) else []
-    return loaded if isinstance(loaded, list) else []
+    issues = _records_issues(loaded)
+    return issues if issues is not None else []
 
 
 def _prime_merge_resume(

--- a/tests/test_deep_pr_comment_integration.py
+++ b/tests/test_deep_pr_comment_integration.py
@@ -300,7 +300,12 @@ class _FakeSDKClient:
                     model=FIXTURE_MODEL_ID,
                 ),
                 FakeResultMessage(
-                    structured_output={"issues": issues},
+                    structured_output={
+                        "issues": issues,
+                        # Issue #742: the deep per-stack parse schema requires a
+                        # ``verdicts`` property (Codex strict-mode output).
+                        "verdicts": [],
+                    },
                     total_cost_usd=0.05,
                     usage={
                         "input_tokens": 1500,

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -1379,3 +1379,26 @@ def test_per_stack_prompt_includes_verification_gate(tmp_path: Path) -> None:
         files=["api.py"], **p,
     )
     assert VERIFICATION_PROTOCOL_INSTRUCTION in out
+
+
+def test_verification_protocol_clean_clause_present_in_all_builders(tmp_path: Path) -> None:
+    """Key Decision 1: a clean verdict also requires a same-turn read, in all four builders."""
+    from daydream.deep.prompts import (
+        build_generic_fallback_prompt, build_per_stack_prompt,
+        build_structural_prompt,
+    )
+    from daydream.deep.coverage import build_uncovered_sweep_prompt
+    p = _paths(tmp_path)
+    prompts = [
+        build_per_stack_prompt(skill_invocation="/beagle-python:review-python",
+                               stack_name="python", files=["api.py"], **p),
+        build_structural_prompt(skill_invocation="/beagle-core:review-structure",
+                                files=["api.py"], **p),
+        build_generic_fallback_prompt(files=["config.yaml"], **p),
+        build_uncovered_sweep_prompt(
+            file="api.py", hunks="", intent_path=p["intent_path"],
+            cwd=p["cwd"], output_path=p["output_path"],
+        ),
+    ]
+    for prompt in prompts:
+        assert "not reviewed" in prompt and "clean" in prompt

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -1368,3 +1368,14 @@ def test_per_stack_prompt_instructs_frontier_read(tmp_path: Path) -> None:
     )
     assert "shared/iface.py" in prompt
     assert "cross-shard" in prompt or "interface file" in prompt
+
+
+def test_per_stack_prompt_includes_verification_gate(tmp_path: Path) -> None:
+    """AC1: the per-stack builder emits the shared anti-confabulation gate."""
+    from daydream.deep.prompts import VERIFICATION_PROTOCOL_INSTRUCTION, build_per_stack_prompt
+    p = _paths(tmp_path)
+    out = build_per_stack_prompt(
+        skill_invocation="/beagle-python:review-python", stack_name="python",
+        files=["api.py"], **p,
+    )
+    assert VERIFICATION_PROTOCOL_INSTRUCTION in out

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -1383,11 +1383,12 @@ def test_per_stack_prompt_includes_verification_gate(tmp_path: Path) -> None:
 
 def test_verification_protocol_clean_clause_present_in_all_builders(tmp_path: Path) -> None:
     """Key Decision 1: a clean verdict also requires a same-turn read, in all four builders."""
+    from daydream.deep.coverage import build_uncovered_sweep_prompt
     from daydream.deep.prompts import (
-        build_generic_fallback_prompt, build_per_stack_prompt,
+        build_generic_fallback_prompt,
+        build_per_stack_prompt,
         build_structural_prompt,
     )
-    from daydream.deep.coverage import build_uncovered_sweep_prompt
     p = _paths(tmp_path)
     prompts = [
         build_per_stack_prompt(skill_invocation="/beagle-python:review-python",

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -1434,3 +1434,22 @@ def test_stack_scope_instruction_is_mandatory_coverage_list(tmp_path: Path) -> N
     # The instruction demands one verdict line per assigned file (clean / has_findings / not_reviewed).
     assert "not_reviewed" in out and "has_findings" in out and "clean" in out
     assert "verdict" in out
+
+
+def test_exploration_pointer_distinguishes_exploration_from_assigned_sources(tmp_path: Path) -> None:
+    """Should-Have: 'do NOT read up front' applies to exploration artifacts, not assigned source files."""
+    from daydream.deep.prompts import build_per_stack_prompt
+    p = _paths(tmp_path)
+    out = build_per_stack_prompt(
+        skill_invocation="/beagle-python:review-python", stack_name="python",
+        files=["api.py"], exploration_dir=tmp_path / ".daydream" / "exploration", **p,
+    )
+    assert "do NOT read them all up front" in out
+    assert "assigned source files" in out and "MUST read in full" in out
+    # The no-up-front-read rule is scoped to exploration artifacts ONLY: the
+    # sentence that forbids up-front reads must not also carry the assigned-
+    # source-files mandate (today's dash-joined wording fails this).
+    upfront = "do NOT read them all up front"
+    sentence = out[out.index(upfront):]
+    sentence = sentence[: sentence.index("\n")]
+    assert "assigned source files" not in sentence

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -1402,3 +1402,19 @@ def test_verification_protocol_clean_clause_present_in_all_builders(tmp_path: Pa
     ]
     for prompt in prompts:
         assert "not reviewed" in prompt and "clean" in prompt
+
+
+def test_diff_instruction_mandates_read_first(tmp_path: Path) -> None:
+    """Key Decision 5: MAY Read is replaced by the sweep's read-first obligation."""
+    from daydream.deep.prompts import build_generic_fallback_prompt, build_per_stack_prompt
+    p = _paths(tmp_path)
+    per_stack = build_per_stack_prompt(
+        skill_invocation="/beagle-python:review-python", stack_name="python",
+        files=["api.py"], inline_diff="@@ -1 +1 @@\n-'x'\n+'y'\n", **p,
+    )
+    fallback = build_generic_fallback_prompt(
+        files=["config.yaml"], inline_diff="@@ -1 +1 @@\n-'x'\n+'y'\n", **p,
+    )
+    for prompt in (per_stack, fallback):
+        assert "you MAY Read the source files directly" not in prompt
+        assert "Read the source file FIRST" in prompt

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -1418,3 +1418,19 @@ def test_diff_instruction_mandates_read_first(tmp_path: Path) -> None:
     for prompt in (per_stack, fallback):
         assert "you MAY Read the source files directly" not in prompt
         assert "Read the source file FIRST" in prompt
+
+
+def test_stack_scope_instruction_is_mandatory_coverage_list(tmp_path: Path) -> None:
+    """Must-Have 5: assigned files are an inclusion obligation, not an exclusion bound."""
+    from daydream.deep.prompts import build_per_stack_prompt
+    p = _paths(tmp_path)
+    out = build_per_stack_prompt(
+        skill_invocation="/beagle-python:review-python", stack_name="python",
+        files=["api.py", "lib/util.py"], **p,
+    )
+    assert "Focus ONLY on these files" not in out
+    assert "Do NOT review files from other stacks" in out  # cross-stack exclusion preserved
+    assert "api.py" in out and "lib/util.py" in out
+    # The instruction demands one verdict line per assigned file (clean / has_findings / not_reviewed).
+    assert "not_reviewed" in out and "has_findings" in out and "clean" in out
+    assert "verdict" in out

--- a/tests/test_findings.py
+++ b/tests/test_findings.py
@@ -148,7 +148,12 @@ async def test_review_mode_writes_findings_artifact(feature_branch_repo, monkeyp
     # phase renders an empty change list from it).
     backend = PhaseDispatchBackend(events=[
         TextEvent(text="Review complete."),
-        ResultEvent(structured_output={"issues": [issue]}, continuation=None),
+        # Issue #742: the deep per-stack parse schema requires a ``verdicts``
+        # property (Codex strict-mode output).
+        ResultEvent(
+            structured_output={"issues": [issue], "verdicts": []},
+            continuation=None,
+        ),
     ])
     head = git_ops.head_sha(feature_branch_repo)
     base = subprocess.run(  # noqa: S603 - arguments are not user-controlled

--- a/tests/test_phase_parse_input_path.py
+++ b/tests/test_phase_parse_input_path.py
@@ -70,4 +70,4 @@ async def test_input_path_is_keyword_only(tmp_path: Path, make_work) -> None:
     """input_path cannot be passed positionally (signature guard)."""
     backend = _SpyBackend()
     with pytest.raises(TypeError):
-        await phase_parse_feedback(backend, make_work(tmp_path), tmp_path / "other.md")  # type: ignore[misc]
+        await phase_parse_feedback(backend, make_work(tmp_path), tmp_path / "other.md")  # type: ignore[call-overload]

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -4040,3 +4040,15 @@ def test_inlineable_diff_budget_counts_utf8_bytes_not_characters() -> None:
     assert len(multibyte) < INLINE_DIFF_BUDGET_BYTES
     assert len(multibyte.encode("utf-8")) > INLINE_DIFF_BUDGET_BYTES
     assert _inlineable_diff(multibyte) is None
+
+
+async def test_per_stack_schema_carries_verdicts_and_feedback_schema_untouched() -> None:
+    """Key Decision 2: PER_STACK_RECORD_SCHEMA gains per-file verdicts; FEEDBACK_SCHEMA is not mutated."""
+    from daydream.phases import FEEDBACK_SCHEMA, PER_STACK_RECORD_SCHEMA
+    props = PER_STACK_RECORD_SCHEMA["properties"]
+    assert "verdicts" in props
+    v_items = props["verdicts"]["items"]["properties"]
+    assert {"path", "lines_read", "verdict"}.issubset(v_items)
+    assert v_items["verdict"]["enum"] == ["clean", "has_findings", "not_reviewed"]
+    assert "verdicts" not in FEEDBACK_SCHEMA["properties"]  # base schema untouched
+    assert "severity" in props["issues"]["items"]["properties"]  # existing field preserved


### PR DESCRIPTION
## Summary
Fixes #742 — per-stack reviewers lacked the anti-confabulation (read-before-comment) gate and could emit a clean verdict on a source file they never read, clearing it from the review.

### Changes
- Per-stack prompts now carry the anti-confabulation gate (`daydream/deep/prompts.py`).
- Reading source files is mandatory before commenting on hunks.
- Per-stack scope is a mandatory-coverage list carrying per-file verdicts.
- Clean verdict requires a same-turn read in the shared gate; unread files downgrade to `not_reviewed`, never a pass.
- Per-stack records now carry per-file verdicts surfaced through `parse`.
- Exploration pointer scoped no-upfront-read to exploration artifacts only.

## Test Plan
- Full gate green independently on a fresh VM: lockcheck, ruff lint, mypy (335 files), 3780 tests passed.
- Two sequential daydream deep-precision reviews (rounds 1 & 2) both passed; all 6 round-2 findings (3 medium, 3 low) addressed.

Closes #742