### PR TITLE
security: scrub credential-bearing Git remotes from archive manifests and Hub uploads

### DIFF
--- a/daydream/archive/__init__.py
+++ b/daydream/archive/__init__.py
@@ -35,6 +35,13 @@ if TYPE_CHECKING:
     from daydream.workspace import WorkContext
 
 
+def _warn(message: str) -> None:
+    """Print a one-line warning through the daydream console (never raises)."""
+    from daydream.ui import create_console, print_warning
+
+    print_warning(create_console(), message)
+
+
 def _flow_runs_merge(flow: DaydreamRunFlow, flow_name: str | None) -> bool:
     """Whether the executed flow runs the deep cross-stack/single-stack merge.
 
@@ -250,8 +257,20 @@ def _archive_run_inner(
     #    so it includes the manifest and evaluation written above.
     if config.dump_artifacts:
         dest = Path(config.dump_artifacts)
-        dest.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(run_dir, dest, dirs_exist_ok=True)
+        from daydream.archive import scan
+
+        # Fail-closed: a bundle whose serialized artifacts carry a credential is
+        # never copied to a user-specified directory. The run itself is already
+        # archived; the dump is skipped with a value-free warning (M11/M12).
+        scan_result = scan.scan_run_dir(run_dir)
+        if not scan_result.clean:
+            _warn(
+                f"Refusing --dump-artifacts copy of {recorder.session_id}: bundle "
+                f"secret scan found problems ({scan_result.summary()})"
+            )
+        else:
+            dest.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(run_dir, dest, dirs_exist_ok=True)
 
 
 def _read_json_artifact(path: Path, expected_type: type) -> Any | None:

--- a/daydream/archive/git_context.py
+++ b/daydream/archive/git_context.py
@@ -54,11 +54,13 @@ def capture_git_context(target_dir: Path) -> GitContext:
     raw_remote = git_ops.remote_url(target_dir)
     if raw_remote:
         repo_slug, canonical_url = normalize_remote_url(raw_remote)
-        # Fail closed: an untrusted or unparseable raw URL is never stored,
-        # not even credential-stripped.
-        if repo_slug is not None:
-            ctx.repo_slug = repo_slug
+        # Fail closed: an unparseable raw URL is never stored, not even
+        # credential-stripped. Identity alone is None for hosts outside the
+        # allowlist, but the credential-stripped canonical URL is still kept.
+        if canonical_url is not None:
             ctx.remote_url = canonical_url
+            if repo_slug is not None:
+                ctx.repo_slug = repo_slug
 
     try:
         ctx.branch = git_ops.current_branch(target_dir)

--- a/daydream/archive/git_context.py
+++ b/daydream/archive/git_context.py
@@ -9,11 +9,11 @@ Exports:
     capture_git_context: Capture current git state from a directory.
 """
 
-import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from daydream import git_ops
+from daydream.archive.git_safe import normalize_remote_url
 from daydream.git_ops import BranchNotFoundError, GitError
 
 
@@ -43,25 +43,6 @@ class GitContext:
     changed_files: list[str] = field(default_factory=list)
 
 
-_SSH_REMOTE_RE = re.compile(r"[^@]+@[^:]+:(.+?)(?:\.git)?$")
-_HTTPS_REMOTE_RE = re.compile(r"https?://[^/]+/(.+?)(?:\.git)?$")
-
-
-def _parse_repo_slug(remote_url: str) -> str | None:
-    """Extract ``owner/repo`` from a git remote URL.
-
-    Handles both SSH (``git@github.com:owner/repo.git``) and HTTPS
-    (``https://github.com/owner/repo.git``) formats.
-    """
-    m = _SSH_REMOTE_RE.match(remote_url)
-    if m:
-        return m.group(1)
-    m = _HTTPS_REMOTE_RE.match(remote_url)
-    if m:
-        return m.group(1)
-    return None
-
-
 def capture_git_context(target_dir: Path) -> GitContext:
     """Capture current git state from *target_dir*.
 
@@ -70,9 +51,14 @@ def capture_git_context(target_dir: Path) -> GitContext:
     """
     ctx = GitContext()
 
-    ctx.remote_url = git_ops.remote_url(target_dir)
-    if ctx.remote_url:
-        ctx.repo_slug = _parse_repo_slug(ctx.remote_url)
+    raw_remote = git_ops.remote_url(target_dir)
+    if raw_remote:
+        repo_slug, canonical_url = normalize_remote_url(raw_remote)
+        # Fail closed: an untrusted or unparseable raw URL is never stored,
+        # not even credential-stripped.
+        if repo_slug is not None:
+            ctx.repo_slug = repo_slug
+            ctx.remote_url = canonical_url
 
     try:
         ctx.branch = git_ops.current_branch(target_dir)

--- a/daydream/archive/git_safe.py
+++ b/daydream/archive/git_safe.py
@@ -96,8 +96,9 @@ def classify_remote_url(raw: str) -> list[str]:
         user = unquote(parsed.username) if parsed.username else ""
         password = unquote(parsed.password) if parsed.password else ""
         # Percent-encoded userinfo (e.g. user%40corp:p%40ss) counts too;
-        # token-only user@ is credential-bearing (x-access-token form).
-        if user or password:
+        # token-only user@ is credential-bearing only on http(s) (the
+        # x-access-token form); a lone SSH login user (ssh://git@...) is not.
+        if password or (user and parsed.scheme.lower() in {"http", "https"}):
             categories.append("userinfo")
         if parsed.query:
             keys = {k.lower() for k, _ in parse_qsl(parsed.query, keep_blank_values=True)}
@@ -105,6 +106,8 @@ def classify_remote_url(raw: str) -> list[str]:
                 categories.append("query")
     else:
         scp = _parse_scp(raw)
-        if scp is not None and scp[0]:
+        # A plain SCP username (git@host:path) is a login, not a credential;
+        # only an embedded user:pass slot (colon in the user group) carries one.
+        if scp is not None and ":" in scp[0]:
             categories.append("userinfo")
     return categories

--- a/daydream/archive/git_safe.py
+++ b/daydream/archive/git_safe.py
@@ -1,0 +1,110 @@
+"""Credential-safe Git URL normalizer (issue #981).
+
+Sole authority for interpreting Git remote URLs. Parses, classifies, strips
+credentials, and reconstructs a canonical HTTPS URL — never serializes
+userinfo or credential-like query parameters into any output form.
+"""
+
+import re
+from urllib.parse import parse_qsl, unquote, urlparse
+
+# Hosts whose owner/repo identity we trust for harvest resolution.
+_DEFAULT_HOSTS = frozenset({"github.com"})
+
+# Query-parameter keys that must never survive into any output form.
+_CREDENTIAL_QUERY_KEYS = frozenset(
+    {"token", "access_token", "key", "secret", "password", "credential"}
+)
+
+# The one regex case allowed by the contract: the SCP form, which
+# urllib.parse cannot interpret (host:path with no scheme).
+_SCP_RE = re.compile(r"^(?:([^@/]+)@)?([^:/]+):(/?.+)$")
+
+
+def _parse_scp(raw: str) -> tuple[str, str, str] | None:
+    """Parse ``git@host:owner/repo(.git)`` -> (user, host, path) or None."""
+    match = _SCP_RE.match(raw)
+    if match is None:
+        return None
+    user, host, path = match.groups()
+    return user or "", host, path
+
+
+def _split_path(path: str) -> tuple[str, str] | None:
+    """Extract (owner, repo) from a URL path, stripping .git / slashes."""
+    trimmed = path.strip("/")
+    if trimmed.endswith(".git"):
+        trimmed = trimmed[: -len(".git")]
+    parts = [p for p in trimmed.split("/") if p]
+    if len(parts) < 2:
+        return None
+    owner, repo = parts[-2], parts[-1]
+    if not owner or not repo:
+        return None
+    return owner, repo
+
+
+def normalize_remote_url(
+    raw: str, *, allowed_hosts: frozenset[str] = _DEFAULT_HOSTS
+) -> tuple[str | None, str | None]:
+    """Normalize a Git remote URL to (identity, credential-free canonical URL).
+
+    Returns (owner/repo, https://host/owner/repo). Identity and URL are None
+    when the input is unparseable; identity alone is None when the host is
+    not on the allowlist (URL is still returned, credential-stripped).
+    Percent-decodes userinfo before classification; never decodes the path.
+    Never raises on malformed input.
+    """
+    if not raw or not raw.strip():
+        return None, None
+
+    parsed = urlparse(raw)
+    if parsed.scheme and parsed.netloc:
+        host = parsed.hostname or ""
+        # Percent-decode userinfo before classification (user%40corp, p%40ss).
+        path = parsed.path or ""
+    else:
+        scp = _parse_scp(raw)
+        if scp is None:
+            return None, None
+        _, host, path = scp
+
+    owner_repo = _split_path(path)
+    if owner_repo is None:
+        return None, None
+    owner, repo = owner_repo
+
+    # Canonical form carries no query string and no userinfo: credential-like
+    # params would leak, userinfo is stripped, and the identity is the path.
+    canonical = f"https://{host.lower()}/{owner}/{repo}"
+
+    if host.lower() not in allowed_hosts:
+        return None, canonical
+    return f"{owner}/{repo}", canonical
+
+
+def classify_remote_url(raw: str) -> list[str]:
+    """Return triage categories for credential exposure in a remote URL.
+
+    Labels among "userinfo" and "query". Empty list for benign URLs.
+    """
+    if not raw or not raw.strip():
+        return []
+    categories: list[str] = []
+    parsed = urlparse(raw)
+    if parsed.scheme and parsed.netloc:
+        user = unquote(parsed.username) if parsed.username else ""
+        password = unquote(parsed.password) if parsed.password else ""
+        # Percent-encoded userinfo (e.g. user%40corp:p%40ss) counts too;
+        # token-only user@ is credential-bearing (x-access-token form).
+        if user or password:
+            categories.append("userinfo")
+        if parsed.query:
+            keys = {k.lower() for k, _ in parse_qsl(parsed.query, keep_blank_values=True)}
+            if keys & _CREDENTIAL_QUERY_KEYS:
+                categories.append("query")
+    else:
+        scp = _parse_scp(raw)
+        if scp is not None and scp[0]:
+            categories.append("userinfo")
+    return categories

--- a/daydream/archive/hub.py
+++ b/daydream/archive/hub.py
@@ -64,7 +64,10 @@ def upload_run_bundle(run_dir: Path, repo_id: str, session_id: str) -> bool:
     the archive callback cannot fail the run. Skips (``False`` + warning) when
     ``HF_TOKEN`` is absent. A pre-existing repo is reused with its current
     visibility (documented behavior), but a public one triggers a warning
-    before the upload proceeds. Retries the upload commit up to 3 total
+    before the upload proceeds. Before anything reaches the Hub the bundle is
+    scanned for secrets (fail-closed): a dirty bundle — or a scanner error —
+    is refused with a safe-only warning and ``False``. Retries the upload
+    commit up to 3 total
     attempts on a commit-conflict shape (concurrent commits from parallel
     processes), backing off exponentially between attempts.
 
@@ -84,6 +87,16 @@ def upload_run_bundle(run_dir: Path, repo_id: str, session_id: str) -> bool:
         except ImportError:
             _warn("Skip HF upload: huggingface_hub not installed (pip install huggingface-hub)")
             return False
+
+    from daydream.archive import scan
+
+    scan_result = scan.scan_run_dir(run_dir)
+    if not scan_result.clean:
+        _warn(
+            f"Refusing HF upload of {session_id}: bundle secret scan found "
+            f"problems ({scan_result.summary()})"
+        )
+        return False
 
     try:
         api = HfApi()

--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -85,6 +85,7 @@ from daydream.archive._schema import (
     _migrate_schema,
     _recreate_label_observations_if_stale,
 )
+from daydream.archive.git_safe import normalize_remote_url
 from daydream.archive.manifest import Manifest
 
 # Re-export for callers (including tests) that import these names from this module.
@@ -222,6 +223,13 @@ def upsert_run(archive_dir: Path, manifest: Manifest) -> None:
     """
     conn = _get_connection(archive_dir)
     daydream = manifest.daydream
+    # Defense-in-depth: never persist a credential-bearing remote URL, even if
+    # upstream capture bypassed the normalizer. None identity stores None.
+    if manifest.remote_url is None:
+        # No remote URL to normalize; keep the manifest's slug as-is.
+        normalized_slug, normalized_url = manifest.repo_slug, None
+    else:
+        normalized_slug, normalized_url = normalize_remote_url(manifest.remote_url)
     try:
         conn.execute(
             _UPSERT_SQL,
@@ -246,8 +254,8 @@ def upsert_run(archive_dir: Path, manifest: Manifest) -> None:
                 "per_stack_review_model": manifest.per_stack_review_model,
                 "review_only": int(manifest.review_only),
                 "deep": int(manifest.deep),
-                "remote_url": manifest.remote_url,
-                "repo_slug": manifest.repo_slug,
+                "remote_url": normalized_url,
+                "repo_slug": normalized_slug,
                 "source_path": manifest.source_path,
                 "branch": manifest.branch,
                 "base_branch": manifest.base_branch,

--- a/daydream/archive/sanitize.py
+++ b/daydream/archive/sanitize.py
@@ -15,8 +15,8 @@ Transformation pipeline per file:
 
 Release gate: every derivative is re-scanned with
 :func:`daydream.archive.scan.scan_run_dir`; a derivative that does not come
-back clean is quarantined (removed from ``sanitized/``, recorded with
-``status="quarantined"``) — never released (fail-closed).
+back clean is moved to ``<archive_dir>/quarantine/<session_id>/`` and recorded
+with ``status="quarantined"`` — never released (fail-closed).
 
 ``derivative_digest`` is a SHA-256 over a canonical manifest of
 ``(relative path, per-file SHA-256)`` pairs, stable across runs on identical
@@ -36,11 +36,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from daydream.archive import scan
 from daydream.archive.git_safe import classify_remote_url, normalize_remote_url
-from daydream.archive.scan import scan_run_dir
 from daydream.trajectory import redact_text, redact_value
 
-__all__ = ["SanitizeResult", "sanitize_archive", "sanitize_bundle"]
+__all__ = ["ImportResult", "SanitizeResult", "import_bundle", "sanitize_archive", "sanitize_bundle"]
 
 _PROGRESS_FILENAME = "progress.jsonl"
 _AUDIT_FILENAME = "audit.jsonl"
@@ -58,6 +58,24 @@ class SanitizeResult:
     source: Path
     derivative_digest: str
     status: str  # "sanitized" | "quarantined"
+
+    @property
+    def released(self) -> bool:
+        """True only when the derivative passed the release scan (M16)."""
+        return self.status == "sanitized"
+
+
+@dataclass(frozen=True)
+class ImportResult:
+    """Outcome of the fail-closed Hub-bundle ingest gate (M18)."""
+
+    source: Path
+    imported: bool
+    quarantined: bool
+
+
+class _DerivativeUncleanError(Exception):
+    """Internal sentinel: the release scan found the derivative unclean."""
 
 
 def _derivative_digest(derivative_dir: Path) -> str:
@@ -156,12 +174,42 @@ def _mark_done(sanitized_dir: Path, session_id: str, derivative_digest: str) -> 
     )
 
 
+def _quarantine_derivative(
+    derivative_dir: Path, sanitized_dir: Path, archive_dir: Path, run_dir: Path, session_id: str
+) -> None:
+    """Move a failed derivative to quarantine and record it (M16, fail-closed).
+
+    Nothing is deleted: the derivative (a copy, never the bronze original) is
+    moved under ``<archive_dir>/quarantine/<session_id>/`` for human review.
+    """
+    quarantine_dir = archive_dir / "quarantine" / session_id
+    quarantine_dir.parent.mkdir(parents=True, exist_ok=True)
+    if derivative_dir.exists():
+        if quarantine_dir.exists():
+            shutil.rmtree(quarantine_dir)  # our own prior derivative copy, not a source
+        shutil.move(str(derivative_dir), str(quarantine_dir))
+    _append_jsonl(
+        sanitized_dir / _AUDIT_FILENAME,
+        {
+            "source": str(run_dir),
+            "session_id": session_id,
+            "derivative_digest": "",
+            "status": "quarantined",
+            "completed_at": _now_iso_utc(),
+        },
+    )
+
+
 def sanitize_bundle(run_dir: Path, archive_dir: Path) -> SanitizeResult:
     """Sanitize one legacy bundle into ``archive_dir/sanitized/<session_id>/``.
 
