### PR TITLE
fix(benchmark): run private Harbor flow on Docker Desktop

### DIFF
--- a/daydream/backends/pi.py
+++ b/daydream/backends/pi.py
@@ -82,6 +82,7 @@ _PI_EVENT_TYPES: frozenset[str] = frozenset(
 _PI_READ_ONLY_TOOLS = "read,find,ls,grep"
 
 _PI_PROVIDER_API_KEY_ENV = {
+    "openrouter": "OPENROUTER_API_KEY",
     "zai": "ZAI_API_KEY",
     "nous": "NOUS_API_KEY",
 }

--- a/daydream/benchmark/cli.py
+++ b/daydream/benchmark/cli.py
@@ -482,9 +482,9 @@ def _build_benchmark_parser() -> argparse.ArgumentParser:
 
     validate_p = sub.add_parser("validate", help="validate the workspace (0/2/1 exit codes)")
     validate_p.add_argument("dir", type=Path, help="workspace directory")
-    validate_p.add_argument("--compiled", action="store_true", help="validate emitted tasks with Harbor 0.21")
+    validate_p.add_argument("--compiled", action="store_true", help="validate emitted tasks with Harbor 0.22")
 
-    build_p = sub.add_parser("build-harbor", help="package a validated workspace for Harbor 0.21")
+    build_p = sub.add_parser("build-harbor", help="package a validated workspace for Harbor 0.22")
     build_p.add_argument("dir", type=Path, help="workspace directory")
     build_p.add_argument("--daydream-wheel", required=True, type=Path, help="wheel for this Daydream version")
 

--- a/daydream/benchmark/harbor/agent.py
+++ b/daydream/benchmark/harbor/agent.py
@@ -1,6 +1,6 @@
 """Harbor ``BaseAgent`` that reviews a frozen private-PR snapshot in-container (issue #780).
 
-``DaydreamReviewAgent`` runs host-side: it guarantees the Claude backend, builds
+``DaydreamReviewAgent`` runs host-side: it guarantees the Pi/OpenRouter backend, builds
 a fail-closed allowlist child environment, and invokes the controlled
 in-container entrypoint (``daydream.benchmark.harbor.entrypoint``) via
 ``environment.exec``. The entrypoint runs the real Daydream runner in-process
@@ -43,9 +43,18 @@ _BANNED_VARS = (
     "DAYDREAM_ARCHIVE_DIR",
     "ANTHROPIC_API_KEY",
     "ANTHROPIC_BASE_URL",
+    "OPENROUTER_API_KEY",
+    "PI_API_KEY",
 )
-# Judge vars and any raw Anthropic SDK vars must never leak into the child env.
-_BANNED_PREFIXES = ("DAYDREAM_JUDGE_", "ANTHROPIC_")
+# Judge vars and raw provider credentials must never leak into the child env.
+_BANNED_PREFIXES = (
+    "DAYDREAM_JUDGE_",
+    "ANTHROPIC_",
+    "MARTIAN_",
+    "OPENAI_",
+    "OPENROUTER_",
+    "PI_",
+)
 
 
 class DaydreamReviewAgent(BaseAgent):  # type: ignore[misc]
@@ -72,15 +81,16 @@ class DaydreamReviewAgent(BaseAgent):  # type: ignore[misc]
 
     async def setup(self, environment: Any) -> None:
         """Network-free setup: confirm the container installs this exact Daydream
-        release and the Claude backend SDK (``claude_agent_sdk``).
+        release and the Pi CLI.
 
         A single ``environment.exec`` runs an in-container Python probe; a
         non-zero exec return (missing exact version or missing backend SDK)
         raises :class:`AgentError` -- never a silent pass.
         """
         probe = (
-            "import importlib.metadata, claude_agent_sdk;"
+            "import importlib.metadata, shutil;"
             f"assert importlib.metadata.version('daydream') == {self.version()!r};"
+            "assert shutil.which('pi') is not None;"
         )
         command = 'python -X utf8 -c "' + probe + '"'
         result = await environment.exec(command)
@@ -98,17 +108,17 @@ class DaydreamReviewAgent(BaseAgent):  # type: ignore[misc]
     ) -> None:
         """Review the frozen snapshot in-container.
 
-        Fail-closed: refuses any backend other than ``claude`` *before* any
+        Fail-closed: refuses any backend other than ``pi`` *before* any
         reviewing (never installs tools or widens network access), maps the
         allowlist child environment, and invokes the controlled entrypoint. A
         non-zero entrypoint return raises :class:`AgentError`.
         """
         if not _HARBOR:
             raise AgentError("Harbor is not installed; install 'daydream[benchmark]'")
-        backend = (self.extra_env.get("DAYDREAM_REVIEW_BACKEND") or "claude").strip().lower()
-        if backend != "claude":
+        backend = (self.extra_env.get("DAYDREAM_REVIEW_BACKEND") or "pi").strip().lower()
+        if backend != "pi":
             raise AgentError(
-                f"unsupported DAYDREAM_REVIEW_BACKEND={backend!r}; only 'claude' is supported"
+                f"unsupported DAYDREAM_REVIEW_BACKEND={backend!r}; only 'pi' is supported"
             )
         parent = {**os.environ, **self.extra_env}
         child_env = build_child_env(parent)
@@ -157,7 +167,7 @@ def build_child_env(parent_env: Mapping[str, str]) -> dict[str, str]:
 
     Keeps only ``DAYDREAM_REVIEW_*`` reviewer config/credential plus the required
     process variables, then explicitly drops the banned variables (GitHub/HF/judge/
-    archive and raw Anthropic SDK vars) so any future secret-holding variable not in
+    archive and raw provider vars) so any future secret-holding variable not in
     the keep-set still cannot leak by default. Never passes the parent env wholesale.
 
     The review-profile candidate (``DAYDREAM_REVIEW_PROFILE_CANDIDATE``, issue

--- a/daydream/benchmark/harbor/build.py
+++ b/daydream/benchmark/harbor/build.py
@@ -861,6 +861,9 @@ def compile_workspace(root: Path, *, wheel: Path | None = None) -> dict:
         for case_file, doc in workspace.load_case_documents(root, manifest_model).items():
             dumped = doc.model_dump(mode="json")
             case_id = dumped["case_id"]
+            if (dumped.get("curation") or {}).get("state") == "excluded":
+                case_docs[case_id] = dumped
+                continue
             if not _is_compilable(dumped.get("curation") or {}):
                 curation = dumped.get("curation") or {}
                 raise CompileError(
@@ -887,6 +890,8 @@ def compile_workspace(root: Path, *, wheel: Path | None = None) -> dict:
                         f"case {case_id} index row has no matching case document "
                         "(row case_id disagrees with the case document's own case_id)"
                     )
+                if (case_doc.get("curation") or {}).get("state") == "excluded":
+                    continue
                 row = _compile_case(
                     stage,
                     root,

--- a/daydream/benchmark/harbor/calibrate.py
+++ b/daydream/benchmark/harbor/calibrate.py
@@ -148,12 +148,15 @@ def _build_calibration_client(env: dict[str, Any], *, http: Any = None) -> Any:
 def _judge_host_from_env(env: dict[str, Any]) -> str:
     """Return the normalized-lowercase judge host for ``env``.
 
-    The anthropic provider (or absent -> anthropic default) always routes to
-    ``api.anthropic.com``; the openai-compatible provider resolves its base URL
-    via the packaged ``resolve_base_url`` and returns that URL's host.
+    An explicit anthropic provider routes to ``api.anthropic.com``; the
+    openai-compatible provider resolves its base URL via the packaged
+    ``resolve_base_url`` and returns that URL's host. Missing providers fail
+    closed rather than selecting an implicit API.
     """
     sr = _load_judge_template()
-    provider = env.get("DAYDREAM_JUDGE_PROVIDER") or "anthropic"
+    provider = env.get("DAYDREAM_JUDGE_PROVIDER") or ""
+    if not provider:
+        raise ValueError("missing DAYDREAM_JUDGE_PROVIDER")
     if provider == "anthropic":
         return "api.anthropic.com"
     base_url = sr.resolve_base_url(
@@ -372,7 +375,7 @@ def _invalidation_inputs(
     reorder of the ordered triples.
     """
     inputs = {
-        "provider": env.get("DAYDREAM_JUDGE_PROVIDER") or "anthropic",
+        "provider": env.get("DAYDREAM_JUDGE_PROVIDER") or "",
         "model": env.get("DAYDREAM_JUDGE_MODEL") or "",
         "host": _judge_host_from_env(env),
         "judge_prompt_sha256": _render_judge_prompt_digest(sr),

--- a/daydream/benchmark/harbor/calibrate.py
+++ b/daydream/benchmark/harbor/calibrate.py
@@ -149,16 +149,23 @@ def _judge_host_from_env(env: dict[str, Any]) -> str:
     """Return the normalized-lowercase judge host for ``env``.
 
     An explicit anthropic provider routes to ``api.anthropic.com``; the
-    openai-compatible provider resolves its base URL via the packaged
-    ``resolve_base_url`` and returns that URL's host. Missing providers fail
-    closed rather than selecting an implicit API.
+    openai-compatible provider requires an explicit base URL, resolves it via
+    the packaged ``resolve_base_url``, and returns that URL's host. Missing
+    providers fail closed rather than selecting an implicit API.
     """
     sr = _load_judge_template()
     provider = env.get("DAYDREAM_JUDGE_PROVIDER") or ""
     if not provider:
         raise ValueError("missing DAYDREAM_JUDGE_PROVIDER")
+    if provider not in {"anthropic", "openai-compatible"}:
+        raise ValueError(
+            f"unsupported DAYDREAM_JUDGE_PROVIDER '{provider}'; "
+            "expected anthropic or openai-compatible"
+        )
     if provider == "anthropic":
         return "api.anthropic.com"
+    if not env.get("DAYDREAM_JUDGE_BASE_URL"):
+        raise ValueError("missing DAYDREAM_JUDGE_BASE_URL for openai-compatible provider")
     base_url = sr.resolve_base_url(
         env.get("DAYDREAM_JUDGE_API_KEY") or "", env.get("DAYDREAM_JUDGE_BASE_URL")
     )
@@ -502,8 +509,8 @@ def run_calibration(
     except storage.WorkspaceCorrupt as exc:
         print(str(exc), file=sys.stderr)
         return 1
-    host = _judge_host_from_env(env)
     try:
+        host = _judge_host_from_env(env)
         _validate_workspace_host(allowlist, host)
     except ValueError as exc:
         print(str(exc), file=sys.stderr)

--- a/daydream/benchmark/harbor/candidate.py
+++ b/daydream/benchmark/harbor/candidate.py
@@ -35,6 +35,23 @@ class CandidateError(Exception):
         self.kind = kind
 
 
+def _candidate_title(description: str) -> str:
+    """Return a verifier-bounded display title without dropping review content.
+
+    Canonical Daydream descriptions can be paragraph-length. The full text is
+    retained in the candidate body; the title uses its first non-empty line and
+    is shortened deterministically only when that line exceeds the verifier's
+    500-character display bound.
+    """
+    first_line = next(
+        (line.strip() for line in description.splitlines() if line.strip()),
+        description.strip(),
+    )
+    if len(first_line) <= 500:
+        return first_line
+    return first_line[:497].rstrip() + "..."
+
+
 def _assemble_body(fields: Any) -> str:
     """Assemble the candidate body exactly like ``benchmark.mapping``.
 
@@ -79,7 +96,7 @@ def build_candidate_findings(items: list[dict], *, case_id: str) -> list[dict]:
             continue
         if fields.line_int is None or fields.line_int < 1:
             continue
-        title = fields.description
+        title = _candidate_title(fields.description)
         body = _assemble_body(fields)
         if not title.strip() or not body.strip():
             continue
@@ -94,7 +111,7 @@ def build_candidate_findings(items: list[dict], *, case_id: str) -> list[dict]:
         # Enforce the verifier's per-finding bounds fail-closed, reusing the
         # verifier's own validators so no drift surfaces as a verifier-rejected
         # artifact after the builder already declared success: an over-long
-        # title (>500 chars) or body (>8 KiB), a non-enum severity, a
+        # body (>8 KiB), a non-enum severity, a
         # rooted/'..'-containing/NUL path, or a non-positive/non-ascending
         # line range are each a typed failure, never an artifact the verifier
         # would reject (``_validate_location`` re-checks path + lines on parse).

--- a/daydream/benchmark/harbor/entrypoint.py
+++ b/daydream/benchmark/harbor/entrypoint.py
@@ -20,6 +20,7 @@ import asyncio
 import json
 import os
 import sys
+import urllib.parse
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -126,21 +127,27 @@ def apply_reviewer_env(env: Mapping[str, str] | None = None) -> None:
     """Map only reviewer config/credential into the Claude SDK env.
 
     Propagates ``DAYDREAM_REVIEW_API_KEY``/``DAYDREAM_REVIEW_BASE_URL`` into
-    ``ANTHROPIC_API_KEY``/``ANTHROPIC_BASE_URL`` on ``os.environ``; never
-    silently substitutes a default credential.  Any pre-existing raw
-    ``ANTHROPIC_*``/``DAYDREAM_JUDGE_*`` credential is cleared first so a
-    host-inherited secret cannot leak into the reviewed scope.
+    the Claude SDK's ``ANTHROPIC_*`` variables on ``os.environ``; OpenRouter
+    uses its required ``ANTHROPIC_AUTH_TOKEN`` route and an explicitly empty
+    ``ANTHROPIC_API_KEY``.  Any pre-existing raw ``ANTHROPIC_*``/
+    ``DAYDREAM_JUDGE_*`` credential is cleared first so a host-inherited secret
+    cannot leak into the reviewed scope.
     """
     source = dict(os.environ if env is None else env)
     for prefix in ("DAYDREAM_JUDGE_", "ANTHROPIC_"):
         for key in [k for k in os.environ if k.startswith(prefix)]:
             os.environ.pop(key, None)
     api_key = source.get(_API_KEY_ENV)
-    if api_key:
-        os.environ["ANTHROPIC_API_KEY"] = api_key
     base_url = source.get(_BASE_URL_ENV)
     if base_url:
         os.environ["ANTHROPIC_BASE_URL"] = base_url
+    host = (urllib.parse.urlsplit(base_url).hostname or "").lower()
+    if host == "openrouter.ai":
+        if api_key:
+            os.environ["ANTHROPIC_AUTH_TOKEN"] = api_key
+        os.environ["ANTHROPIC_API_KEY"] = ""
+    elif api_key:
+        os.environ["ANTHROPIC_API_KEY"] = api_key
 
 
 def _required_env(name: str) -> str:

--- a/daydream/benchmark/harbor/entrypoint.py
+++ b/daydream/benchmark/harbor/entrypoint.py
@@ -3,8 +3,8 @@
 Invoked inside the Harbor task container (``python -m
 daydream.benchmark.harbor.entrypoint``) by :class:`DaydreamReviewAgent`'s
 ``run`` via ``environment.exec``. Owns the fail-closed review surface: it maps
-only the ``DAYDREAM_REVIEW_*`` reviewer config/credential into the Anthropic
-SDK env, refuses any unsupported backend *before* reviewing, runs the real
+only the ``DAYDREAM_REVIEW_*`` reviewer config/credential into Pi's native
+OpenRouter env, refuses any unsupported backend *before* reviewing, runs the real
 Daydream runner **in-process** against the frozen ``base``/``head`` snapshot
 with a fully controlled :class:`RunConfig` (review-only, non-interactive,
 archiving and eval disabled, empty file config), then publishes the canonical
@@ -109,45 +109,60 @@ def build_run_config(
     return config
 
 
-def require_supported_backend() -> None:
-    """Refuse any backend other than ``claude``, before any reviewing.
+def require_supported_backend() -> str:
+    """Refuse any backend other than ``pi``, before any reviewing.
 
-    Reads ``DAYDREAM_REVIEW_BACKEND`` (default ``"claude"``). An unsupported
+    Reads ``DAYDREAM_REVIEW_BACKEND`` (default ``"pi"``). An unsupported
     backend raises :class:`EntrypointError` before tools are installed or
     network access is widened.
     """
-    backend = os.environ.get(_BACKEND_ENV, "claude").strip().lower()
-    if backend != "claude":
+    backend = os.environ.get(_BACKEND_ENV, "pi").strip().lower()
+    if backend != "pi":
         raise EntrypointError(
-            f"unsupported DAYDREAM_REVIEW_BACKEND={backend!r}; only 'claude' is supported"
+            f"unsupported DAYDREAM_REVIEW_BACKEND={backend!r}; only 'pi' is supported"
         )
+    return backend
 
 
 def apply_reviewer_env(env: Mapping[str, str] | None = None) -> None:
-    """Map only reviewer config/credential into the Claude SDK env.
+    """Map only reviewer config/credential into Pi's OpenRouter env.
 
-    Propagates ``DAYDREAM_REVIEW_API_KEY``/``DAYDREAM_REVIEW_BASE_URL`` into
-    the Claude SDK's ``ANTHROPIC_*`` variables on ``os.environ``; OpenRouter
-    uses its required ``ANTHROPIC_AUTH_TOKEN`` route and an explicitly empty
-    ``ANTHROPIC_API_KEY``.  Any pre-existing raw ``ANTHROPIC_*``/
-    ``DAYDREAM_JUDGE_*`` credential is cleared first so a host-inherited secret
-    cannot leak into the reviewed scope.
+    The Harbor reviewer is intentionally OpenRouter-only. The control-plane
+    credential becomes Pi's generic ``PI_API_KEY`` and the Daydream Pi backend
+    maps it to ``OPENROUTER_API_KEY`` only in the child process. Any inherited
+    raw provider or judge credential is cleared first so it cannot leak into
+    the reviewed scope. A non-HTTPS or non-OpenRouter base URL fails closed.
     """
     source = dict(os.environ if env is None else env)
-    for prefix in ("DAYDREAM_JUDGE_", "ANTHROPIC_"):
+    for prefix in (
+        "DAYDREAM_JUDGE_",
+        "ANTHROPIC_",
+        "MARTIAN_",
+        "OPENAI_",
+        "OPENROUTER_",
+        "PI_",
+    ):
         for key in [k for k in os.environ if k.startswith(prefix)]:
             os.environ.pop(key, None)
-    api_key = source.get(_API_KEY_ENV)
-    base_url = source.get(_BASE_URL_ENV)
-    if base_url:
-        os.environ["ANTHROPIC_BASE_URL"] = base_url
-    host = (urllib.parse.urlsplit(base_url).hostname or "").lower()
-    if host == "openrouter.ai":
-        if api_key:
-            os.environ["ANTHROPIC_AUTH_TOKEN"] = api_key
-        os.environ["ANTHROPIC_API_KEY"] = ""
-    elif api_key:
-        os.environ["ANTHROPIC_API_KEY"] = api_key
+    api_key = (source.get(_API_KEY_ENV) or "").strip()
+    base_url = (source.get(_BASE_URL_ENV) or "").strip()
+    parsed = urllib.parse.urlsplit(base_url)
+    if (
+        parsed.scheme.lower() != "https"
+        or (parsed.hostname or "").lower() != "openrouter.ai"
+        or parsed.username is not None
+        or parsed.password is not None
+    ):
+        raise EntrypointError(
+            "DAYDREAM_REVIEW_BASE_URL must be an HTTPS openrouter.ai endpoint"
+        )
+    if not api_key:
+        raise EntrypointError(
+            "missing required environment variable 'DAYDREAM_REVIEW_API_KEY'"
+        )
+    os.environ["PI_PROVIDER"] = "openrouter"
+    os.environ["PI_API_KEY"] = api_key
+    os.environ["PI_TELEMETRY"] = "0"
 
 
 def _required_env(name: str) -> str:
@@ -214,7 +229,7 @@ async def main(*, monkeypatch_env: Mapping[str, str] | None = None) -> int:
             os.environ[key] = value
     try:
         apply_reviewer_env()
-        require_supported_backend()
+        backend = require_supported_backend()
         case_id = _required_env(_CASE_ID_ENV)
         repo_dir = os.environ.get(_REPO_DIR_ENV, _DEFAULT_REPO_DIR)
         artifact_path = os.environ.get(_ARTIFACT_PATH_ENV, _DEFAULT_ARTIFACT_PATH)
@@ -224,7 +239,7 @@ async def main(*, monkeypatch_env: Mapping[str, str] | None = None) -> int:
         config = build_run_config(
             repo_dir=repo_dir,
             trajectory_path=trajectory_path,
-            backend="claude",
+            backend=backend,
             model=os.environ.get("DAYDREAM_REVIEW_MODEL"),
             base_ref=base_ref,
         )

--- a/daydream/benchmark/harbor/objective.py
+++ b/daydream/benchmark/harbor/objective.py
@@ -557,9 +557,14 @@ def _bind_identity(
         reviewer_effort=entry.get("reviewer_effort"),
         judge_provider=entry.get("judge_provider")
         or env.get("DAYDREAM_JUDGE_PROVIDER")
-        or "anthropic",
+        or "",
         judge_model=entry.get("judge_model") or env.get("DAYDREAM_JUDGE_MODEL") or "",
-        judge_host=entry.get("judge_host") or calibrate._judge_host_from_env(env) or "",
+        judge_host=entry.get("judge_host")
+        or (
+            calibrate._judge_host_from_env(env)
+            if env.get("DAYDREAM_JUDGE_PROVIDER")
+            else ""
+        ),
         verifier_template_sha256=calibrate._render_judge_prompt_digest(judge_template),
         threshold=verifier_core.CONFIDENCE_THRESHOLD,
         attempts=attempts,

--- a/daydream/benchmark/harbor/package.py
+++ b/daydream/benchmark/harbor/package.py
@@ -1,7 +1,8 @@
-"""Package compiled benchmark tasks for Harbor 0.21."""
+"""Package compiled benchmark tasks for Harbor 0.22."""
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import importlib.metadata
 import importlib.resources
@@ -23,6 +24,11 @@ GENERATION_COMMAND = "uv export --frozen --no-dev --no-emit-project --format req
 _BASE_DIGEST = "sha256:876416ecde9aca2bcc90e1fb0c7a9500bbf749f5788b70f82d4c5a5c2357f8b4"
 ENV_BASE_IMAGE = f"python:3.12-slim@{_BASE_DIGEST}"
 VERIFIER_BASE_IMAGE = ENV_BASE_IMAGE
+PI_BASE_IMAGE = (
+    "node:24.18.1-bookworm-slim@"
+    "sha256:a09aabc645e86e81e23dab78e0c0f2eaa233cab4277c7188232181a1a8bd5d39"
+)
+PI_PACKAGE = "@earendil-works/pi-coding-agent@0.84.3"
 
 # Marker comment pair delimiting the wheel-install block of the environment
 # Dockerfile template. render_environment_dockerfile strips the delimited block
@@ -48,6 +54,15 @@ class WheelInfo:
     distribution: str
     version: str
     sha256: str
+
+
+@dataclass(frozen=True)
+class DockerNetworkPolicyCapability:
+    """Result of loading Harbor's real Docker egress-control ruleset."""
+
+    supported: bool
+    reason: str = ""
+    image_name: str | None = None
 
 
 def validate_wheel(wheel_path: Path, *, daydream_version: str) -> WheelInfo:
@@ -86,12 +101,12 @@ def resolve_harbor() -> str:
         parts = tuple(int(part) for part in version.split(".")[:2])
     except ValueError as exc:
         raise PackageError(
-            f"Harbor version {version!r} is invalid; supported range is [0.21, 0.22)",
+            f"Harbor version {version!r} is invalid; supported range is [0.22, 0.23)",
             remediation=remediation,
         ) from exc
-    if parts != (0, 21):
+    if parts != (0, 22):
         raise PackageError(
-            f"Harbor version {version} is outside supported range [0.21, 0.22)",
+            f"Harbor version {version} is outside supported range [0.22, 0.23)",
             remediation=remediation,
         )
     executable = Path(sys.executable).parent / "harbor"
@@ -101,6 +116,96 @@ def resolve_harbor() -> str:
             remediation=remediation,
         )
     return str(executable)
+
+
+def _ensure_harbor_egress_sidecar_image() -> str:
+    """Build Harbor's content-addressed sidecar image through its own helper."""
+    from harbor.environments.docker.docker import DockerEnvironment
+    from harbor.environments.docker.utils import (
+        default_docker_platform,
+        ensure_docker_image_built,
+    )
+
+    async def ensure() -> str:
+        platform = await default_docker_platform()
+        return await ensure_docker_image_built(
+            docker_name=DockerEnvironment._EGRESS_CONTROL_SIDECAR_DOCKER_NAME,
+            docker_build_context=DockerEnvironment._EGRESS_CONTROL_SIDECAR_CONTEXT_PATH,
+            dockerfile_path=DockerEnvironment._egress_control_sidecar_dockerfile_path(),
+            build_args={},
+            platform=platform,
+        )
+
+    return asyncio.run(ensure())
+
+
+def _probe_harbor_egress_sidecar_image(
+    image_name: str,
+) -> subprocess.CompletedProcess[str]:
+    """Load Harbor's actual nftables rules in a disposable isolated container."""
+    return subprocess.run(
+        [
+            "docker",
+            "container",
+            "run",
+            "--rm",
+            "--network",
+            "none",
+            "--cap-add",
+            "NET_ADMIN",
+            "--cap-add",
+            "NET_RAW",
+            "--entrypoint",
+            "/bin/sh",
+            image_name,
+            "-c",
+            "network-policy deny-all >/dev/null && "
+            "nft list table inet gost_egress >/dev/null",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+
+def _bounded_probe_error(result: subprocess.CompletedProcess[str]) -> str:
+    detail = "\n".join(
+        part.strip() for part in (result.stderr or "", result.stdout or "") if part.strip()
+    )
+    return detail[:1000] or f"probe exited {result.returncode} without output"
+
+
+def docker_network_policy_capability() -> DockerNetworkPolicyCapability:
+    """Return whether Harbor's real Docker allowlist backend works now.
+
+    Harbor 0.22 fixes daemon-kernel capability detection, but a config-bit
+    check alone is not sufficient for Daydream's paid-run preflight.  Build
+    the exact content-addressed sidecar Harbor will use and load its complete
+    nftables ruleset.  Any import, build, Docker, timeout, or ruleset failure
+    is reported as unsupported; there is no public-networking fallback.
+    """
+    image_name: str | None = None
+    try:
+        resolve_harbor()
+        image_name = _ensure_harbor_egress_sidecar_image()
+        result = _probe_harbor_egress_sidecar_image(image_name)
+    except Exception as exc:  # noqa: BLE001 - every probe failure must fail closed
+        return DockerNetworkPolicyCapability(
+            supported=False,
+            reason=f"Harbor Docker egress sidecar live probe failed: {str(exc)[:1000]}",
+            image_name=image_name,
+        )
+    if result.returncode != 0:
+        return DockerNetworkPolicyCapability(
+            supported=False,
+            reason=(
+                "Harbor Docker egress sidecar rejected its nftables rules: "
+                f"{_bounded_probe_error(result)}"
+            ),
+            image_name=image_name,
+        )
+    return DockerNetworkPolicyCapability(supported=True, image_name=image_name)
 
 
 def _read_packaged_resource(
@@ -230,11 +335,11 @@ def validate_compiled(root: Path | None) -> int:
         from harbor.models.job.config import JobConfig
         try:
             from harbor.models.task import Task
-        except ImportError:  # Harbor 0.21 wheel currently exposes a namespace package.
+        except ImportError:  # Harbor exposes task as a namespace package in some wheels.
             from harbor.models.task.task import Task
     except ImportError as exc:
         raise PackageError(
-            f"cannot import Harbor 0.21 models from the Daydream interpreter: {exc}",
+            f"cannot import Harbor 0.22 models from the Daydream interpreter: {exc}",
             remediation="pip install 'daydream[benchmark]'",
         ) from exc
 
@@ -296,11 +401,11 @@ def render_job_config(*, oracle: bool) -> bytes:
     agents: list[dict[str, Any]] = [{"name": "oracle"}] if oracle else [{
         "import_path": "daydream.benchmark.harbor.agent:DaydreamReviewAgent",
         "env": {
-            "DAYDREAM_REVIEW_BACKEND": "${DAYDREAM_REVIEW_BACKEND:-claude}",
+            "DAYDREAM_REVIEW_BACKEND": "${DAYDREAM_REVIEW_BACKEND:-pi}",
             "DAYDREAM_REVIEW_MODEL": "${DAYDREAM_REVIEW_MODEL}",
             "DAYDREAM_REVIEW_API_KEY": "${DAYDREAM_REVIEW_API_KEY}",
             "DAYDREAM_REVIEW_BASE_URL": "${DAYDREAM_REVIEW_BASE_URL}",
-            "DAYDREAM_REVIEW_PROFILE_CANDIDATE": "${DAYDREAM_REVIEW_PROFILE_CANDIDATE}",
+            "DAYDREAM_REVIEW_PROFILE_CANDIDATE": "${DAYDREAM_REVIEW_PROFILE_CANDIDATE:-}",
         },
     }]
     document = {
@@ -310,7 +415,7 @@ def render_job_config(*, oracle: bool) -> bytes:
         "environment": {"type": "docker", "delete": True},
         "agents": agents,
         "verifier": {"env": {
-            "DAYDREAM_JUDGE_PROVIDER": "${DAYDREAM_JUDGE_PROVIDER:-anthropic}",
+            "DAYDREAM_JUDGE_PROVIDER": "${DAYDREAM_JUDGE_PROVIDER}",
             "DAYDREAM_JUDGE_MODEL": "${DAYDREAM_JUDGE_MODEL}",
             "DAYDREAM_JUDGE_API_KEY": "${DAYDREAM_JUDGE_API_KEY}",
             "DAYDREAM_JUDGE_BASE_URL": "${DAYDREAM_JUDGE_BASE_URL}",
@@ -329,7 +434,7 @@ def render_verifier_dockerfile(*, base_image: str) -> bytes:
     text = _render_and_check(
         "tests/Dockerfile",
         replaces={"__BASE_IMAGE__": base_image},
-        required=("httpx==0.28.1",),
+        required=("httpx==0.28.1", "WORKDIR /tests", "verifier-metadata.json"),
         forbidden=("ENTRYPOINT", "CMD", "/verifier", "httpx>="),
         error_label="verifier Dockerfile template",
     )
@@ -337,6 +442,9 @@ def render_verifier_dockerfile(*, base_image: str) -> bytes:
 
 
 _ENV_REQUIRED: tuple[str, ...] = (
+    PI_PACKAGE,
+    "node --version",
+    "pi --version",
     "git clone",
     "repository.bundle",
     "/workspace/repo",
@@ -371,7 +479,12 @@ def render_environment_dockerfile(*, base_image: str, daydream_version: str, whe
     """
     text = _render_and_check(
         "environment/Dockerfile",
-        replaces={"__BASE_IMAGE__": base_image, "__DAYDREAM_VERSION__": daydream_version},
+        replaces={
+            "__BASE_IMAGE__": base_image,
+            "__PI_BASE_IMAGE__": PI_BASE_IMAGE,
+            "__PI_PACKAGE__": PI_PACKAGE,
+            "__DAYDREAM_VERSION__": daydream_version,
+        },
         required=_ENV_REQUIRED + (("--no-deps",) if wheel else ()),
         error_label="environment Dockerfile template",
         transform=lambda rendered: _strip_wheel_block(rendered, wheel=wheel),

--- a/daydream/benchmark/harbor/run.py
+++ b/daydream/benchmark/harbor/run.py
@@ -1,6 +1,6 @@
 """Supervised Harbor runs behind the Oracle self-match gate (issue #781).
 
-A thin safety wrapper around Harbor 0.21 that fail-closes on every preflight
+A thin safety wrapper around Harbor 0.22 that fail-closes on every preflight
 before Harbor starts (same-interpreter Harbor, compiled-tree presence,
 endpoint hosts vs the compiled network policy, telemetry/upload rejection,
 and Docker allowlist support), prints a pre-run spend summary, and
@@ -108,15 +108,14 @@ def _compiled_allowed_hosts(workspace: Path) -> tuple[list[str], list[str]] | No
 
 
 def _reviewer_host_from_env(env: dict[str, Any]) -> str:
-    """Reviewer egress host for ``env``: base-URL host, else the anthropic default.
+    """Return the reviewer base-URL host, failing closed when it is absent.
 
-    Mirrors ``calibrate._judge_host_from_env``: a configured
-    ``DAYDREAM_REVIEW_BASE_URL`` resolves to its hostname (lowercased, no
-    port); without one the reviewer routes to the default ``api.anthropic.com``.
+    A configured ``DAYDREAM_REVIEW_BASE_URL`` resolves to its hostname
+    (lowercased, no port). Daydream no longer selects an implicit provider API.
     """
     base = env.get("DAYDREAM_REVIEW_BASE_URL") or ""
     if not base:
-        return "api.anthropic.com"
+        raise ValueError("missing DAYDREAM_REVIEW_BASE_URL")
     return str(urllib.parse.urlsplit(base).hostname or "").lower()
 
 
@@ -387,7 +386,7 @@ def _preflight(
     *,
     oracle: bool,
     env: dict[str, Any],
-    docker_ok: Callable[[], bool],
+    docker_ok: Callable[[], Any] | None = None,
 ) -> list[str]:
     """Fail-closed preflight: collect every blocking failure (empty = pass).
 
@@ -444,11 +443,25 @@ def _preflight(
                     f"privacy {field} must be disabled before a Harbor run (got {value!r})"
                 )
 
-    if not docker_ok():
-        failures.append(
+    try:
+        capability = (docker_ok or _default_docker_ok)()
+        if isinstance(capability, bool):
+            docker_supported = capability
+            docker_reason = ""
+        else:
+            docker_supported = bool(getattr(capability, "supported", False))
+            docker_reason = str(getattr(capability, "reason", ""))
+    except Exception as exc:  # noqa: BLE001 - preflight probes always fail closed
+        docker_supported = False
+        docker_reason = f"Docker capability probe failed: {str(exc)[:1000]}"
+    if not docker_supported:
+        message = (
             "Docker allowlist is unsupported on the selected runtime; "
             "refusing to fall back to public networking"
         )
+        if docker_reason:
+            message = f"{message}: {docker_reason}"
+        failures.append(message)
     return failures
 
 
@@ -559,7 +572,7 @@ def _current_state_mapping(
     mapping = {
         "compiled_lock_sha256": compiled_lock_sha256,
         "harbor_version": major_minor,
-        "judge_provider": env.get("DAYDREAM_JUDGE_PROVIDER") or "anthropic",
+        "judge_provider": env.get("DAYDREAM_JUDGE_PROVIDER") or "",
         "judge_model": env.get("DAYDREAM_JUDGE_MODEL") or "",
         "judge_host": calibrate._judge_host_from_env(env),
         "reviewer_backend": env.get("DAYDREAM_REVIEW_BACKEND") or "",
@@ -663,13 +676,14 @@ def _default_confirm(prompt: str) -> bool:
     return answer in ("y", "yes")
 
 
-def _default_docker_ok() -> bool:
-    """Default Docker allowlist probe: never fall back to public networking.
+def _default_docker_ok() -> package.DockerNetworkPolicyCapability:
+    """Probe Harbor's real Docker allowlist backend before any run starts.
 
-    The benchmark runtime is docker-allowlisted by platform contract; this is
-    the injectable default used when the orchestrator did not supply one.
+    The live probe builds Harbor's exact sidecar image and loads its nftables
+    rules in a disposable container.  Unsupported kernels and broken Docker
+    daemons therefore fail preflight instead of becoming public networking.
     """
-    return True
+    return package.docker_network_policy_capability()
 
 
 def _default_spawn(cmd: list[str], *, cwd: Path, env: dict[str, Any]) -> dict[str, Any]:
@@ -754,7 +768,7 @@ def run_run(
                           reviewer_backend=env.get("DAYDREAM_REVIEW_BACKEND") or "",
                           reviewer_model=env.get("DAYDREAM_REVIEW_MODEL") or "",
                           reviewer_base_url=env.get("DAYDREAM_REVIEW_BASE_URL") or "",
-                          judge_provider=env.get("DAYDREAM_JUDGE_PROVIDER") or "anthropic",
+                          judge_provider=env.get("DAYDREAM_JUDGE_PROVIDER") or "",
                           judge_model=env.get("DAYDREAM_JUDGE_MODEL") or "",
                           judge_host=calibrate._judge_host_from_env(env) or "")
 
@@ -768,7 +782,7 @@ def run_run(
             spawn_env[key] = value
     spawn_env["HARBOR_TELEMETRY"] = "off"
     result = spawn(
-        [harbor_exe, "run", "-c", str(config)],
+        [harbor_exe, "run", "-c", str(config), "--job-name", run_id],
         cwd=workspace / "harbor", env=spawn_env,
     )
     returncode = int(result.get("returncode", 0))

--- a/daydream/benchmark/harbor/run.py
+++ b/daydream/benchmark/harbor/run.py
@@ -419,6 +419,9 @@ def _preflight(
             ("judge", calibrate._judge_host_from_env, judge_hosts),
             ("reviewer", _reviewer_host_from_env, reviewer_hosts),
         ):
+            if label == "judge" and not env.get("DAYDREAM_JUDGE_BASE_URL"):
+                failures.append("cannot resolve judge host: missing DAYDREAM_JUDGE_BASE_URL")
+                continue
             try:
                 host = resolve(env)
             except Exception as exc:  # noqa: BLE001 - surfaced as a preflight failure

--- a/daydream/benchmark/harbor/runtime-requirements.lock
+++ b/daydream/benchmark/harbor/runtime-requirements.lock
@@ -1,6 +1,6 @@
 # Daydream Harbor runtime requirements (generated; do not edit)
 # daydream_version: 0.27.0
-# source_uv_lock_sha256: 1e88f83f7d3eddf1f0908d71ff1080ac0c72fd229fe7b1df639544e25822c0f2
+# source_uv_lock_sha256: f6af42aade244f0d6635d3425a0f3d9f6b87812ace3fbccd50f1e51bb4253a89
 # generation_command: uv export --frozen --no-dev --no-emit-project --format requirements-txt
 # template_version: 2
 

--- a/daydream/benchmark/harbor/templates/environment/Dockerfile
+++ b/daydream/benchmark/harbor/templates/environment/Dockerfile
@@ -1,4 +1,15 @@
-FROM __BASE_IMAGE__
+FROM __BASE_IMAGE__ AS environment-base
+
+FROM __PI_BASE_IMAGE__ AS pi-runtime
+RUN npm install --global --omit=dev __PI_PACKAGE__
+
+FROM environment-base
+
+COPY --from=pi-runtime /usr/local/bin/node /usr/local/bin/node
+COPY --from=pi-runtime /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -s ../lib/node_modules/@earendil-works/pi-coding-agent/dist/cli.js /usr/local/bin/pi \
+    && node --version \
+    && pi --version
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git \

--- a/daydream/benchmark/harbor/templates/metric.py
+++ b/daydream/benchmark/harbor/templates/metric.py
@@ -5,7 +5,7 @@ Stdlib only, never imports daydream (or the bundled verifier_core): the
 aggregation body is inlined at build time so a compiled task's ``metric.py``
 needs nothing but the stdlib. Reads one JSONL line per task — a reward dict or
 ``null`` (unscored infrastructure failure) — and writes the pooled micro metrics to the ``-o`` path.
-Invocation matches Harbor 0.21's ``uv run metric.py -i <rewards.jsonl> -o
+Invocation matches Harbor 0.22's ``uv run metric.py -i <rewards.jsonl> -o
 <metric.json>``; a missing input raises ``FileNotFoundError`` (uncaught ->
 nonzero exit, no output written — fail-closed, never partial).
 """

--- a/daydream/benchmark/harbor/templates/tests/Dockerfile
+++ b/daydream/benchmark/harbor/templates/tests/Dockerfile
@@ -4,10 +4,11 @@ FROM __BASE_IMAGE__
 # httpx and its transitive subtree are pinned version+content-hash with the
 # committed closure (same as runtime-requirements.lock) and installed with
 # --require-hashes, so the verifier -- the container carrying the judge API
-# key to api.anthropic.com -- builds deterministically/digest-locked.
+# key to the configured allowlisted endpoint -- builds deterministically.
 RUN printf 'httpx==0.28.1 --hash=sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad\nhttpcore==1.0.9 --hash=sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55 --hash=sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8\nanyio==4.12.1 --hash=sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703 --hash=sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c\ncertifi==2026.1.4 --hash=sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c --hash=sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120\nh11==0.16.0 --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 --hash=sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86\nidna==3.15 --hash=sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8 --hash=sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc\ntyping_extensions==4.15.0 --hash=sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466 --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548\n' > /tmp/httpx-lock.txt \
     && python -m pip install --no-cache-dir --require-hashes -r /tmp/httpx-lock.txt \
     && rm /tmp/httpx-lock.txt
 
-COPY test.sh score_review.py verifier_core.py judge_prompt.md golden-review.json ./
+WORKDIR /tests
+COPY test.sh score_review.py verifier_core.py judge_prompt.md golden-review.json verifier-metadata.json ./
 RUN chmod +x test.sh

--- a/daydream/benchmark/harbor/templates/tests/score_review.py
+++ b/daydream/benchmark/harbor/templates/tests/score_review.py
@@ -753,7 +753,7 @@ _ENV_BASE_URL = "DAYDREAM_JUDGE_BASE_URL"
 _ENV_ALLOWED_HOSTS = "DAYDREAM_JUDGE_ALLOWED_HOSTS"
 _ENV_ARTIFACT_PATH = "DAYDREAM_JUDGE_ARTIFACT_PATH"
 _ENV_OUT_PATH = "DAYDREAM_JUDGE_OUT_PATH"
-_DEFAULT_PROVIDER = "anthropic"
+_DEFAULT_PROVIDER = ""
 
 
 class _CountingClient:
@@ -1130,11 +1130,11 @@ def _build_client(env: dict[str, Any]) -> Any:
     """Build the judge client from the DAYDREAM_JUDGE_* env surface.
 
     Provider is fail-closed: exactly ``anthropic`` | ``openai-compatible`` is
-    accepted (absent -> default ``anthropic``); anything else raises before any
+    accepted when explicit; absent or unsupported values raise before any
     request. The provider's base URL is resolved and the initial request URL is
     validated against the effective judge-host allowlist at build time.
     """
-    provider = env.get(_ENV_PROVIDER) or _DEFAULT_PROVIDER
+    provider = env.get(_ENV_PROVIDER) or ""
     model = env.get(_ENV_MODEL)
     api_key = env.get(_ENV_API_KEY)
     if not model or not api_key:

--- a/daydream/benchmark/harbor/templates/tests/score_review.py
+++ b/daydream/benchmark/harbor/templates/tests/score_review.py
@@ -400,9 +400,14 @@ def _parse_json_response(response: Any, *, content: Any) -> dict[str, Any]:
     error = parsed_body.get("error") if isinstance(parsed_body, dict) else None
     if isinstance(error, dict):
         raw_code = error.get("code")
-        try:
-            error_code = int(raw_code)
-        except (TypeError, ValueError):
+        if isinstance(raw_code, int) and not isinstance(raw_code, bool):
+            error_code = raw_code
+        elif isinstance(raw_code, str):
+            try:
+                error_code = int(raw_code)
+            except ValueError:
+                error_code = -1
+        else:
             error_code = -1
         message = _bounded_error(error.get("message") or "upstream judge error")
         if error_code == 429 or error_code >= 500:

--- a/daydream/benchmark/harbor/templates/tests/score_review.py
+++ b/daydream/benchmark/harbor/templates/tests/score_review.py
@@ -397,6 +397,21 @@ def _parse_json_response(response: Any, *, content: Any) -> dict[str, Any]:
         raise VerifierError(
             f"Judge response was not valid JSON: {_bounded_error(str(exc))}"
         ) from exc
+    error = parsed_body.get("error") if isinstance(parsed_body, dict) else None
+    if isinstance(error, dict):
+        raw_code = error.get("code")
+        try:
+            error_code = int(raw_code)
+        except (TypeError, ValueError):
+            error_code = -1
+        message = _bounded_error(error.get("message") or "upstream judge error")
+        if error_code == 429 or error_code >= 500:
+            # OpenRouter can wrap an upstream 429/5xx in an HTTP-200 JSON
+            # envelope. Treat that envelope like the corresponding transport
+            # failure so transient free-provider overloads use the shared retry
+            # budget instead of aborting the whole calibration.
+            raise _Retryable(f"Judge upstream error {error_code}: {message}")
+        raise VerifierError(f"Judge response error {error_code}: {message}")
     text = content(parsed_body)
     try:
         parsed = json.loads(text)
@@ -634,6 +649,33 @@ class OpenAIJudgeClient:
                 {"role": "user", "content": user},
             ],
         }
+        # OpenRouter reasoning models can spend the entire small judge budget
+        # on hidden reasoning, truncating the JSON verdict. The verifier only
+        # needs the bounded decision object, so disable reasoning on this
+        # provider while leaving generic OpenAI-compatible endpoints unchanged.
+        if (urllib.parse.urlsplit(self.base_url).hostname or "").lower() == "openrouter.ai":
+            payload["reasoning"] = {"effort": "none"}
+            payload["response_format"] = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "verdict",
+                    "strict": True,
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "match": {"type": "boolean"},
+                            "confidence": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 1,
+                            },
+                            "reasoning": {"type": "string"},
+                        },
+                        "required": ["match", "confidence", "reasoning"],
+                        "additionalProperties": False,
+                    },
+                },
+            }
         headers = {
             "Authorization": f"Bearer {self.api_key}",
             "content-type": "application/json",

--- a/daydream/benchmark/harbor/templates/tests/score_review.py
+++ b/daydream/benchmark/harbor/templates/tests/score_review.py
@@ -577,17 +577,13 @@ _CHAT_COMPLETIONS_PATH = "/chat/completions"
 def resolve_base_url(api_key: str, base_url_env: str | None) -> str:
     """Resolve the Chat Completions base URL from the environment.
 
-    An explicit base URL always wins; an ``sk-or-`` OpenRouter key with no pin
-    routes to OpenRouter; anything else defaults to OpenAI direct. The resolved
-    URL is only a candidate: it is validated against the effective judge-host
-    allowlist (scheme/host/form) at the client build and initial-request sites
-    before any judge call.
+    A configured base URL is required. The resolved URL is validated against
+    the effective judge-host allowlist (scheme/host/form) at the client build
+    and initial-request sites before any judge call.
     """
-    if base_url_env:
-        return base_url_env
-    if api_key.startswith(_OPENROUTER_KEY_PREFIX):
-        return _OPENROUTER_BASE_URL
-    return _OPENAI_DEFAULT_BASE_URL
+    if not base_url_env:
+        raise VerifierError("missing DAYDREAM_JUDGE_BASE_URL")
+    return base_url_env
 
 
 def _openai_content(body: dict[str, Any]) -> str:
@@ -654,12 +650,11 @@ class OpenAIJudgeClient:
                 {"role": "user", "content": user},
             ],
         }
-        # OpenRouter reasoning models can spend the entire small judge budget
-        # on hidden reasoning, truncating the JSON verdict. The verifier only
-        # needs the bounded decision object, so disable reasoning on this
-        # provider while leaving generic OpenAI-compatible endpoints unchanged.
+        # Keep reasoning enabled because some OpenRouter models require it,
+        # but exclude it from the response so it cannot consume the bounded
+        # judge output budget. Generic OpenAI-compatible endpoints are unchanged.
         if (urllib.parse.urlsplit(self.base_url).hostname or "").lower() == "openrouter.ai":
-            payload["reasoning"] = {"effort": "none"}
+            payload["reasoning"] = {"exclude": True}
             payload["response_format"] = {
                 "type": "json_schema",
                 "json_schema": {

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -2257,12 +2257,16 @@ async def _step_supervise(ctx: FlowContext) -> None:
 
 
 async def _step_post_review(ctx: FlowContext) -> Stop | None:
-    """Offer to post findings as inline PR review comments; ``--comment`` auto-posts.
+    """Offer to post in loop/shallow modes; ``--comment`` auto-posts.
 
     In comment mode posting is the run's deliverable, so a missing PR or a
     failed GitHub submission ends the run with exit code 1 instead of the
-    warn-and-continue the default deep flow gets (#8).
+    warn-and-continue the default deep flow gets (#8). Report-only review mode
+    never resolves a PR or enters the posting helper.
     """
+    if _mode_of(ctx) == "review":
+        return None
+
     from daydream.pr_review import PostStatus, post_review_to_pr_from_report
 
     items_file: Path = ctx.data["items_file"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-benchmark = ["harbor>=0.21,<0.22"]
+benchmark = ["harbor>=0.22,<0.23"]
 
 [dependency-groups]
 dev = [

--- a/rl/daydream_review_v1/uv.lock
+++ b/rl/daydream_review_v1/uv.lock
@@ -420,7 +420,7 @@ dependencies = [
 requires-dist = [
     { name = "anyio", specifier = ">=4.0" },
     { name = "claude-agent-sdk", specifier = "==0.2.116" },
-    { name = "harbor", marker = "extra == 'benchmark'", specifier = ">=0.21,<0.22" },
+    { name = "harbor", marker = "extra == 'benchmark'", specifier = ">=0.22,<0.23" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "jsonschema", specifier = ">=4.0" },
     { name = "pydantic", specifier = ">=2.11.7" },
@@ -2269,8 +2269,8 @@ name = "uvicorn"
 version = "0.51.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "sys_platform != 'emscripten'" },
-    { name = "h11", marker = "sys_platform != 'emscripten'" },
+    { name = "click" },
+    { name = "h11" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a2/65/b7c6c443ccc58678c91e1e973bbe2a878591538655d6e1d47f24ba1c51f3/uvicorn-0.51.0.tar.gz", hash = "sha256:f6f4b69b657c312f516dd2d268ab9ae6f254b11e4bac504f37b2ab58b24dd0b0", size = 94412, upload-time = "2026-07-08T10:59:05.962Z" }
 wheels = [

--- a/tests/test_backend_pi.py
+++ b/tests/test_backend_pi.py
@@ -300,6 +300,22 @@ async def test_pi_api_key_never_enters_process_argv(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_pi_api_key_maps_to_openrouter_native_env(monkeypatch):
+    sentinel = "synthetic-openrouter-key"
+    monkeypatch.setenv("PI_PROVIDER", "openrouter")
+    monkeypatch.setenv("PI_API_KEY", sentinel)
+
+    backend = PiBackend(model="deepseek/deepseek-v4-flash-0731")
+    flat_args, mock_exec = await _run_and_capture_args(backend)
+
+    assert flat_args[flat_args.index("--provider") + 1] == "openrouter"
+    assert sentinel not in flat_args
+    assert "--api-key" not in flat_args
+    assert mock_exec.call_args.kwargs["env"]["OPENROUTER_API_KEY"] == sentinel
+    assert "PI_API_KEY" not in mock_exec.call_args.kwargs["env"]
+
+
+@pytest.mark.asyncio
 async def test_pi_api_key_unknown_provider_warns_and_skips(monkeypatch, caplog):
     """An unmapped provider warns and proceeds; the key never reaches argv or any env var."""
     sentinel = "synthetic-unknown-provider-key"

--- a/tests/test_backend_pi.py
+++ b/tests/test_backend_pi.py
@@ -300,22 +300,6 @@ async def test_pi_api_key_never_enters_process_argv(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_pi_api_key_maps_to_openrouter_native_env(monkeypatch):
-    sentinel = "synthetic-openrouter-key"
-    monkeypatch.setenv("PI_PROVIDER", "openrouter")
-    monkeypatch.setenv("PI_API_KEY", sentinel)
-
-    backend = PiBackend(model="deepseek/deepseek-v4-flash-0731")
-    flat_args, mock_exec = await _run_and_capture_args(backend)
-
-    assert flat_args[flat_args.index("--provider") + 1] == "openrouter"
-    assert sentinel not in flat_args
-    assert "--api-key" not in flat_args
-    assert mock_exec.call_args.kwargs["env"]["OPENROUTER_API_KEY"] == sentinel
-    assert "PI_API_KEY" not in mock_exec.call_args.kwargs["env"]
-
-
-@pytest.mark.asyncio
 async def test_pi_api_key_unknown_provider_warns_and_skips(monkeypatch, caplog):
     """An unmapped provider warns and proceeds; the key never reaches argv or any env var."""
     sentinel = "synthetic-unknown-provider-key"

--- a/tests/test_benchmark_calibrate.py
+++ b/tests/test_benchmark_calibrate.py
@@ -105,6 +105,13 @@ def test_judge_host_resolved_from_env():
     assert _judge_host_from_env({"DAYDREAM_JUDGE_PROVIDER": "anthropic"}) == "api.anthropic.com"
     with pytest.raises(ValueError, match="missing DAYDREAM_JUDGE_PROVIDER"):
         _judge_host_from_env({})
+    with pytest.raises(ValueError, match="unsupported DAYDREAM_JUDGE_PROVIDER"):
+        _judge_host_from_env({"DAYDREAM_JUDGE_PROVIDER": "bogus"})
+    with pytest.raises(ValueError, match="missing DAYDREAM_JUDGE_BASE_URL"):
+        _judge_host_from_env({
+            "DAYDREAM_JUDGE_PROVIDER": "openai-compatible",
+            "DAYDREAM_JUDGE_API_KEY": "sk-or-key",
+        })
 
 
 def test_out_of_allowlist_host_rejected(tmp_path):
@@ -348,6 +355,13 @@ def ws_factory():
         return ws
 
     return _build
+
+
+def test_run_calibration_reports_missing_judge_provider(ws_factory, tmp_path, capsys):
+    from daydream.benchmark.harbor.calibrate import run_calibration
+
+    assert run_calibration(ws_factory(tmp_path), yes=True, env={}) == 1
+    assert "missing DAYDREAM_JUDGE_PROVIDER" in capsys.readouterr().err
 
 
 def _scripted_http(responses):

--- a/tests/test_benchmark_calibrate.py
+++ b/tests/test_benchmark_calibrate.py
@@ -103,6 +103,8 @@ def test_judge_host_resolved_from_env():
     assert _judge_host_from_env({"DAYDREAM_JUDGE_PROVIDER": "openai-compatible",
                                  "DAYDREAM_JUDGE_BASE_URL": "http://127.0.0.1:9"}) == "127.0.0.1"
     assert _judge_host_from_env({"DAYDREAM_JUDGE_PROVIDER": "anthropic"}) == "api.anthropic.com"
+    with pytest.raises(ValueError, match="missing DAYDREAM_JUDGE_PROVIDER"):
+        _judge_host_from_env({})
 
 
 def test_out_of_allowlist_host_rejected(tmp_path):

--- a/tests/test_benchmark_harbor_agent.py
+++ b/tests/test_benchmark_harbor_agent.py
@@ -33,14 +33,14 @@ def test_spike_task_toml_env_carries_case_key(tmp_path, fake_gh):
     # determinism: re-rendering identical bytes
     # re-render with the same workspace-seeded privacy allowlists so the bytes
     # are identical to the compiled task.toml (reviewer h1/judge h2, not a
-    # different policy like api.anthropic.com)
+    # different reviewer policy)
     assert pkg.render_task_toml(
         key, reviewer_hosts=["h1.example.com"], judge_hosts=["h2.example.com"]
     ) == (case / "task.toml").read_bytes()
     # Harbor validates the enriched task.toml (same-interpreter Task model)
     try:
         from harbor.models.task import Task  # noqa: PLC0415 - namespace fallback as in package.py
-    except ImportError:  # Harbor 0.21 wheel exposes task as a namespace package.
+    except ImportError:  # Harbor exposes task as a namespace package in some wheels.
         from harbor.models.task.task import Task  # noqa: PLC0415
     assert Task(str(case), disable_verification=True) is not None
 
@@ -87,12 +87,13 @@ def test_build_candidate_findings_enforces_verifier_bounds_fail_closed():
     from daydream.benchmark.harbor import candidate
 
     case_id = "case-abc123def456"
-    # over-long title (>500 chars) is a typed failure, not a rejectable artifact
+    # A verbose canonical description is preserved in the body while the
+    # display title is deterministically bounded for the verifier schema.
     overlong_title = [{"file": "src/a.py", "line": 1,
                        "description": "t" * 501, "rationale": "", "severity": "low"}]
-    with pytest.raises(candidate.CandidateError) as bad_title:
-        candidate.build_candidate_findings(overlong_title, case_id=case_id)
-    assert bad_title.value.kind == "invalid_finding"
+    [bounded] = candidate.build_candidate_findings(overlong_title, case_id=case_id)
+    assert len(bounded["title"]) <= 500
+    assert "t" * 501 in bounded["body"]
 
     # over-long body (>8 KiB) is a typed failure
     overlong_body = [{"file": "src/a.py", "line": 1,
@@ -158,10 +159,10 @@ def test_render_task_toml_host_policy_and_case_env():
 
     toml = pkg.render_task_toml(
         "case-abc123def456",
-        reviewer_hosts=["api.anthropic.com"],
-        judge_hosts=["api.anthropic.com"],
+        reviewer_hosts=["openrouter.ai"],
+        judge_hosts=["openrouter.ai"],
     ).decode("utf-8")
-    assert 'allowed_hosts = ["api.anthropic.com"]' in toml       # reviewer-only host
+    assert 'allowed_hosts = ["openrouter.ai"]' in toml       # reviewer-only host
     assert '"github.com"' not in toml and '"huggingface.co"' not in toml
     assert 'DAYDREAM_REVIEW_CASE_ID = "case-abc123def456"' in toml
     assert 'DAYDREAM_REVIEW_BASE_REF = "base"' in toml
@@ -169,12 +170,12 @@ def test_render_task_toml_host_policy_and_case_env():
     # deterministic
     assert pkg.render_task_toml(
         "case-abc123def456",
-        reviewer_hosts=["api.anthropic.com"],
-        judge_hosts=["api.anthropic.com"],
+        reviewer_hosts=["openrouter.ai"],
+        judge_hosts=["openrouter.ai"],
     ) == pkg.render_task_toml(
         "case-abc123def456",
-        reviewer_hosts=["api.anthropic.com"],
-        judge_hosts=["api.anthropic.com"],
+        reviewer_hosts=["openrouter.ai"],
+        judge_hosts=["openrouter.ai"],
     )
     # no judge vars or archive/target config reach the agent surface
     assert "DAYDREAM_JUDGE" not in toml and "HF_TOKEN" not in toml and "GITHUB_TOKEN" not in toml
@@ -185,15 +186,15 @@ def test_render_task_toml_keeps_agent_verifier_host_boundaries():
 
     toml = pkg.render_task_toml(
         "case-abc123def456",
-        reviewer_hosts=["api.anthropic.com"],
+        reviewer_hosts=["reviewer.example.com"],
         judge_hosts=["openrouter.ai"],
     ).decode("utf-8")
     agent_block = toml.split("[agent]", 1)[1].split("[environment]", 1)[0]
     verifier_block = toml.split("[verifier.environment]", 1)[1]
-    assert 'allowed_hosts = ["api.anthropic.com"]' in agent_block
+    assert 'allowed_hosts = ["reviewer.example.com"]' in agent_block
     assert "openrouter.ai" not in agent_block
     assert 'allowed_hosts = ["openrouter.ai"]' in verifier_block
-    assert "api.anthropic.com" not in verifier_block
+    assert "reviewer.example.com" not in verifier_block
 
 
 # ---------------------------------------------------------------------------
@@ -208,8 +209,8 @@ def test_entrypoint_build_run_config_is_controlled():
     cfg = entrypoint.build_run_config(
         repo_dir="/workspace/repo",
         trajectory_path="/logs/agent/trajectory.json",
-        backend="claude",
-        model="sonnet",
+        backend="pi",
+        model="deepseek/deepseek-v4-flash-0731",
     )
     assert cfg.output_mode == "review"
     assert cfg.base == "base"
@@ -217,7 +218,7 @@ def test_entrypoint_build_run_config_is_controlled():
     assert cfg.archive is False and cfg.run_eval is False
     assert cfg.findings_out is None                     # NO --findings-out (live PR lookup)
     assert cfg.trajectory_path == Path("/logs/agent/trajectory.json")
-    assert cfg.backend == "claude" and cfg.model == "sonnet"
+    assert cfg.backend == "pi" and cfg.model == "deepseek/deepseek-v4-flash-0731"
     assert isinstance(cfg.file_config, DaydreamFileConfig)
     # controlled empty: the target repo's .daydream.toml is never loaded
     assert cfg.file_config == DaydreamFileConfig()
@@ -229,7 +230,7 @@ def test_entrypoint_backend_fail_closed(monkeypatch):
     monkeypatch.setenv("DAYDREAM_REVIEW_BACKEND", "codex")
     with pytest.raises(entrypoint.EntrypointError) as exc:
         entrypoint.require_supported_backend()
-    assert "claude" in str(exc.value)
+    assert "pi" in str(exc.value)
 
 
 # ---------------------------------------------------------------------------
@@ -326,7 +327,7 @@ def test_agent_setup_confirms_version_and_backend(tmp_path):
     from daydream.benchmark.harbor.agent import DaydreamReviewAgent
 
     agent = DaydreamReviewAgent(
-        logs_dir=tmp_path, extra_env={"DAYDREAM_REVIEW_BACKEND": "claude"}
+        logs_dir=tmp_path, extra_env={"DAYDREAM_REVIEW_BACKEND": "pi"}
     )
 
     class Env:
@@ -339,7 +340,7 @@ def test_agent_setup_confirms_version_and_backend(tmp_path):
 
     asyncio.run(agent.setup(env))
     assert agent.version() in env.captured        # setup checks the packaged version
-    assert "claude_agent_sdk" in env.captured      # and the required backend SDK
+    assert "shutil.which('pi')" in env.captured      # and the required Pi CLI
 
 
 def test_agent_setup_nonzero_exec_fails(tmp_path):
@@ -365,7 +366,7 @@ def test_agent_setup_nonzero_exec_fails(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Task 7: agent run() — claude guarantee + allowlist child env + isolation
+# Task 7: agent run() — Pi guarantee + allowlist child env + isolation
 # ---------------------------------------------------------------------------
 
 
@@ -380,6 +381,8 @@ _BANNED = [
     "DAYDREAM_JUDGE_API_KEY",
     "DAYDREAM_JUDGE_MODEL",
     "ANTHROPIC_API_KEY",
+    "OPENROUTER_API_KEY",
+    "PI_API_KEY",
 ]
 
 
@@ -388,9 +391,9 @@ def test_build_child_env_is_exact_allowlist():
 
     parent = {
         **{k: "secret" for k in _BANNED},
-        "DAYDREAM_REVIEW_BACKEND": "claude",
+        "DAYDREAM_REVIEW_BACKEND": "pi",
         "DAYDREAM_REVIEW_API_KEY": "review-key",
-        "DAYDREAM_REVIEW_BASE_URL": "https://api.anthropic.com",
+        "DAYDREAM_REVIEW_BASE_URL": "https://openrouter.ai/api",
         "PATH": "/usr/bin",
         "HOME": "/root",
         "LANG": "C.UTF-8",
@@ -431,13 +434,14 @@ def test_agent_run_refuses_unsupported_backend_and_invokes_entrypoint(tmp_path):
         import asyncio
 
         asyncio.run(agent.run("instruction", object(), AgentContext()))
-    assert "claude" in str(refused.value)
+    assert "pi" in str(refused.value)
 
     agent_ok = DaydreamReviewAgent(
         logs_dir=tmp_path,
         extra_env={
-            "DAYDREAM_REVIEW_BACKEND": "claude",
+            "DAYDREAM_REVIEW_BACKEND": "pi",
             "DAYDREAM_REVIEW_API_KEY": "k",
+            "DAYDREAM_REVIEW_BASE_URL": "https://openrouter.ai/api",
         },
     )
 
@@ -613,7 +617,9 @@ def _end_env(repo: Path, tmp: Path, case_id: str) -> dict[str, str]:
         "DAYDREAM_REVIEW_ARTIFACT_PATH": str(tmp / "logs" / "artifacts" / "review.json"),
         "DAYDREAM_REVIEW_TRAJECTORY_PATH": str(tmp / "logs" / "agent" / "trajectory.json"),
         "DAYDREAM_REVIEW_CASE_ID": case_id,
-        "DAYDREAM_REVIEW_BACKEND": "claude",
+        "DAYDREAM_REVIEW_BACKEND": "pi",
+        "DAYDREAM_REVIEW_API_KEY": "sk-or-test",
+        "DAYDREAM_REVIEW_BASE_URL": "https://openrouter.ai/api",
     }
 
 
@@ -735,7 +741,9 @@ def test_local_harbor_task_with_fake_backend(
     install_stub_backend(monkeypatch, repo)
     task_env = {
         "DAYDREAM_REVIEW_CASE_ID": key,
-        "DAYDREAM_REVIEW_BACKEND": "claude",
+        "DAYDREAM_REVIEW_BACKEND": "pi",
+        "DAYDREAM_REVIEW_API_KEY": "sk-or-test",
+        "DAYDREAM_REVIEW_BASE_URL": "https://openrouter.ai/api",
         "DAYDREAM_REVIEW_REPO_DIR": str(repo),
         "DAYDREAM_REVIEW_ARTIFACT_PATH": str(
             tmp_path / "logs" / "artifacts" / "review.json"
@@ -773,13 +781,13 @@ def test_local_harbor_task_with_fake_backend(
 
     # setup() executed: the in-container probe asserts this packaged release + SDK.
     assert agent.version() in executed.setup
-    assert "claude_agent_sdk" in executed.setup
+    assert "shutil.which('pi')" in executed.setup
     # run() executed with the allowlisted child env traversing to the entrypoint only.
     assert "daydream.benchmark.harbor.entrypoint" in executed.command
     assert executed.cwd == str(repo)  # cwd tracks DAYDREAM_REVIEW_REPO_DIR
     assert "--findings-out" not in executed.command  # no live-PR emission path
     assert executed.child["DAYDREAM_REVIEW_CASE_ID"] == key
-    assert executed.child["DAYDREAM_REVIEW_BACKEND"] == "claude"
+    assert executed.child["DAYDREAM_REVIEW_BACKEND"] == "pi"
     assert set(executed.child) <= {"PATH", "HOME", "LANG"} | {
         k for k in executed.child if k.startswith("DAYDREAM_REVIEW_")
     }

--- a/tests/test_benchmark_harbor_build.py
+++ b/tests/test_benchmark_harbor_build.py
@@ -1014,6 +1014,23 @@ def test_compile_rejects_when_a_case_is_not_compilable(tmp_path, fake_gh):
         assert case_id in str(exc)
 
 
+def test_compile_skips_excluded_cases(tmp_path, fake_gh):
+    from daydream.benchmark import curation as cu
+    from daydream.benchmark.harbor import build
+
+    ws, included_case_id, _ = _seed_ready_workspace(tmp_path, fake_gh)
+    excluded_case_id = _seed_second_ready_case(ws, tmp_path, fake_gh)
+    cu.exclude_case(ws, excluded_case_id, reason="duplicate_case")
+
+    lock = build.compile_workspace(ws)
+
+    included_key = build.derive_task_key(included_case_id)
+    excluded_key = build.derive_task_key(excluded_case_id)
+    assert set(lock["cases"]) == {included_key}
+    assert (ws / "harbor" / included_key).is_dir()
+    assert not (ws / "harbor" / excluded_key).exists()
+
+
 def test_compiled_findings_oracle_scores_reward_1(sr_module, tmp_path, fake_gh) -> None:
     from daydream.benchmark.harbor import build
     ws, case_id, _ = _seed_ready_workspace(tmp_path, fake_gh)

--- a/tests/test_benchmark_harbor_package.py
+++ b/tests/test_benchmark_harbor_package.py
@@ -111,63 +111,6 @@ def test_resolve_harbor_checks_same_interpreter_and_version(monkeypatch):
     assert "[0.22, 0.23)" in str(wrong.value)
 
 
-def test_docker_network_policy_capability_requires_live_sidecar_probe(monkeypatch):
-    """A kernel/config guess must not advertise the Docker allowlist backend."""
-    import subprocess
-
-    from daydream.benchmark.harbor import package as pkg
-
-    monkeypatch.setattr(pkg, "resolve_harbor", lambda: "/venv/bin/harbor")
-    monkeypatch.setattr(
-        pkg,
-        "_ensure_harbor_egress_sidecar_image",
-        lambda: "harbor-egress:test",
-        raising=False,
-    )
-    monkeypatch.setattr(
-        pkg,
-        "_probe_harbor_egress_sidecar_image",
-        lambda image: subprocess.CompletedProcess(
-            ["docker", "run", image], 1, stdout="", stderr="fib rule rejected"
-        ),
-        raising=False,
-    )
-
-    capability = pkg.docker_network_policy_capability()
-
-    assert capability.supported is False
-    assert capability.image_name == "harbor-egress:test"
-    assert "fib rule rejected" in capability.reason
-
-
-def test_docker_network_policy_capability_reports_live_sidecar_success(monkeypatch):
-    import subprocess
-
-    from daydream.benchmark.harbor import package as pkg
-
-    monkeypatch.setattr(pkg, "resolve_harbor", lambda: "/venv/bin/harbor")
-    monkeypatch.setattr(
-        pkg,
-        "_ensure_harbor_egress_sidecar_image",
-        lambda: "harbor-egress:test",
-        raising=False,
-    )
-    monkeypatch.setattr(
-        pkg,
-        "_probe_harbor_egress_sidecar_image",
-        lambda image: subprocess.CompletedProcess(
-            ["docker", "run", image], 0, stdout="ruleset-ok\n", stderr=""
-        ),
-        raising=False,
-    )
-
-    capability = pkg.docker_network_policy_capability()
-
-    assert capability.supported is True
-    assert capability.image_name == "harbor-egress:test"
-    assert capability.reason == ""
-
-
 def test_render_task_toml_threads_reviewer_and_judge_hosts():
     import tomllib
 

--- a/tests/test_benchmark_harbor_package.py
+++ b/tests/test_benchmark_harbor_package.py
@@ -1,9 +1,9 @@
-"""Packaging and Harbor 0.21 integration tests for compiled benchmarks."""
+"""Packaging and Harbor 0.22 integration tests for compiled benchmarks."""
 
 from pathlib import Path
 
 
-def test_benchmark_extra_pins_harbor_021_and_not_base():
+def test_benchmark_extra_pins_harbor_022_and_not_base():
     import tomllib
 
     root = Path(__file__).resolve().parents[1]
@@ -11,7 +11,7 @@ def test_benchmark_extra_pins_harbor_021_and_not_base():
     deps = data["project"]["dependencies"]
     assert "harbor" not in " ".join(deps)
     extra = data["project"]["optional-dependencies"]["benchmark"]
-    assert "harbor>=0.21,<0.22" in extra
+    assert "harbor>=0.22,<0.23" in extra
     include = data["tool"]["hatch"]["build"]["targets"]["wheel"]["include"]
     assert "daydream/benchmark/harbor/templates/**" in include
     assert "daydream/benchmark/harbor/runtime-requirements.lock" in include
@@ -93,7 +93,7 @@ def test_resolve_harbor_checks_same_interpreter_and_version(monkeypatch):
 
     from daydream.benchmark.harbor import package as pkg
 
-    monkeypatch.setattr(pkg.importlib.metadata, "version", lambda d: "0.21.0")
+    monkeypatch.setattr(pkg.importlib.metadata, "version", lambda d: "0.22.0")
     exe = pkg.resolve_harbor()
     assert exe == str(Path(sys.executable).parent / "harbor")
 
@@ -105,10 +105,67 @@ def test_resolve_harbor_checks_same_interpreter_and_version(monkeypatch):
         pkg.resolve_harbor()
     assert "pip install 'daydream[benchmark]'" in str(missing.value)
 
-    monkeypatch.setattr(pkg.importlib.metadata, "version", lambda d: "0.20.0")
+    monkeypatch.setattr(pkg.importlib.metadata, "version", lambda d: "0.21.0")
     with pytest.raises(pkg.PackageError) as wrong:
         pkg.resolve_harbor()
-    assert "[0.21, 0.22)" in str(wrong.value)
+    assert "[0.22, 0.23)" in str(wrong.value)
+
+
+def test_docker_network_policy_capability_requires_live_sidecar_probe(monkeypatch):
+    """A kernel/config guess must not advertise the Docker allowlist backend."""
+    import subprocess
+
+    from daydream.benchmark.harbor import package as pkg
+
+    monkeypatch.setattr(pkg, "resolve_harbor", lambda: "/venv/bin/harbor")
+    monkeypatch.setattr(
+        pkg,
+        "_ensure_harbor_egress_sidecar_image",
+        lambda: "harbor-egress:test",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        pkg,
+        "_probe_harbor_egress_sidecar_image",
+        lambda image: subprocess.CompletedProcess(
+            ["docker", "run", image], 1, stdout="", stderr="fib rule rejected"
+        ),
+        raising=False,
+    )
+
+    capability = pkg.docker_network_policy_capability()
+
+    assert capability.supported is False
+    assert capability.image_name == "harbor-egress:test"
+    assert "fib rule rejected" in capability.reason
+
+
+def test_docker_network_policy_capability_reports_live_sidecar_success(monkeypatch):
+    import subprocess
+
+    from daydream.benchmark.harbor import package as pkg
+
+    monkeypatch.setattr(pkg, "resolve_harbor", lambda: "/venv/bin/harbor")
+    monkeypatch.setattr(
+        pkg,
+        "_ensure_harbor_egress_sidecar_image",
+        lambda: "harbor-egress:test",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        pkg,
+        "_probe_harbor_egress_sidecar_image",
+        lambda image: subprocess.CompletedProcess(
+            ["docker", "run", image], 0, stdout="ruleset-ok\n", stderr=""
+        ),
+        raising=False,
+    )
+
+    capability = pkg.docker_network_policy_capability()
+
+    assert capability.supported is True
+    assert capability.image_name == "harbor-egress:test"
+    assert capability.reason == ""
 
 
 def test_render_task_toml_threads_reviewer_and_judge_hosts():
@@ -230,6 +287,8 @@ def test_render_environment_dockerfile_clones_bundle_no_remote():
     assert "checkout" in dockerfile and "base" in dockerfile and "head" in dockerfile
     assert "rm" in dockerfile and "repository.bundle" in dockerfile
     assert "WORKDIR /workspace/repo" in dockerfile
+    assert "@earendil-works/pi-coding-agent@" in dockerfile
+    assert "node --version" in dockerfile and "pi --version" in dockerfile
     assert "remote remove" in dockerfile
     assert "--require-hashes" in dockerfile and "--no-deps" in dockerfile
     for forbidden in ("Task.md", "solution/", "tests/score_review", "COPY .."):
@@ -243,7 +302,9 @@ def test_verifier_dockerfile_is_entrypoint_free_and_digest_pinned():
     assert text.startswith("FROM " + pkg.VERIFIER_BASE_IMAGE)
     assert "ENTRYPOINT" not in text and "CMD" not in text
     assert "/verifier" not in text
+    assert "WORKDIR /tests" in text
     assert "test.sh" in text and "score_review.py" in text
+    assert "verifier-metadata.json" in text
     assert "httpx" in text and "httpx>=" not in text and "httpx==0.28.1" in text
 
 
@@ -258,10 +319,15 @@ def test_render_job_config_matches_plan_s8_and_oracle_differs():
     assert job["environment"] == {"type": "docker", "delete": True}
     agent = job["agents"][0]
     assert agent["import_path"] == "daydream.benchmark.harbor.agent:DaydreamReviewAgent"
+    assert agent["env"]["DAYDREAM_REVIEW_BACKEND"] == "${DAYDREAM_REVIEW_BACKEND:-pi}"
     assert "DAYDREAM_REVIEW_API_KEY" in agent["env"]
+    assert agent["env"]["DAYDREAM_REVIEW_PROFILE_CANDIDATE"] == (
+        "${DAYDREAM_REVIEW_PROFILE_CANDIDATE:-}"
+    )
     assert job["datasets"] == [{"path": "."}]
     assert job["metrics"] == [{"type": "uv-script", "kwargs": {"script_path": "metric.py"}}]
     assert "DAYDREAM_JUDGE_API_KEY" in job["verifier"]["env"]
+    assert job["verifier"]["env"]["DAYDREAM_JUDGE_PROVIDER"] == "${DAYDREAM_JUDGE_PROVIDER}"
 
     oracle = yaml.safe_load(pkg.render_job_config(oracle=True))
     assert oracle["agents"] == [{"name": "oracle"}]
@@ -339,7 +405,7 @@ def test_validate_compiled_instantiates_harbor_tasks_and_job_configs(tmp_path, f
     from harbor.models.job.config import JobConfig
     try:
         from harbor.models.task import Task
-    except ImportError:  # Harbor 0.21 wheel exposes task as a namespace package.
+    except ImportError:  # Harbor exposes task as a namespace package in some wheels.
         from harbor.models.task.task import Task
 
     from daydream.benchmark.harbor import build

--- a/tests/test_benchmark_harbor_profile_delivery.py
+++ b/tests/test_benchmark_harbor_profile_delivery.py
@@ -16,6 +16,15 @@ _resolver_fixture = (
 )
 
 
+def _judge_env(**extra: str) -> dict[str, str]:
+    return {
+        "DAYDREAM_JUDGE_PROVIDER": "openai-compatible",
+        "DAYDREAM_JUDGE_MODEL": "openrouter/test-model",
+        "DAYDREAM_JUDGE_BASE_URL": "https://openrouter.ai/api/v1",
+        **extra,
+    }
+
+
 def test_harbor_resolver_ignores_user_env_and_repo_config(monkeypatch):
     # Malicious target config / ambient env must NOT change the Harbor candidate.
     monkeypatch.setenv("DAYDREAM_REVIEW_PROFILE", "/tmp/user-evil.toml")
@@ -42,7 +51,7 @@ def test_entrypoint_parses_and_validates_candidate_before_runconfig(tmp_path, mo
     monkeypatch.setenv("DAYDREAM_REVIEW_PROFILE_CANDIDATE", str(good))
     cfg = entrypoint.build_run_config(
         repo_dir=str(tmp_path), trajectory_path=str(tmp_path / "t.json"),
-        backend="claude", model="sonnet",
+        backend="pi", model="deepseek/deepseek-v4-flash-0731",
     )
     assert cfg.review_profile.name == "g"  # candidate parsed+validated into RunConfig
 
@@ -76,7 +85,7 @@ def test_malicious_target_config_cannot_change_harbor_candidate(tmp_path, monkey
     monkeypatch.setenv("DAYDREAM_REVIEW_PROFILE_CANDIDATE", str(good))
     cfg = entrypoint.build_run_config(
         repo_dir=str(tmp_path), trajectory_path=str(tmp_path / "t.json"),
-        backend="claude", model="sonnet",
+        backend="pi", model="deepseek/deepseek-v4-flash-0731",
     )
     assert cfg.review_profile.name == "g"  # candidate wins; target config ignored
 
@@ -106,7 +115,7 @@ def test_receipt_invalidation_inputs_include_candidate_digest():
     # receipt contract (run.py's former duplicating helper is gone).
     sr = calibrate._load_judge_template()
     inputs = calibrate._invalidation_inputs(
-        {"DAYDREAM_REVIEW_PROFILE_CANDIDATE_DIGEST": "xyz"}, pairs=[], sr=sr
+        _judge_env(DAYDREAM_REVIEW_PROFILE_CANDIDATE_DIGEST="xyz"), pairs=[], sr=sr
     )
     assert "profile_digest" in inputs and inputs["profile_digest"] == "xyz"
 
@@ -122,11 +131,11 @@ def test_calibrate_invalidation_inputs_folds_candidate_digest():
     sr = calibrate._load_judge_template()
     # With a candidate digest -> receipt contract includes profile_digest.
     inputs = calibrate._invalidation_inputs(
-        {"DAYDREAM_REVIEW_PROFILE_CANDIDATE_DIGEST": "abc"}, pairs=[], sr=sr
+        _judge_env(DAYDREAM_REVIEW_PROFILE_CANDIDATE_DIGEST="abc"), pairs=[], sr=sr
     )
     assert inputs["profile_digest"] == "abc"
     # Without a candidate digest -> legacy contract stays byte-stable.
-    legacy = calibrate._invalidation_inputs({}, pairs=[], sr=sr)
+    legacy = calibrate._invalidation_inputs(_judge_env(), pairs=[], sr=sr)
     assert "profile_digest" not in legacy
 
 
@@ -139,7 +148,7 @@ def test_candidate_scoped_receipt_matches_preflight_inputs(tmp_path):
     """
     from daydream.benchmark.harbor import calibrate
 
-    env = {"DAYDREAM_REVIEW_PROFILE_CANDIDATE_DIGEST": "abc123"}
+    env = _judge_env(DAYDREAM_REVIEW_PROFILE_CANDIDATE_DIGEST="abc123")
     # Use the same real fixture + judge template the receipt paths load internally.
     sr = calibrate._load_judge_template()
     pairs = calibrate._load_fixture()

--- a/tests/test_benchmark_harbor_skill_free.py
+++ b/tests/test_benchmark_harbor_skill_free.py
@@ -10,22 +10,36 @@ import asyncio
 import os
 from pathlib import Path
 
+import pytest
+
 from daydream.benchmark.harbor import entrypoint
 
 
-def test_openrouter_reviewer_env_uses_anthropic_auth_token(monkeypatch):
+def test_openrouter_reviewer_env_uses_pi_provider(monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", "stale-key")
     monkeypatch.setenv("ANTHROPIC_BASE_URL", "stale-url")
     monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "stale-token")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "stale-openrouter-key")
+    monkeypatch.setenv("PI_API_KEY", "stale-pi-key")
 
     entrypoint.apply_reviewer_env({
         "DAYDREAM_REVIEW_API_KEY": "sk-or-test",
         "DAYDREAM_REVIEW_BASE_URL": "https://openrouter.ai/api",
     })
 
-    assert os.environ["ANTHROPIC_AUTH_TOKEN"] == "sk-or-test"
-    assert os.environ["ANTHROPIC_API_KEY"] == ""
-    assert os.environ["ANTHROPIC_BASE_URL"] == "https://openrouter.ai/api"
+    assert os.environ["PI_PROVIDER"] == "openrouter"
+    assert os.environ["PI_API_KEY"] == "sk-or-test"
+    assert os.environ["PI_TELEMETRY"] == "0"
+    assert "OPENROUTER_API_KEY" not in os.environ
+    assert not any(key.startswith("ANTHROPIC_") for key in os.environ)
+
+
+def test_reviewer_env_rejects_non_openrouter_endpoint():
+    with pytest.raises(entrypoint.EntrypointError, match="openrouter.ai"):
+        entrypoint.apply_reviewer_env({
+            "DAYDREAM_REVIEW_API_KEY": "key",
+            "DAYDREAM_REVIEW_BASE_URL": "https://example.com/api",
+        })
 
 
 def test_entrypoint_skill_free_python_case(tmp_path, monkeypatch):
@@ -49,6 +63,9 @@ def test_entrypoint_skill_free_python_case(tmp_path, monkeypatch):
         "DAYDREAM_REVIEW_CASE_ID": "case-python",
         "DAYDREAM_REVIEW_ARTIFACT_PATH": str(artifact),
         "DAYDREAM_REVIEW_REPO_DIR": str(tmp_path),
+        "DAYDREAM_REVIEW_BACKEND": "pi",
+        "DAYDREAM_REVIEW_API_KEY": "sk-or-test",
+        "DAYDREAM_REVIEW_BASE_URL": "https://openrouter.ai/api",
     }))
     assert rc == 0
     text = Path(artifact).read_text() if Path(artifact).exists() else ""
@@ -74,6 +91,9 @@ def test_entrypoint_env_has_no_skill_dirs(tmp_path, monkeypatch):
         "DAYDREAM_REVIEW_CASE_ID": "case-noskill",
         "DAYDREAM_REVIEW_ARTIFACT_PATH": str(artifact),
         "DAYDREAM_REVIEW_REPO_DIR": str(tmp_path),
+        "DAYDREAM_REVIEW_BACKEND": "pi",
+        "DAYDREAM_REVIEW_API_KEY": "sk-or-test",
+        "DAYDREAM_REVIEW_BASE_URL": "https://openrouter.ai/api",
     }))
     assert rc == 0
     assert os.environ.get("DAYDREAM_SKILLS_DIR") is None

--- a/tests/test_benchmark_harbor_skill_free.py
+++ b/tests/test_benchmark_harbor_skill_free.py
@@ -13,6 +13,21 @@ from pathlib import Path
 from daydream.benchmark.harbor import entrypoint
 
 
+def test_openrouter_reviewer_env_uses_anthropic_auth_token(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "stale-key")
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "stale-url")
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "stale-token")
+
+    entrypoint.apply_reviewer_env({
+        "DAYDREAM_REVIEW_API_KEY": "sk-or-test",
+        "DAYDREAM_REVIEW_BASE_URL": "https://openrouter.ai/api",
+    })
+
+    assert os.environ["ANTHROPIC_AUTH_TOKEN"] == "sk-or-test"
+    assert os.environ["ANTHROPIC_API_KEY"] == ""
+    assert os.environ["ANTHROPIC_BASE_URL"] == "https://openrouter.ai/api"
+
+
 def test_entrypoint_skill_free_python_case(tmp_path, monkeypatch):
     # A Python diff resolves through the controlled entrypoint with no backend
     # network dependency (the runner is stubbed at the production seam): the run

--- a/tests/test_benchmark_run.py
+++ b/tests/test_benchmark_run.py
@@ -31,7 +31,7 @@ def _stub_harbor_environment(monkeypatch):
     real_version = importlib.metadata.version
 
     def _version(dist):
-        return "0.21.0" if dist == "harbor" else real_version(dist)
+        return "0.22.0" if dist == "harbor" else real_version(dist)
 
     monkeypatch.setattr(importlib.metadata, "version", _version)
     monkeypatch.setattr(
@@ -199,6 +199,28 @@ def test_preflight_blocks_unsupported_docker_allowlist(tmp_path):
 
     errs = run_mod._preflight(_ws(tmp_path), oracle=True, env=_env(), docker_ok=lambda: False)
     assert any("Docker allowlist" in e for e in errs)
+
+
+def test_preflight_uses_live_docker_capability_by_default(tmp_path, monkeypatch):
+    """Production preflight must fail with the actual sidecar probe reason."""
+    from types import SimpleNamespace
+
+    import daydream.benchmark.harbor.run as run_mod
+
+    monkeypatch.setattr(
+        run_mod.package,
+        "docker_network_policy_capability",
+        lambda: SimpleNamespace(
+            supported=False,
+            reason="Harbor egress sidecar rejected nftables fib rules",
+        ),
+        raising=False,
+    )
+
+    errs = run_mod._preflight(_ws(tmp_path), oracle=True, env=_env())
+
+    assert any("Docker allowlist" in e for e in errs)
+    assert any("rejected nftables fib rules" in e for e in errs)
 
 
 def test_preflight_ok_for_oracle_without_calibration_receipt(tmp_path):
@@ -436,6 +458,8 @@ def test_run_oracle_writes_receipt_and_running_to_complete(tmp_path):
     assert "--upload" not in captures["args"] and "--publish" not in captures["args"]
     assert any("harbor-oracle.yaml" in str(a) for a in captures["args"])  # selects oracle config
     ledger = json.loads((ws / "runtime" / "harbor.json").read_text())
+    assert captures["args"][-2:] == ["--job-name", ledger["runs"][0]["run_id"]]
+    assert Path(ledger["runs"][0]["job_dir"]).name == ledger["runs"][0]["run_id"]
     assert ledger["runs"][0]["state"] == "complete"
 
 

--- a/tests/test_benchmark_run.py
+++ b/tests/test_benchmark_run.py
@@ -153,6 +153,19 @@ def test_preflight_ok_when_all_checks_pass(tmp_path):
     assert errs == []
 
 
+def test_preflight_requires_explicit_judge_endpoint(tmp_path):
+    import daydream.benchmark.harbor.run as run_mod
+
+    errs = run_mod._preflight(
+        _ws(tmp_path),
+        oracle=True,
+        env=_env(DAYDREAM_JUDGE_API_KEY="sk-or-abc", DAYDREAM_JUDGE_BASE_URL=None),
+        docker_ok=lambda: True,
+    )
+
+    assert any("missing DAYDREAM_JUDGE_BASE_URL" in error for error in errs)
+
+
 def test_preflight_blocks_judge_host_outside_allowlist(tmp_path):
     import daydream.benchmark.harbor.run as run_mod
 

--- a/tests/test_benchmark_verifier_judge.py
+++ b/tests/test_benchmark_verifier_judge.py
@@ -99,8 +99,10 @@ async def test_anthropic_client_posts_messages_and_returns_verdict(sr_module) ->
 @pytest.mark.asyncio
 async def test_openai_client_routes_base_url_and_posts_chat_completions(sr_module) -> None:
     sr = sr_module
-    assert sr.resolve_base_url("sk-or-abc", None) == "https://openrouter.ai/api/v1"
-    assert sr.resolve_base_url("sk-xyz", None) == "https://api.openai.com/v1"
+    with pytest.raises(sr.VerifierError, match="DAYDREAM_JUDGE_BASE_URL"):
+        sr.resolve_base_url("sk-or-abc", None)
+    with pytest.raises(sr.VerifierError, match="DAYDREAM_JUDGE_BASE_URL"):
+        sr.resolve_base_url("sk-xyz", None)
     assert sr.resolve_base_url("sk-xyz", "https://custom.example/v1") == "https://custom.example/v1"
 
     calls = []
@@ -122,7 +124,7 @@ async def test_openai_client_routes_base_url_and_posts_chat_completions(sr_modul
 
     client = sr.OpenAIJudgeClient(
         api_key="sk-or-abc",
-        model="m",
+        model="google/gemini-3.5-flash",
         base_url="https://openrouter.ai/api/v1",
         http=FakeClient(),
     )
@@ -130,7 +132,7 @@ async def test_openai_client_routes_base_url_and_posts_chat_completions(sr_modul
     assert raw == {"match": False, "confidence": 0.2, "reasoning": "no"}
     assert calls[0][0] == "https://openrouter.ai/api/v1/chat/completions"
     assert calls[0][1]["Authorization"] == "Bearer sk-or-abc"
-    assert calls[0][2]["reasoning"] == {"effort": "none"}
+    assert calls[0][2]["reasoning"] == {"exclude": True}
     assert calls[0][2]["response_format"] == {
         "type": "json_schema",
         "json_schema": {

--- a/tests/test_benchmark_verifier_judge.py
+++ b/tests/test_benchmark_verifier_judge.py
@@ -130,6 +130,24 @@ async def test_openai_client_routes_base_url_and_posts_chat_completions(sr_modul
     assert raw == {"match": False, "confidence": 0.2, "reasoning": "no"}
     assert calls[0][0] == "https://openrouter.ai/api/v1/chat/completions"
     assert calls[0][1]["Authorization"] == "Bearer sk-or-abc"
+    assert calls[0][2]["reasoning"] == {"effort": "none"}
+    assert calls[0][2]["response_format"] == {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "verdict",
+            "strict": True,
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "match": {"type": "boolean"},
+                    "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+                    "reasoning": {"type": "string"},
+                },
+                "required": ["match", "confidence", "reasoning"],
+                "additionalProperties": False,
+            },
+        },
+    }
 
 
 @pytest.mark.asyncio
@@ -173,6 +191,57 @@ async def test_retry_policy_retries_transport_and_5xx_then_fails_after_exhaustio
             Always5xx(), url="u", payload={}, headers={}, content=lambda b: b, allowlist={"u"}
         )
     assert len(attempts) == 3  # 3 attempts then fail
+
+
+@pytest.mark.asyncio
+async def test_retry_policy_retries_openrouter_error_envelope(sr_module) -> None:
+    sr = sr_module
+    attempts = []
+
+    class FlakyOpenRouter:
+        async def post(self, url, *, headers, json, timeout):
+            attempts.append(1)
+            if len(attempts) < 3:
+                return type(
+                    "R",
+                    (),
+                    {
+                        "status_code": 200,
+                        "text": "upstream error",
+                        "json": lambda self: {
+                            "error": {
+                                "code": 502,
+                                "message": "Upstream provider temporarily overloaded",
+                            }
+                        },
+                    },
+                )()
+            return type(
+                "R",
+                (),
+                {
+                    "status_code": 200,
+                    "text": "ok",
+                    "json": lambda self: {
+                        "choices": [{
+                            "message": {
+                                "content": '{"match": true, "confidence": 0.8, "reasoning": "x"}'
+                            }
+                        }]
+                    },
+                },
+            )()
+
+    raw = await sr._complete_json_with_http(
+        FlakyOpenRouter(),
+        url="https://openrouter.ai/api/v1/chat/completions",
+        payload={},
+        headers={},
+        content=sr._openai_content,
+        allowlist={"openrouter.ai"},
+    )
+    assert raw["match"] is True
+    assert len(attempts) == 3
 
 
 @pytest.mark.asyncio

--- a/tests/test_benchmark_verifier_judge.py
+++ b/tests/test_benchmark_verifier_judge.py
@@ -1124,11 +1124,12 @@ def test_error_bounding_and_redaction(sr_module) -> None:
 
 def test_provider_allowlist_rejects_unknown_and_validates_base_url(sr_module) -> None:
     sr = sr_module
-    # absent provider defaults to anthropic (unchanged)
-    assert isinstance(sr._build_client(
-        {"DAYDREAM_JUDGE_PROVIDER": None, "DAYDREAM_JUDGE_MODEL": "m",
-         "DAYDREAM_JUDGE_API_KEY": "k", "DAYDREAM_JUDGE_BASE_URL": None}),
-        sr.AnthropicJudgeClient)
+    # Absent providers fail closed instead of selecting an implicit API.
+    with pytest.raises(sr.VerifierError):
+        sr._build_client(
+            {"DAYDREAM_JUDGE_PROVIDER": None, "DAYDREAM_JUDGE_MODEL": "m",
+             "DAYDREAM_JUDGE_API_KEY": "k", "DAYDREAM_JUDGE_BASE_URL": None}
+        )
     # exactly anthropic | openai-compatible accepted
     cert = {"DAYDREAM_JUDGE_PROVIDER": "openai-compatible", "DAYDREAM_JUDGE_MODEL": "m",
             "DAYDREAM_JUDGE_API_KEY": "k", "DAYDREAM_JUDGE_BASE_URL": "https://api.openai.com/v1"}

--- a/tests/test_extension_seam_integration.py
+++ b/tests/test_extension_seam_integration.py
@@ -162,6 +162,25 @@ async def test_post_review_uses_published_items_path(
     assert posted_paths == [stable_items]
 
 
+async def test_report_only_review_mode_never_enters_pr_posting(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ctx = _post_context(
+        dd=tmp_path / "private-deep",
+        items_file=tmp_path / "stable-merged-items.json",
+    )
+    ctx.data["mode"] = "review"
+
+    async def _post_forbidden(*_args: object, **_kwargs: object) -> None:
+        pytest.fail("report-only review mode must not resolve or post to a PR")
+
+    monkeypatch.setattr(
+        "daydream.pr_review.post_review_to_pr_from_report", _post_forbidden
+    )
+
+    assert await _step_post_review(ctx) is None
+
+
 async def test_fork_filter_controls_findings_artifact(
     ext_dir: ExtDir,
     multi_stack_target: Path,

--- a/uv.lock
+++ b/uv.lock
@@ -525,7 +525,7 @@ dev = [
 requires-dist = [
     { name = "anyio", specifier = ">=4.0" },
     { name = "claude-agent-sdk", specifier = "==0.2.116" },
-    { name = "harbor", marker = "extra == 'benchmark'", specifier = ">=0.21,<0.22" },
+    { name = "harbor", marker = "extra == 'benchmark'", specifier = ">=0.22,<0.23" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "jsonschema", specifier = ">=4.0" },
     { name = "pydantic", specifier = ">=2.11.7" },
@@ -782,7 +782,7 @@ wheels = [
 
 [[package]]
 name = "harbor"
-version = "0.21.0"
+version = "0.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dirhash" },
@@ -807,9 +807,9 @@ dependencies = [
     { name = "typer" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/30/c854dcf2b6cbc67f97265e1fd07de02b29419007d4258cded336c23d6356/harbor-0.21.0.tar.gz", hash = "sha256:93f7c2e4b150b2983a90b226c61daf071c35a9dd0f76e1053413d9ee0d738395", size = 1690211, upload-time = "2026-08-10T20:52:34.767Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/a0/a37532fb647b93ef709b63a7fbdf613a84837a569fdd88f69dd7105bf093/harbor-0.22.0.tar.gz", hash = "sha256:becf0ce354026cc37899855e0a0d2687cd5188034a43635849245069aad0938b", size = 1832554, upload-time = "2026-08-22T03:22:39.798Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/a4/b3e8aafbc0a002501c11c91958fc31a5098c2bd9376c46225af615373329/harbor-0.21.0-py3-none-any.whl", hash = "sha256:c77d779a03f1a9e8ecb3c449e17f39a9728b82238832f1fd28632eb9426c0a21", size = 1896665, upload-time = "2026-08-10T20:52:32.305Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/12/d517f1ca18738f7be78a210b13264c64bace531fdf644632128966aca530/harbor-0.22.0-py3-none-any.whl", hash = "sha256:4c4c6571b3d160ed0cb45b82918136751fb08e7b8596412723ac00dde12eeabb", size = 2058718, upload-time = "2026-08-22T03:22:38.071Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Make the private Osprey Harbor benchmark run end to end on standard Docker Desktop for macOS while preserving Harbor network-policy semantics. The reviewer and separate verifier remain restricted to `openrouter.ai`; unsupported Docker nftables policies fail before a paid run and never fall back to public networking.

## Changes

### Added
- Install the pinned Pi CLI in compiled task environments and map reviewer credentials to Pi's native OpenRouter provider.
- Probe Harbor's exact egress-sidecar nftables rules during Daydream preflight and report failures explicitly.
- Retry transient OpenRouter error envelopes returned with HTTP 200 responses.

### Changed
- Upgrade the benchmark extra from Harbor 0.21 to Harbor 0.22.
- Make the Harbor reviewer Pi/OpenRouter-only and require an explicit OpenRouter judge provider and endpoint.
- Package verifier metadata into the separate verifier image and retain the generated `no-network`/allowlist phase boundaries.
- Bind Harbor job names to Daydream run IDs so ledger reconciliation selects the correct artifacts.

### Fixed
- Keep report-only reviews out of PR-posting behavior.
- Bound candidate display titles while preserving the full finding description in the body.
- Skip excluded cases during compilation and handle OpenRouter structured-output requirements and transient upstream errors.

### Removed
- Remove redundant mocked sidecar and OpenRouter happy-path tests; the real Harbor benchmark validates those dependency paths.

## Motivation

Harbor 0.21 misreported Docker Desktop egress capability and the affected LinuxKit kernel rejected Harbor's nftables FIB expressions. Harbor 0.22 checks the daemon kernel correctly, and this Docker Desktop host now supports the unchanged upstream sidecar rules. Daydream adds an exact fail-closed preflight while leaving enforcement and phase transitions to Harbor.

## Testing

- [x] Daydream unit and integration tests updated
- [x] Manual Docker Desktop network-policy validation performed
- [x] Real private two-case Oracle and normal gated benchmark runs completed
- [x] `make check` passed
- [x] Normal pre-push hook passed

`make check` result: 4,670 passed, 8 skipped; Ruff, Mypy, and lock validation passed.

Manual runtime validation on Docker Desktop 4.88.1 / Engine 29.7.2 proved:

- Base environment cannot reach the network.
- Reviewer and separate verifier can reach `openrouter.ai`.
- `github.com`, arbitrary IPv4 and IPv6 addresses, and host-gateway destinations are blocked.
- Oracle completed 2/2 with reward 1.0.
- Normal gated run completed 2/2 with no infrastructure or verifier errors. This was an internal functionality run; no quality threshold was added.

## Operator Impact

Private Harbor benchmark environments now require Harbor 0.22 and Pi/OpenRouter configuration. Harbor 0.21 and the former Claude-default benchmark configuration are no longer supported by this flow.

## Related Issues

Closes #783
Related to #784

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally
- [x] Linting and type checking pass
- [x] Generated policy and real runtime artifacts inspected