### PR TITLE
fix(osprey): bound oversized backend streams

### DIFF
--- a/daydream/backends/osprey.py
+++ b/daydream/backends/osprey.py
@@ -45,6 +45,9 @@ from daydream.trajectory import redact_text
 logger = logging.getLogger(__name__)
 
 _OSPREY_STDOUT_LIMIT_BYTES = 10 * 1024 * 1024
+_OSPREY_OBSERVATION_UPDATE_BYTES = 64 * 1024
+_OSPREY_OBSERVATION_INLINE_BYTES = 256 * 1024
+_OSPREY_OBSERVATION_ADMISSION_BYTES = 2 * 1024 * 1024
 _JSONL_PROTOCOL_VERSION = 2
 _MAX_DIAGNOSTIC_LINES = 10
 _MAX_DIAGNOSTIC_LINE_CHARS = 500
@@ -175,18 +178,34 @@ def _bounded_diagnostics(lines: Iterable[str]) -> str:
     for line in lines:
         if len(cleaned) >= _MAX_DIAGNOSTIC_LINES:
             break
-        cleaned.append(redact_text(line)[:_MAX_DIAGNOSTIC_LINE_CHARS])
+        cleaned.append(_bounded_diagnostic_line(line))
     if not cleaned:
         return "no diagnostic output captured"
     return "\n".join(cleaned)
 
 
+def _bounded_diagnostic_line(line: str) -> str:
+    return redact_text(line)[:_MAX_DIAGNOSTIC_LINE_CHARS]
+
+
 async def _drain_stderr(stderr: asyncio.StreamReader, diagnostics: list[str]) -> None:
     """Drain Osprey diagnostics without allowing its stderr pipe to fill."""
-    while line := await stderr.readline():
+    while True:
+        try:
+            line = await stderr.readline()
+        except ValueError:
+            # ``StreamReader.readline`` clears an over-limit unterminated line
+            # before raising. Stderr is diagnostic-only, so discard that line
+            # and keep draining instead of failing an otherwise valid JSONL
+            # session during teardown.
+            if len(diagnostics) < _MAX_DIAGNOSTIC_LINES:
+                diagnostics.append("stderr diagnostic line exceeded stream limit and was discarded")
+            continue
+        if not line:
+            break
         raw = line.decode(errors="replace").strip()
         if raw and len(diagnostics) < _MAX_DIAGNOSTIC_LINES:
-            diagnostics.append(raw)
+            diagnostics.append(_bounded_diagnostic_line(raw))
 
 
 @dataclass(frozen=True)
@@ -392,7 +411,17 @@ class OspreyBackend:
         if continuation is not None and continuation.backend not in {"osprey", ""}:
             continuation = None
 
-        args = [self.osprey_binary, "agent", "--events-jsonl"]
+        args = [
+            self.osprey_binary,
+            "agent",
+            "--events-jsonl",
+            "--observation-budget-update-bytes",
+            str(_OSPREY_OBSERVATION_UPDATE_BYTES),
+            "--observation-budget-inline-bytes",
+            str(_OSPREY_OBSERVATION_INLINE_BYTES),
+            "--observation-budget-admission-bytes",
+            str(_OSPREY_OBSERVATION_ADMISSION_BYTES),
+        ]
         if self.persona:
             args.extend(["--persona", self.persona])
         if self.toolset:
@@ -566,9 +595,15 @@ class OspreyBackend:
             while True:
                 if proc.stdout is None:
                     break
-                line = await readline_with_idle_timeout(
-                    proc.stdout, cli="osprey", timeout_s=stream_idle_timeout_s()
-                )
+                try:
+                    line = await readline_with_idle_timeout(
+                        proc.stdout, cli="osprey", timeout_s=stream_idle_timeout_s()
+                    )
+                except ValueError as exc:
+                    raise OspreyProtocolError(
+                        "Osprey stdout JSONL line exceeded the "
+                        f"{_OSPREY_STDOUT_LIMIT_BYTES}-byte limit"
+                    ) from exc
                 if not line:
                     break
                 raw = line.decode(errors="replace").strip()

--- a/docs/backends/osprey.md
+++ b/docs/backends/osprey.md
@@ -30,14 +30,17 @@ normal environment/configuration; credentials are never placed in argv.
 | Headless approval | `--approval deny-untrusted`; interactive approval values fail before launch |
 | Sandbox / roots | `--sandbox`, repeatable `--allowed-root` |
 | Turn/stream limits | `--max-turns`, `--turn-timeout`, `--stream-idle-timeout-secs`, `--streaming-timeout-secs` |
