### PR TITLE
feat(benchmark): expose typed Harbor objectives and repository-suite aggregation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,11 @@ jobs:
         run: uv lock --check
 
       - name: Install dependencies
-        run: uv sync
+        # The benchmark extra (harbor) is required by the benchmark objective/
+        # aggregate tests in the default suite; a default `uv sync` installs it
+        # only on the (optional) benchmark extra. Install all extras so the full
+        # suite runs with every dependency it exercises.
+        run: uv sync --all-extras
 
       - name: Lint with ruff
         run: uv run ruff check daydream tests bench

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 .PHONY: install lint typecheck test check lockcheck hooks benchmark-report
 
 install:
-	uv sync
+	# All extras so `make check` runs the full suite (benchmark objective tests
+	# need the harbor package from the benchmark extra).
+	uv sync --all-extras
 
 lint:
 	uv run ruff check daydream tests bench

--- a/daydream/benchmark/cli.py
+++ b/daydream/benchmark/cli.py
@@ -456,13 +456,13 @@ def _build_benchmark_parser() -> argparse.ArgumentParser:
     """Build the ``daydream benchmark`` subcommand parser.
 
     Sub-verbs: ``init``, ``status``, ``validate``, ``build-harbor``, ``upgrade``, ``import-prs``,
-    ``curate``, ``calibrate-judge``, ``run``, ``clean``, ``objective``.
+    ``curate``, ``calibrate-judge``, ``run``, ``clean``, ``objective``, ``aggregate``.
     """
     parser = argparse.ArgumentParser(
         prog="daydream benchmark",
         description=(
             "Private PR benchmark workspace: init/status/validate/build-harbor/upgrade/"
-            "import-prs/curate/calibrate-judge/run/clean/objective."
+            "import-prs/curate/calibrate-judge/run/clean/objective/aggregate."
         ),
     )
     sub = parser.add_subparsers(dest="subcommand")
@@ -589,6 +589,19 @@ def _build_benchmark_parser() -> argparse.ArgumentParser:
         default=None,
         metavar="PATH|-",
         help="write the strict objective JSON to this path ('-' writes to stdout)",
+    )
+
+    aggregate_p = sub.add_parser(
+        "aggregate", help="pool a suite manifest of exact runs into one compatible objective JSON"
+    )
+    aggregate_p.add_argument(
+        "manifest", type=Path, help="suite manifest file (schema_version + entries of workspace/run_id)"
+    )
+    aggregate_p.add_argument(
+        "--json",
+        default=None,
+        metavar="PATH|-",
+        help="write the pooled suite objective JSON to this path ('-' writes to stdout)",
     )
 
     return parser
@@ -936,6 +949,93 @@ def _handle_benchmark_objective(args) -> int:
     return 0
 
 
+def _suite_objective_to_json(suite) -> dict[str, object]:
+    """Project a pooled ``SuiteObjective`` into opaque machine-readable JSON.
+
+    Produces the stable ``experiment_id``, the shared ``profile_digest``, the
+    full ``identity`` dict (identical across every pooled entry), and the
+    count-derived ``objective`` dict projected in the authoritative
+    ``aggregate_metrics`` key/shaper set. No repository slug, PR number, source
+    path, sample text, judge reasoning, or source code is emitted; only opaque
+    ids and counts pass through (privacy must-have).
+    """
+    identity = suite.identity
+    objective_json = suite.objective._as_metric_dict()
+    return {
+        "experiment_id": suite.experiment_id,
+        "profile_digest": suite.profile_digest,
+        "identity": {
+            "objective_schema_version": identity.objective_schema_version,
+            "profile_schema_version": identity.profile_schema_version,
+            "profile_name": identity.profile_name,
+            "profile_digest": identity.profile_digest,
+            "daydream_version": identity.daydream_version,
+            "daydream_wheel_sha256": identity.daydream_wheel_sha256,
+            "compiled_lock_sha256": identity.compiled_lock_sha256,
+            "harbor_version": identity.harbor_version,
+            "reviewer_backend": identity.reviewer_backend,
+            "reviewer_model": identity.reviewer_model,
+            "reviewer_base_url": identity.reviewer_base_url,
+            "reviewer_effort": identity.reviewer_effort,
+            "judge_provider": identity.judge_provider,
+            "judge_model": identity.judge_model,
+            "judge_host": identity.judge_host,
+            "verifier_template_sha256": identity.verifier_template_sha256,
+            "threshold": identity.threshold,
+            "attempts": identity.attempts,
+        },
+        "objective": objective_json,
+    }
+
+
+def _handle_benchmark_aggregate(args) -> int:
+    """Pool a suite manifest of exact runs into one compatible objective JSON (issue #888).
+
+    Loads the manifest through ``storage.load_json_strict``, then drives
+    ``objective.aggregate_suite`` (which fails closed on any missing/incomplete/
+    incompatible/malformed/duplicated entry — never a silently-subsetted pool).
+    When ``--json`` is set, the strict suite objective is written through
+    ``storage.atomic_write_json`` (or printed on ``-``); an expected
+    ``ObjectiveError``/``WorkspaceCorrupt`` prints to stderr and returns exit
+    ``1`` without touching an existing output file — never a bare traceback.
+    The shared profile digest and full compatibility identity are always printed
+    to stdout.
+    """
+    from daydream.benchmark.harbor import objective
+    from daydream.benchmark.storage import WorkspaceCorrupt, atomic_write_json, load_json_strict
+
+    try:
+        manifest = load_json_strict(args.manifest)
+        suite = objective.aggregate_suite(manifest, env=dict(os.environ))
+    except objective.ObjectiveError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    except WorkspaceCorrupt as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    blob = _suite_objective_to_json(suite)
+    if args.json is not None:
+        if args.json == "-":
+            print(json.dumps(blob, indent=2))
+        else:
+            atomic_write_json(Path(args.json), blob)
+
+    identity = suite.identity
+    print(f"profile digest: {suite.profile_digest or ''}")
+    print(
+        "identity: "
+        f"profile={identity.profile_name} "
+        f"reviewer={identity.reviewer_backend}/{identity.reviewer_model} "
+        f"judge={identity.judge_provider}/{identity.judge_model}"
+    )
+    print(
+        f"aggregate {suite.objective.task_count} tasks, "
+        f"micro_f1={suite.objective.f1:.4f}, experiment_id={suite.experiment_id}"
+    )
+    return 0
+
+
 def _handle_benchmark_command(argv: list[str]) -> int:
     """Handle ``daydream benchmark init|status|validate|build-harbor|upgrade|import-prs|curate``.
 
@@ -943,9 +1043,10 @@ def _handle_benchmark_command(argv: list[str]) -> int:
     process exit. Expected workspace errors (``InitError``/``WorkspaceCorrupt``/
     ``ImportTargetError``/``PreflightError``/``CurationError``) are printed to
     stderr and mapped to exit ``1`` — never a bare traceback. ``run`` dispatches
-    to :func:`_handle_benchmark_run` (the supervised Harbor runner) and
+    to :func:`_handle_benchmark_run` (the supervised Harbor runner),
     ``objective`` to :func:`_handle_benchmark_objective` (the read-only
-    machine-readable run resolution).
+    machine-readable run resolution), and ``aggregate`` to
+    :func:`_handle_benchmark_aggregate` (the pooled suite objective).
     """
 
     parser = _build_benchmark_parser()
@@ -976,5 +1077,7 @@ def _handle_benchmark_command(argv: list[str]) -> int:
         return _handle_benchmark_clean(args)
     if sub == "objective":
         return _handle_benchmark_objective(args)
+    if sub == "aggregate":
+        return _handle_benchmark_aggregate(args)
     parser.print_help(file=sys.stderr)
     return 2

--- a/daydream/benchmark/cli.py
+++ b/daydream/benchmark/cli.py
@@ -939,14 +939,19 @@ def _handle_benchmark_objective(args) -> int:
             atomic_write_json(Path(args.json), blob)
 
     obj = run.objective
+    # In ``--json -`` mode stdout must stay pure JSON (issue #888 machine-readable
+    # contract); route the human summary to stderr so ``jq``/``> file.json`` sees
+    # only the blob.
+    out_stream = sys.stderr if args.json == "-" else sys.stdout
     if obj is not None:
         print(
             f"objective {run.run_id}: comparison_eligible={obj.comparison_eligible} "
             f"micro_f1={obj.f1:.4f} tasks={obj.task_count} "
-            f"scored={obj.scored_task_count} infra={obj.infra_error_task_count}"
+            f"scored={obj.scored_task_count} infra={obj.infra_error_task_count}",
+            file=out_stream,
         )
     else:
-        print(f"objective {run.run_id}: no objective (unscored run)")
+        print(f"objective {run.run_id}: no objective (unscored run)", file=out_stream)
     return 0
 
 
@@ -960,31 +965,14 @@ def _suite_objective_to_json(suite) -> dict[str, object]:
     path, sample text, judge reasoning, or source code is emitted; only opaque
     ids and counts pass through (privacy must-have).
     """
+    from daydream.benchmark.harbor import objective
+
     identity = suite.identity
     objective_json = suite.objective._as_metric_dict()
     return {
         "experiment_id": suite.experiment_id,
         "profile_digest": suite.profile_digest,
-        "identity": {
-            "objective_schema_version": identity.objective_schema_version,
-            "profile_schema_version": identity.profile_schema_version,
-            "profile_name": identity.profile_name,
-            "profile_digest": identity.profile_digest,
-            "daydream_version": identity.daydream_version,
-            "daydream_wheel_sha256": identity.daydream_wheel_sha256,
-            "compiled_lock_sha256": identity.compiled_lock_sha256,
-            "harbor_version": identity.harbor_version,
-            "reviewer_backend": identity.reviewer_backend,
-            "reviewer_model": identity.reviewer_model,
-            "reviewer_base_url": identity.reviewer_base_url,
-            "reviewer_effort": identity.reviewer_effort,
-            "judge_provider": identity.judge_provider,
-            "judge_model": identity.judge_model,
-            "judge_host": identity.judge_host,
-            "verifier_template_sha256": identity.verifier_template_sha256,
-            "threshold": identity.threshold,
-            "attempts": identity.attempts,
-        },
+        "identity": objective.identity_to_dict(identity),
         "objective": objective_json,
     }
 
@@ -1023,16 +1011,21 @@ def _handle_benchmark_aggregate(args) -> int:
             atomic_write_json(Path(args.json), blob)
 
     identity = suite.identity
-    print(f"profile digest: {suite.profile_digest or ''}")
+    # In ``--json -`` mode stdout must stay pure JSON; route the human summary
+    # to stderr so a ``jq``/file-redirect consumer sees only the blob.
+    out_stream = sys.stderr if args.json == "-" else sys.stdout
+    print(f"profile digest: {suite.profile_digest or ''}", file=out_stream)
     print(
         "identity: "
         f"profile={identity.profile_name} "
         f"reviewer={identity.reviewer_backend}/{identity.reviewer_model} "
-        f"judge={identity.judge_provider}/{identity.judge_model}"
+        f"judge={identity.judge_provider}/{identity.judge_model}",
+        file=out_stream,
     )
     print(
         f"aggregate {suite.objective.task_count} tasks, "
-        f"micro_f1={suite.objective.f1:.4f}, experiment_id={suite.experiment_id}"
+        f"micro_f1={suite.objective.f1:.4f}, experiment_id={suite.experiment_id}",
+        file=out_stream,
     )
     return 0
 

--- a/daydream/benchmark/cli.py
+++ b/daydream/benchmark/cli.py
@@ -16,6 +16,7 @@ checkout (``--benchmark-repo``) or a harvested dir (``--harvest-dir``).
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import sys
 from pathlib import Path
@@ -455,13 +456,13 @@ def _build_benchmark_parser() -> argparse.ArgumentParser:
     """Build the ``daydream benchmark`` subcommand parser.
 
     Sub-verbs: ``init``, ``status``, ``validate``, ``build-harbor``, ``upgrade``, ``import-prs``,
-    ``curate``, ``calibrate-judge``, ``run``, ``clean``.
+    ``curate``, ``calibrate-judge``, ``run``, ``clean``, ``objective``.
     """
     parser = argparse.ArgumentParser(
         prog="daydream benchmark",
         description=(
             "Private PR benchmark workspace: init/status/validate/build-harbor/upgrade/"
-            "import-prs/curate/calibrate-judge/run/clean."
+            "import-prs/curate/calibrate-judge/run/clean/objective."
         ),
     )
     sub = parser.add_subparsers(dest="subcommand")
@@ -576,6 +577,18 @@ def _build_benchmark_parser() -> argparse.ArgumentParser:
     )
     clean_p.add_argument(
         "--yes", action="store_true", help="confirm --all without prompting"
+    )
+
+    objective_p = sub.add_parser(
+        "objective", help="resolve an exact completed run as machine-readable JSON"
+    )
+    objective_p.add_argument("dir", type=Path, help="workspace directory")
+    objective_p.add_argument("--run-id", required=True, help="exact ledgered run id")
+    objective_p.add_argument(
+        "--json",
+        default=None,
+        metavar="PATH|-",
+        help="write the strict objective JSON to this path ('-' writes to stdout)",
     )
 
     return parser
@@ -884,6 +897,45 @@ def _handle_benchmark_curate(args) -> int:
     return 0
 
 
+def _handle_benchmark_objective(args) -> int:
+    """Resolve an exact completed run and emit its machine-readable objective.
+
+    ``--json`` serializes the opaque privacy-safe objective via
+    ``objective.objective_to_json`` and writes it through
+    ``storage.atomic_write_json`` (or prints it directly on ``-``); a parse/
+    compat failure leaves an existing output file byte-identical. Without
+    ``--json``, prints a concise local summary (run_id, comparison_eligible,
+    micro F1, task/infra counts) to stdout. Expected ``ObjectiveError`` prints
+    to stderr and returns exit ``1`` — never a bare traceback.
+    """
+    from daydream.benchmark.harbor import objective
+    from daydream.benchmark.storage import atomic_write_json
+
+    try:
+        run = objective.read_completed_run(args.dir, args.run_id, env=dict(os.environ))
+    except objective.ObjectiveError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    if args.json is not None:
+        blob = objective.objective_to_json(run)
+        if args.json == "-":
+            print(json.dumps(blob, indent=2))
+        else:
+            atomic_write_json(Path(args.json), blob)
+
+    obj = run.objective
+    if obj is not None:
+        print(
+            f"objective {run.run_id}: comparison_eligible={obj.comparison_eligible} "
+            f"micro_f1={obj.f1:.4f} tasks={obj.task_count} "
+            f"scored={obj.scored_task_count} infra={obj.infra_error_task_count}"
+        )
+    else:
+        print(f"objective {run.run_id}: no objective (unscored run)")
+    return 0
+
+
 def _handle_benchmark_command(argv: list[str]) -> int:
     """Handle ``daydream benchmark init|status|validate|build-harbor|upgrade|import-prs|curate``.
 
@@ -891,7 +943,9 @@ def _handle_benchmark_command(argv: list[str]) -> int:
     process exit. Expected workspace errors (``InitError``/``WorkspaceCorrupt``/
     ``ImportTargetError``/``PreflightError``/``CurationError``) are printed to
     stderr and mapped to exit ``1`` — never a bare traceback. ``run`` dispatches
