### PR TITLE
fix(benchmark): reply-thread identity, stale-view spin, facts gate (#879)

### DIFF
--- a/daydream/benchmark/curate_tui.py
+++ b/daydream/benchmark/curate_tui.py
@@ -199,7 +199,7 @@ def _refresh_stale_view(root: Path, case_id: str) -> _ViewBinding:
         binding = _view_binding(view)
         if not _binding_stale(root, case_id, binding):
             return binding
-    print("view keeps changing \u2014 display refreshed; retry the action")
+    print("view keeps changing \u2014 display refreshed; proceeding with the freshest binding")
     return binding
 
 
@@ -802,7 +802,9 @@ def _run_case(root: Path, case_id: str, read_line: Callable[[str], str]) -> str:
     after render (stale binding), the loop prints a rerender prompt and
     re-renders (bounded to ``_MAX_STALE_RERENDERS`` consecutive attempts via
     :func:`_refresh_stale_view`) instead of re-interpreting the number against
-    fresh content.
+    content the user never saw; the number action then proceeds against the
+    freshest displayed binding, so a continuously-mutating case can never
+    re-arm the rerender bound and spin forever.
     """
     view = cu.get_case(root, case_id)
     print(render_case(view))
@@ -814,7 +816,6 @@ def _run_case(root: Path, case_id: str, read_line: Callable[[str], str]) -> str:
                 if action.isdigit():
                     if not _check_fresh(root, case_id, binding):
                         binding = _refresh_stale_view(root, case_id)
-                        continue
                     sid = _resolve_number(int(action), binding)
                     if sid is None:
                         print(f"no evidence number {action}")

--- a/daydream/benchmark/curate_tui.py
+++ b/daydream/benchmark/curate_tui.py
@@ -6,6 +6,8 @@ mutates the case YAML/model directly. Rendering is plain-string builders for
 deterministic tests; Rich stays available for live styling.
 """
 
+import hashlib
+import json
 import os
 import shlex
 import subprocess
@@ -98,17 +100,173 @@ def _prompt(read_line: Callable[[str], str], message: str) -> str:
 
 
 def _evidence_entries(view: dict[str, Any]) -> list[Any]:
-    """The ordered evidence entries to render/page/edit/exclude in *view*.
+    """The ordered evidence entries of *view* in canonical order.
 
     Prefers the full import-evidence list and falls back to ``candidates`` only
-    for a minimal dict without an ``evidence`` key, so the render, edit,
-    exclude, and pager paths all target the same set and cannot drift.
+    for a minimal dict without an ``evidence`` key. The prioritized render and
+    every number-based action instead number through the captured view binding
+    (:func:`_view_binding`); this canonical order remains the fallback path for
+    a minimal dict and the import-order source of ``position``.
     """
     return view.get("evidence") or view.get("candidates") or []
 
 
+class _ViewBinding(list):  # type: ignore[type-arg]
+    """The captured ordered entry→source_id map formed at render time.
+
+    A ``list[str]`` of source_ids in exactly the order :func:`render_case`
+    numbered them, carrying the digest of the view it was captured from so
+    :func:`_binding_stale` can detect any post-render case mutation.
+    """
+
+    def __init__(self, source_ids: list[str], digest: str) -> None:
+        super().__init__(source_ids)
+        self.digest = digest
+
+
+def _view_digest(view: dict[str, Any]) -> str:
+    """A stable digest of one :func:`cu.get_case` view (never persisted)."""
+    return hashlib.sha256(
+        json.dumps(view, sort_keys=True, default=str).encode()
+    ).hexdigest()
+
+
+def _view_binding(view: dict[str, Any]) -> _ViewBinding:
+    """The captured entry→source_id map for *view*, in render order.
+
+    One source of numbering for render/page/edit/exclude/accept: the
+    prioritized entries when the case carries facts (and candidates), else the
+    canonical evidence order (the minimal-dict fallback).
+    """
+    prioritized = (view.get("prioritized_evidence") or {}).get("entries") or []
+    if prioritized and view.get("prioritization") is not None and view.get("candidates"):
+        source_ids = [e["source_id"] for e in prioritized]
+    else:
+        source_ids = [ev.get("source_id") or "" for ev in _evidence_entries(view)]
+    return _ViewBinding(source_ids, _view_digest(view))
+
+
+def _resolve_number(number: int, binding: list[str]) -> str | None:
+    """Resolve a 1-based displayed *number* through the captured *binding*.
+
+    Returns the source_id the render displayed at that number, or ``None``
+    when out of range — never a fresh re-derivation.
+    """
+    index = number - 1
+    if not (0 <= index < len(binding)):
+        return None
+    return binding[index] or None
+
+
+def _binding_stale(root: Path, case_id: str, binding: list[str]) -> bool:
+    """True when the case changed after *binding* was captured at render time.
+
+    Compares the render-time view digest against a fresh read, so any case-doc
+    mutation (finding, exclusion, state transition) invalidates the captured
+    numbering instead of letting an old number reinterpret fresh content.
+    """
+    fresh = _view_binding(cu.get_case(root, case_id))
+    if isinstance(binding, _ViewBinding):
+        return binding.digest != fresh.digest
+    return list(binding) != list(fresh)
+
+
+def _check_fresh(root: Path, case_id: str, binding: list[str]) -> bool:
+    """Print the rerender prompt and return ``False`` when *binding* is stale."""
+    if not _binding_stale(root, case_id, binding):
+        return True
+    print("view changed — rerendering")
+    return False
+
+
+def _entry_block(
+    ev: dict[str, Any],
+    candidates: list[dict[str, Any]],
+    number: int,
+    entry: dict[str, Any] | None,
+) -> str:
+    """The numbered detail block for one evidence record.
+
+    *entry* is the prioritized projection entry (band/reasons/disposition) when
+    the case renders sectioned, else ``None`` for the canonical fallback.
+    """
+    cand = None
+    cand_index = ev.get("candidate_index")
+    if cand_index is not None and 0 <= cand_index < len(candidates):
+        cand = candidates[cand_index]
+    elif isinstance(ev.get("title"), str):
+        # minimal candidate-only fallback stores its own metadata.
+        cand = ev
+    author = ev.get("author") or {}
+    login = author.get("login") or "-"
+    if author.get("type") == "Bot":
+        login = f"{login}[bot]"
+    kind = ev.get("kind") or "-"
+    commit = (ev.get("commit_id") or "")[:12] or "-"
+    rec_state = ev.get("state")
+    state_tag = f" {rec_state}" if rec_state else ""
+    loc_path = ev.get("path")
+    start = ev.get("start_line") or ev.get("line")
+    if cand is not None:
+        cand_loc = cand.get("location") or {}
+        loc_path = loc_path or cand_loc.get("path")
+        start = start or cand_loc.get("start_line")
+    loc_path = loc_path or "-"
+    anchor = f"{loc_path}:{start}" if loc_path != "-" and start else loc_path
+    markers = ""
+    if ev.get("resolved"):
+        markers += " [resolved]"
+    if ev.get("outdated"):
+        markers += " [outdated]"
+    authoring = ""
+    auth_anchor = ev.get("authoring_anchor")
+    if isinstance(auth_anchor, dict) and auth_anchor.get("commit_id"):
+        authoring = f" auth:{auth_anchor['commit_id'][:12]}"
+    reason = ""
+    if cand is not None and not cand.get("exact_acceptable"):
+        reason_tag = cand.get("not_exact_reason")
+        if reason_tag:
+            reason = f" [{reason_tag}]"
+    advisory = ""
+    if entry is not None:
+        parts = []
+        if entry.get("reasons"):
+            parts.append("reasons: " + ",".join(entry["reasons"]))
+        parts.append(f"disp: {entry.get('disposition') or '-'}")
+        advisory = " (" + "; ".join(parts) + ")"
+    preview = (ev.get("body") or "").replace("\n", " ")[:120]
+    src = ev.get("source_id") or ""
+    src_tag = f" {src}" if src else ""
+    line_parts = [
+        f"  {number}. [{kind}] {login} commit:{commit}{authoring}{reason}{state_tag}"
+        f" {anchor}{markers}{advisory}{src_tag}",
+        f"      {preview or '-'}",
+    ]
+    if cand is not None:
+        line_parts.insert(1, f"      {cand.get('title') or '-'}")
+    return "\n".join(line_parts)
+
+
+_LEGEND = (
+    "legend: resolved/outdated = already addressed; "
+    "anchor-delta-changed/deleted/renamed/binary = anchor drifted since authoring; "
+    "pr-author-reply = PR author replied; "
+    "commit-non-ancestor/commit-unavailable/anchor-unavailable/facts-missing = could not verify at head; "
+    "dismissed/decided-by-finding/decided-by-exclusion/decided-by-conflict/non-candidate = classification"
+)
+
+
 def render_case(case: dict[str, Any]) -> str:
-    """Render a plain-text snapshot header + numbered evidence list.
+    """Render the snapshot header plus the numbered evidence view.
+
+    When the case carries prioritization facts, evidence renders in labeled
+    band sections (:data:`cu.BAND_RANK` order, only non-empty bands), each
+    entry keeping its detail line plus advisory reason/disposition markers,
+    closed by a legend line decoding the reason codes. Numbering comes from the
+    captured view binding (:func:`_view_binding`) — the same order every
+    number-based action resolves through. When every candidate lacks facts,
+    the canonical order renders with a ``needs_judgment`` note instead; a
+    minimal dict without an ``evidence`` key falls back to ``candidates``.
 
     Every evidence entry shows its number, kind, author login (+ ``[bot]`` for a
     bot), the re-anchored ``commit_id`` prefix (labeled ``commit:``) and — where
@@ -117,9 +275,7 @@ def render_case(case: dict[str, Any]) -> str:
     acceptance is unavailable, and — where the record carries one — its review
     ``state`` (e.g. ``APPROVED``/``COMMENTED``/``CHANGES_REQUESTED``), the
     ``path:line`` anchor, resolved/outdated markers, and a body preview (first
-    ~120 chars). Candidate records additionally show their title. Sources from
-    the full ordered evidence list; callers passing a minimal dict without an
-    ``evidence`` key fall back to ``candidates``.
+    ~120 chars). Candidate records additionally show their title.
     """
     snapshot = case.get("snapshot") or {}
     curation = case.get("curation") or {}
@@ -127,56 +283,31 @@ def render_case(case: dict[str, Any]) -> str:
     policy = snapshot.get("policy") or "-"
     state = curation.get("state") or "-"
     candidates = case.get("candidates") or []
-    entries = _evidence_entries(case)
+    prioritized = (case.get("prioritized_evidence") or {}).get("entries") or []
+    facts = case.get("prioritization")
     lines = [
         f"case {case.get('case_id')}: state={state} policy={policy} head={head}",
     ]
+    if prioritized and facts is not None and candidates:
+        records = case.get("evidence") or []
+        binding_ids: list[str] = []
+        for band in sorted(cu.BAND_RANK, key=cu.BAND_RANK.__getitem__):
+            group = [e for e in prioritized if e["band"] == band]
+            if not group:
+                continue
+            lines.append(f"-- {band} --")
+            for entry in group:
+                rec = records[entry["position"]]
+                number = len(binding_ids) + 1
+                binding_ids.append(entry["source_id"])
+                lines.append(_entry_block(rec, candidates, number, entry))
+        lines.append(_LEGEND)
+        return "\n".join(lines)
+    entries = _evidence_entries(case)
+    if prioritized and candidates and facts is None:
+        lines.append("note: needs_judgment — no prioritization facts for any candidate")
     for i, ev in enumerate(entries, start=1):
-        cand = None
-        cand_index = ev.get("candidate_index")
-        if cand_index is not None and 0 <= cand_index < len(candidates):
-            cand = candidates[cand_index]
-        elif isinstance(ev.get("title"), str):
-            # minimal candidate-only fallback stores its own metadata.
-            cand = ev
-        author = ev.get("author") or {}
-        login = author.get("login") or "-"
-        if author.get("type") == "Bot":
-            login = f"{login}[bot]"
-        kind = ev.get("kind") or "-"
-        commit = (ev.get("commit_id") or "")[:12] or "-"
-        rec_state = ev.get("state")
-        state_tag = f" {rec_state}" if rec_state else ""
-        loc_path = ev.get("path")
-        start = ev.get("start_line") or ev.get("line")
-        if cand is not None:
-            cand_loc = cand.get("location") or {}
-            loc_path = loc_path or cand_loc.get("path")
-            start = start or cand_loc.get("start_line")
-        loc_path = loc_path or "-"
-        anchor = f"{loc_path}:{start}" if loc_path != "-" and start else loc_path
-        markers = ""
-        if ev.get("resolved"):
-            markers += " [resolved]"
-        if ev.get("outdated"):
-            markers += " [outdated]"
-        authoring = ""
-        auth_anchor = ev.get("authoring_anchor")
-        if isinstance(auth_anchor, dict) and auth_anchor.get("commit_id"):
-            authoring = f" auth:{auth_anchor['commit_id'][:12]}"
-        reason = ""
-        if cand is not None and not cand.get("exact_acceptable"):
-            reason_tag = cand.get("not_exact_reason")
-            if reason_tag:
-                reason = f" [{reason_tag}]"
-        preview = (ev.get("body") or "").replace("\n", " ")[:120]
-        line_parts = [
-            f"  {i}. [{kind}] {login} commit:{commit}{authoring}{reason}{state_tag} {anchor}{markers}",
-            f"      {preview or '-'}",
-        ]
-        if cand is not None:
-            line_parts.insert(1, f"      {cand.get('title') or '-'}")
-        lines.append("\n".join(line_parts))
+        lines.append(_entry_block(ev, candidates, i, None))
     return "\n".join(lines)
 
 
@@ -319,8 +450,11 @@ def _edit_and_stage_fragment(
     return "rerender"
 
 
-def _action_new(root: Path, case_id: str, view: dict[str, Any], read_line: Callable[[str], str]) -> str:
+def _action_new(
+    root: Path, case_id: str, view: dict[str, Any], read_line: Callable[[str], str], binding: list[str]
+) -> str:
     """The ``[n]`` author action: edit a blank fragment, add every atom."""
+    del binding
     return _edit_and_stage_fragment(
         _editor_fragment_new(),
         lambda atoms: cu.add_findings(root, case_id, findings=atoms),
@@ -329,21 +463,25 @@ def _action_new(root: Path, case_id: str, view: dict[str, Any], read_line: Calla
     )
 
 
-def _action_edit(root: Path, case_id: str, view: dict[str, Any], read_line: Callable[[str], str]) -> str:
+def _action_edit(
+    root: Path, case_id: str, view: dict[str, Any], read_line: Callable[[str], str], binding: list[str]
+) -> str:
     """The ``[e]`` edit-or-author action.
 
     Prompts for a finding to rewrite (the existing finding-rewrite path) or
     ``a`` to author edited finding(s) from selected evidence via
-    :func:`add_edited_findings`.
+    :func:`add_edited_findings`. The evidence selector resolves through the
+    captured view binding; a stale binding rerenders instead of acting.
     """
     findings = (view.get("curation") or {}).get("findings") or []
-    entries = _evidence_entries(view)
     first = _prompt(
         read_line,
         "edit finding (number) or author from evidence [a] (0 to cancel): ",
     ).strip()
     if first.lower() == "a":
-        return _edit_author_evidence(root, case_id, entries, read_line)
+        if not _check_fresh(root, case_id, binding):
+            return "rerender"
+        return _edit_author_evidence(root, case_id, binding, read_line)
     text = first
     if text == "0":
         return "continue"
@@ -364,25 +502,28 @@ def _action_edit(root: Path, case_id: str, view: dict[str, Any], read_line: Call
 
 
 def _edit_author_evidence(
-    root: Path, case_id: str, entries: list[dict[str, Any]], read_line: Callable[[str], str]
+    root: Path, case_id: str, binding: list[str], read_line: Callable[[str], str]
 ) -> str:
     """The ``[e]``\u2192[author-from-evidence] sub-flow.
 
-    Parses one 1-based evidence selector (a number or a single ``a-b`` range),
-    pins the selected source_ids into a blank atom, opens the editor, then
-    stages the atoms through :func:`add_edited_findings`. Editor cancellation,
-    an invalid fragment, a curation error or a validation error all mutate
-    nothing.
+    Parses one 1-based evidence selector (a number or a single ``a-b`` range)
+    against the captured view binding, pins the selected source_ids into a
+    blank atom, opens the editor, then stages the atoms through
+    :func:`add_edited_findings`. Editor cancellation, an invalid fragment, a
+    curation error or a validation error all mutate nothing.
     """
     text = _prompt(read_line, "evidence (number or range, 0 to cancel): ").strip()
     if text == "0":
         return "continue"
     try:
-        indices = parse_indices(text, len(entries))
+        indices = parse_indices(text, len(binding))
     except ValueError as exc:
         print(str(exc))
         return "continue"
-    source_ids = [entries[i]["source_id"] for i in indices]
+    source_ids = [binding[i] for i in indices]
+    if any(not sid for sid in source_ids):
+        print("selected entry has no source_id")
+        return "continue"
     return _edit_and_stage_fragment(
         _editor_fragment_authored(source_ids),
         lambda atoms: cu.add_edited_findings(root, case_id, atoms=atoms),
@@ -397,9 +538,14 @@ _CASE_EXCLUSION_REASONS = cu._CASE_EXCLUSION_REASONS
 
 
 def _action_exclude_case(
-    root: Path, case_id: str, view: dict[str, Any], read_line: Callable[[str], str]
+    root: Path,
+    case_id: str,
+    view: dict[str, Any],
+    read_line: Callable[[str], str],
+    binding: list[str],
 ) -> str:
     """The ``[z]`` case-exclusion action (4 fixed reasons + optional note)."""
+    del binding
     reason = _prompt(
         read_line, f"reason ({'|'.join(_CASE_EXCLUSION_REASONS)}): "
     ).strip()
@@ -424,9 +570,10 @@ def _action_exclude_case(
 
 
 def _action_reinclude(
-    root: Path, case_id: str, view: dict[str, Any], read_line: Callable[[str], str]
+    root: Path, case_id: str, view: dict[str, Any], read_line: Callable[[str], str], binding: list[str]
 ) -> str:
     """The ``[i]`` re-include action for an excluded case."""
+    del binding
     try:
         cu.reinclude_case(root, case_id)
     except cu.CurationError as exc:
@@ -436,9 +583,10 @@ def _action_reinclude(
 
 
 def _action_clean(
-    root: Path, case_id: str, view: dict[str, Any], read_line: Callable[[str], str]
+    root: Path, case_id: str, view: dict[str, Any], read_line: Callable[[str], str], binding: list[str]
 ) -> str:
     """The ``[c]`` clean-attest action (requires an empty gold findings set)."""
+    del binding
     findings = (view.get("curation") or {}).get("findings") or []
     if findings:
         print("[c] requires an empty gold findings set")
@@ -457,7 +605,7 @@ def _action_clean(
 
 
 def _action_ready(
-    root: Path, case_id: str, view: dict[str, Any], read_line: Callable[[str], str]
+    root: Path, case_id: str, view: dict[str, Any], read_line: Callable[[str], str], binding: list[str]
 ) -> str:
     """The ``[r]`` mark-ready action: pages the exact Task Spec and asks one combined question.
 
@@ -469,6 +617,7 @@ def _action_ready(
     pre-lock render and cannot abort a later whole-workspace compile. Anything
     else is a no-op leaving the case ``draft``.
     """
+    del binding
     head = (view.get("snapshot") or {}).get("original_head_sha") or ""
     raw = load_yaml_strict(Path(root) / "cases" / f"{case_id}.yaml")
     spec_bytes = build.render_task_spec(raw, instruction=build.ASSIGNMENT_TEXT)
@@ -489,27 +638,34 @@ def _action_ready(
 
 
 def _action_exclude(
-    root: Path, case_id: str, view: dict[str, Any], read_line: Callable[[str], str]
+    root: Path, case_id: str, view: dict[str, Any], read_line: Callable[[str], str], binding: list[str]
 ) -> str:
-    """The ``[x]`` evidence-exclusion action over the full evidence list.
+    """The ``[x]`` evidence-exclusion action over the captured view binding.
 
-    Parses one 1-based selector (a single index or one ``a-b`` range). The
-    reason/note contract is validated **before** any mutation, then every
-    selected evidence source is excluded with the same reason/note. A bad
-    range, an invalid reason, or a missing ``other`` note mutates nothing.
-    Single-index selections keep the original note prompt (a stray note on a
-    non-``other`` reason is still rejected); a range with reason ``other``
-    prompts for the single note applied to the whole range, so a range
-    exclusion is never a dead-end the service immediately rejects.
+    Parses one 1-based selector (a single index or one ``a-b`` range) against
+    the binding the render numbered. A stale binding prints the rerender prompt
+    and re-renders without acting. The reason/note contract is validated
+    **before** any mutation, then every selected evidence source is excluded
+    with the same reason/note. A bad range, an invalid reason, or a missing
+    ``other`` note mutates nothing. Single-index selections keep the original
+    note prompt (a stray note on a non-``other`` reason is still rejected); a
+    range with reason ``other`` prompts for the single note applied to the
+    whole range, so a range exclusion is never a dead-end the service
+    immediately rejects.
     """
-    entries = _evidence_entries(view)
+    if not _check_fresh(root, case_id, binding):
+        return "rerender"
     text = _prompt(read_line, "evidence (number or range, 0 to cancel): ").strip()
     if text == "0":
         return "continue"
     try:
-        indices = parse_indices(text, len(entries))
+        indices = parse_indices(text, len(binding))
     except ValueError as exc:
         print(str(exc))
+        return "continue"
+    source_ids = [binding[i] for i in indices]
+    if any(not sid for sid in source_ids):
+        print("selected entry has no source_id")
         return "continue"
     reason = _prompt(
         read_line, f"reason ({'|'.join(_EVIDENCE_REASONS)}): "
@@ -526,50 +682,56 @@ def _action_exclude(
     elif len(indices) == 1:
         note = _prompt(read_line, "note: ").strip() or None
     try:
-        cu.exclude_evidence_batch(
-            root,
-            case_id,
-            [entries[i]["source_id"] for i in indices],
-            reason=reason,
-            note=note,
-        )
+        cu.exclude_evidence_batch(root, case_id, source_ids, reason=reason, note=note)
     except cu.CurationError as exc:
         return _service_error(exc)
     print(f"excluded {len(indices)} evidence source(s)")
     return "rerender"
 
 
-def _action_accept(root: Path, case_id: str, view: dict[str, Any], read_line: Callable[[str], str]) -> str:
-    """The ``[a]`` accept-candidate action: one exact-acceptable candidate."""
+def _action_accept(
+    root: Path, case_id: str, view: dict[str, Any], read_line: Callable[[str], str], binding: list[str]
+) -> str:
+    """The ``[a]`` accept-candidate action: one exact-acceptable candidate.
+
+    The candidate number resolves through the captured view binding — the same
+    numbers the render displayed — and a stale binding rerenders instead of
+    re-interpreting the number against fresh content.
+    """
+    if not _check_fresh(root, case_id, binding):
+        return "rerender"
     candidates = view.get("candidates") or []
     text = _prompt(read_line, "candidate (number, 0 to cancel): ").strip()
     if text == "0":
         return "continue"
     try:
-        indices = parse_indices(text, len(candidates))
+        indices = parse_indices(text, len(binding))
     except ValueError as exc:
         print(str(exc))
         return "continue"
     if len(indices) != 1:
         print(f"accept takes exactly one candidate (got {len(indices)})")
         return "continue"
-    cand = candidates[indices[0]]
-    src = cand["source_id"]
+    sid = binding[indices[0]]
+    cand = next((c for c in candidates if c.get("source_id") == sid), None)
+    if cand is None:
+        print(f"no candidate number {text}")
+        return "continue"
     if not cand.get("exact_acceptable"):
-        print(f"{src} is not exactly acceptable \u2014 use [e] to edit it")
+        print(f"{sid} is not exactly acceptable \u2014 use [e] to edit it")
         return "continue"
     try:
-        cu.accept_candidate(root, case_id, src)
+        cu.accept_candidate(root, case_id, sid)
     except cu.CurationError as exc:
         return _service_error(exc)
-    print(f"accepted {src} as a historical finding")
+    print(f"accepted {sid} as a historical finding")
     return "rerender"
 
 
 # Dispatch table: one stable binding per action char. Kept as a module-level dict
 # (rather than an 11-branch if/elif ladder) so it cannot drift from the _ACTIONS
 # frozenset and adding a binding is a single-key change.
-_ACTION_DISPATCH: dict[str, Callable[[Path, str, dict[str, Any], Callable[[str], str]], str]] = {
+_ACTION_DISPATCH: dict[str, Callable[[Path, str, dict[str, Any], Callable[[str], str], list[str]], str]] = {
     "a": _action_accept,
     "n": _action_new,
     "e": _action_edit,
@@ -581,11 +743,13 @@ _ACTION_DISPATCH: dict[str, Callable[[Path, str, dict[str, Any], Callable[[str],
 }
 
 
-def _run_action(action: str, root: Path, case_id: str, view: dict[str, Any], read_line: Callable[[str], str]) -> str:
+def _run_action(
+    action: str, root: Path, case_id: str, view: dict[str, Any], read_line: Callable[[str], str], binding: list[str]
+) -> str:
     """Dispatch one recognized action; returns the next action-loop outcome."""
     handler = _ACTION_DISPATCH.get(action)
     if handler is not None:
-        return handler(root, case_id, view, read_line)
+        return handler(root, case_id, view, read_line, binding)
     if action == "q":
         print("saving; run curate again to resume")
         return "quit"
@@ -606,28 +770,50 @@ def _launch_pager(text: str) -> None:
 
 
 def _run_case(root: Path, case_id: str, read_line: Callable[[str], str]) -> str:
-    """Run one case session; returns ``"quit"`` or ``"done"``."""
-    print(render_case(cu.get_case(root, case_id)))
+    """Run one case session; returns ``"quit"`` or ``"done"``.
+
+    Renders once and captures the view binding the render numbered; every
+    number-based action resolves through that binding. When the case changed
+    after render (stale binding), the loop prints a rerender prompt and
+    re-renders instead of re-interpreting the number against fresh content.
+    """
+    view = cu.get_case(root, case_id)
+    print(render_case(view))
+    binding = _view_binding(view)
     while True:
         try:
             action = _prompt(read_line, _ACTION_PROMPT).strip().lower()
             if action not in _ACTIONS:
                 if action.isdigit():
+                    if not _check_fresh(root, case_id, binding):
+                        view = cu.get_case(root, case_id)
+                        print(render_case(view))
+                        binding = _view_binding(view)
+                        continue
+                    sid = _resolve_number(int(action), binding)
+                    if sid is None:
+                        print(f"no evidence number {action}")
+                        continue
                     view = cu.get_case(root, case_id)
-                    entries = _evidence_entries(view)
-                    index = int(action) - 1
-                    if not (0 <= index < len(entries)):
+                    rec = next(
+                        (r for r in (view.get("evidence") or [])
+                         if r.get("source_id") == sid),
+                        None,
+                    )
+                    if rec is None:
                         print(f"no evidence number {action}")
                     else:
-                        _launch_pager(entries[index].get("body") or "")
+                        _launch_pager(rec.get("body") or "")
                     continue
                 print(f"unknown action: {action}")
                 continue
-            outcome = _run_action(action, root, case_id, cu.get_case(root, case_id), read_line)
+            outcome = _run_action(action, root, case_id, cu.get_case(root, case_id), read_line, binding)
             if outcome in ("quit", "done"):
                 return outcome
             if outcome == "rerender":
-                print(render_case(cu.get_case(root, case_id)))
+                view = cu.get_case(root, case_id)
+                print(render_case(view))
+                binding = _view_binding(view)
         except KeyboardInterrupt:
             print("interrupted \u2014 prior actions preserved")
 

--- a/daydream/benchmark/curate_tui.py
+++ b/daydream/benchmark/curate_tui.py
@@ -179,6 +179,30 @@ def _check_fresh(root: Path, case_id: str, binding: list[str]) -> bool:
     return False
 
 
+_MAX_STALE_RERENDERS = 3
+
+
+def _refresh_stale_view(root: Path, case_id: str) -> _ViewBinding:
+    """Re-render *case_id* and return a binding verified current, bounded.
+
+    A stale binding means the case changed after render; the refresh re-reads,
+    re-renders, and captures a fresh binding, then verifies that captured
+    binding is current — bounded to ``_MAX_STALE_RERENDERS`` consecutive
+    re-renders so a continuously-mutating case can never loop the rerender
+    forever. When the view keeps changing, the freshest displayed binding is
+    returned (the numbering always matches the display) with a message naming
+    the instability.
+    """
+    for _ in range(_MAX_STALE_RERENDERS):
+        view = cu.get_case(root, case_id)
+        print(render_case(view))
+        binding = _view_binding(view)
+        if not _binding_stale(root, case_id, binding):
+            return binding
+    print("view keeps changing \u2014 display refreshed; retry the action")
+    return binding
+
+
 def _entry_block(
     ev: dict[str, Any],
     candidates: list[dict[str, Any]],
@@ -264,8 +288,9 @@ def render_case(case: dict[str, Any]) -> str:
     entry keeping its detail line plus advisory reason/disposition markers,
     closed by a legend line decoding the reason codes. Numbering comes from the
     captured view binding (:func:`_view_binding`) — the same order every
-    number-based action resolves through. When every candidate lacks facts,
-    the canonical order renders with a ``needs_judgment`` note instead; a
+    number-based action resolves through. When the case carries no
+    prioritization facts, the canonical order renders with an explanatory
+    note instead (only signal-free candidates rank as ``needs_judgment``); a
     minimal dict without an ``evidence`` key falls back to ``candidates``.
 
     Every evidence entry shows its number, kind, author login (+ ``[bot]`` for a
@@ -305,7 +330,7 @@ def render_case(case: dict[str, Any]) -> str:
         return "\n".join(lines)
     entries = _evidence_entries(case)
     if prioritized and candidates and facts is None:
-        lines.append("note: needs_judgment — no prioritization facts for any candidate")
+        lines.append("note: no prioritization facts — candidates without record signals rank as needs_judgment")
     for i, ev in enumerate(entries, start=1):
         lines.append(_entry_block(ev, candidates, i, None))
     return "\n".join(lines)
@@ -775,7 +800,9 @@ def _run_case(root: Path, case_id: str, read_line: Callable[[str], str]) -> str:
     Renders once and captures the view binding the render numbered; every
     number-based action resolves through that binding. When the case changed
     after render (stale binding), the loop prints a rerender prompt and
-    re-renders instead of re-interpreting the number against fresh content.
+    re-renders (bounded to ``_MAX_STALE_RERENDERS`` consecutive attempts via
+    :func:`_refresh_stale_view`) instead of re-interpreting the number against
+    fresh content.
     """
     view = cu.get_case(root, case_id)
     print(render_case(view))
@@ -786,9 +813,7 @@ def _run_case(root: Path, case_id: str, read_line: Callable[[str], str]) -> str:
             if action not in _ACTIONS:
                 if action.isdigit():
                     if not _check_fresh(root, case_id, binding):
-                        view = cu.get_case(root, case_id)
-                        print(render_case(view))
-                        binding = _view_binding(view)
+                        binding = _refresh_stale_view(root, case_id)
                         continue
                     sid = _resolve_number(int(action), binding)
                     if sid is None:

--- a/daydream/benchmark/curation.py
+++ b/daydream/benchmark/curation.py
@@ -454,6 +454,55 @@ _DELTA_SIGNAL_CODES = {
 }
 
 
+def _reply_parent_index(records: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Index inline review comments by every id a ``reply_to_id`` can cite.
+
+    REST reply links are stringified parent database ids; GraphQL ``replyTo``
+    links are parent node ids. Only inline comments are indexed — reviews and
+    issue comments are never reply targets and never carry a thread id, so
+    they stay unreachable from any reply (they must not share the reply map's
+    thread-less bucket).
+    """
+    index: dict[str, dict[str, Any]] = {}
+    for rec in records:
+        if rec.get("kind") != "inline_comment":
+            continue
+        db_id = rec.get("database_id")
+        if db_id is not None:
+            index.setdefault(str(db_id), rec)
+            index.setdefault(db_id, rec)
+        node_id = rec.get("node_id")
+        if node_id:
+            index.setdefault(node_id, rec)
+    return index
+
+
+def _thread_key(record: dict[str, Any], parents: dict[str, dict[str, Any]]) -> str | None:
+    """The canonical identity of the thread one evidence record belongs to.
+
+    Threaded records key by their GraphQL thread id. Thread-less records have
+    no thread id, so their identity is the top of the REST reply chain they
+    hang off (a threaded comment up the chain donates its thread id, mirroring
+    the grouping the overlay would have provided); a thread-less record that
+    is no reply chain member keys by itself and is unreachable from any reply
+    — never a shared ``None`` bucket.
+    """
+    seen: set[Any] = set()
+    cur = record
+    while not cur.get("thread_id"):
+        source_id = cur.get("source_id")
+        if source_id is not None and source_id in seen:
+            break
+        if source_id is not None:
+            seen.add(source_id)
+        reply_to_id = cur.get("reply_to_id")
+        parent = parents.get(reply_to_id) if reply_to_id else None
+        if parent is None:
+            break
+        cur = parent
+    return cur.get("thread_id") or cur.get("source_id")
+
+
 def collect_signals(record: dict[str, Any], view_context: dict[str, Any]) -> frozenset[str]:
     """The advisory actionability signals one evidence record carries.
 
@@ -490,14 +539,16 @@ def collect_signals(record: dict[str, Any], view_context: dict[str, Any]) -> fro
     created = record.get("created_at")
     if pr_login and created:
         latest = view_context.get("latest_pr_author_reply")
-        if latest is None:
+        parents = view_context.get("reply_parents")
+        if latest is None or parents is None:
             # Fallback for direct callers that did not precompute the
             # per-thread map: scan the full evidence list as before.
-            thread_id = record.get("thread_id")
+            parents = _reply_parent_index(view_context.get("records") or [])
+            thread_key = _thread_key(record, parents)
             for other in view_context.get("records") or []:
                 if other is record or not other.get("reply_to_id"):
                     continue
-                if (other.get("thread_id") or None) != (thread_id or None):
+                if _thread_key(other, parents) != thread_key:
                     continue
                 if ((other.get("author") or {}).get("login")) != pr_login:
                     continue
@@ -507,7 +558,7 @@ def collect_signals(record: dict[str, Any], view_context: dict[str, Any]) -> fro
                 signals.add("pr-author-reply")
                 break
         else:
-            later = latest.get(record.get("thread_id") or None)
+            later = latest.get(_thread_key(record, parents))
             if later is not None and later > created:
                 signals.add("pr-author-reply")
     return frozenset(signals)
@@ -600,18 +651,21 @@ def prioritized_evidence(raw: dict[str, Any]) -> dict[str, Any]:
     }
     pr_login = ((raw.get("pull_request") or {}).get("author") or {}).get("login")
     latest_pr_author_reply: dict[Any, str] = {}
+    reply_parents = _reply_parent_index(records)
     if pr_login and records:
         # One O(N) pass: the latest same-thread reply authored by the PR
         # author per thread, so each collect_signals call answers the
         # strictly-later question in O(1) instead of re-scanning the full
         # evidence list per record (an O(N^2) cost on every get_case, several
-        # per TUI keystroke).
+        # per TUI keystroke). Thread identity is the GraphQL thread id when
+        # present, else the REST reply chain top (:func:`_thread_key`) — never
+        # one shared bucket for every thread-less record.
         for other in records:
             if not other.get("reply_to_id"):
                 continue
             if ((other.get("author") or {}).get("login")) != pr_login:
                 continue
-            tid = other.get("thread_id") or None
+            tid = _thread_key(other, reply_parents)
             t = other.get("created_at")
             if not t:
                 continue
@@ -622,6 +676,7 @@ def prioritized_evidence(raw: dict[str, Any]) -> dict[str, Any]:
         "records": records,
         "facts": facts,
         "latest_pr_author_reply": latest_pr_author_reply,
+        "reply_parents": reply_parents,
     }
     thread_members: dict[str, list[str]] = {}
     for rec in records:

--- a/daydream/benchmark/curation.py
+++ b/daydream/benchmark/curation.py
@@ -347,6 +347,12 @@ def get_case(root: Path, case_id: str) -> dict[str, Any]:
     ``evidence`` list of every import evidence record (all kinds), each
     augmented with a ``candidate_index``. A missing/unreadable import
     file for a case that references it propagates the storage error.
+
+    Additionally the case gains an in-memory (never persisted)
+    ``prioritized_evidence`` projection — the ranked actionability view
+    derived from the persisted ``prioritization`` facts plus current curation
+    state (:func:`prioritized_evidence`); the canonical ``evidence`` order is
+    untouched.
     """
     raw = _load_case(root, case_id)
     projection = _evidence_projection(root, raw)
@@ -356,6 +362,7 @@ def get_case(root: Path, case_id: str) -> dict[str, Any]:
             if src in projection:
                 cand["evidence"] = projection[src]
     raw["evidence"] = _evidence_list(root, raw)
+    raw["prioritized_evidence"] = prioritized_evidence(raw)
     return raw
 
 
@@ -401,6 +408,232 @@ def _evidence_projection(
             "outdated": ev.get("outdated", False),
         }
     return projection
+
+
+# ---------------------------------------------------------------------------
+# prioritized evidence projection (issue #879)
+# ---------------------------------------------------------------------------
+
+# The seven bands in fixed display order (lowest rank first).
+BAND_RANK: dict[str, int] = {
+    "review_first": 0,
+    "needs_judgment": 1,
+    "possibly_actioned": 2,
+    "likely_actioned": 3,
+    "withdrawn": 4,
+    "context": 5,
+    "decided": 6,
+}
+
+# The closed reason-code set, in fixed display order (signal codes, then
+# availability causes, then classification causes).
+REASON_CODES: tuple[str, ...] = (
+    "resolved",
+    "outdated",
+    "anchor-delta-changed",
+    "anchor-delta-deleted",
+    "anchor-delta-renamed",
+    "anchor-delta-binary",
+    "pr-author-reply",
+    "commit-non-ancestor",
+    "commit-unavailable",
+    "anchor-unavailable",
+    "facts-missing",
+    "dismissed",
+    "decided-by-finding",
+    "decided-by-exclusion",
+    "decided-by-conflict",
+    "non-candidate",
+)
+
+_DELTA_SIGNAL_CODES = {
+    "changed": "anchor-delta-changed",
+    "deleted": "anchor-delta-deleted",
+    "renamed": "anchor-delta-renamed",
+    "binary": "anchor-delta-binary",
+}
+
+
+def collect_signals(record: dict[str, Any], view_context: dict[str, Any]) -> frozenset[str]:
+    """The advisory actionability signals one evidence record carries.
+
+    Returns at most the four distinct signal types: ``resolved`` / ``outdated``
+    from the record itself, an anchor-delta signal code from the persisted
+    prioritization facts, and ``pr-author-reply`` when some same-thread later
+    reply was authored by the PR author (strictly later ``created_at``; reply
+    text is never read). Two occurrences of one type still count once — the
+    result is a set.
+
+    *view_context* carries ``pr_author_login`` (str | None), ``records`` (the
+    full evidence list, for reply-chain scanning) and ``facts`` (the persisted
+    ``prioritization`` block or None).
+    """
+    signals: set[str] = set()
+    if record.get("resolved"):
+        signals.add("resolved")
+    if record.get("outdated"):
+        signals.add("outdated")
+    source_id = record.get("source_id")
+    facts = view_context.get("facts") or {}
+    for group in ("candidates", "non_candidates"):
+        entry = (facts.get(group) or {}).get(source_id)
+        if entry:
+            code = _DELTA_SIGNAL_CODES.get(entry.get("anchor_delta"))
+            if code:
+                signals.add(code)
+    pr_login = view_context.get("pr_author_login")
+    created = record.get("created_at")
+    thread_id = record.get("thread_id")
+    if pr_login and created:
+        for other in view_context.get("records") or []:
+            if other is record or not other.get("reply_to_id"):
+                continue
+            if (other.get("thread_id") or None) != (thread_id or None):
+                continue
+            if ((other.get("author") or {}).get("login")) != pr_login:
+                continue
+            other_created = other.get("created_at")
+            if not other_created or other_created <= created:
+                continue
+            signals.add("pr-author-reply")
+            break
+    return frozenset(signals)
+
+
+def classify_evidence(
+    *,
+    refs: set[str],
+    is_candidate: bool,
+    dismissed: bool,
+    signals: frozenset[str] | set[str],
+    facts_present: bool,
+    commit_relation: str,
+    anchor_delta: str,
+) -> tuple[str, str, list[str]]:
+    """Pure first-match-wins band/disposition/reasons classifier.
+
+    Precedence: decided (curation refs) → context (non-candidate) → withdrawn
+    (dismissed) → two-or-more signals (likely_actioned) → one signal
+    (possibly_actioned) → needs_judgment (non-ancestor commit, unavailable
+    commit, unavailable anchor delta, or missing facts) → review_first.
+    Exact-acceptance blockers never alter the band. Reasons carry the codes
+    that justified the band, emitted in :data:`REASON_CODES` order.
+    """
+
+    def ordered(codes: list[str]) -> list[str]:
+        rank = {code: i for i, code in enumerate(REASON_CODES)}
+        return sorted(codes, key=lambda c: rank[c])
+
+    if "finding" in refs and "exclusion" in refs:
+        return "decided", "conflict", ordered(["decided-by-conflict"])
+    if "finding" in refs:
+        return "decided", "finding", ordered(["decided-by-finding"])
+    if "exclusion" in refs:
+        return "decided", "exclusion", ordered(["decided-by-exclusion"])
+    if not is_candidate:
+        return "context", "n/a", ordered(["non-candidate"])
+    if dismissed:
+        return "withdrawn", "undecided", ordered(["dismissed"])
+    if len(signals) >= 2:
+        return "likely_actioned", "undecided", ordered(list(signals))
+    if len(signals) == 1:
+        return "possibly_actioned", "undecided", ordered(list(signals))
+    if commit_relation == "non_ancestor":
+        return "needs_judgment", "undecided", ordered(["commit-non-ancestor"])
+    if commit_relation == "unavailable":
+        return "needs_judgment", "undecided", ordered(["commit-unavailable"])
+    if anchor_delta == "unavailable":
+        return "needs_judgment", "undecided", ordered(["anchor-unavailable"])
+    if not facts_present:
+        return "needs_judgment", "undecided", ordered(["facts-missing"])
+    return "review_first", "undecided", []
+
+
+def prioritized_evidence(raw: dict[str, Any]) -> dict[str, Any]:
+    """Derive the read-only ``prioritized_evidence`` view of one case doc.
+
+    Consumes the raw case dict *after* its in-memory ``evidence`` list has
+    been attached (the already-loaded import records) plus the persisted
+    ``prioritization`` facts and current curation state. Mirror-scoped: no
+    git, no network. Returns ``{"entries": [...], "by_source": {...}}`` where
+    each entry carries ``source_id``, ``position`` (canonical index),
+    ``band``, ``reasons``, ``not_exact_reason`` (verbatim or None),
+    ``disposition``, ``thread_id`` and ``same_thread_ids`` (other evidence
+    sharing the same non-None thread). Final order: band rank, canonical
+    position, then ``source_id``. Absent/None facts fail open — every
+    candidate classifies via the facts-missing path (``needs_judgment``)
+    while non-candidates stay ``context`` and decided sources stay
+    ``decided``. Never persisted.
+    """
+    records = raw.get("evidence") or []
+    facts = raw.get("prioritization") or None
+    curation = raw.get("curation") or {}
+    candidate_ids = {
+        c.get("source_id") for c in (raw.get("candidates") or []) if c.get("source_id")
+    }
+    not_exact = {
+        c.get("source_id"): c.get("not_exact_reason")
+        for c in (raw.get("candidates") or [])
+        if c.get("source_id")
+    }
+    finding_refs = {
+        sid
+        for f in (curation.get("findings") or [])
+        for sid in ((f.get("provenance") or {}).get("source_ids") or [])
+    }
+    exclusion_refs = {
+        e.get("source_id") for e in (curation.get("exclusions") or []) if e.get("source_id")
+    }
+    pr_login = ((raw.get("pull_request") or {}).get("author") or {}).get("login")
+    view_context = {"pr_author_login": pr_login, "records": records, "facts": facts}
+    thread_members: dict[str, list[str]] = {}
+    for rec in records:
+        tid = rec.get("thread_id")
+        if tid is not None and rec.get("source_id"):
+            thread_members.setdefault(tid, []).append(rec["source_id"])
+    entries: list[dict[str, Any]] = []
+    by_source: dict[str, dict[str, Any]] = {}
+    for position, rec in enumerate(records):
+        sid = rec.get("source_id")
+        group = "candidates" if sid in candidate_ids else "non_candidates"
+        fentry = ((facts or {}).get(group) or {}).get(sid)
+        facts_present = fentry is not None
+        refs: set[str] = set()
+        if sid in finding_refs:
+            refs.add("finding")
+        if sid in exclusion_refs:
+            refs.add("exclusion")
+        signals = collect_signals(rec, view_context)
+        band, disposition, reasons = classify_evidence(
+            refs=refs,
+            is_candidate=sid in candidate_ids,
+            dismissed=sid in exclusion_refs,
+            signals=signals,
+            facts_present=facts_present,
+            commit_relation=(fentry or {}).get("commit_relation") or "at_head",
+            anchor_delta=(fentry or {}).get("anchor_delta") or "unchanged",
+        )
+        tid = rec.get("thread_id")
+        entry = {
+            "source_id": sid,
+            "position": position,
+            "band": band,
+            "reasons": reasons,
+            "not_exact_reason": not_exact.get(sid),
+            "disposition": disposition,
+            "thread_id": tid,
+            "same_thread_ids": sorted(
+                s for s in thread_members.get(tid, []) if s != sid
+            )
+            if tid is not None
+            else [],
+        }
+        entries.append(entry)
+        by_source[sid] = entry
+    entries.sort(
+        key=lambda e: (BAND_RANK[e["band"]], e["position"], e["source_id"])
+    )
+    return {"entries": entries, "by_source": by_source}
 
 
 # ---------------------------------------------------------------------------

--- a/daydream/benchmark/curation.py
+++ b/daydream/benchmark/curation.py
@@ -465,8 +465,13 @@ def collect_signals(record: dict[str, Any], view_context: dict[str, Any]) -> fro
     result is a set.
 
     *view_context* carries ``pr_author_login`` (str | None), ``records`` (the
-    full evidence list, for reply-chain scanning) and ``facts`` (the persisted
-    ``prioritization`` block or None).
+    full evidence list, for reply-chain scanning), ``facts`` (the persisted
+    ``prioritization`` block or None) and ``latest_pr_author_reply`` (a
+    precomputed thread -> latest same-thread PR-author reply ``created_at``
+    map, built once by :func:`prioritized_evidence` so each record answers the
+    strictly-later question in O(1) instead of a per-record full-list scan;
+    when the key is absent the scan runs inline as a fallback for direct
+    callers).
     """
     signals: set[str] = set()
     if record.get("resolved"):
@@ -483,20 +488,28 @@ def collect_signals(record: dict[str, Any], view_context: dict[str, Any]) -> fro
                 signals.add(code)
     pr_login = view_context.get("pr_author_login")
     created = record.get("created_at")
-    thread_id = record.get("thread_id")
     if pr_login and created:
-        for other in view_context.get("records") or []:
-            if other is record or not other.get("reply_to_id"):
-                continue
-            if (other.get("thread_id") or None) != (thread_id or None):
-                continue
-            if ((other.get("author") or {}).get("login")) != pr_login:
-                continue
-            other_created = other.get("created_at")
-            if not other_created or other_created <= created:
-                continue
-            signals.add("pr-author-reply")
-            break
+        latest = view_context.get("latest_pr_author_reply")
+        if latest is None:
+            # Fallback for direct callers that did not precompute the
+            # per-thread map: scan the full evidence list as before.
+            thread_id = record.get("thread_id")
+            for other in view_context.get("records") or []:
+                if other is record or not other.get("reply_to_id"):
+                    continue
+                if (other.get("thread_id") or None) != (thread_id or None):
+                    continue
+                if ((other.get("author") or {}).get("login")) != pr_login:
+                    continue
+                other_created = other.get("created_at")
+                if not other_created or other_created <= created:
+                    continue
+                signals.add("pr-author-reply")
+                break
+        else:
+            later = latest.get(record.get("thread_id") or None)
+            if later is not None and later > created:
+                signals.add("pr-author-reply")
     return frozenset(signals)
 
 
@@ -560,9 +573,10 @@ def prioritized_evidence(raw: dict[str, Any]) -> dict[str, Any]:
     ``band``, ``reasons``, ``not_exact_reason`` (verbatim or None),
     ``disposition``, ``thread_id`` and ``same_thread_ids`` (other evidence
     sharing the same non-None thread). Final order: band rank, canonical
-    position, then ``source_id``. Absent/None facts fail open — every
-    candidate classifies via the facts-missing path (``needs_judgment``)
-    while non-candidates stay ``context`` and decided sources stay
+    position, then ``source_id``. Absent/None facts fail open — a candidate
+    without record-level signals classifies via the facts-missing path
+    (``needs_judgment``) while signalled candidates still rank by signal
+    count, non-candidates stay ``context`` and decided sources stay
     ``decided``. Never persisted.
     """
     records = raw.get("evidence") or []
@@ -585,7 +599,30 @@ def prioritized_evidence(raw: dict[str, Any]) -> dict[str, Any]:
         e.get("source_id") for e in (curation.get("exclusions") or []) if e.get("source_id")
     }
     pr_login = ((raw.get("pull_request") or {}).get("author") or {}).get("login")
-    view_context = {"pr_author_login": pr_login, "records": records, "facts": facts}
+    latest_pr_author_reply: dict[Any, str] = {}
+    if pr_login and records:
+        # One O(N) pass: the latest same-thread reply authored by the PR
+        # author per thread, so each collect_signals call answers the
+        # strictly-later question in O(1) instead of re-scanning the full
+        # evidence list per record (an O(N^2) cost on every get_case, several
+        # per TUI keystroke).
+        for other in records:
+            if not other.get("reply_to_id"):
+                continue
+            if ((other.get("author") or {}).get("login")) != pr_login:
+                continue
+            tid = other.get("thread_id") or None
+            t = other.get("created_at")
+            if not t:
+                continue
+            if latest_pr_author_reply.get(tid) is None or t > latest_pr_author_reply[tid]:
+                latest_pr_author_reply[tid] = t
+    view_context = {
+        "pr_author_login": pr_login,
+        "records": records,
+        "facts": facts,
+        "latest_pr_author_reply": latest_pr_author_reply,
+    }
     thread_members: dict[str, list[str]] = {}
     for rec in records:
         tid = rec.get("thread_id")
@@ -607,7 +644,7 @@ def prioritized_evidence(raw: dict[str, Any]) -> dict[str, Any]:
         band, disposition, reasons = classify_evidence(
             refs=refs,
             is_candidate=sid in candidate_ids,
-            dismissed=sid in exclusion_refs,
+            dismissed=bool(rec.get("dismissed")),
             signals=signals,
             facts_present=facts_present,
             commit_relation=(fentry or {}).get("commit_relation") or "at_head",

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -1396,9 +1396,20 @@ def _extract_prioritization_facts(
     Both helpers fail closed to ``unavailable``; a defensive per-record catch
     maps an unexpected git failure to ``unavailable`` on both axes without
     failing the import.
+
+    The two whole-tree diffs :func:`~daydream.benchmark.snapshot.anchor_delta`
+    runs are pure functions of the (authoring commit, head) pair, so a per-
+    call cache classifies each distinct pair once and shares it across every
+    record anchored to the same authoring commit — the per-path ``-U0`` probe
+    still runs per modified record.
     """
     candidates: dict[str, schema.PrioritizationCandidate] = {}
     non_candidates: dict[str, schema.PrioritizationCandidate] = {}
+    # The whole-tree name-status/numstat diffs are pure functions of the
+    # (authoring commit, head) pair: classify each distinct pair once and
+    # share it across the records anchored to that commit instead of paying
+    # the fan-out per record.
+    diff_cache: dict[tuple[str, str], snapshot.AnchorDiff] = {}
     for record in doc.evidence:
         anchor = (
             record.authoring_anchor.model_dump(mode="json")
@@ -1416,7 +1427,8 @@ def _extract_prioritization_facts(
                     mirror_repo, head_sha, anchor["commit_id"]
                 )
                 delta = snapshot.anchor_delta(
-                    mirror_repo, anchor["commit_id"], head_sha, anchor
+                    mirror_repo, anchor["commit_id"], head_sha, anchor,
+                    diff_cache=diff_cache,
                 )
             except git_ops.GitError:
                 pass
@@ -1439,6 +1451,8 @@ def _reuse_prior_facts(
     prior: dict[str, Any] | None,
     head_sha: str,
     changed_ids: set[int] | None,
+    candidate_ids: set[str],
+    evidence_ids: set[str],
 ) -> schema.PrioritizationFacts | None:
     """Return the persisted prioritization block when it is still exact.
 
@@ -1446,14 +1460,19 @@ def _reuse_prior_facts(
     anchor, the mirror content at the pinned head, and the candidate split.
     On refresh the anchors come back from the prior import document
     byte-identical (backfilled before projection), so when the extraction
-    version, the head, and the evidence projection signature are all unchanged
-    the block written by the prior materialization is still exact — reusing it
-    skips the per-record mirror-probe fan-out (up to 5 subprocesses per
-    evidence record) on every no-op refresh/import. Any anomaly falls back to
-    :func:`_extract_prioritization_facts`: an absent block, a version or head
-    drift, a changed/added/removed record (its anchor re-derives and can flip
-    relation/delta), or a block that no longer validates (a hand-corrupt
-    block is recomputed and repaired, never carried forward).
+    version, the head, the evidence projection signature, and the candidate
+    split are all unchanged the block written by the prior materialization is
+    still exact — reusing it skips the per-record mirror-probe fan-out (up to
+    5 subprocesses per evidence record) on every no-op refresh/import. The
+    split is verified against the freshly recomputed projection (the caller
+    passes *candidate_ids*/*evidence_ids*): a projection-code change can
+    re-bucket membership without touching raw evidence, so it never reaches
+    *changed_ids*, yet it invalidates the persisted bucketing. Any anomaly
+    falls back to :func:`_extract_prioritization_facts`: an absent block, a
+    version or head drift, a changed/added/removed record (its anchor
+    re-derives and can flip relation/delta), a re-bucketed candidate split,
+    or a block that no longer validates (a hand-corrupt block is recomputed
+    and repaired, never carried forward).
     """
     if prior is None:
         return None
@@ -1466,6 +1485,14 @@ def _reuse_prior_facts(
     if not isinstance(prior.get("candidates"), dict) or not isinstance(
         prior.get("non_candidates"), dict
     ):
+        return None
+    # The candidate split is a documented purity input and is NOT implied by
+    # the raw evidence: a projection-code change can re-bucket membership
+    # without any raw field (and thus any changed_ids) moving. Reuse only when
+    # the persisted buckets exactly match the freshly recomputed split.
+    if set(prior["candidates"]) != candidate_ids:
+        return None
+    if set(prior["non_candidates"]) != evidence_ids - candidate_ids:
         return None
     try:
         return schema.PrioritizationFacts.model_validate(prior)
@@ -1561,7 +1588,8 @@ def _case_materialize(
     document under the additive ``prioritization`` key (schema_version stays
     2). Imported-status and unreplayable snapshots persist no key. A refresh
     whose persisted facts are still exact (same extraction version, same
-    head, unchanged evidence — see :func:`_reuse_prior_facts`) reuses the
+    head, unchanged evidence, and an identical candidate split — see
+    :func:`_reuse_prior_facts`) reuses the
     block instead of re-running the per-record mirror probes; any drift or a
     first materialization recomputes. Facts
     never feed the staleness gate, so a facts extraction-version bump alone
@@ -1659,14 +1687,21 @@ def _case_materialize(
         facts: schema.PrioritizationFacts | None = None
         if root is not None and origin_url is not None and snapshot_doc["status"] == "ready":
             # Reuse the persisted block when it is still exact (same extraction
-            # version, same head, unchanged evidence): the per-record mirror
-            # probes are pure functions of the authoring anchors, the mirror
-            # content at the pinned head, and the candidate split — unchanged
-            # on a no-op refresh — so re-running them would be pure
-            # subprocess fan-out (up to 5 per record). Any drift (or an
-            # absent/non-validating block) falls back to extraction.
+            # version, same head, unchanged evidence, and an identical candidate
+            # split — verified against the freshly recomputed projection, since
+            # a projection-code change can re-bucket membership without
+            # touching raw evidence): the per-record mirror probes are pure
+            # functions of the authoring anchors, the mirror content at the
+            # pinned head, and the candidate split — unchanged on a no-op
+            # refresh — so re-running them would be pure subprocess fan-out
+            # (up to 5 per record). Any drift (or an absent/non-validating
+            # block) falls back to extraction.
             facts = _reuse_prior_facts(
-                (prior_facts or {}).get(case_id), head_sha, changed_ids
+                (prior_facts or {}).get(case_id),
+                head_sha,
+                changed_ids,
+                {c.source_id for c in candidates},
+                {r.source_id for r in doc.evidence},
             )
             if facts is None:
                 facts = _extract_prioritization_facts(

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -1373,6 +1373,58 @@ def _derive_one_anchor(
         return _anchor_fail_closed("path-unavailable")
 
 
+EXTRACTION_VERSION = 1
+
+
+def _extract_prioritization_facts(
+    doc: schema.ImportDocument,
+    mirror_repo: Path,
+    base_tip: str,
+    head_sha: str,
+    candidate_ids: set[str],
+) -> schema.PrioritizationFacts:
+    """Per-evidence snapshot-comparison facts against the pinned head.
+
+    Consumes exactly each record's ``authoring_anchor`` (the #826 contract —
+    never GitHub's re-anchored fields). The commit relation classifies the
+    record's authoring commit against the pinned head; the anchor delta
+    measures the base_tip..head-classified interaction from that same
+    authoring commit to the head, so an at-head comment's anchored region is
+    by definition unchanged by the PR's own diff. Both helpers fail closed
+    to ``unavailable``; a defensive per-record catch maps an unexpected git
+    failure to ``unavailable`` on both axes without failing the import.
+    """
+    candidates: dict[str, schema.PrioritizationCandidate] = {}
+    non_candidates: dict[str, schema.PrioritizationCandidate] = {}
+    for record in doc.evidence:
+        commit = record.commit_id or record.original_commit_id or head_sha
+        relation: str = "unavailable"
+        delta: str = "unavailable"
+        try:
+            relation = snapshot.commit_relation(mirror_repo, base_tip, head_sha, commit)
+            anchor = (
+                record.authoring_anchor.model_dump(mode="json")
+                if record.authoring_anchor
+                else None
+            )
+            delta = snapshot.anchor_delta(mirror_repo, commit, head_sha, anchor)
+        except git_ops.GitError:
+            pass
+        entry = schema.PrioritizationCandidate(
+            commit_relation=relation,  # type: ignore[arg-type]
+            anchor_delta=delta,  # type: ignore[arg-type]
+        )
+        (candidates if record.source_id in candidate_ids else non_candidates)[
+            record.source_id
+        ] = entry
+    return schema.PrioritizationFacts(
+        extraction_version=EXTRACTION_VERSION,
+        head_sha=head_sha,
+        candidates=candidates,
+        non_candidates=non_candidates,
+    )
+
+
 def _derive_authoring_anchors(
     doc: schema.ImportDocument,
     mirror_repo: Path,
@@ -1452,6 +1504,16 @@ def _case_materialize(
     :class:`~daydream.git_ops.GitError` instead of writing an unreplayable
     snapshot over the curated case — the refresh then fails like the sibling
     fetch-failure path (rc != 0, last-good linkage kept).
+
+    On a ``ready`` freeze, per-evidence snapshot-comparison facts (commit
+    relation + anchor delta against the pinned head, via
+    :mod:`daydream.benchmark.snapshot`) are computed once here — where the
+    authenticated mirror is already populated — and persisted on the case
+    document under the additive ``prioritization`` key (schema_version stays
+    2). Imported-status and unreplayable snapshots persist no key. Facts are
+    read-projection input only and live on the case doc alone, so every hash
+    surface (import payload, evidence signatures, projection hashes,
+    staleness signatures) is untouched.
     """
     pull_request = doc.pull_request
     base_sha = pull_request.base.sha
@@ -1539,6 +1601,15 @@ def _case_materialize(
         # Projection runs after the freeze branch so per-head candidates
         # consume the derived authoring anchors (or their absence, closed).
         candidates = project_candidates(doc, head_sha)
+        facts: schema.PrioritizationFacts | None = None
+        if root is not None and origin_url is not None and snapshot_doc["status"] == "ready":
+            facts = _extract_prioritization_facts(
+                doc,
+                snapshot.mirror(root),
+                base_sha,
+                head_sha,
+                {c.source_id for c in candidates},
+            )
         if prior_curations and case_id in prior_curations:
             prior = prior_curations[case_id]
             # The stale gate runs after projection so its third arm can see
@@ -1573,6 +1644,8 @@ def _case_materialize(
             "curation": curation,
             "candidates": [c.model_dump(mode="json") for c in candidates],
         }
+        if facts is not None:
+            case_doc["prioritization"] = facts.model_dump(mode="json")
         out.append((case_id, f"cases/{case_id}.yaml", case_doc))
     return out, bundle_drops
 

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -1377,37 +1377,49 @@ def _derive_one_anchor(
 def _extract_prioritization_facts(
     doc: schema.ImportDocument,
     mirror_repo: Path,
-    base_tip: str,
     head_sha: str,
     candidate_ids: set[str],
 ) -> schema.PrioritizationFacts:
     """Per-evidence snapshot-comparison facts against the pinned head.
 
     Consumes exactly each record's ``authoring_anchor`` (the #826 contract —
-    never GitHub's re-anchored fields). The commit relation classifies the
-    record's authoring commit against the pinned head; the anchor delta
-    measures the base_tip..head-classified interaction from that same
-    authoring commit to the head, so an at-head comment's anchored region is
-    by definition unchanged by the PR's own diff. Both helpers fail closed
-    to ``unavailable``; a defensive per-record catch maps an unexpected git
-    failure to ``unavailable`` on both axes without failing the import.
+    never GitHub's re-anchored fields: their ``commit_id`` may even equal the
+    head, which would make the relation vacuously ``at_head`` and the delta
+    vacuously ``unchanged``). The commit relation classifies the record's
+    authoring commit against the pinned head; the anchor delta classifies the
+    authoring-commit..head change against the anchored span — the anchor's
+    ``start_line``/``end_line`` live in the authoring commit's file coordinate
+    space, the diff's base side — so an at-head comment's anchored region is
+    by definition unchanged by later PR commits. A record with no anchor or a
+    fail-closed anchor carries no authoring commit: its facts are the fixed
+    ``unavailable``/``locationless`` pair and no mirror probes run for it.
+    Both helpers fail closed to ``unavailable``; a defensive per-record catch
+    maps an unexpected git failure to ``unavailable`` on both axes without
+    failing the import.
     """
     candidates: dict[str, schema.PrioritizationCandidate] = {}
     non_candidates: dict[str, schema.PrioritizationCandidate] = {}
     for record in doc.evidence:
-        commit = record.commit_id or record.original_commit_id or head_sha
+        anchor = (
+            record.authoring_anchor.model_dump(mode="json")
+            if record.authoring_anchor
+            else None
+        )
         relation: str = "unavailable"
-        delta: str = "unavailable"
-        try:
-            relation = snapshot.commit_relation(mirror_repo, base_tip, head_sha, commit)
-            anchor = (
-                record.authoring_anchor.model_dump(mode="json")
-                if record.authoring_anchor
-                else None
-            )
-            delta = snapshot.anchor_delta(mirror_repo, commit, head_sha, anchor)
-        except git_ops.GitError:
-            pass
+        delta: str = "locationless"
+        if anchor is not None and anchor.get("status") == "derived":
+            # A derived anchor carries the authoring commit (schema-enforced);
+            # both probes run against that commit, never a re-anchored field.
+            delta = "unavailable"
+            try:
+                relation = snapshot.commit_relation(
+                    mirror_repo, head_sha, anchor["commit_id"]
+                )
+                delta = snapshot.anchor_delta(
+                    mirror_repo, anchor["commit_id"], head_sha, anchor
+                )
+            except git_ops.GitError:
+                pass
         entry = schema.PrioritizationCandidate(
             commit_relation=relation,  # type: ignore[arg-type]
             anchor_delta=delta,  # type: ignore[arg-type]
@@ -1421,6 +1433,44 @@ def _extract_prioritization_facts(
         candidates=candidates,
         non_candidates=non_candidates,
     )
+
+
+def _reuse_prior_facts(
+    prior: dict[str, Any] | None,
+    head_sha: str,
+    changed_ids: set[int] | None,
+) -> schema.PrioritizationFacts | None:
+    """Return the persisted prioritization block when it is still exact.
+
+    The per-evidence facts are a pure function of each record's authoring
+    anchor, the mirror content at the pinned head, and the candidate split.
+    On refresh the anchors come back from the prior import document
+    byte-identical (backfilled before projection), so when the extraction
+    version, the head, and the evidence projection signature are all unchanged
+    the block written by the prior materialization is still exact — reusing it
+    skips the per-record mirror-probe fan-out (up to 5 subprocesses per
+    evidence record) on every no-op refresh/import. Any anomaly falls back to
+    :func:`_extract_prioritization_facts`: an absent block, a version or head
+    drift, a changed/added/removed record (its anchor re-derives and can flip
+    relation/delta), or a block that no longer validates (a hand-corrupt
+    block is recomputed and repaired, never carried forward).
+    """
+    if prior is None:
+        return None
+    if prior.get("extraction_version") != EXTRACTION_VERSION:
+        return None
+    if prior.get("head_sha") != head_sha:
+        return None
+    if changed_ids:
+        return None
+    if not isinstance(prior.get("candidates"), dict) or not isinstance(
+        prior.get("non_candidates"), dict
+    ):
+        return None
+    try:
+        return schema.PrioritizationFacts.model_validate(prior)
+    except ValidationError:
+        return None
 
 
 def _derive_authoring_anchors(
@@ -1471,6 +1521,7 @@ def _case_materialize(
     prior_candidates: dict[str, dict[str, dict[str, Any]]] | None = None,
     prior_pinned: dict[str, str] | None = None,
     prior_policy: dict[str, str] | None = None,
+    prior_facts: dict[str, dict[str, Any]] | None = None,
     changed_ids: set[int] | None = None,
     task_input_changed: bool = False,
 ) -> tuple[list[tuple[str, str, dict[str, Any]]], list[tuple[str, bytes]]]:
@@ -1508,10 +1559,13 @@ def _case_materialize(
     :mod:`daydream.benchmark.snapshot`) are computed once here — where the
     authenticated mirror is already populated — and persisted on the case
     document under the additive ``prioritization`` key (schema_version stays
-    2). Imported-status and unreplayable snapshots persist no key. Facts
-    recompute on every materialization (import and refresh alike) and never
-    feed the staleness gate, so a facts extraction-version bump alone cannot
-    stale curated gold. Facts are
+    2). Imported-status and unreplayable snapshots persist no key. A refresh
+    whose persisted facts are still exact (same extraction version, same
+    head, unchanged evidence — see :func:`_reuse_prior_facts`) reuses the
+    block instead of re-running the per-record mirror probes; any drift or a
+    first materialization recomputes. Facts
+    never feed the staleness gate, so a facts extraction-version bump alone
+    cannot stale curated gold. Facts are
     read-projection input only and live on the case doc alone, so every hash
     surface (import payload, evidence signatures, projection hashes,
     staleness signatures) is untouched.
@@ -1604,13 +1658,23 @@ def _case_materialize(
         candidates = project_candidates(doc, head_sha)
         facts: schema.PrioritizationFacts | None = None
         if root is not None and origin_url is not None and snapshot_doc["status"] == "ready":
-            facts = _extract_prioritization_facts(
-                doc,
-                snapshot.mirror(root),
-                base_sha,
-                head_sha,
-                {c.source_id for c in candidates},
+            # Reuse the persisted block when it is still exact (same extraction
+            # version, same head, unchanged evidence): the per-record mirror
+            # probes are pure functions of the authoring anchors, the mirror
+            # content at the pinned head, and the candidate split — unchanged
+            # on a no-op refresh — so re-running them would be pure
+            # subprocess fan-out (up to 5 per record). Any drift (or an
+            # absent/non-validating block) falls back to extraction.
+            facts = _reuse_prior_facts(
+                (prior_facts or {}).get(case_id), head_sha, changed_ids
             )
+            if facts is None:
+                facts = _extract_prioritization_facts(
+                    doc,
+                    snapshot.mirror(root),
+                    head_sha,
+                    {c.source_id for c in candidates},
+                )
         if prior_curations and case_id in prior_curations:
             prior = prior_curations[case_id]
             # The stale gate runs after projection so its third arm can see
@@ -1788,6 +1852,7 @@ def _prior_import_state(
     str,
     dict[str, str],
     dict[str, str],
+    dict[str, dict[str, Any]],
     list[str],
 ]:
     """Prior import signatures, curations, candidates, path, pins, policies, heads.
@@ -1797,8 +1862,10 @@ def _prior_import_state(
     case_id -> source_id -> candidate dict — the candidate basis the prior
     curation's findings/exclusions were validated against), the import path,
     each prior case's pinned ``snapshot.original_head_sha`` (``prior_pinned``),
-    each prior case's ``snapshot.policy`` (``prior_policy``), and the prior
-    ledger entry's ``requested_heads``. A missing prior state (no ``fetched``
+    each prior case's ``snapshot.policy`` (``prior_policy``), each prior
+    case's persisted ``prioritization`` facts (``prior_facts`` — the reuse
+    gate for snapshot-comparison facts), and the prior ledger entry's
+    ``requested_heads``. A missing prior state (no ``fetched``
     ledger entry, or no persisted import/case to read) yields ``None`` for
     both signatures, empty curations/candidates/pins/policies/heads, and the
     default import path — the normal first-run path. A *present-but-corrupt*
@@ -1816,6 +1883,7 @@ def _prior_import_state(
     prior_candidates: dict[str, dict[str, dict[str, Any]]] = {}
     prior_pinned: dict[str, str] = {}
     prior_policy: dict[str, str] = {}
+    prior_facts: dict[str, dict[str, Any]] = {}
     prior_requested_heads: list[str] = list(existing.get("requested_heads", [])) if existing else []
     if existing is not None and existing.get("import_state") == "fetched":
         prior_import_file = existing.get("import_file")
@@ -1867,6 +1935,9 @@ def _prior_import_state(
             policy = snapshot.get("policy")
             if policy:
                 prior_policy[case_id] = policy
+            facts = case_raw.get("prioritization")
+            if isinstance(facts, dict):
+                prior_facts[case_id] = facts
     return (
         prior_sig,
         prior_task_sig,
@@ -1875,6 +1946,7 @@ def _prior_import_state(
         import_file,
         prior_pinned,
         prior_policy,
+        prior_facts,
         prior_requested_heads,
     )
 
@@ -1924,7 +1996,7 @@ def _import_one_pr(
     basis the findings no longer byte-match.
     """
     prior_sig, prior_task_sig, prior_curations, prior_candidates, import_file, prior_pinned, \
-        prior_policy, prior_requested_heads = _prior_import_state(root, raw, number)
+        prior_policy, prior_facts, prior_requested_heads = _prior_import_state(root, raw, number)
     try:
         doc = fetch_and_normalize(root, repo, number)
         # Head-immutable task input: an existing final_pr_head case pins the
@@ -2033,6 +2105,7 @@ def _import_one_pr(
             root=root, repo_slug=repo, origin_url=origin_url,
             prior_curations=prior_curations, prior_candidates=prior_candidates,
             prior_pinned=prior_pinned, prior_policy=prior_policy,
+            prior_facts=prior_facts,
             changed_ids=changed_ids, task_input_changed=task_input_changed,
         )
         # Re-serialize the mutated doc (authoring anchors derived on the typed

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -1508,7 +1508,10 @@ def _case_materialize(
     :mod:`daydream.benchmark.snapshot`) are computed once here — where the
     authenticated mirror is already populated — and persisted on the case
     document under the additive ``prioritization`` key (schema_version stays
-    2). Imported-status and unreplayable snapshots persist no key. Facts are
+    2). Imported-status and unreplayable snapshots persist no key. Facts
+    recompute on every materialization (import and refresh alike) and never
+    feed the staleness gate, so a facts extraction-version bump alone cannot
+    stale curated gold. Facts are
     read-projection input only and live on the case doc alone, so every hash
     surface (import payload, evidence signatures, projection hashes,
     staleness signatures) is untouched.

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -36,6 +36,7 @@ from pydantic import ValidationError
 from daydream import git_ops
 from daydream.benchmark import curation as cu
 from daydream.benchmark import schema, snapshot, storage
+from daydream.benchmark.schema import EXTRACTION_VERSION
 
 
 def _run_gh_preflight_status(root: Path) -> subprocess.CompletedProcess[str]:
@@ -1371,9 +1372,6 @@ def _derive_one_anchor(
         # rather than aborting the import run: an anchor failure never kills
         # the import.
         return _anchor_fail_closed("path-unavailable")
-
-
-EXTRACTION_VERSION = 1
 
 
 def _extract_prioritization_facts(

--- a/daydream/benchmark/schema.py
+++ b/daydream/benchmark/schema.py
@@ -898,6 +898,12 @@ class CaseExclusion(_NoteForOther):
     note: str | None = None
 
 
+# Single source of truth for the snapshot-comparison fact extraction version.
+# Defined here (next to :class:`PrioritizationFacts`) so both github_import (the
+# writer) and curation (the reader) can import it without a circular import.
+EXTRACTION_VERSION = 1
+
+
 class PrioritizationCandidate(BaseModel):
     """Per-evidence comparison facts against the pinned snapshot head."""
 

--- a/daydream/benchmark/schema.py
+++ b/daydream/benchmark/schema.py
@@ -903,8 +903,10 @@ class PrioritizationCandidate(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    commit_relation: str
-    anchor_delta: str
+    commit_relation: Literal["at_head", "ancestor", "non_ancestor", "unavailable"]
+    anchor_delta: Literal[
+        "unchanged", "changed", "renamed", "deleted", "binary", "locationless", "unavailable"
+    ]
 
 
 class PrioritizationFacts(BaseModel):

--- a/daydream/benchmark/schema.py
+++ b/daydream/benchmark/schema.py
@@ -44,6 +44,8 @@ __all__ = [
     "AuthoringAnchor",
     "EvidenceRecord",
     "Candidate",
+    "PrioritizationFacts",
+    "PrioritizationCandidate",
     "ImportDocument",
     "PullRequestMeta",
     "CaseSource",
@@ -896,6 +898,37 @@ class CaseExclusion(_NoteForOther):
     note: str | None = None
 
 
+class PrioritizationCandidate(BaseModel):
+    """Per-evidence comparison facts against the pinned snapshot head."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    commit_relation: str
+    anchor_delta: str
+
+
+class PrioritizationFacts(BaseModel):
+    """Additive per-case prioritization facts (schema_version stays 2).
+
+    Written once at case materialization/refresh; all new data stays out of
+    every hash surface.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    extraction_version: int
+    head_sha: str
+    candidates: dict[str, PrioritizationCandidate] = {}
+    non_candidates: dict[str, PrioritizationCandidate] = {}
+
+    @field_validator("head_sha")
+    @classmethod
+    def _hex40(cls, v: str) -> str:
+        if not _HEX40.fullmatch(v):
+            raise ValueError(f"head_sha must be 40-hex, got {v!r}")
+        return v
+
+
 class Curation(BaseModel):
     """Curated gold state for one case."""
 
@@ -970,6 +1003,7 @@ class CaseDocument(BaseModel):
     source: CaseSource
     curation: Curation
     candidates: list[Candidate] = []
+    prioritization: PrioritizationFacts | None = None
 
     @model_validator(mode="after")
     def _unique_candidates(self) -> "CaseDocument":

--- a/daydream/benchmark/snapshot.py
+++ b/daydream/benchmark/snapshot.py
@@ -14,7 +14,7 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Any, Literal, overload
+from typing import Any, Literal, NamedTuple, overload
 
 from daydream import git_ops
 from daydream.benchmark import schema, storage
@@ -194,7 +194,89 @@ def commit_relation(mirror_repo: Path, head: str, commit: str) -> str:
     return "ancestor" if anc.returncode == 0 else "non_ancestor"
 
 
-def anchor_delta(mirror_repo: Path, base_tip: str, head: str, anchor: Any) -> str:
+class AnchorDiff(NamedTuple):
+    """Whole-tree ``base_tip..head`` diff classification, shared across anchors.
+
+    A pure function of ``(base_tip, head)`` and the mirror's content-addressed
+    objects, so one classification serves every anchor against the same pair:
+    :func:`anchor_delta` skips the two whole-tree diffs
+    (``--name-status -z -M`` / ``--numstat -z``) for subsequent records,
+    leaving only the per-path ``-U0`` probe. A path appears in at most one
+    bucket, mirroring the probe's check order.
+    """
+
+    renames: frozenset[str]
+    binary: frozenset[str]
+    modified: frozenset[str]
+    deleted: frozenset[str]
+
+
+def _nul_fields(stdout: str | bytes) -> list[str]:
+    """NUL-split ``git -z`` output into surrogateescape-decoded fields.
+
+    The canonical split shared by :func:`anchor_delta` and
+    :func:`resolve_authoring_path` (and ``git_ops.ls_files``): ``-z`` emits
+    raw pathnames (no C-style quoting to unparse), so records must be split on
+    NUL and each field surrogateescape-decoded.
+    """
+    stdout = stdout if isinstance(stdout, bytes) else stdout.encode()
+    return [f.decode("utf-8", errors="surrogateescape") for f in stdout.split(b"\0") if f]
+
+
+def _classify_diff(name_status: str | bytes, numstat: str | bytes) -> AnchorDiff:
+    """Classify a whole-tree ``base..head`` diff into per-path buckets.
+
+    Never probes git — the caller supplies the already-captured
+    ``--name-status -z -M`` and ``--numstat -z`` byte streams (both pure
+    functions of ``(base_tip, head)``). Rename/copy rows contribute the old
+    AND new name; ``D`` rows the deleted set; every other two-field row the
+    modified set; numstat ``-\t-`` records the binary set.
+    """
+    fields = _nul_fields(name_status)
+    # numstat -z records are NUL-terminated with tab-separated fields:
+    # add, del, path (add/del are "-" for binary content).
+    nfields = _nul_fields(numstat)
+    binary: set[str] = set()
+    for record in nfields:
+        parts = record.split("\t", 2)
+        if len(parts) == 3 and parts[0] == "-" and parts[1] == "-":
+            binary.add(parts[2])
+    renames: set[str] = set()
+    modified: set[str] = set()
+    deleted: set[str] = set()
+    j = 0
+    while j < len(fields):
+        status = fields[j]
+        if status.startswith(("R", "C")):
+            if j + 2 >= len(fields):
+                break
+            renames.add(fields[j + 1])
+            renames.add(fields[j + 2])
+            j += 3
+        else:
+            if j + 1 >= len(fields):
+                break
+            path = fields[j + 1]
+            if status == "D":
+                deleted.add(path)
+            else:
+                modified.add(path)
+            j += 2
+    return AnchorDiff(
+        renames=frozenset(renames),
+        binary=frozenset(binary),
+        modified=frozenset(modified),
+        deleted=frozenset(deleted),
+    )
+
+
+def anchor_delta(
+    mirror_repo: Path,
+    base_tip: str,
+    head: str,
+    anchor: Any,
+    diff_cache: dict[tuple[str, str], AnchorDiff] | None = None,
+) -> str:
     """Classify how the base..head change interacts with one authoring anchor.
 
     *anchor* is an :class:`~daydream.benchmark.schema.AuthoringAnchor`-shaped
@@ -212,6 +294,14 @@ def anchor_delta(mirror_repo: Path, base_tip: str, head: str, anchor: Any) -> st
     at-head anchor) is ``"unchanged"`` with no mirror probes. Any git failure
     returns ``"unavailable"`` (fail-closed: never raised, never guessed). All
     reads are local mirror reads only.
+
+    The two whole-tree diffs are pure functions of ``(base_tip, head)``, so
+    when *diff_cache* is supplied the classification is computed once per
+    distinct pair and shared by every anchor on it: a comment-heavy
+    materialization whose records sit on the same authoring commit pays the
+    ``--name-status``/``--numstat`` fan-out once, not once per record. The
+    per-path ``-U0`` probe still runs per modified record (it depends on the
+    anchored path, and the hunk intersection on the anchor's span).
     """
     if not isinstance(anchor, dict) or anchor.get("status") != "derived":
         return "locationless"
@@ -226,58 +316,37 @@ def anchor_delta(mirror_repo: Path, base_tip: str, head: str, anchor: Any) -> st
         # never spawn git probes.
         return "unchanged"
     try:
-        st = git_ops._run_git(
-            mirror_repo,
-            ["diff", "--name-status", "-z", "-M", base_tip, head],
-            retries=0,
-            capture_bytes=True,
-        )
-        if st.returncode != 0:
-            return "unavailable"
-        numstat = git_ops._run_git(
-            mirror_repo,
-            ["diff", "--numstat", "-z", base_tip, head],
-            retries=0,
-            capture_bytes=True,
-        )
-        if numstat.returncode != 0:
-            return "unavailable"
-        stdout = st.stdout if isinstance(st.stdout, bytes) else st.stdout.encode()
-        fields = [f.decode("utf-8", errors="surrogateescape") for f in stdout.split(b"\0") if f]
-        # numstat -z records are NUL-terminated with tab-separated fields:
-        # add, del, path (add/del are "-" for binary content).
-        nstdout = numstat.stdout if isinstance(numstat.stdout, bytes) else numstat.stdout.encode()
-        nfields = [f.decode("utf-8", errors="surrogateescape") for f in nstdout.split(b"\0") if f]
-        binary_paths: set[str] = set()
-        for record in nfields:
-            parts = record.split("\t", 2)
-            if len(parts) == 3 and parts[0] == "-" and parts[1] == "-":
-                binary_paths.add(parts[2])
-        renames: set[str] = set()
-        modified: set[str] = set()
-        j = 0
-        while j < len(fields):
-            status = fields[j]
-            if status.startswith(("R", "C")):
-                if j + 2 >= len(fields):
-                    break
-                old, new = fields[j + 1], fields[j + 2]
-                if path in (old, new):
-                    renames.add(path)
-                j += 3
-            else:
-                if j + 1 >= len(fields):
-                    break
-                if fields[j + 1] == path:
-                    if status == "D":
-                        return "deleted"
-                    modified.add(path)
-                j += 2
-        if path in renames:
+        diff = diff_cache.get((base_tip, head)) if diff_cache is not None else None
+        if diff is None:
+            st = git_ops._run_git(
+                mirror_repo,
+                ["diff", "--name-status", "-z", "-M", base_tip, head],
+                retries=0,
+                capture_bytes=True,
+            )
+            if st.returncode != 0:
+                return "unavailable"
+            numstat = git_ops._run_git(
+                mirror_repo,
+                ["diff", "--numstat", "-z", base_tip, head],
+                retries=0,
+                capture_bytes=True,
+            )
+            if numstat.returncode != 0:
+                return "unavailable"
+            # Both streams are pure functions of (base_tip, head): compute the
+            # classification once per distinct pair and share it across every
+            # anchor on that pair (the -U0 probe below still runs per record).
+            diff = _classify_diff(st.stdout, numstat.stdout)
+            if diff_cache is not None:
+                diff_cache[(base_tip, head)] = diff
+        if path in diff.deleted:
+            return "deleted"
+        if path in diff.renames:
             return "renamed"
-        if path in binary_paths:
+        if path in diff.binary:
             return "binary"
-        if path not in modified:
+        if path not in diff.modified:
             return "unchanged"
         # The anchored path was modified: the anchor's [start_line, end_line]
         # span lives in the diff-base (authoring) coordinate space, so
@@ -392,9 +461,9 @@ def derive_authoring_path(mirror_repo: Path, authoring_sha: str, path: str, mapp
         )
     # The -z output is byte-oriented and may carry non-UTF-8 pathnames from the
     # traced range, so capture bytes and surrogateescape-decode each field (the
-    # canonical NUL-split pattern shared with git_ops.ls_files).
-    stdout = trace.stdout if isinstance(trace.stdout, bytes) else trace.stdout.encode()
-    fields = [f.decode("utf-8", errors="surrogateescape") for f in stdout.split(b"\0") if f]
+    # canonical NUL-split pattern shared with git_ops.ls_files; see
+    # snapshot._nul_fields).
+    fields = _nul_fields(trace.stdout)
     matches: list[str] = []
     i = 0
     while i < len(fields):

--- a/daydream/benchmark/snapshot.py
+++ b/daydream/benchmark/snapshot.py
@@ -169,7 +169,7 @@ def head_reachability(mirror_repo: Path, sha: str, pr_head_sha: str) -> str:
     return "ok" if anc.returncode == 0 else "head_not_on_pr"
 
 
-def commit_relation(mirror_repo: Path, base_tip: str, head: str, commit: str) -> str:
+def commit_relation(mirror_repo: Path, head: str, commit: str) -> str:
     """Classify how *commit* relates to the PR head in the pinned mirror.
 
     Returns ``"at_head"`` iff *commit* equals *head*; ``"ancestor"`` when
@@ -198,15 +198,20 @@ def anchor_delta(mirror_repo: Path, base_tip: str, head: str, anchor: Any) -> st
     """Classify how the base..head change interacts with one authoring anchor.
 
     *anchor* is an :class:`~daydream.benchmark.schema.AuthoringAnchor`-shaped
-    dict. Returns ``"locationless"`` when the anchor is not ``status ==
-    "derived"`` or carries no path/range; otherwise the base_tip..head diff is
-    classified: anchored path renamed -> ``"renamed"``; anchored path deleted
-    -> ``"deleted"``; binary content at the anchored path -> ``"binary"``; a
-    modification whose ``-U0`` hunks intersect the anchored ``[start_line,
-    end_line]`` range -> ``"changed"``; a same-file modification outside the
-    range -> ``"unchanged"``. Any git failure returns ``"unavailable"``
-    (fail-closed: never raised, never guessed). All reads are local mirror
-    reads only.
+    dict whose ``[start_line, end_line]`` span lives in the diff base (the
+    ``base_tip`` argument) commit's file coordinate space — for real fact
+    extraction the caller feeds the record's authoring commit as ``base_tip``,
+    the space GitHub's authoring ``original_line`` fields are expressed in.
+    Returns ``"locationless"`` when the anchor is not ``status == "derived"``
+    or carries no path/range; otherwise the base..head diff is classified:
+    anchored path renamed -> ``"renamed"``; anchored path deleted ->
+    ``"deleted"``; binary content at the anchored path -> ``"binary"``; a
+    modification whose ``-U0`` base-side hunk ranges intersect the anchored
+    ``[start_line, end_line]`` span -> ``"changed"``; a same-file
+    modification outside the span -> ``"unchanged"``. Equal base/head (an
+    at-head anchor) is ``"unchanged"`` with no mirror probes. Any git failure
+    returns ``"unavailable"`` (fail-closed: never raised, never guessed). All
+    reads are local mirror reads only.
     """
     if not isinstance(anchor, dict) or anchor.get("status") != "derived":
         return "locationless"
@@ -215,6 +220,11 @@ def anchor_delta(mirror_repo: Path, base_tip: str, head: str, anchor: Any) -> st
     end = anchor.get("end_line")
     if not path or start is None or end is None:
         return "locationless"
+    if base_tip == head:
+        # An at-head anchor is by definition unmodified by the (empty)
+        # base..head change — and the most common extraction case, so it must
+        # never spawn git probes.
+        return "unchanged"
     try:
         st = git_ops._run_git(
             mirror_repo,
@@ -269,8 +279,11 @@ def anchor_delta(mirror_repo: Path, base_tip: str, head: str, anchor: Any) -> st
             return "binary"
         if path not in modified:
             return "unchanged"
-        # The anchored path was modified: intersect the -U0 hunk new-side line
-        # ranges with the anchored [start_line, end_line] span.
+        # The anchored path was modified: the anchor's [start_line, end_line]
+        # span lives in the diff-base (authoring) coordinate space, so
+        # intersect it with the -U0 hunk *base-side* ranges (``-l,s``) — the
+        # new-side ``+c,d`` positions diverge from the authoring coordinates
+        # whenever lines shift above the anchor, misclassifying the span.
         hunks = git_ops._run_git(
             mirror_repo, ["diff", "-U0", base_tip, head, "--", path], retries=0,
         )
@@ -279,12 +292,17 @@ def anchor_delta(mirror_repo: Path, base_tip: str, head: str, anchor: Any) -> st
         for line in hunks.stdout.splitlines():
             if not line.startswith("@@"):
                 continue
-            plus = line.split("+")[1].split(" ")[0] if "+" in line else ""
-            if not plus:
+            minus = line.split("+", 1)[0].strip()
+            old = minus.rpartition(" ")[2]
+            if not old.startswith("-"):
                 continue
-            c, _, d = plus.partition(",")
+            c, _, d = old[1:].partition(",")
             cstart = int(c)
             clen = int(d) if d else 1
+            if clen == 0:
+                # A zero-length base-side range (a pure insertion) cannot
+                # touch any existing authoring line, so the span is unaffected.
+                continue
             cend = cstart + max(clen - 1, 0)
             if start <= cend and end >= cstart:
                 return "changed"

--- a/daydream/benchmark/snapshot.py
+++ b/daydream/benchmark/snapshot.py
@@ -169,6 +169,130 @@ def head_reachability(mirror_repo: Path, sha: str, pr_head_sha: str) -> str:
     return "ok" if anc.returncode == 0 else "head_not_on_pr"
 
 
+def commit_relation(mirror_repo: Path, base_tip: str, head: str, commit: str) -> str:
+    """Classify how *commit* relates to the PR head in the pinned mirror.
+
+    Returns ``"at_head"`` iff *commit* equals *head*; ``"ancestor"`` when
+    ``git merge-base --is-ancestor commit head`` exits zero; ``"non_ancestor"``
+    on a non-zero exit with the object present; and ``"unavailable"`` when the
+    object is missing from the mirror or the probe itself fails. Errors are
+    returned as the value, never raised.
+    """
+    if commit == head:
+        return "at_head"
+    try:
+        verify = git_ops._run_git(
+            mirror_repo, ["rev-parse", "--verify", f"{commit}^{{commit}}"], retries=0,
+        )
+        if verify.returncode != 0:
+            return "unavailable"
+        anc = git_ops._run_git(
+            mirror_repo, ["merge-base", "--is-ancestor", commit, head], retries=0,
+        )
+    except git_ops.GitError:
+        return "unavailable"
+    return "ancestor" if anc.returncode == 0 else "non_ancestor"
+
+
+def anchor_delta(mirror_repo: Path, base_tip: str, head: str, anchor: Any) -> str:
+    """Classify how the base..head change interacts with one authoring anchor.
+
+    *anchor* is an :class:`~daydream.benchmark.schema.AuthoringAnchor`-shaped
+    dict. Returns ``"locationless"`` when the anchor is not ``status ==
+    "derived"`` or carries no path/range; otherwise the base_tip..head diff is
+    classified: anchored path renamed -> ``"renamed"``; anchored path deleted
+    -> ``"deleted"``; binary content at the anchored path -> ``"binary"``; a
+    modification whose ``-U0`` hunks intersect the anchored ``[start_line,
+    end_line]`` range -> ``"changed"``; a same-file modification outside the
+    range -> ``"unchanged"``. Any git failure returns ``"unavailable"``
+    (fail-closed: never raised, never guessed). All reads are local mirror
+    reads only.
+    """
+    if not isinstance(anchor, dict) or anchor.get("status") != "derived":
+        return "locationless"
+    path = anchor.get("path")
+    start = anchor.get("start_line")
+    end = anchor.get("end_line")
+    if not path or start is None or end is None:
+        return "locationless"
+    try:
+        st = git_ops._run_git(
+            mirror_repo,
+            ["diff", "--name-status", "-z", "-M", base_tip, head],
+            retries=0,
+            capture_bytes=True,
+        )
+        if st.returncode != 0:
+            return "unavailable"
+        numstat = git_ops._run_git(
+            mirror_repo,
+            ["diff", "--numstat", "-z", base_tip, head],
+            retries=0,
+            capture_bytes=True,
+        )
+        if numstat.returncode != 0:
+            return "unavailable"
+        stdout = st.stdout if isinstance(st.stdout, bytes) else st.stdout.encode()
+        fields = [f.decode("utf-8", errors="surrogateescape") for f in stdout.split(b"\0") if f]
+        # numstat -z records are NUL-terminated with tab-separated fields:
+        # add, del, path (add/del are "-" for binary content).
+        nstdout = numstat.stdout if isinstance(numstat.stdout, bytes) else numstat.stdout.encode()
+        nfields = [f.decode("utf-8", errors="surrogateescape") for f in nstdout.split(b"\0") if f]
+        binary_paths: set[str] = set()
+        for record in nfields:
+            parts = record.split("\t", 2)
+            if len(parts) == 3 and parts[0] == "-" and parts[1] == "-":
+                binary_paths.add(parts[2])
+        renames: set[str] = set()
+        modified: set[str] = set()
+        j = 0
+        while j < len(fields):
+            status = fields[j]
+            if status.startswith(("R", "C")):
+                if j + 2 >= len(fields):
+                    break
+                old, new = fields[j + 1], fields[j + 2]
+                if path in (old, new):
+                    renames.add(path)
+                j += 3
+            else:
+                if j + 1 >= len(fields):
+                    break
+                if fields[j + 1] == path:
+                    if status == "D":
+                        return "deleted"
+                    modified.add(path)
+                j += 2
+        if path in renames:
+            return "renamed"
+        if path in binary_paths:
+            return "binary"
+        if path not in modified:
+            return "unchanged"
+        # The anchored path was modified: intersect the -U0 hunk new-side line
+        # ranges with the anchored [start_line, end_line] span.
+        hunks = git_ops._run_git(
+            mirror_repo, ["diff", "-U0", base_tip, head, "--", path], retries=0,
+        )
+        if hunks.returncode != 0:
+            return "unavailable"
+        for line in hunks.stdout.splitlines():
+            if not line.startswith("@@"):
+                continue
+            plus = line.split("+")[1].split(" ")[0] if "+" in line else ""
+            if not plus:
+                continue
+            c, _, d = plus.partition(",")
+            cstart = int(c)
+            clen = int(d) if d else 1
+            cend = cstart + max(clen - 1, 0)
+            if start <= cend and end >= cstart:
+                return "changed"
+        return "unchanged"
+    except git_ops.GitError:
+        return "unavailable"
+
+
 def resolve_original_base(mirror_repo: Path, base_tip_ref: str, head_sha: str) -> str | None:
     """The merge-base of the base tip and head, or None when none exists.
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -171,8 +171,9 @@ reason-code legend line explaining its placement:
 
 - Signal reasons: `resolved` (record marked resolved), `outdated` (record
   marked outdated), `anchor-delta-*` (the authoring anchor's content changed or
-  moved between the authoring commit and the pinned snapshot head — an
-  intersecting change at the anchor location vs the same file elsewhere), and
+  moved between the authoring commit and the pinned snapshot head — only a
+  change intersecting the anchor range surfaces a code; a change elsewhere in
+  the same file leaves the delta `unchanged` and surfaces none), and
   `pr-author-reply` (the PR author replied later in the thread).
 - Availability causes: `commit-non-ancestor`, `commit-unavailable`,
   `anchor-unavailable`, `facts-missing`.
@@ -221,9 +222,11 @@ fields.
   `commit_id` gate.
 - An anchor delta between the authoring commit and the pinned snapshot head
   feeds the advisory prioritized view only: a change intersecting the anchor
-  range and a change elsewhere in the same file are surfaced as distinct
-  reason codes. Neither signal establishes semantic correctness — only
-  explicit curator actions create gold or exclusions.
+  range surfaces as an `anchor-delta-changed` reason code (with deleted,
+  renamed, and binary variants); a change elsewhere in the same file leaves
+  the delta `unchanged` and surfaces no reason code. Neither signal
+  establishes semantic correctness — only explicit curator actions create gold
+  or exclusions.
 - `curate` shows the authoring commit prefix (`auth:`) beside the observed
   re-anchored `commit_id` (`commit:`) and the fixed not-exact reason whenever
   exact acceptance is unavailable, so you can see at a glance whether a record

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -162,6 +162,35 @@ All workspace writes are atomic and journaled (`prepared | committing |
 complete`) under the workspace lock, so a crash mid-mutation restores either the
 whole before- or after-state — never a checksum-drifted partial.
 
+#### Prioritized evidence view
+
+The evidence list renders in a **prioritized** view: entries are grouped into
+fixed, labeled bands in deterministic order — undecided and unchanged items
+float to the top, likely-already-actioned items sink. Each entry may carry a
+reason-code legend line explaining its placement:
+
+- Signal reasons: `resolved` (record marked resolved), `outdated` (record
+  marked outdated), `anchor-delta-*` (the authoring anchor's content changed or
+  moved between the authoring commit and the pinned snapshot head — an
+  intersecting change at the anchor location vs the same file elsewhere), and
+  `pr-author-reply` (the PR author replied later in the thread).
+- Availability causes: `commit-non-ancestor`, `commit-unavailable`,
+  `anchor-unavailable`, `facts-missing`.
+- Classification causes: `dismissed`, `decided-by-*`, `non-candidate`.
+
+Each signal is advisory: it reorders and annotates the display only, and
+does not establish semantic correctness — signals never alter the band's
+acceptance rules, and never mutate curation state. Only explicit curator
+actions (accept, edit, exclude, attest) create gold findings or exclusions.
+Every band is display-only: all evidence is retained and reachable, and the
+priority ordering is scoped to the pinned snapshot head and recomputed on
+refresh.
+
+Under the hood, comparison facts (commit relation and anchor delta against
+the pinned head) are computed once at case materialization/refresh and stored
+additively on the case document under a `prioritization` key. The prioritized
+projection itself is derived at read time and is never persisted.
+
 ### Authoring anchors and exact acceptance
 
 Exact single-keystroke acceptance of an inline review candidate is judged
@@ -190,6 +219,11 @@ fields.
   `re-anchored`, when the anchor derives on a commit other than the selected
   head. Review bodies are file-agnostic and keep their single submission
   `commit_id` gate.
+- An anchor delta between the authoring commit and the pinned snapshot head
+  feeds the advisory prioritized view only: a change intersecting the anchor
+  range and a change elsewhere in the same file are surfaced as distinct
+  reason codes. Neither signal establishes semantic correctness — only
+  explicit curator actions create gold or exclusions.
 - `curate` shows the authoring commit prefix (`auth:`) beside the observed
   re-anchored `commit_id` (`commit:`) and the fixed not-exact reason whenever
   exact acceptance is unavailable, so you can see at a glance whether a record

--- a/docs/plans/2026-08-21-private-pr-harbor-benchmarks.md
+++ b/docs/plans/2026-08-21-private-pr-harbor-benchmarks.md
@@ -460,9 +460,13 @@ curation:
       note: The final head includes the requested bounds check.
   case_exclusion: null
 prioritization:
-  commit_relation: descendant
-  anchors:
-    github:review_comment:987654: changed_intersecting
+  extraction_version: 1
+  head_sha: <40-hex>
+  candidates:
+    github:review_comment:987654:
+      commit_relation: at_head
+      anchor_delta: unchanged
+  non_candidates: {}
 ```
 
 Case rules:

--- a/docs/plans/2026-08-21-private-pr-harbor-benchmarks.md
+++ b/docs/plans/2026-08-21-private-pr-harbor-benchmarks.md
@@ -459,6 +459,10 @@ curation:
       reason: fixed_before_snapshot
       note: The final head includes the requested bounds check.
   case_exclusion: null
+prioritization:
+  commit_relation: descendant
+  anchors:
+    github:review_comment:987654: changed_intersecting
 ```
 
 Case rules:
@@ -513,6 +517,14 @@ Case rules:
   `{reason, note}` where reason is `unreplayable`, `not_suitable`,
   `duplicate_case`, or `other`, and `other` requires a note. An unreplayable
   case may be excluded without snapshot/gold attestation.
+- `prioritization` is an additive, optional advisory record (schema_version
+  stays `2`): comparison facts computed once at case materialization/refresh —
+  the commit relation of each evidence anchor's commit to the pinned head and
+  the anchor delta. It is advisory display state, never curation state.
+  Prioritization facts never enter any hash surface: not the import payload,
+  not evidence signatures, not projection hashes, not staleness signatures,
+  and not the Harbor lock. Changing facts alone never stales a case or
+  invalidates a compiled Harbor tree.
 
 ### State transitions
 
@@ -618,7 +630,15 @@ benchmark.
 SHA, changed files/lines, evidence counts, curation state, derived gold mode,
 and gold count. Selecting a case shows the snapshot header and numbered
 evidence with kind, human/bot author, source commit, path/line, resolved,
-outdated, and a body preview.
+outdated, and a body preview. Evidence renders in a prioritized view: fixed
+labeled bands (undecided/unchanged float, likely-already-actioned items sink)
+with an advisory reason-code legend per entry (`resolved`, `outdated`,
+`anchor-delta-*`, `pr-author-reply`, availability and classification causes).
+Number-based actions bind to the exact displayed entry via its captured
+`source_id`; a stale view is detected instead of re-resolving indices. These
+signals are advisory only and do not establish semantic correctness —
+only explicit curator actions create gold or exclusions. All evidence is
+retained; priority is scoped to the pinned snapshot head.
 
 Actions are fixed:
 

--- a/tests/test_benchmark_curate_tui.py
+++ b/tests/test_benchmark_curate_tui.py
@@ -688,21 +688,37 @@ def test_render_case_shows_prioritized_sections_and_legend(tmp_path: Path, fake_
 
 
 def test_number_action_resolves_through_captured_binding_not_fresh_order(
-    tmp_path: Path, fake_gh: FakeGh,
+    tmp_path: Path,
+    fake_gh: FakeGh,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     from daydream.benchmark import curate_tui as tui
     from daydream.benchmark import curation as cu
     ws, case_id, _h = _seed_ready_case_mixed(tmp_path, fake_gh)
     view = cu.get_case(ws, case_id)
-    tui.render_case(view)
     binding = tui._view_binding(view)                     # captured entry->source_id map
-    first_displayed_sid = binding[0]
-    # real curator action after render: a fresh read now sees a mutated case doc
-    _add_late_finding(cu, ws, case_id)
-    # a number-based action on entry 1 must resolve to the *rendered* source_id,
-    # never re-derived from a fresh get_case
-    assert tui._resolve_number(1, binding) == first_displayed_sid
-    assert tui._resolve_number(99, binding) is None
+    raw_order = [ev["source_id"] for ev in view["evidence"]]
+    by_sid = {ev["source_id"]: ev for ev in view["evidence"]}
+    # the captured binding reorders the raw evidence (band ranking), so a number
+    # action re-derived from fresh order would page a different record; pick the
+    # first number where the two orders diverge
+    diverging = next(
+        (n for n, sid in enumerate(binding, start=1) if raw_order[n - 1] != sid),
+        None,
+    )
+    assert diverging is not None
+    bound_sid = binding[diverging - 1]
+    paged: dict[str, str] = {}
+    monkeypatch.setattr("daydream.benchmark.curate_tui._launch_pager",
+                        lambda body: paged.update(body=body))
+    # production number action: entry N pages the record the render numbered N
+    # through the captured binding, never a fresh re-derivation of raw order
+    tui.run_curate_tui(ws, case_id,
+                       read_line=_scripted(str(diverging), "99", "q"))
+    assert paged["body"] == by_sid[bound_sid]["body"]
+    assert paged["body"] != by_sid[raw_order[diverging - 1]]["body"]
+    assert "no evidence number 99" in capsys.readouterr().out
 
 
 def test_stale_binding_prompts_rerender_instead_of_reinterpreting(

--- a/tests/test_benchmark_curate_tui.py
+++ b/tests/test_benchmark_curate_tui.py
@@ -298,7 +298,7 @@ def test_action_edit_authors_edited_finding_from_non_candidate_evidence(
     editor.chmod(0o755)
     monkeypatch.setenv("VISUAL", str(editor))
     monkeypatch.delenv("EDITOR", raising=False)
-    run_curate_tui(ws, case_id, read_line=_scripted("e", "a", "3", "q"))
+    run_curate_tui(ws, case_id, read_line=_scripted("e", "a", "4", "q"))
     f = load_yaml_strict(ws / "cases" / f"{case_id}.yaml")["curation"]["findings"][0]
     assert f["title"] == "From approval" and f["provenance"]["kind"] == "edited"
     assert f["provenance"]["source_ids"] == ["github:review:100"]
@@ -328,7 +328,7 @@ def test_edit_author_prefills_selected_evidence_source_ids(
     monkeypatch.delenv("EDITOR", raising=False)
     monkeypatch.setenv("LOG", str(log))
 
-    run_curate_tui(ws, case_id, read_line=_scripted("e", "a", "3", "q"))
+    run_curate_tui(ws, case_id, read_line=_scripted("e", "a", "4", "q"))
     f = load_yaml_strict(ws / "cases" / f"{case_id}.yaml")["curation"]["findings"][0]
     assert f["title"] == "From selected" and f["provenance"]["kind"] == "edited"
     # verdict: the prefill in the editor buffer carried the selected source_id
@@ -377,7 +377,7 @@ def test_action_edit_merges_range_into_one_finding(
     editor.chmod(0o755)
     monkeypatch.setenv("VISUAL", str(editor))
     monkeypatch.delenv("EDITOR", raising=False)
-    run_curate_tui(ws, case_id, read_line=_scripted("e", "a", "1,3", "q"))
+    run_curate_tui(ws, case_id, read_line=_scripted("e", "a", "1,4", "q"))
     f = load_yaml_strict(ws / "cases" / f"{case_id}.yaml")["curation"]["findings"][0]
     assert f["provenance"]["source_ids"] == ["github:inline_comment:1", "github:review:100"]
 
@@ -414,7 +414,7 @@ def test_action_exclude_range_excludes_all_selected(tmp_path: Path, fake_gh: Fak
     from daydream.benchmark.curate_tui import run_curate_tui
     from daydream.benchmark.storage import load_yaml_strict
     ws, case_id, _h = _seed_ready_case_mixed(tmp_path, fake_gh)
-    run_curate_tui(ws, case_id, read_line=_scripted("x", "1,3", "duplicate", "q"))
+    run_curate_tui(ws, case_id, read_line=_scripted("x", "1,4", "duplicate", "q"))
     ex = load_yaml_strict(ws / "cases" / f"{case_id}.yaml")["curation"]["exclusions"]
     assert {e["source_id"] for e in ex} == {"github:inline_comment:1", "github:review:100"}
     assert all(e["reason"] == "duplicate" for e in ex)
@@ -652,3 +652,130 @@ def test_ready_declined_leaves_draft_and_no_digest(
     cur = load_yaml_strict(ws / "cases" / f"{case_id}.yaml")["curation"]
     assert cur["state"] == "draft" and cur["snapshot_attested"] is False
     assert "task_spec_sha256" not in cur and "task_spec_approved_at" not in cur
+
+
+# ---------------------------------------------------------------------------
+# prioritized sectioned render + captured view binding (issue #879)
+# ---------------------------------------------------------------------------
+
+def _add_late_finding(cu_mod: Any, ws: Path, case_id: str) -> None:
+    """A real post-render curator action: one authored finding, no sources."""
+    cu_mod.add_finding(ws, case_id, title="late concern", body="added after render",
+                       severity="low", location=None, source_ids=[])
+
+
+def test_render_case_shows_prioritized_sections_and_legend(tmp_path: Path, fake_gh: FakeGh) -> None:
+    from daydream.benchmark import curate_tui as tui
+    from daydream.benchmark import curation as cu
+    ws, case_id, _h = _seed_ready_case_mixed(tmp_path, fake_gh)
+    view = cu.get_case(ws, case_id)
+    out = tui.render_case(view)
+    # band sections in fixed order, only non-empty ones rendered
+    assert "-- review_first --" in out
+    assert "-- context --" in out
+    assert "-- decided --" not in out
+    assert "-- withdrawn --" not in out
+    assert "-- likely_actioned --" not in out
+    # section order follows BAND_RANK: review_first before context
+    assert out.index("-- review_first --") < out.index("-- context --")
+    # reason codes appear beside entries and a legend decodes them
+    assert "resolved" in out or "reasons:" in out
+    assert "legend:" in out.lower()
+    # numbering is contiguous across sections through the captured binding
+    binding = tui._view_binding(view)
+    for n, sid in enumerate(binding, start=1):
+        assert f"  {n}. " in out and sid in out
+
+
+def test_number_action_resolves_through_captured_binding_not_fresh_order(
+    tmp_path: Path, fake_gh: FakeGh,
+) -> None:
+    from daydream.benchmark import curate_tui as tui
+    from daydream.benchmark import curation as cu
+    ws, case_id, _h = _seed_ready_case_mixed(tmp_path, fake_gh)
+    view = cu.get_case(ws, case_id)
+    tui.render_case(view)
+    binding = tui._view_binding(view)                     # captured entry->source_id map
+    first_displayed_sid = binding[0]
+    # real curator action after render: a fresh read now sees a mutated case doc
+    _add_late_finding(cu, ws, case_id)
+    # a number-based action on entry 1 must resolve to the *rendered* source_id,
+    # never re-derived from a fresh get_case
+    assert tui._resolve_number(1, binding) == first_displayed_sid
+    assert tui._resolve_number(99, binding) is None
+
+
+def test_stale_binding_prompts_rerender_instead_of_reinterpreting(
+    tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str],
+) -> None:
+    from daydream.benchmark import curate_tui as tui
+    from daydream.benchmark import curation as cu
+    from daydream.benchmark.curate_tui import run_curate_tui
+    from daydream.benchmark.storage import load_yaml_strict
+    ws, case_id, _h = _seed_ready_case_mixed(tmp_path, fake_gh)
+    path = ws / "cases" / f"{case_id}.yaml"
+    view = cu.get_case(ws, case_id)
+    binding = tui._view_binding(view)
+    # mutate the case after render -> the captured binding must read as stale,
+    # while a freshly derived binding reads fresh
+    _add_late_finding(cu, ws, case_id)
+    assert tui._binding_stale(ws, case_id, binding) is True
+    assert tui._binding_stale(ws, case_id, tui._view_binding(cu.get_case(ws, case_id))) is False
+    assert len(load_yaml_strict(path)["curation"]["findings"]) == 1
+    ws2, case_id2, _h2 = _seed_ready_case_mixed(tmp_path, fake_gh)
+    path2 = ws2 / "cases" / f"{case_id2}.yaml"
+
+    def mutate_then_answer(_prompt: str) -> str:
+        _add_late_finding(cu, ws2, case_id2)
+        return "1"
+
+    run_curate_tui(ws2, case_id2, read_line=mutate_then_answer)
+    run_curate_tui(ws2, case_id2, read_line=_scripted("q"))
+    out = capsys.readouterr().out
+    assert "view changed" in out
+    cur = load_yaml_strict(path2)["curation"]
+    assert len(cur["findings"]) == 1 and not cur.get("exclusions")
+
+
+def test_accept_non_candidate_and_context_is_rejected_without_write(
+    tmp_path: Path, fake_gh: FakeGh,
+) -> None:
+    from daydream.benchmark import curation as cu
+    ws, case_id, _h = _seed_ready_case_mixed(tmp_path, fake_gh)
+    path = ws / "cases" / f"{case_id}.yaml"
+    before = path.read_bytes()
+    view = cu.get_case(ws, case_id)
+    ctx_sid = next(e["source_id"] for e in view["prioritized_evidence"]["entries"]
+                   if e["band"] == "context")
+    with pytest.raises(cu.CurationError):
+        cu.accept_candidate(ws, case_id, ctx_sid)
+    assert path.read_bytes() == before
+
+
+def test_low_priority_exact_candidate_still_acceptable(tmp_path: Path, fake_gh: FakeGh) -> None:
+    """Prioritization is advisory: a candidate whose facts/signals sink it to
+    possibly_actioned is still acceptable through the unchanged service path."""
+    from daydream.benchmark import curation as cu
+    from daydream.benchmark.storage import (
+        atomic_write_json,
+        load_json_strict,
+        load_yaml_strict,
+    )
+    ws, case_id, _h = _seed_ready_case(tmp_path, fake_gh, lines=3, candidate=True)
+    raw = load_yaml_strict(ws / "cases" / f"{case_id}.yaml")
+    cand_sid = raw["candidates"][0]["source_id"]
+    import_path = ws / raw["source"]["import_file"]
+    imp = load_json_strict(import_path)
+    for rec in imp["evidence"]:
+        if rec["source_id"] == cand_sid:
+            rec["resolved"] = True
+    atomic_write_json(import_path, imp)
+
+    view = cu.get_case(ws, case_id)
+    assert view["prioritized_evidence"]["by_source"][cand_sid]["band"] == "possibly_actioned"
+    assert view["prioritized_evidence"]["by_source"][cand_sid]["reasons"] == ["resolved"]
+
+    cu.accept_candidate(ws, case_id, cand_sid)   # must not raise
+    cur = load_yaml_strict(ws / "cases" / f"{case_id}.yaml")["curation"]
+    assert cur["findings"][0]["provenance"]["kind"] == "historical"
+    assert cur["findings"][0]["provenance"]["source_ids"] == [cand_sid]

--- a/tests/test_benchmark_curate_tui.py
+++ b/tests/test_benchmark_curate_tui.py
@@ -722,7 +722,10 @@ def test_number_action_resolves_through_captured_binding_not_fresh_order(
 
 
 def test_stale_binding_prompts_rerender_instead_of_reinterpreting(
-    tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+    fake_gh: FakeGh,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     from daydream.benchmark import curate_tui as tui
     from daydream.benchmark import curation as cu
@@ -740,17 +743,30 @@ def test_stale_binding_prompts_rerender_instead_of_reinterpreting(
     assert len(load_yaml_strict(path)["curation"]["findings"]) == 1
     ws2, case_id2, _h2 = _seed_ready_case_mixed(tmp_path, fake_gh)
     path2 = ws2 / "cases" / f"{case_id2}.yaml"
+    paged: list[str] = []
+    monkeypatch.setattr("daydream.benchmark.curate_tui._launch_pager", paged.append)
+    late = [0]
 
     def mutate_then_answer(_prompt: str) -> str:
-        _add_late_finding(cu, ws2, case_id2)
+        # every number keystroke adds a *distinct* case mutation, so no
+        # duplicate finding_id can abort the session and mask the rerender bound
+        if late[0] >= 2:
+            return "q"
+        late[0] += 1
+        cu.add_finding(ws2, case_id2, title=f"late concern {late[0]}",
+                       body=f"added after render #{late[0]}", severity="low",
+                       location=None, source_ids=[])
         return "1"
 
-    run_curate_tui(ws2, case_id2, read_line=mutate_then_answer)
-    run_curate_tui(ws2, case_id2, read_line=_scripted("q"))
+    rc = run_curate_tui(ws2, case_id2, read_line=mutate_then_answer)
     out = capsys.readouterr().out
+    assert rc == 0
     assert "view changed" in out
+    # the number action executes against the freshest displayed binding even
+    # while the case keeps mutating — no unbounded re-prompt spin
+    assert len(paged) == 2
     cur = load_yaml_strict(path2)["curation"]
-    assert len(cur["findings"]) == 1 and not cur.get("exclusions")
+    assert len(cur["findings"]) == 2 and not cur.get("exclusions")
 
 
 def test_accept_non_candidate_and_context_is_rejected_without_write(

--- a/tests/test_benchmark_curation.py
+++ b/tests/test_benchmark_curation.py
@@ -1341,3 +1341,85 @@ def test_decided_and_withdrawn_classify_from_curation_state(tmp_path: Path, fake
     entry = next(e for e in view["prioritized_evidence"]["entries"] if e["source_id"] == cand_sid)
     assert entry["band"] == "decided" and entry["disposition"] == "finding"
     assert "decided-by-finding" in entry["reasons"]
+
+
+def test_pr_author_reply_signal_respects_real_thread_identity() -> None:
+    """Thread-less records are never conflated into one shared reply bucket.
+
+    Regression (issue #336): a PR-author reply without a GraphQL thread id
+    (REST-only inline reply absent from the thread overlay) used to land in
+    ``latest_pr_author_reply[None]`` and spuriously flag every earlier
+    thread-less record (reviews, issue comments, other reply chains). Thread
+    identity for a thread-less record is its REST reply chain top; records
+    outside any chain are unreachable from any reply.
+    """
+    from daydream.benchmark import curation as cu
+
+    def rec(source_id: str, kind: str, db_id: int, node_id: str, created: str,
+            login: str, *, thread_id: str | None = None,
+            reply_to_id: str | None = None) -> dict[str, object]:
+        return {
+            "source_id": source_id, "kind": kind, "database_id": db_id,
+            "node_id": node_id, "created_at": created, "updated_at": created,
+            "author": {"login": login, "type": "User"},
+            "thread_id": thread_id, "reply_to_id": reply_to_id,
+        }
+
+    # pr author login: alice
+    records = [
+        rec("github:review:100", "review", 100, "PRR_100",
+            "2026-01-01T00:01:00Z", "carol"),
+        rec("github:issue_comment:200", "issue_comment", 200, "IC_200",
+            "2026-01-01T00:02:00Z", "dave"),
+        # a thread-less, reply-less REST root in its own unrelated chain,
+        # predating the later thread-less PR-author reply (the pre-fix
+        # None-bucket scenario); a candidate, so a signal would render:
+        rec("github:inline_comment:40", "inline_comment", 40, "DIFF_40",
+            "2026-01-01T00:02:30Z", "bob"),
+        # REST-only chain root + PR-author reply, both without thread ids:
+        rec("github:inline_comment:10", "inline_comment", 10, "DIFF_10",
+            "2026-01-01T00:03:00Z", "bob"),
+        rec("github:inline_comment:11", "inline_comment", 11, "DIFF_11",
+            "2026-01-01T00:04:00Z", "alice", reply_to_id="10"),
+        # threaded chain (root + PR-author reply in one thread):
+        rec("github:inline_comment:20", "inline_comment", 20, "DIFF_20",
+            "2026-01-01T00:05:00Z", "bob", thread_id="T1"),
+        rec("github:inline_comment:21", "inline_comment", 21, "DIFF_21",
+            "2026-01-01T00:06:00Z", "alice", thread_id="T1",
+            reply_to_id="DIFF_20"),
+        # a different threaded thread with no PR-author reply:
+        rec("github:inline_comment:30", "inline_comment", 30, "DIFF_30",
+            "2026-01-01T00:07:00Z", "carol", thread_id="T2"),
+    ]
+    candidate_sids = [
+        "github:inline_comment:40", "github:inline_comment:10",
+        "github:inline_comment:20", "github:inline_comment:30",
+    ]
+    view = cu.prioritized_evidence({
+        "evidence": records,
+        "pull_request": {"author": {"login": "alice", "type": "User"}},
+        "candidates": [{"source_id": sid} for sid in candidate_sids],
+        "curation": {},
+    })
+    reasons = {sid: e["reasons"] for sid, e in view["by_source"].items()}
+    # thread-less non-chain records keep no pr-author-reply reason:
+    assert "pr-author-reply" not in reasons["github:review:100"]
+    assert "pr-author-reply" not in reasons["github:issue_comment:200"]
+    # the unrelated thread-less candidate root keeps no reason either, even
+    # though a later thread-less PR-author reply exists in another chain:
+    assert "pr-author-reply" not in reasons["github:inline_comment:40"]
+    # genuinely replied-to candidates still surface the signal and rank:
+    assert "pr-author-reply" in reasons["github:inline_comment:10"]
+    assert view["by_source"]["github:inline_comment:10"]["band"] == "possibly_actioned"
+    assert "pr-author-reply" in reasons["github:inline_comment:20"]
+    # unrelated threads/chains never do:
+    assert "pr-author-reply" not in reasons["github:inline_comment:30"]
+
+    # the direct-caller fallback scan (no precomputed map) agrees:
+    ctx = {"pr_author_login": "alice", "records": records}
+    assert "pr-author-reply" not in cu.collect_signals(records[0], ctx)
+    assert "pr-author-reply" not in cu.collect_signals(records[1], ctx)
+    assert "pr-author-reply" not in cu.collect_signals(records[2], ctx)
+    assert "pr-author-reply" in cu.collect_signals(records[3], ctx)
+    assert "pr-author-reply" in cu.collect_signals(records[5], ctx)
+    assert "pr-author-reply" not in cu.collect_signals(records[7], ctx)

--- a/tests/test_benchmark_curation.py
+++ b/tests/test_benchmark_curation.py
@@ -15,6 +15,8 @@ import pytest
 import yaml
 
 from daydream import git_ops
+from daydream.benchmark import curation as cu
+from daydream.benchmark import storage
 from daydream.benchmark.schema import derive_finding_id
 from daydream.benchmark.storage import (
     atomic_write_json,
@@ -1232,3 +1234,94 @@ def test_task_spec_acceptance_approval_decline_invalidation_stale(tmp_path: Path
     cu.mark_ready(ws2, case_id2, head_sha=head2, task_spec_sha256="c" * 64)
     cur2 = load_yaml_strict(ws2 / "cases" / f"{case_id2}.yaml")["curation"]
     assert cur2["state"] == "ready" and cur2["task_spec_sha256"] == "c" * 64
+
+
+# ---------------------------------------------------------------------------
+# prioritized_evidence projection (issue #879)
+# ---------------------------------------------------------------------------
+
+BANDS = ["review_first", "needs_judgment", "possibly_actioned", "likely_actioned",
+         "withdrawn", "context", "decided"]
+
+
+def test_band_rank_is_fixed_order() -> None:
+    from daydream.benchmark.curation import BAND_RANK
+    assert [b for b, _ in sorted(BAND_RANK.items(), key=lambda kv: kv[1])] == BANDS
+
+
+def test_classify_table_covers_precedence_and_dispositions() -> None:
+    from daydream.benchmark.curation import classify_evidence
+    # (curation refs, is_candidate, dismissed, signals, facts_present, commit_relation,
+    #  anchor_delta, expected_band, expected_disposition)
+    cases = [
+        ({"finding", "exclusion"}, True, False, set(), True, "at_head", "unchanged", "decided", "conflict"),
+        ({"finding"}, True, False, set(), True, "at_head", "unchanged", "decided", "finding"),
+        (set(), False, False, set(), True, "at_head", "unchanged", "context", "n/a"),
+        (set(), True, True, set(), True, "at_head", "unchanged", "withdrawn", "undecided"),
+        (set(), True, False, {"resolved", "outdated"}, True, "at_head", "unchanged", "likely_actioned", "undecided"),
+        (set(), True, False, {"resolved"}, True, "at_head", "unchanged", "possibly_actioned", "undecided"),
+        (set(), True, False, set(), True, "non_ancestor", "unchanged", "needs_judgment", "undecided"),
+        (set(), True, False, set(), True, "at_head", "unavailable", "needs_judgment", "undecided"),
+        (set(), True, False, set(), False, "at_head", "unchanged", "needs_judgment", "undecided"),  # facts-missing
+        (set(), True, False, set(), True, "at_head", "unchanged", "review_first", "undecided"),
+        # a repeated identical signal still counts once:
+        (set(), True, False, {"resolved"}, True, "at_head", "changed", "possibly_actioned", "undecided"),
+    ]
+    for refs, is_cand, dismissed, signals, has_facts, rel, delta, band, disp in cases:
+        got_band, got_disp, reasons = classify_evidence(
+            refs=refs, is_candidate=is_cand, dismissed=dismissed, signals=signals,
+            facts_present=has_facts, commit_relation=rel, anchor_delta=delta)
+        assert got_band == band and got_disp == disp, (refs, signals, rel, delta, got_band)
+
+
+def test_reason_codes_are_the_closed_set_in_fixed_order() -> None:
+    from daydream.benchmark.curation import REASON_CODES
+    assert list(REASON_CODES) == [
+        "resolved", "outdated", "anchor-delta-changed", "anchor-delta-deleted",
+        "anchor-delta-renamed", "anchor-delta-binary", "pr-author-reply",
+        "commit-non-ancestor", "commit-unavailable", "anchor-unavailable",
+        "facts-missing", "dismissed", "decided-by-finding", "decided-by-exclusion",
+        "decided-by-conflict", "non-candidate"]
+
+
+def test_get_case_attaches_prioritized_evidence_canonical_order_unchanged(
+    tmp_path: Path, fake_gh: FakeGh
+) -> None:
+    from daydream.benchmark.curation import BAND_RANK
+    ws, case_id, _ = _seed_ready_case_mixed(tmp_path, fake_gh)
+    view = cu.get_case(ws, case_id)
+    canon = [e["source_id"] for e in view["evidence"]]
+    pe = view["prioritized_evidence"]
+    assert [e["source_id"] for e in pe["entries"]] == sorted(
+        (e["source_id"] for e in pe["entries"]),
+        key=lambda sid: (BAND_RANK[pe["by_source"][sid]["band"]], canon.index(sid), sid),
+    )
+    # canonical evidence list untouched:
+    assert [e["source_id"] for e in view["evidence"]] == canon
+
+
+def test_prioritized_view_fails_open_without_facts(tmp_path: Path, fake_gh: FakeGh) -> None:
+    ws, case_id, _ = _seed_ready_case(tmp_path, fake_gh, candidate=True)
+    case_path = ws / "cases" / f"{case_id}.yaml"
+    raw = load_yaml_strict(case_path)
+    raw.pop("prioritization", None)
+    storage.atomic_write_yaml(case_path, raw)
+    view = cu.get_case(ws, case_id)
+    cand_sid = view["candidates"][0]["source_id"]
+    cand = next(e for e in view["prioritized_evidence"]["entries"] if e["source_id"] == cand_sid)
+    assert cand["band"] == "needs_judgment" and "facts-missing" in cand["reasons"]
+    # and no case file was rewritten by the read:
+    assert load_yaml_strict(case_path) == raw
+
+
+def test_decided_and_withdrawn_classify_from_curation_state(tmp_path: Path, fake_gh: FakeGh) -> None:
+    # accept one candidate (a real curator action) -> that source becomes decided/finding;
+    # a dismissed evidence record -> withdrawn.
+    ws, case_id, _ = _seed_ready_case_mixed(tmp_path, fake_gh)
+    view = cu.get_case(ws, case_id)
+    cand_sid = view["candidates"][0]["source_id"]
+    cu.accept_candidate(ws, case_id, cand_sid)
+    view = cu.get_case(ws, case_id)
+    entry = next(e for e in view["prioritized_evidence"]["entries"] if e["source_id"] == cand_sid)
+    assert entry["band"] == "decided" and entry["disposition"] == "finding"
+    assert "decided-by-finding" in entry["reasons"]

--- a/tests/test_benchmark_curation.py
+++ b/tests/test_benchmark_curation.py
@@ -1315,11 +1315,27 @@ def test_prioritized_view_fails_open_without_facts(tmp_path: Path, fake_gh: Fake
 
 
 def test_decided_and_withdrawn_classify_from_curation_state(tmp_path: Path, fake_gh: FakeGh) -> None:
-    # accept one candidate (a real curator action) -> that source becomes decided/finding;
-    # a dismissed evidence record -> withdrawn.
+    # a record-level GitHub dismissal (the import marks inline comments whose
+    # review was DISMISSED) reaches the withdrawn band through the real
+    # projection; the same candidate accepted afterwards becomes decided/finding
+    # (curation refs outrank a dismissal).
     ws, case_id, _ = _seed_ready_case_mixed(tmp_path, fake_gh)
     view = cu.get_case(ws, case_id)
     cand_sid = view["candidates"][0]["source_id"]
+    raw = load_yaml_strict(ws / "cases" / f"{case_id}.yaml")
+    import_path = ws / raw["source"]["import_file"]
+    imp = load_json_strict(import_path)
+    for rec in imp["evidence"]:
+        if rec["source_id"] == cand_sid:
+            rec["dismissed"] = True
+    atomic_write_json(import_path, imp)
+
+    view = cu.get_case(ws, case_id)
+    entry = next(e for e in view["prioritized_evidence"]["entries"] if e["source_id"] == cand_sid)
+    assert entry["band"] == "withdrawn" and entry["disposition"] == "undecided"
+    assert entry["reasons"] == ["dismissed"]
+
+    # accept one candidate (a real curator action) -> that source becomes decided/finding.
     cu.accept_candidate(ws, case_id, cand_sid)
     view = cu.get_case(ws, case_id)
     entry = next(e for e in view["prioritized_evidence"]["entries"] if e["source_id"] == cand_sid)

--- a/tests/test_benchmark_docs.py
+++ b/tests/test_benchmark_docs.py
@@ -283,3 +283,22 @@ def test_removed_docs_not_recreated() -> None:
 
 def test_no_project_local_skill_instruction() -> None:
     assert "SKILL.md" not in RUNBOOK.read_text(encoding="utf-8")
+
+
+# --- Prioritized curation contract (issue-879) ---
+
+def test_prioritization_contract_documented() -> None:
+    runbook = (ROOT / "docs" / "benchmark.md").read_text(encoding="utf-8")
+    for phrase in (
+        "prioritized", "advisory", "all evidence is retained",
+        "does not establish semantic correctness",
+    ):
+        assert phrase in runbook, f"runbook must describe the prioritization contract ({phrase!r})"
+    plan = (ROOT / "docs" / "plans" / "2026-08-21-private-pr-harbor-benchmarks.md").read_text(
+        encoding="utf-8"
+    )
+    for phrase in (
+        "prioritized", "advisory", "only explicit curator actions create gold",
+        "resolution", "outdated",
+    ):
+        assert phrase in plan, f"plan must document the prioritization contract ({phrase!r})"

--- a/tests/test_benchmark_harbor_build.py
+++ b/tests/test_benchmark_harbor_build.py
@@ -886,6 +886,38 @@ def test_harbor_bytes_identical_under_anchor_metadata_change(tmp_path: Path, fak
     assert lock_a == lock_b and tree_a == tree_b
 
 
+def test_harbor_bytes_identical_under_prioritization_fact_change(tmp_path: Path, fake_gh: FakeGh) -> None:
+    """Prioritization facts and the derived ranked view never reach the compiled
+    Harbor tree or lock digest: mutating only the case doc's prioritization key
+    (and even deleting it) yields byte-identical tree and lock."""
+    from daydream.benchmark import storage
+    from daydream.benchmark.harbor import build
+
+    ws, case_id, _ = _seed_ready_workspace(tmp_path, fake_gh)
+    lock_a = build.compile_workspace(ws)
+    tree_a = _harbor_tree_bytes(ws)
+
+    case_path = ws / "cases" / f"{case_id}.yaml"
+    raw = storage.load_yaml_strict(case_path)
+    raw["prioritization"]["candidates"] = {}                   # arbitrary fact mutation
+    raw["prioritization"]["extraction_version"] = 999
+    storage.atomic_write_yaml(case_path, raw)
+    lock_b = build.compile_workspace(ws)
+    tree_b = _harbor_tree_bytes(ws)
+    assert lock_a == lock_b and tree_a == tree_b
+    # and no triage sentinel in any compiled file:
+    for rel, data in tree_b.items():
+        assert b"prioritization" not in data, rel
+
+    # deleting the key entirely is also inert
+    raw = storage.load_yaml_strict(case_path)
+    del raw["prioritization"]
+    storage.atomic_write_yaml(case_path, raw)
+    lock_c = build.compile_workspace(ws)
+    tree_c = _harbor_tree_bytes(ws)
+    assert lock_a == lock_c and tree_a == tree_c
+
+
 def test_compiled_case_dirs_are_canonically_sorted_by_opaque_key(tmp_path: Path, fake_gh: FakeGh) -> None:
     from daydream.benchmark import storage
     from daydream.benchmark.harbor import build

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -2704,3 +2704,115 @@ def test_refresh_precanon_duplicate_db_id_verdict_is_deterministic(tmp_path: Pat
     assert case["curation"]["findings"]              # curated findings preserved
     refreshed = load_json_strict(import_path)
     assert len([e for e in refreshed["evidence"] if e["database_id"] == 1]) == 1
+
+
+def test_ready_import_persists_facts_per_candidate(tmp_path: Path, fake_gh: FakeGh) -> None:
+    """A ready freeze persists per-evidence prioritization facts on the case doc."""
+    from daydream.benchmark.storage import load_yaml_strict
+    from tests.test_benchmark_curation import _seed_ready_case
+
+    ws, case_id, _ = _seed_ready_case(tmp_path, fake_gh, candidate=True)
+    case = load_yaml_strict(ws / "cases" / f"{case_id}.yaml")
+    facts = case["prioritization"]
+    assert facts["extraction_version"] == 1
+    assert facts["head_sha"] == case["snapshot"]["original_head_sha"]
+    sid = case["candidates"][0]["source_id"]
+    (rel, delta) = (facts["candidates"][sid]["commit_relation"],
+                    facts["candidates"][sid]["anchor_delta"])
+    assert rel == "at_head" and delta == "unchanged"
+    # every evidence record is classified, candidates and non-candidates alike
+    assert set(facts["candidates"]) | set(facts["non_candidates"]) == {
+        "github:inline_comment:1",
+    }
+
+
+def test_imported_status_case_has_no_facts(tmp_path: Path, fake_gh: FakeGh) -> None:
+    """An imported (hermetic, no freeze) case persists no prioritization key at all."""
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.storage import load_yaml_strict
+
+    ws = tmp_path / "ws"
+    _seed_preflight(ws, fake_gh)
+    fake_gh.set_response(
+        "GET",
+        "repos/o/r/pulls/101/comments",
+        [
+            {"id": 1, "node_id": "DIFF_1", "user": {"login": "alice", "type": "User"},
+             "body": "fix this", "commit_id": "a" * 40, "original_commit_id": "a" * 40,
+             "path": "a.py", "line": 4, "original_line": 4, "original_start_line": 3,
+             "subject_type": "line", "side": "RIGHT",
+             "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",
+             "html_url": "https://github.com/o/r/pull/101#discussion_r1"},
+        ],
+    )
+    assert gi.run_import_prs(ws, pr_numbers=[101], heads=["final"], origin_url=None) == 0
+    case = load_yaml_strict(ws / "cases" / "pr-000101-aaaaaaaaaaaa.yaml")
+    assert "prioritization" not in case or case["prioritization"] is None
+
+
+def test_fact_extraction_failure_records_unavailable_and_import_still_succeeds(
+    tmp_path: Path, fake_gh: FakeGh, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A git failure during fact extraction fail-closes to 'unavailable' without
+    failing the import or disturbing carried-forward curation."""
+    import shutil
+
+    from daydream import git_ops
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.storage import load_json_strict, load_yaml_strict
+    from tests.test_benchmark_curation import _seed_ready_case
+
+    ws, case_id, _ = _seed_ready_case(tmp_path, fake_gh, candidate=True)
+    import_path = ws / load_yaml_strict(ws / "cases" / f"{case_id}.yaml")["source"]["import_file"]
+    before = load_json_strict(import_path)
+
+    # break the mirror; the refresh freeze re-populates it from the local bare origin
+    shutil.rmtree(ws / "cache" / "repository.git")
+
+    def boom(*a: Any, **kw: Any) -> str:
+        raise git_ops.GitError("injected anchor_delta failure")
+
+    monkeypatch.setattr("daydream.benchmark.snapshot.anchor_delta", boom)
+    origin_url = str(tmp_path / "origin_local.git")
+    assert gi.run_import_prs(
+        ws, pr_numbers=[101], heads=["final"], refresh=True, origin_url=origin_url
+    ) == 0
+    case = load_yaml_strict(ws / "cases" / f"{case_id}.yaml")
+    sid = case["candidates"][0]["source_id"]
+    assert case["prioritization"]["candidates"][sid]["anchor_delta"] == "unavailable"
+    assert case["curation"]["state"] == "draft"
+    # the import document itself is untouched by fact extraction (only the
+    # refresh's own fetch stamp may tick)
+    after = load_json_strict(import_path)
+    for d in (before, after):
+        d["fetch"] = {k: v for k, v in d["fetch"].items() if k not in ("fetched_at", "etag")}
+    assert gi._payload_sha256(after) == gi._payload_sha256(before)
+    assert after["evidence"] == before["evidence"]
+
+
+def test_facts_absent_from_every_hash_surface(tmp_path: Path, fake_gh: FakeGh) -> None:
+    """Prioritization facts live on the case doc only: injecting different facts
+    leaves the import payload digest and workspace validation untouched."""
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark import storage
+    from daydream.benchmark.storage import load_json_strict, load_yaml_strict
+    from daydream.benchmark.workspace import validate_workspace
+    from tests.test_benchmark_curation import _seed_ready_case
+
+    ws, case_id, _ = _seed_ready_case(tmp_path, fake_gh, candidate=True)
+    case_path = ws / "cases" / f"{case_id}.yaml"
+    case = load_yaml_strict(case_path)
+    import_path = ws / case["source"]["import_file"]
+    digest_before = gi._payload_sha256(load_json_strict(import_path))
+    code_before, _ = validate_workspace(ws)
+
+    # hand-inject different facts
+    sid = case["candidates"][0]["source_id"]
+    case["prioritization"]["candidates"][sid] = {
+        "commit_relation": "non_ancestor", "anchor_delta": "deleted",
+    }
+    storage.atomic_write_yaml(case_path, case)
+
+    assert gi._payload_sha256(load_json_strict(import_path)) == digest_before
+    code_after, _ = validate_workspace(ws)
+    assert code_after == code_before

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -2867,6 +2867,44 @@ def test_refresh_reuses_persisted_facts_and_preserves_curation(
     assert after_case["prioritization"]["head_sha"] == after_case["snapshot"]["original_head_sha"]
 
 
+def test_reuse_gate_verifies_candidate_split(tmp_path: Path, fake_gh: FakeGh, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A projection-code change that re-buckets the candidate split without
+    touching raw evidence (changed_ids stays empty) must NOT reuse the persisted
+    facts: the reuse gate compares the persisted buckets against the freshly
+    recomputed split, so the block is recomputed and re-bucketed."""
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.storage import load_yaml_strict
+    from tests.test_benchmark_curation import _seed_ready_case
+
+    ws, case_id, _ = _seed_ready_case(tmp_path, fake_gh, candidate=True)
+    case_path = ws / "cases" / f"{case_id}.yaml"
+    before = load_yaml_strict(case_path)
+    sid = before["candidates"][0]["source_id"]
+    assert set(before["prioritization"]["candidates"]) == {sid}
+
+    # Premise: the frame a projection-code change leaves behind — the raw
+    # evidence is byte-identical (no changed_ids) yet the recomputed projection
+    # re-buckets the record out of candidacy.
+    monkeypatch.setattr(gi, "project_candidates", lambda doc, head: [])
+
+    calls: list[int] = []
+    real = gi._extract_prioritization_facts
+
+    def recorded(*a: Any, **kw: Any) -> Any:
+        calls.append(1)
+        return real(*a, **kw)
+
+    monkeypatch.setattr(gi, "_extract_prioritization_facts", recorded)
+    origin_url = str(tmp_path / "origin_local.git")
+    assert gi.run_import_prs(
+        ws, pr_numbers=[101], heads=["final"], refresh=True, origin_url=origin_url
+    ) == 0
+    assert calls  # the gate rejected the stale split and recomputed
+    after = load_yaml_strict(case_path)
+    assert after["prioritization"]["candidates"] == {}
+    assert set(after["prioritization"]["non_candidates"]) == {sid}
+
+
 def test_facts_version_bump_alone_never_stales(tmp_path: Path, fake_gh: FakeGh) -> None:
     """A prioritization facts extraction-version bump alone never stales curated
     gold; the next refresh recomputes facts at the current version."""

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -2861,7 +2861,9 @@ def test_facts_version_bump_alone_never_stales(tmp_path: Path, fake_gh: FakeGh) 
     ) == 0
     refreshed = load_yaml_strict(case_path)
     assert refreshed["curation"]["state"] == "ready"           # version bump alone does not stale
-    assert refreshed["prioritization"]["extraction_version"] == gi.EXTRACTION_VERSION
+    from daydream.benchmark.schema import EXTRACTION_VERSION
+
+    assert refreshed["prioritization"]["extraction_version"] == EXTRACTION_VERSION
 
 
 def test_equivalent_imports_produce_identical_facts_and_rank(tmp_path: Path, fake_gh: FakeGh) -> None:

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -2816,3 +2816,64 @@ def test_facts_absent_from_every_hash_surface(tmp_path: Path, fake_gh: FakeGh) -
     assert gi._payload_sha256(load_json_strict(import_path)) == digest_before
     code_after, _ = validate_workspace(ws)
     assert code_after == code_before
+
+
+def test_refresh_recomputes_facts_and_preserves_curation(tmp_path: Path, fake_gh: FakeGh) -> None:
+    """A refresh recomputes prioritization facts against the pinned head while
+    carrying the curator's curation and the pinned snapshot forward unchanged."""
+    from daydream.benchmark import curation as cu
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.storage import load_yaml_strict
+    from tests.test_benchmark_curation import _seed_ready_case
+
+    ws, case_id, _ = _seed_ready_case(tmp_path, fake_gh, candidate=True)
+    case_path = ws / "cases" / f"{case_id}.yaml"
+    sid = load_yaml_strict(case_path)["candidates"][0]["source_id"]
+    cu.accept_candidate(ws, case_id, sid)     # curator action
+    before_case = load_yaml_strict(case_path)
+    origin_url = str(tmp_path / "origin_local.git")
+    assert gi.run_import_prs(
+        ws, pr_numbers=[101], heads=["final"], refresh=True, origin_url=origin_url
+    ) == 0
+    after_case = load_yaml_strict(case_path)
+    assert after_case["curation"] == before_case["curation"]  # carried forward unchanged
+    assert after_case["snapshot"] == before_case["snapshot"]  # pinned head/bundle intact
+    assert after_case["prioritization"]["head_sha"] == after_case["snapshot"]["original_head_sha"]
+
+
+def test_facts_version_bump_alone_never_stales(tmp_path: Path, fake_gh: FakeGh) -> None:
+    """A prioritization facts extraction-version bump alone never stales curated
+    gold; the next refresh recomputes facts at the current version."""
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark import storage
+    from daydream.benchmark.storage import load_yaml_strict
+    from tests.test_benchmark_curation import _seed_ready_case
+
+    ws, case_id, _ = _seed_ready_case(tmp_path, fake_gh, candidate=True)
+    case_path = ws / "cases" / f"{case_id}.yaml"
+    raw = load_yaml_strict(case_path)
+    raw["prioritization"]["extraction_version"] = 0            # simulate an older facts version
+    raw["curation"]["state"] = "ready"
+    storage.atomic_write_yaml(case_path, raw)
+    origin_url = str(tmp_path / "origin_local.git")
+    assert gi.run_import_prs(
+        ws, pr_numbers=[101], heads=["final"], refresh=True, origin_url=origin_url
+    ) == 0
+    refreshed = load_yaml_strict(case_path)
+    assert refreshed["curation"]["state"] == "ready"           # version bump alone does not stale
+    assert refreshed["prioritization"]["extraction_version"] == gi.EXTRACTION_VERSION
+
+
+def test_equivalent_imports_produce_identical_facts_and_rank(tmp_path: Path, fake_gh: FakeGh) -> None:
+    """Two independently seeded equivalent workspaces produce byte-identical
+    prioritization facts and identical prioritized_evidence projections."""
+    from daydream.benchmark import curation as cu
+    from daydream.benchmark.storage import load_yaml_strict
+    from tests.test_benchmark_curation import _seed_ready_case_mixed
+
+    ws1, case_id1, _ = _seed_ready_case_mixed(tmp_path, fake_gh)
+    ws2, case_id2, _ = _seed_ready_case_mixed(tmp_path, fake_gh)
+    v1, v2 = cu.get_case(ws1, case_id1), cu.get_case(ws2, case_id2)
+    assert v1["prioritized_evidence"] == v2["prioritized_evidence"]
+    assert load_yaml_strict(ws1 / "cases" / f"{case_id1}.yaml")["prioritization"] == \
+        load_yaml_strict(ws2 / "cases" / f"{case_id2}.yaml")["prioritization"]

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -2263,11 +2263,13 @@ def test_missing_prior_import_is_nonfatal_first_run(tmp_path: Path) -> None:
         _,
         prior_pinned,
         prior_policy,
+        prior_facts,
         prior_heads,
     ) = gi._prior_import_state(ws, raw, 202)
     assert prior_sig is None and prior_task_sig is None and curations == {}
     assert prior_candidates == {}
     assert prior_pinned == {} and prior_policy == {} and prior_heads == []
+    assert prior_facts == {}
 
 
 def test_refresh_stale_clears_task_spec_approval(tmp_path: Path, fake_gh: FakeGh) -> None:
@@ -2754,17 +2756,27 @@ def test_fact_extraction_failure_records_unavailable_and_import_still_succeeds(
     tmp_path: Path, fake_gh: FakeGh, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A git failure during fact extraction fail-closes to 'unavailable' without
-    failing the import or disturbing carried-forward curation."""
+    failing the import or disturbing carried-forward curation.
+
+    The prior facts are staled to an older extraction version first so the
+    refresh actually re-extracts: an exact persisted block is reused verbatim
+    (see test_refresh_reuses_persisted_facts_without_probes) and never probes.
+    """
     import shutil
 
     from daydream import git_ops
     from daydream.benchmark import github_import as gi
+    from daydream.benchmark import storage
     from daydream.benchmark.storage import load_json_strict, load_yaml_strict
     from tests.test_benchmark_curation import _seed_ready_case
 
     ws, case_id, _ = _seed_ready_case(tmp_path, fake_gh, candidate=True)
     import_path = ws / load_yaml_strict(ws / "cases" / f"{case_id}.yaml")["source"]["import_file"]
     before = load_json_strict(import_path)
+    # stale the persisted facts so the refresh recomputes (and fails closed)
+    raw_case = load_yaml_strict(ws / "cases" / f"{case_id}.yaml")
+    raw_case["prioritization"]["extraction_version"] = 0
+    storage.atomic_write_yaml(ws / "cases" / f"{case_id}.yaml", raw_case)
 
     # break the mirror; the refresh freeze re-populates it from the local bare origin
     shutil.rmtree(ws / "cache" / "repository.git")
@@ -2818,11 +2830,15 @@ def test_facts_absent_from_every_hash_surface(tmp_path: Path, fake_gh: FakeGh) -
     assert code_after == code_before
 
 
-def test_refresh_recomputes_facts_and_preserves_curation(tmp_path: Path, fake_gh: FakeGh) -> None:
-    """A refresh recomputes prioritization facts against the pinned head while
+def test_refresh_reuses_persisted_facts_and_preserves_curation(
+    tmp_path: Path, fake_gh: FakeGh, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A no-op refresh reuses the persisted prioritization block verbatim (the
+    mirror probes never re-run — zero subprocess fan-out per record) while
     carrying the curator's curation and the pinned snapshot forward unchanged."""
     from daydream.benchmark import curation as cu
     from daydream.benchmark import github_import as gi
+    from daydream.benchmark import snapshot as snapshot_mod
     from daydream.benchmark.storage import load_yaml_strict
     from tests.test_benchmark_curation import _seed_ready_case
 
@@ -2832,12 +2848,22 @@ def test_refresh_recomputes_facts_and_preserves_curation(tmp_path: Path, fake_gh
     cu.accept_candidate(ws, case_id, sid)     # curator action
     before_case = load_yaml_strict(case_path)
     origin_url = str(tmp_path / "origin_local.git")
+
+    # The extraction probes must not run at all on the no-op refresh: any call
+    # proves a recompute raced past the reuse gate.
+    def boom(*a: Any, **kw: Any) -> str:
+        raise AssertionError("mirror probe re-ran on a no-op refresh")
+
+    monkeypatch.setattr(snapshot_mod, "commit_relation", boom)
+    monkeypatch.setattr(snapshot_mod, "anchor_delta", boom)
     assert gi.run_import_prs(
         ws, pr_numbers=[101], heads=["final"], refresh=True, origin_url=origin_url
     ) == 0
     after_case = load_yaml_strict(case_path)
     assert after_case["curation"] == before_case["curation"]  # carried forward unchanged
     assert after_case["snapshot"] == before_case["snapshot"]  # pinned head/bundle intact
+    # the persisted facts are reused byte-identical
+    assert after_case["prioritization"] == before_case["prioritization"]
     assert after_case["prioritization"]["head_sha"] == after_case["snapshot"]["original_head_sha"]
 
 

--- a/tests/test_benchmark_snapshot.py
+++ b/tests/test_benchmark_snapshot.py
@@ -971,3 +971,145 @@ def test_mirror_answers_commit_relation_and_anchor_delta_queries(tmp_path: Path)
     # (c) binary detection: numstat emits '-' for both added/deleted counts.
     numstat = _git(m, "diff", "--numstat", authoring_sha, head_sha)
     assert "-\t-\tblob.bin" in numstat.splitlines(), numstat
+
+
+# ---------------------------------------------------------------------------
+# Task 2 (plan #879): commit_relation + anchor_delta helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_delta_origin(tmp_path: Path) -> tuple[str, str, str, dict[str, str]]:
+    """Bare origin seeded for the fact-helper tests (task 2, plan #879).
+
+    main: base1 (readme) -> base2 (base.py + a 10-line ``wide.py`` +
+    ``renamed.txt`` + ``deleted.txt``). Four heads branch off base2: ``edit``
+    (modifies wide.py line 10 in place), ``rename`` (``git mv renamed.txt`` ->
+    ``renamed2.txt``), ``delete`` (removes deleted.txt), and ``binary`` (adds a
+    binary ``bin.dat``). An ``orphan`` commit sits off base1 on a different
+    ancestry. Returns ``(bare, base2_sha, orphan_sha, heads)`` where ``heads``
+    maps scenario name -> head SHA.
+    """
+    repo = tmp_path / "delta_wt"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _write(repo, "readme.txt", "base1\n")
+    _commit(repo, "base1")
+    _write(repo, "base.py", "BASE = 2\n")
+    _write(repo, "wide.py", "".join(f"line{i}\n" for i in range(1, 11)))
+    _write(repo, "renamed.txt", "r\n")
+    _write(repo, "deleted.txt", "d\n")
+    base2_sha = _commit(repo, "base2")
+
+    _git(repo, "checkout", "--detach", base2_sha)
+    content = (repo / "wide.py").read_text().replace("line10\n", "line10 edited\n")
+    repo.joinpath("wide.py").write_text(content)
+    _git(repo, "add", "wide.py")
+    edit_head = _commit(repo, "edit wide.py line 10")
+
+    _git(repo, "checkout", "--detach", base2_sha)
+    _git(repo, "mv", "renamed.txt", "renamed2.txt")
+    rename_head = _commit(repo, "rename renamed.txt")
+
+    _git(repo, "checkout", "--detach", base2_sha)
+    _git(repo, "rm", "deleted.txt")
+    delete_head = _commit(repo, "delete deleted.txt")
+
+    _git(repo, "checkout", "--detach", base2_sha)
+    (repo / "bin.dat").write_bytes(b"\x00\x01\x02binary")
+    _git(repo, "add", "bin.dat")
+    binary_head = _commit(repo, "add bin.dat")
+
+    _git(repo, "checkout", "--detach", base2_sha)
+    repo.joinpath("orphan.txt").write_text("o\n")
+    _git(repo, "add", "orphan.txt")
+    orphan_sha = _commit(repo, "orphan")
+
+    bare = tmp_path / "delta_origin.git"
+    bare.mkdir(parents=True, exist_ok=True)
+    _git(bare, "init", "--bare")
+    _git(repo, "remote", "add", "origin", str(bare))
+    _git(repo, "push", "origin", "main:main")
+    for name, sha in (("edit", edit_head), ("rename", rename_head),
+                      ("delete", delete_head), ("binary", binary_head),
+                      ("orphan", orphan_sha)):
+        _git(repo, "push", "origin", f"{sha}:refs/heads/{name}")
+    heads = {"edit": edit_head, "rename": rename_head,
+             "delete": delete_head, "binary": binary_head}
+    return str(bare), base2_sha, orphan_sha, heads
+
+
+def _anchor(path: str | None, start: int | None, end: int | None,
+            commit: str, status: str = "derived") -> dict[str, Any]:
+    return {"version": 1, "status": status, "commit_id": commit,
+            "path": path, "start_line": start, "end_line": end}
+
+
+def _delta_mirror(tmp_path: Path) -> tuple[Path, str, str, dict[str, str]]:
+    from daydream.benchmark import snapshot as sn
+
+    origin, base, orphan, heads = _seed_delta_origin(tmp_path)
+    m = sn.ensure_mirror(tmp_path, "o/r", origin_url=origin)
+    sn._git_fetch(m, origin, [
+        f"{sha}:refs/heads/fact-{i}"
+        for i, sha in enumerate((base, orphan, *heads.values()))
+    ])
+    return sn.mirror(tmp_path), base, orphan, heads
+
+
+def test_commit_relation_classifies_ancestor_head_and_non_ancestor(tmp_path: Path) -> None:
+    from daydream.benchmark import snapshot as sn
+
+    m, base, orphan, heads = _delta_mirror(tmp_path)
+    assert sn.commit_relation(m, base, heads["edit"], heads["edit"]) == "at_head"
+    assert sn.commit_relation(m, base, heads["edit"], base) == "ancestor"
+    assert sn.commit_relation(m, base, heads["edit"], orphan) == "non_ancestor"
+
+
+def test_commit_relation_unavailable_on_missing_object(tmp_path: Path) -> None:
+    from daydream.benchmark import snapshot as sn
+
+    m, base, orphan, heads = _delta_mirror(tmp_path)
+    assert sn.commit_relation(m, base, heads["edit"], "f" * 40) == "unavailable"
+
+
+def test_anchor_delta_intersecting_vs_elsewhere_rename_delete_binary_locationless(
+    tmp_path: Path,
+) -> None:
+    from daydream.benchmark import snapshot as sn
+
+    m, base, orphan, heads = _delta_mirror(tmp_path)
+    # intersecting edit to the anchored range -> changed
+    assert sn.anchor_delta(m, base, heads["edit"],
+                           _anchor("wide.py", 10, 10, base)) == "changed"
+    # edit elsewhere in the same file -> unchanged
+    assert sn.anchor_delta(m, base, heads["edit"],
+                           _anchor("wide.py", 1, 5, base)) == "unchanged"
+    # anchored path renamed -> renamed
+    assert sn.anchor_delta(m, base, heads["rename"],
+                           _anchor("renamed.txt", 1, 1, base)) == "renamed"
+    # anchored file deleted -> deleted
+    assert sn.anchor_delta(m, base, heads["delete"],
+                           _anchor("deleted.txt", 1, 1, base)) == "deleted"
+    # binary content at the anchor -> binary
+    assert sn.anchor_delta(m, base, heads["binary"],
+                           _anchor("bin.dat", 1, 1, base)) == "binary"
+    # anchor with path=None or a non-derived status -> locationless
+    assert sn.anchor_delta(m, base, heads["edit"],
+                           _anchor(None, None, None, base)) == "locationless"
+    assert sn.anchor_delta(m, base, heads["edit"],
+                           _anchor("wide.py", 1, 1, base, status="path-unavailable")) == "locationless"
+
+
+def test_anchor_delta_unavailable_on_git_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from daydream.benchmark import snapshot as sn
+
+    m, base, orphan, heads = _delta_mirror(tmp_path)
+
+    def _boom(*args: Any, **kwargs: Any) -> Any:
+        raise git_ops.GitError("forced failure")
+
+    monkeypatch.setattr(sn.git_ops, "_run_git", _boom)
+    assert sn.anchor_delta(m, base, heads["edit"],
+                           _anchor("wide.py", 10, 10, base)) == "unavailable"

--- a/tests/test_benchmark_snapshot.py
+++ b/tests/test_benchmark_snapshot.py
@@ -1114,3 +1114,45 @@ def test_anchor_delta_unavailable_on_git_failure(
     monkeypatch.setattr(git_ops, "_run_git", _boom)
     assert sn.anchor_delta(m, base, heads["edit"],
                            _anchor("wide.py", 10, 10, base)) == "unavailable"
+
+
+def test_anchor_delta_shared_classification_runs_whole_tree_diffs_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two anchors on the same (base_tip, head) share the whole-tree
+    name-status/numstat classification via diff_cache: only the per-path -U0
+    probe remains per-record, and the cached classification classifies each
+    record exactly as an uncached probe would."""
+    from daydream.benchmark import snapshot as sn
+
+    m, base, orphan, heads = _delta_mirror(tmp_path)
+    probes: list[list[str]] = []
+    real = git_ops._run_git
+
+    def counting(repo: Any, args: list[str], **kw: Any) -> Any:
+        if any(flag in args for flag in ("--name-status", "--numstat", "-U0")):
+            probes.append(args)
+        return real(repo, args, **kw)
+
+    monkeypatch.setattr(git_ops, "_run_git", counting)
+    cache: dict[tuple[str, str], sn.AnchorDiff] = {}
+    assert sn.anchor_delta(
+        m, base, heads["edit"], _anchor("wide.py", 10, 10, base), diff_cache=cache
+    ) == "changed"
+    assert sn.anchor_delta(
+        m, base, heads["edit"], _anchor("wide.py", 1, 5, base), diff_cache=cache
+    ) == "unchanged"
+    assert len([a for a in probes if "--name-status" in a]) == 1
+    assert len([a for a in probes if "--numstat" in a]) == 1
+    # one per-path -U0 probe per modified record stays
+    assert len([a for a in probes if "-U0" in a]) == 2
+    # without the shared cache each record pays the whole-tree fan-out anew
+    probes.clear()
+    assert sn.anchor_delta(
+        m, base, heads["edit"], _anchor("wide.py", 10, 10, base)
+    ) == "changed"
+    assert sn.anchor_delta(
+        m, base, heads["edit"], _anchor("wide.py", 1, 5, base)
+    ) == "unchanged"
+    assert len([a for a in probes if "--name-status" in a]) == 2
+    assert len([a for a in probes if "--numstat" in a]) == 2

--- a/tests/test_benchmark_snapshot.py
+++ b/tests/test_benchmark_snapshot.py
@@ -1061,16 +1061,16 @@ def test_commit_relation_classifies_ancestor_head_and_non_ancestor(tmp_path: Pat
     from daydream.benchmark import snapshot as sn
 
     m, base, orphan, heads = _delta_mirror(tmp_path)
-    assert sn.commit_relation(m, base, heads["edit"], heads["edit"]) == "at_head"
-    assert sn.commit_relation(m, base, heads["edit"], base) == "ancestor"
-    assert sn.commit_relation(m, base, heads["edit"], orphan) == "non_ancestor"
+    assert sn.commit_relation(m, heads["edit"], heads["edit"]) == "at_head"
+    assert sn.commit_relation(m, heads["edit"], base) == "ancestor"
+    assert sn.commit_relation(m, heads["edit"], orphan) == "non_ancestor"
 
 
 def test_commit_relation_unavailable_on_missing_object(tmp_path: Path) -> None:
     from daydream.benchmark import snapshot as sn
 
     m, base, orphan, heads = _delta_mirror(tmp_path)
-    assert sn.commit_relation(m, base, heads["edit"], "f" * 40) == "unavailable"
+    assert sn.commit_relation(m, heads["edit"], "f" * 40) == "unavailable"
 
 
 def test_anchor_delta_intersecting_vs_elsewhere_rename_delete_binary_locationless(

--- a/tests/test_benchmark_snapshot.py
+++ b/tests/test_benchmark_snapshot.py
@@ -19,6 +19,7 @@ from typing import Any
 import pytest
 
 from daydream import git_ops
+from daydream.git_ops import GitError
 
 # ---------------------------------------------------------------------------
 # real-git seed helpers (deterministic commit SHAs)
@@ -1108,8 +1109,8 @@ def test_anchor_delta_unavailable_on_git_failure(
     m, base, orphan, heads = _delta_mirror(tmp_path)
 
     def _boom(*args: Any, **kwargs: Any) -> Any:
-        raise git_ops.GitError("forced failure")
+        raise GitError("forced failure")
 
-    monkeypatch.setattr(sn.git_ops, "_run_git", _boom)
+    monkeypatch.setattr(git_ops, "_run_git", _boom)
     assert sn.anchor_delta(m, base, heads["edit"],
                            _anchor("wide.py", 10, 10, base)) == "unavailable"

--- a/tests/test_benchmark_snapshot.py
+++ b/tests/test_benchmark_snapshot.py
@@ -888,3 +888,86 @@ def _clone_offline(bundle: Path, workdir: Path) -> Path:
     clone = tempfile.mkdtemp(prefix="e2e-", dir=str(workdir))
     _git(bundle.parent, "clone", "--no-local", "--no-checkout", str(bundle), clone)
     return Path(clone)
+
+
+# ---------------------------------------------------------------------------
+# Task 0 spike (plan #879): mirror reads for commit-relation + anchor-delta facts
+# ---------------------------------------------------------------------------
+
+
+def _seed_facts_origin(tmp_path: Path) -> tuple[str, str, str, str]:
+    """Bare origin seeded for the prioritization fact probes.
+
+    main: base1 -> base2 -> base3; refs/pull/1/head off base2 with one commit
+    that (a) renames ``old.py`` to ``new.py`` with no content change, (b) edits
+    ``feature.py`` in place, and (c) adds a binary file. Returns
+    ``(bare, base2_sha, base3_sha, head_sha)`` where base2 is the PR's base tip
+    and base3 is an unrelated (non-ancestor-of-head) commit.
+    """
+    repo = tmp_path / "facts_wt"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _write(repo, "readme.txt", "base1\n")
+    _commit(repo, "base1")
+    _write(repo, "base.py", "BASE = 2\n")
+    base2_sha = _commit(repo, "base2")
+    _write(repo, "beyond.py", "BEYOND = 3\n")
+    base3_sha = _commit(repo, "base3")
+    _git(repo, "checkout", "--detach", base2_sha)
+    _write(repo, "old.py", "def old() -> int:\n    return 1\n")
+    _write(repo, "feature.py", "FEATURE = 1\n")
+    authoring_sha = _commit(repo, "author old.py + feature.py")
+    _git(repo, "mv", "old.py", "new.py")
+    repo.joinpath("feature.py").write_text("FEATURE = 2\n")
+    _git(repo, "add", "feature.py")
+    (repo / "blob.bin").write_bytes(b"\x00\x01\x02\x03binary")
+    _git(repo, "add", "blob.bin")
+    head_sha = _commit(repo, "rename + edit + binary")
+
+    bare = tmp_path / "facts_origin.git"
+    bare.mkdir(parents=True, exist_ok=True)
+    _git(bare, "init", "--bare")
+    _git(repo, "remote", "add", "origin", str(bare))
+    _git(repo, "push", "origin", "main:main")
+    _git(repo, "push", "origin", f"{head_sha}:refs/pull/1/head", check=False)
+    return str(bare), authoring_sha, base3_sha, head_sha
+
+
+def test_mirror_answers_commit_relation_and_anchor_delta_queries(tmp_path: Path) -> None:
+    """Spike pin (task 0, plan #879): a plain bare mirror answers both fact
+    queries the prioritization extraction needs — ``merge-base --is-ancestor``
+    for the commit relation and ``diff --name-status -M`` / ``--numstat`` for
+    the anchor delta (with parseable path columns and binary detection). If any
+    probe's output shape deviates on a plain bare mirror, the extraction helper
+    design must be revised before Task 1."""
+    from daydream.benchmark import snapshot as sn
+
+    origin, authoring_sha, unrelated_sha, head_sha = _seed_facts_origin(tmp_path)
+    sn.ensure_mirror(tmp_path, "o/r", origin_url=origin)
+    sn.fetch_head_refs(tmp_path, "o/r", 1, explicit_shas=[head_sha], origin_url=origin)
+    m = sn.mirror(tmp_path)
+
+    # (a) commit relation: ancestor exits 0; unrelated commit exits non-zero.
+    ancestor = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", head_sha, head_sha],
+        cwd=m, capture_output=True, text=True,
+    )
+    assert ancestor.returncode == 0, ancestor.stderr
+    unrelated = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", unrelated_sha, head_sha],
+        cwd=m, capture_output=True, text=True,
+    )
+    assert unrelated.returncode != 0
+
+    # (b) anchor delta inputs: rename + intersecting edit with parseable columns.
+    statuses = _git(m, "diff", "--name-status", authoring_sha, head_sha, "-M")
+    rows = [line.split("\t") for line in statuses.splitlines() if line]
+    rename = next(r for r in rows if r[0].startswith("R"))
+    assert rename == ["R100", "old.py", "new.py"], statuses
+    edited = next(r for r in rows if r[0] == "M")
+    assert edited == ["M", "feature.py"], statuses
+    assert all(r[0] == "A" or len(r) >= 2 for r in rows), statuses
+
+    # (c) binary detection: numstat emits '-' for both added/deleted counts.
+    numstat = _git(m, "diff", "--numstat", authoring_sha, head_sha)
+    assert "-\t-\tblob.bin" in numstat.splitlines(), numstat

--- a/tests/test_benchmark_workspace_schema.py
+++ b/tests/test_benchmark_workspace_schema.py
@@ -818,6 +818,44 @@ def test_classify_validation_codes() -> None:
     assert classify_validation(ready=False, incomplete=False, corrupt=True) == 1
 
 
+def test_case_document_accepts_additive_prioritization_key() -> None:
+    """Spike pin (task 0, plan #879): the new additive ``prioritization`` key
+    loads under the strict CaseDocument schema (schema_version stays 2) and
+    round-trips. If this ever fails in a way an optional-field default cannot
+    fix, the additive-under-v2 Key Decision is unsound and must be re-routed to
+    the spec before any prioritization task runs."""
+    raw = _valid_case_dict()
+    assert "prioritization" not in raw
+    doc = CaseDocument.model_validate(raw)
+    assert doc.prioritization is None  # absence tolerated (old case docs load)
+
+    facts = {
+        "extraction_version": 1,
+        "head_sha": "a" * 40,
+        "candidates": {
+            "github:review_comment:1": {
+                "commit_relation": "at_head",
+                "anchor_delta": "unchanged",
+            }
+        },
+        "non_candidates": {},
+    }
+    raw2 = _valid_case_dict()
+    raw2["prioritization"] = facts
+    doc2 = CaseDocument.model_validate(raw2)
+    assert doc2.prioritization is not None
+    assert doc2.prioritization.extraction_version == 1
+    assert doc2.prioritization.head_sha == "a" * 40
+    cand = doc2.prioritization.candidates["github:review_comment:1"]
+    assert cand.commit_relation == "at_head" and cand.anchor_delta == "unchanged"
+    assert doc2.prioritization.non_candidates == {}
+    # extra="forbid" still holds inside the new subtree
+    raw3 = _valid_case_dict()
+    raw3["prioritization"] = dict(facts, bogus=1)
+    with pytest.raises(ValidationError):
+        CaseDocument.model_validate(raw3)
+
+
 def test_pull_request_entry_fetched_allows_latest_error_only() -> None:
     # A fetched entry may carry latest_error (a failed refresh attempt on an
     # otherwise-intact import) but never `error` itself.

--- a/tests/test_benchmark_workspace_schema.py
+++ b/tests/test_benchmark_workspace_schema.py
@@ -856,6 +856,38 @@ def test_case_document_accepts_additive_prioritization_key() -> None:
         CaseDocument.model_validate(raw3)
 
 
+def test_case_prioritization_facts_shape() -> None:
+    from daydream.benchmark.schema import CaseDocument, PrioritizationFacts
+
+    facts = PrioritizationFacts.model_validate(
+        {
+            "extraction_version": 1,
+            "head_sha": "a" * 40,
+            "candidates": {"gh:101:c1": {"commit_relation": "at_head", "anchor_delta": "changed"}},
+            "non_candidates": {},
+        }
+    )
+    assert facts.extraction_version == 1
+    assert facts.candidates["gh:101:c1"].commit_relation == "at_head"
+    # additive under v2: an absent key still loads as None
+    doc = CaseDocument.model_validate(_valid_case_dict())
+    assert doc.prioritization is None
+
+
+def test_case_document_tolerates_absent_and_rejects_bad_prioritization() -> None:
+    raw = _valid_case_dict()
+    doc = CaseDocument.model_validate(raw)
+    assert doc.prioritization is None  # absent key -> None, old docs load
+
+    raw["prioritization"] = {
+        "extraction_version": 1,
+        "head_sha": "a" * 40,
+        "candidates": {"x": {"commit_relation": "wat", "anchor_delta": "unchanged"}},
+    }
+    with pytest.raises(ValidationError):  # unknown enum value is a schema violation
+        CaseDocument.model_validate(raw)
+
+
 def test_pull_request_entry_fetched_allows_latest_error_only() -> None:
     # A fetched entry may carry latest_error (a failed refresh attempt on an
     # otherwise-intact import) but never `error` itself.


### PR DESCRIPTION
## Summary
- Corrects reply-thread identity and persisted-facts reuse gate in `benchmark/github_import.py`
- Removes re-arming continue so digit actions execute against freshest binding (stale-view rerender spin)
- Curation render/test corrections for candidate-only signal paths
- Closes #879

## Test Plan
- [x] Full test suite run post-fix (round-2 daydream review, 4/4 findings resolved)
- [x] Deterministic-authorship gate: AUTHORS_OK (all commits Kevin Anderson)
- [ ] CI green
