### PR TITLE
fix(benchmark): harden claude-cli judge and verifier image build (Closes #965)

### DIFF
--- a/daydream/benchmark/harbor/agent.py
+++ b/daydream/benchmark/harbor/agent.py
@@ -57,6 +57,7 @@ _ANTHROPIC_KEEP_VARS = ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_
 _BANNED_PREFIXES = (
     "DAYDREAM_JUDGE_",
     "ANTHROPIC_",  # dropped from the scrub for backend="claude" (credentials preserved)
+    "CLAUDE_CODE_",  # judge (claude-cli) credential; never legitimate in the reviewed scope
     "OPENAI_",
     "OPENROUTER_",
     "PI_",

--- a/daydream/benchmark/harbor/calibrate.py
+++ b/daydream/benchmark/harbor/calibrate.py
@@ -136,11 +136,22 @@ def _build_calibration_client(env: dict[str, Any], *, http: Any = None) -> Any:
     validation to the packaged ``score_review._build_client`` so the two
     branches cannot silently drift (the judge template is an in-repo,
     editable file); only the injectable ``http=`` seam is added here, and
-    ``None`` leaves the client's real httpx behavior intact.
+    ``None`` leaves the client's real httpx behavior intact. The seam only
+    exists for the HTTP judge clients: the ``claude-cli`` provider shells the
+    Claude Code CLI (its injectable seam is the subprocess ``runner``), so an
+    injected ``http`` is rejected fail-closed rather than silently assigned to
+    an attribute that client never reads -- a no-op attribution would quietly
+    shell the real ``claude`` binary in what the caller believed was a
+    scripted run.
     """
     sr = _load_judge_template()
     client = sr._build_client(env)
     if http is not None:
+        if env.get("DAYDREAM_JUDGE_PROVIDER") == "claude-cli":
+            raise sr.VerifierError(
+                "http seam is not supported for the claude-cli judge provider "
+                "(it shells the Claude Code CLI; inject a fake subprocess runner instead)"
+            )
         client.http = http
     return client
 

--- a/daydream/benchmark/harbor/calibrate.py
+++ b/daydream/benchmark/harbor/calibrate.py
@@ -148,21 +148,22 @@ def _build_calibration_client(env: dict[str, Any], *, http: Any = None) -> Any:
 def _judge_host_from_env(env: dict[str, Any]) -> str:
     """Return the normalized-lowercase judge host for ``env``.
 
-    An explicit anthropic provider routes to ``api.anthropic.com``; the
-    openai-compatible provider requires an explicit base URL, resolves it via
-    the packaged ``resolve_base_url``, and returns that URL's host. Missing
-    providers fail closed rather than selecting an implicit API.
+    An explicit anthropic or claude-cli provider routes to
+    ``api.anthropic.com``; the openai-compatible provider requires an explicit
+    base URL, resolves it via the packaged ``resolve_base_url``, and returns
+    that URL's host. Missing providers fail closed rather than selecting an
+    implicit API.
     """
     sr = _load_judge_template()
     provider = env.get("DAYDREAM_JUDGE_PROVIDER") or ""
     if not provider:
         raise ValueError("missing DAYDREAM_JUDGE_PROVIDER")
-    if provider not in {"anthropic", "openai-compatible"}:
+    if provider not in {"anthropic", "openai-compatible", "claude-cli"}:
         raise ValueError(
             f"unsupported DAYDREAM_JUDGE_PROVIDER '{provider}'; "
-            "expected anthropic or openai-compatible"
+            "expected anthropic, openai-compatible, or claude-cli"
         )
-    if provider == "anthropic":
+    if provider in {"anthropic", "claude-cli"}:
         return "api.anthropic.com"
     if not env.get("DAYDREAM_JUDGE_BASE_URL"):
         raise ValueError("missing DAYDREAM_JUDGE_BASE_URL for openai-compatible provider")

--- a/daydream/benchmark/harbor/entrypoint.py
+++ b/daydream/benchmark/harbor/entrypoint.py
@@ -152,6 +152,7 @@ def apply_reviewer_env(env: Mapping[str, str] | None = None, *, backend: str = "
     for prefix in (
         "DAYDREAM_JUDGE_",
         "ANTHROPIC_",
+        "CLAUDE_CODE_",
         "OPENAI_",
         "OPENROUTER_",
         "PI_",

--- a/daydream/benchmark/harbor/package.py
+++ b/daydream/benchmark/harbor/package.py
@@ -429,6 +429,12 @@ def render_job_config(*, oracle: bool) -> bytes:
             "DAYDREAM_JUDGE_MODEL": "${DAYDREAM_JUDGE_MODEL}",
             "DAYDREAM_JUDGE_API_KEY": "${DAYDREAM_JUDGE_API_KEY}",
             "DAYDREAM_JUDGE_BASE_URL": "${DAYDREAM_JUDGE_BASE_URL}",
+            # CLAUDE_CODE_* feeds the keyless claude-cli judge client; the
+            # nonessential-traffic gate defaults on (fail-safe direction).
+            "CLAUDE_CODE_OAUTH_TOKEN": "${CLAUDE_CODE_OAUTH_TOKEN}",
+            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": (
+                "${CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC:-1}"
+            ),
         }},
         "datasets": [{"path": "."}],
         "metrics": [{"type": "uv-script", "kwargs": {"script_path": "metric.py"}}],

--- a/daydream/benchmark/harbor/run.py
+++ b/daydream/benchmark/harbor/run.py
@@ -449,7 +449,9 @@ def _preflight(
             ("judge", calibrate._judge_host_from_env, judge_hosts),
             ("reviewer", _reviewer_host_from_env, reviewer_hosts),
         ):
-            if label == "judge" and not env.get("DAYDREAM_JUDGE_BASE_URL"):
+            # anthropic and claude-cli resolve their judge host without a base URL
+            if label == "judge" and env.get("DAYDREAM_JUDGE_PROVIDER") == "openai-compatible" \
+                    and not env.get("DAYDREAM_JUDGE_BASE_URL"):
                 failures.append("cannot resolve judge host: missing DAYDREAM_JUDGE_BASE_URL")
                 continue
             try:

--- a/daydream/benchmark/harbor/templates/tests/Dockerfile
+++ b/daydream/benchmark/harbor/templates/tests/Dockerfile
@@ -20,15 +20,17 @@ RUN set -eux; \
         aarch64) narch=arm64; nsha=08bfbf538bad0e8cbb0269f0173cca28d705874a67a22f60b57d99dc99e30050;; \
         *) echo "unsupported arch"; exit 1;; \
     esac; \
-    curl -fsSLO "https://nodejs.org/dist/v22.14.0/node-v22.14.0-linux-${narch}.tar.xz"; \
-    echo "${nsha}  node-v22.14.0-linux-${narch}.tar.xz" | sha256sum -c -; \
+    # python:3.12-slim ships no curl/xz-utils; use the Python stdlib for both
+    # the download and the xz-compressed tar extraction.
+    python -c "import urllib.request,sys; urllib.request.urlretrieve('https://nodejs.org/dist/v22.14.0/node-v22.14.0-linux-'+sys.argv[1]+'.tar.xz', '/tmp/node.tar.xz')" "$narch"; \
+    echo "${nsha}  /tmp/node.tar.xz" | sha256sum -c -; \
     mkdir -p /usr/local/lib/nodejs; \
-    tar -xJf "node-v22.14.0-linux-${narch}.tar.xz" -C /usr/local/lib/nodejs; \
+    python -c "import tarfile; tarfile.open('/tmp/node.tar.xz').extractall('/usr/local/lib/nodejs', filter='data')"; \
+    rm -f /tmp/node.tar.xz; \
     ln -s "/usr/local/lib/nodejs/node-v22.14.0-linux-${narch}/bin/node" /usr/local/bin/node; \
     ln -s "/usr/local/lib/nodejs/node-v22.14.0-linux-${narch}/bin/npm" /usr/local/bin/npm; \
     ln -s "/usr/local/lib/nodejs/node-v22.14.0-linux-${narch}/bin/npx" /usr/local/bin/npx; \
-    rm -f "node-v22.14.0-linux-${narch}.tar.xz"; \
-    npm install -g @anthropic-ai/claude-code@2.1.250; \
+    npm install -g --prefix /usr/local @anthropic-ai/claude-code@2.1.250; \
     node --version && claude --version
 
 WORKDIR /tests

--- a/daydream/benchmark/harbor/templates/tests/Dockerfile
+++ b/daydream/benchmark/harbor/templates/tests/Dockerfile
@@ -1,13 +1,35 @@
 FROM __BASE_IMAGE__
 
-# Separate verifier environment: stdlib plus the hash-locked HTTP client.
-# httpx and its transitive subtree are pinned version+content-hash with the
-# committed closure (same as runtime-requirements.lock) and installed with
-# --require-hashes, so the verifier -- the container carrying the judge API
-# key to the configured allowlisted endpoint -- builds deterministically.
+# Separate verifier environment: stdlib plus the hash-locked HTTP client, a
+# version-pinned Node runtime and the version-pinned Claude Code CLI (the
+# claude-cli judge path). httpx and its transitive subtree are pinned
+# version+content-hash with the committed closure (same as
+# runtime-requirements.lock) and installed with --require-hashes, so the
+# verifier -- the container carrying the judge API key to the configured
+# allowlisted endpoint -- builds deterministically. Node and the CLI add a
+# few hundred MB to the image; accepted for this purpose.
 RUN printf 'httpx==0.28.1 --hash=sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad\nhttpcore==1.0.9 --hash=sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55 --hash=sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8\nanyio==4.12.1 --hash=sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703 --hash=sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c\ncertifi==2026.1.4 --hash=sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c --hash=sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120\nh11==0.16.0 --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 --hash=sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86\nidna==3.15 --hash=sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8 --hash=sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc\ntyping_extensions==4.15.0 --hash=sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466 --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548\n' > /tmp/httpx-lock.txt \
     && python -m pip install --no-cache-dir --require-hashes -r /tmp/httpx-lock.txt \
     && rm /tmp/httpx-lock.txt
+
+# Node v22.14.0 LTS + @anthropic-ai/claude-code@2.1.250, both version-pinned;
+# the tarball is checksum-verified against its published SHASUMS256 value.
+RUN set -eux; \
+    case "$(uname -m)" in \
+        x86_64) narch=x64; nsha=69b09dba5c8dcb05c4e4273a4340db1005abeafe3927efda2bc5b249e80437ec;; \
+        aarch64) narch=arm64; nsha=08bfbf538bad0e8cbb0269f0173cca28d705874a67a22f60b57d99dc99e30050;; \
+        *) echo "unsupported arch"; exit 1;; \
+    esac; \
+    curl -fsSLO "https://nodejs.org/dist/v22.14.0/node-v22.14.0-linux-${narch}.tar.xz"; \
+    echo "${nsha}  node-v22.14.0-linux-${narch}.tar.xz" | sha256sum -c -; \
+    mkdir -p /usr/local/lib/nodejs; \
+    tar -xJf "node-v22.14.0-linux-${narch}.tar.xz" -C /usr/local/lib/nodejs; \
+    ln -s "/usr/local/lib/nodejs/node-v22.14.0-linux-${narch}/bin/node" /usr/local/bin/node; \
+    ln -s "/usr/local/lib/nodejs/node-v22.14.0-linux-${narch}/bin/npm" /usr/local/bin/npm; \
+    ln -s "/usr/local/lib/nodejs/node-v22.14.0-linux-${narch}/bin/npx" /usr/local/bin/npx; \
+    rm -f "node-v22.14.0-linux-${narch}.tar.xz"; \
+    npm install -g @anthropic-ai/claude-code@2.1.250; \
+    node --version && claude --version
 
 WORKDIR /tests
 COPY test.sh score_review.py verifier_core.py judge_prompt.md golden-review.json verifier-metadata.json ./

--- a/daydream/benchmark/harbor/templates/tests/Dockerfile
+++ b/daydream/benchmark/harbor/templates/tests/Dockerfile
@@ -37,8 +37,9 @@ RUN set -eux; \
     ln -s "/usr/local/lib/nodejs/node-v22.14.0-linux-${narch}/bin/node" /usr/local/bin/node; \
     ln -s "/usr/local/lib/nodejs/node-v22.14.0-linux-${narch}/bin/npm" /usr/local/bin/npm; \
     ln -s "/usr/local/lib/nodejs/node-v22.14.0-linux-${narch}/bin/npx" /usr/local/bin/npx; \
-    mkdir -p /tmp/claude-cli; \
-    cat > /tmp/claude-cli/package.json <<'EOF'
+    mkdir -p /tmp/claude-cli
+
+RUN cat > /tmp/claude-cli/package.json <<'EOF'
 {
   "name": "claude-cli-verifier",
   "private": true,
@@ -48,7 +49,8 @@ RUN set -eux; \
   }
 }
 EOF
-    cat > /tmp/claude-cli/package-lock.json <<'EOF'
+
+RUN cat > /tmp/claude-cli/package-lock.json <<'EOF'
 {
   "name": "claude-cli-verifier",
   "version": "1.0.0",
@@ -192,6 +194,8 @@ EOF
   }
 }
 EOF
+
+RUN set -eux; \
     (cd /tmp/claude-cli && npm ci --no-audit --no-fund); \
     ln -s /tmp/claude-cli/node_modules/.bin/claude /usr/local/bin/claude; \
     node --version && claude --version

--- a/daydream/benchmark/harbor/templates/tests/Dockerfile
+++ b/daydream/benchmark/harbor/templates/tests/Dockerfile
@@ -4,16 +4,21 @@ FROM __BASE_IMAGE__
 # version-pinned Node runtime and the version-pinned Claude Code CLI (the
 # claude-cli judge path). httpx and its transitive subtree are pinned
 # version+content-hash with the committed closure (same as
-# runtime-requirements.lock) and installed with --require-hashes, so the
-# verifier -- the container carrying the judge API key to the configured
-# allowlisted endpoint -- builds deterministically. Node and the CLI add a
-# few hundred MB to the image; accepted for this purpose.
+# runtime-requirements.lock) and installed with --require-hashes, and the CLI
+# installs via `npm ci` from a committed package-lock.json so every transitive
+# is version- and integrity-pinned rather than re-resolved from the registry
+# at build time; the verifier -- the container carrying the judge API key to
+# the configured allowlisted endpoint -- builds deterministically. Node and
+# the CLI add a few hundred MB to the image; accepted for this purpose.
 RUN printf 'httpx==0.28.1 --hash=sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad\nhttpcore==1.0.9 --hash=sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55 --hash=sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8\nanyio==4.12.1 --hash=sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703 --hash=sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c\ncertifi==2026.1.4 --hash=sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c --hash=sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120\nh11==0.16.0 --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 --hash=sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86\nidna==3.15 --hash=sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8 --hash=sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc\ntyping_extensions==4.15.0 --hash=sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466 --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548\n' > /tmp/httpx-lock.txt \
     && python -m pip install --no-cache-dir --require-hashes -r /tmp/httpx-lock.txt \
     && rm /tmp/httpx-lock.txt
 
 # Node v22.14.0 LTS + @anthropic-ai/claude-code@2.1.250, both version-pinned;
-# the tarball is checksum-verified against its published SHASUMS256 value.
+# the tarball is checksum-verified against its published SHASUMS256 value and
+# the CLI installs with `npm ci` from the embedded package-lock.json (every
+# transitive version- and integrity-pinned, like the httpx closure), so a
+# re-published tarball fails the build instead of silently changing what ships.
 RUN set -eux; \
     case "$(uname -m)" in \
         x86_64) narch=x64; nsha=69b09dba5c8dcb05c4e4273a4340db1005abeafe3927efda2bc5b249e80437ec;; \
@@ -21,8 +26,10 @@ RUN set -eux; \
         *) echo "unsupported arch"; exit 1;; \
     esac; \
     # python:3.12-slim ships no curl/xz-utils; use the Python stdlib for both
-    # the download and the xz-compressed tar extraction.
-    python -c "import urllib.request,sys; urllib.request.urlretrieve('https://nodejs.org/dist/v22.14.0/node-v22.14.0-linux-'+sys.argv[1]+'.tar.xz', '/tmp/node.tar.xz')" "$narch"; \
+    # the download and the xz-compressed tar extraction. The socket default
+    # timeout bounds every network operation, so a stalled nodejs.org
+    # connection fails the build instead of hanging it indefinitely.
+    python -c "import socket,urllib.request,sys; socket.setdefaulttimeout(60); urllib.request.urlretrieve('https://nodejs.org/dist/v22.14.0/node-v22.14.0-linux-'+sys.argv[1]+'.tar.xz', '/tmp/node.tar.xz')" "$narch"; \
     echo "${nsha}  /tmp/node.tar.xz" | sha256sum -c -; \
     mkdir -p /usr/local/lib/nodejs; \
     python -c "import tarfile; tarfile.open('/tmp/node.tar.xz').extractall('/usr/local/lib/nodejs', filter='data')"; \
@@ -30,7 +37,163 @@ RUN set -eux; \
     ln -s "/usr/local/lib/nodejs/node-v22.14.0-linux-${narch}/bin/node" /usr/local/bin/node; \
     ln -s "/usr/local/lib/nodejs/node-v22.14.0-linux-${narch}/bin/npm" /usr/local/bin/npm; \
     ln -s "/usr/local/lib/nodejs/node-v22.14.0-linux-${narch}/bin/npx" /usr/local/bin/npx; \
-    npm install -g --prefix /usr/local @anthropic-ai/claude-code@2.1.250; \
+    mkdir -p /tmp/claude-cli; \
+    cat > /tmp/claude-cli/package.json <<'EOF'
+{
+  "name": "claude-cli-verifier",
+  "private": true,
+  "version": "1.0.0",
+  "dependencies": {
+    "@anthropic-ai/claude-code": "2.1.250"
+  }
+}
+EOF
+    cat > /tmp/claude-cli/package-lock.json <<'EOF'
+{
+  "name": "claude-cli-verifier",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "claude-cli-verifier",
+      "version": "1.0.0",
+      "dependencies": {
+        "@anthropic-ai/claude-code": "2.1.250"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-code": {
+      "version": "2.1.250",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.250.tgz",
+      "integrity": "sha512-SsqdHBePKgpoquZdMPbwSZZc2PkQy/qBcekroihILhRdPAAtpXXH49POHl7e6bujj55MaKPk4Wa7gpFXuMKwnA==",
+      "hasInstallScript": true,
+      "license": "SEE LICENSE IN README.md",
+      "bin": {
+        "claude": "bin/claude.exe"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-code-darwin-arm64": "2.1.250",
+        "@anthropic-ai/claude-code-darwin-x64": "2.1.250",
+        "@anthropic-ai/claude-code-linux-arm64": "2.1.250",
+        "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.250",
+        "@anthropic-ai/claude-code-linux-x64": "2.1.250",
+        "@anthropic-ai/claude-code-linux-x64-musl": "2.1.250",
+        "@anthropic-ai/claude-code-win32-arm64": "2.1.250",
+        "@anthropic-ai/claude-code-win32-x64": "2.1.250"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-code-darwin-arm64": {
+      "version": "2.1.250",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-arm64/-/claude-code-darwin-arm64-2.1.250.tgz",
+      "integrity": "sha512-THGQj2+aPMXrHpEbBFE/4PzJYK1Y9NlKdo+KhizGK020pZMBLP11KyeeBTm8HUJ5ZHeWIyB7ohwbQoZ7ttKGPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-darwin-x64": {
+      "version": "2.1.250",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-x64/-/claude-code-darwin-x64-2.1.250.tgz",
+      "integrity": "sha512-IF1MlGV5zT60a2fCsRgLyuvlRODrfMfKfhfvdqxPgax0bNaatqzqodZ9n23o2m2QIksHo5HF3T2Oe3frE+8l6Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-arm64": {
+      "version": "2.1.250",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64/-/claude-code-linux-arm64-2.1.250.tgz",
+      "integrity": "sha512-NVbdmP9kLenUGdPjSS9p+XTY0CqC+pjWo3sJMM4DrCOlUeJLqKcAB9f9+IvG5PHBAfDbcEstXjeGqDVavsvLMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-arm64-musl": {
+      "version": "2.1.250",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64-musl/-/claude-code-linux-arm64-musl-2.1.250.tgz",
+      "integrity": "sha512-GSDQ9LSnHojpXCcI/Zru8wWIoa+Kbgk4aHpc3/AneuGgGbNKbnj2Hi9awLYSuOqRg+MmmeQCM+r/4gCUSqyOrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-x64": {
+      "version": "2.1.250",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.250.tgz",
+      "integrity": "sha512-8bNQMnhl9p1j/xQ36vj/ghZrPQo1sm5OUJKbG+kQSVfOzhpsKWnOtrTY/xzABqUDd6lY6r7Tom7O9IXOq6gsHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-x64-musl": {
+      "version": "2.1.250",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64-musl/-/claude-code-linux-x64-musl-2.1.250.tgz",
+      "integrity": "sha512-1IQRUb51+KckMKTuNUJb+666ioPsY0E5NR5jI2iSKfdkzu5iRjyXQtOkn5qSUnRh7DPobx64g7sZHWJQoUvOuQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-win32-arm64": {
+      "version": "2.1.250",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-arm64/-/claude-code-win32-arm64-2.1.250.tgz",
+      "integrity": "sha512-e1GS0M6TXnZK17xwSxmPGR3RtErMKp9vyYcEt3iMLk5aae/gl+dvIQxzu4uNawPBtfQehygI1tHbArIEWd9f7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-win32-x64": {
+      "version": "2.1.250",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-x64/-/claude-code-win32-x64-2.1.250.tgz",
+      "integrity": "sha512-LguXPu3lFuByqyQOy0xIB2XhFl6jlODUSP81xt9Xpgf5Ha7YyOLg7g1lSkZXfWx7jpNq6E5QtFbsfyJzSFsFvg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    }
+  }
+}
+EOF
+    (cd /tmp/claude-cli && npm ci --no-audit --no-fund); \
+    ln -s /tmp/claude-cli/node_modules/.bin/claude /usr/local/bin/claude; \
     node --version && claude --version
 
 WORKDIR /tests

--- a/daydream/benchmark/harbor/templates/tests/score_review.py
+++ b/daydream/benchmark/harbor/templates/tests/score_review.py
@@ -857,6 +857,7 @@ async def judge_pairs(
 _ENV_PROVIDER = "DAYDREAM_JUDGE_PROVIDER"
 _ENV_MODEL = "DAYDREAM_JUDGE_MODEL"
 _ENV_API_KEY = "DAYDREAM_JUDGE_API_KEY"
+_ENV_OAUTH_TOKEN = "CLAUDE_CODE_OAUTH_TOKEN"
 _ENV_BASE_URL = "DAYDREAM_JUDGE_BASE_URL"
 _ENV_ALLOWED_HOSTS = "DAYDREAM_JUDGE_ALLOWED_HOSTS"
 _ENV_ARTIFACT_PATH = "DAYDREAM_JUDGE_ARTIFACT_PATH"
@@ -1239,20 +1240,35 @@ def run_verifier(
 def _build_client(env: dict[str, Any]) -> Any:
     """Build the judge client from the DAYDREAM_JUDGE_* env surface.
 
-    Provider is fail-closed: the ``anthropic`` | ``openai-compatible`` |
-    ``claude-cli`` set is accepted when explicit; absent or unsupported values
-    raise before any request. The provider's base URL is resolved and the
-    initial request URL is validated against the effective judge-host allowlist
-    at build time (the claude-cli provider has no HTTP base URL to validate).
+    the ``anthropic`` | ``openai-compatible`` | ``claude-cli`` set is accepted
+    when explicit; absent or unsupported values raise before any request.
+    The ``anthropic`` and ``openai-compatible`` providers require an API key,
+    resolve a base URL, and validate the initial request URL against the
+    effective judge-host allowlist at build time; the ``claude-cli`` provider
+    instead requires a non-empty ``CLAUDE_CODE_OAUTH_TOKEN`` and has no HTTP
+    base URL to validate.
     """
     provider = env.get(_ENV_PROVIDER) or ""
     model = env.get(_ENV_MODEL)
     api_key = env.get(_ENV_API_KEY)
+    if provider == "claude-cli":
+        # OAuth-token auth via the Claude Code CLI: no API key, no base URL,
+        # no allowlist validation (verified egress is intentionally unavailable
+        # on this path; trusted egress is enforced by the container env set).
+        oauth_token = env.get(_ENV_OAUTH_TOKEN)
+        if not model:
+            raise VerifierError("missing DAYDREAM_JUDGE_MODEL")
+        if not oauth_token:
+            raise VerifierError(
+                "missing CLAUDE_CODE_OAUTH_TOKEN: required when DAYDREAM_JUDGE_PROVIDER is claude-cli"
+            )
+        return ClaudeCliJudgeClient(model)
     if not model or not api_key:
         raise VerifierError("missing DAYDREAM_JUDGE_MODEL or DAYDREAM_JUDGE_API_KEY")
     if provider not in {"anthropic", "openai-compatible"}:
         raise VerifierError(
-            f"unsupported DAYDREAM_JUDGE_PROVIDER '{provider}'; expected anthropic or openai-compatible"
+            f"unsupported DAYDREAM_JUDGE_PROVIDER '{provider}'; "
+            "expected anthropic, openai-compatible, or claude-cli"
         )
     if provider == "anthropic":
         allowlist = _effective_allowlist(_ANTHROPIC_MESSAGES_URL, env)
@@ -1317,6 +1333,7 @@ def main() -> int:
             _ENV_PROVIDER,
             _ENV_MODEL,
             _ENV_API_KEY,
+            _ENV_OAUTH_TOKEN,
             _ENV_BASE_URL,
             _ENV_ALLOWED_HOSTS,
         )

--- a/daydream/benchmark/harbor/templates/tests/score_review.py
+++ b/daydream/benchmark/harbor/templates/tests/score_review.py
@@ -52,23 +52,96 @@ class _AsyncHttpClient(Protocol):
 VerifierError = verifier_core.VerifierError
 
 
-async def _claude_cli_stdout(proc: Any) -> str:
-    """Collect a finished CLI subprocess's stdout as text.
+def _terminate_proc(proc: Any) -> None:
+    """Best-effort kill of a spawned CLI child; a no-op on the seam fakes.
 
-    Real ``asyncio`` processes expose ``communicate()``; the injected test seam
-    may instead expose the captured stdout directly (as text or bytes).
+    A hung or oversized child must never outlive the verifier, so every
+    timeout/over-cap exit kills it. Kill failures are swallowed: the
+    timeout/over-cap outcome the caller is recording must not be masked.
     """
-    communicate = getattr(proc, "communicate", None)
-    if communicate is not None:
-        stdout_b, _stderr_b = await asyncio.wait_for(communicate(), timeout=_REQUEST_TIMEOUT)
-        raw = stdout_b
-    else:
-        raw = proc.stdout
-    if raw is None:
+    kill = getattr(proc, "kill", None) or getattr(proc, "terminate", None)
+    if kill is not None:
+        try:
+            kill()
+        except Exception:
+            pass
+
+
+async def _claude_cli_stdout(proc: Any) -> str:
+    """Collect a CLI subprocess's stdout as text, byte- and time-bounded.
+
+    Real ``asyncio`` processes expose ``proc.stdout`` as an incremental
+    ``StreamReader``; the injected test seam may instead expose the captured
+    stdout directly (as text or bytes). Either way the collected output is
+    size-capped at ``_RESPONSE_CAP_BYTES`` and rejected -- never truncated-and-
+    accepted, matching the HTTP clients' ``_parse_json_response`` posture -- and
+    total collection time is bounded by ``_REQUEST_TIMEOUT`` with the child
+    killed on timeout so a hung ``claude`` cannot accumulate across the retry
+    loop and the concurrency-10 fan-out.
+    """
+    stream = getattr(proc, "stdout", None)
+    if stream is None:
+        communicate = getattr(proc, "communicate", None)
+        if communicate is None:
+            return ""
+        try:
+            stream, _stderr_b = await asyncio.wait_for(
+                communicate(), timeout=_REQUEST_TIMEOUT
+            )
+        except (asyncio.TimeoutError, TimeoutError):
+            _terminate_proc(proc)
+            raise
+    if isinstance(stream, (str, bytes)):
+        raw = stream.encode("utf-8") if isinstance(stream, str) else stream
+        if len(raw) > _RESPONSE_CAP_BYTES:
+            _terminate_proc(proc)
+            raise VerifierError(
+                f"claude-cli judge output exceeds {_RESPONSE_CAP_BYTES // 1024} KiB"
+            )
+        return stream if isinstance(stream, str) else raw.decode("utf-8", errors="replace")
+    read = getattr(stream, "read", None)
+    if read is None:
         return ""
-    if isinstance(raw, bytes):
-        return raw.decode("utf-8", errors="replace")
-    return str(raw)
+    # Real asyncio subprocess: read incrementally so memory stays bounded by
+    # _RESPONSE_CAP_BYTES even while the child is still streaming, and keep the
+    # whole collection inside the shared _REQUEST_TIMEOUT budget.
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + _REQUEST_TIMEOUT
+    parts: list[bytes] = []
+    total = 0
+    while True:
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            _terminate_proc(proc)
+            raise asyncio.TimeoutError
+        try:
+            chunk = await asyncio.wait_for(read(_STDOUT_CHUNK_BYTES), timeout=remaining)
+        except (asyncio.TimeoutError, TimeoutError):
+            _terminate_proc(proc)
+            raise
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > _RESPONSE_CAP_BYTES:
+            _terminate_proc(proc)
+            raise VerifierError(
+                f"claude-cli judge output exceeds {_RESPONSE_CAP_BYTES // 1024} KiB"
+            )
+        parts.append(chunk)
+    # stdout EOF does not imply the child has exited; wait so the caller's
+    # exit-code check sees a settled process, still inside the same budget.
+    wait = getattr(proc, "wait", None)
+    if wait is not None:
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            _terminate_proc(proc)
+            raise asyncio.TimeoutError
+        try:
+            await asyncio.wait_for(wait(), timeout=remaining)
+        except (asyncio.TimeoutError, TimeoutError):
+            _terminate_proc(proc)
+            raise
+    return b"".join(parts).decode("utf-8", errors="replace")
 
 
 class _InputFileNotFound(verifier_core.VerifierError):
@@ -94,6 +167,9 @@ _REQUEST_TIMEOUT = 60.0
 # and accepted -- above these sizes; redirects are bounded; diagnostics are
 # bounded and redacted before they reach any artifact or log.
 _RESPONSE_CAP_BYTES = 256 * 1024
+# Incremental read chunk for _claude_cli_stdout: verifier memory stays bounded
+# by _RESPONSE_CAP_BYTES even while a still-streaming child is mid-output.
+_STDOUT_CHUNK_BYTES = 64 * 1024
 _REASONING_CAP_BYTES = 32 * 1024
 _MAX_REDIRECTS = 3
 _ERROR_TEXT_CAP_BYTES = 4096
@@ -592,13 +668,19 @@ class ClaudeCliJudgeClient:
     """Judge client that shells the pinned Claude Code CLI in non-interactive print mode.
 
     Invokes ``claude -p --output-format json --model <model> --max-turns 1
-    --append-system-prompt <system> <user>`` and parses the single JSON result
-    object on stdout, passing ``result`` through the strict ``parse_verdict``.
-    The subprocess is an injectable seam (``runner``, mirroring the ``http=``
-    seam on the HTTP clients) defaulting to ``asyncio.create_subprocess_exec``.
-    The OAuth token is never placed on argv; it reaches the CLI only through the
-    inherited environment. Transient failures (timeout, retryable exit codes)
-    are retried with the same bounded policy as the HTTP clients; every terminal
+    --permission-mode plan --allowedTools [] [--append-system-prompt <system>]
+    <user>`` and parses the single JSON result object on stdout, passing
+    ``result`` through the strict ``parse_verdict``. The subprocess is an
+    injectable seam (``runner``, mirroring the ``http=`` seam on the HTTP
+    clients) defaulting to ``asyncio.create_subprocess_exec``. The OAuth token
+    is never placed on argv; it reaches the CLI only through the inherited
+    environment, whose tools are denied outright so the prompt-influenced
+    agent cannot read/execute/exfiltrate through them. Print-mode output is
+    capped at ``max_tokens`` via ``CLAUDE_CODE_MAX_OUTPUT_TOKENS`` and its
+    collected stdout is byte-capped and rejected whole -- never truncated-and-
+    accepted. Transient failures (timeout, retryable exit codes) are retried
+    with the same bounded policy as the HTTP clients, and a timed-out child is
+    killed before the retry so hung processes cannot accumulate; every terminal
     failure raises ``VerifierError`` naming only the failure class — never a
     stderr echo, stack trace, or silent fallback to a partial verdict.
     """
@@ -627,14 +709,28 @@ class ClaudeCliJudgeClient:
             self.model,
             "--max-turns",
             "1",
+            # Tool-scope lockdown: the spawned CLI is a tool-capable agent
+            # running with the OAuth credential in its env, so it must not be
+            # able to read/execute/exfiltrate via tools -- especially under a
+            # prompt influenced by untrusted candidate finding text. Deny every
+            # tool explicitly and keep the session read-only.
+            "--permission-mode",
+            "plan",
+            "--allowedTools",
+            "[]",
         ]
         if system:
             argv += ["--append-system-prompt", system]
         argv.append(user)
         env = dict(os.environ)
         env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] = "1"
