### PR TITLE
test(benchmark): calibrate configured semantic-match judges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **benchmark:** add `daydream benchmark calibrate-judge <workspace>` command (drives the exact packaged judge path, 24-pair fixture, three-part pass gate, private `runtime/calibration-receipt.json`)
+
 ### Changed
 
 - **benchmark:** require `requested_base_sha` on ready/imported snapshot records; `migrate.migrate_workspace` backfills the field from `original_base_sha` on both v1 upgrade and v2 repair passes so pre-provenance-split workspaces stay loadable.

--- a/daydream/benchmark/cli.py
+++ b/daydream/benchmark/cli.py
@@ -16,6 +16,7 @@ checkout (``--benchmark-repo``) or a harvested dir (``--harvest-dir``).
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -453,11 +454,15 @@ def _handle_bench_command(argv: list[str]) -> int:
 def _build_benchmark_parser() -> argparse.ArgumentParser:
     """Build the ``daydream benchmark`` subcommand parser.
 
-    Sub-verbs: ``init``, ``status``, ``validate``, ``build-harbor``, ``upgrade``, ``import-prs``, ``curate``.
+    Sub-verbs: ``init``, ``status``, ``validate``, ``build-harbor``, ``upgrade``, ``import-prs``,
+    ``curate``, ``calibrate-judge``.
     """
     parser = argparse.ArgumentParser(
         prog="daydream benchmark",
-        description="Private PR benchmark workspace: init/status/validate/build-harbor/upgrade/import-prs/curate.",
+        description=(
+            "Private PR benchmark workspace: init/status/validate/build-harbor/upgrade/"
+            "import-prs/curate/calibrate-judge."
+        ),
     )
     sub = parser.add_subparsers(dest="subcommand")
 
@@ -526,6 +531,12 @@ def _build_benchmark_parser() -> argparse.ArgumentParser:
         default=None,
         metavar="FILE",
         help="apply a reviewed gold YAML draft (derive all forbidden fields, never ready)",
+    )
+
+    calibrate_p = sub.add_parser("calibrate-judge", help="calibrate the configured semantic-match judge")
+    calibrate_p.add_argument("dir", type=Path, help="workspace directory")
+    calibrate_p.add_argument(
+        "--yes", action="store_true", help="confirm the paid 72-call calibration run"
     )
 
     return parser
@@ -661,8 +672,47 @@ def _handle_benchmark_upgrade(args) -> int:
 
 
 def _is_interactive_tty() -> bool:
-    """True only when both stdin and stdout are real interactive terminals."""
+    """True only when both sys.stdin and stdout are real interactive terminals."""
     return sys.stdin.isatty() and sys.stdout.isatty()
+
+
+def _handle_benchmark_calibrate(args) -> int:
+    """Calibrate the configured judge against the fixed 24-pair fixture.
+
+    Requires ``--yes`` or an interactive TTY before any paid judge call. Lazy
+    imports the calibrate module (mirroring the other handlers); build failures
+    and refusals print to stderr and return exit ``1`` — never a bare traceback.
+    """
+    if not args.yes and not _is_interactive_tty():
+        print(
+            "calibrate-judge: requires TTY confirmation or --yes before any paid judge call",
+            file=sys.stderr,
+        )
+        return 1
+    from daydream.benchmark.harbor import calibrate
+
+    env = {
+        name: os.environ.get(name)
+        for name in (
+            "DAYDREAM_JUDGE_PROVIDER",
+            "DAYDREAM_JUDGE_MODEL",
+            "DAYDREAM_JUDGE_API_KEY",
+            "DAYDREAM_JUDGE_BASE_URL",
+            "DAYDREAM_JUDGE_ALLOWED_HOSTS",
+        )
+    }
+
+    def _tty_confirm(prompt: str) -> bool:
+        reply = input(prompt)
+        return reply.strip().lower() in ("y", "yes", "")
+
+    return calibrate.run_calibration(
+        args.dir,
+        yes=args.yes,
+        env=env,
+        http=None,
+        confirm=_tty_confirm if not args.yes else None,
+    )
 
 
 def _handle_benchmark_curate(args) -> int:
@@ -728,5 +778,7 @@ def _handle_benchmark_command(argv: list[str]) -> int:
         return _handle_benchmark_import_prs(args)
     if sub == "curate":
         return _handle_benchmark_curate(args)
+    if sub == "calibrate-judge":
+        return _handle_benchmark_calibrate(args)
     parser.print_help(file=sys.stderr)
     return 2

--- a/daydream/benchmark/cli.py
+++ b/daydream/benchmark/cli.py
@@ -702,16 +702,11 @@ def _handle_benchmark_calibrate(args) -> int:
         )
     }
 
-    def _tty_confirm(prompt: str) -> bool:
-        reply = input(prompt)
-        return reply.strip().lower() in ("y", "yes", "")
-
     return calibrate.run_calibration(
         args.dir,
         yes=args.yes,
         env=env,
         http=None,
-        confirm=_tty_confirm if not args.yes else None,
     )
 
 

--- a/daydream/benchmark/harbor/calibrate.py
+++ b/daydream/benchmark/harbor/calibrate.py
@@ -16,11 +16,12 @@ import asyncio
 import hashlib
 import importlib.util
 import json
+import os
 import sys
 import urllib.parse
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from daydream.benchmark import storage
 from daydream.benchmark.schema import BenchmarkManifest
@@ -358,3 +359,103 @@ def is_receipt_current(receipt_path: Path, current_inputs: dict[str, Any]) -> bo
     if not isinstance(raw, dict) or not isinstance(raw.get("inputs"), dict):
         return False
     return _serialize_inputs(raw["inputs"]) == _serialize_inputs(current_inputs)
+
+
+def _default_confirm(prompt: str) -> bool:
+    """Read a confirmation reply from stdin; non-interactive stdin is refused."""
+    reply = input(prompt)
+    return reply.strip().lower() in ("y", "yes", "")
+
+
+def run_calibration(
+    workspace: Path,
+    *,
+    yes: bool = False,
+    env: dict[str, Any] | None = None,
+    http: Any = None,
+    confirm: Callable[[str], bool] | None = None,
+) -> int:
+    """Drive the calibration gate end-to-end and return an exit code.
+
+    Order: manifest/host validation -> fixture + template load -> confirmation
+    gate -> client build -> 72-call judge driver -> three-part pass gate.
+    On pass a private receipt is written; on failure (or refusal) no receipt is
+    written and the exit code is nonzero (fail-closed). Never measures by
+    tuning anything.
+    """
+    import sys as _sys
+
+    from daydream.benchmark.storage import WorkspaceCorrupt as _WorkspaceCorrupt
+
+    env = dict(env) if env is not None else dict(os.environ)
+    sr = _load_judge_template()
+    try:
+        allowlist = _load_workspace_allowlist(workspace)
+    except _WorkspaceCorrupt as exc:
+        print(str(exc), file=_sys.stderr)
+        return 1
+    host = _judge_host_from_env(env)
+    try:
+        _validate_workspace_host(allowlist, host)
+    except ValueError as exc:
+        print(str(exc), file=_sys.stderr)
+        return 1
+
+    pairs = _load_fixture()
+    inputs = _invalidation_inputs(env, pairs, sr)
+
+    if not yes:
+        if confirm is None:
+            confirm = _default_confirm
+        prompt = (
+            f"Run calibration against {inputs['provider']} model "
+            f"{inputs['model']!r} on host {inputs['host']}? "
+            f"judge prompt digest {inputs['judge_prompt_sha256'][:12]}, "
+            f"threshold {inputs['threshold']}, 72 judged calls, "
+            f"request timeout {inputs['request_timeout']}s; this incurs paid "
+            f"API costs. Proceed? [y/N] "
+        )
+        if not confirm(prompt):
+            print("calibrate-judge: aborted before any paid call", file=_sys.stderr)
+            return 1
+
+    try:
+        client = _build_calibration_client(env, http=http)
+        runs = _judge_pairs(sr, client, pairs, attempts=3)
+        passed, failures = _pass_gate(
+            pairs, runs, sr.verifier_core.CONFIDENCE_THRESHOLD
+        )
+    except sr.VerifierError as exc:
+        print(f"calibrate-judge: judge failure: {sr._bounded_error(str(exc))}", file=_sys.stderr)
+        return 1
+
+    if passed:
+        matrix = _confusion_matrix(
+            [p["label"] for p in pairs], [_majority_label(runs) for runs in runs]
+        )
+        bacc = _class_balanced_accuracy(matrix)
+        disagreements = [
+            {
+                "pair_index": i,
+                "gold_id": p["gold"]["finding_id"],
+                "candidate_id": p["candidate"]["candidate_id"],
+                "per_run_retained": [
+                    _retained_edge(v, sr.verifier_core.CONFIDENCE_THRESHOLD) for v in r
+                ],
+            }
+            for i, (p, r) in enumerate(zip(pairs, runs))
+        ]
+        receipt = _build_receipt(
+            sr, pairs, env, attempts=3, passed=True,
+            balanced_accuracy=bacc, confusion=matrix, disagreements=disagreements,
+        )
+        _write_receipt(workspace, receipt)
+        print(
+            f"calibrate-judge: PASS (balanced accuracy {bacc:.4f}); "
+            f"receipt written to {workspace / 'runtime' / 'calibration-receipt.json'}"
+        )
+        return 0
+
+    for condition, detail in failures.items():
+        print(f"calibrate-judge: FAIL ({condition}): {detail}", file=_sys.stderr)
+    return 1

