### PR TITLE
fix(deep): show structural review as preflight phase

### DIFF
--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -549,6 +549,14 @@ def _stack_preflight_line(stack: StackAssignment) -> str:
     return f"{stack.stack_name}: {len(stack.files)} file(s){docs_suffix}"
 
 
+def _preflight_stage_names(stacks: list[StackAssignment]) -> list[str]:
+    """Return user-facing stages, including the structural review when active."""
+    stages = list(_PIPELINE_STAGE_NAMES)
+    if any(stack.stack_name == STRUCTURE_STACK_NAME for stack in stacks):
+        stages.insert(3, "structural review (parallel with per-stack reviews)")
+    return stages
+
+
 def _attach_verdicts(items: list[dict[str, Any]], payload: dict[str, Any]) -> list[dict[str, Any]]:
     """Attach verifier verdicts to feedback items by matching `id` to `issue_id`.
 
@@ -4189,7 +4197,11 @@ async def _run_review_spine(config: RunConfig, work: WorkContext, mode: str) -> 
         # Pre-flight notice (D-30). Agent count reflects the tiny-diff collapse
         # when single_stack_mode is active (issue #172): merge+arbiter are
         # skipped, so the estimate uses ``_single_stack_agent_count``.
-        stack_lines = [_stack_preflight_line(s) for s in stacks]
+        stack_lines = [
+            _stack_preflight_line(stack)
+            for stack in stacks
+            if stack.stack_name != STRUCTURE_STACK_NAME
+        ]
         notice_agent_count = (
             _single_stack_agent_count(len(stacks))
             if single_stack_mode
@@ -4197,7 +4209,7 @@ async def _run_review_spine(config: RunConfig, work: WorkContext, mode: str) -> 
         )
         print_preflight_notice(
             console,
-            stages=_PIPELINE_STAGE_NAMES,
+            stages=_preflight_stage_names(stacks),
             stack_lines=stack_lines,
             agent_count=notice_agent_count,
             exploration_available=EXPLORATION_AVAILABLE,

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -3406,11 +3406,22 @@ async def test_preflight_notice(multi_stack_target: Path, monkeypatch: pytest.Mo
     assert exit_code == 0
     assert len(captured) == 1, "pre-flight notice must fire exactly once"
     notice = captured[0]
-    assert len(notice["stages"]) == 5
+    assert notice["stages"] == [
+        "TTT intent",
+        "TTT alternative-review",
+        "per-stack reviews",
+        "structural review (parallel with per-stack reviews)",
+        "cross-stack merge",
+        "optional fix gate",
+    ]
     # Agent count = 2 TTT + N per-stack + N parse + 1 merge + 1 arbiter;
     # fixture yields N=4 (python + react + generic + structure), so 2 + 2*4 + 1 + 1 = 12.
     assert notice["agent_count"] == 12
-    assert len(notice["stack_lines"]) >= 1
+    assert notice["stack_lines"] == [
+        "python: 1 file(s)",
+        "react: 1 file(s)",
+        "generic: 1 file(s)",
+    ]
     # Issue #309 finding 8: the sweep is enabled by default, so the pre-flight
     # estimate appends an upper-bound note. The fixture changes 3 files, so the
     # sweep could add up to 2 x min(3, max_files=10) = 6 review+parse agents.


### PR DESCRIPTION
## Summary

Correct the deep-review preflight presentation so the synthetic structural review scope is shown as a pipeline phase instead of a detected technology stack.

## Changes

### Fixed
- Exclude the internal `structure` meta-stack from the detected-stacks list.
- Show structural review in the stage list when it is active, noting that it runs in parallel with per-stack reviews.
- Preserve the existing scheduling, artifact, and agent-count behavior.

### Changed
- Strengthen the preflight integration test to assert the exact stage and detected-stack output.

## Motivation

`structure` is an internal whole-change review scope, not a technology inferred from changed files. Listing it beside Python, React, and other detected stacks made the preflight output misleading.

## Testing

- [x] Integration test updated
- [x] Ruff passes
- [x] mypy passes
- [x] Full test suite passes: 4709 passed, 8 skipped

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally
- [x] Linting passes