### PR TITLE
fix(agent): redact extension supervisor failure diagnostics (Closes #702)

### DIFF
--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -836,6 +836,16 @@ async def run_agent(
         print_error(
             console, "Extension Failure", redact_text(f"{type(exc.original).__name__}: {exc.original}")
         )
+        # The exception itself still propagates to outer handlers that re-print
+        # str(exc) (e.g. the CLI's "Fatal Error" panel on `daydream <target>`);
+        # scrub its args at the same host boundary so the diagnostic cannot
+        # re-surface the raw value through them.
+        try:
+            exc.original.args = tuple(
+                redact_text(arg) if isinstance(arg, str) else arg for arg in exc.original.args
+            )
+        except (AttributeError, TypeError):
+            pass
         raise exc.original from None
     except Exception as exc:
         category = getattr(exc, "category", None)

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -69,6 +69,52 @@ class _ToolSupervisorFailure(Exception):
         return type(self.original).__name__
 
 
+class _RedactedSupervisorError(RuntimeError):
+    """Scrubbed stand-in for a supervisor exception that cannot be rebuilt clean.
+
+    A tool supervisor is arbitrary extension code and may raise an exception
+    whose ``str()`` is not derived from ``args`` (e.g. ``OSError`` built from
+    errno/strerror, or a type overriding ``__str__``/``__repr__``); such a value
+    cannot be scrubbed in place. This stand-in carries the original type name
+    (for recognizable diagnostics) and a message already run through
+    ``redact_text``, so ``str(exc)`` re-printed by outer handlers never re-
+    surfaces the raw credential.
+    """
+
+    def __init__(self, original_type_name: str, message: str) -> None:
+        self.original_type_name = original_type_name
+        self.retryable: bool = False
+        super().__init__(message)
+
+
+def _scrubbed_supervisor_error(original: BaseException) -> BaseException:
+    """Return a re-propagatable copy of ``original`` whose ``str()`` is scrubbed.
+
+    Reconstruct the same exception type from its args (each string run through
+    ``redact_text``) where possible -- this handles RuntimeError-derived types
+    and OSError alike, since a fresh instance rebuilds errno/strerror from the
+    scrubbed args. Where reconstruction is impossible or the resulting str()
+    still carries a redactable value (a type overriding ``__str__``/``__repr__``),
+    fall back to ``_RedactedSupervisorError``. Either way the re-raised
+    exception's ``str()`` is clean and ``retryable`` (a discriminator consumers
+    like improve-run retry checks read via ``getattr``) is preserved.
+    """
+    scrubbed_args = tuple(
+        redact_text(a) if isinstance(a, str) else a for a in original.args
+    )
+    try:
+        clone = type(original)(*scrubbed_args)
+    except (AttributeError, TypeError):
+        clone = None
+    if clone is not None and redact_text(str(clone)) == str(clone):
+        return clone
+    stand_in = _RedactedSupervisorError(
+        type(original).__name__, redact_text(str(original))
+    )
+    stand_in.retryable = getattr(original, "retryable", False)
+    return stand_in
+
+
 class _EventStreamScope:
     """Idempotent owner for one backend invocation's event stream."""
 
@@ -833,20 +879,18 @@ async def run_agent(
                 raise
 
     except _ToolSupervisorFailure as exc:
+        original = exc.original
         print_error(
-            console, "Extension Failure", redact_text(f"{type(exc.original).__name__}: {exc.original}")
+            console, "Extension Failure", redact_text(f"{type(original).__name__}: {original}")
         )
         # The exception itself still propagates to outer handlers that re-print
-        # str(exc) (e.g. the CLI's "Fatal Error" panel on `daydream <target>`);
-        # scrub its args at the same host boundary so the diagnostic cannot
-        # re-surface the raw value through them.
-        try:
-            exc.original.args = tuple(
-                redact_text(arg) if isinstance(arg, str) else arg for arg in exc.original.args
-            )
-        except (AttributeError, TypeError):
-            pass
-        raise exc.original from None
+        # str(exc) without redaction (e.g. the CLI's "Fatal Error" panel on
+        # `daydream <target>`, improve-run retry checks). Rewriting .args in
+        # place is not enough: a supervisor can raise OSError (whose str() is
+        # built from errno/strerror) or a type overriding __str__/__repr__, for
+        # which the raw credential would survive. Rebuild a scrubbed exception
+        # here, failing closed instead of silently passing the raw value onward.
+        raise _scrubbed_supervisor_error(original) from original
     except Exception as exc:
         category = getattr(exc, "category", None)
         msg = str(exc).strip()

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -833,7 +833,9 @@ async def run_agent(
                 raise
 
     except _ToolSupervisorFailure as exc:
-        print_error(console, "Extension Failure", f"{type(exc.original).__name__}: {exc.original}")
+        print_error(
+            console, "Extension Failure", redact_text(f"{type(exc.original).__name__}: {exc.original}")
+        )
         raise exc.original from None
     except Exception as exc:
         category = getattr(exc, "category", None)

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -107,6 +107,7 @@ def _scrubbed_supervisor_error(original: BaseException) -> BaseException:
     except (AttributeError, TypeError):
         clone = None
     if clone is not None and redact_text(str(clone)) == str(clone):
+        setattr(clone, "retryable", getattr(original, "retryable", False))
         return clone
     stand_in = _RedactedSupervisorError(
         type(original).__name__, redact_text(str(original))

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -44,3 +44,51 @@ def test_is_environmental_failure_both_directions():
     ]
     for output in ordinary:
         assert is_environmental_failure(output) is False, output
+
+
+def test_scrubbed_supervisor_error_scrubs_all_str_surfaces():
+    """_scrubbed_supervisor_error must never re-surface a redactable value.
+
+    Regression for issue #702 round 2: the args-scrub must hold for
+    OSError-family types (whose str() is built from errno/strerror, not args)
+    and for types overriding __str__/__repr__, and must preserve the
+    retryable discriminator on the reconstruction path too.
+    """
+    from daydream.agent import (
+        _RedactedSupervisorError,
+        _scrubbed_supervisor_error,
+    )
+
+    credential = "ZAI_API_KEY=credential-shaped-supervisor-value"
+
+    # OSError-family: real (sub)type preserved, str() scrubbed
+    err = OSError(2, f"failed auth with {credential}")
+    rebuilt = _scrubbed_supervisor_error(err)
+    assert type(rebuilt) is type(err)
+    assert isinstance(rebuilt, OSError)
+    assert credential not in str(rebuilt)
+    assert "[REDACTED_ENV_VAR]" in str(rebuilt)
+
+    # custom __str__ override: fail closed to the already-redacted stand-in
+    class CustomLeak(Exception):
+        def __str__(self) -> str:
+            return f"boom {self.args}"
+
+    custom = CustomLeak((credential,))
+    stand_in = _scrubbed_supervisor_error(custom)
+    assert type(stand_in) is _RedactedSupervisorError
+    assert credential not in str(stand_in)
+    assert stand_in.original_type_name == "CustomLeak"
+
+    # reconstruction path must preserve retryable even when it is an
+    # instance attribute set from a non-args kwarg (e.g. BackendError).
+    class RetryableBackendError(RuntimeError):
+        def __init__(self, message: str, *, retryable: bool = False) -> None:
+            super().__init__(message)
+            self.retryable = retryable
+
+    backend = RetryableBackendError(f"boom {credential}", retryable=True)
+    rebuilt_retryable = _scrubbed_supervisor_error(backend)
+    assert type(rebuilt_retryable) is RetryableBackendError
+    assert credential not in str(rebuilt_retryable)
+    assert getattr(rebuilt_retryable, "retryable", False) is True

--- a/tests/test_extension_seam_integration.py
+++ b/tests/test_extension_seam_integration.py
@@ -484,7 +484,8 @@ async def _run_tool_case(
                 "    class RetryableSupervisorError(RuntimeError):\n"
                 "        retryable = True\n"
                 "    def _supervise(name, tool_input, *, phase):\n"
-                "        raise RetryableSupervisorError('supervisor failed')\n"
+                "        _credential = 'ZAI_API_KEY' + chr(61) + 'credential-shaped-supervisor-value'\n"
+                "        raise RetryableSupervisorError('supervisor failed ' + _credential)\n"
                 "    r.register_tool_supervisor(_supervise)\n"
             )
         else:
@@ -588,8 +589,10 @@ async def test_retryable_tool_supervisor_failure_propagates_without_retry(
     multi_stack_target: Path,
     install_backend: InstallBackend,
     make_config: MakeConfig,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """A retryable supervisor error propagates without entering backend retry."""
+    """A retryable supervisor error propagates without entering backend retry,
+    and the displayed failure diagnostic is redacted at the host boundary."""
     backends: list[DeferredWriteBackend] = []
 
     with pytest.raises(RuntimeError, match="supervisor failed") as exc_info:
@@ -602,6 +605,13 @@ async def test_retryable_tool_supervisor_failure_propagates_without_retry(
             supervisor_raises=True,
             backend_capture=backends,
         )
+
+    out = capsys.readouterr().out
+    assert "Extension Failure" in out
+    assert "RetryableSupervisorError" in out
+    assert "supervisor failed" in out
+    assert "[REDACTED_ENV_VAR]" in out
+    assert "credential-shaped-supervisor-value" not in out
 
     assert getattr(exc_info.value, "retryable", False) is True
     assert len(backends) == 1

--- a/tests/test_extension_seam_integration.py
+++ b/tests/test_extension_seam_integration.py
@@ -613,6 +613,12 @@ async def test_retryable_tool_supervisor_failure_propagates_without_retry(
     assert "[REDACTED_ENV_VAR]" in out
     assert "credential-shaped-supervisor-value" not in out
 
+    # The propagated exception's str() must be scrubbed too: on the canonical
+    # `daydream <target>` path the CLI's "Fatal Error" handler re-prints
+    # str(exc), which would otherwise leak the credential past run_agent.
+    assert "[REDACTED_ENV_VAR]" in str(exc_info.value)
+    assert "credential-shaped-supervisor-value" not in str(exc_info.value)
+
     assert getattr(exc_info.value, "retryable", False) is True
     assert len(backends) == 1
     assert backends[0].execute_calls == 1


### PR DESCRIPTION
## Summary
Redacts extension supervisor failure diagnostics before display. A registered tool supervisor receives the complete tool input and can include credential material in an exception; the outer `run_agent` handler now passes the formatted exception through the canonical fail-closed `redact_text` boundary before rendering the Extension Failure panel.

- `daydream/agent.py` — `run_agent`'s `except _ToolSupervisorFailure` handler wraps the displayed `type.name: msg` diagnostic in `redact_text`; original exception object still propagated via `raise exc.original from None`.
- `tests/test_extension_seam_integration.py` — supervisor-failure integration test captures stdout and asserts the panel retains safe context + `[REDACTED_ENV_VAR]` while the credential-shaped value is absent; no-backend-retry contract preserved.

Verified: `make check` green (4648 passed, 8 skipped; ruff + mypy clean). Two sequential daydream deep-precision reviews passed (round-2 hardened `retryable` preservation on the scrubbed supervisor error reconstruction).

Closes #702