### PR TITLE
feat(benchmark): define review scoring and clean-case semantics

### DIFF
--- a/daydream/benchmark/harbor/__init__.py
+++ b/daydream/benchmark/harbor/__init__.py
@@ -1,0 +1,8 @@
+"""Daydream Harbor verifier core.
+
+A stdlib-only source of truth for pure review scoring: strict gold/candidate/
+reward models, deterministic candidate-ID derivation, maximum-cardinality
+one-to-one matching over injected verdicts, per-task reward, and corpus micro
+metrics. Imports only the Python standard library so issue #7 can copy this
+module byte-for-byte into judge-free verifier images.
+"""

--- a/daydream/benchmark/harbor/verifier_core.py
+++ b/daydream/benchmark/harbor/verifier_core.py
@@ -1,0 +1,22 @@
+"""Pure review scoring core for the Daydream Harbor verifier.
+
+Stdlib-only (dataclasses, hashlib, json, re, math) so this module can be
+copied byte-for-byte into a judge-free Harbor verifier image. No daydream
+source, no pydantic, no third-party imports.
+"""
+
+from __future__ import annotations
+
+import re
+
+MAX_ARTIFACT_BYTES = 1_048_576
+MAX_CANDIDATE_FINDINGS = 100
+MAX_GOLD_FINDINGS = 50
+CONFIDENCE_THRESHOLD = 0.7
+
+_SEP = "\x1f"
+_HEX64 = re.compile(r"^[0-9a-f]{64}$")
+
+
+class VerifierError(Exception):
+    """Raised on any invalid verifier input (mirrors a pydantic error)."""

--- a/daydream/benchmark/harbor/verifier_core.py
+++ b/daydream/benchmark/harbor/verifier_core.py
@@ -8,6 +8,7 @@ source, no pydantic, no third-party imports.
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 
 MAX_ARTIFACT_BYTES = 1_048_576
 MAX_CANDIDATE_FINDINGS = 100
@@ -20,3 +21,163 @@ _HEX64 = re.compile(r"^[0-9a-f]{64}$")
 
 class VerifierError(Exception):
     """Raised on any invalid verifier input (mirrors a pydantic error)."""
+
+
+# ---------------------------------------------------------------------------
+# field validators
+# ---------------------------------------------------------------------------
+
+
+def _validate_hex64(value: object, field: str) -> str:
+    if not isinstance(value, str) or not _HEX64.fullmatch(value):
+        raise VerifierError(f"{field} must be 64-hex, got {value!r}")
+    return value
+
+
+def _validate_title(value: object) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise VerifierError(f"title must not be blank, got {value!r}")
+    if "\x00" in value:
+        raise VerifierError("title must not contain NUL")
+    if len(value.encode("utf-8")) > 500:
+        raise VerifierError("title exceeds 500 UTF-8 bytes")
+    return value
+
+
+def _validate_body(value: object) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise VerifierError(f"body must not be blank, got {value!r}")
+    if "\x00" in value:
+        raise VerifierError("body must not contain NUL")
+    if len(value.encode("utf-8")) > 8 * 1024:
+        raise VerifierError("body exceeds 8 KiB")
+    return value
+
+
+def _validate_severity(value: object) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or value not in ("high", "medium", "low"):
+        raise VerifierError(f"severity must be high/medium/low or null, got {value!r}")
+    return value
+
+
+def _validate_path(value: object) -> str:
+    if not isinstance(value, str) or not value:
+        raise VerifierError(f"path must not be blank, got {value!r}")
+    if value.startswith("/"):
+        raise VerifierError(f"path must be relative, got {value!r}")
+    if value == ".." or value.startswith("../") or "/../" in value or value.endswith("/.."):
+        raise VerifierError(f"path must not contain '..' segments: {value!r}")
+    if "\x00" in value:
+        raise VerifierError("path must not contain NUL")
+    return value
+
+
+def _validate_lines(start_line: object, end_line: object) -> tuple[int, int]:
+    if not isinstance(start_line, int) or isinstance(start_line, bool):
+        raise VerifierError(f"start_line must be an integer, got {start_line!r}")
+    if not isinstance(end_line, int) or isinstance(end_line, bool):
+        raise VerifierError(f"end_line must be an integer, got {end_line!r}")
+    if start_line < 1 or end_line < 1:
+        raise VerifierError("start_line/end_line must be positive")
+    if start_line > end_line:
+        raise VerifierError("start_line must be <= end_line")
+    return start_line, end_line
+
+
+def _content_fields(raw: dict[str, object]) -> dict[str, object]:
+    """Validate the content fields shared by gold and candidate findings."""
+    try:
+        return {
+            "title": _validate_title(raw["title"]),
+            "body": _validate_body(raw["body"]),
+            "severity": _validate_severity(raw.get("severity")),
+            "path": _validate_path(raw["path"]),
+            "start_line": raw["start_line"],
+            "end_line": raw["end_line"],
+        }
+    except KeyError as exc:
+        raise VerifierError(f"missing required field {exc.args[0]}") from exc
+
+
+@dataclass(frozen=True)
+class GoldFinding:
+    """A hidden gold finding, validated with schema.py Finding limits."""
+
+    finding_id: str
+    title: str
+    body: str
+    severity: str | None
+    path: str
+    start_line: int
+    end_line: int
+
+    def __post_init__(self) -> None:
+        _validate_hex64(self.finding_id, "finding id")
+        _validate_title(self.title)
+        _validate_body(self.body)
+        _validate_severity(self.severity)
+        _validate_path(self.path)
+        _validate_lines(self.start_line, self.end_line)
+
+
+@dataclass(frozen=True)
+class CandidateFinding:
+    """A daydream candidate finding, validated with schema.py Finding limits."""
+
+    candidate_id: str
+    title: str
+    body: str
+    severity: str | None
+    path: str
+    start_line: int
+    end_line: int
+
+    def __post_init__(self) -> None:
+        _validate_hex64(self.candidate_id, "candidate id")
+        _validate_title(self.title)
+        _validate_body(self.body)
+        _validate_severity(self.severity)
+        _validate_path(self.path)
+        _validate_lines(self.start_line, self.end_line)
+
+
+def parse_gold_finding(raw: dict[str, object]) -> GoldFinding:
+    """Validate a raw gold-finding dict and return a GoldFinding."""
+    if not isinstance(raw, dict):
+        raise VerifierError("gold finding must be a dict")
+    try:
+        ident = _validate_hex64(raw["finding_id"], "finding_id")
+    except KeyError as exc:
+        raise VerifierError(f"missing required field {exc.args[0]}") from exc
+    fields = _content_fields(raw)
+    return GoldFinding(
+        finding_id=ident,
+        title=fields["title"],  # type: ignore[arg-type]
+        body=fields["body"],  # type: ignore[arg-type]
+        severity=fields["severity"],  # type: ignore[arg-type]
+        path=fields["path"],  # type: ignore[arg-type]
+        start_line=fields["start_line"],  # type: ignore[arg-type]
+        end_line=fields["end_line"],  # type: ignore[arg-type]
+    )
+
+
+def parse_candidate_finding(raw: dict[str, object]) -> CandidateFinding:
+    """Validate a raw candidate-finding dict and return a CandidateFinding."""
+    if not isinstance(raw, dict):
+        raise VerifierError("candidate finding must be a dict")
+    try:
+        ident = _validate_hex64(raw["candidate_id"], "candidate_id")
+    except KeyError as exc:
+        raise VerifierError(f"missing required field {exc.args[0]}") from exc
+    fields = _content_fields(raw)
+    return CandidateFinding(
+        candidate_id=ident,
+        title=fields["title"],  # type: ignore[arg-type]
+        body=fields["body"],  # type: ignore[arg-type]
+        severity=fields["severity"],  # type: ignore[arg-type]
+        path=fields["path"],  # type: ignore[arg-type]
+        start_line=fields["start_line"],  # type: ignore[arg-type]
+        end_line=fields["end_line"],  # type: ignore[arg-type]
+    )

--- a/daydream/benchmark/harbor/verifier_core.py
+++ b/daydream/benchmark/harbor/verifier_core.py
@@ -325,3 +325,59 @@ def retained_edges(
         and v.gold_id in gold_set
         and v.candidate_id in cand_set
     ]
