### PR TITLE
fix(training): derive labels from reply meaning, not reply/merge presence (Closes #980)

### DIFF
--- a/daydream/archive/_schema.py
+++ b/daydream/archive/_schema.py
@@ -282,8 +282,13 @@ def _migrate_label_observations_schema(conn: sqlite3.Connection) -> None:
         ],
     )
     # Stamp history exactly once (M17): rows written before the reply-label
-    # columns existed have ``labeler_policy_version IS NULL`` — the condition is
-    # its own idempotency guard, so pre-existing rows are marked ``legacy`` on
-    # first open and never rewritten afterwards. No row's labels/observed_at/
+    # columns existed have ``labeler_policy_version IS NULL``. The additional
+    # ``legacy = 'auto'`` condition is the actual idempotency guard — once a
+    # row is marked ``legacy`` it stops matching, so later connection opens do
+    # not re-execute the UPDATE (or rewrite matched rows into the WAL) even
+    # though ``labeler_policy_version`` stays NULL. No row's labels/observed_at/
     # rubric_json is ever written here.
-    conn.execute("UPDATE label_observations SET legacy = 'legacy' WHERE labeler_policy_version IS NULL")
+    conn.execute(
+        "UPDATE label_observations SET legacy = 'legacy' "
+        "WHERE labeler_policy_version IS NULL AND legacy = 'auto'"
+    )

--- a/daydream/archive/_schema.py
+++ b/daydream/archive/_schema.py
@@ -108,6 +108,16 @@ CREATE TABLE IF NOT EXISTS runs (
 # ``'human'`` for maintainer overrides) — human-sourced rows win in the "latest
 # label" projections regardless of recency. Pre-existing rows default to ``'auto'``
 # via the additive ``_migrate_label_observations_schema`` ALTER-ADD migration.
+# ``labeler_policy_version`` mirrors ``labeler_version`` so the policy axis is an
+# explicit column; ``reply_classifier_version`` / ``reply_evidence_digest`` carry
+# the reply-classifier version and a stable digest over the combined reply
+# evidence — together with ``evidence_sha`` they form the auto-dedup key
+# ``(evidence_sha, labeler_policy_version, reply_evidence_digest, labels,
+# has_posterior)``, replacing the older ``(evidence_sha, reward_version)`` key.
+# ``legacy`` marks provenance generation: new rows default ``'auto'``
+# (current-generation); the additive migration stamps every pre-existing row
+# (``labeler_policy_version IS NULL``) ``'legacy'`` exactly once, never touching
+# its labels/observed_at/rubric_json.
 _CREATE_LABEL_OBSERVATIONS_TABLE = """
 CREATE TABLE IF NOT EXISTS label_observations (
     session_id       TEXT NOT NULL,
@@ -124,6 +134,10 @@ CREATE TABLE IF NOT EXISTS label_observations (
     reviewer_logins  TEXT,
     has_posterior    INTEGER NOT NULL DEFAULT 0,
     source           TEXT NOT NULL DEFAULT 'auto',
+    labeler_policy_version TEXT,
+    reply_classifier_version TEXT,
+    reply_evidence_digest  TEXT,
+    legacy           TEXT NOT NULL DEFAULT 'auto',
     PRIMARY KEY (session_id, observed_at)
 )
 """
@@ -261,5 +275,15 @@ def _migrate_label_observations_schema(conn: sqlite3.Connection) -> None:
         "label_observations",
         [
             ("source", "TEXT NOT NULL DEFAULT 'auto'"),
+            ("labeler_policy_version", "TEXT"),
+            ("reply_classifier_version", "TEXT"),
+            ("reply_evidence_digest", "TEXT"),
+            ("legacy", "TEXT NOT NULL DEFAULT 'auto'"),
         ],
     )
+    # Stamp history exactly once (M17): rows written before the reply-label
+    # columns existed have ``labeler_policy_version IS NULL`` — the condition is
+    # its own idempotency guard, so pre-existing rows are marked ``legacy`` on
+    # first open and never rewritten afterwards. No row's labels/observed_at/
+    # rubric_json is ever written here.
+    conn.execute("UPDATE label_observations SET legacy = 'legacy' WHERE labeler_policy_version IS NULL")

