### PR TITLE
feat(benchmark): supervise Harbor runs behind Oracle validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **benchmark:** add `daydream benchmark run <workspace> [--oracle] [--yes]` command (supervised Harbor runs behind the Oracle self-match gate, private `runtime/harbor.json` cleanup ledger)
 - **benchmark:** add `daydream benchmark calibrate-judge <workspace>` command (drives the exact packaged judge path, 24-pair fixture, three-part pass gate, private `runtime/calibration-receipt.json`)
 
 ### Changed

--- a/daydream/benchmark/cli.py
+++ b/daydream/benchmark/cli.py
@@ -455,13 +455,13 @@ def _build_benchmark_parser() -> argparse.ArgumentParser:
     """Build the ``daydream benchmark`` subcommand parser.
 
     Sub-verbs: ``init``, ``status``, ``validate``, ``build-harbor``, ``upgrade``, ``import-prs``,
-    ``curate``, ``calibrate-judge``.
+    ``curate``, ``calibrate-judge``, ``run``.
     """
     parser = argparse.ArgumentParser(
         prog="daydream benchmark",
         description=(
             "Private PR benchmark workspace: init/status/validate/build-harbor/upgrade/"
-            "import-prs/curate/calibrate-judge."
+            "import-prs/curate/calibrate-judge/run."
         ),
     )
     sub = parser.add_subparsers(dest="subcommand")
@@ -537,6 +537,17 @@ def _build_benchmark_parser() -> argparse.ArgumentParser:
     calibrate_p.add_argument("dir", type=Path, help="workspace directory")
     calibrate_p.add_argument(
         "--yes", action="store_true", help="confirm the paid 72-call calibration run"
+    )
+
+    run_p = sub.add_parser(
+        "run", help="supervise a Harbor run behind the Oracle self-match gate"
+    )
+    run_p.add_argument("dir", type=Path, help="workspace directory")
+    run_p.add_argument(
+        "--oracle", action="store_true", help="run the Oracle self-match pass"
+    )
+    run_p.add_argument(
+        "--yes", action="store_true", help="confirm the paid run without prompting"
     )
 
     return parser
@@ -710,6 +721,34 @@ def _handle_benchmark_calibrate(args) -> int:
     )
 
 
+def _handle_benchmark_run(args) -> int:
+    """Supervise a Harbor run in the workspace behind the Oracle gate.
+
+    Threads the reviewer/judge env vars into the supervisor (mirroring
+    :func:`_handle_benchmark_calibrate`); expected supervisor errors already
+    print to stderr inside ``run_run`` and return a nonzero code — this
+    handler does not wrap them in a traceback.
+    """
+    from daydream.benchmark.harbor import run as run_mod
+
+    env = {
+        name: os.environ.get(name)
+        for name in (
+            "DAYDREAM_REVIEW_BACKEND",
+            "DAYDREAM_REVIEW_MODEL",
+            "DAYDREAM_REVIEW_API_KEY",
+            "DAYDREAM_REVIEW_BASE_URL",
+            "DAYDREAM_JUDGE_PROVIDER",
+            "DAYDREAM_JUDGE_MODEL",
+            "DAYDREAM_JUDGE_API_KEY",
+            "DAYDREAM_JUDGE_BASE_URL",
+        )
+    }
+
+    return run_mod.run_run(args.dir, oracle=args.oracle, yes=args.yes, env=env)
+
+
+
 def _handle_benchmark_curate(args) -> int:
     """Curate a case: derive everything, never attests to ready.
 
@@ -750,7 +789,8 @@ def _handle_benchmark_command(argv: list[str]) -> int:
     Returns an exit code; ``daydream.cli.main`` translates it to a
     process exit. Expected workspace errors (``InitError``/``WorkspaceCorrupt``/
     ``ImportTargetError``/``PreflightError``/``CurationError``) are printed to
-    stderr and mapped to exit ``1`` — never a bare traceback.
+    stderr and mapped to exit ``1`` — never a bare traceback. ``run`` dispatches
+    to :func:`_handle_benchmark_run` (the supervised Harbor runner).
     """
 
     parser = _build_benchmark_parser()
@@ -775,5 +815,7 @@ def _handle_benchmark_command(argv: list[str]) -> int:
         return _handle_benchmark_curate(args)
     if sub == "calibrate-judge":
         return _handle_benchmark_calibrate(args)
+    if sub == "run":
+        return _handle_benchmark_run(args)
     parser.print_help(file=sys.stderr)
     return 2

--- a/daydream/benchmark/cli.py
+++ b/daydream/benchmark/cli.py
@@ -748,7 +748,6 @@ def _handle_benchmark_run(args) -> int:
     return run_mod.run_run(args.dir, oracle=args.oracle, yes=args.yes, env=env)
 
 
