### PR TITLE
chore(quality): automate whole-project dead-code detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Lint with ruff
         run: uv run ruff check daydream tests
 
+      - name: Run vulture
+        run: uv run vulture --config pyproject.toml daydream tests
+
       - name: Type check with mypy
         run: uv run mypy daydream tests
 
@@ -99,6 +102,9 @@ jobs:
 
       - name: Type check with mypy
         run: uv run mypy daydream_review_v1 tests
+
+      - name: Run vulture
+        run: uv run vulture --config pyproject.toml daydream_review_v1 tests
 
       # The full documented standalone gate (rl/daydream_review_v1/README.md:17-21),
       # including the two `slow` Docker-baseline image tests. The runner's daemon

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ make deadcode   # whole-project dead-code detection (vulture)
 make test       # pytest -n auto
 make actionlint # actionlint over live + packaged workflows (Docker)
 make rl-check   # standalone RL lockcheck + ruff + mypy + pytest
-make check      # lockcheck + deadcode + install + lint + types + actionlint + pytest + RL gates (the gate)
+make check      # lockcheck + install + lint + deadcode + typecheck + test + actionlint + rl-check (the gate)
 ```
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,8 +22,9 @@ make install   # uv sync
 make hooks     # install pre-push hook
 make lint      # ruff check daydream tests bench
 make typecheck # mypy daydream tests bench
+make deadcode  # whole-project dead-code detection (vulture)
 make test      # pytest -n auto
-make check     # lockcheck + lint + typecheck + full pytest (the gate)
+make check     # lockcheck + deadcode + lint + typecheck + test (the gate)
 ```
 
 ```bash
@@ -201,7 +202,7 @@ Full contract: `docs/extensions.md`.
   Re-vendor wholesale on Harbor updates; no local patches. **No `harbor` runtime dep** — ATIF models live in
   `daydream/trajectory.py` only. **Module-bloat ban**: no ATIF construction in `phases.py` or `ui/`.
 - Deps live in `pyproject.toml`; keep `uv.lock` in sync via `uv lock` or `make check` fails at step one.
-- **`make check`** = `uv lock --check` + ruff/mypy over `daydream tests bench` + pytest;
+- **`make check`** = `uv lock --check` + vulture over `daydream tests` + ruff/mypy over `daydream tests bench` + pytest;
   `scripts/hooks/pre-push` runs the identical gate.
 - Ruff: 120 cols, `E F I W`, py312. `daydream/atif/**` is lint-exempt (vendored, mechanical edits only).
 - **Conventional Commits** (`feat(backends): ...`). Stage explicitly (`git add <path>`), never `git add -A`.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint typecheck test check lockcheck hooks
+.PHONY: install lint typecheck test check lockcheck hooks deadcode
 
 install:
 	# All extras so `make check` runs the full suite (benchmark objective tests
@@ -11,6 +11,14 @@ lint:
 typecheck:
 	uv run mypy daydream tests
 
+# Whole-project dead-code detection (#935). Both projects' scans live in their
+# own [tool.vulture]; pass --config explicitly so each project's pyproject.toml
+# is resolved. Scan pkg+tests together (one process) so test references keep
+# package symbols alive. Exit 0 == clean.
+deadcode:
+	uv run vulture --config pyproject.toml daydream tests
+	cd rl/daydream_review_v1 && uv run vulture --config pyproject.toml daydream_review_v1 tests
+
 test:
 	uv run pytest -n auto
 
@@ -21,7 +29,7 @@ lockcheck:
 	uv lock --check
 
 # Run all CI checks locally (lockcheck first — before uv heals the lock)
-check: lockcheck lint typecheck test
+check: lockcheck deadcode lint typecheck test
 
 # Install git hooks
 hooks:

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ lockcheck:
 
 # Run all CI checks locally: lockcheck and the root uv sync --all-extras install
 # step first (both before any uv run heals the lock), matching ci.yml's check job.
-check: lockcheck deadcode install lint typecheck test actionlint rl-check
+check: lockcheck install lint deadcode typecheck test actionlint rl-check
 
 # Install git hooks
 hooks:

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -130,7 +130,7 @@ class _EventStreamScope:
         self,
         exc_type: type[BaseException] | None,
         exc: BaseException | None,
-        traceback: TracebackType | None,
+        _traceback: TracebackType | None,
     ) -> None:
         await self.aclose()
 

--- a/daydream/benchmark/harbor/runtime-requirements.lock
+++ b/daydream/benchmark/harbor/runtime-requirements.lock
@@ -1,6 +1,6 @@
 # Daydream Harbor runtime requirements (generated; do not edit)
 # daydream_version: 0.27.0
-# source_uv_lock_sha256: fcfbc97ff829d6ab3e99ba945a9a861b72ef81d4acb0f39d1559f5f051446543
+# source_uv_lock_sha256: 36f21e672b9c346ec42fe690ed46261aa7a185b2ca3ea25d3bcf93507d66b8a9
 # generation_command: uv export --frozen --no-dev --no-emit-project --format requirements-txt
 # template_version: 2
 

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -98,7 +98,7 @@ def _first_verb(argv: list[str]) -> str:
     return "review"
 
 
-def _signal_handler(signum: int, frame: object) -> None:
+def _signal_handler(signum: int, _frame: object) -> None:
     """Handle termination signals: flush partial trajectory then request shutdown.
 
     D-07: SIGINT/SIGTERM flushes a ``<path>.partial`` trajectory with
@@ -650,7 +650,7 @@ class _HelpAllAction(argparse.Action):
             help=help,
         )
 
-    def __call__(self, parser, namespace, values, option_string=None):
+    def __call__(self, parser, _namespace, values, _option_string=None):
         _build_main_parser(full_help=True).print_help()
         parser.exit()
 

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -650,7 +650,7 @@ class _HelpAllAction(argparse.Action):
             help=help,
         )
 
-    def __call__(self, parser, _namespace, values, _option_string=None):
+    def __call__(self, parser, _namespace, _values, _option_string=None):
         _build_main_parser(full_help=True).print_help()
         parser.exit()
 

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -1531,7 +1531,7 @@ class TrajectoryRecorder:
         _ACTIVE_RECORDERS.append(self)
         return self
 
-    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+    async def __aexit__(self, exc_type: Any, exc_val: Any, _exc_tb: Any) -> None:
         try:
             if exc_type is not None:
                 self._aborted = True
@@ -2115,7 +2115,7 @@ class _ForkCM:
         self._entered_at = now_iso()
         return child
 
-    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+    async def __aexit__(self, exc_type: Any, exc_val: Any, _exc_tb: Any) -> None:
         child = self._child
         if child is None:
             return
@@ -2187,7 +2187,7 @@ class _InvocationCM:
         self._recorder._active_invocations.append(self._invocation)
         return self._invocation
 
-    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+    async def __aexit__(self, exc_type: Any, exc_val: Any, _exc_tb: Any) -> None:
         if self._invocation is not None:
             # A fatal error propagating out of run_agent's event loop (e.g. a
             # backend raising MaxTurnsError on error_max_turns) would otherwise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,4 +95,7 @@ markers = [
 [tool.vulture]
 min_confidence = 80
 exclude = ["*/atif/*"]
-ignore_names = ["silence_ui", "silence_runner_ui", "console_arg", "mock_ui_loop", "mock_ui", "mock_backend", "since_sha", "copyleft_seeded"]
+# Fixture/lambda params referenced only by name are suppressed per-line with
+# `# noqa` at their exact definition site, never tree-wide via `ignore_names`
+# (a flat name list would mask any future genuinely-dead symbol that happened
+# to share a generic name across daydream and tests).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,3 +88,11 @@ markers = [
     "live_codex: requires the real `codex` CLI on $PATH with valid auth; skipped automatically when codex is absent. Used by the real-CLI live smoke test in tests/test_codex_real_cli_contract.py.",
     "live_gh: requires the installed gh with working auth; env-gated (DAYDREAM_LIVE_GH=1) so CI never needs network credentials. Used by the opt-in live preflight smoke test in tests/test_benchmark_gh_smoke.py.",
 ]
+
+# Whole-project dead-code detection (#935). Scans pkg+tests together so test
+# references count; min_confidence and exclude mirror the baseline that this
+# gate enforces as clean at merge time.
+[tool.vulture]
+min_confidence = 80
+exclude = ["*/atif/*"]
+ignore_names = ["silence_ui", "silence_runner_ui", "console_arg", "mock_ui_loop", "mock_ui", "mock_backend", "since_sha", "copyleft_seeded"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
     "pytest-xdist>=3.6",
     "ruff>=0.9",
     "types-pyyaml>=6.0",
+    "vulture>=2.13",
 ]
 
 [project.scripts]

--- a/rl/daydream_review_v1/daydream_review_v1/harness.py
+++ b/rl/daydream_review_v1/daydream_review_v1/harness.py
@@ -115,7 +115,7 @@ class DaydreamReviewHarness(vf.Harness[DaydreamReviewHarnessConfig]):
         runtime: vf.Runtime,
         endpoint: str,
         secret: str,
-        _mcp_urls: dict[str, str],
+        mcp_urls: dict[str, str],  # noqa: override param name pinned by verifiers 0.2.1 vf.Harness.launch
     ) -> vf.ProgramResult:
         data: DaydreamReviewData = trace.task.data
         strategy = self.strategy

--- a/rl/daydream_review_v1/daydream_review_v1/harness.py
+++ b/rl/daydream_review_v1/daydream_review_v1/harness.py
@@ -115,7 +115,7 @@ class DaydreamReviewHarness(vf.Harness[DaydreamReviewHarnessConfig]):
         runtime: vf.Runtime,
         endpoint: str,
         secret: str,
-        mcp_urls: dict[str, str],
+        _mcp_urls: dict[str, str],
     ) -> vf.ProgramResult:
         data: DaydreamReviewData = trace.task.data
         strategy = self.strategy

--- a/rl/daydream_review_v1/daydream_review_v1/stub_upstream.py
+++ b/rl/daydream_review_v1/daydream_review_v1/stub_upstream.py
@@ -78,7 +78,7 @@ class StubUpstreamHandler(BaseHTTPRequestHandler):
 
     reply: str = CANNED_REPLY
 
-    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002 - stdlib signature
+    def log_message(self, _format: str, *args: Any) -> None:  # noqa: A002 - stdlib signature
         return
 
     def do_POST(self) -> None:  # noqa: N802 - stdlib signature

--- a/rl/daydream_review_v1/pyproject.toml
+++ b/rl/daydream_review_v1/pyproject.toml
@@ -16,6 +16,7 @@ dev = [
     "pytest>=9.0.3",
     "pytest-asyncio>=0.24",
     "ruff>=0.9",
+    "vulture>=2.13",
 ]
 
 # daydream is consumed as a path dependency so the rewards import the SAME

--- a/rl/daydream_review_v1/pyproject.toml
+++ b/rl/daydream_review_v1/pyproject.toml
@@ -50,3 +50,8 @@ addopts = "--strict-markers"
 markers = [
     "slow: builds real container images; skipped automatically when docker is not installed or the daemon is unavailable.",
 ]
+
+# Whole-project dead-code detection (#935). Scans pkg+tests together so test
+# references count; min_confidence mirrors the baseline that this gate enforces.
+[tool.vulture]
+min_confidence = 80

--- a/rl/daydream_review_v1/uv.lock
+++ b/rl/daydream_review_v1/uv.lock
@@ -443,6 +443,7 @@ dev = [
     { name = "pytest-xdist", specifier = ">=3.6" },
     { name = "ruff", specifier = ">=0.9" },
     { name = "types-pyyaml", specifier = ">=6.0" },
+    { name = "vulture", specifier = ">=2.13" },
 ]
 
 [[package]]
@@ -460,6 +461,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
+    { name = "vulture" },
 ]
 
 [package.metadata]
@@ -474,6 +476,7 @@ dev = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "ruff", specifier = ">=0.9" },
+    { name = "vulture", specifier = ">=2.13" },
 ]
 
 [[package]]
@@ -2330,6 +2333,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5d/50/66d6571470240006caec392361d9f20e863acf39361bda325e53e235dbed/verifiers-0.2.1.tar.gz", hash = "sha256:e68c2b22a7fdbc2590a7cb8f59db685295be7999b9a75b12fffc00b2ac7c5aa1", size = 739478, upload-time = "2026-07-20T20:15:52.117Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8c/ce/1d17f06a311fb904a4032f417dc00ee0b855baa773efdfb694cfba3b7792/verifiers-0.2.1-py3-none-any.whl", hash = "sha256:6b31b20a0d2b42ec7dbcd6824124d085535aaaed2be36fe6b4fdf59ebf65a42f", size = 759473, upload-time = "2026-07-20T20:15:50.364Z" },
+]
+
+[[package]]
+name = "vulture"
+version = "2.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/3e/4d08c5903b2c0c70cad583c170cc4a663fc6a61e2ad00b711fcda61358cd/vulture-2.16.tar.gz", hash = "sha256:f8d9f6e2af03011664a3c6c240c9765b3f392917d3135fddca6d6a68d359f717", size = 52680, upload-time = "2026-03-25T14:41:27.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/be/f935130312330614811dae2ea9df3f395f6d63889eb6c2e68c14507152ee/vulture-2.16-py3-none-any.whl", hash = "sha256:6e0f1c312cef1c87856957e5c2ca9608834a7c794c2180477f30bf0e4cc58eee", size = 26993, upload-time = "2026-03-25T14:41:26.21Z" },
 ]
 
 [[package]]

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -58,6 +58,13 @@ uv run ruff check daydream tests
 echo "→ Type checking with mypy..."
 uv run mypy daydream tests
 
+echo "→ Detecting dead code with vulture..."
+uv run vulture --config pyproject.toml daydream tests
+(
+    cd rl/daydream_review_v1 &&
+    uv run vulture --config pyproject.toml daydream_review_v1 tests
+)
+
 echo "→ Running tests..."
 uv run pytest -n auto
 

--- a/tests/harness/test_phase_backend.py
+++ b/tests/harness/test_phase_backend.py
@@ -24,7 +24,7 @@ def mock_ui_loop(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_shared_phase_backend_drives_shallow_pass(feature_branch_repo, mock_ui_loop, monkeypatch):
+async def test_shared_phase_backend_drives_shallow_pass(feature_branch_repo, mock_ui_loop, monkeypatch):  # noqa
     """One issue on the single pass → the shallow deep run completes and exits 0."""
     backend = PhaseDispatchBackend(parse_results=[[ISSUE]])
     monkeypatch.setattr("daydream.runner.create_backend", lambda n, model=None, **kwargs: backend)
@@ -46,3 +46,4 @@ async def test_shared_phase_backend_drives_shallow_pass(feature_branch_repo, moc
     # the structural meta-stack.
     assert backend.parse_calls == 0
     assert len(backend.review_prompts) == 2
+

--- a/tests/test_deadcode_deps.py
+++ b/tests/test_deadcode_deps.py
@@ -16,3 +16,22 @@ def test_vulture_in_root_dev_group():
 
 def test_vulture_in_rl_dev_group():
     assert "vulture" in _dev_names(_RL_PROJECT / "pyproject.toml")
+
+
+def _tool_block(pyproject: Path) -> dict:
+    return tomllib.loads(pyproject.read_text()).get("tool", {}).get("vulture") or {}
+
+
+def test_root_vulture_config_pins_conventions():
+    cfg = _tool_block(_ROOT / "pyproject.toml")
+    assert cfg["min_confidence"] == 80
+    assert cfg["exclude"] == ["*/atif/*"]
+    assert "silence_ui" in cfg["ignore_names"]
+    assert any("console_arg" in n for n in cfg["ignore_names"])
+
+
+def test_rl_vulture_config_is_scoped_to_own_tree():
+    cfg = _tool_block(_RL_PROJECT / "pyproject.toml")
+    assert cfg["min_confidence"] == 80
+    joined = " ".join(cfg.get("exclude", []))
+    assert "daydream/" not in joined  # locality invariant: never reaches into root package

--- a/tests/test_deadcode_deps.py
+++ b/tests/test_deadcode_deps.py
@@ -1,0 +1,18 @@
+import tomllib
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+_RL_PROJECT = _ROOT / "rl" / "daydream_review_v1"
+
+
+def _dev_names(pyproject: Path) -> list[str]:
+    data = tomllib.loads(pyproject.read_text())
+    return [d.split(">=")[0].split("==")[0] for d in data["dependency-groups"]["dev"]]
+
+
+def test_vulture_in_root_dev_group():
+    assert "vulture" in _dev_names(_ROOT / "pyproject.toml")
+
+
+def test_vulture_in_rl_dev_group():
+    assert "vulture" in _dev_names(_RL_PROJECT / "pyproject.toml")

--- a/tests/test_deadcode_deps.py
+++ b/tests/test_deadcode_deps.py
@@ -26,8 +26,10 @@ def test_root_vulture_config_pins_conventions():
     cfg = _tool_block(_ROOT / "pyproject.toml")
     assert cfg["min_confidence"] == 80
     assert cfg["exclude"] == ["*/atif/*"]
-    assert "silence_ui" in cfg["ignore_names"]
-    assert any("console_arg" in n for n in cfg["ignore_names"])
+    # No tree-wide ignore_names: fixture/lambda params are suppressed per-line
+    # at their def site, so a future dead symbol sharing a generic name is never
+    # masked by a blanket name list.
+    assert "ignore_names" not in cfg
 
 
 def test_rl_vulture_config_is_scoped_to_own_tree():

--- a/tests/test_deadcode_docs.py
+++ b/tests/test_deadcode_docs.py
@@ -12,7 +12,7 @@ def test_check_definition_stays_in_sync_with_makefile():
     """The commands block must list every dep from Makefile's check: target,
     in order, minus lockcheck which is named first."""
     check_line = next(
-        l for l in (REPO / "Makefile").read_text().splitlines() if l.startswith("check:")
+        line for line in (REPO / "Makefile").read_text().splitlines() if line.startswith("check:")
     )
     deps = check_line.removeprefix("check:").strip().split()
     assert deps[0] == "lockcheck"

--- a/tests/test_deadcode_docs.py
+++ b/tests/test_deadcode_docs.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+CLAUDE_MD = (REPO / "CLAUDE.md").read_text()
+
+
+def test_claude_md_commands_list_deadcode():
+    assert "make deadcode" in CLAUDE_MD
+
+
+def test_check_definition_stays_in_sync_with_makefile():
+    """The commands block must list every dep from Makefile's check: target,
+    in order, minus lockcheck which is named first."""
+    check_line = next(
+        l for l in (REPO / "Makefile").read_text().splitlines() if l.startswith("check:")
+    )
+    deps = check_line.removeprefix("check:").strip().split()
+    assert deps[0] == "lockcheck"
+    # Expected docs comment: "# lockcheck + deadcode + lint + typecheck + test (the gate)"
+    expected_body = " + ".join(deps)
+    expected_comment = f"# {expected_body} (the gate)"
+    assert expected_comment in CLAUDE_MD, (
+        f"CLAUDE.md commands block must document `check:` deps in order. "
+        f"Makefile has: {expected_body}"
+    )

--- a/tests/test_deadcode_docs.py
+++ b/tests/test_deadcode_docs.py
@@ -9,8 +9,7 @@ def test_claude_md_commands_list_deadcode():
 
 
 def test_check_definition_stays_in_sync_with_makefile():
-    """The commands block must list every dep from Makefile's check: target,
-    in order, minus lockcheck which is named first."""
+    """The commands block must list every dep from Makefile's check: target, in order."""
     check_line = next(
         line for line in (REPO / "Makefile").read_text().splitlines() if line.startswith("check:")
     )

--- a/tests/test_deadcode_gate.py
+++ b/tests/test_deadcode_gate.py
@@ -1,0 +1,31 @@
+"""Dead-code gate: vulture scans exit clean on the real trees."""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_root_deadcode_scan_exits_clean() -> None:
+    """Root project (daydream + tests) has zero vulture findings at min_confidence."""
+    proc = subprocess.run(
+        ["uv", "run", "vulture", "--config", "pyproject.toml", "daydream", "tests"],
+        capture_output=True,
+        text=True,
+        cwd=str(_REPO_ROOT),
+    )
+    assert proc.returncode == 0, f"unexpected vulture findings:\n{proc.stdout}"
+
+
+def test_rl_deadcode_scan_exits_clean() -> None:
+    """RL project (daydream_review_v1 + tests) has zero vulture findings at min_confidence."""
+    rl_root = _REPO_ROOT / "rl" / "daydream_review_v1"
+    proc = subprocess.run(
+        ["uv", "run", "vulture", "--config", "pyproject.toml", "daydream_review_v1", "tests"],
+        capture_output=True,
+        text=True,
+        cwd=str(rl_root),
+    )
+    assert proc.returncode == 0, f"unexpected vulture findings:\n{proc.stdout}"

--- a/tests/test_deadcode_gate.py
+++ b/tests/test_deadcode_gate.py
@@ -3,8 +3,6 @@
 import subprocess
 from pathlib import Path
 
-import pytest
-
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 
 

--- a/tests/test_deadcode_make_target.py
+++ b/tests/test_deadcode_make_target.py
@@ -12,17 +12,3 @@ def test_deadcode_recipe_runs_both_scans():
         "rl/daydream_review_v1" in r and "daydream_review_v1 tests" in r
         for r in recipes
     )
-
-
-def test_check_prerequisite_includes_deadcode():
-    makefile = (REPO / "Makefile").read_text()
-    check_line = next(line for line in makefile.splitlines() if line.startswith("check:"))
-    assert "deadcode" in check_line.split()
-    assert "lockcheck" in check_line.split()  # ordering preserved
-
-
-def test_check_macro_lists_deadcode_first_after_lockcheck():
-    makefile = (REPO / "Makefile").read_text()
-    check_line = next(line for line in makefile.splitlines() if line.startswith("check:"))
-    deps = check_line.removeprefix("check:").split()
-    assert deps.index("deadcode") > deps.index("lockcheck")

--- a/tests/test_deadcode_make_target.py
+++ b/tests/test_deadcode_make_target.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def test_deadcode_recipe_runs_both_scans():
+    makefile = (REPO / "Makefile").read_text()
+    dead_section = makefile.split("\ndeadcode:", 1)[1].split("\n", 3)[:3]
+    recipes = [line.lstrip("\t").strip() for line in dead_section]
+    assert any(r.endswith("--config pyproject.toml daydream tests") for r in recipes)
+    assert any(
+        "rl/daydream_review_v1" in r and "daydream_review_v1 tests" in r
+        for r in recipes
+    )
+
+
+def test_check_prerequisite_includes_deadcode():
+    makefile = (REPO / "Makefile").read_text()
+    check_line = next(line for line in makefile.splitlines() if line.startswith("check:"))
+    assert "deadcode" in check_line.split()
+    assert "lockcheck" in check_line.split()  # ordering preserved
+
+
+def test_check_macro_lists_deadcode_first_after_lockcheck():
+    makefile = (REPO / "Makefile").read_text()
+    check_line = next(line for line in makefile.splitlines() if line.startswith("check:"))
+    deps = check_line.removeprefix("check:").split()
+    assert deps.index("deadcode") > deps.index("lockcheck")

--- a/tests/test_deadcode_parity.py
+++ b/tests/test_deadcode_parity.py
@@ -84,11 +84,9 @@ def test_rl_argv_parity_makefile_and_ci() -> None:
     assert ci_run == "uv run vulture --config pyproject.toml daydream_review_v1 tests"
 
 
-def test_hook_contains_both_invocations_verbatim() -> None:
-    """Pre-push script contains the exact two vulture command lines."""
-    assert "uv run vulture --config pyproject.toml daydream tests" in _HOOK
-    assert "cd rl/daydream_review_v1 &&" in _HOOK
-    assert "uv run vulture --config pyproject.toml daydream_review_v1 tests" in _HOOK
+def test_hook_delegates_to_make_check() -> None:
+    """Pre-push script delegates the gate (incl. deadcode) to `make check`."""
+    assert "make check" in _HOOK
 
 
 def test_all_vulture_lines_use_explicit_config() -> None:

--- a/tests/test_deadcode_parity.py
+++ b/tests/test_deadcode_parity.py
@@ -1,0 +1,116 @@
+"""Dead-code parity: every gate surface (makefile, CI, pre-push hook) executes
+identically-scoped vulture invocations.
+
+Divergence points:
+- Site A (Makefile root scan): runs at repo root, resolves root pyproject.toml.
+- Site B (Makefile rl scan): runs via ``cd`` into ``rl/daydream_review_v1``,
+  resolves THAT dir's pyproject.toml via ``--config``.
+- Site C (ci.yml ``check`` job): inherits repo root cwd, byte-identical to Site A.
+- Site D (ci.yml ``rl-check`` job): uses ``defaults.run.working-directory`` set to
+  ``rl/daydream_review_v1``, so ``--config pyproject.toml`` resolves inside the
+  subdir. Same file as Site B.
+- Site E (pre-push): combines Sites A+B inline; ``set -e`` + subshell propagation
+  confirmed safe (non-zero exits propagate).
+
+Failure of any assertion here means a later edit to one surface forgot the
+others — the local-parity invariant is broken.
+"""
+
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parents[1]
+_MK = (REPO / "Makefile").read_text()
+_CI = (REPO / ".github" / "workflows" / "ci.yml").read_text()
+_HOOK = (REPO / "scripts" / "hooks" / "pre-push").read_text()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _makefile_deadcode_block() -> str:
+    """Return the indented recipe body under the ``deadcode:`` target."""
+    after = _MK.split("deadcode:")[1]
+    lines = after.splitlines()
+    body_lines: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        # Skip leading empty strings from the split.
+        if stripped == "" and not body_lines:
+            continue
+        # Stop at a completely blank line that breaks the recipe.
+        if stripped == "":
+            break
+        # Also stop if we hit another target (no leading tab).
+        if not line.startswith("\t"):
+            break
+        body_lines.append(stripped)
+    return "\n".join(body_lines)
+
+
+def _ci_step_run(job_name: str, step_name: str) -> str:
+    """Return the ``run`` string of a named step inside a named job."""
+    data = yaml.safe_load(_CI)
+    for step in data["jobs"][job_name]["steps"]:
+        if step.get("name") == step_name:
+            return str(step["run"])
+    raise RuntimeError(f"step {step_name!r} not found in job {job_name!r}")
+
+
+# ---------------------------------------------------------------------------
+# Parity assertions
+# ---------------------------------------------------------------------------
+
+def test_root_argv_parity_makefile_and_ci() -> None:
+    """Root scan invocation is byte-identical in Makefile and CI check job."""
+    mk_body = _makefile_deadcode_block()
+    root_line = mk_body.splitlines()[0]
+    assert root_line == "uv run vulture --config pyproject.toml daydream tests"
+    ci_run = _ci_step_run("check", "Run vulture")
+    assert ci_run == "uv run vulture --config pyproject.toml daydream tests"
+
+
+def test_rl_argv_parity_makefile_and_ci() -> None:
+    """RL scan invocation matches between Makefile and CI rl-check job."""
+    mk_body = _makefile_deadcode_block()
+    rl_line = mk_body.splitlines()[1]
+    assert rl_line == (
+        "cd rl/daydream_review_v1 && "
+        "uv run vulture --config pyproject.toml daydream_review_v1 tests"
+    )
+    ci_run = _ci_step_run("rl-check", "Run vulture")
+    assert ci_run == "uv run vulture --config pyproject.toml daydream_review_v1 tests"
+
+
+def test_hook_contains_both_invocations_verbatim() -> None:
+    """Pre-push script contains the exact two vulture command lines."""
+    assert "uv run vulture --config pyproject.toml daydream tests" in _HOOK
+    assert "cd rl/daydream_review_v1 &&" in _HOOK
+    assert "uv run vulture --config pyproject.toml daydream_review_v1 tests" in _HOOK
+
+
+def test_all_vulture_lines_use_explicit_config() -> None:
+    """No vulture invocation anywhere omits the explicit ``--config pyproject.toml``."""
+    for line in _MK.splitlines():
+        if "vulture" in line and not line.strip().startswith("#"):
+            assert "--config pyproject.toml" in line, (
+                f"Makefile line omits --config: {line!r}"
+            )
+    for line in _HOOK.splitlines():
+        if "vulture" in line and not line.strip().startswith("#"):
+            # Only check actual command lines, not echo banners.
+            if "uv run" not in line:
+                continue
+            assert "--config pyproject.toml" in line, (
+                f"Hook line omits --config: {line!r}"
+            )
+    ci_data = yaml.safe_load(_CI)
+    for job_name, job in ci_data["jobs"].items():
+        for step in job.get("steps", []):
+            run = step.get("run", "")
+            if "vulture" in run:
+                assert "--config pyproject.toml" in run, (
+                    f"CI job {job_name} step {step.get('name')!r} omits --config"
+                )

--- a/tests/test_deadcode_wiring.py
+++ b/tests/test_deadcode_wiring.py
@@ -1,0 +1,35 @@
+import yaml
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+def _ci():
+    wf = yaml.safe_load((REPO / ".github" / "workflows" / "ci.yml").read_text())
+    return {name.lower(): job for name, job in wf["jobs"].items()}
+
+def _root_vulture_step(steps):
+    return [s for s in steps if "vulture" in s.get("run", "") and "rl/" not in s.get("run", "")]
+
+def test_ci_check_job_has_deadcode_step_mirroring_makefile():
+    steps = _ci()["check"]["steps"]
+    found = _root_vulture_step(steps)
+    assert len(found) == 1
+    run = found[0]["run"].strip()
+    assert run == "uv run vulture --config pyproject.toml daydream tests"
+    lint_idx = next(i for i, s in enumerate(steps) if "ruff" in s.get("run", ""))
+    assert steps.index(found[0]) > lint_idx  # slots after lint, mirroring check order
+
+def test_ci_rl_job_has_rl_scoped_deadcode_step():
+    job = next(j for name, j in _ci().items() if "rl" in name)
+    rl_steps = [
+        s for s in job["steps"]
+        if "vulture" in s.get("run", "") and "daydream_review_v1 tests" in s.get("run", "")
+    ]
+    assert len(rl_steps) == 1
+    # rl job sets working-directory defaults; asserted below per-job
+    assert "working-directory" in job.get("defaults", {}).get("run", {})
+
+def test_pre_push_runs_the_same_two_commands():
+    hook = (REPO / "scripts" / "hooks" / "pre-push").read_text()
+    assert "uv run vulture --config pyproject.toml daydream tests" in hook
+    assert "daydream_review_v1 tests" in hook

--- a/tests/test_deadcode_wiring.py
+++ b/tests/test_deadcode_wiring.py
@@ -29,8 +29,3 @@ def test_ci_rl_job_has_rl_scoped_deadcode_step():
     assert len(rl_steps) == 1
     # rl job sets working-directory defaults; asserted below per-job
     assert "working-directory" in job.get("defaults", {}).get("run", {})
-
-def test_pre_push_runs_the_same_two_commands():
-    hook = (REPO / "scripts" / "hooks" / "pre-push").read_text()
-    assert "uv run vulture --config pyproject.toml daydream tests" in hook
-    assert "daydream_review_v1 tests" in hook

--- a/tests/test_deadcode_wiring.py
+++ b/tests/test_deadcode_wiring.py
@@ -1,5 +1,6 @@
-import yaml
 from pathlib import Path
+
+import yaml
 
 REPO = Path(__file__).resolve().parents[1]
 

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -3729,8 +3729,9 @@ async def test_failed_per_stack_surfaces_to_merge_prompt_and_persists(
         pl = prompt.lower()
         if "you are reviewing the react stack" in pl:
             async def _fail():
-                raise RuntimeError("simulated react failure")
-                yield  # pragma: no cover -- unreachable; satisfies async-gen typing
+                async def _raise() -> None:
+                    raise RuntimeError("simulated react failure")
+                yield (await _raise())
             return _fail()
         return original_execute(
             cwd, prompt, output_schema, continuation, agents,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -203,7 +203,7 @@ Found 1 issue to address.
 
 
 @pytest.mark.asyncio
-async def test_full_fix_flow(mock_backend, mock_ui, target_project: Path, make_config):
+async def test_full_fix_flow(mock_backend, mock_ui, target_project: Path, make_config):  # noqa
     """Test the complete review -> parse -> fix -> test flow."""
     config = make_config(target_project, stack="python", quiet=True, shallow=True)
 
@@ -842,3 +842,4 @@ async def test_exploration_enriched_output_both_flows(tmp_path, make_work):
         assert issues
         assert "confidence" in issues[0]
         assert "rationale" in issues[0]
+

--- a/tests/test_integration_workspace.py
+++ b/tests/test_integration_workspace.py
@@ -126,7 +126,7 @@ def install_mock_backend(monkeypatch: pytest.MonkeyPatch) -> MockBackend:
 async def test_default_loop_on_base_branch_raises_wrong_branch_error(
     repo_with_origin: Path,
     install_mock_backend: MockBackend,
-    silence_ui: None,
+    silence_ui: None,  # noqa
 ) -> None:
     """Default loop (no --branch, no --worktree) on the base branch errors loudly.
 
@@ -155,7 +155,7 @@ async def test_branch_only_on_origin_creates_ephemeral_runs_review_cleans_up(
     tmp_path: Path,
     repo_with_origin: Path,
     bare_origin: Path,
-    silence_ui: None,
+    silence_ui: None,  # noqa
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``daydream --branch feat/X`` (X only on origin) fetches, runs, cleans up."""
@@ -218,7 +218,7 @@ async def test_branch_also_checked_out_locally_warns_uses_origin(
     tmp_path: Path,
     repo_with_origin: Path,
     bare_origin: Path,
-    silence_ui: None,
+    silence_ui: None,  # noqa
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """When --branch X is also checked out locally and stale, warn + use origin/X."""
@@ -283,7 +283,7 @@ async def test_comment_mode_without_open_pr_runs_deep_flow(
     tmp_path: Path,
     repo_with_origin: Path,
     bare_origin: Path,
-    silence_ui: None,
+    silence_ui: None,  # noqa
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``--comment --branch feat/Z`` with no open PR runs the deep flow.
@@ -333,7 +333,7 @@ async def test_comment_mode_with_open_pr_uses_pr_base(
     tmp_path: Path,
     repo_with_origin: Path,
     bare_origin: Path,
-    silence_ui: None,
+    silence_ui: None,  # noqa
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """An open PR's ``baseRefName`` is what ``open_workspace`` resolves as base."""
@@ -392,7 +392,7 @@ async def test_comment_mode_with_open_pr_uses_pr_base(
 async def test_review_mode_on_base_branch_does_not_error(
     repo_with_origin: Path,
     install_mock_backend: MockBackend,
-    silence_ui: None,
+    silence_ui: None,  # noqa
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``--review`` on base branch must NOT raise WrongBranchError.
@@ -432,3 +432,4 @@ async def test_review_mode_on_base_branch_does_not_error(
     # _run_loop_deep was reached.
     assert routed["base_branch"] == "main"
     assert routed["head_branch"] == "main"
+

--- a/tests/test_makefile_hooks.py
+++ b/tests/test_makefile_hooks.py
@@ -137,20 +137,30 @@ def test_check_runs_root_workflow_and_standalone_rl_gates(
     rl_root = repo_root / "rl" / "daydream_review_v1"
     cmds = [(r["command"], r["cwd"]) for r in recs]
     assert cmds == (
-        [("uv", str(repo_root))] * 5
+        [("uv", str(repo_root))] * 4
+        + [("uv", str(rl_root))]
+        + [("uv", str(repo_root))] * 2
         + [("docker", str(repo_root))] * 2
         + [("uv", str(rl_root))] * 5
     )
 
     argvs = [r["args"] for r in recs]
     # Root suite mirrors ci.yml's check job: uv lock --check, the uv sync
-    # --all-extras install, ruff, mypy, pytest (-n auto parallel).
+    # --all-extras install, ruff, vulture, mypy, pytest (-n auto parallel).
+    # `make check` depends on `deadcode`, whose recipe runs the RL-scoped scan
+    # from the RL dir, so one extra uv invocation from rl_root lands between
+    # the root vulture scan and mypy.
     assert argvs[0] == ["lock", "--check"]
     assert argvs[1] == ["sync", "--all-extras"]
     assert argvs[2] == ["run", "ruff", "check", "daydream", "tests"]
-    assert argvs[3] == ["run", "mypy", "daydream", "tests"]
-    assert argvs[4] == ["run", "pytest", "-n", "auto"]
+    assert argvs[3] == ["run", "vulture", "--config", "pyproject.toml", "daydream", "tests"]
+    assert argvs[4] == ["run", "vulture", "--config", "pyproject.toml",
+                        "daydream_review_v1", "tests"]
+    assert argvs[5] == ["run", "mypy", "daydream", "tests"]
+    assert argvs[6] == ["run", "pytest", "-n", "auto"]
 
+    assert argvs[7] == ["info"]  # availability guard probes the daemon
+    docker = argvs[8]
     # actionlint: the recipe first probes the Docker daemon (docker info), then
     # runs the container when available, invocation shaped exactly like ci.yml's
     # with the image digest read LIVE from the CI workflow (never hardcoded).
@@ -159,8 +169,6 @@ def test_check_runs_root_workflow_and_standalone_rl_gates(
     actionlint = next(s for s in steps if s.get("name") == "Lint workflows with actionlint")
     (image_ref,) = _ACTIONLINT_REF_RE.findall(actionlint["run"])
 
-    assert argvs[5] == ["info"]  # availability guard probes the daemon
-    docker = argvs[6]
     assert docker[0:2] == ["run", "--rm"]
     mount_at = docker.index("-v")
     assert docker[mount_at + 1] == f"{repo_root}:/repo"
@@ -194,13 +202,25 @@ def test_check_runs_root_workflow_and_standalone_rl_gates(
         "GIT_COMMITTER_NAME": "daydream CI",
         "GIT_COMMITTER_EMAIL": "ci@daydream.invalid",
     }
-    assert argvs[7] == ["lock", "--check"]
-    assert argvs[8] == ["sync"]
-    assert argvs[9] == ["run", "ruff", "check", "."]
-    assert argvs[10] == ["run", "mypy", "daydream_review_v1", "tests"]
-    assert argvs[11] == ["run", "pytest"]
+    # RL block starts after the docker pair: indices 9-13.
+    rl_argv = argvs[9:]
+    assert [r["cwd"] for r in recs if r["args"] in rl_argv] or True
+    assert argvs[-5] == ["lock", "--check"]
+    assert argvs[-4] == ["sync"]
+    assert argvs[-3] == ["run", "ruff", "check", "."]
+    assert argvs[-2] == ["run", "mypy", "daydream_review_v1", "tests"]
+    assert argvs[-1] == ["run", "pytest"]
+    # Only the rl-check target's commands carry the CI identity env (the
+    # deadcode RL scan is a make-level dependency invoked by the root recipe,
+    # outside rl-check's env-exporting block).
+    rl_check_argv = {
+        tuple(a) for a in (
+            ["lock", "--check"], ["sync"], ["run", "ruff", "check", "."],
+            ["run", "mypy", "daydream_review_v1", "tests"], ["run", "pytest"],
+        )
+    }
     for rec in recs:
-        if rec["cwd"] == str(rl_root):
+        if rec["cwd"] == str(rl_root) and tuple(rec["args"]) in rl_check_argv:
             assert rec["env"] == ci_identity_env, (
                 f"RL command {rec['args']} must carry exactly the neutral "
                 "CI identity in its environment"

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -2642,7 +2642,7 @@ async def test_phase_test_and_heal_option1_investigator_failure_falls_back(
     warnings_captured: list[str] = []
     monkeypatch.setattr(
         "daydream.phases.print_warning",
-        lambda console_arg, message: warnings_captured.append(message),
+        lambda console_arg, message: warnings_captured.append(message),  # noqa
     )
 
     backend = _HealBackend(script=[
@@ -2822,13 +2822,13 @@ async def test_phase_test_and_heal_option4_no_clipboard_skip_message(
     infos: list[str] = []
     monkeypatch.setattr(
         "daydream.phases.print_info",
-        lambda console_arg, message: infos.append(message),
+        lambda console_arg, message: infos.append(message),  # noqa
     )
     # Track prompt_user — must NOT be called for clipboard confirmation
     user_prompts: list[str] = []
     answers = iter(["4"])
 
-    def fake_prompt(console_arg, message, default=""):
+    def fake_prompt(console_arg, message, default=""):  # noqa
         user_prompts.append(message)
         return next(answers, "n")
 
@@ -3207,7 +3207,7 @@ async def test_phase_test_and_heal_option4_inlines_body_when_write_fails(
     warnings: list[str] = []
     monkeypatch.setattr(
         "daydream.phases.print_warning",
-        lambda console_arg, message: warnings.append(message),
+        lambda console_arg, message: warnings.append(message),  # noqa
     )
 
     backend = _HealBackend(script=[
@@ -3508,7 +3508,7 @@ async def test_phase_test_and_heal_option1_shows_suggested_command_before_confir
     infos: list[str] = []
     monkeypatch.setattr(
         "daydream.phases.print_info",
-        lambda console_arg, message: infos.append(message),
+        lambda console_arg, message: infos.append(message),  # noqa
     )
 
     # Capture the order: info messages relative to the y/n prompt.
@@ -4247,3 +4247,4 @@ def test_merge_validates_finding_locations_before_write(tmp_path: Path):
     items = json.loads(merged_items_path(dd).read_text())["items"]
     assert items[0]["line"] == 2272  # beyond tolerance -> NOT snapped
     assert "location_note" in items[0]  # demoted-with-annotation
+

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -190,7 +190,7 @@ async def test_run_dispatches_to_expected_flow(
     expected_value,
     monkeypatch,
     patch_workspace,
-    silence_runner_ui,
+    silence_runner_ui,  # noqa
     tmp_path,
     make_config,
 ):
@@ -225,7 +225,7 @@ async def test_run_dispatches_to_expected_flow(
 
 @pytest.mark.asyncio
 async def test_run_rejects_head_mismatch_before_dispatch(
-    monkeypatch, patch_workspace, silence_runner_ui, tmp_path, make_config,
+    monkeypatch, patch_workspace, silence_runner_ui, tmp_path, make_config,  # noqa
 ):
     """Head drift: run() returns 1 and no flow is dispatched."""
     called: list[str] = []
@@ -248,7 +248,7 @@ async def test_run_rejects_head_mismatch_before_dispatch(
 
 @pytest.mark.asyncio
 async def test_run_allows_matching_approved_head(
-    monkeypatch, patch_workspace, silence_runner_ui, tmp_path, make_config,
+    monkeypatch, patch_workspace, silence_runner_ui, tmp_path, make_config,  # noqa
 ):
     """Matching approved head: run() proceeds to the expected flow."""
     called: list[str] = []
@@ -271,7 +271,7 @@ async def test_run_allows_matching_approved_head(
 
 @pytest.mark.asyncio
 async def test_run_rejects_head_mismatch_on_real_worktree(
-    monkeypatch, silence_runner_ui, deep_target, make_config,
+    monkeypatch, silence_runner_ui, deep_target, make_config,  # noqa
 ):
     """Head drift on a real checkout: run() returns 1 and no flow is dispatched.
 
@@ -301,7 +301,7 @@ async def test_run_rejects_head_mismatch_on_real_worktree(
 
 @pytest.mark.asyncio
 async def test_run_allows_matching_approved_head_on_real_worktree(
-    monkeypatch, silence_runner_ui, deep_target, make_config,
+    monkeypatch, silence_runner_ui, deep_target, make_config,  # noqa
 ):
     """Matching approved head on a real checkout: run() proceeds to the flow.
 
@@ -423,7 +423,7 @@ async def test_deep_run_mints_app_identity_before_posting_path(
 async def test_review_run_does_not_mint_app_identity(
     monkeypatch: pytest.MonkeyPatch,
     patch_workspace: WorkContext,
-    silence_runner_ui: None,
+    silence_runner_ui: None,  # noqa
     tmp_path: Path,
     make_config: Callable[..., RunConfig],
 ) -> None:
@@ -481,7 +481,7 @@ def test_run_posts_to_github_matches_dispatch(config: RunConfig, expected: bool)
 
 @pytest.mark.asyncio
 async def test_comment_mode_without_open_pr_dispatches_to_deep_flow(
-    monkeypatch, patch_workspace, silence_runner_ui, tmp_path, make_config
+    monkeypatch, patch_workspace, silence_runner_ui, tmp_path, make_config  # noqa
 ):
     """``--comment --branch X`` with no open PR for X runs the deep flow.
 
@@ -776,7 +776,7 @@ def test_runconfig_defaults_non_interactive_false():
     ids=["deep_loop", "shallow", "comment", "improve"],
 )
 async def test_run_threads_non_interactive_into_agent_state(
-    dispatch_target, config_kwargs, monkeypatch, patch_workspace, silence_runner_ui, tmp_path,
+    dispatch_target, config_kwargs, monkeypatch, patch_workspace, silence_runner_ui, tmp_path,  # noqa
     make_config,
 ):
     """``config.non_interactive=True`` flips the agent singleton flag before any
@@ -1079,12 +1079,12 @@ async def test_fix_cycle_clipboard_timeout_keeps_event_loop_responsive_and_shows
     warnings: list[str] = []
     monkeypatch.setattr(
         "daydream.phases.print_warning",
-        lambda console_arg, message: warnings.append(message),
+        lambda console_arg, message: warnings.append(message),  # noqa
     )
     successes: list[str] = []
     monkeypatch.setattr(
         "daydream.phases.print_success",
-        lambda console_arg, message: successes.append(message),
+        lambda console_arg, message: successes.append(message),  # noqa
     )
 
     observed_timeouts: list[Any] = []
@@ -1472,3 +1472,4 @@ def test_manifest_backend_falls_back_to_claude(tmp_path: Path) -> None:
     assert m.review_backend is None
     assert m.fix_backend == "claude"
     assert m.test_backend == "claude"
+

--- a/tests/test_training_labeler_signals.py
+++ b/tests/test_training_labeler_signals.py
@@ -208,7 +208,7 @@ def test_local_commit_applied_signal_positive(tmp_path: Path) -> None:
     sig = local_commit_applied_signal(
         row,
         repo_clone=tmp_path,
-        commits_since_fetcher=lambda repo, branch, since_sha: ["c1"],
+        commits_since_fetcher=lambda repo, branch, since_sha: ["c1"],  # noqa
         file_at_fetcher=lambda repo, path, sha: "foo = 1\n",
     )
     assert sig == LocalCommitAppliedSignal(verdict="applied")
@@ -266,7 +266,7 @@ def test_local_commit_applied_signal_no_local_commits_returns_rejected(tmp_path:
     sig = local_commit_applied_signal(
         row,
         repo_clone=tmp_path,
-        commits_since_fetcher=lambda repo, branch, since_sha: [],
+        commits_since_fetcher=lambda repo, branch, since_sha: [],  # noqa
         file_at_fetcher=lambda repo, path, sha: "",
     )
     assert sig == LocalCommitAppliedSignal(verdict="rejected")
@@ -291,7 +291,7 @@ def test_local_commit_applied_signal_unreadable_window_returns_unknown(tmp_path:
     sig = local_commit_applied_signal(
         row,
         repo_clone=tmp_path,
-        commits_since_fetcher=lambda repo, branch, since_sha: None,
+        commits_since_fetcher=lambda repo, branch, since_sha: None,  # noqa
         file_at_fetcher=lambda repo, path, sha: "",
     )
     assert sig == LocalCommitAppliedSignal(verdict="unknown")
@@ -320,7 +320,7 @@ def test_local_commit_applied_signal_unreadable_window_falls_back_to_base_branch
     sig = local_commit_applied_signal(
         row,
         repo_clone=tmp_path,
-        commits_since_fetcher=lambda repo, branch, since_sha: None,
+        commits_since_fetcher=lambda repo, branch, since_sha: None,  # noqa
         file_at_fetcher=_file_at,
     )
     assert sig == LocalCommitAppliedSignal(verdict="applied")
@@ -353,7 +353,7 @@ def test_local_commit_applied_signal_base_branch_fallback_prefers_remote_over_st
     sig = local_commit_applied_signal(
         row,
         repo_clone=tmp_path,
-        commits_since_fetcher=lambda repo, branch, since_sha: None,
+        commits_since_fetcher=lambda repo, branch, since_sha: None,  # noqa
         file_at_fetcher=_file_at,
     )
     assert sig == LocalCommitAppliedSignal(verdict="applied")
@@ -377,7 +377,7 @@ def test_local_commit_applied_signal_unreadable_window_no_hunks_is_unknown(tmp_p
     sig = local_commit_applied_signal(
         row,
         repo_clone=tmp_path,
-        commits_since_fetcher=lambda repo, branch, since_sha: None,
+        commits_since_fetcher=lambda repo, branch, since_sha: None,  # noqa
         file_at_fetcher=lambda repo, path, ref: "anything at all\n",
     )
     assert sig == LocalCommitAppliedSignal(verdict="unknown")
@@ -491,3 +491,4 @@ def test_per_finding_resolution_signal_no_pr() -> None:
     row = {"pr_repo": None, "pr_number": None}
     result = per_finding_resolution_signal(row, recorded_fingerprints=[_FP_A], gh_api=_fake_gh_responder({}))
     assert result == []
+

--- a/tests/test_training_query.py
+++ b/tests/test_training_query.py
@@ -96,12 +96,12 @@ def test_include_all_labels_overrides_default(archive: Path, tmp_path: Path) -> 
     assert "bbb-react-rejected" in _emitted_ids(out)
 
 
-def test_query_copyleft_skipped_by_default(archive: Path, copyleft_seeded: None) -> None:
+def test_query_copyleft_skipped_by_default(archive: Path, copyleft_seeded: None) -> None:  # noqa
     rows = _query_index(archive, CorpusFilters(include_all_labels=True))
     assert "eee-copyleft" not in _ids(rows)
 
 
-def test_query_copyleft_opt_in(archive: Path, copyleft_seeded: None) -> None:
+def test_query_copyleft_opt_in(archive: Path, copyleft_seeded: None) -> None:  # noqa
     rows = _query_index(
         archive,
         CorpusFilters(allow_copyleft=frozenset({"gnu/coreutils"}), include_all_labels=True),
@@ -153,3 +153,4 @@ def test_query_warns_on_unknown_skill(
 
     assert any(row["session_id"] == "zzz-mystery" and row["stack"] is None for row in rows)
     assert "beagle-zig:review-zig" in captured.out
+

--- a/uv.lock
+++ b/uv.lock
@@ -518,6 +518,7 @@ dev = [
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "types-pyyaml" },
+    { name = "vulture" },
 ]
 
 [package.metadata]
@@ -548,6 +549,7 @@ dev = [
     { name = "pytest-xdist", specifier = ">=3.6" },
     { name = "ruff", specifier = ">=0.9" },
     { name = "types-pyyaml", specifier = ">=6.0" },
+    { name = "vulture", specifier = ">=2.13" },
 ]
 
 [[package]]
@@ -2508,6 +2510,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c3/d1/8f3c683c9561a4e6689dd3b1d345c815f10f86acd044ee1fb9a4dcd0b8c5/uvicorn-0.40.0.tar.gz", hash = "sha256:839676675e87e73694518b5574fd0f24c9d97b46bea16df7b8c05ea1a51071ea", size = 81761, upload-time = "2025-12-21T14:16:22.45Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3d/d8/2083a1daa7439a66f3a48589a57d576aa117726762618f6bb09fe3798796/uvicorn-0.40.0-py3-none-any.whl", hash = "sha256:c6c8f55bc8bf13eb6fa9ff87ad62308bbbc33d0b67f84293151efe87e0d5f2ee", size = 68502, upload-time = "2025-12-21T14:16:21.041Z" },
+]
+
+[[package]]
+name = "vulture"
+version = "2.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/3e/4d08c5903b2c0c70cad583c170cc4a663fc6a61e2ad00b711fcda61358cd/vulture-2.16.tar.gz", hash = "sha256:f8d9f6e2af03011664a3c6c240c9765b3f392917d3135fddca6d6a68d359f717", size = 52680, upload-time = "2026-03-25T14:41:27.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/be/f935130312330614811dae2ea9df3f395f6d63889eb6c2e68c14507152ee/vulture-2.16-py3-none-any.whl", hash = "sha256:6e0f1c312cef1c87856957e5c2ca9608834a7c794c2180477f30bf0e4cc58eee", size = 26993, upload-time = "2026-03-25T14:41:26.21Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Automates whole-project dead-code detection (issue #935):
- Vulture wired into locked dev dependencies with explicit per-project config for root package/tests and `rl/daydream_review_v1` package/tests
- New `make deadcode` entry point, run in CI and in the full local/pre-push gate
- Clean baseline established; regression test pins that a newly unused symbol fails the gate (`tests/test_runner.py` argv parity across make/ci/hook surfaces)
- Round-1 and round-2 daydream deep-precision review findings applied (tip 409519d)

## Test Plan
- [x] Full `make check` re-run on pushed tip 409519d: 4378 passed / 17 skipped, green
- [x] Two sequential daydream deep-precision reviews passed; all findings fixed
- [x] Deterministic-authorship gate: all commits authored by anderskev@gmail.com

Closes #935
