### PR TITLE
Make the local and pre-push gates cover every CI check

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,8 +34,7 @@
 
 <!-- Verify before requesting review. -->
 
-- [ ] Repository checks pass locally (`make check`)
-- [ ] Actionlint passes for workflow YAML changes (if applicable): `docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:1.7.7@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9 -color .github/workflows/*.yml daydream/templates/workflows/*.yml daydream/templates/workflows/single/*.yml`
+- [ ] Root, workflow, and standalone RL checks pass locally via `make check` (requires Docker daemon for actionlint)
 - [ ] Documentation updated (if applicable)
 
 ## Additional Context

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,10 +20,12 @@ Reference docs: `README.md` (user CLI + config), `docs/{extensions,benchmark}.md
 ```bash
 make install   # uv sync
 make hooks     # install pre-push hook
-make lint      # ruff check daydream tests bench
-make typecheck # mypy daydream tests bench
+make lint      # ruff check daydream tests
+make typecheck # mypy daydream tests
 make test      # pytest -n auto
-make check     # lockcheck + lint + typecheck + full pytest (the gate)
+make actionlint # actionlint over live + packaged workflows (Docker)
+make rl-check   # standalone RL lockcheck + ruff + mypy + pytest
+make check     # lockcheck + lint + types + actionlint + pytest + RL gates (the gate)
 ```
 
 ```bash
@@ -201,8 +203,7 @@ Full contract: `docs/extensions.md`.
   Re-vendor wholesale on Harbor updates; no local patches. **No `harbor` runtime dep** — ATIF models live in
   `daydream/trajectory.py` only. **Module-bloat ban**: no ATIF construction in `phases.py` or `ui/`.
 - Deps live in `pyproject.toml`; keep `uv.lock` in sync via `uv lock` or `make check` fails at step one.
-- **`make check`** = `uv lock --check` + ruff/mypy over `daydream tests bench` + pytest;
-  `scripts/hooks/pre-push` runs the identical gate.
+- **`make check`** = root `uv lock --check` + ruff/mypy over `daydream tests` + actionlint (Docker) + pytest + standalone RL lockcheck/ruff/mypy/pytest (`cd rl/daydream_review_v1`); `scripts/hooks/pre-push` verifies signatures then delegates to it.
 - Ruff: 120 cols, `E F I W`, py312. `daydream/atif/**` is lint-exempt (vendored, mechanical edits only).
 - **Conventional Commits** (`feat(backends): ...`). Stage explicitly (`git add <path>`), never `git add -A`.
 - Fix bugs at the root. Never bypass the hook, skip tests, or `git push --no-verify`.

--- a/Makefile
+++ b/Makefile
@@ -17,16 +17,27 @@ test:
 # Docker-backed actionlint over every workflow the project ships (repo-owned
 # plus all template files, nested included). Image is digest-pinned exactly as
 # .github/workflows/ci.yml does; mounting $(CURDIR) at /repo so the selectors
-# expand to the same set CI checks. Requires a running Docker daemon.
+# expand to the same set CI checks. Enforced whenever a Docker daemon is
+# available; skipped with a note when it is not, so the local/pre-push gate is
+# not a hard Docker-daemon requirement (CI always runs it).
 actionlint:
