### PR TITLE
feat(benchmark): import explicit private GitHub PR evidence

### DIFF
--- a/daydream/benchmark/__init__.py
+++ b/daydream/benchmark/__init__.py
@@ -15,10 +15,14 @@ from daydream.benchmark.orchestrator import run_bench
 from daydream.benchmark.prs import EVALUABLE_PRS, EvaluablePR, load_evaluable_prs
 from daydream.benchmark.schema import (
     BenchmarkManifest,
+    Candidate,
     CaseDocument,
     CaseIndexEntry,
+    EvidenceRecord,
+    ImportDocument,
     PullRequestEntry,
     Snapshot,
+    SnapshotImported,
     classify_validation,
     derive_workspace_state,
     normalize_hostname,
@@ -28,22 +32,28 @@ from daydream.benchmark.workspace import (
     validate_workspace,
     workspace_status,
 )
+from daydream.benchmark.github_import import run_import_prs
 
 __all__ = [
     "EVALUABLE_PRS",
     "BenchConfig",
     "BenchmarkManifest",
+    "Candidate",
     "CaseDocument",
     "CaseIndexEntry",
+    "EvidenceRecord",
     "EvaluablePR",
+    "ImportDocument",
     "PullRequestEntry",
     "Snapshot",
+    "SnapshotImported",
     "classify_validation",
     "derive_workspace_state",
     "init_workspace",
     "load_evaluable_prs",
     "normalize_hostname",
     "run_bench",
+    "run_import_prs",
     "validate_workspace",
     "workspace_status",
 ]

--- a/daydream/benchmark/__init__.py
+++ b/daydream/benchmark/__init__.py
@@ -11,6 +11,7 @@ future issues.
 """
 
 from daydream.benchmark.config import BenchConfig
+from daydream.benchmark.github_import import run_import_prs
 from daydream.benchmark.orchestrator import run_bench
 from daydream.benchmark.prs import EVALUABLE_PRS, EvaluablePR, load_evaluable_prs
 from daydream.benchmark.schema import (
@@ -32,7 +33,6 @@ from daydream.benchmark.workspace import (
     validate_workspace,
     workspace_status,
 )
-from daydream.benchmark.github_import import run_import_prs
 
 __all__ = [
     "EVALUABLE_PRS",

--- a/daydream/benchmark/cli.py
+++ b/daydream/benchmark/cli.py
@@ -451,10 +451,13 @@ def _handle_bench_command(argv: list[str]) -> int:
 
 
 def _build_benchmark_parser() -> argparse.ArgumentParser:
-    """Build the ``daydream benchmark`` subcommand parser."""
+    """Build the ``daydream benchmark`` subcommand parser.
+
+    Sub-verbs: ``init``, ``status``, ``validate``, and ``import-prs``.
+    """
     parser = argparse.ArgumentParser(
         prog="daydream benchmark",
-        description="Private PR benchmark workspace: init/status/validate.",
+        description="Private PR benchmark workspace: init/status/validate/import-prs.",
     )
     sub = parser.add_subparsers(dest="subcommand")
 
@@ -474,7 +477,60 @@ def _build_benchmark_parser() -> argparse.ArgumentParser:
     validate_p = sub.add_parser("validate", help="validate the workspace (0/2/1 exit codes)")
     validate_p.add_argument("dir", type=Path, help="workspace directory")
 
+    import_prs_p = sub.add_parser(
+        "import-prs", help="import explicit private GitHub PR evidence into the workspace"
+    )
+    import_prs_p.add_argument("dir", type=Path, help="workspace directory")
+    import_prs_p.add_argument(
+        "--pr",
+        action="append",
+        default=[],
+        metavar="N|URL",
+        help="PR number or https://github.com/OWNER/REPO/pull/N (repeatable)",
+    )
+    import_prs_p.add_argument(
+        "--pr-file", action="append", default=[], type=Path, metavar="FILE",
+        help="file listing PR numbers/URLs, one per line (repeatable)",
+    )
+    import_prs_p.add_argument(
+        "--head", action="append", default=[], metavar="SHA",
+        help="requested head SHA in addition to the PR default head (repeatable)",
+    )
+    import_prs_p.add_argument(
+        "--refresh", action="store_true",
+        help="re-fetch already-imported PRs",
+    )
+
     return parser
+
+
+def _handle_benchmark_import_prs(args) -> int:
+    """Import explicit private PRs: parse targets, preflight, then run the import.
+
+    Expected errors (mis-tokenized targets, preflight failure) print a message
+    to stderr and return exit ``1`` — never a bare traceback.
+    """
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.workspace import WorkspaceCorrupt
+
+    try:
+        targets = gi.parse_import_targets(args.pr, args.pr_file, args.head)
+    except gi.ImportTargetError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    try:
+        return gi.run_import_prs(
+            args.dir,
+            targets.pr_numbers,
+            heads=targets.requested_heads,
+            refresh=args.refresh,
+        )
+    except gi.PreflightError as exc:
+        print(f"{exc.code}: {exc.message}", file=sys.stderr)
+        return 1
+    except WorkspaceCorrupt as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
 
 
 def _handle_benchmark_init(dir_path: Path, repo: str, reviewer_hosts: list[str], judge_hosts: list[str]) -> int:
@@ -519,11 +575,12 @@ def _handle_benchmark_validate(dir_path: Path) -> int:
 
 
 def _handle_benchmark_command(argv: list[str]) -> int:
-    """Handle ``daydream benchmark init|status|validate``.
+    """Handle ``daydream benchmark init|status|validate|import-prs``.
 
     Returns an exit code; ``daydream.cli.main`` translates it to a
-    process exit. Expected workspace errors (``InitError``/``WorkspaceCorrupt``)
-    are printed to stderr and mapped to exit ``1`` — never a bare traceback.
+    process exit. Expected workspace errors (``InitError``/``WorkspaceCorrupt``/
+    ``ImportTargetError``/``PreflightError``) are printed to stderr and mapped
+    to exit ``1`` — never a bare traceback.
     """
 
     parser = _build_benchmark_parser()
@@ -538,5 +595,7 @@ def _handle_benchmark_command(argv: list[str]) -> int:
         return _handle_benchmark_status(args.dir)
     if sub == "validate":
         return _handle_benchmark_validate(args.dir)
+    if sub == "import-prs":
+        return _handle_benchmark_import_prs(args)
     parser.print_help(file=sys.stderr)
     return 2

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -463,6 +463,37 @@ def _evidence_from_thread(thread: dict[str, Any], comment: dict[str, Any]) -> di
     return fields
 
 
+def _graphql_with_rate_limit_retry(root: Path, variables: dict[str, Any]) -> dict[str, Any]:
+    """Call the paginated reviewThreads GraphQL query honoring the rate-limit retry policy.
+
+    REST paths flow through :func:`_call_with_rate_limit_retry` (3 attempts,
+    honoring Retry-After); the GraphQL query must follow the same policy so a
+    transient rate limit is retried and, when exhausted, surfaces as
+    :class:`_ImportRateLimitError` (recorded as ``rate_limit`` in the ledger,
+    not ``fetch``).
+    """
+    last_rate_limit: git_ops.RateLimitError | None = None
+    for attempt in range(_RATE_LIMIT_ATTEMPTS):
+        try:
+            resp = git_ops.gh_api(
+                root,
+                "graphql",
+                method="POST",
+                idempotent=True,
+                input_data={"query": _REVIEW_THREADS_QUERY, "variables": variables},
+            )
+            return resp
+        except git_ops.RateLimitError as exc:
+            last_rate_limit = exc
+            if attempt < _RATE_LIMIT_ATTEMPTS - 1:
+                wait = exc.retry_after if exc.retry_after is not None else _RATE_LIMIT_MAX_SLEEP_S
+                time.sleep(min(wait, _RATE_LIMIT_MAX_SLEEP_S))
+    assert last_rate_limit is not None
+    raise _ImportRateLimitError(
+        f"gh api graphql reviewThreads rate limited: {last_rate_limit}"
+    ) from last_rate_limit
+
+
 def _graphql_review_threads(root: Path, owner_repo: str, number: int) -> list[dict[str, Any]]:
     """Paginate every review thread (and reply) for a PR via GraphQL.
 
@@ -476,13 +507,7 @@ def _graphql_review_threads(root: Path, owner_repo: str, number: int) -> list[di
         variables: dict[str, Any] = {"owner": owner, "name": name, "number": number}
         if after is not None:
             variables["after"] = after
-        resp = git_ops.gh_api(
-            root,
-            "graphql",
-            method="POST",
-            idempotent=True,
-            input_data={"query": _REVIEW_THREADS_QUERY, "variables": variables},
-        )
+        resp = _graphql_with_rate_limit_retry(root, variables)
         if not isinstance(resp, dict):
             raise git_ops.GitError("graphql reviewThreads returned a non-object response")
         if resp.get("errors"):
@@ -673,10 +698,14 @@ def _case_materialize(
             "exclusions": [],
             "case_exclusion": None,
         }
-        if changed and prior_curations and case_id in prior_curations:
+        if prior_curations and case_id in prior_curations:
             prior = prior_curations[case_id]
             curation = dict(prior)
-            if prior.get("state") in ("ready", "stale"):
+            # Preserve prior curation whenever a curated case exists (unchanged
+            # re-import / refresh must NOT wipe findings or attestation). Only
+            # demote to stale (and clear attestation) when the evidence actually
+            # drifted (changed=True).
+            if changed and prior.get("state") in ("ready", "stale"):
                 curation["state"] = "stale"
                 curation["snapshot_attested"] = False
         case_doc: dict[str, Any] = {
@@ -731,7 +760,13 @@ def _stamp_fetched(
         },
     )
     for case_id in case_ids:
-        raw.setdefault("cases", []).append(
+        # Replace any prior index row for this case_id so a re-import of the same
+        # PR (incl. the fetched->fetched --refresh path) never leaves duplicate
+        # cases[] rows. Mirrors _ledger_replace's replace-by-key semantics.
+        raw["cases"] = [
+            c for c in raw.get("cases", []) if c.get("case_id") != case_id
+        ]
+        raw["cases"].append(
             {"case_id": case_id, "pr_number": number, "case_file": f"cases/{case_id}.yaml"}
         )
     raw["cases"] = _sorted_cases(raw["cases"])

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -603,14 +603,32 @@ def _payload_sha256(records: list[schema.EvidenceRecord]) -> str:
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
+def _evidence_signature_from_doc(doc: schema.ImportDocument) -> frozenset[tuple[str, str]]:
+    return frozenset((e.source_id, e.body_sha256) for e in doc.evidence)
+
+
+def _evidence_signature_from_raw(raw: dict[str, Any]) -> frozenset[tuple[str, str]]:
+    return frozenset(
+        (str(e.get("source_id")), str(e.get("body_sha256"))) for e in raw.get("evidence", [])
+    )
+
+
 def _case_materialize(
     doc: schema.ImportDocument,
     number: int,
     requested_heads: list[str],
     import_file: str,
     import_sha256: str,
+    *,
+    prior_curations: dict[str, dict[str, Any]] | None = None,
+    changed: bool = False,
 ) -> list[tuple[str, str, dict[str, Any]]]:
-    """One materialized case document per requested head."""
+    """One materialized case document per requested head.
+
+    When *changed* is True and a prior curated case exists, its curation is
+    carried over and flipped to ``stale`` with attestation cleared — findings
+    and exclusions are never overwritten by a refresh.
+    """
     pull_request = doc.pull_request
     base_sha = (pull_request.get("base") or {}).get("sha")
     out: list[tuple[str, str, dict[str, Any]]] = []
@@ -622,6 +640,21 @@ def _case_materialize(
         seen.add(head_sha)
         case_id = schema.case_id_for(number, head_sha)
         candidates = project_candidates(doc, head_sha)
+        curation: dict[str, Any] = {
+            "state": "draft",
+            "snapshot_attested": False,
+            "clean_attested": False,
+            "gold_status": None,
+            "findings": [],
+            "exclusions": [],
+            "case_exclusion": None,
+        }
+        if changed and prior_curations and case_id in prior_curations:
+            prior = prior_curations[case_id]
+            curation = dict(prior)
+            if prior.get("state") in ("ready", "stale"):
+                curation["state"] = "stale"
+                curation["snapshot_attested"] = False
         case_doc: dict[str, Any] = {
             "schema_version": 1,
             "case_id": case_id,
@@ -635,15 +668,7 @@ def _case_materialize(
                 "error": None,
             },
             "source": {"import_file": import_file, "import_sha256": import_sha256},
-            "curation": {
-                "state": "draft",
-                "snapshot_attested": False,
-                "clean_attested": False,
-                "gold_status": None,
-                "findings": [],
-                "exclusions": [],
-                "case_exclusion": None,
-            },
+            "curation": curation,
             "candidates": [c.model_dump(mode="json") for c in candidates],
         }
         out.append((case_id, f"cases/{case_id}.yaml", case_doc))
@@ -711,6 +736,14 @@ def _pending_pr_state(raw: dict[str, Any], number: int) -> str:
     return "pending"
 
 
+def _manifest_entry(raw: dict[str, Any], number: int) -> dict[str, Any] | None:
+    """The ledger entry for *number*, or None when not yet imported."""
+    for entry in raw.get("pull_requests", []):
+        if entry.get("number") == number:
+            return entry
+    return None
+
+
 def _sorted_cases(cases: list[dict[str, Any]]) -> list[dict[str, Any]]:
     def _key(c: dict[str, Any]) -> tuple[int, str, str]:
         return (int(c["pr_number"]), schema.head_sha_from_case_id(c["case_id"]), c["case_id"])
@@ -736,7 +769,6 @@ def run_import_prs(
     import/case file — only a ledger flip to ``fetch_failed`` with an exact
     error. The overall exit is non-zero when any PR failed.
     """
-    del refresh
     root = Path(root)
     requested_heads: list[str] = []
     seen_heads: set[str] = set()
@@ -751,13 +783,31 @@ def run_import_prs(
         raw = storage.load_yaml_strict(root / "benchmark.yaml")
         repo = raw.get("source", {}).get("repository") or ""
         for number in pr_numbers:
+            existing = _manifest_entry(raw, number)
+            prior_sig: frozenset[tuple[str, str]] | None = None
+            prior_curations: dict[str, dict[str, Any]] = {}
+            import_file = f"imports/pr-{number:06d}.json"
+            if existing is not None and existing.get("import_state") == "fetched":
+                try:
+                    prior_raw = storage.load_json_strict(root / existing["import_file"])
+                    prior_sig = _evidence_signature_from_raw(prior_raw)
+                except Exception:
+                    prior_sig = None
+                for case_id in existing.get("case_ids", []):
+                    try:
+                        cur = storage.load_yaml_strict(root / "cases" / f"{case_id}.yaml").get("curation")
+                        if isinstance(cur, dict):
+                            prior_curations[case_id] = cur
+                    except Exception:
+                        pass
             try:
                 doc = fetch_and_normalize(root, repo, number, heads or ["final"])
-                import_file = f"imports/pr-{number:06d}.json"
+                changed = refresh and prior_sig is not None and prior_sig != _evidence_signature_from_doc(doc)
                 import_bytes = json.dumps(doc.model_dump(mode="json"), indent=2).encode("utf-8")
                 import_sha256 = hashlib.sha256(import_bytes).hexdigest()
                 cases = _case_materialize(
-                    doc, number, requested_heads, import_file, import_sha256
+                    doc, number, requested_heads, import_file, import_sha256,
+                    prior_curations=prior_curations, changed=changed,
                 )
                 with storage.Transaction(root, op_id=f"import-{number}", kind="import") as tx:
                     tx.stage(import_file, import_bytes)

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -603,6 +603,191 @@ def _payload_sha256(records: list[schema.EvidenceRecord]) -> str:
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
+def _case_materialize(
+    doc: schema.ImportDocument,
+    number: int,
+    requested_heads: list[str],
+    import_file: str,
+    import_sha256: str,
+) -> list[tuple[str, str, dict[str, Any]]]:
+    """One materialized case document per requested head."""
+    pull_request = doc.pull_request
+    base_sha = (pull_request.get("base") or {}).get("sha")
+    out: list[tuple[str, str, dict[str, Any]]] = []
+    seen: set[str] = set()
+    for head_token in requested_heads:
+        head_sha = head_token if head_token != "final" else (pull_request.get("head") or {}).get("sha")
+        if not head_sha or head_sha in seen:
+            continue
+        seen.add(head_sha)
+        case_id = schema.case_id_for(number, head_sha)
+        candidates = project_candidates(doc, head_sha)
+        case_doc: dict[str, Any] = {
+            "schema_version": 1,
+            "case_id": case_id,
+            "pull_request": pull_request,
+            "snapshot": {
+                "status": "imported",
+                "policy": "final_pr_head",
+                "requested_head": head_token,
+                "original_base_sha": base_sha,
+                "original_head_sha": head_sha,
+                "error": None,
+            },
+            "source": {"import_file": import_file, "import_sha256": import_sha256},
+            "curation": {
+                "state": "draft",
+                "snapshot_attested": False,
+                "clean_attested": False,
+                "gold_status": None,
+                "findings": [],
+                "exclusions": [],
+                "case_exclusion": None,
+            },
+            "candidates": [c.model_dump(mode="json") for c in candidates],
+        }
+        out.append((case_id, f"cases/{case_id}.yaml", case_doc))
+    return out
+
+
+def _ledger_replace(raw: dict[str, Any], entry: dict[str, Any]) -> None:
+    """Replace (or append) one ``pull_requests[]`` entry, keeping stable order."""
+    raw["pull_requests"] = [
+        e for e in raw.get("pull_requests", []) if e.get("number") != entry["number"]
+    ]
+    raw["pull_requests"].append(entry)
+
+
+def _stamp_fetched(
+    raw: dict[str, Any],
+    number: int,
+    import_file: str,
+    import_sha256: str,
+    requested_heads: list[str],
+    case_ids: list[str],
+) -> None:
+    schema.validate_pr_transition(
+        _pending_pr_state(raw, number), "fetched"
+    )
+    _ledger_replace(
+        raw,
+        {
+            "number": number,
+            "import_state": "fetched",
+            "import_file": import_file,
+            "import_sha256": import_sha256,
+            "error": None,
+            "requested_heads": requested_heads,
+            "case_ids": case_ids,
+        },
+    )
+    for case_id in case_ids:
+        raw.setdefault("cases", []).append(
+            {"case_id": case_id, "pr_number": number, "case_file": f"cases/{case_id}.yaml"}
+        )
+    raw["cases"] = _sorted_cases(raw["cases"])
+
+
+def _stages_failed(raw: dict[str, Any], number: int, code: str, message: str) -> None:
+    schema.validate_pr_transition(_pending_pr_state(raw, number), "fetch_failed")
+    _ledger_replace(
+        raw,
+        {
+            "number": number,
+            "import_state": "fetch_failed",
+            "import_file": None,
+            "import_sha256": None,
+            "error": {"code": code, "message": message},
+            "requested_heads": [],
+            "case_ids": [],
+        },
+    )
+
+
+def _pending_pr_state(raw: dict[str, Any], number: int) -> str:
+    for entry in raw.get("pull_requests", []):
+        if entry.get("number") == number:
+            return entry.get("import_state", "pending")
+    return "pending"
+
+
+def _sorted_cases(cases: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    def _key(c: dict[str, Any]) -> tuple[int, str, str]:
+        return (int(c["pr_number"]), schema.head_sha_from_case_id(c["case_id"]), c["case_id"])
+
+    return sorted(cases, key=_key)
+
+
+def _manifest_bytes(raw: dict[str, Any]) -> bytes:
+    return yaml.safe_dump(raw, sort_keys=False).encode("utf-8")
+
+
+def run_import_prs(
+    root: Path,
+    pr_numbers: list[int],
+    heads: list[str] | None = None,
+    refresh: bool = False,
+) -> int:
+    """Import each PR's evidence into one atomic import ledger/case transaction.
+
+    Runs startup recovery then preflight (identity idempotent), then for each PR
+    writes its import file, one case per requested head, and the ledger through
+    one :class:`Transaction` (``benchmark.yaml`` last). A failed fetch stages no
+    import/case file — only a ledger flip to ``fetch_failed`` with an exact
+    error. The overall exit is non-zero when any PR failed.
+    """
+    del refresh
+    root = Path(root)
+    requested_heads: list[str] = []
+    seen_heads: set[str] = set()
+    for head in ["final", *(heads or [])]:
+        if head not in seen_heads:
+            seen_heads.add(head)
+            requested_heads.append(head)
+    exit_code = 0
+    with storage.WorkspaceLock(root):
+        storage.recover_startup(root)
+        preflight(root, len(pr_numbers))
+        raw = storage.load_yaml_strict(root / "benchmark.yaml")
+        repo = raw.get("source", {}).get("repository") or ""
+        for number in pr_numbers:
+            try:
+                doc = fetch_and_normalize(root, repo, number, heads or ["final"])
+                import_file = f"imports/pr-{number:06d}.json"
+                import_bytes = json.dumps(doc.model_dump(mode="json"), indent=2).encode("utf-8")
+                import_sha256 = hashlib.sha256(import_bytes).hexdigest()
+                cases = _case_materialize(
+                    doc, number, requested_heads, import_file, import_sha256
+                )
+                with storage.Transaction(root, op_id=f"import-{number}", kind="import") as tx:
+                    tx.stage(import_file, import_bytes)
+                    for _, case_path, case_doc in cases:
+                        tx.stage(case_path, yaml.safe_dump(case_doc, sort_keys=False).encode("utf-8"))
+                    _stamp_fetched(
+                        raw,
+                        number,
+                        import_file,
+                        import_sha256,
+                        requested_heads,
+                        [c[0] for c in cases],
+                    )
+                    tx.stage("benchmark.yaml", _manifest_bytes(raw))
+                    tx.commit()
+            except _ImportRateLimitError as exc:
+                _stages_failed(raw, number, "rate_limit", str(exc))
+                with storage.Transaction(root, op_id=f"import-{number}", kind="import") as tx:
+                    tx.stage("benchmark.yaml", _manifest_bytes(raw))
+                    tx.commit()
+                exit_code = 1
+            except (git_ops.GitError, schema.TransitionError, storage.WorkspaceError, PreflightError) as exc:
+                _stages_failed(raw, number, "fetch", str(exc))
+                with storage.Transaction(root, op_id=f"import-{number}", kind="import") as tx:
+                    tx.stage("benchmark.yaml", _manifest_bytes(raw))
+                    tx.commit()
+                exit_code = 1
+    return exit_code
+
+
 def _repository_block(root: Path, owner_repo: str) -> dict[str, Any]:
     """The resolved repository identity for the import.
 

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -1,0 +1,43 @@
+"""Import normalized evidence from explicit private GitHub PRs.
+
+Task 0 spike: prove the importer's ``gh``/``git`` calls route through
+:mod:`daydream.git_ops` (so the in-process ``fake_gh`` router intercepts
+them) before any collection logic is written. The functions here are the
+thin preflight call sites; later tasks build the full
+:func:`fetch_and_normalize` / :func:`preflight` / :func:`run_import_prs`
+surface on top of them.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from daydream import git_ops
+
+
+def _run_gh_preflight_status(root: Path):
+    """Run ``gh auth status --hostname github.com`` (exit code is the contract)."""
+    return git_ops._run_gh(root, ["auth", "status", "--hostname", "github.com"])
+
+
+def _run_gh_api_user(root: Path) -> dict:
+    """Return the authenticated GitHub user record from ``gh api user``."""
+    proc = git_ops._run_gh(root, ["api", "user"])
+    if proc.returncode != 0:
+        raise git_ops.GitError(f"gh api user failed: {proc.stderr.strip()}")
+    return json.loads(proc.stdout)
+
+
+def _gh_auth_git_credential(root: Path) -> str:
+    """Run the command-scoped git credential helper and return its protocol text."""
+    proc = git_ops._run_gh(root, ["auth", "git-credential"])
+    if proc.returncode != 0:
+        raise git_ops.GitError(f"gh auth git-credential failed: {proc.stderr.strip()}")
+    return proc.stdout
+
+
+def _git_ls_remote(root: Path, url: str) -> str:
+    """Run an authenticated ``git ls-remote <url>`` and return the refs text."""
+    proc = git_ops._run_git(root, ["ls-remote", url])
+    return proc.stdout

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -10,10 +10,14 @@ surface on top of them.
 
 from __future__ import annotations
 
+import hashlib
 import json
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 from daydream import git_ops
+from daydream.benchmark import schema, storage
 
 
 def _run_gh_preflight_status(root: Path):
@@ -41,3 +45,204 @@ def _git_ls_remote(root: Path, url: str) -> str:
     """Run an authenticated ``git ls-remote <url>`` and return the refs text."""
     proc = git_ops._run_git(root, ["ls-remote", url])
     return proc.stdout
+
+
+def _now_rfc3339() -> str:
+    """Current UTC time as an RFC3339 string."""
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _parse_ndjson(text: str) -> list[Any]:
+    """Parse ``gh `` --jq '.[] | @json'`` NDJSON output into a list of values.
+
+    A missing required/failed line or a non-JSON line surfaces as :class:`GitError`
+    rather than being silently defaulted.
+    """
+    values: list[Any] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            values.append(json.loads(line))
+        except json.JSONDecodeError as exc:
+            raise git_ops.GitError(f"gh returned non-JSON line {lineno}: {exc}") from exc
+    return values
+
+
+def _rest(root: Path, endpoint: str) -> list[Any]:
+    """Fetch one REST resource, paginating fully, returning the parsed NDJSON rows.
+
+    ``--paginate`` walks Link headers so every page is retained (the fake serves
+    the complete canned list in one NDJSON stream).
+    """
+    proc = git_ops._run_gh(root, ["api", "--paginate", endpoint, "--jq", ".[] | @json"])
+    if proc.returncode != 0:
+        raise git_ops.GitError(f"gh api {endpoint} failed: {proc.stderr.strip()}")
+    return _parse_ndjson(proc.stdout)
+
+
+def _as_author(raw: dict) -> dict:
+    author = raw.get("user") or {}
+    return {"login": author.get("login", ""), "type": author.get("type", "User")}
+
+
+def _evidence_from_review(raw: dict[str, Any]) -> dict[str, Any]:
+    db_id = int(raw["id"])
+    submitted = raw.get("submitted_at")
+    body = raw.get("body") or ""
+    return {
+        "source_id": f"github:review:{db_id}",
+        "kind": "review",
+        "database_id": db_id,
+        "node_id": raw.get("node_id") or f"PRR_{db_id}",
+        "author": _as_author(raw),
+        "body": body,
+        "body_sha256": hashlib.sha256(body.encode("utf-8")).hexdigest(),
+        "created_at": raw.get("created_at") or submitted,
+        "updated_at": raw.get("updated_at") or submitted,
+        "submitted_at": submitted,
+        "commit_id": raw.get("commit_id"),
+        "original_commit_id": raw.get("original_commit_id"),
+        "state": raw.get("state"),
+        "is_bot": (raw.get("user") or {}).get("type") == "Bot",
+        "url": raw.get("html_url") or "",
+    }
+
+
+def _evidence_from_inline(raw: dict[str, Any]) -> dict[str, Any]:
+    db_id = int(raw["id"])
+    body = raw.get("body") or ""
+    subject_type = raw.get("subject_type")
+    if subject_type is None:
+        subject_type = "file" if raw.get("path") is None else "line"
+    return {
+        "source_id": f"github:inline_comment:{db_id}",
+        "kind": "inline_comment",
+        "database_id": db_id,
+        "node_id": raw.get("node_id") or f"DIFF_{db_id}",
+        "author": _as_author(raw),
+        "body": body,
+        "body_sha256": hashlib.sha256(body.encode("utf-8")).hexdigest(),
+        "created_at": raw.get("created_at"),
+        "updated_at": raw.get("updated_at"),
+        "commit_id": raw.get("commit_id"),
+        "original_commit_id": raw.get("original_commit_id"),
+        "path": raw.get("path"),
+        "original_path": raw.get("original_path"),
+        "line": raw.get("line"),
+        "start_line": raw.get("start_line"),
+        "original_line": raw.get("original_line"),
+        "thread_id": None,
+        "reply_to_id": str(raw["in_reply_to_id"]) if raw.get("in_reply_to_id") is not None else None,
+        "subject_type": subject_type,
+        "side": raw.get("side"),
+        "start_side": raw.get("start_side"),
+        "is_bot": bool((raw.get("user") or {}).get("type") == "Bot"),
+        "url": raw.get("html_url") or "",
+    }
+
+
+def _evidence_from_issue(raw: dict[str, Any]) -> dict[str, Any]:
+    db_id = int(raw["id"])
+    body = raw.get("body") or ""
+    return {
+        "source_id": f"github:issue_comment:{db_id}",
+        "kind": "issue_comment",
+        "database_id": db_id,
+        "node_id": raw.get("node_id") or f"IC_{db_id}",
+        "author": _as_author(raw),
+        "body": body,
+        "body_sha256": hashlib.sha256(body.encode("utf-8")).hexdigest(),
+        "created_at": raw.get("created_at"),
+        "updated_at": raw.get("updated_at"),
+        "is_bot": bool((raw.get("user") or {}).get("type") == "Bot"),
+        "url": raw.get("html_url") or "",
+    }
+
+
+def _payload_sha256(records: list[schema.EvidenceRecord]) -> str:
+    """sha256 over the canonical JSON of the evidence list."""
+    canonical = json.dumps(
+        [r.model_dump(mode="json") for r in records],
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _repository_block(root: Path, owner_repo: str) -> dict[str, Any]:
+    """The resolved repository identity for the import.
+
+    Prefers the workspace manifest's resolved ``source`` (set by preflight) so
+    the immutable repository id/visibility flow into the import; falls back to
+    a default private identity when no manifest exists (unit tests drive
+    ``fetch_and_normalize`` directly).
+    """
+    try:
+        raw = storage.load_yaml_strict(root / "benchmark.yaml")
+        source = raw.get("source") or {}
+        visibility = source.get("visibility", "unresolved")
+        return {
+            "id": source.get("repository_id") or 0,
+            "name_with_owner": source.get("repository") or owner_repo,
+            "visibility": "public" if visibility == "public" else "private",
+        }
+    except Exception:
+        return {"id": 0, "name_with_owner": owner_repo, "visibility": "private"}
+
+
+def fetch_and_normalize(
+    root: Path,
+    owner_repo: str,
+    number: int,
+    heads: list[str],
+) -> schema.ImportDocument:
+    """Fetch one PR's full evidence set through REST and normalize it.
+
+    Pulls the PR header, then every submitted review, top-level inline comment,
+    and conversation comment in order. Every retrieved record is retained as an
+    :class:`EvidenceRecord` with a stable source ID and body hash; ``is_bot`` is
+    derived from the author type and never filters. Failure of any call raises
+    :class:`GitError` — never a silent default.
+    """
+    del heads  # requested heads are consumed by the orchestrator, not the fetch
+    header_rows = _rest(root, f"repos/{owner_repo}/pulls/{number}")
+    if not header_rows:
+        raise git_ops.GitError(f"gh gives no PR header for {owner_repo}#{number}")
+    header = header_rows[0]
+
+    evidence: list[dict[str, Any]] = []
+    for raw in _rest(root, f"repos/{owner_repo}/pulls/{number}/reviews"):
+        evidence.append(_evidence_from_review(raw))
+    for raw in _rest(root, f"repos/{owner_repo}/pulls/{number}/comments"):
+        evidence.append(_evidence_from_inline(raw))
+    for raw in _rest(root, f"repos/{owner_repo}/issues/{number}/comments"):
+        evidence.append(_evidence_from_issue(raw))
+
+    records = [schema.EvidenceRecord.model_validate(e) for e in evidence]
+    base = header.get("base") or {}
+    head = header.get("head") or {}
+    pull_request = {
+        "number": header["number"],
+        "url": header.get("url") or "",
+        "title": header.get("title") or "",
+        "state": header.get("state") or "",
+        "base": {"sha": base.get("sha"), "ref": base.get("ref")},
+        "head": {"sha": head.get("sha")},
+        "created_at": header.get("created_at"),
+        "updated_at": header.get("updated_at"),
+        "author": _as_author(header),
+    }
+    return schema.ImportDocument.model_validate(
+        {
+            "schema_version": 1,
+            "repository": _repository_block(root, owner_repo),
+            "pull_request": pull_request,
+            "evidence": [e.model_dump(mode="json") for e in records],
+            "fetch": {
+                "fetched_at": _now_rfc3339(),
+                "etag": None,
+                "payload_sha256": _payload_sha256(records),
+            },
+        }
+    )

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -1,11 +1,18 @@
 """Import normalized evidence from explicit private GitHub PRs.
 
-Task 0 spike: prove the importer's ``gh``/``git`` calls route through
-:mod:`daydream.git_ops` (so the in-process ``fake_gh`` router intercepts
-them) before any collection logic is written. The functions here are the
-thin preflight call sites; later tasks build the full
-:func:`fetch_and_normalize` / :func:`preflight` / :func:`run_import_prs`
-surface on top of them.
+This module delivers the full import surface: parse ``--pr``/``--pr-file``/
+``--head`` targets; run six ordered preflight checks (binaries, ``gh``
+authentication, identity, repository read access + immutable identity); fetch
+and normalize a PR's header, submitted reviews, inline comments and
+conversation comments (REST) plus all review threads/replies (GraphQL);
+deterministically project import-time candidates; and atomically persist one
+import file, one materialized case per requested head, and the ledger through
+a single crash-consistent :class:`storage.Transaction`.
+
+Every ``gh``/``git`` call routes through :mod:`daydream.git_ops`, so the
+in-process ``fake_gh`` router intercepts it. Rate-limit retries are bounded
+(``Retry-After`` honored, 60s cap); a fetch that exhausts them marks that PR
+``fetch_failed`` in the ledger rather than silently dropping evidence.
 """
 
 from __future__ import annotations
@@ -255,43 +262,54 @@ _RATE_LIMIT_MAX_SLEEP_S = 60.0
 
 def _call_with_rate_limit_retry(
     call: Callable[[], Any],
-) -> Any:
+) -> tuple[Any, git_ops.RateLimitError | None]:
     """Run *call* up to 3 times, sleeping ``min(retry_after, 60)`` between rate-limit failures.
 
-    A non-rate-limit failure returns immediately. After the third rate-limit
-    attempt the last (failed) result is returned so the orchestrator can mark
-    that PR ``fetch_failed`` — never a silent placeholder.
+    A non-rate-limit failure returns immediately. Returns ``(result, error)``
+    where *error* is the classified :class:`git_ops.RateLimitError` when the
+    last result is a rate-limited failure and ``None`` otherwise. After the
+    third rate-limit attempt the last (failed) result is returned so the
+    orchestrator can mark that PR ``fetch_failed`` — never a silent placeholder.
     """
     last = None
+    last_rate_limit: git_ops.RateLimitError | None = None
     for attempt in range(_RATE_LIMIT_ATTEMPTS):
         proc = call()
         if proc.returncode == 0:
-            return proc
+            return proc, None
         error = git_ops._gh_error_for(f"gh call failed: {proc.stderr.strip()}", proc.stderr)
         if not isinstance(error, git_ops.RateLimitError):
-            return proc
+            return proc, None
         retry_after = error.retry_after if error.retry_after is not None else _RATE_LIMIT_MAX_SLEEP_S
         wait = min(retry_after, _RATE_LIMIT_MAX_SLEEP_S)
         if attempt < _RATE_LIMIT_ATTEMPTS - 1:
             time.sleep(wait)
         last = proc
-    return last
+        last_rate_limit = error
+    return last, last_rate_limit
 
 
-def _fetch_with_retry(root: Path, owner_repo: str, number: int):
-    """Fetch ``pulls/<number>`` with the bounded rate-limit retry policy."""
+def _fetch_with_retry(root: Path, owner_repo: str, number: int) -> dict[str, Any]:
+    """Fetch the singular ``pulls/<number>`` object with the bounded retry policy.
+
+    The singular pulls endpoint returns one object, so it is fetched with the
+    ``@json`` filter (not the array-flattening ``.[]``) and parsed as a
+    single JSON value. A failed call raises :class:`git_ops.GitError`; a
+    rate-limit that exhausts the retry budget raises
+    :class:`_ImportRateLimitError`.
+    """
     endpoint = f"repos/{owner_repo}/pulls/{number}"
-    return _call_with_rate_limit_retry(
-        lambda: git_ops._run_gh(
-            root, ["api", "--paginate", endpoint, "--jq", ".[] | @json"]
-        )
+    proc, rate_limit = _call_with_rate_limit_retry(
+        lambda: git_ops._run_gh(root, ["api", endpoint, "--jq", "@json"])
     )
-
-
-def _is_rate_limit_error(proc) -> bool:
-    """True when a failed call's stderr carries a GitHub rate-limit signal."""
-    error = git_ops._gh_error_for(f"gh call failed: {proc.stderr.strip()}", proc.stderr)
-    return isinstance(error, git_ops.RateLimitError)
+    if proc.returncode != 0:
+        if rate_limit is not None:
+            raise _ImportRateLimitError(f"gh api {endpoint} rate limited: {proc.stderr.strip()}")
+        raise git_ops.GitError(f"gh api {endpoint} failed: {proc.stderr.strip()}")
+    header = json.loads(proc.stdout)
+    if not isinstance(header, dict):
+        raise git_ops.GitError(f"gh gives no PR header for {owner_repo}#{number}")
+    return header
 
 
 def _rest(root: Path, endpoint: str) -> list[Any]:
@@ -300,11 +318,11 @@ def _rest(root: Path, endpoint: str) -> list[Any]:
     ``--paginate`` walks Link headers so every page is retained (the fake serves
     the complete canned list in one NDJSON stream).
     """
-    proc = _call_with_rate_limit_retry(
+    proc, rate_limit = _call_with_rate_limit_retry(
         lambda: git_ops._run_gh(root, ["api", "--paginate", endpoint, "--jq", ".[] | @json"])
     )
     if proc.returncode != 0:
-        if _is_rate_limit_error(proc):
+        if rate_limit is not None:
             raise _ImportRateLimitError(f"gh api {endpoint} rate limited: {proc.stderr.strip()}")
         raise git_ops.GitError(f"gh api {endpoint} failed: {proc.stderr.strip()}")
     return _parse_ndjson(proc.stdout)
@@ -319,27 +337,35 @@ def _as_author(raw: dict) -> dict:
     return {"login": author.get("login", ""), "type": author.get("type", "User")}
 
 
+def _record_common(author: dict, body: str) -> dict[str, Any]:
+    """The author + body-hash + bot block shared by every evidence record builder."""
+    return {
+        "author": {"login": author.get("login", ""), "type": author.get("type", "User")},
+        "body": body,
+        "body_sha256": hashlib.sha256(body.encode("utf-8")).hexdigest(),
+        "is_bot": author.get("type") == "Bot",
+    }
+
+
 def _evidence_from_review(raw: dict[str, Any]) -> dict[str, Any]:
     db_id = int(raw["id"])
     submitted = raw.get("submitted_at")
     body = raw.get("body") or ""
-    return {
+    fields = {
         "source_id": f"github:review:{db_id}",
         "kind": "review",
         "database_id": db_id,
         "node_id": raw.get("node_id") or f"PRR_{db_id}",
-        "author": _as_author(raw),
-        "body": body,
-        "body_sha256": hashlib.sha256(body.encode("utf-8")).hexdigest(),
         "created_at": raw.get("created_at") or submitted,
         "updated_at": raw.get("updated_at") or submitted,
         "submitted_at": submitted,
         "commit_id": raw.get("commit_id"),
         "original_commit_id": raw.get("original_commit_id"),
         "state": raw.get("state"),
-        "is_bot": (raw.get("user") or {}).get("type") == "Bot",
         "url": raw.get("html_url") or "",
     }
+    fields.update(_record_common(raw.get("user") or {}, body))
+    return fields
 
 
 def _evidence_from_inline(raw: dict[str, Any]) -> dict[str, Any]:
@@ -348,14 +374,11 @@ def _evidence_from_inline(raw: dict[str, Any]) -> dict[str, Any]:
     subject_type = raw.get("subject_type")
     if subject_type is None:
         subject_type = "file" if raw.get("path") is None else "line"
-    return {
+    fields = {
         "source_id": f"github:inline_comment:{db_id}",
         "kind": "inline_comment",
         "database_id": db_id,
         "node_id": raw.get("node_id") or f"DIFF_{db_id}",
-        "author": _as_author(raw),
-        "body": body,
-        "body_sha256": hashlib.sha256(body.encode("utf-8")).hexdigest(),
         "created_at": raw.get("created_at"),
         "updated_at": raw.get("updated_at"),
         "commit_id": raw.get("commit_id"),
@@ -370,27 +393,26 @@ def _evidence_from_inline(raw: dict[str, Any]) -> dict[str, Any]:
         "subject_type": subject_type,
         "side": raw.get("side"),
         "start_side": raw.get("start_side"),
-        "is_bot": bool((raw.get("user") or {}).get("type") == "Bot"),
         "url": raw.get("html_url") or "",
     }
+    fields.update(_record_common(raw.get("user") or {}, body))
+    return fields
 
 
 def _evidence_from_issue(raw: dict[str, Any]) -> dict[str, Any]:
     db_id = int(raw["id"])
     body = raw.get("body") or ""
-    return {
+    fields = {
         "source_id": f"github:issue_comment:{db_id}",
         "kind": "issue_comment",
         "database_id": db_id,
         "node_id": raw.get("node_id") or f"IC_{db_id}",
-        "author": _as_author(raw),
-        "body": body,
-        "body_sha256": hashlib.sha256(body.encode("utf-8")).hexdigest(),
         "created_at": raw.get("created_at"),
         "updated_at": raw.get("updated_at"),
-        "is_bot": bool((raw.get("user") or {}).get("type") == "Bot"),
         "url": raw.get("html_url") or "",
     }
+    fields.update(_record_common(raw.get("user") or {}, body))
+    return fields
 
 
 _REVIEW_THREADS_QUERY = """
@@ -418,14 +440,11 @@ def _evidence_from_thread(thread: dict[str, Any], comment: dict[str, Any]) -> di
     author = comment.get("author") or {}
     subject = str(thread.get("subjectType") or "").lower()
     subject_type = subject if subject in ("line", "file") else None
-    return {
+    fields = {
         "source_id": f"github:thread_comment:{db_id}",
         "kind": "thread_comment",
         "database_id": db_id,
         "node_id": comment.get("id") or f"TH_{db_id}",
-        "author": {"login": author.get("login", ""), "type": author.get("type", "User")},
-        "body": body,
-        "body_sha256": hashlib.sha256(body.encode("utf-8")).hexdigest(),
         "created_at": comment.get("createdAt"),
         "updated_at": comment.get("updatedAt") or comment.get("createdAt"),
         "subject_type": subject_type,
@@ -438,9 +457,10 @@ def _evidence_from_thread(thread: dict[str, Any], comment: dict[str, Any]) -> di
         "outdated": bool(thread.get("isOutdated", False)),
         "thread_id": thread.get("id"),
         "reply_to_id": (comment.get("replyTo") or {}).get("id"),
-        "is_bot": bool(author.get("type") == "Bot"),
         "url": comment.get("url") or "",
     }
+    fields.update(_record_common(author, body))
+    return fields
 
 
 def _graphql_review_threads(root: Path, owner_repo: str, number: int) -> list[dict[str, Any]]:
@@ -759,6 +779,92 @@ def _manifest_bytes(raw: dict[str, Any]) -> bytes:
     return yaml.safe_dump(raw, sort_keys=False).encode("utf-8")
 
 
+def _stage_fetch_failure(
+    root: Path, raw: dict[str, Any], number: int, code: str, message: str
+) -> None:
+    """Atomically flip a PR's ledger entry to ``fetch_failed``.
+
+    Stages only ``benchmark.yaml`` through one :class:`Transaction`; a failed
+    fetch materializes no import/case file (the whole before/after ledger state
+    is atomic).
+    """
+    _stages_failed(raw, number, code, message)
+    with storage.Transaction(root, op_id=f"import-{number}", kind="import") as tx:
+        tx.stage("benchmark.yaml", _manifest_bytes(raw))
+        tx.commit()
+
+
+def _prior_import_state(
+    root: Path, raw: dict[str, Any], number: int
+) -> tuple[frozenset[tuple[str, str]] | None, dict[str, dict[str, Any]], str]:
+    """The prior snapshot signature, prior case curations, and the import file path.
+
+    A missing/unreadable prior snapshot yields a ``None`` signature (so a
+    refresh cannot compare); an unreadable curation file is skipped, never fatal.
+    """
+    import_file = f"imports/pr-{number:06d}.json"
+    existing = _manifest_entry(raw, number)
+    prior_sig: frozenset[tuple[str, str]] | None = None
+    prior_curations: dict[str, dict[str, Any]] = {}
+    if existing is not None and existing.get("import_state") == "fetched":
+        try:
+            prior_raw = storage.load_json_strict(root / existing["import_file"])
+            prior_sig = _evidence_signature_from_raw(prior_raw)
+        except Exception:
+            prior_sig = None
+        for case_id in existing.get("case_ids", []):
+            try:
+                cur = storage.load_yaml_strict(root / "cases" / f"{case_id}.yaml").get("curation")
+                if isinstance(cur, dict):
+                    prior_curations[case_id] = cur
+            except Exception:
+                pass
+    return prior_sig, prior_curations, import_file
+
+
+def _import_one_pr(
+    root: Path,
+    raw: dict[str, Any],
+    repo: str,
+    number: int,
+    requested_heads: list[str],
+    *,
+    refresh: bool,
+) -> int:
+    """Fetch + materialize one PR, or stage its failure: 0 on success, 1 on failure."""
+    prior_sig, prior_curations, import_file = _prior_import_state(root, raw, number)
+    try:
+        doc = fetch_and_normalize(root, repo, number)
+        changed = refresh and prior_sig is not None and prior_sig != _evidence_signature_from_doc(doc)
+        import_bytes = json.dumps(doc.model_dump(mode="json"), indent=2).encode("utf-8")
+        import_sha256 = hashlib.sha256(import_bytes).hexdigest()
+        cases = _case_materialize(
+            doc, number, requested_heads, import_file, import_sha256,
+            prior_curations=prior_curations, changed=changed,
+        )
+        with storage.Transaction(root, op_id=f"import-{number}", kind="import") as tx:
+            tx.stage(import_file, import_bytes)
+            for _, case_path, case_doc in cases:
+                tx.stage(case_path, yaml.safe_dump(case_doc, sort_keys=False).encode("utf-8"))
+            _stamp_fetched(
+                raw,
+                number,
+                import_file,
+                import_sha256,
+                requested_heads,
+                [c[0] for c in cases],
+            )
+            tx.stage("benchmark.yaml", _manifest_bytes(raw))
+            tx.commit()
+        return 0
+    except _ImportRateLimitError as exc:
+        _stage_fetch_failure(root, raw, number, "rate_limit", str(exc))
+        return 1
+    except (git_ops.GitError, schema.TransitionError, storage.WorkspaceError, PreflightError) as exc:
+        _stage_fetch_failure(root, raw, number, "fetch", str(exc))
+        return 1
+
+
 def run_import_prs(
     root: Path,
     pr_numbers: list[int],
@@ -787,57 +893,7 @@ def run_import_prs(
         raw = storage.load_yaml_strict(root / "benchmark.yaml")
         repo = raw.get("source", {}).get("repository") or ""
         for number in pr_numbers:
-            existing = _manifest_entry(raw, number)
-            prior_sig: frozenset[tuple[str, str]] | None = None
-            prior_curations: dict[str, dict[str, Any]] = {}
-            import_file = f"imports/pr-{number:06d}.json"
-            if existing is not None and existing.get("import_state") == "fetched":
-                try:
-                    prior_raw = storage.load_json_strict(root / existing["import_file"])
-                    prior_sig = _evidence_signature_from_raw(prior_raw)
-                except Exception:
-                    prior_sig = None
-                for case_id in existing.get("case_ids", []):
-                    try:
-                        cur = storage.load_yaml_strict(root / "cases" / f"{case_id}.yaml").get("curation")
-                        if isinstance(cur, dict):
-                            prior_curations[case_id] = cur
-                    except Exception:
-                        pass
-            try:
-                doc = fetch_and_normalize(root, repo, number, heads or ["final"])
-                changed = refresh and prior_sig is not None and prior_sig != _evidence_signature_from_doc(doc)
-                import_bytes = json.dumps(doc.model_dump(mode="json"), indent=2).encode("utf-8")
-                import_sha256 = hashlib.sha256(import_bytes).hexdigest()
-                cases = _case_materialize(
-                    doc, number, requested_heads, import_file, import_sha256,
-                    prior_curations=prior_curations, changed=changed,
-                )
-                with storage.Transaction(root, op_id=f"import-{number}", kind="import") as tx:
-                    tx.stage(import_file, import_bytes)
-                    for _, case_path, case_doc in cases:
-                        tx.stage(case_path, yaml.safe_dump(case_doc, sort_keys=False).encode("utf-8"))
-                    _stamp_fetched(
-                        raw,
-                        number,
-                        import_file,
-                        import_sha256,
-                        requested_heads,
-                        [c[0] for c in cases],
-                    )
-                    tx.stage("benchmark.yaml", _manifest_bytes(raw))
-                    tx.commit()
-            except _ImportRateLimitError as exc:
-                _stages_failed(raw, number, "rate_limit", str(exc))
-                with storage.Transaction(root, op_id=f"import-{number}", kind="import") as tx:
-                    tx.stage("benchmark.yaml", _manifest_bytes(raw))
-                    tx.commit()
-                exit_code = 1
-            except (git_ops.GitError, schema.TransitionError, storage.WorkspaceError, PreflightError) as exc:
-                _stages_failed(raw, number, "fetch", str(exc))
-                with storage.Transaction(root, op_id=f"import-{number}", kind="import") as tx:
-                    tx.stage("benchmark.yaml", _manifest_bytes(raw))
-                    tx.commit()
+            if _import_one_pr(root, raw, repo, number, requested_heads, refresh=refresh):
                 exit_code = 1
     return exit_code
 
@@ -867,7 +923,6 @@ def fetch_and_normalize(
     root: Path,
     owner_repo: str,
     number: int,
-    heads: list[str],
 ) -> schema.ImportDocument:
     """Fetch one PR's full evidence set through REST and normalize it.
 
@@ -877,11 +932,7 @@ def fetch_and_normalize(
     derived from the author type and never filters. Failure of any call raises
     :class:`GitError` — never a silent default.
     """
-    del heads  # requested heads are consumed by the orchestrator, not the fetch
-    header_rows = _rest(root, f"repos/{owner_repo}/pulls/{number}")
-    if not header_rows:
-        raise git_ops.GitError(f"gh gives no PR header for {owner_repo}#{number}")
-    header = header_rows[0]
+    header = _fetch_with_retry(root, owner_repo, number)
 
     evidence: list[dict[str, Any]] = []
     for raw in _rest(root, f"repos/{owner_repo}/pulls/{number}/reviews"):

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -46,6 +47,71 @@ def _git_ls_remote(root: Path, url: str) -> str:
     """Run an authenticated ``git ls-remote <url>`` and return the refs text."""
     proc = git_ops._run_git(root, ["ls-remote", url])
     return proc.stdout
+
+
+class ImportTargetError(Exception):
+    """An import-prs target (PR number/URL/file line/head SHA) failed to parse."""
+
+
+_PR_URL_RE = re.compile(r"^https://github\.com/([^/]+)/([^/]+)/pull/(\d+)$")
+
+
+@dataclass
+class ImportTargets:
+    """The deduplicated PR targets + requested heads for one import run."""
+
+    pr_numbers: list[int]
+    requested_heads: list[str]
+
+
+def _parse_pr_token(token: str) -> int:
+    """Parse one CLI arg or file line to a PR number, raising on anything else."""
+    token = token.strip()
+    if token.isdigit():
+        return int(token)
+    match = _PR_URL_RE.match(token)
+    if match is not None:
+        return int(match.group(3))
+    raise ImportTargetError(
+        f"invalid PR target {token!r} (expected a PR number or https://github.com/OWNER/REPO/pull/N)"
+    )
+
+
+def parse_import_targets(
+    pr_args: list[str],
+    pr_files: list[Path],
+    heads: list[str],
+) -> ImportTargets:
+    """Resolve CLI ``--pr`` args + ``--pr-file`` lines + ``--head`` SHAs.
+
+    Number/URL/file selections merge CLI-first then file in order and dedupe
+    to the first-seen, stable order. ``requested_heads`` always starts with
+    ``"final"`` (the PR's default head) followed by the validated 40-hex
+    ``heads``. An unparseable token or malformed head raises
+    :class:`ImportTargetError` naming the offending value.
+    """
+    numbers: list[int] = []
+    seen: set[int] = set()
+
+    def _add(number: int) -> None:
+        if number not in seen:
+            seen.add(number)
+            numbers.append(number)
+
+    for arg in pr_args:
+        _add(_parse_pr_token(arg))
+    for pr_file in pr_files:
+        for line in Path(pr_file).read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            _add(_parse_pr_token(line))
+
+    validated_heads: list[str] = []
+    for head in heads:
+        if re.fullmatch(r"[0-9a-f]{40}", head) is None:
+            raise ImportTargetError(f"invalid head SHA {head!r} (expected 40-hex)")
+        validated_heads.append(head)
+    return ImportTargets(pr_numbers=numbers, requested_heads=["final", *validated_heads])
 
 
 def _now_rfc3339() -> str:

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -147,6 +147,8 @@ def preflight(root: Path, pr_count: int) -> PreflightResult:
         raise PreflightError("repo_unresolved", "repository identity is in a partial/corrupt state")
     if visibility not in ("public", "private"):
         raise PreflightError("repo_unresolved", "repository identity did not resolve to public/private")
+    if not isinstance(repository_id, int):
+        raise PreflightError("incomplete_resolution", "repository identity lacks a numeric repository_id")
 
     try:
         _git_ls_remote(root, f"https://github.com/{repo_slug}.git")
@@ -157,7 +159,7 @@ def preflight(root: Path, pr_count: int) -> PreflightResult:
     print(f"repository visibility: {visibility}")
     print(f"requested PR count: {pr_count}")
     print(f"local destination: {root / 'imports'}")
-    return PreflightResult(login=login, repository_id=int(repository_id), visibility=visibility)
+    return PreflightResult(login=login, repository_id=repository_id, visibility=visibility)
 
 
 class ImportTargetError(Exception):
@@ -268,7 +270,8 @@ def _call_with_rate_limit_retry(
         error = git_ops._gh_error_for(f"gh call failed: {proc.stderr.strip()}", proc.stderr)
         if not isinstance(error, git_ops.RateLimitError):
             return proc
-        wait = min(error.retry_after if error.retry_after is not None else _RATE_LIMIT_MAX_SLEEP_S, _RATE_LIMIT_MAX_SLEEP_S)
+        retry_after = error.retry_after if error.retry_after is not None else _RATE_LIMIT_MAX_SLEEP_S
+        wait = min(retry_after, _RATE_LIMIT_MAX_SLEEP_S)
         if attempt < _RATE_LIMIT_ATTEMPTS - 1:
             time.sleep(wait)
         last = proc
@@ -287,7 +290,8 @@ def _fetch_with_retry(root: Path, owner_repo: str, number: int):
 
 def _is_rate_limit_error(proc) -> bool:
     """True when a failed call's stderr carries a GitHub rate-limit signal."""
-    return isinstance(git_ops._gh_error_for(f"gh call failed: {proc.stderr.strip()}", proc.stderr), git_ops.RateLimitError)
+    error = git_ops._gh_error_for(f"gh call failed: {proc.stderr.strip()}", proc.stderr)
+    return isinstance(error, git_ops.RateLimitError)
 
 
 def _rest(root: Path, endpoint: str) -> list[Any]:

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -14,6 +14,8 @@ import hashlib
 import json
 import re
 import shutil
+import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -245,16 +247,67 @@ def _parse_ndjson(text: str) -> list[Any]:
     return values
 
 
+_RATE_LIMIT_ATTEMPTS = 3
+_RATE_LIMIT_MAX_SLEEP_S = 60.0
+
+
+def _call_with_rate_limit_retry(
+    call: Callable[[], Any],
+) -> Any:
+    """Run *call* up to 3 times, sleeping ``min(retry_after, 60)`` between rate-limit failures.
+
+    A non-rate-limit failure returns immediately. After the third rate-limit
+    attempt the last (failed) result is returned so the orchestrator can mark
+    that PR ``fetch_failed`` — never a silent placeholder.
+    """
+    last = None
+    for attempt in range(_RATE_LIMIT_ATTEMPTS):
+        proc = call()
+        if proc.returncode == 0:
+            return proc
+        error = git_ops._gh_error_for(f"gh call failed: {proc.stderr.strip()}", proc.stderr)
+        if not isinstance(error, git_ops.RateLimitError):
+            return proc
+        wait = min(error.retry_after if error.retry_after is not None else _RATE_LIMIT_MAX_SLEEP_S, _RATE_LIMIT_MAX_SLEEP_S)
+        if attempt < _RATE_LIMIT_ATTEMPTS - 1:
+            time.sleep(wait)
+        last = proc
+    return last
+
+
+def _fetch_with_retry(root: Path, owner_repo: str, number: int):
+    """Fetch ``pulls/<number>`` with the bounded rate-limit retry policy."""
+    endpoint = f"repos/{owner_repo}/pulls/{number}"
+    return _call_with_rate_limit_retry(
+        lambda: git_ops._run_gh(
+            root, ["api", "--paginate", endpoint, "--jq", ".[] | @json"]
+        )
+    )
+
+
+def _is_rate_limit_error(proc) -> bool:
+    """True when a failed call's stderr carries a GitHub rate-limit signal."""
+    return isinstance(git_ops._gh_error_for(f"gh call failed: {proc.stderr.strip()}", proc.stderr), git_ops.RateLimitError)
+
+
 def _rest(root: Path, endpoint: str) -> list[Any]:
     """Fetch one REST resource, paginating fully, returning the parsed NDJSON rows.
 
     ``--paginate`` walks Link headers so every page is retained (the fake serves
     the complete canned list in one NDJSON stream).
     """
-    proc = git_ops._run_gh(root, ["api", "--paginate", endpoint, "--jq", ".[] | @json"])
+    proc = _call_with_rate_limit_retry(
+        lambda: git_ops._run_gh(root, ["api", "--paginate", endpoint, "--jq", ".[] | @json"])
+    )
     if proc.returncode != 0:
+        if _is_rate_limit_error(proc):
+            raise _ImportRateLimitError(f"gh api {endpoint} rate limited: {proc.stderr.strip()}")
         raise git_ops.GitError(f"gh api {endpoint} failed: {proc.stderr.strip()}")
     return _parse_ndjson(proc.stdout)
+
+
+class _ImportRateLimitError(Exception):
+    """A fetch exhausted its rate-limit retries; the PR becomes ``fetch_failed``."""
 
 
 def _as_author(raw: dict) -> dict:

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -160,6 +160,94 @@ def _evidence_from_issue(raw: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+_REVIEW_THREADS_QUERY = """
+query ReviewThreads($owner: String!, $name: String!, $number: Int!, $after: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 50, after: $after) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id isResolved isOutdated isResolvedBy subjectType path line originalLine side startSide
+          comments(first: 100) {
+            nodes { id databaseId body author { login type isBot } createdAt updatedAt url replyTo { id } }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def _evidence_from_thread(thread: dict[str, Any], comment: dict[str, Any]) -> dict[str, Any]:
+    db_id = int(comment["databaseId"])
+    body = comment.get("body") or ""
+    author = comment.get("author") or {}
+    subject = str(thread.get("subjectType") or "").lower()
+    subject_type = subject if subject in ("line", "file") else None
+    return {
+        "source_id": f"github:thread_comment:{db_id}",
+        "kind": "thread_comment",
+        "database_id": db_id,
+        "node_id": comment.get("id") or f"TH_{db_id}",
+        "author": {"login": author.get("login", ""), "type": author.get("type", "User")},
+        "body": body,
+        "body_sha256": hashlib.sha256(body.encode("utf-8")).hexdigest(),
+        "created_at": comment.get("createdAt"),
+        "updated_at": comment.get("updatedAt") or comment.get("createdAt"),
+        "subject_type": subject_type,
+        "side": thread.get("side"),
+        "start_side": thread.get("startSide"),
+        "path": thread.get("path"),
+        "line": thread.get("line"),
+        "original_line": thread.get("originalLine"),
+        "resolved": bool(thread.get("isResolved", False)),
+        "outdated": bool(thread.get("isOutdated", False)),
+        "thread_id": thread.get("id"),
+        "reply_to_id": (comment.get("replyTo") or {}).get("id"),
+        "is_bot": bool(author.get("type") == "Bot"),
+        "url": comment.get("url") or "",
+    }
+
+
+def _graphql_review_threads(root: Path, owner_repo: str, number: int) -> list[dict[str, Any]]:
+    """Paginate every review thread (and reply) for a PR via GraphQL.
+
+    A GraphQL ``errors`` block, a missing ``data.repository.pullRequest.reviewThreads``
+    key, or a failed call raises :class:`GitError` — never a silent empty fallback.
+    """
+    owner, name = owner_repo.split("/", 1)
+    all_nodes: list[dict[str, Any]] = []
+    after: str | None = None
+    while True:
+        variables: dict[str, Any] = {"owner": owner, "name": name, "number": number}
+        if after is not None:
+            variables["after"] = after
+        resp = git_ops.gh_api(
+            root,
+            "graphql",
+            method="POST",
+            idempotent=True,
+            input_data={"query": _REVIEW_THREADS_QUERY, "variables": variables},
+        )
+        if not isinstance(resp, dict):
+            raise git_ops.GitError("graphql reviewThreads returned a non-object response")
+        if resp.get("errors"):
+            raise git_ops.GitError(f"graphql reviewThreads failed: {resp['errors']}")
+        try:
+            threads = resp["data"]["repository"]["pullRequest"]["reviewThreads"]
+        except (KeyError, TypeError) as exc:
+            raise git_ops.GitError(f"graphql response missing reviewThreads: {exc}") from exc
+        all_nodes.extend(threads.get("nodes") or [])
+        page_info = threads.get("pageInfo") or {}
+        if not page_info.get("hasNextPage"):
+            break
+        after = page_info.get("endCursor")
+        if after is None:
+            raise git_ops.GitError("graphql reviewThreads hasNextPage without an endCursor")
+    return all_nodes
+
+
 def _payload_sha256(records: list[schema.EvidenceRecord]) -> str:
     """sha256 over the canonical JSON of the evidence list."""
     canonical = json.dumps(
@@ -218,6 +306,10 @@ def fetch_and_normalize(
         evidence.append(_evidence_from_inline(raw))
     for raw in _rest(root, f"repos/{owner_repo}/issues/{number}/comments"):
         evidence.append(_evidence_from_issue(raw))
+
+    for thread in _graphql_review_threads(root, owner_repo, number):
+        for comment in thread.get("comments", {}).get("nodes", []):
+            evidence.append(_evidence_from_thread(thread, comment))
 
     records = [schema.EvidenceRecord.model_validate(e) for e in evidence]
     base = header.get("base") or {}

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -13,10 +13,13 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import shutil
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+import yaml
 
 from daydream import git_ops
 from daydream.benchmark import schema, storage
@@ -37,16 +40,122 @@ def _run_gh_api_user(root: Path) -> dict:
 
 def _gh_auth_git_credential(root: Path) -> str:
     """Run the command-scoped git credential helper and return its protocol text."""
-    proc = git_ops._run_gh(root, ["auth", "git-credential"])
-    if proc.returncode != 0:
-        raise git_ops.GitError(f"gh auth git-credential failed: {proc.stderr.strip()}")
-    return proc.stdout
+    return git_ops.gh_auth_git_credential(root)
 
 
 def _git_ls_remote(root: Path, url: str) -> str:
     """Run an authenticated ``git ls-remote <url>`` and return the refs text."""
-    proc = git_ops._run_git(root, ["ls-remote", url])
-    return proc.stdout
+    return git_ops.git_ls_remote(root, url)
+
+
+class PreflightError(Exception):
+    """A preflight check failed with an exact ``{code, message}`` pair."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(f"preflight failed: {code}: {message}")
+        self.code = code
+        self.message = message
+
+
+@dataclass
+class PreflightResult:
+    """The authenticated identity + resolved repository captured by preflight."""
+
+    login: str
+    repository_id: int
+    visibility: str
+
+
+def _run_repo_view(root: Path, repo_slug: str) -> dict[str, Any]:
+    """Resolve a repository's identity and the caller's read access to it."""
+    proc = git_ops._run_gh(
+        root,
+        ["repo", "view", repo_slug, "--json", "id,nameWithOwner,url,visibility,defaultBranchRef"],
+    )
+    if proc.returncode != 0:
+        raise PreflightError("no_access", f"cannot read repository {repo_slug}: {proc.stderr.strip()}")
+    try:
+        view = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise PreflightError("repo_unresolved", f"repo view returned invalid JSON: {exc}") from exc
+    if not isinstance(view, dict) or view.get("id") is None:
+        raise PreflightError("repo_unresolved", f"repo view of {repo_slug} returned no identity")
+    return view
+
+
+def _resolve_identity(root: Path, repo_slug: str) -> tuple[int, str]:
+    """Fill the immutable repository identity atomically on first success.
+
+    Stage ``benchmark.yaml`` (the only mutated file) through one
+    :class:`Transaction` under the workspace lock, so a crash restores the
+    whole before- or after-state. A concurrent partial state is surfaced as
+    :class:`PreflightError` rather than repaired.
+    """
+    view = _run_repo_view(root, repo_slug)
+    repository_id = int(view["id"])
+    visibility = str(view.get("visibility") or "").lower()
+    if visibility not in ("public", "private"):
+        raise PreflightError("repo_unresolved", f"unrecognized visibility {visibility!r}")
+    with storage.WorkspaceLock(root):
+        raw = storage.load_yaml_strict(root / "benchmark.yaml")
+        current = raw.get("source") or {}
+        if current.get("repository_id") is not None or current.get("visibility") != "unresolved":
+            raise PreflightError("repo_unresolved", "repository identity is already resolved")
+        raw["source"]["repository_id"] = repository_id
+        raw["source"]["visibility"] = visibility
+        with storage.Transaction(
+            root, op_id="identity-" + repo_slug.replace("/", "_"), kind="identity"
+        ) as tx:
+            tx.stage("benchmark.yaml", yaml.safe_dump(raw, sort_keys=False).encode("utf-8"))
+            tx.commit()
+    return repository_id, visibility
+
+
+def preflight(root: Path, pr_count: int) -> PreflightResult:
+    """Run the six fixed-order preflight checks before any fetch.
+
+    Fails the run at the first failing check with an exact ``{code, message}``
+    pair (:class:`PreflightError`). Repository identity resolves once and is
+    immutable for the workspace's lifetime.
+    """
+    root = Path(root)
+    if shutil.which("git") is None or shutil.which("gh") is None:
+        raise PreflightError("missing_binary", "git and gh binaries must be reachable")
+
+    status = _run_gh_preflight_status(root)
+    if status.returncode != 0:
+        raise PreflightError("not_authenticated", "gh is not authenticated to github.com")
+
+    try:
+        user = _run_gh_api_user(root)
+    except git_ops.GitError as exc:
+        raise PreflightError("auth_failed", str(exc)) from exc
+    login = user.get("login") if isinstance(user, dict) else None
+    if not login:
+        raise PreflightError("auth_failed", "gh api user returned no login")
+
+    raw = storage.load_yaml_strict(root / "benchmark.yaml")
+    source = raw.get("source") or {}
+    repo_slug = source.get("repository") or ""
+    repository_id = source.get("repository_id")
+    visibility = source.get("visibility", "unresolved")
+    if repository_id is None and visibility == "unresolved":
+        repository_id, visibility = _resolve_identity(root, repo_slug)
+    elif (repository_id is None) != (visibility == "unresolved"):
+        raise PreflightError("repo_unresolved", "repository identity is in a partial/corrupt state")
+    if visibility not in ("public", "private"):
+        raise PreflightError("repo_unresolved", "repository identity did not resolve to public/private")
+
+    try:
+        _git_ls_remote(root, f"https://github.com/{repo_slug}.git")
+    except git_ops.GitError as exc:
+        raise PreflightError("git_preflight_failed", str(exc)) from exc
+
+    print(f"authenticated identity: {login}")
+    print(f"repository visibility: {visibility}")
+    print(f"requested PR count: {pr_count}")
+    print(f"local destination: {root / 'imports'}")
+    return PreflightResult(login=login, repository_id=int(repository_id), visibility=visibility)
 
 
 class ImportTargetError(Exception):

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -246,6 +247,122 @@ def _graphql_review_threads(root: Path, owner_repo: str, number: int) -> list[di
         if after is None:
             raise git_ops.GitError("graphql reviewThreads hasNextPage without an endCursor")
     return all_nodes
+
+
+def _normalize_body(body: str) -> str:
+    """Normalize line endings and strip trailing whitespace at the document end.
+
+    CRLF/CR are converted to LF; internal Markdown whitespace is preserved.
+    """
+    return body.replace("\r\n", "\n").replace("\r", "\n").rstrip()
+
+
+_MARKDOWN_PREFIX = re.compile(r"^(#{1,6}\s+|[-*]\s+)")
+
+
+def _derive_title(body: str) -> str:
+    """The bounded title from the first nonblank line of a body."""
+    for line in body.split("\n"):
+        if not line.strip():
+            continue
+        title = " ".join(line.split())
+        return _MARKDOWN_PREFIX.sub("", title, count=1)
+    return ""
+
+
+def _title_ok(title: str) -> bool:
+    """True when *title* is non-empty and within the 500 UTF-8 byte bound."""
+    if not title:
+        return False
+    return 0 < len(title.encode("utf-8")) <= 500
+
+
+def _anchor_location(
+    evidence: schema.EvidenceRecord,
+) -> tuple[schema.Location | None, str | None]:
+    """Project a RIGHT-side inline anchor to a ``Location``, or the block reason.
+
+    Returns ``(location, None)`` on a usable anchor, or ``(None, reason)`` when
+    the anchor is unusable or the comment is not a right-side line anchor.
+    """
+    if evidence.subject_type == "file":
+        return None, None
+    if evidence.side == "LEFT" or evidence.start_side == "LEFT":
+        return None, "side"
+    path = evidence.original_path or evidence.path
+    start = evidence.start_line or evidence.line
+    end = evidence.line or evidence.start_line
+    if not path or start is None or end is None or start < 1 or end < start:
+        return None, "anchor"
+    return schema.Location(path=path, start_line=start, end_line=end), None
+
+
+def _project_one(evidence: schema.EvidenceRecord, head_sha: str) -> schema.Candidate:
+    body = _normalize_body(evidence.body)
+    title = _derive_title(body)
+    title_ok = _title_ok(title)
+
+    location: schema.Location | None = None
+    exact = title_ok
+    reason: str | None = None
+    if evidence.kind == "inline_comment":
+        loc, anchor_reason = _anchor_location(evidence)
+        location = loc
+        if anchor_reason is not None:
+            exact = False
+            reason = anchor_reason
+    # review bodies are file-agnostic: no location, no side constraint
+
+    if not title_ok:
+        exact = False
+        reason = "title"
+    if evidence.commit_id != head_sha:
+        exact = False
+        reason = "commit"
+    if evidence.outdated:
+        exact = False
+        reason = "outdated"
+    if evidence.dismissed:
+        exact = False
+        reason = "dismissed"
+
+    return schema.Candidate(
+        source_id=evidence.source_id,
+        title=title,
+        body=body,
+        severity=None,
+        location=location,
+        exact_acceptable=exact,
+        not_exact_reason=reason if not exact else None,
+    )
+
+
+def project_candidates(
+    doc: schema.ImportDocument, head_sha: str
+) -> list[schema.Candidate]:
+    """The deterministic §5 projection of root comments + non-pure reviews.
+
+    Root inline comments with a non-empty body and ``COMMENTED`` /
+    ``CHANGES_REQUESTED`` review bodies become candidates; pure approvals,
+    replies, and conversation comments are retained as evidence only.
+    Projection never raises — an underivable title, a LEFT-side anchor, an
+    unusable anchor, an off-head commit, an outdated, or a dismissed record all
+    set ``exact_acceptable`` low with a ``not_exact_reason``.
+    """
+    cands: list[schema.Candidate] = []
+    for evidence in doc.evidence:
+        if not evidence.body:
+            continue
+        if evidence.kind == "inline_comment":
+            if evidence.reply_to_id is not None:
+                continue  # replies are evidence, not candidates
+        elif evidence.kind == "review":
+            if evidence.state not in ("COMMENTED", "CHANGES_REQUESTED"):
+                continue
+        else:
+            continue
+        cands.append(_project_one(evidence, head_sha))
+    return cands
 
 
 def _payload_sha256(records: list[schema.EvidenceRecord]) -> str:

--- a/daydream/benchmark/schema.py
+++ b/daydream/benchmark/schema.py
@@ -237,6 +237,9 @@ class BenchmarkManifest(BaseModel):
         ordered = sorted(self.cases, key=_cases_key)
         if [c.case_id for c in ordered] != [c.case_id for c in self.cases]:
             raise ValueError("cases[] index must be sorted by (pr_number, head-sha, case_id)")
+        ids = [c.case_id for c in self.cases]
+        if len(set(ids)) != len(ids):
+            raise ValueError("cases[] index must not contain duplicate case_id rows")
         return self
 
 

--- a/daydream/benchmark/schema.py
+++ b/daydream/benchmark/schema.py
@@ -478,6 +478,7 @@ class EvidenceRecord(BaseModel):
     resolved: bool = False
     outdated: bool = False
     dismissed: bool = False
+    state: str | None = None
     is_bot: bool
     url: str
 

--- a/daydream/benchmark/schema.py
+++ b/daydream/benchmark/schema.py
@@ -779,7 +779,9 @@ class CaseDocument(BaseModel):
         return self
 
 
-def snapshot_head_sha(snapshot: "SnapshotReady | SnapshotUnreplayable") -> str | None:
+def snapshot_head_sha(
+    snapshot: "SnapshotReady | SnapshotUnreplayable | SnapshotImported",
+) -> str | None:
     """The 40-hex head SHA of a snapshot, or None when unknown (unreplayable)."""
     return snapshot.original_head_sha
 

--- a/daydream/benchmark/schema.py
+++ b/daydream/benchmark/schema.py
@@ -5,9 +5,11 @@ schemas plus their invariants:
 
 * ``normalize_hostname`` and the manifest ``source``/``privacy`` blocks.
 * the ``pull_requests[]`` ledger and ``cases[]`` index.
-* the snapshot ``ready | unreplayable`` union, the case/gold/provenance/
+* the snapshot ``ready | unreplayable | imported`` union, the case/gold/provenance/
   exclusion models, ``case_id`` / finding-id derivation, and the Daydream
   self-marker rule.
+* the import models: ``ImportDocument`` and its ``EvidenceRecord``/``Candidate``
+  evidence + candidate records with stable ``github:<kind>:<id>`` source IDs.
 
 Every model uses ``extra="forbid"`` so an unknown field is a schema violation.
 Later tasks add derived workspace state, transitions, and the ``0/2/1``
@@ -38,6 +40,10 @@ __all__ = [
     "Snapshot",
     "SnapshotReady",
     "SnapshotUnreplayable",
+    "SnapshotImported",
+    "EvidenceRecord",
+    "Candidate",
+    "ImportDocument",
     "derive_finding_id",
     "derive_gold_status",
     "derive_gold_mode",
@@ -46,6 +52,25 @@ __all__ = [
 _REPOSITORY_SHAPE = re.compile(r"^[^/]+/[^/]+$")
 _HEX40 = re.compile(r"^[0-9a-f]{40}$")
 _HEX64 = re.compile(r"^[0-9a-f]{64}$")
+_SOURCE_ID_RE = re.compile(r"^github:(review|inline_comment|thread_comment|issue_comment):\d+$")
+
+
+def _rfc3339(value: str | datetime) -> datetime:
+    """Parse an RFC3339 timestamp (UTC) into a timezone-aware datetime."""
+    if isinstance(value, datetime):
+        parsed = value
+    else:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError(f"timestamp must carry a UTC offset, got {value!r}")
+    return parsed.astimezone(timezone.utc)
+
+
+def _hex64(value: str) -> str:
+    """Require a lowercase 64-hex digest."""
+    if not _HEX64.fullmatch(value):
+        raise ValueError(f"digest must be lowercase 64-hex, got {value!r}")
+    return value
 
 
 def normalize_hostname(raw: str) -> str:
@@ -351,7 +376,31 @@ class SnapshotUnreplayable(_SnapshotBase):
         return v
 
 
-Snapshot = Annotated[SnapshotReady | SnapshotUnreplayable, Field(discriminator="status")]
+class SnapshotImported(_SnapshotBase):
+    """An import-time snapshot holding only the PR-known base/head SHAs.
+
+    Issue 3 transitions ``imported -> ready|unreplayable`` once snapshot
+    bundles exist; at import the tree/bundle fields are unknowable, so they
+    are deliberately absent.
+    """
+
+    status: Literal["imported"]
+    original_base_sha: str
+    original_head_sha: str
+    error: None = None
+
+    @field_validator("original_base_sha", "original_head_sha")
+    @classmethod
+    def _sha40(cls, v: str) -> str:
+        if not _HEX40.fullmatch(v):
+            raise ValueError(f"SHA must be lowercase 40-hex, got {v!r}")
+        return v
+
+
+Snapshot = Annotated[
+    SnapshotReady | SnapshotUnreplayable | SnapshotImported,
+    Field(discriminator="status"),
+]
 
 # ---------------------------------------------------------------------------
 # location / finding / provenance / exclusions
@@ -387,6 +436,155 @@ class Location(BaseModel):
         if self.start_line > self.end_line:
             raise ValueError("start_line must be <= end_line")
         return self
+
+
+class _EvidenceAuthor(BaseModel):
+    """The author of an evidence record (login + GitHub user/bot type)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    login: str
+    type: str
+
+
+class EvidenceRecord(BaseModel):
+    """One normalized GitHub PR evidence record."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    source_id: str
+    kind: Literal["review", "inline_comment", "thread_comment", "issue_comment"]
+    database_id: int
+    node_id: str
+    author: _EvidenceAuthor
+    body: str
+    body_sha256: str
+    created_at: datetime
+    updated_at: datetime
+    submitted_at: datetime | None = None
+    commit_id: str | None = None
+    original_commit_id: str | None = None
+    path: str | None = None
+    original_path: str | None = None
+    line: int | None = None
+    start_line: int | None = None
+    original_line: int | None = None
+    review_id: str | None = None
+    thread_id: str | None = None
+    reply_to_id: str | None = None
+    subject_type: Literal["line", "file"] | None = None
+    side: Literal["LEFT", "RIGHT"] | None = None
+    start_side: Literal["LEFT", "RIGHT"] | None = None
+    resolved: bool = False
+    outdated: bool = False
+    dismissed: bool = False
+    is_bot: bool
+    url: str
+
+    @field_validator("source_id")
+    @classmethod
+    def _canonical_source_id(cls, v: str) -> str:
+        if not _SOURCE_ID_RE.fullmatch(v):
+            raise ValueError(f"source_id must be github:<kind>:<database-id>, got {v!r}")
+        return v
+
+    @field_validator("body_sha256")
+    @classmethod
+    def _sha64(cls, v: str) -> str:
+        return _hex64(v)
+
+    @field_validator("created_at", "updated_at", "submitted_at", mode="before")
+    @classmethod
+    def _ts(cls, v: str | datetime | None) -> datetime | None:
+        if v is None:
+            return None
+        return _rfc3339(v)
+
+    @field_validator("commit_id", "original_commit_id")
+    @classmethod
+    def _sha40_nullable(cls, v: str | None) -> str | None:
+        if v is not None and not _HEX40.fullmatch(v):
+            raise ValueError(f"commit SHA must be lowercase 40-hex, got {v!r}")
+        return v
+
+    @field_validator("line", "start_line", "original_line")
+    @classmethod
+    def _positive_line(cls, v: int | None) -> int | None:
+        if v is not None and v < 1:
+            raise ValueError("line anchor must be positive when set")
+        return v
+
+    @model_validator(mode="after")
+    def _body_hash(self) -> "EvidenceRecord":
+        if self.body and self.body_sha256 != hashlib.sha256(self.body.encode("utf-8")).hexdigest():
+            raise ValueError("body_sha256 must equal sha256(body)")
+        return self
+
+
+class Candidate(BaseModel):
+    """An import-time deterministic candidate projected from one evidence record."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    source_id: str
+    title: str
+    body: str
+    severity: None = None
+    location: Location | None = None
+    exact_acceptable: bool
+    not_exact_reason: str | None = None
+
+    @field_validator("source_id")
+    @classmethod
+    def _canonical_source_id(cls, v: str) -> str:
+        if not _SOURCE_ID_RE.fullmatch(v):
+            raise ValueError(f"source_id must be github canonical, got {v!r}")
+        return v
+
+    @model_validator(mode="after")
+    def _reason(self) -> "Candidate":
+        if self.exact_acceptable is False and self.not_exact_reason is None:
+            raise ValueError("not_exact_reason is required when exact_acceptable is False")
+        if self.exact_acceptable and self.not_exact_reason is not None:
+            raise ValueError("not_exact_reason must be blank when exact_acceptable is True")
+        return self
+
+
+class _ImportRepository(BaseModel):
+    """The resolved repository identity captured at import time."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: int
+    name_with_owner: str
+    visibility: Literal["public", "private"]
+
+
+class _FetchInfo(BaseModel):
+    """The fetch bookkeeping of one import document."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    fetched_at: str
+    etag: str | None = None
+    payload_sha256: str
+
+    @field_validator("payload_sha256")
+    @classmethod
+    def _sha64(cls, v: str) -> str:
+        return _hex64(v)
+
+
+class ImportDocument(BaseModel):
+    """A normalized, verifiable import of one PR's full evidence set."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1] = 1
+    repository: _ImportRepository
+    pull_request: dict
+    evidence: list[EvidenceRecord] = []
+    fetch: _FetchInfo
 
 
 class Provenance(BaseModel):
@@ -552,6 +750,14 @@ class CaseDocument(BaseModel):
     snapshot: Snapshot
     source: dict
     curation: Curation
+    candidates: list[Candidate] = []
+
+    @model_validator(mode="after")
+    def _unique_candidates(self) -> "CaseDocument":
+        ids = [c.source_id for c in self.candidates]
+        if len(set(ids)) != len(ids):
+            raise ValueError("case contains duplicate candidate source_ids")
+        return self
 
     @model_validator(mode="after")
     def _case_id_matches(self) -> "CaseDocument":

--- a/daydream/benchmark/schema.py
+++ b/daydream/benchmark/schema.py
@@ -825,8 +825,8 @@ class TransitionError(Exception):
 
 _PR_TRANSITIONS: dict[str, set[str]] = {
     "pending": {"fetched", "fetch_failed"},
-    "fetch_failed": {"fetched"},
-    "fetched": {"fetched"},
+    "fetch_failed": {"fetched", "fetch_failed"},
+    "fetched": {"fetched", "fetch_failed"},
 }
 
 _CASE_TRANSITIONS: dict[str, set[str]] = {

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -324,6 +324,7 @@ def _run_git(
     timeout: int = 5,
     capture_bytes: bool = False,
     retries: int = _GIT_TIMEOUT_RETRIES,
+    env_cmd: Any | None = None,
 ) -> subprocess.CompletedProcess[Any]:
     """Run ``git`` in *repo* with hardened defaults.
 
@@ -335,6 +336,10 @@ def _run_git(
             Mutating wrappers pass ``retries=0`` because re-running a
             non-idempotent git command after a timeout is unsafe; only
             read-only queries inherit the retrying default.
+        env_cmd: Optional environment mapping for the subprocess (default None
+            inherits the parent environment). Preflight read-only helpers pass
+            ``GIT_TERMINAL_PROMPT=0`` here so a credential failure is surfaced
+            rather than prompting on stdin.
 
     Returns:
         The completed process. ``returncode`` is left to the caller to inspect.
@@ -357,6 +362,7 @@ def _run_git(
                 timeout=timeout,
                 shell=False,
                 check=False,
+                env=env_cmd,
             )
         except subprocess.TimeoutExpired as exc:
             last_timeout = exc
@@ -2020,6 +2026,42 @@ def split_owner_repo(slug: str) -> tuple[str, str] | None:
     if not owner or not repo:
         return None
     return owner, repo
+
+
+def gh_auth_git_credential(repo: Path) -> str:
+    """Return the git credential-helper protocol from ``gh auth git-credential``.
+
+    The helper exposes GitHub's stored-auth credentials to ``git`` for one
+    read at a time; the caller scopes it to a single ``git ls-remote`` (it never
+    writes git config or puts a token on the argument vector).
+
+    Raises:
+        GitError: If the ``gh auth git-credential`` call fails.
+    """
+    proc = _run_gh(repo, ["auth", "git-credential"])
+    if proc.returncode != 0:
+        raise GitError(f"gh auth git-credential failed: {proc.stderr.strip()}")
+    return proc.stdout
+
+
+def git_ls_remote(repo: Path, url: str) -> str:
+    """Authenticated read of *url*'s refs via ``git ls-remote``.
+
+    Pins ``GIT_TERMINAL_PROMPT=0`` (command-scoped, never a global config
+    change) so a credential failure surfaces as a git error rather than a
+    stuck stdin prompt. The credential itself comes from the ambient
+    ``GH_TOKEN``/gh auth state through ``gh auth git-credential``, never from a
+    URL or argv.
+
+    Raises:
+        GitError: If the ``git ls-remote`` call fails.
+    """
+    gh_auth_git_credential(repo)  # force the credential helper to resolve first
+    env = {**os.environ, "GIT_TERMINAL_PROMPT": "0"}
+    proc = _run_git(repo, ["ls-remote", url], env_cmd=env)
+    if proc.returncode != 0:
+        raise GitError(f"git ls-remote {url} failed: {proc.stderr.strip()}")
+    return proc.stdout
 
 
 def gh_repo_view(repo: Path) -> tuple[str, str] | None:

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -400,6 +400,20 @@ crash-consistent, and safe to build on.
 The legacy `daydream bench` command remains available alongside `benchmark`;
 removal is a separate cutover.
 
+- `daydream benchmark import-prs <dir> --pr N|URL [--pr-file FILE] [--head SHA]
+  [--refresh]` imports explicit private PR evidence into an initialized
+  workspace. A six-step preflight (binaries, `gh` auth to github.com, the
+  authenticated user, repository identity + read access, a credentialed
+  `git ls-remote`, then a summary print) runs before any fetch; the first
+  successful repository resolution fills `repository_id`/`visibility`
+  atomically and immutably. Each PR's import file, one case per requested
+  head, and the ledger are written as one atomic, crash-recoverable unit;
+  a failed fetch leaves no import file and marks that PR `fetch_failed` in
+  the resumable ledger. Rate-limited requests retry three times honoring
+  `Retry-After` (60s cap). `--refresh` re-fetches and marks stale cases
+  without overwriting curation. The command never selects gold and never
+  filters bot authors — bot classification is retained as metadata only.
+
 All workspace writes are atomic and journaled (`prepared | committing |
 complete`) under the workspace lock, so a crash mid-mutation restores either
 the whole before- or after-state — never a checksum-drifted partial.

--- a/tests/harness/fake_gh.py
+++ b/tests/harness/fake_gh.py
@@ -192,6 +192,14 @@ def _handle_pr_list(argv: list[str], state: Path) -> tuple[int, str, str]:
 def _handle_repo_view(argv: list[str], state: Path) -> tuple[int, str, str]:
     _record(state, {"kind": "repo view", "argv": argv, "stdin": ""})
     responses = _read_responses(state)
+    # The import-prs preflight passes an OWNER/REPO positional + --json and
+    # expects the full resolved identity object; legacy callers pass only
+    # ``--json nameWithOwner -q .nameWithOwner`` and get the bare slug.
+    if any(tok for tok in argv[2:] if not tok.startswith("-")):
+        full = responses.get("repo-view-full")
+        if full is None:
+            return 1, "", "fake gh: no repo-view-full response configured\n"
+        return 0, json.dumps(full) + "\n", ""
     value = responses.get("repo-view")
     if value is None:
         if "pr-view" not in responses:

--- a/tests/harness/fake_gh.py
+++ b/tests/harness/fake_gh.py
@@ -225,6 +225,10 @@ def _handle_api(argv: list[str], state: Path) -> tuple[int, str, str]:
         return 0, _emit(responses[bare_key], jq), ""
     if method == "GET" and re.fullmatch(r"repos/[^/]+/[^/]+/pulls/\d+/reviews", endpoint):
         return 0, _emit([], jq), ""
+    if method == "GET" and re.fullmatch(r"repos/[^/]+/[^/]+/pulls/\d+/comments", endpoint):
+        return 0, _emit([], jq), ""
+    if method == "GET" and re.fullmatch(r"repos/[^/]+/[^/]+/issues/\d+/comments", endpoint):
+        return 0, _emit([], jq), ""
     if method == "POST" and re.fullmatch(r"repos/[^/]+/[^/]+/pulls/\d+/reviews", endpoint):
         return 0, json.dumps({"html_url": "https://github.test/fake/pull/7#pullrequestreview-1"}) + "\n", ""
     if method == "POST" and re.fullmatch(r"repos/[^/]+/[^/]+/pulls/\d+/comments", endpoint):
@@ -275,10 +279,13 @@ class GhCall:
         endpoint: Endpoint with any leading slash stripped (``graphql`` for
             GraphQL calls).
         payload: Parsed ``--input`` JSON payload, or None.
+        argv: The full ``gh api`` argv (after ``gh``) as recorded, so tests
+            can assert flags like ``--paginate`` were passed.
     """
 
     endpoint: str
     payload: Any
+    argv: list[str] | None = None
 
 
 @dataclass
@@ -332,7 +339,13 @@ class FakeGh:
                 continue
             if wanted_endpoint is not None and record["endpoint"] != wanted_endpoint:
                 continue
-            out.append(GhCall(endpoint=record["endpoint"], payload=record["payload"]))
+            out.append(
+                GhCall(
+                    endpoint=record["endpoint"],
+                    payload=record["payload"],
+                    argv=record.get("argv"),
+                )
+            )
         return out
 
     def command_calls(self, kind: str) -> list[GhCommandCall]:

--- a/tests/harness/fake_gh.py
+++ b/tests/harness/fake_gh.py
@@ -56,6 +56,18 @@ def _argv_opt(argv: list[str], name: str) -> str | None:
             return argv[i + 1]
     return None
 
+_GIT_CREDENTIAL_HELPER = (
+    "protocol=https\n"
+    "host=github.com\n"
+    "username=x\n"
+    "password=<fake>\n"
+)
+
+_LS_REMOTE_DEFAULT = (
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\trefs/heads/head\n"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\trefs/heads/base\n"
+)
+
 _EMPTY_THREADS_RESPONSE: dict[str, Any] = {
     "data": {
         "repository": {
@@ -244,6 +256,12 @@ def _handle_gh(argv: list[str], stdin_text: str, state: Path) -> tuple[int, str,
         return _handle_pr_create(argv, state)
     if argv[:2] == ["repo", "view"]:
         return _handle_repo_view(argv, state)
+    if argv[:2] == ["auth", "status"]:
+        _record(state, {"kind": "auth status", "argv": argv, "stdin": ""})
+        return 0, "", ""
+    if argv[:2] == ["auth", "git-credential"]:
+        _record(state, {"kind": "auth git-credential", "argv": argv, "stdin": ""})
+        return 0, _GIT_CREDENTIAL_HELPER, ""
     if not argv or argv[0] != "api":
         return 1, "", f"fake gh: unsupported invocation: {argv!r}\n"
     return _handle_api(argv, state)
@@ -513,6 +531,18 @@ def install_fake_gh(state_dir: Path, monkeypatch: pytest.MonkeyPatch) -> FakeGh:
         if isinstance(args, (list, tuple)) and args and args[0] == "gh":
             rc, out, err = _handle_gh(list(args[1:]), kwargs.get("input") or "", state_dir)
             return subprocess.CompletedProcess(list(args), rc, stdout=out, stderr=err)
+        if (
+            isinstance(args, (list, tuple))
+            and args
+            and args[0] == "git"
+            and "ls-remote" in args
+        ):
+            refs = _read_responses(state_dir).get("git-ls-remote", _LS_REMOTE_DEFAULT)
+            _record(
+                state_dir,
+                {"kind": "git ls-remote", "argv": list(args), "env": kwargs.get("env")},
+            )
+            return subprocess.CompletedProcess(list(args), 0, stdout=refs, stderr="")
         return real_run(args, *pargs, **kwargs)
 
     monkeypatch.setattr("daydream.git_ops.subprocess.run", router)

--- a/tests/harness/fake_gh.py
+++ b/tests/harness/fake_gh.py
@@ -192,10 +192,11 @@ def _handle_pr_list(argv: list[str], state: Path) -> tuple[int, str, str]:
 def _handle_repo_view(argv: list[str], state: Path) -> tuple[int, str, str]:
     _record(state, {"kind": "repo view", "argv": argv, "stdin": ""})
     responses = _read_responses(state)
-    # The import-prs preflight passes an OWNER/REPO positional + --json and
-    # expects the full resolved identity object; legacy callers pass only
-    # ``--json nameWithOwner -q .nameWithOwner`` and get the bare slug.
-    if any(tok for tok in argv[2:] if not tok.startswith("-")):
+    # The import-prs preflight passes a leading OWNER/REPO positional + --json
+    # and expects the full resolved identity object; legacy callers pass
+    # ``--json nameWithOwner -q .nameWithOwner`` (no leading positional) and
+    # get the bare slug.
+    if len(argv) > 2 and not argv[2].startswith("-"):
         full = responses.get("repo-view-full")
         if full is None:
             return 1, "", "fake gh: no repo-view-full response configured\n"

--- a/tests/harness/fake_gh.py
+++ b/tests/harness/fake_gh.py
@@ -222,15 +222,23 @@ def _handle_api(argv: list[str], state: Path) -> tuple[int, str, str]:
             reply: dict[str, Any] = {"data": {"minimizeComment": {"minimizedComment": {"isMinimized": True}}}}
             return 0, json.dumps(reply) + "\n", ""
         if "reviewThreads" in query:
-            return 0, json.dumps(responses.get("graphql_threads", _EMPTY_THREADS_RESPONSE)) + "\n", ""
+            variables = (payload or {}).get("variables") or {}
+            pr_num = variables.get("number") if isinstance(variables, dict) else None
+            key = f"graphql_threads:{pr_num}" if pr_num is not None else "graphql_threads"
+            value = responses.get(key) or responses.get("graphql_threads") or _EMPTY_THREADS_RESPONSE
+            return 0, json.dumps(value) + "\n", ""
         return 1, "", "fake gh: unrecognized graphql query\n"
     key = f"{method} {endpoint}"
+    if key in responses and isinstance(responses[key], dict) and "__error__" in responses[key]:
+        return 1, "", str(responses[key]["__error__"]) + "\n"
     if key in responses:
         if responses[key] is None:
             return 1, "", f"fake gh: 404 {endpoint} (no such resource)\n"
         return 0, _emit(responses[key], jq), ""
     # Query strings select/paginate; the canned response is keyed by path alone.
     bare_key = f"{method} {endpoint.split('?')[0]}"
+    if bare_key in responses and isinstance(responses[bare_key], dict) and "__error__" in responses[bare_key]:
+        return 0, "", str(responses[bare_key]["__error__"]) + "\n"
     if bare_key in responses:
         if responses[bare_key] is None:
             return 1, "", f"fake gh: 404 {endpoint} (no such resource)\n"
@@ -534,11 +542,13 @@ class FakeGh:
             "comments": {"nodes": [comment]},
         }
 
-    def _write_threads(self, nodes: list[dict[str, Any]]) -> None:
+    def _write_threads(self, nodes: list[dict[str, Any]], number: int | None = None) -> None:
+        """Serve *nodes* as the review-thread inventory for one PR (or globally)."""
         response = json.loads(json.dumps(_EMPTY_THREADS_RESPONSE))
         response["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"] = nodes
         responses = self._read_responses()
-        responses["graphql_threads"] = response
+        key = f"graphql_threads:{number}" if number is not None else "graphql_threads"
+        responses[key] = response
         self._responses_path.write_text(json.dumps(responses), encoding="utf-8")
 
     def _read_responses(self) -> dict[str, Any]:

--- a/tests/harness/fake_gh.py
+++ b/tests/harness/fake_gh.py
@@ -226,10 +226,14 @@ def _handle_api(argv: list[str], state: Path) -> tuple[int, str, str]:
         return 1, "", "fake gh: unrecognized graphql query\n"
     key = f"{method} {endpoint}"
     if key in responses:
+        if responses[key] is None:
+            return 1, "", f"fake gh: 404 {endpoint} (no such resource)\n"
         return 0, _emit(responses[key], jq), ""
     # Query strings select/paginate; the canned response is keyed by path alone.
     bare_key = f"{method} {endpoint.split('?')[0]}"
     if bare_key in responses:
+        if responses[bare_key] is None:
+            return 1, "", f"fake gh: 404 {endpoint} (no such resource)\n"
         return 0, _emit(responses[bare_key], jq), ""
     if method == "GET" and re.fullmatch(r"repos/[^/]+/[^/]+/pulls/\d+/reviews", endpoint):
         return 0, _emit([], jq), ""

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -520,3 +520,99 @@ def test_benchmark_help_lists_import_prs():
 
     r = subprocess.run(["daydream", "benchmark", "--help"], capture_output=True, text=True)
     assert r.returncode == 0 and "import-prs" in r.stdout
+def test_reimport_does_not_duplicate_cases_rows(tmp_path, fake_gh):
+    """Re-importing the same PR (unchanged evidence) must not duplicate cases[] rows."""
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.storage import load_yaml_strict
+
+    ws = tmp_path / "ws"
+    _seed_preflight(ws, fake_gh)
+    assert gi.run_import_prs(ws, pr_numbers=[101], heads=["final"]) == 0
+    raw1 = load_yaml_strict(ws / "benchmark.yaml")
+    assert len(raw1["cases"]) == 1
+    # re-import same PR, unchanged evidence (responses not changed) — fetched->fetched allowed
+    assert gi.run_import_prs(ws, pr_numbers=[101], heads=["final"]) == 0
+    raw2 = load_yaml_strict(ws / "benchmark.yaml")
+    ids = [c["case_id"] for c in raw2["cases"]]
+    assert len(raw2["cases"]) == 1, f"cases[] grew to {len(raw2['cases'])}: {ids}"
+    assert ids[0] == "pr-000101-aaaaaaaaaaaa"
+
+
+def test_reimport_unchanged_evidence_preserves_curation(tmp_path, fake_gh):
+    """Re-import with unchanged evidence must not wipe curated findings/attestation."""
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.storage import load_yaml_strict
+
+    ws = tmp_path / "ws"
+    _seed_preflight(ws, fake_gh)
+    assert gi.run_import_prs(ws, pr_numbers=[101], heads=["final"]) == 0
+    case_file = "pr-000101-aaaaaaaaaaaa.yaml"
+    _curate_case(ws, case_file)  # state=ready, snapshot_attested=True, findings non-empty
+    before = load_yaml_strict(ws / "cases" / case_file)["curation"]
+    assert before["state"] == "ready" and before["snapshot_attested"] is True and before["findings"]
+    # Re-import same PR WITHOUT refresh, unchanged evidence.
+    assert gi.run_import_prs(ws, pr_numbers=[101], heads=["final"]) == 0
+    after = load_yaml_strict(ws / "cases" / case_file)["curation"]
+    assert after["state"] in ("ready", "stale"), "curation must not reset to draft"
+    assert after["findings"], "curated findings must not be wiped"
+    assert after["snapshot_attested"] is True, "unchanged re-import must keep attestation"
+
+
+def test_refresh_unchanged_signature_preserves_curation(tmp_path, fake_gh):
+    """Refresh with an UNCHANGED evidence signature must keep curated findings."""
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.storage import load_yaml_strict
+
+    ws = tmp_path / "ws"
+    _seed_preflight(ws, fake_gh)
+    assert gi.run_import_prs(ws, pr_numbers=[101], heads=["final"]) == 0
+    case_file = "pr-000101-aaaaaaaaaaaa.yaml"
+    _curate_case(ws, case_file)
+    # refresh with IDENTICAL evidence responses (signature unchanged) -> changed=False
+    assert gi.run_import_prs(ws, pr_numbers=[101], heads=["final"], refresh=True) == 0
+    after = load_yaml_strict(ws / "cases" / case_file)["curation"]
+    assert after["findings"], "curated findings must not be wiped on unchanged refresh"
+    assert after["state"] != "draft", "curation must not reset to draft on unchanged refresh"
+
+
+def test_graphql_review_threads_retries_rate_limit_then_fails(tmp_path, fake_gh, monkeypatch):
+    """GraphQL reviewThreads honors the rate-limit retry policy (3x)."""
+    import daydream.benchmark.github_import as gi_mod
+    from daydream.git_ops import RateLimitError
+
+    ws = tmp_path / "ws"
+    _seed_preflight(ws, fake_gh)
+
+    calls = {"n": 0}
+
+    def flaky_gh_api(*a, **kw):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise RateLimitError("graphql rate limited", retry_after=0.0)
+        ok = {"repository": {"pullRequest": {"reviewThreads": {"nodes": [], "pageInfo": {"hasNextPage": False}}}}}
+        return {"data": ok}
+
+    monkeypatch.setattr(gi_mod.git_ops, "gh_api", flaky_gh_api)
+    monkeypatch.setattr(gi_mod, "time", type("_T", (), {"sleep": staticmethod(lambda _s: None)})())
+    threads = gi_mod._graphql_review_threads(ws, "o/r", 101)
+    assert threads == []
+    assert calls["n"] == 3, "rate-limit retry should make 3 attempts"
+
+
+def test_graphql_review_threads_records_rate_limit_after_retries(tmp_path, fake_gh, monkeypatch):
+    """Exhausting GraphQL rate-limit retries surfaces _ImportRateLimitError (ledger rate_limit)."""
+    import pytest
+
+    import daydream.benchmark.github_import as gi_mod
+    from daydream.git_ops import RateLimitError
+
+    ws = tmp_path / "ws"
+    _seed_preflight(ws, fake_gh)
+
+    def always_limited(*a, **kw):
+        raise RateLimitError("graphql rate limited", retry_after=0.0)
+
+    monkeypatch.setattr(gi_mod.git_ops, "gh_api", always_limited)
+    monkeypatch.setattr(gi_mod, "time", type("_T", (), {"sleep": staticmethod(lambda _s: None)})())
+    with pytest.raises(gi_mod._ImportRateLimitError):
+        gi_mod._graphql_review_threads(ws, "o/r", 101)

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -84,3 +84,39 @@ def test_fetch_normalizes_all_rest_evidence(tmp_path, fake_gh):
     assert doc.evidence[1].is_bot is True      # bot classification retained, not dropped
     assert doc.evidence[1].subject_type == "line" and doc.evidence[1].side == "RIGHT"
     assert all("--paginate" in (c.argv or []) for c in fake_gh.calls("GET"))
+
+
+def test_graphql_threads_and_replies_normalized(tmp_path, fake_gh):
+    from daydream.benchmark import github_import as gi
+
+    ws = tmp_path / "ws"
+    (ws / "imports").mkdir(parents=True)
+    fake_gh.set_response("GET", "repos/o/r/pulls/101", _PR_HEADER)
+    for ep, val in [
+        ("repos/o/r/pulls/101/reviews", []),
+        ("repos/o/r/pulls/101/comments", []),
+        ("repos/o/r/issues/101/comments", []),
+    ]:
+        fake_gh.set_response("GET", ep, val)
+    fake_gh._write_threads([
+        {"id": "thread_1", "isResolved": True,
+         "isOutdated": True, "isResolvedBy": None,
+         "subjectType": "LINE", "path": "a.py", "line": 4, "originalLine": 3,
+         "side": "RIGHT", "startSide": None,
+         "comments": {"nodes": [
+             {"id": "c1", "databaseId": 10, "body": "root", "author": {"login": "dave", "type": "User"},
+              "createdAt": "2026-01-01T00:00:00Z", "url": "https://github.com/o/r/pull/101#discussion_r10"},
+             {"id": "c2", "databaseId": 11, "body": "reply", "replyTo": {"id": "c1"},
+              "author": {"login": "eve", "type": "User"},
+              "createdAt": "2026-01-01T00:00:00Z", "url": "https://github.com/o/r/pull/101#discussion_r11"},
+         ]}},
+    ])
+    doc = gi.fetch_and_normalize(ws, "o/r", 101, heads=["final"])
+    kinds = {e.kind for e in doc.evidence}
+    assert "thread_comment" in kinds
+    root = next(e for e in doc.evidence if e.database_id == 10)
+    reply = next(e for e in doc.evidence if e.database_id == 11)
+    assert root.resolved is True and root.outdated is True
+    assert root.side == "RIGHT" and root.path == "a.py" and root.line == 4
+    assert reply.kind == "thread_comment" and reply.reply_to_id == "c1"
+    assert reply.thread_id == "thread_1"

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -219,3 +219,45 @@ def test_preflight_six_checks_in_order_and_atomic_identity(tmp_path, fake_gh):
     # second preflight is a no-op on identity (immutable, already resolved)
     out2 = gi.preflight(ws, pr_count=1)
     assert out2.repository_id == 5
+
+
+def test_rate_limit_retries_three_then_fails_pr(tmp_path, fake_gh, monkeypatch):
+    import subprocess
+
+    from daydream import git_ops as _git_ops
+    from daydream.benchmark import github_import as gi
+
+    ws = tmp_path / "ws"
+    (ws / "imports").mkdir(parents=True)
+    attempts = {"n": 0}
+    fake_gh.set_response("GET", "repos/o/r/pulls/101", _PR_HEADER)
+    fake_gh.set_response("GET", "repos/o/r/pulls/101/reviews", [])
+    fake_gh.set_response("GET", "repos/o/r/pulls/101/comments", [])
+    fake_gh.set_response("GET", "repos/o/r/issues/101/comments", [])
+    slept: list[float] = []
+    monkeypatch.setattr("daydream.benchmark.github_import.time.sleep", lambda s: slept.append(s))
+    real_run = _git_ops.subprocess.run
+
+    def flaky_gh(args, *pargs, **kwargs):
+        argv = list(args)
+        joined = " ".join(argv)
+        if (
+            argv
+            and argv[0] == "gh"
+            and "pulls/101" in joined
+            and "reviews" not in joined
+            and "comments" not in joined
+            and "issues" not in joined
+        ):
+            attempts["n"] += 1
+            if attempts["n"] < 3:
+                return subprocess.CompletedProcess(
+                    argv, 1, "API rate limit exceeded",
+                    "gh: API rate limit exceeded Retry-After: 2",
+                )
+        return real_run(args, *pargs, **kwargs)
+
+    monkeypatch.setattr("daydream.git_ops.subprocess.run", flaky_gh)
+    ok = gi._fetch_with_retry(ws, "o/r", 101)
+    assert attempts["n"] == 3 and ok.returncode == 0
+    assert slept and all(w <= 60 for w in slept)  # Retry-After honored, 60s cap

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -6,10 +6,6 @@ are intercepted by the in-process ``fake_gh`` router. Subsequent
 collection/normalization/projection/orchestration tasks build on this seam.
 """
 
-import json
-
-import pytest
-
 _PR_HEADER = {
     "number": 101,
     "url": "https://github.com/o/r/pull/101",
@@ -204,7 +200,7 @@ def test_preflight_six_checks_in_order_and_atomic_identity(tmp_path, fake_gh):
     from daydream.benchmark.storage import load_yaml_strict
 
     ws = tmp_path / "ws"
-    _seed_manifest(ws)  # Source(provider=github, hostname=github.com, repository=o/r, repository_id=None, visibility=unresolved)
+    _seed_manifest(ws)  # unresolved Source (repository=o/r)
     fake_gh.set_response("GET", "user", {"login": "octocat", "type": "User"})
     fake_gh.set_response(
         "repo-view-full",
@@ -492,7 +488,7 @@ def test_e2e_paginated_human_bot_evidence_and_no_comment_pr(tmp_path, fake_gh):
 
 def test_e2e_partial_failure_persists_ledger_and_exits_nonzero(tmp_path, fake_gh):
     from daydream.benchmark.cli import _handle_benchmark_command
-    from daydream.benchmark.storage import load_json_strict, load_yaml_strict
+    from daydream.benchmark.storage import load_yaml_strict
 
     ws = tmp_path / "ws"
     _seed_manifest(ws)

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -1,9 +1,11 @@
 """Tests for ``daydream benchmark import-prs``.
 
-Task 0 spike: the load-bearing claim that the importer's ``gh``/``git``
-calls, made through :mod:`daydream.git_ops` with ``cwd=<workspace root>``,
-are intercepted by the in-process ``fake_gh`` router. Subsequent
-collection/normalization/projection/orchestration tasks build on this seam.
+Covers the full import surface through the in-process ``fake_gh`` router:
+target parsing, six-check preflight + immutable identity, REST + GraphQL
+fetch/normalize, candidate projection, bounded rate-limit retry, atomic
+ledger/case transactions, refresh/staleness (curation preservation), and both
+e2e acceptance paths including partial-failure persistence. All ``gh``/``git``
+calls route through :mod:`daydream.git_ops` with ``cwd=<workspace root>``.
 """
 
 _PR_HEADER = {
@@ -72,14 +74,19 @@ def test_fetch_normalizes_all_rest_evidence(tmp_path, fake_gh):
              "html_url": "https://github.com/o/r/pull/101#issuecomment-9"},
         ],
     )
-    doc = gi.fetch_and_normalize(ws, "o/r", 101, heads=["final"])
+    doc = gi.fetch_and_normalize(ws, "o/r", 101)
     kinds = {e.kind for e in doc.evidence}
     assert kinds == {"review", "inline_comment", "issue_comment"}
     assert doc.evidence[0].source_id == "github:review:1"
     assert doc.evidence[0].is_bot is False
     assert doc.evidence[1].is_bot is True      # bot classification retained, not dropped
     assert doc.evidence[1].subject_type == "line" and doc.evidence[1].side == "RIGHT"
-    assert all("--paginate" in (c.argv or []) for c in fake_gh.calls("GET"))
+    get_calls = fake_gh.calls("GET")
+    header_args = [c.argv for c in get_calls if c.endpoint == "repos/o/r/pulls/101"]
+    collection_args = [c.argv for c in get_calls if c.endpoint != "repos/o/r/pulls/101"]
+    # list endpoints paginate; the singular header is fetched as one object, not array-flattened
+    assert header_args and "@json" in (header_args[0] or []) and "--paginate" not in (header_args[0] or [])
+    assert all("--paginate" in (a or []) for a in collection_args)
 
 
 def test_graphql_threads_and_replies_normalized(tmp_path, fake_gh):
@@ -107,7 +114,7 @@ def test_graphql_threads_and_replies_normalized(tmp_path, fake_gh):
               "createdAt": "2026-01-01T00:00:00Z", "url": "https://github.com/o/r/pull/101#discussion_r11"},
          ]}},
     ])
-    doc = gi.fetch_and_normalize(ws, "o/r", 101, heads=["final"])
+    doc = gi.fetch_and_normalize(ws, "o/r", 101)
     kinds = {e.kind for e in doc.evidence}
     assert "thread_comment" in kinds
     root = next(e for e in doc.evidence if e.database_id == 10)
@@ -159,7 +166,7 @@ def test_candidate_projection_right_file_body_left(tmp_path, fake_gh):
     )
     fake_gh.set_response("GET", "repos/o/r/issues/101/comments", [])
     fake_gh._write_threads([])
-    doc_gi = gi.fetch_and_normalize(ws, "o/r", 101, heads=["final"])
+    doc_gi = gi.fetch_and_normalize(ws, "o/r", 101)
     cands = gi.project_candidates(doc_gi, head_sha="a" * 40)
     by_src = {c.source_id: c for c in cands}
     right = by_src["github:inline_comment:1"]
@@ -255,7 +262,7 @@ def test_rate_limit_retries_three_then_fails_pr(tmp_path, fake_gh, monkeypatch):
 
     monkeypatch.setattr("daydream.git_ops.subprocess.run", flaky_gh)
     ok = gi._fetch_with_retry(ws, "o/r", 101)
-    assert attempts["n"] == 3 and ok.returncode == 0
+    assert attempts["n"] == 3 and ok["number"] == 101
     assert slept and all(w <= 60 for w in slept)  # Retry-After honored, 60s cap
 
 

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -400,6 +400,118 @@ def test_refresh_marks_stale_and_never_overwrites_curation(tmp_path, fake_gh):
     assert case["curation"]["findings"]              # prior curated findings preserved
 
 
+def _pr_header(number: int) -> dict:
+    header = dict(_PR_HEADER)
+    header["number"] = number
+    header["url"] = f"https://github.com/o/r/pull/{number}"
+    return header
+
+
+def _seed_identity(fake_gh) -> None:
+    """Seed the preflight identity + repo-access responses (no PR data)."""
+    fake_gh.set_response("GET", "user", {"login": "octocat", "type": "User"})
+    fake_gh.set_response(
+        "repo-view-full",
+        value={"id": 5, "nameWithOwner": "o/r",
+               "url": "https://github.com/o/r", "visibility": "PRIVATE",
+               "defaultBranchRef": {"name": "main"}},
+    )
+
+
+def _seed_rest(gh, number: int, *, reviews, comments, issue_comments) -> None:
+    """Seed one PR's REST evidence into the fake router."""
+    gh.set_response("GET", f"repos/o/r/pulls/{number}", _pr_header(number))
+    gh.set_response("GET", f"repos/o/r/pulls/{number}/reviews", reviews)
+    gh.set_response("GET", f"repos/o/r/pulls/{number}/comments", comments)
+    gh.set_response("GET", f"repos/o/r/issues/{number}/comments", issue_comments)
+
+
+def test_e2e_paginated_human_bot_evidence_and_no_comment_pr(tmp_path, fake_gh):
+    from daydream.benchmark.cli import _handle_benchmark_command
+    from daydream.benchmark.storage import load_json_strict, load_yaml_strict
+
+    ws = tmp_path / "ws"
+    _seed_manifest(ws)
+    _seed_identity(fake_gh)
+    _seed_rest(
+        fake_gh, 101,
+        reviews=[
+            {"id": 1, "node_id": "PRR_1", "user": {"login": "cr[bot]", "type": "Bot"},
+             "body": "Found a bug.", "state": "COMMENTED", "commit_id": "a" * 40,
+             "submitted_at": "2026-01-01T00:00:00Z", "html_url": "https://github.com/o/r/pull/101#pullrequestreview-1"},
+            {"id": 2, "node_id": "PRR_2", "user": {"login": "carol", "type": "User"},
+             "body": "Nice work.", "state": "COMMENTED", "commit_id": "a" * 40,
+             "submitted_at": "2026-01-01T00:00:00Z", "html_url": "https://github.com/o/r/pull/101#pullrequestreview-2"},
+        ],
+        comments=[
+            {"id": 7, "node_id": "DIFF_7", "user": {"login": "bot[bot]", "type": "Bot"},
+             "body": "please fix the cache", "path": "a.py", "line": 4,
+             "subject_type": "line", "side": "RIGHT", "commit_id": "a" * 40,
+             "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",
+             "html_url": "https://github.com/o/r/pull/101#discussion_r7"},
+            {"id": 8, "node_id": "DIFF_8", "user": {"login": "dave", "type": "User"},
+             "body": "Order matters here.", "path": "b.py", "line": 2,
+             "subject_type": "line", "side": "RIGHT", "commit_id": "a" * 40,
+             "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",
+             "html_url": "https://github.com/o/r/pull/101#discussion_r8"},
+        ],
+        issue_comments=[
+            {"id": 9, "node_id": "IC_9", "user": {"login": "carol", "type": "User"},
+             "body": "question", "created_at": "2026-01-01T00:00:00Z",
+             "updated_at": "2026-01-01T00:00:00Z",
+             "html_url": "https://github.com/o/r/pull/101#issuecomment-9"},
+        ],
+    )
+    fake_gh._write_threads(
+        [
+            {"id": "thread_1", "isResolved": False, "isOutdated": False,
+             "subjectType": "LINE", "path": "a.py", "line": 4, "side": "RIGHT",
+             "comments": {"nodes": [
+                 {"id": "c1", "databaseId": 10, "body": "root",
+                  "author": {"login": "dave", "type": "User"},
+                  "createdAt": "2026-01-01T00:00:00Z",
+                  "url": "https://github.com/o/r/pull/101#discussion_r10"},
+             ]}},
+        ],
+        number=101,
+    )
+    _seed_rest(fake_gh, 102, reviews=[], comments=[], issue_comments=[])
+    rc = _handle_benchmark_command(
+        ["import-prs", str(ws), "--pr", "101", "--pr", "102", "--pr", "https://github.com/o/r/pull/102"]
+    )
+    assert rc == 0
+    raw = load_yaml_strict(ws / "benchmark.yaml")
+    assert [p["number"] for p in raw["pull_requests"]] == [101, 102]
+    imp = load_json_strict(ws / "imports/pr-000101.json")
+    kinds = {e["kind"] for e in imp["evidence"]}
+    assert kinds == {"review", "inline_comment", "issue_comment", "thread_comment"}
+    assert any(e["is_bot"] for e in imp["evidence"])      # bot author retained
+    assert any(not e["is_bot"] for e in imp["evidence"])  # human author retained
+    assert load_json_strict(ws / "imports/pr-000102.json")["evidence"] == []  # no-comment PR retained
+
+
+def test_e2e_partial_failure_persists_ledger_and_exits_nonzero(tmp_path, fake_gh):
+    from daydream.benchmark.cli import _handle_benchmark_command
+    from daydream.benchmark.storage import load_json_strict, load_yaml_strict
+
+    ws = tmp_path / "ws"
+    _seed_manifest(ws)
+    _seed_identity(fake_gh)
+    _seed_rest(fake_gh, 101, reviews=[], comments=[], issue_comments=[])
+    fake_gh.set_response(
+        "GET", "repos/o/r/pulls/102", {"__error__": "API rate limit exceeded Retry-After: 1"}
+    )
+    rc = _handle_benchmark_command(["import-prs", str(ws), "--pr", "101", "--pr", "102"])
+    assert rc != 0
+    raw = load_yaml_strict(ws / "benchmark.yaml")
+    by_n = {p["number"]: p for p in raw["pull_requests"]}
+    assert by_n[101]["import_state"] == "fetched"
+    assert by_n[102]["import_state"] == "fetch_failed"
+    assert by_n[102]["error"]["code"] == "rate_limit"
+    assert (ws / "imports/pr-000101.json").exists()
+    assert not (ws / "imports/pr-000102.json").exists()   # failed fetch: no import file
+
+
 def test_benchmark_help_lists_import_prs():
     import subprocess
 

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -176,3 +176,17 @@ def test_candidate_projection_right_file_body_left(tmp_path, fake_gh):
     assert by_src["github:review:5"].location is None               # review body
     assert by_src["github:review:5"].exact_acceptable is True
     assert "github:review:6" not in by_src                          # pure approval: no candidate
+
+
+def test_parse_targets_dedupes_and_orders(tmp_path):
+    from daydream.benchmark import github_import as gi
+
+    pf = tmp_path / "prs.txt"
+    pf.write_text("42\nhttps://github.com/o/r/pull/9\n7\n42\n")
+    targets = gi.parse_import_targets(
+        pr_args=["https://github.com/o/r/pull/9", "7"],
+        pr_files=[pf],
+        heads=["abc" * 13 + "1", "abc" * 13 + "2"],
+    )
+    assert targets.pr_numbers == [9, 7, 42]     # stable: CLI order then file order; dupes collapsed
+    assert targets.requested_heads == ["final", "abc" * 13 + "1", "abc" * 13 + "2"]  # 'final' always present

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -261,3 +261,66 @@ def test_rate_limit_retries_three_then_fails_pr(tmp_path, fake_gh, monkeypatch):
     ok = gi._fetch_with_retry(ws, "o/r", 101)
     assert attempts["n"] == 3 and ok.returncode == 0
     assert slept and all(w <= 60 for w in slept)  # Retry-After honored, 60s cap
+
+
+def _seed_preflight(ws, fake_gh, *, pull_header=_PR_HEADER):
+    """Seed an unresolved workspace + canned preflight/REST data for pr 101."""
+    _seed_manifest(ws)
+    fake_gh.set_response("GET", "user", {"login": "octocat", "type": "User"})
+    fake_gh.set_response(
+        "repo-view-full",
+        value={"id": 5, "nameWithOwner": "o/r",
+               "url": "https://github.com/o/r", "visibility": "PRIVATE",
+               "defaultBranchRef": {"name": "main"}},
+    )
+    fake_gh.set_response("GET", "repos/o/r/pulls/101", pull_header)
+    fake_gh.set_response("GET", "repos/o/r/pulls/101/reviews", [])
+    fake_gh.set_response("GET", "repos/o/r/pulls/101/comments", [])
+    fake_gh.set_response("GET", "repos/o/r/issues/101/comments", [])
+
+
+def test_import_writes_atomic_unit_and_no_file_on_failure(tmp_path, fake_gh):
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.storage import load_yaml_strict, sha256_file
+
+    ws = tmp_path / "ws"
+    _seed_preflight(ws, fake_gh)  # preflight + rest/graphql canned data for pr 101 (one head)
+    rc = gi.run_import_prs(ws, pr_numbers=[101], heads=["final"])
+    assert rc == 0
+    raw = load_yaml_strict(ws / "benchmark.yaml")
+    pr = raw["pull_requests"][0]
+    assert pr["import_state"] == "fetched"
+    assert pr["import_file"] == "imports/pr-000101.json"
+    assert pr["import_sha256"] == sha256_file(ws / pr["import_file"])
+    assert pr["requested_heads"] == ["final"]
+    assert pr["case_ids"] == ["pr-000101-" + "a" * 12]   # head from _PR_HEADER
+    assert (ws / "cases" / "pr-000101-aaaaaaaaaaaa.yaml").exists()
+
+
+def test_failed_fetch_leaves_no_import_file_and_ledger_error(tmp_path, fake_gh):
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.storage import load_yaml_strict
+
+    ws = tmp_path / "ws"
+    _seed_preflight(ws, fake_gh, pull_header=None)  # 404 -> fetch fails
+    rc = gi.run_import_prs(ws, pr_numbers=[101], heads=["final"])
+    assert rc != 0
+    raw = load_yaml_strict(ws / "benchmark.yaml")
+    pr = raw["pull_requests"][0]
+    assert pr["import_state"] == "fetch_failed"
+    assert pr["error"]["code"] and pr["error"]["message"]
+    assert pr["import_file"] is None and pr["import_sha256"] is None
+    assert not (ws / "imports" / "pr-000101.json").exists()
+
+
+def test_status_reflects_fetched_import_and_resolved_identity(tmp_path, fake_gh):
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.workspace import workspace_status
+
+    ws = tmp_path / "ws"
+    _seed_preflight(ws, fake_gh)
+    rc = gi.run_import_prs(ws, pr_numbers=[101], heads=["final"])
+    assert rc == 0
+    st = workspace_status(ws)
+    assert st.workspace_state != "empty"
+    assert st.repository_identity_resolved is True

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -120,3 +120,59 @@ def test_graphql_threads_and_replies_normalized(tmp_path, fake_gh):
     assert root.side == "RIGHT" and root.path == "a.py" and root.line == 4
     assert reply.kind == "thread_comment" and reply.reply_to_id == "c1"
     assert reply.thread_id == "thread_1"
+
+
+def test_candidate_projection_right_file_body_left(tmp_path, fake_gh):
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.schema import Location
+
+    ws = tmp_path / "ws"
+    (ws / "imports").mkdir(parents=True)
+    fake_gh.set_response("GET", "repos/o/r/pulls/101", _PR_HEADER)
+    fake_gh.set_response(
+        "GET",
+        "repos/o/r/pulls/101/reviews",
+        [
+            {"id": 5, "node_id": "PRR_5", "user": {"login": "alice", "type": "User"},
+             "body": "review body", "state": "COMMENTED", "commit_id": "a" * 40,
+             "submitted_at": "2026-01-01T00:00:00Z", "html_url": "https://github.com/o/r/pull/101#pullrequestreview-5"},
+            {"id": 6, "node_id": "PRR_6", "user": {"login": "alice", "type": "User"},
+             "body": "looks good", "state": "APPROVED", "commit_id": "a" * 40,
+             "submitted_at": "2026-01-01T00:00:00Z", "html_url": "https://github.com/o/r/pull/101#pullrequestreview-6"},
+        ],
+    )
+    fake_gh.set_response(
+        "GET",
+        "repos/o/r/pulls/101/comments",
+        [
+            {"id": 1, "node_id": "DIFF_1", "user": {"login": "alice", "type": "User"},
+             "body": "## note\nfix this", "path": "a.py", "line": 5, "start_line": 4,
+             "subject_type": "line", "side": "RIGHT", "start_side": None,
+             "commit_id": "a" * 40, "created_at": "2026-01-01T00:00:00Z",
+             "updated_at": "2026-01-01T00:00:00Z", "html_url": "https://github.com/o/r/pull/101#discussion_r1"},
+            {"id": 2, "node_id": "DIFF_2", "user": {"login": "alice", "type": "User"},
+             "body": "file-level", "subject_type": "file",
+             "commit_id": "a" * 40, "created_at": "2026-01-01T00:00:00Z",
+             "updated_at": "2026-01-01T00:00:00Z", "html_url": "https://github.com/o/r/pull/101#discussion_r2"},
+            {"id": 3, "node_id": "DIFF_3", "user": {"login": "alice", "type": "User"},
+             "body": "left-side", "path": "a.py", "line": 2, "start_line": 2,
+             "subject_type": "line", "side": "LEFT", "start_side": None,
+             "commit_id": "a" * 40, "created_at": "2026-01-01T00:00:00Z",
+             "updated_at": "2026-01-01T00:00:00Z", "html_url": "https://github.com/o/r/pull/101#discussion_r3"},
+        ],
+    )
+    fake_gh.set_response("GET", "repos/o/r/issues/101/comments", [])
+    fake_gh._write_threads([])
+    doc_gi = gi.fetch_and_normalize(ws, "o/r", 101, heads=["final"])
+    cands = gi.project_candidates(doc_gi, head_sha="a" * 40)
+    by_src = {c.source_id: c for c in cands}
+    right = by_src["github:inline_comment:1"]
+    assert right.title == "note" and "fix this" in right.body
+    assert right.severity is None
+    assert right.location == Location(path="a.py", start_line=4, end_line=5)
+    assert right.exact_acceptable is True
+    assert by_src["github:inline_comment:2"].location is None       # file-level
+    assert by_src["github:inline_comment:3"].exact_acceptable is False  # LEFT
+    assert by_src["github:review:5"].location is None               # review body
+    assert by_src["github:review:5"].exact_acceptable is True
+    assert "github:review:6" not in by_src                          # pure approval: no candidate

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -10,6 +10,20 @@ import json
 
 import pytest
 
+_PR_HEADER = {
+    "number": 101,
+    "url": "https://github.com/o/r/pull/101",
+    "title": "Fix cache",
+    "state": "open",
+    "base": {"ref": "main", "sha": "b" * 40},
+    "head": {"ref": "feature/cache", "sha": "a" * 40},
+    "merged_at": None,
+    "closed_at": None,
+    "created_at": "2026-01-01T00:00:00Z",
+    "updated_at": "2026-01-01T00:00:00Z",
+    "user": {"login": "alice", "type": "User"},
+}
+
 
 def test_preflight_gh_and_ls_remote_route_through_fake(tmp_path, fake_gh):
     from daydream.benchmark import github_import as gi
@@ -25,3 +39,48 @@ def test_preflight_gh_and_ls_remote_route_through_fake(tmp_path, fake_gh):
     assert login == {"login": "octocat", "type": "User"}
     assert "password=" in cred
     assert "refs/heads/head" in refs
+
+
+def test_fetch_normalizes_all_rest_evidence(tmp_path, fake_gh):
+    from daydream.benchmark import github_import as gi
+
+    ws = tmp_path / "ws"
+    (ws / "imports").mkdir(parents=True)
+    fake_gh.set_response("GET", "repos/o/r/pulls/101", _PR_HEADER)
+    fake_gh.set_response(
+        "GET",
+        "repos/o/r/pulls/101/reviews",
+        [
+            {"id": 1, "node_id": "PRR_1", "user": {"login": "alice", "type": "User"},
+             "body": "approved", "state": "APPROVED", "commit_id": "a" * 40,
+             "submitted_at": "2026-01-01T00:00:00Z", "html_url": "https://github.com/o/r/pull/101#pullrequestreview-1"},
+        ],
+    )
+    fake_gh.set_response(
+        "GET",
+        "repos/o/r/pulls/101/comments",
+        [
+            {"id": 7, "node_id": "DIFF_7", "user": {"login": "bot[bot]", "type": "Bot"},
+             "body": "please fix", "commit_id": "a" * 40, "original_commit_id": "a" * 40,
+             "path": "a.py", "original_position": 3, "line": 4, "original_line": 3,
+             "subject_type": "line", "side": "RIGHT", "created_at": "2026-01-01T00:00:00Z",
+             "updated_at": "2026-01-01T00:00:00Z", "html_url": "https://github.com/o/r/pull/101#discussion_r7"},
+        ],
+    )
+    fake_gh.set_response(
+        "GET",
+        "repos/o/r/issues/101/comments",
+        [
+            {"id": 9, "user": {"login": "carol", "type": "User"}, "body": "question",
+             "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",
+             "html_url": "https://github.com/o/r/pull/101#issuecomment-9"},
+        ],
+    )
+    doc = gi.fetch_and_normalize(ws, "o/r", 101, heads=["final"])
+    kinds = {e.kind for e in doc.evidence}
+    assert kinds == {"review", "inline_comment", "issue_comment"}
+    assert doc.evidence[0].source_id == "github:review:1"
+    assert doc.evidence[0].is_bot is False
+    assert doc.evidence[1].is_bot is True      # bot classification retained, not dropped
+    assert doc.evidence[1].subject_type == "line" and doc.evidence[1].side == "RIGHT"
+    assert all("--paginate" in (c.argv or []) for c in fake_gh.calls("GET"))

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -324,3 +324,26 @@ def test_status_reflects_fetched_import_and_resolved_identity(tmp_path, fake_gh)
     st = workspace_status(ws)
     assert st.workspace_state != "empty"
     assert st.repository_identity_resolved is True
+
+
+def test_cli_import_prs_drives_command(tmp_path, fake_gh, capsys):
+    from daydream.benchmark.cli import _handle_benchmark_command
+    from daydream.benchmark.storage import load_yaml_strict
+
+    ws = tmp_path / "ws"
+    _seed_preflight(ws, fake_gh)
+    rc = _handle_benchmark_command(["import-prs", str(ws), "--pr", "101", "--head", "a" * 40])
+    assert rc == 0
+    raw = load_yaml_strict(ws / "benchmark.yaml")
+    assert raw["pull_requests"][0]["import_state"] == "fetched"
+    out = capsys.readouterr().out
+    assert "octocat" in out and "private" in out        # preflight print: identity + visibility
+    assert "1" in out                                       # requested PR count
+    assert str(ws / "imports") in out                      # local destination
+
+
+def test_benchmark_help_lists_import_prs():
+    import subprocess
+
+    r = subprocess.run(["daydream", "benchmark", "--help"], capture_output=True, text=True)
+    assert r.returncode == 0 and "import-prs" in r.stdout

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -1,0 +1,27 @@
+"""Tests for ``daydream benchmark import-prs``.
+
+Task 0 spike: the load-bearing claim that the importer's ``gh``/``git``
+calls, made through :mod:`daydream.git_ops` with ``cwd=<workspace root>``,
+are intercepted by the in-process ``fake_gh`` router. Subsequent
+collection/normalization/projection/orchestration tasks build on this seam.
+"""
+
+import json
+
+import pytest
+
+
+def test_preflight_gh_and_ls_remote_route_through_fake(tmp_path, fake_gh):
+    from daydream.benchmark import github_import as gi
+
+    fake_gh.set_response("GET", "user", {"login": "octocat", "type": "User"})
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    status = gi._run_gh_preflight_status(ws)       # gh auth status --hostname github.com
+    login = gi._run_gh_api_user(ws)                # gh api user
+    cred = gi._gh_auth_git_credential(ws)          # gh auth git-credential
+    refs = gi._git_ls_remote(ws, "https://github.com/o/r.git")  # git ls-remote
+    assert status.returncode == 0
+    assert login == {"login": "octocat", "type": "User"}
+    assert "password=" in cred
+    assert "refs/heads/head" in refs

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -190,3 +190,32 @@ def test_parse_targets_dedupes_and_orders(tmp_path):
     )
     assert targets.pr_numbers == [9, 7, 42]     # stable: CLI order then file order; dupes collapsed
     assert targets.requested_heads == ["final", "abc" * 13 + "1", "abc" * 13 + "2"]  # 'final' always present
+
+
+def _seed_manifest(ws):
+    """Build an initialized private workspace with an unresolved Source (o/r)."""
+    from daydream.benchmark.workspace import init_workspace
+
+    init_workspace(ws, "o/r", ["h1.example.com"], ["h2.example.com"])
+
+
+def test_preflight_six_checks_in_order_and_atomic_identity(tmp_path, fake_gh):
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.storage import load_yaml_strict
+
+    ws = tmp_path / "ws"
+    _seed_manifest(ws)  # Source(provider=github, hostname=github.com, repository=o/r, repository_id=None, visibility=unresolved)
+    fake_gh.set_response("GET", "user", {"login": "octocat", "type": "User"})
+    fake_gh.set_response(
+        "repo-view-full",
+        value={"id": 5, "nameWithOwner": "o/r",
+               "url": "https://github.com/o/r", "visibility": "PRIVATE", "defaultBranchRef": {"name": "main"}},
+    )
+    out = gi.preflight(ws, pr_count=2)
+    assert out.login == "octocat" and out.repository_id == 5 and out.visibility == "private"
+    # identity written atomically into benchmark.yaml source block
+    raw = load_yaml_strict(ws / "benchmark.yaml")
+    assert raw["source"]["repository_id"] == 5 and raw["source"]["visibility"] == "private"
+    # second preflight is a no-op on identity (immutable, already resolved)
+    out2 = gi.preflight(ws, pr_count=1)
+    assert out2.repository_id == 5

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -338,8 +338,66 @@ def test_cli_import_prs_drives_command(tmp_path, fake_gh, capsys):
     assert raw["pull_requests"][0]["import_state"] == "fetched"
     out = capsys.readouterr().out
     assert "octocat" in out and "private" in out        # preflight print: identity + visibility
-    assert "1" in out                                       # requested PR count
+    assert "1" in out                                        # requested PR count
     assert str(ws / "imports") in out                      # local destination
+
+
+def _curate_case(ws, case_file):
+    """Mark a materialized case ready + attested with one historical finding."""
+    import yaml
+
+    from daydream.benchmark.schema import derive_finding_id
+    from daydream.benchmark.storage import load_yaml_strict
+
+    path = ws / "cases" / case_file
+    raw = load_yaml_strict(path)
+    finding = {
+        "title": "bot asks to fix the cache",
+        "body": "please fix",
+        "severity": "low",
+        "location": {"path": "a.py", "start_line": 4, "end_line": 4},
+        "provenance": {"kind": "historical", "source_ids": ["github:inline_comment:1"]},
+    }
+    finding["finding_id"] = derive_finding_id(finding)
+    raw["curation"] = {
+        "state": "ready",
+        "snapshot_attested": True,
+        "clean_attested": False,
+        "gold_status": "findings",
+        "findings": [finding],
+        "exclusions": [],
+        "case_exclusion": None,
+    }
+    path.write_text(yaml.safe_dump(raw, sort_keys=False))
+
+
+def test_refresh_marks_stale_and_never_overwrites_curation(tmp_path, fake_gh):
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.storage import load_yaml_strict
+
+    ws = tmp_path / "ws"
+    _seed_preflight(ws, fake_gh)   # seed REST with one evidence record via the comment fixture below
+    fake_gh.set_response(
+        "GET",
+        "repos/o/r/pulls/101/comments",
+        [
+            {"id": 1, "node_id": "DIFF_1", "user": {"login": "bot[bot]", "type": "Bot"},
+             "body": "please fix", "commit_id": "a" * 40, "original_commit_id": "a" * 40,
+             "path": "a.py", "line": 4, "subject_type": "line", "side": "RIGHT",
+             "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",
+             "html_url": "https://github.com/o/r/pull/101#discussion_r1"},
+        ],
+    )
+    rc = gi.run_import_prs(ws, pr_numbers=[101], heads=["final"])
+    assert rc == 0
+    _curate_case(ws, "pr-000101-aaaaaaaaaaaa.yaml")   # curation.state=ready, snapshot_attested=True
+    # refresh re-fetches; the referenced evidence now disappears
+    fake_gh.set_response("GET", "repos/o/r/pulls/101/comments", [])
+    rc = gi.run_import_prs(ws, pr_numbers=[101], heads=["final"], refresh=True)
+    assert rc == 0
+    case = load_yaml_strict(ws / "cases" / "pr-000101-aaaaaaaaaaaa.yaml")
+    assert case["curation"]["state"] == "stale" and case["curation"]["snapshot_attested"] is False
+    assert case["curation"]["findings"]              # prior curated findings preserved
 
 
 def test_benchmark_help_lists_import_prs():

--- a/tests/test_benchmark_workspace_schema.py
+++ b/tests/test_benchmark_workspace_schema.py
@@ -1,3 +1,4 @@
+import hashlib
 import tomllib
 from pathlib import Path
 
@@ -7,6 +8,8 @@ from pydantic import ValidationError
 from daydream.benchmark.schema import (
     BenchmarkManifest,
     CaseDocument,
+    EvidenceRecord,
+    ImportDocument,
     PullRequestEntry,
     TransitionError,
     case_id_for,
@@ -130,6 +133,59 @@ def test_ledger_entry_valid_and_fetch_failed_error_shape():
         error={"code": "E_AUTH", "message": "no access"},
     )
     assert failed.error["code"] == "E_AUTH"
+
+
+def _evidence(kind, db_id, **kw):
+    body = "see above"
+    base = {
+        "source_id": f"github:{kind}:{db_id}", "kind": kind, "database_id": db_id,
+        "node_id": "N1", "author": {"login": "bot[bot]", "type": "Bot"},
+        "body": body, "body_sha256": hashlib.sha256(body.encode()).hexdigest(),
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z", "submitted_at": None, "is_bot": True,
+        "url": "https://github.com/o/r/pull/1#discussion_r1",
+    }
+    base.update(kw)
+    return base
+
+
+def _valid_import_document():
+    return {
+        "schema_version": 1,
+        "repository": {"id": 5, "name_with_owner": "o/r", "visibility": "private"},
+        "pull_request": {
+            "number": 101,
+            "url": "https://github.com/o/r/pull/101",
+            "title": "Fix cache",
+            "state": "open",
+            "base": {"ref": "main", "sha": "b" * 40},
+            "head": {"ref": "feature/cache", "sha": "h" * 40},
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+            "author": {"login": "alice", "type": "User"},
+        },
+        "evidence": [_evidence("inline_comment", 7)],
+        "fetch": {"fetched_at": "2026-01-01T00:00:00Z", "etag": None, "payload_sha256": "a" * 64},
+    }
+
+
+def test_import_document_validates_and_forbids_unknown():
+    doc = _valid_import_document()
+    assert ImportDocument.model_validate(doc).pull_request["number"] == 101
+    doc["bogus"] = True
+    with pytest.raises(ValidationError):
+        ImportDocument.model_validate(doc)
+
+
+def test_evidence_requires_canonical_source_id_and_body_hash():
+    e = _evidence("inline_comment", 7)
+    e["source_id"] = "not-canonical"
+    with pytest.raises(ValidationError):
+        EvidenceRecord.model_validate(e)
+    e2 = _evidence("inline_comment", 8)
+    e2["body_sha256"] = "zz"
+    with pytest.raises(ValidationError):
+        EvidenceRecord.model_validate(e2)
 
 
 def _valid_case_dict():

--- a/tests/test_benchmark_workspace_schema.py
+++ b/tests/test_benchmark_workspace_schema.py
@@ -366,7 +366,14 @@ def test_gold_status_and_mode_derived():
 
 @pytest.mark.parametrize(
     "frm,to",
-    [("pending", "fetched"), ("pending", "fetch_failed"), ("fetch_failed", "fetched"), ("fetched", "fetched")],
+    [
+        ("pending", "fetched"),
+        ("pending", "fetch_failed"),
+        ("fetch_failed", "fetched"),
+        ("fetch_failed", "fetch_failed"),
+        ("fetched", "fetched"),
+        ("fetched", "fetch_failed"),
+    ],
 )
 def test_valid_pr_transitions(frm, to):
     validate_pr_transition(frm, to)  # must not raise

--- a/tests/test_benchmark_workspace_storage.py
+++ b/tests/test_benchmark_workspace_storage.py
@@ -192,3 +192,35 @@ def test_crash_injection_at_every_boundary_restores_before_or_after(tmp_path):
             assert not (tmp_path / "transactions").exists() or not list(
                 (tmp_path / "transactions").iterdir()
             )
+
+
+def test_import_crash_transaction_restores_before_or_after(tmp_path):
+    # The import writes {import file, case, benchmark.yaml} as one atomic unit.
+    # Driving crater recovery across that whole set proves a crash at any
+    # boundary leaves the complete before- or after-state, never a mix.
+    for boundary in ("journal", "data", "manifest"):
+        imp = tmp_path / "imports" / "pr-000101.json"
+        case = tmp_path / "cases" / "pr-000101-aaaaaaaaaaaa.yaml"
+        manifest = tmp_path / "benchmark.yaml"
+        for f in (imp, case):
+            f.parent.mkdir(parents=True, exist_ok=True)
+            f.write_text("before")
+        manifest.write_text("ledger-before")
+        with Transaction(tmp_path, op_id=f"imp-{boundary}", kind="import") as tx:
+            tx.stage("imports/pr-000101.json", b"import-after")
+            tx.stage("cases/pr-000101-aaaaaaaaaaaa.yaml", b"case-after")
+            tx.stage("benchmark.yaml", b"ledger-after")
+            tx.inject_crash(boundary)
+        recover_startup(tmp_path)
+        if boundary in ("journal", "data"):
+            assert imp.read_text() == "before"
+            assert case.read_text() == "before"
+            assert manifest.read_text() == "ledger-before"
+        else:  # manifest (complete journal kept)
+            assert imp.read_text() == "import-after"
+            assert case.read_text() == "case-after"
+            assert manifest.read_text() == "ledger-after"
+        if boundary in ("journal", "data", "manifest"):
+            assert not (tmp_path / "transactions").exists() or not list(
+                (tmp_path / "transactions").iterdir()
+            )


### PR DESCRIPTION
## Summary
Adds the `daydream bench import-prs` command to import explicit private GitHub PR evidence for benchmarking. Handles preflight + immutable repository identity resolution, REST PR evidence pagination/normalization, GraphQL review threads/replies, atomic import with ledger + case transaction and crash recovery, refresh/staleness semantics, and rate-limit retry honoring Retry-After.

## Key changes
- New `daydream/benchmark/github_import.py` (import surface)
- `benchmark` CLI, schema, and `git_ops` integration
- `docs/benchmark.md` documentation
- Real-path end-to-end acceptance tests with fake gh

## Test Plan
- `make check` green (3982 passed / 6 skipped)
- End-to-end import-prs acceptance with fake gh
- Regression tests for curation preservation, cases dedup, GraphQL rate-limit retry

Closes #772