### PR TITLE
fix(tests): make curation permission assertions portable

### DIFF
--- a/tests/test_benchmark_curate_tui.py
+++ b/tests/test_benchmark_curate_tui.py
@@ -142,7 +142,9 @@ def test_action_new_via_real_editor_persists_authored(tmp_path, fake_gh, monkeyp
     editor = tmp_path / "edit.py"
     editor.write_text(
         "#!/usr/bin/env python3\n"
-        "import os, stat, sys\n"
+        "import os\n"
+        "import stat\n"
+        "import sys\n"
         "buf = sys.argv[1]\n"
         "with open(os.environ['LOG'], 'w') as fh:\n"
         "    fh.write(f'{stat.S_IMODE(os.stat(buf).st_mode):o} {buf}\\n')\n"

--- a/tests/test_benchmark_curate_tui.py
+++ b/tests/test_benchmark_curate_tui.py
@@ -139,11 +139,17 @@ def test_action_new_via_real_editor_persists_authored(tmp_path, fake_gh, monkeyp
     from daydream.benchmark.storage import load_yaml_strict
     ws, case_id, _h = _seed_ready_case(tmp_path, fake_gh, lines=3)
     log = tmp_path / "editor.log"
-    editor = tmp_path / "edit.sh"
-    editor.write_text("#!/bin/sh\nprintf '%s %s\\n' \"$(stat -c '%a' \"$1\")\" \"$1\" > \"$LOG\"\n"
-                      "cat > \"$1\" <<'EOF'\nfindings:\n"
-                      "  - title: New concern\n    body: fresh wording\n"
-                      "    severity: medium\n    location: null\n    source_ids: []\nEOF\n")
+    editor = tmp_path / "edit.py"
+    editor.write_text(
+        "#!/usr/bin/env python3\n"
+        "import os, stat, sys\n"
+        "buf = sys.argv[1]\n"
+        "with open(os.environ['LOG'], 'w') as fh:\n"
+        "    fh.write(f'{stat.S_IMODE(os.stat(buf).st_mode):o} {buf}\\n')\n"
+        "with open(buf, 'w') as fh:\n"
+        "    fh.write('findings:\\n  - title: New concern\\n    body: fresh wording\\n"
+        "    severity: medium\\n    location: null\\n    source_ids: []\\n')\n"
+    )
     editor.chmod(0o755)
     monkeypatch.setenv("VISUAL", str(editor))
     monkeypatch.delenv("EDITOR", raising=False)


### PR DESCRIPTION
## Summary
Fixes #809 — makes curation permission assertions portable.

## Changes
- `tests/test_benchmark_curate_tui.py`: portability fix for curation permission assertions.
- Style: split multi-name import in embedded fake editor (one-per-line).

## Test Plan
- Full repo gate `make check` PASSED (ruff clean, mypy clean, pytest 4208 passed / 6 skipped).

Closes #809