### PR TITLE
fix(benchmark): decouple Oracle from unverified calibration and honor OpenRouter policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **benchmark:** add `daydream benchmark run <workspace> [--oracle] [--yes]` command (supervised Harbor runs behind the Oracle self-match gate, private `runtime/harbor.json` cleanup ledger)
-- **benchmark:** add `daydream benchmark calibrate-judge <workspace>` command (drives the exact packaged judge path, 24-pair fixture, three-part pass gate, private `runtime/calibration-receipt.json`)
+- **benchmark:** add `daydream benchmark calibrate-judge <workspace>` command (optional diagnostic of judge agreement against the unverified 24-pair fixture — it is not an authorization or correctness gate; writes an unverified `runtime/calibration-receipt.json`)
 
 ### Changed
+
+- **benchmark:** decouple the Oracle self-match/reward gate and the normal benchmark-after-Oracle gate from loaded calibration fixtures; `run.py` no longer treats a calibration receipt as a run prerequisite or tracks `calibration_receipt_sha256` in the shared Oracle-state mapping (old receipts with the legacy field stay usable)
+- **benchmark:** re-scope the calibration fixture and receipts as explicit unverified, diagnostic-only artifacts; `pairs.json` carries machine-readable provenance and receipts validate it; the `0.90` judge-agreement diagnostic metric is distinct from the `0.70` retained-edge threshold
+- **benchmark:** compile the workspace's persisted network policy from `benchmark.yaml` privacy allowlists into Harbor task TOML (`render_task_toml` now requires explicit reviewer/judge host lists and fails closed); an allowlist change invalidates existing Oracle receipts via the compiled lock digest
+- **benchmark:** regression coverage for Oracle decoupling, fixture provenance, fail-closed host policies, and agent/verifier host separation; docs distinguish diagnostics, the Oracle gate, and the OpenRouter data-handling requirement
 
 - **benchmark:** require `requested_base_sha` on ready/imported snapshot records; `migrate.migrate_workspace` backfills the field from `original_base_sha` on both v1 upgrade and v2 repair passes so pre-provenance-split workspaces stay loadable.
 

--- a/daydream/benchmark/cli.py
+++ b/daydream/benchmark/cli.py
@@ -534,7 +534,15 @@ def _build_benchmark_parser() -> argparse.ArgumentParser:
         help="apply a reviewed gold YAML draft (derive all forbidden fields, never ready)",
     )
 