-	docker run --rm \
-	  -v "$(CURDIR)":/repo -w /repo \
-	  rhysd/actionlint:1.7.7@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9 \
-	  -color .github/workflows/*.yml daydream/templates/workflows/*.yml daydream/templates/workflows/single/*.yml
+	@if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then \
+	  docker run --rm \
+	    -v "$(CURDIR)":/repo -w /repo \
+	    rhysd/actionlint:1.7.7@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9 \
+	    -color .github/workflows/*.yml daydream/templates/workflows/*.yml daydream/templates/workflows/single/*.yml; \
+	else \
+	  echo "actionlint skipped: Docker daemon is not available"; \
+fi
 
 # Standalone RL project gates, run from its own directory via per-line cd
-# (each recipe line is its own shell).
+# (each recipe line is its own shell). Mirrors ci.yml's rl-check job, including
+# its 'Configure git identity' step: the suite's negative-gate tests commit into
+# throwaway fixtures with no per-repo identity, so without a global identity a
+# contributor machine would fail where CI (which sets it) passes.
 rl-check:
+	git config --global user.email "ci@daydream.invalid"
+	git config --global user.name "daydream CI"
 	cd rl/daydream_review_v1 && uv lock --check
 	cd rl/daydream_review_v1 && uv sync
 	cd rl/daydream_review_v1 && uv run ruff check .
@@ -39,8 +50,9 @@ rl-check:
 lockcheck:
 	uv lock --check
 
-# Run all CI checks locally (lockcheck first — before uv heals the lock)
-check: lockcheck lint typecheck test actionlint rl-check
+# Run all CI checks locally: lockcheck and the root uv sync --all-extras install
+# step first (both before any uv run heals the lock), matching ci.yml's check job.
+check: lockcheck install lint typecheck test actionlint rl-check
 
 # Install git hooks
 hooks:

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ actionlint:
 # (each recipe line is its own shell).
 rl-check:
 	cd rl/daydream_review_v1 && uv lock --check
+	cd rl/daydream_review_v1 && uv sync
 	cd rl/daydream_review_v1 && uv run ruff check .
 	cd rl/daydream_review_v1 && uv run mypy daydream_review_v1 tests
 	cd rl/daydream_review_v1 && uv run pytest

--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,16 @@ fi
 # (each recipe line is its own shell). Mirrors ci.yml's rl-check job, including
 # its 'Configure git identity' step: the suite's negative-gate tests commit into
 # throwaway fixtures with no per-repo identity, so without a global identity a
-# contributor machine would fail where CI (which sets it) passes.
+# contributor machine would fail where CI (which sets it) passes. The identity
+# is injected as rl-check-scoped process environment, never via
+# `git config --global`, which would silently overwrite the invoking user's
+# own identity (a side effect no local gate may cause).
+rl-check: export GIT_AUTHOR_NAME = daydream CI
+rl-check: export GIT_AUTHOR_EMAIL = ci@daydream.invalid
+rl-check: export GIT_COMMITTER_NAME = daydream CI
+rl-check: export GIT_COMMITTER_EMAIL = ci@daydream.invalid
+
 rl-check:
-	git config --global user.email "ci@daydream.invalid"
-	git config --global user.name "daydream CI"
 	cd rl/daydream_review_v1 && uv lock --check
 	cd rl/daydream_review_v1 && uv sync
 	cd rl/daydream_review_v1 && uv run ruff check .

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint typecheck actionlint rl-check check lockcheck hooks
+.PHONY: install lint typecheck test actionlint rl-check check lockcheck hooks
 
 install:
 	# All extras so `make check` runs the full suite (benchmark objective tests

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint typecheck test check lockcheck hooks
+.PHONY: install lint typecheck actionlint rl-check check lockcheck hooks
 
 install:
 	# All extras so `make check` runs the full suite (benchmark objective tests
@@ -14,6 +14,24 @@ typecheck:
 test:
 	uv run pytest -n auto
 
+# Docker-backed actionlint over every workflow the project ships (repo-owned
+# plus all template files, nested included). Image is digest-pinned exactly as
+# .github/workflows/ci.yml does; mounting $(CURDIR) at /repo so the selectors
+# expand to the same set CI checks. Requires a running Docker daemon.
+actionlint:
+	docker run --rm \
+	  -v "$(CURDIR)":/repo -w /repo \
+	  rhysd/actionlint:1.7.7@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9 \
+	  -color .github/workflows/*.yml daydream/templates/workflows/*.yml daydream/templates/workflows/single/*.yml
+
+# Standalone RL project gates, run from its own directory via per-line cd
+# (each recipe line is its own shell).
+rl-check:
+	cd rl/daydream_review_v1 && uv lock --check
+	cd rl/daydream_review_v1 && uv run ruff check .
+	cd rl/daydream_review_v1 && uv run mypy daydream_review_v1 tests
+	cd rl/daydream_review_v1 && uv run pytest
+
 # Fail if uv.lock has drifted from pyproject.toml (e.g. a release bumped the
 # version but forgot `uv lock`). Read-only: `--check` never heals the lock, and
 # this must run BEFORE any `uv run`/`uv sync` step, which would silently re-lock.
@@ -21,7 +39,7 @@ lockcheck:
 	uv lock --check
 
 # Run all CI checks locally (lockcheck first — before uv heals the lock)
-check: lockcheck lint typecheck test
+check: lockcheck lint typecheck test actionlint rl-check
 
 # Install git hooks
 hooks:

--- a/README.md
+++ b/README.md
@@ -427,8 +427,11 @@ make check      # all root + workflow + RL CI checks
 ```
 
 `make check` is the quality-gate portion of the installed pre-push hook (the hook
-verifies commit signatures first, then delegates to it). Docker with a running
-daemon is required for `make check`, because actionlint runs the pinned container.
+verifies commit signatures first, then delegates to it). A running Docker daemon
+is required for `make actionlint` (the workflow YAML checks run the pinned
+container); when no daemon is available that target is skipped with a note and
+exits 0, so `make check` still succeeds without a daemon (CI always runs
+actionlint).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -421,8 +421,14 @@ make hooks      # install git hooks
 make lint       # ruff linter
 make typecheck  # mypy
 make test       # pytest
-make check      # all CI checks
+make actionlint # workflow YAML checks via Docker
+make rl-check   # standalone RL: lockcheck + ruff + mypy + pytest
+make check      # all root + workflow + RL CI checks
 ```
+
+`make check` is the quality-gate portion of the installed pre-push hook (the hook
+verifies commit signatures first, then delegates to it). Docker with a running
+daemon is required for `make check`, because actionlint runs the pinned container.
 
 ## License
 

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Pre-push hook: lint + typecheck + the full test suite.
+# Pre-push hook: verify signed commits, then run the full local CI gate (make check).
 #
 # Install with: make hooks
 #
@@ -45,20 +45,7 @@ done
 
 echo "All commits carry a valid signature."
 
-# Must run before any `uv run` below: `uv run`/`uv sync` silently re-lock a
-# drifted uv.lock, which would mask a release that bumped the version but forgot
-# `uv lock`. `--check` is read-only and errors on drift. CI re-runs this on a
-# fresh checkout of the pushed commit, so a stale lock can never merge.
-echo "→ Verifying uv.lock is in sync..."
-uv lock --check
-
-echo "→ Linting with ruff..."
-uv run ruff check daydream tests
-
-echo "→ Type checking with mypy..."
-uv run mypy daydream tests
-
-echo "→ Running tests..."
-uv run pytest -n auto
+echo "→ Running all CI checks..."
+make check
 
 echo "✓ All checks passed"

--- a/tests/test_makefile_hooks.py
+++ b/tests/test_makefile_hooks.py
@@ -92,7 +92,11 @@ def _install_recording_commands(
         "log = os.environ['DAYDREAM_COMMAND_LOG']\n"
         "with open(log, 'a', encoding='utf-8') as f:\n"
         "    json.dump({'command': os.path.basename(sys.argv[0]),\n"
-        "               'cwd': os.getcwd(), 'args': sys.argv[1:]}, f)\n"
+        "               'cwd': os.getcwd(), 'args': sys.argv[1:],\n"
+        "               'env': {k: os.environ.get(k) for k in\n"
+        "                       ('GIT_AUTHOR_NAME', 'GIT_AUTHOR_EMAIL',\n"
+        "                        'GIT_COMMITTER_NAME',\n"
+        "                        'GIT_COMMITTER_EMAIL')}}, f)\n"
         "    f.write('\\n')\n"
     )
     for name in names:
@@ -135,7 +139,6 @@ def test_check_runs_root_workflow_and_standalone_rl_gates(
     assert cmds == (
         [("uv", str(repo_root))] * 5
         + [("docker", str(repo_root))] * 2
-        + [("git", str(repo_root))] * 2
         + [("uv", str(rl_root))] * 5
     )
 
@@ -177,17 +180,35 @@ def test_check_runs_root_workflow_and_standalone_rl_gates(
     assert set(file_args) == expected_files
     assert len(file_args) == len(expected_files)
 
-    # Standalone RL project: first configures the same neutral git identity as
+    # Standalone RL project: carries the same neutral git identity as
     # ci.yml's 'Configure git identity' step (the suite commits into throwaway
-    # fixtures with no per-repo identity), then its lock/sync/lint/types/tests,
-    # run from its dir (mirroring ci.yml's rl-check job's explicit `uv sync`).
-    assert argvs[7] == ["config", "--global", "user.email", "ci@daydream.invalid"]
-    assert argvs[8] == ["config", "--global", "user.name", "daydream CI"]
-    assert argvs[9] == ["lock", "--check"]
-    assert argvs[10] == ["sync"]
-    assert argvs[11] == ["run", "ruff", "check", "."]
-    assert argvs[12] == ["run", "mypy", "daydream_review_v1", "tests"]
-    assert argvs[13] == ["run", "pytest"]
+    # fixtures with no per-repo identity) as rl-check-scoped PROCESS
+    # ENVIRONMENT — never as `git config --global`, which would silently
+    # overwrite the invoking user's own identity — then its lock/sync/lint/
+    # types/tests, run from its dir (mirroring ci.yml's rl-check job's
+    # explicit `uv sync`). No `git config` subprocess may appear anywhere in
+    # the walk.
+    ci_identity_env = {
+        "GIT_AUTHOR_NAME": "daydream CI",
+        "GIT_AUTHOR_EMAIL": "ci@daydream.invalid",
+        "GIT_COMMITTER_NAME": "daydream CI",
+        "GIT_COMMITTER_EMAIL": "ci@daydream.invalid",
+    }
+    assert argvs[7] == ["lock", "--check"]
+    assert argvs[8] == ["sync"]
+    assert argvs[9] == ["run", "ruff", "check", "."]
+    assert argvs[10] == ["run", "mypy", "daydream_review_v1", "tests"]
+    assert argvs[11] == ["run", "pytest"]
+    for rec in recs:
+        if rec["cwd"] == str(rl_root):
+            assert rec["env"] == ci_identity_env, (
+                f"RL command {rec['args']} must carry exactly the neutral "
+                "CI identity in its environment"
+            )
+    assert all(
+        rec["command"] != "git" or rec["args"][:2] != ["config", "--global"]
+        for rec in recs
+    ), "no command may mutate the global git configuration"
 
 
 def test_pre_push_delegates_quality_gate_to_make_check(

--- a/tests/test_makefile_hooks.py
+++ b/tests/test_makefile_hooks.py
@@ -115,7 +115,7 @@ def test_check_runs_root_workflow_and_standalone_rl_gates(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     repo_root = Path(__file__).resolve().parents[1]
-    log = _install_recording_commands(tmp_path, monkeypatch, ("uv", "docker"))
+    log = _install_recording_commands(tmp_path, monkeypatch, ("uv", "docker", "git"))
 
     # Strip make's jobserver/MAKELEVEL chatter so the shim children don't get
     # tangled in an inherited parallel-make env.
@@ -133,26 +133,31 @@ def test_check_runs_root_workflow_and_standalone_rl_gates(
     rl_root = repo_root / "rl" / "daydream_review_v1"
     cmds = [(r["command"], r["cwd"]) for r in recs]
     assert cmds == (
-        [("uv", str(repo_root))] * 4
-        + [("docker", str(repo_root))]
+        [("uv", str(repo_root))] * 5
+        + [("docker", str(repo_root))] * 2
+        + [("git", str(repo_root))] * 2
         + [("uv", str(rl_root))] * 5
     )
 
     argvs = [r["args"] for r in recs]
-    # Root suite: uv lock --check, ruff, mypy, pytest (-n auto parallel).
+    # Root suite mirrors ci.yml's check job: uv lock --check, the uv sync
+    # --all-extras install, ruff, mypy, pytest (-n auto parallel).
     assert argvs[0] == ["lock", "--check"]
-    assert argvs[1] == ["run", "ruff", "check", "daydream", "tests"]
-    assert argvs[2] == ["run", "mypy", "daydream", "tests"]
-    assert argvs[3] == ["run", "pytest", "-n", "auto"]
+    assert argvs[1] == ["sync", "--all-extras"]
+    assert argvs[2] == ["run", "ruff", "check", "daydream", "tests"]
+    assert argvs[3] == ["run", "mypy", "daydream", "tests"]
+    assert argvs[4] == ["run", "pytest", "-n", "auto"]
 
-    # actionlint: docker invocation shaped exactly like ci.yml's, with the
-    # image digest read LIVE from the CI workflow (never hardcoded here).
+    # actionlint: the recipe first probes the Docker daemon (docker info), then
+    # runs the container when available, invocation shaped exactly like ci.yml's
+    # with the image digest read LIVE from the CI workflow (never hardcoded).
     wf = load_workflow(REPO_WORKFLOWS_DIR / "ci.yml")
     steps = job_steps(wf, "check")
     actionlint = next(s for s in steps if s.get("name") == "Lint workflows with actionlint")
     (image_ref,) = _ACTIONLINT_REF_RE.findall(actionlint["run"])
 
-    docker = argvs[4]
+    assert argvs[5] == ["info"]  # availability guard probes the daemon
+    docker = argvs[6]
     assert docker[0:2] == ["run", "--rm"]
     mount_at = docker.index("-v")
     assert docker[mount_at + 1] == f"{repo_root}:/repo"
@@ -172,13 +177,17 @@ def test_check_runs_root_workflow_and_standalone_rl_gates(
     assert set(file_args) == expected_files
     assert len(file_args) == len(expected_files)
 
-    # Standalone RL project: its own lock/sync/lint/types/tests, run from its
-    # dir (mirroring ci.yml's rl-check job, which runs an explicit `uv sync`).
-    assert argvs[5] == ["lock", "--check"]
-    assert argvs[6] == ["sync"]
-    assert argvs[7] == ["run", "ruff", "check", "."]
-    assert argvs[8] == ["run", "mypy", "daydream_review_v1", "tests"]
-    assert argvs[9] == ["run", "pytest"]
+    # Standalone RL project: first configures the same neutral git identity as
+    # ci.yml's 'Configure git identity' step (the suite commits into throwaway
+    # fixtures with no per-repo identity), then its lock/sync/lint/types/tests,
+    # run from its dir (mirroring ci.yml's rl-check job's explicit `uv sync`).
+    assert argvs[7] == ["config", "--global", "user.email", "ci@daydream.invalid"]
+    assert argvs[8] == ["config", "--global", "user.name", "daydream CI"]
+    assert argvs[9] == ["lock", "--check"]
+    assert argvs[10] == ["sync"]
+    assert argvs[11] == ["run", "ruff", "check", "."]
+    assert argvs[12] == ["run", "mypy", "daydream_review_v1", "tests"]
+    assert argvs[13] == ["run", "pytest"]
 
 
 def test_pre_push_delegates_quality_gate_to_make_check(

--- a/tests/test_makefile_hooks.py
+++ b/tests/test_makefile_hooks.py
@@ -1,21 +1,43 @@
-"""Real-path test for ``make hooks`` pre-push hook installation (issue #388).
+"""Real-path contract tests for the local and pre-push make gates (issues #388, #717).
 
-Runs the real Makefile's ``hooks:`` target from a real git worktree — both a
-primary worktree (``.git`` is a directory) and a linked worktree (``.git`` is a
-gitdir-pointer file) — and asserts the hook is installed as a symlink at Git's
-resolved ``hooks/pre-push`` path pointing at the invoking worktree's
-``scripts/hooks/pre-push``. Installation only; never executes the installed hook.
+Three contracts are exercised here against the real Makefile and hook script
+from a real git worktree:
+
+- ``make hooks`` installs the pre-push hook as a worktree-aware symlink,
+  pointing at the invoking worktree's own source file (both primary and linked
+  worktrees).
+- ``make check`` composes every gate CI enforces: the root lock/lint/types/tests
+  suite, the Docker-backed actionlint pass over all workflow templates, and the
+  standalone RL project's four gates — each run from the right working
+  directory with the exact command line CI would issue.
+- the pre-push hook delegates to ``make check`` after its signature loop.
+
+The composition/delegation tests never execute the real tooling: PATH-shim
+recorders named ``uv``/``docker`` capture ``{command, cwd, args}`` as JSONL so the
+real Makefile dependency graph and the real hook are observable without a Docker
+daemon, a network pull, or a resolver touch.
 """
 
 from __future__ import annotations
 
+import json
+import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from tests.harness.git_helpers import git as _git
+from tests.test_workflow_templates import (
+    _ACTIONLINT_REF_RE,
+    REPO_WORKFLOWS_DIR,
+    TEMPLATES_DIR,
+    job_steps,
+    load_workflow,
+)
 
 
 @pytest.mark.parametrize("worktree_name", ["main", "linked"])
@@ -48,3 +70,110 @@ def test_hooks_installs_pre_push_from_worktree(
     assert dest.is_symlink()
     # The symlink resolves to THIS worktree's source file (never a sibling's).
     assert dest.resolve() == (worktree / "scripts" / "hooks" / "pre-push").resolve()
+
+
+def _install_recording_commands(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, names: tuple[str, ...]
+) -> Path:
+    """Prepend a fakebin of PATH-shim recorders for ``names`` to PATH.
+
+    Each shim appends ``{"command": <basename>, "cwd": os.getcwd(),
+    "args": sys.argv[1:]}`` to the JSONL log at ``$DAYDREAM_COMMAND_LOG`` and
+    exits 0, so the real Makefile graph can be observed without any real
+    tooling. The shebang is pinned to ``sys.executable`` (never the ambient
+    python). Returns the log path.
+    """
+    fakebin = tmp_path / "fakebin"
+    fakebin.mkdir()
+    log = tmp_path / "command-log.jsonl"
+    monkeypatch.setenv("DAYDREAM_COMMAND_LOG", str(log))
+    shim_body = (
+        "import json, os, sys\n"
+        "log = os.environ['DAYDREAM_COMMAND_LOG']\n"
+        "with open(log, 'a', encoding='utf-8') as f:\n"
+        "    json.dump({'command': os.path.basename(sys.argv[0]),\n"
+        "               'cwd': os.getcwd(), 'args': sys.argv[1:]}, f)\n"
+        "    f.write('\\n')\n"
+    )
+    for name in names:
+        shim = fakebin / name
+        shim.write_text(f"#!{sys.executable}\n{shim_body}", encoding="utf-8")
+        shim.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{fakebin}:{os.environ.get('PATH', '')}")
+    return log
+
+
+def _read_command_records(log: Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for line in log.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            records.append(json.loads(line.encode("utf-8")))
+    return records
+
+
+def test_check_runs_root_workflow_and_standalone_rl_gates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    log = _install_recording_commands(tmp_path, monkeypatch, ("uv", "docker"))
+
+    # Strip make's jobserver/MAKELEVEL chatter so the shim children don't get
+    # tangled in an inherited parallel-make env.
+    clean_env = {k: v for k, v in os.environ.items() if k not in ("MAKEFLAGS", "MFLAGS")}
+    proc = subprocess.run(
+        ["make", "check"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        env=clean_env,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+    recs = _read_command_records(log)
+    rl_root = repo_root / "rl" / "daydream_review_v1"
+    cmds = [(r["command"], r["cwd"]) for r in recs]
+    assert cmds == (
+        [("uv", str(repo_root))] * 4
+        + [("docker", str(repo_root))]
+        + [("uv", str(rl_root))] * 4
+    )
+
+    argvs = [r["args"] for r in recs]
+    # Root suite: uv lock --check, ruff, mypy, pytest (-n auto parallel).
+    assert argvs[0] == ["lock", "--check"]
+    assert argvs[1] == ["run", "ruff", "check", "daydream", "tests"]
+    assert argvs[2] == ["run", "mypy", "daydream", "tests"]
+    assert argvs[3] == ["run", "pytest", "-n", "auto"]
+
+    # actionlint: docker invocation shaped exactly like ci.yml's, with the
+    # image digest read LIVE from the CI workflow (never hardcoded here).
+    wf = load_workflow(REPO_WORKFLOWS_DIR / "ci.yml")
+    steps = job_steps(wf, "check")
+    actionlint = next(s for s in steps if s.get("name") == "Lint workflows with actionlint")
+    (image_ref,) = _ACTIONLINT_REF_RE.findall(actionlint["run"])
+
+    docker = argvs[4]
+    assert docker[0:2] == ["run", "--rm"]
+    mount_at = docker.index("-v")
+    assert docker[mount_at + 1] == f"{repo_root}:/repo"
+    assert [a for a in docker if a.endswith(":/repo")] == [f"{repo_root}:/repo"]
+    w_at = docker.index("-w")
+    assert docker[w_at + 1] == "/repo"
+    assert image_ref in docker
+    image_idx = docker.index(image_ref)
+    assert "-color" in docker
+    # The selectors expand (shell glob) to the full shipped-workflow set, each
+    # exactly once, positionally grouped by the three GLB globs.
+    file_args = docker[image_idx + 2 :]  # drop the image and -color
+    expected_files = {
+        *(p.relative_to(repo_root).as_posix() for p in REPO_WORKFLOWS_DIR.glob("*.yml")),
+        *(p.relative_to(repo_root).as_posix() for p in TEMPLATES_DIR.rglob("*.yml")),
+    }
+    assert set(file_args) == expected_files
+    assert len(file_args) == len(expected_files)
+
+    # Standalone RL project: its own lock/lint/types/tests, run from its dir.
+    assert argvs[5] == ["lock", "--check"]
+    assert argvs[6] == ["run", "ruff", "check", "."]
+    assert argvs[7] == ["run", "mypy", "daydream_review_v1", "tests"]
+    assert argvs[8] == ["run", "pytest"]

--- a/tests/test_makefile_hooks.py
+++ b/tests/test_makefile_hooks.py
@@ -135,7 +135,7 @@ def test_check_runs_root_workflow_and_standalone_rl_gates(
     assert cmds == (
         [("uv", str(repo_root))] * 4
         + [("docker", str(repo_root))]
-        + [("uv", str(rl_root))] * 4
+        + [("uv", str(rl_root))] * 5
     )
 
     argvs = [r["args"] for r in recs]
@@ -172,11 +172,13 @@ def test_check_runs_root_workflow_and_standalone_rl_gates(
     assert set(file_args) == expected_files
     assert len(file_args) == len(expected_files)
 
-    # Standalone RL project: its own lock/lint/types/tests, run from its dir.
+    # Standalone RL project: its own lock/sync/lint/types/tests, run from its
+    # dir (mirroring ci.yml's rl-check job, which runs an explicit `uv sync`).
     assert argvs[5] == ["lock", "--check"]
-    assert argvs[6] == ["run", "ruff", "check", "."]
-    assert argvs[7] == ["run", "mypy", "daydream_review_v1", "tests"]
-    assert argvs[8] == ["run", "pytest"]
+    assert argvs[6] == ["sync"]
+    assert argvs[7] == ["run", "ruff", "check", "."]
+    assert argvs[8] == ["run", "mypy", "daydream_review_v1", "tests"]
+    assert argvs[9] == ["run", "pytest"]
 
 
 def test_pre_push_delegates_quality_gate_to_make_check(

--- a/tests/test_makefile_hooks.py
+++ b/tests/test_makefile_hooks.py
@@ -177,3 +177,29 @@ def test_check_runs_root_workflow_and_standalone_rl_gates(
     assert argvs[6] == ["run", "ruff", "check", "."]
     assert argvs[7] == ["run", "mypy", "daydream_review_v1", "tests"]
     assert argvs[8] == ["run", "pytest"]
+
+
+def test_pre_push_delegates_quality_gate_to_make_check(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    _install_recording_commands(tmp_path, monkeypatch, ("make", "uv", "docker"))
+    log = tmp_path / "command-log.jsonl"
+
+    clean_env = {k: v for k, v in os.environ.items() if k not in ("MAKEFLAGS", "MFLAGS")}
+    proc = subprocess.run(
+        [str(repo_root / "scripts" / "hooks" / "pre-push")],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        input="",
+        env=clean_env,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "✓ All checks passed" in proc.stdout
+
+    recs = _read_command_records(log)
+    assert len(recs) == 1
+    assert recs[0]["command"] == "make"
+    assert recs[0]["cwd"] == str(repo_root)
+    assert recs[0]["args"] == ["check"]

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -44,7 +44,6 @@ import yaml
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 TEMPLATES_DIR = _REPO_ROOT / "daydream" / "templates" / "workflows"
 REPO_WORKFLOWS_DIR = _REPO_ROOT / ".github" / "workflows"
-PR_TEMPLATE_PATH = _REPO_ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md"
 # The digest below matches the immutable rhysd/actionlint:1.7.7 manifest digest
 # verified against the live OCI registry (`docker buildx imagetools inspect
 # rhysd/actionlint:1.7.7` / `docker manifest inspect …@sha256:887a…147e9`;
@@ -769,15 +768,16 @@ def test_ci_and_pr_template_pin_actionlint_image_by_digest() -> None:
     actionlint = next(s for s in steps if s.get("name") == "Lint workflows with actionlint")
 
     ci_refs = _ACTIONLINT_REF_RE.findall(actionlint["run"])
-    pr_refs = _ACTIONLINT_REF_RE.findall(PR_TEMPLATE_PATH.read_text(encoding="utf-8"))
+    makefile_text = (_REPO_ROOT / "Makefile").read_text(encoding="utf-8")
+    make_refs = _ACTIONLINT_REF_RE.findall(makefile_text)
 
     assert ci_refs == [_ACTIONLINT_IMAGE], (
         "CI actionlint step must reference the digest-pinned image exactly once: "
         f"found {ci_refs}"
     )
-    assert pr_refs == [_ACTIONLINT_IMAGE], (
-        "PR template Actionlint checklist must reference the digest-pinned image "
-        f"exactly once: found {pr_refs}"
+    assert make_refs == [_ACTIONLINT_IMAGE], (
+        "Makefile actionlint target must carry the digest-pinned image exactly "
+        f"once: found {make_refs}"
     )
 
 
@@ -788,6 +788,35 @@ def test_ci_and_pr_template_pin_actionlint_image_by_digest() -> None:
 # actionlint step and expands them, so a selector that stops covering a shipped
 # file (or a newly nested template) fails this test rather than silently
 # shipping un-linted workflows.
+
+
+def test_makefile_actionlint_selectors_match_ci() -> None:
+    wf = load_workflow(REPO_WORKFLOWS_DIR / "ci.yml")
+    steps = job_steps(wf, "check")
+    actionlint = next(s for s in steps if s.get("name") == "Lint workflows with actionlint")
+    ci_selectors = [
+        tok for tok in actionlint["run"].split()
+        if tok.endswith(".yml") and not tok.startswith("-")
+    ]
+    mk = (_REPO_ROOT / "Makefile").read_text(encoding="utf-8")
+    assert "rhysd/actionlint" in mk
+    # Every CI selector appears verbatim in the Makefile's actionlint recipe,
+    # and vice versa: adding a directory on either side strands the other gate.
+    for sel in ci_selectors:
+        assert sel in mk, f"selector {sel!r} missing from Makefile actionlint target"
+    # Parse ONLY the actionlint target's recipe (between the target line and the
+    # next top-level target), not comments, which may mention ci.yml in prose.
+    mk_lines = mk.splitlines()
+    start = next(i for i, line in enumerate(mk_lines) if line.strip() == "actionlint:")
+    recipe: list[str] = []
+    for line in mk_lines[start + 1:]:
+        if line and not line.startswith(("\t", " ")):
+            break
+        recipe.append(line)
+    mk_toks = [t.strip("\\\t ") for t in " ".join(recipe).split()]
+    mk_selectors = {t for t in mk_toks if t.endswith(".yml") and t != "\\"}
+    for sel in mk_selectors:
+        assert sel in ci_selectors, f"Makefile-only selector {sel!r} escapes CI"
 
 
 def test_ci_actionlint_covers_all_workflow_sources() -> None:

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -20,7 +20,7 @@ cannot verify and that a careless edit could silently break:
 - The repository workflow README declares these files as repository-only Codex
   dogfood configuration and points to the packaged install guide (never copies
   ``ANTHROPIC_API_KEY``).
-- The CI actionlint step and the contributor PR checklist both reference the
+- The CI actionlint step and the Makefile actionlint target both reference the
   actionlint image by immutable OCI digest (``rhysd/actionlint:1.7.7@sha256:…``),
   so a revert to a mutable tag, or drift between the two, fails the suite.
 - The CI actionlint step covers every workflow the project ships — the repo's
@@ -754,7 +754,7 @@ def test_repo_workflow_readme_declares_codex_and_points_to_canonical_install() -
         assert stale not in text
 
 
-def test_ci_and_pr_template_pin_actionlint_image_by_digest() -> None:
+def test_makefile_and_ci_pin_actionlint_image_by_digest() -> None:
     # Caveat (matches _PINNED_ACTION_VERSIONS, which also cannot verify a
     # SHA-->release mapping against its upstream): these assertions only prove the
     # three copies agree with one another. They cannot, and are not intended to,


### PR DESCRIPTION
## Summary
- Aligns the local `make check` gate and the pre-push hook with every check CI runs, so a green local run means a green CI run
- Adds `uv sync` to `rl-check`, scopes its git identity to the process environment, and skips actionlint when the Docker daemon is unavailable
- Covers the pre-push delegation to `make check` with tests; restores `.PHONY test`; fixes README overclaim about hard Docker requirement

## Test Plan
- [x] Focused suites: test_makefile_hooks.py + test_workflow_templates.py — 49 passed
- [x] ruff clean
- [x] Full root `make test`: 4360 passed / 17 skipped

Closes #717