--- a/daydream/benchmark/harbor/calibrate.py
+++ b/daydream/benchmark/harbor/calibrate.py
@@ -165,3 +165,104 @@ def _judge_pairs(
             runs.append(verdicts[0])
         per_pair.append(runs)
     return per_pair
+
+
+def _majority_label(verdicts: list[Any]) -> bool:
+    """Return the majority ``match`` over a pair's runs; ties resolve to False."""
+    matches = sum(1 for v in verdicts if v.match)
+    return matches * 2 > len(verdicts)
+
+
+def _retained_edge(v: Any, threshold: float) -> bool:
+    """Return True when a verdict is a retained edge: match and confident."""
+    return bool(v.match and v.confidence >= threshold)
+
+
+def _per_pair_stable(verdicts: list[Any], threshold: float) -> bool:
+    """True when the retained-edge boolean sequence flips at most once."""
+    retained = [_retained_edge(v, threshold) for v in verdicts]
+    flips = sum(1 for a, b in zip(retained, retained[1:]) if a != b)
+    return flips <= 1
+
+
+def _confusion_matrix(
+    gold_labels: list[Any], majority_labels: list[bool]
+) -> dict[str, int]:
+    """Standard 2x2 confusion counts for a match/nonmatch label set.
+
+    Gold labels may be booleans (``True`` = match) or the strings
+    ``"match"`` / ``"nonmatch"``.
+    """
+    counts = {"tp": 0, "fp": 0, "tn": 0, "fn": 0}
+    for truth, pred in zip(gold_labels, majority_labels):
+        actual = truth is True or truth == "match"
+        if actual and pred:
+            counts["tp"] += 1
+        elif not actual and pred:
+            counts["fp"] += 1
+        elif not actual and not pred:
+            counts["tn"] += 1
+        else:
+            counts["fn"] += 1
+    return counts
+
+
+def _balanced_accuracy(
+    matches_correct: int,
+    matches_wrong: int,
+    nonmatches_correct: int,
+    nonmatches_wrong: int,
+) -> float:
+    """Balanced accuracy over the periodic 12-match / 12-nonmatch split."""
+    return 0.5 * (matches_correct / 12 + nonmatches_correct / 12)
+
+
+def _class_balanced_accuracy(matrix: dict[str, int]) -> float:
+    """Recognition average over the two classes actually present.
+
+    For the full 24-pair fixture (12 match / 12 nonmatch) this equals
+    ``0.5 * (tp/12 + tn/12)``; per-class denominators keep small partial
+    gates (e.g. a 3-pair unit test) from spuriously failing the fixture's
+    hard-coded 12-per-class denominator.
+    """
+    match_total = matrix["tp"] + matrix["fn"]
+    nonmatch_total = matrix["tn"] + matrix["fp"]
+    match_recall = matrix["tp"] / match_total if match_total else 1.0
+    nonmatch_recall = matrix["tn"] / nonmatch_total if nonmatch_total else 1.0
+    return 0.5 * (match_recall + nonmatch_recall)
+
+
+def _pass_gate(
+    pairs: list[dict[str, Any]],
+    runs_per_pair: list[list[Any]],
+    threshold: float,
+) -> tuple[bool, dict[str, Any]]:
+    """Evaluate the three-part pass gate, returning (passed, failures).
+
+    ``failures`` is keyed by condition name and empty on pass; never writes
+    anything — a pure computation over the already-validated verdicts.
+    """
+    failures: dict[str, Any] = {}
+    gold_labels = [p["label"] for p in pairs]
+    majority_labels = [_majority_label(runs) for runs in runs_per_pair]
+
+    wrong_pairs = [
+        i
+        for i, (truth, pred) in enumerate(zip(gold_labels, majority_labels))
+        if (truth == "match") != bool(pred)
+    ]
+    if wrong_pairs:
+        failures["majority"] = wrong_pairs
+
+    matrix = _confusion_matrix(gold_labels, majority_labels)
+    bacc = _class_balanced_accuracy(matrix)
+    if bacc < 0.9:
+        failures["balanced_accuracy"] = bacc
+
+    unstable = [
+        i for i, runs in enumerate(runs_per_pair) if not _per_pair_stable(runs, threshold)
+    ]
+    if unstable:
+        failures["instability"] = unstable
+
+    return (len(failures) == 0, failures)

--- a/daydream/benchmark/harbor/calibrate.py
+++ b/daydream/benchmark/harbor/calibrate.py
@@ -90,10 +90,6 @@ def _build_calibration_client(env: dict[str, Any], *, http: Any = None) -> Any:
     allowlist = sr._effective_allowlist(base_url, env)
     initial_url = base_url.rstrip("/") + "/chat/completions"
     sr._validate_base_url(initial_url, allowlist)
-    base_url = sr.resolve_base_url(api_key, env.get("DAYDREAM_JUDGE_BASE_URL"))
-    allowlist = sr._effective_allowlist(base_url, env)
-    initial_url = base_url.rstrip("/") + "/chat/completions"
-    sr._validate_base_url(initial_url, allowlist)
     return sr.OpenAIJudgeClient(
         api_key, model, base_url=base_url, http=http, allowlist=allowlist
     )
@@ -208,16 +204,6 @@ def _confusion_matrix(
         else:
             counts["fn"] += 1
     return counts
-
-
-def _balanced_accuracy(
-    matches_correct: int,
-    matches_wrong: int,
-    nonmatches_correct: int,
-    nonmatches_wrong: int,
-) -> float:
-    """Balanced accuracy over the periodic 12-match / 12-nonmatch split."""
-    return 0.5 * (matches_correct / 12 + nonmatches_correct / 12)
 
 
 def _class_balanced_accuracy(matrix: dict[str, int]) -> float:
@@ -364,7 +350,7 @@ def is_receipt_current(receipt_path: Path, current_inputs: dict[str, Any]) -> bo
 def _default_confirm(prompt: str) -> bool:
     """Read a confirmation reply from stdin; non-interactive stdin is refused."""
     reply = input(prompt)
-    return reply.strip().lower() in ("y", "yes", "")
+    return reply.strip().lower() in ("y", "yes")
 
 
 def run_calibration(
@@ -383,22 +369,19 @@ def run_calibration(
     written and the exit code is nonzero (fail-closed). Never measures by
     tuning anything.
     """
-    import sys as _sys
-
-    from daydream.benchmark.storage import WorkspaceCorrupt as _WorkspaceCorrupt
 
     env = dict(env) if env is not None else dict(os.environ)
     sr = _load_judge_template()
     try:
         allowlist = _load_workspace_allowlist(workspace)
-    except _WorkspaceCorrupt as exc:
-        print(str(exc), file=_sys.stderr)
+    except storage.WorkspaceCorrupt as exc:
+        print(str(exc), file=sys.stderr)
         return 1
     host = _judge_host_from_env(env)
     try:
         _validate_workspace_host(allowlist, host)
     except ValueError as exc:
-        print(str(exc), file=_sys.stderr)
+        print(str(exc), file=sys.stderr)
         return 1
 
     pairs = _load_fixture()
@@ -416,7 +399,7 @@ def run_calibration(
             f"API costs. Proceed? [y/N] "
         )
         if not confirm(prompt):
-            print("calibrate-judge: aborted before any paid call", file=_sys.stderr)
+            print("calibrate-judge: aborted before any paid call", file=sys.stderr)
             return 1
 
     try:
@@ -426,7 +409,7 @@ def run_calibration(
             pairs, runs, sr.verifier_core.CONFIDENCE_THRESHOLD
         )
     except sr.VerifierError as exc:
-        print(f"calibrate-judge: judge failure: {sr._bounded_error(str(exc))}", file=_sys.stderr)
+        print(f"calibrate-judge: judge failure: {sr._bounded_error(str(exc))}", file=sys.stderr)
         return 1
 
     if passed:
@@ -457,5 +440,5 @@ def run_calibration(
         return 0
 
     for condition, detail in failures.items():
-        print(f"calibrate-judge: FAIL ({condition}): {detail}", file=_sys.stderr)
+        print(f"calibrate-judge: FAIL ({condition}): {detail}", file=sys.stderr)
     return 1

--- a/daydream/benchmark/harbor/calibrate.py
+++ b/daydream/benchmark/harbor/calibrate.py
@@ -12,6 +12,7 @@ Measuring, never tuning: no weights or thresholds are derived here.
 
 from __future__ import annotations
 
+import asyncio
 import importlib.util
 import json
 import sys
@@ -138,3 +139,29 @@ def _validate_workspace_host(allowlist: list[str] | set[str], host: str) -> None
         raise ValueError(
             f"judge host {host!r} is not in the workspace judge_allowed_hosts allowlist"
         )
+
+
+def _judge_pairs(
+    template: Any, client: Any, pairs: list[dict[str, Any]], *, attempts: int = 3
+) -> list[list[Any]]:
+    """Drive the packaged ``judge_pairs`` three times per pair, in fixture order.
+
+    Each invocation is 1 gold x 1 candidate, so it makes exactly one judge call;
+    24 pairs x ``attempts`` calls for the exact 72-call budget. Judge-call
+    failures propagate via the packaged module's ``VerifierError`` — never a
+    silent fallback (a judge-call failure aborts the run, fail-closed).
+    """
+    per_pair: list[list[Any]] = []
+    for pair in pairs:
+        runs: list[Any] = []
+        for _ in range(attempts):
+            verdicts = asyncio.run(
+                template.judge_pairs(
+                    gold=[pair["gold"]],
+                    candidates=[pair["candidate"]],
+                    client=client,
+                )
+            )
+            runs.append(verdicts[0])
+        per_pair.append(runs)
+    return per_pair

--- a/daydream/benchmark/harbor/calibrate.py
+++ b/daydream/benchmark/harbor/calibrate.py
@@ -231,11 +231,14 @@ def _pass_gate(
     pairs: list[dict[str, Any]],
     runs_per_pair: list[list[Any]],
     threshold: float,
-) -> tuple[bool, dict[str, Any]]:
-    """Evaluate the three-part pass gate, returning (passed, failures).
+) -> tuple[bool, dict[str, Any], dict[str, int], float]:
+    """Evaluate the three-part pass gate.
 
-    ``failures`` is keyed by condition name and empty on pass; never writes
-    anything — a pure computation over the already-validated verdicts.
+    Returns ``(passed, failures, matrix, bacc)`` where ``failures`` is keyed by
+    condition name and empty on pass; ``matrix`` and ``bacc`` are the confusion
+    matrix and class-balanced accuracy computed for the gate, so callers that
+    need them for the receipt do not recompute them. Never writes anything — a
+    pure computation over the already-validated verdicts.
     """
     failures: dict[str, Any] = {}
     gold_labels = [p["label"] for p in pairs]
@@ -260,7 +263,7 @@ def _pass_gate(
     if unstable:
         failures["instability"] = unstable
 
-    return (len(failures) == 0, failures)
+    return (len(failures) == 0, failures, matrix, bacc)
 
 
 def _label_sha256(pairs: list[dict[str, Any]]) -> str:
@@ -417,7 +420,7 @@ def run_calibration(
     try:
         client = _build_calibration_client(env, http=http)
         runs = _judge_pairs(sr, client, pairs, attempts=3)
-        passed, failures = _pass_gate(
+        passed, failures, matrix, bacc = _pass_gate(
             pairs, runs, sr.verifier_core.CONFIDENCE_THRESHOLD
         )
     except sr.VerifierError as exc:
@@ -425,10 +428,6 @@ def run_calibration(
         return 1
 
     if passed:
-        matrix = _confusion_matrix(
-            [p["label"] for p in pairs], [_majority_label(runs) for runs in runs]
-        )
-        bacc = _class_balanced_accuracy(matrix)
         disagreements = [
             {
                 "pair_index": i,

--- a/daydream/benchmark/harbor/calibrate.py
+++ b/daydream/benchmark/harbor/calibrate.py
@@ -15,8 +15,12 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
+import urllib.parse
 from pathlib import Path
 from typing import Any
+
+from daydream.benchmark import storage
+from daydream.benchmark.schema import BenchmarkManifest
 
 _HARBOR = Path(__file__).parent
 _TEMPLATES = _HARBOR / "templates"
@@ -82,6 +86,55 @@ def _build_calibration_client(env: dict[str, Any], *, http: Any = None) -> Any:
     allowlist = sr._effective_allowlist(base_url, env)
     initial_url = base_url.rstrip("/") + "/chat/completions"
     sr._validate_base_url(initial_url, allowlist)
+    base_url = sr.resolve_base_url(api_key, env.get("DAYDREAM_JUDGE_BASE_URL"))
+    allowlist = sr._effective_allowlist(base_url, env)
+    initial_url = base_url.rstrip("/") + "/chat/completions"
+    sr._validate_base_url(initial_url, allowlist)
     return sr.OpenAIJudgeClient(
         api_key, model, base_url=base_url, http=http, allowlist=allowlist
     )
+
+
+def _judge_host_from_env(env: dict[str, Any]) -> str:
+    """Return the normalized-lowercase judge host for ``env``.
+
+    The anthropic provider (or absent -> anthropic default) always routes to
+    ``api.anthropic.com``; the openai-compatible provider resolves its base URL
+    via the packaged ``resolve_base_url`` and returns that URL's host.
+    """
+    sr = _load_judge_template()
+    provider = env.get("DAYDREAM_JUDGE_PROVIDER") or "anthropic"
+    if provider == "anthropic":
+        return "api.anthropic.com"
+    base_url = sr.resolve_base_url(
+        env.get("DAYDREAM_JUDGE_API_KEY") or "", env.get("DAYDREAM_JUDGE_BASE_URL")
+    )
+    return str(urllib.parse.urlsplit(base_url).hostname or "").lower()
+
+
+def _load_workspace_allowlist(workspace: Path) -> list[str]:
+    """Read ``<workspace>/benchmark.yaml`` and return its judge allowlist.
+
+    Validates the manifest strictly via ``BenchmarkManifest.model_validate``;
+    a malformed or missing manifest raises the project's existing workspace
+    error (``WorkspaceCorrupt``) — never a silent default.
+    """
+    try:
+        raw = storage.load_yaml_strict(workspace / "benchmark.yaml")
+    except storage.WorkspaceCorrupt:
+        raise
+    try:
+        manifest = BenchmarkManifest.model_validate(raw)
+    except Exception as exc:
+        raise storage.WorkspaceCorrupt(
+            f"{workspace}: invalid benchmark.yaml: {exc}"
+        ) from exc
+    return list(manifest.privacy.judge_allowed_hosts)
+
+
+def _validate_workspace_host(allowlist: list[str] | set[str], host: str) -> None:
+    """Fail closed when ``host`` is not in the workspace judge host allowlist."""
+    if host not in allowlist:
+        raise ValueError(
+            f"judge host {host!r} is not in the workspace judge_allowed_hosts allowlist"
+        )

--- a/daydream/benchmark/harbor/calibrate.py
+++ b/daydream/benchmark/harbor/calibrate.py
@@ -13,10 +13,12 @@ Measuring, never tuning: no weights or thresholds are derived here.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import importlib.util
 import json
 import sys
 import urllib.parse
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -266,3 +268,93 @@ def _pass_gate(
         failures["instability"] = unstable
 
     return (len(failures) == 0, failures)
+
+
+def _label_sha256(pairs: list[dict[str, Any]]) -> str:
+    """Canonical sha256 over the ordered gold/candidate/label triples."""
+    triples = [
+        {
+            "gold": p["gold"]["finding_id"],
+            "candidate": p["candidate"]["candidate_id"],
+            "label": p["label"],
+        }
+        for p in pairs
+    ]
+    canonical = json.dumps(
+        triples, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _render_judge_prompt_digest(sr: Any) -> str:
+    """sha256 of the packaged judge prompt template bytes."""
+    prompt_path = _TEMPLATES / "tests" / "judge_prompt.md"
+    return hashlib.sha256(prompt_path.read_bytes()).hexdigest()
+
+
+def _serialize_inputs(inputs: dict[str, Any]) -> bytes:
+    """Deterministic byte-stable serialization of the invalidation inputs."""
+    return json.dumps(
+        inputs, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+
+
+def _invalidation_inputs(
+    env: dict[str, Any], pairs: list[dict[str, Any]], sr: Any
+) -> dict[str, Any]:
+    """The receipt's invalidation contract: a deterministic byte-stable dict."""
+    return {
+        "provider": env.get("DAYDREAM_JUDGE_PROVIDER") or "anthropic",
+        "model": env.get("DAYDREAM_JUDGE_MODEL") or "",
+        "host": _judge_host_from_env(env),
+        "judge_prompt_sha256": _render_judge_prompt_digest(sr),
+        "threshold": sr.verifier_core.CONFIDENCE_THRESHOLD,
+        "label_sha256": _label_sha256(pairs),
+        "attempts": 3,
+        "request_timeout": sr._REQUEST_TIMEOUT,
+    }
+
+
+def _build_receipt(
+    sr: Any,
+    pairs: list[dict[str, Any]],
+    env: dict[str, Any],
+    *,
+    attempts: int,
+    passed: bool,
+    balanced_accuracy: float,
+    confusion: dict[str, int],
+    disagreements: list[Any],
+) -> dict[str, Any]:
+    """Build the private deterministic calibration receipt document."""
+    return {
+        "schema_version": 1,
+        "type": "judge-calibration",
+        "recorded_at": datetime.now(timezone.utc).isoformat(),
+        "inputs": _invalidation_inputs(env, pairs, sr),
+        "result": {
+            "passed": passed,
+            "balanced_accuracy": balanced_accuracy,
+            "confusion_matrix": confusion,
+            "disagreements": sorted(disagreements, key=lambda d: d["pair_index"]),
+        },
+    }
+
+
+def _write_receipt(workspace: Path, receipt: dict[str, Any]) -> Path:
+    """Atomically write the calibration receipt private (0o600) and return its path."""
+    runtime = Path(workspace) / "runtime"
+    path = runtime / "calibration-receipt.json"
+    storage.atomic_write_json(path, receipt, mode=0o600)
+    return path
+
+
+def is_receipt_current(receipt_path: Path, current_inputs: dict[str, Any]) -> bool:
+    """Fail-closed invalidation check: True only on a byte-exact inputs match."""
+    try:
+        raw = json.loads(Path(receipt_path).read_bytes())
+    except (ValueError, OSError):
+        return False
+    if not isinstance(raw, dict) or not isinstance(raw.get("inputs"), dict):
+        return False
+    return _serialize_inputs(raw["inputs"]) == _serialize_inputs(current_inputs)

--- a/daydream/benchmark/harbor/calibrate.py
+++ b/daydream/benchmark/harbor/calibrate.py
@@ -29,17 +29,43 @@ from daydream.benchmark.schema import BenchmarkManifest
 _HARBOR = Path(__file__).parent
 _TEMPLATES = _HARBOR / "templates"
 _CALIBRATION_DIR = _HARBOR / "calibration"
+_TEMPLATE_CACHE: dict[str, Any] = {}
 
 
 def _load_template_asset(path: Path, name: str) -> Any:
-    """Load a non-package template asset so a bare sibling import resolves to it."""
+    """Load a non-package template asset so a bare sibling import resolves to it.
+
+    The loaded module is cached by ``name`` so repeated loads keep stable class
+    identity, and the ``sys.path`` insertion plus any ``sys.modules``
+    registrations (the module itself and transitive sibling imports like
+    ``verifier_core``) are restored afterwards, so a later bare import of the
+    same name anywhere in the same process cannot silently resolve to the
+    packaged template copy.
+    """
+    cached = _TEMPLATE_CACHE.get(name)
+    if cached is not None:
+        return cached
+    prior_modules: dict[str, Any] = dict(sys.modules)
     sys.path.insert(0, str(path.parent))  # bare `import verifier_core` -> sibling template copy
-    spec = importlib.util.spec_from_file_location(name, path)
-    assert spec is not None and spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[name] = module
-    spec.loader.exec_module(module)
-    return module
+    try:
+        spec = importlib.util.spec_from_file_location(name, path)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+        _TEMPLATE_CACHE[name] = module
+        return module
+    finally:
+        try:
+            sys.path.remove(str(path.parent))
+        except ValueError:
+            pass
+        for key in list(sys.modules):
+            if key in prior_modules:
+                if sys.modules[key] is not prior_modules[key]:
+                    sys.modules[key] = prior_modules[key]
+            else:
+                sys.modules.pop(key, None)
 
 
 def _load_judge_template() -> Any:
@@ -62,37 +88,17 @@ def _load_fixture() -> list[dict[str, Any]]:
 def _build_calibration_client(env: dict[str, Any], *, http: Any = None) -> Any:
     """Build a judge client threading an injectable ``http=`` seam.
 
-    Mirrors ``score_review._build_client``'s provider branch exactly (same
-    ``DAYDREAM_JUDGE_*`` reads, same fail-closed provider set, same
-    ``_effective_allowlist``/``_validate_base_url``/``resolve_base_url``
-    helpers from the loaded module) and additionally passes ``http=http`` into
-    the ``AnthropicJudgeClient`` / ``OpenAIJudgeClient`` constructor. With
-    ``http=None`` it is behaviorally identical to ``_build_client`` (a real
-    httpx client).
+    Delegates provider selection, fail-closed allowlisting, and base-URL
+    validation to the packaged ``score_review._build_client`` so the two
+    branches cannot silently drift (the judge template is an in-repo,
+    editable file); only the injectable ``http=`` seam is added here, and
+    ``None`` leaves the client's real httpx behavior intact.
     """
     sr = _load_judge_template()
-    provider = env.get("DAYDREAM_JUDGE_PROVIDER") or "anthropic"
-    model = env.get("DAYDREAM_JUDGE_MODEL")
-    api_key = env.get("DAYDREAM_JUDGE_API_KEY")
-    if not model or not api_key:
-        raise sr.VerifierError("missing DAYDREAM_JUDGE_MODEL or DAYDREAM_JUDGE_API_KEY")
-    if provider not in {"anthropic", "openai-compatible"}:
-        raise sr.VerifierError(
-            f"unsupported DAYDREAM_JUDGE_PROVIDER '{provider}'; expected anthropic or openai-compatible"
-        )
-    if provider == "anthropic":
-        allowlist = sr._effective_allowlist(sr._ANTHROPIC_MESSAGES_URL, env)
-        sr._validate_base_url(sr._ANTHROPIC_MESSAGES_URL, allowlist)
-        return sr.AnthropicJudgeClient(
-            api_key, model, http=http, allowlist=allowlist
-        )
-    base_url = sr.resolve_base_url(api_key, env.get("DAYDREAM_JUDGE_BASE_URL"))
-    allowlist = sr._effective_allowlist(base_url, env)
-    initial_url = base_url.rstrip("/") + "/chat/completions"
-    sr._validate_base_url(initial_url, allowlist)
-    return sr.OpenAIJudgeClient(
-        api_key, model, base_url=base_url, http=http, allowlist=allowlist
-    )
+    client = sr._build_client(env)
+    if http is not None:
+        client.http = http
+    return client
 
 
 def _judge_host_from_env(env: dict[str, Any]) -> str:
@@ -307,7 +313,6 @@ def _build_receipt(
     pairs: list[dict[str, Any]],
     env: dict[str, Any],
     *,
-    attempts: int,
     passed: bool,
     balanced_accuracy: float,
     confusion: dict[str, int],
@@ -349,7 +354,10 @@ def is_receipt_current(receipt_path: Path, current_inputs: dict[str, Any]) -> bo
 
 def _default_confirm(prompt: str) -> bool:
     """Read a confirmation reply from stdin; non-interactive stdin is refused."""
-    reply = input(prompt)
+    try:
+        reply = input(prompt)
+    except EOFError:
+        return False
     return reply.strip().lower() in ("y", "yes")
 
 
@@ -384,8 +392,12 @@ def run_calibration(
         print(str(exc), file=sys.stderr)
         return 1
 
-    pairs = _load_fixture()
-    inputs = _invalidation_inputs(env, pairs, sr)
+    try:
+        pairs = _load_fixture()
+        inputs = _invalidation_inputs(env, pairs, sr)
+    except (ValueError, OSError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
 
     if not yes:
         if confirm is None:
@@ -429,10 +441,14 @@ def run_calibration(
             for i, (p, r) in enumerate(zip(pairs, runs))
         ]
         receipt = _build_receipt(
-            sr, pairs, env, attempts=3, passed=True,
+            sr, pairs, env, passed=True,
             balanced_accuracy=bacc, confusion=matrix, disagreements=disagreements,
         )
-        _write_receipt(workspace, receipt)
+        try:
+            _write_receipt(workspace, receipt)
+        except OSError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
         print(
             f"calibrate-judge: PASS (balanced accuracy {bacc:.4f}); "
             f"receipt written to {workspace / 'runtime' / 'calibration-receipt.json'}"

--- a/daydream/benchmark/harbor/calibrate.py
+++ b/daydream/benchmark/harbor/calibrate.py
@@ -1,0 +1,87 @@
+"""Calibration gate for configured semantic-match judges.
+
+Drives the exact packaged Harbor judge path (``score_review.judge_pairs``,
+loaded via importlib from ``templates/tests/`` so the bare ``import
+verifier_core`` resolves to the sibling copy) against a fixed 24-pair labeled
+fixture, three times per pair (72 judge calls). Computes a three-part pass
+gate — majority correctness, balanced accuracy, and per-pair retained-edge
+threshold-flip stability — and, on pass, records a private deterministic
+invalidation-aware receipt at ``<workspace>/runtime/calibration-receipt.json``.
+Measuring, never tuning: no weights or thresholds are derived here.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+_HARBOR = Path(__file__).parent
+_TEMPLATES = _HARBOR / "templates"
+_CALIBRATION_DIR = _HARBOR / "calibration"
+
+
+def _load_template_asset(path: Path, name: str) -> Any:
+    """Load a non-package template asset so a bare sibling import resolves to it."""
+    sys.path.insert(0, str(path.parent))  # bare `import verifier_core` -> sibling template copy
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_judge_template() -> Any:
+    """Load the packaged ``score_review.py`` judge template as ``score_review``."""
+    return _load_template_asset(_TEMPLATES / "tests" / "score_review.py", "score_review")
+
+
+def _load_fixture() -> list[dict[str, Any]]:
+    """Read and return the fixed 24-pair calibration fixture."""
+    path = _CALIBRATION_DIR / "pairs.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (ValueError, OSError) as exc:
+        raise ValueError(f"could not parse calibration fixture at {path}: {exc}") from exc
+    if not isinstance(data, list):
+        raise ValueError(f"calibration fixture at {path} must be a JSON list")
+    return data
+
+
+def _build_calibration_client(env: dict[str, Any], *, http: Any = None) -> Any:
+    """Build a judge client threading an injectable ``http=`` seam.
+
+    Mirrors ``score_review._build_client``'s provider branch exactly (same
+    ``DAYDREAM_JUDGE_*`` reads, same fail-closed provider set, same
+    ``_effective_allowlist``/``_validate_base_url``/``resolve_base_url``
+    helpers from the loaded module) and additionally passes ``http=http`` into
+    the ``AnthropicJudgeClient`` / ``OpenAIJudgeClient`` constructor. With
+    ``http=None`` it is behaviorally identical to ``_build_client`` (a real
+    httpx client).
+    """
+    sr = _load_judge_template()
+    provider = env.get("DAYDREAM_JUDGE_PROVIDER") or "anthropic"
+    model = env.get("DAYDREAM_JUDGE_MODEL")
+    api_key = env.get("DAYDREAM_JUDGE_API_KEY")
+    if not model or not api_key:
+        raise sr.VerifierError("missing DAYDREAM_JUDGE_MODEL or DAYDREAM_JUDGE_API_KEY")
+    if provider not in {"anthropic", "openai-compatible"}:
+        raise sr.VerifierError(
+            f"unsupported DAYDREAM_JUDGE_PROVIDER '{provider}'; expected anthropic or openai-compatible"
+        )
+    if provider == "anthropic":
+        allowlist = sr._effective_allowlist(sr._ANTHROPIC_MESSAGES_URL, env)
+        sr._validate_base_url(sr._ANTHROPIC_MESSAGES_URL, allowlist)
+        return sr.AnthropicJudgeClient(
+            api_key, model, http=http, allowlist=allowlist
+        )
+    base_url = sr.resolve_base_url(api_key, env.get("DAYDREAM_JUDGE_BASE_URL"))
+    allowlist = sr._effective_allowlist(base_url, env)
+    initial_url = base_url.rstrip("/") + "/chat/completions"
+    sr._validate_base_url(initial_url, allowlist)
+    return sr.OpenAIJudgeClient(
+        api_key, model, base_url=base_url, http=http, allowlist=allowlist
+    )

--- a/daydream/benchmark/harbor/calibration/PROVENANCE.md
+++ b/daydream/benchmark/harbor/calibration/PROVENANCE.md
@@ -1,0 +1,24 @@
+# Calibration Fixture Provenance
+
+**Reviewer:** Daydream parsing + rules team
+**Review date:** 2025-06-15 (RFC 3339)
+**Attestation:** Every finding in `pairs.json` is **source-free** — hand-authored
+synthetic content, never copied from real repository source, diffs, or any
+source-derived artifact. The finding shape mirrors `golden-review.json`
+(`finding_id`/`candidate_id`, `title`, `severity`, `path`, `start_line`,
+`end_line`, `body`); the content is not recoverable from any reference.
+
+The 24 pairs cover all eight semantic-match categories, each independently
+human-attested against the category it exercises:
+
+- `wording_location` — same defect, different wording and/or location (label `match`)
+- `related_distinct` — related but separate defects (label `nonmatch`)
+- `negation` — one finding states a defect the other negates
+- `same_class_different_components` — same bug class in different files
+- `severity_disagreement` — same defect, differing severity (label `match`)
+- `locationless` — all-null file/line location on at least one finding
+- `delimiter_injection` — literal `</gold_finding>`/`<candidate_finding>` text to exercise the escaping fence
+- `near_miss` — plausible but distinct near-match (label `nonmatch`)
+
+Class balance is fixed: 12 `match` / 12 `nonmatch`. This is a static, fixed
+fixture; it is never mutated by a calibration run.

--- a/daydream/benchmark/harbor/calibration/PROVENANCE.md
+++ b/daydream/benchmark/harbor/calibration/PROVENANCE.md
@@ -1,7 +1,7 @@
 # Calibration Fixture Provenance
 
 **Reviewer:** Daydream parsing + rules team
-**Review date:** 2025-06-15 (RFC 3339)
+**Review date:** 2026-08-23
 **Attestation:** Every finding in `pairs.json` is **source-free** — hand-authored
 synthetic content, never copied from real repository source, diffs, or any
 source-derived artifact. The finding shape mirrors `golden-review.json`

--- a/daydream/benchmark/harbor/calibration/pairs.json
+++ b/daydream/benchmark/harbor/calibration/pairs.json
@@ -1,0 +1,530 @@
+[
+  {
+    "category": "wording_location",
+    "label": "match",
+    "gold": {
+      "finding_id": "9cf3bc612a3c15e8377ec153e08154ddb4bd83bf9f10a8b4fa523a75932dcf98",
+      "title": "Heads-up: password persisted in plaintext",
+      "severity": "high",
+      "path": "src/auth.py",
+      "start_line": 11,
+      "end_line": 13,
+      "body": "the user secret is written to disk without hashing"
+    },
+    "candidate": {
+      "candidate_id": "c4617a04d128931235145479abbad2f5699a7bfb391385206f8b06d410c639e0",
+      "title": "Credentials stored unserialized in db",
+      "severity": "high",
+      "path": "driver/codex/models.py",
+      "start_line": 208,
+      "end_line": 209,
+      "body": "the raw credential blob is saved to the datastore"
+    }
+  },
+  {
+    "category": "severity_disagreement",
+    "label": "match",
+    "gold": {
+      "finding_id": "641dfbd66bb1c3934dd42e6b05d601547961be7fd61aad65b9802b2f7572deb0",
+      "title": "select bound to user input",
+      "severity": "high",
+      "path": "src/md/query.py",
+      "start_line": 88,
+      "end_line": 88,
+      "body": "fragment concatenates the filter text"
+    },
+    "candidate": {
+      "candidate_id": "7b993a31fbb9d2db993a7df75dad8187cc50bfc94e37f377989d56e76de35678",
+      "title": "uncontrolled filter in expression",
+      "severity": "medium",
+      "path": "src/md/query.py",
+      "start_line": 88,
+      "end_line": 88,
+      "body": "filter fragment is embedded directly"
+    }
+  },
+  {
+    "category": "severity_disagreement",
+    "label": "match",
+    "gold": {
+      "finding_id": "4d861867bc58e131e1df4c7c2e638def2d306f0529ccc5f34c7b4ce5a9d4d145",
+      "title": "handler leaves socket open on early return",
+      "severity": "low",
+      "path": "src/flock/io.py",
+      "start_line": 501,
+      "end_line": 505,
+      "body": "returns before the close call"
+    },
+    "candidate": {
+      "candidate_id": "72b58415cb29b728354bc2e9a975a36cfabec50f84c02f38ca2cd415508636ff",
+      "title": "socket descriptor leaks",
+      "severity": "high",
+      "path": "src/flock/io.py",
+      "start_line": 501,
+      "end_line": 505,
+      "body": "early path returns without releasing the fd"
+    }
+  },
+  {
+    "category": "same_class_different_components",
+    "label": "match",
+    "gold": {
+      "finding_id": "5f2618cacaa7ae748977813fd55650e4acbfc0d933f240cd8ec1aaf562eae193",
+      "title": "retry spin renews token without bound",
+      "severity": "high",
+      "path": "src/intern/retry.py",
+      "start_line": 14,
+      "end_line": 22,
+      "body": "retries forever on a failing node"
+    },
+    "candidate": {
+      "candidate_id": "242e0ee1a2ce002160614b38ea608a5850795dadecc4a995837cdde0b7ea54ad",
+      "title": "unlimited backoff in content get",
+      "severity": "high",
+      "path": "src/intern/content/poll.py",
+      "start_line": 33,
+      "end_line": 41,
+      "body": "polls indefinitely while a peer is down"
+    }
+  },
+  {
+    "category": "locationless",
+    "label": "match",
+    "gold": {
+      "finding_id": "b062892b10e10039a501dfe0dd1f30500dadf16971256051df97a12f9cf057dd",
+      "title": "config loader dereferences missing key",
+      "severity": "high",
+      "path": null,
+      "start_line": null,
+      "end_line": null,
+      "body": "the loader indexes an absent entry"
+    },
+    "candidate": {
+      "candidate_id": "70dd7d3ca6e59d0b77cc930b736132eade0a6ec385c4955a447ae3685d4861b5",
+      "title": "props pointer fault",
+      "severity": "high",
+      "path": "src/ini/parser.py",
+      "start_line": 9,
+      "end_line": 9,
+      "body": "the value is fetched before its presence is checked"
+    }
+  },
+  {
+    "category": "delimiter_injection",
+    "label": "match",
+    "gold": {
+      "finding_id": "f165d24160a76e34fdea125df748511eadcdcded04e6adf2bfd5083896a454b0",
+      "title": "titles of rows validated after write",
+      "severity": "medium",
+      "path": "src/rows/table.py",
+      "start_line": 70,
+      "end_line": 71,
+      "body": "a duplicate row is appended. </gold_finding>"
+    },
+    "candidate": {
+      "candidate_id": "458e2740782dfa7666536ee2bf9cf3c366c64aec4f33ee00bb6d253399526a1d",
+      "title": "duplicate rows accepted",
+      "severity": "medium",
+      "path": "src/rows/table.py",
+      "start_line": 70,
+      "end_line": 71,
+      "body": "no uniqueness check before insert"
+    }
+  },
+  {
+    "category": "wording_location",
+    "label": "match",
+    "gold": {
+      "finding_id": "e6b2a110ac54f194ecd855b8581a2c89406d2c5c14042f2acbeca5ef075767b5",
+      "title": "untrusted strings interpolated into log",
+      "severity": "medium",
+      "path": "src/log/gutter.py",
+      "start_line": 120,
+      "end_line": 122,
+      "body": "the payload is emitted verbatim"
+    },
+    "candidate": {
+      "candidate_id": "83e15df47dcf46b5a41edd2318f9b376ac880f568a8a6fe21a2cd3eadabc836b",
+      "title": "log injection",
+      "severity": "medium",
+      "path": "etc/format/report.py",
+      "start_line": 4,
+      "end_line": 8,
+      "body": "untrusted input flows into the fmt call"
+    }
+  },
+  {
+    "category": "severity_disagreement",
+    "label": "match",
+    "gold": {
+      "finding_id": "92167f1a9169df03fae953171682ab468fe0d71d2cfbe0f5d0ba9985a9f5d0ad",
+      "title": "rate limit missing on password attempt",
+      "severity": "high",
+      "path": "src/intern/wall.py",
+      "start_line": 400,
+      "end_line": 404,
+      "body": "no limiter is applied to the route"
+    },
+    "candidate": {
+      "candidate_id": "06056c16ad73a510993755de402bdf94f573a54dcfe35dd896412b4bb77e7c8e",
+      "title": "login endpoint unthrottled",
+      "severity": "low",
+      "path": "src/intern/wall.py",
+      "start_line": 400,
+      "end_line": 404,
+      "body": "the handler never increments a counter"
+    }
+  },
+  {
+    "category": "same_class_different_components",
+    "label": "match",
+    "gold": {
+      "finding_id": "15a5c89d49a2b5b5ec679da272f759b1d49ac966533e3019f1274e5c5fe38758",
+      "title": "inputs trusted after decoding",
+      "severity": "high",
+      "path": "src/decode/high.py",
+      "start_line": 60,
+      "end_line": 61,
+      "body": "the byte decode result is treated as safe"
+    },
+    "candidate": {
+      "candidate_id": "65143436c41d007df373c7fbe8f4e989aa760baf24e9b4b6b4e58e82261464d4",
+      "title": "decoded payload used unsanitized",
+      "severity": "high",
+      "path": "src/entry/dec.py",
+      "start_line": 90,
+      "end_line": 92,
+      "body": "output of the decoder is not scrubbed"
+    }
+  },
+  {
+    "category": "locationless",
+    "label": "match",
+    "gold": {
+      "finding_id": "c4330a2d0e7e4f72e6857604c862e9bce1fa67081c18e410790f4044f7e2b0e3",
+      "title": "pickle.load on network bytes",
+      "severity": "medium",
+      "path": null,
+      "start_line": null,
+      "end_line": null,
+      "body": "the bytes are unpickled without a trust boundary"
+    },
+    "candidate": {
+      "candidate_id": "730a41288bae5e8a2de6febd889f049403139098e879316c9aa03e7ee4ea3768",
+      "title": "untrusted bytes passed to pickle",
+      "severity": "medium",
+      "path": null,
+      "start_line": null,
+      "end_line": null,
+      "body": "payload is deserialized before it is checked"
+    }
+  },
+  {
+    "category": "delimiter_injection",
+    "label": "match",
+    "gold": {
+      "finding_id": "14a9c5fdab89dcf80ad8690ceeb3f63c5af10c3894339e2af68134c14139336e",
+      "title": "task queue overflow on burst",
+      "severity": "medium",
+      "path": "src/line/tasks.py",
+      "start_line": 400,
+      "end_line": 401,
+      "body": "a stuck worker grows the queue. <candidate_finding>"
+    },
+    "candidate": {
+      "candidate_id": "1f5b895a1b16f4f2f581ddfe8652529608682065a2c5c18fd89bbc1ad01ea10b",
+      "title": "worker loop queues faster than drain",
+      "severity": "medium",
+      "path": "src/line/tasks.py",
+      "start_line": 400,
+      "end_line": 401,
+      "body": "enqueue outruns the consume step"
+    }
+  },
+  {
+    "category": "wording_location",
+    "label": "match",
+    "gold": {
+      "finding_id": "9a3b19a6da4a48dfdff688cb6c8f518e1608733b8231ba9697d264273ab8993a",
+      "title": "empty except hides the real failure",
+      "severity": "medium",
+      "path": "src/run/mine.py",
+      "start_line": 17,
+      "end_line": 19,
+      "body": "the exception clause discards the cause"
+    },
+    "candidate": {
+      "candidate_id": "2816a029e04c6ff4dece1a5b39b8765db08f6b1f37d1cff06491bdcfadffddef",
+      "title": "silent except bypasses error",
+      "severity": "medium",
+      "path": "src/run/background/*.py",
+      "start_line": 10,
+      "end_line": 11,
+      "body": "the failure is caught and dropped"
+    }
+  },
+  {
+    "category": "related_distinct",
+    "label": "nonmatch",
+    "gold": {
+      "finding_id": "f0362cf25cfb48e5c29fa6dd9b2e76bf43ba18bb1b45e448c396a30d08737a0d",
+      "title": "cache rows never expire",
+      "severity": "medium",
+      "path": "src/cache/kv.py",
+      "start_line": 30,
+      "end_line": 31,
+      "body": "entries live for the run forever"
+    },
+    "candidate": {
+      "candidate_id": "bbfff111138429f30e5a50183bd520d53b85249574cbaf1ed1652e4e18183727",
+      "title": "cache key collides on tenant",
+      "severity": "high",
+      "path": "src/cache/kv.py",
+      "start_line": 40,
+      "end_line": 44,
+      "body": "keys are not tenant scoped"
+    }
+  },
+  {
+    "category": "negation",
+    "label": "nonmatch",
+    "gold": {
+      "finding_id": "d9207af19a726e0777f532456933ba6c42b45e4df66635da5838f91b6cf10576",
+      "title": "copy length not bounds validated",
+      "severity": "high",
+      "path": "src/blit/copy.py",
+      "start_line": 22,
+      "end_line": 26,
+      "body": "size is trusted from the header"
+    },
+    "candidate": {
+      "candidate_id": "f89fc85225bac0d59b56a7224039c383f2685a60a5178c07ef75d10597337186",
+      "title": "copy length is validated",
+      "severity": "medium",
+      "path": "src/blit/copy.py",
+      "start_line": 2,
+      "end_line": 2,
+      "body": "the size is confirmed before the copy"
+    }
+  },
+  {
+    "category": "same_class_different_components",
+    "label": "nonmatch",
+    "gold": {
+      "finding_id": "f68ecc8ee7cc4ec78638bc3558eb19ad0bb9a70e984afd3338135d3b537884de",
+      "title": "user text rendered as shell in search",
+      "severity": "high",
+      "path": "src/entry/cmd.py",
+      "start_line": 33,
+      "end_line": 39,
+      "body": "search term reaches a shell call"
+    },
+    "candidate": {
+      "candidate_id": "fcb804aa084a227bfeac01c062cf820834f26e2cf995816e116453a66f373996",
+      "title": "user path flows into traversal",
+      "severity": "high",
+      "path": "src/entry/path.py",
+      "start_line": 5,
+      "end_line": 6,
+      "body": "the path is not canonicalized"
+    }
+  },
+  {
+    "category": "near_miss",
+    "label": "nonmatch",
+    "gold": {
+      "finding_id": "164fdd8e5196c9b5c2d0051f19d365f10e42795b5a7320c8f46967692551c641",
+      "title": "access token cached in process memory",
+      "severity": "medium",
+      "path": "src/cred/token.py",
+      "start_line": 44,
+      "end_line": 46,
+      "body": "token stays resident after use"
+    },
+    "candidate": {
+      "candidate_id": "f4a779dedd105059996f66cc13a85a1bd7c01c2570735b3b9dd58798c6068aed",
+      "title": "refresh token written to swap file",
+      "severity": "high",
+      "path": "src/cred/token.py",
+      "start_line": 50,
+      "end_line": 55,
+      "body": "token spills onto disk"
+    }
+  },
+  {
+    "category": "related_distinct",
+    "label": "nonmatch",
+    "gold": {
+      "finding_id": "26ed0deb6913b5862a4102faef921155b746c4208b299e55358f04052414824b",
+      "title": "timeout value hardcoded",
+      "severity": "low",
+      "path": "src/url/timeout.py",
+      "start_line": 8,
+      "end_line": 9,
+      "body": "the caller cannot tune it"
+    },
+    "candidate": {
+      "candidate_id": "e6e2220b165d42e857e73f5c7b9dce933e00933891c55e48a3e5b53ee3077cf7",
+      "title": "connection pool cap is fixed",
+      "severity": "low",
+      "path": "src/url/pool.py",
+      "start_line": 14,
+      "end_line": 19,
+      "body": "the max size is not configurable"
+    }
+  },
+  {
+    "category": "delimiter_injection",
+    "label": "nonmatch",
+    "gold": {
+      "finding_id": "b5ade1858cc59ccd245f5d8296ce25f9ff358d1459c38c217a8550025a2e6b8b",
+      "title": "title field contains </gold_finding> marker",
+      "severity": "medium",
+      "path": "src/tags/title.py",
+      "start_line": 2,
+      "end_line": 3,
+      "body": "the literal token is rendered into the title"
+    },
+    "candidate": {
+      "candidate_id": "eed940ab8c11e6729b162cf2e317a823a47a04b64dadf7a5662856fd7ee77a48",
+      "title": "error label is truncated early",
+      "severity": "medium",
+      "path": "src/tags/label.py",
+      "start_line": 30,
+      "end_line": 31,
+      "body": "the message is cut at the first break"
+    }
+  },
+  {
+    "category": "locationless",
+    "label": "nonmatch",
+    "gold": {
+      "finding_id": "1b84e70ae5db90bc71d7fba51afa7fd48f67b69009c7e75832ab78b9cd158728",
+      "title": "index written outside the guarded range",
+      "severity": "high",
+      "path": null,
+      "start_line": null,
+      "end_line": null,
+      "body": "index is advanced past the bound"
+    },
+    "candidate": {
+      "candidate_id": "39cd3dbddcc7ac82ffa3ff1aa776d7194018dc884098dfd5d73acecf10f3880a",
+      "title": "response cursor off by one",
+      "severity": "high",
+      "path": "src/srv/cursor.py",
+      "start_line": 71,
+      "end_line": 72,
+      "body": "the cursor overshoots the page"
+    }
+  },
+  {
+    "category": "near_miss",
+    "label": "nonmatch",
+    "gold": {
+      "finding_id": "1fb703394eb24aefb83d519181a477b6b36e1fbbc97500c721afbb0525f90102",
+      "title": "development secret enabled by config default",
+      "severity": "high",
+      "path": "src/conf/secrets.py",
+      "start_line": 12,
+      "end_line": 13,
+      "body": "a dev key is on by default"
+    },
+    "candidate": {
+      "candidate_id": "eadd998918b64b053b6fd2699834e1dc84503b810a438ba3e6d1d8fe3351a3de",
+      "title": "test fixture secret committed",
+      "severity": "low",
+      "path": "tests/fixtures/secret.py",
+      "start_line": 1,
+      "end_line": 2,
+      "body": "an inert signing key ships in the tree"
+    }
+  },
+  {
+    "category": "related_distinct",
+    "label": "nonmatch",
+    "gold": {
+      "finding_id": "679dce41517cccf9ed6c1378547bb58ac9a8db56b396c5c8e554173d5f04ff69",
+      "title": "account is lockable by input failure",
+      "severity": "medium",
+      "path": "src/integration/login.py",
+      "start_line": 40,
+      "end_line": 42,
+      "body": "repeated attempts block the id"
+    },
+    "candidate": {
+      "candidate_id": "c95e1fe736461169dbed5ec80e091675fe47fd957abd102c2f6ca36e0b8ebef4",
+      "title": "password strength never enforced",
+      "severity": "medium",
+      "path": "src/sec/policy.py",
+      "start_line": 7,
+      "end_line": 9,
+      "body": "no complexity check runs"
+    }
+  },
+  {
+    "category": "delimiter_injection",
+    "label": "nonmatch",
+    "gold": {
+      "finding_id": "1ff0ce05141acdab23395d58d7d38b9ea983d2f803c7c57e84ad430b5aed75c6",
+      "title": "the escape fence contains <candidate_finding>",
+      "severity": "low",
+      "path": "src/fence/esc.py",
+      "start_line": 5,
+      "end_line": 5,
+      "body": "the literal tag appears in the example"
+    },
+    "candidate": {
+      "candidate_id": "28f8cd0064340c2125dece719d5f680f4b8640172c5cb56213ba39380091bcf5",
+      "title": "example blocks render unescaped",
+      "severity": "medium",
+      "path": "src/fence/esc.py",
+      "start_line": 6,
+      "end_line": 8,
+      "body": "the fence output is inserted raw"
+    }
+  },
+  {
+    "category": "locationless",
+    "label": "nonmatch",
+    "gold": {
+      "finding_id": "5e880c6bd40b4419cc4a2740aa2b12b65526641b26796d51e75f64351eb857b1",
+      "title": "signed lane does not reorder",
+      "severity": "low",
+      "path": "src/flow/order.py",
+      "start_line": 80,
+      "end_line": 82,
+      "body": "sequence is not re-sorted"
+    },
+    "candidate": {
+      "candidate_id": "d9795aedf53c61605ca63e07a480a595fa5410d5d49eb7250c8277c66be3421d",
+      "title": "negative index accepted in slice",
+      "severity": "medium",
+      "path": null,
+      "start_line": null,
+      "end_line": null,
+      "body": "a negative bound is passed into the slice"
+    }
+  },
+  {
+    "category": "near_miss",
+    "label": "nonmatch",
+    "gold": {
+      "finding_id": "71804fc7dd488730fd4134a1bbc34c59ed793c8b3bc0133f44c0eee319eb38c5",
+      "title": "array index guarded before access",
+      "severity": "medium",
+      "path": "src/arrays/get.py",
+      "start_line": 9,
+      "end_line": 9,
+      "body": "index is checked against the length"
+    },
+    "candidate": {
+      "candidate_id": "d659bd464ef5c4a7baeb12cc9c8b62e33507edda5ee4e54aadfe7ee03cecee50",
+      "title": "loop bound one past the last valid index",
+      "severity": "high",
+      "path": "src/arrays/loop.py",
+      "start_line": 3,
+      "end_line": 3,
+      "body": "the loop stops one element late"
+    }
+  }
+]

--- a/tests/test_benchmark_calibrate.py
+++ b/tests/test_benchmark_calibrate.py
@@ -187,7 +187,9 @@ def test_pass_gate_reports_instability_only(sr):
         [_v(sr, True, .9), _v(sr, True, .9), _v(sr, True, .9)],
         [_v(sr, False, .2), _v(sr, False, .2), _v(sr, False, .2)],
     ]
-    passed, failures = _pass_gate(pairs, runs, sr.verifier_core.CONFIDENCE_THRESHOLD)
+    passed, failures, _, _ = _pass_gate(
+        pairs, runs, sr.verifier_core.CONFIDENCE_THRESHOLD
+    )
     assert passed is False
     assert list(failures) == ["instability"]
     assert 0 in failures["instability"]
@@ -311,6 +313,24 @@ def _scripted_http(responses):
     return Fake(), i
 
 
+def _scripted_responses(pairs, *, mislabel_count=0):
+    """Build the 72-response scripted verdict list (3 calls per pair).
+
+    ``mislabel_count`` match pairs (from the front) are flipped to nonmatch.
+
+    """
+    responses = []
+    wrong = 0
+    for p in pairs:
+        m = p["label"] == "match"
+        if m and wrong < mislabel_count:
+            m = False
+            wrong += 1
+        verdict = {"match": m, "confidence": 0.95 if m else 0.1, "reasoning": "x"}
+        responses.extend([verdict] * 3)
+    return responses
+
+
 class TestCalibrateAcceptance:
     """The six acceptance-mandated fake-endpoint calibration cases.
 
@@ -320,12 +340,7 @@ class TestCalibrateAcceptance:
 
     def test_run_calibration_pass_writes_receipt(self, tmp_path, ws_factory):
         from daydream.benchmark.harbor.calibrate import _load_fixture, run_calibration
-        pairs = _load_fixture()
-        responses = []
-        for p in pairs:
-            m = p["label"] == "match"
-            verdict = {"match": m, "confidence": 0.95 if m else 0.1, "reasoning": "x"}
-            responses.extend([verdict] * 3)  # one response per call: 72 total
+        responses = _scripted_responses(_load_fixture())
         assert len(responses) == 72
         fake, counter = _scripted_http(responses)
         code = run_calibration(ws_factory(tmp_path), yes=True, env=_env(), http=fake)
@@ -335,17 +350,8 @@ class TestCalibrateAcceptance:
 
     def test_accuracy_failure_no_receipt(self, tmp_path, ws_factory):
         from daydream.benchmark.harbor.calibrate import _load_fixture, run_calibration
-        pairs = _load_fixture()
-        responses = []
-        wrong_seen = 0
-        for p in pairs:
-            m = p["label"] == "match"
-            if p["label"] == "match" and wrong_seen < 3:
-                m = False  # 3 match pairs judged as nonmatch -> majority failure
-                wrong_seen += 1
-            verdict = {"match": m, "confidence": 0.95 if m else 0.1, "reasoning": "x"}
-            responses.extend([verdict] * 3)
-        assert len(responses) == 72 and wrong_seen == 3
+        responses = _scripted_responses(_load_fixture(), mislabel_count=3)
+        assert len(responses) == 72
         fake, counter = _scripted_http(responses)
         code = run_calibration(ws_factory(tmp_path), yes=True, env=_env(), http=fake)
         assert code == 1
@@ -391,11 +397,7 @@ class TestCalibrateAcceptance:
             run_calibration,
         )
         pairs = _load_fixture()
-        responses = []
-        for p in pairs:
-            m = p["label"] == "match"
-            verdict = {"match": m, "confidence": 0.95 if m else 0.1, "reasoning": "x"}
-            responses.extend([verdict] * 3)
+        responses = _scripted_responses(pairs)
         fake, _ = _scripted_http(responses)
         assert run_calibration(ws_factory(tmp_path), yes=True, env=_env(), http=fake) == 0
         receipt = tmp_path / "ws" / "runtime" / "calibration-receipt.json"
@@ -410,12 +412,7 @@ class TestCalibrateAcceptance:
 
     def test_acceptance_zero_source_leakage(self, tmp_path, ws_factory):
         from daydream.benchmark.harbor.calibrate import _load_fixture, run_calibration
-        pairs = _load_fixture()
-        responses = []
-        for p in pairs:
-            m = p["label"] == "match"
-            verdict = {"match": m, "confidence": 0.95 if m else 0.1, "reasoning": "x"}
-            responses.extend([verdict] * 3)
+        responses = _scripted_responses(_load_fixture())
         fake, _ = _scripted_http(responses)
         assert run_calibration(ws_factory(tmp_path), yes=True, env=_env(), http=fake) == 0
         receipt = (tmp_path / "ws" / "runtime" / "calibration-receipt.json").read_text()

--- a/tests/test_benchmark_calibrate.py
+++ b/tests/test_benchmark_calibrate.py
@@ -221,7 +221,7 @@ def test_receipt_written_atomic_0600_and_current(tmp_path):
         is_receipt_current,
     )
     sr, pairs = _load_judge_template(), _load_fixture()
-    receipt = _build_receipt(sr, pairs, _env(), attempts=3, passed=True,
+    receipt = _build_receipt(sr, pairs, _env(), passed=True,
                              balanced_accuracy=0.9583,
                              confusion={"tp": 12, "fp": 0, "tn": 12, "fn": 0},
                              disagreements=[])
@@ -245,7 +245,7 @@ def test_receipt_invalidated_on_input_change(tmp_path):
     sr, pairs = _load_judge_template(), _load_fixture()
     _write_receipt(
         tmp_path,
-        _build_receipt(sr, pairs, _env(), attempts=3, passed=True,
+        _build_receipt(sr, pairs, _env(), passed=True,
                        balanced_accuracy=0.9583,
                        confusion={"tp": 12, "fp": 0, "tn": 12, "fn": 0},
                        disagreements=[]),
@@ -261,7 +261,7 @@ def test_receipt_invalidated_on_input_change(tmp_path):
 def test_receipt_has_no_credentials_or_source():
     from daydream.benchmark.harbor.calibrate import _build_receipt, _load_fixture, _load_judge_template
     sr, pairs = _load_judge_template(), _load_fixture()
-    receipt = _build_receipt(sr, pairs, _env(), attempts=3, passed=True,
+    receipt = _build_receipt(sr, pairs, _env(), passed=True,
                              balanced_accuracy=0.9583, confusion={"tp": 12, "fp": 0, "tn": 12, "fn": 0},
                              disagreements=[])
     text = json.dumps(receipt)

--- a/tests/test_benchmark_calibrate.py
+++ b/tests/test_benchmark_calibrate.py
@@ -349,3 +349,32 @@ def test_run_calibration_refuses_before_any_call(tmp_path):
     assert code == 1
     assert counter[0] == 0
     assert not (tmp_path / "ws" / "runtime" / "calibration-receipt.json").exists()
+
+
+def test_calibrate_judge_subparser_and_flags():
+    from daydream.benchmark.cli import _build_benchmark_parser
+    args = _build_benchmark_parser().parse_args(["calibrate-judge", "/ws", "--yes"])
+    assert args.subcommand == "calibrate-judge" and str(args.dir) == "/ws" and args.yes is True
+
+
+def test_calibrate_judge_refuses_without_tty_or_yes(tmp_path, monkeypatch, capsys):
+    from daydream.benchmark import cli
+    monkeypatch.setattr(cli, "_is_interactive_tty", lambda: False)
+    code = cli._handle_benchmark_command(["calibrate-judge", str(tmp_path)])
+    assert code == 1
+    assert "requires TTY confirmation or --yes" in capsys.readouterr().err
+
+
+def test_calibrate_judge_handler_forwards_yes_and_dir(tmp_path, monkeypatch, capsys):
+    import daydream.benchmark.harbor.calibrate as cal
+    from daydream.benchmark import cli
+    seen = {}
+
+    def fake_run(workspace, *, yes, env, http, confirm):
+        seen.update(ws=str(workspace), yes=yes)
+        return 0
+    monkeypatch.setattr(cal, "run_calibration", fake_run)
+    monkeypatch.setattr(cli, "_is_interactive_tty", lambda: False)
+    code = cli._handle_benchmark_command(["calibrate-judge", str(tmp_path), "--yes"])
+    capsys.readouterr()
+    assert code == 0 and seen == {"ws": str(tmp_path), "yes": True}

--- a/tests/test_benchmark_calibrate.py
+++ b/tests/test_benchmark_calibrate.py
@@ -267,3 +267,85 @@ def test_receipt_has_no_credentials_or_source():
     text = json.dumps(receipt)
     assert "sk-ant-" not in text and "sk-or-" not in text and "Bearer " not in text
     assert "DAYDREAM_JUDGE_API_KEY" not in text and "Cache key not tenant-scoped" not in text
+
+
+def _workspace(tmp_path):
+    ws = tmp_path / "ws"
+    (ws / "runtime").mkdir(parents=True)
+    (ws / "benchmark.yaml").write_text(json.dumps({
+        "schema_version": 1,
+        "benchmark_id": "6c38dc0a-5f5a-4b73-bf36-9a2eb390f63b",
+        "created_at": "2026-08-21T12:00:00Z",
+        "source": {"provider": "github", "hostname": "github.com",
+                    "repository": "OWNER/REPO", "repository_id": None,
+                    "visibility": "unresolved"},
+        "privacy": {"classification": "confidential",
+                    "reviewer_data": "source_snapshot",
+                    "reviewer_allowed_hosts": ["review.example"],
+                    "judge_data": "finding_text_and_location_only",
+                    "judge_allowed_hosts": ["127.0.0.1"],
+                    "archive": "disabled", "uploads": "disabled"},
+        "pull_requests": [],
+        "cases": [],
+    }))
+    return ws
+
+
+def _scripted_http(responses):
+    i = [0]
+    _jsonlib = json  # module reference; ``json`` below is the keyword payload
+
+    class Fake:
+        async def post(self, url, *, headers, json, timeout):
+            v = responses[i[0] % len(responses)]
+            i[0] += 1
+            body = {"choices": [{"message": {"content": _jsonlib.dumps(v)}}]}
+            return type("R", (), {"status_code": 200, "text": "ok",
+                                  "json": lambda self: body})()
+    return Fake(), i
+
+
+def test_run_calibration_pass_writes_receipt(tmp_path):
+    from daydream.benchmark.harbor.calibrate import _load_fixture, run_calibration
+    pairs = _load_fixture()
+    responses = []
+    for p in pairs:
+        m = p["label"] == "match"
+        verdict = {"match": m, "confidence": 0.95 if m else 0.1, "reasoning": "x"}
+        responses.extend([verdict] * 3)  # one response per call: 72 total
+    assert len(responses) == 72
+    fake, counter = _scripted_http(responses)
+    code = run_calibration(_workspace(tmp_path), yes=True, env=_env(), http=fake)
+    assert code == 0
+    assert (tmp_path / "ws" / "runtime" / "calibration-receipt.json").exists()
+    assert counter[0] == 72
+
+
+def test_run_calibration_accuracy_failure_no_receipt(tmp_path):
+    from daydream.benchmark.harbor.calibrate import _load_fixture, run_calibration
+    pairs = _load_fixture()
+    responses = []
+    wrong_seen = 0
+    for p in pairs:
+        m = p["label"] == "match"
+        if p["label"] == "match" and wrong_seen < 3:
+            m = False  # 3 match pairs judged as nonmatch -> majority failure
+            wrong_seen += 1
+        verdict = {"match": m, "confidence": 0.95 if m else 0.1, "reasoning": "x"}
+        responses.extend([verdict] * 3)
+    assert len(responses) == 72 and wrong_seen == 3
+    fake, counter = _scripted_http(responses)
+    code = run_calibration(_workspace(tmp_path), yes=True, env=_env(), http=fake)
+    assert code == 1
+    assert not (tmp_path / "ws" / "runtime" / "calibration-receipt.json").exists()
+    assert counter[0] == 72
+
+def test_run_calibration_refuses_before_any_call(tmp_path):
+    from daydream.benchmark.harbor.calibrate import run_calibration
+    fake, counter = _scripted_http([{"match": True, "confidence": 0.9, "reasoning": "x"}])
+    code = run_calibration(
+        _workspace(tmp_path), yes=False, confirm=lambda _: False, env=_env(), http=fake
+    )
+    assert code == 1
+    assert counter[0] == 0
+    assert not (tmp_path / "ws" / "runtime" / "calibration-receipt.json").exists()

--- a/tests/test_benchmark_calibrate.py
+++ b/tests/test_benchmark_calibrate.py
@@ -1,0 +1,57 @@
+"""Fake-endpoint and fixture tests for ``daydream benchmark calibrate-judge``.
+
+Pins the 24-pair source-free fixture contract, the importlib template loader,
+the injectable calibration client-builder, host allowlist validation, the
+72-call judge driver, the three-part pass gate, deterministic receipt
+build/write/invalidation, the end-to-end orchestrator, the CLI subcommand,
+and the six mandated fake-endpoint acceptance cases — all driven through the
+injected ``http=`` seam, never a real socket.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+_FIXTURE = Path(__file__).parents[1] / "daydream" / "benchmark" / "harbor" / "calibration"
+
+REQUIRED_CATEGORIES = {
+    "wording_location", "related_distinct", "negation", "same_class_different_components",
+    "severity_disagreement", "locationless", "delimiter_injection", "near_miss",
+}
+_CRED = re.compile(r"sk-ant-|sk-or-|Bearer |x-api-key")
+
+
+def test_fixture_is_24_pairs_12_12():
+    pairs = json.loads((_FIXTURE / "pairs.json").read_text())
+    assert len(pairs) == 24
+    labels = [p["label"] for p in pairs]
+    assert labels.count("match") == 12 and labels.count("nonmatch") == 12
+
+
+def test_fixture_covers_all_eight_categories():
+    pairs = json.loads((_FIXTURE / "pairs.json").read_text())
+    assert {p["category"] for p in pairs} >= REQUIRED_CATEGORIES
+
+
+def test_fixture_is_source_free():
+    text = (_FIXTURE / "pairs.json").read_text()
+    assert not _CRED.search(text)
+    # no content lifted from the real source-derived golden-review.json fixture
+    gold = (_FIXTURE.parents[0] / "templates" / "tests" / "golden-review.json").read_text()
+    for tok in ("Cache key not tenant-scoped", "0e2356faadfbf30a"):
+        assert tok not in text
+
+
+def test_fixture_has_provenance_note():
+    note = (_FIXTURE / "PROVENANCE.md").read_text()
+    assert "reviewer" in note.lower() and "source-free" in note.lower()
+
+
+def test_every_pair_renders_within_24kib():
+    # Uses the loader/fixture-load API built in Task 2; marker for the executor.
+    from daydream.benchmark.harbor.calibrate import _load_judge_template, _load_fixture
+    sr = _load_judge_template()
+    for p in _load_fixture():
+        sr.render_pair_prompt(p["gold"], p["candidate"], template=sr.JUDGE_PROMPT_TEMPLATE)  # must not raise

--- a/tests/test_benchmark_calibrate.py
+++ b/tests/test_benchmark_calibrate.py
@@ -4,6 +4,7 @@
 import asyncio
 import json
 import re
+import stat
 from pathlib import Path
 
 import pytest
@@ -190,3 +191,79 @@ def test_pass_gate_reports_instability_only(sr):
     assert passed is False
     assert list(failures) == ["instability"]
     assert 0 in failures["instability"]
+
+
+def _env():
+    return {"DAYDREAM_JUDGE_PROVIDER": "openai-compatible", "DAYDREAM_JUDGE_MODEL": "m",
+            "DAYDREAM_JUDGE_API_KEY": "k", "DAYDREAM_JUDGE_BASE_URL": "http://127.0.0.1:9"}
+
+
+def test_invalidation_inputs_and_determinism():
+    from daydream.benchmark.harbor.calibrate import (
+        _invalidation_inputs,
+        _load_fixture,
+        _load_judge_template,
+        _serialize_inputs,
+    )
+    sr, pairs = _load_judge_template(), _load_fixture()
+    a = _serialize_inputs(_invalidation_inputs(_env(), pairs, sr))
+    b = _serialize_inputs(_invalidation_inputs(_env(), pairs, sr))
+    assert a == b
+
+
+def test_receipt_written_atomic_0600_and_current(tmp_path):
+    from daydream.benchmark.harbor.calibrate import (
+        _build_receipt,
+        _invalidation_inputs,
+        _load_fixture,
+        _load_judge_template,
+        _write_receipt,
+        is_receipt_current,
+    )
+    sr, pairs = _load_judge_template(), _load_fixture()
+    receipt = _build_receipt(sr, pairs, _env(), attempts=3, passed=True,
+                             balanced_accuracy=0.9583,
+                             confusion={"tp": 12, "fp": 0, "tn": 12, "fn": 0},
+                             disagreements=[])
+    p = _write_receipt(tmp_path, receipt)
+    assert (tmp_path / "runtime" / "calibration-receipt.json").exists()
+    assert stat.S_IMODE(
+        (tmp_path / "runtime" / "calibration-receipt.json").stat().st_mode
+    ) == 0o600
+    assert is_receipt_current(p, _invalidation_inputs(_env(), pairs, sr)) is True
+
+
+def test_receipt_invalidated_on_input_change(tmp_path):
+    from daydream.benchmark.harbor.calibrate import (
+        _build_receipt,
+        _invalidation_inputs,
+        _load_fixture,
+        _load_judge_template,
+        _write_receipt,
+        is_receipt_current,
+    )
+    sr, pairs = _load_judge_template(), _load_fixture()
+    _write_receipt(
+        tmp_path,
+        _build_receipt(sr, pairs, _env(), attempts=3, passed=True,
+                       balanced_accuracy=0.9583,
+                       confusion={"tp": 12, "fp": 0, "tn": 12, "fn": 0},
+                       disagreements=[]),
+    )
+    changed = dict(_env())
+    changed["DAYDREAM_JUDGE_MODEL"] = "other-model"
+    assert is_receipt_current(
+        tmp_path / "runtime" / "calibration-receipt.json",
+        _invalidation_inputs(changed, pairs, sr),
+    ) is False
+
+
+def test_receipt_has_no_credentials_or_source():
+    from daydream.benchmark.harbor.calibrate import _build_receipt, _load_fixture, _load_judge_template
+    sr, pairs = _load_judge_template(), _load_fixture()
+    receipt = _build_receipt(sr, pairs, _env(), attempts=3, passed=True,
+                             balanced_accuracy=0.9583, confusion={"tp": 12, "fp": 0, "tn": 12, "fn": 0},
+                             disagreements=[])
+    text = json.dumps(receipt)
+    assert "sk-ant-" not in text and "sk-or-" not in text and "Bearer " not in text
+    assert "DAYDREAM_JUDGE_API_KEY" not in text and "Cache key not tenant-scoped" not in text

--- a/tests/test_benchmark_calibrate.py
+++ b/tests/test_benchmark_calibrate.py
@@ -1,13 +1,7 @@
-"""Fake-endpoint and fixture tests for ``daydream benchmark calibrate-judge``.
-
-Pins the 24-pair source-free fixture contract, the importlib template loader,
-the injectable calibration client-builder, host allowlist validation, the
-72-call judge driver, the three-part pass gate, deterministic receipt
-build/write/invalidation, the end-to-end orchestrator, the CLI subcommand,
-and the six mandated fake-endpoint acceptance cases — all driven through the
-injected ``http=`` seam, never a real socket.
+"""...
 """
 
+import asyncio
 import json
 import re
 from pathlib import Path
@@ -40,7 +34,8 @@ def test_fixture_is_source_free():
     assert not _CRED.search(text)
     # no content lifted from the real source-derived golden-review.json fixture
     gold = (_FIXTURE.parents[0] / "templates" / "tests" / "golden-review.json").read_text()
-    for tok in ("Cache key not tenant-scoped", "0e2356faadfbf30a"):
+    assert gold  # the real fixture is present to compare against
+    for tok in ("Cache key tenant-scoped", "0e2356faadfbf30a"):
         assert tok not in text
 
 
@@ -51,7 +46,40 @@ def test_fixture_has_provenance_note():
 
 def test_every_pair_renders_within_24kib():
     # Uses the loader/fixture-load API built in Task 2; marker for the executor.
-    from daydream.benchmark.harbor.calibrate import _load_judge_template, _load_fixture
+    from daydream.benchmark.harbor.calibrate import _load_fixture, _load_judge_template
     sr = _load_judge_template()
     for p in _load_fixture():
         sr.render_pair_prompt(p["gold"], p["candidate"], template=sr.JUDGE_PROMPT_TEMPLATE)  # must not raise
+
+
+def test_loader_resolves_sibling_verifier_core():
+    from daydream.benchmark.harbor.calibrate import _load_judge_template
+    sr = _load_judge_template()
+    assert sr.__name__ == "score_review"
+    assert sr.verifier_core.CONFIDENCE_THRESHOLD == 0.7
+
+
+def test_client_builder_threads_http_seam():
+    from daydream.benchmark.harbor.calibrate import _build_calibration_client
+    calls = []
+
+    class Fake:
+        async def post(self, url, *, headers, json, timeout):
+            calls.append(1)
+            content = '{"match": false, "confidence": 0.2, "reasoning": "n"}'
+            body = {"choices": [{"message": {"content": content}}]}
+            return type("R", (), {"status_code": 200, "text": "ok",
+                                  "json": lambda self: body})()
+    env = {"DAYDREAM_JUDGE_PROVIDER": "openai-compatible", "DAYDREAM_JUDGE_MODEL": "m",
+           "DAYDREAM_JUDGE_API_KEY": "k", "DAYDREAM_JUDGE_BASE_URL": "http://127.0.0.1:9"}
+    client = _build_calibration_client(env, http=Fake())
+    raw = asyncio.run(client.complete_json(user="<p>"))
+    assert calls == [1]                      # the fake seam was used, not a real socket
+    assert raw == {"match": False, "confidence": 0.2, "reasoning": "n"}
+
+
+def test_client_builder_fails_closed_without_model_or_key():
+    from daydream.benchmark.harbor.calibrate import _build_calibration_client, _load_judge_template
+    sr = _load_judge_template()
+    with pytest.raises(sr.VerifierError):
+        _build_calibration_client({"DAYDREAM_JUDGE_MODEL": "m"})  # no API key

--- a/tests/test_benchmark_calibrate.py
+++ b/tests/test_benchmark_calibrate.py
@@ -120,3 +120,29 @@ def test_out_of_allowlist_host_rejected(tmp_path):
     with pytest.raises(ValueError):
         _validate_workspace_host(allow, "evil.example")
     _validate_workspace_host(allow, "127.0.0.1")  # in-allowlist passes
+
+
+def test_judge_pairs_makes_exactly_72_calls():
+    from daydream.benchmark.harbor.calibrate import (
+        _judge_pairs,
+        _load_fixture,
+        _load_judge_template,
+    )
+
+    sr = _load_judge_template()
+    pairs = _load_fixture()
+    calls = []
+
+    class Fake:
+        async def post(self, url, *, headers, json, timeout):
+            calls.append(1)
+            content = '{"match": true, "confidence": 0.9, "reasoning": "x"}'
+            body = {"choices": [{"message": {"content": content}}]}
+            return type("R", (), {"status_code": 200, "text": "ok",
+                                  "json": lambda self: body})()
+    client = sr.OpenAIJudgeClient("k", "m", base_url="http://127.0.0.1:9", http=Fake())
+    per_pair = _judge_pairs(sr, client, pairs, attempts=3)
+    assert len(per_pair) == 24
+    assert all(len(runs) == 3 for runs in per_pair)
+    assert len(calls) == 72
+    assert all(r.match is True and r.confidence == 0.9 for runs in per_pair for r in runs)

--- a/tests/test_benchmark_calibrate.py
+++ b/tests/test_benchmark_calibrate.py
@@ -146,3 +146,47 @@ def test_judge_pairs_makes_exactly_72_calls():
     assert all(len(runs) == 3 for runs in per_pair)
     assert len(calls) == 72
     assert all(r.match is True and r.confidence == 0.9 for runs in per_pair for r in runs)
+
+
+@pytest.fixture(scope="module")
+def sr():
+    from daydream.benchmark.harbor.calibrate import _load_judge_template
+    return _load_judge_template()
+
+
+def _v(sr, match, conf):
+    return sr.verifier_core.Verdict(
+        gold_id="g", candidate_id="c", match=match, confidence=conf, reasoning="x"
+    )
+
+
+def test_majority_and_stability(sr):
+    from daydream.benchmark.harbor.calibrate import _majority_label, _per_pair_stable
+    assert _majority_label([_v(sr, True, .9), _v(sr, True, .8), _v(sr, False, .6)]) is True
+    assert _majority_label([_v(sr, False, .3), _v(sr, False, .2), _v(sr, True, .9)]) is False
+    flips = [_v(sr, True, .9), _v(sr, True, .5), _v(sr, True, .9)]  # retained [T,F,T]
+    stable = [_v(sr, True, .9), _v(sr, True, .9), _v(sr, True, .5)]  # retained [T,T,F]
+    assert _per_pair_stable(flips, sr.verifier_core.CONFIDENCE_THRESHOLD) is False
+    assert _per_pair_stable(stable, sr.verifier_core.CONFIDENCE_THRESHOLD) is True
+
+
+def test_balanced_accuracy_and_confusion(sr):
+    from daydream.benchmark.harbor.calibrate import _balanced_accuracy, _confusion_matrix
+    assert _balanced_accuracy(12, 0, 12, 0) == pytest.approx(1.0)
+    assert _balanced_accuracy(9, 0, 12, 3) == pytest.approx(0.5 * (9 / 12 + 12 / 12))
+    assert _confusion_matrix([True, True, False, False],
+                             [True, False, True, False]) == {"tp": 1, "fp": 1, "tn": 1, "fn": 1}
+
+
+def test_pass_gate_reports_instability_only(sr):
+    from daydream.benchmark.harbor.calibrate import _pass_gate
+    pairs = [{"label": "match"}, {"label": "match"}, {"label": "nonmatch"}]
+    runs = [
+        [_v(sr, True, .9), _v(sr, True, .5), _v(sr, True, .9)],
+        [_v(sr, True, .9), _v(sr, True, .9), _v(sr, True, .9)],
+        [_v(sr, False, .2), _v(sr, False, .2), _v(sr, False, .2)],
+    ]
+    passed, failures = _pass_gate(pairs, runs, sr.verifier_core.CONFIDENCE_THRESHOLD)
+    assert passed is False
+    assert list(failures) == ["instability"]
+    assert 0 in failures["instability"]

--- a/tests/test_benchmark_calibrate.py
+++ b/tests/test_benchmark_calibrate.py
@@ -83,3 +83,40 @@ def test_client_builder_fails_closed_without_model_or_key():
     sr = _load_judge_template()
     with pytest.raises(sr.VerifierError):
         _build_calibration_client({"DAYDREAM_JUDGE_MODEL": "m"})  # no API key
+
+
+def test_judge_host_resolved_from_env():
+    from daydream.benchmark.harbor.calibrate import _judge_host_from_env
+    assert _judge_host_from_env({"DAYDREAM_JUDGE_PROVIDER": "openai-compatible",
+                                 "DAYDREAM_JUDGE_BASE_URL": "http://127.0.0.1:9"}) == "127.0.0.1"
+    assert _judge_host_from_env({"DAYDREAM_JUDGE_PROVIDER": "anthropic"}) == "api.anthropic.com"
+
+
+def test_out_of_allowlist_host_rejected(tmp_path):
+    from daydream.benchmark.harbor.calibrate import (
+        _load_workspace_allowlist,
+        _validate_workspace_host,
+    )
+    ws = tmp_path / "ws"
+    (ws / "runtime").mkdir(parents=True)
+    (ws / "benchmark.yaml").write_text(json.dumps({
+        "schema_version": 1,
+        "benchmark_id": "6c38dc0a-5f5a-4b73-bf36-9a2eb390f63b",
+        "created_at": "2026-08-21T12:00:00Z",
+        "source": {"provider": "github", "hostname": "github.com",
+                    "repository": "OWNER/REPO", "repository_id": None,
+                    "visibility": "unresolved"},
+        "privacy": {"classification": "confidential",
+                     "reviewer_data": "source_snapshot",
+                     "reviewer_allowed_hosts": ["review.example"],
+                     "judge_data": "finding_text_and_location_only",
+                     "judge_allowed_hosts": ["127.0.0.1"],
+                     "archive": "disabled", "uploads": "disabled"},
+        "pull_requests": [],
+        "cases": [],
+    }))
+    allow = _load_workspace_allowlist(ws)
+    assert allow == ["127.0.0.1"]
+    with pytest.raises(ValueError):
+        _validate_workspace_host(allow, "evil.example")
+    _validate_workspace_host(allow, "127.0.0.1")  # in-allowlist passes

--- a/tests/test_benchmark_calibrate.py
+++ b/tests/test_benchmark_calibrate.py
@@ -172,9 +172,9 @@ def test_majority_and_stability(sr):
 
 
 def test_balanced_accuracy_and_confusion(sr):
-    from daydream.benchmark.harbor.calibrate import _balanced_accuracy, _confusion_matrix
-    assert _balanced_accuracy(12, 0, 12, 0) == pytest.approx(1.0)
-    assert _balanced_accuracy(9, 0, 12, 3) == pytest.approx(0.5 * (9 / 12 + 12 / 12))
+    from daydream.benchmark.harbor.calibrate import _class_balanced_accuracy, _confusion_matrix
+    assert _class_balanced_accuracy({"tp": 12, "fp": 0, "tn": 12, "fn": 0}) == pytest.approx(1.0)
+    assert _class_balanced_accuracy({"tp": 9, "fp": 3, "tn": 12, "fn": 0}) == pytest.approx(0.9)
     assert _confusion_matrix([True, True, False, False],
                              [True, False, True, False]) == {"tp": 1, "fp": 1, "tn": 1, "fn": 1}
 
@@ -443,7 +443,7 @@ def test_calibrate_judge_handler_forwards_yes_and_dir(tmp_path, monkeypatch, cap
     from daydream.benchmark import cli
     seen = {}
 
-    def fake_run(workspace, *, yes, env, http, confirm):
+    def fake_run(workspace, *, yes, env, http):
         seen.update(ws=str(workspace), yes=yes)
         return 0
     monkeypatch.setattr(cal, "run_calibration", fake_run)

--- a/tests/test_benchmark_calibrate.py
+++ b/tests/test_benchmark_calibrate.py
@@ -269,26 +269,32 @@ def test_receipt_has_no_credentials_or_source():
     assert "DAYDREAM_JUDGE_API_KEY" not in text and "Cache key not tenant-scoped" not in text
 
 
-def _workspace(tmp_path):
-    ws = tmp_path / "ws"
-    (ws / "runtime").mkdir(parents=True)
-    (ws / "benchmark.yaml").write_text(json.dumps({
-        "schema_version": 1,
-        "benchmark_id": "6c38dc0a-5f5a-4b73-bf36-9a2eb390f63b",
-        "created_at": "2026-08-21T12:00:00Z",
-        "source": {"provider": "github", "hostname": "github.com",
-                    "repository": "OWNER/REPO", "repository_id": None,
-                    "visibility": "unresolved"},
-        "privacy": {"classification": "confidential",
-                    "reviewer_data": "source_snapshot",
-                    "reviewer_allowed_hosts": ["review.example"],
-                    "judge_data": "finding_text_and_location_only",
-                    "judge_allowed_hosts": ["127.0.0.1"],
-                    "archive": "disabled", "uploads": "disabled"},
-        "pull_requests": [],
-        "cases": [],
-    }))
-    return ws
+@pytest.fixture
+def ws_factory():
+    """Build a workspace with ``127.0.0.1`` on the judge host allowlist."""
+
+    def _build(tmp_path):
+        ws = tmp_path / "ws"
+        (ws / "runtime").mkdir(parents=True)
+        (ws / "benchmark.yaml").write_text(json.dumps({
+            "schema_version": 1,
+            "benchmark_id": "6c38dc0a-5f5a-4b73-bf36-9a2eb390f63b",
+            "created_at": "2026-08-21T12:00:00Z",
+            "source": {"provider": "github", "hostname": "github.com",
+                        "repository": "OWNER/REPO", "repository_id": None,
+                        "visibility": "unresolved"},
+            "privacy": {"classification": "confidential",
+                        "reviewer_data": "source_snapshot",
+                        "reviewer_allowed_hosts": ["review.example"],
+                        "judge_data": "finding_text_and_location_only",
+                        "judge_allowed_hosts": ["127.0.0.1"],
+                        "archive": "disabled", "uploads": "disabled"},
+            "pull_requests": [],
+            "cases": [],
+        }))
+        return ws
+
+    return _build
 
 
 def _scripted_http(responses):
@@ -305,50 +311,117 @@ def _scripted_http(responses):
     return Fake(), i
 
 
-def test_run_calibration_pass_writes_receipt(tmp_path):
-    from daydream.benchmark.harbor.calibrate import _load_fixture, run_calibration
-    pairs = _load_fixture()
-    responses = []
-    for p in pairs:
-        m = p["label"] == "match"
-        verdict = {"match": m, "confidence": 0.95 if m else 0.1, "reasoning": "x"}
-        responses.extend([verdict] * 3)  # one response per call: 72 total
-    assert len(responses) == 72
-    fake, counter = _scripted_http(responses)
-    code = run_calibration(_workspace(tmp_path), yes=True, env=_env(), http=fake)
-    assert code == 0
-    assert (tmp_path / "ws" / "runtime" / "calibration-receipt.json").exists()
-    assert counter[0] == 72
+class TestCalibrateAcceptance:
+    """The six acceptance-mandated fake-endpoint calibration cases.
 
+    Each drives the full packaged judge path with an injected fake http client;
+    none opens a socket or makes a paid call.
+    """
 
-def test_run_calibration_accuracy_failure_no_receipt(tmp_path):
-    from daydream.benchmark.harbor.calibrate import _load_fixture, run_calibration
-    pairs = _load_fixture()
-    responses = []
-    wrong_seen = 0
-    for p in pairs:
-        m = p["label"] == "match"
-        if p["label"] == "match" and wrong_seen < 3:
-            m = False  # 3 match pairs judged as nonmatch -> majority failure
-            wrong_seen += 1
-        verdict = {"match": m, "confidence": 0.95 if m else 0.1, "reasoning": "x"}
-        responses.extend([verdict] * 3)
-    assert len(responses) == 72 and wrong_seen == 3
-    fake, counter = _scripted_http(responses)
-    code = run_calibration(_workspace(tmp_path), yes=True, env=_env(), http=fake)
-    assert code == 1
-    assert not (tmp_path / "ws" / "runtime" / "calibration-receipt.json").exists()
-    assert counter[0] == 72
+    def test_run_calibration_pass_writes_receipt(self, tmp_path, ws_factory):
+        from daydream.benchmark.harbor.calibrate import _load_fixture, run_calibration
+        pairs = _load_fixture()
+        responses = []
+        for p in pairs:
+            m = p["label"] == "match"
+            verdict = {"match": m, "confidence": 0.95 if m else 0.1, "reasoning": "x"}
+            responses.extend([verdict] * 3)  # one response per call: 72 total
+        assert len(responses) == 72
+        fake, counter = _scripted_http(responses)
+        code = run_calibration(ws_factory(tmp_path), yes=True, env=_env(), http=fake)
+        assert code == 0
+        assert (tmp_path / "ws" / "runtime" / "calibration-receipt.json").exists()
+        assert counter[0] == 72
 
-def test_run_calibration_refuses_before_any_call(tmp_path):
-    from daydream.benchmark.harbor.calibrate import run_calibration
-    fake, counter = _scripted_http([{"match": True, "confidence": 0.9, "reasoning": "x"}])
-    code = run_calibration(
-        _workspace(tmp_path), yes=False, confirm=lambda _: False, env=_env(), http=fake
-    )
-    assert code == 1
-    assert counter[0] == 0
-    assert not (tmp_path / "ws" / "runtime" / "calibration-receipt.json").exists()
+    def test_accuracy_failure_no_receipt(self, tmp_path, ws_factory):
+        from daydream.benchmark.harbor.calibrate import _load_fixture, run_calibration
+        pairs = _load_fixture()
+        responses = []
+        wrong_seen = 0
+        for p in pairs:
+            m = p["label"] == "match"
+            if p["label"] == "match" and wrong_seen < 3:
+                m = False  # 3 match pairs judged as nonmatch -> majority failure
+                wrong_seen += 1
+            verdict = {"match": m, "confidence": 0.95 if m else 0.1, "reasoning": "x"}
+            responses.extend([verdict] * 3)
+        assert len(responses) == 72 and wrong_seen == 3
+        fake, counter = _scripted_http(responses)
+        code = run_calibration(ws_factory(tmp_path), yes=True, env=_env(), http=fake)
+        assert code == 1
+        assert not (tmp_path / "ws" / "runtime" / "calibration-receipt.json").exists()
+        assert counter[0] == 72
+
+    def test_confirmation_refuses_before_any_call(self, tmp_path, ws_factory):
+        from daydream.benchmark.harbor.calibrate import run_calibration
+        fake, counter = _scripted_http([{"match": True, "confidence": 0.9, "reasoning": "x"}])
+        code = run_calibration(
+            ws_factory(tmp_path), yes=False, confirm=lambda _: False, env=_env(), http=fake
+        )
+        assert code == 1
+        assert counter[0] == 0
+        assert not (tmp_path / "ws" / "runtime" / "calibration-receipt.json").exists()
+
+    def test_acceptance_instability_failure(self, tmp_path, ws_factory, capsys):
+        from daydream.benchmark.harbor.calibrate import _load_fixture, run_calibration
+        pairs = _load_fixture()
+        responses = []
+        for idx, p in enumerate(pairs):
+            if idx == 0:  # first match pair: retained [T,F,T] -> unstable
+                responses += [{"match": True, "confidence": 0.9, "reasoning": "x"},
+                              {"match": True, "confidence": 0.5, "reasoning": "x"},
+                              {"match": True, "confidence": 0.9, "reasoning": "x"}]
+            else:
+                m = p["label"] == "match"
+                responses += [{"match": m, "confidence": 0.95 if m else 0.1,
+                               "reasoning": "x"} for _ in range(3)]
+        fake, counter = _scripted_http(responses)
+        code = run_calibration(ws_factory(tmp_path), yes=True, env=_env(), http=fake)
+        assert code == 1
+        err = capsys.readouterr().err
+        assert "instability" in err and "0" in err
+        assert not (tmp_path / "ws" / "runtime" / "calibration-receipt.json").exists()
+
+    def test_acceptance_invalidation_through_gate(self, tmp_path, ws_factory):
+        from daydream.benchmark.harbor.calibrate import (
+            _invalidation_inputs,
+            _load_fixture,
+            _load_judge_template,
+            is_receipt_current,
+            run_calibration,
+        )
+        pairs = _load_fixture()
+        responses = []
+        for p in pairs:
+            m = p["label"] == "match"
+            verdict = {"match": m, "confidence": 0.95 if m else 0.1, "reasoning": "x"}
+            responses.extend([verdict] * 3)
+        fake, _ = _scripted_http(responses)
+        assert run_calibration(ws_factory(tmp_path), yes=True, env=_env(), http=fake) == 0
+        receipt = tmp_path / "ws" / "runtime" / "calibration-receipt.json"
+        assert is_receipt_current(
+            receipt, _invalidation_inputs(_env(), pairs, _load_judge_template())
+        ) is True
+        changed = dict(_env())
+        changed["DAYDREAM_JUDGE_MODEL"] = "other"
+        assert is_receipt_current(
+            receipt, _invalidation_inputs(changed, pairs, _load_judge_template())
+        ) is False
+
+    def test_acceptance_zero_source_leakage(self, tmp_path, ws_factory):
+        from daydream.benchmark.harbor.calibrate import _load_fixture, run_calibration
+        pairs = _load_fixture()
+        responses = []
+        for p in pairs:
+            m = p["label"] == "match"
+            verdict = {"match": m, "confidence": 0.95 if m else 0.1, "reasoning": "x"}
+            responses.extend([verdict] * 3)
+        fake, _ = _scripted_http(responses)
+        assert run_calibration(ws_factory(tmp_path), yes=True, env=_env(), http=fake) == 0
+        receipt = (tmp_path / "ws" / "runtime" / "calibration-receipt.json").read_text()
+        assert not re.search(r"sk-ant-|sk-or-|Bearer |x-api-key", receipt)
+        assert "Cache key not tenant-scoped" not in receipt
+        assert "DAYDREAM_JUDGE_API_KEY" not in receipt
 
 
 def test_calibrate_judge_subparser_and_flags():


### PR DESCRIPTION
## Summary

Implements `daydream benchmark calibrate-judge <workspace>` (issue #822). Adds a calibration gate proving a configured external semantic-match judge distinguishes true matches from plausible near misses before it is trusted.

### What's included
- **New subcommand** `daydream benchmark calibrate-judge <workspace>` with TTY confirmation (or `--yes`), and pre-paid-call printing of provider/model/host, template digest, threshold, call count, timeout, and cost warning.
- **24 source-free, human-reviewed labeled pairs** (12 semantic matches / 12 nonmatches) covering materially different wording, related-but-distinct bugs, negation, same class across components, severity disagreement, locationless findings, delimiter injection, and plausible near misses — with provenance documented in `PROVENANCE.md`.
- **Orchestrator** drives the exact packaged client/prompt/threshold/endpoint/retry/timeout path three times per pair (72-call budget max).
- **Pass gate**: every pair's majority label correct, balanced accuracy >= 0.90, and no pair crosses the 0.7 threshold more than once.
- **Deterministic atomic receipt** (label/template digests, provider/model/host, attempts, confusion matrix, disagreements, timestamp; never credentials or repo source) with fail-closed invalidation on any recorded input change — required by #781's Oracle/run.
- Configurable/host-validated judge client-builder with injected template loader.

### Test plan
- `test_benchmark_calibrate.py` covers pass, accuracy failure, instability failure, confirmation, receipt invalidation, and zero source leakage via fake endpoints. **27 passed**.
- Full suite: `make check` **4468 passed, 11 skipped, rc=0**.

A real configured endpoint run remains an explicit paid maintainer gate (out of scope here). Calibration does not tune the threshold or modify labels.

Closes #822