### PR TITLE
fix(eval): findings metrics exclude every wonder/alternatives item, inflating cost-per-finding ~2x (#741)

### DIFF
--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -876,7 +876,7 @@ def build_merge_prompt(
 
     The merge agent returns a schema-validated JSON item list
     (``MERGED_ITEMS_SCHEMA``) -- NOT markdown. Each item is one actionable
-    finding tagged with ``lens`` (``per-stack`` | ``cross-stack``) and
+    finding tagged with ``lens`` (``per-stack`` | ``cross-stack`` | ``wonder``) and
     ``severity``. The host (``phase_cross_stack_merge``) appends structural
     findings tagged ``lens="structural"`` in Python, normalizes ids, writes the
     canonical ``merged-items.json``, and renders ``review-output.md`` from it.
@@ -884,8 +884,9 @@ def build_merge_prompt(
     section, or a write-to-file step.
 
     Each emitted item MUST:
-      - carry a ``lens`` of ``per-stack`` or ``cross-stack`` (D-26 — cross-stack
-        for concerns spanning multiple stacks)
+      - carry a ``lens`` of ``per-stack``, ``cross-stack`` (D-26 — cross-stack
+        for concerns spanning multiple stacks), or ``wonder`` (alternatives.json-
+        sourced findings)
       - carry a ``severity`` of ``high`` | ``medium`` | ``low`` (D-25 ordering)
       - collapse duplicates per dedup candidate adjudication (D-27)
 
@@ -963,8 +964,9 @@ def build_merge_prompt(
         "Item fields (MANDATORY):\n"
         "  - id: integer; any value -- the host renumbers contiguously.\n"
         "  - lens: \"per-stack\" for a single-stack finding, \"cross-stack\" for a "
-        "concern spanning multiple stacks. (Structural findings are appended by the "
-        "host -- do NOT emit them yourself.)\n"
+        "concern spanning multiple stacks, and \"wonder\" for an "
+        "alternatives.json-sourced finding. (Structural findings are appended by "
+        "the host -- do NOT emit them yourself.)\n"
         "  - severity: \"high\" | \"medium\" | \"low\".\n"
         "  - confidence: \"HIGH\" | \"MEDIUM\" | \"LOW\".\n"
         "  - file: the FULL repo-relative path exactly as it appears in the per-stack "

--- a/daydream/deep/render.py
+++ b/daydream/deep/render.py
@@ -44,28 +44,22 @@ def render_report(items: list[dict[str, Any]]) -> str:
     Returns:
         The rendered markdown report as a string.
     """
-    structural = [i for i in items if i.get("lens") == "structural"]
-    per_stack = [i for i in items if i.get("lens") == "per-stack"]
-    cross_stack = [i for i in items if i.get("lens") == "cross-stack"]
-    wonder = [i for i in items if i.get("lens") == "wonder"]
-
     sections: list[str] = ["# Review"]
 
-    if structural:
-        body = "\n".join(_finding_line(i) for i in structural)
-        sections.append(f"## Structural Review\n{body}")
+    # lens -> (section title, line prefix). One arm per lens; a section is
+    # emitted only when it has items.
+    lens_sections = [
+        ("structural", "## Structural Review", ""),
+        ("per-stack", "## Issues", ""),
+        ("cross-stack", "## Cross-Stack Issues", "[cross-stack] "),
+        ("wonder", "## Wonder Findings", ""),
+    ]
 
-    if per_stack:
-        body = "\n".join(_finding_line(i) for i in per_stack)
-        sections.append(f"## Issues\n{body}")
-
-    if cross_stack:
-        body = "\n".join(_finding_line(i, prefix="[cross-stack] ") for i in cross_stack)
-        sections.append(f"## Cross-Stack Issues\n{body}")
-
-    if wonder:
-        body = "\n".join(_finding_line(i) for i in wonder)
-        sections.append(f"## Wonder Findings\n{body}")
+    for lens, title, prefix in lens_sections:
+        rows = [i for i in items if i.get("lens") == lens]
+        if rows:
+            body = "\n".join(_finding_line(i, prefix=prefix) for i in rows)
+            sections.append(f"{title}\n{body}")
 
     return "\n\n".join(sections) + "\n"
 

--- a/daydream/deep/render.py
+++ b/daydream/deep/render.py
@@ -30,11 +30,12 @@ def render_report(items: list[dict[str, Any]]) -> str:
     """Render canonical items into the deep-review markdown report.
 
     Groups items by ``lens`` and emits, in order: ``## Structural Review``
-    (only when structural items exist), ``## Issues`` (per-stack lens), and
+    (only when structural items exist), ``## Issues`` (per-stack lens),
     ``## Cross-Stack Issues`` (cross-stack lens, each title prefixed with the
-    literal ``[cross-stack]``). A section is omitted entirely when it has no
-    items. Each finding line is ``N. [FILE:LINE] DESCRIPTION``, unbolded, where
-    ``N`` is the item's canonical ``id``.
+    literal ``[cross-stack]``), and ``## Wonder Findings`` (wonder lens). A
+    section is omitted entirely when it has no items. Each finding line is
+    ``N. [FILE:LINE] DESCRIPTION``, unbolded, where ``N`` is the item's
+    canonical ``id``.
 
     Args:
         items: Canonical merged finding items, each carrying ``id``, ``lens``,
@@ -46,6 +47,7 @@ def render_report(items: list[dict[str, Any]]) -> str:
     structural = [i for i in items if i.get("lens") == "structural"]
     per_stack = [i for i in items if i.get("lens") == "per-stack"]
     cross_stack = [i for i in items if i.get("lens") == "cross-stack"]
+    wonder = [i for i in items if i.get("lens") == "wonder"]
 
     sections: list[str] = ["# Review"]
 
@@ -60,6 +62,10 @@ def render_report(items: list[dict[str, Any]]) -> str:
     if cross_stack:
         body = "\n".join(_finding_line(i, prefix="[cross-stack] ") for i in cross_stack)
         sections.append(f"## Cross-Stack Issues\n{body}")
+
+    if wonder:
+        body = "\n".join(_finding_line(i) for i in wonder)
+        sections.append(f"## Wonder Findings\n{body}")
 
     return "\n\n".join(sections) + "\n"
 

--- a/daydream/eval/analyzer.py
+++ b/daydream/eval/analyzer.py
@@ -643,7 +643,14 @@ def _records_issues_or_empty(records: Any) -> list[Any]:
 
 
 def analyze_findings(daydream_dir: Path) -> dict:
-    """Parse per-stack records, dedup stats, and merged review."""
+    """Parse per-stack records, dedup stats, and merged review.
+
+    ``total``/``by_confidence`` report the shipped review set: ``merged-items.json``
+    is authoritative when present (it is the canonical set the posted review is
+    rendered from). When that file is absent, the count falls back to the
+    ``merged_finding_count`` regex on ``review-output.md``, then to the pre-merge
+    per-stack total so archived runs never regress to zero.
+    """
     deep_dir = daydream_dir / "deep"
     if not deep_dir.is_dir():
         return {
@@ -693,9 +700,29 @@ def analyze_findings(daydream_dir: Path) -> dict:
             re.findall(r"^\d+\.\s+\[", text, re.MULTILINE)
         )
 
+    # Issue #741: count the shipped set. merged-items.json is authoritative
+    # (present-but-empty means "shipped nothing"); the regex count is a
+    # resilience fallback when the file is absent, and the pre-merge per-stack
+    # total protects archived runs from regressing to zero. A present-but-corrupt
+    # file is a data-integrity error: let its JSONDecodeError propagate rather
+    # than silently hiding it behind the fallback.
+    merged_items_file = deep_dir / "merged-items.json"
+    if merged_items_file.exists():
+        merged_items = json.loads(merged_items_file.read_text()).get("items", [])
+        total = len(merged_items)
+        by_confidence = dict(
+            Counter(i.get("confidence", "UNKNOWN") for i in merged_items)
+        )
+    elif merged_review.get("merged_finding_count"):
+        total = merged_review["merged_finding_count"]
+        by_confidence = dict(confidence_counts)
+    else:
+        total = len(all_findings)
+        by_confidence = dict(confidence_counts)
+
     return {
-        "total": len(all_findings),
-        "by_confidence": dict(confidence_counts),
+        "total": total,
+        "by_confidence": by_confidence,
         "findings": all_findings,
         "stacks": stacks,
         "dedup": dedup_stats,

--- a/daydream/eval/analyzer.py
+++ b/daydream/eval/analyzer.py
@@ -676,8 +676,8 @@ def _shipped_counts(
     """Select the shipped review set and report (total, by_confidence) together.
 
     ``merged-items.json`` is authoritative when present (present-but-empty means
-    "shipped nothing"), and only the items the renderer emits count: the
-    renderer drops wonder-lens items, so they are excluded here too. When that
+    "shipped nothing"); every item it carries is shipped, including wonder-lens
+    findings (the renderer emits them, so they count -- issue #741). When that
     file is absent the count falls back to the ``merged_finding_count`` regex on
     ``review-output.md``; when neither exists it falls back to the pre-merge
     per-stack total so archived runs never regress to zero. ``by_confidence``
@@ -689,11 +689,13 @@ def _shipped_counts(
     merged_items_file = deep_dir / "merged-items.json"
     if merged_items_file.exists():
         merged_items = json.loads(merged_items_file.read_text()).get("items", [])
-        shipped = [i for i in merged_items if i.get("lens") != "wonder"]
+        # Every merged item is shipped: the renderer now emits wonder-lens
+        # findings too (issue #741), so the shipped set equals the posted
+        # review. A present-but-empty list means "shipped nothing".
         by_confidence = dict(
-            Counter(i.get("confidence", "UNKNOWN") for i in shipped)
+            Counter(i.get("confidence", "UNKNOWN") for i in merged_items)
         )
-        return len(shipped), by_confidence
+        return len(merged_items), by_confidence
     if merged_review.get("merged_finding_count"):
         # The review is the shipped rendering but carries no confidence values,
         # so no confidence attribution is possible without another source. Return

--- a/daydream/eval/analyzer.py
+++ b/daydream/eval/analyzer.py
@@ -649,7 +649,9 @@ def analyze_findings(daydream_dir: Path) -> dict:
     is authoritative when present (it is the canonical set the posted review is
     rendered from). When that file is absent, the count falls back to the
     ``merged_finding_count`` regex on ``review-output.md``, then to the pre-merge
-    per-stack total so archived runs never regress to zero.
+    per-stack total so archived runs never regress to zero. ``per_lens`` attributes
+    findings across the wonder (``alternatives.json``), per-stack, uncovered, and
+    structure lenses.
     """
     deep_dir = daydream_dir / "deep"
     if not deep_dir.is_dir():
@@ -660,10 +662,21 @@ def analyze_findings(daydream_dir: Path) -> dict:
             "stacks": [],
             "dedup": {},
             "merged_review": {},
+            "per_lens": {"wonder": 0, "per-stack": 0, "uncovered": 0, "structure": 0},
         }
 
     all_findings: list[dict] = []
     stacks: list[dict] = []
+
+    # Issue #741: per-lens finding attribution. wonder reads the bare-list
+    # alternatives.json (the canonical wonder artifact); the existing
+    # stack-*-records.json glob buckets into structure / uncovered / per-stack.
+    per_lens: dict[str, int] = {"wonder": 0, "per-stack": 0, "uncovered": 0, "structure": 0}
+    alts_path = deep_dir / "alternatives.json"
+    if alts_path.exists():
+        alternatives = json.loads(alts_path.read_text())
+        if isinstance(alternatives, list):
+            per_lens["wonder"] = len(alternatives)
 
     for f in sorted(deep_dir.glob("stack-*-records.json")):
         stack_name = f.stem.replace("stack-", "").replace("-records", "")
@@ -673,6 +686,12 @@ def analyze_findings(daydream_dir: Path) -> dict:
         # either way (legacy bare lists pass through).
         records = _records_issues_or_empty(loaded)
         stacks.append({"name": stack_name, "finding_count": len(records)})
+        if stack_name == "uncovered":
+            per_lens["uncovered"] += len(records)
+        elif stack_name == "structure":
+            per_lens["structure"] += len(records)
+        else:
+            per_lens["per-stack"] += len(records)
         for r in records:
             r["_stack"] = stack_name
             all_findings.append(r)
@@ -727,6 +746,7 @@ def analyze_findings(daydream_dir: Path) -> dict:
         "stacks": stacks,
         "dedup": dedup_stats,
         "merged_review": merged_review,
+        "per_lens": per_lens,
     }
 
 
@@ -1837,6 +1857,7 @@ def analyze_session(daydream_dir: str | Path, session_id: str | None = None) -> 
             "stacks": findings_data["stacks"],
             "dedup": findings_data["dedup"],
             "merged_review": findings_data.get("merged_review", {}),
+            "per_lens": findings_data.get("per_lens", {}),
         },
         "grounding": grounding,
         "exploration_utilization": exploration,

--- a/daydream/eval/analyzer.py
+++ b/daydream/eval/analyzer.py
@@ -650,12 +650,23 @@ def _bucketed_lens_counts(deep_dir: Path) -> dict[str, int]:
 
     ``wonder`` reads the bare-list ``alternatives.json`` (the canonical wonder
     artifact); the existing ``stack-*-records.json`` glob buckets into
-    per-stack / uncovered / structure by stack name.
+    per-stack / uncovered / structure by stack name. These lens counts are raw,
+    pre-merge attribution -- they are *not* derived from the shipped
+    ``merged-items.json`` set, so they need not sum to, or relate to, the
+    shipped ``total`` reported by ``_shipped_counts``. The distinction is
+    deliberate and documented: reconciling a lens to the shipped set would hide
+    how many items survived merge/dedup, so report readers should treat the
+    lens as raw attribution rather than a partition of the shipped set.
     """
     per_lens = dict(_EMPTY_PER_LENS)
     alts_path = deep_dir / "alternatives.json"
     if alts_path.exists():
-        alternatives = json.loads(alts_path.read_text())
+        try:
+            alternatives = json.loads(alts_path.read_text())
+        except json.JSONDecodeError:
+            # A present-but-malformed alternatives.json must not take down
+            # analyze_findings / analyze_session; leave wonder attribution at 0.
+            alternatives = None
         if isinstance(alternatives, list):
             per_lens["wonder"] = len(alternatives)
     for f in sorted(deep_dir.glob("stack-*-records.json")):
@@ -681,14 +692,30 @@ def _shipped_counts(
     file is absent the count falls back to the ``merged_finding_count`` regex on
     ``review-output.md``; when neither exists it falls back to the pre-merge
     per-stack total so archived runs never regress to zero. ``by_confidence``
-    is in every branch derived from the artifact that supplies ``total``. A
-    present-but-corrupt ``merged-items.json`` is a data-integrity error: let its
-    ``JSONDecodeError`` propagate rather than silently hiding it behind the
-    fallback.
+    is in every branch derived from the artifact that supplies ``total``.
+
+    A present-but-corrupt ``merged-items.json`` is a data-integrity error that
+    propagates rather than being silently hidden behind the fallback: a
+    *syntax*-invalid file surfaces ``JSONDecodeError`` from ``json.loads``, and a
+    well-formed file with the wrong shape (top-level non-object, or an ``items``
+    field that is not a list) raises ``ValueError`` from the explicit shape
+    check. Both are the same documented error class -- a bogus shipped set is
+    never silently counted.
     """
     merged_items_file = deep_dir / "merged-items.json"
     if merged_items_file.exists():
-        merged_items = json.loads(merged_items_file.read_text()).get("items", [])
+        merged = json.loads(merged_items_file.read_text())
+        # Shape-check before use so a well-formed-but-wrong-shape file (top-level
+        # non-object, or ``items`` not a list) is treated as the documented
+        # data-integrity error instead of silently yielding a bogus count. The
+        # writer always emits the ``items`` key, so a missing ``items`` is a
+        # wrong shape too -- only ``items": []`` is "shipped nothing".
+        if not isinstance(merged, dict) or not isinstance(merged.get("items"), list):
+            raise ValueError(
+                "merged-items.json must be an object whose ``items`` is a list; "
+                f"got top-level type {type(merged).__name__}"
+            )
+        merged_items = merged["items"]
         # Every merged item is shipped: the renderer now emits wonder-lens
         # findings too (issue #741), so the shipped set equals the posted
         # review. A present-but-empty list means "shipped nothing".
@@ -778,6 +805,13 @@ def analyze_findings(daydream_dir: Path) -> dict:
 
 def analyze_grounding(trajectories: dict, findings: list[dict]) -> dict:
     """Tier 1 grounding: verify cited files were actually read by the agent.
+
+    The denominator is the pre-merge per-stack finding list held in
+    ``findings_data["findings"]`` -- those are the records tagged with
+    ``_stack`` to match against a deep-stack reader -- not the shipped ``total``
+    from ``merged-items.json``. Shipped wonder/structural items are absent from
+    this set because they have no per-stack reader stream to ground to, so they
+    neither inflate the denominator nor get grounding credit here.
 
     ``grounding_rate`` is ``None`` over an empty finding set: the ratio is
     undefined, not perfect. It feeds the RL/SFT reward as a credit axis

--- a/daydream/eval/analyzer.py
+++ b/daydream/eval/analyzer.py
@@ -642,6 +642,68 @@ def _records_issues_or_empty(records: Any) -> list[Any]:
     return issues
 
 
+_EMPTY_PER_LENS = {"wonder": 0, "per-stack": 0, "uncovered": 0, "structure": 0}
+
+
+def _bucketed_lens_counts(deep_dir: Path) -> dict[str, int]:
+    """Attribute findings across the wonder / per-stack / uncovered / structure lenses.
+
+    ``wonder`` reads the bare-list ``alternatives.json`` (the canonical wonder
+    artifact); the existing ``stack-*-records.json`` glob buckets into
+    per-stack / uncovered / structure by stack name.
+    """
+    per_lens = dict(_EMPTY_PER_LENS)
+    alts_path = deep_dir / "alternatives.json"
+    if alts_path.exists():
+        alternatives = json.loads(alts_path.read_text())
+        if isinstance(alternatives, list):
+            per_lens["wonder"] = len(alternatives)
+    for f in sorted(deep_dir.glob("stack-*-records.json")):
+        stack_name = f.stem.replace("stack-", "").replace("-records", "")
+        records = _records_issues_or_empty(json.loads(f.read_text()))
+        if stack_name == "uncovered":
+            per_lens["uncovered"] += len(records)
+        elif stack_name == "structure":
+            per_lens["structure"] += len(records)
+        else:
+            per_lens["per-stack"] += len(records)
+    return per_lens
+
+
+def _shipped_counts(
+    deep_dir: Path, all_findings: list[dict], merged_review: dict
+) -> tuple[int, dict[str, int]]:
+    """Select the shipped review set and report (total, by_confidence) together.
+
+    ``merged-items.json`` is authoritative when present (present-but-empty means
+    "shipped nothing"), and only the items the renderer emits count: the
+    renderer drops wonder-lens items, so they are excluded here too. When that
+    file is absent the count falls back to the ``merged_finding_count`` regex on
+    ``review-output.md``; when neither exists it falls back to the pre-merge
+    per-stack total so archived runs never regress to zero. ``by_confidence``
+    is in every branch derived from the artifact that supplies ``total``. A
+    present-but-corrupt ``merged-items.json`` is a data-integrity error: let its
+    ``JSONDecodeError`` propagate rather than silently hiding it behind the
+    fallback.
+    """
+    merged_items_file = deep_dir / "merged-items.json"
+    if merged_items_file.exists():
+        merged_items = json.loads(merged_items_file.read_text()).get("items", [])
+        shipped = [i for i in merged_items if i.get("lens") != "wonder"]
+        by_confidence = dict(
+            Counter(i.get("confidence", "UNKNOWN") for i in shipped)
+        )
+        return len(shipped), by_confidence
+    if merged_review.get("merged_finding_count"):
+        # The review is the shipped rendering but carries no confidence values,
+        # so no confidence attribution is possible without another source. Return
+        # an empty rather than cross-mix the pre-merge per-stack confidences.
+        return merged_review["merged_finding_count"], {}
+    return len(all_findings), dict(
+        Counter(f.get("confidence", "UNKNOWN") for f in all_findings)
+    )
+
+
 def analyze_findings(daydream_dir: Path) -> dict:
     """Parse per-stack records, dedup stats, and merged review.
 
@@ -662,41 +724,21 @@ def analyze_findings(daydream_dir: Path) -> dict:
             "stacks": [],
             "dedup": {},
             "merged_review": {},
-            "per_lens": {"wonder": 0, "per-stack": 0, "uncovered": 0, "structure": 0},
+            "per_lens": dict(_EMPTY_PER_LENS),
         }
 
     all_findings: list[dict] = []
     stacks: list[dict] = []
 
