### PR TITLE
fix(benchmark): harden authoring schemas and canonical finding identity (Closes #806)

### DIFF
--- a/daydream/benchmark/cli.py
+++ b/daydream/benchmark/cli.py
@@ -606,7 +606,8 @@ def _handle_benchmark_upgrade(args) -> int:
     """Deterministically upgrade legacy v1 case documents to v2 in place.
 
     Prints the per-case report plus any surfaced errors. Returns ``0`` on a
-    successful upgrade, ``1`` when a case errored or nothing changed.
+    successful upgrade (including an idempotent no-op second run) and ``1``
+    when a case errored.
     """
     from daydream.benchmark import migrate
 
@@ -618,7 +619,7 @@ def _handle_benchmark_upgrade(args) -> int:
         )
     for e in report.errors:
         print(f"error: {e}", file=sys.stderr)
-    if report.errors or not report.cases:
+    if report.errors:
         return 1
     return 0
 

--- a/daydream/benchmark/cli.py
+++ b/daydream/benchmark/cli.py
@@ -453,11 +453,11 @@ def _handle_bench_command(argv: list[str]) -> int:
 def _build_benchmark_parser() -> argparse.ArgumentParser:
     """Build the ``daydream benchmark`` subcommand parser.
 
-    Sub-verbs: ``init``, ``status``, ``validate``, ``import-prs``, ``curate``.
+    Sub-verbs: ``init``, ``status``, ``validate``, ``upgrade``, ``import-prs``, ``curate``.
     """
     parser = argparse.ArgumentParser(
         prog="daydream benchmark",
-        description="Private PR benchmark workspace: init/status/validate/import-prs/curate.",
+        description="Private PR benchmark workspace: init/status/validate/upgrade/import-prs/curate.",
     )
     sub = parser.add_subparsers(dest="subcommand")
 
@@ -476,6 +476,12 @@ def _build_benchmark_parser() -> argparse.ArgumentParser:
 
     validate_p = sub.add_parser("validate", help="validate the workspace (0/2/1 exit codes)")
     validate_p.add_argument("dir", type=Path, help="workspace directory")
