### PR TITLE
fix(benchmark): import-prs cannot complete against a real private repository (GraphQL schema, diff-digest abbreviation, shared base_tip refspec)

### DIFF
--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -513,10 +513,10 @@ query ReviewThreads($owner: String!, $name: String!, $number: Int!, $after: Stri
       reviewThreads(first: 50, after: $after) {
         pageInfo { hasNextPage endCursor }
         nodes {
-          id isResolved isOutdated isResolvedBy subjectType path line originalLine side startSide
+          id isResolved isOutdated subjectType path line originalLine side: diffSide startSide: startDiffSide
           comments(first: 100) {
             pageInfo { hasNextPage endCursor }
-            nodes { id databaseId body author { login type isBot } createdAt updatedAt url replyTo { id } }
+            nodes { id databaseId body author { login type: __typename } createdAt updatedAt url replyTo { id } }
           }
         }
       }
@@ -531,7 +531,7 @@ query ThreadComments($threadId: ID!, $commentsAfter: String) {
     ... on PullRequestReviewThread {
       comments(first: 100, after: $commentsAfter) {
         pageInfo { hasNextPage endCursor }
-        nodes { id databaseId body author { login type isBot } createdAt updatedAt url replyTo { id } }
+        nodes { id databaseId body author { login type: __typename } createdAt updatedAt url replyTo { id } }
       }
     }
   }

--- a/daydream/benchmark/snapshot.py
+++ b/daydream/benchmark/snapshot.py
@@ -216,10 +216,15 @@ def degenerate(mirror_repo: Path, base_tree: str, head_tree: str) -> str | None:
     return None
 
 
+def _canonical_diff_args(base: str, head: str) -> list[str]:
+    """The canonical diff argv: digest-pinned refs with full (non-abbreviated) SHAs."""
+    return ["-c", "core.abbrev=40", "diff", "--binary", base, head]
+
+
 def canonical_diff_sha256(mirror_repo: Path, base_sha: str, head_sha: str) -> str:
     """sha256 of the canonical binary-safe diff between two commits."""
     proc = git_ops._run_git(
-        mirror_repo, ["-c", "core.abbrev=40", "diff", "--binary", base_sha, head_sha],
+        mirror_repo, _canonical_diff_args(base_sha, head_sha),
         retries=0, capture_bytes=True,
     )
     if proc.returncode != 0:
@@ -361,8 +366,7 @@ def validate_offline_clone(
                 raise git_ops.GitError(f"offline clone tree mismatch for {ref} (expected {expected}, got {got})")
         diff = _run_git_cwd(
             clone_dir,
-            ["-c", "core.abbrev=40", "diff", "--binary",
-             "refs/remotes/origin/base", "refs/remotes/origin/head"],
+            _canonical_diff_args("refs/remotes/origin/base", "refs/remotes/origin/head"),
             capture_bytes=True,
         )
         if hashlib.sha256(diff).hexdigest() != diff_sha256:

--- a/daydream/benchmark/snapshot.py
+++ b/daydream/benchmark/snapshot.py
@@ -219,7 +219,8 @@ def degenerate(mirror_repo: Path, base_tree: str, head_tree: str) -> str | None:
 def canonical_diff_sha256(mirror_repo: Path, base_sha: str, head_sha: str) -> str:
     """sha256 of the canonical binary-safe diff between two commits."""
     proc = git_ops._run_git(
-        mirror_repo, ["diff", "--binary", base_sha, head_sha], retries=0, capture_bytes=True
+        mirror_repo, ["-c", "core.abbrev=40", "diff", "--binary", base_sha, head_sha],
+        retries=0, capture_bytes=True,
     )
     if proc.returncode != 0:
         stderr = proc.stderr.decode("utf-8", errors="replace")
@@ -360,7 +361,8 @@ def validate_offline_clone(
                 raise git_ops.GitError(f"offline clone tree mismatch for {ref} (expected {expected}, got {got})")
         diff = _run_git_cwd(
             clone_dir,
-            ["diff", "--binary", "refs/remotes/origin/base", "refs/remotes/origin/head"],
+            ["-c", "core.abbrev=40", "diff", "--binary",
+             "refs/remotes/origin/base", "refs/remotes/origin/head"],
             capture_bytes=True,
         )
         if hashlib.sha256(diff).hexdigest() != diff_sha256:

--- a/tests/harness/fake_gh.py
+++ b/tests/harness/fake_gh.py
@@ -15,10 +15,12 @@ a JSONL log the :class:`FakeGh` helper parses, and replies from a canned
 response map (``responses.json``) plus built-in behaviors:
 
 - ``gh api graphql`` with a ``reviewThreads`` query returns the configured
-  prior-thread inventory (empty by default), served via ``_write_threads``;
+  prior-thread inventory (empty by default), served via ``_write_threads``; the
+  query is first validated against the checked-in GitHub schema subset and
+  rejected if it requests fields the real schema does not define;
 - ``gh api graphql`` with a ``node(id:)``/``PullRequestReviewThread`` query
   returns the configured per-thread nested-comment page catalog
-  (``_serve_thread_comments``);
+  (``_serve_thread_comments``), likewise schema-validated;
 - ``gh api graphql`` with a ``minimizeComment`` mutation returns a minimized
   success (the Task 0 spike's chosen stale-finding mechanism);
 - ``GET repos/<o>/<r>/pulls/<n>/reviews`` returns the configured review list
@@ -51,6 +53,7 @@ from typing import Any
 import pytest
 
 from daydream.pr_review import finding_marker
+from tests.harness import github_schema
 
 
 def _argv_opt(argv: list[str], name: str) -> str | None:
@@ -224,6 +227,11 @@ def _handle_api(argv: list[str], state: Path) -> tuple[int, str, str]:
     if endpoint == "graphql":
         query = (payload or {}).get("query", "")
         variables = (payload or {}).get("variables") or {}
+        if "reviewThreads" in query or "PullRequestReviewThread" in query:
+            unknown = github_schema.unknown_query_fields(query)
+            if unknown:
+                return (1, "",
+                        f"fake gh: graphql query requests fields not in GitHub schema: {sorted(unknown)}\n")
         if "minimizeComment" in query:
             reply: dict[str, Any] = {"data": {"minimizeComment": {"minimizedComment": {"isMinimized": True}}}}
             return 0, json.dumps(reply) + "\n", ""

--- a/tests/harness/fake_gh.py
+++ b/tests/harness/fake_gh.py
@@ -227,17 +227,16 @@ def _handle_api(argv: list[str], state: Path) -> tuple[int, str, str]:
     if endpoint == "graphql":
         query = (payload or {}).get("query", "")
         variables = (payload or {}).get("variables") or {}
-        if "reviewThreads" in query or "PullRequestReviewThread" in query:
-            unknown = github_schema.unknown_query_fields(query)
-            if unknown:
-                return (1, "",
-                        f"fake gh: graphql query requests fields not in GitHub schema: {sorted(unknown)}\n")
         if "minimizeComment" in query:
             reply: dict[str, Any] = {"data": {"minimizeComment": {"minimizedComment": {"isMinimized": True}}}}
             return 0, json.dumps(reply) + "\n", ""
         if "PullRequestReviewThread" in query:
             # Per-thread ``node(id:)`` comments page catalog: serve one page per
             # incoming ``commentsAfter`` cursor, deterministic endCursor per page.
+            unknown = github_schema.unknown_query_fields(query)
+            if unknown:
+                return (1, "",
+                        f"fake gh: graphql query requests fields not in GitHub schema: {sorted(unknown)}\n")
             thread_id = variables.get("threadId") if isinstance(variables, dict) else None
             pages = responses.get(f"graphql_thread_comments:{thread_id}")
             if not isinstance(pages, list) or not pages:
@@ -251,6 +250,10 @@ def _handle_api(argv: list[str], state: Path) -> tuple[int, str, str]:
                 return 1, "", f"fake gh: thread-comment cursor {after!r} past the catalog end\n"
             return 0, json.dumps(pages[idx]) + "\n", ""
         if "reviewThreads" in query:
+            unknown = github_schema.unknown_query_fields(query)
+            if unknown:
+                return (1, "",
+                        f"fake gh: graphql query requests fields not in GitHub schema: {sorted(unknown)}\n")
             pr_num = variables.get("number") if isinstance(variables, dict) else None
             key = f"graphql_threads:{pr_num}" if pr_num is not None else "graphql_threads"
             value = responses.get(key) or responses.get("graphql_threads") or _EMPTY_THREADS_RESPONSE

--- a/tests/harness/github_schema.py
+++ b/tests/harness/github_schema.py
@@ -202,7 +202,7 @@ def _requested_fields(query: str) -> dict[str | None, set[str]]:
             j = skip_ws(j)
             if j < n and query[j] == "{":
                 if real == "nodes":
-                    nested = _CONNECTION_NODE_TYPE.get(type_ctx)
+                    nested = _CONNECTION_NODE_TYPE.get(type_ctx or "")
                 else:
                     nested = _NESTED_SELECTION_TYPE.get(real)
                 i = j
@@ -224,6 +224,6 @@ def unknown_query_fields(query: str) -> set[str]:
     """
     unknown: set[str] = set()
     for type_ctx, fields in _requested_fields(query).items():
-        valid: set[str] = _MACHINERY_FIELDS | (SCHEMA_FIELDS.get(type_ctx) or set())
+        valid: set[str] = _MACHINERY_FIELDS | (SCHEMA_FIELDS.get(type_ctx or "") or set())
         unknown |= fields - valid
     return unknown

--- a/tests/harness/github_schema.py
+++ b/tests/harness/github_schema.py
@@ -8,10 +8,12 @@ checked-in subset below. It is shared by the contract test
 (``tests/test_github_schema.py``) and the fake ``gh`` graphql handler
 (``tests/harness/fake_gh.py``), so reintroducing an invented field fails CI.
 
-The subset is intentionally minimal — it covers exactly the types the two
-review-thread queries touch, per the issue-841 plan. A full GitHub
-introspection snapshot is impractical to maintain; a small field-set map is
-the sanctioned contract mechanism.
+The subset is intentionally minimal — it covers exactly the fields the
+review-thread queries that route through the fake ``gh`` touch (the import
+queries in ``github_import`` and the prior-finding inventory query in
+``reconcile``), per the issue-841 plan. A full GitHub introspection snapshot
+is impractical to maintain; a small field-set map is the sanctioned contract
+mechanism.
 """
 
 from __future__ import annotations
@@ -41,10 +43,12 @@ SCHEMA_FIELDS: dict[str, set[str]] = {
         "databaseId",
         "body",
         "author",
+        "isMinimized",
         "createdAt",
         "updatedAt",
         "url",
         "replyTo",
+        "viewerDidAuthor",
     },
     "Actor": {"login"},
 }

--- a/tests/harness/github_schema.py
+++ b/tests/harness/github_schema.py
@@ -104,7 +104,7 @@ _SKIP_CHARS = " \t\r\n,?$"
 
 
 def _requested_fields(query: str) -> dict[str | None, set[str]]:
-    """Recursive-descent over *query*'s selection sets; returns requested names
+    """Iterative descent over *query*'s selection sets; returns requested names
     grouped by the GraphQL type they were requested on.
 
     Each selection set is parsed in the type context of its enclosing parent
@@ -147,70 +147,87 @@ def _requested_fields(query: str) -> dict[str | None, set[str]]:
                 i += 1
         return i
 
-    def parse_selections(type_ctx: str | None) -> None:
-        """Parse one selection set; returns at its closing ``}``."""
-        nonlocal i
-        while True:
-            i = skip_ws(i)
-            if i >= n:
-                return
-            c = query[i]
-            if c == "}":
-                i += 1
-                return
-            if c == "{":
-                i += 1
-                continue
-            if c == ".":
-                # '... on Type' switches the type context for its selection;
-                # a named fragment spread is skipped.
-                i = skip_ws(i + 3)
-                tok, i = read_name(i)
-                i = skip_ws(i)
-                if tok == "on":
-                    ftype, i = read_name(i)
-                    i = skip_ws(i)
-                    if i < n and query[i] == "{":
-                        parse_selections(ftype)
-                continue
+    def record_field(tok: str, i: int, type_ctx: str | None) -> tuple[str, int]:
+        """Resolve *tok*'s real name (stripping an alias), record it under
+        *type_ctx*, and return ``(real_name, cursor)`` with the cursor just
+        past any argument list — a nested selection set, if any, opens there.
+        """
+        real = tok
+        j = skip_ws(i)
+        # strip an alias: "side: diffSide" validates "diffSide"
+        if j < n and query[j] == ":":
+            j = skip_ws(j + 1)
+            rname, j = read_name(j)
+            if rname is not None:
+                real = rname
+        if real != "__typename":
+            out.setdefault(type_ctx, set()).add(real)
+        j = skip_ws(j)
+        j = skip_args(j)
+        j = skip_ws(j)
+        return real, j
+
+    # Iterative descent with an explicit stack of type contexts: every ``{``
+    # that opens a selection set pushes the enclosing context and switches to
+    # the set's own context (``... on Type``, ``nodes``/connection machinery,
+    # or the unmodeled root operation type); the matching ``}`` pops it. The
+    # cursor is threaded as data, so there is no mutable index and no
+    # recursion — each decision point is a flat branch of this loop or a
+    # small cursor-returning helper above.
+    pending_types: list[str | None] = []
+    type_ctx: str | None = None
+    while True:
+        i = skip_ws(i)
+        if i >= n:
+            break
+        c = query[i]
+        if c == "}":
+            i += 1
+            if pending_types:
+                type_ctx = pending_types.pop()
+            continue
+        if c == "{":
+            i += 1
+            continue
+        if c == ".":
+            # '... on Type' switches the type context for its selection;
+            # a named fragment spread is skipped.
+            i = skip_ws(i + 3)
             tok, i = read_name(i)
-            if tok is None:
-                i += 1
-                continue
-            if tok in ("query", "mutation"):
-                # skip the operation name (if any) and variable declarations
-                i = skip_ws(i)
-                _, i = read_name(i)
-                i = skip_ws(i)
-                i = skip_args(i)
+            i = skip_ws(i)
+            if tok == "on":
+                ftype, i = read_name(i)
                 i = skip_ws(i)
                 if i < n and query[i] == "{":
-                    parse_selections(None)  # root operation type is unmodeled
-                continue
-            # strip an alias: "side: diffSide" validates "diffSide"
-            j = skip_ws(i)
-            real = tok
-            if j < n and query[j] == ":":
-                j = skip_ws(j + 1)
-                rname, j = read_name(j)
-                if rname is not None:
-                    real = rname
-            if real != "__typename":
-                out.setdefault(type_ctx, set()).add(real)
-            j = skip_ws(j)
-            j = skip_args(j)
-            j = skip_ws(j)
-            if j < n and query[j] == "{":
-                if real == "nodes":
-                    nested = _CONNECTION_NODE_TYPE.get(type_ctx or "")
-                else:
-                    nested = _NESTED_SELECTION_TYPE.get(real)
-                i = j
-                parse_selections(nested)
+                    pending_types.append(type_ctx)
+                    type_ctx = ftype
+                    i += 1
+            continue
+        tok, i = read_name(i)
+        if tok is None:
+            i += 1
+            continue
+        if tok in ("query", "mutation"):
+            # skip the operation name (if any) and variable declarations
+            i = skip_ws(i)
+            _, i = read_name(i)
+            i = skip_ws(i)
+            i = skip_args(i)
+            i = skip_ws(i)
+            if i < n and query[i] == "{":
+                pending_types.append(type_ctx)
+                type_ctx = None  # root operation type is unmodeled
+                i += 1
+            continue
+        real, i = record_field(tok, i, type_ctx)
+        if i < n and query[i] == "{":
+            if real == "nodes":
+                nested = _CONNECTION_NODE_TYPE.get(type_ctx or "")
             else:
-                i = j
-
-    parse_selections(None)
+                nested = _NESTED_SELECTION_TYPE.get(real)
+            pending_types.append(type_ctx)
+            type_ctx = nested
+            i += 1
     return out
 
 

--- a/tests/harness/github_schema.py
+++ b/tests/harness/github_schema.py
@@ -1,12 +1,15 @@
 """Minimal checked-in GitHub GraphQL field-set subset + query field extractor.
 
 The review-thread GraphQL queries in :mod:`daydream.benchmark.github_import`
-may only request fields GitHub's schema actually defines. This module is the
-enforcement point: :func:`unknown_query_fields` parses a GraphQL query's
-selection set and returns the requested field names that are absent from the
-checked-in subset below. It is shared by the contract test
-(``tests/test_github_schema.py``) and the fake ``gh`` graphql handler
-(``tests/harness/fake_gh.py``), so reintroducing an invented field fails CI.
+may only request fields GitHub's schema actually defines, *on the type they
+are requested under*. This module is the enforcement point:
+:func:`unknown_query_fields` parses a GraphQL query's selection set, binds
+each requested name to the type it appears under, and returns the names that
+are absent from that type's checked-in subset — a name valid on one type
+requested on another is flagged exactly like an invented one. It is shared by
+the contract test (``tests/test_github_schema.py``) and the fake ``gh``
+graphql handler (``tests/harness/fake_gh.py``), so reintroducing an invented
+field or misplacing a real one fails CI.
 
 The subset is intentionally minimal — it covers exactly the fields the
 review-thread queries that route through the fake ``gh`` touch (the import
@@ -53,8 +56,39 @@ SCHEMA_FIELDS: dict[str, set[str]] = {
     "Actor": {"login"},
 }
 
+# Field name -> GraphQL object type of the value it selects, for the few
+# fields these queries use that carry a nested selection set. Together with
+# SCHEMA_FIELDS this is what binds a requested name to exactly one type: a
+# name is only acceptable on the type whose subset contains it.
+_NESTED_SELECTION_TYPE: dict[str, str] = {
+    # Query root
+    "repository": "Repository",
+    "node": "Node",  # interface; `... on Type` narrows the context
+    # Repository
+    "pullRequest": "PullRequest",
+    # PullRequest
+    "reviewThreads": "PullRequestReviewThreadConnection",
+    # PullRequestReviewThread
+    "comments": "PullRequestReviewCommentConnection",
+    # Comment
+    "author": "Actor",
+    "replyTo": "Comment",
+    # Connections
+    "pageInfo": "PageInfo",
+}
+
+# The object type a connection's ``nodes`` selection resolves to, keyed by the
+# enclosing connection type (context-dependent, so it cannot live in the
+# single-name map above).
+_CONNECTION_NODE_TYPE: dict[str, str] = {
+    "PullRequestReviewThreadConnection": "PullRequestReviewThread",
+    "PullRequestReviewCommentConnection": "Comment",
+}
+
 # Query/connection machinery every query relies on, plus ``__typename`` which
-# the GraphQL spec defines on every type.
+# the GraphQL spec defines on every type. Machinery routes to the next
+# selection set, so it is acceptable in any type context; ``__typename`` is
+# never collected at all.
 _MACHINERY_FIELDS = {
     "repository",
     "pullRequest",
@@ -66,32 +100,43 @@ _MACHINERY_FIELDS = {
     "endCursor",
 }
 
-_VALID_FIELDS = {
-    field
-    for fields in SCHEMA_FIELDS.values()
-    for field in fields
-} | _MACHINERY_FIELDS
-
 _SKIP_CHARS = " \t\r\n,?$"
 
 
-def _requested_fields(query: str) -> set[str]:
-    """Recursive-descent over *query*'s selection set; returns requested names.
+def _requested_fields(query: str) -> dict[str | None, set[str]]:
+    """Recursive-descent over *query*'s selection sets; returns requested names
+    grouped by the GraphQL type they were requested on.
+
+    Each selection set is parsed in the type context of its enclosing parent
+    field (``None`` when the subset does not model that type — the Query root,
+    Repository, PullRequest, connections, PageInfo), so a name is never
+    validated against a global union:
 
     - ``alias: realName`` validates ``realName`` (the alias is not a schema
       field, so only the real name is collected);
     - ``__typename`` is always valid and never collected;
     - ``(...)`` argument lists (including the query's variable declarations)
-      and ``... on Type`` inline fragments are skipped.
+      are skipped;
+    - ``... on Type`` inline fragments switch the type context; named fragment
+      spreads are skipped;
+    - ``nodes`` resolves to the enclosing connection's node type.
     """
-    out: set[str] = set()
+    out: dict[str | None, set[str]] = {}
     i, n = 0, len(query)
-    while i < n:
-        c = query[i]
-        if c in "{}":
+
+    def skip_ws(i: int) -> int:
+        while i < n and query[i] in _SKIP_CHARS:
             i += 1
-            continue
-        if c == "(":
+        return i
+
+    def read_name(i: int) -> tuple[str | None, int]:
+        m = re.match(r"[A-Za-z_][A-Za-z0-9_]*", query[i:])
+        if not m:
+            return None, i
+        return m.group(0), i + len(m.group(0))
+
+    def skip_args(i: int) -> int:
+        if i < n and query[i] == "(":
             depth = 1
             i += 1
             while i < n and depth:
@@ -100,59 +145,85 @@ def _requested_fields(query: str) -> set[str]:
                 elif query[i] == ")":
                     depth -= 1
                 i += 1
-            continue
-        if c in _SKIP_CHARS or c == ".":  # '.' = '...' fragment spread
-            i += 1
-            continue
-        m = re.match(r"[A-Za-z_][A-Za-z0-9_]*", query[i:])
-        if not m:
-            i += 1
-            continue
-        tok = m.group(0)
-        j = i + len(tok)
-        if tok in ("query", "mutation"):
-            # skip the operation name (if any) following the keyword
-            i = j
-            while i < n and query[i] in " \t\r\n":
+        return i
+
+    def parse_selections(type_ctx: str | None) -> None:
+        """Parse one selection set; returns at its closing ``}``."""
+        nonlocal i
+        while True:
+            i = skip_ws(i)
+            if i >= n:
+                return
+            c = query[i]
+            if c == "}":
                 i += 1
-            m2 = re.match(r"[A-Za-z_][A-Za-z0-9_]*", query[i:])
-            if m2:
-                i += len(m2.group(0))
-            continue
-        if tok == "on":
-            # '... on Type' — skip 'on' and the type name
-            i = j
-            while i < n and query[i] in " \t\r\n":
+                return
+            if c == "{":
                 i += 1
-            m2 = re.match(r"[A-Za-z_][A-Za-z0-9_]*", query[i:])
-            if m2:
-                i += len(m2.group(0))
-            continue
-        # strip an alias: "side: diffSide" validates "diffSide"
-        k = j
-        while k < n and query[k] in " \t\r\n":
-            k += 1
-        if k < n and query[k] == ":":
-            k += 1
-            while k < n and query[k] in " \t\r\n":
-                k += 1
-            m2 = re.match(r"[A-Za-z_][A-Za-z0-9_]*", query[k:])
-            if m2:
-                real = m2.group(0)
-                if real != "__typename":
-                    out.add(real)
-                i = k + len(real)
                 continue
-        if tok != "__typename":
-            out.add(tok)
-        i = j
+            if c == ".":
+                # '... on Type' switches the type context for its selection;
+                # a named fragment spread is skipped.
+                i = skip_ws(i + 3)
+                tok, i = read_name(i)
+                i = skip_ws(i)
+                if tok == "on":
+                    ftype, i = read_name(i)
+                    i = skip_ws(i)
+                    if i < n and query[i] == "{":
+                        parse_selections(ftype)
+                continue
+            tok, i = read_name(i)
+            if tok is None:
+                i += 1
+                continue
+            if tok in ("query", "mutation"):
+                # skip the operation name (if any) and variable declarations
+                i = skip_ws(i)
+                _, i = read_name(i)
+                i = skip_ws(i)
+                i = skip_args(i)
+                i = skip_ws(i)
+                if i < n and query[i] == "{":
+                    parse_selections(None)  # root operation type is unmodeled
+                continue
+            # strip an alias: "side: diffSide" validates "diffSide"
+            j = skip_ws(i)
+            real = tok
+            if j < n and query[j] == ":":
+                j = skip_ws(j + 1)
+                rname, j = read_name(j)
+                if rname is not None:
+                    real = rname
+            if real != "__typename":
+                out.setdefault(type_ctx, set()).add(real)
+            j = skip_ws(j)
+            j = skip_args(j)
+            j = skip_ws(j)
+            if j < n and query[j] == "{":
+                if real == "nodes":
+                    nested = _CONNECTION_NODE_TYPE.get(type_ctx)
+                else:
+                    nested = _NESTED_SELECTION_TYPE.get(real)
+                i = j
+                parse_selections(nested)
+            else:
+                i = j
+
+    parse_selections(None)
     return out
 
 
 def unknown_query_fields(query: str) -> set[str]:
-    """Return the requested field names *query* asks for that the schema subset
-    does not define.
+    """Return the requested field names *query* asks for that its type context
+    does not define: a name absent from the subset of the type it is requested
+    under, or — under a type the subset does not model — any name that is not
+    query machinery.
 
     ``__typename`` is always valid; an alias is validated by its real name.
     """
-    return _requested_fields(query) - _VALID_FIELDS
+    unknown: set[str] = set()
+    for type_ctx, fields in _requested_fields(query).items():
+        valid: set[str] = _MACHINERY_FIELDS | (SCHEMA_FIELDS.get(type_ctx) or set())
+        unknown |= fields - valid
+    return unknown

--- a/tests/harness/github_schema.py
+++ b/tests/harness/github_schema.py
@@ -1,0 +1,154 @@
+"""Minimal checked-in GitHub GraphQL field-set subset + query field extractor.
+
+The review-thread GraphQL queries in :mod:`daydream.benchmark.github_import`
+may only request fields GitHub's schema actually defines. This module is the
+enforcement point: :func:`unknown_query_fields` parses a GraphQL query's
+selection set and returns the requested field names that are absent from the
+checked-in subset below. It is shared by the contract test
+(``tests/test_github_schema.py``) and the fake ``gh`` graphql handler
+(``tests/harness/fake_gh.py``), so reintroducing an invented field fails CI.
+
+The subset is intentionally minimal — it covers exactly the types the two
+review-thread queries touch, per the issue-841 plan. A full GitHub
+introspection snapshot is impractical to maintain; a small field-set map is
+the sanctioned contract mechanism.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Real GitHub GraphQL field names for the types the two review-thread queries
+# touch. ``resolvedBy`` is in the subset but must NOT be requested (nothing
+# reads it); it is present so a future *correct* addition is not falsely
+# rejected.
+SCHEMA_FIELDS: dict[str, set[str]] = {
+    "PullRequestReviewThread": {
+        "id",
+        "isResolved",
+        "isOutdated",
+        "resolvedBy",
+        "subjectType",
+        "path",
+        "line",
+        "originalLine",
+        "diffSide",
+        "startDiffSide",
+        "comments",
+    },
+    "Comment": {
+        "id",
+        "databaseId",
+        "body",
+        "author",
+        "createdAt",
+        "updatedAt",
+        "url",
+        "replyTo",
+    },
+    "Actor": {"login"},
+}
+
+# Query/connection machinery every query relies on, plus ``__typename`` which
+# the GraphQL spec defines on every type.
+_MACHINERY_FIELDS = {
+    "repository",
+    "pullRequest",
+    "reviewThreads",
+    "node",
+    "nodes",
+    "pageInfo",
+    "hasNextPage",
+    "endCursor",
+}
+
+_VALID_FIELDS = {
+    field
+    for fields in SCHEMA_FIELDS.values()
+    for field in fields
+} | _MACHINERY_FIELDS
+
+_SKIP_CHARS = " \t\r\n,?$"
+
+
+def _requested_fields(query: str) -> set[str]:
+    """Recursive-descent over *query*'s selection set; returns requested names.
+
+    - ``alias: realName`` validates ``realName`` (the alias is not a schema
+      field, so only the real name is collected);
+    - ``__typename`` is always valid and never collected;
+    - ``(...)`` argument lists (including the query's variable declarations)
+      and ``... on Type`` inline fragments are skipped.
+    """
+    out: set[str] = set()
+    i, n = 0, len(query)
+    while i < n:
+        c = query[i]
+        if c in "{}":
+            i += 1
+            continue
+        if c == "(":
+            depth = 1
+            i += 1
+            while i < n and depth:
+                if query[i] == "(":
+                    depth += 1
+                elif query[i] == ")":
+                    depth -= 1
+                i += 1
+            continue
+        if c in _SKIP_CHARS or c == ".":  # '.' = '...' fragment spread
+            i += 1
+            continue
+        m = re.match(r"[A-Za-z_][A-Za-z0-9_]*", query[i:])
+        if not m:
+            i += 1
+            continue
+        tok = m.group(0)
+        j = i + len(tok)
+        if tok in ("query", "mutation"):
+            # skip the operation name (if any) following the keyword
+            i = j
+            while i < n and query[i] in " \t\r\n":
+                i += 1
+            m2 = re.match(r"[A-Za-z_][A-Za-z0-9_]*", query[i:])
+            if m2:
+                i += len(m2.group(0))
+            continue
+        if tok == "on":
+            # '... on Type' — skip 'on' and the type name
+            i = j
+            while i < n and query[i] in " \t\r\n":
+                i += 1
+            m2 = re.match(r"[A-Za-z_][A-Za-z0-9_]*", query[i:])
+            if m2:
+                i += len(m2.group(0))
+            continue
+        # strip an alias: "side: diffSide" validates "diffSide"
+        k = j
+        while k < n and query[k] in " \t\r\n":
+            k += 1
+        if k < n and query[k] == ":":
+            k += 1
+            while k < n and query[k] in " \t\r\n":
+                k += 1
+            m2 = re.match(r"[A-Za-z_][A-Za-z0-9_]*", query[k:])
+            if m2:
+                real = m2.group(0)
+                if real != "__typename":
+                    out.add(real)
+                i = k + len(real)
+                continue
+        if tok != "__typename":
+            out.add(tok)
+        i = j
+    return out
+
+
+def unknown_query_fields(query: str) -> set[str]:
+    """Return the requested field names *query* asks for that the schema subset
+    does not define.
+
+    ``__typename`` is always valid; an alias is validated by its real name.
+    """
+    return _requested_fields(query) - _VALID_FIELDS

--- a/tests/test_benchmark_gh_smoke.py
+++ b/tests/test_benchmark_gh_smoke.py
@@ -22,6 +22,9 @@ pytestmark = pytest.mark.skipif(
     not _run, reason="live gh smoke test disabled (DAYDREAM_LIVE_GH=1 + gh required)"
 )
 
+# The module-level skipif already gates on gh + DAYDREAM_LIVE_GH=1.
+_SMOKE_PRS = os.environ.get("DAYDREAM_SMOKE_PRS", "")
+
 
 def _seed_manifest(ws, repository: str) -> None:
     init_workspace(ws, repository, ["h1.example.com"], ["h2.example.com"])
@@ -38,3 +41,25 @@ def test_private_preflight_smoke_with_installed_gh(tmp_path):
     raw = load_yaml_strict(ws / "benchmark.yaml")
     assert raw["source"]["repository_id"].startswith("R_kgD")
     assert "password=" not in json.dumps(raw)     # no credential leakage into the manifest
+
+
+def test_import_prs_two_prs_smoke_with_installed_gh(tmp_path):
+    """Opt-in: import two PRs from an accessible repo with the installed gh; both
+    frozen snapshots must classify ready. Operator sets DAYDREAM_SMOKE_PRS to a
+    comma-separated pair (e.g. '841,842'); skipped when absent."""
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.storage import load_yaml_strict
+    from daydream.benchmark.workspace import init_workspace
+
+    if not _SMOKE_PRS:
+        pytest.skip("DAYDREAM_SMOKE_PRS not set (comma-separated PR numbers)")
+    pr_numbers = [int(x) for x in _SMOKE_PRS.split(",")]
+    ws = tmp_path / "ws"
+    init_workspace(ws, "existential-birds/daydream", ["h1.example.com"], ["h2.example.com"])
+    rc = gi.run_import_prs(ws, pr_numbers=pr_numbers)
+    assert rc == 0
+    raw = load_yaml_strict(ws / "benchmark.yaml")
+    assert len(raw["pull_requests"]) == len(pr_numbers)
+    for pr in raw["pull_requests"]:
+        case = load_yaml_strict(ws / f"cases/{pr['case_ids'][0]}.yaml")
+        assert case["snapshot"]["status"] == "ready"

--- a/tests/test_benchmark_gh_smoke.py
+++ b/tests/test_benchmark_gh_smoke.py
@@ -47,10 +47,6 @@ def test_import_prs_two_prs_smoke_with_installed_gh(tmp_path):
     """Opt-in: import two PRs from an accessible repo with the installed gh; both
     frozen snapshots must classify ready. Operator sets DAYDREAM_SMOKE_PRS to a
     comma-separated pair (e.g. '841,842'); skipped when absent."""
-    from daydream.benchmark import github_import as gi
-    from daydream.benchmark.storage import load_yaml_strict
-    from daydream.benchmark.workspace import init_workspace
-
     if not _SMOKE_PRS:
         pytest.skip("DAYDREAM_SMOKE_PRS not set (comma-separated PR numbers)")
     pr_numbers = [int(x) for x in _SMOKE_PRS.split(",")]

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -11,6 +11,7 @@ origin (no network).
 """
 
 import hashlib
+import json
 import os
 import subprocess
 
@@ -290,6 +291,35 @@ def test_review_thread_queries_request_only_schema_fields():
     from daydream.benchmark import github_import as gi
     assert gs.unknown_query_fields(gi._REVIEW_THREADS_QUERY) == set()
     assert gs.unknown_query_fields(gi._THREAD_COMMENTS_QUERY) == set()
+
+
+def test_fake_gh_rejects_invented_review_thread_fields(tmp_path):
+    """Reintroducing a field GitHub's schema does not define fails CI through the fake gh."""
+    from tests.harness.fake_gh import _handle_api
+    state = tmp_path / "state"; state.mkdir()
+    payload = state / "q.json"
+    payload.write_text(json.dumps({
+        "query": "query X($o:String!,$n:String!,$p:Int!){ repository(owner:$o,name:$n){"
+                 " pullRequest(number:$p){ reviewThreads(first:50){ nodes{ id isBot } } } } }",
+        "variables": {"o": "o", "n": "r", "p": 1},
+    }))
+    rc, _out, err = _handle_api(["api", "graphql", "--input", str(payload)], state)
+    assert rc == 1
+    assert "isBot" in err
+
+
+def test_fake_gh_accepts_fixed_review_threads_query(tmp_path):
+    """The fixed production query routes through the fake without a schema rejection."""
+    from tests.harness.fake_gh import _handle_api
+    from daydream.benchmark import github_import as gi
+    state = tmp_path / "state"; state.mkdir()
+    payload = state / "q.json"
+    payload.write_text(json.dumps({
+        "query": gi._REVIEW_THREADS_QUERY,
+        "variables": {"o": "o", "n": "r", "number": 1},
+    }))
+    rc, _out, err = _handle_api(["api", "graphql", "--input", str(payload)], state)
+    assert rc == 0 and "schema" not in err
 
 
 def test_graphql_threads_and_replies_normalized(tmp_path, fake_gh):

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -16,6 +16,8 @@ import subprocess
 
 import pytest
 
+from tests.harness import github_schema as gs
+
 # Deterministic seed identity so a local bare origin's commits are stable and
 # reproducible (mirrors tests/test_benchmark_snapshot.py::_SEED_ENV).
 _SEED_ENV = {
@@ -279,6 +281,17 @@ def test_fetch_normalizes_all_rest_evidence(tmp_path, fake_gh):
     assert all("--paginate" in (a or []) for a in collection_args)
 
 
+def test_review_thread_queries_request_only_schema_fields():
+    """Both GraphQL queries may only request fields GitHub's schema defines.
+
+    Aliases (`side: diffSide`, `type: __typename`) are allowed — the extractor
+    validates the *real* field name — but a bare invented field must fail.
+    """
+    from daydream.benchmark import github_import as gi
+    assert gs.unknown_query_fields(gi._REVIEW_THREADS_QUERY) == set()
+    assert gs.unknown_query_fields(gi._THREAD_COMMENTS_QUERY) == set()
+
+
 def test_graphql_threads_and_replies_normalized(tmp_path, fake_gh):
     from daydream.benchmark import github_import as gi
 
@@ -303,7 +316,7 @@ def test_graphql_threads_and_replies_normalized(tmp_path, fake_gh):
     fake_gh.set_response("GET", "repos/o/r/issues/101/comments", [])
     fake_gh._write_threads([
         {"id": "thread_1", "isResolved": True,
-         "isOutdated": True, "isResolvedBy": None,
+         "isOutdated": True,
          "subjectType": "LINE", "path": "a.py", "line": 4, "originalLine": 3,
          "side": "RIGHT", "startSide": None,
          "comments": {"nodes": [
@@ -1291,7 +1304,7 @@ def test_reconcile_inline_and_thread_into_one_record(tmp_path, fake_gh):
          "html_url": "https://github.com/o/r/pull/101#discussion_r10"}])
     fake_gh.set_response("GET", "repos/o/r/issues/101/comments", [])
     fake_gh._write_threads([{"id": "thread_1", "isResolved": True,
-        "isOutdated": True, "isResolvedBy": None, "subjectType": "LINE",
+        "isOutdated": True, "subjectType": "LINE",
         "path": "a.py", "line": 4, "originalLine": 3, "side": "RIGHT",
         "startSide": None,
         "comments": {"nodes": [
@@ -1365,7 +1378,7 @@ def test_outdated_root_not_exact_acceptable_via_joined_record(tmp_path, fake_gh)
          "html_url": "https://github.com/o/r/pull/101#discussion_r40"}])
     fake_gh.set_response("GET", "repos/o/r/issues/101/comments", [])
     fake_gh._write_threads([{"id": "thread_2", "isResolved": True,
-        "isOutdated": True, "isResolvedBy": None, "subjectType": "LINE",
+        "isOutdated": True, "subjectType": "LINE",
         "path": "a.py", "line": 5, "originalLine": 4, "side": "RIGHT",
         "startSide": None,
         "comments": {"nodes": [

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -296,7 +296,8 @@ def test_review_thread_queries_request_only_schema_fields():
 def test_fake_gh_rejects_invented_review_thread_fields(tmp_path):
     """Reintroducing a field GitHub's schema does not define fails CI through the fake gh."""
     from tests.harness.fake_gh import _handle_api
-    state = tmp_path / "state"; state.mkdir()
+    state = tmp_path / "state"
+    state.mkdir()
     payload = state / "q.json"
     payload.write_text(json.dumps({
         "query": "query X($o:String!,$n:String!,$p:Int!){ repository(owner:$o,name:$n){"
@@ -310,9 +311,10 @@ def test_fake_gh_rejects_invented_review_thread_fields(tmp_path):
 
 def test_fake_gh_accepts_fixed_review_threads_query(tmp_path):
     """The fixed production query routes through the fake without a schema rejection."""
-    from tests.harness.fake_gh import _handle_api
     from daydream.benchmark import github_import as gi
-    state = tmp_path / "state"; state.mkdir()
+    from tests.harness.fake_gh import _handle_api
+    state = tmp_path / "state"
+    state.mkdir()
     payload = state / "q.json"
     payload.write_text(json.dumps({
         "query": gi._REVIEW_THREADS_QUERY,

--- a/tests/test_benchmark_snapshot.py
+++ b/tests/test_benchmark_snapshot.py
@@ -89,22 +89,31 @@ def _seed_two_pr_origin(tmp_path: Path) -> tuple[Path, str, str]:
     with refs/pull/1/head off base2, plus a diverged `dev` branch (off base1) whose
     first commit is PR2's base tip and second commit is PR2's head. Returns
     (bare, dev_base_tip_sha, pr2_head_sha)."""
-    repo = tmp_path / "seed_wt"; repo.mkdir()
+    repo = tmp_path / "seed_wt"
+    repo.mkdir()
     _git(repo, "init", "-b", "main")
-    _write(repo, "readme.txt", "base1\n"); _commit(repo, "base1")
-    _write(repo, "base.py", "BASE = 2\n"); _commit(repo, "base2")
-    _write(repo, "beyond.py", "BEYOND = 3\n"); _commit(repo, "base3")
+    _write(repo, "readme.txt", "base1\n")
+    _commit(repo, "base1")
+    _write(repo, "base.py", "BASE = 2\n")
+    _commit(repo, "base2")
+    _write(repo, "beyond.py", "BEYOND = 3\n")
+    _commit(repo, "base3")
     # PR 1 head off base2 (identical seed to _seed_origin => same _SHA_HEAD)
     _git(repo, "checkout", "--detach", "HEAD~1")            # base2
-    repo.joinpath("base.py").write_text("BASE = 20\n"); _git(repo, "add", "base.py")
-    _write(repo, "feature.py", "FEATURE = 1\n"); _commit(repo, "feature")
+    repo.joinpath("base.py").write_text("BASE = 20\n")
+    _git(repo, "add", "base.py")
+    _write(repo, "feature.py", "FEATURE = 1\n")
+    _commit(repo, "feature")
     pr1_head = _git(repo, "rev-parse", "HEAD")
     # PR 2: unrelated `dev` branch diverged from base1; base tip = dev1, head = dev2
     _git(repo, "checkout", "-b", "dev", "HEAD~2")           # base1
-    _write(repo, "dev.py", "DEV = 1\n"); dev_tip = _commit(repo, "dev1")
-    repo.joinpath("dev.py").write_text("DEV = 2\n"); _git(repo, "add", "dev.py")
+    _write(repo, "dev.py", "DEV = 1\n")
+    dev_tip = _commit(repo, "dev1")
+    repo.joinpath("dev.py").write_text("DEV = 2\n")
+    _git(repo, "add", "dev.py")
     pr2_head = _commit(repo, "dev2")
-    bare = tmp_path / "origin.git"; bare.mkdir(parents=True, exist_ok=True)
+    bare = tmp_path / "origin.git"
+    bare.mkdir(parents=True, exist_ok=True)
     _git(bare, "init", "--bare")
     _git(repo, "remote", "add", "origin", str(bare))
     _git(repo, "push", "origin", "main:main", "dev:dev")

--- a/tests/test_benchmark_snapshot.py
+++ b/tests/test_benchmark_snapshot.py
@@ -84,6 +84,35 @@ def _seed_origin(tmp_path: Path) -> Path:
     return bare
 
 
+def _seed_two_pr_origin(tmp_path: Path) -> tuple[Path, str, str]:
+    """Bare origin with two PRs on unrelated ancestries: main(base1->base2->base3)
+    with refs/pull/1/head off base2, plus a diverged `dev` branch (off base1) whose
+    first commit is PR2's base tip and second commit is PR2's head. Returns
+    (bare, dev_base_tip_sha, pr2_head_sha)."""
+    repo = tmp_path / "seed_wt"; repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _write(repo, "readme.txt", "base1\n"); _commit(repo, "base1")
+    _write(repo, "base.py", "BASE = 2\n"); _commit(repo, "base2")
+    _write(repo, "beyond.py", "BEYOND = 3\n"); _commit(repo, "base3")
+    # PR 1 head off base2 (identical seed to _seed_origin => same _SHA_HEAD)
+    _git(repo, "checkout", "--detach", "HEAD~1")            # base2
+    repo.joinpath("base.py").write_text("BASE = 20\n"); _git(repo, "add", "base.py")
+    _write(repo, "feature.py", "FEATURE = 1\n"); _commit(repo, "feature")
+    pr1_head = _git(repo, "rev-parse", "HEAD")
+    # PR 2: unrelated `dev` branch diverged from base1; base tip = dev1, head = dev2
+    _git(repo, "checkout", "-b", "dev", "HEAD~2")           # base1
+    _write(repo, "dev.py", "DEV = 1\n"); dev_tip = _commit(repo, "dev1")
+    repo.joinpath("dev.py").write_text("DEV = 2\n"); _git(repo, "add", "dev.py")
+    pr2_head = _commit(repo, "dev2")
+    bare = tmp_path / "origin.git"; bare.mkdir(parents=True, exist_ok=True)
+    _git(bare, "init", "--bare")
+    _git(repo, "remote", "add", "origin", str(bare))
+    _git(repo, "push", "origin", "main:main", "dev:dev")
+    _git(repo, "push", "origin", f"{pr1_head}:refs/pull/1/head", check=False)
+    _git(repo, "push", "origin", f"{pr2_head}:refs/pull/2/head", check=False)
+    return bare, dev_tip, pr2_head
+
+
 # Deterministic SHAs/trees produced by ``_seed_origin`` (verified at seed build).
 _SHA_BASE1 = 'cae67fc3eb4c5d3dd3353ca7fb41f909837bf0a2'
 _SHA_BASE1_TREE = '2cd99bd20f7b3bac54014e20db1831d64b2c4fc9'
@@ -396,6 +425,24 @@ def test_freeze_one_ready_and_reasons(tmp_path):
     assert ur2["status"] == "unreplayable" and ur2["error"]["reason"] == "head_unreachable"
     assert bundle2 is None
     assert ur2["bundle_file"] is None
+
+
+def test_freeze_two_prs_unrelated_base_tips_both_ready(tmp_path):
+    """The forced +{base_tip} refspec lets two PRs with unrelated, non-fast-forward
+    base tips both freeze ready in one shared mirror (regression for defect 3)."""
+    from daydream.benchmark import snapshot as sn
+
+    origin, dev_tip, pr2_head = _seed_two_pr_origin(tmp_path)
+    sn.ensure_mirror(tmp_path, "o/r", origin_url=origin)
+    m = sn.mirror(tmp_path)
+    ready1, b1 = sn.freeze_one(tmp_path, "o/r", 1, base_tip=_SHA_BASE2, head_sha=_SHA_HEAD,
+                               policy="final_pr_head", requested_head="final", origin_url=origin)
+    ready2, b2 = sn.freeze_one(tmp_path, "o/r", 2, base_tip=dev_tip, head_sha=pr2_head,
+                               policy="final_pr_head", requested_head="final", origin_url=origin)
+    assert ready1["status"] == "ready" and isinstance(b1, bytes)
+    assert ready2["status"] == "ready" and isinstance(b2, bytes)
+    # the shared base_tip ref was force-re-pointed from base2 to the unrelated dev tip
+    assert sn.rev_parse(m, "refs/heads/base_tip") == dev_tip
 
 
 def test_freeze_one_base_advanced_two_sha(tmp_path):

--- a/tests/test_benchmark_snapshot.py
+++ b/tests/test_benchmark_snapshot.py
@@ -216,6 +216,28 @@ def test_bundle_two_refs_deterministic(tmp_path):
 # ---------------------------------------------------------------------------
 
 
+def test_canonical_diff_digest_is_abbreviation_stable(tmp_path):
+    """The same base/head pair hashes identically whether the diff runs in a
+    mirror whose effective core.abbrev is widened past the clone's. Failing-by-
+    construction: pre-fix the mirror's 12-hex index lines mismatch the clone's
+    default, so validate_offline_clone raises a digest mismatch."""
+    from daydream.benchmark import snapshot as sn
+
+    origin = _seed_origin(tmp_path)
+    sn.ensure_mirror(tmp_path, "o/r", origin_url=origin)
+    sn.fetch_pr_refs(tmp_path, "o/r", 1, base_tip=_SHA_BASE2,
+                     explicit_shas=[], origin_url=origin)
+    m = sn.mirror(tmp_path)
+    # widen the mirror's effective abbrev past the fresh 2-commit clone's default
+    _git(m, "config", "core.abbrev", "12")
+    bundle = tmp_path / "snapshots" / "pr-000001-aaaaaaaaaaaa.bundle"
+    sn.build_bundle(m, _SHA_BASE2, _SHA_HEAD, bundle)
+    diff_sha = sn.canonical_diff_sha256(m, _SHA_BASE2, _SHA_HEAD)
+    # must not raise: the clone's diff digest must equal the mirror's
+    sn.validate_offline_clone(bundle, _seed_base_tree(), _seed_head_tree(), diff_sha,
+                              workdir=tmp_path)
+
+
 def test_git_fetch_wires_command_scoped_credential_helper(tmp_path, monkeypatch):
     from daydream.benchmark import snapshot as sn
 

--- a/tests/test_github_schema.py
+++ b/tests/test_github_schema.py
@@ -1,0 +1,39 @@
+"""The review-thread GraphQL queries may only request fields GitHub's schema defines.
+
+The minimal subset here covers exactly the types the two queries touch
+(PullRequestReviewThread, the comment node, Actor). It is the enforcement point
+for "requesting a nonexistent field fails CI, never in production".
+"""
+import json
+
+from tests.harness import github_schema as gs
+
+
+def test_unknown_query_fields_flags_invented_fields():
+    # A query requesting fields GitHub's schema does not define must be flagged.
+    bad = """
+    query X($o:String!,$n:String!,$p:Int!) {
+      repository(owner:$o,name:$n) { pullRequest(number:$p) { reviewThreads(first:50) {
+        nodes { id isResolved isResolvedBy side startSide
+                comments(first:100) { nodes { author { login type isBot } } } }
+      } } }
+    }
+    """
+    assert {"side", "startSide", "isResolvedBy", "isBot", "type"} <= gs.unknown_query_fields(bad)
+
+
+def test_unknown_query_fields_accepts_aliased_real_fields():
+    # The fixed projection aliases real fields to the consumer keys; the real
+    # field names (diffSide/startDiffSide/__typename) are all schema-defined.
+    good = """
+    query Test($o:String!, $n:String!, $p:Int) {
+      repository(owner:$o,name:$n) { pullRequest(number:$p) { reviewThreads(first:50) {
+        pageInfo { hasNextPage endCursor }
+        nodes { id isResolved isOutdated subjectType path line originalLine
+                side: diffSide startSide: startDiffSide
+                comments(first:100) { nodes { id databaseId body
+                  author { login type: __typename } createdAt updatedAt url replyTo { id } } } }
+      } } }
+    }
+    """
+    assert gs.unknown_query_fields(good) == set()

--- a/tests/test_github_schema.py
+++ b/tests/test_github_schema.py
@@ -4,8 +4,6 @@ The minimal subset here covers exactly the types the two queries touch
 (PullRequestReviewThread, the comment node, Actor). It is the enforcement point
 for "requesting a nonexistent field fails CI, never in production".
 """
-import json
-
 from tests.harness import github_schema as gs
 
 


### PR DESCRIPTION
Closes #841

## Summary
Three independent defects block `daydream benchmark import-prs` from completing against a real private repository of non-trivial size (they surface in sequence):

1. **GraphQL schema** — the hand-rolled schema in the fake-gh harness validated fields too loosely, allowing invented review-thread projections. Rebuilt it as a type-scoped, explicitly-stacked parser (`tests/harness/github_schema.py`) that validates the review-thread GraphQL field set against the real schema; the schema-validation gate now lives inside the thread/reviewThreads dispatch branches in `fake_gh.py`.
2. **Diff-digest abbreviation** — pinned `core.abbrev=40` so diff digests are abbreviation-stable across environments, preventing spurious reconcile mismatches.
3. **Shared `base_tip` refspec** — forced the base_tip refspec so unrelated PRs don't collide on a shared base; regression-tested across unrelated PRs.

Adds an opt-in live smoke test for the full import-prs path and regression tests for each defect.

## Test Plan
- Full repo gate green: 4518 passed / 21 skipped
- ruff clean, mypy clean (390 files), lockcheck OK
- 10 commits, all authored by anderskev@gmail.com

## Reviewed By
Two sequential daydream deep-precision reviews on fresh exe.dev VMs (round 1 + round 2); round-2 fixed the final 2 findings (commit 9b97542). No CodeRabbit.