### PR TITLE
fix(benchmark): reconcile and fully paginate review-thread evidence

### DIFF
--- a/daydream/benchmark/__init__.py
+++ b/daydream/benchmark/__init__.py
@@ -14,8 +14,10 @@ consumers and future issues.
 from daydream.benchmark.config import BenchConfig
 from daydream.benchmark.curation import (  # noqa: F401 - stable service surface
     CurationError,
+    StaleStateError,
     accept_candidate,
     add_finding,
+    add_findings,
     apply_gold_fragment,
     attest_clean,
     exclude_case,
@@ -56,6 +58,7 @@ __all__ = [
     "BenchConfig",
     "BenchmarkManifest",
     "CurationError",
+    "StaleStateError",
     "Candidate",
     "CaseDocument",
     "CaseIndexEntry",
@@ -75,6 +78,7 @@ __all__ = [
     "run_import_prs",
     "accept_candidate",
     "add_finding",
+    "add_findings",
     "apply_gold_fragment",
     "attest_clean",
     "exclude_case",

--- a/daydream/benchmark/curation.py
+++ b/daydream/benchmark/curation.py
@@ -8,9 +8,9 @@ through. Every mutating operation (``accept_candidate``, ``add_finding``,
 runs its complete read -> validate -> mutate -> commit sequence under the
 workspace lock:
 
-1. acquires the blocking :class:`storage.WorkspaceLock` (per-thread reentrant per
-   root, so concurrent curators — threads or separate processes — serialize and
-   can never silently lose an update),
+1. acquires the blocking :class:`storage.WorkspaceLock` (process-reentrant per
+   root), so concurrent curators/processes serialize and can never silently
+   lose an update,
 2. heals any prior interrupted journal via :func:`storage.recover_startup`
    under the lock, so a crashed earlier process's leftover ``committing``
    journal is rolled back before a new write,

--- a/daydream/benchmark/curation.py
+++ b/daydream/benchmark/curation.py
@@ -2,19 +2,34 @@
 
 This module is the issue-#5 browser/terminal seam: the fixed operation set a
 curator (or the future interactive client) drives every gold-curation action
-through. Every mutating operation:
+through. Every mutating operation (``accept_candidate``, ``add_finding``,
+``add_findings``, ``replace_findings``, ``exclude_evidence``, ``mark_ready``,
+``attest_clean``, ``exclude_case``, ``reinclude_case``, ``apply_gold_fragment``)
+runs its complete read -> validate -> mutate -> commit sequence under the
+workspace lock:
 
-1. loads the target case YAML strictly,
-2. derives ``finding_id`` / ``provenance.kind`` / ``gold_status`` /
-   ``gold_mode`` / ``state`` — never caller-supplied,
-3. enforces state transitions via :meth:`schema.validate_case_transition`,
-4. re-validates the whole resulting :class:`schema.CaseDocument` plus
+1. acquires the blocking :class:`storage.WorkspaceLock` (process-reentrant per
+   root), so concurrent curators/processes serialize and can never silently
+   lose an update,
+2. heals any prior interrupted journal via :func:`storage.recover_startup`
+   under the lock, so a crashed earlier process's leftover ``committing``
+   journal is rolled back before a new write,
+3. loads the target case YAML strictly **after** acquiring the lock — never a
+   stale pre-lock view,
+4. derives ``finding_id`` / ``provenance.kind`` / ``gold_status`` /
+   ``gold_mode`` / ``state`` — never caller-supplied — and enforces state
+   transitions via :meth:`schema.validate_case_transition`,
+5. re-validates the whole resulting :class:`schema.CaseDocument` plus
    curation-service rules (location-vs-head from the shared bare mirror,
    >50 gold cap, duplicate canonical finding, historical byte-match,
    exclusion/re-inclusion contract),
-5. stages the rewritten case through the existing
+6. stages the rewritten case through the existing
    :class:`storage.Transaction` journal, or raises :class:`CurationError`
    naming the violated invariant **before** opening the Transaction.
+
+Read-only paths (``list_cases``, ``get_case``, ``validate_case``, the pager)
+take no lock and never mutate, so status/pager stay safe to run concurrently
+with a writer and no nested-lock deadlock is possible.
 
 The service imports no Rich/input/editor/HTTP code; it depends only on the
 fixed schema, the mode-safe storage/journal layer, the bare mirror, and
@@ -23,7 +38,7 @@ fixed schema, the mode-safe storage/journal layer, the bare mirror, and
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Callable, cast
 
 import yaml
 from pydantic import ValidationError
@@ -40,6 +55,16 @@ class CurationError(Exception):
     def __init__(self, message: str):
         super().__init__(message)
         self.message = message
+
+
+class StaleStateError(CurationError):
+    """A curation operation ran against a stale attestation state.
+
+    Raised when a mutation's precondition no longer holds against the freshly
+    read on-disk state (e.g. a :func:`mark_ready` head SHA that no longer
+    matches the snapshot) — the caller's view is stale and nothing was
+    written.
+    """
 
 
 def _head_file_line_count(root: Path, head_sha: str, path: str) -> int:
@@ -71,6 +96,27 @@ def _load_case(root: Path, case_id: str) -> dict[str, Any]:
     if not path.exists():
         raise CurationError(f"unknown case {case_id}")
     return load_yaml_strict(path)
+
+
+def _with_case_lock(
+    root: Path, case_id: str, op: str, mutate: Callable[[dict[str, Any]], None]
+) -> None:
+    """Run one curation mutation's whole read-validate-mutate-commit under the lock.
+
+    Acquires the blocking :class:`storage.WorkspaceLock`, heals any prior
+    interrupted journal via :func:`storage.recover_startup` (so a crashed
+    earlier process's leftover ``committing`` journal is rolled back before a
+    new write), loads the case **after** acquiring the lock (never a stale
+    pre-lock view), runs ``mutate(raw)``, then stages the atomic rewrite
+    through :class:`storage.Transaction`. ``mutate`` is called only with the
+    lock held; its ``CurationError`` propagates and leaves the disk
+    byte-unchanged.
+    """
+    with storage.WorkspaceLock(root):
+        storage.recover_startup(root)
+        raw = _load_case(root, case_id)
+        mutate(raw)
+        _stage_case(root, case_id, raw, op=op)
 
 
 def _changed_file_stats(root: Path, case_id: str, snapshot_doc: dict[str, Any]) -> tuple[int, int]:
@@ -350,29 +396,31 @@ def accept_candidate(root: Path, case_id: str, source_id: str) -> None:
     candidate projection, ``provenance.kind`` is ``historical`` (the only path
     that produces it), and ``finding_id`` is derived from the content.
     """
-    raw = _load_case(root, case_id)
-    candidate = next(
-        (c for c in (raw.get("candidates") or []) if c.get("source_id") == source_id),
-        None,
-    )
-    if candidate is None:
-        raise CurationError(f"no candidate {source_id} in case {case_id}")
-    if not candidate.get("exact_acceptable"):
-        raise CurationError(f"candidate {source_id} is not exact_acceptable")
 
-    curation = raw.setdefault("curation", {})
-    _reopen_for_mutation(curation)
-    finding = {
-        "title": candidate["title"],
-        "body": candidate["body"],
-        "severity": candidate.get("severity"),
-        "location": candidate.get("location"),
-        "provenance": {"kind": "historical", "source_ids": [source_id]},
-    }
-    finding["finding_id"] = schema.derive_finding_id(finding, case_id=case_id)
-    raw.setdefault("curation", {}).setdefault("findings", []).append(finding)
-    _derive_content(raw)
-    _stage_case(root, case_id, raw, op="accept")
+    def mutate(raw: dict[str, Any]) -> None:
+        candidate = next(
+            (c for c in (raw.get("candidates") or []) if c.get("source_id") == source_id),
+            None,
+        )
+        if candidate is None:
+            raise CurationError(f"no candidate {source_id} in case {case_id}")
+        if not candidate.get("exact_acceptable"):
+            raise CurationError(f"candidate {source_id} is not exact_acceptable")
+
+        curation = raw.setdefault("curation", {})
+        _reopen_for_mutation(curation)
+        finding = {
+            "title": candidate["title"],
+            "body": candidate["body"],
+            "severity": candidate.get("severity"),
+            "location": candidate.get("location"),
+            "provenance": {"kind": "historical", "source_ids": [source_id]},
+        }
+        finding["finding_id"] = schema.derive_finding_id(finding, case_id=case_id)
+        raw.setdefault("curation", {}).setdefault("findings", []).append(finding)
+        _derive_content(raw)
+
+    _with_case_lock(root, case_id, "accept", mutate)
 
 
 def _derive_provenance_kind(
@@ -413,24 +461,26 @@ def add_finding(
 ) -> None:
     """Add an authored (new) finding. provenance is ``authored`` with empty sources."""
     source_ids = source_ids or []
-    raw = _load_case(root, case_id)
-    _check_candidate_sources(raw, source_ids, case_id)
-    curation = raw.setdefault("curation", {})
-    _reopen_for_mutation(curation)
-    finding = {
-        "title": title,
-        "body": body,
-        "severity": severity,
-        "location": location,
-        "provenance": {
-            "kind": _derive_provenance_kind(source_ids, authored=True),
-            "source_ids": source_ids,
-        },
-    }
-    finding["finding_id"] = schema.derive_finding_id(finding, case_id=case_id)
-    raw.setdefault("curation", {}).setdefault("findings", []).append(finding)
-    _derive_content(raw)
-    _stage_case(root, case_id, raw, op="add")
+
+    def mutate(raw: dict[str, Any]) -> None:
+        _check_candidate_sources(raw, source_ids, case_id)
+        curation = raw.setdefault("curation", {})
+        _reopen_for_mutation(curation)
+        finding = {
+            "title": title,
+            "body": body,
+            "severity": severity,
+            "location": location,
+            "provenance": {
+                "kind": _derive_provenance_kind(source_ids, authored=True),
+                "source_ids": source_ids,
+            },
+        }
+        finding["finding_id"] = schema.derive_finding_id(finding, case_id=case_id)
+        raw.setdefault("curation", {}).setdefault("findings", []).append(finding)
+        _derive_content(raw)
+
+    _with_case_lock(root, case_id, "add", mutate)
 
 
 def add_findings(
@@ -444,27 +494,29 @@ def add_findings(
     add stays all-or-nothing and never leaves earlier atoms persisted on a
     failure.
     """
-    raw = _load_case(root, case_id)
-    for fi in findings:
-        _check_candidate_sources(raw, list(fi.get("source_ids") or []), case_id)
-    curation = raw.setdefault("curation", {})
-    _reopen_for_mutation(curation)
-    for fi in findings:
-        source_ids = list(fi.get("source_ids") or [])
-        finding = {
-            "title": fi["title"],
-            "body": fi["body"],
-            "severity": fi.get("severity"),
-            "location": fi.get("location"),
-            "provenance": {
-                "kind": _derive_provenance_kind(source_ids, authored=True),
-                "source_ids": source_ids,
-            },
-        }
-        finding["finding_id"] = schema.derive_finding_id(finding, case_id=case_id)
-        curation.setdefault("findings", []).append(finding)
-    _derive_content(raw)
-    _stage_case(root, case_id, raw, op="add")
+
+    def mutate(raw: dict[str, Any]) -> None:
+        for fi in findings:
+            _check_candidate_sources(raw, list(fi.get("source_ids") or []), case_id)
+        curation = raw.setdefault("curation", {})
+        _reopen_for_mutation(curation)
+        for fi in findings:
+            source_ids = list(fi.get("source_ids") or [])
+            finding = {
+                "title": fi["title"],
+                "body": fi["body"],
+                "severity": fi.get("severity"),
+                "location": fi.get("location"),
+                "provenance": {
+                    "kind": _derive_provenance_kind(source_ids, authored=True),
+                    "source_ids": source_ids,
+                },
+            }
+            finding["finding_id"] = schema.derive_finding_id(finding, case_id=case_id)
+            curation.setdefault("findings", []).append(finding)
+        _derive_content(raw)
+
+    _with_case_lock(root, case_id, "add", mutate)
 
 
 def _build_replacement(
@@ -496,21 +548,23 @@ def replace_findings(
     replacement concatenates its own sources); the replacements are the atomic
     toehold set and are revalidated with the whole case.
     """
-    raw = _load_case(root, case_id)
-    curation = raw.setdefault("curation", {})
-    _reopen_for_mutation(curation)
-    findings = curation.setdefault("findings", [])
-    index = next(
-        (i for i, f in enumerate(findings) if f.get("finding_id") == finding_id),
-        None,
-    )
-    if index is None:
-        raise CurationError(f"no finding {finding_id}")
-    built = [_build_replacement(raw, case_id, r) for r in replacements]
-    new_findings = list(findings[:index]) + built + list(findings[index + 1:])
-    curation["findings"] = new_findings
-    _derive_content(raw)
-    _stage_case(root, case_id, raw, op="replace")
+
+    def mutate(raw: dict[str, Any]) -> None:
+        curation = raw.setdefault("curation", {})
+        _reopen_for_mutation(curation)
+        findings = curation.setdefault("findings", [])
+        index = next(
+            (i for i, f in enumerate(findings) if f.get("finding_id") == finding_id),
+            None,
+        )
+        if index is None:
+            raise CurationError(f"no finding {finding_id}")
+        built = [_build_replacement(raw, case_id, r) for r in replacements]
+        new_findings = list(findings[:index]) + built + list(findings[index + 1:])
+        curation["findings"] = new_findings
+        _derive_content(raw)
+
+    _with_case_lock(root, case_id, "replace", mutate)
 
 
 _EVIDENCE_REASONS = frozenset({
@@ -565,14 +619,16 @@ def exclude_evidence(
     existing row (a single entry per source). ``reason == "other"`` requires a
     non-blank note; a stray note on any other reason is rejected.
     """
-    raw = _load_case(root, case_id)
-    _validate_evidence_exclusion_contract(reason, note)
-    _check_candidate_sources(raw, [source_id], case_id)
 
-    curation = raw.setdefault("curation", {})
-    _reopen_for_mutation(curation)
-    _append_evidence_exclusion(curation, source_id, reason, note)
-    _stage_case(root, case_id, raw, op="exclude-evidence")
+    def mutate(raw: dict[str, Any]) -> None:
+        _validate_evidence_exclusion_contract(reason, note)
+        _check_candidate_sources(raw, [source_id], case_id)
+
+        curation = raw.setdefault("curation", {})
+        _reopen_for_mutation(curation)
+        _append_evidence_exclusion(curation, source_id, reason, note)
+
+    _with_case_lock(root, case_id, "exclude-evidence", mutate)
 
 
 def _validate_transition(frm: str | None, to: str) -> None:
@@ -633,21 +689,25 @@ def mark_ready(root: Path, case_id: str, *, head_sha: str) -> None:
     stale -> ready). Sets ``snapshot_attested=True`` and ``state=ready`` after
     the full case revalidates.
     """
-    raw = _load_case(root, case_id)
-    snapshot_doc = raw.get("snapshot") or {}
-    original = snapshot_doc.get("original_head_sha")
-    if head_sha != original:
-        raise CurationError(f"attestation SHA mismatch: expected {original} got {head_sha}")
-    curation = raw.setdefault("curation", {})
-    if not curation.get("findings"):
-        raise CurationError(
-            f"case {case_id} cannot be marked ready with an empty gold findings set"
-        )
-    _validate_transition(curation.get("state"), "ready")
-    curation["state"] = "ready"
-    curation["snapshot_attested"] = True
-    _derive_content(raw)
-    _stage_case(root, case_id, raw, op="mark-ready")
+
+    def mutate(raw: dict[str, Any]) -> None:
+        snapshot_doc = raw.get("snapshot") or {}
+        original = snapshot_doc.get("original_head_sha")
+        if head_sha != original:
+            raise StaleStateError(
+                f"attestation SHA mismatch: expected {original} got {head_sha}"
+            )
+        curation = raw.setdefault("curation", {})
+        if not curation.get("findings"):
+            raise CurationError(
+                f"case {case_id} cannot be marked ready with an empty gold findings set"
+            )
+        _validate_transition(curation.get("state"), "ready")
+        curation["state"] = "ready"
+        curation["snapshot_attested"] = True
+        _derive_content(raw)
+
+    _with_case_lock(root, case_id, "mark-ready", mutate)
 
 
 def attest_clean(root: Path, case_id: str) -> None:
@@ -657,19 +717,21 @@ def attest_clean(root: Path, case_id: str) -> None:
     ``snapshot_attested`` and never marks ready — the final-attest operation
     remains required.
     """
-    raw = _load_case(root, case_id)
-    curation = raw.setdefault("curation", {})
-    if curation.get("findings"):
-        raise CurationError(
-            f"case {case_id} has gold findings; clean attestation requires an empty gold set"
-        )
-    # Route through the mutation discipline: a ready/stale case reopens to
-    # draft (clearing snapshot attestation) instead of lingering as
-    # ready-but-unattested, which the revalidation guard forbids. A draft case
-    # stays draft -- the final-attest op remains required.
-    _reopen_for_mutation(curation)
-    _set_clean(curation)
-    _stage_case(root, case_id, raw, op="attest-clean")
+
+    def mutate(raw: dict[str, Any]) -> None:
+        curation = raw.setdefault("curation", {})
+        if curation.get("findings"):
+            raise CurationError(
+                f"case {case_id} has gold findings; clean attestation requires an empty gold set"
+            )
+        # Route through the mutation discipline: a ready/stale case reopens to
+        # draft (clearing snapshot attestation) instead of lingering as
+        # ready-but-unattested, which the revalidation guard forbids. A draft case
+        # stays draft -- the final-attest op remains required.
+        _reopen_for_mutation(curation)
+        _set_clean(curation)
+
+    _with_case_lock(root, case_id, "attest-clean", mutate)
 
 
 _CASE_EXCLUSION_REASONS = frozenset({"unreplayable", "not_suitable", "duplicate_case", "other"})
@@ -703,10 +765,12 @@ def exclude_case(
     ``ready -> draft -> excluded`` double edge (clearing attestation on the
     ``ready -> draft`` step).
     """
-    raw = _load_case(root, case_id)
-    curation = raw.setdefault("curation", {})
-    _apply_case_exclusion(curation, reason=reason, note=note)
-    _stage_case(root, case_id, raw, op="exclude-case")
+
+    def mutate(raw: dict[str, Any]) -> None:
+        curation = raw.setdefault("curation", {})
+        _apply_case_exclusion(curation, reason=reason, note=note)
+
+    _with_case_lock(root, case_id, "exclude-case", mutate)
 
 
 def reinclude_case(root: Path, case_id: str) -> None:
@@ -715,17 +779,19 @@ def reinclude_case(root: Path, case_id: str) -> None:
     A ready-snapshot case re-includes to ``draft``; an unreplayable-snapshot
     case to ``unreplayable``. Requires the case be currently ``excluded``.
     """
-    raw = _load_case(root, case_id)
-    curation = raw.setdefault("curation", {})
-    if curation.get("state") != "excluded":
-        raise CurationError(f"case {case_id} is not excluded")
-    snapshot_doc = raw.get("snapshot") or {}
-    destination = "draft" if snapshot_doc.get("status") == "ready" else "unreplayable"
-    _validate_transition("excluded", destination)
-    curation["state"] = destination
-    curation["snapshot_attested"] = False
-    curation["case_exclusion"] = None
-    _stage_case(root, case_id, raw, op="reinclude-case")
+
+    def mutate(raw: dict[str, Any]) -> None:
+        curation = raw.setdefault("curation", {})
+        if curation.get("state") != "excluded":
+            raise CurationError(f"case {case_id} is not excluded")
+        snapshot_doc = raw.get("snapshot") or {}
+        destination = "draft" if snapshot_doc.get("status") == "ready" else "unreplayable"
+        _validate_transition("excluded", destination)
+        curation["state"] = destination
+        curation["snapshot_attested"] = False
+        curation["case_exclusion"] = None
+
+    _with_case_lock(root, case_id, "reinclude-case", mutate)
 
 
 def _fragment_provenance(
@@ -762,51 +828,53 @@ def apply_gold_fragment(root: Path, case_id: str, fragment: dict[str, Any]) -> N
     ready-snapshot case ``draft`` and never sets ``snapshot_attested`` — it
     can never produce ready gold.
     """
-    raw = _load_case(root, case_id)
-    curation = raw.setdefault("curation", {})
-    _reopen_for_mutation(curation)
 
-    findings: list[dict[str, Any]] = []
-    for frag in fragment.get("findings") or []:
-        finding = {
-            "title": frag["title"],
-            "body": frag["body"],
-            "severity": frag.get("severity"),
-            "location": frag.get("location"),
-        }
-        kind, source_ids = _fragment_provenance(
-            raw, finding, list(frag.get("source_ids") or []), case_id=case_id
-        )
-        finding["provenance"] = {"kind": kind, "source_ids": source_ids}
-        finding["finding_id"] = schema.derive_finding_id(finding, case_id=case_id)
-        findings.append(finding)
-    curation["findings"] = findings
+    def mutate(raw: dict[str, Any]) -> None:
+        curation = raw.setdefault("curation", {})
+        _reopen_for_mutation(curation)
 
-    for exc in fragment.get("exclusions") or []:
-        src = exc["source_id"]
-        reason = exc["reason"]
-        note = exc.get("note")
-        _validate_evidence_exclusion_contract(reason, note)
-        _check_candidate_sources(raw, [src], case_id)
-        _append_evidence_exclusion(curation, src, reason, note)
-    curation["exclusions"] = curation.get("exclusions") or []
-
-    case_exclusion = fragment.get("case_exclusion")
-    if case_exclusion is not None:
-        _apply_case_exclusion(
-            curation, reason=case_exclusion["reason"], note=case_exclusion.get("note")
-        )
-
-    clean = bool(fragment.get("clean"))
-    if clean:
-        if findings:
-            raise CurationError(
-                f"case {case_id} clean fragment requires an empty gold findings set"
+        findings: list[dict[str, Any]] = []
+        for frag in fragment.get("findings") or []:
+            finding = {
+                "title": frag["title"],
+                "body": frag["body"],
+                "severity": frag.get("severity"),
+                "location": frag.get("location"),
+            }
+            kind, source_ids = _fragment_provenance(
+                raw, finding, list(frag.get("source_ids") or []), case_id=case_id
             )
-        _set_clean(curation)
-    else:
-        _derive_content(raw)
-    _stage_case(root, case_id, raw, op="apply-gold")
+            finding["provenance"] = {"kind": kind, "source_ids": source_ids}
+            finding["finding_id"] = schema.derive_finding_id(finding, case_id=case_id)
+            findings.append(finding)
+        curation["findings"] = findings
+
+        for exc in fragment.get("exclusions") or []:
+            src = exc["source_id"]
+            reason = exc["reason"]
+            note = exc.get("note")
+            _validate_evidence_exclusion_contract(reason, note)
+            _check_candidate_sources(raw, [src], case_id)
+            _append_evidence_exclusion(curation, src, reason, note)
+        curation["exclusions"] = curation.get("exclusions") or []
+
+        case_exclusion = fragment.get("case_exclusion")
+        if case_exclusion is not None:
+            _apply_case_exclusion(
+                curation, reason=case_exclusion["reason"], note=case_exclusion.get("note")
+            )
+
+        clean = bool(fragment.get("clean"))
+        if clean:
+            if findings:
+                raise CurationError(
+                    f"case {case_id} clean fragment requires an empty gold findings set"
+                )
+            _set_clean(curation)
+        else:
+            _derive_content(raw)
+
+    _with_case_lock(root, case_id, "apply-gold", mutate)
 
 
 def _validate_exclusion_contract(

--- a/daydream/benchmark/curation.py
+++ b/daydream/benchmark/curation.py
@@ -8,9 +8,9 @@ through. Every mutating operation (``accept_candidate``, ``add_finding``,
 runs its complete read -> validate -> mutate -> commit sequence under the
 workspace lock:
 
-1. acquires the blocking :class:`storage.WorkspaceLock` (process-reentrant per
-   root), so concurrent curators/processes serialize and can never silently
-   lose an update,
+1. acquires the blocking :class:`storage.WorkspaceLock` (per-thread reentrant per
+   root, so concurrent curators — threads or separate processes — serialize and
+   can never silently lose an update),
 2. heals any prior interrupted journal via :func:`storage.recover_startup`
    under the lock, so a crashed earlier process's leftover ``committing``
    journal is rolled back before a new write,

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -513,9 +513,23 @@ query ReviewThreads($owner: String!, $name: String!, $number: Int!, $after: Stri
         nodes {
           id isResolved isOutdated isResolvedBy subjectType path line originalLine side startSide
           comments(first: 100) {
+            pageInfo { hasNextPage endCursor }
             nodes { id databaseId body author { login type isBot } createdAt updatedAt url replyTo { id } }
           }
         }
+      }
+    }
+  }
+}
+"""
+
+_THREAD_COMMENTS_QUERY = """
+query ThreadComments($threadId: ID!, $commentsAfter: String) {
+  node(id: $threadId) {
+    ... on PullRequestReviewThread {
+      comments(first: 100, after: $commentsAfter) {
+        pageInfo { hasNextPage endCursor }
+        nodes { id databaseId body author { login type isBot } createdAt updatedAt url replyTo { id } }
       }
     }
   }
@@ -552,11 +566,11 @@ def _evidence_from_thread(thread: dict[str, Any], comment: dict[str, Any]) -> di
     return fields
 
 
-def _graphql_with_rate_limit_retry(root: Path, variables: dict[str, Any]) -> dict[str, Any]:
-    """Call the paginated reviewThreads GraphQL query honoring the rate-limit retry policy.
+def _graphql_with_rate_limit_retry(root: Path, variables: dict[str, Any], *, query: str = _REVIEW_THREADS_QUERY) -> dict[str, Any]:
+    """Call one GraphQL query honoring the rate-limit retry policy.
 
     REST paths flow through :func:`_call_with_rate_limit_retry` (3 attempts,
-    honoring Retry-After); the GraphQL query must follow the same policy so a
+    honoring Retry-After); GraphQL queries must follow the same policy so a
     transient rate limit is retried and, when exhausted, surfaces as
     :class:`_ImportRateLimitError` (recorded as ``rate_limit`` in the ledger,
     not ``fetch``).
@@ -569,7 +583,7 @@ def _graphql_with_rate_limit_retry(root: Path, variables: dict[str, Any]) -> dic
                 "graphql",
                 method="POST",
                 idempotent=True,
-                input_data={"query": _REVIEW_THREADS_QUERY, "variables": variables},
+                input_data={"query": query, "variables": variables},
             )
             return resp
         except git_ops.RateLimitError as exc:
@@ -583,11 +597,58 @@ def _graphql_with_rate_limit_retry(root: Path, variables: dict[str, Any]) -> dic
     ) from last_rate_limit
 
 
+def _graphql_thread_comments(
+    root: Path, thread_id: str, *, after: str | None = None
+) -> dict[str, Any]:
+    """Fetch one nested page of a review thread's comments via ``node(id:)``.
+
+    An ``errors`` block, a missing/null ``data.node``, or a ``comments``
+    connection lacking ``pageInfo``/``nodes`` raises :class:`GitError` with a
+    message naming the thread id — never a silent empty fallback, so a malformed
+    page can never drop replies.
+    """
+    variables: dict[str, Any] = {"threadId": thread_id}
+    if after is not None:
+        variables["commentsAfter"] = after
+    resp = _graphql_with_rate_limit_retry(root, variables, query=_THREAD_COMMENTS_QUERY)
+    if not isinstance(resp, dict):
+        raise git_ops.GitError(
+            f"graphql thread comments for {thread_id} returned a non-object response"
+        )
+    if resp.get("errors"):
+        raise git_ops.GitError(f"graphql thread comments for {thread_id} failed: {resp['errors']}")
+    try:
+        node = resp["data"]["node"]
+    except (KeyError, TypeError) as exc:
+        raise git_ops.GitError(
+            f"graphql response missing node for thread {thread_id}: {exc}"
+        ) from exc
+    if node is None:
+        raise git_ops.GitError(f"graphql node(id:{thread_id}) returned null")
+    try:
+        comments = node["comments"]
+    except (KeyError, TypeError) as exc:
+        raise git_ops.GitError(
+            f"graphql thread {thread_id} missing comments connection: {exc}"
+        ) from exc
+    if not isinstance(comments, dict) or not isinstance(comments.get("nodes"), list) or not isinstance(
+        comments.get("pageInfo"), dict
+    ):
+        raise git_ops.GitError(f"graphql thread {thread_id} comments missing nodes/pageInfo")
+    return comments
+
+
 def _graphql_review_threads(root: Path, owner_repo: str, number: int) -> list[dict[str, Any]]:
     """Paginate every review thread (and reply) for a PR via GraphQL.
 
-    A GraphQL ``errors`` block, a missing ``data.repository.pullRequest.reviewThreads``
-    key, or a failed call raises :class:`GitError` — never a silent empty fallback.
+    The outer loop walks ``reviewThreads`` by cursor; a thread whose nested
+    ``comments(first: 100)`` connection reports ``hasNextPage`` is completed by
+    a per-thread ``node(id:)`` follow-up loop that walks strictly forward by
+    ``endCursor``, so every reply past 100 is collected exactly once and page
+    boundaries never reorder or drop comments. A GraphQL ``errors`` block, a
+    missing ``data.repository.pullRequest.reviewThreads`` key, a failed call, or
+    a nested ``comments`` connection missing ``pageInfo.hasNextPage`` raises
+    :class:`GitError` — never a silent empty fallback.
     """
     owner, name = owner_repo.split("/", 1)
     all_nodes: list[dict[str, Any]] = []
@@ -612,6 +673,35 @@ def _graphql_review_threads(root: Path, owner_repo: str, number: int) -> list[di
         after = page_info.get("endCursor")
         if after is None:
             raise git_ops.GitError("graphql reviewThreads hasNextPage without an endCursor")
+    for thread in all_nodes:
+        comments = thread.get("comments")
+        if not isinstance(comments, dict):
+            raise git_ops.GitError(
+                f"graphql review thread {thread.get('id')} has no comments connection"
+            )
+        page_info = comments.get("pageInfo")
+        if not isinstance(page_info, dict) or "hasNextPage" not in page_info:
+            raise git_ops.GitError(
+                f"graphql review thread {thread.get('id')} comments missing pageInfo.hasNextPage"
+            )
+        if not page_info.get("hasNextPage"):
+            continue
+        nested_after = page_info.get("endCursor")
+        if nested_after is None:
+            raise git_ops.GitError(
+                f"graphql review thread {thread.get('id')} comments hasNextPage without an endCursor"
+            )
+        while True:
+            page = _graphql_thread_comments(root, thread["id"], after=nested_after)
+            comments.setdefault("nodes", []).extend(page["nodes"])
+            page_info = page["pageInfo"]
+            if not page_info.get("hasNextPage"):
+                break
+            nested_after = page_info.get("endCursor")
+            if nested_after is None:
+                raise git_ops.GitError(
+                    f"graphql thread comments for {thread['id']} hasNextPage without an endCursor"
+                )
     return all_nodes
 
 

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -686,6 +686,21 @@ def _graphql_with_rate_limit_retry(
     ) from last_rate_limit
 
 
+def _next_cursor(page_info: dict[str, Any], *, context: str) -> str | None:
+    """Return the next ``endCursor``, or ``None`` when there is no next page.
+
+    Fails closed: a connection reporting ``hasNextPage`` without an
+    ``endCursor`` raises :class:`GitError` naming ``context`` instead of
+    silently dropping a page.
+    """
+    if not page_info.get("hasNextPage"):
+        return None
+    after = page_info.get("endCursor")
+    if after is None:
+        raise git_ops.GitError(f"graphql {context} hasNextPage without an endCursor")
+    return after
+
+
 def _graphql_thread_comments(
     root: Path, thread_id: str, *, after: str | None = None
 ) -> dict[str, Any]:
@@ -720,8 +735,10 @@ def _graphql_thread_comments(
         raise git_ops.GitError(
             f"graphql thread {thread_id} missing comments connection: {exc}"
         ) from exc
-    if not isinstance(comments, dict) or not isinstance(comments.get("nodes"), list) or not isinstance(
-        comments.get("pageInfo"), dict
+    if not (
+        isinstance(comments, dict)
+        and isinstance(comments.get("nodes"), list)
+        and isinstance(comments.get("pageInfo"), dict)
     ):
         raise git_ops.GitError(f"graphql thread {thread_id} comments missing nodes/pageInfo")
     return comments
@@ -757,11 +774,9 @@ def _graphql_review_threads(root: Path, owner_repo: str, number: int) -> list[di
             raise git_ops.GitError(f"graphql response missing reviewThreads: {exc}") from exc
         all_nodes.extend(threads.get("nodes") or [])
         page_info = threads.get("pageInfo") or {}
-        if not page_info.get("hasNextPage"):
-            break
-        after = page_info.get("endCursor")
+        after = _next_cursor(page_info, context="reviewThreads")
         if after is None:
-            raise git_ops.GitError("graphql reviewThreads hasNextPage without an endCursor")
+            break
     for thread in all_nodes:
         comments = thread.get("comments")
         if not isinstance(comments, dict):
@@ -773,24 +788,20 @@ def _graphql_review_threads(root: Path, owner_repo: str, number: int) -> list[di
             raise git_ops.GitError(
                 f"graphql review thread {thread.get('id')} comments missing pageInfo.hasNextPage"
             )
-        if not page_info.get("hasNextPage"):
-            continue
-        nested_after = page_info.get("endCursor")
+        nested_after = _next_cursor(
+            page_info, context=f"review thread {thread.get('id')} comments"
+        )
         if nested_after is None:
-            raise git_ops.GitError(
-                f"graphql review thread {thread.get('id')} comments hasNextPage without an endCursor"
-            )
+            continue
         while True:
             page = _graphql_thread_comments(root, thread["id"], after=nested_after)
             comments.setdefault("nodes", []).extend(page["nodes"])
             page_info = page["pageInfo"]
-            if not page_info.get("hasNextPage"):
-                break
-            nested_after = page_info.get("endCursor")
+            nested_after = _next_cursor(
+                page_info, context=f"thread comments for {thread['id']}"
+            )
             if nested_after is None:
-                raise git_ops.GitError(
-                    f"graphql thread comments for {thread['id']} hasNextPage without an endCursor"
-                )
+                break
     return all_nodes
 
 

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -478,6 +478,7 @@ def _evidence_from_inline(raw: dict[str, Any]) -> dict[str, Any]:
         "start_line": raw.get("start_line"),
         "original_line": raw.get("original_line"),
         "thread_id": None,
+        "review_id": str(raw["pull_request_review_id"]) if raw.get("pull_request_review_id") is not None else None,
         "reply_to_id": str(raw["in_reply_to_id"]) if raw.get("in_reply_to_id") is not None else None,
         "subject_type": subject_type,
         "side": raw.get("side"),
@@ -566,7 +567,93 @@ def _evidence_from_thread(thread: dict[str, Any], comment: dict[str, Any]) -> di
     return fields
 
 
-def _graphql_with_rate_limit_retry(root: Path, variables: dict[str, Any], *, query: str = _REVIEW_THREADS_QUERY) -> dict[str, Any]:
+def _canonical_comment_from_thread(
+    thread: dict[str, Any], comment: dict[str, Any]
+) -> dict[str, Any]:
+    """Build a canonical ``inline_comment`` record from GraphQL thread fields.
+
+    Used for thread comments with no REST counterpart (never dropped, and never
+    emitted with the ``thread_comment`` kind). The thread carries the anchors;
+    commit anchors are absent because only REST exposes them.
+    """
+    rec = _evidence_from_thread(thread, comment)
+    db_id = rec["database_id"]
+    rec["source_id"] = f"github:inline_comment:{db_id}"
+    rec["kind"] = "inline_comment"
+    rec["commit_id"] = None
+    rec["original_commit_id"] = None
+    rec["review_id"] = None
+    rec["dismissed"] = False
+    return rec
+
+
+def _reconcile_inline_evidence(
+    inline_records: list[dict[str, Any]],
+    thread_nodes: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Merge REST inline comments and GraphQL thread comments into one record per comment.
+
+    The REST inline record is the canonical base — it carries the anchors only
+    REST exposes (``commit_id``/``original_commit_id``, ``path``/``original_path``,
+    line/start line, ``subject_type``, ``side``/``start_side``, ``url``). GraphQL
+    thread state (``thread_id``, ``resolved``, ``outdated``, and the reply link
+    when REST lacks it) is overlaid by ``database_id`` with a ``node_id``
+    fallback, so every comment that exists in both feeds yields exactly one
+    record. A thread comment with no REST counterpart is surfaced as a canonical
+    ``inline_comment`` record built from thread fields — never dropped, never
+    emitted as ``thread_comment``. Exactly one record is produced per comment
+    database id.
+    """
+    inline_by_db = {rec["database_id"]: rec for rec in inline_records}
+    inline_by_node = {rec["node_id"]: rec for rec in inline_records if rec.get("node_id")}
+    canonical: list[dict[str, Any]] = [dict(rec) for rec in inline_records]
+    canonical_by_db = {rec["database_id"]: rec for rec in canonical}
+    for thread in thread_nodes:
+        nodes = thread.get("comments", {}).get("nodes")
+        if nodes is None:
+            continue  # a thread with no comments contributes nothing
+        for comment in nodes:
+            if not isinstance(comment, dict) or "databaseId" not in comment:
+                continue
+            db_id = int(comment["databaseId"])
+            base = inline_by_db.get(db_id)
+            if base is None and comment.get("id"):
+                base = inline_by_node.get(comment["id"])
+            if base is not None:
+                rec = canonical_by_db[base["database_id"]]
+            else:
+                rec = _canonical_comment_from_thread(thread, comment)
+                canonical.append(rec)
+            rec["thread_id"] = thread.get("id")
+            rec["resolved"] = bool(thread.get("isResolved", False))
+            rec["outdated"] = bool(thread.get("isOutdated", False))
+            if rec.get("reply_to_id") is None:
+                rec["reply_to_id"] = (comment.get("replyTo") or {}).get("id")
+    return canonical
+
+
+def _join_dismissal(
+    canonical: list[dict[str, Any]], review_records: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Mark ``dismissed`` on comments whose review was dismissed.
+
+    Dismissal is joined deterministically from the review set already fetched:
+    REST review ``state == "DISMISSED"`` mapped through the comment's
+    ``pull_request_review_id``. Pure dict join — a comment whose review id maps
+    to no DISMISSED review (or to no review at all) simply keeps the default
+    ``dismissed=False``.
+    """
+    states = {str(int(raw["id"])): raw.get("state") for raw in review_records}
+    for rec in canonical:
+        review_id = rec.get("review_id")
+        if rec.get("kind") == "inline_comment" and review_id and states.get(review_id) == "DISMISSED":
+            rec["dismissed"] = True
+    return canonical
+
+
+def _graphql_with_rate_limit_retry(
+    root: Path, variables: dict[str, Any], *, query: str = _REVIEW_THREADS_QUERY
+) -> dict[str, Any]:
     """Call one GraphQL query honoring the rate-limit retry policy.
 
     REST paths flow through :func:`_call_with_rate_limit_retry` (3 attempts,
@@ -1254,8 +1341,11 @@ def fetch_and_normalize(
 ) -> schema.ImportDocument:
     """Fetch one PR's full evidence set through REST and normalize it.
 
-    Pulls the PR header, then every submitted review, top-level inline comment,
-    and conversation comment in order. The normalized ``pull_request`` block
+    Pulls the PR header, then every submitted review and conversation comment;
+    each top-level inline comment is reconciled with its GraphQL thread state
+    into one canonical ``inline_comment`` record (REST anchors plus joined
+    thread id/resolved/outdated/dismissal), and review dismissal is joined by
+    review id. The normalized ``pull_request`` block
     carries the complete header: number, url/html_url, title, body, state,
     merge/close timestamps, created/updated timestamps, author, exact
     base/head (sha + ref), and the persisted ``title_sha256``/``body_sha256``
@@ -1267,17 +1357,14 @@ def fetch_and_normalize(
     """
     header = _fetch_with_retry(root, owner_repo, number)
 
-    evidence: list[dict[str, Any]] = []
-    for raw in _rest(root, f"repos/{owner_repo}/pulls/{number}/reviews"):
-        evidence.append(_evidence_from_review(raw))
-    for raw in _rest(root, f"repos/{owner_repo}/pulls/{number}/comments"):
-        evidence.append(_evidence_from_inline(raw))
+    review_records = _rest(root, f"repos/{owner_repo}/pulls/{number}/reviews")
+    inline_records = [_evidence_from_inline(raw) for raw in _rest(root, f"repos/{owner_repo}/pulls/{number}/comments")]
+    threads = _graphql_review_threads(root, owner_repo, number)
+
+    evidence: list[dict[str, Any]] = [_evidence_from_review(raw) for raw in review_records]
+    evidence.extend(_join_dismissal(_reconcile_inline_evidence(inline_records, threads), review_records))
     for raw in _rest(root, f"repos/{owner_repo}/issues/{number}/comments"):
         evidence.append(_evidence_from_issue(raw))
-
-    for thread in _graphql_review_threads(root, owner_repo, number):
-        for comment in thread.get("comments", {}).get("nodes", []):
-            evidence.append(_evidence_from_thread(thread, comment))
 
     records = [schema.EvidenceRecord.model_validate(e) for e in evidence]
     record_dicts = [r.model_dump(mode="json") for r in records]

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -614,7 +614,9 @@ def _reconcile_inline_evidence(
             continue  # a thread with no comments contributes nothing
         for comment in nodes:
             if not isinstance(comment, dict) or "databaseId" not in comment:
-                continue
+                raise git_ops.GitError(
+                    f"graphql review thread {thread.get('id')} comment node missing databaseId"
+                )
             db_id = int(comment["databaseId"])
             base = inline_by_db.get(db_id)
             if base is None and comment.get("id"):
@@ -921,13 +923,24 @@ def _payload_sha256(import_doc: dict[str, Any]) -> str:
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
-def _evidence_signature_from_doc(doc: schema.ImportDocument) -> frozenset[tuple[str, str]]:
-    return frozenset((e.source_id, e.body_sha256) for e in doc.evidence)
+def _evidence_signature_from_doc(doc: schema.ImportDocument) -> frozenset[tuple[int, str]]:
+    """Content signature: one ``(database_id, body_sha256)`` pair per evidence record.
+
+    Keyed on the physical comment id rather than ``source_id`` so the refresh
+    stale check is immune to the canonical-record format change: pre-canonicalization
+    files rekinded thread-only comments and persisted a comment that existed in
+    both feeds twice, while the canonical format emits exactly one
+    ``inline_comment`` per database id. Byte-identical GitHub content changed only
+    the persisted shape, so a first ``--refresh`` after the format change must
+    compare equal and keep prior curated cases — a genuine content change (a
+    comment added/removed/edited) still flips the digest.
+    """
+    return frozenset((e.database_id, e.body_sha256) for e in doc.evidence)
 
 
-def _evidence_signature_from_raw(raw: dict[str, Any]) -> frozenset[tuple[str, str]]:
+def _evidence_signature_from_raw(raw: dict[str, Any]) -> frozenset[tuple[int, str]]:
     return frozenset(
-        (str(e.get("source_id")), str(e.get("body_sha256"))) for e in raw.get("evidence", [])
+        (int(e["database_id"]), str(e.get("body_sha256"))) for e in raw.get("evidence", [])
     )
 
 
@@ -1159,7 +1172,7 @@ def _stage_fetch_failure(
 def _prior_import_state(
     root: Path, raw: dict[str, Any], number: int
 ) -> tuple[
-    frozenset[tuple[str, str]] | None,
+    frozenset[tuple[int, str]] | None,
     str | None,
     dict[str, dict[str, Any]],
     str,
@@ -1172,7 +1185,7 @@ def _prior_import_state(
     """
     import_file = f"imports/pr-{number:06d}.json"
     existing = _manifest_entry(raw, number)
-    prior_sig: frozenset[tuple[str, str]] | None = None
+    prior_sig: frozenset[tuple[int, str]] | None = None
     prior_task_sig: str | None = None
     prior_curations: dict[str, dict[str, Any]] = {}
     if existing is not None and existing.get("import_state") == "fetched":

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -1345,7 +1345,9 @@ def fetch_and_normalize(
     each top-level inline comment is reconciled with its GraphQL thread state
     into one canonical ``inline_comment`` record (REST anchors plus joined
     thread id/resolved/outdated/dismissal), and review dismissal is joined by
-    review id. The normalized ``pull_request`` block
+    review id. Evidence is emitted in deterministic ``(database_id, created_at)``
+    order, independent of REST/GraphQL page boundaries. The normalized
+    ``pull_request`` block
     carries the complete header: number, url/html_url, title, body, state,
     merge/close timestamps, created/updated timestamps, author, exact
     base/head (sha + ref), and the persisted ``title_sha256``/``body_sha256``
@@ -1367,6 +1369,9 @@ def fetch_and_normalize(
         evidence.append(_evidence_from_issue(raw))
 
     records = [schema.EvidenceRecord.model_validate(e) for e in evidence]
+    # Canonical order: sort by (database_id, created_at) so persisted order and
+    # payload_sha256 are independent of REST/GraphQL page boundaries.
+    records.sort(key=lambda r: (r.database_id, r.created_at))
     record_dicts = [r.model_dump(mode="json") for r in records]
     base = header.get("base") or {}
     head = header.get("head") or {}

--- a/daydream/benchmark/migrate.py
+++ b/daydream/benchmark/migrate.py
@@ -69,8 +69,22 @@ def migrate_workspace(root: Path, *, dry_run: bool = False) -> UpgradeReport:
     writing changed cases atomically through ``storage.Transaction``. When
     *dry_run* is True the report is computed without writing. Invalid cases are
     recorded in ``report.errors`` and left byte-unchanged.
+
+    The migration's writes run under the workspace lock so they serialize
+    against concurrent curators — otherwise a curator mutation and a migration
+    could race on the same case file and lose an update. (The *dry_run* path is
+    read-only and intentionally runs without the lock.)
     """
     root = Path(root)
+    if dry_run:
+        return _migrate_workspace_unlocked(root, dry_run=True)
+    with storage.WorkspaceLock(root):
+        storage.recover_startup(root)
+        return _migrate_workspace_unlocked(root, dry_run=False)
+
+
+def _migrate_workspace_unlocked(root: Path, *, dry_run: bool) -> UpgradeReport:
+    """Run the migration body (caller holds the workspace lock unless dry_run)."""
     manifest = storage.load_yaml_strict(root / "benchmark.yaml")
     report = UpgradeReport()
     writes: dict[str, bytes] = {}
@@ -103,7 +117,7 @@ def migrate_workspace(root: Path, *, dry_run: bool = False) -> UpgradeReport:
 
     if not dry_run:
         for case_path, content in writes.items():
-            with storage.Transaction(root, op_id=f"migrate-{case_path}", kind="migrate") as tx:
+            with storage.Transaction(root, op_id=f"migrate-{case_path.replace('/', '_')}", kind="migrate") as tx:
                 tx.stage(case_path, content)
                 tx.commit()
 

--- a/daydream/benchmark/storage.py
+++ b/daydream/benchmark/storage.py
@@ -170,7 +170,11 @@ class WorkspaceLock:
     ``<root>/.benchmark.lock`` file. The lock is process-reentrant per root:
     nested acquisitions within the same process share the same open fd and
     only bump a depth counter, so a command that holds the lock across its own
-    journal writes cannot deadlock against itself.
+    journal writes cannot deadlock against itself. The curation service
+    (``daydream/benchmark/curation.py``) relies on this blocking,
+    process-reentrant semantics for every mutation: each locked mutation runs
+    its whole read -> validate -> mutate -> commit sequence under one
+    acquisition, so concurrent curators serialize instead of losing updates.
 
     The ``.benchmark.lock`` file itself is left on disk after release (removal
     races are unsafe), and mutual-exclusion among separate OS processes is

--- a/daydream/benchmark/storage.py
+++ b/daydream/benchmark/storage.py
@@ -18,7 +18,6 @@ import os
 import re
 import shutil
 import tempfile
-import threading
 from contextlib import suppress
 from dataclasses import dataclass
 from functools import lru_cache
@@ -158,7 +157,7 @@ def sha256_file(path: Path) -> str:
 
 @dataclass
 class _HeldLock:
-    """A workspace lock currently held by one thread (fd + reuse depth)."""
+    """A workspace lock currently held by this process (fd + reuse depth)."""
 
     fd: int
     depth: int
@@ -168,24 +167,21 @@ class WorkspaceLock:
     """An ``fcntl``-backed exclusive lock scoped to a workspace root directory.
 
     Holds ``LOCK_EX`` (blocking) or ``LOCK_EX | LOCK_NB`` on a sibling
-    ``<root>/.benchmark.lock`` file. The lock is reentrant per thread per root:
-    nested acquisitions within the same thread share the same open fd and only
-    bump a depth counter, so a command that holds the lock across its own
-    journal writes cannot deadlock against itself. A different thread of the
-    same process opens its own fd, and the kernel ``fcntl.flock`` byte-range
-    lock excludes it (flock conflicts across open file descriptions even
-    within one process), so concurrent curators — threads or separate
-    processes — serialize instead of losing updates. The curation service
+    ``<root>/.benchmark.lock`` file. The lock is process-reentrant per root:
+    nested acquisitions within the same process share the same open fd and
+    only bump a depth counter, so a command that holds the lock across its own
+    journal writes cannot deadlock against itself. The curation service
     (``daydream/benchmark/curation.py``) relies on this blocking,
-    per-thread-reentrant semantics for every mutation: each locked mutation
-    runs its whole read -> validate -> mutate -> commit sequence under one
+    process-reentrant semantics for every mutation: each locked mutation runs
+    its whole read -> validate -> mutate -> commit sequence under one
     acquisition, so concurrent curators serialize instead of losing updates.
 
     The ``.benchmark.lock`` file itself is left on disk after release (removal
-    races are unsafe).
+    races are unsafe), and mutual-exclusion among separate OS processes is
+    provided by the kernel ``fcntl.flock`` byte-range lock.
     """
 
-    _held: dict[tuple[Path, int], _HeldLock] = {}
+    _held: dict[Path, _HeldLock] = {}
 
     def __init__(self, root: Path, *, blocking: bool = True) -> None:
         self._root = Path(root)
@@ -193,10 +189,9 @@ class WorkspaceLock:
         self._acquired = False
 
     def __enter__(self) -> "WorkspaceLock":
-        key = (self._root, threading.get_ident())
-        held = WorkspaceLock._held.get(key)
+        held = WorkspaceLock._held.get(self._root)
         if held is not None:
-            # Already holding the lock for this root in this thread — reentrant
+            # Already holding the lock for this root in this process — reentrant
             # on the same open file description. Bump the depth and reuse the fd.
             held.depth += 1
             self._acquired = False
@@ -211,22 +206,21 @@ class WorkspaceLock:
         except BlockingIOError:
             os.close(fd)
             raise LockContentionError(
-                f"workspace is locked by another process or thread: {self._root}"
+                f"workspace is locked by another process: {self._root}"
             ) from None
-        WorkspaceLock._held[key] = _HeldLock(fd=fd, depth=1)
+        WorkspaceLock._held[self._root] = _HeldLock(fd=fd, depth=1)
         self._acquired = True
         return self
 
     def __exit__(self, *_exc: object) -> Literal[False]:
-        key = (self._root, threading.get_ident())
-        held = WorkspaceLock._held.get(key)
+        held = WorkspaceLock._held.get(self._root)
         if held is None:
             return False
         held.depth -= 1
         if held.depth <= 0:
             fcntl.flock(held.fd, fcntl.LOCK_UN)
             os.close(held.fd)
-            WorkspaceLock._held.pop(key, None)
+            WorkspaceLock._held.pop(self._root, None)
         return False
 
 

--- a/daydream/benchmark/storage.py
+++ b/daydream/benchmark/storage.py
@@ -18,6 +18,7 @@ import os
 import re
 import shutil
 import tempfile
+import threading
 from contextlib import suppress
 from dataclasses import dataclass
 from functools import lru_cache
@@ -157,7 +158,7 @@ def sha256_file(path: Path) -> str:
 
 @dataclass
 class _HeldLock:
-    """A workspace lock currently held by this process (fd + reuse depth)."""
+    """A workspace lock currently held by one thread (fd + reuse depth)."""
 
     fd: int
     depth: int
@@ -167,21 +168,24 @@ class WorkspaceLock:
     """An ``fcntl``-backed exclusive lock scoped to a workspace root directory.
 
     Holds ``LOCK_EX`` (blocking) or ``LOCK_EX | LOCK_NB`` on a sibling
-    ``<root>/.benchmark.lock`` file. The lock is process-reentrant per root:
-    nested acquisitions within the same process share the same open fd and
-    only bump a depth counter, so a command that holds the lock across its own
-    journal writes cannot deadlock against itself. The curation service
+    ``<root>/.benchmark.lock`` file. The lock is reentrant per thread per root:
+    nested acquisitions within the same thread share the same open fd and only
+    bump a depth counter, so a command that holds the lock across its own
+    journal writes cannot deadlock against itself. A different thread of the
+    same process opens its own fd, and the kernel ``fcntl.flock`` byte-range
+    lock excludes it (flock conflicts across open file descriptions even
+    within one process), so concurrent curators — threads or separate
+    processes — serialize instead of losing updates. The curation service
     (``daydream/benchmark/curation.py``) relies on this blocking,
-    process-reentrant semantics for every mutation: each locked mutation runs
-    its whole read -> validate -> mutate -> commit sequence under one
+    per-thread-reentrant semantics for every mutation: each locked mutation
+    runs its whole read -> validate -> mutate -> commit sequence under one
     acquisition, so concurrent curators serialize instead of losing updates.
 
     The ``.benchmark.lock`` file itself is left on disk after release (removal
-    races are unsafe), and mutual-exclusion among separate OS processes is
-    provided by the kernel ``fcntl.flock`` byte-range lock.
+    races are unsafe).
     """
 
-    _held: dict[Path, _HeldLock] = {}
+    _held: dict[tuple[Path, int], _HeldLock] = {}
 
     def __init__(self, root: Path, *, blocking: bool = True) -> None:
         self._root = Path(root)
@@ -189,9 +193,10 @@ class WorkspaceLock:
         self._acquired = False
 
     def __enter__(self) -> "WorkspaceLock":
-        held = WorkspaceLock._held.get(self._root)
+        key = (self._root, threading.get_ident())
+        held = WorkspaceLock._held.get(key)
         if held is not None:
-            # Already holding the lock for this root in this process — reentrant
+            # Already holding the lock for this root in this thread — reentrant
             # on the same open file description. Bump the depth and reuse the fd.
             held.depth += 1
             self._acquired = False
@@ -206,21 +211,22 @@ class WorkspaceLock:
         except BlockingIOError:
             os.close(fd)
             raise LockContentionError(
-                f"workspace is locked by another process: {self._root}"
+                f"workspace is locked by another process or thread: {self._root}"
             ) from None
-        WorkspaceLock._held[self._root] = _HeldLock(fd=fd, depth=1)
+        WorkspaceLock._held[key] = _HeldLock(fd=fd, depth=1)
         self._acquired = True
         return self
 
     def __exit__(self, *_exc: object) -> Literal[False]:
-        held = WorkspaceLock._held.get(self._root)
+        key = (self._root, threading.get_ident())
+        held = WorkspaceLock._held.get(key)
         if held is None:
             return False
         held.depth -= 1
         if held.depth <= 0:
             fcntl.flock(held.fd, fcntl.LOCK_UN)
             os.close(held.fd)
-            WorkspaceLock._held.pop(self._root, None)
+            WorkspaceLock._held.pop(key, None)
         return False
 
 

--- a/tests/harness/fake_gh.py
+++ b/tests/harness/fake_gh.py
@@ -15,8 +15,7 @@ a JSONL log the :class:`FakeGh` helper parses, and replies from a canned
 response map (``responses.json``) plus built-in behaviors:
 
 - ``gh api graphql`` with a ``reviewThreads`` query returns the configured
-  prior-thread inventory (empty by default), served as a multi-page cursor
-  catalog when configured via ``_write_threads_paginated``;
+  prior-thread inventory (empty by default), served via ``_write_threads``;
 - ``gh api graphql`` with a ``node(id:)``/``PullRequestReviewThread`` query
   returns the configured per-thread nested-comment page catalog
   (``_serve_thread_comments``);
@@ -245,16 +244,6 @@ def _handle_api(argv: list[str], state: Path) -> tuple[int, str, str]:
             return 0, json.dumps(pages[idx]) + "\n", ""
         if "reviewThreads" in query:
             pr_num = variables.get("number") if isinstance(variables, dict) else None
-            pages_key = f"graphql_thread_pages:{pr_num}" if pr_num is not None else None
-            pages = responses.get(pages_key) if pages_key is not None else None
-            if isinstance(pages, list) and pages:
-                # Multi-page outer inventory: the response's own hasNextPage /
-                # endCursor drives the next page when ``after`` matches it.
-                after = variables.get("after") if isinstance(variables, dict) else None
-                idx = 0 if after is None else int(str(after).rsplit(":outer:", 1)[1]) + 1
-                if idx >= len(pages):
-                    return 1, "", f"fake gh: reviewThreads cursor {after!r} past the page list\n"
-                return 0, json.dumps(pages[idx]) + "\n", ""
             key = f"graphql_threads:{pr_num}" if pr_num is not None else "graphql_threads"
             value = responses.get(key) or responses.get("graphql_threads") or _EMPTY_THREADS_RESPONSE
             return 0, json.dumps(value) + "\n", ""
@@ -611,20 +600,6 @@ class FakeGh:
         response["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"] = nodes
         key = f"graphql_threads:{number}" if number is not None else "graphql_threads"
         responses[key] = response
-        self._responses_path.write_text(json.dumps(responses), encoding="utf-8")
-
-    def _write_threads_paginated(
-        self, pages: list[dict[str, Any]], number: int | None = None
-    ) -> None:
-        """Serve a multi-page outer ``reviewThreads`` inventory.
-
-        Each element of *pages* is a full reviewThreads response body; page N's
-        ``endCursor`` (``"<pr>:outer:<N>"``) selects page N+1 when the caller
-        passes it as ``after``; the last page must report ``hasNextPage: false``.
-        """
-        responses = self._read_responses()
-        key = f"graphql_thread_pages:{number}" if number is not None else "graphql_thread_pages"
-        responses[key] = copy.deepcopy(pages)
         self._responses_path.write_text(json.dumps(responses), encoding="utf-8")
 
     def _serve_thread_comments(

--- a/tests/harness/fake_gh.py
+++ b/tests/harness/fake_gh.py
@@ -15,7 +15,11 @@ a JSONL log the :class:`FakeGh` helper parses, and replies from a canned
 response map (``responses.json``) plus built-in behaviors:
 
 - ``gh api graphql`` with a ``reviewThreads`` query returns the configured
-  prior-thread inventory (empty by default);
+  prior-thread inventory (empty by default), served as a multi-page cursor
+  catalog when configured via ``_write_threads_paginated``;
+- ``gh api graphql`` with a ``node(id:)``/``PullRequestReviewThread`` query
+  returns the configured per-thread nested-comment page catalog
+  (``_serve_thread_comments``);
 - ``gh api graphql`` with a ``minimizeComment`` mutation returns a minimized
   success (the Task 0 spike's chosen stale-finding mechanism);
 - ``GET repos/<o>/<r>/pulls/<n>/reviews`` returns the configured review list
@@ -37,6 +41,7 @@ Any other invocation exits non-zero so unexpected calls surface as failures.
 
 from __future__ import annotations
 
+import copy
 import json
 import re
 import subprocess
@@ -219,12 +224,37 @@ def _handle_api(argv: list[str], state: Path) -> tuple[int, str, str]:
     responses = _read_responses(state)
     if endpoint == "graphql":
         query = (payload or {}).get("query", "")
+        variables = (payload or {}).get("variables") or {}
         if "minimizeComment" in query:
             reply: dict[str, Any] = {"data": {"minimizeComment": {"minimizedComment": {"isMinimized": True}}}}
             return 0, json.dumps(reply) + "\n", ""
+        if "PullRequestReviewThread" in query:
+            # Per-thread ``node(id:)`` comments page catalog: serve one page per
+            # incoming ``commentsAfter`` cursor, deterministic endCursor per page.
+            thread_id = variables.get("threadId") if isinstance(variables, dict) else None
+            pages = responses.get(f"graphql_thread_comments:{thread_id}")
+            if not isinstance(pages, list) or not pages:
+                return 1, "", f"fake gh: no thread-comment catalog for {thread_id}\n"
+            after = variables.get("commentsAfter") if isinstance(variables, dict) else None
+            if after is None:
+                idx = 0
+            else:
+                idx = int(str(after).rsplit(":p", 1)[1]) + 1
+            if idx >= len(pages):
+                return 1, "", f"fake gh: thread-comment cursor {after!r} past the catalog end\n"
+            return 0, json.dumps(pages[idx]) + "\n", ""
         if "reviewThreads" in query:
-            variables = (payload or {}).get("variables") or {}
             pr_num = variables.get("number") if isinstance(variables, dict) else None
+            pages_key = f"graphql_thread_pages:{pr_num}" if pr_num is not None else None
+            pages = responses.get(pages_key) if pages_key is not None else None
+            if isinstance(pages, list) and pages:
+                # Multi-page outer inventory: the response's own hasNextPage /
+                # endCursor drives the next page when ``after`` matches it.
+                after = variables.get("after") if isinstance(variables, dict) else None
+                idx = 0 if after is None else int(str(after).rsplit(":outer:", 1)[1]) + 1
+                if idx >= len(pages):
+                    return 1, "", f"fake gh: reviewThreads cursor {after!r} past the page list\n"
+                return 0, json.dumps(pages[idx]) + "\n", ""
             key = f"graphql_threads:{pr_num}" if pr_num is not None else "graphql_threads"
             value = responses.get(key) or responses.get("graphql_threads") or _EMPTY_THREADS_RESPONSE
             return 0, json.dumps(value) + "\n", ""
@@ -552,16 +582,83 @@ class FakeGh:
         return {
             "id": thread_id,
             "isResolved": False,
-            "comments": {"nodes": [comment]},
+            "comments": {
+                "nodes": [comment],
+                "pageInfo": {"hasNextPage": False, "endCursor": None},
+            },
         }
 
     def _write_threads(self, nodes: list[dict[str, Any]], number: int | None = None) -> None:
-        """Serve *nodes* as the review-thread inventory for one PR (or globally)."""
+        """Serve *nodes* as the review-thread inventory for one PR (or globally).
+
+        Every nested ``comments`` connection is given a ``pageInfo`` (single-page
+        by default). A thread with a configured :meth:`_serve_thread_comments`
+        catalog is served with ``hasNextPage`` set so the production per-thread
+        ``node(id:)`` follow-up loop drives the remaining nested pages.
+        """
         response = json.loads(json.dumps(_EMPTY_THREADS_RESPONSE))
-        response["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"] = nodes
+        nodes = copy.deepcopy(nodes)
         responses = self._read_responses()
+        for thread in nodes:
+            comments = thread.get("comments")
+            if not isinstance(comments, dict) or isinstance(comments.get("pageInfo"), dict):
+                continue
+            catalog = responses.get(f"graphql_thread_comments:{thread.get('id')}")
+            if isinstance(catalog, list) and len(catalog) > 1:
+                comments["pageInfo"] = {"hasNextPage": True, "endCursor": f"{thread['id']}:p0"}
+            else:
+                comments["pageInfo"] = {"hasNextPage": False, "endCursor": None}
+        response["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"] = nodes
         key = f"graphql_threads:{number}" if number is not None else "graphql_threads"
         responses[key] = response
+        self._responses_path.write_text(json.dumps(responses), encoding="utf-8")
+
+    def _write_threads_paginated(
+        self, pages: list[dict[str, Any]], number: int | None = None
+    ) -> None:
+        """Serve a multi-page outer ``reviewThreads`` inventory.
+
+        Each element of *pages* is a full reviewThreads response body; page N's
+        ``endCursor`` (``"<pr>:outer:<N>"``) selects page N+1 when the caller
+        passes it as ``after``; the last page must report ``hasNextPage: false``.
+        """
+        responses = self._read_responses()
+        key = f"graphql_thread_pages:{number}" if number is not None else "graphql_thread_pages"
+        responses[key] = copy.deepcopy(pages)
+        self._responses_path.write_text(json.dumps(responses), encoding="utf-8")
+
+    def _serve_thread_comments(
+        self, thread_id: str, comment_nodes: list[dict[str, Any]], *, page_size: int
+    ) -> None:
+        """Store a per-thread nested-comment page catalog for ``node(id:)`` queries.
+
+        A ``node(id: \"<thread_id>\") { ... on PullRequestReviewThread { comments(
+        first: <page_size>, after: $commentsAfter) ... } } }`` query returns
+        ``page_size`` nodes per page, ``hasNextPage`` true until the last page,
+        with a deterministic ``endCursor`` (``"<thread_id>:p<N>"``) per page.
+        """
+        pages: list[dict[str, Any]] = []
+        for start in range(0, len(comment_nodes), page_size):
+            chunk = comment_nodes[start : start + page_size]
+            page_index = start // page_size
+            has_next = start + page_size < len(comment_nodes)
+            pages.append(
+                {
+                    "data": {
+                        "node": {
+                            "comments": {
+                                "pageInfo": {
+                                    "hasNextPage": has_next,
+                                    "endCursor": f"{thread_id}:p{page_index}" if has_next else None,
+                                },
+                                "nodes": chunk,
+                            }
+                        }
+                    }
+                }
+            )
+        responses = self._read_responses()
+        responses[f"graphql_thread_comments:{thread_id}"] = pages
         self._responses_path.write_text(json.dumps(responses), encoding="utf-8")
 
     def _read_responses(self) -> dict[str, Any]:

--- a/tests/test_benchmark_curation.py
+++ b/tests/test_benchmark_curation.py
@@ -8,6 +8,8 @@ rejection / transition surface of :mod:`daydream.benchmark.curation`.
 
 import os
 import subprocess
+import sys
+from pathlib import Path
 
 import pytest
 import yaml
@@ -15,6 +17,8 @@ import yaml
 from daydream import git_ops
 from daydream.benchmark.schema import derive_finding_id
 from daydream.benchmark.storage import atomic_write_yaml, load_yaml_strict
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
 
 # Deterministic seed identity so a local bare origin's commits are stable and
 # reproducible (mirrors tests/test_benchmark_import_prs.py::_SEED_ENV).
@@ -545,4 +549,170 @@ def test_validate_case_accepts_clean_and_rejects_duplicate_and_over_cap(tmp_path
     path.write_text(yaml.safe_dump(raw, sort_keys=False))
     with pytest.raises(cu.CurationError):
         cu.validate_case(ws, case_id)
+
+
+_WORKER = (
+    "import sys\n"
+    "from daydream.benchmark import curation as cu\n"
+    "op, ws, cid = sys.argv[1], sys.argv[2], sys.argv[3]\n"
+    "if op == 'add':\n"
+    "    cu.add_finding(ws, cid, title=sys.argv[4], body='b', severity='low',\n"
+    "                   location={'path': 'feature.py', 'start_line': 1, 'end_line': 1},\n"
+    "                   source_ids=[])\n"
+    "elif op == 'accept':\n"
+    "    cu.accept_candidate(ws, cid, sys.argv[4])\n"
+    "elif op == 'exclude':\n"
+    "    cu.exclude_evidence(ws, cid, sys.argv[4], reason='duplicate')\n"
+    "elif op == 'clean':\n"
+    "    cu.attest_clean(ws, cid)\n"
+    "else:\n"
+    "    raise SystemExit('unknown op')\n"
+)
+
+
+def _spawn_worker(args: list[str]) -> subprocess.Popen[str]:
+    return subprocess.Popen(
+        [sys.executable, "-c", _WORKER, *args],
+        cwd=_REPO_ROOT, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+    )
+
+
+def test_concurrent_accept_and_add_do_not_lose_updates(tmp_path, fake_gh):
+    from daydream.benchmark import curation as cu
+    ws, case_id, _ = _seed_ready_case(tmp_path, fake_gh, lines=4, candidate=True)
+    src = next(c["source_id"] for c in cu.get_case(ws, case_id)["candidates"] if c["exact_acceptable"])
+    procs = [_spawn_worker(["accept", str(ws), case_id, src])]
+    procs += [_spawn_worker(["add", str(ws), case_id, f"conc-{i}"]) for i in range(4)]
+    for p in procs:
+        out, err = p.communicate(timeout=120)
+        assert p.returncode == 0, (out, err)
+    findings = load_yaml_strict(ws / "cases" / f"{case_id}.yaml")["curation"]["findings"]
+    assert len(findings) == 5                                   # all 5 concurrent updates landed
+    assert {"conc-0", "conc-1", "conc-2", "conc-3"} <= {f["title"] for f in findings}
+    hist = [f for f in findings if f["provenance"]["kind"] == "historical"]
+    assert len(hist) == 1 and hist[0]["provenance"]["source_ids"] == [src]
+
+
+def test_concurrent_excludes_serialize_to_single_row(tmp_path, fake_gh):
+    from daydream.benchmark import curation as cu
+    ws, case_id, _ = _seed_ready_case(tmp_path, fake_gh, lines=3, candidate=True)
+    src = next(c["source_id"] for c in cu.get_case(ws, case_id)["candidates"])
+    # Mixed concurrent mutations on one case: 3 idempotent excludes of the same
+    # source must serialize to a single row, AND 3 distinguishable adds must all
+    # land — a lost update (if the workspace lock were removed) would drop one.
+    procs = [_spawn_worker(["exclude", str(ws), case_id, src]) for _ in range(3)]
+    procs += [_spawn_worker(["add", str(ws), case_id, f"mix-{i}"]) for i in range(3)]
+    for p in procs:
+        out, err = p.communicate(timeout=120)
+        assert p.returncode == 0, (out, err)
+    raw = load_yaml_strict(ws / "cases" / f"{case_id}.yaml")
+    assert raw["curation"]["exclusions"] == [{"source_id": src, "reason": "duplicate", "note": None}]
+    assert {"mix-0", "mix-1", "mix-2"} <= {f["title"] for f in raw["curation"]["findings"]}
+    assert cu.validate_case(ws, case_id) is None                # case not corrupted by interleaving
+
+
+def test_concurrent_clean_attestation_serializes(tmp_path, fake_gh):
+    ws, case_id, _ = _seed_ready_case(tmp_path, fake_gh, lines=3)   # empty gold
+    procs = [_spawn_worker(["clean", str(ws), case_id]) for _ in range(3)]
+    for p in procs:
+        out, err = p.communicate(timeout=120)
+        assert p.returncode == 0, (out, err)
+    cur = load_yaml_strict(ws / "cases" / f"{case_id}.yaml")["curation"]
+    assert cur["clean_attested"] is True and cur["gold_status"] == "clean"
+    assert cur["state"] == "draft" and cur["snapshot_attested"] is False
+
+
+def test_concurrent_adds_then_final_readiness_lands(tmp_path, fake_gh):
+    from daydream.benchmark import curation as cu
+    ws, case_id, head_sha = _seed_ready_case(tmp_path, fake_gh, lines=4, candidate=True)
+    procs = [_spawn_worker(["add", str(ws), case_id, f"r-{i}"]) for i in range(3)]
+    for p in procs:
+        out, err = p.communicate(timeout=120)
+        assert p.returncode == 0, (out, err)
+    cu.mark_ready(ws, case_id, head_sha=head_sha)                 # final readiness on top of the concurrent adds
+    raw = load_yaml_strict(ws / "cases" / f"{case_id}.yaml")
+    # All three concurrent adds land before readiness (order is lock-acquisition
+    # order, so title order is nondeterministic — assert the set, not the order).
+    assert sorted(f["title"] for f in raw["curation"]["findings"]) == ["r-0", "r-1", "r-2"]
+    assert raw["curation"]["state"] == "ready" and raw["curation"]["snapshot_attested"] is True
+
+
+def test_lock_file_and_error_text_contain_no_repo_evidence(tmp_path, fake_gh):
+    from daydream.benchmark import curation as cu
+    ws, case_id, _ = _seed_ready_case(tmp_path, fake_gh, lines=3, candidate=True)
+    src = next(c["source_id"] for c in cu.get_case(ws, case_id)["candidates"])
+    cu.exclude_evidence(ws, case_id, src, reason="duplicate")   # acquires + releases the lock
+    assert (ws / ".benchmark.lock").read_bytes() == b""         # lock file is empty: no repo evidence/credentials
+    with pytest.raises(cu.CurationError) as ei:
+        cu.exclude_evidence(ws, case_id, "not-a-source", reason="duplicate")
+    msg = str(ei.value)
+    assert "o/r" not in msg and "token" not in msg.lower() and "api_key" not in msg.lower()
+
+
+def test_read_only_paths_run_concurrent_with_a_writer(tmp_path, fake_gh):
+    from daydream.benchmark import curation as cu
+    ws, case_id, _ = _seed_ready_case(tmp_path, fake_gh, lines=3, candidate=True)
+    lock_path = ws / ".benchmark.lock"
+    # A writer holds the flock for a long window (30s) — far longer than any
+    # plausible read-only path — so a differential probe can detect whether the
+    # read-only paths block on the lock without a fragile wall-clock assertion.
+    holder = subprocess.Popen(
+        [sys.executable, "-c",
+         "import fcntl, time, sys\n"
+         "fd = open(sys.argv[1], 'w')\n"
+         "fcntl.flock(fd, fcntl.LOCK_EX)\n"
+         "print('held', flush=True)\n"
+         "time.sleep(30)\n",
+         str(lock_path)],
+        stdout=subprocess.PIPE, text=True,
+    )
+    assert holder.stdout.readline().strip() == "held"            # another process now holds the flock
+    try:
+        cu.list_cases(ws)
+        cu.get_case(ws, case_id)
+        cu.validate_case(ws, case_id)
+        # The writer must STILL be holding the flock after the reads returned:
+        # had a read-only path blocked on the lock it could not finish until the
+        # writer released (30s later).
+        assert holder.poll() is None
+    finally:
+        holder.wait(timeout=30)
+
+
+def test_locked_mutation_heals_interrupted_journal_before_new_write(tmp_path, fake_gh):
+    from daydream.benchmark import curation as cu
+    from daydream.benchmark.storage import Transaction
+    ws, case_id, _ = _seed_ready_case(tmp_path, fake_gh, lines=3)
+    path = ws / "cases" / f"{case_id}.yaml"
+    raw = load_yaml_strict(path)
+    mutated = dict(raw)
+    mutated["curation"] = dict(raw["curation"])
+    mutated["curation"]["state"] = "excluded"          # an interrupted mutation left in flight
+    with Transaction(ws, op_id=f"curate-{case_id}", kind="curation:exclude-case") as tx:
+        tx.stage(f"cases/{case_id}.yaml", yaml.safe_dump(mutated, sort_keys=False).encode("utf-8"))
+        tx.inject_crash("target-1")                    # target applied under 'committing', then halt
+    assert load_yaml_strict(path)["curation"]["state"] == "excluded"
+    cu.add_finding(ws, case_id, title="recovered", body="b", severity="low",
+                   location={"path": "feature.py", "start_line": 1, "end_line": 1}, source_ids=[])
+    assert not list((ws / "transactions").iterdir())   # prior journal healed
+    final = load_yaml_strict(path)
+    assert final["curation"]["state"] == "draft"       # interrupted 'excluded' write was rolled back
+    assert [f["title"] for f in final["curation"]["findings"]] == ["recovered"]
+
+
+def test_stale_state_error_is_exported_curation_subtype():
+    import daydream.benchmark as bm
+    assert issubclass(bm.StaleStateError, bm.CurationError)
+
+
+def test_stale_attestation_raises_stale_state_error_and_leaves_unchanged(tmp_path, fake_gh):
+    from daydream.benchmark import curation as cu
+    ws, case_id, head_sha = _seed_ready_case(tmp_path, fake_gh, lines=3, candidate=True)
+    src = next(c["source_id"] for c in cu.get_case(ws, case_id)["candidates"] if c["exact_acceptable"])
+    cu.accept_candidate(ws, case_id, src)
+    path = ws / "cases" / f"{case_id}.yaml"
+    before = path.read_bytes()
+    with pytest.raises(cu.StaleStateError):
+        cu.mark_ready(ws, case_id, head_sha="f" * 40)   # stale attestation SHA
+    assert path.read_bytes() == before                    # a rejected mutation writes nothing
 

--- a/tests/test_benchmark_curation.py
+++ b/tests/test_benchmark_curation.py
@@ -9,6 +9,7 @@ rejection / transition surface of :mod:`daydream.benchmark.curation`.
 import os
 import subprocess
 import sys
+import threading
 from pathlib import Path
 
 import pytest
@@ -677,6 +678,30 @@ def test_read_only_paths_run_concurrent_with_a_writer(tmp_path, fake_gh):
         assert holder.poll() is None
     finally:
         holder.wait(timeout=30)
+
+
+def test_workspace_lock_serializes_between_threads_within_one_process(tmp_path):
+    from daydream.benchmark import storage
+    with storage.WorkspaceLock(tmp_path):
+        # A second thread must NOT take the same-process reentrant path: it
+        # opens its own fd and the kernel flock excludes it (flock conflicts
+        # across open file descriptions even within one process). The probe is
+        # non-blocking so this cannot deadlock against the holder.
+        outcome: list[str] = []
+
+        def probe() -> None:
+            try:
+                storage.WorkspaceLock(tmp_path, blocking=False).__enter__()
+            except storage.LockContentionError:
+                outcome.append("contended")
+            else:
+                outcome.append("reentrant")
+
+        t = threading.Thread(target=probe)
+        t.start()
+        t.join(timeout=30)
+        assert not t.is_alive()
+        assert outcome == ["contended"]
 
 
 def test_locked_mutation_heals_interrupted_journal_before_new_write(tmp_path, fake_gh):

--- a/tests/test_benchmark_curation.py
+++ b/tests/test_benchmark_curation.py
@@ -9,7 +9,6 @@ rejection / transition surface of :mod:`daydream.benchmark.curation`.
 import os
 import subprocess
 import sys
-import threading
 from pathlib import Path
 
 import pytest
@@ -678,30 +677,6 @@ def test_read_only_paths_run_concurrent_with_a_writer(tmp_path, fake_gh):
         assert holder.poll() is None
     finally:
         holder.wait(timeout=30)
-
-
-def test_workspace_lock_serializes_between_threads_within_one_process(tmp_path):
-    from daydream.benchmark import storage
-    with storage.WorkspaceLock(tmp_path):
-        # A second thread must NOT take the same-process reentrant path: it
-        # opens its own fd and the kernel flock excludes it (flock conflicts
-        # across open file descriptions even within one process). The probe is
-        # non-blocking so this cannot deadlock against the holder.
-        outcome: list[str] = []
-
-        def probe() -> None:
-            try:
-                storage.WorkspaceLock(tmp_path, blocking=False).__enter__()
-            except storage.LockContentionError:
-                outcome.append("contended")
-            else:
-                outcome.append("reentrant")
-
-        t = threading.Thread(target=probe)
-        t.start()
-        t.join(timeout=30)
-        assert not t.is_alive()
-        assert outcome == ["contended"]
 
 
 def test_locked_mutation_heals_interrupted_journal_before_new_write(tmp_path, fake_gh):

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -1228,6 +1228,38 @@ def test_evidence_order_deterministic_across_page_sizes(tmp_path, fake_gh):
     assert doc2.fetch.payload_sha256 == payload
 
 
+def test_outdated_root_not_exact_acceptable_via_joined_record(tmp_path, fake_gh):
+    from daydream.benchmark import github_import as gi
+
+    ws = tmp_path / "ws"
+    (ws / "imports").mkdir(parents=True)
+    fake_gh.set_response("GET", "repos/o/r/pulls/101", _PR_HEADER)
+    fake_gh.set_response("GET", "repos/o/r/pulls/101/reviews", [])
+    # REST copy of comment 40 is OUTDATED via the joined GraphQL thread state
+    fake_gh.set_response("GET", "repos/o/r/pulls/101/comments", [
+        {"id": 40, "node_id": "DIFF_40", "user": {"login": "dave", "type": "User"},
+         "body": "outdated root", "commit_id": "a" * 40, "path": "a.py", "line": 5,
+         "subject_type": "line", "side": "RIGHT",
+         "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",
+         "html_url": "https://github.com/o/r/pull/101#discussion_r40"}])
+    fake_gh.set_response("GET", "repos/o/r/issues/101/comments", [])
+    fake_gh._write_threads([{"id": "thread_2", "isResolved": True,
+        "isOutdated": True, "isResolvedBy": None, "subjectType": "LINE",
+        "path": "a.py", "line": 5, "originalLine": 4, "side": "RIGHT",
+        "startSide": None,
+        "comments": {"nodes": [
+            {"id": "c40", "databaseId": 40, "body": "outdated root",
+             "author": {"login": "dave", "type": "User"},
+             "createdAt": "2026-01-01T00:00:00Z",
+             "url": "https://github.com/o/r/pull/101#discussion_r40"}]}}],
+        number=101)
+    doc = gi.fetch_and_normalize(ws, "o/r", 101)
+    cands = {c.source_id: c for c in gi.project_candidates(doc, head_sha="a" * 40)}
+    cand = cands["github:inline_comment:40"]
+    assert cand.exact_acceptable is False
+    assert cand.not_exact_reason == "outdated"
+
+
 def test_graphql_review_threads_records_rate_limit_after_retries(tmp_path, fake_gh, monkeypatch):
     """Exhausting GraphQL rate-limit retries surfaces _ImportRateLimitError (ledger rate_limit)."""
     import pytest

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -1193,6 +1193,41 @@ def test_reconcile_inline_and_thread_into_one_record(tmp_path, fake_gh):
     assert not any(e.kind == "thread_comment" for e in doc.evidence)
 
 
+def test_evidence_order_deterministic_across_page_sizes(tmp_path, fake_gh):
+    from daydream.benchmark import github_import as gi
+
+    ws = tmp_path / "ws"
+    (ws / "imports").mkdir(parents=True)
+    fake_gh.set_response("GET", "repos/o/r/pulls/101", _PR_HEADER)
+    # REST-only comments with distinct database ids + timestamps
+    fake_gh.set_response("GET", "repos/o/r/pulls/101/reviews", [
+        {"id": 1, "node_id": "PRR_1", "user": {"login": "alice", "type": "User"},
+         "body": "approved", "state": "APPROVED", "commit_id": "a" * 40,
+         "submitted_at": "2026-01-01T00:00:00Z",
+         "html_url": "https://github.com/o/r/pull/101#pullrequestreview-1"}])
+    comments = [
+        {"id": 30, "node_id": "DIFF_30", "user": {"login": "dave", "type": "User"},
+         "body": "first", "commit_id": "a" * 40, "path": "a.py", "line": 1,
+         "subject_type": "line", "side": "RIGHT",
+         "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",
+         "html_url": "https://github.com/o/r/pull/101#discussion_r30"},
+        {"id": 7, "node_id": "DIFF_7", "user": {"login": "carol", "type": "User"},
+         "body": "second", "commit_id": "a" * 40, "path": "b.py", "line": 2,
+         "subject_type": "line", "side": "RIGHT",
+         "created_at": "2026-01-02T00:00:00Z", "updated_at": "2026-01-02T00:00:00Z",
+         "html_url": "https://github.com/o/r/pull/101#discussion_r7"},
+    ]
+    fake_gh.set_response("GET", "repos/o/r/pulls/101/comments", comments)
+    fake_gh.set_response("GET", "repos/o/r/issues/101/comments", [])
+    fake_gh._write_threads([], number=101)
+    doc = gi.fetch_and_normalize(ws, "o/r", 101)
+    # deterministic order: sorted by (database_id, created_at)
+    assert [e.database_id for e in doc.evidence] == [1, 7, 30]
+    payload = doc.fetch.payload_sha256
+    doc2 = gi.fetch_and_normalize(ws, "o/r", 101)     # refetch: identical digest
+    assert doc2.fetch.payload_sha256 == payload
+
+
 def test_graphql_review_threads_records_rate_limit_after_retries(tmp_path, fake_gh, monkeypatch):
     """Exhausting GraphQL rate-limit retries surfaces _ImportRateLimitError (ledger rate_limit)."""
     import pytest

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -1275,6 +1275,50 @@ def test_outdated_root_not_exact_acceptable_via_joined_record(tmp_path, fake_gh)
     assert cand.not_exact_reason == "outdated"
 
 
+def test_fixture_matrix_evidence_preserved_and_historical(tmp_path, fake_gh):
+    from daydream.benchmark import github_import as gi
+
+    ws = tmp_path / "ws"
+    (ws / "imports").mkdir(parents=True)
+    fake_gh.set_response("GET", "repos/o/r/pulls/101", _PR_HEADER)
+    fake_gh.set_response("GET", "repos/o/r/pulls/101/reviews", [
+        {"id": 1, "node_id": "PRR_1", "user": {"login": "cr[bot]", "type": "Bot"},
+         "body": "Found a bug.", "state": "COMMENTED", "commit_id": "a" * 40,
+         "submitted_at": "2026-01-01T00:00:00Z",
+         "html_url": "https://github.com/o/r/pull/101#pullrequestreview-1"},   # non-pure review body
+        {"id": 2, "node_id": "PRR_2", "user": {"login": "carol", "type": "User"},
+         "body": "Nice work.", "state": "APPROVED", "commit_id": "a" * 40,
+         "submitted_at": "2026-01-01T00:00:00Z",
+         "html_url": "https://github.com/o/r/pull/101#pullrequestreview-2"},   # pure approval
+    ])
+    # edited comment: updated_at != created_at
+    fake_gh.set_response("GET", "repos/o/r/pulls/101/comments", [
+        {"id": 7, "node_id": "DIFF_7", "user": {"login": "bot[bot]", "type": "Bot"},
+         "body": "please fix", "commit_id": "a" * 40, "path": "a.py", "line": 4,
+         "subject_type": "line", "side": "RIGHT",
+         "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-03T00:00:00Z",
+         "html_url": "https://github.com/o/r/pull/101#discussion_r7"}])
+    fake_gh.set_response("GET", "repos/o/r/issues/101/comments", [
+        {"id": 9, "node_id": "IC_9", "user": {"login": "carol", "type": "User"},
+         "body": "question", "created_at": "2026-01-01T00:00:00Z",
+         "updated_at": "2026-01-01T00:00:00Z",
+         "html_url": "https://github.com/o/r/pull/101#issuecomment-9"}])
+    fake_gh._write_threads([], number=101)
+    doc = gi.fetch_and_normalize(ws, "o/r", 101)
+    kinds = {e.kind for e in doc.evidence}
+    assert kinds == {"review", "inline_comment", "issue_comment"}   # nothing dropped
+    assert any(e.is_bot for e in doc.evidence)                        # bot actor retained
+    assert any(not e.is_bot for e in doc.evidence)                    # human actor retained
+    edited = next(e for e in doc.evidence if e.database_id == 7)
+    assert edited.updated_at > edited.created_at                      # edit metadata preserved
+    by_src = {e.source_id: e for e in doc.evidence}
+    assert by_src["github:review:1"].state == "COMMENTED"             # non-pure review body retained
+    assert by_src["github:review:2"].state == "APPROVED"              # pure approval retained as evidence
+    cands = {c.source_id for c in gi.project_candidates(doc, head_sha="a" * 40)}
+    assert "github:inline_comment:7" in cands                          # root comment is a candidate
+    assert "github:review:2" not in cands                              # pure approval: evidence only
+
+
 def test_graphql_review_threads_records_rate_limit_after_retries(tmp_path, fake_gh, monkeypatch):
     """Exhausting GraphQL rate-limit retries surfaces _ImportRateLimitError (ledger rate_limit)."""
     import pytest

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -1093,6 +1093,32 @@ def test_graphql_review_threads_retries_rate_limit_then_fails(tmp_path, fake_gh,
     assert calls["n"] == 3, "rate-limit retry should make 3 attempts"
 
 
+def test_spike_nested_comments_paginate_past_100(tmp_path, fake_gh):
+    from daydream.benchmark import github_import as gi
+
+    ws = tmp_path / "ws"
+    (ws / "imports").mkdir(parents=True)
+    fake_gh.set_response("GET", "repos/o/r/pulls/101", _PR_HEADER)
+    for ep, val in [("repos/o/r/pulls/101/reviews", []),
+                    ("repos/o/r/pulls/101/comments", []),
+                    ("repos/o/r/issues/101/comments", [])]:
+        fake_gh.set_response("GET", ep, val)
+    # thread "thread_1" carries 150 replies split across nested pages of 100+50
+    comments = [{"id": f"c{i}", "databaseId": 1000 + i, "body": f"r{i}",
+                 "author": {"login": "dave", "type": "User"},
+                 "createdAt": f"2026-01-01T00:00:{i % 60:02d}Z",
+                 "url": f"https://github.com/o/r/pull/101#discussion_r{1000+i}"}
+                for i in range(1, 151)]
+    fake_gh._serve_thread_comments("thread_1", comments, page_size=100)
+    fake_gh._write_threads([{"id": "thread_1", "isResolved": False,
+        "isOutdated": False, "subjectType": "LINE", "path": "a.py", "line": 4,
+        "side": "RIGHT", "comments": {"nodes": comments[:100]}}], number=101)
+    doc = gi.fetch_and_normalize(ws, "o/r", 101)
+    ids = {e.database_id for e in doc.evidence}
+    assert {1000 + i for i in range(1, 151)} <= ids     # all 150 collected
+    assert len([e for e in doc.evidence if 1000 <= e.database_id <= 1149]) == 150
+
+
 def test_graphql_review_threads_records_rate_limit_after_retries(tmp_path, fake_gh, monkeypatch):
     """Exhausting GraphQL rate-limit retries surfaces _ImportRateLimitError (ledger rate_limit)."""
     import pytest

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -1116,7 +1116,35 @@ def test_spike_nested_comments_paginate_past_100(tmp_path, fake_gh):
     doc = gi.fetch_and_normalize(ws, "o/r", 101)
     ids = {e.database_id for e in doc.evidence}
     assert {1000 + i for i in range(1, 151)} <= ids     # all 150 collected
-    assert len([e for e in doc.evidence if 1000 <= e.database_id <= 1149]) == 150
+    assert len([e for e in doc.evidence if 1000 <= e.database_id <= 1150]) == 150
+
+
+def test_graphql_threads_replies_collect_past_100(tmp_path, fake_gh):
+    from daydream.benchmark import github_import as gi
+
+    ws = tmp_path / "ws"
+    (ws / "imports").mkdir(parents=True)
+    fake_gh.set_response("GET", "repos/o/r/pulls/101", _PR_HEADER)
+    for ep in ("repos/o/r/pulls/101/reviews", "repos/o/r/pulls/101/comments",
+               "repos/o/r/issues/101/comments"):
+        fake_gh.set_response("GET", ep, [])
+    comments = [{"id": f"c{i}", "databaseId": 2000 + i, "body": f"reply {i}",
+                 "author": {"login": "eve", "type": "User"},
+                 "createdAt": f"2026-01-01T00:{i // 60:02d}:{i % 60:02d}Z",
+                 "replyTo": {"id": "c1"},
+                 "url": f"https://github.com/o/r/pull/101#discussion_r{2000+i}"}
+                for i in range(1, 251)]     # 250 replies -> 3 nested pages
+    fake_gh._serve_thread_comments("thread_9", comments, page_size=100)
+    fake_gh._write_threads([{"id": "thread_9", "isResolved": False,
+        "isOutdated": False, "subjectType": "LINE", "path": "a.py", "line": 4,
+        "side": "RIGHT", "comments": {"nodes": comments[:100]}}], number=101)
+    doc = gi.fetch_and_normalize(ws, "o/r", 101)
+    replies = [e for e in doc.evidence if 2000 <= e.database_id <= 2250]
+    assert len(replies) == 250
+    assert len({e.database_id for e in replies}) == 250        # no dup
+    # deterministic creation order preserved end to end
+    assert [e.database_id for e in sorted(replies, key=lambda r: r.database_id)] \
+           == sorted(range(2001, 2251))
 
 
 def test_graphql_review_threads_records_rate_limit_after_retries(tmp_path, fake_gh, monkeypatch):

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -1147,6 +1147,52 @@ def test_graphql_threads_replies_collect_past_100(tmp_path, fake_gh):
            == sorted(range(2001, 2251))
 
 
+def test_reconcile_inline_and_thread_into_one_record(tmp_path, fake_gh):
+    from daydream.benchmark import github_import as gi
+
+    ws = tmp_path / "ws"
+    (ws / "imports").mkdir(parents=True)
+    fake_gh.set_response("GET", "repos/o/r/pulls/101", _PR_HEADER)
+    # review id 5 with state DISMISSED (dismissal source for comment 10)
+    fake_gh.set_response("GET", "repos/o/r/pulls/101/reviews", [
+        {"id": 5, "node_id": "PRR_5", "user": {"login": "alice", "type": "User"},
+         "body": "", "state": "DISMISSED", "commit_id": "a" * 40,
+         "submitted_at": "2026-01-01T00:00:00Z",
+         "html_url": "https://github.com/o/r/pull/101#pullrequestreview-5"}])
+    # REST inline comment 10 is the root of thread_1, belongs to review 5
+    fake_gh.set_response("GET", "repos/o/r/pulls/101/comments", [
+        {"id": 10, "node_id": "DIFF_10", "user": {"login": "dave", "type": "User"},
+         "body": "root", "commit_id": "a" * 40, "original_commit_id": "a" * 40,
+         "path": "a.py", "original_path": "a.py", "line": 4, "original_line": 3,
+         "subject_type": "line", "side": "RIGHT",
+         "pull_request_review_id": 5,
+         "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",
+         "html_url": "https://github.com/o/r/pull/101#discussion_r10"}])
+    fake_gh.set_response("GET", "repos/o/r/issues/101/comments", [])
+    fake_gh._write_threads([{"id": "thread_1", "isResolved": True,
+        "isOutdated": True, "isResolvedBy": None, "subjectType": "LINE",
+        "path": "a.py", "line": 4, "originalLine": 3, "side": "RIGHT",
+        "startSide": None,
+        "comments": {"nodes": [
+            {"id": "c1", "databaseId": 10, "body": "root",
+             "author": {"login": "dave", "type": "User"},
+             "createdAt": "2026-01-01T00:00:00Z",
+             "url": "https://github.com/o/r/pull/101#discussion_r10"}]}}],
+        number=101)
+    doc = gi.fetch_and_normalize(ws, "o/r", 101)
+    by_db = {e.database_id: e for e in doc.evidence}
+    rec = by_db[10]
+    assert rec.kind == "inline_comment"
+    assert rec.source_id == "github:inline_comment:10"
+    assert rec.thread_id == "thread_1" and rec.resolved is True
+    assert rec.outdated is True and rec.dismissed is True      # via review 5 DISMISSED
+    assert rec.review_id == "5"
+    assert rec.commit_id == "a" * 40 and rec.path == "a.py"     # REST anchors kept
+    # exactly one record with database_id 10, no thread_comment kind anywhere
+    assert len([e for e in doc.evidence if e.database_id == 10]) == 1
+    assert not any(e.kind == "thread_comment" for e in doc.evidence)
+
+
 def test_graphql_review_threads_records_rate_limit_after_retries(tmp_path, fake_gh, monkeypatch):
     """Exhausting GraphQL rate-limit retries surfaces _ImportRateLimitError (ledger rate_limit)."""
     import pytest

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -265,12 +265,22 @@ def test_graphql_threads_and_replies_normalized(tmp_path, fake_gh):
     ws = tmp_path / "ws"
     (ws / "imports").mkdir(parents=True)
     fake_gh.set_response("GET", "repos/o/r/pulls/101", _PR_HEADER)
-    for ep, val in [
-        ("repos/o/r/pulls/101/reviews", []),
-        ("repos/o/r/pulls/101/comments", []),
-        ("repos/o/r/issues/101/comments", []),
-    ]:
-        fake_gh.set_response("GET", ep, val)
+    fake_gh.set_response("GET", "repos/o/r/pulls/101/reviews", [])
+    # REST comments for db 10 (root) and 11 (reply to 10)
+    fake_gh.set_response("GET", "repos/o/r/pulls/101/comments", [
+        {"id": 10, "node_id": "DIFF_10", "user": {"login": "dave", "type": "User"},
+         "body": "root", "commit_id": "a" * 40, "original_commit_id": "a" * 40,
+         "path": "a.py", "original_path": "a.py", "line": 4, "original_line": 3,
+         "subject_type": "line", "side": "RIGHT",
+         "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",
+         "html_url": "https://github.com/o/r/pull/101#discussion_r10"},
+        {"id": 11, "node_id": "DIFF_11", "user": {"login": "eve", "type": "User"},
+         "body": "reply", "commit_id": "a" * 40, "path": "a.py", "line": 5,
+         "subject_type": "line", "side": "RIGHT", "in_reply_to_id": 10,
+         "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",
+         "html_url": "https://github.com/o/r/pull/101#discussion_r11"},
+    ])
+    fake_gh.set_response("GET", "repos/o/r/issues/101/comments", [])
     fake_gh._write_threads([
         {"id": "thread_1", "isResolved": True,
          "isOutdated": True, "isResolvedBy": None,
@@ -285,14 +295,14 @@ def test_graphql_threads_and_replies_normalized(tmp_path, fake_gh):
          ]}},
     ])
     doc = gi.fetch_and_normalize(ws, "o/r", 101)
-    kinds = {e.kind for e in doc.evidence}
-    assert "thread_comment" in kinds
-    root = next(e for e in doc.evidence if e.database_id == 10)
-    reply = next(e for e in doc.evidence if e.database_id == 11)
+    by_db = {e.database_id: e for e in doc.evidence}
+    root, reply = by_db[10], by_db[11]
+    assert root.kind == "inline_comment" and root.source_id == "github:inline_comment:10"
     assert root.resolved is True and root.outdated is True
-    assert root.side == "RIGHT" and root.path == "a.py" and root.line == 4
-    assert reply.kind == "thread_comment" and reply.reply_to_id == "c1"
-    assert reply.thread_id == "thread_1"
+    assert root.thread_id == "thread_1" and root.side == "RIGHT" and root.path == "a.py"
+    assert reply.kind == "inline_comment" and reply.thread_id == "thread_1"
+    assert reply.reply_to_id == "10"          # REST in_reply_to_id (parent db id)
+    assert not any(e.kind == "thread_comment" for e in doc.evidence)
 
 
 def test_candidate_projection_right_file_body_left(tmp_path, fake_gh):
@@ -981,7 +991,12 @@ def test_e2e_paginated_human_bot_evidence_and_no_comment_pr(tmp_path, fake_gh):
     assert [p["number"] for p in raw["pull_requests"]] == [101, 102]
     imp = load_json_strict(ws / "imports/pr-000101.json")
     kinds = {e["kind"] for e in imp["evidence"]}
-    assert kinds == {"review", "inline_comment", "issue_comment", "thread_comment"}
+    assert kinds == {"review", "inline_comment", "issue_comment"}
+    # overlapping root (db 10) appears exactly once as a canonical inline_comment
+    assert len([e for e in imp["evidence"] if e["database_id"] == 10]) == 1
+    db10 = next(e for e in imp["evidence"] if e["database_id"] == 10)
+    assert db10["kind"] == "inline_comment" and db10["source_id"] == "github:inline_comment:10"
+    assert db10["thread_id"] == "thread_1"
     assert any(e["is_bot"] for e in imp["evidence"])      # bot author retained
     assert any(not e["is_bot"] for e in imp["evidence"])  # human author retained
     assert load_json_strict(ws / "imports/pr-000102.json")["evidence"] == []  # no-comment PR retained

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -883,6 +883,83 @@ def test_refresh_predate_import_metadata_change_does_not_stale(tmp_path, fake_gh
     assert case["curation"]["findings"]                  # curated gold preserved
 
 
+def test_refresh_predate_canonical_format_drift_does_not_stale(tmp_path, fake_gh):
+    """A first ``--refresh`` after the canonical-record format change must NOT
+    flip prior curated cases stale on pure format drift. Pre-canonicalization
+    files persisted a comment that existed in both feeds twice (REST
+    ``inline_comment`` + GraphQL ``thread_comment``) and thread-only comments
+    under the ``thread_comment`` kind; the canonical format emits exactly one
+    ``inline_comment`` per database id. With byte-identical GitHub content the
+    only difference is the persisted shape, so the (database_id-keyed) evidence
+    signature must compare equal and keep the curated case ready."""
+    import json
+
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.storage import load_json_strict, load_yaml_strict
+
+    ws = tmp_path / "ws"
+    _seed_preflight(ws, fake_gh)
+    fake_gh.set_response(
+        "GET",
+        "repos/o/r/pulls/101/comments",
+        [
+            {"id": 1, "node_id": "DIFF_1", "user": {"login": "alice", "type": "User"},
+             "body": "please fix", "commit_id": "a" * 40, "original_commit_id": "a" * 40,
+             "path": "a.py", "line": 4, "subject_type": "line", "side": "RIGHT",
+             "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",
+             "html_url": "https://github.com/o/r/pull/101#discussion_r1"},
+        ],
+    )
+    fake_gh._write_threads(
+        [
+            {"id": "thread_1", "isResolved": False, "isOutdated": False,
+             "subjectType": "LINE", "path": "a.py", "line": 4, "side": "RIGHT",
+             "comments": {"nodes": [
+                 {"id": "c1", "databaseId": 1, "body": "please fix",
+                  "author": {"login": "alice", "type": "User"},
+                  "createdAt": "2026-01-01T00:00:00Z",
+                  "url": "https://github.com/o/r/pull/101#discussion_r1"},
+                 {"id": "c2", "databaseId": 2, "body": "thread-only",
+                  "author": {"login": "alice", "type": "User"},
+                  "createdAt": "2026-01-01T00:00:00Z",
+                  "url": "https://github.com/o/r/pull/101#discussion_r2"},
+             ]}},
+        ],
+        number=101,
+    )
+    assert gi.run_import_prs(ws, pr_numbers=[101], heads=["final"], origin_url=None) == 0
+    _curate_case(ws, "pr-000101-aaaaaaaaaaaa.yaml")       # state=ready, attested
+    # Rewrite the persisted import in the pre-canonicalization shape: the comment
+    # that existed in both feeds (db 1) is stored twice (inline + thread_comment)
+    # and the thread-only comment (db 2) under the thread_comment kind.
+    import_path = ws / "imports" / "pr-000101.json"
+    raw = load_json_strict(import_path)
+    old_evidence: list[dict] = []
+    for e in raw["evidence"]:
+        if e.get("thread_id"):
+            if e.get("commit_id"):
+                old_evidence.append({**e,
+                                     "source_id": f"github:inline_comment:{e['database_id']}",
+                                     "kind": "inline_comment"})
+            old_evidence.append({**e,
+                                 "source_id": f"github:thread_comment:{e['database_id']}",
+                                 "kind": "thread_comment"})
+        else:
+            old_evidence.append(e)
+    assert len(old_evidence) == 3      # db 1 twice, db 2 once as thread_comment
+    import_path.write_text(json.dumps({**raw, "evidence": old_evidence}, indent=2))
+    # refresh with IDENTICAL GitHub content: only the persisted format changed
+    assert gi.run_import_prs(ws, pr_numbers=[101], heads=["final"], refresh=True, origin_url=None) == 0
+    case = load_yaml_strict(ws / "cases" / "pr-000101-aaaaaaaaaaaa.yaml")
+    assert case["curation"]["state"] == "ready"           # format drift must NOT stale gold
+    assert case["curation"]["findings"]                   # curated gold preserved
+    # the migration path rewrites the file to the canonical shape: exactly one
+    # inline_comment per database id
+    refreshed = load_json_strict(import_path)
+    assert len(refreshed["evidence"]) == 2
+    assert {e["kind"] for e in refreshed["evidence"]} == {"inline_comment"}
+
+
 def test_refresh_marks_stale_and_never_overwrites_curation(tmp_path, fake_gh):
     from daydream.benchmark import github_import as gi
     from daydream.benchmark.storage import load_yaml_strict

--- a/tests/test_benchmark_migrate.py
+++ b/tests/test_benchmark_migrate.py
@@ -2,6 +2,8 @@ import hashlib
 import uuid
 from pathlib import Path
 
+import yaml
+
 from daydream.benchmark import migrate, schema, storage
 
 _BASE = "0123456789abcdef0123456789abcdef01234567"
@@ -158,3 +160,28 @@ def test_upgrade_cli_error_returns_1(tmp_path, capsys):
     rc = _handle_benchmark_command(["upgrade", str(ws)])
     assert rc == 1
     assert "error" in capsys.readouterr().err
+
+
+def test_migrate_heals_interrupted_journal_under_lock(tmp_path):
+    """migrate_workspace must recover_startup under the workspace lock (like every
+    other locked writer) so a crashed curator journal is healed before it reads;
+    and its transaction op_id must be flat so no residue is left that bricks a
+    later recover_startup with WorkspaceCorrupt."""
+    ws, case_id, _ = _seed_v1_workspace(tmp_path)
+    path = ws / "cases" / f"{case_id}.yaml"
+    raw = storage.load_yaml_strict(path)
+    mutated = dict(raw)
+    mutated["curation"] = dict(raw["curation"])
+    mutated["curation"]["state"] = "excluded"    # an interrupted mutation left in flight
+    with storage.Transaction(ws, op_id=f"migrate-{case_id}", kind="migrate") as tx:
+        tx.stage(f"cases/{case_id}.yaml", yaml.safe_dump(mutated, sort_keys=False).encode("utf-8"))
+        tx.inject_crash("target-1")              # target applied under 'committing', then halt
+    assert storage.load_yaml_strict(path)["curation"]["state"] == "excluded"
+
+    migrate.migrate_workspace(ws)               # recover_startup under lock rolls the crash back
+
+    assert not list((ws / "transactions").iterdir())    # healed AND no residue left behind
+    final = storage.load_yaml_strict(path)
+    assert final["curation"]["state"] == "draft"        # interrupted 'excluded' write rolled back
+    assert final["schema_version"] == 2                 # the migration still ran
+    storage.recover_startup(ws)                         # a follow-up recovery must not brick


### PR DESCRIPTION
## Summary
Fixes #811 — reconcile and fully paginate review-thread evidence in the benchmark harness.

- Join REST inline review comments and GraphQL thread comments by stable GitHub database/node identity into one canonical root record.
- Retain each reply exactly once and paginate nested `comments(first:100)` beyond 100 (closed cursor, fail-closed).
- Preserve original/current anchors, commit IDs, outdated/resolved state, dismissal/deletion/edit metadata, author type, and review state.
- Require exact candidates' anchors valid at the selected frozen head; keep conversation comments, pure approvals, review bodies, roots, and replies as historical evidence.
- Deterministic ordering and source IDs independent of pagination page size.

## Acceptance criteria covered
- Fixtures cover overlapping REST/GraphQL roots, bot/human actors, edited/deleted comments, outdated/resolved threads, dismissal, pure approval, no-comment PRs, and >100 replies.
- One GitHub comment database ID yields one normalized evidence record.
- Outdated REST duplicates cannot bypass exact-candidate filtering.
- Pagination retries/resume do not duplicate or reorder evidence.
- No review evidence enters generated agent tasks except approved bounded PR title/body context.

## Test plan
- Full gate (`make check`): 4324 passed / 7 skipped, rc=0.
- Two sequential daydream deep-precision reviews passed (round 1 + round 2 on fresh VMs).

Closes #811