+
+
+# ---------------------------------------------------------------------------
+# maximum-cardinality one-to-one matching
+# ---------------------------------------------------------------------------
+
+
+def _edge_key(v: Verdict) -> tuple[float, str, str]:
+    return (-v.confidence, v.gold_id, v.candidate_id)
+
+
+def maximum_matching(
+    verdicts: list[Verdict],
+    gold_ids: list[str],
+    candidate_ids: list[str],
+) -> set[tuple[str, str]]:
+    """Maximum-cardinality one-to-one matching over retained verdict edges.
+
+    Edges are ordered deterministically (descending confidence, then gold ID,
+    then candidate ID); golds are visited in sorted-id order and candidates in
+    the fixed adjacency order, so the result is stable run-to-run. Never
+    iterates a set/dict for an ordering decision.
+    """
+    ordered = sorted(verdicts, key=_edge_key)
+    adjacency: dict[str, list[str]] = {}
+    for v in ordered:
+        adjacency.setdefault(v.gold_id, []).append(v.candidate_id)
+    gold_order = sorted(gold_ids)
+
+    match_candidate: dict[str, str] = {}  # candidate_id -> gold_id
+
+    def _first_free(gold: str) -> str | None:
+        for cand in adjacency.get(gold, []):
+            if cand not in match_candidate:
+                return cand
+        return None
+
+    def _augment(gold: str, seen: set[str]) -> bool:
+        for cand in adjacency.get(gold, []):
+            if cand in seen:
+                continue
+            seen.add(cand)
+            owner = match_candidate.get(cand)
+            if owner is None or _augment(owner, seen):
+                match_candidate[cand] = gold
+                return True
+        return False
+
+    for gold in gold_order:
+        free = _first_free(gold)
+        if free is not None:
+            match_candidate[free] = gold
+        else:
+            _augment(gold, set())
+
+    return {(match_candidate[c], c) for c in match_candidate}

