### PR TITLE
fix(verifier): capture staged+unstaged tracked fixes in candidate diff (Closes #725)

### DIFF
--- a/rl/daydream_review_v1/daydream_review_v1/harness.py
+++ b/rl/daydream_review_v1/daydream_review_v1/harness.py
@@ -207,8 +207,8 @@ class DaydreamReviewHarness(vf.Harness[DaydreamReviewHarnessConfig]):
         # agent's write window has closed: the reward verifies the staged copy
         # against this seal before trusting any value, so an attempted tamper
         # with the archived artifacts zeroes the reward instead of recording
-        # honest telemetry. The candidate diff is the rollout's own committed
-        # diff against the baked head (b"" when it cannot be re-derived).
+        # honest telemetry. The candidate diff is the rollout's own current
+        # tracked diff against the baked head (b"" when it cannot be re-derived).
         sealed = await seal_archived_run(
             runtime,
             self.config.archive_root,

--- a/rl/daydream_review_v1/daydream_review_v1/rundir.py
+++ b/rl/daydream_review_v1/daydream_review_v1/rundir.py
@@ -79,7 +79,7 @@ def candidate_diff_cmd(repo: str, head_sha: str) -> list[str]:
     return [
         "git", "-C", repo, "diff",
         *GIT_DIFF_HARDENING_FLAGS,
-        head_sha, "HEAD",
+        head_sha,
     ]
 
 

--- a/rl/daydream_review_v1/daydream_review_v1/rundir.py
+++ b/rl/daydream_review_v1/daydream_review_v1/rundir.py
@@ -63,12 +63,17 @@ GIT_DIFF_HARDENING_FLAGS: tuple[str, str] = ("--no-ext-diff", "--no-textconv")
 
 
 def candidate_diff_cmd(repo: str, head_sha: str) -> list[str]:
-    """Argv for re-deriving the rollout's committed diff against the baked head.
+    """Argv for re-deriving the rollout's candidate diff against the baked head.
 
     The candidate diff is the load-bearing contract the seal binds and the
     verifier re-applies, so it must be derived identically everywhere it is
     needed (seal production, seal verification, and the verify-checkout
     construction). Single-sourcing the command keeps those sites from drifting.
+
+    The one-revision form (``git diff <flags> <head_sha>``) compares the
+    current tracked tree — committed, staged, and unstaged — against the
+    baked ``head_sha``, excluding untracked files. This matches the working-
+    tree semantics ``_fixes_applied`` uses to accept a fix.
 
     The ``--no-ext-diff --no-textconv`` flags harden the derivation against a
     repository-configured external diff helper or text conversion driver: the
@@ -228,7 +233,7 @@ async def verify_seal(
     # Re-derive the candidate diff from the sandbox exactly as the seal
     # producer did (and as the verifier checkout will apply it): the seal's
     # embedded copy is an audit record, never the verification input, so a
-    # committed diff rewritten after sealing fails the digest check.
+    # tracked change rewritten after sealing fails the digest check.
     try:
         diff_result = await runtime.run(candidate_diff_cmd(repo, head_sha), {})
     except Exception:
@@ -254,8 +259,8 @@ async def seal_archived_run(
 
     The supervisor (harness) runs this after the launch returns, so the seal is
     produced outside the agent's write window and the reward can verify the
-    staged copy against it. The candidate diff is the rollout's own committed
-    diff against the baked head (``b""`` when the runner cannot produce one).
+    staged copy against it. The candidate diff is the rollout's own current
+    tracked diff against the baked head (``b""`` when the runner cannot produce one).
 
     Returns:
         ``True`` when a seal was written (and, under docker, the run dir

--- a/rl/daydream_review_v1/daydream_review_v1/rundir.py
+++ b/rl/daydream_review_v1/daydream_review_v1/rundir.py
@@ -61,6 +61,16 @@ DEFAULT_ARCHIVE_ROOT = "/rollout/archive"
 #: once cannot silently leave another deriv site unhardened.
 GIT_DIFF_HARDENING_FLAGS: tuple[str, str] = ("--no-ext-diff", "--no-textconv")
 
+#: Git pathspec (passed as a bare argv element, never shell-interpolated)
+#: excluding daydream's own ``.daydream/`` artifacts from the candidate product
+#: diff. daydream may write its own tracked artifacts into the tree during a
+#: rollout, but they are never part of the candidate product; the load-bearing
+#: seal/verify diff must agree with the fix-acceptance oracle
+#: (``_fixes_applied``), which excludes ``.daydream/`` from both of its probes.
+#: Defined here, the single-sourced deriv helper, so the exclusion can only
+#: drift by intentional edit and never by one string falling out of sync.
+DAYDREAM_EXCLUDE = ":(exclude).daydream"
+
 
 def candidate_diff_cmd(repo: str, head_sha: str) -> list[str]:
     """Argv for re-deriving the rollout's candidate diff against the baked head.
@@ -80,11 +90,20 @@ def candidate_diff_cmd(repo: str, head_sha: str) -> list[str]:
     supervisor runs as root, while a repo-local ``diff.external`` / textconv
     runs under the repo's own (untrusted) identity, so neither may execute
     during the load-bearing diff.
+
+    ``DAYDREAM_EXCLUDE`` (``:(exclude).daydream``) restricts the diff to the
+    candidate product only: daydream's own tracked artifacts under
+    ``.daydream/`` are never a fix signal, and this is the same exclusion the
+    fix-acceptance oracle ``_fixes_applied`` applies to both of its probes, so
+    the oracle and the load-bearing diff fully agree about what counts as the
+    candidate diff.
     """
     return [
         "git", "-C", repo, "diff",
         *GIT_DIFF_HARDENING_FLAGS,
         head_sha,
+        "--",
+        DAYDREAM_EXCLUDE,
     ]
 
 

--- a/rl/daydream_review_v1/daydream_review_v1/taskset.py
+++ b/rl/daydream_review_v1/daydream_review_v1/taskset.py
@@ -32,6 +32,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from verifiers.v1.errors import boundary
 
 from daydream_review_v1.rundir import (
+    DAYDREAM_EXCLUDE,
     DEFAULT_ARCHIVE_ROOT,
     candidate_diff_cmd,
     candidate_quiet_diff_cmd,
@@ -85,12 +86,6 @@ def _manifest_row(run_dir: Path) -> dict[str, Any]:
     metrics = manifest.get("metrics") or {}
     return {**manifest, **metrics}
 
-
-#: Git pathspec (passed as a bare argv element, never shell-interpolated)
-#: excluding daydream's own ``.daydream/`` artifacts from the fix signal.
-#: Shared by both dirty-tree and moved-HEAD probes so the exclusion set only
-#: drifts by intentional edit, never by one string falling out of sync.
-DAYDREAM_EXCLUDE = ":(exclude).daydream"
 
 #: Extra pathspecs the oracle probes treat as part of the oracle itself.
 #: ``git ls-files --exclude-standard`` honors ignore rules, so a rollout that

--- a/rl/daydream_review_v1/daydream_review_v1/taskset.py
+++ b/rl/daydream_review_v1/daydream_review_v1/taskset.py
@@ -358,7 +358,7 @@ async def _prepare_verify_checkout(runtime: vf.Runtime, repo: str, head_sha: str
 
     The manifest ``test_command`` must never run against the agent-mutable tree.
     This clones the current tree, detaches at the baked head, applies the
-    candidate product diff (the rollout's own committed diff against
+    candidate product diff (the rollout's own current tracked diff against
     ``head_sha``), and makes the result root-owned and read-only — the reward
     re-runs the suite there under the distinct non-root verifier identity.
 

--- a/rl/daydream_review_v1/tests/test_rewards.py
+++ b/rl/daydream_review_v1/tests/test_rewards.py
@@ -1567,13 +1567,14 @@ async def test_verify_checkout_failed_diff_fails_closed(
 async def test_verify_checkout_empty_diff_is_clean_noop(
     tmp_path, runtime, corpus_mini_dir, fixture_manifest_path,
 ) -> None:
-    """A review-only rollout (no committed fix) has an empty candidate diff; it
-    must apply cleanly as a no-op, never failing _prepare_verify_checkout.
+    """A review-only rollout (no committed fix) has an empty candidate diff; its
+    committed, staged, AND unstaged tracked contents all match the baked head,
+    so the diff must apply cleanly as a no-op, never failing _prepare_verify_checkout.
     """
     from daydream_review_v1 import taskset
 
     task = _task(corpus_mini_dir, fixture_manifest_path)
-    # --allow-empty commit: HEAD advances, tree identical -> genuinely empty diff
+    # --allow-empty commit: HEAD advances, committed tree identical -> genuinely empty diff
     repo = _stage_repo(tmp_path / "repo", task.data.head_sha, commit=True)
     result = await taskset._prepare_verify_checkout(runtime, str(repo), task.data.head_sha)
     if os.geteuid() == 0:

--- a/rl/daydream_review_v1/tests/test_rewards.py
+++ b/rl/daydream_review_v1/tests/test_rewards.py
@@ -17,6 +17,7 @@ import shutil
 import subprocess
 from collections.abc import Awaitable, Callable
 from pathlib import Path
+from typing import Any
 
 import pytest
 import verifiers.v1 as vf
@@ -1743,3 +1744,81 @@ async def test_protected_test_paths_unchanged_quiet_probe_carries_hardening_flag
 # the genuine repo-configurable-helper surface is the non-quiet candidate-diff
 # path, covered by test_verify_checkout_external_diff_ignored and
 # test_verify_checkout_textconv_ignored.
+
+
+# --- oracle / candidate-diff working-tree equivalence (issue #725 pin) ---
+#
+# Round 2 of the issue-#725 review found that the acceptance oracle
+# (``_fixes_applied``) and the load-bearing candidate-diff derivation
+# (``candidate_diff_cmd``) share ``DAYDREAM_EXCLUDE`` but encode their
+# working-tree semantics independently: convergence is exact today, but only
+# by docstring reasoning, and a future edit to either side silently re-opens
+# the drift class of issue #725 (oracle accepts a state whose candidate diff
+# is empty, or vice versa). These tests are the executable form of that
+# reasoning: over every canonical repo state a rollout can produce, the
+# oracle's verdict and the derived diff's emptiness must agree.
+
+@pytest.mark.parametrize(
+    ("stage_kwargs", "expected"),
+    [
+        pytest.param({}, False, id="clean-tree-at-baked-head"),
+        pytest.param({"edit": _CALC_FIXED}, True, id="uncommitted-edit"),
+        pytest.param({"edit": _CALC_FIXED, "commit": True}, True, id="committed-fix"),
+        pytest.param({"commit": True}, False, id="empty-commit-moves-head-only"),
+        pytest.param(
+            {"patch": "not-a-fix-signal", "commit": True, "commit_patch": True},
+            False,
+            id="committed-daydream-artifacts-only",
+        ),
+        pytest.param(
+            {
+                "edit": _CALC_FIXED,
+                "patch": "not-a-fix-signal",
+                "commit": True,
+                "commit_patch": True,
+            },
+            True,
+            id="committed-fix-plus-daydream-artifacts",
+        ),
+    ],
+)
+async def test_oracle_acceptance_matches_candidate_diff_semantics(
+    tmp_path, runtime, corpus_mini_dir, fixture_manifest_path,
+    stage_kwargs: dict[str, Any], expected: bool,
+) -> None:
+    """Whichever repo state the oracle accepts, the candidate diff must show.
+
+    Regression pin for the issue-#725 drift class, round-2 findings 1+2: the
+    single-sourced ``DAYDREAM_EXCLUDE`` keeps both probes honest about
+    ``.daydream/``, but each probe still encodes its own tracked-tree
+    semantics (status OR committed quiet diff versus ``git diff <head>``).
+    Equivalence across the canonical states below is exact today — committed,
+    staged, and unstaged tracked edits read identically through both probes
+    while untracked files (including daydream's own committed-but-excluded
+    artifacts and the never-staged recommended.patch) read as no-op through
+    both — and this test turns any future divergence into a CI failure
+    instead of docstring archaeology.
+    """
+    from daydream_review_v1 import rundir as rundir_mod
+    from daydream_review_v1 import taskset
+
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    repo = _stage_repo(tmp_path / "repo", task.data.head_sha, **stage_kwargs)
+
+    accepted = await taskset._fixes_applied(runtime, str(repo), task.data.head_sha)
+    assert accepted == expected, (
+        f"oracle verdict {accepted!r} contradicts canonical state "
+        f"{stage_kwargs!r}: the acceptance probe drifted from the "
+        f"tracked-tree contract"
+    )
+
+    proc = subprocess.run(
+        rundir_mod.candidate_diff_cmd(str(repo), task.data.head_sha),
+        capture_output=True,
+    )
+    produced_fix = bool(proc.stdout.strip())
+    assert produced_fix == expected, (
+        f"derived candidate diff {'showed changes' if produced_fix else 'was empty'} "
+        f"against canonical state {stage_kwargs!r}: the deriv site drifted "
+        f"from the tracked-tree contract"
+    )

--- a/rl/daydream_review_v1/tests/test_rewards.py
+++ b/rl/daydream_review_v1/tests/test_rewards.py
@@ -1644,13 +1644,13 @@ async def test_verify_checkout_applies_exactly_the_candidate_diff(
 
 
 def test_candidate_diff_cmd_carries_hardening_flags() -> None:
-    from daydream_review_v1.rundir import candidate_diff_cmd
+    from daydream_review_v1.rundir import DAYDREAM_EXCLUDE, candidate_diff_cmd
 
     argv = candidate_diff_cmd("/work/repo", "deadbeef")
     assert argv == [
         "git", "-C", "/work/repo", "diff",
         "--no-ext-diff", "--no-textconv",
-        "deadbeef",
+        "deadbeef", "--", DAYDREAM_EXCLUDE,
     ]
 
 

--- a/rl/daydream_review_v1/tests/test_rewards.py
+++ b/rl/daydream_review_v1/tests/test_rewards.py
@@ -1642,7 +1642,7 @@ def test_candidate_diff_cmd_carries_hardening_flags() -> None:
     assert argv == [
         "git", "-C", "/work/repo", "diff",
         "--no-ext-diff", "--no-textconv",
-        "deadbeef", "HEAD",
+        "deadbeef",
     ]
 
 

--- a/rl/daydream_review_v1/tests/test_rewards.py
+++ b/rl/daydream_review_v1/tests/test_rewards.py
@@ -349,17 +349,17 @@ _CALC_FIXED = _CALC_BROKEN.replace("return a + b + 1", "return a + b")
 def _seal_run(run_dir: Path, task: DaydreamReviewTask, repo_path: Path) -> Path:
     """Harness-side seal production over a staged committed-fix repo.
 
-    Stages the fixture repo with the fix COMMITTED (the seal binds the committed
-    diff the verifier re-derives at scoring time, never the working tree),
-    hashes the archive members the harness recorded, and writes ``seal.json``
-    into *run_dir*. Returns the staged repo path.
+    Stages the fixture repo with the fix committed, derives the candidate diff
+    through the shared :func:`~daydream_review_v1.rundir.candidate_diff_cmd`
+    helper, hashes the archive members the harness recorded, and writes
+    ``seal.json`` into *run_dir*. Returns the staged repo path.
     """
-    from daydream_review_v1.rundir import RUN_DIR_FILES
+    from daydream_review_v1.rundir import RUN_DIR_FILES, candidate_diff_cmd
     from daydream_review_v1.verifier import seal_artifacts
 
     repo = _stage_repo(repo_path, task.data.head_sha, edit=_CALC_FIXED, commit=True)
     diff = subprocess.run(
-        ["git", "-C", str(repo), "diff", task.data.head_sha, "HEAD"],
+        candidate_diff_cmd(str(repo), task.data.head_sha),
         capture_output=True,
         check=True,
     ).stdout
@@ -531,7 +531,9 @@ async def test_green_suite_records_non_regression(
     assert trace.metrics["test_oracle_unchanged"] == 1.0
 
 
+@pytest.mark.parametrize("stage_edit", [False, True], ids=["unstaged", "staged"])
 async def test_verifier_identity_branch_executes_and_fails_closed(
+    stage_edit: bool,
     tmp_path: Path,
     runtime,
     corpus_mini_dir: Path,
@@ -558,10 +560,15 @@ async def test_verifier_identity_branch_executes_and_fails_closed(
     archive_root = tmp_path / "archive"
     (archive_root / "runs").mkdir(parents=True)
     task = _task(corpus_mini_dir, fixture_manifest_path)
-    # The fix is COMMITTED: the verifier checkout's candidate diff is
-    # ``git diff <head_sha> HEAD``, i.e. the committed contents, never the
-    # working tree.
-    repo = _stage_repo(tmp_path / "repo", task.data.head_sha, edit=_CALC_FIXED, commit=True)
+    repo = _stage_repo(tmp_path / "repo", task.data.head_sha, edit=_CALC_FIXED)
+    if stage_edit:
+        subprocess.run(["git", "-C", str(repo), "add", "calc.py"], check=True)
+    # HEAD must stay exactly at the baked snapshot in both rows.
+    assert subprocess.run(["git", "-C", str(repo), "rev-parse", "HEAD"],
+                          capture_output=True, text=True, check=True).stdout.strip() == task.data.head_sha
+    expected_status = "M  calc.py\n" if stage_edit else " M calc.py\n"
+    assert subprocess.run(["git", "-C", str(repo), "status", "--porcelain", "--untracked-files=no"],
+                          capture_output=True, text=True, check=True).stdout == expected_status
     trace = _trace(task, archive_root=archive_root, repo_path=repo)
 
     # Keep the real host probe (setpriv + verifier user) before it is replaced:


### PR DESCRIPTION
## Summary
- Derive candidate diff as a one-revision head_sha diff capturing staged + unstaged tracked fixes (757495d)
- Document sealed tree semantics as current tracked tree relative to head_sha (3cf4acc)
- Cover staged/unstaged tracked fixes through the real verify-checkout path (963d7d6); single-source .daydream diff exclusion (3f4adfd); pin oracle/candidate-diff working-tree equivalence in tests (7a895f8)

Two sequential daydream deep-precision review rounds passed (round 2 clean, tip 7a895f8).

Closes #725