### PR TITLE
fix(benchmark): complete reviewed-clean final attestation (Closes #815)

### DIFF
--- a/daydream/benchmark/curation.py
+++ b/daydream/benchmark/curation.py
@@ -698,7 +698,10 @@ def mark_ready(root: Path, case_id: str, *, head_sha: str) -> None:
                 f"attestation SHA mismatch: expected {original} got {head_sha}"
             )
         curation = raw.setdefault("curation", {})
-        if not curation.get("findings") and not curation.get("clean_attested"):
+        # Single-sourced empty-gold eligibility: derive_gold_status is None
+        # exactly when the gold set is empty and never clean-attested -- the
+        # same derived status harbor/build._is_compilable trusts.
+        if schema.derive_gold_status(_curation_model(curation)) is None:
             raise CurationError(
                 f"case {case_id} cannot be marked ready with an empty gold findings set "
                 "and no clean attestation (clean-attest first)"

--- a/daydream/benchmark/curation.py
+++ b/daydream/benchmark/curation.py
@@ -700,7 +700,8 @@ def mark_ready(root: Path, case_id: str, *, head_sha: str) -> None:
         curation = raw.setdefault("curation", {})
         if not curation.get("findings") and not curation.get("clean_attested"):
             raise CurationError(
-                f"case {case_id} cannot be marked ready with an empty gold findings set"
+                f"case {case_id} cannot be marked ready with an empty gold findings set "
+                "and no clean attestation (clean-attest first)"
             )
         _validate_transition(curation.get("state"), "ready")
         curation["state"] = "ready"

--- a/daydream/benchmark/curation.py
+++ b/daydream/benchmark/curation.py
@@ -698,7 +698,7 @@ def mark_ready(root: Path, case_id: str, *, head_sha: str) -> None:
                 f"attestation SHA mismatch: expected {original} got {head_sha}"
             )
         curation = raw.setdefault("curation", {})
-        if not curation.get("findings"):
+        if not curation.get("findings") and not curation.get("clean_attested"):
             raise CurationError(
                 f"case {case_id} cannot be marked ready with an empty gold findings set"
             )

