### PR TITLE
fix(pi): detect stalled responses before wall budget

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ recorder are backend-agnostic.
 | `DEFAULT_TOOL_CALL_BUDGET` | `None` | unlimited; per-call `tool_call_budget` still accepted |
 | `DEFAULT_GROUP_MAX_WALL_S` / `_SERIAL_ITEMS` | 600s / 6 | cumulative over all fix calls for one file group |
 | `EXPLORATION_MAX_TURNS` | 50 | exploration specialists — the only `max_turns` call site |
-| `DAYDREAM_STREAM_IDLE_TIMEOUT_S` | 2700s | pi/codex stdout silence before the subprocess is killed |
+| `DAYDREAM_STREAM_IDLE_TIMEOUT_S` | 300s / 2700s | pi response silence / active-tool and codex silence before the subprocess is killed |
 
 - Exhaustion emits a `TurnEndEvent` and marks the trajectory partial. **Truncation is never silently
   absorbed**: a truncated wonder or parse raises; a truncated per-stack review goes to `failed_stacks` so
@@ -129,9 +129,10 @@ recorder are backend-agnostic.
 - Do not add `max_turns` to fix or verify — it does not fail soft. The turn ends `error_max_turns`, the
   backend raises `MaxTurnsError`, and the fix group lands in `fix-failures.json` and is reverted, throwing
   a real fix away rather than trimming it.
-- `run_agent` retries any `retryable` backend error with exponential backoff, **20 attempts**, all backends
-  (`DAYDREAM_PI_RETRY_ATTEMPTS` overrides). Never retried: tool-supervisor veto,
-  non-transport logic error. A stall fires only on the *absence* of output, never on slow output.
+- `run_agent` retries retryable backend errors with exponential backoff, up to **20 attempts**, all backends
+  (`DAYDREAM_PI_RETRY_ATTEMPTS` overrides); a stream stall gets one fresh attempt. Never retried:
+  tool-supervisor veto, non-transport logic error. A stall fires only on the *absence* of output, never
+  on slow output; pi keeps the long window while a tool is active.
 
 ### Config and per-phase model overrides
 
@@ -221,7 +222,7 @@ Full contract: `docs/extensions.md`.
 | `PI_API_KEY` | Pi | Copied into the child's provider-native var (e.g. `ZAI_API_KEY`), **never onto argv**; warns and ignores if the provider has no mapped var |
 | `DAYDREAM_PI_RETRY_ATTEMPTS` / `_BASE_DELAY_S` / `_MAX_DELAY_S` | Retry | Attempts default 20, all backends |
 | `DAYDREAM_FANOUT_CONCURRENCY` | Claude / Codex | Parallel `execute()` hint (default 8; bad value warns). Pi uses `DAYDREAM_PI_FANOUT_CONCURRENCY` (default 10) |
