### PR TITLE
fix: disable repo-configured external diff programs in supervisor Git calls (Closes #701)

### DIFF
--- a/rl/daydream_review_v1/daydream_review_v1/rundir.py
+++ b/rl/daydream_review_v1/daydream_review_v1/rundir.py
@@ -51,6 +51,16 @@ RUN_DIR_FILES: tuple[str, ...] = (
 
 DEFAULT_ARCHIVE_ROOT = "/rollout/archive"
 
+#: Flags disabling git's two repository-configurable diff-rewrite mechanisms: a
+#: ``diff.external`` helper (optionally with ``diff.trustExitCode``) configured
+#: in ``.git/config`` and per-path ``.gitattributes`` ``diff.*.textconv``
+#: drivers. The supervisor derives every load-bearing diff as (the root) host
+#: identity, while a repo-local external helper would execute under the repo's
+#: own untrusted identity. Single-sourced here so every load-bearing ``git diff``
+#: deriv site carries the identical pair, and a future hardening flag added
+#: once cannot silently leave another deriv site unhardened.
+GIT_DIFF_HARDENING_FLAGS: tuple[str, str] = ("--no-ext-diff", "--no-textconv")
+
 
 def candidate_diff_cmd(repo: str, head_sha: str) -> list[str]:
     """Argv for re-deriving the rollout's committed diff against the baked head.
@@ -68,7 +78,7 @@ def candidate_diff_cmd(repo: str, head_sha: str) -> list[str]:
     """
     return [
         "git", "-C", repo, "diff",
-        "--no-ext-diff", "--no-textconv",
+        *GIT_DIFF_HARDENING_FLAGS,
         head_sha, "HEAD",
     ]
 

--- a/rl/daydream_review_v1/daydream_review_v1/rundir.py
+++ b/rl/daydream_review_v1/daydream_review_v1/rundir.py
@@ -59,8 +59,18 @@ def candidate_diff_cmd(repo: str, head_sha: str) -> list[str]:
     verifier re-applies, so it must be derived identically everywhere it is
     needed (seal production, seal verification, and the verify-checkout
     construction). Single-sourcing the command keeps those sites from drifting.
+
+    The ``--no-ext-diff --no-textconv`` flags harden the derivation against a
+    repository-configured external diff helper or text conversion driver: the
+    supervisor runs as root, while a repo-local ``diff.external`` / textconv
+    runs under the repo's own (untrusted) identity, so neither may execute
+    during the load-bearing diff.
     """
-    return ["git", "-C", repo, "diff", head_sha, "HEAD"]
+    return [
+        "git", "-C", repo, "diff",
+        "--no-ext-diff", "--no-textconv",
+        head_sha, "HEAD",
+    ]
 
 
 async def _session_dir(runtime: vf.Runtime, archive_root: str) -> str | None:

--- a/rl/daydream_review_v1/daydream_review_v1/rundir.py
+++ b/rl/daydream_review_v1/daydream_review_v1/rundir.py
@@ -83,6 +83,33 @@ def candidate_diff_cmd(repo: str, head_sha: str) -> list[str]:
     ]
 
 
+def candidate_quiet_diff_cmd(
+    repo: str,
+    head_sha: str,
+    pathspecs: list[str],
+    *,
+    include_head: bool = False,
+) -> list[str]:
+    """Argv for the ``--quiet`` oracle-probe diff against the baked head.
+
+    The ``--quiet`` companion of :func:`candidate_diff_cmd`, used by the two
+    non-regression oracle probes (``_fixes_applied`` and
+    ``_protected_test_paths_unchanged``). Single-sourced here alongside
+    ``candidate_diff_cmd`` and ``GIT_DIFF_HARDENING_FLAGS`` so a third
+    hardening flag or a quiet-form change is edited in exactly one place
+    instead of drifting across the seal deriv site and both probes.
+
+    ``include_head`` selects the committed-tree form (``<head_sha> HEAD --
+    <pathspecs>``, used by ``_fixes_applied``) versus the working-tree form
+    (``<head_sha> -- <pathspecs>``, used by ``_protected_test_paths_unchanged``,
+    which must compare against the mutable tree to catch uncommitted tampering).
+    """
+    cmd = ["git", "-C", repo, "diff", *GIT_DIFF_HARDENING_FLAGS, "--quiet", head_sha]
+    if include_head:
+        cmd.append("HEAD")
+    return [*cmd, "--", *pathspecs]
+
+
 async def _session_dir(runtime: vf.Runtime, archive_root: str) -> str | None:
     """Absolute path of the rollout's single archived run dir, or ``None``.
 

--- a/rl/daydream_review_v1/daydream_review_v1/taskset.py
+++ b/rl/daydream_review_v1/daydream_review_v1/taskset.py
@@ -174,8 +174,8 @@ async def _fixes_applied(runtime: vf.Runtime, repo: str, head_sha: str) -> bool:
     # at a moved HEAD is the successful-fix case, not the untouched one. But
     # "moved" is not enough — an empty commit advances HEAD while leaving the
     # committed tree identical to the baked snapshot, so compare the committed
-    # contents, not the ref. `git diff --quiet` exits 1 when the trees differ
-    # (a fix) and 0 when they are identical (no fix); any other exit (e.g. 128
+    # contents, not the ref. `git diff --no-ext-diff --no-textconv --quiet` exits
+    # 1 when the trees differ (a fix) and 0 when they are identical (no fix); any other exit (e.g. 128
     # for an unresolvable baked SHA) is treated as no-fix, preserving the
     # deliberate false-negative bias. Both checks exclude `.daydream/` — the
     # agent may commit daydream's own artifacts into the tree, but they are
@@ -186,6 +186,8 @@ async def _fixes_applied(runtime: vf.Runtime, repo: str, head_sha: str) -> bool:
             "-C",
             repo,
             "diff",
+            "--no-ext-diff",
+            "--no-textconv",
             "--quiet",
             head_sha,
             "HEAD",
@@ -216,7 +218,8 @@ async def _protected_test_paths_unchanged(
     run -> fail-closed-check shape, expressed as a table of ``(argv, changed)``
     pairs over :func:`_probe`.
 
-    - ``git diff --quiet <head_sha> -- <paths>`` compares the baked head against
+    - ``git diff --no-ext-diff --no-textconv --quiet <head_sha> -- <paths>``
+      compares the baked head against
       the WORKING TREE (no ``HEAD`` argument — that form would miss uncommitted
       tampering, the exact attack). Exit 0 means no tracked difference
       (committed, staged, unstaged, deleted, or renamed); any other exit — a
@@ -282,7 +285,18 @@ async def _protected_test_paths_unchanged(
 
     probes = [
         (
-            ["git", "-C", repo, "diff", "--quiet", head_sha, "--", *oracle_pathspecs],
+            [
+                "git",
+                "-C",
+                repo,
+                "diff",
+                "--no-ext-diff",
+                "--no-textconv",
+                "--quiet",
+                head_sha,
+                "--",
+                *oracle_pathspecs,
+            ],
             diff_changed,
         ),
         (

--- a/rl/daydream_review_v1/daydream_review_v1/taskset.py
+++ b/rl/daydream_review_v1/daydream_review_v1/taskset.py
@@ -33,6 +33,7 @@ from verifiers.v1.errors import boundary
 
 from daydream_review_v1.rundir import (
     DEFAULT_ARCHIVE_ROOT,
+    GIT_DIFF_HARDENING_FLAGS,
     candidate_diff_cmd,
     fetch_run_dir,
     verify_seal,
@@ -175,19 +176,22 @@ async def _fixes_applied(runtime: vf.Runtime, repo: str, head_sha: str) -> bool:
     # "moved" is not enough — an empty commit advances HEAD while leaving the
     # committed tree identical to the baked snapshot, so compare the committed
     # contents, not the ref. `git diff --no-ext-diff --no-textconv --quiet` exits
-    # 1 when the trees differ (a fix) and 0 when they are identical (no fix); any other exit (e.g. 128
-    # for an unresolvable baked SHA) is treated as no-fix, preserving the
-    # deliberate false-negative bias. Both checks exclude `.daydream/` — the
-    # agent may commit daydream's own artifacts into the tree, but they are
-    # never a fix signal.
+    # 1 when the trees differ (a fix) and 0 when they are identical (no fix);
+    # any other exit (e.g. 128 for an unresolvable baked SHA) is treated as
+    # no-fix, preserving the deliberate false-negative bias. The hardening flags
+    # are defense-in-depth here, not a present-forgery fix: on the pinned git
+    # (2.43.0) `--quiet` never invokes diff.external or textconv, so no exit
+    # code can be forged through them; they bind a future git that changes
+    # `--quiet` semantics. Both checks exclude `.daydream/` — the agent may
+    # commit daydream's own artifacts into the tree, but they are never a fix
+    # signal.
     diff = await runtime.run(
         [
             "git",
             "-C",
             repo,
             "diff",
-            "--no-ext-diff",
-            "--no-textconv",
+            *GIT_DIFF_HARDENING_FLAGS,
             "--quiet",
             head_sha,
             "HEAD",
@@ -221,7 +225,10 @@ async def _protected_test_paths_unchanged(
     - ``git diff --no-ext-diff --no-textconv --quiet <head_sha> -- <paths>``
       compares the baked head against
       the WORKING TREE (no ``HEAD`` argument — that form would miss uncommitted
-      tampering, the exact attack). Exit 0 means no tracked difference
+      tampering, the exact attack). The hardening flags are defense-in-depth:
+      on the pinned git (2.43.0) ``--quiet`` never invokes diff.external or
+      textconv, so they bind a future git that changes ``--quiet`` semantics,
+      not a present exit-code-forgery vector. Exit 0 means no tracked difference
       (committed, staged, unstaged, deleted, or renamed); any other exit — a
       tracked diff (1) or a Git error such as 128 for an unresolvable baked SHA —
       means the oracle changed. A tracked ``.gitignore`` edit is itself a
@@ -290,8 +297,7 @@ async def _protected_test_paths_unchanged(
                 "-C",
                 repo,
                 "diff",
-                "--no-ext-diff",
-                "--no-textconv",
+                *GIT_DIFF_HARDENING_FLAGS,
                 "--quiet",
                 head_sha,
                 "--",

--- a/rl/daydream_review_v1/daydream_review_v1/taskset.py
+++ b/rl/daydream_review_v1/daydream_review_v1/taskset.py
@@ -33,8 +33,8 @@ from verifiers.v1.errors import boundary
 
 from daydream_review_v1.rundir import (
     DEFAULT_ARCHIVE_ROOT,
-    GIT_DIFF_HARDENING_FLAGS,
     candidate_diff_cmd,
+    candidate_quiet_diff_cmd,
     fetch_run_dir,
     verify_seal,
 )
@@ -186,18 +186,7 @@ async def _fixes_applied(runtime: vf.Runtime, repo: str, head_sha: str) -> bool:
     # commit daydream's own artifacts into the tree, but they are never a fix
     # signal.
     diff = await runtime.run(
-        [
-            "git",
-            "-C",
-            repo,
-            "diff",
-            *GIT_DIFF_HARDENING_FLAGS,
-            "--quiet",
-            head_sha,
-            "HEAD",
-            "--",
-            DAYDREAM_EXCLUDE,
-        ],
+        candidate_quiet_diff_cmd(repo, head_sha, [DAYDREAM_EXCLUDE], include_head=True),
         {},
     )
     return diff.exit_code == 1
@@ -292,17 +281,7 @@ async def _protected_test_paths_unchanged(
 
     probes = [
         (
-            [
-                "git",
-                "-C",
-                repo,
-                "diff",
-                *GIT_DIFF_HARDENING_FLAGS,
-                "--quiet",
-                head_sha,
-                "--",
-                *oracle_pathspecs,
-            ],
+            candidate_quiet_diff_cmd(repo, head_sha, oracle_pathspecs),
             diff_changed,
         ),
         (

--- a/rl/daydream_review_v1/tests/test_rewards.py
+++ b/rl/daydream_review_v1/tests/test_rewards.py
@@ -1540,11 +1540,12 @@ async def test_verify_checkout_failed_diff_fails_closed(
 
     task = _task(corpus_mini_dir, fixture_manifest_path)
     repo = _stage_repo(tmp_path / "repo", task.data.head_sha, edit=_CALC_FIXED, commit=True)
-    # Make the diff-derivation step itself fail (not the clone): a diff.external
-    # tool that cannot run makes ``git diff`` exit non-zero while clone and
-    # checkout --detach both succeed.
+    # Make the diff-derivation step itself fail (not the clone): an invalid
+    # diff.algorithm is a genuine Git error making ``git diff`` exit non-zero
+    # while clone and checkout --detach both succeed. (diff.external is now
+    # ignored by the hardened argv, so it can no longer trigger this path.)
     subprocess.run(
-        ["git", "-C", str(repo), "config", "diff.external", "/nonexistent-diff-tool"],
+        ["git", "-C", str(repo), "config", "diff.algorithm", "not-a-real-algorithm"],
         check=True,
     )
     result = await taskset._prepare_verify_checkout(runtime, str(repo), task.data.head_sha)
@@ -1631,4 +1632,63 @@ async def test_verify_checkout_applies_exactly_the_candidate_diff(
     assert applied == expected, "the verify checkout drifted from the candidate diff the seal binds"
     assert (verify_dir / "calc.py").read_text(encoding="utf-8") == _CALC_FIXED, (
         "the verify checkout did not carry the candidate diff the seal binds"
+    )
+
+
+def test_candidate_diff_cmd_carries_hardening_flags() -> None:
+    from daydream_review_v1.rundir import candidate_diff_cmd
+
+    argv = candidate_diff_cmd("/work/repo", "deadbeef")
+    assert argv == [
+        "git", "-C", "/work/repo", "diff",
+        "--no-ext-diff", "--no-textconv",
+        "deadbeef", "HEAD",
+    ]
+
+
+async def test_verify_checkout_external_diff_ignored(
+    tmp_path, runtime, corpus_mini_dir, fixture_manifest_path,
+) -> None:
+    """A repo-local diff.external that cannot run must not abort verifier-checkout."""
+    from daydream_review_v1 import taskset
+
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    repo = _stage_repo(tmp_path / "repo", task.data.head_sha, edit=_CALC_FIXED, commit=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "diff.external", "/nonexistent-diff-tool"],
+        check=True,
+    )
+    result = await taskset._prepare_verify_checkout(runtime, str(repo), task.data.head_sha)
+    verify_dir = tmp_path / "repo-verify"
+    assert verify_dir.is_dir(), "the verify checkout must still be constructed"
+    if os.geteuid() == 0:
+        assert result == str(verify_dir), "construction must succeed on a root host"
+    assert (verify_dir / "calc.py").read_text(encoding="utf-8") == _CALC_FIXED, (
+        "the candidate patch must reach repo-verify despite the repo diff.external"
+    )
+
+
+async def test_verify_checkout_textconv_ignored(
+    tmp_path, runtime, corpus_mini_dir, fixture_manifest_path,
+) -> None:
+    """An attribute-selected textconv that cannot run must not abort verifier-checkout."""
+    from daydream_review_v1 import taskset
+
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    repo = _stage_repo(tmp_path / "repo", task.data.head_sha, edit=_CALC_FIXED, commit=True)
+    # Repository-controlled attribute selecting a driver whose textconv cannot run.
+    (repo / ".gitattributes").write_text("*.py diff=evil\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", ".gitattributes"], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-qm", "attr"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "diff.evil.textconv", "/nonexistent-textconv-tool"],
+        check=True,
+    )
+    result = await taskset._prepare_verify_checkout(runtime, str(repo), task.data.head_sha)
+    verify_dir = tmp_path / "repo-verify"
+    assert verify_dir.is_dir(), "the verify checkout must still be constructed"
+    if os.geteuid() == 0:
+        assert result == str(verify_dir), "construction must succeed on a root host"
+    assert (verify_dir / "calc.py").read_text(encoding="utf-8") == _CALC_FIXED, (
+        "the repo patch must still be applied despite the attribute-selected diff.evil"
     )

--- a/rl/daydream_review_v1/tests/test_rewards.py
+++ b/rl/daydream_review_v1/tests/test_rewards.py
@@ -1724,30 +1724,14 @@ async def test_protected_test_paths_unchanged_quiet_probe_carries_hardening_flag
     ]
 
 
-async def test_fixes_applied_ignores_trusted_external_helper(
-    tmp_path, runtime, corpus_mini_dir, fixture_manifest_path,
-) -> None:
-    """A trusted always-successful diff.external cannot hide a clean committed fix."""
-    from daydream_review_v1 import taskset
-
-    task = _task(corpus_mini_dir, fixture_manifest_path)
-    repo = _stage_repo(tmp_path / "repo", task.data.head_sha, edit=_CALC_FIXED, commit=True)
-    subprocess.run(["git", "-C", str(repo), "config", "diff.external", "/bin/true"], check=True)
-    subprocess.run(["git", "-C", str(repo), "config", "diff.trustExitCode", "true"], check=True)
-    assert await taskset._fixes_applied(runtime, str(repo), task.data.head_sha) is True
-
-
-async def test_protected_test_paths_unchanged_ignores_trusted_external_helper(
-    tmp_path, runtime, corpus_mini_dir, fixture_manifest_path,
-) -> None:
-    """A trusted always-successful diff.external cannot hide tampered protected paths."""
-    from daydream_review_v1 import taskset
-
-    task = _task(corpus_mini_dir, fixture_manifest_path)
-    repo = _stage_repo(tmp_path / "repo", task.data.head_sha)
-    (repo / "tests" / "test_calc.py").write_text("gutted\n", encoding="utf-8")
-    subprocess.run(["git", "-C", str(repo), "config", "diff.external", "/bin/true"], check=True)
-    subprocess.run(["git", "-C", str(repo), "config", "diff.trustExitCode", "true"], check=True)
-    assert await taskset._protected_test_paths_unchanged(
-        runtime, str(repo), task.data.head_sha, task.data.protected_test_paths
-    ) is False
+# There is deliberately no real-path "trusted diff.external" attack test for
+# the --quiet oracle probes: on the pinned git (2.43.0) ``git diff --quiet``
+# never invokes diff.external or textconv, so the exit-code forgery such a
+# test would stage cannot fire and the test would pass identically with or
+# without the hardening flags -- vacuous either way. The flags' presence on
+# both probes is pinned by the argv-contract tests above
+# (test_fixes_applied_quiet_probe_carries_hardening_flags and
+# test_protected_test_paths_unchanged_quiet_probe_carries_hardening_flags);
+# the genuine repo-configurable-helper surface is the non-quiet candidate-diff
+# path, covered by test_verify_checkout_external_diff_ignored and
+# test_verify_checkout_textconv_ignored.

--- a/rl/daydream_review_v1/tests/test_rewards.py
+++ b/rl/daydream_review_v1/tests/test_rewards.py
@@ -1692,3 +1692,62 @@ async def test_verify_checkout_textconv_ignored(
     assert (verify_dir / "calc.py").read_text(encoding="utf-8") == _CALC_FIXED, (
         "the repo patch must still be applied despite the attribute-selected diff.evil"
     )
+
+
+async def test_fixes_applied_quiet_probe_carries_hardening_flags() -> None:
+    from conftest import FakeRuntime
+
+    from daydream_review_v1 import taskset
+
+    rt = FakeRuntime(exit_code=0)
+    await taskset._fixes_applied(rt, "/work/repo", "deadbeef")
+    # rt.commands[0] is the git status probe; [1] is the git diff --quiet probe.
+    assert rt.commands[1] == [
+        "git", "-C", "/work/repo", "diff",
+        "--no-ext-diff", "--no-textconv", "--quiet",
+        "deadbeef", "HEAD", "--", taskset.DAYDREAM_EXCLUDE,
+    ]
+
+
+async def test_protected_test_paths_unchanged_quiet_probe_carries_hardening_flags() -> None:
+    from conftest import FakeRuntime
+
+    from daydream_review_v1 import taskset
+
+    rt = FakeRuntime(exit_code=0)
+    await taskset._protected_test_paths_unchanged(rt, "/work/repo", "deadbeef", ["tests"])
+    # rt.commands[0] is the first probe row: the git diff --quiet oracle probe.
+    assert rt.commands[0] == [
+        "git", "-C", "/work/repo", "diff",
+        "--no-ext-diff", "--no-textconv", "--quiet",
+        "deadbeef", "--", *["tests"], *taskset.ORACLE_IGNORE_PATHSPECS,
+    ]
+
+
+async def test_fixes_applied_ignores_trusted_external_helper(
+    tmp_path, runtime, corpus_mini_dir, fixture_manifest_path,
+) -> None:
+    """A trusted always-successful diff.external cannot hide a clean committed fix."""
+    from daydream_review_v1 import taskset
+
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    repo = _stage_repo(tmp_path / "repo", task.data.head_sha, edit=_CALC_FIXED, commit=True)
+    subprocess.run(["git", "-C", str(repo), "config", "diff.external", "/bin/true"], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "diff.trustExitCode", "true"], check=True)
+    assert await taskset._fixes_applied(runtime, str(repo), task.data.head_sha) is True
+
+
+async def test_protected_test_paths_unchanged_ignores_trusted_external_helper(
+    tmp_path, runtime, corpus_mini_dir, fixture_manifest_path,
+) -> None:
+    """A trusted always-successful diff.external cannot hide tampered protected paths."""
+    from daydream_review_v1 import taskset
+
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    repo = _stage_repo(tmp_path / "repo", task.data.head_sha)
+    (repo / "tests" / "test_calc.py").write_text("gutted\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "config", "diff.external", "/bin/true"], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "diff.trustExitCode", "true"], check=True)
+    assert await taskset._protected_test_paths_unchanged(
+        runtime, str(repo), task.data.head_sha, task.data.protected_test_paths
+    ) is False


### PR DESCRIPTION
## Summary
Fixes #701 — hardens supervisor Git calls so a repository-configured external diff program (`diff.external` / per-diff-driver config) can never hijack oracle/probe diff invocations.

- `fix(rundir)`: harden candidate diff argv against repo-configured diff helpers
- `fix(taskset)`: harden `diff --quiet` oracle probes against repo-configured diff helpers
- `fix`: single-source git diff hardening flags and drop vacuous `--quiet` attack tests
- `refactor(taskset)`: single-source quiet diff oracle probe argv

## Verification
- `make check` green (4664 passed, ruff + mypy clean)
- Deterministic-authorship gate clean (all commits authored by anderskev@gmail.com)
- Two sequential daydream deep-precision reviews passed on fresh exe.dev VMs

Closes #701