-    The source bundle is never modified. On any failure the derivative is
-    removed, a ``status="quarantined"`` audit record is appended, and the
-    exception is re-raised so a bulk caller can continue with the next bundle.
+    The source bundle is never modified. The derivative is released only when
+    the post-transform release scan comes back clean; otherwise it is moved to
+    ``archive_dir/quarantine/<session_id>/``, a ``status="quarantined"`` audit
+    record is appended, and a quarantined (``released=False``) result is
+    returned — nothing under ``sanitized/`` (M16, fail-closed). Unexpected
+    failures clean the partial derivative, record the quarantine, and re-raise
+    so a bulk caller can continue with the next bundle.
     """
     sanitized_dir = archive_dir / "sanitized"
     manifest: dict[str, Any] = {}
@@ -189,15 +237,23 @@ def sanitize_bundle(run_dir: Path, archive_dir: Path) -> SanitizeResult:
         _sanitize_derivative(derivative_dir)
 
         # Fail-closed release gate: only a clean scan releases the derivative.
-        scan_result = scan_run_dir(derivative_dir)
+        scan_result = scan.scan_run_dir(derivative_dir)
         if not scan_result.clean:
-            raise ValueError(f"derivative scan found {scan_result.summary()}")
+            raise _DerivativeUncleanError(f"derivative scan found {scan_result.summary()}")
 
         digest = _derivative_digest(derivative_dir)
+    except _DerivativeUncleanError:
+        _quarantine_derivative(derivative_dir, sanitized_dir, archive_dir, run_dir, session_id)
+        return SanitizeResult(
+            session_id=session_id,
+            source=run_dir,
+            derivative_digest="",
+            status="quarantined",
+        )
     except Exception:
         if derivative_dir.exists():
             shutil.rmtree(derivative_dir, ignore_errors=True)
-        _append_jsonl(
+        _append_jsonl(  # unexpected failure: record quarantine, re-raise for bulk loop
             sanitized_dir / _AUDIT_FILENAME,
             {
                 "source": str(run_dir),
@@ -253,6 +309,27 @@ def sanitize_archive(archive_dir: Path) -> list[SanitizeResult]:
             if current_digest == recorded_digest:
                 continue  # M19: completed items are not re-processed
         result = sanitize_bundle(run_dir, archive_dir)
-        _mark_done(sanitized_dir, result.session_id, result.derivative_digest)
+        if result.released:
+            _mark_done(sanitized_dir, result.session_id, result.derivative_digest)
         results.append(result)
     return results
+
+
+def import_bundle(run_dir: Path, archive_dir: Path) -> ImportResult:
+    """Fail-closed ingest gate for a downloaded Hub bundle (M18).
+
+    The incoming bundle is scanned before ingestion. A clean bundle is
+    imported in place; an affected bundle is moved to
+    ``<archive_dir>/quarantine/<session_id>/`` and skipped — never imported
+    raw, even when a released derivative exists. The move is never a deletion
+    of a source bundle; when the quarantine slot is already occupied the move
+    is skipped and the bundle is still reported quarantined.
+    """
+    scan_result = scan.scan_run_dir(run_dir)
+    if scan_result.clean:
+        return ImportResult(source=run_dir, imported=True, quarantined=False)
+    quarantine_dir = archive_dir / "quarantine" / run_dir.name
+    quarantine_dir.parent.mkdir(parents=True, exist_ok=True)
+    if not quarantine_dir.exists():
+        shutil.move(str(run_dir), str(quarantine_dir))
+    return ImportResult(source=run_dir, imported=False, quarantined=True)

--- a/daydream/archive/sanitize.py
+++ b/daydream/archive/sanitize.py
@@ -111,8 +111,16 @@ def _sanitize_json_value(value: Any) -> Any:
 
 
 def _sanitize_text(text: str) -> str:
-    """Redact one text file body, then re-check with the scanner's extra rules."""
-    return redact_text(text)
+    """Redact one text file body, then re-check with the scanner's extra rules.
+
+    The scanner's two local gaps (token-only userinfo, credential query params)
+    are applied from scan.py's own patterns, so a rule added there applies here
+    too and the derivative passes the release scan (M16).
+    """
+    text = redact_text(text)
+    text = scan._TOKEN_ONLY_USERINFO_PATTERN.sub(r"\1[REDACTED_USER]@", text)
+    text = scan._QUERY_CREDENTIAL_PATTERN.sub(r"\1\2=[REDACTED_CREDENTIAL]", text)
+    return text
 
 
 def _sanitize_derivative(derivative_dir: Path) -> None:
@@ -308,7 +316,12 @@ def sanitize_archive(archive_dir: Path) -> list[SanitizeResult]:
                 current_digest = None
             if current_digest == recorded_digest:
                 continue  # M19: completed items are not re-processed
-        result = sanitize_bundle(run_dir, archive_dir)
+        try:
+            result = sanitize_bundle(run_dir, archive_dir)
+        except Exception:
+            # sanitize_bundle already recorded the quarantine audit line and
+            # cleaned the partial derivative; one bad bundle never stops the pass.
+            continue
         if result.released:
             _mark_done(sanitized_dir, result.session_id, result.derivative_digest)
         results.append(result)

--- a/daydream/archive/sanitize.py
+++ b/daydream/archive/sanitize.py
@@ -333,3 +333,31 @@ def import_bundle(run_dir: Path, archive_dir: Path) -> ImportResult:
     if not quarantine_dir.exists():
         shutil.move(str(run_dir), str(quarantine_dir))
     return ImportResult(source=run_dir, imported=False, quarantined=True)
+
+
+def report_inventory(archive_dir: Path) -> dict[str, int]:
+    """Value-free inventory mode (M11): classify each bundle's remote URL.
+
+    For every ``runs/*`` bundle, ``manifest.json``'s ``git.remote_url`` is
+    classified via :func:`classify_remote_url`. Prints and returns counts by
+    category (session counts only — never a URL fragment or matched value).
+    A malformed manifest counts under ``"unparseable"``. Never raises.
+    """
+    counts: dict[str, int] = {}
+    runs_dir = archive_dir / "runs"
+    if runs_dir.is_dir():
+        for run_dir in sorted(p for p in runs_dir.iterdir() if p.is_dir()):
+            manifest = run_dir / "manifest.json"
+            categories: list[str]
+            try:
+                data = json.loads(manifest.read_text())
+                raw = data["git"]["remote_url"]
+            except (OSError, json.JSONDecodeError, KeyError, TypeError):
+                categories = ["unparseable"]
+            else:
+                categories = classify_remote_url(raw) if isinstance(raw, str) else ["unparseable"]
+            for category in categories or ["clean"]:
+                counts[category] = counts.get(category, 0) + 1
+    for category in sorted(counts):
+        print(f"{category}: {counts[category]}")
+    return counts

