### PR TITLE
ci: pin the actionlint 1.7.7 container and contributor command by OCI digest (Closes #709)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,7 +35,7 @@
 <!-- Verify before requesting review. -->
 
 - [ ] Repository checks pass locally (`make check`)
-- [ ] Actionlint passes for workflow YAML changes (if applicable): `docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:1.7.7 -color .github/workflows/*.yml daydream/templates/workflows/*.yml daydream/templates/workflows/single/*.yml`
+- [ ] Actionlint passes for workflow YAML changes (if applicable): `docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:1.7.7@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9 -color .github/workflows/*.yml daydream/templates/workflows/*.yml daydream/templates/workflows/single/*.yml`
 - [ ] Documentation updated (if applicable)
 
 ## Additional Context

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         run: uv run mypy daydream tests bench
 
       - name: Lint workflows with actionlint
-        run: docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:1.7.7 -color .github/workflows/*.yml daydream/templates/workflows/*.yml daydream/templates/workflows/single/*.yml
+        run: docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:1.7.7@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9 -color .github/workflows/*.yml daydream/templates/workflows/*.yml daydream/templates/workflows/single/*.yml
 
       - name: Run tests
         run: uv run pytest -n auto

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -20,6 +20,9 @@ cannot verify and that a careless edit could silently break:
 - The repository workflow README declares these files as repository-only Codex
   dogfood configuration and points to the packaged install guide (never copies
   ``ANTHROPIC_API_KEY``).
+- The CI actionlint step and the contributor PR checklist both reference the
+  actionlint image by immutable OCI digest (``rhysd/actionlint:1.7.7@sha256:…``),
+  so a revert to a mutable tag, or drift between the two, fails the suite.
 - The CI actionlint step covers every workflow the project ships — the repo's
   own top-level workflows plus all recursively discovered template workflows
   (the nested ``single/daydream.yml`` included) — and each selector still has
@@ -41,8 +44,11 @@ import yaml
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 TEMPLATES_DIR = _REPO_ROOT / "daydream" / "templates" / "workflows"
 REPO_WORKFLOWS_DIR = _REPO_ROOT / ".github" / "workflows"
+PR_TEMPLATE_PATH = _REPO_ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md"
+_ACTIONLINT_IMAGE = "rhysd/actionlint:1.7.7@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9"
 
 _SECRET_REF_RE = re.compile(r"secrets\.([A-Za-z0-9_]+)")
+_ACTIONLINT_REF_RE = re.compile(r"rhysd/actionlint:[^\s`]+")
 
 
 def load_workflow(path: Path) -> dict[str, Any]:
@@ -740,6 +746,24 @@ def test_repo_workflow_readme_declares_codex_and_points_to_canonical_install() -
     # Absence of the stale strings.
     for stale in ("Copy the three workflow files", "Install step 1", "ANTHROPIC_API_KEY"):
         assert stale not in text
+
+
+def test_ci_and_pr_template_pin_actionlint_image_by_digest() -> None:
+    wf = load_workflow(REPO_WORKFLOWS_DIR / "ci.yml")
+    steps = job_steps(wf, "check")
+    actionlint = next(s for s in steps if s.get("name") == "Lint workflows with actionlint")
+
+    ci_refs = _ACTIONLINT_REF_RE.findall(actionlint["run"])
+    pr_refs = _ACTIONLINT_REF_RE.findall(PR_TEMPLATE_PATH.read_text(encoding="utf-8"))
+
+    assert ci_refs == [_ACTIONLINT_IMAGE], (
+        "CI actionlint step must reference the digest-pinned image exactly once: "
+        f"found {ci_refs}"
+    )
+    assert pr_refs == [_ACTIONLINT_IMAGE], (
+        "PR template Actionlint checklist must reference the digest-pinned image "
+        f"exactly once: found {pr_refs}"
+    )
 
 
 # CI coverage guard: the actionlint step in .github/workflows/ci.yml must

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -45,6 +45,13 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 TEMPLATES_DIR = _REPO_ROOT / "daydream" / "templates" / "workflows"
 REPO_WORKFLOWS_DIR = _REPO_ROOT / ".github" / "workflows"
 PR_TEMPLATE_PATH = _REPO_ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md"
+# The digest below matches the immutable rhysd/actionlint:1.7.7 manifest digest
+# verified against the live OCI registry (`docker buildx imagetools inspect
+# rhysd/actionlint:1.7.7` / `docker manifest inspect …@sha256:887a…147e9`;
+# both the tagged ref and the raw sha256 resolve to it). The registry is the only
+# authoritative source: this constant is a pin, not a verification of itself.
+# Any future edit to the digest MUST be re-verified against that registry before
+# landing, or CI `docker pull` will fail at run time.
 _ACTIONLINT_IMAGE = "rhysd/actionlint:1.7.7@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9"
 
 _SECRET_REF_RE = re.compile(r"secrets\.([A-Za-z0-9_]+)")
@@ -749,6 +756,14 @@ def test_repo_workflow_readme_declares_codex_and_points_to_canonical_install() -
 
 
 def test_ci_and_pr_template_pin_actionlint_image_by_digest() -> None:
+    # Caveat (matches _PINNED_ACTION_VERSIONS, which also cannot verify a
+    # SHA-->release mapping against its upstream): these assertions only prove the
+    # three copies agree with one another. They cannot, and are not intended to,
+    # re-derive the manifest digest from the registry. _ACTIONLINT_IMAGE is a
+    # golden pin whose correctness was verified against the live OCI registry at
+    # write time (see its definition comment); if it is ever changed to a
+    # different 64-hex value without such a re-verification, this suite stays
+    # green and the failure surfaces only at CI runtime on `docker pull`.
     wf = load_workflow(REPO_WORKFLOWS_DIR / "ci.yml")
     steps = job_steps(wf, "check")
     actionlint = next(s for s in steps if s.get("name") == "Lint workflows with actionlint")


### PR DESCRIPTION
## Summary
- Pins the actionlint 1.7.7 container image and contributor-facing command to an immutable OCI digest instead of a mutable tag
- Adds test documentation for registry re-verification of the pinned digest (round-2 review follow-up)

Two sequential daydream deep-precision reviews passed (rounds 1 & 2); `make check` green on the pushed tree (4710 passed / 8 skipped).

Closes #709