### PR TITLE
benchmark: fix snapshot.bundle_heads and compile_workspace for relative bundle/workspace paths

### DIFF
--- a/daydream/benchmark/harbor/build.py
+++ b/daydream/benchmark/harbor/build.py
@@ -813,8 +813,14 @@ def compile_workspace(root: Path, *, wheel: Path | None = None) -> dict:
     writes the lock + root control-plane, runs the leakage scan, then swaps the
     stage in place only on full success. On any rejection the exception
     re-raises and the prior ``harbor/`` is left untouched.
+
+    The root is resolved to a canonical absolute path before the workspace
+    lock is acquired, so callers passing ``.``, a relative path, or the literal
+    resolved path for the same workspace converge on the same reentrancy key
+    and all downstream-derived paths (stage, bundle sources/destinations,
+    storage digests) inherit canonical form. Absolute inputs are unchanged.
     """
-    root = Path(root)
+    root = Path(root).resolve()
     from daydream.benchmark.harbor import package as pkg
 
     daydream_version = importlib.metadata.version("daydream")

--- a/daydream/benchmark/snapshot.py
+++ b/daydream/benchmark/snapshot.py
@@ -259,7 +259,7 @@ def build_bundle(
     non-zero step raises :class:`GitError` so the caller maps it to
     ``bundle_failure``.
     """
-    bundle_path = Path(bundle_path)
+    bundle_path = Path(bundle_path).resolve()
     bundle_path.parent.mkdir(parents=True, exist_ok=True)
     env = _synthetic_env()
     base_tree = rev_parse(mirror_repo, f"{base_sha}^{{tree}}")