--- a/daydream/benchmark/harbor/verifier_core.py
+++ b/daydream/benchmark/harbor/verifier_core.py
@@ -368,51 +368,18 @@ def maximum_matching(
 class Reward:
     """The 12-field §10 per-task reward output."""
 
-    reward: float
-    tp: int
-    fp: int
-    fn: int
-    precision: float
-    recall: float
-    f1: float
-    gold_count: int
-    candidate_count: int
-    clean_task: int
-    clean_pass: int
-    verifier_error: int
-
-    @classmethod
-    def _make(
-        cls,
-        *,
-        reward: float = 0.0,
-        tp: int = 0,
-        fp: int = 0,
-        fn: int = 0,
-        precision: float = 0.0,
-        recall: float = 0.0,
-        f1: float = 0.0,
-        gold_count: int = 0,
-        candidate_count: int = 0,
-        clean_task: int = 0,
-        clean_pass: int = 0,
-        verifier_error: int = 0,
-    ) -> "Reward":
-        """Build a Reward with the 12 \u00a710 fields defaulting to zero."""
-        return cls(
-            reward=reward,
-            tp=tp,
-            fp=fp,
-            fn=fn,
-            precision=precision,
-            recall=recall,
-            f1=f1,
-            gold_count=gold_count,
-            candidate_count=candidate_count,
-            clean_task=clean_task,
-            clean_pass=clean_pass,
-            verifier_error=verifier_error,
-        )
+    reward: float = 0.0
+    tp: int = 0
+    fp: int = 0
+    fn: int = 0
+    precision: float = 0.0
+    recall: float = 0.0
+    f1: float = 0.0
+    gold_count: int = 0
+    candidate_count: int = 0
+    clean_task: int = 0
+    clean_pass: int = 0
+    verifier_error: int = 0
 
     def to_dict(self) -> dict[str, float | int]:
         """Numeric-only dict with exactly the 12 §10 keys."""
@@ -449,7 +416,7 @@ def _finding_id(finding: object) -> str:
 
 
 def _empty_side_error(gold_count: int) -> Reward:
-    return Reward._make(reward=0.0, gold_count=gold_count, verifier_error=1)
+    return Reward(reward=0.0, gold_count=gold_count, verifier_error=1)
 
 
 def score_review(
@@ -466,17 +433,17 @@ def score_review(
     candidate_count = len(candidates)
 
     if gold_count == 0 and candidate_count == 0:
-        return Reward._make(
+        return Reward(
             reward=1.0, precision=1.0, recall=1.0, f1=1.0,
             clean_task=1, clean_pass=1,
         )
     if gold_count == 0:
-        return Reward._make(
+        return Reward(
             fp=candidate_count, recall=1.0,
             candidate_count=candidate_count, clean_task=1,
         )
     if candidate_count == 0:
-        return Reward._make(
+        return Reward(
             fn=gold_count, precision=1.0, gold_count=gold_count,
         )
 
@@ -490,7 +457,7 @@ def score_review(
     precision = tp / (tp + fp) if (tp + fp) else 1.0
     recall = tp / (tp + fn) if (tp + fn) else 1.0
     f1 = 0.0 if tp == 0 else _f1(precision, recall)
-    return Reward._make(
+    return Reward(
         reward=f1,
         tp=tp,
         fp=fp,
@@ -551,7 +518,7 @@ def reward_details(
         "matches": [
             {"gold_id": g, "candidate_id": c} for g, c in sorted(matches)
         ],
-        "unmatched_gold": [gid for gid in gold_ids if gid not in matched_gold],
+        "unmatched_gold": sorted(gid for gid in gold_ids if gid not in matched_gold),
         "unmatched_candidates": sorted(
             cid for cid in cand_ids if cid not in matched_candidates
         ),
@@ -600,7 +567,10 @@ def aggregate_metrics(rows: list[dict[str, object] | None]) -> dict[str, float |
     mean_task_score = sum(rewards) / task_count if task_count else 1.0
     micro_precision = total_tp / (total_tp + total_fp) if (total_tp + total_fp) else 1.0
     micro_recall = total_tp / (total_tp + total_fn) if (total_tp + total_fn) else 1.0
-    micro_f1 = _f1(micro_precision, micro_recall)
+    if total_tp == 0 and (total_tp + total_fp > 0 or total_tp + total_fn > 0):
+        micro_f1 = 0.0
+    else:
+        micro_f1 = _f1(micro_precision, micro_recall)
     clean_accuracy = clean_correct / clean_total if clean_total else 1.0
 
     return {

--- a/daydream/benchmark/harbor/verifier_core.py
+++ b/daydream/benchmark/harbor/verifier_core.py
@@ -8,6 +8,7 @@ source, no pydantic, no third-party imports.
 from __future__ import annotations
 
 import hashlib
+import json
 import re
 from dataclasses import dataclass
 
@@ -223,3 +224,59 @@ def _component_int(finding: object, name: str) -> int:
     if isinstance(value, bool) or not isinstance(value, int):
         raise VerifierError(f"{name} must be an integer, got {value!r}")
     return value
+
+
+# ---------------------------------------------------------------------------
+# candidate artifact + gold set validation
+# ---------------------------------------------------------------------------
+
+
+def _canonical_tuple(finding: object) -> tuple[object, ...]:
+    return (
+        str(_finding_component(finding, "title") or ""),
+        str(_finding_component(finding, "body") or ""),
+        str(_finding_component(finding, "severity") or ""),
+        str(_finding_component(finding, "path")),
+        _component_int(finding, "start_line"),
+        _component_int(finding, "end_line"),
+    )
+
+
+def validate_candidate_artifact(raw: dict[str, object]) -> list[CandidateFinding]:
+    """Validate a §9 candidate artifact and return its parsed findings."""
+    if not isinstance(raw, dict):
+        raise VerifierError("candidate artifact must be a dict")
+    try:
+        schema_version = raw["schema_version"]
+        case_id = raw["case_id"]
+        base_ref = raw["base_ref"]
+        head_ref = raw["head_ref"]
+        findings = raw["findings"]
+    except KeyError as exc:
+        raise VerifierError(f"missing artifact field {exc.args[0]}") from exc
+    if schema_version != 1:
+        raise VerifierError(f"unsupported schema_version {schema_version!r}")
+    if not isinstance(case_id, str) or not isinstance(base_ref, str) or not isinstance(head_ref, str):
+        raise VerifierError("case_id/base_ref/head_ref must be strings")
+    if len(json.dumps(raw).encode("utf-8")) > MAX_ARTIFACT_BYTES:
+        raise VerifierError("candidate artifact exceeds 1 MiB")
+    if not isinstance(findings, list):
+        raise VerifierError("artifact findings must be a list")
+    if len(findings) > MAX_CANDIDATE_FINDINGS:
+        raise VerifierError("candidate artifact exceeds 100 findings")
+
+    parsed = [parse_candidate_finding(f) for f in findings]  # type: ignore[arg-type]
+
+    seen: dict[tuple[object, ...], int] = {}
+    ids: set[str] = set()
+    for finding in parsed:
+        canon = _canonical_tuple(finding)
+        ordinal = seen.get(canon, 0)
+        seen[canon] = ordinal + 1
+        expected = derive_candidate_id(case_id, finding, ordinal)
+        if finding.candidate_id != expected:
+            raise VerifierError("candidate_id does not match the derived id")
+        if finding.candidate_id in ids:
+            raise VerifierError("duplicate candidate_id in artifact")
+        ids.add(finding.candidate_id)
+    return parsed

--- a/daydream/benchmark/harbor/verifier_core.py
+++ b/daydream/benchmark/harbor/verifier_core.py
@@ -1,6 +1,6 @@
 """Pure review scoring core for the Daydream Harbor verifier.
 
-Stdlib-only (dataclasses, hashlib, json, re, math) so this module can be
+Stdlib-only (dataclasses, hashlib, json, re) so this module can be
 copied byte-for-byte into a judge-free Harbor verifier image. No daydream
 source, no pydantic, no third-party imports.
 """
@@ -104,10 +104,9 @@ def _content_fields(raw: dict[str, object]) -> dict[str, object]:
 
 
 @dataclass(frozen=True)
-class GoldFinding:
-    """A hidden gold finding, validated with schema.py Finding limits."""
+class _FindingContent:
+    """Content fields shared by gold and candidate findings."""
 
-    finding_id: str
     title: str
     body: str
     severity: str | None
@@ -116,7 +115,6 @@ class GoldFinding:
     end_line: int
 
     def __post_init__(self) -> None:
-        _validate_hex64(self.finding_id, "finding id")
         _validate_title(self.title)
         _validate_body(self.body)
         _validate_severity(self.severity)
@@ -125,64 +123,50 @@ class GoldFinding:
 
 
 @dataclass(frozen=True)
-class CandidateFinding:
+class GoldFinding(_FindingContent):
+    """A hidden gold finding, validated with schema.py Finding limits."""
+
+    finding_id: str
+
+    def __post_init__(self) -> None:
+        _validate_hex64(self.finding_id, "finding id")
+        super().__post_init__()
+
+
+@dataclass(frozen=True)
+class CandidateFinding(_FindingContent):
     """A daydream candidate finding, validated with schema.py Finding limits."""
 
     candidate_id: str
-    title: str
-    body: str
-    severity: str | None
-    path: str
-    start_line: int
-    end_line: int
 
     def __post_init__(self) -> None:
         _validate_hex64(self.candidate_id, "candidate id")
-        _validate_title(self.title)
-        _validate_body(self.body)
-        _validate_severity(self.severity)
-        _validate_path(self.path)
-        _validate_lines(self.start_line, self.end_line)
+        super().__post_init__()
+
+
+def _finding_kwargs(
+    raw: dict[str, object], *, side: str, id_key: str
+) -> dict[str, object]:
+    """Validate a raw finding dict and return its model constructor kwargs."""
+    if not isinstance(raw, dict):
+        raise VerifierError(f"{side} finding must be a dict")
+    try:
+        ident = _validate_hex64(raw[id_key], id_key)
+    except KeyError as exc:
+        raise VerifierError(f"missing required field {exc.args[0]}") from exc
+    fields = _content_fields(raw)
+    fields[id_key] = ident
+    return fields
 
 
 def parse_gold_finding(raw: dict[str, object]) -> GoldFinding:
     """Validate a raw gold-finding dict and return a GoldFinding."""
-    if not isinstance(raw, dict):
-        raise VerifierError("gold finding must be a dict")
-    try:
-        ident = _validate_hex64(raw["finding_id"], "finding_id")
-    except KeyError as exc:
-        raise VerifierError(f"missing required field {exc.args[0]}") from exc
-    fields = _content_fields(raw)
-    return GoldFinding(
-        finding_id=ident,
-        title=fields["title"],  # type: ignore[arg-type]
-        body=fields["body"],  # type: ignore[arg-type]
-        severity=fields["severity"],  # type: ignore[arg-type]
-        path=fields["path"],  # type: ignore[arg-type]
-        start_line=fields["start_line"],  # type: ignore[arg-type]
-        end_line=fields["end_line"],  # type: ignore[arg-type]
-    )
+    return GoldFinding(**_finding_kwargs(raw, side="gold", id_key="finding_id"))  # type: ignore[arg-type]
 
 
 def parse_candidate_finding(raw: dict[str, object]) -> CandidateFinding:
     """Validate a raw candidate-finding dict and return a CandidateFinding."""
-    if not isinstance(raw, dict):
-        raise VerifierError("candidate finding must be a dict")
-    try:
-        ident = _validate_hex64(raw["candidate_id"], "candidate_id")
-    except KeyError as exc:
-        raise VerifierError(f"missing required field {exc.args[0]}") from exc
-    fields = _content_fields(raw)
-    return CandidateFinding(
-        candidate_id=ident,
-        title=fields["title"],  # type: ignore[arg-type]
-        body=fields["body"],  # type: ignore[arg-type]
-        severity=fields["severity"],  # type: ignore[arg-type]
-        path=fields["path"],  # type: ignore[arg-type]
-        start_line=fields["start_line"],  # type: ignore[arg-type]
-        end_line=fields["end_line"],  # type: ignore[arg-type]
-    )
+    return CandidateFinding(**_finding_kwargs(raw, side="candidate", id_key="candidate_id"))  # type: ignore[arg-type]
 
 
 # ---------------------------------------------------------------------------
@@ -206,15 +190,7 @@ def derive_candidate_id(
     ordinal: int,
 ) -> str:
     """Return the deterministic sha256 candidate id for a finding."""
-    title = str(_finding_component(finding, "title") or "")
-    body = str(_finding_component(finding, "body") or "")
-    severity = str(_finding_component(finding, "severity") or "")
-    path = str(_finding_component(finding, "path"))
-    start_line = _component_int(finding, "start_line")
-    end_line = _component_int(finding, "end_line")
-    canonical = _SEP.join(
-        [title, body, severity, path, str(start_line), str(end_line)]
-    )
+    canonical = _SEP.join(str(part) for part in _canonical_tuple(finding))
     payload = _SEP.join([str(case_key), canonical, str(ordinal)])
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
@@ -405,6 +381,39 @@ class Reward:
     clean_pass: int
     verifier_error: int
 
+    @classmethod
+    def _make(
+        cls,
+        *,
+        reward: float = 0.0,
+        tp: int = 0,
+        fp: int = 0,
+        fn: int = 0,
+        precision: float = 0.0,
+        recall: float = 0.0,
+        f1: float = 0.0,
+        gold_count: int = 0,
+        candidate_count: int = 0,
+        clean_task: int = 0,
+        clean_pass: int = 0,
+        verifier_error: int = 0,
+    ) -> "Reward":
+        """Build a Reward with the 12 \u00a710 fields defaulting to zero."""
+        return cls(
+            reward=reward,
+            tp=tp,
+            fp=fp,
+            fn=fn,
+            precision=precision,
+            recall=recall,
+            f1=f1,
+            gold_count=gold_count,
+            candidate_count=candidate_count,
+            clean_task=clean_task,
+            clean_pass=clean_pass,
+            verifier_error=verifier_error,
+        )
+
     def to_dict(self) -> dict[str, float | int]:
         """Numeric-only dict with exactly the 12 §10 keys."""
         return {
@@ -440,20 +449,7 @@ def _finding_id(finding: object) -> str:
 
 
 def _empty_side_error(gold_count: int) -> Reward:
-    return Reward(
-        reward=0.0,
-        tp=0,
-        fp=0,
-        fn=0,
-        precision=0.0,
-        recall=0.0,
-        f1=0.0,
-        gold_count=gold_count,
-        candidate_count=0,
-        clean_task=0,
-        clean_pass=0,
-        verifier_error=1,
-    )
+    return Reward._make(reward=0.0, gold_count=gold_count, verifier_error=1)
 
 
 def score_review(
@@ -470,49 +466,18 @@ def score_review(
     candidate_count = len(candidates)
 
     if gold_count == 0 and candidate_count == 0:
-        return Reward(
-            reward=1.0,
-            tp=0,
-            fp=0,
-            fn=0,
-            precision=1.0,
-            recall=1.0,
-            f1=1.0,
-            gold_count=0,
-            candidate_count=0,
-            clean_task=1,
-            clean_pass=1,
-            verifier_error=0,
+        return Reward._make(
+            reward=1.0, precision=1.0, recall=1.0, f1=1.0,
+            clean_task=1, clean_pass=1,
         )
     if gold_count == 0:
-        return Reward(
-            reward=0.0,
-            tp=0,
-            fp=candidate_count,
-            fn=0,
-            precision=0.0,
-            recall=1.0,
-            f1=0.0,
-            gold_count=0,
-            candidate_count=candidate_count,
-            clean_task=1,
-            clean_pass=0,
-            verifier_error=0,
+        return Reward._make(
+            fp=candidate_count, recall=1.0,
+            candidate_count=candidate_count, clean_task=1,
         )
     if candidate_count == 0:
-        return Reward(
-            reward=0.0,
-            tp=0,
-            fp=0,
-            fn=gold_count,
-            precision=1.0,
-            recall=0.0,
-            f1=0.0,
-            gold_count=gold_count,
-            candidate_count=0,
-            clean_task=0,
-            clean_pass=0,
-            verifier_error=0,
+        return Reward._make(
+            fn=gold_count, precision=1.0, gold_count=gold_count,
         )
 
     gold_ids = [_finding_id(g) for g in gold]
@@ -524,8 +489,8 @@ def score_review(
     fn = gold_count - tp
     precision = tp / (tp + fp) if (tp + fp) else 1.0
     recall = tp / (tp + fn) if (tp + fn) else 1.0
-    f1 = _f1(precision, recall)
-    return Reward(
+    f1 = 0.0 if tp == 0 else _f1(precision, recall)
+    return Reward._make(
         reward=f1,
         tp=tp,
         fp=fp,
@@ -535,9 +500,6 @@ def score_review(
         f1=f1,
         gold_count=gold_count,
         candidate_count=candidate_count,
-        clean_task=0,
-        clean_pass=0,
-        verifier_error=0,
     )
 
 
@@ -638,10 +600,7 @@ def aggregate_metrics(rows: list[dict[str, object] | None]) -> dict[str, float |
     mean_task_score = sum(rewards) / task_count if task_count else 1.0
     micro_precision = total_tp / (total_tp + total_fp) if (total_tp + total_fp) else 1.0
     micro_recall = total_tp / (total_tp + total_fn) if (total_tp + total_fn) else 1.0
-    if micro_precision + micro_recall == 0:
-        micro_f1 = 1.0
-    else:
-        micro_f1 = 2 * micro_precision * micro_recall / (micro_precision + micro_recall)
+    micro_f1 = _f1(micro_precision, micro_recall)
     clean_accuracy = clean_correct / clean_total if clean_total else 1.0
 
     return {

--- a/daydream/benchmark/harbor/verifier_core.py
+++ b/daydream/benchmark/harbor/verifier_core.py
@@ -280,3 +280,10 @@ def validate_candidate_artifact(raw: dict[str, object]) -> list[CandidateFinding
             raise VerifierError("duplicate candidate_id in artifact")
         ids.add(finding.candidate_id)
     return parsed
+
+
+def validate_gold_set(raw: list[dict[str, object]]) -> list[GoldFinding]:
+    """Validate a gold set against the 50-finding cap and field limits."""
+    if len(raw) > MAX_GOLD_FINDINGS:
+        raise VerifierError("gold set exceeds 50 findings")
+    return [parse_gold_finding(f) for f in raw]

--- a/daydream/benchmark/harbor/verifier_core.py
+++ b/daydream/benchmark/harbor/verifier_core.py
@@ -599,3 +599,73 @@ def reward_details(
 def reward_details_to_json(details: dict[str, object]) -> str:
     """Serialize a reward-details dict to JSON."""
     return json.dumps(details)
+
+
+# ---------------------------------------------------------------------------
+# corpus micro-metric aggregation
+# ---------------------------------------------------------------------------
+
+
+def aggregate_metrics(rows: list[dict[str, object] | None]) -> dict[str, float | int]:
+    """Aggregate per-task reward JSONL rows into pooled corpus micro metrics.
+
+    TP/FP/FN are pooled across tasks (never averaged per task). A ``None`` row
+    or a row with ``verifier_error == 1`` is a failed task: it contributes
+    reward 0 to the mean, zero counts, and increments ``failed_task_count``.
+    Zero denominators evaluate to 1.0 throughout.
+    """
+    failed = 0
+    clean_correct = 0
+    clean_total = 0
+    rewards: list[float] = []
+    total_tp = total_fp = total_fn = 0
+
+    for row in rows:
+        if row is None or row.get("verifier_error") == 1:
+            failed += 1
+            rewards.append(0.0)
+            continue
+        total_tp += _as_int(row["tp"])
+        total_fp += _as_int(row["fp"])
+        total_fn += _as_int(row["fn"])
+        rewards.append(_as_float(row["reward"]))
+        if row.get("clean_task") == 1:
+            clean_total += 1
+            if _as_int(row["fp"]) == 0:
+                clean_correct += 1
+
+    task_count = len(rows)
+    mean_task_score = sum(rewards) / task_count if task_count else 1.0
+    micro_precision = total_tp / (total_tp + total_fp) if (total_tp + total_fp) else 1.0
+    micro_recall = total_tp / (total_tp + total_fn) if (total_tp + total_fn) else 1.0
+    if micro_precision + micro_recall == 0:
+        micro_f1 = 1.0
+    else:
+        micro_f1 = 2 * micro_precision * micro_recall / (micro_precision + micro_recall)
+    clean_accuracy = clean_correct / clean_total if clean_total else 1.0
+
+    return {
+        "micro_precision": micro_precision,
+        "micro_recall": micro_recall,
+        "micro_f1": micro_f1,
+        "mean_task_score": mean_task_score,
+        "clean_accuracy": clean_accuracy,
+        "task_count": task_count,
+        "clean_task_count": clean_total,
+        "failed_task_count": failed,
+        "total_tp": total_tp,
+        "total_fp": total_fp,
+        "total_fn": total_fn,
+    }
+
+
+def _as_int(value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise VerifierError(f"expected integer, got {value!r}")
+    return value
+
+
+def _as_float(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise VerifierError(f"expected number, got {value!r}")
+    return float(value)

--- a/daydream/benchmark/harbor/verifier_core.py
+++ b/daydream/benchmark/harbor/verifier_core.py
@@ -539,3 +539,63 @@ def score_review(
         clean_pass=0,
         verifier_error=0,
     )
+
+
+# ---------------------------------------------------------------------------
+# reward / reward-details serialization
+# ---------------------------------------------------------------------------
+
+
+def reward_to_json(reward: Reward) -> str:
+    """Serialize a Reward to a numeric-only JSON document."""
+    return json.dumps(reward.to_dict())
+
+
+def _candidate_id(finding: object) -> str:
+    if isinstance(finding, dict):
+        try:
+            return finding["candidate_id"]
+        except KeyError as exc:
+            raise VerifierError("missing candidate_id") from exc
+    return getattr(finding, "candidate_id")
+
+
+def reward_details(
+    gold: list[object],
+    candidates: list[object],
+    verdicts: list[Verdict],
+    matches: set[tuple[str, str]],
+) -> dict[str, object]:
+    """Capture verdicts, selected matches, and unmatched gold/candidates.
+
+    Never embeds finding title/body/path content, source, or diffs — only ids
+    and verdict reasoning.
+    """
+    matched_gold = {g for g, _ in matches}
+    matched_candidates = {c for _, c in matches}
+    gold_ids = [_finding_id(g) for g in gold]
+    cand_ids = [_candidate_id(c) for c in candidates]
+    return {
+        "verdicts": [
+            {
+                "gold_id": v.gold_id,
+                "candidate_id": v.candidate_id,
+                "match": v.match,
+                "confidence": v.confidence,
+                "reasoning": v.reasoning,
+            }
+            for v in verdicts
+        ],
+        "matches": [
+            {"gold_id": g, "candidate_id": c} for g, c in sorted(matches)
+        ],
+        "unmatched_gold": [gid for gid in gold_ids if gid not in matched_gold],
+        "unmatched_candidates": sorted(
+            cid for cid in cand_ids if cid not in matched_candidates
+        ),
+    }
+
+
+def reward_details_to_json(details: dict[str, object]) -> str:
+    """Serialize a reward-details dict to JSON."""
+    return json.dumps(details)

--- a/daydream/benchmark/harbor/verifier_core.py
+++ b/daydream/benchmark/harbor/verifier_core.py
@@ -7,6 +7,7 @@ source, no pydantic, no third-party imports.
 
 from __future__ import annotations
 
+import hashlib
 import re
 from dataclasses import dataclass
 
@@ -181,3 +182,44 @@ def parse_candidate_finding(raw: dict[str, object]) -> CandidateFinding:
         start_line=fields["start_line"],  # type: ignore[arg-type]
         end_line=fields["end_line"],  # type: ignore[arg-type]
     )
+
+
+# ---------------------------------------------------------------------------
+# deterministic candidate-ID derivation
+# ---------------------------------------------------------------------------
+
+
+def _finding_component(finding: object, name: str) -> object:
+    """Read a field from either a dataclass attribute or a dict key."""
+    if isinstance(finding, dict):
+        try:
+            return finding[name]
+        except KeyError as exc:
+            raise VerifierError(f"missing required field {name}") from exc
+    return getattr(finding, name)
+
+
+def derive_candidate_id(
+    case_key: str,
+    finding: CandidateFinding | dict[str, object],
+    ordinal: int,
+) -> str:
+    """Return the deterministic sha256 candidate id for a finding."""
+    title = str(_finding_component(finding, "title") or "")
+    body = str(_finding_component(finding, "body") or "")
+    severity = str(_finding_component(finding, "severity") or "")
+    path = str(_finding_component(finding, "path"))
+    start_line = _component_int(finding, "start_line")
+    end_line = _component_int(finding, "end_line")
+    canonical = _SEP.join(
+        [title, body, severity, path, str(start_line), str(end_line)]
+    )
+    payload = _SEP.join([str(case_key), canonical, str(ordinal)])
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _component_int(finding: object, name: str) -> int:
+    value = _finding_component(finding, name)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise VerifierError(f"{name} must be an integer, got {value!r}")
+    return value

--- a/daydream/benchmark/harbor/verifier_core.py
+++ b/daydream/benchmark/harbor/verifier_core.py
@@ -287,3 +287,41 @@ def validate_gold_set(raw: list[dict[str, object]]) -> list[GoldFinding]:
     if len(raw) > MAX_GOLD_FINDINGS:
         raise VerifierError("gold set exceeds 50 findings")
     return [parse_gold_finding(f) for f in raw]
+
+
+# ---------------------------------------------------------------------------
+# verdicts + edge retention
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """A caller-injected verdict for one gold/candidate pair."""
+
+    gold_id: str
+    candidate_id: str
+    match: bool
+    confidence: float
+    reasoning: str
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.confidence <= 1.0:
+            raise VerifierError(f"confidence must be in [0,1], got {self.confidence!r}")
+
+
+def retained_edges(
+    verdicts: list[Verdict],
+    gold_ids: list[str],
+    candidate_ids: list[str],
+) -> list[Verdict]:
+    """Return verdicts retained as edges: match true and confidence >= 0.7."""
+    gold_set = set(gold_ids)
+    cand_set = set(candidate_ids)
+    return [
+        v
+        for v in verdicts
+        if v.match
+        and v.confidence >= CONFIDENCE_THRESHOLD
+        and v.gold_id in gold_set
+        and v.candidate_id in cand_set
+    ]

--- a/daydream/benchmark/harbor/verifier_core.py
+++ b/daydream/benchmark/harbor/verifier_core.py
@@ -381,3 +381,161 @@ def maximum_matching(
             _augment(gold, set())
 
     return {(match_candidate[c], c) for c in match_candidate}
+
+
+# ---------------------------------------------------------------------------
+# reward + score_review
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Reward:
+    """The 12-field §10 per-task reward output."""
+
+    reward: float
+    tp: int
+    fp: int
+    fn: int
+    precision: float
+    recall: float
+    f1: float
+    gold_count: int
+    candidate_count: int
+    clean_task: int
+    clean_pass: int
+    verifier_error: int
+
+    def to_dict(self) -> dict[str, float | int]:
+        """Numeric-only dict with exactly the 12 §10 keys."""
+        return {
+            "reward": self.reward,
+            "tp": self.tp,
+            "fp": self.fp,
+            "fn": self.fn,
+            "precision": self.precision,
+            "recall": self.recall,
+            "f1": self.f1,
+            "gold_count": self.gold_count,
+            "candidate_count": self.candidate_count,
+            "clean_task": self.clean_task,
+            "clean_pass": self.clean_pass,
+            "verifier_error": self.verifier_error,
+        }
+
+
+def _f1(precision: float, recall: float) -> float:
+    if precision + recall == 0:
+        return 1.0
+    return 2 * precision * recall / (precision + recall)
+
+
+def _finding_id(finding: object) -> str:
+    """Read a gold finding's id from either a GoldFinding or a raw dict."""
+    if isinstance(finding, dict):
+        try:
+            return finding["finding_id"]
+        except KeyError as exc:
+            raise VerifierError("missing gold finding_id") from exc
+    return getattr(finding, "finding_id")
+
+
+def _empty_side_error(gold_count: int) -> Reward:
+    return Reward(
+        reward=0.0,
+        tp=0,
+        fp=0,
+        fn=0,
+        precision=0.0,
+        recall=0.0,
+        f1=0.0,
+        gold_count=gold_count,
+        candidate_count=0,
+        clean_task=0,
+        clean_pass=0,
+        verifier_error=1,
+    )
+
+
+def score_review(
+    gold: list[GoldFinding],
+    candidate_artifact: dict[str, object],
+    verdicts: list[Verdict],
+) -> Reward:
+    """Score one review against hidden gold and injected verdicts."""
+    gold_count = len(gold)
+    try:
+        candidates = validate_candidate_artifact(candidate_artifact)
+    except VerifierError:
+        return _empty_side_error(gold_count)
+    candidate_count = len(candidates)
+
+    if gold_count == 0 and candidate_count == 0:
+        return Reward(
+            reward=1.0,
+            tp=0,
+            fp=0,
+            fn=0,
+            precision=1.0,
+            recall=1.0,
+            f1=1.0,
+            gold_count=0,
+            candidate_count=0,
+            clean_task=1,
+            clean_pass=1,
+            verifier_error=0,
+        )
+    if gold_count == 0:
+        return Reward(
+            reward=0.0,
+            tp=0,
+            fp=candidate_count,
+            fn=0,
+            precision=0.0,
+            recall=1.0,
+            f1=0.0,
+            gold_count=0,
+            candidate_count=candidate_count,
+            clean_task=1,
+            clean_pass=0,
+            verifier_error=0,
+        )
+    if candidate_count == 0:
+        return Reward(
+            reward=0.0,
+            tp=0,
+            fp=0,
+            fn=gold_count,
+            precision=1.0,
+            recall=0.0,
+            f1=0.0,
+            gold_count=gold_count,
+            candidate_count=0,
+            clean_task=0,
+            clean_pass=0,
+            verifier_error=0,
+        )
+
+    gold_ids = [_finding_id(g) for g in gold]
+    cand_ids = [c.candidate_id for c in candidates]
+    retained = retained_edges(verdicts, gold_ids, cand_ids)
+    matches = maximum_matching(retained, gold_ids, cand_ids)
+    tp = len(matches)
+    fp = candidate_count - tp
+    fn = gold_count - tp
+    precision = tp / (tp + fp) if (tp + fp) else 1.0
+    recall = tp / (tp + fn) if (tp + fn) else 1.0
+    f1 = _f1(precision, recall)
+    return Reward(
+        reward=f1,
+        tp=tp,
+        fp=fp,
+        fn=fn,
+        precision=precision,
+        recall=recall,
+        f1=f1,
+        gold_count=gold_count,
+        candidate_count=candidate_count,
+        clean_task=0,
+        clean_pass=0,
+        verifier_error=0,
+    )

--- a/tests/test_benchmark_verifier_core.py
+++ b/tests/test_benchmark_verifier_core.py
@@ -10,6 +10,7 @@ from daydream.benchmark.harbor.verifier_core import (
     parse_candidate_finding,
     parse_gold_finding,
     validate_candidate_artifact,
+    validate_gold_set,
 )
 
 
@@ -210,3 +211,18 @@ def test_artifact_rejects_over_one_mib():
 def test_artifact_rejects_over_100_findings():
     with pytest.raises(VerifierError):
         validate_candidate_artifact(_artifact(_valid_findings(101)))
+
+def test_gold_set_accepts_and_returns_models():
+    gs = validate_gold_set([_gold(), _gold(finding_id="b" * 64, title="B")])
+    assert len(gs) == 2 and all(isinstance(g, GoldFinding) for g in gs)
+
+
+def test_gold_set_rejects_over_50():
+    many = [_gold(finding_id=(hex(i)[2:].zfill(64)), title=f"f{i}") for i in range(51)]
+    with pytest.raises(VerifierError):
+        validate_gold_set(many)
+
+
+def test_gold_set_rejects_invalid_member():
+    with pytest.raises(VerifierError):
+        validate_gold_set([_gold(severity="nope")])

--- a/tests/test_benchmark_verifier_core.py
+++ b/tests/test_benchmark_verifier_core.py
@@ -1,5 +1,100 @@
 """Tests for the stdlib-only harbor verifier core module."""
 
+import pytest
+
+from daydream.benchmark.harbor.verifier_core import (
+    CandidateFinding,
+    GoldFinding,
+    VerifierError,
+    parse_candidate_finding,
+    parse_gold_finding,
+)
+
+
+def _cand(**overrides):
+    base = {
+        "candidate_id": "a" * 64,
+        "title": "Cache key not scoped",
+        "body": "Cache key omits the auth realm",
+        "severity": "high",
+        "path": "src/cache.py",
+        "start_line": 42,
+        "end_line": 42,
+    }
+    base.update(overrides)
+    return base
+
+
+def _gold(**overrides):
+    base = {
+        "finding_id": "a" * 64,
+        "title": "Cache key not scoped",
+        "body": "Cache key omits the auth realm",
+        "severity": "high",
+        "path": "src/cache.py",
+        "start_line": 42,
+        "end_line": 42,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_candidate_parses_valid():
+    f = parse_candidate_finding(_cand())
+    assert isinstance(f, CandidateFinding)
+    assert (f.title, f.severity, f.path, f.start_line, f.end_line) == (
+        "Cache key not scoped",
+        "high",
+        "src/cache.py",
+        42,
+        42,
+    )
+
+
+def test_gold_parses_valid():
+    g = parse_gold_finding(_gold())
+    assert isinstance(g, GoldFinding) and g.finding_id == "a" * 64
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("severity", "critical"),
+        ("title", "   "),
+        ("body", ""),
+        ("path", "../etc/passwd"),
+        ("path", "/abs/path"),
+        ("start_line", 5),
+    ],
+)
+def test_candidate_rejects_invalid(field, value):
+    kw = _cand()
+    if field == "start_line":
+        kw["start_line"], kw["end_line"] = 5, 3  # end < start
+    else:
+        kw[field] = value
+    with pytest.raises(VerifierError):
+        parse_candidate_finding(kw)
+
+
+def test_candidate_rejects_nul_and_oversize_title():
+    with pytest.raises(VerifierError):
+        parse_candidate_finding(_cand(title="a\x00b"))
+    with pytest.raises(VerifierError):
+        parse_candidate_finding(_cand(title="x" * 501))
+    with pytest.raises(VerifierError):
+        parse_candidate_finding(_cand(body="y" * (8 * 1024 + 1)))
+
+
+def test_candidate_rejects_bad_id_hex():
+    with pytest.raises(VerifierError):
+        parse_candidate_finding(_cand(candidate_id="xyz"))
+
+
+def test_gold_rejects_bad_id_hex():
+    with pytest.raises(VerifierError):
+        parse_gold_finding(_gold(finding_id="not-hex"))
+
 
 def test_harbor_package_imports_stdlib_only():
     import daydream.benchmark.harbor.verifier_core as vc

--- a/tests/test_benchmark_verifier_core.py
+++ b/tests/test_benchmark_verifier_core.py
@@ -5,10 +5,12 @@ import pytest
 from daydream.benchmark.harbor.verifier_core import (
     CandidateFinding,
     GoldFinding,
+    Verdict,
     VerifierError,
     derive_candidate_id,
     parse_candidate_finding,
     parse_gold_finding,
+    retained_edges,
     validate_candidate_artifact,
     validate_gold_set,
 )
@@ -226,3 +228,23 @@ def test_gold_set_rejects_over_50():
 def test_gold_set_rejects_invalid_member():
     with pytest.raises(VerifierError):
         validate_gold_set([_gold(severity="nope")])
+
+def test_verdict_parses_and_validates():
+    v = Verdict(gold_id="g", candidate_id="c", match=True, confidence=0.9, reasoning="same bug")
+    assert (v.match, v.confidence) == (True, 0.9)
+
+
+def test_verdict_rejects_out_of_range_confidence():
+    with pytest.raises(VerifierError):
+        Verdict("g", "c", True, 1.5, "")
+
+
+def test_retained_edges_threshold():
+    vs = [
+        Verdict("g1", "c1", True, 0.9, "m"),  # keep
+        Verdict("g2", "c2", True, 0.69, "m"),  # drop: below 0.7
+        Verdict("g3", "c3", False, 0.95, "m"),  # drop: match false
+        Verdict("g4", "c4", True, 0.7, "m"),  # keep: exactly 0.7
+    ]
+    kept = retained_edges(vs, ["g1", "g2", "g3", "g4"], ["c1", "c2", "c3", "c4"])
+    assert {(v.gold_id, v.candidate_id) for v in kept} == {("g1", "c1"), ("g4", "c4")}

--- a/tests/test_benchmark_verifier_core.py
+++ b/tests/test_benchmark_verifier_core.py
@@ -9,6 +9,7 @@ from daydream.benchmark.harbor.verifier_core import (
     derive_candidate_id,
     parse_candidate_finding,
     parse_gold_finding,
+    validate_candidate_artifact,
 )
 
 
@@ -134,3 +135,78 @@ def test_null_fields_normalize_to_empty_string():
     cid = derive_candidate_id("case-x", raw, 0)
     raw2 = _cand(title="", body="", severity=None)
     assert cid == derive_candidate_id("case-x", raw2, 0)
+
+
+def _artifact(findings, **overrides):
+    base = {
+        "schema_version": 1,
+        "case_id": "case-x",
+        "base_ref": "base",
+        "head_ref": "head",
+        "findings": findings,
+    }
+    base.update(overrides)
+    return base
+
+
+def _valid_findings(n=1, key="case-x"):
+    out = []
+    groups: dict[tuple, int] = {}
+    for i in range(n):
+        base = _cand(title=f"f{i}", body=f"body{i}")
+        canon = (
+            f"f{i}",
+            f"body{i}",
+            base.get("severity") or "",
+            base["path"],
+            base["start_line"],
+            base["end_line"],
+        )
+        ordinal = groups.get(canon, 0)
+        groups[canon] = ordinal + 1
+        base["candidate_id"] = derive_candidate_id(key, base, ordinal)
+        out.append(base)
+    return out
+
+
+def test_artifact_accepts_and_returns_models():
+    fs = validate_candidate_artifact(_artifact(_valid_findings(2)))
+    assert len(fs) == 2 and all(isinstance(f, CandidateFinding) for f in fs)
+
+
+def test_artifact_rejects_duplicate_candidate_id():
+    dup = _valid_findings(2)
+    dup[1] = dict(dup[0])  # same id, different title → not allowed
+    with pytest.raises(VerifierError):
+        validate_candidate_artifact(_artifact(dup))
+
+
+def test_artifact_rejects_mismatched_candidate_id():
+    bad = _valid_findings(1)
+    bad[0]["candidate_id"] = "f" * 64  # does not match derived id
+    with pytest.raises(VerifierError):
+        validate_candidate_artifact(_artifact(bad))
+
+
+def test_artifact_rejects_wrong_schema_version():
+    with pytest.raises(VerifierError):
+        validate_candidate_artifact(_artifact([], schema_version=2))
+
+
+def test_artifact_rejects_missing_refs():
+    art = _artifact([])
+    del art["head_ref"]
+    with pytest.raises(VerifierError):
+        validate_candidate_artifact(art)
+
+
+def test_artifact_rejects_over_one_mib():
+    big = _valid_findings(1)
+    big[0]["body"] = "x" * (1_048_576)  # artifact JSON > 1 MiB
+    with pytest.raises(VerifierError):
+        validate_candidate_artifact(_artifact(big))
+
+
+def test_artifact_rejects_over_100_findings():
+    with pytest.raises(VerifierError):
+        validate_candidate_artifact(_artifact(_valid_findings(101)))

--- a/tests/test_benchmark_verifier_core.py
+++ b/tests/test_benchmark_verifier_core.py
@@ -6,6 +6,7 @@ from daydream.benchmark.harbor.verifier_core import (
     CandidateFinding,
     GoldFinding,
     VerifierError,
+    derive_candidate_id,
     parse_candidate_finding,
     parse_gold_finding,
 )
@@ -104,3 +105,32 @@ def test_harbor_package_imports_stdlib_only():
     assert vc.MAX_ARTIFACT_BYTES == 1_048_576
     assert vc.CONFIDENCE_THRESHOLD == 0.7
     assert issubclass(vc.VerifierError, Exception)
+
+def test_candidate_id_is_64_lower_hex():
+    cid = derive_candidate_id("case-x", _cand(), 0)
+    assert len(cid) == 64 and all(ch in "0123456789abcdef" for ch in cid)
+
+
+def test_candidate_id_scoped_by_case_key():
+    a = derive_candidate_id("case-x", _cand(), 0)
+    b = derive_candidate_id("case-y", _cand(), 0)
+    assert a != b
+
+
+def test_duplicate_content_gets_distinct_ordinals_and_ids():
+    # two byte-identical findings, ordinals 0 and 1 → distinct IDs, both preserved
+    first = derive_candidate_id("case-x", _cand(), 0)
+    second = derive_candidate_id("case-x", _cand(), 1)
+    assert first != second
+
+
+def test_same_content_same_key_same_ordinal_is_stable():
+    assert derive_candidate_id("case-x", _cand(), 0) == derive_candidate_id("case-x", _cand(), 0)
+
+
+def test_null_fields_normalize_to_empty_string():
+    # title/body/severity null → "" — the digest must be stable for a null vs "" field
+    raw = _cand(title=None, body=None, severity=None)
+    cid = derive_candidate_id("case-x", raw, 0)
+    raw2 = _cand(title="", body="", severity=None)
+    assert cid == derive_candidate_id("case-x", raw2, 0)

--- a/tests/test_benchmark_verifier_core.py
+++ b/tests/test_benchmark_verifier_core.py
@@ -307,6 +307,16 @@ def test_score_gold_no_candidates():
     assert r.fp == 0 and r.clean_task == 0
 
 
+def test_score_zero_match_reward_is_zero():
+    # nonempty gold and nonempty candidates with zero matching edges → f1/reward 0.0
+    gold = [_gold(), _gold(finding_id="b" * 64, title="B")]
+    art = _artifact(_valid_findings(2))
+    r = score_review(gold, art, [])
+    assert (r.tp, r.fp, r.fn) == (0, 2, 2)
+    assert r.precision == 0.0 and r.recall == 0.0
+    assert r.f1 == 0.0 and r.reward == 0.0
+
+
 def test_score_f1_example():
     # 3 gold / 2 candidates, TP=2, FN=1 → precision 1.0, recall 0.6666666667, f1 0.8
     gold = [_gold(), _gold(finding_id="b" * 64, title="B"), _gold(finding_id="c" * 64, title="C")]

--- a/tests/test_benchmark_verifier_core.py
+++ b/tests/test_benchmark_verifier_core.py
@@ -1,5 +1,7 @@
 """Tests for the stdlib-only harbor verifier core module."""
 
+import json
+
 import pytest
 
 from daydream.benchmark.harbor.verifier_core import (
@@ -12,6 +14,9 @@ from daydream.benchmark.harbor.verifier_core import (
     parse_candidate_finding,
     parse_gold_finding,
     retained_edges,
+    reward_details,
+    reward_details_to_json,
+    reward_to_json,
     score_review,
     validate_candidate_artifact,
     validate_gold_set,
@@ -338,3 +343,29 @@ def test_reward_dict_is_numeric_only_with_all_keys():
                       "gold_count", "candidate_count", "clean_task", "clean_pass", "verifier_error"}
     for k, v in d.items():
         assert isinstance(v, (int, float)) and not isinstance(v, bool)
+
+def test_reward_to_json_is_numeric_only():
+    art = _artifact(_valid_findings(1))
+    cand = _valid_findings(1)[0]
+    r = score_review([_gold()], art, [Verdict("a" * 64, cand["candidate_id"], True, 0.9, "same")])
+    d = json.loads(reward_to_json(r))
+    assert all(isinstance(v, (int, float)) and not isinstance(v, bool) for v in d.values())
+
+
+def test_reward_details_shape_and_no_source_leak():
+    gold = [_gold(), _gold(finding_id="b" * 64, title="B")]
+    cands = [
+        parse_candidate_finding(_cand(candidate_id="c" * 64, title="f1")),
+        parse_candidate_finding(_cand(candidate_id="d" * 64, title="f2")),
+    ]
+    vs = [Verdict("a" * 64, cands[0].candidate_id, True, 0.9, "same bug")]
+    m = {("a" * 64, cands[0].candidate_id)}
+    details = reward_details(gold, cands, vs, m)
+    for key in ("verdicts", "matches", "unmatched_gold", "unmatched_candidates"):
+        assert key in details
+    assert details["unmatched_gold"] == ["b" * 64]
+    assert sorted(details["unmatched_candidates"]) == sorted([cands[1].candidate_id])
+    blob = reward_details_to_json(details)
+    assert "same bug" in blob  # reasoning is kept
+    assert "Cache key not scoped" not in blob  # finding body/title never leaks
+    assert "f1" not in blob  # candidate content never leaks

--- a/tests/test_benchmark_verifier_core.py
+++ b/tests/test_benchmark_verifier_core.py
@@ -1,0 +1,11 @@
+"""Tests for the stdlib-only harbor verifier core module."""
+
+
+def test_harbor_package_imports_stdlib_only():
+    import daydream.benchmark.harbor.verifier_core as vc
+
+    assert vc.MAX_GOLD_FINDINGS == 50
+    assert vc.MAX_CANDIDATE_FINDINGS == 100
+    assert vc.MAX_ARTIFACT_BYTES == 1_048_576
+    assert vc.CONFIDENCE_THRESHOLD == 0.7
+    assert issubclass(vc.VerifierError, Exception)

--- a/tests/test_benchmark_verifier_core.py
+++ b/tests/test_benchmark_verifier_core.py
@@ -321,3 +321,20 @@ def test_score_malformed_artifact_is_verifier_error():
            "findings": [{"candidate_id": "not-hex"}]}
     r = score_review([], art, [])
     assert r.reward == 0.0 and r.verifier_error == 1
+
+def test_empty_side_resolves_with_zero_verdicts():
+    # clean/0 and N/0 both resolve deterministically with an EMPTY verdict set
+    r0 = score_review([], _artifact([]), [])
+    assert r0.reward == 1.0
+    rn = score_review([_gold()], _artifact([]), [])
+    assert rn.reward == 0.0 and rn.fn == 1
+    # passing any verdict for an empty side must not change the result (ignored/not required)
+    assert score_review([], _artifact([]), [Verdict("g", "c", True, 0.9, "")]).reward == 1.0
+
+
+def test_reward_dict_is_numeric_only_with_all_keys():
+    d = score_review([_gold()], _artifact(_valid_findings(1)), []).to_dict()
+    assert set(d) == {"reward", "tp", "fp", "fn", "precision", "recall", "f1",
+                      "gold_count", "candidate_count", "clean_task", "clean_pass", "verifier_error"}
+    for k, v in d.items():
+        assert isinstance(v, (int, float)) and not isinstance(v, bool)

--- a/tests/test_benchmark_verifier_core.py
+++ b/tests/test_benchmark_verifier_core.py
@@ -8,6 +8,7 @@ from daydream.benchmark.harbor.verifier_core import (
     Verdict,
     VerifierError,
     derive_candidate_id,
+    maximum_matching,
     parse_candidate_finding,
     parse_gold_finding,
     retained_edges,
@@ -248,3 +249,32 @@ def test_retained_edges_threshold():
     ]
     kept = retained_edges(vs, ["g1", "g2", "g3", "g4"], ["c1", "c2", "c3", "c4"])
     assert {(v.gold_id, v.candidate_id) for v in kept} == {("g1", "c1"), ("g4", "c4")}
+
+def test_max_cardinality_beats_greedy():
+    # A-1 (0.9), A-2 (0.8), B-1 (0.7) — greedy only matches A-1; max-cardinality matches 2.
+    vs = [Verdict("A", "1", True, 0.9, ""), Verdict("A", "2", True, 0.8, ""), Verdict("B", "1", True, 0.7, "")]
+    m = maximum_matching(vs, ["A", "B"], ["1", "2"])
+    assert m == {("A", "2"), ("B", "1")}
+
+
+def test_one_candidate_cannot_match_two_golds():
+    vs = [Verdict("g1", "c1", True, 0.9, ""), Verdict("g2", "c1", True, 0.8, "")]
+    m = maximum_matching(vs, ["g1", "g2"], ["c1"])
+    assert len(m) == 1
+    assert {c for _, c in m} == {"c1"}  # c1 used at most once
+
+
+def test_one_gold_cannot_match_two_candidates():
+    vs = [Verdict("g1", "c1", True, 0.9, ""), Verdict("g1", "c2", True, 0.8, "")]
+    m = maximum_matching(vs, ["g1"], ["c1", "c2"])
+    assert len(m) == 1 and {g for g, _ in m} == {"g1"}
+
+
+def test_matching_is_deterministic_across_runs():
+    # ties on confidence: ordering must still be stable run-to-run
+    vs = [Verdict("g1", "c1", True, 0.8, ""), Verdict("g1", "c2", True, 0.8, ""),
+          Verdict("g2", "c1", True, 0.8, ""), Verdict("g2", "c2", True, 0.8, "")]
+    gold, cand = ["g1", "g2"], ["c1", "c2"]
+    r1 = maximum_matching(vs, gold, cand)
+    r2 = maximum_matching(vs, gold, cand)
+    assert r1 == r2 == {("g1", "c1"), ("g2", "c2")}

--- a/tests/test_benchmark_verifier_core.py
+++ b/tests/test_benchmark_verifier_core.py
@@ -12,6 +12,7 @@ from daydream.benchmark.harbor.verifier_core import (
     parse_candidate_finding,
     parse_gold_finding,
     retained_edges,
+    score_review,
     validate_candidate_artifact,
     validate_gold_set,
 )
@@ -278,3 +279,45 @@ def test_matching_is_deterministic_across_runs():
     r1 = maximum_matching(vs, gold, cand)
     r2 = maximum_matching(vs, gold, cand)
     assert r1 == r2 == {("g1", "c1"), ("g2", "c2")}
+
+def test_score_clean_zero_candidates():
+    r = score_review([], _artifact([]), [])
+    d = r.to_dict()
+    assert d["reward"] == 1.0 and d["clean_task"] == 1 and d["clean_pass"] == 1
+    assert (d["tp"], d["fp"], d["fn"]) == (0, 0, 0)
+    assert (d["precision"], d["recall"], d["f1"]) == (1.0, 1.0, 1.0)  # zero-denom → 1.0
+
+
+def test_score_clean_with_candidates():
+    art = _artifact(_valid_findings(2))
+    r = score_review([], art, [])
+    assert (r.reward, r.fp, r.clean_pass) == (0.0, 2, 0)
+    assert r.tp == 0 and r.fn == 0 and r.clean_task == 1
+
+
+def test_score_gold_no_candidates():
+    gold = [_gold(), _gold(finding_id="b" * 64, title="B")]
+    r = score_review(gold, _artifact([]), [])
+    assert (r.reward, r.fn) == (0.0, 2)
+    assert r.fp == 0 and r.clean_task == 0
+
+
+def test_score_f1_example():
+    # 3 gold / 2 candidates, TP=2, FN=1 → precision 1.0, recall 0.6666666667, f1 0.8
+    gold = [_gold(), _gold(finding_id="b" * 64, title="B"), _gold(finding_id="c" * 64, title="C")]
+    cands = _valid_findings(2)
+    art = _artifact(cands)
+    vs = [Verdict("a" * 64, cands[0]["candidate_id"], True, 0.9, "same"),
+          Verdict("b" * 64, cands[1]["candidate_id"], True, 0.8, "same")]
+    r = score_review(gold, art, vs)
+    assert (r.tp, r.fp, r.fn) == (2, 0, 1)
+    assert r.precision == 1.0
+    assert abs(r.recall - 0.6666666667) < 1e-9
+    assert abs(r.f1 - 0.8) < 1e-9 and abs(r.reward - 0.8) < 1e-9
+
+
+def test_score_malformed_artifact_is_verifier_error():
+    art = {"schema_version": 1, "case_id": "c", "base_ref": "b", "head_ref": "h",
+           "findings": [{"candidate_id": "not-hex"}]}
+    r = score_review([], art, [])
+    assert r.reward == 0.0 and r.verifier_error == 1

--- a/tests/test_benchmark_verifier_core.py
+++ b/tests/test_benchmark_verifier_core.py
@@ -374,7 +374,7 @@ def test_reward_details_shape_and_no_source_leak():
     for key in ("verdicts", "matches", "unmatched_gold", "unmatched_candidates"):
         assert key in details
     assert details["unmatched_gold"] == ["b" * 64]
-    assert sorted(details["unmatched_candidates"]) == sorted([cands[1].candidate_id])
+    assert details["unmatched_candidates"] == [cands[1].candidate_id]
     blob = reward_details_to_json(details)
     assert "same bug" in blob  # reasoning is kept
     assert "Cache key not scoped" not in blob  # finding body/title never leaks

--- a/tests/test_benchmark_verifier_metrics.py
+++ b/tests/test_benchmark_verifier_metrics.py
@@ -1,0 +1,35 @@
+"""Tests for the harbor verifier corpus metric aggregation."""
+
+from daydream.benchmark.harbor.verifier_core import aggregate_metrics
+
+
+def _row(reward, tp, fp, fn, clean_task=0, clean_pass=0, verifier_error=0):
+    p = tp / (tp + fp) if (tp + fp) else 1.0
+    r = tp / (tp + fn) if (tp + fn) else 1.0
+    f1 = 2 * p * r / (p + r) if (p + r) else 1.0
+    return {"reward": reward, "tp": tp, "fp": fp, "fn": fn, "precision": p, "recall": r,
+            "f1": f1, "gold_count": tp + fn, "candidate_count": tp + fp,
+            "clean_task": clean_task, "clean_pass": clean_pass, "verifier_error": verifier_error}
+
+
+def test_micro_metrics_pooled_not_averaged():
+    rows = [_row(1.0, 3, 0, 0), _row(0.5, 1, 1, 1)]  # pooled tp=4 fp=1 fn=1
+    m = aggregate_metrics(rows)
+    assert abs(m["micro_precision"] - 0.8) < 1e-9  # 4/5
+    assert abs(m["micro_recall"] - 0.8) < 1e-9  # 4/5
+    assert abs(m["micro_f1"] - 0.8) < 1e-9
+    assert m["micro_precision"] != 0.75  # averaging (1.0+0.5)/2 would give 0.75
+    assert (m["total_tp"], m["total_fp"], m["total_fn"]) == (4, 1, 1)
+
+
+def test_zero_denominator_metrics_are_one():
+    m = aggregate_metrics([_row(0.0, 0, 0, 0)])
+    assert (m["micro_precision"], m["micro_recall"], m["micro_f1"]) == (1.0, 1.0, 1.0)
+
+
+def test_mean_task_score_and_counts():
+    rows = [_row(1.0, 3, 0, 0), _row(0.5, 1, 1, 1), None, _row(0.0, 0, 0, 0, verifier_error=1)]
+    m = aggregate_metrics(rows)
+    assert m["task_count"] == 4
+    assert m["failed_task_count"] == 2  # None + verifier_error
+    assert abs(m["mean_task_score"] - (1.0 + 0.5 + 0.0 + 0.0) / 4) < 1e-9

--- a/tests/test_benchmark_verifier_metrics.py
+++ b/tests/test_benchmark_verifier_metrics.py
@@ -27,6 +27,17 @@ def test_zero_denominator_metrics_are_one():
     assert (m["micro_precision"], m["micro_recall"], m["micro_f1"]) == (1.0, 1.0, 1.0)
 
 
+def test_all_missed_pooled_f1_is_zero():
+    # tp==0 with non-zero FP/FN: pooled denominators are non-zero, so micro-F1
+    # must be 0.0, consistent with score_review's tp==0 rule (vs the
+    # genuinely zero-denominator 1.0 case above).
+    m = aggregate_metrics([_row(0.0, 0, 5, 5)])
+    assert m["micro_precision"] == 0.0
+    assert m["micro_recall"] == 0.0
+    assert m["micro_f1"] == 0.0
+    assert m["mean_task_score"] == 0.0
+
+
 def test_mean_task_score_and_counts():
     rows = [_row(1.0, 3, 0, 0), _row(0.5, 1, 1, 1), None, _row(0.0, 0, 0, 0, verifier_error=1)]
     m = aggregate_metrics(rows)

--- a/tests/test_benchmark_verifier_metrics.py
+++ b/tests/test_benchmark_verifier_metrics.py
@@ -33,3 +33,19 @@ def test_mean_task_score_and_counts():
     assert m["task_count"] == 4
     assert m["failed_task_count"] == 2  # None + verifier_error
     assert abs(m["mean_task_score"] - (1.0 + 0.5 + 0.0 + 0.0) / 4) < 1e-9
+
+def test_clean_accuracy_counts_only_clean_tasks():
+    rows = [
+        _row(1.0, 0, 0, 0, clean_task=1),  # correct clean (no FP)
+        _row(0.0, 0, 2, 0, clean_task=1),  # failed clean (clean gold with FPs)
+        _row(0.5, 1, 1, 1, clean_task=0),  # non-clean, excluded from denominator
+    ]
+    m = aggregate_metrics(rows)
+    assert m["clean_task_count"] == 2
+    assert abs(m["clean_accuracy"] - 0.5) < 1e-9  # 1 correct / 2 clean tasks
+
+
+def test_clean_accuracy_zero_clean_tasks_is_one():
+    m = aggregate_metrics([_row(0.5, 1, 1, 1, clean_task=0)])
+    assert m["clean_task_count"] == 0
+    assert m["clean_accuracy"] == 1.0  # zero-denominator → 1.0


### PR DESCRIPTION
## Summary
Implements issue #776 — pure review artifacts, one-to-one matching, and micro metrics for the benchmark corpus.

- Strict gold/candidate/reward models, candidate ID derivation with duplicate occurrence ordinal, 1 MiB / 50-gold / 100-candidate limits, deterministic empty-side handling
- Maximum-cardinality one-to-one matching over injected verdicts, reward details, and corpus metric aggregation
- Clean-task rules and zero-denominator conventions (stdlib-only `daydream/benchmark/harbor/verifier_core.py` source of truth)

Closes #776