### PR TITLE
fix(deep): re-capture recommended.patch after the test phase so it ships suite-green (#743)

### DIFF
--- a/daydream/archive/__init__.py
+++ b/daydream/archive/__init__.py
@@ -177,6 +177,7 @@ def _archive_run_inner(
     fix_failures = _read_fix_failures(target_dir)
     fix_leftover_untracked = _read_fix_leftover_untracked(target_dir)
     fix_quality_gate = _read_fix_quality_gate(target_dir, recorder.session_id)
+    recommended_capture = _read_recommended_capture(target_dir, recorder.session_id)
     if fix_failures:
         status = "partial"
 
@@ -220,6 +221,7 @@ def _archive_run_inner(
         fix_failures=fix_failures,
         fix_leftover_untracked=fix_leftover_untracked,
         fix_quality_gate=fix_quality_gate,
+        recommended_capture=(recommended_capture or {}).get("capture_point"),
         pipeline_status=pipeline_status,
         phase_states=phase_states,
         provenance=provenance,
@@ -315,6 +317,31 @@ def _read_fix_quality_gate(target_dir: Path, session_id: str | None) -> dict[str
     if session_id is None:
         return None
     data = _read_json_artifact(fix_quality_gate_path(target_dir / ".daydream" / "deep"), dict)
+    if data is None:
+        return None
+    if data.get("session_id") != session_id:
+        return None
+    return data
+
+
+def _read_recommended_capture(target_dir: Path, session_id: str | None) -> dict[str, Any] | None:
+    """Read ``deep/recommended-capture.json`` from the source tree, if present.
+
+    Written by the deep orchestrator's best-effort post-test re-capture
+    (#743): ``{"session_id": ..., "capture_point": "post_test"}`` recording
+    which tree produced the archived ``recommended.patch``. Returns the parsed
+    dict only when its ``session_id`` matches the current run's -- an artifact
+    left behind by a DIFFERENT session must not be attributed to this run.
+    Returns ``None`` when the file is absent, empty, malformed, unbound, or
+    bound to another session (mirrors :func:`_read_fix_quality_gate`).
+    """
+    from daydream.deep.artifacts import recommended_capture_path
+
+    if session_id is None:
+        return None
+    data = _read_json_artifact(
+        recommended_capture_path(target_dir / ".daydream" / "deep"), dict
+    )
     if data is None:
         return None
     if data.get("session_id") != session_id:

--- a/daydream/archive/__init__.py
+++ b/daydream/archive/__init__.py
@@ -19,7 +19,7 @@ import logging
 import os
 import shutil
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 from daydream.archive.git_context import capture_git_context
 from daydream.archive.index import upsert_run
@@ -300,6 +300,30 @@ def _read_fix_leftover_untracked(target_dir: Path) -> list[str] | None:
     return [str(p) for p in data]
 
 
+def _read_session_bound_json_artifact(
+    target_dir: Path, session_id: str | None, resolver: Callable[[Path], Path]
+) -> dict[str, Any] | None:
+    """Read a session-bound ``deep/*.json`` sidecar if it matches this run.
+
+    Shared reader for the deep-flow sidecar artifacts (fix-quality-gate,
+    recommended-capture): parses the JSON written at ``resolver`` under
+    ``<target_dir>/.daydream/deep`` and returns it only when its
+    ``session_id`` matches the current run's -- an artifact left behind by a
+    DIFFERENT session (e.g. a prior deep run on the same target repo) must not
+    be attributed to this run (#329). Returns ``None`` when the file is
+    absent, empty, malformed, unbound (no ``session_id`` key), or bound to
+    another session.
+    """
+    if session_id is None:
+        return None
+    data = _read_json_artifact(resolver(target_dir / ".daydream" / "deep"), dict)
+    if data is None:
+        return None
+    if data.get("session_id") != session_id:
+        return None
+    return data
+
+
 def _read_fix_quality_gate(target_dir: Path, session_id: str | None) -> dict[str, Any] | None:
     """Read ``deep/fix-quality-gate.json`` from the source tree, if present.
 
@@ -314,14 +338,7 @@ def _read_fix_quality_gate(target_dir: Path, session_id: str | None) -> dict[str
     """
     from daydream.deep.artifacts import fix_quality_gate_path
 
-    if session_id is None:
-        return None
-    data = _read_json_artifact(fix_quality_gate_path(target_dir / ".daydream" / "deep"), dict)
-    if data is None:
-        return None
-    if data.get("session_id") != session_id:
-        return None
-    return data
+    return _read_session_bound_json_artifact(target_dir, session_id, fix_quality_gate_path)
 
 
 def _read_recommended_capture(target_dir: Path, session_id: str | None) -> dict[str, Any] | None:
@@ -337,16 +354,7 @@ def _read_recommended_capture(target_dir: Path, session_id: str | None) -> dict[
     """
     from daydream.deep.artifacts import recommended_capture_path
 
-    if session_id is None:
-        return None
-    data = _read_json_artifact(
-        recommended_capture_path(target_dir / ".daydream" / "deep"), dict
-    )
-    if data is None:
-        return None
-    if data.get("session_id") != session_id:
-        return None
-    return data
+    return _read_session_bound_json_artifact(target_dir, session_id, recommended_capture_path)
 
 
 def _copy_bundle(

--- a/daydream/archive/_schema.py
+++ b/daydream/archive/_schema.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import sqlite3
 import warnings
 
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
 
 _PRECEDENCE_ORDER = "CASE WHEN source = 'human' THEN 1 ELSE 0 END DESC, observed_at DESC"
 """SQL ORDER BY expression that ranks label_observations by human-first precedence then recency.
@@ -73,6 +73,7 @@ CREATE TABLE IF NOT EXISTS runs (
     erosion REAL,
     verbosity REAL,
     fix_quality_gate TEXT,
+    recommended_patch_capture TEXT,
     total_prompt_tokens INTEGER,
     total_completion_tokens INTEGER,
     total_cached_tokens INTEGER,
@@ -140,7 +141,7 @@ INSERT OR REPLACE INTO runs (
     review_only, deep, remote_url, repo_slug, source_path, branch, base_branch,
     head_sha, base_sha, changed_files, pr_number, pr_repo, total_cost_usd, total_findings,
     grounding_rate, coverage_ratio, cost_per_finding_usd, wall_clock_seconds,
-    erosion, verbosity, fix_quality_gate,
+    erosion, verbosity, fix_quality_gate, recommended_patch_capture,
     total_prompt_tokens, total_completion_tokens, total_cached_tokens,
     outcome_labels, labeled_at, composite_reward, archive_path, schema_version
 ) VALUES (
@@ -151,7 +152,7 @@ INSERT OR REPLACE INTO runs (
     :review_only, :deep, :remote_url, :repo_slug, :source_path, :branch, :base_branch,
     :head_sha, :base_sha, :changed_files, :pr_number, :pr_repo, :total_cost_usd, :total_findings,
     :grounding_rate, :coverage_ratio, :cost_per_finding_usd, :wall_clock_seconds,
-    :erosion, :verbosity, :fix_quality_gate,
+    :erosion, :verbosity, :fix_quality_gate, :recommended_patch_capture,
     :total_prompt_tokens, :total_completion_tokens, :total_cached_tokens,
     :outcome_labels, :labeled_at, :composite_reward, :archive_path, :schema_version
 )
@@ -200,6 +201,7 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
             ("erosion", "REAL"),
             ("verbosity", "REAL"),
             ("fix_quality_gate", "TEXT"),
+            ("recommended_patch_capture", "TEXT"),
             ("archive_status", "TEXT NOT NULL DEFAULT 'complete'"),
             ("pipeline_status", "TEXT NOT NULL DEFAULT 'unknown'"),
             ("phase_states", "TEXT"),

--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -266,6 +266,7 @@ def upsert_run(archive_dir: Path, manifest: Manifest) -> None:
                 "fix_quality_gate": json.dumps(manifest.fix_quality_gate)
                 if manifest.fix_quality_gate is not None
                 else None,
+                "recommended_patch_capture": manifest.recommended_patch_capture,
                 "total_prompt_tokens": manifest.total_prompt_tokens,
                 "total_completion_tokens": manifest.total_completion_tokens,
                 "total_cached_tokens": manifest.total_cached_tokens,

--- a/daydream/archive/manifest.py
+++ b/daydream/archive/manifest.py
@@ -241,6 +241,11 @@ class Manifest:
     # diff.patch fallback must not fire. Defaults True for every new manifest;
     # legacy manifests simply omit the key.
     recommended_patch_supported: bool = True
+    # Provenance flag recording which capture produced the archived
+    # recommended.patch (issue #743): ``"post_test"`` = the post-heal
+    # re-capture (the exact tree committed), ``"pre_test"`` = the fix-phase
+    # fallback capture. ``None`` on legacy manifests (which predate the field).
+    recommended_patch_capture: str | None = None
     session_id: str = ""
     archived_at: str = ""
     status: str = "complete"
@@ -325,6 +330,7 @@ class Manifest:
         return {
             "schema_version": self.schema_version,
             "recommended_patch_supported": self.recommended_patch_supported,
+            **_omit_falsy(recommended_patch_capture=self.recommended_patch_capture),
             "session_id": self.session_id,
             "archived_at": self.archived_at,
             "status": self.status,
@@ -407,6 +413,7 @@ def build_manifest(
     fix_failures: dict[str, str] | None = None,
     fix_leftover_untracked: list[str] | None = None,
     fix_quality_gate: dict[str, Any] | None = None,
+    recommended_capture: str | None = None,
     pipeline_status: str = "unknown",
     phase_states: dict[str, Any] | None = None,
     provenance: Any | None = None,
@@ -430,6 +437,10 @@ def build_manifest(
         fix_quality_gate: The fix-phase anti-degradation quality-gate verdict
             (issue #315), or ``None`` when the artifact is absent. Recorded
             verbatim on the manifest.
+        recommended_capture: Which tree produced the archived ``recommended.patch``
+            (``"pre_test"`` = fix-phase fallback, ``"post_test"`` = post-heal
+            re-capture), or ``None`` on legacy runs. Absent sidecar defaults
+            ``recommended_patch_capture`` to ``"pre_test"``.
         pipeline_status: Pipeline-outcome aggregate (succeeded/failed/partial/
             cancelled/unknown) derived from per-phase terminal states; distinct
             from ``status``/``archive_status`` (archive finalization).
@@ -531,6 +542,7 @@ def build_manifest(
         fix_failures=fix_failures or None,
         fix_leftover_untracked=fix_leftover_untracked or None,
         fix_quality_gate=fix_quality_gate or None,
+        recommended_patch_capture=recommended_capture or "pre_test",
         source_path=source_path,
         remote_url=git_ctx.remote_url,
         repo_slug=git_ctx.repo_slug,

--- a/daydream/archive/manifest.py
+++ b/daydream/archive/manifest.py
@@ -547,7 +547,11 @@ def build_manifest(
         recommended_patch_capture=(
             recommended_capture
             if recommended_capture
-            else ("pre_test" if runs_fix else None)
+            else (
+                "pre_test"
+                if runs_fix and recorder.run_flow is not DaydreamRunFlow.PR
+                else None
+            )
         ),
         source_path=source_path,
         remote_url=git_ctx.remote_url,

--- a/daydream/archive/manifest.py
+++ b/daydream/archive/manifest.py
@@ -439,8 +439,10 @@ def build_manifest(
             verbatim on the manifest.
         recommended_capture: Which tree produced the archived ``recommended.patch``
             (``"pre_test"`` = fix-phase fallback, ``"post_test"`` = post-heal
-            re-capture), or ``None`` on legacy runs. Absent sidecar defaults
-            ``recommended_patch_capture`` to ``"pre_test"``.
+            re-capture), or ``None`` on legacy runs. On fix-bearing flows an
+            absent sidecar defaults ``recommended_patch_capture`` to ``"pre_test"``;
+            flows with no fix phase (review-only / improve / feedback) leave it
+            ``None`` since they never produce a fix-phase fallback capture.
         pipeline_status: Pipeline-outcome aggregate (succeeded/failed/partial/
             cancelled/unknown) derived from per-phase terminal states; distinct
             from ``status``/``archive_status`` (archive finalization).
@@ -542,7 +544,11 @@ def build_manifest(
         fix_failures=fix_failures or None,
         fix_leftover_untracked=fix_leftover_untracked or None,
         fix_quality_gate=fix_quality_gate or None,
-        recommended_patch_capture=recommended_capture or "pre_test",
+        recommended_patch_capture=(
+            recommended_capture
+            if recommended_capture
+            else ("pre_test" if runs_fix else None)
+        ),
         source_path=source_path,
         remote_url=git_ctx.remote_url,
         repo_slug=git_ctx.repo_slug,

--- a/daydream/deep/artifacts.py
+++ b/daydream/deep/artifacts.py
@@ -161,6 +161,17 @@ def fix_outcomes_path(deep_dir_path: Path) -> Path:
     return deep_dir_path / "fix-outcomes.json"
 
 
+def recommended_capture_path(deep_dir_path: Path) -> Path:
+    """Capture-point sidecar recording which tree produced recommended.patch.
+
+    Mirrors :func:`fix_quality_gate_path`: written session-bound by the deep
+    orchestrator's post-test re-capture (``"post_test"``) or, when absent,
+    defaulted to ``"pre_test"`` by the archive manifest builder. The archive
+    reads this file to record which capture produced the archived patch.
+    """
+    return deep_dir_path / "recommended-capture.json"
+
+
 def fix_quality_gate_path(deep_dir_path: Path) -> Path:
     """Fix-phase anti-degradation quality gate verdict (issue #315).
 

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -3782,6 +3782,7 @@ async def _step_test(ctx: FlowContext) -> Stop | None:
     # exact tree _step_commit commits. Runs only on the success path (after the
     # test-failure early return) and only in flows with a fix/test cycle.
     # Best-effort: a raise writes nothing and leaves the pre-test patch intact.
+    re_captured = False
     try:
         git_ops.capture_recommended_patch_with_base(
             ctx.work.repo,
@@ -3790,17 +3791,21 @@ async def _step_test(ctx: FlowContext) -> Stop | None:
             ctx.work.repo / ".daydream" / "recommended.patch",
             preexisting_untracked=ctx.data.get("pre_fix_untracked"),
         )
+        re_captured = True
     except Exception:
         pass
     # Session-bound capture-point sidecar, mirrored from fix-quality-gate.json.
-    try:
-        recommended_capture_path(ctx.data["dd"]).write_text(
-            json.dumps(
-                {"session_id": _current_session_id(), "capture_point": "post_test"}, indent=2
+    # Only record "post_test" when the re-capture succeeded; otherwise the patched
+    # tree on disk is still the pre-test capture, not the post-heal tree.
+    if re_captured:
+        try:
+            recommended_capture_path(ctx.data["dd"]).write_text(
+                json.dumps(
+                    {"session_id": _current_session_id(), "capture_point": "post_test"}, indent=2
+                )
             )
-        )
-    except Exception:
-        pass
+        except Exception:
+            pass
     return None
 
 

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -67,6 +67,7 @@ from daydream.deep.artifacts import (
     merged_report_path,
     per_stack_failures_path,
     per_stack_records_path,
+    recommended_capture_path,
     test_verdict_path,
 )
 from daydream.deep.artifacts import (
@@ -3462,6 +3463,13 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
     # (_step_test) so it measures the same base on the same trust gate.
     ctx.data["pre_fix_ref"] = pre_fix_ref
     ctx.data["pre_fix_snapshot_captured"] = pre_fix_snapshot_captured
+    # Thread the raw pre-fix base onto ctx.data so _step_test's post-test
+    # re-capture passes an IDENTICAL base to the archived recommended.patch.
+    # pre_fix_head is None when a snapshot was captured (the snapshot is the
+    # base), and the pre-fix HEAD SHA when the tree was clean — exactly what
+    # the first capture passed at :3367-3368.
+    ctx.data["pre_fix_snapshot"] = pre_fix_snapshot
+    ctx.data["pre_fix_head"] = pre_fix_head
     residual_guard_result = _revert_out_of_scope_edits(
         work,
         pre_fix_ref=pre_fix_ref,
@@ -3739,6 +3747,7 @@ def _render_fix_outcome_summary(
 
 async def _step_test(ctx: FlowContext) -> Stop | None:
     """Post-fix test validation."""
+    from daydream import git_ops
     async with phase_scope(DaydreamPhase.TEST):
         passed, retries, proceed = await phase_test_and_heal(
             ctx.backend_for("test"), ctx.work, feedback_items=ctx.data["items"]
@@ -3767,6 +3776,31 @@ async def _step_test(ctx: FlowContext) -> Stop | None:
             "pre-fix snapshot; HEAD may include edits present before the fix pass."
         ),
     )
+    # Issue #743: best-effort post-test re-capture. The pre-test capture above
+    # (in _step_fix) predates test-and-heal edits; re-capture the post-heal
+    # (post-scrub) tree here so the archived recommended.patch reproduces the
+    # exact tree _step_commit commits. Runs only on the success path (after the
+    # test-failure early return) and only in flows with a fix/test cycle.
+    # Best-effort: a raise writes nothing and leaves the pre-test patch intact.
+    try:
+        git_ops.capture_recommended_patch_with_base(
+            ctx.work.repo,
+            ctx.data.get("pre_fix_snapshot"),
+            ctx.data.get("pre_fix_head"),
+            ctx.work.repo / ".daydream" / "recommended.patch",
+            preexisting_untracked=ctx.data.get("pre_fix_untracked"),
+        )
+    except Exception:
+        pass
+    # Session-bound capture-point sidecar, mirrored from fix-quality-gate.json.
+    try:
+        recommended_capture_path(ctx.data["dd"]).write_text(
+            json.dumps(
+                {"session_id": _current_session_id(), "capture_point": "post_test"}, indent=2
+            )
+        )
+    except Exception:
+        pass
     return None
 
 

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -889,6 +889,34 @@ def test_runs_fix_quality_gate_column_migrates_existing_db(tmp_path: Path):
     assert json.loads(row["fix_quality_gate"]) == gate
 
 
+def test_upsert_run_persists_recommended_patch_capture(tmp_path: Path):
+    upsert_run(tmp_path, make_manifest(session_id="s-cap", recommended_patch_capture="post_test"))
+    row = query_runs(tmp_path, where="session_id = ?", params=("s-cap",))[0]
+    assert row["recommended_patch_capture"] == "post_test"
+
+
+def test_runs_recommended_patch_capture_column_migrates_existing_db(tmp_path: Path):
+    from daydream.archive.index import _CREATE_TABLE
+
+    legacy_ddl = _CREATE_TABLE.replace("    recommended_patch_capture TEXT,\n", "")
+    assert "recommended_patch_capture" not in legacy_ddl
+    conn = sqlite3.connect(str(tmp_path / "index.db"))
+    conn.execute(legacy_ddl)
+    conn.execute(
+        "INSERT INTO runs (session_id, archived_at, run_flow, archive_path) VALUES (?, ?, ?, ?)",
+        ("legacy-cap-run", "2026-01-01T00:00:00Z", "normal", str(tmp_path / "legacy-cap-run")),
+    )
+    conn.commit()
+    conn.close()
+
+    upsert_run(tmp_path, make_manifest(session_id="s-mig-cap", recommended_patch_capture="pre_test"))
+
+    legacy = query_runs(tmp_path, where="session_id = ?", params=("legacy-cap-run",))[0]
+    assert legacy["recommended_patch_capture"] is None  # pre-existing row preserved, column nullable
+    row = query_runs(tmp_path, where="session_id = ?", params=("s-mig-cap",))[0]
+    assert row["recommended_patch_capture"] == "pre_test"
+
+
 def test_read_fix_quality_gate_requires_matching_session(tmp_path: Path):
     """#329: only an artifact bound to the current session is read.
 
@@ -1517,7 +1545,7 @@ def test_existing_db_migrates_to_posterior_columns(tmp_path: Path) -> None:
     """A pre-v4 index.db (runs + label_observations lacking the posterior columns)
     is migrated/recreated on the next connection: runs gains has_posterior via
     ALTER, the stale label_observations is dropped+recreated with both new
-    columns, and PRAGMA user_version reaches SCHEMA_VERSION (6)."""
+    columns, and PRAGMA user_version reaches SCHEMA_VERSION (7)."""
     from daydream.archive.index import _CREATE_TABLE, SCHEMA_VERSION
 
     db_path = tmp_path / "index.db"
@@ -1563,7 +1591,7 @@ def test_existing_db_migrates_to_posterior_columns(tmp_path: Path) -> None:
     conn.close()
     assert "has_posterior" in runs_cols
     assert {"reviewer_logins", "has_posterior"} <= lo_cols
-    assert user_version == SCHEMA_VERSION == 6
+    assert user_version == SCHEMA_VERSION == 7
 
     obs = latest_label_observation(tmp_path, "mig-1")
     assert obs is not None

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -980,6 +980,17 @@ def test_manifest_recommended_patch_capture_passes_through(tmp_path: Path):
     assert m.to_dict()["recommended_patch_capture"] == "post_test"
 
 
+def test_feedback_run_leaves_recommended_patch_capture_none():
+    """PR/feedback runs never produce a pre-test fix-phase capture, so an
+    absent sidecar must leave ``recommended_patch_capture`` ``None`` rather
+    than defaulting to ``"pre_test"`` (feedback's ``_step_fix_items`` never
+    writes ``recommended.patch``)."""
+    recorder = _MockRecorder(run_flow=DaydreamRunFlow.PR)
+    m = _build(tmp_path=Path("/tmp"), recorder=recorder)
+    assert m.recommended_patch_capture is None
+    assert "recommended_patch_capture" not in m.to_dict()
+
+
 def test_get_archive_dir_creates_structure(monkeypatch, tmp_path: Path):
     target = tmp_path / "custom_archive"
     monkeypatch.setenv("DAYDREAM_ARCHIVE_DIR", str(target))

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -918,6 +918,40 @@ def test_read_fix_quality_gate_unbound_artifact_is_none(tmp_path: Path):
     assert _read_fix_quality_gate(tmp_path, "sess-42") is None
 
 
+def test_read_recommended_capture_requires_matching_session(tmp_path: Path):
+    from daydream.archive import _read_recommended_capture
+
+    cap = {"session_id": "sess-42", "capture_point": "post_test"}
+    p = tmp_path / ".daydream" / "deep" / "recommended-capture.json"
+    p.parent.mkdir(parents=True)
+    p.write_text(json.dumps(cap))
+
+    assert _read_recommended_capture(tmp_path, "sess-42") == cap
+    assert _read_recommended_capture(tmp_path, "sess-other") is None
+    assert _read_recommended_capture(tmp_path, None) is None
+
+
+def test_read_recommended_capture_absent_is_none(tmp_path: Path):
+    from daydream.archive import _read_recommended_capture
+
+    assert _read_recommended_capture(tmp_path, "sess-42") is None
+
+
+def test_manifest_recommended_patch_capture_defaults_pre_test(tmp_path: Path):
+    m = _build(tmp_path)  # no recommended_capture arg => sidecar absent
+    assert m.recommended_patch_capture == "pre_test"
+    assert m.to_dict()["recommended_patch_capture"] == "pre_test"
+
+
+def test_manifest_recommended_patch_capture_omitted_when_none():
+    assert "recommended_patch_capture" not in Manifest().to_dict()
+
+
+def test_manifest_recommended_patch_capture_passes_through(tmp_path: Path):
+    m = _build(tmp_path, recommended_capture="post_test")
+    assert m.to_dict()["recommended_patch_capture"] == "post_test"
+
+
 def test_get_archive_dir_creates_structure(monkeypatch, tmp_path: Path):
     target = tmp_path / "custom_archive"
     monkeypatch.setenv("DAYDREAM_ARCHIVE_DIR", str(target))

--- a/tests/test_archive_data_capture.py
+++ b/tests/test_archive_data_capture.py
@@ -114,6 +114,11 @@ def _install_deep_capture_backend(
     return stub
 
 
+async def _ok_with_heal_edit(target: Path):
+    (target / "heal_edit.py").write_text("def healed():\n    pass\n")
+    return await _ok()
+
+
 # --- AC1 + AC3: default deep run populates eval metrics AND captures recommended.patch ---
 
 
@@ -198,6 +203,34 @@ async def test_deep_archive_recommended_patch_excludes_preexisting_untracked_fil
     recommended = (run_dir / "recommended.patch").read_text()
     assert "migrations/0002_add_x.sql" in recommended  # fix-created file present
     assert "notes.txt" not in recommended              # pre-existing file excluded
+
+
+async def test_deep_heal_edit_lands_in_archived_recommended_patch(
+    multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch, archive_dir: Path
+) -> None:
+    remote = bare_remote(archive_dir.parent / "origin.git")
+    git(multi_stack_target, "remote", "add", "archive", str(remote))
+    stub = _install_deep_capture_backend(multi_stack_target, monkeypatch)  # real_internal_phases=False
+    stub.fix_edit_line = "# daydream recommended change\n"
+    monkeypatch.setattr(
+        "daydream.deep.orchestrator.phase_test_and_heal",
+        lambda *a, **k: _ok_with_heal_edit(multi_stack_target),
+    )
+
+    exit_code = await run(
+        RunConfig(target=str(multi_stack_target), assume="yes", output_mode="loop", cleanup=False)
+    )
+    assert exit_code == 0
+
+    run_dir = _only_archived_run(archive_dir)
+    # The heal edit was written after the pre-test capture; only a post-test
+    # re-capture can put it in the archived patch.
+    assert "heal_edit.py" in (run_dir / "recommended.patch").read_text()
+    # Session-bound capture-point sidecar, mirrored from fix-quality-gate.json.
+    sidecar = json.loads(
+        (multi_stack_target / ".daydream" / "deep" / "recommended-capture.json").read_text()
+    )
+    assert sidecar == {"session_id": run_dir.name, "capture_point": "post_test"}
 
 
 async def test_deep_archive_commit_excludes_preexisting_untracked_files(

--- a/tests/test_archive_data_capture.py
+++ b/tests/test_archive_data_capture.py
@@ -231,6 +231,8 @@ async def test_deep_heal_edit_lands_in_archived_recommended_patch(
         (multi_stack_target / ".daydream" / "deep" / "recommended-capture.json").read_text()
     )
     assert sidecar == {"session_id": run_dir.name, "capture_point": "post_test"}
+    manifest = json.loads((run_dir / "manifest.json").read_text())
+    assert manifest["recommended_patch_capture"] == "post_test"
 
 
 async def test_deep_archive_commit_excludes_preexisting_untracked_files(


### PR DESCRIPTION
## Summary

Fixes #743. `recommended.patch` was captured inside `_step_fix` before the test-and-heal step ran, so any edit the heal loop made to turn the suite green was missing from the archived artifact — a user applying `recommended.patch` got a failing suite, and the manifest's `recommended_patch_supported: true` advertised an artifact that did not reproduce the verified-green state.

## Changes

- **Re-capture post-test** (`daydream/deep/orchestrator.py`): the original early capture in `_step_fix` is kept as a guarantee for the `Stop(1)` fix-failure/test-failure paths; a second capture at the end of `_step_test` overwrites it with the final, suite-green diff when the test step runs to completion.
- **Capture-point sidecar** (`daydream/deep/artifacts.py`, `daydream/archive/manifest.py`, `daydream/archive/_schema.py`, `daydream/archive/__init__.py`, `daydream/archive/index.py`): record which capture point produced the shipped patch (pre-test vs post-test), index it in the runs table, and surface it in the manifest so a consumer can tell them apart.
- **Tests** (`tests/test_archive.py`, `tests/test_archive_data_capture.py`): cover the re-capture-on-test-completion behavior and the capture-point sidecar.

## Verification

- Full repo gate green on the branch tip: `make check` → 3862 passed, 6 skipped, exit 0.
- Two sequential deep-precision review rounds completed on the branch (round-2 addressed one merged finding, commit `270dedd`).

Closes #743