+| Observation budget | Always enables Osprey's 64 KiB per-update, 256 KiB per-call inline, and 2 MiB aggregate admission limits so tool streaming remains below Daydream's JSONL framing limit |
 | Result caps/spill | `--tool-result-cap`, `--tool-result-head`, `--tool-result-tail`, `--tool-result-max-lines`, `--tool-result-raw-dir` |
 | Structured output | Writes the supplied JSON Schema to a temporary file and passes `--output-schema`; the file is removed after the subprocess ends |
 | Persistence | Osprey sessions are persistent by default; `resume` and `fork` map to `--resume` and `--fork-from`. `persist_session=False` fails closed because this CLI has no ephemeral-session flag |
 | Provider/base URL | Resolved by Osprey config/environment; the current CLI exposes no verified provider/base-url flags |
 
-Omitting an option preserves Osprey’s own defaults. Unsupported options are
-typed `OspreyUnsupportedOption` errors rather than silently dropped security
-or policy settings.
+Except for the adapter-enforced observation budget, omitting an option preserves
+Osprey’s own defaults. Unsupported options are typed `OspreyUnsupportedOption`
+errors rather than silently dropped security or policy settings. Osprey's
+sandbox lane does not currently apply the per-update or per-call observation
+caps, so the adapter's framing guard remains authoritative in sandboxed runs.
 
 ## Stream and terminal semantics
 
@@ -52,7 +55,10 @@ Other terminal outcomes (`failed`, `cancelled`, `max_continuations`,
 producer’s outcome when the subprocess exits successfully. A non-zero subprocess
 exit is a backend failure even if the stream reported a terminal outcome. Missing
 headers, malformed required fields, unknown event names, and truncated streams
-are also explicit bounded backend failures.
+are also explicit bounded backend failures. A stdout JSONL record exceeding the
+10 MiB framing limit raises a typed `OspreyProtocolError`; an oversized stderr
+diagnostic is discarded with a bounded sentinel while the adapter continues to
+drain the diagnostic pipe.
 
 ## Identity and tool calls
 

--- a/tests/test_backend_osprey.py
+++ b/tests/test_backend_osprey.py
@@ -26,6 +26,7 @@ from daydream.backends.osprey import (
     OspreyError,
     OspreyTerminalError,
     OspreyUnsupportedOption,
+    _drain_stderr,
 )
 from daydream.trajectory import DaydreamPhase, DaydreamRunFlow, TrajectoryRecorder
 
@@ -64,10 +65,12 @@ class _FakeProcess:
         returncode: int = 0,
         stderr_lines: list[str] | None = None,
         stderr_held_open: bool = False,
+        stdout_reader: asyncio.StreamReader | None = None,
+        stderr_reader: asyncio.StreamReader | None = None,
     ) -> None:
-        self.stdout = _FakeStdout(lines)
+        self.stdout = stdout_reader or _FakeStdout(lines)
         self._stderr_eof = asyncio.Event() if stderr_held_open else None
-        self.stderr = _FakeStderr(stderr_lines or [], self._stderr_eof)
+        self.stderr = stderr_reader or _FakeStderr(stderr_lines or [], self._stderr_eof)
         self.returncode = returncode
         self.pid = 137
 
@@ -114,6 +117,13 @@ def _stream(
     ], returncode
 
 
+def _over_limit_reader(payload: bytes) -> asyncio.StreamReader:
+    reader = asyncio.StreamReader(limit=64)
+    reader.feed_data(payload)
+    reader.feed_eof()
+    return reader
+
+
 async def _collect(
     backend: OspreyBackend,
     lines: list[dict[str, object]],
@@ -127,12 +137,16 @@ async def _collect(
     persist_session: bool = True,
     stderr_lines: list[str] | None = None,
     stderr_held_open: bool = False,
+    stdout_reader: asyncio.StreamReader | None = None,
+    stderr_reader: asyncio.StreamReader | None = None,
 ) -> tuple[list[AgentEvent], AsyncMock]:
     process = _FakeProcess(
         lines,
         returncode=returncode,
         stderr_lines=stderr_lines,
         stderr_held_open=stderr_held_open,
+        stdout_reader=stdout_reader,
+        stderr_reader=stderr_reader,
     )
     exec_mock = AsyncMock(return_value=process)
     terminate_mock = AsyncMock(side_effect=lambda _process: process.close_stderr())
@@ -154,6 +168,66 @@ async def _collect(
             )
         ]
     return events, exec_mock