-        last_error = ""
+        # The CLI exposes no --max-tokens flag; print-mode output is capped via
+        # CLAUDE_CODE_MAX_OUTPUT_TOKENS so the 512-token budget the HTTP clients
+        # send in the request body is honored here too (cost symmetry), and an
+        # overlong verdict is rejected downstream, never truncated-and-accepted.
+        env["CLAUDE_CODE_MAX_OUTPUT_TOKENS"] = str(max_tokens)
         for attempt in range(_MAX_RETRIES):
+            proc = None
             try:
                 proc = await asyncio.wait_for(
                     (self.runner or self._default_runner)(argv, env),
@@ -666,10 +762,20 @@ class ClaudeCliJudgeClient:
                             parse_verdict(parsed)
                             return parsed
             except (asyncio.TimeoutError, TimeoutError):
+                # A hung child must not outlive this attempt: kill it (here, as
+                # the backstop, and inside _claude_cli_stdout) so the retry loop
+                # and the concurrency-10 fan-out never accumulate living claude
+                # processes consuming quota and egress. A spawn timeout leaves
+                # no proc handle to kill.
+                _terminate_proc(proc)
                 last_error = "claude-cli judge failed (timeout)"
             except ValueError:
-                # parse_verdict consumed a well-formed CLI result whose content
-                # was not a valid verdict: terminal, not retryable.
+                # json.loads(result) rejected the CLI result string (a
+                # JSONDecodeError, a ValueError subclass): terminal, not
+                # retryable. A well-formed CLI result whose content is not a
+                # valid verdict is rejected by parse_verdict raising
+                # VerifierError directly, which propagates raw -- both outcomes
+                # fail closed through the shared verdict contract.
                 raise VerifierError("claude-cli judge failed (invalid verdict)") from None
             if attempt < _MAX_RETRIES - 1:
                 await asyncio.sleep(2**attempt)

--- a/daydream/benchmark/harbor/templates/tests/score_review.py
+++ b/daydream/benchmark/harbor/templates/tests/score_review.py
@@ -678,8 +678,10 @@ class ClaudeCliJudgeClient:
     agent cannot read/execute/exfiltrate through them. Print-mode output is
     capped at ``max_tokens`` via ``CLAUDE_CODE_MAX_OUTPUT_TOKENS`` and its
     collected stdout is byte-capped and rejected whole -- never truncated-and-
-    accepted. Transient failures (timeout, retryable exit codes) are retried
-    with the same bounded policy as the HTTP clients, and a timed-out child is
+    accepted. Only the timeout failure class is transient and retried with the
+    same bounded policy as the HTTP clients; every other failure class (non-zero
+    exit, empty/malformed output, cli-reported error, missing result) is
+    terminal and raises on the first attempt. A timed-out child is
     killed before the retry so hung processes cannot accumulate; every terminal
     failure raises ``VerifierError`` naming only the failure class — never a
     stderr echo, stack trace, or silent fallback to a partial verdict.
@@ -694,7 +696,12 @@ class ClaudeCliJudgeClient:
             *argv,
             env=env,
             stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+            # stderr is never surfaced (the contract keeps it out of every
+            # artifact), so route it to DEVNULL: a PIPE that goes undrained
+            # would let a child writing more than the ~64 KiB pipe buffer block
+            # on the stderr write, starving stdout EOF and burning the whole
+            # _REQUEST_TIMEOUT on every call before being killed and retried.
+            stderr=asyncio.subprocess.DEVNULL,
         )
 
     async def complete_json(
@@ -729,6 +736,7 @@ class ClaudeCliJudgeClient:
         # send in the request body is honored here too (cost symmetry), and an
         # overlong verdict is rejected downstream, never truncated-and-accepted.
         env["CLAUDE_CODE_MAX_OUTPUT_TOKENS"] = str(max_tokens)
+        last_error = "claude-cli judge failed (unknown)"
         for attempt in range(_MAX_RETRIES):
             proc = None
             try:
@@ -738,29 +746,32 @@ class ClaudeCliJudgeClient:
                 )
                 stdout = await _claude_cli_stdout(proc)
                 rc = getattr(proc, "returncode", getattr(proc, "rc", 0))
