### PR TITLE
fix(benchmark): enforce exact task-bound verifier artifacts (Closes #817)

### DIFF
--- a/daydream/benchmark/harbor/build.py
+++ b/daydream/benchmark/harbor/build.py
@@ -408,6 +408,19 @@ def _compile_case(stage: Path, ws: Path, case_doc: dict, repo_slug: str) -> dict
     gold_path.parent.mkdir(parents=True, exist_ok=True)
     gold_path.write_bytes(gold_bytes)
 
+    # Immutable, deterministic per-case verifier metadata beside the gold file
+    # (no timestamps): opaque case id + base/head refs + the hidden-gold sentinel.
+    metadata = {
+        "schema_version": 1,
+        "case_id": key,
+        "base_ref": "base",
+        "head_ref": "head",
+        "template_version": TEMPLATE_VERSION,
+        "gold_sha256": hashlib.sha256(gold_bytes).hexdigest(),
+    }
+    meta_path = case_stage / "tests" / "verifier-metadata.json"
+    meta_path.write_text(json.dumps(metadata, sort_keys=True))
+
     oracle = build_oracle_artifact(key, findings)
     oracle_bytes = json.dumps(oracle).encode("utf-8")
     oracle_path = case_stage / "solution" / "golden-review.json"
@@ -419,7 +432,8 @@ def _compile_case(stage: Path, ws: Path, case_doc: dict, repo_slug: str) -> dict
     files: dict[str, str] = {}
     for rel in (
         "README.md", "instruction.md", "environment/repository.bundle",
-        "tests/golden-review.json", "solution/golden-review.json",
+        "tests/golden-review.json", "tests/verifier-metadata.json",
+        "solution/golden-review.json",
     ):
         files[rel] = hashlib.sha256((case_stage / rel).read_bytes()).hexdigest()
     for rel, sha in assets:
@@ -435,6 +449,10 @@ def _compile_case(stage: Path, ws: Path, case_doc: dict, repo_slug: str) -> dict
         "bundle_sha256": hashlib.sha256(bundle_dst.read_bytes()).hexdigest(),
         "gold_sha256": hashlib.sha256(gold_bytes).hexdigest(),
         "oracle_sha256": hashlib.sha256(oracle_bytes).hexdigest(),
+        "verifier_script_sha256": hashlib.sha256(
+            (case_stage / "tests" / "score_review.py").read_bytes()
+            + (case_stage / "tests" / "verifier_core.py").read_bytes()
+        ).hexdigest(),
         "files": files,
     }
 

--- a/daydream/benchmark/harbor/build.py
+++ b/daydream/benchmark/harbor/build.py
@@ -177,8 +177,11 @@ def build_oracle_artifact(opaque_key: str, findings: list) -> dict:
     ``head_ref`` are the deterministic ``base`` / ``head`` refs. Findings are
     flattened (reusing :func:`_flatten_finding` -- a location-less finding
     raises :class:`CompileError`), ordered by ``finding_id`` ascending, and
-    assigned ordinal 0,1,2,... in that order; each entry's ``candidate_id`` is
-    derived via ``verifier_core.derive_candidate_id``. Empty input -> ``[]``.
+    assigned ordinal 0,1,2,... in that order; each entry is exactly
+    candidate-shaped -- ``candidate_id`` plus the flattened content fields
+    (``title``/``body``/``severity``/``path``/``start_line``/``end_line``),
+    never the gold-only ``finding_id`` -- with ``candidate_id`` derived via
+    ``verifier_core.derive_candidate_id``. Empty input -> ``[]``.
     """
     from daydream.benchmark.harbor import verifier_core as vc
     if not findings:
@@ -196,7 +199,7 @@ def build_oracle_artifact(opaque_key: str, findings: list) -> dict:
     # artifact re-derives identical ids under ``validate_candidate_artifact``.
     groups: dict[tuple, int] = {}
     entries = []
-    for flattened, fid in flat:
+    for flattened, _ in flat:
         canon = (
             str(flattened.get("title") or ""),
             str(flattened.get("body") or ""),
@@ -207,7 +210,7 @@ def build_oracle_artifact(opaque_key: str, findings: list) -> dict:
         )
         ordinal = groups.get(canon, 0)
         groups[canon] = ordinal + 1
-        entry = {**flattened, "finding_id": fid}
+        entry = dict(flattened)
         entry["candidate_id"] = vc.derive_candidate_id(opaque_key, entry, ordinal)
         entries.append(entry)
     return {

--- a/daydream/benchmark/harbor/templates/tests/golden-review.json
+++ b/daydream/benchmark/harbor/templates/tests/golden-review.json
@@ -1,6 +1,6 @@
 [
   {
-    "finding_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "finding_id": "ddcdd0b8729228dcaaa1259002bdd579ed4c872d6d4f5c1e6a9be0bbcfebbb12",
     "title": "Cache key not tenant-scoped",
     "body": "The cache key collides across tenants.",
     "severity": "high",
@@ -9,7 +9,7 @@
     "end_line": 42
   },
   {
-    "finding_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "finding_id": "1bd3098840e229306e03a15f7aa3da9a3aaacdde8d56af56e0cbeab5683fb91c",
     "title": "Response not validated",
     "body": "The response is interpolated without escaping.",
     "severity": "medium",

--- a/daydream/benchmark/harbor/templates/tests/score_review.py
+++ b/daydream/benchmark/harbor/templates/tests/score_review.py
@@ -12,6 +12,7 @@ atomically.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import os
 import sys
@@ -152,11 +153,10 @@ def parse_verdict(raw: object) -> verifier_core.Verdict:
 
     ``gold_id``/``candidate_id`` are placeholders the caller (``judge_pairs``)
     stamps onto the returned verdict. Any violation — wrong type, out-of-range
-    confidence, missing key, non-dict input — raises ``VerifierError``; never
-    silently coerces a fallback value.
+    confidence, missing key, unknown key, non-dict input — raises
+    ``VerifierError``; never silently coerces a fallback value.
     """
-    if not isinstance(raw, dict):
-        raise VerifierError("verdict must be a JSON object")
+    verifier_core.validate_exact_keys(raw, {"match", "confidence", "reasoning"}, "verdict")
     if "match" not in raw:
         raise VerifierError("verdict missing required field 'match'")
     match = raw["match"]
@@ -490,6 +490,40 @@ def _read_json(path: Path) -> Any:
         raise VerifierError(f"could not read {path}: {exc}") from exc
 
 