+
+
+@pytest.mark.asyncio
+async def test_oversized_stdout_line_is_categorized_as_protocol_error() -> None:
+    stdout = _over_limit_reader(b"x" * 65)
+    backend = OspreyBackend(osprey_binary="fake")
+
+    with pytest.raises(OspreyError, match=r"(?i)stdout.*limit") as exc_info:
+        await _collect(
+            backend,
+            [],
+            stdout_reader=stdout,
+        )
+
+    assert exc_info.value.category == "PROTOCOL"
+    assert backend._processes == []
+
+
+@pytest.mark.asyncio
+async def test_oversized_stderr_diagnostic_does_not_fail_successful_run() -> None:
+    lines, _ = _stream()
+    stderr = _over_limit_reader(b"diagnostic" * 8)
+
+    events, _ = await _collect(
+        OspreyBackend(osprey_binary="fake"),
+        lines,
+        stderr_reader=stderr,
+    )
+
+    assert [type(event) for event in events] == [ResultEvent]
+
+
+@pytest.mark.asyncio
+async def test_oversized_stderr_diagnostic_is_reported_on_process_failure() -> None:
+    lines, _ = _stream()
+    stderr = _over_limit_reader(b"provider authentication failed" * 3)
+
+    with pytest.raises(OspreyError, match="stderr diagnostic line exceeded stream limit"):
+        await _collect(
+            OspreyBackend(osprey_binary="fake"),
+            lines,
+            returncode=1,
+            stderr_reader=stderr,
+        )
+
+
+@pytest.mark.asyncio
+async def test_stderr_diagnostics_are_redacted_and_capped_while_draining() -> None:
+    secret = "sk-realvalue123"
+    diagnostics: list[str] = []
+    stderr = asyncio.StreamReader(limit=2_048)
+    stderr.feed_data((f"OPENAI_API_KEY={secret} " + "x" * 1_024 + "\n").encode())
+    stderr.feed_eof()
+
+    await _drain_stderr(stderr, diagnostics)
+
+    assert len(diagnostics) == 1
+    assert len(diagnostics[0]) <= 500
+    assert secret not in diagnostics[0]
+    assert "[REDACTED_ENV_VAR]" in diagnostics[0]
 
 
 @pytest.mark.asyncio
@@ -202,6 +276,12 @@ def test_factory_builds_verified_osprey_jsonl_command() -> None:
         "fake-osprey",
         "agent",
         "--events-jsonl",
+        "--observation-budget-update-bytes",
+        "65536",
+        "--observation-budget-inline-bytes",
+        "262144",
+        "--observation-budget-admission-bytes",
+        "2097152",
         "--model",
         "test-model",
         "hello",
@@ -497,7 +577,19 @@ def test_command_forwards_verified_policy_resume_fork_and_schema_flags(tmp_path:
         max_turns=3,
         read_only=True,
     )
-    assert command[:5] == ["fake", "agent", "--events-jsonl", "--model", "m"]
+    assert command[:11] == [
+        "fake",
+        "agent",
+        "--events-jsonl",
+        "--observation-budget-update-bytes",
+        "65536",
+        "--observation-budget-inline-bytes",
+        "262144",
+        "--observation-budget-admission-bytes",
+        "2097152",
+        "--model",
+        "m",
+    ]
     assert "--read-only" in command
     assert command[command.index("--fork-from") + 1] == "s"
     assert command[command.index("--output-schema") + 1].endswith("schema.json")


### PR DESCRIPTION
## Summary

Prevents oversized Osprey JSONL and diagnostic records from surfacing as an uncategorized fatal asyncio `ValueError` during Daydream's listen phase.

## Changes

### Fixed

- Enable Osprey observation budgets for streamed updates, inline tool results, and aggregate admission.
- Convert oversized stdout JSONL records into a typed, bounded `OspreyProtocolError` while preserving process cleanup.
- Keep stderr diagnostic-only: discard oversized records, retain a bounded sentinel, and redact/cap diagnostics at ingestion.

### Added

- Regression coverage for oversized stdout, oversized stderr on successful and failed runs, cleanup, diagnostic bounds, and observation-budget argv.
- Osprey backend documentation for the observation-budget and stream-failure contracts.

## Motivation

Osprey produced an observation without an active budget, while Daydream's adapter read newline-delimited records through a 10 MiB `StreamReader`. An oversized record therefore escaped as `ValueError: Separator is not found, and chunk exceed the limit` instead of a typed backend error. This change constrains the producer where supported and hardens the adapter boundary for every path.

## Testing

- [x] Osprey regression suite: 32 passed
- [x] Full core suite: 4,676 passed, 4 skipped
- [x] RL suite: 172 passed, 1 skipped
- [x] Ruff, mypy, vulture, lock checks, coverage, and commit-signature verification passed
- [x] Independent code review completed with no Critical or Important findings

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally
- [x] Linting passes
- [x] Documentation updated
