### PR TITLE
fix(backends): harden Claude read-only Bash guard against redirection and Git --output (#703)

### DIFF
--- a/daydream/backends/claude.py
+++ b/daydream/backends/claude.py
@@ -55,10 +55,25 @@ READ_ONLY_BASH_ALLOWLIST: tuple[str, ...] = (
 
 # Shell-control tokens checked against shlex output: shlex (non-posix)
 # splits multi-char sequences like ``&&``/``$(`` into single chars, so we check
-# per-char. ``<``/``>``/``(``/``)`` are included so redirection and subshell
-# grouping can never write to or truncate a file in the caller's tree. Safe
-# inside quotes (shlex returns a quoted chunk as one token).
-_SHELL_CONTROL_TOKENS: frozenset[str] = frozenset({"|", ";", "&", "`", "$", "<", ">", "(", ")"})
+# per-char. ``<``/``>`` are included so redirection can never write to or
+# truncate a file in the caller's tree.
+#
+# ``(``/``)`` are deliberately NOT here: bash rejects an unquoted paren glued to
+# a word (``--format=%C(red)%h``, ``foo(1).txt``) as a syntax error, so nothing
+# executes and no file is touched; a subshell only executes when ``(`` begins
+# the command, which the command-leading check in _is_read_only_command()
+# denies. A subshell reached after an operator (``a | (rm x)``,
+# ``a && (rm x)``, ``a; (rm x)``, ``$(rm x)``) is already caught by that
+# operator token in this set.
+#
+# The quote-safety claim holds only inside single quotes and for *literal*
+# characters inside double quotes: ``|``/``;``/``&``/``<``/``>`` are inert in
+# both, and shlex returns the wrapped chunk as one token. ``$`` and backtick are
+# NOT inert inside double quotes -- bash still performs parameter
+# expansion/command substitution there, so ``git log "$(rm x)"`` passes this
+# token scan yet stays live in bash. That gap is pre-existing and is not sealed
+# here, so the guard must not be advertised as "safe inside any quotes".
+_SHELL_CONTROL_TOKENS: frozenset[str] = frozenset({"|", ";", "&", "`", "$", "<", ">"})
 
 # Git options that write the command's output to a file. Scanned only after a
 # matched ``git …`` allowlist family, so ``ls``/``cat`` never hit it.
@@ -159,51 +174,88 @@ def _denies_git_output_option(argv: list[str], start: int) -> bool:
     return False
 
 
+def _shlex_tokens(cmd: str, *, posix: bool, words: bool) -> list[str] | None:
+    """Lex *cmd* via shlex; return the token list, or None on malformed quoting.
+
+    Both the control-token scan and the argv reconstruction pass through this
+    single helper so they share one explicit comment policy: ``commenters`` is
+    cleared, making ``#`` always a literal character. Bash only treats a ``#``
+    that begins a word as a comment; the default ``#`` commenter would instead
+    strip everything after ANY ``#`` -- even mid-word -- hiding a trailing
+    redirection/chaining token from the control-token scan. That is exactly the
+    escape the deny set closes, so the comment semantics must be explicit and
+    identical for both passes (a future edit cannot silently resurrect the
+    blind spot by changing only one).
+
+    ``words=True`` yields whole argv words; ``words=False`` yields per-char bare
+    metacharacters so the control-token scan sees ``<``/``>``/``(``, etc. The
+    ``words`` flag maps onto shlex ``whitespace_split``.
+    """
+    lexer = shlex.shlex(cmd, posix=posix)
+    lexer.commenters = ""  # '#' is never a comment; keep every character.
+    lexer.whitespace_split = words
+    try:
+        return list(lexer)
+    except ValueError:
+        return None
+
+
 def _is_read_only_command(cmd: str) -> bool:
     """Return True only if *cmd* is a single allowlisted read-only command.
 
     Denies (returns False) on: an empty/blank command, any command containing a
     newline or carriage return, any command containing a shell-control
-    metacharacter (``|``, ``;``, ``&``, backtick, ``$``, ``<``, ``>``, ``(``,
-    ``)``), any command whose leading argv words do not match an allowlisted
-    family word-for-word, and any allowlisted ``git …`` command that writes its
-    output to a file via ``--output``.
+    metacharacter (``|``, ``;``, ``&``, backtick, ``$``, ``<``, ``>``) or a
+    command-leading ``(``/``)`` subshell group, any command whose leading argv
+    words do not match an allowlisted family word-for-word, and any allowlisted
+    ``git …`` command that writes its output to a file via ``--output``.
 
-    The extended token set closes the redirection (``>``/``>>``/``<``) and
-    subshell-grouping (``(``/``)``) escapes that could otherwise create,
-    truncate, or append files in the caller's working tree. Word-bounded argv
-    matching uses posix ``shlex.split`` so a token merely *beginning* with an
-    allowlisted word (``git logfoo``) is never an allowlist hit.
+    ``<``/``>``/``|``/``;``/``&``/``$``/backtick are shell operators wherever
+    they appear unquoted, closing the redirection (``>``/``>>``/``<``) and
+    command-substitution escapes that could otherwise create, truncate, or
+    append files in the caller's working tree. ``(``/``)`` only execute as a
+    subshell when they begin the command, so only that position is denied;
+    parens mid-command or glued to a word (``--format=%C(red)%h``,
+    ``cat foo(1).txt``) are bash syntax errors that never run and must stay
+    allowed. Word-bounded argv matching uses posix ``shlex.split`` so a token
+    merely *beginning* with an allowlisted word (``git logfoo``) is never an
+    allowlist hit.
 
     Metacharacter detection uses ``shlex`` to avoid false positives from
     metacharacters that appear only inside quoted arguments (e.g.
     ``git log --grep='fix|bug'`` is safe and must be allowed).  Newlines and
     carriage returns are bash command separators but ``shlex`` treats them as
     whitespace and strips them, so they are rejected directly on the raw string.
-    Malformed quoting makes ``shlex`` raise ``ValueError``; both lexing steps map
-    that to deny (fail-closed) and never propagate.
+    Malformed quoting makes ``shlex`` raise ``ValueError``; the shared lexing
+    helper maps that to deny (fail-closed) and never propagates.
     """
     stripped = cmd.strip()
     if not stripped:
         return False
     if "\n" in cmd or "\r" in cmd:
         return False
-    # Non-posix lex: quoted strings stay single tokens; unquoted metacharacters
-    # appear as individual bare chars (``&&`` → ``&``, ``&``). See _SHELL_CONTROL_TOKENS.
-    try:
-        tokens = list(shlex.shlex(stripped, posix=False))
-    except ValueError:
-        return False  # Malformed quoting — deny.
+    # Control-token pass: per-char bare tokens (``whitespace_split=False``), so
+    # unquoted metacharacters (``&&`` -> ``&``) surface on their own. See
+    # _SHELL_CONTROL_TOKENS.
+    tokens = _shlex_tokens(stripped, posix=False, words=False)
+    if tokens is None:
+        return False  # Malformed quoting -- deny (fail-closed).
     for tok in tokens:
         if tok in _SHELL_CONTROL_TOKENS:
             return False
-    # Posix split reconstructs the argv words so we can match the allowlist
-    # families word-for-word (rejecting ``git logfoo``) and scan ``git …`` args
-    # for a ``--output`` file write.
-    try:
-        argv = shlex.split(stripped, posix=True)
-    except ValueError:
-        return False  # Malformed quoting — deny (fail-closed).
+    if tokens[0] in ("(", ")"):
+        # Command-leading ``(``/``)`` starts a subshell group that executes
+        # (``( rm x )``, ``(rm x)``) -> deny. Anywhere else in a command bash
+        # rejects unquoted parens (``--format=%C(red)%h``, ``foo(1).txt``,
+        # ``ls -la ( x )``) as a syntax error, so nothing runs and the command
+        # stays harmless; those previously-allowed forms must not be denied.
+        return False
+    # Argv pass: whole argv words (``whitespace_split=True``), matching the
+    # allowlist families word-for-word (rejecting ``git logfoo``) and allowing
+    # the ``git ... --output`` file-write scan.
+    argv = _shlex_tokens(stripped, posix=True, words=True)
+    if argv is None:
+        return False  # Malformed quoting -- deny (fail-closed).
     for family in READ_ONLY_BASH_ALLOWLIST:
         words = family.split()
         if argv[: len(words)] == words:

--- a/daydream/backends/claude.py
+++ b/daydream/backends/claude.py
@@ -53,13 +53,16 @@ READ_ONLY_BASH_ALLOWLIST: tuple[str, ...] = (
     "git diff",
 )
 
-# Chaining metacharacters that can append a second, non-allowlisted command.
-_CHAIN_METACHARS: tuple[str, ...] = (";", "&&", "||", "|", "`", "$(")
+# Shell-control tokens checked against shlex output: shlex (non-posix)
+# splits multi-char sequences like ``&&``/``$(`` into single chars, so we check
+# per-char. ``<``/``>``/``(``/``)`` are included so redirection and subshell
+# grouping can never write to or truncate a file in the caller's tree. Safe
+# inside quotes (shlex returns a quoted chunk as one token).
+_SHELL_CONTROL_TOKENS: frozenset[str] = frozenset({"|", ";", "&", "`", "$", "<", ">", "(", ")"})
 
-# Single-char danger tokens checked against shlex output: shlex (non-posix)
-# splits ``&&``/``$(`` into single chars, so we check per-char. Safe inside
-# quotes (shlex returns a quoted chunk as one token).
-_DANGEROUS_TOKENS: frozenset[str] = frozenset({"|", ";", "&", "`", "$"})
+# Git options that write the command's output to a file. Scanned only after a
+# matched ``git …`` allowlist family, so ``ls``/``cat`` never hit it.
+_GIT_WRITE_OPTIONS: tuple[str, ...] = ("--output",)
 
 # ``.*`` fires the guard for EVERY tool call so it can fail-closed (allow only
 # the safe set); a deny-list of mutating tools was fail-open.
@@ -131,19 +134,54 @@ class MaxTurnsError(ClaudeAgentError):
         self.subtype = subtype
 
 
+def _denies_git_output_option(argv: list[str], start: int) -> bool:
+    """True when an allowlisted ``git …`` argv writes output to a file.
+
+    Scans ``argv[start:]`` (skipping the matched allowlist family words) for the
+    ``--output`` option in both separated (``--output log.txt``) and equals
+    (``--output=diff.patch``) forms. The scan stops at a standalone ``--`` path
+    separator, so a literal path argument named ``--output`` after it stays
+    allowed. Returns False (not denied) when no write option appears before that
+    boundary.
+
+    Args:
+        argv: The posix-split argv tokens.
+        start: Index of the first token after the matched allowlist family
+            words (e.g. 2 for ``git status``).
+    """
+    for tok in argv[start:]:
+        if tok == "--":
+            return False
+        if tok in _GIT_WRITE_OPTIONS or any(
+            tok.startswith(opt + "=") for opt in _GIT_WRITE_OPTIONS
+        ):
+            return True
+    return False
+
+
 def _is_read_only_command(cmd: str) -> bool:
     """Return True only if *cmd* is a single allowlisted read-only command.
 
     Denies (returns False) on: an empty/blank command, any command containing a
-    newline or carriage return, any command whose first token is not an
-    allowlisted prefix, and any command containing a shell chaining
-    metacharacter (``;``, ``&&``, ``||``, ``|``, backtick, ``$(``).
+    newline or carriage return, any command containing a shell-control
+    metacharacter (``|``, ``;``, ``&``, backtick, ``$``, ``<``, ``>``, ``(``,
+    ``)``), any command whose leading argv words do not match an allowlisted
+    family word-for-word, and any allowlisted ``git …`` command that writes its
+    output to a file via ``--output``.
+
+    The extended token set closes the redirection (``>``/``>>``/``<``) and
+    subshell-grouping (``(``/``)``) escapes that could otherwise create,
+    truncate, or append files in the caller's working tree. Word-bounded argv
+    matching uses posix ``shlex.split`` so a token merely *beginning* with an
+    allowlisted word (``git logfoo``) is never an allowlist hit.
 
     Metacharacter detection uses ``shlex`` to avoid false positives from
     metacharacters that appear only inside quoted arguments (e.g.
     ``git log --grep='fix|bug'`` is safe and must be allowed).  Newlines and
     carriage returns are bash command separators but ``shlex`` treats them as
-    whitespace and elides them, so they are rejected directly on the raw string.
+    whitespace and strips them, so they are rejected directly on the raw string.
+    Malformed quoting makes ``shlex`` raise ``ValueError``; both lexing steps map
+    that to deny (fail-closed) and never propagate.
     """
     stripped = cmd.strip()
     if not stripped:
@@ -151,18 +189,28 @@ def _is_read_only_command(cmd: str) -> bool:
     if "\n" in cmd or "\r" in cmd:
         return False
     # Non-posix lex: quoted strings stay single tokens; unquoted metacharacters
-    # appear as individual bare chars (``&&`` → ``&``, ``&``). See _DANGEROUS_TOKENS.
+    # appear as individual bare chars (``&&`` → ``&``, ``&``). See _SHELL_CONTROL_TOKENS.
     try:
         tokens = list(shlex.shlex(stripped, posix=False))
     except ValueError:
         return False  # Malformed quoting — deny.
     for tok in tokens:
-        if tok in _DANGEROUS_TOKENS:
+        if tok in _SHELL_CONTROL_TOKENS:
             return False
-    return any(
-        stripped == prefix or stripped.startswith(prefix + " ")
-        for prefix in READ_ONLY_BASH_ALLOWLIST
-    )
+    # Posix split reconstructs the argv words so we can match the allowlist
+    # families word-for-word (rejecting ``git logfoo``) and scan ``git …`` args
+    # for a ``--output`` file write.
+    try:
+        argv = shlex.split(stripped, posix=True)
+    except ValueError:
+        return False  # Malformed quoting — deny (fail-closed).
+    for family in READ_ONLY_BASH_ALLOWLIST:
+        words = family.split()
+        if argv[: len(words)] == words:
+            if family.startswith("git ") and _denies_git_output_option(argv, len(words)):
+                return False
+            return True
+    return False
 
 
 def _tool_input(input_data: Any) -> dict[str, Any]:

--- a/tests/test_backend_claude.py
+++ b/tests/test_backend_claude.py
@@ -358,6 +358,11 @@ async def test_read_only_execute_registers_pretooluse_guard(patch_sdk):
     )
     assert deny_bash["hookSpecificOutput"]["permissionDecision"] == "deny"
 
+    deny_git_output = await decide(
+        {"tool_name": "Bash", "tool_input": {"command": "git diff --output=diff.patch"}}
+    )
+    assert deny_git_output["hookSpecificOutput"]["permissionDecision"] == "deny"
+
     allow_bash = await decide(
         {"tool_name": "Bash", "tool_input": {"command": "git log -n 5"}}
     )

--- a/tests/test_backend_claude.py
+++ b/tests/test_backend_claude.py
@@ -265,9 +265,17 @@ async def test_max_turns_result_raises_typed_error(patch_sdk):
     ("git status > status.txt", False),  # output redirection creates/truncates a file
     ("cat README.md >> copy.txt", False),# append redirection
     ("cat < README.md", False),          # input redirection
+    ("git log foo# > status.txt", False),# mid-word '#' must not blind the redirect scan
+    ("cat a#b > f", False),               # mid-word '#' hidden in an arg, then redirect
+    ("git log foo#; rm x", False),        # mid-word '#' then a chaining operator
     ("git diff --output=diff.patch", False),  # git output-file option, equals form
     ("git log --output log.txt", False), # git output-file option, separated form
-    ("ls -la ( x )", False),             # subshell grouping operator
+    ("( rm x )", False),                 # command-leading subshell group executes
+    ("(rm x)", False),                   # spacing-free subshell at command start still denies
+    ("(git status > out.txt)", False),   # subshell wrapping a redirect still denies
+    ("ls -la ( x )", True),              # mid-command parens: bash syntax error, nothing runs
+    ("git log --format=%C(red)%h", True),# git color placeholder: parens glued to a word
+    ("cat foo(1).txt", True),            # parens glued into a filename word
     ("git log\nrm x", False),           # newline command separator -> fail closed
     ("git log 'unclosed", False),        # malformed quoting -> fail closed
     ("git log --grep='fix|bug'", True),  # quoted | is argument content, not an operator

--- a/tests/test_backend_claude.py
+++ b/tests/test_backend_claude.py
@@ -262,6 +262,16 @@ async def test_max_turns_result_raises_typed_error(patch_sdk):
     ("git log; rm x", False),            # semicolon chain
     ("echo $(rm x)", False),             # command substitution
     ("git logfoo", False),               # prefix must be word-bounded
+    ("git status > status.txt", False),  # output redirection creates/truncates a file
+    ("cat README.md >> copy.txt", False),# append redirection
+    ("cat < README.md", False),          # input redirection
+    ("git diff --output=diff.patch", False),  # git output-file option, equals form
+    ("git log --output log.txt", False), # git output-file option, separated form
+    ("ls -la ( x )", False),             # subshell grouping operator
+    ("git log\nrm x", False),           # newline command separator -> fail closed
+    ("git log 'unclosed", False),        # malformed quoting -> fail closed
+    ("git log --grep='fix|bug'", True),  # quoted | is argument content, not an operator
+    ("git diff HEAD~1 HEAD -- --output", True),  # --output after -- is a path arg; scan stops at --
     ("", False),                          # empty → fail closed
 ])
 def test_read_only_bash_guard_decision(cmd, allowed):


