### PR TITLE
fix(benchmark): make verifier failures and metrics Harbor-native (Closes #820)

### DIFF
--- a/daydream/benchmark/harbor/build.py
+++ b/daydream/benchmark/harbor/build.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from daydream.benchmark import schema, snapshot, storage
 from daydream.benchmark.harbor import verifier_core as vc
 
-TEMPLATE_VERSION = "1"
+TEMPLATE_VERSION = "2"
 
 
 _METRIC_AGG_BEGIN = "# __AGGREGATION_BODY_BEGIN__"

--- a/daydream/benchmark/harbor/build.py
+++ b/daydream/benchmark/harbor/build.py
@@ -46,7 +46,11 @@ def render_metric() -> bytes:
     share one aggregation contract and cannot drift.
     """
     text = (_TEMPLATE_DIR / "metric.py").read_text(encoding="utf-8")
-    assert _METRIC_AGG_BEGIN in text and _METRIC_AGG_END in text
+    if _METRIC_AGG_BEGIN not in text or _METRIC_AGG_END not in text:
+        raise CompileError(
+            "metric.py template is missing the aggregation markers "
+            f"({_METRIC_AGG_BEGIN!r} / {_METRIC_AGG_END!r}); cannot render compiled metric"
+        )
     start = text.index(_METRIC_AGG_BEGIN)
     stop = text.index(_METRIC_AGG_END) + len(_METRIC_AGG_END)
     body = inspect.getsource(vc.aggregate_metrics)

--- a/daydream/benchmark/harbor/build.py
+++ b/daydream/benchmark/harbor/build.py
@@ -12,6 +12,7 @@ command surface.
 from __future__ import annotations
 
 import hashlib
+import inspect
 import json
 import os
 import re
@@ -24,12 +25,32 @@ from daydream.benchmark.harbor import verifier_core as vc
 TEMPLATE_VERSION = "1"
 
 
+_METRIC_AGG_BEGIN = "# __AGGREGATION_BODY_BEGIN__"
+_METRIC_AGG_END = "# __AGGREGATION_BODY_END__"
+
+
 class CompileError(Exception):
     """Raised on any compile/leakage/validation rejection."""
 
     def __init__(self, message: str) -> None:
         super().__init__(message)
         self.message = message
+
+
+def render_metric() -> bytes:
+    """Render the compiled ``metric.py`` with its aggregation body from verifier_core.
+
+    The template's ``aggregate_metrics`` placeholder between the two marker
+    comments is replaced, markers inclusive, with ``inspect.getsource(vc.
+    aggregate_metrics)`` so the compiled metric and the in-repo corpus pool
+    share one aggregation contract and cannot drift.
+    """
+    text = (_TEMPLATE_DIR / "metric.py").read_text(encoding="utf-8")
+    assert _METRIC_AGG_BEGIN in text and _METRIC_AGG_END in text
+    start = text.index(_METRIC_AGG_BEGIN)
+    stop = text.index(_METRIC_AGG_END) + len(_METRIC_AGG_END)
+    body = inspect.getsource(vc.aggregate_metrics)
+    return (text[:start] + body + text[stop:]).encode("utf-8")
 
 
 def derive_task_key(case_id: str) -> str:
@@ -566,7 +587,7 @@ def compile_workspace(root: Path) -> dict:
                 ).read_text()
 
             (stage / "README.md").write_text(_ROOT_README)
-            metric_bytes = (_TEMPLATE_DIR / "metric.py").read_bytes()
+            metric_bytes = render_metric()
             (stage / "metric.py").write_bytes(metric_bytes)
             (stage / "jobs").mkdir(exist_ok=True)
 

--- a/daydream/benchmark/harbor/templates/metric.py
+++ b/daydream/benchmark/harbor/templates/metric.py
@@ -2,9 +2,12 @@
 """Self-contained corpus micro-metric aggregation for the Harbor verifier image.
 
 Stdlib only, never imports daydream (or the bundled verifier_core): the
-aggregation body is inlined so a compiled task's ``metric.py`` needs nothing but
-the stdlib. Reads one JSONL line per task — a reward dict or ``null`` (failed
-task) — and emits the pooled micro metrics.
+aggregation body is inlined at build time so a compiled task's ``metric.py``
+needs nothing but the stdlib. Reads one JSONL line per task — a reward dict or
+``null`` (failed task) — and writes the pooled micro metrics to the ``-o`` path.
+Invocation matches Harbor 0.21's ``uv run metric.py -i <rewards.jsonl> -o
+<metric.json>``; a missing input raises ``FileNotFoundError`` (uncaught ->
+nonzero exit, no output written — fail-closed, never partial).
 """
 # /// script
 # requires-python = ">=3.12"
@@ -13,7 +16,9 @@ task) — and emits the pooled micro metrics.
 
 from __future__ import annotations
 
+import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -40,57 +45,18 @@ def _f1(precision: float, recall: float) -> float:
     return 2 * precision * recall / (precision + recall)
 
 
+# __AGGREGATION_BODY_BEGIN__
 def aggregate_metrics(rows: list[dict[str, object] | None]) -> dict[str, float | int]:
-    """Aggregate per-task reward JSONL rows into pooled corpus micro metrics.
+    """Placeholder — replaced at build time by ``verifier_core.aggregate_metrics``.
 
-    Inline copy of ``verifier_core.aggregate_metrics`` so the compiled metric is
-    self-contained. A ``None`` row or a row with ``verifier_error == 1`` is a
-    failed task: reward 0 to the mean, zero counts, ``failed_task_count`` += 1.
-    Zero denominators evaluate to 1.0 throughout.
+    ``build.render_metric()`` splices ``inspect.getsource(verifier_core.
+    aggregate_metrics)`` over the region between the two marker comments, so the
+    compiled metric and the in-repo corpus pool can never drift.
     """
-    failed = 0
-    clean_correct = 0
-    clean_total = 0
-    rewards: list[float] = []
-    total_tp = total_fp = total_fn = 0
-
-    for row in rows:
-        if row is None or row.get("verifier_error") == 1:
-            failed += 1
-            rewards.append(0.0)
-            continue
-        total_tp += _as_int(row["tp"])
-        total_fp += _as_int(row["fp"])
-        total_fn += _as_int(row["fn"])
-        rewards.append(_as_float(row["reward"]))
-        if row.get("clean_task") == 1:
-            clean_total += 1
-            if _as_int(row["fp"]) == 0:
-                clean_correct += 1
-
-    task_count = len(rows)
-    mean_task_score = sum(rewards) / task_count if task_count else 1.0
-    micro_precision = total_tp / (total_tp + total_fp) if (total_tp + total_fp) else 1.0
-    micro_recall = total_tp / (total_tp + total_fn) if (total_tp + total_fn) else 1.0
-    if total_tp == 0 and (total_tp + total_fp > 0 or total_tp + total_fn > 0):
-        micro_f1 = 0.0
-    else:
-        micro_f1 = _f1(micro_precision, micro_recall)
-    clean_accuracy = clean_correct / clean_total if clean_total else 1.0
-
-    return {
-        "micro_precision": micro_precision,
-        "micro_recall": micro_recall,
-        "micro_f1": micro_f1,
-        "mean_task_score": mean_task_score,
-        "clean_accuracy": clean_accuracy,
-        "task_count": task_count,
-        "clean_task_count": clean_total,
-        "failed_task_count": failed,
-        "total_tp": total_tp,
-        "total_fp": total_fp,
-        "total_fn": total_fn,
-    }
+    raise NotImplementedError(
+        "aggregation body is rendered at build time from verifier_core.aggregate_metrics"
+    )
+# __AGGREGATION_BODY_END__
 
 
 def aggregate_rewards_file(path: str) -> dict[str, float | int]:
@@ -112,9 +78,17 @@ def aggregate_rewards_file(path: str) -> dict[str, float | int]:
     return aggregate_metrics(rows)
 
 
-def main() -> int:
-    results = aggregate_rewards_file("/logs/verifier/reward.json")
-    print(json.dumps(results))
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Aggregate Harbor verifier rewards JSONL into pooled micro metrics.")
+    parser.add_argument("-i", "--input", required=True, help="JSONL rewards input (one reward dict or null per task)")
+    parser.add_argument("-o", "--output", required=True, help="JSON metric output path (written atomically)")
+    args = parser.parse_args(argv)
+    result = aggregate_rewards_file(args.input)
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    tmp = out.parent / f".{out.name}.{os.getpid()}.tmp"
+    tmp.write_text(json.dumps(result), encoding="utf-8")
+    os.replace(tmp, out)
     return 0
 
 

--- a/daydream/benchmark/harbor/templates/metric.py
+++ b/daydream/benchmark/harbor/templates/metric.py
@@ -4,7 +4,7 @@
 Stdlib only, never imports daydream (or the bundled verifier_core): the
 aggregation body is inlined at build time so a compiled task's ``metric.py``
 needs nothing but the stdlib. Reads one JSONL line per task — a reward dict or
-``null`` (failed task) — and writes the pooled micro metrics to the ``-o`` path.
+``null`` (unscored infrastructure failure) — and writes the pooled micro metrics to the ``-o`` path.
 Invocation matches Harbor 0.21's ``uv run metric.py -i <rewards.jsonl> -o
 <metric.json>``; a missing input raises ``FileNotFoundError`` (uncaught ->
 nonzero exit, no output written — fail-closed, never partial).
@@ -62,8 +62,9 @@ def aggregate_metrics(rows: list[dict[str, object] | None]) -> dict[str, float |
 def aggregate_rewards_file(path: str) -> dict[str, float | int]:
     """Read a JSONL rewards file (reward dict or null per line) and aggregate.
 
-    A malformed/non-dict line is a failed-task ``None`` row, never an aborting
-    exception. An empty file aggregates to ``task_count == 0`` / score 1.0.
+    A malformed/non-dict line is an unscored infrastructure ``None`` row, never
+    an aborting exception. An empty file aggregates to ``task_count == 0`` /
+    score 1.0.
     """
     rows: list[dict[str, object] | None] = []
     for line in Path(path).read_text(encoding="utf-8").splitlines():

--- a/daydream/benchmark/harbor/templates/tests/score_review.py
+++ b/daydream/benchmark/harbor/templates/tests/score_review.py
@@ -50,6 +50,18 @@ class _AsyncHttpClient(Protocol):
 
 VerifierError = verifier_core.VerifierError
 
+
+class _InputFileNotFound(verifier_core.VerifierError):
+    """A required input file is absent — an infrastructure problem, not agent output.
+
+    Subclass of ``VerifierError`` so the candidate-zone handler can route a
+    missing candidate-artifact file to the unscored infra zone (reward-details
+    only) instead of treating it as a scored-zero agent failure. A missing
+    artifact file almost always means a wrong ``DAYDREAM_JUDGE_ARTIFACT_PATH``
+    or a missing mount reaching the entrypoint — infrastructure, never a real
+    score of zero.
+    """
+
 JUDGE_PROMPT_TEMPLATE = (
     Path(__file__).with_name("judge_prompt.md").read_text(encoding="utf-8")
 )
@@ -739,7 +751,7 @@ def _read_artifact_bytes(path: str | Path) -> dict[str, Any]:
     try:
         raw = Path(path).read_bytes()
     except FileNotFoundError:
-        raise VerifierError(f"input file not found: {Path(path)}") from None
+        raise _InputFileNotFound(f"input file not found: {Path(path)}") from None
     except OSError as exc:
         raise VerifierError(f"could not read {Path(path)}: {exc}") from exc
     if len(raw) > verifier_core.MAX_ARTIFACT_BYTES:
@@ -832,6 +844,27 @@ def _error_details(provider: str, model: str, request_counts: dict[str, int], er
     }
 
 
+def _write_details(
+    out_dir: str | Path,
+    provider: str,
+    model: str,
+    request_counts: dict[str, int],
+    errors: list[str],
+) -> Path:
+    """Normalize/mkdir ``out_dir`` and atomically write the shared reward-details.json.
+
+    Shared by both the scored-zero and unscored-error artifact writers so the
+    mkdir + details-build + atomic-write lines cannot drift between the two
+    zones. Returns the normalized ``out_dir`` for the caller's ``reward.json``
+    write (scored zone only).
+    """
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    details = _error_details(provider, model, request_counts, errors)
+    _atomic_write(out_dir, "reward-details.json", json.dumps(details))
+    return out_dir
+
+
 def _write_scored_zero_artifact(
     out_dir: str | Path,
     provider: str,
@@ -849,14 +882,11 @@ def _write_scored_zero_artifact(
     zero rather than being unscored. ``errors`` must already be
     bounded/redacted before the call.
     """
-    out_dir = Path(out_dir)
-    out_dir.mkdir(parents=True, exist_ok=True)
+    out_dir = _write_details(out_dir, provider, model, request_counts, errors)
     scored_zero = verifier_core.Reward(
         reward=0.0, gold_count=gold_count, verifier_error=0
     )
-    details = _error_details(provider, model, request_counts, errors)
     _atomic_write(out_dir, "reward.json", verifier_core.reward_to_json(scored_zero))
-    _atomic_write(out_dir, "reward-details.json", json.dumps(details))
     return scored_zero
 
 
@@ -871,21 +901,43 @@ def _write_error_artifact(
     """Write the unscored error artifacts and return the error reward.
 
     Every infrastructure failure path -- metadata load, gold read/digest/
-    validate, judging, exhausted retries, a missing client, or an unexpected
-    runtime exception -- funnels through here so ``reward-details.json`` is
-    always written with typed bounded diagnostics, never a bare exit. Only
-    ``reward-details.json`` is written: no ``reward.json`` on an infra path,
-    so the trial is unscored (never a numeric zero). ``errors`` must already
-    be bounded/redacted before the call.
+    validate, judging, exhausted retries, a missing client, an unexpected
+    runtime exception, or a missing candidate-artifact file -- funnels through
+    here so ``reward-details.json`` is always written with typed bounded
+    diagnostics, never a bare exit. Only ``reward-details.json`` is written: no
+    ``reward.json`` on an infra path, so the trial is unscored (never a numeric
+    zero). ``errors`` must already be bounded/redacted before the call.
     """
-    out_dir = Path(out_dir)
-    out_dir.mkdir(parents=True, exist_ok=True)
+    out_dir = _write_details(out_dir, provider, model, request_counts, errors)
     error_reward = verifier_core.Reward(
         reward=0.0, gold_count=gold_count, verifier_error=1
     )
     details = _error_details(provider, model, request_counts, errors)
     _atomic_write(out_dir, "reward-details.json", json.dumps(details))
     return error_reward
+
+
+def _scored_zero_reward(
+    exc: Exception,
+    *,
+    out_dir: str | Path,
+    provider: str,
+    model: str,
+    request_counts: dict[str, int],
+    errors: list[str],
+) -> verifier_core.Reward:
+    """Record a bounded candidate-zone diagnostic and return the scored-zero reward.
+
+    Shared by the candidate and binding zones in ``run_verifier``: both treat a
+    failure about the agent's own artifact as a scored outcome (reward=0,
+    verifier_error=0) and both prepend the bounded error before writing. A
+    single helper keeps the two zones from growing more verbatim copies of the
+    guard.
+    """
+    errors.insert(0, _bounded_error(str(exc)))
+    return _write_scored_zero_artifact(
+        out_dir, provider, model, request_counts, errors, gold_count=0
+    )
 
 
 def run_verifier(
@@ -929,12 +981,23 @@ def run_verifier(
         try:
             artifact_raw = _read_artifact_bytes(artifact_path)
             candidates = verifier_core.validate_candidate_artifact(artifact_raw)
+        except _InputFileNotFound as exc:
+            # Infra zone: a missing candidate-artifact file (wrong
+            # DAYDREAM_JUDGE_ARTIFACT_PATH, missing mount reaching the
+            # entrypoint that skips test.sh's existence pre-check) is
+            # infrastructure trouble, not the agent's output -- unscored
+            # (reward-details only), never a scored-zero that drags down the
+            # mean with no infra_error_task_count signal.
+            errors.insert(0, _bounded_error(str(exc)))
+            return _write_error_artifact(
+                out_dir, provider, model, request_counts, errors, gold_count=0
+            )
         except VerifierError as exc:
             # Candidate zone: reading/validating the agent's own artifact is a
             # scored outcome -- a scored-zero reward, never an infra error.
-            errors.insert(0, _bounded_error(str(exc)))
-            return _write_scored_zero_artifact(
-                out_dir, provider, model, request_counts, errors, gold_count=0
+            return _scored_zero_reward(
+                exc, out_dir=out_dir, provider=provider, model=model,
+                request_counts=request_counts, errors=errors,
             )
 
         metadata = _load_verifier_metadata(Path(gold_path))
@@ -948,9 +1011,9 @@ def run_verifier(
         except VerifierError as exc:
             # Binding zone: a candidate pointing at the wrong task is still the
             # agent's own output -- scored zero, not unscored.
-            errors.insert(0, _bounded_error(str(exc)))
-            return _write_scored_zero_artifact(
-                out_dir, provider, model, request_counts, errors, gold_count=0
+            return _scored_zero_reward(
+                exc, out_dir=out_dir, provider=provider, model=model,
+                request_counts=request_counts, errors=errors,
             )
 
         gold_raw = _read_gold_bytes(Path(gold_path), metadata["gold_sha256"])

--- a/daydream/benchmark/harbor/templates/tests/score_review.py
+++ b/daydream/benchmark/harbor/templates/tests/score_review.py
@@ -52,14 +52,14 @@ VerifierError = verifier_core.VerifierError
 
 
 class _InputFileNotFound(verifier_core.VerifierError):
-    """A required input file is absent — an infrastructure problem, not agent output.
+    """A required input file is absent or unreadable — an infrastructure problem, not agent output.
 
     Subclass of ``VerifierError`` so the candidate-zone handler can route a
-    missing candidate-artifact file to the unscored infra zone (reward-details
-    only) instead of treating it as a scored-zero agent failure. A missing
-    artifact file almost always means a wrong ``DAYDREAM_JUDGE_ARTIFACT_PATH``
-    or a missing mount reaching the entrypoint — infrastructure, never a real
-    score of zero.
+    missing or unreadable candidate-artifact file (EACCES/EISDIR/ENOTDIR and
+    friends) to the unscored infra zone (reward-details only) instead of
+    treating it as a scored-zero agent failure. A missing artifact file almost
+    always means a wrong ``DAYDREAM_JUDGE_ARTIFACT_PATH`` or a missing mount
+    reaching the entrypoint — infrastructure, never a real score of zero.
     """
 
 JUDGE_PROMPT_TEMPLATE = (
@@ -753,7 +753,11 @@ def _read_artifact_bytes(path: str | Path) -> dict[str, Any]:
     except FileNotFoundError:
         raise _InputFileNotFound(f"input file not found: {Path(path)}") from None
     except OSError as exc:
-        raise VerifierError(f"could not read {Path(path)}: {exc}") from exc
+        # An unreadable candidate-artifact file is the same infrastructure
+        # problem as a missing one (wrong DAYDREAM_JUDGE_ARTIFACT_PATH, a
+        # broken mount, bad permissions) -- unscored infra zone, never a
+        # scored-zero agent failure.
+        raise _InputFileNotFound(f"could not read {Path(path)}: {exc}") from exc
     if len(raw) > verifier_core.MAX_ARTIFACT_BYTES:
         raise VerifierError("candidate artifact exceeds 1 MiB (raw bytes)")
     try:
@@ -912,8 +916,6 @@ def _write_error_artifact(
     error_reward = verifier_core.Reward(
         reward=0.0, gold_count=gold_count, verifier_error=1
     )
-    details = _error_details(provider, model, request_counts, errors)
-    _atomic_write(out_dir, "reward-details.json", json.dumps(details))
     return error_reward
 
 
@@ -936,6 +938,29 @@ def _scored_zero_reward(
     """
     errors.insert(0, _bounded_error(str(exc)))
     return _write_scored_zero_artifact(
+        out_dir, provider, model, request_counts, errors, gold_count=0
+    )
+
+
+def _infra_error_reward(
+    exc: Exception,
+    *,
+    out_dir: str | Path,
+    provider: str,
+    model: str,
+    request_counts: dict[str, int],
+    errors: list[str],
+) -> verifier_core.Reward:
+    """Record a bounded infra-zone diagnostic and return the unscored error reward.
+
+    Shared by the infra-zone branches in ``run_verifier``: a failure about the
+    environment (a missing/unreadable candidate-artifact file) is unscored
+    (reward-details only, verifier_error=1, never a numeric zero) with the
+    bounded error prepended before writing. A single helper keeps the zones
+    from growing more verbatim copies of the guard.
+    """
+    errors.insert(0, _bounded_error(str(exc)))
+    return _write_error_artifact(
         out_dir, provider, model, request_counts, errors, gold_count=0
     )
 
@@ -982,15 +1007,15 @@ def run_verifier(
             artifact_raw = _read_artifact_bytes(artifact_path)
             candidates = verifier_core.validate_candidate_artifact(artifact_raw)
         except _InputFileNotFound as exc:
-            # Infra zone: a missing candidate-artifact file (wrong
-            # DAYDREAM_JUDGE_ARTIFACT_PATH, missing mount reaching the
-            # entrypoint that skips test.sh's existence pre-check) is
-            # infrastructure trouble, not the agent's output -- unscored
-            # (reward-details only), never a scored-zero that drags down the
-            # mean with no infra_error_task_count signal.
-            errors.insert(0, _bounded_error(str(exc)))
-            return _write_error_artifact(
-                out_dir, provider, model, request_counts, errors, gold_count=0
+            # Infra zone: a missing or unreadable candidate-artifact file
+            # (wrong DAYDREAM_JUDGE_ARTIFACT_PATH, missing mount reaching the
+            # entrypoint that skips test.sh's existence pre-check, EACCES/
+            # EISDIR/ENOTDIR) is infrastructure trouble, not the agent's
+            # output -- unscored (reward-details only), never a scored-zero
+            # that drags down the mean with no infra_error_task_count signal.
+            return _infra_error_reward(
+                exc, out_dir=out_dir, provider=provider, model=model,
+                request_counts=request_counts, errors=errors,
             )
         except VerifierError as exc:
             # Candidate zone: reading/validating the agent's own artifact is a

--- a/daydream/benchmark/harbor/templates/tests/score_review.py
+++ b/daydream/benchmark/harbor/templates/tests/score_review.py
@@ -14,9 +14,13 @@ sit in the configured allowlist (``DAYDREAM_JUDGE_ALLOWED_HOSTS``; own-host
 fallback when absent), redirects are bounded to ``_MAX_REDIRECTS``
 credential-preserving same-origin hops whose targets are re-validated against
 the allowlist, response/reasoning payloads are size-capped (rejected, never
-truncated-and-accepted), and every failure path writes typed bounded (redacted)
-diagnostics to ``reward.json`` / ``reward-details.json`` -- never a bare exit
-and never an unbounded or credential-bearing error.
+truncated-and-accepted), and failures split into two zones: invalid candidate
+output (read/validate/bind failures on the agent's own artifact) is a scored
+zero written to ``reward.json`` / ``reward-details.json``, while every
+infrastructure failure (metadata, gold, judging, credentials, a verifier bug)
+is unscored and writes ONLY ``reward-details.json`` -- never a bare exit and
+never an unbounded or credential-bearing error, and never a numeric zero on an
+infra path.
 """
 
 from __future__ import annotations
@@ -828,6 +832,34 @@ def _error_details(provider: str, model: str, request_counts: dict[str, int], er
     }
 
 
+def _write_scored_zero_artifact(
+    out_dir: str | Path,
+    provider: str,
+    model: str,
+    request_counts: dict[str, int],
+    errors: list[str],
+    gold_count: int,
+) -> verifier_core.Reward:
+    """Write the scored-zero artifacts for invalid candidate output.
+
+    Candidate-zone failures -- reading, validating, or binding the agent's own
+    artifact -- are a scored outcome, not infrastructure trouble: both
+    ``reward.json`` (``reward=0, verifier_error=0``) and ``reward-details.json``
+    are written atomically with typed bounded diagnostics, so the trial scores
+    zero rather than being unscored. ``errors`` must already be
+    bounded/redacted before the call.
+    """
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    scored_zero = verifier_core.Reward(
+        reward=0.0, gold_count=gold_count, verifier_error=0
+    )
+    details = _error_details(provider, model, request_counts, errors)
+    _atomic_write(out_dir, "reward.json", verifier_core.reward_to_json(scored_zero))
+    _atomic_write(out_dir, "reward-details.json", json.dumps(details))
+    return scored_zero
+
+
 def _write_error_artifact(
     out_dir: str | Path,
     provider: str,
@@ -836,12 +868,14 @@ def _write_error_artifact(
     errors: list[str],
     gold_count: int,
 ) -> verifier_core.Reward:
-    """Write the fail-whole error artifacts and return the error reward.
+    """Write the unscored error artifacts and return the error reward.
 
-    Every failure path -- validation, binding, digest, judging, exhausted
-    retries, a missing client, or an unexpected runtime exception -- funnels
-    through here so ``reward.json``/``reward-details.json`` are always written
-    with typed bounded diagnostics, never a bare exit. ``errors`` must already
+    Every infrastructure failure path -- metadata load, gold read/digest/
+    validate, judging, exhausted retries, a missing client, or an unexpected
+    runtime exception -- funnels through here so ``reward-details.json`` is
+    always written with typed bounded diagnostics, never a bare exit. Only
+    ``reward-details.json`` is written: no ``reward.json`` on an infra path,
+    so the trial is unscored (never a numeric zero). ``errors`` must already
     be bounded/redacted before the call.
     """
     out_dir = Path(out_dir)
@@ -850,7 +884,6 @@ def _write_error_artifact(
         reward=0.0, gold_count=gold_count, verifier_error=1
     )
     details = _error_details(provider, model, request_counts, errors)
-    _atomic_write(out_dir, "reward.json", verifier_core.reward_to_json(error_reward))
     _atomic_write(out_dir, "reward-details.json", json.dumps(details))
     return error_reward
 
@@ -870,13 +903,15 @@ def run_verifier(
     the task's immutable ``verifier-metadata.json`` (case id + base/head refs);
     the gold is then read as raw bytes and its sha256 must match the
     compiler-rendered ``gold_sha256`` sentinel before it is parsed and validated
-    (canonical/unique gold ids). Any ``VerifierError`` (validation, binding,
-    digest, parsing, judging, exhausted retries, or a missing client) -- and
-    any unexpected runtime exception -- becomes a typed bounded diagnostic that
-    still writes ``Reward(reward=0, verifier_error=1)`` plus both output files
-    atomically (temp + rename); the task fails whole, never reporting a
-    partial score and never escaping to a bare exit. Error text is redacted and
-    size-bounded before it reaches any artifact. Never emits source or diffs.
+    (canonical/unique gold ids). Failures split into two zones: anything about
+    the agent's own candidate artifact (read, validate, task-bind) is a scored
+    outcome written to ``reward.json`` with ``reward=0, verifier_error=0``
+    (plus bounded ``reward-details.json``); anything about the environment
+    (metadata, gold read/digest/validate, judging, exhausted retries, a missing
+    client, an unexpected runtime exception) is unscored and writes ONLY
+    ``reward-details.json`` -- never a bare exit, never a numeric zero, and
+    never a partial score. Error text is redacted and size-bounded before it
+    reaches any artifact. Never emits source or diffs.
     """
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -891,13 +926,32 @@ def run_verifier(
     try:
         if client is None:
             raise VerifierError("no judge client configured (missing DAYDREAM_JUDGE_*)")
-        artifact_raw = _read_artifact_bytes(artifact_path)
-        candidates = verifier_core.validate_candidate_artifact(artifact_raw)
+        try:
+            artifact_raw = _read_artifact_bytes(artifact_path)
+            candidates = verifier_core.validate_candidate_artifact(artifact_raw)
+        except VerifierError as exc:
+            # Candidate zone: reading/validating the agent's own artifact is a
+            # scored outcome -- a scored-zero reward, never an infra error.
+            errors.insert(0, _bounded_error(str(exc)))
+            return _write_scored_zero_artifact(
+                out_dir, provider, model, request_counts, errors, gold_count=0
+            )
 
         metadata = _load_verifier_metadata(Path(gold_path))
-        for field in ("case_id", "base_ref", "head_ref"):
-            if artifact_raw[field] != metadata[field]:
-                raise VerifierError(f"candidate {field} does not match the bound task")
+
+        try:
+            for field in ("case_id", "base_ref", "head_ref"):
+                if artifact_raw[field] != metadata[field]:
+                    raise VerifierError(
+                        f"candidate {field} does not match the bound task"
+                    )
+        except VerifierError as exc:
+            # Binding zone: a candidate pointing at the wrong task is still the
+            # agent's own output -- scored zero, not unscored.
+            errors.insert(0, _bounded_error(str(exc)))
+            return _write_scored_zero_artifact(
+                out_dir, provider, model, request_counts, errors, gold_count=0
+            )
 
         gold_raw = _read_gold_bytes(Path(gold_path), metadata["gold_sha256"])
         gold_parsed = verifier_core.validate_gold_set(
@@ -934,7 +988,8 @@ def run_verifier(
         )
     except Exception as exc:
         # Unexpected runtime failures must not escape to a bare exit: they
-        # become a typed bounded diagnostic that still writes both artifacts.
+        # become a typed bounded diagnostic -- infra zone, written unscored
+        # (reward-details.json only, no numeric reward).
         errors.insert(0, _bounded_error(f"unexpected verifier failure: {exc}"))
         return _write_error_artifact(
             out_dir, provider, model, request_counts, errors, len(gold_parsed)
@@ -1013,8 +1068,8 @@ def main() -> int:
 
     Provider selection is fail-closed: an unsupported ``DAYDREAM_JUDGE_PROVIDER``
     or an out-of-allowlist judge host writes a typed bounded diagnostic artifact
-    (``reward.json``/``reward-details.json``) instead of a barren ``client=None``
-    exit with no provider reason. ``DAYDREAM_JUDGE_ARTIFACT_PATH`` /
+    (``reward-details.json`` only -- infra zone, no numeric reward) instead of a
+    barren ``client=None`` exit with no provider reason. ``DAYDREAM_JUDGE_ARTIFACT_PATH`` /
     ``DAYDREAM_JUDGE_OUT_PATH`` relocate the compiled defaults for isolated
     subprocess runs; the compiled defaults ``/logs/artifacts/review.json`` and
     ``/logs/verifier`` are unchanged.

--- a/daydream/benchmark/harbor/templates/tests/score_review.py
+++ b/daydream/benchmark/harbor/templates/tests/score_review.py
@@ -1048,19 +1048,12 @@ def _emit_reward(reward: verifier_core.Reward) -> int:
     Shared by both ``main()`` terminal paths (a fail-closed client build
     rejection and the completed ``run_verifier``) so the two failure/success
     emissions cannot drift. ``Reward.to_dict()`` always exists (the compiled
-    verifier_core twin is byte-identical); the fallback dict is a defensive
-    guard that keeps the shape stable even if a duck-typed reward lacks it.
+    verifier_core twin is byte-identical), so the payload is always the full
+    12-key typed dict.
     """
-    payload = (
-        reward.to_dict()
-        if hasattr(reward, "to_dict")
-        else {
-            "verifier_error": int(getattr(reward, "verifier_error", 0)),
-            "reward": float(getattr(reward, "reward", 0.0)),
-        }
-    )
+    payload = reward.to_dict()
     print(json.dumps(payload))
-    return 1 if getattr(reward, "verifier_error", 0) else 0
+    return 1 if reward.verifier_error else 0
 
 
 def main() -> int:

--- a/daydream/benchmark/harbor/templates/tests/verifier_core.py
+++ b/daydream/benchmark/harbor/templates/tests/verifier_core.py
@@ -485,7 +485,7 @@ def _finding_id(finding: object) -> str:
 
 
 def _empty_side_error(gold_count: int) -> Reward:
-    return Reward(reward=0.0, gold_count=gold_count, verifier_error=1)
+    return Reward(reward=0.0, gold_count=gold_count, verifier_error=0)
 
 
 def score_review(
@@ -608,32 +608,37 @@ def aggregate_metrics(rows: list[dict[str, object] | None]) -> dict[str, float |
     """Aggregate per-task reward JSONL rows into pooled corpus micro metrics.
 
     TP/FP/FN are pooled across tasks (never averaged per task). A ``None`` row
-    or a row with ``verifier_error == 1`` is a failed task: it contributes
-    reward 0 to the mean, zero counts, and increments ``failed_task_count``.
-    Zero denominators evaluate to 1.0 throughout.
+    or a row with ``verifier_error == 1`` is an unscored infrastructure
+    failure: it increments ``infra_error_task_count`` and contributes nothing
+    (no reward, no tp/fp/fn, no clean counts). Scored rows (``verifier_error
+    == 0``) pool into ``scored_task_count``/``total_tp/fp/fn`` and the mean,
+    which is over scored rows only (zero scored rows -> 1.0). Zero
+    denominators evaluate to 1.0 throughout.
     """
-    failed = 0
+    infra_errors = 0
     clean_correct = 0
     clean_total = 0
-    rewards: list[float] = []
+    scored_rewards: list[float] = []
     total_tp = total_fp = total_fn = 0
 
     for row in rows:
         if row is None or row.get("verifier_error") == 1:
-            failed += 1
-            rewards.append(0.0)
+            infra_errors += 1
             continue
         total_tp += _as_int(row["tp"])
         total_fp += _as_int(row["fp"])
         total_fn += _as_int(row["fn"])
-        rewards.append(_as_float(row["reward"]))
+        scored_rewards.append(_as_float(row["reward"]))
         if row.get("clean_task") == 1:
             clean_total += 1
             if _as_int(row["fp"]) == 0:
                 clean_correct += 1
 
     task_count = len(rows)
-    mean_task_score = sum(rewards) / task_count if task_count else 1.0
+    scored_task_count = len(scored_rewards)
+    mean_task_score = (
+        sum(scored_rewards) / scored_task_count if scored_task_count else 1.0
+    )
     micro_precision = total_tp / (total_tp + total_fp) if (total_tp + total_fp) else 1.0
     micro_recall = total_tp / (total_tp + total_fn) if (total_tp + total_fn) else 1.0
     if total_tp == 0 and (total_tp + total_fp > 0 or total_tp + total_fn > 0):
@@ -649,8 +654,9 @@ def aggregate_metrics(rows: list[dict[str, object] | None]) -> dict[str, float |
         "mean_task_score": mean_task_score,
         "clean_accuracy": clean_accuracy,
         "task_count": task_count,
+        "scored_task_count": scored_task_count,
+        "infra_error_task_count": infra_errors,
         "clean_task_count": clean_total,
-        "failed_task_count": failed,
         "total_tp": total_tp,
         "total_fp": total_fp,
         "total_fn": total_fn,

--- a/daydream/benchmark/harbor/verifier_core.py
+++ b/daydream/benchmark/harbor/verifier_core.py
@@ -485,7 +485,7 @@ def _finding_id(finding: object) -> str:
 
 
 def _empty_side_error(gold_count: int) -> Reward:
-    return Reward(reward=0.0, gold_count=gold_count, verifier_error=1)
+    return Reward(reward=0.0, gold_count=gold_count, verifier_error=0)
 
 
 def score_review(
@@ -608,32 +608,37 @@ def aggregate_metrics(rows: list[dict[str, object] | None]) -> dict[str, float |
     """Aggregate per-task reward JSONL rows into pooled corpus micro metrics.
 
     TP/FP/FN are pooled across tasks (never averaged per task). A ``None`` row
-    or a row with ``verifier_error == 1`` is a failed task: it contributes
-    reward 0 to the mean, zero counts, and increments ``failed_task_count``.
-    Zero denominators evaluate to 1.0 throughout.
+    or a row with ``verifier_error == 1`` is an unscored infrastructure
+    failure: it increments ``infra_error_task_count`` and contributes nothing
+    (no reward, no tp/fp/fn, no clean counts). Scored rows (``verifier_error
+    == 0``) pool into ``scored_task_count``/``total_tp/fp/fn`` and the mean,
+    which is over scored rows only (zero scored rows -> 1.0). Zero
+    denominators evaluate to 1.0 throughout.
     """
-    failed = 0
+    infra_errors = 0
     clean_correct = 0
     clean_total = 0
-    rewards: list[float] = []
+    scored_rewards: list[float] = []
     total_tp = total_fp = total_fn = 0
 
     for row in rows:
         if row is None or row.get("verifier_error") == 1:
-            failed += 1
-            rewards.append(0.0)
+            infra_errors += 1
             continue
         total_tp += _as_int(row["tp"])
         total_fp += _as_int(row["fp"])
         total_fn += _as_int(row["fn"])
-        rewards.append(_as_float(row["reward"]))
+        scored_rewards.append(_as_float(row["reward"]))
         if row.get("clean_task") == 1:
             clean_total += 1
             if _as_int(row["fp"]) == 0:
                 clean_correct += 1
 
     task_count = len(rows)
-    mean_task_score = sum(rewards) / task_count if task_count else 1.0
+    scored_task_count = len(scored_rewards)
+    mean_task_score = (
+        sum(scored_rewards) / scored_task_count if scored_task_count else 1.0
+    )
     micro_precision = total_tp / (total_tp + total_fp) if (total_tp + total_fp) else 1.0
     micro_recall = total_tp / (total_tp + total_fn) if (total_tp + total_fn) else 1.0
     if total_tp == 0 and (total_tp + total_fp > 0 or total_tp + total_fn > 0):
@@ -649,8 +654,9 @@ def aggregate_metrics(rows: list[dict[str, object] | None]) -> dict[str, float |
         "mean_task_score": mean_task_score,
         "clean_accuracy": clean_accuracy,
         "task_count": task_count,
+        "scored_task_count": scored_task_count,
+        "infra_error_task_count": infra_errors,
         "clean_task_count": clean_total,
-        "failed_task_count": failed,
         "total_tp": total_tp,
         "total_fp": total_fp,
         "total_fn": total_fn,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import importlib.util
 import os
 import sys
 import tomllib
+import types
 from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -839,8 +840,18 @@ def sr_module() -> Any:
 
 @pytest.fixture(scope="session")
 def sr_metric() -> Any:
-    """The loaded ``templates/metric.py`` corpus aggregation entry module."""
-    return _load_template_asset(_TEMPLATES / "metric.py", "metric")
+    """The rendered ``templates/metric.py`` corpus aggregation entry module.
+
+    Execs ``build.render_metric()`` output (the compiled artifact, aggregation
+    body injected from ``verifier_core``) instead of loading the static
+    template, so tests exercise exactly what ``compile_workspace`` ships.
+    The rendered shebang / ``# /// script`` lines are comments and exec-safe.
+    """
+    from daydream.benchmark.harbor import build
+
+    mod = types.ModuleType("metric")
+    exec(compile(build.render_metric().decode("utf-8"), "metric.py", "exec"), mod.__dict__)
+    return mod
 
 
 def improve_fixture_test_command_anchor(pyproject: Path) -> int:

--- a/tests/test_benchmark_verifier_assets.py
+++ b/tests/test_benchmark_verifier_assets.py
@@ -10,12 +10,35 @@ import hashlib
 import json
 import subprocess
 from pathlib import Path
+from typing import Any
 
 REPO = Path(__file__).resolve().parents[1]
 
 
 def _sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _run_metric_subprocess(tmp_path: Path, rows: str, out: Path | None = None) -> tuple[Path, dict[str, Any]]:
+    """Compile the metric entrypoint, feed it ``rows`` JSONL, and run it via ``uv run --script``.
+
+    Keeps the subprocess contract/flag surface (``-i``/``-o``, timeout, returncode
+    assertion) in one place; returns ``(out, parsed_result)``.
+    """
+    from daydream.benchmark.harbor import build
+
+    metric_path = tmp_path / "metric.py"
+    metric_path.write_bytes(build.render_metric())
+    inp = tmp_path / "rewards.jsonl"
+    inp.write_text(rows)
+    if out is None:
+        out = tmp_path / "metric.json"
+    proc = subprocess.run(
+        ["uv", "run", "--script", str(metric_path), "-i", str(inp), "-o", str(out)],
+        capture_output=True, text=True, timeout=120,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return out, json.loads(out.read_text())
 
 
 def test_verifier_core_template_is_byte_identical_to_source() -> None:
@@ -82,23 +105,13 @@ def test_metric_entry_aggregates_as_identically_to_verifier_core(sr_metric, tmp_
 
 
 def test_metric_subprocess_runs_with_harbor_args_and_writes_output(tmp_path) -> None:
-    from daydream.benchmark.harbor import build
-
-    metric_path = tmp_path / "metric.py"
-    metric_path.write_bytes(build.render_metric())
-    inp = tmp_path / "rewards.jsonl"
-    inp.write_text(
+    out, result = _run_metric_subprocess(
+        tmp_path,
         '{"reward":0.8,"tp":2,"fp":0,"fn":1}\n'
         'null\n'
-        '{"reward":1.0,"tp":0,"fp":0,"fn":0,"clean_task":1}\n'
+        '{"reward":1.0,"tp":0,"fp":0,"fn":0,"clean_task":1}\n',
+        out=tmp_path / "out" / "metric.json",
     )
-    out = tmp_path / "out" / "metric.json"
-    proc = subprocess.run(
-        ["uv", "run", "--script", str(metric_path), "-i", str(inp), "-o", str(out)],
-        capture_output=True, text=True, timeout=120,
-    )
-    assert proc.returncode == 0, proc.stderr
-    result = json.loads(out.read_text())
     assert result["task_count"] == 3  # attempted = all rows (stable across old/new aggregation)
     # atomic write leaves no temp leftover: metric.py names its temp
     # ".{out.name}.{pid}.tmp", so glob the pid-suffixed pattern the write
@@ -107,23 +120,13 @@ def test_metric_subprocess_runs_with_harbor_args_and_writes_output(tmp_path) -> 
 
 
 def test_metric_subprocess_unscored_rows_not_turned_into_zeros(tmp_path) -> None:
-    from daydream.benchmark.harbor import build
-
-    metric_path = tmp_path / "metric.py"
-    metric_path.write_bytes(build.render_metric())
-    inp = tmp_path / "rewards.jsonl"
-    inp.write_text(
+    _, m = _run_metric_subprocess(
+        tmp_path,
         '{"reward":0.8,"tp":2,"fp":0,"fn":1}\n'
         'null\n'
         '{"reward":1.0,"tp":0,"fp":0,"fn":0,"clean_task":1}\n'
-        '{"reward":0.0,"tp":0,"fp":5,"fn":5,"verifier_error":1}\n')
-    out = tmp_path / "metric.json"
-    proc = subprocess.run(
-        ["uv", "run", "--script", str(metric_path), "-i", str(inp), "-o", str(out)],
-        capture_output=True, text=True, timeout=120,
+        '{"reward":0.0,"tp":0,"fp":5,"fn":5,"verifier_error":1}\n',
     )
-    assert proc.returncode == 0, proc.stderr
-    m = json.loads(out.read_text())
     assert m["task_count"] == 4
     assert m["scored_task_count"] == 2 and m["infra_error_task_count"] == 2
     assert (m["total_tp"], m["total_fp"], m["total_fn"]) == (2, 0, 1)  # unscored rows contribute nothing

--- a/tests/test_benchmark_verifier_assets.py
+++ b/tests/test_benchmark_verifier_assets.py
@@ -8,6 +8,7 @@ fail loudly. ``templates/metric.py``'s inlined aggregation must equal
 
 import hashlib
 import json
+import subprocess
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
@@ -77,3 +78,25 @@ def test_metric_entry_aggregates_as_identically_to_verifier_core(sr_metric, tmp_
     assert result == expected  # same aggregation contract on the same rows
     assert result["failed_task_count"] == 1 and result["task_count"] == 3
     assert result["mean_task_score"] == (0.8 + 0.0 + 1.0) / 3
+
+
+def test_metric_subprocess_runs_with_harbor_args_and_writes_output(tmp_path) -> None:
+    from daydream.benchmark.harbor import build
+
+    metric_path = tmp_path / "metric.py"
+    metric_path.write_bytes(build.render_metric())
+    inp = tmp_path / "rewards.jsonl"
+    inp.write_text(
+        '{"reward":0.8,"tp":2,"fp":0,"fn":1}\n'
+        'null\n'
+        '{"reward":1.0,"tp":0,"fp":0,"fn":0,"clean_task":1}\n'
+    )
+    out = tmp_path / "out" / "metric.json"
+    proc = subprocess.run(
+        ["uv", "run", "--script", str(metric_path), "-i", str(inp), "-o", str(out)],
+        capture_output=True, text=True, timeout=120,
+    )
+    assert proc.returncode == 0, proc.stderr
+    result = json.loads(out.read_text())
+    assert result["task_count"] == 3  # attempted = all rows (stable across old/new aggregation)
+    assert not (out.parent / ".metric.json.tmp").exists()  # atomic write leaves no temp leftover

--- a/tests/test_benchmark_verifier_assets.py
+++ b/tests/test_benchmark_verifier_assets.py
@@ -100,7 +100,10 @@ def test_metric_subprocess_runs_with_harbor_args_and_writes_output(tmp_path) -> 
     assert proc.returncode == 0, proc.stderr
     result = json.loads(out.read_text())
     assert result["task_count"] == 3  # attempted = all rows (stable across old/new aggregation)
-    assert not (out.parent / ".metric.json.tmp").exists()  # atomic write leaves no temp leftover
+    # atomic write leaves no temp leftover: metric.py names its temp
+    # ".{out.name}.{pid}.tmp", so glob the pid-suffixed pattern the write
+    # actually uses (the old ".metric.json.tmp" literal could never match).
+    assert not list(out.parent.glob(f".{out.name}.*.tmp"))
 
 
 def test_metric_subprocess_unscored_rows_not_turned_into_zeros(tmp_path) -> None:
@@ -126,3 +129,23 @@ def test_metric_subprocess_unscored_rows_not_turned_into_zeros(tmp_path) -> None
     assert (m["total_tp"], m["total_fp"], m["total_fn"]) == (2, 0, 1)  # unscored rows contribute nothing
     assert abs(m["mean_task_score"] - 0.9) < 1e-9                       # (0.8+1.0)/2, never over 4
     assert m["micro_precision"] == 1.0 and m["micro_recall"] == 2.0 / 3.0
+
+
+def test_metric_helper_functions_cannot_drift_from_verifier_core() -> None:
+    """The metric.py template's helper functions must stay byte-identical to verifier_core.
+
+    ``render_metric()`` splices only ``aggregate_metrics`` into the compiled
+    metric; the ``_as_int/_as_float/_f1`` helpers it resolves at runtime are the
+    template-local copies. They must not drift from the in-repo verifier_core
+    copies (which the corpus pool uses), or the compiled metric and the pool
+    would disagree on row coercion / f1. This gate makes any drift fail loudly
+    instead of silently diverging.
+    """
+    import inspect
+
+    from daydream.benchmark.harbor import verifier_core as vc
+
+    tmpl = (REPO / "daydream" / "benchmark" / "harbor" / "templates" / "metric.py").read_text(encoding="utf-8")
+    for name in ("_as_int", "_as_float", "_f1"):
+        src = inspect.getsource(getattr(vc, name))
+        assert src in tmpl, f"metric.py template's {name} drifted from verifier_core.py"

--- a/tests/test_benchmark_verifier_assets.py
+++ b/tests/test_benchmark_verifier_assets.py
@@ -75,9 +75,10 @@ def test_metric_entry_aggregates_as_identically_to_verifier_core(sr_metric, tmp_
     expected = vc.aggregate_metrics(rows)
 
     result = sr_metric.aggregate_rewards_file(str(lp))
-    assert result == expected  # same aggregation contract on the same rows
-    assert result["failed_task_count"] == 1 and result["task_count"] == 3
-    assert result["mean_task_score"] == (0.8 + 0.0 + 1.0) / 3
+    assert result == expected                          # same aggregation contract
+    assert result["task_count"] == 3 and result["scored_task_count"] == 2
+    assert result["infra_error_task_count"] == 1 and "failed_task_count" not in result
+    assert result["mean_task_score"] == (0.8 + 1.0) / 2
 
 
 def test_metric_subprocess_runs_with_harbor_args_and_writes_output(tmp_path) -> None:

--- a/tests/test_benchmark_verifier_assets.py
+++ b/tests/test_benchmark_verifier_assets.py
@@ -101,3 +101,28 @@ def test_metric_subprocess_runs_with_harbor_args_and_writes_output(tmp_path) -> 
     result = json.loads(out.read_text())
     assert result["task_count"] == 3  # attempted = all rows (stable across old/new aggregation)
     assert not (out.parent / ".metric.json.tmp").exists()  # atomic write leaves no temp leftover
+
+
+def test_metric_subprocess_unscored_rows_not_turned_into_zeros(tmp_path) -> None:
+    from daydream.benchmark.harbor import build
+
+    metric_path = tmp_path / "metric.py"
+    metric_path.write_bytes(build.render_metric())
+    inp = tmp_path / "rewards.jsonl"
+    inp.write_text(
+        '{"reward":0.8,"tp":2,"fp":0,"fn":1}\n'
+        'null\n'
+        '{"reward":1.0,"tp":0,"fp":0,"fn":0,"clean_task":1}\n'
+        '{"reward":0.0,"tp":0,"fp":5,"fn":5,"verifier_error":1}\n')
+    out = tmp_path / "metric.json"
+    proc = subprocess.run(
+        ["uv", "run", "--script", str(metric_path), "-i", str(inp), "-o", str(out)],
+        capture_output=True, text=True, timeout=120,
+    )
+    assert proc.returncode == 0, proc.stderr
+    m = json.loads(out.read_text())
+    assert m["task_count"] == 4
+    assert m["scored_task_count"] == 2 and m["infra_error_task_count"] == 2
+    assert (m["total_tp"], m["total_fp"], m["total_fn"]) == (2, 0, 1)  # unscored rows contribute nothing
+    assert abs(m["mean_task_score"] - 0.9) < 1e-9                       # (0.8+1.0)/2, never over 4
+    assert m["micro_precision"] == 1.0 and m["micro_recall"] == 2.0 / 3.0

--- a/tests/test_benchmark_verifier_core.py
+++ b/tests/test_benchmark_verifier_core.py
@@ -356,11 +356,11 @@ def test_score_f1_example():
     assert abs(r.f1 - 0.8) < 1e-9 and abs(r.reward - 0.8) < 1e-9
 
 
-def test_score_malformed_artifact_is_verifier_error():
+def test_score_malformed_artifact_is_scored_zero():
     art = {"schema_version": 1, "case_id": "c", "base_ref": "b", "head_ref": "h",
            "findings": [{"candidate_id": "not-hex"}]}
     r = score_review([], art, [])
-    assert r.reward == 0.0 and r.verifier_error == 1
+    assert r.reward == 0.0 and r.verifier_error == 0   # invalid agent output is scored zero
 
 def test_empty_side_resolves_with_zero_verdicts():
     # clean/0 and N/0 both resolve deterministically with an EMPTY verdict set

--- a/tests/test_benchmark_verifier_judge.py
+++ b/tests/test_benchmark_verifier_judge.py
@@ -488,7 +488,7 @@ def test_main_reads_only_tests_and_logs_artifact_paths(sr_module, tmp_path, monk
         seen["gold"] = str(gold_path)
         seen["artifact"] = str(artifact_path)
         seen["out"] = str(out_dir)
-        return type("R", (), {"verifier_error": 0, "reward": 1.0})()
+        return sr.verifier_core.Reward(reward=1.0, verifier_error=0)
 
     monkeypatch.setattr(sr, "run_verifier", fake_run_verifier)
     # guard the env overrides: main() reads them from real os.environ and the
@@ -1251,6 +1251,15 @@ async def test_both_providers_share_identical_hardened_error_and_redirect_policy
         with pytest.raises(sr.VerifierError) as e:
             await client.complete_json(user="u")
         assert "allowlist" in str(e.value)
+
+
+def test_emit_reward_emits_full_reward_dict_and_exit_code(sr_module, capsys) -> None:
+    sr = sr_module
+    r = sr.verifier_core.Reward(reward=0.8, tp=2, verifier_error=0)
+    assert sr._emit_reward(r) == 0
+    assert json.loads(capsys.readouterr().out) == r.to_dict()   # full 12-key dict, never the 2-key fallback shape
+    r2 = sr.verifier_core.Reward(reward=0.0, verifier_error=1)
+    assert sr._emit_reward(r2) == 1
 
 
 def test_run_verifier_without_client_is_unscored(sr_module, tmp_path) -> None:

--- a/tests/test_benchmark_verifier_judge.py
+++ b/tests/test_benchmark_verifier_judge.py
@@ -454,8 +454,9 @@ def test_judge_failure_fails_whole_task_not_partial_score(sr_module, tmp_path) -
         },
     )
     assert reward.verifier_error == 1 and reward.reward == 0.0
-    rj = json.loads((out_dir / "reward.json").read_text())
-    assert rj["verifier_error"] == 1 and rj["reward"] == 0
+    assert not (out_dir / "reward.json").exists()                 # NO numeric reward on any infra path
+    details = json.loads((out_dir / "reward-details.json").read_text())
+    assert len(details["errors"]) >= 1                            # bounded diagnostic written
 
 
 def test_provider_selection_builds_expected_client(sr_module, monkeypatch) -> None:
@@ -815,9 +816,12 @@ def test_oversized_body_fails_whole_task_with_no_judge_call(sr_module, tmp_path)
     env = {"DAYDREAM_JUDGE_PROVIDER": "anthropic", "DAYDREAM_JUDGE_MODEL": "m",
            "DAYDREAM_JUDGE_API_KEY": "k", "DAYDREAM_JUDGE_BASE_URL": None}
     reward = sr.run_verifier(gold_path, art_path, out, client=client, env=env)
-    assert reward.verifier_error == 1 and reward.reward == 0.0
+    assert reward.verifier_error == 0 and reward.reward == 0.0   # scored, not infra
+    rj = json.loads((out / "reward.json").read_text())
+    assert rj["verifier_error"] == 0 and rj["reward"] == 0        # reward.json IS present, verifier_error 0
     assert client.requests == 0  # no judge call
     details = json.loads((out / "reward-details.json").read_text())
+    assert len(details["errors"]) >= 1                            # bounded diagnostic still written
     assert details["request_counts"]["requests"] == 0
     blob = json.dumps(details)
     assert oversized_body not in blob and ("t" * 500) not in blob and ("p" * 200) not in blob
@@ -871,7 +875,11 @@ def test_run_verifier_rejects_whitespace_padded_over_one_mib(sr_module, tmp_path
     env = {"DAYDREAM_JUDGE_PROVIDER": "anthropic", "DAYDREAM_JUDGE_MODEL": "m",
            "DAYDREAM_JUDGE_API_KEY": "k", "DAYDREAM_JUDGE_BASE_URL": None}
     reward = sr.run_verifier(gold_path, artifact_path, out, client=client, env=env)
-    assert reward.verifier_error == 1 and reward.reward == 0.0
+    assert reward.verifier_error == 0 and reward.reward == 0.0   # scored, not infra
+    rj = json.loads((out / "reward.json").read_text())
+    assert rj["verifier_error"] == 0 and rj["reward"] == 0        # reward.json IS present, verifier_error 0
+    details = json.loads((out / "reward-details.json").read_text())
+    assert len(details["errors"]) >= 1                            # bounded diagnostic still written
 
 
 
@@ -909,7 +917,11 @@ def test_run_verifier_rejects_cross_case_replay(sr_module, tmp_path) -> None:
     env = {"DAYDREAM_JUDGE_PROVIDER": "anthropic", "DAYDREAM_JUDGE_MODEL": "m",
            "DAYDREAM_JUDGE_API_KEY": "k", "DAYDREAM_JUDGE_BASE_URL": None}
     reward = sr.run_verifier(gold_path, artifact_path, out, client=client, env=env)
-    assert reward.verifier_error == 1 and reward.reward == 0.0
+    assert reward.verifier_error == 0 and reward.reward == 0.0   # scored, not infra
+    rj = json.loads((out / "reward.json").read_text())
+    assert rj["verifier_error"] == 0 and rj["reward"] == 0        # reward.json IS present, verifier_error 0
+    details = json.loads((out / "reward-details.json").read_text())
+    assert len(details["errors"]) >= 1                            # bounded diagnostic still written
 
 
 def test_run_verifier_rejects_ref_mismatch(sr_module, tmp_path) -> None:
@@ -926,7 +938,11 @@ def test_run_verifier_rejects_ref_mismatch(sr_module, tmp_path) -> None:
     env = {"DAYDREAM_JUDGE_PROVIDER": "anthropic", "DAYDREAM_JUDGE_MODEL": "m",
            "DAYDREAM_JUDGE_API_KEY": "k", "DAYDREAM_JUDGE_BASE_URL": None}
     reward = sr.run_verifier(gold_path, artifact_path, out, client=client, env=env)
-    assert reward.verifier_error == 1 and reward.reward == 0.0
+    assert reward.verifier_error == 0 and reward.reward == 0.0   # scored, not infra
+    rj = json.loads((out / "reward.json").read_text())
+    assert rj["verifier_error"] == 0 and rj["reward"] == 0        # reward.json IS present, verifier_error 0
+    details = json.loads((out / "reward-details.json").read_text())
+    assert len(details["errors"]) >= 1                            # bounded diagnostic still written
 
 
 def test_run_verifier_rejects_single_byte_gold_corruption(sr_module, tmp_path) -> None:
@@ -947,6 +963,9 @@ def test_run_verifier_rejects_single_byte_gold_corruption(sr_module, tmp_path) -
            "DAYDREAM_JUDGE_API_KEY": "k", "DAYDREAM_JUDGE_BASE_URL": None}
     reward = sr.run_verifier(gold_path, artifact_path, out, client=client, env=env)
     assert reward.verifier_error == 1 and reward.reward == 0.0
+    assert not (out / "reward.json").exists()                     # NO numeric reward on any infra path
+    details = json.loads((out / "reward-details.json").read_text())
+    assert len(details["errors"]) >= 1                            # bounded diagnostic written
 
 
 
@@ -1166,9 +1185,9 @@ def test_arbitrary_runtime_failure_writes_bounded_diagnostics(sr_module, tmp_pat
     reward = sr.run_verifier(gold_path, art_path, out, client=Exploding(), env=env)
     # unexpected runtime exception no longer escapes to a bare exit
     assert reward.verifier_error == 1 and reward.reward == 0.0
-    rj = json.loads((out / "reward.json").read_text())
-    assert rj["verifier_error"] == 1 and rj["reward"] == 0
+    assert not (out / "reward.json").exists()                     # NO numeric reward on any infra path
     details = json.loads((out / "reward-details.json").read_text())
+    assert len(details["errors"]) >= 1                            # bounded diagnostic written
     blob = json.dumps(details)
     assert "sk-ant-leakme123" not in blob and "<redacted>" in blob   # no credential, redacted
     assert len(details["errors"]) >= 1 and any("unexpected" in e for e in details["errors"])
@@ -1186,9 +1205,9 @@ def test_main_fail_closed_on_bad_provider_and_reads_path_overrides(sr_module, tm
         _candidate_artifact(sr, case_id="c", n=0)))
     rc = sr.main()
     assert rc == 1  # verifier_error
-    rj = json.loads((out / "reward.json").read_text())
-    assert rj["verifier_error"] == 1 and rj["reward"] == 0
+    assert not (out / "reward.json").exists()                     # NO numeric reward on any infra path
     details = json.loads((out / "reward-details.json").read_text())
+    assert len(details["errors"]) >= 1                            # bounded diagnostic written
     assert any("unsupported" in e or "expected anthropic or openai-compatible" in e
                for e in details["errors"])  # typed diagnostic surfaced, not a barren client=None exit
 
@@ -1232,3 +1251,58 @@ async def test_both_providers_share_identical_hardened_error_and_redirect_policy
         with pytest.raises(sr.VerifierError) as e:
             await client.complete_json(user="u")
         assert "allowlist" in str(e.value)
+
+
+def test_run_verifier_without_client_is_unscored(sr_module, tmp_path) -> None:
+    sr = sr_module
+    gold_path = tmp_path / "golden-review.json"
+    gold_path.write_text(json.dumps(_gold_list(1)))
+    _write_metadata(gold_path)
+    artifact_path = tmp_path / "review.json"
+    artifact_path.write_text(json.dumps(_candidate_artifact(sr, n=1)))
+    out = tmp_path / "out"
+    reward = sr.run_verifier(gold_path, artifact_path, out, client=None,
+        env={"DAYDREAM_JUDGE_PROVIDER": "anthropic", "DAYDREAM_JUDGE_MODEL": "m",
+             "DAYDREAM_JUDGE_API_KEY": "k", "DAYDREAM_JUDGE_BASE_URL": None})
+    assert reward.verifier_error == 1
+    assert not (out / "reward.json").exists()
+    details = json.loads((out / "reward-details.json").read_text())
+    assert any("no judge client" in e for e in details["errors"])
+
+
+def test_run_verifier_missing_gold_file_is_unscored(sr_module, tmp_path) -> None:
+    sr = sr_module
+    gold_path = tmp_path / "golden-review.json"
+    gold_path.write_text(json.dumps(_gold_list(1)))
+    _write_metadata(gold_path)
+    gold_path.unlink()                                    # metadata present, gold missing
+    artifact_path = tmp_path / "review.json"
+    artifact_path.write_text(json.dumps(_candidate_artifact(sr, n=1)))
+    out = tmp_path / "out"
+    reward = sr.run_verifier(gold_path, artifact_path, out, client=_CountingClient(),
+        env={"DAYDREAM_JUDGE_PROVIDER": "anthropic", "DAYDREAM_JUDGE_MODEL": "m",
+             "DAYDREAM_JUDGE_API_KEY": "k", "DAYDREAM_JUDGE_BASE_URL": None})
+    assert reward.verifier_error == 1
+    assert not (out / "reward.json").exists()
+    details = json.loads((out / "reward-details.json").read_text())
+    assert any("not found" in e for e in details["errors"])
+
+
+def test_run_verifier_malformed_judge_output_is_unscored(sr_module, tmp_path) -> None:
+    sr = sr_module
+    gold_path = tmp_path / "golden-review.json"
+    gold_path.write_text(json.dumps(_gold_list(1)))
+    _write_metadata(gold_path)
+    artifact_path = tmp_path / "review.json"
+    artifact_path.write_text(json.dumps(_candidate_artifact(sr, n=1)))
+    out = tmp_path / "out"
+    class BadJudge:
+        async def complete_json(self, *, user, system, max_tokens):
+            return {"match": True, "confidence": 0.0}    # missing reasoning -> parse VerifierError
+    reward = sr.run_verifier(gold_path, artifact_path, out, client=BadJudge(),
+        env={"DAYDREAM_JUDGE_PROVIDER": "anthropic", "DAYDREAM_JUDGE_MODEL": "m",
+             "DAYDREAM_JUDGE_API_KEY": "k", "DAYDREAM_JUDGE_BASE_URL": None})
+    assert reward.verifier_error == 1
+    assert not (out / "reward.json").exists()
+    details = json.loads((out / "reward-details.json").read_text())
+    assert len(details["errors"]) >= 1

--- a/tests/test_benchmark_verifier_judge.py
+++ b/tests/test_benchmark_verifier_judge.py
@@ -1297,6 +1297,33 @@ def test_run_verifier_missing_gold_file_is_unscored(sr_module, tmp_path) -> None
     assert any("not found" in e for e in details["errors"])
 
 
+def test_run_verifier_missing_artifact_file_is_unscored_infra(sr_module, tmp_path) -> None:
+    """A missing candidate-artifact file is infra, not a scored-zero agent failure.
+
+    The FileNotFoundError branch is routed to the unscored infra zone
+    (reward-details only, verifier_error=1) so an infra path misconfiguration
+    (wrong DAYDREAM_JUDGE_ARTIFACT_PATH, missing mount) never drags down the
+    mean with no infra_error_task_count signal. This pins finding #820's
+    file-absent vs file-invalid distinction.
+    """
+    sr = sr_module
+    gold_path = tmp_path / "golden-review.json"
+    gold_path.write_text(json.dumps(_gold_list(1)))
+    _write_metadata(gold_path)
+    artifact_path = tmp_path / "review.json"
+    artifact_path.write_text(json.dumps(_candidate_artifact(sr, n=1)))
+    artifact_path.unlink()                                 # artifact missing
+    out = tmp_path / "out"
+    reward = sr.run_verifier(gold_path, artifact_path, out, client=_CountingClient(),
+        env={"DAYDREAM_JUDGE_PROVIDER": "anthropic", "DAYDREAM_JUDGE_MODEL": "m",
+             "DAYDREAM_JUDGE_API_KEY": "k", "DAYDREAM_JUDGE_BASE_URL": None})
+    assert reward.verifier_error == 1
+    assert reward.reward == 0.0
+    assert not (out / "reward.json").exists()              # unscored: no numeric reward
+    details = json.loads((out / "reward-details.json").read_text())
+    assert any("not found" in e for e in details["errors"])
+
+
 def test_run_verifier_malformed_judge_output_is_unscored(sr_module, tmp_path) -> None:
     sr = sr_module
     gold_path = tmp_path / "golden-review.json"

--- a/tests/test_benchmark_verifier_metrics.py
+++ b/tests/test_benchmark_verifier_metrics.py
@@ -42,8 +42,23 @@ def test_mean_task_score_and_counts():
     rows = [_row(1.0, 3, 0, 0), _row(0.5, 1, 1, 1), None, _row(0.0, 0, 0, 0, verifier_error=1)]
     m = aggregate_metrics(rows)
     assert m["task_count"] == 4
-    assert m["failed_task_count"] == 2  # None + verifier_error
-    assert abs(m["mean_task_score"] - (1.0 + 0.5 + 0.0 + 0.0) / 4) < 1e-9
+    assert m["scored_task_count"] == 2
+    assert m["infra_error_task_count"] == 2           # None + verifier_error==1
+    assert "failed_task_count" not in m               # removed
+    assert abs(m["mean_task_score"] - (1.0 + 0.5) / 2) < 1e-9   # mean over scored only
+
+
+def test_unscored_rows_excluded_from_micro_and_mean():
+    rows = [_row(1.0, 3, 0, 0), None, _row(0.0, 0, 5, 5, verifier_error=1)]
+    m = aggregate_metrics(rows)
+    assert (m["total_tp"], m["total_fp"], m["total_fn"]) == (3, 0, 0)  # unscored contribute nothing
+    assert abs(m["mean_task_score"] - 1.0) < 1e-9                     # scored-only mean
+    assert m["scored_task_count"] == 1 and m["infra_error_task_count"] == 2
+
+
+def test_mean_task_score_is_one_when_zero_scored():
+    m = aggregate_metrics([None, None])
+    assert m["mean_task_score"] == 1.0 and m["scored_task_count"] == 0 and m["infra_error_task_count"] == 2
 
 def test_clean_accuracy_counts_only_clean_tasks():
     rows = [


### PR DESCRIPTION
## Summary
Fixes #820

Makes verifier failures and metrics Harbor-native per the canonical plan (`docs/plans/2026-08-21-private-pr-harbor-benchmarks.md`).

- Separates invalid agent output (scored) from verifier/judge/infrastructure failure (unscored).
- Routes unreadable candidate-artifact reads (EACCES/EISDIR/ENOTDIR) and other non-FileNotFound OSErrors to the unscored infra zone via a unified `_infra_error_reward` helper.
- Missing/corrupt hidden inputs, digest mismatch, judge credential/endpoint/timeout/retry failures, malformed judge output, and verifier bugs: atomically write bounded `reward-details.json`, omit `reward.json`, exit nonzero, leaving Harbor to record an unscored verifier failure.
- Dedupes the `_write_error_artifact` double-write of `reward-details.json`.
- `metric.py` implements Harbor's `uv run metric.py -i <rewards.jsonl> -o <metric.json>` interface (Harbor `-i`/`-o` CLI), and unscored infra rows are excluded from the compiled metric.
- Derives aggregation from `verifier_core`; treats infra failures as unscored in corpus aggregation.

## Review
Two sequential daydream deep-precision reviews on fresh VMs (round-2 branch tip `215abf4`), all 7 findings from round 2 fixed and pushed.

## Test Plan
- `make check` green: lockcheck + ruff + mypy (378 files) + pytest (4289 passed, 7 skipped, 0 errors).

Closes #820