@@ -315,7 +315,7 @@ def validate_offline_clone(
     unexpected ref set, ancestry/parent mismatch, tree mismatch, or diff-digest
     mismatch. Returns ``None``.
     """
-    bundle_path = Path(bundle_path)
+    bundle_path = Path(bundle_path).resolve()
     import tempfile
 
     clone_dir = Path(tempfile.mkdtemp(prefix="clone-", dir=str(workdir)))

--- a/daydream/benchmark/snapshot.py
+++ b/daydream/benchmark/snapshot.py
@@ -283,7 +283,7 @@ def build_bundle(
 
 def bundle_heads(bundle_path: Path) -> set[str]:
     """The list of refs a bundle exposes."""
-    bundle_path = Path(bundle_path)
+    bundle_path = Path(bundle_path).resolve()
     proc = git_ops._run_git(
         bundle_path.parent, ["bundle", "list-heads", str(bundle_path)], retries=0, timeout=30
     )

--- a/tests/test_benchmark_harbor_build.py
+++ b/tests/test_benchmark_harbor_build.py
@@ -998,32 +998,80 @@ def test_compiled_tree_contains_no_raw_authoring_files(tmp_path, fake_gh):
     assert all(r.startswith("case-") or r in root_files for r in rels)
 
 
-def test_compile_workspace_with_relative_root_matches_resolved_root_bytes(tmp_path, fake_gh):
-    import json
+def test_compile_workspace_with_relative_root_matches_resolved_root_bytes(
+    tmp_path, fake_gh, monkeypatch
+):
+    """The same workspace compiled via an absolute root and via a relative root
+    (from a different CWD) yields byte-identical ``harbor/benchmark.lock.json``
+    output, and ``compile_workspace`` acquires ``WorkspaceLock`` under the
+    canonical absolute root either way.
+
+    Asserting the canonical lock root is the regression guard for the
+    root-canonicalization fix: the lock JSON is purely content-derived, so its
+    bytes cannot distinguish canonicalized from verbatim roots — only the
+    reentrancy key handed to ``WorkspaceLock`` can. If ``compile_workspace``
+    stopped resolving the root, a relative invocation from another CWD would key
+    the process-reentrant lock on the verbatim relative path, diverge from the
+    absolute spelling of the same workspace, and self-deadlock on nested
+    acquisition; this test fails on exactly that mutation instead of hanging.
+    """
     import os
 
     from daydream.benchmark.harbor import build
 
-    ws_a, _, _ = _seed_ready_workspace(tmp_path, fake_gh)
-    (tmp_path / "b").mkdir()
-    ws_b, _, _ = _seed_ready_workspace(tmp_path / "b", fake_gh)
+    ws, _, _ = _seed_ready_workspace(tmp_path, fake_gh)
+    ws_resolved = ws.resolve()
 
-    build.compile_workspace(ws_a)                      # absolute control run
+    build.compile_workspace(ws)                        # absolute control run
+    lock_path = ws / "harbor" / "benchmark.lock.json"
+    lock_bytes_abs = lock_path.read_bytes()
 
     outside = tmp_path / "outside"
     outside.mkdir()
+
+    # Record every WorkspaceLock construction during the relative-spelled compile
+    # so we can assert the lock key is the canonical absolute root, not whatever
+    # spelling the caller happened to pass. The wrapper mirrors WorkspaceLock's
+    # class-level ``_held`` registry onto the real dict: the genuine lock's
+    # methods resolve ``WorkspaceLock`` through this patched module global, so
+    # the mirror keeps their bookkeeping working unchanged.
+    real_lock_cls = build.storage.WorkspaceLock
+    constructed_roots: list[object] = []
+
+    class _RecordingLock:
+        _held = real_lock_cls._held
+
+        def __init__(self, root, **kwargs):
+            constructed_roots.append(root)
+            self._inner = real_lock_cls(root, **kwargs)
+
+        def __enter__(self):
+            return self._inner.__enter__()
+
+        def __exit__(self, *_exc):
+            return self._inner.__exit__(*_exc)
+
+    monkeypatch.setattr(build.storage, "WorkspaceLock", _RecordingLock)
+
     old = os.getcwd()
     os.chdir(outside)
     try:
-        rel_root = Path(os.path.relpath(ws_b, outside))
+        rel_root = Path(os.path.relpath(ws_resolved, outside))
         build.compile_workspace(Path(rel_root))         # relative, differing CWD
     finally:
         os.chdir(old)
 
-    lock_rel = json.loads((ws_b / "harbor" / "benchmark.lock.json").read_text())
-    lock_abs = json.loads((ws_a / "harbor" / "benchmark.lock.json").read_text())
-    assert lock_rel["authoring_input_digest"] == lock_abs["authoring_input_digest"]
-    assert set(lock_rel["cases"]) == set(lock_abs["cases"])
+    # Deterministic rebuild: second compile of the SAME workspace is byte-identical.
+    assert lock_path.read_bytes() == lock_bytes_abs
+
+    # Reentrancy-key convergence: even invoked relatively from a different CWD,
+    # the lock is keyed on the resolved workspace, so absolute/relative/"."
+    # spellings share one key.
+    assert constructed_roots, "WorkspaceLock was never constructed"
+    assert constructed_roots[-1] == ws_resolved, (
+        f"lock keyed on non-canonical root {constructed_roots[-1]!r}, "
+        f"expected resolved {ws_resolved!s}"
+    )
 
 
 def test_compile_rejects_when_a_case_is_not_compilable(tmp_path, fake_gh):

--- a/tests/test_benchmark_harbor_build.py
+++ b/tests/test_benchmark_harbor_build.py
@@ -998,6 +998,34 @@ def test_compiled_tree_contains_no_raw_authoring_files(tmp_path, fake_gh):
     assert all(r.startswith("case-") or r in root_files for r in rels)
 
 
+def test_compile_workspace_with_relative_root_matches_resolved_root_bytes(tmp_path, fake_gh):
+    import json
+    import os
+
+    from daydream.benchmark.harbor import build
+
+    ws_a, _, _ = _seed_ready_workspace(tmp_path, fake_gh)
+    (tmp_path / "b").mkdir()
+    ws_b, _, _ = _seed_ready_workspace(tmp_path / "b", fake_gh)
+
+    build.compile_workspace(ws_a)                      # absolute control run
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    old = os.getcwd()
+    os.chdir(outside)
+    try:
+        rel_root = Path(os.path.relpath(ws_b, outside))
+        build.compile_workspace(Path(rel_root))         # relative, differing CWD
+    finally:
+        os.chdir(old)
+
+    lock_rel = json.loads((ws_b / "harbor" / "benchmark.lock.json").read_text())
+    lock_abs = json.loads((ws_a / "harbor" / "benchmark.lock.json").read_text())
+    assert lock_rel["authoring_input_digest"] == lock_abs["authoring_input_digest"]
+    assert set(lock_rel["cases"]) == set(lock_abs["cases"])
+
+
 def test_compile_rejects_when_a_case_is_not_compilable(tmp_path, fake_gh):
     from daydream.benchmark import storage
     from daydream.benchmark.harbor import build

--- a/tests/test_benchmark_snapshot.py
+++ b/tests/test_benchmark_snapshot.py
@@ -9,6 +9,7 @@ against the real object store. Only the import-gating tests (in
 
 from __future__ import annotations
 
+import contextlib
 import os
 import re
 import shutil
@@ -56,6 +57,16 @@ def _write(repo: Path, name: str, content: str | bytes) -> None:
     else:
         path.write_text(content)
     _git(repo, "add", name)
+
+
+@contextlib.contextmanager
+def monkeypatch_relative_cwd(cwd: Path):
+    old = os.getcwd()
+    os.chdir(cwd)
+    try:
+        yield
+    finally:
+        os.chdir(old)
 
 
 def _seed_origin(tmp_path: Path) -> Path:
@@ -247,6 +258,26 @@ def test_bundle_two_refs_deterministic(tmp_path):
     first = sn.storage.sha256_file(bundle)
     sn.build_bundle(m, _SHA_BASE2, _SHA_HEAD, bundle)
     assert sn.storage.sha256_file(bundle) == first
+
+
+def test_bundle_heads_accepts_relative_path_from_any_cwd(tmp_path):
+    import os
+
+    from daydream.benchmark import snapshot as sn
+
+    origin = _seed_origin(tmp_path)
+    sn.ensure_mirror(tmp_path, "o/r", origin_url=origin)
+    sn.fetch_pr_refs(tmp_path, "o/r", 1, base_tip=_SHA_BASE2,
+                     explicit_shas=[_SHA_HEAD], origin_url=origin)
+    m = sn.mirror(tmp_path)
+    bundle = tmp_path / "snapshots" / "pr-000001-aaaaaaaaaaaa.bundle"
+    sn.build_bundle(m, _SHA_BASE2, _SHA_HEAD, bundle)
+    rel_bundle = Path(os.path.relpath(bundle, tmp_path))
+    with monkeypatch_relative_cwd(tmp_path):
+        heads_rel = sn.bundle_heads(rel_bundle)
+        heads_abs = sn.bundle_heads(bundle)
+    assert heads_rel == {"refs/heads/base", "refs/heads/head"}
+    assert heads_abs == {"refs/heads/base", "refs/heads/head"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_benchmark_snapshot.py
+++ b/tests/test_benchmark_snapshot.py
@@ -349,6 +349,25 @@ def test_offline_clone_validates(tmp_path):
                                   workdir=tmp_path)
 
 
+def test_build_bundle_and_offline_clone_accept_relative_paths(tmp_path):
+    from daydream.benchmark import snapshot as sn
+
+    origin = _seed_origin(tmp_path)
+    sn.ensure_mirror(tmp_path, "o/r", origin_url=origin)
+    sn.fetch_pr_refs(tmp_path, "o/r", 1, base_tip=_SHA_BASE2,
+                     explicit_shas=[_SHA_HEAD], origin_url=origin)
+    m = sn.mirror(tmp_path)
+    abs_bundle = tmp_path / "snapshots" / "rel.bundle"
+    with monkeypatch_relative_cwd(m):
+        sn.build_bundle(m, _SHA_BASE2, _SHA_HEAD, abs_bundle)
+    assert abs_bundle.is_file()
+    diff_sha = sn.canonical_diff_sha256(m, _SHA_BASE2, _SHA_HEAD)
+    with monkeypatch_relative_cwd(m):
+        rel = Path(os.path.relpath(abs_bundle, m))
+        sn.validate_offline_clone(rel, _seed_base_tree(), _seed_head_tree(), diff_sha,
+                                  workdir=tmp_path)
+
+
 def test_offline_clone_fidelity_rejects_tampering(tmp_path):
     """Acceptance (b/c) at unit level: the offline-clone fidelity contract
     rejects every structurally-distinct tampered bundle shape (extra ref,


### PR DESCRIPTION
Closes #847

## Summary
- Resolve bundle path in `snapshot.bundle_heads` and `build_bundle`/`validate_offline_clone` so relative bundle paths work from any cwd
- Fix `compile_workspace` to resolve the workspace root end-to-end so relative workspace roots work
- Harden tests: pin lock-key canonicalization across relative-root spellings (byte-identical locks), per round-2 review

## Test Plan
- [x] `make check` green: 4360 passed, 17 skipped (round-2 baseline identical)
- [x] Two daydream deep-precision review rounds passed; merged low finding fixed and pushed (f7e648d)