### PR TITLE
fix(osprey): harden JSONL and thinking event streams

### DIFF
--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -628,6 +628,20 @@ async def run_agent(
             budget_reason: str | None = None
             # Track tool names by id for log mode output
             tool_names: dict[str, str] = {}
+            callback_text_parts: list[str] = []
+
+            async def _flush_callback_text() -> None:
+                """Render one line for a consecutive run of streamed text deltas."""
+                if progress_callback is None or not callback_text_parts:
+                    return
+                text = "".join(callback_text_parts)
+                callback_text_parts.clear()
+                last_line = text.strip().split("\n")[-1]
+                if last_line:
+                    result = progress_callback(format_callback_text(last_line))
+                    if inspect.isawaitable(result):
+                        await result
+
             # Created per attempt so a failed retry's UI panels and task-label
             # mappings cannot be flushed or reused by a later successful attempt.
             tool_registry = LiveToolPanelRegistry(console, _state.quiet_mode)
@@ -664,17 +678,16 @@ async def run_agent(
 
                     with wall_scope:
                         async for event in event_iter:
+                            if use_callback and not isinstance(event, TextEvent):
+                                await _flush_callback_text()
+
                             if isinstance(event, TextEvent):
                                 output_parts.append(event.text)
 
                                 if _state.log_mode:
                                     _print_log(event.text)
                                 elif use_callback and progress_callback is not None:
-                                    last_line = event.text.strip().split("\n")[-1]
-                                    if last_line:
-                                        result = progress_callback(format_callback_text(last_line))
-                                        if inspect.isawaitable(result):
-                                            await result
+                                    callback_text_parts.append(event.text)
                                 elif output_schema is None:
                                     # Structured-output text is the JSON payload, redundant with
                                     # the returned structured result — don't echo it to the terminal.
@@ -824,6 +837,9 @@ async def run_agent(
                                 if inv is not None:
                                     inv.observe(event)
 
+                        if use_callback:
+                            await _flush_callback_text()
+
                     # Abort handling: the wall scope cancelled the loop, a quantitative
                     # tool ceiling fired, or a supervisor veto broke out. Mark the
                     # ATIF turn aborted and let the invocation's event-stream scope
@@ -857,6 +873,8 @@ async def run_agent(
             except _ToolSupervisorFailure:
                 raise
             except Exception as exc:
+                if use_callback:
+                    await _flush_callback_text()
                 exception_max_retries = min(
                     max_attempts, getattr(exc, "max_retries", max_attempts)
                 )

--- a/daydream/backends/__init__.py
+++ b/daydream/backends/__init__.py
@@ -125,7 +125,7 @@ class CostEvent:
         model_name: Real SDK model id observed during this call (e.g.
             ``claude-opus-4-5-20250901``). ``None`` when unavailable; the
             recorder uses it to upgrade a generic backend label
-            (``"claude"``, ``"codex"``) to the actual model id.
+            (``"claude"``, ``"codex"``, ``"osprey"``) to the actual model id.
         timestamp: ISO 8601 UTC timestamp populated at backend yield time.
     """
 
@@ -178,7 +178,7 @@ class MetricsEvent:
         model_name: Real SDK model id observed for this turn (e.g.
             ``claude-opus-4-5-20250901``). ``None`` when unavailable;
             recorder uses it to upgrade a generic backend label
-            (``"claude"``, ``"codex"``) to the actual model id.
+            (``"claude"``, ``"codex"``, ``"osprey"``) to the actual model id.
         timestamp: ISO 8601 UTC timestamp populated at backend yield time.
     """
 
@@ -234,12 +234,19 @@ class ResultEvent:
             True), or None. Callers that pass
             ``validate_structured_output=False`` re-validate downstream.
         continuation: Optional continuation token for multi-turn flows.
+        model_name: Real SDK model id observed for this invocation. Backends
+            should populate this when the model is only available from a
+            session-level terminal event rather than per-turn usage.
         timestamp: ISO 8601 UTC timestamp populated at backend yield time.
     """
 
     structured_output: Any | None
     continuation: ContinuationToken | None
     timestamp: str = field(default_factory=now_iso)
+    # Keep this after timestamp so existing three-positional-argument
+    # ResultEvent callers continue to interpret their third argument as the
+    # timestamp.
+    model_name: str | None = None
 
 
 AgentEvent = (

--- a/daydream/backends/osprey.py
+++ b/daydream/backends/osprey.py
@@ -19,6 +19,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+import anyio
+
 from daydream.backends import (
     AgentEvent,
     ContinuationToken,
@@ -177,6 +179,14 @@ def _bounded_diagnostics(lines: Iterable[str]) -> str:
     if not cleaned:
         return "no diagnostic output captured"
     return "\n".join(cleaned)
+
+
+async def _drain_stderr(stderr: asyncio.StreamReader, diagnostics: list[str]) -> None:
+    """Drain Osprey diagnostics without allowing its stderr pipe to fill."""
+    while line := await stderr.readline():
+        raw = line.decode(errors="replace").strip()
+        if raw and len(diagnostics) < _MAX_DIAGNOSTIC_LINES:
+            diagnostics.append(raw)
 
 
 @dataclass(frozen=True)
@@ -515,7 +525,8 @@ class OspreyBackend:
         turn_durations_ms: list[int] = []
         total_cost: float | None = None
         saw_metric_cost = False
-        non_json_lines: list[str] = []
+        stderr_lines: list[str] = []
+        stderr_task: asyncio.Task[None] | None = None
         terminal_outcome: str | None = None
         terminal_exit_code: int | None = None
         terminal_structured_output: Any = None
@@ -539,12 +550,15 @@ class OspreyBackend:
                 cwd=str(cwd),
                 stdin=asyncio.subprocess.DEVNULL,
                 stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.STDOUT,
+                stderr=asyncio.subprocess.PIPE,
                 limit=_OSPREY_STDOUT_LIMIT_BYTES,
                 env=child_env,
                 start_new_session=True,
             )
             self._processes.append(proc)
+            if proc.stderr is None:
+                raise OspreyError("Osprey stderr pipe is unavailable", category="PROCESS_START")
+            stderr_task = asyncio.create_task(_drain_stderr(proc.stderr, stderr_lines))
             while True:
                 if proc.stdout is None:
                     break
@@ -559,11 +573,9 @@ class OspreyBackend:
                 try:
                     event = json.loads(raw)
                 except json.JSONDecodeError as exc:
-                    if len(non_json_lines) < _MAX_DIAGNOSTIC_LINES:
-                        non_json_lines.append(raw)
                     raise OspreyProtocolError(
                         "Osprey emitted a non-JSON line in JSONL mode: "
-                        f"{_bounded_diagnostics(non_json_lines)}"
+                        f"{_bounded_diagnostics([raw])}"
                     ) from exc
                 if not isinstance(event, dict):
                     raise OspreyProtocolError("Osprey JSONL event must be an object")
@@ -719,10 +731,15 @@ class OspreyBackend:
                     raise OspreyProtocolError(f"unknown Osprey JSONL event {event_name!r}")
 
             await proc.wait()
+            # A descendant can outlive Osprey while retaining the inherited
+            # stderr fd. Reap the process group and close its transports before
+            # awaiting EOF so the diagnostic drain cannot hang indefinitely.
+            await terminate_process(proc)
+            await stderr_task
             returncode = proc.returncode
             if returncode not in (None, 0):
                 raise OspreyError(
-                    f"Osprey CLI exited with return code {returncode}: {_bounded_diagnostics(non_json_lines)}",
+                    f"Osprey CLI exited with return code {returncode}: {_bounded_diagnostics(stderr_lines)}",
                     category="PROCESS_EXIT",
                 )
             if not saw_header:
@@ -764,8 +781,13 @@ class OspreyBackend:
                 ),
             )
         finally:
-            if proc is not None:
-                await terminate_process(proc)
+            with anyio.CancelScope(shield=True):
+                if proc is not None:
+                    await terminate_process(proc)
+                if stderr_task is not None:
+                    if not stderr_task.done():
+                        stderr_task.cancel()
+                    await asyncio.gather(stderr_task, return_exceptions=True)
             self._processes = [active for active in self._processes if active is not proc]
             if schema_path is not None:
                 Path(schema_path).unlink(missing_ok=True)

--- a/daydream/backends/osprey.py
+++ b/daydream/backends/osprey.py
@@ -298,7 +298,10 @@ class OspreyBackend:
             raise OspreyUnsupportedOption("tool_search_mode", f"invalid mode {tool_search_mode!r}")
 
         self._model_override = model
-        self.model = model or "osprey"
+        # Osprey may resolve an omitted model from its own config and model
+        # preference store. Until session_start reports that choice, the
+        # backend name is not a valid model identity.
+        self.model = model or "unknown"
         self.reasoning_effort = reasoning_effort
         self.osprey_binary = osprey_binary or os.environ.get("OSPREY_BINARY", "osprey")
         self.cwd = cwd
@@ -602,6 +605,10 @@ class OspreyBackend:
                     session_id = _required_string(event, "session_id")
                     _required_string(event, "started_at")
                     session_model = _required_string(event, "model")
+                    # ``self.model`` starts as a backend-only placeholder when
+                    # Osprey is allowed to resolve its own config. The session
+                    # header is the authoritative model identity for this run.
+                    self.model = session_model
                     provider = _required_string(event, "provider")
                     saw_session_start = True
                     continue
@@ -611,8 +618,10 @@ class OspreyBackend:
                     raise OspreyProtocolError("session_start did not provide a session_id")
 
                 if event_name != "thinking_delta" and thinking_parts:
-                    yield ThinkingEvent("".join(thinking_parts))
+                    thinking_text = "".join(thinking_parts)
                     thinking_parts.clear()
+                    if thinking_text.strip():
+                        yield ThinkingEvent(thinking_text)
 
                 if event_name == "session_end":
                     outcome = _required_string(event, "outcome")
@@ -784,6 +793,7 @@ class OspreyBackend:
                         "exit_code": terminal_exit_code,
                     },
                 ),
+                model_name=session_model,
             )
         finally:
             with anyio.CancelScope(shield=True):

--- a/daydream/backends/osprey.py
+++ b/daydream/backends/osprey.py
@@ -531,6 +531,7 @@ class OspreyBackend:
         terminal_exit_code: int | None = None
         terminal_structured_output: Any = None
         turn_text_emitted = False
+        thinking_parts: list[str] = []
         protocol_state = _OspreyProtocolState()
 
         try:
@@ -609,6 +610,10 @@ class OspreyBackend:
                 if session_id is None:
                     raise OspreyProtocolError("session_start did not provide a session_id")
 
+                if event_name != "thinking_delta" and thinking_parts:
+                    yield ThinkingEvent("".join(thinking_parts))
+                    thinking_parts.clear()
+
                 if event_name == "session_end":
                     outcome = _required_string(event, "outcome")
                     if "exit_code" not in event:
@@ -635,7 +640,7 @@ class OspreyBackend:
                     content = event.get("content")
                     if not isinstance(content, str):
                         raise OspreyProtocolError("thinking_delta requires string content")
-                    yield ThinkingEvent(content)
+                    thinking_parts.append(content)
                 elif event_name == "tool_call":
                     call_id = _required_string(event, "tool_call_id")
                     tool_name = _required_string(event, "tool_name")

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -1611,7 +1611,7 @@ async def _run_uncovered_sweep(ctx: FlowContext) -> None:
     # directly -- there is no `parse-uncovered-<n>` fork.
     parse_backend = ctx.backend_for("parse")
     limiter = anyio.CapacityLimiter(effective_fanout_concurrency(10, parse_backend))
-    review_outputs: dict[str, Path] = {}
+    completed_reviews: set[str] = set()
     sweep_failures: dict[str, str] = {}
     sweep_records_by_file: dict[str, list[dict[str, Any]]] = {}
 
@@ -1631,7 +1631,6 @@ async def _run_uncovered_sweep(ctx: FlowContext) -> None:
             async def _sweep_one(
                 file: str = file,
                 task_prompt: str = prompt,
-                task_output: Path = output_path,
                 n: int = n,
             ) -> None:
                 async with limiter:
@@ -1654,13 +1653,11 @@ async def _run_uncovered_sweep(ctx: FlowContext) -> None:
                             issues = structured.get("issues")
                             issues = issues if isinstance(issues, list) else []
                             sweep_records_by_file[file] = issues
-                            # A backend can return normally without writing its
-                            # output; only an actual review file counts as
-                            # coverage, so `completed_files` never sees phantom
-                            # outputs (the review.md is a byproduct of the stub;
-                            # structured records ARE the authoritative output).
-                            if task_output.is_file():
-                                review_outputs[file] = task_output
+                            # Structured records are the authoritative sweep
+                            # output. Markdown review files are optional backend
+                            # byproducts and cannot gate persistence. Coverage is
+                            # still computed independently from verified Reads.
+                            completed_reviews.add(file)
                     except Exception as exc:  # noqa: BLE001 -- parallel isolation; fail-open
                         sweep_failures[file] = f"{type(exc).__name__}: {exc}"
 
@@ -1685,7 +1682,7 @@ async def _run_uncovered_sweep(ctx: FlowContext) -> None:
             "files_read_by_reviewers": post_coverage["files_read_by_reviewers"],
             "coverage_ratio": post_coverage["coverage_ratio"],
         }
-        stats["covered_files"] = sorted(f for f in review_outputs if f not in post_uncovered)
+        stats["covered_files"] = sorted(f for f in completed_reviews if f not in post_uncovered)
     except Exception:  # noqa: BLE001 -- fail-open: keep the pre-sweep fallback
         pass
 
@@ -1700,7 +1697,7 @@ async def _run_uncovered_sweep(ctx: FlowContext) -> None:
     for file in sorted(sweep_records_by_file):
         sweep_records.extend(sweep_records_by_file[file])
     stats["sweep_failures"] = {**sweep_failures}
-    stats["completed_files"] = sorted(review_outputs)
+    stats["completed_files"] = sorted(completed_reviews)
     # Issue #309 finding 6: per-file attempt status. A completed review output
     # is a completed ATTEMPT; only files with a verified post-sweep completed
     # read are "read". Anything else is "reviewed (hunks only)" and must not
@@ -1708,9 +1705,9 @@ async def _run_uncovered_sweep(ctx: FlowContext) -> None:
     covered_set = set(stats.get("covered_files") or [])
     stats["sweep_attempt_status"] = {
         file: ("read" if file in covered_set else "reviewed (hunks only)")
-        for file in sorted(review_outputs)
+        for file in sorted(completed_reviews)
     }
-    if review_outputs:
+    if completed_reviews:
         records_path = per_stack_records_path(dd, "uncovered")
         records_path.write_text(json.dumps(sweep_records, indent=2))
         ctx.data["records_paths"].append(records_path)
@@ -1718,8 +1715,8 @@ async def _run_uncovered_sweep(ctx: FlowContext) -> None:
         ctx.data["record_sources"].extend("uncovered" for _ in sweep_records)
         stats["sweep_finding_count"] = len(sweep_records)
     else:
-        # No review produced output: on a re-run, write a current empty records
-        # artifact so a stale file from the resumed run cannot linger.
+        # No structured review produced output: on a re-run, write a current
+        # empty records artifact so a stale file cannot linger.
         if config.start_at == "per-stack":
             per_stack_records_path(dd, "uncovered").write_text(json.dumps([]))
     stats_p.write_text(json.dumps(stats, indent=2))

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -1061,7 +1061,6 @@ async def _step_exploration(ctx: FlowContext) -> None:
         else:
             print_phase_hero(console, "EXPLORE", phase_subtitle("EXPLORE"))
             explore_backend = ctx.backend_for("exploration")
-            print_dim(console, f"Exploration model: {explore_backend.model}")
             async with phase_scope(DaydreamPhase.EXPLORATION):
                 config.exploration_context = await safe_explore(
                     pre_scan,
@@ -1077,6 +1076,11 @@ async def _step_exploration(ctx: FlowContext) -> None:
                         "exploration.repository_survey": ctx.strategy("exploration.repository_survey"),
                     },
                 )
+            # Osprey resolves an omitted model from its own config and reports
+            # the authoritative value in session_start, during safe_explore.
+            # Log after that boundary so the backend name is never presented as
+            # the model id.
+            print_dim(console, f"Exploration model: {explore_backend.model}")
             console.print(render_exploration_summary(config.exploration_context))
         if config.exploration_context is not None:
             exploration_dir = config.exploration_context.write_to_dir(exploration_path)

--- a/daydream/pr_comment_renderer.py
+++ b/daydream/pr_comment_renderer.py
@@ -62,9 +62,12 @@ FALLBACK_NOTE = "*run details unavailable*"
 
 # Generic backend labels that pre-date a real SDK model id arriving on the
 # event stream. Defense-in-depth: trajectory.TrajectoryRecorder upgrades
-# these as soon as the first MetricsEvent / CostEvent surfaces a real id,
+# these as soon as a MetricsEvent, CostEvent, or ResultEvent surfaces a real
+# id,
 # so a generic label here means the run never observed a real model name.
-_GENERIC_MODEL_LABELS: frozenset[str] = frozenset({"claude", "codex", ""})
+_GENERIC_MODEL_LABELS: frozenset[str] = frozenset(
+    {"claude", "codex", "osprey", "unknown", ""}
+)
 
 
 def _parse_ts(ts: str) -> datetime:

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -59,10 +59,13 @@ _console = create_console()
 _INITIAL_TOTALS: dict[str, Any] = {"prompt": 0, "completion": 0, "cached": 0, "cost": 0.0, "any_cost_seen": False}  # noqa: E501 - module-level constant cloned via dict.copy() at recorder init
 
 # Generic backend labels that should be replaced as soon as a real SDK
-# model id arrives via MetricsEvent / CostEvent. Runner stamps the recorder
+# model id arrives via MetricsEvent, CostEvent, or ResultEvent. Runner stamps
+# the recorder
 # with one of these (or empty) at init since the real model id isn't known
 # until the first agent turn streams back.
-_GENERIC_MODEL_LABELS: frozenset[str] = frozenset({"claude", "codex", ""})
+_GENERIC_MODEL_LABELS: frozenset[str] = frozenset(
+    {"claude", "codex", "osprey", "unknown", ""}
+)
 
 
 def _reasoning_extra(reasoning_tokens: int | None) -> dict[str, Any] | None:
@@ -1219,6 +1222,19 @@ class Invocation:
             # concentration; issue #747).
             self._fold_cost_event(event)
         elif isinstance(event, ResultEvent):
+            if event.model_name:
+                if self._open_step_dict is not None:
+                    self._open_step_dict["_model_name"] = event.model_name
+                else:
+                    for index, step in enumerate(self.steps):
+                        if (
+                            step.source == "agent"
+                            and (step.model_name or "") in _GENERIC_MODEL_LABELS
+                        ):
+                            self.steps[index] = self.recorder.redactor.redact_step(
+                                step.model_copy(update={"model_name": event.model_name})
+                            )
+                self.recorder._upgrade_model_name(event.model_name)
             self._close_open_step()
         elif isinstance(event, TurnEndEvent):
             # Per-turn close: a TurnEndEvent arriving while no Step is open is
@@ -1753,15 +1769,27 @@ class TrajectoryRecorder:
     def _upgrade_model_name(self, candidate: str) -> None:
         """Promote *candidate* over a generic backend label.
 
-        Runner stamps the recorder with a generic alias (``"claude"`` /
-        ``"codex"``) or empty string at init since the real SDK model id is
-        only known after the first agent turn streams back. The first real
-        model id observed from MetricsEvent / CostEvent upgrades the
-        recorder's ``agent_model_name`` so the rendered Trajectory.agent
-        carries the real id rather than the alias.
+        Runner stamps the recorder with a generic alias (``"claude"``,
+        ``"codex"``, ``"osprey"``, ``"unknown"``) or empty string at init
+        since the real SDK model id is only known after the first agent turn
+        streams back. The first real model id observed from MetricsEvent /
+        CostEvent / ResultEvent
+        upgrades the recorder's ``agent_model_name`` so the rendered
+        Trajectory.agent carries the real id rather than the alias. Any
+        already-closed agent Steps carrying the same provisional label are
+        upgraded too; this matters when a backend emits its identity only in a
+        terminal ResultEvent after TurnEndEvent has closed the Step.
         """
         if candidate and (self.agent_model_name or "") in _GENERIC_MODEL_LABELS:
             self.agent_model_name = candidate
+            for index, step in enumerate(self.steps):
+                if (
+                    step.source == "agent"
+                    and (step.model_name or "") in _GENERIC_MODEL_LABELS
+                ):
+                    self.steps[index] = self.redactor.redact_step(
+                        step.model_copy(update={"model_name": candidate})
+                    )
 
     def _accumulate_metrics(
         self,

--- a/docs/backends/osprey.md
+++ b/docs/backends/osprey.md
@@ -57,10 +57,13 @@ are also explicit bounded backend failures.
 ## Identity and tool calls
 
 The successful `ResultEvent` continuation retains Osprey’s provider, model,
-session ID, terminal outcome, and exit code. Tool calls retain the producer’s
-underlying `tool_name` and `tool_call_id`, including MCP calls resolved through
-Tool Search. Daydream’s existing trajectory recorder continues to own the
-top-level run identity.
+session ID, terminal outcome, and exit code. The event’s `model_name` carries
+that same resolved session model into Daydream’s trajectory, including when
+Osprey did not report per-turn usage. The backend’s display model is
+`unknown` until `session_start` resolves an omitted model. Tool calls retain
+the producer’s underlying `tool_name` and `tool_call_id`, including MCP calls
+resolved through Tool Search. Daydream’s existing trajectory recorder
+continues to own the top-level run identity.
 
 Use this boundary rather than implementing another Python agent loop. Protocol
 drift requires an explicit Osprey JSONL version change and a corresponding

--- a/rl/daydream_review_v1/daydream_review_v1/harness.py
+++ b/rl/daydream_review_v1/daydream_review_v1/harness.py
@@ -32,6 +32,13 @@ from daydream_review_v1.taskset import DEFAULT_REPO_PATH, DaydreamReviewData
 
 logger = logging.getLogger(__name__)
 
+_ROLLOUT_GITHUB_ENV_TO_UNSET = (
+    "DAYDREAM_APP_ID",
+    "DAYDREAM_APP_PRIVATE_KEY",
+    "GH_TOKEN",
+    "GITHUB_TOKEN",
+)
+
 
 class DaydreamReviewHarnessConfig(vf.HarnessConfig):
     backend: str = "claude"
@@ -132,7 +139,18 @@ class DaydreamReviewHarness(vf.Harness[DaydreamReviewHarnessConfig]):
         # which would make every rollout a review-only rollout. --review is never
         # set: with --yes it is a parse error (cli.py:978-981). Deep is the default
         # flow, so there is no --deep to pass (runner.py:812).
+        #
+        # The subprocess runtime inherits non-API-key host variables. Explicitly
+        # remove GitHub credentials so a developer's App configuration cannot
+        # divert or abort the hermetic fixture rollout before its first model call.
+        github_env_unsets = [
+            argument
+            for name in _ROLLOUT_GITHUB_ENV_TO_UNSET
+            for argument in ("-u", name)
+        ]
         argv = [
+            "env",
+            *github_env_unsets,
             "daydream",
             "--non-interactive",
             "--yes",

--- a/rl/daydream_review_v1/tests/test_harness.py
+++ b/rl/daydream_review_v1/tests/test_harness.py
@@ -94,7 +94,7 @@ async def test_launch_passes_the_selected_backend_to_the_cli(
     await harness.launch(_ctx(), trace, runtime, ENDPOINT, SECRET, {})
 
     (argv, env), = runtime.programs
-    assert argv[0] == "daydream"
+    assert "daydream" in argv
     assert argv[argv.index("--backend") + 1] == backend
     assert argv[argv.index("--model") + 1] == MODEL
     assert argv[argv.index("--base") + 1] == task.data.base_sha
@@ -123,6 +123,30 @@ async def test_launch_carries_extra_args_before_the_target(
     (argv, _), = runtime.programs
     assert argv[argv.index("--reasoning-effort") + 1] == "high"
     assert argv.index("--reasoning-effort") < argv.index("/work/repo")
+
+
+async def test_launch_unsets_ambient_github_credentials(
+    corpus_mini_dir: Path, fixture_manifest_path: Path
+) -> None:
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    harness = DaydreamReviewHarness(DaydreamReviewHarnessConfig())
+    runtime = FakeRuntime(exit_code=0)
+
+    await harness.launch(_ctx(), _trace(task), runtime, ENDPOINT, SECRET, {})
+
+    (argv, _), = runtime.programs
+    assert argv[:10] == [
+        "env",
+        "-u",
+        "DAYDREAM_APP_ID",
+        "-u",
+        "DAYDREAM_APP_PRIVATE_KEY",
+        "-u",
+        "GH_TOKEN",
+        "-u",
+        "GITHUB_TOKEN",
+        "daydream",
+    ]
 
 
 async def test_launch_stops_the_trace_when_a_completed_run_exits_nonzero(
@@ -270,7 +294,8 @@ async def test_launch_uses_run_as_agent_wrapper_under_docker(
 
     (argv, _), = runtime.programs
     assert argv[0] == "run-as-agent"
-    assert argv[1] == "daydream"
+    assert argv[1] == "env"
+    assert "daydream" in argv
     assert argv[argv.index("--backend") + 1] == "claude"
 
     # Pin the terminal property of the seam by executing it: root must drop

--- a/tests/harness/stub_backend.py
+++ b/tests/harness/stub_backend.py
@@ -226,11 +226,16 @@ class StubBackend:
         # (instead of the default api.py), so stack-uncovered-records.json names
         # the swept file.
         self.sweep_file: str | None = None
-        # When True, the uncovered-file-sweep branch returns success WITHOUT
-        # writing the review output file -- a backend can return normally while
-        # producing nothing (issue #309 finding 7). A successful return must
-        # NOT be recorded as completed coverage.
+        # When True, the uncovered-file-sweep branch returns success without
+        # either structured output or a review file -- a backend can return
+        # normally while producing nothing (issue #309 finding 7). A successful
+        # return must NOT be recorded as completed coverage.
         self.sweep_no_output: bool = False
+        # When True, the sweep still returns valid structured output but omits
+        # the legacy Markdown review sidecar. Real structured-output backends
+        # can behave this way; the host-owned records artifact remains the
+        # authoritative finding source.
+        self.sweep_no_review_file: bool = False
         # When True, the uncovered-file-sweep branch writes its review output
         # but emits NO Read tool call -- a successful hunk-only review (issue
         # #309 finding 6). The file must be recorded as a completed ATTEMPT
@@ -453,7 +458,7 @@ class StubBackend:
                 raise RuntimeError("stub: uncovered-file sweep blew up")
             file_match = re.search(r"changed file (\S+) was NOT read", prompt)
             swept_file = file_match.group(1) if file_match else "notes.txt"
-            if not self.sweep_no_output:
+            if not self.sweep_no_output and not self.sweep_no_review_file:
                 out_match = re.search(r"write your full review to (\S+)", prompt, flags=re.IGNORECASE)
                 if out_match is not None:
                     out_path = Path(out_match.group(1).rstrip("."))

--- a/tests/test_backend_osprey.py
+++ b/tests/test_backend_osprey.py
@@ -287,6 +287,38 @@ async def test_coalesces_streaming_thinking_deltas_before_text() -> None:
 
 
 @pytest.mark.asyncio
+async def test_ignores_blank_thinking_deltas() -> None:
+    lines, _ = _stream(
+        {"event": "turn_start", "turn_id": "t-1", "timestamp": "now"},
+        {"event": "thinking_delta", "content": ""},
+        {"event": "thinking_delta", "content": "  \n"},
+        {"event": "text_delta", "content": "Done."},
+        {"event": "turn_end", "turn_id": "t-1", "usage_reported": False},
+    )
+
+    events, _ = await _collect(OspreyBackend(osprey_binary="fake"), lines)
+
+    assert not any(isinstance(event, ThinkingEvent) for event in events)
+
+
+@pytest.mark.asyncio
+async def test_result_exposes_session_model_without_usage_metrics() -> None:
+    lines, _ = _stream(
+        {"event": "turn_start", "turn_id": "t-1", "timestamp": "now"},
+        {"event": "text_delta", "content": "Done."},
+        {"event": "turn_end", "turn_id": "t-1", "usage_reported": False},
+    )
+
+    backend = OspreyBackend(osprey_binary="fake")
+    assert backend.model == "unknown"
+    events, _ = await _collect(backend, lines)
+    result = next(event for event in events if isinstance(event, ResultEvent))
+
+    assert result.model_name == "custom-model"
+    assert backend.model == "custom-model"
+
+
+@pytest.mark.asyncio
 async def test_separates_thinking_runs_at_protocol_boundaries() -> None:
     lines, _ = _stream(
         {"event": "turn_start", "turn_id": "t-1", "timestamp": "now"},
@@ -343,6 +375,8 @@ async def test_trajectory_records_coalesced_thinking_as_prose(tmp_path: Path) ->
 
     trajectory = recorder.build_trajectory().model_dump(exclude_none=True)
     assert trajectory["steps"][1]["reasoning_content"] == "Let me think."
+    assert trajectory["agent"]["model_name"] == "custom-model"
+    assert trajectory["steps"][1]["model_name"] == "custom-model"
 
 
 @pytest.mark.asyncio

--- a/tests/test_backend_osprey.py
+++ b/tests/test_backend_osprey.py
@@ -259,6 +259,93 @@ async def test_translates_text_thinking_tool_identity_metrics_and_result() -> No
 
 
 @pytest.mark.asyncio
+async def test_coalesces_streaming_thinking_deltas_before_text() -> None:
+    lines, _ = _stream(
+        {"event": "turn_start", "turn_id": "t-1", "timestamp": "now"},
+        {"event": "thinking_delta", "content": "Let"},
+        {"event": "thinking_delta", "content": " me"},
+        {"event": "thinking_delta", "content": " think."},
+        {"event": "text_delta", "content": "Done."},
+        {
+            "event": "turn_end",
+            "turn_id": "t-1",
+            "usage_reported": False,
+        },
+    )
+
+    events, _ = await _collect(OspreyBackend(osprey_binary="fake"), lines)
+
+    assert [type(event) for event in events] == [
+        ThinkingEvent,
+        TextEvent,
+        TurnEndEvent,
+        ResultEvent,
+    ]
+    assert [event.text for event in events if isinstance(event, ThinkingEvent)] == [
+        "Let me think."
+    ]
+
+
+@pytest.mark.asyncio
+async def test_separates_thinking_runs_at_protocol_boundaries() -> None:
+    lines, _ = _stream(
+        {"event": "turn_start", "turn_id": "t-1", "timestamp": "now"},
+        {"event": "thinking_delta", "content": "first attempt"},
+        {"event": "driver_retry"},
+        {"event": "thinking_delta", "content": "second attempt"},
+        {"event": "text_delta", "content": "Done."},
+        {
+            "event": "turn_end",
+            "turn_id": "t-1",
+            "usage_reported": False,
+        },
+    )
+
+    events, _ = await _collect(OspreyBackend(osprey_binary="fake"), lines)
+
+    assert [event.text for event in events if isinstance(event, ThinkingEvent)] == [
+        "first attempt",
+        "second attempt",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_trajectory_records_coalesced_thinking_as_prose(tmp_path: Path) -> None:
+    lines, _ = _stream(
+        {"event": "turn_start", "turn_id": "t-1", "timestamp": "now"},
+        {"event": "thinking_delta", "content": "Let"},
+        {"event": "thinking_delta", "content": " me"},
+        {"event": "thinking_delta", "content": " think."},
+        {
+            "event": "message_end",
+            "messages": [{"type": "result", "data": {"content": "Done."}}],
+        },
+        {
+            "event": "turn_end",
+            "turn_id": "t-1",
+            "usage_reported": False,
+        },
+    )
+    recorder = TrajectoryRecorder(
+        path=tmp_path / "trajectory.json",
+        run_flow=DaydreamRunFlow.NORMAL,
+        target_dir=tmp_path,
+        agent_model_name="osprey",
+        session_id="daydream-session",
+    )
+
+    async with recorder:
+        async with recorder.invocation(phase=DaydreamPhase.REVIEW) as invocation:
+            invocation.observe_user_step("prompt")
+            events, _ = await _collect(OspreyBackend(osprey_binary="fake"), lines)
+            for event in events:
+                invocation.observe(event)
+
+    trajectory = recorder.build_trajectory().model_dump(exclude_none=True)
+    assert trajectory["steps"][1]["reasoning_content"] == "Let me think."
+
+
+@pytest.mark.asyncio
 async def test_usage_and_structured_output_preserve_optional_metrics() -> None:
     lines, _ = _stream(
         {"event": "turn_start", "turn_id": "t-1", "timestamp": "now"},

--- a/tests/test_backend_osprey.py
+++ b/tests/test_backend_osprey.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -42,14 +43,40 @@ class _FakeStdout:
             return b""
 
 
+class _FakeStderr:
+    def __init__(self, lines: list[str], held_open: asyncio.Event | None = None) -> None:
+        self._lines = iter(line.encode() + b"\n" for line in lines)
+        self._held_open = held_open
+
+    async def readline(self) -> bytes:
+        try:
+            return next(self._lines)
+        except StopIteration:
+            if self._held_open is not None:
+                await self._held_open.wait()
+            return b""
+
+
 class _FakeProcess:
-    def __init__(self, lines: list[dict[str, object]], returncode: int = 0) -> None:
+    def __init__(
+        self,
+        lines: list[dict[str, object]],
+        returncode: int = 0,
+        stderr_lines: list[str] | None = None,
+        stderr_held_open: bool = False,
+    ) -> None:
         self.stdout = _FakeStdout(lines)
+        self._stderr_eof = asyncio.Event() if stderr_held_open else None
+        self.stderr = _FakeStderr(stderr_lines or [], self._stderr_eof)
         self.returncode = returncode
         self.pid = 137
 
     async def wait(self) -> int:
         return self.returncode
+
+    def close_stderr(self) -> None:
+        if self._stderr_eof is not None:
+            self._stderr_eof.set()
 
 
 def _stream(
@@ -98,12 +125,20 @@ async def _collect(
     max_turns: int | None = None,
     read_only: bool = False,
     persist_session: bool = True,
+    stderr_lines: list[str] | None = None,
+    stderr_held_open: bool = False,
 ) -> tuple[list[AgentEvent], AsyncMock]:
-    process = _FakeProcess(lines, returncode=returncode)
+    process = _FakeProcess(
+        lines,
+        returncode=returncode,
+        stderr_lines=stderr_lines,
+        stderr_held_open=stderr_held_open,
+    )
     exec_mock = AsyncMock(return_value=process)
+    terminate_mock = AsyncMock(side_effect=lambda _process: process.close_stderr())
     with (
         patch("daydream.backends.osprey.asyncio.create_subprocess_exec", exec_mock),
-        patch("daydream.backends.osprey.terminate_process", new=AsyncMock()),
+        patch("daydream.backends.osprey.terminate_process", new=terminate_mock),
     ):
         events = [
             event
@@ -119,6 +154,39 @@ async def _collect(
             )
         ]
     return events, exec_mock
+
+
+@pytest.mark.asyncio
+async def test_stderr_is_drained_separately_from_jsonl_stdout() -> None:
+    lines, _ = _stream()
+
+    events, exec_mock = await _collect(
+        OspreyBackend(osprey_binary="fake"),
+        lines,
+        stderr_lines=[
+            "2026-08-27T23:07:54Z INFO osprey_cli::headless: "
+            "restoring remembered model preference"
+        ],
+    )
+
+    assert [type(event) for event in events] == [ResultEvent]
+    assert exec_mock.call_args.kwargs["stderr"] is asyncio.subprocess.PIPE
+
+
+@pytest.mark.asyncio
+async def test_process_cleanup_releases_inherited_stderr_before_waiting_for_eof() -> None:
+    lines, _ = _stream()
+
+    events, _ = await asyncio.wait_for(
+        _collect(
+            OspreyBackend(osprey_binary="fake"),
+            lines,
+            stderr_held_open=True,
+        ),
+        timeout=0.5,
+    )
+
+    assert [type(event) for event in events] == [ResultEvent]
 
 
 def test_factory_builds_verified_osprey_jsonl_command() -> None:
@@ -367,6 +435,19 @@ async def test_non_success_terminal_outcome_with_nonzero_process_exit_is_process
     with pytest.raises(OspreyError, match="return code 1") as exc_info:
         await _collect(OspreyBackend(osprey_binary="fake"), lines, returncode=1)
     assert exc_info.value.category == "PROCESS_EXIT"
+
+
+@pytest.mark.asyncio
+async def test_nonzero_process_exit_includes_stderr_diagnostics() -> None:
+    lines, _ = _stream()
+
+    with pytest.raises(OspreyError, match="provider authentication failed"):
+        await _collect(
+            OspreyBackend(osprey_binary="fake"),
+            lines,
+            returncode=1,
+            stderr_lines=["provider authentication failed"],
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -8153,6 +8153,49 @@ async def test_run_deep_uncovered_sweep_review_without_read_not_claimed_as_cover
     assert "Coverage ratio: 0.75" in report
 
 
+async def test_run_deep_uncovered_sweep_structured_output_without_review_file_is_merged(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+    mute_side_effects: Mute,
+) -> None:
+    """Valid structured sweep output is authoritative without a Markdown sidecar.
+
+    Structured-output backends need not write the legacy ``uncovered-*-review.md``
+    byproduct. Their finding must still reach the host-owned records artifact and
+    merge, while the absence of a verified Read keeps coverage unchanged.
+    """
+    from daydream.runner import run
+
+    target = _uncovered_sweep_target(tmp_path)
+    _silence(monkeypatch)
+    mute_side_effects()
+    stub = _install_stub_backend(monkeypatch, target)
+    stub.per_stack_emit_reads = True
+    stub.per_stack_unread = frozenset({"notes.txt"})
+    stub.sweep_file = "notes.txt"
+    stub.sweep_no_review_file = True
+    stub.sweep_no_read = True
+    stub.merge_echo_records = True
+
+    exit_code = await run(make_config(target, assume="yes", output_mode="loop"))
+    assert exit_code == 0
+
+    deep = target / ".daydream" / "deep"
+    assert not list(deep.glob("uncovered-*-review.md"))
+    records = json.loads((deep / "stack-uncovered-records.json").read_text())
+    assert [record["file"] for record in records] == ["notes.txt"]
+    merged = json.loads((deep / "merged-items.json").read_text())["items"]
+    assert any(item.get("file") == "notes.txt" for item in merged)
+
+    stats = json.loads((deep / "coverage-stats.json").read_text())
+    assert stats["completed_files"] == ["notes.txt"]
+    assert stats["covered_files"] == []
+    assert stats["sweep_attempt_status"] == {"notes.txt": "reviewed (hunks only)"}
+    assert stats["sweep_finding_count"] == 1
+    assert stats["sweep_failures"] == {}
+
+
 async def test_uncovered_sweep_per_stack_resume_fails_closed_on_unremovable_artifact(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_pr_comment_renderer.py
+++ b/tests/test_pr_comment_renderer.py
@@ -589,6 +589,32 @@ def test_step_model_falls_back_to_root_agent_model(tmp_path: Path) -> None:
     assert "not in the price table" not in out
 
 
+def test_osprey_backend_alias_is_not_rendered_as_model(tmp_path: Path) -> None:
+    """The backend name is a fallback, not an actual model identity."""
+    p = _write_trajectory(
+        tmp_path,
+        model="osprey",
+        steps=[
+            _user_step(),
+            _agent_step(
+                step_id=2,
+                phase="exploration",
+                model="osprey",
+                prompt=0,
+                completion=0,
+                cached=0,
+            ),
+        ],
+    )
+
+    out = render_run_info_block([p])
+
+    assert "- **Model:** unknown" in out
+    exploration_row = next(line for line in out.splitlines() if line.startswith("| Exploration |"))
+    assert [cell.strip() for cell in exploration_row.split("|")][2] == "unknown"
+    assert "| osprey |" not in out
+
+
 # Duration formatting
 @pytest.mark.parametrize(
     ("seconds", "expected"),

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -369,6 +369,38 @@ async def test_run_agent_callback_path_labels_taskoutput(tmp_path: Path) -> None
     assert "TaskOutput a066168" not in joined  # opaque bare-id dump form is gone
 
 
+async def test_run_agent_callback_coalesces_streaming_text_deltas(tmp_path: Path) -> None:
+    """Token-sized text deltas render as one parallel-fix narration line."""
+    from rich.text import Text
+
+    from daydream.agent import run_agent
+    from daydream.backends import ResultEvent, TextEvent
+    from daydream.trajectory import DaydreamPhase
+    from tests.test_agent_recorder_integration import MockBackend
+
+    backend = MockBackend(
+        [
+            TextEvent("B"),
+            TextEvent("ash"),
+            TextEvent(" is"),
+            TextEvent(" blocked."),
+            ResultEvent(structured_output=None, continuation=None),
+        ]
+    )
+    lines: list[Text] = []
+
+    result, _, _ = await run_agent(
+        backend,
+        tmp_path,
+        "go",
+        phase=DaydreamPhase.FIX,
+        progress_callback=lines.append,
+    )
+
+    assert result == "Bash is blocked."
+    assert [line.plain for line in lines] == ["    Bash is blocked."]
+
+
 async def test_run_agent_callback_path_edit_shows_file_not_bool(tmp_path: Path) -> None:
     """The parallel-fix callback line names the edited file, never a stray flag.
 


### PR DESCRIPTION
## Summary

- Keep Osprey's versioned JSONL stdout isolated from informational stderr logs while continuously draining bounded diagnostics.
- Coalesce token-sized `thinking_delta` fragments into semantic Daydream thinking events without merging across retry or protocol boundaries.
- Reap inherited stderr pipe holders before awaiting EOF, preventing descendant processes from hanging backend completion.
- Isolate standalone RL rollouts from ambient GitHub credentials uncovered by the mandatory local gate.

## Motivation

Osprey correctly writes JSONL protocol records to stdout and operational tracing to stderr. Daydream merged both descriptors, so a normal `tracing::info!` message such as `restoring remembered model preference` was parsed as JSON and raised `OspreyProtocolError`.

Osprey also correctly describes provider reasoning chunks as streaming `thinking_delta` events. Daydream previously translated every fragment into a complete `ThinkingEvent`, causing log mode to print nearly one `[thinking]` record per token and trajectories to insert newlines between token fragments.

## Changes

### Fixed

- Pipe Osprey stderr separately from strict JSONL stdout.
- Drain, redact, and bound Osprey stderr diagnostics without stopping the drain at the capture limit.
- Shield stderr-task cleanup on cancellation and close inherited pipe holders before awaiting EOF.
- Buffer consecutive Osprey thinking deltas and flush one complete reasoning event at the next protocol boundary.
- Keep retry-separated reasoning runs distinct and preserve thinking-before-text/tool event ordering.
- Remove ambient GitHub App and token credentials from local and Docker RL rollout process trees.

### Tests

- Informational stderr remains separate from JSONL stdout.
- Nonzero exits retain bounded stderr diagnostics.
- Inherited stderr descriptors cannot hang backend completion.
- Consecutive thinking deltas produce one `ThinkingEvent` and clean trajectory prose.
- Retry/protocol boundaries keep distinct reasoning runs separate.
- RL rollout credential isolation and Docker wrapper ordering remain hermetic.

## Test Plan

- [x] `uv run pytest tests/test_backend_osprey.py -q` — 26 passed
- [x] Focused Ruff, strict mypy, dead-code analysis, and `git diff --check`
- [x] Independent subagent review — no actionable findings
- [x] `make check` — 4,445 root tests passed / 4 skipped; 172 RL tests passed / 1 skipped
- [x] Ordinary hook-enabled `git push` repeated signature verification and the full `make check` gate successfully

## Checklist

- [x] Root, workflow, and standalone RL checks pass locally via `make check`
- [x] Documentation updated (not applicable; public configuration and Osprey's protocol remain unchanged)