-    # Issue #741: per-lens finding attribution. wonder reads the bare-list
-    # alternatives.json (the canonical wonder artifact); the existing
-    # stack-*-records.json glob buckets into structure / uncovered / per-stack.
-    per_lens: dict[str, int] = {"wonder": 0, "per-stack": 0, "uncovered": 0, "structure": 0}
-    alts_path = deep_dir / "alternatives.json"
-    if alts_path.exists():
-        alternatives = json.loads(alts_path.read_text())
-        if isinstance(alternatives, list):
-            per_lens["wonder"] = len(alternatives)
+    per_lens = _bucketed_lens_counts(deep_dir)
 
     for f in sorted(deep_dir.glob("stack-*-records.json")):
         stack_name = f.stem.replace("stack-", "").replace("-records", "")
-        loaded = json.loads(f.read_text())
-        # Issue #742: fresh-run per-stack records files carry the dict shape
-        # {"issues": [...], "verdicts": [...]}; findings are the issues list
-        # either way (legacy bare lists pass through).
-        records = _records_issues_or_empty(loaded)
+        records = _records_issues_or_empty(json.loads(f.read_text()))
         stacks.append({"name": stack_name, "finding_count": len(records)})
-        if stack_name == "uncovered":
-            per_lens["uncovered"] += len(records)
-        elif stack_name == "structure":
-            per_lens["structure"] += len(records)
-        else:
-            per_lens["per-stack"] += len(records)
         for r in records:
             r["_stack"] = stack_name
             all_findings.append(r)
