### PR TITLE
fix(review): unify severity vocabulary, demotion-aware approval gate, wire arbiter/suppression knobs (Closes #972)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -480,7 +480,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **review:** Precision-mode arbiter suppression for evidenced-but-minor findings ([#248](https://github.com/existential-birds/daydream/pull/248))
 
-  The arbiter now drops findings that are evidence-backed but below a severity/confidence threshold, reducing noise from technically-correct-but-trivial comments. Suppressed findings are logged to a sidecar audit file. Activated via `--precision` or automatically when the diff exceeds 500 lines.
+  The arbiter now drops findings that are evidence-backed but below a severity/confidence threshold, reducing noise from technically-correct-but-trivial comments. Suppressed findings are logged to a sidecar audit file. Activated via the `--precision` flag (or the corresponding file-config setting); there is no automatic diff-size trigger.
 
 - **training:** Stable per-finding join key for accept/reject labels ([#246](https://github.com/existential-birds/daydream/pull/246))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **benchmark:** require `requested_base_sha` on ready/imported snapshot records; `migrate.migrate_workspace` backfills the field from `original_base_sha` on both v1 upgrade and v2 repair passes so pre-provenance-split workspaces stay loadable.
 
 - **tests:** enforce the branch-coverage floor (`fail_under`) on full-suite runs only — coverage flags moved out of global pytest `addopts` into `make test` and the CI check job so targeted `pytest tests/foo.py` runs stay plain, and `coverage.xml` is retained on failed runs for the CI artifact upload (#932)
+- **review:** unify finding-severity policy under a single canonical `low|medium|high` vocabulary (`daydream/severity.py`) with a host-owned severity rubric appended to every severity-assigning prompt; missing or off-vocabulary severities no longer render with a fabricated `medium` default (issue #972)
+- **review:** make the approval gate demotion-aware — findings demoted for an unverified citation (beyond-tolerance location) and asserted off-vocabulary severity strings block approval even when their folded severity is non-blocking; location demotion is now non-destructive (the original severity is preserved and surfaced on the report) (issue #972)
+- **review:** expose `Arbitration.min_severity` and `Suppression.severity_classes` review-profile knobs for the arbiter and suppression passes; arbitration defaults to high-severity (plus contested) findings and suppression defaults to low-severity findings only
 
 
 ## [0.28.0] - 2026-08-27

--- a/daydream/benchmark/harbor/build.py
+++ b/daydream/benchmark/harbor/build.py
@@ -23,6 +23,7 @@ from typing import Any
 
 from pydantic import ValidationError
 
+from daydream import severity
 from daydream.benchmark import schema, snapshot, storage, workspace
 from daydream.benchmark.harbor import verifier_core as vc
 
@@ -196,6 +197,18 @@ def bounded_pr_context(
     )
 
 
+def _gold_severity_label(value: object) -> str:
+    """Label a gold-finding severity for Task.md emission.
+
+    Canonical severity values are lowercased via ``severity.normalize_severity``;
+    a null (or otherwise unknown) severity becomes the explicit labeled string
+    ``"unknown"``. This is a gold-fixture emission label, not a canonical
+    severity level (R6.2: mapped-or-labeled, never silent).
+    """
+    normalized = severity.normalize_severity(value)
+    return normalized if normalized is not None else "unknown"
+
+
 def render_task_spec(case_doc: dict[str, Any], *, instruction: str) -> bytes:
     """Deterministic per-case Task.md render; the single source shared by [r] approval and compile (D3)."""
     pull_request = case_doc.get("pull_request") or {}
@@ -205,7 +218,7 @@ def render_task_spec(case_doc: dict[str, Any], *, instruction: str) -> bytes:
     if findings:
         counts: dict[str, int] = {}
         for finding in findings:
-            severity = str(finding.get("severity") or "unknown")
+            severity = _gold_severity_label(finding.get("severity"))
             counts[severity] = counts.get(severity, 0) + 1
         severity_summary = ", ".join(
             f"{count} {severity}" for severity, count in sorted(counts.items())
@@ -217,7 +230,7 @@ def render_task_spec(case_doc: dict[str, Any], *, instruction: str) -> bytes:
             "are graded, never the raw review-thread text."
         )
         stable_summary = "\n".join(
-            f"- {f.get('severity') or 'unknown'}: {f.get('title') or ''}"
+            f"- {_gold_severity_label(f.get('severity'))}: {f.get('title') or ''}"
             for f in findings
         )
     else:

--- a/daydream/deep/arbiter.py
+++ b/daydream/deep/arbiter.py
@@ -33,7 +33,13 @@ from daydream.severity import CANONICAL_LEVELS, SEVERITY_RANK
 
 
 def _severity(record: dict[str, Any]) -> str:
-    """Normalize a record's severity to a lowercase string ("" when absent)."""
+    """Normalize a record's severity to a lowercase string ("" when absent).
+
+    Unified fallback policy for the arbiter's own view (issue #972 R3.1): an
+    empty string means "absent severity ⇒ not selectable by severity"; the
+    contested path still applies to such records. No severity value is
+    fabricated here.
+    """
     value = record.get("severity")
     return value.lower() if isinstance(value, str) else ""
 

--- a/daydream/deep/arbiter.py
+++ b/daydream/deep/arbiter.py
@@ -7,13 +7,16 @@ arbiter, so it can be unit-tested against adversarial shapes (mixed-severity,
 multi-stack, same-``file:line`` collisions) independent of any agent call.
 
 A record is selected when EITHER:
-  - it is ``severity == "high"`` (heavy findings always get the Opus second look), OR
+  - its severity is at or above the ``min_severity`` knob (default ``"high"``;
+    heavy findings always get the Opus second look), OR
   - it is *contested*: the same ``(file, line)`` location is surfaced by two or
     more distinct stacks that disagree on severity. Divergent severity at one
     location is exactly the case a cheaper model is most likely to mis-rank.
 
-Low/medium uncontested findings never reach the arbiter — that is the whole
-point of the cost split.
+With the default knob, low/medium uncontested findings never reach the arbiter —
+that is the whole point of the cost split. Lowering ``min_severity`` (the
+profile's ``Arbitration.min_severity``) widens the severity branch; the contested
+branch is unaffected.
 
 Residual risk: a genuinely-high issue that a cheaper per-stack model under-ranked
 as an isolated, uncontested medium/low at a unique location is also never
@@ -25,6 +28,8 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Iterable
 from typing import Any
+
+from daydream.severity import CANONICAL_LEVELS, SEVERITY_RANK
 
 
 def _severity(record: dict[str, Any]) -> str:
@@ -39,27 +44,50 @@ def _confidence(record: dict[str, Any]) -> str:
     return value.upper() if isinstance(value, str) else ""
 
 
+def _at_or_above(min_severity: str) -> frozenset[str]:
+    """Return every canonical level ranked at or above ``min_severity``.
+
+    Raises:
+        ValueError: If ``min_severity`` is not a canonical severity level
+            (fail loud — an unknown knob value must never silently widen or
+            narrow selection).
+    """
+    if min_severity not in SEVERITY_RANK:
+        raise ValueError(
+            f"min_severity must be one of {', '.join(CANONICAL_LEVELS)}; got {min_severity!r}"
+        )
+    rank = SEVERITY_RANK[min_severity]
+    return frozenset(level for level, level_rank in SEVERITY_RANK.items() if level_rank <= rank)
+
+
 def select_arbiter_targets(
     records: list[dict[str, Any]],
     sources: list[str],
+    min_severity: str = "high",
 ) -> list[int]:
     """Return the indices of records that need arbiter re-review.
 
     Args:
         records: Parsed per-stack records (each ideally carrying ``severity``,
             ``file``, ``line``). Records missing ``severity`` are treated as
-            non-high and only become selectable through the contested path.
+            below the severity knob and only become selectable through the
+            contested path.
         sources: Per-record originating stack name, positionally aligned with
             ``records`` (``len(sources) == len(records)``).
+        min_severity: Lowest canonical severity level the severity branch
+            selects (``"high"`` by default; ``"medium"`` also selects medium
+            records, ``"low"`` selects everything). The contested branch is
+            independent of this knob.
 
     Returns:
         Sorted, de-duplicated list of indices into ``records`` selected for the
-        arbiter: every high-severity record, plus every record at a
+        arbiter: every record at or above ``min_severity``, plus every record at a
         ``(file, line)`` location contested across >=2 stacks with divergent
         severity.
 
     Raises:
-        ValueError: If ``records`` and ``sources`` differ in length.
+        ValueError: If ``records`` and ``sources`` differ in length, or if
+            ``min_severity`` is not a canonical severity level.
     """
     if len(records) != len(sources):
         raise ValueError(
@@ -68,9 +96,12 @@ def select_arbiter_targets(
 
     selected: set[int] = set()
 
-    # High severity: always arbitrated.
+    # Severity branch: everything at or above the ``min_severity`` knob
+    # (default "high" — the profile's ``Arbitration.min_severity`` governs this
+    # in the production path).
+    eligible = _at_or_above(min_severity)
     for i, record in enumerate(records):
-        if _severity(record) == "high":
+        if _severity(record) in eligible:
             selected.add(i)
 
     # Contested: same (file, line) reported by >=2 distinct stacks that disagree

--- a/daydream/deep/arbiter.py
+++ b/daydream/deep/arbiter.py
@@ -31,6 +31,10 @@ from typing import Any
 
 from daydream.severity import CANONICAL_LEVELS, SEVERITY_RANK
 
+# Canonical confidence vocabulary (uppercase HIGH|MEDIUM|LOW schema enum,
+# mirroring ``review_profile._CONFIDENCE_LEVELS``).
+_CONFIDENCE_LEVELS: frozenset[str] = frozenset(("HIGH", "MEDIUM", "LOW"))
+
 
 def _severity(record: dict[str, Any]) -> str:
     """Normalize a record's severity to a lowercase string ("" when absent).
@@ -70,6 +74,7 @@ def select_arbiter_targets(
     records: list[dict[str, Any]],
     sources: list[str],
     min_severity: str = "high",
+    contested_location: bool = True,
 ) -> list[int]:
     """Return the indices of records that need arbiter re-review.
 
@@ -84,12 +89,17 @@ def select_arbiter_targets(
             selects (``"high"`` by default; ``"medium"`` also selects medium
             records, ``"low"`` selects everything). The contested branch is
             independent of this knob.
+        contested_location: Whether the contested branch (same ``(file, line)``
+            reported by >=2 distinct stacks with divergent severity) selects
+            records (default ``True``; the profile's
+            ``Arbitration.contested_location`` governs this in the production
+            path).
 
     Returns:
         Sorted, de-duplicated list of indices into ``records`` selected for the
         arbiter: every record at or above ``min_severity``, plus every record at a
         ``(file, line)`` location contested across >=2 stacks with divergent
-        severity.
+        severity (when ``contested_location`` is enabled).
 
     Raises:
         ValueError: If ``records`` and ``sources`` differ in length, or if
@@ -112,15 +122,16 @@ def select_arbiter_targets(
 
     # Contested: same (file, line) reported by >=2 distinct stacks that disagree
     # on severity. Group by location, then test cross-stack severity divergence.
-    by_location: dict[tuple[Any, Any], list[int]] = defaultdict(list)
-    for i, record in enumerate(records):
-        by_location[(record.get("file"), record.get("line"))].append(i)
+    if contested_location:
+        by_location: dict[tuple[Any, Any], list[int]] = defaultdict(list)
+        for i, record in enumerate(records):
+            by_location[(record.get("file"), record.get("line"))].append(i)
 
-    for indices in by_location.values():
-        stacks = {sources[i] for i in indices}
-        severities = {_severity(records[i]) for i in indices if _severity(records[i])}
-        if len(stacks) >= 2 and len(severities) >= 2:
-            selected.update(indices)
+        for indices in by_location.values():
+            stacks = {sources[i] for i in indices}
+            severities = {_severity(records[i]) for i in indices if _severity(records[i])}
+            if len(stacks) >= 2 and len(severities) >= 2:
+                selected.update(indices)
 
     return sorted(selected)
 
@@ -130,12 +141,13 @@ def select_suppression_targets(
     sources: list[str],
     exclude: Iterable[int] = (),
     severity_classes: tuple[str, ...] = ("low",),
+    confidence_classes: tuple[str, ...] = ("LOW",),
 ) -> list[int]:
     """Return indices of borderline, uncontested records for the suppression pass (#232).
 
     The precision-mode suppression pass gives a skeptical LLM second opinion to
     *evidenced-but-minor* findings the arbiter never scrutinizes: records that are
-    ``confidence == "LOW"`` and/or low-severity (per ``severity_classes``) and are
+    in ``confidence_classes`` and/or low-severity (per ``severity_classes``) and are
     neither high-severity nor contested. It mirrors :func:`select_arbiter_targets` as a
     pure, side-effect-free predicate so it can be unit-tested against adversarial
     shapes independent of any agent call.
@@ -144,7 +156,7 @@ def select_suppression_targets(
     must never touch them, so callers pass the arbiter's target indices as
     ``exclude``. Because that set already covers every high-severity and contested
     record, excluding it leaves only higher-severity uncontested records -- of
-    which the LOW-confidence ones and those in ``severity_classes`` are the
+    which the ones in ``confidence_classes`` and those in ``severity_classes`` are the
     borderline findings selected here.
 
     Args:
@@ -160,15 +172,20 @@ def select_suppression_targets(
         severity_classes: Canonical severity levels the severity branch selects
             (default ``("low",)``; the profile's ``Suppression.severity_classes``
             governs this in the production path).
+        confidence_classes: Canonical uppercase confidence levels the confidence
+            branch selects (default ``("LOW",)``; the profile's
+            ``Suppression.confidence_classes`` governs this in the production
+            path).
 
     Returns:
         Sorted, de-duplicated list of indices into ``records`` selected for the
-        suppression pass: every ``exclude``-free record that is LOW-confidence
-        or low-severity (per ``severity_classes``).
+        suppression pass: every ``exclude``-free record that is in
+        ``confidence_classes`` or low-severity (per ``severity_classes``).
 
     Raises:
-        ValueError: If ``records`` and ``sources`` differ in length, or if
-            ``severity_classes`` contains a non-canonical severity value.
+        ValueError: If ``records`` and ``sources`` differ in length, if
+            ``severity_classes`` contains a non-canonical severity value, or if
+            ``confidence_classes`` contains a non-canonical confidence value.
     """
     classes = frozenset(
         cls.lower() for cls in severity_classes
@@ -178,6 +195,13 @@ def select_suppression_targets(
         raise ValueError(
             f"severity_classes must be a subset of {', '.join(sorted(CANONICAL_LEVELS))}; "
             f"got unknown value(s): {', '.join(sorted(unknown))}"
+        )
+    confidence = frozenset(cnf.upper() for cnf in confidence_classes)
+    unknown_conf = confidence - _CONFIDENCE_LEVELS
+    if unknown_conf:
+        raise ValueError(
+            f"confidence_classes must be a subset of {', '.join(sorted(_CONFIDENCE_LEVELS))}; "
+            f"got unknown value(s): {', '.join(sorted(unknown_conf))}"
         )
     if len(records) != len(sources):
         raise ValueError(
@@ -189,6 +213,6 @@ def select_suppression_targets(
     for i, record in enumerate(records):
         if i in excluded:
             continue
-        if _confidence(record) == "LOW" or _severity(record) in classes:
+        if _confidence(record) in confidence or _severity(record) in classes:
             selected.append(i)
     return selected

--- a/daydream/deep/arbiter.py
+++ b/daydream/deep/arbiter.py
@@ -123,21 +123,23 @@ def select_suppression_targets(
     records: list[dict[str, Any]],
     sources: list[str],
     exclude: Iterable[int] = (),
+    severity_classes: tuple[str, ...] = ("low",),
 ) -> list[int]:
     """Return indices of borderline, uncontested records for the suppression pass (#232).
 
     The precision-mode suppression pass gives a skeptical LLM second opinion to
     *evidenced-but-minor* findings the arbiter never scrutinizes: records that are
-    ``confidence == "LOW"`` and/or ``severity == "low"`` and are neither
-    high-severity nor contested. It mirrors :func:`select_arbiter_targets` as a
+    ``confidence == "LOW"`` and/or low-severity (per ``severity_classes``) and are
+    neither high-severity nor contested. It mirrors :func:`select_arbiter_targets` as a
     pure, side-effect-free predicate so it can be unit-tested against adversarial
     shapes independent of any agent call.
 
     High-severity and contested records reach the *arbiter* (fail-open); this pass
     must never touch them, so callers pass the arbiter's target indices as
     ``exclude``. Because that set already covers every high-severity and contested
-    record, excluding it leaves only low/medium uncontested records -- of which the
-    LOW-confidence / low-severity ones are the borderline findings selected here.
+    record, excluding it leaves only higher-severity uncontested records -- of
+    which the LOW-confidence ones and those in ``severity_classes`` are the
+    borderline findings selected here.
 
     Args:
         records: Parsed per-stack records (each ideally carrying ``severity`` and
@@ -149,14 +151,28 @@ def select_suppression_targets(
         exclude: Indices to skip (the arbiter target set). A record already routed
             to the arbiter is never a suppression target.
 
+        severity_classes: Canonical severity levels the severity branch selects
+            (default ``("low",)``; the profile's ``Suppression.severity_classes``
+            governs this in the production path).
+
     Returns:
         Sorted, de-duplicated list of indices into ``records`` selected for the
         suppression pass: every ``exclude``-free record that is LOW-confidence
-        or low-severity.
+        or low-severity (per ``severity_classes``).
 
     Raises:
-        ValueError: If ``records`` and ``sources`` differ in length.
+        ValueError: If ``records`` and ``sources`` differ in length, or if
+            ``severity_classes`` contains a non-canonical severity value.
     """
+    classes = frozenset(
+        cls.lower() for cls in severity_classes
+    )
+    unknown = classes - frozenset(CANONICAL_LEVELS)
+    if unknown:
+        raise ValueError(
+            f"severity_classes must be a subset of {', '.join(sorted(CANONICAL_LEVELS))}; "
+            f"got unknown value(s): {', '.join(sorted(unknown))}"
+        )
     if len(records) != len(sources):
         raise ValueError(
             f"records/sources length mismatch: {len(records)} != {len(sources)}"
@@ -167,6 +183,6 @@ def select_suppression_targets(
     for i, record in enumerate(records):
         if i in excluded:
             continue
-        if _confidence(record) == "LOW" or _severity(record) == "low":
+        if _confidence(record) == "LOW" or _severity(record) in classes:
             selected.append(i)
     return selected

--- a/daydream/deep/coverage.py
+++ b/daydream/deep/coverage.py
@@ -43,6 +43,7 @@ from daydream.phases import (
     _dependency_impact_instructions,
     _exploration_pointer,
 )
+from daydream.severity import SEVERITY_RUBRIC
 
 
 def _path_component_matches(absolute: str, relative: str) -> bool:
@@ -585,5 +586,6 @@ def build_uncovered_sweep_prompt(
     parts.append(_confidence_and_convention_instructions())
     parts.append(_dependency_impact_instructions())
     parts.append(VERIFICATION_PROTOCOL_INSTRUCTION)
+    parts.append(SEVERITY_RUBRIC)
     parts.append(f"Work in {cwd}. Write your full review to {output_path}.")
     return "\n\n".join(parts)

--- a/daydream/deep/location_validator.py
+++ b/daydream/deep/location_validator.py
@@ -112,14 +112,19 @@ def validate_records(
         the nearest hunk boundary (the record's ``nearest_hunk`` start or end)
         and align the ``file:line`` citation in ``record["evidence"]`` to the
         snapped line, so the evidence and snapped line never diverge.
-      - ``distance > tolerance``: demote the record in place -- lower
+      - ``distance > tolerance``: demote the record non-destructively --
+        preserve the original severity in ``record["severity_before_demotion"]``,
+        set ``record["location_distrust"] = True`` (machine-readable demotion
+        mark, read by the approval gate and the report renderer), then lower
         ``record["severity"]`` to ``"low"``, ``record["confidence"]`` to
         ``"LOW"`` and set ``record["location_note"]`` to a demotion annotation
         naming the file, cited line, nearest hunk and distance -- so the
-        unverified citation no longer reaches the report at full severity.
+        unverified citation no longer reaches the report at full severity while
+        the originally adjudicated severity remains recoverable (issue #972 R2).
 
     The mutation surface is the snap (line + evidence) and the demote
-    (severity/confidence/location_note); an in-hunk record is untouched.
+    (severity_before_demotion/location_distrust/severity/confidence/location_note);
+    an in-hunk record is untouched.
     Records without a file/line (or with a non-int line) pass through unchanged.
     Never raises. Returns the (possibly mutated) record list.
     """
@@ -148,12 +153,18 @@ def validate_records(
             _align_evidence(record, file, line, snapped)
         else:
             start, end = check.nearest_hunk
+            # Non-destructive demotion (issue #972 R2): keep the originally
+            # adjudicated severity recoverable and mark the record so the
+            # approval gate and the report renderer can surface the demotion
+            # instead of silently reading the lowered value as the verdict.
+            record["severity_before_demotion"] = record.get("severity")
+            record["location_distrust"] = True
             record["severity"] = "low"
             record["confidence"] = "LOW"
             record["location_note"] = (
                 f"cited line {line} in {file} is {check.distance} lines from the "
                 f"nearest hunk {start}..{end} (tolerance {tolerance}); demoted to "
-                f"informational (unverified citation)."
+                f"low (unverified citation)."
             )
     return records
 

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -201,7 +201,8 @@ def total_agent_count(stack_count: int) -> int:
 
     Formula: 2 (TTT intent + alternative-review) + N per-stack reviews
     + N per-stack parse passes + 1 cross-stack merge + 1 conditional
-    arbiter (Opus pass over high-severity / contested findings). The
+    arbiter (Opus pass over findings at or above the profile's
+    ``Arbitration.min_severity`` — default high — plus contested findings). The
     arbiter fires when qualifying findings exist; the pre-flight estimate
     always includes it so users aren't surprised by the extra Opus call.
     The fix-gate agents are user-gated and excluded from the estimate.
@@ -1749,7 +1750,10 @@ async def _step_arbiter(ctx: FlowContext) -> None:
         ctx.pipeline().arbitration.enabled
         and (config.start_at != "merge" or not adjudication_marker.is_file())
     ):
-        arbiter_targets = select_arbiter_targets(all_records, record_sources)
+        arbiter_targets = select_arbiter_targets(
+            all_records, record_sources,
+            min_severity=ctx.pipeline().arbitration.min_severity,
+        )
         # Capture the identities of records the arbiter will see, before
         # `_apply_adjudication_verdicts` compacts the list (#232). `arbiter_targets`
         # are indices into this pre-apply list; once records are dropped the

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -1753,6 +1753,7 @@ async def _step_arbiter(ctx: FlowContext) -> None:
         arbiter_targets = select_arbiter_targets(
             all_records, record_sources,
             min_severity=ctx.pipeline().arbitration.min_severity,
+            contested_location=ctx.pipeline().arbitration.contested_location,
         )
         # Capture the identities of records the arbiter will see, before
         # `_apply_adjudication_verdicts` compacts the list (#232). `arbiter_targets`
@@ -1814,6 +1815,7 @@ async def _step_arbiter(ctx: FlowContext) -> None:
                 record_sources,
                 suppression_exclude,
                 severity_classes=ctx.pipeline().suppression.severity_classes,
+                confidence_classes=ctx.pipeline().suppression.confidence_classes,
             )
             if suppression_targets:
                 async with phase_scope(DaydreamPhase.DEEP, stage="suppression"):

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -1799,7 +1799,8 @@ async def _step_arbiter(ctx: FlowContext) -> None:
         # off (product default) this block never runs, `select_suppression_targets`
         # is never called, and arbiter output is byte-identical. When on, it gives
         # the borderline (LOW-confidence / low-severity uncontested) findings the
-        # arbiter never sees a skeptical second opinion, dropping any it cannot
+        # arbiter never sees a skeptical second opinion (for the profile's
+        # ``Suppression.severity_classes`` severity classes), dropping any it cannot
         # confirm (fail-CLOSED, the inverse of the arbiter). The arbiter target set
         # is the exclusion set so nothing high-severity / contested is re-judged
         # here. One batched agent call, resolved via the cheaper `suppression`
@@ -1809,7 +1810,10 @@ async def _step_arbiter(ctx: FlowContext) -> None:
                 i for i, r in enumerate(all_records) if id(r) in arbitrated_ids
             ]
             suppression_targets = select_suppression_targets(
-                all_records, record_sources, suppression_exclude
+                all_records,
+                record_sources,
+                suppression_exclude,
+                severity_classes=ctx.pipeline().suppression.severity_classes,
             )
             if suppression_targets:
                 async with phase_scope(DaydreamPhase.DEEP, stage="suppression"):

--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -757,11 +757,12 @@ def build_arbiter_prompt(
         "its `arb_id` unchanged. For each:\n"
         "  - keep: true if the finding is real and actionable; false to reject a "
         "false positive or a non-issue (rejected findings are dropped entirely).\n"
-        "  - severity: your adjudicated high | medium | low (you may change it).\n"
+        "  - severity: your adjudicated severity per the rubric below (you may "
+        "change it).\n"
         "  - confidence: your adjudicated HIGH | MEDIUM | LOW.\n"
         "  - description: a sharpened one-line summary (keep it about the same "
         "finding; do not repurpose the slot for a different issue).\n"
-        "  - rationale: why it matters, grounded in what you actually read."
+        "  - rationale: why it matters, grounded in what you actually read.\n\n" + SEVERITY_RUBRIC
     )
     return "\n\n".join(parts)
 
@@ -802,7 +803,7 @@ def build_supervise_prompt(
         "id and choose exactly one action: allow, drop, edit, or hold. Explain "
         "the decision in reason. For edit, revise only severity, confidence, "
         "description, rationale, or evidence; never file, line, or id. Missing "
-        "verdicts are treated as allow by the host."
+        "verdicts are treated as allow by the host.\n\n" + SEVERITY_RUBRIC
     )
     return "\n\n".join(parts)
 
@@ -862,12 +863,12 @@ def build_suppression_prompt(
         "its `sup_id` unchanged. For each:\n"
         "  - keep: true ONLY if you cite confirming evidence that the finding is "
         "real and actionable; false to drop an unconfirmed / immaterial finding.\n"
-        "  - severity: your adjudicated high | medium | low.\n"
+        "  - severity: your adjudicated severity per the rubric below.\n"
         "  - confidence: your adjudicated HIGH | MEDIUM | LOW.\n"
         "  - description: a sharpened one-line summary of the SAME finding.\n"
         "  - rationale: for a keep, the concrete evidence you found; for a drop, "
         "why it is not confirmable.\n"
-        "  - evidence: the grounded `file:line` citation backing a kept finding."
+        "  - evidence: the grounded `file:line` citation backing a kept finding.\n\n" + SEVERITY_RUBRIC
     )
     return "\n\n".join(parts)
 
@@ -983,7 +984,7 @@ def build_merge_prompt(
         "concern spanning multiple stacks, and \"wonder\" for an "
         "alternatives.json-sourced finding. (Structural findings are appended by "
         "the host -- do NOT emit them yourself.)\n"
-        "  - severity: \"high\" | \"medium\" | \"low\".\n"
+        "  - severity: one level per the rubric below.\n"
         "  - confidence: \"HIGH\" | \"MEDIUM\" | \"LOW\".\n"
         "  - file: the FULL repo-relative path exactly as it appears in the per-stack "
         "records (e.g. `services/my-svc/handler.py`, not just `handler.py`). "
@@ -1009,7 +1010,7 @@ def build_merge_prompt(
         "findings (same concern across files), emit ONE item with the primary file "
         "and list every other affected file in the `related_files` array (NOT buried "
         "in the rationale).\n"
-        "  - Do not invent findings not supported by the source records."
+        "  - Do not invent findings not supported by the source records.\n\n" + SEVERITY_RUBRIC
     )
     if resumed_from_arbiter:
         # Resuming the arbiter's session replays ITS context, which holds the

--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -35,6 +35,7 @@ from daydream.prompts.wire_contract import (
     WIRE_CONTRACT_GENERIC_INSTRUCTION,
     WIRE_CONTRACT_RUST_INSTRUCTION,
 )
+from daydream.severity import SEVERITY_RUBRIC
 
 DOC_REVIEW_NOTICE = (
     "[Notice] Dedicated documentation review is planned but not yet "
@@ -128,7 +129,7 @@ VERIFICATION_PROTOCOL_INSTRUCTION = (
     'tool output, a file:line citation, or an explicit "none" / "N matches" '
     'after a repo search. Never claim you "looked" without an artifact.\n'
     "  Gate 3 (severity): calibrate severity to impact; a request for net-new "
-    "code that did not exist in scope is Informational only.\n"
+    "code that did not exist in scope is at most low.\n"
     "Do NOT report a finding that fails any gate."
 )
 
@@ -628,6 +629,7 @@ def build_per_stack_prompt(
     parts.append(ANTI_SLOP_RUBRIC_INSTRUCTION)
     parts.append(VERIFICATION_PROTOCOL_INSTRUCTION)
     parts.append(CONFIG_FLOW_TRACE_INSTRUCTION)
+    parts.append(SEVERITY_RUBRIC)
     parts.append(TRUST_MODEL_INSTRUCTION)
     if stack_name == "rust":
         parts.append(WIRE_CONTRACT_RUST_INSTRUCTION)
@@ -695,6 +697,7 @@ def build_structural_prompt(
     parts.append(_full_diff_pointer(diff_path))
     parts.append(strategy)
     parts.append(VERIFICATION_PROTOCOL_INSTRUCTION)
+    parts.append(SEVERITY_RUBRIC)
     parts.append(ANTI_SLOP_RUBRIC_INSTRUCTION)
     parts.append(CROSS_FILE_SYMBOL_EXISTENCE_INSTRUCTION)
     parts.append(TRUST_MODEL_INSTRUCTION)
@@ -1277,6 +1280,7 @@ def build_generic_fallback_prompt(
 
     parts.append(VERIFICATION_PROTOCOL_INSTRUCTION)
     parts.append(CONFIG_FLOW_TRACE_INSTRUCTION)
+    parts.append(SEVERITY_RUBRIC)
     parts.append(TRUST_MODEL_INSTRUCTION)
     parts.append(WIRE_CONTRACT_GENERIC_INSTRUCTION)
     parts.append(f"Write your full review to {output_path}.")

--- a/daydream/findings.py
+++ b/daydream/findings.py
@@ -76,6 +76,11 @@ FINDINGS_SCHEMA: dict[str, Any] = {
                     "severity": {"type": ["string", "null"]},
                     "confidence": {"type": ["string", "null"]},
                     "is_cross_stack": {"type": "boolean"},
+                    # Optional (issue #972 R2): findings written by a Phase A
+                    # that ran location validation carry the demotion mark so
+                    # the poster's approval gate stays demotion-aware. Absent
+                    # on older artifacts — treated as False on load.
+                    "location_distrust": {"type": "boolean"},
                 },
             },
         },
@@ -101,6 +106,8 @@ class ArtifactFinding:
         severity: Severity label, or None.
         confidence: Confidence label, or None.
         is_cross_stack: Whether the finding came from the cross-stack merge.
+        location_distrust: True when location validation demoted the finding
+            (citation beyond tolerance); absent on older artifacts -> False.
     """
 
     fingerprint: str
@@ -112,6 +119,7 @@ class ArtifactFinding:
     severity: str | None
     confidence: str | None
     is_cross_stack: bool
+    location_distrust: bool = False
 
 
 @dataclass
@@ -145,6 +153,7 @@ def _finding_dict(issue: ParsedIssue, *, placement: str, line: int | None) -> di
         "severity": issue.severity,
         "confidence": issue.confidence,
         "is_cross_stack": issue.is_cross_stack,
+        "location_distrust": issue.location_distrust,
     }
 
 

--- a/daydream/findings.py
+++ b/daydream/findings.py
@@ -86,6 +86,12 @@ FINDINGS_SCHEMA: dict[str, Any] = {
                     # block the poster's approval gate; the raw signal rides
                     # through here. Absent on older artifacts -> False on load.
                     "severity_off_vocabulary": {"type": "boolean"},
+                    # Optional: the original severity before a location-
+                    # validation demotion, so the poster's approval gate only
+                    # re-blocks a demoted finding when that original severity
+                    # was itself blocking. Absent on older artifacts -> None on
+                    # load.
+                    "severity_before_demotion": {"type": ["string", "null"]},
                 },
             },
         },
@@ -113,6 +119,10 @@ class ArtifactFinding:
         is_cross_stack: Whether the finding came from the cross-stack merge.
         location_distrust: True when location validation demoted the finding
             (citation beyond tolerance); absent on older artifacts -> False.
+        severity_before_demotion: Original severity before a location-
+            validation demotion, if any; the poster's approval gate checks it
+            so only a demotion from a blocking severity stays blocking. Absent
+            on older artifacts -> None.
         severity_off_vocabulary: True when the finding carried a present
             severity string outside the canonical vocabulary (e.g.
             "critical") that was folded into ``None`` at the boundary. The
@@ -130,6 +140,7 @@ class ArtifactFinding:
     confidence: str | None
     is_cross_stack: bool
     location_distrust: bool = False
+    severity_before_demotion: str | None = None
     severity_off_vocabulary: bool = False
 
 
@@ -165,6 +176,7 @@ def _finding_dict(issue: ParsedIssue, *, placement: str, line: int | None) -> di
         "confidence": issue.confidence,
         "is_cross_stack": issue.is_cross_stack,
         "location_distrust": issue.location_distrust,
+        "severity_before_demotion": issue.severity_before_demotion,
         "severity_off_vocabulary": issue.severity_off_vocabulary,
     }
 

--- a/daydream/findings.py
+++ b/daydream/findings.py
@@ -81,6 +81,11 @@ FINDINGS_SCHEMA: dict[str, Any] = {
                     # the poster's approval gate stays demotion-aware. Absent
                     # on older artifacts — treated as False on load.
                     "location_distrust": {"type": "boolean"},
+                    # Optional (issue #972): present-but-off-canonical severity
+                    # strings fold into ``None`` at the boundary but must still
+                    # block the poster's approval gate; the raw signal rides
+                    # through here. Absent on older artifacts -> False on load.
+                    "severity_off_vocabulary": {"type": "boolean"},
                 },
             },
         },
@@ -108,6 +113,11 @@ class ArtifactFinding:
         is_cross_stack: Whether the finding came from the cross-stack merge.
         location_distrust: True when location validation demoted the finding
             (citation beyond tolerance); absent on older artifacts -> False.
+        severity_off_vocabulary: True when the finding carried a present
+            severity string outside the canonical vocabulary (e.g.
+            "critical") that was folded into ``None`` at the boundary. The
+            poster's approval gate must still block on it, so the raw signal
+            rides through the artifact; absent on older artifacts -> False.
     """
 
     fingerprint: str
@@ -120,6 +130,7 @@ class ArtifactFinding:
     confidence: str | None
     is_cross_stack: bool
     location_distrust: bool = False
+    severity_off_vocabulary: bool = False
 
 
 @dataclass
@@ -154,6 +165,7 @@ def _finding_dict(issue: ParsedIssue, *, placement: str, line: int | None) -> di
         "confidence": issue.confidence,
         "is_cross_stack": issue.is_cross_stack,
         "location_distrust": issue.location_distrust,
+        "severity_off_vocabulary": issue.severity_off_vocabulary,
     }
 
 

--- a/daydream/improve/orchestrator.py
+++ b/daydream/improve/orchestrator.py
@@ -68,6 +68,7 @@ from daydream.improve.plans import (
     record_rejections,
 )
 from daydream.improve.prioritize import (
+    _map_axis_severity,
     aggregate_cross_service,
     leverage_score,
     order_by_leverage,
@@ -1206,16 +1207,14 @@ def _apply_vet_verdicts(
             if verdict.get(field) is not None:
                 corrected[field] = verdict[field]
         # The vet contract uses human-readable severity names while the
-        # prioritizer's axes use the audit vocabulary. Normalize at the host
-        # boundary so aggregation cannot silently promote every vetted item to
-        # its conservative fallback.
+        # prioritizer's axes use the audit vocabulary. Map at the host boundary
+        # via the shared P-BOUNDARY mapper (issue #972 R3.1/R6.2): unknown or
+        # absent values do not pass through raw — the axis is omitted and the
+        # prioritizer drops it instead of promoting to a conservative fallback.
         severity = corrected.get("severity")
-        if isinstance(severity, str):
-            corrected["severity"] = {
-                "high": "HIGH",
-                "medium": "MED",
-                "low": "LOW",
-            }.get(severity.lower(), severity)
+        mapped_severity = _map_axis_severity(severity)
+        if mapped_severity is not None:
+            corrected["severity"] = mapped_severity
         # Unlike the other corrected fields, ``None`` is a meaningful vet
         # correction here: it explicitly retracts an audit-time reuse target.
         if "reuse_target" in verdict:

--- a/daydream/improve/orchestrator.py
+++ b/daydream/improve/orchestrator.py
@@ -1215,6 +1215,11 @@ def _apply_vet_verdicts(
         mapped_severity = _map_axis_severity(severity)
         if mapped_severity is not None:
             corrected["severity"] = mapped_severity
+        elif "severity" in corrected:
+            # Off-vocabulary mappers to None must not pass through raw: omit
+            # the axis so a corrected member and its work package stay in sync
+            # (P-BOUNDARY, issue #972 R3.1/R6.2).
+            del corrected["severity"]
         # Unlike the other corrected fields, ``None`` is a meaningful vet
         # correction here: it explicitly retracts an audit-time reuse target.
         if "reuse_target" in verdict:

--- a/daydream/improve/prioritize.py
+++ b/daydream/improve/prioritize.py
@@ -22,7 +22,7 @@ _IMPACT_ORDER = {"LOW": 0, "MED": 1, "HIGH": 2}
 _EFFORT_UNITS = {"S": 1, "M": 2, "L": 3}
 _RISK_ORDER = {"LOW": 0, "MED": 1, "HIGH": 2}
 _CONFIDENCE_ORDER = {"LOW": 0, "MED": 1, "HIGH": 2}
-_SEVERITY_ORDER = {"LOW": 0, "MED": 1, "HIGH": 2, "CRITICAL": 3}
+_SEVERITY_ORDER = {"LOW": 0, "MED": 1, "HIGH": 2}
 _CHANGE_SHAPES = {
     "delete",
     "reuse",
@@ -452,16 +452,14 @@ def _map_axis_severity(value: object) -> str | None:
     """Map a finding's severity to the audit-axis vocabulary, or ``None``.
 
     Canonical lowercase levels (``daydream.severity``) map to their uppercase
-    axis names; values already in the axis vocabulary pass through as known
-    vocabulary (not an unknown passthrough). Anything else — unknown, absent,
-    ``None`` — maps to ``None`` so the caller can omit the axis instead of
-    promoting it to a conservative fallback (P-BOUNDARY, issue #972 R3.1/R6.2).
+    axis names. Anything else — unknown, absent, ``None``, or off-canonical
+    (e.g. ``"CRITICAL"``) — maps to ``None`` so the caller can omit the axis
+    instead of promoting it to a conservative fallback (P-BOUNDARY, issue
+    #972 R3.1/R6.2).
     """
     normalized = normalize_severity(value)
     if normalized is not None:
         return {"low": "LOW", "medium": "MED", "high": "HIGH"}[normalized]
-    if isinstance(value, str) and value in _SEVERITY_ORDER:
-        return value
     return None
 
 

--- a/daydream/improve/prioritize.py
+++ b/daydream/improve/prioritize.py
@@ -8,6 +8,7 @@ from collections import Counter
 from typing import Any
 
 from daydream.deep.dedup import bigrams, jaccard, normalize_title
+from daydream.severity import normalize_severity
 
 _IMPACT = {"HIGH": 3.0, "MED": 2.0, "LOW": 1.0}
 _EFFORT = {"S": 1.0, "M": 2.0, "L": 3.0}
@@ -328,8 +329,17 @@ def _merge_work_package(findings: list[dict[str, Any]]) -> dict[str, Any]:
         "LOW",
         highest=False,
     )
-    if any("severity" in member for member in members):
-        merged["severity"] = _conservative_axis(members, "severity", _SEVERITY_ORDER, "HIGH")
+    # Unified fallback policy (issue #972 R3.1): when no member carries a
+    # known severity the axis is omitted entirely — no conservative "HIGH"
+    # default is fabricated for severity (the one permitted "high" default is
+    # the structural-lens setdefault in phases.py).
+    severity_values = [
+        axis
+        for member in members
+        if "severity" in member and (axis := _map_axis_severity(member["severity"])) is not None
+    ]
+    if severity_values:
+        merged["severity"] = max(severity_values, key=_SEVERITY_ORDER.__getitem__)
     merged["leverage"] = round(leverage_score(merged), 2)
 
     if len(members) > 1:
@@ -436,6 +446,23 @@ def _combined_change_shape(findings: list[dict[str, Any]]) -> str:
     if "neutral" in shapes:
         return "neutral"
     return "consolidate"
+
+
+def _map_axis_severity(value: object) -> str | None:
+    """Map a finding's severity to the audit-axis vocabulary, or ``None``.
+
+    Canonical lowercase levels (``daydream.severity``) map to their uppercase
+    axis names; values already in the axis vocabulary pass through as known
+    vocabulary (not an unknown passthrough). Anything else — unknown, absent,
+    ``None`` — maps to ``None`` so the caller can omit the axis instead of
+    promoting it to a conservative fallback (P-BOUNDARY, issue #972 R3.1/R6.2).
+    """
+    normalized = normalize_severity(value)
+    if normalized is not None:
+        return {"low": "LOW", "medium": "MED", "high": "HIGH"}[normalized]
+    if isinstance(value, str) and value in _SEVERITY_ORDER:
+        return value
+    return None
 
 
 def _conservative_axis(

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -58,7 +58,7 @@ from daydream.repository_paths import (
 from daydream.repository_paths import (
     path_is_confined,
 )
-from daydream.severity import SEVERITY_RUBRIC
+from daydream.severity import SEVERITY_RANK, SEVERITY_RUBRIC
 from daydream.trajectory import (
     DaydreamPhase,
     TrajectoryRecorder,
@@ -1119,15 +1119,9 @@ def _evidence_gate_then_validate(
     return validate_records(index, evidenced)
 
 
-# Canonical severity ordering shared by the deep fix loop and the shallow fix
-# loop. Defined here (next to normalize_items / MERGED_ITEMS_SCHEMA) so both
-# callers can import a single helper rather than duplicate the map.
-_SEVERITY_RANK: dict[str, int] = {"high": 0, "medium": 1, "low": 2}
-
-
 def severity_sorted(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Stable-sort canonical items by severity (high < medium < low)."""
-    return sorted(items, key=lambda it: _SEVERITY_RANK.get(it.get("severity") or "", 1))
+    return sorted(items, key=lambda it: SEVERITY_RANK.get(it.get("severity") or "", 1))
 
 
 def group_items_by_footprint(items: list[dict[str, Any]]) -> list[tuple[str, list[dict[str, Any]]]]:

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -1539,9 +1539,7 @@ def build_parse_prompt(
     *,
     strategy: str,
     review_output_path: Path,
-    severity_hint: str,
     verdicts_hint: str,
-    severity_field: str,
     verdicts_example: str,
     verdicts_empty: str,
 ) -> str:
@@ -1549,26 +1547,23 @@ def build_parse_prompt(
 
     The profile-owned ``parse`` strategy carries the extraction/dedup judgment
     prose as a template (``copied: daydream.phases.phase_parse_feedback``); the
-    host fills the runtime ``review_output_path`` and the schema/severity/verdict
-    envelope placeholders so the rendered prompt stays byte-identical to the
-    pre-extraction literal.
+    host fills the runtime ``review_output_path`` and the verdict
+    envelope placeholders so the rendered prompt matches the profile-owned
+    extraction strategy (the host-owned severity rubric in
+    ``daydream.severity`` now carries all severity instruction; the former
+    in-prompt severity hint died with the parse stage (issue #972 R3).
 
     Args:
         strategy: The profile-owned ``parse`` strategy content.
         review_output_path: Absolute path to the review markdown to parse.
-        severity_hint: Severity-extraction instruction (empty when the schema
-            does not request a ``severity`` field).
         verdicts_hint: Per-file verdict-surface instruction (empty when
             ``include_verdicts`` is False).
-        severity_field: The schema's severity enum fragment (empty when absent).
         verdicts_example: The schema's verdicts example fragment.
         verdicts_empty: The schema's empty-verdicts fragment.
     """
     return strategy.format(
         review_output_path=review_output_path,
-        severity_hint=severity_hint,
         verdicts_hint=verdicts_hint,
-        severity_field=severity_field,
         verdicts_example=verdicts_example,
         verdicts_empty=verdicts_empty,
     )
@@ -1741,21 +1736,6 @@ async def phase_parse_feedback(
     print_dim(console, f"Model: {backend.model}")
 
     schema = output_schema if output_schema is not None else FEEDBACK_SCHEMA
-    wants_severity = "severity" in (
-        schema.get("properties", {})
-        .get("issues", {})
-        .get("items", {})
-        .get("properties", {})
-    )
-    severity_field = ', "severity": "high|medium|low"' if wants_severity else ""
-    severity_hint = (
-        "\nAlso set a `severity` of high | medium | low for each issue, taken from the "
-        "review's own severity/priority label. Default to high when the review gives "
-        "no explicit severity.\n"
-        if wants_severity
-        else ""
-    )
-
     # Per-file verdict surface (issue #742). Deep-mode's per-stack parse emits
     # the schema-required ``verdicts`` array, so the prompt must teach the
     # verdict-line shape and its sub-fields; otherwise the strict-mode model
@@ -1791,9 +1771,7 @@ async def phase_parse_feedback(
     prompt = build_parse_prompt(
         strategy=strategy,
         review_output_path=review_output_path,
-        severity_hint=severity_hint,
         verdicts_hint=verdicts_hint,
-        severity_field=severity_field,
         verdicts_example=verdicts_example,
         verdicts_empty=verdicts_empty,
     )
@@ -4408,6 +4386,10 @@ def _append_structural_and_write_merged(
                 continue
             item = {**rec, "lens": "structural"}
             item.setdefault("confidence", "HIGH")
+            # The one documented exception to severity.DEFAULT_SEVERITY_POLICY
+            # (R3.3 structural high-conviction invariant): a structural finding
+            # that survived the evidence gate is high-conviction by
+            # construction, so it defaults to ``high``.
             item.setdefault("severity", "high")
             structural_items.append(item)
 

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -4418,9 +4418,11 @@ def _append_structural_and_write_merged(
     # makes that order structurally unreachable (issue #745). The validator
     # snaps in-tolerance citations to the nearest hunk boundary (aligning the
     # evidence citation) and demotes-with-annotation beyond-tolerance ones
-    # (severity/confidence lowered, ``location_note`` carried through
-    # normalize_items), so no unverified citation reaches the report at full
-    # severity. Fail-open: a missing index validates nothing (pre-change
+    # (severity/confidence lowered, ``location_note``, plus the non-destructive
+    # demotion fields ``severity_before_demotion``/``location_distrust``, all
+    # carried through normalize_items unchanged), so no unverified citation
+    # reaches the report at full severity while the original judgment stays
+    # recoverable. Fail-open: a missing index validates nothing (pre-change
     # behavior); the validator never raises and never rejects.
     evidenced = _evidence_gate_then_validate(
         base_items + structural_items, items_path

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -58,6 +58,7 @@ from daydream.repository_paths import (
 from daydream.repository_paths import (
     path_is_confined,
 )
+from daydream.severity import SEVERITY_RUBRIC
 from daydream.trajectory import (
     DaydreamPhase,
     TrajectoryRecorder,
@@ -1530,6 +1531,7 @@ def build_alternative_review_prompt(
     else:
         body = strategy_filled
     parts.append(body + "\n")
+    parts.append(SEVERITY_RUBRIC)
     return "\n".join(parts)
 
 

--- a/daydream/pr_review.py
+++ b/daydream/pr_review.py
@@ -47,6 +47,7 @@ from daydream.extensions import (
 )
 from daydream.git_ops import GitError
 from daydream.pr_comment_renderer import render_run_info_block
+from daydream.severity import normalize_severity
 from daydream.trajectory import TrajectoryRecorder, get_current_recorder
 from daydream.ui import print_error, print_info, print_success, print_warning
 
@@ -254,6 +255,19 @@ def parse_finding_markers(text: str) -> list[str]:
     return FINDING_MARKER_RE.findall(text)
 
 
+def _normalize_severity(raw: dict[str, Any]) -> str | None:
+    """Normalize a raw item's severity against the canonical vocabulary.
+
+    Total: never raises. Present-but-null severities (the wire schema emits
+    ``severity: null``) and omitted keys both map to ``None``, as do unknown
+    or non-string values — never the string ``"none"``. Unknown string
+    severities (e.g. ``"critical"``) also map to ``None`` here; the approval
+    gate independently fails closed on raw strings in paths that skip this
+    helper.
+    """
+    return normalize_severity(raw.get("severity"))
+
+
 def alt_issues_to_parsed(alt_issues: list[dict[str, Any]]) -> list[ParsedIssue]:
     """Convert `phase_alternative_review` dicts into ParsedIssue objects.
 
@@ -274,7 +288,7 @@ def alt_issues_to_parsed(alt_issues: list[dict[str, Any]]) -> list[ParsedIssue]:
         title = str(raw.get("title", "")).strip()
         description = str(raw.get("description", "")).strip()
         recommendation = str(raw.get("recommendation", "")).strip()
-        severity = str(raw.get("severity", "")).strip().lower() or None
+        severity = _normalize_severity(raw)
         confidence = str(raw.get("confidence", "")).strip().upper() or None
         body_parts = []
         if severity:
@@ -316,7 +330,7 @@ def extract_item_fields(
     line_int = int(line) if isinstance(line, int) and not isinstance(line, bool) else None
     description = str(raw.get("description", "")).strip()
     rationale = str(raw.get("rationale", "")).strip()
-    severity = str(raw.get("severity", "")).strip().lower() or None
+    severity = _normalize_severity(raw)
     confidence = str(raw.get("confidence", "")).strip().upper() or None
     is_cross_stack = str(raw.get("lens", "")).strip() == "cross-stack"
     location_distrust = bool(raw.get("location_distrust"))

--- a/daydream/pr_review.py
+++ b/daydream/pr_review.py
@@ -91,6 +91,9 @@ class ParsedIssue:
         fingerprint: Deterministic SHA256 identity for cross-run dedup. Set on
             canonical merged findings and alt-review issues; None on other
             construction paths.
+        location_distrust: True when location validation demoted this finding
+            (its citation was beyond tolerance), issue #972 R2. Blocks approval
+            regardless of the (demoted) severity and renders a demotion note.
     """
 
     path: str
@@ -101,6 +104,7 @@ class ParsedIssue:
     confidence: str | None = None
     severity: str | None = None
     fingerprint: str | None = None
+    location_distrust: bool = False
 
 
 @dataclass
@@ -131,6 +135,8 @@ class ItemFields:
     severity: str | None
     confidence: str | None
     is_cross_stack: bool
+    location_distrust: bool = False
+    severity_before_demotion: str | None = None
 
 
 @dataclass
@@ -313,6 +319,9 @@ def extract_item_fields(
     severity = str(raw.get("severity", "")).strip().lower() or None
     confidence = str(raw.get("confidence", "")).strip().upper() or None
     is_cross_stack = str(raw.get("lens", "")).strip() == "cross-stack"
+    location_distrust = bool(raw.get("location_distrust"))
+    before = raw.get("severity_before_demotion")
+    severity_before_demotion = str(before).strip().lower() or None if before else None
     return ItemFields(
         path=path,
         line_int=line_int,
@@ -321,6 +330,8 @@ def extract_item_fields(
         severity=severity,
         confidence=confidence,
         is_cross_stack=is_cross_stack,
+        location_distrust=location_distrust,
+        severity_before_demotion=severity_before_demotion,
     )
 
 
@@ -348,6 +359,16 @@ def parsed_issues_from_items(items: list[dict[str, Any]]) -> list[ParsedIssue]:
             body_parts.append(f"**Severity:** {fields.severity}")
         if fields.confidence:
             body_parts.append(f"**Confidence:** {fields.confidence}")
+        if fields.location_distrust:
+            # First production reader of the location-distrust signal (issue
+            # #972 R2): the demotion is visible on the report, never silent.
+            if fields.severity_before_demotion:
+                body_parts.append(
+                    "**Location:** unverified citation "
+                    f"(severity demoted from {fields.severity_before_demotion})"
+                )
+            else:
+                body_parts.append("**Location:** unverified citation (severity demoted)")
         if fields.rationale and fields.rationale != fields.description:
             body_parts.append(fields.rationale)
         body = "\n\n".join(body_parts)
@@ -363,6 +384,7 @@ def parsed_issues_from_items(items: list[dict[str, Any]]) -> list[ParsedIssue]:
                 fingerprint=compute_fingerprint(
                     fields.path, fields.description, fields.rationale
                 ),
+                location_distrust=fields.location_distrust,
             )
         )
     return out
@@ -1097,6 +1119,21 @@ def _severity_blocks_approval(severity: str | None) -> bool:
     return severity is not None and severity.lower() not in _NON_BLOCKING_SEVERITIES
 
 
+def _finding_blocks_approval(severity: str | None, location_distrust: bool) -> bool:
+    """Whether one finding blocks an approval, demotion-aware (issue #972 R2).
+
+    A finding marked ``location_distrust=True`` was judged at a higher severity
+    and demoted by location validation (its citation was beyond tolerance);
+    the demoted severity must not silently make it non-blocking. This check is
+    deliberately separate from ``_severity_blocks_approval`` (and NOT folded
+    into ``_NON_BLOCKING_SEVERITIES``) so off-vocabulary severity strings keep
+    failing closed for their own reason.
+    """
+    if location_distrust:
+        return True
+    return _severity_blocks_approval(severity)
+
+
 def _is_clean_review(classified: _ClassifiedIssues, approve_on_clean: bool) -> bool:
     """Whether an opted-in review may post as an approval (issue #343).
 
@@ -1110,7 +1147,8 @@ def _is_clean_review(classified: _ClassifiedIssues, approve_on_clean: bool) -> b
     if not approve_on_clean:
         return False
     return not any(
-        _severity_blocks_approval(issue.severity) for issue in classified.all_issues()
+        _finding_blocks_approval(issue.severity, issue.location_distrust)
+        for issue in classified.all_issues()
     )
 
 
@@ -1490,7 +1528,8 @@ def post_findings_from_artifact(
     # open high finding (#343 R2 F2b). Matched findings are never re-posted
     # as comments — only their severities count here.
     can_approve = approve_on_clean and not any(
-        _severity_blocks_approval(finding.severity) for finding in artifact.findings
+        _finding_blocks_approval(finding.severity, finding.location_distrust)
+        for finding in artifact.findings
     )
 
     if classified.is_empty() and not can_approve:
@@ -1551,4 +1590,5 @@ def _issue_from_artifact_finding(finding: ArtifactFinding) -> ParsedIssue:
         confidence=finding.confidence,
         severity=finding.severity,
         fingerprint=finding.fingerprint,
+        location_distrust=finding.location_distrust,
     )

--- a/daydream/pr_review.py
+++ b/daydream/pr_review.py
@@ -95,6 +95,11 @@ class ParsedIssue:
         location_distrust: True when location validation demoted this finding
             (its citation was beyond tolerance), issue #972 R2. Blocks approval
             regardless of the (demoted) severity and renders a demotion note.
+        severity_off_vocabulary: True when this issue carried a present severity
+            string outside the canonical vocabulary (e.g. ``"critical"``). The
+            boundary folds such labels into ``None`` for ``severity`` (so the
+            canonical render path stays clean), but the gate must still fail
+            closed on them rather than read them as an omitted severity.
     """
 
     path: str
@@ -106,6 +111,7 @@ class ParsedIssue:
     severity: str | None = None
     fingerprint: str | None = None
     location_distrust: bool = False
+    severity_off_vocabulary: bool = False
 
 
 @dataclass
@@ -138,6 +144,7 @@ class ItemFields:
     is_cross_stack: bool
     location_distrust: bool = False
     severity_before_demotion: str | None = None
+    severity_off_vocabulary: bool = False
 
 
 @dataclass
@@ -261,11 +268,31 @@ def _normalize_severity(raw: dict[str, Any]) -> str | None:
     Total: never raises. Present-but-null severities (the wire schema emits
     ``severity: null``) and omitted keys both map to ``None``, as do unknown
     or non-string values — never the string ``"none"``. Unknown string
-    severities (e.g. ``"critical"``) also map to ``None`` here; the approval
-    gate independently fails closed on raw strings in paths that skip this
-    helper.
+    severities (e.g. ``"critical"``) also map to ``None`` here so the
+    canonical render path stays clean; callers must pair this with
+    :func:`_severity_off_vocabulary` so a present-but-off-vocabulary label
+    still fails closed at the approval gate instead of looking like a model
+    that omitted severity.
     """
     return normalize_severity(raw.get("severity"))
+
+
+def _severity_off_vocabulary(raw: dict[str, Any]) -> bool:
+    """True when ``raw`` carries a present, non-empty severity string outside
+    the canonical vocabulary (e.g. ``"critical"``).
+
+    ``_normalize_severity`` folds such labels into ``None``, but a raw
+    off-vocabulary label is a severity the model asserted — it must not be
+    indistinguishable from an omitted severity at the approval gate. The gate
+    blocks on this flag, restoring the documented fail-closed invariant for
+    off-vocabulary labels (issue #972).
+    """
+    value = raw.get("severity")
+    return (
+        isinstance(value, str)
+        and bool(value.strip())
+        and normalize_severity(value) is None
+    )
 
 
 def alt_issues_to_parsed(alt_issues: list[dict[str, Any]]) -> list[ParsedIssue]:
@@ -309,6 +336,7 @@ def alt_issues_to_parsed(alt_issues: list[dict[str, Any]]) -> list[ParsedIssue]:
                     body=body,
                     confidence=confidence,
                     severity=severity,
+                    severity_off_vocabulary=_severity_off_vocabulary(raw),
                     fingerprint=compute_fingerprint(str(path), title, description),
                 )
             )
@@ -346,6 +374,7 @@ def extract_item_fields(
         is_cross_stack=is_cross_stack,
         location_distrust=location_distrust,
         severity_before_demotion=severity_before_demotion,
+        severity_off_vocabulary=_severity_off_vocabulary(raw),
     )
 
 
@@ -399,6 +428,7 @@ def parsed_issues_from_items(items: list[dict[str, Any]]) -> list[ParsedIssue]:
                     fields.path, fields.description, fields.rationale
                 ),
                 location_distrust=fields.location_distrust,
+                severity_off_vocabulary=fields.severity_off_vocabulary,
             )
         )
     return out
@@ -1133,7 +1163,11 @@ def _severity_blocks_approval(severity: str | None) -> bool:
     return severity is not None and severity.lower() not in _NON_BLOCKING_SEVERITIES
 
 
-def _finding_blocks_approval(severity: str | None, location_distrust: bool) -> bool:
+def _finding_blocks_approval(
+    severity: str | None,
+    location_distrust: bool,
+    severity_off_vocabulary: bool = False,
+) -> bool:
     """Whether one finding blocks an approval, demotion-aware (issue #972 R2).
 
     A finding marked ``location_distrust=True`` was judged at a higher severity
@@ -1141,9 +1175,14 @@ def _finding_blocks_approval(severity: str | None, location_distrust: bool) -> b
     the demoted severity must not silently make it non-blocking. This check is
     deliberately separate from ``_severity_blocks_approval`` (and NOT folded
     into ``_NON_BLOCKING_SEVERITIES``) so off-vocabulary severity strings keep
-    failing closed for their own reason.
+    failing closed for their own reason. ``severity_off_vocabulary`` carries
+    that signal: a present-but-off-canonical label (e.g. ``"critical"``) is
+    folded into ``None`` at the boundary but was still a severity the model
+    asserted, so it blocks rather than reading as an omitted severity.
     """
     if location_distrust:
+        return True
+    if severity_off_vocabulary:
         return True
     return _severity_blocks_approval(severity)
 
@@ -1161,7 +1200,9 @@ def _is_clean_review(classified: _ClassifiedIssues, approve_on_clean: bool) -> b
     if not approve_on_clean:
         return False
     return not any(
-        _finding_blocks_approval(issue.severity, issue.location_distrust)
+        _finding_blocks_approval(
+            issue.severity, issue.location_distrust, issue.severity_off_vocabulary
+        )
         for issue in classified.all_issues()
     )
 
@@ -1542,7 +1583,11 @@ def post_findings_from_artifact(
     # open high finding (#343 R2 F2b). Matched findings are never re-posted
     # as comments — only their severities count here.
     can_approve = approve_on_clean and not any(
-        _finding_blocks_approval(finding.severity, finding.location_distrust)
+        _finding_blocks_approval(
+            finding.severity,
+            finding.location_distrust,
+            finding.severity_off_vocabulary,
+        )
         for finding in artifact.findings
     )
 
@@ -1605,4 +1650,5 @@ def _issue_from_artifact_finding(finding: ArtifactFinding) -> ParsedIssue:
         severity=finding.severity,
         fingerprint=finding.fingerprint,
         location_distrust=finding.location_distrust,
+        severity_off_vocabulary=finding.severity_off_vocabulary,
     )

--- a/daydream/pr_review.py
+++ b/daydream/pr_review.py
@@ -93,8 +93,13 @@ class ParsedIssue:
             canonical merged findings and alt-review issues; None on other
             construction paths.
         location_distrust: True when location validation demoted this finding
-            (its citation was beyond tolerance), issue #972 R2. Blocks approval
-            regardless of the (demoted) severity and renders a demotion note.
+            (its citation was beyond tolerance), issue #972 R2. Renders a
+            demotion note; blocks approval only when the finding was demoted
+            from a blocking original severity (see ``severity_before_demotion``).
+        severity_before_demotion: The original severity before location-
+            validation demotion, if any; the approval gate compares it against
+            the blocking set so an initially-low or never-asserted severity
+            stays non-blocking despite the demotion mark.
         severity_off_vocabulary: True when this issue carried a present severity
             string outside the canonical vocabulary (e.g. ``"critical"``). The
             boundary folds such labels into ``None`` for ``severity`` (so the
@@ -111,6 +116,7 @@ class ParsedIssue:
     severity: str | None = None
     fingerprint: str | None = None
     location_distrust: bool = False
+    severity_before_demotion: str | None = None
     severity_off_vocabulary: bool = False
 
 
@@ -428,6 +434,7 @@ def parsed_issues_from_items(items: list[dict[str, Any]]) -> list[ParsedIssue]:
                     fields.path, fields.description, fields.rationale
                 ),
                 location_distrust=fields.location_distrust,
+                severity_before_demotion=fields.severity_before_demotion,
                 severity_off_vocabulary=fields.severity_off_vocabulary,
             )
         )
@@ -1167,20 +1174,25 @@ def _finding_blocks_approval(
     severity: str | None,
     location_distrust: bool,
     severity_off_vocabulary: bool = False,
+    severity_before_demotion: str | None = None,
 ) -> bool:
     """Whether one finding blocks an approval, demotion-aware (issue #972 R2).
 
     A finding marked ``location_distrust=True`` was judged at a higher severity
     and demoted by location validation (its citation was beyond tolerance);
-    the demoted severity must not silently make it non-blocking. This check is
-    deliberately separate from ``_severity_blocks_approval`` (and NOT folded
-    into ``_NON_BLOCKING_SEVERITIES``) so off-vocabulary severity strings keep
+    the demoted severity must not silently make it non-blocking. The demotion
+    mark is written for any beyond-tolerance record regardless of its original
+    severity, so the gate only re-blocks when the pre-demotion severity carried
+    via ``severity_before_demotion`` was itself blocking; an originally-low or
+    never-asserted severity stays non-blocking. This check is deliberately
+    separate from ``_severity_blocks_approval`` (and NOT folded into
+    ``_NON_BLOCKING_SEVERITIES``) so off-vocabulary severity strings keep
     failing closed for their own reason. ``severity_off_vocabulary`` carries
     that signal: a present-but-off-canonical label (e.g. ``"critical"``) is
     folded into ``None`` at the boundary but was still a severity the model
     asserted, so it blocks rather than reading as an omitted severity.
     """
-    if location_distrust:
+    if location_distrust and _severity_blocks_approval(severity_before_demotion):
         return True
     if severity_off_vocabulary:
         return True
@@ -1201,7 +1213,10 @@ def _is_clean_review(classified: _ClassifiedIssues, approve_on_clean: bool) -> b
         return False
     return not any(
         _finding_blocks_approval(
-            issue.severity, issue.location_distrust, issue.severity_off_vocabulary
+            issue.severity,
+            issue.location_distrust,
+            issue.severity_off_vocabulary,
+            issue.severity_before_demotion,
         )
         for issue in classified.all_issues()
     )
@@ -1587,6 +1602,7 @@ def post_findings_from_artifact(
             finding.severity,
             finding.location_distrust,
             finding.severity_off_vocabulary,
+            finding.severity_before_demotion,
         )
         for finding in artifact.findings
     )
@@ -1650,5 +1666,6 @@ def _issue_from_artifact_finding(finding: ArtifactFinding) -> ParsedIssue:
         severity=finding.severity,
         fingerprint=finding.fingerprint,
         location_distrust=finding.location_distrust,
+        severity_before_demotion=finding.severity_before_demotion,
         severity_off_vocabulary=finding.severity_off_vocabulary,
     )

--- a/daydream/review_profile.py
+++ b/daydream/review_profile.py
@@ -167,7 +167,7 @@ class Suppression:
     """
 
     enabled: bool = False
-    severity_classes: tuple[str, ...] = ("low", "medium")
+    severity_classes: tuple[str, ...] = ("low",)
     confidence_classes: tuple[str, ...] = ("LOW",)
 
 

--- a/daydream/review_profile.py
+++ b/daydream/review_profile.py
@@ -30,6 +30,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from daydream import severity
 from daydream.improve.prompts import AUDIT_PLAYBOOK_SECTIONS
 
 
@@ -80,11 +81,12 @@ STAGE_KEYS: frozenset[str] = frozenset(
 )
 
 
-# Host-owned severity/confidence vocabularies (R5; mirror the repo's allowed
-# sets: severity is the lowercase low|medium|high scale -- benchmark/mapping.py,
-# benchmark/cli.py:284-287; confidence is the uppercase HIGH|MEDIUM|LOW schema
-# enum -- phases.py:4048,4250, deep/prompts.py arbiter/suppression/merge).
-_SEVERITY_LEVELS: frozenset[str] = frozenset(("low", "medium", "high"))
+# Host-owned severity/confidence vocabularies (R5): severity derives from the
+# canonical vocabulary in daydream/severity.py (CANONICAL_LEVELS -- the only
+# declaration of the lowercase low|medium|high scale); confidence is the
+# uppercase HIGH|MEDIUM|LOW schema enum -- phases.py:4048,4250,
+# deep/prompts.py arbiter/suppression/merge).
+_SEVERITY_LEVELS: frozenset[str] = frozenset(severity.CANONICAL_LEVELS)
 _CONFIDENCE_LEVELS: frozenset[str] = frozenset(("HIGH", "MEDIUM", "LOW"))
 
 

--- a/daydream/review_profile.py
+++ b/daydream/review_profile.py
@@ -423,14 +423,20 @@ def build_default_profile() -> ReviewProfile:
                 "- \"Good Patterns\" or \"Strengths\"\n"
                 "- \"Summary\" sections\n"
                 "- Any positive observations\n"
-                "{severity_hint}{verdicts_hint}\n"
+                "{verdicts_hint}\n"
                 "For each issue found, return a JSON object with this structure:\n"
                 "{{\"issues\": [\n"
-                "  {{\"id\": 1, \"description\": \"Brief description of the issue\", \"file\": \"path/to/file.py\", \"line\": 42{severity_field}}}\n"  # noqa: E501 (verbatim copy of the phase_parse_feedback literal)
+                "  {{\"id\": 1, \"description\": \"Brief description of the issue\", \"file\": \"path/to/file.py\", \"line\": 42}}\n"  # noqa: E501 (mirrors the phase_parse_feedback example shape)
                 "]{verdicts_example}}}\n\n"
                 "If there are no actionable issues, return: {{\"issues\": []{verdicts_empty}}}\n"
             ),
-            source="copied: daydream.phases.phase_parse_feedback",
+            # The parse stage itself is removed (issue #745); this copy is kept
+            # only as schema documentation. It no longer mirrors a live literal
+            # byte-for-byte: the host-appended severity rubric
+            # (daydream.severity.SEVERITY_RUBRIC) now carries all severity
+            # instruction, and the former {severity_hint} fallback fragment is gone
+            # (issue #972 R3/A2).
+            source="mirrors: daydream.phases.phase_parse_feedback (parse stage removed, issue #745)",
         ),
         "uncovered_review": Strategy(
             content=(

--- a/daydream/severity.py
+++ b/daydream/severity.py
@@ -31,6 +31,35 @@ assignment: it does not constitute a fallback severity policy.
 """
 
 
+SEVERITY_RUBRIC = (
+    "## Severity Rubric\n"
+    "\n"
+    "Assign exactly one level per finding:\n"
+    "\n"
+    "- high: the defect breaks a primary user journey, causes data loss or "
+    "corruption, introduces a security vulnerability, or leaves the changed "
+    "code incorrect as merged. A finding is high only when it meets one of "
+    "these conditions.\n"
+    "- medium: a real defect with a workaround or a limited blast radius -- "
+    "wrong in a secondary path, an edge case, or recoverable at runtime.\n"
+    "- low: a style, clarity, naming, or minor robustness issue with no "
+    "behavioral break. Requests for work outside this diff are not findings; "
+    "when surfaced at all, they are low.\n"
+    "\n"
+    "Maintainability, readability, and structural-erosion findings are never "
+    "high: they do not break a primary user journey, lose or corrupt data, open a "
+    "security vulnerability, or make the merged code incorrect."
+)
+"""Host-owned severity rubric appended to every severity-assigning prompt.
+
+Defines all three canonical levels in observable, checkable terms. It is
+appended AFTER all profile strategy text (P-RUBRIC) and is never routed
+through profile-owned strategy content (R1.4): builders import this constant
+from this module, so no builder can inline a divergent copy or expose the
+rubric to profile override.
+"""
+
+
 def normalize_severity(value: object) -> str | None:
     """Normalize a severity value to the canonical vocabulary.
 

--- a/daydream/severity.py
+++ b/daydream/severity.py
@@ -1,0 +1,45 @@
+"""Single source of truth for finding severity vocabulary and policy.
+
+This module is the one place to look for the canonical severity levels, the
+sort-rank mapping, and the missing-severity fallback policy. It is a leaf
+module: it must not import from any other daydream module, so it stays
+importable everywhere in the pipeline.
+
+P6 rule: off-vocabulary severity values are never silently passed through.
+A boundary site that encounters an unknown or absent value must map it
+explicitly (via :func:`normalize_severity`, which returns ``None`` for
+unknown/absent) and decide what that means in its own context.
+
+Default severity policy (R3.1, documented once):
+
+- A missing severity stays ``None`` on report and approval paths; ``None``
+  deliberately does not block approval.
+- The only ``"high"`` default permitted anywhere is the structural-lens
+  ``setdefault("severity", "high")`` (structural high-conviction invariant).
+- No other fallback severity value is permitted.
+"""
+
+CANONICAL_LEVELS: tuple[str, ...] = ("low", "medium", "high")
+"""The canonical severity vocabulary: the only declaration of the levels."""
+
+SEVERITY_RANK: dict[str, int] = {"high": 0, "medium": 1, "low": 2}
+"""Sort rank mirroring ``phases._SEVERITY_RANK`` exactly.
+
+Unknown or absent values rank as medium (``1``) at the sort site via
+``SEVERITY_RANK.get(value, 1)``. This is a sort rank, not a severity
+assignment: it does not constitute a fallback severity policy.
+"""
+
+
+def normalize_severity(value: object) -> str | None:
+    """Normalize a severity value to the canonical vocabulary.
+
+    Returns the canonical lowercase value for known levels (case- and
+    whitespace-tolerant), and ``None`` for unknown, non-string, or absent
+    values. Callers must handle ``None`` explicitly — an unknown value is
+    never mapped implicitly.
+    """
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    return normalized if normalized in CANONICAL_LEVELS else None

--- a/daydream/severity.py
+++ b/daydream/severity.py
@@ -23,11 +23,14 @@ CANONICAL_LEVELS: tuple[str, ...] = ("low", "medium", "high")
 """The canonical severity vocabulary: the only declaration of the levels."""
 
 SEVERITY_RANK: dict[str, int] = {"high": 0, "medium": 1, "low": 2}
-"""Sort rank mirroring ``phases._SEVERITY_RANK`` exactly.
+"""Sort rank for the canonical levels (high < medium < low).
 
-Unknown or absent values rank as medium (``1``) at the sort site via
-``SEVERITY_RANK.get(value, 1)``. This is a sort rank, not a severity
-assignment: it does not constitute a fallback severity policy.
+The single source of truth consumed by both the deep arbiter (target
+selection) and the deep/shallow fix-loop sort site (``phases.severity_sorted``),
+so a reorder anywhere can never silently diverge. Unknown or absent values
+rank as medium (``1``) at the sort site via ``SEVERITY_RANK.get(value, 1)``.
+This is a sort rank, not a severity assignment: it does not constitute a
+fallback severity policy.
 """
 
 

--- a/daydream/ui/summary.py
+++ b/daydream/ui/summary.py
@@ -16,6 +16,7 @@ from rich.style import Style
 from rich.table import Table
 from rich.text import Text
 
+from daydream.severity import normalize_severity
 from daydream.ui.messages import print_dim
 from daydream.ui.theme import (
     NEON_COLORS,
@@ -143,6 +144,16 @@ def print_summary(console: Console, data: SummaryData) -> None:
     console.print(table)
 
 
+def _display_severity(issue: dict[str, Any]) -> str | None:
+    """Normalize an issue's severity for display (issue #972 R3.1).
+
+    Unified fallback policy: a missing or unknown severity renders as absent
+    (``None``) — never the fabricated literal ``"medium"``. Known values are
+    normalized to the canonical lowercase vocabulary.
+    """
+    return normalize_severity(issue.get("severity"))
+
+
 def print_issues_table(console: Console, issues: list[dict[str, Any]]) -> None:
     """Display issues as a numbered Rich table.
 
@@ -164,10 +175,10 @@ def print_issues_table(console: Console, issues: list[dict[str, Any]]) -> None:
     severity_style = {"high": STYLE_RED, "medium": STYLE_YELLOW, "low": STYLE_GREEN}
 
     for issue in issues:
-        sev = issue.get("severity", "medium")
+        sev = _display_severity(issue)
         table.add_row(
             str(issue.get("id", "?")),
-            Text(sev, style=severity_style.get(sev, STYLE_FG)),
+            Text(sev or "--", style=severity_style.get(sev or "", STYLE_FG)),
             issue.get("title", issue.get("description", "No title")),
         )
 

--- a/tests/test_arbiter.py
+++ b/tests/test_arbiter.py
@@ -187,3 +187,53 @@ def test_select_suppression_targets_honors_severity_classes_knob() -> None:
     assert select_suppression_targets(records, sources) == [0, 2]
     # Knob widened to include medium.
     assert select_suppression_targets(records, sources, severity_classes=("low", "medium")) == [0, 1, 2]
+
+
+def test_select_suppression_targets_honors_confidence_classes_knob() -> None:
+    """The profile's ``Suppression.confidence_classes`` governs the confidence
+    branch live, not a hardcoded LOW predicate (fail-open fix): widening to
+    include MEDIUM routes otherwise-borderline MEDIUM-confidence findings to the
+    suppression pass, narrowing to HIGH excludes LOW-confidence ones."""
+    records = [
+        {"severity": "medium", "confidence": "LOW", "file": "a.py", "line": 1},
+        {"severity": "medium", "confidence": "MEDIUM", "file": "b.py", "line": 2},
+        {"severity": "medium", "confidence": "HIGH", "file": "c.py", "line": 3},
+    ]
+    sources = ["s1", "s2", "s3"]
+    # Default ("LOW",): LOW-confidence selected; MEDIUM- and HIGH-confidence not.
+    assert select_suppression_targets(records, sources) == [0]
+    # Widened to include MEDIUM: now selects LOW- and MEDIUM-confidence.
+    assert select_suppression_targets(
+        records, sources, confidence_classes=("LOW", "MEDIUM")
+    ) == [0, 1]
+    # Narrowed to HIGH (or any other non-LOW selection) must NOT silently fall
+    # back to the old LOW-only branch -- the knob is live in both directions.
+    assert select_suppression_targets(records, sources, confidence_classes=("HIGH",)) == [2]
+
+
+def test_suppression_rejects_unknown_confidence_class() -> None:
+    import pytest
+
+    records = [_rec_conf("a.py", 1, "low", "LOW")]
+    with pytest.raises(ValueError):
+        select_suppression_targets(records, ["python"], confidence_classes=("LOW", "GUESSED"))
+
+
+def test_select_arbiter_targets_honors_contested_location_knob() -> None:
+    """The profile's ``Arbitration.contested_location`` gates the contested
+    branch of arbiter selection: disabling it leaves only the severity branch,
+    so divergent-severity multi-stack collisions no longer route to the arbiter."""
+    records = [
+        _rec("api.py", 10, "high"),
+        _rec("api.py", 10, "medium"),
+    ]
+    sources = ["python", "react"]
+    # Default on: the medium finding is contested with the high one and is selected.
+    assert select_arbiter_targets(records, sources) == [0, 1]
+    # Knob off: only the severity branch selects; the contested medium drops out.
+    assert select_arbiter_targets(records, sources, contested_location=False) == [0]
+    # Severity branch still fully live when the contested branch is disabled:
+    # lowering min_severity to medium pulls the medium finding back in.
+    assert select_arbiter_targets(
+        records, sources, min_severity="medium", contested_location=False
+    ) == [0, 1]

--- a/tests/test_arbiter.py
+++ b/tests/test_arbiter.py
@@ -34,6 +34,19 @@ def _rec_conf(file: str, line: int, severity: str, confidence: str) -> dict[str,
     return rec
 
 
+def test_select_arbiter_targets_honors_min_severity_knob() -> None:
+    records = [
+        {"severity": "medium", "file": "a.py", "line": 1},
+        {"severity": "high", "file": "b.py", "line": 2},
+        {"severity": "low", "file": "c.py", "line": 3},
+    ]
+    sources = ["s1", "s2", "s3"]
+    # Default unchanged: only the high record is selected.
+    assert select_arbiter_targets(records, sources) == [1]
+    # Knob lowered: medium is now arbitrated too.
+    assert select_arbiter_targets(records, sources, min_severity="medium") == [0, 1]
+
+
 def test_mixed_severity_multi_stack_collision_selects_high_and_contested() -> None:
     # Index map:
     #  0 python  api.py:10  high     -> selected (high severity)

--- a/tests/test_arbiter.py
+++ b/tests/test_arbiter.py
@@ -174,3 +174,16 @@ def test_suppression_length_mismatch_raises() -> None:
 
     with pytest.raises(ValueError):
         select_suppression_targets([_rec("a.py", 1, "low")], ["python", "react"])
+
+
+def test_select_suppression_targets_honors_severity_classes_knob() -> None:
+    records = [
+        {"severity": "low", "file": "a.py", "line": 1},
+        {"severity": "medium", "file": "b.py", "line": 2},
+        {"severity": "low", "confidence": "LOW", "file": "c.py", "line": 3},
+    ]
+    sources = ["s1", "s2", "s3"]
+    # Default ("low",): low-severity records selected; medium not; LOW-confidence still selected.
+    assert select_suppression_targets(records, sources) == [0, 2]
+    # Knob widened to include medium.
+    assert select_suppression_targets(records, sources, severity_classes=("low", "medium")) == [0, 1, 2]

--- a/tests/test_benchmark_harbor_agent.py
+++ b/tests/test_benchmark_harbor_agent.py
@@ -104,12 +104,13 @@ def test_build_candidate_findings_enforces_verifier_bounds_fail_closed() -> None
         candidate.build_candidate_findings(overlong_body, case_id=case_id)
     assert bad_body.value.kind == "invalid_finding"
 
-    # non-enum severity is a typed failure
-    bad_severity = [{"file": "src/a.py", "line": 1,
-                     "description": "x", "rationale": "", "severity": "CRITICAL"}]
-    with pytest.raises(candidate.CandidateError) as bad_sev:
-        candidate.build_candidate_findings(bad_severity, case_id=case_id)
-    assert bad_sev.value.kind == "invalid_finding"
+    # off-vocabulary severity is mapped, never propagated: the shared
+    # extraction boundary (pr_review.extract_item_fields -> severity.normalize_severity)
+    # maps 'CRITICAL' to None, and null severity is verifier-valid (R6 boundary mapping).
+    off_vocab = [{"file": "src/a.py", "line": 1,
+                  "description": "x", "rationale": "", "severity": "CRITICAL"}]
+    [mapped] = candidate.build_candidate_findings(off_vocab, case_id=case_id)
+    assert mapped["severity"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_benchmark_harbor_build.py
+++ b/tests/test_benchmark_harbor_build.py
@@ -1357,3 +1357,13 @@ def test_policy_change_alters_compiled_digest(tmp_path: Path, fake_gh: FakeGh) -
     digest_b = lock_b["files"][next(iter(lock_b["cases"])) + "/task.toml"]
     assert digest_a != digest_b
     assert lock_a != lock_b          # lock bytes differ -> compiled_lock_sha256 differs
+
+
+def test_harbor_build_null_gold_severity_labeled_not_silent() -> None:
+    # build.py emits "unknown" for null gold severity — must remain an EXPLICIT
+    # labeled value, documented at the emission site (label, not canonical
+    # passthrough).
+    from daydream.benchmark.harbor import build
+
+    assert build._gold_severity_label(None) == "unknown"
+    assert build._gold_severity_label("HIGH") == "high"

--- a/tests/test_deep_coverage.py
+++ b/tests/test_deep_coverage.py
@@ -985,3 +985,24 @@ def test_strip_dot_slash_shared_by_both_record_loaders(tmp_path: Path) -> None:
     assert "api.py" not in uncovered
     assert stats["coverage_by_evidence"]["inline_hunk_reviewed"] == 1
 
+
+
+def test_uncovered_sweep_prompt_carries_severity_rubric(tmp_path: Path) -> None:
+    """Issue #972 R1.1: the sweep reviewer assigns severities, so it gets the
+    host severity rubric, appended after the profile strategy text."""
+    from daydream import severity
+
+    intent = tmp_path / ".daydream" / "deep" / "intent.md"
+    output = tmp_path / ".daydream" / "deep" / "uncovered-0-review.md"
+    hunks = diff_block_for_file(_DIFF, "notes.txt") or ""
+    strategy = rp.build_default_profile().strategies["uncovered_review"].content
+    prompt = build_uncovered_sweep_prompt(
+        strategy=strategy,
+        file="notes.txt",
+        hunks=hunks,
+        intent_path=intent,
+        cwd=tmp_path,
+        output_path=output,
+    )
+    assert severity.SEVERITY_RUBRIC in prompt
+    assert prompt.index(severity.SEVERITY_RUBRIC) > prompt.index(strategy.format(file="notes.txt"))

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -137,6 +137,17 @@ async def _run_deep(
     return await run(config)
 
 
+_SEVERITY_SORT_RANK = {"high": 0, "medium": 1, "low": 2}
+
+
+def _severity_sort_key(s: str) -> int:
+    """Sort rank for canonical severities; errors naming unknown/absent values."""
+    try:
+        return _SEVERITY_SORT_RANK[s]
+    except KeyError:
+        raise ValueError(f"unexpected severity in fixture: {s!r}") from None
+
+
 def _merge_item(item_id: int, file: str, severity: str, *, desc: str | None = None) -> dict[str, Any]:
     """Build a validated merged item (shape copied from the stub default)."""
     return {
@@ -4484,7 +4495,16 @@ async def test_structural_finding_reaches_fix_loop(
         f"fix loop; items fixed: {[(i.get('lens'), i.get('severity')) for i in fixed]!r}"
     )
     sev = [str(i["severity"]) for i in fixed]
-    assert sev == sorted(sev, key=lambda s: {"high": 0, "medium": 1, "low": 2}[s])
+    assert sev == sorted(sev, key=_severity_sort_key)
+
+
+def test_severity_sort_key_names_unknown_value() -> None:
+    """Should-Have (R3): an unknown/absent severity in a fixture errors with a
+    message that names the value, instead of a bare ``KeyError``."""
+    with pytest.raises(ValueError, match="bogus"):
+        _severity_sort_key("bogus")
+    with pytest.raises(ValueError, match="unexpected severity in fixture"):
+        _severity_sort_key("")
 
 
 async def test_start_at_fix_recovers_merged_items(

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -5186,6 +5186,17 @@ def _merged_item_descriptions(target: Path) -> list[str]:
     return [it.get("description", "") for it in items]
 
 
+# Issue #336 review: the profile's ``suppression_confidence_classes`` must govern
+# the suppression confidence branch LIVE (fail-open fix). The borderline finding
+# here is MEDIUM-confidence / medium-severity uncontested: invisible to the default
+# LOW-only confidence branch AND the default low-only severity branch, so it is the
+# sole discriminator for whether the confidence knob is wired through.
+_CONFIDENCE_KNOB_STACKS: dict[str, dict[str, Any]] = {
+    "python": {"severity": "high", "confidence": "HIGH", "file": "api.py", "line": 1},
+    "react": {"severity": "medium", "confidence": "MEDIUM", "file": "App.tsx", "line": 1},
+}
+
+
 # A borderline LOW-severity sibling sharing one (file, line) with a HIGH finding
 # from the SAME stack (py_module.py:7). Single stack -> uncontested, so only the
 # HIGH one is an arbiter target. Other stacks stay on api.py:1 (no severity) so
@@ -5336,6 +5347,78 @@ async def test_precision_on_keeps_low_finding_with_evidence(
     files = _merged_item_files(multi_stack_target)
     assert "App.tsx" in files, f"a confirmed borderline finding must be kept:\n{files}"
     assert "api.py" in files
+
+
+async def test_precision_confidence_classes_default_keeps_medium_conf_finding(
+    multi_stack_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default ``suppression_confidence_classes`` ("LOW",): a MEDIUM-confidence,
+    medium-severity uncontested finding is selected by neither the LOW-only
+    confidence branch nor the low-only severity branch, so the suppression pass
+    has no target for it and it survives to merge. Binary first half: the knob is
+    NOT silently widening selection by default."""
+    _silence(monkeypatch)
+    calls = _install_model_capturing_stubs(
+        monkeypatch,
+        multi_stack_target,
+        merge_echo_records=True,
+        parse_by_stack=_CONFIDENCE_KNOB_STACKS,
+        suppression_keep=False,
+    )
+
+    exit_code = await _run_deep(multi_stack_target, precision_mode=True)
+    assert exit_code == 0
+
+    files = _merged_item_files(multi_stack_target)
+    assert "App.tsx" in files, f"a MEDIUM finding must survive the default LOW-only branches:\n{files}"
+    assert "api.py" in files
+
+    sup_calls = [c for c in calls if "you are the suppression reviewer" in c["prompt"].lower()]
+    assert sup_calls == [], (
+        "a MEDIUM-confidence / medium-severity finding must NOT reach suppression "
+        "under the default LOW-only confidence + low-only severity classes"
+    )
+
+
+async def test_precision_confidence_classes_widened_routes_medium_conf_to_suppression(
+    multi_stack_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Profile ``suppression_confidence_classes = ("LOW", "MEDIUM")`` widens the
+    confidence branch LIVE: the same MEDIUM-confidence medium-severity finding is
+    now a suppression target and is dropped (keep=false) instead of surviving
+    unreviewed. Regression for the fail-open bug where the knob was accepted but
+    inert and the predicate hardcoded LOW."""
+    _silence(monkeypatch)
+    calls = _install_model_capturing_stubs(
+        monkeypatch,
+        multi_stack_target,
+        merge_echo_records=True,
+        parse_by_stack=_CONFIDENCE_KNOB_STACKS,
+        suppression_keep=False,
+    )
+
+    exit_code = await _run_deep(
+        multi_stack_target,
+        precision_mode=True,
+        review_profile=_profile_with_pipeline(
+            suppression_confidence_classes=("LOW", "MEDIUM")
+        ),
+    )
+    assert exit_code == 0
+
+    files = _merged_item_files(multi_stack_target)
+    assert "App.tsx" not in files, (
+        f"widened confidence classes must route the MEDIUM finding into suppression:\n{files}"
+    )
+    assert "api.py" in files
+
+    sup_calls = [c for c in calls if "you are the suppression reviewer" in c["prompt"].lower()]
+    assert len(sup_calls) == 1, (
+        f"widened confidence knob must fire the suppression pass exactly once:"
+        f"{len(sup_calls)}"
+    )
 
 
 # Issue #343: config-gated bot APPROVE for clean deep reviews.

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -16,6 +16,8 @@ from daydream.deep.prompts import (
     build_generic_fallback_prompt,
     build_merge_prompt,
     build_per_stack_prompt,
+    build_supervise_prompt,
+    build_suppression_prompt,
     build_structural_prompt,
 )
 from daydream.prompt_budget import INLINE_DIFF_BUDGET_BYTES
@@ -1600,3 +1602,63 @@ def test_rubric_after_strategy_text(tmp_path: Path) -> None:
         assert prompts[prompt].index(severity.SEVERITY_RUBRIC) > prompts[prompt].index(
             _default_strategy(strategy_stage)
         )
+
+
+# =============================================================================
+# Issue #972 R1.3 — adjudication restatements cite the severity rubric
+# =============================================================================
+
+
+def _adjudication_prompts(tmp_path: Path) -> dict[str, str]:
+    p = _paths(tmp_path)
+    return {
+        "build_arbiter_prompt": build_arbiter_prompt(
+            strategy=_default_strategy("arbitration"),
+            arbiter_input_path=tmp_path / "arbiter-input.json",
+            diff_path=p["diff_path"],
+            intent_path=p["intent_path"],
+            alternatives_path=p["alternatives_path"],
+            cwd=p["cwd"],
+        ),
+        "build_suppression_prompt": build_suppression_prompt(
+            strategy=_default_strategy("suppression"),
+            suppression_input_path=tmp_path / "suppression-input.json",
+            diff_path=p["diff_path"],
+            intent_path=p["intent_path"],
+            alternatives_path=p["alternatives_path"],
+            cwd=p["cwd"],
+        ),
+        "build_merge_prompt": build_merge_prompt(
+            strategy=_default_strategy("merge"),
+            **_merge_paths(tmp_path),  # type: ignore[arg-type]
+        ),
+        "build_supervise_prompt": build_supervise_prompt(
+            strategy=_default_strategy("supervision"),
+            supervise_input_path=tmp_path / "supervise-input.json",
+            diff_path=p["diff_path"],
+            intent_path=p["intent_path"],
+            alternatives_path=p["alternatives_path"],
+            cwd=p["cwd"],
+        ),
+    }
+
+
+@pytest.mark.parametrize(
+    "builder",
+    ["build_arbiter_prompt", "build_suppression_prompt", "build_merge_prompt", "build_supervise_prompt"],
+)
+def test_adjudication_prompts_reference_severity_rubric(builder: str, tmp_path: Path) -> None:
+    """R1.3: each adjudication restatement prompt cites the shared severity rubric."""
+    from daydream import severity
+
+    prompt = _adjudication_prompts(tmp_path)[builder]
+    assert severity.SEVERITY_RUBRIC in prompt or "severity rubric" in prompt
+
+
+@pytest.mark.parametrize(
+    "builder",
+    ["build_arbiter_prompt", "build_suppression_prompt", "build_merge_prompt", "build_supervise_prompt"],
+)
+def test_adjudication_prompts_no_divergent_severity_fragment(builder: str, tmp_path: Path) -> None:
+    """R1.3: no adjudication prompt retains a bare "high | medium" restatement."""
+    assert "high | medium" not in _adjudication_prompts(tmp_path)[builder]

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -16,9 +16,9 @@ from daydream.deep.prompts import (
     build_generic_fallback_prompt,
     build_merge_prompt,
     build_per_stack_prompt,
+    build_structural_prompt,
     build_supervise_prompt,
     build_suppression_prompt,
-    build_structural_prompt,
 )
 from daydream.prompt_budget import INLINE_DIFF_BUDGET_BYTES
 from daydream.prompts.authorial_intent import AUTHORITATIVE_INTENT_RULE

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -1534,3 +1534,69 @@ def test_structural_prompt_uses_profile_strategy_and_no_skill() -> None:
     assert "Review the repository-wide interactions" in p
     assert "a.py, b.ts" in p and "/d" in p and "/c" in p
     assert "/beagle-" not in p and "Apply this specialist skill" not in p
+
+
+# =============================================================================
+# Issue #972 R1 — host-owned severity rubric reaches every assigning prompt
+# =============================================================================
+
+
+def _rubric_assigning_prompts(tmp_path: Path) -> list[str]:
+    from daydream.phases import build_alternative_review_prompt
+
+    p = _paths(tmp_path)
+    per_stack = build_per_stack_prompt(
+        strategy=_default_strategy("discovery.per_stack"),
+        stack_name="python",
+        files=["api.py"],
+        **p,
+    )
+    structural = build_structural_prompt(
+        strategy=_default_strategy("discovery.structural"),
+        files=["api.py"],
+        **p,
+    )
+    generic = build_generic_fallback_prompt(
+        strategy=_default_strategy("discovery.generic_fallback"),
+        files=["api.py"],
+        **p,
+    )
+    alternative = build_alternative_review_prompt(
+        strategy=_default_strategy("alternatives"),
+        intent_summary="intent",
+        diff_path=str(p["diff_path"]),
+    )
+    return [per_stack, structural, generic, alternative]
+
+
+def test_every_assigning_prompt_carries_severity_rubric(tmp_path: Path) -> None:
+    """R1.1: every prompt that assigns a severity embeds the host rubric."""
+    from daydream import severity
+
+    for prompt in _rubric_assigning_prompts(tmp_path):
+        assert severity.SEVERITY_RUBRIC in prompt
+
+
+def test_rubric_is_high_definition_not_a_prohibition() -> None:
+    """R1.2: the rubric defines all three levels in checkable terms, high first."""
+    from daydream import severity
+
+    rubric = severity.SEVERITY_RUBRIC
+    assert "high" in rubric and "medium" in rubric and "low" in rubric
+    assert rubric.index("high") < rubric.index("medium") < rubric.index("low")
+    assert "Informational" not in rubric
+
+
+def test_rubric_after_strategy_text(tmp_path: Path) -> None:
+    """R1.4: the host rubric lands after the profile strategy text."""
+    from daydream import severity
+
+    for prompt, strategy_stage in (
+        (0, "discovery.per_stack"),
+        (1, "discovery.structural"),
+        (2, "discovery.generic_fallback"),
+    ):
+        prompts = _rubric_assigning_prompts(tmp_path)
+        assert prompts[prompt].index(severity.SEVERITY_RUBRIC) > prompts[prompt].index(
+            _default_strategy(strategy_stage)
+        )

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -99,7 +99,7 @@ def test_fresh_install_docs_have_no_plugin_step() -> None:
 
 def test_historical_records_preserved() -> None:
     expected = {
-        "CHANGELOG.md": "7dfe5219b2e9b19f8f147877dee249bd79d5b22ca9381a92de7fdd455f2b49a0",
+        "CHANGELOG.md": "6c6537d3096aa14159d9e71133508ee1749816810372b108e205b3ded583c031",
     }
     for rel, want in expected.items():
         data = (ROOT / rel).read_bytes()

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -99,7 +99,7 @@ def test_fresh_install_docs_have_no_plugin_step() -> None:
 
 def test_historical_records_preserved() -> None:
     expected = {
-        "CHANGELOG.md": "7c6f787e0bd4324576532ca110cec9b4eed6a560a2df7a59a30f6adcd82b46ee",
+        "CHANGELOG.md": "7dfe5219b2e9b19f8f147877dee249bd79d5b22ca9381a92de7fdd455f2b49a0",
     }
     for rel, want in expected.items():
         data = (ROOT / rel).read_bytes()

--- a/tests/test_improve_prioritize.py
+++ b/tests/test_improve_prioritize.py
@@ -417,3 +417,6 @@ def test_prioritize_unknown_severity_maps_explicitly() -> None:
     assert prioritize._map_axis_severity(None) is None
     assert prioritize._map_axis_severity("high") == "HIGH"
     assert prioritize._map_axis_severity("weird") is None
+    # The axis vocabulary is 3-level; the off-canonical "CRITICAL" must not
+    # pass through as raw, exactly as the docstring asserts.
+    assert prioritize._map_axis_severity("CRITICAL") is None

--- a/tests/test_improve_prioritize.py
+++ b/tests/test_improve_prioritize.py
@@ -406,3 +406,14 @@ def test_member_aliases_survive_wording_and_expose_membership_drift() -> None:
     assert before["package_fingerprint"] == after["package_fingerprint"]
     assert set(after["member_aliases"]) < set(expanded["member_aliases"])
     assert expanded["package_fingerprint"] != after["package_fingerprint"]
+
+
+def test_prioritize_unknown_severity_maps_explicitly() -> None:
+    """P-BOUNDARY (R6.2): unknown severity does not silently pass through as
+    ``"CRITICAL"``/raw — the axis mapper returns ``None`` and the caller omits
+    the axis instead of promoting to a conservative fallback."""
+    from daydream.improve import prioritize
+
+    assert prioritize._map_axis_severity(None) is None
+    assert prioritize._map_axis_severity("high") == "HIGH"
+    assert prioritize._map_axis_severity("weird") is None

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -4558,3 +4558,37 @@ def test_merge_validates_finding_locations_before_write(tmp_path: Path) -> None:
     assert items[0]["line"] == 2272  # beyond tolerance -> NOT snapped
     assert "location_note" in items[0]  # demoted-with-annotation
 
+
+def test_merge_demotion_preserves_original_severity_and_marks_distrust(tmp_path: Path) -> None:
+    """R2.1/R2.4: a beyond-tolerance demotion keeps the original severity recoverable
+    and carries a machine-readable ``location_distrust`` mark through the merge."""
+    from daydream.hunk_index import write_hunk_index
+    from daydream.phases import _write_single_stack_merged_items
+
+    dd = tmp_path / ".daydream" / "deep"
+    dd.mkdir(parents=True)
+    write_hunk_index(
+        tmp_path / ".daydream",
+        "diff --git a/orchestrator.py b/orchestrator.py\n--- a/orchestrator.py\n+++ b/orchestrator.py\n"
+        "@@ -2270,3 +2284,5 @@\n x\n+x1\n+x2\n",
+    )
+    records = [
+        {
+            "id": 1,
+            "description": "off-citation",
+            "file": "orchestrator.py",
+            "line": 2272,
+            "severity": "high",
+            "confidence": "HIGH",
+            "rationale": "r",
+            "evidence": "e",
+        }
+    ]
+    _write_single_stack_merged_items(tmp_path, dd, records, None)
+    from daydream.deep.artifacts import merged_items_path
+
+    items = json.loads(merged_items_path(dd).read_text())["items"]
+    assert items[0]["severity"] == "low"  # demoted value (report-facing)
+    assert items[0]["severity_before_demotion"] == "high"  # original preserved (R2.1)
+    assert items[0]["location_distrust"] is True  # machine-readable demotion mark
+

--- a/tests/test_pr_review.py
+++ b/tests/test_pr_review.py
@@ -1148,11 +1148,47 @@ def test_demoted_high_finding_still_blocks_approval(pr: PRInfo) -> None:
         inline=[{"path": "a.py", "line": 10, "side": "RIGHT", "body": "x"}],
         inline_issues=[
             ParsedIssue(path="a.py", line=10, title="t", body="b",
-                        severity="low", location_distrust=True)
+                        severity="low", location_distrust=True,
+                        severity_before_demotion="high")
         ],
     )
     payload = build_payload(pr, classified, approve_on_clean=True)
     assert payload["event"] == "COMMENT"
+
+
+def test_demoted_low_finding_does_not_block_approval(pr: PRInfo) -> None:
+    """#336: a demoted finding whose ORIGINAL severity was already low (or never
+    asserted) must not block APPROVE — the location_distrust mark is written for
+    every beyond-tolerance record, but only a demotion from a blocking severity
+    keeps the gate closed."""
+    for before in ("low", None):
+        classified = pr_review._ClassifiedIssues(
+            inline=[{"path": "a.py", "line": 10, "side": "RIGHT", "body": "x"}],
+            inline_issues=[
+                ParsedIssue(path="a.py", line=10, title="t", body="b",
+                            severity="low", location_distrust=True,
+                            severity_before_demotion=before)
+            ],
+        )
+        payload = build_payload(pr, classified, approve_on_clean=True)
+        assert payload["event"] == "APPROVE"
+
+
+def test_demoted_low_finding_approval_gate_does_not_block() -> None:
+    """#336: the approval-gate unit check itself — location_distrust alone no
+    longer blocks once the original severity was low or never asserted."""
+    assert pr_review._finding_blocks_approval(
+        "low", True, False, "low"
+    ) is False
+    assert pr_review._finding_blocks_approval(
+        "low", True, False, None
+    ) is False
+    assert pr_review._finding_blocks_approval(
+        "low", True, False, "high"
+    ) is True
+    assert pr_review._finding_blocks_approval(
+        "low", True, False, "medium"
+    ) is True
 
 
 def test_parsed_issues_carry_location_distrust_and_report_note() -> None:

--- a/tests/test_pr_review.py
+++ b/tests/test_pr_review.py
@@ -11,6 +11,7 @@ from typing import Any
 import pytest
 
 from daydream import git_ops, pr_review
+from daydream.findings import ArtifactFinding
 from daydream.pr_review import (
     DAYDREAM_FOOTER,
     ParsedIssue,
@@ -1198,3 +1199,53 @@ def test_null_severity_does_not_block_approval(
     payload = build_payload(pr, classified, approve_on_clean=True)
     assert payload["event"] == "APPROVE"
     assert "**Severity:** none" not in payload["body"]  # no phantom label rendered
+
+
+def test_artifact_off_vocabulary_severity_blocks_approval() -> None:
+    """R1/F1: an off-vocabulary label ('critical') folded to None at the Phase A
+    boundary must still block the artifact-backed approve gate.
+
+    The raw off-vocabulary signal rides through the artifact as
+    ``severity_off_vocabulary`` so the poster's gate fails closed even though
+    ``severity`` reads ``None``.
+    """
+    finding = ArtifactFinding(
+        fingerprint="f" * 64,
+        path="a.py",
+        line=10,
+        placement="inline",
+        title="t",
+        body="b",
+        severity=None,  # "critical" was folded to None by Phase A normalization
+        confidence="HIGH",
+        is_cross_stack=False,
+        severity_off_vocabulary=True,
+    )
+    issue = pr_review._issue_from_artifact_finding(finding)
+    assert issue.severity is None
+    assert issue.severity_off_vocabulary is True
+    # The approval gate blocks on the off-vocabulary signal even with severity None.
+    assert pr_review._finding_blocks_approval(
+        issue.severity, issue.location_distrust, issue.severity_off_vocabulary
+    ) is True
+
+
+def test_artifact_folding_to_none_not_off_vocabulary_does_not_block() -> None:
+    """Present-but-null severity (wire ``severity: null``) is not an asserted
+    off-vocabulary label: it models an omitted severity and does not block."""
+    finding = ArtifactFinding(
+        fingerprint="f" * 64,
+        path="a.py",
+        line=10,
+        placement="inline",
+        title="t",
+        body="b",
+        severity=None,
+        confidence="HIGH",
+        is_cross_stack=False,
+        severity_off_vocabulary=False,
+    )
+    issue = pr_review._issue_from_artifact_finding(finding)
+    assert pr_review._finding_blocks_approval(
+        issue.severity, issue.location_distrust, issue.severity_off_vocabulary
+    ) is False

--- a/tests/test_pr_review.py
+++ b/tests/test_pr_review.py
@@ -1138,3 +1138,38 @@ def test_file_hunks_gh_fallback_handles_subprocess_error(
         git_repo, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", "HEAD", "x.py", pr_number=42
     )
     assert hunks == []
+
+
+def test_demoted_high_finding_still_blocks_approval(pr: PRInfo) -> None:
+    """R2.2: a judged-high finding demoted to low by location validation must
+    still block APPROVE — demotion is visible, never approval-silencing."""
+    classified = pr_review._ClassifiedIssues(
+        inline=[{"path": "a.py", "line": 10, "side": "RIGHT", "body": "x"}],
+        inline_issues=[
+            ParsedIssue(path="a.py", line=10, title="t", body="b",
+                        severity="low", location_distrust=True)
+        ],
+    )
+    payload = build_payload(pr, classified, approve_on_clean=True)
+    assert payload["event"] == "COMMENT"
+
+
+def test_parsed_issues_carry_location_distrust_and_report_note() -> None:
+    """R2 visibility: the demotion reaches the human-read issue body and the
+    machine-readable flag rides on the ParsedIssue."""
+    items = [
+        {
+            "file": "a.py",
+            "line": 10,
+            "description": "off-citation",
+            "rationale": "r",
+            "severity": "low",
+            "confidence": "LOW",
+            "severity_before_demotion": "high",
+            "location_distrust": True,
+        }
+    ]
+    issues = parsed_issues_from_items(items)
+    assert len(issues) == 1
+    assert issues[0].location_distrust is True
+    assert "**Location:** unverified citation (severity demoted from high)" in issues[0].body

--- a/tests/test_pr_review.py
+++ b/tests/test_pr_review.py
@@ -1173,3 +1173,28 @@ def test_parsed_issues_carry_location_distrust_and_report_note() -> None:
     assert len(issues) == 1
     assert issues[0].location_distrust is True
     assert "**Location:** unverified citation (severity demoted from high)" in issues[0].body
+
+
+@pytest.mark.parametrize("raw", [{"severity": None}, {}])  # present-but-null ≡ omitted (R4.1)
+def test_null_severity_coerces_to_none_not_none_string(raw: dict[str, Any]) -> None:
+    fields = pr_review.extract_item_fields({"file": "a.py", "line": 1, **raw})
+    assert fields is not None
+    assert fields.severity is None  # not the string "none"
+
+
+def test_null_severity_does_not_block_approval(
+    pr: PRInfo, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # SUPERVISE_SCHEMA emits severity: null — must approve like omitted.
+    classified = pr_review._ClassifiedIssues(
+        inline=[{"path": "a.py", "line": 10, "side": "RIGHT", "body": "x"}],
+        inline_issues=[ParsedIssue(path="a.py", line=10, title="t", body="b", severity=None)],
+    )
+    fixture = (
+        Path(__file__).parent / "fixtures" / "trajectories" / "single_phase_claude.json"
+    )
+    monkeypatch.setattr(pr_review, "_resolve_trajectory_paths", lambda _r: ([fixture], None))
+
+    payload = build_payload(pr, classified, approve_on_clean=True)
+    assert payload["event"] == "APPROVE"
+    assert "**Severity:** none" not in payload["body"]  # no phantom label rendered

--- a/tests/test_review_profile.py
+++ b/tests/test_review_profile.py
@@ -202,3 +202,7 @@ def test_clone_override_revalidates_and_rejects_forbidden() -> None:
     base = rp.build_default_profile()
     with pytest.raises(rp.ProfileError):
         rp.clone_with_overrides(base, {"intent": {"backend": "claude"}})  # host-owned
+
+
+def test_suppression_severity_classes_default_narrowed() -> None:
+    assert rp.Suppression.severity_classes == ("low",)

--- a/tests/test_review_profile.py
+++ b/tests/test_review_profile.py
@@ -213,3 +213,16 @@ def test_parse_review_strategy_has_no_default_to_high_hint() -> None:
     strategy must no longer carry the "Default to high" severity instruction
     (parse stage removed, issue #745)."""
     assert "Default to high" not in rp.build_default_profile().strategies["parse"].content
+
+
+def test_review_profile_severity_levels_derive_from_severity_module() -> None:
+    from daydream import severity
+
+    assert rp._SEVERITY_LEVELS == frozenset(severity.CANONICAL_LEVELS)
+
+
+def test_review_profile_no_stale_mapping_citation() -> None:
+    # benchmark/mapping.py does not exist — the comment citing it must be gone/corrected.
+    import inspect
+
+    assert "benchmark/mapping.py" not in inspect.getsource(rp)

--- a/tests/test_review_profile.py
+++ b/tests/test_review_profile.py
@@ -206,3 +206,10 @@ def test_clone_override_revalidates_and_rejects_forbidden() -> None:
 
 def test_suppression_severity_classes_default_narrowed() -> None:
     assert rp.Suppression.severity_classes == ("low",)
+
+
+def test_parse_review_strategy_has_no_default_to_high_hint() -> None:
+    """R3/A2: the mirrored parse-hint copy is dead — the profile's ``parse``
+    strategy must no longer carry the "Default to high" severity instruction
+    (parse stage removed, issue #745)."""
+    assert "Default to high" not in rp.build_default_profile().strategies["parse"].content

--- a/tests/test_severity.py
+++ b/tests/test_severity.py
@@ -1,0 +1,21 @@
+# tests/test_severity.py
+from daydream import severity
+
+
+def test_canonical_levels_are_low_medium_high() -> None:
+    assert severity.CANONICAL_LEVELS == ("low", "medium", "high")
+
+
+def test_normalize_severity_maps_known_and_rejects_unknown() -> None:
+    assert severity.normalize_severity("HIGH") == "high"
+    assert severity.normalize_severity(" Medium ") == "medium"
+    assert severity.normalize_severity("low") == "low"
+    assert severity.normalize_severity("") is None
+    assert severity.normalize_severity(None) is None
+    assert severity.normalize_severity("CRITICAL") is None  # unknown: caller maps explicitly
+
+
+def test_severity_rank_matches_current_ordering() -> None:
+    # Pins the existing sort semantics: unknown/absent ranks as medium (1).
+    assert severity.SEVERITY_RANK == {"low": 2, "medium": 1, "high": 0}
+    assert severity.SEVERITY_RANK.get("bogus", 1) == 1

--- a/tests/test_ui_summary.py
+++ b/tests/test_ui_summary.py
@@ -1,0 +1,24 @@
+"""Tests for daydream.ui.summary severity rendering policy (issue #972 R3)."""
+
+from typing import Any
+
+from daydream.ui import summary
+
+
+def test_summary_missing_severity_is_none_not_medium() -> None:
+    """R3.1: missing severity renders as absent (``None``), never a fabricated
+    ``"medium"`` — the unified fallback policy at the UI boundary."""
+    assert summary._display_severity({}) is None
+
+
+def test_summary_known_severity_normalizes() -> None:
+    assert summary._display_severity({"severity": "HIGH"}) == "high"
+
+
+def test_summary_unknown_severity_is_none() -> None:
+    assert summary._display_severity({"severity": "bogus"}) is None
+
+
+def test_display_severity_is_none_safe() -> None:
+    issue: dict[str, Any] = {"severity": None}
+    assert summary._display_severity(issue) is None


### PR DESCRIPTION
## Summary
- Unify finding-severity policy under a single canonical `low|medium|high` vocabulary (`daydream/severity.py`) with a host-owned severity rubric appended to every severity-assigning prompt; no more fabricated `medium` defaults for missing/off-vocabulary severities
- Make the approval gate demotion-aware: findings demoted for unverified citations and off-vocabulary severity strings block approval even when folded severity is non-blocking; location demotion is non-destructive (original severity preserved)
- Wire `Arbitration.min_severity` and `Suppression.severity_classes` review-profile knobs into the arbiter and suppression passes
- Correct CHANGELOG precision-mode activation claim (docs-only; no version-header changes)

## Test Plan
- [x] Full test suite green on branch (incl. round-2 review fixes, commit 6e55dec)
- [x] `test_historical_records_preserved` passes (CHANGELOG digest intact)
- [x] Authorship gate: AUTHORS_OK on all branch commits

Closes #972