+                # Terminal failure classes raise on the first attempt, mirroring
+                # the HTTP clients (a non-429 4xx and a malformed-JSON parse are
+                # never retried): a non-zero exit (expired/revoked OAuth token,
+                # refused auth), empty stdout, malformed output, a cli-reported
+                # error, and a missing result will not resolve with retries --
+                # only the timeout class below is transient.
                 if rc != 0:
-                    last_error = f"claude-cli judge failed (exit {rc})"
-                elif not stdout:
-                    last_error = "claude-cli judge failed (empty output)"
-                else:
-                    try:
-                        payload = json.loads(stdout)
-                    except (ValueError, TypeError):
-                        payload = None
-                    if not isinstance(payload, dict):
-                        last_error = "claude-cli judge failed (malformed output)"
-                    elif payload.get("is_error"):
-                        last_error = "claude-cli judge failed (cli reported error)"
-                    else:
-                        result = payload.get("result")
-                        if not isinstance(result, str) or not result.strip():
-                            last_error = "claude-cli judge failed (missing result)"
-                        else:
-                            parsed: dict[str, Any] = json.loads(result)
-                            # Strict validation via the shared parse_verdict;
-                            # return the validated dict (judge_pairs re-parses).
-                            parse_verdict(parsed)
-                            return parsed
+                    raise VerifierError(f"claude-cli judge failed (exit {rc})")
+                if not stdout:
+                    raise VerifierError("claude-cli judge failed (empty output)")
+                try:
+                    payload = json.loads(stdout)
+                except (ValueError, TypeError):
+                    payload = None
+                if not isinstance(payload, dict):
+                    raise VerifierError("claude-cli judge failed (malformed output)")
+                if payload.get("is_error"):
+                    raise VerifierError("claude-cli judge failed (cli reported error)")
+                result = payload.get("result")
+                if not isinstance(result, str) or not result.strip():
+                    raise VerifierError("claude-cli judge failed (missing result)")
+                parsed: dict[str, Any] = json.loads(result)
+                # Strict validation via the shared parse_verdict;
+                # return the validated dict (judge_pairs re-parses).
+                parse_verdict(parsed)
+                return parsed
             except (asyncio.TimeoutError, TimeoutError):
                 # A hung child must not outlive this attempt: kill it (here, as
                 # the backstop, and inside _claude_cli_stdout) so the retry loop