+
+    upgrade_p = sub.add_parser(
+        "upgrade", help="deterministically upgrade legacy case documents (finding_id + schema_version)"
+    )
+    upgrade_p.add_argument("dir", type=Path, help="workspace directory")
+    upgrade_p.add_argument("--dry-run", action="store_true", help="report the upgrade without writing")
 
     import_prs_p = sub.add_parser(
         "import-prs", help="import explicit private GitHub PR evidence into the workspace"
@@ -596,6 +602,27 @@ def _handle_benchmark_validate(dir_path: Path) -> int:
     return code
 
 
+def _handle_benchmark_upgrade(args) -> int:
+    """Deterministically upgrade legacy v1 case documents to v2 in place.
+
+    Prints the per-case report plus any surfaced errors. Returns ``0`` on a
+    successful upgrade, ``1`` when a case errored or nothing changed.
+    """
+    from daydream.benchmark import migrate
+
+    report = migrate.migrate_workspace(args.dir, dry_run=args.dry_run)
+    for c in report.cases:
+        print(
+            f"case {c['case_id']}: finding_ids_recomputed={c['finding_ids_recomputed']} "
+            f"changed={c['changed']}"
+        )
+    for e in report.errors:
+        print(f"error: {e}", file=sys.stderr)
+    if report.errors or not report.cases:
+        return 1
+    return 0
+
+
 def _is_interactive_tty() -> bool:
     """True only when both stdin and stdout are real interactive terminals."""
     return sys.stdin.isatty() and sys.stdout.isatty()
@@ -636,7 +663,7 @@ def _handle_benchmark_curate(args) -> int:
 
 
 def _handle_benchmark_command(argv: list[str]) -> int:
-    """Handle ``daydream benchmark init|status|validate|import-prs|curate``.
+    """Handle ``daydream benchmark init|status|validate|upgrade|import-prs|curate``.
 
     Returns an exit code; ``daydream.cli.main`` translates it to a
     process exit. Expected workspace errors (``InitError``/``WorkspaceCorrupt``/
@@ -656,6 +683,8 @@ def _handle_benchmark_command(argv: list[str]) -> int:
         return _handle_benchmark_status(args.dir)
     if sub == "validate":
         return _handle_benchmark_validate(args.dir)
+    if sub == "upgrade":
+        return _handle_benchmark_upgrade(args)
     if sub == "import-prs":
         return _handle_benchmark_import_prs(args)
     if sub == "curate":

--- a/daydream/benchmark/cli.py
+++ b/daydream/benchmark/cli.py
@@ -614,8 +614,8 @@ def _handle_benchmark_upgrade(args) -> int:
     report = migrate.migrate_workspace(args.dir, dry_run=args.dry_run)
     for c in report.cases:
         print(
-            f"case {c['case_id']}: finding_ids_recomputed={c['finding_ids_recomputed']} "
-            f"changed={c['changed']}"
+            f"case {c.case_id}: finding_ids_recomputed={c.finding_ids_recomputed} "
+            f"changed={c.changed}"
         )
     for e in report.errors:
         print(f"error: {e}", file=sys.stderr)

--- a/daydream/benchmark/curation.py
+++ b/daydream/benchmark/curation.py
@@ -290,11 +290,8 @@ def _validate_raw(root: Path, case_id: str, raw: dict[str, Any]) -> None:
         if ids.count(fid) > 1:
             raise CurationError(f"case {case_id} has duplicate finding {fid}")
 
-    # A ready (final-attested) case must be snapshot-attested; the fixed schema
-    # does not express this, so the curation service enforces it as a rule.
-    if curation.get("state") == "ready" and not curation.get("snapshot_attested"):
-        raise CurationError(f"case {case_id} is ready but not snapshot-attested")
-
+    # ready => snapshot_attested and stale => not-attested are enforced by the
+    # schema Curation._consistent validator.
     candidates = raw.get("candidates") or []
     for finding in findings:
         _validate_location(root, raw, finding)

--- a/daydream/benchmark/curation.py
+++ b/daydream/benchmark/curation.py
@@ -30,6 +30,7 @@ from pydantic import ValidationError
 
 from daydream import git_ops
 from daydream.benchmark import schema, snapshot, storage
+from daydream.benchmark.schema import _schema_ready
 from daydream.benchmark.storage import load_yaml_strict
 
 
@@ -214,15 +215,6 @@ def _curation_model(curation: dict[str, Any]) -> schema.Curation:
     dropped here (it is recomputed by ``derive_gold_mode`` when read).
     """
     return schema.Curation(**{k: v for k, v in curation.items() if k != "gold_mode"})
-
-
-def _schema_ready(raw: dict[str, Any]) -> dict[str, Any]:
-    """A schema-valid copy of a raw case doc (persisted audit fields stripped)."""
-    doc = dict(raw)
-    curation = dict(raw.get("curation") or {})
-    curation.pop("gold_mode", None)
-    doc["curation"] = curation
-    return doc
 
 
 def _snapshot_head(raw: dict[str, Any]) -> str | None:

--- a/daydream/benchmark/curation.py
+++ b/daydream/benchmark/curation.py
@@ -380,7 +380,7 @@ def accept_candidate(root: Path, case_id: str, source_id: str) -> None:
         "location": candidate.get("location"),
         "provenance": {"kind": "historical", "source_ids": [source_id]},
     }
-    finding["finding_id"] = schema.derive_finding_id(finding)
+    finding["finding_id"] = schema.derive_finding_id(finding, case_id=case_id)
     raw.setdefault("curation", {}).setdefault("findings", []).append(finding)
     _derive_content(raw)
     _stage_case(root, case_id, raw, op="accept")
@@ -438,7 +438,7 @@ def add_finding(
             "source_ids": source_ids,
         },
     }
-    finding["finding_id"] = schema.derive_finding_id(finding)
+    finding["finding_id"] = schema.derive_finding_id(finding, case_id=case_id)
     raw.setdefault("curation", {}).setdefault("findings", []).append(finding)
     _derive_content(raw)
     _stage_case(root, case_id, raw, op="add")
@@ -472,7 +472,7 @@ def add_findings(
                 "source_ids": source_ids,
             },
         }
-        finding["finding_id"] = schema.derive_finding_id(finding)
+        finding["finding_id"] = schema.derive_finding_id(finding, case_id=case_id)
         curation.setdefault("findings", []).append(finding)
     _derive_content(raw)
     _stage_case(root, case_id, raw, op="add")
@@ -494,7 +494,7 @@ def _build_replacement(
             "source_ids": source_ids,
         },
     }
-    finding["finding_id"] = schema.derive_finding_id(finding)
+    finding["finding_id"] = schema.derive_finding_id(finding, case_id=case_id)
     return finding
 
 
@@ -789,7 +789,7 @@ def apply_gold_fragment(root: Path, case_id: str, fragment: dict[str, Any]) -> N
             raw, finding, list(frag.get("source_ids") or []), case_id=case_id
         )
         finding["provenance"] = {"kind": kind, "source_ids": source_ids}
-        finding["finding_id"] = schema.derive_finding_id(finding)
+        finding["finding_id"] = schema.derive_finding_id(finding, case_id=case_id)
         findings.append(finding)
     curation["findings"] = findings
 

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -778,7 +778,7 @@ def _case_materialize(
                 "error": None,
             }
         case_doc: dict[str, Any] = {
-            "schema_version": 1,
+            "schema_version": 2,
             "case_id": case_id,
             "pull_request": pull_request.model_dump(mode="json"),
             "snapshot": snapshot_doc,

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -728,12 +728,12 @@ def _case_materialize(
     attestation cleared — findings/exclusions are never overwritten by refresh.
     """
     pull_request = doc.pull_request
-    base_sha = (pull_request.get("base") or {}).get("sha")
+    base_sha = pull_request.base.sha
     out: list[tuple[str, str, dict[str, Any]]] = []
     bundle_drops: list[tuple[str, bytes]] = []
     seen: set[str] = set()
     for head_token in requested_heads:
-        head_sha = head_token if head_token != "final" else (pull_request.get("head") or {}).get("sha")
+        head_sha = head_token if head_token != "final" else pull_request.head.sha
         if not head_sha or head_sha in seen:
             continue
         seen.add(head_sha)
@@ -780,7 +780,7 @@ def _case_materialize(
         case_doc: dict[str, Any] = {
             "schema_version": 1,
             "case_id": case_id,
-            "pull_request": pull_request,
+            "pull_request": pull_request.model_dump(mode="json"),
             "snapshot": snapshot_doc,
             "source": {"import_file": import_file, "import_sha256": import_sha256},
             "curation": curation,

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -591,10 +591,10 @@ def _derive_title(body: str) -> str:
 
 
 def _title_ok(title: str) -> bool:
-    """True when *title* is non-empty and within the 500 UTF-8 byte bound."""
+    """True when *title* is non-empty and within the 500-character bound."""
     if not title:
         return False
-    return 0 < len(title.encode("utf-8")) <= 500
+    return 0 < len(title) <= 500
 
 
 def _anchor_location(

--- a/daydream/benchmark/harbor/build.py
+++ b/daydream/benchmark/harbor/build.py
@@ -156,16 +156,39 @@ def _flatten_finding(finding: dict) -> dict:
     }
 
 
-def build_gold_list(findings: list) -> list:
+def _gold_finding_ids(key: str, finding: dict) -> str:
+    """Derive the compiled gold id bound to the opaque task *key*.
+
+    Mirrors ``verifier_core.validate_gold_set``'s digest: sha256 over
+    ``(key, title, body, severity, path, start_line, end_line)`` joined by the
+    ``\x1f`` separator. The compiled gold ids are bound to the opaque compiled
+    task key (never the raw workspace authoring id), so the shipped gold
+    bundle carries no ``pr-...`` authoring token across the judge surface.
+    """
+    location = finding.get("location") or {}
+    payload = "\x1f".join([
+        str(key or ""),
+        str(finding.get("title") or ""),
+        str(finding.get("body") or ""),
+        str(finding.get("severity") or ""),
+        str(location.get("path")), str(location.get("start_line")),
+        str(location.get("end_line")),
+    ])
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def build_gold_list(findings: list, *, key: str) -> list:
     """Return the provenance-free hidden gold list, ordered by ``finding_id``.
 
-    ``[]`` for empty input; otherwise each entry carries ``finding_id`` plus
-    the flattened content fields, sorted by ``finding_id`` ascending. A
-    location-less finding raises :class:`CompileError`.
+    ``[]`` for empty input; otherwise each entry carries a ``finding_id``
+    derived under the opaque compiled task *key* (see
+    :func:`_gold_finding_ids`) plus the flattened content fields, sorted by
+    ``finding_id`` ascending. A location-less finding raises
+    :class:`CompileError`.
     """
     if not findings:
         return []
-    flat = [(_flatten_finding(f), f["finding_id"]) for f in findings]
+    flat = [(_flatten_finding(f), _gold_finding_ids(key, f)) for f in findings]
     flat.sort(key=lambda item: item[1])
     return [{"finding_id": fid, **flattened} for flattened, fid in flat]
 
@@ -362,7 +385,9 @@ def _authoring_input_digest(case_docs: dict, manifest: dict) -> str:
         payload[case_id] = {
             "title": str(pull_request.get("title") or ""),
             "body": str(pull_request.get("body") or ""),
-            "findings": build_gold_list(curation.get("findings") or []),
+            "findings": build_gold_list(
+                curation.get("findings") or [], key=derive_task_key(case_id)
+            ),
             "base": snapshot.get("original_base_sha"),
             "head": snapshot.get("original_head_sha"),
             "bundle_sha256": snapshot.get("bundle_sha256"),
@@ -402,7 +427,7 @@ def _compile_case(stage: Path, ws: Path, case_doc: dict, repo_slug: str) -> dict
         )
     validate_bundle_inventory(bundle_dst)
 
-    gold = build_gold_list(findings)
+    gold = build_gold_list(findings, key=key)
     gold_bytes = json.dumps(gold, sort_keys=False).encode("utf-8")
     gold_path = case_stage / "tests" / "golden-review.json"
     gold_path.parent.mkdir(parents=True, exist_ok=True)
@@ -410,12 +435,14 @@ def _compile_case(stage: Path, ws: Path, case_doc: dict, repo_slug: str) -> dict
 
     # Immutable, deterministic per-case verifier metadata beside the gold file
     # (no timestamps): opaque task key + base/head refs + the hidden-gold sentinel.
-    # ``source_case_id`` is the schema-scoped case id the gold finding ids were
-    # derived with (the opaque ``case_id`` binds the candidate artifact).
+    # ``source_case_id`` is the compiled opaque task key the gold finding ids
+    # are derived with (never the raw workspace authoring id); the opaque
+    # ``case_id`` binds the candidate artifact. This keeps the authoring
+    # identifier out of every shipped surface the leakage scan screens.
     metadata = {
         "schema_version": 1,
         "case_id": key,
-        "source_case_id": case_id,
+        "source_case_id": key,
         "base_ref": "base",
         "head_ref": "head",
         "template_version": TEMPLATE_VERSION,
@@ -520,6 +547,9 @@ def compile_workspace(root: Path) -> dict:
                 all_files.update({f"{key}/{rel}": sha for rel, sha in row["files"].items()})
                 control_plane[f"{key}/README.md"] = _CASE_README
                 control_plane[f"{key}/instruction.md"] = (stage / key / "instruction.md").read_text()
+                control_plane[f"{key}/tests/verifier-metadata.json"] = (
+                    stage / key / "tests" / "verifier-metadata.json"
+                ).read_text()
 
             (stage / "README.md").write_text(_ROOT_README)
             metric_bytes = (_TEMPLATE_DIR / "metric.py").read_bytes()

--- a/daydream/benchmark/harbor/build.py
+++ b/daydream/benchmark/harbor/build.py
@@ -18,7 +18,7 @@ import re
 import shutil
 from pathlib import Path
 
-from daydream.benchmark import snapshot, storage
+from daydream.benchmark import schema, snapshot, storage
 
 TEMPLATE_VERSION = "1"
 
@@ -159,22 +159,16 @@ def _flatten_finding(finding: dict) -> dict:
 def _gold_finding_ids(key: str, finding: dict) -> str:
     """Derive the compiled gold id bound to the opaque task *key*.
 
-    Mirrors ``verifier_core.validate_gold_set``'s digest: sha256 over
-    ``(key, title, body, severity, path, start_line, end_line)`` joined by the
-    ``\x1f`` separator. The compiled gold ids are bound to the opaque compiled
-    task key (never the raw workspace authoring id), so the shipped gold
-    bundle carries no ``pr-...`` authoring token across the judge surface.
+    Delegates to the canonical ``schema.derive_finding_id`` digest (sha256 over
+    the case-scoped ``(case_id, title, body, severity, path, start_line,
+    end_line)`` tuple, nulls normalized to the empty string) under the opaque
+    compiled task key as ``case_id``. The compiled gold ids are bound to the
+    opaque compiled task key (never the raw workspace authoring id), so the
+    shipped gold bundle carries no ``pr-...`` authoring token across the judge
+    surface. Delegating keeps this digest identical to the canonical workspace
+    derivation instead of a drifting local re-implementation.
     """
-    location = finding.get("location") or {}
-    payload = "\x1f".join([
-        str(key or ""),
-        str(finding.get("title") or ""),
-        str(finding.get("body") or ""),
-        str(finding.get("severity") or ""),
-        str(location.get("path")), str(location.get("start_line")),
-        str(location.get("end_line")),
-    ])
-    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    return schema.derive_finding_id(finding, case_id=key)
 
 
 def build_gold_list(findings: list, *, key: str) -> list:

--- a/daydream/benchmark/harbor/build.py
+++ b/daydream/benchmark/harbor/build.py
@@ -409,10 +409,13 @@ def _compile_case(stage: Path, ws: Path, case_doc: dict, repo_slug: str) -> dict
     gold_path.write_bytes(gold_bytes)
 
     # Immutable, deterministic per-case verifier metadata beside the gold file
-    # (no timestamps): opaque case id + base/head refs + the hidden-gold sentinel.
+    # (no timestamps): opaque task key + base/head refs + the hidden-gold sentinel.
+    # ``source_case_id`` is the schema-scoped case id the gold finding ids were
+    # derived with (the opaque ``case_id`` binds the candidate artifact).
     metadata = {
         "schema_version": 1,
         "case_id": key,
+        "source_case_id": case_id,
         "base_ref": "base",
         "head_ref": "head",
         "template_version": TEMPLATE_VERSION,

--- a/daydream/benchmark/harbor/templates/tests/golden-review.json
+++ b/daydream/benchmark/harbor/templates/tests/golden-review.json
@@ -1,6 +1,6 @@
 [
   {
-    "finding_id": "ddcdd0b8729228dcaaa1259002bdd579ed4c872d6d4f5c1e6a9be0bbcfebbb12",
+    "finding_id": "0e2356faadfbf30a1087a14255ca9273ed0bd6bc1edc741f0b709c4e52c237b5",
     "title": "Cache key not tenant-scoped",
     "body": "The cache key collides across tenants.",
     "severity": "high",
@@ -9,7 +9,7 @@
     "end_line": 42
   },
   {
-    "finding_id": "1bd3098840e229306e03a15f7aa3da9a3aaacdde8d56af56e0cbeab5683fb91c",
+    "finding_id": "68f808c0cf14de126374b79475fc3e40793c54bac5664ddc1f49f54a1446852d",
     "title": "Response not validated",
     "body": "The response is interpolated without escaping.",
     "severity": "medium",

--- a/daydream/benchmark/harbor/templates/tests/score_review.py
+++ b/daydream/benchmark/harbor/templates/tests/score_review.py
@@ -552,7 +552,6 @@ def _load_verifier_metadata(gold_path: Path) -> dict[str, Any]:
     for field in (
         "schema_version",
         "case_id",
-        "source_case_id",
         "base_ref",
         "head_ref",
         "template_version",
@@ -635,7 +634,7 @@ def run_verifier(
 
         gold_raw = _read_gold_bytes(Path(gold_path), metadata["gold_sha256"])
         gold_parsed = verifier_core.validate_gold_set(
-            gold_raw, case_id=metadata["source_case_id"]
+            gold_raw, case_id=metadata.get("source_case_id")
         )
 
         verdicts: list[verifier_core.Verdict] = []

--- a/daydream/benchmark/harbor/templates/tests/score_review.py
+++ b/daydream/benchmark/harbor/templates/tests/score_review.py
@@ -552,6 +552,7 @@ def _load_verifier_metadata(gold_path: Path) -> dict[str, Any]:
     for field in (
         "schema_version",
         "case_id",
+        "source_case_id",
         "base_ref",
         "head_ref",
         "template_version",
@@ -633,7 +634,9 @@ def run_verifier(
                 raise VerifierError(f"candidate {field} does not match the bound task")
 
         gold_raw = _read_gold_bytes(Path(gold_path), metadata["gold_sha256"])
-        gold_parsed = verifier_core.validate_gold_set(gold_raw)
+        gold_parsed = verifier_core.validate_gold_set(
+            gold_raw, case_id=metadata["source_case_id"]
+        )
 
         verdicts: list[verifier_core.Verdict] = []
         matches: set[tuple[str, str]] = set()

--- a/daydream/benchmark/harbor/templates/tests/verifier_core.py
+++ b/daydream/benchmark/harbor/templates/tests/verifier_core.py
@@ -47,8 +47,8 @@ def _validate_title(value: object) -> str:
         raise VerifierError(f"title must not be blank, got {value!r}")
     if "\x00" in value:
         raise VerifierError("title must not contain NUL")
-    if len(value.encode("utf-8")) > 500:
-        raise VerifierError("title exceeds 500 UTF-8 bytes")
+    if len(value) > 500:
+        raise VerifierError("title exceeds 500 characters")
     return value
 
 

--- a/daydream/benchmark/harbor/templates/tests/verifier_core.py
+++ b/daydream/benchmark/harbor/templates/tests/verifier_core.py
@@ -285,16 +285,27 @@ def validate_candidate_artifact(raw: dict[str, object]) -> list[CandidateFinding
     return parsed
 
 
-def validate_gold_set(raw: list[dict[str, object]]) -> list[GoldFinding]:
-    """Validate a gold set: 50-finding cap, per-member fields, canonical unique ids."""
+def validate_gold_set(
+    raw: list[dict[str, object]], *, case_id: str | None = None
+) -> list[GoldFinding]:
+    """Validate a gold set: 50-finding cap, per-member fields, canonical unique ids.
+
+    ``case_id`` is the schema-scoped case id the gold finding ids were derived
+    with (``sha256(case_id, title, body, severity, path, start_line, end_line)``);
+    a non-empty gold set requires it. An empty gold set (pure-clean case) needs
+    no case_id.
+    """
     if len(raw) > MAX_GOLD_FINDINGS:
         raise VerifierError("gold set exceeds 50 findings")
     parsed = [parse_gold_finding(f) for f in raw]
+    if not parsed:
+        return parsed
+    if case_id is None:
+        raise VerifierError("gold set validation requires a task case_id")
     seen: set[str] = set()
     for f in parsed:
-        expected = hashlib.sha256(
-            _SEP.join(str(part) for part in _canonical_tuple(f)).encode("utf-8")
-        ).hexdigest()
+        payload = _SEP.join(str(part) for part in (case_id,) + _canonical_tuple(f))
+        expected = hashlib.sha256(payload.encode("utf-8")).hexdigest()
         if f.finding_id != expected:
             raise VerifierError("gold finding_id is not the canonical digest")
         if f.finding_id in seen:

--- a/daydream/benchmark/harbor/templates/tests/verifier_core.py
+++ b/daydream/benchmark/harbor/templates/tests/verifier_core.py
@@ -292,19 +292,24 @@ def validate_gold_set(
 
     ``case_id`` is the schema-scoped case id the gold finding ids were derived
     with (``sha256(case_id, title, body, severity, path, start_line, end_line)``);
-    a non-empty gold set requires it. An empty gold set (pure-clean case) needs
-    no case_id.
+    a non-empty gold set requires it unless ``case_id`` is ``None`` (legacy
+    back-scoring of tasks compiled before the case-scoped digest), in which case
+    the finding ids are validated against the prior content-only digest. An
+    empty gold set (pure-clean case) needs no case_id.
     """
     if len(raw) > MAX_GOLD_FINDINGS:
         raise VerifierError("gold set exceeds 50 findings")
     parsed = [parse_gold_finding(f) for f in raw]
     if not parsed:
         return parsed
-    if case_id is None:
-        raise VerifierError("gold set validation requires a task case_id")
     seen: set[str] = set()
     for f in parsed:
-        payload = _SEP.join(str(part) for part in (case_id,) + _canonical_tuple(f))
+        digest_tail = (
+            _canonical_tuple(f)
+            if case_id is None
+            else ((case_id,) + _canonical_tuple(f))
+        )
+        payload = _SEP.join(str(part) for part in digest_tail)
         expected = hashlib.sha256(payload.encode("utf-8")).hexdigest()
         if f.finding_id != expected:
             raise VerifierError("gold finding_id is not the canonical digest")

--- a/daydream/benchmark/harbor/verifier_core.py
+++ b/daydream/benchmark/harbor/verifier_core.py
@@ -47,8 +47,8 @@ def _validate_title(value: object) -> str:
         raise VerifierError(f"title must not be blank, got {value!r}")
     if "\x00" in value:
         raise VerifierError("title must not contain NUL")
-    if len(value.encode("utf-8")) > 500:
-        raise VerifierError("title exceeds 500 UTF-8 bytes")
+    if len(value) > 500:
+        raise VerifierError("title exceeds 500 characters")
     return value
 
 

--- a/daydream/benchmark/harbor/verifier_core.py
+++ b/daydream/benchmark/harbor/verifier_core.py
@@ -285,16 +285,27 @@ def validate_candidate_artifact(raw: dict[str, object]) -> list[CandidateFinding
     return parsed
 
 
-def validate_gold_set(raw: list[dict[str, object]]) -> list[GoldFinding]:
-    """Validate a gold set: 50-finding cap, per-member fields, canonical unique ids."""
+def validate_gold_set(
+    raw: list[dict[str, object]], *, case_id: str | None = None
+) -> list[GoldFinding]:
+    """Validate a gold set: 50-finding cap, per-member fields, canonical unique ids.
+
+    ``case_id`` is the schema-scoped case id the gold finding ids were derived
+    with (``sha256(case_id, title, body, severity, path, start_line, end_line)``);
+    a non-empty gold set requires it. An empty gold set (pure-clean case) needs
+    no case_id.
+    """
     if len(raw) > MAX_GOLD_FINDINGS:
         raise VerifierError("gold set exceeds 50 findings")
     parsed = [parse_gold_finding(f) for f in raw]
+    if not parsed:
+        return parsed
+    if case_id is None:
+        raise VerifierError("gold set validation requires a task case_id")
     seen: set[str] = set()
     for f in parsed:
-        expected = hashlib.sha256(
-            _SEP.join(str(part) for part in _canonical_tuple(f)).encode("utf-8")
-        ).hexdigest()
+        payload = _SEP.join(str(part) for part in (case_id,) + _canonical_tuple(f))
+        expected = hashlib.sha256(payload.encode("utf-8")).hexdigest()
         if f.finding_id != expected:
             raise VerifierError("gold finding_id is not the canonical digest")
         if f.finding_id in seen:

--- a/daydream/benchmark/harbor/verifier_core.py
+++ b/daydream/benchmark/harbor/verifier_core.py
@@ -292,19 +292,24 @@ def validate_gold_set(
 
     ``case_id`` is the schema-scoped case id the gold finding ids were derived
     with (``sha256(case_id, title, body, severity, path, start_line, end_line)``);
-    a non-empty gold set requires it. An empty gold set (pure-clean case) needs
-    no case_id.
+    a non-empty gold set requires it unless ``case_id`` is ``None`` (legacy
+    back-scoring of tasks compiled before the case-scoped digest), in which case
+    the finding ids are validated against the prior content-only digest. An
+    empty gold set (pure-clean case) needs no case_id.
     """
     if len(raw) > MAX_GOLD_FINDINGS:
         raise VerifierError("gold set exceeds 50 findings")
     parsed = [parse_gold_finding(f) for f in raw]
     if not parsed:
         return parsed
-    if case_id is None:
-        raise VerifierError("gold set validation requires a task case_id")
     seen: set[str] = set()
     for f in parsed:
-        payload = _SEP.join(str(part) for part in (case_id,) + _canonical_tuple(f))
+        digest_tail = (
+            _canonical_tuple(f)
+            if case_id is None
+            else ((case_id,) + _canonical_tuple(f))
+        )
+        payload = _SEP.join(str(part) for part in digest_tail)
         expected = hashlib.sha256(payload.encode("utf-8")).hexdigest()
         if f.finding_id != expected:
             raise VerifierError("gold finding_id is not the canonical digest")

--- a/daydream/benchmark/migrate.py
+++ b/daydream/benchmark/migrate.py
@@ -1,0 +1,113 @@
+"""Deterministic, non-destructive upgrade path for legacy authoring cases.
+
+Issue #806 hardened the authoring schemas and made ``finding_id`` case-scoped
+(``sha256(case_id, title, body, severity, path, start_line, end_line)``) via
+:func:`daydream.benchmark.schema.derive_finding_id`, gated on
+``CaseDocument.schema_version == 2`` so pre-change v1 workspaces stay loadable.
+This module deterministically re-derives ``finding_id`` for every v1 case and
+bumps its ``schema_version`` to 2, mutating only those two fields and never
+touching authored content.
+
+Invalid data is **never** silently rewritten: a case that fails to load or
+validate is surfaced in ``UpgradeReport.errors`` and left byte-unchanged.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+from daydream.benchmark import schema, storage
+from daydream.benchmark.curation import _schema_ready
+
+
+@dataclass
+class CaseUpgrade:
+    """One upgraded case's record."""
+
+    case_id: str
+    finding_ids_recomputed: int
+    changed: bool
+
+    def __getitem__(self, key: str) -> object:
+        return getattr(self, key)
+
+
+@dataclass
+class UpgradeReport:
+    """The outcome of one :func:`migrate_workspace` run."""
+
+    cases: list[CaseUpgrade] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+def _upgrade_case(raw: dict, case_id: str) -> tuple[dict, int]:
+    """Return a copy of *raw* with case-scoped finding ids and schema_version 2.
+
+    Only ``finding_id`` values and ``schema_version`` are mutated; every
+    authored field is preserved verbatim.
+    """
+    doc = dict(raw)
+    findings = doc.get("curation", {}).get("findings") or []
+    recomputed = 0
+    new_findings = list(findings)
+    for i, finding in enumerate(findings):
+        expected = schema.derive_finding_id(finding, case_id=case_id)
+        if finding.get("finding_id") != expected:
+            new_findings[i] = {**finding, "finding_id": expected}
+            recomputed += 1
+    if recomputed:
+        curation = dict(doc["curation"])
+        curation["findings"] = new_findings
+        doc["curation"] = curation
+    doc["schema_version"] = 2
+    return doc, recomputed
+
+
+def migrate_workspace(root: Path, *, dry_run: bool = False) -> UpgradeReport:
+    """Deterministically upgrade every v1 case in the workspace to v2.
+
+    Recomputes case-scoped ``finding_id`` and bumps ``schema_version`` to 2,
+    writing changed cases atomically through ``storage.Transaction``. When
+    *dry_run* is True the report is computed without writing. Invalid cases are
+    recorded in ``report.errors`` and left byte-unchanged.
+    """
+    root = Path(root)
+    manifest = storage.load_yaml_strict(root / "benchmark.yaml")
+    report = UpgradeReport()
+    writes: dict[str, bytes] = {}
+    upgrades: list[CaseUpgrade] = []
+
+    for _case in manifest.get("cases") or []:
+        case_id = _case.get("case_id")
+        case_file = _case.get("case_file")
+        try:
+            raw = storage.load_yaml_strict(root / case_file)
+            current = raw.get("schema_version")
+            if current == 2:
+                continue
+            if current != 1:
+                raise ValueError(
+                    f"case {case_id} has unsupported schema_version {current!r}"
+                )
+            new_raw, recomputed = _upgrade_case(raw, case_id)
+            # strip the persisted audit field for validation (curation pattern),
+            # but keep it in the written output — authored content is preserved.
+            schema.CaseDocument.model_validate(_schema_ready(new_raw))
+            changed = new_raw.get("schema_version") != raw.get("schema_version") or recomputed > 0
+            upgrades.append(CaseUpgrade(case_id=case_id, finding_ids_recomputed=recomputed,
+                                        changed=changed))
+            writes[case_id] = yaml.safe_dump(new_raw, sort_keys=False).encode("utf-8")
+        except Exception as exc:  # never silently rewrite a case
+            report.errors.append(f"{case_id}: {exc}")
+
+    if not dry_run:
+        for case_id, content in writes.items():
+            with storage.Transaction(root, op_id=f"migrate-{case_id}", kind="migrate") as tx:
+                tx.stage(f"cases/{case_id}.yaml", content)
+                tx.commit()
+
+    report.cases.extend(upgrades)
+    return report

--- a/daydream/benchmark/migrate.py
+++ b/daydream/benchmark/migrate.py
@@ -20,7 +20,6 @@ from pathlib import Path
 import yaml
 
 from daydream.benchmark import schema, storage
-from daydream.benchmark.curation import _schema_ready
 
 
 @dataclass
@@ -95,18 +94,18 @@ def migrate_workspace(root: Path, *, dry_run: bool = False) -> UpgradeReport:
             new_raw, recomputed = _upgrade_case(raw, case_id)
             # strip the persisted audit field for validation (curation pattern),
             # but keep it in the written output — authored content is preserved.
-            schema.CaseDocument.model_validate(_schema_ready(new_raw))
-            changed = new_raw.get("schema_version") != raw.get("schema_version") or recomputed > 0
+            schema.CaseDocument.model_validate(schema._schema_ready(new_raw))
+            changed = recomputed > 0
             upgrades.append(CaseUpgrade(case_id=case_id, finding_ids_recomputed=recomputed,
                                         changed=changed))
-            writes[case_id] = yaml.safe_dump(new_raw, sort_keys=False).encode("utf-8")
+            writes[case_file] = yaml.safe_dump(new_raw, sort_keys=False).encode("utf-8")
         except Exception as exc:  # never silently rewrite a case
             report.errors.append(f"{case_id}: {exc}")
 
     if not dry_run:
-        for case_id, content in writes.items():
-            with storage.Transaction(root, op_id=f"migrate-{case_id}", kind="migrate") as tx:
-                tx.stage(f"cases/{case_id}.yaml", content)
+        for case_path, content in writes.items():
+            with storage.Transaction(root, op_id=f"migrate-{case_path}", kind="migrate") as tx:
+                tx.stage(case_path, content)
                 tx.commit()
 
     report.cases.extend(upgrades)

--- a/daydream/benchmark/migrate.py
+++ b/daydream/benchmark/migrate.py
@@ -30,9 +30,6 @@ class CaseUpgrade:
     finding_ids_recomputed: int
     changed: bool
 
-    def __getitem__(self, key: str) -> object:
-        return getattr(self, key)
-
 
 @dataclass
 class UpgradeReport:
@@ -95,7 +92,9 @@ def migrate_workspace(root: Path, *, dry_run: bool = False) -> UpgradeReport:
             # strip the persisted audit field for validation (curation pattern),
             # but keep it in the written output — authored content is preserved.
             schema.CaseDocument.model_validate(schema._schema_ready(new_raw))
-            changed = recomputed > 0
+            # Every loadable v1 case is staged: the schema_version bump is
+            # unconditional, so a write occurs even when no finding_id changed.
+            changed = True
             upgrades.append(CaseUpgrade(case_id=case_id, finding_ids_recomputed=recomputed,
                                         changed=changed))
             writes[case_file] = yaml.safe_dump(new_raw, sort_keys=False).encode("utf-8")

--- a/daydream/benchmark/schema.py
+++ b/daydream/benchmark/schema.py
@@ -44,6 +44,8 @@ __all__ = [
     "EvidenceRecord",
     "Candidate",
     "ImportDocument",
+    "PullRequestMeta",
+    "CaseSource",
     "derive_finding_id",
     "derive_gold_status",
     "derive_gold_mode",
@@ -579,6 +581,50 @@ class _FetchInfo(BaseModel):
         return _hex64(v)
 
 
+class _PrRef(BaseModel):
+    """A base/head ref-sha pair of a pull request."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    sha: str
+    ref: str | None = None
+
+
+class PullRequestMeta(BaseModel):
+    """The typed pull-request block shared by ``ImportDocument`` and ``CaseDocument``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    number: int
+    url: str
+    title: str
+    state: str
+    base: _PrRef
+    head: _PrRef
+    created_at: datetime
+    updated_at: datetime
+    author: _EvidenceAuthor
+
+    @field_validator("created_at", "updated_at", mode="before")
+    @classmethod
+    def _ts(cls, v: str | datetime) -> datetime:
+        return _rfc3339(v)
+
+
+class CaseSource(BaseModel):
+    """The typed source block of a case document (import provenance)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    import_file: str
+    import_sha256: str
+
+    @field_validator("import_sha256")
+    @classmethod
+    def _sha64(cls, v: str) -> str:
+        return _hex64(v)
+
+
 class ImportDocument(BaseModel):
     """A normalized, verifiable import of one PR's full evidence set."""
 
@@ -586,7 +632,7 @@ class ImportDocument(BaseModel):
 
     schema_version: Literal[1] = 1
     repository: _ImportRepository
-    pull_request: dict
+    pull_request: PullRequestMeta
     evidence: list[EvidenceRecord] = []
     fetch: _FetchInfo
 
@@ -750,9 +796,9 @@ class CaseDocument(BaseModel):
 
     schema_version: Literal[1] = 1
     case_id: str
-    pull_request: dict
+    pull_request: PullRequestMeta
     snapshot: Snapshot
-    source: dict
+    source: CaseSource
     curation: Curation
     candidates: list[Candidate] = []
 
@@ -765,7 +811,7 @@ class CaseDocument(BaseModel):
 
     @model_validator(mode="after")
     def _case_id_matches(self) -> "CaseDocument":
-        pr_number = int(self.pull_request["number"])
+        pr_number = self.pull_request.number
         head = snapshot_head_sha(self.snapshot)
         if head is None:
             raise ValueError("snapshot carries no head SHA to derive case_id")

--- a/daydream/benchmark/schema.py
+++ b/daydream/benchmark/schema.py
@@ -677,8 +677,8 @@ class Finding(BaseModel):
             raise ValueError("title must not be blank")
         if "\x00" in v:
             raise ValueError("title must not contain NUL")
-        if len(v.encode("utf-8")) > 500:
-            raise ValueError("title exceeds 500 UTF-8 bytes")
+        if len(v) > 500:
+            raise ValueError("title exceeds 500 characters")
         return v
 
     @field_validator("body")

--- a/daydream/benchmark/schema.py
+++ b/daydream/benchmark/schema.py
@@ -280,14 +280,18 @@ def _field_of(value: "Finding | dict", name: str) -> Any:
     return getattr(value, name, None)
 
 
-def derive_finding_id(finding: "Finding | dict") -> str:
-    """sha256 over the canonical (title, body, severity, path, start/end) tuple.
+def derive_finding_id(finding: "Finding | dict", *, case_id: str) -> str:
+    """sha256 over the case-scoped canonical (case_id, title, body, severity,
+    path, start/end) tuple.
 
     Nulls are normalized to the empty string; ``finding_id`` must equal this
     digest so a case's findings are content-addressable and dedupe-friendly.
+    ``case_id`` is required (keyword-only) so every caller binds findings to a
+    case.
     """
     payload = "\x1f".join(
         [
+            str(case_id or ""),
             str(_field_of(finding, "title") or ""),
             str(_field_of(finding, "body") or ""),
             str(_field_of(finding, "severity") or ""),
@@ -689,9 +693,7 @@ class Finding(BaseModel):
         return v
 
     @model_validator(mode="after")
-    def _canonical_id(self) -> "Finding":
-        if self.finding_id != derive_finding_id(self):
-            raise ValueError("finding_id is not the canonical sha256")
+    def _historical_marker(self) -> "Finding":
         if self.provenance.kind == "historical":
             text = f"{self.title}\n{self.body}"
             if FINDING_MARKER_RE.search(text):
@@ -787,7 +789,7 @@ class CaseDocument(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    schema_version: Literal[1] = 1
+    schema_version: Literal[1, 2] = 2
     case_id: str
     pull_request: PullRequestMeta
     snapshot: Snapshot
@@ -811,6 +813,16 @@ class CaseDocument(BaseModel):
         expected = case_id_for(pr_number, head)
         if self.case_id != expected:
             raise ValueError(f"case_id {self.case_id!r} mismatches {expected!r}")
+        return self
+
+    @model_validator(mode="after")
+    def _canonical_finding_ids(self) -> "CaseDocument":
+        if self.schema_version == 2:
+            for i, f in enumerate(self.curation.findings):
+                if f.finding_id != derive_finding_id(f, case_id=self.case_id):
+                    raise ValueError(
+                        f"finding[{i}] finding_id is not the canonical sha256 for case {self.case_id}"
+                    )
         return self
 
     @model_validator(mode="after")

--- a/daydream/benchmark/schema.py
+++ b/daydream/benchmark/schema.py
@@ -772,6 +772,10 @@ class Curation(BaseModel):
     def _consistent(self) -> "Curation":
         if self.case_exclusion is not None and self.state != "excluded":
             raise ValueError("case_exclusion is only valid when state == 'excluded'")
+        if self.state == "ready" and self.snapshot_attested is not True:
+            raise ValueError("ready curation requires snapshot_attested=True")
+        if self.state == "stale" and self.snapshot_attested is not False:
+            raise ValueError("stale curation requires snapshot_attested=False")
         if self.gold_status == "findings":
             if not self.findings or self.clean_attested:
                 raise ValueError("gold_status 'findings' requires >=1 finding and clean_attested=False")
@@ -830,6 +834,18 @@ class CaseDocument(BaseModel):
         ids = [f.finding_id for f in self.curation.findings]
         if len(set(ids)) != len(ids):
             raise ValueError("case contains duplicate canonical findings")
+        return self
+
+    @model_validator(mode="after")
+    def _unreplayable_coupling(self) -> "CaseDocument":
+        if (
+            self.curation.state == "unreplayable"
+            and self.snapshot.status != "unreplayable"
+            and self.curation.case_exclusion is None
+        ):
+            raise ValueError(
+                "unreplayable curation requires an unreplayable snapshot unless case_exclusion is set"
+            )
         return self
 
 

--- a/daydream/benchmark/schema.py
+++ b/daydream/benchmark/schema.py
@@ -874,8 +874,6 @@ def derive_gold_mode(curation: Curation) -> str:
         return "authored"
     if "authored" in kinds:
         return "mixed"
-    if kinds == {"edited"}:
-        return "edited"
     return "historical"
 
 

--- a/daydream/benchmark/schema.py
+++ b/daydream/benchmark/schema.py
@@ -146,13 +146,13 @@ class Privacy(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    classification: str
-    reviewer_data: str
+    classification: Literal["confidential"]
+    reviewer_data: Literal["source_snapshot"]
     reviewer_allowed_hosts: list[str]
-    judge_data: str
+    judge_data: Literal["finding_text_and_location_only"]
     judge_allowed_hosts: list[str]
-    archive: str
-    uploads: str
+    archive: Literal["disabled"]
+    uploads: Literal["disabled"]
 
     @field_validator("reviewer_allowed_hosts")
     @classmethod
@@ -306,15 +306,8 @@ class _SnapshotBase(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     status: str
-    policy: str
+    policy: Literal["final_pr_head", "explicit_head"]
     requested_head: str
-
-    @field_validator("policy")
-    @classmethod
-    def _policy_nonblank(cls, v: str) -> str:
-        if not v or not v.strip():
-            raise ValueError("policy must not be blank")
-        return v
 
 
 class SnapshotReady(_SnapshotBase):

--- a/daydream/benchmark/schema.py
+++ b/daydream/benchmark/schema.py
@@ -788,6 +788,15 @@ class Curation(BaseModel):
         return self
 
 
+def _schema_ready(raw: dict[str, Any]) -> dict[str, Any]:
+    """A schema-valid copy of a raw case doc (persisted audit fields stripped)."""
+    doc = dict(raw)
+    curation = dict(raw.get("curation") or {})
+    curation.pop("gold_mode", None)
+    doc["curation"] = curation
+    return doc
+
+
 class CaseDocument(BaseModel):
     """One ``cases/<case-id>.yaml`` document."""
 

--- a/tests/test_benchmark_curation.py
+++ b/tests/test_benchmark_curation.py
@@ -219,7 +219,7 @@ def test_accept_candidate_produces_historical_derived_finding(tmp_path, fake_gh)
     assert f["provenance"]["source_ids"] == [cand["source_id"]]
     assert f["title"] == cand["title"] and f["body"] == cand["body"]
     assert f["location"] == cand["location"]
-    assert f["finding_id"] == derive_finding_id(f)      # derived, content-addressed
+    assert f["finding_id"] == derive_finding_id(f, case_id=case_id)      # derived, content-addressed
     assert raw["curation"]["gold_status"] == "findings"
     assert raw["curation"]["gold_mode"] == "historical"
     assert raw["curation"]["state"] == "draft"           # accept on draft stays draft
@@ -248,7 +248,7 @@ def test_add_finding_is_authored_and_replace_is_edited(tmp_path, fake_gh):
     f2 = raw["curation"]["findings"][0]
     assert f2["provenance"]["kind"] == "edited" and f2["finding_id"] != f["finding_id"]
     assert f2["title"] == "New concern (v2)" and raw["curation"]["gold_mode"] == "edited"
-    assert f2["finding_id"] == derive_finding_id(f2)
+    assert f2["finding_id"] == derive_finding_id(f2, case_id=case_id)
 
 def test_exclude_evidence_reason_contract_and_other_requires_note(tmp_path, fake_gh):
     from daydream.benchmark import curation as cu
@@ -367,7 +367,7 @@ def test_apply_gold_fragment_strips_forged_fields_and_never_ready(tmp_path, fake
     cu.apply_gold_fragment(ws, case_id, fragment)
     raw = load_yaml_strict(ws / "cases" / f"{case_id}.yaml")
     f = raw["curation"]["findings"][0]
-    assert f["finding_id"] == derive_finding_id(f)          # forged id discarded
+    assert f["finding_id"] == derive_finding_id(f, case_id=case_id)          # forged id discarded
     assert f["provenance"]["kind"] == "historical"          # derived from candidate match
     assert raw["curation"]["state"] == "draft"              # never ready
     assert raw["curation"]["snapshot_attested"] is False
@@ -529,7 +529,7 @@ def test_validate_case_accepts_clean_and_rejects_duplicate_and_over_cap(tmp_path
     raw = load_yaml_strict(path)
     f1 = {"title": "dup", "body": "b", "severity": "low",
           "provenance": {"kind": "authored", "source_ids": []}}
-    f1["finding_id"] = derive_finding_id(f1)
+    f1["finding_id"] = derive_finding_id(f1, case_id=case_id)
     raw["curation"]["findings"] = [f1, dict(f1)]   # same canonical -> duplicates
     raw["curation"]["state"] = "draft"
     path.write_text(yaml.safe_dump(raw, sort_keys=False))
@@ -541,7 +541,7 @@ def test_validate_case_accepts_clean_and_rejects_duplicate_and_over_cap(tmp_path
         {"title": f"f{i}", "body": "b", "severity": "low",
          "provenance": {"kind": "authored", "source_ids": []}} for i in range(51)]
     for f in raw["curation"]["findings"]:
-        f["finding_id"] = derive_finding_id(f)
+        f["finding_id"] = derive_finding_id(f, case_id=case_id)
     path.write_text(yaml.safe_dump(raw, sort_keys=False))
     with pytest.raises(cu.CurationError):
         cu.validate_case(ws, case_id)

--- a/tests/test_benchmark_curation.py
+++ b/tests/test_benchmark_curation.py
@@ -247,7 +247,7 @@ def test_add_finding_is_authored_and_replace_is_edited(tmp_path, fake_gh):
     raw = load_yaml_strict(ws / "cases" / f"{case_id}.yaml")
     f2 = raw["curation"]["findings"][0]
     assert f2["provenance"]["kind"] == "edited" and f2["finding_id"] != f["finding_id"]
-    assert f2["title"] == "New concern (v2)" and raw["curation"]["gold_mode"] == "edited"
+    assert f2["title"] == "New concern (v2)" and raw["curation"]["gold_mode"] == "historical"
     assert f2["finding_id"] == derive_finding_id(f2, case_id=case_id)
 
 def test_exclude_evidence_reason_contract_and_other_requires_note(tmp_path, fake_gh):

--- a/tests/test_benchmark_harbor_build.py
+++ b/tests/test_benchmark_harbor_build.py
@@ -478,7 +478,7 @@ def test_compile_findings_case_full_tree_and_gold_oracle_agree(tmp_path, fake_gh
 
     gold = _load_json(case / "tests" / "golden-review.json")
     oracle = storage.load_json_strict(case / "solution" / "golden-review.json")
-    assert vc.validate_gold_set(gold)                       # gold passes gold-set validation
+    assert vc.validate_gold_set(gold, case_id=case_id)      # gold passes gold-set validation
     vc.validate_candidate_artifact(oracle)                 # oracle passes candidate validation
     assert [f["finding_id"] for f in gold] == sorted(f["finding_id"] for f in gold)
     # gold↔oracle agreement: same content fields, in the same finding_id order

--- a/tests/test_benchmark_harbor_build.py
+++ b/tests/test_benchmark_harbor_build.py
@@ -214,7 +214,7 @@ def _seed_second_ready_case(ws: Path, tmp_path: Path, fake_gh, *, lines: int = 3
 
 
 def _inject_body(ws: Path, case_id: str, body: str) -> None:
-    """Seed a body into the case document's pull_request block (schema-legal raw dict)."""
+    """Seed a body into the case document's raw pull_request block (raw-dict compile path)."""
     from daydream.benchmark import storage
     path = ws / "cases" / f"{case_id}.yaml"
     raw = storage.load_yaml_strict(path)
@@ -285,9 +285,9 @@ def _seed_bare_bundle(tmp_path: Path) -> tuple[Path, bytes]:
 
 
 def test_spike_persisted_pull_request_field_set():
-    """The import persists pull_request as a raw dict; the compiler must tolerate a missing body."""
-    from daydream.benchmark.schema import ImportDocument
-    assert ImportDocument.model_fields["pull_request"].annotation is dict
+    """The import persists pull_request as a typed strict submodel; the compiler must tolerate a missing body."""
+    from daydream.benchmark.schema import ImportDocument, PullRequestMeta
+    assert ImportDocument.model_fields["pull_request"].annotation is PullRequestMeta
     # Field set is pinned by the constructor at github_import.py:1080-1090: it carries
     # number/url/title/state/base/head/created_at/updated_at/author and NO body.
     from daydream.benchmark import github_import as gi

--- a/tests/test_benchmark_harbor_build.py
+++ b/tests/test_benchmark_harbor_build.py
@@ -365,8 +365,16 @@ def test_build_gold_list_is_provenance_free_and_location_required():
          "location": {"path": "src/render.py", "start_line": 10, "end_line": 14},
          "provenance": {"kind": "authored", "source_ids": []}},
     ]
-    gold = build.build_gold_list(findings)
-    assert [f["finding_id"] for f in gold] == ["a" * 64, "c" * 64]        # ordered by finding_id
+    gold = build.build_gold_list(findings, key="case-key")
+    # compiled gold ids are the task-key-scoped digests, not the raw workspace ids
+    def _id(f):
+        loc = f["location"]
+        payload = "\x1f".join(["case-key", str(f["title"]), str(f["body"]),
+                                str(f["severity"]), str(loc["path"]),
+                                str(loc["start_line"]), str(loc["end_line"])])
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    expected = sorted(_id(f) for f in findings)
+    assert [f["finding_id"] for f in gold] == expected                  # ordered by finding_id
     assert all(set(f) == {"finding_id", "title", "body", "severity", "path", "start_line", "end_line"}
                for f in gold)                                             # no provenance/source/gold keys
     assert gold[0]["path"] == "src/render.py" and gold[0]["start_line"] == 10
@@ -374,7 +382,7 @@ def test_build_gold_list_is_provenance_free_and_location_required():
 
 def test_build_gold_list_clean_is_empty():
     from daydream.benchmark.harbor import build
-    assert build.build_gold_list([]) == []
+    assert build.build_gold_list([], key="case-key") == []
 
 
 def test_build_gold_list_rejects_locationless_finding():
@@ -385,7 +393,7 @@ def test_build_gold_list_rejects_locationless_finding():
             "finding_id": "a" * 64, "title": "T", "body": "B",
             "severity": None, "location": None,
             "provenance": {"kind": "authored", "source_ids": []},
-        }])
+        }], key="case-key")
         assert False, "expected CompileError for a location-less finding"
     except CompileError as exc:
         assert "location" in str(exc)
@@ -478,7 +486,7 @@ def test_compile_findings_case_full_tree_and_gold_oracle_agree(tmp_path, fake_gh
 
     gold = _load_json(case / "tests" / "golden-review.json")
     oracle = storage.load_json_strict(case / "solution" / "golden-review.json")
-    assert vc.validate_gold_set(gold, case_id=case_id)      # gold passes gold-set validation
+    assert vc.validate_gold_set(gold, case_id=key)      # gold passes via the compiled opaque key
     vc.validate_candidate_artifact(oracle)                 # oracle passes candidate validation
     assert [f["finding_id"] for f in gold] == sorted(f["finding_id"] for f in gold)
     # gold↔oracle agreement: same content fields, in the same finding_id order

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -552,7 +552,7 @@ def _curate_case(ws, case_file):
         "location": {"path": "a.py", "start_line": 4, "end_line": 4},
         "provenance": {"kind": "historical", "source_ids": ["github:inline_comment:1"]},
     }
-    finding["finding_id"] = derive_finding_id(finding)
+    finding["finding_id"] = derive_finding_id(finding, case_id=raw["case_id"])
     raw["curation"] = {
         "state": "ready",
         "snapshot_attested": True,

--- a/tests/test_benchmark_migrate.py
+++ b/tests/test_benchmark_migrate.py
@@ -91,9 +91,9 @@ def _seed_v1_workspace(tmp_path: Path):
 def test_migrate_recomputes_finding_ids_and_bumps_version(tmp_path):
     ws, case_id, title = _seed_v1_workspace(tmp_path)
     report = migrate.migrate_workspace(ws)
-    assert [c["case_id"] for c in report.cases] == [case_id]
-    assert report.cases[0]["finding_ids_recomputed"] == 1
-    assert report.cases[0]["changed"] is True
+    assert [c.case_id for c in report.cases] == [case_id]
+    assert report.cases[0].finding_ids_recomputed == 1
+    assert report.cases[0].changed is True
     raw = storage.load_yaml_strict(ws / "cases" / f"{case_id}.yaml")
     assert raw["schema_version"] == 2
     f = raw["curation"]["findings"][0]
@@ -110,7 +110,7 @@ def test_migrate_dry_run_writes_nothing_and_is_idempotent(tmp_path):
     assert storage.load_yaml_strict(ws / "cases" / f"{case_id}.yaml")["schema_version"] == 1
     migrate.migrate_workspace(ws)
     second = migrate.migrate_workspace(ws)
-    assert all(c["changed"] is False for c in second.cases)   # no-op second run
+    assert all(c.changed is False for c in second.cases)   # no-op second run
 
 
 def test_migrate_surfaces_invalid_case_without_rewriting(tmp_path):
@@ -123,3 +123,38 @@ def test_migrate_surfaces_invalid_case_without_rewriting(tmp_path):
     assert report.cases == []                        # no case rewritten
     assert any("duplicate" in e for e in report.errors)
     assert storage.load_yaml_strict(ws / "cases" / f"{case_id}.yaml")["schema_version"] == 1  # untouched
+
+def test_upgrade_cli_wiring_dry_run_and_real_run(tmp_path, capsys):
+    """The ``upgrade`` verb drives migrate_workspace through the CLI seam (exit 0)."""
+    from daydream.benchmark.cli import _handle_benchmark_command
+
+    ws, case_id, _ = _seed_v1_workspace(tmp_path)
+
+    # --dry-run reports the upgrade (finding recomputed, would change) without writing.
+    rc = _handle_benchmark_command(["upgrade", str(ws), "--dry-run"])
+    assert rc == 0
+    assert storage.load_yaml_strict(ws / "cases" / f"{case_id}.yaml")["schema_version"] == 1
+    out = capsys.readouterr().out
+    assert "changed=True" in out and "finding_ids_recomputed=1" in out
+
+    # A real run rewrites the v1 case and exits 0.
+    rc = _handle_benchmark_command(["upgrade", str(ws)])
+    assert rc == 0
+    assert storage.load_yaml_strict(ws / "cases" / f"{case_id}.yaml")["schema_version"] == 2
+
+    # The no-op second run still exits 0.
+    rc = _handle_benchmark_command(["upgrade", str(ws)])
+    assert rc == 0
+
+
+def test_upgrade_cli_error_returns_1(tmp_path, capsys):
+    """An errored case surfaces on stderr and yields exit code 1."""
+    from daydream.benchmark.cli import _handle_benchmark_command
+
+    ws, case_id, _ = _seed_v1_workspace(tmp_path)
+    raw = storage.load_yaml_strict(ws / "cases" / f"{case_id}.yaml")
+    raw["schema_version"] = "bogus"
+    storage.atomic_write_yaml(ws / "cases" / f"{case_id}.yaml", raw)
+    rc = _handle_benchmark_command(["upgrade", str(ws)])
+    assert rc == 1
+    assert "error" in capsys.readouterr().err

--- a/tests/test_benchmark_migrate.py
+++ b/tests/test_benchmark_migrate.py
@@ -1,0 +1,125 @@
+import hashlib
+import uuid
+from pathlib import Path
+
+from daydream.benchmark import migrate, schema, storage
+
+_BASE = "0123456789abcdef0123456789abcdef01234567"
+_HEAD_HEX = "0123456789abcdef0123456789abcdef01234567"
+_CASE_ID = "pr-000101-0123456789ab"
+_TITLE = "Cache misses"
+
+
+def _legacy_finding_id(title, body, severity, path, start_line, end_line):
+    payload = "\x1f".join([str(title or ""), str(body or ""), str(severity or ""),
+                           str(path or ""), str(start_line or ""), str(end_line or "")])
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _seed_manifest():
+    return {
+        "schema_version": 1,
+        "benchmark_id": str(uuid.uuid4()),
+        "created_at": "2026-08-21T12:00:00Z",
+        "source": {"provider": "github", "hostname": "github.com",
+                   "repository": "OWNER/REPO", "repository_id": None,
+                   "visibility": "unresolved"},
+        "privacy": {
+            "classification": "confidential",
+            "reviewer_data": "source_snapshot",
+            "reviewer_allowed_hosts": ["api.anthropic.com"],
+            "judge_data": "finding_text_and_location_only",
+            "judge_allowed_hosts": ["api.anthropic.com"],
+            "archive": "disabled",
+            "uploads": "disabled",
+        },
+        "pull_requests": [],
+        "cases": [{"case_id": _CASE_ID, "pr_number": 101, "case_file": f"cases/{_CASE_ID}.yaml"}],
+    }
+
+
+def _seed_v1_case():
+    finding = {
+        "title": _TITLE,
+        "body": "The cache layers never populate.",
+        "severity": "high",
+        "location": {"path": "src/cache.py", "start_line": 2, "end_line": 2},
+        "provenance": {"kind": "authored", "source_ids": []},
+        "finding_id": _legacy_finding_id(_TITLE, "The cache layers never populate.", "high",
+                                         "src/cache.py", 2, 2),
+    }
+    return {
+        "schema_version": 1,
+        "case_id": _CASE_ID,
+        "pull_request": {
+            "number": 101,
+            "url": "https://github.com/o/r/pull/101",
+            "title": "Fix cache",
+            "state": "open",
+            "base": {"ref": "main", "sha": "b" * 40},
+            "head": {"ref": "feature/cache", "sha": "h" * 40},
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+            "author": {"login": "alice", "type": "User"},
+        },
+        "snapshot": {
+            "status": "ready", "policy": "final_pr_head", "requested_head": "final",
+            "original_base_sha": _BASE, "original_head_sha": _HEAD_HEX,
+            "base_tree_sha": "0" * 40, "head_tree_sha": "0" * 40,
+            "diff_sha256": "a" * 64, "bundle_file": "snapshots/x.bundle",
+            "bundle_sha256": "b" * 64, "error": None,
+        },
+        "source": {"import_file": "imports/pr-101.json", "import_sha256": "c" * 64},
+        "curation": {
+            "state": "draft", "snapshot_attested": False, "clean_attested": False,
+            "gold_status": None, "findings": [finding], "exclusions": [],
+            "case_exclusion": None,
+        },
+    }
+
+
+def _seed_v1_workspace(tmp_path: Path):
+    ws = tmp_path / "ws"
+    storage.ensure_private_dir(ws)
+    storage.atomic_write_yaml(ws / "benchmark.yaml", _seed_manifest())
+    case_dir = ws / "cases"
+    storage.ensure_private_dir(case_dir)
+    storage.atomic_write_yaml(case_dir / f"{_CASE_ID}.yaml", _seed_v1_case())
+    return ws, _CASE_ID, _TITLE
+
+
+def test_migrate_recomputes_finding_ids_and_bumps_version(tmp_path):
+    ws, case_id, title = _seed_v1_workspace(tmp_path)
+    report = migrate.migrate_workspace(ws)
+    assert [c["case_id"] for c in report.cases] == [case_id]
+    assert report.cases[0]["finding_ids_recomputed"] == 1
+    assert report.cases[0]["changed"] is True
+    raw = storage.load_yaml_strict(ws / "cases" / f"{case_id}.yaml")
+    assert raw["schema_version"] == 2
+    f = raw["curation"]["findings"][0]
+    assert f["finding_id"] == schema.derive_finding_id(f, case_id=case_id)  # now case-scoped
+    assert f["title"] == title and f["provenance"]["kind"] == "authored"    # authored content preserved
+    # migrated doc fully validates
+    from daydream.benchmark.curation import _schema_ready
+    schema.CaseDocument.model_validate(_schema_ready(raw))
+
+
+def test_migrate_dry_run_writes_nothing_and_is_idempotent(tmp_path):
+    ws, case_id, _ = _seed_v1_workspace(tmp_path)
+    migrate.migrate_workspace(ws, dry_run=True)
+    assert storage.load_yaml_strict(ws / "cases" / f"{case_id}.yaml")["schema_version"] == 1
+    migrate.migrate_workspace(ws)
+    second = migrate.migrate_workspace(ws)
+    assert all(c["changed"] is False for c in second.cases)   # no-op second run
+
+
+def test_migrate_surfaces_invalid_case_without_rewriting(tmp_path):
+    ws, case_id, _ = _seed_v1_workspace(tmp_path)
+    # corrupt the case: duplicate finding_id (uniqueness violated)
+    raw = storage.load_yaml_strict(ws / "cases" / f"{case_id}.yaml")
+    raw["curation"]["findings"].append(dict(raw["curation"]["findings"][0]))
+    storage.atomic_write_yaml(ws / "cases" / f"{case_id}.yaml", raw)
+    report = migrate.migrate_workspace(ws)
+    assert report.cases == []                        # no case rewritten
+    assert any("duplicate" in e for e in report.errors)
+    assert storage.load_yaml_strict(ws / "cases" / f"{case_id}.yaml")["schema_version"] == 1  # untouched

--- a/tests/test_benchmark_verifier_core.py
+++ b/tests/test_benchmark_verifier_core.py
@@ -224,26 +224,42 @@ def test_artifact_rejects_over_100_findings():
 
 def test_gold_set_accepts_and_returns_models():
     g1 = _gold()
-    g1["finding_id"] = _canonical_gold_id(g1)
+    g1["finding_id"] = _canonical_gold_id("case-x", g1)
     g2 = _gold(title="B")
-    g2["finding_id"] = _canonical_gold_id(g2)
-    gs = validate_gold_set([g1, g2])
+    g2["finding_id"] = _canonical_gold_id("case-x", g2)
+    gs = validate_gold_set([g1, g2], case_id="case-x")
     assert len(gs) == 2 and all(isinstance(g, GoldFinding) for g in gs)
+
+
+def test_gold_finding_id_is_case_scoped():
+    # gold finding_id must equal sha256(case_id, title, body, severity, path, start, end)
+    g = _gold()
+    g["finding_id"] = _canonical_gold_id("case-x", g)
+    validate_gold_set([g], case_id="case-x")                       # case-scoped digest accepted
+    legacy = _gold()
+    legacy["finding_id"] = "f" * 64  # valid 64-hex, case_id-less digest -> rejected
+    with pytest.raises(VerifierError):
+        validate_gold_set([legacy], case_id="case-x")
+    # a case-scoped digest under a different case_id is rejected
+    g2 = _gold()
+    g2["finding_id"] = _canonical_gold_id("case-y", g2)
+    with pytest.raises(VerifierError):
+        validate_gold_set([g2], case_id="case-x")
 
 
 def test_gold_set_rejects_over_50():
     many = []
     for i in range(51):
         f = _gold(title=f"f{i}")
-        f["finding_id"] = _canonical_gold_id(f)
+        f["finding_id"] = _canonical_gold_id("case-x", f)
         many.append(f)
     with pytest.raises(VerifierError):
-        validate_gold_set(many)
+        validate_gold_set(many, case_id="case-x")
 
 
 def test_gold_set_rejects_invalid_member():
     with pytest.raises(VerifierError):
-        validate_gold_set([_gold(severity="nope")])
+        validate_gold_set([_gold(severity="nope")], case_id="case-x")
 
 def test_verdict_parses_and_validates():
     v = Verdict(gold_id="g", candidate_id="c", match=True, confidence=0.9, reasoning="same bug")
@@ -408,12 +424,12 @@ def test_gold_set_rejects_unknown_finding_key():
     g = _gold()
     g["provenance"] = {"kind": "authored", "source_ids": []}
     with pytest.raises(VerifierError):
-        validate_gold_set([g])
+        validate_gold_set([g], case_id="case-x")
 
 
-def _canonical_gold_id(f: dict) -> str:
+def _canonical_gold_id(case_id: str, f: dict) -> str:
     payload = "\x1f".join([
-        str(f.get("title") or ""), str(f.get("body") or ""),
+        str(case_id or ""), str(f.get("title") or ""), str(f.get("body") or ""),
         str(f.get("severity") or ""), str(f.get("path") or ""),
         str(f.get("start_line")), str(f.get("end_line")),
     ])
@@ -424,13 +440,13 @@ def test_gold_set_rejects_non_canonical_finding_id():
     f = _gold()
     f["finding_id"] = "f" * 64  # valid 64-hex but not the canonical digest
     with pytest.raises(VerifierError):
-        validate_gold_set([f])
+        validate_gold_set([f], case_id="case-x")
 
 
 def test_gold_set_rejects_duplicate_finding_ids():
-    fid = _canonical_gold_id(_gold())
+    fid = _canonical_gold_id("case-x", _gold())
     with pytest.raises(VerifierError):
         validate_gold_set([
             {**_gold(), "finding_id": fid},
             {**_gold(), "finding_id": fid},
-        ])
+        ], case_id="case-x")

--- a/tests/test_benchmark_verifier_judge.py
+++ b/tests/test_benchmark_verifier_judge.py
@@ -546,6 +546,62 @@ def test_oracle_artifact_scores_reward_1_for_findings_and_clean(sr_module, tmp_p
     assert clean.reward == 1.0 and clean.clean_pass == 1 and clean.clean_task == 1
 
 
+def test_back_scores_legacy_task_without_source_case_id(sr_module, tmp_path) -> None:
+    # A Harbor task compiled before the case-scoped gold digest carries no
+    # ``source_case_id`` in its verifier metadata and its gold finding ids are
+    # derived content-only. Back-scoring it must not fail on the missing field
+    # or on a digest mismatch: the verifier falls back to the legacy content
+    # digest when ``source_case_id`` is absent.
+    import hashlib as _h
+    sr = sr_module
+    gold = []
+    for title in ("t0", "t1"):
+        f = {"title": title, "body": "b", "severity": "high",
+             "path": "p", "start_line": 1, "end_line": 1}
+        payload = "\x1f".join([str(f["title"]), str(f["body"]), str(f["severity"]),
+                                str(f["path"]), str(f["start_line"]), str(f["end_line"])])
+        f["finding_id"] = _h.sha256(payload.encode("utf-8")).hexdigest()
+        gold.append(f)
+
+    gold_path = tmp_path / "golden-review.json"
+    gold_path.write_text(json.dumps(gold))
+    # deliberately legacy: no ``source_case_id`` key in the metadata
+    import hashlib as _mh
+    meta = {
+        "schema_version": 1,
+        "case_id": "legacy",
+        "base_ref": "base",
+        "head_ref": "head",
+        "template_version": "1",
+        "gold_sha256": _mh.sha256(gold_path.read_bytes()).hexdigest(),
+    }
+    gold_path.with_name("verifier-metadata.json").write_text(
+        json.dumps(meta, sort_keys=True)
+    )
+
+    artifact_path = tmp_path / "review.json"
+    artifact_path.write_text(json.dumps(_candidate_artifact(sr, case_id="legacy")))
+
+    class MatchClient:
+        async def complete_json(self, *, user, system, max_tokens):
+            return {"match": True, "confidence": 1.0, "reasoning": "identical"}
+
+    out = tmp_path / "out"
+    reward = sr.run_verifier(
+        gold_path,
+        artifact_path,
+        out,
+        client=MatchClient(),
+        env={
+            "DAYDREAM_JUDGE_PROVIDER": "anthropic",
+            "DAYDREAM_JUDGE_MODEL": "m",
+            "DAYDREAM_JUDGE_API_KEY": "k",
+            "DAYDREAM_JUDGE_BASE_URL": None,
+        },
+    )
+    assert reward.reward == 1.0 and reward.verifier_error == 0 and reward.tp == 2
+
+
 def test_generated_asset_tree_is_self_contained(sr_module) -> None:
     base = Path(sr_module.__file__).parent
     for rel in (

--- a/tests/test_benchmark_verifier_judge.py
+++ b/tests/test_benchmark_verifier_judge.py
@@ -340,13 +340,13 @@ class _CountingClient:
         return {"match": True, "confidence": 0.9, "reasoning": "x"}
 
 
-def _gold_list(n: int = 2) -> list[dict]:
+def _gold_list(n: int = 2, *, case_id: str = "case-x") -> list[dict]:
     import hashlib as _h
     out = []
     for i in range(n):
         f = {"title": f"t{i}", "body": "b", "severity": "high",
              "path": "p", "start_line": 1, "end_line": 1}
-        payload = "\x1f".join([str(f["title"]), str(f["body"]), str(f["severity"]),
+        payload = "\x1f".join([str(case_id), str(f["title"]), str(f["body"]), str(f["severity"]),
                                str(f["path"]), str(f["start_line"]), str(f["end_line"])])
         f["finding_id"] = _h.sha256(payload.encode("utf-8")).hexdigest()
         out.append(f)
@@ -354,11 +354,13 @@ def _gold_list(n: int = 2) -> list[dict]:
 
 
 def _write_metadata(gold_path: Path, *, case_id: str = "case-x",
-                    base_ref: str = "base", head_ref: str = "head") -> None:
+                    base_ref: str = "base", head_ref: str = "head",
+                    source_case_id: str | None = None) -> None:
     import hashlib as _h
     meta = {
         "schema_version": 1,
         "case_id": case_id,
+        "source_case_id": case_id if source_case_id is None else source_case_id,
         "base_ref": base_ref,
         "head_ref": head_ref,
         "template_version": "1",
@@ -425,7 +427,7 @@ def test_run_verifier_writes_reward_and_details_atomically(sr_module, tmp_path, 
 def test_judge_failure_fails_whole_task_not_partial_score(sr_module, tmp_path) -> None:
     sr = sr_module
     gold_path = tmp_path / "g.json"
-    gold_path.write_text(json.dumps(_gold_list(2)))
+    gold_path.write_text(json.dumps(_gold_list(2, case_id="c")))
     _write_metadata(gold_path, case_id="c")
     artifact_path = tmp_path / "r.json"
     artifact_path.write_text(json.dumps(_candidate_artifact(sr, case_id="c")))
@@ -494,7 +496,7 @@ def test_main_reads_only_tests_and_logs_artifact_paths(sr_module, tmp_path, monk
 def test_oracle_artifact_scores_reward_1_for_findings_and_clean(sr_module, tmp_path) -> None:
     sr = sr_module
     gold_path = tmp_path / "golden-review.json"
-    gold_path.write_text(json.dumps(_gold_list(2)))
+    gold_path.write_text(json.dumps(_gold_list(2, case_id="organic")))
     _write_metadata(gold_path, case_id="organic")
 
     oracle = _candidate_artifact(sr, case_id="organic")
@@ -585,7 +587,7 @@ def test_shipped_gold_and_oracle_fixtures_validate_and_score_reward_1(
     solution_path = base.parent / "solution" / "golden-review.json"
 
     gold_raw = json.loads(gold_path.read_text(encoding="utf-8"))
-    gold = sr.verifier_core.validate_gold_set(gold_raw)
+    gold = sr.verifier_core.validate_gold_set(gold_raw, case_id="case-x")
     assert len(gold) == 2
 
     solution_raw = json.loads(solution_path.read_text(encoding="utf-8"))
@@ -767,7 +769,7 @@ def test_dense_but_verifier_legal_body_is_judged_not_failed_whole(sr_module, tmp
     # past the cap and fail the whole task. A legal pair is judged, never voided.
     gold = [{"title": "t" * 500, "body": _DENSE_BODY,
              "severity": "high", "path": "p" * 200, "start_line": 1, "end_line": 1}]
-    payload = "\x1f".join([str(gold[0]["title"]), str(gold[0]["body"]), str(gold[0]["severity"]),
+    payload = "\x1f".join(["c", str(gold[0]["title"]), str(gold[0]["body"]), str(gold[0]["severity"]),
                             str(gold[0]["path"]), str(gold[0]["start_line"]), str(gold[0]["end_line"])])
     import hashlib as _h
     gold[0]["finding_id"] = _h.sha256(payload.encode("utf-8")).hexdigest()
@@ -811,7 +813,7 @@ def test_run_verifier_rejects_whitespace_padded_over_one_mib(sr_module, tmp_path
 def test_run_verifier_rejects_cross_case_replay(sr_module, tmp_path) -> None:
     sr = sr_module
     gold_path = tmp_path / "golden-review.json"
-    gold_path.write_text(json.dumps(_gold_list(1)))
+    gold_path.write_text(json.dumps(_gold_list(1, case_id="task-A")))
     _write_metadata(gold_path, case_id="task-A")
     artifact_path = tmp_path / "review.json"
     artifact_path.write_text(json.dumps(_candidate_artifact(sr, case_id="task-B", n=1)))

--- a/tests/test_benchmark_workspace_schema.py
+++ b/tests/test_benchmark_workspace_schema.py
@@ -419,6 +419,25 @@ def test_finding_rejects_nul_in_title():
         CaseDocument.model_validate(raw)
 
 
+def test_title_bound_is_unicode_characters_not_bytes():
+    # "界" is 3 UTF-8 bytes; 500 chars = 1500 bytes. Passes under a char bound.
+    title = "界" * 500
+    raw = _valid_case_dict()
+    raw["curation"]["findings"][0]["title"] = title
+    raw["curation"]["findings"][0]["finding_id"] = derive_finding_id(
+        {"title": title, "body": "The cache layers never populate.", "severity": "high",
+         "location": {"path": "src/cache.py", "start_line": 2, "end_line": 2}},
+        case_id=raw["case_id"],
+    )
+    doc = CaseDocument.model_validate(raw)          # 500 chars passes
+    assert doc.curation.findings[0].title == title
+    # 501 chars fails
+    raw2 = _valid_case_dict()
+    raw2["curation"]["findings"][0]["title"] = "界" * 501
+    with pytest.raises(ValidationError):
+        CaseDocument.model_validate(raw2)
+
+
 def test_finding_severity_enum():
     raw = _valid_case_dict()
     raw["curation"]["findings"][0]["severity"] = "critical"

--- a/tests/test_benchmark_workspace_schema.py
+++ b/tests/test_benchmark_workspace_schema.py
@@ -171,10 +171,46 @@ def _valid_import_document():
 
 def test_import_document_validates_and_forbids_unknown():
     doc = _valid_import_document()
-    assert ImportDocument.model_validate(doc).pull_request["number"] == 101
+    assert ImportDocument.model_validate(doc).pull_request.number == 101
     doc["bogus"] = True
     with pytest.raises(ValidationError):
         ImportDocument.model_validate(doc)
+
+
+def test_import_pull_request_is_strict_submodel():
+    doc = _valid_import_document()
+    doc["pull_request"]["bogus"] = True
+    with pytest.raises(ValidationError) as ei:
+        ImportDocument.model_validate(doc)
+    assert ei.value.errors()[0]["loc"][0] == "pull_request"
+
+
+def test_case_pull_request_is_strict_submodel():
+    # partial (missing a required field) rejected
+    raw = _valid_case_dict()
+    raw["pull_request"].pop("author")
+    with pytest.raises(ValidationError) as ei:
+        CaseDocument.model_validate(raw)
+    assert ei.value.errors()[0]["loc"][0] == "pull_request"
+    # unknown nested key rejected
+    raw2 = _valid_case_dict()
+    raw2["pull_request"]["bogus"] = 1
+    with pytest.raises(ValidationError):
+        CaseDocument.model_validate(raw2)
+
+
+def test_case_source_is_strict_submodel():
+    raw = _valid_case_dict()
+    raw["source"]["bogus"] = 1
+    with pytest.raises(ValidationError) as ei:
+        CaseDocument.model_validate(raw)
+    assert ei.value.errors()[0]["loc"][0] == "source"
+
+
+def test_import_and_case_pull_request_share_shape():
+    doc = ImportDocument.model_validate(_valid_import_document())
+    pr = doc.pull_request
+    assert pr.number == 101 and pr.author.login == "alice" and pr.head.sha == "h" * 40
 
 
 def test_evidence_requires_canonical_source_id_and_body_hash():
@@ -192,7 +228,17 @@ def _valid_case_dict():
     return {
         "schema_version": 1,
         "case_id": "pr-000101-0123456789ab",
-        "pull_request": {"number": 101, "url": "https://github.com/O/R/pull/101", "title": "Fix cache"},
+        "pull_request": {
+            "number": 101,
+            "url": "https://github.com/o/r/pull/101",
+            "title": "Fix cache",
+            "state": "open",
+            "base": {"ref": "main", "sha": "b" * 40},
+            "head": {"ref": "feature/cache", "sha": "h" * 40},
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+            "author": {"login": "alice", "type": "User"},
+        },
         "snapshot": {
             "status": "ready",
             "policy": "final_pr_head",
@@ -208,7 +254,7 @@ def _valid_case_dict():
         },
         "source": {
             "import_file": "imports/pr-101.json",
-            "import_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+            "import_sha256": "c" * 64,
         },
         "curation": {
             "state": "ready",

--- a/tests/test_benchmark_workspace_schema.py
+++ b/tests/test_benchmark_workspace_schema.py
@@ -250,7 +250,7 @@ def test_evidence_requires_canonical_source_id_and_body_hash():
 
 def _valid_case_dict():
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "case_id": "pr-000101-0123456789ab",
         "pull_request": {
             "number": 101,
@@ -288,8 +288,9 @@ def _valid_case_dict():
             "findings": [
                 {
                     "finding_id": _finding_id_for(
+                        "pr-000101-0123456789ab",
                         "Cache misses", "The cache layers never populate.", "high", "src/cache.py", 2, 2
-                    ) or "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+                    ),
                     "title": "Cache misses",
                     "body": "The cache layers never populate.",
                     "severity": "high",
@@ -303,14 +304,15 @@ def _valid_case_dict():
     }
 
 
-def _finding_id_for(title, body, severity, path, start_line, end_line):
+def _finding_id_for(case_id, title, body, severity, path, start_line, end_line):
     return derive_finding_id(
         {
             "title": title,
             "body": body,
             "severity": severity,
             "location": {"path": path, "start_line": start_line, "end_line": end_line},
-        }
+        },
+        case_id=case_id,
     )
 
 
@@ -401,13 +403,36 @@ def test_finding_location_must_be_relative_and_ordered():
 
 def test_finding_id_sha256_and_duplicate_rejection():
     f = _valid_case().curation.findings[0]
-    expected = derive_finding_id(f)
+    expected = derive_finding_id(f, case_id="pr-000101-0123456789ab")
     assert f.finding_id == expected
     # duplicate canonical finding in one case rejected
     raw = _valid_case_dict()
     raw["curation"]["findings"].append(raw["curation"]["findings"][0])
     with pytest.raises(ValidationError):
         CaseDocument.model_validate(raw)
+
+
+def test_finding_id_is_case_scoped():
+    f = _valid_case().curation.findings[0]
+    id1 = derive_finding_id(f, case_id="pr-000101-0123456789ab")
+    id2 = derive_finding_id(f, case_id="pr-000102-0123456789ab")
+    assert id1 != id2                      # identical content, different case -> different id
+
+
+def test_v2_case_rejects_noncanonical_finding_id():
+    raw = _valid_case_dict()
+    raw["curation"]["findings"][0]["finding_id"] = "0" * 64   # wrong digest
+    with pytest.raises(ValidationError) as ei:
+        CaseDocument.model_validate(raw)
+    assert "finding_id" in str(ei.value)
+
+
+def test_v1_legacy_case_loads_without_digest_check():
+    raw = _valid_case_dict()
+    raw["schema_version"] = 1
+    raw["curation"]["findings"][0]["finding_id"] = "e" * 64   # legacy id, not case-scoped
+    doc = CaseDocument.model_validate(raw)                    # must load (digest gated on v2)
+    assert doc.schema_version == 1
 
 
 def test_historical_daydream_marker_cannot_be_gold():
@@ -422,7 +447,8 @@ def test_historical_daydream_marker_cannot_be_gold():
         "location": None,
         "provenance": {"kind": "historical", "source_ids": ["github:review_comment:1"]},
     }
-    finding["finding_id"] = derive_finding_id(finding)  # canonical, so the marker guard is what rejects
+    # canonical, so the marker guard is what rejects
+    finding["finding_id"] = derive_finding_id(finding, case_id=raw["case_id"])
     raw["curation"]["findings"][0] = finding
     with pytest.raises(ValidationError):
         CaseDocument.model_validate(raw)

--- a/tests/test_benchmark_workspace_schema.py
+++ b/tests/test_benchmark_workspace_schema.py
@@ -107,6 +107,30 @@ def test_manifest_rejects_empty_host_allowlists():
         BenchmarkManifest.model_validate(base)
 
 
+def test_privacy_classification_and_policies_are_literals():
+    m = _valid_manifest()
+    for key, bad in [("classification", "public"), ("reviewer_data", "everything"),
+                     ("judge_data", "full"), ("archive", "enabled"), ("uploads", "enabled")]:
+        raw = dict(m)
+        raw["privacy"] = dict(m["privacy"])
+        raw["privacy"][key] = bad
+        with pytest.raises(ValidationError):
+            BenchmarkManifest.model_validate(raw)
+
+
+def test_snapshot_policy_is_literal():
+    raw = _valid_case_dict()
+    raw["snapshot"]["policy"] = "some_head"
+    with pytest.raises(ValidationError):
+        CaseDocument.model_validate(raw)
+
+
+def test_reviewer_judge_hosts_stay_lists():
+    m = BenchmarkManifest.model_validate(_valid_manifest())
+    assert m.privacy.reviewer_allowed_hosts == ["api.anthropic.com"]
+    assert m.privacy.judge_allowed_hosts == ["api.anthropic.com"]
+
+
 def test_manifest_rejects_bad_uuid():
     base = _valid_manifest()
     base["benchmark_id"] = "not-a-uuid"

--- a/tests/test_benchmark_workspace_schema.py
+++ b/tests/test_benchmark_workspace_schema.py
@@ -8,8 +8,11 @@ from pydantic import ValidationError
 from daydream.benchmark.schema import (
     BenchmarkManifest,
     CaseDocument,
+    Curation,
     EvidenceRecord,
+    Finding,
     ImportDocument,
+    Provenance,
     PullRequestEntry,
     TransitionError,
     case_id_for,
@@ -490,7 +493,29 @@ def test_historical_daydream_marker_cannot_be_gold():
 def test_gold_status_and_mode_derived():
     case = _valid_case()  # ready, 1 finding, clean_attested=False
     assert derive_gold_status(case.curation) == "findings"
-    assert derive_gold_mode(case.curation) == "edited"
+    assert derive_gold_mode(case.curation) == "historical"
+
+
+@pytest.mark.parametrize("kinds,expected", [
+    ([], "clean"),
+    (["historical"], "historical"),
+    (["edited"], "historical"),              # all-edited historical evidence stays historical
+    (["authored"], "authored"),
+    (["historical", "edited"], "historical"),
+    (["authored", "historical"], "mixed"),
+    (["authored", "edited"], "mixed"),
+])
+def test_gold_mode_truth_table(kinds, expected):
+    findings = [
+        Finding(finding_id="e" * 64, title=f"f{i}", body="b",
+                provenance=Provenance(
+                    kind=k,
+                    source_ids=["github:review_comment:1"] if k in ("historical", "edited") else [],
+                ))
+        for i, k in enumerate(kinds)
+    ]
+    curation = Curation(state="draft", findings=findings)
+    assert derive_gold_mode(curation) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_benchmark_workspace_schema.py
+++ b/tests/test_benchmark_workspace_schema.py
@@ -338,6 +338,39 @@ def test_ready_snapshot_rejects_missing_bundle_fields():
         CaseDocument.model_validate(raw)
 
 
+def test_ready_requires_snapshot_attestation():
+    raw = _valid_case_dict()
+    raw["curation"].update({"state": "ready", "snapshot_attested": False})
+    with pytest.raises(ValidationError):
+        CaseDocument.model_validate(raw)
+
+
+def test_stale_requires_snapshot_not_attested():
+    raw = _valid_case_dict()
+    raw["curation"].update({"state": "stale", "snapshot_attested": True,
+                            "gold_status": None, "clean_attested": False})
+    with pytest.raises(ValidationError):
+        CaseDocument.model_validate(raw)
+
+
+def test_unreplayable_curation_requires_unreplayable_snapshot():
+    raw = _valid_case_dict()                       # snapshot.status == ready
+    raw["curation"].update({"state": "unreplayable", "snapshot_attested": False,
+                            "clean_attested": False, "gold_status": None, "findings": []})
+    with pytest.raises(ValidationError):           # ready snapshot + unreplayable state
+        CaseDocument.model_validate(raw)
+    # a genuine unreplayable snapshot + unreplayable state loads
+    raw["snapshot"] = {
+        "status": "unreplayable", "policy": "final_pr_head", "requested_head": "final",
+        "original_base_sha": None, "original_head_sha": "0123456789abcdef0123456789abcdef01234567",
+        "base_tree_sha": None, "head_tree_sha": None, "diff_sha256": None,
+        "bundle_file": None, "bundle_sha256": None,
+        "error": {"reason": "head_not_on_pr", "detail": "head sha not on PR"},
+    }
+    doc = CaseDocument.model_validate(raw)
+    assert doc.curation.state == "unreplayable"
+
+
 def test_unreplayable_snapshot_requires_error_and_null_bundle():
     raw = _valid_case_dict()
     raw["snapshot"] = {


### PR DESCRIPTION
## Summary
- Canonicalize `derive_finding_id` to include `case_id` in the digest tuple, so a finding identity cannot replay across cases (`sha256(case_id, title, body, severity, path, start_line, end_line)`)
- Collapse gold-mode derivation to exactly four modes: `clean|historical|authored|mixed` (any historical/edited → `historical`; any authored mixed with historical/edited → `mixed`) — the spurious fifth `edited` mode is removed
- Enforce the finding title bound as 500 Unicode **characters** (not UTF-8 bytes); body/size byte caps remain byte caps
- Make `ImportDocument.pull_request`, `CaseDocument.pull_request`, and source fields strict Pydantic submodels (`extra="forbid"`) enforcing literal privacy/snapshot values
- Add a deterministic `schema_version` bump + `migrate.py` upgrade path that back-scores legacy findings with a content-only digest fallback

## Motivation

Closes #806. Refactor follow-up to #817 (which landed exact-key/size/task-binding verifier hardening). This PR reconciles the authoring-schema findings the canonical plan mandates but #817 did not cover — one implementation PR, no downstream issue scope absorbed.

## Changes

### Added
- `daydream/benchmark/migrate.py`: deterministic finding-id upgrade path with `schema_version` bump and legacy back-scoring
- Tests for case-scoped digest identity, cross-case replay prevention, char-vs-byte title bounds, gold-mode set collapse, schema migration, verifier back-scoring

### Changed
- `schema.py`: `derive_finding_id` includes `case_id`; `_gold_finding_ids` delegates to it; strict Pydantic submodels for import/case `pull_request` and source fields
- `curation.py`: removed ready-attestation duplication; gold mode set collapsed to exactly four modes
- `harbor/verifier_core.py` + template: verifier back-scoring via `case_id=None` content-only digest fallback; `changed=True` unconditionally on `schema_version` bump
- `cli.py`: `migrate` subcommand wiring; removed `CaseUpgrade.__getitem__` shim for attribute access

## Test Plan

- [x] `make check` green (lockcheck + ruff + mypy clean; full pytest 4208 passed / 6 skipped / 0 failed)
- [x] Deterministic-authorship gate passed (`verify-branch-authors.sh` AUTHORS_OK, all 11 commits owner-authored)

## Checklist

- [x] Repository checks pass locally (`make check`)
- [ ] Actionlint passes for workflow YAML changes (if applicable)
- [x] Documentation updated (if applicable)

## Additional Context

Two sequential daydream deep-precision reviews (rounds 1 & 2) performed on fresh VMs; all 8 round-2 findings resolved. Trajectories uploaded to HF. NO CodeRabbit in this org.