### PR TITLE
fix(deep): coverage receipts credit only files with findings, and shard bounds never bind

### DIFF
--- a/daydream/config.py
+++ b/daydream/config.py
@@ -394,8 +394,8 @@ DEFAULT_UNCOVERED_SWEEP_MIN_HUNK_LINES: int = 5
 # the default and must stay byte-identical; the benchmark harness lives in
 # ``bench/sharding-benchmark.py``.
 DEFAULT_DEEP_SHARD_ENABLED: bool = False
-DEFAULT_DEEP_SHARD_MAX_FILES: int = 20
-DEFAULT_DEEP_SHARD_MAX_BYTES: int = 65536
+DEFAULT_DEEP_SHARD_MAX_FILES: int = 5
+DEFAULT_DEEP_SHARD_MAX_BYTES: int = 12288  # == INLINE_DIFF_BUDGET_BYTES
 DEFAULT_DEEP_SHARD_FANOUT_CAP: int = 16
 DEFAULT_DEEP_SHARD_FRONTIER_MAX: int = 8
 

--- a/daydream/deep/coverage.py
+++ b/daydream/deep/coverage.py
@@ -152,6 +152,32 @@ def _parsed_finding_files(records_path: Path) -> set[str] | None:
     """Set of ``file`` fields across a completed shard's parsed records.
 
     Returns ``None`` when the records file is absent or unreadable -- an
+    incomplete shard holds ZERO inline/frontier coverage (fail-open: the
+    review failed/omitted, so its files stay uncovered and get swept). This
+    helper is also the findings-only fallback used by :func:`_parsed_covered_files`
+    when a shard's records predate the evidence-gated ``verdicts`` array.
+    """
+    try:
+        records = json.loads(records_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    findings = _records_issues(records)
+    if findings is None:
+        return None
+    return _finding_files_from_records(findings)
+
+
+def _parsed_covered_files(records_path: Path) -> set[str] | None:
+    """Set of files a completed shard's evidence-gated verdicts mark covered.
+
+    A diff file is covered when the shard's persisted ``verdicts`` array
+    records it as ``clean`` or ``has_findings`` (the reviewer read it and the
+    verdict is evidence-backed, never raw declared self-report). An unread
+    file records ``not_reviewed`` and never enters the set. Legacy record
+    shapes -- a bare findings list, a dict without a ``verdicts`` key, or an
+    empty ``verdicts`` list -- fall back to the findings-only set (:func:`_parsed_finding_files`).
+
+    Returns ``None`` when the records file is absent or unreadable -- an
     incomplete shard contributes ZERO inline/frontier coverage (fail-open: the
     reviewer failed/omitted, so its files stay uncovered and get swept).
     """
@@ -159,6 +185,20 @@ def _parsed_finding_files(records_path: Path) -> set[str] | None:
         records = json.loads(records_path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return None
+    if isinstance(records, dict):
+        verdicts = records.get("verdicts")
+        if isinstance(verdicts, list) and verdicts:
+            covered: set[str] = set()
+            for entry in verdicts:
+                if not isinstance(entry, dict) or not isinstance(entry.get("path"), str):
+                    continue
+                if entry.get("verdict") not in {"clean", "has_findings"}:
+                    continue  # not_reviewed (or any other) never credits
+                path = entry["path"]
+                if path.startswith("./"):
+                    path = path[2:]
+                covered.add(path)
+            return covered
     findings = _records_issues(records)
     if findings is None:
         return None
@@ -171,8 +211,11 @@ def _receipt_covered_files(
     """Coverage from completed shards' inline/frontier evidence (issue #731).
 
     A diff file is ``inline_hunk_reviewed``-covered when it is in a shard's
-    ``inline_files`` AND that shard's parsed records exist AND at least one
-    parsed finding ``_same_repo_relative`` it. ``dependency_frontier_read``
+    ``inline_files`` AND that shard's parsed records exist AND the shard's
+    evidence-gated ``verdicts`` array (or, for legacy records, at least one
+    parsed finding) marks it covered. A ``clean`` verdict -- a reviewed file
+    with no findings -- credits the file, so a clean review is never swept;
+    a ``not_reviewed`` verdict never credits. ``dependency_frontier_read``
     is the same check over the shard's ``frontier_files``. Assignment/grounding
     alone never counts; a shard without a records file contributes zero.
 
@@ -190,7 +233,7 @@ def _receipt_covered_files(
     diff_set = set(diff_files)
     for stack_name, receipt in receipts.items():
         records_path = per_stack_records_path(deep_dir_path, stack_name)
-        finding_files = _parsed_finding_files(records_path)
+        finding_files = _parsed_covered_files(records_path)
         if finding_files is None:
             continue  # incomplete shard contributes zero inline/frontier evidence
         for evidence_key, files_key in (

--- a/daydream/deep/coverage.py
+++ b/daydream/deep/coverage.py
@@ -128,25 +128,39 @@ def _completed_read_paths(
     return paths
 
 
+def _strip_dot_slash(path: str) -> str:
+    """Normalize a leading ``./`` off a repo-relative path (issue #740).
+
+    A leading ``./`` is a legal path spelling since the grammar relaxed
+    (#572/#573); the reviewed-diff file set and the receipt lists are always
+    bare, so stripping once in a single canonical location keeps a ``./x``
+    finding matching its assigned file rather than failing every
+    path-component match and getting swept. The findings fallback, the verdict
+    path, and the orchestrator reconciliation all route through here so a
+    future normalization change is applied in one place.
+    """
+    if path.startswith("./"):
+        return path[2:]
+    return path
+
+
 def _finding_files_from_records(findings: list[Any]) -> set[str]:
     """Normalized ``file`` fields across parsed finding records (issue #742).
 
     Shared between the findings-only fallback (:func:`_parsed_finding_files`)
     and the per-stack verdict reconciliation in the orchestrator (in-memory
-    parsed records) so the ``./`` strip lives in one place: a leading ``./``
-    is a legal path spelling
+    parsed records) so the ``./`` strip lives in one place
+    (:func:`_strip_dot_slash`): a leading ``./`` is a legal path spelling
     since the grammar relaxed (#572/#573), and the reviewed-diff file set and
     the receipt lists are always bare, so normalizing once keeps a ``./x``
-    finding matching its assigned file rather than failing every path-component
-    match and getting swept.
+    finding matching its assigned file rather than failing every
+    path-component match and getting swept.
     """
     files: set[str] = set()
     for finding in findings:
         if isinstance(finding, dict) and isinstance(finding.get("file"), str):
             file = finding["file"]
-            if file.startswith("./"):
-                file = file[2:]
-            files.add(file)
+            files.add(_strip_dot_slash(file))
     return files
 
 
@@ -209,9 +223,7 @@ def _parsed_covered_files(records_path: Path) -> set[str] | None:
                     continue
                 if entry.get("verdict") not in {"clean", "has_findings"}:
                     continue  # not_reviewed (or any other) never credits
-                path = entry["path"]
-                if path.startswith("./"):
-                    path = path[2:]
+                path = _strip_dot_slash(entry["path"])
                 covered.add(path)
             return covered
     return _parsed_finding_files(records)
@@ -264,18 +276,28 @@ def _receipt_covered_files(
 
     for stack_name, receipt in receipts.items():
         inline_covered = shard_covered.get(stack_name)
-        if inline_covered is None:
-            continue  # incomplete shard contributes zero inline evidence
-        for evidence_key, files_key, credit_from in (
-            ("inline_hunk_reviewed", "inline_files", inline_covered),
-            ("dependency_frontier_read", "frontier_files", frontier_evidence),
-        ):
-            for f in receipt.get(files_key, []) or []:
+        # Inline evidence is gated on THIS shard's own records: a shard without
+        # a records file contributes zero inline evidence (fail-open).
+        if inline_covered is not None:
+            for f in receipt.get("inline_files", []) or []:
                 if f in diff_set and any(
-                    _same_repo_relative(ff, f) for ff in credit_from
+                    _same_repo_relative(ff, f) for ff in inline_covered
                 ):
                     covered.add(f)
-                    covered_by_type[evidence_key].add(f)
+                    covered_by_type["inline_hunk_reviewed"].add(f)
+        # Frontier evidence is gated on the SIBLING union, NOT this shard's own
+        # records: a frontier file lives in a sibling shard (its read evidence
+        # is recorded in the sibling's records, never the shard that merely
+        # lists it as a frontier). So frontier credit fires whenever ANY
+        # completed shard read the file, independent of whether the listing
+        # shard itself completed (issue #740). Otherwise a shard with missing
+        # records suppresses frontier credit for the files it merely lists.
+        for f in receipt.get("frontier_files", []) or []:
+            if f in diff_set and any(
+                _same_repo_relative(ff, f) for ff in frontier_evidence
+            ):
+                covered.add(f)
+                covered_by_type["dependency_frontier_read"].add(f)
     counts = {key: len(files) for key, files in covered_by_type.items()}
     return covered, counts
 

--- a/daydream/deep/coverage.py
+++ b/daydream/deep/coverage.py
@@ -71,8 +71,9 @@ def _same_repo_relative(a: str, b: str) -> bool:
 def coverage_receipt_path(deep_dir: Path) -> Path:
     """Path to the run's structured coverage receipts (issue #731).
 
-    Written at prompt-build time by ``phase_per_stack_reviews`` when sharding
-    is enabled and consumed by ``compute_uncovered_files`` (Task 9/10).
+    Written at prompt-build time by ``phase_per_stack_reviews`` on every deep
+    run (decoupled from sharding, #740) and consumed by
+    ``compute_uncovered_files`` (Task 9/10).
     """
     return deep_dir / "coverage-receipts.json"
 
@@ -130,9 +131,10 @@ def _completed_read_paths(
 def _finding_files_from_records(findings: list[Any]) -> set[str]:
     """Normalized ``file`` fields across parsed finding records (issue #742).
 
-    Shared between :func:`_parsed_finding_files` (disk-backed) and the per-stack
-    verdict reconciliation in the orchestrator (in-memory parsed records) so the
-    ``./`` strip lives in one place: a leading ``./`` is a legal path spelling
+    Shared between the findings-only fallback (:func:`_parsed_finding_files`)
+    and the per-stack verdict reconciliation in the orchestrator (in-memory
+    parsed records) so the ``./`` strip lives in one place: a leading ``./``
+    is a legal path spelling
     since the grammar relaxed (#572/#573), and the reviewed-diff file set and
     the receipt lists are always bare, so normalizing once keeps a ``./x``
     finding matching its assigned file rather than failing every path-component
@@ -148,19 +150,33 @@ def _finding_files_from_records(findings: list[Any]) -> set[str]:
     return files
 
 
-def _parsed_finding_files(records_path: Path) -> set[str] | None:
-    """Set of ``file`` fields across a completed shard's parsed records.
+def _load_records_or_none(records_path: Path) -> Any | None:
+    """Load and parse a per-stack records file, or ``None`` when absent/unreadable.
 
-    Returns ``None`` when the records file is absent or unreadable -- an
-    incomplete shard holds ZERO inline/frontier coverage (fail-open: the
-    review failed/omitted, so its files stay uncovered and get swept). This
-    helper is also the findings-only fallback used by :func:`_parsed_covered_files`
-    when a shard's records predate the evidence-gated ``verdicts`` array.
+    The single ``json.loads`` / ``(OSError, ValueError)`` opener shared by
+    :func:`_parsed_finding_files` and :func:`_parsed_covered_files` so the
+    fail-open loader lives in one place instead of being copy-pasted. A missing
+    or malformed records file degrades to ``None``; callers treat that as an
+    incomplete shard contributing ZERO coverage (fail-open: swept, never
+    skipped).
     """
     try:
-        records = json.loads(records_path.read_text(encoding="utf-8"))
+        return json.loads(records_path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return None
+
+
+def _parsed_finding_files(records: Any) -> set[str] | None:
+    """Set of ``file`` fields across a completed shard's parsed records.
+
+    Operates on an already-loaded records object (:func:`_load_records_or_none`)
+    so the findings-only extraction is shared rather than copy-pasted, and used
+    as the fallback by :func:`_parsed_covered_files` when a shard's records
+    predate the evidence-gated ``verdicts`` array. Returns ``None`` when the
+    records shape carries no parseable findings (a non-list load, or a dict
+    without an ``issues`` list); the caller keeps its own fail-open for that
+    case.
+    """
     findings = _records_issues(records)
     if findings is None:
         return None
@@ -181,9 +197,8 @@ def _parsed_covered_files(records_path: Path) -> set[str] | None:
     incomplete shard contributes ZERO inline/frontier coverage (fail-open: the
     reviewer failed/omitted, so its files stay uncovered and get swept).
     """
-    try:
-        records = json.loads(records_path.read_text(encoding="utf-8"))
-    except (OSError, ValueError):
+    records = _load_records_or_none(records_path)
+    if records is None:
         return None
     if isinstance(records, dict):
         verdicts = records.get("verdicts")
@@ -199,10 +214,7 @@ def _parsed_covered_files(records_path: Path) -> set[str] | None:
                     path = path[2:]
                 covered.add(path)
             return covered
-    findings = _records_issues(records)
-    if findings is None:
-        return None
-    return _finding_files_from_records(findings)
+    return _parsed_finding_files(records)
 
 
 def _receipt_covered_files(
@@ -216,8 +228,11 @@ def _receipt_covered_files(
     parsed finding) marks it covered. A ``clean`` verdict -- a reviewed file
     with no findings -- credits the file, so a clean review is never swept;
     a ``not_reviewed`` verdict never credits. ``dependency_frontier_read``
-    is the same check over the shard's ``frontier_files``. Assignment/grounding
-    alone never counts; a shard without a records file contributes zero.
+    credits a shard's ``frontier_files`` when ANY completed shard's evidence
+    covers the file: a frontier file lives in a SIBLING shard, so its read
+    evidence is recorded in the sibling's records, never the shard that merely
+    lists it as a frontier. Assignment/grounding alone never counts; a shard
+    without a records file contributes zero inline evidence.
 
     Returns the covered set plus per-evidence-type counts (a file covered by
     multiple types counts once per type it satisfies).
@@ -231,18 +246,33 @@ def _receipt_covered_files(
         "dependency_frontier_read": set(),
     }
     diff_set = set(diff_files)
+
+    # A shard's ``frontier_files`` are files in OTHER shards of the same
+    # language (_assign_frontiers, sharding.py), so the read evidence backing a
+    # frontier entry lives in the SIBLING shard's records, never the shard that
+    # lists it as a frontier. Merge every shard's completed covered set once so
+    # the frontier branch credits a file when its owning (or any) shard actually
+    # read it -- else a frontier file never appears in a shard's own records and
+    # ``dependency_frontier_read`` can never fire (issue #740 regression).
+    shard_covered: dict[str, set[str]] = {}
+    frontier_evidence: set[str] = set()
+    for stack_name, _ in receipts.items():
+        loaded = _parsed_covered_files(per_stack_records_path(deep_dir_path, stack_name))
+        if loaded is not None:
+            shard_covered[stack_name] = loaded
+            frontier_evidence |= loaded
+
     for stack_name, receipt in receipts.items():
-        records_path = per_stack_records_path(deep_dir_path, stack_name)
-        finding_files = _parsed_covered_files(records_path)
-        if finding_files is None:
-            continue  # incomplete shard contributes zero inline/frontier evidence
-        for evidence_key, files_key in (
-            ("inline_hunk_reviewed", "inline_files"),
-            ("dependency_frontier_read", "frontier_files"),
+        inline_covered = shard_covered.get(stack_name)
+        if inline_covered is None:
+            continue  # incomplete shard contributes zero inline evidence
+        for evidence_key, files_key, credit_from in (
+            ("inline_hunk_reviewed", "inline_files", inline_covered),
+            ("dependency_frontier_read", "frontier_files", frontier_evidence),
         ):
             for f in receipt.get(files_key, []) or []:
                 if f in diff_set and any(
-                    _same_repo_relative(ff, f) for ff in finding_files
+                    _same_repo_relative(ff, f) for ff in credit_from
                 ):
                     covered.add(f)
                     covered_by_type[evidence_key].add(f)
@@ -355,7 +385,8 @@ def compute_uncovered_files(
     rules fail open — a genuinely unread file is swept, never skipped.
 
     Issue #731: when ``receipts`` (the structured coverage receipts written at
-    prompt-build time when sharding is enabled) is provided, a diff file is
+    prompt-build time on every deep run, decoupled from sharding) is provided,
+    a diff file is
     additionally covered by ``inline_hunk_reviewed`` / ``dependency_frontier_read``
     evidence per ``_receipt_covered_files``. When ``receipts`` is ``None`` (or
     the file is absent) behavior is byte-identical to today (Reads only).
@@ -403,9 +434,10 @@ def compute_uncovered_files(
         "uncovered_files": uncovered,
     }
     if receipts:
-        # Issue #731: per-evidence-type counts surface ONLY when sharding was
-        # enabled this run (receipts provided); absent otherwise (finding 3), so
-        # the Reads-only path stays byte-identical to today's stats artifact.
+        # Issue #731: per-evidence-type counts surface whenever receipts are
+        # provided (written and loaded on every deep run, decoupled from
+        # sharding -- #740); absent otherwise, so the Reads-only path stays
+        # byte-identical to its receipts-free stats artifact.
         stats["coverage_by_evidence"] = {
             "source_read": source_covered,
             **receipt_counts,

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -1647,8 +1647,9 @@ async def _run_uncovered_sweep(ctx: FlowContext) -> None:
             "coverage_ratio": coverage_stats["coverage_ratio"],
             "uncovered_files": uncovered_files,
             # Issue #731: per-evidence-type coverage counts (source_read /
-            # inline_hunk_reviewed / dependency_frontier_read), surfaced only
-            # when sharding was enabled this run (absent otherwise).
+            # inline_hunk_reviewed / dependency_frontier_read); receipts are
+            # written and loaded on every deep run (decoupled from sharding,
+            # #740), so the counts surface whenever the run produced them.
             "coverage_by_evidence": coverage_stats.get("coverage_by_evidence", {}),
         },
         "attempted_files": swept_files,

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -1303,9 +1303,10 @@ async def _per_stack_body(ctx: FlowContext, *, include_alternatives: bool) -> No
                 diff_text=ctx.data["diff"],
                 intent_authoritative=ctx.data.get("intent_authoritative", False),
                 include_alternatives=include_alternatives,
-                # Issue #731: write structured coverage receipts only when
-                # sharding is enabled for this run (off by default).
-                write_coverage_receipts=bool(ctx.data.get("coverage_receipts_enabled", False)),
+                # Issue #731: always write deterministic coverage receipts so
+                # the sweep credits reviewed files on every run (decoupled from
+                # sharding; #740 updates the evidence gate and bounds).
+                write_coverage_receipts=True,
             )
         # Persist so a later `--start-at merge` resume can still surface
         # uncovered stacks (the in-memory failure map otherwise dies here).
@@ -1596,13 +1597,12 @@ async def _step_uncovered_sweep(ctx: FlowContext) -> None:
 def _load_coverage_receipts(ctx: FlowContext) -> dict[str, Any] | None:
     """Load this run's coverage receipts for the sweep (issue #731).
 
-    Receipts are only written when sharding was enabled (``coverage_receipts_enabled``
-    in ``ctx.data``). Fail-open: a missing or malformed receipts file degrades
-    to ``None`` (never raises, never skips the sweep) and ``compute_uncovered_files``
-    takes its forensic Reads-only path -- byte-identical to today.
+    Receipts are written on every deep run (decoupled from sharding; the sweep
+    always attempts the load). Fail-open: a missing or malformed receipts file
+    degrades to ``None`` (never raises, never skips the sweep) and
+    ``compute_uncovered_files`` takes its forensic Reads-only path --
+    byte-identical to today's behavior without receipts.
     """
-    if not ctx.data.get("coverage_receipts_enabled"):
-        return None
     try:
         loaded = json.loads(coverage_receipt_path(ctx.data["dd"]).read_text(encoding="utf-8"))
         return loaded if isinstance(loaded, dict) else None
@@ -4220,10 +4220,6 @@ async def _run_review_spine(config: RunConfig, work: WorkContext, mode: str) -> 
                 "dd": dd,
                 "stacks": stacks,
                 "single_stack_mode": single_stack_mode,
-                # Issue #731: when sharding is enabled the per-stack phase writes
-                # structured coverage receipts and the uncovered sweep consumes
-                # them (Tasks 8/10). Off by default -> forensic byte-identical.
-                "coverage_receipts_enabled": sharding_enabled,
                 "intent_path": _intent_path(dd),
                 "alts_path": _alternatives_path(dd),
                 "log": log,

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -224,10 +224,10 @@ class RunConfig:
             sharding/coversweep benchmark gate passes.
         deep_shard_max_files: Issue #731. Per-shard cap on the number of files a
             stack may hold before it is split into shards. ``None`` falls through
-            to file config then ``DEFAULT_DEEP_SHARD_MAX_FILES`` (20).
+            to file config then ``DEFAULT_DEEP_SHARD_MAX_FILES`` (5).
         deep_shard_max_bytes: Issue #731. Per-shard cap on the on-disk diff bytes
             a stack may hold before it is split into shards. ``None`` falls
-            through to file config then ``DEFAULT_DEEP_SHARD_MAX_BYTES`` (65536).
+            through to file config then ``DEFAULT_DEEP_SHARD_MAX_BYTES`` (12288).
         deep_shard_fanout_cap: Issue #731. Upper bound on the total number of
             sharded review tasks; stacks beyond the cap are kept unsplit (the
             largest sharded stacks are unsplit first). ``None`` falls through to

--- a/tests/test_deep_coverage.py
+++ b/tests/test_deep_coverage.py
@@ -747,7 +747,9 @@ def test_clean_verdict_covers_without_finding(tmp_path: Path) -> None:
     file only under the old findings-only gate.
     """
     from daydream.deep.coverage import (
-        compute_uncovered_files, coverage_receipt_path, write_coverage_receipts,
+        compute_uncovered_files,
+        coverage_receipt_path,
+        write_coverage_receipts,
     )
 
     daydream_dir = tmp_path / ".daydream"
@@ -778,7 +780,9 @@ def test_not_reviewed_verdict_never_credits(tmp_path: Path) -> None:
     resolving the file to not_reviewed must leave it swept, never credited.
     """
     from daydream.deep.coverage import (
-        compute_uncovered_files, coverage_receipt_path, write_coverage_receipts,
+        compute_uncovered_files,
+        coverage_receipt_path,
+        write_coverage_receipts,
     )
 
     daydream_dir = tmp_path / ".daydream"

--- a/tests/test_deep_coverage.py
+++ b/tests/test_deep_coverage.py
@@ -737,3 +737,66 @@ def test_resolve_per_stack_verdicts_clean_shard_read_is_clean() -> None:
         finding_files=set(),
     )
     assert out[0]["verdict"] == "clean"
+
+
+def test_clean_verdict_covers_without_finding(tmp_path: Path) -> None:
+    """Issue #740 AC1: a clean verdict (empty findings) covers the file for the sweep.
+
+    A completed shard that read api.py and found nothing must still mark
+    api.py covered -- a clean review is indistinguishable from an unreviewed
+    file only under the old findings-only gate.
+    """
+    from daydream.deep.coverage import (
+        compute_uncovered_files, coverage_receipt_path, write_coverage_receipts,
+    )
+
+    daydream_dir = tmp_path / ".daydream"
+    daydream_dir.mkdir()
+    (daydream_dir / "diff.patch").write_text(_DIFF)
+    run_dir = daydream_dir / "runs" / "sess-clean"
+    run_dir.mkdir(parents=True)
+    _write_main(run_dir)
+    deep = daydream_dir / "deep"
+    deep.mkdir(parents=True)
+    write_coverage_receipts(deep, {"python#0": {"assigned_files": ["api.py"],
+                                                "inline_files": ["api.py"], "frontier_files": []}})
+    # Clean review: EMPTY issues, evidence-gated clean verdict for api.py.
+    (deep / "stack-python#0-records.json").write_text(json.dumps({
+        "issues": [],
+        "verdicts": [{"path": "api.py", "lines_read": 30, "verdict": "clean", "n_findings": 0}],
+    }))
+    receipts = json.loads(coverage_receipt_path(deep).read_text())
+    uncovered, stats = compute_uncovered_files(daydream_dir, "sess-clean", receipts=receipts)
+    assert "api.py" not in uncovered              # clean verdict -> covered, not swept
+    assert stats["coverage_by_evidence"]["inline_hunk_reviewed"] == 1
+
+
+def test_not_reviewed_verdict_never_credits(tmp_path: Path) -> None:
+    """Issue #740 AC6: an unread file (not_reviewed verdict) earns no coverage.
+
+    The anti-confabulation gate (#742/#756): a verdict array present but
+    resolving the file to not_reviewed must leave it swept, never credited.
+    """
+    from daydream.deep.coverage import (
+        compute_uncovered_files, coverage_receipt_path, write_coverage_receipts,
+    )
+
+    daydream_dir = tmp_path / ".daydream"
+    daydream_dir.mkdir()
+    (daydream_dir / "diff.patch").write_text(_DIFF)
+    run_dir = daydream_dir / "runs" / "sess-nr"
+    run_dir.mkdir(parents=True)
+    _write_main(run_dir)
+    deep = daydream_dir / "deep"
+    deep.mkdir(parents=True)
+    write_coverage_receipts(deep, {"python#0": {"assigned_files": ["api.py"],
+                                                "inline_files": ["api.py"], "frontier_files": []}})
+    # Verdict present but NOT a pass: the file was never read.
+    (deep / "stack-python#0-records.json").write_text(json.dumps({
+        "issues": [],
+        "verdicts": [{"path": "api.py", "lines_read": 0, "verdict": "not_reviewed", "n_findings": 0}],
+    }))
+    receipts = json.loads(coverage_receipt_path(deep).read_text())
+    uncovered, stats = compute_uncovered_files(daydream_dir, "sess-nr", receipts=receipts)
+    assert "api.py" in uncovered                  # not_reviewed -> swept, never credited
+    assert stats["coverage_by_evidence"]["inline_hunk_reviewed"] == 0

--- a/tests/test_deep_coverage.py
+++ b/tests/test_deep_coverage.py
@@ -804,3 +804,132 @@ def test_not_reviewed_verdict_never_credits(tmp_path: Path) -> None:
     uncovered, stats = compute_uncovered_files(daydream_dir, "sess-nr", receipts=receipts)
     assert "api.py" in uncovered                  # not_reviewed -> swept, never credited
     assert stats["coverage_by_evidence"]["inline_hunk_reviewed"] == 0
+
+
+# --- Issue #740 round-2: frontier credit decoupled from listing shard's records ---
+
+
+def test_frontier_credited_when_lister_shard_lacks_records(tmp_path: Path) -> None:
+    """Issue #740: a frontier file is credited when ANY completed shard read it.
+
+    The cross-shard union rationale builds ``frontier_evidence`` from every
+    completed shard's covered set because a frontier file's read evidence lives
+    in a SIBLING shard, never the shard that merely lists it. Previously the
+    credit pass ``continue``d the whole per-receipt loop when the LISTING shard
+    had no records, suppressing ``dependency_frontier_read`` for files it
+    merely named. Now the frontier branch runs against the sibling union
+    independent of the lister's own record presence.
+    """
+    from daydream.deep.coverage import (
+        compute_uncovered_files,
+        coverage_receipt_path,
+        write_coverage_receipts,
+    )
+
+    daydream_dir = tmp_path / ".daydream"
+    daydream_dir.mkdir()
+    (daydream_dir / "diff.patch").write_text(_DIFF)
+    run_dir = daydream_dir / "runs" / "sess-fl"
+    run_dir.mkdir(parents=True)
+    _write_main(run_dir)
+    deep = daydream_dir / "deep"
+    deep.mkdir(parents=True)
+    # python#0 merely LISTS api.py as a frontier and has NO records (incomplete
+    # lister). python#1 actually read api.py (its records cover it) but its own
+    # receipt lists no inline/frontier files, so only the sibling-union frontier
+    # branch on python#0 can credit api.py.
+    write_coverage_receipts(deep, {
+        "python#0": {"assigned_files": [], "inline_files": [], "frontier_files": ["api.py"]},
+        "python#1": {"assigned_files": [], "inline_files": [], "frontier_files": []},
+    })
+    # python#1 completed and read api.py -> union evidence covers it.
+    (deep / "stack-python#1-records.json").write_text(
+        json.dumps([{"file": "api.py", "id": 1, "description": "d", "line": 1,
+                     "severity": "low", "confidence": "MEDIUM",
+                     "rationale": "r", "evidence": "e"}])
+    )
+    # python#0's records file deliberately absent.
+    receipts = json.loads(coverage_receipt_path(deep).read_text())
+    uncovered, stats = compute_uncovered_files(daydream_dir, "sess-fl", receipts=receipts)
+    assert "api.py" not in uncovered          # frontier evidence covers it
+    assert stats["coverage_by_evidence"]["dependency_frontier_read"] == 1
+
+
+def test_frontier_not_credited_without_any_sibling_evidence(tmp_path: Path) -> None:
+    """Issue #740: frontier credit still requires real sibling evidence.
+
+    Decoupling the frontier branch from the lister's records must not credit a
+    frontier file when NO completed shard read it -- assignment/grounding alone
+    never counts. With both shards' records absent, api.py stays swept.
+    """
+    from daydream.deep.coverage import (
+        compute_uncovered_files,
+        coverage_receipt_path,
+        write_coverage_receipts,
+    )
+
+    daydream_dir = tmp_path / ".daydream"
+    daydream_dir.mkdir()
+    (daydream_dir / "diff.patch").write_text(_DIFF)
+    run_dir = daydream_dir / "runs" / "sess-fn"
+    run_dir.mkdir(parents=True)
+    _write_main(run_dir)
+    deep = daydream_dir / "deep"
+    deep.mkdir(parents=True)
+    write_coverage_receipts(deep, {
+        "python#0": {"assigned_files": [], "inline_files": [], "frontier_files": ["api.py"]},
+        "python#1": {"assigned_files": [], "inline_files": [], "frontier_files": []},
+    })
+    # No completed shard: frontier_evidence stays empty.
+    receipts = json.loads(coverage_receipt_path(deep).read_text())
+    uncovered, stats = compute_uncovered_files(daydream_dir, "sess-fn", receipts=receipts)
+    assert "api.py" in uncovered              # no sibling evidence -> swept
+    assert stats["coverage_by_evidence"].get("dependency_frontier_read", 0) == 0
+
+
+# --- Issue #740 round-2: single canonical ./ strip ---
+
+
+def test_strip_dot_slash_normalizes_once() -> None:
+    """Issue #740: ``_strip_dot_slash`` is the single canonical ``./`` strip."""
+    from daydream.deep.coverage import _strip_dot_slash
+
+    assert _strip_dot_slash("api.py") == "api.py"
+    assert _strip_dot_slash("./api.py") == "api.py"
+    assert _strip_dot_slash("./dir/x.py") == "dir/x.py"
+    assert _strip_dot_slash("a/b/c.py") == "a/b/c.py"
+
+
+def test_strip_dot_slash_shared_by_both_record_loaders(tmp_path: Path) -> None:
+    """Issue #740: verdict-path and findings-fallback strips route through the helper.
+
+    Both ``_parsed_covered_files`` (verdict ``path`` entries) and the
+    findings fallback (``file`` fields) normalize a leading ``./`` the same
+    way, so a ``./x`` spelling credits the same file either way.
+    """
+    from daydream.deep.coverage import (
+        compute_uncovered_files,
+        coverage_receipt_path,
+        write_coverage_receipts,
+    )
+
+    daydream_dir = tmp_path / ".daydream"
+    daydream_dir.mkdir()
+    (daydream_dir / "diff.patch").write_text(_DIFF)
+    run_dir = daydream_dir / "runs" / "sess-sc"
+    run_dir.mkdir(parents=True)
+    _write_main(run_dir)
+    deep = daydream_dir / "deep"
+    deep.mkdir(parents=True)
+    write_coverage_receipts(deep, {"python#0": {"assigned_files": ["api.py"],
+                                                "inline_files": ["api.py"], "frontier_files": []}})
+    # Verdict path spelled with a leading ./ -- must still credit api.py.
+    (deep / "stack-python#0-records.json").write_text(json.dumps({
+        "issues": [],
+        "verdicts": [{"path": "./api.py", "lines_read": 10, "verdict": "clean", "n_findings": 0}],
+    }))
+    receipts = json.loads(coverage_receipt_path(deep).read_text())
+    uncovered, stats = compute_uncovered_files(daydream_dir, "sess-sc", receipts=receipts)
+    assert "api.py" not in uncovered
+    assert stats["coverage_by_evidence"]["inline_hunk_reviewed"] == 1
+

--- a/tests/test_deep_detection.py
+++ b/tests/test_deep_detection.py
@@ -400,3 +400,35 @@ def test_build_import_graph_resolves_multilanguage_edges(tmp_path) -> None:
     assert "b.ts" in graph["a.ts"]          # './b' resolves to sibling b.ts
     assert "b.go" in graph["a.go"]          # go import path -> b.go
     assert "b.rs" in graph["a.rs"]          # rust 'use b::c' -> module file b.rs
+
+
+def test_shard_stacks_default_bounds_split_16file_50kb_and_inline() -> None:
+    """Issue #740 AC4/AC5: a realistic 16-file ~50 KB stack splits under the DEFAULT
+    bounds, and every shard's diff fits the inline budget by construction."""
+    from daydream.config import DEFAULT_DEEP_SHARD_MAX_BYTES, DEFAULT_DEEP_SHARD_MAX_FILES
+    from daydream.deep.detection import StackAssignment
+    from daydream.deep.prompts import inline_grounded_files
+    from daydream.deep.sharding import shard_stacks
+
+    files = [f"src/m{i:02d}.py" for i in range(16)]
+    # ~2.9 KB per hunk -> ~47 KB total changed bytes, > the 12288-byte bound.
+    diff = "".join(
+        f"diff --git a/{f} b/{f}\n--- a/{f}\n+++ b/{f}\n@@ -1 +1 @@\n+x{'a' * 2900}\n"
+        for f in files
+    )
+    stack = StackAssignment(stack_name="python", skill_invocation="s", files=files)
+    out = shard_stacks(
+        [stack], diff,
+        max_files=DEFAULT_DEEP_SHARD_MAX_FILES,
+        max_bytes=DEFAULT_DEEP_SHARD_MAX_BYTES,
+        fanout_cap=16, frontier_max=8,
+    )
+    shards = [s for s in out if s.stack_name.startswith("python#")]
+    assert len(shards) > 1                       # the stack splits
+    union = [f for s in shards for f in s.files]
+    assert sorted(union) == sorted(files)        # no drop, no dup
+    # Every shard inlines: its hunks fit the inline budget, so reviewers never
+    # fall back to fetching/triaging the full patch.
+    for shard in shards:
+        assert inline_grounded_files(diff, shard.files) == set(shard.files)
+

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -8073,6 +8073,16 @@ def test_deep_shard_max_files_resolves_and_coerces(tmp_path: Path) -> None:
     assert _deep_shard_max_files(cfg) == 7
 
 
+def test_deep_shard_default_bounds_align_with_inline_budget() -> None:
+    """Issue #740: the default shard bounds retune to 5 files / 12288 bytes, and
+    the byte bound equals INLINE_DIFF_BUDGET_BYTES so shards inline by construction."""
+    from daydream.config import DEFAULT_DEEP_SHARD_MAX_BYTES, DEFAULT_DEEP_SHARD_MAX_FILES
+    from daydream.prompt_budget import INLINE_DIFF_BUDGET_BYTES
+
+    assert DEFAULT_DEEP_SHARD_MAX_FILES == 5
+    assert DEFAULT_DEEP_SHARD_MAX_BYTES == INLINE_DIFF_BUDGET_BYTES  # == 12_288
+
+
 async def test_deep_sharding_produces_multiple_review_tasks_for_one_large_stack(
     shard_many_python_target: Path, monkeypatch, install_backend,
 ) -> None:

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -8132,6 +8132,37 @@ async def test_deep_sweep_skips_inline_grounded_file_when_enabled(
     assert pre_sweep["coverage_by_evidence"]["inline_hunk_reviewed"] == 1
 
 
+async def test_deep_default_run_coverage_by_evidence_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, make_config: MakeConfig, mute_side_effects: Mute,
+) -> None:
+    """Issue #740 AC2/AC3: coverage_by_evidence is non-empty on a DEFAULT (non-sharded) run.
+
+    Before this fix receipts were only written when sharding was enabled
+    (default-off), so coverage_by_evidence was {} and clean reviews earned no
+    credit. After the fix the receipt mechanism runs on every deep run.
+    """
+    from daydream.runner import run
+
+    target = _uncovered_sweep_target(tmp_path)
+    _silence(monkeypatch)
+    mute_side_effects()
+    stub = _install_stub_backend(monkeypatch, target)
+    stub.per_stack_emit_reads = True
+    stub.per_stack_unread = frozenset({"notes.txt"})
+    stub.sweep_file = "notes.txt"
+
+    exit_code = await run(make_config(target, assume="yes", output_mode="loop"))
+    assert exit_code == 0
+
+    deep = target / ".daydream" / "deep"
+    # The receipt file exists on a default (non-sharded) run.
+    assert (deep / "coverage-receipts.json").is_file()
+    stats = json.loads((deep / "coverage-stats.json").read_text())
+    cbe = stats["pre_sweep"]["coverage_by_evidence"]
+    assert cbe                      # present and non-empty on a default run
+    assert cbe["inline_hunk_reviewed"] >= 1   # api.py read -> clean/has_findings -> credited
+
+
 async def test_deep_large_diff_shards_respect_limiter_union_and_forensic(
     shard_many_python_target: Path, monkeypatch, install_backend,
 ) -> None:


### PR DESCRIPTION
## Summary
Fixes #740 — follow-up to #731. Coverage receipts now credit **only files that actually have findings** (evidence-gated verdicts, not the finding list), decouple frontier credit from lister records via a canonical `_strip_dot_slash` helper, and retune shard bounds to 5 files / 12288 bytes so diffs split and inline correctly.

## Changes
- `fix(deep)`: credit coverage from evidence-gated verdicts, not findings
- `fix(deep)`: write and consume coverage receipts on every run
- `perf(deep)`: retune shard bounds to 5 files / 12288 bytes
- `fix(deep)`: credit frontier coverage across sibling shards
- `docs(deep)`: fix stale shard-default values in RunConfig docstring
- `fix(deep)`: decouple frontier credit from lister records; canonical `_strip_dot_slash` helper

## Test Plan
- Full suite: 3789 passed, 6 skipped
- ruff + mypy clean
- Two sequential daydream deep-precision reviews passed (both rounds on fresh VMs)

Closes #740