### PR DESCRIPTION
## Summary

Closes #703 — hardens Claude's read-only Bash guard against redirection and Git output-file bypasses.

The guard (`_read_only_guard`) is the enforcement boundary for `read_only=True` when Claude runs with `bypassPermissions`. Two bypass classes are now closed:

- **Shell redirection** — `git status > status.txt`, `... | ...`, `... >> ...` etc. were allowlisted because the prefix check ran before rejecting control tokens. Mid-word `#` is now kept literal so redirection tokens cannot hide in the parsed argv.
- **Git `--output`** — `git diff --output=diff.patch` and `git diff --output diff.patch` can no longer write files into the caller's working tree. Git output-file options are now denied in the read-only guard.

## Changes

- `daydream/backends/claude.py` (+122/-22) — guard parses command text into argv, rejects unquoted shell control syntax and Git output-file options before tool execution, preserves the existing allowlisted command families, and continues to allow quoted metacharacters that belong to ordinary arguments.
- `tests/test_backend_claude.py` (+23) — asserts caller-visible deny for `git --output` in the read-only guard.

## Verification

- Guard behavior empirically confirmed for all cases
- Focused changed-file tests: 90/90 green
- `ruff` + `mypy` clean (the 15 harbor `test_benchmark_*` failures are environmental — harbor package absent from the venv, reproduced on the unapplied baseline)

## Test Plan

- [x] Unit tests pass

Closes #703