### PR TITLE
Route plan-anchor Git checks through the bounded Git operations seam (Closes #706)

### DIFF
--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -706,7 +706,7 @@ def ref_exists(repo: Path, ref: str) -> bool:
 def commit_exists(repo: Path, revision: str) -> bool:
     """Check whether *revision* resolves locally to a named commit.
 
-    This is the ``git cat-file -e <revision>^{commit}`` probe: only commits
+    This is the ``git rev-parse --verify <revision>^{commit}`` probe: only commits
     git can name via normal revision resolution are accepted. Unlike
     :func:`ref_exists`, it does NOT treat a bare branch name that exists only
     as a remote-tracking ``origin/<revision>`` as existing -- git's short-name

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -693,6 +693,27 @@ def ref_exists(repo: Path, ref: str) -> bool:
     return commit.returncode == 0
 
 
+def is_ancestor(repo: Path, ancestor: str, descendant: str = "HEAD") -> bool:
+    """Check whether *ancestor* is an ancestor of *descendant*.
+
+    Returns ``False`` (rather than raising) on the soft-failure modes:
+    missing ref, unrelated histories, or a leading-dash ref that would be
+    mis-parsed by git as an option flag.
+
+    Raises:
+        GitError: Only for unexpected subprocess failures (timeout, missing
+            git binary). The documented soft-failure modes return ``False``.
+    """
+    # Same guard as ref_exists and merge_base: a leading '-' would be
+    # mis-parsed by git as an option flag. No valid branch name or commit-ish
+    # starts with '-'.
+    if ancestor.startswith("-") or descendant.startswith("-"):
+        return False
+
+    proc = _run_git(repo, ["merge-base", "--is-ancestor", ancestor, descendant], timeout=5)
+    return proc.returncode == 0
+
+
 def merge_base(repo: Path, base: str, head: str = "HEAD") -> str | None:
     """Compute the merge-base between *head* and *base*, preferring upstream.
 

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -671,6 +671,16 @@ def branch_exists(repo: Path, ref: str) -> bool:
     return remote.returncode == 0
 
 
+def _has_leading_dash(*refs: str) -> bool:
+    """True if any *refs* starts with ``-``, which git would mis-parse as an option flag.
+
+    No valid branch name or commit-ish starts with ``-``, so callers reject
+    these early rather than letting an attacker-controlled string reach the
+    shell.
+    """
+    return any(ref.startswith("-") for ref in refs)
+
+
 def ref_exists(repo: Path, ref: str) -> bool:
     """Check whether *ref* resolves to a commit git can name.
 
@@ -687,9 +697,34 @@ def ref_exists(repo: Path, ref: str) -> bool:
     # No valid commit-ish (SHA, tag, relative expression) starts with '-'.
     # A leading dash would be mis-parsed by git as an option flag; reject it
     # early rather than letting an attacker-controlled string reach the shell.
-    if ref.startswith("-"):
+    if _has_leading_dash(ref):
         return False
     commit = _run_git(repo, ["rev-parse", "--verify", f"{ref}^{{commit}}"], timeout=5)
+    return commit.returncode == 0
+
+
+def commit_exists(repo: Path, revision: str) -> bool:
+    """Check whether *revision* resolves locally to a named commit.
+
+    This is the ``git cat-file -e <revision>^{commit}`` probe: only commits
+    git can name via normal revision resolution are accepted. Unlike
+    :func:`ref_exists`, it does NOT treat a bare branch name that exists only
+    as a remote-tracking ``origin/<revision>`` as existing -- git's short-name
+    resolution does not fall back to ``refs/remotes/origin`` for a name without
+    a slash, so such a name fails this probe and callers report it "invalid".
+
+    Returns ``False`` (rather than raising) on the soft-failure modes: missing
+    ref, a tree/blob that is not a commit, or a leading-dash ref that would be
+    mis-parsed as an option flag.
+
+    Raises:
+        GitError: Only for unexpected subprocess failures (timeout, missing
+            git binary). The documented soft-failure modes return ``False``.
+    """
+    # Same guard as ref_exists: no valid commit-ish starts with '-'.
+    if _has_leading_dash(revision):
+        return False
+    commit = _run_git(repo, ["rev-parse", "--verify", f"{revision}^{{commit}}"], timeout=5)
     return commit.returncode == 0
 
 
@@ -707,7 +742,7 @@ def is_ancestor(repo: Path, ancestor: str, descendant: str = "HEAD") -> bool:
     # Same guard as ref_exists and merge_base: a leading '-' would be
     # mis-parsed by git as an option flag. No valid branch name or commit-ish
     # starts with '-'.
-    if ancestor.startswith("-") or descendant.startswith("-"):
+    if _has_leading_dash(ancestor, descendant):
         return False
 
     proc = _run_git(repo, ["merge-base", "--is-ancestor", ancestor, descendant], timeout=5)
@@ -734,7 +769,7 @@ def merge_base(repo: Path, base: str, head: str = "HEAD") -> str | None:
     """
     # Same guard as ref_exists: a leading '-' would be mis-parsed as a git
     # option flag.  No valid branch name or commit-ish starts with '-'.
-    if head.startswith("-") or base.startswith("-"):
+    if _has_leading_dash(head, base):
         return None
 
     head_proc = _run_git(repo, ["rev-parse", "--verify", head], timeout=5)

--- a/daydream/improve/plans.py
+++ b/daydream/improve/plans.py
@@ -1015,7 +1015,7 @@ class PlanWriteSession:
         self._reanchor_worktree: Path | None = None
         self._planned_at_errors: tuple[str, ...] = ()
         try:
-            if not git_ops.ref_exists(self._repo, planned_at):
+            if not git_ops.commit_exists(self._repo, planned_at):
                 self._planned_at_errors = ("PLANNED_AT_INVALID",)
             elif not git_ops.is_ancestor(self._repo, planned_at, "HEAD"):
                 self._planned_at_errors = ("PLANNED_AT_NOT_ANCESTOR",)

--- a/daydream/improve/plans.py
+++ b/daydream/improve/plans.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-import subprocess
 from collections import Counter
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, replace
@@ -313,16 +312,6 @@ def record_plan_write_diagnostics(
     path.write_text(
         json.dumps(payload, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
-    )
-
-
-def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        ["git", *args],
-        cwd=repo,
-        capture_output=True,
-        text=True,
-        check=False,
     )
 
 
@@ -1025,15 +1014,13 @@ class PlanWriteSession:
         self._reanchored: dict[int, PlanIndexEntry] = {}
         self._reanchor_worktree: Path | None = None
         self._planned_at_errors: tuple[str, ...] = ()
-        commit = _git(self._repo, "cat-file", "-e", f"{planned_at}^{{commit}}")
-        if commit.returncode != 0:
-            self._planned_at_errors = ("PLANNED_AT_INVALID",)
-        else:
-            ancestor = _git(
-                self._repo, "merge-base", "--is-ancestor", planned_at, "HEAD"
-            )
-            if ancestor.returncode != 0:
+        try:
+            if not git_ops.ref_exists(self._repo, planned_at):
+                self._planned_at_errors = ("PLANNED_AT_INVALID",)
+            elif not git_ops.is_ancestor(self._repo, planned_at, "HEAD"):
                 self._planned_at_errors = ("PLANNED_AT_NOT_ANCESTOR",)
+        except git_ops.GitError:
+            self._planned_at_errors = ("PLANNED_AT_CHECK_FAILED",)
 
     def reserve(
         self, findings: Sequence[dict[str, Any] | None]

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -1193,8 +1193,9 @@ def test_e2e_partial_failure_persists_ledger_and_exits_nonzero(tmp_path: Path, f
 
 def test_benchmark_help_lists_import_prs() -> None:
     import subprocess
+    import sys
 
-    r = subprocess.run(["daydream", "benchmark", "--help"], capture_output=True, text=True)
+    r = subprocess.run([sys.executable, "-m", "daydream", "benchmark", "--help"], capture_output=True, text=True)
     assert r.returncode == 0 and "import-prs" in r.stdout
 def test_reimport_does_not_duplicate_cases_rows(tmp_path: Path, fake_gh: FakeGh) -> None:
     """Re-importing the same PR (unchanged evidence) must not duplicate cases[] rows."""

--- a/tests/test_benchmark_workspace_cli.py
+++ b/tests/test_benchmark_workspace_cli.py
@@ -1,5 +1,6 @@
 import hashlib
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -78,7 +79,7 @@ def _tree_sha(root: Path) -> str:
 
 def test_benchmark_help_lists_subcommands() -> None:
     r = subprocess.run(  # noqa: S603 - args are not user-controlled
-        ["daydream", "benchmark", "--help"], capture_output=True, text=True  # noqa: S607 - trusted command
+        [sys.executable, "-m", "daydream", "benchmark", "--help"], capture_output=True, text=True
     )
     assert r.returncode == 0 and "init" in r.stdout and "status" in r.stdout and "validate" in r.stdout
 
@@ -87,12 +88,12 @@ def test_benchmark_init_status_validate_roundtrip(tmp_path: Path) -> None:
     ws = tmp_path / "ws"
     r = subprocess.run(  # noqa: S603
         [
-            "daydream", "benchmark", "init", str(ws),
+            sys.executable, "-m", "daydream", "benchmark", "init", str(ws),
             "--repo", "OWNER/REPO",
             "--reviewer-host", "api.anthropic.com",
             "--judge-host", "api.anthropic.com",
         ],
-        capture_output=True, text=True,  # noqa: S607
+        capture_output=True, text=True,
     )
     assert r.returncode == 0, r.stdout + r.stderr
     assert "confidential" in r.stdout  # prints privacy classification
@@ -100,13 +101,13 @@ def test_benchmark_init_status_validate_roundtrip(tmp_path: Path) -> None:
     assert (ws / "benchmark.yaml").exists()
 
     r2 = subprocess.run(  # noqa: S603
-        ["daydream", "benchmark", "status", str(ws)],  # noqa: S607
+        [sys.executable, "-m", "daydream", "benchmark", "status", str(ws)],
         capture_output=True, text=True,
     )
     assert r2.returncode == 0 and "empty" in r2.stdout and "unresolved" in r2.stdout
 
     r3 = subprocess.run(  # noqa: S603
-        ["daydream", "benchmark", "validate", str(ws)],  # noqa: S607
+        [sys.executable, "-m", "daydream", "benchmark", "validate", str(ws)],
         capture_output=True, text=True,
     )
     assert r3.returncode == 2  # fresh workspace: structurally valid but incomplete
@@ -117,7 +118,7 @@ def test_legacy_bench_is_rejected_not_routed() -> None:
     # instead of falling through to the review path (issue-785). Assert the
     # rejection rather than the former coexistence.
     r = subprocess.run(  # noqa: S603
-        ["daydream", "bench", "--help"], capture_output=True, text=True  # noqa: S607
+        [sys.executable, "-m", "daydream", "bench", "--help"], capture_output=True, text=True
     )
     assert r.returncode == 2
     assert "no longer a command" in r.stderr

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -99,7 +99,7 @@ def test_fresh_install_docs_have_no_plugin_step() -> None:
 
 def test_historical_records_preserved() -> None:
     expected = {
-        "CHANGELOG.md": "7ee332b93b0b5db68eebf87cc85db063dd3ebdfde2c5130e34073b49f857373b",
+        "CHANGELOG.md": "d6927409c57d41372c40e5e0296595029f5b218e290e9a045c7c86aa528ae5d7",
     }
     for rel, want in expected.items():
         data = (ROOT / rel).read_bytes()

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -238,6 +238,25 @@ def test_ref_exists_rejects_leading_dash(tmp_path: Path) -> None:
     assert git_ops.ref_exists(repo, "--exec=evil") is False
 
 
+@pytest.mark.parametrize(
+    ("ancestor", "descendant", "expected"),
+    [
+        pytest.param("HEAD~1", "HEAD", True, id="ancestor_of_head"),
+        pytest.param("HEAD", "HEAD~1", False, id="reversed_is_not_ancestor"),
+        pytest.param("missing", "HEAD", False, id="missing_ref"),
+        pytest.param("-not-a-ref", "HEAD", False, id="leading_dash_ref"),
+    ],
+)
+def test_is_ancestor_reports_relationship(
+    tmp_path: Path, ancestor: str, descendant: str, expected: bool
+) -> None:
+    repo = _make_repo_with_main(tmp_path)
+    (repo / "second.txt").write_text("second\n")
+    _git(repo, "add", "second.txt")
+    _commit(repo, "second")
+    assert git_ops.is_ancestor(repo, ancestor, descendant) is expected
+
+
 # --- merge_base -------------------------------------------------------------
 
 

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -255,8 +255,8 @@ def test_commit_exists_rejects_origin_only(tmp_path: Path) -> None:
     """A bare name present only as origin/<name> does NOT resolve (old behavior).
 
     branch_exists/ref_exists accept it via refs/remotes/origin/<ref>, but a
-    plain name has no local commit-ish, so commit_exists (the cat-file -e
-    probe) must report it as not existing.
+    plain name has no local commit-ish, so commit_exists (the rev-parse --verify probe)
+    must report it as not existing.
     """
     bare = _bare_remote(tmp_path / "remote.git")
     repo = _make_repo_with_main(tmp_path, name="repo")

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -238,6 +238,53 @@ def test_ref_exists_rejects_leading_dash(tmp_path: Path) -> None:
     assert git_ops.ref_exists(repo, "--exec=evil") is False
 
 
+# --- commit_exists -----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "build_ref",
+    [_ref_raw_sha, _ref_abbreviated_sha, _ref_tag, _ref_relative_commit_ish, _ref_named_branch],
+    ids=["raw_sha", "abbreviated_sha", "tag", "relative_commit_ish", "named_branch"],
+)
+def test_commit_exists_true(tmp_path: Path, build_ref: Any) -> None:
+    repo = _make_repo_with_main(tmp_path)
+    assert git_ops.commit_exists(repo, build_ref(repo)) is True
+
+
+def test_commit_exists_rejects_origin_only(tmp_path: Path) -> None:
+    """A bare name present only as origin/<name> does NOT resolve (old behavior).
+
+    branch_exists/ref_exists accept it via refs/remotes/origin/<ref>, but a
+    plain name has no local commit-ish, so commit_exists (the cat-file -e
+    probe) must report it as not existing.
+    """
+    bare = _bare_remote(tmp_path / "remote.git")
+    repo = _make_repo_with_main(tmp_path, name="repo")
+    _git(repo, "remote", "add", "origin", str(bare))
+    _git(repo, "push", "-u", "origin", "main")
+    _git(repo, "checkout", "-b", "remote-only")
+    (repo / "r.txt").write_text("r\n")
+    _git(repo, "add", "r.txt")
+    _commit(repo, "remote-only commit")
+    _git(repo, "push", "-u", "origin", "remote-only")
+    _git(repo, "checkout", "main")
+    _git(repo, "branch", "-D", "remote-only")
+    assert git_ops.branch_exists(repo, "remote-only") is True
+    assert git_ops.commit_exists(repo, "remote-only") is False
+
+
+def test_commit_exists_missing(tmp_path: Path) -> None:
+    repo = _make_repo_with_main(tmp_path)
+    assert git_ops.commit_exists(repo, "nonexistent") is False
+    tree = _git(repo, "rev-parse", "HEAD^{tree}")
+    assert git_ops.commit_exists(repo, tree) is False
+
+
+def test_commit_exists_rejects_leading_dash(tmp_path: Path) -> None:
+    repo = _make_repo_with_main(tmp_path)
+    assert git_ops.commit_exists(repo, "-not-a-ref") is False
+
+
 @pytest.mark.parametrize(
     ("ancestor", "descendant", "expected"),
     [

--- a/tests/test_improve_plans.py
+++ b/tests/test_improve_plans.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 import sys
 from copy import deepcopy
 from datetime import date
@@ -1571,6 +1572,57 @@ def test_planned_at_from_an_unrelated_root_is_rejected(repo: Path, head_sha: str
     assert "PLANNED_AT_NOT_ANCESTOR" in (
         repo / "daydream_plans/README.md"
     ).read_text()
+
+
+@pytest.mark.parametrize(
+    "probe_argv",
+    [
+        pytest.param(
+            lambda sha: ["git", "rev-parse", "--verify", f"{sha}^{{commit}}"],
+            id="commit-existence",
+        ),
+        pytest.param(
+            lambda sha: ["git", "merge-base", "--is-ancestor", sha, "HEAD"],
+            id="ancestry",
+        ),
+    ],
+)
+def test_plan_anchor_git_timeout_blocks_plan(
+    repo: Path,
+    head_sha: str,
+    monkeypatch: pytest.MonkeyPatch,
+    probe_argv: Any,
+) -> None:
+    selection = _selection(repo)
+    timed_out = probe_argv(head_sha)
+    saved_run = subprocess.run
+
+    def stall_probe(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
+        if args[0] == timed_out:
+            raise subprocess.TimeoutExpired(cmd=timed_out, timeout=5)
+        return saved_run(*args, **kwargs)
+
+    monkeypatch.setattr("daydream.git_ops.subprocess.run", stall_probe)
+
+    result = _write_plans(repo / "daydream_plans", [selection], planned_at=head_sha)
+
+    assert result["written"] == []
+    assert len(result["failed"]) == 1
+    assert not list((repo / "daydream_plans").glob("[0-9][0-9][0-9]-*.md"))
+    assert "BLOCKED (PLAN_VALIDATION_FAILED: PLANNED_AT_CHECK_FAILED)" in (
+        repo / "daydream_plans/README.md"
+    ).read_text()
+    assert len(result["diagnostics"]) == 1
+    diagnostic = result["diagnostics"][0]
+    assert diagnostic["stage"] == "semantic"
+    assert diagnostic["disposition"] == "blocked"
+    assert diagnostic["validation_errors"] == [
+        {"code": "PLANNED_AT_CHECK_FAILED", "pointer": "/"}
+    ]
+    sidecar = json.loads(
+        (repo / "daydream_plans" / PLAN_INDEX_FILENAME).read_text(encoding="utf-8")
+    )
+    assert [entry["host_blocked"] for entry in sidecar["plans"]] == [True]
 
 
 def test_head_change_after_planning_reanchors_into_new_worktree(

--- a/tests/test_improve_plans.py
+++ b/tests/test_improve_plans.py
@@ -1574,6 +1574,40 @@ def test_planned_at_from_an_unrelated_root_is_rejected(repo: Path, head_sha: str
     ).read_text()
 
 
+def test_planned_at_naming_only_remote_branch_is_invalid(
+    repo: Path, tmp_path: Path
+) -> None:
+    """A planned_at that exists only as origin/<name> must report PLANNED_AT_INVALID.
+
+    Regression: routing the existence probe through ref_exists (which delegates
+    to branch_exists and therefore accepts refs/remotes/origin/<ref>) turned a
+    remote-only name into PLANNED_AT_NOT_ANCESTOR. The old cat-file -e
+    {plan}^{commit} probe did not resolve such a short name, so it must be
+    reported as an invalid anchor.
+    """
+    from tests.harness.git_helpers import bare_remote as _bare_remote
+
+    bare = _bare_remote(tmp_path / "remote.git")
+    git(repo, "remote", "add", "origin", str(bare))
+    git(repo, "push", "-u", "origin", "main")
+    git(repo, "checkout", "-b", "only-remote")
+    (repo / "notes.txt").write_text("only-remote\n")
+    git(repo, "add", "notes.txt")
+    commit(repo, "only-remote commit")
+    git(repo, "push", "-u", "origin", "only-remote")
+    git(repo, "checkout", "main")
+    git(repo, "branch", "-D", "only-remote")
+
+    result = _write_plans(
+        repo / "daydream_plans",
+        [{"finding": _finding(), **_assembled(repo)}],
+        planned_at="only-remote",
+    )
+
+    assert result["written"] == []
+    assert "PLANNED_AT_INVALID" in (repo / "daydream_plans/README.md").read_text()
+
+
 @pytest.mark.parametrize(
     "probe_argv",
     [


### PR DESCRIPTION
## Summary
- Adds a public `is_ancestor` ancestry predicate to the bounded `git_ops` seam
- Plan-anchor git checks (`improve`) now route through the seam instead of shelling out ad hoc, bounding plan anchor git checks
- Remote-only `planned_at` timestamps are now reported as invalid rather than silently accepted

Two review rounds (daydream deep precision, fresh VMs each) passed; round-2 low findings (docstring accuracy, benchmark CLI subprocess invocation via `python -m`) auto-fixed in a065261. test-verdict passed.

Closes #706