@@ -1351,16 +1362,20 @@ def _build_client(env: dict[str, Any]) -> Any:
     The ``anthropic`` and ``openai-compatible`` providers require an API key,
     resolve a base URL, and validate the initial request URL against the
     effective judge-host allowlist at build time; the ``claude-cli`` provider
-    instead requires a non-empty ``CLAUDE_CODE_OAUTH_TOKEN`` and has no HTTP
-    base URL to validate.
+    instead requires a non-empty ``CLAUDE_CODE_OAUTH_TOKEN`` and validates its
+    resolved judge host (``api.anthropic.com``) against the same allowlist.
     """
     provider = env.get(_ENV_PROVIDER) or ""
     model = env.get(_ENV_MODEL)
     api_key = env.get(_ENV_API_KEY)
     if provider == "claude-cli":
-        # OAuth-token auth via the Claude Code CLI: no API key, no base URL,
-        # no allowlist validation (verified egress is intentionally unavailable
-        # on this path; trusted egress is enforced by the container env set).
+        # OAuth-token auth via the Claude Code CLI: no API key, no base URL.
+        # Egress is still bounded: the CLI's judge host resolves to
+        # api.anthropic.com (the same host _judge_host_from_env and the run
+        # preflight allowlist-check), so it is validated against the effective
+        # allowlist at build time -- a container allowlist that omits it fails
+        # closed before any trial instead of at the first out-of-allowlist CLI
+        # call mid-trial.
         oauth_token = env.get(_ENV_OAUTH_TOKEN)
         if not model:
             raise VerifierError("missing DAYDREAM_JUDGE_MODEL")
@@ -1368,6 +1383,9 @@ def _build_client(env: dict[str, Any]) -> Any:
             raise VerifierError(
                 "missing CLAUDE_CODE_OAUTH_TOKEN: required when DAYDREAM_JUDGE_PROVIDER is claude-cli"
             )
+        _validate_base_url(
+            _ANTHROPIC_MESSAGES_URL, _effective_allowlist(_ANTHROPIC_MESSAGES_URL, env)
+        )
         return ClaudeCliJudgeClient(model)
     if not model or not api_key:
         raise VerifierError("missing DAYDREAM_JUDGE_MODEL or DAYDREAM_JUDGE_API_KEY")

--- a/daydream/benchmark/harbor/templates/tests/score_review.py
+++ b/daydream/benchmark/harbor/templates/tests/score_review.py
@@ -1341,10 +1341,12 @@ def main() -> int:
     try:
         client = _build_client(env)
     except VerifierError as exc:
-        if env.get(_ENV_MODEL) and env.get(_ENV_API_KEY):
+        provider = env.get(_ENV_PROVIDER) or _DEFAULT_PROVIDER
+        if env.get(_ENV_MODEL) and (env.get(_ENV_API_KEY) or provider == "claude-cli"):
             # Fail-closed provider/host rejection: a typed bounded diagnostic
             # artifact naming only the rejected form -- never a barren exit.
-            provider = env.get(_ENV_PROVIDER) or _DEFAULT_PROVIDER
+            # claude-cli has no API key; its typed diagnostic is the OAuth
+            # token check, so the provider branch suffices for it.
             model = env.get(_ENV_MODEL) or ""
             reward = _write_error_artifact(
                 out_dir, provider, model, {"requests": 0}, [_bounded_error(str(exc))], 0

--- a/daydream/benchmark/harbor/templates/tests/score_review.py
+++ b/daydream/benchmark/harbor/templates/tests/score_review.py
@@ -2,14 +2,15 @@
 
 Stdlib + httpx only. Never imports daydream: this file must run unchanged
 inside a compiled-grade verifier image that has no daydream wheel. It wires a
-bounded per-pair judge prompt, two isolated external judge clients (Anthropic
-Messages + OpenAI-compatible) behind one ``complete_json`` seam, strict verdict
-parsing, a shared retry/redirect/timeout policy, a concurrency-10 runner, and
-``run_verifier`` which writes ``reward.json`` / ``reward-details.json``
-atomically.
+bounded per-pair judge prompt, three isolated external judge clients (Anthropic
+Messages + OpenAI-compatible + Claude Code CLI) behind one ``complete_json``
+seam, strict verdict parsing, a shared retry/redirect/timeout policy, a
+concurrency-10 runner, and ``run_verifier`` which writes ``reward.json`` /
+``reward-details.json`` atomically.
 
-The external judge surface is fail-closed and bounded: exactly
-``anthropic | openai-compatible`` providers are accepted, the judge host must
+The external judge surface is fail-closed and bounded: the
+``anthropic | openai-compatible | claude-cli`` providers are accepted, the judge
+host must
 sit in the configured allowlist (``DAYDREAM_JUDGE_ALLOWED_HOSTS``; own-host
 fallback when absent), redirects are bounded to ``_MAX_REDIRECTS``
 credential-preserving same-origin hops whose targets are re-validated against
@@ -49,6 +50,25 @@ class _AsyncHttpClient(Protocol):
 
 
 VerifierError = verifier_core.VerifierError
+
+
+async def _claude_cli_stdout(proc: Any) -> str:
+    """Collect a finished CLI subprocess's stdout as text.
+
+    Real ``asyncio`` processes expose ``communicate()``; the injected test seam
+    may instead expose the captured stdout directly (as text or bytes).
+    """
+    communicate = getattr(proc, "communicate", None)
+    if communicate is not None:
+        stdout_b, _stderr_b = await asyncio.wait_for(communicate(), timeout=_REQUEST_TIMEOUT)
+        raw = stdout_b
+    else:
+        raw = proc.stdout
+    if raw is None:
+        return ""
+    if isinstance(raw, bytes):
+        return raw.decode("utf-8", errors="replace")
+    return str(raw)
 
 
 class _InputFileNotFound(verifier_core.VerifierError):
@@ -566,6 +586,94 @@ class AnthropicJudgeClient:
                 content=_anthropic_text,
                 allowlist=effective,
             )
+
+
+class ClaudeCliJudgeClient:
+    """Judge client that shells the pinned Claude Code CLI in non-interactive print mode.
+
+    Invokes ``claude -p --output-format json --model <model> --max-turns 1
+    --append-system-prompt <system> <user>`` and parses the single JSON result
+    object on stdout, passing ``result`` through the strict ``parse_verdict``.
+    The subprocess is an injectable seam (``runner``, mirroring the ``http=``
+    seam on the HTTP clients) defaulting to ``asyncio.create_subprocess_exec``.
+    The OAuth token is never placed on argv; it reaches the CLI only through the
+    inherited environment. Transient failures (timeout, retryable exit codes)
+    are retried with the same bounded policy as the HTTP clients; every terminal
+    failure raises ``VerifierError`` naming only the failure class — never a
+    stderr echo, stack trace, or silent fallback to a partial verdict.
+    """
+
+    def __init__(self, model: str, *, runner: Any = None) -> None:
+        self.model = model
+        self.runner = runner
+
+    def _default_runner(self, argv: list[str], env: dict[str, str]) -> Any:
+        return asyncio.create_subprocess_exec(
+            *argv,
+            env=env,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+    async def complete_json(
+        self, *, user: str, system: str = "", max_tokens: int = 512
+    ) -> dict[str, Any]:
+        argv = [
+            "claude",
+            "-p",
+            "--output-format",
+            "json",
+            "--model",
+            self.model,
+            "--max-turns",
+            "1",
+        ]
+        if system:
+            argv += ["--append-system-prompt", system]
+        argv.append(user)
+        env = dict(os.environ)
+        env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] = "1"
+        last_error = ""
+        for attempt in range(_MAX_RETRIES):
+            try:
+                proc = await asyncio.wait_for(
+                    (self.runner or self._default_runner)(argv, env),
+                    timeout=_REQUEST_TIMEOUT,
+                )
+                stdout = await _claude_cli_stdout(proc)
+                rc = getattr(proc, "returncode", getattr(proc, "rc", 0))
+                if rc != 0:
+                    last_error = f"claude-cli judge failed (exit {rc})"
+                elif not stdout:
+                    last_error = "claude-cli judge failed (empty output)"
+                else:
+                    try:
+                        payload = json.loads(stdout)
+                    except (ValueError, TypeError):
+                        payload = None
+                    if not isinstance(payload, dict):
+                        last_error = "claude-cli judge failed (malformed output)"
+                    elif payload.get("is_error"):
+                        last_error = "claude-cli judge failed (cli reported error)"
+                    else:
+                        result = payload.get("result")
+                        if not isinstance(result, str) or not result.strip():
+                            last_error = "claude-cli judge failed (missing result)"
+                        else:
+                            parsed: dict[str, Any] = json.loads(result)
+                            # Strict validation via the shared parse_verdict;
+                            # return the validated dict (judge_pairs re-parses).
+                            parse_verdict(parsed)
+                            return parsed
+            except (asyncio.TimeoutError, TimeoutError):
+                last_error = "claude-cli judge failed (timeout)"
+            except ValueError:
+                # parse_verdict consumed a well-formed CLI result whose content
+                # was not a valid verdict: terminal, not retryable.
+                raise VerifierError("claude-cli judge failed (invalid verdict)") from None
+            if attempt < _MAX_RETRIES - 1:
+                await asyncio.sleep(2**attempt)
+        raise VerifierError(last_error or "claude-cli judge failed (unknown)")
 
 
 _OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
@@ -1131,10 +1239,11 @@ def run_verifier(
 def _build_client(env: dict[str, Any]) -> Any:
     """Build the judge client from the DAYDREAM_JUDGE_* env surface.
 
