### PR TITLE
fix(benchmark): make evidence refresh snapshot-pinned and provenance-aware (Closes #813)

### DIFF
--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -1121,11 +1121,9 @@ def _case_materialize(
         if head_token == "final":
             # head-immutable: an existing final_pr_head case resolves to its
             # pinned commit; only a first import (no pin) uses the live head.
-            if prior_policy and prior_pinned:
-                for prior_case_id, prior_pol in prior_policy.items():
-                    if prior_pol == "final_pr_head" and prior_case_id in prior_pinned:
-                        head_sha = prior_pinned[prior_case_id]
-                        break
+            pinned = _pinned_head_sha(prior_policy, prior_pinned)
+            if pinned is not None:
+                head_sha = pinned
             if head_sha is None:
                 head_sha = pull_request.head.sha
         if not head_sha or head_sha in seen:
@@ -1404,6 +1402,26 @@ def _prior_import_state(
     )
 
 
+def _pinned_head_sha(
+    prior_policy: dict[str, str] | None,
+    prior_pinned: dict[str, str] | None,
+) -> str | None:
+    """Return the pinned head sha for an existing ``final_pr_head`` case, if any.
+
+    Head-immutable task input: an existing ``final`` case resolves to the pinned
+    head from its prior ``snapshot.original_head_sha``, so a live head advance
+    neither re-anchors the case nor flips its task-input signature. Only a first
+    import with no ``final_pr_head`` pin uses the live head (caller falls back).
+    Shared by the materialize path and ``_import_one_pr`` so the pinning logic
+    and its ``final_pr_head`` magic string live in exactly one place.
+    """
+    if prior_policy and prior_pinned:
+        for prior_case_id, prior_pol in prior_policy.items():
+            if prior_pol == "final_pr_head" and prior_case_id in prior_pinned:
+                return prior_pinned[prior_case_id]
+    return None
+
+
 def _import_one_pr(
     root: Path,
     raw: dict[str, Any],
@@ -1424,11 +1442,9 @@ def _import_one_pr(
         # head advance neither re-anchors the case nor flips the task-input
         # signature of the pinned case; only a first import (no pin) keeps the
         # live pull_request.head.sha.
-        if prior_policy and prior_pinned:
-            for prior_case_id, prior_pol in prior_policy.items():
-                if prior_pol == "final_pr_head" and prior_case_id in prior_pinned:
-                    doc.pull_request.head.sha = prior_pinned[prior_case_id]
-                    break
+        pinned = _pinned_head_sha(prior_policy, prior_pinned)
+        if pinned is not None:
+            doc.pull_request.head.sha = pinned
         # Two independent stale signals: the per-case referenced-evidence arm
         # (database_ids whose projection hash changed or disappeared — runs on
         # refresh AND plain re-import) and the PR-wide task-input arm (the

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -934,24 +934,79 @@ def _payload_sha256(import_doc: dict[str, Any]) -> str:
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
+def _evidence_projection_hash(rec: dict[str, Any]) -> str:
+    """sha256 over the sorted-JSON of the projection-relevant evidence fields.
+
+    One digest per physical evidence record over exactly the fields that feed
+    candidate projection and the curated review surface: body sha, author
+    (login/type), commit anchors, path/line anchors, side, subject type,
+    resolution state, dismissal, and review state. Values use ``.get()``
+    defaults (``False`` for booleans, ``None`` for optional fields, ``""`` for
+    strings) so an absent pre-canonicalization key equals the canonical
+    default. ``kind``/``source_id``/``database_id``/``url``/timestamps are
+    excluded: they are format-drift/metadata-sensitive and must not flip the
+    signature.
+    """
+    author_raw = rec.get("author")
+    author = author_raw if isinstance(author_raw, dict) else {}
+    values: dict[str, Any] = {
+        "body_sha256": str(rec.get("body_sha256") or ""),
+        "author.login": str(author.get("login") or ""),
+        "author.type": str(author.get("type") or ""),
+        "commit_id": rec.get("commit_id"),
+        "original_commit_id": rec.get("original_commit_id"),
+        "path": rec.get("path"),
+        "original_path": rec.get("original_path"),
+        "line": rec.get("line"),
+        "start_line": rec.get("start_line"),
+        "original_line": rec.get("original_line"),
+        "side": rec.get("side"),
+        "start_side": rec.get("start_side"),
+        "subject_type": rec.get("subject_type"),
+        "resolved": bool(rec.get("resolved", False)),
+        "outdated": bool(rec.get("outdated", False)),
+        "dismissed": bool(rec.get("dismissed", False)),
+        "state": rec.get("state"),
+    }
+    canonical = json.dumps(values, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
 def _evidence_signature_from_doc(doc: schema.ImportDocument) -> frozenset[tuple[int, str]]:
-    """Content signature: one ``(database_id, body_sha256)`` pair per evidence record.
+    """Projection signature: one ``(database_id, projection_hash)`` per evidence record.
 
     Keyed on the physical comment id rather than ``source_id`` so the refresh
     stale check is immune to the canonical-record format change: pre-canonicalization
     files rekinded thread-only comments and persisted a comment that existed in
     both feeds twice, while the canonical format emits exactly one
-    ``inline_comment`` per database id. Byte-identical GitHub content changed only
-    the persisted shape, so a first ``--refresh`` after the format change must
-    compare equal and keep prior curated cases — a genuine content change (a
-    comment added/removed/edited) still flips the digest.
+    ``inline_comment`` per database id. The per-record hash spans the full
+    projection-relevant provenance (body, author, commit/anchor fields, sides,
+    subject type, resolution state, dismissal, review state) and excludes
+    ``kind``/``source_id``/``database_id``/``url``/timestamps, so a duplicate
+    pre-canon record collapses to one identical set element and a pure
+    format/metadata change keeps prior curated cases — a genuine content
+    change (a comment added/removed/edited, re-anchored, or re-resolved) still
+    flips the digest. Deletion is carried by the set: a removed record's
+    ``database_id`` simply disappears (no fallback hash).
     """
-    return frozenset((e.database_id, e.body_sha256) for e in doc.evidence)
+    return frozenset(
+        (e.database_id, _evidence_projection_hash(e.model_dump(mode="json")))
+        for e in doc.evidence
+    )
 
 
 def _evidence_signature_from_raw(raw: dict[str, Any]) -> frozenset[tuple[int, str]]:
+    """The projection signature computed over a raw import document's dict.
+
+    Shares the per-record hash helper with :func:`_evidence_signature_from_doc`
+    so the persisted-file path and the typed-doc path always agree; a record
+    appearing twice for one ``database_id`` (the pre-canonicalization duplicate)
+    collapses to one identical set element, and a deleted record simply
+    disappears from the set.
+    """
     return frozenset(
-        (int(e["database_id"]), str(e.get("body_sha256"))) for e in raw.get("evidence", [])
+        (int(e["database_id"]), _evidence_projection_hash(e))
+        for e in raw.get("evidence", [])
     )
 
 

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -1428,16 +1428,23 @@ def _import_one_pr(
                     doc.pull_request.head.sha = prior_pinned[prior_case_id]
                     break
         # Two independent stale signals: the per-case referenced-evidence arm
-        # (database_ids whose projection hash changed or disappeared) and the
-        # PR-wide task-input arm (the title/body/base/head a reviewer was
-        # shown). A metadata-only change updates checksums without staling.
+        # (database_ids whose projection hash changed or disappeared — runs on
+        # refresh AND plain re-import) and the PR-wide task-input arm (the
+        # title/body/base/head a reviewer was shown — refresh only). A
+        # metadata-only change updates checksums without staling.
         task_input_changed = (
             refresh
             and prior_task_sig is not None
             and prior_task_sig != _task_input_signature_from_doc(doc)
         )
         changed_ids: set[int] | None = None
-        if refresh and prior_sig is not None:
+        # The referenced-evidence arm runs for ANY fetched PR, refresh or plain
+        # re-import: a curated case whose own referenced evidence changed or
+        # disappeared must stale even on a non-refresh import (the refresh
+        # semantics cannot be bypassed). Only the PR-wide task-input arm stays
+        # gated on *refresh* (Assumption 3: a plain re-import never stales on
+        # title/body/base/head). A first import (no prior_sig) computes nothing.
+        if prior_sig is not None:
             prior_by_id = dict(prior_sig)
             new_by_id = dict(_evidence_signature_from_doc(doc))
             changed_ids = {

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -940,7 +940,8 @@ def _evidence_projection_hash(rec: dict[str, Any]) -> str:
     One digest per physical evidence record over exactly the fields that feed
     candidate projection and the curated review surface: body sha, author
     (login/type), commit anchors, path/line anchors, side, subject type,
-    resolution state, dismissal, and review state. Values use ``.get()``
+    reply status (replies are evidence, never candidates), resolution
+    state, dismissal, and review state. Values use ``.get()``
     defaults (``False`` for booleans, ``None`` for optional fields, ``""`` for
     strings) so an absent pre-canonicalization key equals the canonical
     default. ``kind``/``source_id``/``database_id``/``url``/timestamps are
@@ -963,6 +964,7 @@ def _evidence_projection_hash(rec: dict[str, Any]) -> str:
         "side": rec.get("side"),
         "start_side": rec.get("start_side"),
         "subject_type": rec.get("subject_type"),
+        "reply_to_id": rec.get("reply_to_id"),
         "resolved": bool(rec.get("resolved", False)),
         "outdated": bool(rec.get("outdated", False)),
         "dismissed": bool(rec.get("dismissed", False)),
@@ -981,7 +983,7 @@ def _evidence_signature_from_doc(doc: schema.ImportDocument) -> frozenset[tuple[
     both feeds twice, while the canonical format emits exactly one
     ``inline_comment`` per database id. The per-record hash spans the full
     projection-relevant provenance (body, author, commit/anchor fields, sides,
-    subject type, resolution state, dismissal, review state) and excludes
+    subject type, reply status, resolution state, dismissal, review state) and excludes
     ``kind``/``source_id``/``database_id``/``url``/timestamps, so a duplicate pre-canon record
     collapses only when its projections are identical; when the thread copy lacks the commit
     anchors the two copies project differently, and the refresh changed-check treats the fresh
@@ -1051,6 +1053,22 @@ def _task_input_signature_from_raw(raw: dict[str, Any]) -> str | None:
     return hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
 
 
+def _referenced_evidence_id(sid: str) -> int:
+    """The trailing database id of one canonical ``github:<kind>:<id>`` source_id.
+
+    Fail-closed, mirroring the schema's ``_canonical_source_id`` validator: a
+    non-canonical source_id (a hand-edited or externally-mutated curation) is
+    corrupt prior state and is never silently dropped from the referenced-
+    evidence set, or the per-case stale gate would fail open and let
+    referenced evidence change without the case flipping stale.
+    """
+    if not schema._SOURCE_ID_RE.fullmatch(sid):
+        raise storage.WorkspaceCorrupt(
+            f"curation references non-canonical source_id {sid!r}"
+        )
+    return int(sid.rsplit(":", 1)[-1])
+
+
 def _referenced_evidence_ids(curation: dict[str, Any]) -> set[int]:
     """The physical database_ids a curation references via its source_ids.
 
@@ -1058,7 +1076,9 @@ def _referenced_evidence_ids(curation: dict[str, Any]) -> set[int]:
     ``exclusions[].source_id`` by parsing the canonical
     ``github:<kind>:<id>`` form to the trailing int. Used by the per-case
     stale decision so a case stales only when evidence *it references*
-    changed; an unreferenced record never flips it.
+    changed; an unreferenced record never flips it. A non-canonical
+    reference raises :class:`~daydream.benchmark.storage.WorkspaceCorrupt`
+    (see :func:`_referenced_evidence_id`) instead of being skipped.
     """
     ids: set[int] = set()
     for finding in curation.get("findings", []):
@@ -1066,16 +1086,11 @@ def _referenced_evidence_ids(curation: dict[str, Any]) -> set[int]:
             continue
         provenance = finding.get("provenance") or {}
         for sid in provenance.get("source_ids", []):
-            match = schema._SOURCE_ID_RE.fullmatch(str(sid))
-            if match:
-                ids.add(int(str(sid).rsplit(":", 1)[-1]))
+            ids.add(_referenced_evidence_id(str(sid)))
     for exclusion in curation.get("exclusions", []):
         if not isinstance(exclusion, dict):
             continue
-        sid = exclusion.get("source_id")
-        match = schema._SOURCE_ID_RE.fullmatch(str(sid or ""))
-        if match:
-            ids.add(int(str(sid).rsplit(":", 1)[-1]))
+        ids.add(_referenced_evidence_id(str(exclusion.get("source_id") or "")))
     return ids
 
 
@@ -1109,7 +1124,12 @@ def _case_materialize(
     *task_input_changed* (PR-wide) or its own referenced evidence ids
     intersect *changed_ids* (a referenced record changed or disappeared).
     An unreferenced evidence change never stales it and an untouched PR keeps
-    it ready — findings/exclusions are never overwritten by refresh.
+    it ready — findings/exclusions are never overwritten by refresh. A freeze
+    of an existing ``ready|stale`` case that comes back ``unreplayable`` (the
+    pinned head became unreachable after a force-push/rebased branch) raises
+    :class:`~daydream.git_ops.GitError` instead of writing an unreplayable
+    snapshot over the curated case — the refresh then fails like the sibling
+    fetch-failure path (rc != 0, last-good linkage kept).
     """
     pull_request = doc.pull_request
     base_sha = pull_request.base.sha
@@ -1164,6 +1184,22 @@ def _case_materialize(
             )
             if snapshot_doc.get("status") == "ready" and bundle_bytes is not None:
                 bundle_drops.append((snapshot_doc["bundle_file"], bundle_bytes))
+            elif snapshot_doc.get("status") != "ready" and prior_curations and (
+                prior_curations.get(case_id) or {}
+            ).get("state") in ("ready", "stale"):
+                # A pinned head that became unreachable (force-push/rebased
+                # branch) makes the re-freeze of a previously curated case
+                # unreplayable. Never overwrite the curated case's snapshot
+                # with an unreplayable dict: that would orphan its staged
+                # bundle and silently flip the case out of ready while
+                # _import_one_pr still returns 0. Fail the refresh like the
+                # sibling fetch-failure path (rc 1, last-good linkage kept)
+                # so the curated state and its bundle stay intact and indexed.
+                error = snapshot_doc.get("error") or {}
+                raise git_ops.GitError(
+                    f"PR {number} freeze of curated case {case_id} is unreplayable "
+                    f"({error.get('reason')}): {error.get('detail')}"
+                )
         else:
             snapshot_doc = {
                 "status": "imported",

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -982,9 +982,11 @@ def _evidence_signature_from_doc(doc: schema.ImportDocument) -> frozenset[tuple[
     ``inline_comment`` per database id. The per-record hash spans the full
     projection-relevant provenance (body, author, commit/anchor fields, sides,
     subject type, resolution state, dismissal, review state) and excludes
-    ``kind``/``source_id``/``database_id``/``url``/timestamps, so a duplicate
-    pre-canon record collapses to one identical set element and a pure
-    format/metadata change keeps prior curated cases — a genuine content
+    ``kind``/``source_id``/``database_id``/``url``/timestamps, so a duplicate pre-canon record
+    collapses only when its projections are identical; when the thread copy lacks the commit
+    anchors the two copies project differently, and the refresh changed-check treats the fresh
+    canonical projection as unchanged while it matches any prior projection for that database id —
+    so a pure format/metadata change keeps prior curated cases, while a genuine content
     change (a comment added/removed/edited, re-anchored, or re-resolved) still
     flips the digest. Deletion is carried by the set: a removed record's
     ``database_id`` simply disappears (no fallback hash).
@@ -1001,8 +1003,8 @@ def _evidence_signature_from_raw(raw: dict[str, Any]) -> frozenset[tuple[int, st
     Shares the per-record hash helper with :func:`_evidence_signature_from_doc`
     so the persisted-file path and the typed-doc path always agree; a record
     appearing twice for one ``database_id`` (the pre-canonicalization duplicate)
-    collapses to one identical set element, and a deleted record simply
-    disappears from the set.
+    may linger as two format-only projections when the thread copy lacks
+    the commit anchors, and a deleted record simply disappears from the set.
     """
     return frozenset(
         (int(e["database_id"]), _evidence_projection_hash(e))
@@ -1445,12 +1447,32 @@ def _import_one_pr(
         # gated on *refresh* (Assumption 3: a plain re-import never stales on
         # title/body/base/head). A first import (no prior_sig) computes nothing.
         if prior_sig is not None:
-            prior_by_id = dict(prior_sig)
-            new_by_id = dict(_evidence_signature_from_doc(doc))
+            # Per-id projection-hash SETS instead of a dict() collapse: two
+            # records for one database_id (the pre-canonicalization duplicate —
+            # a REST inline copy and a GraphQL thread copy under the same id)
+            # carry different projection hashes, and which tuple dict() keeps
+            # depends on frozenset iteration order, which hash randomization
+            # makes nondeterministic across processes. Comparing per-id hash
+            # sets is order-independent. A database id counts as changed only
+            # when its fresh canonical projection is NOT covered by the prior
+            # projections: a genuine content/anchor/resolution edit, an
+            # addition, or a deletion. The pre-canonical thread copy lacks the
+            # commit anchors only REST exposes, so it is a pure format artifact
+            # — the fresh REST-derived projection still matches a prior
+            # projection and the first post-format refresh must NOT stale
+            # curated gold. When every id is unique on both sides this reduces
+            # exactly to the old single-hash comparison.
+            prior_by_id: dict[int, set[str]] = {}
+            for db_id, proj_hash in prior_sig:
+                prior_by_id.setdefault(db_id, set()).add(proj_hash)
+            new_by_id: dict[int, set[str]] = {}
+            for db_id, proj_hash in _evidence_signature_from_doc(doc):
+                new_by_id.setdefault(db_id, set()).add(proj_hash)
             changed_ids = {
                 db_id
                 for db_id in set(prior_by_id) | set(new_by_id)
-                if new_by_id.get(db_id) != prior_by_id.get(db_id)
+                if db_id not in new_by_id
+                or not (new_by_id[db_id] <= prior_by_id.get(db_id, set()))
             }
         import_bytes = json.dumps(doc.model_dump(mode="json"), indent=2).encode("utf-8")
         import_sha256 = hashlib.sha256(import_bytes).hexdigest()

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -1049,6 +1049,34 @@ def _task_input_signature_from_raw(raw: dict[str, Any]) -> str | None:
     return hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
 
 
+def _referenced_evidence_ids(curation: dict[str, Any]) -> set[int]:
+    """The physical database_ids a curation references via its source_ids.
+
+    Derives each id from ``findings[].provenance.source_ids`` and
+    ``exclusions[].source_id`` by parsing the canonical
+    ``github:<kind>:<id>`` form to the trailing int. Used by the per-case
+    stale decision so a case stales only when evidence *it references*
+    changed; an unreferenced record never flips it.
+    """
+    ids: set[int] = set()
+    for finding in curation.get("findings", []):
+        if not isinstance(finding, dict):
+            continue
+        provenance = finding.get("provenance") or {}
+        for sid in provenance.get("source_ids", []):
+            match = schema._SOURCE_ID_RE.fullmatch(str(sid))
+            if match:
+                ids.add(int(str(sid).rsplit(":", 1)[-1]))
+    for exclusion in curation.get("exclusions", []):
+        if not isinstance(exclusion, dict):
+            continue
+        sid = exclusion.get("source_id")
+        match = schema._SOURCE_ID_RE.fullmatch(str(sid or ""))
+        if match:
+            ids.add(int(str(sid).rsplit(":", 1)[-1]))
+    return ids
+
+
 def _case_materialize(
     doc: schema.ImportDocument,
     number: int,
@@ -1060,16 +1088,20 @@ def _case_materialize(
     repo_slug: str = "",
     origin_url: str | None = None,
     prior_curations: dict[str, dict[str, Any]] | None = None,
-    changed: bool = False,
+    changed_ids: set[int] | None = None,
+    task_input_changed: bool = False,
 ) -> tuple[list[tuple[str, str, dict[str, Any]]], list[tuple[str, bytes]]]:
     """One materialized case document per requested head.
 
     When *root*/origin are provided the case ``snapshot`` is frozen via
     :func:`daydream.benchmark.snapshot.freeze_one` (a ``ready|unreplayable``
     dict) and any produced bundle is returned in the second element for the
-    caller to stage atomically. When *changed* is True and a prior curated
-    case exists, its curation is carried over and flipped to ``stale`` with
-    attestation cleared — findings/exclusions are never overwritten by refresh.
+    caller to stage atomically. When a prior curated case exists, its curation
+    is carried over; it is flipped to ``stale`` with attestation cleared iff
+    *task_input_changed* (PR-wide) or its own referenced evidence ids
+    intersect *changed_ids* (a referenced record changed or disappeared).
+    An unreferenced evidence change never stales it and an untouched PR keeps
+    it ready — findings/exclusions are never overwritten by refresh.
     """
     pull_request = doc.pull_request
     base_sha = pull_request.base.sha
@@ -1095,7 +1127,11 @@ def _case_materialize(
         if prior_curations and case_id in prior_curations:
             prior = prior_curations[case_id]
             curation = dict(prior)
-            if changed and prior.get("state") in ("ready", "stale"):
+            should_stale = task_input_changed or (
+                changed_ids is not None
+                and bool(_referenced_evidence_ids(prior) & changed_ids)
+            )
+            if should_stale and prior.get("state") in ("ready", "stale"):
                 curation["state"] = "stale"
                 curation["snapshot_attested"] = False
         if root is not None and origin_url is not None and base_sha and head_sha:
@@ -1299,26 +1335,31 @@ def _import_one_pr(
     prior_sig, prior_task_sig, prior_curations, import_file = _prior_import_state(root, raw, number)
     try:
         doc = fetch_and_normalize(root, repo, number)
-        # stale only on an evidence change OR a task-input-contract change
-        # (the title/body/base/head a reviewer was shown); a metadata-only change
-        # updates checksums without staling gold.
-        changed = (
+        # Two independent stale signals: the per-case referenced-evidence arm
+        # (database_ids whose projection hash changed or disappeared) and the
+        # PR-wide task-input arm (the title/body/base/head a reviewer was
+        # shown). A metadata-only change updates checksums without staling.
+        task_input_changed = (
             refresh
-            and prior_sig is not None
-            and (
-                prior_sig != _evidence_signature_from_doc(doc)
-                or (
-                    prior_task_sig is not None
-                    and prior_task_sig != _task_input_signature_from_doc(doc)
-                )
-            )
+            and prior_task_sig is not None
+            and prior_task_sig != _task_input_signature_from_doc(doc)
         )
+        changed_ids: set[int] | None = None
+        if refresh and prior_sig is not None:
+            prior_by_id = dict(prior_sig)
+            new_by_id = dict(_evidence_signature_from_doc(doc))
+            changed_ids = {
+                db_id
+                for db_id in set(prior_by_id) | set(new_by_id)
+                if new_by_id.get(db_id) != prior_by_id.get(db_id)
+            }
         import_bytes = json.dumps(doc.model_dump(mode="json"), indent=2).encode("utf-8")
         import_sha256 = hashlib.sha256(import_bytes).hexdigest()
         cases, bundle_rels = _case_materialize(
             doc, number, requested_heads, import_file, import_sha256,
             root=root, repo_slug=repo, origin_url=origin_url,
-            prior_curations=prior_curations, changed=changed,
+            prior_curations=prior_curations,
+            changed_ids=changed_ids, task_input_changed=task_input_changed,
         )
         with storage.Transaction(root, op_id=f"import-{number}", kind="import") as tx:
             tx.stage(import_file, import_bytes)

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -1088,6 +1088,8 @@ def _case_materialize(
     repo_slug: str = "",
     origin_url: str | None = None,
     prior_curations: dict[str, dict[str, Any]] | None = None,
+    prior_pinned: dict[str, str] | None = None,
+    prior_policy: dict[str, str] | None = None,
     changed_ids: set[int] | None = None,
     task_input_changed: bool = False,
 ) -> tuple[list[tuple[str, str, dict[str, Any]]], list[tuple[str, bytes]]]:
@@ -1096,7 +1098,11 @@ def _case_materialize(
     When *root*/origin are provided the case ``snapshot`` is frozen via
     :func:`daydream.benchmark.snapshot.freeze_one` (a ``ready|unreplayable``
     dict) and any produced bundle is returned in the second element for the
-    caller to stage atomically. When a prior curated case exists, its curation
+    caller to stage atomically. An existing ``final`` case resolves to the
+    pinned head from its prior ``snapshot.original_head_sha`` (head-immutable,
+    so a live head advance reproduces the identical ``case_id``); only a first
+    import with no prior ``final_pr_head`` pin uses the live
+    ``pull_request.head.sha``. When a prior curated case exists, its curation
     is carried over; it is flipped to ``stale`` with attestation cleared iff
     *task_input_changed* (PR-wide) or its own referenced evidence ids
     intersect *changed_ids* (a referenced record changed or disappeared).
@@ -1109,7 +1115,17 @@ def _case_materialize(
     bundle_drops: list[tuple[str, bytes]] = []
     seen: set[str] = set()
     for head_token in requested_heads:
-        head_sha = head_token if head_token != "final" else pull_request.head.sha
+        head_sha = head_token if head_token != "final" else None
+        if head_token == "final":
+            # head-immutable: an existing final_pr_head case resolves to its
+            # pinned commit; only a first import (no pin) uses the live head.
+            if prior_policy and prior_pinned:
+                for prior_case_id, prior_pol in prior_policy.items():
+                    if prior_pol == "final_pr_head" and prior_case_id in prior_pinned:
+                        head_sha = prior_pinned[prior_case_id]
+                        break
+            if head_sha is None:
+                head_sha = pull_request.head.sha
         if not head_sha or head_sha in seen:
             continue
         seen.add(head_sha)
@@ -1278,22 +1294,34 @@ def _prior_import_state(
     str | None,
     dict[str, dict[str, Any]],
     str,
+    dict[str, str],
+    dict[str, str],
+    list[str],
 ]:
-    """The prior evidence signature, task-input signature, curations, and import path.
+    """Prior import signatures, curations, path, pins, policies, and heads.
 
-    A missing prior state (no ``fetched`` ledger entry, or no persisted
-    import/case to read) yields ``None`` for both signatures and empty
-    curations — the normal first-run path. A *present-but-corrupt* prior
-    import or curation file is fatal: :class:`~daydream.benchmark.storage.WorkspaceCorrupt`
+    Returns the prior evidence signature, task-input signature, per-case
+    curations, the import path, each prior case's pinned
+    ``snapshot.original_head_sha`` (``prior_pinned``), each prior case's
+    ``snapshot.policy`` (``prior_policy``), and the prior ledger entry's
+    ``requested_heads``. A missing prior state (no ``fetched`` ledger entry, or
+    no persisted import/case to read) yields ``None`` for both signatures,
+    empty curations/pins/policies/heads, and the default import path — the
+    normal first-run path. A *present-but-corrupt* prior import or curation
+    file is fatal: :class:`~daydream.benchmark.storage.WorkspaceCorrupt`
     from the strict loaders propagates so a refresh fails before any network
     fetch or mutation, never silently healing corrupt prior state to
-    ``None``/``draft``.
+    ``None``/``draft``. A ``ready``/``stale`` prior case missing its pinned
+    head is also corrupt prior state — never a silent live-head default.
     """
     import_file = f"imports/pr-{number:06d}.json"
     existing = _manifest_entry(raw, number)
     prior_sig: frozenset[tuple[int, str]] | None = None
     prior_task_sig: str | None = None
     prior_curations: dict[str, dict[str, Any]] = {}
+    prior_pinned: dict[str, str] = {}
+    prior_policy: dict[str, str] = {}
+    prior_requested_heads: list[str] = list(existing.get("requested_heads", [])) if existing else []
     if existing is not None and existing.get("import_state") == "fetched":
         prior_import_file = existing.get("import_file")
         if not prior_import_file:
@@ -1313,12 +1341,39 @@ def _prior_import_state(
         prior_sig = _evidence_signature_from_raw(prior_raw)
         prior_task_sig = _task_input_signature_from_raw(prior_raw)
         for case_id in existing.get("case_ids", []):
-            cur = storage.load_yaml_strict(
+            case_raw = storage.load_yaml_strict(
                 storage.resolve_authoring_path(root, f"cases/{case_id}.yaml")
-            ).get("curation")
+            )
+            cur = case_raw.get("curation")
             if isinstance(cur, dict):
                 prior_curations[case_id] = cur
-    return prior_sig, prior_task_sig, prior_curations, import_file
+            snapshot = case_raw.get("snapshot") or {}
+            original_head_sha = snapshot.get("original_head_sha")
+            if (
+                isinstance(cur, dict)
+                and cur.get("state") in ("ready", "stale")
+                and not original_head_sha
+            ):
+                # A curated case must know which commit it was curated against;
+                # an absent pin makes head-immutable refresh impossible without
+                # silently re-anchoring to the live head.
+                raise storage.WorkspaceCorrupt(
+                    f"{root}: ready/stale case {case_id} is missing snapshot.original_head_sha"
+                )
+            if original_head_sha:
+                prior_pinned[case_id] = original_head_sha
+            policy = snapshot.get("policy")
+            if policy:
+                prior_policy[case_id] = policy
+    return (
+        prior_sig,
+        prior_task_sig,
+        prior_curations,
+        import_file,
+        prior_pinned,
+        prior_policy,
+        prior_requested_heads,
+    )
 
 
 def _import_one_pr(
@@ -1332,9 +1387,19 @@ def _import_one_pr(
     origin_url: str | None = None,
 ) -> int:
     """Fetch + materialize one PR, or stage its failure: 0 on success, 1 on failure."""
-    prior_sig, prior_task_sig, prior_curations, import_file = _prior_import_state(root, raw, number)
+    prior_sig, prior_task_sig, prior_curations, import_file, prior_pinned, prior_policy, prior_requested_heads = _prior_import_state(root, raw, number)
     try:
         doc = fetch_and_normalize(root, repo, number)
+        # Head-immutable task input: an existing final_pr_head case pins the
+        # refreshed doc's head to its snapshot.original_head_sha, so a live
+        # head advance neither re-anchors the case nor flips the task-input
+        # signature of the pinned case; only a first import (no pin) keeps the
+        # live pull_request.head.sha.
+        if prior_policy and prior_pinned:
+            for prior_case_id, prior_pol in prior_policy.items():
+                if prior_pol == "final_pr_head" and prior_case_id in prior_pinned:
+                    doc.pull_request.head.sha = prior_pinned[prior_case_id]
+                    break
         # Two independent stale signals: the per-case referenced-evidence arm
         # (database_ids whose projection hash changed or disappeared) and the
         # PR-wide task-input arm (the title/body/base/head a reviewer was
@@ -1355,10 +1420,17 @@ def _import_one_pr(
             }
         import_bytes = json.dumps(doc.model_dump(mode="json"), indent=2).encode("utf-8")
         import_sha256 = hashlib.sha256(import_bytes).hexdigest()
+        # Refresh/re-import never orphans a previously pinned case: materialize
+        # the union of the prior ledger heads and the newly-requested heads so
+        # _stamp_fetched's cases[] rewrite keeps every curated case indexed.
+        materialize_heads = requested_heads
+        if prior_requested_heads:
+            materialize_heads = list(dict.fromkeys([*prior_requested_heads, *requested_heads]))
         cases, bundle_rels = _case_materialize(
-            doc, number, requested_heads, import_file, import_sha256,
+            doc, number, materialize_heads, import_file, import_sha256,
             root=root, repo_slug=repo, origin_url=origin_url,
             prior_curations=prior_curations,
+            prior_pinned=prior_pinned, prior_policy=prior_policy,
             changed_ids=changed_ids, task_input_changed=task_input_changed,
         )
         with storage.Transaction(root, op_id=f"import-{number}", kind="import") as tx:
@@ -1372,7 +1444,7 @@ def _import_one_pr(
                 number,
                 import_file,
                 import_sha256,
-                requested_heads,
+                materialize_heads,
                 [c[0] for c in cases],
             )
             tx.stage("benchmark.yaml", _manifest_bytes(raw))

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -1213,6 +1213,7 @@ def _stamp_fetched(
             "import_file": import_file,
             "import_sha256": import_sha256,
             "error": None,
+            "latest_error": None,  # a successful import/refresh clears the prior failed attempt
             "requested_heads": requested_heads,
             "case_ids": case_ids,
         },
@@ -1231,7 +1232,28 @@ def _stamp_fetched(
 
 
 def _stages_failed(raw: dict[str, Any], number: int, code: str, message: str) -> None:
-    schema.validate_pr_transition(_pending_pr_state(raw, number), "fetch_failed")
+    prior_state = _pending_pr_state(raw, number)
+    if prior_state == "fetched":
+        # Non-destructive failed refresh (issue #813): a fetched PR keeps its
+        # last-good linkage (import_file/import_sha256/requested_heads/case_ids)
+        # and records the failed attempt separately in latest_error — it never
+        # flips to bare fetch_failed, which would orphan its curated cases.
+        entry = _manifest_entry(raw, number) or {}
+        _ledger_replace(
+            raw,
+            {
+                "number": number,
+                "import_state": "fetched",
+                "import_file": entry.get("import_file"),
+                "import_sha256": entry.get("import_sha256"),
+                "error": None,
+                "latest_error": {"code": code, "message": message},
+                "requested_heads": entry.get("requested_heads", []),
+                "case_ids": entry.get("case_ids", []),
+            },
+        )
+        return
+    schema.validate_pr_transition(prior_state, "fetch_failed")
     _ledger_replace(
         raw,
         {
@@ -1240,6 +1262,7 @@ def _stages_failed(raw: dict[str, Any], number: int, code: str, message: str) ->
             "import_file": None,
             "import_sha256": None,
             "error": {"code": code, "message": message},
+            "latest_error": None,
             "requested_heads": [],
             "case_ids": [],
         },
@@ -1275,11 +1298,14 @@ def _manifest_bytes(raw: dict[str, Any]) -> bytes:
 def _stage_fetch_failure(
     root: Path, raw: dict[str, Any], number: int, code: str, message: str
 ) -> None:
-    """Atomically flip a PR's ledger entry to ``fetch_failed``.
+    """Atomically stage a failed fetch on a PR's ledger entry.
 
-    Stages only ``benchmark.yaml`` through one :class:`Transaction`; a failed
-    fetch materializes no import/case file (the whole before/after ledger state
-    is atomic).
+    A first-import failure flips the entry to ``fetch_failed`` with an exact
+    error; a failed refresh on an already-``fetched`` PR preserves its last-good
+    linkage and records the attempt in ``latest_error`` instead. Stages only
+    ``benchmark.yaml`` through one :class:`Transaction`; a failed fetch
+    materializes no import/case file (the whole before/after ledger state is
+    atomic).
     """
     _stages_failed(raw, number, code, message)
     with storage.Transaction(root, op_id=f"import-{number}", kind="import") as tx:
@@ -1387,7 +1413,8 @@ def _import_one_pr(
     origin_url: str | None = None,
 ) -> int:
     """Fetch + materialize one PR, or stage its failure: 0 on success, 1 on failure."""
-    prior_sig, prior_task_sig, prior_curations, import_file, prior_pinned, prior_policy, prior_requested_heads = _prior_import_state(root, raw, number)
+    prior_sig, prior_task_sig, prior_curations, import_file, prior_pinned, prior_policy, \
+        prior_requested_heads = _prior_import_state(root, raw, number)
     try:
         doc = fetch_and_normalize(root, repo, number)
         # Head-immutable task input: an existing final_pr_head case pins the

--- a/daydream/benchmark/schema.py
+++ b/daydream/benchmark/schema.py
@@ -187,6 +187,7 @@ class PullRequestEntry(BaseModel):
     import_file: str | None = None
     import_sha256: str | None = None
     error: dict[str, str] | None = None
+    latest_error: dict[str, str] | None = None
     requested_heads: list[str] = []
     case_ids: list[str] = []
 
@@ -204,9 +205,18 @@ class PullRequestEntry(BaseModel):
                 raise ValueError("fetch_failed import requires an error")
             if self.import_file is not None or self.import_sha256 is not None:
                 raise ValueError("fetch_failed import must not set import_file/import_sha256")
+            if self.latest_error is not None:
+                raise ValueError("fetch_failed import must not carry a latest_error")
         else:  # pending
-            if self.import_file is not None or self.import_sha256 is not None or self.error is not None:
-                raise ValueError("pending import must not set import_file/import_sha256/error")
+            if (
+                self.import_file is not None
+                or self.import_sha256 is not None
+                or self.error is not None
+                or self.latest_error is not None
+            ):
+                raise ValueError(
+                    "pending import must not set import_file/import_sha256/error/latest_error"
+                )
         if self.import_file is not None and not self.import_file:
             raise ValueError("import_file must not be blank")
         return self
@@ -975,7 +985,11 @@ class PreflightLedger(BaseModel):
 _PR_TRANSITIONS: dict[str, set[str]] = {
     "pending": {"fetched", "fetch_failed"},
     "fetch_failed": {"fetched", "fetch_failed"},
-    "fetched": {"fetched", "fetch_failed"},
+    # A fetched PR never goes to bare fetch_failed: a failed refresh preserves
+    # its last-good linkage and records the attempt in ``latest_error`` instead
+    # of wiping it (issue #813). Only a first-import failure (pending/fetch_failed
+    # with no linkage) stages a plain fetch_failed.
+    "fetched": {"fetched"},
 }
 
 _CASE_TRANSITIONS: dict[str, set[str]] = {

--- a/tests/test_benchmark_curation.py
+++ b/tests/test_benchmark_curation.py
@@ -666,8 +666,8 @@ def test_read_only_paths_run_concurrent_with_a_writer(tmp_path, fake_gh):
          str(lock_path)],
         stdout=subprocess.PIPE, text=True,
     )
-    assert holder.stdout.readline().strip() == "held"            # another process now holds the flock
     try:
+        assert holder.stdout.readline().strip() == "held"        # another process now holds the flock
         cu.list_cases(ws)
         cu.get_case(ws, case_id)
         cu.validate_case(ws, case_id)
@@ -676,7 +676,11 @@ def test_read_only_paths_run_concurrent_with_a_writer(tmp_path, fake_gh):
         # writer released (30s later).
         assert holder.poll() is None
     finally:
-        holder.wait(timeout=30)
+        # Cleanup must not race the writer's 30s sleep: a bare wait(timeout=30)
+        # started ~milliseconds after the sleep begins has zero scheduling
+        # margin and can TimeoutExpired under parallel-suite load. Kill instead.
+        holder.kill()
+        holder.wait()
 
 
 def test_locked_mutation_heals_interrupted_journal_before_new_write(tmp_path, fake_gh):

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -1601,3 +1601,35 @@ def test_refresh_after_head_advance_keeps_case_id(tmp_path, fake_gh):
     assert (ws / "cases" / "pr-000101-aaaaaaaaaaaa.yaml").exists()
     case = load_yaml_strict(ws / "cases" / "pr-000101-aaaaaaaaaaaa.yaml")
     assert case["curation"]["state"] == "ready"       # unchanged evidence -> stays ready
+
+
+# ---------------------------------------------------------------------------
+# non-destructive failed refresh (issue #813): a failed refresh on an already-
+# fetched PR preserves last-good linkage and records the attempt in latest_error
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_failure_preserves_linkage_and_records_attempt(tmp_path, fake_gh):
+    # Import + curate PR 101 successfully, then make the refresh fetch fail: the
+    # last-good import_file/import_sha256/case_ids are preserved and the attempt
+    # is recorded separately in latest_error (NOT reset to fetch_failed).
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.storage import load_yaml_strict
+
+    ws = tmp_path / "ws"
+    _seed_preflight(ws, fake_gh)
+    assert gi.run_import_prs(ws, pr_numbers=[101], heads=["final"], origin_url=None) == 0
+    _curate_case(ws, "pr-000101-aaaaaaaaaaaa.yaml")
+    before = load_yaml_strict(ws / "benchmark.yaml")["pull_requests"][0]
+    fake_gh.set_response(
+        "GET", "repos/o/r/pulls/101", {"__error__": "API rate limit exceeded Retry-After: 1"}
+    )
+    rc = gi.run_import_prs(ws, pr_numbers=[101], heads=["final"], refresh=True, origin_url=None)
+    assert rc != 0
+    after = load_yaml_strict(ws / "benchmark.yaml")["pull_requests"][0]
+    assert after["import_state"] == "fetched"            # NOT reset to fetch_failed
+    assert after["import_file"] == before["import_file"]  # last-good linkage preserved
+    assert after["import_sha256"] == before["import_sha256"]
+    assert after["case_ids"] == before["case_ids"]
+    assert after["latest_error"]["code"] == "rate_limit"  # attempt recorded separately
+    assert (ws / "cases" / "pr-000101-aaaaaaaaaaaa.yaml").exists()  # case still indexed

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -1453,3 +1453,58 @@ def test_missing_prior_import_is_nonfatal_first_run(tmp_path):
     raw = load_yaml_strict(ws / "benchmark.yaml")
     prior_sig, prior_task_sig, curations, _ = gi._prior_import_state(ws, raw, 202)
     assert prior_sig is None and prior_task_sig is None and curations == {}
+
+
+# ---------------------------------------------------------------------------
+# widened evidence signature (issue #813): projection-relevant provenance keyed
+# per physical database_id; kind/source_id/url/timestamps excluded
+# ---------------------------------------------------------------------------
+
+
+def _one_evidence() -> dict:
+    """One canonical inline-comment evidence record dict (projection fields)."""
+    return {"database_id": 1, "body_sha256": "a" * 64, "body": "please fix",
+            "path": "a.py", "line": 4, "commit_id": "a" * 40, "outdated": False,
+            "resolved": False, "dismissed": False, "state": "COMMENTED",
+            "subject_type": "line", "side": "RIGHT", "start_side": None,
+            "original_path": "a.py", "original_line": 4, "original_commit_id": "a" * 40,
+            "author": {"login": "alice", "type": "User"}}
+
+
+def _sig(ev: dict):
+    """Signature over one raw evidence record: ``{"evidence": [ev]}`` wrapper."""
+    from daydream.benchmark import github_import as gi
+
+    return gi._evidence_signature_from_raw({"evidence": [ev]})
+
+
+def test_signature_changes_on_anchor_move():
+    base = _one_evidence()
+    moved = {**base, "line": 7}                     # same body, moved anchor
+    assert _sig(base) != _sig(moved)
+
+
+def test_signature_changes_on_resolution_state():
+    base = _one_evidence()
+    assert _sig(base) != _sig({**base, "resolved": True})
+    assert _sig(base) != _sig({**base, "outdated": True})
+    assert _sig(base) != _sig({**base, "dismissed": True})
+    assert _sig(base) != _sig({**base, "commit_id": "b" * 40})
+    assert _sig(base) != _sig({**base, "author": {"login": "bob", "type": "User"}})
+
+
+def test_signature_ignores_metadata_only_change():
+    base = _one_evidence()
+    meta = {**base, "updated_at": "2026-01-02T00:00:00Z", "url": "https://e.example/2"}
+    assert _sig(base) == _sig(meta)
+
+
+def test_signature_ignores_format_drift_duplicate_and_kind():
+    from daydream.benchmark import github_import as gi
+
+    base = _one_evidence()
+    dup = [{**base, "kind": "inline_comment"},      # same database_id stored twice
+           {**base, "kind": "thread_comment"}]
+    canon = [base]
+    assert gi._evidence_signature_from_raw({"evidence": dup}) \
+        == gi._evidence_signature_from_raw({"evidence": canon})

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -1451,8 +1451,17 @@ def test_missing_prior_import_is_nonfatal_first_run(tmp_path):
     ws = tmp_path / "ws"
     init_workspace(ws, "o/r", ["h1.example.com"], ["h2.example.com"])
     raw = load_yaml_strict(ws / "benchmark.yaml")
-    prior_sig, prior_task_sig, curations, _ = gi._prior_import_state(ws, raw, 202)
+    (
+        prior_sig,
+        prior_task_sig,
+        curations,
+        _,
+        prior_pinned,
+        prior_policy,
+        prior_heads,
+    ) = gi._prior_import_state(ws, raw, 202)
     assert prior_sig is None and prior_task_sig is None and curations == {}
+    assert prior_pinned == {} and prior_policy == {} and prior_heads == []
 
 
 # ---------------------------------------------------------------------------
@@ -1563,3 +1572,32 @@ def test_refresh_changed_anchor_on_referenced_evidence_stales(tmp_path, fake_gh)
     assert case["curation"]["state"] == "stale"
     assert case["curation"]["findings"]               # curated findings preserved
     assert case["curation"]["snapshot_attested"] is False
+
+
+# ---------------------------------------------------------------------------
+# head-immutability (issue #813): an existing case resolves to its pinned head,
+# so a live head advance reproduces the same case_id with no orphan
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_after_head_advance_keeps_case_id(tmp_path, fake_gh):
+    # Import + curate PR 101 at head a*40, then change the live head to b*40
+    # (the branch advanced) and refresh: the SAME case_id is reproduced, no
+    # new case, no orphan, and the untouched pinned case stays ready.
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.storage import load_yaml_strict
+
+    ws = tmp_path / "ws"
+    _seed_preflight(ws, fake_gh)
+    assert gi.run_import_prs(ws, pr_numbers=[101], heads=["final"], origin_url=None) == 0
+    _curate_case(ws, "pr-000101-aaaaaaaaaaaa.yaml")
+    hdr = dict(_PR_HEADER)
+    hdr["head"] = {"ref": "feature/cache", "sha": "b" * 40}   # live head now advanced (valid 40-hex)
+    _seed_preflight(ws, fake_gh, pull_header=hdr)
+    assert gi.run_import_prs(ws, pr_numbers=[101], heads=["final"], refresh=True, origin_url=None) == 0
+    raw = load_yaml_strict(ws / "benchmark.yaml")
+    ids = [c["case_id"] for c in raw["cases"]]
+    assert ids == ["pr-000101-aaaaaaaaaaaa"]          # pinned, not advanced to b*40
+    assert (ws / "cases" / "pr-000101-aaaaaaaaaaaa.yaml").exists()
+    case = load_yaml_strict(ws / "cases" / "pr-000101-aaaaaaaaaaaa.yaml")
+    assert case["curation"]["state"] == "ready"       # unchanged evidence -> stays ready

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -1508,3 +1508,58 @@ def test_signature_ignores_format_drift_duplicate_and_kind():
     canon = [base]
     assert gi._evidence_signature_from_raw({"evidence": dup}) \
         == gi._evidence_signature_from_raw({"evidence": canon})
+
+
+# ---------------------------------------------------------------------------
+# per-case staleness via reference intersection (issue #813): a case stales
+# only when its own referenced evidence changed (or the PR-wide task input)
+# ---------------------------------------------------------------------------
+
+
+def _seed_discussion(db_id: int, body: str = "please fix", line: int = 4) -> dict:
+    """One canonical REST inline-comment dict for the fake router."""
+    return {"id": db_id, "node_id": f"DIFF_{db_id}", "user": {"login": "bot[bot]", "type": "Bot"},
+            "body": body, "commit_id": "a" * 40, "original_commit_id": "a" * 40,
+            "path": "a.py", "line": line, "subject_type": "line", "side": "RIGHT",
+            "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",
+            "html_url": f"https://github.com/o/r/pull/101#discussion_r{db_id}"}
+
+
+def test_refresh_unrelated_new_comment_does_not_stale(tmp_path, fake_gh):
+    # PR 101 imported with one referenced comment (db 1) and curated ready; a NEW
+    # unrelated comment (db 99) must not stale the referenced case on refresh.
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.storage import load_yaml_strict
+
+    ws = tmp_path / "ws"
+    _seed_preflight(ws, fake_gh)
+    fake_gh.set_response("GET", "repos/o/r/pulls/101/comments", [_seed_discussion(1)])
+    assert gi.run_import_prs(ws, pr_numbers=[101], heads=["final"], origin_url=None) == 0
+    _curate_case(ws, "pr-000101-aaaaaaaaaaaa.yaml")    # references github:inline_comment:1
+    fake_gh.set_response(
+        "GET", "repos/o/r/pulls/101/comments",
+        [_seed_discussion(1), {**_seed_discussion(99), "path": "b.py", "body": "unrelated nit"}],
+    )
+    assert gi.run_import_prs(ws, pr_numbers=[101], heads=["final"], refresh=True, origin_url=None) == 0
+    case = load_yaml_strict(ws / "cases" / "pr-000101-aaaaaaaaaaaa.yaml")
+    assert case["curation"]["state"] == "ready"       # NOT staled by an unrelated new comment
+    assert case["curation"]["findings"]
+
+
+def test_refresh_changed_anchor_on_referenced_evidence_stales(tmp_path, fake_gh):
+    # Same body, moved anchor on the REFERENCED comment (db 1) -> the case stales
+    # while its curated findings stay preserved.
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.storage import load_yaml_strict
+
+    ws = tmp_path / "ws"
+    _seed_preflight(ws, fake_gh)
+    fake_gh.set_response("GET", "repos/o/r/pulls/101/comments", [_seed_discussion(1)])
+    assert gi.run_import_prs(ws, pr_numbers=[101], heads=["final"], origin_url=None) == 0
+    _curate_case(ws, "pr-000101-aaaaaaaaaaaa.yaml")    # references github:inline_comment:1
+    fake_gh.set_response("GET", "repos/o/r/pulls/101/comments", [_seed_discussion(1, line=7)])
+    assert gi.run_import_prs(ws, pr_numbers=[101], heads=["final"], refresh=True, origin_url=None) == 0
+    case = load_yaml_strict(ws / "cases" / "pr-000101-aaaaaaaaaaaa.yaml")
+    assert case["curation"]["state"] == "stale"
+    assert case["curation"]["findings"]               # curated findings preserved
+    assert case["curation"]["snapshot_attested"] is False

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -1633,3 +1633,45 @@ def test_refresh_failure_preserves_linkage_and_records_attempt(tmp_path, fake_gh
     assert after["case_ids"] == before["case_ids"]
     assert after["latest_error"]["code"] == "rate_limit"  # attempt recorded separately
     assert (ws / "cases" / "pr-000101-aaaaaaaaaaaa.yaml").exists()  # case still indexed
+
+
+def test_reimport_changed_referenced_evidence_stales(tmp_path, fake_gh):
+    """A plain re-import (refresh=False) with changed referenced evidence must not
+    silently keep the curated case ready — it routes through the same per-case
+    stale decision as refresh (issue #813)."""
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.storage import load_yaml_strict
+
+    ws = tmp_path / "ws"
+    _seed_preflight(ws, fake_gh)
+    # Seed the referenced comment (db 1) at line 4 for the first import.
+    fake_gh.set_response(
+        "GET",
+        "repos/o/r/pulls/101/comments",
+        [
+            {"id": 1, "node_id": "DIFF_1", "user": {"login": "bot[bot]", "type": "Bot"},
+             "body": "please fix", "commit_id": "a" * 40, "original_commit_id": "a" * 40,
+             "path": "a.py", "line": 4, "subject_type": "line", "side": "RIGHT",
+             "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",
+             "html_url": "https://github.com/o/r/pull/101#discussion_r1"},
+        ],
+    )
+    assert gi.run_import_prs(ws, pr_numbers=[101], heads=["final"], origin_url=None) == 0
+    _curate_case(ws, "pr-000101-aaaaaaaaaaaa.yaml")    # references github:inline_comment:1
+    # Re-seed the REFERENCED comment (db 1) with a moved anchor, same body.
+    fake_gh.set_response(
+        "GET",
+        "repos/o/r/pulls/101/comments",
+        [
+            {"id": 1, "node_id": "DIFF_1", "user": {"login": "bot[bot]", "type": "Bot"},
+             "body": "please fix", "commit_id": "a" * 40, "original_commit_id": "a" * 40,
+             "path": "a.py", "line": 7, "subject_type": "line", "side": "RIGHT",
+             "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",
+             "html_url": "https://github.com/o/r/pull/101#discussion_r1"},
+        ],
+    )
+    rc = gi.run_import_prs(ws, pr_numbers=[101], heads=["final"], refresh=False, origin_url=None)
+    assert rc == 0
+    case = load_yaml_strict(ws / "cases" / "pr-000101-aaaaaaaaaaaa.yaml")
+    assert case["curation"]["state"] == "stale"        # cannot bypass refresh semantics
+    assert case["curation"]["findings"]                # curated findings preserved

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -941,9 +941,16 @@ def test_refresh_predate_canonical_format_drift_does_not_stale(tmp_path, fake_gh
                 old_evidence.append({**e,
                                      "source_id": f"github:inline_comment:{e['database_id']}",
                                      "kind": "inline_comment"})
-            old_evidence.append({**e,
-                                 "source_id": f"github:thread_comment:{e['database_id']}",
-                                 "kind": "thread_comment"})
+            # The thread feed never carried commit anchors, so the pre-canonical
+            # thread_comment copy has no commit_id/original_commit_id: the two
+            # copies of db 1 must project DIFFERENTLY.  Spreading e verbatim
+            # would make them hash identically and collapse onto one element,
+            # under-modeling the drift (and hiding the spurious stale it used to
+            # trigger on the first post-format refresh).
+            old_evidence.append({
+                **{k: v for k, v in e.items() if k not in ("commit_id", "original_commit_id")},
+                "source_id": f"github:thread_comment:{e['database_id']}",
+                "kind": "thread_comment"})
         else:
             old_evidence.append(e)
     assert len(old_evidence) == 3      # db 1 twice, db 2 once as thread_comment
@@ -1675,3 +1682,58 @@ def test_reimport_changed_referenced_evidence_stales(tmp_path, fake_gh):
     case = load_yaml_strict(ws / "cases" / "pr-000101-aaaaaaaaaaaa.yaml")
     assert case["curation"]["state"] == "stale"        # cannot bypass refresh semantics
     assert case["curation"]["findings"]                # curated findings preserved
+
+
+def test_refresh_precanon_duplicate_db_id_verdict_is_deterministic(tmp_path, fake_gh):
+    """A legacy raw import file storing the same database_id twice - a REST
+    inline copy WITH ``commit_id`` and a GraphQL thread copy WITHOUT it (the
+    pre-canonicalization duplicate) - must yield ONE deterministic changed
+    verdict per id. The two copies' projection hashes differ (``commit_id`` is
+    projected), and the thread copy's missing commit anchors are a pure format
+    artifact: the fresh REST-derived canonical projection is still covered by a
+    prior projection, so the first post-format refresh must NOT stale the
+    curated case. The old ``dict(prior_sig)`` collapse left which tuple survives
+    to frozenset iteration order (nondeterministic across processes under hash
+    randomization), making the spurious stale a coin toss.
+    """
+    import json
+
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.storage import load_json_strict, load_yaml_strict
+
+    ws = tmp_path / "ws"
+    _seed_preflight(ws, fake_gh)
+    fake_gh.set_response("GET", "repos/o/r/pulls/101/comments", [_seed_discussion(1)])
+    assert gi.run_import_prs(ws, pr_numbers=[101], heads=["final"], origin_url=None) == 0
+    _curate_case(ws, "pr-000101-aaaaaaaaaaaa.yaml")    # references github:inline_comment:1
+
+    # Rewrite the prior import file to the REAL historical shape: the same
+    # database_id persisted twice — the REST inline copy (commit_id present) and
+    # a GraphQL thread copy (commit_id absent) — whose projection hashes differ.
+    import_path = ws / "imports/pr-000101.json"
+    prior = load_json_strict(import_path)
+    rest = next(e for e in prior["evidence"] if e["database_id"] == 1)
+    thread = {k: v for k, v in rest.items() if k not in ("commit_id", "original_commit_id")}
+    thread.update(kind="thread_comment", source_id="github:thread_comment:1")
+    prior["evidence"] = [thread, rest]
+    import_path.write_text(json.dumps(prior, indent=2))
+
+    # Premise check: the duplicate's two tuples are genuinely distinct (the
+    # thread copy lacks the projected commit_id), so a dict() collapse would
+    # hand the survivor to frozenset iteration order instead of comparing sets.
+    sig = gi._evidence_signature_from_raw(prior)
+    assert len(sig) == 2 and len({h for _, h in sig}) == 2
+
+    # Refresh against the canonical feed (one record per id, unchanged body):
+    # the fresh REST-derived projection matches a prior projection, so the
+    # per-id comparison (order-independent) leaves the curated case ready, and
+    # the refreshed file carries exactly one record per id.
+    fake_gh.set_response("GET", "repos/o/r/pulls/101/comments", [_seed_discussion(1)])
+    assert gi.run_import_prs(
+        ws, pr_numbers=[101], heads=["final"], refresh=True, origin_url=None
+    ) == 0
+    case = load_yaml_strict(ws / "cases" / "pr-000101-aaaaaaaaaaaa.yaml")
+    assert case["curation"]["state"] == "ready"      # format drift must NOT stale gold
+    assert case["curation"]["findings"]              # curated findings preserved
+    refreshed = load_json_strict(import_path)
+    assert len([e for e in refreshed["evidence"] if e["database_id"] == 1]) == 1

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -1642,6 +1642,111 @@ def test_refresh_failure_preserves_linkage_and_records_attempt(tmp_path, fake_gh
     assert (ws / "cases" / "pr-000101-aaaaaaaaaaaa.yaml").exists()  # case still indexed
 
 
+def test_refresh_unreachable_pinned_head_freezes_fails_without_clobber(tmp_path, fake_gh):
+    """A refresh whose re-freeze of a curated pinned head goes unreplayable
+    (force-push/rebased branch made the head unreachable) must fail the refresh
+    (rc != 0) and keep the curated ready case + its bundle intact and indexed —
+    never write the unreplayable snapshot over the curated case (issue #813)."""
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.storage import load_yaml_strict
+    from daydream.benchmark.workspace import init_workspace, validate_workspace
+
+    ws = tmp_path / "ws"
+    init_workspace(ws, "o/r", ["api.anthropic.com"], ["api.anthropic.com"])
+    _seed_preflight(ws, fake_gh)
+    origin_url, _base_sha, head_sha = _seed_local_origin(tmp_path, fake_gh)
+    assert gi.run_import_prs(ws, pr_numbers=[101], heads=[], origin_url=origin_url) == 0
+    case_id = f"pr-000101-{head_sha[:12]}"
+    _curate_case(ws, f"{case_id}.yaml")
+    case_path = ws / "cases" / f"{case_id}.yaml"
+    before = load_yaml_strict(case_path)
+    assert before["snapshot"]["status"] == "ready"
+    bundle_rel = before["snapshot"]["bundle_file"]
+
+    # force-push: repoint refs/pull/101/head to a commit that does NOT contain
+    # the pinned head (a rebased branch), so the pinned head is unreachable.
+    repo = tmp_path / "local_wt"
+    _seed_git(repo, "checkout", "main")
+    _seed_write(repo, "rebased.py", "REBASED = 1\n")
+    _seed_git(repo, "add", "rebased.py")
+    new_head = _seed_commit(repo, "force-pushed rebased head")
+    _seed_git(repo, "push", "-f", "origin", f"{new_head}:refs/pull/101/head", check=False)
+    hdr = dict(_PR_HEADER)
+    hdr["head"] = {"ref": "feature/cache", "sha": new_head}
+    _seed_preflight(ws, fake_gh, pull_header=hdr)
+
+    rc = gi.run_import_prs(ws, pr_numbers=[101], heads=[], refresh=True, origin_url=origin_url)
+    assert rc != 0
+    after = load_yaml_strict(case_path)
+    assert after["snapshot"]["status"] == "ready"   # NOT replaced with unreplayable
+    assert after["curation"]["state"] == "ready"     # curated gold preserved
+    assert (ws / bundle_rel).exists()                  # bundle still on disk and referenced
+    raw = load_yaml_strict(ws / "benchmark.yaml")
+    pr = raw["pull_requests"][0]
+    assert pr["import_state"] == "fetched"            # last-good linkage preserved
+    assert pr["latest_error"] is not None              # attempt recorded, not silent
+    code, _label = validate_workspace(ws)
+    assert code == 0                                    # no orphan bundle corruption
+
+
+def test_refresh_noncanonical_referenced_source_id_fails_closed(tmp_path, fake_gh):
+    """A hand-edited/externally-mutated curation whose referenced source_id is
+    non-canonical must fail the re-import (rc != 0) instead of being silently
+    dropped from the per-case stale gate — never fail open (issue #813)."""
+    import yaml
+
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.storage import load_yaml_strict
+
+    ws = tmp_path / "ws"
+    _seed_preflight(ws, fake_gh)
+    fake_gh.set_response("GET", "repos/o/r/pulls/101/comments", [_seed_discussion(1)])
+    assert gi.run_import_prs(ws, pr_numbers=[101], heads=["final"], origin_url=None) == 0
+    case_path = ws / "cases" / "pr-000101-aaaaaaaaaaaa.yaml"
+    _curate_case(ws, "pr-000101-aaaaaaaaaaaa.yaml")    # references github:inline_comment:1
+
+    # hand-edit: a non-canonical referenced source_id (malformed reference).
+    raw = load_yaml_strict(case_path)
+    raw["curation"]["findings"][0]["provenance"]["source_ids"] = [
+        "https://github.com/o/r/pull/101#discussion_r1"
+    ]
+    case_path.write_text(yaml.safe_dump(raw, sort_keys=False))
+
+    rc = gi.run_import_prs(ws, pr_numbers=[101], heads=["final"], refresh=True, origin_url=None)
+    assert rc != 0                                      # fail closed, not silently skipped
+    after = load_yaml_strict(ws / "benchmark.yaml")
+    pr = after["pull_requests"][0]
+    assert pr["latest_error"] is not None
+    on_disk = load_yaml_strict(case_path)
+    assert on_disk["curation"]["findings"][0]["provenance"]["source_ids"] == [
+        "https://github.com/o/r/pull/101#discussion_r1"
+    ]   # curation was NOT rewritten by the failed refresh
+
+
+def test_refresh_gained_reply_status_flips_signature_and_stales(tmp_path, fake_gh):
+    """reply_to_id gates candidacy (replies are evidence, never candidates), so it
+    must sit in the projection hash: a comment gaining reply status shifts the
+    candidate set and must flip the signature, staling a referencing case."""
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.storage import load_yaml_strict
+
+    ws = tmp_path / "ws"
+    _seed_preflight(ws, fake_gh)
+    fake_gh.set_response("GET", "repos/o/r/pulls/101/comments", [_seed_discussion(1)])
+    assert gi.run_import_prs(ws, pr_numbers=[101], heads=["final"], origin_url=None) == 0
+    _curate_case(ws, "pr-000101-aaaaaaaaaaaa.yaml")    # references github:inline_comment:1
+
+    # the same comment now carries a reply parent (gains reply status): its
+    # projection hash must flip even though body/anchor fields are unchanged.
+    reply = dict(_seed_discussion(1))
+    reply["in_reply_to_id"] = 10
+    fake_gh.set_response("GET", "repos/o/r/pulls/101/comments", [reply])
+    assert gi.run_import_prs(ws, pr_numbers=[101], heads=["final"], refresh=True, origin_url=None) == 0
+    case = load_yaml_strict(ws / "cases" / "pr-000101-aaaaaaaaaaaa.yaml")
+    assert case["curation"]["state"] == "stale"       # referenced id's projection changed
+    assert case["curation"]["findings"]               # curated gold preserved
+
+
 def test_reimport_changed_referenced_evidence_stales(tmp_path, fake_gh):
     """A plain re-import (refresh=False) with changed referenced evidence must not
     silently keep the curated case ready — it routes through the same per-case

--- a/tests/test_benchmark_workspace.py
+++ b/tests/test_benchmark_workspace.py
@@ -586,3 +586,28 @@ def test_duplicate_inode_indexed_files_is_corruption(tmp_path):
     next((root / "cases").glob("*.yaml")).write_text(yaml.safe_dump(case_raw, sort_keys=False))
     code, label = validate_workspace(root)
     assert code == 1 and "corrupt" in label.lower()   # gated on Task 0 spike 4 verdict
+
+
+def test_status_surfaces_failed_refresh_with_good_linkage(tmp_path, fake_gh):
+    """A PR whose latest refresh failed but whose last import is intact: the
+    status surface reports the attempt failure distinctly and does NOT classify
+    the workspace as collecting.  Task 6 (issue #813)."""
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.workspace import workspace_status
+    from tests.test_benchmark_import_prs import _curate_case, _seed_preflight
+
+    ws = tmp_path / "ws"
+    _seed_preflight(ws, fake_gh)
+    assert gi.run_import_prs(ws, pr_numbers=[101], heads=["final"], origin_url=None) == 0
+    _curate_case(ws, "pr-000101-aaaaaaaaaaaa.yaml")
+    # now make the REFRESH fetch fail (PR already fetched: last import is intact)
+    fake_gh.set_response(
+        "GET", "repos/o/r/pulls/101", {"__error__": "API rate limit exceeded Retry-After: 1"}
+    )
+    rc = gi.run_import_prs(ws, pr_numbers=[101], heads=["final"], refresh=True, origin_url=None)
+    assert rc != 0
+    st = workspace_status(ws)
+    pr = st.ledger.pull_requests[0]
+    assert pr.latest_error is not None and pr.latest_error["code"] == "rate_limit"
+    assert pr.import_state == "fetched"                # intact linkage, not collecting
+    assert st.workspace_state != "collecting"          # evidence is not missing

--- a/tests/test_benchmark_workspace_schema.py
+++ b/tests/test_benchmark_workspace_schema.py
@@ -650,14 +650,20 @@ def test_gold_mode_truth_table(kinds, expected):
         ("fetch_failed", "fetched"),
         ("fetch_failed", "fetch_failed"),
         ("fetched", "fetched"),
-        ("fetched", "fetch_failed"),
     ],
 )
 def test_valid_pr_transitions(frm, to):
     validate_pr_transition(frm, to)  # must not raise
 
 
-@pytest.mark.parametrize("frm,to", [("fetched", "pending"), ("pending", "draft")])
+@pytest.mark.parametrize(
+    "frm,to",
+    [
+        ("fetched", "pending"),
+        ("fetched", "fetch_failed"),  # a fetched PR preserves linkage via latest_error
+        ("pending", "draft"),
+    ],
+)
 def test_invalid_pr_transition_rejected(frm, to):
     with pytest.raises(TransitionError):
         validate_pr_transition(frm, to)
@@ -714,3 +720,25 @@ def test_classify_validation_codes():
     assert classify_validation(ready=True, incomplete=False, corrupt=False) == 0
     assert classify_validation(ready=False, incomplete=True, corrupt=False) == 2
     assert classify_validation(ready=False, incomplete=False, corrupt=True) == 1
+
+
+def test_pull_request_entry_fetched_allows_latest_error_only():
+    # A fetched entry may carry latest_error (a failed refresh attempt on an
+    # otherwise-intact import) but never `error` itself.
+    base_entry = {
+        "number": 101,
+        "import_state": "pending",
+        "requested_heads": ["final"],
+        "case_ids": [],
+    }
+    valid = dict(
+        base_entry,
+        import_state="fetched",
+        import_file="imports/pr-000101.json",
+        import_sha256="a" * 64,
+        latest_error={"code": "fetch", "message": "x"},
+    )
+    PullRequestEntry.model_validate(valid)                       # OK
+    bad = dict(valid, error={"code": "fetch", "message": "x"})   # error still forbidden on fetched
+    with pytest.raises(ValidationError):
+        PullRequestEntry.model_validate(bad)


### PR DESCRIPTION
## Summary
Implements issue #813: make evidence refresh **snapshot-pinned and provenance-aware** so re-imports never change case identity/snapshot or silently corrupt curated state.

- Refresh evidence for each existing case against its pinned commits; never change case ID, bundle, selected head/base, or snapshot.
- Compute change from the full projection-relevant evidence provenance (body, anchor, commit, outdated/resolved, dismissal, deletion, author/review-state).
- Stale only cases whose accepted/edited provenance or explicit exclusions changed materially; unrelated new evidence does not stale a case.
- Preserve last complete fetched ledger/import/case artifacts on failure; record latest attempt status/error separately.
- Require explicit new-case creation to select a newer head.
- Fail closed (WorkspaceCorrupt/GitError) rather than silently skipping non-canonical source ids or unreplayable curated freezes.
- Add reply_to_id to the projection hash so reply status now flips the signature.

## Test Plan
- Full `make check` green: ruff pass, mypy pass (378 files), 4373 passed / 7 skipped / 0 failures.
- Two sequential daydream deep-precision reviews (rounds 1 & 2) completed clean; 3 findings merged and fixed in e31cb8f (+3 tests).

Closes #813
