### PR TITLE
fix(benchmark): harden external judge endpoints and failure handling

### DIFF
--- a/daydream/benchmark/harbor/templates/tests/score_review.py
+++ b/daydream/benchmark/harbor/templates/tests/score_review.py
@@ -121,7 +121,7 @@ def _effective_allowlist(base_url: str, env: dict[str, Any]) -> set[str]:
     host of ``base_url`` so an unconfigured verifier can only ever reach its
     own judge endpoint -- never an arbitrary host.
     """
-    raw = (env or {}).get("DAYDREAM_JUDGE_ALLOWED_HOSTS")
+    raw = (env or {}).get(_ENV_ALLOWED_HOSTS)
     if raw:
         hosts = {
             _normalize_host(host)
@@ -201,6 +201,16 @@ def _bounded_error(text: object) -> str:
         return redacted
     return encoded[:_ERROR_TEXT_CAP_BYTES].decode("utf-8", errors="ignore")
 
+
+def _bounded_repr(value: object) -> str:
+    """Return ``repr(value)`` redacted and bounded like any other error text.
+
+    Composes the module's single redact-and-bound seam (``_bounded_error``)
+    over ``repr`` so the four verdict-field diagnostics (match/confidence/
+    reasoning) never repeat the wrap and stay byte-identical to today's
+    output.
+    """
+    return _bounded_error(repr(value))
 
 
 def _render_filled(
@@ -305,26 +315,28 @@ def parse_verdict(raw: object) -> verifier_core.Verdict:
     match = raw["match"]
     if not isinstance(match, bool):
         raise VerifierError(
-            f"verdict 'match' must be a boolean, got {_bounded_error(repr(match))}"
+            f"verdict 'match' must be a boolean, got {_bounded_repr(match)}"
         )
     confidence = raw["confidence"]
     if isinstance(confidence, bool) or not isinstance(confidence, (int, float)):
         raise VerifierError(
-            f"verdict 'confidence' must be a number in [0,1], got {_bounded_error(repr(confidence))}"
+            f"verdict 'confidence' must be a number in [0,1], got {_bounded_repr(confidence)}"
         )
     if not 0.0 <= confidence <= 1.0:
         raise VerifierError(
-            f"verdict 'confidence' must be in [0,1], got {_bounded_error(repr(confidence))}"
+            f"verdict 'confidence' must be in [0,1], got {_bounded_repr(confidence)}"
         )
     reasoning = raw["reasoning"]
     if not isinstance(reasoning, str):
         raise VerifierError(
-            f"verdict 'reasoning' must be a string, got {_bounded_error(repr(reasoning))}"
+            f"verdict 'reasoning' must be a string, got {_bounded_repr(reasoning)}"
         )
     # Reasoning is capped at 32 KiB and rejected -- never truncated-and-accepted
     # -- so an oversized/untrusted value can never bloat a diagnostic.
     if len(reasoning.encode("utf-8")) > _REASONING_CAP_BYTES:
-        raise VerifierError("verdict reasoning exceeds 32 KiB")
+        raise VerifierError(
+            f"verdict reasoning exceeds {_REASONING_CAP_BYTES // 1024} KiB"
+        )
     return verifier_core.Verdict(
         gold_id="",
         candidate_id="",
@@ -348,7 +360,9 @@ def _parse_json_response(response: Any, *, content: Any) -> dict[str, Any]:
     """
     body = _response_bytes(response)
     if len(body) > _RESPONSE_CAP_BYTES:
-        raise VerifierError("judge response body exceeds 256 KiB")  # terminal, never truncated
+        raise VerifierError(  # terminal, never truncated
+            f"judge response body exceeds {_RESPONSE_CAP_BYTES // 1024} KiB"
+        )
     status_code = getattr(response, "status_code", None)
     if status_code is None or not 200 <= int(status_code) < 300:
         body_text = body.decode("utf-8", errors="replace")
@@ -431,10 +445,13 @@ async def _complete_json_with_http(
                     continue
                 return _parse_json_response(response, content=content)
             except _Retryable:
-                if attempt == _MAX_RETRIES - 1:
-                    raise VerifierError("Judge request failed after retries")
-                await asyncio.sleep(2**attempt)
+                if attempt < _MAX_RETRIES - 1:
+                    # A retry remains: back off 2 ** attempt seconds, then the
+                    # outer loop issues the next attempt.
+                    await asyncio.sleep(2**attempt)
                 break
+    # Reaching here means the final attempt failed: this single raise is the
+    # retry-exhaustion exit -- never a partial result.
     raise VerifierError("Judge request failed after retries")
 
 

--- a/daydream/benchmark/harbor/templates/tests/score_review.py
+++ b/daydream/benchmark/harbor/templates/tests/score_review.py
@@ -7,6 +7,16 @@ Messages + OpenAI-compatible) behind one ``complete_json`` seam, strict verdict
 parsing, a shared retry/redirect/timeout policy, a concurrency-10 runner, and
 ``run_verifier`` which writes ``reward.json`` / ``reward-details.json``
 atomically.
+
+The external judge surface is fail-closed and bounded: exactly
+``anthropic | openai-compatible`` providers are accepted, the judge host must
+sit in the configured allowlist (``DAYDREAM_JUDGE_ALLOWED_HOSTS``; own-host
+fallback when absent), redirects are bounded to ``_MAX_REDIRECTS``
+credential-preserving same-origin hops whose targets are re-validated against
+the allowlist, response/reasoning payloads are size-capped (rejected, never
+truncated-and-accepted), and every failure path writes typed bounded (redacted)
+diagnostics to ``reward.json`` / ``reward-details.json`` -- never a bare exit
+and never an unbounded or credential-bearing error.
 """
 
 from __future__ import annotations
@@ -438,7 +448,12 @@ def _anthropic_text(body: dict[str, Any]) -> str:
 
 
 class AnthropicJudgeClient:
-    """Small Anthropic Messages API client returning strict parsed JSON verdicts."""
+    """Small Anthropic Messages API client returning strict parsed JSON verdicts.
+
+    Validates the initial Messages URL against the effective judge-host
+    allowlist before any request (fail-closed); redirects are bounded and
+    allowlist-checked inside the shared ``_complete_json_with_http`` policy.
+    """
 
     def __init__(
         self,
@@ -504,7 +519,10 @@ def resolve_base_url(api_key: str, base_url_env: str | None) -> str:
     """Resolve the Chat Completions base URL from the environment.
 
     An explicit base URL always wins; an ``sk-or-`` OpenRouter key with no pin
-    routes to OpenRouter; anything else defaults to OpenAI direct.
+    routes to OpenRouter; anything else defaults to OpenAI direct. The resolved
+    URL is only a candidate: it is validated against the effective judge-host
+    allowlist (scheme/host/form) at the client build and initial-request sites
+    before any judge call.
     """
     if base_url_env:
         return base_url_env
@@ -536,7 +554,13 @@ def _openai_content(body: dict[str, Any]) -> str:
 
 
 class OpenAIJudgeClient:
-    """Small OpenAI-compatible Chat Completions client returning strict parsed verdicts."""
+    """Small OpenAI-compatible Chat Completions client returning strict parsed verdicts.
+
+    Validates the initial Chat Completions URL against the effective
+    judge-host allowlist before any request (fail-closed); redirects are
+    bounded and allowlist-checked inside the shared ``_complete_json_with_http``
+    policy -- identical to the Anthropic client.
+    """
     def __init__(
         self,
         api_key: str,
@@ -824,10 +848,12 @@ def run_verifier(
     the gold is then read as raw bytes and its sha256 must match the
     compiler-rendered ``gold_sha256`` sentinel before it is parsed and validated
     (canonical/unique gold ids). Any ``VerifierError`` (validation, binding,
-    digest, parsing, judging, exhausted retries, or a missing client) becomes a
-    ``Reward(reward=0, verifier_error=1)`` — the task fails whole, never
-    reporting a partial score. Both output files are written atomically (temp +
-    rename). Never emits source or diffs.
+    digest, parsing, judging, exhausted retries, or a missing client) -- and
+    any unexpected runtime exception -- becomes a typed bounded diagnostic that
+    still writes ``Reward(reward=0, verifier_error=1)`` plus both output files
+    atomically (temp + rename); the task fails whole, never reporting a
+    partial score and never escaping to a bare exit. Error text is redacted and
+    size-bounded before it reaches any artifact. Never emits source or diffs.
     """
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)

--- a/daydream/benchmark/harbor/templates/tests/score_review.py
+++ b/daydream/benchmark/harbor/templates/tests/score_review.py
@@ -326,17 +326,28 @@ def _parse_json_response(response: Any, *, content: Any) -> dict[str, Any]:
         code = int(status_code) if status_code is not None else -1
         # 429 is retryable (rate limit); all other 4xx are terminal client errors.
         if 400 <= code < 500 and code != 429:
-            raise VerifierError(f"Judge request failed with HTTP {status_code}: {body_text}")
-        raise _Retryable(f"Judge request failed with HTTP {status_code}: {body_text}")
+            raise VerifierError(
+                f"Judge request failed with HTTP {status_code}: {_bounded_error(body_text)}"
+            )
+        raise _Retryable(
+            f"Judge request failed with HTTP {status_code}: {_bounded_error(body_text)}"
+        )
+    body = _response_bytes(response)
+    if len(body) > _RESPONSE_CAP_BYTES:
+        raise VerifierError("judge response body exceeds 256 KiB")  # terminal, never truncated
     try:
         parsed_body = response.json()
     except Exception as exc:
-        raise VerifierError(f"Judge response was not valid JSON: {exc}") from exc
+        raise VerifierError(
+            f"Judge response was not valid JSON: {_bounded_error(str(exc))}"
+        ) from exc
     text = content(parsed_body)
     try:
         parsed = json.loads(text)
     except json.JSONDecodeError as exc:
-        raise VerifierError(f"Judge text content was not valid JSON: {exc}") from exc
+        raise VerifierError(
+            f"Judge text content was not valid JSON: {_bounded_error(str(exc))}"
+        ) from exc
     if not isinstance(parsed, dict):
         raise VerifierError("Judge text content JSON was not an object")
     return parsed
@@ -349,46 +360,55 @@ async def _complete_json_with_http(
     payload: dict[str, Any],
     headers: dict[str, str],
     content: Any,
-    allowlist: set[str] | None = None,
+    allowlist: set[str],
 ) -> dict[str, Any]:
     """Single retry/redirect/timeout policy shared by both judge clients.
 
     - Up to 3 attempts. Transport exceptions (including timeout) and HTTP
       429/5xx retry with exponential backoff (`2 ** attempt`); a terminal 4xx
       (non-429) and a malformed-JSON parse are not retried.
-    - 3xx responses: never follow a redirect to a host outside the request
-      URL's own host (allowlist); same-host redirects are followed once.
+    - 3xx responses: bounded credential-preserving redirects. At most
+      ``_MAX_REDIRECTS`` hops; each next target is resolved against the request
+      URL first (relative ``Location``) and must be inside the judge-host
+      ``allowlist``. Configured auth headers are preserved across the hop and
+      server-provided response headers are never replayed. A redirect-target
+      rejection or an exhausted hop count is a terminal ``VerifierError``,
+      never retried.
     - After 3 failed attempts, raise ``VerifierError`` — never a partial result.
     """
+    current_url = url
     for attempt in range(_MAX_RETRIES):
-        try:
+        hop = 0
+        while True:
             try:
-                response = await http.post(
-                    url, headers=headers, json=payload, timeout=_REQUEST_TIMEOUT
-                )
-            except Exception as exc:
-                raise _Retryable(f"Judge request failed: {exc}") from exc
-            status_code = getattr(response, "status_code", None)
-            if status_code is not None and 300 <= int(status_code) < 400:
-                headers = getattr(response, "headers", {}) or {}
-                location = headers.get("location")
-                if not location:
-                    raise VerifierError("Judge request redirected without a Location")
-                request_host = urllib.parse.urlparse(url).hostname
-                redirect_host = urllib.parse.urlparse(location).hostname
-                if redirect_host != request_host:
-                    raise VerifierError(
-                        "Judge request would redirect to a host outside the verifier allowlist"
+                try:
+                    response = await http.post(
+                        current_url, headers=headers, json=payload, timeout=_REQUEST_TIMEOUT
                     )
-                # Same-host redirect: follow once by re-issuing to the Location.
-                response = await http.post(
-                    location, headers=headers, json=payload, timeout=_REQUEST_TIMEOUT
-                )
-            return _parse_json_response(response, content=content)
-        except _Retryable:
-            if attempt == _MAX_RETRIES - 1:
-                raise VerifierError("Judge request failed after retries")
-            await asyncio.sleep(2**attempt)
+                except Exception as exc:
+                    raise _Retryable(f"Judge request failed: {exc}") from exc
+                status_code = getattr(response, "status_code", None)
+                if status_code is not None and 300 <= int(status_code) < 400:
+                    if hop >= _MAX_REDIRECTS:
+                        raise VerifierError("judge request exceeded maximum redirects")
+                    response_headers = getattr(response, "headers", {}) or {}
+                    location = response_headers.get("location")
+                    if not location:
+                        raise VerifierError("judge request redirected without a Location")
+                    # Resolve relative Location against the request URL and
+                    # fail closed on cross-host/out-of-allowlist targets. The
+                    # configured ``headers`` are intentionally NOT replaced by
+                    # the response headers, so auth survives the hop and server
+                    # headers are never replayed.
+                    current_url = _resolve_redirect(current_url, location, allowlist)
+                    hop += 1
+                    continue
+                return _parse_json_response(response, content=content)
+            except _Retryable:
+                if attempt == _MAX_RETRIES - 1:
+                    raise VerifierError("Judge request failed after retries")
+                await asyncio.sleep(2**attempt)
+                break
     raise VerifierError("Judge request failed after retries")
 
 

--- a/daydream/benchmark/harbor/templates/tests/score_review.py
+++ b/daydream/benchmark/harbor/templates/tests/score_review.py
@@ -779,6 +779,33 @@ def _error_details(provider: str, model: str, request_counts: dict[str, int], er
     }
 
 
+def _write_error_artifact(
+    out_dir: str | Path,
+    provider: str,
+    model: str,
+    request_counts: dict[str, int],
+    errors: list[str],
+    gold_count: int,
+) -> verifier_core.Reward:
+    """Write the fail-whole error artifacts and return the error reward.
+
+    Every failure path -- validation, binding, digest, judging, exhausted
+    retries, a missing client, or an unexpected runtime exception -- funnels
+    through here so ``reward.json``/``reward-details.json`` are always written
+    with typed bounded diagnostics, never a bare exit. ``errors`` must already
+    be bounded/redacted before the call.
+    """
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    error_reward = verifier_core.Reward(
+        reward=0.0, gold_count=gold_count, verifier_error=1
+    )
+    details = _error_details(provider, model, request_counts, errors)
+    _atomic_write(out_dir, "reward.json", verifier_core.reward_to_json(error_reward))
+    _atomic_write(out_dir, "reward-details.json", json.dumps(details))
+    return error_reward
+
+
 def run_verifier(
     gold_path: str | Path,
     artifact_path: str | Path,
@@ -841,7 +868,7 @@ def run_verifier(
             matches = verifier_core.maximum_matching(retained, gold_ids, cand_ids)
             request_counts["requests"] = counting.requests
             if counting.errors:
-                errors.extend(counting.errors)
+                errors.extend(_bounded_error(str(e)) for e in counting.errors)
 
         reward = verifier_core.score_review(gold_parsed, artifact_raw, verdicts)
         inner = verifier_core.reward_details(gold_parsed, candidates, verdicts, matches)
@@ -850,14 +877,17 @@ def run_verifier(
         _atomic_write(out_dir, "reward-details.json", json.dumps(details))
         return reward
     except VerifierError as exc:
-        errors.insert(0, str(exc))
-        error_reward = verifier_core.Reward(
-            reward=0.0, gold_count=len(gold_parsed), verifier_error=1
+        errors.insert(0, _bounded_error(str(exc)))
+        return _write_error_artifact(
+            out_dir, provider, model, request_counts, errors, len(gold_parsed)
         )
-        details = _error_details(provider, model, request_counts, errors)
-        _atomic_write(out_dir, "reward.json", verifier_core.reward_to_json(error_reward))
-        _atomic_write(out_dir, "reward-details.json", json.dumps(details))
-        return error_reward
+    except Exception as exc:
+        # Unexpected runtime failures must not escape to a bare exit: they
+        # become a typed bounded diagnostic that still writes both artifacts.
+        errors.insert(0, _bounded_error(f"unexpected verifier failure: {exc}"))
+        return _write_error_artifact(
+            out_dir, provider, model, request_counts, errors, len(gold_parsed)
+        )
 
 
 def _build_client(env: dict[str, Any]) -> Any:

--- a/daydream/benchmark/harbor/templates/tests/score_review.py
+++ b/daydream/benchmark/harbor/templates/tests/score_review.py
@@ -294,17 +294,27 @@ def parse_verdict(raw: object) -> verifier_core.Verdict:
     verifier_core.validate_exact_keys(raw, {"match", "confidence", "reasoning"}, "verdict")
     match = raw["match"]
     if not isinstance(match, bool):
-        raise VerifierError(f"verdict 'match' must be a boolean, got {match!r}")
+        raise VerifierError(
+            f"verdict 'match' must be a boolean, got {_bounded_error(repr(match))}"
+        )
     confidence = raw["confidence"]
     if isinstance(confidence, bool) or not isinstance(confidence, (int, float)):
         raise VerifierError(
-            f"verdict 'confidence' must be a number in [0,1], got {confidence!r}"
+            f"verdict 'confidence' must be a number in [0,1], got {_bounded_error(repr(confidence))}"
         )
     if not 0.0 <= confidence <= 1.0:
-        raise VerifierError(f"verdict 'confidence' must be in [0,1], got {confidence!r}")
+        raise VerifierError(
+            f"verdict 'confidence' must be in [0,1], got {_bounded_error(repr(confidence))}"
+        )
     reasoning = raw["reasoning"]
     if not isinstance(reasoning, str):
-        raise VerifierError(f"verdict 'reasoning' must be a string, got {reasoning!r}")
+        raise VerifierError(
+            f"verdict 'reasoning' must be a string, got {_bounded_error(repr(reasoning))}"
+        )
+    # Reasoning is capped at 32 KiB and rejected -- never truncated-and-accepted
+    # -- so an oversized/untrusted value can never bloat a diagnostic.
+    if len(reasoning.encode("utf-8")) > _REASONING_CAP_BYTES:
+        raise VerifierError("verdict reasoning exceeds 32 KiB")
     return verifier_core.Verdict(
         gold_id="",
         candidate_id="",

--- a/daydream/benchmark/harbor/templates/tests/score_review.py
+++ b/daydream/benchmark/harbor/templates/tests/score_review.py
@@ -349,6 +349,7 @@ async def _complete_json_with_http(
     payload: dict[str, Any],
     headers: dict[str, str],
     content: Any,
+    allowlist: set[str] | None = None,
 ) -> dict[str, Any]:
     """Single retry/redirect/timeout policy shared by both judge clients.
 
@@ -410,15 +411,27 @@ class AnthropicJudgeClient:
     """Small Anthropic Messages API client returning strict parsed JSON verdicts."""
 
     def __init__(
-        self, api_key: str, model: str, *, http: _AsyncHttpClient | None = None
+        self,
+        api_key: str,
+        model: str,
+        *,
+        http: _AsyncHttpClient | None = None,
+        allowlist: set[str] | None = None,
     ) -> None:
         self.api_key = api_key
         self.model = model
         self.http = http
+        self.allowlist = allowlist
 
     async def complete_json(
         self, *, user: str, system: str = "", max_tokens: int = 512
     ) -> dict[str, Any]:
+        effective = self.allowlist or _effective_allowlist(
+            "anthropic", _ANTHROPIC_MESSAGES_URL, {}
+        )
+        # Fail closed before any request: a forced disallowed allowlist must
+        # reject the initial URL here, never after a POST has been issued.
+        _validate_base_url(_ANTHROPIC_MESSAGES_URL, effective)
         payload = {
             "model": self.model,
             "max_tokens": max_tokens,
@@ -438,6 +451,7 @@ class AnthropicJudgeClient:
                 payload=payload,
                 headers=headers,
                 content=_anthropic_text,
+                allowlist=effective,
             )
         async with httpx.AsyncClient() as http:
             return await _complete_json_with_http(
@@ -446,6 +460,7 @@ class AnthropicJudgeClient:
                 payload=payload,
                 headers=headers,
                 content=_anthropic_text,
+                allowlist=effective,
             )
 
 
@@ -499,15 +514,24 @@ class OpenAIJudgeClient:
         *,
         base_url: str,
         http: _AsyncHttpClient | None = None,
+        allowlist: set[str] | None = None,
     ) -> None:
         self.api_key = api_key
         self.model = model
         self.base_url = base_url
         self.http = http
+        self.allowlist = allowlist
 
     async def complete_json(
         self, *, user: str, system: str = "", max_tokens: int = 512
     ) -> dict[str, Any]:
+        url = self.base_url.rstrip("/") + _CHAT_COMPLETIONS_PATH
+        effective = self.allowlist or _effective_allowlist(
+            "openai-compatible", self.base_url, {}
+        )
+        # Fail closed before any request: a base URL host outside the allowlist
+        # is rejected here, never after a POST has been issued.
+        _validate_base_url(url, effective)
         payload = {
             "model": self.model,
             "max_tokens": max_tokens,
@@ -521,7 +545,6 @@ class OpenAIJudgeClient:
             "Authorization": f"Bearer {self.api_key}",
             "content-type": "application/json",
         }
-        url = self.base_url.rstrip("/") + _CHAT_COMPLETIONS_PATH
         if self.http is not None:
             return await _complete_json_with_http(
                 self.http,
@@ -529,6 +552,7 @@ class OpenAIJudgeClient:
                 payload=payload,
                 headers=headers,
                 content=_openai_content,
+                allowlist=effective,
             )
         async with httpx.AsyncClient() as http:
             return await _complete_json_with_http(
@@ -537,6 +561,7 @@ class OpenAIJudgeClient:
                 payload=payload,
                 headers=headers,
                 content=_openai_content,
+                allowlist=effective,
             )
 
 
@@ -590,6 +615,7 @@ _ENV_PROVIDER = "DAYDREAM_JUDGE_PROVIDER"
 _ENV_MODEL = "DAYDREAM_JUDGE_MODEL"
 _ENV_API_KEY = "DAYDREAM_JUDGE_API_KEY"
 _ENV_BASE_URL = "DAYDREAM_JUDGE_BASE_URL"
+_ENV_ALLOWED_HOSTS = "DAYDREAM_JUDGE_ALLOWED_HOSTS"
 _DEFAULT_PROVIDER = "anthropic"
 
 
@@ -805,17 +831,33 @@ def run_verifier(
 
 
 def _build_client(env: dict[str, Any]) -> Any:
-    """Build the judge client from the DAYDREAM_JUDGE_* env surface."""
+    """Build the judge client from the DAYDREAM_JUDGE_* env surface.
+
+    Provider is fail-closed: exactly ``anthropic`` | ``openai-compatible`` is
+    accepted (absent -> default ``anthropic``); anything else raises before any
+    request. The provider's base URL is resolved and the initial request URL is
+    validated against the effective judge-host allowlist at build time.
+    """
     provider = env.get(_ENV_PROVIDER) or _DEFAULT_PROVIDER
     model = env.get(_ENV_MODEL)
     api_key = env.get(_ENV_API_KEY)
     if not model or not api_key:
         raise VerifierError("missing DAYDREAM_JUDGE_MODEL or DAYDREAM_JUDGE_API_KEY")
+    if provider not in {"anthropic", "openai-compatible"}:
+        raise VerifierError(
+            f"unsupported DAYDREAM_JUDGE_PROVIDER '{provider}'; expected anthropic or openai-compatible"
+        )
     if provider == "anthropic":
-        return AnthropicJudgeClient(api_key, model)
-    return OpenAIJudgeClient(
-        api_key, model, base_url=resolve_base_url(api_key, env.get(_ENV_BASE_URL))
-    )
+        return AnthropicJudgeClient(
+            api_key,
+            model,
+            allowlist=_effective_allowlist("anthropic", _ANTHROPIC_MESSAGES_URL, env),
+        )
+    base_url = resolve_base_url(api_key, env.get(_ENV_BASE_URL))
+    allowlist = _effective_allowlist("openai-compatible", base_url, env)
+    initial_url = base_url.rstrip("/") + _CHAT_COMPLETIONS_PATH
+    _validate_base_url(initial_url, allowlist)  # fail-closed before any request
+    return OpenAIJudgeClient(api_key, model, base_url=base_url, allowlist=allowlist)
 
 
 def main() -> int:

--- a/daydream/benchmark/harbor/templates/tests/score_review.py
+++ b/daydream/benchmark/harbor/templates/tests/score_review.py
@@ -15,6 +15,7 @@ import asyncio
 import hashlib
 import json
 import os
+import re
 import sys
 import urllib.parse
 from pathlib import Path
@@ -42,6 +43,15 @@ JUDGE_PROMPT_TEMPLATE = (
 _PROMPT_CAP_BYTES = 24 * 1024
 _MAX_RETRIES = 3
 _REQUEST_TIMEOUT = 60.0
+
+# Hardening caps: response/reasoning payloads are rejected -- never truncated
+# and accepted -- above these sizes; redirects are bounded; diagnostics are
+# bounded and redacted before they reach any artifact or log.
+_RESPONSE_CAP_BYTES = 256 * 1024
+_REASONING_CAP_BYTES = 32 * 1024
+_MAX_REDIRECTS = 3
+_ERROR_TEXT_CAP_BYTES = 4096
+_LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1"}
 
 _ESCAPED_FINDING_TAGS = {
     "<gold_finding>": "&lt;gold_finding&gt;",
@@ -75,6 +85,111 @@ def _escape_finding_delimiters(text: str) -> str:
 _ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages"
 _ANTHROPIC_VERSION = "2023-06-01"
 
+
+_REDACTION_PATTERNS = (
+    re.compile(r"sk-ant-[A-Za-z0-9]+"),
+    re.compile(r"sk-or-[A-Za-z0-9]+"),
+    re.compile(r"Bearer [A-Za-z0-9._~+/=-]+"),
+    re.compile(r"x-api-key:?\s*\S+"),
+    re.compile(r"[0-9a-fA-F]{32,}"),
+    re.compile(r"[A-Za-z0-9+/]{40,}={0,2}"),
+)
+
+
+def _normalize_host(host: str | None) -> str:
+    """Lowercase ``host`` and strip a trailing dot; never raises."""
+    if host is None:
+        return ""
+    return host.strip().lower().rstrip(".")
+
+
+def _effective_allowlist(provider: str, base_url: str, env: dict[str, Any]) -> set[str]:
+    """Resolve the judge-host allowlist from env; absent -> own-host fail-closed.
+
+    A non-empty ``DAYDREAM_JUDGE_ALLOWED_HOSTS`` (whitespace/comma-separated)
+    wins; otherwise the effective allowlist is exactly the resolved judge
+    host of ``base_url`` so an unconfigured verifier can only ever reach its
+    own judge endpoint -- never an arbitrary host.
+    """
+    raw = (env or {}).get("DAYDREAM_JUDGE_ALLOWED_HOSTS")
+    if raw:
+        hosts = {
+            _normalize_host(host)
+            for host in re.split(r"[\s,]+", str(raw))
+            if host.strip()
+        }
+        if hosts:
+            return hosts
+    return {_normalize_host(urllib.parse.urlsplit(base_url).hostname)}
+
+
+def _validate_base_url(url: str, allowlist: set[str]) -> str:
+    """Validate ``url`` against the hardened judge-request contract.
+
+    Rejects userinfo, any query string or fragment, non-HTTPS remote schemes
+    (``http`` is permitted only to a loopback host), and any host outside
+    ``allowlist``. Returns ``url`` unchanged; every rejection is a bounded
+    ``VerifierError`` naming only the rejected form -- never URL content.
+    """
+    parsed = urllib.parse.urlsplit(url)
+    if parsed.username is not None or parsed.password is not None:
+        raise VerifierError("judge URL must not contain userinfo")
+    if parsed.query:
+        raise VerifierError("judge URL must not contain a query string")
+    if parsed.fragment:
+        raise VerifierError("judge URL must not contain a fragment")
+    host = _normalize_host(parsed.hostname)
+    if parsed.scheme != "https" and not (
+        parsed.scheme == "http" and host in _LOOPBACK_HOSTS
+    ):
+        raise VerifierError("judge URL must use https (loopback http allowed)")
+    if not host or host not in allowlist:
+        raise VerifierError("judge host is not in the verifier allowlist")
+    return url
+
+
+def _resolve_redirect(request_url: str, location: str, allowlist: set[str]) -> str:
+    """Resolve a redirect ``location`` against ``request_url`` and host-check it.
+
+    A relative ``Location`` is resolved against the request URL first, then the
+    resolved target is validated against ``allowlist`` exactly like an initial
+    base URL -- a cross-host, out-of-allowlist, or malformed target is a
+    terminal bounded ``VerifierError``.
+    """
+    resolved = urllib.parse.urljoin(request_url, location)
+    return _validate_base_url(resolved, allowlist)
+
+
+def _response_bytes(response: Any) -> bytes:
+    """Return the response payload as bytes, preferring ``.content``."""
+    content = getattr(response, "content", None)
+    if content is not None:
+        return bytes(content)
+    text = getattr(response, "text", "")
+    return str(text).encode("utf-8")
+
+
+def _redact_text(text: str) -> str:
+    """Replace credential-like content with ``<redacted>``."""
+    for pattern in _REDACTION_PATTERNS:
+        text = pattern.sub("<redacted>", text)
+    return text
+
+
+def _bounded_error(text: object) -> str:
+    """Redact ``text`` and bound it to ``_ERROR_TEXT_CAP_BYTES`` UTF-8 bytes.
+
+    Redaction runs before the truncation so a credential in the first bytes can
+    never survive a cut; truncation lands on a UTF-8 byte boundary. Empty input
+    returns ``""``; any non-empty input stays non-empty.
+    """
+    if not text:
+        return ""
+    redacted = _redact_text(str(text))
+    encoded = redacted.encode("utf-8")
+    if len(encoded) <= _ERROR_TEXT_CAP_BYTES:
+        return redacted
+    return encoded[:_ERROR_TEXT_CAP_BYTES].decode("utf-8", errors="ignore")
 
 
 

--- a/daydream/benchmark/harbor/templates/tests/score_review.py
+++ b/daydream/benchmark/harbor/templates/tests/score_review.py
@@ -113,7 +113,7 @@ def _normalize_host(host: str | None) -> str:
     return host.strip().lower().rstrip(".")
 
 
-def _effective_allowlist(provider: str, base_url: str, env: dict[str, Any]) -> set[str]:
+def _effective_allowlist(base_url: str, env: dict[str, Any]) -> set[str]:
     """Resolve the judge-host allowlist from env; absent -> own-host fail-closed.
 
     A non-empty ``DAYDREAM_JUDGE_ALLOWED_HOSTS`` (whitespace/comma-separated)
@@ -339,10 +339,19 @@ class _Retryable(Exception):
 
 
 def _parse_json_response(response: Any, *, content: Any) -> dict[str, Any]:
-    """Parse an httpx-like response through the ``content`` extraction callable."""
+    """Parse an httpx-like response through the ``content`` extraction callable.
+
+    The raw body is size-capped (``_RESPONSE_CAP_BYTES``) BEFORE any status
+    handling, so an oversized body is rejected regardless of status code -- a
+    non-2xx (4xx/5xx) judge body must not bypass the cap. An over-cap body is a
+    terminal ``VerifierError`` (rejected, never truncated-and-accepted).
+    """
+    body = _response_bytes(response)
+    if len(body) > _RESPONSE_CAP_BYTES:
+        raise VerifierError("judge response body exceeds 256 KiB")  # terminal, never truncated
     status_code = getattr(response, "status_code", None)
     if status_code is None or not 200 <= int(status_code) < 300:
-        body_text = getattr(response, "text", "")
+        body_text = body.decode("utf-8", errors="replace")
         code = int(status_code) if status_code is not None else -1
         # 429 is retryable (rate limit); all other 4xx are terminal client errors.
         if 400 <= code < 500 and code != 429:
@@ -352,9 +361,6 @@ def _parse_json_response(response: Any, *, content: Any) -> dict[str, Any]:
         raise _Retryable(
             f"Judge request failed with HTTP {status_code}: {_bounded_error(body_text)}"
         )
-    body = _response_bytes(response)
-    if len(body) > _RESPONSE_CAP_BYTES:
-        raise VerifierError("judge response body exceeds 256 KiB")  # terminal, never truncated
     try:
         parsed_body = response.json()
     except Exception as exc:
@@ -388,8 +394,8 @@ async def _complete_json_with_http(
       429/5xx retry with exponential backoff (`2 ** attempt`); a terminal 4xx
       (non-429) and a malformed-JSON parse are not retried.
     - 3xx responses: bounded credential-preserving redirects. At most
-      ``_MAX_REDIRECTS`` hops; each next target is resolved against the request
-      URL first (relative ``Location``) and must be inside the judge-host
+      ``_MAX_REDIRECTS`` hops per call; each next target is resolved against the
+      request URL first (relative ``Location``) and must be inside the judge-host
       ``allowlist``. Configured auth headers are preserved across the hop and
       server-provided response headers are never replayed. A redirect-target
       rejection or an exhausted hop count is a terminal ``VerifierError``,
@@ -397,8 +403,8 @@ async def _complete_json_with_http(
     - After 3 failed attempts, raise ``VerifierError`` — never a partial result.
     """
     current_url = url
+    hop = 0
     for attempt in range(_MAX_RETRIES):
-        hop = 0
         while True:
             try:
                 try:
@@ -472,7 +478,7 @@ class AnthropicJudgeClient:
         self, *, user: str, system: str = "", max_tokens: int = 512
     ) -> dict[str, Any]:
         effective = self.allowlist or _effective_allowlist(
-            "anthropic", _ANTHROPIC_MESSAGES_URL, {}
+            _ANTHROPIC_MESSAGES_URL, {}
         )
         # Fail closed before any request: a forced disallowed allowlist must
         # reject the initial URL here, never after a POST has been issued.
@@ -581,7 +587,7 @@ class OpenAIJudgeClient:
     ) -> dict[str, Any]:
         url = self.base_url.rstrip("/") + _CHAT_COMPLETIONS_PATH
         effective = self.allowlist or _effective_allowlist(
-            "openai-compatible", self.base_url, {}
+            self.base_url, {}
         )
         # Fail closed before any request: a base URL host outside the allowlist
         # is rejected here, never after a POST has been issued.
@@ -936,13 +942,19 @@ def _build_client(env: dict[str, Any]) -> Any:
             f"unsupported DAYDREAM_JUDGE_PROVIDER '{provider}'; expected anthropic or openai-compatible"
         )
     if provider == "anthropic":
+        allowlist = _effective_allowlist(_ANTHROPIC_MESSAGES_URL, env)
+        # Fail-closed at build time, matching the openai-compatible branch: the
+        # initial Messages URL is validated against the effective allowlist
+        # before any request can be issued, so both providers share identical
+        # validation timing.
+        _validate_base_url(_ANTHROPIC_MESSAGES_URL, allowlist)
         return AnthropicJudgeClient(
             api_key,
             model,
-            allowlist=_effective_allowlist("anthropic", _ANTHROPIC_MESSAGES_URL, env),
+            allowlist=allowlist,
         )
     base_url = resolve_base_url(api_key, env.get(_ENV_BASE_URL))
-    allowlist = _effective_allowlist("openai-compatible", base_url, env)
+    allowlist = _effective_allowlist(base_url, env)
     initial_url = base_url.rstrip("/") + _CHAT_COMPLETIONS_PATH
     _validate_base_url(initial_url, allowlist)  # fail-closed before any request
     return OpenAIJudgeClient(api_key, model, base_url=base_url, allowlist=allowlist)
@@ -956,6 +968,27 @@ def _env_path(name: str, default: str) -> Path:
     """
     value = os.environ.get(name)
     return Path(value) if value else Path(default)
+
+
+def _emit_reward(reward: verifier_core.Reward) -> int:
+    """Print the reward payload JSON and return the verifier-error exit code.
+
+    Shared by both ``main()`` terminal paths (a fail-closed client build
+    rejection and the completed ``run_verifier``) so the two failure/success
+    emissions cannot drift. ``Reward.to_dict()`` always exists (the compiled
+    verifier_core twin is byte-identical); the fallback dict is a defensive
+    guard that keeps the shape stable even if a duck-typed reward lacks it.
+    """
+    payload = (
+        reward.to_dict()
+        if hasattr(reward, "to_dict")
+        else {
+            "verifier_error": int(getattr(reward, "verifier_error", 0)),
+            "reward": float(getattr(reward, "reward", 0.0)),
+        }
+    )
+    print(json.dumps(payload))
+    return 1 if getattr(reward, "verifier_error", 0) else 0
 
 
 def main() -> int:
@@ -993,30 +1026,12 @@ def main() -> int:
             reward = _write_error_artifact(
                 out_dir, provider, model, {"requests": 0}, [_bounded_error(str(exc))], 0
             )
-            payload = (
-                reward.to_dict()
-                if hasattr(reward, "to_dict")
-                else {
-                    "verifier_error": int(getattr(reward, "verifier_error", 0)),
-                    "reward": float(getattr(reward, "reward", 0.0)),
-                }
-            )
-            print(json.dumps(payload))
-            return 1 if getattr(reward, "verifier_error", 0) else 0
+            return _emit_reward(reward)
         # Missing MODEL/API_KEY keeps the compiled path: run_verifier emits its
         # own "no judge client configured" typed diagnostic.
         client = None
     reward = run_verifier(gold_path, artifact_path, out_dir, client=client, env=env)
-    payload = (
-        reward.to_dict()
-        if hasattr(reward, "to_dict")
-        else {
-            "verifier_error": int(getattr(reward, "verifier_error", 0)),
-            "reward": float(getattr(reward, "reward", 0.0)),
-        }
-    )
-    print(json.dumps(payload))
-    return 1 if getattr(reward, "verifier_error", 0) else 0
+    return _emit_reward(reward)
 
 
 if __name__ == "__main__":

--- a/daydream/benchmark/harbor/templates/tests/score_review.py
+++ b/daydream/benchmark/harbor/templates/tests/score_review.py
@@ -646,6 +646,8 @@ _ENV_MODEL = "DAYDREAM_JUDGE_MODEL"
 _ENV_API_KEY = "DAYDREAM_JUDGE_API_KEY"
 _ENV_BASE_URL = "DAYDREAM_JUDGE_BASE_URL"
 _ENV_ALLOWED_HOSTS = "DAYDREAM_JUDGE_ALLOWED_HOSTS"
+_ENV_ARTIFACT_PATH = "DAYDREAM_JUDGE_ARTIFACT_PATH"
+_ENV_OUT_PATH = "DAYDREAM_JUDGE_OUT_PATH"
 _DEFAULT_PROVIDER = "anthropic"
 
 
@@ -920,23 +922,65 @@ def _build_client(env: dict[str, Any]) -> Any:
     return OpenAIJudgeClient(api_key, model, base_url=base_url, allowlist=allowlist)
 
 
+def _env_path(name: str, default: str) -> Path:
+    """Return ``Path(os.environ[name])`` when set, else ``Path(default)``.
+
+    The compiled-image defaults are unchanged; the overrides only relocate the
+    artifact/out paths for isolated subprocess runs (e.g. the isolation test).
+    """
+    value = os.environ.get(name)
+    return Path(value) if value else Path(default)
+
+
 def main() -> int:
-    """Compiled entry: resolve the §10 paths, read real env, judge, print reward JSON."""
+    """Compiled entry: resolve the §10 paths, read real env, judge, print reward JSON.
+
+    Provider selection is fail-closed: an unsupported ``DAYDREAM_JUDGE_PROVIDER``
+    or an out-of-allowlist judge host writes a typed bounded diagnostic artifact
+    (``reward.json``/``reward-details.json``) instead of a barren ``client=None``
+    exit with no provider reason. ``DAYDREAM_JUDGE_ARTIFACT_PATH`` /
+    ``DAYDREAM_JUDGE_OUT_PATH`` relocate the compiled defaults for isolated
+    subprocess runs; the compiled defaults ``/logs/artifacts/review.json`` and
+    ``/logs/verifier`` are unchanged.
+    """
     gold_path = Path(__file__).with_name("golden-review.json")
-    artifact_path = Path("/logs/artifacts/review.json")
-    out_dir = Path("/logs/verifier")
+    artifact_path = _env_path(_ENV_ARTIFACT_PATH, "/logs/artifacts/review.json")
+    out_dir = _env_path(_ENV_OUT_PATH, "/logs/verifier")
     env = {
         name: os.environ.get(name)
-        for name in (_ENV_PROVIDER, _ENV_MODEL, _ENV_API_KEY, _ENV_BASE_URL)
+        for name in (
+            _ENV_PROVIDER,
+            _ENV_MODEL,
+            _ENV_API_KEY,
+            _ENV_BASE_URL,
+            _ENV_ALLOWED_HOSTS,
+        )
     }
     try:
         client = _build_client(env)
-    except VerifierError:
+    except VerifierError as exc:
+        if env.get(_ENV_MODEL) and env.get(_ENV_API_KEY):
+            # Fail-closed provider/host rejection: a typed bounded diagnostic
+            # artifact naming only the rejected form -- never a barren exit.
+            provider = env.get(_ENV_PROVIDER) or _DEFAULT_PROVIDER
+            model = env.get(_ENV_MODEL) or ""
+            reward = _write_error_artifact(
+                out_dir, provider, model, {"requests": 0}, [_bounded_error(str(exc))], 0
+            )
+            payload = (
+                reward.to_dict()
+                if hasattr(reward, "to_dict")
+                else {
+                    "verifier_error": int(getattr(reward, "verifier_error", 0)),
+                    "reward": float(getattr(reward, "reward", 0.0)),
+                }
+            )
+            print(json.dumps(payload))
+            return 1 if getattr(reward, "verifier_error", 0) else 0
+        # Missing MODEL/API_KEY keeps the compiled path: run_verifier emits its
+        # own "no judge client configured" typed diagnostic.
         client = None
-    try:
-        reward = run_verifier(gold_path, artifact_path, out_dir, client=client, env=env)
-    except Exception:
-        reward = verifier_core.Reward(reward=0.0, gold_count=0, verifier_error=1)
+    reward = run_verifier(gold_path, artifact_path, out_dir, client=client, env=env)
     payload = (
         reward.to_dict()
         if hasattr(reward, "to_dict")

--- a/tests/test_benchmark_verifier_isolation.py
+++ b/tests/test_benchmark_verifier_isolation.py
@@ -1,0 +1,116 @@
+"""Real separate-process/environment isolation test for the judge verifier.
+
+Runs the actual templates/tests/score_review.py entrypoint in a subprocess with
+a whitelisted env + a local loopback judge server, and proves the verifier
+cannot see host credentials, source, reviewer config, or agent outputs beyond
+the candidate artifact.
+"""
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+
+_TEMPLATES_TESTS = (
+    Path(__file__).resolve().parents[1]
+    / "daydream" / "benchmark" / "harbor" / "templates" / "tests"
+)
+
+_SENTINELS = {
+    "GH_TOKEN": "GH_TOKEN_SENTINEL_9f3a",
+    "GITHUB_TOKEN": "GITHUB_TOKEN_SENTINEL_7b2c",
+    "HF_TOKEN": "HF_TOKEN_SENTINEL_1a4d",
+    "DAYDREAM_APP_PRIVATE_KEY": "APP_PRIVATE_KEY_SENTINEL_0c8e",
+}
+
+_JUDGE_KEY = "sk-or-isolation-only-7f1e"
+
+
+class _Judge(BaseHTTPRequestHandler):
+    def do_POST(self):
+        self.rfile.read(int(self.headers.get("Content-Length", 0)))
+        body = json.dumps({"choices": [{"message": {"content":
+            '{"match": true, "confidence": 1.0, "reasoning": "identical"}'}}]}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(body)
+    def log_message(self, *a): pass
+
+
+def _serve() -> HTTPServer:
+    srv = HTTPServer(("127.0.0.1", 0), _Judge)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return srv
+
+
+def test_entrypoint_in_isolation_cannot_see_secrets_or_source(tmp_path, monkeypatch) -> None:
+    # host workspace carries credentials + source + reviewer config + agent outputs
+    for name, val in _SENTINELS.items():
+        monkeypatch.setenv(name, val)
+    secret_file = tmp_path / "secrets" / "reviewer.toml"
+    secret_file.parent.mkdir(parents=True)
+    secret_file.write_text("token = 'REVIEWER_SECRET_SENTINEL_5d91'\n")
+    source_file = tmp_path / "source" / "main.py"
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text("# PRIVATE_SOURCE_SENTINEL_2e4f\n")
+    agent_file = tmp_path / "agent_outputs" / "trajectory.json"
+    agent_file.parent.mkdir(parents=True)
+    agent_file.write_text('{"output": "AGENT_OUTPUT_SENTINEL_6b3a"}\n')
+    pre = {p: p.read_bytes() for p in (secret_file, source_file, agent_file)}
+
+    # isolate the verifier in its own env dir
+    verifier_dir = tmp_path / "verifier"
+    verifier_dir.mkdir()
+    for rel in ("score_review.py", "verifier_core.py", "judge_prompt.md", "golden-review.json"):
+        (verifier_dir / rel).write_bytes((_TEMPLATES_TESTS / rel).read_bytes())
+    # task-binding metadata: run_verifier binds the candidate to the immutable
+    # verifier-metadata.json beside the gold (case id + base/head refs + digest)
+    gold_bytes = (verifier_dir / "golden-review.json").read_bytes()
+    (verifier_dir / "verifier-metadata.json").write_text(json.dumps({
+        "schema_version": 1,
+        "case_id": "case-x",
+        "source_case_id": "case-x",
+        "base_ref": "base",
+        "head_ref": "head",
+        "template_version": "1",
+        "gold_sha256": hashlib.sha256(gold_bytes).hexdigest(),
+    }))
+    artifact_path = tmp_path / "artifacts" / "review.json"
+    artifact_path.parent.mkdir()
+    artifact_path.write_bytes((Path(_TEMPLATES_TESTS / ".." / "solution" / "golden-review.json").resolve()).read_bytes())
+    out_dir = tmp_path / "verifier-out"
+
+    srv = _serve()
+    try:
+        env = {
+            "PATH": os.environ.get("PATH", ""),
+            "PYTHONPATH": str(verifier_dir),            # bare `import verifier_core` resolves here
+            "DAYDREAM_JUDGE_PROVIDER": "openai-compatible",
+            "DAYDREAM_JUDGE_MODEL": "m",
+            "DAYDREAM_JUDGE_API_KEY": _JUDGE_KEY,
+            "DAYDREAM_JUDGE_BASE_URL": f"http://127.0.0.1:{srv.server_port}",
+            "DAYDREAM_JUDGE_ALLOWED_HOSTS": "127.0.0.1",
+            "DAYDREAM_JUDGE_ARTIFACT_PATH": str(artifact_path),
+            "DAYDREAM_JUDGE_OUT_PATH": str(out_dir),
+        }  # whitelist: NONE of the host sentinels are inherited
+        proc = subprocess.run([sys.executable, "score_review.py"], cwd=verifier_dir,
+                              env=env, capture_output=True, text=True, timeout=120)
+        assert proc.returncode == 0, proc.stderr
+    finally:
+        srv.shutdown()
+
+    rj = json.loads((out_dir / "reward.json").read_text())
+    assert rj["verifier_error"] == 0 and rj["reward"] == 1  # judged orbitally, not an error exit
+    artifacts_blob = ((out_dir / "reward.json").read_text() + (out_dir / "reward-details.json").read_text()
+                      + proc.stdout + proc.stderr)
+    for sentinel in list(_SENTINELS.values()) + ["REVIEWER_SECRET_SENTINEL_5d91", "PRIVATE_SOURCE_SENTINEL_2e4f",
+                                                 "AGENT_OUTPUT_SENTINEL_6b3a", _JUDGE_KEY]:
+        assert sentinel not in artifacts_blob        # no credential/source/agent/agent-key leakage
+    for p, digest in zip((secret_file, source_file, agent_file), pre.values()):
+        assert p.read_bytes() == digest             # host files untouched (no writes outside out_dir)

--- a/tests/test_benchmark_verifier_isolation.py
+++ b/tests/test_benchmark_verifier_isolation.py
@@ -117,7 +117,9 @@ def test_entrypoint_in_isolation_cannot_see_secrets_or_source(tmp_path, monkeypa
     assert rj["verifier_error"] == 0 and rj["reward"] == 1  # judged orbitally, not an error exit
     artifacts_blob = ((out_dir / "reward.json").read_text() + (out_dir / "reward-details.json").read_text()
                       + proc.stdout + proc.stderr)
-    judge_blob = b"".join(srv.posted_bodies).decode("utf-8", errors="replace")  # judge-bound channel: what the verifier POSTed
+    judge_blob = b"".join(srv.posted_bodies).decode(  # judge-bound channel
+        "utf-8", errors="replace"
+    )  # what the verifier POSTed
     for sentinel in list(_SENTINELS.values()) + ["REVIEWER_SECRET_SENTINEL_5d91", "PRIVATE_SOURCE_SENTINEL_2e4f",
                                                  "AGENT_OUTPUT_SENTINEL_6b3a", _JUDGE_KEY]:
         assert sentinel not in artifacts_blob        # no credential/source/agent/agent-key leakage

--- a/tests/test_benchmark_verifier_isolation.py
+++ b/tests/test_benchmark_verifier_isolation.py
@@ -29,20 +29,27 @@ _SENTINELS = {
 _JUDGE_KEY = "sk-or-isolation-only-7f1e"
 
 
+class _JudgeServer(HTTPServer):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.posted_bodies: list[bytes] = []
+
+
 class _Judge(BaseHTTPRequestHandler):
     def do_POST(self):
-        self.rfile.read(int(self.headers.get("Content-Length", 0)))
-        body = json.dumps({"choices": [{"message": {"content":
+        body = self.rfile.read(int(self.headers.get("Content-Length", 0)))
+        self.server.posted_bodies.append(body)  # observed by the leakage assertions below
+        resp = json.dumps({"choices": [{"message": {"content":
             '{"match": true, "confidence": 1.0, "reasoning": "identical"}'}}]}).encode()
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
         self.end_headers()
-        self.wfile.write(body)
+        self.wfile.write(resp)
     def log_message(self, *a): pass
 
 
-def _serve() -> HTTPServer:
-    srv = HTTPServer(("127.0.0.1", 0), _Judge)
+def _serve() -> _JudgeServer:
+    srv = _JudgeServer(("127.0.0.1", 0), _Judge)
     threading.Thread(target=srv.serve_forever, daemon=True).start()
     return srv
 
@@ -65,11 +72,13 @@ def test_entrypoint_in_isolation_cannot_see_secrets_or_source(tmp_path, monkeypa
     # isolate the verifier in its own env dir
     verifier_dir = tmp_path / "verifier"
     verifier_dir.mkdir()
+    # the same template asset bundle asserted by test_generated_asset_tree_is_self_contained
     for rel in ("score_review.py", "verifier_core.py", "judge_prompt.md", "golden-review.json"):
         (verifier_dir / rel).write_bytes((_TEMPLATES_TESTS / rel).read_bytes())
     # task-binding metadata: run_verifier binds the candidate to the immutable
     # verifier-metadata.json beside the gold (case id + base/head refs + digest)
     gold_bytes = (verifier_dir / "golden-review.json").read_bytes()
+    # case id tied to the shipped fixture via test_shipped_gold_and_oracle_fixtures_validate_and_score_reward_1
     (verifier_dir / "verifier-metadata.json").write_text(json.dumps({
         "schema_version": 1,
         "case_id": "case-x",
@@ -108,8 +117,10 @@ def test_entrypoint_in_isolation_cannot_see_secrets_or_source(tmp_path, monkeypa
     assert rj["verifier_error"] == 0 and rj["reward"] == 1  # judged orbitally, not an error exit
     artifacts_blob = ((out_dir / "reward.json").read_text() + (out_dir / "reward-details.json").read_text()
                       + proc.stdout + proc.stderr)
+    judge_blob = b"".join(srv.posted_bodies).decode("utf-8", errors="replace")  # judge-bound channel: what the verifier POSTed
     for sentinel in list(_SENTINELS.values()) + ["REVIEWER_SECRET_SENTINEL_5d91", "PRIVATE_SOURCE_SENTINEL_2e4f",
                                                  "AGENT_OUTPUT_SENTINEL_6b3a", _JUDGE_KEY]:
         assert sentinel not in artifacts_blob        # no credential/source/agent/agent-key leakage
+        assert sentinel not in judge_blob            # ... nor through the judge request body
     for p, digest in zip((secret_file, source_file, agent_file), pre.values()):
         assert p.read_bytes() == digest             # host files untouched (no writes outside out_dir)

--- a/tests/test_benchmark_verifier_isolation.py
+++ b/tests/test_benchmark_verifier_isolation.py
@@ -14,8 +14,6 @@ import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 
-import pytest
-
 _TEMPLATES_TESTS = (
     Path(__file__).resolve().parents[1]
     / "daydream" / "benchmark" / "harbor" / "templates" / "tests"
@@ -83,7 +81,8 @@ def test_entrypoint_in_isolation_cannot_see_secrets_or_source(tmp_path, monkeypa
     }))
     artifact_path = tmp_path / "artifacts" / "review.json"
     artifact_path.parent.mkdir()
-    artifact_path.write_bytes((Path(_TEMPLATES_TESTS / ".." / "solution" / "golden-review.json").resolve()).read_bytes())
+    oracle = Path(_TEMPLATES_TESTS / ".." / "solution" / "golden-review.json").resolve()
+    artifact_path.write_bytes(oracle.read_bytes())
     out_dir = tmp_path / "verifier-out"
 
     srv = _serve()

--- a/tests/test_benchmark_verifier_judge.py
+++ b/tests/test_benchmark_verifier_judge.py
@@ -1123,3 +1123,20 @@ async def test_response_body_is_size_capped_before_json_parse(sr_module) -> None
                                           content=lambda b: b, allowlist={"u"})
     assert "256 KiB" in str(e.value) or "exceeds" in str(e.value)
     assert len(calls) == 1  # oversized body is terminal, not retried
+
+
+def test_verdict_reasoning_is_size_capped_and_errors_are_bounded(sr_module) -> None:
+    sr = sr_module
+    ok = sr.parse_verdict({"match": True, "confidence": 0.9, "reasoning": "short"})
+    assert ok.match is True
+    # over-cap reasoning rejected with a typed bounded diagnostic
+    with pytest.raises(sr.VerifierError) as e:
+        sr.parse_verdict({"match": True, "confidence": 0.9,
+                          "reasoning": "r" * (sr._REASONING_CAP_BYTES + 1)})
+    assert "reasoning" in str(e.value)
+    assert ("r" * 64) not in str(e.value)  # never embeds the oversized value
+    # non-string reasoning whose repr is huge is bounded
+    huge = {"match": True, "confidence": 0.9, "reasoning": ["x" * 5000]}
+    with pytest.raises(sr.VerifierError) as e:
+        sr.parse_verdict(huge)
+    assert len(str(e.value).encode("utf-8")) < 5000  # never echoes the full value

--- a/tests/test_benchmark_verifier_judge.py
+++ b/tests/test_benchmark_verifier_judge.py
@@ -470,7 +470,7 @@ def test_provider_selection_builds_expected_client(sr_module, monkeypatch) -> No
         )
 
     assert isinstance(make("anthropic", None), sr.AnthropicJudgeClient)
-    assert isinstance(make("openai", "https://openrouter.ai/api/v1"), sr.OpenAIJudgeClient)
+    assert isinstance(make("openai-compatible", "https://openrouter.ai/api/v1"), sr.OpenAIJudgeClient)
     with pytest.raises(sr.VerifierError):
         make("anthropic", None, model=None)  # missing MODEL -> verifier error
     with pytest.raises(sr.VerifierError):
@@ -1026,3 +1026,43 @@ def test_error_bounding_and_redaction(sr_module) -> None:
     assert "Bearer sk-or-longtokenvalue123" not in sr._bounded_error("Authorization: Bearer sk-or-longtokenvalue123")
     long = "x" * 5000
     assert len(sr._bounded_error(long).encode("utf-8")) <= sr._ERROR_TEXT_CAP_BYTES
+
+
+def test_provider_allowlist_rejects_unknown_and_validates_base_url(sr_module) -> None:
+    sr = sr_module
+    # absent provider defaults to anthropic (unchanged)
+    assert isinstance(sr._build_client(
+        {"DAYDREAM_JUDGE_PROVIDER": None, "DAYDREAM_JUDGE_MODEL": "m",
+         "DAYDREAM_JUDGE_API_KEY": "k", "DAYDREAM_JUDGE_BASE_URL": None}),
+        sr.AnthropicJudgeClient)
+    # exactly anthropic | openai-compatible accepted
+    cert = {"DAYDREAM_JUDGE_PROVIDER": "openai-compatible", "DAYDREAM_JUDGE_MODEL": "m",
+            "DAYDREAM_JUDGE_API_KEY": "k", "DAYDREAM_JUDGE_BASE_URL": "https://api.openai.com/v1"}
+    assert isinstance(sr._build_client(cert), sr.OpenAIJudgeClient)
+    # anything else fails closed BEFORE any request
+    for bad in ("martian", "garbage", "Anthropic"):
+        with pytest.raises(sr.VerifierError) as e:
+            sr._build_client({**cert, "DAYDREAM_JUDGE_PROVIDER": bad})
+        assert "expected anthropic or openai-compatible" in str(e.value)
+    # a base URL host outside the allowlist fails closed at build time
+    with pytest.raises(sr.VerifierError):
+        sr._build_client({**cert, "DAYDREAM_JUDGE_ALLOWED_HOSTS": "api.anthropic.com"})
+
+
+@pytest.mark.asyncio
+async def test_clients_validate_initial_url_before_request(sr_module) -> None:
+    sr = sr_module
+    calls = []
+    class F:
+        async def post(self, url, *, headers, json, timeout):
+            calls.append(url);  # would be reached only if validation passed
+            return type("R", (), {"status_code": 200, "text": "ok",
+                "json": lambda self: {"content": [{"type": "text", "text": '{"match": true, "confidence": 0.9, "reasoning": "x"}'}]}})()
+    # anthropic validates the hardcoded constant -> ok when allowlist matches
+    c = sr.AnthropicJudgeClient("sk-ant-x", "m", http=F())
+    assert await c.complete_json(user="u") is not None and len(calls) == 1
+    # a disallowed initial host fails closed before post is hit
+    c2 = sr.AnthropicJudgeClient("sk-ant-x", "m", http=F(), allowlist={"evil.example"})
+    with pytest.raises(sr.VerifierError):
+        await c2.complete_json(user="u")
+    assert len(calls) == 1  # no new request issued

--- a/tests/test_benchmark_verifier_judge.py
+++ b/tests/test_benchmark_verifier_judge.py
@@ -1140,3 +1140,27 @@ def test_verdict_reasoning_is_size_capped_and_errors_are_bounded(sr_module) -> N
     with pytest.raises(sr.VerifierError) as e:
         sr.parse_verdict(huge)
     assert len(str(e.value).encode("utf-8")) < 5000  # never echoes the full value
+
+
+def test_arbitrary_runtime_failure_writes_bounded_diagnostics(sr_module, tmp_path) -> None:
+    sr = sr_module
+    gold_path = tmp_path / "g.json"
+    gold_path.write_text(json.dumps(_gold_list(1, case_id="c")))
+    _write_metadata(gold_path, case_id="c")
+    art_path = tmp_path / "r.json"
+    art_path.write_text(json.dumps(_candidate_artifact(sr, case_id="c", n=1)))
+    out = tmp_path / "out"
+    class Exploding:
+        async def complete_json(self, *, user, system, max_tokens):
+            raise RuntimeError("sk-ant-leakme123 boom %s" % ("y" * 1000))
+    env = {"DAYDREAM_JUDGE_PROVIDER": "anthropic", "DAYDREAM_JUDGE_MODEL": "m",
+           "DAYDREAM_JUDGE_API_KEY": "k", "DAYDREAM_JUDGE_BASE_URL": None}
+    reward = sr.run_verifier(gold_path, art_path, out, client=Exploding(), env=env)
+    # unexpected runtime exception no longer escapes to a bare exit
+    assert reward.verifier_error == 1 and reward.reward == 0.0
+    rj = json.loads((out / "reward.json").read_text())
+    assert rj["verifier_error"] == 1 and rj["reward"] == 0
+    details = json.loads((out / "reward-details.json").read_text())
+    blob = json.dumps(details)
+    assert "sk-ant-leakme123" not in blob and "<redacted>" in blob   # no credential, redacted
+    assert len(details["errors"]) >= 1 and any("unexpected" in e for e in details["errors"])

--- a/tests/test_benchmark_verifier_judge.py
+++ b/tests/test_benchmark_verifier_judge.py
@@ -155,7 +155,8 @@ async def test_retry_policy_retries_transport_and_5xx_then_fails_after_exhaustio
             )()
 
     raw = await sr._complete_json_with_http(
-        FlakyClient(), url="u", payload={}, headers={}, content=lambda b: b["content"][0]["text"]
+        FlakyClient(), url="u", payload={}, headers={}, content=lambda b: b["content"][0]["text"],
+        allowlist={"u"}
     )
     assert raw == {"match": True, "confidence": 0.8, "reasoning": "x"}
     assert len(attempts) == 3
@@ -169,7 +170,7 @@ async def test_retry_policy_retries_transport_and_5xx_then_fails_after_exhaustio
 
     with pytest.raises(sr.VerifierError):
         await sr._complete_json_with_http(
-            Always5xx(), url="u", payload={}, headers={}, content=lambda b: b
+            Always5xx(), url="u", payload={}, headers={}, content=lambda b: b, allowlist={"u"}
         )
     assert len(attempts) == 3  # 3 attempts then fail
 
@@ -186,7 +187,7 @@ async def test_terminal_4xx_is_not_retried_and_redirect_to_other_host_is_rejecte
 
     with pytest.raises(sr.VerifierError):
         await sr._complete_json_with_http(
-            BadRequest(), url="u", payload={}, headers={}, content=lambda b: b
+            BadRequest(), url="u", payload={}, headers={}, content=lambda b: b, allowlist={"u"}
         )
     assert len(attempts) == 1  # terminal 4xx, no retry
 
@@ -210,6 +211,7 @@ async def test_terminal_4xx_is_not_retried_and_redirect_to_other_host_is_rejecte
             payload={},
             headers={},
             content=lambda b: b,
+            allowlist={"api.anthropic.com"},
         )
 
 
@@ -1066,3 +1068,58 @@ async def test_clients_validate_initial_url_before_request(sr_module) -> None:
     with pytest.raises(sr.VerifierError):
         await c2.complete_json(user="u")
     assert len(calls) == 1  # no new request issued
+
+
+@pytest.mark.asyncio
+async def test_redirects_preserve_configured_headers_and_bound_depth(sr_module) -> None:
+    sr = sr_module
+    seen = []
+    class Redirecting:
+        def __init__(self, hops): self.hops = list(hops)
+        async def post(self, url, *, headers, json, timeout):
+            seen.append((url, dict(headers)))
+            loc = self.hops.pop(0) if self.hops else None
+            if loc is not None:
+                return type("R", (), {"status_code": 302, "headers": {"location": loc, "x-server-token": "SHOULD-NOT-REPLAY"}, "text": ""})()
+            return type("R", (), {"status_code": 200, "text": "ok",
+                "json": lambda self: {"content": [{"type": "text", "text": '{"match": true, "confidence": 0.9, "reasoning": "x"}'}]}})()
+    allow = {"api.anthropic.com"}
+    client = Redirecting(["/v1/next"])  # relative Location, same host
+    raw = await sr._complete_json_with_http(
+        client, url="https://api.anthropic.com/v1/messages", payload={"x": 1},
+        headers={"x-api-key": "SECRET", "authorization": "Bearer K"}, content=lambda b: b["content"][0]["text"],
+        allowlist=allow)
+    assert raw["match"] is True
+    assert len(seen) == 2
+    final_url, final_headers = seen[-1]
+    assert final_url == "https://api.anthropic.com/v1/next"  # relative resolved
+    assert final_headers["x-api-key"] == "SECRET"             # configured header preserved
+    assert "x-server-token" not in final_headers             # server header never replayed
+
+    # cross-host redirect rejected
+    bad = Redirecting(["https://evil.example/x"])
+    with pytest.raises(sr.VerifierError):
+        await sr._complete_json_with_http(bad, url="https://api.anthropic.com/v1/messages",
+            payload={}, headers={"x-api-key": "K"}, content=lambda b: b, allowlist=allow)
+
+    # redirect loop bounded by _MAX_REDIRECTS
+    loop = Redirecting(["/v1/next"] * (sr._MAX_REDIRECTS + 1))
+    with pytest.raises(sr.VerifierError):
+        await sr._complete_json_with_http(loop, url="https://api.anthropic.com/v1/messages",
+            payload={}, headers={}, content=lambda b: b, allowlist=allow)
+
+
+@pytest.mark.asyncio
+async def test_response_body_is_size_capped_before_json_parse(sr_module) -> None:
+    sr = sr_module
+    calls = []
+    class Huge:
+        async def post(self, url, *, headers, json, timeout):
+            calls.append(1)
+            return type("R", (), {"status_code": 200, "text": "", "content": b"x" * (sr._RESPONSE_CAP_BYTES + 1),
+                                  "json": lambda self: {"content": [{"type": "text", "text": '{"match": true}'}]}})()
+    with pytest.raises(sr.VerifierError) as e:
+        await sr._complete_json_with_http(Huge(), url="u", payload={}, headers={},
+                                          content=lambda b: b, allowlist={"u"})
+    assert "256 KiB" in str(e.value) or "exceeds" in str(e.value)
+    assert len(calls) == 1  # oversized body is terminal, not retried

--- a/tests/test_benchmark_verifier_judge.py
+++ b/tests/test_benchmark_verifier_judge.py
@@ -1057,9 +1057,10 @@ async def test_clients_validate_initial_url_before_request(sr_module) -> None:
     calls = []
     class F:
         async def post(self, url, *, headers, json, timeout):
-            calls.append(url);  # would be reached only if validation passed
+            calls.append(url)  # would be reached only if validation passed
+            verdict = '{"match": true, "confidence": 0.9, "reasoning": "x"}'
             return type("R", (), {"status_code": 200, "text": "ok",
-                "json": lambda self: {"content": [{"type": "text", "text": '{"match": true, "confidence": 0.9, "reasoning": "x"}'}]}})()
+                "json": lambda self: {"content": [{"type": "text", "text": verdict}]}})()
     # anthropic validates the hardcoded constant -> ok when allowlist matches
     c = sr.AnthropicJudgeClient("sk-ant-x", "m", http=F())
     assert await c.complete_json(user="u") is not None and len(calls) == 1
@@ -1080,9 +1081,12 @@ async def test_redirects_preserve_configured_headers_and_bound_depth(sr_module) 
             seen.append((url, dict(headers)))
             loc = self.hops.pop(0) if self.hops else None
             if loc is not None:
-                return type("R", (), {"status_code": 302, "headers": {"location": loc, "x-server-token": "SHOULD-NOT-REPLAY"}, "text": ""})()
+                return type("R", (), {"status_code": 302,
+                    "headers": {"location": loc, "x-server-token": "SHOULD-NOT-REPLAY"},
+                    "text": ""})()
+            verdict = '{"match": true, "confidence": 0.9, "reasoning": "x"}'
             return type("R", (), {"status_code": 200, "text": "ok",
-                "json": lambda self: {"content": [{"type": "text", "text": '{"match": true, "confidence": 0.9, "reasoning": "x"}'}]}})()
+                "json": lambda self: {"content": [{"type": "text", "text": verdict}]}})()
     allow = {"api.anthropic.com"}
     client = Redirecting(["/v1/next"])  # relative Location, same host
     raw = await sr._complete_json_with_http(
@@ -1183,3 +1187,44 @@ def test_main_fail_closed_on_bad_provider_and_reads_path_overrides(sr_module, tm
     details = json.loads((out / "reward-details.json").read_text())
     assert any("unsupported" in e or "expected anthropic or openai-compatible" in e
                for e in details["errors"])  # typed diagnostic surfaced, not a barren client=None exit
+
+
+@pytest.mark.asyncio
+async def test_both_providers_share_identical_hardened_error_and_redirect_policy(sr_module) -> None:
+    sr = sr_module
+    allow = {"api.anthropic.com"}
+    anthropic = sr.AnthropicJudgeClient("k", "m", allowlist=allow)
+    openai = sr.OpenAIJudgeClient("k", "m", base_url="https://api.anthropic.com/v1", allowlist=allow)
+    for client in (anthropic, openai):
+        # identical redirect-hop bound: a forever-redirecting judge exhausts
+        # _MAX_REDIRECTS on both providers before the same VerifierError
+        seen = []
+        class RedirectRule:
+            async def post(self, url, *, headers, json, timeout):
+                seen.append(1)
+                return type("R", (), {"status_code": 302,
+                    "headers": {"location": "/v1/next", "x-srv": "NO-REPLAY"}, "text": ""})()
+        client.http = RedirectRule()
+        with pytest.raises(sr.VerifierError):
+            await client.complete_json(user="u")
+        assert len(seen) == (sr._MAX_REDIRECTS + 1)       # identical hop bound on both
+
+        # identical oversized-response diagnostic on both providers
+        class Oversize:
+            async def post(self, url, *, headers, json, timeout):
+                return type("R", (), {"status_code": 200, "text": "",
+                    "content": b"x" * (sr._RESPONSE_CAP_BYTES + 1), "json": lambda self: {}})()
+        client.http = Oversize()
+        with pytest.raises(sr.VerifierError) as e:
+            await client.complete_json(user="u")
+        assert "256 KiB" in str(e.value)
+
+        # identical out-of-allowlist redirect rejection on both providers
+        class BadRedirect:
+            async def post(self, url, *, headers, json, timeout):
+                return type("R", (), {"status_code": 302,
+                    "headers": {"location": "https://evil.example/x"}, "text": ""})()
+        client.http = BadRedirect()
+        with pytest.raises(sr.VerifierError) as e:
+            await client.complete_json(user="u")
+        assert "allowlist" in str(e.value)

--- a/tests/test_benchmark_verifier_judge.py
+++ b/tests/test_benchmark_verifier_judge.py
@@ -490,6 +490,10 @@ def test_main_reads_only_tests_and_logs_artifact_paths(sr_module, tmp_path, monk
         return type("R", (), {"verifier_error": 0, "reward": 1.0})()
 
     monkeypatch.setattr(sr, "run_verifier", fake_run_verifier)
+    # guard the env overrides: main() reads them from real os.environ and the
+    # assertions below expect the compile-time defaults
+    monkeypatch.delenv("DAYDREAM_JUDGE_ARTIFACT_PATH", raising=False)
+    monkeypatch.delenv("DAYDREAM_JUDGE_OUT_PATH", raising=False)
     sr.main()  # must not require real /tests or /logs — it only passes the paths through
     assert seen["gold"].endswith("golden-review.json")
     assert "tests" in Path(seen["gold"]).parts  # the __file__ sibling (templates/tests/)

--- a/tests/test_benchmark_verifier_judge.py
+++ b/tests/test_benchmark_verifier_judge.py
@@ -986,3 +986,43 @@ def test_parse_verdict_rejects_unknown_key(sr_module) -> None:
     sr = sr_module
     with pytest.raises(sr.VerifierError):
         sr.parse_verdict({"match": True, "confidence": 0.9, "reasoning": "ok", "extra": 1})
+
+
+def test_url_validation_and_allowlist_helpers(sr_module) -> None:
+    sr = sr_module
+    # allowlist resolution: explicit env wins; absent -> own-host fail-closed fallback
+    assert sr._effective_allowlist("openai-compatible", "https://api.openai.com/v1",
+                                   {"DAYDREAM_JUDGE_ALLOWED_HOSTS": "api.anthropic.com  judge.example"}) \
+        == {"api.anthropic.com", "judge.example"}
+    assert sr._effective_allowlist("anthropic", "https://api.anthropic.com/v1/messages", {}) \
+        == {"api.anthropic.com"}
+
+    def rejects(url, allowlist):
+        with pytest.raises(sr.VerifierError):
+            sr._validate_base_url(url, allowlist)
+
+    allow = {"api.anthropic.com"}
+    sr._validate_base_url("https://api.anthropic.com/v1/messages", allow)               # ok
+    sr._validate_base_url("https://sub.api.anthropic.com/x", {"sub.api.anthropic.com"}) # sub in allowlist
+    rejects("https://user:pass@api.anthropic.com/v1", allow)       # userinfo
+    rejects("https://api.anthropic.com/v1?q=1", allow)             # query
+    rejects("https://api.anthropic.com/v1#frag", allow)            # fragment
+    rejects("http://api.anthropic.com/v1", allow)                  # non-HTTPS remote
+    rejects("https://evil.example/v1", allow)                      # host outside allowlist
+    sr._validate_base_url("http://127.0.0.1:8000/v1", {"127.0.0.1"})  # loopback http allowed
+
+    # redirect resolution: relative Location resolved against request URL, then host-checked
+    assert sr._resolve_redirect("https://api.anthropic.com/v1/messages",
+                                "/v1/next", {"api.anthropic.com"}) == "https://api.anthropic.com/v1/next"
+    with pytest.raises(sr.VerifierError):
+        sr._resolve_redirect("https://api.anthropic.com/v1/messages",
+                             "https://evil.example/x", {"api.anthropic.com"})
+
+
+def test_error_bounding_and_redaction(sr_module) -> None:
+    sr = sr_module
+    assert "sk-ant-abcdef1234567890" not in sr._bounded_error("key=sk-ant-abcdef1234567890 end")
+    assert "<redacted>" in sr._bounded_error("key=sk-ant-abcdef1234567890 end")
+    assert "Bearer sk-or-longtokenvalue123" not in sr._bounded_error("Authorization: Bearer sk-or-longtokenvalue123")
+    long = "x" * 5000
+    assert len(sr._bounded_error(long).encode("utf-8")) <= sr._ERROR_TEXT_CAP_BYTES

--- a/tests/test_benchmark_verifier_judge.py
+++ b/tests/test_benchmark_verifier_judge.py
@@ -997,10 +997,10 @@ def test_parse_verdict_rejects_unknown_key(sr_module) -> None:
 def test_url_validation_and_allowlist_helpers(sr_module) -> None:
     sr = sr_module
     # allowlist resolution: explicit env wins; absent -> own-host fail-closed fallback
-    assert sr._effective_allowlist("openai-compatible", "https://api.openai.com/v1",
+    assert sr._effective_allowlist("https://api.openai.com/v1",
                                    {"DAYDREAM_JUDGE_ALLOWED_HOSTS": "api.anthropic.com  judge.example"}) \
         == {"api.anthropic.com", "judge.example"}
-    assert sr._effective_allowlist("anthropic", "https://api.anthropic.com/v1/messages", {}) \
+    assert sr._effective_allowlist("https://api.anthropic.com/v1/messages", {}) \
         == {"api.anthropic.com"}
 
     def rejects(url, allowlist):

--- a/tests/test_benchmark_verifier_judge.py
+++ b/tests/test_benchmark_verifier_judge.py
@@ -1164,3 +1164,22 @@ def test_arbitrary_runtime_failure_writes_bounded_diagnostics(sr_module, tmp_pat
     blob = json.dumps(details)
     assert "sk-ant-leakme123" not in blob and "<redacted>" in blob   # no credential, redacted
     assert len(details["errors"]) >= 1 and any("unexpected" in e for e in details["errors"])
+
+
+def test_main_fail_closed_on_bad_provider_and_reads_path_overrides(sr_module, tmp_path, monkeypatch) -> None:
+    sr = sr_module
+    out = tmp_path / "out"
+    monkeypatch.setenv("DAYDREAM_JUDGE_PROVIDER", "nonsense")
+    monkeypatch.setenv("DAYDREAM_JUDGE_MODEL", "m")
+    monkeypatch.setenv("DAYDREAM_JUDGE_API_KEY", "k")
+    monkeypatch.setenv("DAYDREAM_JUDGE_ARTIFACT_PATH", str(tmp_path / "review.json"))
+    monkeypatch.setenv("DAYDREAM_JUDGE_OUT_PATH", str(out))
+    (tmp_path / "review.json").write_text(json.dumps(
+        _candidate_artifact(sr, case_id="c", n=0)))
+    rc = sr.main()
+    assert rc == 1  # verifier_error
+    rj = json.loads((out / "reward.json").read_text())
+    assert rj["verifier_error"] == 1 and rj["reward"] == 0
+    details = json.loads((out / "reward-details.json").read_text())
+    assert any("unsupported" in e or "expected anthropic or openai-compatible" in e
+               for e in details["errors"])  # typed diagnostic surfaced, not a barren client=None exit


### PR DESCRIPTION
Closes #819

Harden the external judge endpoints and failure handling in the benchmark verifier.

## Summary
- Bounded credential-preserving redirects and a response-size cap in the judge verifier
- Fail-closed provider allowlist and initial-base-URL validation
- Typed bounded diagnostics on every judge verifier failure path
- Cap verdict reasoning size and bound verdict error text
- Size-cap all judge bodies, bound redirects per call, validate anthropic at build, de-duplicate main emission
- Consolidate judge retry exhaustion and byte-cap error paths
- Real-path tests proving filesystem/environment isolation and byte-identical hardened judge policy across providers

## Test Plan
- Full `make check` green (4264 passed, 6 skipped)
- Two sequential daydream deep-precision reviews passed
- All commits owner-authored (deterministic-authorship gate clean)

Closes #819