--- a/daydream/archive/sanitize.py
+++ b/daydream/archive/sanitize.py
@@ -1,0 +1,258 @@
+"""Legacy bronze bundle sanitizer (issue #981 M14/M15/M19).
+
+Copies legacy bronze run bundles into content-addressed, credential-free
+derivatives under ``<archive_dir>/sanitized/<session_id>/``. Sources are never
+modified (M14): the bundle is copied first, then the copy is transformed.
+
+Transformation pipeline per file:
+
+* ``manifest.json`` (and any JSON file): credential-bearing URL string leaves
+  are rewritten through :func:`daydream.archive.git_safe.normalize_remote_url`
+  (the sole URL authority); the whole document is then passed through
+  :func:`daydream.trajectory.redact_value`.
+* Text files: :func:`daydream.trajectory.redact_text` plus the scanner's
+  extended userinfo/query-param substitutions.
+
+Release gate: every derivative is re-scanned with
+:func:`daydream.archive.scan.scan_run_dir`; a derivative that does not come
+back clean is quarantined (removed from ``sanitized/``, recorded with
+``status="quarantined"``) — never released (fail-closed).
+
+``derivative_digest`` is a SHA-256 over a canonical manifest of
+``(relative path, per-file SHA-256)`` pairs, stable across runs on identical
+input (M15). Bulk passes via :func:`sanitize_archive` are resumable: a
+``progress.jsonl`` marker records completed session ids + digests (mirroring
+the ``BackfillCache`` resume-marker pattern), and a session is only skipped
+when its derivative still hashes to the recorded digest (M19).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from daydream.archive.git_safe import classify_remote_url, normalize_remote_url
+from daydream.archive.scan import scan_run_dir
+from daydream.trajectory import redact_text, redact_value
+
+__all__ = ["SanitizeResult", "sanitize_archive", "sanitize_bundle"]
+
+_PROGRESS_FILENAME = "progress.jsonl"
+_AUDIT_FILENAME = "audit.jsonl"
+
+
+def _now_iso_utc() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@dataclass(frozen=True)
+class SanitizeResult:
+    """Outcome of sanitizing one bundle."""
+
+    session_id: str
+    source: Path
+    derivative_digest: str
+    status: str  # "sanitized" | "quarantined"
+
+
+def _derivative_digest(derivative_dir: Path) -> str:
+    """SHA-256 over a canonical (relpath, file digest) manifest — M15 stable."""
+    entries: list[tuple[str, str]] = []
+    for file_path in sorted(derivative_dir.rglob("*")):
+        if not file_path.is_file():
+            continue
+        rel = file_path.relative_to(derivative_dir).as_posix()
+        digest = hashlib.sha256(file_path.read_bytes()).hexdigest()
+        entries.append((rel, digest))
+    canonical = "".join(f"{rel}\t{digest}\n" for rel, digest in entries)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _sanitize_url_string(value: str) -> str:
+    """Rewrite a credential-bearing URL string to its canonical form."""
+    if classify_remote_url(value):
+        _identity, canonical = normalize_remote_url(value)
+        if canonical is not None:
+            return canonical
+    return value
+
+
+def _sanitize_json_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _sanitize_json_value(child) for key, child in value.items()}
+    if isinstance(value, list):
+        return [_sanitize_json_value(child) for child in value]
+    if isinstance(value, str):
+        return _sanitize_url_string(value)
+    return value
+
+
+def _sanitize_text(text: str) -> str:
+    """Redact one text file body, then re-check with the scanner's extra rules."""
+    return redact_text(text)
+
+
+def _sanitize_derivative(derivative_dir: Path) -> None:
+    """Transform every file of a copied bundle in place."""
+    for file_path in sorted(derivative_dir.rglob("*")):
+        if not file_path.is_file():
+            continue
+        text = file_path.read_text(encoding="utf-8")
+        if file_path.suffix == ".json":
+            try:
+                doc = json.loads(text)
+            except ValueError:
+                doc = None
+            if isinstance(doc, (dict, list)):
+                sanitized = redact_value(_sanitize_json_value(doc))
+                file_path.write_text(
+                    json.dumps(sanitized, indent=2, sort_keys=True, default=str) + "\n",
+                    encoding="utf-8",
+                )
+                continue
+        file_path.write_text(_sanitize_text(text), encoding="utf-8")
+
+
+def _append_jsonl(path: Path, record: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def _read_progress(sanitized_dir: Path) -> dict[str, str]:
+    """Return {session_id: derivative_digest} from the resume marker file."""
+    progress_path = sanitized_dir / _PROGRESS_FILENAME
+    if not progress_path.exists():
+        return {}
+    completed: dict[str, str] = {}
+    for line in progress_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except ValueError:
+            continue  # append-only log; a partial last line is the only failure mode
+        session_id = record.get("session_id")
+        digest = record.get("derivative_digest")
+        if isinstance(session_id, str) and isinstance(digest, str):
+            completed[session_id] = digest
+    return completed
+
+
+def _mark_done(sanitized_dir: Path, session_id: str, derivative_digest: str) -> None:
+    _append_jsonl(
+        sanitized_dir / _PROGRESS_FILENAME,
+        {
+            "session_id": session_id,
+            "derivative_digest": derivative_digest,
+            "completed_at": _now_iso_utc(),
+        },
+    )
+
+
+def sanitize_bundle(run_dir: Path, archive_dir: Path) -> SanitizeResult:
+    """Sanitize one legacy bundle into ``archive_dir/sanitized/<session_id>/``.
+
+    The source bundle is never modified. On any failure the derivative is
+    removed, a ``status="quarantined"`` audit record is appended, and the
+    exception is re-raised so a bulk caller can continue with the next bundle.
+    """
+    sanitized_dir = archive_dir / "sanitized"
+    manifest: dict[str, Any] = {}
+    manifest_path = run_dir / "manifest.json"
+    if manifest_path.exists():
+        try:
+            loaded = json.loads(manifest_path.read_text(encoding="utf-8"))
+            if isinstance(loaded, dict):
+                manifest = loaded
+        except ValueError:
+            manifest = {}
+    session_id = str(manifest.get("session_id") or run_dir.name)
+    derivative_dir = sanitized_dir / session_id
+
+    try:
+        if derivative_dir.exists():
+            shutil.rmtree(derivative_dir)
+        derivative_dir.mkdir(parents=True)
+        for item in sorted(run_dir.iterdir()):
+            target = derivative_dir / item.name
+            if item.is_dir():
+                shutil.copytree(item, target)
+            else:
+                shutil.copy2(item, target)
+        _sanitize_derivative(derivative_dir)
+
+        # Fail-closed release gate: only a clean scan releases the derivative.
+        scan_result = scan_run_dir(derivative_dir)
+        if not scan_result.clean:
+            raise ValueError(f"derivative scan found {scan_result.summary()}")
+
+        digest = _derivative_digest(derivative_dir)
+    except Exception:
+        if derivative_dir.exists():
+            shutil.rmtree(derivative_dir, ignore_errors=True)
+        _append_jsonl(
+            sanitized_dir / _AUDIT_FILENAME,
+            {
+                "source": str(run_dir),
+                "session_id": session_id,
+                "derivative_digest": "",
+                "status": "quarantined",
+                "completed_at": _now_iso_utc(),
+            },
+        )
+        raise
+
+    _append_jsonl(
+        sanitized_dir / _AUDIT_FILENAME,
+        {
+            "source": str(run_dir),
+            "session_id": session_id,
+            "derivative_digest": digest,
+            "status": "sanitized",
+            "completed_at": _now_iso_utc(),
+        },
+    )
+    return SanitizeResult(
+        session_id=session_id,
+        source=run_dir,
+        derivative_digest=digest,
+        status="sanitized",
+    )
+
+
+def sanitize_archive(archive_dir: Path) -> list[SanitizeResult]:
+    """Sanitize every bundle under ``archive_dir/runs/*``; resumable (M19).
+
+    A session recorded in ``progress.jsonl`` is skipped only when its
+    derivative still exists and hashes to the recorded digest — partial or
+    corrupted derivatives are re-processed. One bad bundle never stops the
+    pass: its failure is quarantined and the loop continues.
+    """
+    sanitized_dir = archive_dir / "sanitized"
+    sanitized_dir.mkdir(parents=True, exist_ok=True)
+    completed = _read_progress(sanitized_dir)
+    results: list[SanitizeResult] = []
+    runs_dir = archive_dir / "runs"
+    if not runs_dir.is_dir():
+        return results
+    for run_dir in sorted(p for p in runs_dir.iterdir() if p.is_dir()):
+        session_id = run_dir.name
+        recorded_digest = completed.get(session_id)
+        if recorded_digest is not None and (sanitized_dir / session_id).is_dir():
+            try:
+                current_digest = _derivative_digest(sanitized_dir / session_id)
+            except OSError:
+                current_digest = None
+            if current_digest == recorded_digest:
+                continue  # M19: completed items are not re-processed
+        result = sanitize_bundle(run_dir, archive_dir)
+        _mark_done(sanitized_dir, result.session_id, result.derivative_digest)
+        results.append(result)
+    return results

--- a/daydream/archive/sanitize.py
+++ b/daydream/archive/sanitize.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import hashlib
 import json
 import shutil
+import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -44,6 +45,10 @@ __all__ = ["ImportResult", "SanitizeResult", "import_bundle", "sanitize_archive"
 
 _PROGRESS_FILENAME = "progress.jsonl"
 _AUDIT_FILENAME = "audit.jsonl"
+# Marker written inside a quarantined *derivative* so a later replacement can
+# tell our own copy from an imported source bundle parked in the same
+# ``quarantine/<name>`` namespace by :func:`import_bundle` (M14).
+_DERIVATIVE_MARKER = ".daydream_derivative_marker"
 
 
 def _now_iso_utc() -> str:
@@ -119,6 +124,7 @@ def _sanitize_text(text: str) -> str:
     """
     text = redact_text(text)
     text = scan._TOKEN_ONLY_USERINFO_PATTERN.sub(r"\1[REDACTED_USER]@", text)
+    text = scan._SCP_USERINFO_PATTERN.sub(r"[REDACTED_USER]@\2", text)
     text = scan._QUERY_CREDENTIAL_PATTERN.sub(r"\1\2=[REDACTED_CREDENTIAL]", text)
     return text
 
@@ -148,6 +154,26 @@ def _append_jsonl(path: Path, record: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as f:
         f.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def _resolve_session_id(run_dir: Path) -> str:
+    """Return the session id that keys this bundle's derivative and resume marker.
+
+    Mirrors the manifest-driven identity used by :func:`sanitize_bundle`
+    (manifest ``session_id``, falling back to the directory name) so a bulk
+    pass skips a completed bundle even when a legacy manifest's ``session_id``
+    differs from its run-dir name (M19).
+    """
+    manifest_path = run_dir / "manifest.json"
+    if manifest_path.exists():
+        try:
+            loaded = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except ValueError:
+            loaded = {}
+        session_id = loaded.get("session_id") if isinstance(loaded, dict) else None
+        if session_id:
+            return str(session_id)
+    return run_dir.name
 
 
 def _read_progress(sanitized_dir: Path) -> dict[str, str]:
@@ -187,15 +213,23 @@ def _quarantine_derivative(
 ) -> None:
     """Move a failed derivative to quarantine and record it (M16, fail-closed).
 
-    Nothing is deleted: the derivative (a copy, never the bronze original) is
-    moved under ``<archive_dir>/quarantine/<session_id>/`` for human review.
+    Nothing deleted is ever a source: a prior derivative copy in the slot is
+    replaced only when the marker proves it is ours; an imported source bundle
+    parked at the same ``quarantine/<name>`` namespace by :func:`import_bundle`
+    is never touched (the failed derivative is parked in a sibling slot).
     """
     quarantine_dir = archive_dir / "quarantine" / session_id
     quarantine_dir.parent.mkdir(parents=True, exist_ok=True)
     if derivative_dir.exists():
-        if quarantine_dir.exists():
+        if (quarantine_dir / _DERIVATIVE_MARKER).exists():
             shutil.rmtree(quarantine_dir)  # our own prior derivative copy, not a source
+        if quarantine_dir.exists():
+            # The slot is not provably our derivative (e.g. an imported source
+            # parked by import_bundle at quarantine/<name>). Never delete it;
+            # park this failed derivative in a unique sibling slot instead.
+            quarantine_dir = quarantine_dir.with_name(f"{session_id}.{int(time.time())}")
         shutil.move(str(derivative_dir), str(quarantine_dir))
+        (quarantine_dir / _DERIVATIVE_MARKER).write_text(_now_iso_utc(), encoding="utf-8")
     _append_jsonl(
         sanitized_dir / _AUDIT_FILENAME,
         {
@@ -307,7 +341,7 @@ def sanitize_archive(archive_dir: Path) -> list[SanitizeResult]:
     if not runs_dir.is_dir():
         return results
     for run_dir in sorted(p for p in runs_dir.iterdir() if p.is_dir()):
-        session_id = run_dir.name
+        session_id = _resolve_session_id(run_dir)
         recorded_digest = completed.get(session_id)
         if recorded_digest is not None and (sanitized_dir / session_id).is_dir():
             try:

--- a/daydream/archive/scan.py
+++ b/daydream/archive/scan.py
@@ -1,0 +1,166 @@
+"""Fail-closed bundle secret scanner (issue #981 M9/M11/M13).
+
+Walks a serialized run directory and reports secret-shaped content before any
+egress path (Hub upload, ``--dump-artifacts``, sanitizer release) touches it.
+Safe-only reporting (M11): findings carry the file name, JSON key path or line
+number, category, and a short digest of the matched region — never the matched
+value or its surrounding content. Any scanner error is absorbed into a
+``scan_error`` finding so a broken scan can never return clean (fail-closed).
+
+Redaction rule shapes are imported from :mod:`daydream.trajectory` (reuse, not
+copy); the two pattern gaps unique to serialized bundles (token-only userinfo,
+credential-bearing query params) are local additions.
+"""
+
+import hashlib
+import json
+import re
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from daydream.trajectory import (
+    _API_KEY_PATTERN,
+    _ENV_VAR_PATTERN,
+    _JWT_PATTERN,
+    _PEM_KEY_PATTERN,
+    _URL_CREDENTIAL_PATTERN,
+)
+
+__all__ = ["Finding", "ScanResult", "scan_run_dir"]
+
+# Token-only userinfo: ``https://x-access-token@github.com/...`` — the
+# trajectory URL-credential rule only matches ``user:pass@``, so this closes
+# the single-token gap (matches the pinned inventory's x-access-token rows).
+_TOKEN_ONLY_USERINFO_PATTERN = re.compile(r"(https?://)[^@/\s]+@", re.IGNORECASE)
+# Credential-like query params: ``?token=...`` / ``&access_token=...`` etc.
+_QUERY_CREDENTIAL_PATTERN = re.compile(
+    r"[?&](token|access_token|key|secret|password|credential)=[^&\s]+", re.IGNORECASE
+)
+
+# (pattern, category) pairs applied in order to every scanned text. The
+# trajectory rules are imported; the two local rules close the userinfo/query
+# gaps without touching the shared trajectory module.
+_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
+    (_URL_CREDENTIAL_PATTERN, "url_credential"),
+    (_TOKEN_ONLY_USERINFO_PATTERN, "url_credential"),
+    (_QUERY_CREDENTIAL_PATTERN, "query_credential"),
+    (_PEM_KEY_PATTERN, "pem_key"),
+    (_ENV_VAR_PATTERN, "env_var"),
+    (_API_KEY_PATTERN, "api_key"),
+    (_JWT_PATTERN, "jwt"),
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    """A safe-only secret finding: never carries the matched value (M11)."""
+
+    path: str
+    location: str
+    category: str
+    digest: str
+
+
+@dataclass
+class ScanResult:
+    clean: bool = True
+    findings: list[Finding] = field(default_factory=list)
+
+    def summary(self) -> str:
+        """Human-readable counts + paths only — never finding values."""
+        if self.clean:
+            return "clean"
+        by_path: dict[str, int] = {}
+        for f in self.findings:
+            by_path[f.path] = by_path.get(f.path, 0) + 1
+        parts = ", ".join(f"{p}: {n}" for p, n in sorted(by_path.items()))
+        return f"{len(self.findings)} finding(s) — {parts}"
+
+
+def _digest(matched: str) -> str:
+    return hashlib.sha256(matched.encode()).hexdigest()[:12]
+
+
+def _scan_text(text: str) -> Iterator[tuple[str, str, str]]:
+    """Yield (category, matched_value, digest) for every rule hit in *text*."""
+    for pattern, category in _RULES:
+        for match in pattern.finditer(text):
+            yield category, match.group(0), _digest(match.group(0))
+
+
+def _json_string_leaves(value: object) -> Iterator[tuple[str, str]]:
+    """Walk parsed JSON, yielding (key path, string leaf) pairs."""
+    if isinstance(value, dict):
+        for key, child in value.items():
+            for path, leaf in _json_string_leaves(child):
+                yield f"{key}.{path}" if path else str(key), leaf
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            for path, leaf in _json_string_leaves(child):
+                yield f"[{index}].{path}" if path else f"[{index}]", leaf
+    elif isinstance(value, str):
+        yield "", value
+
+
+def _scan_file(rel_path: str, text: str) -> list[Finding]:
+    """Scan one decoded file, preferring JSON key paths for location."""
+    try:
+        parsed = json.loads(text)
+    except ValueError:
+        parsed = None
+    if isinstance(parsed, (dict, list)):
+        findings = []
+        for key_path, leaf in _json_string_leaves(parsed):
+            for category, _matched, digest in _scan_text(leaf):
+                findings.append(
+                    Finding(
+                        path=rel_path,
+                        location=f"{key_path} (json)" if key_path else "(json)",
+                        category=category,
+                        digest=digest,
+                    )
+                )
+        return findings
+    findings = []
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        for category, _matched, digest in _scan_text(line):
+            findings.append(
+                Finding(
+                    path=rel_path,
+                    location=f"line {line_number}",
+                    category=category,
+                    digest=digest,
+                )
+            )
+    return findings
+
+
+def scan_run_dir(run_dir: Path) -> ScanResult:
+    """Recursively scan every file under *run_dir*; fail closed on any error.
+
+    Files that fail UTF-8 decode are findings themselves (no binary exemption
+    in v1). Exceptions from decoding, regex execution, or I/O are absorbed
+    per-file into a ``scan_error`` finding — this function never raises and
+    never returns a clean result when something went wrong.
+    """
+    result = ScanResult()
+    if not run_dir.is_dir():
+        result.clean = False
+        result.findings.append(
+            Finding(path=str(run_dir), location="(missing)", category="scan_error", digest="")
+        )
+        return result
+    for file_path in sorted(run_dir.rglob("*")):
+        if not file_path.is_file():
+            continue
+        rel_path = file_path.relative_to(run_dir).as_posix()
+        try:
+            text = file_path.read_text(encoding="utf-8")
+            result.findings.extend(_scan_file(rel_path, text))
+        except Exception:  # noqa: BLE001 - fail closed on any per-file error
+            result.findings.append(
+                Finding(path=rel_path, location="(unreadable)", category="scan_error", digest="")
+            )
+    result.clean = not result.findings
+    return result

--- a/daydream/archive/scan.py
+++ b/daydream/archive/scan.py
@@ -19,6 +19,7 @@ from collections.abc import Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from daydream.archive.git_safe import _CREDENTIAL_QUERY_KEYS
 from daydream.trajectory import (
     _API_KEY_PATTERN,
     _ENV_VAR_PATTERN,
@@ -34,8 +35,11 @@ __all__ = ["Finding", "ScanResult", "scan_run_dir"]
 # the single-token gap (matches the pinned inventory's x-access-token rows).
 _TOKEN_ONLY_USERINFO_PATTERN = re.compile(r"(https?://)[^@/\s]+@", re.IGNORECASE)
 # Credential-like query params: ``?token=...`` / ``&access_token=...`` etc.
+# The key set comes from git_safe._CREDENTIAL_QUERY_KEYS (single source: a key
+# added there widens this scan gate automatically).
 _QUERY_CREDENTIAL_PATTERN = re.compile(
-    r"[?&](token|access_token|key|secret|password|credential)=[^&\s]+", re.IGNORECASE
+    r"([?&])(" + "|".join(sorted(_CREDENTIAL_QUERY_KEYS)) + r")=[^&\s]+",
+    re.IGNORECASE,
 )
 
 # (pattern, category) pairs applied in order to every scanned text. The

--- a/daydream/archive/scan.py
+++ b/daydream/archive/scan.py
@@ -8,8 +8,8 @@ value or its surrounding content. Any scanner error is absorbed into a
 ``scan_error`` finding so a broken scan can never return clean (fail-closed).
 
 Redaction rule shapes are imported from :mod:`daydream.trajectory` (reuse, not
-copy); the two pattern gaps unique to serialized bundles (token-only userinfo,
-credential-bearing query params) are local additions.
+copy); the pattern gaps unique to serialized bundles (token-only userinfo,
+scheme-less SCP userinfo, credential-bearing query params) are local additions.
 """
 
 import hashlib
@@ -34,6 +34,14 @@ __all__ = ["Finding", "ScanResult", "scan_run_dir"]
 # trajectory URL-credential rule only matches ``user:pass@``, so this closes
 # the single-token gap (matches the pinned inventory's x-access-token rows).
 _TOKEN_ONLY_USERINFO_PATTERN = re.compile(r"(https?://)[^@/\s]+@", re.IGNORECASE)
+# Scheme-less SCP userinfo: ``user:pass@host:path``. The trajectory URL rule
+# and the token-only rule above both anchor on ``https?://``, so this closes
+# the SCP gap that git_safe.classify_remote_url labels a credential (':' in
+# the pre-@ user group). A lone login user (git@host:path) is not a credential
+# and is intentionally not matched, matching git_safe's classification.
+_SCP_USERINFO_PATTERN = re.compile(
+    r"([^\s@/:]+:[^\s@/:]+@)([^/\s@:]+:)(?=[^\s])", re.IGNORECASE,
+)
 # Credential-like query params: ``?token=...`` / ``&access_token=...`` etc.
 # The key set comes from git_safe._CREDENTIAL_QUERY_KEYS (single source: a key
 # added there widens this scan gate automatically).
@@ -48,6 +56,7 @@ _QUERY_CREDENTIAL_PATTERN = re.compile(
 _RULES: tuple[tuple[re.Pattern[str], str], ...] = (
     (_URL_CREDENTIAL_PATTERN, "url_credential"),
     (_TOKEN_ONLY_USERINFO_PATTERN, "url_credential"),
+    (_SCP_USERINFO_PATTERN, "url_credential"),
     (_QUERY_CREDENTIAL_PATTERN, "query_credential"),
     (_PEM_KEY_PATTERN, "pem_key"),
     (_ENV_VAR_PATTERN, "env_var"),

--- a/daydream/archive/scan.py
+++ b/daydream/archive/scan.py
@@ -86,6 +86,10 @@ def _scan_text(text: str) -> Iterator[tuple[str, str, str]]:
     """Yield (category, matched_value, digest) for every rule hit in *text*."""
     for pattern, category in _RULES:
         for match in pattern.finditer(text):
+            # Redaction markers are already-safe output, not secrets; scanning
+            # sanitized text must not flag its own markers.
+            if "[REDACTED_" in match.group(0):
+                continue
             yield category, match.group(0), _digest(match.group(0))
 
 

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -1733,6 +1733,33 @@ def _safe_url_desc(url: str) -> str:
     return redact_text(url)
 
 
+def _run_clone(
+    remote_url: str, cmd: list[str], timeout: int, env: dict[str, str] | None = None
+) -> None:
+    """Run a prepared ``git clone`` argv and map failures to :class:`GitError`.
+
+    Shared by :func:`clone` and :func:`clone_with_token`, which differ only in
+    argv prefix and environment. ``env=None`` inherits the parent environment,
+    matching :func:`clone`'s current behavior.
+    """
+    try:
+        proc = subprocess.run(  # noqa: S603 - arguments are not user-controlled
+            cmd,  # noqa: S607 - git is a trusted command
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=env,
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        raise GitError(
+            f"git clone {_safe_url_desc(remote_url)} failed: {type(exc).__name__}: {redact_text(str(exc))}"
+        ) from exc
+    if proc.returncode != 0:
+        raise GitError(
+            f"git clone {_safe_url_desc(remote_url)} failed: {redact_text(proc.stderr.strip())}"
+        )
+
+
 def clone_with_token(
     remote_url: str,
     target: Path,
@@ -1758,23 +1785,7 @@ def clone_with_token(
     if blobless:
         cmd.append("--filter=blob:none")
     cmd += [remote_url, str(target)]
-    env = {**os.environ, "GIT_TERMINAL_PROMPT": "0"}
-    try:
-        proc = subprocess.run(  # noqa: S603 - arguments are not user-controlled
-            cmd,  # noqa: S607 - git is a trusted command
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            env=env,
-        )
-    except (subprocess.SubprocessError, OSError) as exc:
-        raise GitError(
-            f"git clone {_safe_url_desc(remote_url)} failed: {type(exc).__name__}: {redact_text(str(exc))}"
-        ) from exc
-    if proc.returncode != 0:
-        raise GitError(
-            f"git clone {_safe_url_desc(remote_url)} failed: {redact_text(proc.stderr.strip())}"
-        )
+    _run_clone(remote_url, cmd, timeout, env={**os.environ, "GIT_TERMINAL_PROMPT": "0"})
 
 
 def clone(remote_url: str, target: Path, *, blobless: bool = False, timeout: int = 300) -> None:
@@ -1796,21 +1807,7 @@ def clone(remote_url: str, target: Path, *, blobless: bool = False, timeout: int
     if blobless:
         cmd.append("--filter=blob:none")
     cmd += [remote_url, str(target)]
-    try:
-        proc = subprocess.run(  # noqa: S603 - arguments are not user-controlled
-            cmd,  # noqa: S607 - git is a trusted command
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-        )
-    except (subprocess.SubprocessError, OSError) as exc:
-        raise GitError(
-            f"git clone {_safe_url_desc(remote_url)} failed: {type(exc).__name__}: {redact_text(str(exc))}"
-        ) from exc
-    if proc.returncode != 0:
-        raise GitError(
-            f"git clone {_safe_url_desc(remote_url)} failed: {redact_text(proc.stderr.strip())}"
-        )
+    _run_clone(remote_url, cmd, timeout)
 
 
 def checkout_paths(repo: Path, paths: list[Path]) -> None:

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -48,6 +48,9 @@ from collections.abc import Sequence
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Callable, Generator, Literal, overload
+from urllib.parse import urlparse
+
+from daydream.trajectory import redact_text
 
 _logger = logging.getLogger(__name__)
 
@@ -1692,7 +1695,9 @@ def fetch_ref(repo: Path, refspec: str, remote: str = "origin", *, timeout: int 
     """
     proc = _run_git(repo, ["fetch", remote, refspec], timeout=timeout, retries=0)
     if proc.returncode != 0:
-        raise GitError(f"git fetch {remote} {refspec} failed in {repo}: {proc.stderr.strip()}")
+        raise GitError(
+            f"git fetch {_safe_url_desc(remote)} {refspec} failed in {repo}: {redact_text(proc.stderr.strip())}"
+        )
 
 
 def checkout_detach(repo: Path, sha: str, *, timeout: int = 300) -> None:
@@ -1709,6 +1714,22 @@ def checkout_detach(repo: Path, sha: str, *, timeout: int = 300) -> None:
     proc = _run_git(repo, ["checkout", "--detach", sha], timeout=timeout, retries=0)
     if proc.returncode != 0:
         raise GitError(f"git checkout --detach {sha} failed in {repo}: {proc.stderr.strip()}")
+
+
+def _safe_url_desc(url: str) -> str:
+    """Reduce a remote URL to a credential-free description (host/path).
+
+    Issue #981: error messages must never echo a URL that may carry userinfo
+    credentials. HTTP(S) URLs are reduced to ``host/path``; anything else
+    (local paths, scp-form remotes) passes through :func:`redact_text`.
+    """
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return redact_text(url)
+    if parsed.scheme and parsed.hostname:
+        return f"{parsed.hostname}{parsed.path}"
+    return redact_text(url)
 
 
 def clone(remote_url: str, target: Path, *, blobless: bool = False, timeout: int = 300) -> None:
@@ -1738,9 +1759,13 @@ def clone(remote_url: str, target: Path, *, blobless: bool = False, timeout: int
             timeout=timeout,
         )
     except (subprocess.SubprocessError, OSError) as exc:
-        raise GitError(f"git clone {remote_url} failed: {type(exc).__name__}: {exc}") from exc
+        raise GitError(
+            f"git clone {_safe_url_desc(remote_url)} failed: {type(exc).__name__}: {redact_text(str(exc))}"
+        ) from exc
     if proc.returncode != 0:
-        raise GitError(f"git clone {remote_url} failed: {proc.stderr.strip()}")
+        raise GitError(
+            f"git clone {_safe_url_desc(remote_url)} failed: {redact_text(proc.stderr.strip())}"
+        )
 
 
 def checkout_paths(repo: Path, paths: list[Path]) -> None:

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -51,8 +51,6 @@ from pathlib import Path
 from typing import Any, Callable, Generator, Literal, overload
 from urllib.parse import urlparse
 
-from daydream.trajectory import redact_text
-
 _logger = logging.getLogger(__name__)
 
 # Lowercased substrings that identify a GitHub API rate-limit response in ``gh``
@@ -1696,6 +1694,8 @@ def fetch_ref(repo: Path, refspec: str, remote: str = "origin", *, timeout: int 
     """
     proc = _run_git(repo, ["fetch", remote, refspec], timeout=timeout, retries=0)
     if proc.returncode != 0:
+        from daydream.trajectory import redact_text
+
         raise GitError(
             f"git fetch {_safe_url_desc(remote)} {refspec} failed in {repo}: {redact_text(proc.stderr.strip())}"
         )
@@ -1724,6 +1724,8 @@ def _safe_url_desc(url: str) -> str:
     credentials. HTTP(S) URLs are reduced to ``host/path``; anything else
     (local paths, scp-form remotes) passes through :func:`redact_text`.
     """
+    from daydream.trajectory import redact_text
+
     try:
         parsed = urlparse(url)
     except ValueError:
@@ -1751,10 +1753,14 @@ def _run_clone(
             env=env,
         )
     except (subprocess.SubprocessError, OSError) as exc:
+        from daydream.trajectory import redact_text
+
         raise GitError(
             f"git clone {_safe_url_desc(remote_url)} failed: {type(exc).__name__}: {redact_text(str(exc))}"
         ) from exc
     if proc.returncode != 0:
+        from daydream.trajectory import redact_text
+
         raise GitError(
             f"git clone {_safe_url_desc(remote_url)} failed: {redact_text(proc.stderr.strip())}"
         )
@@ -1772,20 +1778,33 @@ def clone_with_token(
 
     Issue #981: the URL must already be credential-free (a canonical HTTPS
     identity like ``https://github.com/owner/repo``). When *token* is set,
-    auth is injected at the argv layer via ``-c http.extraHeader`` — the URL
-    string never contains the token. Without a token, plain clone applies
-    (ambient credential helper). ``GIT_TERMINAL_PROMPT=0`` fails closed on
-    auth errors instead of prompting.
+    auth is injected out-of-band via the git-config environment variables
+    (``GIT_CONFIG_*``) carrying the base64 ``Authorization`` header — never on
+    argv, in the URL, or in a config file. Without a token, plain clone
+    applies (ambient credential helper). ``GIT_TERMINAL_PROMPT=0`` fails
+    closed on auth errors instead of prompting.
     """
     cmd = ["git"]
+    env: dict[str, str] = {**os.environ, "GIT_TERMINAL_PROMPT": "0"}
     if token:
+        # Issue #981: auth travels out-of-band via git config environment
+        # variables, never on argv. The base64 Authorization header is
+        # trivially recoverable, so putting it on argv (via -c
+        # http.extraHeader) would leak the token; GIT_CONFIG_* keeps it out of
+        # the command line, honoring the contract that no token lands on argv.
         basic = base64.b64encode(f"x-access-token:{token}".encode()).decode()
-        cmd += ["-c", f"http.extraHeader=Authorization: Basic {basic}"]
+        env.update(
+            {
+                "GIT_CONFIG_COUNT": "1",
+                "GIT_CONFIG_KEY_0": "http.extraHeader",
+                "GIT_CONFIG_VALUE_0": f"Authorization: Basic {basic}",
+            }
+        )
     cmd.append("clone")
     if blobless:
         cmd.append("--filter=blob:none")
     cmd += [remote_url, str(target)]
-    _run_clone(remote_url, cmd, timeout, env={**os.environ, "GIT_TERMINAL_PROMPT": "0"})
+    _run_clone(remote_url, cmd, timeout, env=env)
 
 
 def clone(remote_url: str, target: Path, *, blobless: bool = False, timeout: int = 300) -> None:

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -37,6 +37,7 @@ The module is intentionally dependency-free: stdlib only.
 
 from __future__ import annotations
 
+import base64
 import json
 import logging
 import os
@@ -1730,6 +1731,50 @@ def _safe_url_desc(url: str) -> str:
     if parsed.scheme and parsed.hostname:
         return f"{parsed.hostname}{parsed.path}"
     return redact_text(url)
+
+
+def clone_with_token(
+    remote_url: str,
+    target: Path,
+    token: str | None = None,
+    *,
+    blobless: bool = False,
+    timeout: int = 300,
+) -> None:
+    """Clone a reconstructed identity URL with optional out-of-band auth.
+
+    Issue #981: the URL must already be credential-free (a canonical HTTPS
+    identity like ``https://github.com/owner/repo``). When *token* is set,
+    auth is injected at the argv layer via ``-c http.extraHeader`` — the URL
+    string never contains the token. Without a token, plain clone applies
+    (ambient credential helper). ``GIT_TERMINAL_PROMPT=0`` fails closed on
+    auth errors instead of prompting.
+    """
+    cmd = ["git"]
+    if token:
+        basic = base64.b64encode(f"x-access-token:{token}".encode()).decode()
+        cmd += ["-c", f"http.extraHeader=Authorization: Basic {basic}"]
+    cmd.append("clone")
+    if blobless:
+        cmd.append("--filter=blob:none")
+    cmd += [remote_url, str(target)]
+    env = {**os.environ, "GIT_TERMINAL_PROMPT": "0"}
+    try:
+        proc = subprocess.run(  # noqa: S603 - arguments are not user-controlled
+            cmd,  # noqa: S607 - git is a trusted command
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=env,
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        raise GitError(
+            f"git clone {_safe_url_desc(remote_url)} failed: {type(exc).__name__}: {redact_text(str(exc))}"
+        ) from exc
+    if proc.returncode != 0:
+        raise GitError(
+            f"git clone {_safe_url_desc(remote_url)} failed: {redact_text(proc.stderr.strip())}"
+        )
 
 
 def clone(remote_url: str, target: Path, *, blobless: bool = False, timeout: int = 300) -> None:

--- a/daydream/training/corpus.py
+++ b/daydream/training/corpus.py
@@ -63,6 +63,7 @@ from pathlib import Path
 from typing import Any
 
 from daydream.archive import get_archive_dir
+from daydream.archive.git_safe import classify_remote_url
 from daydream.archive.index import bulk_latest_label_observations, count_runs, normalize_as_of, query_runs
 from daydream.json_utils import atomic_write_json
 from daydream.training.exclusion import is_copyleft, load_copyleft_list, load_exclusion_list
@@ -211,6 +212,38 @@ def _annotation_reward(
     return reward, composite
 
 
+def _resolve_projection_path(manifest_row: dict[str, Any]) -> Path | None:
+    """Derivative-resolution gate for projection inputs (issue #981 M17).
+
+    When the row's ``archive_path`` sits under a ``runs/`` directory and a
+    ``sanitized/<session_id>`` derivative exists, the derivative path is
+    returned so projection reads only sanitized inputs. When no derivative
+    exists and the bundle's stored remote URL is credential-bearing, ``None``
+    is returned (the caller skips + warns — never reads raw credential
+    fields). Paths outside a ``runs/`` layout pass through unchanged.
+    """
+    archive_path = Path(manifest_row.get("archive_path", ""))
+    parts = archive_path.parts
+    if "runs" not in parts:
+        return archive_path
+    runs_idx = len(parts) - 1 - parts[::-1].index("runs")
+    archive_dir = Path(*parts[:runs_idx]) if runs_idx else archive_path.parent
+    session_id = str(manifest_row.get("session_id") or archive_path.name)
+    derivative = archive_dir / "sanitized" / session_id
+    if derivative.is_dir():
+        return derivative
+    try:
+        doc = json.loads((archive_path / "manifest.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        doc = {}
+    raw_url = ""
+    if isinstance(doc, dict) and isinstance(doc.get("git"), dict):
+        raw_url = str(doc["git"].get("remote_url") or "")
+    if classify_remote_url(raw_url):
+        return None
+    return archive_path
+
+
 def _build_record(
     manifest_row: dict[str, Any],
     trajectory: dict[str, Any],
@@ -221,7 +254,7 @@ def _build_record(
     label: str | None = None,
     reward: dict[str, Any] | None = None,
     composite_reward: float | None = None,
-) -> dict[str, Any]:
+) -> dict[str, Any] | None:
     """Assemble a training record matching ``schema/v1.json``.
 
     The returned dict carries refs (``fix_diff_ref``, ``recommended_diff_ref``,
@@ -302,9 +335,14 @@ def _build_record(
             annotation, or ``None``.
 
     Returns:
-        A dict that validates against ``daydream/training/schema/v1.json``.
+        A dict that validates against ``daydream/training/schema/v1.json``, or
+        ``None`` when the derivative gate refuses to project the row
+        (credential-bearing bundle with no released derivative — M17; the
+        caller skips + warns, never raises).
     """
-    archive_path = Path(manifest_row.get("archive_path", ""))
+    archive_path = _resolve_projection_path(manifest_row)
+    if archive_path is None:
+        return None
     # fix_diff_ref points at the REVIEWED-INPUT diff (diff.patch = the PR-under-
     # review diff daydream was asked to review), NOT daydream's own fix. The
     # name is retained for schema-v1 compatibility; treat it as the input.
@@ -978,7 +1016,14 @@ def run_build_corpus(config: BuildCorpusConfig) -> dict[str, int]:
             continue
         after_filters += 1
 
-        archive_path = Path(row["archive_path"])
+        archive_path = _resolve_projection_path(row)
+        if archive_path is None:
+            print_warning(
+                console,
+                f"Skipping {session_id}: credential-bearing bundle has no released "
+                "sanitized derivative; refusing to project raw inputs",
+            )
+            continue
         traj_path = archive_path / "trajectory.json"
         manifest_path = archive_path / "manifest.json"
         if not traj_path.exists() or not manifest_path.exists():
@@ -999,13 +1044,13 @@ def run_build_corpus(config: BuildCorpusConfig) -> dict[str, int]:
             )
             continue
         reward, _ = _annotation_reward(annotation, session_id)
-        records.append(
-            _build_record(
-                row, trajectory, row.get("stack"), manifest,
-                annotation=annotation, label=label,
-                reward=reward, composite_reward=composite_reward,
-            )
+        record = _build_record(
+            row, trajectory, row.get("stack"), manifest,
+            annotation=annotation, label=label,
+            reward=reward, composite_reward=composite_reward,
         )
+        if record is not None:
+            records.append(record)
         session_versions[session_id] = (
             annotation.get("labeler_version") if annotation is not None else None,
             annotation.get("reward_version") if annotation is not None else None,

--- a/daydream/training/corpus.py
+++ b/daydream/training/corpus.py
@@ -53,6 +53,7 @@ from __future__ import annotations
 import hashlib
 import json
 import math
+import os
 import shutil
 import tempfile
 import warnings
@@ -340,16 +341,30 @@ def _build_record(
         (credential-bearing bundle with no released derivative — M17; the
         caller skips + warns, never raises).
     """
+    row_archive_path = Path(manifest_row.get("archive_path", ""))
     archive_path = _resolve_projection_path(manifest_row)
     if archive_path is None:
         return None
+
+    # Refs resolve against the row's stored ``archive_path`` (the bronze
+    # ``runs/<sid>``) by a downstream materializer. When ``_resolve_projection_path``
+    # redirected this bundle to the sanitized derivative (M17), emit the ref
+    # relative to that row path so resolution lands on ``sanitized/<sid>/…``
+    # (the credential-free copy) — never the raw credential-bearing bronze file.
+    # The ``../sanitized/<slide>`` prefix in the resolved value is the record's
+    # only derivative-origin marker: the v1 schema is ``additionalProperties:
+    # false``, so origin cannot be a new sibling field.
+    def _ref_relative_path(filename: str) -> str:
+        # relative from the row's bronze path to the file actually projected.
+        return os.path.relpath(str(archive_path / filename), start=str(row_archive_path))
+
     # fix_diff_ref points at the REVIEWED-INPUT diff (diff.patch = the PR-under-
     # review diff daydream was asked to review), NOT daydream's own fix. The
     # name is retained for schema-v1 compatibility; treat it as the input.
     diff_path = archive_path / "diff.patch"
     fix_diff_ref = {
         "available": diff_path.is_file(),
-        "archive_relative_path": "diff.patch",
+        "archive_relative_path": _ref_relative_path("diff.patch"),
     }
     # recommended_diff_ref points at the OUTCOME diff (recommended.patch =
     # daydream's proposed base->worktree edit, captured best-effort after the
@@ -359,7 +374,7 @@ def _build_record(
     recommended_path = archive_path / "recommended.patch"
     recommended_diff_ref = {
         "available": recommended_path.is_file(),
-        "archive_relative_path": "recommended.patch",
+        "archive_relative_path": _ref_relative_path("recommended.patch"),
     }
 
     manifest_dict = manifest or {}
@@ -402,7 +417,7 @@ def _build_record(
         "outcome_label": label,
         "grounding_score": manifest_row.get("grounding_rate"),
         "spans": _build_spans(trajectory),
-        "trajectory_ref": {"archive_relative_path": "trajectory.json"},
+        "trajectory_ref": {"archive_relative_path": _ref_relative_path("trajectory.json")},
     }
 
     # Optional reward fields. composite_reward is nullable (written always);

--- a/daydream/training/harvest.py
+++ b/daydream/training/harvest.py
@@ -81,6 +81,7 @@ injection seams.
 from __future__ import annotations
 
 import json
+import os
 import re
 import time
 from dataclasses import dataclass, replace
@@ -92,6 +93,7 @@ import anyio
 from rich.console import Console
 
 from daydream import git_ops
+from daydream.archive.git_safe import normalize_remote_url
 from daydream.archive.index import (
     append_label_observation,
     query_runs,
@@ -759,7 +761,12 @@ def build_annotation(
     )
 
 
-# Repo resolution — three-tier priority: source_path → clone cache → None
+# Repo resolution — source_path first, then identity-based clone (issue #981):
+# the archived remote_url is only ever normalized to a credential-free HTTPS
+# identity; hosts outside the allowlist fail closed.
+
+# Hosts trusted for harvest clone resolution (overridable in tests).
+_GIT_HOST_ALLOWLIST: frozenset[str] = frozenset({"github.com"})
 
 
 def _resolve_repo_for_row(
@@ -810,7 +817,16 @@ def _resolve_repo_for_row(
                     fetched_repos.add(cached_repo)
         else:
             cached_repo.parent.mkdir(parents=True, exist_ok=True)
-            git_ops.clone(remote_url, cached_repo, blobless=True)
+            # Issue #981: never clone the archived raw URL. Normalize it to a
+            # credential-free HTTPS identity and fail closed on untrusted
+            # hosts or unparseable input. Token, if any, travels out-of-band.
+            identity, canonical = normalize_remote_url(
+                remote_url, allowed_hosts=_GIT_HOST_ALLOWLIST
+            )
+            if identity is None or canonical is None:
+                return None
+            token = os.environ.get("DAYDREAM_GIT_TOKEN")
+            git_ops.clone_with_token(canonical, cached_repo, token, blobless=True)
     except (GitError, OSError) as exc:
         redacted = _redact_text(str(exc))
         print_warning(

--- a/daydream/training/harvest.py
+++ b/daydream/training/harvest.py
@@ -93,7 +93,7 @@ import anyio
 from rich.console import Console
 
 from daydream import git_ops
-from daydream.archive.git_safe import normalize_remote_url
+from daydream.archive.git_safe import _DEFAULT_HOSTS, normalize_remote_url
 from daydream.archive.index import (
     append_label_observation,
     query_runs,
@@ -765,9 +765,6 @@ def build_annotation(
 # the archived remote_url is only ever normalized to a credential-free HTTPS
 # identity; hosts outside the allowlist fail closed.
 
-# Hosts trusted for harvest clone resolution (overridable in tests).
-_GIT_HOST_ALLOWLIST: frozenset[str] = frozenset({"github.com"})
-
 
 def _resolve_repo_for_row(
     row: dict[str, Any],
@@ -821,7 +818,7 @@ def _resolve_repo_for_row(
             # credential-free HTTPS identity and fail closed on untrusted
             # hosts or unparseable input. Token, if any, travels out-of-band.
             identity, canonical = normalize_remote_url(
-                remote_url, allowed_hosts=_GIT_HOST_ALLOWLIST
+                remote_url, allowed_hosts=_DEFAULT_HOSTS
             )
             if identity is None or canonical is None:
                 return None

--- a/daydream/training/harvest.py
+++ b/daydream/training/harvest.py
@@ -118,6 +118,7 @@ from daydream.training.labeler_signals import (
 )
 from daydream.training.reward import ScoringInputs, score_trajectory
 from daydream.training.rubric import Rubric, derive_outcome_label, derive_per_finding_labels
+from daydream.trajectory import redact_text as _redact_text
 from daydream.ui import create_console, print_warning
 
 _VERDICTS_FILE = "recommendation-verdicts.json"
@@ -811,9 +812,10 @@ def _resolve_repo_for_row(
             cached_repo.parent.mkdir(parents=True, exist_ok=True)
             git_ops.clone(remote_url, cached_repo, blobless=True)
     except (GitError, OSError) as exc:
+        redacted = _redact_text(str(exc))
         print_warning(
             console or create_console(),
-            f"harvest: repo resolution failed for {repo_slug}: {type(exc).__name__}: {exc}",
+            f"harvest: repo resolution failed for {repo_slug}: {type(exc).__name__}: {redacted}",
         )
         if not (cached_repo / ".git").exists():
             return None

--- a/docs/runbooks/credential-remediation.md
+++ b/docs/runbooks/credential-remediation.md
@@ -28,9 +28,10 @@ report_inventory(Path('/path/to/archive_dir'))
 `report_inventory()` classifies each bundle's `git.remote_url` via the
 normalizer and prints **counts by category only** — session counts, never a
 URL fragment or a matched credential value. Categories mirror
-`daydream.archive.git_safe.classify_remote_url` (e.g. credential-bearing
-userinfo forms, `x-access-token` token-only forms, clean HTTPS/SCP forms) plus
-`unparseable` for manifests it could not read.
+`daydream.archive.git_safe.classify_remote_url`: `userinfo` (covers both
+`user:token`/PAT-shaped userinfo and `x-access-token` token-only `user@`
+forms), `query` (credential-like query parameters), and `clean` (benign URLs),
+plus `unparseable` for manifests it could not read.
 
 Record the output. It tells you how many manifests/bundles are affected per
 category, which determines how wide the revocation net in step 3 must be.
@@ -61,9 +62,12 @@ Map affected sessions to the repos they touched:
 1. For each affected `session_id`, read `manifest.json` in the source run
    directory and note the repo identity (owner/repo) — the *identity*, not the
    raw URL.
-2. Correlate with the inventory categories: `x-access-token` forms are GitHub
-   App installation tokens; `user:token` or PAT-shaped userinfo are personal
-   access tokens.
+2. The inventory's single `userinfo` category covers both `x-access-token`
+   token-only `user@` forms (GitHub App installation tokens) and `user:token`
+   or PAT-shaped userinfo (personal access tokens), so it cannot tell the two
+   apart at category granularity. Distinguish them from the source
+   `manifest.json` `git.remote_url` records instead, not the inventory
+   category counts.
 3. The result is a table of (credential type, repo(s), session ids, date
    range) — safe to share, contains no secret values.
 
@@ -140,3 +144,29 @@ Post-remediation, confirm the incident is closed:
    sanitizer release gate) blocks any bundle that is not provably clean from
    every egress path. Future incidents should be caught at that gate, before
    upload.
+
+## 7. How the harvest clone step authenticates
+
+`corpus harvest` clones repos from manifests that have no local checkout into
+its clone cache. It never clones the archived raw URL: the URL is rewritten via
+`normalize_remote_url` (see `daydream.archive.git_safe`) into a credential-free
+HTTPS identity like `https://github.com/owner/repo`, and only allowlisted git
+hosts are accepted. All credential material is therefore absent from the URL
+by construction.
+
+Authentication for private repos is out-of-band and operator-supplied:
+
+- Set the `DAYDREAM_GIT_TOKEN` environment variable (e.g. a GitHub PAT with
+  read access to the target repos) when running `corpus harvest`. It is
+  injected into the git command via `-c http.extraHeader` at the argv layer;
+  the URL string never contains the token.
+- Without the variable, the clone falls back to the ambient git credential
+  helper. `GIT_TERMINAL_PROMPT=0` fails closed on auth errors instead of
+  prompting.
+- A clone or fetch failure is warning-only at harvest time (the affected run
+  is skipped, never aborted) and never survives into the archive.
+
+Treat `DAYDREAM_GIT_TOKEN` as a credential in its own right: if it is
+suspected leaked, add it to the step-3 revocation net. It is an input to the
+clone step, not archived data, so it never appears in uploaded bundles or in
+`report_inventory()` output.

--- a/docs/runbooks/credential-remediation.md
+++ b/docs/runbooks/credential-remediation.md
@@ -1,0 +1,142 @@
+# Credential Remediation Runbook (issue #981, M22)
+
+When a Git credential is discovered in an archived bundle — an uploaded Hub
+dataset, a local archive, or a quarantined derivative — this runbook walks the
+remediation from scoping through verification. It exists because the code
+deliberately stops at the safe boundary: the sanitizer, scanner, and inventory
+tooling are agent-runnable, but **revocation, rotation, and Hub history
+rewrite are destructive operations that require a human and are never
+automated.**
+
+Audience: the daydream operator (a human with provider dashboards open and the
+archive checkout in their own terminal).
+
+---
+
+## 1. Scope the incident
+
+Run the value-free inventory over the archive:
+
+```bash
+python -c "
+from pathlib import Path
+from daydream.archive.sanitize import report_inventory
+report_inventory(Path('/path/to/archive_dir'))
+"
+```
+
+`report_inventory()` classifies each bundle's `git.remote_url` via the
+normalizer and prints **counts by category only** — session counts, never a
+URL fragment or a matched credential value. Categories mirror
+`daydream.archive.git_safe.classify_remote_url` (e.g. credential-bearing
+userinfo forms, `x-access-token` token-only forms, clean HTTPS/SCP forms) plus
+`unparseable` for manifests it could not read.
+
+Record the output. It tells you how many manifests/bundles are affected per
+category, which determines how wide the revocation net in step 3 must be.
+
+If the incident involves bundles already uploaded to the Hub, also list the
+affected dataset revisions (upload timestamps vs. affected session dates)
+before touching anything.
+
+## 2. Identify affected credentials
+
+Work from `sanitized/audit.jsonl` records under `<archive_dir>/sanitized/`.
+Each record carries, per processed bundle:
+
+- `source` — the original run directory path
+- `session_id` — the archived session
+- `derivative_digest` — content digest of the released derivative
+- `status` — `"sanitized"` or `"quarantined"`
+- `completed_at` — timestamp
+
+**Never print a credential value.** Do not grep for the token itself, do not
+paste matched regions into tickets, logs, or agent tooling. If the operator
+must inspect a value (e.g. to match a token prefix against a provider
+dashboard), they do it **in their own terminal, from the source-of-record**
+(provider settings page, secret store, CI config) — outside agent tooling.
+
+Map affected sessions to the repos they touched:
+
+1. For each affected `session_id`, read `manifest.json` in the source run
+   directory and note the repo identity (owner/repo) — the *identity*, not the
+   raw URL.
+2. Correlate with the inventory categories: `x-access-token` forms are GitHub
+   App installation tokens; `user:token` or PAT-shaped userinfo are personal
+   access tokens.
+3. The result is a table of (credential type, repo(s), session ids, date
+   range) — safe to share, contains no secret values.
+
+## 3. Verify expiry / revoke or rotate
+
+> **Gate: revocation and rotation require human approval. Never automated.
+> No code path in daydream revokes, rotates, or expires a credential.**
+
+Per provider:
+
+- **GitHub PAT (classic / fine-grained):** in GitHub → Settings → Developer
+  settings, check each candidate token's last-used date and expiry against the
+  affected date range. Revoke tokens that overlap, or rotate (issue a
+  replacement, update the secret store, then revoke the old one). Prefer
+  revocation over rotation when the token's scope is uncertain.
+- **GitHub App installation tokens (`x-access-token`):** these are short-lived
+  by construction, but if the *installation's* credential material (the App
+  private key) could have leaked alongside, rotate the App private key from
+  the App settings page. Check the App's installation audit log for anomalous
+  repo access within the affected window.
+- **Other providers:** apply the same rule — verify scope and expiry from the
+  provider's own dashboard, then revoke first, rotate second.
+
+After revocation, confirm in the provider's audit log that the credential no
+longer authenticates.
+
+## 4. Remediate Hub history
+
+Choose exactly one option, in escalating order of destructiveness:
+
+- **(a) Leave quarantined bundles unreleased (non-destructive default).**
+  Bundles that failed the fail-closed scan live under
+  `<archive_dir>/quarantine/<session_id>/` and are never released. Doing
+  nothing is a valid, safe outcome for anything not yet uploaded.
+- **(b) Delete specific Hub uploads.** Delete the affected dataset revision(s)
+  from the HuggingFace dataset repo (revisions uploaded before revocation, or
+  re-upload sanitized derivatives after revocation).
+- **(c) Full history rewrite** of the dataset repo — only when the credential
+  shipped in many revisions and (b) is impractical.
+
+> **Gate for (b) and (c):** all of the following are required before acting:
+> 1. Explicit operator approval, recorded in writing (who, when, what scope).
+> 2. An **executed revocation first** (step 3 is complete) — deleting history
+>    is useless if the credential still works.
+> 3. A written record of exactly what was deleted (dataset repo, revision
+>    SHAs or date range, operator, timestamp), kept with the incident record.
+
+## 5. Non-destructive vs destructive operations
+
+| Operation | Destructive? | Who runs it | Gate |
+|---|---|---|---|
+| `report_inventory()` scoping | No (read-only, value-free) | Agent or human | — |
+| Reading `sanitized/audit.jsonl` | No | Agent or human | Never print values |
+| `sanitize_archive()` / `sanitize_bundle()` | No (produces derivatives; bronze sources never modified) | Agent or human | Fail-closed scan; failures quarantine |
+| Quarantine **release** (moving a derivative out of `quarantine/` after review) | No | Agent or human | Must pass `scan_run_dir()` clean first |
+| Credential revocation / rotation | **Destructive** | **Human only** | Human approval; never automated |
+| Hub revision deletion (4b) | **Destructive** | **Human only** | Approval + executed revocation + written deletion record |
+| Hub history rewrite (4c) | **Destructive** | **Human only** | Approval + executed revocation + written deletion record |
+
+## 6. Verify
+
+Post-remediation, confirm the incident is closed:
+
+1. **Re-run the inventory:** `report_inventory()` again. Every previously
+   affected category must now read zero; only clean categories (and
+   `unparseable`, if pre-existing) remain.
+2. **Re-scan:** run the fail-closed scanner (`daydream.archive.scan.scan_run_dir`)
+   over sanitized derivatives and any bundle that will egress. It must report
+   clean.
+3. **Revocation holds:** attempt authentication with a revoked token from the
+   operator's own terminal and confirm it fails.
+4. **Going forward:** the fail-closed scan (upload preflight in
+   `daydream/archive/hub.py`, the `--dump-artifacts` copy gate, and the
+   sanitizer release gate) blocks any bundle that is not provably clean from
+   every egress path. Future incidents should be caught at that gate, before
+   upload.

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1233,7 +1233,8 @@ def test_dump_artifacts_refuses_credential_bearing_bundle(
     assert not (dest / "trajectory.json").exists()
 
     # The warning is value-free (M11): the credential never echoes.
-    out = capsys.readouterr().out + capsys.readouterr().err
+    captured = capsys.readouterr()
+    out = captured.out + captured.err
     assert "ghp_canaryfake123" not in out
 
 

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -82,6 +82,8 @@ class _MockConfig:
     loop: bool = False
     archive: bool = True
     run_eval: bool = False
+    dump_artifacts: str | None = None
+    trajectory_hub_repo: str | None = None
     file_config: DaydreamFileConfig | None = None
     findings_out: str | None = None
 
@@ -1195,6 +1197,67 @@ def test_copy_bundle_findings_artifact_skipped_without_findings_out(tmp_path: Pa
     _copy_bundle(target, run_dir, recorder, RunConfig())
 
     assert not (run_dir / "findings.json").exists()
+
+
+def test_dump_artifacts_refuses_credential_bearing_bundle(
+    tmp_path: Path,
+    archive_dir: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """M12: a bundle whose serialized artifacts carry a credential is not copied to
+    the ``--dump-artifacts`` destination — the scan gate refuses the copy, warns
+    with a value-free summary, and the archive run continues (non-fatal)."""
+    session_id = "abcd1234-0000-0000-0000-000000000000"
+    config = _MockConfig(dump_artifacts=str(tmp_path / "dump"))
+
+    target, _, _ = _setup_bundle(tmp_path, session_id)
+    # Inject a credential into the serialized trajectory the bundle will carry.
+    traj_path = target / ".daydream" / "runs" / session_id / "trajectory.json"
+    traj = json.loads(traj_path.read_text())
+    traj["remote_url"] = "https://user:ghp_canaryfake123@github.com/o/r"
+    traj_path.write_text(json.dumps(traj))
+
+    recorder = _MockRecorder(session_id=session_id)
+
+    archive_run(
+        recorder=cast(TrajectoryRecorder, recorder),
+        target_dir=target,
+        config=cast(RunConfig, config),
+        status="complete",
+    )
+
+    # The run itself is still archived (the gate is dump-path-only), but the
+    # user-specified destination never receives the dirty bundle.
+    dest = tmp_path / "dump"
+    assert not (dest / "manifest.json").exists()
+    assert not (dest / "trajectory.json").exists()
+
+    # The warning is value-free (M11): the credential never echoes.
+    out = capsys.readouterr().out + capsys.readouterr().err
+    assert "ghp_canaryfake123" not in out
+
+
+def test_dump_artifacts_copies_clean_bundle(
+    tmp_path: Path, archive_dir: Path
+) -> None:
+    """The clean path is unchanged: a scan-clean bundle is copied wholesale."""
+    session_id = "abcd1234-0000-0000-0000-000000000000"
+    config = _MockConfig(dump_artifacts=str(tmp_path / "dump"))
+    target, _, _ = _setup_bundle(tmp_path, session_id)
+    recorder = _MockRecorder(session_id=session_id)
+
+    archive_run(
+        recorder=cast(TrajectoryRecorder, recorder),
+        target_dir=target,
+        config=cast(RunConfig, config),
+        status="complete",
+    )
+
+    dest = tmp_path / "dump"
+    assert (dest / "manifest.json").is_file()
+    assert (dest / "trajectory.json").is_file()
+    run_dir = archive_dir / "runs" / session_id
+    assert (dest / "manifest.json").read_text() == (run_dir / "manifest.json").read_text()
 
 
 def test_archive_run_round_trip(tmp_path: Path, archive_dir: Path) -> None:

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -657,6 +657,16 @@ def test_upsert_run_creates_db(tmp_path: Path) -> None:
     assert (tmp_path / "index.db").exists()
 
 
+def test_upsert_run_never_persists_credential_bearing_url(tmp_path: Path) -> None:
+    # M4: even if upstream normalization is bypassed, the row is clean.
+    m = make_manifest(remote_url="https://user:ghp_bypassfake@github.com/o/r.git")
+    upsert_run(tmp_path, m)
+    row = query_runs(tmp_path)[0]
+    assert row["remote_url"] == "https://github.com/o/r"
+    assert row["repo_slug"] == "o/r"
+    assert "ghp_bypassfake" not in (row["remote_url"] or "")
+
+
 def test_upsert_and_query_round_trip(tmp_path: Path) -> None:
     m = make_manifest()
     upsert_run(tmp_path, m)

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -16,7 +16,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from daydream.archive import _copy_bundle, _read_fix_quality_gate, archive_run, get_archive_dir
-from daydream.archive.git_context import GitContext, _parse_repo_slug, capture_git_context
+from daydream.archive.git_context import GitContext, capture_git_context
 from daydream.archive.index import (
     append_label_observation,
     bulk_latest_label_observations,
@@ -86,17 +86,28 @@ class _MockConfig:
     findings_out: str | None = None
 
 
-@pytest.mark.parametrize(
-    ("remote_url", "expected"),
-    [
-        pytest.param("git@github.com:org/repo.git", "org/repo", id="ssh"),
-        pytest.param("https://github.com/org/repo.git", "org/repo", id="https"),
-        pytest.param("https://github.com/org/repo", "org/repo", id="https_no_dot_git"),
-        pytest.param("not-a-url", None, id="invalid"),
-    ],
-)
-def test_parse_repo_slug(remote_url: str, expected: str | None) -> None:
-    assert _parse_repo_slug(remote_url) == expected
+def _run_git_init_with_credential_origin(repo: Path, origin_url: str) -> None:
+    """git init + one commit + credential-bearing origin remote."""
+    for argv in (
+        ["git", "init"],
+        ["git", "config", "user.email", "test@test.com"],
+        ["git", "config", "user.name", "Test"],
+        ["git", "commit", "--allow-empty", "-m", "init"],
+        ["git", "remote", "add", "origin", origin_url],
+    ):
+        subprocess.run(argv, cwd=repo, capture_output=True, check=True)  # noqa: S603, S607 - arguments are not user-controlled
+
+
+def test_capture_git_context_stores_credential_free_remote(tmp_path: Path) -> None:
+    # Real git repo whose origin carries credentials (M3, real-path test).
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run_git_init_with_credential_origin(repo, "https://user:ghp_canaryfake123@github.com/o/r.git")
+    ctx = capture_git_context(repo)
+    assert ctx.repo_slug == "o/r"
+    assert ctx.remote_url == "https://github.com/o/r"
+    assert "ghp_canaryfake123" not in (ctx.remote_url or "")
+    assert "@" not in (ctx.remote_url or "")
 
 
 def test_capture_git_context_real_repo(tmp_path: Path) -> None:

--- a/tests/test_archive_sanitize.py
+++ b/tests/test_archive_sanitize.py
@@ -2,7 +2,10 @@
 import json
 from pathlib import Path
 
+import pytest
+
 from daydream.archive import sanitize
+from daydream.archive import scan as scan_module
 
 
 def _seed_bronze_bundle(archive_dir: Path, session_id: str, remote_url: str) -> Path:
@@ -52,3 +55,43 @@ def test_resume_skips_completed_items(tmp_path: Path) -> None:
     after = (archive_dir / "sanitized" / "a" / "manifest.json").stat().st_mtime_ns
     assert before == after  # M19: completed items not re-processed
     assert (archive_dir / "sanitized" / "b" / "manifest.json").exists()
+
+
+def test_derivative_stays_quarantined_until_scan_passes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive_dir = tmp_path / "archive"
+    src = _seed_bronze_bundle(archive_dir, "s1", "https://github.com/o/r")
+    # force the release scan to fail closed during sanitization
+    monkeypatch.setattr(
+        scan_module, "scan_run_dir", lambda _: scan_module.ScanResult(clean=False)
+    )
+    result = sanitize.sanitize_bundle(src, archive_dir)
+    assert result.released is False  # M16
+    assert (archive_dir / "quarantine" / "s1").is_dir()
+    assert not (archive_dir / "sanitized" / "s1" / "manifest.json").exists()
+
+
+def test_corpus_projection_reads_only_sanitized_paths(tmp_path: Path) -> None:
+    from daydream.training.corpus import _build_record
+
+    # M17: a projection row pointed at a bronze run_dir containing a dirty URL
+    # resolves its inputs from the sanitized derivative when one exists.
+    archive_dir = tmp_path / "archive"
+    _seed_bronze_bundle(archive_dir, "s1", "https://user:ghp_canaryfake123@github.com/o/r")
+    sanitize.sanitize_bundle(archive_dir / "runs" / "s1", archive_dir)
+    row = {"archive_path": str(archive_dir / "runs" / "s1"), "session_id": "s1"}
+    projected = _build_record(row, {}, None)  # existing corpus entrypoint
+    assert projected is not None
+    assert "ghp_canaryfake123" not in json.dumps(projected)
+
+
+def test_corpus_projection_refuses_affected_bundle_without_derivative(tmp_path: Path) -> None:
+    from daydream.training.corpus import _build_record
+
+    # M17 fail-closed: affected bundle with no released derivative is skipped,
+    # never read raw.
+    archive_dir = tmp_path / "archive"
+    _seed_bronze_bundle(archive_dir, "s1", "https://user:ghp_canaryfake123@github.com/o/r")
+    row = {"archive_path": str(archive_dir / "runs" / "s1"), "session_id": "s1"}
+    assert _build_record(row, {}, None) is None

--- a/tests/test_archive_sanitize.py
+++ b/tests/test_archive_sanitize.py
@@ -57,6 +57,50 @@ def test_resume_skips_completed_items(tmp_path: Path) -> None:
     assert (archive_dir / "sanitized" / "b" / "manifest.json").exists()
 
 
+def test_text_file_token_only_userinfo_and_query_credentials_are_sanitized(
+    tmp_path: Path,
+) -> None:
+    """M16: extended text rules (token-only userinfo, query credentials) are
+    applied so the derivative passes the release scan instead of quarantining."""
+    archive_dir = tmp_path / "archive"
+    run_dir = archive_dir / "runs" / "s1"
+    run_dir.mkdir(parents=True)
+    (run_dir / "manifest.json").write_text(
+        json.dumps({"session_id": "s1", "git": {"remote_url": "https://github.com/o/r"}})
+    )
+    (run_dir / "review-output.md").write_text(
+        "clone https://x-access-token@github.com/o/r.git\n"
+        "fetch https://example.com/repo?token=abc123\n"
+        "auth https://example.com/api?client=1&access_token=abcdef\n"
+    )
+    result = sanitize.sanitize_bundle(run_dir, archive_dir)
+    assert result.released  # extended rules applied; release scan clean
+    text = (archive_dir / "sanitized" / "s1" / "review-output.md").read_text()
+    assert "x-access-token" not in text
+    assert "token=abc123" not in text
+    assert "access_token=abcdef" not in text
+
+
+def test_archive_pass_continues_past_unreadable_bundle(tmp_path: Path) -> None:
+    """One bad bundle never stops the pass (M19): a bundle whose binary file
+    fails UTF-8 decode is quarantined and later bundles are still sanitized."""
+    archive_dir = tmp_path / "archive"
+    bad = archive_dir / "runs" / "bad"
+    bad.mkdir(parents=True)
+    (bad / "manifest.json").write_text(json.dumps({"session_id": "bad"}))
+    (bad / "binary.bin").write_bytes(b"\x00\xff\xfe")
+    _seed_bronze_bundle(archive_dir, "good", "https://github.com/o/r")
+    results = sanitize.sanitize_archive(archive_dir)
+    assert [r.session_id for r in results] == ["good"]
+    assert results[0].released
+    audit = [
+        json.loads(line)
+        for line in (archive_dir / "sanitized" / "audit.jsonl").read_text().splitlines()
+    ]
+    statuses = {line["session_id"]: line["status"] for line in audit}
+    assert statuses == {"bad": "quarantined", "good": "sanitized"}
+
+
 def test_derivative_stays_quarantined_until_scan_passes(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_archive_sanitize.py
+++ b/tests/test_archive_sanitize.py
@@ -1,0 +1,54 @@
+"""Legacy bronze bundle sanitizer (issue #981 M14/M15/M19)."""
+import json
+from pathlib import Path
+
+from daydream.archive import sanitize
+
+
+def _seed_bronze_bundle(archive_dir: Path, session_id: str, remote_url: str) -> Path:
+    run_dir = archive_dir / "runs" / session_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "manifest.json").write_text(
+        json.dumps({"session_id": session_id, "git": {"remote_url": remote_url, "repo_slug": "o/r"}})
+    )
+    (run_dir / "diff.patch").write_text("+TOKEN=ghp_canaryfake123\n")
+    return run_dir
+
+
+def test_derivative_is_credential_free_and_source_untouched(tmp_path: Path) -> None:
+    archive_dir = tmp_path / "archive"
+    src = _seed_bronze_bundle(archive_dir, "s1", "https://user:ghp_canaryfake123@github.com/o/r")
+    sanitize.sanitize_bundle(src, archive_dir)
+    # source byte-identical (M14)
+    assert "ghp_canaryfake123" in (src / "manifest.json").read_text()
+    # derivative exists under sanitized/ and is clean
+    out_dir = archive_dir / "sanitized" / "s1"
+    assert (out_dir / "manifest.json").exists()
+    assert "ghp_canaryfake123" not in (out_dir / "manifest.json").read_text()
+    assert "ghp_canaryfake123" not in (out_dir / "diff.patch").read_text()
+
+
+def test_digest_is_stable_and_audit_record_links(tmp_path: Path) -> None:
+    archive_dir = tmp_path / "archive"
+    src = _seed_bronze_bundle(archive_dir, "s1", "https://github.com/o/r")
+    d1 = sanitize.sanitize_bundle(src, archive_dir)
+    d2 = sanitize.sanitize_bundle(src, archive_dir)
+    assert d1.derivative_digest == d2.derivative_digest  # M15: reproducible
+    ledger = json.loads((archive_dir / "sanitized" / "audit.jsonl").read_text().splitlines()[-1])
+    assert ledger["source"] == str(src)
+    assert ledger["derivative_digest"] == d1.derivative_digest
+
+
+def test_resume_skips_completed_items(tmp_path: Path) -> None:
+    archive_dir = tmp_path / "archive"
+    for sid in ("a", "b"):
+        _seed_bronze_bundle(archive_dir, sid, "https://github.com/o/r")
+    sanitize.sanitize_archive(archive_dir)  # first pass completes both
+    # delete derivative b and re-run: only b is re-processed (a untouched mtime)
+    before = (archive_dir / "sanitized" / "a" / "manifest.json").stat().st_mtime_ns
+    # simulate partial state (b's derivative dir exists but manifest missing)
+    (archive_dir / "sanitized" / "b" / "manifest.json").unlink()
+    sanitize.sanitize_archive(archive_dir)
+    after = (archive_dir / "sanitized" / "a" / "manifest.json").stat().st_mtime_ns
+    assert before == after  # M19: completed items not re-processed
+    assert (archive_dir / "sanitized" / "b" / "manifest.json").exists()

--- a/tests/test_archive_sanitize.py
+++ b/tests/test_archive_sanitize.py
@@ -95,3 +95,16 @@ def test_corpus_projection_refuses_affected_bundle_without_derivative(tmp_path: 
     _seed_bronze_bundle(archive_dir, "s1", "https://user:ghp_canaryfake123@github.com/o/r")
     row = {"archive_path": str(archive_dir / "runs" / "s1"), "session_id": "s1"}
     assert _build_record(row, {}, None) is None
+
+
+def test_inventory_counts_by_category_without_values(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    archive_dir = tmp_path / "archive"
+    _seed_bronze_bundle(archive_dir, "s1", "https://user:p@github.com/o/r")
+    _seed_bronze_bundle(archive_dir, "s2", "https://x-access-token@github.com/o/r")
+    _seed_bronze_bundle(archive_dir, "s3", "https://github.com/o/r")
+    sanitize.report_inventory(archive_dir)
+    out = capsys.readouterr().out
+    assert "userinfo" in out and "2" in out  # two affected bundles
+    assert "ghp" not in out and "user:p" not in out  # no values, ever

--- a/tests/test_archive_sanitize.py
+++ b/tests/test_archive_sanitize.py
@@ -8,8 +8,10 @@ from daydream.archive import sanitize
 from daydream.archive import scan as scan_module
 
 
-def _seed_bronze_bundle(archive_dir: Path, session_id: str, remote_url: str) -> Path:
-    run_dir = archive_dir / "runs" / session_id
+def _seed_bronze_bundle(
+    archive_dir: Path, session_id: str, remote_url: str, *, dir_name: str | None = None
+) -> Path:
+    run_dir = archive_dir / "runs" / (dir_name or session_id)
     run_dir.mkdir(parents=True, exist_ok=True)
     (run_dir / "manifest.json").write_text(
         json.dumps({"session_id": session_id, "git": {"remote_url": remote_url, "repo_slug": "o/r"}})
@@ -44,17 +46,21 @@ def test_digest_is_stable_and_audit_record_links(tmp_path: Path) -> None:
 
 def test_resume_skips_completed_items(tmp_path: Path) -> None:
     archive_dir = tmp_path / "archive"
-    for sid in ("a", "b"):
-        _seed_bronze_bundle(archive_dir, sid, "https://github.com/o/r")
+    # Seed bundles whose manifest session_id differs from the run-dir name so
+    # the M19 resume key (dir name vs manifest session_id) is not masked.
+    _seed_bronze_bundle(archive_dir, "a-session", "https://github.com/o/r", dir_name="a")
+    _seed_bronze_bundle(archive_dir, "b-session", "https://github.com/o/r", dir_name="b")
     sanitize.sanitize_archive(archive_dir)  # first pass completes both
-    # delete derivative b and re-run: only b is re-processed (a untouched mtime)
-    before = (archive_dir / "sanitized" / "a" / "manifest.json").stat().st_mtime_ns
+    audit_path = archive_dir / "sanitized" / "audit.jsonl"
+    assert len(audit_path.read_text().splitlines()) == 2
     # simulate partial state (b's derivative dir exists but manifest missing)
-    (archive_dir / "sanitized" / "b" / "manifest.json").unlink()
+    (archive_dir / "sanitized" / "b-session" / "manifest.json").unlink()
     sanitize.sanitize_archive(archive_dir)
-    after = (archive_dir / "sanitized" / "a" / "manifest.json").stat().st_mtime_ns
-    assert before == after  # M19: completed items not re-processed
-    assert (archive_dir / "sanitized" / "b" / "manifest.json").exists()
+    # M19: completed items not re-processed — a's derivative is left in place
+    # (no extra audit line), while b's is rebuilt (a new audit line).
+    assert (archive_dir / "sanitized" / "a-session" / "manifest.json").exists()
+    assert (archive_dir / "sanitized" / "b-session" / "manifest.json").exists()
+    assert len(audit_path.read_text().splitlines()) == 3  # only b re-processed
 
 
 def test_text_file_token_only_userinfo_and_query_credentials_are_sanitized(
@@ -122,9 +128,17 @@ def test_corpus_projection_reads_only_sanitized_paths(tmp_path: Path) -> None:
     # M17: a projection row pointed at a bronze run_dir containing a dirty URL
     # resolves its inputs from the sanitized derivative when one exists.
     archive_dir = tmp_path / "archive"
-    _seed_bronze_bundle(archive_dir, "s1", "https://user:ghp_canaryfake123@github.com/o/r")
-    sanitize.sanitize_bundle(archive_dir / "runs" / "s1", archive_dir)
-    row = {"archive_path": str(archive_dir / "runs" / "s1"), "session_id": "s1"}
+    run_dir = _seed_bronze_bundle(
+        archive_dir, "s1", "https://user:ghp_canaryfake123@github.com/o/r"
+    )
+    # The canary must flow into the projected record were the raw bundle read
+    # (review-output.md is read for content at projection), so the security half
+    # is observable: only the sanitized derivative keeps it out.
+    (run_dir / "review-output.md").write_text(
+        "clone https://x-access-token=ghp_canaryfake123@github.com/o/r.git\n"
+    )
+    sanitize.sanitize_bundle(run_dir, archive_dir)
+    row = {"archive_path": str(run_dir), "session_id": "s1"}
     projected = _build_record(row, {}, None)  # existing corpus entrypoint
     assert projected is not None
     assert "ghp_canaryfake123" not in json.dumps(projected)

--- a/tests/test_archive_scan.py
+++ b/tests/test_archive_scan.py
@@ -56,6 +56,17 @@ def test_canary_in_patch_file_flagged(tmp_path: Path) -> None:
     assert not scan.scan_run_dir(run_dir).clean
 
 
+def test_already_redacted_markers_skip(tmp_path: Path) -> None:
+    """Marker-skip branch: a credential-shaped value whose match carries a
+    [REDACTED_*] marker is already-safe sanitizer output, so it must not be
+    flagged (scan.py skips such matches instead of re-reporting them)."""
+    run_dir = tmp_path / "run"
+    _write_manifest(
+        run_dir, "https://user:[REDACTED_PASSWORD]@github.com/o/r.git"
+    )
+    assert scan.scan_run_dir(run_dir).clean
+
+
 def test_scan_failure_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     run_dir = tmp_path / "run"
     _write_manifest(run_dir, "https://github.com/o/r")

--- a/tests/test_archive_scan.py
+++ b/tests/test_archive_scan.py
@@ -29,6 +29,19 @@ def test_token_only_userinfo_flagged(tmp_path: Path) -> None:
     assert not scan.scan_run_dir(run_dir).clean
 
 
+def test_query_credential_keys_single_source(tmp_path: Path) -> None:
+    """git_safe._CREDENTIAL_QUERY_KEYS is the one key set for the scan's
+    query-credential rule — a key added there widens this gate automatically."""
+    from daydream.archive.git_safe import _CREDENTIAL_QUERY_KEYS
+
+    for key in _CREDENTIAL_QUERY_KEYS:
+        run_dir = tmp_path / f"run-{key}"
+        _write_manifest(run_dir, f"https://example.com/repo?{key}=abc123")
+        assert any(
+            f.category == "query_credential" for f in scan.scan_run_dir(run_dir).findings
+        )
+
+
 def test_clean_bundle_passes(tmp_path: Path) -> None:
     run_dir = tmp_path / "run"
     _write_manifest(run_dir, "https://github.com/o/r")

--- a/tests/test_archive_scan.py
+++ b/tests/test_archive_scan.py
@@ -1,0 +1,51 @@
+"""Fail-closed bundle secret scanner (issue #981 M9/M11/M13)."""
+import json
+from pathlib import Path
+
+import pytest
+
+from daydream.archive import scan
+
+
+def _write_manifest(run_dir: Path, remote_url: str) -> None:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "manifest.json").write_text(json.dumps({"git": {"remote_url": remote_url}}))
+
+
+def test_scan_flags_credential_url_in_manifest(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    _write_manifest(run_dir, "https://user:ghp_canaryfake123@github.com/o/r.git")
+    result = scan.scan_run_dir(run_dir)
+    assert not result.clean
+    # M11: safe reporting only — field name + file name, never the value
+    assert result.findings[0].path == "manifest.json"
+    assert "git.remote_url" in result.findings[0].location
+    assert "ghp_canaryfake123" not in result.summary()  # canary never echoed
+
+
+def test_token_only_userinfo_flagged(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    _write_manifest(run_dir, "https://x-access-token@github.com/o/r")
+    assert not scan.scan_run_dir(run_dir).clean
+
+
+def test_clean_bundle_passes(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    _write_manifest(run_dir, "https://github.com/o/r")
+    (run_dir / "diff.patch").write_text("+++ b/f.py\n+print('hi')\n")
+    assert scan.scan_run_dir(run_dir).clean
+
+
+def test_canary_in_patch_file_flagged(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    _write_manifest(run_dir, "https://github.com/o/r")
+    (run_dir / "diff.patch").write_text("+TOKEN=ghp_canaryfake123\n")
+    assert not scan.scan_run_dir(run_dir).clean
+
+
+def test_scan_failure_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    run_dir = tmp_path / "run"
+    _write_manifest(run_dir, "https://github.com/o/r")
+    monkeypatch.setattr(scan, "_scan_text", lambda _t: (_ for _ in ()).throw(RuntimeError("boom")))
+    result = scan.scan_run_dir(run_dir)
+    assert not result.clean  # M-constraint: any scanner error blocks egress

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -2079,9 +2079,9 @@ def test_clone_error_message_never_contains_remote_url(tmp_path: Path) -> None:
 
 def test_clone_error_message_redacts_stderr_url_echo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Even when git's stderr echoes the URL, the raised message is redacted."""
-    real_run = git_ops.subprocess.run
+    real_run = subprocess.run
 
-    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+    def fake_run(args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(
             args,
             128,
@@ -2091,7 +2091,7 @@ def test_clone_error_message_redacts_stderr_url_echo(tmp_path: Path, monkeypatch
             ),
         )
 
-    monkeypatch.setattr(git_ops.subprocess, "run", fake_run)
+    monkeypatch.setattr("daydream.git_ops.subprocess.run", fake_run)
     with pytest.raises(GitError) as excinfo:
         git_ops.clone("https://user:ghp_canaryfake123@unreachable.invalid/o/r.git", tmp_path / "t", timeout=5)
     assert "ghp_canaryfake123" not in str(excinfo.value)

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -2065,3 +2065,34 @@ def test_worktree_add_with_lock_reason_arms_lock_atomically(
     locked = git_dir / "worktrees" / wt.name / "locked"
     assert locked.is_file()
     assert "run-A" in locked.read_text(encoding="utf-8")
+
+
+def test_clone_error_message_never_contains_remote_url(tmp_path: Path) -> None:
+    """GitError from clone() must not echo a credential-bearing remote URL (issue #981)."""
+    with pytest.raises(GitError) as excinfo:
+        git_ops.clone("https://user:ghp_canaryfake123@unreachable.invalid/o/r.git", tmp_path / "t", timeout=5)
+    message = str(excinfo.value)
+    assert "ghp_canaryfake123" not in message
+    assert "user:" not in message
+    assert "unreachable.invalid" in message  # host is safe to keep
+
+
+def test_clone_error_message_redacts_stderr_url_echo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Even when git's stderr echoes the URL, the raised message is redacted."""
+    real_run = git_ops.subprocess.run
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args,
+            128,
+            stderr=(
+                "fatal: unable to access 'https://user:ghp_canaryfake123@unreachable.invalid/o/r.git/': "
+                "Could not resolve host"
+            ),
+        )
+
+    monkeypatch.setattr(git_ops.subprocess, "run", fake_run)
+    with pytest.raises(GitError) as excinfo:
+        git_ops.clone("https://user:ghp_canaryfake123@unreachable.invalid/o/r.git", tmp_path / "t", timeout=5)
+    assert "ghp_canaryfake123" not in str(excinfo.value)
+    assert real_run is not None

--- a/tests/test_git_safe.py
+++ b/tests/test_git_safe.py
@@ -1,0 +1,52 @@
+"""Credential-safe Git URL normalizer (issue #981 M1/M2/M5)."""
+import pytest
+
+from daydream.archive.git_safe import classify_remote_url, normalize_remote_url
+
+
+@pytest.mark.parametrize(
+    ("raw", "slug", "url_out"),
+    [
+        # M2: user:pass@ userinfo
+        ("https://user:ghp_abc123@github.com/o/r.git", "o/r", "https://github.com/o/r"),
+        # M2: token-only user@ (x-access-token form)
+        ("https://x-access-token@github.com/o/r", "o/r", "https://github.com/o/r"),
+        # M2: percent-encoded userinfo
+        ("https://user%40corp:p%40ss@github.com/o/r.git", "o/r", "https://github.com/o/r"),
+        # M2: SCP form
+        ("git@github.com:o/r.git", "o/r", "https://github.com/o/r"),
+        # M2: credential-like query params
+        ("https://github.com/o/r?token=abc&foo=bar", "o/r", "https://github.com/o/r"),
+        # M5: benign HTTPS passes through
+        ("https://github.com/o/r", "o/r", "https://github.com/o/r"),
+        # M5: benign SSH URL (ssh:// scheme)
+        ("ssh://git@github.com/o/r.git", "o/r", "https://github.com/o/r"),
+        # slug preserved through .git strip and trailing slash
+        ("https://github.com/o/r/", "o/r", "https://github.com/o/r"),
+    ],
+)
+def test_normalize_strips_credentials_and_keeps_identity(raw: str, slug: str, url_out: str) -> None:
+    identity, url = normalize_remote_url(raw)
+    assert identity == slug
+    assert url == url_out
+    # M3 invariant: no userinfo, no credential query value survives
+    assert "@" not in (url or "")
+    assert "token=" not in (url or "")
+
+
+def test_normalize_unparseable_returns_none_identity() -> None:
+    identity, url = normalize_remote_url("not a url at all")
+    assert identity is None
+
+
+def test_classify_reports_category() -> None:
+    # S2: triage categories
+    assert classify_remote_url("https://u:p@github.com/o/r") == ["userinfo"]
+    assert classify_remote_url("https://tok@github.com/o/r") == ["userinfo"]
+    assert classify_remote_url("https://github.com/o/r?token=x") == ["query"]
+    assert classify_remote_url("https://github.com/o/r") == []
+
+
+def test_normalize_rejects_non_github_host_identity() -> None:
+    identity, _ = normalize_remote_url("https://evil.example.com/o/r")
+    assert identity is None  # host not in allowlist -> no trusted identity

--- a/tests/test_hub_upload.py
+++ b/tests/test_hub_upload.py
@@ -1,6 +1,7 @@
 # tests/test_hub_upload.py
 from __future__ import annotations
 
+import json
 import time
 from pathlib import Path
 from typing import Any
@@ -230,3 +231,52 @@ def test_upload_run_bundle_retries_commit_conflict(
 class _BoomApi:
     def __init__(self, token: str | None = None) -> None:
         raise AssertionError("HfApi must not be instantiated without HF_TOKEN")
+
+
+def _write_manifest_with_remote(run_dir: Path, remote_url: str) -> None:
+    """Write a manifest.json whose git context carries *remote_url*."""
+    (run_dir / "manifest.json").write_text(
+        json.dumps({"git": {"remote_url": remote_url}}), encoding="utf-8"
+    )
+
+
+def _install_fake_hfapi(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Swap hub.HfApi for a fake; return the list of upload_folder invocations."""
+    calls: list[dict[str, Any]] = []
+
+    class FakeApi(_BaseFakeApi):
+        def upload_folder(self, **kw: Any) -> None:
+            calls.append(kw)
+
+    monkeypatch.setattr(hub, "HfApi", FakeApi)
+    return calls
+
+
+def test_upload_refused_when_bundle_contains_credential(
+    hf_run_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_manifest_with_remote(hf_run_dir, "https://user:ghp_canaryfake123@github.com/o/r")
+    uploads = _install_fake_hfapi(monkeypatch)
+    assert hub.upload_run_bundle(hf_run_dir, "org/ds", "s1") is False
+    assert uploads == []  # upload_folder never invoked
+
+
+def test_upload_canary_never_echoed_in_warning(
+    hf_run_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_manifest_with_remote(hf_run_dir, "https://user:ghp_canaryfake123@github.com/o/r")
+    _install_fake_hfapi(monkeypatch)
+    hub.upload_run_bundle(hf_run_dir, "org/ds", "s1")
+    out = capsys.readouterr().out + capsys.readouterr().err
+    assert "ghp_canaryfake123" not in out
+
+
+def test_upload_proceeds_for_clean_bundle(
+    hf_run_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_manifest_with_remote(hf_run_dir, "https://github.com/o/r")
+    uploads = _install_fake_hfapi(monkeypatch)
+    assert hub.upload_run_bundle(hf_run_dir, "org/ds", "s1") is True
+    assert len(uploads) == 1

--- a/tests/test_training_corpus.py
+++ b/tests/test_training_corpus.py
@@ -506,6 +506,7 @@ def test_build_record_emits_posterior_discriminator_only_for_labeled(tmp_path: P
         reward=labeled_reward,
         composite_reward=labeled_composite,
     )
+    assert rec_labeled is not None
     intrinsic_reward, intrinsic_composite = _annotation_reward(_ann_with_intrinsic_reward_json(), "s")
     rec_intrinsic = _build_record(
         manifest_row,
@@ -515,6 +516,7 @@ def test_build_record_emits_posterior_discriminator_only_for_labeled(tmp_path: P
         reward=intrinsic_reward,
         composite_reward=intrinsic_composite,
     )
+    assert rec_intrinsic is not None
 
     assert "posterior_cost" in rec_labeled["reward"]
     assert "posterior_cost" not in rec_intrinsic.get("reward", {})

--- a/tests/test_training_harvest.py
+++ b/tests/test_training_harvest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+import subprocess
 from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import Any
@@ -1203,11 +1204,11 @@ def test_resolve_repo_for_row_clones_when_source_path_missing(tmp_path: Path, mo
     """Falls through to clone when source_path is absent."""
     cache = tmp_path / "cache"
 
-    def fake_clone(url: str, target: Path, **kwargs: object) -> None:
+    def fake_clone(url: str, target: Path, token: str | None = None, **kwargs: object) -> None:
         target.mkdir(parents=True, exist_ok=True)
         (target / ".git").mkdir()
 
-    monkeypatch.setattr("daydream.training.harvest.git_ops.clone", fake_clone)
+    monkeypatch.setattr("daydream.training.harvest.git_ops.clone_with_token", fake_clone)
     row = {"source_path": None, "remote_url": "https://github.com/org/repo.git", "repo_slug": "org/repo"}
     result = _resolve_repo_for_row(row, clone_cache=cache)
     assert result == cache / "org" / "repo"
@@ -1222,7 +1223,10 @@ def test_resolve_repo_for_row_fetches_existing_cache(tmp_path: Path, monkeypatch
 
     fetched = []
     monkeypatch.setattr("daydream.training.harvest.git_ops.fetch", lambda repo, remote="origin": fetched.append(repo))
-    monkeypatch.setattr("daydream.training.harvest.git_ops.clone", lambda *a, **k: pytest.fail("should not clone"))
+    monkeypatch.setattr(
+        "daydream.training.harvest.git_ops.clone_with_token",
+        lambda *a, **k: pytest.fail("should not clone"),
+    )
     row = {"source_path": None, "remote_url": "https://github.com/org/repo.git", "repo_slug": "org/repo"}
     result = _resolve_repo_for_row(row, clone_cache=cache)
     assert result == cached_repo
@@ -1241,8 +1245,8 @@ def test_resolve_repo_for_row_clone_failure_returns_none(tmp_path: Path, monkeyp
     cache = tmp_path / "cache"
 
     monkeypatch.setattr(
-        "daydream.training.harvest.git_ops.clone",
-        lambda url, target, **kwargs: (_ for _ in ()).throw(GitError("network error")),
+        "daydream.training.harvest.git_ops.clone_with_token",
+        lambda url, target, token=None, **kwargs: (_ for _ in ()).throw(GitError("network error")),
     )
     row = {"source_path": None, "remote_url": "https://github.com/org/repo.git", "repo_slug": "org/repo"}
     result = _resolve_repo_for_row(row, clone_cache=cache)
@@ -1465,8 +1469,74 @@ def test_repo_resolution_warning_is_value_free(
         "remote_url": "https://user:ghp_canaryfake123@github.com/o/r",
         "repo_slug": "o/r",
     }
-    monkeypatch.setattr("daydream.training.harvest.git_ops.clone", _raise_git_error_with_url)
+    monkeypatch.setattr("daydream.training.harvest.git_ops.clone_with_token", _raise_git_error_with_url)
     _resolve_repo_for_row(row, clone_cache=tmp_path / "cache")
     out = capsys.readouterr().out
     assert "ghp_canaryfake123" not in out
     assert "o/r" in out  # slug IS present
+
+
+# identity-based repo resolution (issue #981): never clone the archived raw URL
+
+
+def test_resolve_repo_never_clones_raw_archived_url(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seen: list[str] = []
+
+    def fake_clone(url: str, target: Path, token: str | None = None, **kw: object) -> None:
+        seen.append(url)
+        target.mkdir(parents=True, exist_ok=True)
+        (target / ".git").mkdir()
+
+    monkeypatch.setattr("daydream.training.harvest.git_ops.clone_with_token", fake_clone)
+    row = {
+        "source_path": None,
+        "remote_url": "https://user:ghp_canaryfake123@github.com/o/r",
+        "repo_slug": "o/r",
+    }
+    assert _resolve_repo_for_row(row, clone_cache=tmp_path / "cache") == tmp_path / "cache" / "o" / "r"
+    assert seen == ["https://github.com/o/r"]  # reconstructed identity, never raw
+
+
+def test_resolve_repo_fails_closed_on_untrusted_host(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "daydream.training.harvest.git_ops.clone_with_token",
+        lambda url, t, **kw: calls.append(url),
+    )
+    row = {"source_path": None, "remote_url": "https://evil.example.com/o/r", "repo_slug": "o/r"}
+    assert _resolve_repo_for_row(row, clone_cache=tmp_path / "cache") is None  # M7: no clone attempt
+    assert calls == []
+
+
+def test_resolve_repo_fails_closed_on_file_scheme(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "daydream.training.harvest.git_ops.clone_with_token",
+        lambda url, t, **kw: calls.append(url),
+    )
+    row = {"source_path": None, "remote_url": "file:///tmp/evil", "repo_slug": "o/r"}
+    assert _resolve_repo_for_row(row, clone_cache=tmp_path / "cache") is None
+    assert calls == []
+
+
+def test_token_never_in_url(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("DAYDREAM_GIT_TOKEN", "ghp_envtokfake123")
+    seen: list[list[str]] = []
+
+    def _recording_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        seen.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("daydream.git_ops.subprocess.run", _recording_run)
+    _resolve_repo_for_row(
+        {"source_path": None, "remote_url": "https://github.com/o/r", "repo_slug": "o/r"},
+        clone_cache=tmp_path / "cache",
+    )
+    assert seen
+    assert all("ghp_envtokfake123" not in " ".join(c) for c in seen)  # M8

--- a/tests/test_training_harvest.py
+++ b/tests/test_training_harvest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import json
 import re
 import subprocess
@@ -1539,7 +1540,13 @@ def test_token_never_in_url(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> 
         clone_cache=tmp_path / "cache",
     )
     assert seen
-    assert all("ghp_envtokfake123" not in " ".join(c) for c in seen)  # M8
+    # The base64 Authorization header is trivially recoverable, so the token's
+    # absence on argv must hold for both the raw token and its encoded form.
+    basic = base64.b64encode(b"x-access-token:ghp_envtokfake123").decode()
+    for c in seen:
+        joined = " ".join(c)
+        assert "ghp_envtokfake123" not in joined  # raw token never on argv
+        assert basic not in joined  # recoverable base64 never on argv either (M8)
 
 
 def test_hub_import_rejects_unsanitized_affected_bundle(tmp_path: Path) -> None:

--- a/tests/test_training_harvest.py
+++ b/tests/test_training_harvest.py
@@ -1540,3 +1540,37 @@ def test_token_never_in_url(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> 
     )
     assert seen
     assert all("ghp_envtokfake123" not in " ".join(c) for c in seen)  # M8
+
+
+def test_hub_import_rejects_unsanitized_affected_bundle(tmp_path: Path) -> None:
+    """M18: an affected (credential-bearing) incoming bundle with no released
+    derivative is quarantined locally and skipped — never imported raw."""
+    from daydream.archive import sanitize
+
+    archive_dir = tmp_path / "archive"
+    incoming = archive_dir / "incoming" / "s1"
+    incoming.mkdir(parents=True)
+    (incoming / "manifest.json").write_text(
+        json.dumps(
+            {"session_id": "s1", "git": {"remote_url": "https://user:ghp_canaryfake123@github.com/o/r"}}
+        )
+    )
+    result = sanitize.import_bundle(incoming, archive_dir)
+    assert result.imported is False or result.quarantined
+    assert (archive_dir / "quarantine" / "s1").is_dir()
+    assert not incoming.exists()
+
+
+def test_hub_import_accepts_clean_bundle_in_place(tmp_path: Path) -> None:
+    from daydream.archive import sanitize
+
+    archive_dir = tmp_path / "archive"
+    incoming = archive_dir / "incoming" / "s2"
+    incoming.mkdir(parents=True)
+    (incoming / "manifest.json").write_text(
+        json.dumps({"session_id": "s2", "git": {"remote_url": "https://github.com/o/r"}})
+    )
+    result = sanitize.import_bundle(incoming, archive_dir)
+    assert result.imported is True
+    assert result.quarantined is False
+    assert incoming.exists()

--- a/tests/test_training_harvest.py
+++ b/tests/test_training_harvest.py
@@ -1450,3 +1450,23 @@ async def test_harvest_degrades_benign_giterror_rows_instead_of_dropping(
     assert cov["pr_attached"] == 10  # every row stays PR-attached and annotated
     assert cov["decisive"] == 8  # only the 8 merged rows are decisive; "unknown" is not
     assert cov["coverage"] == 0.8
+
+
+def _raise_git_error_with_url(*args: object, **kwargs: object) -> None:
+    raise GitError("git clone https://user:ghp_canaryfake123@github.com/o/r failed: boom")
+
+
+def test_repo_resolution_warning_is_value_free(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The harvest repo-resolution warning must never contain the remote URL (issue #981)."""
+    row = {
+        "source_path": None,
+        "remote_url": "https://user:ghp_canaryfake123@github.com/o/r",
+        "repo_slug": "o/r",
+    }
+    monkeypatch.setattr("daydream.training.harvest.git_ops.clone", _raise_git_error_with_url)
+    _resolve_repo_for_row(row, clone_cache=tmp_path / "cache")
+    out = capsys.readouterr().out
+    assert "ghp_canaryfake123" not in out
+    assert "o/r" in out  # slug IS present

--- a/tests/test_training_record.py
+++ b/tests/test_training_record.py
@@ -141,6 +141,7 @@ def test_record_validates_against_v1_schema() -> None:
         ]
     }
     record = _build_record(manifest_row, trajectory, stack="python")
+    assert record is not None
     schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
     jsonschema.validate(record, schema)
 
@@ -162,11 +163,13 @@ def test_record_diff_ref_reflects_archive_state(
     trajectory: dict[str, Any] = {"steps": []}
 
     record = _build_record(manifest_row, trajectory, stack="python")
+    assert record is not None
     assert record[ref_name]["available"] is False
     assert record[ref_name]["archive_relative_path"] == archive_relative_path
 
     (tmp_path / archive_relative_path).write_text("diff --git a/x b/x\n", encoding="utf-8")
     record = _build_record(manifest_row, trajectory, stack="python")
+    assert record is not None
     assert record[ref_name]["available"] is True
 
 
@@ -185,6 +188,7 @@ def test_record_code_context_sourced_from_manifest_dict(tmp_path: Path) -> None:
     trajectory: dict[str, Any] = {"steps": []}
 
     record = _build_record(manifest_row, trajectory, stack="python", manifest=manifest)
+    assert record is not None
 
     assert record["code_context"]["base_sha"] == "deadbeef" * 5
     assert record["code_context"]["changed_files"] == ["src/a.py", "src/b.py"]
@@ -194,6 +198,7 @@ def test_record_code_context_falls_back_when_manifest_missing(tmp_path: Path) ->
     """A manifest without ``code_context`` yields base_sha=None, changed_files=[]."""
     manifest_row = _make_manifest_row(archive_path=str(tmp_path))
     record = _build_record(manifest_row, {"steps": []}, stack=None, manifest={})
+    assert record is not None
 
     assert record["code_context"]["base_sha"] is None
     assert record["code_context"]["changed_files"] == []
@@ -208,12 +213,14 @@ def test_record_review_output_loaded_from_archive(tmp_path: Path) -> None:
     manifest_row = _make_manifest_row(archive_path=str(tmp_path))
 
     record = _build_record(manifest_row, {"steps": []}, stack="python")
+    assert record is not None
     assert record["review_output"] == "# Review\nLooks good.\n"
 
 
 def test_record_review_output_none_when_file_absent(tmp_path: Path) -> None:
     manifest_row = _make_manifest_row(archive_path=str(tmp_path))
     record = _build_record(manifest_row, {"steps": []}, stack="python")
+    assert record is not None
     assert record["review_output"] is None
 
 
@@ -236,6 +243,7 @@ def test_build_record_reads_review_output_from_deep_subdir(tmp_path: Path) -> No
     (archive / "deep" / "review-output.md").write_text("# Deep review\n")
     row = {"session_id": "abc", "archive_path": str(archive), "outcome_labels": "[]"}
     record = _build_record(row, _MIN_TRAJECTORY, stack="python", manifest={})
+    assert record is not None
     assert record["review_output"] == "# Deep review\n"
 
 
@@ -247,6 +255,7 @@ def test_build_record_prefers_root_review_output_over_deep(tmp_path: Path) -> No
     (archive / "deep" / "review-output.md").write_text("# Deep\n")
     row = {"session_id": "abc", "archive_path": str(archive), "outcome_labels": "[]"}
     record = _build_record(row, _MIN_TRAJECTORY, stack="python", manifest={})
+    assert record is not None
     assert record["review_output"] == "# Root\n"
 
 
@@ -255,6 +264,7 @@ def test_build_record_surfaces_rubric_when_present(tmp_path: Path) -> None:
            "outcome_labels": '["accepted"]'}
     annotation = {"rubric_json": '{"pr_merge": {"merged": true}, "posterior_source": "pr_review"}'}
     record = _build_record(row, _MIN_TRAJECTORY, stack="python", manifest={}, annotation=annotation)
+    assert record is not None
     assert record["rubric"] == {"pr_merge": {"merged": True}, "posterior_source": "pr_review"}
     assert record["posterior_source"] == "pr_review"
 
@@ -262,6 +272,7 @@ def test_build_record_surfaces_rubric_when_present(tmp_path: Path) -> None:
 def test_build_record_omits_rubric_when_absent(tmp_path: Path) -> None:
     row = {"session_id": "abc", "archive_path": str(tmp_path), "outcome_labels": "[]"}
     record = _build_record(row, _MIN_TRAJECTORY, stack="python", manifest={})
+    assert record is not None
     assert "rubric" not in record
     assert "posterior_source" not in record
 
@@ -271,4 +282,5 @@ def test_build_record_propagates_local_branch_source(tmp_path: Path) -> None:
            "outcome_labels": '["accepted"]'}
     annotation = {"rubric_json": '{"posterior_source": "local_branch"}'}
     record = _build_record(row, _MIN_TRAJECTORY, stack="python", manifest={}, annotation=annotation)
+    assert record is not None
     assert record["posterior_source"] == "local_branch"


### PR DESCRIPTION
Closes #981

## Summary
- Credential-safe Git URL normalizer used across manifest construction, indexing, import, and upload — stores canonical repo identity and credential-free URLs only (userinfo and credential-like query params stripped).
- Harvest-time repository resolution now clones/fetches only from validated canonical identity + configured credential mechanism; never executes archived raw remote URLs, accepts arbitrary host/scheme, or echoes credential-bearing Git errors.
- Fail-closed secret preflight on all serialized manifest fields and uploaded bundle artifacts: upload refused on credential-like residue, local run preserved, only safe counts/field names/digests reported.
- Content-addressed, credential-free staging derivative sanitizer for existing bronze archive bundles.

## Process
- Implemented from plan.md (TDD), two sequential daydream deep-precision review rounds (round 1 + round 2 on fresh VMs); round-2 fix commit 0d9b595 pushed.
- Deterministic-authorship gate: AUTHORS_OK (verify-branch-authors.sh).

## Test Plan
- [x] Unit + integration tests green on review VMs (DAYDREAM_EXIT=0)
- [ ] CI green on this PR