-
-    confidence_counts = Counter(f.get("confidence", "UNKNOWN") for f in all_findings)
 
     dedup_stats: dict = {}
     dedup_path = deep_dir / "dedup-candidates.json"
@@ -719,25 +761,7 @@ def analyze_findings(daydream_dir: Path) -> dict:
             re.findall(r"^\d+\.\s+\[", text, re.MULTILINE)
         )
 
-    # Issue #741: count the shipped set. merged-items.json is authoritative
-    # (present-but-empty means "shipped nothing"); the regex count is a
-    # resilience fallback when the file is absent, and the pre-merge per-stack
-    # total protects archived runs from regressing to zero. A present-but-corrupt
-    # file is a data-integrity error: let its JSONDecodeError propagate rather
-    # than silently hiding it behind the fallback.
-    merged_items_file = deep_dir / "merged-items.json"
-    if merged_items_file.exists():
-        merged_items = json.loads(merged_items_file.read_text()).get("items", [])
-        total = len(merged_items)
-        by_confidence = dict(
-            Counter(i.get("confidence", "UNKNOWN") for i in merged_items)
-        )
-    elif merged_review.get("merged_finding_count"):
-        total = merged_review["merged_finding_count"]
-        by_confidence = dict(confidence_counts)
-    else:
-        total = len(all_findings)
-        by_confidence = dict(confidence_counts)
+    total, by_confidence = _shipped_counts(deep_dir, all_findings, merged_review)
 
     return {
         "total": total,

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -909,7 +909,7 @@ MERGED_ITEMS_SCHEMA: dict[str, Any] = {
                     "confidence": {"type": "string", "enum": ["HIGH", "MEDIUM"]},
                     "rationale": {"type": "string"},
                     "evidence": {"type": "string"},
-                    "lens": {"type": "string", "enum": ["per-stack", "cross-stack", "structural"]},
+                    "lens": {"type": "string", "enum": ["per-stack", "cross-stack", "structural", "wonder"]},
                     "severity": {"type": "string", "enum": ["high", "medium", "low"]},
                 },
                 "required": [

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1536,3 +1536,21 @@ def test_shipped_count_never_zero_without_artifacts(tmp_path: Path):
     seed_stack_records(deep, "python", n=4)
     out = analyze_findings(dd)
     assert out["total"] == 4                    # pre-merge fallback, never 0
+
+
+def test_per_lens_attribution_reads_alternatives_and_stack_buckets(tmp_path: Path):
+    dd = tmp_path / ".daydream"; deep = dd / "deep"; deep.mkdir(parents=True)
+    (deep / "alternatives.json").write_text(json.dumps([{"id": 1}, {"id": 2}]))
+    seed_stack_records(deep, "python", n=3)
+    seed_stack_records(deep, "uncovered", n=1)
+    seed_stack_records(deep, "structure", n=2)
+    out = analyze_findings(dd)
+    assert out["per_lens"] == {"wonder": 2, "per-stack": 3, "uncovered": 1, "structure": 2}
+
+
+def test_per_lens_wonder_only_run_reports_nonzero_wonder(tmp_path: Path):
+    dd = tmp_path / ".daydream"; deep = dd / "deep"; deep.mkdir(parents=True)
+    (deep / "alternatives.json").write_text(json.dumps([{"id": i} for i in range(6)]))
+    out = analyze_findings(dd)
+    assert out["per_lens"]["wonder"] == 6
+    assert out["per_lens"]["per-stack"] == 0

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1552,6 +1552,41 @@ def test_shipped_count_includes_wonder_lens_items(tmp_path: Path):
     assert out["by_confidence"] == {"HIGH": 4, "MEDIUM": 4}
 
 
+def test_shipped_count_wrong_shape_merged_items_propagates(tmp_path: Path):
+    # ``_shipped_counts`` documents present-but-corrupt merged-items.json as a
+    # data-integrity error. A well-formed file with the wrong shape must surface
+    # that error too, not silently yield a bogus count behind the fallback.
+    dd = tmp_path / ".daydream"
+    deep = dd / "deep"
+    deep.mkdir(parents=True)
+    seed_stack_records(deep, "python", n=4)
+    # ``items`` present but a non-list, and a top-level list, are both wrong
+    # shapes, as is a missing ``items`` key -- the writer always emits it.
+    (deep / "merged-items.json").write_text(json.dumps({"items": {"a": 1}}))
+    with pytest.raises(ValueError):
+        analyze_findings(dd)
+
+
+def test_shipped_count_missing_items_key_propagates(tmp_path: Path):
+    dd = tmp_path / ".daydream"
+    deep = dd / "deep"
+    deep.mkdir(parents=True)
+    (deep / "merged-items.json").write_text(json.dumps({}))
+    with pytest.raises(ValueError):
+        analyze_findings(dd)
+
+
+def test_shipped_count_corrupt_merged_items_propagates_json_decode_error(tmp_path: Path):
+    # A *syntax*-invalid merged-items.json surfaces, not the fallback.
+    dd = tmp_path / ".daydream"
+    deep = dd / "deep"
+    deep.mkdir(parents=True)
+    seed_stack_records(deep, "python", n=4)
+    (deep / "merged-items.json").write_text("{not json")
+    with pytest.raises(json.JSONDecodeError):
+        analyze_findings(dd)
+
+
 def test_shipped_count_falls_back_to_regex_when_merged_items_absent(tmp_path: Path):
     dd = tmp_path / ".daydream"
     deep = dd / "deep"
@@ -1581,6 +1616,17 @@ def test_per_lens_attribution_reads_alternatives_and_stack_buckets(tmp_path: Pat
     seed_stack_records(deep, "structure", n=2)
     out = analyze_findings(dd)
     assert out["per_lens"] == {"wonder": 2, "per-stack": 3, "uncovered": 1, "structure": 2}
+
+
+def test_per_lens_malformed_alternatives_does_not_crash(tmp_path: Path):
+    # A present-but-malformed alternatives.json must not take down
+    # analyze_findings / analyze_session (it served wonder attribution either).
+    dd = tmp_path / ".daydream"
+    deep = dd / "deep"
+    deep.mkdir(parents=True)
+    (deep / "alternatives.json").write_text("{not json")
+    out = analyze_findings(dd)
+    assert out["per_lens"]["wonder"] == 0
 
 
 def test_per_lens_wonder_only_run_reports_nonzero_wonder(tmp_path: Path):

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -21,6 +21,7 @@ from daydream.eval.analyzer import (
     _tokenize_command,
     analyze_costs,
     analyze_coverage,
+    analyze_findings,
     analyze_grounding,
     analyze_quality,
     analyze_session,
@@ -1463,3 +1464,75 @@ def test_quality_excludes_explicitly_vendored_subtree(tmp_path: Path):
     assert result["scoped_files"] == 1
     assert list(result["per_file"]) == ["app.py"]
     assert result["erosion"] == 0.0
+
+
+# ----------------------------------------------------------------------------
+# Shipped-set findings metrics (issue #741): analyze_findings counts the
+# authoritative merged-items.json set, falling back to the merged review
+# regex count, then the pre-merge per-stack total.
+# ----------------------------------------------------------------------------
+
+def seed_shipped_items(deep: Path, *, high: int, med: int) -> None:
+    """Write deep/\"merged-items.json\" = {\"items\": [high+med schema-valid items]}."""
+    items = []
+    for i in range(high):
+        items.append({
+            "id": i,
+            "description": f"high-{i}",
+            "file": "a.py",
+            "line": i + 1,
+            "confidence": "HIGH",
+            "rationale": "r",
+            "evidence": "a.py:1",
+            "lens": "per-stack",
+            "severity": "high",
+        })
+    for i in range(med):
+        items.append({
+            "id": high + i,
+            "description": f"med-{i}",
+            "file": "b.py",
+            "line": i + 1,
+            "confidence": "MEDIUM",
+            "rationale": "r",
+            "evidence": "b.py:1",
+            "lens": "per-stack",
+            "severity": "medium",
+        })
+    (deep / "merged-items.json").write_text(json.dumps({"items": items}))
+
+
+def seed_stack_records(deep: Path, stack_name: str, *, n: int) -> None:
+    """Write deep/f\"stack-{stack_name}-records.json\" = [{\"id\": i, \"confidence\": \"HIGH\"}]*n."""
+    records = [{"id": i, "confidence": "HIGH"} for i in range(n)]
+    (deep / f"stack-{stack_name}-records.json").write_text(json.dumps(records))
+
+
+def seed_review_output(deep: Path, *, count: int) -> None:
+    """Write deep/\"review-output.md\" with `count` lines matching ^\\d+\\.\\s+\\[."""
+    lines = [f"{i}. [HIGH] finding {i}" for i in range(1, count + 1)]
+    (deep / "review-output.md").write_text("\n".join(lines) + "\n")
+
+
+def test_shipped_count_wins_over_per_stack_records(tmp_path: Path):
+    dd = tmp_path / ".daydream"; deep = dd / "deep"; deep.mkdir(parents=True)
+    seed_shipped_items(deep, high=4, med=4)     # merged-items.json: 8 items (4 HIGH, 4 MEDIUM)
+    seed_stack_records(deep, "python", n=4)     # stack-python-records.json: 4 HIGH
+    out = analyze_findings(dd)
+    assert out["total"] == 8
+    assert out["by_confidence"] == {"HIGH": 4, "MEDIUM": 4}
+
+
+def test_shipped_count_falls_back_to_regex_when_merged_items_absent(tmp_path: Path):
+    dd = tmp_path / ".daydream"; deep = dd / "deep"; deep.mkdir(parents=True)
+    seed_review_output(deep, count=8)           # review-output.md: 8 numbered [ items
+    seed_stack_records(deep, "python", n=4)
+    out = analyze_findings(dd)
+    assert out["total"] == 8                    # from merged_finding_count regex, not per-stack
+
+
+def test_shipped_count_never_zero_without_artifacts(tmp_path: Path):
+    dd = tmp_path / ".daydream"; deep = dd / "deep"; deep.mkdir(parents=True)
+    seed_stack_records(deep, "python", n=4)
+    out = analyze_findings(dd)
+    assert out["total"] == 4                    # pre-merge fallback, never 0

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1525,6 +1525,33 @@ def test_shipped_count_wins_over_per_stack_records(tmp_path: Path):
     assert out["by_confidence"] == {"HIGH": 4, "MEDIUM": 4}
 
 
+def test_shipped_count_includes_wonder_lens_items(tmp_path: Path):
+    # Issue #741: wonder-lens merged items are shipped findings and MUST count
+    # toward total_findings (they were dropped by the pre-fix renderer, inflating
+    # cost_per_finding ~2x). The analyzer counts every merged-items.json item.
+    dd = tmp_path / ".daydream"
+    deep = dd / "deep"
+    deep.mkdir(parents=True)
+    # 4 per-stack + 4 wonder = 8 shipped items.
+    items = []
+    for i in range(4):
+        items.append({
+            "id": i, "description": f"high-{i}", "file": "a.py", "line": i + 1,
+            "confidence": "HIGH", "rationale": "r", "evidence": "a.py:1",
+            "lens": "per-stack", "severity": "high",
+        })
+    for i in range(4):
+        items.append({
+            "id": 4 + i, "description": f"wonder-{i}", "file": "w.py", "line": i + 1,
+            "confidence": "MEDIUM", "rationale": "r", "evidence": "w.py:1",
+            "lens": "wonder", "severity": "medium",
+        })
+    (deep / "merged-items.json").write_text(json.dumps({"items": items}))
+    out = analyze_findings(dd)
+    assert out["total"] == 8                     # wonder items are counted (issue #741)
+    assert out["by_confidence"] == {"HIGH": 4, "MEDIUM": 4}
+
+
 def test_shipped_count_falls_back_to_regex_when_merged_items_absent(tmp_path: Path):
     dd = tmp_path / ".daydream"
     deep = dd / "deep"

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1554,3 +1554,29 @@ def test_per_lens_wonder_only_run_reports_nonzero_wonder(tmp_path: Path):
     out = analyze_findings(dd)
     assert out["per_lens"]["wonder"] == 6
     assert out["per_lens"]["per-stack"] == 0
+
+
+def seed_run_trajectory(dd: Path, session_id: str, *, total_cost_usd: float) -> None:
+    """Write dd/\"runs\"/<session_id>/\"trajectory.json\" with final metrics."""
+    run_dir = dd / "runs" / session_id
+    run_dir.mkdir(parents=True)
+    (run_dir / "trajectory.json").write_text(json.dumps({
+        "session_id": session_id,
+        "final_metrics": {"total_cost_usd": total_cost_usd},
+        "agent": {"name": "test"},
+        "extra": {},
+    }))
+
+
+def test_analyze_session_shipped_metrics_match_a80b9373(tmp_path: Path):
+    sid = "a80b9373-56d6-4062-9ab5-4c75e475ab67"
+    dd = tmp_path / ".daydream"
+    seed_run_trajectory(dd, sid, total_cost_usd=18.2056)
+    deep = dd / "deep"; deep.mkdir(parents=True)
+    seed_shipped_items(deep, high=4, med=4)     # 8 shipped items, the a80b9373 shape
+    (deep / "alternatives.json").write_text(json.dumps([{"id": i} for i in range(6)]))
+    res = analyze_session(dd, session_id=sid)
+    assert res["findings"]["total"] == 8
+    assert res["findings"]["by_confidence"] == {"HIGH": 4, "MEDIUM": 4}
+    assert res["findings"]["per_lens"]["wonder"] == 6
+    assert res["derived"]["cost_per_finding_usd"] == pytest.approx(18.2056 / 8, rel=1e-4)

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1515,7 +1515,9 @@ def seed_review_output(deep: Path, *, count: int) -> None:
 
 
 def test_shipped_count_wins_over_per_stack_records(tmp_path: Path):
-    dd = tmp_path / ".daydream"; deep = dd / "deep"; deep.mkdir(parents=True)
+    dd = tmp_path / ".daydream"
+    deep = dd / "deep"
+    deep.mkdir(parents=True)
     seed_shipped_items(deep, high=4, med=4)     # merged-items.json: 8 items (4 HIGH, 4 MEDIUM)
     seed_stack_records(deep, "python", n=4)     # stack-python-records.json: 4 HIGH
     out = analyze_findings(dd)
@@ -1524,7 +1526,9 @@ def test_shipped_count_wins_over_per_stack_records(tmp_path: Path):
 
 
 def test_shipped_count_falls_back_to_regex_when_merged_items_absent(tmp_path: Path):
-    dd = tmp_path / ".daydream"; deep = dd / "deep"; deep.mkdir(parents=True)
+    dd = tmp_path / ".daydream"
+    deep = dd / "deep"
+    deep.mkdir(parents=True)
     seed_review_output(deep, count=8)           # review-output.md: 8 numbered [ items
     seed_stack_records(deep, "python", n=4)
     out = analyze_findings(dd)
@@ -1532,14 +1536,18 @@ def test_shipped_count_falls_back_to_regex_when_merged_items_absent(tmp_path: Pa
 
 
 def test_shipped_count_never_zero_without_artifacts(tmp_path: Path):
-    dd = tmp_path / ".daydream"; deep = dd / "deep"; deep.mkdir(parents=True)
+    dd = tmp_path / ".daydream"
+    deep = dd / "deep"
+    deep.mkdir(parents=True)
     seed_stack_records(deep, "python", n=4)
     out = analyze_findings(dd)
     assert out["total"] == 4                    # pre-merge fallback, never 0
 
 
 def test_per_lens_attribution_reads_alternatives_and_stack_buckets(tmp_path: Path):
-    dd = tmp_path / ".daydream"; deep = dd / "deep"; deep.mkdir(parents=True)
+    dd = tmp_path / ".daydream"
+    deep = dd / "deep"
+    deep.mkdir(parents=True)
     (deep / "alternatives.json").write_text(json.dumps([{"id": 1}, {"id": 2}]))
     seed_stack_records(deep, "python", n=3)
     seed_stack_records(deep, "uncovered", n=1)
@@ -1549,7 +1557,9 @@ def test_per_lens_attribution_reads_alternatives_and_stack_buckets(tmp_path: Pat
 
 
 def test_per_lens_wonder_only_run_reports_nonzero_wonder(tmp_path: Path):
-    dd = tmp_path / ".daydream"; deep = dd / "deep"; deep.mkdir(parents=True)
+    dd = tmp_path / ".daydream"
+    deep = dd / "deep"
+    deep.mkdir(parents=True)
     (deep / "alternatives.json").write_text(json.dumps([{"id": i} for i in range(6)]))
     out = analyze_findings(dd)
     assert out["per_lens"]["wonder"] == 6
@@ -1572,7 +1582,8 @@ def test_analyze_session_shipped_metrics_match_a80b9373(tmp_path: Path):
     sid = "a80b9373-56d6-4062-9ab5-4c75e475ab67"
     dd = tmp_path / ".daydream"
     seed_run_trajectory(dd, sid, total_cost_usd=18.2056)
-    deep = dd / "deep"; deep.mkdir(parents=True)
+    deep = dd / "deep"
+    deep.mkdir(parents=True)
     seed_shipped_items(deep, high=4, med=4)     # 8 shipped items, the a80b9373 shape
     (deep / "alternatives.json").write_text(json.dumps([{"id": i} for i in range(6)]))
     res = analyze_session(dd, session_id=sid)

--- a/tests/test_canonical_items.py
+++ b/tests/test_canonical_items.py
@@ -36,3 +36,10 @@ def test_verdict_join_matches_after_collision_resolution():
     joined = _attach_verdicts(items, payload)
     assert joined[0].get("verifier_verdict") is None       # structural NOT mismatched
     assert joined[1]["verifier_verdict"] == "contradicts"  # right item got the verdict
+
+
+def test_schema_accepts_wonder_lens():
+    item = {"id": 1, "description": "d", "file": "a.py", "line": 4,
+            "confidence": "MEDIUM", "rationale": "r", "evidence": "a.py:4",
+            "lens": "wonder", "severity": "medium"}
+    jsonschema.validate({"items": [item]}, MERGED_ITEMS_SCHEMA)  # must pass

--- a/tests/test_deep_merge.py
+++ b/tests/test_deep_merge.py
@@ -144,3 +144,15 @@ def test_merge_prompt_accepts_shard_records_paths(tmp_path: Path) -> None:
     )
     for r in records:
         assert str(r) in prompt
+
+
+def test_merge_prompt_tags_alternatives_items_as_wonder(tmp_path: Path) -> None:
+    prompt = build_merge_prompt(
+        per_stack_records_paths=[tmp_path / "r.json"],
+        intent_path=tmp_path / "i.md",
+        alternatives_path=tmp_path / "a.json",
+        dedup_candidates_path=tmp_path / "d.json",
+        output_path=tmp_path / ".review-output.md",
+    )
+    assert '"wonder"' in prompt      # the lens value the agent must emit for alt items
+    assert "alternatives" in prompt

--- a/tests/test_deep_render.py
+++ b/tests/test_deep_render.py
@@ -11,7 +11,9 @@ def test_render_places_structural_above_issues_and_keeps_all_lenses():
         _item(1, "structural", "big.py", 1, "high", "1k-line file"),
         _item(2, "per-stack", "a.py", 9, "medium", "bug"),
         _item(3, "cross-stack", "b.py", 2, "high", "contract drift"),
+        _item(4, "wonder", "w.py", 5, "medium", "wonder finding"),
     ])
     assert md.index("## Structural Review") < md.index("## Issues") < md.index("## Cross-Stack Issues")
     assert "[cross-stack]" in md                       # cross-stack prefix preserved
     assert "big.py" in md and "a.py" in md and "b.py" in md   # nothing dropped
+    assert "## Wonder Findings" in md and "w.py" in md  # wonder items are shipped (issue #741)


### PR DESCRIPTION
## Summary
Fixes issue #741: findings metrics were excluding every wonder/alternatives item, inflating cost-per-finding ~2x.

- count shipped findings from merged-items.json (`_shipped_counts` now shape-checks the merged-items shape, ValueError on wrong shape)
- report per-lens finding counts including wonder (`_bucketed_lens_counts` guards malformed alternatives.json -> wonder 0)
- tag alternatives-sourced merged items with the wonder lens
- collapse render lens-branch duplication into a table loop while preserving the ## Wonder Findings section
- regression test for shipped-set cost-per-finding

## Test Plan
- Full suite: 3802 passed, 6 skipped, 3 warnings (`uv run pytest -q`)
- ruff clean on changed files
- Two sequential daydream deep-precision reviews passed (round 1 + round 2, each on a fresh VM)

Closes #741