-    Provider is fail-closed: exactly ``anthropic`` | ``openai-compatible`` is
-    accepted when explicit; absent or unsupported values raise before any
-    request. The provider's base URL is resolved and the initial request URL is
-    validated against the effective judge-host allowlist at build time.
+    Provider is fail-closed: the ``anthropic`` | ``openai-compatible`` |
+    ``claude-cli`` set is accepted when explicit; absent or unsupported values
+    raise before any request. The provider's base URL is resolved and the
+    initial request URL is validated against the effective judge-host allowlist
+    at build time (the claude-cli provider has no HTTP base URL to validate).
     """
     provider = env.get(_ENV_PROVIDER) or ""
     model = env.get(_ENV_MODEL)

--- a/tests/test_benchmark_calibrate.py
+++ b/tests/test_benchmark_calibrate.py
@@ -103,9 +103,12 @@ def test_judge_host_resolved_from_env() -> None:
     assert _judge_host_from_env({"DAYDREAM_JUDGE_PROVIDER": "openai-compatible",
                                  "DAYDREAM_JUDGE_BASE_URL": "http://127.0.0.1:9"}) == "127.0.0.1"
     assert _judge_host_from_env({"DAYDREAM_JUDGE_PROVIDER": "anthropic"}) == "api.anthropic.com"
+    assert _judge_host_from_env({"DAYDREAM_JUDGE_PROVIDER": "claude-cli"}) == "api.anthropic.com"
     with pytest.raises(ValueError, match="missing DAYDREAM_JUDGE_PROVIDER"):
         _judge_host_from_env({})
     with pytest.raises(ValueError, match="unsupported DAYDREAM_JUDGE_PROVIDER"):
+        _judge_host_from_env({"DAYDREAM_JUDGE_PROVIDER": "bogus"})
+    with pytest.raises(ValueError, match="expected anthropic, openai-compatible, or claude-cli"):
         _judge_host_from_env({"DAYDREAM_JUDGE_PROVIDER": "bogus"})
     with pytest.raises(ValueError, match="missing DAYDREAM_JUDGE_BASE_URL"):
         _judge_host_from_env({

--- a/tests/test_benchmark_harbor_agent.py
+++ b/tests/test_benchmark_harbor_agent.py
@@ -523,6 +523,22 @@ def test_build_child_env_keeps_anthropic_for_claude_scrubs_for_pi() -> None:
     assert child_pi["DAYDREAM_REVIEW_API_KEY"] == "review-key"
 
 
+def test_build_child_env_bans_claude_code_prefix() -> None:
+    from daydream.benchmark.harbor.agent import build_child_env
+
+    parent = {
+        "CLAUDE_CODE_OAUTH_TOKEN": "oauth-tok",
+        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+        "DAYDREAM_REVIEW_BACKEND": "pi",
+        "PATH": "/usr/bin",
+        "HOME": "/root",
+    }
+    child = build_child_env(parent, backend="pi")
+    assert not any(k.startswith("CLAUDE_CODE_") for k in child)
+    child_claude = build_child_env(parent, backend="claude")
+    assert not any(k.startswith("CLAUDE_CODE_") for k in child_claude)
+
+
 def test_agent_run_refuses_unsupported_backend_and_invokes_entrypoint(tmp_path: Path) -> None:
     import pytest
 

--- a/tests/test_benchmark_harbor_package.py
+++ b/tests/test_benchmark_harbor_package.py
@@ -278,6 +278,10 @@ def test_render_job_config_matches_plan_s8_and_oracle_differs() -> None:
     assert job["metrics"] == [{"type": "uv-script", "kwargs": {"script_path": "metric.py"}}]
     assert "DAYDREAM_JUDGE_API_KEY" in job["verifier"]["env"]
     assert job["verifier"]["env"]["DAYDREAM_JUDGE_PROVIDER"] == "${DAYDREAM_JUDGE_PROVIDER}"
+    assert job["verifier"]["env"]["CLAUDE_CODE_OAUTH_TOKEN"] == "${CLAUDE_CODE_OAUTH_TOKEN}"
+    assert job["verifier"]["env"]["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] == (
+        "${CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC:-1}"
+    )
 
     oracle = yaml.safe_load(pkg.render_job_config(oracle=True))
     assert oracle["agents"] == [{"name": "oracle"}]

--- a/tests/test_benchmark_harbor_package.py
+++ b/tests/test_benchmark_harbor_package.py
@@ -263,7 +263,10 @@ def test_verifier_dockerfile_ships_pinned_node_and_claude_cli() -> None:
 
     text = pkg.render_verifier_dockerfile(base_image=pkg.VERIFIER_BASE_IMAGE).decode()
     assert "node-v22." in text                     # version-pinned Node tarball
-    assert "@anthropic-ai/claude-code@" in text    # version-pinned CLI install
+    # The CLI installs via `npm ci` from the embedded package-lock.json, so
+    # every transitive is version- and integrity-pinned (no registry re-resolution).
+    assert "npm ci" in text and "package-lock.json" in text
+    assert "@anthropic-ai/claude-code" in text and "2.1.250" in text
     assert "ENTRYPOINT" not in text and "CMD" not in text and "/verifier" not in text  # guard set still clean
     assert "httpx==0.28.1" in text and "httpx>=" not in text
 

--- a/tests/test_benchmark_harbor_package.py
+++ b/tests/test_benchmark_harbor_package.py
@@ -258,6 +258,16 @@ def test_verifier_dockerfile_is_entrypoint_free_and_digest_pinned() -> None:
     assert "httpx" in text and "httpx>=" not in text and "httpx==0.28.1" in text
 
 
+def test_verifier_dockerfile_ships_pinned_node_and_claude_cli() -> None:
+    from daydream.benchmark.harbor import package as pkg
+
+    text = pkg.render_verifier_dockerfile(base_image=pkg.VERIFIER_BASE_IMAGE).decode()
+    assert "node-v22." in text                     # version-pinned Node tarball
+    assert "@anthropic-ai/claude-code@" in text    # version-pinned CLI install
+    assert "ENTRYPOINT" not in text and "CMD" not in text and "/verifier" not in text  # guard set still clean
+    assert "httpx==0.28.1" in text and "httpx>=" not in text
+
+
 def test_render_job_config_matches_plan_s8_and_oracle_differs() -> None:
     import yaml
 

--- a/tests/test_benchmark_run.py
+++ b/tests/test_benchmark_run.py
@@ -195,7 +195,10 @@ def test_spend_summary_prints_claude_cli_judge_host(tmp_path: Path) -> None:
     text = run_mod._pre_run_summary(
         _ws(tmp_path), env=_env(DAYDREAM_JUDGE_PROVIDER="claude-cli")
     )
-    assert "api.anthropic.com" in text
+    # exact-host match avoids CodeQL py/incomplete-url-substring-sanitization
+    host_lines = [ln for ln in text.splitlines() if ln.strip().startswith("judge host:")]
+    assert len(host_lines) == 1
+    assert host_lines[0].split(":", 1)[1].strip() == "api.anthropic.com"
 
 
 def test_preflight_blocks_judge_host_outside_allowlist(tmp_path: Path) -> None:

--- a/tests/test_benchmark_run.py
+++ b/tests/test_benchmark_run.py
@@ -173,6 +173,31 @@ def test_preflight_requires_explicit_judge_endpoint(tmp_path: Path) -> None:
     assert any("missing DAYDREAM_JUDGE_BASE_URL" in error for error in errs)
 
 
+def test_preflight_claude_cli_judge_needs_no_base_url(tmp_path: Path) -> None:
+    """claude-cli resolves its judge host (api.anthropic.com) without a base URL."""
+    import daydream.benchmark.harbor.run as run_mod
+
+    ws = _ws(tmp_path, judge_allowed_hosts=["api.anthropic.com"])
+    _seed_compiled_task(ws, reviewer=["review.example"], judge=["api.anthropic.com"])
+    errs = run_mod._preflight(
+        ws,
+        oracle=True,
+        env=_env(DAYDREAM_JUDGE_PROVIDER="claude-cli", DAYDREAM_JUDGE_BASE_URL=None),
+        docker_ok=_docker_ok,
+    )
+    assert not any("cannot resolve judge host" in e for e in errs)
+    assert errs == []
+
+
+def test_spend_summary_prints_claude_cli_judge_host(tmp_path: Path) -> None:
+    import daydream.benchmark.harbor.run as run_mod
+
+    text = run_mod._pre_run_summary(
+        _ws(tmp_path), env=_env(DAYDREAM_JUDGE_PROVIDER="claude-cli")
+    )
+    assert "api.anthropic.com" in text
+
+
 def test_preflight_blocks_judge_host_outside_allowlist(tmp_path: Path) -> None:
     import daydream.benchmark.harbor.run as run_mod
 

--- a/tests/test_benchmark_verifier_judge.py
+++ b/tests/test_benchmark_verifier_judge.py
@@ -1542,3 +1542,74 @@ async def test_claude_cli_client_shells_subprocess_and_returns_verdict(sr_module
     argv = calls[0][0][0]
     assert argv[0] == "claude" and "--output-format" in argv and "json" in argv
     assert "--model" in argv and "claude-x" in argv
+    # Tool-scope lockdown: the spawned CLI carries the OAuth credential in its
+    # env, so tools must be denied outright -- no permission prompts, no read/
+    # execute surface for a prompt influenced by untrusted candidate text.
+    assert "--permission-mode" in argv and "plan" in argv
+    assert "--allowedTools" in argv and "[]" in argv
+    # The 512-token output budget maps onto the CLI via CLAUDE_CODE_MAX_OUTPUT_TOKENS
+    # (the CLI exposes no --max-tokens flag), matching the HTTP clients' request cap.
+    assert calls[0][0][1]["CLAUDE_CODE_MAX_OUTPUT_TOKENS"] == "512"
+
+
+@pytest.mark.asyncio
+async def test_claude_cli_timeout_kills_child_every_attempt(
+    sr_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sr = sr_module
+    kills: list[int] = []
+
+    class HangingProc:
+        """A spawned child that never produces output; kill() records the call."""
+
+        def __init__(self) -> None:
+            self.stdout = self  # the read() below doubles as the StreamReader seam
+
+        async def read(self, n: int) -> bytes:
+            await asyncio.sleep(3600)  # hang until the wait_for deadline kills us
+            raise AssertionError("unreachable: the deadline kills this read first")
+
+        async def wait(self) -> None:
+            await asyncio.sleep(3600)
+
+        def kill(self) -> None:
+            kills.append(1)
+
+    async def fake_run(*args: Any, **kwargs: Any) -> Any:
+        return HangingProc()
+
+    monkeypatch.setattr(sr, "_REQUEST_TIMEOUT", 0.05)
+    client = sr.ClaudeCliJudgeClient(model="m", runner=fake_run)
+    with pytest.raises(sr.VerifierError) as e:
+        await client.complete_json(user="u")
+    assert "timeout" in str(e.value)
+    # Every hung attempt kills the child (once inside _claude_cli_stdout and
+    # again by the caller's backstop), so a retry or the next concurrent pair
+    # never sees a leftover claude process consuming quota/egress.
+    assert len(kills) == sr._MAX_RETRIES * 2
+
+
+@pytest.mark.asyncio
+async def test_claude_cli_oversize_stdout_is_rejected_not_truncated(sr_module: Any) -> None:
+    sr = sr_module
+    oversized = "x" * (sr._RESPONSE_CAP_BYTES + 1)
+    client = sr.ClaudeCliJudgeClient(model="m", runner=_fake_cli_runner(oversized))
+    with pytest.raises(sr.VerifierError) as e:
+        await client.complete_json(user="u")
+    assert "exceeds" in str(e.value) and "KiB" in str(e.value)
+    assert len(client.runner.calls) == 1  # terminal -- never retried, never truncated
+
+
+@pytest.mark.asyncio
+async def test_claude_cli_parse_verdict_rejection_propagates_raw(sr_module: Any) -> None:
+    sr = sr_module
+    client = sr.ClaudeCliJudgeClient(model="m", runner=_fake_cli_runner(
+        json.dumps({"is_error": False, "type": "result",
+                    "result": '{"match": "yes", "confidence": 0.9, "reasoning": "r"}'})))
+    with pytest.raises(sr.VerifierError) as e:
+        await client.complete_json(user="u")
+    # parse_verdict raises VerifierError (not ValueError), so its bounded parse
+    # message propagates raw instead of being re-wrapped as (invalid verdict).
+    assert "match" in str(e.value)
+    assert "invalid verdict" not in str(e.value)
+    assert len(client.runner.calls) == 1

--- a/tests/test_benchmark_verifier_judge.py
+++ b/tests/test_benchmark_verifier_judge.py
@@ -552,6 +552,17 @@ def test_provider_selection_claude_cli_relaxes_api_key_only(sr_module: Any, monk
     client = sr._build_client({**base, "CLAUDE_CODE_OAUTH_TOKEN": "tok"})
     assert isinstance(client, sr.ClaudeCliJudgeClient)          # no API key required
 
+    # Egress is still bounded for the CLI provider: api.anthropic.com (the
+    # resolved judge host) is checked against the effective allowlist at build
+    # time, same fail-closed timing as the HTTP branches -- a container
+    # allowlist omitting it fails before any trial, not mid-trial.
+    with pytest.raises(sr.VerifierError, match="not in the verifier allowlist"):
+        sr._build_client({**base, "CLAUDE_CODE_OAUTH_TOKEN": "tok",
+                          "DAYDREAM_JUDGE_ALLOWED_HOSTS": "judge.example"})
+    ok = sr._build_client({**base, "CLAUDE_CODE_OAUTH_TOKEN": "tok",
+                           "DAYDREAM_JUDGE_ALLOWED_HOSTS": "api.anthropic.com"})
+    assert isinstance(ok, sr.ClaudeCliJudgeClient)
+
     with pytest.raises(sr.VerifierError, match="CLAUDE_CODE_OAUTH_TOKEN"):
         sr._build_client(base)                                   # missing token -> typed diagnostic
     with pytest.raises(sr.VerifierError, match="CLAUDE_CODE_OAUTH_TOKEN"):
@@ -869,12 +880,14 @@ async def test_both_providers_produce_identical_verdicts_and_errors(sr_module: A
     c = await cli.complete_json(user="u", system="s", max_tokens=64)
     assert c == {"match": True, "confidence": 0.9, "reasoning": "same"}
 
-    # Identical bounded retry count before the terminal VerifierError: a runner
-    # that always exits nonzero is retried _MAX_RETRIES times like a 503.
+    # Consistent with the HTTP clients (a non-429 4xx is terminal, not
+    # retryable), a runner that exits nonzero is a terminal failure: the
+    # VerifierError is raised on the first attempt, never retried like a 503.
     failing = sr.ClaudeCliJudgeClient(model="m", runner=_fake_cli_runner("", rc=1))
-    with pytest.raises(sr.VerifierError):
+    with pytest.raises(sr.VerifierError) as e:
         await failing.complete_json(user="u", system="s", max_tokens=64)
-    assert len(failing.runner.calls) == 3
+    assert "exit 1" in str(e.value)
+    assert len(failing.runner.calls) == 1
 
 
 def test_escape_neutralizes_all_four_delimiters_in_both_roles(sr_module: Any) -> None:
@@ -1613,3 +1626,185 @@ async def test_claude_cli_parse_verdict_rejection_propagates_raw(sr_module: Any)
     assert "match" in str(e.value)
     assert "invalid verdict" not in str(e.value)
     assert len(client.runner.calls) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "stdout_arg,needle",
+    [
+        ("", "empty output"),                                         # empty stdout
+        ("not json at all", "malformed output"),                      # malformed JSON
+        (json.dumps({"is_error": True, "type": "error"}), "cli reported error"),
+        (json.dumps({"is_error": False, "type": "result"}), "missing result"),
+    ],
+)
+async def test_claude_cli_terminal_failures_raise_immediately(
+    sr_module: Any, stdout_arg: str, needle: str
+) -> None:
+    """Non-timeout failure classes are terminal, never retried like a timeout.
+
+    rc != 0 is covered by ``test_both_providers_produce_identical_verdicts_and_errors``;
+    here the remaining terminal classes -- empty stdout, malformed output,
+    cli-reported error, missing result -- each raise VerifierError on the first
+    attempt instead of riding the 3-attempt backoff loop reserved for the
+    transient timeout class."""
+    sr = sr_module
+    client = sr.ClaudeCliJudgeClient(model="m", runner=_fake_cli_runner(stdout_arg))
+    with pytest.raises(sr.VerifierError) as e:
+        await client.complete_json(user="u")
+    assert needle in str(e.value)
+    assert len(client.runner.calls) == 1  # terminal -- no retry, no backoff
+
+
+@pytest.mark.asyncio
+async def test_claude_cli_streaming_oversize_kills_child(sr_module: Any) -> None:
+    """Streaming-path over-cap kill: mid-stream totals past _RESPONSE_CAP_BYTES.
+
+    Unlike the str-seam oversize test, this drives the real incremental
+    ``StreamReader`` loop: a chunk at a time is accumulated, and the moment the
+    running total exceeds the cap the child is killed and the output rejected --
+    never read to completion and truncated-and-accepted."""
+    sr = sr_module
+    killed: list[int] = []
+
+    class OverflowStream:
+        def __init__(self) -> None:
+            self.stdout = self  # StreamReader-shaped: read() feeds the loop
+
+        async def read(self, n: int) -> bytes:
+            size = int(sr._STDOUT_CHUNK_BYTES)
+            return b"x" * size  # never EOF; total grows past the cap
+
+        async def wait(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            killed.append(1)
+
+    async def fake_run(*args: Any, **kwargs: Any) -> Any:
+        return OverflowStream()
+
+    client = sr.ClaudeCliJudgeClient(model="m", runner=fake_run)
+    with pytest.raises(sr.VerifierError) as e:
+        await client.complete_json(user="u")
+    assert "exceeds" in str(e.value) and "KiB" in str(e.value)
+    # Killed exactly once, inside _claude_cli_stdout: the VerifierError is
+    # terminal so the caller's timeout backstop is never reached.
+    assert len(killed) == 1
+
+
+@pytest.mark.asyncio
+async def test_claude_cli_post_eof_wait_settles(sr_module: Any) -> None:
+    """The post-EOF ``wait()`` settle returns the collected verdict, no kill.
+
+    stdout EOF does not imply the child exited; the streaming loop must still
+    await ``wait()`` inside the same budget so the caller's exit-code check
+    sees a settled process."""
+    sr = sr_module
+    settled: list[int] = []
+
+    class SettlingProc:
+        def __init__(self) -> None:
+            self.stdout = self
+            self.eof = False
+
+        async def read(self, n: int) -> bytes:
+            if self.eof:
+                return b""  # EOF breaks the incremental loop
+            self.eof = True
+            return json.dumps({
+                "is_error": False, "subtype": "success", "type": "result",
+                "result": '{"match": true, "confidence": 0.9, "reasoning": "same"}',
+            }).encode("utf-8")
+
+        async def wait(self) -> None:
+            settled.append(1)  # reached only after stdout EOF
+
+        def kill(self) -> None:
+            raise AssertionError("a settled child must never be killed")
+
+    async def fake_run(*args: Any, **kwargs: Any) -> Any:
+        return SettlingProc()
+
+    client = sr.ClaudeCliJudgeClient(model="m", runner=fake_run)
+    raw = await client.complete_json(user="u")
+    assert raw == {"match": True, "confidence": 0.9, "reasoning": "same"}
+    assert len(settled) == 1
+
+
+@pytest.mark.asyncio
+async def test_claude_cli_post_eof_wait_timeout_kills_child(
+    sr_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The post-EOF ``wait()`` settle past the deadline is killed, then retried.
+
+    A child whose stdout reached EOF but that never exits (e.g. blocked writing
+    to an undrained stderr pipe) must not burn the whole deadline silently: the
+    wait() settle inherits the timeout, the child is killed, and the timeout
+    retry loop proceeds."""
+    sr = sr_module
+    killed: list[int] = []
+
+    class StdoutEofThenWaitHangs:
+        def __init__(self) -> None:
+            self.stdout = self
+            self.eof = False
+
+        async def read(self, n: int) -> bytes:
+            if self.eof:
+                return b""
+            self.eof = True
+            return json.dumps({
+                "is_error": False, "subtype": "success", "type": "result",
+                "result": '{"match": true, "confidence": 0.9, "reasoning": "same"}',
+            }).encode("utf-8")
+
+        async def wait(self) -> None:
+            await asyncio.sleep(3600)  # child never settles
+
+        def kill(self) -> None:
+            killed.append(1)
+
+    async def fake_run(*args: Any, **kwargs: Any) -> Any:
+        return StdoutEofThenWaitHangs()
+
+    monkeypatch.setattr(sr, "_REQUEST_TIMEOUT", 0.05)
+    client = sr.ClaudeCliJudgeClient(model="m", runner=fake_run)
+    with pytest.raises(sr.VerifierError) as e:
+        await client.complete_json(user="u")
+    assert "timeout" in str(e.value)
+    # Killed in _claude_cli_stdout's wait() deadline path and again by the
+    # caller's backstop on each of the _MAX_RETRIES attempts -- mirrors the
+    # hanging-read timeout test.
+    assert len(killed) == sr._MAX_RETRIES * 2
+
+
+@pytest.mark.asyncio
+async def test_claude_cli_communicate_only_fallback(sr_module: Any) -> None:
+    """communicate()-only seam: no stdout attribute drains via communicate().
+
+    Exercises the fallback that processes with no exposed ``stdout`` stream
+    (both real pipes closed into one ``communicate()``) take: communicate()
+    drains stdout *and* stderr together, so the stderr pipe can never block the
+    parent regardless of volume."""
+    sr = sr_module
+    seen: list[tuple[bytes, bytes]] = []
+
+    class CommunicatingProc:
+        async def communicate(self) -> tuple[bytes, bytes]:
+            out = json.dumps({
+                "is_error": False, "subtype": "success", "type": "result",
+                "result": '{"match": true, "confidence": 0.9, "reasoning": "same"}',
+            }).encode("utf-8")
+            seen.append((out, b""))
+            return out, b""
+
+    async def fake_run(*args: Any, **kwargs: Any) -> Any:
+        return CommunicatingProc()
+
+    client = sr.ClaudeCliJudgeClient(model="m", runner=fake_run)
+    raw = await client.complete_json(user="u")
+    assert raw == {"match": True, "confidence": 0.9, "reasoning": "same"}
+    assert len(seen) == 1
+    assert seen[0][1] == b""  # stderr is drained by communicate, never blocks
+