+def _read_artifact_bytes(path: str | Path) -> dict[str, Any]:
+    """Read the candidate artifact as raw bytes, size-checked and parsed in one step.
+
+    The raw byte size is checked against ``verifier_core.MAX_ARTIFACT_BYTES``
+    BEFORE any parse -- a whitespace-inflated payload over the cap fails on its
+    raw size alone, never reaching the judge. A ``JSONDecodeError`` becomes a
+    ``VerifierError`` naming only the path (never content).
+    """
+    raw = Path(path).read_bytes()
+    if len(raw) > verifier_core.MAX_ARTIFACT_BYTES:
+        raise VerifierError("candidate artifact exceeds 1 MiB (raw bytes)")
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        raise VerifierError(f"candidate artifact is not valid JSON: {Path(path)}") from None
+    return parsed
+
+
+def _load_verifier_metadata(gold_path: Path) -> dict[str, Any]:
+    """Load the sibling immutable task-bound verifier metadata beside the gold file.
+
+    Requires the ``{schema_version, case_id, base_ref, head_ref,
+    template_version, gold_sha256}`` object the compiler renders per case; a
+    missing/dict-violating field raises ``VerifierError``.
+    """
+    meta = _read_json(gold_path.parent / "verifier-metadata.json")
+    if not isinstance(meta, dict):
+        raise VerifierError("verifier metadata must be a JSON object")
+    for field in ("case_id", "base_ref", "head_ref", "gold_sha256"):
+        if field not in meta:
+            raise VerifierError(f"verifier metadata missing required field {field}")
+    return meta
+
+
 def _atomic_write(out_dir: Path, filename: str, payload: str) -> None:
     """Write a file atomically via temp + rename so a crash never leaves a partial file."""
     tmp = out_dir / f".{filename}.{os.getpid()}.tmp"