-    calibrate_p = sub.add_parser("calibrate-judge", help="calibrate the configured semantic-match judge")
+    calibrate_p = sub.add_parser(
+        "calibrate-judge",
+        help="diagnostic: measure the configured judge's agreement with the unverified fixture",
+        description=(
+            "diagnostic: measure the configured judge's agreement with the unverified "
+            "labeled fixture. A passing result only means the judge agrees with this "
+            "unverified fixture — it is not calibrated or correct."
+        ),
+    )
     calibrate_p.add_argument("dir", type=Path, help="workspace directory")
     calibrate_p.add_argument(
         "--yes", action="store_true", help="confirm the paid 72-call calibration run"
@@ -742,11 +750,13 @@ def _is_interactive_tty() -> bool:
 
 
 def _handle_benchmark_calibrate(args) -> int:
-    """Calibrate the configured judge against the fixed 24-pair fixture.
+    """Diagnostic: measure the configured judge's agreement with the unverified fixture.
 
-    Requires ``--yes`` or an interactive TTY before any paid judge call. Lazy
-    imports the calibrate module (mirroring the other handlers); build failures
-    and refusals print to stderr and return exit ``1`` — never a bare traceback.
+    A passing result only means the judge agrees with this unverified labeled
+    fixture — it is not calibrated or correct. Requires ``--yes`` or an
+    interactive TTY before any paid judge call. Lazy imports the calibrate
+    module (mirroring the other handlers); build failures and refusals print to
+    stderr and return exit ``1`` — never a bare traceback.
     """
     if not args.yes and not _is_interactive_tty():
         print(
@@ -768,9 +778,9 @@ def _handle_benchmark_calibrate(args) -> int:
     }
 
     # Issue #885/R12: thread the control-plane candidate profile digest so a
-    # candidate-scoped calibration can be produced (run.py's oracle preflight
-    # compares the receipt against inputs that fold the digest). Fail-closed on
-    # an invalid candidate, matching run.py's handling. None for default runs.
+    # candidate-scoped diagnostic receipt can be produced (its invalidation
+    # inputs fold the digest). Fail-closed on an invalid candidate. None for
+    # default runs. The receipt is diagnostic-only — it is not read by run.py.
     env["DAYDREAM_REVIEW_PROFILE_CANDIDATE_DIGEST"] = _candidate_profile_digest()
 
     return calibrate.run_calibration(

--- a/daydream/benchmark/harbor/build.py
+++ b/daydream/benchmark/harbor/build.py
@@ -654,7 +654,13 @@ def _compile_case(
         render_task_toml,
     )
 
-    (case_stage / "task.toml").write_bytes(render_task_toml(key))
+    (case_stage / "task.toml").write_bytes(
+        render_task_toml(
+            key,
+            reviewer_hosts=["api.anthropic.com"],
+            judge_hosts=["api.anthropic.com"],
+        )
+    )
     (case_stage / "environment").mkdir(exist_ok=True)
     (case_stage / "environment" / "Dockerfile").write_bytes(
         render_environment_dockerfile(

--- a/daydream/benchmark/harbor/build.py
+++ b/daydream/benchmark/harbor/build.py
@@ -630,8 +630,19 @@ def _compile_case(
     *,
     runtime_lock: bytes,
     wheel: Path | None,
+    reviewer_hosts: list[str],
+    judge_hosts: list[str],
 ) -> dict:
-    """Compile one case tree into ``stage/<key>/`` and return its lock row."""
+    """Compile one case tree into ``stage/<key>/`` and return its lock row.
+
+    The network policy is threaded from the workspace's persisted privacy
+    allowlists: ``reviewer_hosts`` become ``[agent].allowed_hosts`` and
+    ``judge_hosts`` become ``[verifier.environment].allowed_hosts``, keeping
+    the two egress boundaries separate. Because the policy lands in
+    ``task.toml`` and that file's digest is inventoried in the lock, a policy
+    change propagates to the lock bytes / ``compiled_lock_sha256`` and thereby
+    invalidates any existing Oracle receipt.
+    """
     case_id = case_doc["case_id"]
     key = derive_task_key(case_id)
     case_stage = stage / key
@@ -657,8 +668,8 @@ def _compile_case(
     (case_stage / "task.toml").write_bytes(
         render_task_toml(
             key,
-            reviewer_hosts=["api.anthropic.com"],
-            judge_hosts=["api.anthropic.com"],
+            reviewer_hosts=reviewer_hosts,
+            judge_hosts=judge_hosts,
         )
     )
     (case_stage / "environment").mkdir(exist_ok=True)
@@ -831,6 +842,17 @@ def compile_workspace(root: Path, *, wheel: Path | None = None) -> dict:
         # validate/status read path); a present-but-corrupt case raises
         # ``WorkspaceCorrupt`` before any staging begins.
         manifest_model = schema.BenchmarkManifest.model_validate(manifest)
+        # The compiled network policy is sourced from the workspace's persisted
+        # privacy allowlists -- never a hardcoded default. The pydantic model
+        # already rejects empty lists, but re-raise fail-closed so a private
+        # workspace can never silently compile an unsafe (or hostless) policy.
+        reviewer_hosts = list(manifest_model.privacy.reviewer_allowed_hosts)
+        judge_hosts = list(manifest_model.privacy.judge_allowed_hosts)
+        if not reviewer_hosts or not judge_hosts:
+            raise CompileError(
+                "network policy requires non-empty privacy reviewer_allowed_hosts "
+                "and judge_allowed_hosts in benchmark.yaml"
+            )
         case_docs: dict[str, dict] = {}
         for case_file, doc in workspace.load_case_documents(root, manifest_model).items():
             dumped = doc.model_dump(mode="json")
@@ -868,6 +890,8 @@ def compile_workspace(root: Path, *, wheel: Path | None = None) -> dict:
                     repo_slug,
                     runtime_lock=runtime_lock,
                     wheel=wheel,
+                    reviewer_hosts=reviewer_hosts,
+                    judge_hosts=judge_hosts,
                 )
                 case_rows.append(row)
                 key = row["key"]

--- a/daydream/benchmark/harbor/build.py
+++ b/daydream/benchmark/harbor/build.py
@@ -21,6 +21,8 @@ import shutil
 from pathlib import Path
 from typing import Any
 
+from pydantic import ValidationError
+
 from daydream.benchmark import schema, snapshot, storage, workspace
 from daydream.benchmark.harbor import verifier_core as vc
 
@@ -840,8 +842,14 @@ def compile_workspace(root: Path, *, wheel: Path | None = None) -> dict:
         # Every indexed case is loaded through the shared model-gated loader
         # (same ``_schema_ready`` + ``CaseDocument`` validation as the
         # validate/status read path); a present-but-corrupt case raises
-        # ``WorkspaceCorrupt`` before any staging begins.
-        manifest_model = schema.BenchmarkManifest.model_validate(manifest)
+        # ``WorkspaceCorrupt`` before any staging begins. The manifest model
+        # validation (which rejects malformed/empty privacy host lists) is
+        # surfaced as ``CompileError`` so a disallowed-host policy fails the
+        # compile closed through the documented rejection type.
+        try:
+            manifest_model = schema.BenchmarkManifest.model_validate(manifest)
+        except ValidationError as exc:
+            raise CompileError(f"{root}: invalid benchmark.yaml: {exc}") from exc
         # The compiled network policy is sourced from the workspace's persisted
         # privacy allowlists -- never a hardcoded default. The pydantic model
         # already rejects empty lists, but re-raise fail-closed so a private

--- a/daydream/benchmark/harbor/build.py
+++ b/daydream/benchmark/harbor/build.py
@@ -851,16 +851,12 @@ def compile_workspace(root: Path, *, wheel: Path | None = None) -> dict:
         except ValidationError as exc:
             raise CompileError(f"{root}: invalid benchmark.yaml: {exc}") from exc
         # The compiled network policy is sourced from the workspace's persisted
-        # privacy allowlists -- never a hardcoded default. The pydantic model
-        # already rejects empty lists, but re-raise fail-closed so a private
-        # workspace can never silently compile an unsafe (or hostless) policy.
+        # privacy allowlists -- never a hardcoded default. The Privacy field
+        # validators (_normalize_host_list) already reject empty/malformed
+        # lists during model_validate, surfacing above as CompileError, so an
+        # unsafe (or hostless) policy can never reach the task render.
         reviewer_hosts = list(manifest_model.privacy.reviewer_allowed_hosts)
         judge_hosts = list(manifest_model.privacy.judge_allowed_hosts)
-        if not reviewer_hosts or not judge_hosts:
-            raise CompileError(
-                "network policy requires non-empty privacy reviewer_allowed_hosts "
-                "and judge_allowed_hosts in benchmark.yaml"
-            )
         case_docs: dict[str, dict] = {}
         for case_file, doc in workspace.load_case_documents(root, manifest_model).items():
             dumped = doc.model_dump(mode="json")

--- a/daydream/benchmark/harbor/calibrate.py
+++ b/daydream/benchmark/harbor/calibrate.py
@@ -1,13 +1,18 @@
-"""Calibration gate for configured semantic-match judges.
+"""Optional diagnostic of a configured semantic-match judge's agreement with a labeled fixture.
 
-Drives the exact packaged Harbor judge path (``score_review.judge_pairs``,
+Runs the exact packaged Harbor judge path (``score_review.judge_pairs``,
 loaded via importlib from ``templates/tests/`` so the bare ``import
 verifier_core`` resolves to the sibling copy) against a fixed 24-pair labeled
-fixture, three times per pair (72 judge calls). Computes a three-part pass
-gate — majority correctness, balanced accuracy, and per-pair retained-edge
-threshold-flip stability — and, on pass, records a private deterministic
-invalidation-aware receipt at ``<workspace>/runtime/calibration-receipt.json``.
-Measuring, never tuning: no weights or thresholds are derived here.
+fixture, three times per pair (72 judge calls). Computes a three-part
+agreement metric — majority correctness, balanced accuracy, and per-pair
+retained-edge threshold-flip stability — and, on pass, records a private
+deterministic invalidation-aware receipt at
+``<workspace>/runtime/calibration-receipt.json``.
+
+A passing result means only that the configured judge agrees with this
+unverified fixture; it is not calibrated or correct, and this module is not
+an authorization gate for any other path. Measuring, never tuning: no
+weights or thresholds are derived here.
 """
 
 from __future__ import annotations
@@ -459,13 +464,14 @@ def run_calibration(
     http: Any = None,
     confirm: Callable[[str], bool] | None = None,
 ) -> int:
-    """Drive the calibration gate end-to-end and return an exit code.
+    """Run the diagnostic judge-agreement check end-to-end and return an exit code.
 
     Order: manifest/host validation -> fixture + template load -> confirmation
-    gate -> client build -> 72-call judge driver -> three-part pass gate.
-    On pass a private receipt is written; on failure (or refusal) no receipt is
-    written and the exit code is nonzero (fail-closed). Never measures by
-    tuning anything.
+    gate -> client build -> 72-call judge driver -> three-part agreement
+    metric. A passing result means the configured judge agrees with the
+    unverified fixture — it is not calibrated or correct. On pass a private
+    receipt is written; on failure (or refusal) no receipt is written and the
+    exit code is nonzero (fail-closed). Never measures by tuning anything.
     """
 
     env = dict(env) if env is not None else dict(os.environ)

--- a/daydream/benchmark/harbor/calibrate.py
+++ b/daydream/benchmark/harbor/calibrate.py
@@ -292,7 +292,11 @@ def _pass_gate(
 
 
 def _label_sha256(pairs: list[dict[str, Any]]) -> str:
-    """Canonical sha256 over the ordered gold/candidate/label triples."""
+    """Canonical sha256 over the ordered gold/candidate/label triples.
+
+    Retained as a compatibility field; the full-content ``fixture_sha256`` is
+    the authoritative invalidation digest.
+    """
     triples = [
         {
             "gold": p["gold"]["finding_id"],
@@ -305,6 +309,20 @@ def _label_sha256(pairs: list[dict[str, Any]]) -> str:
         triples, sort_keys=True, separators=(",", ":"), ensure_ascii=True
     ).encode("utf-8")
     return hashlib.sha256(canonical).hexdigest()
+
+
+def _fixture_sha256() -> str:
+    """Canonical sha256 over the full pairs.json bytes (content + provenance).
+
+    Digests the raw file, so any change to the fixture object — a pair's
+    content or the provenance block — invalidates every existing diagnostic
+    receipt.
+    """
+    path = _CALIBRATION_DIR / "pairs.json"
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError as exc:
+        raise ValueError(f"could not read calibration fixture at {path}: {exc}") from exc
 
 
 def _render_judge_prompt_digest(sr: Any) -> str:
@@ -323,7 +341,13 @@ def _serialize_inputs(inputs: dict[str, Any]) -> bytes:
 def _invalidation_inputs(
     env: dict[str, Any], pairs: list[dict[str, Any]], sr: Any
 ) -> dict[str, Any]:
-    """The receipt's invalidation contract: a deterministic byte-stable dict."""
+    """The receipt's invalidation contract: a deterministic byte-stable dict.
+
+    ``fixture_sha256`` digests the full pairs.json bytes (content + provenance),
+    and ``fixture_provenance`` mirrors the provenance block, so a fixture
+    content or provenance change invalidates existing receipts — not just a
+    reorder of the ordered triples covered by ``label_sha256``.
+    """
     inputs = {
         "provider": env.get("DAYDREAM_JUDGE_PROVIDER") or "anthropic",
         "model": env.get("DAYDREAM_JUDGE_MODEL") or "",
@@ -331,14 +355,16 @@ def _invalidation_inputs(
         "judge_prompt_sha256": _render_judge_prompt_digest(sr),
         "threshold": sr.verifier_core.CONFIDENCE_THRESHOLD,
         "label_sha256": _label_sha256(pairs),
+        "fixture_sha256": _fixture_sha256(),
+        "fixture_provenance": _load_provenance(),
         "attempts": 3,
         "request_timeout": sr._REQUEST_TIMEOUT,
     }
     # Candidate review-profile digest (issue #885/R12): a change of candidate
     # invalidates the calibration receipt (per-candidate attribution). Omitted
     # when absent so the legacy receipt contract stays byte-stable for default
-    # runs. Mirrors run._calibration_invalidation_inputs so the receipt built
-    # here and the preflight check in run.py produce identical inputs.
+    # runs. Mirrors run._calibration_invalidation_inputs, which delegates here,
+    # so the receipt built here and run.py's helper produce identical inputs.
     digest = env.get("DAYDREAM_REVIEW_PROFILE_CANDIDATE_DIGEST")
     if digest:
         inputs["profile_digest"] = str(digest)
@@ -355,12 +381,17 @@ def _build_receipt(
     confusion: dict[str, int],
     disagreements: list[Any],
 ) -> dict[str, Any]:
-    """Build the private deterministic calibration receipt document."""
+    """Build the private deterministic calibration receipt document.
+
+    The receipt mirrors the fixture's machine-readable provenance, so a future
+    re-verification of the fixture is visible in every receipt built from it.
+    """
     return {
         "schema_version": 1,
         "type": "judge-calibration",
         "recorded_at": datetime.now(timezone.utc).isoformat(),
         "inputs": _invalidation_inputs(env, pairs, sr),
+        "provenance": _load_provenance(),
         "result": {
             "passed": passed,
             "balanced_accuracy": balanced_accuracy,
@@ -379,12 +410,34 @@ def _write_receipt(workspace: Path, receipt: dict[str, Any]) -> Path:
 
 
 def is_receipt_current(receipt_path: Path, current_inputs: dict[str, Any]) -> bool:
-    """Fail-closed invalidation check: True only on a byte-exact inputs match."""
+    """Fail-closed invalidation check for diagnostic receipts.
+
+    True only when the stored inputs byte-match the current inputs AND the
+    document satisfies the diagnostic-receipt contract: ``schema_version`` 1,
+    ``type`` ``judge-calibration``, ``result.passed`` True, and a provenance
+    block declaring the fixture ``llm_generated`` and not ``human_reviewed``.
+    Any violation — including a fixture content or provenance change, which
+    moves ``fixture_sha256`` — returns False.
+    """
     try:
         raw = json.loads(Path(receipt_path).read_bytes())
     except (ValueError, OSError):
         return False
     if not isinstance(raw, dict) or not isinstance(raw.get("inputs"), dict):
+        return False
+    if raw.get("schema_version") != 1:
+        return False
+    if raw.get("type") != "judge-calibration":
+        return False
+    result = raw.get("result")
+    if not isinstance(result, dict) or result.get("passed") is not True:
+        return False
+    provenance = raw.get("provenance")
+    if not isinstance(provenance, dict):
+        return False
+    if provenance.get("origin") != "llm_generated":
+        return False
+    if provenance.get("human_reviewed") is not False:
         return False
     return _serialize_inputs(raw["inputs"]) == _serialize_inputs(current_inputs)
 

--- a/daydream/benchmark/harbor/calibrate.py
+++ b/daydream/benchmark/harbor/calibrate.py
@@ -120,7 +120,7 @@ def _load_provenance(pairs: list[dict[str, Any]]) -> dict[str, Any]:
         raise ValueError('calibration fixture must contain a "provenance" object')
     balance: dict[str, int] = {}
     for pair in pairs:
-        label = pair.get("label")
+        label = pair.get("label") or ""
         balance[label] = balance.get(label, 0) + 1
     return {
         **provenance,

--- a/daydream/benchmark/harbor/calibrate.py
+++ b/daydream/benchmark/harbor/calibrate.py
@@ -103,16 +103,30 @@ def _load_fixture() -> list[dict[str, Any]]:
     return pairs
 
 
-def _load_provenance() -> dict[str, Any]:
-    """Read and return the fixture's machine-readable provenance block.
+def _load_provenance(pairs: list[dict[str, Any]]) -> dict[str, Any]:
+    """Return the fixture's provenance declaration bound to the passed pairs.
 
-    Raises ``ValueError`` if the provenance block is absent or not an object.
+    The declaration (``origin``, ``human_reviewed``, ``labels``, notes) comes
+    from the fixture document, while the pair-attestable facts
+    (``class_balance``, ``categories``) are computed from the passed ``pairs``
+    argument, so the provenance describes exactly the pairs a receipt was
+    built from and a synthetic or subset-pairs caller gets a matching
+    declaration. Raises ``ValueError`` if the provenance block is absent or
+    not an object.
     """
     data = _load_fixture_document()
     provenance = data.get("provenance")
     if not isinstance(provenance, dict):
         raise ValueError('calibration fixture must contain a "provenance" object')
-    return provenance
+    balance: dict[str, int] = {}
+    for pair in pairs:
+        label = pair.get("label")
+        balance[label] = balance.get(label, 0) + 1
+    return {
+        **provenance,
+        "class_balance": balance,
+        "categories": len({pair.get("category") for pair in pairs}),
+    }
 
 
 def _build_calibration_client(env: dict[str, Any], *, http: Any = None) -> Any:
@@ -316,18 +330,21 @@ def _label_sha256(pairs: list[dict[str, Any]]) -> str:
     return hashlib.sha256(canonical).hexdigest()
 
 
-def _fixture_sha256() -> str:
-    """Canonical sha256 over the full pairs.json bytes (content + provenance).
+def _fixture_sha256(pairs: list[dict[str, Any]]) -> str:
+    """Canonical sha256 over the full passed fixture pairs.
 
-    Digests the raw file, so any change to the fixture object — a pair's
-    content or the provenance block — invalidates every existing diagnostic
-    receipt.
+    Digests the ``pairs`` argument — every pair field (gold/candidate content,
+    category, label), not just the ordered triples covered by ``label_sha256`` —
+    so the authoritative invalidation digest is bound to exactly what was
+    judged. A caller passing synthetic or subset pairs binds the digest to
+    those pairs rather than to a fixed on-disk file; any fixture content change
+    moves the digest even without a triple reorder and invalidates existing
+    receipts.
     """
-    path = _CALIBRATION_DIR / "pairs.json"
-    try:
-        return hashlib.sha256(path.read_bytes()).hexdigest()
-    except OSError as exc:
-        raise ValueError(f"could not read calibration fixture at {path}: {exc}") from exc
+    canonical = json.dumps(
+        pairs, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
 
 
 def _render_judge_prompt_digest(sr: Any) -> str:
@@ -348,10 +365,11 @@ def _invalidation_inputs(
 ) -> dict[str, Any]:
     """The receipt's invalidation contract: a deterministic byte-stable dict.
 
-    ``fixture_sha256`` digests the full pairs.json bytes (content + provenance),
-    and ``fixture_provenance`` mirrors the provenance block, so a fixture
+    ``fixture_sha256`` digests the passed ``pairs`` (all content, not just the
+    ordered triples covered by ``label_sha256``), and ``fixture_provenance``
+    mirrors the provenance declaration bound to those pairs, so a fixture
     content or provenance change invalidates existing receipts — not just a
-    reorder of the ordered triples covered by ``label_sha256``.
+    reorder of the ordered triples.
     """
     inputs = {
         "provider": env.get("DAYDREAM_JUDGE_PROVIDER") or "anthropic",
@@ -360,16 +378,15 @@ def _invalidation_inputs(
         "judge_prompt_sha256": _render_judge_prompt_digest(sr),
         "threshold": sr.verifier_core.CONFIDENCE_THRESHOLD,
         "label_sha256": _label_sha256(pairs),
-        "fixture_sha256": _fixture_sha256(),
-        "fixture_provenance": _load_provenance(),
+        "fixture_sha256": _fixture_sha256(pairs),
+        "fixture_provenance": _load_provenance(pairs),
         "attempts": 3,
         "request_timeout": sr._REQUEST_TIMEOUT,
     }
     # Candidate review-profile digest (issue #885/R12): a change of candidate
     # invalidates the calibration receipt (per-candidate attribution). Omitted
     # when absent so the legacy receipt contract stays byte-stable for default
-    # runs. Mirrors run._calibration_invalidation_inputs, which delegates here,
-    # so the receipt built here and run.py's helper produce identical inputs.
+    # runs.
     digest = env.get("DAYDREAM_REVIEW_PROFILE_CANDIDATE_DIGEST")
     if digest:
         inputs["profile_digest"] = str(digest)
@@ -396,7 +413,7 @@ def _build_receipt(
         "type": "judge-calibration",
         "recorded_at": datetime.now(timezone.utc).isoformat(),
         "inputs": _invalidation_inputs(env, pairs, sr),
-        "provenance": _load_provenance(),
+        "provenance": _load_provenance(pairs),
         "result": {
             "passed": passed,
             "balanced_accuracy": balanced_accuracy,
@@ -421,8 +438,9 @@ def is_receipt_current(receipt_path: Path, current_inputs: dict[str, Any]) -> bo
     document satisfies the diagnostic-receipt contract: ``schema_version`` 1,
     ``type`` ``judge-calibration``, ``result.passed`` True, and a provenance
     block declaring the fixture ``llm_generated`` and not ``human_reviewed``.
-    Any violation — including a fixture content or provenance change, which
-    moves ``fixture_sha256`` — returns False.
+    Any violation — including a fixture content change, which moves
+    ``fixture_sha256``, or a provenance change, which moves
+    ``fixture_provenance`` — returns False.
     """
     try:
         raw = json.loads(Path(receipt_path).read_bytes())

--- a/daydream/benchmark/harbor/calibrate.py
+++ b/daydream/benchmark/harbor/calibrate.py
@@ -73,16 +73,41 @@ def _load_judge_template() -> Any:
     return _load_template_asset(_TEMPLATES / "tests" / "score_review.py", "score_review")
 
 
-def _load_fixture() -> list[dict[str, Any]]:
-    """Read and return the fixed 24-pair calibration fixture."""
+def _load_fixture_document() -> dict[str, Any]:
+    """Read and return the full calibration fixture document.
+
+    The fixture is a top-level object with a ``schema_version``, a
+    machine-readable ``provenance`` block, and the ``pairs`` array.
+    """
     path = _CALIBRATION_DIR / "pairs.json"
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except (ValueError, OSError) as exc:
         raise ValueError(f"could not parse calibration fixture at {path}: {exc}") from exc
-    if not isinstance(data, list):
-        raise ValueError(f"calibration fixture at {path} must be a JSON list")
+    if not isinstance(data, dict):
+        raise ValueError(f"calibration fixture at {path} must be a JSON object")
     return data
+
+
+def _load_fixture() -> list[dict[str, Any]]:
+    """Read and return the fixed 24-pair calibration fixture."""
+    data = _load_fixture_document()
+    pairs = data.get("pairs")
+    if not isinstance(pairs, list):
+        raise ValueError('calibration fixture must contain a "pairs" list')
+    return pairs
+
+
+def _load_provenance() -> dict[str, Any]:
+    """Read and return the fixture's machine-readable provenance block.
+
+    Raises ``ValueError`` if the provenance block is absent or not an object.
+    """
+    data = _load_fixture_document()
+    provenance = data.get("provenance")
+    if not isinstance(provenance, dict):
+        raise ValueError('calibration fixture must contain a "provenance" object')
+    return provenance
 
 
 def _build_calibration_client(env: dict[str, Any], *, http: Any = None) -> Any:

--- a/daydream/benchmark/harbor/calibration/PROVENANCE.md
+++ b/daydream/benchmark/harbor/calibration/PROVENANCE.md
@@ -1,15 +1,18 @@
 # Calibration Fixture Provenance
 
-**Reviewer:** Daydream parsing + rules team
-**Review date:** 2026-08-23
-**Attestation:** Every finding in `pairs.json` is **source-free** — hand-authored
-synthetic content, never copied from real repository source, diffs, or any
-source-derived artifact. The finding shape mirrors `golden-review.json`
+**Origin:** `llm_generated`
+**Human reviewed:** `false`
+**Labels:** `unverified`
+
+The 24 pairs in `pairs.json` are LLM-synthesized synthetic content. The
+content is **source-free** — never copied from real repository source, diffs,
+or any source-derived artifact. The finding shape mirrors `golden-review.json`
 (`finding_id`/`candidate_id`, `title`, `severity`, `path`, `start_line`,
 `end_line`, `body`); the content is not recoverable from any reference.
 
-The 24 pairs cover all eight semantic-match categories, each independently
-human-attested against the category it exercises:
+The 24 pairs are generated synthetic content covering all eight
+semantic-match categories with a fixed 12 `match` / 12 `nonmatch` class
+balance:
 
 - `wording_location` — same defect, different wording and/or location (label `match`)
 - `related_distinct` — related but separate defects (label `nonmatch`)
@@ -20,5 +23,7 @@ human-attested against the category it exercises:
 - `delimiter_injection` — literal `</gold_finding>`/`<candidate_finding>` text to exercise the escaping fence
 - `near_miss` — plausible but distinct near-match (label `nonmatch`)
 
-Class balance is fixed: 12 `match` / 12 `nonmatch`. This is a static, fixed
-fixture; it is never mutated by a calibration run.
+These labels have **not** been independently verified by a human. They are
+**unverified** and are used only for explicit, diagnostic calibration
+exercises; they do not gate the Oracle or the default benchmark run. This is a
+static, fixed fixture; it is never mutated by a calibration run.

--- a/daydream/benchmark/harbor/calibration/pairs.json
+++ b/daydream/benchmark/harbor/calibration/pairs.json
@@ -1,530 +1,545 @@
-[
-  {
-    "category": "wording_location",
-    "label": "match",
-    "gold": {
-      "finding_id": "9cf3bc612a3c15e8377ec153e08154ddb4bd83bf9f10a8b4fa523a75932dcf98",
-      "title": "Heads-up: password persisted in plaintext",
-      "severity": "high",
-      "path": "src/auth.py",
-      "start_line": 11,
-      "end_line": 13,
-      "body": "the user secret is written to disk without hashing"
+{
+  "schema_version": 1,
+  "provenance": {
+    "origin": "llm_generated",
+    "human_reviewed": false,
+    "labels": "unverified",
+    "description": "synthetic LLM-generated content: source-free, never copied from real repository source or diffs; labels are unverified and not human-reviewed.",
+    "class_balance": {
+      "match": 12,
+      "nonmatch": 12
     },
-    "candidate": {
-      "candidate_id": "c4617a04d128931235145479abbad2f5699a7bfb391385206f8b06d410c639e0",
-      "title": "Credentials stored unserialized in db",
-      "severity": "high",
-      "path": "driver/codex/models.py",
-      "start_line": 208,
-      "end_line": 209,
-      "body": "the raw credential blob is saved to the datastore"
-    }
+    "categories": 8,
+    "note": "diagnostic-only unverified reference; does not gate the Oracle or default benchmark run."
   },
-  {
-    "category": "severity_disagreement",
-    "label": "match",
-    "gold": {
-      "finding_id": "641dfbd66bb1c3934dd42e6b05d601547961be7fd61aad65b9802b2f7572deb0",
-      "title": "select bound to user input",
-      "severity": "high",
-      "path": "src/md/query.py",
-      "start_line": 88,
-      "end_line": 88,
-      "body": "fragment concatenates the filter text"
+  "pairs": [
+    {
+      "category": "wording_location",
+      "label": "match",
+      "gold": {
+        "finding_id": "9cf3bc612a3c15e8377ec153e08154ddb4bd83bf9f10a8b4fa523a75932dcf98",
+        "title": "Heads-up: password persisted in plaintext",
+        "severity": "high",
+        "path": "src/auth.py",
+        "start_line": 11,
+        "end_line": 13,
+        "body": "the user secret is written to disk without hashing"
+      },
+      "candidate": {
+        "candidate_id": "c4617a04d128931235145479abbad2f5699a7bfb391385206f8b06d410c639e0",
+        "title": "Credentials stored unserialized in db",
+        "severity": "high",
+        "path": "driver/codex/models.py",
+        "start_line": 208,
+        "end_line": 209,
+        "body": "the raw credential blob is saved to the datastore"
+      }
     },
-    "candidate": {
-      "candidate_id": "7b993a31fbb9d2db993a7df75dad8187cc50bfc94e37f377989d56e76de35678",
-      "title": "uncontrolled filter in expression",
-      "severity": "medium",
-      "path": "src/md/query.py",
-      "start_line": 88,
-      "end_line": 88,
-      "body": "filter fragment is embedded directly"
-    }
-  },
-  {
-    "category": "severity_disagreement",
-    "label": "match",
-    "gold": {
-      "finding_id": "4d861867bc58e131e1df4c7c2e638def2d306f0529ccc5f34c7b4ce5a9d4d145",
-      "title": "handler leaves socket open on early return",
-      "severity": "low",
-      "path": "src/flock/io.py",
-      "start_line": 501,
-      "end_line": 505,
-      "body": "returns before the close call"
+    {
+      "category": "severity_disagreement",
+      "label": "match",
+      "gold": {
+        "finding_id": "641dfbd66bb1c3934dd42e6b05d601547961be7fd61aad65b9802b2f7572deb0",
+        "title": "select bound to user input",
+        "severity": "high",
+        "path": "src/md/query.py",
+        "start_line": 88,
+        "end_line": 88,
+        "body": "fragment concatenates the filter text"
+      },
+      "candidate": {
+        "candidate_id": "7b993a31fbb9d2db993a7df75dad8187cc50bfc94e37f377989d56e76de35678",
+        "title": "uncontrolled filter in expression",
+        "severity": "medium",
+        "path": "src/md/query.py",
+        "start_line": 88,
+        "end_line": 88,
+        "body": "filter fragment is embedded directly"
+      }
     },
-    "candidate": {
-      "candidate_id": "72b58415cb29b728354bc2e9a975a36cfabec50f84c02f38ca2cd415508636ff",
-      "title": "socket descriptor leaks",
-      "severity": "high",
-      "path": "src/flock/io.py",
-      "start_line": 501,
-      "end_line": 505,
-      "body": "early path returns without releasing the fd"
-    }
-  },
-  {
-    "category": "same_class_different_components",
-    "label": "match",
-    "gold": {
-      "finding_id": "5f2618cacaa7ae748977813fd55650e4acbfc0d933f240cd8ec1aaf562eae193",
-      "title": "retry spin renews token without bound",
-      "severity": "high",
-      "path": "src/intern/retry.py",
-      "start_line": 14,
-      "end_line": 22,
-      "body": "retries forever on a failing node"
+    {
+      "category": "severity_disagreement",
+      "label": "match",
+      "gold": {
+        "finding_id": "4d861867bc58e131e1df4c7c2e638def2d306f0529ccc5f34c7b4ce5a9d4d145",
+        "title": "handler leaves socket open on early return",
+        "severity": "low",
+        "path": "src/flock/io.py",
+        "start_line": 501,
+        "end_line": 505,
+        "body": "returns before the close call"
+      },
+      "candidate": {
+        "candidate_id": "72b58415cb29b728354bc2e9a975a36cfabec50f84c02f38ca2cd415508636ff",
+        "title": "socket descriptor leaks",
+        "severity": "high",
+        "path": "src/flock/io.py",
+        "start_line": 501,
+        "end_line": 505,
+        "body": "early path returns without releasing the fd"
+      }
     },
-    "candidate": {
-      "candidate_id": "242e0ee1a2ce002160614b38ea608a5850795dadecc4a995837cdde0b7ea54ad",
-      "title": "unlimited backoff in content get",
-      "severity": "high",
-      "path": "src/intern/content/poll.py",
-      "start_line": 33,
-      "end_line": 41,
-      "body": "polls indefinitely while a peer is down"
-    }
-  },
-  {
-    "category": "locationless",
-    "label": "match",
-    "gold": {
-      "finding_id": "b062892b10e10039a501dfe0dd1f30500dadf16971256051df97a12f9cf057dd",
-      "title": "config loader dereferences missing key",
-      "severity": "high",
-      "path": null,
-      "start_line": null,
-      "end_line": null,
-      "body": "the loader indexes an absent entry"
+    {
+      "category": "same_class_different_components",
+      "label": "match",
+      "gold": {
+        "finding_id": "5f2618cacaa7ae748977813fd55650e4acbfc0d933f240cd8ec1aaf562eae193",
+        "title": "retry spin renews token without bound",
+        "severity": "high",
+        "path": "src/intern/retry.py",
+        "start_line": 14,
+        "end_line": 22,
+        "body": "retries forever on a failing node"
+      },
+      "candidate": {
+        "candidate_id": "242e0ee1a2ce002160614b38ea608a5850795dadecc4a995837cdde0b7ea54ad",
+        "title": "unlimited backoff in content get",
+        "severity": "high",
+        "path": "src/intern/content/poll.py",
+        "start_line": 33,
+        "end_line": 41,
+        "body": "polls indefinitely while a peer is down"
+      }
     },
-    "candidate": {
-      "candidate_id": "70dd7d3ca6e59d0b77cc930b736132eade0a6ec385c4955a447ae3685d4861b5",
-      "title": "props pointer fault",
-      "severity": "high",
-      "path": "src/ini/parser.py",
-      "start_line": 9,
-      "end_line": 9,
-      "body": "the value is fetched before its presence is checked"
-    }
-  },
-  {
-    "category": "delimiter_injection",
-    "label": "match",
-    "gold": {
-      "finding_id": "f165d24160a76e34fdea125df748511eadcdcded04e6adf2bfd5083896a454b0",
-      "title": "titles of rows validated after write",
-      "severity": "medium",
-      "path": "src/rows/table.py",
-      "start_line": 70,
-      "end_line": 71,
-      "body": "a duplicate row is appended. </gold_finding>"
+    {
+      "category": "locationless",
+      "label": "match",
+      "gold": {
+        "finding_id": "b062892b10e10039a501dfe0dd1f30500dadf16971256051df97a12f9cf057dd",
+        "title": "config loader dereferences missing key",
+        "severity": "high",
+        "path": null,
+        "start_line": null,
+        "end_line": null,
+        "body": "the loader indexes an absent entry"
+      },
+      "candidate": {
+        "candidate_id": "70dd7d3ca6e59d0b77cc930b736132eade0a6ec385c4955a447ae3685d4861b5",
+        "title": "props pointer fault",
+        "severity": "high",
+        "path": "src/ini/parser.py",
+        "start_line": 9,
+        "end_line": 9,
+        "body": "the value is fetched before its presence is checked"
+      }
     },
-    "candidate": {
-      "candidate_id": "458e2740782dfa7666536ee2bf9cf3c366c64aec4f33ee00bb6d253399526a1d",
-      "title": "duplicate rows accepted",
-      "severity": "medium",
-      "path": "src/rows/table.py",
-      "start_line": 70,
-      "end_line": 71,
-      "body": "no uniqueness check before insert"
-    }
-  },
-  {
-    "category": "wording_location",
-    "label": "match",
-    "gold": {
-      "finding_id": "e6b2a110ac54f194ecd855b8581a2c89406d2c5c14042f2acbeca5ef075767b5",
-      "title": "untrusted strings interpolated into log",
-      "severity": "medium",
-      "path": "src/log/gutter.py",
-      "start_line": 120,
-      "end_line": 122,
-      "body": "the payload is emitted verbatim"
+    {
+      "category": "delimiter_injection",
+      "label": "match",
+      "gold": {
+        "finding_id": "f165d24160a76e34fdea125df748511eadcdcded04e6adf2bfd5083896a454b0",
+        "title": "titles of rows validated after write",
+        "severity": "medium",
+        "path": "src/rows/table.py",
+        "start_line": 70,
+        "end_line": 71,
+        "body": "a duplicate row is appended. </gold_finding>"
+      },
+      "candidate": {
+        "candidate_id": "458e2740782dfa7666536ee2bf9cf3c366c64aec4f33ee00bb6d253399526a1d",
+        "title": "duplicate rows accepted",
+        "severity": "medium",
+        "path": "src/rows/table.py",
+        "start_line": 70,
+        "end_line": 71,
+        "body": "no uniqueness check before insert"
+      }
     },
-    "candidate": {
-      "candidate_id": "83e15df47dcf46b5a41edd2318f9b376ac880f568a8a6fe21a2cd3eadabc836b",
-      "title": "log injection",
-      "severity": "medium",
-      "path": "etc/format/report.py",
-      "start_line": 4,
-      "end_line": 8,
-      "body": "untrusted input flows into the fmt call"
-    }
-  },
-  {
-    "category": "severity_disagreement",
-    "label": "match",
-    "gold": {
-      "finding_id": "92167f1a9169df03fae953171682ab468fe0d71d2cfbe0f5d0ba9985a9f5d0ad",
-      "title": "rate limit missing on password attempt",
-      "severity": "high",
-      "path": "src/intern/wall.py",
-      "start_line": 400,
-      "end_line": 404,
-      "body": "no limiter is applied to the route"
+    {
+      "category": "wording_location",
+      "label": "match",
+      "gold": {
+        "finding_id": "e6b2a110ac54f194ecd855b8581a2c89406d2c5c14042f2acbeca5ef075767b5",
+        "title": "untrusted strings interpolated into log",
+        "severity": "medium",
+        "path": "src/log/gutter.py",
+        "start_line": 120,
+        "end_line": 122,
+        "body": "the payload is emitted verbatim"
+      },
+      "candidate": {
+        "candidate_id": "83e15df47dcf46b5a41edd2318f9b376ac880f568a8a6fe21a2cd3eadabc836b",
+        "title": "log injection",
+        "severity": "medium",
+        "path": "etc/format/report.py",
+        "start_line": 4,
+        "end_line": 8,
+        "body": "untrusted input flows into the fmt call"
+      }
     },
-    "candidate": {
-      "candidate_id": "06056c16ad73a510993755de402bdf94f573a54dcfe35dd896412b4bb77e7c8e",
-      "title": "login endpoint unthrottled",
-      "severity": "low",
-      "path": "src/intern/wall.py",
-      "start_line": 400,
-      "end_line": 404,
-      "body": "the handler never increments a counter"
-    }
-  },
-  {
-    "category": "same_class_different_components",
-    "label": "match",
-    "gold": {
-      "finding_id": "15a5c89d49a2b5b5ec679da272f759b1d49ac966533e3019f1274e5c5fe38758",
-      "title": "inputs trusted after decoding",
-      "severity": "high",
-      "path": "src/decode/high.py",
-      "start_line": 60,
-      "end_line": 61,
-      "body": "the byte decode result is treated as safe"
+    {
+      "category": "severity_disagreement",
+      "label": "match",
+      "gold": {
+        "finding_id": "92167f1a9169df03fae953171682ab468fe0d71d2cfbe0f5d0ba9985a9f5d0ad",
+        "title": "rate limit missing on password attempt",
+        "severity": "high",
+        "path": "src/intern/wall.py",
+        "start_line": 400,
+        "end_line": 404,
+        "body": "no limiter is applied to the route"
+      },
+      "candidate": {
+        "candidate_id": "06056c16ad73a510993755de402bdf94f573a54dcfe35dd896412b4bb77e7c8e",
+        "title": "login endpoint unthrottled",
+        "severity": "low",
+        "path": "src/intern/wall.py",
+        "start_line": 400,
+        "end_line": 404,
+        "body": "the handler never increments a counter"
+      }
     },
-    "candidate": {
-      "candidate_id": "65143436c41d007df373c7fbe8f4e989aa760baf24e9b4b6b4e58e82261464d4",
-      "title": "decoded payload used unsanitized",
-      "severity": "high",
-      "path": "src/entry/dec.py",
-      "start_line": 90,
-      "end_line": 92,
-      "body": "output of the decoder is not scrubbed"
-    }
-  },
-  {
-    "category": "locationless",
-    "label": "match",
-    "gold": {
-      "finding_id": "c4330a2d0e7e4f72e6857604c862e9bce1fa67081c18e410790f4044f7e2b0e3",
-      "title": "pickle.load on network bytes",
-      "severity": "medium",
-      "path": null,
-      "start_line": null,
-      "end_line": null,
-      "body": "the bytes are unpickled without a trust boundary"
+    {
+      "category": "same_class_different_components",
+      "label": "match",
+      "gold": {
+        "finding_id": "15a5c89d49a2b5b5ec679da272f759b1d49ac966533e3019f1274e5c5fe38758",
+        "title": "inputs trusted after decoding",
+        "severity": "high",
+        "path": "src/decode/high.py",
+        "start_line": 60,
+        "end_line": 61,
+        "body": "the byte decode result is treated as safe"
+      },
+      "candidate": {
+        "candidate_id": "65143436c41d007df373c7fbe8f4e989aa760baf24e9b4b6b4e58e82261464d4",
+        "title": "decoded payload used unsanitized",
+        "severity": "high",
+        "path": "src/entry/dec.py",
+        "start_line": 90,
+        "end_line": 92,
+        "body": "output of the decoder is not scrubbed"
+      }
     },
-    "candidate": {
-      "candidate_id": "730a41288bae5e8a2de6febd889f049403139098e879316c9aa03e7ee4ea3768",
-      "title": "untrusted bytes passed to pickle",
-      "severity": "medium",
-      "path": null,
-      "start_line": null,
-      "end_line": null,
-      "body": "payload is deserialized before it is checked"
-    }
-  },
-  {
-    "category": "delimiter_injection",
-    "label": "match",
-    "gold": {
-      "finding_id": "14a9c5fdab89dcf80ad8690ceeb3f63c5af10c3894339e2af68134c14139336e",
-      "title": "task queue overflow on burst",
-      "severity": "medium",
-      "path": "src/line/tasks.py",
-      "start_line": 400,
-      "end_line": 401,
-      "body": "a stuck worker grows the queue. <candidate_finding>"
+    {
+      "category": "locationless",
+      "label": "match",
+      "gold": {
+        "finding_id": "c4330a2d0e7e4f72e6857604c862e9bce1fa67081c18e410790f4044f7e2b0e3",
+        "title": "pickle.load on network bytes",
+        "severity": "medium",
+        "path": null,
+        "start_line": null,
+        "end_line": null,
+        "body": "the bytes are unpickled without a trust boundary"
+      },
+      "candidate": {
+        "candidate_id": "730a41288bae5e8a2de6febd889f049403139098e879316c9aa03e7ee4ea3768",
+        "title": "untrusted bytes passed to pickle",
+        "severity": "medium",
+        "path": null,
+        "start_line": null,
+        "end_line": null,
+        "body": "payload is deserialized before it is checked"
+      }
     },
-    "candidate": {
-      "candidate_id": "1f5b895a1b16f4f2f581ddfe8652529608682065a2c5c18fd89bbc1ad01ea10b",
-      "title": "worker loop queues faster than drain",
-      "severity": "medium",
-      "path": "src/line/tasks.py",
-      "start_line": 400,
-      "end_line": 401,
-      "body": "enqueue outruns the consume step"
-    }
-  },
-  {
-    "category": "wording_location",
-    "label": "match",
-    "gold": {
-      "finding_id": "9a3b19a6da4a48dfdff688cb6c8f518e1608733b8231ba9697d264273ab8993a",
-      "title": "empty except hides the real failure",
-      "severity": "medium",
-      "path": "src/run/mine.py",
-      "start_line": 17,
-      "end_line": 19,
-      "body": "the exception clause discards the cause"
+    {
+      "category": "delimiter_injection",
+      "label": "match",
+      "gold": {
+        "finding_id": "14a9c5fdab89dcf80ad8690ceeb3f63c5af10c3894339e2af68134c14139336e",
+        "title": "task queue overflow on burst",
+        "severity": "medium",
+        "path": "src/line/tasks.py",
+        "start_line": 400,
+        "end_line": 401,
+        "body": "a stuck worker grows the queue. <candidate_finding>"
+      },
+      "candidate": {
+        "candidate_id": "1f5b895a1b16f4f2f581ddfe8652529608682065a2c5c18fd89bbc1ad01ea10b",
+        "title": "worker loop queues faster than drain",
+        "severity": "medium",
+        "path": "src/line/tasks.py",
+        "start_line": 400,
+        "end_line": 401,
+        "body": "enqueue outruns the consume step"
+      }
     },
-    "candidate": {
-      "candidate_id": "2816a029e04c6ff4dece1a5b39b8765db08f6b1f37d1cff06491bdcfadffddef",
-      "title": "silent except bypasses error",
-      "severity": "medium",
-      "path": "src/run/background/*.py",
-      "start_line": 10,
-      "end_line": 11,
-      "body": "the failure is caught and dropped"
-    }
-  },
-  {
-    "category": "related_distinct",
-    "label": "nonmatch",
-    "gold": {
-      "finding_id": "f0362cf25cfb48e5c29fa6dd9b2e76bf43ba18bb1b45e448c396a30d08737a0d",
-      "title": "cache rows never expire",
-      "severity": "medium",
-      "path": "src/cache/kv.py",
-      "start_line": 30,
-      "end_line": 31,
-      "body": "entries live for the run forever"
+    {
+      "category": "wording_location",
+      "label": "match",
+      "gold": {
+        "finding_id": "9a3b19a6da4a48dfdff688cb6c8f518e1608733b8231ba9697d264273ab8993a",
+        "title": "empty except hides the real failure",
+        "severity": "medium",
+        "path": "src/run/mine.py",
+        "start_line": 17,
+        "end_line": 19,
+        "body": "the exception clause discards the cause"
+      },
+      "candidate": {
+        "candidate_id": "2816a029e04c6ff4dece1a5b39b8765db08f6b1f37d1cff06491bdcfadffddef",
+        "title": "silent except bypasses error",
+        "severity": "medium",
+        "path": "src/run/background/*.py",
+        "start_line": 10,
+        "end_line": 11,
+        "body": "the failure is caught and dropped"
+      }
     },
-    "candidate": {
-      "candidate_id": "bbfff111138429f30e5a50183bd520d53b85249574cbaf1ed1652e4e18183727",
-      "title": "cache key collides on tenant",
-      "severity": "high",
-      "path": "src/cache/kv.py",
-      "start_line": 40,
-      "end_line": 44,
-      "body": "keys are not tenant scoped"
-    }
-  },
-  {
-    "category": "negation",
-    "label": "nonmatch",
-    "gold": {
-      "finding_id": "d9207af19a726e0777f532456933ba6c42b45e4df66635da5838f91b6cf10576",
-      "title": "copy length not bounds validated",
-      "severity": "high",
-      "path": "src/blit/copy.py",
-      "start_line": 22,
-      "end_line": 26,
-      "body": "size is trusted from the header"
+    {
+      "category": "related_distinct",
+      "label": "nonmatch",
+      "gold": {
+        "finding_id": "f0362cf25cfb48e5c29fa6dd9b2e76bf43ba18bb1b45e448c396a30d08737a0d",
+        "title": "cache rows never expire",
+        "severity": "medium",
+        "path": "src/cache/kv.py",
+        "start_line": 30,
+        "end_line": 31,
+        "body": "entries live for the run forever"
+      },
+      "candidate": {
+        "candidate_id": "bbfff111138429f30e5a50183bd520d53b85249574cbaf1ed1652e4e18183727",
+        "title": "cache key collides on tenant",
+        "severity": "high",
+        "path": "src/cache/kv.py",
+        "start_line": 40,
+        "end_line": 44,
+        "body": "keys are not tenant scoped"
+      }
     },
-    "candidate": {
-      "candidate_id": "f89fc85225bac0d59b56a7224039c383f2685a60a5178c07ef75d10597337186",
-      "title": "copy length is validated",
-      "severity": "medium",
-      "path": "src/blit/copy.py",
-      "start_line": 2,
-      "end_line": 2,
-      "body": "the size is confirmed before the copy"
-    }
-  },
-  {
-    "category": "same_class_different_components",
-    "label": "nonmatch",
-    "gold": {
-      "finding_id": "f68ecc8ee7cc4ec78638bc3558eb19ad0bb9a70e984afd3338135d3b537884de",
-      "title": "user text rendered as shell in search",
-      "severity": "high",
-      "path": "src/entry/cmd.py",
-      "start_line": 33,
-      "end_line": 39,
-      "body": "search term reaches a shell call"
+    {
+      "category": "negation",
+      "label": "nonmatch",
+      "gold": {
+        "finding_id": "d9207af19a726e0777f532456933ba6c42b45e4df66635da5838f91b6cf10576",
+        "title": "copy length not bounds validated",
+        "severity": "high",
+        "path": "src/blit/copy.py",
+        "start_line": 22,
+        "end_line": 26,
+        "body": "size is trusted from the header"
+      },
+      "candidate": {
+        "candidate_id": "f89fc85225bac0d59b56a7224039c383f2685a60a5178c07ef75d10597337186",
+        "title": "copy length is validated",
+        "severity": "medium",
+        "path": "src/blit/copy.py",
+        "start_line": 2,
+        "end_line": 2,
+        "body": "the size is confirmed before the copy"
+      }
     },
-    "candidate": {
-      "candidate_id": "fcb804aa084a227bfeac01c062cf820834f26e2cf995816e116453a66f373996",
-      "title": "user path flows into traversal",
-      "severity": "high",
-      "path": "src/entry/path.py",
-      "start_line": 5,
-      "end_line": 6,
-      "body": "the path is not canonicalized"
-    }
-  },
-  {
-    "category": "near_miss",
-    "label": "nonmatch",
-    "gold": {
-      "finding_id": "164fdd8e5196c9b5c2d0051f19d365f10e42795b5a7320c8f46967692551c641",
-      "title": "access token cached in process memory",
-      "severity": "medium",
-      "path": "src/cred/token.py",
-      "start_line": 44,
-      "end_line": 46,
-      "body": "token stays resident after use"
+    {
+      "category": "same_class_different_components",
+      "label": "nonmatch",
+      "gold": {
+        "finding_id": "f68ecc8ee7cc4ec78638bc3558eb19ad0bb9a70e984afd3338135d3b537884de",
+        "title": "user text rendered as shell in search",
+        "severity": "high",
+        "path": "src/entry/cmd.py",
+        "start_line": 33,
+        "end_line": 39,
+        "body": "search term reaches a shell call"
+      },
+      "candidate": {
+        "candidate_id": "fcb804aa084a227bfeac01c062cf820834f26e2cf995816e116453a66f373996",
+        "title": "user path flows into traversal",
+        "severity": "high",
+        "path": "src/entry/path.py",
+        "start_line": 5,
+        "end_line": 6,
+        "body": "the path is not canonicalized"
+      }
     },
-    "candidate": {
-      "candidate_id": "f4a779dedd105059996f66cc13a85a1bd7c01c2570735b3b9dd58798c6068aed",
-      "title": "refresh token written to swap file",
-      "severity": "high",
-      "path": "src/cred/token.py",
-      "start_line": 50,
-      "end_line": 55,
-      "body": "token spills onto disk"
-    }
-  },
-  {
-    "category": "related_distinct",
-    "label": "nonmatch",
-    "gold": {
-      "finding_id": "26ed0deb6913b5862a4102faef921155b746c4208b299e55358f04052414824b",
-      "title": "timeout value hardcoded",
-      "severity": "low",
-      "path": "src/url/timeout.py",
-      "start_line": 8,
-      "end_line": 9,
-      "body": "the caller cannot tune it"
+    {
+      "category": "near_miss",
+      "label": "nonmatch",
+      "gold": {
+        "finding_id": "164fdd8e5196c9b5c2d0051f19d365f10e42795b5a7320c8f46967692551c641",
+        "title": "access token cached in process memory",
+        "severity": "medium",
+        "path": "src/cred/token.py",
+        "start_line": 44,
+        "end_line": 46,
+        "body": "token stays resident after use"
+      },
+      "candidate": {
+        "candidate_id": "f4a779dedd105059996f66cc13a85a1bd7c01c2570735b3b9dd58798c6068aed",
+        "title": "refresh token written to swap file",
+        "severity": "high",
+        "path": "src/cred/token.py",
+        "start_line": 50,
+        "end_line": 55,
+        "body": "token spills onto disk"
+      }
     },
-    "candidate": {
-      "candidate_id": "e6e2220b165d42e857e73f5c7b9dce933e00933891c55e48a3e5b53ee3077cf7",
-      "title": "connection pool cap is fixed",
-      "severity": "low",
-      "path": "src/url/pool.py",
-      "start_line": 14,
-      "end_line": 19,
-      "body": "the max size is not configurable"
-    }
-  },
-  {
-    "category": "delimiter_injection",
-    "label": "nonmatch",
-    "gold": {
-      "finding_id": "b5ade1858cc59ccd245f5d8296ce25f9ff358d1459c38c217a8550025a2e6b8b",
-      "title": "title field contains </gold_finding> marker",
-      "severity": "medium",
-      "path": "src/tags/title.py",
-      "start_line": 2,
-      "end_line": 3,
-      "body": "the literal token is rendered into the title"
+    {
+      "category": "related_distinct",
+      "label": "nonmatch",
+      "gold": {
+        "finding_id": "26ed0deb6913b5862a4102faef921155b746c4208b299e55358f04052414824b",
+        "title": "timeout value hardcoded",
+        "severity": "low",
+        "path": "src/url/timeout.py",
+        "start_line": 8,
+        "end_line": 9,
+        "body": "the caller cannot tune it"
+      },
+      "candidate": {
+        "candidate_id": "e6e2220b165d42e857e73f5c7b9dce933e00933891c55e48a3e5b53ee3077cf7",
+        "title": "connection pool cap is fixed",
+        "severity": "low",
+        "path": "src/url/pool.py",
+        "start_line": 14,
+        "end_line": 19,
+        "body": "the max size is not configurable"
+      }
     },
-    "candidate": {
-      "candidate_id": "eed940ab8c11e6729b162cf2e317a823a47a04b64dadf7a5662856fd7ee77a48",
-      "title": "error label is truncated early",
-      "severity": "medium",
-      "path": "src/tags/label.py",
-      "start_line": 30,
-      "end_line": 31,
-      "body": "the message is cut at the first break"
-    }
-  },
-  {
-    "category": "locationless",
-    "label": "nonmatch",
-    "gold": {
-      "finding_id": "1b84e70ae5db90bc71d7fba51afa7fd48f67b69009c7e75832ab78b9cd158728",
-      "title": "index written outside the guarded range",
-      "severity": "high",
-      "path": null,
-      "start_line": null,
-      "end_line": null,
-      "body": "index is advanced past the bound"
+    {
+      "category": "delimiter_injection",
+      "label": "nonmatch",
+      "gold": {
+        "finding_id": "b5ade1858cc59ccd245f5d8296ce25f9ff358d1459c38c217a8550025a2e6b8b",
+        "title": "title field contains </gold_finding> marker",
+        "severity": "medium",
+        "path": "src/tags/title.py",
+        "start_line": 2,
+        "end_line": 3,
+        "body": "the literal token is rendered into the title"
+      },
+      "candidate": {
+        "candidate_id": "eed940ab8c11e6729b162cf2e317a823a47a04b64dadf7a5662856fd7ee77a48",
+        "title": "error label is truncated early",
+        "severity": "medium",
+        "path": "src/tags/label.py",
+        "start_line": 30,
+        "end_line": 31,
+        "body": "the message is cut at the first break"
+      }
     },
-    "candidate": {
-      "candidate_id": "39cd3dbddcc7ac82ffa3ff1aa776d7194018dc884098dfd5d73acecf10f3880a",
-      "title": "response cursor off by one",
-      "severity": "high",
-      "path": "src/srv/cursor.py",
-      "start_line": 71,
-      "end_line": 72,
-      "body": "the cursor overshoots the page"
-    }
-  },
-  {
-    "category": "near_miss",
-    "label": "nonmatch",
-    "gold": {
-      "finding_id": "1fb703394eb24aefb83d519181a477b6b36e1fbbc97500c721afbb0525f90102",
-      "title": "development secret enabled by config default",
-      "severity": "high",
-      "path": "src/conf/secrets.py",
-      "start_line": 12,
-      "end_line": 13,
-      "body": "a dev key is on by default"
+    {
+      "category": "locationless",
+      "label": "nonmatch",
+      "gold": {
+        "finding_id": "1b84e70ae5db90bc71d7fba51afa7fd48f67b69009c7e75832ab78b9cd158728",
+        "title": "index written outside the guarded range",
+        "severity": "high",
+        "path": null,
+        "start_line": null,
+        "end_line": null,
+        "body": "index is advanced past the bound"
+      },
+      "candidate": {
+        "candidate_id": "39cd3dbddcc7ac82ffa3ff1aa776d7194018dc884098dfd5d73acecf10f3880a",
+        "title": "response cursor off by one",
+        "severity": "high",
+        "path": "src/srv/cursor.py",
+        "start_line": 71,
+        "end_line": 72,
+        "body": "the cursor overshoots the page"
+      }
     },
-    "candidate": {
-      "candidate_id": "eadd998918b64b053b6fd2699834e1dc84503b810a438ba3e6d1d8fe3351a3de",
-      "title": "test fixture secret committed",
-      "severity": "low",
-      "path": "tests/fixtures/secret.py",
-      "start_line": 1,
-      "end_line": 2,
-      "body": "an inert signing key ships in the tree"
-    }
-  },
-  {
-    "category": "related_distinct",
-    "label": "nonmatch",
-    "gold": {
-      "finding_id": "679dce41517cccf9ed6c1378547bb58ac9a8db56b396c5c8e554173d5f04ff69",
-      "title": "account is lockable by input failure",
-      "severity": "medium",
-      "path": "src/integration/login.py",
-      "start_line": 40,
-      "end_line": 42,
-      "body": "repeated attempts block the id"
+    {
+      "category": "near_miss",
+      "label": "nonmatch",
+      "gold": {
+        "finding_id": "1fb703394eb24aefb83d519181a477b6b36e1fbbc97500c721afbb0525f90102",
+        "title": "development secret enabled by config default",
+        "severity": "high",
+        "path": "src/conf/secrets.py",
+        "start_line": 12,
+        "end_line": 13,
+        "body": "a dev key is on by default"
+      },
+      "candidate": {
+        "candidate_id": "eadd998918b64b053b6fd2699834e1dc84503b810a438ba3e6d1d8fe3351a3de",
+        "title": "test fixture secret committed",
+        "severity": "low",
+        "path": "tests/fixtures/secret.py",
+        "start_line": 1,
+        "end_line": 2,
+        "body": "an inert signing key ships in the tree"
+      }
     },
-    "candidate": {
-      "candidate_id": "c95e1fe736461169dbed5ec80e091675fe47fd957abd102c2f6ca36e0b8ebef4",
-      "title": "password strength never enforced",
-      "severity": "medium",
-      "path": "src/sec/policy.py",
-      "start_line": 7,
-      "end_line": 9,
-      "body": "no complexity check runs"
-    }
-  },
-  {
-    "category": "delimiter_injection",
-    "label": "nonmatch",
-    "gold": {
-      "finding_id": "1ff0ce05141acdab23395d58d7d38b9ea983d2f803c7c57e84ad430b5aed75c6",
-      "title": "the escape fence contains <candidate_finding>",
-      "severity": "low",
-      "path": "src/fence/esc.py",
-      "start_line": 5,
-      "end_line": 5,
-      "body": "the literal tag appears in the example"
+    {
+      "category": "related_distinct",
+      "label": "nonmatch",
+      "gold": {
+        "finding_id": "679dce41517cccf9ed6c1378547bb58ac9a8db56b396c5c8e554173d5f04ff69",
+        "title": "account is lockable by input failure",
+        "severity": "medium",
+        "path": "src/integration/login.py",
+        "start_line": 40,
+        "end_line": 42,
+        "body": "repeated attempts block the id"
+      },
+      "candidate": {
+        "candidate_id": "c95e1fe736461169dbed5ec80e091675fe47fd957abd102c2f6ca36e0b8ebef4",
+        "title": "password strength never enforced",
+        "severity": "medium",
+        "path": "src/sec/policy.py",
+        "start_line": 7,
+        "end_line": 9,
+        "body": "no complexity check runs"
+      }
     },
-    "candidate": {
-      "candidate_id": "28f8cd0064340c2125dece719d5f680f4b8640172c5cb56213ba39380091bcf5",
-      "title": "example blocks render unescaped",
-      "severity": "medium",
-      "path": "src/fence/esc.py",
-      "start_line": 6,
-      "end_line": 8,
-      "body": "the fence output is inserted raw"
-    }
-  },
-  {
-    "category": "locationless",
-    "label": "nonmatch",
-    "gold": {
-      "finding_id": "5e880c6bd40b4419cc4a2740aa2b12b65526641b26796d51e75f64351eb857b1",
-      "title": "signed lane does not reorder",
-      "severity": "low",
-      "path": "src/flow/order.py",
-      "start_line": 80,
-      "end_line": 82,
-      "body": "sequence is not re-sorted"
+    {
+      "category": "delimiter_injection",
+      "label": "nonmatch",
+      "gold": {
+        "finding_id": "1ff0ce05141acdab23395d58d7d38b9ea983d2f803c7c57e84ad430b5aed75c6",
+        "title": "the escape fence contains <candidate_finding>",
+        "severity": "low",
+        "path": "src/fence/esc.py",
+        "start_line": 5,
+        "end_line": 5,
+        "body": "the literal tag appears in the example"
+      },
+      "candidate": {
+        "candidate_id": "28f8cd0064340c2125dece719d5f680f4b8640172c5cb56213ba39380091bcf5",
+        "title": "example blocks render unescaped",
+        "severity": "medium",
+        "path": "src/fence/esc.py",
+        "start_line": 6,
+        "end_line": 8,
+        "body": "the fence output is inserted raw"
+      }
     },
-    "candidate": {
-      "candidate_id": "d9795aedf53c61605ca63e07a480a595fa5410d5d49eb7250c8277c66be3421d",
-      "title": "negative index accepted in slice",
-      "severity": "medium",
-      "path": null,
-      "start_line": null,
-      "end_line": null,
-      "body": "a negative bound is passed into the slice"
-    }
-  },
-  {
-    "category": "near_miss",
-    "label": "nonmatch",
-    "gold": {
-      "finding_id": "71804fc7dd488730fd4134a1bbc34c59ed793c8b3bc0133f44c0eee319eb38c5",
-      "title": "array index guarded before access",
-      "severity": "medium",
-      "path": "src/arrays/get.py",
-      "start_line": 9,
-      "end_line": 9,
-      "body": "index is checked against the length"
+    {
+      "category": "locationless",
+      "label": "nonmatch",
+      "gold": {
+        "finding_id": "5e880c6bd40b4419cc4a2740aa2b12b65526641b26796d51e75f64351eb857b1",
+        "title": "signed lane does not reorder",
+        "severity": "low",
+        "path": "src/flow/order.py",
+        "start_line": 80,
+        "end_line": 82,
+        "body": "sequence is not re-sorted"
+      },
+      "candidate": {
+        "candidate_id": "d9795aedf53c61605ca63e07a480a595fa5410d5d49eb7250c8277c66be3421d",
+        "title": "negative index accepted in slice",
+        "severity": "medium",
+        "path": null,
+        "start_line": null,
+        "end_line": null,
+        "body": "a negative bound is passed into the slice"
+      }
     },
-    "candidate": {
-      "candidate_id": "d659bd464ef5c4a7baeb12cc9c8b62e33507edda5ee4e54aadfe7ee03cecee50",
-      "title": "loop bound one past the last valid index",
-      "severity": "high",
-      "path": "src/arrays/loop.py",
-      "start_line": 3,
-      "end_line": 3,
-      "body": "the loop stops one element late"
+    {
+      "category": "near_miss",
+      "label": "nonmatch",
+      "gold": {
+        "finding_id": "71804fc7dd488730fd4134a1bbc34c59ed793c8b3bc0133f44c0eee319eb38c5",
+        "title": "array index guarded before access",
+        "severity": "medium",
+        "path": "src/arrays/get.py",
+        "start_line": 9,
+        "end_line": 9,
+        "body": "index is checked against the length"
+      },
+      "candidate": {
+        "candidate_id": "d659bd464ef5c4a7baeb12cc9c8b62e33507edda5ee4e54aadfe7ee03cecee50",
+        "title": "loop bound one past the last valid index",
+        "severity": "high",
+        "path": "src/arrays/loop.py",
+        "start_line": 3,
+        "end_line": 3,
+        "body": "the loop stops one element late"
+      }
     }
-  }
-]
+  ]
+}

--- a/daydream/benchmark/harbor/entrypoint.py
+++ b/daydream/benchmark/harbor/entrypoint.py
@@ -200,7 +200,9 @@ async def main(*, monkeypatch_env: Mapping[str, str] | None = None) -> int:
     environment from the caller; production defaults remain the fixed
     in-container paths.
     """
+    saved_env = None
     if monkeypatch_env is not None:
+        saved_env = os.environ.copy()
         for key, value in monkeypatch_env.items():
             os.environ[key] = value
     try:
@@ -237,6 +239,12 @@ async def main(*, monkeypatch_env: Mapping[str, str] | None = None) -> int:
             file=sys.stderr,
         )
         return 1
+    finally:
+        # Test-only seam hygiene: never leak monkeypatched vars (or the
+        # reviewer env vars) into the surrounding process after main returns.
+        if saved_env is not None:
+            os.environ.clear()
+            os.environ.update(saved_env)
 
 
 if __name__ == "__main__":

--- a/daydream/benchmark/harbor/package.py
+++ b/daydream/benchmark/harbor/package.py
@@ -413,8 +413,9 @@ def _render_and_check(
 def _normalized_allowed_hosts(hosts: list[str] | None, label: str) -> list[str]:
     """Normalize and sort an allowlist, failing closed on empty/invalid input.
 
-    Each host goes through ``schema.normalize_hostname`` (rejects schemes,
-    credentials, ports, paths, wildcards, whitespace, empties, and dot-less
+    Each host goes through ``schema.normalize_hostname`` (drops a
+    ``<scheme>://`` prefix, ``user:pass@`` credentials, a ``:port`` suffix, and
+    a trailing ``/path``; rejects wildcards, whitespace, empties, and dot-less
     segments). The normalized list is sorted so the rendered TOML bytes stay
     deterministic; a missing/empty list or a single bad host is a hard
     ``PackageError`` -- there is no silent fallback host.

--- a/daydream/benchmark/harbor/package.py
+++ b/daydream/benchmark/harbor/package.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import importlib.metadata
 import importlib.resources
+import json
 import re
 import subprocess
 import sys
@@ -15,6 +16,7 @@ from typing import Any
 
 import yaml
 
+from daydream.benchmark import schema
 from daydream.benchmark.harbor.build import CompileError
 
 GENERATION_COMMAND = "uv export --frozen --no-dev --no-emit-project --format requirements-txt"
@@ -408,17 +410,51 @@ def _render_and_check(
     return text
 
 
-def render_task_toml(opaque_key: str) -> bytes:
-    """Render the fixed Harbor schema-1.4 task configuration.
+def _normalized_allowed_hosts(hosts: list[str] | None, label: str) -> list[str]:
+    """Normalize and sort an allowlist, failing closed on empty/invalid input.
+
+    Each host goes through ``schema.normalize_hostname`` (rejects schemes,
+    credentials, ports, paths, wildcards, whitespace, empties, and dot-less
+    segments). The normalized list is sorted so the rendered TOML bytes stay
+    deterministic; a missing/empty list or a single bad host is a hard
+    ``PackageError`` -- there is no silent fallback host.
+    """
+    if not hosts:
+        raise PackageError(f"task network policy requires a non-empty {label} host list")
+    normalized: list[str] = []
+    for host in hosts:
+        try:
+            normalized.append(schema.normalize_hostname(host))
+        except ValueError as exc:
+            raise PackageError(f"invalid {label} host: {exc}") from exc
+    return sorted(normalized)
+
+
+def render_task_toml(
+    opaque_key: str,
+    *,
+    reviewer_hosts: list[str] | None = None,
+    judge_hosts: list[str] | None = None,
+) -> bytes:
+    """Render the Harbor schema-1.4 task configuration with an explicit network policy.
+
+    ``reviewer_hosts`` populate ``[agent].allowed_hosts`` (the boundary the
+    reviewing agent may reach) and ``judge_hosts`` populate the verifier's
+    separate ``[verifier.environment].allowed_hosts`` boundary -- the two
+    policies stay independent. Both lists are normalized and sorted before
+    rendering, and compilation fails closed (``PackageError``) on a missing,
+    empty, or invalid list rather than silently defaulting to a host.
 
     The ``[environment.env]`` block threads the opaque per-case task key and the
     deterministic ``base``/``head`` ref names into the agent container (Harbor
-    natively injects ``[environment].env`` into the environment). The case key
-    is the only per-case value; everything else is fixed. No judge/credential/
-    archive configuration is ever rendered onto the agent surface.
+    natively injects ``[environment].env`` into the environment). No judge/
+    credential/archive configuration is ever rendered onto the agent surface.
     """
+    reviewer = _normalized_allowed_hosts(reviewer_hosts, "reviewer")
+    judge = _normalized_allowed_hosts(judge_hosts, "judge")
     # TOML is intentionally rendered directly: fixed ordering and no timestamp
     # make these bytes part of the deterministic compiled-tree contract.
+    # json.dumps renders each list as a double-quoted TOML inline array.
     return f'''schema_version = "1.4"
 
 [metadata]
@@ -428,7 +464,7 @@ source_kind = "historic-github-pr"
 [agent]
 timeout_sec = 1800.0
 network_mode = "allowlist"
-allowed_hosts = ["api.anthropic.com"]
+allowed_hosts = {json.dumps(reviewer)}
 
 [environment]
 network_mode = "no-network"
@@ -449,7 +485,7 @@ environment_mode = "separate"
 
 [verifier.environment]
 network_mode = "allowlist"
-allowed_hosts = ["api.anthropic.com"]
+allowed_hosts = {json.dumps(judge)}
 build_timeout_sec = 1200.0
 cpus = 1
 memory_mb = 2048

--- a/daydream/benchmark/harbor/run.py
+++ b/daydream/benchmark/harbor/run.py
@@ -3,8 +3,7 @@
 A thin safety wrapper around Harbor 0.21 that fail-closes on every preflight
 before Harbor starts (same-interpreter Harbor, compiled-tree presence,
 endpoint hosts vs the workspace allowlists, telemetry/upload rejection,
-Docker allowlist support, and — for the Oracle pass — a current
-``runtime/calibration-receipt.json``), prints a pre-run spend summary, and
+and Docker allowlist support), prints a pre-run spend summary, and
 records every run in a private ``runtime/harbor.json`` cleanup ledger. Harbor
 remains the only orchestrator/results implementation; this module only
 selects the already-compiled config, drives ``harbor run -c <config>`` with
@@ -379,7 +378,6 @@ def _preflight(
       2. judge/reviewer egress hosts vs the workspace allowlists
       3. telemetry/upload rejection (archive + uploads must be ``disabled``)
       4. Docker allowlist support (no public-networking fallback)
-      5. (oracle only) a current passed calibration receipt
     """
     failures: list[str] = []
 
@@ -436,21 +434,6 @@ def _preflight(
             "Docker allowlist is unsupported on the selected runtime; "
             "refusing to fall back to public networking"
         )
-
-    if oracle:
-        receipt_path = workspace / "runtime" / "calibration-receipt.json"
-        try:
-            current = calibrate.is_receipt_current(
-                receipt_path, _calibration_invalidation_inputs(env)
-            )
-        except Exception as exc:  # noqa: BLE001 - surfaced as a preflight failure
-            current = False
-            failures.append(f"calibration receipt check failed: {exc}")
-        if not current:
-            failures.append(
-                "no current calibration receipt at runtime/calibration-receipt.json "
-                "(run 'daydream benchmark calibrate-judge' first)"
-            )
     return failures
 
 

--- a/daydream/benchmark/harbor/run.py
+++ b/daydream/benchmark/harbor/run.py
@@ -530,8 +530,7 @@ def _environment_from_trial(trial: Path) -> dict[str, Any]:
 
 
 def _current_state_mapping(
-    *, workspace: Path, compiled_lock_sha256: str, env: dict[str, Any],
-    calibration_digest: str,
+    workspace: Path, *, compiled_lock_sha256: str, env: dict[str, Any],
 ) -> dict[str, Any]:
     """The current Oracle/Harbor state an oracle receipt must match.
 
@@ -554,7 +553,6 @@ def _current_state_mapping(
         "verifier_template_sha256": calibrate._render_judge_prompt_digest(sr),
         "threshold": verifier_core.CONFIDENCE_THRESHOLD,
         "attempts": config.get("n_attempts", 1),
-        "calibration_receipt_sha256": calibration_digest,
     }
     # Daydream wheel provenance (issue #888): bind the exact compiled wheel
     # digest/version the run was built under from the authoritative lock. An
@@ -581,12 +579,11 @@ def _current_state_mapping(
 
 def _oracle_receipt_document(
     *, workspace: Path, compiled_lock_sha256: str, env: dict[str, Any],
-    calibration_digest: str, result_dir: Path,
+    result_dir: Path,
 ) -> dict[str, Any]:
     """Assemble the private deterministic Oracle receipt (mode-0600)."""
     doc = _current_state_mapping(
         workspace=workspace, compiled_lock_sha256=compiled_lock_sha256, env=env,
-        calibration_digest=calibration_digest,
     )
     doc["result_dir"] = str(Path(result_dir).resolve())
     doc["timestamp"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
@@ -595,7 +592,7 @@ def _oracle_receipt_document(
 
 def _write_oracle_receipt(
     workspace: Path, *, job_dir: Path, compiled_lock_sha256: str,
-    env: dict[str, Any], calibration_digest: str,
+    env: dict[str, Any],
 ) -> int:
     """Write the oracle-receipt only when the Oracle run reproduced gold."""
     ok, _ = _parse_job_results(Path(job_dir))
@@ -608,7 +605,7 @@ def _write_oracle_receipt(
         return 1
     doc = _oracle_receipt_document(
         workspace=workspace, compiled_lock_sha256=compiled_lock_sha256, env=env,
-        calibration_digest=calibration_digest, result_dir=Path(job_dir),
+        result_dir=Path(job_dir),
     )
     storage.atomic_write_json(
         workspace / "harbor" / "oracle-receipt.json", doc, mode=0o600
@@ -618,7 +615,6 @@ def _write_oracle_receipt(
 
 def _default_run_gate(
     workspace: Path, *, env: dict[str, Any], compiled_lock_sha256: str,
-    calibration_digest: str,
 ) -> str | None:
     """Gate a default (non-Oracle) run behind a matching Oracle receipt."""
     receipt_path = workspace / "harbor" / "oracle-receipt.json"
@@ -632,7 +628,6 @@ def _default_run_gate(
         return f"malformed oracle receipt at {receipt_path}"
     current = _current_state_mapping(
         workspace=workspace, compiled_lock_sha256=compiled_lock_sha256, env=env,
-        calibration_digest=calibration_digest,
     )
     for key, value in current.items():
         if receipt.get(key) != value:
@@ -666,15 +661,6 @@ def _default_spawn(cmd: list[str], *, cwd: Path, env: dict[str, Any]) -> dict[st
     """Default Harbor subprocess spawn (the real production seam)."""
     completed = subprocess.run(cmd, cwd=str(cwd), env=dict(env))
     return {"returncode": completed.returncode}
-
-
-def _calibration_digest(workspace: Path) -> str:
-    """sha256 of ``runtime/calibration-receipt.json`` bytes (empty when absent)."""
-    path = workspace / "runtime" / "calibration-receipt.json"
-    try:
-        return hashlib.sha256(path.read_bytes()).hexdigest()
-    except OSError:
-        return ""
 
 
 def _ledger_job_dir(workspace: Path, run_id: str) -> Path:
@@ -737,7 +723,6 @@ def run_run(
     if not oracle:
         gate_reason = _default_run_gate(
             workspace, env=env, compiled_lock_sha256=compiled_lock_sha,
-            calibration_digest=_calibration_digest(workspace),
         )
         if gate_reason is not None:
             print(gate_reason, file=sys.stderr)
@@ -792,7 +777,7 @@ def run_run(
                 return returncode or 1
             write_code = _write_oracle_receipt(
                 workspace, job_dir=actual_dir, compiled_lock_sha256=compiled_lock_sha,
-                env=env, calibration_digest=_calibration_digest(workspace),
+                env=env,
             )
             ledger_mark(workspace, run_id, state="complete",
                         environments=environments)

--- a/daydream/benchmark/harbor/run.py
+++ b/daydream/benchmark/harbor/run.py
@@ -2,7 +2,7 @@
 
 A thin safety wrapper around Harbor 0.21 that fail-closes on every preflight
 before Harbor starts (same-interpreter Harbor, compiled-tree presence,
-endpoint hosts vs the workspace allowlists, telemetry/upload rejection,
+endpoint hosts vs the compiled network policy, telemetry/upload rejection,
 and Docker allowlist support), prints a pre-run spend summary, and
 records every run in a private ``runtime/harbor.json`` cleanup ledger. Harbor
 remains the only orchestrator/results implementation; this module only
@@ -25,6 +25,7 @@ import json
 import os
 import subprocess
 import sys
+import tomllib
 import urllib.parse
 import uuid
 from pathlib import Path
@@ -64,13 +65,46 @@ def _load_workspace_privacy(workspace: Path) -> dict[str, Any]:
     return privacy
 
 
-def _normalize_allowlist(values: Any, what: str) -> list[str]:
-    """Normalize a workspace allowlist with the schema's hostname rules."""
-    from daydream.benchmark.schema import normalize_hostname
+def _compiled_allowed_hosts(workspace: Path) -> tuple[list[str], list[str]] | None:
+    """The reviewer/judge egress allowlists Harbor will actually enforce.
 
-    if not isinstance(values, list) or not values:
-        raise RunBlocked(f"privacy {what} must be a non-empty host list")
-    return [normalize_hostname(str(v)) for v in values]
+    Harbor applies the policy written into each compiled case's ``task.toml``
+    -- ``[agent].allowed_hosts`` (reviewer boundary) and
+    ``[verifier.environment].allowed_hosts`` (judge boundary) -- not the raw
+    ``benchmark.yaml``, which may be stale relative to the compiled tree
+    (``compile_workspace`` threads one reviewer/judge allowlist into every
+    compiled case; the task hashed digest is locked into ``compiled_lock_sha256``).
+    Reading the compiled cases enumerated by ``benchmark.lock.json`` keeps the
+    preflight checking the same artifact Harbor executes, ignoring any runtime
+    ``jobs/`` trial copies of ``task.toml`` that may linger from earlier runs.
+    Returns ``None`` when there are no compiled cases (nothing Harbor runs, so
+    no egress boundary to enforce). Fail-closed: a listed case without a
+    readable ``task.toml`` raises ``RunBlocked`` -- the egress check is never
+    skipped when a policy exists.
+    """
+    compiled = workspace / "harbor"
+    lock_path = compiled / "benchmark.lock.json"
+    try:
+        lock = json.loads(lock_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RunBlocked(f"cannot read compiled lock at {lock_path}: {exc}") from exc
+    cases = lock.get("cases") if isinstance(lock, dict) else None
+    keys = list(cases.keys()) if isinstance(cases, dict) else []
+    if not keys:
+        return None
+    task_tomls = sorted((compiled / str(key) / "task.toml").resolve() for key in keys)
+    reviewer: set[str] = set()
+    judge: set[str] = set()
+    for path in task_tomls:
+        try:
+            doc = tomllib.loads(path.read_text(encoding="utf-8"))
+        except (OSError, tomllib.TOMLDecodeError) as exc:
+            raise RunBlocked(f"cannot read compiled network policy at {path}: {exc}") from exc
+        reviewer.update(doc.get("agent", {}).get("allowed_hosts") or [])
+        judge.update(
+            doc.get("verifier", {}).get("environment", {}).get("allowed_hosts") or []
+        )
+    return sorted(reviewer), sorted(judge)
 
 
 def _reviewer_host_from_env(env: dict[str, Any]) -> str:
@@ -359,7 +393,7 @@ def _preflight(
 
     Checks, in order, without stopping at the first failure:
       1. same-interpreter Harbor resolution + compiled-tree presence
-      2. judge/reviewer egress hosts vs the workspace allowlists
+      2. judge/reviewer egress hosts vs the compiled network policy
       3. telemetry/upload rejection (archive + uploads must be ``disabled``)
       4. Docker allowlist support (no public-networking fallback)
     """
@@ -376,22 +410,12 @@ def _preflight(
             failures.append(f"missing compiled Harbor tree file: harbor/{required}")
 
     try:
-        privacy = _load_workspace_privacy(workspace)
-    except storage.WorkspaceCorrupt as exc:
+        compiled_hosts = _compiled_allowed_hosts(workspace)
+    except RunError as exc:
         failures.append(str(exc))
-        privacy = {}
-
-    if privacy:
-        try:
-            reviewer_hosts = _normalize_allowlist(
-                privacy.get("reviewer_allowed_hosts"), "reviewer_allowed_hosts"
-            )
-            judge_hosts = _normalize_allowlist(
-                privacy.get("judge_allowed_hosts"), "judge_allowed_hosts"
-            )
-        except RunBlocked as exc:
-            failures.append(str(exc))
-            reviewer_hosts, judge_hosts = [], []
+        compiled_hosts = None
+    if compiled_hosts is not None:
+        reviewer_hosts, judge_hosts = compiled_hosts
         for label, resolve, hosts in (
             ("judge", calibrate._judge_host_from_env, judge_hosts),
             ("reviewer", _reviewer_host_from_env, reviewer_hosts),
@@ -403,9 +427,16 @@ def _preflight(
                 continue
             if host and host not in hosts:
                 failures.append(
-                    f"{label} host {host!r} is not in the workspace "
-                    f"{label}_allowed_hosts allowlist ({sorted(hosts)})"
+                    f"{label} host {host!r} is not in the compiled "
+                    f"{label} allowed_hosts policy ({sorted(hosts)})"
                 )
+
+    try:
+        privacy = _load_workspace_privacy(workspace)
+    except storage.WorkspaceCorrupt as exc:
+        failures.append(str(exc))
+        privacy = {}
+    if privacy:
         for field in ("archive", "uploads"):
             value = privacy.get(field)
             if value != "disabled":

--- a/daydream/benchmark/harbor/run.py
+++ b/daydream/benchmark/harbor/run.py
@@ -348,22 +348,6 @@ def ledger_mark(
         raise RunError(f"run {run_id!r} not found in cleanup ledger {path}")
 
 
-def _calibration_invalidation_inputs(env: dict[str, Any]) -> dict[str, Any]:
-    """The calibration-receipt invalidation inputs for ``env`` (reused verbatim)."""
-    sr = calibrate._load_judge_template()
-    pairs = calibrate._load_fixture()
-    inputs = calibrate._invalidation_inputs(env, pairs, sr)
-    # Candidate review-profile digest (issue #885/R12): when the control plane
-    # supplies a ``DAYDREAM_REVIEW_PROFILE_CANDIDATE_DIGEST``, a change of
-    # candidate invalidates the calibration receipt (benchmark attribution
-    # requires per-candidate invalidation). Omitted when absent so the
-    # legacy receipt contract stays byte-stable for default-profile runs.
-    digest = env.get("DAYDREAM_REVIEW_PROFILE_CANDIDATE_DIGEST")
-    if digest:
-        inputs["profile_digest"] = str(digest)
-    return inputs
-
-
 def _preflight(
     workspace: Path,
     *,

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -427,13 +427,14 @@ the whole before- or after-state — never a checksum-drifted partial.
 
 ## Diagnostics vs the Oracle gate vs the benchmark-after-Oracle gate
 
-The Harbor/private-benchmark path has three distinct concepts that are easy to
-conflate. Keep them separate:
+The Harbor/private-benchmark path has four distinct concepts (or three concepts
+plus one threshold distinction) that are easy to conflate. Keep them separate:
 
 1. **Optional unverified judge-agreement diagnostics** — `daydream benchmark
    calibrate-judge <workspace>` drives the exact packaged judge path over an
    **unverified** 24-pair fixture and reports how closely the judge agrees with
-   that fixture (the `0.90` diagnostic metric). It is optional, diagnostic-only,
+   that fixture, passing on a `0.90` balanced-accuracy threshold. It is
+   optional, diagnostic-only,
    and is **not** an authorization, correctness, or validation check. Neither the
    fixture nor its receipts gate any run: they are machine-readable provenance
    artifacts you may inspect, never a pass/fail prerequisite. Loading a
@@ -449,9 +450,11 @@ conflate. Keep them separate:
    the workspace's compiled lock state (for example, an allowlist change
    invalidates an existing receipt). This governs normal runs against a verified
    Oracle; it does not read calibration diagnostics.
-4. **The `0.90` diagnostic metric vs the `0.70` retained-edge threshold.** These
-   are different numbers with different purposes: `0.90` is the judge-agreement
-   diagnostic threshold reported during calibration; `0.70` is the benchmark's
+4. **The `0.90` judge-agreement diagnostic threshold vs the `0.70` retained-edge
+   threshold.** These are different numbers with different purposes: `0.90` is
+   the judge-agreement diagnostic threshold (the pass threshold on balanced
+   accuracy) reported
+   during calibration; `0.70` is the benchmark's
    retained-edge (per-case) threshold. Do not treat one as the other.
 
 ### OpenRouter data handling

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -424,3 +424,41 @@ removal is a separate cutover.
 All workspace writes are atomic and journaled (`prepared | committing |
 complete`) under the workspace lock, so a crash mid-mutation restores either
 the whole before- or after-state — never a checksum-drifted partial.
+
+## Diagnostics vs the Oracle gate vs the benchmark-after-Oracle gate
+
+The Harbor/private-benchmark path has three distinct concepts that are easy to
+conflate. Keep them separate:
+
+1. **Optional unverified judge-agreement diagnostics** — `daydream benchmark
+   calibrate-judge <workspace>` drives the exact packaged judge path over an
+   **unverified** 24-pair fixture and reports how closely the judge agrees with
+   that fixture (the `0.90` diagnostic metric). It is optional, diagnostic-only,
+   and is **not** an authorization, correctness, or validation check. Neither the
+   fixture nor its receipts gate any run: they are machine-readable provenance
+   artifacts you may inspect, never a pass/fail prerequisite. Loading a
+   calibration receipt is not required to run the benchmark and carries no
+   operational authority.
+
+2. **The Oracle self-match/reward gate.** The supervised run uses `--oracle` and
+   gates on the reviewer achieving the Oracle's **self-match / reward** result —
+   a verified, operational state — not on any calibration fixture or receipt.
+   This is the actual quality gate.
+3. **The normal benchmark-after-Oracle gate.** Once an Oracle receipt exists, a
+   normal (non-`--oracle`) run is gated on the matching receipt being current for
+   the workspace's compiled lock state (for example, an allowlist change
+   invalidates an existing receipt). This governs normal runs against a verified
+   Oracle; it does not read calibration diagnostics.
+4. **The `0.90` diagnostic metric vs the `0.70` retained-edge threshold.** These
+   are different numbers with different purposes: `0.90` is the judge-agreement
+   diagnostic threshold reported during calibration; `0.70` is the benchmark's
+   retained-edge (per-case) threshold. Do not treat one as the other.
+
+### OpenRouter data handling
+
+Live private-source runs that route through **OpenRouter** send private
+source data to a third-party provider. Before running such a run you must
+explicitly accept that provider's **data-handling and retention policy** —
+especially for its free endpoints, which may retain or further process inputs.
+Never put API keys or source findings in docs or receipts.
+

--- a/tests/test_benchmark_calibrate.py
+++ b/tests/test_benchmark_calibrate.py
@@ -46,11 +46,15 @@ def test_fixture_is_source_free():
 def test_fixture_provenance_declares_unverified_llm_origin():
     from daydream.benchmark.harbor.calibrate import _load_fixture, _load_provenance
 
-    prov = _load_provenance()
+    pairs = _load_fixture()
+    prov = _load_provenance(pairs)
     assert prov["origin"] == "llm_generated"
     assert prov["human_reviewed"] is False
     assert prov["labels"] == "unverified"
-    assert len(_load_fixture()) == 24          # the 24 pairs survive the shape change
+    # Pair-attestable facts are derived from the passed pairs, not a fixed file.
+    assert prov["class_balance"] == {"match": 12, "nonmatch": 12}
+    assert prov["categories"] == 8
+    assert len(pairs) == 24          # the 24 pairs survive the shape change
 
 
 def test_every_pair_renders_within_24kib():
@@ -285,7 +289,7 @@ def test_diagnostic_receipt_invalidates_on_fixture_content_change(tmp_path, monk
     assert receipt["provenance"]["human_reviewed"] is False
     assert receipt["provenance"]["labels"] == "unverified"
     # Full fixture content (provenance + all pairs) is part of the invalidation inputs.
-    assert receipt["inputs"]["fixture_sha256"] == calibrate._fixture_sha256()
+    assert receipt["inputs"]["fixture_sha256"] == calibrate._fixture_sha256(pairs)
     assert receipt["inputs"]["fixture_provenance"]["origin"] == "llm_generated"
 
     assert calibrate.is_receipt_current(path, calibrate._invalidation_inputs(env, pairs, sr))
@@ -293,13 +297,13 @@ def test_diagnostic_receipt_invalidates_on_fixture_content_change(tmp_path, monk
     # A provenance-block change (the fixture now claims human_reviewed=true)
     # must invalidate an existing diagnostic receipt, even though the ordered
     # gold/candidate/label triples (label_sha256) are unchanged.
-    modified_provenance = dict(calibrate._load_provenance())
+    modified_provenance = dict(calibrate._load_provenance(pairs))
     modified_provenance["human_reviewed"] = True
-    monkeypatch.setattr(calibrate, "_load_provenance", lambda: modified_provenance)
+    monkeypatch.setattr(calibrate, "_load_provenance", lambda pairs: modified_provenance)
     monkeypatch.setattr(
         calibrate,
         "_fixture_sha256",
-        lambda: hashlib.sha256(b"fixture-with-human-revised-provenance").hexdigest(),
+        lambda pairs: hashlib.sha256(b"fixture-with-human-revised-provenance").hexdigest(),
     )
     assert not calibrate.is_receipt_current(
         path, calibrate._invalidation_inputs(env, pairs, sr))

--- a/tests/test_benchmark_calibrate.py
+++ b/tests/test_benchmark_calibrate.py
@@ -2,6 +2,7 @@
 """
 
 import asyncio
+import hashlib
 import json
 import re
 import stat
@@ -265,6 +266,43 @@ def test_receipt_invalidated_on_input_change(tmp_path):
         tmp_path / "runtime" / "calibration-receipt.json",
         _invalidation_inputs(changed, pairs, sr),
     ) is False
+
+
+def test_diagnostic_receipt_invalidates_on_fixture_content_change(tmp_path, monkeypatch):
+    from daydream.benchmark.harbor import calibrate
+
+    sr = calibrate._load_judge_template()
+    pairs = calibrate._load_fixture()
+    env = {"DAYDREAM_JUDGE_PROVIDER": "openai-compatible", "DAYDREAM_JUDGE_MODEL": "m",
+           "DAYDREAM_JUDGE_BASE_URL": "http://127.0.0.1:9", "DAYDREAM_JUDGE_API_KEY": "k"}
+    receipt = calibrate._build_receipt(
+        sr, pairs, env, passed=True, balanced_accuracy=1.0,
+        confusion={"tp": 12, "fp": 0, "tn": 12, "fn": 0}, disagreements=[])
+    path = calibrate._write_receipt(tmp_path, receipt)
+
+    # Diagnostic receipts carry honest machine-readable provenance matching the fixture.
+    assert receipt["provenance"]["origin"] == "llm_generated"
+    assert receipt["provenance"]["human_reviewed"] is False
+    assert receipt["provenance"]["labels"] == "unverified"
+    # Full fixture content (provenance + all pairs) is part of the invalidation inputs.
+    assert receipt["inputs"]["fixture_sha256"] == calibrate._fixture_sha256()
+    assert receipt["inputs"]["fixture_provenance"]["origin"] == "llm_generated"
+
+    assert calibrate.is_receipt_current(path, calibrate._invalidation_inputs(env, pairs, sr))
+
+    # A provenance-block change (the fixture now claims human_reviewed=true)
+    # must invalidate an existing diagnostic receipt, even though the ordered
+    # gold/candidate/label triples (label_sha256) are unchanged.
+    modified_provenance = dict(calibrate._load_provenance())
+    modified_provenance["human_reviewed"] = True
+    monkeypatch.setattr(calibrate, "_load_provenance", lambda: modified_provenance)
+    monkeypatch.setattr(
+        calibrate,
+        "_fixture_sha256",
+        lambda: hashlib.sha256(b"fixture-with-human-revised-provenance").hexdigest(),
+    )
+    assert not calibrate.is_receipt_current(
+        path, calibrate._invalidation_inputs(env, pairs, sr))
 
 
 def test_receipt_has_no_credentials_or_source():

--- a/tests/test_benchmark_calibrate.py
+++ b/tests/test_benchmark_calibrate.py
@@ -19,14 +19,16 @@ _CRED = re.compile(r"sk-ant-|sk-or-|Bearer |x-api-key")
 
 
 def test_fixture_is_24_pairs_12_12():
-    pairs = json.loads((_FIXTURE / "pairs.json").read_text())
+    from daydream.benchmark.harbor.calibrate import _load_fixture
+    pairs = _load_fixture()
     assert len(pairs) == 24
     labels = [p["label"] for p in pairs]
     assert labels.count("match") == 12 and labels.count("nonmatch") == 12
 
 
 def test_fixture_covers_all_eight_categories():
-    pairs = json.loads((_FIXTURE / "pairs.json").read_text())
+    from daydream.benchmark.harbor.calibrate import _load_fixture
+    pairs = _load_fixture()
     assert {p["category"] for p in pairs} >= REQUIRED_CATEGORIES
 
 
@@ -40,9 +42,14 @@ def test_fixture_is_source_free():
         assert tok not in text
 
 
-def test_fixture_has_provenance_note():
-    note = (_FIXTURE / "PROVENANCE.md").read_text()
-    assert "reviewer" in note.lower() and "source-free" in note.lower()
+def test_fixture_provenance_declares_unverified_llm_origin():
+    from daydream.benchmark.harbor.calibrate import _load_fixture, _load_provenance
+
+    prov = _load_provenance()
+    assert prov["origin"] == "llm_generated"
+    assert prov["human_reviewed"] is False
+    assert prov["labels"] == "unverified"
+    assert len(_load_fixture()) == 24          # the 24 pairs survive the shape change
 
 
 def test_every_pair_renders_within_24kib():

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -28,6 +28,14 @@ def test_benchmark_parser_has_build_harbor_and_compiled():
     assert validate_args.compiled is True
 
 
+def test_calibrate_judge_help_describes_diagnostic_agreement():
+    parser = _build_benchmark_parser()
+    help_text = parser._subparsers._group_actions[0].choices["calibrate-judge"].format_help()
+    assert "diagnostic" in help_text.lower() or "agreement" in help_text.lower()
+    assert "calibrat" in help_text.lower()          # still called calibrate-judge
+    assert "unverified" in help_text.lower()
+
+
 def test_benchmark_build_harbor_real_cli_entry(tmp_path, fake_gh, capsys):
     import importlib.metadata
 

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -36,6 +36,15 @@ def test_calibrate_judge_help_describes_diagnostic_agreement():
     assert "unverified" in help_text.lower()
 
 
+def test_docs_distinguish_diagnostics_from_oracle_gate():
+    changelog = Path(__file__).parents[1] / "CHANGELOG.md"
+    bench_doc = Path(__file__).parents[1] / "docs" / "benchmark.md"
+    text = changelog.read_text() + bench_doc.read_text()
+    assert "Oracle" in text and "diagnostic" in text.lower()
+    assert "self-match" in text.lower() or "reward" in text.lower()
+    assert "OpenRouter" in text and "data-handling" in text.lower()
+
+
 def test_benchmark_build_harbor_real_cli_entry(tmp_path, fake_gh, capsys):
     import importlib.metadata
 

--- a/tests/test_benchmark_harbor_agent.py
+++ b/tests/test_benchmark_harbor_agent.py
@@ -31,8 +31,11 @@ def test_spike_task_toml_env_carries_case_key(tmp_path, fake_gh):
     assert f"DAYDREAM_REVIEW_CASE_ID = \"{key}\"" in toml
     assert "[environment]" in toml
     # determinism: re-rendering identical bytes
+    # re-render with the same workspace-seeded privacy allowlists so the bytes
+    # are identical to the compiled task.toml (reviewer h1/judge h2, not a
+    # different policy like api.anthropic.com)
     assert pkg.render_task_toml(
-        key, reviewer_hosts=["api.anthropic.com"], judge_hosts=["api.anthropic.com"]
+        key, reviewer_hosts=["h1.example.com"], judge_hosts=["h2.example.com"]
     ) == (case / "task.toml").read_bytes()
     # Harbor validates the enriched task.toml (same-interpreter Task model)
     try:

--- a/tests/test_benchmark_harbor_agent.py
+++ b/tests/test_benchmark_harbor_agent.py
@@ -31,7 +31,9 @@ def test_spike_task_toml_env_carries_case_key(tmp_path, fake_gh):
     assert f"DAYDREAM_REVIEW_CASE_ID = \"{key}\"" in toml
     assert "[environment]" in toml
     # determinism: re-rendering identical bytes
-    assert pkg.render_task_toml(key) == (case / "task.toml").read_bytes()
+    assert pkg.render_task_toml(
+        key, reviewer_hosts=["api.anthropic.com"], judge_hosts=["api.anthropic.com"]
+    ) == (case / "task.toml").read_bytes()
     # Harbor validates the enriched task.toml (same-interpreter Task model)
     try:
         from harbor.models.task import Task  # noqa: PLC0415 - namespace fallback as in package.py
@@ -151,16 +153,44 @@ def test_artifact_write_failure_raises(tmp_path):
 def test_render_task_toml_host_policy_and_case_env():
     from daydream.benchmark.harbor import package as pkg
 
-    toml = pkg.render_task_toml("case-abc123def456").decode("utf-8")
+    toml = pkg.render_task_toml(
+        "case-abc123def456",
+        reviewer_hosts=["api.anthropic.com"],
+        judge_hosts=["api.anthropic.com"],
+    ).decode("utf-8")
     assert 'allowed_hosts = ["api.anthropic.com"]' in toml       # reviewer-only host
     assert '"github.com"' not in toml and '"huggingface.co"' not in toml
     assert 'DAYDREAM_REVIEW_CASE_ID = "case-abc123def456"' in toml
     assert 'DAYDREAM_REVIEW_BASE_REF = "base"' in toml
     assert 'DAYDREAM_REVIEW_HEAD_REF = "head"' in toml
     # deterministic
-    assert pkg.render_task_toml("case-abc123def456") == pkg.render_task_toml("case-abc123def456")
+    assert pkg.render_task_toml(
+        "case-abc123def456",
+        reviewer_hosts=["api.anthropic.com"],
+        judge_hosts=["api.anthropic.com"],
+    ) == pkg.render_task_toml(
+        "case-abc123def456",
+        reviewer_hosts=["api.anthropic.com"],
+        judge_hosts=["api.anthropic.com"],
+    )
     # no judge vars or archive/target config reach the agent surface
     assert "DAYDREAM_JUDGE" not in toml and "HF_TOKEN" not in toml and "GITHUB_TOKEN" not in toml
+
+
+def test_render_task_toml_keeps_agent_verifier_host_boundaries():
+    from daydream.benchmark.harbor import package as pkg
+
+    toml = pkg.render_task_toml(
+        "case-abc123def456",
+        reviewer_hosts=["api.anthropic.com"],
+        judge_hosts=["openrouter.ai"],
+    ).decode("utf-8")
+    agent_block = toml.split("[agent]", 1)[1].split("[environment]", 1)[0]
+    verifier_block = toml.split("[verifier.environment]", 1)[1]
+    assert 'allowed_hosts = ["api.anthropic.com"]' in agent_block
+    assert "openrouter.ai" not in agent_block
+    assert 'allowed_hosts = ["openrouter.ai"]' in verifier_block
+    assert "api.anthropic.com" not in verifier_block
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_benchmark_harbor_build.py
+++ b/tests/test_benchmark_harbor_build.py
@@ -1178,3 +1178,42 @@ def test_compiled_agent_and_verifier_surfaces_exclude_task_md(tmp_path, fake_gh)
     assert env_files == {
         "repository.bundle", "Dockerfile", "runtime-requirements.lock"
     }, f"unexpected environment files: {env_files}"
+
+
+def test_compiled_policy_comes_from_workspace_allowlists(tmp_path, fake_gh):
+    """The compiled task TOML's agent/verifier host policies are populated from the
+    workspace's persisted privacy allowlists (reviewer -> [agent].allowed_hosts,
+    judge -> [verifier.environment].allowed_hosts), kept as separate boundaries."""
+    import tomllib
+
+    from daydream.benchmark.harbor import build
+
+    ws, case_id, _ = _seed_ready_workspace(tmp_path, fake_gh)
+    lock = build.compile_workspace(ws)                 # h1.example.com / h2.example.com
+    key = next(iter(lock["cases"]))
+    toml = (ws / "harbor" / key / "task.toml").read_bytes()
+    doc = tomllib.loads(toml.decode())
+    assert doc["agent"]["allowed_hosts"] == ["h1.example.com"]
+    assert doc["verifier"]["environment"]["allowed_hosts"] == ["h2.example.com"]
+    assert "h1.example.com" not in doc["verifier"]["environment"]["allowed_hosts"]
+    assert "h2.example.com" not in doc["agent"]["allowed_hosts"]
+
+
+def test_policy_change_alters_compiled_digest(tmp_path, fake_gh):
+    """Changing a persisted privacy allowlist changes the compiled task.toml bytes
+    (and thus the lock's files inventory -> lock bytes -> compiled_lock_sha256), so
+    an existing Oracle receipt is invalidated by a network-policy change."""
+    from daydream.benchmark import storage
+    from daydream.benchmark.harbor import build
+
+    ws, case_id, _ = _seed_ready_workspace(tmp_path, fake_gh)
+    lock_a = build.compile_workspace(ws)
+    digest_a = lock_a["files"][next(iter(lock_a["cases"])) + "/task.toml"]
+    # change the reviewer allowlist in benchmark.yaml
+    raw = storage.load_yaml_strict(ws / "benchmark.yaml")
+    raw["privacy"]["reviewer_allowed_hosts"] = ["other.example"]
+    storage.atomic_write_yaml(ws / "benchmark.yaml", raw)
+    lock_b = build.compile_workspace(ws)
+    digest_b = lock_b["files"][next(iter(lock_b["cases"])) + "/task.toml"]
+    assert digest_a != digest_b
+    assert lock_a != lock_b          # lock bytes differ -> compiled_lock_sha256 differs

--- a/tests/test_benchmark_harbor_build.py
+++ b/tests/test_benchmark_harbor_build.py
@@ -1199,6 +1199,44 @@ def test_compiled_policy_comes_from_workspace_allowlists(tmp_path, fake_gh):
     assert "h2.example.com" not in doc["agent"]["allowed_hosts"]
 
 
+def test_openrouter_policy_compiles_and_is_not_leak_flagged(tmp_path, fake_gh):
+    """The OpenRouter workspace resolves both persisted allowlists to
+    ``openrouter.ai``; the compiled task.toml carries that host in both egress
+    boundaries and the control-plane leakage scan does not flag a bare
+    legitimate hostname.
+    """
+    import tomllib
+
+    from daydream.benchmark import storage
+    from daydream.benchmark.harbor import build
+
+    ws, case_id, _ = _seed_ready_workspace(tmp_path, fake_gh)
+    raw = storage.load_yaml_strict(ws / "benchmark.yaml")
+    raw["privacy"]["reviewer_allowed_hosts"] = ["openrouter.ai"]
+    raw["privacy"]["judge_allowed_hosts"] = ["openrouter.ai"]
+    storage.atomic_write_yaml(ws / "benchmark.yaml", raw)
+    lock = build.compile_workspace(ws)          # must not raise a leakage CompileError
+    key = next(iter(lock["cases"]))
+    doc = tomllib.loads((ws / "harbor" / key / "task.toml").read_bytes().decode())
+    assert doc["agent"]["allowed_hosts"] == ["openrouter.ai"]
+    assert doc["verifier"]["environment"]["allowed_hosts"] == ["openrouter.ai"]
+
+
+def test_compile_rejects_disallowed_judge_host(tmp_path, fake_gh):
+    """A malformed judge host must fail compilation (fail closed), never be
+    silently normalized or defaulted.
+    """
+    from daydream.benchmark import storage
+    from daydream.benchmark.harbor import build
+
+    ws, case_id, _ = _seed_ready_workspace(tmp_path, fake_gh)
+    raw = storage.load_yaml_strict(ws / "benchmark.yaml")
+    raw["privacy"]["judge_allowed_hosts"] = ["no-dot-segment"]   # normalize_hostname rejects
+    storage.atomic_write_yaml(ws / "benchmark.yaml", raw)
+    with pytest.raises(build.CompileError):
+        build.compile_workspace(ws)
+
+
 def test_policy_change_alters_compiled_digest(tmp_path, fake_gh):
     """Changing a persisted privacy allowlist changes the compiled task.toml bytes
     (and thus the lock's files inventory -> lock bytes -> compiled_lock_sha256), so

--- a/tests/test_benchmark_harbor_package.py
+++ b/tests/test_benchmark_harbor_package.py
@@ -111,12 +111,75 @@ def test_resolve_harbor_checks_same_interpreter_and_version(monkeypatch):
     assert "[0.21, 0.22)" in str(wrong.value)
 
 
+def test_render_task_toml_threads_reviewer_and_judge_hosts():
+    import tomllib
+
+    from daydream.benchmark.harbor import package as pkg
+
+    text = pkg.render_task_toml(
+        "case-abc123def456",
+        reviewer_hosts=["api.anthropic.com"],
+        judge_hosts=["openrouter.ai"]).decode()
+    doc = tomllib.loads(text)
+    assert doc["agent"]["allowed_hosts"] == ["api.anthropic.com"]
+    assert doc["verifier"]["environment"]["allowed_hosts"] == ["openrouter.ai"]
+    # deterministic
+    assert pkg.render_task_toml("case-abc123def456",
+                                reviewer_hosts=["api.anthropic.com"],
+                                judge_hosts=["openrouter.ai"]) == \
+           pkg.render_task_toml("case-abc123def456",
+                                reviewer_hosts=["api.anthropic.com"],
+                                judge_hosts=["openrouter.ai"])
+
+
+def test_render_task_toml_fails_closed_on_empty_or_missing_hosts():
+    import pytest
+
+    from daydream.benchmark.harbor import package as pkg
+
+    for kw in ({"reviewer_hosts": [], "judge_hosts": ["h.example"]},
+               {"reviewer_hosts": ["h.example"], "judge_hosts": []},
+               {"reviewer_hosts": [], "judge_hosts": []}):
+        with pytest.raises(pkg.PackageError):
+            pkg.render_task_toml("case-abc", **kw)
+    with pytest.raises(pkg.PackageError):
+        pkg.render_task_toml("case-abc")   # missing required kwargs
+
+
+def test_render_task_toml_normalizes_and_sorts_hosts():
+    import tomllib
+
+    import pytest
+
+    from daydream.benchmark.harbor import package as pkg
+
+    doc = tomllib.loads(pkg.render_task_toml(
+        "case-abc",
+        reviewer_hosts=["HTTPS://B.Example.com", "a.example.com"],
+        judge_hosts=["openrouter.ai"],
+    ).decode())
+    assert doc["agent"]["allowed_hosts"] == ["a.example.com", "b.example.com"]
+    assert doc["verifier"]["environment"]["allowed_hosts"] == ["openrouter.ai"]
+    with pytest.raises(pkg.PackageError):
+        pkg.render_task_toml("case-abc",
+                             reviewer_hosts=["not-a-host"],
+                             judge_hosts=["openrouter.ai"])
+    with pytest.raises(pkg.PackageError):
+        pkg.render_task_toml("case-abc",
+                             reviewer_hosts=["api.anthropic.com"],
+                             judge_hosts=["*.example.com"])
+
+
 def test_render_task_toml_matches_plan_s8():
     import tomllib
 
     from daydream.benchmark.harbor import package as pkg
 
-    text = pkg.render_task_toml("case-4f7c81d922a0").decode()
+    text = pkg.render_task_toml(
+        "case-4f7c81d922a0",
+        reviewer_hosts=["api.anthropic.com"],
+        judge_hosts=["api.anthropic.com"],
+    ).decode()
     doc = tomllib.loads(text)
     assert doc["schema_version"] == "1.4"
     assert doc["metadata"] == {

--- a/tests/test_benchmark_harbor_profile_delivery.py
+++ b/tests/test_benchmark_harbor_profile_delivery.py
@@ -100,19 +100,22 @@ def test_ledger_entry_records_candidate_digest(tmp_path):
 
 
 def test_receipt_invalidation_inputs_include_candidate_digest():
-    from daydream.benchmark.harbor import run
+    from daydream.benchmark.harbor import calibrate
 
-    inputs = run._calibration_invalidation_inputs(
-        {"DAYDREAM_REVIEW_PROFILE_CANDIDATE_DIGEST": "xyz"}
+    # calibrate._invalidation_inputs is the single source of truth for the
+    # receipt contract (run.py's former duplicating helper is gone).
+    sr = calibrate._load_judge_template()
+    inputs = calibrate._invalidation_inputs(
+        {"DAYDREAM_REVIEW_PROFILE_CANDIDATE_DIGEST": "xyz"}, pairs=[], sr=sr
     )
     assert "profile_digest" in inputs and inputs["profile_digest"] == "xyz"
 
 
 # Issue #885 R2 finding 4 (HIGH): the calibration RECEIPT WRITE side
 # (calibrate._invalidation_inputs) must fold the candidate digest too, so a
-# candidate-scoped receipt is producible and byte-matches run.py's preflight
-# _calibration_invalidation_inputs. Legacy default runs (no digest) stay
-# byte-stable. Without this the oracle preflight always fails under a candidate.
+# candidate-scoped receipt is producible from the single shared producer.
+# Legacy default runs (no digest) stay byte-stable. Without this the oracle
+# preflight always fails under a candidate.
 def test_calibrate_invalidation_inputs_folds_candidate_digest():
     from daydream.benchmark.harbor import calibrate
 
@@ -128,19 +131,19 @@ def test_calibrate_invalidation_inputs_folds_candidate_digest():
 
 
 def test_candidate_scoped_receipt_matches_preflight_inputs():
-    """A receipt written by the calibrate path under a candidate is byte-identical
-    to the preflight inputs run.py checks, so is_receipt_current passes."""
-    from daydream.benchmark.harbor import calibrate, run
+    """A candidate-scoped receipt produced through the shared invalidation-inputs
+    producer serializes deterministically (byte-exact is_receipt_current
+    contract)."""
+    from daydream.benchmark.harbor import calibrate
 
     env = {"DAYDREAM_REVIEW_PROFILE_CANDIDATE_DIGEST": "abc123"}
-    # Use the same real fixture + judge template both paths load internally.
+    # Use the same real fixture + judge template the receipt paths load internally.
     sr = calibrate._load_judge_template()
     pairs = calibrate._load_fixture()
-    # Receipt write path folds the digest (via calibrate._invalidation_inputs).
+    # Receipt write path and the read-path preflight share the one producer
+    # (calibrate._invalidation_inputs), so both must serialize identically.
     write_inputs = calibrate._invalidation_inputs(env, pairs, sr)
-    # run.py's preflight check folds the same digest (via its own producer).
-    check_inputs = run._calibration_invalidation_inputs(env)
-    # Both must serialize identically (byte-exact is_receipt_current contract).
+    check_inputs = calibrate._invalidation_inputs(env, pairs, sr)
     assert calibrate._serialize_inputs(write_inputs) == calibrate._serialize_inputs(check_inputs)
 # Issue #885 R1 items 2/10: the control-plane benchmark handler must thread the
 # candidate profile digest into the env dict it hands to run_run, because run.py

--- a/tests/test_benchmark_harbor_profile_delivery.py
+++ b/tests/test_benchmark_harbor_profile_delivery.py
@@ -130,21 +130,30 @@ def test_calibrate_invalidation_inputs_folds_candidate_digest():
     assert "profile_digest" not in legacy
 
 
-def test_candidate_scoped_receipt_matches_preflight_inputs():
-    """A candidate-scoped receipt produced through the shared invalidation-inputs
-    producer serializes deterministically (byte-exact is_receipt_current
-    contract)."""
+def test_candidate_scoped_receipt_matches_preflight_inputs(tmp_path):
+    """A candidate-scoped receipt round-trips write -> read as current.
+
+    Builds the receipt through _build_receipt/_write_receipt with the candidate
+    digest folded in, then asserts is_receipt_current returns True when the
+    preflight recomputes inputs from the shared _invalidation_inputs producer.
+    """
     from daydream.benchmark.harbor import calibrate
 
     env = {"DAYDREAM_REVIEW_PROFILE_CANDIDATE_DIGEST": "abc123"}
     # Use the same real fixture + judge template the receipt paths load internally.
     sr = calibrate._load_judge_template()
     pairs = calibrate._load_fixture()
-    # Receipt write path and the read-path preflight share the one producer
-    # (calibrate._invalidation_inputs), so both must serialize identically.
-    write_inputs = calibrate._invalidation_inputs(env, pairs, sr)
-    check_inputs = calibrate._invalidation_inputs(env, pairs, sr)
-    assert calibrate._serialize_inputs(write_inputs) == calibrate._serialize_inputs(check_inputs)
+    receipt = calibrate._build_receipt(
+        sr, pairs, env, passed=True,
+        balanced_accuracy=0.9583,
+        confusion={"tp": 12, "fp": 0, "tn": 12, "fn": 0},
+        disagreements=[],
+    )
+    receipt_path = calibrate._write_receipt(tmp_path, receipt)
+    # The read-path preflight recomputes the candidate-scoped inputs through the
+    # one shared producer and must accept the written receipt as current.
+    current = calibrate._invalidation_inputs(env, pairs, sr)
+    assert calibrate.is_receipt_current(receipt_path, current) is True
 # Issue #885 R1 items 2/10: the control-plane benchmark handler must thread the
 # candidate profile digest into the env dict it hands to run_run, because run.py
 # reads DAYDREAM_REVIEW_PROFILE_CANDIDATE_DIGEST from that env dict and the

--- a/tests/test_benchmark_run.py
+++ b/tests/test_benchmark_run.py
@@ -55,6 +55,9 @@ def _ws(tmp_path, **privacy):
          "reviewer_allowed_hosts": ["review.example"], "judge_data": "finding_text_and_location_only",
          "judge_allowed_hosts": ["127.0.0.1"], "archive": "disabled", "uploads": "disabled"}
     p.update(privacy)
+    _seed_compiled_task(
+        ws, reviewer=p["reviewer_allowed_hosts"], judge=p["judge_allowed_hosts"]
+    )
     (ws / "benchmark.yaml").write_text(json.dumps({
         "schema_version": 1, "benchmark_id": "6c38dc0a-5f5a-4b73-bf36-9a2eb390f63b",
         "created_at": "2026-08-21T12:00:00Z",
@@ -80,6 +83,26 @@ def _seed_compiled_lock(ws, wheel=_WHEEL):
     lock = {"schema_version": 1, "cases": {"case-a": {"key": "case-a"}}, "files": {},
             "daydream": wheel}
     (ws / "harbor" / "benchmark.lock.json").write_text(json.dumps(lock))
+
+
+def _seed_compiled_task(ws, *, reviewer, judge):
+    """Write the compiled task.toml egress policy Harbor will enforce.
+
+    Mirrors what ``compile_workspace`` threads into ``harbor/case-*/task.toml``
+    (reviewer -> ``[agent].allowed_hosts``, judge -> ``[verifier.environment].allowed_hosts``)
+    so the preflight, which now reads the compiled tree (not raw benchmark.yaml),
+    has the same artifact Harbor executes.
+    """
+    case = ws / "harbor" / "case-a"
+    case.mkdir(parents=True, exist_ok=True)
+    (case / "task.toml").write_text(
+        "[agent]\n"
+        f"allowed_hosts = {json.dumps(reviewer)}\n"
+        "\n"
+        "[verifier.environment]\n"
+        f"allowed_hosts = {json.dumps(judge)}\n",
+        encoding="utf-8",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -144,6 +167,23 @@ def test_preflight_blocks_reviewer_host_outside_allowlist(tmp_path):
     errs = run_mod._preflight(_ws(tmp_path), oracle=True,
                               env=_env(DAYDREAM_REVIEW_BASE_URL="http://other.example"), docker_ok=lambda: True)
     assert any("reviewer host" in e and "other.example" in e for e in errs)
+
+
+def test_preflight_enforces_compiled_task_policy_not_raw_manifest(tmp_path):
+    """Preflight reads the compiled task.toml Harbor enforces, not raw yaml.
+
+    A host ``benchmark.yaml`` permits but the compiled tree rejects (the tree
+    predates the manifest edit) must still block the run, because the stale
+    compiled task.toml is the artifact Harbor actually executes.
+    """
+    import daydream.benchmark.harbor.run as run_mod
+
+    ws = _ws(tmp_path, judge_allowed_hosts=["127.0.0.1", "stale.example"])
+    # simulate a compiled tree produced before the manifest added stale.example
+    _seed_compiled_task(ws, reviewer=["review.example"], judge=["127.0.0.1"])
+    errs = run_mod._preflight(ws, oracle=True,
+                              env=_env(DAYDREAM_JUDGE_BASE_URL="http://stale.example"), docker_ok=lambda: True)
+    assert any("judge host" in e and "stale.example" in e for e in errs)
 
 
 def test_preflight_blocks_uploads_enabled(tmp_path):

--- a/tests/test_benchmark_run.py
+++ b/tests/test_benchmark_run.py
@@ -175,11 +175,11 @@ def test_preflight_blocks_unsupported_docker_allowlist(tmp_path):
     assert any("Docker allowlist" in e for e in errs)
 
 
-def test_preflight_blocks_missing_calibration_receipt_for_oracle(tmp_path):
+def test_preflight_ok_for_oracle_without_calibration_receipt(tmp_path):
     import daydream.benchmark.harbor.run as run_mod
 
     errs = run_mod._preflight(_ws(tmp_path), oracle=True, env=_env(), docker_ok=lambda: True)
-    assert any("calibration" in e for e in errs)  # runtime/calibration-receipt.json absent
+    assert errs == []          # Oracle preflight no longer requires a calibration receipt
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_benchmark_run.py
+++ b/tests/test_benchmark_run.py
@@ -643,6 +643,38 @@ def test_oracle_receipt_has_no_calibration_state(tmp_path):
     assert "calibration_receipt_sha256" not in mapping
 
 
+def test_oracle_writes_receipt_without_calibration_file(tmp_path):
+    import hashlib
+
+    import daydream.benchmark.harbor.run as run_mod
+
+    ws = _ws(tmp_path)
+    job_dir = ws / "harbor" / "jobs" / "j1"
+    trial = job_dir / "t1" / "verifier"
+    trial.mkdir(parents=True)
+    (trial / "reward.json").write_text(json.dumps(_score(1.0)))  # gold reproduced
+    lock_sha = hashlib.sha256(
+        (ws / "harbor" / "benchmark.lock.json").read_bytes()).hexdigest()
+    code = run_mod._write_oracle_receipt(ws, job_dir=job_dir,
+                                         compiled_lock_sha256=lock_sha, env=_env())
+    assert code == 0
+    receipt = json.loads((ws / "harbor" / "oracle-receipt.json").read_text())
+    assert "calibration_receipt_sha256" not in receipt
+    assert receipt["compiled_lock_sha256"] == lock_sha
+
+
+def test_default_run_still_blocks_without_oracle_receipt(tmp_path):
+    import hashlib
+
+    import daydream.benchmark.harbor.run as run_mod
+
+    ws = _ws(tmp_path)
+    lock_sha = hashlib.sha256(
+        (ws / "harbor" / "benchmark.lock.json").read_bytes()).hexdigest()
+    reason = run_mod._default_run_gate(ws, env=_env(), compiled_lock_sha256=lock_sha)
+    assert reason is not None and "no matching oracle receipt" in reason
+
+
 def test_ledger_reviewer_effort_defaults_none_when_omitted(tmp_path):
     import daydream.benchmark.harbor.run as run_mod
 

--- a/tests/test_benchmark_run.py
+++ b/tests/test_benchmark_run.py
@@ -122,24 +122,10 @@ def test_handle_benchmark_run_routes_to_supervisor(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def _seed_calibration_receipt(ws):
-    """Write a current calibration receipt matching ``_env()`` via the #872 writer."""
-    from daydream.benchmark.harbor import calibrate
-
-    sr = calibrate._load_judge_template()
-    pairs = calibrate._load_fixture()
-    receipt = calibrate._build_receipt(
-        sr, pairs, _env(), passed=True, balanced_accuracy=1.0,
-        confusion={"tp": 12, "fp": 0, "tn": 12, "fn": 0}, disagreements=[],
-    )
-    calibrate._write_receipt(ws, receipt)
-
-
 def test_preflight_ok_when_all_checks_pass(tmp_path):
     import daydream.benchmark.harbor.run as run_mod
 
     ws = _ws(tmp_path)
-    _seed_calibration_receipt(ws)
     errs = run_mod._preflight(ws, oracle=True, env=_env(), docker_ok=lambda: True)
     assert errs == []
 
@@ -266,16 +252,14 @@ def test_oracle_parse_success_writes_receipt(tmp_path):
     assert ok is True
     code = run_mod._write_oracle_receipt(
         ws, job_dir=job_dir, compiled_lock_sha256="a" * 64, env=_env(),
-        calibration_digest="c" * 64,
     )
     assert code == 0
     receipt = json.loads((ws / "harbor" / "oracle-receipt.json").read_text())
     for key in ("compiled_lock_sha256", "harbor_version", "judge_provider", "judge_model",
                 "judge_host", "verifier_template_sha256", "threshold", "attempts",
-                "calibration_receipt_sha256", "result_dir", "timestamp"):
+                "result_dir", "timestamp"):
         assert key in receipt, f"receipt missing {key}"
     assert receipt["compiled_lock_sha256"] == "a" * 64
-    assert receipt["calibration_receipt_sha256"] == "c" * 64
 
 
 def test_oracle_no_receipt_on_reward_below_one(tmp_path):
@@ -290,7 +274,6 @@ def test_oracle_no_receipt_on_reward_below_one(tmp_path):
     assert ok is False
     code = run_mod._write_oracle_receipt(
         ws, job_dir=job_dir, compiled_lock_sha256="a" * 64, env=_env(),
-        calibration_digest="c" * 64,
     )
     assert code == 1
     assert not (ws / "harbor" / "oracle-receipt.json").exists()
@@ -329,7 +312,6 @@ def test_gate_blocks_on_compiled_lock_mismatch(tmp_path):
     (verifier / "reward.json").write_text(json.dumps(_score(1.0)))
     assert run_mod._write_oracle_receipt(
         ws, job_dir=job_dir, compiled_lock_sha256=lock_sha, env=_env(),
-        calibration_digest="c" * 64,
     ) == 0
     # now the current compiled lock digest differs from the receipt's (wheel
     # block kept so the daydream provenance read stays authoritative)
@@ -338,7 +320,7 @@ def test_gate_blocks_on_compiled_lock_mismatch(tmp_path):
     reason = run_mod._default_run_gate(
         ws, env=_env(), compiled_lock_sha256=hashlib.sha256(
             json.dumps(changed).encode()
-        ).hexdigest(), calibration_digest="c" * 64,
+        ).hexdigest(),
     )
     assert reason is not None
     assert "compiled lock" in reason
@@ -349,7 +331,6 @@ def test_gate_blocks_when_oracle_receipt_missing(tmp_path):
 
     reason = run_mod._default_run_gate(
         _ws(tmp_path), env=_env(), compiled_lock_sha256="a" * 64,
-        calibration_digest="c" * 64,
     )
     assert reason is not None
     assert "no matching oracle receipt" in reason
@@ -370,10 +351,9 @@ def test_gate_passes_when_inputs_match(tmp_path):
     (verifier / "reward.json").write_text(json.dumps(_score(1.0)))
     assert run_mod._write_oracle_receipt(
         ws, job_dir=job_dir, compiled_lock_sha256=lock_sha, env=_env(),
-        calibration_digest="c" * 64,
     ) == 0
     reason = run_mod._default_run_gate(
-        ws, env=_env(), compiled_lock_sha256=lock_sha, calibration_digest="c" * 64,
+        ws, env=_env(), compiled_lock_sha256=lock_sha,
     )
     assert reason is None
 
@@ -389,7 +369,6 @@ def test_run_oracle_writes_receipt_and_running_to_complete(tmp_path):
     import daydream.benchmark.harbor.run as run_mod
 
     ws = _ws(tmp_path)
-    _seed_calibration_receipt(ws)
     captures = {}
 
     def spawn(cmd, *, cwd, env):
@@ -424,7 +403,6 @@ def test_run_oracle_from_unrelated_cwd_resolves_harbor_cwd(tmp_path, monkeypatch
     import daydream.benchmark.harbor.run as run_mod
 
     ws = _ws(tmp_path)
-    _seed_calibration_receipt(ws)
     unrelated = tmp_path / "unrelated"
     unrelated.mkdir()
     monkeypatch.chdir(unrelated)
@@ -468,8 +446,6 @@ def test_oracle_fails_writes_no_receipt_and_ledger_cleanup_pending(tmp_path):
     import daydream.benchmark.harbor.run as run_mod
 
     ws = _ws(tmp_path)
-    _seed_calibration_receipt(ws)
-
     def spawn(cmd, *, cwd, env):
         ledger = json.loads((ws / "runtime" / "harbor.json").read_text())
         job_dir = Path(ledger["runs"][0]["job_dir"])
@@ -501,12 +477,9 @@ def test_default_run_propagates_harbor_exit_code(tmp_path):
     verifier = job_dir / "case-abc" / "verifier"
     verifier.mkdir(parents=True)
     (verifier / "reward.json").write_text(json.dumps(_score(1.0)))
-    (ws / "runtime" / "calibration-receipt.json").write_bytes(b"cal")
-    cal_digest = hashlib.sha256(b"cal").hexdigest()
     # seed a matching oracle receipt the gate will accept
     assert run_mod._write_oracle_receipt(
         ws, job_dir=job_dir, compiled_lock_sha256=lock_sha, env=_env(),
-        calibration_digest=cal_digest,
     ) == 0
 
     def spawn(cmd, *, cwd, env):
@@ -544,8 +517,6 @@ def test_run_persists_trial_environments_to_ledger(tmp_path):
     import daydream.benchmark.harbor.run as run_mod
 
     ws = _ws(tmp_path)
-    _seed_calibration_receipt(ws)
-
     def spawn(cmd, *, cwd, env):
         ledger = json.loads((ws / "runtime" / "harbor.json").read_text())
         job = Path(ledger["runs"][0]["job_dir"])
@@ -570,8 +541,6 @@ def test_run_failed_path_persists_environments_cleanup_pending(tmp_path):
     import daydream.benchmark.harbor.run as run_mod
 
     ws = _ws(tmp_path)
-    _seed_calibration_receipt(ws)
-
     def spawn(cmd, *, cwd, env):
         ledger = json.loads((ws / "runtime" / "harbor.json").read_text())
         job = Path(ledger["runs"][0]["job_dir"])
@@ -619,7 +588,7 @@ def test_current_state_mapping_includes_effort_and_wheel_digest(tmp_path):
     ws = _ws(tmp_path)
     _seed_compiled_lock(ws)   # benchmark.lock.json with daydream block
     m = run_mod._current_state_mapping(
-        workspace=ws, compiled_lock_sha256="a" * 64, env=_env(), calibration_digest="")
+        workspace=ws, compiled_lock_sha256="a" * 64, env=_env())
     assert m["daydream_wheel_sha256"] == "c" * 64
     assert m["daydream_version"] == "0.1.0"
     assert "reviewer_effort" in m
@@ -637,6 +606,41 @@ def test_ledger_records_reviewer_effort_when_present(tmp_path):
     doc = run_mod._load_ledger(ws)
     assert doc["runs"][0]["profile_digest"] == "d" * 64
     assert doc["runs"][0]["reviewer_effort"] == "high"
+
+
+# ---------------------------------------------------------------------------
+# Task 2 (issue #909): Oracle mapping decoupled from unverified calibration
+# ---------------------------------------------------------------------------
+
+
+def test_default_run_accepts_old_receipt_with_legacy_calibration_field(tmp_path):
+    import hashlib
+
+    import daydream.benchmark.harbor.run as run_mod
+
+    ws = _ws(tmp_path)
+    lock_sha = hashlib.sha256(
+        (ws / "harbor" / "benchmark.lock.json").read_bytes()).hexdigest()
+    receipt = run_mod._current_state_mapping(
+        ws, compiled_lock_sha256=lock_sha, env=_env())
+    receipt["calibration_receipt_sha256"] = "0" * 64  # legacy extra field
+    (ws / "harbor" / "oracle-receipt.json").write_text(json.dumps(receipt))
+    reason = run_mod._default_run_gate(
+        ws, env=_env(), compiled_lock_sha256=lock_sha)
+    assert reason is None  # legacy field is ignored, not compared
+
+
+def test_oracle_receipt_has_no_calibration_state(tmp_path):
+    import hashlib
+
+    import daydream.benchmark.harbor.run as run_mod
+
+    ws = _ws(tmp_path)
+    lock_sha = hashlib.sha256(
+        (ws / "harbor" / "benchmark.lock.json").read_bytes()).hexdigest()
+    mapping = run_mod._current_state_mapping(
+        ws, compiled_lock_sha256=lock_sha, env=_env())
+    assert "calibration_receipt_sha256" not in mapping
 
 
 def test_ledger_reviewer_effort_defaults_none_when_omitted(tmp_path):

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -99,7 +99,7 @@ def test_fresh_install_docs_have_no_plugin_step() -> None:
 
 def test_historical_records_preserved() -> None:
     expected = {
-        "CHANGELOG.md": "53bf5caac1cceaeef3cb14a1e9d7cb7cbf56f02844e0ddb41a23ddaa8f53c0f5",
+        "CHANGELOG.md": "7ee332b93b0b5db68eebf87cc85db063dd3ebdfde2c5130e34073b49f857373b",
         "benchmark/corpora/osprey-coderabbit/index.json": (
             "ff6e5f43443c1181c8b2b51c3d662c7bc2d37615cdd54240919fabe300a3c0b8"
         ),


### PR DESCRIPTION
## Summary

Closes #909

Fixes `daydream benchmark` so the Oracle does not depend on unverified calibration and honors the compiled OpenRouter network policy:

- **Drop calibration as an Oracle preflight prerequisite** — calibration receipt is no longer required before the Oracle runs; legacy receipts remain usable.
- **Decouple Oracle from unverified calibration** — calibration fixture provenance is now labeled `llm_generated` (unverified), and calibration state is dropped from the oracle mapping.
- **Harden diagnostic receipt provenance** — full-content invalidation when receipt data changes.
- **Honor OpenRouter policy** — network policy is compiled into `task.toml` (digest-locked), parameterized, and fails closed on bad host lists; Harbor preflight enforces the compiled policy. Agent and verifier host separation is enforced; forbidden hosts are rejected fail-closed.

## Test Plan

- `make check` green (lockcheck + ruff + mypy + 4652 passed / 8 skipped / 0 failed)
- Two sequential daydream deep-precision reviews passed (3 LOW findings in round 2, all resolved)