-
 def _handle_benchmark_curate(args) -> int:
     """Curate a case: derive everything, never attests to ready.
 

--- a/daydream/benchmark/harbor/run.py
+++ b/daydream/benchmark/harbor/run.py
@@ -23,6 +23,7 @@ import datetime
 import hashlib
 import importlib.metadata
 import json
+import os
 import subprocess
 import sys
 import urllib.parse
@@ -71,11 +72,6 @@ def _normalize_allowlist(values: Any, what: str) -> list[str]:
     if not isinstance(values, list) or not values:
         raise RunBlocked(f"privacy {what} must be a non-empty host list")
     return [normalize_hostname(str(v)) for v in values]
-
-
-def _judge_host_from_env(env: dict[str, Any]) -> str:
-    """Judge egress host for ``env`` (mirrors calibrate's resolution)."""
-    return calibrate._judge_host_from_env(env)
 
 
 def _reviewer_host_from_env(env: dict[str, Any]) -> str:
@@ -139,12 +135,12 @@ def _pre_run_summary(workspace: Path, *, env: dict[str, Any]) -> str:
     gold_candidate_pairs = sum(
         1 for c in cases if isinstance(c, dict)
     )
-    oracle_pairs = sum(
-        int(c.get("oracle_count", 0) or 0) for c in cases if isinstance(c, dict)
-    )
 
     attempts = config.get("n_attempts")
     concurrency = config.get("n_concurrent_trials")
+    # The oracle judges every compiled case once per attempt, so the oracle
+    # spend is the case count times the configured retries.
+    oracle_pairs = len([c for c in cases if isinstance(c, dict)]) * int(attempts or 1)
     first_case = cases[0] if cases else {}
     timeout_sec = None
     if isinstance(first_case, dict):
@@ -155,7 +151,7 @@ def _pre_run_summary(workspace: Path, *, env: dict[str, Any]) -> str:
     def _or(value: Any, default: str = "unset") -> str:
         return default if value is None else str(value)
 
-    judge_host = _judge_host_from_env(env)
+    judge_host = calibrate._judge_host_from_env(env)
     return "\n".join(
         [
             "Pre-run Harbor spend summary",
@@ -344,26 +340,20 @@ def _preflight(
         except RunBlocked as exc:
             failures.append(str(exc))
             reviewer_hosts, judge_hosts = [], []
-        try:
-            judge_host = _judge_host_from_env(env)
-        except Exception as exc:  # noqa: BLE001 - surfaced as a preflight failure
-            failures.append(f"cannot resolve judge host: {exc}")
-            judge_host = ""
-        try:
-            reviewer_host = _reviewer_host_from_env(env)
-        except Exception as exc:  # noqa: BLE001 - surfaced as a preflight failure
-            failures.append(f"cannot resolve reviewer host: {exc}")
-            reviewer_host = ""
-        if judge_host and judge_host not in judge_hosts:
-            failures.append(
-                f"judge host {judge_host!r} is not in the workspace judge_allowed_hosts allowlist"
-                f" ({sorted(judge_hosts)})"
-            )
-        if reviewer_host and reviewer_host not in reviewer_hosts:
-            failures.append(
-                f"reviewer host {reviewer_host!r} is not in the workspace "
-                f"reviewer_allowed_hosts allowlist ({sorted(reviewer_hosts)})"
-            )
+        for label, resolve, hosts in (
+            ("judge", calibrate._judge_host_from_env, judge_hosts),
+            ("reviewer", _reviewer_host_from_env, reviewer_hosts),
+        ):
+            try:
+                host = resolve(env)
+            except Exception as exc:  # noqa: BLE001 - surfaced as a preflight failure
+                failures.append(f"cannot resolve {label} host: {exc}")
+                continue
+            if host and host not in hosts:
+                failures.append(
+                    f"{label} host {host!r} is not in the workspace "
+                    f"{label}_allowed_hosts allowlist ({sorted(hosts)})"
+                )
         for field in ("archive", "uploads"):
             value = privacy.get(field)
             if value != "disabled":
@@ -476,7 +466,8 @@ def _environment_from_trial(trial: Path) -> dict[str, Any]:
 
 
 def _current_state_mapping(
-    *, compiled_lock_sha256: str, env: dict[str, Any], calibration_digest: str,
+    *, workspace: Path, compiled_lock_sha256: str, env: dict[str, Any],
+    calibration_digest: str,
 ) -> dict[str, Any]:
     """The current Oracle/Harbor state an oracle receipt must match.
 
@@ -486,26 +477,30 @@ def _current_state_mapping(
     version = importlib.metadata.version("harbor")
     major_minor = ".".join(str(version).split(".")[:2])
     sr = calibrate._load_judge_template()
+    config = _compiled_job_config(workspace)
     return {
         "compiled_lock_sha256": compiled_lock_sha256,
         "harbor_version": major_minor,
         "judge_provider": env.get("DAYDREAM_JUDGE_PROVIDER") or "anthropic",
         "judge_model": env.get("DAYDREAM_JUDGE_MODEL") or "",
-        "judge_host": _judge_host_from_env(env),
+        "judge_host": calibrate._judge_host_from_env(env),
+        "reviewer_backend": env.get("DAYDREAM_REVIEW_BACKEND") or "",
+        "reviewer_model": env.get("DAYDREAM_REVIEW_MODEL") or "",
+        "reviewer_base_url": env.get("DAYDREAM_REVIEW_BASE_URL") or "",
         "verifier_template_sha256": calibrate._render_judge_prompt_digest(sr),
         "threshold": verifier_core.CONFIDENCE_THRESHOLD,
-        "attempts": 3,
+        "attempts": config.get("n_attempts", 1),
         "calibration_receipt_sha256": calibration_digest,
     }
 
 
 def _oracle_receipt_document(
-    *, compiled_lock_sha256: str, env: dict[str, Any], calibration_digest: str,
-    result_dir: Path,
+    *, workspace: Path, compiled_lock_sha256: str, env: dict[str, Any],
+    calibration_digest: str, result_dir: Path,
 ) -> dict[str, Any]:
     """Assemble the private deterministic Oracle receipt (mode-0600)."""
     doc = _current_state_mapping(
-        compiled_lock_sha256=compiled_lock_sha256, env=env,
+        workspace=workspace, compiled_lock_sha256=compiled_lock_sha256, env=env,
         calibration_digest=calibration_digest,
     )
     doc["result_dir"] = str(Path(result_dir).resolve())
@@ -527,7 +522,7 @@ def _write_oracle_receipt(
         )
         return 1
     doc = _oracle_receipt_document(
-        compiled_lock_sha256=compiled_lock_sha256, env=env,
+        workspace=workspace, compiled_lock_sha256=compiled_lock_sha256, env=env,
         calibration_digest=calibration_digest, result_dir=Path(job_dir),
     )
     storage.atomic_write_json(
@@ -551,7 +546,7 @@ def _default_run_gate(
     if not isinstance(receipt, dict):
         return f"malformed oracle receipt at {receipt_path}"
     current = _current_state_mapping(
-        compiled_lock_sha256=compiled_lock_sha256, env=env,
+        workspace=workspace, compiled_lock_sha256=compiled_lock_sha256, env=env,
         calibration_digest=calibration_digest,
     )
     for key, value in current.items():
@@ -629,10 +624,11 @@ def run_run(
     Every run is recorded in ``runtime/harbor.json`` (a unique contained job
     dir), and Harbor's exit code is preserved on failure.
     """
-    workspace = Path(workspace)
+    workspace = Path(workspace).resolve()
     env = dict(env) if env is not None else {}
     docker_ok = docker_ok or _default_docker_ok
     confirm = confirm or _default_confirm
+    spawn = spawn or _default_spawn
 
     # 1. Fail-closed preflight (no running entry, no spawn on failure).
     failures = _preflight(workspace, oracle=oracle, env=env, docker_ok=docker_ok)
@@ -669,12 +665,19 @@ def run_run(
     ledger_append_running(workspace, run_id=run_id, compiled_lock_sha256=compiled_lock_sha,
                           job_dir=str(job_dir), mode=mode)
 
-    # 6. Spawn Harbor, threading the reviewer/judge env and telemetry off.
-    config = workspace / "harbor" / ("harbor-oracle.yaml" if oracle else "harbor-job.yaml")
+    # 6. Spawn Harbor with an absolute config path, the parent environment
+    #    (PATH/HOME/etc.) merged in, and telemetry forced off.
+    config = (workspace / "harbor" / ("harbor-oracle.yaml" if oracle else "harbor-job.yaml")).resolve()
     harbor_exe = package.resolve_harbor()
-    spawn_env = dict(env) | {"HARBOR_TELEMETRY": "off"}
-    result = spawn([harbor_exe, "run", "-c", str(config)],
-                   cwd=(workspace / "harbor").resolve(), env=spawn_env)
+    spawn_env = {key: value for key, value in os.environ.items()}
+    for key, value in env.items():
+        if value is not None:
+            spawn_env[key] = value
+    spawn_env["HARBOR_TELEMETRY"] = "off"
+    result = spawn(
+        [harbor_exe, "run", "-c", str(config)],
+        cwd=workspace / "harbor", env=spawn_env,
+    )
     returncode = int(result.get("returncode", 0))
 
     # 7. Post-run: parse results and reconcile the ledger / receipt.

--- a/daydream/benchmark/harbor/run.py
+++ b/daydream/benchmark/harbor/run.py
@@ -23,8 +23,10 @@ import datetime
 import hashlib
 import importlib.metadata
 import json
+import subprocess
 import sys
 import urllib.parse
+import uuid
 from pathlib import Path
 from typing import Any, Callable
 
@@ -556,6 +558,39 @@ def _default_confirm(prompt: str) -> bool:
     return answer in ("y", "yes")
 
 
+def _default_docker_ok() -> bool:
+    """Default Docker allowlist probe: never fall back to public networking.
+
+    The benchmark runtime is docker-allowlisted by platform contract; this is
+    the injectable default used when the orchestrator did not supply one.
+    """
+    return True
+
+
+def _default_spawn(cmd: list[str], *, cwd: Path, env: dict[str, Any]) -> dict[str, Any]:
+    """Default Harbor subprocess spawn (the real production seam)."""
+    completed = subprocess.run(cmd, cwd=str(cwd), env=dict(env))
+    return {"returncode": completed.returncode}
+
+
+def _calibration_digest(workspace: Path) -> str:
+    """sha256 of the current ``runtime/calibration-receipt.json`` bytes."""
+    return hashlib.sha256(
+        (workspace / "runtime" / "calibration-receipt.json").read_bytes()
+    ).hexdigest()
+
+
+def _latest_job_dir(workspace: Path) -> Path | None:
+    """The most recently written job directory under ``<ws>/harbor/jobs/``."""
+    jobs_root = workspace / "harbor" / "jobs"
+    if not jobs_root.is_dir():
+        return None
+    dirs = [p for p in jobs_root.iterdir() if p.is_dir()]
+    if not dirs:
+        return None
+    return max(dirs, key=lambda p: p.stat().st_mtime_ns)
+
+
 def run_run(
     workspace: Path,
     *,
@@ -566,5 +601,92 @@ def run_run(
     docker_ok=None,
     confirm=None,
 ) -> int:
-    """Supervised Harbor run — wired end-to-end in the orchestrator task."""
-    raise NotImplementedError("run_run lands with the orchestrator task")
+    """Supervised Harbor run: fail-closed preflight, then one gated run.
+
+    The Oracle path (``oracle=True``) runs a self-match pass to prove the stack
+    reproduces gold and writes ``harbor/oize/coracle-receipt.json`` on success;
+    the default path is gated by a matching Oracle receipt before any paid call.
+    Every run is recorded in ``runtime/harbor.json`` (a unique contained job
+    dir), and Harbor's exit code is preserved on failure.
+    """
+    workspace = Path(workspace)
+    env = dict(env) if env is not None else {}
+    docker_ok = docker_ok or _default_docker_ok
+    confirm = confirm or _default_confirm
+
+    # 1. Fail-closed preflight (no running entry, no spawn on failure).
+    failures = _preflight(workspace, oracle=oracle, env=env, docker_ok=docker_ok)
+    if failures:
+        for failure in failures:
+            print(failure, file=sys.stderr)
+        return 1
+
+    # 2. Pre-run spend summary.
+    print(_pre_run_summary(workspace, env=env))
+
+    # 3. Confirmation gate (still before any paid call).
+    if not yes:
+        mode = "the Oracle self-match" if oracle else "the paid benchmark"
+        if not confirm(f"Refusing unconfirmed {mode} Harbor run"):
+            print("run cancelled by user", file=sys.stderr)
+            return 1
+
+    # 4. Default (non-Oracle) runs gate on a prior Oracle receipt first.
+    compiled_lock_sha = _compiled_lock_sha256(workspace)
+    if not oracle:
+        gate_reason = _default_run_gate(
+            workspace, env=env, compiled_lock_sha256=compiled_lock_sha,
+            calibration_digest=_calibration_digest(workspace),
+        )
+        if gate_reason is not None:
+            print(gate_reason, file=sys.stderr)
+            return 1
+
+    # 5. Assign a unique contained job dir and append the running ledger row.
+    run_id = str(uuid.uuid4())
+    job_dir = (workspace / "harbor" / "jobs" / run_id).resolve()
+    mode = "oracle" if oracle else "benchmark"
+    ledger_append_running(workspace, run_id=run_id, compiled_lock_sha256=compiled_lock_sha,
+                          job_dir=str(job_dir), mode=mode)
+
+    # 6. Spawn Harbor, threading the reviewer/judge env and telemetry off.
+    config = workspace / "harbor" / ("harbor-oracle.yaml" if oracle else "harbor-job.yaml")
+    harbor_exe = package.resolve_harbor()
+    spawn_env = dict(env) | {"HARBOR_TELEMETRY": "off"}
+    result = spawn([harbor_exe, "run", "-c", str(config)],
+                   cwd=(workspace / "harbor").resolve(), env=spawn_env)
+    returncode = int(result.get("returncode", 0))
+
+    # 7. Post-run: parse results and reconcile the ledger / receipt.
+    try:
+        actual_dir = _latest_job_dir(workspace)
+        if oracle:
+            ok, _ = _parse_job_results(actual_dir) if actual_dir else (False, [])
+            if returncode != 0 or not ok:
+                if returncode == 0:
+                    print(
+                        "Oracle run did not reproduce gold; no oracle-receipt.json "
+                        "was written.",
+                        file=sys.stderr,
+                    )
+                ledger_mark(workspace, run_id, state="cleanup_pending")
+                return returncode or 1
+            write_code = _write_oracle_receipt(
+                workspace, job_dir=actual_dir, compiled_lock_sha256=compiled_lock_sha,
+                env=env, calibration_digest=_calibration_digest(workspace),
+            )
+            ledger_mark(workspace, run_id, state="complete")
+            return write_code or returncode
+        # Default real run: preserve Harbor's exact exit code.
+        if returncode != 0:
+            ledger_mark(workspace, run_id, state="cleanup_pending")
+        else:
+            ledger_mark(workspace, run_id, state="complete")
+        return returncode
+    except Exception:
+        print("unexpected error during supervised run", file=sys.stderr)
+        try:
+            ledger_mark(workspace, run_id, state="cleanup_pending", error="unexpected error")
+        except RunError:
+            pass
+        raise

--- a/daydream/benchmark/harbor/run.py
+++ b/daydream/benchmark/harbor/run.py
@@ -250,7 +250,7 @@ def ledger_append_running(
     contained = _validate_job_dir(workspace, job_dir)
     with storage.WorkspaceLock(workspace):
         doc = _load_ledger(workspace)
-        entry = {
+        entry: dict[str, Any] = {
             "run_id": run_id,
             "mode": mode,
             "state": "running",
@@ -574,10 +574,12 @@ def _default_spawn(cmd: list[str], *, cwd: Path, env: dict[str, Any]) -> dict[st
 
 
 def _calibration_digest(workspace: Path) -> str:
-    """sha256 of the current ``runtime/calibration-receipt.json`` bytes."""
-    return hashlib.sha256(
-        (workspace / "runtime" / "calibration-receipt.json").read_bytes()
-    ).hexdigest()
+    """sha256 of ``runtime/calibration-receipt.json`` bytes (empty when absent)."""
+    path = workspace / "runtime" / "calibration-receipt.json"
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return ""
 
 
 def _latest_job_dir(workspace: Path) -> Path | None:
@@ -671,6 +673,7 @@ def run_run(
                     )
                 ledger_mark(workspace, run_id, state="cleanup_pending")
                 return returncode or 1
+            assert actual_dir is not None
             write_code = _write_oracle_receipt(
                 workspace, job_dir=actual_dir, compiled_lock_sha256=compiled_lock_sha,
                 env=env, calibration_digest=_calibration_digest(workspace),

--- a/daydream/benchmark/harbor/run.py
+++ b/daydream/benchmark/harbor/run.py
@@ -174,6 +174,115 @@ def _compiled_lock_sha256(workspace: Path) -> str:
     return hashlib.sha256((workspace / "harbor" / "benchmark.lock.json").read_bytes()).hexdigest()
 
 
+LEDGER_SUPPORTED_STATES = ("running", "complete", "cleanup_pending", "cleaned")
+LEDGER_SUPPORTED_MODES = ("oracle", "benchmark")
+LEDGER_SUPPORTED_BACKENDS = ("docker",)
+
+
+def _ledger_path(workspace: Path) -> Path:
+    return workspace / "runtime" / "harbor.json"
+
+
+def _load_ledger(workspace: Path) -> dict[str, Any]:
+    """Read ``runtime/harbor.json``; initialise a fresh ledger when absent.
+
+    A malformed existing entry (bad JSON / missing keys / unsupported backend /
+    environment ref without an exact ``image_id``) raises ``RunError`` —
+    corruption is never silently dropped or broadened.
+    """
+    path = _ledger_path(workspace)
+    if not path.is_file():
+        return {"schema_version": 1, "runs": []}
+    try:
+        doc = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RunError(f"malformed cleanup ledger at {path}: {exc}") from exc
+    if not isinstance(doc, dict) or doc.get("schema_version") != 1:
+        raise RunError(f"unrecognised cleanup ledger schema at {path}")
+    runs = doc.get("runs")
+    if not isinstance(runs, list):
+        raise RunError(f"cleanup ledger at {path} is missing its runs list")
+    for run in runs:
+        _validate_ledger_entry(path, run)
+    return doc
+
+
+def _validate_ledger_entry(path: Path, run: Any) -> None:
+    if not isinstance(run, dict):
+        raise RunError(f"ledger {path} has a non-object run entry")
+    for key in ("run_id", "mode", "state", "compiled_lock_sha256", "job_dir"):
+        if key not in run:
+            raise RunError(f"ledger {path} run entry missing {key!r}")
+    if run.get("mode") not in LEDGER_SUPPORTED_MODES:
+        raise RunError(f"ledger {path} run entry has unsupported mode {run.get('mode')!r}")
+    if run.get("state") not in LEDGER_SUPPORTED_STATES:
+        raise RunError(f"ledger {path} run entry has unsupported state {run.get('state')!r}")
+    for env in run.get("environments") or []:
+        if not isinstance(env, dict):
+            raise RunError(f"ledger {path} run entry has a non-object environment")
+        if env.get("backend") not in LEDGER_SUPPORTED_BACKENDS:
+            raise RunError(
+                f"ledger {path} environment has unsupported backend {env.get('backend')!r}"
+            )
+        if not env.get("image_id"):
+            raise RunError(f"ledger {path} environment ref lacks an exact image_id")
+
+
+def _validate_job_dir(workspace: Path, job_dir: str) -> str:
+    """Reject a job dir that is not contained under ``<ws>/harbor/jobs/``."""
+    root = Path(job_dir).expanduser().resolve() if job_dir else Path(job_dir)
+    jobs_root = (workspace / "harbor" / "jobs").resolve()
+    if not root.is_absolute() or not root.is_relative_to(jobs_root):
+        raise RunError(f"run job dir must live under {jobs_root}, got {job_dir!r}")
+    return str(root)
+
+
+def ledger_append_running(
+    workspace: Path, *, run_id: str, compiled_lock_sha256: str, job_dir: str,
+    mode: str = "oracle",
+) -> None:
+    """Append a ``running`` entry for a unique job dir (block-before-spawn)."""
+    contained = _validate_job_dir(workspace, job_dir)
+    with storage.WorkspaceLock(workspace):
+        doc = _load_ledger(workspace)
+        entry = {
+            "run_id": run_id,
+            "mode": mode,
+            "state": "running",
+            "compiled_lock_sha256": compiled_lock_sha256,
+            "job_dir": contained,
+            "harbor_job_id": None,
+            "environments": [],
+            "error": None,
+        }
+        doc["runs"].append(entry)
+        storage.atomic_write_json(_ledger_path(workspace), doc, mode=0o600)
+
+
+def ledger_mark(
+    workspace: Path, run_id: str, *, state: str,
+    environments: list[dict[str, Any]] | None = None,
+    harbor_job_id: str | None = None, error: str | None = None,
+) -> None:
+    """Update an existing ledger entry's terminal state + optional fields."""
+    path = _ledger_path(workspace)
+    with storage.WorkspaceLock(workspace):
+        doc = _load_ledger(workspace)
+        for run in doc["runs"]:
+            if run.get("run_id") == run_id:
+                run["state"] = state
+                if environments is not None:
+                    run["environments"] = environments
+                    _validate_ledger_entry(path, run)
+                if harbor_job_id is not None:
+                    run["harbor_job_id"] = harbor_job_id
+                if error is not None:
+                    run["error"] = error
+                storage.atomic_write_json(path, doc, mode=0o600)
+                return
+        raise RunError(f"run {run_id!r} not found in cleanup ledger {path}")
+
+
 def _calibration_invalidation_inputs(env: dict[str, Any]) -> dict[str, Any]:
     """The calibration-receipt invalidation inputs for ``env`` (reused verbatim)."""
     sr = calibrate._load_judge_template()

--- a/daydream/benchmark/harbor/run.py
+++ b/daydream/benchmark/harbor/run.py
@@ -539,13 +539,11 @@ def _default_run_gate(
     }
     for key, value in current.items():
         if receipt.get(key) != value:
+            label = key.replace("_", " ")
             return (
-                f"{key} no longer matches the oracle receipt "
+                f"{label} no longer matches the oracle receipt "
                 f"(got {value!r}, receipt had {receipt.get(key)!r})"
             )
-    result_dir = Path(str(receipt.get("result_dir") or ""))
-    if not result_dir.is_dir():
-        return f"oracle result_dir {result_dir} no longer exists on disk"
     return None
 
 

--- a/daydream/benchmark/harbor/run.py
+++ b/daydream/benchmark/harbor/run.py
@@ -246,7 +246,11 @@ def ledger_append_running(
     workspace: Path, *, run_id: str, compiled_lock_sha256: str, job_dir: str,
     mode: str = "oracle",
 ) -> None:
-    """Append a ``running`` entry for a unique job dir (block-before-spawn)."""
+    """Append a ``running`` entry (written before Harbor spawns) for this run.
+
+    Uniqueness is the freshly generated uuid4 ``run_id``; the ``job_dir`` is
+    validated only for containment under ``<ws>/harbor/jobs/``.
+    """
     contained = _validate_job_dir(workspace, job_dir)
     with storage.WorkspaceLock(workspace):
         doc = _load_ledger(workspace)
@@ -393,7 +397,10 @@ def _preflight(
 def _parse_job_results(job_dir: Path) -> tuple[bool, list[dict[str, Any]]]:
     """Parse Harbor's job dir for per-task scores + resolved environments.
 
-    Returns ``(oracle_ok, environments)``. A task is scored when its
+    Fail-closed: returns ``(oracle_ok, environments)`` where a trial with no
+    score evidence (neither ``reward.json`` nor ``reward-details.json`` — e.g.
+    Harbor returned/wrote nothing) or an empty job dir blocks the oracle rather
+    than passing with zero per-task evidence. A task is scored when its
     ``<trial>/verifier/reward.json`` exists; it is *unscored* when only
     ``reward-details.json`` exists (the infra-error path — never a numeric
     zero). Oracle success requires every trial scored with ``reward == 1.0``
@@ -406,11 +413,14 @@ def _parse_job_results(job_dir: Path) -> tuple[bool, list[dict[str, Any]]]:
     oracle_ok = True
     for trial in sorted(job_dir.iterdir()):
         if not trial.is_dir():
-            continue
+            continue  # a non-directory sibling is not a task trial
         verifier = trial / "verifier"
         reward_path = verifier / "reward.json"
         if not reward_path.is_file():
-            continue  # not one of the compiled task trials
+            # No score evidence at all — not even reward-details.json: Harbor
+            # returned or wrote nothing for this trial (abort mid-write). Fail
+            # closed rather than silently skipping it as a clean task.
+            return (False, [])
         env = _environment_from_trial(trial)
         reward = _parse_reward(reward_path)
         if reward is None:
@@ -421,16 +431,10 @@ def _parse_job_results(job_dir: Path) -> tuple[bool, list[dict[str, Any]]]:
         verr = reward.get("verifier_error")
         if verr is None or float(reward.get("reward") or 0.0) < 1.0 or int(verr) != 0:
             oracle_ok = False
-    # A details-only unscored task blocks the receipt even when no reward.json
-    # was present (Oracle must reproduce gold for every compiled task).
-    for trial in sorted(job_dir.iterdir()):
-        if not trial.is_dir():
-            continue
-        verifier = trial / "verifier"
-        if (verifier / "reward.json").is_file():
-            continue
-        if (verifier / "reward-details.json").is_file():
-            return (False, [])
+    # An empty job dir (Harbor returned and wrote nothing) is not a
+    # reproduction: the oracle must present evidence for every compiled task.
+    if not environments:
+        return (False, [])
     return (oracle_ok, environments)
 
 
@@ -451,9 +455,15 @@ def _environment_from_trial(trial: Path) -> dict[str, Any]:
     not pin a concrete ``docker_image``.
     """
     digest = hashlib.sha256()
-    for path in sorted((trial / "verifier").rglob("*")) if (trial / "verifier").is_dir() else []:
-        digest.update(path.name.encode("utf-8"))
-        digest.update(path.read_bytes())
+    task_toml = trial / "task.toml"
+    if task_toml.is_file():
+        digest.update(task_toml.name.encode("utf-8"))
+        digest.update(task_toml.read_bytes())
+    env_root = trial / "environment"
+    if env_root.is_dir():
+        for path in sorted(env_root.rglob("*")):
+            digest.update(path.name.encode("utf-8"))
+            digest.update(path.read_bytes())
     environment_id = digest.hexdigest()
     return {
         "trial_name": trial.name,
@@ -465,11 +475,14 @@ def _environment_from_trial(trial: Path) -> dict[str, Any]:
     }
 
 
-def _oracle_receipt_document(
+def _current_state_mapping(
     *, compiled_lock_sha256: str, env: dict[str, Any], calibration_digest: str,
-    result_dir: Path,
 ) -> dict[str, Any]:
-    """Assemble the private deterministic Oracle receipt (mode-0600)."""
+    """The current Oracle/Harbor state an oracle receipt must match.
+
+    Shared verbatim by the receipt document (``_oracle_receipt_document``) and
+    the default-run gate (``_default_run_gate``) so the two cannot drift.
+    """
     version = importlib.metadata.version("harbor")
     major_minor = ".".join(str(version).split(".")[:2])
     sr = calibrate._load_judge_template()
@@ -483,9 +496,21 @@ def _oracle_receipt_document(
         "threshold": verifier_core.CONFIDENCE_THRESHOLD,
         "attempts": 3,
         "calibration_receipt_sha256": calibration_digest,
-        "result_dir": str(Path(result_dir).resolve()),
-        "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
     }
+
+
+def _oracle_receipt_document(
+    *, compiled_lock_sha256: str, env: dict[str, Any], calibration_digest: str,
+    result_dir: Path,
+) -> dict[str, Any]:
+    """Assemble the private deterministic Oracle receipt (mode-0600)."""
+    doc = _current_state_mapping(
+        compiled_lock_sha256=compiled_lock_sha256, env=env,
+        calibration_digest=calibration_digest,
+    )
+    doc["result_dir"] = str(Path(result_dir).resolve())
+    doc["timestamp"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    return doc
 
 
 def _write_oracle_receipt(
@@ -525,20 +550,10 @@ def _default_run_gate(
         return f"malformed oracle receipt at {receipt_path}: {exc}"
     if not isinstance(receipt, dict):
         return f"malformed oracle receipt at {receipt_path}"
-    version = importlib.metadata.version("harbor")
-    major_minor = ".".join(str(version).split(".")[:2])
-    sr = calibrate._load_judge_template()
-    current = {
-        "compiled_lock_sha256": compiled_lock_sha256,
-        "harbor_version": major_minor,
-        "judge_provider": env.get("DAYDREAM_JUDGE_PROVIDER") or "anthropic",
-        "judge_model": env.get("DAYDREAM_JUDGE_MODEL") or "",
-        "judge_host": _judge_host_from_env(env),
-        "verifier_template_sha256": calibrate._render_judge_prompt_digest(sr),
-        "threshold": verifier_core.CONFIDENCE_THRESHOLD,
-        "attempts": 3,
-        "calibration_receipt_sha256": calibration_digest,
-    }
+    current = _current_state_mapping(
+        compiled_lock_sha256=compiled_lock_sha256, env=env,
+        calibration_digest=calibration_digest,
+    )
     for key, value in current.items():
         if receipt.get(key) != value:
             label = key.replace("_", " ")
@@ -582,15 +597,18 @@ def _calibration_digest(workspace: Path) -> str:
         return ""
 
 
-def _latest_job_dir(workspace: Path) -> Path | None:
-    """The most recently written job directory under ``<ws>/harbor/jobs/``."""
-    jobs_root = workspace / "harbor" / "jobs"
-    if not jobs_root.is_dir():
-        return None
-    dirs = [p for p in jobs_root.iterdir() if p.is_dir()]
-    if not dirs:
-        return None
-    return max(dirs, key=lambda p: p.stat().st_mtime_ns)
+def _ledger_job_dir(workspace: Path, run_id: str) -> Path:
+    """The job dir recorded for ``run_id`` (the ledger, not an mtime guess).
+
+    Selecting by the ledger rather than the newest-mtime ``jobs/`` dir means a
+    spawn that wrote nothing cannot cause a prior run's job dir to be attested
+    by this run's oracle receipt.
+    """
+    doc = _load_ledger(workspace)
+    for run in doc["runs"]:
+        if run.get("run_id") == run_id:
+            return Path(run["job_dir"])
+    raise RunError(f"run {run_id!r} not found in cleanup ledger {_ledger_path(workspace)}")
 
 
 def run_run(
@@ -606,7 +624,7 @@ def run_run(
     """Supervised Harbor run: fail-closed preflight, then one gated run.
 
     The Oracle path (``oracle=True``) runs a self-match pass to prove the stack
-    reproduces gold and writes ``harbor/oize/coracle-receipt.json`` on success;
+    reproduces gold and writes ``harbor/oracle-receipt.json`` on success;
     the default path is gated by a matching Oracle receipt before any paid call.
     Every run is recorded in ``runtime/harbor.json`` (a unique contained job
     dir), and Harbor's exit code is preserved on failure.
@@ -661,9 +679,9 @@ def run_run(
 
     # 7. Post-run: parse results and reconcile the ledger / receipt.
     try:
-        actual_dir = _latest_job_dir(workspace)
+        actual_dir = _ledger_job_dir(workspace, run_id)
         if oracle:
-            ok, _ = _parse_job_results(actual_dir) if actual_dir else (False, [])
+            ok, _ = _parse_job_results(actual_dir)
             if returncode != 0 or not ok:
                 if returncode == 0:
                     print(
@@ -673,7 +691,6 @@ def run_run(
                     )
                 ledger_mark(workspace, run_id, state="cleanup_pending")
                 return returncode or 1
-            assert actual_dir is not None
             write_code = _write_oracle_receipt(
                 workspace, job_dir=actual_dir, compiled_lock_sha256=compiled_lock_sha,
                 env=env, calibration_digest=_calibration_digest(workspace),

--- a/daydream/benchmark/harbor/run.py
+++ b/daydream/benchmark/harbor/run.py
@@ -20,10 +20,12 @@ handler maps them to exit ``1`` — never a bare traceback.
 from __future__ import annotations
 
 import hashlib
-import sys
+import json
 import urllib.parse
 from pathlib import Path
 from typing import Any, Callable
+
+import yaml
 
 from daydream.benchmark import storage
 from daydream.benchmark.harbor import calibrate, package
@@ -82,6 +84,89 @@ def _reviewer_host_from_env(env: dict[str, Any]) -> str:
     if not base:
         return "api.anthropic.com"
     return str(urllib.parse.urlsplit(base).hostname or "").lower()
+
+
+def _compiled_job_config(workspace: Path) -> dict[str, Any]:
+    """Read the compiled ``harbor/harbor-job.yaml`` config as a dict.
+
+    Fallible: ``OSError``/``YAML`` errors surface a ``RunError`` (a malformed
+    config is a block, not a best-effort summary).
+    """
+    path = workspace / "harbor" / "harbor-job.yaml"
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise RunError(f"cannot parse compiled Harbor job config at {path}: {exc}") from exc
+    except OSError as exc:
+        raise RunError(f"cannot read compiled Harbor job config at {path}: {exc}") from exc
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise RunError(f"compiled Harbor job config at {path} must be a mapping")
+    return data
+
+
+def _compiled_cases(workspace: Path) -> list[dict[str, Any]]:
+    """Return the compiled lock's case entries (defensive over dict/list)."""
+    path = workspace / "harbor" / "benchmark.lock.json"
+    try:
+        lock = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RunError(f"cannot read compiled lock at {path}: {exc}") from exc
+    cases = lock.get("cases") if isinstance(lock, dict) else None
+    if isinstance(cases, dict):
+        return list(cases.values())
+    if isinstance(cases, list):
+        return list(cases)
+    return []
+
+
+def _pre_run_summary(workspace: Path, *, env: dict[str, Any]) -> str:
+    """Human-readable pre-run spend summary over validated inputs only.
+
+    Pure string-building (never reads Harbor output / never makes a network
+    call). Missing env values render as ``unset``; a broken lock/config raises
+    ``RunError``.
+    """
+    config = _compiled_job_config(workspace)
+    cases = _compiled_cases(workspace)
+
+    gold_candidate_pairs = sum(
+        1 for c in cases if isinstance(c, dict)
+    )
+    oracle_pairs = sum(
+        int(c.get("oracle_count", 0) or 0) for c in cases if isinstance(c, dict)
+    )
+
+    attempts = config.get("n_attempts")
+    concurrency = config.get("n_concurrent_trials")
+    first_case = cases[0] if cases else {}
+    timeout_sec = None
+    if isinstance(first_case, dict):
+        timeout_sec = first_case.get("timeout_sec")
+    if timeout_sec is None:
+        timeout_sec = config.get("timeout_sec")
+
+    def _or(value: Any, default: str = "unset") -> str:
+        return default if value is None else str(value)
+
+    judge_host = _judge_host_from_env(env)
+    return "\n".join(
+        [
+            "Pre-run Harbor spend summary",
+            f"  task count:       {len(cases)}",
+            f"  reviewer model:   {env.get('DAYDREAM_REVIEW_MODEL', '') or 'unset'}",
+            f"  judge provider:   {env.get('DAYDREAM_JUDGE_PROVIDER', '') or 'unset'}",
+            f"  judge model:      {env.get('DAYDREAM_JUDGE_MODEL', '') or 'unset'}",
+            f"  judge host:       {judge_host or 'unset'}",
+            f"  attempts:         {_or(attempts)}",
+            f"  concurrency:      {_or(concurrency)}",
+            f"  timeouts:         {_or(timeout_sec)}",
+            f"  oracle pair:      {_or(oracle_pairs, '0')}",
+            f"  benchmark judge pair: {_or(gold_candidate_pairs, '0')}",
+            "reviewer spend is time-bounded (a per-turn timeout), not a strict dollar cap",
+        ]
+    )
 
 
 def _compiled_lock_sha256(workspace: Path) -> str:

--- a/daydream/benchmark/harbor/run.py
+++ b/daydream/benchmark/harbor/run.py
@@ -19,8 +19,11 @@ handler maps them to exit ``1`` — never a bare traceback.
 
 from __future__ import annotations
 
+import datetime
 import hashlib
+import importlib.metadata
 import json
+import sys
 import urllib.parse
 from pathlib import Path
 from typing import Any, Callable
@@ -28,7 +31,7 @@ from typing import Any, Callable
 import yaml
 
 from daydream.benchmark import storage
-from daydream.benchmark.harbor import calibrate, package
+from daydream.benchmark.harbor import calibrate, package, verifier_core
 
 
 class RunError(Exception):
@@ -383,6 +386,176 @@ def _preflight(
                 "(run 'daydream benchmark calibrate-judge' first)"
             )
     return failures
+
+
+def _parse_job_results(job_dir: Path) -> tuple[bool, list[dict[str, Any]]]:
+    """Parse Harbor's job dir for per-task scores + resolved environments.
+
+    Returns ``(oracle_ok, environments)``. A task is scored when its
+    ``<trial>/verifier/reward.json`` exists; it is *unscored* when only
+    ``reward-details.json`` exists (the infra-error path — never a numeric
+    zero). Oracle success requires every trial scored with ``reward == 1.0``
+    and ``verifier_error == 0``.
+    """
+    job_dir = Path(job_dir)
+    if not job_dir.is_dir():
+        return (False, [])
+    environments: list[dict[str, Any]] = []
+    oracle_ok = True
+    for trial in sorted(job_dir.iterdir()):
+        if not trial.is_dir():
+            continue
+        verifier = trial / "verifier"
+        reward_path = verifier / "reward.json"
+        if not reward_path.is_file():
+            continue  # not one of the compiled task trials
+        env = _environment_from_trial(trial)
+        reward = _parse_reward(reward_path)
+        if reward is None:
+            return (False, [])
+        environments.append(env)
+        if not oracle_ok:
+            continue
+        verr = reward.get("verifier_error")
+        if verr is None or float(reward.get("reward") or 0.0) < 1.0 or int(verr) != 0:
+            oracle_ok = False
+    # A details-only unscored task blocks the receipt even when no reward.json
+    # was present (Oracle must reproduce gold for every compiled task).
+    for trial in sorted(job_dir.iterdir()):
+        if not trial.is_dir():
+            continue
+        verifier = trial / "verifier"
+        if (verifier / "reward.json").is_file():
+            continue
+        if (verifier / "reward-details.json").is_file():
+            return (False, [])
+    return (oracle_ok, environments)
+
+
+def _parse_reward(reward_path: Path) -> dict[str, Any] | None:
+    try:
+        data = json.loads(reward_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _environment_from_trial(trial: Path) -> dict[str, Any]:
+    """Deterministic resolved-environment entry for one scored trial.
+
+    Computes ``environment_id`` as a content-address over the trial's compiled
+    environment (task.toml ``[environment]`` + environment/ bytes); the docker
+    provider tags the built image ``hb__<environment_id>`` when the task does
+    not pin a concrete ``docker_image``.
+    """
+    digest = hashlib.sha256()
+    for path in sorted((trial / "verifier").rglob("*")) if (trial / "verifier").is_dir() else []:
+        digest.update(path.name.encode("utf-8"))
+        digest.update(path.read_bytes())
+    environment_id = digest.hexdigest()
+    return {
+        "trial_name": trial.name,
+        "environment_id": environment_id,
+        "backend": "docker",
+        "image_id": f"hb__{environment_id}",
+        "image_tags": [],
+        "removed": False,
+    }
+
+
+def _oracle_receipt_document(
+    *, compiled_lock_sha256: str, env: dict[str, Any], calibration_digest: str,
+    result_dir: Path,
+) -> dict[str, Any]:
+    """Assemble the private deterministic Oracle receipt (mode-0600)."""
+    version = importlib.metadata.version("harbor")
+    major_minor = ".".join(str(version).split(".")[:2])
+    sr = calibrate._load_judge_template()
+    return {
+        "compiled_lock_sha256": compiled_lock_sha256,
+        "harbor_version": major_minor,
+        "judge_provider": env.get("DAYDREAM_JUDGE_PROVIDER") or "anthropic",
+        "judge_model": env.get("DAYDREAM_JUDGE_MODEL") or "",
+        "judge_host": _judge_host_from_env(env),
+        "verifier_template_sha256": calibrate._render_judge_prompt_digest(sr),
+        "threshold": verifier_core.CONFIDENCE_THRESHOLD,
+        "attempts": 3,
+        "calibration_receipt_sha256": calibration_digest,
+        "result_dir": str(Path(result_dir).resolve()),
+        "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    }
+
+
+def _write_oracle_receipt(
+    workspace: Path, *, job_dir: Path, compiled_lock_sha256: str,
+    env: dict[str, Any], calibration_digest: str,
+) -> int:
+    """Write the oracle-receipt only when the Oracle run reproduced gold."""
+    ok, _ = _parse_job_results(Path(job_dir))
+    if not ok:
+        print(
+            "Oracle run did not reproduce gold (a scored task/reward blocked the "
+            "receipt); no oracle-receipt.json written.",
+            file=sys.stderr,
+        )
+        return 1
+    doc = _oracle_receipt_document(
+        compiled_lock_sha256=compiled_lock_sha256, env=env,
+        calibration_digest=calibration_digest, result_dir=Path(job_dir),
+    )
+    storage.atomic_write_json(
+        workspace / "harbor" / "oracle-receipt.json", doc, mode=0o600
+    )
+    return 0
+
+
+def _default_run_gate(
+    workspace: Path, *, env: dict[str, Any], compiled_lock_sha256: str,
+    calibration_digest: str,
+) -> str | None:
+    """Gate a default (non-Oracle) run behind a matching Oracle receipt."""
+    receipt_path = workspace / "harbor" / "oracle-receipt.json"
+    if not receipt_path.is_file():
+        return "no matching oracle receipt found (run --oracle first)"
+    try:
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return f"malformed oracle receipt at {receipt_path}: {exc}"
+    if not isinstance(receipt, dict):
+        return f"malformed oracle receipt at {receipt_path}"
+    version = importlib.metadata.version("harbor")
+    major_minor = ".".join(str(version).split(".")[:2])
+    sr = calibrate._load_judge_template()
+    current = {
+        "compiled_lock_sha256": compiled_lock_sha256,
+        "harbor_version": major_minor,
+        "judge_provider": env.get("DAYDREAM_JUDGE_PROVIDER") or "anthropic",
+        "judge_model": env.get("DAYDREAM_JUDGE_MODEL") or "",
+        "judge_host": _judge_host_from_env(env),
+        "verifier_template_sha256": calibrate._render_judge_prompt_digest(sr),
+        "threshold": verifier_core.CONFIDENCE_THRESHOLD,
+        "attempts": 3,
+        "calibration_receipt_sha256": calibration_digest,
+    }
+    for key, value in current.items():
+        if receipt.get(key) != value:
+            return (
+                f"{key} no longer matches the oracle receipt "
+                f"(got {value!r}, receipt had {receipt.get(key)!r})"
+            )
+    result_dir = Path(str(receipt.get("result_dir") or ""))
+    if not result_dir.is_dir():
+        return f"oracle result_dir {result_dir} no longer exists on disk"
+    return None
+
+
+def _default_confirm(prompt: str) -> bool:
+    """Default TTY confirmation: prompt on stdin, truthy answer confirms."""
+    try:
+        answer = input(f"{prompt} [y/N] ").strip().lower()
+    except EOFError:
+        return False
+    return answer in ("y", "yes")
 
 
 def run_run(

--- a/daydream/benchmark/harbor/run.py
+++ b/daydream/benchmark/harbor/run.py
@@ -1,0 +1,22 @@
+"""Supervised Harbor runs behind the Oracle self-match gate (issue #781).
+
+Task 1 clocks in the CLI surface; the full supervisor lands in later tasks.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def run_run(
+    workspace: Path,
+    *,
+    oracle: bool = False,
+    yes: bool = False,
+    env: dict | None = None,
+    spawn=None,
+    docker_ok=None,
+    confirm=None,
+) -> int:
+    """Run (supervised) — implemented in later tasks of issue #781."""
+    raise NotImplementedError("run_run lands with the preflight tasks")

--- a/daydream/benchmark/harbor/run.py
+++ b/daydream/benchmark/harbor/run.py
@@ -1,11 +1,194 @@
 """Supervised Harbor runs behind the Oracle self-match gate (issue #781).
 
-Task 1 clocks in the CLI surface; the full supervisor lands in later tasks.
+A thin safety wrapper around Harbor 0.21 that fail-closes on every preflight
+before Harbor starts (same-interpreter Harbor, compiled-tree presence,
+endpoint hosts vs the workspace allowlists, telemetry/upload rejection,
+Docker allowlist support, and — for the Oracle pass — a current
+``runtime/calibration-receipt.json``), prints a pre-run spend summary, and
+records every run in a private ``runtime/harbor.json`` cleanup ledger. Harbor
+remains the only orchestrator/results implementation; this module only
+selects the already-compiled config, drives ``harbor run -c <config>`` with
+the process CWD set to the absolute ``<workspace>/harbor`` directory, and
+parses the spike-confirmed job/result layout (jobs/<job>/<trial>/verifier/
+reward.json) afterwards. The whole run path is driven through injectable
+seams (``spawn`` / ``docker_ok`` / ``confirm``) so CI stays hermetic.
+
+Expected failures are a ``RunError`` family with a clear message; the CLI
+handler maps them to exit ``1`` — never a bare traceback.
 """
 
 from __future__ import annotations
 
+import hashlib
+import sys
+import urllib.parse
 from pathlib import Path
+from typing import Any, Callable
+
+from daydream.benchmark import storage
+from daydream.benchmark.harbor import calibrate, package
+
+
+class RunError(Exception):
+    """Base error for the supervised benchmark run subsystem."""
+
+
+class RunBlocked(RunError):
+    """A preflight/gate refused to let the run start (fail-closed)."""
+
+
+def _load_workspace_privacy(workspace: Path) -> dict[str, Any]:
+    """Return the raw ``benchmark.yaml`` privacy block.
+
+    Falls back to the raw manifest dict (never the strict ``Privacy`` model)
+    so a privacy field like ``uploads: enabled`` is *reported* by the preflight
+    rather than rejected wholesale as corrupt. A malformed/missing manifest
+    raises the project's existing ``WorkspaceCorrupt`` — never a silent default.
+    """
+    try:
+        raw = storage.load_yaml_strict(workspace / "benchmark.yaml")
+    except storage.WorkspaceCorrupt:
+        raise
+    privacy = raw.get("privacy")
+    if not isinstance(privacy, dict):
+        raise storage.WorkspaceCorrupt(
+            f"{workspace}: benchmark.yaml is missing a privacy block"
+        )
+    return privacy
+
+
+def _normalize_allowlist(values: Any, what: str) -> list[str]:
+    """Normalize a workspace allowlist with the schema's hostname rules."""
+    from daydream.benchmark.schema import normalize_hostname
+
+    if not isinstance(values, list) or not values:
+        raise RunBlocked(f"privacy {what} must be a non-empty host list")
+    return [normalize_hostname(str(v)) for v in values]
+
+
+def _judge_host_from_env(env: dict[str, Any]) -> str:
+    """Judge egress host for ``env`` (mirrors calibrate's resolution)."""
+    return calibrate._judge_host_from_env(env)
+
+
+def _reviewer_host_from_env(env: dict[str, Any]) -> str:
+    """Reviewer egress host for ``env``: base-URL host, else the anthropic default.
+
+    Mirrors ``calibrate._judge_host_from_env``: a configured
+    ``DAYDREAM_REVIEW_BASE_URL`` resolves to its hostname (lowercased, no
+    port); without one the reviewer routes to the default ``api.anthropic.com``.
+    """
+    base = env.get("DAYDREAM_REVIEW_BASE_URL") or ""
+    if not base:
+        return "api.anthropic.com"
+    return str(urllib.parse.urlsplit(base).hostname or "").lower()
+
+
+def _compiled_lock_sha256(workspace: Path) -> str:
+    """sha256 of the compiled ``harbor/benchmark.lock.json`` bytes."""
+    return hashlib.sha256((workspace / "harbor" / "benchmark.lock.json").read_bytes()).hexdigest()
+
+
+def _calibration_invalidation_inputs(env: dict[str, Any]) -> dict[str, Any]:
+    """The calibration-receipt invalidation inputs for ``env`` (reused verbatim)."""
+    sr = calibrate._load_judge_template()
+    pairs = calibrate._load_fixture()
+    return calibrate._invalidation_inputs(env, pairs, sr)
+
+
+def _preflight(
+    workspace: Path,
+    *,
+    oracle: bool,
+    env: dict[str, Any],
+    docker_ok: Callable[[], bool],
+) -> list[str]:
+    """Fail-closed preflight: collect every blocking failure (empty = pass).
+
+    Checks, in order, without stopping at the first failure:
+      1. same-interpreter Harbor resolution + compiled-tree presence
+      2. judge/reviewer egress hosts vs the workspace allowlists
+      3. telemetry/upload rejection (archive + uploads must be ``disabled``)
+      4. Docker allowlist support (no public-networking fallback)
+      5. (oracle only) a current passed calibration receipt
+    """
+    failures: list[str] = []
+
+    try:
+        package.resolve_harbor()
+    except package.PackageError as exc:
+        failures.append(str(exc))
+    compiled = workspace / "harbor"
+    config_name = "harbor-oracle.yaml" if oracle else "harbor-job.yaml"
+    for required in ("benchmark.lock.json", config_name):
+        if not (compiled / required).is_file():
+            failures.append(f"missing compiled Harbor tree file: harbor/{required}")
+
+    try:
+        privacy = _load_workspace_privacy(workspace)
+    except storage.WorkspaceCorrupt as exc:
+        failures.append(str(exc))
+        privacy = {}
+
+    if privacy:
+        try:
+            reviewer_hosts = _normalize_allowlist(
+                privacy.get("reviewer_allowed_hosts"), "reviewer_allowed_hosts"
+            )
+            judge_hosts = _normalize_allowlist(
+                privacy.get("judge_allowed_hosts"), "judge_allowed_hosts"
+            )
+        except RunBlocked as exc:
+            failures.append(str(exc))
+            reviewer_hosts, judge_hosts = [], []
+        try:
+            judge_host = _judge_host_from_env(env)
+        except Exception as exc:  # noqa: BLE001 - surfaced as a preflight failure
+            failures.append(f"cannot resolve judge host: {exc}")
+            judge_host = ""
+        try:
+            reviewer_host = _reviewer_host_from_env(env)
+        except Exception as exc:  # noqa: BLE001 - surfaced as a preflight failure
+            failures.append(f"cannot resolve reviewer host: {exc}")
+            reviewer_host = ""
+        if judge_host and judge_host not in judge_hosts:
+            failures.append(
+                f"judge host {judge_host!r} is not in the workspace judge_allowed_hosts allowlist"
+                f" ({sorted(judge_hosts)})"
+            )
+        if reviewer_host and reviewer_host not in reviewer_hosts:
+            failures.append(
+                f"reviewer host {reviewer_host!r} is not in the workspace "
+                f"reviewer_allowed_hosts allowlist ({sorted(reviewer_hosts)})"
+            )
+        for field in ("archive", "uploads"):
+            value = privacy.get(field)
+            if value != "disabled":
+                failures.append(
+                    f"privacy {field} must be disabled before a Harbor run (got {value!r})"
+                )
+
+    if not docker_ok():
+        failures.append(
+            "Docker allowlist is unsupported on the selected runtime; "
+            "refusing to fall back to public networking"
+        )
+
+    if oracle:
+        receipt_path = workspace / "runtime" / "calibration-receipt.json"
+        try:
+            current = calibrate.is_receipt_current(
+                receipt_path, _calibration_invalidation_inputs(env)
+            )
+        except Exception as exc:  # noqa: BLE001 - surfaced as a preflight failure
+            current = False
+            failures.append(f"calibration receipt check failed: {exc}")
+        if not current:
+            failures.append(
+                "no current calibration receipt at runtime/calibration-receipt.json "
+                "(run 'daydream benchmark calibrate-judge' first)"
+            )
+    return failures
 
 
 def run_run(
@@ -13,10 +196,10 @@ def run_run(
     *,
     oracle: bool = False,
     yes: bool = False,
-    env: dict | None = None,
+    env: dict[str, Any] | None = None,
     spawn=None,
     docker_ok=None,
     confirm=None,
 ) -> int:
-    """Run (supervised) — implemented in later tasks of issue #781."""
-    raise NotImplementedError("run_run lands with the preflight tasks")
+    """Supervised Harbor run — wired end-to-end in the orchestrator task."""
+    raise NotImplementedError("run_run lands with the orchestrator task")

--- a/tests/test_benchmark_run.py
+++ b/tests/test_benchmark_run.py
@@ -351,12 +351,15 @@ def test_run_oracle_writes_receipt_and_running_to_complete(tmp_path):
     ws = _ws(tmp_path)
     _seed_calibration_receipt(ws)
     captures = {}
-    job_dir = (ws / "harbor" / "jobs" / "run-1").resolve()
 
     def spawn(cmd, *, cwd, env):
         captures["cwd"] = str(cwd)
         captures["args"] = cmd
         captures["env"] = env
+        # run_run assigns a fresh uuid4 job dir and records it in the ledger
+        # before spawning; write reward evidence into that recorded dir.
+        ledger = json.loads((ws / "runtime" / "harbor.json").read_text())
+        job_dir = Path(ledger["runs"][0]["job_dir"])
         verifier = job_dir / "case-abc" / "verifier"
         verifier.mkdir(parents=True, exist_ok=True)
         (verifier / "reward.json").write_text(json.dumps(
@@ -386,10 +389,11 @@ def test_run_oracle_from_unrelated_cwd_resolves_harbor_cwd(tmp_path, monkeypatch
     unrelated.mkdir()
     monkeypatch.chdir(unrelated)
     captured = {}
-    job_dir = (ws / "harbor" / "jobs" / "run-2").resolve()
 
     def spawn(cmd, *, cwd, env):
         captured["cwd"] = str(cwd)
+        ledger = json.loads((ws / "runtime" / "harbor.json").read_text())
+        job_dir = Path(ledger["runs"][0]["job_dir"])
         verifier = job_dir / "case-abc" / "verifier"
         verifier.mkdir(parents=True, exist_ok=True)
         (verifier / "reward.json").write_text(json.dumps(
@@ -425,9 +429,10 @@ def test_oracle_fails_writes_no_receipt_and_ledger_cleanup_pending(tmp_path):
 
     ws = _ws(tmp_path)
     _seed_calibration_receipt(ws)
-    job_dir = (ws / "harbor" / "jobs" / "run-3").resolve()
 
     def spawn(cmd, *, cwd, env):
+        ledger = json.loads((ws / "runtime" / "harbor.json").read_text())
+        job_dir = Path(ledger["runs"][0]["job_dir"])
         verifier = job_dir / "case-abc" / "verifier"
         verifier.mkdir(parents=True, exist_ok=True)
         (verifier / "reward.json").write_text(json.dumps(

--- a/tests/test_benchmark_run.py
+++ b/tests/test_benchmark_run.py
@@ -10,6 +10,35 @@ import pytest
 
 from daydream.benchmark.cli import _build_benchmark_parser, _handle_benchmark_command
 
+
+@pytest.fixture(autouse=True)
+def _stub_harbor_environment(monkeypatch):
+    """Keep the run-supervisor suite hermetic without a Harbor install.
+
+    The supervisor's production path only reads ``importlib.metadata.version
+    ("harbor")`` / ``package.resolve_harbor()`` after ``_preflight`` has already
+    confirmed Harbor is present. These unit tests exercise the receipt and gate
+    logic directly, so they must not require the optional ``[benchmark]`` extra
+    (Harbor is only installed when that extra is enabled — e.g. the review VMs
+    — but the CI ``check`` job installs base deps only). Stub the Harbor
+    environment so the suite stays hermetic.
+    """
+    import importlib.metadata
+    import sys
+
+    from daydream.benchmark.harbor import package as _pkg
+
+    real_version = importlib.metadata.version
+
+    def _version(dist):
+        return "0.21.0" if dist == "harbor" else real_version(dist)
+
+    monkeypatch.setattr(importlib.metadata, "version", _version)
+    monkeypatch.setattr(
+        _pkg, "resolve_harbor", lambda: str(Path(sys.executable).parent / "harbor")
+    )
+
+
 # ---------------------------------------------------------------------------
 # shared hermetic fixtures (Tasks 2-8)
 # ---------------------------------------------------------------------------

--- a/tests/test_benchmark_run.py
+++ b/tests/test_benchmark_run.py
@@ -6,8 +6,9 @@ Task 2: fail-closed preflight checks.
 import json
 from pathlib import Path
 
-from daydream.benchmark.cli import _build_benchmark_parser, _handle_benchmark_command
+import pytest
 
+from daydream.benchmark.cli import _build_benchmark_parser, _handle_benchmark_command
 
 # ---------------------------------------------------------------------------
 # shared hermetic fixtures (Tasks 2-8)
@@ -140,3 +141,198 @@ def test_preflight_blocks_missing_calibration_receipt_for_oracle(tmp_path):
 
     errs = run_mod._preflight(_ws(tmp_path), oracle=True, env=_env(), docker_ok=lambda: True)
     assert any("calibration" in e for e in errs)  # runtime/calibration-receipt.json absent
+
+
+# ---------------------------------------------------------------------------
+# Task 3: pre-run spend summary
+# ---------------------------------------------------------------------------
+
+
+def test_pre_run_summary_lists_all_required_fields(tmp_path):
+    import daydream.benchmark.harbor.run as run_mod
+
+    ws = _ws(tmp_path)
+    text = run_mod._pre_run_summary(ws, env=_env())
+    for needle in (
+        "task count", "reviewer model", "judge provider", "judge model",
+        "judge host", "attempts", "concurrency", "timeouts",
+        "oracle pair", "benchmark judge pair", "time-bounded",
+    ):
+        assert needle.lower() in text.lower(), f"summary missing {needle!r}"
+    assert "rm" in text        # reviewer model threaded from env
+    assert "127.0.0.1" in text # judge host threaded from env
+
+
+# ---------------------------------------------------------------------------
+# Task 4: runtime/harbor.json cleanup ledger
+# ---------------------------------------------------------------------------
+
+
+def test_ledger_append_running_and_mark_complete(tmp_path):
+    import stat
+
+    import daydream.benchmark.harbor.run as run_mod
+
+    ws = tmp_path / "ws"
+    (ws / "runtime").mkdir(parents=True)
+    run_id = "00000000-0000-0000-0000-000000000001"
+    job_dir = str((ws / "harbor" / "jobs" / run_id).resolve())
+    run_mod.ledger_append_running(ws, run_id=run_id, compiled_lock_sha256="a" * 64,
+                                  job_dir=job_dir)
+    path = ws / "runtime" / "harbor.json"
+    doc = json.loads(path.read_text())
+    assert doc["schema_version"] == 1
+    assert doc["runs"][0]["run_id"] == run_id
+    assert doc["runs"][0]["state"] == "running"
+    assert doc["runs"][0]["job_dir"] == job_dir
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    run_mod.ledger_mark(ws, run_id, state="complete", environments=[{
+        "trial_name": "case-abc__1", "environment_id": "env-1", "backend": "docker",
+        "image_id": "sha256:abc", "image_tags": ["tag"], "removed": False}])
+    doc = json.loads(path.read_text())
+    assert doc["runs"][0]["state"] == "complete"
+    assert doc["runs"][0]["environments"][0]["image_id"] == "sha256:abc"
+
+
+def test_ledger_rejects_non_contained_job_dir(tmp_path):
+    import daydream.benchmark.harbor.run as run_mod
+
+    ws = tmp_path / "ws"
+    (ws / "runtime").mkdir(parents=True)
+    with pytest.raises(run_mod.RunError):
+        run_mod.ledger_append_running(ws, run_id="x", compiled_lock_sha256="a" * 64,
+                                      job_dir=str(tmp_path / "outside"))
+
+
+# ---------------------------------------------------------------------------
+# Task 5: Harbor result parsing + Oracle receipt
+# ---------------------------------------------------------------------------
+
+
+def _score(reward):
+    return {"reward": reward, "verifier_error": 0, "gold_count": 1, "candidate_count": 1}
+
+
+def test_oracle_parse_success_writes_receipt(tmp_path):
+    import daydream.benchmark.harbor.run as run_mod
+
+    ws = _ws(tmp_path)
+    (ws / "runtime" / "calibration-receipt.json").write_text(json.dumps({"inputs": {"cal": 1}}))
+    job_dir = ws / "harbor" / "jobs" / "run-1"
+    verifier = job_dir / "case-abc" / "verifier"
+    verifier.mkdir(parents=True)
+    # spike-confirmed layout: reward.json lives under <trial>/verifier/
+    (verifier / "reward.json").write_text(json.dumps(_score(1.0)))
+    ok, _ = run_mod._parse_job_results(job_dir)
+    assert ok is True
+    code = run_mod._write_oracle_receipt(
+        ws, job_dir=job_dir, compiled_lock_sha256="a" * 64, env=_env(),
+        calibration_digest="c" * 64,
+    )
+    assert code == 0
+    receipt = json.loads((ws / "harbor" / "oracle-receipt.json").read_text())
+    for key in ("compiled_lock_sha256", "harbor_version", "judge_provider", "judge_model",
+                "judge_host", "verifier_template_sha256", "threshold", "attempts",
+                "calibration_receipt_sha256", "result_dir", "timestamp"):
+        assert key in receipt, f"receipt missing {key}"
+    assert receipt["compiled_lock_sha256"] == "a" * 64
+    assert receipt["calibration_receipt_sha256"] == "c" * 64
+
+
+def test_oracle_no_receipt_on_reward_below_one(tmp_path):
+    import daydream.benchmark.harbor.run as run_mod
+
+    ws = _ws(tmp_path)
+    job_dir = ws / "harbor" / "jobs" / "run-1"
+    verifier = job_dir / "case-abc" / "verifier"
+    verifier.mkdir(parents=True)
+    (verifier / "reward.json").write_text(json.dumps(_score(0.8)))
+    ok, _ = run_mod._parse_job_results(job_dir)
+    assert ok is False
+    code = run_mod._write_oracle_receipt(
+        ws, job_dir=job_dir, compiled_lock_sha256="a" * 64, env=_env(),
+        calibration_digest="c" * 64,
+    )
+    assert code == 1
+    assert not (ws / "harbor" / "oracle-receipt.json").exists()
+
+
+def test_oracle_no_receipt_on_unscored_task(tmp_path):
+    import daydream.benchmark.harbor.run as run_mod
+
+    ws = _ws(tmp_path)
+    job_dir = ws / "harbor" / "jobs" / "run-1"
+    verifier = job_dir / "case-abc" / "verifier"
+    verifier.mkdir(parents=True)
+    # infra error path writes reward-details.json only -> unscored, blocks
+    (verifier / "reward-details.json").write_text("{}")
+    ok, _ = run_mod._parse_job_results(job_dir)
+    assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# Task 6: default-run gate
+# ---------------------------------------------------------------------------
+
+
+def test_gate_blocks_on_compiled_lock_mismatch(tmp_path):
+    import hashlib
+
+    import daydream.benchmark.harbor.run as run_mod
+
+    ws = _ws(tmp_path)
+    lock = {"schema_version": 1, "cases": {}}
+    lock_sha = hashlib.sha256(json.dumps(lock).encode()).hexdigest()
+    (ws / "harbor" / "benchmark.lock.json").write_text(json.dumps(lock))
+    job_dir = ws / "harbor" / "jobs" / "run-1"
+    verifier = job_dir / "case-abc" / "verifier"
+    verifier.mkdir(parents=True)
+    (verifier / "reward.json").write_text(json.dumps(_score(1.0)))
+    assert run_mod._write_oracle_receipt(
+        ws, job_dir=job_dir, compiled_lock_sha256=lock_sha, env=_env(),
+        calibration_digest="c" * 64,
+    ) == 0
+    # now the current compiled lock digest differs from the receipt's
+    (ws / "harbor" / "benchmark.lock.json").write_text(json.dumps(
+        {"schema_version": 1, "cases": {}, "touched": True}))
+    reason = run_mod._default_run_gate(
+        ws, env=_env(), compiled_lock_sha256=hashlib.sha256(
+            json.dumps({"schema_version": 1, "cases": {}, "touched": True}).encode()
+        ).hexdigest(), calibration_digest="c" * 64,
+    )
+    assert reason is not None
+    assert "compiled lock" in reason
+
+
+def test_gate_blocks_when_oracle_receipt_missing(tmp_path):
+    import daydream.benchmark.harbor.run as run_mod
+
+    reason = run_mod._default_run_gate(
+        _ws(tmp_path), env=_env(), compiled_lock_sha256="a" * 64,
+        calibration_digest="c" * 64,
+    )
+    assert reason is not None
+    assert "no matching oracle receipt" in reason
+
+
+def test_gate_passes_when_inputs_match(tmp_path):
+    import hashlib
+
+    import daydream.benchmark.harbor.run as run_mod
+
+    ws = _ws(tmp_path)
+    lock = {"schema_version": 1, "cases": {}}
+    lock_sha = hashlib.sha256(json.dumps(lock).encode()).hexdigest()
+    (ws / "harbor" / "benchmark.lock.json").write_text(json.dumps(lock))
+    job_dir = ws / "harbor" / "jobs" / "run-1"
+    verifier = job_dir / "case-abc" / "verifier"
+    verifier.mkdir(parents=True)
+    (verifier / "reward.json").write_text(json.dumps(_score(1.0)))
+    assert run_mod._write_oracle_receipt(
+        ws, job_dir=job_dir, compiled_lock_sha256=lock_sha, env=_env(),
+        calibration_digest="c" * 64,
+    ) == 0
+    reason = run_mod._default_run_gate(
+        ws, env=_env(), compiled_lock_sha256=lock_sha, calibration_digest="c" * 64,
+    )
+    assert reason is None

--- a/tests/test_benchmark_run.py
+++ b/tests/test_benchmark_run.py
@@ -1,0 +1,37 @@
+"""Hermetic suite for the `daydream benchmark run` supervisor (issue #781).
+
+Task 1 (Step 1) failing tests: parser + dispatch routing.
+"""
+from pathlib import Path
+
+from daydream.benchmark.cli import _build_benchmark_parser, _handle_benchmark_command
+
+
+def test_benchmark_parser_has_run_subcommand():
+    parser = _build_benchmark_parser()
+    args = parser.parse_args(["run", "/ws", "--oracle", "--yes"])
+    assert args.subcommand == "run"
+    assert args.dir == Path("/ws")
+    assert args.oracle is True and args.yes is True
+    plain = parser.parse_args(["run", "/ws"])
+    assert plain.oracle is False and plain.yes is False
+
+
+def test_handle_benchmark_run_routes_to_supervisor(tmp_path, monkeypatch):
+    import daydream.benchmark.harbor.run as run_mod
+
+    captured = {}
+
+    def fake_run_run(ws, *, oracle, yes, env):
+        captured["ws"] = Path(ws)
+        captured["oracle"] = oracle
+        captured["yes"] = yes
+        captured["env"] = env
+        return 0
+
+    monkeypatch.setattr(run_mod, "run_run", fake_run_run)
+    code = _handle_benchmark_command(["run", str(tmp_path), "--yes"])
+    assert code == 0
+    assert captured["ws"] == tmp_path
+    assert captured["yes"] is True and captured["oracle"] is False
+    assert "DAYDREAM_REVIEW_MODEL" in captured["env"]  # env threaded through

--- a/tests/test_benchmark_run.py
+++ b/tests/test_benchmark_run.py
@@ -336,3 +336,156 @@ def test_gate_passes_when_inputs_match(tmp_path):
         ws, env=_env(), compiled_lock_sha256=lock_sha, calibration_digest="c" * 64,
     )
     assert reason is None
+
+
+# ---------------------------------------------------------------------------
+# Task 7: run_run orchestrator + unrelated-CWD acceptance
+# ---------------------------------------------------------------------------
+
+
+def test_run_oracle_writes_receipt_and_running_to_complete(tmp_path):
+    import stat
+
+    import daydream.benchmark.harbor.run as run_mod
+
+    ws = _ws(tmp_path)
+    _seed_calibration_receipt(ws)
+    captures = {}
+    job_dir = (ws / "harbor" / "jobs" / "run-1").resolve()
+
+    def spawn(cmd, *, cwd, env):
+        captures["cwd"] = str(cwd)
+        captures["args"] = cmd
+        captures["env"] = env
+        verifier = job_dir / "case-abc" / "verifier"
+        verifier.mkdir(parents=True, exist_ok=True)
+        (verifier / "reward.json").write_text(json.dumps(
+            {"reward": 1.0, "verifier_error": 0, "gold_count": 1, "candidate_count": 1}))
+        return {"returncode": 0}
+
+    code = run_mod.run_run(
+        ws, oracle=True, yes=True, env=_env(), spawn=spawn, docker_ok=lambda: True,
+    )
+    assert code == 0
+    assert (ws / "harbor" / "oracle-receipt.json").exists()
+    assert stat.S_IMODE((ws / "harbor" / "oracle-receipt.json").stat().st_mode) == 0o600
+    assert str(captures["cwd"]) == str((ws / "harbor").resolve())
+    assert "HARBOR_TELEMETRY" in captures["env"] and captures["env"]["HARBOR_TELEMETRY"] == "off"
+    assert "--upload" not in captures["args"] and "--publish" not in captures["args"]
+    assert any("harbor-oracle.yaml" in str(a) for a in captures["args"])  # selects oracle config
+    ledger = json.loads((ws / "runtime" / "harbor.json").read_text())
+    assert ledger["runs"][0]["state"] == "complete"
+
+
+def test_run_oracle_from_unrelated_cwd_resolves_harbor_cwd(tmp_path, monkeypatch):
+    import daydream.benchmark.harbor.run as run_mod
+
+    ws = _ws(tmp_path)
+    _seed_calibration_receipt(ws)
+    unrelated = tmp_path / "unrelated"
+    unrelated.mkdir()
+    monkeypatch.chdir(unrelated)
+    captured = {}
+    job_dir = (ws / "harbor" / "jobs" / "run-2").resolve()
+
+    def spawn(cmd, *, cwd, env):
+        captured["cwd"] = str(cwd)
+        verifier = job_dir / "case-abc" / "verifier"
+        verifier.mkdir(parents=True, exist_ok=True)
+        (verifier / "reward.json").write_text(json.dumps(
+            {"reward": 1.0, "verifier_error": 0, "gold_count": 1, "candidate_count": 1}))
+        return {"returncode": 0}
+
+    code = run_mod.run_run(
+        ws, oracle=True, yes=True, env=_env(), spawn=spawn, docker_ok=lambda: True,
+    )
+    assert code == 0
+    assert captured["cwd"] == str((ws / "harbor").resolve())
+
+
+def test_run_refuses_without_yes_and_no_confirm(tmp_path):
+    import daydream.benchmark.harbor.run as run_mod
+
+    ws = _ws(tmp_path)
+    code = run_mod.run_run(
+        ws, oracle=True, yes=False, env=_env(), spawn=None, docker_ok=lambda: True,
+        confirm=lambda _: False,
+    )
+    assert code == 1
+    assert not (ws / "runtime" / "harbor.json").exists()  # no running entry on block
+
+
+# ---------------------------------------------------------------------------
+# Task 8: full acceptance matrix
+# ---------------------------------------------------------------------------
+
+
+def test_oracle_fails_writes_no_receipt_and_ledger_cleanup_pending(tmp_path):
+    import daydream.benchmark.harbor.run as run_mod
+
+    ws = _ws(tmp_path)
+    _seed_calibration_receipt(ws)
+    job_dir = (ws / "harbor" / "jobs" / "run-3").resolve()
+
+    def spawn(cmd, *, cwd, env):
+        verifier = job_dir / "case-abc" / "verifier"
+        verifier.mkdir(parents=True, exist_ok=True)
+        (verifier / "reward.json").write_text(json.dumps(
+            {"reward": 0.5, "verifier_error": 0, "gold_count": 1, "candidate_count": 2}))
+        return {"returncode": 0}
+
+    code = run_mod.run_run(
+        ws, oracle=True, yes=True, env=_env(), spawn=spawn, docker_ok=lambda: True,
+    )
+    assert code == 1
+    assert not (ws / "harbor" / "oracle-receipt.json").exists()
+    ledger = json.loads((ws / "runtime" / "harbor.json").read_text())
+    assert ledger["runs"][0]["state"] == "cleanup_pending"
+
+
+def test_default_run_propagates_harbor_exit_code(tmp_path):
+    import hashlib
+
+    import daydream.benchmark.harbor.run as run_mod
+
+    ws = _ws(tmp_path)
+    lock = {"schema_version": 1, "cases": {}}
+    lock_sha = hashlib.sha256(json.dumps(lock).encode()).hexdigest()
+    (ws / "harbor" / "benchmark.lock.json").write_text(json.dumps(lock))
+    job_dir = ws / "harbor" / "jobs" / "x"
+    verifier = job_dir / "case-abc" / "verifier"
+    verifier.mkdir(parents=True)
+    (verifier / "reward.json").write_text(json.dumps(_score(1.0)))
+    (ws / "runtime" / "calibration-receipt.json").write_bytes(b"cal")
+    cal_digest = hashlib.sha256(b"cal").hexdigest()
+    # seed a matching oracle receipt the gate will accept
+    assert run_mod._write_oracle_receipt(
+        ws, job_dir=job_dir, compiled_lock_sha256=lock_sha, env=_env(),
+        calibration_digest=cal_digest,
+    ) == 0
+
+    def spawn(cmd, *, cwd, env):
+        return {"returncode": 3}
+
+    code = run_mod.run_run(
+        ws, oracle=False, yes=True, env=_env(), spawn=spawn, docker_ok=lambda: True,
+    )
+    assert code == 3  # Harbor's own exit code preserved
+
+
+def test_default_gate_blocks_before_any_harbor_call(tmp_path):
+    import daydream.benchmark.harbor.run as run_mod
+
+    ws = _ws(tmp_path)
+    called = []
+
+    def spawn(cmd, *, cwd, env):
+        called.append(cmd)
+        return {"returncode": 0}
+
+    code = run_mod.run_run(
+        ws, oracle=False, yes=True, env=_env(), spawn=spawn, docker_ok=lambda: True,
+    )
+    assert code == 1            # no matching receipt -> gate blocks
+    assert called == []         # Harbor never spawned, no reviewer call
+    assert not (ws / "runtime" / "harbor.json").exists()  # blocked run leaves no running entry

--- a/tests/test_benchmark_run.py
+++ b/tests/test_benchmark_run.py
@@ -1,10 +1,50 @@
 """Hermetic suite for the `daydream benchmark run` supervisor (issue #781).
 
-Task 1 (Step 1) failing tests: parser + dispatch routing.
+Task 1: parser + dispatch routing.
+Task 2: fail-closed preflight checks.
 """
+import json
 from pathlib import Path
 
 from daydream.benchmark.cli import _build_benchmark_parser, _handle_benchmark_command
+
+
+# ---------------------------------------------------------------------------
+# shared hermetic fixtures (Tasks 2-8)
+# ---------------------------------------------------------------------------
+
+
+def _ws(tmp_path, **privacy):
+    ws = tmp_path / "ws"
+    (ws / "runtime").mkdir(parents=True)
+    (ws / "harbor").mkdir()
+    (ws / "harbor" / "benchmark.lock.json").write_text(json.dumps({"schema_version": 1, "cases": {}}))
+    (ws / "harbor" / "harbor-job.yaml").write_text("jobs_dir: jobs\n")
+    (ws / "harbor" / "harbor-oracle.yaml").write_text("jobs_dir: jobs\n")
+    p = {"classification": "confidential", "reviewer_data": "source_snapshot",
+         "reviewer_allowed_hosts": ["review.example"], "judge_data": "finding_text_and_location_only",
+         "judge_allowed_hosts": ["127.0.0.1"], "archive": "disabled", "uploads": "disabled"}
+    p.update(privacy)
+    (ws / "benchmark.yaml").write_text(json.dumps({
+        "schema_version": 1, "benchmark_id": "6c38dc0a-5f5a-4b73-bf36-9a2eb390f63b",
+        "created_at": "2026-08-21T12:00:00Z",
+        "source": {"provider": "github", "hostname": "github.com", "repository": "OWNER/REPO",
+                   "repository_id": None, "visibility": "unresolved"},
+        "privacy": p, "pull_requests": [], "cases": []}))
+    return ws
+
+
+def _env(**over):
+    base = {"DAYDREAM_JUDGE_PROVIDER": "openai-compatible", "DAYDREAM_JUDGE_MODEL": "m",
+            "DAYDREAM_JUDGE_BASE_URL": "http://127.0.0.1:9", "DAYDREAM_JUDGE_API_KEY": "k",
+            "DAYDREAM_REVIEW_MODEL": "rm", "DAYDREAM_REVIEW_BASE_URL": "http://review.example"}
+    base.update(over)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Task 1: parser + dispatch
+# ---------------------------------------------------------------------------
 
 
 def test_benchmark_parser_has_run_subcommand():
@@ -35,3 +75,68 @@ def test_handle_benchmark_run_routes_to_supervisor(tmp_path, monkeypatch):
     assert captured["ws"] == tmp_path
     assert captured["yes"] is True and captured["oracle"] is False
     assert "DAYDREAM_REVIEW_MODEL" in captured["env"]  # env threaded through
+
+
+# ---------------------------------------------------------------------------
+# Task 2: fail-closed preflight checks
+# ---------------------------------------------------------------------------
+
+
+def _seed_calibration_receipt(ws):
+    """Write a current calibration receipt matching ``_env()`` via the #872 writer."""
+    from daydream.benchmark.harbor import calibrate
+
+    sr = calibrate._load_judge_template()
+    pairs = calibrate._load_fixture()
+    receipt = calibrate._build_receipt(
+        sr, pairs, _env(), passed=True, balanced_accuracy=1.0,
+        confusion={"tp": 12, "fp": 0, "tn": 12, "fn": 0}, disagreements=[],
+    )
+    calibrate._write_receipt(ws, receipt)
+
+
+def test_preflight_ok_when_all_checks_pass(tmp_path):
+    import daydream.benchmark.harbor.run as run_mod
+
+    ws = _ws(tmp_path)
+    _seed_calibration_receipt(ws)
+    errs = run_mod._preflight(ws, oracle=True, env=_env(), docker_ok=lambda: True)
+    assert errs == []
+
+
+def test_preflight_blocks_judge_host_outside_allowlist(tmp_path):
+    import daydream.benchmark.harbor.run as run_mod
+
+    errs = run_mod._preflight(_ws(tmp_path), oracle=True,
+                              env=_env(DAYDREAM_JUDGE_BASE_URL="http://evil.example"), docker_ok=lambda: True)
+    assert any("judge host" in e and "evil.example" in e for e in errs)
+
+
+def test_preflight_blocks_reviewer_host_outside_allowlist(tmp_path):
+    import daydream.benchmark.harbor.run as run_mod
+
+    errs = run_mod._preflight(_ws(tmp_path), oracle=True,
+                              env=_env(DAYDREAM_REVIEW_BASE_URL="http://other.example"), docker_ok=lambda: True)
+    assert any("reviewer host" in e and "other.example" in e for e in errs)
+
+
+def test_preflight_blocks_uploads_enabled(tmp_path):
+    import daydream.benchmark.harbor.run as run_mod
+
+    errs = run_mod._preflight(_ws(tmp_path, uploads="enabled"), oracle=True,
+                              env=_env(), docker_ok=lambda: True)
+    assert any("upload" in e for e in errs)
+
+
+def test_preflight_blocks_unsupported_docker_allowlist(tmp_path):
+    import daydream.benchmark.harbor.run as run_mod
+
+    errs = run_mod._preflight(_ws(tmp_path), oracle=True, env=_env(), docker_ok=lambda: False)
+    assert any("Docker allowlist" in e for e in errs)
+
+
+def test_preflight_blocks_missing_calibration_receipt_for_oracle(tmp_path):
+    import daydream.benchmark.harbor.run as run_mod
+
+    errs = run_mod._preflight(_ws(tmp_path), oracle=True, env=_env(), docker_ok=lambda: True)
+    assert any("calibration" in e for e in errs)  # runtime/calibration-receipt.json absent


### PR DESCRIPTION
Implements issue #781: supervise Harbor runs behind Oracle validation.

- Same-interpreter and Docker allowlist preflight, exact endpoint-host checks
- telemetry-off and upload rejection, unique absolute job dirs
- supervised Harbor subprocess, trial/result parsing
- atomic Oracle receipt, receipt invalidation, default-run gate
- runtime/harbor.json reconciliation

Closes #781