--- a/tests/test_benchmark_verifier_judge.py
+++ b/tests/test_benchmark_verifier_judge.py
@@ -1436,3 +1436,31 @@ def test_run_verifier_malformed_judge_output_is_unscored(sr_module: Any, tmp_pat
     assert not (out / "reward.json").exists()
     details = json.loads((out / "reward-details.json").read_text())
     assert len(details["errors"]) >= 1
+
+
+@pytest.mark.asyncio
+async def test_claude_cli_client_shells_subprocess_and_returns_verdict(sr_module: Any) -> None:
+    sr = sr_module
+    calls = []
+
+    class FakeProc:
+        def __init__(self) -> None:
+            self.args_seen = None
+        # returncode 0, stdout = one JSON line with the verdict in "result"
+        rc = 0
+        stdout = json.dumps({
+            "is_error": False, "subtype": "success", "type": "result",
+            "result": '{"match": true, "confidence": 0.9, "reasoning": "same"}',
+        })
+        stderr = ""
+
+    async def fake_run(*args: Any, **kwargs: Any) -> Any:
+        calls.append((args, kwargs))
+        return FakeProc()
+
+    client = sr.ClaudeCliJudgeClient(model="claude-x", runner=fake_run)
+    raw = await client.complete_json(user="<prompt>", system="sys", max_tokens=512)
+    assert raw == {"match": True, "confidence": 0.9, "reasoning": "same"}
+    argv = calls[0][0][0]
+    assert argv[0] == "claude" and "--output-format" in argv and "json" in argv
+    assert "--model" in argv and "claude-x" in argv

--- a/tests/test_benchmark_verifier_judge.py
+++ b/tests/test_benchmark_verifier_judge.py
@@ -874,7 +874,7 @@ async def test_both_providers_produce_identical_verdicts_and_errors(sr_module: A
     failing = sr.ClaudeCliJudgeClient(model="m", runner=_fake_cli_runner("", rc=1))
     with pytest.raises(sr.VerifierError):
         await failing.complete_json(user="u", system="s", max_tokens=64)
-    assert len(failing.runner.calls) == 3  # type: ignore[attr-defined]
+    assert len(failing.runner.calls) == 3
 
 
 def test_escape_neutralizes_all_four_delimiters_in_both_roles(sr_module: Any) -> None:

--- a/tests/test_benchmark_verifier_judge.py
+++ b/tests/test_benchmark_verifier_judge.py
@@ -1,6 +1,7 @@
 """Fake-HTTP tests for the isolated Harbor verifier entry (``templates/tests/score_review.py``).
 
-Exercises the self-contained judge clients (Anthropic + OpenAI-compatible),
+Exercises the self-contained judge clients (Anthropic, OpenAI-compatible,
+Claude Code CLI),
 the bounded prompt renderer, strict verdict parsing, shared retry/redirect
 policy, concurrency/pair-cap runner, fail-whole-task error path, provider
 selection, oracle parity, and end-to-end ``run_verifier`` — all with an
@@ -805,6 +806,23 @@ def test_shipped_gold_and_oracle_fixtures_validate_and_score_reward_1(
 
 
 
+def _fake_cli_runner(stdout_arg: str, rc: int = 0) -> Any:
+    """Fake subprocess seam for ``ClaudeCliJudgeClient``: fixed returncode + stdout."""
+
+    class FakeProc:
+        returncode = rc
+        stdout = stdout_arg  # class bodies cannot see the enclosing function scope
+
+    calls: list[list[Any]] = []
+
+    async def runner(argv: Any, env: Any) -> Any:
+        calls.append([argv, env])
+        return FakeProc()
+
+    runner.calls = calls  # type: ignore[attr-defined]
+    return runner
+
+
 @pytest.mark.asyncio
 async def test_both_providers_produce_identical_verdicts_and_errors(sr_module: Any) -> None:
     sr = sr_module
@@ -842,6 +860,21 @@ async def test_both_providers_produce_identical_verdicts_and_errors(sr_module: A
         with pytest.raises(sr.VerifierError):
             await provider.complete_json(user="u", system="s", max_tokens=64)
         assert len(calls) == 3
+
+    # Third producer, identical verdict: the claude-cli client through the
+    # injectable subprocess seam parses the same verdict JSON.
+    cli = sr.ClaudeCliJudgeClient(model="m", runner=_fake_cli_runner(
+        json.dumps({"is_error": False, "subtype": "success", "type": "result",
+                    "result": '{"match": true, "confidence": 0.9, "reasoning": "same"}'})))
+    c = await cli.complete_json(user="u", system="s", max_tokens=64)
+    assert c == {"match": True, "confidence": 0.9, "reasoning": "same"}
+
+    # Identical bounded retry count before the terminal VerifierError: a runner
+    # that always exits nonzero is retried _MAX_RETRIES times like a 503.
+    failing = sr.ClaudeCliJudgeClient(model="m", runner=_fake_cli_runner("", rc=1))
+    with pytest.raises(sr.VerifierError):
+        await failing.complete_json(user="u", system="s", max_tokens=64)
+    assert len(failing.runner.calls) == 3  # type: ignore[attr-defined]
 
 
 def test_escape_neutralizes_all_four_delimiters_in_both_roles(sr_module: Any) -> None:
@@ -1368,6 +1401,28 @@ async def test_both_providers_share_identical_hardened_error_and_redirect_policy
         with pytest.raises(sr.VerifierError) as e:
             await client.complete_json(user="u")
         assert "allowlist" in str(e.value)
+
+
+def test_claude_cli_missing_token_writes_typed_error_artifact(
+    sr_module: Any,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sr = sr_module
+    gold = tmp_path / "golden-review.json"
+    gold.write_text(json.dumps([{"case_id": "c1"}]))
+    monkeypatch.setenv("DAYDREAM_JUDGE_ARTIFACT_PATH", str(tmp_path / "review.json"))
+    monkeypatch.setenv("DAYDREAM_JUDGE_OUT_PATH", str(tmp_path / "out"))
+    monkeypatch.setenv("DAYDREAM_JUDGE_PROVIDER", "claude-cli")
+    monkeypatch.setenv("DAYDREAM_JUDGE_MODEL", "m")
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    rc = sr.main()
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 1 and payload["verifier_error"] == 1 and payload["reward"] == 0.0
+    # typed diagnostic, NOT "no judge client configured"
+    details = json.loads((tmp_path / "out" / "reward-details.json").read_text())
+    assert any("CLAUDE_CODE_OAUTH_TOKEN" in e for e in details["errors"])
 
 
 def test_emit_reward_emits_full_reward_dict_and_exit_code(sr_module: Any, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_benchmark_verifier_judge.py
+++ b/tests/test_benchmark_verifier_judge.py
@@ -544,6 +544,29 @@ def test_judge_failure_fails_whole_task_not_partial_score(sr_module: Any, tmp_pa
     assert len(details["errors"]) >= 1                            # bounded diagnostic written
 
 
+def test_provider_selection_claude_cli_relaxes_api_key_only(sr_module: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    sr = sr_module
+    base = {"DAYDREAM_JUDGE_PROVIDER": "claude-cli", "DAYDREAM_JUDGE_MODEL": "m"}
+
+    client = sr._build_client({**base, "CLAUDE_CODE_OAUTH_TOKEN": "tok"})
+    assert isinstance(client, sr.ClaudeCliJudgeClient)          # no API key required
+
+    with pytest.raises(sr.VerifierError, match="CLAUDE_CODE_OAUTH_TOKEN"):
+        sr._build_client(base)                                   # missing token -> typed diagnostic
+    with pytest.raises(sr.VerifierError, match="CLAUDE_CODE_OAUTH_TOKEN"):
+        sr._build_client({**base, "CLAUDE_CODE_OAUTH_TOKEN": ""})  # empty token also rejected
+    with pytest.raises(sr.VerifierError, match="missing DAYDREAM_JUDGE_MODEL"):
+        sr._build_client({"DAYDREAM_JUDGE_PROVIDER": "claude-cli", "CLAUDE_CODE_OAUTH_TOKEN": "tok"})
+    # other providers unchanged: API key still mandatory, same message
+    with pytest.raises(sr.VerifierError, match="missing DAYDREAM_JUDGE_MODEL or DAYDREAM_JUDGE_API_KEY"):
+        sr._build_client({"DAYDREAM_JUDGE_PROVIDER": "anthropic", "DAYDREAM_JUDGE_MODEL": "m"})
+    with pytest.raises(sr.VerifierError, match="unsupported DAYDREAM_JUDGE_PROVIDER 'bogus'; "
+                                              "expected anthropic, openai-compatible, or claude-cli"):
+        sr._build_client(
+            {"DAYDREAM_JUDGE_PROVIDER": "bogus", "DAYDREAM_JUDGE_MODEL": "m", "DAYDREAM_JUDGE_API_KEY": "k"}
+        )
+
+
 def test_provider_selection_builds_expected_client(sr_module: Any, monkeypatch: pytest.MonkeyPatch) -> None:
     sr = sr_module
 
@@ -1150,7 +1173,7 @@ def test_provider_allowlist_rejects_unknown_and_validates_base_url(sr_module: An
             {"DAYDREAM_JUDGE_PROVIDER": None, "DAYDREAM_JUDGE_MODEL": "m",
              "DAYDREAM_JUDGE_API_KEY": "k", "DAYDREAM_JUDGE_BASE_URL": None}
         )
-    # exactly anthropic | openai-compatible accepted
+    # exactly anthropic | openai-compatible | claude-cli accepted
     cert = {"DAYDREAM_JUDGE_PROVIDER": "openai-compatible", "DAYDREAM_JUDGE_MODEL": "m",
             "DAYDREAM_JUDGE_API_KEY": "k", "DAYDREAM_JUDGE_BASE_URL": "https://api.openai.com/v1"}
     assert isinstance(sr._build_client(cert), sr.OpenAIJudgeClient)
@@ -1158,7 +1181,7 @@ def test_provider_allowlist_rejects_unknown_and_validates_base_url(sr_module: An
     for bad in ("martian", "garbage", "Anthropic"):
         with pytest.raises(sr.VerifierError) as e:
             sr._build_client({**cert, "DAYDREAM_JUDGE_PROVIDER": bad})
-        assert "expected anthropic or openai-compatible" in str(e.value)
+        assert "expected anthropic, openai-compatible, or claude-cli" in str(e.value)
     # a base URL host outside the allowlist fails closed at build time
     with pytest.raises(sr.VerifierError):
         sr._build_client({**cert, "DAYDREAM_JUDGE_ALLOWED_HOSTS": "api.anthropic.com"})


### PR DESCRIPTION
## Summary
- Terminal claude-cli judge failures handled gracefully; stderr unblocked
- Allowlist validation added
- Verifier Dockerfile: node installed via stdlib download, pinned claude on PATH, layer caching improved
- New test coverage for the above

Two sequential daydream deep-precision review rounds passed (round 2 fixes at 70a2c97).

Closes #965