--- a/daydream/benchmark/harbor/build.py
+++ b/daydream/benchmark/harbor/build.py
@@ -434,7 +434,14 @@ _ROOT_README = (
 
 def _is_compilable(curation: dict) -> bool:
     """Eligible iff ready AND snapshot-attested (findings-ready or clean-ready)."""
-    return bool(curation.get("state") == "ready" and curation.get("snapshot_attested"))
+    if not (curation.get("state") == "ready" and curation.get("snapshot_attested")):
+        return False
+    if not curation.get("findings"):
+        # An empty gold set is a genuine clean case only when clean-attested;
+        # mark_ready enforces the same guard on the authoring path, so a ready
+        # case that never received clean attestation must not compile as clean.
+        return bool(curation.get("clean_attested"))
+    return True
 
 
 def _authoring_input_digest(case_docs: dict, manifest: dict) -> str:

--- a/daydream/benchmark/harbor/build.py
+++ b/daydream/benchmark/harbor/build.py
@@ -436,12 +436,11 @@ def _is_compilable(curation: dict) -> bool:
     """Eligible iff ready AND snapshot-attested (findings-ready or clean-ready)."""
     if not (curation.get("state") == "ready" and curation.get("snapshot_attested")):
         return False
-    if not curation.get("findings"):
-        # An empty gold set is a genuine clean case only when clean-attested;
-        # mark_ready enforces the same guard on the authoring path, so a ready
-        # case that never received clean attestation must not compile as clean.
-        return bool(curation.get("clean_attested"))
-    return True
+    # Single-sourced empty-gold eligibility: derive_gold_status is None exactly
+    # when the gold set is empty and never clean-attested, the same derived
+    # status mark_ready's guard trusts, so a ready case that never received
+    # clean attestation must not compile as clean.
+    return schema.derive_gold_status(schema.Curation(**curation)) is not None
 
 
 def _authoring_input_digest(case_docs: dict, manifest: dict) -> str:

--- a/daydream/benchmark/harbor/build.py
+++ b/daydream/benchmark/harbor/build.py
@@ -433,13 +433,8 @@ _ROOT_README = (
 
 
 def _is_compilable(curation: dict) -> bool:
-    """Assumption 1: ready-with-findings or clean-attested."""
-    return bool(
-        (curation.get("state") == "ready"
-         and curation.get("snapshot_attested")
-         and bool(curation.get("findings")))
-        or (curation.get("clean_attested") and not curation.get("findings"))
-    )
+    """Eligible iff ready AND snapshot-attested (findings-ready or clean-ready)."""
+    return bool(curation.get("state") == "ready" and curation.get("snapshot_attested"))
 
 
 def _authoring_input_digest(case_docs: dict, manifest: dict) -> str:

--- a/tests/test_benchmark_curate_tui.py
+++ b/tests/test_benchmark_curate_tui.py
@@ -258,6 +258,18 @@ def test_clean_confirm_does_not_mark_ready(tmp_path, fake_gh, capsys):
             capsys.readouterr().out)
 
 
+def test_no_comment_clean_then_ready_marks_case_ready(tmp_path, fake_gh, capsys):
+    from daydream.benchmark.curate_tui import run_curate_tui
+    from daydream.benchmark.storage import load_yaml_strict
+    ws, case_id, _h = _seed_ready_case(tmp_path, fake_gh, lines=2)   # no-comment, empty gold
+    run_curate_tui(ws, case_id, read_line=_scripted("c", "y", "r", "y", "q"))
+    cur = load_yaml_strict(ws / "cases" / f"{case_id}.yaml")["curation"]
+    assert cur["state"] == "ready" and cur["snapshot_attested"] is True
+    assert cur["clean_attested"] is True and cur["gold_status"] == "clean"
+    out = capsys.readouterr().out
+    assert "attested" in out and f"mark {case_id} ready?" in out
+
+
 def test_mark_ready_requires_yes_and_exact_sha(tmp_path, fake_gh, capsys):
     from daydream.benchmark.curate_tui import run_curate_tui
     from daydream.benchmark.storage import load_yaml_strict

--- a/tests/test_benchmark_curation.py
+++ b/tests/test_benchmark_curation.py
@@ -309,6 +309,43 @@ def test_mark_ready_requires_sha_and_attest_clean_never_ready(tmp_path, fake_gh)
     assert raw2["curation"]["state"] == "draft" and raw2["curation"]["snapshot_attested"] is False
 
 
+def test_mark_ready_clean_attested_empty_yields_ready(tmp_path, fake_gh):
+    from daydream.benchmark import curation as cu
+    from daydream.benchmark.storage import load_yaml_strict
+    from daydream.benchmark.workspace import validate_workspace
+    ws, case_id, head_sha = _seed_ready_case(tmp_path, fake_gh, lines=2)  # empty gold
+    cu.attest_clean(ws, case_id)
+    cu.mark_ready(ws, case_id, head_sha=head_sha)
+    cur = load_yaml_strict(ws / "cases" / f"{case_id}.yaml")["curation"]
+    assert cur["state"] == "ready" and cur["snapshot_attested"] is True
+    assert cur["clean_attested"] is True
+    assert cur["gold_status"] == "clean" and cur["gold_mode"] == "clean"
+    code, _label = validate_workspace(ws)     # ready-clean passes workspace validation
+    assert code == 0
+
+
+def test_mark_ready_empty_not_clean_attested_still_raises(tmp_path, fake_gh):
+    from daydream.benchmark import curation as cu
+    from daydream.benchmark.storage import load_yaml_strict
+    ws, case_id, head_sha = _seed_ready_case(tmp_path, fake_gh, lines=2)  # empty gold, NOT attested
+    with pytest.raises(cu.CurationError):
+        cu.mark_ready(ws, case_id, head_sha=head_sha)
+    cur = load_yaml_strict(ws / "cases" / f"{case_id}.yaml")["curation"]
+    assert cur["state"] == "draft" and cur["snapshot_attested"] is False
+
+
+def test_mark_ready_clean_wrong_sha_is_non_mutating(tmp_path, fake_gh):
+    from daydream.benchmark import curation as cu
+    from daydream.benchmark.storage import load_yaml_strict
+    ws, case_id, _ = _seed_ready_case(tmp_path, fake_gh, lines=2)
+    cu.attest_clean(ws, case_id)
+    with pytest.raises(cu.StaleStateError):
+        cu.mark_ready(ws, case_id, head_sha="f" * 40)
+    cur = load_yaml_strict(ws / "cases" / f"{case_id}.yaml")["curation"]
+    assert cur["state"] == "draft" and cur["snapshot_attested"] is False
+    assert cur["clean_attested"] is True        # attestation preserved; only readiness failed
+
+
 def test_ready_edit_reopens_draft_and_clears_attestation(tmp_path, fake_gh):
     from daydream.benchmark import curation as cu
     ws, case_id, head_sha = _seed_ready_case(tmp_path, fake_gh, lines=3, candidate=True)

--- a/tests/test_benchmark_harbor_build.py
+++ b/tests/test_benchmark_harbor_build.py
@@ -672,6 +672,31 @@ def test_compile_clean_case_has_empty_gold_and_oracle(tmp_path, fake_gh):
     assert lock["cases"][key]["gold_sha256"] == hashlib.sha256(b"[]").hexdigest()
 
 
+def test_ready_empty_gold_without_clean_attestation_does_not_compile(tmp_path, fake_gh):
+    """A ready empty-gold case with no clean attestation must not compile.
+
+    mark_ready refuses to final-attest an empty gold set that was never
+    clean-attested, so only a hand-edited doc can reach ready with
+    ``clean_attested=False``; the compiler must reject it rather than ship
+    the empty gold as a clean case.
+    """
+    from daydream.benchmark import storage
+    from daydream.benchmark.harbor import build
+    ws, case_id, _ = _seed_clean_workspace(tmp_path, fake_gh, ready=False)  # clean-attested draft
+    path = ws / "cases" / f"{case_id}.yaml"
+    raw = storage.load_yaml_strict(path)
+    curation = dict(raw["curation"])
+    curation["state"] = "ready"            # hand-edit bypasses mark_ready
+    curation["snapshot_attested"] = True
+    curation["clean_attested"] = False     # never clean-attested
+    curation["gold_status"] = None         # no clean label without attestation
+    raw["curation"] = curation
+    storage.atomic_write_yaml(path, raw)
+    with pytest.raises(build.CompileError):
+        build.compile_workspace(ws)
+    assert not (ws / "harbor").exists()    # failed compile leaves no bundle
+
+
 def test_unbounded_pr_body_never_leaks_to_compiled_surface(tmp_path, fake_gh):
     from daydream.benchmark.harbor.build import compile_workspace
     ws, case_id, _ = _seed_ready_workspace(tmp_path, fake_gh)

--- a/tests/test_benchmark_harbor_build.py
+++ b/tests/test_benchmark_harbor_build.py
@@ -172,8 +172,12 @@ def _seed_ready_workspace(tmp_path: Path, fake_gh, *, lines: int = 3) -> tuple[P
     return ws, case_id, head_sha
 
 
-def _seed_clean_workspace(tmp_path: Path, fake_gh) -> tuple[Path, str, str]:
-    """Seed a reviewed-clean workspace: import with no comments, then attest clean."""
+def _seed_clean_workspace(tmp_path: Path, fake_gh, *, ready: bool = True) -> tuple[Path, str, str]:
+    """Seed a reviewed-clean workspace: import with no comments, then attest clean.
+
+    With *ready* True (default), the clean-attested case is also final-attested
+    ready; with *ready* False it stays a clean-attested draft.
+    """
     from daydream.benchmark import curation as cu
     from daydream.benchmark import github_import as gi
     from daydream.benchmark.storage import load_yaml_strict
@@ -188,6 +192,8 @@ def _seed_clean_workspace(tmp_path: Path, fake_gh) -> tuple[Path, str, str]:
     raw = load_yaml_strict(ws / "benchmark.yaml")
     case_id = raw["cases"][0]["case_id"]
     cu.attest_clean(ws, case_id)
+    if ready:
+        cu.mark_ready(ws, case_id, head_sha=head_sha)
     return ws, case_id, head_sha
 
 
@@ -643,6 +649,13 @@ def test_compile_findings_case_full_tree_and_gold_oracle_agree(tmp_path, fake_gh
         if rel == "benchmark.lock.json":
             continue
         assert lock["files"][rel] == hashlib.sha256(data).hexdigest()
+
+
+def test_clean_attested_draft_does_not_compile(tmp_path, fake_gh):
+    from daydream.benchmark.harbor import build
+    ws, case_id, _ = _seed_clean_workspace(tmp_path, fake_gh, ready=False)  # draft-clean
+    with pytest.raises(build.CompileError):
+        build.compile_workspace(ws)
 
 
 def test_compile_clean_case_has_empty_gold_and_oracle(tmp_path, fake_gh):


### PR DESCRIPTION
## Summary
Closes #815.

Completes the reviewed-clean final attestation flow in the benchmark compiler/TUI path:
- `[c]` records a clean-truth attestation without itself marking the case ready.
- A subsequent exact snapshot-SHA `[r]` confirmation may mark the case ready.
- The compiler only builds `ready` cases, and only those with a clean (or permitted empty-gold) attestation.

## Review
This branch passed two sequential daydream deep-precision reviews (round 1, round 2) on fresh VMs. Deterministic-authorship gate: AUTHORS_OK (all commits authored by anderskev@gmail.com).

## Test Plan
- `make check`: uv lock OK, ruff OK, mypy OK
- `pytest`: 4364 passed, 7 skipped