--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -303,6 +303,8 @@ def append_label_observation(
     reviewer_logins: list[str] | None = None,
     has_posterior: bool = False,
     source: str = "auto",
+    reply_classifier_version: str | None = None,
+    reply_evidence_digest: str | None = None,
 ) -> bool:
     """Append a row to the immutable ``label_observations`` history.
 
@@ -354,6 +356,12 @@ def append_label_observation(
             Coerced to ``int`` and written to ``label_observations.has_posterior``
             and mirrored onto ``runs.has_posterior`` so SQL consumers can split
             labeled/unlabeled populations without parsing ``reward_json``.
+        reply_classifier_version: Version of the reply classifier that produced
+            the per-finding dispositions (version axis, M13); accepted here so
+            callers can thread it ahead of the column's persistence.
+        reply_evidence_digest: Stable digest over the combined reply evidence
+            (versioned dedup input, M14); accepted here so callers can thread
+            it ahead of the column's persistence.
         source: Provenance of this observation — ``"auto"`` (automated rubric
             labeler; the default that keeps existing harvest callers
             unchanged) or ``"human"`` (operator override). Human-sourced rows

--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -357,11 +357,11 @@ def append_label_observation(
             and mirrored onto ``runs.has_posterior`` so SQL consumers can split
             labeled/unlabeled populations without parsing ``reward_json``.
         reply_classifier_version: Version of the reply classifier that produced
-            the per-finding dispositions (version axis, M13); accepted here so
-            callers can thread it ahead of the column's persistence.
+            the per-finding dispositions (version axis, M13); persisted on the
+            row so each annotation generation is self-describing.
         reply_evidence_digest: Stable digest over the combined reply evidence
-            (versioned dedup input, M14); accepted here so callers can thread
-            it ahead of the column's persistence.
+            (versioned dedup input, M14); persisted and compared in the auto
+            dedup key so an edited reply appends a new generation.
         source: Provenance of this observation — ``"auto"`` (automated rubric
             labeler; the default that keeps existing harvest callers
             unchanged) or ``"human"`` (operator override). Human-sourced rows
@@ -372,12 +372,18 @@ def append_label_observation(
     Returns:
         ``True`` when a new observation row was inserted; ``False`` when the
         append was a deduped no-op. Dedup is **auto-only**: an automated
-        (``source="auto"``) append whose ``(evidence_sha, reward_version)``
-        matches the latest existing *auto* observation for the session is
-        skipped without inserting and without touching the cache. Human
+        (``source="auto"``) append matching the latest existing *auto*
+        observation for the session on the versioned evidence tuple
+        ``(evidence_sha, labeler_policy_version,
+        reply_evidence_digest, labels, has_posterior)`` is
+        skipped without inserting and without touching the cache. A
+        policy-version bump or an edited-reply digest change on
+        otherwise-identical evidence appends
+        a fresh generation. A ``None`` digest is not coerced to ``""`` — ``None``
+        never equals a present digest, so digest-less legacy callers dedupe on
+        the remaining tuple exactly as before (deliberate default). Human
         (``source != "auto"``) appends are never deduped and always return
-        ``True``; a reward-version bump on otherwise-identical evidence also
-        appends a fresh generation.
+        ``True``.
 
     Raises:
         ValueError: When ``session_id`` is not present in the ``runs`` table,
@@ -401,9 +407,18 @@ def append_label_observation(
         # Idempotency: an automated re-score with identical evidence is a no-op.
         # Compare against the latest *auto* row specifically so a human override
         # appended in between cannot mask a genuine automated re-score.
+        #
+        # The dedup key is the versioned evidence tuple (M14):
+        # ``(evidence_sha, labeler_policy_version, reply_evidence_digest, labels,
+        # has_posterior)``. A policy-version bump or an edited-reply digest
+        # change therefore appends a new generation rather than deduping. A
+        # ``None`` digest is deliberately NOT coerced to ``""``: ``None`` never
+        # equals a present digest, so digest-less legacy callers dedupe on the
+        # remaining tuple exactly as before.
         if source == "auto":
             latest_auto = conn.execute(
-                "SELECT evidence_sha, reward_version, labels, has_posterior FROM label_observations "
+                "SELECT evidence_sha, labeler_policy_version, reply_evidence_digest, labels, has_posterior "
+                "FROM label_observations "
                 "WHERE session_id = ? AND source = 'auto' "
                 "ORDER BY observed_at DESC LIMIT 1",
                 (session_id,),
@@ -411,7 +426,8 @@ def append_label_observation(
             if (
                 latest_auto is not None
                 and latest_auto["evidence_sha"] == evidence_sha
-                and latest_auto["reward_version"] == reward_version
+                and latest_auto["labeler_policy_version"] == labeler_version
+                and latest_auto["reply_evidence_digest"] == reply_evidence_digest
                 and latest_auto["labels"] == labels_json
                 # Population membership varies independently of the label (a
                 # local_branch outcome is labeled but not posterior evidence).
@@ -427,8 +443,9 @@ def append_label_observation(
                 conn.execute(
                     "INSERT INTO label_observations "
                     "(session_id, observed_at, labels, pr_state, labeler_version, evidence_sha, rubric_json, "
-                    "valid_at, reward_version, reward_json, composite_reward, reviewer_logins, has_posterior, source) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    "valid_at, reward_version, reward_json, composite_reward, reviewer_logins, has_posterior, source, "
+                    "labeler_policy_version, reply_classifier_version, reply_evidence_digest, legacy) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'auto')",
                     (
                         session_id,
                         observed_at,
@@ -444,6 +461,9 @@ def append_label_observation(
                         reviewer_logins_json,
                         has_posterior_int,
                         source,
+                        labeler_version,
+                        reply_classifier_version,
+                        reply_evidence_digest,
                     ),
                 )
                 break

--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -374,11 +374,11 @@ def append_label_observation(
         append was a deduped no-op. Dedup is **auto-only**: an automated
         (``source="auto"``) append matching the latest existing *auto*
         observation for the session on the versioned evidence tuple
-        ``(evidence_sha, labeler_policy_version,
-        reply_evidence_digest, labels, has_posterior)`` is
+        ``(evidence_sha, labeler_policy_version, reply_evidence_digest,
+        labels, has_posterior, reward_version)`` is
         skipped without inserting and without touching the cache. A
-        policy-version bump or an edited-reply digest change on
-        otherwise-identical evidence appends
+        policy-version bump, a reward-version bump, or an edited-reply digest
+        change on otherwise-identical evidence appends
         a fresh generation. A ``None`` digest is not coerced to ``""`` — ``None``
         never equals a present digest, so digest-less legacy callers dedupe on
         the remaining tuple exactly as before (deliberate default). Human
@@ -410,14 +410,16 @@ def append_label_observation(
         #
         # The dedup key is the versioned evidence tuple (M14):
         # ``(evidence_sha, labeler_policy_version, reply_evidence_digest, labels,
-        # has_posterior)``. A policy-version bump or an edited-reply digest
-        # change therefore appends a new generation rather than deduping. A
+        # has_posterior, reward_version)``. A policy-version bump, a
+        # reward-version bump, or an edited-reply digest change therefore
+        # appends a new generation rather than deduping. A
         # ``None`` digest is deliberately NOT coerced to ``""``: ``None`` never
         # equals a present digest, so digest-less legacy callers dedupe on the
         # remaining tuple exactly as before.
         if source == "auto":
             latest_auto = conn.execute(
-                "SELECT evidence_sha, labeler_policy_version, reply_evidence_digest, labels, has_posterior "
+                "SELECT evidence_sha, labeler_policy_version, reply_evidence_digest, labels, has_posterior, "
+                "reward_version "
                 "FROM label_observations "
                 "WHERE session_id = ? AND source = 'auto' "
                 "ORDER BY observed_at DESC LIMIT 1",
@@ -428,6 +430,7 @@ def append_label_observation(
                 and latest_auto["evidence_sha"] == evidence_sha
                 and latest_auto["labeler_policy_version"] == labeler_version
                 and latest_auto["reply_evidence_digest"] == reply_evidence_digest
+                and latest_auto["reward_version"] == reward_version
                 and latest_auto["labels"] == labels_json
                 # Population membership varies independently of the label (a
                 # local_branch outcome is labeled but not posterior evidence).

--- a/daydream/training/backfill.py
+++ b/daydream/training/backfill.py
@@ -15,8 +15,9 @@ Failure policy:
 * A *benign* PR absence (fork/deleted PR 404, unpushed-SHA 422, detected via
   :func:`~daydream.training.harvest._is_benign_pr_absence`) degrades inside
   ``build_annotation`` to a local-branch rubric whose outcome is ``unknown``;
-  the backfill stores that as ``["unknown"]`` — fail closed, never decisive
-  (M19/M22).
+  the backfill stores that as the empty label list (harvest's serialization)
+  — fail closed, never decisive (M19/M22), and byte-identical to the harvest
+  writer so the M14 auto-dedup tuple matches between the two writers.
 * Transient per-row failures count in ``summary["errors"]`` and never derail
   subsequent rows (harvest's isolation pattern). ``RateLimitError`` aborts the
   sweep cleanly, preserving the remaining queue for a later re-run.
@@ -228,13 +229,12 @@ def run_backfill(
                     f"backfill: PR evidence absent for session {row['session_id']} "
                     f"({type(exc).__name__}: {exc}); labeling unknown (fail closed)",
                 )
-                labels = ["unknown"]
+                labels: list[str] = []
                 transitions[row["session_id"]] = {
                     "old_labels": old_labels,
                     "new_labels": labels,
                 }
                 pr_state_counts["unknown"] += 1
-                class_balance["unknown"] += 1
                 if dry_run:
                     summary["sessions_reprocessed"] += 1
                     continue
@@ -249,9 +249,10 @@ def run_backfill(
                 summary["appended" if appended else "skipped"] += 1
                 summary["sessions_reprocessed"] += 1
                 continue
-            # Fail closed (M19): an unknown outcome is stored as ["unknown"],
-            # never as an empty/decisive label set.
-            labels = payload.labels or ["unknown"]
+            # Fail closed (M19): an unknown outcome is stored as the empty
+            # label list — harvest's serialization — so the M14 dedup tuple
+            # stays byte-identical between the two writers, never decisive.
+            labels = payload.labels
             transitions[row["session_id"]] = {
                 "old_labels": old_labels,
                 "new_labels": labels,

--- a/daydream/training/backfill.py
+++ b/daydream/training/backfill.py
@@ -1,0 +1,326 @@
+"""Backfill pass — re-annotate indexed runs and append a fresh generation.
+
+Walks the archive index and, for every PR-linked run, rebuilds the annotation
+through the *same* :func:`~daydream.training.harvest.build_annotation` path the
+harvest pass uses (imported, never forked), then appends it to
+``label_observations`` with the current
+:data:`~daydream.training.labeler_versions.LABELER_POLICY_VERSION`. The write
+layer's versioned dedup key makes an unchanged re-run a no-op (M18); a policy
+or reply-evidence change appends a fresh generation so older ``as_of`` pins
+still resolve their original generation. Legacy rows are never mutated or
+deleted (M17) — backfill only ever appends.
+
+Failure policy:
+
+* A *benign* PR absence (fork/deleted PR 404, unpushed-SHA 422, detected via
+  :func:`~daydream.training.harvest._is_benign_pr_absence`) degrades inside
+  ``build_annotation`` to a local-branch rubric whose outcome is ``unknown``;
+  the backfill stores that as ``["unknown"]`` — fail closed, never decisive
+  (M19/M22).
+* Transient per-row failures count in ``summary["errors"]`` and never derail
+  subsequent rows (harvest's isolation pattern). ``RateLimitError`` aborts the
+  sweep cleanly, preserving the remaining queue for a later re-run.
+* Every fallible step (fetch, observation append, report write) propagates real
+  errors — a report write failure raises *after* observations are committed, and
+  the summary reports what landed.
+
+The optional machine-readable report (M20) is written with ``sort_keys=True``
+for deterministic diffing: per-session run-label transitions, disposition
+counts, the classifier's parser rule count, the ambiguous-manual-review queue
+seed count, bot/self-reply exclusions, PR-state counts, and class balance.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from rich.console import Console
+
+from daydream.archive.index import append_label_observation, query_runs
+from daydream.git_ops import GitError, RateLimitError
+from daydream.training import labeler_versions
+from daydream.training.harvest import (
+    _gh_api,
+    _is_benign_pr_absence,
+    _materialize_base_sha_if_missing,
+    _resolve_repo_for_row,
+    build_annotation,
+)
+from daydream.training.reply_classifier import (
+    _ACCEPT_RULES,
+    _DAYDREAM_AGENT_LOGINS,
+    _DISPUTE_RULES,
+    _FACTUAL_DISAGREEMENT_RULES,
+    _REJECT_RULES,
+)
+from daydream.ui import create_console, print_warning
+
+__all__ = ["run_backfill"]
+
+
+def _parser_rule_count() -> int:
+    """Size of the reply classifier's exported rule table (M20 report)."""
+    return (
+        len(_ACCEPT_RULES)
+        + len(_REJECT_RULES)
+        + len(_DISPUTE_RULES)
+        + len(_FACTUAL_DISAGREEMENT_RULES)
+    )
+
+
+def _latest_labels(archive_dir: Path, session_id: str) -> list[str] | None:
+    """Latest existing observation's labels for a session, or ``None``.
+
+    Read *before* the append so the report's ``run_label_transitions`` records
+    the old winning generation, not the one backfill just wrote.
+    """
+    import sqlite3
+
+    conn = sqlite3.connect(archive_dir / "index.db")
+    conn.row_factory = sqlite3.Row
+    try:
+        row = conn.execute(
+            "SELECT labels FROM label_observations WHERE session_id = ? "
+            "ORDER BY observed_at DESC LIMIT 1",
+            (session_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    if row is None or row["labels"] is None:
+        return None
+    try:
+        labels = json.loads(row["labels"])
+    except ValueError:
+        return None
+    return labels if isinstance(labels, list) else None
+
+
+def _count_bot_self_reply_exclusions(comments: list[Any]) -> int:
+    """Count fetched replies authored by daydream's own accounts (M20 report).
+
+    Scans the raw ``/comments`` payloads captured through the ``gh_api`` seam:
+    a thread reply whose author login is one of daydream's agent logins (or is
+    flagged ``is_self_reply`` by the API shape) is a self-reply exclusion.
+    """
+    exclusions = 0
+    for comment in comments:
+        if not isinstance(comment, dict) or comment.get("in_reply_to_id") is None:
+            continue
+        if comment.get("is_self_reply"):
+            exclusions += 1
+            continue
+        user = comment.get("user")
+        login = user.get("login") if isinstance(user, dict) else None
+        if isinstance(login, str) and login in _DAYDREAM_AGENT_LOGINS:
+            exclusions += 1
+    return exclusions
+
+
+class _RecordingGH:
+    """``gh_api`` proxy that captures ``/comments`` payloads for the report."""
+
+    def __init__(self, inner: Any) -> None:
+        self._inner = inner
+        self.comments: list[Any] = []
+
+    def __call__(self, repo: str, endpoint: str, **kwargs: Any) -> Any:
+        response = self._inner(repo, endpoint, **kwargs)
+        if endpoint.endswith("/comments") and isinstance(response, list):
+            self.comments.extend(response)
+        return response
+
+
+def run_backfill(
+    archive_dir: Path,
+    *,
+    dry_run: bool = False,
+    session_filter: str | None = None,
+    report_path: Path | None = None,
+    valid_at_override: str | None = None,
+) -> dict[str, Any]:
+    """Re-annotate every PR-linked indexed run and append a fresh generation.
+
+    Args:
+        archive_dir: Archive root containing ``index.db``.
+        dry_run: Build annotations but suppress writes (and the report's
+            post-write transitions stay prospective).
+        session_filter: Optional ``session_id`` prefix restricting the queue.
+        report_path: When given, write the M20 machine-readable report JSON
+            (``sort_keys=True``) after the observation loop; a write failure
+            raises after observations are committed.
+        valid_at_override: Explicit valid-time passed through to the
+            annotation builder, beating the derived decisive-evidence stamp.
+
+    Returns:
+        Summary dict with ``sessions_reprocessed`` (PR-linked rows walked),
+        ``appended``, ``skipped`` (deduped no-ops), ``non_pr_skipped``,
+        ``errors``, and ``aborted``.
+    """
+    if not archive_dir.exists():
+        msg = f"archive_dir does not exist: {archive_dir}"
+        raise FileNotFoundError(msg)
+
+    if session_filter:
+        queue = query_runs(
+            archive_dir,
+            "session_id LIKE ? || '%'",
+            (session_filter,),
+        )
+    else:
+        queue = query_runs(archive_dir)
+    # Pinned session order for determinism (M18): identical archives must
+    # produce identical report and append orderings.
+    queue = sorted(queue, key=lambda row: row["session_id"])
+
+    console: Console = create_console()
+    recording_gh = _RecordingGH(_gh_api)
+
+    summary: dict[str, Any] = {
+        "sessions_reprocessed": 0,
+        "appended": 0,
+        "skipped": 0,
+        "non_pr_skipped": 0,
+        "errors": 0,
+        "aborted": 0,
+    }
+    transitions: dict[str, dict[str, Any]] = {}
+    disposition_counts: Counter[str] = Counter()
+    pr_state_counts: Counter[str] = Counter()
+    class_balance: Counter[str] = Counter()
+    ambiguous_manual_review = 0
+    fetched_repos: set[Path] = set()
+
+    for row in queue:
+        if not row.get("pr_repo") or row.get("pr_number") is None:
+            summary["non_pr_skipped"] += 1
+            continue
+        try:
+            run_dir = Path(row["archive_path"])
+            row_repo_clone = _resolve_repo_for_row(
+                row, clone_cache=None, fetched_repos=fetched_repos, console=console
+            )
+            _materialize_base_sha_if_missing(row, run_dir, repo_clone=row_repo_clone, console=console)
+            old_labels = _latest_labels(archive_dir, row["session_id"])
+            try:
+                payload = build_annotation(
+                    row,
+                    run_dir=run_dir,
+                    archive_dir=archive_dir,
+                    gh_api=recording_gh,
+                    repo_clone=row_repo_clone or archive_dir,
+                    clone_resolved=row_repo_clone is not None,
+                    valid_at_override=valid_at_override,
+                )
+            except RateLimitError:
+                raise
+            except GitError as exc:
+                # Benign absence (deleted repo/PR/comments 404, unpushed-SHA
+                # 422) that escaped build_annotation's internal degrade — fail
+                # closed (M19/M22): store unknown with the current policy
+                # version, never a decisive label. Transient failures re-raise
+                # into the per-row isolation handler below.
+                if not _is_benign_pr_absence(exc):
+                    raise
+                print_warning(
+                    console,
+                    f"backfill: PR evidence absent for session {row['session_id']} "
+                    f"({type(exc).__name__}: {exc}); labeling unknown (fail closed)",
+                )
+                labels = ["unknown"]
+                transitions[row["session_id"]] = {
+                    "old_labels": old_labels,
+                    "new_labels": labels,
+                }
+                pr_state_counts["unknown"] += 1
+                class_balance["unknown"] += 1
+                if dry_run:
+                    summary["skipped"] += 1
+                    continue
+                appended = append_label_observation(
+                    archive_dir,
+                    row["session_id"],
+                    labels=labels,
+                    pr_state=None,
+                    labeler_version=labeler_versions.LABELER_POLICY_VERSION,
+                    evidence_sha=row.get("head_sha"),
+                )
+                summary["appended" if appended else "skipped"] += 1
+                summary["sessions_reprocessed"] += 1
+                continue
+            # Fail closed (M19): an unknown outcome is stored as ["unknown"],
+            # never as an empty/decisive label set.
+            labels = payload.labels or ["unknown"]
+            transitions[row["session_id"]] = {
+                "old_labels": old_labels,
+                "new_labels": labels,
+            }
+            rubric = json.loads(payload.rubric_json) if payload.rubric_json else {}
+            outcomes = rubric.get("per_finding_outcomes") or []
+            for outcome in outcomes:
+                disposition_counts[str(outcome)] += 1
+                if outcome == "ambiguous":
+                    ambiguous_manual_review += 1
+            pr_state_counts[str(payload.pr_state)] += 1
+            for label in labels:
+                class_balance[str(label)] += 1
+            if dry_run:
+                summary["skipped"] += 1
+                continue
+            appended = append_label_observation(
+                archive_dir,
+                row["session_id"],
+                labels=labels,
+                pr_state=payload.pr_state,
+                labeler_version=labeler_versions.LABELER_POLICY_VERSION,
+                evidence_sha=payload.evidence_sha,
+                rubric_json=payload.rubric_json,
+                valid_at=payload.valid_at,
+                reward_version=payload.reward_version,
+                reward_json=payload.reward_json,
+                composite_reward=payload.composite_reward,
+                reviewer_logins=payload.reviewer_logins,
+                has_posterior=payload.has_posterior,
+                reply_classifier_version=payload.reply_classifier_version,
+                reply_evidence_digest=payload.reply_evidence_digest,
+                source="auto",
+            )
+            if appended:
+                summary["appended"] += 1
+            else:
+                # Deduped: unchanged evidence + unchanged versions is a no-op (M18).
+                summary["skipped"] += 1
+            summary["sessions_reprocessed"] += 1
+        except RateLimitError:
+            summary["aborted"] = 1
+            print_warning(
+                console,
+                "backfill: GitHub rate limit exhausted; aborting cleanly.",
+            )
+            break
+        except Exception as exc:  # noqa: BLE001 - per-row isolation by design
+            summary["errors"] += 1
+            print_warning(
+                console,
+                f"backfill: session {row.get('session_id', '<unknown>')} failed: "
+                f"{type(exc).__name__}: {exc}",
+            )
+            continue
+
+    if report_path is not None:
+        report = {
+            "dry_run": dry_run,
+            "run_label_transitions": transitions,
+            "disposition_counts": dict(sorted(disposition_counts.items())),
+            "parser_rule_count": _parser_rule_count(),
+            "ambiguous_manual_review": ambiguous_manual_review,
+            "bot_self_reply_exclusions": _count_bot_self_reply_exclusions(recording_gh.comments),
+            "pr_state_counts": dict(sorted(pr_state_counts.items())),
+            "class_balance": dict(sorted(class_balance.items())),
+            "summary": dict(summary),
+        }
+        report_path.write_text(json.dumps(report, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+    return summary

--- a/daydream/training/backfill.py
+++ b/daydream/training/backfill.py
@@ -39,7 +39,11 @@ from typing import Any
 
 from rich.console import Console
 
-from daydream.archive.index import append_label_observation, query_runs
+from daydream.archive.index import (
+    append_label_observation,
+    latest_label_observation,
+    query_runs,
+)
 from daydream.git_ops import GitError, RateLimitError
 from daydream.training import labeler_versions
 from daydream.training.harvest import (
@@ -75,20 +79,12 @@ def _latest_labels(archive_dir: Path, session_id: str) -> list[str] | None:
     """Latest existing observation's labels for a session, or ``None``.
 
     Read *before* the append so the report's ``run_label_transitions`` records
-    the old winning generation, not the one backfill just wrote.
+    the old winning generation, not the one backfill just wrote. Uses the
+    archive's winner projection (human-first precedence, then recency) so a
+    human override coexisting with a newer auto row still reads as the human
+    generation.
     """
-    import sqlite3
-
-    conn = sqlite3.connect(archive_dir / "index.db")
-    conn.row_factory = sqlite3.Row
-    try:
-        row = conn.execute(
-            "SELECT labels FROM label_observations WHERE session_id = ? "
-            "ORDER BY observed_at DESC LIMIT 1",
-            (session_id,),
-        ).fetchone()
-    finally:
-        conn.close()
+    row = latest_label_observation(archive_dir, session_id)
     if row is None or row["labels"] is None:
         return None
     try:
@@ -146,7 +142,10 @@ def run_backfill(
     Args:
         archive_dir: Archive root containing ``index.db``.
         dry_run: Build annotations but suppress writes (and the report's
-            post-write transitions stay prospective).
+            post-write transitions stay prospective). Walked PR-linked rows
+            still count in ``sessions_reprocessed`` but never in ``skipped``,
+            so the summary distinguishes 'nothing changed' from 'dry run
+            suppressed writes'.
         session_filter: Optional ``session_id`` prefix restricting the queue.
         report_path: When given, write the M20 machine-readable report JSON
             (``sort_keys=True``) after the observation loop; a write failure
@@ -237,7 +236,7 @@ def run_backfill(
                 pr_state_counts["unknown"] += 1
                 class_balance["unknown"] += 1
                 if dry_run:
-                    summary["skipped"] += 1
+                    summary["sessions_reprocessed"] += 1
                     continue
                 appended = append_label_observation(
                     archive_dir,
@@ -267,7 +266,11 @@ def run_backfill(
             for label in labels:
                 class_balance[str(label)] += 1
             if dry_run:
-                summary["skipped"] += 1
+                # Suppressed write, not a deduped no-op: count the row as
+                # walked; ``skipped`` stays reserved for deduped no-ops (M18)
+                # so the summary distinguishes 'nothing changed' from 'dry run
+                # suppressed writes'.
+                summary["sessions_reprocessed"] += 1
                 continue
             appended = append_label_observation(
                 archive_dir,

--- a/daydream/training/backfill_cache.py
+++ b/daydream/training/backfill_cache.py
@@ -9,14 +9,21 @@ re-paying for completed work.
 This module provides two cooperating pieces:
 
 * :class:`BackfillCache` — a callable wrapping ``gh_api`` that memoizes
-  responses to JSON files under ``cache_dir``. Historical PRs are
-  immutable, so no TTL is needed (see ``/tmp/research-backfill-sla.md``).
+  responses to JSON files under ``cache_dir``. GitHub state is only
+  immutable within a freshness window — replies can be edited and PRs
+  can merge — so a memoized entry older than ``CACHE_TTL_SECONDS`` is
+  refetched rather than served (M14): the reply-evidence digest is
+  recomputed from live data, so an edited reply appends a fresh
+  generation instead of being masked by a stale memoized response.
 * ``progress.jsonl`` — an append-only JSONL log of completed
   ``session_id`` rows, written by :meth:`BackfillCache.mark_session_done`
   and read back by :meth:`BackfillCache.completed_sessions`. Each row is
   stamped with the labeler policy version in force at completion time, so
   a policy bump wholesale-invalidates the resume markers (M15) and forces
-  a re-fetch rather than silently resuming stale labels.
+  a re-fetch rather than silently resuming stale labels. Markers also
+  age out past ``CACHE_TTL_SECONDS`` (on their ``completed_at``), so a
+  re-run outside the freshness window re-processes the session and can
+  observe a reply edit.
 
 The cache is intentionally process-local and lock-free: each cache key
 maps to one file, and the labeler runs single-process. Cache files are
@@ -30,6 +37,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
@@ -40,6 +48,16 @@ from daydream.ui import create_console, print_warning
 
 GHApiFn = Callable[..., Any]
 """Signature of the wrapped ``gh_api`` callable: ``(repo, endpoint, **kwargs) -> Any``."""
+
+CACHE_TTL_SECONDS = 24 * 60 * 60
+"""Freshness window (seconds) for memoized responses and resume markers.
+
+GitHub state is not truly immutable — replies can be edited, PRs can merge —
+so an entry older than this window is refetched (and a completion marker
+older than this window does not resume the session), letting a re-run observe
+a reply edit and append a fresh generation (M14) instead of being masked by a
+stale memoized response.
+"""
 
 
 def _now_iso_utc() -> str:
@@ -95,9 +113,11 @@ class BackfillCache:
     def __call__(self, repo: str, endpoint: str, **kwargs: Any) -> Any:
         """Return the cached response for ``(repo, endpoint, **kwargs)``.
 
-        On a cache hit, the JSON cache file is read and returned. On a
-        miss (or on a corrupt cache read), ``inner`` is called and the
-        result is written through to the cache before being returned.
+        On a cache hit within the freshness window
+        (:data:`CACHE_TTL_SECONDS`), the JSON cache file is read and
+        returned. On a miss, a stale cache file, or a corrupt cache read,
+        ``inner`` is called and the result is written through to the cache
+        before being returned.
         """
         digest = _cache_key(repo, endpoint, kwargs)
         owner, _, name = repo.partition("/")
@@ -107,15 +127,20 @@ class BackfillCache:
 
         if path.exists():
             try:
-                with path.open("r", encoding="utf-8") as f:
-                    return json.load(f)
-            except (json.JSONDecodeError, OSError) as exc:
-                print_warning(
-                    create_console(),
-                    f"BackfillCache: corrupt cache file {path.name} ({exc}); "
-                    "refetching from inner gh_api.",
-                )
-                # Fall through to refetch.
+                fresh = time.time() - path.stat().st_mtime < CACHE_TTL_SECONDS
+            except OSError:
+                fresh = False
+            if fresh:
+                try:
+                    with path.open("r", encoding="utf-8") as f:
+                        return json.load(f)
+                except (json.JSONDecodeError, OSError) as exc:
+                    print_warning(
+                        create_console(),
+                        f"BackfillCache: corrupt cache file {path.name} ({exc}); "
+                        "refetching from inner gh_api.",
+                    )
+                    # Fall through to refetch.
 
         result = self.inner(repo, endpoint, **kwargs)
         atomic_write_json(path, result, default=str)
@@ -147,14 +172,19 @@ class BackfillCache:
         :data:`~daydream.training.labeler_versions.LABELER_POLICY_VERSION`
         (read at call time) count as done — a policy bump re-fetches every
         previously completed session (M15 wholesale invalidation). Rows from
-        before the version field existed never match. Returns an empty set if
-        the log does not exist. Malformed lines are skipped (the log is
-        append-only and a partial last-line write is the only realistic
-        failure mode).
+        before the version field existed never match. A marker also ages out
+        once its ``completed_at`` is older than
+        :data:`CACHE_TTL_SECONDS`, so a re-run outside the freshness window
+        re-processes the session — letting an edited reply append a fresh
+        generation (M14) rather than being masked by a stale marker. Returns
+        an empty set if the log does not exist. Malformed lines are skipped
+        (the log is append-only and a partial last-line write is the only
+        realistic failure mode).
         """
         if not self.progress_path.exists():
             return set()
         current_version = labeler_versions.LABELER_POLICY_VERSION
+        cutoff = time.time() - CACHE_TTL_SECONDS
         out: set[str] = set()
         with self.progress_path.open("r", encoding="utf-8") as f:
             for raw in f:
@@ -166,6 +196,16 @@ class BackfillCache:
                 except json.JSONDecodeError:
                     continue
                 sid = row.get("session_id")
-                if isinstance(sid, str) and row.get("labeler_policy_version") == current_version:
-                    out.add(sid)
+                if not (isinstance(sid, str) and row.get("labeler_policy_version") == current_version):
+                    continue
+                completed_at = row.get("completed_at")
+                if not isinstance(completed_at, str):
+                    continue
+                try:
+                    stamped = datetime.fromisoformat(completed_at)
+                except ValueError:
+                    continue
+                if stamped.timestamp() < cutoff:
+                    continue
+                out.add(sid)
         return out

--- a/daydream/training/backfill_cache.py
+++ b/daydream/training/backfill_cache.py
@@ -13,7 +13,10 @@ This module provides two cooperating pieces:
   immutable, so no TTL is needed (see ``/tmp/research-backfill-sla.md``).
 * ``progress.jsonl`` — an append-only JSONL log of completed
   ``session_id`` rows, written by :meth:`BackfillCache.mark_session_done`
-  and read back by :meth:`BackfillCache.completed_sessions`.
+  and read back by :meth:`BackfillCache.completed_sessions`. Each row is
+  stamped with the labeler policy version in force at completion time, so
+  a policy bump wholesale-invalidates the resume markers (M15) and forces
+  a re-fetch rather than silently resuming stale labels.
 
 The cache is intentionally process-local and lock-free: each cache key
 maps to one file, and the labeler runs single-process. Cache files are
@@ -32,6 +35,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from daydream.json_utils import atomic_write_json
+from daydream.training import labeler_versions
 from daydream.ui import create_console, print_warning
 
 GHApiFn = Callable[..., Any]
@@ -120,25 +124,37 @@ class BackfillCache:
     def mark_session_done(self, session_id: str) -> None:
         """Append a completion row for ``session_id`` to ``progress.jsonl``.
 
+        The row records the labeler policy version in force at completion
+        time (M15), so a later policy bump invalidates the marker wholesale.
         Creates ``cache_dir`` if it does not already exist.
         """
         self.cache_dir.mkdir(parents=True, exist_ok=True)
         line = json.dumps(
-            {"session_id": session_id, "completed_at": _now_iso_utc()},
+            {
+                "session_id": session_id,
+                "labeler_policy_version": labeler_versions.LABELER_POLICY_VERSION,
+                "completed_at": _now_iso_utc(),
+            },
             sort_keys=True,
         )
         with self.progress_path.open("a", encoding="utf-8") as f:
             f.write(line + "\n")
 
     def completed_sessions(self) -> set[str]:
-        """Return the set of ``session_id``s recorded in ``progress.jsonl``.
+        """Return sessions recorded in ``progress.jsonl`` for the current policy.
 
-        Returns an empty set if the log does not exist. Malformed lines
-        are skipped (the log is append-only and a partial last-line
-        write is the only realistic failure mode).
+        Only rows whose stored ``labeler_policy_version`` equals the *current*
+        :data:`~daydream.training.labeler_versions.LABELER_POLICY_VERSION`
+        (read at call time) count as done — a policy bump re-fetches every
+        previously completed session (M15 wholesale invalidation). Rows from
+        before the version field existed never match. Returns an empty set if
+        the log does not exist. Malformed lines are skipped (the log is
+        append-only and a partial last-line write is the only realistic
+        failure mode).
         """
         if not self.progress_path.exists():
             return set()
+        current_version = labeler_versions.LABELER_POLICY_VERSION
         out: set[str] = set()
         with self.progress_path.open("r", encoding="utf-8") as f:
             for raw in f:
@@ -150,6 +166,6 @@ class BackfillCache:
                 except json.JSONDecodeError:
                     continue
                 sid = row.get("session_id")
-                if isinstance(sid, str):
+                if isinstance(sid, str) and row.get("labeler_policy_version") == current_version:
                     out.add(sid)
         return out

--- a/daydream/training/corpus.py
+++ b/daydream/training/corpus.py
@@ -844,7 +844,8 @@ def _is_admitted(
 
     - ``include_all_labels=True`` ⇒ always admit.
     - Otherwise admit when the pinned ``label`` is in ``filters.labels``
-      **and the row carries posterior evidence** (C9 accepted-only), **OR**
+      **and** it passes the gold-admission guard **and the row carries
+      posterior evidence** (C9 accepted-only), **OR**
       when ``filters.min_reward`` is set and the intrinsic
       ``composite_reward`` is present and ``>= min_reward``.
 
@@ -856,10 +857,12 @@ def _is_admitted(
     tiers. Rows whose label is not backed by a posterior are admissible only via
     the explicit intrinsic ``min_reward`` path or ``include_all_labels``.
 
-    The label path additionally requires the gold-admission guard
-    (``_is_admitted_outcome_gold``): rows are admitted only when their rubric
-    evidence is current-policy and decisive-only, so legacy reply-count/merge
-    rows and contested mixes never enter the corpus as gold.
+    The ``label in filters.labels`` conjunct keeps ``filters.labels``
+    authoritative for what counts as an admissible label (e.g. ``labels=()``
+    admits nothing on the label path); the gold-admission guard
+    (``_is_admitted_outcome_gold``) then constrains those rows to current-policy,
+    decisive-only rubric evidence, so legacy reply-count/merge rows and
+    contested mixes never enter the corpus as gold.
 
     The ``min_reward`` comparison is intrinsic-only **by construction** (C5),
     not by stripping a posterior term. Post-C5 the stored ``composite_reward``
@@ -873,7 +876,9 @@ def _is_admitted(
     """
     if filters.include_all_labels:
         return True
-    if _is_admitted_outcome_gold(label, has_posterior, labeler_policy_version, decisive_mix, decisive_only):
+    if label is not None and label in filters.labels and _is_admitted_outcome_gold(
+        label, has_posterior, labeler_policy_version, decisive_mix, decisive_only
+    ):
         return True
     if filters.min_reward is not None and composite_reward is not None and composite_reward >= filters.min_reward:
         return True

--- a/daydream/training/corpus.py
+++ b/daydream/training/corpus.py
@@ -772,12 +772,71 @@ def _is_posterior_leak(annotation: dict[str, Any] | None, as_of: str | None) -> 
     return datetime.fromisoformat(valid_at) > datetime.fromisoformat(as_of)
 
 
+_OUTCOME_GOLD_LABELS = frozenset({"accepted"})
+
+
+def _rubric_decisive_only(annotation: dict[str, Any] | None) -> bool:
+    """Derive the ``decisive_only`` flag from the observation's rubric JSON.
+
+    ``True`` when every per-finding disposition in ``per_finding_outcomes`` is
+    decisive (accepted/rejected) — or when the rubric carries no finding-level
+    evidence at all, in which case there is nothing to contradict a decisive
+    run label. A missing or malformed rubric is not itself disqualifying: the
+    legacy gate is ``labeler_policy_version is None``, which the guard checks
+    separately (M16) — that coercion, not this default, is what excludes
+    legacy rows.
+    """
+    raw_rubric = annotation.get("rubric_json") if annotation else None
+    if not isinstance(raw_rubric, str) or not raw_rubric:
+        return True
+    try:
+        rubric = json.loads(raw_rubric)
+    except json.JSONDecodeError:
+        return True
+    if not isinstance(rubric, dict):
+        return True
+    outcomes = rubric.get("per_finding_outcomes")
+    if not isinstance(outcomes, list) or not outcomes:
+        return True
+    return all(d in ("accepted", "rejected") for d in outcomes)
+
+
+def _is_admitted_outcome_gold(
+    label: str | None,
+    has_posterior: bool,
+    labeler_policy_version: str | None,
+    decisive_mix: bool,
+    decisive_only: bool,
+) -> bool:
+    """Gold-admission guard for outcome-bearing observations (M16/M22).
+
+    Admitted iff the label is an accepted-class gold label **and** the row
+    carries posterior evidence **and** the reply-classifier policy version is
+    known **and** the run-level rubric is decisive-only (no contested mix of
+    accepted/rejected dispositions, no ambiguous findings). Legacy rows —
+    reply-count / merge-presence gold with no ``labeler_policy_version`` — are
+    rejected: a missing policy version is the guard working, never a silent
+    fallback to admitted.
+    """
+    return (
+        label is not None
+        and label in _OUTCOME_GOLD_LABELS
+        and has_posterior
+        and labeler_policy_version is not None
+        and not decisive_mix
+        and decisive_only
+    )
+
+
 def _is_admitted(
     label: str | None,
     composite_reward: float | None,
     filters: CorpusFilters,
     *,
     has_posterior: bool = False,
+    labeler_policy_version: str | None = None,
+    decisive_mix: bool = False,
+    decisive_only: bool = True,
 ) -> bool:
     """Decide whether a run is admitted into the corpus.
 
@@ -797,6 +856,11 @@ def _is_admitted(
     tiers. Rows whose label is not backed by a posterior are admissible only via
     the explicit intrinsic ``min_reward`` path or ``include_all_labels``.
 
+    The label path additionally requires the gold-admission guard
+    (``_is_admitted_outcome_gold``): rows are admitted only when their rubric
+    evidence is current-policy and decisive-only, so legacy reply-count/merge
+    rows and contested mixes never enter the corpus as gold.
+
     The ``min_reward`` comparison is intrinsic-only **by construction** (C5),
     not by stripping a posterior term. Post-C5 the stored ``composite_reward``
     *is* the pure intrinsic composite (correctness + grounding − length
@@ -809,7 +873,7 @@ def _is_admitted(
     """
     if filters.include_all_labels:
         return True
-    if label is not None and label in filters.labels and has_posterior:
+    if _is_admitted_outcome_gold(label, has_posterior, labeler_policy_version, decisive_mix, decisive_only):
         return True
     if filters.min_reward is not None and composite_reward is not None and composite_reward >= filters.min_reward:
         return True
@@ -974,7 +1038,18 @@ def run_build_corpus(config: BuildCorpusConfig) -> dict[str, int]:
         composite_reward = annotation.get("composite_reward") if annotation is not None else None
         # A leaked posterior is not evidence at this pin, so it cannot admit on the label path.
         has_posterior = bool(annotation.get("has_posterior")) and not posterior_leak if annotation else False
-        if not _is_admitted(label, composite_reward, config.filters, has_posterior=has_posterior):
+        labeler_policy_version = annotation.get("labeler_policy_version") if annotation else None
+        decisive_mix = label == "contested"
+        decisive_only = _rubric_decisive_only(annotation)
+        if not _is_admitted(
+            label,
+            composite_reward,
+            config.filters,
+            has_posterior=has_posterior,
+            labeler_policy_version=labeler_policy_version,
+            decisive_mix=decisive_mix,
+            decisive_only=decisive_only,
+        ):
             continue
         after_filters += 1
 

--- a/daydream/training/corpus.py
+++ b/daydream/training/corpus.py
@@ -873,6 +873,11 @@ def _is_admitted(
     on its intrinsic score alone — there is no deduction to remove here. This
     invariant is pinned by
     ``test_is_admitted_min_reward_compares_intrinsic_only``.
+
+    A row admitted through the intrinsic ``min_reward`` path must still not
+    carry an outcome-gold label that the gold-admission guard rejects — the
+    caller drops such a label, so a legacy/contested/unevidenced ``accepted``
+    never re-enters the gold population via the reward back door.
     """
     if filters.include_all_labels:
         return True
@@ -1056,6 +1061,19 @@ def run_build_corpus(config: BuildCorpusConfig) -> dict[str, int]:
             decisive_only=decisive_only,
         ):
             continue
+        # The intrinsic ``min_reward`` path admits a row on its composite score
+        # alone (C5/M16). That must not smuggle an outcome-gold label whose
+        # evidence fails the gold-admission guard into the corpus as gold: a
+        # legacy NULL-policy ``accepted``, a contested/ambiguous mix, or an
+        # unevidenced (local_branch) accept would otherwise re-enter the
+        # accepted/gold population through the back door. Such a row is still
+        # admitted (the intrinsic path is unchanged) but only as an unlabeled
+        # intrinsic row — its label is dropped. Current-policy, evidenced,
+        # decisive-only gold keeps its label.
+        if label in _OUTCOME_GOLD_LABELS and not _is_admitted_outcome_gold(
+            label, has_posterior, labeler_policy_version, decisive_mix, decisive_only
+        ):
+            label = None
         after_filters += 1
 
         archive_path = Path(row["archive_path"])

--- a/daydream/training/harvest.py
+++ b/daydream/training/harvest.py
@@ -441,6 +441,8 @@ def _build_rubric_pr(
     repo_clone: Path,
     pr_merge: PRMergeSignal | None = None,
     changed_files: list[str],
+    pr_author_logins: frozenset[str] = frozenset(),
+    review_author_logins: frozenset[str] = frozenset(),
 ) -> Rubric:
     """Compose all four signals for a row that originated from a PR.
 
@@ -451,6 +453,11 @@ def _build_rubric_pr(
             fetched here as before.
         changed_files: Pre-decoded ``changed_files`` for ``row`` (the caller
             already decoded the JSON column via ``_row_changed_files``).
+        pr_author_logins: Logins whose replies count as PR-author judgment
+            under the M6 gate (passed through to
+            :func:`~daydream.training.labeler_signals.per_finding_resolution_signal`).
+        review_author_logins: Logins whose replies count as formal-review
+            judgment under the M6 gate.
     """
     signal_row = {**row, "changed_files": changed_files}
     if pr_merge is None:
@@ -482,6 +489,8 @@ def _build_rubric_pr(
             recorded_fingerprints=recorded_fingerprints,
             gh_api=gh_api,
             threads=comment_threads,
+            pr_author_logins=pr_author_logins,
+            review_author_logins=review_author_logins,
         )
         rubric = replace(rubric, per_finding_resolutions=list(per_finding))
     return rubric
@@ -720,16 +729,12 @@ def build_annotation(
             # Merge confirmed, so the PR provably exists; a secondary comment-fetch
             # GitError is transient and must propagate, not discard the confirmed
             # PRMergeSignal by degrading to local.
-            rubric = _build_rubric_pr(
-                row,
-                gh_api=gh_api,
-                repo_clone=repo_clone,
-                pr_merge=_pr_merge,
-                changed_files=changed_files,
-            )
-            valid_at = _decisive_evidence_valid_at(rubric)
-            if valid_at is None and rubric.pr_merge.merged:
-                valid_at = rubric.pr_merge.merged_at
+            # Resolve the human reviewer set BEFORE composing the per-finding
+            # rubric so the M6 gate can count PR-author and formal-review-author
+            # logins (issues #2/#4): a decisive reply from a fork-PR author or
+            # review author whose association is not OWNER/MEMBER/COLLABORATOR
+            # must not be excluded. An auxiliary-lookup GitError keeps the same
+            # degrade semantics as before — empty reviewer set, no prior.
             try:
                 reviewer_logins = reviewer_logins_signal(row, gh_api=gh_api)
             except RateLimitError:
@@ -738,17 +743,28 @@ def build_annotation(
                 # Reviewer-set prior only refines the decided outcome; an
                 # auxiliary-lookup failure degrades to no prior, keeping the label.
                 reviewer_logins = []
-                outcome_prior = None
-                prior_n = 0
-            else:
-                pooled, prior_n = reviewer_set_penalty_prior(
-                    archive_dir,
-                    reviewer_logins,
-                    before_valid_at=valid_at or datetime.now(timezone.utc).isoformat(),
-                    exclude_session=row["session_id"],
-                    repo_slug=row.get("repo_slug"),
-                )
-                outcome_prior = pooled if prior_n >= _PRIOR_SUFFICIENCY_THRESHOLD else None
+            rubric = _build_rubric_pr(
+                row,
+                gh_api=gh_api,
+                repo_clone=repo_clone,
+                pr_merge=_pr_merge,
+                changed_files=changed_files,
+                pr_author_logins=(
+                    frozenset({_pr_merge.author_login}) if _pr_merge.author_login else frozenset()
+                ),
+                review_author_logins=frozenset(reviewer_logins),
+            )
+            valid_at = _decisive_evidence_valid_at(rubric)
+            if valid_at is None and rubric.pr_merge.merged:
+                valid_at = rubric.pr_merge.merged_at
+            pooled, prior_n = reviewer_set_penalty_prior(
+                archive_dir,
+                reviewer_logins,
+                before_valid_at=valid_at or datetime.now(timezone.utc).isoformat(),
+                exclude_session=row["session_id"],
+                repo_slug=row.get("repo_slug"),
+            )
+            outcome_prior = pooled if prior_n >= _PRIOR_SUFFICIENCY_THRESHOLD else None
     else:
         rubric, valid_at, reviewer_logins, outcome_prior, prior_n = _degrade_to_local(
             row, repo_clone=repo_clone, clone_resolved=clone_resolved

--- a/daydream/training/harvest.py
+++ b/daydream/training/harvest.py
@@ -117,7 +117,7 @@ from daydream.training.labeler_signals import (
     reviewer_logins_signal,
 )
 from daydream.training.reward import ScoringInputs, score_trajectory
-from daydream.training.rubric import Rubric, derive_outcome_label, derive_per_finding_labels
+from daydream.training.rubric import Rubric, derive_outcome_label
 from daydream.ui import create_console, print_warning
 
 _VERDICTS_FILE = "recommendation-verdicts.json"
@@ -475,7 +475,7 @@ def _build_rubric_pr(
             gh_api=gh_api,
             threads=comment_threads,
         )
-        rubric = replace(rubric, per_finding_labels=list(derive_per_finding_labels(rubric, per_finding)))
+        rubric = replace(rubric, per_finding_resolutions=list(per_finding))
     return rubric
 
 

--- a/daydream/training/harvest.py
+++ b/daydream/training/harvest.py
@@ -54,8 +54,11 @@ Annotation builder:
   unpushed-SHA 422) degrades the row to its local-branch posterior; every other
   reviewer-signal, prior-query, posterior-fetch, and git error propagates to the
   caller, which isolates per-row.
-* ``valid_at`` is the PR merge timestamp for PR rows and ``None`` for
-  non-PR/local rows (the write layer collapses ``None`` → ``observed_at``).
+* ``valid_at`` is the earliest qualifying decisive-evidence timestamp — the
+  ``created_at`` of a reply supporting an ``accepted``/``rejected`` disposition
+  (M12) — falling back to the PR merge timestamp when no decisive evidence
+  exists, and ``None`` for non-PR/local rows (the write layer collapses
+  ``None`` → ``observed_at``).
 
 Orchestrator (:func:`run_harvest`):
 
@@ -550,9 +553,11 @@ class AnnotationPayload:
             ``"unknown"``, else a single-element list).
         pr_state: sqlite ``pr_state`` discriminator (``"merged"``/``"closed"``
             for PR rows, ``None`` for local-branch rows).
-        valid_at: The valid-time of the posterior outcome — the PR merge
-            timestamp for PR rows, ``None`` for non-PR/local rows (the write
-            layer collapses ``None`` → ``observed_at``).
+        valid_at: The valid-time of the posterior outcome — the earliest
+            qualifying decisive-evidence timestamp (M12), falling back to the
+            PR merge timestamp when no decisive evidence exists, and ``None``
+            for non-PR/local rows (the write layer collapses ``None`` →
+            ``observed_at``).
         reward_version: The :data:`daydream.training.reward.REWARD_VERSION`
             observed at scoring time.
         reward_json: ``json.dumps`` of the full
@@ -792,11 +797,14 @@ def _decisive_evidence_valid_at(rubric: Rubric) -> str | None:
     """Earliest qualifying decisive-evidence timestamp from the rubric (M12).
 
     Scans the per-finding resolutions' persisted evidence for ``created_at``
-    stamps of replies that support an ``accepted``/``rejected`` disposition
-    (non-excluded authors only). Malformed entries (missing/blank
-    ``created_at``) are skipped for the min computation; when no decisive
-    timestamp exists the caller falls back to the merge time or ``None`` —
-    never a fabricated timestamp.
+    stamps of replies that support the resolution's ``accepted``/``rejected``
+    disposition: an entry counts only when its author qualified (the
+    ``reason`` is not ``excluded:*``) AND the reply's own ``classifier_label``
+    matches the disposition — so an earlier qualifying-but-ambiguous reply
+    never pulls ``valid_at`` before the reply that actually decided the
+    finding. Malformed entries (missing/blank ``created_at``) are skipped for
+    the min computation; when no decisive timestamp exists the caller falls
+    back to the merge time or ``None`` — never a fabricated timestamp.
     """
     stamps: list[str] = []
     for resolution in rubric.per_finding_resolutions or []:
@@ -807,6 +815,8 @@ def _decisive_evidence_valid_at(rubric: Rubric) -> str | None:
                 continue
             reason = entry.get("reason")
             if not isinstance(reason, str) or reason.startswith("excluded:"):
+                continue
+            if entry.get("classifier_label") != resolution.disposition:
                 continue
             created_at = entry.get("created_at")
             if isinstance(created_at, str) and created_at:
@@ -1081,7 +1091,8 @@ async def run_harvest(config: HarvestConfig) -> dict[str, int]:
                 if appended:
                     summary["annotated"] += 1
                 else:
-                    # Deduped: unchanged evidence/reward-version is a no-op re-run.
+                    # Deduped: unchanged evidence/policy/digest/labels/posterior
+                    # is a no-op re-run.
                     summary["skipped"] += 1
                 # Either way the row is "done" for resume — re-running must not re-fetch it.
                 if cache is not None:

--- a/daydream/training/harvest.py
+++ b/daydream/training/harvest.py
@@ -60,9 +60,10 @@ Annotation builder:
 Orchestrator (:func:`run_harvest`):
 
 * **Idempotent and re-runnable:** every indexed run is considered on every
-  pass, but the write layer dedups on ``(evidence_sha, reward_version)`` — a
-  re-harvest with unchanged evidence is a no-op (counted in ``skipped``). A
-  ``REWARD_VERSION`` bump changes the dedup key and so appends a fresh
+  pass, but the write layer dedups on ``(evidence_sha, labeler_policy_version,
+  reply_evidence_digest, labels, has_posterior)`` — a re-harvest with unchanged
+  evidence is a no-op (counted in ``skipped``). A ``LABELER_POLICY_VERSION`` or
+  reply-evidence change alters the dedup key and so appends a fresh
   generation, letting older ``as_of`` pins still resolve their original
   generation. Only the ``cache``/``dry_run`` paths otherwise suppress writes.
 * **Per-row error isolation:** an exception on one row counts in ``errors`` and
@@ -956,11 +957,12 @@ async def run_harvest(config: HarvestConfig) -> dict[str, int]:
     ``reviewer_logins`` and the ``has_posterior`` population discriminator).
 
     **Idempotent and re-runnable:** every indexed run is considered, but the
-    write layer dedups on ``(evidence_sha, reward_version)`` — a re-harvest with
+    write layer dedups on ``(evidence_sha, labeler_policy_version,
+    reply_evidence_digest, labels, has_posterior)`` — a re-harvest with
     unchanged evidence is a no-op counted in ``skipped``. A later
-    ``REWARD_VERSION`` bump changes the dedup key and so appends a fresh
-    generation, letting older ``as_of`` pins still resolve their original
-    generation. Only the ``cache``/``dry_run`` paths otherwise suppress writes.
+    ``LABELER_POLICY_VERSION`` or reply-evidence change alters the dedup key
+    and so appends a fresh generation, letting older ``as_of`` pins still
+    resolve their original generation. Only the ``cache``/``dry_run`` paths otherwise suppress writes.
 
     Per-row error isolation: an exception on one row counts in ``errors`` and
     does not derail subsequent rows. Configuration errors (missing
@@ -980,7 +982,8 @@ async def run_harvest(config: HarvestConfig) -> dict[str, int]:
         raise FileNotFoundError(msg)
 
     # Queue every indexed run (optionally prefix-filtered); the write layer makes
-    # re-harvest idempotent by deduping unchanged (evidence_sha, reward_version).
+    # re-harvest idempotent by deduping unchanged evidence (evidence_sha,
+    # labeler_policy_version, reply_evidence_digest, labels, has_posterior).
     if config.session_filter:
         queue = query_runs(
             config.archive_dir,

--- a/daydream/training/harvest.py
+++ b/daydream/training/harvest.py
@@ -99,7 +99,7 @@ from daydream.archive.index import (
     set_run_pr_link,
 )
 from daydream.git_ops import GitError, RateLimitError
-from daydream.training import reward
+from daydream.training import labeler_versions, reward
 from daydream.training.backfill_cache import BackfillCache
 from daydream.training.base_sha import materialize_base_sha
 from daydream.training.labeler_signals import (
@@ -453,7 +453,12 @@ def _build_rubric_pr(
         pr_merge = pr_merge_signal(signal_row, gh_api=gh_api)
     # Fetch + index the PR's review comments once; both resolution signals
     # consume this index instead of each hitting the /comments endpoint.
-    comment_threads = index_pr_review_comments(signal_row, gh_api=gh_api)
+    recorded_fingerprints = _row_recorded_fingerprints(row)
+    comment_threads = index_pr_review_comments(
+        signal_row,
+        gh_api=gh_api,
+        session_fingerprints=recorded_fingerprints,
+    )
     comments = comment_resolution_signal(signal_row, gh_api=gh_api, threads=comment_threads)
     fix = _safe_fix_applied(
         signal_row,
@@ -467,7 +472,6 @@ def _build_rubric_pr(
         local_commit_applied=None,
         posterior_source="pr_review",
     )
-    recorded_fingerprints = _row_recorded_fingerprints(row)
     if recorded_fingerprints:
         per_finding = per_finding_resolution_signal(
             signal_row,
@@ -523,11 +527,14 @@ def _pr_state_for_rubric(rubric: Rubric) -> str | None:
     """Map a PR-review rubric to a sqlite ``pr_state`` discriminator.
 
     For local-branch rubrics returns ``None`` so the column reflects "no PR
-    associated".
+    associated". An unmerged PR preserves its live GitHub ``state`` (M11) —
+    ``open`` stays ``open`` rather than being collapsed to ``closed``.
     """
     if rubric.posterior_source != "pr_review":
         return None
-    return "merged" if rubric.pr_merge.merged else "closed"
+    if rubric.pr_merge.merged:
+        return "merged"
+    return rubric.pr_merge.state if rubric.pr_merge.state in ("open", "closed") else "closed"
 
 
 # Per-run annotation builder
@@ -567,6 +574,12 @@ class AnnotationPayload:
             penalty. ``local_branch`` rows keep their label but are **not**
             posterior evidence (a local commit is not a maintainer acting in a
             PR), so they carry ``False`` and no ``posterior_cost``.
+        reply_classifier_version: The
+            :data:`~daydream.training.labeler_versions.REPLY_CLASSIFIER_VERSION`
+            that produced the per-finding dispositions (M13 version axis).
+        reply_evidence_digest: Stable digest over the session's combined reply
+            evidence (M14 dedup input), or ``None`` when no reply evidence
+            exists.
     """
 
     labels: list[str]
@@ -579,6 +592,8 @@ class AnnotationPayload:
     rubric_json: str | None
     reviewer_logins: list[str]
     has_posterior: bool
+    reply_classifier_version: str | None = None
+    reply_evidence_digest: str | None = None
 
 
 def _degrade_to_local(
@@ -606,6 +621,7 @@ def build_annotation(
     gh_api: Any,
     repo_clone: Path,
     clone_resolved: bool = True,
+    valid_at_override: str | None = None,
 ) -> AnnotationPayload:
     """Build one run's bitemporal annotation payload (pure of DB writes).
 
@@ -650,10 +666,17 @@ def build_annotation(
             row. When ``False`` the local-branch posterior is forced to
             ``"unknown"`` rather than risking a ``"rejected"`` mislabel from a
             commit check that had no repository to inspect.
+        valid_at_override: Explicit valid-time that beats the derived
+            decisive-evidence timestamp when supplied (wired from the backfill
+            CLI); ``None`` keeps the derived value.
 
     Returns:
-        A frozen :class:`AnnotationPayload`. ``valid_at`` is the PR merge
-        timestamp for PR rows and ``None`` for non-PR/local rows.
+        A frozen :class:`AnnotationPayload`. ``valid_at`` is the earliest
+        qualifying decisive-evidence timestamp (the ``created_at`` of an
+        accepted/rejected-supporting reply, M12); when no decisive evidence
+        exists it falls back to the PR merge timestamp for merged PR rows and
+        ``None`` otherwise (and for non-PR/local rows). An explicit
+        ``valid_at_override`` wins over the derived value.
 
     Raises:
         AssertionError: When the scored breakdown does not carry the canonical
@@ -698,7 +721,9 @@ def build_annotation(
                 pr_merge=_pr_merge,
                 changed_files=changed_files,
             )
-            valid_at = rubric.pr_merge.merged_at
+            valid_at = _decisive_evidence_valid_at(rubric)
+            if valid_at is None and rubric.pr_merge.merged:
+                valid_at = rubric.pr_merge.merged_at
             try:
                 reviewer_logins = reviewer_logins_signal(row, gh_api=gh_api)
             except RateLimitError:
@@ -725,6 +750,8 @@ def build_annotation(
 
     outcome_label = derive_outcome_label(rubric)
     labels = [outcome_label] if outcome_label != "unknown" else []
+    if valid_at_override is not None:
+        valid_at = valid_at_override
 
     inputs = assemble_scoring_inputs(run_dir, row)
     # Only a maintainer acting on a real PR is posterior evidence; a local commit
@@ -755,7 +782,45 @@ def build_annotation(
         rubric_json=json.dumps(rubric.to_dict()),
         reviewer_logins=reviewer_logins,
         has_posterior=isinstance(rb, reward.PosteriorBreakdown),
+        reply_classifier_version=labeler_versions.REPLY_CLASSIFIER_VERSION,
+        reply_evidence_digest=_reply_evidence_digest(rubric),
     )
+
+
+def _decisive_evidence_valid_at(rubric: Rubric) -> str | None:
+    """Earliest qualifying decisive-evidence timestamp from the rubric (M12).
+
+    Scans the per-finding resolutions' persisted evidence for ``created_at``
+    stamps of replies that support an ``accepted``/``rejected`` disposition
+    (non-excluded authors only). Malformed entries (missing/blank
+    ``created_at``) are skipped for the min computation; when no decisive
+    timestamp exists the caller falls back to the merge time or ``None`` —
+    never a fabricated timestamp.
+    """
+    stamps: list[str] = []
+    for resolution in rubric.per_finding_resolutions or []:
+        if resolution.disposition not in ("accepted", "rejected"):
+            continue
+        for entry in resolution.evidence:
+            if not isinstance(entry, dict):
+                continue
+            reason = entry.get("reason")
+            if not isinstance(reason, str) or reason.startswith("excluded:"):
+                continue
+            created_at = entry.get("created_at")
+            if isinstance(created_at, str) and created_at:
+                stamps.append(created_at)
+    return min(stamps) if stamps else None
+
+
+def _reply_evidence_digest(rubric: Rubric) -> str | None:
+    """Stable digest over the session's combined reply evidence (M14).
+
+    ``None`` when no reply evidence was collected, so a digest-less row never
+    collides with a digested one under the versioned dedup key.
+    """
+    evidence = [entry for res in rubric.per_finding_resolutions or [] for entry in res.evidence]
+    return labeler_versions.reply_evidence_digest(evidence) if evidence else None
 
 
 # Repo resolution — three-tier priority: source_path → clone cache → None
@@ -998,7 +1063,7 @@ async def run_harvest(config: HarvestConfig) -> dict[str, int]:
                     row["session_id"],
                     labels=payload.labels,
                     pr_state=payload.pr_state,
-                    labeler_version=reward.REWARD_VERSION,
+                    labeler_version=labeler_versions.LABELER_POLICY_VERSION,
                     evidence_sha=payload.evidence_sha,
                     rubric_json=payload.rubric_json,
                     valid_at=payload.valid_at,
@@ -1007,6 +1072,8 @@ async def run_harvest(config: HarvestConfig) -> dict[str, int]:
                     composite_reward=payload.composite_reward,
                     reviewer_logins=payload.reviewer_logins,
                     has_posterior=payload.has_posterior,
+                    reply_classifier_version=payload.reply_classifier_version,
+                    reply_evidence_digest=payload.reply_evidence_digest,
                 )
                 if appended:
                     summary["annotated"] += 1

--- a/daydream/training/labeler_signals.py
+++ b/daydream/training/labeler_signals.py
@@ -71,12 +71,18 @@ class PRMergeSignal:
     Attributes:
         merged: ``True`` if the PR is marked merged on GitHub.
         merged_at: ISO-8601 timestamp of merge, or ``None``.
+        author_login: GitHub login of the PR author, or ``None`` when the
+            pull payload does not expose one (or the row has no PR). The
+            M6 gate uses it to count a PR-author reply as qualifying even
+            when their ``author_association`` is not
+            OWNER/MEMBER/COLLABORATOR (fork PRs, first-time contributors).
     """
 
     merged: bool
     merged_at: str | None
     state: Literal["open", "closed", "merged", "unknown"] = "unknown"
     draft: bool = False
+    author_login: str | None = None
 
 
 @dataclass(frozen=True)
@@ -390,6 +396,7 @@ def pr_merge_signal(
     if repo is None or number is None:
         return PRMergeSignal(merged=False, merged_at=None)
     payload = gh_api(repo, f"repos/{repo}/pulls/{number}")
+    user = payload.get("user") or {}
     return PRMergeSignal(
         merged=bool(payload.get("merged", False)),
         merged_at=payload.get("merged_at"),
@@ -401,6 +408,7 @@ def pr_merge_signal(
             else "unknown"
         ),
         draft=bool(payload.get("draft", False)),
+        author_login=user.get("login"),
     )
 
 

--- a/daydream/training/labeler_signals.py
+++ b/daydream/training/labeler_signals.py
@@ -9,8 +9,8 @@ labels:
 * :func:`fix_applied_signal` — did the recommended diff land in the
   upstream default branch within a configurable window? Implements the
   layered cascade documented in ``docs/signals/fix-applied.md``.
-* :func:`comment_resolution_signal` — did bot review comments get a
-  reply (proxy for "addressed")?
+* :func:`comment_resolution_signal` — aggregate over daydream review
+  comment threads (context only, not an outcome label).
 * :func:`local_commit_applied_signal` — for PR-less runs (see
   ``docs/signals/no-pr.md``), did a later local commit on the same
   branch carry the recommended diff content?
@@ -66,6 +66,8 @@ class PRMergeSignal:
 
     merged: bool
     merged_at: str | None
+    state: Literal["open", "closed", "merged", "unknown"] = "unknown"
+    draft: bool = False
 
 
 @dataclass(frozen=True)
@@ -284,6 +286,14 @@ def pr_merge_signal(
     return PRMergeSignal(
         merged=bool(payload.get("merged", False)),
         merged_at=payload.get("merged_at"),
+        state=(
+            "merged"
+            if payload.get("merged")
+            else payload.get("state")
+            if payload.get("state") in ("open", "closed")
+            else "unknown"
+        ),
+        draft=bool(payload.get("draft", False)),
     )
 
 
@@ -408,22 +418,31 @@ class PRCommentThreads:
 
     Attributes:
         top_level_daydream_ids: IDs of footer-marked daydream comments with
-            no parent (the "issue" comments).
+            no parent (the "issue" comments), scoped to the session's
+            fingerprints when one was supplied at index time.
         replied_ids: Subset of ``top_level_daydream_ids`` that received at
             least one reply.
         comment_id_by_fingerprint: First comment ID carrying each finding
             marker, keyed by 64-hex fingerprint.
+        replies_by_comment: Full reply comment dicts keyed by the parent
+            top-level comment ID. Replies are preserved as complete
+            objects (author, association, body, timestamps) — never
+            reduced to counts — so downstream classifiers can read the
+            reply text. Empty for other-run threads when a session
+            fingerprint scope was supplied.
     """
 
     top_level_daydream_ids: set[int]
     replied_ids: set[int]
     comment_id_by_fingerprint: dict[str, int]
+    replies_by_comment: dict[int, list[dict[str, Any]]] = field(default_factory=dict)
 
 
 def index_pr_review_comments(
     row: dict[str, Any],
     *,
     gh_api: Callable[..., Any],
+    session_fingerprints: list[str] | None = None,
 ) -> PRCommentThreads | None:
     """Fetch and index a PR's review comments for the resolution signals.
 
@@ -437,6 +456,11 @@ def index_pr_review_comments(
         row: Manifest row carrying ``pr_repo`` and ``pr_number``.
         gh_api: Callable returning the parsed comment list. Exceptions
             propagate to the caller.
+        session_fingerprints: When supplied, only top-level daydream
+            comments carrying at least one marker for one of these
+            fingerprints are indexed; other runs' threads stay out of
+            the evidence (they remain PR context, not this run's
+            outcome). ``None`` keeps the legacy all-threads behavior.
 
     Returns:
         :class:`PRCommentThreads`, or ``None`` when the row has no
@@ -449,27 +473,37 @@ def index_pr_review_comments(
 
     comments = gh_api(repo, f"repos/{repo}/pulls/{number}/comments", paginate=True)
 
+    scope = set(session_fingerprints) if session_fingerprints is not None else None
+
     # Pass 1: top-level daydream comment IDs and the fingerprints they carry.
     top_level_daydream_ids: set[int] = set()
     comment_id_by_fingerprint: dict[str, int] = {}
     for comment in comments:
         if comment.get("in_reply_to_id") is None and _is_daydream_comment(comment):
+            markers = parse_finding_markers(comment.get("body") or "")
+            if scope is not None and not any(fp in scope for fp in markers):
+                continue
             cid = comment["id"]
             top_level_daydream_ids.add(cid)
-            for fingerprint in parse_finding_markers(comment.get("body") or ""):
+            for fingerprint in markers:
                 comment_id_by_fingerprint.setdefault(fingerprint, cid)
 
-    # Pass 2: which top-level comments received a reply.
+    # Pass 2: which top-level comments received a reply, keeping the full
+    # reply objects (author, association, body, timestamps) rather than a
+    # count — the reply text is the evidence downstream classifiers need.
     replied_ids: set[int] = set()
+    replies_by_comment: dict[int, list[dict[str, Any]]] = {}
     for comment in comments:
         in_reply_to = comment.get("in_reply_to_id")
         if in_reply_to in top_level_daydream_ids:
             replied_ids.add(in_reply_to)
+            replies_by_comment.setdefault(in_reply_to, []).append(comment)
 
     return PRCommentThreads(
         top_level_daydream_ids=top_level_daydream_ids,
         replied_ids=replied_ids,
         comment_id_by_fingerprint=comment_id_by_fingerprint,
+        replies_by_comment=replies_by_comment,
     )
 
 
@@ -479,12 +513,17 @@ def comment_resolution_signal(
     gh_api: Callable[..., Any],
     threads: PRCommentThreads | None = None,
 ) -> CommentResolutionSignal:
-    """Return a proxy for "review comments addressed".
+    """Return an aggregate over daydream review-comment threads.
 
     Top-level review comments authored by daydream (identified by the
     :data:`DAYDREAM_FOOTER` badge in the comment body) are treated as
     issues; any reply (regardless of author or body) marks the issue
-    resolved.
+    resolved. This is a context-reporting aggregate only — reply presence
+    is not evidence of acceptance or rejection.
+
+    When the supplied (or fetched) threads were built with a session
+    fingerprint scope, the counts derive from that scope only: other
+    runs' threads on the same PR never inflate this run's evidence (M8).
 
     Args:
         row: Manifest row carrying ``pr_repo`` and ``pr_number``.
@@ -494,7 +533,9 @@ def comment_resolution_signal(
             :func:`index_pr_review_comments`. When supplied, the
             ``/comments`` fetch is skipped, letting a caller that needs
             both this and :func:`per_finding_resolution_signal` on one row
-            fetch the endpoint once.
+            fetch the endpoint once. The run-level signal path must pass
+            threads built with ``session_fingerprints`` so the aggregate
+            is fingerprint-scoped.
 
     Returns:
         :class:`CommentResolutionSignal` with ``(0, 0, 0)`` when the row

--- a/daydream/training/labeler_signals.py
+++ b/daydream/training/labeler_signals.py
@@ -23,13 +23,21 @@ HTTP calls.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Literal
+from typing import Any, Callable, Literal, cast
 
 from daydream.pr_review import parse_finding_markers
+from daydream.training.labeler_versions import reply_evidence_digest
+from daydream.training.reply_classifier import (
+    _QUALIFYING_ASSOCIATIONS,
+    _identity_gates_pass,
+    _login,
+    classify_reply,
+)
 
 # Version-stable footer prefix: matching only this prefix (not the full
 # version-pinned DAYDREAM_FOOTER) recognises comments from any daydream release.
@@ -107,22 +115,101 @@ class CommentResolutionSignal:
     unresolved: int
 
 
+PerFindingDisposition = Literal["accepted", "rejected", "ambiguous", "unanswered", "missing"]
+
+
+def _reply_reason(
+    reply: dict[str, Any],
+    pr_author_logins: frozenset[str],
+    review_author_logins: frozenset[str],
+) -> str:
+    """Why this reply's author qualified or was excluded (evidence ``reason``)."""
+    if reply.get("is_self_reply"):
+        return "excluded:self-reply"
+    if not _identity_gates_pass(reply):
+        return "excluded:bot"
+    assoc = reply.get("author_association")
+    if isinstance(assoc, str) and assoc in _QUALIFYING_ASSOCIATIONS:
+        return f"assoc:{assoc}"
+    login = _login(reply)
+    if login in pr_author_logins:
+        return "pr_author"
+    if login in review_author_logins:
+        return "review_author"
+    return "excluded:non-qualifying"
+
+
+def _reply_evidence(
+    replies: list[dict[str, Any]],
+    pr_author_logins: frozenset[str],
+    review_author_logins: frozenset[str],
+) -> list[dict[str, Any]]:
+    """Persist every reply as a full evidence entry — never reduced to a count (M3)."""
+    evidence: list[dict[str, Any]] = []
+    for reply in replies:
+        if not isinstance(reply, dict):
+            continue
+        evidence.append(
+            {
+                "reply_id": reply.get("id"),
+                "author": _login(reply),
+                "author_association": reply.get("author_association", ""),
+                "created_at": reply.get("created_at", ""),
+                "body_sha256": hashlib.sha256((reply.get("body") or "").encode("utf-8")).hexdigest(),
+                "reason": _reply_reason(reply, pr_author_logins, review_author_logins),
+            }
+        )
+    return evidence
+
+
+def _disposition_for_replies(
+    replies: list[dict[str, Any]],
+    evidence: list[dict[str, Any]],
+) -> PerFindingDisposition:
+    """Map replies to a disposition via the versioned classifier (M1/M4).
+
+    Deleted/inaccessible comments never reach here (``missing`` is decided
+    by the join, so a deleted comment can never map to ``rejected``).
+    """
+    if not any(isinstance(reply, dict) and _identity_gates_pass(reply) for reply in replies):
+        return "unanswered"
+    votes: set[PerFindingDisposition] = set()
+    for reply in replies:
+        if not isinstance(reply, dict) or not _identity_gates_pass(reply):
+            continue
+        label = classify_reply(reply)
+        if label in ("accepted", "rejected"):
+            votes.add(cast(PerFindingDisposition, label))
+    if len(votes) == 1:
+        return votes.pop()
+    return "ambiguous"
+
+
 @dataclass(frozen=True)
 class PerFindingResolution:
-    """Resolution state for one recorded finding, joined by fingerprint.
+    """Semantic disposition for one recorded finding, joined by fingerprint.
 
     Attributes:
         fingerprint: The 64-hex finding fingerprint recorded at review time.
-        resolved: ``True`` when the finding's posted comment received at
-            least one reply (proxy for "addressed").
         comment_id: GitHub review-comment ID carrying the finding marker,
             or ``None`` when no surviving comment carries the fingerprint
             (deleted, edited away, or never posted).
+        disposition: ``accepted``/``rejected``/``ambiguous`` from the
+            classifier over qualifying replies, ``unanswered`` when no
+            qualifying reply exists, ``missing`` when the fingerprint has
+            no surviving comment.
+        evidence: One entry per reply — ``reply_id``, ``author``,
+            ``author_association``, ``created_at``, ``body_sha256`` and a
+            ``reason`` recording why the author qualified or was excluded.
+            Full reply objects are persisted, never reduced to a count (M3).
+        evidence_digest: Stable digest over the evidence (M14 dedup input).
     """
 
     fingerprint: str
-    resolved: bool
     comment_id: int | None
+    disposition: PerFindingDisposition
+    evidence: list[dict[str, Any]] = field(default_factory=list)
+    evidence_digest: str = ""
 
 
 @dataclass(frozen=True)
@@ -554,17 +641,23 @@ def per_finding_resolution_signal(
     row: dict[str, Any],
     *,
     recorded_fingerprints: list[str],
-    gh_api: Callable[..., Any],
+    gh_api: Callable[..., Any] | None,
     threads: PRCommentThreads | None = None,
+    pr_author_logins: frozenset[str] = frozenset(),
+    review_author_logins: frozenset[str] = frozenset(),
 ) -> list[PerFindingResolution]:
-    """Resolve each recorded finding to its posted comment and reply state.
+    """Resolve each recorded finding to a semantic disposition (M1/M4).
 
     Joins the fingerprints recorded at review time (``recorded_fingerprints``)
     against the PR's live review comments by the hidden
     ``<!-- daydream-finding: <fp> -->`` marker embedded in each daydream
-    comment body. A finding is ``resolved`` when its comment received at
-    least one reply; a fingerprint with no surviving comment yields
-    ``comment_id=None`` (deleted / edited away / never posted).
+    comment body, then classifies the surviving replies through the
+    versioned reply classifier: qualifying decisive votes give their label,
+    qualifying non-directional or conflicting replies give ``ambiguous``,
+    and no qualifying reply gives ``unanswered``. A fingerprint with no
+    surviving comment yields ``missing`` with ``comment_id=None`` (deleted /
+    edited away / never posted) — a deleted comment can never map to
+    ``rejected`` (M4).
 
     Args:
         row: Manifest row carrying ``pr_repo`` and ``pr_number``.
@@ -577,12 +670,18 @@ def per_finding_resolution_signal(
             ``/comments`` fetch is skipped, letting a caller that needs
             both this and :func:`comment_resolution_signal` on one row
             fetch the endpoint once.
+        pr_author_logins: Logins whose replies count as PR-author judgment
+            (recorded in evidence reasons).
+        review_author_logins: Logins whose replies count as formal-review
+            judgment (recorded in evidence reasons).
 
     Returns:
         One :class:`PerFindingResolution` per recorded fingerprint, or an
         empty list when the row has no associated PR.
     """
     if threads is None:
+        if gh_api is None:
+            raise ValueError("per_finding_resolution_signal needs gh_api when threads is not supplied")
         threads = index_pr_review_comments(row, gh_api=gh_api)
     if threads is None:
         return []
@@ -590,9 +689,21 @@ def per_finding_resolution_signal(
     resolutions: list[PerFindingResolution] = []
     for fingerprint in recorded_fingerprints:
         comment_id = threads.comment_id_by_fingerprint.get(fingerprint)
-        resolved = comment_id is not None and comment_id in threads.replied_ids
+        if comment_id is None:
+            resolutions.append(
+                PerFindingResolution(fingerprint=fingerprint, comment_id=None, disposition="missing")
+            )
+            continue
+        replies = threads.replies_by_comment.get(comment_id, [])
+        evidence = _reply_evidence(replies, pr_author_logins, review_author_logins)
         resolutions.append(
-            PerFindingResolution(fingerprint=fingerprint, resolved=resolved, comment_id=comment_id)
+            PerFindingResolution(
+                fingerprint=fingerprint,
+                comment_id=comment_id,
+                disposition=_disposition_for_replies(replies, evidence),
+                evidence=evidence,
+                evidence_digest=reply_evidence_digest(evidence),
+            )
         )
     return resolutions
 

--- a/daydream/training/labeler_signals.py
+++ b/daydream/training/labeler_signals.py
@@ -37,6 +37,7 @@ from daydream.training.reply_classifier import (
     _identity_gates_pass,
     _login,
     classify_reply,
+    is_qualifying_author,
 )
 
 # Version-stable footer prefix: matching only this prefix (not the full
@@ -157,6 +158,11 @@ def _reply_evidence(
                 "created_at": reply.get("created_at", ""),
                 "body_sha256": hashlib.sha256((reply.get("body") or "").encode("utf-8")).hexdigest(),
                 "reason": _reply_reason(reply, pr_author_logins, review_author_logins),
+                # Per-reply classifier axis (``classify_reply`` output): the field
+                # harvest's ``_decisive_evidence_valid_at`` filters on, so an earlier
+                # qualifying-but-ambiguous reply never moves ``valid_at`` ahead of
+                # the reply that actually decided the disposition (M12).
+                "classifier_label": classify_reply(reply),
             }
         )
     return evidence
@@ -164,18 +170,32 @@ def _reply_evidence(
 
 def _disposition_for_replies(
     replies: list[dict[str, Any]],
-    evidence: list[dict[str, Any]],
+    pr_author_logins: frozenset[str],
+    review_author_logins: frozenset[str],
 ) -> PerFindingDisposition:
-    """Map replies to a disposition via the versioned classifier (M1/M4).
+    """Map replies to a disposition via the versioned classifier (M1/M4/M6).
 
     Deleted/inaccessible comments never reach here (``missing`` is decided
     by the join, so a deleted comment can never map to ``rejected``).
+
+    Only replies whose author qualifies under the M6 gate
+    (:func:`is_qualifying_author`) may cast a decisive vote — the same gate
+    the persisted evidence ``reason`` records (``_reply_reason``). A reply
+    whose own evidence says ``excluded:non-qualifying`` must not decide the
+    finding, or harvest's ``_decisive_evidence_valid_at`` would drop its
+    timestamp as excluded while the disposition kept its vote (M6).
     """
-    if not any(isinstance(reply, dict) and _identity_gates_pass(reply) for reply in replies):
+    if not any(
+        isinstance(reply, dict)
+        and is_qualifying_author(reply, pr_author_logins, review_author_logins)
+        for reply in replies
+    ):
         return "unanswered"
     votes: set[PerFindingDisposition] = set()
     for reply in replies:
-        if not isinstance(reply, dict) or not _identity_gates_pass(reply):
+        if not isinstance(reply, dict):
+            continue
+        if not is_qualifying_author(reply, pr_author_logins, review_author_logins):
             continue
         label = classify_reply(reply)
         if label in ("accepted", "rejected"):
@@ -700,7 +720,9 @@ def per_finding_resolution_signal(
             PerFindingResolution(
                 fingerprint=fingerprint,
                 comment_id=comment_id,
-                disposition=_disposition_for_replies(replies, evidence),
+                disposition=_disposition_for_replies(
+                    replies, pr_author_logins, review_author_logins
+                ),
                 evidence=evidence,
                 evidence_digest=reply_evidence_digest(evidence),
             )

--- a/daydream/training/labeler_versions.py
+++ b/daydream/training/labeler_versions.py
@@ -20,13 +20,16 @@ REPLY_EVIDENCE_DIGEST_FORMAT = "sha256/1"
 def reply_evidence_digest(replies: list[dict[str, Any]]) -> str:
     """Stable sha256 hexdigest over the canonical reply-evidence JSON.
 
-    Replies are sorted by ``id`` and serialized with sorted keys. Missing keys
-    contribute ``""`` (via ``sort_keys``-safe defaults) rather than raising;
-    semantic fallbacks are the caller's contract, never applied here.
+    Replies are sorted by ``reply_id`` (falling back to ``id`` for raw
+    review-comment dicts), so the order normalization actually runs on the
+    evidence entries this pipeline passes in — keyed ``reply_id``/``body_sha256``
+    — and then serialized with sorted keys. Missing keys contribute ``""``
+    (via ``sort_keys``-safe defaults) rather than raising; semantic fallbacks
+    are the caller's contract, never applied here.
     """
     normalized = [
         {**reply, "body": reply.get("body", "")}
-        for reply in sorted(replies, key=lambda r: r.get("id", ""))
+        for reply in sorted(replies, key=lambda r: str(r.get("reply_id", r.get("id", ""))))
     ]
     canonical = json.dumps(normalized, sort_keys=True, default=str)
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()

--- a/daydream/training/labeler_versions.py
+++ b/daydream/training/labeler_versions.py
@@ -1,0 +1,32 @@
+"""Version constants for the reply-labeling pipeline and reply evidence digest.
+
+Independent version axes (M13): rubric schema, labeler policy, reply classifier,
+and evidence digest format each evolve separately from ``reward.REWARD_VERSION``.
+This module imports nothing from the rest of the training package.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+RUBRIC_SCHEMA_VERSION = "980-rubric-r1"
+LABELER_POLICY_VERSION = "980-policy-r1"
+REPLY_CLASSIFIER_VERSION = "980-classifier-r1"
+REPLY_EVIDENCE_DIGEST_FORMAT = "sha256/1"
+
+
+def reply_evidence_digest(replies: list[dict[str, Any]]) -> str:
+    """Stable sha256 hexdigest over the canonical reply-evidence JSON.
+
+    Replies are sorted by ``id`` and serialized with sorted keys. Missing keys
+    contribute ``""`` (via ``sort_keys``-safe defaults) rather than raising;
+    semantic fallbacks are the caller's contract, never applied here.
+    """
+    normalized = [
+        {**reply, "body": reply.get("body", "")}
+        for reply in sorted(replies, key=lambda r: r.get("id", ""))
+    ]
+    canonical = json.dumps(normalized, sort_keys=True, default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()

--- a/daydream/training/labeler_versions.py
+++ b/daydream/training/labeler_versions.py
@@ -11,7 +11,7 @@ import hashlib
 import json
 from typing import Any
 
-RUBRIC_SCHEMA_VERSION = "980-rubric-r1"
+RUBRIC_SCHEMA_VERSION = "980-rubric-r2"
 LABELER_POLICY_VERSION = "980-policy-r1"
 REPLY_CLASSIFIER_VERSION = "980-classifier-r1"
 REPLY_EVIDENCE_DIGEST_FORMAT = "sha256/1"

--- a/daydream/training/reply_classifier.py
+++ b/daydream/training/reply_classifier.py
@@ -1,0 +1,206 @@
+"""Conservative, versioned reply classifier for semantic gold labels.
+
+Turns qualifying human reply text into a per-finding disposition:
+``"accepted"``, ``"rejected"``, or ``"ambiguous"``. Pure functions only —
+no I/O. Anything unclassifiable fails closed to ``"ambiguous"``.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+REPLY_CLASSIFIER_VERSION = "reply-classifier-v1"
+
+#: Logins that never qualify as reply authors (daydream's own accounts).
+_DAYDREAM_AGENT_LOGINS = frozenset({"daydream-agent", "daydream-bot"})
+
+_QUALIFYING_ASSOCIATIONS = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
+
+_DECISIVE = ("accepted", "rejected")
+
+# (pattern, kind) pairs. Matching is per-line, case-insensitive, whole-phrase
+# with word boundaries — never bare substrings.
+_ACCEPT_RULES: tuple[tuple[str, str], ...] = (
+    (r"fixed\s+in\s+\b[0-9a-f]{6,40}\b", "sha"),
+    (r"\bapplied\b", "applied"),
+    (r"\bgood\s+catch\b", "agree"),
+    (r"\bagreed\b,?\s*(the\s+)?fix", "agree"),
+)
+
+_REJECT_RULES: tuple[tuple[str, str], ...] = (
+    (r"\bnot\s+applicable\b", "na"),
+    (r"\balready\s+(?:handled|exists)\b", "handled"),
+    (r"\bfalse\s+positive\b", "fp"),
+    (r"\bintentional\b", "intentional"),
+)
+
+#: "won't fix" is only a rejection when a dispute phrase co-occurs.
+_DISPUTE_RULES: tuple[tuple[str, str], ...] = (
+    (r"won'?t\s+fix", "wontfix"),
+    (r"\bwrong\b", "wrong"),
+    (r"\bincorrect\b", "incorrect"),
+    (r"\bnot\s+a\s+bug\b", "notabug"),
+    (r"\bthe\s+code\s+already\b", "codealready"),
+)
+
+_FACTUAL_DISAGREEMENT_RULES: tuple[tuple[str, str], ...] = (
+    (r"\bdisagree\b", "disagree"),
+    (r"\bthe\s+docs\s+say\b", "docs"),
+)
+
+_NEGATION_TOKENS = re.compile(r"\b(?:not|never)\b|\bn't\b", re.IGNORECASE)
+
+
+def _sentence_containing(text: str, start: int, end: int) -> str:
+    """Return the sentence (split on .!?; and newlines) containing [start, end)."""
+    sentence_starts = [0] + [m.end() for m in re.finditer(r"[.!?;\n]", text) if m.end() <= start]
+    start_idx = sentence_starts[-1]
+    tail = re.search(r"[.!?;\n]", text[end:])
+    end_idx = end + (tail.start() if tail else len(text[end:]))
+    return text[start_idx:end_idx]
+
+
+def _is_negated(text: str, start: int) -> bool:
+    """True when a negation token appears before ``start`` in the same sentence."""
+    sentence = _sentence_containing(text, start, start)
+    return bool(_NEGATION_TOKENS.search(sentence[: _sentence_offset(sentence, text, start)]))
+
+
+def _sentence_offset(sentence: str, text: str, start: int) -> int:
+    # Offset of `start` within its sentence.
+    idx = text.find(sentence)
+    return start - idx if idx >= 0 else start
+
+
+def _match_rules(
+    text: str, rules: tuple[tuple[str, str], ...], *, guard_negation: bool
+) -> bool:
+    for pattern, _kind in rules:
+        for m in re.finditer(pattern, text, re.IGNORECASE):
+            if guard_negation and _is_negated(text, m.start()):
+                continue
+            return True
+    return False
+
+
+def _dispute_present(text: str) -> bool:
+    """Any dispute marker, un-negated, co-occurring in the body."""
+    for pattern, _kind in _DISPUTE_RULES[1:]:
+        for m in re.finditer(pattern, text, re.IGNORECASE):
+            if not _is_negated(text, m.start()):
+                return True
+    # "won't fix" itself is a dispute trigger phrase but does not self-satisfy;
+    # a *second*, distinct dispute marker is required.
+    return False
+
+
+def _direction(body: str) -> str:
+    lines = body.splitlines() or [""]
+    directions: set[str] = set()
+    for line in lines:
+        if not line.strip():
+            continue
+        has_accept = _match_rules(line, _ACCEPT_RULES, guard_negation=True)
+        has_wontfix = bool(re.search(_DISPUTE_RULES[0][0], line, re.IGNORECASE))
+        has_dispute = _dispute_present(line)
+        has_reject = _match_rules(line, _REJECT_RULES, guard_negation=False) or (
+            has_wontfix and has_dispute
+        )
+        has_factual = _match_rules(line, _FACTUAL_DISAGREEMENT_RULES, guard_negation=False)
+        if has_accept:
+            directions.add("accepted")
+        if has_reject or has_factual:
+            directions.add("rejected")
+    if len(directions) == 1:
+        return directions.pop()
+    return "ambiguous"
+
+
+def _login(reply: dict[str, Any]) -> str:
+    user = reply.get("user")
+    if not isinstance(user, dict):
+        return ""
+    login = user.get("login")
+    return login if isinstance(login, str) else ""
+
+
+def _user_type(reply: dict[str, Any]) -> str:
+    user = reply.get("user")
+    if not isinstance(user, dict):
+        return ""
+    utype = user.get("type")
+    return utype if isinstance(utype, str) else ""
+
+
+def _identity_gates_pass(reply: dict[str, Any]) -> bool:
+    """Bot / daydream-agent / empty-login gates, independent of association."""
+    if reply.get("is_self_reply"):
+        return False
+    if _user_type(reply) == "Bot":
+        return False
+    login = _login(reply)
+    if not login or login.lower() in _DAYDREAM_AGENT_LOGINS:
+        return False
+    if login.lower().endswith("[bot]"):
+        return False
+    return True
+
+
+def is_qualifying_author(
+    reply: dict[str, Any],
+    pr_author_logins: set[str] | frozenset[str],
+    review_author_logins: set[str] | frozenset[str] = frozenset(),
+) -> bool:
+    """True when the reply's author is a human whose judgment counts (M6).
+
+    Qualifies when the author is not a bot, has a non-empty login that is not
+    a daydream agent, is not a marked self-reply, and is either a PR author,
+    a formal-review author, or holds OWNER/MEMBER/COLLABORATOR association.
+    """
+    if reply.get("is_self_reply"):
+        return False
+    if not _identity_gates_pass(reply):
+        return False
+    login = _login(reply)
+    assoc = reply.get("author_association")
+    if isinstance(assoc, str) and assoc in _QUALIFYING_ASSOCIATIONS:
+        return True
+    if login in pr_author_logins or login in review_author_logins:
+        return True
+    return False
+
+
+def classify_reply(reply: dict[str, Any]) -> str:
+    """Classify a single reply as ``"accepted"``/``"rejected"``/``"ambiguous"``.
+
+    Non-qualifying authors and unparseable bodies are always ``"ambiguous"``.
+    """
+    if not _identity_gates_pass(reply):
+        return "ambiguous"
+    body = reply.get("body")
+    if not isinstance(body, str) or not body.strip():
+        return "ambiguous"
+    return _direction(body)
+
+
+def classify_replies(replies: list[dict[str, Any]]) -> str:
+    """Aggregate reply classifications conservatively (M18/M22).
+
+    Filters to qualifying authors, drops ambiguous votes, and returns the
+    single decisive label, ``"ambiguous"`` on conflict, or ``"ambiguous"``
+    when no decisive vote exists. Deterministic: identical input yields
+    identical output.
+    """
+    votes: set[str] = set()
+    for reply in replies:
+        if not isinstance(reply, dict):
+            continue
+        if not _identity_gates_pass(reply):
+            continue
+        label = classify_reply(reply)
+        if label in _DECISIVE:
+            votes.add(label)
+    if len(votes) == 1:
+        return votes.pop()
+    return "ambiguous"

--- a/daydream/training/reply_classifier.py
+++ b/daydream/training/reply_classifier.py
@@ -10,14 +10,14 @@ from __future__ import annotations
 import re
 from typing import Any
 
-REPLY_CLASSIFIER_VERSION = "reply-classifier-v1"
+from daydream.training.labeler_versions import (
+    REPLY_CLASSIFIER_VERSION as REPLY_CLASSIFIER_VERSION,
+)
 
 #: Logins that never qualify as reply authors (daydream's own accounts).
 _DAYDREAM_AGENT_LOGINS = frozenset({"daydream-agent", "daydream-bot"})
 
 _QUALIFYING_ASSOCIATIONS = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
-
-_DECISIVE = ("accepted", "rejected")
 
 # (pattern, kind) pairs. Matching is per-line, case-insensitive, whole-phrase
 # with word boundaries — never bare substrings.
@@ -73,9 +73,7 @@ def _sentence_offset(sentence: str, text: str, start: int) -> int:
     return start - idx if idx >= 0 else start
 
 
-def _match_rules(
-    text: str, rules: tuple[tuple[str, str], ...], *, guard_negation: bool
-) -> bool:
+def _match_rules(text: str, rules: tuple[tuple[str, str], ...], *, guard_negation: bool) -> bool:
     for pattern, _kind in rules:
         for m in re.finditer(pattern, text, re.IGNORECASE):
             if guard_negation and _is_negated(text, m.start()):
@@ -104,10 +102,8 @@ def _direction(body: str) -> str:
         has_accept = _match_rules(line, _ACCEPT_RULES, guard_negation=True)
         has_wontfix = bool(re.search(_DISPUTE_RULES[0][0], line, re.IGNORECASE))
         has_dispute = _dispute_present(line)
-        has_reject = _match_rules(line, _REJECT_RULES, guard_negation=False) or (
-            has_wontfix and has_dispute
-        )
-        has_factual = _match_rules(line, _FACTUAL_DISAGREEMENT_RULES, guard_negation=False)
+        has_reject = _match_rules(line, _REJECT_RULES, guard_negation=True) or (has_wontfix and has_dispute)
+        has_factual = _match_rules(line, _FACTUAL_DISAGREEMENT_RULES, guard_negation=True)
         if has_accept:
             directions.add("accepted")
         if has_reject or has_factual:
@@ -182,25 +178,3 @@ def classify_reply(reply: dict[str, Any]) -> str:
     if not isinstance(body, str) or not body.strip():
         return "ambiguous"
     return _direction(body)
-
-
-def classify_replies(replies: list[dict[str, Any]]) -> str:
-    """Aggregate reply classifications conservatively (M18/M22).
-
-    Filters to qualifying authors, drops ambiguous votes, and returns the
-    single decisive label, ``"ambiguous"`` on conflict, or ``"ambiguous"``
-    when no decisive vote exists. Deterministic: identical input yields
-    identical output.
-    """
-    votes: set[str] = set()
-    for reply in replies:
-        if not isinstance(reply, dict):
-            continue
-        if not _identity_gates_pass(reply):
-            continue
-        label = classify_reply(reply)
-        if label in _DECISIVE:
-            votes.add(label)
-    if len(votes) == 1:
-        return votes.pop()
-    return "ambiguous"

--- a/daydream/training/rubric.py
+++ b/daydream/training/rubric.py
@@ -34,7 +34,7 @@ from daydream.training.labeler_signals import (
 
 PosteriorSource = Literal["pr_review", "local_branch", "none"]
 
-PerFindingLabel = Literal["accepted", "rejected", "ambiguous", "unanswered", "missing", "unknown", "contested"]
+PerFindingLabel = Literal["accepted", "rejected", "ambiguous", "unanswered", "missing", "unknown"]
 
 _DECISIVE = ("accepted", "rejected")
 _NON_DECISIVE = ("ambiguous", "unanswered", "missing")

--- a/daydream/training/rubric.py
+++ b/daydream/training/rubric.py
@@ -13,6 +13,10 @@ A :class:`Rubric` knows two things:
   :func:`derive_outcome_label`. Both are pure functions — invalid
   invariants (e.g. ``unresolved > total``) are not validated here;
   upstream extractors guarantee them.
+
+Per-finding label vocabulary: ``accepted`` / ``rejected`` (decisive
+classifier dispositions), ``ambiguous`` / ``unanswered`` /
+``missing`` (non-decisive), and ``unknown`` (non-PR posterior sources).
 """
 
 from __future__ import annotations
@@ -30,7 +34,10 @@ from daydream.training.labeler_signals import (
 
 PosteriorSource = Literal["pr_review", "local_branch", "none"]
 
-PerFindingLabel = Literal["accepted", "contested", "rejected", "unknown", "missing"]
+PerFindingLabel = Literal["accepted", "rejected", "ambiguous", "unanswered", "missing", "unknown", "contested"]
+
+_DECISIVE = ("accepted", "rejected")
+_NON_DECISIVE = ("ambiguous", "unanswered", "missing")
 
 
 @dataclass(frozen=True)
@@ -38,7 +45,8 @@ class Rubric:
     """Bundle of posterior signals + the discriminator for outcome derivation.
 
     Attributes:
-        pr_merge: Whether the originating PR was merged.
+        pr_merge: Whether the originating PR was merged (plus preserved
+            PR ``state``/``draft`` context).
         fix_applied: Layered-cascade verdict on whether the recommended
             diff landed upstream within the review window.
         comment_resolution: Proxy for "review comments addressed".
@@ -46,9 +54,9 @@ class Rubric:
             row originated from a PR.
         posterior_source: Discriminator selecting which sub-signal
             carries the authoritative outcome label.
-        per_finding_labels: One outcome label per recorded finding
-            (fingerprint-joined), or ``None`` when no per-finding join was
-            performed.
+        per_finding_resolutions: Per-finding dispositions joined by
+            fingerprint, or ``None`` when no per-finding join was
+            performed. Serialized as ``per_finding_outcomes``.
     """
 
     pr_merge: PRMergeSignal
@@ -56,7 +64,7 @@ class Rubric:
     comment_resolution: CommentResolutionSignal
     local_commit_applied: LocalCommitAppliedSignal | None
     posterior_source: PosteriorSource
-    per_finding_labels: list[str] | None = None
+    per_finding_resolutions: list[PerFindingResolution] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-serializable representation with explicit key order.
@@ -69,6 +77,8 @@ class Rubric:
             "pr_merge": {
                 "merged": self.pr_merge.merged,
                 "merged_at": self.pr_merge.merged_at,
+                "state": self.pr_merge.state,
+                "draft": self.pr_merge.draft,
             },
             "fix_applied": {
                 "verdict": self.fix_applied.verdict,
@@ -84,8 +94,8 @@ class Rubric:
         }
         if self.local_commit_applied is not None:
             out["local_commit_applied"] = {"verdict": self.local_commit_applied.verdict}
-        if self.per_finding_labels is not None:
-            out["per_finding_outcomes"] = list(self.per_finding_labels)
+        if self.per_finding_resolutions is not None:
+            out["per_finding_outcomes"] = derive_per_finding_labels(self, self.per_finding_resolutions)
         return out
 
 
@@ -94,13 +104,15 @@ def derive_outcome_label(rubric: Rubric) -> str:
 
     Selection follows ``rubric.posterior_source``:
 
-    * ``"pr_review"`` — merge-state plus comment resolution decide:
-      ``"accepted"`` (merged, at least one tracked daydream comment, none
-      unresolved), ``"contested"`` (merged but unresolved > 0),
-      ``"rejected"`` (not merged), or ``"unknown"`` (merged with **zero**
-      tracked comments). A merge alone is not an accept: with ``total == 0``
-      the run has no evidence it contributed anything to the PR, and
-      ``unresolved == 0`` would otherwise be vacuously true.
+    * ``"pr_review"`` — conservatively aggregate the per-finding
+      dispositions (never bare merge state): ``"accepted"`` when every
+      disposition is ``accepted`` and at least one finding was mapped,
+      ``"rejected"`` when every disposition is ``rejected`` (also with at
+      least one mapped finding), ``"contested"`` when decisive
+      dispositions are mixed or decisive evidence coexists with
+      ambiguous/unanswered/missing findings, and ``"unknown"`` when no
+      finding was mapped or none of the dispositions is decisive. Merge
+      state is context only — it never decides the label.
     * ``"local_branch"`` — passes through the verdict on
       :attr:`Rubric.local_commit_applied`.
     * ``"none"`` — always ``"unknown"``.
@@ -110,14 +122,19 @@ def derive_outcome_label(rubric: Rubric) -> str:
         ``"unknown"``.
     """
     if rubric.posterior_source == "pr_review":
-        if rubric.pr_merge.merged:
-            if rubric.comment_resolution.total == 0:
-                # No tracked comments ⇒ unresolved == 0 is vacuous, not evidence.
-                return "unknown"
-            if rubric.comment_resolution.unresolved == 0:
-                return "accepted"
+        dispositions = [r.disposition for r in (rubric.per_finding_resolutions or [])]
+        if not dispositions:
+            return "unknown"
+        decisive = [d for d in dispositions if d in _DECISIVE]
+        if not decisive:
+            return "unknown"
+        if any(d in _NON_DECISIVE for d in dispositions):
             return "contested"
-        return "rejected"
+        if all(d == "accepted" for d in decisive):
+            return "accepted"
+        if all(d == "rejected" for d in decisive):
+            return "rejected"
+        return "contested"
     if rubric.posterior_source == "local_branch":
         # Extractor invariant: posterior_source="local_branch" implies
         # local_commit_applied is not None.
@@ -140,19 +157,15 @@ def derive_per_finding_labels(
 ) -> list[PerFindingLabel]:
     """Reduce per-finding resolutions to one outcome label per finding.
 
-    Only ``posterior_source == "pr_review"`` yields decisive per-finding
-    labels; any other source is inconclusive at finding granularity:
-
-    * ``"pr_review"`` on a **merged** PR:
-      - resolved (replied) → ``"accepted"``
-      - unresolved with a surviving comment → ``"contested"``
-      - unresolved with no comment (deleted / never posted) → ``"missing"``
-    * ``"pr_review"`` on an **unmerged** PR → all ``"rejected"``.
-    * any other posterior source → all ``"unknown"``.
+    Only ``posterior_source == "pr_review"`` yields dispositions as
+    labels, passed through verbatim in order — the classifier already
+    decided per finding, and merge state is context only (never mapped
+    onto a disposition). Any other posterior source is inconclusive at
+    finding granularity: all ``"unknown"``.
 
     Args:
-        rubric: The rubric whose posterior source and merge state decide
-            the mapping.
+        rubric: The rubric whose posterior source decides whether
+            dispositions may be trusted.
         per_finding: The per-finding resolutions to label, in order.
 
     Returns:
@@ -161,15 +174,4 @@ def derive_per_finding_labels(
     """
     if rubric.posterior_source != "pr_review":
         return ["unknown" for _ in per_finding]
-    if not rubric.pr_merge.merged:
-        return ["rejected" for _ in per_finding]
-
-    labels: list[PerFindingLabel] = []
-    for resolution in per_finding:
-        if resolution.resolved:
-            labels.append("accepted")
-        elif resolution.comment_id is not None:
-            labels.append("contested")
-        else:
-            labels.append("missing")
-    return labels
+    return [resolution.disposition for resolution in per_finding]

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -2298,7 +2298,7 @@ def test_dedup_includes_policy_version_and_digest(tmp_path: Path) -> None:
     assert append_label_observation(tmp_path, "sess-1", **kw) is False       # identical → dedup
     kw2 = {**kw, "labeler_version": "980-policy2"}
     assert append_label_observation(tmp_path, "sess-1", **kw2) is True       # policy bump → append
-    kw3 = {**kw, "reply_evidence_digest": "e" * 64}
+    kw3 = {**kw2, "reply_evidence_digest": "e" * 64}
     assert append_label_observation(tmp_path, "sess-1", **kw3) is True       # edited reply → append
 
 

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -2217,3 +2217,108 @@ def test_upsert_run_persists_pipeline_fields(tmp_path: Path) -> None:
     assert row["pipeline_status"] == "failed"
     assert row["daydream_version"] == "0.27.0"
     assert row["daydream_dirty"] == 0
+
+
+# Task 7: versioned reply-label columns, digest-keyed dedup, legacy marking
+
+
+_LEGACY_ROW_OBSERVED_AT_SNAPSHOT = "2026-03-04T05:06:07+00:00"
+
+# Old DDL: everything up to (but excluding) the four reply-label/legacy columns.
+_PRE_REPLY_LABEL_DDL = """
+CREATE TABLE IF NOT EXISTS label_observations (
+    session_id       TEXT NOT NULL,
+    observed_at      TEXT NOT NULL,
+    labels           TEXT NOT NULL,
+    pr_state         TEXT,
+    labeler_version  TEXT NOT NULL,
+    evidence_sha     TEXT,
+    rubric_json      TEXT,
+    valid_at         TEXT,
+    reward_version   TEXT,
+    reward_json      TEXT,
+    composite_reward REAL,
+    reviewer_logins  TEXT,
+    has_posterior    INTEGER NOT NULL DEFAULT 0,
+    source           TEXT NOT NULL DEFAULT 'auto',
+    PRIMARY KEY (session_id, observed_at)
+)
+"""
+
+
+def _seed_pre_reply_label_row(archive_dir: Path, session_id: str) -> None:
+    """Insert a label_observations row using the DDL that predates the four new columns."""
+    conn = sqlite3.connect(str(archive_dir / "index.db"))
+    try:
+        conn.execute("DROP TABLE IF EXISTS label_observations")
+        conn.execute(_PRE_REPLY_LABEL_DDL)
+        conn.execute(
+            "INSERT INTO label_observations "
+            "(session_id, observed_at, labels, pr_state, labeler_version, evidence_sha) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (session_id, _LEGACY_ROW_OBSERVED_AT_SNAPSHOT, '["accepted"]', "merged", "v1", "sha1"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_append_label_observation_persists_versions_and_digest(tmp_path: Path) -> None:
+    _seed_one_run(tmp_path, "sess-1")
+    ok = append_label_observation(
+        tmp_path, "sess-1", labels=["contested"], pr_state="open",
+        labeler_version="980-policy", evidence_sha="abc",
+        reply_classifier_version="980-r1", reply_evidence_digest="d" * 64,
+    )
+    assert ok is True
+    row = latest_label_observation(tmp_path, "sess-1")
+    assert row is not None
+    assert row["reply_classifier_version"] == "980-r1"
+    assert row["reply_evidence_digest"] == "d" * 64
+    assert row["labeler_policy_version"] == "980-policy"
+
+
+def test_dedup_includes_policy_version_and_digest(tmp_path: Path) -> None:
+    """Unchanged evidence + bumped policy version ⇒ new generation, not dedup (M14/M22)."""
+    _seed_one_run(tmp_path, "sess-1")
+    kw: dict[str, Any] = dict(labels=["contested"], pr_state="open", labeler_version="980-policy",
+              evidence_sha="abc", reply_classifier_version="980-r1", reply_evidence_digest="d" * 64)
+    assert append_label_observation(tmp_path, "sess-1", **kw) is True
+    assert append_label_observation(tmp_path, "sess-1", **kw) is False       # identical → dedup
+    kw2 = {**kw, "labeler_version": "980-policy2"}
+    assert append_label_observation(tmp_path, "sess-1", **kw2) is True       # policy bump → append
+    kw3 = {**kw, "reply_evidence_digest": "e" * 64}
+    assert append_label_observation(tmp_path, "sess-1", **kw3) is True       # edited reply → append
+
+
+def test_human_rows_keep_precedence_over_newer_auto(tmp_path: Path) -> None:
+    """Human observation wins in the runs cache even after a newer auto append (M14/M22)."""
+    _seed_one_run(tmp_path, "sess-1")
+    append_label_observation(tmp_path, "sess-1", labels=["contested"], pr_state="open",
+                             labeler_version="980-policy", evidence_sha="abc",
+                             reply_classifier_version="980-r1", reply_evidence_digest="d" * 64)
+    append_label_observation(tmp_path, "sess-1", labels=["rejected"], pr_state="open",
+                             labeler_version="human", evidence_sha="abc", source="human")
+    append_label_observation(tmp_path, "sess-1", labels=["accepted"], pr_state="open",
+                             labeler_version="980-policy2", evidence_sha="abc",
+                             reply_classifier_version="980-r1", reply_evidence_digest="f" * 64)
+    row = query_runs(tmp_path, "session_id = ?", ("sess-1",))[0]
+    assert row["outcome_labels"] == '["rejected"]' and row["labeled_at"] is not None
+    obs = latest_label_observation(tmp_path, "sess-1")
+    assert obs is not None and obs["source"] == "human" and obs["labels"] == '["rejected"]'
+
+
+def test_migration_marks_legacy_rows(tmp_path: Path) -> None:
+    """Pre-existing auto rows are marked legacy='legacy' and never mutated otherwise (M17/M22)."""
+    _seed_one_run(tmp_path, "sess-legacy")
+    _seed_pre_reply_label_row(tmp_path, "sess-legacy")
+
+    # The production connection path must ALTER-ADD the new columns and stamp history.
+    upsert_run(tmp_path, make_manifest(session_id="sess-legacy-2"))
+
+    rows = label_observation_history(tmp_path, "sess-legacy")
+    assert rows
+    assert all(r["legacy"] == "legacy" for r in rows if r["labeler_policy_version"] is None)
+    # original labels/observed_at untouched:
+    assert rows[0]["observed_at"] == _LEGACY_ROW_OBSERVED_AT_SNAPSHOT
+    assert rows[0]["labels"] == '["accepted"]'

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1328,12 +1328,23 @@ def test_auto_append_dedups_on_unchanged_evidence(tmp_path: Path) -> None:
                                       labeler_version="rv1", evidence_sha="shaA", source="auto")
     assert first is True and second is False
     assert len(label_observation_history(tmp_path, "s-dedup")) == 1
-    # A reward_version change DOES append:
+    # A labeler_policy_version change DOES append: the M14 auto-dedup tuple is
+    # (evidence_sha, labeler_policy_version, reply_evidence_digest, labels,
+    # has_posterior, reward_version), so this append fires on the
+    # labeler_version bump:
     third = append_label_observation(tmp_path, "s-dedup", labels=["accepted"], pr_state="merged",
                                      labeler_version="rv2", evidence_sha="shaA",
                                      reward_version="rv2", source="auto")
     assert third is True
     assert len(label_observation_history(tmp_path, "s-dedup")) == 2
+    # An independent reward_version bump (identical evidence AND policy) also
+    # appends: reward_version is part of the M14 tuple, so the freshly
+    # computed reward_json/composite_reward must not be silently discarded.
+    fourth = append_label_observation(tmp_path, "s-dedup", labels=["accepted"], pr_state="merged",
+                                      labeler_version="rv2", evidence_sha="shaA",
+                                      reward_version="rv3", source="auto")
+    assert fourth is True
+    assert len(label_observation_history(tmp_path, "s-dedup")) == 3
 
 
 def test_auto_append_appends_when_only_has_posterior_changes(tmp_path: Path) -> None:

--- a/tests/test_capture_loop.py
+++ b/tests/test_capture_loop.py
@@ -243,8 +243,9 @@ def test_file_level_finding_is_captured_and_resolvable(fake_gh: FakeGh, file_lev
     reply = {
         "id": 9999,
         "in_reply_to_id": comments[0]["id"],
-        "user": {"login": "kevin"},
-        "body": "fixed",
+        "user": {"login": "kevin", "type": "User"},
+        "author_association": "MEMBER",
+        "body": "Fixed in abc123",
     }
     replied = [*comments, reply]
     threads = index_pr_review_comments(row, gh_api=lambda *a, **k: replied)
@@ -253,7 +254,7 @@ def test_file_level_finding_is_captured_and_resolvable(fake_gh: FakeGh, file_lev
     per_finding = per_finding_resolution_signal(
         row, recorded_fingerprints=[FILE_FINGERPRINT], gh_api=_never_fetch, threads=threads
     )
-    assert [(r.fingerprint, r.resolved) for r in per_finding] == [(FILE_FINGERPRINT, True)]
+    assert [(r.fingerprint, r.disposition) for r in per_finding] == [(FILE_FINGERPRINT, "accepted")]
 
 
 def test_file_level_post_rejected_falls_back_to_review_body(fake_gh: FakeGh, file_level_artifact: Path) -> None:

--- a/tests/test_training_backfill.py
+++ b/tests/test_training_backfill.py
@@ -133,7 +133,7 @@ def snapshot_rows(archive: Path) -> list[dict[str, Any]]:
     return _observations(archive)
 
 
-def test_backfill_appends_new_generation(tmp_path, monkeypatch):
+def test_backfill_appends_new_generation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     archive = _archive_with_session(tmp_path, monkeypatch, replies=[_reply("Fixed in abc123", assoc="OWNER")])
     summary = run_backfill(archive, dry_run=False)
     assert summary["sessions_reprocessed"] == 1
@@ -142,7 +142,7 @@ def test_backfill_appends_new_generation(tmp_path, monkeypatch):
     assert rows[-1]["labels"] == '["accepted"]'
 
 
-def test_backfill_rerun_is_noop(tmp_path, monkeypatch):
+def test_backfill_rerun_is_noop(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Unchanged GitHub evidence + unchanged versions ⇒ second run appends nothing (M18)."""
     archive = _archive_with_session(tmp_path, monkeypatch, replies=[_reply("Fixed in abc123", assoc="OWNER")])
     run_backfill(archive, dry_run=False)
@@ -152,7 +152,7 @@ def test_backfill_rerun_is_noop(tmp_path, monkeypatch):
     assert summary["appended"] == 0 and summary["skipped"] >= 1
 
 
-def test_backfill_fails_closed_on_deleted_comments(tmp_path, monkeypatch):
+def test_backfill_fails_closed_on_deleted_comments(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Deleted/inaccessible comments ⇒ unknown, never decisive (M19/M22)."""
     archive = _archive_with_session(tmp_path, monkeypatch, replies=None, gh_error=404)
     run_backfill(archive, dry_run=False)
@@ -160,7 +160,7 @@ def test_backfill_fails_closed_on_deleted_comments(tmp_path, monkeypatch):
     assert rows[-1]["labels"] == '["unknown"]'
 
 
-def test_backfill_report_is_machine_readable(tmp_path, monkeypatch):
+def test_backfill_report_is_machine_readable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     archive = _archive_with_session(tmp_path, monkeypatch, replies=[_reply("False positive", assoc="OWNER")])
     summary = run_backfill(archive, dry_run=False, report_path=tmp_path / "report.json")
     report = json.loads((tmp_path / "report.json").read_text())
@@ -170,7 +170,7 @@ def test_backfill_report_is_machine_readable(tmp_path, monkeypatch):
     assert summary is not None
 
 
-def test_backfill_historical_rows_untouched(tmp_path, monkeypatch):
+def test_backfill_historical_rows_untouched(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Backfill never mutates or deletes existing label_observations (M17)."""
     archive = _archive_with_session(tmp_path, monkeypatch, replies=[_reply("Fixed in abc123", assoc="OWNER")])
     legacy = snapshot_rows(archive)

--- a/tests/test_training_backfill.py
+++ b/tests/test_training_backfill.py
@@ -193,7 +193,7 @@ def test_backfill_fails_closed_on_deleted_comments(tmp_path: Path, monkeypatch: 
     archive = _archive_with_session(tmp_path, monkeypatch, replies=None, gh_error=404)
     run_backfill(archive, dry_run=False)
     rows = all_observations(archive)
-    assert rows[-1]["labels"] == '["unknown"]'
+    assert rows[-1]["labels"] == '[]'
 
 
 def test_backfill_report_is_machine_readable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -246,7 +246,7 @@ def test_backfill_fails_closed_on_benign_escape(tmp_path: Path, monkeypatch: pyt
     assert summary["appended"] == 1
     assert summary["errors"] == 0
     rows = all_observations(tmp_path / "archive")
-    assert rows[-1]["labels"] == '["unknown"]'
+    assert rows[-1]["labels"] == '[]'
     assert rows[-1]["pr_state"] is None
 
 

--- a/tests/test_training_backfill.py
+++ b/tests/test_training_backfill.py
@@ -5,8 +5,12 @@ machine-readable migration report.
 Covers:
 * Append-only backfill: new generations carry the current policy version (M17).
 * Idempotent re-run: unchanged evidence + unchanged versions dedup to a no-op (M18).
-* Fail-closed on deleted/inaccessible PR comments (M19/M22).
-* Machine-readable report keys (M20).
+* Fail-closed on deleted/inaccessible PR comments (M19/M22), including a benign
+  404 that escapes ``build_annotation`` into backfill's own benign-escape handler.
+* ``dry_run=True`` (headline mode) builds annotations without writing.
+* ``RateLimitError`` aborts cleanly; transient errors isolate per-row.
+* ``non_pr_skipped``, ``session_filter``, and ``valid_at_override``.
+* Machine-readable report keys and values (M20).
 * Legacy ``label_observations`` rows are never mutated or deleted (M17).
 """
 
@@ -21,10 +25,16 @@ import pytest
 
 from daydream.archive.index import upsert_run
 from daydream.archive.manifest import Manifest
-from daydream.git_ops import GitError
+from daydream.git_ops import GitError, RateLimitError
 from daydream.pr_review import DAYDREAM_FOOTER, finding_marker
 from daydream.training import backfill
 from daydream.training.backfill import run_backfill
+from daydream.training.reply_classifier import (
+    _ACCEPT_RULES,
+    _DISPUTE_RULES,
+    _FACTUAL_DISAGREEMENT_RULES,
+    _REJECT_RULES,
+)
 
 _FP_A = "a" * 64
 
@@ -60,19 +70,35 @@ def _fake_gh(
     return responder
 
 
-def _archive_with_session(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    replies: list[dict[str, Any]] | None,
-    gh_error: int | None = None,
-) -> Path:
-    """Archive with one PR-linked session whose reply evidence is ``replies``.
+_DAYDREAM_COMMENT = {
+    "id": 1,
+    "in_reply_to_id": None,
+    "user": {"login": "daydream-runner"},
+    "body": f"finding\n\n{finding_marker(_FP_A)}\n\n{DAYDREAM_FOOTER}",
+}
 
-    ``gh_api`` is monkeypatched to return the comment payloads without network.
+
+def _thread_comments(replies: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+    """The PR's daydream comment plus the qualifying human replies under it."""
+    return [_DAYDREAM_COMMENT, *(replies or [])]
+
+
+def _add_run(
+    tmp_path: Path,
+    *,
+    session_id: str = "s1",
+    run_dir_name: str = "run",
+    repo_slug: str = "o/r",
+    pr_repo: str | None = "o/r",
+    pr_number: int | None = 7,
+) -> Path:
+    """Index one archived run (no ``gh_api`` patching); returns the archive root.
+
+    Reused by multi-session tests so several runs share one archive.
     """
     archive = tmp_path / "archive"
     archive.mkdir(parents=True, exist_ok=True)
-    run_dir = tmp_path / "run"
+    run_dir = tmp_path / run_dir_name
     (run_dir / "deep").mkdir(parents=True)
     (run_dir / "deep" / "recommendation-verdicts.json").write_text(
         json.dumps({"verdicts": [{"issue_id": 1, "verdict": "consistent"}]})
@@ -81,30 +107,40 @@ def _archive_with_session(
     (run_dir / "findings.json").write_text(
         json.dumps({"findings": [{"fingerprint": _FP_A}]})
     )
-    daydream_comment = {
-        "id": 1,
-        "in_reply_to_id": None,
-        "user": {"login": "daydream-runner"},
-        "body": f"finding\n\n{finding_marker(_FP_A)}\n\n{DAYDREAM_FOOTER}",
-    }
-    comments = [daydream_comment, *(replies or [])]
-    monkeypatch.setattr(backfill, "_gh_api", _fake_gh(comments=comments, gh_error=gh_error))
     upsert_run(
         archive,
         Manifest(
-            session_id="s1",
+            session_id=session_id,
             archived_at="2026-01-01T00:00:00Z",
             run_flow="normal",
             backend="claude",
-            repo_slug="o/r",
-            pr_repo="o/r",
-            pr_number=7,
+            repo_slug=repo_slug,
+            pr_repo=pr_repo,
+            pr_number=pr_number,
             head_sha="h",
             base_branch="main",
             grounding_rate=1.0,
             changed_files=["app.py"],
             archive_path=str(run_dir),
         ),
+    )
+    return archive
+
+
+def _archive_with_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    replies: list[dict[str, Any]] | None,
+    gh_error: int | None = None,
+    **run_kwargs: Any,
+) -> Path:
+    """Archive with one PR-linked session whose reply evidence is ``replies``.
+
+    ``gh_api`` is monkeypatched to return the comment payloads without network.
+    """
+    archive = _add_run(tmp_path, **run_kwargs)
+    monkeypatch.setattr(
+        backfill, "_gh_api", _fake_gh(comments=_thread_comments(replies), gh_error=gh_error)
     )
     return archive
 
@@ -168,6 +204,123 @@ def test_backfill_report_is_machine_readable(tmp_path: Path, monkeypatch: pytest
                 "ambiguous_manual_review", "bot_self_reply_exclusions", "pr_state_counts", "class_balance"):
         assert key in report
     assert summary is not None
+    assert report["summary"] == summary
+    assert report["dry_run"] is False
+    assert report["run_label_transitions"] == {"s1": {"old_labels": None, "new_labels": ["rejected"]}}
+    assert report["disposition_counts"] == {"rejected": 1}
+    assert report["pr_state_counts"] == {"merged": 1}
+    assert report["class_balance"] == {"rejected": 1}
+    assert report["ambiguous_manual_review"] == 0
+    assert report["bot_self_reply_exclusions"] == 0
+    assert report["parser_rule_count"] == (
+        len(_ACCEPT_RULES) + len(_REJECT_RULES) + len(_DISPUTE_RULES) + len(_FACTUAL_DISAGREEMENT_RULES)
+    )
+
+
+def test_backfill_dry_run_builds_without_writing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """dry_run=True (the module's headline mode) builds annotations but writes nothing."""
+    archive = _archive_with_session(tmp_path, monkeypatch, replies=[_reply("Fixed in abc123", assoc="OWNER")])
+    summary = run_backfill(archive, dry_run=True, report_path=tmp_path / "report.json")
+    assert summary["appended"] == 0
+    assert summary["skipped"] == 0
+    assert summary["sessions_reprocessed"] == 1
+    assert observation_count(archive) == 0
+    report = json.loads((tmp_path / "report.json").read_text())
+    assert report["dry_run"] is True
+    assert report["summary"] == summary
+
+
+def test_backfill_fails_closed_on_benign_escape(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A benign 404 escaping build_annotation (merge OK, comment fetch 404) lands in
+    backfill's own fail-closed handler: unknown with the current policy version."""
+    _add_run(tmp_path)
+
+    def responder(repo: str, endpoint: str, **kwargs: Any) -> Any:
+        if endpoint.endswith("/comments") or endpoint.endswith("/reviews"):
+            raise GitError(f"gh api {endpoint} failed (HTTP 404)")
+        return {"merged": True, "merged_at": None}
+
+    monkeypatch.setattr(backfill, "_gh_api", responder)
+    summary = run_backfill(tmp_path / "archive", dry_run=False)
+    assert summary["sessions_reprocessed"] == 1
+    assert summary["appended"] == 1
+    assert summary["errors"] == 0
+    rows = all_observations(tmp_path / "archive")
+    assert rows[-1]["labels"] == '["unknown"]'
+    assert rows[-1]["pr_state"] is None
+
+
+def test_backfill_aborts_on_rate_limit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """RateLimitError aborts the sweep cleanly, preserving the remaining queue."""
+    _add_run(tmp_path)
+
+    def responder(repo: str, endpoint: str, **kwargs: Any) -> Any:
+        raise RateLimitError(f"gh api {endpoint} failed (HTTP 429)", retry_after=5)
+
+    monkeypatch.setattr(backfill, "_gh_api", responder)
+    summary = run_backfill(tmp_path / "archive", dry_run=False)
+    assert summary["aborted"] == 1
+    assert summary["appended"] == 0
+    assert observation_count(tmp_path / "archive") == 0
+
+
+def test_backfill_non_pr_skipped(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A run with no PR link is skipped and counted, never annotated."""
+    _add_run(tmp_path, pr_repo=None, pr_number=None)
+    monkeypatch.setattr(backfill, "_gh_api", _fake_gh(comments=_thread_comments(None)))
+    summary = run_backfill(tmp_path / "archive", dry_run=False)
+    assert summary["non_pr_skipped"] == 1
+    assert summary["sessions_reprocessed"] == 0
+    assert observation_count(tmp_path / "archive") == 0
+
+
+def test_backfill_session_filter(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """session_filter restricts the queue; filtered-out sessions stay untouched."""
+    _archive_with_session(
+        tmp_path, monkeypatch, replies=[_reply("Fixed in abc123", assoc="OWNER")],
+        session_id="s1", run_dir_name="run_a",
+    )
+    _archive_with_session(
+        tmp_path, monkeypatch, replies=[_reply("Fixed in abc123", assoc="OWNER")],
+        session_id="s2", run_dir_name="run_b",
+    )
+    summary = run_backfill(tmp_path / "archive", dry_run=False, session_filter="s2")
+    assert summary["sessions_reprocessed"] == 1
+    assert summary["non_pr_skipped"] == 0
+    rows = all_observations(tmp_path / "archive")
+    assert [row["session_id"] for row in rows] == ["s2"]
+
+
+def test_backfill_valid_at_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """valid_at_override beats the derived decisive-evidence timestamp."""
+    archive = _archive_with_session(tmp_path, monkeypatch, replies=[_reply("Fixed in abc123", assoc="OWNER")])
+    run_backfill(archive, dry_run=False, valid_at_override="2026-02-01T00:00:00Z")
+    rows = all_observations(archive)
+    assert rows[-1]["valid_at"] == "2026-02-01T00:00:00+00:00"
+
+
+def test_backfill_per_row_isolation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A transient failure (HTTP 500) on one row isolates; the next row survives."""
+    _add_run(tmp_path, session_id="s1", run_dir_name="run_a", repo_slug="o/fail", pr_repo="o/fail")
+    _add_run(tmp_path, session_id="s2", run_dir_name="run_b", repo_slug="o/ok", pr_repo="o/ok")
+
+    def responder(repo: str, endpoint: str, **kwargs: Any) -> Any:
+        if repo == "o/fail":
+            raise GitError(f"gh api {endpoint} failed (HTTP 500)")
+        if endpoint.endswith("/comments"):
+            return _thread_comments([_reply("Fixed in abc123", assoc="OWNER")])
+        if endpoint.endswith("/reviews"):
+            return []
+        return {"merged": True, "merged_at": None}
+
+    monkeypatch.setattr(backfill, "_gh_api", responder)
+    summary = run_backfill(tmp_path / "archive", dry_run=False)
+    assert summary["errors"] == 1
+    assert summary["appended"] == 1
+    assert summary["sessions_reprocessed"] == 1
+    rows = all_observations(tmp_path / "archive")
+    assert [row["session_id"] for row in rows] == ["s2"]
+    assert rows[-1]["labels"] == '["accepted"]'
 
 
 def test_backfill_historical_rows_untouched(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -176,3 +329,40 @@ def test_backfill_historical_rows_untouched(tmp_path: Path, monkeypatch: pytest.
     legacy = snapshot_rows(archive)
     run_backfill(archive, dry_run=False)
     assert snapshot_rows(archive)[: len(legacy)] == legacy
+
+
+def test_backfill_dry_run_counts_walked_rows(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Dry run suppresses writes but still walks PR-linked rows: each walked
+    row counts as reprocessed — never as skipped — and nothing lands (M20)."""
+    archive = _archive_with_session(tmp_path, monkeypatch, replies=[_reply("Fixed in abc123", assoc="OWNER")])
+    summary = run_backfill(archive, dry_run=True)
+    assert summary["sessions_reprocessed"] == 1
+    assert summary["appended"] == 0
+    assert summary["skipped"] == 0
+    assert observation_count(archive) == 0
+
+
+def test_backfill_old_labels_human_precedence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """run_label_transitions['old_labels'] reflects the archive's winner
+    projection: a human override beats a newer auto row (human-first)."""
+    archive = _archive_with_session(tmp_path, monkeypatch, replies=[_reply("Fixed in abc123", assoc="OWNER")])
+    conn = sqlite3.connect(archive / "index.db")
+    try:
+        conn.execute(
+            "INSERT INTO label_observations (session_id, observed_at, labels, labeler_version, source) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("s1", "2026-01-02T00:00:00Z", '["auto"]', "v1", "auto"),
+        )
+        conn.execute(
+            "INSERT INTO label_observations (session_id, observed_at, labels, labeler_version, source) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("s1", "2026-01-01T00:00:00Z", '["human"]', "v1", "human"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    summary = run_backfill(archive, dry_run=True, report_path=tmp_path / "report.json")
+    report = json.loads((tmp_path / "report.json").read_text())
+    transition = report["run_label_transitions"]["s1"]
+    assert transition["old_labels"] == ["human"]
+    assert summary["sessions_reprocessed"] == 1

--- a/tests/test_training_backfill.py
+++ b/tests/test_training_backfill.py
@@ -1,0 +1,178 @@
+"""Tests for the backfill pass — re-annotate indexed runs through the harvest
+annotation path and append a fresh ``label_observations`` generation, with a
+machine-readable migration report.
+
+Covers:
+* Append-only backfill: new generations carry the current policy version (M17).
+* Idempotent re-run: unchanged evidence + unchanged versions dedup to a no-op (M18).
+* Fail-closed on deleted/inaccessible PR comments (M19/M22).
+* Machine-readable report keys (M20).
+* Legacy ``label_observations`` rows are never mutated or deleted (M17).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from daydream.archive.index import upsert_run
+from daydream.archive.manifest import Manifest
+from daydream.git_ops import GitError
+from daydream.pr_review import DAYDREAM_FOOTER, finding_marker
+from daydream.training import backfill
+from daydream.training.backfill import run_backfill
+
+_FP_A = "a" * 64
+
+
+def _reply(body: str, assoc: str = "OWNER") -> dict[str, Any]:
+    """A qualifying human reply to the daydream finding comment (id 1)."""
+    return {
+        "id": 2,
+        "in_reply_to_id": 1,
+        "user": {"login": "amelia"},
+        "author_association": assoc,
+        "body": body,
+    }
+
+
+def _fake_gh(
+    *,
+    comments: list[dict[str, Any]] | None = None,
+    gh_error: int | None = None,
+) -> Any:
+    """``gh_api(repo, endpoint, **kw)`` responder; ``gh_error`` makes every
+    endpoint fail with that HTTP status (deleted repo/PR/comments)."""
+
+    def responder(repo: str, endpoint: str, **kwargs: Any) -> Any:
+        if gh_error is not None:
+            raise GitError(f"gh api {endpoint} failed (HTTP {gh_error})")
+        if endpoint.endswith("/comments"):
+            return list(comments or [])
+        if endpoint.endswith("/reviews"):
+            return []
+        return {"merged": True, "merged_at": None}
+
+    return responder
+
+
+def _archive_with_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    replies: list[dict[str, Any]] | None,
+    gh_error: int | None = None,
+) -> Path:
+    """Archive with one PR-linked session whose reply evidence is ``replies``.
+
+    ``gh_api`` is monkeypatched to return the comment payloads without network.
+    """
+    archive = tmp_path / "archive"
+    archive.mkdir(parents=True, exist_ok=True)
+    run_dir = tmp_path / "run"
+    (run_dir / "deep").mkdir(parents=True)
+    (run_dir / "deep" / "recommendation-verdicts.json").write_text(
+        json.dumps({"verdicts": [{"issue_id": 1, "verdict": "consistent"}]})
+    )
+    (run_dir / "diff.patch").write_text("+new_line\n")
+    (run_dir / "findings.json").write_text(
+        json.dumps({"findings": [{"fingerprint": _FP_A}]})
+    )
+    daydream_comment = {
+        "id": 1,
+        "in_reply_to_id": None,
+        "user": {"login": "daydream-runner"},
+        "body": f"finding\n\n{finding_marker(_FP_A)}\n\n{DAYDREAM_FOOTER}",
+    }
+    comments = [daydream_comment, *(replies or [])]
+    monkeypatch.setattr(backfill, "_gh_api", _fake_gh(comments=comments, gh_error=gh_error))
+    upsert_run(
+        archive,
+        Manifest(
+            session_id="s1",
+            archived_at="2026-01-01T00:00:00Z",
+            run_flow="normal",
+            backend="claude",
+            repo_slug="o/r",
+            pr_repo="o/r",
+            pr_number=7,
+            head_sha="h",
+            base_branch="main",
+            grounding_rate=1.0,
+            changed_files=["app.py"],
+            archive_path=str(run_dir),
+        ),
+    )
+    return archive
+
+
+def _observations(archive: Path) -> list[dict[str, Any]]:
+    conn = sqlite3.connect(archive / "index.db")
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT * FROM label_observations ORDER BY observed_at"
+        ).fetchall()
+        return [dict(row) for row in rows]
+    finally:
+        conn.close()
+
+
+def all_observations(archive: Path) -> list[dict[str, Any]]:
+    return _observations(archive)
+
+
+def observation_count(archive: Path) -> int:
+    return len(_observations(archive))
+
+
+def snapshot_rows(archive: Path) -> list[dict[str, Any]]:
+    return _observations(archive)
+
+
+def test_backfill_appends_new_generation(tmp_path, monkeypatch):
+    archive = _archive_with_session(tmp_path, monkeypatch, replies=[_reply("Fixed in abc123", assoc="OWNER")])
+    summary = run_backfill(archive, dry_run=False)
+    assert summary["sessions_reprocessed"] == 1
+    rows = all_observations(archive)
+    assert rows[-1]["labeler_policy_version"] is not None
+    assert rows[-1]["labels"] == '["accepted"]'
+
+
+def test_backfill_rerun_is_noop(tmp_path, monkeypatch):
+    """Unchanged GitHub evidence + unchanged versions ⇒ second run appends nothing (M18)."""
+    archive = _archive_with_session(tmp_path, monkeypatch, replies=[_reply("Fixed in abc123", assoc="OWNER")])
+    run_backfill(archive, dry_run=False)
+    before = observation_count(archive)
+    summary = run_backfill(archive, dry_run=False)
+    assert observation_count(archive) == before
+    assert summary["appended"] == 0 and summary["skipped"] >= 1
+
+
+def test_backfill_fails_closed_on_deleted_comments(tmp_path, monkeypatch):
+    """Deleted/inaccessible comments ⇒ unknown, never decisive (M19/M22)."""
+    archive = _archive_with_session(tmp_path, monkeypatch, replies=None, gh_error=404)
+    run_backfill(archive, dry_run=False)
+    rows = all_observations(archive)
+    assert rows[-1]["labels"] == '["unknown"]'
+
+
+def test_backfill_report_is_machine_readable(tmp_path, monkeypatch):
+    archive = _archive_with_session(tmp_path, monkeypatch, replies=[_reply("False positive", assoc="OWNER")])
+    summary = run_backfill(archive, dry_run=False, report_path=tmp_path / "report.json")
+    report = json.loads((tmp_path / "report.json").read_text())
+    for key in ("run_label_transitions", "disposition_counts", "parser_rule_count",
+                "ambiguous_manual_review", "bot_self_reply_exclusions", "pr_state_counts", "class_balance"):
+        assert key in report
+    assert summary is not None
+
+
+def test_backfill_historical_rows_untouched(tmp_path, monkeypatch):
+    """Backfill never mutates or deletes existing label_observations (M17)."""
+    archive = _archive_with_session(tmp_path, monkeypatch, replies=[_reply("Fixed in abc123", assoc="OWNER")])
+    legacy = snapshot_rows(archive)
+    run_backfill(archive, dry_run=False)
+    assert snapshot_rows(archive)[: len(legacy)] == legacy

--- a/tests/test_training_backfill_cache.py
+++ b/tests/test_training_backfill_cache.py
@@ -4,6 +4,7 @@ Covers:
 * File-backed memoization of ``gh_api(repo, endpoint, **kwargs)`` calls.
 * Cache key isolation by endpoint.
 * JSONL ``progress.jsonl`` resume log — append + read.
+* Policy-version stamping: a bump wholesale-invalidates resume markers (M15).
 """
 
 from __future__ import annotations
@@ -11,6 +12,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from daydream.training import labeler_versions
 from daydream.training.backfill_cache import BackfillCache
 
 
@@ -42,20 +44,38 @@ def test_cache_misses_for_different_endpoints(tmp_path: Path) -> None:
 
 
 def test_progress_log_appends_one_line_per_session(tmp_path: Path) -> None:
-    """BackfillCache writes a JSONL line per session_id processed."""
+    """BackfillCache writes a versioned JSONL line per session_id processed."""
     cache = BackfillCache(cache_dir=tmp_path, inner=lambda r, e, **kw: {})
     cache.mark_session_done("session-abc")
     cache.mark_session_done("session-xyz")
     lines = (tmp_path / "progress.jsonl").read_text().splitlines()
     assert len(lines) == 2
-    assert json.loads(lines[0])["session_id"] == "session-abc"
+    first = json.loads(lines[0])
+    assert first["session_id"] == "session-abc"
+    # M15: the row is stamped with the labeler policy version at completion time.
+    assert first["labeler_policy_version"] == labeler_versions.LABELER_POLICY_VERSION
 
 
 def test_completed_sessions_resume(tmp_path: Path) -> None:
-    """On startup, BackfillCache exposes the set of already-completed sessions."""
+    """On startup, BackfillCache exposes the set of already-completed sessions.
+
+    Only rows stamped with the *current* labeler policy version count; legacy
+    rows without the version field (or from an older policy) never match, so a
+    policy bump re-fetches previously completed sessions (M15).
+    """
+    current = labeler_versions.LABELER_POLICY_VERSION
     (tmp_path / "progress.jsonl").write_text(
-        '{"session_id": "s1", "completed_at": "2026-05-22T00:00:00Z"}\n'
-        '{"session_id": "s2", "completed_at": "2026-05-22T00:00:00Z"}\n'
+        json.dumps(
+            {"session_id": "s1", "labeler_policy_version": current,
+             "completed_at": "2026-05-22T00:00:00Z"},
+        ) + "\n"
+        + json.dumps(
+            {"session_id": "s-legacy", "completed_at": "2026-05-22T00:00:00Z"},
+        ) + "\n"
+        + json.dumps(
+            {"session_id": "s-old", "labeler_policy_version": "980-policy-r0",
+             "completed_at": "2026-05-22T00:00:00Z"},
+        ) + "\n"
     )
     cache = BackfillCache(cache_dir=tmp_path, inner=lambda r, e, **kw: {})
-    assert cache.completed_sessions() == {"s1", "s2"}
+    assert cache.completed_sessions() == {"s1"}

--- a/tests/test_training_backfill_cache.py
+++ b/tests/test_training_backfill_cache.py
@@ -3,17 +3,50 @@
 Covers:
 * File-backed memoization of ``gh_api(repo, endpoint, **kwargs)`` calls.
 * Cache key isolation by endpoint.
+* Freshness window: memoized responses older than ``CACHE_TTL_SECONDS``
+  are refetched (M14 edited-reply freshness).
 * JSONL ``progress.jsonl`` resume log — append + read.
 * Policy-version stamping: a bump wholesale-invalidates resume markers (M15).
+* Marker aging: a completion older than ``CACHE_TTL_SECONDS`` does not resume.
 """
 
 from __future__ import annotations
 
 import json
+import os
+import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 from daydream.training import labeler_versions
-from daydream.training.backfill_cache import BackfillCache
+from daydream.training.backfill_cache import CACHE_TTL_SECONDS, BackfillCache
+
+
+def test_cache_refetches_stale_response(tmp_path: Path) -> None:
+    """A memoized response older than CACHE_TTL_SECONDS is refetched (M14).
+
+    An edited reply must not be masked by a stale memoized /comments payload:
+    once the freshness window expires the inner gh_api is called again, so the
+    reply-evidence digest is recomputed from live data.
+    """
+    calls: list[tuple[str, str]] = []
+
+    def real_gh(repo: str, endpoint: str, **kwargs: object) -> dict[str, object]:
+        calls.append((repo, endpoint))
+        return {"merged": True, "n": len(calls)}
+
+    cache = BackfillCache(cache_dir=tmp_path, inner=real_gh)
+    first = cache("org/repo", "repos/org/repo/pulls/42")
+    assert first == {"merged": True, "n": 1}
+    assert calls == [("org/repo", "repos/org/repo/pulls/42")]
+    # Age the cache file beyond the freshness window (tmp_path also holds the
+    # autouse ``archive_dir`` fixture dir, so target the ``.json`` entry).
+    path = next(p for p in tmp_path.iterdir() if p.suffix == ".json")
+    old = time.time() - CACHE_TTL_SECONDS - 60
+    os.utime(path, (old, old))
+    second = cache("org/repo", "repos/org/repo/pulls/42")
+    assert second == {"merged": True, "n": 2}
+    assert calls == [("org/repo", "repos/org/repo/pulls/42")] * 2
 
 
 def test_cache_returns_cached_response_on_second_call(tmp_path: Path) -> None:
@@ -59,23 +92,50 @@ def test_progress_log_appends_one_line_per_session(tmp_path: Path) -> None:
 def test_completed_sessions_resume(tmp_path: Path) -> None:
     """On startup, BackfillCache exposes the set of already-completed sessions.
 
-    Only rows stamped with the *current* labeler policy version count; legacy
-    rows without the version field (or from an older policy) never match, so a
-    policy bump re-fetches previously completed sessions (M15).
+    Only rows stamped with the *current* labeler policy version and completed
+    inside the freshness window count; legacy rows without the version field
+    (or from an older policy) never match, so a policy bump re-fetches
+    previously completed sessions (M15).
     """
     current = labeler_versions.LABELER_POLICY_VERSION
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     (tmp_path / "progress.jsonl").write_text(
         json.dumps(
             {"session_id": "s1", "labeler_policy_version": current,
-             "completed_at": "2026-05-22T00:00:00Z"},
+             "completed_at": now},
         ) + "\n"
         + json.dumps(
-            {"session_id": "s-legacy", "completed_at": "2026-05-22T00:00:00Z"},
+            {"session_id": "s-legacy", "completed_at": now},
         ) + "\n"
         + json.dumps(
             {"session_id": "s-old", "labeler_policy_version": "980-policy-r0",
-             "completed_at": "2026-05-22T00:00:00Z"},
+             "completed_at": now},
         ) + "\n"
     )
     cache = BackfillCache(cache_dir=tmp_path, inner=lambda r, e, **kw: {})
     assert cache.completed_sessions() == {"s1"}
+
+
+def test_completed_sessions_age_out_after_freshness_window(tmp_path: Path) -> None:
+    """A marker older than CACHE_TTL_SECONDS does not resume the session (M14).
+
+    A completion marker from a previous run must not permanently filter the
+    queue: once the freshness window passes, the session is re-processed so a
+    reply edit appends a fresh generation through the standard pipeline.
+    """
+    current = labeler_versions.LABELER_POLICY_VERSION
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    stale_ts = time.time() - CACHE_TTL_SECONDS - 60
+    stale = datetime.fromtimestamp(stale_ts, timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    (tmp_path / "progress.jsonl").write_text(
+        json.dumps(
+            {"session_id": "s-fresh", "labeler_policy_version": current,
+             "completed_at": now},
+        ) + "\n"
+        + json.dumps(
+            {"session_id": "s-stale", "labeler_policy_version": current,
+             "completed_at": stale},
+        ) + "\n"
+    )
+    cache = BackfillCache(cache_dir=tmp_path, inner=lambda r, e, **kw: {})
+    assert cache.completed_sessions() == {"s-fresh"}

--- a/tests/test_training_corpus.py
+++ b/tests/test_training_corpus.py
@@ -654,6 +654,18 @@ def test_gold_admission_accepts_current_clean_evidence() -> None:
     assert _is_admitted_outcome_gold(**GOOD) is True
 
 
+def test_is_admitted_label_path_respects_filters_labels() -> None:
+    """The label path requires both filters.labels membership and the gold guard.
+
+    A ``labels=()`` filter admits nothing on the label path even when the row
+    is current-policy gold — and a clean gold row still admits under the
+    default ``("accepted",)`` filter, so the guard never narrows the default.
+    """
+    assert _is_admitted("accepted", None, CorpusFilters(labels=()), **
+                        {k: v for k, v in GOOD.items() if k != "label"}) is False
+    assert _is_admitted(**GOOD, composite_reward=None, filters=CorpusFilters()) is True
+
+
 def test_min_reward_path_unaffected() -> None:
     """The intrinsic min_reward path keeps its existing contract (no creep)."""
     assert _is_admitted("rejected", 1.0, CorpusFilters(min_reward=0.5)) is True

--- a/tests/test_training_corpus.py
+++ b/tests/test_training_corpus.py
@@ -29,6 +29,7 @@ from daydream.training.corpus import (
     _is_admitted_outcome_gold,
     run_build_corpus,
 )
+from daydream.training.labeler_versions import LABELER_POLICY_VERSION
 from daydream.training.reward import PosteriorBreakdown, RewardBreakdown
 from tests.fixtures.training.build_archive import build_fixture_archive
 
@@ -45,7 +46,7 @@ def _seed_run_with_annotation(
     reward_version: str = "r1",
     rubric_json: str | None = None,
     has_posterior: bool | None = None,
-    labeler_policy_version: str | None = "980-policy",
+    labeler_policy_version: str | None = LABELER_POLICY_VERSION,
     observed_at: str,
     valid_at: str,
     pipeline_status: str = "unknown",
@@ -124,9 +125,9 @@ def _seed_run_with_annotation(
         # every caller means. A local_branch row passes has_posterior=False.
         has_posterior=(label is not None) if has_posterior is None else has_posterior,
     )
-    # Stamp the policy axis: current-policy seeds (default "980-policy") are
-    # admitted as outcome gold; None models a legacy row stamped before the
-    # reply-classifier policy axis existed.
+    # Stamp the policy axis: current-policy seeds (default
+    # LABELER_POLICY_VERSION) are admitted as outcome gold; None models a
+    # legacy row stamped before the reply-classifier policy axis existed.
     import sqlite3
 
     conn = sqlite3.connect(str(archive_dir / "index.db"))
@@ -634,10 +635,10 @@ def test_cli_build_corpus_default_excludes_failed_pipelines(tmp_path: Path, arch
 
 LEGACY: dict[str, Any] = {"label": "accepted", "has_posterior": True, "labeler_policy_version": None,
                           "decisive_mix": False, "decisive_only": True}
-MIXED: dict[str, Any]  = {**LEGACY, "labeler_policy_version": "980-policy", "decisive_mix": True}
+MIXED: dict[str, Any]  = {**LEGACY, "labeler_policy_version": LABELER_POLICY_VERSION, "decisive_mix": True}
 AMBIG: dict[str, Any]  = {
-    **LEGACY, "labeler_policy_version": "980-policy", "decisive_mix": False, "decisive_only": False}
-GOOD: dict[str, Any]   = {**LEGACY, "labeler_policy_version": "980-policy"}
+    **LEGACY, "labeler_policy_version": LABELER_POLICY_VERSION, "decisive_mix": False, "decisive_only": False}
+GOOD: dict[str, Any]   = {**LEGACY, "labeler_policy_version": LABELER_POLICY_VERSION}
 
 
 def test_gold_admission_rejects_legacy_observations() -> None:
@@ -669,3 +670,90 @@ def test_is_admitted_label_path_respects_filters_labels() -> None:
 def test_min_reward_path_unaffected() -> None:
     """The intrinsic min_reward path keeps its existing contract (no creep)."""
     assert _is_admitted("rejected", 1.0, CorpusFilters(min_reward=0.5)) is True
+
+
+def test_min_reward_path_drops_legacy_and_unevidenced_gold_label(tmp_path: Path, archive_dir: Any) -> None:
+    """The min_reward back door must not admit a failed-guard ``accepted`` as gold (#980).
+
+    The intrinsic ``min_reward`` path keeps admitting rows, but an outcome-gold
+    ``accepted`` whose evidence fails the gold-admission guard (legacy NULL
+    policy, or unevidenced local_branch) is admitted only as an unlabeled
+    intrinsic row — its label is dropped so it never re-enters the accepted/gold
+    population. A current-policy, evidenced, decisive-only ``accepted`` admitted
+    via ``min_reward`` keeps its label.
+    """
+    decisive = json.dumps(
+        {"posterior_source": "pr_review", "per_finding_outcomes": ["accepted", "accepted"]}
+    )
+    kwargs = dict(
+        composite_reward=0.9,
+        observed_at="2026-03-01T00:00:00+00:00",
+        valid_at="2026-03-01T00:00:00+00:00",
+    )
+    # Legacy NULL-policy mislabeled accept: admitted intrinsically, label dropped.
+    _seed_run_with_annotation(
+        archive_dir, "s-legacy", label="accepted", rubric_json=decisive,
+        has_posterior=True, labeler_policy_version=None, **kwargs,
+    )
+    # Unevidenced local_branch accept: admitted intrinsically, label dropped.
+    _seed_run_with_annotation(
+        archive_dir, "s-local", label="accepted", rubric_json=decisive,
+        has_posterior=False, **kwargs,
+    )
+    # Current-policy evidenced accept: keeps its gold label.
+    _seed_run_with_annotation(
+        archive_dir, "s-good", label="accepted", rubric_json=decisive,
+        has_posterior=True, **kwargs,
+    )
+    out = tmp_path / "corpus.jsonl"
+    run_build_corpus(BuildCorpusConfig(
+        out_path=out, archive_dir=archive_dir,
+        filters=CorpusFilters(min_reward=0.5),
+        as_of="2026-04-01T00:00:00+00:00",
+    ))
+    labels = {json.loads(line)["session_id"]: json.loads(line)["outcome_label"]
+              for line in out.read_text().splitlines()}
+    assert labels["s-good"] == "accepted"
+    assert labels["s-legacy"] is None
+    assert labels["s-local"] is None
+
+
+def test_gold_admission_gates_legacy_and_ambiguous_rows_in_build(tmp_path: Path, archive_dir: Any) -> None:
+    """Real-path gold guard: legacy NULL-policy and rubric-ambiguous rows are excluded (M16/M22).
+
+    The pure ``_is_admitted_outcome_gold`` tests above drive the guard in
+    isolation; this drives the same gate through ``run_build_corpus`` so the
+    ``_rubric_decisive_only`` derivation from the persisted ``rubric_json`` —
+    including its FALSE branch on ambiguous ``per_finding_outcomes`` and the
+    legacy ``labeler_policy_version=None`` row — is exercised end-to-end.
+    """
+    decisive_rubric = json.dumps(
+        {"posterior_source": "pr_review", "per_finding_outcomes": ["accepted", "accepted"]}
+    )
+    ambiguous_rubric = json.dumps(
+        {"posterior_source": "pr_review", "per_finding_outcomes": ["accepted", "ambiguous"]}
+    )
+    kwargs = dict(
+        composite_reward=0.9,
+        has_posterior=True,
+        observed_at="2026-05-01T00:00:00+00:00",
+        valid_at="2026-04-01T00:00:00+00:00",
+    )
+    # Current-policy + decisive rubric: admitted as gold.
+    _seed_run_with_annotation(
+        tmp_path, "s-good", label="accepted", rubric_json=decisive_rubric, **kwargs
+    )
+    # Current-policy + ambiguous rubric: ``_rubric_decisive_only`` returns False, so no gold.
+    _seed_run_with_annotation(
+        tmp_path, "s-ambiguous", label="accepted", rubric_json=ambiguous_rubric, **kwargs
+    )
+    # Legacy NULL policy + decisive rubric: the policy gate rejects it.
+    _seed_run_with_annotation(
+        tmp_path, "s-legacy", label="accepted", rubric_json=decisive_rubric,
+        labeler_policy_version=None, **kwargs,
+    )
+    out = tmp_path / "corpus.jsonl"
+    run_build_corpus(_cfg(tmp_path, out_path=out))
+
+    emitted = [json.loads(line)["session_id"] for line in out.read_text().splitlines()]
+    assert emitted == ["s-good"]

--- a/tests/test_training_corpus.py
+++ b/tests/test_training_corpus.py
@@ -685,25 +685,29 @@ def test_min_reward_path_drops_legacy_and_unevidenced_gold_label(tmp_path: Path,
     decisive = json.dumps(
         {"posterior_source": "pr_review", "per_finding_outcomes": ["accepted", "accepted"]}
     )
-    kwargs = dict(
-        composite_reward=0.9,
-        observed_at="2026-03-01T00:00:00+00:00",
-        valid_at="2026-03-01T00:00:00+00:00",
-    )
+    kw_composite_reward = 0.9
+    kw_observed_at = "2026-03-01T00:00:00+00:00"
+    kw_valid_at = "2026-03-01T00:00:00+00:00"
     # Legacy NULL-policy mislabeled accept: admitted intrinsically, label dropped.
     _seed_run_with_annotation(
         archive_dir, "s-legacy", label="accepted", rubric_json=decisive,
-        has_posterior=True, labeler_policy_version=None, **kwargs,
+        has_posterior=True, labeler_policy_version=None,
+        composite_reward=kw_composite_reward, observed_at=kw_observed_at,
+        valid_at=kw_valid_at,
     )
     # Unevidenced local_branch accept: admitted intrinsically, label dropped.
     _seed_run_with_annotation(
         archive_dir, "s-local", label="accepted", rubric_json=decisive,
-        has_posterior=False, **kwargs,
+        has_posterior=False,
+        composite_reward=kw_composite_reward, observed_at=kw_observed_at,
+        valid_at=kw_valid_at,
     )
     # Current-policy evidenced accept: keeps its gold label.
     _seed_run_with_annotation(
         archive_dir, "s-good", label="accepted", rubric_json=decisive,
-        has_posterior=True, **kwargs,
+        has_posterior=True,
+        composite_reward=kw_composite_reward, observed_at=kw_observed_at,
+        valid_at=kw_valid_at,
     )
     out = tmp_path / "corpus.jsonl"
     run_build_corpus(BuildCorpusConfig(
@@ -733,24 +737,28 @@ def test_gold_admission_gates_legacy_and_ambiguous_rows_in_build(tmp_path: Path,
     ambiguous_rubric = json.dumps(
         {"posterior_source": "pr_review", "per_finding_outcomes": ["accepted", "ambiguous"]}
     )
-    kwargs = dict(
-        composite_reward=0.9,
-        has_posterior=True,
-        observed_at="2026-05-01T00:00:00+00:00",
-        valid_at="2026-04-01T00:00:00+00:00",
-    )
+    kw_composite_reward = 0.9
+    kw_has_posterior = True
+    kw_observed_at = "2026-05-01T00:00:00+00:00"
+    kw_valid_at = "2026-04-01T00:00:00+00:00"
     # Current-policy + decisive rubric: admitted as gold.
     _seed_run_with_annotation(
-        tmp_path, "s-good", label="accepted", rubric_json=decisive_rubric, **kwargs
+        tmp_path, "s-good", label="accepted", rubric_json=decisive_rubric,
+        has_posterior=kw_has_posterior, composite_reward=kw_composite_reward,
+        observed_at=kw_observed_at, valid_at=kw_valid_at,
     )
     # Current-policy + ambiguous rubric: ``_rubric_decisive_only`` returns False, so no gold.
     _seed_run_with_annotation(
-        tmp_path, "s-ambiguous", label="accepted", rubric_json=ambiguous_rubric, **kwargs
+        tmp_path, "s-ambiguous", label="accepted", rubric_json=ambiguous_rubric,
+        has_posterior=kw_has_posterior, composite_reward=kw_composite_reward,
+        observed_at=kw_observed_at, valid_at=kw_valid_at,
     )
     # Legacy NULL policy + decisive rubric: the policy gate rejects it.
     _seed_run_with_annotation(
         tmp_path, "s-legacy", label="accepted", rubric_json=decisive_rubric,
-        labeler_policy_version=None, **kwargs,
+        labeler_policy_version=None,
+        has_posterior=kw_has_posterior, composite_reward=kw_composite_reward,
+        observed_at=kw_observed_at, valid_at=kw_valid_at,
     )
     out = tmp_path / "corpus.jsonl"
     run_build_corpus(_cfg(tmp_path, out_path=out))

--- a/tests/test_training_corpus.py
+++ b/tests/test_training_corpus.py
@@ -26,6 +26,7 @@ from daydream.training.corpus import (
     _build_query,
     _build_record,
     _is_admitted,
+    _is_admitted_outcome_gold,
     run_build_corpus,
 )
 from daydream.training.reward import PosteriorBreakdown, RewardBreakdown
@@ -44,6 +45,7 @@ def _seed_run_with_annotation(
     reward_version: str = "r1",
     rubric_json: str | None = None,
     has_posterior: bool | None = None,
+    labeler_policy_version: str | None = "980-policy",
     observed_at: str,
     valid_at: str,
     pipeline_status: str = "unknown",
@@ -122,6 +124,20 @@ def _seed_run_with_annotation(
         # every caller means. A local_branch row passes has_posterior=False.
         has_posterior=(label is not None) if has_posterior is None else has_posterior,
     )
+    # Stamp the policy axis: current-policy seeds (default "980-policy") are
+    # admitted as outcome gold; None models a legacy row stamped before the
+    # reply-classifier policy axis existed.
+    import sqlite3
+
+    conn = sqlite3.connect(str(archive_dir / "index.db"))
+    try:
+        conn.execute(
+            "UPDATE label_observations SET labeler_policy_version = ? WHERE session_id = ?",
+            (labeler_policy_version, session_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
     # append_label_observation stamps observed_at with wall clock; overwrite it
     # so as_of pins in tests are deterministic.
     import sqlite3
@@ -614,3 +630,30 @@ def test_cli_build_corpus_default_excludes_failed_pipelines(tmp_path: Path, arch
     lines2 = [line for line in out2.read_text().splitlines() if line.strip()]
     assert len(lines2) == 1
     assert json.loads(lines2[0])["session_id"] == "bad-run"
+
+
+LEGACY: dict[str, Any] = {"label": "accepted", "has_posterior": True, "labeler_policy_version": None,
+                          "decisive_mix": False, "decisive_only": True}
+MIXED: dict[str, Any]  = {**LEGACY, "labeler_policy_version": "980-policy", "decisive_mix": True}
+AMBIG: dict[str, Any]  = {
+    **LEGACY, "labeler_policy_version": "980-policy", "decisive_mix": False, "decisive_only": False}
+GOOD: dict[str, Any]   = {**LEGACY, "labeler_policy_version": "980-policy"}
+
+
+def test_gold_admission_rejects_legacy_observations() -> None:
+    """Legacy reply-count/merge-presence rows are excluded from outcome-bearing gold (M16/M22)."""
+    assert _is_admitted_outcome_gold(**LEGACY) is False
+
+
+def test_gold_admission_rejects_mixed_and_ambiguous() -> None:
+    assert _is_admitted_outcome_gold(**MIXED) is False
+    assert _is_admitted_outcome_gold(**AMBIG) is False
+
+
+def test_gold_admission_accepts_current_clean_evidence() -> None:
+    assert _is_admitted_outcome_gold(**GOOD) is True
+
+
+def test_min_reward_path_unaffected() -> None:
+    """The intrinsic min_reward path keeps its existing contract (no creep)."""
+    assert _is_admitted("rejected", 1.0, CorpusFilters(min_reward=0.5)) is True

--- a/tests/test_training_harvest.py
+++ b/tests/test_training_harvest.py
@@ -433,7 +433,7 @@ def test_build_annotation_fork_pr_author_reply_is_decisive(tmp_path: Path) -> No
     assert payload.labels == ["accepted"]
     # The PR-author reply is the decisive evidence, so it sets valid_at (M12).
     assert payload.valid_at == reply_created
-    rubric = json.loads(payload.rubric_json)
+    rubric = json.loads(payload.rubric_json or "{}")
     assert rubric.get("per_finding_outcomes") == ["accepted"]
 
 
@@ -478,7 +478,7 @@ def test_build_annotation_formal_review_author_reply_is_decisive(tmp_path: Path)
         row, run_dir=run_dir, archive_dir=tmp_path, gh_api=review_gh, repo_clone=tmp_path,
     )
     assert payload.labels == ["rejected"]
-    rubric = json.loads(payload.rubric_json)
+    rubric = json.loads(payload.rubric_json or "{}")
     assert rubric.get("per_finding_outcomes") == ["rejected"]
 
 

--- a/tests/test_training_harvest.py
+++ b/tests/test_training_harvest.py
@@ -60,6 +60,7 @@ def _seed_deep_bronze(tmp_path: Path, *, verdict: str, grounding: float) -> Path
 # in the daydream comment bodies, so the per-finding join can resolve them.
 _FP_A = "a" * 64
 _FP_B = "b" * 64
+_FP_C = "c" * 64
 
 
 def _finding_comments(
@@ -246,6 +247,76 @@ def test_build_annotation_pr_row_carries_per_finding_outcomes(tmp_path: Path) ->
                            repo_clone=tmp_path)
     assert ann.rubric_json is not None
     assert json.loads(ann.rubric_json)["per_finding_outcomes"] == ["accepted", "unanswered"]
+
+
+def test_harvest_626_shape_yields_both_polarities(tmp_path: Path) -> None:
+    """Three findings on a merged PR: one OWNER 'Fixed in <sha>', one OWNER 'False positive',
+    one qualifying question. Run label contested; per-finding exact (M22 final case)."""
+    run_dir = _seed_deep_bronze(tmp_path, verdict="consistent", grounding=1.0)
+    _write_findings(run_dir, _FP_A, _FP_B, _FP_C)
+    row = {"session_id": "s_626", "pr_repo": "o/r", "pr_number": 7, "head_sha": "h",
+           "base_branch": "main", "archive_path": str(run_dir),
+           "grounding_rate": 1.0, "changed_files": "[]"}
+    ann = build_annotation(
+        row,
+        run_dir=run_dir,
+        archive_dir=tmp_path,
+        gh_api=_fake_gh(
+            merged_at="2026-02-05T00:00:00+00:00",
+            comments=[
+                {
+                    "id": 1,
+                    "in_reply_to_id": None,
+                    "user": {"login": "daydream-runner"},
+                    "body": f"finding\n\n{finding_marker(_FP_A)}\n\n{DAYDREAM_FOOTER}",
+                },
+                {
+                    "id": 2,
+                    "in_reply_to_id": None,
+                    "user": {"login": "daydream-runner"},
+                    "body": f"finding\n\n{finding_marker(_FP_B)}\n\n{DAYDREAM_FOOTER}",
+                },
+                {
+                    "id": 3,
+                    "in_reply_to_id": None,
+                    "user": {"login": "daydream-runner"},
+                    "body": f"finding\n\n{finding_marker(_FP_C)}\n\n{DAYDREAM_FOOTER}",
+                },
+                {
+                    "id": 4,
+                    "in_reply_to_id": 1,
+                    "user": {"login": "amelia"},
+                    "author_association": "OWNER",
+                    "body": "Fixed in abc123",
+                    "created_at": "2026-02-01T10:00:00Z",
+                },
+                {
+                    "id": 5,
+                    "in_reply_to_id": 2,
+                    "user": {"login": "amelia"},
+                    "author_association": "OWNER",
+                    "body": "False positive",
+                    "created_at": "2026-02-01T11:00:00Z",
+                },
+                {
+                    "id": 6,
+                    "in_reply_to_id": 3,
+                    "user": {"login": "bob"},
+                    "author_association": "MEMBER",
+                    "body": "Which branch is this against?",
+                    "created_at": "2026-02-01T09:00:00Z",
+                },
+            ],
+        ),
+        repo_clone=tmp_path,
+    )
+    assert ann.labels == ["contested"]
+    assert ann.rubric_json is not None
+    rubric = json.loads(ann.rubric_json)
+    assert rubric["per_finding_outcomes"] == ["accepted", "rejected", "ambiguous"]
+    # valid_at is the earliest decisive evidence across the joined findings; the
+    # ambiguous MEMBER question is not decisive (M22).
+    assert ann.valid_at == "2026-02-01T10:00:00Z"
 
 
 def test_build_annotation_applies_posterior_penalty_for_rejected_pr(tmp_path: Path) -> None:

--- a/tests/test_training_harvest.py
+++ b/tests/test_training_harvest.py
@@ -7,6 +7,7 @@ import re
 from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -22,7 +23,7 @@ from daydream.archive.index import (
 from daydream.archive.manifest import Manifest
 from daydream.git_ops import GitError
 from daydream.pr_review import DAYDREAM_FOOTER, finding_marker
-from daydream.training import harvest
+from daydream.training import harvest, labeler_versions, reward
 from daydream.training.backfill_cache import BackfillCache
 from daydream.training.harvest import (
     HarvestConfig,
@@ -55,12 +56,61 @@ def _seed_deep_bronze(tmp_path: Path, *, verdict: str, grounding: float) -> Path
     return run_dir
 
 
-# One footer-marked daydream finding plus a human reply to it —
-# ``comment_resolution == (1, 1, 0)``, so the rubric yields ``accepted`` on real
-# evidence. A merged PR with *no* tracked comments is deliberately NOT this
-# shape: ``comment_resolution`` is ``(0, 0, 0)`` and ``unresolved == 0`` is
-# vacuously true, which the rubric must read as ``unknown`` — a merge alone is
-# not evidence daydream contributed.
+# Fingerprints recorded at review time (findings.json) and embedded as markers
+# in the daydream comment bodies, so the per-finding join can resolve them.
+_FP_A = "a" * 64
+_FP_B = "b" * 64
+
+
+def _finding_comments(
+    fp: str,
+    *,
+    reply: str | None = None,
+    reply_created_at: str | None = None,
+    reply_author: str = "amelia",
+) -> list[dict[str, Any]]:
+    """A footer-marked daydream finding comment for ``fp``, optionally replied.
+
+    The reply (when supplied) is a qualifying OWNER human, so it is decisive
+    evidence the classifier can label. ``reply_created_at`` feeds the
+    decisive-evidence ``valid_at`` derivation.
+    """
+    comments: list[dict[str, Any]] = [
+        {
+            "id": 1,
+            "in_reply_to_id": None,
+            "user": {"login": "daydream-runner"},
+            "body": f"finding\n\n{finding_marker(fp)}\n\n{DAYDREAM_FOOTER}",
+        }
+    ]
+    if reply is not None:
+        entry: dict[str, Any] = {
+            "id": 2,
+            "in_reply_to_id": 1,
+            "user": {"login": reply_author},
+            "author_association": "OWNER",
+            "body": reply,
+        }
+        if reply_created_at is not None:
+            entry["created_at"] = reply_created_at
+        comments.append(entry)
+    return comments
+
+
+def _write_findings(run_dir: Path, *fps: str) -> None:
+    """Record the given fingerprints in the run's ``findings.json`` artifact."""
+    (run_dir / "findings.json").write_text(
+        json.dumps({"findings": [{"fingerprint": fp} for fp in fps]})
+    )
+
+
+# One footer-marked daydream finding plus a human reply to it — used by tests
+# that only exercise plumbing (idempotent re-harvest, resume markers) where the
+# label itself is irrelevant; it carries no fingerprint marker, so the scoped
+# per-finding join sees nothing and the run labels ``unknown``. A merged PR
+# with *no* tracked comments is deliberately NOT an accepted shape either:
+# ``comment_resolution`` is ``(0, 0, 0)`` and a merge alone is not evidence
+# daydream contributed.
 _REPLIED_FINDING: list[dict[str, Any]] = [
     {
         "id": 1,
@@ -128,16 +178,26 @@ def _unused_gh(repo: str, endpoint: str, **kwargs: Any) -> Any:
     raise AssertionError(f"gh_api should not be called for a local row (endpoint={endpoint})")
 
 
-def test_build_annotation_pr_row_carries_label_reward_and_merge_valid_at(tmp_path: Path) -> None:
+def test_build_annotation_pr_row_labels_from_decisive_reply_evidence(tmp_path: Path) -> None:
     run_dir = _seed_deep_bronze(tmp_path, verdict="consistent", grounding=1.0)
+    _write_findings(run_dir, _FP_A)
     row = {"session_id": "s1", "pr_repo": "o/r", "pr_number": 7, "head_sha": "h",
            "base_branch": "main", "archive_path": str(run_dir),
            "grounding_rate": 1.0, "changed_files": "[]"}
-    ann = build_annotation(row, run_dir=run_dir, archive_dir=tmp_path,
-                           gh_api=_fake_gh(merged_at="2026-02-01T00:00:00+00:00", comments=_REPLIED_FINDING),
-                           repo_clone=tmp_path)
+    ann = build_annotation(
+        row,
+        run_dir=run_dir,
+        archive_dir=tmp_path,
+        gh_api=_fake_gh(
+            merged_at="2026-02-05T00:00:00+00:00",
+            comments=_finding_comments(_FP_A, reply="applied", reply_created_at="2026-02-01T10:00:00Z"),
+        ),
+        repo_clone=tmp_path,
+    )
     assert ann.labels == ["accepted"]
-    assert ann.valid_at == "2026-02-01T00:00:00+00:00"        # PR merge time (Q2)
+    # valid_at is the decisive evidence time (the qualifying accept reply), not
+    # the later merge timestamp (M12).
+    assert ann.valid_at == "2026-02-01T10:00:00Z"
     assert ann.composite_reward == json.loads(ann.reward_json)["composite"]
 
 
@@ -164,7 +224,7 @@ def _fake_gh_merged_per_finding(merged_at: str, fp_replied: str, fp_unreplied: s
                 "user": {"login": "daydream-runner"},
                 "body": f"finding\n\n{finding_marker(fp_unreplied)}\n\n{DAYDREAM_FOOTER}",
             },
-            {"id": 3, "in_reply_to_id": 1, "user": {"login": "human"}, "body": "fixed"},
+            {"id": 3, "in_reply_to_id": 1, "user": {"login": "human"}, "body": "applied"},
         ],
     )
 
@@ -185,7 +245,7 @@ def test_build_annotation_pr_row_carries_per_finding_outcomes(tmp_path: Path) ->
                            gh_api=_fake_gh_merged_per_finding("2026-02-01T00:00:00+00:00", fp_a, fp_b),
                            repo_clone=tmp_path)
     assert ann.rubric_json is not None
-    assert json.loads(ann.rubric_json)["per_finding_outcomes"] == ["accepted", "contested"]
+    assert json.loads(ann.rubric_json)["per_finding_outcomes"] == ["accepted", "unanswered"]
 
 
 def test_build_annotation_applies_posterior_penalty_for_rejected_pr(tmp_path: Path) -> None:
@@ -201,9 +261,14 @@ def test_build_annotation_applies_posterior_penalty_for_rejected_pr(tmp_path: Pa
     intrinsic_inputs = assemble_scoring_inputs(run_dir, row)
     intrinsic_only_composite = score_trajectory(intrinsic_inputs).composite
 
-    payload = build_annotation(row, run_dir=run_dir, archive_dir=tmp_path,
-                               gh_api=_fake_gh(merged=False),
-                               repo_clone=tmp_path)
+    _write_findings(run_dir, _FP_A)
+    payload = build_annotation(
+        row,
+        run_dir=run_dir,
+        archive_dir=tmp_path,
+        gh_api=_fake_gh(merged=False, comments=_finding_comments(_FP_A, reply="not applicable")),
+        repo_clone=tmp_path,
+    )
 
     assert payload.labels == ["rejected"]
     assert payload.has_posterior is True
@@ -221,9 +286,18 @@ def test_build_annotation_rejected_pr_empty_pool_uses_default_prior(tmp_path: Pa
     row = {"session_id": "s_rej_prod", "pr_repo": "o/r", "pr_number": 9, "head_sha": "h",
            "base_branch": "main", "archive_path": str(run_dir),
            "grounding_rate": 1.0, "changed_files": "[]"}
-    payload = build_annotation(row, run_dir=run_dir, archive_dir=archive_dir,
-                               gh_api=_fake_gh(merged=False, reviews=[{"user": {"login": "alice"}}]),
-                               repo_clone=tmp_path)
+    _write_findings(run_dir, _FP_A)
+    payload = build_annotation(
+        row,
+        run_dir=run_dir,
+        archive_dir=archive_dir,
+        gh_api=_fake_gh(
+            merged=False,
+            reviews=[{"user": {"login": "alice"}}],
+            comments=_finding_comments(_FP_A, reply="not applicable"),
+        ),
+        repo_clone=tmp_path,
+    )
     assert payload.labels == ["rejected"]
     assert payload.has_posterior is True
     rb = json.loads(payload.reward_json)
@@ -231,7 +305,8 @@ def test_build_annotation_rejected_pr_empty_pool_uses_default_prior(tmp_path: Pa
     assert rb["outcome_prior"] is None
     assert rb["outcome_prior_n"] == 0
     assert rb["posterior_cost"] == 0.5
-    assert payload.reviewer_logins == ["alice"]
+    # The qualifying reply author joins the reviewer set alongside the review author.
+    assert payload.reviewer_logins == ["alice", "amelia"]
 
 
 def test_build_annotation_shallow_local_row_null_valid_at_reward_present(tmp_path: Path) -> None:
@@ -293,11 +368,16 @@ def test_build_annotation_rejected_pr_populated_prior_drives_pool(tmp_path: Path
         "grounding_rate": 1.0,
         "changed_files": "[]",
     }
+    _write_findings(run_dir, _FP_A)
     payload = build_annotation(
         row,
         run_dir=run_dir,
         archive_dir=archive_dir,
-        gh_api=_fake_gh(merged=False, reviews=[{"user": {"login": "alice"}}]),
+        gh_api=_fake_gh(
+            merged=False,
+            reviews=[{"user": {"login": "alice"}}],
+            comments=_finding_comments(_FP_A, reply="not applicable"),
+        ),
         repo_clone=tmp_path,
     )
     assert payload.labels == ["rejected"]
@@ -321,8 +401,10 @@ def test_build_annotation_pr_uses_pooled_prior_and_persists_reviewers(
     row = {"session_id": "s_rej", "pr_repo": "o/r", "pr_number": 9, "head_sha": "h",
            "base_branch": "main", "archive_path": str(run_dir), "grounding_rate": 1.0,
            "changed_files": "[]"}
+    _write_findings(run_dir, _FP_A)
     p = build_annotation(row, run_dir=run_dir, archive_dir=tmp_path,
-                         gh_api=_fake_gh(merged=False), repo_clone=tmp_path)
+                         gh_api=_fake_gh(merged=False, comments=_finding_comments(_FP_A, reply="not applicable")),
+                         repo_clone=tmp_path)
     rb = json.loads(p.reward_json)
     assert rb["posterior_cost"] == pytest.approx(0.2)   # max(0, 1.0 - 0.8)
     assert rb["outcome_prior"] == 0.8 and rb["outcome_prior_n"] == 12
@@ -340,9 +422,11 @@ def test_build_annotation_below_threshold_falls_back_to_default_prior(
     row = {"session_id": "s_rej", "pr_repo": "o/r", "pr_number": 9, "head_sha": "h",
            "base_branch": "main", "archive_path": str(run_dir), "grounding_rate": 1.0,
            "changed_files": "[]"}
+    _write_findings(run_dir, _FP_A)
     rb = json.loads(
         build_annotation(row, run_dir=run_dir, archive_dir=tmp_path,
-                         gh_api=_fake_gh(merged=False), repo_clone=tmp_path).reward_json
+                         gh_api=_fake_gh(merged=False, comments=_finding_comments(_FP_A, reply="not applicable")),
+                         repo_clone=tmp_path).reward_json
     )
     assert rb["outcome_prior"] is None and rb["outcome_prior_n"] == 4  # n recorded; prior None -> 0.5
     assert rb["posterior_cost"] == 0.5
@@ -541,7 +625,13 @@ def _seed_orphan_run(
     return run_dir
 
 
-def _seed_pr_runs(archive_dir: Path, bronze_parent: Path, count: int) -> None:
+def _seed_pr_runs(
+    archive_dir: Path,
+    bronze_parent: Path,
+    count: int,
+    *,
+    fingerprints: Sequence[str] | None = None,
+) -> None:
     """Seed ``count`` PR-attached deep runs (sessions ``s1``..``sN``, ``pr_number`` 1..N).
 
     Each run gets its own bronze dir under ``bronze_parent/<session_id>`` so the
@@ -568,6 +658,8 @@ def _seed_pr_runs(archive_dir: Path, bronze_parent: Path, count: int) -> None:
                 archive_path=str(run_dir),
             ),
         )
+        if fingerprints:
+            _write_findings(run_dir, *fingerprints)
 
 
 async def test_harvest_writes_one_annotation(tmp_path: Path, archive_dir: Any, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -602,27 +694,26 @@ async def test_harvest_stores_github_z_merge_timestamp_canonically(
     assert obs["valid_at"] == "2026-02-01T00:00:00+00:00"
 
 
-async def test_harvest_labels_unresolved_daydream_comment_contested(
+async def test_harvest_unresolved_daydream_comment_stays_unknown(
     tmp_path: Path,
     archive_dir: Any,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Real-path: a merged PR whose daydream comment is unresolved → ``contested``.
+    """Real-path: a merged PR whose only finding has no qualifying reply is ``unknown``.
 
-    Bug 1 regression guard. daydream posts review comments as a normal
-    authenticated (non-``[bot]``) user, so the old ``[bot]`` author check made
-    its findings invisible → every merged PR was mislabeled ``accepted``. This
-    drives ``run_harvest`` end-to-end and asserts the persisted run label is
-    ``contested``, the rubric's correct verdict for an unresolved finding.
+    An unresolved daydream comment is *non-decisive* evidence (M9): nobody said
+    accept or reject, so the conservative rubric persists ``unknown`` (empty
+    labels) — bare reply absence and merge state never fabricate a label.
     """
-    _seed_archived_deep_run(archive_dir, "s-contest", merged_at="2026-02-01T00:00:00+00:00")
+    run_dir = _seed_archived_deep_run(archive_dir, "s-contest", merged_at="2026-02-01T00:00:00+00:00")
+    _write_findings(run_dir, _FP_A)
     monkeypatch.setattr(
         "daydream.training.harvest._gh_api",
-        _fake_gh(merged_at="2026-02-01T00:00:00+00:00", comments=_UNRESOLVED_FINDING),
+        _fake_gh(merged_at="2026-02-01T00:00:00+00:00", comments=_finding_comments(_FP_A)),
     )
     await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
     row = query_runs(archive_dir, "session_id = ?", ("s-contest",))[0]
-    assert json.loads(row["outcome_labels"]) == ["contested"]
+    assert json.loads(row["outcome_labels"]) == []  # unknown, never "accepted"
 
 
 async def test_harvest_relinks_orphan_run_and_labels_it(
@@ -636,14 +727,24 @@ async def test_harvest_relinks_orphan_run_and_labels_it(
     ``pr_number=None``. Harvest must re-link the orphan row by its ``head_sha``
     (via ``commits/{sha}/pulls``), persist the linkage, and then label the run
     through the PR path. Drives ``run_harvest`` end-to-end and asserts both the
-    persisted linkage and the resulting ``contested`` label.
+    persisted linkage and the resulting ``contested`` label (decisive accept
+    beside an unresolved finding — mixed evidence, M9).
     """
-    _seed_orphan_run(archive_dir, tmp_path, session_id="s-orph")
+    run_dir = _seed_orphan_run(archive_dir, tmp_path, session_id="s-orph")
+    _write_findings(run_dir, _FP_A, _FP_B)
     monkeypatch.setattr(
         "daydream.training.harvest._gh_api",
         _fake_gh(
             merged_at="2026-02-01T00:00:00+00:00",
-            comments=_UNRESOLVED_FINDING,
+            comments=[
+                *_finding_comments(_FP_A, reply="applied"),
+                {
+                    "id": 3,
+                    "in_reply_to_id": None,
+                    "user": {"login": "daydream-runner"},
+                    "body": f"finding\n\n{finding_marker(_FP_B)}\n\n{DAYDREAM_FOOTER}",
+                },
+            ],
             commit_pulls=_ORPHAN_COMMIT_PULLS,
         ),
     )
@@ -964,36 +1065,167 @@ async def test_harvest_merged_pr_with_zero_comments_is_not_labeled_accepted(
     assert "posterior_cost" not in json.loads(obs["reward_json"])
 
 
-async def test_harvest_merged_pr_with_replied_comment_is_labeled_accepted(
+async def test_harvest_merged_pr_with_reject_reply_is_contested(
     tmp_path: Path,
     archive_dir: Any,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Real-path: the evidenced accept survives the fix and IS posterior evidence.
+    """The amelia#626 shape: merged PR + explicit human rejection ⇒ contested, never accepted (M10/M22).
 
-    The positive arm of the same distinction: one tracked daydream finding, a
-    human reply resolving it, PR merged. This must stay ``accepted`` with
-    ``has_posterior`` set, or the fix would have erased the only genuinely
-    discriminative positives in the corpus.
+    One daydream finding is explicitly rejected by a qualifying OWNER reply
+    ("False positive…") while a second finding goes unanswered. The decisive
+    reject beside non-decisive evidence aggregates to ``contested`` — a merge
+    can never upgrade an explicit rejection to ``accepted``.
     """
-    _seed_archived_deep_run(archive_dir, "s-evidenced", merged_at="2026-02-01T00:00:00+00:00")
+    run_dir = _seed_archived_deep_run(archive_dir, "s-reject", merged_at="2026-08-10T00:00:00Z")
+    _write_findings(run_dir, _FP_A, _FP_B)
     monkeypatch.setattr(
         "daydream.training.harvest._gh_api",
-        _fake_gh(merged_at="2026-02-01T00:00:00+00:00", comments=_REPLIED_FINDING),
+        _fake_gh(
+            merged_at="2026-08-10T00:00:00Z",
+            comments=[
+                *_finding_comments(_FP_A, reply="False positive — the code already handles this"),
+                {
+                    "id": 3,
+                    "in_reply_to_id": None,
+                    "user": {"login": "daydream-runner"},
+                    "body": f"finding\n\n{finding_marker(_FP_B)}\n\n{DAYDREAM_FOOTER}",
+                },
+            ],
+        ),
     )
 
     summary = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
 
     assert summary["errors"] == 0 and summary["annotated"] == 1
-    row = query_runs(archive_dir, "session_id = ?", ("s-evidenced",))[0]
-    assert json.loads(row["outcome_labels"]) == ["accepted"]
-    obs = latest_label_observation(archive_dir, "s-evidenced")
+    row = query_runs(archive_dir, "session_id = ?", ("s-reject",))[0]
+    assert json.loads(row["outcome_labels"]) == ["contested"]  # NEVER ["accepted"]
+    obs = latest_label_observation(archive_dir, "s-reject")
     assert obs is not None
-    resolution = json.loads(obs["rubric_json"])["comment_resolution"]
-    assert (resolution["total"], resolution["unresolved"]) == (1, 0)
-    # A maintainer acting on a real PR IS posterior evidence.
-    assert obs["has_posterior"] == 1
-    assert json.loads(obs["reward_json"])["false_positive_penalty"] == 0.0
+    assert json.loads(obs["rubric_json"])["per_finding_outcomes"] == ["rejected", "unanswered"]
+
+
+async def test_harvest_unmerged_pr_with_no_semantic_reply_is_unknown(
+    tmp_path: Path,
+    archive_dir: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Open PR, bot-only reply ⇒ unknown; pr_state == 'open' preserved (M11/M22).
+
+    The only reply to the finding is from a bot, which never qualifies as human
+    judgment, so the finding is ``unanswered`` and the run stays ``unknown``.
+    The PR's open state is preserved as context, not read as a rejection.
+    """
+    run_dir = _seed_archived_deep_run(archive_dir, "s-open", merged_at="2026-08-10T00:00:00Z")
+    _write_findings(run_dir, _FP_A)
+
+    def _gh_open(repo: str, endpoint: str, **kwargs: Any) -> Any:
+        if endpoint.endswith("/comments"):
+            return [
+                *_finding_comments(_FP_A),
+                {
+                    "id": 2,
+                    "in_reply_to_id": 1,
+                    "user": {"login": "dependabot[bot]", "type": "Bot"},
+                    "body": "applied",
+                },
+            ]
+        if endpoint.endswith("/reviews"):
+            return []
+        return {"merged": False, "merged_at": None, "state": "open"}
+
+    monkeypatch.setattr("daydream.training.harvest._gh_api", _gh_open)
+
+    summary = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
+
+    assert summary["errors"] == 0 and summary["annotated"] == 1
+    row = query_runs(archive_dir, "session_id = ?", ("s-open",))[0]
+    assert json.loads(row["outcome_labels"]) == []  # unknown, NOT ["rejected"]
+    obs = latest_label_observation(archive_dir, "s-open")
+    assert obs is not None
+    assert obs["pr_state"] == "open"
+
+
+def test_valid_at_is_decisive_evidence_time(tmp_path: Path) -> None:
+    """valid_at = qualifying reply timestamp, not merged_at (M12/M22)."""
+    run_dir = _seed_deep_bronze(tmp_path, verdict="consistent", grounding=1.0)
+    _write_findings(run_dir, _FP_A)
+    row = {"session_id": "s-val", "pr_repo": "o/r", "pr_number": 7, "head_sha": "h",
+           "base_branch": "main", "archive_path": str(run_dir),
+           "grounding_rate": 1.0, "changed_files": "[]"}
+    ann = build_annotation(
+        row,
+        run_dir=run_dir,
+        archive_dir=tmp_path,
+        gh_api=_fake_gh(
+            merged_at="2026-08-10T00:00:00Z",
+            comments=_finding_comments(_FP_A, reply="applied", reply_created_at="2026-08-02T10:00:00Z"),
+        ),
+        repo_clone=tmp_path,
+    )
+    assert ann.valid_at == "2026-08-02T10:00:00Z"
+
+
+def test_valid_at_override_respected(tmp_path: Path) -> None:
+    """An explicit override beats derived evidence time (M12)."""
+    run_dir = _seed_deep_bronze(tmp_path, verdict="consistent", grounding=1.0)
+    _write_findings(run_dir, _FP_A)
+    row = {"session_id": "s-val-ovr", "pr_repo": "o/r", "pr_number": 7, "head_sha": "h",
+           "base_branch": "main", "archive_path": str(run_dir),
+           "grounding_rate": 1.0, "changed_files": "[]"}
+    ann = build_annotation(
+        row,
+        run_dir=run_dir,
+        archive_dir=tmp_path,
+        gh_api=_fake_gh(
+            merged_at="2026-08-10T00:00:00Z",
+            comments=_finding_comments(_FP_A, reply="applied", reply_created_at="2026-08-02T10:00:00Z"),
+        ),
+        repo_clone=tmp_path,
+        valid_at_override="2026-09-01T00:00:00Z",
+    )
+    assert ann.valid_at == "2026-09-01T00:00:00Z"
+
+
+async def test_labeler_version_is_not_reward_version(
+    tmp_path: Path,
+    archive_dir: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """append_label_observation receives labeler_versions.LABELER_POLICY_VERSION (M13/M22)."""
+    run_dir = _seed_archived_deep_run(archive_dir, "s-lv", merged_at="2026-08-10T00:00:00Z")
+    _write_findings(run_dir, _FP_A)
+    monkeypatch.setattr(
+        "daydream.training.harvest._gh_api",
+        _fake_gh(
+            merged_at="2026-08-10T00:00:00Z",
+            comments=_finding_comments(_FP_A, reply="applied", reply_created_at="2026-08-02T10:00:00Z"),
+        ),
+    )
+    captured: dict[str, Any] = {}
+
+    def _capture(_archive_dir: Path, _session_id: str, **kwargs: Any) -> bool:
+        captured.update(kwargs)
+        return True
+
+    monkeypatch.setattr("daydream.training.harvest.append_label_observation", _capture)
+    summary = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
+
+    assert summary["annotated"] == 1
+    assert captured["labeler_version"] == labeler_versions.LABELER_POLICY_VERSION
+    assert captured["labeler_version"] != reward.REWARD_VERSION
+    assert captured["reply_classifier_version"] == labeler_versions.REPLY_CLASSIFIER_VERSION
+    assert captured["reply_evidence_digest"]
+
+
+def test_resume_cache_invalidated_on_policy_bump(tmp_path: Path) -> None:
+    """A policy-version change re-fetches sessions previously marked done (M15/M22)."""
+    cache = BackfillCache(cache_dir=tmp_path, inner=lambda r, e, **kw: {})
+    cache.mark_session_done("sess-1")
+    with patch.object(labeler_versions, "LABELER_POLICY_VERSION", "980-r2"):
+        assert "sess-1" not in cache.completed_sessions()
+    # And without the bump the session is still resumable:
+    assert "sess-1" in cache.completed_sessions()
 
 
 async def test_harvest_local_branch_accept_keeps_label_but_is_not_posterior_evidence(
@@ -1371,22 +1603,15 @@ async def test_harvest_keeps_labeled_row_when_reviewer_lookup_errors(
     only the optional prior), not dropped as a hard error through the per-row
     catch-all. Drives ``run_harvest`` end-to-end.
     """
-    _seed_archived_deep_run(archive_dir, "s-reviews-err", merged_at="2026-02-01T00:00:00+00:00")
+    run_dir = _seed_archived_deep_run(archive_dir, "s-reviews-err", merged_at="2026-02-01T00:00:00+00:00")
+    _write_findings(run_dir, _FP_A)
 
     def _gh_reviews_fail(repo: str, endpoint: str, **kwargs: Any) -> Any:
         if endpoint.endswith("/reviews"):
             raise GitError("gh: Internal Server Error (HTTP 500)")
         if endpoint.endswith("/comments"):
             # A resolved daydream thread: the evidence that makes the merge decisive.
-            return [
-                {
-                    "id": 1,
-                    "in_reply_to_id": None,
-                    "user": {"login": "daydream-runner"},
-                    "body": f"finding\n\n{DAYDREAM_FOOTER}",
-                },
-                {"id": 2, "in_reply_to_id": 1, "user": {"login": "human"}, "body": "fixed"},
-            ]
+            return _finding_comments(_FP_A, reply="applied")
         return {"merged": True, "merged_at": "2026-02-01T00:00:00+00:00"}
 
     monkeypatch.setattr("daydream.training.harvest._gh_api", _gh_reviews_fail)
@@ -1410,9 +1635,12 @@ async def test_harvest_degrades_benign_giterror_rows_instead_of_dropping(
     # instead of dropping them: errors == 0, annotated == 10. Degraded rows route
     # through _build_rubric_local, so their pr_state is None (NOT a fabricated PR
     # rubric) — observable proof no merged=False rubric drove their label.
-    _seed_pr_runs(archive_dir, tmp_path, 10)
+    _seed_pr_runs(archive_dir, tmp_path, 10, fingerprints=(_FP_A,))
 
-    merged = _fake_gh(merged_at="2026-02-01T00:00:00+00:00", comments=_REPLIED_FINDING)
+    merged = _fake_gh(
+        merged_at="2026-02-01T00:00:00+00:00",
+        comments=_finding_comments(_FP_A, reply="applied"),
+    )
 
     def _gh(repo: str, endpoint: str, **kw: Any) -> Any:
         match = re.search(r"/pulls/(\d+)", endpoint)

--- a/tests/test_training_harvest.py
+++ b/tests/test_training_harvest.py
@@ -124,7 +124,7 @@ _REPLIED_FINDING: list[dict[str, Any]] = [
 
 # Daydream's footer-marked comment with NO reply, authored as a normal human
 # user (not a ``[bot]``): one unresolved daydream issue, which the rubric must
-# read as ``contested``, never ``accepted``.
+# read as ``unanswered``, never ``accepted``.
 _UNRESOLVED_FINDING: list[dict[str, Any]] = [
     {
         "id": 1,
@@ -233,7 +233,7 @@ def _fake_gh_merged_per_finding(merged_at: str, fp_replied: str, fp_unreplied: s
 
 def test_build_annotation_pr_row_carries_per_finding_outcomes(tmp_path: Path) -> None:
     """A merged PR with a findings.json in the archive yields per-finding labels
-    joined by fingerprint: the replied finding is accepted, the unreplied one contested."""
+    joined by fingerprint: the replied finding is accepted, the unreplied one unanswered."""
     fp_a = "a" * 64
     fp_b = "b" * 64
     run_dir = _seed_deep_bronze(tmp_path, verdict="consistent", grounding=1.0)
@@ -379,6 +379,107 @@ def test_build_annotation_rejected_pr_empty_pool_uses_default_prior(tmp_path: Pa
     assert rb["posterior_cost"] == 0.5
     # The qualifying reply author joins the reviewer set alongside the review author.
     assert payload.reviewer_logins == ["alice", "amelia"]
+
+
+def test_build_annotation_fork_pr_author_reply_is_decisive(tmp_path: Path) -> None:
+    """M6 wiring (issues #2/#4): a fork-PR author's reply is decisive.
+
+    A fork/contributor author (``author_association`` ``NONE``) whose login
+    matches the pull's author must be able to cast the decisive vote through
+    the production harvest path — ``pr_author_logins`` is now threaded into
+    ``per_finding_resolution_signal`` via ``build_annotation``. Without the
+    wiring the reply is ``excluded:non-qualifying``, the finding stays
+    ``unanswered``, and the run would resolve to ``unknown`` instead.
+    """
+    run_dir = _seed_deep_bronze(tmp_path, verdict="consistent", grounding=1.0)
+    _write_findings(run_dir, _FP_A)
+    row = {"session_id": "s_fork_auth", "pr_repo": "o/r", "pr_number": 13, "head_sha": "h",
+           "base_branch": "main", "archive_path": str(run_dir),
+           "grounding_rate": 1.0, "changed_files": "[]"}
+    reply_created = "2026-08-02T10:00:00Z"
+    comments = [
+        {
+            "id": 1,
+            "in_reply_to_id": None,
+            "user": {"login": "daydream-runner"},
+            "body": f"finding\n\n{finding_marker(_FP_A)}\n\n{DAYDREAM_FOOTER}",
+        },
+        {
+            "id": 2,
+            "in_reply_to_id": 1,
+            "user": {"login": "prfiona", "type": "User"},
+            "author_association": "NONE",  # fork contributor
+            "body": "Fixed in abc123",      # decisive accept
+            "created_at": reply_created,
+        },
+    ]
+
+    def fork_gh(repo: str, endpoint: str, **kwargs: Any) -> Any:
+        if endpoint.endswith("/comments"):
+            return comments
+        if endpoint.endswith("/reviews"):
+            return []
+        # The pull payload carries the PR author == the fork reply author.
+        return {
+            "merged": True,
+            "merged_at": "2026-08-03T00:00:00Z",
+            "state": "merged",
+            "user": {"login": "prfiona"},
+        }
+
+    payload = build_annotation(
+        row, run_dir=run_dir, archive_dir=tmp_path, gh_api=fork_gh, repo_clone=tmp_path,
+    )
+    assert payload.labels == ["accepted"]
+    # The PR-author reply is the decisive evidence, so it sets valid_at (M12).
+    assert payload.valid_at == reply_created
+    rubric = json.loads(payload.rubric_json)
+    assert rubric.get("per_finding_outcomes") == ["accepted"]
+
+
+def test_build_annotation_formal_review_author_reply_is_decisive(tmp_path: Path) -> None:
+    """M6 wiring (issues #2/#4): a formal-review author's reply is decisive.
+
+    A reviewer author (not OWNER/MEMBER/COLLABORATOR) whose login comes back
+    from the ``/reviews`` lookup counts under the M6 gate through the same
+    ``review_author_logins`` plumbing in ``build_annotation``.
+    """
+    run_dir = _seed_deep_bronze(tmp_path, verdict="consistent", grounding=1.0)
+    _write_findings(run_dir, _FP_A)
+    row = {"session_id": "s_review_auth", "pr_repo": "o/r", "pr_number": 14, "head_sha": "h",
+           "base_branch": "main", "archive_path": str(run_dir),
+           "grounding_rate": 1.0, "changed_files": "[]"}
+    comments = [
+        {
+            "id": 1,
+            "in_reply_to_id": None,
+            "user": {"login": "daydream-runner"},
+            "body": f"finding\n\n{finding_marker(_FP_A)}\n\n{DAYDREAM_FOOTER}",
+        },
+        {
+            "id": 2,
+            "in_reply_to_id": 1,
+            "user": {"login": "revbob", "type": "User"},
+            "author_association": "NONE",  # reviewed the PR but not a maintainer
+            "body": "False positive, the linter is wrong here",
+            "created_at": "2026-08-02T09:00:00Z",
+        },
+    ]
+
+    def review_gh(repo: str, endpoint: str, **kwargs: Any) -> Any:
+        if endpoint.endswith("/comments"):
+            return comments
+        if endpoint.endswith("/reviews"):
+            return [{"user": {"login": "revbob"}}]
+        return {"merged": True, "merged_at": "2026-08-03T00:00:00Z", "state": "merged",
+                "user": {"login": "someone-else"}}
+
+    payload = build_annotation(
+        row, run_dir=run_dir, archive_dir=tmp_path, gh_api=review_gh, repo_clone=tmp_path,
+    )
+    assert payload.labels == ["rejected"]
+    rubric = json.loads(payload.rubric_json)
+    assert rubric.get("per_finding_outcomes") == ["rejected"]
 
 
 def test_build_annotation_shallow_local_row_null_valid_at_reward_present(tmp_path: Path) -> None:

--- a/tests/test_training_harvest.py
+++ b/tests/test_training_harvest.py
@@ -1373,7 +1373,7 @@ async def test_re_harvest_appends_on_version_bump(
         _fake_gh(merged_at="2026-02-01T00:00:00+00:00", comments=_REPLIED_FINDING),
     )
     await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c1"))
-    monkeypatch.setattr("daydream.training.harvest.reward.REWARD_VERSION", "9999.99.99-bump")
+    monkeypatch.setattr("daydream.training.labeler_versions.LABELER_POLICY_VERSION", "980-policy-bump")
     await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c2"))
     assert len(label_observation_history(archive_dir, "s1")) == 2
 

--- a/tests/test_training_harvest.py
+++ b/tests/test_training_harvest.py
@@ -225,7 +225,8 @@ def _fake_gh_merged_per_finding(merged_at: str, fp_replied: str, fp_unreplied: s
                 "user": {"login": "daydream-runner"},
                 "body": f"finding\n\n{finding_marker(fp_unreplied)}\n\n{DAYDREAM_FOOTER}",
             },
-            {"id": 3, "in_reply_to_id": 1, "user": {"login": "human"}, "body": "applied"},
+            {"id": 3, "in_reply_to_id": 1, "user": {"login": "human"},
+             "author_association": "MEMBER", "body": "applied"},
         ],
     )
 

--- a/tests/test_training_labeler_signals.py
+++ b/tests/test_training_labeler_signals.py
@@ -16,6 +16,7 @@ from daydream.training.labeler_signals import (
     FixAppliedSignal,
     LocalCommitAppliedSignal,
     PerFindingResolution,
+    PRCommentThreads,
     PRMergeSignal,
     comment_resolution_signal,
     fix_applied_signal,
@@ -46,7 +47,9 @@ def test_pr_merge_signal_positive() -> None:
             },
         }
     )
-    assert pr_merge_signal(row, gh_api=gh) == PRMergeSignal(merged=True, merged_at="2026-01-01T00:00:00Z")
+    assert pr_merge_signal(row, gh_api=gh) == PRMergeSignal(
+        merged=True, merged_at="2026-01-01T00:00:00Z", state="merged"
+    )
 
 
 def test_pr_merge_signal_no_pr() -> None:
@@ -141,60 +144,84 @@ def test_fix_applied_signal_50pct_hunk_threshold(tmp_path: Path) -> None:
     assert sig.hunks_total == 3
 
 
-@pytest.mark.parametrize(
-    ("comments", "expected"),
-    [
-        pytest.param(
-            [
-                {
-                    "id": 1,
-                    "in_reply_to_id": None,
-                    "user": {"login": "daydream-runner"},
-                    "body": f"finding\n\n{DAYDREAM_FOOTER}",
-                },
-                {"id": 2, "in_reply_to_id": 1, "user": {"login": "human"}, "body": "ack"},
-            ],
-            CommentResolutionSignal(total=1, replied=1, unresolved=0),
-            id="all-resolved",
-        ),
-        pytest.param(
-            [
-                {
-                    "id": 1,
-                    "in_reply_to_id": None,
-                    "user": {"login": "kevin"},
-                    "body": f"finding\n\n{DAYDREAM_FOOTER}",
-                },
-            ],
-            CommentResolutionSignal(total=1, replied=0, unresolved=1),
-            id="human-authored-footer",
-        ),
-        pytest.param(
-            [
-                {
-                    "id": 1,
-                    "in_reply_to_id": None,
-                    "user": {"login": "coderabbitai[bot]"},
-                    "body": "nit",
-                },
-            ],
-            CommentResolutionSignal(total=0, replied=0, unresolved=0),
-            id="non-daydream-bot",
-        ),
-    ],
-)
-def test_comment_resolution_signal(
-    comments: list[dict[str, Any]],
-    expected: CommentResolutionSignal,
-) -> None:
-    """Classify resolution from bot, human, empty, and mixed review threads."""
-    row = {"pr_repo": "org/repo", "pr_number": 42}
-    gh = _fake_gh_responder(
-        {
-            ("org/repo", "repos/org/repo/pulls/42/comments"): comments,
-        }
+FP = "a" * 64
+
+
+def test_comment_resolution_signal_counts_top_level_threads() -> None:
+    """Aggregate counts top-level daydream threads and reply presence (context only)."""
+    comments = [
+        _comment(1, f"finding\n\n{DAYDREAM_FOOTER}"),
+        _comment(2, "ack", in_reply_to=1),
+        _comment(3, f"finding\n\n{DAYDREAM_FOOTER}"),
+    ]
+    gh = _fake_gh_responder({("org/repo", "repos/org/repo/pulls/42/comments"): comments})
+    assert comment_resolution_signal({"pr_repo": "org/repo", "pr_number": 42}, gh_api=gh) == (
+        CommentResolutionSignal(total=2, replied=1, unresolved=1)
     )
-    assert comment_resolution_signal(row, gh_api=gh) == expected
+
+
+def _scoped_threads(replies: list[tuple[str, dict[str, Any]]]) -> PRCommentThreads:
+    comments = [_comment(10, _daydream_body(FP))] + [
+        _comment(100 + i, body, in_reply_to=10, **over) for i, (body, over) in enumerate(replies)
+    ]
+    gh = _fake_gh_responder({("org/repo", "repos/org/repo/pulls/11/comments"): comments})
+    threads = index_pr_review_comments({"pr_repo": "org/repo", "pr_number": 11}, gh_api=gh, session_fingerprints=[FP])
+    assert threads is not None
+    return threads
+
+
+def _resolve(replies: list[tuple[str, dict[str, Any]]]) -> list[PerFindingResolution]:
+    threads = _scoped_threads(replies)
+    return per_finding_resolution_signal(
+        {"pr_repo": "org/repo", "pr_number": 11}, recorded_fingerprints=[FP], gh_api=None, threads=threads,
+    )
+
+
+def test_disposition_accepted_on_qualifying_accept() -> None:
+    (res,) = _resolve([("Fixed in abc123", {"login": "maint", "assoc": "OWNER"})])
+    assert res.disposition == "accepted"
+    assert res.comment_id == 10
+    ev = res.evidence[0]
+    assert ev["reply_id"] == 100 and ev["author"] == "maint"
+    assert ev["author_association"] == "OWNER" and ev["reason"] == "assoc:OWNER"
+
+
+def test_disposition_rejected_on_false_positive() -> None:
+    (res,) = _resolve([("False positive, path is unreachable", {"login": "dev", "assoc": "NONE"})])
+    assert res.disposition == "rejected"
+
+
+def test_disposition_ambiguous_on_question() -> None:
+    (res,) = _resolve([("Is this still true on 3.12?", {"login": "dev", "assoc": "NONE"})])
+    assert res.disposition == "ambiguous"
+
+
+def test_disposition_unanswered_on_bot_only_and_self_replies() -> None:
+    (res,) = _resolve([
+        ("Fixed in abc", {"bot": "Bot", "login": "app[bot]", "assoc": "NONE"}),
+        ("Fixed in abc", {"login": "daydream-agent", "assoc": "NONE", "_self": True}),
+    ])
+    assert res.disposition == "unanswered"
+    # evidence still persists (M3) — exclusion is recorded, not dropped
+    assert len(res.evidence) == 2
+    assert all("excluded" in ev["reason"] for ev in res.evidence)
+
+
+def test_disposition_missing_when_comment_deleted() -> None:
+    threads = _scoped_threads([])  # comment exists but...
+    assert threads is not None
+    threads.comment_id_by_fingerprint.clear()  # simulate edited-away/deleted marker
+    (res,) = per_finding_resolution_signal(
+        {"pr_repo": "org/repo", "pr_number": 11}, recorded_fingerprints=[FP], gh_api=None, threads=threads,
+    )
+    assert res.disposition == "missing" and res.comment_id is None
+
+
+def test_disposition_evidence_digest_changes_with_reply_edit() -> None:
+    """An edited reply body changes the evidence digest (M14 input)."""
+    (r1,) = _resolve([("Fixed in abc", {"login": "m", "assoc": "OWNER"})])
+    (r2,) = _resolve([("Fixed in abc — well, partially", {"login": "m", "assoc": "OWNER"})])
+    assert r1.evidence_digest != r2.evidence_digest
 
 
 def test_local_commit_applied_signal_positive(tmp_path: Path) -> None:
@@ -437,26 +464,27 @@ def _daydream_finding_comment(comment_id: int, fingerprint: str) -> dict[str, An
 
 
 def test_per_finding_resolution_signal_mixed_outcomes() -> None:
-    """Two findings: one replied (resolved), one not (unresolved)."""
+    """Two findings: one with a decisive human reply, one only a non-directional reply."""
     row = {"pr_repo": "org/repo", "pr_number": 42}
     gh = _fake_gh_responder(
         {
             ("org/repo", "repos/org/repo/pulls/42/comments"): [
                 _daydream_finding_comment(1, _FP_A),
                 _daydream_finding_comment(2, _FP_B),
-                {"id": 3, "in_reply_to_id": 1, "user": {"login": "human"}, "body": "fixed"},
+                _comment(3, "Fixed in abc123", in_reply_to=1, login="human"),
             ],
         }
     )
     result = per_finding_resolution_signal(row, recorded_fingerprints=[_FP_A, _FP_B], gh_api=gh)
-    assert result == [
-        PerFindingResolution(fingerprint=_FP_A, resolved=True, comment_id=1),
-        PerFindingResolution(fingerprint=_FP_B, resolved=False, comment_id=2),
+    assert [(r.fingerprint, r.comment_id, r.disposition) for r in result] == [
+        (_FP_A, 1, "accepted"),
+        (_FP_B, 2, "unanswered"),
     ]
+    assert result[0].evidence and not result[1].evidence
 
 
 def test_per_finding_resolution_signal_deleted_comment() -> None:
-    """A recorded fingerprint with no surviving comment → comment_id=None, unresolved."""
+    """A recorded fingerprint with no surviving comment → missing, comment_id=None (M4)."""
     row = {"pr_repo": "org/repo", "pr_number": 42}
     gh = _fake_gh_responder(
         {
@@ -466,25 +494,26 @@ def test_per_finding_resolution_signal_deleted_comment() -> None:
         }
     )
     result = per_finding_resolution_signal(row, recorded_fingerprints=[_FP_A, _FP_C], gh_api=gh)
-    assert result == [
-        PerFindingResolution(fingerprint=_FP_A, resolved=False, comment_id=1),
-        PerFindingResolution(fingerprint=_FP_C, resolved=False, comment_id=None),
+    assert [(r.fingerprint, r.comment_id, r.disposition) for r in result] == [
+        (_FP_A, 1, "unanswered"),
+        (_FP_C, None, "missing"),
     ]
 
 
 def test_per_finding_resolution_signal_single_finding() -> None:
-    """Standard single-finding case with a reply → resolved."""
+    """Standard single-finding case: reply body drives the disposition."""
     row = {"pr_repo": "org/repo", "pr_number": 42}
     gh = _fake_gh_responder(
         {
             ("org/repo", "repos/org/repo/pulls/42/comments"): [
                 _daydream_finding_comment(9, _FP_A),
-                {"id": 10, "in_reply_to_id": 9, "user": {"login": "human"}, "body": "ack"},
+                _comment(10, "Not a bug — already handled", in_reply_to=9, login="human"),
             ],
         }
     )
     result = per_finding_resolution_signal(row, recorded_fingerprints=[_FP_A], gh_api=gh)
-    assert result == [PerFindingResolution(fingerprint=_FP_A, resolved=True, comment_id=9)]
+    assert len(result) == 1
+    assert (result[0].comment_id, result[0].disposition) == (9, "rejected")
 
 
 def test_per_finding_resolution_signal_no_pr() -> None:
@@ -495,16 +524,32 @@ def test_per_finding_resolution_signal_no_pr() -> None:
 
 
 
-def _comment(cid, body, in_reply_to=None, login="alice", assoc="MEMBER", bot="User", created="2026-08-01T00:00:00Z"):
-    return {"id": cid, "in_reply_to_id": in_reply_to, "user": {"login": login, "type": bot},
-            "author_association": assoc, "body": body, "created_at": created}
+def _comment(
+    cid: int,
+    body: str,
+    in_reply_to: int | None = None,
+    login: str = "alice",
+    assoc: str = "MEMBER",
+    bot: str = "User",
+    created: str = "2026-08-01T00:00:00Z",
+    **extra: Any,
+) -> dict[str, Any]:
+    self_reply = extra.pop("_self", False)
+    comment: dict[str, Any] = {
+        "id": cid, "in_reply_to_id": in_reply_to, "user": {"login": login, "type": bot},
+        "author_association": assoc, "body": body, "created_at": created,
+    }
+    if self_reply:
+        comment["is_self_reply"] = True
+    comment.update(extra)
+    return comment
 
 
-def _daydream_body(*fps):
+def _daydream_body(*fps: str) -> str:
     return "\n".join(finding_marker(fp) for fp in fps) + "\n" + DAYDREAM_FOOTER
 
 
-def _threads_response(comments):
+def _threads_response(comments: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return comments
 
 
@@ -536,6 +581,7 @@ def test_thread_index_keeps_full_reply_objects() -> None:
     ]
     gh = _fake_gh_responder({("org/repo", "repos/org/repo/pulls/5/comments"): comments})
     threads = index_pr_review_comments({"pr_repo": "org/repo", "pr_number": 5}, gh_api=gh)
+    assert threads is not None
     replies = threads.replies_by_comment[10]
     assert len(replies) == 1
     r = replies[0]
@@ -557,6 +603,7 @@ def test_thread_index_scopes_to_fingerprints() -> None:
         {"pr_repo": "org/repo", "pr_number": 7}, gh_api=gh,
         session_fingerprints=[fp_mine],
     )
+    assert threads is not None
     assert set(threads.comment_id_by_fingerprint) == {fp_mine}
     assert 31 not in threads.top_level_daydream_ids
     assert threads.replies_by_comment.get(31) is None  # other-run thread not in evidence

--- a/tests/test_training_labeler_signals.py
+++ b/tests/test_training_labeler_signals.py
@@ -19,6 +19,7 @@ from daydream.training.labeler_signals import (
     PRMergeSignal,
     comment_resolution_signal,
     fix_applied_signal,
+    index_pr_review_comments,
     local_commit_applied_signal,
     per_finding_resolution_signal,
     pr_link_signal,
@@ -492,3 +493,85 @@ def test_per_finding_resolution_signal_no_pr() -> None:
     result = per_finding_resolution_signal(row, recorded_fingerprints=[_FP_A], gh_api=_fake_gh_responder({}))
     assert result == []
 
+
+
+def _comment(cid, body, in_reply_to=None, login="alice", assoc="MEMBER", bot="User", created="2026-08-01T00:00:00Z"):
+    return {"id": cid, "in_reply_to_id": in_reply_to, "user": {"login": login, "type": bot},
+            "author_association": assoc, "body": body, "created_at": created}
+
+
+def _daydream_body(*fps):
+    return "\n".join(finding_marker(fp) for fp in fps) + "\n" + DAYDREAM_FOOTER
+
+
+def _threads_response(comments):
+    return comments
+
+
+def test_pr_merge_signal_preserves_state() -> None:
+    """Open PR keeps state='open'; closed-unmerged keeps 'closed' (M11)."""
+    gh = _fake_gh_responder({
+        ("org/repo", "repos/org/repo/pulls/1"): {"merged": False, "merged_at": None, "state": "open", "draft": False},
+        ("org/repo", "repos/org/repo/pulls/2"): {"merged": False, "merged_at": None, "state": "closed", "draft": False},
+    })
+    assert pr_merge_signal({"pr_repo": "org/repo", "pr_number": 1}, gh_api=gh).state == "open"
+    sig2 = pr_merge_signal({"pr_repo": "org/repo", "pr_number": 2}, gh_api=gh)
+    assert sig2.state == "closed" and sig2.merged is False
+
+
+def test_pr_merge_signal_legacy_payload_defaults() -> None:
+    """A payload without state/draft (cached fixtures) degrades to safe defaults, not 'closed'."""
+    gh = _fake_gh_responder({("org/repo", "repos/org/repo/pulls/3"): {"merged": False, "merged_at": None}})
+    sig = pr_merge_signal({"pr_repo": "org/repo", "pr_number": 3}, gh_api=gh)
+    assert sig.state == "unknown" and sig.draft is False
+
+
+def test_thread_index_keeps_full_reply_objects() -> None:
+    """Replies persist as objects with author/body/assoc/timestamps (M3), not a count."""
+    fp_a, fp_b = "a" * 64, "b" * 64
+    comments = [
+        _comment(10, _daydream_body(fp_a)),
+        _comment(11, _daydream_body(fp_b)),
+        _comment(20, "Fixed in abc123", in_reply_to=10, login="maint", assoc="OWNER", created="2026-08-02T10:00:00Z"),
+    ]
+    gh = _fake_gh_responder({("org/repo", "repos/org/repo/pulls/5/comments"): comments})
+    threads = index_pr_review_comments({"pr_repo": "org/repo", "pr_number": 5}, gh_api=gh)
+    replies = threads.replies_by_comment[10]
+    assert len(replies) == 1
+    r = replies[0]
+    assert r["user"]["login"] == "maint" and r["author_association"] == "OWNER"
+    assert r["body"] == "Fixed in abc123" and r["created_at"] == "2026-08-02T10:00:00Z"
+
+
+def test_thread_index_scopes_to_fingerprints() -> None:
+    """Only the session's recorded fingerprints are exposed; other runs' threads are context (M8)."""
+    fp_mine, fp_other = "c" * 64, "d" * 64
+    comments = [
+        _comment(30, _daydream_body(fp_mine)),
+        _comment(31, _daydream_body(fp_other)),  # another daydream run's finding
+        _comment(40, "already handled", in_reply_to=31),   # reply to OTHER run's thread
+        _comment(41, "fixed in abc", in_reply_to=30),
+    ]
+    gh = _fake_gh_responder({("org/repo", "repos/org/repo/pulls/7/comments"): comments})
+    threads = index_pr_review_comments(
+        {"pr_repo": "org/repo", "pr_number": 7}, gh_api=gh,
+        session_fingerprints=[fp_mine],
+    )
+    assert set(threads.comment_id_by_fingerprint) == {fp_mine}
+    assert 31 not in threads.top_level_daydream_ids
+    assert threads.replies_by_comment.get(31) is None  # other-run thread not in evidence
+
+
+def test_comment_resolution_signal_becomes_fingerprint_scoped_aggregate() -> None:
+    """Run-level counts derive from session fingerprints only (M8) — other runs' replies don't count."""
+    fp_mine, fp_other = "e" * 64, "f" * 64
+    comments = [
+        _comment(50, _daydream_body(fp_mine)),
+        _comment(51, _daydream_body(fp_other)),
+        _comment(60, "thanks", in_reply_to=51),
+    ]
+    gh = _fake_gh_responder({("org/repo", "repos/org/repo/pulls/9/comments"): comments})
+    row = {"pr_repo": "org/repo", "pr_number": 9}
+    threads = index_pr_review_comments(row, gh_api=gh, session_fingerprints=[fp_mine])
+    sig = comment_resolution_signal(row, gh_api=gh, threads=threads)
+    assert (sig.total, sig.replied, sig.unresolved) == (1, 0, 1)

--- a/tests/test_training_labeler_signals.py
+++ b/tests/test_training_labeler_signals.py
@@ -514,13 +514,18 @@ def test_per_finding_resolution_signal_deleted_comment() -> None:
 
 
 def test_per_finding_resolution_signal_single_finding() -> None:
-    """Standard single-finding case: reply body drives the disposition."""
+    """Standard single-finding case: reply body drives the disposition (M22).
+
+    The reply avoids a pre-matching negation token so the reject phrase is not
+    canceled by the negation guard ("Not a bug — already handled" now fails
+    closed to ambiguous: the sentence-level ``not`` negates ``already handled``).
+    """
     row = {"pr_repo": "org/repo", "pr_number": 42}
     gh = _fake_gh_responder(
         {
             ("org/repo", "repos/org/repo/pulls/42/comments"): [
                 _daydream_finding_comment(9, _FP_A),
-                _comment(10, "Not a bug — already handled", in_reply_to=9, login="human"),
+                _comment(10, "This is already handled upstream", in_reply_to=9, login="human"),
             ],
         }
     )

--- a/tests/test_training_labeler_signals.py
+++ b/tests/test_training_labeler_signals.py
@@ -187,13 +187,26 @@ def test_disposition_accepted_on_qualifying_accept() -> None:
 
 
 def test_disposition_rejected_on_false_positive() -> None:
-    (res,) = _resolve([("False positive, path is unreachable", {"login": "dev", "assoc": "NONE"})])
+    (res,) = _resolve([("False positive, path is unreachable", {"login": "dev", "assoc": "MEMBER"})])
     assert res.disposition == "rejected"
 
 
 def test_disposition_ambiguous_on_question() -> None:
-    (res,) = _resolve([("Is this still true on 3.12?", {"login": "dev", "assoc": "NONE"})])
+    (res,) = _resolve([("Is this still true on 3.12?", {"login": "dev", "assoc": "MEMBER"})])
     assert res.disposition == "ambiguous"
+
+
+def test_disposition_non_qualifying_author_does_not_vote() -> None:
+    """A decisive-text reply from a non-qualifying author never casts a vote.
+
+    assoc NONE with no PR/review-author match persists evidence reason
+    ``excluded:non-qualifying``, so the disposition must agree (M6): no
+    qualifying reply means ``unanswered``, and the timestamp is not decisive
+    evidence either.
+    """
+    (res,) = _resolve([("Fixed in abc123", {"login": "dev", "assoc": "NONE"})])
+    assert res.disposition == "unanswered"
+    assert res.evidence[0]["reason"] == "excluded:non-qualifying"
 
 
 def test_disposition_unanswered_on_bot_only_and_self_replies() -> None:

--- a/tests/test_training_labeler_versions.py
+++ b/tests/test_training_labeler_versions.py
@@ -1,0 +1,22 @@
+"""Tests for labeler version constants and reply evidence digest."""
+
+from daydream.training import labeler_versions as lv
+from daydream.training import reward
+
+
+def test_versions_are_independent() -> None:
+    """The four version axes exist and never alias reward.REWARD_VERSION."""
+    assert lv.RUBRIC_SCHEMA_VERSION != lv.LABELER_POLICY_VERSION
+    assert lv.LABELER_POLICY_VERSION != lv.REPLY_CLASSIFIER_VERSION
+    assert lv.REPLY_EVIDENCE_DIGEST_FORMAT == "sha256/1"
+    assert lv.LABELER_POLICY_VERSION != reward.REWARD_VERSION
+    assert lv.RUBRIC_SCHEMA_VERSION != reward.REWARD_VERSION
+
+
+def test_evidence_digest_is_deterministic() -> None:
+    """reply_evidence_digest is a stable sha256 over the canonical evidence JSON."""
+    a = lv.reply_evidence_digest([{"id": 1, "body": "fixed in abc"}])
+    b = lv.reply_evidence_digest([{"id": 1, "body": "fixed in abc"}])
+    c = lv.reply_evidence_digest([{"id": 1, "body": "not fixed"}])
+    assert a == b and a != c
+    assert len(a) == 64

--- a/tests/test_training_labeler_versions.py
+++ b/tests/test_training_labeler_versions.py
@@ -15,8 +15,9 @@ def test_versions_are_independent() -> None:
 
 def test_evidence_digest_is_deterministic() -> None:
     """reply_evidence_digest is a stable sha256 over the canonical evidence JSON."""
-    a = lv.reply_evidence_digest([{"id": 1, "body": "fixed in abc"}])
-    b = lv.reply_evidence_digest([{"id": 1, "body": "fixed in abc"}])
+    replies = [{"id": 1, "body": "fixed in abc"}, {"id": 2, "body": "fixed too"}]
+    a = lv.reply_evidence_digest(replies)
+    b = lv.reply_evidence_digest(list(reversed(replies)))
     c = lv.reply_evidence_digest([{"id": 1, "body": "not fixed"}])
     assert a == b and a != c
     assert len(a) == 64

--- a/tests/test_training_reply_classifier.py
+++ b/tests/test_training_reply_classifier.py
@@ -1,0 +1,92 @@
+import pytest
+
+from daydream.training.reply_classifier import (
+    REPLY_CLASSIFIER_VERSION,
+    classify_replies,
+    classify_reply,
+    is_qualifying_author,
+)
+
+
+def _reply(body: str, login: str = "maintainer", assoc: str = "MEMBER", bot: str = "User") -> dict:
+    return {"user": {"login": login, "type": bot}, "author_association": assoc, "body": body}
+
+
+@pytest.mark.parametrize(
+    "body,expected",
+    [
+        ("Fixed in abc123", "accepted"),                    # M22: fixed-in-sha
+        ("Good catch, merged the fix", "accepted"),         # explicit agree
+        ("Not applicable — this path is unreachable", "rejected"),   # M22
+        ("This is already handled upstream", "rejected"),   # M22
+        ("False positive, the linter is wrong here", "rejected"),    # M22
+        ("This behavior is intentional", "rejected"),       # M22
+        ("I disagree with the finding; the docs say otherwise", "rejected"),  # factual disagreement
+        ("Thanks for the review!", "ambiguous"),            # bare ack
+        ("Could you elaborate on line 12?", "ambiguous"),   # question
+        ("Deferring this to the next milestone", "ambiguous"),       # deferral
+        ("Won't fix, but not because it's wrong", "ambiguous"),      # won't-fix w/o dispute
+        ("not fixed yet, still reproduces", "ambiguous"),   # M22: negation fails closed
+        ("", "ambiguous"),                                  # empty body
+        ("Fixed in abc123. Though the other finding was a false positive.", "ambiguous"),  # mixed direction
+    ],
+)
+def test_classify_directional_rules(body: str, expected: str) -> None:
+    assert classify_reply(_reply(body)) == expected
+
+
+@pytest.mark.parametrize(
+    "reply,expected",
+    [
+        (_reply("Fixed in abc123", assoc="NONE"), "accepted"),      # PR-author path covered below
+        (_reply("Fixed in abc123", bot="Bot", login="dependabot[bot]"), "ambiguous"),  # bot excluded
+        (_reply("Fixed in abc123", login="", assoc="NONE"), "ambiguous"),  # empty author excluded
+        (_reply("Fixed in abc123", login="daydream-agent"), "ambiguous"),  # daydream self-reply excluded
+    ],
+)
+def test_qualifying_author_gates_decisive_labels(reply: dict, expected: str) -> None:
+    assert classify_reply(reply) == expected
+
+
+def test_qualifying_author_rules() -> None:
+    """PR author, OWNER/MEMBER/COLLABORATOR, or formal-review author qualify (M6)."""
+    assert is_qualifying_author(_reply("x", assoc="OWNER"), pr_author_logins={"someone"}) is True
+    assert is_qualifying_author(_reply("x", assoc="COLLABORATOR"), pr_author_logins=set()) is True
+    assert is_qualifying_author(_reply("x", login="alice", assoc="NONE"), pr_author_logins={"alice"}) is True
+    # formal review author: passed in via review_author_logins
+    assert (
+        is_qualifying_author(_reply("x", assoc="NONE"), pr_author_logins=set(), review_author_logins={"bob"}) is False
+    )
+    assert (
+        is_qualifying_author(
+            _reply("x", login="bob", assoc="NONE"), pr_author_logins=set(), review_author_logins={"bob"}
+        )
+        is True
+    )
+    assert is_qualifying_author(_reply("x", bot="Bot", login="ci[bot]"), pr_author_logins=set()) is False
+
+
+def test_conflicting_replies_fail_closed_to_ambiguous() -> None:
+    """One accept + one reject from qualifying humans ⇒ ambiguous (M22)."""
+    replies = [
+        {"id": 1, **_reply("Fixed in abc123")},
+        {"id": 2, **_reply("False positive", login="other", assoc="NONE")},
+    ]
+    assert classify_replies(replies) == "ambiguous"
+
+
+def test_bot_only_replies_yield_no_decisive_label() -> None:
+    """Bot-only replies never produce accepted/rejected (M22)."""
+    replies = [{"id": 1, **_reply("Fixed in abc123", bot="Bot", login="app[bot]"), "is_self_reply": False}]
+    assert classify_replies(replies) == "ambiguous"
+
+
+def test_self_replies_yield_no_decisive_label() -> None:
+    """The daydream account replying to its own finding ⇒ ambiguous (M5/M22)."""
+    replies = [{"id": 1, **_reply("Fixed in abc123", login="daydream-agent"), "is_self_reply": True}]
+    assert classify_replies(replies) == "ambiguous"
+
+
+def test_classifier_version_is_exported() -> None:
+    """The rule version ties classifications to re-fetch identity (M13/M14)."""
+    assert REPLY_CLASSIFIER_VERSION

--- a/tests/test_training_reply_classifier.py
+++ b/tests/test_training_reply_classifier.py
@@ -4,7 +4,6 @@ import pytest
 
 from daydream.training.reply_classifier import (
     REPLY_CLASSIFIER_VERSION,
-    classify_replies,
     classify_reply,
     is_qualifying_author,
 )
@@ -31,6 +30,10 @@ def _reply(body: str, login: str = "maintainer", assoc: str = "MEMBER", bot: str
         ("not fixed yet, still reproduces", "ambiguous"),   # M22: negation fails closed
         ("", "ambiguous"),                                  # empty body
         ("Fixed in abc123. Though the other finding was a false positive.", "ambiguous"),  # mixed direction
+        # M22: negating a reject phrase fails closed to ambiguous, never 'rejected'.
+        ("This is not a false positive — it reproduces on main.", "ambiguous"),
+        ("This is not intentional; it's a real bug.", "ambiguous"),
+        ("This is not applicable to this PR.", "rejected"),  # affirm 'not applicable' is still a rejection
     ],
 )
 def test_classify_directional_rules(body: str, expected: str) -> None:
@@ -66,27 +69,6 @@ def test_qualifying_author_rules() -> None:
         is True
     )
     assert is_qualifying_author(_reply("x", bot="Bot", login="ci[bot]"), pr_author_logins=set()) is False
-
-
-def test_conflicting_replies_fail_closed_to_ambiguous() -> None:
-    """One accept + one reject from qualifying humans ⇒ ambiguous (M22)."""
-    replies = [
-        {"id": 1, **_reply("Fixed in abc123")},
-        {"id": 2, **_reply("False positive", login="other", assoc="NONE")},
-    ]
-    assert classify_replies(replies) == "ambiguous"
-
-
-def test_bot_only_replies_yield_no_decisive_label() -> None:
-    """Bot-only replies never produce accepted/rejected (M22)."""
-    replies = [{"id": 1, **_reply("Fixed in abc123", bot="Bot", login="app[bot]"), "is_self_reply": False}]
-    assert classify_replies(replies) == "ambiguous"
-
-
-def test_self_replies_yield_no_decisive_label() -> None:
-    """The daydream account replying to its own finding ⇒ ambiguous (M5/M22)."""
-    replies = [{"id": 1, **_reply("Fixed in abc123", login="daydream-agent"), "is_self_reply": True}]
-    assert classify_replies(replies) == "ambiguous"
 
 
 def test_classifier_version_is_exported() -> None:

--- a/tests/test_training_reply_classifier.py
+++ b/tests/test_training_reply_classifier.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from daydream.training.reply_classifier import (
@@ -8,7 +10,7 @@ from daydream.training.reply_classifier import (
 )
 
 
-def _reply(body: str, login: str = "maintainer", assoc: str = "MEMBER", bot: str = "User") -> dict:
+def _reply(body: str, login: str = "maintainer", assoc: str = "MEMBER", bot: str = "User") -> dict[str, Any]:
     return {"user": {"login": login, "type": bot}, "author_association": assoc, "body": body}
 
 
@@ -44,7 +46,7 @@ def test_classify_directional_rules(body: str, expected: str) -> None:
         (_reply("Fixed in abc123", login="daydream-agent"), "ambiguous"),  # daydream self-reply excluded
     ],
 )
-def test_qualifying_author_gates_decisive_labels(reply: dict, expected: str) -> None:
+def test_qualifying_author_gates_decisive_labels(reply: dict[str, Any], expected: str) -> None:
     assert classify_reply(reply) == expected
 
 

--- a/tests/test_training_rubric.py
+++ b/tests/test_training_rubric.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-import pytest
-
 from daydream.training.labeler_signals import (
     CommentResolutionSignal,
     FixAppliedSignal,
     LocalCommitAppliedSignal,
+    PerFindingDisposition,
     PerFindingResolution,
     PRMergeSignal,
 )
@@ -45,136 +44,83 @@ def test_rubric_serializes_with_local_source() -> None:
     assert rub.to_dict()["local_commit_applied"] == {"verdict": "applied"}
 
 
-@pytest.mark.parametrize(
-    ("rubric", "expected"),
-    [
-        pytest.param(
-            Rubric(
-                pr_merge=PRMergeSignal(True, "2026-01-01T00:00:00Z"),
-                fix_applied=FixAppliedSignal("applied", 1, 1, ["c1"]),
-                comment_resolution=CommentResolutionSignal(2, 2, 0),
-                local_commit_applied=None,
-                posterior_source="pr_review",
-            ),
-            "accepted",
-            id="pr-merged-all-resolved",
-        ),
-        pytest.param(
-            Rubric(
-                pr_merge=PRMergeSignal(True, "2026-01-01T00:00:00Z"),
-                fix_applied=FixAppliedSignal("unknown", 0, 0, []),
-                comment_resolution=CommentResolutionSignal(0, 0, 0),
-                local_commit_applied=None,
-                posterior_source="pr_review",
-            ),
-            "unknown",
-            id="pr-merged-no-comments",
-        ),
-        pytest.param(
-            Rubric(
-                pr_merge=PRMergeSignal(True, "2026-01-01T00:00:00Z"),
-                fix_applied=FixAppliedSignal("applied", 1, 1, ["c1"]),
-                comment_resolution=CommentResolutionSignal(3, 1, 2),
-                local_commit_applied=None,
-                posterior_source="pr_review",
-            ),
-            "contested",
-            id="pr-merged-unresolved",
-        ),
-        pytest.param(
-            Rubric(
-                pr_merge=PRMergeSignal(False, None),
-                fix_applied=FixAppliedSignal("not_applied", 0, 1, []),
-                comment_resolution=CommentResolutionSignal(1, 0, 1),
-                local_commit_applied=None,
-                posterior_source="pr_review",
-            ),
-            "rejected",
-            id="pr-closed-unmerged",
-        ),
-        pytest.param(
-            Rubric(
-                pr_merge=PRMergeSignal(False, None),
-                fix_applied=FixAppliedSignal("unknown", 0, 0, []),
-                comment_resolution=CommentResolutionSignal(0, 0, 0),
-                local_commit_applied=LocalCommitAppliedSignal("applied"),
-                posterior_source="local_branch",
-            ),
-            "accepted",
-            id="local-branch-applied",
-        ),
-        pytest.param(
-            Rubric(
-                pr_merge=PRMergeSignal(False, None),
-                fix_applied=FixAppliedSignal("unknown", 0, 0, []),
-                comment_resolution=CommentResolutionSignal(0, 0, 0),
-                local_commit_applied=LocalCommitAppliedSignal("rejected"),
-                posterior_source="local_branch",
-            ),
-            "rejected",
-            id="local-branch-rejected",
-        ),
-        pytest.param(
-            Rubric(
-                pr_merge=PRMergeSignal(False, None),
-                fix_applied=FixAppliedSignal("unknown", 0, 0, []),
-                comment_resolution=CommentResolutionSignal(0, 0, 0),
-                local_commit_applied=LocalCommitAppliedSignal("unknown"),
-                posterior_source="none",
-            ),
-            "unknown",
-            id="no-signal",
-        ),
-    ],
-)
-def test_derive_outcome_label(rubric: Rubric, expected: str) -> None:
-    """Derive accepted, rejected, unknown, and local labels from rubric evidence."""
-    assert derive_outcome_label(rubric) == expected
-
-
-def _pr_rubric(*, merged: bool, source: PosteriorSource = "pr_review") -> Rubric:
-    """A minimal rubric for per-finding label derivation."""
+def _fp_rubric(
+    pr_merge: PRMergeSignal, resolutions: list[PerFindingResolution], source: PosteriorSource = "pr_review"
+) -> Rubric:
     return Rubric(
-        pr_merge=PRMergeSignal(merged, "2026-01-01T00:00:00Z" if merged else None),
+        pr_merge=pr_merge,
         fix_applied=FixAppliedSignal("unknown", 0, 0, []),
-        comment_resolution=CommentResolutionSignal(0, 0, 0),
-        local_commit_applied=None if source == "pr_review" else LocalCommitAppliedSignal("unknown"),
+        comment_resolution=CommentResolutionSignal(
+            len(resolutions),
+            sum(r.disposition == "accepted" for r in resolutions),
+            sum(r.disposition in ("unanswered", "missing") for r in resolutions),
+        ),
+        local_commit_applied=None,
         posterior_source=source,
+        per_finding_resolutions=resolutions,
     )
 
 
-def test_derive_per_finding_labels_mixed() -> None:
-    """Merged PR: a replied finding is accepted, an unreplied one contested."""
-    rub = _pr_rubric(merged=True)
-    per_finding = [
-        PerFindingResolution(fingerprint="a" * 64, resolved=True, comment_id=1),
-        PerFindingResolution(fingerprint="b" * 64, resolved=False, comment_id=2),
-    ]
-    assert derive_per_finding_labels(rub, per_finding) == ["accepted", "contested"]
+def _res(disp: PerFindingDisposition) -> PerFindingResolution:
+    return PerFindingResolution(
+        fingerprint="a" * 64,
+        comment_id=1 if disp != "missing" else None,
+        disposition=disp,
+        evidence=[],
+        evidence_digest="x",
+    )
 
 
-def test_derive_per_finding_labels_rejected() -> None:
-    """Unmerged PR: every finding is rejected regardless of reply state."""
-    rub = _pr_rubric(merged=False)
-    per_finding = [
-        PerFindingResolution(fingerprint="a" * 64, resolved=True, comment_id=1),
-        PerFindingResolution(fingerprint="b" * 64, resolved=False, comment_id=None),
-    ]
-    assert derive_per_finding_labels(rub, per_finding) == ["rejected", "rejected"]
+MERGED = PRMergeSignal(True, "2026-01-01T00:00:00Z", state="merged")
 
 
-def test_derive_per_finding_labels_missing() -> None:
-    """Merged PR: an unresolved finding whose comment vanished is missing."""
-    rub = _pr_rubric(merged=True)
-    per_finding = [PerFindingResolution(fingerprint="a" * 64, resolved=False, comment_id=None)]
-    assert derive_per_finding_labels(rub, per_finding) == ["missing"]
+def test_run_label_all_accepted_any_merge_state() -> None:
+    """All-accepted maps to accepted regardless of merge state (M22/M10)."""
+    for pr in (MERGED, PRMergeSignal(False, None, state="open"), PRMergeSignal(False, None, state="closed")):
+        assert derive_outcome_label(_fp_rubric(pr, [_res("accepted")])) == "accepted"
 
 
-def test_derive_per_finding_labels_local_branch() -> None:
-    """Non-pr_review posterior yields unknown for every finding."""
-    rub = _pr_rubric(merged=False, source="local_branch")
-    per_finding = [
-        PerFindingResolution(fingerprint="a" * 64, resolved=True, comment_id=1),
-        PerFindingResolution(fingerprint="b" * 64, resolved=False, comment_id=2),
-    ]
-    assert derive_per_finding_labels(rub, per_finding) == ["unknown", "unknown"]
+def test_run_label_all_rejected_any_merge_state() -> None:
+    for pr in (MERGED, PRMergeSignal(False, None, state="closed")):
+        assert derive_outcome_label(_fp_rubric(pr, [_res("rejected")])) == "rejected"
+
+
+def test_run_label_mixed_decisive_is_contested() -> None:
+    """Mixed decisive evidence → contested (M9); the amelia#626 shape (M10)."""
+    rub = _fp_rubric(MERGED, [_res("accepted"), _res("rejected")])
+    assert derive_outcome_label(rub) == "contested"
+
+
+def test_run_label_decisive_with_non_decisive_is_contested() -> None:
+    rub = _fp_rubric(MERGED, [_res("accepted"), _res("unanswered"), _res("missing")])
+    assert derive_outcome_label(rub) == "contested"
+
+
+def test_run_label_no_decisive_evidence_is_unknown() -> None:
+    for pr in (MERGED, PRMergeSignal(False, None, state="open")):
+        for disps in ([], [_res("ambiguous")], [_res("unanswered")], [_res("missing")]):
+            assert derive_outcome_label(_fp_rubric(pr, disps)) == "unknown"
+
+
+def test_run_label_local_branch_unchanged() -> None:
+    """The local-branch posterior semantics are byte-stable (Out of Scope)."""
+    rub = Rubric(
+        pr_merge=PRMergeSignal(False, None),
+        fix_applied=FixAppliedSignal("unknown", 0, 0, []),
+        comment_resolution=CommentResolutionSignal(0, 0, 0),
+        local_commit_applied=LocalCommitAppliedSignal("applied"),
+        posterior_source="local_branch",
+    )
+    assert derive_outcome_label(rub) == "accepted"
+
+
+def test_per_finding_labels_come_from_dispositions() -> None:
+    """Per-finding labels pass dispositions through; merge state is irrelevant (M10)."""
+    rub = _fp_rubric(PRMergeSignal(False, None, state="closed"), [])
+    per = [_res("accepted"), _res("rejected"), _res("ambiguous"), _res("unanswered"), _res("missing")]
+    assert derive_per_finding_labels(rub, per) == ["accepted", "rejected", "ambiguous", "unanswered", "missing"]
+
+
+def test_per_finding_non_pr_source_stays_unknown() -> None:
+    rub = _fp_rubric(MERGED, [], source="local_branch")
+    assert derive_per_finding_labels(rub, [_res("accepted")]) == ["unknown"]

--- a/tests/test_training_rubric.py
+++ b/tests/test_training_rubric.py
@@ -20,7 +20,7 @@ from daydream.training.rubric import (
 
 def test_rubric_serializes_to_dict_with_pr_source() -> None:
     rub = Rubric(
-        pr_merge=PRMergeSignal(True, "2026-01-01T00:00:00Z"),
+        pr_merge=PRMergeSignal(True, "2026-01-01T00:00:00Z", state="merged", draft=False),
         fix_applied=FixAppliedSignal("applied", 2, 2, ["c1", "c2"]),
         comment_resolution=CommentResolutionSignal(1, 1, 0),
         local_commit_applied=None,
@@ -29,6 +29,9 @@ def test_rubric_serializes_to_dict_with_pr_source() -> None:
     d = rub.to_dict()
     assert d["posterior_source"] == "pr_review"
     assert d["pr_merge"]["merged"] is True
+    assert d["pr_merge"]["merged_at"] == "2026-01-01T00:00:00Z"
+    assert d["pr_merge"]["state"] == "merged"
+    assert d["pr_merge"]["draft"] is False
     assert d["fix_applied"]["hunks_applied"] == 2
 
 
@@ -47,13 +50,15 @@ def test_rubric_serializes_with_local_source() -> None:
 def _fp_rubric(
     pr_merge: PRMergeSignal, resolutions: list[PerFindingResolution], source: PosteriorSource = "pr_review"
 ) -> Rubric:
+    # CommentResolutionSignal invariant: unresolved = total - replied.
+    replied = sum(r.disposition == "accepted" for r in resolutions)
     return Rubric(
         pr_merge=pr_merge,
         fix_applied=FixAppliedSignal("unknown", 0, 0, []),
         comment_resolution=CommentResolutionSignal(
             len(resolutions),
-            sum(r.disposition == "accepted" for r in resolutions),
-            sum(r.disposition in ("unanswered", "missing") for r in resolutions),
+            replied,
+            len(resolutions) - replied,
         ),
         local_commit_applied=None,
         posterior_source=source,
@@ -112,6 +117,36 @@ def test_run_label_local_branch_unchanged() -> None:
         posterior_source="local_branch",
     )
     assert derive_outcome_label(rub) == "accepted"
+
+
+def test_run_label_local_branch_rejected() -> None:
+    """local_branch with ``rejected`` verdict maps to ``rejected`` (rubric.py:113-116)."""
+    rub = Rubric(
+        pr_merge=PRMergeSignal(False, None),
+        fix_applied=FixAppliedSignal("unknown", 0, 0, []),
+        comment_resolution=CommentResolutionSignal(0, 0, 0),
+        local_commit_applied=LocalCommitAppliedSignal("rejected"),
+        posterior_source="local_branch",
+    )
+    assert derive_outcome_label(rub) == "rejected"
+
+
+def test_run_label_local_branch_unknown() -> None:
+    """local_branch with any other verdict maps to ``unknown`` (rubric.py:116-117)."""
+    rub = Rubric(
+        pr_merge=PRMergeSignal(False, None),
+        fix_applied=FixAppliedSignal("unknown", 0, 0, []),
+        comment_resolution=CommentResolutionSignal(0, 0, 0),
+        local_commit_applied=LocalCommitAppliedSignal("unknown"),
+        posterior_source="local_branch",
+    )
+    assert derive_outcome_label(rub) == "unknown"
+
+
+def test_run_label_no_signal_is_unknown() -> None:
+    """posterior_source ``none`` always maps to ``unknown`` (rubric.py:118)."""
+    rub = _fp_rubric(MERGED, [_res("accepted")], source="none")
+    assert derive_outcome_label(rub) == "unknown"
 
 
 def test_per_finding_labels_come_from_dispositions() -> None:


### PR DESCRIPTION
Closes #980

## Summary
- Derive training labels from reply meaning, not reply/merge presence: per-finding dispositions (accepted/rejected/ambiguous/unanswered/missing) joined by hidden finding fingerprints.
- Conservative, deterministic, versioned reply classifier; fails closed to ambiguous. Bot/self replies excluded; authoritative-author rules persisted.
- PR state (open/closed/merged/draft) stored as context only; never creates a finding label by itself. Unmerged-with-no-evidence is unknown, not rejected.
- Conservative run-level aggregation (accepted/rejected/contested/unknown); mixed PRs like amelia#626 become contested with per-finding evidence preserved.
- Independent provenance: rubric schema version, labeler policy version, classifier version, immutable reply-evidence digest. Decisive-evidence timestamps drive valid_at (as-of leakage guard preserved).
- Archive dedup keyed on labeler policy + evidence digest; legacy reply-count observations marked legacy and excluded from gold by default.
- Harvest resume cache versioned by labeler/evidence; human overrides keep precedence.
- Corpus gold-admission guard rejects legacy reply-count and mixed/ambiguous labels.

## Test Plan
- Focused unit + real-path tests for classifier semantics (accept/reject/ambiguous/negation/bot/missing), fingerprint scoping, PR-state mapping, aggregation, versioning/dedup/resume invalidation, human override precedence, amelia#626 fixture.
- mypy clean, ruff clean, pytest -n auto: 4548 passed, 20 skipped.