@@ -520,10 +554,16 @@ def run_verifier(
 ) -> verifier_core.Reward:
     """Validate gold + the candidate artifact, judge all pairs, score, and write atomically.
 
-    Any ``VerifierError`` (validation, judging, parsing, exhausted retries, or a
-    missing client) becomes a ``Reward(reward=0, verifier_error=1)`` — the task
-    fails whole, never reporting a partial score. Both output files are written
-    atomically (temp + rename). Never emits source or diffs.
+    Validation order (issue #817): the candidate artifact is read as raw bytes
+    (size-checked before parse), validated to its exact schema, then bound to
+    the task's immutable ``verifier-metadata.json`` (case id + base/head refs);
+    the gold is then read as raw bytes and its sha256 must match the
+    compiler-rendered ``gold_sha256`` sentinel before it is parsed and validated
+    (canonical/unique gold ids). Any ``VerifierError`` (validation, binding,
+    digest, parsing, judging, exhausted retries, or a missing client) becomes a
+    ``Reward(reward=0, verifier_error=1)`` — the task fails whole, never
+    reporting a partial score. Both output files are written atomically (temp +
+    rename). Never emits source or diffs.
     """
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -538,12 +578,27 @@ def run_verifier(
     try:
         if client is None:
             raise VerifierError("no judge client configured (missing DAYDREAM_JUDGE_*)")
-        gold_raw = _read_json(Path(gold_path))
+        artifact_raw = _read_artifact_bytes(artifact_path)
+        candidates = verifier_core.validate_candidate_artifact(artifact_raw)
+
+        metadata = _load_verifier_metadata(Path(gold_path))
+        if artifact_raw["case_id"] != metadata["case_id"]:
+            raise VerifierError("candidate case_id does not match the bound task")
+        if artifact_raw["base_ref"] != metadata["base_ref"]:
+            raise VerifierError("candidate base_ref does not match the bound task")
+        if artifact_raw["head_ref"] != metadata["head_ref"]:
+            raise VerifierError("candidate head_ref does not match the bound task")
+
+        gold_bytes = Path(gold_path).read_bytes()
+        if hashlib.sha256(gold_bytes).hexdigest() != metadata["gold_sha256"]:
+            raise VerifierError("gold digest mismatch")
+        try:
+            gold_raw = json.loads(gold_bytes)
+        except json.JSONDecodeError:
+            raise VerifierError(f"gold set is not valid JSON: {Path(gold_path)}") from None
         if not isinstance(gold_raw, list):
             raise VerifierError("gold set must be a JSON list")
         gold_parsed = verifier_core.validate_gold_set(gold_raw)
-        artifact_raw = _read_json(Path(artifact_path))
-        candidates = verifier_core.validate_candidate_artifact(artifact_raw)
 
         verdicts: list[verifier_core.Verdict] = []
         matches: set[tuple[str, str]] = set()

--- a/daydream/benchmark/harbor/templates/tests/score_review.py
+++ b/daydream/benchmark/harbor/templates/tests/score_review.py
@@ -159,13 +159,9 @@ def parse_verdict(raw: object) -> verifier_core.Verdict:
     if not isinstance(raw, dict):
         raise VerifierError("verdict must be a JSON object")
     verifier_core.validate_exact_keys(raw, {"match", "confidence", "reasoning"}, "verdict")
-    if "match" not in raw:
-        raise VerifierError("verdict missing required field 'match'")
     match = raw["match"]
     if not isinstance(match, bool):
         raise VerifierError(f"verdict 'match' must be a boolean, got {match!r}")
-    if "confidence" not in raw:
-        raise VerifierError("verdict missing required field 'confidence'")
     confidence = raw["confidence"]
     if isinstance(confidence, bool) or not isinstance(confidence, (int, float)):
         raise VerifierError(
@@ -173,8 +169,6 @@ def parse_verdict(raw: object) -> verifier_core.Verdict:
         )
     if not 0.0 <= confidence <= 1.0:
         raise VerifierError(f"verdict 'confidence' must be in [0,1], got {confidence!r}")
-    if "reasoning" not in raw:
-        raise VerifierError("verdict missing required field 'reasoning'")
     reasoning = raw["reasoning"]
     if not isinstance(reasoning, str):
         raise VerifierError(f"verdict 'reasoning' must be a string, got {reasoning!r}")
@@ -500,7 +494,12 @@ def _read_artifact_bytes(path: str | Path) -> dict[str, Any]:
     raw size alone, never reaching the judge. A ``JSONDecodeError`` becomes a
     ``VerifierError`` naming only the path (never content).
     """
-    raw = Path(path).read_bytes()
+    try:
+        raw = Path(path).read_bytes()
+    except FileNotFoundError:
+        raise VerifierError(f"input file not found: {Path(path)}") from None
+    except OSError as exc:
+        raise VerifierError(f"could not read {Path(path)}: {exc}") from exc
     if len(raw) > verifier_core.MAX_ARTIFACT_BYTES:
         raise VerifierError("candidate artifact exceeds 1 MiB (raw bytes)")
     try:
@@ -584,14 +583,16 @@ def run_verifier(
         candidates = verifier_core.validate_candidate_artifact(artifact_raw)
 
         metadata = _load_verifier_metadata(Path(gold_path))
-        if artifact_raw["case_id"] != metadata["case_id"]:
-            raise VerifierError("candidate case_id does not match the bound task")
-        if artifact_raw["base_ref"] != metadata["base_ref"]:
-            raise VerifierError("candidate base_ref does not match the bound task")
-        if artifact_raw["head_ref"] != metadata["head_ref"]:
-            raise VerifierError("candidate head_ref does not match the bound task")
+        for field in ("case_id", "base_ref", "head_ref"):
+            if artifact_raw[field] != metadata[field]:
+                raise VerifierError(f"candidate {field} does not match the bound task")
 
-        gold_bytes = Path(gold_path).read_bytes()
+        try:
+            gold_bytes = Path(gold_path).read_bytes()
+        except FileNotFoundError:
+            raise VerifierError(f"input file not found: {gold_path}") from None
+        except OSError as exc:
+            raise VerifierError(f"could not read {gold_path}: {exc}") from exc
         if hashlib.sha256(gold_bytes).hexdigest() != metadata["gold_sha256"]:
             raise VerifierError("gold digest mismatch")
         try:

--- a/daydream/benchmark/harbor/templates/tests/score_review.py
+++ b/daydream/benchmark/harbor/templates/tests/score_review.py
@@ -156,6 +156,8 @@ def parse_verdict(raw: object) -> verifier_core.Verdict:
     confidence, missing key, unknown key, non-dict input — raises
     ``VerifierError``; never silently coerces a fallback value.
     """
+    if not isinstance(raw, dict):
+        raise VerifierError("verdict must be a JSON object")
     verifier_core.validate_exact_keys(raw, {"match", "confidence", "reasoning"}, "verdict")
     if "match" not in raw:
         raise VerifierError("verdict missing required field 'match'")

--- a/daydream/benchmark/harbor/templates/tests/score_review.py
+++ b/daydream/benchmark/harbor/templates/tests/score_review.py
@@ -509,19 +509,64 @@ def _read_artifact_bytes(path: str | Path) -> dict[str, Any]:
     return parsed
 
 
+def _read_gold_bytes(gold_path: Path, expected_sha256: str) -> list[Any]:
+    """Read the gold set as raw bytes, digest-checked, parsed, and list-validated.
+
+    Symmetric to ``_read_artifact_bytes`` for the trusted gold half: read the
+    raw bytes, verify the sha256 against the compiler-rendered sentinel, parse
+    the JSON, and assert the payload is a list. No raw-size cap applies -- gold
+    is shipped, read-only task data while the candidate artifact is the
+    attacker-controlled surface.
+    """
+    try:
+        gold_bytes = gold_path.read_bytes()
+    except FileNotFoundError:
+        raise VerifierError(f"input file not found: {gold_path}") from None
+    except OSError as exc:
+        raise VerifierError(f"could not read {gold_path}: {exc}") from exc
+    if hashlib.sha256(gold_bytes).hexdigest() != expected_sha256:
+        raise VerifierError("gold digest mismatch")
+    try:
+        gold_raw = json.loads(gold_bytes)
+    except json.JSONDecodeError:
+        raise VerifierError(f"gold set is not valid JSON: {gold_path}") from None
+    if not isinstance(gold_raw, list):
+        raise VerifierError("gold set must be a JSON list")
+    return gold_raw
+
+
 def _load_verifier_metadata(gold_path: Path) -> dict[str, Any]:
     """Load the sibling immutable task-bound verifier metadata beside the gold file.
 
     Requires the ``{schema_version, case_id, base_ref, head_ref,
     template_version, gold_sha256}`` object the compiler renders per case; a
-    missing/dict-violating field raises ``VerifierError``.
+    missing/dict-violating field raises ``VerifierError``. The versioned shape
+    is gated: ``schema_version`` must be 1 (parity with the candidate
+    artifact's own gate in ``verifier_core``) and ``template_version`` must be
+    a non-empty string, so a mismatched metadata schema fails the task whole
+    rather than mis-binding it.
     """
     meta = _read_json(gold_path.parent / "verifier-metadata.json")
     if not isinstance(meta, dict):
         raise VerifierError("verifier metadata must be a JSON object")
-    for field in ("case_id", "base_ref", "head_ref", "gold_sha256"):
+    for field in (
+        "schema_version",
+        "case_id",
+        "base_ref",
+        "head_ref",
+        "template_version",
+        "gold_sha256",
+    ):
         if field not in meta:
             raise VerifierError(f"verifier metadata missing required field {field}")
+    if meta["schema_version"] != 1:
+        raise VerifierError(
+            f"unsupported verifier metadata schema_version {meta['schema_version']!r}"
+        )
+    if not isinstance(meta["template_version"], str) or not meta["template_version"].strip():
+        raise VerifierError(
+            "verifier metadata template_version must be a non-empty string"
+        )
     return meta
 
 
@@ -587,20 +632,7 @@ def run_verifier(
             if artifact_raw[field] != metadata[field]:
                 raise VerifierError(f"candidate {field} does not match the bound task")
 
-        try:
-            gold_bytes = Path(gold_path).read_bytes()
-        except FileNotFoundError:
-            raise VerifierError(f"input file not found: {gold_path}") from None
-        except OSError as exc:
-            raise VerifierError(f"could not read {gold_path}: {exc}") from exc
-        if hashlib.sha256(gold_bytes).hexdigest() != metadata["gold_sha256"]:
-            raise VerifierError("gold digest mismatch")
-        try:
-            gold_raw = json.loads(gold_bytes)
-        except json.JSONDecodeError:
-            raise VerifierError(f"gold set is not valid JSON: {Path(gold_path)}") from None
-        if not isinstance(gold_raw, list):
-            raise VerifierError("gold set must be a JSON list")
+        gold_raw = _read_gold_bytes(Path(gold_path), metadata["gold_sha256"])
         gold_parsed = verifier_core.validate_gold_set(gold_raw)
 
         verdicts: list[verifier_core.Verdict] = []

--- a/daydream/benchmark/harbor/templates/tests/verifier_core.py
+++ b/daydream/benchmark/harbor/templates/tests/verifier_core.py
@@ -175,7 +175,7 @@ def _finding_kwargs(
         raise VerifierError(f"{side} finding must be a dict")
     validate_exact_keys(
         raw,
-        {id_key, "title", "body", "severity", "path", "start_line", "end_line"},
+        CANDIDATE_FINDING_KEYS if side == "candidate" else GOLD_FINDING_KEYS,
         f"{side} finding",
     )
     try:

--- a/daydream/benchmark/harbor/templates/tests/verifier_core.py
+++ b/daydream/benchmark/harbor/templates/tests/verifier_core.py
@@ -20,6 +20,12 @@ CONFIDENCE_THRESHOLD = 0.7
 _SEP = "\x1f"
 _HEX64 = re.compile(r"^[0-9a-f]{64}$")
 
+# Exact, versioned key sets (issue #817): a candidate artifact / finding and a
+# gold finding must carry exactly these keys -- no more, no fewer.
+CANDIDATE_ARTIFACT_KEYS = {"schema_version", "case_id", "base_ref", "head_ref", "findings"}
+CANDIDATE_FINDING_KEYS = {"candidate_id", "title", "body", "severity", "path", "start_line", "end_line"}
+GOLD_FINDING_KEYS = {"finding_id", "title", "body", "severity", "path", "start_line", "end_line"}
+
 
 class VerifierError(Exception):
     """Raised on any invalid verifier input (mirrors a pydantic error)."""
@@ -144,12 +150,34 @@ class CandidateFinding(_FindingContent):
         super().__post_init__()
 
 
+def validate_exact_keys(raw: object, allowed: set[str], context: str) -> None:
+    """Enforce an exact key set over a dict, naming only keys and context.
+
+    Raises :class:`VerifierError` when *raw* is not a dict, when any allowed
+    key is missing, or when any key present is not in *allowed* -- with a
+    leak-free message naming only the keys and *context*, never values.
+    """
+    if not isinstance(raw, dict):
+        raise VerifierError(f"{context} must be a JSON object")
+    missing = sorted(allowed - set(raw))
+    if missing:
+        raise VerifierError(f"{context} missing required field(s): {', '.join(missing)}")
+    extra = sorted(set(raw) - allowed)
+    if extra:
+        raise VerifierError(f"{context} contains unknown field(s): {', '.join(extra)}")
+
+
 def _finding_kwargs(
     raw: dict[str, object], *, side: str, id_key: str
 ) -> dict[str, object]:
     """Validate a raw finding dict and return its model constructor kwargs."""
     if not isinstance(raw, dict):
         raise VerifierError(f"{side} finding must be a dict")
+    validate_exact_keys(
+        raw,
+        {id_key, "title", "body", "severity", "path", "start_line", "end_line"},
+        f"{side} finding",
+    )
     try:
         ident = _validate_hex64(raw[id_key], id_key)
     except KeyError as exc:
@@ -220,8 +248,7 @@ def _canonical_tuple(finding: object) -> tuple[object, ...]:
 
 def validate_candidate_artifact(raw: dict[str, object]) -> list[CandidateFinding]:
     """Validate a §9 candidate artifact and return its parsed findings."""
-    if not isinstance(raw, dict):
-        raise VerifierError("candidate artifact must be a dict")
+    validate_exact_keys(raw, CANDIDATE_ARTIFACT_KEYS, "candidate artifact")
     try:
         schema_version = raw["schema_version"]
         case_id = raw["case_id"]

--- a/daydream/benchmark/harbor/templates/tests/verifier_core.py
+++ b/daydream/benchmark/harbor/templates/tests/verifier_core.py
@@ -286,10 +286,21 @@ def validate_candidate_artifact(raw: dict[str, object]) -> list[CandidateFinding
 
 
 def validate_gold_set(raw: list[dict[str, object]]) -> list[GoldFinding]:
-    """Validate a gold set against the 50-finding cap and field limits."""
+    """Validate a gold set: 50-finding cap, per-member fields, canonical unique ids."""
     if len(raw) > MAX_GOLD_FINDINGS:
         raise VerifierError("gold set exceeds 50 findings")
-    return [parse_gold_finding(f) for f in raw]
+    parsed = [parse_gold_finding(f) for f in raw]
+    seen: set[str] = set()
+    for f in parsed:
+        expected = hashlib.sha256(
+            _SEP.join(str(part) for part in _canonical_tuple(f)).encode("utf-8")
+        ).hexdigest()
+        if f.finding_id != expected:
+            raise VerifierError("gold finding_id is not the canonical digest")
+        if f.finding_id in seen:
+            raise VerifierError("duplicate gold finding_id")
+        seen.add(f.finding_id)
+    return parsed
 
 
 # ---------------------------------------------------------------------------

--- a/daydream/benchmark/harbor/verifier_core.py
+++ b/daydream/benchmark/harbor/verifier_core.py
@@ -175,7 +175,7 @@ def _finding_kwargs(
         raise VerifierError(f"{side} finding must be a dict")
     validate_exact_keys(
         raw,
-        {id_key, "title", "body", "severity", "path", "start_line", "end_line"},
+        CANDIDATE_FINDING_KEYS if side == "candidate" else GOLD_FINDING_KEYS,
         f"{side} finding",
     )
     try:

--- a/daydream/benchmark/harbor/verifier_core.py
+++ b/daydream/benchmark/harbor/verifier_core.py
@@ -20,6 +20,12 @@ CONFIDENCE_THRESHOLD = 0.7
 _SEP = "\x1f"
 _HEX64 = re.compile(r"^[0-9a-f]{64}$")
 
+# Exact, versioned key sets (issue #817): a candidate artifact / finding and a
+# gold finding must carry exactly these keys -- no more, no fewer.
+CANDIDATE_ARTIFACT_KEYS = {"schema_version", "case_id", "base_ref", "head_ref", "findings"}
+CANDIDATE_FINDING_KEYS = {"candidate_id", "title", "body", "severity", "path", "start_line", "end_line"}
+GOLD_FINDING_KEYS = {"finding_id", "title", "body", "severity", "path", "start_line", "end_line"}
+
 
 class VerifierError(Exception):
     """Raised on any invalid verifier input (mirrors a pydantic error)."""
@@ -144,12 +150,34 @@ class CandidateFinding(_FindingContent):
         super().__post_init__()
 
 
+def validate_exact_keys(raw: object, allowed: set[str], context: str) -> None:
+    """Enforce an exact key set over a dict, naming only keys and context.
+
+    Raises :class:`VerifierError` when *raw* is not a dict, when any allowed
+    key is missing, or when any key present is not in *allowed* -- with a
+    leak-free message naming only the keys and *context*, never values.
+    """
+    if not isinstance(raw, dict):
+        raise VerifierError(f"{context} must be a JSON object")
+    missing = sorted(allowed - set(raw))
+    if missing:
+        raise VerifierError(f"{context} missing required field(s): {', '.join(missing)}")
+    extra = sorted(set(raw) - allowed)
+    if extra:
+        raise VerifierError(f"{context} contains unknown field(s): {', '.join(extra)}")
+
+
 def _finding_kwargs(
     raw: dict[str, object], *, side: str, id_key: str
 ) -> dict[str, object]:
     """Validate a raw finding dict and return its model constructor kwargs."""
     if not isinstance(raw, dict):
         raise VerifierError(f"{side} finding must be a dict")
+    validate_exact_keys(
+        raw,
+        {id_key, "title", "body", "severity", "path", "start_line", "end_line"},
+        f"{side} finding",
+    )
     try:
         ident = _validate_hex64(raw[id_key], id_key)
     except KeyError as exc:
@@ -220,8 +248,7 @@ def _canonical_tuple(finding: object) -> tuple[object, ...]:
 
 def validate_candidate_artifact(raw: dict[str, object]) -> list[CandidateFinding]:
     """Validate a §9 candidate artifact and return its parsed findings."""
-    if not isinstance(raw, dict):
-        raise VerifierError("candidate artifact must be a dict")
+    validate_exact_keys(raw, CANDIDATE_ARTIFACT_KEYS, "candidate artifact")
     try:
         schema_version = raw["schema_version"]
         case_id = raw["case_id"]

--- a/daydream/benchmark/harbor/verifier_core.py
+++ b/daydream/benchmark/harbor/verifier_core.py
@@ -286,10 +286,21 @@ def validate_candidate_artifact(raw: dict[str, object]) -> list[CandidateFinding
 
 
 def validate_gold_set(raw: list[dict[str, object]]) -> list[GoldFinding]:
-    """Validate a gold set against the 50-finding cap and field limits."""
+    """Validate a gold set: 50-finding cap, per-member fields, canonical unique ids."""
     if len(raw) > MAX_GOLD_FINDINGS:
         raise VerifierError("gold set exceeds 50 findings")
-    return [parse_gold_finding(f) for f in raw]
+    parsed = [parse_gold_finding(f) for f in raw]
+    seen: set[str] = set()
+    for f in parsed:
+        expected = hashlib.sha256(
+            _SEP.join(str(part) for part in _canonical_tuple(f)).encode("utf-8")
+        ).hexdigest()
+        if f.finding_id != expected:
+            raise VerifierError("gold finding_id is not the canonical digest")
+        if f.finding_id in seen:
+            raise VerifierError("duplicate gold finding_id")
+        seen.add(f.finding_id)
+    return parsed
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_benchmark_harbor_build.py
+++ b/tests/test_benchmark_harbor_build.py
@@ -507,6 +507,20 @@ def test_compile_findings_case_full_tree_and_gold_oracle_agree(tmp_path, fake_gh
     assert lock["cases"][key]["files"]["tests/verifier_core.py"] == \
         lock["files"][f"{key}/tests/verifier_core.py"]
     assert not any("timestamp" in k or "created_at" in k for k in lock.keys())
+
+    # compiler-rendered immutable verifier metadata beside the gold file
+    meta = _load_json(case / "tests" / "verifier-metadata.json")
+    assert meta["case_id"] == key and meta["base_ref"] == "base" and meta["head_ref"] == "head"
+    assert meta["schema_version"] == 1 and meta["template_version"] == build.TEMPLATE_VERSION
+    assert meta["gold_sha256"] == lock["cases"][key]["gold_sha256"]
+    assert meta["gold_sha256"] == hashlib.sha256((case / "tests" / "golden-review.json").read_bytes()).hexdigest()
+    # hidden digest + rendered verifier-script digest inventoried in the lock
+    assert "verifier_script_sha256" in lock["cases"][key]
+    assert lock["cases"][key]["gold_sha256"]  # the hidden-gold sentinel
+    sr_bytes = (case / "tests" / "score_review.py").read_bytes()
+    vc_bytes = (case / "tests" / "verifier_core.py").read_bytes()
+    assert lock["cases"][key]["verifier_script_sha256"] == hashlib.sha256(sr_bytes + vc_bytes).hexdigest()
+
     for rel, data in _harbor_tree_bytes(ws).items():
         if rel == "benchmark.lock.json":
             continue
@@ -685,3 +699,26 @@ def test_compile_rejects_when_a_case_is_not_compilable(tmp_path, fake_gh):
         assert False, "expected CompileError for a non-ready case"
     except CompileError as exc:
         assert case_id in str(exc)
+
+
+def test_compiled_findings_oracle_scores_reward_1(sr_module, tmp_path, fake_gh) -> None:
+    from daydream.benchmark.harbor import build
+    ws, case_id, _ = _seed_ready_workspace(tmp_path, fake_gh)
+    key = build.derive_task_key(case_id)
+    build.compile_workspace(ws)
+    case = ws / "harbor" / key
+
+    class MatchClient:
+        async def complete_json(self, *, user, system, max_tokens):
+            return {"match": True, "confidence": 1.0, "reasoning": "identical"}
+
+    gold_path = case / "tests" / "golden-review.json"
+    oracle_path = case / "solution" / "golden-review.json"
+    out = tmp_path / "out"
+    reward = sr_module.run_verifier(
+        gold_path, oracle_path, out,
+        client=MatchClient(),
+        env={"DAYDREAM_JUDGE_PROVIDER": "anthropic", "DAYDREAM_JUDGE_MODEL": "m",
+             "DAYDREAM_JUDGE_API_KEY": "k", "DAYDREAM_JUDGE_BASE_URL": None},
+    )
+    assert reward.reward == 1.0 and reward.verifier_error == 0

--- a/tests/test_benchmark_harbor_build.py
+++ b/tests/test_benchmark_harbor_build.py
@@ -421,6 +421,10 @@ def test_build_oracle_artifact_passes_validation_and_derives_candidate_ids():
         groups[canon] = ordinal + 1
         expected_ids.append(vc.derive_candidate_id(key, f, ordinal))
     assert [f["candidate_id"] for f in art["findings"]] == expected_ids
+    # exactly candidate-shaped: gold-only finding_id and provenance are absent
+    for entry in art["findings"]:
+        assert set(entry) == {"candidate_id", "title", "body", "severity",
+                              "path", "start_line", "end_line"}
     # round-trips through the verifier's own validation
     assert vc.validate_candidate_artifact(art)
 

--- a/tests/test_benchmark_verifier_core.py
+++ b/tests/test_benchmark_verifier_core.py
@@ -1,5 +1,6 @@
 """Tests for the stdlib-only harbor verifier core module."""
 
+import hashlib
 import json
 
 import pytest
@@ -222,12 +223,20 @@ def test_artifact_rejects_over_100_findings():
         validate_candidate_artifact(_artifact(_valid_findings(101)))
 
 def test_gold_set_accepts_and_returns_models():
-    gs = validate_gold_set([_gold(), _gold(finding_id="b" * 64, title="B")])
+    g1 = _gold()
+    g1["finding_id"] = _canonical_gold_id(g1)
+    g2 = _gold(title="B")
+    g2["finding_id"] = _canonical_gold_id(g2)
+    gs = validate_gold_set([g1, g2])
     assert len(gs) == 2 and all(isinstance(g, GoldFinding) for g in gs)
 
 
 def test_gold_set_rejects_over_50():
-    many = [_gold(finding_id=(hex(i)[2:].zfill(64)), title=f"f{i}") for i in range(51)]
+    many = []
+    for i in range(51):
+        f = _gold(title=f"f{i}")
+        f["finding_id"] = _canonical_gold_id(f)
+        many.append(f)
     with pytest.raises(VerifierError):
         validate_gold_set(many)
 
@@ -400,3 +409,28 @@ def test_gold_set_rejects_unknown_finding_key():
     g["provenance"] = {"kind": "authored", "source_ids": []}
     with pytest.raises(VerifierError):
         validate_gold_set([g])
+
+
+def _canonical_gold_id(f: dict) -> str:
+    payload = "\x1f".join([
+        str(f.get("title") or ""), str(f.get("body") or ""),
+        str(f.get("severity") or ""), str(f.get("path") or ""),
+        str(f.get("start_line")), str(f.get("end_line")),
+    ])
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def test_gold_set_rejects_non_canonical_finding_id():
+    f = _gold()
+    f["finding_id"] = "f" * 64  # valid 64-hex but not the canonical digest
+    with pytest.raises(VerifierError):
+        validate_gold_set([f])
+
+
+def test_gold_set_rejects_duplicate_finding_ids():
+    fid = _canonical_gold_id(_gold())
+    with pytest.raises(VerifierError):
+        validate_gold_set([
+            {**_gold(), "finding_id": fid},
+            {**_gold(), "finding_id": fid},
+        ])

--- a/tests/test_benchmark_verifier_core.py
+++ b/tests/test_benchmark_verifier_core.py
@@ -379,3 +379,24 @@ def test_reward_details_shape_and_no_source_leak():
     assert "same bug" in blob  # reasoning is kept
     assert "Cache key not scoped" not in blob  # finding body/title never leaks
     assert "f1" not in blob  # candidate content never leaks
+
+
+def test_artifact_rejects_unknown_top_level_key():
+    art = _artifact(_valid_findings(1))
+    art["smuggled"] = "x"
+    with pytest.raises(VerifierError):
+        validate_candidate_artifact(art)
+
+
+def test_artifact_rejects_unknown_finding_key():
+    fs = _valid_findings(1)
+    fs[0]["smuggled"] = "x"
+    with pytest.raises(VerifierError):
+        validate_candidate_artifact(_artifact(fs))
+
+
+def test_gold_set_rejects_unknown_finding_key():
+    g = _gold()
+    g["provenance"] = {"kind": "authored", "source_ids": []}
+    with pytest.raises(VerifierError):
+        validate_gold_set([g])

--- a/tests/test_benchmark_verifier_judge.py
+++ b/tests/test_benchmark_verifier_judge.py
@@ -801,7 +801,10 @@ def test_run_verifier_rejects_whitespace_padded_over_one_mib(sr_module, tmp_path
     # pad ABOVE the 1 MiB cap so the raw byte size is the only signal
     artifact_path.write_bytes(b" " * (sr.verifier_core.MAX_ARTIFACT_BYTES + 1 - len(compact)) + compact)
     out = tmp_path / "out"
-    reward = sr.run_verifier(gold_path, artifact_path, out, client=None, env={})
+    client = _CountingClient()
+    env = {"DAYDREAM_JUDGE_PROVIDER": "anthropic", "DAYDREAM_JUDGE_MODEL": "m",
+           "DAYDREAM_JUDGE_API_KEY": "k", "DAYDREAM_JUDGE_BASE_URL": None}
+    reward = sr.run_verifier(gold_path, artifact_path, out, client=client, env=env)
     assert reward.verifier_error == 1 and reward.reward == 0.0
 
 
@@ -813,7 +816,10 @@ def test_run_verifier_rejects_cross_case_replay(sr_module, tmp_path) -> None:
     artifact_path = tmp_path / "review.json"
     artifact_path.write_text(json.dumps(_candidate_artifact(sr, case_id="task-B", n=1)))
     out = tmp_path / "out"
-    reward = sr.run_verifier(gold_path, artifact_path, out, client=None, env={})
+    client = _CountingClient()
+    env = {"DAYDREAM_JUDGE_PROVIDER": "anthropic", "DAYDREAM_JUDGE_MODEL": "m",
+           "DAYDREAM_JUDGE_API_KEY": "k", "DAYDREAM_JUDGE_BASE_URL": None}
+    reward = sr.run_verifier(gold_path, artifact_path, out, client=client, env=env)
     assert reward.verifier_error == 1 and reward.reward == 0.0
 
 
@@ -827,7 +833,10 @@ def test_run_verifier_rejects_ref_mismatch(sr_module, tmp_path) -> None:
     art["head_ref"] = "feature/x"  # not the bound head ref
     artifact_path.write_text(json.dumps(art))
     out = tmp_path / "out"
-    reward = sr.run_verifier(gold_path, artifact_path, out, client=None, env={})
+    client = _CountingClient()
+    env = {"DAYDREAM_JUDGE_PROVIDER": "anthropic", "DAYDREAM_JUDGE_MODEL": "m",
+           "DAYDREAM_JUDGE_API_KEY": "k", "DAYDREAM_JUDGE_BASE_URL": None}
+    reward = sr.run_verifier(gold_path, artifact_path, out, client=client, env=env)
     assert reward.verifier_error == 1 and reward.reward == 0.0
 
 
@@ -844,7 +853,10 @@ def test_run_verifier_rejects_single_byte_gold_corruption(sr_module, tmp_path) -
     corrupted[-1] ^= 1
     gold_path.write_bytes(bytes(corrupted))
     out = tmp_path / "out"
-    reward = sr.run_verifier(gold_path, artifact_path, out, client=None, env={})
+    client = _CountingClient()
+    env = {"DAYDREAM_JUDGE_PROVIDER": "anthropic", "DAYDREAM_JUDGE_MODEL": "m",
+           "DAYDREAM_JUDGE_API_KEY": "k", "DAYDREAM_JUDGE_BASE_URL": None}
+    reward = sr.run_verifier(gold_path, artifact_path, out, client=client, env=env)
     assert reward.verifier_error == 1 and reward.reward == 0.0
 
 

--- a/tests/test_benchmark_verifier_judge.py
+++ b/tests/test_benchmark_verifier_judge.py
@@ -341,18 +341,16 @@ class _CountingClient:
 
 
 def _gold_list(n: int = 2) -> list[dict]:
-    return [
-        {
-            "finding_id": f"{i:064x}",
-            "title": "t",
-            "body": "b",
-            "severity": "high",
-            "path": "p",
-            "start_line": 1,
-            "end_line": 1,
-        }
-        for i in range(n)
-    ]
+    import hashlib as _h
+    out = []
+    for i in range(n):
+        f = {"title": f"t{i}", "body": "b", "severity": "high",
+             "path": "p", "start_line": 1, "end_line": 1}
+        payload = "\x1f".join([f["title"], f["body"], f["severity"],
+                               f["path"], str(f["start_line"]), str(f["end_line"])])
+        f["finding_id"] = _h.sha256(payload.encode("utf-8")).hexdigest()
+        out.append(f)
+    return out
 
 
 def _candidate_artifact(sr_module, *, case_id: str = "case-x", n: int = 2) -> dict:
@@ -738,8 +736,12 @@ def test_dense_but_verifier_legal_body_is_judged_not_failed_whole(sr_module, tmp
     # _DENSE_BODY is under the verifier's 8 KiB body byte bound, so the evaluator
     # escapes it -- but the fused rendering must not let that inflate the pair
     # past the cap and fail the whole task. A legal pair is judged, never voided.
-    gold = [{"finding_id": "0" * 64, "title": "t" * 500, "body": _DENSE_BODY,
+    gold = [{"title": "t" * 500, "body": _DENSE_BODY,
              "severity": "high", "path": "p" * 200, "start_line": 1, "end_line": 1}]
+    payload = "\x1f".join([gold[0]["title"], gold[0]["body"], gold[0]["severity"],
+                            gold[0]["path"], str(gold[0]["start_line"]), str(gold[0]["end_line"])])
+    import hashlib as _h
+    gold[0]["finding_id"] = _h.sha256(payload.encode("utf-8")).hexdigest()
     gold_path.write_text(json.dumps(gold))
     cand = {"title": "t" * 500, "body": _DENSE_BODY, "severity": "high",
             "path": "p" * 200, "start_line": 1, "end_line": 1}

--- a/tests/test_benchmark_verifier_judge.py
+++ b/tests/test_benchmark_verifier_judge.py
@@ -353,6 +353,22 @@ def _gold_list(n: int = 2) -> list[dict]:
     return out
 
 
+def _write_metadata(gold_path: Path, *, case_id: str = "case-x",
+                    base_ref: str = "base", head_ref: str = "head") -> None:
+    import hashlib as _h
+    meta = {
+        "schema_version": 1,
+        "case_id": case_id,
+        "base_ref": base_ref,
+        "head_ref": head_ref,
+        "template_version": "1",
+        "gold_sha256": _h.sha256(Path(gold_path).read_bytes()).hexdigest(),
+    }
+    Path(gold_path).with_name("verifier-metadata.json").write_text(
+        json.dumps(meta, sort_keys=True)
+    )
+
+
 def _candidate_artifact(sr_module, *, case_id: str = "case-x", n: int = 2) -> dict:
     finding_gen = []
     for i in range(n):
@@ -379,6 +395,7 @@ def test_run_verifier_writes_reward_and_details_atomically(sr_module, tmp_path, 
     sr = sr_module
     gold_path = tmp_path / "golden-review.json"
     gold_path.write_text(json.dumps(_gold_list(2)))
+    _write_metadata(gold_path)
     artifact_path = tmp_path / "review.json"
     artifact_path.write_text(json.dumps(_candidate_artifact(sr)))
     out_dir = tmp_path / "out"
@@ -409,6 +426,7 @@ def test_judge_failure_fails_whole_task_not_partial_score(sr_module, tmp_path) -
     sr = sr_module
     gold_path = tmp_path / "g.json"
     gold_path.write_text(json.dumps(_gold_list(2)))
+    _write_metadata(gold_path, case_id="c")
     artifact_path = tmp_path / "r.json"
     artifact_path.write_text(json.dumps(_candidate_artifact(sr, case_id="c")))
     out_dir = tmp_path / "out"
@@ -477,6 +495,7 @@ def test_oracle_artifact_scores_reward_1_for_findings_and_clean(sr_module, tmp_p
     sr = sr_module
     gold_path = tmp_path / "golden-review.json"
     gold_path.write_text(json.dumps(_gold_list(2)))
+    _write_metadata(gold_path, case_id="organic")
 
     oracle = _candidate_artifact(sr, case_id="organic")
     artifact_path = tmp_path / "review.json"
@@ -504,6 +523,7 @@ def test_oracle_artifact_scores_reward_1_for_findings_and_clean(sr_module, tmp_p
     # clean fixture: gold empty, candidates empty -> reward 1, clean_pass 1
     clean_gold = tmp_path / "cg.json"
     clean_gold.write_text(json.dumps([]))
+    _write_metadata(clean_gold, case_id="c", base_ref="b", head_ref="h")
     clean_art = tmp_path / "cr.json"
     clean_art.write_text(
         json.dumps({"schema_version": 1, "case_id": "c", "base_ref": "b", "head_ref": "h", "findings": []})
@@ -575,14 +595,22 @@ def test_shipped_gold_and_oracle_fixtures_validate_and_score_reward_1(
     candidates = sr.verifier_core.validate_candidate_artifact(solution_raw)
     assert len(candidates) == 2
 
+    # Run against temp copies (beside the shipped fixtures would pollute the
+    # checked-in template dir) with the matching task-bound metadata.
+    run_gold = tmp_path / "golden-review.json"
+    run_gold.write_bytes(gold_path.read_bytes())
+    run_solution = tmp_path / "solution-golden-review.json"
+    run_solution.write_bytes(solution_path.read_bytes())
+    _write_metadata(run_gold, case_id="case-x")
+
     class MatchClient:
         async def complete_json(self, *, user, system, max_tokens):
             return {"match": True, "confidence": 1.0, "reasoning": "identical"}
 
     out = tmp_path / "oracle-out"
     reward = sr.run_verifier(
-        gold_path,
-        solution_path,
+        run_gold,
+        run_solution,
         out,
         client=MatchClient(),
         env={
@@ -708,6 +736,7 @@ def test_oversized_body_fails_whole_task_with_no_judge_call(sr_module, tmp_path)
     gold = [{"finding_id": "0" * 64, "title": "t" * 500, "body": oversized_body,
              "severity": "high", "path": "p" * 200, "start_line": 1, "end_line": 1}]
     gold_path.write_text(json.dumps(gold))
+    _write_metadata(gold_path, case_id="c", base_ref="b", head_ref="h")
     cand = {"title": "t" * 500, "body": oversized_body, "severity": "high",
             "path": "p" * 200, "start_line": 1, "end_line": 1}
     cand["candidate_id"] = sr.verifier_core.derive_candidate_id("c", cand, 0)
@@ -743,6 +772,7 @@ def test_dense_but_verifier_legal_body_is_judged_not_failed_whole(sr_module, tmp
     import hashlib as _h
     gold[0]["finding_id"] = _h.sha256(payload.encode("utf-8")).hexdigest()
     gold_path.write_text(json.dumps(gold))
+    _write_metadata(gold_path, case_id="c", base_ref="b", head_ref="h")
     cand = {"title": "t" * 500, "body": _DENSE_BODY, "severity": "high",
             "path": "p" * 200, "start_line": 1, "end_line": 1}
     cand["candidate_id"] = sr.verifier_core.derive_candidate_id("c", cand, 0)
@@ -759,3 +789,66 @@ def test_dense_but_verifier_legal_body_is_judged_not_failed_whole(sr_module, tmp
     assert client.requests == 1         # not failed whole
     details = json.loads((out / "reward-details.json").read_text())
     assert _DENSE_BODY not in json.dumps(details)  # never leaks finding content
+
+
+def test_run_verifier_rejects_whitespace_padded_over_one_mib(sr_module, tmp_path) -> None:
+    sr = sr_module
+    gold_path = tmp_path / "golden-review.json"
+    gold_path.write_text(json.dumps(_gold_list(1)))
+    _write_metadata(gold_path)
+    artifact_path = tmp_path / "review.json"
+    compact = json.dumps(_candidate_artifact(sr, n=1)).encode("utf-8")
+    # pad ABOVE the 1 MiB cap so the raw byte size is the only signal
+    artifact_path.write_bytes(b" " * (sr.verifier_core.MAX_ARTIFACT_BYTES + 1 - len(compact)) + compact)
+    out = tmp_path / "out"
+    reward = sr.run_verifier(gold_path, artifact_path, out, client=None, env={})
+    assert reward.verifier_error == 1 and reward.reward == 0.0
+
+
+def test_run_verifier_rejects_cross_case_replay(sr_module, tmp_path) -> None:
+    sr = sr_module
+    gold_path = tmp_path / "golden-review.json"
+    gold_path.write_text(json.dumps(_gold_list(1)))
+    _write_metadata(gold_path, case_id="task-A")
+    artifact_path = tmp_path / "review.json"
+    artifact_path.write_text(json.dumps(_candidate_artifact(sr, case_id="task-B", n=1)))
+    out = tmp_path / "out"
+    reward = sr.run_verifier(gold_path, artifact_path, out, client=None, env={})
+    assert reward.verifier_error == 1 and reward.reward == 0.0
+
+
+def test_run_verifier_rejects_ref_mismatch(sr_module, tmp_path) -> None:
+    sr = sr_module
+    gold_path = tmp_path / "golden-review.json"
+    gold_path.write_text(json.dumps(_gold_list(1)))
+    _write_metadata(gold_path, head_ref="head")
+    artifact_path = tmp_path / "review.json"
+    art = _candidate_artifact(sr, n=1)
+    art["head_ref"] = "feature/x"  # not the bound head ref
+    artifact_path.write_text(json.dumps(art))
+    out = tmp_path / "out"
+    reward = sr.run_verifier(gold_path, artifact_path, out, client=None, env={})
+    assert reward.verifier_error == 1 and reward.reward == 0.0
+
+
+def test_run_verifier_rejects_single_byte_gold_corruption(sr_module, tmp_path) -> None:
+    sr = sr_module
+    gold_path = tmp_path / "golden-review.json"
+    gold = json.dumps(_gold_list(1))
+    gold_path.write_text(gold)
+    _write_metadata(gold_path)  # sentinel over the uncorrupted bytes
+    artifact_path = tmp_path / "review.json"
+    artifact_path.write_text(json.dumps(_candidate_artifact(sr, n=1)))
+    # corrupt one byte of the gold bytes after the sentinel was captured
+    corrupted = bytearray(gold.encode("utf-8"))
+    corrupted[-1] ^= 1
+    gold_path.write_bytes(bytes(corrupted))
+    out = tmp_path / "out"
+    reward = sr.run_verifier(gold_path, artifact_path, out, client=None, env={})
+    assert reward.verifier_error == 1 and reward.reward == 0.0
+
+
+def test_parse_verdict_rejects_unknown_key(sr_module) -> None:
+    sr = sr_module
+    with pytest.raises(sr.VerifierError):
+        sr.parse_verdict({"match": True, "confidence": 0.9, "reasoning": "ok", "extra": 1})

--- a/tests/test_benchmark_verifier_judge.py
+++ b/tests/test_benchmark_verifier_judge.py
@@ -346,8 +346,8 @@ def _gold_list(n: int = 2) -> list[dict]:
     for i in range(n):
         f = {"title": f"t{i}", "body": "b", "severity": "high",
              "path": "p", "start_line": 1, "end_line": 1}
-        payload = "\x1f".join([f["title"], f["body"], f["severity"],
-                               f["path"], str(f["start_line"]), str(f["end_line"])])
+        payload = "\x1f".join([str(f["title"]), str(f["body"]), str(f["severity"]),
+                               str(f["path"]), str(f["start_line"]), str(f["end_line"])])
         f["finding_id"] = _h.sha256(payload.encode("utf-8")).hexdigest()
         out.append(f)
     return out
@@ -767,8 +767,8 @@ def test_dense_but_verifier_legal_body_is_judged_not_failed_whole(sr_module, tmp
     # past the cap and fail the whole task. A legal pair is judged, never voided.
     gold = [{"title": "t" * 500, "body": _DENSE_BODY,
              "severity": "high", "path": "p" * 200, "start_line": 1, "end_line": 1}]
-    payload = "\x1f".join([gold[0]["title"], gold[0]["body"], gold[0]["severity"],
-                            gold[0]["path"], str(gold[0]["start_line"]), str(gold[0]["end_line"])])
+    payload = "\x1f".join([str(gold[0]["title"]), str(gold[0]["body"]), str(gold[0]["severity"]),
+                            str(gold[0]["path"]), str(gold[0]["start_line"]), str(gold[0]["end_line"])])
     import hashlib as _h
     gold[0]["finding_id"] = _h.sha256(payload.encode("utf-8")).hexdigest()
     gold_path.write_text(json.dumps(gold))


### PR DESCRIPTION
## Summary
- Enforce exact, versioned top-level/finding/verdict key sets for hidden gold and candidate artifacts — reject every unknown/missing key and wrong scalar type
- Enforce candidate byte size before JSON parsing; validate hidden-gold bytes against the compiler-rendered SHA-256 sentinel before parsing
- Bind candidate case_id, opaque task identity, base ref, and head ref to compiler-rendered immutable verifier metadata
- Emit an Oracle artifact that is exactly candidate-shaped (no gold-only IDs/provenance); treat any mismatch as bounded infrastructure failure with no judge call

## Motivation

Closes #817. The merged verifier ignored unknown top-level and finding keys, applied the 1 MiB limit after parsing/reserializing, and accepted arbitrary nonempty case_id/refs instead of binding them to the active opaque task. These permitted schema smuggling, whitespace size bypass, and cross-case replay. This PR enforces the exact contract so mismatches fail safely.

## Changes

### Added
- Hidden digest and rendered verifier-script digest inventoried in `benchmark.lock.json`
- Digest-checked gold loader; metadata schema/template version gating
- Tests for byte-parity, digest mismatch, whitespace-padded >1 MiB, duplicate IDs, cross-case replay, ref mismatch

### Changed
- `_read_gold_bytes` extraction; side-specific candidate/gold finding-key constants

### Fixed
- Verifier accepting unknown keys, size-bypass, cross-case replay; oracle emitting gold-only IDs

## Test Plan

- [x] `make check` green (lockcheck + ruff + mypy clean; full pytest 4178 passed / 6 skipped / 0 failed)
- [x] Template byte-parity verified (`verifier_core.py` == template)
- [x] Deterministic-authorship gate passed (`verify-branch-authors.sh` AUTHORS_OK)

## Checklist

- [x] Repository checks pass locally (`make check`)
- [ ] Actionlint passes for workflow YAML changes (if applicable)
- [x] Documentation updated (if applicable)

## Additional Context

Two sequential daydream deep-precision reviews (rounds 1 & 2) performed on fresh VMs; all findings resolved. Trajectories uploaded to HF.