### PR TITLE
fix(benchmark): make workspace validation authoritative and path-contained

### DIFF
--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -1003,11 +1003,18 @@ def _prior_import_state(
     prior_task_sig: str | None = None
     prior_curations: dict[str, dict[str, Any]] = {}
     if existing is not None and existing.get("import_state") == "fetched":
-        prior_raw = storage.load_json_strict(root / existing["import_file"])
+        # Ledger-derived authoring paths go through the containment gate (same
+        # as every other workspace authoring read), so an absolute or escaping
+        # import_file/case_id can never read outside the workspace root.
+        prior_raw = storage.load_json_strict(
+            storage.resolve_authoring_path(root, existing["import_file"])
+        )
         prior_sig = _evidence_signature_from_raw(prior_raw)
         prior_task_sig = _task_input_signature_from_raw(prior_raw)
         for case_id in existing.get("case_ids", []):
-            cur = storage.load_yaml_strict(root / "cases" / f"{case_id}.yaml").get("curation")
+            cur = storage.load_yaml_strict(
+                storage.resolve_authoring_path(root, f"cases/{case_id}.yaml")
+            ).get("curation")
             if isinstance(cur, dict):
                 prior_curations[case_id] = cur
     return prior_sig, prior_task_sig, prior_curations, import_file

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -989,9 +989,13 @@ def _prior_import_state(
 ]:
     """The prior evidence signature, task-input signature, curations, and import path.
 
-    A missing/unreadable prior snapshot yields ``None`` for both signatures (so
-    a refresh cannot compare); an unreadable curation file is skipped, never
-    fatal.
+    A missing prior state (no ``fetched`` ledger entry, or no persisted
+    import/case to read) yields ``None`` for both signatures and empty
+    curations — the normal first-run path. A *present-but-corrupt* prior
+    import or curation file is fatal: :class:`~daydream.benchmark.storage.WorkspaceCorrupt`
+    from the strict loaders propagates so a refresh fails before any network
+    fetch or mutation, never silently healing corrupt prior state to
+    ``None``/``draft``.
     """
     import_file = f"imports/pr-{number:06d}.json"
     existing = _manifest_entry(raw, number)
@@ -999,20 +1003,13 @@ def _prior_import_state(
     prior_task_sig: str | None = None
     prior_curations: dict[str, dict[str, Any]] = {}
     if existing is not None and existing.get("import_state") == "fetched":
-        try:
-            prior_raw = storage.load_json_strict(root / existing["import_file"])
-            prior_sig = _evidence_signature_from_raw(prior_raw)
-            prior_task_sig = _task_input_signature_from_raw(prior_raw)
-        except Exception:
-            prior_sig = None
-            prior_task_sig = None
+        prior_raw = storage.load_json_strict(root / existing["import_file"])
+        prior_sig = _evidence_signature_from_raw(prior_raw)
+        prior_task_sig = _task_input_signature_from_raw(prior_raw)
         for case_id in existing.get("case_ids", []):
-            try:
-                cur = storage.load_yaml_strict(root / "cases" / f"{case_id}.yaml").get("curation")
-                if isinstance(cur, dict):
-                    prior_curations[case_id] = cur
-            except Exception:
-                pass
+            cur = storage.load_yaml_strict(root / "cases" / f"{case_id}.yaml").get("curation")
+            if isinstance(cur, dict):
+                prior_curations[case_id] = cur
     return prior_sig, prior_task_sig, prior_curations, import_file
 
 

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -1003,11 +1003,20 @@ def _prior_import_state(
     prior_task_sig: str | None = None
     prior_curations: dict[str, dict[str, Any]] = {}
     if existing is not None and existing.get("import_state") == "fetched":
+        prior_import_file = existing.get("import_file")
+        if not prior_import_file:
+            # A fetched ledger entry must name its import document; one that
+            # lacks or nulls import_file is corrupt prior state — without the
+            # guard it escapes as a bare KeyError/TypeError instead of the
+            # documented fail-closed WorkspaceCorrupt of the strict loaders.
+            raise storage.WorkspaceCorrupt(
+                f"{root}: fetched ledger entry for PR {number} is missing import_file"
+            )
         # Ledger-derived authoring paths go through the containment gate (same
         # as every other workspace authoring read), so an absolute or escaping
         # import_file/case_id can never read outside the workspace root.
         prior_raw = storage.load_json_strict(
-            storage.resolve_authoring_path(root, existing["import_file"])
+            storage.resolve_authoring_path(root, prior_import_file)
         )
         prior_sig = _evidence_signature_from_raw(prior_raw)
         prior_task_sig = _task_input_signature_from_raw(prior_raw)

--- a/daydream/benchmark/harbor/build.py
+++ b/daydream/benchmark/harbor/build.py
@@ -93,8 +93,11 @@ def _escape_historical_delimiters(text: str) -> str:
 
 # A persisted ``body_sha256`` is interpolated into the truncation marker only
 # when it has the schema's own digest shape (_hex64: lowercase 64-hex). The
-# compile path reads raw case docs with no model_validate, so any other value
-# is unvalidated input and falls back to the deterministic stored-body digest.
+# compile path loads every case through the shared model gate, where
+# ``PullRequestMeta._body_hash_consistency`` rejects a digest that mismatches
+# the stored body before it ever reaches this function; the shape check +
+# stored-body verification here is defense-in-depth, and any other value falls
+# back to the deterministic stored-body digest.
 _SHA256_HEX = re.compile(r"^[0-9a-f]{64}$")
 
 
@@ -140,12 +143,13 @@ def bounded_pr_context(
     # The marker attests the persisted normalized-body digest (body_sha256 at
     # import time) verbatim -- but only when it satisfies the schema's own
     # _body_hash_consistency contract (lowercase 64-hex equal to sha256 of the
-    # stored normalized body). The compile path reads raw case docs with no
-    # model_validate, so a hand-edited body_sha256 could otherwise inject
-    # content past the marker line or attest a digest that no longer matches
-    # the compiled body; any value outside that contract falls back to the
-    # deterministic stored-body digest (the same fallback as a missing key).
-    # Never re-derived from the escaped surface.
+    # stored normalized body). Every case the compile path loads passes the
+    # model gate first, so a hand-edited body_sha256 is rejected as corruption
+    # before it could inject content past the marker line or attest a digest
+    # that no longer matches the compiled body; any other value (e.g. an
+    # absent/blank digest) falls back to the deterministic stored-body digest
+    # (the same fallback as a missing key). Never re-derived from the escaped
+    # surface.
     stored_body = str(pull_request.get("body") or "")
     stored_digest = hashlib.sha256(stored_body.encode("utf-8")).hexdigest()
     persisted = str(pull_request.get("body_sha256") or "")
@@ -456,7 +460,7 @@ def _compile_case(stage: Path, ws: Path, case_doc: dict, repo_slug: str) -> dict
     expected = snapshot.get("bundle_sha256")
     if not bundle_rel or not expected:
         raise CompileError(f"case {case_id} ready snapshot missing bundle_file/bundle_sha256")
-    bundle_src = ws / bundle_rel
+    bundle_src = storage.resolve_authoring_path(ws, bundle_rel)
     if not bundle_src.is_file():
         raise CompileError(f"case {case_id} missing bundle {bundle_rel}")
     bundle_dst = case_stage / "environment" / "repository.bundle"
@@ -569,7 +573,11 @@ def compile_workspace(root: Path) -> dict:
         # requires the canonical order; reversed rows are not corruption here).
         manifest["cases"] = sorted(
             manifest.get("cases") or [],
-            key=lambda c: (c.get("pr_number", 0), schema.head_sha_from_case_id(c["case_id"]), c["case_id"]),
+            key=lambda c: (
+                int(c["pr_number"]),
+                schema.head_sha_from_case_id(c["case_id"]),
+                c["case_id"],
+            ),
         )
         # Every indexed case is loaded through the shared model-gated loader
         # (same ``_schema_ready`` + ``CaseDocument`` validation as the
@@ -600,7 +608,13 @@ def compile_workspace(root: Path) -> dict:
             control_plane: dict[str, str] = {"README.md": _ROOT_README}
             for _case in manifest.get("cases") or []:
                 case_id = _case.get("case_id")
-                row = _compile_case(stage, root, case_docs[case_id], repo_slug)
+                case_doc = case_docs.get(case_id)
+                if case_doc is None:
+                    raise CompileError(
+                        f"case {case_id} index row has no matching case document "
+                        "(row case_id disagrees with the case document's own case_id)"
+                    )
+                row = _compile_case(stage, root, case_doc, repo_slug)
                 case_rows.append(row)
                 key = row["key"]
                 all_files.update({f"{key}/{rel}": sha for rel, sha in row["files"].items()})

--- a/daydream/benchmark/harbor/build.py
+++ b/daydream/benchmark/harbor/build.py
@@ -574,9 +574,9 @@ def compile_workspace(root: Path) -> dict:
         manifest["cases"] = sorted(
             manifest.get("cases") or [],
             key=lambda c: (
-                int(c["pr_number"]),
-                schema.head_sha_from_case_id(c["case_id"]),
-                c["case_id"],
+                int(c.get("pr_number", 0) or 0),
+                schema.head_sha_from_case_id(c.get("case_id", "")),
+                c.get("case_id", ""),
             ),
         )
         # Every indexed case is loaded through the shared model-gated loader

--- a/daydream/benchmark/harbor/build.py
+++ b/daydream/benchmark/harbor/build.py
@@ -18,7 +18,7 @@ import re
 import shutil
 from pathlib import Path
 
-from daydream.benchmark import schema, snapshot, storage
+from daydream.benchmark import schema, snapshot, storage, workspace
 from daydream.benchmark.harbor import verifier_core as vc
 
 TEMPLATE_VERSION = "1"
@@ -563,18 +563,31 @@ def compile_workspace(root: Path) -> dict:
         manifest = storage.load_yaml_strict(root / "benchmark.yaml")
         repo_slug = manifest.get("source", {}).get("repository") or ""
 
+        # Compile canonicalizes the manifest's ``cases[]`` row order to the
+        # schema's canonical (pr_number, head-sha, case_id) order before model
+        # validation, so compile output stays row-order-insensitive (the model
+        # requires the canonical order; reversed rows are not corruption here).
+        manifest["cases"] = sorted(
+            manifest.get("cases") or [],
+            key=lambda c: (c.get("pr_number", 0), schema.head_sha_from_case_id(c["case_id"]), c["case_id"]),
+        )
+        # Every indexed case is loaded through the shared model-gated loader
+        # (same ``_schema_ready`` + ``CaseDocument`` validation as the
+        # validate/status read path); a present-but-corrupt case raises
+        # ``WorkspaceCorrupt`` before any staging begins.
+        manifest_model = schema.BenchmarkManifest.model_validate(manifest)
         case_docs: dict[str, dict] = {}
-        for _case in manifest.get("cases") or []:
-            case_id = _case.get("case_id")
-            doc = storage.load_yaml_strict(root / _case["case_file"])
-            if not _is_compilable(doc.get("curation") or {}):
-                curation = doc.get("curation") or {}
+        for case_file, doc in workspace.load_case_documents(root, manifest_model).items():
+            dumped = doc.model_dump(mode="json")
+            case_id = dumped["case_id"]
+            if not _is_compilable(dumped.get("curation") or {}):
+                curation = dumped.get("curation") or {}
                 raise CompileError(
                     f"case {case_id} is not compilable (state {curation.get('state')}, "
                     f"findings {len(curation.get('findings') or [])}, "
                     f"clean_attested {bool(curation.get('clean_attested'))})"
                 )
-            case_docs[case_id] = doc
+            case_docs[case_id] = dumped
 
         stage = root / "cache" / "harbor-build-stage"
         if stage.exists():

--- a/daydream/benchmark/storage.py
+++ b/daydream/benchmark/storage.py
@@ -586,6 +586,20 @@ def _resolve_target(root: Path, target: str | Path) -> str:
     return _resolve_cached(str(root_r), str(target))
 
 
+def resolve_authoring_path(root: Path, rel: str | Path) -> Path:
+    """Resolve an authoring path (case/import/bundle) contained in ``root``.
+
+    Stricter than :func:`_resolve_target` (which keeps serving the transaction
+    journal): any *absolute* authoring path is a containment violation, even
+    one resolving inside ``root``. ``..``, symlink-escape, and outside-root
+    inputs are rejected by :func:`_resolve_target` and surface as
+    :class:`WorkspaceCorrupt` naming the path.
+    """
+    if Path(rel).is_absolute():
+        raise WorkspaceCorrupt(f"{root}: authoring path must be relative: {rel!r}")
+    return root / _resolve_target(root, rel)
+
+
 # ---------------------------------------------------------------------------
 # startup recovery + orphan rules
 # ---------------------------------------------------------------------------
@@ -869,7 +883,7 @@ def _verify_complete(root: Path, op_dir: Path, doc: dict[str, Any]) -> None:
 
 
 def _apply_orphan_rule(root: Path, indexed: set[str], on_disk: set[Path]) -> None:
-    indexed_norm = {p.replace(os.sep, "/").lstrip("/") for p in indexed}
+    indexed_norm = {p.replace(os.sep, "/") for p in indexed}
     disk_rel: set[str] = set()
     for item in on_disk:
         p = Path(item)

--- a/daydream/benchmark/workspace.py
+++ b/daydream/benchmark/workspace.py
@@ -313,9 +313,13 @@ def _derived_state(
         pull_requests=pr_dicts,
         cases=_case_curation_states(root, manifest, docs),
     )
-    _verify_import_checksums(root, manifest)
+    # Model-validate every fetched import exactly once per call; the checksum
+    # and cross-document verifiers share this set instead of each re-reading
+    # and re-model-validating the same documents.
+    imports = _import_documents(root, manifest)
+    _verify_import_checksums(root, manifest, imports=imports)
     _verify_snapshot_checksums(root, manifest, docs)
-    _verify_cross_document(root, manifest, docs)
+    _verify_cross_document(root, manifest, docs, imports=imports)
     _verify_duplicate_inodes(root, manifest, docs)
     resolved = manifest.source.repository_id is not None and manifest.source.visibility != "unresolved"
     return state, resolved
@@ -339,8 +343,11 @@ def load_case_documents(root: Path, manifest: BenchmarkManifest) -> dict[str, Ca
         try:
             docs[case.case_file] = CaseDocument.model_validate(schema._schema_ready(raw))
         except Exception as exc:
+            # The diagnostic names only the case file -- never the pydantic
+            # error, whose repr embeds the input document (PR bodies/evidence)
+            # that the CLI's no-disclosure contract keeps off stderr.
             raise WorkspaceCorrupt(
-                f"{root}: case {case.case_file} is not a valid case document: {exc}"
+                f"{root}: case {case.case_file} is not a valid case document"
             ) from exc
     return docs
 
@@ -383,11 +390,52 @@ def _verify_snapshot_checksums(
             )
 
 
-def _verify_import_checksums(root: Path, manifest: BenchmarkManifest) -> None:
+def _load_import_document(root: Path, import_file: str) -> ImportDocument:
+    """Model-gate one fetched import through the shared strict loader.
+
+    The single definition of the import load+validate block shared by the
+    checksum and cross-document verifiers: resolution through
+    :func:`resolve_authoring_path` plus ``ImportDocument.model_validate`` on
+    the strict JSON read. A present-but-invalid import raises
+    :class:`WorkspaceCorrupt` naming only the import file -- the diagnostic
+    never embeds the document body (the CLI's no-disclosure contract).
+    """
+    path = resolve_authoring_path(root, import_file)
+    try:
+        return ImportDocument.model_validate(load_json_strict(path))
+    except Exception as exc:
+        raise WorkspaceCorrupt(
+            f"{root}: import {import_file} is not a valid import document"
+        ) from exc
+
+
+def _import_documents(root: Path, manifest: BenchmarkManifest) -> dict[str, ImportDocument]:
+    """Load every fetched import once through the shared model gate.
+
+    ``_derived_state`` precomputes the validated set so the checksum and
+    cross-document verifiers consume the same models instead of each
+    re-reading and re-model-validating every fetched import per call.
+    """
+    return {
+        pr.import_file: _load_import_document(root, pr.import_file)
+        for pr in manifest.pull_requests
+        if pr.import_state == "fetched" and pr.import_file
+    }
+
+
+def _verify_import_checksums(
+    root: Path,
+    manifest: BenchmarkManifest,
+    imports: dict[str, ImportDocument] | None = None,
+) -> None:
     """Verify each fetched import's on-disk sha256 against ``import_sha256``.
 
     A missing import file or a checksum mismatch is a :class:`WorkspaceCorrupt`
-    failure — it is never folded into an incomplete/curating result.
+    failure — it is never folded into an incomplete/curating result. When
+    ``imports`` is ``None`` each fetched import is additionally run through
+    the shared model gate (:func:`_load_import_document`); the validate/status
+    path precomputes the validated set (see :func:`_derived_state`) so every
+    import is model-validated exactly once per call.
     """
     for pr in manifest.pull_requests:
         if pr.import_state != "fetched" or pr.import_file is None or pr.import_sha256 is None:
@@ -403,15 +451,16 @@ def _verify_import_checksums(root: Path, manifest: BenchmarkManifest) -> None:
                 f"{root}: import {pr.import_file} checksum mismatch "
                 f"(expected {pr.import_sha256}, got {actual})"
             )
-        try:
-            ImportDocument.model_validate(load_json_strict(path))
-        except Exception as exc:
-            raise WorkspaceCorrupt(
-                f"{root}: import {pr.import_file} is not a valid import document: {exc}"
-            ) from exc
+        if imports is None:
+            _load_import_document(root, pr.import_file)
 
 
-def _verify_cross_document(root: Path, manifest: BenchmarkManifest, docs: dict[str, CaseDocument]) -> None:
+def _verify_cross_document(
+    root: Path,
+    manifest: BenchmarkManifest,
+    docs: dict[str, CaseDocument],
+    imports: dict[str, ImportDocument] | None = None,
+) -> None:
     """Verify every cross-document identity link and exact index membership.
 
     Each ``cases[]`` row must reference exactly ``cases/<case_id>.yaml`` and
@@ -449,13 +498,11 @@ def _verify_cross_document(root: Path, manifest: BenchmarkManifest, docs: dict[s
     for pr in manifest.pull_requests:
         if pr.import_state != "fetched" or pr.import_file is None:
             continue
-        path = resolve_authoring_path(root, pr.import_file)
-        try:
-            imp = ImportDocument.model_validate(load_json_strict(path))
-        except Exception as exc:
-            raise WorkspaceCorrupt(
-                f"{root}: import {pr.import_file} is not a valid import document: {exc}"
-            ) from exc
+        imp = (
+            imports[pr.import_file]
+            if imports is not None and pr.import_file in imports
+            else _load_import_document(root, pr.import_file)
+        )
         if imp.pull_request.number != pr.number:
             raise WorkspaceCorrupt(
                 f"{root}: import {pr.import_file} pull_request.number "

--- a/daydream/benchmark/workspace.py
+++ b/daydream/benchmark/workspace.py
@@ -265,12 +265,13 @@ def validate_workspace(root: Path) -> tuple[int, str]:
                 f"corrupt: invalid benchmark.yaml ({exc})",
             )
 
-        # Orphan + missing-indexed-file rule over the case/import set.
+        # Orphan + missing-indexed-file rule over the case/import/bundle set.
         try:
+            docs = load_case_documents(root, manifest)
             recover_startup(
                 root,
-                indexed=_case_index_paths(manifest),
-                on_disk=_scan_case_files(root),
+                indexed=_case_index_paths(manifest, docs),
+                on_disk=_scan_authoring_files(root),
             )
         except WorkspaceCorrupt as exc:
             return (classify_validation(corrupt=True, ready=False, incomplete=False), f"corrupt: {exc}")
@@ -279,7 +280,7 @@ def validate_workspace(root: Path) -> tuple[int, str]:
         # strictly and verifying import checksums (below) surfaces a
         # present-but-corrupt case as ``1`` rather than silently ``draft``.
         try:
-            state, resolved = _derived_state(root, manifest)
+            state, resolved = _derived_state(root, manifest, docs)
         except WorkspaceCorrupt as exc:
             return (classify_validation(corrupt=True, ready=False, incomplete=False), f"corrupt: {exc}")
 
@@ -315,6 +316,7 @@ def _derived_state(
     _verify_import_checksums(root, manifest)
     _verify_snapshot_checksums(root, manifest, docs)
     _verify_cross_document(root, manifest, docs)
+    _verify_duplicate_inodes(root, manifest, docs)
     resolved = manifest.source.repository_id is not None and manifest.source.visibility != "unresolved"
     return state, resolved
 
@@ -467,8 +469,51 @@ def _verify_cross_document(root: Path, manifest: BenchmarkManifest, docs: dict[s
             )
 
 
-def _case_index_paths(manifest: BenchmarkManifest) -> set[str]:
-    return {c.case_file for c in manifest.cases}
+def _case_index_paths(manifest: BenchmarkManifest, docs: dict[str, CaseDocument]) -> set[str]:
+    """Every authoring file the workspace index owns, across all three trees.
+
+    The manifest index covers each indexed case document **plus** every
+    ``fetched`` ledger import file **plus** every ``ready`` snapshot bundle
+    referenced by the model-validated case docs. Orphan detection then spans
+    ``cases/``, ``imports/``, and ``snapshots/``, so an unindexed import or
+    bundle — and a referenced-but-missing one — surfaces as
+    :class:`WorkspaceCorrupt` instead of being silently adopted or reported
+    ``incomplete``.
+    """
+    paths = {c.case_file for c in manifest.cases}
+    for pr in manifest.pull_requests:
+        if pr.import_state == "fetched" and pr.import_file:
+            paths.add(pr.import_file)
+    for case in manifest.cases:
+        doc = docs[case.case_file]
+        if doc.snapshot.status == "ready" and doc.snapshot.bundle_file:
+            paths.add(doc.snapshot.bundle_file)
+    return paths
+
+
+def _verify_duplicate_inodes(root: Path, manifest: BenchmarkManifest, docs: dict[str, CaseDocument]) -> None:
+    """Reject two distinct indexed authoring files sharing one ``(st_dev, st_ino)``.
+
+    A hard link (or any duplicate-inode surprise) between two differently-
+    named indexed authoring files is corruption: ``Path.resolve()`` cannot
+    distinguish the names (both resolve inside ``root``), so the batch inode
+    cross-check across every resolved indexed authoring file is the enforcement
+    point (Task 0 spike 4). Every check here is a hard failure — never a skip.
+    """
+    seen: dict[tuple[int, int], str] = {}
+    for rel in sorted(_case_index_paths(manifest, docs)):
+        path = resolve_authoring_path(root, rel)
+        if not path.exists():
+            # Missing indexed files are already corruption via the orphan rule /
+            # checksum gates; only collide on files that actually exist.
+            continue
+        key = (path.stat().st_dev, path.stat().st_ino)
+        if key in seen:
+            raise WorkspaceCorrupt(
+                f"{root}: indexed authoring files {seen[key]!r} and {rel!r} "
+                f"share inode ({key[0]}, {key[1]})"
+            )
+        seen[key] = rel
 
 
 def _case_curation_states(
@@ -520,12 +565,20 @@ def _case_snapshot_summaries(
     return summaries
 
 
-def _scan_case_files(root: Path) -> set[Path]:
-    cases_dir = root / "cases"
-    if not cases_dir.exists():
-        return set()
+def _scan_authoring_files(root: Path) -> set[Path]:
+    """Every regular file under the authoring trees: ``cases/``, ``imports/``, ``snapshots/``.
+
+    Runtime/cache/transaction residue is not authoring content, so it is never
+    scanned — an unindexed authoring file in one of the three trees is
+    orphan corruption, while internal state under ``runtime/``/``cache/``/
+    ``transactions/`` stays out of the orphan rule.
+    """
     found: set[Path] = set()
-    for entry in cases_dir.rglob("*"):
-        if entry.is_file():
-            found.add(entry)
+    for sub in ("cases", "imports", "snapshots"):
+        tree = root / sub
+        if not tree.exists():
+            continue
+        for entry in tree.rglob("*"):
+            if entry.is_file():
+                found.add(entry)
     return found

--- a/daydream/benchmark/workspace.py
+++ b/daydream/benchmark/workspace.py
@@ -24,6 +24,7 @@ from daydream.benchmark.schema import (
     BenchmarkManifest,
     CaseDocument,
     CaseIndexEntry,
+    ImportDocument,
     PreflightLedger,
     Privacy,
     PullRequestEntry,
@@ -383,17 +384,28 @@ def _verify_import_checksums(root: Path, manifest: BenchmarkManifest) -> None:
     """Verify each fetched import's on-disk sha256 against ``import_sha256``.
 
     A missing import file or a checksum mismatch is a :class:`WorkspaceCorrupt`
-    case — it is never folded into an incomplete/curating result.
+    failure — it is never folded into an incomplete/curating result.
     """
     for pr in manifest.pull_requests:
         if pr.import_state != "fetched" or pr.import_file is None or pr.import_sha256 is None:
             continue
-        actual = sha256_file(root / pr.import_file)
+        path = resolve_authoring_path(root, pr.import_file)
+        if not path.exists():
+            raise WorkspaceCorrupt(
+                f"{root}: import {pr.import_file} is missing on disk"
+            )
+        actual = sha256_file(path)
         if actual != pr.import_sha256:
             raise WorkspaceCorrupt(
                 f"{root}: import {pr.import_file} checksum mismatch "
                 f"(expected {pr.import_sha256}, got {actual})"
             )
+        try:
+            ImportDocument.model_validate(load_json_strict(path))
+        except Exception as exc:
+            raise WorkspaceCorrupt(
+                f"{root}: import {pr.import_file} is not a valid import document: {exc}"
+            ) from exc
 
 
 def _case_index_paths(manifest: BenchmarkManifest) -> set[str]:

--- a/daydream/benchmark/workspace.py
+++ b/daydream/benchmark/workspace.py
@@ -19,8 +19,10 @@ from uuid import uuid4
 
 import yaml
 
+from daydream.benchmark import schema
 from daydream.benchmark.schema import (
     BenchmarkManifest,
+    CaseDocument,
     CaseIndexEntry,
     PreflightLedger,
     Privacy,
@@ -37,6 +39,7 @@ from daydream.benchmark.storage import (
     load_json_strict,
     load_yaml_strict,
     recover_startup,
+    resolve_authoring_path,
     sha256_file,
 )
 
@@ -204,7 +207,7 @@ def workspace_status(root: Path) -> WorkspaceStatus:
             manifest = BenchmarkManifest.model_validate(raw)
         except Exception as exc:
             raise WorkspaceCorrupt(f"{root}: invalid benchmark.yaml: {exc}") from exc
-        docs = _load_case_docs(root, manifest)
+        docs = load_case_documents(root, manifest)
         state, resolved = _derived_state(root, manifest, docs)
         case_snapshots = _case_snapshot_summaries(root, manifest, docs)
     return WorkspaceStatus(
@@ -290,18 +293,19 @@ def validate_workspace(root: Path) -> tuple[int, str]:
 
 
 def _derived_state(
-    root: Path, manifest: BenchmarkManifest, docs: dict[str, dict] | None = None
+    root: Path, manifest: BenchmarkManifest, docs: dict[str, CaseDocument] | None = None
 ) -> tuple[str, bool]:
     """Shared (workspace state, identity-resolved) derivation for status+validate.
 
-    Loading each indexed case document with the strict loader and verifying
-    each fetched import's on-disk sha256 plus each ``ready`` snapshot's bundle
-    sha256 keeps the two read-only call paths on one rule set, so a
-    state/resolution rule can't diverge between them. An unreadable/invalid
-    case or a checksum mismatch surfaces as :class:`WorkspaceCorrupt`.
+    Loading each indexed case document with the shared model-gated loader and
+    verifying each fetched import's on-disk sha256 plus each ``ready``
+    snapshot's bundle sha256 keeps the two read-only call paths on one rule
+    set, so a state/resolution rule can't diverge between them. An
+    unreadable/invalid case or a checksum mismatch surfaces as
+    :class:`WorkspaceCorrupt`.
     """
     if docs is None:
-        docs = _load_case_docs(root, manifest)
+        docs = load_case_documents(root, manifest)
     pr_dicts = [{"import_state": pr.import_state} for pr in manifest.pull_requests]
     state = derive_workspace_state(
         pull_requests=pr_dicts,
@@ -313,24 +317,32 @@ def _derived_state(
     return state, resolved
 
 
-def _load_case_docs(root: Path, manifest: BenchmarkManifest) -> dict[str, dict]:
-    """Load every indexed case document strictly, once, keyed by ``case_file``.
+def load_case_documents(root: Path, manifest: BenchmarkManifest) -> dict[str, CaseDocument]:
+    """Load every indexed case document as a strict ``CaseDocument`` model.
 
-    ``_derived_state`` / ``_case_curation_states`` / ``_case_snapshot_summaries``
-    all need the same per-case YAML. Loading each file here once and sharing
-    the mapping avoids re-reading every case 2-3x per ``status``/``validate``
-    call. The strict loader is used, so an unreadable/invalid case surfaces as
-    :class:`WorkspaceCorrupt` (storage's invariant: a corrupt file is an error,
-    never defaulted).
+    Shared by the validate/status read path and the ``harbor`` compile path,
+    keyed by ``case_file``. Each case file is resolved through
+    :func:`resolve_authoring_path` (containment enforced) and validated with
+    ``CaseDocument.model_validate`` after the persisted ``gold_mode`` audit
+    field is stripped via :func:`schema._schema_ready` — a present-but-corrupt
+    case raises :class:`WorkspaceCorrupt` naming the ``case_file``, never a
+    defaulted/skipped read.
     """
-    docs: dict[str, dict] = {}
+    docs: dict[str, CaseDocument] = {}
     for case in manifest.cases:
-        docs[case.case_file] = load_yaml_strict(root / case.case_file)
+        path = resolve_authoring_path(root, case.case_file)
+        raw = load_yaml_strict(path)
+        try:
+            docs[case.case_file] = CaseDocument.model_validate(schema._schema_ready(raw))
+        except Exception as exc:
+            raise WorkspaceCorrupt(
+                f"{root}: case {case.case_file} is not a valid case document: {exc}"
+            ) from exc
     return docs
 
 
 def _verify_snapshot_checksums(
-    root: Path, manifest: BenchmarkManifest, docs: dict[str, dict] | None = None
+    root: Path, manifest: BenchmarkManifest, docs: dict[str, CaseDocument] | None = None
 ) -> None:
     """Verify each indexed ``ready`` snapshot's bundle file + sha256 digest.
 
@@ -342,24 +354,24 @@ def _verify_snapshot_checksums(
     structurally invalid and reported corrupt.
     """
     if docs is None:
-        docs = _load_case_docs(root, manifest)
+        docs = load_case_documents(root, manifest)
     for case in manifest.cases:
-        raw = docs[case.case_file]
-        snapshot = raw.get("snapshot")
-        if not isinstance(snapshot, dict) or snapshot.get("status") != "ready":
+        doc = docs[case.case_file]
+        snapshot = doc.snapshot
+        if snapshot.status != "ready":
             continue
-        bundle_rel = snapshot.get("bundle_file")
-        expected = snapshot.get("bundle_sha256")
+        bundle_rel = getattr(snapshot, "bundle_file", None)
+        expected = getattr(snapshot, "bundle_sha256", None)
         if not bundle_rel or not expected:
             raise WorkspaceCorrupt(
                 f"{root}: case {case.case_id} ready snapshot missing bundle_file/bundle_sha256"
             )
-        bundle_path = root / bundle_rel
-        actual = sha256_file(bundle_path) if bundle_path.exists() else ""
+        bundle_path = resolve_authoring_path(root, bundle_rel)
         if not bundle_path.exists():
             raise WorkspaceCorrupt(
                 f"{root}: case {case.case_id} snapshot bundle missing: {bundle_rel}"
             )
+        actual = sha256_file(bundle_path)
         if actual != expected:
             raise WorkspaceCorrupt(
                 f"{root}: case {case.case_id} snapshot bundle checksum mismatch "
@@ -389,54 +401,48 @@ def _case_index_paths(manifest: BenchmarkManifest) -> set[str]:
 
 
 def _case_curation_states(
-    root: Path, manifest: BenchmarkManifest, docs: dict[str, dict] | None = None
+    root: Path, manifest: BenchmarkManifest, docs: dict[str, CaseDocument] | None = None
 ) -> list[dict[str, str]]:
     """The ``curation.state`` per indexed case, for workspace-state derivation.
 
     ``derive_workspace_state`` needs the real curation states (its ``ready`` /
     ``stale`` / ``curating`` branches are driven by them); passing ``[]`` made
     those branches unreachable so a fully curated workspace could never report
-    ``ready``. Each case document is loaded with the strict loader — an
-    unreadable/invalid case surfaces as :class:`WorkspaceCorrupt` rather than
-    being silently folded into ``draft`` (storage's strict-loader invariant: a
-    corrupt file is an error, never defaulted). A present document without an
-    explicit curation state (or a non-mapping curation block) is treated
-    conservatively as ``draft`` so a workspace cannot claim ``ready`` while any
-    case is not verifiably curated.
+    ``ready``. Each case document is loaded through the shared model-gated
+    loader — an unreadable/invalid case surfaces as
+    :class:`WorkspaceCorrupt` rather than being silently folded into ``draft``
+    (storage's strict-loader invariant: a corrupt file is an error, never
+    defaulted). A validated model always carries a concrete ``curation.state``.
     """
     if docs is None:
-        docs = _load_case_docs(root, manifest)
+        docs = load_case_documents(root, manifest)
     states: list[dict[str, str]] = []
     for case in manifest.cases:
-        raw = docs[case.case_file]
-        curation = raw.get("curation")
-        cs = curation.get("state") if isinstance(curation, dict) else None
-        states.append({"curation_state": cs or "draft"})
+        states.append({"curation_state": docs[case.case_file].curation.state})
     return states
 
 
 def _case_snapshot_summaries(
-    root: Path, manifest: BenchmarkManifest, docs: dict[str, dict] | None = None
+    root: Path, manifest: BenchmarkManifest, docs: dict[str, CaseDocument] | None = None
 ) -> list[dict[str, str]]:
     """Per-case snapshot summary for ``status``: snapshot state + frozen head.
 
-    For each indexed case, loads the case strictly and reports its snapshot
-    ``status`` (``ready``/``unreplayable``/``imported``) and the frozen head
-    prefix (``original_head_sha[:12]``) when present. An unreadable/invalid
-    case surfaces as :class:`WorkspaceCorrupt` (shared with the validate path).
+    For each indexed case, loads the case through the shared model-gated
+    loader and reports its snapshot ``status`` and the frozen head prefix
+    (``original_head_sha[:12]``) when present. An unreadable/invalid case
+    surfaces as :class:`WorkspaceCorrupt` (shared with the validate path).
     """
     if docs is None:
-        docs = _load_case_docs(root, manifest)
+        docs = load_case_documents(root, manifest)
     summaries: list[dict[str, str]] = []
     for case in manifest.cases:
-        raw = docs[case.case_file]
-        snapshot = raw.get("snapshot")
-        status = snapshot.get("status") if isinstance(snapshot, dict) else "imported"
-        head = (snapshot or {}).get("original_head_sha") or ""
+        doc = docs[case.case_file]
+        status = doc.snapshot.status or "imported"
+        head = doc.snapshot.original_head_sha or ""
         summaries.append(
             {
                 "case_id": case.case_id,
-                "snapshot_status": status or "imported",
+                "snapshot_status": status,
                 "head_prefix": head[:12],
             }
         )

--- a/daydream/benchmark/workspace.py
+++ b/daydream/benchmark/workspace.py
@@ -44,7 +44,7 @@ from daydream.benchmark.storage import (
     sha256_file,
 )
 
-_SUBDIRS = ("imports", "cases", "snapshots", "transactions", "runtime", "cache", "harbor")
+_SUBDIRS = ("imports", "cases", "snapshots", "transactions", "runtime", "cache")
 
 _PRIVACY_CLASSIFICATION = "confidential"
 

--- a/daydream/benchmark/workspace.py
+++ b/daydream/benchmark/workspace.py
@@ -314,6 +314,7 @@ def _derived_state(
     )
     _verify_import_checksums(root, manifest)
     _verify_snapshot_checksums(root, manifest, docs)
+    _verify_cross_document(root, manifest, docs)
     resolved = manifest.source.repository_id is not None and manifest.source.visibility != "unresolved"
     return state, resolved
 
@@ -406,6 +407,64 @@ def _verify_import_checksums(root: Path, manifest: BenchmarkManifest) -> None:
             raise WorkspaceCorrupt(
                 f"{root}: import {pr.import_file} is not a valid import document: {exc}"
             ) from exc
+
+
+def _verify_cross_document(root: Path, manifest: BenchmarkManifest, docs: dict[str, CaseDocument]) -> None:
+    """Verify every cross-document identity link and exact index membership.
+
+    Each ``cases[]`` row must reference exactly ``cases/<case_id>.yaml`` and
+    agree with its case document's ``pull_request.number``; every case must
+    appear in the ``pull_requests[]`` ledger; every ``fetched`` ledger entry's
+    ``case_ids`` must cover its cases; and each fetched import document must
+    name the same PR number and repository as its ledger entry. Any mismatch
+    is :class:`WorkspaceCorrupt` — never a logged skip.
+    """
+    ledger = {pr.number: pr for pr in manifest.pull_requests}
+    for case in manifest.cases:
+        exact = f"cases/{case.case_id}.yaml"
+        if case.case_file != exact:
+            raise WorkspaceCorrupt(
+                f"{root}: case {case.case_id} case_file {case.case_file!r} is not the "
+                f"exact index path {exact!r}"
+            )
+        doc = docs[case.case_file]
+        if doc.pull_request.number != case.pr_number:
+            raise WorkspaceCorrupt(
+                f"{root}: case {case.case_id} pull_request.number {doc.pull_request.number} "
+                f"mismatches cases[] pr_number {case.pr_number}"
+            )
+        pr = ledger.get(case.pr_number)
+        if pr is None:
+            raise WorkspaceCorrupt(
+                f"{root}: case {case.case_id} PR {case.pr_number} is absent from "
+                f"the pull_requests ledger"
+            )
+        if case.case_id not in pr.case_ids:
+            raise WorkspaceCorrupt(
+                f"{root}: ledger PR {case.pr_number} case_ids {pr.case_ids!r} does not "
+                f"contain indexed case {case.case_id}"
+            )
+    for pr in manifest.pull_requests:
+        if pr.import_state != "fetched" or pr.import_file is None:
+            continue
+        path = resolve_authoring_path(root, pr.import_file)
+        try:
+            imp = ImportDocument.model_validate(load_json_strict(path))
+        except Exception as exc:
+            raise WorkspaceCorrupt(
+                f"{root}: import {pr.import_file} is not a valid import document: {exc}"
+            ) from exc
+        if imp.pull_request.number != pr.number:
+            raise WorkspaceCorrupt(
+                f"{root}: import {pr.import_file} pull_request.number "
+                f"{imp.pull_request.number} mismatches ledger PR {pr.number}"
+            )
+        if imp.repository.name_with_owner != manifest.source.repository:
+            raise WorkspaceCorrupt(
+                f"{root}: import {pr.import_file} repository "
+                f"{imp.repository.name_with_owner!r} mismatches manifest source "
+                f"{manifest.source.repository!r}"
+            )
 
 
 def _case_index_paths(manifest: BenchmarkManifest) -> set[str]:

--- a/daydream/benchmark/workspace.py
+++ b/daydream/benchmark/workspace.py
@@ -12,12 +12,15 @@ failures map to the documented exit codes.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any, TypeVar
 from uuid import uuid4
 
 import yaml
+from pydantic import BaseModel
 
 from daydream.benchmark import schema
 from daydream.benchmark.schema import (
@@ -299,12 +302,12 @@ def _derived_state(
 ) -> tuple[str, bool]:
     """Shared (workspace state, identity-resolved) derivation for status+validate.
 
-    Loading each indexed case document with the shared model-gated loader and
-    verifying each fetched import's on-disk sha256 plus each ``ready``
-    snapshot's bundle sha256 keeps the two read-only call paths on one rule
-    set, so a state/resolution rule can't diverge between them. An
-    unreadable/invalid case or a checksum mismatch surfaces as
-    :class:`WorkspaceCorrupt`.
+    Loading each indexed case document with the shared model-gated loader,
+    resolving every indexed authoring file exactly once, and verifying each
+    fetched import's on-disk sha256 plus each ``ready`` snapshot's bundle
+    sha256 keeps the two read-only call paths on one rule, so a
+    state/resolution rule can't diverge between them. An unreadable/invalid
+    case or a checksum mismatch surfaces as :class:`WorkspaceCorrupt`.
     """
     if docs is None:
         docs = load_case_documents(root, manifest)
@@ -315,12 +318,16 @@ def _derived_state(
     )
     # Model-validate every fetched import exactly once per call; the checksum
     # and cross-document verifiers share this set instead of each re-reading
-    # and re-model-validating the same documents.
+    # and re-model-validating the same documents. The authoring index is
+    # likewise resolved (and existence-checked) exactly once per call, shared
+    # by the checksum + duplicate-inode verifiers instead of each verifier
+    # re-resolving the same files.
     imports = _import_documents(root, manifest)
-    _verify_import_checksums(root, manifest, imports=imports)
-    _verify_snapshot_checksums(root, manifest, docs)
+    paths = _resolved_authoring_paths(root, manifest, docs)
+    _verify_import_checksums(root, manifest, paths)
+    _verify_snapshot_checksums(root, manifest, docs, paths)
     _verify_cross_document(root, manifest, docs, imports=imports)
-    _verify_duplicate_inodes(root, manifest, docs)
+    _verify_duplicate_inodes(root, paths)
     resolved = manifest.source.repository_id is not None and manifest.source.visibility != "unresolved"
     return state, resolved
 
@@ -338,22 +345,58 @@ def load_case_documents(root: Path, manifest: BenchmarkManifest) -> dict[str, Ca
     """
     docs: dict[str, CaseDocument] = {}
     for case in manifest.cases:
-        path = resolve_authoring_path(root, case.case_file)
-        raw = load_yaml_strict(path)
-        try:
-            docs[case.case_file] = CaseDocument.model_validate(schema._schema_ready(raw))
-        except Exception as exc:
-            # The diagnostic names only the case file -- never the pydantic
-            # error, whose repr embeds the input document (PR bodies/evidence)
-            # that the CLI's no-disclosure contract keeps off stderr.
-            raise WorkspaceCorrupt(
-                f"{root}: case {case.case_file} is not a valid case document"
-            ) from exc
+        docs[case.case_file] = _load_authoring_document(
+            root,
+            case.case_file,
+            what="case",
+            loader=load_yaml_strict,
+            model=CaseDocument,
+            preprocess=schema._schema_ready,
+        )
     return docs
 
 
+_ModelT = TypeVar("_ModelT", bound=BaseModel)
+
+
+def _load_authoring_document(
+    root: Path,
+    rel: str,
+    *,
+    what: str,
+    loader: Callable[[Path], dict[str, Any]],
+    model: type[_ModelT],
+    preprocess: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+) -> _ModelT:
+    """Resolve one authoring document and model-gate it through the strict loader.
+
+    The single definition of the resolve -> strict-load -> model-validate ->
+    wrap-in-:class:`WorkspaceCorrupt` block shared by the case and import
+    authoring loaders: resolution through :func:`resolve_authoring_path`, the
+    strict ``loader``, then ``model.model_validate`` (with an optional
+    ``preprocess`` of the raw dict, e.g. :func:`schema._schema_ready`). A
+    present-but-invalid document raises :class:`WorkspaceCorrupt` naming only
+    ``what`` + the authoring file -- the diagnostic never embeds the pydantic
+    error, whose repr embeds the input document (PR bodies/evidence) that the
+    CLI's no-disclosure contract keeps off stderr.
+    """
+    path = resolve_authoring_path(root, rel)
+    try:
+        raw = loader(path)
+        if preprocess is not None:
+            raw = preprocess(raw)
+        return model.model_validate(raw)
+    except Exception as exc:
+        raise WorkspaceCorrupt(
+            f"{root}: {what} {rel} is not a valid {what} document"
+        ) from exc
+
+
 def _verify_snapshot_checksums(
-    root: Path, manifest: BenchmarkManifest, docs: dict[str, CaseDocument] | None = None
+    root: Path,
+    manifest: BenchmarkManifest,
+    docs: dict[str, CaseDocument],
+    paths: dict[str, Path],
 ) -> None:
     """Verify each indexed ``ready`` snapshot's bundle file + sha256 digest.
 
@@ -362,23 +405,22 @@ def _verify_snapshot_checksums(
     never curatable staleness, and never mutates the case document or ledger.
 
     A ``ready`` snapshot with no ``bundle_file``/``bundle_sha256`` is itself
-    structurally invalid and reported corrupt.
+    structurally invalid and reported corrupt. ``paths`` is the shared
+    single-resolution pass (:func:`_resolved_authoring_paths`); a ``ready``
+    bundle absent from it is a missing file.
     """
-    if docs is None:
-        docs = load_case_documents(root, manifest)
     for case in manifest.cases:
-        doc = docs[case.case_file]
-        snapshot = doc.snapshot
-        if snapshot.status != "ready":
+        snapshot = docs[case.case_file].snapshot
+        if not isinstance(snapshot, schema.SnapshotReady):
             continue
-        bundle_rel = getattr(snapshot, "bundle_file", None)
-        expected = getattr(snapshot, "bundle_sha256", None)
+        bundle_rel = snapshot.bundle_file
+        expected = snapshot.bundle_sha256
         if not bundle_rel or not expected:
             raise WorkspaceCorrupt(
                 f"{root}: case {case.case_id} ready snapshot missing bundle_file/bundle_sha256"
             )
-        bundle_path = resolve_authoring_path(root, bundle_rel)
-        if not bundle_path.exists():
+        bundle_path = paths.get(bundle_rel)
+        if bundle_path is None:
             raise WorkspaceCorrupt(
                 f"{root}: case {case.case_id} snapshot bundle missing: {bundle_rel}"
             )
@@ -394,19 +436,20 @@ def _load_import_document(root: Path, import_file: str) -> ImportDocument:
     """Model-gate one fetched import through the shared strict loader.
 
     The single definition of the import load+validate block shared by the
-    checksum and cross-document verifiers: resolution through
-    :func:`resolve_authoring_path` plus ``ImportDocument.model_validate`` on
-    the strict JSON read. A present-but-invalid import raises
-    :class:`WorkspaceCorrupt` naming only the import file -- the diagnostic
-    never embeds the document body (the CLI's no-disclosure contract).
+    checksum and cross-document verifiers (see :func:`_load_authoring_document`):
+    resolution through :func:`resolve_authoring_path` plus
+    ``ImportDocument.model_validate`` on the strict JSON read. A
+    present-but-invalid import raises :class:`WorkspaceCorrupt` naming only
+    the import file -- the diagnostic never embeds the document body (the
+    CLI's no-disclosure contract).
     """
-    path = resolve_authoring_path(root, import_file)
-    try:
-        return ImportDocument.model_validate(load_json_strict(path))
-    except Exception as exc:
-        raise WorkspaceCorrupt(
-            f"{root}: import {import_file} is not a valid import document"
-        ) from exc
+    return _load_authoring_document(
+        root,
+        import_file,
+        what="import",
+        loader=load_json_strict,
+        model=ImportDocument,
+    )
 
 
 def _import_documents(root: Path, manifest: BenchmarkManifest) -> dict[str, ImportDocument]:
@@ -426,33 +469,29 @@ def _import_documents(root: Path, manifest: BenchmarkManifest) -> dict[str, Impo
 def _verify_import_checksums(
     root: Path,
     manifest: BenchmarkManifest,
-    imports: dict[str, ImportDocument] | None = None,
+    paths: dict[str, Path],
 ) -> None:
     """Verify each fetched import's on-disk sha256 against ``import_sha256``.
 
     A missing import file or a checksum mismatch is a :class:`WorkspaceCorrupt`
-    failure — it is never folded into an incomplete/curating result. When
-    ``imports`` is ``None`` each fetched import is additionally run through
-    the shared model gate (:func:`_load_import_document`); the validate/status
-    path precomputes the validated set (see :func:`_derived_state`) so every
-    import is model-validated exactly once per call.
+    failure — it is never folded into an incomplete/curating result. Each
+    import is model-validated exactly once per call by :func:`_import_documents`
+    before the verifiers run (see :func:`_derived_state`), and ``paths`` is
+    the shared single-resolution pass (:func:`_resolved_authoring_paths`);
+    an import absent from it is a missing file.
     """
     for pr in manifest.pull_requests:
         if pr.import_state != "fetched" or pr.import_file is None or pr.import_sha256 is None:
             continue
-        path = resolve_authoring_path(root, pr.import_file)
-        if not path.exists():
-            raise WorkspaceCorrupt(
-                f"{root}: import {pr.import_file} is missing on disk"
-            )
+        path = paths.get(pr.import_file)
+        if path is None:
+            raise WorkspaceCorrupt(f"{root}: import {pr.import_file} is missing on disk")
         actual = sha256_file(path)
         if actual != pr.import_sha256:
             raise WorkspaceCorrupt(
                 f"{root}: import {pr.import_file} checksum mismatch "
                 f"(expected {pr.import_sha256}, got {actual})"
             )
-        if imports is None:
-            _load_import_document(root, pr.import_file)
 
 
 def _verify_cross_document(
@@ -464,11 +503,16 @@ def _verify_cross_document(
     """Verify every cross-document identity link and exact index membership.
 
     Each ``cases[]`` row must reference exactly ``cases/<case_id>.yaml`` and
-    agree with its case document's ``pull_request.number``; every case must
-    appear in the ``pull_requests[]`` ledger; every ``fetched`` ledger entry's
-    ``case_ids`` must cover its cases; and each fetched import document must
-    name the same PR number and repository as its ledger entry. Any mismatch
-    is :class:`WorkspaceCorrupt` — never a logged skip.
+    agree with its case document's ``pull_request.number``, and its PR must be
+    present in the ``pull_requests[]`` ledger. Every case_id a ledger entry
+    claims must be backed by an indexed ``cases[]`` row naming the same PR —
+    the reverse (every indexed case covered by ``case_ids``) is not required,
+    because a fetched->fetched narrower re-import (shrink) rewrites the
+    ledger's ``case_ids`` to the newly requested heads while the previously
+    imported case rows stay indexed, so the index legitimately outgrows the
+    claim. Each fetched import document must name the same PR number and
+    repository as its ledger entry. Any mismatch is
+    :class:`WorkspaceCorrupt` — never a logged skip.
     """
     ledger = {pr.number: pr for pr in manifest.pull_requests}
     for case in manifest.cases:
@@ -484,18 +528,20 @@ def _verify_cross_document(
                 f"{root}: case {case.case_id} pull_request.number {doc.pull_request.number} "
                 f"mismatches cases[] pr_number {case.pr_number}"
             )
-        pr = ledger.get(case.pr_number)
-        if pr is None:
+        if case.pr_number not in ledger:
             raise WorkspaceCorrupt(
                 f"{root}: case {case.case_id} PR {case.pr_number} is absent from "
                 f"the pull_requests ledger"
             )
-        if case.case_id not in pr.case_ids:
-            raise WorkspaceCorrupt(
-                f"{root}: ledger PR {case.pr_number} case_ids {pr.case_ids!r} does not "
-                f"contain indexed case {case.case_id}"
-            )
+    indexed_cases = {case.case_id: case for case in manifest.cases}
     for pr in manifest.pull_requests:
+        for case_id in pr.case_ids:
+            row = indexed_cases.get(case_id)
+            if row is None or row.pr_number != pr.number:
+                raise WorkspaceCorrupt(
+                    f"{root}: ledger PR {pr.number} case_ids {pr.case_ids!r} claims "
+                    f"case {case_id} with no matching indexed cases[] row"
+                )
         if pr.import_state != "fetched" or pr.import_file is None:
             continue
         imp = (
@@ -538,22 +584,43 @@ def _case_index_paths(manifest: BenchmarkManifest, docs: dict[str, CaseDocument]
     return paths
 
 
-def _verify_duplicate_inodes(root: Path, manifest: BenchmarkManifest, docs: dict[str, CaseDocument]) -> None:
+def _resolved_authoring_paths(
+    root: Path, manifest: BenchmarkManifest, docs: dict[str, CaseDocument]
+) -> dict[str, Path]:
+    """Resolve every indexed authoring file exactly once, omitting missing ones.
+
+    One :func:`resolve_authoring_path` + existence check per indexed rel,
+    shared by the checksum and duplicate-inode verifiers so each
+    validate/status call makes a single resolve+stat pass over the index
+    instead of one per verifier. Missing files never enter the map — the
+    checksum verifiers report them as corrupt (a missing import/bundle is
+    :class:`WorkspaceCorrupt`), and the inode verifier only collides files
+    that actually exist.
+    """
+    paths: dict[str, Path] = {}
+    for rel in _case_index_paths(manifest, docs):
+        path = resolve_authoring_path(root, rel)
+        if path.exists():
+            paths[rel] = path
+    return paths
+
+
+def _verify_duplicate_inodes(root: Path, paths: dict[str, Path]) -> None:
     """Reject two distinct indexed authoring files sharing one ``(st_dev, st_ino)``.
 
     A hard link (or any duplicate-inode surprise) between two differently-
     named indexed authoring files is corruption: ``Path.resolve()`` cannot
     distinguish the names (both resolve inside ``root``), so the batch inode
     cross-check across every resolved indexed authoring file is the enforcement
-    point (Task 0 spike 4). Every check here is a hard failure — never a skip.
+    point (Task 0 spike 4). ``paths`` is the shared single-resolution pass
+    (:func:`_resolved_authoring_paths`): missing files are already omitted
+    there (they are corruption via the orphan rule / checksum gates), so only
+    files that actually exist are collided. Every check here is a hard
+    failure — never a skip.
     """
     seen: dict[tuple[int, int], str] = {}
-    for rel in sorted(_case_index_paths(manifest, docs)):
-        path = resolve_authoring_path(root, rel)
-        if not path.exists():
-            # Missing indexed files are already corruption via the orphan rule /
-            # checksum gates; only collide on files that actually exist.
-            continue
+    for rel in sorted(paths):
+        path = paths[rel]
         key = (path.stat().st_dev, path.stat().st_ino)
         if key in seen:
             raise WorkspaceCorrupt(

--- a/tests/test_benchmark_harbor_build.py
+++ b/tests/test_benchmark_harbor_build.py
@@ -686,26 +686,38 @@ def test_unbounded_pr_body_never_leaks_to_compiled_surface(tmp_path, fake_gh):
 
 def test_compile_guards_marker_digest_against_raw_doc_injection(tmp_path, fake_gh):
     from daydream.benchmark import storage
-    from daydream.benchmark.harbor.build import compile_workspace
+    from daydream.benchmark.harbor.build import CompileError, compile_workspace
+    from daydream.benchmark.storage import WorkspaceCorrupt
     ws, case_id, _ = _seed_ready_workspace(tmp_path, fake_gh)
     # hand-edited case YAML: an unbounded body (forces truncation under the
-    # compiled 32 KiB default). The model gate now requires the persisted
-    # body_sha256 to equal sha256(body), so an attacker-supplied bogus digest
-    # never reaches the compiler; the marker must still carry the truthful
-    # digest rather than trusting a field it does not re-derive.
+    # compiled 32 KiB default). The model gate requires the persisted
+    # body_sha256 to equal sha256(body), so a bogus attacker-supplied digest
+    # fails closed at load time and never reaches the compiler.
     case_path = ws / "cases" / f"{case_id}.yaml"
     raw = storage.load_yaml_strict(case_path)
     raw["pull_request"] = dict(raw["pull_request"])
     body = "secret-sentinel-a1b2 " + "\U0001F600" * 9000 + "\nZ" * 500
     raw["pull_request"]["body"] = body
+    # bogus digest: 64-hex but != sha256(body) -> the model gate rejects the
+    # case before any compile, so a poisoned body_sha256 can neither inject
+    # content past the marker nor attest a wrong digest (fail-closed end-to-end
+    # through compile_workspace).
+    raw["pull_request"]["body_sha256"] = "c3d4" * 16
+    storage.atomic_write_yaml(case_path, raw)
+    with pytest.raises((CompileError, WorkspaceCorrupt)):
+        compile_workspace(ws)
+    # truthful digest passes the gate; the marker must still carry that
+    # truthful digest rather than trusting a field the compiler does not
+    # re-derive.
     raw["pull_request"]["body_sha256"] = hashlib.sha256(body.encode("utf-8")).hexdigest()
     storage.atomic_write_yaml(case_path, raw)
     lock = compile_workspace(ws)
     key = next(iter(lock["cases"]))
     instr = (ws / "harbor" / key / "instruction.md").read_text()
     assert instr.count("</historical_pr_context>") == 1   # no breakout via body_sha256
-    assert "secret-sentinel-c3d4" not in instr
     inner = instr.split("<historical_pr_context>", 1)[1].split("</historical_pr_context>", 1)[0]
+    outside = instr.replace(f"<historical_pr_context>{inner}</historical_pr_context>", "")
+    assert "secret-sentinel-a1b2" not in outside          # raw body stays inside the block
     marker = next(
         line for line in inner.splitlines() if line.startswith("[truncated")
     )

--- a/tests/test_benchmark_harbor_build.py
+++ b/tests/test_benchmark_harbor_build.py
@@ -948,5 +948,10 @@ def test_compile_uses_shared_model_gated_loader(tmp_path, fake_gh, monkeypatch):
 
     monkeypatch.setattr(ws_mod, "load_case_documents", spy)
     ws, case_id, _ = _seed_ready_workspace(tmp_path, fake_gh)
-    build.compile_workspace(ws)
+    key = build.derive_task_key(case_id)
+    lock = build.compile_workspace(ws)
     assert calls, "compile must consume the shared model-gated loader"
+    case = ws / "harbor" / key
+    assert (case / "instruction.md").exists()
+    assert (case / "tests" / "golden-review.json").exists()
+    assert lock["cases"][key]["case_id"] == case_id

--- a/tests/test_benchmark_harbor_build.py
+++ b/tests/test_benchmark_harbor_build.py
@@ -216,12 +216,17 @@ def _seed_second_ready_case(ws: Path, tmp_path: Path, fake_gh, *, lines: int = 3
 
 
 def _inject_body(ws: Path, case_id: str, body: str) -> None:
-    """Seed a body into the case document's raw pull_request block (raw-dict compile path)."""
+    """Seed a body into the case document, carrying a truthful ``body_sha256``.
+
+    The case doc is model-validated on both read paths, so the injected body
+    must ship the matching digest to reach the compile-time leak guards.
+    """
     from daydream.benchmark import storage
     path = ws / "cases" / f"{case_id}.yaml"
     raw = storage.load_yaml_strict(path)
     raw["pull_request"] = dict(raw["pull_request"])
     raw["pull_request"]["body"] = body
+    raw["pull_request"]["body_sha256"] = hashlib.sha256(body.encode("utf-8")).hexdigest()
     storage.atomic_write_yaml(path, raw)
 
 
@@ -684,17 +689,16 @@ def test_compile_guards_marker_digest_against_raw_doc_injection(tmp_path, fake_g
     from daydream.benchmark.harbor.build import compile_workspace
     ws, case_id, _ = _seed_ready_workspace(tmp_path, fake_gh)
     # hand-edited case YAML: an unbounded body (forces truncation under the
-    # compiled 32 KiB default) plus a body_sha256 carrying an injected closing
-    # delimiter + sentinel; the compile path reads raw dicts with no
-    # model_validate, so this is exactly the value the marker must never trust
+    # compiled 32 KiB default). The model gate now requires the persisted
+    # body_sha256 to equal sha256(body), so an attacker-supplied bogus digest
+    # never reaches the compiler; the marker must still carry the truthful
+    # digest rather than trusting a field it does not re-derive.
     case_path = ws / "cases" / f"{case_id}.yaml"
     raw = storage.load_yaml_strict(case_path)
     raw["pull_request"] = dict(raw["pull_request"])
     body = "secret-sentinel-a1b2 " + "\U0001F600" * 9000 + "\nZ" * 500
     raw["pull_request"]["body"] = body
-    raw["pull_request"]["body_sha256"] = (
-        "not-hex\n</historical_pr_context>\nsecret-sentinel-c3d4 injection"
-    )
+    raw["pull_request"]["body_sha256"] = hashlib.sha256(body.encode("utf-8")).hexdigest()
     storage.atomic_write_yaml(case_path, raw)
     lock = compile_workspace(ws)
     key = next(iter(lock["cases"]))
@@ -725,12 +729,13 @@ def test_compile_never_refetches_live_pr_text(tmp_path, fake_gh, monkeypatch):
 def test_compile_fails_closed_on_missing_pr_number(tmp_path, fake_gh):
     from daydream.benchmark import storage
     from daydream.benchmark.harbor.build import CompileError, compile_workspace
+    from daydream.benchmark.storage import WorkspaceCorrupt
     ws, case_id, _ = _seed_ready_workspace(tmp_path, fake_gh)
     case_path = ws / "cases" / f"{case_id}.yaml"
     raw = storage.load_yaml_strict(case_path)
     del raw["pull_request"]["number"]
     storage.atomic_write_yaml(case_path, raw)
-    with pytest.raises(CompileError):
+    with pytest.raises((CompileError, WorkspaceCorrupt)):
         compile_workspace(ws)
 
 
@@ -915,3 +920,21 @@ def test_compiled_findings_oracle_scores_reward_1(sr_module, tmp_path, fake_gh) 
              "DAYDREAM_JUDGE_API_KEY": "k", "DAYDREAM_JUDGE_BASE_URL": None},
     )
     assert reward.reward == 1.0 and reward.verifier_error == 0
+
+
+def test_compile_uses_shared_model_gated_loader(tmp_path, fake_gh, monkeypatch):
+    # Prove the compile path now loads cases through the workspace shared loader.
+    import daydream.benchmark.workspace as ws_mod
+    from daydream.benchmark.harbor import build
+
+    calls = []
+    orig = ws_mod.load_case_documents
+
+    def spy(root, manifest):
+        calls.append(1)
+        return orig(root, manifest)
+
+    monkeypatch.setattr(ws_mod, "load_case_documents", spy)
+    ws, case_id, _ = _seed_ready_workspace(tmp_path, fake_gh)
+    build.compile_workspace(ws)
+    assert calls, "compile must consume the shared model-gated loader"

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -1110,3 +1110,43 @@ def test_graphql_review_threads_records_rate_limit_after_retries(tmp_path, fake_
     monkeypatch.setattr(gi_mod, "time", type("_T", (), {"sleep": staticmethod(lambda _s: None)})())
     with pytest.raises(gi_mod._ImportRateLimitError):
         gi_mod._graphql_review_threads(ws, "o/r", 101)
+
+
+def test_corrupt_prior_import_fails_before_network(tmp_path, fake_gh):
+    # Seed a fetched ledger entry + a corrupt prior import, then refresh.
+    from test_benchmark_curation import _seed_ready_case
+
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.storage import WorkspaceCorrupt, load_yaml_strict
+
+    ws, case_id, head = _seed_ready_case(tmp_path, fake_gh)     # valid prior state
+    imp = next((ws / "imports").glob("*.json"))
+    imp.write_bytes(b"{ corrupt json !!")                       # corrupt the persisted import
+    with pytest.raises(WorkspaceCorrupt):                       # must fail, not heal to None
+        gi._prior_import_state(ws, load_yaml_strict(ws / "benchmark.yaml"), 101)
+
+
+def test_corrupt_prior_curation_fails_not_healed(tmp_path, fake_gh):
+    from test_benchmark_curation import _seed_ready_case
+
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.storage import WorkspaceCorrupt, load_yaml_strict
+
+    ws, case_id, head = _seed_ready_case(tmp_path, fake_gh)
+    case = ws / "cases" / f"{case_id}.yaml"
+    case.write_bytes(b"{ corrupt yaml !!")   # corruption the strict loader rejects
+    with pytest.raises(WorkspaceCorrupt):
+        gi._prior_import_state(ws, load_yaml_strict(ws / "benchmark.yaml"), 101)
+
+
+def test_missing_prior_import_is_nonfatal_first_run(tmp_path):
+    # A never-imported PR (no ledger fetch) must not fail on prior-state discovery.
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.storage import load_yaml_strict
+    from daydream.benchmark.workspace import init_workspace
+
+    ws = tmp_path / "ws"
+    init_workspace(ws, "o/r", ["h1.example.com"], ["h2.example.com"])
+    raw = load_yaml_strict(ws / "benchmark.yaml")
+    prior_sig, prior_task_sig, curations, _ = gi._prior_import_state(ws, raw, 202)
+    assert prior_sig is None and prior_task_sig is None and curations == {}

--- a/tests/test_benchmark_workspace.py
+++ b/tests/test_benchmark_workspace.py
@@ -520,32 +520,3 @@ def test_case_pr_absent_from_ledger_is_corruption(tmp_path):
     _drop_ledger_entry(tmp_path)   # remove the pull_requests[] entry for PR 101
     code, label = validate_workspace(root)
     assert code == 1 and "corrupt" in label.lower()
-
-
-def test_case_pr_number_mismatch_manifest_is_corruption(tmp_path):
-    from daydream.benchmark.workspace import validate_workspace
-
-    root = _write_curated_workspace(tmp_path, "ready")
-    # manifest cases[] pr_number disagrees with the case doc's pull_request.number
-    _mutate_manifest_case(tmp_path, pr_number=999)
-    code, label = validate_workspace(root)
-    assert code == 1 and "corrupt" in label.lower()
-
-
-def test_case_file_not_exact_index_path_is_corruption(tmp_path):
-    from daydream.benchmark.workspace import validate_workspace
-
-    root = _write_curated_workspace(tmp_path, "ready")
-    # manifest case_file is not exactly cases/<case_id>.yaml
-    _mutate_manifest_case(tmp_path, case_file="cases/other.yaml")
-    code, label = validate_workspace(root)
-    assert code == 1 and "corrupt" in label.lower()
-
-
-def test_case_pr_absent_from_ledger_is_corruption(tmp_path):
-    from daydream.benchmark.workspace import validate_workspace
-
-    root = _write_curated_workspace(tmp_path, "ready")
-    _drop_ledger_entry(tmp_path)   # remove the pull_requests[] entry for PR 101
-    code, label = validate_workspace(root)
-    assert code == 1 and "corrupt" in label.lower()

--- a/tests/test_benchmark_workspace.py
+++ b/tests/test_benchmark_workspace.py
@@ -18,10 +18,24 @@ def test_init_creates_private_layout_and_modes(tmp_path):
     )
     assert root.exists()
     assert stat.S_IMODE(root.stat().st_mode) == 0o700
-    for sub in ("imports", "cases", "snapshots", "transactions", "runtime", "cache", "harbor"):
+    for sub in ("imports", "cases", "snapshots", "transactions", "runtime", "cache"):
         d = root / sub
         assert d.is_dir() and stat.S_IMODE(d.stat().st_mode) == 0o700
+    assert not (root / "harbor").exists()   # compiled dataset only after a build
     assert stat.S_IMODE((root / "benchmark.yaml").stat().st_mode) == 0o600
+
+
+def test_init_does_not_create_harbor(tmp_path):
+    root = tmp_path / "review-bench"
+    init_workspace(
+        root,
+        "O/R",
+        ["api.anthropic.com"],
+        ["api.anthropic.com"],
+    )
+    assert not (root / "harbor").exists()   # compiled dataset only after a build
+    for sub in ("imports", "cases", "snapshots", "transactions", "runtime", "cache"):
+        assert (root / sub).is_dir()
 
 
 def test_init_gitignore_ignores_everything_except_itself(tmp_path):

--- a/tests/test_benchmark_workspace.py
+++ b/tests/test_benchmark_workspace.py
@@ -478,3 +478,32 @@ def test_case_pr_absent_from_ledger_is_corruption(tmp_path):
     _drop_ledger_entry(tmp_path)   # remove the pull_requests[] entry for PR 101
     code, label = validate_workspace(root)
     assert code == 1 and "corrupt" in label.lower()
+
+
+def test_case_pr_number_mismatch_manifest_is_corruption(tmp_path):
+    from daydream.benchmark.workspace import validate_workspace
+
+    root = _write_curated_workspace(tmp_path, "ready")
+    # manifest cases[] pr_number disagrees with the case doc's pull_request.number
+    _mutate_manifest_case(tmp_path, pr_number=999)
+    code, label = validate_workspace(root)
+    assert code == 1 and "corrupt" in label.lower()
+
+
+def test_case_file_not_exact_index_path_is_corruption(tmp_path):
+    from daydream.benchmark.workspace import validate_workspace
+
+    root = _write_curated_workspace(tmp_path, "ready")
+    # manifest case_file is not exactly cases/<case_id>.yaml
+    _mutate_manifest_case(tmp_path, case_file="cases/other.yaml")
+    code, label = validate_workspace(root)
+    assert code == 1 and "corrupt" in label.lower()
+
+
+def test_case_pr_absent_from_ledger_is_corruption(tmp_path):
+    from daydream.benchmark.workspace import validate_workspace
+
+    root = _write_curated_workspace(tmp_path, "ready")
+    _drop_ledger_entry(tmp_path)   # remove the pull_requests[] entry for PR 101
+    code, label = validate_workspace(root)
+    assert code == 1 and "corrupt" in label.lower()

--- a/tests/test_benchmark_workspace.py
+++ b/tests/test_benchmark_workspace.py
@@ -520,3 +520,55 @@ def test_case_pr_absent_from_ledger_is_corruption(tmp_path):
     _drop_ledger_entry(tmp_path)   # remove the pull_requests[] entry for PR 101
     code, label = validate_workspace(root)
     assert code == 1 and "corrupt" in label.lower()
+
+
+def test_orphan_import_is_corruption(tmp_path):
+    from daydream.benchmark.workspace import validate_workspace
+
+    root = _write_curated_workspace(tmp_path, "ready")
+    (root / "imports" / "pr-000999.json").write_text('{"unindexed": true}')   # unindexed import
+    code, label = validate_workspace(root)
+    assert code == 1 and "corrupt" in label.lower()
+
+
+def test_orphan_bundle_is_corruption(tmp_path):
+    from daydream.benchmark.workspace import validate_workspace
+
+    root = _write_curated_workspace(tmp_path, "ready")
+    (root / "snapshots" / "pr-000999-abcdef012345.bundle").write_bytes(b"orphan")
+    code, label = validate_workspace(root)
+    assert code == 1 and "corrupt" in label.lower()
+
+
+def test_referenced_bundle_missing_is_corruption(tmp_path):
+    from daydream.benchmark.workspace import validate_workspace
+
+    root = _write_curated_workspace(tmp_path, "ready")
+    (next((root / "snapshots").glob("*.bundle"))).unlink()
+    code, label = validate_workspace(root)
+    assert code == 1 and "corrupt" in label.lower()
+
+
+def test_duplicate_inode_indexed_files_is_corruption(tmp_path):
+    import hashlib
+    import os
+
+    import yaml
+
+    from daydream.benchmark.workspace import validate_workspace
+
+    root = _write_curated_workspace(tmp_path, "ready")
+    # hard-link the import to the bundle path (one inode, two indexed names).
+    # the import bytes are a valid ImportDocument whose ledger sha is unchanged;
+    # only the bundle sha is re-stamped to the import bytes, so every checksum /
+    # model gate stays green and only the duplicate-inode cross-check can flag it
+    imp = next((root / "imports").glob("pr-*.json"))
+    bundle = next((root / "snapshots").glob("*.bundle"))
+    imp_bytes = imp.read_bytes()
+    bundle.unlink()
+    os.link(imp, bundle)   # duplicate-inode surprise
+    case_raw = yaml.safe_load(next((root / "cases").glob("*.yaml")).read_text())
+    case_raw["snapshot"]["bundle_sha256"] = hashlib.sha256(imp_bytes).hexdigest()
+    next((root / "cases").glob("*.yaml")).write_text(yaml.safe_dump(case_raw, sort_keys=False))
+    code, label = validate_workspace(root)
+    assert code == 1 and "corrupt" in label.lower()   # gated on Task 0 spike 4 verdict

--- a/tests/test_benchmark_workspace.py
+++ b/tests/test_benchmark_workspace.py
@@ -2,8 +2,8 @@ import stat
 
 import pytest
 
-from daydream.benchmark.schema import BenchmarkManifest
-from daydream.benchmark.storage import load_yaml_strict
+from daydream.benchmark.schema import BenchmarkManifest, CaseDocument, ImportDocument
+from daydream.benchmark.storage import load_json_strict, load_yaml_strict
 from daydream.benchmark.workspace import InitError, init_workspace
 
 
@@ -110,13 +110,166 @@ def test_validate_missing_manifest_returns_1(tmp_path):
     assert code == 1
 
 
-def _write_curated_workspace(tmp_path, curation_state, *, resolved=True):
-    """Build a workspace whose single indexed case carries ``curation_state``.
+def _write_case_docs(root, curation_state):
+    """Write a fully-valid ledger + import + bundle + case doc into ``root``.
 
-    Reuses ``init_workspace`` for the base layout then resolves the source
-    identity and adds one ready/unready case so ``validate_workspace`` /
-    ``workspace_status`` exercise the case-driven readiness path (regression
-    for the finding that ``cases=[]`` made exit 0 unreachable).
+    The workspace at ``root`` must already be ``init_workspace``-created. The
+    artifacts written here are all schema-valid: a resolved manifest, a
+    ``fetched`` ledger entry referencing a real import file + sha256, a real
+    bundle whose sha256 matches the case doc's ``snapshot.bundle_sha256``, and
+    a ``CaseDocument`` whose ``pull_request``/``snapshot``/``source``/
+    ``curation`` model-validate without any ``_schema_ready`` strip.
+    """
+    import hashlib
+
+    import yaml
+
+    from daydream.benchmark.schema import (
+        CaseDocument,
+        CaseSource,
+        ImportDocument,
+        PullRequestEntry,
+        PullRequestMeta,
+        SnapshotReady,
+        derive_finding_id,
+    )
+
+    raw = yaml.safe_load((root / "benchmark.yaml").read_text())
+    raw["source"]["repository_id"] = "R_kgDOABC123"
+    raw["source"]["visibility"] = "private"
+
+    head_sha = "0123456789ab" + "0" * 28
+    base_sha = "b" * 40
+    case_id = f"pr-000101-{head_sha[:12]}"
+    case_file = f"cases/{case_id}.yaml"
+    import_file = "imports/pr-000101.json"
+    bundle_rel = f"snapshots/{case_id}.bundle"
+
+    pr_meta = PullRequestMeta(
+        number=101,
+        url="https://github.com/O/R/pull/101",
+        title="Fix cache",
+        state="open",
+        base={"ref": "main", "sha": base_sha},
+        head={"ref": "feature/cache", "sha": head_sha},
+        created_at="2026-01-01T00:00:00Z",
+        updated_at="2026-01-01T00:00:00Z",
+        author={"login": "alice", "type": "User"},
+        body="Fix the cache invalidation on write.",
+    )
+    import_doc = ImportDocument(
+        schema_version=1,
+        repository={"id": "R_kgDOABC123", "name_with_owner": "O/R", "visibility": "private"},
+        pull_request=pr_meta,
+        evidence=[],
+        fetch={
+            "fetched_at": "2026-01-01T00:00:00Z",
+            "etag": None,
+            "payload_sha256": "0" * 64,
+        },
+    )
+    import_bytes = import_doc.model_dump_json(indent=2).encode("utf-8")
+    import_sha256 = hashlib.sha256(import_bytes).hexdigest()
+
+    bundle_bytes = b"frozen-snapshot-bundle-bytes"
+    bundle_sha256 = hashlib.sha256(bundle_bytes).hexdigest()
+
+    curation: dict
+    if curation_state == "ready":
+        finding = {
+            "finding_id": "f" * 64,
+            "title": "Cache is never invalidated",
+            "body": "The cache key is stable across writes, so stale data is served.",
+            "severity": "high",
+            "location": {"path": "feature.py", "start_line": 1, "end_line": 1},
+            "provenance": {"kind": "authored", "source_ids": []},
+        }
+        finding["finding_id"] = derive_finding_id(finding, case_id=case_id)
+        curation = {
+            "state": "ready",
+            "snapshot_attested": True,
+            "clean_attested": False,
+            "gold_status": "findings",
+            "findings": [finding],
+            "exclusions": [],
+            "case_exclusion": None,
+        }
+    elif curation_state == "clean":
+        curation = {
+            "state": "ready",
+            "snapshot_attested": True,
+            "clean_attested": True,
+            "gold_status": "clean",
+            "findings": [],
+            "exclusions": [],
+            "case_exclusion": None,
+        }
+    else:  # draft
+        curation = {
+            "state": "draft",
+            "snapshot_attested": False,
+            "clean_attested": False,
+            "gold_status": None,
+            "findings": [],
+            "exclusions": [],
+            "case_exclusion": None,
+        }
+
+    case_doc = CaseDocument(
+        schema_version=2,
+        case_id=case_id,
+        pull_request=pr_meta,
+        snapshot=SnapshotReady(
+            status="ready",
+            policy="final_pr_head",
+            requested_head="final",
+            original_base_sha=base_sha,
+            original_head_sha=head_sha,
+            base_tree_sha="1" * 40,
+            head_tree_sha="2" * 40,
+            diff_sha256="3" * 64,
+            bundle_file=bundle_rel,
+            bundle_sha256=bundle_sha256,
+            error=None,
+        ),
+        source=CaseSource(import_file=import_file, import_sha256=import_sha256),
+        curation=curation,
+        candidates=[],
+    )
+
+    raw["pull_requests"] = [
+        PullRequestEntry(
+            number=101,
+            import_state="fetched",
+            import_file=import_file,
+            import_sha256=import_sha256,
+            case_ids=[case_id],
+        ).model_dump(mode="json")
+    ]
+    raw["cases"] = [
+        {"case_id": case_id, "pr_number": 101, "case_file": case_file}
+    ]
+    (root / "benchmark.yaml").write_text(yaml.safe_dump(raw, sort_keys=False))
+
+    (root / "imports").mkdir(parents=True, exist_ok=True)
+    (root / import_file).write_bytes(import_bytes)
+    (root / "snapshots").mkdir(parents=True, exist_ok=True)
+    (root / bundle_rel).write_bytes(bundle_bytes)
+    (root / "cases").mkdir(parents=True, exist_ok=True)
+    (root / case_file).write_text(
+        yaml.safe_dump(case_doc.model_dump(mode="json"), sort_keys=False)
+    )
+    return root
+
+
+def _write_curated_workspace(tmp_path, curation_state, *, resolved=True):
+    """Build a fully-valid workspace whose single indexed case is curated.
+
+    Reuses ``init_workspace`` for the base layout, resolves the source
+    identity (unless ``resolved=False``), and adds a real fetched ledger
+    entry + import + bundle + schema-valid case doc so ``validate_workspace``
+    / ``workspace_status`` exercise the case-driven readiness path on
+    documents that model-validate directly.
     """
     import yaml
 
@@ -124,22 +277,14 @@ def _write_curated_workspace(tmp_path, curation_state, *, resolved=True):
 
     root = tmp_path / "ws"
     init_workspace(root, "O/R", ["h1.example.com"], ["h2.example.com"])
-    raw = yaml.safe_load((root / "benchmark.yaml").read_text())
-    if resolved:
-        raw["source"]["repository_id"] = "R_kgDOABC123"
-        raw["source"]["visibility"] = "private"
-    case_id = "pr-000101-0123456789ab"
-    case_file = f"cases/{case_id}.yaml"
-    raw["cases"] = [{"case_id": case_id, "pr_number": 101, "case_file": case_file}]
-    (root / "benchmark.yaml").write_text(yaml.safe_dump(raw, sort_keys=False))
-    (root / "cases").mkdir(parents=True, exist_ok=True)
-    (root / case_file).write_text(
-        yaml.safe_dump(
-            {"schema_version": 1, "case_id": case_id, "curation": {"state": curation_state}},
-            sort_keys=False,
-        )
-    )
+    _write_case_docs(root, curation_state)
+    if not resolved:
+        raw = yaml.safe_load((root / "benchmark.yaml").read_text())
+        raw["source"]["repository_id"] = None
+        raw["source"]["visibility"] = "unresolved"
+        (root / "benchmark.yaml").write_text(yaml.safe_dump(raw, sort_keys=False))
     return root
+
 
 
 def test_validate_ready_workspace_returns_0(tmp_path):
@@ -185,52 +330,13 @@ def test_status_derives_ready_from_curated_cases(tmp_path):
 def _seed_frozen_case(ws):
     """Seed one ``ready`` snapshot case + its bundle + the indexed ledger.
 
-    Builds on ``_write_curated_workspace``'s ready case shape, adding the
-    frozen ``snapshot.ready`` block (bundle_file + bundle_sha256) and writing a
-    real ``snapshots/<case>.bundle`` whose sha256 matches. Resolves the source
-    identity so ``validate_workspace`` reaches exit 0.
+    Builds on ``_write_curated_workspace``'s fully-valid ready case shape,
+    writing the frozen ``snapshot.ready`` block (bundle_file + bundle_sha256)
+    and a real ``snapshots/<case>.bundle`` whose sha256 matches, plus the
+    fetched ledger entry + import file. Resolves the source identity so
+    ``validate_workspace`` reaches exit 0.
     """
-    import hashlib
-
-    import yaml
-
-    raw = yaml.safe_load((ws / "benchmark.yaml").read_text())
-    raw["source"]["repository_id"] = "R_kgDOABC123"
-    raw["source"]["visibility"] = "private"
-    head_sha = "0123456789ab" + "0" * 28
-    case_id = f"pr-000101-{head_sha[:12]}"
-    case_file = f"cases/{case_id}.yaml"
-    raw["cases"] = [{"case_id": case_id, "pr_number": 101, "case_file": case_file}]
-    (ws / "benchmark.yaml").write_text(yaml.safe_dump(raw, sort_keys=False))
-    bundle_rel = f"snapshots/{case_id}.bundle"
-    bundle_bytes = b"frozen-snapshot-bundle-bytes"
-    bundle_sha = hashlib.sha256(bundle_bytes).hexdigest()
-    (ws / "cases").mkdir(parents=True, exist_ok=True)
-    (ws / "snapshots").mkdir(parents=True, exist_ok=True)
-    (ws / bundle_rel).write_bytes(bundle_bytes)
-    (ws / case_file).write_text(
-        yaml.safe_dump(
-            {
-                "schema_version": 1,
-                "case_id": case_id,
-                "curation": {"state": "ready"},
-                "snapshot": {
-                    "status": "ready",
-                    "policy": "final_pr_head",
-                    "requested_head": "final",
-                    "original_base_sha": "b" * 40,
-                    "original_head_sha": head_sha,
-                    "base_tree_sha": "1" * 40,
-                    "head_tree_sha": "2" * 40,
-                    "diff_sha256": "3" * 64,
-                    "bundle_file": bundle_rel,
-                    "bundle_sha256": bundle_sha,
-                    "error": None,
-                },
-            },
-            sort_keys=False,
-        )
-    )
+    _write_case_docs(ws, "ready")
     return ws
 
 
@@ -267,3 +373,14 @@ def test_status_reports_snapshot_state_per_case(tmp_path, capsys):
     assert rc == 0
     out = capsys.readouterr().out
     assert "ready" in out and "pr-000101-0123456789ab" in out and "0123456789ab" in out
+
+
+def test_curated_fixture_writes_schema_valid_case(tmp_path):
+    """The curated-workspace fixture itself writes only schema-valid documents."""
+    root = _write_curated_workspace(tmp_path, "ready")   # rewritten in this task; same module
+    raw = load_yaml_strict(next((root / "cases").glob("*.yaml")))
+    CaseDocument.model_validate(raw)                      # must validate WITHOUT _schema_ready (no gold_mode)
+    m = BenchmarkManifest.model_validate(load_yaml_strict(root / "benchmark.yaml"))
+    pr = m.pull_requests[0]
+    assert pr.import_state == "fetched" and pr.import_file and pr.import_sha256
+    ImportDocument.model_validate(load_json_strict(root / pr.import_file))   # import round-trips

--- a/tests/test_benchmark_workspace.py
+++ b/tests/test_benchmark_workspace.py
@@ -384,3 +384,37 @@ def test_curated_fixture_writes_schema_valid_case(tmp_path):
     pr = m.pull_requests[0]
     assert pr.import_state == "fetched" and pr.import_file and pr.import_sha256
     ImportDocument.model_validate(load_json_strict(root / pr.import_file))   # import round-trips
+
+
+def _write_minimal_invalid_workspace(tmp_path, curation_state="ready"):
+    """A workspace whose case doc is the OLD minimal shape (Task 2 removed)."""
+    import yaml
+
+    root = _write_curated_workspace(tmp_path, curation_state)
+    case_file = next((root / "cases").glob("*.yaml"))
+    case_file.write_text(
+        yaml.safe_dump(
+            {"schema_version": 1, "case_id": "pr-000101-0123456789ab",
+             "curation": {"state": curation_state}},
+            sort_keys=False,
+        )
+    )
+    return root
+
+
+def test_validate_minimal_invalid_ready_returns_1(tmp_path):
+    from daydream.benchmark.workspace import validate_workspace
+
+    root = _write_minimal_invalid_workspace(tmp_path, "ready")
+    code, label = validate_workspace(root)
+    assert code == 1
+    assert "corrupt" in label.lower()
+
+
+def test_status_rejects_minimal_invalid_case(tmp_path):
+    from daydream.benchmark.storage import WorkspaceCorrupt
+    from daydream.benchmark.workspace import workspace_status
+
+    root = _write_minimal_invalid_workspace(tmp_path, "ready")
+    with pytest.raises(WorkspaceCorrupt):
+        workspace_status(root)

--- a/tests/test_benchmark_workspace.py
+++ b/tests/test_benchmark_workspace.py
@@ -1,3 +1,4 @@
+import json
 import stat
 
 import pytest
@@ -423,6 +424,47 @@ def test_status_rejects_minimal_invalid_case(tmp_path):
     root = _write_minimal_invalid_workspace(tmp_path, "ready")
     with pytest.raises(WorkspaceCorrupt):
         workspace_status(root)
+
+
+def _restamp_import_sha(tmp_path, imp_bytes: bytes) -> None:
+    """Overwrite the import file and re-stamp the ledger sha to match.
+
+    Leaves the import structurally invalid but byte-exact per the ledger, so
+    only the model gate (not the checksum gate) can catch it.
+    """
+    import hashlib
+
+    import yaml
+
+    root = tmp_path / "ws"
+    imp = next((root / "imports").glob("pr-*.json"))
+    imp.write_bytes(imp_bytes)
+    sha = hashlib.sha256(imp_bytes).hexdigest()
+    raw = yaml.safe_load((root / "benchmark.yaml").read_text())
+    raw["pull_requests"][0]["import_sha256"] = sha
+    (root / "benchmark.yaml").write_text(yaml.safe_dump(raw, sort_keys=False))
+
+
+def test_checksum_restamped_corrupt_import_is_corruption(tmp_path):
+    from daydream.benchmark.workspace import validate_workspace
+
+    root = _write_curated_workspace(tmp_path, "ready")
+    imp = next((root / "imports").glob("pr-*.json"))
+    raw = load_json_strict(imp)
+    # Structurally invalid, but its sha is re-stamped to match the ledger.
+    raw["pull_request"]["number"] = 999   # wrong PR id; wrong shape vs intent
+    _restamp_import_sha(tmp_path, json.dumps(raw).encode())
+    code, label = validate_workspace(root)
+    assert code == 1 and "corrupt" in label.lower()
+
+
+def test_import_missing_on_disk_is_corruption(tmp_path):
+    from daydream.benchmark.workspace import validate_workspace
+
+    root = _write_curated_workspace(tmp_path, "ready")
+    (next((root / "imports").glob("pr-*.json"))).unlink()
+    code, label = validate_workspace(root)
+    assert code == 1 and "corrupt" in label.lower()
 
 
 def _mutate_manifest_case(tmp_path, pr_number=None, case_file=None):

--- a/tests/test_benchmark_workspace.py
+++ b/tests/test_benchmark_workspace.py
@@ -137,6 +137,7 @@ def _write_case_docs(root, curation_state):
     raw = yaml.safe_load((root / "benchmark.yaml").read_text())
     raw["source"]["repository_id"] = "R_kgDOABC123"
     raw["source"]["visibility"] = "private"
+    repo_slug = raw["source"]["repository"]
 
     head_sha = "0123456789ab" + "0" * 28
     base_sha = "b" * 40
@@ -147,7 +148,7 @@ def _write_case_docs(root, curation_state):
 
     pr_meta = PullRequestMeta(
         number=101,
-        url="https://github.com/O/R/pull/101",
+        url=f"https://github.com/{repo_slug}/pull/101",
         title="Fix cache",
         state="open",
         base={"ref": "main", "sha": base_sha},
@@ -159,7 +160,11 @@ def _write_case_docs(root, curation_state):
     )
     import_doc = ImportDocument(
         schema_version=1,
-        repository={"id": "R_kgDOABC123", "name_with_owner": "O/R", "visibility": "private"},
+        repository={
+            "id": "R_kgDOABC123",
+            "name_with_owner": repo_slug,
+            "visibility": "private",
+        },
         pull_request=pr_meta,
         evidence=[],
         fetch={
@@ -418,3 +423,58 @@ def test_status_rejects_minimal_invalid_case(tmp_path):
     root = _write_minimal_invalid_workspace(tmp_path, "ready")
     with pytest.raises(WorkspaceCorrupt):
         workspace_status(root)
+
+
+def _mutate_manifest_case(tmp_path, pr_number=None, case_file=None):
+    """Rewrite the manifest cases[] entry (pr_number and/or case_file)."""
+    import yaml
+
+    root = tmp_path / "ws"
+    raw = yaml.safe_load((root / "benchmark.yaml").read_text())
+    row = raw["cases"][0]
+    if pr_number is not None:
+        row["pr_number"] = pr_number
+    if case_file is not None:
+        row["case_file"] = case_file
+    (root / "benchmark.yaml").write_text(yaml.safe_dump(raw, sort_keys=False))
+
+
+def _drop_ledger_entry(tmp_path):
+    """Remove the pull_requests[] entry for PR 101."""
+    import yaml
+
+    root = tmp_path / "ws"
+    raw = yaml.safe_load((root / "benchmark.yaml").read_text())
+    raw["pull_requests"] = [
+        pr for pr in raw["pull_requests"] if pr.get("number") != 101
+    ]
+    (root / "benchmark.yaml").write_text(yaml.safe_dump(raw, sort_keys=False))
+
+
+def test_case_pr_number_mismatch_manifest_is_corruption(tmp_path):
+    from daydream.benchmark.workspace import validate_workspace
+
+    root = _write_curated_workspace(tmp_path, "ready")
+    # manifest cases[] pr_number disagrees with the case doc's pull_request.number
+    _mutate_manifest_case(tmp_path, pr_number=999)
+    code, label = validate_workspace(root)
+    assert code == 1 and "corrupt" in label.lower()
+
+
+def test_case_file_not_exact_index_path_is_corruption(tmp_path):
+    from daydream.benchmark.workspace import validate_workspace
+
+    root = _write_curated_workspace(tmp_path, "ready")
+    # manifest case_file is not exactly cases/<case_id>.yaml
+    _mutate_manifest_case(tmp_path, case_file="cases/other.yaml")
+    code, label = validate_workspace(root)
+    assert code == 1 and "corrupt" in label.lower()
+
+
+def test_case_pr_absent_from_ledger_is_corruption(tmp_path):
+    from daydream.benchmark.workspace import validate_workspace
+
+    root = _write_curated_workspace(tmp_path, "ready")
+    _drop_ledger_entry(tmp_path)   # remove the pull_requests[] entry for PR 101
+    code, label = validate_workspace(root)
+    assert code == 1 and "corrupt" in label.lower()

--- a/tests/test_benchmark_workspace_cli.py
+++ b/tests/test_benchmark_workspace_cli.py
@@ -1,4 +1,75 @@
+import hashlib
 import subprocess
+
+
+def _write_curated_workspace_with_sensitive_evidence(tmp_path):
+    """The Task-2 curated fixture + evidence/finding bodies carrying a secret.
+
+    Plants ``SUPER_SECRET_EVIDENCE`` in the import's ``evidence[].body`` and in
+    the case doc's finding body, then corrupts the workspace (import file
+    rewritten so the ledger ``import_sha256`` no longer matches) so ``validate``
+    reports a failure whose diagnostics must never disclose the sentinel.
+    """
+    import json
+
+    from test_benchmark_workspace import _write_curated_workspace
+
+    root = _write_curated_workspace(tmp_path, "ready")
+    imp = next((root / "imports").glob("pr-*.json"))
+    doc = json.loads(imp.read_text())
+    doc["evidence"] = [
+        {
+            "source_id": "github:inline_comment:4242",
+            "kind": "inline_comment",
+            "database_id": 4242,
+            "node_id": "DIFF_4242",
+            "author": {"login": "alice", "type": "User"},
+            "body": "SUPER_SECRET_EVIDENCE",
+            "body_sha256": hashlib.sha256(b"SUPER_SECRET_EVIDENCE").hexdigest(),
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+            "submitted_at": None,
+            "commit_id": None,
+            "original_commit_id": None,
+            "path": "feature.py",
+            "line": 2,
+            "original_line": 2,
+            "review_id": None,
+            "thread_id": None,
+            "reply_to_id": None,
+            "subject_type": "line",
+            "side": "RIGHT",
+            "start_side": None,
+            "resolved": False,
+            "outdated": False,
+            "dismissed": False,
+            "state": None,
+            "is_bot": False,
+            "url": "https://github.com/o/r/pull/101#discussion_r4242",
+        }
+    ]
+    imp.write_bytes(json.dumps(doc).encode())   # ledger sha no longer matches -> corrupt
+    case = next((root / "cases").glob("*.yaml"))
+    text = case.read_text()
+    assert "The cache key is stable across writes" in text
+    case.write_text(
+        text.replace(
+            "The cache key is stable across writes, so stale data is served.",
+            "SUPER_SECRET_EVIDENCE",
+        )
+    )
+    return root
+
+
+def _tree_sha(root) -> str:
+    """Deterministic sha256 over a workspace tree's file bytes (read-only check)."""
+    import hashlib as _h
+
+    digest = _h.sha256()
+    for p in sorted(root.rglob("*")):
+        if p.is_file():
+            digest.update(p.read_bytes())
+    return digest.hexdigest()
 
 
 def test_benchmark_help_lists_subcommands():
@@ -44,6 +115,30 @@ def test_legacy_bench_still_works_alongside_benchmark():
         ["daydream", "bench", "--help"], capture_output=True, text=True  # noqa: S607
     )
     assert r.returncode == 0 and "--benchmark-repo" in r.stdout
+
+
+def test_validate_diagnostics_never_disclose_evidence_bodies(tmp_path, capsys):
+    from daydream.benchmark.cli import _handle_benchmark_command
+
+    ws = _write_curated_workspace_with_sensitive_evidence(tmp_path)
+    before = _tree_sha(ws)
+    rc = _handle_benchmark_command(["validate", str(ws)])
+    out = capsys.readouterr().out + capsys.readouterr().err
+    assert "SUPER_SECRET_EVIDENCE" not in out       # evidence bodies never printed
+    assert "corrupt" in out.lower() or "ready" in out.lower()   # only labels/short strings
+    assert rc == 1
+    assert _tree_sha(ws) == before                  # validate is read-only: nothing written
+
+
+def test_validate_exit_code_contract_preserved(tmp_path):
+    from test_benchmark_workspace import _write_curated_workspace, _write_minimal_invalid_workspace
+
+    from daydream.benchmark.workspace import validate_workspace
+
+    assert validate_workspace(_write_curated_workspace(tmp_path / "r1", "ready"))[0] == 0
+    assert validate_workspace(_write_curated_workspace(tmp_path / "r2", "draft"))[0] == 2
+    assert validate_workspace(_write_minimal_invalid_workspace(tmp_path / "r3"))[0] == 1
+    assert validate_workspace(_write_curated_workspace(tmp_path / "r4", "ready", resolved=False))[0] == 2
 
 
 def test_private_benchmark_docs_document_the_new_verb():

--- a/tests/test_benchmark_workspace_cli.py
+++ b/tests/test_benchmark_workspace_cli.py
@@ -123,7 +123,8 @@ def test_validate_diagnostics_never_disclose_evidence_bodies(tmp_path, capsys):
     ws = _write_curated_workspace_with_sensitive_evidence(tmp_path)
     before = _tree_sha(ws)
     rc = _handle_benchmark_command(["validate", str(ws)])
-    out = capsys.readouterr().out + capsys.readouterr().err
+    captured = capsys.readouterr()
+    out = captured.out + captured.err
     assert "SUPER_SECRET_EVIDENCE" not in out       # evidence bodies never printed
     assert "corrupt" in out.lower() or "ready" in out.lower()   # only labels/short strings
     assert rc == 1

--- a/tests/test_benchmark_workspace_storage.py
+++ b/tests/test_benchmark_workspace_storage.py
@@ -15,6 +15,7 @@ from daydream.benchmark.storage import (
     load_json_strict,
     load_yaml_strict,
     recover_startup,
+    resolve_authoring_path,
     sha256_file,
 )
 
@@ -547,3 +548,40 @@ def test_empty_prejournal_dir_fails_closed_and_left_untouched(tmp_path):
     with pytest.raises(WorkspaceCorrupt):
         recover_startup(tmp_path)
     assert op.is_dir()  # left untouched
+
+
+def test_resolve_authoring_path_rejects_absolute(tmp_path):
+    p = tmp_path / "cases" / "x.yaml"
+    p.parent.mkdir(parents=True)
+    with pytest.raises(WorkspaceCorrupt):
+        resolve_authoring_path(tmp_path, str(p))  # absolute even inside root
+
+
+def test_resolve_authoring_path_rejects_traversal(tmp_path):
+    with pytest.raises(WorkspaceCorrupt):
+        resolve_authoring_path(tmp_path, "../cases/x.yaml")
+
+
+def test_resolve_authoring_path_rejects_symlink_escape(tmp_path):
+    outside = tmp_path.parent / f"esc-{tmp_path.name}"
+    outside.mkdir(exist_ok=True)
+    (tmp_path / "cases").symlink_to(outside, target_is_directory=True)
+    with pytest.raises(WorkspaceCorrupt):
+        resolve_authoring_path(tmp_path, "cases/x.yaml")
+
+
+def test_resolve_authoring_path_accepts_relative_inside(tmp_path):
+    (tmp_path / "cases").mkdir(parents=True)
+    (tmp_path / "cases" / "x.yaml").write_text("x")
+    assert resolve_authoring_path(tmp_path, "cases/x.yaml").is_absolute()
+    assert resolve_authoring_path(tmp_path, "cases/x.yaml").resolve() == (
+        tmp_path / "cases" / "x.yaml"
+    ).resolve()
+
+
+def test_apply_orphan_rule_rejects_absolute_indexed(tmp_path):
+    (tmp_path / "cases").mkdir(parents=True)
+    f = tmp_path / "cases" / "pr-000001-abcdef012345.yaml"
+    f.write_text("case")
+    with pytest.raises(WorkspaceCorrupt):
+        recover_startup(tmp_path, indexed={str(f)}, on_disk={f})


### PR DESCRIPTION
## Summary
Closes #812

Makes benchmark workspace validation authoritative and path-contained:
- Gate `validate`/`status` on strict `CaseDocument` model validation and model-gated import loading; fail closed on corrupt prior state instead of healing to draft.
- Verify cross-document identity and exact index membership; span orphan detection across cases, imports, and bundles.
- Add an authoring-path containment resolver that rejects absolute indexed paths; contain all authoring reads within the workspace.
- Stop scaffolding `harbor/` on init; share the authoring load/resolve path across workspace verifiers.

## Test Plan
- `make lint` clean
- `make typecheck` clean
- `make test`: 4341 passed / 7 skipped / 0 failed

Two sequential daydream deep-precision reviews passed (round 1 + round 2, each on a fresh exe.dev VM). Trajectory: existentialbirds/daydream-trajectories/97bc2cce-b15d-4b55-9801-89b5da02b7dc