### PR TITLE
fix(archive): record executable provenance and separate archival completion from run outcome

### DIFF
--- a/daydream/archive/__init__.py
+++ b/daydream/archive/__init__.py
@@ -25,6 +25,7 @@ from daydream.archive.git_context import capture_git_context
 from daydream.archive.index import upsert_run
 from daydream.archive.manifest import _flow_fix_test_steps, build_manifest
 from daydream.config import REVIEW_OUTPUT_FILE
+from daydream.trajectory import DaydreamRunFlow
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +33,30 @@ if TYPE_CHECKING:
     from daydream.runner import RunConfig
     from daydream.trajectory import TrajectoryRecorder
     from daydream.workspace import WorkContext
+
+
+def _flow_runs_merge(flow: DaydreamRunFlow, flow_name: str | None) -> bool:
+    """Whether the executed flow runs the deep cross-stack/single-stack merge.
+
+    The deep pipeline's merge step runs in every non-feedback mode -- loop and
+    shallow (NORMAL/DEEP) run the full fix cycle, and review/comment (TTT) run
+    the spine up to ``post-review`` (which still executes the merge). Feedback
+    (PR) runs only the comment-fetch prefix and never enters the spine, and
+    improve-only never invokes the deep orchestrator, so neither runs merge.
+    Custom flows are classified from their registered pipeline (a fork
+    composing the built-in deep merge step is detected as it runs), mirroring
+    ``_flow_fix_test_steps`` in ``archive.manifest``.
+    """
+    if flow is DaydreamRunFlow.PR:
+        return False
+    if flow is DaydreamRunFlow.IMPROVE:
+        return False
+    if flow is DaydreamRunFlow.CUSTOM:
+        from daydream.archive.manifest import _flow_phase_steps, _runtime_flow_name
+
+        steps = _flow_phase_steps(_runtime_flow_name(flow, flow_name))
+        return any("merge" in step for step in steps)
+    return True
 
 
 def get_archive_dir() -> Path:
@@ -165,7 +190,18 @@ def _archive_run_inner(
 
     provenance = capture_executable_provenance()
     runs_fix, runs_test = _flow_fix_test_steps(recorder.run_flow, config.flow_name)
-    phase_states = derive_phase_states(target_dir, phase_events=getattr(recorder, "_phase_events", []))
+    # Gate the per-phase derivation to only the phases THIS flow actually runs:
+    # the deep artifacts it reads are session-agnostic, so a non-deep flow on a
+    # previously deep-reviewed repo must not inherit a prior run's state (#336,
+    # #762). ``runs_merge`` mirrors the ``_flow_fix_test_steps`` classification.
+    runs_merge = _flow_runs_merge(recorder.run_flow, config.flow_name)
+    phase_states = derive_phase_states(
+        target_dir,
+        phase_events=getattr(recorder, "_phase_events", []),
+        runs_merge=runs_merge,
+        runs_fix=runs_fix,
+        runs_test=runs_test,
+    )
     pipeline_status = derive_pipeline_status(
         status, fix_failures, phase_states, runs_fix=runs_fix, runs_test=runs_test,
     )

--- a/daydream/archive/__init__.py
+++ b/daydream/archive/__init__.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Any
 
 from daydream.archive.git_context import capture_git_context
 from daydream.archive.index import upsert_run
-from daydream.archive.manifest import build_manifest
+from daydream.archive.manifest import _flow_fix_test_steps, build_manifest
 from daydream.config import REVIEW_OUTPUT_FILE
 
 logger = logging.getLogger(__name__)
@@ -155,6 +155,21 @@ def _archive_run_inner(
     if fix_failures:
         status = "partial"
 
+    # 3c. Executable provenance + pipeline outcome. Best-effort by contract:
+    #     capture_executable_provenance never raises (per-field "unknown"), and
+    #     derive_phase_states/derive_pipeline_status never raise on bad artifacts
+    #     (absent/malformed -> absent/neutral). A failure here must never abort
+    #     the archive (the surrounding archive_run try/except is a second net).
+    from daydream.archive.pipeline import derive_phase_states, derive_pipeline_status
+    from daydream.archive.provenance import capture_executable_provenance
+
+    provenance = capture_executable_provenance()
+    runs_fix, runs_test = _flow_fix_test_steps(recorder.run_flow, config.flow_name)
+    phase_states = derive_phase_states(target_dir, phase_events=getattr(recorder, "_phase_events", []))
+    pipeline_status = derive_pipeline_status(
+        status, fix_failures, phase_states, runs_fix=runs_fix, runs_test=runs_test,
+    )
+
     # 4. Build and write manifest
     source_path = str(work.source) if work is not None else str(target_dir)
     manifest = build_manifest(
@@ -169,6 +184,9 @@ def _archive_run_inner(
         fix_failures=fix_failures,
         fix_leftover_untracked=fix_leftover_untracked,
         fix_quality_gate=fix_quality_gate,
+        pipeline_status=pipeline_status,
+        phase_states=phase_states,
+        provenance=provenance,
     )
     manifest_path = run_dir / "manifest.json"
     manifest_path.write_text(json.dumps(manifest.to_dict(), indent=2), encoding="utf-8")

--- a/daydream/archive/_schema.py
+++ b/daydream/archive/_schema.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import sqlite3
 import warnings
 
-SCHEMA_VERSION = 5
+SCHEMA_VERSION = 6
 
 _PRECEDENCE_ORDER = "CASE WHEN source = 'human' THEN 1 ELSE 0 END DESC, observed_at DESC"
 """SQL ORDER BY expression that ranks label_observations by human-first precedence then recency.
@@ -35,6 +35,14 @@ CREATE TABLE IF NOT EXISTS runs (
     session_id TEXT PRIMARY KEY,
     archived_at TEXT NOT NULL,
     status TEXT NOT NULL DEFAULT 'complete',
+    archive_status TEXT NOT NULL DEFAULT 'complete',
+    pipeline_status TEXT NOT NULL DEFAULT 'unknown',
+    phase_states TEXT,
+    daydream_version TEXT,
+    daydream_install_source TEXT,
+    daydream_commit TEXT,
+    daydream_dirty INTEGER,
+    daydream_container_digest TEXT,
     run_flow TEXT NOT NULL,
     skill TEXT,
     model TEXT,
@@ -125,7 +133,9 @@ _CREATE_INDEXES = [
 
 _UPSERT_SQL = """
 INSERT OR REPLACE INTO runs (
-    session_id, archived_at, status, run_flow, skill, model, backend,
+    session_id, archived_at, status, archive_status, pipeline_status, phase_states,
+    daydream_version, daydream_install_source, daydream_commit, daydream_dirty,
+    daydream_container_digest, run_flow, skill, model, backend,
     review_backend, fix_backend, test_backend, per_stack_review_backend, per_stack_review_model,
     review_only, deep, remote_url, repo_slug, source_path, branch, base_branch,
     head_sha, base_sha, changed_files, pr_number, pr_repo, total_cost_usd, total_findings,
@@ -134,7 +144,9 @@ INSERT OR REPLACE INTO runs (
     total_prompt_tokens, total_completion_tokens, total_cached_tokens,
     outcome_labels, labeled_at, composite_reward, archive_path, schema_version
 ) VALUES (
-    :session_id, :archived_at, :status, :run_flow, :skill, :model, :backend,
+    :session_id, :archived_at, :status, :archive_status, :pipeline_status, :phase_states,
+    :daydream_version, :daydream_install_source, :daydream_commit, :daydream_dirty,
+    :daydream_container_digest, :run_flow, :skill, :model, :backend,
     :review_backend, :fix_backend, :test_backend, :per_stack_review_backend, :per_stack_review_model,
     :review_only, :deep, :remote_url, :repo_slug, :source_path, :branch, :base_branch,
     :head_sha, :base_sha, :changed_files, :pr_number, :pr_repo, :total_cost_usd, :total_findings,
@@ -188,6 +200,14 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
             ("erosion", "REAL"),
             ("verbosity", "REAL"),
             ("fix_quality_gate", "TEXT"),
+            ("archive_status", "TEXT NOT NULL DEFAULT 'complete'"),
+            ("pipeline_status", "TEXT NOT NULL DEFAULT 'unknown'"),
+            ("phase_states", "TEXT"),
+            ("daydream_version", "TEXT"),
+            ("daydream_install_source", "TEXT"),
+            ("daydream_commit", "TEXT"),
+            ("daydream_dirty", "INTEGER"),
+            ("daydream_container_digest", "TEXT"),
         ],
     )
 

--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -193,6 +193,7 @@ def upsert_run(archive_dir: Path, manifest: Manifest) -> None:
     for SQLite storage.
     """
     conn = _get_connection(archive_dir)
+    daydream = manifest.daydream
     try:
         conn.execute(
             _UPSERT_SQL,
@@ -205,20 +206,20 @@ def upsert_run(archive_dir: Path, manifest: Manifest) -> None:
                 "phase_states": json.dumps(manifest.phase_states)
                 if manifest.phase_states is not None
                 else None,
-                "daydream_version": manifest.daydream.version
-                if manifest.daydream is not None
+                "daydream_version": daydream.version
+                if daydream is not None
                 else None,
-                "daydream_install_source": manifest.daydream.install_source
-                if manifest.daydream is not None
+                "daydream_install_source": daydream.install_source
+                if daydream is not None
                 else None,
-                "daydream_commit": manifest.daydream.commit
-                if manifest.daydream is not None
+                "daydream_commit": daydream.commit
+                if daydream is not None
                 else None,
-                "daydream_dirty": int(manifest.daydream.dirty)
-                if manifest.daydream is not None and isinstance(manifest.daydream.dirty, bool)
+                "daydream_dirty": int(daydream.dirty)
+                if daydream is not None and isinstance(daydream.dirty, bool)
                 else None,
-                "daydream_container_digest": manifest.daydream.container_digest
-                if manifest.daydream is not None
+                "daydream_container_digest": daydream.container_digest
+                if daydream is not None
                 else None,
                 "run_flow": manifest.run_flow,
                 "skill": manifest.skill,

--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -186,10 +186,37 @@ def _get_connection(archive_dir: Path) -> sqlite3.Connection:
     return conn
 
 
+def _project_daydream(daydream) -> dict:
+    """Project the ``manifest.daydream`` provenance onto per-column values.
+
+    Collapses the guarded-ternary projection ladder into one place so the five
+    ``daydream_*`` projections stay in sync with the ``_UPSERT_SQL`` column
+    list. ``None`` (no executable provenance captured) projects every field to
+    ``None``; ``daydream_dirty`` is stored as an int only when it is a real
+    bool so a sentinel (non-bool) dirty state persists as ``NULL``.
+    """
+    if daydream is None:
+        return {
+            "daydream_version": None,
+            "daydream_install_source": None,
+            "daydream_commit": None,
+            "daydream_dirty": None,
+            "daydream_container_digest": None,
+        }
+    dirty = daydream.dirty
+    return {
+        "daydream_version": daydream.version,
+        "daydream_install_source": daydream.install_source,
+        "daydream_commit": daydream.commit,
+        "daydream_dirty": int(dirty) if isinstance(dirty, bool) else None,
+        "daydream_container_digest": daydream.container_digest,
+    }
+
+
 def upsert_run(archive_dir: Path, manifest: Manifest) -> None:
     """Insert or replace a run entry from a Manifest.
 
-    Bool fields (review_only, deep) are mapped to integers (0/1)
+    Bool fields (review_only, deep) are normalized to integers (0/1)
     for SQLite storage.
     """
     conn = _get_connection(archive_dir)
@@ -206,21 +233,7 @@ def upsert_run(archive_dir: Path, manifest: Manifest) -> None:
                 "phase_states": json.dumps(manifest.phase_states)
                 if manifest.phase_states is not None
                 else None,
-                "daydream_version": daydream.version
-                if daydream is not None
-                else None,
-                "daydream_install_source": daydream.install_source
-                if daydream is not None
-                else None,
-                "daydream_commit": daydream.commit
-                if daydream is not None
-                else None,
-                "daydream_dirty": int(daydream.dirty)
-                if daydream is not None and isinstance(daydream.dirty, bool)
-                else None,
-                "daydream_container_digest": daydream.container_digest
-                if daydream is not None
-                else None,
+                **_project_daydream(daydream),
                 "run_flow": manifest.run_flow,
                 "skill": manifest.skill,
                 "model": manifest.model,

--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -200,6 +200,26 @@ def upsert_run(archive_dir: Path, manifest: Manifest) -> None:
                 "session_id": manifest.session_id,
                 "archived_at": manifest.archived_at,
                 "status": manifest.status,
+                "archive_status": manifest.archive_status,
+                "pipeline_status": manifest.pipeline_status,
+                "phase_states": json.dumps(manifest.phase_states)
+                if manifest.phase_states is not None
+                else None,
+                "daydream_version": manifest.daydream.version
+                if manifest.daydream is not None
+                else None,
+                "daydream_install_source": manifest.daydream.install_source
+                if manifest.daydream is not None
+                else None,
+                "daydream_commit": manifest.daydream.commit
+                if manifest.daydream is not None
+                else None,
+                "daydream_dirty": int(manifest.daydream.dirty)
+                if manifest.daydream is not None and isinstance(manifest.daydream.dirty, bool)
+                else None,
+                "daydream_container_digest": manifest.daydream.container_digest
+                if manifest.daydream is not None
+                else None,
                 "run_flow": manifest.run_flow,
                 "skill": manifest.skill,
                 "model": manifest.model,

--- a/daydream/archive/manifest.py
+++ b/daydream/archive/manifest.py
@@ -4,6 +4,11 @@ Assembles a ``manifest.json`` from the recorder, run config, git context,
 and optional evaluation results. The manifest is the single source of
 truth for what's in an archive bundle.
 
+Provenance namespaces: ``git.*`` and ``code_context.*`` record provenance
+of the repository under review (target ``base_sha``/``head_sha``); the
+``daydream.*`` block records the immutable Daydream executable that
+produced the run. The two must never be conflated.
+
 Exports:
     MANIFEST_SCHEMA_VERSION: Current schema version string.
     Manifest: Dataclass representing the manifest.
@@ -126,7 +131,9 @@ class Manifest:
             key.
         session_id: UUID4 session identifier from the trajectory recorder.
         archived_at: ISO 8601 timestamp of when the archive was created.
-        status: Run status — ``complete``, ``partial``, or ``failed``.
+        status: Run status — ``complete`` alias of ``archive_status``, kept
+            byte-identical for backward compatibility (archive finalization),
+            never conflated with ``pipeline_status``.
         run_flow: Run flow type (normal, ttt, pr, deep).
         skill: Review skill used (python, react, etc.).
         model: Model name (opus, sonnet, haiku).
@@ -231,6 +238,25 @@ class Manifest:
     session_id: str = ""
     archived_at: str = ""
     status: str = "complete"
+    # archive_status is byte-identical to the legacy ``status`` alias (spec Key
+    # Decision 1): archive finalization, distinct from pipeline_status. Kept as a
+    # separate key so consumers distinguishing "cleanly archived" from "pipeline
+    # succeeded" do not repurpose the legacy field.
+    archive_status: str = "complete"
+    # pipeline_status is the pipeline-outcome signal: succeeded / failed /
+    # partial / cancelled / unknown. Distinct from archive_status: a run that
+    # merged-failed and never tested is cleanly archived but its pipeline
+    # failed.
+    pipeline_status: str = "unknown"
+    # Per-phase terminal states (``merge``/``fix``/``test``), each
+    # ``{"ran": bool, "status": str}`` where status is one of
+    # succeeded/failed/partial/absent/unknown. ``None``/omitted for legacy
+    # manifests.
+    phase_states: dict[str, Any] | None = None
+    # Executable provenance: the immutable Daydream executable that produced
+    # this run (vendor ``ExecutableProvenance``). Never merged into the
+    # target-repo ``git.*`` / ``code_context.*`` blocks.
+    daydream: Any | None = None
 
     # Run config
     run_flow: str = ""
@@ -296,6 +322,12 @@ class Manifest:
             "session_id": self.session_id,
             "archived_at": self.archived_at,
             "status": self.status,
+            "archive_status": self.archive_status,
+            "pipeline_status": self.pipeline_status,
+            **_omit_falsy(
+                daydream=self.daydream.to_dict() if self.daydream is not None else None,
+                phase_states=self.phase_states,
+            ),
             "run": {
                 "flow": self.run_flow,
                 "skill": self.skill,

--- a/daydream/archive/manifest.py
+++ b/daydream/archive/manifest.py
@@ -9,6 +9,12 @@ of the repository under review (target ``base_sha``/``head_sha``); the
 ``daydream.*`` block records the immutable Daydream executable that
 produced the run. The two must never be conflated.
 
+Status split: ``status`` is a backward-compat alias of ``archive_status``
+(archive finalization — was the run cleanly archived?); ``pipeline_status``
+is the pipeline-outcome signal (succeeded/failed/partial/cancelled) — a run
+that merged-failed and never tested is cleanly archived but its pipeline
+failed.
+
 Exports:
     MANIFEST_SCHEMA_VERSION: Current schema version string.
     Manifest: Dataclass representing the manifest.

--- a/daydream/archive/manifest.py
+++ b/daydream/archive/manifest.py
@@ -401,6 +401,9 @@ def build_manifest(
     fix_failures: dict[str, str] | None = None,
     fix_leftover_untracked: list[str] | None = None,
     fix_quality_gate: dict[str, Any] | None = None,
+    pipeline_status: str = "unknown",
+    phase_states: dict[str, Any] | None = None,
+    provenance: Any | None = None,
 ) -> Manifest:
     """Construct a Manifest from run context.
 
@@ -421,6 +424,13 @@ def build_manifest(
         fix_quality_gate: The fix-phase anti-degradation quality-gate verdict
             (issue #315), or ``None`` when the artifact is absent. Recorded
             verbatim on the manifest.
+        pipeline_status: Pipeline-outcome aggregate (succeeded/failed/partial/
+            cancelled/unknown) derived from per-phase terminal states; distinct
+            from ``status``/``archive_status`` (archive finalization).
+        phase_states: Per-phase terminal states (``merge``/``fix``/``test``),
+            each ``{"ran": bool, "status": str}``, or ``None`` for legacy runs.
+        provenance: The ``ExecutableProvenance`` of the Daydream executable that
+            produced this run, or ``None`` (never merged into ``git.*``).
 
     Returns:
         A fully populated Manifest.
@@ -506,6 +516,10 @@ def build_manifest(
         test_backend=_resolved_backend_name(config, "test") if runs_test else None,
         per_stack_review_backend=per_stack_review_backend,
         per_stack_review_model=per_stack_review_model,
+        archive_status=status,
+        pipeline_status=pipeline_status,
+        phase_states=phase_states,
+        daydream=provenance,
         review_only=config.output_mode == "review",
         deep=not config.shallow,
         fix_failures=fix_failures or None,

--- a/daydream/archive/pipeline.py
+++ b/daydream/archive/pipeline.py
@@ -15,10 +15,10 @@ Exports:
         per-phase states.
 """
 
-import json
 from pathlib import Path
 from typing import Any
 
+from daydream.archive import _read_json_artifact
 from daydream.trajectory import DaydreamPhase
 
 # Phase status values shared by phase_states entries and pipeline_status.
@@ -27,23 +27,6 @@ _FAILED = "failed"
 _PARTIAL = "partial"
 _ABSENT = "absent"
 _UNKNOWN = "unknown"
-
-
-def _read_json_artifact(path: Path, expected_type: type) -> Any | None:
-    """Read a JSON artifact, returning ``None`` when absent, empty, or malformed.
-
-    Mirrors ``daydream/archive/__init__.py:_read_json_artifact``: any read
-    failure degrades to ``None`` ("we cannot know"), never a raise.
-    """
-    if not path.is_file():
-        return None
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError, ValueError):
-        return None
-    if not isinstance(data, expected_type) or not data:
-        return None
-    return data
 
 
 def _deep_dir(target_dir: Path) -> Path:
@@ -128,7 +111,10 @@ def derive_pipeline_status(
     2. ``failed`` when merge or test reports failed.
     3. ``partial`` when ``fix_failures`` are present.
     4. ``partial`` when a phase the flow runs never ran (run stopped early).
-    5. ``succeeded`` when every phase is succeeded or absent.
+    5. ``succeeded`` when every phase is succeeded or absent AND at least one
+       phase actually ran (a flow that runs neither fix nor test surfaces no
+       derivable phase signal, so an early-aborted/failed run must not be
+       archived as unqualified success).
     6. else ``unknown``.
     """
     if archive_status == "partial" and not fix_failures:
@@ -147,4 +133,13 @@ def derive_pipeline_status(
         status = (phase_states.get(name) or {}).get("status")
         if status is not None and status not in (_SUCCEEDED, _ABSENT):
             return _UNKNOWN
-    return _SUCCEEDED
+    # Only claim success when at least one derivable phase actually ran. A flow
+    # that runs neither fix nor test (TTT review, improve-only) surfaces no
+    # phase evidence, so every phase reading ``absent`` means we cannot tell a
+    # clean profile from an early aborted/failed run — report ``unknown``.
+    if any(
+        (phase_states.get(name) or {}).get("status") == _SUCCEEDED
+        for name in ("merge", "fix", "test")
+    ):
+        return _SUCCEEDED
+    return _UNKNOWN

--- a/daydream/archive/pipeline.py
+++ b/daydream/archive/pipeline.py
@@ -80,19 +80,51 @@ def _test_state(target_dir: Path) -> dict[str, Any]:
     return {"ran": True, "status": _SUCCEEDED}
 
 
-def derive_phase_states(target_dir: Path, *, phase_events: list) -> dict[str, dict]:
+def _absent() -> dict[str, Any]:
+    """Return the neutral per-phase state for a phase this run did not execute."""
+    return {"ran": False, "status": _ABSENT}
+
+
+def derive_phase_states(
+    target_dir: Path,
+    *,
+    phase_events: list,
+    runs_merge: bool = True,
+    runs_fix: bool = True,
+    runs_test: bool = True,
+) -> dict[str, dict]:
     """Return per-phase terminal states for ``merge``, ``fix``, and ``test``.
 
     Each entry is ``{"ran": bool, "status": str}`` with status one of
     ``succeeded``/``failed``/``partial``/``absent``/``unknown``. Pure
     derivation over on-disk deep artifacts + recorder phase events; never
     raises on absent/malformed artifacts (they read as ``absent``).
+
+    The deep artifacts (``per-stack-failures.json`` / ``merged-items.json`` /
+    ``test-verdict.json`` / ``fix-failures.json``) are session-agnostic -- they
+    live in ``target_dir/.daydream/deep`` with no run-bound ``session_id``. A
+    non-deep flow run against a previously deep-reviewed repo would otherwise
+    inherit a PRIOR run's artifacts as its own pipeline state. ``runs_merge`` /
+    ``runs_fix`` / ``runs_test`` gate each phase read to only the phases the
+    current flow actually executes; a phase the flow never runs reads
+    ``absent`` (neutral) regardless of what stale artifacts sit on disk.
     """
     return {
-        "merge": _merge_state(target_dir),
-        "fix": _fix_state(target_dir, phase_events),
-        "test": _test_state(target_dir),
+        "merge": _merge_state(target_dir) if runs_merge else _absent(),
+        "fix": _fix_state(target_dir, phase_events) if runs_fix else _absent(),
+        "test": _test_state(target_dir) if runs_test else _absent(),
     }
+
+
+def _phase(phase_states: dict, name: str) -> dict:
+    """Return a phase's state dict, defaulting to ``{}`` when absent/malformed.
+
+    Unifies the two key styles used across ``derive_pipeline_status`` (reading
+    ``"status"`` vs ``"ran"``) into one spelling, so an absent phase entry
+    reads as an empty dict: ``.get("status")`` -> ``None`` and ``.get("ran")``
+    -> ``None`` both degrade to the all-absent case instead of raising.
+    """
+    return phase_states.get(name) or {}
 
 
 def derive_pipeline_status(
@@ -119,18 +151,18 @@ def derive_pipeline_status(
     """
     if archive_status == "partial" and not fix_failures:
         return "cancelled"
-    merge_status = (phase_states.get("merge") or {}).get("status")
-    test_status = (phase_states.get("test") or {}).get("status")
+    merge_status = _phase(phase_states, "merge").get("status")
+    test_status = _phase(phase_states, "test").get("status")
     if merge_status == _FAILED or test_status == _FAILED:
         return _FAILED
     if fix_failures:
         return _PARTIAL
-    if (runs_test and (phase_states.get("test") or {}).get("ran") is False) or (
-        runs_fix and (phase_states.get("fix") or {}).get("ran") is False
+    if (runs_test and _phase(phase_states, "test").get("ran") is False) or (
+        runs_fix and _phase(phase_states, "fix").get("ran") is False
     ):
         return _PARTIAL
     for name in ("merge", "fix", "test"):
-        status = (phase_states.get(name) or {}).get("status")
+        status = _phase(phase_states, name).get("status")
         if status is not None and status not in (_SUCCEEDED, _ABSENT):
             return _UNKNOWN
     # Only claim success when at least one derivable phase actually ran. A flow
@@ -138,7 +170,7 @@ def derive_pipeline_status(
     # phase evidence, so every phase reading ``absent`` means we cannot tell a
     # clean profile from an early aborted/failed run — report ``unknown``.
     if any(
-        (phase_states.get(name) or {}).get("status") == _SUCCEEDED
+        _phase(phase_states, name).get("status") == _SUCCEEDED
         for name in ("merge", "fix", "test")
     ):
         return _SUCCEEDED

--- a/daydream/archive/pipeline.py
+++ b/daydream/archive/pipeline.py
@@ -133,7 +133,9 @@ def derive_pipeline_status(
     """
     if archive_status == "partial" and not fix_failures:
         return "cancelled"
-    if (phase_states.get("merge") or {}).get("status") == _FAILED or (phase_states.get("test") or {}).get("status") == _FAILED:
+    merge_status = (phase_states.get("merge") or {}).get("status")
+    test_status = (phase_states.get("test") or {}).get("status")
+    if merge_status == _FAILED or test_status == _FAILED:
         return _FAILED
     if fix_failures:
         return _PARTIAL

--- a/daydream/archive/pipeline.py
+++ b/daydream/archive/pipeline.py
@@ -1,0 +1,148 @@
+"""Per-phase pipeline state derivation for archived runs.
+
+Derives per-phase terminal states (merge/fix/test) and the ``pipeline_status``
+aggregate from existing deep artifacts + phase events — no new runtime
+instrumentation. Separates pipeline outcome from archive finalization so a run
+that merged-failed and never tested is never archived as unqualified success.
+
+Artifact reads are best-effort: absent/empty/malformed artifacts mean "we
+cannot know the phase ran", reported honestly as ``absent``/neutral — these
+functions never raise on bad input.
+
+Exports:
+    derive_phase_states: Per-phase terminal states from artifacts + events.
+    derive_pipeline_status: Aggregate pipeline outcome from archive state +
+        per-phase states.
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+from daydream.trajectory import DaydreamPhase
+
+# Phase status values shared by phase_states entries and pipeline_status.
+_SUCCEEDED = "succeeded"
+_FAILED = "failed"
+_PARTIAL = "partial"
+_ABSENT = "absent"
+_UNKNOWN = "unknown"
+
+
+def _read_json_artifact(path: Path, expected_type: type) -> Any | None:
+    """Read a JSON artifact, returning ``None`` when absent, empty, or malformed.
+
+    Mirrors ``daydream/archive/__init__.py:_read_json_artifact``: any read
+    failure degrades to ``None`` ("we cannot know"), never a raise.
+    """
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, ValueError):
+        return None
+    if not isinstance(data, expected_type) or not data:
+        return None
+    return data
+
+
+def _deep_dir(target_dir: Path) -> Path:
+    return target_dir / ".daydream" / "deep"
+
+
+def _merge_state(target_dir: Path) -> dict[str, Any]:
+    """Derive the merge phase terminal state from deep artifacts.
+
+    Discriminator (issue #762 spike): ``per-stack-failures.json`` is written
+    with ``{"__merge__": ...}`` ONLY on the merge-failure consolidation path,
+    while ``merged-items.json`` is written on BOTH the failure path and the
+    success paths — so the merge key wins over merged-items presence.
+    """
+    failures = _read_json_artifact(_deep_dir(target_dir) / "per-stack-failures.json", dict)
+    if failures is not None and "__merge__" in failures:
+        return {"ran": True, "status": _FAILED}
+    if (_deep_dir(target_dir) / "merged-items.json").is_file():
+        return {"ran": True, "status": _SUCCEEDED}
+    return {"ran": False, "status": _ABSENT}
+
+
+def _fix_state(target_dir: Path, phase_events: list) -> dict[str, Any]:
+    """Derive the fix terminal state from ``fix-failures.json`` + phase events.
+
+    A present non-empty ``fix-failures.json`` means fix groups were
+    dropped/reverted (partial); otherwise a ``phase_start`` for
+    ``DaydreamPhase.FIX`` marks the fix phase as having run successfully.
+    """
+    fix_failures = _read_json_artifact(_deep_dir(target_dir) / "fix-failures.json", dict)
+    if fix_failures:
+        return {"ran": True, "status": _PARTIAL}
+    for ev in phase_events or []:
+        phase = getattr(ev, "phase", None)
+        if phase is DaydreamPhase.FIX and getattr(ev, "event", None) == "phase_start":
+            return {"ran": True, "status": _SUCCEEDED}
+    return {"ran": False, "status": _ABSENT}
+
+
+def _test_state(target_dir: Path) -> dict[str, Any]:
+    """Derive the test terminal state from ``test-verdict.json``.
+
+    The verdict is written for BOTH outcomes before the failure early-return, so
+    presence ⇔ the test phase ran; ``passed: false`` ⇔ failed.
+    """
+    verdict = _read_json_artifact(_deep_dir(target_dir) / "test-verdict.json", dict)
+    if verdict is None:
+        return {"ran": False, "status": _ABSENT}
+    if verdict.get("passed") is False:
+        return {"ran": True, "status": _FAILED}
+    return {"ran": True, "status": _SUCCEEDED}
+
+
+def derive_phase_states(target_dir: Path, *, phase_events: list) -> dict[str, dict]:
+    """Return per-phase terminal states for ``merge``, ``fix``, and ``test``.
+
+    Each entry is ``{"ran": bool, "status": str}`` with status one of
+    ``succeeded``/``failed``/``partial``/``absent``/``unknown``. Pure
+    derivation over on-disk deep artifacts + recorder phase events; never
+    raises on absent/malformed artifacts (they read as ``absent``).
+    """
+    return {
+        "merge": _merge_state(target_dir),
+        "fix": _fix_state(target_dir, phase_events),
+        "test": _test_state(target_dir),
+    }
+
+
+def derive_pipeline_status(
+    archive_status: str,
+    fix_failures: dict | None,
+    phase_states: dict,
+    *,
+    runs_fix: bool = False,
+    runs_test: bool = False,
+) -> str:
+    """Aggregate pipeline outcome from the archive state + per-phase states.
+
+    Precedence:
+    1. ``cancelled`` when the archive is ``partial`` with no fix failures
+       (``write_partial`` signal flush — the run stopped early, nothing failed).
+    2. ``failed`` when merge or test reports failed.
+    3. ``partial`` when ``fix_failures`` are present.
+    4. ``partial`` when a phase the flow runs never ran (run stopped early).
+    5. ``succeeded`` when every phase is succeeded or absent.
+    6. else ``unknown``.
+    """
+    if archive_status == "partial" and not fix_failures:
+        return "cancelled"
+    if (phase_states.get("merge") or {}).get("status") == _FAILED or (phase_states.get("test") or {}).get("status") == _FAILED:
+        return _FAILED
+    if fix_failures:
+        return _PARTIAL
+    if (runs_test and (phase_states.get("test") or {}).get("ran") is False) or (
+        runs_fix and (phase_states.get("fix") or {}).get("ran") is False
+    ):
+        return _PARTIAL
+    for name in ("merge", "fix", "test"):
+        status = (phase_states.get(name) or {}).get("status")
+        if status is not None and status not in (_SUCCEEDED, _ABSENT):
+            return _UNKNOWN
+    return _SUCCEEDED

--- a/daydream/archive/provenance.py
+++ b/daydream/archive/provenance.py
@@ -1,0 +1,120 @@
+"""Executable provenance capture for archived runs.
+
+Records the immutable Daydream executable that produced a run: version,
+install source, resolved commit, dirty state, and opt-in container digest.
+This lives in its own ``daydream.*`` namespace and is never conflated with
+the target-repository ``git.*`` / ``code_context.*`` blocks.
+
+Each fallible field is a best-effort capture with an explicit ``"unknown"``
+sentinel — a failure to resolve a field reports ``"unknown"`` rather than a
+raise or a fabricated value (mirroring ``git_context.capture_git_context``'s
+independent-fields pattern, degrading to ``"unknown"`` instead of ``None``).
+
+Exports:
+    ExecutableProvenance: Dataclass holding captured executable provenance.
+    capture_executable_provenance: Capture provenance from the installed
+        package dir + opt-in env.
+"""
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+import daydream
+from daydream import git_ops
+from daydream.git_ops import GitError
+
+
+@dataclass
+class ExecutableProvenance:
+    """The immutable Daydream executable that produced an archived run.
+
+    Attributes:
+        version: Package version (``daydream.__version__``).
+        install_source: ``editable`` (uv/editable install), ``git``
+            (VCS-derived direct_url), ``package`` (no direct_url), or
+            ``unknown`` when the distribution cannot be resolved.
+        commit: Full SHA of the package dir's git HEAD, or ``"unknown"``.
+        dirty: ``True``/``False`` when the package-dir git state resolves,
+            else ``"unknown"``.
+        container_digest: The opt-in ``DAYDREAM_IMAGE_DIGEST`` value, or
+            ``"unknown"``. Never auto-detected.
+    """
+
+    version: str
+    install_source: str
+    commit: str = "unknown"
+    dirty: bool | str = "unknown"
+    container_digest: str = "unknown"
+
+    def to_dict(self) -> dict[str, str | bool]:
+        """Return exactly the five provenance fields (unknowns as strings)."""
+        return {
+            "version": self.version,
+            "install_source": self.install_source,
+            "commit": self.commit,
+            "dirty": self.dirty,
+            "container_digest": self.container_digest,
+        }
+
+
+def _resolve_install_source() -> str:
+    """Resolve the package install source from ``importlib.metadata``.
+
+    Returns ``"unknown"`` on any lookup failure — never raises.
+    """
+    try:
+        from importlib.metadata import distribution
+
+        dist = distribution("daydream")
+        if dist is None:
+            return "unknown"
+        direct_url_file = (dist.locate_file("direct_url.json")
+                           if hasattr(dist, "locate_file") else dist._path)  # noqa: SLF001
+        if not direct_url_file or not getattr(direct_url_file, "exists", lambda: False)():
+            # No direct_url.json -> conventional package install (site-packages, no
+            # install-time VCS/editable marker).
+            return "package"
+        try:
+            info = json.loads(Path(direct_url_file).read_text(encoding="utf-8"))
+        except Exception:  # noqa: BLE001 - unreadable/malformed direct_url, never raise
+            return "unknown"
+        dir_info = info.get("dir_info")
+        if isinstance(dir_info, dict) and dir_info.get("editable"):
+            return "editable"
+        if info.get("vcs_info"):
+            return "git"
+        # direct_url present but no dir_info/vcs_info -> install-time info
+        # unavailable, reported honestly as unknown, never a fabricated value.
+        return "unknown"
+    except Exception:  # noqa: BLE001 - unknown install source, never raise
+        return "unknown"
+
+
+def capture_executable_provenance() -> ExecutableProvenance:
+    """Capture the Daydream executable provenance.
+
+    Best-effort per field; never raises. The package dir is the directory
+    holding ``daydream/__file__``. Commit/dirty resolve from that dir's git
+    state (walking up to the enclosing checkout) or degrade to ``"unknown"``.
+    Container digest is opt-in via ``DAYDREAM_IMAGE_DIGEST``.
+    """
+    pkg_dir = Path(daydream.__file__).parent
+
+    try:
+        commit = git_ops.head_sha(pkg_dir)
+    except GitError:
+        commit = "unknown"
+
+    try:
+        dirty = bool(git_ops.status_porcelain(pkg_dir))
+    except GitError:
+        dirty = "unknown"
+
+    return ExecutableProvenance(
+        version=daydream.__version__,
+        install_source=_resolve_install_source(),
+        commit=commit,
+        dirty=dirty,
+        container_digest=os.environ.get("DAYDREAM_IMAGE_DIGEST") or "unknown",
+    )

--- a/daydream/archive/provenance.py
+++ b/daydream/archive/provenance.py
@@ -16,6 +16,7 @@ Exports:
         package dir + opt-in env.
 """
 
+import json
 import os
 from dataclasses import dataclass
 from pathlib import Path
@@ -69,14 +70,16 @@ def _resolve_install_source() -> str:
         dist = distribution("daydream")
         if dist is None:
             return "unknown"
-        direct_url_file = (dist.locate_file("direct_url.json")
-                           if hasattr(dist, "locate_file") else dist._path)  # noqa: SLF001
-        if not direct_url_file or not getattr(direct_url_file, "exists", lambda: False)():
-            # No direct_url.json -> conventional package install (site-packages, no
-            # install-time VCS/editable marker).
-            return "package"
+        dist = distribution("daydream")
+        if dist is None:
+            return "unknown"
         try:
-            info = json.loads(Path(direct_url_file).read_text(encoding="utf-8"))
+            direct_url_json = dist.read_text("direct_url.json")
+            if direct_url_json is None:
+                # No direct_url.json -> conventional package install
+                # (site-packages, no install-time VCS/editable marker).
+                return "package"
+            info = json.loads(direct_url_json)
         except Exception:  # noqa: BLE001 - unreadable/malformed direct_url, never raise
             return "unknown"
         dir_info = info.get("dir_info")
@@ -106,6 +109,7 @@ def capture_executable_provenance() -> ExecutableProvenance:
     except GitError:
         commit = "unknown"
 
+    dirty: bool | str
     try:
         dirty = bool(git_ops.status_porcelain(pkg_dir))
     except GitError:

--- a/daydream/archive/provenance.py
+++ b/daydream/archive/provenance.py
@@ -70,9 +70,6 @@ def _resolve_install_source() -> str:
         dist = distribution("daydream")
         if dist is None:
             return "unknown"
-        dist = distribution("daydream")
-        if dist is None:
-            return "unknown"
         try:
             direct_url_json = dist.read_text("direct_url.json")
             if direct_url_json is None:

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -400,6 +400,15 @@ def _build_build_corpus_parser() -> argparse.ArgumentParser:
         default="complete",
         help="Match manifest.status exactly (default: 'complete')",
     )
+    parser.add_argument(
+        "--pipeline-status",
+        type=str,
+        default="succeeded",
+        dest="pipeline_status",
+        help="Match pipeline_status exactly (succeeded/failed/partial/cancelled/"
+             "unknown; default: 'succeeded' — excludes failed/partial runs that "
+             "archived as complete)",
+    )
 
     # Stratification
     parser.add_argument(
@@ -512,6 +521,7 @@ def _handle_build_corpus_command(argv: list[str]) -> int:
         config = BuildCorpusConfig(
             out_path=args.out,
             filters=filters,
+            pipeline_status=args.pipeline_status,
             stratify_by=args.stratify_by,
             max_stack_share=args.max_stack_share,
             dry_run=args.dry_run,

--- a/daydream/training/corpus.py
+++ b/daydream/training/corpus.py
@@ -912,6 +912,32 @@ def run_build_corpus(config: BuildCorpusConfig) -> dict[str, int]:
         filters = replace(config.filters, pipeline_status=config.pipeline_status)
     else:
         filters = config.filters
+
+    # 3b. Surface the pipeline_status gate's exclusions. The CLI default
+    #     (``--pipeline-status succeeded``) is also the column default of
+    #     ``unknown`` for pre-existing legacy runs and non-review flows, so a
+    #     default build would otherwise silently drop them — give the count a
+    #     visible warning instead of an unqualified empty/excluded cohort.
+    effective_pipeline_status = filters.pipeline_status
+    if effective_pipeline_status is not None:
+        excluded_by_pipeline = count_runs(
+            archive_dir,
+            "pipeline_status != ? AND status = ?",
+            (effective_pipeline_status, filters.status),
+        )
+        if excluded_by_pipeline:
+            legacy_unknown = count_runs(
+                archive_dir,
+                "pipeline_status = ? AND status = ?",
+                ("unknown", filters.status),
+            )
+            print_warning(
+                console,
+                f"{excluded_by_pipeline} run(s) excluded by pipeline_status="
+                f"'{effective_pipeline_status}' (including {legacy_unknown} "
+                f"legacy run(s) with pipeline_status='unknown') are dropped from "
+                "the corpus",
+            )
     rows = _query_index(archive_dir, filters)
 
     # 5. Resolve the pinned annotation per row, apply the admission gate, build

--- a/daydream/training/corpus.py
+++ b/daydream/training/corpus.py
@@ -429,6 +429,10 @@ class CorpusFilters:
         min_grounding: Optional minimum ``grounding_rate`` (inclusive).
         status: Exact-match filter on the ``status`` column. Defaults to
             ``"complete"`` so partial / failed runs never enter training.
+        pipeline_status: Optional exact-match filter on the ``pipeline_status``
+            column — the authoritative pipeline-outcome gate
+            (succeeded/failed/partial/cancelled). ``None`` (default) applies no
+            pipeline filter, preserving pre-#762 behavior exactly.
         include_all_labels: When ``True``, suppresses the label admission
             filter so every run (labeled or not) passes.
         allow_copyleft: ``owner/repo`` slugs the caller has explicitly
@@ -448,6 +452,7 @@ class CorpusFilters:
     labels: tuple[str, ...] = ("accepted",)
     min_grounding: float | None = None
     status: str = "complete"
+    pipeline_status: str | None = None
     include_all_labels: bool = False
     allow_copyleft: frozenset[str] = frozenset()
     min_reward: float | None = None
@@ -502,12 +507,13 @@ def _build_query(
     Clauses, in fixed order:
 
     1. ``status = ?`` — always.
-    2. C5 exclusion: ``repo_slug IS NULL OR repo_slug NOT IN (...)`` — always
+    2. ``pipeline_status = ?`` — when ``filters.pipeline_status`` is set.
+    3. C5 exclusion: ``repo_slug IS NULL OR repo_slug NOT IN (...)`` — always
        (when the exclusion list is non-empty; otherwise omitted to keep the
        SQL clean). Placeholder count is derived from the loaded set size.
-    3. ``skill = ?`` — when ``filters.skill`` is set.
-    4. ``repo_slug IN (...)`` — when ``filters.repos`` is non-empty.
-    5. ``grounding_rate >= ?`` — when ``filters.min_grounding`` is set.
+    4. ``skill = ?`` — when ``filters.skill`` is set.
+    5. ``repo_slug IN (...)`` — when ``filters.repos`` is non-empty.
+    6. ``grounding_rate >= ?`` — when ``filters.min_grounding`` is set.
 
     Returns:
         ``(where_clause, params)`` where ``where_clause`` has no leading
@@ -520,6 +526,11 @@ def _build_query(
     # 1. status — always
     clauses.append("status = ?")
     params.append(filters.status)
+
+    # 1b. pipeline_status — optional (authoritative pipeline-outcome gate)
+    if filters.pipeline_status is not None:
+        clauses.append("pipeline_status = ?")
+        params.append(filters.pipeline_status)
 
     # 2. C5 exclusion — always (when list is non-empty)
     if exclusion is None:
@@ -678,6 +689,10 @@ class BuildCorpusConfig:
         out_path: Destination JSONL file. Written atomically via tempfile +
             ``Path.replace``; ``schema.json`` is emitted next to it.
         filters: Resolved post-exclusion filter knobs.
+        pipeline_status: Optional pipeline-outcome gate (succeeded/failed/
+            partial/cancelled) overlaid onto ``filters`` when set — the
+            authoritative ``pipeline_status`` column filter distinguishing
+            pipeline success from mere archive finalization.
         archive_dir: Daydream archive root. ``None`` defers to
             :func:`daydream.archive.get_archive_dir`.
         stratify_by: ``"stack"`` to apply :func:`_stratify`; ``None`` to skip.
@@ -704,6 +719,7 @@ class BuildCorpusConfig:
 
     out_path: Path
     filters: CorpusFilters
+    pipeline_status: str | None = None
     archive_dir: Path | None = None
     stratify_by: str | None = None
     max_stack_share: float = 0.6
@@ -887,8 +903,16 @@ def run_build_corpus(config: BuildCorpusConfig) -> dict[str, int]:
     # 3. Unfiltered count for the summary.
     total_in_index = count_runs(archive_dir)
 
-    # 4. Apply label-independent SQL filters.
-    rows = _query_index(archive_dir, config.filters)
+    # 4. Apply label-independent SQL filters. The config-level ``pipeline_status``
+    #    knob (when set) is overlaid onto the resolved filters so the authoritative
+    #    pipeline-outcome gate joins the status gate.
+    if config.pipeline_status is not None:
+        from dataclasses import replace
+
+        filters = replace(config.filters, pipeline_status=config.pipeline_status)
+    else:
+        filters = config.filters
+    rows = _query_index(archive_dir, filters)
 
     # 5. Resolve the pinned annotation per row, apply the admission gate, build
     #    records. Label/reward come from the silver annotation, never the

--- a/docs/evaluation-framework.md
+++ b/docs/evaluation-framework.md
@@ -325,6 +325,24 @@ reference anchors, not thresholds.
 | CodeFuse-CR-Bench | End-to-end repo-level Python review with multi-dimensional scoring | 601 instances, 70 projects | [11] |
 | SeRe | Security-specific code review evaluation | 6,732 instances, 5 languages | [8] |
 
+## Archived Manifest Schema: Provenance Namespaces & Status Split
+
+The archived ``manifest.json`` keeps two provenance namespaces, which must
+never be conflated:
+
+- ``git.*`` and ``code_context.*`` record provenance of the **target repository**
+  under review (``base_sha``/``head_sha``, changed files).
+- ``daydream.*`` records the **immutable Daydream executable provenance** — the
+  executable that produced the run (``version``, resolved ``install_source``,
+  ``commit`` + ``dirty``, opt-in ``container_digest``).
+
+Likewise the status fields split archive finalization from pipeline outcome:
+``status`` is an alias of ``archive_status`` (was the run cleanly **archived**?)
+``pipeline_status`` is the pipeline-outcome signal (``succeeded``/``failed``/
+``partial``/``cancelled``) — a run that merged-failed and never tested is cleanly
+archived but its **pipeline failed**.
+See ``daydream/archive/manifest.py`` for the authoritative field documentation.
+
 ---
 
 ## References

--- a/docs/evaluation-framework.md
+++ b/docs/evaluation-framework.md
@@ -339,7 +339,7 @@ never be conflated:
 Likewise the status fields split archive finalization from pipeline outcome:
 ``status`` is an alias of ``archive_status`` (was the run cleanly **archived**?)
 ``pipeline_status`` is the pipeline-outcome signal (``succeeded``/``failed``/
-``partial``/``cancelled``) — a run that merged-failed and never tested is cleanly
+``partial``/``cancelled``/``unknown``) — a run that merged-failed and never tested is cleanly
 archived but its **pipeline failed**.
 See ``daydream/archive/manifest.py`` for the authoritative field documentation.
 

--- a/spike-notes.md
+++ b/spike-notes.md
@@ -1,0 +1,48 @@
+# Spike Notes — Per-Phase Terminal Signal Coverage (issue #762)
+
+Re-verified against HEAD (`d31cb99d`). Conclusion: the spec's Key Decision 2 survives
+intact — existing phase-event + deep-artifact signals cover every per-phase terminal
+state. No spec revision needed.
+
+## Confirmed signals
+
+1. **Merge ran/failed** — via `deep/per-stack-failures.json["__merge__"]`:
+   - `MERGE_FAILURE_KEY = "__merge__"` (orchestrator.py:1952).
+   - Written **only** on the merge-failure consolidation path (`_salvage_merge_failure`,
+     orchestrator.py:2160).
+   - `merged-items.json` is written on BOTH the merge-failure path (`_salvage_merge_failure`,
+     ~2197) and success paths (`_step_single_stack_merge`, `phase_cross_stack_merge`).
+   - **Load-bearing:** merge `succeeded` ⇔ `merged-items.json` present AND `"__merge__"`
+     absent from `per-stack-failures.json`. Presence of `merged-items.json` alone is NOT
+     sufficient (it is also written on the failure path).
+   - `DaydreamPhase` has NO `MERGE` member; `phase_scope(DaydreamPhase...)` call sites cover
+     EXPLORATION/INTENT/ALTERNATIVES/DEEP(stage=…)/PARSE/VERIFY/FIX/TEST — no merge. So merge
+     terminal state must come from deep artifacts, not phase events.
+
+2. **Fix via `fix-failures.json`:**
+   - `fix_failures_p` written only when `all_non_success` (dropped/reverted groups) is
+     non-empty; unlinked when clean (orchestrator.py:3248-3262).
+   - Present ⇔ fix phase had dropped/reverted groups (partial); absent ⇔ clean or never ran.
+
+3. **Test via `test-verdict.json`:**
+   - `test_verdict_path(dd).write_text(...)` occurs BEFORE the failure early-return
+     (orchestrator.py:3445), so `{"passed": bool, "retries": int, "ignored": bool}` is written
+     for BOTH outcomes.
+   - Present ⇔ test phase ran (both outcomes); absent ⇔ test never ran (merge-failure-no-test,
+     review-only, improve).
+
+4. **Cancelled via `archive_status == "partial"` && no fix_failures:**
+   - `Trajectory.write_partial()` → `on_write(self, "partial")` (trajectory.py:2042), signal flush = cancelled.
+   - `_write` → `on_write(self, "complete")` (trajectory.py:1986).
+   - `_archive_run_inner` coerces `complete → partial` when `fix_failures` present (archive/__init__.py:152-156).
+   - **Confirmed:** `cancelled` ⇔ `archive_status == "partial"` AND no `fix_failures`; `partial` ⇔ `fix_failures` present.
+
+## Flow awareness
+`_flow_fix_test_steps(recorder.run_flow, config.flow_name)` (manifest.py:75) returns
+`(runs_fix, runs_test)` by runtime mode/registry: `TTT` → (False, False); `PR` → (True, False)
+(fix only); NORMAL/DEEP/IMPROVE/CUSTOM classified by registered pipeline. A phase the flow
+does not run is `absent` and neutral; only a phase the flow DOES run that is absent forces
+`partial` (run stopped early).
+
+These four confirmed signals + the flow-awareness requirement drive `derive_phase_states` /
+`derive_pipeline_status` in Task 3 and the `_archive_run_inner` wiring in Task 4.

--- a/tests/fixtures/training/build_archive.py
+++ b/tests/fixtures/training/build_archive.py
@@ -128,6 +128,7 @@ def _build_manifest(session: FixtureSession, session_dir: Path) -> Manifest:
         session_id=session.session_id,
         archived_at=ARCHIVED_AT,
         status=session.status,
+        pipeline_status="succeeded",
         skill=session.skill,
         repo_slug=session.repo_slug,
         branch="feat/x",

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -2056,6 +2056,41 @@ def test_pipeline_status_precedence():
         {"merge": {"ran": True, "status": "succeeded"},
          "fix": {"ran": True, "status": "succeeded"},
          "test": {"ran": True, "status": "succeeded"}}) == "succeeded"
+    # all-absent (a flow that runs neither fix nor test and surfaced no phase
+    # evidence) -> unknown, never succeeded
+    assert pipeline.derive_pipeline_status("complete", None,
+        {"merge": {"ran": False, "status": "absent"},
+         "fix": {"ran": False, "status": "absent"},
+         "test": {"ran": False, "status": "absent"}},
+        runs_fix=False, runs_test=False) == "unknown"
+    # an unexpected/unknown per-phase status drives the _UNKNOWN branch
+    assert pipeline.derive_pipeline_status("complete", None,
+        {"merge": {"ran": True, "status": "succeeded"},
+         "fix": {"ran": True, "status": "unknown"},
+         "test": {"ran": True, "status": "succeeded"}}) == "unknown"
+
+
+def test_non_deep_flow_ignores_stale_deep_artifacts(tmp_path):
+    # Issue #336: derive_phase_states is flow-aware. A prior deep run left
+    # session-agnostic merge/fix/test artifacts in target_dir/.daydream/deep;
+    # a non-deep flow run afterwards must NOT inherit them as its own pipeline
+    # state -- the phases it does not run read absent regardless of disk.
+    from daydream.archive import pipeline
+    _write_deep(tmp_path, "merged-items.json", {"items": []})
+    _write_deep(tmp_path, "per-stack-failures.json", {"__merge__": {"message": "x"}})
+    _write_deep(tmp_path, "test-verdict.json", {"passed": False})
+    _write_deep(tmp_path, "fix-failures.json", {"src/a.py": "reverted"})
+    # TTT review runs the merge spine but never the fix/test cycle.
+    states = pipeline.derive_phase_states(tmp_path, phase_events=[],
+                                          runs_merge=True, runs_fix=False, runs_test=False)
+    assert states["merge"]["status"] == "failed"   # merge ran (spine wrote fresh artifacts)
+    assert states["fix"] == {"ran": False, "status": "absent"}    # stale fix ignored
+    assert states["test"] == {"ran": False, "status": "absent"}   # stale test ignored
+    # An improve-only flow runs none of the deep phases at all.
+    states = pipeline.derive_phase_states(tmp_path, phase_events=[],
+                                          runs_merge=False, runs_fix=False, runs_test=False)
+    assert all(s == {"ran": False, "status": "absent"} for s in states.values())
+
 
 
 def _deep(tmp_path: Path, name: str, data):

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1946,3 +1946,37 @@ def test_build_manifest_omits_per_stack_review_on_merge_fix_resume(tmp_path: Pat
         assert m.per_stack_review_model is None, f"start_at={start_at}"
         assert "per_stack_review_backend" not in run, f"start_at={start_at}"
         assert "per_stack_review_model" not in run, f"start_at={start_at}"
+
+
+def test_manifest_splits_status_from_pipeline():
+    from daydream.archive.provenance import ExecutableProvenance
+    m = Manifest(
+        session_id="s-1", status="complete", archive_status="complete",
+        pipeline_status="failed", phase_states={
+            "merge": {"ran": True, "status": "failed"},
+            "fix": {"ran": False, "status": "absent"},
+            "test": {"ran": False, "status": "absent"},
+        },
+        daydream=ExecutableProvenance(version="0.27.0", install_source="git",
+                                      commit="abc", dirty=False,
+                                      container_digest="unknown"),
+    )
+    d = m.to_dict()
+    assert d["status"] == "complete"
+    assert d["archive_status"] == "complete"
+    assert d["pipeline_status"] == "failed"
+    assert d["phase_states"]["merge"]["status"] == "failed"
+    # Namespace separation: executable provenance never merged into git.*
+    assert d["daydream"]["version"] == "0.27.0"
+    assert d["git"]["head_sha"] is None  # target-repo sha stays in git.*
+    assert "commit" not in d["git"]
+
+
+def test_legacy_manifest_reads_new_fields_as_unknown():
+    legacy = {k: v for k, v in Manifest().to_dict().items()
+              if k not in ("archive_status", "pipeline_status", "phase_states", "daydream")}
+    # A raw manifest.json dict without the new keys still yields explicit
+    # unknown for consumers, never a KeyError and never a fabricated value.
+    assert legacy.get("pipeline_status", "unknown") == "unknown"
+    assert legacy.get("archive_status", "unknown") == "unknown"
+    assert legacy.get("daydream", "unknown") == "unknown"

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1483,7 +1483,7 @@ def test_existing_db_migrates_to_posterior_columns(tmp_path: Path) -> None:
     """A pre-v4 index.db (runs + label_observations lacking the posterior columns)
     is migrated/recreated on the next connection: runs gains has_posterior via
     ALTER, the stale label_observations is dropped+recreated with both new
-    columns, and PRAGMA user_version reaches SCHEMA_VERSION (4)."""
+    columns, and PRAGMA user_version reaches SCHEMA_VERSION (6)."""
     from daydream.archive.index import _CREATE_TABLE, SCHEMA_VERSION
 
     db_path = tmp_path / "index.db"
@@ -1972,14 +1972,17 @@ def test_manifest_splits_status_from_pipeline():
     assert "commit" not in d["git"]
 
 
-def test_legacy_manifest_reads_new_fields_as_unknown():
-    legacy = {k: v for k, v in Manifest().to_dict().items()
-              if k not in ("archive_status", "pipeline_status", "phase_states", "daydream")}
-    # A raw manifest.json dict without the new keys still yields explicit
-    # unknown for consumers, never a KeyError and never a fabricated value.
-    assert legacy.get("pipeline_status", "unknown") == "unknown"
-    assert legacy.get("archive_status", "unknown") == "unknown"
-    assert legacy.get("daydream", "unknown") == "unknown"
+def test_legacy_manifest_reads_new_fields_as_unknown(tmp_path: Path):
+    # A pre-#762 Manifest carries no archive_status/pipeline_status/phase_states/
+    # daydream keys. Indexing it and reading it back through the production
+    # query_runs path surfaces the new fields as explicit schema-default
+    # sentinels (pipeline_status "unknown"), never a KeyError and never a
+    # fabricated value.
+    upsert_run(tmp_path, Manifest())
+    row = query_runs(tmp_path)[0]
+    assert row["pipeline_status"] == "unknown"
+    assert row["archive_status"] == "complete"
+    assert row["daydream_version"] is None
 
 
 def _write_deep(target: Path, name: str, data):
@@ -2077,7 +2080,7 @@ def test_merge_failed_archives_failed_pipeline(tmp_path: Path, make_config: Make
     assert m["pipeline_status"] == "failed"    # ...but the pipeline failed
     assert m["phase_states"]["merge"]["status"] == "failed"
     assert m["daydream"]["version"]  # executable provenance recorded
-    assert m["daydream"]["commit"] in {"unknown"} or m["daydream"]["commit"]
+    assert m["daydream"]["commit"]  # a real SHA or the "unknown" sentinel, never blank
 
 
 def test_schema_additive_columns_and_migration(tmp_path):

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -2053,3 +2053,28 @@ def test_pipeline_status_precedence():
         {"merge": {"ran": True, "status": "succeeded"},
          "fix": {"ran": True, "status": "succeeded"},
          "test": {"ran": True, "status": "succeeded"}}) == "succeeded"
+
+
+def _deep(tmp_path: Path, name: str, data):
+    d = tmp_path / ".daydream" / "deep"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / name).write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_merge_failed_archives_failed_pipeline(tmp_path: Path, make_config: MakeConfig):
+    from daydream.archive import _archive_run_inner
+    from tests.harness.trajectory import make_recorder
+    _deep(tmp_path, "merged-items.json", {"items": []})
+    _deep(tmp_path, "per-stack-failures.json", {"__merge__": {"message": "x"}})
+    _deep(tmp_path, "test-verdict.json", {"passed": False, "retries": 0, "ignored": False})
+    recorder = make_recorder(tmp_path)  # run_flow NORMAL; fake config with archive=False
+    config = make_config(tmp_path, archive=False)
+    _archive_run_inner(recorder=recorder, target_dir=tmp_path, config=config,
+                       status="complete", run_eval=False, work=None, upload=False)
+    manifest_path = sorted(get_archive_dir().glob("runs/*/manifest.json"))[-1]
+    m = json.loads(manifest_path.read_text())
+    assert m["archive_status"] == "complete"   # cleanly archived...
+    assert m["pipeline_status"] == "failed"    # ...but the pipeline failed
+    assert m["phase_states"]["merge"]["status"] == "failed"
+    assert m["daydream"]["version"]  # executable provenance recorded
+    assert m["daydream"]["commit"] in {"unknown"} or m["daydream"]["commit"]

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1529,7 +1529,7 @@ def test_existing_db_migrates_to_posterior_columns(tmp_path: Path) -> None:
     conn.close()
     assert "has_posterior" in runs_cols
     assert {"reviewer_logins", "has_posterior"} <= lo_cols
-    assert user_version == SCHEMA_VERSION == 5
+    assert user_version == SCHEMA_VERSION == 6
 
     obs = latest_label_observation(tmp_path, "mig-1")
     assert obs is not None
@@ -2078,3 +2078,33 @@ def test_merge_failed_archives_failed_pipeline(tmp_path: Path, make_config: Make
     assert m["phase_states"]["merge"]["status"] == "failed"
     assert m["daydream"]["version"]  # executable provenance recorded
     assert m["daydream"]["commit"] in {"unknown"} or m["daydream"]["commit"]
+
+
+def test_schema_additive_columns_and_migration(tmp_path):
+    from daydream.archive import _schema
+    db = tmp_path / "index.db"
+    conn = sqlite3.connect(db)
+    conn.execute("CREATE TABLE runs (session_id TEXT PRIMARY KEY, status TEXT NOT NULL DEFAULT 'complete')")
+    conn.commit()
+    conn.close()
+    # _migrate_schema adds the new columns idempotently to an existing table
+    _schema._migrate_schema(sqlite3.connect(db))
+    cols = {r[1] for r in sqlite3.connect(db).execute("PRAGMA table_info(runs)").fetchall()}
+    assert "archive_status" in cols and "pipeline_status" in cols and "phase_states" in cols
+    assert "daydream_version" in cols and "daydream_commit" in cols and "daydream_dirty" in cols
+
+
+def test_upsert_run_persists_pipeline_fields(tmp_path):
+    from daydream.archive import index
+    from daydream.archive.manifest import Manifest
+    from daydream.archive.provenance import ExecutableProvenance
+    m = Manifest(session_id="s-2", status="complete", archive_status="complete",
+                 pipeline_status="failed", phase_states={"merge": {"ran": True, "status": "failed"}},
+                 daydream=ExecutableProvenance(version="0.27.0", install_source="git",
+                                               commit="abc", dirty=False, container_digest="unknown"))
+    index.upsert_run(tmp_path, m)
+    row = index.query_runs(tmp_path, "session_id = ?", ("s-2",))[0]
+    assert row["archive_status"] == "complete"
+    assert row["pipeline_status"] == "failed"
+    assert row["daydream_version"] == "0.27.0"
+    assert row["daydream_dirty"] == 0

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1980,3 +1980,76 @@ def test_legacy_manifest_reads_new_fields_as_unknown():
     assert legacy.get("pipeline_status", "unknown") == "unknown"
     assert legacy.get("archive_status", "unknown") == "unknown"
     assert legacy.get("daydream", "unknown") == "unknown"
+
+
+def _write_deep(target: Path, name: str, data):
+    deep = target / ".daydream" / "deep"
+    deep.mkdir(parents=True, exist_ok=True)
+    (deep / name).write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_merge_failed_discriminates_on_merge_key_not_merged_items(tmp_path):
+    from daydream.archive import pipeline
+    _write_deep(tmp_path, "merged-items.json", {"items": []})
+    _write_deep(tmp_path, "per-stack-failures.json", {"__merge__": {"message": "x"}})
+    states = pipeline.derive_phase_states(tmp_path, phase_events=[])
+    assert states["merge"]["ran"] is True
+    assert states["merge"]["status"] == "failed"   # merged-items present is NOT sufficient
+
+
+def test_merge_succeeded_when_items_and_no_merge_key(tmp_path):
+    from daydream.archive import pipeline
+    _write_deep(tmp_path, "merged-items.json", {"items": []})
+    states = pipeline.derive_phase_states(tmp_path, phase_events=[])
+    assert states["merge"]["status"] == "succeeded"
+
+
+def test_test_failed_from_verdict(tmp_path):
+    from daydream.archive import pipeline
+    _write_deep(tmp_path, "test-verdict.json", {"passed": False, "retries": 1, "ignored": False})
+    states = pipeline.derive_phase_states(tmp_path, phase_events=[])
+    assert states["test"]["ran"] is True
+    assert states["test"]["status"] == "failed"
+
+
+def test_test_absent_when_no_verdict(tmp_path):
+    from daydream.archive import pipeline
+    states = pipeline.derive_phase_states(tmp_path, phase_events=[])
+    assert states["test"]["ran"] is False
+    assert states["test"]["status"] == "absent"
+
+
+def test_fix_partial_from_failures(tmp_path):
+    from daydream.archive import pipeline
+    _write_deep(tmp_path, "fix-failures.json", {"src/a.py": "reverted"})
+    states = pipeline.derive_phase_states(tmp_path, phase_events=[])
+    assert states["fix"]["status"] == "partial"
+
+
+def test_pipeline_status_precedence():
+    from daydream.archive import pipeline
+    # cancelled beats everything when archive partial with no fix failures
+    assert pipeline.derive_pipeline_status("partial", None,
+        {"merge": {"ran": True, "status": "succeeded"},
+         "fix": {"ran": True, "status": "succeeded"},
+         "test": {"ran": True, "status": "succeeded"}}) == "cancelled"
+    # merge failed -> failed even though archive_status complete
+    assert pipeline.derive_pipeline_status("complete", None,
+        {"merge": {"ran": True, "status": "failed"},
+         "fix": {"ran": False, "status": "absent"},
+         "test": {"ran": False, "status": "absent"}}, runs_test=True) == "failed"
+    # test failed -> failed
+    assert pipeline.derive_pipeline_status("complete", None,
+        {"merge": {"ran": True, "status": "succeeded"},
+         "fix": {"ran": True, "status": "succeeded"},
+         "test": {"ran": True, "status": "failed"}}) == "failed"
+    # flow runs test but it never ran -> partial
+    assert pipeline.derive_pipeline_status("complete", None,
+        {"merge": {"ran": True, "status": "succeeded"},
+         "fix": {"ran": True, "status": "succeeded"},
+         "test": {"ran": False, "status": "absent"}}, runs_test=True) == "partial"
+    # clean deep run -> succeeded
+    assert pipeline.derive_pipeline_status("complete", None,
+        {"merge": {"ran": True, "status": "succeeded"},
+         "fix": {"ran": True, "status": "succeeded"},
+         "test": {"ran": True, "status": "succeeded"}}) == "succeeded"

--- a/tests/test_corpus_silver_pinning.py
+++ b/tests/test_corpus_silver_pinning.py
@@ -66,6 +66,7 @@ def _seed_divergent_archive(archive_dir: Path) -> None:
         rubric_json=json.dumps(SILVER_RUBRIC_PINNED),
         observed_at="2026-03-01T00:00:00+00:00",
         valid_at="2026-03-01T00:00:00+00:00",
+        pipeline_status="succeeded",
     )
     # Newer silver generation (different label + evidence so the auto-dedup
     # doesn't swallow it); it wins the cache but is observed AFTER the pin.
@@ -80,6 +81,7 @@ def _seed_divergent_archive(archive_dir: Path) -> None:
         rubric_json=json.dumps(SILVER_RUBRIC_POSTERIOR),
         observed_at="2026-03-01T00:00:00+00:00",
         valid_at="2026-09-01T00:00:00+00:00",  # outcome true only after the pin
+        pipeline_status="succeeded",
     )
 
     conn = sqlite3.connect(str(archive_dir / "index.db"))

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,39 @@
+import pytest
+
+from daydream.archive import provenance
+
+
+def test_version_is_package_version():
+    import daydream
+    p = provenance.capture_executable_provenance()
+    assert p.version == daydream.__version__
+
+
+def test_container_digest_from_optin_env(monkeypatch):
+    monkeypatch.setenv("DAYDREAM_IMAGE_DIGEST", "sha256:abc123")
+    assert provenance.capture_executable_provenance().container_digest == "sha256:abc123"
+
+
+def test_container_digest_unknown_when_unset(monkeypatch):
+    monkeypatch.delenv("DAYDREAM_IMAGE_DIGEST", raising=False)
+    assert provenance.capture_executable_provenance().container_digest == "unknown"
+
+
+def test_commit_and_dirty_resolve_or_unknown():
+    p = provenance.capture_executable_provenance()
+    # The package dir is a git checkout in CI/dev; when git state is
+    # unresolvable the field must be the explicit string "unknown", never
+    # None and never a target-repo sha.
+    assert p.commit in {"unknown"} or (p.commit and len(p.commit) == 40)
+    assert p.dirty in (True, False, "unknown")
+
+
+def test_install_source_is_known_or_unknown():
+    p = provenance.capture_executable_provenance()
+    assert p.install_source in {"editable", "git", "package", "unknown"}
+
+
+def test_to_dict_never_omits_unknown():
+    p = provenance.capture_executable_provenance()
+    d = p.to_dict()
+    assert set(d) == {"version", "install_source", "commit", "dirty", "container_digest"}

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -32,6 +32,21 @@ def test_install_source_is_known_or_unknown():
     assert p.install_source in {"editable", "git", "package", "unknown"}
 
 
+def test_commit_and_dirty_unknown_on_git_error(monkeypatch):
+    from daydream.git_ops import GitError
+
+    def _raise(_repo):
+        raise GitError("synthetic git failure")
+
+    monkeypatch.setattr("daydream.git_ops.head_sha", _raise)
+    monkeypatch.setattr("daydream.git_ops.status_porcelain", _raise)
+    p = provenance.capture_executable_provenance()
+    # A deterministic git failure must resolve to the explicit "unknown"
+    # sentinel, never raise and never fabricate a value.
+    assert p.commit == "unknown"
+    assert p.dirty == "unknown"
+
+
 def test_to_dict_never_omits_unknown():
     p = provenance.capture_executable_provenance()
     d = p.to_dict()

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -51,3 +51,22 @@ def test_to_dict_never_omits_unknown():
     p = provenance.capture_executable_provenance()
     d = p.to_dict()
     assert set(d) == {"version", "install_source", "commit", "dirty", "container_digest"}
+
+
+def test_install_source_unknown_on_distribution_error(monkeypatch):
+    """Deterministically exercise the distribution-failure branch of
+    _resolve_install_source: when importlib.metadata.distribution("daydream")
+    is unavailable (e.g. a non-installed/import-time-only environment), the
+    field must resolve to the explicit "unknown" sentinel, never raise.
+
+    Closes the remaining smoke-test gap in finding #5 (daydream covered the
+    git-error branch; this covers the distribution-error branch).
+    """
+    import importlib.metadata
+
+    def _raise(_name):
+        raise importlib.metadata.PackageNotFoundError("synthetic dist lookup failure")
+
+    monkeypatch.setattr(importlib.metadata, "distribution", _raise)
+    p = provenance.capture_executable_provenance()
+    assert p.install_source == "unknown"

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,4 +1,3 @@
-import pytest
 
 from daydream.archive import provenance
 

--- a/tests/test_training_corpus.py
+++ b/tests/test_training_corpus.py
@@ -23,6 +23,7 @@ from daydream.training.corpus import (
     BuildCorpusConfig,
     CorpusFilters,
     _annotation_reward,
+    _build_query,
     _build_record,
     _is_admitted,
     run_build_corpus,
@@ -45,6 +46,7 @@ def _seed_run_with_annotation(
     has_posterior: bool | None = None,
     observed_at: str,
     valid_at: str,
+    pipeline_status: str = "unknown",
 ) -> Path:
     """Index a run and append one bitemporal annotation carrying label + reward.
 
@@ -101,6 +103,7 @@ def _seed_run_with_annotation(
             grounding_rate=1.0,
             changed_files=["app.py"],
             archive_path=str(run_dir),
+            pipeline_status=pipeline_status,
         ),
     )
     append_label_observation(
@@ -518,3 +521,59 @@ def test_build_record_emits_posterior_discriminator_only_for_labeled(tmp_path: P
     # The discriminator does not leak into the intrinsic composite scalar.
     assert rec_labeled["composite_reward"] == 0.6
     assert rec_intrinsic["composite_reward"] == 0.6
+
+
+def test_corpus_can_filter_on_pipeline_status(tmp_path, archive_dir):
+    """The status gate (default 'complete') must be able to exclude failed pipelines.
+
+    ``BuildCorpusConfig`` gains a ``pipeline_status`` knob that flows into the
+    WHERE clause as ``pipeline_status = ?``, mirroring the existing
+    ``status = ?`` construction — the ''authoritative'' pipeline-outcome gate
+    the spec's consumer migration calls for.
+    """
+    cfg = BuildCorpusConfig(out_path=tmp_path / "out.jsonl",
+                            filters=CorpusFilters(status="complete"),
+                            pipeline_status="succeeded", archive_dir=archive_dir)
+    assert cfg.pipeline_status == "succeeded"
+    where, params = _build_query(filters=cfg.filters)
+    # The status gate itself is unchanged...
+    assert "status = ?" in where and "complete" in params
+    # ...and with the config-level knob applied the query gains the pipeline gate.
+    from dataclasses import replace
+    effective = replace(cfg.filters, pipeline_status=cfg.pipeline_status)
+    where2, params2 = _build_query(filters=effective)
+    assert "pipeline_status = ?" in where2 and "succeeded" in params2
+
+
+def test_build_corpus_pipeline_status_gate_excludes_failed_pipelines(tmp_path, archive_dir):
+    """Real-path: a corpus built with pipeline_status='succeeded' drops failed runs.
+
+    Seeds one succeeded and one failed pipeline run in the index; the emitted
+    JSONL must contain only the succeeded run.
+    """
+    _seed_run_with_annotation(archive_dir, "ok-run", label="accepted",
+                              observed_at="2026-03-01T00:00:00+00:00",
+                              valid_at="2026-03-01T00:00:00+00:00",
+                              pipeline_status="succeeded")
+    _seed_run_with_annotation(archive_dir, "bad-run", label="accepted",
+                              observed_at="2026-03-01T00:00:00+00:00",
+                              valid_at="2026-03-01T00:00:00+00:00",
+                              pipeline_status="failed")
+    out = tmp_path / "corpus.jsonl"
+    run_build_corpus(BuildCorpusConfig(
+        out_path=out, archive_dir=archive_dir,
+        filters=CorpusFilters(status="complete"), pipeline_status="succeeded",
+        as_of="2026-04-01T00:00:00+00:00",
+    ))
+    lines = [line for line in out.read_text().splitlines() if line.strip()]
+    assert len(lines) == 1
+    assert json.loads(lines[0])["session_id"] == "ok-run"
+    # Without the knob, both runs are admitted (backward compat preserved).
+    out2 = tmp_path / "corpus-all.jsonl"
+    run_build_corpus(BuildCorpusConfig(
+        out_path=out2, archive_dir=archive_dir,
+        filters=CorpusFilters(status="complete"),
+        as_of="2026-04-01T00:00:00+00:00",
+    ))
+    lines2 = [line for line in out2.read_text().splitlines() if line.strip()]
+    assert len(lines2) == 2

--- a/tests/test_training_corpus.py
+++ b/tests/test_training_corpus.py
@@ -534,7 +534,6 @@ def test_corpus_can_filter_on_pipeline_status(tmp_path, archive_dir):
     cfg = BuildCorpusConfig(out_path=tmp_path / "out.jsonl",
                             filters=CorpusFilters(status="complete"),
                             pipeline_status="succeeded", archive_dir=archive_dir)
-    assert cfg.pipeline_status == "succeeded"
     where, params = _build_query(filters=cfg.filters)
     # The status gate itself is unchanged...
     assert "status = ?" in where and "complete" in params

--- a/tests/test_training_corpus.py
+++ b/tests/test_training_corpus.py
@@ -576,3 +576,41 @@ def test_build_corpus_pipeline_status_gate_excludes_failed_pipelines(tmp_path, a
     ))
     lines2 = [line for line in out2.read_text().splitlines() if line.strip()]
     assert len(lines2) == 2
+
+
+def test_cli_build_corpus_default_excludes_failed_pipelines(tmp_path, archive_dir):
+    """Finding #8: the corpus build CLI gates on pipeline_status='succeeded' by
+    default, so a default build drops merge-failed runs (archived status=complete
+    but pipeline_status=failed) rather than admitting them into training data.
+
+    The config-level knob already exists; this pins that the CLI *wires* it with
+    a safe default instead of leaving it opt-in only.
+    """
+    from daydream.cli import _handle_build_corpus_command
+
+    _seed_run_with_annotation(archive_dir, "ok-run", label="accepted",
+                              observed_at="2026-03-01T00:00:00+00:00",
+                              valid_at="2026-03-01T00:00:00+00:00",
+                              pipeline_status="succeeded")
+    _seed_run_with_annotation(archive_dir, "bad-run", label="accepted",
+                              observed_at="2026-03-01T00:00:00+00:00",
+                              valid_at="2026-03-01T00:00:00+00:00",
+                              pipeline_status="failed")
+    out = tmp_path / "corpus.jsonl"
+    # No --pipeline-status passed: the CLI default ('succeeded') must apply and
+    # drop the merge-failed run.
+    rc = _handle_build_corpus_command(["--out", str(out)])
+    assert rc == 0
+    lines = [line for line in out.read_text().splitlines() if line.strip()]
+    assert len(lines) == 1
+    assert json.loads(lines[0])["session_id"] == "ok-run"
+
+    # An explicit override proves the flag threads through to the SQL gate.
+    out2 = tmp_path / "corpus-failed.jsonl"
+    rc2 = _handle_build_corpus_command(
+        ["--out", str(out2), "--pipeline-status", "failed"]
+    )
+    assert rc2 == 0
+    lines2 = [line for line in out2.read_text().splitlines() if line.strip()]
+    assert len(lines2) == 1
+    assert json.loads(lines2[0])["session_id"] == "bad-run"


### PR DESCRIPTION
## Summary

- Records immutable Daydream executable provenance (package version, install source, resolved git commit, workflow ref/commit, container digest, dirty/editable state) separately from target-repository provenance.
- Splits archival completion from run outcome: introduces `archive_status` (artifact finalization) vs `pipeline_status` (succeeded / failed / partial / cancelled) plus per-phase terminal states, replacing the ambiguous `status: complete`.
- Keeps the existing `base_sha`/`head_sha` fields explicitly scoped to the repository under review.

## Motivation

Archived trajectories did not identify the Daydream executable that produced them, and `manifest.status: complete` conflated archive finalization with a successful review pipeline — so failed or partial runs looked complete to downstream consumers. This prevents reliable attribution of behavior to a Daydream change.

Closes #762

## Changes

- Add `pipeline_status` and provenance columns to the run index (`feat(training)` gates corpus filtering on `pipeline_status=succeeded` by default).
- Record executable provenance and `pipeline_status` in manifests; add a daydream provenance block (package version, install source, resolved commit, container image digest, dirty/editable state).
- Derive per-phase terminal states and `pipeline_status`; split `archive_status` from `pipeline_status`.
- Don't report unqualified success when no phase ran; gate phase-state derivation to flow-executed phases so non-deep flows can't inherit a prior run's session-agnostic deep artifacts.
- Document executable provenance vs target-repo provenance; corpus build warns on silently-dropped legacy `unknown` runs.
- Regression tests for flow-aware derivation, deterministic distribution-error provenance, and spike-notes for per-phase terminal signal coverage.

## Test Plan

- [x] Unit tests pass: 3831 passed, 6 skipped, 0 failures (`GATE_EXIT=0`)
- [x] `ruff` clean
- [x] `mypy` clean (338 files)
- [x] Two sequential daydream deep-precision review rounds on fresh exe.dev VMs (round 1 + round 2 incl. round-1 fixes), all findings addressed

## Notes for Reviewers

- No CodeRabbit. Merge gate is the two daydream review rounds (both green; branch tip `f95ca7d`).
- This is the manifest/provenance contract work; merge recovery (#361) and terminal artifact recapture (#743) are separate issues.