-    to :func:`_handle_benchmark_run` (the supervised Harbor runner).
+    to :func:`_handle_benchmark_run` (the supervised Harbor runner) and
+    ``objective`` to :func:`_handle_benchmark_objective` (the read-only
+    machine-readable run resolution).
     """
 
     parser = _build_benchmark_parser()
@@ -920,5 +974,7 @@ def _handle_benchmark_command(argv: list[str]) -> int:
         return _handle_benchmark_run(args)
     if sub == "clean":
         return _handle_benchmark_clean(args)
+    if sub == "objective":
+        return _handle_benchmark_objective(args)
     parser.print_help(file=sys.stderr)
     return 2

--- a/daydream/benchmark/cli.py
+++ b/daydream/benchmark/cli.py
@@ -798,6 +798,7 @@ def _handle_benchmark_run(args) -> int:
             "DAYDREAM_REVIEW_MODEL",
             "DAYDREAM_REVIEW_API_KEY",
             "DAYDREAM_REVIEW_BASE_URL",
+            "DAYDREAM_REVIEW_EFFORT",
             "DAYDREAM_JUDGE_PROVIDER",
             "DAYDREAM_JUDGE_MODEL",
             "DAYDREAM_JUDGE_API_KEY",

--- a/daydream/benchmark/harbor/objective.py
+++ b/daydream/benchmark/harbor/objective.py
@@ -196,9 +196,81 @@ def read_completed_run(
 _OBJECTIVE_SCHEMA_VERSION = 1
 
 
-# The review-profile schema version this plan's identity binds (the current
-# ``ReviewProfile.schema_version``). There is no read-only source for a loaded
-# profile's ``name`` here, so it stays empty rather than fabricated.
+def objective_to_json(run: CompletedRun) -> dict[str, object]:
+    """Project a completed run into opaque, privacy-safe machine-readable JSON.
+
+    Produces only the opaque ``run_id``, ``mode``, ``schema_version``, the
+    ``identity`` dict, and the ``objective`` dict (counts + ``comparison_eligible``
+    + optional ``tokens``/``cost``). No repository slug, PR number, source path,
+    gold/candidate text, judge reasoning, or source code is ever emitted; only
+    opaque benchmark/run ids and counts pass through (spec privacy must-have).
+
+    The ledger entry's ``job_dir`` is deliberately dropped before projection so
+    the workspace filesystem path never leaks into the output.
+    """
+    identity = run.identity
+    identity_json = None
+    if identity is not None:
+        identity_json = {
+            "objective_schema_version": identity.objective_schema_version,
+            "profile_schema_version": identity.profile_schema_version,
+            "profile_name": identity.profile_name,
+            "profile_digest": identity.profile_digest,
+            "daydream_version": identity.daydream_version,
+            "daydream_wheel_sha256": identity.daydream_wheel_sha256,
+            "compiled_lock_sha256": identity.compiled_lock_sha256,
+            "harbor_version": identity.harbor_version,
+            "reviewer_backend": identity.reviewer_backend,
+            "reviewer_model": identity.reviewer_model,
+            "reviewer_base_url": identity.reviewer_base_url,
+            "reviewer_effort": identity.reviewer_effort,
+            "judge_provider": identity.judge_provider,
+            "judge_model": identity.judge_model,
+            "judge_host": identity.judge_host,
+            "verifier_template_sha256": identity.verifier_template_sha256,
+            "threshold": identity.threshold,
+            "attempts": identity.attempts,
+        }
+
+    objective_dict: dict[str, object] | None = None
+    if run.objective is not None:
+        obj = run.objective
+        objective_dict = {
+            "tp": obj.tp,
+            "fp": obj.fp,
+            "fn": obj.fn,
+            "precision": obj.precision,
+            "recall": obj.recall,
+            "f1": obj.f1,
+            "clean_task_count": obj.clean_task_count,
+            "clean_pass_count": obj.clean_pass_count,
+            "clean_accuracy": obj.clean_accuracy,
+            "task_count": obj.task_count,
+            "scored_task_count": obj.scored_task_count,
+            "candidate_count": obj.candidate_count,
+            "gold_count": obj.gold_count,
+            "infra_error_task_count": obj.infra_error_task_count,
+            "verifier_error_task_count": obj.verifier_error_task_count,
+            "malformed_task_count": obj.malformed_task_count,
+            "failed_task_count": obj.failed_task_count,
+            "comparison_eligible": obj.comparison_eligible,
+            "mean_task_score": obj.mean_task_score,
+        }
+        if obj.tokens is not None:
+            objective_dict["tokens"] = obj.tokens
+        if obj.cost is not None:
+            objective_dict["cost"] = obj.cost
+
+    return {
+        "run_id": run.run_id,
+        "mode": run.mode,
+        "schema_version": _OBJECTIVE_SCHEMA_VERSION,
+        "identity": identity_json,
+        "objective": objective_dict,
+    }
+
+
+
 _PROFILE_SCHEMA_VERSION = 1
 
 

--- a/daydream/benchmark/harbor/objective.py
+++ b/daydream/benchmark/harbor/objective.py
@@ -1,0 +1,81 @@
+"""Read-only resolution of exact completed Harbor benchmark runs (issue #888).
+
+A future optimizer can consume an attributable, machine-readable Harbor
+objective for any exact completed run. This module is the read-only surface:
+it resolves a ledgered run by explicit ``run_id``, validates it reached a
+terminal ``complete`` state, and binds its identity/metrics in later tasks.
+
+Everything here is strictly read-only and immutable. State is modelled with
+frozen dataclasses; ``_load_ledger`` is reused from ``run`` so the reader never
+re-implements ledger parsing or validation — it only filters on ``state``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from daydream.benchmark.harbor import run as run_mod
+
+
+class ObjectiveError(Exception):
+    """The single typed error for objective resolution.
+
+    Raised when a run is absent from the ledger, is not in a terminal
+    ``complete`` state, or the ledger itself fails to parse/validate. The
+    message always names the offending artifact path and run id.
+    """
+
+
+@dataclass(frozen=True)
+class CompletedRun:
+    """Immutable projection of a ledgered, completed benchmark run."""
+
+    run_id: str
+    mode: str
+    state: str
+    # Bound in Task 3 (full compatibility identity).
+    identity: Any | None = None
+    # Per-task reward rows (flattened); populated in Task 2.
+    task_rows: list[dict[str, object] | None] = field(default_factory=list)
+    # Bound in Task 4 (count-derived objective).
+    objective: Any | None = None
+
+
+def read_completed_run(
+    workspace: Path, run_id: str, *, env: dict[str, Any] | None = None
+) -> CompletedRun:
+    """Resolve a ledgered run by explicit ``run_id``.
+
+    Loads the ledger through ``run_mod._load_ledger`` and admits only a run
+    whose ``state == "complete"``. Missing runs, running/cleanup-pending/
+    cleaned runs, and any ledger parse/validation failure all fail closed with
+    an ``ObjectiveError`` naming the run id and workspace.
+    """
+    del env  # reserved for provenance binding in later tasks.
+    try:
+        doc = run_mod._load_ledger(workspace)
+    except run_mod.RunError as exc:
+        raise ObjectiveError(f"ledger failure at {workspace}: {exc}") from exc
+
+    entry = None
+    for run in doc["runs"]:
+        if run.get("run_id") == run_id:
+            entry = run
+            break
+
+    if entry is None:
+        raise ObjectiveError(
+            f"run {run_id!r} not found in the harbor ledger at {workspace}"
+        )
+    if entry.get("state") != "complete":
+        raise ObjectiveError(
+            f"run {run_id!r} at {workspace} is not complete "
+            f"(state {entry.get('state')!r})"
+        )
+
+    return CompletedRun(
+        run_id=entry["run_id"],
+        mode=entry["mode"],
+        state=entry["state"],
+    )

--- a/daydream/benchmark/harbor/objective.py
+++ b/daydream/benchmark/harbor/objective.py
@@ -3,33 +3,73 @@
 A future optimizer can consume an attributable, machine-readable Harbor
 objective for any exact completed run. This module is the read-only surface:
 it resolves a ledgered run by explicit ``run_id``, validates it reached a
-terminal ``complete`` state, and binds its identity/metrics in later tasks.
+terminal ``complete`` state, parses its per-task reward artifacts in strict
+fail-closed fashion, and binds its count-derived micro-metrics.
 
 Everything here is strictly read-only and immutable. State is modelled with
-frozen dataclasses; ``_load_ledger`` is reused from ``run`` so the reader never
-re-implements ledger parsing or validation — it only filters on ``state``.
+frozen dataclasses; ``_load_ledger`` and ``_validate_job_dir`` are reused from
+``run`` so the reader never re-implements ledger parsing, validation, or job
+dir containment — it only filters on ``state`` and reads the reward rows.
 """
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 from daydream.benchmark.harbor import run as run_mod
+from daydream.benchmark.harbor import verifier_core
 
 
 class ObjectiveError(Exception):
     """The single typed error for objective resolution.
 
     Raised when a run is absent from the ledger, is not in a terminal
-    ``complete`` state, or the ledger itself fails to parse/validate. The
-    message always names the offending artifact path and run id.
+    ``complete`` state, the ledger fails to parse/validate, or any per-task
+    reward artifact is malformed. The message always names the offending
+    artifact path and run id.
     """
 
 
 @dataclass(frozen=True)
+class Objective:
+    """Count-derived micro-metrics for a single completed run.
+
+    TP/FP/FN are pooled (never per-task averaged) along with the clean/task/
+    infra counts by feeding the flattened per-task reward rows through
+    ``verifier_core.aggregate_metrics`` — the same authoritative scorer the
+    generated corpus uses. ``comparison_eligible`` is ``False`` whenever any
+    trial failed to produce a legitimate scored row and must not participate
+    in comparison.
+    """
+
+    tp: int
+    fp: int
+    fn: int
+    precision: float
+    recall: float
+    f1: float
+    clean_task_count: int
+    clean_pass_count: int
+    clean_accuracy: float
+    task_count: int
+    scored_task_count: int
+    candidate_count: int
+    gold_count: int
+    infra_error_task_count: int
+    verifier_error_task_count: int
+    malformed_task_count: int
+    failed_task_count: int
+    comparison_eligible: bool
+    mean_task_score: float
+    tokens: float | None = None
+    cost: float | None = None
+
+
+@dataclass(frozen=True)
 class CompletedRun:
-    """Immutable projection of a ledgered, completed benchmark run."""
+    """Immutable projection of a completed, ledgered benchmark run."""
 
     run_id: str
     mode: str
@@ -38,8 +78,10 @@ class CompletedRun:
     identity: Any | None = None
     # Per-task reward rows (flattened); populated in Task 2.
     task_rows: list[dict[str, object] | None] = field(default_factory=list)
-    # Bound in Task 4 (count-derived objective).
-    objective: Any | None = None
+    # Count-derived objective (populated in Task 2).
+    objective: Objective | None = None
+    # The validated, contained job dir this run executed under.
+    job_dir: str = ""
 
 
 def read_completed_run(
@@ -48,9 +90,11 @@ def read_completed_run(
     """Resolve a ledgered run by explicit ``run_id``.
 
     Loads the ledger through ``run_mod._load_ledger`` and admits only a run
-    whose ``state == "complete"``. Missing runs, running/cleanup-pending/
-    cleaned runs, and any ledger parse/validation failure all fail closed with
-    an ``ObjectiveError`` naming the run id and workspace.
+    whose ``state == "complete"``, then parses its per-task reward rows in
+    strict fail-closed fashion and binds the count-derived ``Objective``.
+    Missing runs, running/cleanup-pending/cleaned runs, any ledger parse/
+    validation failure, and any malformed reward artifact all fail closed with
+    an ``ObjectiveError`` naming the run id and the offending artifact.
     """
     del env  # reserved for provenance binding in later tasks.
     try:
@@ -74,8 +118,164 @@ def read_completed_run(
             f"(state {entry.get('state')!r})"
         )
 
+    job_dir = run_mod._validate_job_dir(workspace, str(entry.get("job_dir") or ""))
+    rows, infra_errors = _parse_task_rows(Path(job_dir), run_id)
+    objective = _build_objective(rows, infra_errors)
+
     return CompletedRun(
         run_id=entry["run_id"],
         mode=entry["mode"],
         state=entry["state"],
+        task_rows=rows,
+        objective=objective,
+        job_dir=job_dir,
+    )
+
+
+# The integer count keys a scored task must carry as JSON integers (mirrors
+# the generated reward-row shape consumed by ``verifier_core.aggregate_metrics``).
+_SCORED_COUNT_KEYS = ("tp", "fp", "fn")
+
+
+def _parse_task_rows(
+    job_dir: Path, run_id: str
+) -> tuple[list[dict[str, object] | None], int]:
+    """Read the run's per-task reward rows in strict fail-closed fashion.
+
+    Walks the job dir exactly as ``run_mod._parse_job_results`` does (sorted
+    trial subdirectories with ``<trial>/verifier/``): a scored task has a
+    ``reward.json`` (parsed as a strict reward dict); a trial with only
+    ``reward-details.json`` is an unscored infra failure and becomes a ``None``
+    row (never a numeric zero).
+
+    A task with ``clean_task == 1`` and zero findings/candidates is a
+    legitimate clean task — it stays a scored row, never an infra failure. Any
+    malformed ``reward.json`` (bad JSON, non-object, a non-integer count, any
+    non-finite/negative value) raises ``ObjectiveError`` naming the artifact
+    and run id.
+    """
+    if not job_dir.is_dir():
+        return [], 0
+    rows: list[dict[str, object] | None] = []
+    infra_errors = 0
+    for trial in sorted(job_dir.iterdir()):
+        if not trial.is_dir():
+            continue  # a non-directory sibling is not a task trial
+        verifier = trial / "verifier"
+        reward_path = verifier / "reward.json"
+        if reward_path.is_file():
+            row = _parse_reward_strict(reward_path, run_id)
+            rows.append(row)
+        elif (verifier / "reward-details.json").is_file():
+            # Unscored infra trial (never a numeric zero).
+            rows.append(None)
+            infra_errors += 1
+        else:
+            raise ObjectiveError(
+                f"trial {trial.name} in run {run_id!r} has no score evidence at "
+                f"{reward_path}"
+            )
+    return rows, infra_errors
+
+
+def _parse_reward_strict(reward_path: Path, run_id: str) -> dict[str, object]:
+    """Parse one ``reward.json`` into a strict reward dict.
+
+    Fails closed on any malformed artifact: non-object JSON, a non-integer
+    ``tp``/``fp``/``fn``/``verifier_error``, a negative or non-finite count, or
+    a non-numeric ``reward``. The error message always names the artifact path
+    and run id. Never ``unwrap_or`` a plausible default or coerce a malformed
+    numeric to zero.
+    """
+    try:
+        data = json.loads(reward_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ObjectiveError(
+            f"malformed reward artifact at {reward_path} in run {run_id!r}: {exc}"
+        ) from exc
+    if not isinstance(data, dict):
+        raise ObjectiveError(
+            f"reward artifact at {reward_path} in run {run_id!r} is not an object"
+        )
+
+    for key in _SCORED_COUNT_KEYS:
+        value = data.get(key)
+        if not _is_int(value):
+            raise ObjectiveError(
+                f"reward artifact at {reward_path} in run {run_id!r} has "
+                f"non-integer {key!r}: {value!r}"
+            )
+        if int(value) < 0:
+            raise ObjectiveError(
+                f"reward artifact at {reward_path} in run {run_id!r} has "
+                f"negative {key!r}: {value!r}"
+            )
+
+    reward = data.get("reward")
+    if not isinstance(reward, (int, float)) or isinstance(reward, bool):
+        raise ObjectiveError(
+            f"reward artifact at {reward_path} in run {run_id!r} has "
+            f"non-numeric reward: {reward!r}"
+        )
+    if not _is_finite(reward):
+        raise ObjectiveError(
+            f"reward artifact at {reward_path} in run {run_id!r} has "
+            f"non-finite reward: {reward!r}"
+        )
+    return data
+
+
+def _is_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _is_finite(value: float) -> bool:
+    return value == value and value not in (float("inf"), float("-inf"))
+
+
+def _build_objective(
+    rows: list[dict[str, object] | None], infra_errors: int
+) -> Objective:
+    """Populate the count-derived ``Objective`` from the parsed rows.
+
+    TP/FP/FN, precision/recall/f1 and the clean/task/scored/infra counts come
+    from feeding the rows (infra rows included) through
+    ``verifier_core.aggregate_metrics`` — the same authoritative pool the
+    generated corpus metrics use. The verifier-error count is derived from the
+    rows' ``verifier_error`` flags. ``comparison_eligible`` is ``False``
+    whenever any trial failed to produce a legitimate scored row.
+    """
+    agg = verifier_core.aggregate_metrics(rows)
+    verifier_errors = sum(
+        1 for row in rows if row is not None and int(row.get("verifier_error") or 0) == 1
+    )
+    # Malformed rows fail closed in ``_parse_reward_strict`` and so never reach
+    # this pool; the count stays zero by construction.
+    malformed = 0
+    failed = max(verifier_errors, infra_errors)
+    candidate_count = sum(
+        int(row["candidate_count"]) for row in rows if row is not None
+    )
+    gold_count = sum(int(row["gold_count"]) for row in rows if row is not None)
+    clean_task_count = int(agg["clean_task_count"])
+    return Objective(
+        tp=int(agg["total_tp"]),
+        fp=int(agg["total_fp"]),
+        fn=int(agg["total_fn"]),
+        precision=float(agg["micro_precision"]),
+        recall=float(agg["micro_recall"]),
+        f1=float(agg["micro_f1"]),
+        clean_task_count=clean_task_count,
+        clean_pass_count=int(round(agg["clean_accuracy"] * clean_task_count)),
+        clean_accuracy=float(agg["clean_accuracy"]),
+        task_count=int(agg["task_count"]),
+        scored_task_count=int(agg["scored_task_count"]),
+        candidate_count=candidate_count,
+        gold_count=gold_count,
+        infra_error_task_count=int(agg["infra_error_task_count"]),
+        verifier_error_task_count=verifier_errors,
+        malformed_task_count=malformed,
+        failed_task_count=failed,
+        comparison_eligible=not (infra_errors + verifier_errors + malformed + failed),
+        mean_task_score=float(agg["mean_task_score"]),
     )

--- a/daydream/benchmark/harbor/objective.py
+++ b/daydream/benchmark/harbor/objective.py
@@ -150,11 +150,14 @@ class SuiteManifest:
     entries: tuple[SuiteEntry, ...]
 
 
-def _compatibility_fields(identity: CompatibilityIdentity) -> dict[str, object]:
-    """Every compatibility field that must match across a pooled suite.
+def identity_to_dict(identity: CompatibilityIdentity) -> dict[str, object]:
+    """Canonical 18-field compatibility/identity projection.
 
-    Repository/benchmark ids and the per-run ``run_id`` are deliberately not
-    part of the identity and so are free to differ across entries.
+    Single source of truth for the identity mapping reused by
+    ``objective_to_json``, the suite aggregate identity, and the CLI's
+    ``_suite_objective_to_json`` (issue #888 anti-slop: adding/renaming a field
+    in one place must not silently desynchronize the others). Repository/
+    benchmark ids are deliberately not part of the identity.
     """
     return {
         "objective_schema_version": identity.objective_schema_version,
@@ -176,6 +179,15 @@ def _compatibility_fields(identity: CompatibilityIdentity) -> dict[str, object]:
         "threshold": identity.threshold,
         "attempts": identity.attempts,
     }
+
+
+def _compatibility_fields(identity: CompatibilityIdentity) -> dict[str, object]:
+    """Every compatibility field that must match across a pooled suite.
+
+    Repository/benchmark ids and the per-run ``run_id`` are deliberately not
+    part of the identity and so are free to differ across entries.
+    """
+    return identity_to_dict(identity)
 
 
 @dataclass(frozen=True)
@@ -287,26 +299,7 @@ def objective_to_json(run: CompletedRun) -> dict[str, object]:
     identity = run.identity
     identity_json = None
     if identity is not None:
-        identity_json = {
-            "objective_schema_version": identity.objective_schema_version,
-            "profile_schema_version": identity.profile_schema_version,
-            "profile_name": identity.profile_name,
-            "profile_digest": identity.profile_digest,
-            "daydream_version": identity.daydream_version,
-            "daydream_wheel_sha256": identity.daydream_wheel_sha256,
-            "compiled_lock_sha256": identity.compiled_lock_sha256,
-            "harbor_version": identity.harbor_version,
-            "reviewer_backend": identity.reviewer_backend,
-            "reviewer_model": identity.reviewer_model,
-            "reviewer_base_url": identity.reviewer_base_url,
-            "reviewer_effort": identity.reviewer_effort,
-            "judge_provider": identity.judge_provider,
-            "judge_model": identity.judge_model,
-            "judge_host": identity.judge_host,
-            "verifier_template_sha256": identity.verifier_template_sha256,
-            "threshold": identity.threshold,
-            "attempts": identity.attempts,
-        }
+        identity_json = identity_to_dict(identity)
 
     objective_dict: dict[str, object] | None = None
     if run.objective is not None:
@@ -535,20 +528,10 @@ def _bind_identity(
             f"on-disk compiled lock at {workspace / 'harbor' / 'benchmark.lock.json'}"
         )
 
-    lock = _load_compiled_lock(workspace, run_id)
-    day = lock.get("daydream")
-    if not isinstance(day, dict):
-        raise ObjectiveError(
-            f"run {run_id!r}: compiled lock at {workspace / 'harbor' / 'benchmark.lock.json'}"
-            f" is missing its 'daydream' wheel block"
-        )
-    wheel_sha = day.get("sha256")
-    wheel_version = day.get("version")
-    if not isinstance(wheel_sha, str) or not wheel_sha or not isinstance(wheel_version, str):
-        raise ObjectiveError(
-            f"run {run_id!r}: compiled lock at {workspace / 'harbor' / 'benchmark.lock.json'}"
-            f" has a malformed or missing 'daydream' wheel digest/version"
-        )
+    try:
+        wheel_version, wheel_sha = run_mod._compiled_daydream_wheel(workspace)
+    except run_mod.RunError as exc:
+        raise ObjectiveError(f"run {run_id!r}: {exc}") from exc
 
     try:
         harbor_version = ".".join(
@@ -592,20 +575,6 @@ def _bind_identity(
     )
 
 
-def _load_compiled_lock(workspace: Path, run_id: str) -> dict[str, Any]:
-    """Read the compiled ``harbor/benchmark.lock.json`` strictly."""
-    path = workspace / "harbor" / "benchmark.lock.json"
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise ObjectiveError(
-            f"run {run_id!r}: cannot read compiled lock at {path}: {exc}"
-        ) from exc
-    if not isinstance(data, dict):
-        raise ObjectiveError(f"run {run_id!r}: compiled lock at {path} must be a mapping")
-    return data
-
-
 # The integer count keys a scored task must carry as JSON integers (mirrors
 # the generated reward-row shape consumed by ``verifier_core.aggregate_metrics``).
 _SCORED_COUNT_KEYS = ("tp", "fp", "fn")
@@ -632,9 +601,7 @@ def _parse_task_rows(
         return [], 0
     rows: list[dict[str, object] | None] = []
     infra_errors = 0
-    for trial in sorted(job_dir.iterdir()):
-        if not trial.is_dir():
-            continue  # a non-directory sibling is not a task trial
+    for trial in run_mod._iter_trial_dirs(job_dir):
         verifier = trial / "verifier"
         reward_path = verifier / "reward.json"
         if reward_path.is_file():

--- a/daydream/benchmark/harbor/objective.py
+++ b/daydream/benchmark/harbor/objective.py
@@ -124,6 +124,32 @@ class CompatibilityIdentity:
 
 
 @dataclass(frozen=True)
+class SuiteEntry:
+    """One exact completion referenced by a suite manifest.
+
+    ``workspace`` is the repository workspace path the run was recorded against
+    and ``run_id`` resolves the exact ledgered completion within it. Instances
+    are immutable and preserve manifest order.
+    """
+
+    workspace: Path
+    run_id: str
+
+
+@dataclass(frozen=True)
+class SuiteManifest:
+    """A validated, versioned manifest of exact completions to pool.
+
+    ``entries`` is a tuple of ``SuiteEntry`` in manifest order. Instances are
+    immutable; every entry was already validated to carry a ``workspace`` and
+    ``run_id`` and to be unique by ``(workspace, run_id)``.
+    """
+
+    schema_version: int
+    entries: tuple[SuiteEntry, ...]
+
+
+@dataclass(frozen=True)
 class CompletedRun:
     """Immutable projection of a completed, ledgered benchmark run."""
 
@@ -272,6 +298,55 @@ def objective_to_json(run: CompletedRun) -> dict[str, object]:
 
 
 _PROFILE_SCHEMA_VERSION = 1
+
+_SUITE_SCHEMA_VERSION = 1
+
+
+def validate_suite_manifest(manifest: dict) -> list[SuiteEntry]:
+    """Validate a suite manifest and return its entries in manifest order.
+
+    Rejects a manifest whose ``schema_version`` is not 1, a missing/non-list
+    ``entries``, a non-dict entry, or an entry missing ``workspace``/``run_id``
+    --- every failure raises ``ObjectiveError``. Any duplicated
+    ``(workspace, run_id)`` pair is also rejected, naming the offending entry
+    and its index. Bad entries are never skipped nor coerced to a default;
+    the error always carries the entry index and offending field.
+    """
+    if not isinstance(manifest, dict):
+        raise ObjectiveError("suite manifest must be a mapping object")
+    if manifest.get("schema_version") != _SUITE_SCHEMA_VERSION:
+        raise ObjectiveError(
+            f"suite manifest has unsupported schema_version "
+            f"{manifest.get('schema_version')!r}"
+        )
+    entries = manifest.get("entries")
+    if not isinstance(entries, list):
+        raise ObjectiveError("suite manifest is missing its entries list")
+
+    result: list[SuiteEntry] = []
+    seen: set[tuple[str, str]] = set()
+    for index, raw in enumerate(entries):
+        if not isinstance(raw, dict):
+            raise ObjectiveError(
+                f"suite manifest entry #{index} is not an object: {raw!r}"
+            )
+        missing = [key for key in ("workspace", "run_id") if not raw.get(key)]
+        if missing:
+            raise ObjectiveError(
+                f"suite manifest entry #{index} is missing field(s) "
+                f"{', '.join(repr(k) for k in missing)}"
+            )
+        workspace = Path(str(raw["workspace"]))
+        run_id = str(raw["run_id"])
+        pair = (str(workspace), run_id)
+        if pair in seen:
+            raise ObjectiveError(
+                f"suite manifest entry #{index} duplicates (workspace={workspace!s}, "
+                f"run_id={run_id!r})"
+            )
+        seen.add(pair)
+        result.append(SuiteEntry(workspace=workspace, run_id=run_id))
+    return result
 
 
 def _bind_identity(

--- a/daydream/benchmark/harbor/objective.py
+++ b/daydream/benchmark/harbor/objective.py
@@ -67,6 +67,29 @@ class Objective:
     tokens: float | None = None
     cost: float | None = None
 
+    def _as_metric_dict(self) -> dict[str, float | int]:
+        """Project this objective in the exact shape ``aggregate_metrics`` returns.
+
+        The count-derived fields were bound by feeding the run's flattened rows
+        through ``verifier_core.aggregate_metrics`` exactly once, so this maps
+        them back into the authoritative scorer's key/shaper set for byte-for-
+        value comparison against the generated ``metric.py`` aggregation.
+        """
+        return {
+            "micro_precision": self.precision,
+            "micro_recall": self.recall,
+            "micro_f1": self.f1,
+            "mean_task_score": self.mean_task_score,
+            "clean_accuracy": self.clean_accuracy,
+            "task_count": self.task_count,
+            "scored_task_count": self.scored_task_count,
+            "infra_error_task_count": self.infra_error_task_count,
+            "clean_task_count": self.clean_task_count,
+            "total_tp": self.tp,
+            "total_fp": self.fp,
+            "total_fn": self.fn,
+        }
+
 
 @dataclass(frozen=True)
 class CompatibilityIdentity:
@@ -156,7 +179,7 @@ def read_completed_run(
     job_dir = run_mod._validate_job_dir(workspace, str(entry.get("job_dir") or ""))
     identity = _bind_identity(workspace, entry, run_id, env)
     rows, infra_errors = _parse_task_rows(Path(job_dir), run_id)
-    objective = _build_objective(rows, infra_errors)
+    objective = _build_objective(rows, infra_errors, Path(job_dir), run_id)
 
     return CompletedRun(
         run_id=entry["run_id"],
@@ -378,7 +401,8 @@ def _is_finite(value: float) -> bool:
 
 
 def _build_objective(
-    rows: list[dict[str, object] | None], infra_errors: int
+    rows: list[dict[str, object] | None], infra_errors: int,
+    job_dir: Path, run_id: str,
 ) -> Objective:
     """Populate the count-derived ``Objective`` from the parsed rows.
 
@@ -389,7 +413,12 @@ def _build_objective(
     rows' ``verifier_error`` flags. ``comparison_eligible`` is ``False``
     whenever any trial failed to produce a legitimate scored row.
     """
-    agg = verifier_core.aggregate_metrics(rows)
+    try:
+        agg = verifier_core.aggregate_metrics(rows)
+    except verifier_core.VerifierError as exc:
+        raise ObjectiveError(
+            f"malformed reward row(s) in run {run_id!r} under {job_dir}: {exc}"
+        ) from exc
     verifier_errors = sum(
         1 for row in rows if row is not None and int(row.get("verifier_error") or 0) == 1
     )

--- a/daydream/benchmark/harbor/objective.py
+++ b/daydream/benchmark/harbor/objective.py
@@ -13,6 +13,7 @@ dir containment — it only filters on ``state`` and reads the reward rows.
 """
 from __future__ import annotations
 
+import hashlib
 import importlib.metadata
 import json
 from dataclasses import dataclass, field
@@ -147,6 +148,55 @@ class SuiteManifest:
 
     schema_version: int
     entries: tuple[SuiteEntry, ...]
+
+
+def _compatibility_fields(identity: CompatibilityIdentity) -> dict[str, object]:
+    """Every compatibility field that must match across a pooled suite.
+
+    Repository/benchmark ids and the per-run ``run_id`` are deliberately not
+    part of the identity and so are free to differ across entries.
+    """
+    return {
+        "objective_schema_version": identity.objective_schema_version,
+        "profile_schema_version": identity.profile_schema_version,
+        "profile_name": identity.profile_name,
+        "profile_digest": identity.profile_digest,
+        "daydream_version": identity.daydream_version,
+        "daydream_wheel_sha256": identity.daydream_wheel_sha256,
+        "compiled_lock_sha256": identity.compiled_lock_sha256,
+        "harbor_version": identity.harbor_version,
+        "reviewer_backend": identity.reviewer_backend,
+        "reviewer_model": identity.reviewer_model,
+        "reviewer_base_url": identity.reviewer_base_url,
+        "reviewer_effort": identity.reviewer_effort,
+        "judge_provider": identity.judge_provider,
+        "judge_model": identity.judge_model,
+        "judge_host": identity.judge_host,
+        "verifier_template_sha256": identity.verifier_template_sha256,
+        "threshold": identity.threshold,
+        "attempts": identity.attempts,
+    }
+
+
+@dataclass(frozen=True)
+class SuiteObjective:
+    """A pooled, compatible suite of exact completions.
+
+    ``objective`` holds the count-derived micro-metrics pooled across every
+    entry's flattened per-task rows (never per-repository averages).
+    ``experiment_id`` is a stable SHA-256 derived from the canonicalized
+    manifest plus the shared compatibility identity. ``identity`` is the
+    (single, verified-shared) ``CompatibilityIdentity``; ``profile_digest`` is
+    always present (spec must-have). ``diagnostics`` carries per-entry
+    ``{index, workspace, run_id, error}`` records for the error/reporting path
+    -- never prose-only -- and is empty on a cleanly pooled suite.
+    """
+
+    objective: Objective
+    experiment_id: str
+    profile_digest: str | None
+    identity: CompatibilityIdentity
+    diagnostics: list[dict[str, object]] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -295,6 +345,116 @@ def objective_to_json(run: CompletedRun) -> dict[str, object]:
         "objective": objective_dict,
     }
 
+
+
+def _canonical_suite_manifest(entries: list[SuiteEntry]) -> dict[str, object]:
+    """Canonical, reorder-stable projection of a validated suite manifest."""
+    return {
+        "schema_version": _SUITE_SCHEMA_VERSION,
+        "entries": sorted(
+            ({"workspace": str(e.workspace), "run_id": e.run_id} for e in entries),
+            key=lambda ent: (ent["workspace"], ent["run_id"]),
+        ),
+    }
+
+
+def _suite_experiment_id(
+    entries: list[SuiteEntry], identity: CompatibilityIdentity
+) -> str:
+    """Stable SHA-256 over the canonicalized manifest plus the shared identity.
+
+    Canonicalizing (sorting unique entries) means reordering identical unique
+    entries yields the same id; duplicates are rejected before this runs.
+    """
+    payload = {
+        "manifest": _canonical_suite_manifest(entries),
+        "identity": _compatibility_fields(identity),
+    }
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def aggregate_suite(
+    manifest: dict, *, env: dict[str, Any] | None = None
+) -> SuiteObjective:
+    """Validate and pool a suite manifest into one compatible ``SuiteObjective``.
+
+    Validates the manifest, resolves every entry via ``read_completed_run``, and
+    requires the full compatibility identity to match across every entry
+    (non-optional): any differing compatibility field — profile digest, wheel/
+    runtime digest, reviewer/judge identity, verifier template, threshold, or
+    attempts — raises ``ObjectiveError`` naming the field. Any entry that is
+    incomplete, malformed, comparison-ineligible, or a duplicated pair fails the
+    entire command fail-closed — never a silently-subsetted pool.
+
+    The pooled objective feeds the flattened per-task rows across all entries
+    through ``verifier_core.aggregate_metrics`` exactly once; TP/FP/FN pool to
+    micro precision/recall/F1 and the task/clean/infra counts sum across entries.
+    Per-repository precision/recall/F1 are never averaged.
+    """
+    env = env or {}
+    entries = validate_suite_manifest(manifest)
+
+    resolved: list[tuple[SuiteEntry, CompletedRun]] = []
+    diagnostics: list[dict[str, object]] = []
+    for index, entry in enumerate(entries):
+        try:
+            run = read_completed_run(entry.workspace, entry.run_id, env=env)
+        except ObjectiveError as exc:
+            diagnostics.append({
+                "index": index,
+                "workspace": str(entry.workspace),
+                "run_id": entry.run_id,
+                "error": str(exc),
+            })
+            raise ObjectiveError(f"suite entry #{index} failed: {exc}") from exc
+        resolved.append((entry, run))
+
+    identities: list[CompatibilityIdentity | None] = [r.identity for _, r in resolved]
+    if any(identity is None for identity in identities):
+        raise ObjectiveError(
+            "suite entries must each bind a compatibility identity for pooling"
+        )
+    base = identities[0]
+    assert base is not None
+    base_fields = _compatibility_fields(base)
+    for entry, run in resolved[1:]:
+        run_identity = run.identity
+        assert run_identity is not None
+        for comp_field, value in base_fields.items():
+            if getattr(run_identity, comp_field) != value:
+                raise ObjectiveError(
+                    f"suite is not comparable: {comp_field} differs across entries "
+                    f"at workspace {entry.workspace} run {entry.run_id!r}"
+                )
+
+    # Fail closed on any comparison-ineligible entry (never a subsetted pool).
+    for entry, run in resolved:
+        if run.objective is not None and not run.objective.comparison_eligible:
+            raise ObjectiveError(
+                f"suite entry at workspace {entry.workspace} run {entry.run_id!r} "
+                f"is not comparison-eligible; refusing to pool"
+            )
+
+    rows = [row for _, run in resolved for row in run.task_rows]
+    infra_errors = sum(1 for row in rows if row is None)
+    suite_label = _suite_label(entries)
+    pooled = _build_objective(
+        rows, infra_errors, job_dir=Path("@suite"), run_id=suite_label
+    )
+    experiment_id = _suite_experiment_id(entries, base)
+    return SuiteObjective(
+        objective=pooled,
+        experiment_id=experiment_id,
+        profile_digest=base.profile_digest,
+        identity=base,
+        diagnostics=diagnostics,
+    )
+
+
+def _suite_label(entries: list[SuiteEntry]) -> str:
+    return "-".join(f"{e.workspace.name}:{e.run_id}" for e in entries)
 
 
 _PROFILE_SCHEMA_VERSION = 1

--- a/daydream/benchmark/harbor/objective.py
+++ b/daydream/benchmark/harbor/objective.py
@@ -137,19 +137,6 @@ class SuiteEntry:
     run_id: str
 
 
-@dataclass(frozen=True)
-class SuiteManifest:
-    """A validated, versioned manifest of exact completions to pool.
-
-    ``entries`` is a tuple of ``SuiteEntry`` in manifest order. Instances are
-    immutable; every entry was already validated to carry a ``workspace`` and
-    ``run_id`` and to be unique by ``(workspace, run_id)``.
-    """
-
-    schema_version: int
-    entries: tuple[SuiteEntry, ...]
-
-
 def identity_to_dict(identity: CompatibilityIdentity) -> dict[str, object]:
     """Canonical 18-field compatibility/identity projection.
 
@@ -179,15 +166,6 @@ def identity_to_dict(identity: CompatibilityIdentity) -> dict[str, object]:
         "threshold": identity.threshold,
         "attempts": identity.attempts,
     }
-
-
-def _compatibility_fields(identity: CompatibilityIdentity) -> dict[str, object]:
-    """Every compatibility field that must match across a pooled suite.
-
-    Repository/benchmark ids and the per-run ``run_id`` are deliberately not
-    part of the identity and so are free to differ across entries.
-    """
-    return identity_to_dict(identity)
 
 
 @dataclass(frozen=True)
@@ -264,7 +242,12 @@ def read_completed_run(
             f"(state {entry.get('state')!r})"
         )
 
-    job_dir = run_mod._validate_job_dir(workspace, str(entry.get("job_dir") or ""))
+    try:
+        job_dir = run_mod._validate_job_dir(workspace, str(entry.get("job_dir") or ""))
+    except run_mod.RunError as exc:
+        raise ObjectiveError(
+            f"run {run_id!r} at {workspace} has uncontained job_dir: {exc}"
+        ) from exc
     identity = _bind_identity(workspace, entry, run_id, env)
     rows, infra_errors = _parse_task_rows(Path(job_dir), run_id)
     objective = _build_objective(rows, infra_errors, Path(job_dir), run_id)
@@ -361,7 +344,7 @@ def _suite_experiment_id(
     """
     payload = {
         "manifest": _canonical_suite_manifest(entries),
-        "identity": _compatibility_fields(identity),
+        "identity": identity_to_dict(identity),
     }
     return hashlib.sha256(
         json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
@@ -411,7 +394,7 @@ def aggregate_suite(
         )
     base = identities[0]
     assert base is not None
-    base_fields = _compatibility_fields(base)
+    base_fields = identity_to_dict(base)
     for entry, run in resolved[1:]:
         run_identity = run.identity
         assert run_identity is not None
@@ -541,8 +524,8 @@ def _bind_identity(
         raise ObjectiveError(f"run {run_id!r}: harbor package metadata not found") from exc
 
     judge_template = calibrate._load_judge_template()
-    profile_digest = env.get("DAYDREAM_REVIEW_PROFILE_CANDIDATE_DIGEST") or entry.get(
-        "profile_digest"
+    profile_digest = entry.get("profile_digest") or env.get(
+        "DAYDREAM_REVIEW_PROFILE_CANDIDATE_DIGEST"
     )
     try:
         attempts = int(run_mod._compiled_job_config(workspace).get("n_attempts", 1))
@@ -561,14 +544,22 @@ def _bind_identity(
         daydream_wheel_sha256=str(wheel_sha),
         compiled_lock_sha256=str(ledger_digest),
         harbor_version=harbor_version,
-        reviewer_backend=env.get("DAYDREAM_REVIEW_BACKEND") or "",
-        reviewer_model=env.get("DAYDREAM_REVIEW_MODEL") or "",
-        reviewer_base_url=env.get("DAYDREAM_REVIEW_BASE_URL") or "",
+        reviewer_backend=entry.get("reviewer_backend")
+        or env.get("DAYDREAM_REVIEW_BACKEND")
+        or "",
+        reviewer_model=entry.get("reviewer_model")
+        or env.get("DAYDREAM_REVIEW_MODEL")
+        or "",
+        reviewer_base_url=entry.get("reviewer_base_url")
+        or env.get("DAYDREAM_REVIEW_BASE_URL")
+        or "",
         # Recorded at run-append time; absent -> None (never fabricated).
         reviewer_effort=entry.get("reviewer_effort"),
-        judge_provider=env.get("DAYDREAM_JUDGE_PROVIDER") or "anthropic",
-        judge_model=env.get("DAYDREAM_JUDGE_MODEL") or "",
-        judge_host=calibrate._judge_host_from_env(env),
+        judge_provider=entry.get("judge_provider")
+        or env.get("DAYDREAM_JUDGE_PROVIDER")
+        or "anthropic",
+        judge_model=entry.get("judge_model") or env.get("DAYDREAM_JUDGE_MODEL") or "",
+        judge_host=entry.get("judge_host") or calibrate._judge_host_from_env(env) or "",
         verifier_template_sha256=calibrate._render_judge_prompt_digest(judge_template),
         threshold=verifier_core.CONFIDENCE_THRESHOLD,
         attempts=attempts,
@@ -737,6 +728,8 @@ def _build_objective(
         verifier_error_task_count=verifier_errors,
         malformed_task_count=malformed,
         failed_task_count=failed,
-        comparison_eligible=not (infra_errors + verifier_errors + malformed + failed),
+        comparison_eligible=bool(agg["scored_task_count"]) and not (
+            infra_errors + verifier_errors + malformed + failed
+        ),
         mean_task_score=float(agg["mean_task_score"]),
     )

--- a/daydream/benchmark/harbor/objective.py
+++ b/daydream/benchmark/harbor/objective.py
@@ -18,7 +18,7 @@ import importlib.metadata
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeGuard
 
 from daydream.benchmark.harbor import calibrate, verifier_core
 from daydream.benchmark.harbor import run as run_mod
@@ -662,7 +662,7 @@ def _parse_reward_strict(reward_path: Path, run_id: str) -> dict[str, object]:
     numeric to zero.
     """
     try:
-        data = json.loads(reward_path.read_text(encoding="utf-8"))
+        data: dict[str, object] = json.loads(reward_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         raise ObjectiveError(
             f"malformed reward artifact at {reward_path} in run {run_id!r}: {exc}"
@@ -679,7 +679,7 @@ def _parse_reward_strict(reward_path: Path, run_id: str) -> dict[str, object]:
                 f"reward artifact at {reward_path} in run {run_id!r} has "
                 f"non-integer {key!r}: {value!r}"
             )
-        if int(value) < 0:
+        if value < 0:
             raise ObjectiveError(
                 f"reward artifact at {reward_path} in run {run_id!r} has "
                 f"negative {key!r}: {value!r}"
@@ -699,8 +699,19 @@ def _parse_reward_strict(reward_path: Path, run_id: str) -> dict[str, object]:
     return data
 
 
-def _is_int(value: object) -> bool:
+def _is_int(value: object) -> TypeGuard[int]:
     return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _row_int(row: dict[str, object], key: str) -> int:
+    """Read an integer-valued row field, defaulting to 0 when absent.
+
+    Only the scored count keys are validated strictly at parse time; auxiliary
+    reporting keys (``candidate_count``/``gold_count``/``verifier_error``) are
+    read here with a non-integer value falling back to 0 rather than crashing.
+    """
+    value = row.get(key)
+    return value if _is_int(value) else 0
 
 
 def _is_finite(value: float) -> bool:
@@ -726,17 +737,20 @@ def _build_objective(
         raise ObjectiveError(
             f"malformed reward row(s) in run {run_id!r} under {job_dir}: {exc}"
         ) from exc
-    verifier_errors = sum(
-        1 for row in rows if row is not None and int(row.get("verifier_error") or 0) == 1
-    )
+    verifier_errors = len([
+        row for row in rows
+        if row is not None and _row_int(row, "verifier_error") == 1
+    ])
     # Malformed rows fail closed in ``_parse_reward_strict`` and so never reach
     # this pool; the count stays zero by construction.
     malformed = 0
     failed = max(verifier_errors, infra_errors)
     candidate_count = sum(
-        int(row["candidate_count"]) for row in rows if row is not None
+        _row_int(row, "candidate_count") for row in rows if row is not None
     )
-    gold_count = sum(int(row["gold_count"]) for row in rows if row is not None)
+    gold_count = sum(
+        _row_int(row, "gold_count") for row in rows if row is not None
+    )
     clean_task_count = int(agg["clean_task_count"])
     return Objective(
         tp=int(agg["total_tp"]),

--- a/daydream/benchmark/harbor/objective.py
+++ b/daydream/benchmark/harbor/objective.py
@@ -13,13 +13,14 @@ dir containment — it only filters on ``state`` and reads the reward rows.
 """
 from __future__ import annotations
 
+import importlib.metadata
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from daydream.benchmark.harbor import calibrate, verifier_core
 from daydream.benchmark.harbor import run as run_mod
-from daydream.benchmark.harbor import verifier_core
 
 
 class ObjectiveError(Exception):
@@ -68,14 +69,46 @@ class Objective:
 
 
 @dataclass(frozen=True)
+class CompatibilityIdentity:
+    """Frozen, attributable compatibility identity of one exact completed run.
+
+    Every field is bound from an authoritative source only (the ledger entry,
+    the compiled ``benchmark.lock.json`` ``daydream`` block, the trusted
+    control-plane env, ``verifier_core``/``calibrate`` constants, and the
+    compiled ``harbor-job.yaml`` attempts) — never from inference or coercion.
+    ``reviewer_effort`` is the ledger-recorder effort (read-only) or ``None``
+    when absent; it is never fabricated.
+    """
+
+    objective_schema_version: int
+    profile_schema_version: int
+    profile_name: str
+    profile_digest: str | None
+    daydream_version: str
+    daydream_wheel_sha256: str
+    compiled_lock_sha256: str
+    harbor_version: str
+    reviewer_backend: str
+    reviewer_model: str
+    reviewer_base_url: str
+    reviewer_effort: str | None
+    judge_provider: str
+    judge_model: str
+    judge_host: str
+    verifier_template_sha256: str
+    threshold: float
+    attempts: int
+
+
+@dataclass(frozen=True)
 class CompletedRun:
     """Immutable projection of a completed, ledgered benchmark run."""
 
     run_id: str
     mode: str
     state: str
-    # Bound in Task 3 (full compatibility identity).
-    identity: Any | None = None
+    # Full compatibility identity from authoritative sources.
+    identity: CompatibilityIdentity | None = None
     # Per-task reward rows (flattened); populated in Task 2.
     task_rows: list[dict[str, object] | None] = field(default_factory=list)
     # Count-derived objective (populated in Task 2).
@@ -90,13 +123,15 @@ def read_completed_run(
     """Resolve a ledgered run by explicit ``run_id``.
 
     Loads the ledger through ``run_mod._load_ledger`` and admits only a run
-    whose ``state == "complete"``, then parses its per-task reward rows in
-    strict fail-closed fashion and binds the count-derived ``Objective``.
+    whose ``state == "complete"``, binds its full compatibility identity from
+    authoritative sources, then parses its per-task reward rows in strict
+    fail-closed fashion and binds the count-derived ``Objective``.
     Missing runs, running/cleanup-pending/cleaned runs, any ledger parse/
-    validation failure, and any malformed reward artifact all fail closed with
-    an ``ObjectiveError`` naming the run id and the offending artifact.
+    validation failure, any identity disagreement, and any malformed reward
+    artifact all fail closed with an ``ObjectiveError`` naming the run id and
+    the offending artifact.
     """
-    del env  # reserved for provenance binding in later tasks.
+    env = env or {}
     try:
         doc = run_mod._load_ledger(workspace)
     except run_mod.RunError as exc:
@@ -119,6 +154,7 @@ def read_completed_run(
         )
 
     job_dir = run_mod._validate_job_dir(workspace, str(entry.get("job_dir") or ""))
+    identity = _bind_identity(workspace, entry, run_id, env)
     rows, infra_errors = _parse_task_rows(Path(job_dir), run_id)
     objective = _build_objective(rows, infra_errors)
 
@@ -126,10 +162,118 @@ def read_completed_run(
         run_id=entry["run_id"],
         mode=entry["mode"],
         state=entry["state"],
+        identity=identity,
         task_rows=rows,
         objective=objective,
         job_dir=job_dir,
     )
+
+
+# The schema version recorded in ``CompatibilityIdentity.objective_schema_version``.
+_OBJECTIVE_SCHEMA_VERSION = 1
+
+
+# The review-profile schema version this plan's identity binds (the current
+# ``ReviewProfile.schema_version``). There is no read-only source for a loaded
+# profile's ``name`` here, so it stays empty rather than fabricated.
+_PROFILE_SCHEMA_VERSION = 1
+
+
+def _bind_identity(
+    workspace: Path, entry: dict[str, Any], run_id: str, env: dict[str, Any]
+) -> CompatibilityIdentity:
+    """Bind the full compatibility identity from authoritative sources.
+
+    The ledger's ``compiled_lock_sha256`` must equal the hash of the on-disk
+    compiled lock (oracle/default-run gate contract); disagreement is corruption
+    and raises ``ObjectiveError`` naming the offending field. Every other
+    fallible read (lock parse, missing/malformed ``daydream`` wheel block,
+    compiled job config) propagates via ``ObjectiveError`` naming the artifact
+    path — no plausible placeholder is ever defaulted.
+    """
+    ledger_digest = entry.get("compiled_lock_sha256")
+    try:
+        disk_digest = run_mod._compiled_lock_sha256(workspace)
+    except OSError as exc:
+        raise ObjectiveError(
+            f"run {run_id!r}: cannot hash compiled lock at "
+            f"{workspace / 'harbor' / 'benchmark.lock.json'}: {exc}"
+        ) from exc
+    if ledger_digest != disk_digest:
+        raise ObjectiveError(
+            f"run {run_id!r} ledger compiled_lock_sha256 disagrees with the "
+            f"on-disk compiled lock at {workspace / 'harbor' / 'benchmark.lock.json'}"
+        )
+
+    lock = _load_compiled_lock(workspace, run_id)
+    day = lock.get("daydream")
+    if not isinstance(day, dict):
+        raise ObjectiveError(
+            f"run {run_id!r}: compiled lock at {workspace / 'harbor' / 'benchmark.lock.json'}"
+            f" is missing its 'daydream' wheel block"
+        )
+    wheel_sha = day.get("sha256")
+    wheel_version = day.get("version")
+    if not isinstance(wheel_sha, str) or not wheel_sha or not isinstance(wheel_version, str):
+        raise ObjectiveError(
+            f"run {run_id!r}: compiled lock at {workspace / 'harbor' / 'benchmark.lock.json'}"
+            f" has a malformed or missing 'daydream' wheel digest/version"
+        )
+
+    try:
+        harbor_version = ".".join(
+            str(importlib.metadata.version("harbor")).split(".")[:2]
+        )
+    except importlib.metadata.PackageNotFoundError as exc:  # pragma: no cover
+        raise ObjectiveError(f"run {run_id!r}: harbor package metadata not found") from exc
+
+    judge_template = calibrate._load_judge_template()
+    profile_digest = env.get("DAYDREAM_REVIEW_PROFILE_CANDIDATE_DIGEST") or entry.get(
+        "profile_digest"
+    )
+    try:
+        attempts = int(run_mod._compiled_job_config(workspace).get("n_attempts", 1))
+    except (run_mod.RunError, ValueError, TypeError) as exc:
+        raise ObjectiveError(
+            f"run {run_id!r}: cannot read compiled harbor-job.yaml at "
+            f"{workspace / 'harbor' / 'harbor-job.yaml'}: {exc}"
+        ) from exc
+
+    return CompatibilityIdentity(
+        objective_schema_version=_OBJECTIVE_SCHEMA_VERSION,
+        profile_schema_version=_PROFILE_SCHEMA_VERSION,
+        profile_name="",
+        profile_digest=str(profile_digest) if profile_digest else None,
+        daydream_version=str(wheel_version),
+        daydream_wheel_sha256=str(wheel_sha),
+        compiled_lock_sha256=str(ledger_digest),
+        harbor_version=harbor_version,
+        reviewer_backend=env.get("DAYDREAM_REVIEW_BACKEND") or "",
+        reviewer_model=env.get("DAYDREAM_REVIEW_MODEL") or "",
+        reviewer_base_url=env.get("DAYDREAM_REVIEW_BASE_URL") or "",
+        # Recorded at run-append time; absent -> None (never fabricated).
+        reviewer_effort=entry.get("reviewer_effort"),
+        judge_provider=env.get("DAYDREAM_JUDGE_PROVIDER") or "anthropic",
+        judge_model=env.get("DAYDREAM_JUDGE_MODEL") or "",
+        judge_host=calibrate._judge_host_from_env(env),
+        verifier_template_sha256=calibrate._render_judge_prompt_digest(judge_template),
+        threshold=verifier_core.CONFIDENCE_THRESHOLD,
+        attempts=attempts,
+    )
+
+
+def _load_compiled_lock(workspace: Path, run_id: str) -> dict[str, Any]:
+    """Read the compiled ``harbor/benchmark.lock.json`` strictly."""
+    path = workspace / "harbor" / "benchmark.lock.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ObjectiveError(
+            f"run {run_id!r}: cannot read compiled lock at {path}: {exc}"
+        ) from exc
+    if not isinstance(data, dict):
+        raise ObjectiveError(f"run {run_id!r}: compiled lock at {path} must be a mapping")
+    return data
 
 
 # The integer count keys a scored task must carry as JSON integers (mirrors

--- a/daydream/benchmark/harbor/run.py
+++ b/daydream/benchmark/harbor/run.py
@@ -175,6 +175,32 @@ def _compiled_lock_sha256(workspace: Path) -> str:
     return hashlib.sha256((workspace / "harbor" / "benchmark.lock.json").read_bytes()).hexdigest()
 
 
+def _compiled_daydream_wheel(workspace: Path) -> tuple[str, str]:
+    """The ``daydream`` wheel ``(version, sha256)`` from the compiled lock.
+
+    Authoritative provenance source (issue #888): the compiled
+    ``harbor/benchmark.lock.json`` ``daydream`` block describing the exact
+    Daydream wheel the run executed under. Fail-closed: an absent/malformed
+    block (or unreadable lock) raises ``RunError`` naming the lock path — a
+    plausible placeholder is never defaulted.
+    """
+    path = workspace / "harbor" / "benchmark.lock.json"
+    try:
+        lock = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RunError(f"cannot read compiled lock at {path}: {exc}") from exc
+    if not isinstance(lock, dict):
+        raise RunError(f"compiled lock at {path} must be a mapping")
+    day = lock.get("daydream")
+    if not isinstance(day, dict) or not isinstance(day.get("version"), str) \
+            or not isinstance(day.get("sha256"), str):
+        raise RunError(
+            f"compiled lock at {path} is missing its 'daydream' wheel block "
+            "(version/sha256)"
+        )
+    return day["version"], day["sha256"]
+
+
 LEDGER_SUPPORTED_STATES = ("running", "complete", "cleanup_pending", "cleaned")
 LEDGER_SUPPORTED_MODES = ("oracle", "benchmark")
 LEDGER_SUPPORTED_BACKENDS = ("docker",)
@@ -242,6 +268,7 @@ def ledger_append_running(
     workspace: Path, *, run_id: str, compiled_lock_sha256: str, job_dir: str,
     mode: str = "oracle",
     profile_digest: str | None = None,
+    reviewer_effort: str | None = None,
 ) -> None:
     """Append a ``running`` entry (written before Harbor spawns) for this run.
 
@@ -253,8 +280,13 @@ def ledger_append_running(
     plane (the entrypoint computes it from the validated candidate); this
     function never reads ambient env itself. Optional: legacy/late callers
     that omit it leave the field ``None`` on the entry.
+
+    ``reviewer_effort`` (issue #888) is the reviewer reasoning-effort this run
+    executed under, threaded from the control-plane env so the read-only
+    objective can recover it without inference. Optional: callers that omit it
+    leave the field ``None`` on the entry (legacy/late callers stay byte-stable).
     """
-    contained = _validate_job_dir(workspace, job_dir)
+    validated = _validate_job_dir(workspace, job_dir)
     with storage.WorkspaceLock(workspace):
         doc = _load_ledger(workspace)
         entry: dict[str, Any] = {
@@ -262,11 +294,12 @@ def ledger_append_running(
             "mode": mode,
             "state": "running",
             "compiled_lock_sha256": compiled_lock_sha256,
-            "job_dir": contained,
+            "job_dir": validated,
             "harbor_job_id": None,
             "environments": [],
             "error": None,
             "profile_digest": profile_digest,
+            "reviewer_effort": reviewer_effort,
         }
         doc["runs"].append(entry)
         storage.atomic_write_json(_ledger_path(workspace), doc, mode=0o600)
@@ -510,6 +543,13 @@ def _current_state_mapping(
         "attempts": config.get("n_attempts", 1),
         "calibration_receipt_sha256": calibration_digest,
     }
+    # Daydream wheel provenance (issue #888): bind the exact compiled wheel
+    # digest/version the run was built under from the authoritative lock. An
+    # absent/malformed block raises ``RunError`` naming the lock path — never a
+    # default.
+    wheel_version, wheel_sha = _compiled_daydream_wheel(workspace)
+    mapping["daydream_version"] = wheel_version
+    mapping["daydream_wheel_sha256"] = wheel_sha
     # Candidate review-profile digest (issue #885/R12): fold it into the shared
     # oracle state so both the oracle-receipt document and the default-run gate
     # compare the tested candidate. Omitted when no candidate is set so legacy
@@ -517,6 +557,12 @@ def _current_state_mapping(
     digest = env.get("DAYDREAM_REVIEW_PROFILE_CANDIDATE_DIGEST")
     if digest:
         mapping["profile_digest"] = str(digest)
+    # Reviewer reasoning-effort (issue #888): the control plane threads the
+    # reviewer effort under which this run executes into the shared state via
+    # the env, so both the oracle-receipt document and the default-run gate
+    # compare the identical effort. Always present (``""`` when unset) so a
+    # reviewer-less run's receipt and gate agree.
+    mapping["reviewer_effort"] = env.get("DAYDREAM_REVIEW_EFFORT") or ""
     return mapping
 
 
@@ -690,7 +736,8 @@ def run_run(
     mode = "oracle" if oracle else "benchmark"
     ledger_append_running(workspace, run_id=run_id, compiled_lock_sha256=compiled_lock_sha,
                           job_dir=str(job_dir), mode=mode,
-                          profile_digest=env.get("DAYDREAM_REVIEW_PROFILE_CANDIDATE_DIGEST"))
+                          profile_digest=env.get("DAYDREAM_REVIEW_PROFILE_CANDIDATE_DIGEST"),
+                          reviewer_effort=env.get("DAYDREAM_REVIEW_EFFORT"))
 
     # 6. Spawn Harbor with an absolute config path, the parent environment
     #    (PATH/HOME/etc.) merged in, and telemetry forced off.

--- a/daydream/benchmark/harbor/run.py
+++ b/daydream/benchmark/harbor/run.py
@@ -434,6 +434,18 @@ def _preflight(
     return failures
 
 
+def _iter_trial_dirs(job_dir: Path):
+    """Yield the sorted trial subdirectories of a Harbor job dir.
+
+    Non-directory siblings (lockfiles, READMEs) are skipped. Shared by
+    ``_parse_job_results`` (oracle path) and ``objective._parse_task_rows`` so
+    the trial-dir traversal skeleton lives in one place (issue #888 anti-slop).
+    """
+    for trial in sorted(job_dir.iterdir()):
+        if trial.is_dir():
+            yield trial
+
+
 def _parse_job_results(job_dir: Path) -> tuple[bool, list[dict[str, Any]]]:
     """Parse Harbor's job dir for per-task scores + resolved environments.
 
@@ -451,9 +463,7 @@ def _parse_job_results(job_dir: Path) -> tuple[bool, list[dict[str, Any]]]:
         return (False, [])
     environments: list[dict[str, Any]] = []
     oracle_ok = True
-    for trial in sorted(job_dir.iterdir()):
-        if not trial.is_dir():
-            continue  # a non-directory sibling is not a task trial
+    for trial in _iter_trial_dirs(job_dir):
         verifier = trial / "verifier"
         reward_path = verifier / "reward.json"
         # Resolve the trial environment even when the trial carries no claimable

--- a/daydream/benchmark/harbor/run.py
+++ b/daydream/benchmark/harbor/run.py
@@ -269,6 +269,12 @@ def ledger_append_running(
     mode: str = "oracle",
     profile_digest: str | None = None,
     reviewer_effort: str | None = None,
+    reviewer_backend: str | None = None,
+    reviewer_model: str | None = None,
+    reviewer_base_url: str | None = None,
+    judge_provider: str | None = None,
+    judge_model: str | None = None,
+    judge_host: str | None = None,
 ) -> None:
     """Append a ``running`` entry (written before Harbor spawns) for this run.
 
@@ -285,6 +291,14 @@ def ledger_append_running(
     executed under, threaded from the control-plane env so the read-only
     objective can recover it without inference. Optional: callers that omit it
     leave the field ``None`` on the entry (legacy/late callers stay byte-stable).
+
+    ``reviewer_backend``/``reviewer_model``/``reviewer_base_url``/``judge_provider``/
+    ``judge_model``/``judge_host`` (issue #888) persist the reviewer/judge
+    attribution the run actually executed under, so the read-only objective
+    binds them from the run's recorded state rather than the resolution-time
+    ambient env (which would mis-attribute a historical run under env drift).
+    These are always supplied by the control-plane env; callers that omit them
+    leave the fields ``None`` on the entry (legacy/late callers stay byte-stable).
     """
     validated = _validate_job_dir(workspace, job_dir)
     with storage.WorkspaceLock(workspace):
@@ -300,6 +314,12 @@ def ledger_append_running(
             "error": None,
             "profile_digest": profile_digest,
             "reviewer_effort": reviewer_effort,
+            "reviewer_backend": reviewer_backend,
+            "reviewer_model": reviewer_model,
+            "reviewer_base_url": reviewer_base_url,
+            "judge_provider": judge_provider,
+            "judge_model": judge_model,
+            "judge_host": judge_host,
         }
         doc["runs"].append(entry)
         storage.atomic_write_json(_ledger_path(workspace), doc, mode=0o600)
@@ -747,7 +767,13 @@ def run_run(
     ledger_append_running(workspace, run_id=run_id, compiled_lock_sha256=compiled_lock_sha,
                           job_dir=str(job_dir), mode=mode,
                           profile_digest=env.get("DAYDREAM_REVIEW_PROFILE_CANDIDATE_DIGEST"),
-                          reviewer_effort=env.get("DAYDREAM_REVIEW_EFFORT"))
+                          reviewer_effort=env.get("DAYDREAM_REVIEW_EFFORT"),
+                          reviewer_backend=env.get("DAYDREAM_REVIEW_BACKEND") or "",
+                          reviewer_model=env.get("DAYDREAM_REVIEW_MODEL") or "",
+                          reviewer_base_url=env.get("DAYDREAM_REVIEW_BASE_URL") or "",
+                          judge_provider=env.get("DAYDREAM_JUDGE_PROVIDER") or "anthropic",
+                          judge_model=env.get("DAYDREAM_JUDGE_MODEL") or "",
+                          judge_host=calibrate._judge_host_from_env(env) or "")
 
     # 6. Spawn Harbor with an absolute config path, the parent environment
     #    (PATH/HOME/etc.) merged in, and telemetry forced off.

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -399,6 +399,22 @@ def test_objective_cli_writes_json_atomically_and_summary(tmp_path, capsys):
     assert "run-1" in captured   # concise local summary by default
 
 
+def test_objective_cli_json_dash_keeps_stdout_pure_json(tmp_path, capsys):
+    from daydream.benchmark.cli import _handle_benchmark_command
+
+    ws = _objective_ws(tmp_path)
+    code = _handle_benchmark_command([
+        "objective", str(ws), "--run-id", "run-1", "--json", "-",
+    ])
+    assert code == 0
+    captured = capsys.readouterr()
+    # Issue #888 machine-readable '-' mode: stdout must be exactly the JSON blob
+    # (no interleaved human summary); the summary routes to stderr.
+    doc = json.loads(captured.out)
+    assert doc["run_id"] == "run-1" and "f1" in doc["objective"]
+    assert "objective run-1:" in captured.err   # human summary went to stderr
+
+
 def test_objective_cli_failure_leaves_output_unchanged(tmp_path):
     from daydream.benchmark.cli import _handle_benchmark_command
     from daydream.benchmark.harbor import run as run_mod

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -414,6 +414,41 @@ def test_objective_cli_failure_leaves_output_unchanged(tmp_path):
     assert out.read_text() == "SENTINEL"
 
 
+def test_aggregate_cli_writes_json_and_prints_digest(tmp_path, capsys):
+    from daydream.benchmark.cli import _handle_benchmark_command
+    from tests.test_benchmark_objective import _complete_ws_at, _reward
+    a = _complete_ws_at(tmp_path, "a", "r1", [_reward(tp=1, fp=0, fn=0)])
+    b = _complete_ws_at(tmp_path, "b", "r2", [_reward(tp=1, fp=0, fn=0)])
+    manifest = tmp_path / "suite.json"
+    manifest.write_text(json.dumps({"schema_version": 1, "entries": [
+        {"workspace": str(a), "run_id": "r1"},
+        {"workspace": str(b), "run_id": "r2"}]}))
+    out = tmp_path / "agg.json"
+    code = _handle_benchmark_command(["aggregate", str(manifest), "--json", str(out)])
+    assert code == 0
+    doc = json.loads(out.read_text())
+    assert doc["experiment_id"]
+    assert doc["profile_digest"]
+    assert "micro_precision" in doc["objective"]
+    assert "d"*64 in capsys.readouterr().out   # digest always printed
+
+
+def test_aggregate_cli_fails_closed_leaves_output_unchanged(tmp_path):
+    from daydream.benchmark.cli import _handle_benchmark_command
+    from tests.test_benchmark_objective import _complete_ws_at, _reward
+    a = _complete_ws_at(tmp_path, "a", "r1", [_reward(tp=1, fp=0, fn=0)], digest="d"*64)
+    b = _complete_ws_at(tmp_path, "b", "r2", [_reward(tp=1, fp=0, fn=0)], digest="e"*64)
+    manifest = tmp_path / "suite.json"
+    manifest.write_text(json.dumps({"schema_version": 1, "entries": [
+        {"workspace": str(a), "run_id": "r1"},
+        {"workspace": str(b), "run_id": "r2"}]}))
+    out = tmp_path / "agg.json"
+    out.write_text("SENTINEL")
+    code = _handle_benchmark_command(["aggregate", str(manifest), "--json", str(out)])
+    assert code == 1
+    assert out.read_text() == "SENTINEL"
+
+
 def test_bench_help_lists_flags():
     r = subprocess.run(  # noqa: S603 - args are not user-controlled
         ["daydream", "bench", "--help"], capture_output=True, text=True  # noqa: S607 - daydream is a trusted command

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -4,6 +4,7 @@ Covers an arg-parse unit test for ``_bench_config_from_argv`` and tier-3
 real-path tests through the installed ``daydream`` console script.
 """
 
+import json
 import os
 import subprocess
 from pathlib import Path
@@ -375,6 +376,42 @@ def test_bench_dotenv_autoloads_credential_through_compiled_entrypoint(tmp_path)
         cwd=tmp_path,  # the .env lives here; the real bench entry must auto-load it from cwd
     )
     assert "MARTIAN_API_KEY is not set" not in (r.stdout + r.stderr)
+
+
+def _objective_ws(tmp_path):
+    """A complete, consistent run seeded via the Task-1/2 test helper."""
+    from tests.test_benchmark_objective import _complete_ws
+    return _complete_ws(tmp_path)
+
+
+def test_objective_cli_writes_json_atomically_and_summary(tmp_path, capsys):
+    from daydream.benchmark.cli import _handle_benchmark_command
+
+    ws = _objective_ws(tmp_path)
+    out = tmp_path / "obj.json"
+    code = _handle_benchmark_command([
+        "objective", str(ws), "--run-id", "run-1", "--json", str(out),
+    ])
+    assert code == 0
+    doc = json.loads(out.read_text())
+    assert doc["run_id"] == "run-1" and "f1" in doc["objective"]
+    captured = capsys.readouterr().out
+    assert "run-1" in captured   # concise local summary by default
+
+
+def test_objective_cli_failure_leaves_output_unchanged(tmp_path):
+    from daydream.benchmark.cli import _handle_benchmark_command
+    from daydream.benchmark.harbor import run as run_mod
+
+    ws = _objective_ws(tmp_path)
+    run_mod.ledger_mark(ws, "run-1", state="running")   # non-terminal -> fail closed
+    out = tmp_path / "obj.json"
+    out.write_text("SENTINEL")
+    code = _handle_benchmark_command([
+        "objective", str(ws), "--run-id", "run-1", "--json", str(out),
+    ])
+    assert code == 1
+    assert out.read_text() == "SENTINEL"
 
 
 def test_bench_help_lists_flags():

--- a/tests/test_benchmark_objective.py
+++ b/tests/test_benchmark_objective.py
@@ -1,7 +1,8 @@
 """Hermetic suite for the explicit-run ledger resolution (issue #888).
 
-Task 1: ObjectiveError, CompletedRun, and explicit-run ledger resolution.
+Task 1: ObjectiveRun, CompletedRun, and explicit-run ledger resolution.
 Task 2: per-task reward parsing and failure classification.
+Task 3: full compatibility-identity binding and the compile-lock cross-check.
 """
 import json
 
@@ -10,14 +11,22 @@ import pytest
 from daydream.benchmark.harbor import objective
 from daydream.benchmark.harbor import run as run_mod
 
+_WHEEL = {"distribution": "daydream", "version": "0.1.0", "sha256": "c" * 64}
+
+
+def _seed_compiled_lock(ws, wheel=_WHEEL):
+    """Write a compiled lock with the ``daydream`` wheel block + a case entry."""
+    lock = {"schema_version": 1, "cases": {"case-a": {"key": "case-a"}}, "files": {},
+            "daydream": wheel}
+    (ws / "harbor" / "benchmark.lock.json").write_text(json.dumps(lock))
+
 
 def _ws(tmp_path):
     ws = tmp_path / "ws"
     (ws / "runtime").mkdir(parents=True)
     (ws / "harbor").mkdir()
-    (ws / "harbor" / "benchmark.lock.json").write_text(
-        json.dumps({"schema_version": 1, "cases": {}})
-    )
+    _seed_compiled_lock(ws)
+    (ws / "harbor" / "harbor-job.yaml").write_text("jobs_dir: jobs\nn_attempts: 3\n")
     (ws / "benchmark.yaml").write_text(json.dumps({
         "schema_version": 1, "benchmark_id": "6c38dc0a-5f5a-4b73-bf36-9a2eb390f63b",
         "created_at": "2026-08-21T12:00:00Z", "source": {}, "privacy": {}, "pull_requests": [],
@@ -25,11 +34,39 @@ def _ws(tmp_path):
     return ws
 
 
+def _env(**over):
+    """A trusted control-plane env; the default already pins the candidate digest."""
+    base = {
+        "DAYDREAM_JUDGE_PROVIDER": "anthropic",
+        "DAYDREAM_JUDGE_MODEL": "m",
+        "DAYDREAM_REVIEW_MODEL": "rm",
+        "DAYDREAM_REVIEW_BACKEND": "claude",
+        "DAYDREAM_REVIEW_BASE_URL": "http://review.example",
+        "DAYDREAM_REVIEW_PROFILE_CANDIDATE_DIGEST": "d" * 64,
+    }
+    base.update(over)
+    return base
+
+
 def _append(ws, run_id='run-1'):
     run_mod.ledger_append_running(
-        ws, run_id=run_id, compiled_lock_sha256="a" * 64,
+        ws, run_id=run_id,
+        compiled_lock_sha256=run_mod._compiled_lock_sha256(ws),
         job_dir=str((ws / "harbor" / "jobs" / run_id).resolve()),
     )
+
+
+def _complete_ws(tmp_path, run_id="run-1"):
+    """A complete, consistent run whose ledger lock hash matches the seed lock."""
+    ws = _ws(tmp_path)
+    run_mod.ledger_append_running(
+        ws, run_id=run_id,
+        compiled_lock_sha256=run_mod._compiled_lock_sha256(ws),
+        job_dir=str((ws / "harbor" / "jobs" / run_id).resolve()),
+    )
+    run_mod.ledger_mark(ws, run_id, state="complete")
+    _seed_trials(ws, run_id, [_reward(tp=2, fp=1, fn=0)])
+    return ws
 
 
 def _reward(tp=0, fp=0, fn=0, reward=0.0, clean_task=0, clean_pass=0,
@@ -106,3 +143,29 @@ def test_objective_malformed_numeric_fails_closed(tmp_path):
     with pytest.raises(objective.ObjectiveError) as e:
         objective.read_completed_run(ws, run_id, env={})
     assert "run-1" in str(e.value)
+
+
+def test_objective_binds_full_compatibility_identity(tmp_path):
+    ws = _complete_ws(tmp_path)
+    run = objective.read_completed_run(ws, "run-1", env=_env())
+    ident = run.identity
+    assert ident.profile_digest == "d" * 64
+    assert ident.reviewer_model == "rm"          # from _env
+    assert ident.judge_model == "m"              # from _env
+    assert ident.daydream_wheel_sha256 == "c" * 64
+    assert ident.daydream_version == "0.1.0"
+    assert ident.compiled_lock_sha256 == run_mod._compiled_lock_sha256(ws)
+    assert ident.attempts == 3
+
+
+def test_objective_rejects_identity_disagreement(tmp_path):
+    ws = _ws(tmp_path)
+    # ledger says lock hash "a"*64 but the on-disk lock hashes to something else
+    run_mod.ledger_append_running(
+        ws, run_id="run-1", compiled_lock_sha256="a" * 64,
+        job_dir=str((ws / "harbor" / "jobs" / "run-1").resolve()),
+    )
+    run_mod.ledger_mark(ws, "run-1", state="complete")
+    with pytest.raises(objective.ObjectiveError) as e:
+        objective.read_completed_run(ws, "run-1", env={})
+    assert "compiled_lock" in str(e.value).lower()

--- a/tests/test_benchmark_objective.py
+++ b/tests/test_benchmark_objective.py
@@ -1,0 +1,52 @@
+"""Hermetic suite for the explicit-run ledger resolution (issue #888).
+
+Task 1: ObjectiveError, CompletedRun, and explicit-run ledger resolution.
+"""
+import json
+
+import pytest
+
+from daydream.benchmark.harbor import objective
+from daydream.benchmark.harbor import run as run_mod
+
+
+def _ws(tmp_path):
+    ws = tmp_path / "ws"
+    (ws / "runtime").mkdir(parents=True)
+    (ws / "harbor").mkdir()
+    (ws / "harbor" / "benchmark.lock.json").write_text(
+        json.dumps({"schema_version": 1, "cases": {}})
+    )
+    (ws / "benchmark.yaml").write_text(json.dumps({
+        "schema_version": 1, "benchmark_id": "6c38dc0a-5f5a-4b73-bf36-9a2eb390f63b",
+        "created_at": "2026-08-21T12:00:00Z", "source": {}, "privacy": {}, "pull_requests": [],
+        "cases": []}))
+    return ws
+
+
+def _append(ws, run_id='run-1'):
+    run_mod.ledger_append_running(
+        ws, run_id=run_id, compiled_lock_sha256="a" * 64,
+        job_dir=str((ws / "harbor" / "jobs" / run_id).resolve()),
+    )
+
+
+def test_objective_resolves_complete_run_by_explicit_run_id(tmp_path):
+    ws = _ws(tmp_path)
+    run_id = "run-1"
+    _append(ws, run_id)
+    run_mod.ledger_mark(ws, run_id, state="complete")
+    run = objective.read_completed_run(ws, run_id, env={})
+    assert run.run_id == run_id
+    assert run.state == "complete"
+
+
+def test_objective_rejects_missing_and_nonterminal_runs(tmp_path):
+    ws = _ws(tmp_path)
+    run_id = "run-1"
+    _append(ws, run_id)
+    run_mod.ledger_mark(ws, run_id, state="running")
+    for bad in ("running", "missing-run"):
+        with pytest.raises(objective.ObjectiveError) as e:
+            objective.read_completed_run(ws, bad, env={})
+        assert bad in str(e.value) and str(ws) in str(e.value)

--- a/tests/test_benchmark_objective.py
+++ b/tests/test_benchmark_objective.py
@@ -298,6 +298,44 @@ def test_aggregate_suite_fails_closed_on_incompatible_identity(tmp_path):
     assert "profile_digest" in str(e.value)
 
 
+def test_suite_pooled_output_equals_authoritative_scoring_end_to_end(tmp_path):
+    """Task 11 gate: pooled output equals the authoritative scoring.
+
+    The pooled ``SuiteObjective`` must equal ``verifier_core.aggregate_metrics``
+    over the exact flattened cross-run rows byte-for-value after numeric
+    normalization, and must also equal what the deployed generated
+    ``metric.py`` would compute over the same JSONL (the authoritative corpus
+    scorer — ``build.render_metric`` inlines ``verifier_core.aggregate_metrics``).
+    """
+    import types
+
+    from daydream.benchmark.harbor import build, verifier_core
+
+    def _rendered_metric():
+        # The deployed ``metric.py`` is the template with the authoritative
+        # ``aggregate_metrics`` body spliced in at build time.
+        mod = types.ModuleType("metric")
+        exec(compile(build.render_metric().decode("utf-8"), "metric.py", "exec"), mod.__dict__)
+        return mod
+
+    # Two compatible workspaces with a realistic, comparison-eligible mix: scored
+    # and gold-free clean tasks (an infra-error ``None`` trial would make the entry
+    # comparison-ineligible and ``aggregate_suite`` correctly refuses to pool it).
+    a = _complete_ws_at(tmp_path, "a", "r1",
+                        [_reward(tp=2, fp=1, fn=0, reward=0.8),
+                         _reward(clean_task=1, clean_pass=1)])
+    b = _complete_ws_at(tmp_path, "b", "r2", [_reward(tp=1, fp=0, fn=1, reward=0.5)])
+    manifest = {"schema_version": 1, "entries": [
+        {"workspace": str(a), "run_id": "r1"}, {"workspace": str(b), "run_id": "r2"}]}
+    suite = objective.aggregate_suite(manifest, env={})
+    a_rows = objective.read_completed_run(a, "r1", env={}).task_rows
+    b_rows = objective.read_completed_run(b, "r2", env={}).task_rows
+    flat = a_rows + b_rows   # the exact flattened per-task rows across both runs
+    assert suite.objective._as_metric_dict() == verifier_core.aggregate_metrics(flat)
+    jsonl = _rows_to_jsonl(flat, tmp_path / "gate.jsonl")
+    assert suite.objective._as_metric_dict() == _rendered_metric().aggregate_rewards_file(str(jsonl))
+
+
 def test_suite_manifest_validation(tmp_path):
     good = {"schema_version": 1, "entries": [
         {"workspace": str(tmp_path / "a"), "run_id": "r1"},

--- a/tests/test_benchmark_objective.py
+++ b/tests/test_benchmark_objective.py
@@ -361,3 +361,45 @@ def test_suite_manifest_rejects_duplicate_and_incomplete(tmp_path):
     unsupported = {"schema_version": 99, "entries": []}
     with pytest.raises(objective.ObjectiveError):
         objective.validate_suite_manifest(unsupported)
+
+
+def test_identity_to_dict_is_single_source_for_all_projections(tmp_path):
+    """Issue #888 anti-slop: one shared identity projection everywhere.
+
+    ``objective_to_json`` (per-run), ``_compatibility_fields`` (pool compat),
+    and the suite aggregate identity must all be byte-identical projections of
+    the same ``CompatibilityIdentity`` so a field added/renamed in one place
+    can't silently desynchronize the others.
+    """
+    ws = _complete_ws(tmp_path)
+    run = objective.read_completed_run(ws, "run-1", env=_env())
+    assert run.identity is not None
+
+    per_run = objective.objective_to_json(run)["identity"]
+    compat = objective._compatibility_fields(run.identity)
+    assert per_run == compat == objective.identity_to_dict(run.identity)
+
+    # The suite aggregate identity for the same workspace must match too.
+    manifest = {"schema_version": 1, "entries": [
+        {"workspace": str(ws), "run_id": "run-1"}]}
+    suite = objective.aggregate_suite(manifest, env=_env())
+    assert suite.identity == run.identity
+    assert objective.identity_to_dict(suite.identity) == per_run
+
+
+def test_shared_trial_walker_skips_non_dirs_and_matches_parse_job_results(tmp_path):
+    """Issue #888 anti-slop: objective._parse_task_rows reuses run's trial walker.
+
+    The shared ``run_mod._iter_trial_dirs`` skips non-directory siblings and
+    yields the same sorted trials the oracle path traverses.
+    """
+    import daydream.benchmark.harbor.run as run_mod
+
+    ws = _complete_ws(tmp_path)
+    job_dir = ws / "harbor" / "jobs" / "run-1"
+    (job_dir / "README.txt").write_text("not a trial")
+    trials = [p.name for p in run_mod._iter_trial_dirs(job_dir)]
+    assert "README.txt" not in trials
+    assert trials == sorted(
+        p.name for p in job_dir.iterdir() if p.is_dir()
+    )

--- a/tests/test_benchmark_objective.py
+++ b/tests/test_benchmark_objective.py
@@ -3,6 +3,7 @@
 Task 1: ObjectiveRun, CompletedRun, and explicit-run ledger resolution.
 Task 2: per-task reward parsing and failure classification.
 Task 3: full compatibility-identity binding and the compile-lock cross-check.
+Task 4: count-derived metrics equal the authoritative scoring.
 """
 import json
 
@@ -56,7 +57,7 @@ def _append(ws, run_id='run-1'):
     )
 
 
-def _complete_ws(tmp_path, run_id="run-1"):
+def _complete_ws(tmp_path, run_id="run-1", trials=None):
     """A complete, consistent run whose ledger lock hash matches the seed lock."""
     ws = _ws(tmp_path)
     run_mod.ledger_append_running(
@@ -65,7 +66,9 @@ def _complete_ws(tmp_path, run_id="run-1"):
         job_dir=str((ws / "harbor" / "jobs" / run_id).resolve()),
     )
     run_mod.ledger_mark(ws, run_id, state="complete")
-    _seed_trials(ws, run_id, [_reward(tp=2, fp=1, fn=0)])
+    if trials is None:
+        trials = [_reward(tp=2, fp=1, fn=0)]
+    _seed_trials(ws, run_id, trials)
     return ws
 
 
@@ -88,6 +91,11 @@ def _seed_trials(ws, run_id, trials):
             (trial / "reward-details.json").write_text("{}")   # unscored infra path
         else:
             (trial / "reward.json").write_text(json.dumps(row))
+
+
+def _rows_to_jsonl(rows, path):
+    path.write_text("\n".join(("null" if r is None else json.dumps(r)) for r in rows) + "\n")
+    return path
 
 
 def test_objective_resolves_complete_run_by_explicit_run_id(tmp_path):
@@ -169,3 +177,37 @@ def test_objective_rejects_identity_disagreement(tmp_path):
     with pytest.raises(objective.ObjectiveError) as e:
         objective.read_completed_run(ws, "run-1", env={})
     assert "compiled_lock" in str(e.value).lower()
+
+
+def test_objective_metrics_equal_verifier_core_and_metric_py(tmp_path):
+    import types
+
+    from daydream.benchmark.harbor import build, verifier_core
+
+    def _compiled_metric():
+        mod = types.ModuleType("metric")
+        exec(compile(build.render_metric().decode("utf-8"), "metric.py", "exec"), mod.__dict__)
+        return mod
+
+    ws = _complete_ws(tmp_path, trials=[_reward(tp=2, fp=1, fn=0, reward=0.8),
+                                        _reward(tp=1, fp=0, fn=1, reward=0.5), None])
+    run = objective.read_completed_run(ws, "run-1", env={})
+    flat = list(run.task_rows)
+    expected = verifier_core.aggregate_metrics(flat)
+    assert run.objective.tp == expected["total_tp"]
+    assert run.objective.fp == expected["total_fp"]
+    assert run.objective.fn == expected["total_fn"]
+    assert run.objective.precision == expected["micro_precision"]
+    assert run.objective.recall == expected["micro_recall"]
+    assert run.objective.f1 == expected["micro_f1"]
+    assert run.objective.task_count == expected["task_count"]
+    assert run.objective.infra_error_task_count == expected["infra_error_task_count"]
+    jsonl = _rows_to_jsonl(flat, tmp_path / "flat.jsonl")
+    via_metric = _compiled_metric().aggregate_rewards_file(str(jsonl))
+    assert run.objective._as_metric_dict() == via_metric
+
+
+def test_objective_tokens_cost_absent_when_unrecorded(tmp_path):
+    ws = _complete_ws(tmp_path)
+    run = objective.read_completed_run(ws, "run-1", env={})
+    assert run.objective.tokens is None and run.objective.cost is None

--- a/tests/test_benchmark_objective.py
+++ b/tests/test_benchmark_objective.py
@@ -1,6 +1,7 @@
 """Hermetic suite for the explicit-run ledger resolution (issue #888).
 
 Task 1: ObjectiveError, CompletedRun, and explicit-run ledger resolution.
+Task 2: per-task reward parsing and failure classification.
 """
 import json
 
@@ -31,6 +32,27 @@ def _append(ws, run_id='run-1'):
     )
 
 
+def _reward(tp=0, fp=0, fn=0, reward=0.0, clean_task=0, clean_pass=0,
+            gold_count=0, candidate_count=0, verifier_error=0):
+    return {"reward": reward, "tp": tp, "fp": fp, "fn": fn,
+            "precision": (tp/(tp+fp)) if (tp+fp) else 1.0,
+            "recall": (tp/(tp+fn)) if (tp+fn) else 1.0,
+            "f1": 0.0, "gold_count": gold_count, "candidate_count": candidate_count,
+            "clean_task": clean_task, "clean_pass": clean_pass,
+            "verifier_error": verifier_error}
+
+
+def _seed_trials(ws, run_id, trials):
+    job = ws / "harbor" / "jobs" / run_id
+    for i, row in enumerate(trials):
+        trial = job / f"case-{i}" / "verifier"
+        trial.mkdir(parents=True)
+        if row is None:
+            (trial / "reward-details.json").write_text("{}")   # unscored infra path
+        else:
+            (trial / "reward.json").write_text(json.dumps(row))
+
+
 def test_objective_resolves_complete_run_by_explicit_run_id(tmp_path):
     ws = _ws(tmp_path)
     run_id = "run-1"
@@ -50,3 +72,37 @@ def test_objective_rejects_missing_and_nonterminal_runs(tmp_path):
         with pytest.raises(objective.ObjectiveError) as e:
             objective.read_completed_run(ws, bad, env={})
         assert bad in str(e.value) and str(ws) in str(e.value)
+
+
+def test_objective_parses_scored_and_infra_trials(tmp_path):
+    ws = _ws(tmp_path)
+    run_id = "run-1"
+    _append(ws, run_id)
+    run_mod.ledger_mark(ws, run_id, state="complete")
+    _seed_trials(ws, run_id, [_reward(tp=2, fp=1, fn=0), None])
+    run = objective.read_completed_run(ws, run_id, env={})
+    assert run.task_rows[0]["tp"] == 2 and run.task_rows[1] is None
+    assert run.objective.infra_error_task_count == 1
+    assert run.objective.scored_task_count == 1
+
+
+def test_objective_clean_task_is_not_infra_failure(tmp_path):
+    ws = _ws(tmp_path)
+    run_id = "run-1"
+    _append(ws, run_id)
+    run_mod.ledger_mark(ws, run_id, state="complete")
+    _seed_trials(ws, run_id, [_reward(clean_task=1, clean_pass=1)])
+    run = objective.read_completed_run(ws, run_id, env={})
+    assert run.objective.clean_task_count == 1
+    assert run.objective.infra_error_task_count == 0
+
+
+def test_objective_malformed_numeric_fails_closed(tmp_path):
+    ws = _ws(tmp_path)
+    run_id = "run-1"
+    _append(ws, run_id)
+    run_mod.ledger_mark(ws, run_id, state="complete")
+    _seed_trials(ws, run_id, [{"reward": 0.5, "tp": "not-an-int", "fp": 0, "fn": 0}])
+    with pytest.raises(objective.ObjectiveError) as e:
+        objective.read_completed_run(ws, run_id, env={})
+    assert "run-1" in str(e.value)

--- a/tests/test_benchmark_objective.py
+++ b/tests/test_benchmark_objective.py
@@ -366,7 +366,7 @@ def test_suite_manifest_rejects_duplicate_and_incomplete(tmp_path):
 def test_identity_to_dict_is_single_source_for_all_projections(tmp_path):
     """Issue #888 anti-slop: one shared identity projection everywhere.
 
-    ``objective_to_json`` (per-run), ``_compatibility_fields`` (pool compat),
+    ``objective_to_json`` (per-run), ``identity_to_dict`` (pool compat),
     and the suite aggregate identity must all be byte-identical projections of
     the same ``CompatibilityIdentity`` so a field added/renamed in one place
     can't silently desynchronize the others.
@@ -376,7 +376,7 @@ def test_identity_to_dict_is_single_source_for_all_projections(tmp_path):
     assert run.identity is not None
 
     per_run = objective.objective_to_json(run)["identity"]
-    compat = objective._compatibility_fields(run.identity)
+    compat = objective.identity_to_dict(run.identity)
     assert per_run == compat == objective.identity_to_dict(run.identity)
 
     # The suite aggregate identity for the same workspace must match too.

--- a/tests/test_benchmark_objective.py
+++ b/tests/test_benchmark_objective.py
@@ -211,3 +211,21 @@ def test_objective_tokens_cost_absent_when_unrecorded(tmp_path):
     ws = _complete_ws(tmp_path)
     run = objective.read_completed_run(ws, "run-1", env={})
     assert run.objective.tokens is None and run.objective.cost is None
+
+
+def test_objective_json_is_opaque(tmp_path):
+    ws = _complete_ws(tmp_path)
+    # seed a private repo slug + gold/judge text into the workspace artifacts
+    (ws / "benchmark.yaml").write_text(json.dumps(
+        {"schema_version": 1, "source": {"repository": "acme/private-repo"},
+         "cases": [], "pull_requests": []}))
+    job = ws / "harbor" / "jobs" / "run-1" / "case-0" / "verifier"
+    (job / "reward-details.json").write_text(
+        json.dumps({"reasoning": "the gold finding in private-repo", "path": "/src/x.py"}))
+    run = objective.read_completed_run(ws, "run-1", env={})
+    blob = json.dumps(objective.objective_to_json(run))
+    for forbidden in ("acme", "private-repo", "/src/", "reasoning"):
+        assert forbidden not in blob
+    doc = json.loads(blob)
+    assert set(doc) <= {"run_id", "mode", "schema_version", "identity", "objective"}
+    assert isinstance(doc["objective"], dict)

--- a/tests/test_benchmark_objective.py
+++ b/tests/test_benchmark_objective.py
@@ -229,3 +229,30 @@ def test_objective_json_is_opaque(tmp_path):
     doc = json.loads(blob)
     assert set(doc) <= {"run_id", "mode", "schema_version", "identity", "objective"}
     assert isinstance(doc["objective"], dict)
+
+
+def test_suite_manifest_validation(tmp_path):
+    good = {"schema_version": 1, "entries": [
+        {"workspace": str(tmp_path / "a"), "run_id": "r1"},
+        {"workspace": str(tmp_path / "b"), "run_id": "r2"},
+    ]}
+    entries = objective.validate_suite_manifest(good)
+    assert [ (e.workspace.name, e.run_id) for e in entries ] == [("a", "r1"), ("b", "r2")]
+
+
+def test_suite_manifest_rejects_duplicate_and_incomplete(tmp_path):
+    dup = {"schema_version": 1, "entries": [
+        {"workspace": str(tmp_path / "a"), "run_id": "r1"},
+        {"workspace": str(tmp_path / "a"), "run_id": "r1"},
+    ]}
+    with pytest.raises(objective.ObjectiveError) as e:
+        objective.validate_suite_manifest(dup)
+    assert "duplicate" in str(e.value).lower()
+    incomplete = {"schema_version": 1, "entries": [
+        {"workspace": str(tmp_path / "a")},
+    ]}
+    with pytest.raises(objective.ObjectiveError):
+        objective.validate_suite_manifest(incomplete)
+    unsupported = {"schema_version": 99, "entries": []}
+    with pytest.raises(objective.ObjectiveError):
+        objective.validate_suite_manifest(unsupported)

--- a/tests/test_benchmark_objective.py
+++ b/tests/test_benchmark_objective.py
@@ -231,6 +231,73 @@ def test_objective_json_is_opaque(tmp_path):
     assert isinstance(doc["objective"], dict)
 
 
+def _complete_ws_at(tmp_path, name, run_id, trials, digest="d" * 64, wheel=None):
+    """A complete, consistent run under a repository workspace of the given name.
+
+    The ledger stores the on-disk compiled-lock hash and the supplied ``digest``
+    as the canonical review-profile digest, so ``read_completed_run`` resolves
+    the run and binds a differing profile digest per caller-supplied value.
+    """
+    ws = _ws(tmp_path / name)
+    _seed_compiled_lock(ws, wheel=wheel or _WHEEL)
+    run_mod.ledger_append_running(
+        ws, run_id=run_id,
+        compiled_lock_sha256=run_mod._compiled_lock_sha256(ws),
+        job_dir=str((ws / "harbor" / "jobs" / run_id).resolve()),
+        profile_digest=digest,
+    )
+    run_mod.ledger_mark(ws, run_id, state="complete")
+    _seed_trials(ws, run_id, trials)
+    return ws
+
+
+def test_aggregate_suite_pools_micro_metrics_and_never_mean(tmp_path):
+    from daydream.benchmark.harbor import verifier_core
+
+    a = _complete_ws_at(tmp_path, "a", "r1", [_reward(tp=1, fp=1, fn=0)])
+    b = _complete_ws_at(tmp_path, "b", "r2", [_reward(tp=1, fp=3, fn=0)])
+    manifest = {"schema_version": 1, "entries": [
+        {"workspace": str(a), "run_id": "r1"},
+        {"workspace": str(b), "run_id": "r2"},
+    ]}
+    suite = objective.aggregate_suite(manifest, env={})
+    assert suite.objective.precision == pytest.approx(2 / 6)  # pooled, not mean
+    assert suite.objective.precision != pytest.approx((0.5 + 0.25) / 2)
+    a_rows = objective.read_completed_run(a, "r1", env={}).task_rows
+    b_rows = objective.read_completed_run(b, "r2", env={}).task_rows
+    flat = a_rows + b_rows   # flattened per-task dicts across both runs
+    assert suite.objective._as_metric_dict() == verifier_core.aggregate_metrics(flat)
+
+
+def test_aggregate_suite_experiment_id_stable_under_reorder_rejects_dup(tmp_path):
+    a = _complete_ws_at(tmp_path, "a", "r1", [_reward(tp=1, fp=0, fn=0)])
+    b = _complete_ws_at(tmp_path, "b", "r2", [_reward(tp=1, fp=0, fn=0)])
+    m1 = {"schema_version": 1, "entries": [
+        {"workspace": str(a), "run_id": "r1"}, {"workspace": str(b), "run_id": "r2"}]}
+    m2 = {"schema_version": 1, "entries": [
+        {"workspace": str(b), "run_id": "r2"}, {"workspace": str(a), "run_id": "r1"}]}
+    s1 = objective.aggregate_suite(m1, env={})
+    s2 = objective.aggregate_suite(m2, env={})
+    assert s1.experiment_id == s2.experiment_id
+    assert s1.objective == s2.objective
+    dup = {"schema_version": 1, "entries": [
+        {"workspace": str(a), "run_id": "r1"}, {"workspace": str(a), "run_id": "r1"}]}
+    with pytest.raises(objective.ObjectiveError):
+        objective.aggregate_suite(dup, env={})
+
+
+def test_aggregate_suite_fails_closed_on_incompatible_identity(tmp_path):
+    a = _complete_ws_at(tmp_path, "a", "r1", [_reward(tp=1, fp=0, fn=0)],
+                        digest="d" * 64)
+    b = _complete_ws_at(tmp_path, "b", "r2", [_reward(tp=1, fp=0, fn=0)],
+                        digest="e" * 64)
+    manifest = {"schema_version": 1, "entries": [
+        {"workspace": str(a), "run_id": "r1"}, {"workspace": str(b), "run_id": "r2"}]}
+    with pytest.raises(objective.ObjectiveError) as e:
+        objective.aggregate_suite(manifest, env={})
+    assert "profile_digest" in str(e.value)
+
+
 def test_suite_manifest_validation(tmp_path):
     good = {"schema_version": 1, "entries": [
         {"workspace": str(tmp_path / "a"), "run_id": "r1"},

--- a/tests/test_benchmark_run.py
+++ b/tests/test_benchmark_run.py
@@ -48,7 +48,7 @@ def _ws(tmp_path, **privacy):
     ws = tmp_path / "ws"
     (ws / "runtime").mkdir(parents=True)
     (ws / "harbor").mkdir()
-    (ws / "harbor" / "benchmark.lock.json").write_text(json.dumps({"schema_version": 1, "cases": {}}))
+    _seed_compiled_lock(ws)
     (ws / "harbor" / "harbor-job.yaml").write_text("jobs_dir: jobs\n")
     (ws / "harbor" / "harbor-oracle.yaml").write_text("jobs_dir: jobs\n")
     p = {"classification": "confidential", "reviewer_data": "source_snapshot",
@@ -70,6 +70,16 @@ def _env(**over):
             "DAYDREAM_REVIEW_MODEL": "rm", "DAYDREAM_REVIEW_BASE_URL": "http://review.example"}
     base.update(over)
     return base
+
+
+_WHEEL = {"distribution": "daydream", "version": "0.1.0", "sha256": "c" * 64}
+
+
+def _seed_compiled_lock(ws, wheel=_WHEEL):
+    """Write a compiled lock with the ``daydream`` wheel block logged."""
+    lock = {"schema_version": 1, "cases": {"case-a": {"key": "case-a"}}, "files": {},
+            "daydream": wheel}
+    (ws / "harbor" / "benchmark.lock.json").write_text(json.dumps(lock))
 
 
 # ---------------------------------------------------------------------------
@@ -310,7 +320,7 @@ def test_gate_blocks_on_compiled_lock_mismatch(tmp_path):
     import daydream.benchmark.harbor.run as run_mod
 
     ws = _ws(tmp_path)
-    lock = {"schema_version": 1, "cases": {}}
+    lock = {"schema_version": 1, "cases": {}, "daydream": _WHEEL}
     lock_sha = hashlib.sha256(json.dumps(lock).encode()).hexdigest()
     (ws / "harbor" / "benchmark.lock.json").write_text(json.dumps(lock))
     job_dir = ws / "harbor" / "jobs" / "run-1"
@@ -321,12 +331,13 @@ def test_gate_blocks_on_compiled_lock_mismatch(tmp_path):
         ws, job_dir=job_dir, compiled_lock_sha256=lock_sha, env=_env(),
         calibration_digest="c" * 64,
     ) == 0
-    # now the current compiled lock digest differs from the receipt's
-    (ws / "harbor" / "benchmark.lock.json").write_text(json.dumps(
-        {"schema_version": 1, "cases": {}, "touched": True}))
+    # now the current compiled lock digest differs from the receipt's (wheel
+    # block kept so the daydream provenance read stays authoritative)
+    changed = {"schema_version": 1, "cases": {}, "touched": True, "daydream": _WHEEL}
+    (ws / "harbor" / "benchmark.lock.json").write_text(json.dumps(changed))
     reason = run_mod._default_run_gate(
         ws, env=_env(), compiled_lock_sha256=hashlib.sha256(
-            json.dumps({"schema_version": 1, "cases": {}, "touched": True}).encode()
+            json.dumps(changed).encode()
         ).hexdigest(), calibration_digest="c" * 64,
     )
     assert reason is not None
@@ -350,7 +361,7 @@ def test_gate_passes_when_inputs_match(tmp_path):
     import daydream.benchmark.harbor.run as run_mod
 
     ws = _ws(tmp_path)
-    lock = {"schema_version": 1, "cases": {}}
+    lock = {"schema_version": 1, "cases": {}, "daydream": _WHEEL}
     lock_sha = hashlib.sha256(json.dumps(lock).encode()).hexdigest()
     (ws / "harbor" / "benchmark.lock.json").write_text(json.dumps(lock))
     job_dir = ws / "harbor" / "jobs" / "run-1"
@@ -483,7 +494,7 @@ def test_default_run_propagates_harbor_exit_code(tmp_path):
     import daydream.benchmark.harbor.run as run_mod
 
     ws = _ws(tmp_path)
-    lock = {"schema_version": 1, "cases": {}}
+    lock = {"schema_version": 1, "cases": {}, "daydream": _WHEEL}
     lock_sha = hashlib.sha256(json.dumps(lock).encode()).hexdigest()
     (ws / "harbor" / "benchmark.lock.json").write_text(json.dumps(lock))
     job_dir = ws / "harbor" / "jobs" / "x"
@@ -595,3 +606,33 @@ def test_parse_job_results_records_env_when_reward_missing(tmp_path):
     assert ok is False
     assert envs and envs[0]["image_id"].startswith("hb__")   # was [] before the fix
     assert envs[0]["backend"] == "docker"
+
+
+# ---------------------------------------------------------------------------
+# Task 10: provenance — reviewer effort and Daydream wheel digest
+# ---------------------------------------------------------------------------
+
+
+def test_current_state_mapping_includes_effort_and_wheel_digest(tmp_path):
+    import daydream.benchmark.harbor.run as run_mod
+
+    ws = _ws(tmp_path)
+    _seed_compiled_lock(ws)   # benchmark.lock.json with daydream block
+    m = run_mod._current_state_mapping(
+        workspace=ws, compiled_lock_sha256="a" * 64, env=_env(), calibration_digest="")
+    assert m["daydream_wheel_sha256"] == "c" * 64
+    assert m["daydream_version"] == "0.1.0"
+    assert "reviewer_effort" in m
+
+
+def test_ledger_records_reviewer_effort_when_present(tmp_path):
+    import daydream.benchmark.harbor.run as run_mod
+
+    ws = _ws(tmp_path)
+    run_id = "run-1"
+    run_mod.ledger_append_running(ws, run_id=run_id, compiled_lock_sha256="a" * 64,
+                                  job_dir=str((ws / "harbor" / "jobs" / run_id).resolve()),
+                                  profile_digest="d" * 64)
+    run_mod.ledger_mark(ws, run_id, state="complete")
+    doc = run_mod._load_ledger(ws)
+    assert doc["runs"][0]["profile_digest"] == "d" * 64

--- a/tests/test_benchmark_run.py
+++ b/tests/test_benchmark_run.py
@@ -632,7 +632,22 @@ def test_ledger_records_reviewer_effort_when_present(tmp_path):
     run_id = "run-1"
     run_mod.ledger_append_running(ws, run_id=run_id, compiled_lock_sha256="a" * 64,
                                   job_dir=str((ws / "harbor" / "jobs" / run_id).resolve()),
-                                  profile_digest="d" * 64)
+                                  profile_digest="d" * 64, reviewer_effort="high")
     run_mod.ledger_mark(ws, run_id, state="complete")
     doc = run_mod._load_ledger(ws)
     assert doc["runs"][0]["profile_digest"] == "d" * 64
+    assert doc["runs"][0]["reviewer_effort"] == "high"
+
+
+def test_ledger_reviewer_effort_defaults_none_when_omitted(tmp_path):
+    import daydream.benchmark.harbor.run as run_mod
+
+    ws = _ws(tmp_path)
+    run_id = "run-1"
+    run_mod.ledger_append_running(ws, run_id=run_id, compiled_lock_sha256="a" * 64,
+                                  job_dir=str((ws / "harbor" / "jobs" / run_id).resolve()))
+    run_mod.ledger_mark(ws, run_id, state="complete")
+    doc = run_mod._load_ledger(ws)
+    # Issue #888: an omitted effort stays None on the entry (byte-stable for
+    # legacy callers); the objective reader surfaces it as None, never 0/"".
+    assert doc["runs"][0]["reviewer_effort"] is None


### PR DESCRIPTION
Closes #888

## Summary
Expose typed Harbor objectives and repository-suite aggregation in the benchmark tooling:
- Add `ObjectiveError` and explicit-run ledger resolution, binding objective identity from recorded run state
- Parse per-task rewards, classify failures, and project opaque privacy-safe objective JSON
- Bind and cross-check compatibility identity; derive count metrics from authoritative scoring
- Aggregate compatible runs into pooled micro metrics; validate suite manifest entries
- Wire `objective` and `aggregate` CLI subcommands
- Record reviewer effort and wheel digest in provenance

## Test Plan
- Gate: `make check` — 4636 passed, 8 skipped (ruff/mypy/lockcheck clean)
- Two sequential daydream deep-precision reviews (rounds 1 & 2) completed on fresh VMs; round-2 findings addressed
- Trajectory uploaded to HF session `81ca7002-f024-4ca4-bdcf-be44eabaf076`

Closes #888
