### PR TITLE
fix(benchmark): contain and fully recover authoring transactions (Closes #807)

### DIFF
--- a/daydream/benchmark/storage.py
+++ b/daydream/benchmark/storage.py
@@ -316,7 +316,7 @@ class Transaction:
         ``init_workspace`` build the private scaffold subdirs through the same
         crash-consistent journal instead of leaving them outside it.
         """
-        rel = _rel_of(self._root, target_rel)
+        rel = _resolve_target(self._root, target_rel)
         ensure_private_dir(self._root / rel)
         if rel not in self._created_dirs:
             self._created_dirs.append(rel)
@@ -328,7 +328,7 @@ class Transaction:
         ``transactions/<op_id>/`` and records before/after digests. The real
         target is not touched here.
         """
-        rel = _rel_of(self._root, target_rel)
+        rel = _resolve_target(self._root, target_rel)
         if rel in self._states:
             raise WorkspaceCorrupt(f"{self._root}: duplicate staged target {rel!r}")
         target = self._root / rel
@@ -385,6 +385,7 @@ class Transaction:
         _fsync_file(self._journal_path())
         for rel in self._replacement_order:
             st = self._states[rel]
+            rel = _resolve_target(self._root, rel)
             target = self._root / rel
             ensure_private_dir(target.parent)
             st.applied = True
@@ -488,11 +489,26 @@ def _fsync_dir(path: Path) -> None:
         os.close(fd)
 
 
-def _rel_of(root: Path, target: str | Path) -> str:
+def _resolve_target(root: Path, target: str | Path) -> str:
+    """Resolve ``target`` to a canonical POSIX rel, forcing it beneath ``root``.
+
+    The containment invariant is enforced at the *resolved* path, not the
+    literal string: a ``../x`` relative input, an absolute path, and a path
+    whose parent is a symlink to an outside directory all collapse to
+    "resolves outside root" and are rejected uniformly. Absolute paths that
+    resolve inside the root are accepted (the canonical ``rel`` is returned).
+    """
+    root_r = Path(root).resolve()
     p = Path(target)
-    if p.is_absolute():
-        return os.path.relpath(p, root).replace(os.sep, "/")
-    return p.as_posix()
+    candidate = p if p.is_absolute() else root_r / p
+    resolved = candidate.resolve()
+    try:
+        rel = resolved.relative_to(root_r)
+    except ValueError:
+        raise WorkspaceCorrupt(
+            f"{root}: target resolves outside the workspace root: {target!r}"
+        ) from None
+    return rel.as_posix()
 
 
 # ---------------------------------------------------------------------------

--- a/daydream/benchmark/storage.py
+++ b/daydream/benchmark/storage.py
@@ -733,7 +733,6 @@ def _validate_journal(root: Path, op_dir: Path, doc: dict[str, Any]) -> None:
     order = doc.get("replacement_order")
     if not isinstance(order, list):
         raise WorkspaceCorrupt(f"{root}: journal replacement_order is not a list")
-    order_rels: set[str] = set()
     for item in order:
         if not isinstance(item, str):
             raise WorkspaceCorrupt(f"{root}: journal replacement_order entry is not a string")

--- a/daydream/benchmark/storage.py
+++ b/daydream/benchmark/storage.py
@@ -20,6 +20,7 @@ import shutil
 import tempfile
 from contextlib import suppress
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Literal
 
@@ -538,6 +539,33 @@ def _fsync_dir(path: Path) -> None:
         os.close(fd)
 
 
+@lru_cache(maxsize=None)
+def _resolve_cached(root_r: str, target: str) -> str:
+    """Resolve ``target`` against the already-resolved absolute ``root_r``.
+
+    Every non-partial resolution/containment failure fails closed with
+    :class:`WorkspaceCorrupt`, mirroring the sibling strict loaders. The
+    result is memoized on ``(root_r, target)`` so recovery consumers that
+    re-resolve the same validated rels after :func:`_validate_journal` reuse
+    the canonical rel instead of repeating ``Path.resolve()`` syscalls.
+    """
+    p = Path(target)
+    candidate = p if p.is_absolute() else Path(root_r) / p
+    try:
+        resolved = candidate.resolve()
+    except (OSError, RuntimeError) as exc:
+        raise WorkspaceCorrupt(
+            f"{root_r}: cannot resolve target {target!r}: {exc}"
+        ) from exc
+    try:
+        rel = resolved.relative_to(Path(root_r))
+    except ValueError:
+        raise WorkspaceCorrupt(
+            f"{root_r}: target resolves outside the workspace root: {target!r}"
+        ) from None
+    return rel.as_posix()
+
+
 def _resolve_target(root: Path, target: str | Path) -> str:
     """Resolve ``target`` to a canonical POSIX rel, forcing it beneath ``root``.
 
@@ -547,17 +575,11 @@ def _resolve_target(root: Path, target: str | Path) -> str:
     "resolves outside root" and are rejected uniformly. Absolute paths that
     resolve inside the root are accepted (the canonical ``rel`` is returned).
     """
-    root_r = Path(root).resolve()
-    p = Path(target)
-    candidate = p if p.is_absolute() else root_r / p
-    resolved = candidate.resolve()
     try:
-        rel = resolved.relative_to(root_r)
-    except ValueError:
-        raise WorkspaceCorrupt(
-            f"{root}: target resolves outside the workspace root: {target!r}"
-        ) from None
-    return rel.as_posix()
+        root_r = Path(root).resolve()
+    except (OSError, RuntimeError) as exc:
+        raise WorkspaceCorrupt(f"{root}: cannot resolve the workspace root: {exc}") from exc
+    return _resolve_cached(str(root_r), str(target))
 
 
 # ---------------------------------------------------------------------------
@@ -736,7 +758,10 @@ def _validate_journal(root: Path, op_dir: Path, doc: dict[str, Any]) -> None:
             val = t.get(field)
             if val is None and field == "backup":
                 continue
-            if not isinstance(val, str) or os.path.basename(val) != val:
+            # Reject empty strings too: os.path.basename("") == "", so the bare
+            # name check alone would accept "", letting ``op_dir / "" == op_dir``
+            # make _rollback_committing rename the whole op dir as the target.
+            if not isinstance(val, str) or not val or os.path.basename(val) != val:
                 raise WorkspaceCorrupt(f"{root}: journal target {rel!r} {field} is not a bare filename")
     order = doc.get("replacement_order")
     if not isinstance(order, list):

--- a/daydream/benchmark/storage.py
+++ b/daydream/benchmark/storage.py
@@ -371,6 +371,21 @@ class Transaction:
         self._write_journal()
         _fsync_file(self._journal_path())
 
+    def _begin_committing(self) -> None:
+        """Transition the journal to ``committing`` with nothing applied.
+
+        A transaction enters ``committing`` by rewriting the journal with
+        ``state == committing`` and ``applied_count == 0`` before any target
+        is replaced. Both ``begin_commit`` and the per-target crash-injection
+        branch collapse to this single sequence, so the ``target-<n>``
+        mid-loop crash state stays byte-identical to a real halt reached via
+        ``begin_commit``.
+        """
+        self._state = "committing"
+        self._applied_count = 0
+        self._write_journal()
+        _fsync_file(self._journal_path())
+
     def begin_commit(self) -> None:
         """Rewrite the journal ``committing``, then apply targets in ordered list.
 
@@ -381,10 +396,7 @@ class Transaction:
         last-replaced file unrecoverable — a checksum-drifted mixed state the
         journal's never-drift contract forbids.
         """
-        self._state = "committing"
-        self._applied_count = 0
-        self._write_journal()
-        _fsync_file(self._journal_path())
+        self._begin_committing()
         self._apply_replacements()
         _fsync_dir(self._root)
 
@@ -480,10 +492,7 @@ class Transaction:
             self.prepare()
             if n == 0:
                 return
-            self._state = "committing"
-            self._applied_count = 0
-            self._write_journal()
-            _fsync_file(self._journal_path())
+            self._begin_committing()
             self._apply_replacements(stop_after=n)
             return
         raise ValueError(f"unknown crash boundary {boundary!r}")
@@ -743,6 +752,14 @@ def _validate_journal(root: Path, op_dir: Path, doc: dict[str, Any]) -> None:
     applied = doc.get("applied_count")
     if not isinstance(applied, int) or not (0 <= applied <= len(order)):
         raise WorkspaceCorrupt(f"{root}: journal applied_count is out of bounds")
+    created = doc.get("created_dirs")
+    if created is not None:
+        if not isinstance(created, list):
+            raise WorkspaceCorrupt(f"{root}: journal created_dirs is not a list")
+        for rel in created:
+            if not isinstance(rel, str):
+                raise WorkspaceCorrupt(f"{root}: malformed journal created_dirs entry")
+            _resolve_target(root, rel)
 
 
 def _targets_from_doc(doc: dict[str, Any]) -> list[dict[str, Any]]:
@@ -798,6 +815,7 @@ def _remove_created_dirs(root: Path, doc: dict[str, Any]) -> None:
     """
     created = doc.get("created_dirs") or []
     for rel in sorted(created, key=len, reverse=True):
+        rel = _resolve_target(root, rel)
         with suppress(OSError):
             (root / rel).rmdir()
 

--- a/daydream/benchmark/storage.py
+++ b/daydream/benchmark/storage.py
@@ -563,11 +563,66 @@ def _empty_transactions(root: Path) -> None:
             shutil.rmtree(op_dir, ignore_errors=True)
 
 
+def _validate_journal(root: Path, op_dir: Path, doc: dict[str, Any]) -> None:
+    """Strictly validate a journal document, failing closed with no mutation.
+
+    Every check here is a hard requirement: a journal that violates any rule
+    is corruption, never something to silently skip or partially trust. The
+    validator performs no filesystem mutation — it only proves the doc is
+    structurally sound and that every path it names resolves within ``root``.
+    Recovery readers then trust the validated ``rel`` strings.
+    """
+    state = doc.get("state")
+    if state not in ("prepared", "committing", "complete"):
+        raise WorkspaceCorrupt(f"{root}: invalid journal state {state!r}")
+    if doc.get("op_id") != op_dir.name:
+        raise WorkspaceCorrupt(
+            f"{root}: journal op_id {doc.get('op_id')!r} does not match dir {op_dir.name!r}"
+        )
+    targets = doc.get("targets")
+    if not isinstance(targets, list):
+        raise WorkspaceCorrupt(f"{root}: journal targets is not a list")
+    rels: set[str] = set()
+    for t in targets:
+        if not isinstance(t, dict) or not isinstance(t.get("rel"), str):
+            raise WorkspaceCorrupt(f"{root}: malformed journal target entry")
+        rel = _resolve_target(root, t["rel"])
+        if rel in rels:
+            raise WorkspaceCorrupt(f"{root}: duplicate target rel in journal: {rel!r}")
+        rels.add(rel)
+        for field in ("stage",):
+            val = t.get(field)
+            if not isinstance(val, str) or os.path.basename(val) != val:
+                raise WorkspaceCorrupt(f"{root}: journal target {rel!r} {field} is not a bare filename")
+        backup = t.get("backup")
+        if backup is not None and (
+            not isinstance(backup, str) or os.path.basename(backup) != backup
+        ):
+            raise WorkspaceCorrupt(f"{root}: journal target {rel!r} backup is not a bare filename")
+    order = doc.get("replacement_order")
+    if not isinstance(order, list):
+        raise WorkspaceCorrupt(f"{root}: journal replacement_order is not a list")
+    order_rels: set[str] = set()
+    for item in order:
+        if not isinstance(item, str):
+            raise WorkspaceCorrupt(f"{root}: journal replacement_order entry is not a string")
+        order_rels.add(item)
+        if item not in rels:
+            raise WorkspaceCorrupt(
+                f"{root}: journal replacement_order names unknown target {item!r}"
+            )
+    applied = doc.get("applied_count")
+    if not isinstance(applied, int) or not (0 <= applied <= len(order)):
+        raise WorkspaceCorrupt(f"{root}: journal applied_count is out of bounds")
+
+
 def _recover_one_journal(root: Path, journal_path: Path, op_dir: Path) -> None:
     try:
         doc = load_json_strict(journal_path)
     except WorkspaceCorrupt as exc:
         raise WorkspaceCorrupt(f"{root}: unreadable transaction journal: {exc}") from exc
+    # Fail closed: validate the whole doc BEFORE any unlink/replace/rmdir.
+    _validate_journal(root, op_dir, doc)
     state = doc.get("state")
     if state == "prepared":
         _rollback_prepared(root, op_dir, doc)

--- a/daydream/benchmark/storage.py
+++ b/daydream/benchmark/storage.py
@@ -639,13 +639,20 @@ def _is_transaction_residue(op_dir: Path) -> bool:
 
 
 def _empty_transactions(root: Path) -> None:
-    """Remove any leftover per-op journal dirs (keep the empty ``transactions/`` root)."""
+    """Clean leftover per-op dirs, keeping the empty ``transactions/`` root.
+
+    Only dirs that pass :func:`_is_transaction_residue` (positive
+    identification) are removed. Symlinks, foreign files, and unknown subdirs
+    are never touched here — ``recover_startup`` already raised on them before
+    this runs — and a failure to remove a positively-identified dir propagates
+    rather than being swallowed.
+    """
     txn_root = root / "transactions"
     if not txn_root.exists():
         return
     for op_dir in txn_root.iterdir():
-        if op_dir.is_dir():
-            shutil.rmtree(op_dir, ignore_errors=True)
+        if _is_transaction_residue(op_dir):
+            shutil.rmtree(op_dir)
 
 
 def _validate_journal(root: Path, op_dir: Path, doc: dict[str, Any]) -> None:

--- a/daydream/benchmark/storage.py
+++ b/daydream/benchmark/storage.py
@@ -232,7 +232,8 @@ class WorkspaceLock:
 # ``complete`` journal. Because the journal lives on the same filesystem as
 # the targets and every phase is fsynced before the next begins, a crash at
 # any boundary restores either the whole before-state or the whole after-state
-# — never a checksum-drifted partial.
+# — never a checksum-drifted partial. Recovery is mode-safe: verified targets
+# keep ``0600``, and scaffold dirs kept by ``_remove_created_dirs`` stay ``0700``.
 
 
 @dataclass
@@ -812,6 +813,8 @@ def _verify_complete(root: Path, op_dir: Path, doc: dict[str, Any]) -> None:
             raise WorkspaceCorrupt(
                 f"{root}: complete journal {t['rel']} digest mismatch (expected {t['after_digest']}, got {actual})"
             )
+        # Recovery never widens a private target's mode, even if it drifted.
+        os.chmod(target, 0o600)
     if op_dir.exists():
         shutil.rmtree(op_dir, ignore_errors=True)
 

--- a/daydream/benchmark/storage.py
+++ b/daydream/benchmark/storage.py
@@ -15,6 +15,7 @@ import fcntl
 import hashlib
 import json
 import os
+import re
 import shutil
 import tempfile
 from contextlib import suppress
@@ -533,17 +534,39 @@ def recover_startup(
     absent markers, and a ``complete`` journal is verified against after-state
     digests then cleared. With ``indexed``/``on_disk`` supplied and no journal
     present, the orphan rule applies: an on-disk import/case/bundle not in
-    ``indexed``, or an indexed file missing from disk, is corruption.
+    ``indexed``, or an indexed file missing from disk, is corruption. When no
+    journal is present, recovery still runs: it removes only positively-
+    identified pre-journal ``stage-*.bin``/``backup-*.bin`` residue and treats
+    any unidentifiable entry under ``transactions/`` as corruption.
     """
     root = Path(root)
     txn_root = root / "transactions"
     journal_files: list[Path] = []
+    residue_dirs: list[Path] = []
     if txn_root.exists():
         for op_dir in txn_root.iterdir():
-            if op_dir.is_dir():
-                jf = op_dir / "journal.json"
-                if jf.exists():
-                    journal_files.append(jf)
+            if op_dir.is_symlink():
+                # Never follow a symlink under transactions/ — it is
+                # unidentifiable residue and fails closed.
+                raise WorkspaceCorrupt(
+                    f"{root}: unidentifiable symlink under transactions: {op_dir.name}"
+                )
+            if not op_dir.is_dir():
+                # A plain file under transactions/ is not our residue -> fail closed.
+                raise WorkspaceCorrupt(
+                    f"{root}: unidentifiable file under transactions: {op_dir.name}"
+                )
+            jf = op_dir / "journal.json"
+            if jf.exists():
+                journal_files.append(jf)
+            elif _is_transaction_residue(op_dir):
+                residue_dirs.append(op_dir)
+            else:
+                # A dir with unknown contents is not positively-identified
+                # residue — fail closed and leave it untouched.
+                raise WorkspaceCorrupt(
+                    f"{root}: unidentifiable residue under transactions: {op_dir.name}"
+                )
 
     if journal_files:
         # Phase 1: validate every journal + collect claimed target rels,
@@ -579,10 +602,40 @@ def recover_startup(
         _empty_transactions(root)
         return
 
+    # No journal present: remove only positively-identified pre-journal
+    # residue, then apply the orphan rule if indexed/on_disk were supplied.
+    for op_dir in residue_dirs:
+        shutil.rmtree(op_dir)
     if indexed is None or on_disk is None:
         return
 
     _apply_orphan_rule(root, indexed, on_disk)
+
+
+_TRANSACTION_RESIDUE_RE = re.compile(r"^(?:stage|backup)-\d{4}\.bin$")
+
+
+def _is_transaction_residue(op_dir: Path) -> bool:
+    """True iff ``op_dir`` is positively-identified pre-journal residue.
+
+    A residue dir is a real directory (not a symlink) whose *only* contents
+    are regular files matching the exact ``stage-NNNN.bin`` / ``backup-NNNN.bin``
+    staging patterns. A dir containing ``journal.json``, a subdirectory, a
+    foreign file, or any symlink is -- by definition -- not residue, so
+    recovery never guesses and never deletes anything it cannot identify.
+    """
+    if not op_dir.is_dir() or op_dir.is_symlink():
+        return False
+    try:
+        entries = list(op_dir.iterdir())
+    except OSError:
+        return False
+    for entry in entries:
+        if entry.is_symlink() or not entry.is_file():
+            return False
+        if not _TRANSACTION_RESIDUE_RE.match(entry.name):
+            return False
+    return True
 
 
 def _empty_transactions(root: Path) -> None:

--- a/daydream/benchmark/storage.py
+++ b/daydream/benchmark/storage.py
@@ -524,12 +524,16 @@ def recover_startup(
 ) -> None:
     """Recover an interrupted journal before reading workspace state.
 
-    A ``prepared`` journal rolls back (targets were never applied); a
-    ``committing`` journal rolls back in reverse from backups/absent markers;
-    a ``complete`` journal is verified against after_state digests and then
-    cleared. With ``indexed``/``on_disk`` supplied and no journal present, the
-    orphan rule applies: an on-disk import/case/bundle not in ``indexed``, or
-    an indexed file missing from disk, is corruption.
+    Recovery is fail-closed and two-phase. Phase 1 loads and validates the
+    *entire* journal set (via :func:`_validate_journal`) and builds a
+    ``{rel: op_dir}`` claim map, rejecting any cross-transaction target
+    conflict before any filesystem mutation. Phase 2 then dispatches each
+    validated journal: a ``prepared`` journal rolls back (targets were never
+    applied), a ``committing`` journal rolls back in reverse from backups/
+    absent markers, and a ``complete`` journal is verified against after-state
+    digests then cleared. With ``indexed``/``on_disk`` supplied and no journal
+    present, the orphan rule applies: an on-disk import/case/bundle not in
+    ``indexed``, or an indexed file missing from disk, is corruption.
     """
     root = Path(root)
     txn_root = root / "transactions"
@@ -542,8 +546,36 @@ def recover_startup(
                     journal_files.append(jf)
 
     if journal_files:
+        # Phase 1: validate every journal + collect claimed target rels,
+        # rejecting any cross-transaction conflict before mutation.
+        journaled: list[tuple[Path, dict[str, Any]]] = []
+        claims: dict[str, str] = {}
         for jf in journal_files:
-            _recover_one_journal(root, jf, jf.parent)
+            try:
+                doc = load_json_strict(jf)
+            except WorkspaceCorrupt as exc:
+                raise WorkspaceCorrupt(
+                    f"{root}: unreadable transaction journal: {exc}"
+                ) from exc
+            op_dir = jf.parent
+            _validate_journal(root, op_dir, doc)
+            journaled.append((op_dir, doc))
+            for t in _targets_from_doc(doc):
+                rel = _resolve_target(root, t["rel"])
+                if rel in claims:
+                    raise WorkspaceCorrupt(
+                        f"{root}: cross-transaction target conflict on {rel!r}"
+                    )
+                claims[rel] = op_dir.name
+        # Phase 2: dispatch each validated journal (no conflict possible now).
+        for op_dir, doc in journaled:
+            state = doc.get("state")
+            if state == "prepared":
+                _rollback_prepared(root, op_dir, doc)
+            elif state == "committing":
+                _rollback_committing(root, op_dir, doc)
+            else:  # complete
+                _verify_complete(root, op_dir, doc)
         _empty_transactions(root)
         return
 
@@ -606,7 +638,6 @@ def _validate_journal(root: Path, op_dir: Path, doc: dict[str, Any]) -> None:
     for item in order:
         if not isinstance(item, str):
             raise WorkspaceCorrupt(f"{root}: journal replacement_order entry is not a string")
-        order_rels.add(item)
         if item not in rels:
             raise WorkspaceCorrupt(
                 f"{root}: journal replacement_order names unknown target {item!r}"
@@ -614,24 +645,6 @@ def _validate_journal(root: Path, op_dir: Path, doc: dict[str, Any]) -> None:
     applied = doc.get("applied_count")
     if not isinstance(applied, int) or not (0 <= applied <= len(order)):
         raise WorkspaceCorrupt(f"{root}: journal applied_count is out of bounds")
-
-
-def _recover_one_journal(root: Path, journal_path: Path, op_dir: Path) -> None:
-    try:
-        doc = load_json_strict(journal_path)
-    except WorkspaceCorrupt as exc:
-        raise WorkspaceCorrupt(f"{root}: unreadable transaction journal: {exc}") from exc
-    # Fail closed: validate the whole doc BEFORE any unlink/replace/rmdir.
-    _validate_journal(root, op_dir, doc)
-    state = doc.get("state")
-    if state == "prepared":
-        _rollback_prepared(root, op_dir, doc)
-    elif state == "committing":
-        _rollback_committing(root, op_dir, doc)
-    elif state == "complete":
-        _verify_complete(root, op_dir, doc)
-    else:
-        raise WorkspaceCorrupt(f"{root}: unknown journal state {state!r}")
 
 
 def _targets_from_doc(doc: dict[str, Any]) -> list[dict[str, Any]]:

--- a/daydream/benchmark/storage.py
+++ b/daydream/benchmark/storage.py
@@ -384,7 +384,22 @@ class Transaction:
         self._applied_count = 0
         self._write_journal()
         _fsync_file(self._journal_path())
-        for rel in self._replacement_order:
+        self._apply_replacements()
+        _fsync_dir(self._root)
+
+    def _apply_replacements(self, *, stop_after: int | None = None) -> None:
+        """Apply targets in ``replacement_order``, fsyncing each rename.
+
+        Each target's rename is made durable (file + *parent directory* fsync)
+        before the next target is applied, so a crash at any per-target
+        boundary still restores the whole before- or after-state, never a
+        checksum-drifted mix. ``stop_after`` (a test-only hook) applies only
+        the first ``N`` targets and leaves the journal ``committing`` with
+        ``applied_count == N``, byte-identical to a real mid-loop crash.
+        """
+        for i, rel in enumerate(self._replacement_order):
+            if stop_after is not None and i >= stop_after:
+                break
             st = self._states[rel]
             rel = _resolve_target(self._root, rel)
             target = self._root / rel
@@ -396,7 +411,7 @@ class Transaction:
             os.replace(st.stage_path, target)
             _fsync_file(target)
             os.chmod(target, 0o600)
-        _fsync_dir(self._root)
+            _fsync_dir(target.parent)
 
     def commit(self) -> None:
         """Run the full pipeline to ``complete`` and remove the journal."""
@@ -416,13 +431,14 @@ class Transaction:
     def inject_crash(self, boundary: str | None = None) -> None:
         """Simulate a crash at a named pipeline boundary (test-only).
 
-        With ``boundary is None`` (Task 4's scalar form) this simply halts at
-        the transaction's current state — recovery must adjudicate whatever
-        phase is already persisted. With a named ``boundary``
+        With ``boundary is None`` this simply halts at the transaction's
+        current state — recovery must adjudicate whatever phase is already
+        persisted. With a named ``boundary``
         (``staged|backup|journal|data|manifest``) it first advances to that
         boundary (so a caller may drive an arbitrary mid-state) and then
-        halts. This is the acceptance-test hook that proves a crash restores
-        either the whole before- or after-state.
+        halts. A ``target-<n>`` boundary applies exactly the first ``n``
+        targets of ``replacement_order`` under ``committing`` and halts,
+        leaving a crash state byte-identical to a real mid-loop halt.
         """
         if boundary is None or boundary in ("staged", "backup"):
             # Staging (and any backup file) is written but no journal is
@@ -446,6 +462,28 @@ class Transaction:
             self.prepare()
             self.begin_commit()
             self.force_state("complete")
+            return
+        if boundary is not None and boundary.startswith("target-"):
+            # Per-target boundary ``target-<n>``: prepare, then apply exactly
+            # the first ``n`` targets and halt before the parent-dir fsync of
+            # the next rename / the final root fsync. Recovery rolls all of
+            # them back, restoring the all-old state. ``target-0`` is exactly
+            # the ``journal`` boundary (prepared, nothing applied).
+            suffix = boundary[len("target-"):]
+            try:
+                n = int(suffix)
+            except ValueError:
+                raise ValueError(f"invalid target boundary {boundary!r}") from None
+            if not (0 <= n <= len(self._replacement_order)):
+                raise ValueError(f"target boundary {n!r} out of range")
+            self.prepare()
+            if n == 0:
+                return
+            self._state = "committing"
+            self._applied_count = 0
+            self._write_journal()
+            _fsync_file(self._journal_path())
+            self._apply_replacements(stop_after=n)
             return
         raise ValueError(f"unknown crash boundary {boundary!r}")
 
@@ -741,9 +779,11 @@ def _rollback_committing(root: Path, op_dir: Path, doc: dict[str, Any]) -> None:
         if backup is not None:
             os.replace(op_dir / backup, target)
             os.chmod(target, 0o600)
+            _fsync_dir(target.parent)
         else:
             with suppress(OSError):
                 target.unlink()
+            _fsync_dir(target.parent)
     if op_dir.exists():
         shutil.rmtree(op_dir, ignore_errors=True)
     _remove_created_dirs(root, doc)

--- a/daydream/benchmark/storage.py
+++ b/daydream/benchmark/storage.py
@@ -678,6 +678,8 @@ def _is_transaction_residue(op_dir: Path) -> bool:
         entries = list(op_dir.iterdir())
     except OSError:
         return False
+    if not entries:
+        return False
     for entry in entries:
         if entry.is_symlink() or not entry.is_file():
             return False
@@ -730,15 +732,12 @@ def _validate_journal(root: Path, op_dir: Path, doc: dict[str, Any]) -> None:
         if rel in rels:
             raise WorkspaceCorrupt(f"{root}: duplicate target rel in journal: {rel!r}")
         rels.add(rel)
-        for field in ("stage",):
+        for field in ("stage", "backup"):
             val = t.get(field)
+            if val is None and field == "backup":
+                continue
             if not isinstance(val, str) or os.path.basename(val) != val:
                 raise WorkspaceCorrupt(f"{root}: journal target {rel!r} {field} is not a bare filename")
-        backup = t.get("backup")
-        if backup is not None and (
-            not isinstance(backup, str) or os.path.basename(backup) != backup
-        ):
-            raise WorkspaceCorrupt(f"{root}: journal target {rel!r} backup is not a bare filename")
     order = doc.get("replacement_order")
     if not isinstance(order, list):
         raise WorkspaceCorrupt(f"{root}: journal replacement_order is not a list")
@@ -784,7 +783,10 @@ def _rollback_prepared(root: Path, op_dir: Path, doc: dict[str, Any]) -> None:
 def _rollback_committing(root: Path, op_dir: Path, doc: dict[str, Any]) -> None:
     order = doc.get("replacement_order") or []
     applied = int(doc.get("applied_count") or 0)
-    targets = {t["rel"]: t for t in _targets_from_doc(doc)}
+    # Key by the canonical rel the validator computed (replacement_order holds
+    # canonical rels), so a crafted non-canonical target rel can't silently
+    # evade recovery via a key mismatch (fail-closed all-or-nothing).
+    targets = {_resolve_target(root, t["rel"]): t for t in _targets_from_doc(doc)}
     # Reverse order so benchmark.yaml (last) is restored first.
     prefix = order[: applied if applied else len(order)]
     for rel in reversed(prefix):
@@ -822,13 +824,14 @@ def _remove_created_dirs(root: Path, doc: dict[str, Any]) -> None:
 
 def _verify_complete(root: Path, op_dir: Path, doc: dict[str, Any]) -> None:
     for t in _targets_from_doc(doc):
-        target = root / t["rel"]
+        rel = _resolve_target(root, t["rel"])
+        target = root / rel
         if not target.exists():
-            raise WorkspaceCorrupt(f"{root}: complete journal {t['rel']} missing on disk")
+            raise WorkspaceCorrupt(f"{root}: complete journal {rel} missing on disk")
         actual = sha256_file(target)
         if actual != t["after_digest"]:
             raise WorkspaceCorrupt(
-                f"{root}: complete journal {t['rel']} digest mismatch (expected {t['after_digest']}, got {actual})"
+                f"{root}: complete journal {rel} digest mismatch (expected {t['after_digest']}, got {actual})"
             )
         # Recovery never widens a private target's mode, even if it drifted.
         os.chmod(target, 0o600)

--- a/tests/test_benchmark_workspace_storage.py
+++ b/tests/test_benchmark_workspace_storage.py
@@ -1,4 +1,5 @@
 import fcntl
+import os
 import stat
 
 import pytest
@@ -439,3 +440,30 @@ def test_single_target_target_boundary(tmp_path):
     recover_startup(root)
     assert t.read_text() == "before"
     assert not (root / "transactions").exists() or not list((root / "transactions").iterdir())
+
+
+def test_verify_complete_preserves_0600_target(tmp_path):
+    t = tmp_path / "target.yaml"; t.write_text("old"); os.chmod(t, 0o600)
+    with Transaction(tmp_path, op_id="op-c", kind="write") as tx:
+        _stage(tx, t, "new"); tx.commit(); tx.force_state("complete")
+    recover_startup(tmp_path)
+    assert stat.S_IMODE(t.stat().st_mode) == 0o600
+
+
+def test_rollback_preserves_0700_scaffold_dir(tmp_path):
+    with Transaction(tmp_path, op_id="op-i", kind="init") as tx:
+        tx.create_dir("cases"); tx.stage("cases/keep.yaml", b"keep")
+        tx.prepare()
+    (tmp_path / "cases" / "keep.yaml").write_text("keep")  # non-empty -> dir preserved
+    recover_startup(tmp_path)
+    if (tmp_path / "cases").exists():
+        assert stat.S_IMODE((tmp_path / "cases").stat().st_mode) == 0o700
+
+
+def test_rollback_committing_restored_target_is_0600(tmp_path):
+    t = tmp_path / "target.yaml"; t.write_text("old"); os.chmod(t, 0o600)
+    with Transaction(tmp_path, op_id="op-r", kind="write") as tx:
+        _stage(tx, t, "new"); tx.begin_commit(); tx.inject_crash()
+    recover_startup(tmp_path)
+    assert t.read_text() == "old"
+    assert stat.S_IMODE(t.stat().st_mode) == 0o600

--- a/tests/test_benchmark_workspace_storage.py
+++ b/tests/test_benchmark_workspace_storage.py
@@ -513,3 +513,37 @@ def test_complete_restart_recovery_is_idempotent(tmp_path):
     recover_startup(tmp_path)
     recover_startup(tmp_path)   # second pass: complete journal already verified+cleaned
     assert t.read_text() == "new"
+
+
+def test_recovery_trusts_canonical_rel_not_raw_doc_rel(tmp_path):
+    """Recovery consumes the canonical rel the validator computed, never the
+    raw journal string -- a crafted non-canonical-but-inside-root target rel
+    must still be rolled back, not silently skipped (all-or-nothing)."""
+    target = tmp_path / "target.yaml"
+    target.write_text("old")
+    with Transaction(tmp_path, op_id="op-noncanon", kind="write") as tx:
+        _stage(tx, target, "new")
+        tx.prepare()
+        tx.begin_commit()   # state=committing, applied_count=1, target -> "new"
+        tx.inject_crash()
+    # Corrupt the journal target rel to a non-canonical form that still
+    # resolves inside root; keep replacement_order canonical (as the
+    # validator's rels set is built from _resolve_target).
+    jf = tmp_path / "transactions" / "op-noncanon" / "journal.json"
+    doc = load_json_strict(jf)
+    doc["targets"][0]["rel"] = "./target.yaml"
+    doc["replacement_order"] = ["target.yaml"]
+    atomic_write_json(jf, doc)
+    assert target.read_text() == "new"
+    recover_startup(tmp_path)
+    assert target.read_text() == "old"  # restored from backup, not skipped
+
+
+def test_empty_prejournal_dir_fails_closed_and_left_untouched(tmp_path):
+    """A genuinely empty dir under transactions/ is not positively-identified
+    residue -- recovery fails closed and never deletes what it can't identify."""
+    op = tmp_path / "transactions" / "op-empty"
+    op.mkdir(parents=True)
+    with pytest.raises(WorkspaceCorrupt):
+        recover_startup(tmp_path)
+    assert op.is_dir()  # left untouched

--- a/tests/test_benchmark_workspace_storage.py
+++ b/tests/test_benchmark_workspace_storage.py
@@ -224,3 +224,40 @@ def test_import_crash_transaction_restores_before_or_after(tmp_path):
             assert not (tmp_path / "transactions").exists() or not list(
                 (tmp_path / "transactions").iterdir()
             )
+
+
+def test_stage_rejects_rel_escape(tmp_path):
+    outside = tmp_path.parent / "escaped.bin"
+    outside.unlink(missing_ok=True)
+    with Transaction(tmp_path, op_id="op-esc", kind="write") as tx:
+        with pytest.raises(WorkspaceCorrupt):
+            tx.stage("../escaped.bin", b"x")
+    assert not outside.exists()
+
+
+def test_stage_rejects_absolute_outside(tmp_path):
+    outside = tmp_path.parent / "outside" / "evil.bin"
+    outside.parent.mkdir(parents=True, exist_ok=True)
+    with Transaction(tmp_path, op_id="op-abs", kind="write") as tx:
+        with pytest.raises(WorkspaceCorrupt):
+            tx.stage(str(outside), b"x")
+    assert not outside.exists()
+
+
+def test_stage_rejects_symlink_parent_escape(tmp_path):
+    outside = tmp_path.parent / "outside"
+    outside.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "cases").symlink_to(outside, target_is_directory=True)
+    with Transaction(tmp_path, op_id="op-sym", kind="write") as tx:
+        with pytest.raises(WorkspaceCorrupt):
+            tx.stage("cases/x.yaml", b"x")
+    assert not (outside / "x.yaml").exists()
+
+
+def test_stage_accepts_absolute_inside_root(tmp_path):
+    target = tmp_path / "cases" / "a.yaml"
+    target.parent.mkdir(parents=True)
+    with Transaction(tmp_path, op_id="op", kind="write") as tx:
+        _stage(tx, target, "ok")
+        tx.commit()
+    assert target.read_text() == "ok"

--- a/tests/test_benchmark_workspace_storage.py
+++ b/tests/test_benchmark_workspace_storage.py
@@ -188,10 +188,41 @@ def test_crash_injection_at_every_boundary_restores_before_or_after(tmp_path):
         else:  # manifest
             # A complete journal is verified against the after-state and kept.
             assert target.read_text() == "after"
-        if boundary not in ("staged", "backup"):
-            assert not (tmp_path / "transactions").exists() or not list(
-                (tmp_path / "transactions").iterdir()
-            )
+        assert not (tmp_path / "transactions").exists() or not list(
+            (tmp_path / "transactions").iterdir()
+        )
+
+
+def test_prejournal_stage_residue_is_removed(tmp_path):
+    target = tmp_path / "t.yaml"
+    target.write_text("before")
+    with Transaction(tmp_path, op_id="op-pre", kind="write") as tx:
+        _stage(tx, target, "after")
+        tx.inject_crash("staged")  # stage-*.bin written, NO journal.json
+    recover_startup(tmp_path)
+    assert target.read_text() == "before"  # untouched
+    txn = tmp_path / "transactions"
+    assert not txn.exists() or not list(txn.iterdir())  # residue gone
+
+
+def test_prejournal_backup_residue_is_removed(tmp_path):
+    target = tmp_path / "t.yaml"
+    target.write_text("before")
+    with Transaction(tmp_path, op_id="op-pre2", kind="write") as tx:
+        _stage(tx, target, "after")
+        tx.inject_crash("backup")  # stage + backup written, NO journal.json
+    recover_startup(tmp_path)
+    txn = tmp_path / "transactions"
+    assert not txn.exists() or not list(txn.iterdir())
+
+
+def test_unidentifiable_residue_is_corruption_and_left_untouched(tmp_path):
+    op = tmp_path / "transactions" / "op-x"
+    op.mkdir(parents=True)
+    (op / "foreign.txt").write_text("not residue")
+    with pytest.raises(WorkspaceCorrupt):
+        recover_startup(tmp_path)
+    assert (op / "foreign.txt").read_text() == "not residue"  # left untouched, never guessed/deleted
 
 
 def test_import_crash_transaction_restores_before_or_after(tmp_path):

--- a/tests/test_benchmark_workspace_storage.py
+++ b/tests/test_benchmark_workspace_storage.py
@@ -324,7 +324,8 @@ def test_journal_opid_mismatch_fails_closed(tmp_path):
 def test_journal_rel_escape_fails_closed(tmp_path):
     outside = tmp_path.parent / "escaped-by-journal.bin"
     outside.unlink(missing_ok=True)
-    _write_corrupt_journal(tmp_path, "op-3", lambda d: d["targets"][0].__setitem__("rel", "../../escaped-by-journal.bin"))
+    _write_corrupt_journal(tmp_path, "op-3",
+        lambda d: d["targets"][0].__setitem__("rel", "../../escaped-by-journal.bin"))
     with pytest.raises(WorkspaceCorrupt):
         recover_startup(tmp_path)
     assert not outside.exists()  # no path outside the workspace changed
@@ -369,12 +370,16 @@ def test_cross_transaction_target_conflict_is_corruption(tmp_path):
 
 
 def test_disjoint_transactions_both_recover(tmp_path):
-    t1 = tmp_path / "a.yaml"; t2 = tmp_path / "b.yaml"
-    t1.write_text("a-before"); t2.write_text("b-before")
+    t1 = tmp_path / "a.yaml"
+    t2 = tmp_path / "b.yaml"
+    t1.write_text("a-before")
+    t2.write_text("b-before")
     with Transaction(tmp_path, op_id="op-a", kind="write") as tx:
-        _stage(tx, t1, "a-after"); tx.prepare()
+        _stage(tx, t1, "a-after")
+        tx.prepare()
     with Transaction(tmp_path, op_id="op-b", kind="write") as tx:
-        _stage(tx, t2, "b-after"); tx.prepare()
+        _stage(tx, t2, "b-after")
+        tx.prepare()
     recover_startup(tmp_path)  # disjoint targets must both roll back cleanly
     assert t1.read_text() == "a-before" and t2.read_text() == "b-before"
 
@@ -415,12 +420,15 @@ def test_empty_transactions_removes_only_positive_residue(tmp_path):
 def test_multi_target_each_per_target_boundary_restores_all_old(tmp_path):
     # 3 targets; inject a crash after each individual rename/fsync boundary.
     for n in range(0, 4):  # after applying 0, 1, 2, 3 of the 3 targets
-        root = tmp_path / f"ws-{n}"; root.mkdir()
+        root = tmp_path / f"ws-{n}"
+        root.mkdir()
         before = {}
         for i in range(3):
             rel = f"cases/t{i}.yaml"
             before[rel] = f"before-{i}"
-            p = root / rel; p.parent.mkdir(parents=True, exist_ok=True); p.write_text(before[rel])
+            p = root / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(before[rel])
         with Transaction(root, op_id=f"op-{n}", kind="import") as tx:
             for i in range(3):
                 _stage(tx, root / f"cases/t{i}.yaml", f"after-{i}")
@@ -432,8 +440,10 @@ def test_multi_target_each_per_target_boundary_restores_all_old(tmp_path):
 
 
 def test_single_target_target_boundary(tmp_path):
-    root = tmp_path / "ws"; root.mkdir()
-    t = root / "t.yaml"; t.write_text("before")
+    root = tmp_path / "ws"
+    root.mkdir()
+    t = root / "t.yaml"
+    t.write_text("before")
     with Transaction(root, op_id="op-1t", kind="write") as tx:
         _stage(tx, t, "after")
         tx.inject_crash(boundary="target-0")
@@ -443,16 +453,21 @@ def test_single_target_target_boundary(tmp_path):
 
 
 def test_verify_complete_preserves_0600_target(tmp_path):
-    t = tmp_path / "target.yaml"; t.write_text("old"); os.chmod(t, 0o600)
+    t = tmp_path / "target.yaml"
+    t.write_text("old")
+    os.chmod(t, 0o600)
     with Transaction(tmp_path, op_id="op-c", kind="write") as tx:
-        _stage(tx, t, "new"); tx.commit(); tx.force_state("complete")
+        _stage(tx, t, "new")
+        tx.commit()
+        tx.force_state("complete")
     recover_startup(tmp_path)
     assert stat.S_IMODE(t.stat().st_mode) == 0o600
 
 
 def test_rollback_preserves_0700_scaffold_dir(tmp_path):
     with Transaction(tmp_path, op_id="op-i", kind="init") as tx:
-        tx.create_dir("cases"); tx.stage("cases/keep.yaml", b"keep")
+        tx.create_dir("cases")
+        tx.stage("cases/keep.yaml", b"keep")
         tx.prepare()
     (tmp_path / "cases" / "keep.yaml").write_text("keep")  # non-empty -> dir preserved
     recover_startup(tmp_path)
@@ -461,18 +476,25 @@ def test_rollback_preserves_0700_scaffold_dir(tmp_path):
 
 
 def test_rollback_committing_restored_target_is_0600(tmp_path):
-    t = tmp_path / "target.yaml"; t.write_text("old"); os.chmod(t, 0o600)
+    t = tmp_path / "target.yaml"
+    t.write_text("old")
+    os.chmod(t, 0o600)
     with Transaction(tmp_path, op_id="op-r", kind="write") as tx:
-        _stage(tx, t, "new"); tx.begin_commit(); tx.inject_crash()
+        _stage(tx, t, "new")
+        tx.begin_commit()
+        tx.inject_crash()
     recover_startup(tmp_path)
     assert t.read_text() == "old"
     assert stat.S_IMODE(t.stat().st_mode) == 0o600
 
 
 def test_restart_recovery_is_idempotent(tmp_path):
-    t = tmp_path / "target.yaml"; t.write_text("old")
+    t = tmp_path / "target.yaml"
+    t.write_text("old")
     with Transaction(tmp_path, op_id="op-idem", kind="write") as tx:
-        _stage(tx, t, "new"); tx.begin_commit(); tx.inject_crash()
+        _stage(tx, t, "new")
+        tx.begin_commit()
+        tx.inject_crash()
     recover_startup(tmp_path)   # first pass: roll back committing journal
     first_txn = list((tmp_path / "transactions").iterdir()) if (tmp_path / "transactions").exists() else []
     recover_startup(tmp_path)   # second pass: must be a clean no-op
@@ -482,9 +504,12 @@ def test_restart_recovery_is_idempotent(tmp_path):
 
 
 def test_complete_restart_recovery_is_idempotent(tmp_path):
-    t = tmp_path / "target.yaml"; t.write_text("old")
+    t = tmp_path / "target.yaml"
+    t.write_text("old")
     with Transaction(tmp_path, op_id="op-idem2", kind="write") as tx:
-        _stage(tx, t, "new"); tx.commit(); tx.force_state("complete")
+        _stage(tx, t, "new")
+        tx.commit()
+        tx.force_state("complete")
     recover_startup(tmp_path)
     recover_startup(tmp_path)   # second pass: complete journal already verified+cleaned
     assert t.read_text() == "new"

--- a/tests/test_benchmark_workspace_storage.py
+++ b/tests/test_benchmark_workspace_storage.py
@@ -268,7 +268,7 @@ def test_stage_rejects_rel_escape(tmp_path):
 
 
 def test_stage_rejects_absolute_outside(tmp_path):
-    outside = tmp_path.parent / "outside" / "evil.bin"
+    outside = tmp_path.parent / f"outside-{tmp_path.name}" / "evil.bin"
     outside.parent.mkdir(parents=True, exist_ok=True)
     with Transaction(tmp_path, op_id="op-abs", kind="write") as tx:
         with pytest.raises(WorkspaceCorrupt):
@@ -277,7 +277,7 @@ def test_stage_rejects_absolute_outside(tmp_path):
 
 
 def test_stage_rejects_symlink_parent_escape(tmp_path):
-    outside = tmp_path.parent / "outside"
+    outside = tmp_path.parent / f"outside-{tmp_path.name}"
     outside.mkdir(parents=True, exist_ok=True)
     (tmp_path / "cases").symlink_to(outside, target_is_directory=True)
     with Transaction(tmp_path, op_id="op-sym", kind="write") as tx:

--- a/tests/test_benchmark_workspace_storage.py
+++ b/tests/test_benchmark_workspace_storage.py
@@ -322,3 +322,26 @@ def test_journal_replacement_order_unknown_target_fails_closed(tmp_path):
         lambda d: d.__setitem__("replacement_order", ["not-a-target"]))
     with pytest.raises(WorkspaceCorrupt):
         recover_startup(tmp_path)
+
+
+def test_cross_transaction_target_conflict_is_corruption(tmp_path):
+    target = tmp_path / "target.yaml"
+    target.write_text("before")
+    for i in (1, 2):
+        with Transaction(tmp_path, op_id=f"op-{i}", kind="write") as tx:
+            _stage(tx, target, f"after-{i}")
+            tx.prepare()
+    with pytest.raises(WorkspaceCorrupt):
+        recover_startup(tmp_path)
+    assert target.read_text() == "before"  # neither journal applied; no last-writer-wins
+
+
+def test_disjoint_transactions_both_recover(tmp_path):
+    t1 = tmp_path / "a.yaml"; t2 = tmp_path / "b.yaml"
+    t1.write_text("a-before"); t2.write_text("b-before")
+    with Transaction(tmp_path, op_id="op-a", kind="write") as tx:
+        _stage(tx, t1, "a-after"); tx.prepare()
+    with Transaction(tmp_path, op_id="op-b", kind="write") as tx:
+        _stage(tx, t2, "b-after"); tx.prepare()
+    recover_startup(tmp_path)  # disjoint targets must both roll back cleanly
+    assert t1.read_text() == "a-before" and t2.read_text() == "b-before"

--- a/tests/test_benchmark_workspace_storage.py
+++ b/tests/test_benchmark_workspace_storage.py
@@ -261,3 +261,64 @@ def test_stage_accepts_absolute_inside_root(tmp_path):
         _stage(tx, target, "ok")
         tx.commit()
     assert target.read_text() == "ok"
+
+
+def _write_corrupt_journal(tmp_path, op_id, mutate):
+    """Build a valid prepared transaction, then corrupt its journal doc."""
+    target = tmp_path / "target.yaml"
+    target.write_text("old")  # pre-existing target so "untouched" is observable
+    with Transaction(tmp_path, op_id=op_id, kind="write") as tx:
+        _stage(tx, target, "old")
+        tx.prepare()
+    jf = tmp_path / "transactions" / op_id / "journal.json"
+    doc = load_json_strict(jf)
+    mutate(doc)
+    atomic_write_json(jf, doc)
+
+
+def test_journal_invalid_state_fails_closed(tmp_path):
+    _write_corrupt_journal(tmp_path, "op-1", lambda d: d.__setitem__("state", "bogus"))
+    with pytest.raises(WorkspaceCorrupt):
+        recover_startup(tmp_path)
+    assert (tmp_path / "target.yaml").read_text() == "old"  # target untouched
+
+
+def test_journal_opid_mismatch_fails_closed(tmp_path):
+    _write_corrupt_journal(tmp_path, "op-2", lambda d: d.__setitem__("op_id", "other-dir"))
+    with pytest.raises(WorkspaceCorrupt):
+        recover_startup(tmp_path)
+
+
+def test_journal_rel_escape_fails_closed(tmp_path):
+    outside = tmp_path.parent / "escaped-by-journal.bin"
+    outside.unlink(missing_ok=True)
+    _write_corrupt_journal(tmp_path, "op-3", lambda d: d["targets"][0].__setitem__("rel", "../../escaped-by-journal.bin"))
+    with pytest.raises(WorkspaceCorrupt):
+        recover_startup(tmp_path)
+    assert not outside.exists()  # no path outside the workspace changed
+
+
+def test_journal_stage_with_separator_fails_closed(tmp_path):
+    _write_corrupt_journal(tmp_path, "op-4", lambda d: d["targets"][0].__setitem__("stage", "sub/stage-0000.bin"))
+    with pytest.raises(WorkspaceCorrupt):
+        recover_startup(tmp_path)
+
+
+def test_journal_duplicate_target_rel_fails_closed(tmp_path):
+    _write_corrupt_journal(tmp_path, "op-5",
+        lambda d: d["targets"].append(dict(d["targets"][0])))
+    with pytest.raises(WorkspaceCorrupt):
+        recover_startup(tmp_path)
+
+
+def test_journal_applied_count_out_of_bounds_fails_closed(tmp_path):
+    _write_corrupt_journal(tmp_path, "op-6", lambda d: d.__setitem__("applied_count", 99))
+    with pytest.raises(WorkspaceCorrupt):
+        recover_startup(tmp_path)
+
+
+def test_journal_replacement_order_unknown_target_fails_closed(tmp_path):
+    _write_corrupt_journal(tmp_path, "op-7",
+        lambda d: d.__setitem__("replacement_order", ["not-a-target"]))
+    with pytest.raises(WorkspaceCorrupt):
+        recover_startup(tmp_path)

--- a/tests/test_benchmark_workspace_storage.py
+++ b/tests/test_benchmark_workspace_storage.py
@@ -409,3 +409,33 @@ def test_empty_transactions_removes_only_positive_residue(tmp_path):
     with pytest.raises(WorkspaceCorrupt):  # foreign op dir is unidentifiable
         recover_startup(tmp_path)
     assert (foreign / "note.txt").read_text() == "keep"  # foreign left untouched
+
+
+def test_multi_target_each_per_target_boundary_restores_all_old(tmp_path):
+    # 3 targets; inject a crash after each individual rename/fsync boundary.
+    for n in range(0, 4):  # after applying 0, 1, 2, 3 of the 3 targets
+        root = tmp_path / f"ws-{n}"; root.mkdir()
+        before = {}
+        for i in range(3):
+            rel = f"cases/t{i}.yaml"
+            before[rel] = f"before-{i}"
+            p = root / rel; p.parent.mkdir(parents=True, exist_ok=True); p.write_text(before[rel])
+        with Transaction(root, op_id=f"op-{n}", kind="import") as tx:
+            for i in range(3):
+                _stage(tx, root / f"cases/t{i}.yaml", f"after-{i}")
+            tx.inject_crash(boundary=f"target-{n}")  # new per-target boundary
+        recover_startup(root)
+        for rel, content in before.items():
+            assert (root / rel).read_text() == content  # every target back to all-old
+        assert not (root / "transactions").exists() or not list((root / "transactions").iterdir())
+
+
+def test_single_target_target_boundary(tmp_path):
+    root = tmp_path / "ws"; root.mkdir()
+    t = root / "t.yaml"; t.write_text("before")
+    with Transaction(root, op_id="op-1t", kind="write") as tx:
+        _stage(tx, t, "after")
+        tx.inject_crash(boundary="target-0")
+    recover_startup(root)
+    assert t.read_text() == "before"
+    assert not (root / "transactions").exists() or not list((root / "transactions").iterdir())

--- a/tests/test_benchmark_workspace_storage.py
+++ b/tests/test_benchmark_workspace_storage.py
@@ -376,3 +376,36 @@ def test_disjoint_transactions_both_recover(tmp_path):
         _stage(tx, t2, "b-after"); tx.prepare()
     recover_startup(tmp_path)  # disjoint targets must both roll back cleanly
     assert t1.read_text() == "a-before" and t2.read_text() == "b-before"
+
+
+def test_empty_transactions_never_follows_symlink(tmp_path):
+    # A journaled op dir exists so recover_startup reaches _empty_transactions,
+    # plus a symlink under transactions/ that must NOT be followed or deleted.
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "precious.txt").write_text("keep me")
+    with Transaction(tmp_path, op_id="op-ok", kind="write") as tx:
+        _stage(tx, tmp_path / "target.yaml", "new")
+        tx.prepare()
+    (tmp_path / "transactions" / "op-link").symlink_to(outside, target_is_directory=True)
+    with pytest.raises(WorkspaceCorrupt):  # symlink residue is unidentifiable -> fail closed
+        recover_startup(tmp_path)
+    assert (outside / "precious.txt").read_text() == "keep me"  # never followed/deleted
+    assert (tmp_path / "transactions" / "op-link").is_symlink()  # never removed
+
+
+def test_empty_transactions_removes_only_positive_residue(tmp_path):
+    # Journaled dir is cleaned by _recover_one_journal; a leftover positively-
+    # identified residue dir is removed; a foreign file is left untouched.
+    with Transaction(tmp_path, op_id="op-j", kind="write") as tx:
+        _stage(tx, tmp_path / "a.yaml", "x")
+        tx.prepare()
+    residue = tmp_path / "transactions" / "op-residue"
+    residue.mkdir(parents=True)
+    (residue / "stage-0000.bin").write_bytes(b"stale")
+    foreign = tmp_path / "transactions" / "op-foreign"
+    foreign.mkdir()
+    (foreign / "note.txt").write_text("keep")
+    with pytest.raises(WorkspaceCorrupt):  # foreign op dir is unidentifiable
+        recover_startup(tmp_path)
+    assert (foreign / "note.txt").read_text() == "keep"  # foreign left untouched

--- a/tests/test_benchmark_workspace_storage.py
+++ b/tests/test_benchmark_workspace_storage.py
@@ -467,3 +467,24 @@ def test_rollback_committing_restored_target_is_0600(tmp_path):
     recover_startup(tmp_path)
     assert t.read_text() == "old"
     assert stat.S_IMODE(t.stat().st_mode) == 0o600
+
+
+def test_restart_recovery_is_idempotent(tmp_path):
+    t = tmp_path / "target.yaml"; t.write_text("old")
+    with Transaction(tmp_path, op_id="op-idem", kind="write") as tx:
+        _stage(tx, t, "new"); tx.begin_commit(); tx.inject_crash()
+    recover_startup(tmp_path)   # first pass: roll back committing journal
+    first_txn = list((tmp_path / "transactions").iterdir()) if (tmp_path / "transactions").exists() else []
+    recover_startup(tmp_path)   # second pass: must be a clean no-op
+    assert t.read_text() == "old"                       # state identical to first pass
+    txn = list((tmp_path / "transactions").iterdir()) if (tmp_path / "transactions").exists() else []
+    assert txn == first_txn                              # no leftover residue, no second-pass failure
+
+
+def test_complete_restart_recovery_is_idempotent(tmp_path):
+    t = tmp_path / "target.yaml"; t.write_text("old")
+    with Transaction(tmp_path, op_id="op-idem2", kind="write") as tx:
+        _stage(tx, t, "new"); tx.commit(); tx.force_state("complete")
+    recover_startup(tmp_path)
+    recover_startup(tmp_path)   # second pass: complete journal already verified+cleaned
+    assert t.read_text() == "new"

--- a/tests/test_improve_flow.py
+++ b/tests/test_improve_flow.py
@@ -3173,7 +3173,7 @@ def test_stamp_finding_rejects_unconfined_missing_and_out_of_range_evidence(
 def test_stamp_finding_rejects_evidence_crossing_a_symlink(
     tmp_path: Path,
 ) -> None:
-    outside = tmp_path.parent / "outside"
+    outside = tmp_path.parent / f"outside-{tmp_path.name}"
     outside.mkdir()
     (outside / "secret.py").write_text("secret\n")
     (tmp_path / "escape").symlink_to(outside, target_is_directory=True)


### PR DESCRIPTION
## Summary
Fix(benchmark): contain and fully recover authoring transactions (Closes #807)

Contain every target, stage, backup, and journal path beneath the canonical workspace/transaction roots before any recovery mutation, and fully recover authoring transactions across every per-target interruption boundary.

## Changes
- Resolve all transaction paths under the workspace/transaction roots; reject absolute paths, `..`, symlink escapes, duplicated targets, cross-transaction paths, and malformed journals (fail closed, no mutation)
- Reject empty-string journal target names
- Memoize resolved targets via `lru_cache`
- Make metadata durable before externally visible renames with deterministic recovery for pre-journal stage/backup residue
- Recover to all-old or all-new state at every stage/backup/replace/fsync/cleanup interruption boundary
- Clean only positively identified residue; preserve private modes and directory fsync guarantees
- Fail closed when `Path.resolve` raises (OSError/RuntimeError)

## Verification
- Adversarial journal + symlink tests prove no path outside the workspace changes
- Failure injection covers every rename/fsync boundary for one and multiple targets
- Restart recovery is idempotent and leaves no private stage/backup residue
- Corrupt recovery metadata fails closed with bounded diagnostic
- `make check` green: ruff all-checks-passed, mypy no-errors, pytest 4235 passed / 6 skipped / 0 failed

Two sequential daydream deep-precision reviews passed on fresh exe.dev VMs; trajectories uploaded to existentialbirds/daydream-trajectories.

Closes #807