-| `DAYDREAM_STREAM_IDLE_TIMEOUT_S` | Pi / Codex | Stdout-silence kill (default 2700; `0` disables) |
+| `DAYDREAM_STREAM_IDLE_TIMEOUT_S` | Pi / Codex | Stdout-silence kill (pi response default 300; active-tool/codex default 2700; `0` disables) |
 | `DAYDREAM_REVIEW_API_KEY` / `DAYDREAM_JUDGE_API_KEY` | Benchmark | Harbor reviewer/judge OpenRouter keys; read from the launching env, never written into the workspace or task |
 
 Plain path overrides: `DAYDREAM_PRICES_FILE`, `DAYDREAM_ARCHIVE_DIR`, `PI_CODING_AGENT_DIR` (`~/.pi/agent`), `CLAUDE_CONFIG_DIR` (`~/.claude`).

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -855,14 +855,17 @@ async def run_agent(
             except _ToolSupervisorFailure:
                 raise
             except Exception as exc:
-                if attempt < max_attempts and getattr(exc, "retryable", False):
+                exception_max_retries = min(
+                    max_attempts, getattr(exc, "max_retries", max_attempts)
+                )
+                if attempt < exception_max_retries and getattr(exc, "retryable", False):
                     delay = min(
                         base_delay * (2 ** attempt) + random.uniform(0, 1),
                         max_delay,
                     )
                     retry_msg = (
                         f"Backend error ({type(exc).__name__}), retrying "
-                        f"attempt {attempt + 2}/{max_attempts + 1} after {delay:.1f}s..."
+                        f"attempt {attempt + 2}/{exception_max_retries + 1} after {delay:.1f}s..."
                     )
                     if _state.log_mode:
                         _print_log(f"[retry] {retry_msg}")

--- a/daydream/backends/_subprocess.py
+++ b/daydream/backends/_subprocess.py
@@ -34,12 +34,12 @@ logger = logging.getLogger(__name__)
 #    stream is legitimately dead for the whole duration of any single tool call
 #    or generation block.
 #
-# 2700s is 2.7x codex's largest observed turn span and 1.4x pi's, and it sits
-# deliberately ABOVE ``config.DEFAULT_WALL_BUDGET_S`` (1800s) so it can never
-# act as a second, shorter turn cap on phases that already carry a wall budget.
-# It is a backstop for the turns nothing else bounds — the improve phases run
-# with no wall budget at all — and for stalls that outlive the process.
+# 2700s is 2.7x codex's largest observed turn span and remains the tool-active
+# window for pi, where an output-silent build or test may legitimately run for
+# most of a phase's wall budget. Pi model responses use a shorter default below:
+# unlike codex, pi emits token-level message updates while the model is alive.
 DEFAULT_STREAM_IDLE_TIMEOUT_S = 2700.0
+DEFAULT_PI_RESPONSE_IDLE_TIMEOUT_S = 300.0
 STREAM_IDLE_TIMEOUT_ENV = "DAYDREAM_STREAM_IDLE_TIMEOUT_S"
 
 # Grace between SIGTERM and SIGKILL when reaping a subprocess. A cooperative CLI
@@ -56,6 +56,7 @@ class StreamStalledError(Exception):
     """
 
     retryable = True
+    max_retries = 1
 
     def __init__(self, cli: str, timeout_s: float) -> None:
         super().__init__(
@@ -67,12 +68,14 @@ class StreamStalledError(Exception):
         self.timeout_s = timeout_s
 
 
-def stream_idle_timeout_s() -> float | None:
+def stream_idle_timeout_s(
+    *, default: float = DEFAULT_STREAM_IDLE_TIMEOUT_S
+) -> float | None:
     """Resolve the stdout idle timeout in seconds.
 
     Returns ``None`` when idle detection is disabled — an explicit ``0`` in
     ``$DAYDREAM_STREAM_IDLE_TIMEOUT_S``. A malformed, non-finite, or negative
-    value logs a warning and falls back to the default (mirroring
+    value logs a warning and falls back to *default* (mirroring
     ``DAYDREAM_PI_RETRY_ATTEMPTS`` handling in :mod:`daydream.backends.pi`).
     """
     raw = os.environ.get(STREAM_IDLE_TIMEOUT_ENV)
@@ -82,24 +85,24 @@ def stream_idle_timeout_s() -> float | None:
         except ValueError:
             logger.warning(
                 "%s=%r is not a valid float; using default %g",
-                STREAM_IDLE_TIMEOUT_ENV, raw, DEFAULT_STREAM_IDLE_TIMEOUT_S,
+                STREAM_IDLE_TIMEOUT_ENV, raw, default,
             )
         else:
             if not math.isfinite(value):
                 logger.warning(
                     "%s=%r is not finite; using default %g",
-                    STREAM_IDLE_TIMEOUT_ENV, raw, DEFAULT_STREAM_IDLE_TIMEOUT_S,
+                    STREAM_IDLE_TIMEOUT_ENV, raw, default,
                 )
             elif value < 0:
                 logger.warning(
                     "%s=%r is negative; using default %g",
-                    STREAM_IDLE_TIMEOUT_ENV, raw, DEFAULT_STREAM_IDLE_TIMEOUT_S,
+                    STREAM_IDLE_TIMEOUT_ENV, raw, default,
                 )
             elif value == 0:
                 return None
             else:
                 return value
-    return DEFAULT_STREAM_IDLE_TIMEOUT_S
+    return default
 
 
 async def readline_with_idle_timeout(

--- a/daydream/backends/pi.py
+++ b/daydream/backends/pi.py
@@ -49,6 +49,8 @@ from daydream.backends import (
     resolve_fanout_concurrency,
 )
 from daydream.backends._subprocess import (
+    DEFAULT_PI_RESPONSE_IDLE_TIMEOUT_S,
+    DEFAULT_STREAM_IDLE_TIMEOUT_S,
     cancel_processes,
     readline_with_idle_timeout,
     stream_idle_timeout_s,
@@ -669,13 +671,25 @@ class PiBackend:
             )
             self._processes.append(proc)
 
-            idle_timeout_s = stream_idle_timeout_s()
+            response_idle_timeout_s = stream_idle_timeout_s(
+                default=DEFAULT_PI_RESPONSE_IDLE_TIMEOUT_S
+            )
+            tool_idle_timeout_s = stream_idle_timeout_s(
+                default=DEFAULT_STREAM_IDLE_TIMEOUT_S
+            )
+            active_tool_calls = 0
             is_first_line = True
             while True:
                 if proc.stdout is None:
                     break
                 line = await readline_with_idle_timeout(
-                    proc.stdout, cli="pi", timeout_s=idle_timeout_s
+                    proc.stdout,
+                    cli="pi",
+                    timeout_s=(
+                        tool_idle_timeout_s
+                        if active_tool_calls > 0
+                        else response_idle_timeout_s
+                    ),
                 )
                 if not line:
                     break
@@ -738,6 +752,7 @@ class PiBackend:
                             last_assistant_text = "".join(text_parts)
 
                 elif event_type == "tool_execution_start":
+                    active_tool_calls += 1
                     yield ToolStartEvent(
                         id=event.get("toolCallId") or str(uuid.uuid4()),
                         name=event.get("toolName", "unknown"),
@@ -745,6 +760,7 @@ class PiBackend:
                     )
 
                 elif event_type == "tool_execution_end":
+                    active_tool_calls = max(0, active_tool_calls - 1)
                     yield ToolResultEvent(
                         id=event.get("toolCallId") or str(uuid.uuid4()),
                         output=_render_tool_result(event.get("result")),
@@ -752,6 +768,7 @@ class PiBackend:
                     )
 
                 elif event_type == "turn_end":
+                    active_tool_calls = 0
                     msg = event.get("message") or {}
                     stop_reason = msg.get("stopReason")
                     if stop_reason == "error":

--- a/tests/test_agent_retry.py
+++ b/tests/test_agent_retry.py
@@ -16,6 +16,7 @@ import pytest
 
 from daydream.agent import run_agent
 from daydream.backends import ResultEvent, TextEvent
+from daydream.backends._subprocess import StreamStalledError
 from daydream.backends.pi import PiError, _is_retryable_error_message
 from daydream.trajectory import DaydreamPhase, DaydreamRunFlow, TrajectoryRecorder
 from tests.harness.backend import ScriptedBackend
@@ -158,6 +159,26 @@ async def test_run_agent_retry_exhausted(monkeypatch, tmp_path: Path) -> None:
 
     # 1 original attempt + 2 retries = 3 total
     assert backend.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_stream_stall_gets_only_one_fresh_attempt(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Repeated dead-air windows cannot multiply into hours of retries."""
+    monkeypatch.setenv("DAYDREAM_PI_RETRY_BASE_DELAY_S", "0")
+    monkeypatch.setenv("DAYDREAM_PI_RETRY_MAX_DELAY_S", "0")
+    backend = ScriptedBackend(
+        events=[StreamStalledError("pi", 300)],
+        retry_attempts=5,
+        retry_base_delay_s=0,
+        retry_max_delay_s=0,
+    )
+
+    with pytest.raises(StreamStalledError):
+        await run_agent(backend, tmp_path, "review", phase=DaydreamPhase.REVIEW)
+
+    assert backend.call_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_backend_stream_idle.py
+++ b/tests/test_backend_stream_idle.py
@@ -29,11 +29,13 @@ import textwrap
 from pathlib import Path
 from typing import Any
 
+import anyio
 import pytest
 
 from daydream.agent import run_agent
 from daydream.backends import ResultEvent, TextEvent
 from daydream.backends._subprocess import (
+    DEFAULT_PI_RESPONSE_IDLE_TIMEOUT_S,
     DEFAULT_STREAM_IDLE_TIMEOUT_S,
     STREAM_IDLE_TIMEOUT_ENV,
     StreamStalledError,
@@ -159,6 +161,86 @@ async def test_pi_stalls_before_first_line(
     assert_stalled_and_reaped(spawner)
 
 
+@pytest.mark.asyncio
+async def test_pi_response_stall_uses_shorter_default_window(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Silence after a completed tool result is a model-response stall.
+
+    The archived failure this covers completed a bounded source read and then
+    emitted nothing for the rest of the 30-minute wall budget. Pi streams model
+    deltas, so once no tool is active its response-specific idle window should
+    preempt the generic subprocess window and surface a retryable stall.
+    """
+    lines = [
+        json.dumps({"type": "session", "id": "sess-response-stall"}),
+        json.dumps({"type": "agent_start"}),
+        json.dumps({"type": "turn_start"}),
+        json.dumps(
+            {
+                "type": "tool_execution_start",
+                "toolCallId": "read-1",
+                "toolName": "read",
+                "args": {"path": "src/lib.rs"},
+            }
+        ),
+        json.dumps(
+            {
+                "type": "tool_execution_end",
+                "toolCallId": "read-1",
+                "result": {"content": [{"type": "text", "text": "done"}]},
+            }
+        ),
+    ]
+    spawner = install_fake_cli_process(monkeypatch, "pi", lines=lines, hang=True)
+    monkeypatch.delenv(STREAM_IDLE_TIMEOUT_ENV, raising=False)
+    monkeypatch.setattr(
+        "daydream.backends.pi.DEFAULT_PI_RESPONSE_IDLE_TIMEOUT_S", 0.05, raising=False
+    )
+
+    with anyio.fail_after(1):
+        with pytest.raises(StreamStalledError) as excinfo:
+            await drain(PiBackend(model="test-model"), tmp_path)
+
+    assert excinfo.value.timeout_s == pytest.approx(0.05)
+    assert_stalled_and_reaped(spawner)
+
+
+@pytest.mark.asyncio
+async def test_pi_active_tool_keeps_long_subprocess_window(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An output-silent tool may legitimately outlive the response window."""
+    lines = [
+        json.dumps({"type": "session", "id": "sess-active-tool"}),
+        json.dumps({"type": "agent_start"}),
+        json.dumps({"type": "turn_start"}),
+        json.dumps(
+            {
+                "type": "tool_execution_start",
+                "toolCallId": "cargo-1",
+                "toolName": "bash",
+                "args": {"command": "cargo build --quiet"},
+            }
+        ),
+    ]
+    spawner = install_fake_cli_process(monkeypatch, "pi", lines=lines, hang=True)
+    monkeypatch.delenv(STREAM_IDLE_TIMEOUT_ENV, raising=False)
+    monkeypatch.setattr(
+        "daydream.backends.pi.DEFAULT_PI_RESPONSE_IDLE_TIMEOUT_S", 0.05, raising=False
+    )
+    monkeypatch.setattr(
+        "daydream.backends.pi.DEFAULT_STREAM_IDLE_TIMEOUT_S", 0.2, raising=False
+    )
+
+    with anyio.fail_after(1):
+        with pytest.raises(StreamStalledError) as excinfo:
+            await drain(PiBackend(model="test-model"), tmp_path)
+
+    assert excinfo.value.timeout_s == pytest.approx(0.2)
+    assert_stalled_and_reaped(spawner)
+
+
 # --------------------------------------------------------------------------
 # A stream with data flowing must NOT trip, however small the window. This is
 # the regression that keeps a genuinely slow-but-alive model from being killed
@@ -242,19 +324,22 @@ def test_malformed_override_falls_back_to_default(
     assert stream_idle_timeout_s() == DEFAULT_STREAM_IDLE_TIMEOUT_S
 
 
-def test_default_exceeds_the_wall_budget(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The idle window must never act as a shorter, second turn cap.
+def test_default_windows_straddle_the_wall_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pi responses preempt the wall; tools and codex retain the long window.
 
-    Budgeted phases are bounded by ``DEFAULT_WALL_BUDGET_S``; the idle timeout is
-    a backstop for the turns nothing else bounds (the improve phases run with no
-    wall budget). Keeping it strictly above the wall budget is what guarantees
-    this change cannot shorten any phase that works today.
+    Pi's response stream is live while the model generates, so five minutes of
+    silence is a stall. Codex generations and output-silent tools can legitimately
+    remain quiet much longer and must still be bounded by the phase wall budget.
     """
     from daydream.config import DEFAULT_WALL_BUDGET_S
 
     monkeypatch.delenv(STREAM_IDLE_TIMEOUT_ENV, raising=False)
     assert stream_idle_timeout_s() == DEFAULT_STREAM_IDLE_TIMEOUT_S
-    assert DEFAULT_STREAM_IDLE_TIMEOUT_S > DEFAULT_WALL_BUDGET_S
+    assert (
+        DEFAULT_PI_RESPONSE_IDLE_TIMEOUT_S
+        < DEFAULT_WALL_BUDGET_S
+        < DEFAULT_STREAM_IDLE_TIMEOUT_S
+    )
 
 
 # --------------------------------------------------------------------------
@@ -264,10 +349,10 @@ def test_default_exceeds_the_wall_budget(monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 @pytest.mark.asyncio
-async def test_stall_is_retried_within_bounded_budget(
+async def test_stall_retry_is_limited_below_backend_retry_budget(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A persistently-stalling ``pi`` consumes only the bounded retry budget."""
+    """A persistent stall gets one fresh process, not every transport retry."""
     spawner = install_fake_cli_process(monkeypatch, "pi", lines=PI_LINES[:2], hang=True)
     monkeypatch.setenv(STREAM_IDLE_TIMEOUT_ENV, TINY_WINDOW)
     monkeypatch.setenv("DAYDREAM_PI_RETRY_ATTEMPTS", "3")
@@ -290,7 +375,7 @@ async def test_stall_is_retried_within_bounded_budget(
         async with recorder:
             await run_agent(backend, tmp_path, "review", phase=DaydreamPhase.REVIEW)
 
-    assert_stalled_and_reaped(spawner, expected_spawns=4)
+    assert_stalled_and_reaped(spawner, expected_spawns=2)
 
     trajectory = json.loads(trajectory_path.read_text(encoding="utf-8"))
     assert trajectory["extra"]["partial"] is True


### PR DESCRIPTION
## Summary

- Detect silent Pi model responses after five minutes, before the 30-minute phase wall budget.
- Preserve the existing 45-minute idle allowance while a Pi tool is active, so long-running builds and tests continue uninterrupted.
- Limit stream-stall recovery to one fresh attempt and add regression coverage for both response stalls and active tools.

## Root cause

The latest archived wall-budget failure was session `58d571cb-31d0-47f6-ba7f-7c9475916510`. Its alternatives phase began at 19:21:17 and completed 21 tool turns by 19:26:21. The final tool event was a bounded source-file read; there was no Cargo, Make, test, or build command. The next semantic event was `wall_budget_exceeded` at 19:51:22, exactly 30 minutes after the phase began.

Pi inherited the generic 45-minute stdout-idle timeout calibrated for Codex. Because that timeout exceeded the phase's 30-minute wall budget, a silent Pi provider/model response could never reach the retry path before the wall budget aborted the entire fanout.

Pi emits token-level updates while a model response is alive, so this change uses a five-minute response-only idle window. Tool execution keeps the existing 45-minute window. A stream stall is allowed one fresh process attempt to avoid turning a shorter idle window into unbounded retry amplification.

## Testing

- `uv lock --check`
- `uv run ruff check daydream tests`
- `uv run mypy daydream tests`
- `uv run pytest -q tests/test_backend_stream_idle.py tests/test_backend_pi.py tests/test_agent_retry.py tests/test_subprocess_lifecycle.py` — 153 passed, 1 skipped
- `uv run pytest -n auto` — 4,387 passed, 4 skipped
- Normal hook-enabled push completed all repository pre-push checks

## Breaking changes

None.
