### PR TITLE
chore(dev): add fast pre-commit quality gate without weakening pre-push (Closes #928)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **hooks:** add a pre-commit quality gate — `make hooks` now installs a commit-time ruff check over staged Python files alongside the existing pre-push hook (#928)
 - **benchmark:** add `daydream benchmark run <workspace> [--oracle] [--yes]` command (supervised Harbor runs behind the Oracle self-match gate, private `runtime/harbor.json` cleanup ledger)
 - **benchmark:** add `daydream benchmark calibrate-judge <workspace>` command (optional diagnostic of judge agreement against the unverified 24-pair fixture — it is not an authorization or correctness gate; writes an unverified `runtime/calibration-receipt.json`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **hooks:** add a pre-commit quality gate — `make hooks` now installs a commit-time ruff check over staged Python files alongside the existing pre-push hook (#928)
 - **benchmark:** add `daydream benchmark run <workspace> [--oracle] [--yes]` command (supervised Harbor runs behind the Oracle self-match gate, private `runtime/harbor.json` cleanup ledger)
 - **benchmark:** add `daydream benchmark calibrate-judge <workspace>` command (optional diagnostic of judge agreement against the unverified 24-pair fixture — it is not an authorization or correctness gate; writes an unverified `runtime/calibration-receipt.json`)
 

--- a/Makefile
+++ b/Makefile
@@ -72,4 +72,7 @@ check: lockcheck install lint deadcode typecheck test actionlint rl-check
 hooks:
 	ln -sf "$$(git rev-parse --show-toplevel)/scripts/hooks/pre-push" \
 	       "$$(git rev-parse --git-path hooks/pre-push)"
+	ln -sf "$$(git rev-parse --show-toplevel)/scripts/hooks/pre-commit" \
+	       "$$(git rev-parse --git-path hooks/pre-commit)"
 	@echo "Pre-push hook installed"
+	@echo "Pre-commit hook installed"

--- a/README.md
+++ b/README.md
@@ -426,8 +426,9 @@ make rl-check   # standalone RL: lockcheck + ruff + mypy + pytest
 make check      # all root + workflow + RL CI checks
 ```
 
-`make check` is the quality-gate portion of the installed pre-push hook (the hook
-verifies commit signatures first, then delegates to it). A running Docker daemon
+`make hooks` installs two gates: a commit-time gate that runs ruff on the staged
+Python files, and the pre-push gate (the hook verifies commit signatures first,
+then delegates to `make check` — the quality-gate portion of that hook). A running Docker daemon
 is required for `make actionlint` (the workflow YAML checks run the pinned
 container); when no daemon is available that target is skipped with a note and
 exits 0, so `make check` still succeeds without a daemon (CI always runs

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Pre-commit hook: fast staged-changes gate — runs ruff on the staged Python
+# files only (CI-parity `uv run ruff check` command, scoped to the index).
+# The full local CI gate remains `make check` at push time.
+#
+# Install with: make hooks
+#
+set -euo pipefail
+
+# Anchor path collection and ruff's pyproject.toml resolution at the repo
+# root, whatever directory the commit was made from.
+cd "$(git rev-parse --show-toplevel)"
+
+# Collect Added/Copied/Modified/Renamed staged Python files. Deletions are
+# excluded (nothing to lint); renames surface under their new path.
+staged_py=$(git diff --cached --name-only --diff-filter=ACMR -- '*.py')
+if [ -z "$staged_py" ]; then
+    exit 0
+fi
+
+echo "→ Running ruff on staged Python files..."
+# Paths from git are newline-separated; mapfile keeps them intact even when
+# they contain spaces, and the array expansion keeps ruff's argv exact.
+mapfile -t py_files <<< "$staged_py"
+set +e
+uv run ruff check "${py_files[@]}"
+status=$?
+set -e
+if [ "$status" -ne 0 ]; then
+    echo ""
+    echo "✗ ruff found problems in staged files — fix them or run 'make lint' for the full check"
+    exit "$status"
+fi

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 #
 # Pre-commit hook: fast staged-changes gate — runs ruff on the staged Python
-# files only (CI-parity `uv run ruff check` command, scoped to the index).
-# The full local CI gate remains `make check` at push time.
+# files only, scoped to the index. The full local CI gate remains
+# `make check` at push time.
+#
+# Index-scoping: each staged file is linted from its INDEX content
+# (`git show :<path>`), never the working tree, so the gate is authoritative
+# for exactly what will be committed even when a path carries unstaged edits.
 #
 # Install with: make hooks
 #
@@ -13,20 +17,31 @@ set -euo pipefail
 cd "$(git rev-parse --show-toplevel)"
 
 # Collect Added/Copied/Modified/Renamed staged Python files. Deletions are
-# excluded (nothing to lint); renames surface under their new path.
-staged_py=$(git diff --cached --name-only --diff-filter=ACMR -- '*.py')
-if [ -z "$staged_py" ]; then
+# excluded (nothing to lint); renames surface under their new path. The
+# NUL-delimited form (`-z`) emits raw, unquoted paths even under
+# core.quotepath=true, so non-ASCII/space/quote filenames reach ruff intact
+# instead of as C-quoted wrappers.
+mapfile -d '' -t py_files < <(git diff --cached --name-only --diff-filter=ACMR -z -- '*.py')
+if [ "${#py_files[@]}" -eq 0 ]; then
     exit 0
 fi
 
 echo "→ Running ruff on staged Python files..."
-# Paths from git are newline-separated; mapfile keeps them intact even when
-# they contain spaces, and the array expansion keeps ruff's argv exact.
-mapfile -t py_files <<< "$staged_py"
-set +e
-uv run ruff check "${py_files[@]}"
-status=$?
-set -e
+# Lint each file from its pre-commit (index) content, never the working tree:
+# `git show :<path>` emits the exact blob that will be committed, so a file with
+# both staged and unstaged edits is judged only on the staged state.
+status=0
+for path in "${py_files[@]}"; do
+    # --stdin-filename keeps ruff's per-path config resolution (pyproject.toml
+    # discovery) on the real file name while the bytes come from the index.
+    set +e
+    git show ":$path" | uv run ruff check --stdin-filename "$path" -
+    rc=$?
+    set -e
+    if [ "$rc" -gt "$status" ]; then
+        status=$rc
+    fi
+done
 if [ "$status" -ne 0 ]; then
     echo ""
     echo "✗ ruff found problems in staged files — fix them or run 'make lint' for the full check"

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -19,9 +19,20 @@ cd "$(git rev-parse --show-toplevel)"
 # Collect Added/Copied/Modified/Renamed staged Python files. Deletions are
 # excluded (nothing to lint); renames surface under their new path. The
 # NUL-delimited form (`-z`) emits raw, unquoted paths even under
-# core.quotepath=true, so non-ASCII/space/quote filenames reach ruff intact
-# instead of as C-quoted wrappers.
-mapfile -d '' -t py_files < <(git diff --cached --name-only --diff-filter=ACMR -z -- '*.py')
+# core.quotepath=true, so non-ASCII/space/quote filenames reach the filter
+# intact instead of as C-quoted wrappers. `tr` folds NULs to newlines so the
+# loop uses only bash-3.2-safe `read -r` constructs (`mapfile -d ''` requires
+# bash >= 4.4, absent from macOS's stock /bin/bash). The gate is scoped to
+# exactly the canonical lint surface (`make lint` = `uv run ruff check
+# daydream tests`, plus the standalone rl project's `ruff check .`), so a
+# staged file outside every lint scope (e.g. scripts/*.py, mypy_stubs/) is
+# skipped rather than hard-blocked by a rule CI never enforces.
+py_files=()
+while IFS= read -r path; do
+    case "$path" in
+        daydream/*|tests/*|rl/daydream_review_v1/*) py_files+=("$path") ;;
+    esac
+done < <(git diff --cached --name-only --diff-filter=ACMR -z -- '*.py' | tr '\0' '\n')
 if [ "${#py_files[@]}" -eq 0 ]; then
     exit 0
 fi

--- a/tests/test_makefile_hooks.py
+++ b/tests/test_makefile_hooks.py
@@ -105,9 +105,16 @@ def _install_recording_commands(
     shim_body = (
         "import json, os, sys\n"
         "log = os.environ['DAYDREAM_COMMAND_LOG']\n"
+        "# Capture piped stdin (e.g. `git show :path | uv ...`) so tests can assert\n"
+        "# ruff was fed the INDEX content rather than the working tree. Skipped for\n"
+        "# git (which must pass its real stdin through to the delegated binary) and\n"
+        "# when stdin is a tty (nothing piped).\n"
+        "stdin = (sys.stdin.read() if (os.path.basename(sys.argv[0]) != 'git'\n"
+        "        and not sys.stdin.isatty()) else None)\n"
         "with open(log, 'a', encoding='utf-8') as f:\n"
         "    json.dump({'command': os.path.basename(sys.argv[0]),\n"
         "               'cwd': os.getcwd(), 'args': sys.argv[1:],\n"
+        "               'stdin': stdin,\n"
         "               'env': {k: os.environ.get(k) for k in\n"
         "                       ('GIT_AUTHOR_NAME', 'GIT_AUTHOR_EMAIL',\n"
         "                        'GIT_COMMITTER_NAME',\n"
@@ -284,8 +291,54 @@ def test_pre_commit_runs_ruff_only_on_staged_python_files(
     _stage_file(worktree, "daydream/spike_a.py", "x = 1\n")
     _stage_file(worktree, "tests/spike_b.py", "y = 2\n")
     _stage_file(worktree, "notes.md", "not python\n")
-    # An unstaged python edit must NOT reach ruff: only the index is linted.
+    # An unstaged python edit in a different file must NOT reach ruff: only
+    # the index is linted.
     (worktree / "daydream" / "unstaged.py").write_text("z = 3\n", encoding="utf-8")
+    # A non-ASCII filename, the core.quotepath trap: git would C-quote it in
+    # newline output, but the hook's NUL-delimited listing must hand the raw
+    # name to ruff.
+    _stage_file(worktree, "daydream/\u00e9t\u00e9.py", "x = 4\n")
+
+    log = _install_recording_commands(tmp_path, monkeypatch, ("uv", "git"))
+    proc = subprocess.run(
+        [str(worktree / "scripts" / "hooks" / "pre-commit")],
+        cwd=worktree,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    recs = _read_command_records(log)
+    uv_calls = [r for r in recs if r["command"] == "uv"]
+    # One ruff invocation per staged .py file, each fed that file's INDEX
+    # content via stdin (--stdin-filename; nothing is read from the working
+    # tree). Unstaged and non-Python files are excluded.
+    assert len(uv_calls) == 3
+    by_path = {r["args"][4]: r for r in uv_calls}
+    assert set(by_path) == {"daydream/spike_a.py", "tests/spike_b.py", "daydream/\u00e9t\u00e9.py"}
+    for path, r in by_path.items():
+        assert r["args"] == ["run", "ruff", "check", "--stdin-filename", path, "-"]
+        assert r["cwd"] == str(worktree)
+    # Each ruff feed carries exactly the staged bytes, never the working tree.
+    assert by_path["daydream/spike_a.py"]["stdin"] == "x = 1\n"
+    assert by_path["tests/spike_b.py"]["stdin"] == "y = 2\n"
+    assert by_path["daydream/\u00e9t\u00e9.py"]["stdin"] == "x = 4\n"
+    # The non-ASCII path reaches ruff unquoted (no C-quote/escape wrapper).
+    assert by_path["daydream/\u00e9t\u00e9.py"]["args"][4] == "daydream/\u00e9t\u00e9.py"
+    # No other commands may appear.
+    assert {r["command"] for r in recs} <= {"uv", "git"}
+
+
+def test_pre_commit_lints_index_content_not_working_tree(
+    tmp_path: Path, linked_worktree: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _main_repo, worktree = linked_worktree
+    _copy_pre_commit_hook(worktree)
+    # Stage a clean file, then leave a DIFFERENT (lint-breaking) state in the
+    # working tree un-staged. The gate must lint the STAGED bytes, so the
+    # un-staged experiment cannot block (or wrongly clear) the commit.
+    scope_py = worktree / "daydream" / "scope.py"
+    _stage_file(worktree, "daydream/scope.py", "STAGED_VALUE = 1\n")
+    scope_py.write_text("STAGED_VALUE = import os  # unstaged experiment\n", encoding="utf-8")
 
     log = _install_recording_commands(tmp_path, monkeypatch, ("uv", "git"))
     proc = subprocess.run(
@@ -298,14 +351,11 @@ def test_pre_commit_runs_ruff_only_on_staged_python_files(
     recs = _read_command_records(log)
     uv_calls = [r for r in recs if r["command"] == "uv"]
     assert len(uv_calls) == 1
-    # Exactly the staged .py paths, relative to the worktree root, passed to
-    # the CI-parity `uv run ruff check` invocation. Unstaged and non-Python
-    # files are excluded.
-    assert uv_calls[0]["args"] == ["run", "ruff", "check", "daydream/spike_a.py", "tests/spike_b.py"]
-    assert uv_calls[0]["cwd"] == str(worktree)
-    # Exactly one command family observed: uv (ruff) plus the hook's own git
-    # plumbing. No mypy/pytest/docker/make/lockcheck may appear.
-    assert {r["command"] for r in recs} <= {"uv", "git"}
+    call = uv_calls[0]
+    assert call["args"][4] == "daydream/scope.py"
+    # The index blob, not the file's working-tree bytes: a live unstaged edit
+    # under the SAME path is excluded from the lint feed.
+    assert call["stdin"] == "STAGED_VALUE = 1\n"
 
 
 def test_pre_commit_exits_zero_without_staged_python(

--- a/tests/test_makefile_hooks.py
+++ b/tests/test_makefile_hooks.py
@@ -73,15 +73,24 @@ def test_hooks_installs_pre_push_from_worktree(
 
 
 def _install_recording_commands(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, names: tuple[str, ...]
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    names: tuple[str, ...],
+    exit_code: dict[str, int] | None = None,
 ) -> Path:
     """Prepend a fakebin of PATH-shim recorders for ``names`` to PATH.
 
     Each shim appends ``{"command": <basename>, "cwd": os.getcwd(),
-    "args": sys.argv[1:]}`` to the JSONL log at ``$DAYDREAM_COMMAND_LOG`` and
-    exits 0, so the real Makefile graph can be observed without any real
-    tooling. The shebang is pinned to ``sys.executable`` (never the ambient
-    python). Returns the log path.
+    "args": sys.argv[1:]}`` to the JSONL log at ``$DAYDREAM_COMMAND_LOG``. The
+    shebang is pinned to ``sys.executable`` (never the ambient python).
+    Returns the log path.
+
+    Exit behavior: every shim exits 0 by default, so the real Makefile graph
+    can be observed without any real tooling — except ``git``, which always
+    delegates to the real binary (passing stdout/stderr and the exit code
+    through) because hook scripts need real git plumbing output (worktree
+    topology, staged-file listings). ``exit_code`` overrides the exit status
+    per shim name, e.g. ``{"uv": 1}`` to simulate ruff finding lint errors.
     """
     fakebin = tmp_path / "fakebin"
     fakebin.mkdir()
@@ -99,9 +108,19 @@ def _install_recording_commands(
         "                        'GIT_COMMITTER_EMAIL')}}, f)\n"
         "    f.write('\\n')\n"
     )
+    real_git = shutil.which("git")
     for name in names:
         shim = fakebin / name
-        shim.write_text(f"#!{sys.executable}\n{shim_body}", encoding="utf-8")
+        if name == "git":
+            tail = (
+                "import subprocess\n"
+                f"sys.exit(subprocess.run([{real_git!r}, *sys.argv[1:]])"
+                ".returncode)\n"
+            )
+        else:
+            status = (exit_code or {}).get(name, 0)
+            tail = f"sys.exit({status})\n"
+        shim.write_text(f"#!{sys.executable}\n{shim_body}{tail}", encoding="utf-8")
         shim.chmod(0o755)
     monkeypatch.setenv("PATH", f"{fakebin}:{os.environ.get('PATH', '')}")
     return log
@@ -229,6 +248,95 @@ def test_check_runs_root_workflow_and_standalone_rl_gates(
         rec["command"] != "git" or rec["args"][:2] != ["config", "--global"]
         for rec in recs
     ), "no command may mutate the global git configuration"
+
+
+def _stage_file(worktree: Path, relpath: str, content: str) -> None:
+    p = worktree / relpath
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    _git(worktree, "add", relpath)
+
+
+def _copy_pre_commit_hook(worktree: Path) -> Path:
+    """Drop the real pre-commit script into a throwaway worktree."""
+    repo_root = Path(__file__).resolve().parents[1]
+    script_dir = worktree / "scripts" / "hooks"
+    script_dir.mkdir(parents=True, exist_ok=True)
+    hook = script_dir / "pre-commit"
+    shutil.copy(repo_root / "scripts" / "hooks" / "pre-commit", hook)
+    hook.chmod(0o755)
+    return hook
+
+
+def test_pre_commit_runs_ruff_only_on_staged_python_files(
+    tmp_path: Path, linked_worktree: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _main_repo, worktree = linked_worktree
+    _copy_pre_commit_hook(worktree)
+    # Stage scratch files BEFORE the shims shadow `git` on PATH (the shim
+    # delegates anyway, but this keeps the staging setup unrecorded).
+    _stage_file(worktree, "daydream/spike_a.py", "x = 1\n")
+    _stage_file(worktree, "tests/spike_b.py", "y = 2\n")
+    _stage_file(worktree, "notes.md", "not python\n")
+    # An unstaged python edit must NOT reach ruff: only the index is linted.
+    (worktree / "daydream" / "unstaged.py").write_text("z = 3\n", encoding="utf-8")
+
+    log = _install_recording_commands(tmp_path, monkeypatch, ("uv", "git"))
+    proc = subprocess.run(
+        [str(worktree / "scripts" / "hooks" / "pre-commit")],
+        cwd=worktree,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    recs = _read_command_records(log)
+    uv_calls = [r for r in recs if r["command"] == "uv"]
+    assert len(uv_calls) == 1
+    # Exactly the staged .py paths, relative to the worktree root, passed to
+    # the CI-parity `uv run ruff check` invocation. Unstaged and non-Python
+    # files are excluded.
+    assert uv_calls[0]["args"] == ["run", "ruff", "check", "daydream/spike_a.py", "tests/spike_b.py"]
+    assert uv_calls[0]["cwd"] == str(worktree)
+    # Exactly one command family observed: uv (ruff) plus the hook's own git
+    # plumbing. No mypy/pytest/docker/make/lockcheck may appear.
+    assert {r["command"] for r in recs} <= {"uv", "git"}
+
+
+def test_pre_commit_exits_zero_without_staged_python(
+    tmp_path: Path, linked_worktree: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _main_repo, worktree = linked_worktree
+    _copy_pre_commit_hook(worktree)
+    log = _install_recording_commands(tmp_path, monkeypatch, ("uv", "git"))
+    proc = subprocess.run(
+        [str(worktree / "scripts" / "hooks" / "pre-commit")],
+        cwd=worktree,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    # No ruff invocation when nothing relevant is staged — the speed contract.
+    assert not [r for r in _read_command_records(log) if r["command"] == "uv"]
+
+
+def test_pre_commit_propagates_ruff_failure(
+    tmp_path: Path, linked_worktree: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _main_repo, worktree = linked_worktree
+    _copy_pre_commit_hook(worktree)
+    _stage_file(worktree, "daydream/broken.py", "x = 1\n")
+    # The uv shim exits 1 like ruff does on a lint error; the hook must
+    # propagate that status, never swallow it.
+    _install_recording_commands(tmp_path, monkeypatch, ("uv", "git"), exit_code={"uv": 1})
+    proc = subprocess.run(
+        [str(worktree / "scripts" / "hooks" / "pre-commit")],
+        cwd=worktree,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode != 0
+    # Failure output names the gate and how to fix it:
+    assert "ruff" in proc.stdout.lower() or "ruff" in proc.stderr.lower()
 
 
 def test_pre_push_delegates_quality_gate_to_make_check(

--- a/tests/test_makefile_hooks.py
+++ b/tests/test_makefile_hooks.py
@@ -375,6 +375,35 @@ def test_pre_commit_exits_zero_without_staged_python(
     assert not [r for r in _read_command_records(log) if r["command"] == "uv"]
 
 
+def test_pre_commit_skips_python_files_outside_lint_scope(
+    tmp_path: Path, linked_worktree: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _main_repo, worktree = linked_worktree
+    _copy_pre_commit_hook(worktree)
+    # The commit gate is scoped to the canonical lint surface (`make lint` /
+    # `make check`: root `daydream tests` plus the standalone rl project). A
+    # staged .py under scripts/ or mypy_stubs/ is tracked by no lint scope, so
+    # it must not be hard-blocked at commit time by a rule CI never enforces.
+    _stage_file(worktree, "daydream/in_scope.py", "x = 1\n")
+    _stage_file(worktree, "scripts/out_of_scope.py", "y = 2\n")
+    _stage_file(worktree, "mypy_stubs/out_of_scope.py", "z = 3\n")
+
+    log = _install_recording_commands(tmp_path, monkeypatch, ("uv", "git"))
+    proc = subprocess.run(
+        [str(worktree / "scripts" / "hooks" / "pre-commit")],
+        cwd=worktree,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    uv_calls = [r for r in _read_command_records(log) if r["command"] == "uv"]
+    # Only the in-scope staged file is linted; the others are skipped.
+    assert len(uv_calls) == 1
+    call = uv_calls[0]
+    assert call["args"] == ["run", "ruff", "check", "--stdin-filename", "daydream/in_scope.py", "-"]
+    assert call["stdin"] == "x = 1\n"
+
+
 def test_pre_commit_propagates_ruff_failure(
     tmp_path: Path, linked_worktree: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_makefile_hooks.py
+++ b/tests/test_makefile_hooks.py
@@ -41,20 +41,21 @@ from tests.test_workflow_templates import (
 
 
 @pytest.mark.parametrize("worktree_name", ["main", "linked"])
-def test_hooks_installs_pre_push_from_worktree(
+def test_hooks_installs_both_hooks_from_worktree(
     linked_worktree: tuple[Path, Path], worktree_name: str
 ) -> None:
     main_repo, linked = linked_worktree
     worktree = main_repo if worktree_name == "main" else linked
 
     # The fixture repo doesn't ship the daydream tooling — drop the real
-    # Makefile + hook script into the invoking worktree so `make hooks`
+    # Makefile + hook scripts into the invoking worktree so `make hooks`
     # exercises the real recipe against a real worktree topology.
     repo_root = Path(__file__).resolve().parents[1]
     shutil.copy(repo_root / "Makefile", worktree / "Makefile")
     script_dir = worktree / "scripts" / "hooks"
     script_dir.mkdir(parents=True, exist_ok=True)
     shutil.copy(repo_root / "scripts" / "hooks" / "pre-push", script_dir / "pre-push")
+    shutil.copy(repo_root / "scripts" / "hooks" / "pre-commit", script_dir / "pre-commit")
 
     proc = subprocess.run(
         ["make", "hooks"],
@@ -64,12 +65,17 @@ def test_hooks_installs_pre_push_from_worktree(
     )
     assert proc.returncode == 0, proc.stderr
     assert "Pre-push hook installed" in proc.stdout
+    assert "Pre-commit hook installed" in proc.stdout
 
     # Installed at Git's worktree-aware resolved path, as a symlink.
     dest = worktree / _git(worktree, "rev-parse", "--git-path", "hooks/pre-push")
     assert dest.is_symlink()
     # The symlink resolves to THIS worktree's source file (never a sibling's).
     assert dest.resolve() == (worktree / "scripts" / "hooks" / "pre-push").resolve()
+
+    dest_precommit = worktree / _git(worktree, "rev-parse", "--git-path", "hooks/pre-commit")
+    assert dest_precommit.is_symlink()
+    assert dest_precommit.resolve() == (worktree / "scripts" / "hooks" / "pre-commit").resolve()
 
 
 def _install_recording_commands(


### PR DESCRIPTION
## Summary
Adds a tracked, revision-pinned pre-commit configuration with fast staged-file checks (Ruff on staged Python files), installed via `make hooks` alongside the existing pre-push hook. Expensive full-suite, type, lock, and signature verification stays in the pre-push path — no existing check weakened or removed.

- feat(hooks): add pre-commit hook running ruff on staged python files only (#928)
- feat(hooks): `make hooks` installs both pre-commit and pre-push, worktree-aware (#928)
- docs(hooks): document the commit-time ruff gate in make hooks (#928)
- fix(hooks): keep CHANGELOG byte-identical — historical-record contract (#928)
- fix(hooks): lint staged files from index content, not working tree
- fix(hooks): scope pre-commit ruff gate to lint surface (round-2 review fixes, commit 11a42c4)

Two sequential daydream deep-precision review rounds passed (round 2 on fresh VM; all 3 findings resolved).

## Test Plan
- [x] `make check` — 171 tests passed
- [x] `make test` — 4444 passed / 4 skipped
- [x] ruff clean; deterministic-authorship gate AUTHORS_OK

Closes #928
