### PR TITLE
feat(hydrate): corpus hydrate-hub — pinned Hub hydration with dedupe, resumable download, and publication cycle (Closes #982)

### DIFF
--- a/daydream/archive/hydrate.py
+++ b/daydream/archive/hydrate.py
@@ -65,6 +65,10 @@ class MovingBranchError(HydrationError):
     """A symbolic ref (moving branch/tag) was requested without ``exploratory=True``."""
 
 
+class PublicDestinationError(HydrationError):
+    """The target Hub repo is public — hydration publishes only to private repos (M17)."""
+
+
 def resolve_source_revision(client: HubClient, revision: str, *, exploratory: bool) -> str:
     """Resolve ``revision`` to a pinned, immutable commit SHA (issue #982 M2).
 
@@ -729,6 +733,233 @@ def build_import_ledger(stage: Path, *, revision: str, source_commit: str) -> di
     }
     _atomic_write_json(curated / "import-ledger.json", ledger)
     return ledger
+
+
+# ---------------------------------------------------------------------------
+# Publication: additive batches + remote resume ledger (Task 9)
+# ---------------------------------------------------------------------------
+
+_UPLOAD_ATTEMPTS = 6
+_UPLOAD_BASE_DELAY_S = 2.0
+_UPLOAD_MAX_DELAY_S = 120.0
+
+
+@dataclass(frozen=True)
+class ResumeState:
+    """Resume checkpoint derived from the remote Hub ledger (never VM-local state)."""
+
+    completed_sessions: set[str] = field(default_factory=set)
+    redownloaded: list[str] = field(default_factory=list)
+
+
+def _retry_upload(client: HubClient, mapping: dict[str | Path, Path], commit_message: str) -> None:
+    """Upload with the hub.py commit-conflict retry shape (exponential backoff).
+
+    More attempts than hub.py's warning-path loop, because hydration is fatal
+    on final failure. Content identity never changes across retries (M21).
+    """
+    for attempt in range(1, _UPLOAD_ATTEMPTS + 1):
+        try:
+            client.upload_files(mapping, commit_message)
+            return
+        except HydrationError as exc:
+            conflict = "concurrent update" in str(exc)
+            if conflict and attempt < _UPLOAD_ATTEMPTS:
+                time.sleep(min(_UPLOAD_BASE_DELAY_S * (2 ** (attempt - 1)), _UPLOAD_MAX_DELAY_S))
+                continue
+            raise HydrationError(redact_text(str(exc))) from exc
+
+
+def _curated_upload_paths(stage: Path, curation_id: str) -> list[Path]:
+    """All staging files under ``stage/curated/<curation-id>/`` (relative, sorted)."""
+    curated = stage / "curated" / curation_id
+    if not curated.is_dir():
+        return []
+    return sorted(p for p in curated.rglob("*") if p.is_file())
+
+
+def publish_batches(client: HubClient, stage: Path, *, curation_id: str) -> None:
+    """Publish sanitized batches additively under ``curated/<curation-id>/`` (M13/M15/M16).
+
+    Hard-fails with :class:`PublicDestinationError` when the repo is not private
+    (unlike hub.py, which only warns — hydration is an operator command and a
+    public destination would leak sanitized-but-sensitive content). Uploads,
+    additively under the curated prefix only: sanitized batches under
+    ``batches/``, the import ledger, the resolution map, ``SHA256SUMS`` over the
+    published file set, and the resume ledger ``resume/ledger.jsonl`` (one
+    record per completed batch: session_id, batch digest, source commit).
+
+    Bronze safety (M10/M13): the module asserts its own upload path list never
+    leaves the ``curated/`` prefix before a single byte is written. Upload
+    failures after retries are fatal, redacted :class:`HydrationError`s;
+    content-addressed batch paths make re-upload idempotent.
+    """
+    if not client.repo_private:
+        raise PublicDestinationError(
+            "refusing to publish: the Hub repo is not private; hydration "
+            "publishes sanitized corpora only to private repos (M17)"
+        )
+    curated = stage / "curated" / curation_id
+    _stage_batches(stage, curated)
+    _write_resolution_map(stage, curated)
+    _write_resume_ledger(stage, curated, curation_id)
+    files = _curated_upload_paths(stage, curation_id)
+    if not files:
+        raise HydrationError(redact_text(f"nothing to publish under curated/{curation_id}"))
+
+    prefix = f"curated/{curation_id}/"
+    relpaths = sorted(f.relative_to(curated).as_posix() for f in files)
+    # Bronze safety gate: assert nothing escapes the curated prefix (M10/M13).
+    assert all(not p.startswith(("bronze", "runs/", "downloads/")) and ".." not in p
+               for p in relpaths), relpaths
+
+    # SHA256SUMS covers every published file except itself (self-inclusion would
+    # make the checksum file unstable across idempotent re-publishes).
+    checksums = "".join(
+        f"{hashlib.sha256((curated / p).read_bytes()).hexdigest()}  {prefix}{p}\n"
+        for p in relpaths if p != "SHA256SUMS"
+    )
+    sums_path = curated / "SHA256SUMS"
+    sums_path.write_text(checksums, encoding="utf-8")
+    files = _curated_upload_paths(stage, curation_id)
+
+    mapping: dict[str | Path, Path] = {
+        f"{prefix}{f.relative_to(curated).as_posix()}": f for f in files
+    }
+    _retry_upload(client, mapping, f"daydream hydrate {curation_id}: additive batch publication")
+
+
+def _stage_batches(stage: Path, curated: Path) -> None:
+    """Copy every admitted derivative (``stage/runs/<sid>``) into ``batches/<sid>/``."""
+    runs_dir = stage / "runs"
+    if not runs_dir.is_dir():
+        return
+    for derivative in sorted(p for p in runs_dir.iterdir() if p.is_dir()):
+        target = curated / "batches" / derivative.name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if target.exists():
+            shutil.rmtree(target)  # content-addressed rewrite: same content, same digest
+        shutil.copytree(derivative, target)
+
+
+def _write_resolution_map(stage: Path, curated: Path) -> None:
+    """Materialize ``resolution-map.json`` under the curated prefix when absent.
+
+    Rebuilt from the staging index (data only, no clones); an existing file —
+    from a prior publish of the same curation id — is left untouched so the
+    published map stays stable and additive.
+    """
+    map_path = curated / "resolution-map.json"
+    if map_path.exists():
+        return
+    source_commit = None
+    ledger_path = curated / "import-ledger.json"
+    if ledger_path.is_file():
+        try:
+            source_commit = json.loads(ledger_path.read_text(encoding="utf-8")).get("source_commit")
+        except (OSError, ValueError):
+            source_commit = None
+    cmap = build_resolution_map(stage, source_commit=source_commit or "unknown")
+    _atomic_write_json(map_path, cmap)
+
+
+def _write_resume_ledger(stage: Path, curated: Path, curation_id: str) -> None:
+    """Write (append) one resume record per admitted batch under ``resume/ledger.jsonl``.
+
+    Content-addressed: re-publishing identical content produces byte-identical
+    records, so the ledger stays deduplicated (latest entry per session wins).
+    """
+    source_commit = None
+    ledger_path = curated / "import-ledger.json"
+    if ledger_path.is_file():
+        try:
+            source_commit = json.loads(ledger_path.read_text(encoding="utf-8")).get("source_commit")
+        except (OSError, ValueError):
+            source_commit = None
+    batches_dir = curated / "batches"
+    entries: dict[str, dict[str, Any]] = {}
+    if batches_dir.is_dir():
+        for batch in sorted(p for p in batches_dir.iterdir() if p.is_dir()):
+            entries[batch.name] = {
+                "session_id": batch.name,
+                "batch_digest": sanitize._derivative_digest(batch),
+                "source_commit": source_commit,
+                "curation_id": curation_id,
+                "at": _utc_now(),
+            }
+    resume_path = curated / "resume" / "ledger.jsonl"
+    existing: dict[str, dict[str, Any]] = {}
+    if resume_path.is_file():
+        try:
+            for line in resume_path.read_text(encoding="utf-8").splitlines():
+                if line.strip():
+                    rec = json.loads(line)
+                    if rec.get("session_id"):
+                        existing[str(rec["session_id"])] = rec
+        except (OSError, ValueError):
+            existing = {}
+    # Additive ledger: first record per session wins; re-publishing identical
+    # content never rewrites history (content-addressed idempotence).
+    for sid, entry in entries.items():
+        existing.setdefault(sid, entry)
+    resume_path.parent.mkdir(parents=True, exist_ok=True)
+    resume_path.write_text(
+        "".join(json.dumps(existing[sid], sort_keys=True) + "\n" for sid in sorted(existing)),
+        encoding="utf-8",
+    )
+
+
+def resume_state(client: HubClient, *, curation_id: str, stage_dir: Path) -> ResumeState:
+    """Discover the remote resume ledger under ``curated/<curation-id>/`` (M15).
+
+    Downloads ``resume/ledger.jsonl`` when present and verifies each recorded
+    batch digest against the actual ``batches/…`` content on the Hub, hashing
+    into ``stage_dir`` (a fresh VM's empty disk is fine). Completed sessions are
+    those whose remote batch content matches the recorded digest; mismatches
+    are reported in ``redownloaded`` — what would need re-fetching. VM-local
+    artifacts are never consulted as canonical state. A missing ledger yields
+    an empty checkpoint (nothing completed); download errors on the ledger or
+    a batch are fatal, redacted :class:`HydrationError`s.
+    """
+    prefix = f"curated/{curation_id}/"
+    try:
+        raw = client.download_file(f"{prefix}resume/ledger.jsonl")
+    except HydrationError:
+        raw = None  # no checkpoint yet: nothing completed, nothing redownloaded
+    completed: set[str] = set()
+    redownloaded: list[str] = []
+    if raw is None:
+        return ResumeState(completed_sessions=completed, redownloaded=redownloaded)
+    repo_files = set(client.list_repo_files())
+    for line in raw.decode("utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except ValueError as exc:
+            raise HydrationError(redact_text(f"corrupt resume ledger entry: {exc}")) from exc
+        sid = str(entry.get("session_id") or "")
+        digest = str(entry.get("batch_digest") or "")
+        if not sid or not digest:
+            continue
+        batch_prefix = f"{prefix}batches/{sid}/"
+        batch_relpaths = sorted(p[len(batch_prefix):] for p in repo_files if p.startswith(batch_prefix))
+        if not batch_relpaths:
+            redownloaded.append(sid)
+            continue
+        batch_dir = stage_dir / "batches" / sid
+        for rel in batch_relpaths:
+            data = client.download_file(f"{batch_prefix}{rel}")
+            target = batch_dir / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(data)
+        local_digest = sanitize._derivative_digest(batch_dir)
+        if local_digest == digest:
+            completed.add(sid)
+        else:
+            redownloaded.append(sid)
+    return ResumeState(completed_sessions=completed, redownloaded=redownloaded)
 
 
 def _import_hf_hub() -> Any:

--- a/daydream/archive/hydrate.py
+++ b/daydream/archive/hydrate.py
@@ -18,9 +18,15 @@ from __future__ import annotations
 
 import importlib.util
 import os
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
+
+from daydream.trajectory import redact_text
+
+_FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+_HEX_PREFIX_RE = re.compile(r"^[0-9a-f]{4,39}$")
 
 
 class HydrationError(Exception):
@@ -33,6 +39,63 @@ class HubUnavailableError(HydrationError):
 
 class HubDownloadError(HydrationError):
     """A requested path/revision does not exist in the Hub repo (fail-closed)."""
+
+
+class MovingBranchError(HydrationError):
+    """A symbolic ref (moving branch/tag) was requested without ``exploratory=True``."""
+
+
+def resolve_source_revision(client: HubClient, revision: str, *, exploratory: bool) -> str:
+    """Resolve ``revision`` to a pinned, immutable commit SHA (issue #982 M2).
+
+    - A full 40-hex SHA is verified to exist and returned unchanged.
+    - A hex short prefix (4-39 chars) resolves to the unique matching commit
+      SHA; an ambiguous or unknown prefix is a fail-closed :class:`HydrationError`.
+    - Any other name is a symbolic ref (moving branch/tag) and raises
+      :class:`MovingBranchError` — naming the ref and ``exploratory`` — unless
+      ``exploratory=True``, in which case it resolves to the ref's current SHA.
+      Exploratory output is flagged non-canonical downstream; canonical v1 runs
+      must pin an exact SHA.
+
+    Client errors are redacted via ``daydream.trajectory.redact_text`` before
+    being re-raised as :class:`HydrationError`, so no credential material ever
+    reaches the console or ledger.
+    """
+    revision = revision.strip().lower()
+    if _FULL_SHA_RE.fullmatch(revision):
+        try:
+            client.repo_info(revision=revision)  # verify it exists
+        except HydrationError as exc:
+            raise HydrationError(redact_text(str(exc))) from exc
+        return revision
+
+    if _HEX_PREFIX_RE.fullmatch(revision):
+        list_revisions = getattr(client, "list_revisions", None)
+        matches = (
+            [r for r in list_revisions() if r.startswith(revision)]
+            if callable(list_revisions)
+            else []
+        )
+        if len(matches) > 1:
+            raise HydrationError(
+                redact_text(f"ambiguous revision prefix {revision!r}: {len(matches)} matching commits")
+            )
+        if len(matches) == 1:
+            return str(matches[0])
+        # Not a known prefix — fall through to symbolic-ref resolution so a
+        # hex-named ref still gets the moving-branch treatment below.
+
+    try:
+        info = client.repo_info(revision=revision)
+    except HydrationError as exc:
+        raise HydrationError(redact_text(f"unknown revision {revision!r}: {exc}")) from exc
+    if not exploratory:
+        raise MovingBranchError(
+            f"ref {revision!r} is a moving branch/tag, not a pinned commit; pass "
+            "exploratory=True to accept it (output is non-canonical), or pin an "
+            "exact 40-char commit SHA"
+        )
+    return info.sha
 
 
 @dataclass(frozen=True)
@@ -141,6 +204,14 @@ class HfHubClient:
             return list(self._api.list_repo_files(self._repo_id, repo_type="dataset"))
         except Exception as exc:
             raise HubDownloadError(f"list_repo_files failed for {self._repo_id}: {exc}") from exc
+
+    def list_revisions(self) -> list[str]:
+        """Commit SHAs known to the Hub, for short-prefix resolution (best effort)."""
+        try:
+            commits = self._api.list_repo_commits(self._repo_id, repo_type="dataset")
+            return [str(c.commit_id) for c in commits]
+        except Exception as exc:  # enumeration is best-effort; fail closed on use
+            raise HubDownloadError(f"list_repo_commits failed for {self._repo_id}: {exc}") from exc
 
     def download_file(self, path_in_repo: str, revision: str | None = None) -> bytes:
         try:

--- a/daydream/archive/hydrate.py
+++ b/daydream/archive/hydrate.py
@@ -33,6 +33,7 @@ from daydream.archive.git_safe import normalize_remote_url
 from daydream.archive.hydrate_rules import (
     REASON_CODE_BUNDLE_UNREADABLE,
     REASON_CODE_IDENTITY_COLLISION,
+    REASON_CODE_PATH_TRAVERSAL,
     REASON_CODE_SANITIZE_FAILED,
     REASON_CODE_SECRETS_SCAN_DIRTY,
     REASON_CODE_UNTRUSTED_REMOTE_HOST,
@@ -90,24 +91,30 @@ def resolve_source_revision(client: HubClient, revision: str, *, exploratory: bo
     being re-raised as :class:`HydrationError`, so no credential material ever
     reaches the console or ledger.
     """
-    revision = revision.strip().lower()
-    if _FULL_SHA_RE.fullmatch(revision):
+    revision = revision.strip()
+    if _FULL_SHA_RE.fullmatch(revision.lower()):
+        # Hex validation is case-insensitive and the Hub's canonical SHAs are
+        # lowercase, so fold only inside the hex branches — a symbolic ref
+        # (branch/tag name) is resolved case-sensitively below (M2 contract:
+        # no silent case-folding of symbolic refs).
+        revision = revision.lower()
         try:
             client.repo_info(revision=revision)  # verify it exists
         except HydrationError as exc:
             raise HydrationError(redact_text(str(exc))) from exc
         return revision
 
-    if _HEX_PREFIX_RE.fullmatch(revision):
+    if _HEX_PREFIX_RE.fullmatch(revision.lower()):
+        prefix = revision.lower()
         list_revisions = getattr(client, "list_revisions", None)
         matches = (
-            [r for r in list_revisions() if r.startswith(revision)]
+            [r for r in list_revisions() if r.startswith(prefix)]
             if callable(list_revisions)
             else []
         )
         if len(matches) > 1:
             raise HydrationError(
-                redact_text(f"ambiguous revision prefix {revision!r}: {len(matches)} matching commits")
+                redact_text(f"ambiguous revision prefix {prefix!r}: {len(matches)} matching commits")
             )
         if len(matches) == 1:
             return str(matches[0])
@@ -141,7 +148,7 @@ class HubClient(Protocol):
 
     def repo_info(self, revision: str | None = None) -> RepoInfo: ...
 
-    def list_repo_files(self) -> list[str]: ...
+    def list_repo_files(self, revision: str | None = None) -> list[str]: ...
 
     def download_file(self, path_in_repo: str, revision: str | None = None) -> bytes: ...
 
@@ -186,6 +193,17 @@ def _validate_relpath(relpath: str, root: Path) -> Path:
     return target
 
 
+def _is_bare_segment(value: str) -> bool:
+    """True when ``value`` is one safe path segment (no separators, no ``..``).
+
+    Enforces the M4 trust boundary on Hub-derived session ids before they are
+    joined into a filesystem path — the same boundary :func:`_validate_relpath`
+    applies to download relpaths. An absolute, empty, ``.``/``..``, or
+    separator-bearing value can never be a bare segment.
+    """
+    return bool(value) and value not in (".", "..") and "/" not in value and "\\" not in value
+
+
 def download_snapshot(
     client: HubClient,
     *,
@@ -219,7 +237,7 @@ def download_snapshot(
         except (OSError, ValueError, KeyError, TypeError):
             records = {}  # corrupt ledger: rebuild from disk state
 
-    relpaths = list(client.list_repo_files())
+    relpaths = list(client.list_repo_files(revision=revision))
     downloaded = 0
     skipped = 0
     digests: dict[str, str] = {}
@@ -281,6 +299,20 @@ def _read_manifest_dict(bundle_dir: Path) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
+def _read_manifest_field(data: dict[str, Any], key: str) -> Any:
+    """Read a provenance field from a produced manifest, with flat fallback.
+
+    The canonical producer nests ``git.remote_url`` / ``git.source_path`` /
+    ``git.repo_slug`` under ``git.*`` (``Manifest.to_dict``); hand-built
+    (test-stage / legacy flat) manifests carry the same keys top-level. Read
+    the nested spelling first, then the flat fallback.
+    """
+    git = data.get("git")
+    if isinstance(git, dict) and key in git:
+        return git[key]
+    return data.get(key)
+
+
 @dataclass(frozen=True)
 class IngestResult:
     """Outcome of the ingest gate for one staged session bundle (issue #982 M4/M6)."""
@@ -338,7 +370,13 @@ def ingest_bundles(stage: Path, *, revision: str) -> list[IngestResult]:
             results.append(IngestResult(name, "quarantined", REASON_CODE_BUNDLE_UNREADABLE))
             continue
         session_id = str(data.get("session_id") or name)
-        raw_url = data.get("remote_url")
+        if not _is_bare_segment(session_id):
+            # M4: the manifest's session id is Hub-provided path data; reject
+            # traversal/absolute ids before any write — the sanitize gate
+            # (which mkdirs from the session id) never sees them.
+            results.append(IngestResult(session_id, "quarantined", REASON_CODE_PATH_TRAVERSAL))
+            continue
+        raw_url = _read_manifest_field(data, "remote_url")
         if isinstance(raw_url, str) and raw_url.strip():
             identity, _canonical = normalize_remote_url(raw_url)
             if identity is None:
@@ -425,8 +463,14 @@ def rebuild_index(stage: Path) -> None:
             )
         valid = {f.name for f in dataclass_fields(Manifest)}
         rewritten = {"archive_path", "source_path", "remote_url", "repo_slug"}
-        kwargs = {k: v for k, v in data.items() if k in valid and k not in rewritten}
-        raw_url = data.get("remote_url")
+        # ``daydream`` provenance is a nested dict in produced manifests; the
+        # index expects the executable-provenance object, so it is dropped from
+        # the hydrated rebuild (never coerced into a Manifest field).
+        kwargs = {
+            k: v for k, v in data.items()
+            if k in valid and k not in rewritten and k != "daydream"
+        }
+        raw_url = _read_manifest_field(data, "remote_url")
         if isinstance(raw_url, str) and raw_url.strip():
             slug, canonical = normalize_remote_url(raw_url)
             kwargs["repo_slug"] = slug
@@ -434,7 +478,7 @@ def rebuild_index(stage: Path) -> None:
         else:
             kwargs["repo_slug"] = None
             kwargs["remote_url"] = None
-        kwargs["source_path"] = _staging_local_source_path(data.get("source_path"), stage)
+        kwargs["source_path"] = _staging_local_source_path(_read_manifest_field(data, "source_path"), stage)
         kwargs["archive_path"] = str(derivative)
         upsert_run(stage, Manifest(**kwargs))
 
@@ -479,7 +523,7 @@ def build_resolution_map(stage: Path, *, source_commit: str) -> dict[str, Any]:
         session_id = str(data.get("session_id") or manifest_path.parent.name)
         if session_id in indexed:
             continue
-        raw_url = data.get("remote_url")
+        raw_url = _read_manifest_field(data, "remote_url")
         slug = normalize_remote_url(raw_url)[0] if isinstance(raw_url, str) and raw_url.strip() else None
         if slug is None and session_id not in unavailable:
             unavailable.append(session_id)
@@ -515,6 +559,17 @@ def _curated_dir(stage: Path, source_commit: str) -> Path:
     return stage / "curated" / cid
 
 
+def _dedupe_dir(stage: Path, curation_id: str) -> Path:
+    """Internal dedupe state (ledger + admitted baselines) for a curation.
+
+    Deliberately outside ``stage/curated/<curation-id>/``: the append-only
+    dedupe ledger and the admitted-baseline copies are VM-local bookkeeping and
+    are never part of the published file set (M13 publication list), so they
+    are never re-uploaded on additive runs.
+    """
+    return stage / "_dedupe" / curation_id
+
+
 def _append_dedupe_entry(path: Path, entry: dict[str, Any]) -> None:
     """Append one JSONL record to the dedupe ledger (same shape as sanitize progress)."""
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -548,6 +603,33 @@ def _move_dir(source: Path, target: Path) -> None:
     shutil.move(str(source), str(target))
 
 
+def _deep_artifact_evidence(derivative: Path, data: dict[str, Any]) -> dict[str, object] | None:
+    """Synthesize M9 revalidation evidence from a real bundle's deep artifacts.
+
+    Produced manifests never carry a top-level ``deep_artifacts`` key; the
+    evidence lives in the bundle's ``deep/*.json`` sidecars (copied from
+    ``.daydream/deep``, keyed by stem) plus the manifest's own derived
+    ``phase_states`` / ``fix_failures`` / ``archive_status`` fields. ``None``
+    when no evidence exists — the M9 gate then excludes the bundle.
+    """
+    evidence: dict[str, object] = {}
+    deep_dir = derivative / "deep"
+    if deep_dir.is_dir():
+        for path in sorted(deep_dir.glob("*.json")):
+            try:
+                evidence[path.stem] = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                continue
+    for key, value in (
+        ("fix_failures", data.get("fix_failures")),
+        ("phase_states", data.get("phase_states")),
+        ("archive_status", data.get("archive_status")),
+    ):
+        if key not in evidence and isinstance(value, (dict, str)):
+            evidence[key] = value
+    return evidence or None
+
+
 def dedupe_admitted(stage: Path, *, revision: str) -> DedupeResult:
     """Content-addressed dedupe over the admitted derivatives (issue #982 M7/M8/M9).
 
@@ -576,9 +658,13 @@ def dedupe_admitted(stage: Path, *, revision: str) -> DedupeResult:
     """
     revision = str(revision)
     curated = _curated_dir(stage, revision)
-    ledger_path = curated / "dedupe.jsonl"
-    baseline_root = curated / "admitted"
-    recorded = _load_dedupe_ledger(ledger_path)
+    dedupe_dir = _dedupe_dir(stage, curated.name)
+    ledger_path = dedupe_dir / "dedupe.jsonl"
+    baseline_root = dedupe_dir / "admitted"
+    # The latest *admitted* digest is the durable collision key: a later
+    # collision entry must not let a re-run re-admit the mutated derivative
+    # over the published baseline (M7 durability across re-runs).
+    admitted_digests = _latest_admitted_digests(ledger_path)
     result = DedupeResult()
     runs_dir = stage / "runs"
     if runs_dir.is_dir():
@@ -590,6 +676,12 @@ def dedupe_admitted(stage: Path, *, revision: str) -> DedupeResult:
                     redact_text(f"admitted derivative {name} has an unreadable manifest")
                 )
             sid = str(data.get("session_id") or name)
+            if not _is_bare_segment(sid):
+                # M4: the manifest's session id must never be joined into a
+                # staging path (excluded/, quarantine/, baseline restore).
+                raise HydrationError(
+                    redact_text(f"admitted derivative {name} has an unsafe session id {sid!r}")
+                )
 
             # M8: fixture exclusion, pre-dedupe, stable codes.
             try:
@@ -597,10 +689,12 @@ def dedupe_admitted(stage: Path, *, revision: str) -> DedupeResult:
             except (OSError, ValueError):
                 codes = [REASON_CODE_BUNDLE_UNREADABLE]
             if not codes and "pipeline_status" in data:
-                # M9: revalidate the legacy field; evidence-absent never succeeds.
+                # M9: revalidate the legacy field against the bundle's real
+                # evidence; evidence-absent never succeeds (produced manifests
+                # never carry a top-level ``deep_artifacts`` key).
                 verdict = hydrate_rules.legacy_pipeline_status(
                     data.get("pipeline_status"),
-                    data.get("deep_artifacts") if isinstance(data.get("deep_artifacts"), dict) else None,
+                    _deep_artifact_evidence(derivative, data),
                 )
                 if isinstance(verdict, tuple):
                     codes = [verdict[1]]
@@ -616,9 +710,7 @@ def dedupe_admitted(stage: Path, *, revision: str) -> DedupeResult:
                 continue
 
             digest = sanitize._derivative_digest(derivative)
-            prev = recorded.get(sid)
-            if prev is not None and prev.get("status") == "admitted" \
-                    and prev.get("content_digest") not in (None, digest):
+            if admitted_digests.get(sid) not in (None, digest):
                 # Identity collision: quarantine the new derivative, restore the
                 # original admitted content — never overwrite (M7).
                 baseline = baseline_root / sid
@@ -691,8 +783,9 @@ def build_import_ledger(stage: Path, *, revision: str, source_commit: str) -> di
     revision = str(revision)
     source_commit = str(source_commit)
     curated = _curated_dir(stage, source_commit)
-    recorded = _load_dedupe_ledger(curated / "dedupe.jsonl")
-    admitted_digests = _latest_admitted_digests(curated / "dedupe.jsonl")
+    dedupe_ledger = _dedupe_dir(stage, curated.name) / "dedupe.jsonl"
+    recorded = _load_dedupe_ledger(dedupe_ledger)
+    admitted_digests = _latest_admitted_digests(dedupe_ledger)
 
     ingest_results: list[dict[str, Any]] = []
     ingest_path = stage / "downloads" / revision / "_ingest_results.json"
@@ -709,6 +802,14 @@ def build_import_ledger(stage: Path, *, revision: str, source_commit: str) -> di
     admitted_ids = {
         str(e["session_id"]) for e in ingest_results if e.get("status") == "admitted"
     } | indexed_ids
+    # Sessions whose latest dedupe decision is a rejection (identity collision
+    # / fixture exclusion) are recorded once, under that status: the manifest
+    # must never list them as admitted again (M7/frozen schema).
+    rejected_latest = {
+        sid for sid, entry in recorded.items()
+        if entry.get("status") in ("collision", "excluded")
+    }
+    admitted_ids -= rejected_latest
 
     imported: list[dict[str, Any]] = []
     for sid in sorted(admitted_ids):
@@ -991,10 +1092,12 @@ def resume_state(client: HubClient, *, curation_id: str, stage_dir: Path) -> Res
         if not batch_relpaths:
             redownloaded.append(sid)
             continue
+        if not _is_bare_segment(sid):
+            raise StageError(redact_text(f"refusing resume session id {sid!r}: traversal"))
         batch_dir = stage_dir / "batches" / sid
         for rel in batch_relpaths:
             data = client.download_file(f"{batch_prefix}{rel}")
-            target = batch_dir / rel
+            target = _validate_relpath(rel, batch_dir)
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_bytes(data)
         local_digest = sanitize._derivative_digest(batch_dir)
@@ -1075,14 +1178,14 @@ class HfHubClient:
 
     def repo_info(self, revision: str | None = None) -> RepoInfo:
         try:
-            info = self._api.repo_info(revision or "main", repo_type="dataset")
+            info = self._api.repo_info(self._repo_id, revision=revision, repo_type="dataset")
         except Exception as exc:  # mapped, never swallowed
             raise HubDownloadError(f"repo_info failed for {self._repo_id}: {exc}") from exc
         return RepoInfo(sha=str(info.sha), private=bool(info.private))
 
-    def list_repo_files(self) -> list[str]:
+    def list_repo_files(self, revision: str | None = None) -> list[str]:
         try:
-            return list(self._api.list_repo_files(self._repo_id, repo_type="dataset"))
+            return list(self._api.list_repo_files(self._repo_id, revision=revision, repo_type="dataset"))
         except Exception as exc:
             raise HubDownloadError(f"list_repo_files failed for {self._repo_id}: {exc}") from exc
 
@@ -1169,14 +1272,25 @@ def _curation_manifest_doc(
         code = rejection.get("reason_code")
         status = "excluded" if code in hydrate_rules.EXCLUSION_CODES else "quarantined"
         root = "excluded" if status == "excluded" else "quarantine"
+        # Rejected bundles are never published, so the relpath names the actual
+        # staging tree (portable/relative): dedupe moves identity collisions to
+        # ``quarantine/<sid>.conflict``, everything else to ``<root>/<sid>``.
+        # A non-bare session id is a traversal attempt — reference a derived
+        # hash segment instead of the raw value and never touch the filesystem.
+        segment = sid if _is_bare_segment(sid) else hashlib.sha256(sid.encode()).hexdigest()
+        collision = code == hydrate_rules.REASON_CODE_IDENTITY_COLLISION
+        relpath = f"{root}/{segment}.conflict" if collision else f"{root}/{segment}"
         digest = rejection.get("content_digest")
         if not isinstance(digest, str) or not digest:
             # Rejected bundles carry no derivative digest; derive one from the
             # rejected copy on staging (or the session id when it was moved).
-            source_dir = stage / root / sid
-            if not source_dir.is_dir():
-                source_dir = stage / "downloads" / str(ledger["pinned_revision"]) / "bundles" / sid
-            digest = sanitize._derivative_digest(source_dir) if source_dir.is_dir() \
+            candidates: list[Path] = []
+            if collision:
+                candidates.append(stage / "quarantine" / f"{segment}.conflict")
+            candidates.append(stage / root / segment)
+            candidates.append(stage / "downloads" / str(ledger["pinned_revision"]) / "bundles" / segment)
+            source_dir = next((c for c in candidates if c.is_dir()), None)
+            digest = sanitize._derivative_digest(source_dir) if source_dir is not None \
                 else hashlib.sha256(sid.encode()).hexdigest()
         batches.append(
             {
@@ -1184,7 +1298,7 @@ def _curation_manifest_doc(
                 "content_digest": str(digest),
                 "status": status,
                 "reason_code": code,
-                "artifact_relpath": f"{root}/{sid}",
+                "artifact_relpath": relpath,
                 "manifest_relpath": None,
             }
         )
@@ -1201,12 +1315,15 @@ def _curation_manifest_doc(
 
 
 def finalize(client: HubClient, stage: Path, *, curation_id: str, source_commit: str) -> str:
-    """Publish the curation manifest, then ``_SUCCESS`` as the terminal commit (M18).
+    """Publish the curation manifest and refreshed checksums (M18).
 
     The manifest is rendered from the real persisted import ledger and uploaded
-    first; ``curated/<curation-id>/_SUCCESS`` is uploaded as the very last
-    commit — nothing is ever uploaded after it. Returns the output commit SHA
-    (the Hub head after the ``_SUCCESS`` commit), which the verify cycle pins.
+    with ``SHA256SUMS`` over the final published file set. The ``_SUCCESS``
+    marker is deliberately NOT uploaded here: it is published only after the
+    clean-room verification cycle passes (verify-before-success), so a
+    verification failure can never leave a published "complete" marker.
+    Returns the output commit SHA (the Hub head after the manifest commit),
+    which the verify cycle pins.
     """
     curated = stage / "curated" / curation_id
     ledger_path = curated / "import-ledger.json"
@@ -1220,10 +1337,14 @@ def finalize(client: HubClient, stage: Path, *, curation_id: str, source_commit:
     # SHA256SUMS must cover the *final* published file set — including the
     # curation manifest rendered just above, which can change between runs
     # (e.g. a newly recorded identity collision). Refresh it here so the
-    # checksums always match the bytes the verify cycle will pin.
-    final_relpaths = sorted(
-        p.relative_to(curated).as_posix() for p in curated.rglob("*") if p.is_file()
-    )
+    # checksums always match the bytes the verify cycle will pin. ``_SUCCESS``
+    # is never covered: the marker does not exist at the verify commit (it is
+    # published only after verification), and a stale local marker must never
+    # leak into the pinned checksums on a re-run.
+    final_relpaths = [
+        p.relative_to(curated).as_posix()
+        for p in curated.rglob("*") if p.is_file() and p.name != "_SUCCESS"
+    ]
     checksums = "".join(
         f"{hashlib.sha256((curated / p).read_bytes()).hexdigest()}  {prefix}{p}\n"
         for p in final_relpaths if p != "SHA256SUMS"
@@ -1237,6 +1358,21 @@ def finalize(client: HubClient, stage: Path, *, curation_id: str, source_commit:
         },
         f"daydream hydrate {curation_id}: curation manifest + checksums",
     )
+    return str(client.repo_info().sha)
+
+
+def _publish_success_marker(
+    client: HubClient, stage: Path, *, curation_id: str, source_commit: str
+) -> None:
+    """Publish ``curated/<curation-id>/_SUCCESS`` as the terminal commit (M18).
+
+    Called only after :func:`verify_publication` passes — every failure path
+    leaves it unpublished, so a published ``_SUCCESS`` always means the
+    clean-room cycle verified the output commit. Returns nothing; the caller
+    re-reads the hub head as the final output commit SHA.
+    """
+    curated = stage / "curated" / curation_id
+    prefix = f"curated/{curation_id}/"
     success_path = curated / "_SUCCESS"
     success_path.write_text(
         json.dumps({"curation_id": curation_id, "source_hub_commit": str(source_commit), "status": "complete"}) + "\n",
@@ -1244,7 +1380,6 @@ def finalize(client: HubClient, stage: Path, *, curation_id: str, source_commit:
     )
     _retry_upload(client, {f"{prefix}_SUCCESS": success_path},
                   f"daydream hydrate {curation_id}: success marker")
-    return str(client.repo_info().sha)
 
 
 def verify_publication(
@@ -1304,7 +1439,9 @@ def verify_publication(
         raise VerificationError(redact_text(f"verify: curation manifest invalid: {errors[0].message}"))
     if doc["curation_id"] != curation_id or doc["source_hub_commit"] != str(source_commit):
         raise VerificationError(redact_text("verify: curation manifest identity mismatch"))
-    _download("_SUCCESS")  # the marker must be present at the pinned output commit
+    # The _SUCCESS marker is *not* expected at this commit: it is published by
+    # run_hydrate_hub only after this cycle passes (verify-before-success), so
+    # a failed verification can never leave a published "complete" marker.
 
     # 3. Rescan every published batch (clean-room) and rebuild the scratch index.
     valid = {f.name for f in dataclass_fields(Manifest)}
@@ -1331,9 +1468,9 @@ def verify_publication(
         data = _read_manifest_dict(batch_dir)
         if data is None:
             raise VerificationError(redact_text(f"verify: batch {sid!r} has an unreadable manifest"))
-        kwargs = {k: v for k, v in data.items() if k in valid}
+        kwargs = {k: v for k, v in data.items() if k in valid and k != "daydream"}
         kwargs["archive_path"] = str(batch_dir)
-        raw_url = data.get("remote_url")
+        raw_url = _read_manifest_field(data, "remote_url")
         if isinstance(raw_url, str) and raw_url.strip():
             slug, canonical = normalize_remote_url(raw_url)
             kwargs["repo_slug"], kwargs["remote_url"] = slug, canonical
@@ -1358,31 +1495,44 @@ def run_hydrate_hub(config: HydrateHubConfig, client: HubClient | None = None) -
     """Orchestrate hydration end-to-end: pin, download, ingest, dedupe, publish, verify.
 
     Composes Tasks 4–9 in order with fatal, redacted failure semantics: resolve
-    the pinned source revision, download the snapshot, run the ingest gate,
-    dedupe + ledger, publish additive batches (continuous checkpoints, M16),
-    finalize (manifest then ``_SUCCESS`` last, M18), and only then run the
-    clean-room verification cycle (M19/M20). ``client=None`` builds the
-    production :class:`HfHubClient` via :func:`_make_client`. The summary's
-    ``verified`` flag is set only after verification passes; every failure
-    path leaves it False and never uploads a success marker.
+    the pinned source revision from the source repo, download the snapshot,
+    run the ingest gate, dedupe + ledger, publish additive batches (continuous
+    checkpoints, M16), finalize (curation manifest + refreshed checksums, M18),
+    run the clean-room verification cycle against that pinned commit (M19/M20),
+    and only after it passes publish the ``_SUCCESS`` marker as the very last
+    commit — a verification failure never leaves a published success marker.
+    ``client=None`` builds two production :class:`HfHubClient` instances via
+    :func:`_make_client` (one for the source snapshot repo, one for the
+    destination publication repo). The summary's ``verified`` flag is set only
+    after verification passes; every failure path leaves it False and never
+    uploads a success marker.
     """
-    client = client if client is not None else _make_client(config.destination_repo)
-    if not client.repo_private:
+    # Two clients: the source repo guards the pinned snapshot, the destination
+    # repo receives the published output. Tests inject one FakeHub for both.
+    source_client = client if client is not None else _make_client(config.source_repo)
+    dest_client = client if client is not None else _make_client(config.destination_repo)
+    if not dest_client.repo_private:
         raise PublicDestinationError(
             "refusing to publish: the Hub repo is not private; hydration "
             "publishes sanitized corpora only to private repos (M17)"
         )
-    source_commit = resolve_source_revision(client, config.source_revision, exploratory=config.exploratory)
-    download_snapshot(client, revision=source_commit, stage_dir=config.stage_dir / "downloads")
+    source_commit = resolve_source_revision(
+        source_client, config.source_revision, exploratory=config.exploratory
+    )
+    download_snapshot(source_client, revision=source_commit, stage_dir=config.stage_dir / "downloads")
     ingest_bundles(config.stage_dir, revision=source_commit)
     dedupe_admitted(config.stage_dir, revision=source_commit)
     ledger = build_import_ledger(config.stage_dir, revision=source_commit, source_commit=source_commit)
     curation_id = str(ledger["curation_id"])
-    checkpoint = resume_state(client, curation_id=curation_id, stage_dir=config.stage_dir / "_resume")
+    checkpoint = resume_state(dest_client, curation_id=curation_id, stage_dir=config.stage_dir / "_resume")
     publish_batches(
-        client, config.stage_dir, curation_id=curation_id, skip_sessions=checkpoint.completed_sessions
+        dest_client, config.stage_dir, curation_id=curation_id, skip_sessions=checkpoint.completed_sessions
     )
-    output_commit_sha = finalize(client, config.stage_dir, curation_id=curation_id, source_commit=source_commit)
+    # finalize pins the verify commit (manifest + checksums); _SUCCESS is
+    # uploaded only after the clean-room cycle passes (M18/M20).
+    output_commit_sha = finalize(
+        dest_client, config.stage_dir, curation_id=curation_id, source_commit=source_commit
+    )
     summary = HydrateSummary(
         source_commit=source_commit,
         curation_id=curation_id,
@@ -1390,12 +1540,16 @@ def run_hydrate_hub(config: HydrateHubConfig, client: HubClient | None = None) -
         dry_run_admitted=int(ledger["tallies"]["imported"]),
     )
     summary.verify_admitted = verify_publication(
-        client,
+        dest_client,
         config.stage_dir,
         output_commit_sha=output_commit_sha,
         curation_id=curation_id,
         dry_run_admitted=summary.dry_run_admitted,
         source_commit=source_commit,
     )
+    _publish_success_marker(
+        dest_client, config.stage_dir, curation_id=curation_id, source_commit=source_commit
+    )
+    summary.output_commit_sha = str(dest_client.repo_info().sha)  # head after the _SUCCESS commit
     summary.verified = True  # only after the full clean-room cycle passes (M20)
     return summary

--- a/daydream/archive/hydrate.py
+++ b/daydream/archive/hydrate.py
@@ -39,6 +39,7 @@ from daydream.archive.hydrate_rules import (
 )
 from daydream.archive.index import upsert_run
 from daydream.archive.manifest import Manifest
+from daydream.archive.scan import scan_run_dir
 from daydream.trajectory import redact_text
 
 _FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
@@ -67,6 +68,10 @@ class MovingBranchError(HydrationError):
 
 class PublicDestinationError(HydrationError):
     """The target Hub repo is public — hydration publishes only to private repos (M17)."""
+
+
+class VerificationError(HydrationError):
+    """The clean-room verification cycle failed — success is never reported (M20)."""
 
 
 def resolve_source_revision(client: HubClient, revision: str, *, exploratory: bool) -> str:
@@ -778,7 +783,9 @@ def _curated_upload_paths(stage: Path, curation_id: str) -> list[Path]:
     return sorted(p for p in curated.rglob("*") if p.is_file())
 
 
-def publish_batches(client: HubClient, stage: Path, *, curation_id: str) -> None:
+def publish_batches(
+    client: HubClient, stage: Path, *, curation_id: str, skip_sessions: set[str] | None = None
+) -> None:
     """Publish sanitized batches additively under ``curated/<curation-id>/`` (M13/M15/M16).
 
     Hard-fails with :class:`PublicDestinationError` when the repo is not private
@@ -788,6 +795,11 @@ def publish_batches(client: HubClient, stage: Path, *, curation_id: str) -> None
     ``batches/``, the import ledger, the resolution map, ``SHA256SUMS`` over the
     published file set, and the resume ledger ``resume/ledger.jsonl`` (one
     record per completed batch: session_id, batch digest, source commit).
+
+    Additive publication is resumable (M15/M16): ``skip_sessions`` — completed
+    session ids from the remote resume ledger — are omitted from the upload
+    mapping (they already exist at their content-addressed paths from prior
+    commits) while still contributing to SHA256SUMS and the resume ledger.
 
     Bronze safety (M10/M13): the module asserts its own upload path list never
     leaves the ``curated/`` prefix before a single byte is written. Upload
@@ -824,9 +836,15 @@ def publish_batches(client: HubClient, stage: Path, *, curation_id: str) -> None
     files = _curated_upload_paths(stage, curation_id)
 
     mapping: dict[str | Path, Path] = {
-        f"{prefix}{f.relative_to(curated).as_posix()}": f for f in files
+        f"{prefix}{f.relative_to(curated).as_posix()}": f
+        for f in files
+        if not any(
+            f.relative_to(curated).as_posix().startswith(f"batches/{sid}/")
+            for sid in skip_sessions or ()
+        )
     }
-    _retry_upload(client, mapping, f"daydream hydrate {curation_id}: additive batch publication")
+    if mapping:
+        _retry_upload(client, mapping, f"daydream hydrate {curation_id}: additive batch publication")
 
 
 def _stage_batches(stage: Path, curated: Path) -> None:
@@ -1074,3 +1092,267 @@ class HfHubClient:
                 )
         except Exception as exc:
             raise HydrationError(f"upload failed for {self._repo_id}: {exc}") from exc
+
+
+# ---------------------------------------------------------------------------
+# Finalization + verify-before-success cycle (Task 10, M18/M19/M20)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class HydrateHubConfig:
+    """Operator configuration for ``run_hydrate_hub`` (harvest ``RunConfig`` discipline)."""
+
+    source_repo: str
+    source_revision: str
+    destination_repo: str
+    stage_dir: Path
+    exploratory: bool = False
+
+
+@dataclass
+class HydrateSummary:
+    """Outcome of one ``run_hydrate_hub`` invocation; ``verified`` gates success."""
+
+    source_commit: str
+    curation_id: str
+    output_commit_sha: str | None = None
+    dry_run_admitted: int = 0
+    verify_admitted: int = 0
+    verified: bool = False
+
+
+def _curation_manifest_doc(
+    stage: Path, *, curation_id: str, source_commit: str, ledger: dict[str, Any]
+) -> dict[str, Any]:
+    """Render the portable curation manifest (schema v1) from the real ledger (M12/M18)."""
+    batches: list[dict[str, Any]] = []
+    for entry in ledger.get("imported", []):
+        sid = str(entry["session_id"])
+        batches.append(
+            {
+                "session_id": sid,
+                "content_digest": str(entry.get("content_digest") or ""),
+                "status": "admitted",
+                "reason_code": None,
+                "artifact_relpath": f"batches/{sid}",
+                "manifest_relpath": f"batches/{sid}/manifest.json",
+            }
+        )
+    for rejection in ledger.get("rejections", []):
+        sid = str(rejection["session_id"])
+        code = rejection.get("reason_code")
+        status = "excluded" if code in hydrate_rules.EXCLUSION_CODES else "quarantined"
+        root = "excluded" if status == "excluded" else "quarantine"
+        digest = rejection.get("content_digest")
+        if not isinstance(digest, str) or not digest:
+            # Rejected bundles carry no derivative digest; derive one from the
+            # rejected copy on staging (or the session id when it was moved).
+            source_dir = stage / root / sid
+            if not source_dir.is_dir():
+                source_dir = stage / "downloads" / str(ledger["pinned_revision"]) / "bundles" / sid
+            digest = sanitize._derivative_digest(source_dir) if source_dir.is_dir() \
+                else hashlib.sha256(sid.encode()).hexdigest()
+        batches.append(
+            {
+                "session_id": sid,
+                "content_digest": str(digest),
+                "status": status,
+                "reason_code": code,
+                "artifact_relpath": f"{root}/{sid}",
+                "manifest_relpath": None,
+            }
+        )
+    return {
+        "schema_version": hydrate_rules.HYDRATION_INDEX_SCHEMA_VERSION,
+        "source_hub_commit": str(source_commit),
+        "curation_id": curation_id,
+        "sanitizer_version": hydrate_rules.SANITIZER_VERSION,
+        "hydration_index_schema_version": hydrate_rules.HYDRATION_INDEX_SCHEMA_VERSION,
+        "admission_policy_version": hydrate_rules.ADMISSION_POLICY_VERSION,
+        "publication_prefix": f"curated/{curation_id}/",
+        "batches": batches,
+    }
+
+
+def finalize(client: HubClient, stage: Path, *, curation_id: str, source_commit: str) -> str:
+    """Publish the curation manifest, then ``_SUCCESS`` as the terminal commit (M18).
+
+    The manifest is rendered from the real persisted import ledger and uploaded
+    first; ``curated/<curation-id>/_SUCCESS`` is uploaded as the very last
+    commit — nothing is ever uploaded after it. Returns the output commit SHA
+    (the Hub head after the ``_SUCCESS`` commit), which the verify cycle pins.
+    """
+    curated = stage / "curated" / curation_id
+    ledger_path = curated / "import-ledger.json"
+    if not ledger_path.is_file():
+        raise HydrationError(redact_text(f"no import ledger under curated/{curation_id}; cannot finalize"))
+    ledger = json.loads(ledger_path.read_text(encoding="utf-8"))
+    doc = _curation_manifest_doc(stage, curation_id=curation_id, source_commit=source_commit, ledger=ledger)
+    manifest_path = curated / "curation-manifest.json"
+    _atomic_write_json(manifest_path, doc)
+    prefix = f"curated/{curation_id}/"
+    _retry_upload(client, {f"{prefix}curation-manifest.json": manifest_path},
+                  f"daydream hydrate {curation_id}: curation manifest")
+    success_path = curated / "_SUCCESS"
+    success_path.write_text(
+        json.dumps({"curation_id": curation_id, "source_hub_commit": str(source_commit), "status": "complete"}) + "\n",
+        encoding="utf-8",
+    )
+    _retry_upload(client, {f"{prefix}_SUCCESS": success_path},
+                  f"daydream hydrate {curation_id}: success marker")
+    return str(client.repo_info().sha)
+
+
+def verify_publication(
+    client: HubClient,
+    stage: Path,
+    *,
+    output_commit_sha: str,
+    curation_id: str,
+    dry_run_admitted: int,
+    source_commit: str,
+) -> int:
+    """Clean-room verification of the published output commit (M19/M20).
+
+    Downloads exactly the pinned output commit into a fresh staging dir,
+    validates SHA256SUMS against the uploaded content, validates the curation
+    manifest against the frozen schema, rescan every published batch with
+    ``scan_run_dir`` (must be clean), rebuilds a scratch index from the
+    portable artifacts alone, and recomputes the candidate count. Any mismatch
+    raises :class:`VerificationError` — success is never reported on a failed
+    verification. Returns the verified admitted count.
+    """
+    prefix = f"curated/{curation_id}/"
+    verify_dir = stage / "_verify"
+    if verify_dir.exists():
+        shutil.rmtree(verify_dir)
+    verify_dir.mkdir(parents=True)
+
+    def _download(relpath: str) -> bytes:
+        try:
+            return client.download_file(f"{prefix}{relpath}", revision=output_commit_sha)
+        except HydrationError as exc:
+            raise VerificationError(redact_text(f"verify: published file {relpath!r} missing: {exc}")) from exc
+
+    # 1. SHA256SUMS must match every published file byte-for-byte.
+    try:
+        sums_text = _download("SHA256SUMS").decode("utf-8")
+    except VerificationError:
+        raise
+    except HydrationError as exc:
+        raise VerificationError(redact_text(f"verify: SHA256SUMS missing: {exc}")) from exc
+    for line in sums_text.splitlines():
+        if not line.strip():
+            continue
+        digest, _, relpath = line.partition("  ")
+        relpath = relpath.removeprefix(prefix)
+        actual = hashlib.sha256(_download(relpath)).hexdigest()
+        if actual != digest:
+            raise VerificationError(redact_text(f"verify: checksum mismatch for {relpath!r}"))
+
+    # 2. Curation manifest: schema-valid and consistent with the pinned inputs.
+    from jsonschema import Draft202012Validator  # noqa: PLC0415  # lazy: verify-time only
+
+    schema_path = Path(__file__).parent.parent / "training" / "schema" / "curation-manifest-v1.json"
+    doc = json.loads(_download("curation-manifest.json").decode("utf-8"))
+    errors = sorted(Draft202012Validator(json.loads(schema_path.read_text())).iter_errors(doc), key=str)
+    if errors:
+        raise VerificationError(redact_text(f"verify: curation manifest invalid: {errors[0].message}"))
+    if doc["curation_id"] != curation_id or doc["source_hub_commit"] != str(source_commit):
+        raise VerificationError(redact_text("verify: curation manifest identity mismatch"))
+    _download("_SUCCESS")  # the marker must be present at the pinned output commit
+
+    # 3. Rescan every published batch (clean-room) and rebuild the scratch index.
+    valid = {f.name for f in dataclass_fields(Manifest)}
+    for batch in doc["batches"]:
+        if batch["status"] != "admitted":
+            continue
+        sid = batch["session_id"]
+        batch_dir = verify_dir / "batches" / sid
+        for line in sums_text.splitlines():
+            if not line.strip():
+                continue
+            _, _, relpath = line.partition("  ")
+            relpath = relpath.removeprefix(prefix)
+            if not relpath.startswith(f"batches/{sid}/"):
+                continue
+            target = batch_dir / relpath.removeprefix(f"batches/{sid}/")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(_download(relpath))
+        scan = scan_run_dir(batch_dir)
+        if not scan.clean:
+            raise VerificationError(redact_text(f"verify: published batch {sid!r} fails the secrets scan"))
+        if sanitize._derivative_digest(batch_dir) != batch["content_digest"]:
+            raise VerificationError(redact_text(f"verify: batch {sid!r} digest mismatch"))
+        data = _read_manifest_dict(batch_dir)
+        if data is None:
+            raise VerificationError(redact_text(f"verify: batch {sid!r} has an unreadable manifest"))
+        kwargs = {k: v for k, v in data.items() if k in valid}
+        kwargs["archive_path"] = str(batch_dir)
+        raw_url = data.get("remote_url")
+        if isinstance(raw_url, str) and raw_url.strip():
+            slug, canonical = normalize_remote_url(raw_url)
+            kwargs["repo_slug"], kwargs["remote_url"] = slug, canonical
+        else:
+            kwargs["repo_slug"], kwargs["remote_url"] = None, None
+        upsert_run(verify_dir, Manifest(**kwargs))
+
+    from daydream.archive.index import query_runs  # noqa: PLC0415  # local: avoid import cycle
+
+    verify_admitted = len(query_runs(verify_dir))
+    if verify_admitted != dry_run_admitted:
+        raise VerificationError(
+            redact_text(
+                f"verify: candidate count mismatch — dry run admitted {dry_run_admitted}, "
+                f"clean-room rebuild found {verify_admitted}"
+            )
+        )
+    return verify_admitted
+
+
+def run_hydrate_hub(config: HydrateHubConfig, client: HubClient | None = None) -> HydrateSummary:
+    """Orchestrate hydration end-to-end: pin, download, ingest, dedupe, publish, verify.
+
+    Composes Tasks 4–9 in order with fatal, redacted failure semantics: resolve
+    the pinned source revision, download the snapshot, run the ingest gate,
+    dedupe + ledger, publish additive batches (continuous checkpoints, M16),
+    finalize (manifest then ``_SUCCESS`` last, M18), and only then run the
+    clean-room verification cycle (M19/M20). ``client=None`` builds the
+    production :class:`HfHubClient` via :func:`_make_client`. The summary's
+    ``verified`` flag is set only after verification passes; every failure
+    path leaves it False and never uploads a success marker.
+    """
+    client = client if client is not None else _make_client(config.destination_repo)
+    if not client.repo_private:
+        raise PublicDestinationError(
+            "refusing to publish: the Hub repo is not private; hydration "
+            "publishes sanitized corpora only to private repos (M17)"
+        )
+    source_commit = resolve_source_revision(client, config.source_revision, exploratory=config.exploratory)
+    download_snapshot(client, revision=source_commit, stage_dir=config.stage_dir / "downloads")
+    ingest_bundles(config.stage_dir, revision=source_commit)
+    dedupe_admitted(config.stage_dir, revision=source_commit)
+    ledger = build_import_ledger(config.stage_dir, revision=source_commit, source_commit=source_commit)
+    curation_id = str(ledger["curation_id"])
+    checkpoint = resume_state(client, curation_id=curation_id, stage_dir=config.stage_dir / "_resume")
+    publish_batches(
+        client, config.stage_dir, curation_id=curation_id, skip_sessions=checkpoint.completed_sessions
+    )
+    output_commit_sha = finalize(client, config.stage_dir, curation_id=curation_id, source_commit=source_commit)
+    summary = HydrateSummary(
+        source_commit=source_commit,
+        curation_id=curation_id,
+        output_commit_sha=output_commit_sha,
+        dry_run_admitted=int(ledger["tallies"]["imported"]),
+    )
+    summary.verify_admitted = verify_publication(
+        client,
+        config.stage_dir,
+        output_commit_sha=output_commit_sha,
+        curation_id=curation_id,
+        dry_run_admitted=summary.dry_run_admitted,
+        source_commit=source_commit,
+    )
+    summary.verified = True  # only after the full clean-room cycle passes (M20)
+    return summary

--- a/daydream/archive/hydrate.py
+++ b/daydream/archive/hydrate.py
@@ -28,10 +28,11 @@ from dataclasses import fields as dataclass_fields
 from pathlib import Path, PurePosixPath
 from typing import Any, Protocol, runtime_checkable
 
-from daydream.archive import sanitize
+from daydream.archive import hydrate_rules, sanitize
 from daydream.archive.git_safe import normalize_remote_url
 from daydream.archive.hydrate_rules import (
     REASON_CODE_BUNDLE_UNREADABLE,
+    REASON_CODE_IDENTITY_COLLISION,
     REASON_CODE_SANITIZE_FAILED,
     REASON_CODE_SECRETS_SCAN_DIRTY,
     REASON_CODE_UNTRUSTED_REMOTE_HOST,
@@ -280,6 +281,22 @@ class IngestResult:
     reason_code: str | None = None
 
 
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write ``payload`` to ``path`` atomically (temp file + rename); fatal on failure."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".tmp")
+    try:
+        tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        tmp.replace(path)
+    except OSError:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def _utc_now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
 def ingest_bundles(stage: Path, *, revision: str) -> list[IngestResult]:
     """Run every staged bundle through the #981 ingest gate (issue #982 M4/M6).
 
@@ -346,6 +363,16 @@ def ingest_bundles(stage: Path, *, revision: str) -> list[IngestResult]:
         target.parent.mkdir(parents=True, exist_ok=True)
         shutil.move(str(derivative), str(target))  # staging layout only, not the gate
         results.append(IngestResult(session_id, "admitted"))
+    _atomic_write_json(
+        bundles_root.parent / "_ingest_results.json",
+        {
+            "revision": str(revision),
+            "results": [
+                {"session_id": r.session_id, "status": r.status, "reason_code": r.reason_code}
+                for r in results
+            ],
+        },
+    )
     return results
 
 
@@ -450,6 +477,258 @@ def build_resolution_map(stage: Path, *, source_commit: str) -> dict[str, Any]:
     if unavailable:
         cmap["unavailable"] = sorted(unavailable)
     return cmap
+
+
+# ---------------------------------------------------------------------------
+# Content-addressed dedupe + collision quarantine + import ledger (Task 8)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DedupeResult:
+    """Outcome of one :func:`dedupe_admitted` pass over ``stage/runs/`` (M7/M8/M9)."""
+
+    admitted: int = 0
+    skipped: int = 0
+    collisions: int = 0
+    collision_ids: list[str] = field(default_factory=list)
+    excluded: list[tuple[str, str]] = field(default_factory=list)  # (session_id, reason_code)
+
+
+def _curated_dir(stage: Path, source_commit: str) -> Path:
+    """Curated prefix for a source commit: ``stage/curated/<curation-id>/``."""
+    cid = hydrate_rules.derive_curation_id(
+        source_commit,
+        hydrate_rules.SANITIZER_VERSION,
+        hydrate_rules.HYDRATION_INDEX_SCHEMA_VERSION,
+        hydrate_rules.ADMISSION_POLICY_VERSION,
+    )
+    return stage / "curated" / cid
+
+
+def _append_dedupe_entry(path: Path, entry: dict[str, Any]) -> None:
+    """Append one JSONL record to the dedupe ledger (same shape as sanitize progress)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry) + "\n")
+
+
+def _load_dedupe_ledger(path: Path) -> dict[str, dict[str, Any]]:
+    """Latest recorded dedupe entry per session id (empty when absent/corrupt)."""
+    latest: dict[str, dict[str, Any]] = {}
+    if not path.is_file():
+        return latest
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            entry = json.loads(line)
+            if isinstance(entry, dict) and entry.get("session_id"):
+                latest[str(entry["session_id"])] = entry
+    except (OSError, ValueError):
+        return latest
+    return latest
+
+
+def _move_dir(source: Path, target: Path) -> None:
+    """Move a directory, replacing any prior occupant of ``target``."""
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        shutil.rmtree(target)
+    shutil.move(str(source), str(target))
+
+
+def dedupe_admitted(stage: Path, *, revision: str) -> DedupeResult:
+    """Content-addressed dedupe over the admitted derivatives (issue #982 M7/M8/M9).
+
+    The dedupe key is ``(session_id, derivative content digest)`` where the
+    digest is ``sanitize._derivative_digest`` over ``stage/runs/<sid>``. The
+    ledger lives at ``stage/curated/<curation-id>/dedupe.jsonl`` (append-only,
+    latest entry per session wins).
+
+    Per derivative, in order:
+
+    1. Fixture exclusion (M8): ``hydrate_rules.fixture_exclusion_codes`` runs
+       pre-dedupe; a coded bundle is moved to ``stage/excluded/<sid>/`` and
+       reported with its stable code — never indexed, never harvested.
+    2. Legacy ``pipeline_status`` revalidation (M9): a manifest carrying the
+       legacy field is revalidated via ``hydrate_rules.legacy_pipeline_status``;
+       evidence-absent rows are excluded with the stable code.
+    3. Identity collision (M7): the same ``session_id`` with a *different*
+       derivative digest is moved to ``quarantine/<sid>.conflict`` and the
+       original admitted derivative restored from the curated baseline copy —
+       the admitted derivative is never overwritten. Identical digests are
+       idempotent (no duplicate ledger entry, no duplicate index row).
+
+    Admitted sessions are indexed (idempotent ``upsert_run``); an unreadable
+    manifest on an admitted derivative is fatal. The dedupe ledger records
+    every decision as ``{session_id, status, content_digest, reason_code}``.
+    """
+    revision = str(revision)
+    curated = _curated_dir(stage, revision)
+    ledger_path = curated / "dedupe.jsonl"
+    baseline_root = curated / "admitted"
+    recorded = _load_dedupe_ledger(ledger_path)
+    result = DedupeResult()
+    runs_dir = stage / "runs"
+    if runs_dir.is_dir():
+        for derivative in sorted(p for p in runs_dir.iterdir() if p.is_dir()):
+            name = derivative.name
+            data = _read_manifest_dict(derivative)
+            if data is None:
+                raise HydrationError(
+                    redact_text(f"admitted derivative {name} has an unreadable manifest")
+                )
+            sid = str(data.get("session_id") or name)
+
+            # M8: fixture exclusion, pre-dedupe, stable codes.
+            try:
+                codes = hydrate_rules.fixture_exclusion_codes(derivative)
+            except (OSError, ValueError):
+                codes = [REASON_CODE_BUNDLE_UNREADABLE]
+            if not codes and "pipeline_status" in data:
+                # M9: revalidate the legacy field; evidence-absent never succeeds.
+                verdict = hydrate_rules.legacy_pipeline_status(
+                    data.get("pipeline_status"),
+                    data.get("deep_artifacts") if isinstance(data.get("deep_artifacts"), dict) else None,
+                )
+                if isinstance(verdict, tuple):
+                    codes = [verdict[1]]
+            if codes:
+                code = codes[0]
+                _move_dir(derivative, stage / "excluded" / sid)
+                _append_dedupe_entry(
+                    ledger_path,
+                    {"session_id": sid, "status": "excluded", "reason_code": code,
+                     "content_digest": None, "revision": revision, "at": _utc_now()},
+                )
+                result.excluded.append((sid, code))
+                continue
+
+            digest = sanitize._derivative_digest(derivative)
+            prev = recorded.get(sid)
+            if prev is not None and prev.get("status") == "admitted" \
+                    and prev.get("content_digest") not in (None, digest):
+                # Identity collision: quarantine the new derivative, restore the
+                # original admitted content — never overwrite (M7).
+                baseline = baseline_root / sid
+                if not baseline.is_dir():
+                    raise HydrationError(
+                        redact_text(
+                            f"identity collision for {sid} but no admitted baseline exists"
+                        )
+                    )
+                _move_dir(derivative, stage / "quarantine" / f"{sid}.conflict")
+                shutil.copytree(baseline, runs_dir / sid)
+                _append_dedupe_entry(
+                    ledger_path,
+                    {"session_id": sid, "status": "collision",
+                     "reason_code": REASON_CODE_IDENTITY_COLLISION,
+                     "content_digest": digest, "revision": revision, "at": _utc_now()},
+                )
+                result.collisions += 1
+                result.collision_ids.append(sid)
+                continue
+
+            baseline = baseline_root / sid
+            if not baseline.exists():
+                baseline.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copytree(derivative, baseline)
+            _append_dedupe_entry(
+                ledger_path,
+                {"session_id": sid, "status": "admitted", "reason_code": None,
+                 "content_digest": digest, "revision": revision, "at": _utc_now()},
+            )
+            result.admitted += 1
+    rebuild_index(stage)
+    return result
+
+
+def build_import_ledger(stage: Path, *, revision: str, source_commit: str) -> dict[str, Any]:
+    """Build and persist the value-free admission ledger (issue #982 M11).
+
+    Composes the ingest results, the dedupe ledger, and the staging index into
+    ``stage/curated/<curation-id>/import-ledger.json``. Every rejection entry
+    carries only stable reason codes, session ids, and content digests — never
+    a raw URL, path, or any matched secret value. The write is atomic; a
+    failure propagates (fatal semantics) so a partial ledger can never claim
+    success.
+    """
+    revision = str(revision)
+    source_commit = str(source_commit)
+    curated = _curated_dir(stage, source_commit)
+    recorded = _load_dedupe_ledger(curated / "dedupe.jsonl")
+
+    ingest_results: list[dict[str, Any]] = []
+    ingest_path = stage / "downloads" / revision / "_ingest_results.json"
+    if ingest_path.is_file():
+        try:
+            loaded = json.loads(ingest_path.read_text(encoding="utf-8"))
+            ingest_results = list(loaded.get("results", []))
+        except (OSError, ValueError, AttributeError):
+            ingest_results = []
+
+    from daydream.archive.index import query_runs  # noqa: PLC0415  # local: avoid import cycle
+
+    indexed_ids = {str(row["session_id"]) for row in query_runs(stage)}
+    admitted_ids = {
+        str(e["session_id"]) for e in ingest_results if e.get("status") == "admitted"
+    } | indexed_ids
+
+    imported: list[dict[str, Any]] = []
+    for sid in sorted(admitted_ids):
+        entry = recorded.get(sid)
+        imported.append(
+            {
+                "session_id": sid,
+                "content_digest": entry.get("content_digest") if entry else None,
+            }
+        )
+
+    quarantined: list[dict[str, Any]] = []
+    for e in ingest_results:
+        if e.get("status") == "quarantined":
+            quarantined.append(
+                {"session_id": str(e["session_id"]), "reason_code": e.get("reason_code")}
+            )
+    excluded: list[dict[str, Any]] = []
+    for sid, entry in sorted(recorded.items()):
+        if entry.get("status") == "collision":
+            quarantined.append(
+                {"session_id": sid, "reason_code": entry.get("reason_code")}
+            )
+        elif entry.get("status") == "excluded":
+            excluded.append({"session_id": sid, "reason_code": entry.get("reason_code")})
+
+    rejections = [
+        {
+            "session_id": e["session_id"],
+            "reason_code": e.get("reason_code"),
+            "content_digest": (recorded.get(e["session_id"], {}) or {}).get("content_digest"),
+        }
+        for e in sorted(quarantined + excluded, key=lambda x: x["session_id"])
+    ]
+
+    ledger: dict[str, Any] = {
+        "schema_version": hydrate_rules.HYDRATION_INDEX_SCHEMA_VERSION,
+        "pinned_revision": revision,
+        "source_commit": source_commit,
+        "curation_id": curated.name,
+        "generated_at": _utc_now(),
+        "imported": imported,
+        "quarantined": sorted(quarantined, key=lambda x: x["session_id"]),
+        "excluded": sorted(excluded, key=lambda x: x["session_id"]),
+        "rejections": rejections,
+        "tallies": {
+            "imported": len(imported),
+            "quarantined": len(quarantined),
+            "excluded": len(excluded),
+            "rejections": len(rejections),
+        },
+    }
+    _atomic_write_json(curated / "import-ledger.json", ledger)
+    return ledger
 
 
 def _import_hf_hub() -> Any:

--- a/daydream/archive/hydrate.py
+++ b/daydream/archive/hydrate.py
@@ -16,11 +16,14 @@ monkeypatch seam used by tests.
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
+import json
 import os
 import re
-from dataclasses import dataclass
-from pathlib import Path
+import time
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
 from typing import Any, Protocol, runtime_checkable
 
 from daydream.trajectory import redact_text
@@ -39,6 +42,10 @@ class HubUnavailableError(HydrationError):
 
 class HubDownloadError(HydrationError):
     """A requested path/revision does not exist in the Hub repo (fail-closed)."""
+
+
+class StageError(HydrationError):
+    """Staging the pinned snapshot failed (download, digest, or path violation)."""
 
 
 class MovingBranchError(HydrationError):
@@ -122,6 +129,124 @@ class HubClient(Protocol):
 
     @property
     def repo_private(self) -> bool: ...
+
+
+@dataclass(frozen=True)
+class DownloadResult:
+    """Outcome of one :func:`download_snapshot` pass over the pinned revision."""
+
+    downloaded: int = 0
+    skipped: int = 0
+    digests: dict[str, str] = field(default_factory=dict)  # relpath -> sha256
+
+
+def _validate_relpath(relpath: str, root: Path) -> Path:
+    """Enforce the M4 trust boundary: resolve ``relpath`` strictly under ``root``.
+
+    Raises :class:`StageError` naming "traversal" when the path is absolute,
+    carries ``..`` segments, or otherwise escapes the staging root. Nothing is
+    ever written before this check passes.
+    """
+    p = PurePosixPath(relpath)
+    if p.is_absolute() or any(part == ".." for part in p.parts):
+        raise StageError(
+            redact_text(
+                f"refusing relpath {relpath!r}: traversal — path escapes the staging root"
+            )
+        )
+    target = (root / relpath).resolve()
+    if not target.is_relative_to(root.resolve()):
+        raise StageError(
+            redact_text(
+                f"refusing relpath {relpath!r}: traversal — resolved path escapes the staging root"
+            )
+        )
+    return target
+
+
+def download_snapshot(
+    client: HubClient,
+    *,
+    revision: str,
+    stage_dir: Path,
+    expect: dict[str, str] | None = None,
+) -> DownloadResult:
+    """Resumable, content-addressed download of a pinned snapshot revision (issue #982 M3).
+
+    Lists the repo's bundle content (paths under ``bundles/``), writes each
+    artifact to ``stage_dir/<revision>/<relpath>``, and records a per-artifact
+    ledger (relpath, sha256, size, fetched_at) in
+    ``stage_dir/<revision>/_download_manifest.json``.
+
+    Resume: an on-disk artifact whose sha256 matches the existing ledger record
+    is skipped, not re-downloaded; missing or mismatched artifacts are fetched,
+    re-hashed, and their records updated. ``expect`` — ``{relpath: sha256}``
+    from a pinned manifest — makes any disagreement a hard :class:`StageError`
+    naming "digest". Every relpath is validated against the staging root before
+    any write (see :func:`_validate_relpath`); download failures delete the
+    partial artifact and raise :class:`StageError` with redacted messages.
+    """
+    revision = str(revision)
+    root = stage_dir / revision
+    manifest_path = root / "_download_manifest.json"
+    records: dict[str, dict[str, Any]] = {}
+    if manifest_path.exists():
+        try:
+            loaded = json.loads(manifest_path.read_text())
+            records = {a["relpath"]: a for a in loaded.get("artifacts", [])}
+        except (OSError, ValueError, KeyError, TypeError):
+            records = {}  # corrupt ledger: rebuild from disk state
+
+    relpaths = list(client.list_repo_files())
+    downloaded = 0
+    skipped = 0
+    digests: dict[str, str] = {}
+    artifacts: list[dict[str, Any]] = []
+
+    for relpath in relpaths:
+        target = _validate_relpath(relpath, root)
+        if not relpath.startswith("bundles/"):
+            continue  # non-bundle paths (top-level manifests, etc.) are not staged here
+        expected_sha = (expect or {}).get(relpath)
+        try:
+            if target.exists():
+                existing = hashlib.sha256(target.read_bytes()).hexdigest()
+                record_sha = records.get(relpath, {}).get("sha256")
+                if expected_sha in (None, existing) and record_sha in (None, existing):
+                    digests[relpath] = existing
+                    skipped += 1
+                    artifacts.append({**records.get(relpath, {}), "relpath": relpath, "sha256": existing})
+                    continue
+            data = client.download_file(relpath, revision=revision)
+        except HydrationError as exc:
+            raise StageError(redact_text(str(exc))) from exc
+        sha = hashlib.sha256(data).hexdigest()
+        if expected_sha is not None and sha != expected_sha:
+            raise StageError(
+                redact_text(f"digest mismatch for {relpath!r}: expected {expected_sha}, got {sha}")
+            )
+        target.parent.mkdir(parents=True, exist_ok=True)
+        tmp = target.with_name(target.name + ".partial")
+        try:
+            tmp.write_bytes(data)
+            tmp.replace(target)
+        except OSError as exc:
+            tmp.unlink(missing_ok=True)
+            raise StageError(redact_text(f"write failed for {relpath!r}: {exc}")) from exc
+        downloaded += 1
+        digests[relpath] = sha
+        artifacts.append(
+            {
+                "relpath": relpath,
+                "sha256": sha,
+                "size": len(data),
+                "fetched_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            }
+        )
+
+    root.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(json.dumps({"revision": revision, "artifacts": artifacts}, indent=2))
+    return DownloadResult(downloaded=downloaded, skipped=skipped, digests=digests)
 
 
 def _import_hf_hub() -> Any:

--- a/daydream/archive/hydrate.py
+++ b/daydream/archive/hydrate.py
@@ -654,6 +654,30 @@ def dedupe_admitted(stage: Path, *, revision: str) -> DedupeResult:
     return result
 
 
+def _latest_admitted_digests(path: Path) -> dict[str, str | None]:
+    """Latest *admitted* dedupe entry per session id (collision entries never win).
+
+    The admitted derivative is never overwritten (M7), so a later collision
+    entry must not replace the admitted content digest in the import ledger —
+    the published batch content is still the baseline.
+    """
+    latest: dict[str, str | None] = {}
+    if not path.is_file():
+        return latest
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            entry = json.loads(line)
+            if isinstance(entry, dict) and entry.get("session_id") \
+                    and entry.get("status") == "admitted":
+                latest[str(entry["session_id"])] = entry.get("content_digest")
+    except (OSError, ValueError):
+        return {}
+    return latest
+
+
 def build_import_ledger(stage: Path, *, revision: str, source_commit: str) -> dict[str, Any]:
     """Build and persist the value-free admission ledger (issue #982 M11).
 
@@ -668,6 +692,7 @@ def build_import_ledger(stage: Path, *, revision: str, source_commit: str) -> di
     source_commit = str(source_commit)
     curated = _curated_dir(stage, source_commit)
     recorded = _load_dedupe_ledger(curated / "dedupe.jsonl")
+    admitted_digests = _latest_admitted_digests(curated / "dedupe.jsonl")
 
     ingest_results: list[dict[str, Any]] = []
     ingest_path = stage / "downloads" / revision / "_ingest_results.json"
@@ -691,7 +716,7 @@ def build_import_ledger(stage: Path, *, revision: str, source_commit: str) -> di
         imported.append(
             {
                 "session_id": sid,
-                "content_digest": entry.get("content_digest") if entry else None,
+                "content_digest": admitted_digests.get(sid, entry.get("content_digest") if entry else None),
             }
         )
 
@@ -1192,8 +1217,26 @@ def finalize(client: HubClient, stage: Path, *, curation_id: str, source_commit:
     manifest_path = curated / "curation-manifest.json"
     _atomic_write_json(manifest_path, doc)
     prefix = f"curated/{curation_id}/"
-    _retry_upload(client, {f"{prefix}curation-manifest.json": manifest_path},
-                  f"daydream hydrate {curation_id}: curation manifest")
+    # SHA256SUMS must cover the *final* published file set — including the
+    # curation manifest rendered just above, which can change between runs
+    # (e.g. a newly recorded identity collision). Refresh it here so the
+    # checksums always match the bytes the verify cycle will pin.
+    final_relpaths = sorted(
+        p.relative_to(curated).as_posix() for p in curated.rglob("*") if p.is_file()
+    )
+    checksums = "".join(
+        f"{hashlib.sha256((curated / p).read_bytes()).hexdigest()}  {prefix}{p}\n"
+        for p in final_relpaths if p != "SHA256SUMS"
+    )
+    (curated / "SHA256SUMS").write_text(checksums, encoding="utf-8")
+    _retry_upload(
+        client,
+        {
+            f"{prefix}curation-manifest.json": manifest_path,
+            f"{prefix}SHA256SUMS": curated / "SHA256SUMS",
+        },
+        f"daydream hydrate {curation_id}: curation manifest + checksums",
+    )
     success_path = curated / "_SUCCESS"
     success_path.write_text(
         json.dumps({"curation_id": curation_id, "source_hub_commit": str(source_commit), "status": "complete"}) + "\n",

--- a/daydream/archive/hydrate.py
+++ b/daydream/archive/hydrate.py
@@ -21,11 +21,23 @@ import importlib.util
 import json
 import os
 import re
+import shutil
 import time
 from dataclasses import dataclass, field
+from dataclasses import fields as dataclass_fields
 from pathlib import Path, PurePosixPath
 from typing import Any, Protocol, runtime_checkable
 
+from daydream.archive import sanitize
+from daydream.archive.git_safe import normalize_remote_url
+from daydream.archive.hydrate_rules import (
+    REASON_CODE_BUNDLE_UNREADABLE,
+    REASON_CODE_SANITIZE_FAILED,
+    REASON_CODE_SECRETS_SCAN_DIRTY,
+    REASON_CODE_UNTRUSTED_REMOTE_HOST,
+)
+from daydream.archive.index import upsert_run
+from daydream.archive.manifest import Manifest
 from daydream.trajectory import redact_text
 
 _FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
@@ -247,6 +259,148 @@ def download_snapshot(
     root.mkdir(parents=True, exist_ok=True)
     manifest_path.write_text(json.dumps({"revision": revision, "artifacts": artifacts}, indent=2))
     return DownloadResult(downloaded=downloaded, skipped=skipped, digests=digests)
+
+
+def _read_manifest_dict(bundle_dir: Path) -> dict[str, Any] | None:
+    """Read ``manifest.json`` from ``bundle_dir``; ``None`` when absent/unparseable."""
+    path = bundle_dir / "manifest.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+@dataclass(frozen=True)
+class IngestResult:
+    """Outcome of the ingest gate for one staged session bundle (issue #982 M4/M6)."""
+
+    session_id: str
+    status: str  # "admitted" | "quarantined"
+    reason_code: str | None = None
+
+
+def ingest_bundles(stage: Path, *, revision: str) -> list[IngestResult]:
+    """Run every staged bundle through the #981 ingest gate (issue #982 M4/M6).
+
+    For each session bundle under ``stage/downloads/<revision>/bundles/``:
+
+    1. The manifest must parse and carry a trusted remote host
+       (:func:`daydream.archive.git_safe.normalize_remote_url` identity); an
+       unreadable manifest or non-allowlisted host is quarantined (fail-closed,
+       stable reason codes) without ever dereferencing embedded paths.
+    2. ``sanitize.import_bundle`` is the sole secrets gate: a dirty bundle is
+       moved to ``stage/quarantine/<name>`` by the #981 implementation itself —
+       hydrate never forks the scan or the quarantine move.
+    3. A clean bundle is sanitized by ``sanitize.sanitize_bundle`` (release
+       scan fail-closed), and the released derivative is placed at
+       ``stage/runs/<session_id>/``. Any ``.git`` directory inside the
+       downloaded copy is stripped before sanitize so no hydrated bundle ever
+       ships one (harvest priority-1 safety, Task 0B constraint).
+
+    Identity-collision dedupe is Task 8's concern; this pass guarantees one
+    derivative per staged bundle or a quarantine result.
+    """
+    bundles_root = stage / "downloads" / str(revision) / "bundles"
+    if not bundles_root.is_dir():
+        return []
+    results: list[IngestResult] = []
+    for bundle_dir in sorted(p for p in bundles_root.iterdir() if p.is_dir()):
+        name = bundle_dir.name
+        data = _read_manifest_dict(bundle_dir)
+        if data is None:
+            results.append(IngestResult(name, "quarantined", REASON_CODE_BUNDLE_UNREADABLE))
+            continue
+        session_id = str(data.get("session_id") or name)
+        raw_url = data.get("remote_url")
+        if isinstance(raw_url, str) and raw_url.strip():
+            identity, _canonical = normalize_remote_url(raw_url)
+            if identity is None:
+                # Non-allowlisted host: rejected as admission data before any
+                # gate work; the raw copy stays in downloads, never indexed.
+                results.append(
+                    IngestResult(session_id, "quarantined", REASON_CODE_UNTRUSTED_REMOTE_HOST)
+                )
+                continue
+        gate = sanitize.import_bundle(bundle_dir, stage)
+        if gate.quarantined or not gate.imported:
+            results.append(IngestResult(session_id, "quarantined", REASON_CODE_SECRETS_SCAN_DIRTY))
+            continue
+        # Task 0B constraint: hydrated staging bundles must exclude .git (the
+        # raw download copy is daydream-staged data, safe to prune locally).
+        for git_dir in list(bundle_dir.rglob(".git")):
+            if git_dir.is_dir():
+                shutil.rmtree(git_dir)
+        try:
+            sanitized = sanitize.sanitize_bundle(bundle_dir, stage)
+        except Exception:
+            results.append(IngestResult(session_id, "quarantined", REASON_CODE_SANITIZE_FAILED))
+            continue
+        if not sanitized.released:
+            results.append(IngestResult(session_id, "quarantined", REASON_CODE_SECRETS_SCAN_DIRTY))
+            continue
+        derivative = stage / "sanitized" / session_id
+        target = stage / "runs" / session_id
+        if target.exists():
+            shutil.rmtree(target)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(derivative), str(target))  # staging layout only, not the gate
+        results.append(IngestResult(session_id, "admitted"))
+    return results
+
+
+def _staging_local_source_path(raw: Any, stage: Path) -> str | None:
+    """Rewrite an embedded ``source_path`` to a staging-local value or ``None``.
+
+    Embedded paths are data: an absolute path outside the staging root is
+    dropped (never dereferenced, never carried into the index).
+    """
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    p = Path(raw)
+    if not p.is_absolute():
+        return raw
+    try:
+        p.relative_to(stage)
+    except ValueError:
+        return None
+    return raw
+
+
+def rebuild_index(stage: Path) -> None:
+    """Index every admitted derivative under ``stage/runs/`` (issue #982 M6).
+
+    Each derivative's manifest is loaded and its path/URL fields rewritten to
+    staging-local, credential-free values before ``index.upsert_run`` writes
+    the row: ``archive_path`` points inside the staging root (never the raw
+    download tree), ``source_path`` is staging-local or ``None``, and
+    ``remote_url``/``repo_slug`` come from ``normalize_remote_url`` output.
+    ``upsert_run`` errors propagate — an admitted bundle is never silently
+    skipped.
+    """
+    runs_dir = stage / "runs"
+    if not runs_dir.is_dir():
+        return
+    for derivative in sorted(p for p in runs_dir.iterdir() if p.is_dir()):
+        data = _read_manifest_dict(derivative)
+        if data is None:
+            raise HydrationError(
+                redact_text(f"admitted derivative {derivative.name} has an unreadable manifest")
+            )
+        valid = {f.name for f in dataclass_fields(Manifest)}
+        rewritten = {"archive_path", "source_path", "remote_url", "repo_slug"}
+        kwargs = {k: v for k, v in data.items() if k in valid and k not in rewritten}
+        raw_url = data.get("remote_url")
+        if isinstance(raw_url, str) and raw_url.strip():
+            slug, canonical = normalize_remote_url(raw_url)
+            kwargs["repo_slug"] = slug
+            kwargs["remote_url"] = canonical
+        else:
+            kwargs["repo_slug"] = None
+            kwargs["remote_url"] = None
+        kwargs["source_path"] = _staging_local_source_path(data.get("source_path"), stage)
+        kwargs["archive_path"] = str(derivative)
+        upsert_run(stage, Manifest(**kwargs))
 
 
 def _import_hf_hub() -> Any:

--- a/daydream/archive/hydrate.py
+++ b/daydream/archive/hydrate.py
@@ -403,6 +403,55 @@ def rebuild_index(stage: Path) -> None:
         upsert_run(stage, Manifest(**kwargs))
 
 
+def build_resolution_map(stage: Path, *, source_commit: str) -> dict[str, Any]:
+    """Build the deferred-clone repository resolution map (issue #982 M5).
+
+    From the admitted index rows under ``stage/runs/``, group sessions by the
+    ``normalize_remote_url`` slug. Each entry carries ``repo_slug``,
+    ``pinned_sha`` (the source commit the snapshot was hydrated from —
+    deferred-clone consumers fetch exactly this revision), and the contributing
+    ``session_ids``. Rows with no resolvable slug (no remote, or a
+    non-allowlisted host) land under ``map["unavailable"]`` as a list of
+    session ids — a reported outcome, never a raw-URL fallback and never a
+    clone.
+
+    No I/O beyond reading the staging index: this never shells out to git, so
+    hydration never clones or fetches (M5). Raw URLs are consumed as data only
+    and never appear in the map. Unexpected IO errors propagate.
+    """
+    from daydream.archive.index import query_runs  # noqa: PLC0415  # local: avoid import cycle at module load
+
+    cmap: dict[str, Any] = {}
+    unavailable: list[str] = []
+    indexed: set[str] = set()
+    for row in query_runs(stage):
+        indexed.add(str(row["session_id"]))
+        slug = row.get("repo_slug")
+        if not slug:
+            unavailable.append(str(row["session_id"]))
+            continue
+        entry = cmap.setdefault(
+            str(slug), {"repo_slug": str(slug), "pinned_sha": source_commit, "session_ids": []}
+        )
+        entry["session_ids"].append(str(row["session_id"]))
+    # Bundles rejected at admission for a non-allowlisted host never reached the
+    # index; they are still reported under "unavailable" (no raw-URL fallback).
+    for manifest_path in sorted(stage.glob("downloads/*/bundles/*/manifest.json")):
+        data = _read_manifest_dict(manifest_path.parent)
+        if data is None:
+            continue
+        session_id = str(data.get("session_id") or manifest_path.parent.name)
+        if session_id in indexed:
+            continue
+        raw_url = data.get("remote_url")
+        slug = normalize_remote_url(raw_url)[0] if isinstance(raw_url, str) and raw_url.strip() else None
+        if slug is None and session_id not in unavailable:
+            unavailable.append(session_id)
+    if unavailable:
+        cmap["unavailable"] = sorted(unavailable)
+    return cmap
+
+
 def _import_hf_hub() -> Any:
     """Return the ``huggingface_hub`` module, or ``None`` when not installed.
 

--- a/daydream/archive/hydrate.py
+++ b/daydream/archive/hydrate.py
@@ -1,0 +1,167 @@
+"""Hub hydration for issue #982 (task 1: client seam).
+
+Defines the :class:`HubClient` protocol that isolates ``huggingface_hub`` behind
+a narrow surface (list/download/commit/repo-info), the lazy production adapter
+:class:`HfHubClient`, and the fatal :class:`HubUnavailableError` raised when the
+optional ``hub`` extra (or its ``HF_TOKEN``) is missing. Unlike
+``daydream.archive.hub`` — whose upload callback must never fail a run and
+therefore warns — hydration is an explicit operator command, so every unmet
+prerequisite is fatal and fail-closed.
+
+``huggingface_hub`` is imported only inside :func:`_import_hf_hub`; production
+code and tests that use :class:`~daydream.archive.hydrate_client.FakeHub` never
+need it installed. The module-level :func:`_make_client` factory is the
+monkeypatch seam used by tests.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+
+class HydrationError(Exception):
+    """Base class for every hydrate failure mode; the orchestrator decides."""
+
+
+class HubUnavailableError(HydrationError):
+    """The ``huggingface_hub`` extra or its ``HF_TOKEN`` prerequisite is missing."""
+
+
+class HubDownloadError(HydrationError):
+    """A requested path/revision does not exist in the Hub repo (fail-closed)."""
+
+
+@dataclass(frozen=True)
+class RepoInfo:
+    """Minimal repo metadata the hydration flow needs."""
+
+    sha: str
+    private: bool
+
+
+@runtime_checkable
+class HubClient(Protocol):
+    """Narrow Hub surface hydration depends on (list/download/commit/repo-info)."""
+
+    def repo_info(self, revision: str | None = None) -> RepoInfo: ...
+
+    def list_repo_files(self) -> list[str]: ...
+
+    def download_file(self, path_in_repo: str, revision: str | None = None) -> bytes: ...
+
+    def upload_files(
+        self, mapping: dict[str | Path, Path], commit_message: str
+    ) -> None: ...
+
+    @property
+    def repo_private(self) -> bool: ...
+
+
+def _import_hf_hub() -> Any:
+    """Return the ``huggingface_hub`` module, or ``None`` when not installed.
+
+    Kept as a module-level function so tests can monkeypatch it to ``None`` to
+    simulate the missing-extra environment.
+    """
+    if importlib.util.find_spec("huggingface_hub") is None:
+        return None
+    import huggingface_hub  # noqa: PLC0415  # lazy: optional extra
+
+    return huggingface_hub
+
+
+def _make_client(repo_id: str, *, token_present: bool | None = None) -> HfHubClient:
+    """Build the production :class:`HfHubClient` for ``repo_id``.
+
+    ``token_present`` overrides the ``HF_TOKEN`` environment check when
+    explicitly given (``None`` derives it from the environment). Raises
+    :class:`HubUnavailableError` — fatally, never a warning — when either the
+    package or the token is absent. Error messages name prerequisites only;
+    token material is never echoed.
+    """
+    if token_present is False:
+        raise HubUnavailableError(
+            "HF_TOKEN is not set; hydration requires a read token for the "
+            "private Hub repo. Export HF_TOKEN (or pass --token-source) and retry."
+        )
+    if _import_hf_hub() is None:
+        raise HubUnavailableError(
+            "The 'huggingface-hub' package is required for hydrate but is not "
+            "installed. Install the optional extra: `uv sync --extra hub` "
+            "(or `pip install 'daydream[hub]'`)."
+        )
+    if token_present is None:
+        token_present = bool(os.environ.get("HF_TOKEN"))
+    if not token_present:
+        raise HubUnavailableError(
+            "HF_TOKEN is not set; hydration requires a read token for the "
+            "private Hub repo. Export HF_TOKEN and retry."
+        )
+    return HfHubClient(repo_id)
+
+
+class HfHubClient:
+    """Production :class:`HubClient` adapter over a lazily imported ``huggingface_hub``.
+
+    The token is read from ``os.environ["HF_TOKEN"]`` only and is never stored
+    on argv, logged, or included in ``repr``.
+    """
+
+    def __init__(self, repo_id: str) -> None:
+        hf = _import_hf_hub()
+        if hf is None:
+            raise HubUnavailableError(
+                "The 'huggingface-hub' package is required for hydrate but is not "
+                "installed. Install the optional extra: `uv sync --extra hub`."
+            )
+        self._repo_id = repo_id
+        self._hf: Any = hf
+        self._api: Any = hf.HfApi(token=os.environ.get("HF_TOKEN"))
+
+    def __repr__(self) -> str:  # never leaks the token
+        return f"HfHubClient(repo_id={self._repo_id!r})"
+
+    @property
+    def repo_private(self) -> bool:
+        return bool(self.repo_info().private)
+
+    def repo_info(self, revision: str | None = None) -> RepoInfo:
+        try:
+            info = self._api.repo_info(revision or "main", repo_type="dataset")
+        except Exception as exc:  # mapped, never swallowed
+            raise HubDownloadError(f"repo_info failed for {self._repo_id}: {exc}") from exc
+        return RepoInfo(sha=str(info.sha), private=bool(info.private))
+
+    def list_repo_files(self) -> list[str]:
+        try:
+            return list(self._api.list_repo_files(self._repo_id, repo_type="dataset"))
+        except Exception as exc:
+            raise HubDownloadError(f"list_repo_files failed for {self._repo_id}: {exc}") from exc
+
+    def download_file(self, path_in_repo: str, revision: str | None = None) -> bytes:
+        try:
+            local = self._api.hf_hub_download(
+                self._repo_id, path_in_repo, repo_type="dataset", revision=revision
+            )
+        except Exception as exc:
+            raise HubDownloadError(
+                f"download failed for {self._repo_id}:{path_in_repo}: {exc}"
+            ) from exc
+        return Path(local).read_bytes()
+
+    def upload_files(self, mapping: dict[str | Path, Path], commit_message: str) -> None:
+        try:
+            for path_in_repo, local_path in mapping.items():
+                self._api.upload_file(
+                    path_or_fileobj=str(local_path),
+                    path_in_repo=str(path_in_repo),
+                    repo_id=self._repo_id,
+                    repo_type="dataset",
+                    commit_message=commit_message,
+                )
+        except Exception as exc:
+            raise HydrationError(f"upload failed for {self._repo_id}: {exc}") from exc

--- a/daydream/archive/hydrate_client.py
+++ b/daydream/archive/hydrate_client.py
@@ -22,7 +22,7 @@ class FakeHub:
         repo_id: str,
         private: bool = True,
         files: dict[str, bytes] | None = None,
-        head_sha: str = "main",
+        head_sha: str = "head",
     ) -> None:
         self.repo_id = repo_id
         self.private = private
@@ -30,19 +30,34 @@ class FakeHub:
         self._head = head_sha
         # Revision name -> immutable snapshot of the file tree at that revision.
         self._revisions: dict[str, dict[str, bytes]] = {head_sha: dict(self.files)}
+        # Symbolic refs (branches) -> sha they currently point at.
+        self._refs: dict[str, str] = {}
 
     def __repr__(self) -> str:
         return f"FakeHub(repo_id={self.repo_id!r})"
 
-    def commit_revision(self, sha: str) -> None:
-        """Pin the current file tree under ``sha`` as a new commit revision."""
+    def commit_revision(self, sha: str, *, ref: str | None = None) -> None:
+        """Pin the current file tree under ``sha``; optionally point ``ref`` at it."""
         self._head = sha
         self._revisions[sha] = dict(self.files)
+        if ref is not None:
+            self._refs[ref] = sha
 
     def repo_info(self, revision: str | None = None) -> RepoInfo:
-        if revision is not None and revision not in self._revisions:
-            raise HubDownloadError(f"unknown revision {revision!r} for {self.repo_id}")
-        return RepoInfo(sha=self._head, private=self.private)
+        return RepoInfo(sha=self._resolve_revision(revision), private=self.private)
+
+    def list_revisions(self) -> list[str]:
+        """All known immutable revision names (commit shas), for prefix resolution."""
+        return sorted(self._revisions)
+
+    def _resolve_revision(self, revision: str | None) -> str:
+        if revision is None:
+            return self._head
+        if revision in self._revisions:
+            return revision
+        if revision in self._refs:
+            return self._refs[revision]
+        raise HubDownloadError(f"unknown revision {revision!r} for {self.repo_id}")
 
     @property
     def repo_private(self) -> bool:
@@ -52,7 +67,11 @@ class FakeHub:
         return sorted(self.files)
 
     def download_file(self, path_in_repo: str, revision: str | None = None) -> bytes:
-        tree = self.files if revision is None else self._revision_tree(revision)
+        tree = (
+            self.files
+            if revision is None
+            else self._revision_tree(self._resolve_revision(revision))
+        )
         if path_in_repo not in tree:
             raise HubDownloadError(
                 f"path {path_in_repo!r} not found in {self.repo_id} "

--- a/daydream/archive/hydrate_client.py
+++ b/daydream/archive/hydrate_client.py
@@ -1,0 +1,72 @@
+"""In-memory Hub double for offline hydration tests (issue #982).
+
+Implements the :class:`~daydream.archive.hydrate.HubClient` protocol against a
+plain ``dict[str, bytes]`` file tree. Kept in-package so integration tests and
+future tooling share one fake; production modules must never import it.
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+
+from daydream.archive.hydrate import HubDownloadError, RepoInfo
+
+
+class FakeHub:
+    """Minimal in-memory Hub serving a checked-in snapshot fixture."""
+
+    def __init__(
+        self,
+        *,
+        repo_id: str,
+        private: bool = True,
+        files: dict[str, bytes] | None = None,
+        head_sha: str = "main",
+    ) -> None:
+        self.repo_id = repo_id
+        self.private = private
+        self.files: dict[str, bytes] = dict(files or {})
+        self._head = head_sha
+        # Revision name -> immutable snapshot of the file tree at that revision.
+        self._revisions: dict[str, dict[str, bytes]] = {head_sha: dict(self.files)}
+
+    def __repr__(self) -> str:
+        return f"FakeHub(repo_id={self.repo_id!r})"
+
+    def commit_revision(self, sha: str) -> None:
+        """Pin the current file tree under ``sha`` as a new commit revision."""
+        self._head = sha
+        self._revisions[sha] = dict(self.files)
+
+    def repo_info(self, revision: str | None = None) -> RepoInfo:
+        if revision is not None and revision not in self._revisions:
+            raise HubDownloadError(f"unknown revision {revision!r} for {self.repo_id}")
+        return RepoInfo(sha=self._head, private=self.private)
+
+    @property
+    def repo_private(self) -> bool:
+        return self.private
+
+    def list_repo_files(self) -> list[str]:
+        return sorted(self.files)
+
+    def download_file(self, path_in_repo: str, revision: str | None = None) -> bytes:
+        tree = self.files if revision is None else self._revision_tree(revision)
+        if path_in_repo not in tree:
+            raise HubDownloadError(
+                f"path {path_in_repo!r} not found in {self.repo_id} "
+                f"(revision={revision or self._head})"
+            )
+        return tree[path_in_repo]
+
+    def upload_files(self, mapping: dict[str | Path, Path], commit_message: str) -> None:
+        del commit_message  # recorded only for future assertion needs
+        for path_in_repo, local_path in mapping.items():
+            self.files[str(path_in_repo)] = Path(local_path).read_bytes()
+
+    def _revision_tree(self, revision: str) -> dict[str, bytes]:
+        tree = self._revisions.get(revision)
+        if tree is None:
+            raise HubDownloadError(f"unknown revision {revision!r} for {self.repo_id}")
+        return copy.copy(tree)

--- a/daydream/archive/hydrate_client.py
+++ b/daydream/archive/hydrate_client.py
@@ -27,6 +27,8 @@ class FakeHub:
         self.repo_id = repo_id
         self.private = private
         self.files: dict[str, bytes] = dict(files or {})
+        # Every successful download_file() call, in order (test observation seam).
+        self.downloaded_log: list[str] = []
         self._head = head_sha
         # Revision name -> immutable snapshot of the file tree at that revision.
         self._revisions: dict[str, dict[str, bytes]] = {head_sha: dict(self.files)}
@@ -77,6 +79,7 @@ class FakeHub:
                 f"path {path_in_repo!r} not found in {self.repo_id} "
                 f"(revision={revision or self._head})"
             )
+        self.downloaded_log.append(path_in_repo)
         return tree[path_in_repo]
 
     def upload_files(self, mapping: dict[str | Path, Path], commit_message: str) -> None:

--- a/daydream/archive/hydrate_client.py
+++ b/daydream/archive/hydrate_client.py
@@ -8,9 +8,11 @@ future tooling share one fake; production modules must never import it.
 from __future__ import annotations
 
 import copy
+import hashlib
 from pathlib import Path
+from typing import Any
 
-from daydream.archive.hydrate import HubDownloadError, RepoInfo
+from daydream.archive.hydrate import HubDownloadError, HydrationError, RepoInfo
 
 
 class FakeHub:
@@ -34,6 +36,12 @@ class FakeHub:
         self._revisions: dict[str, dict[str, bytes]] = {head_sha: dict(self.files)}
         # Symbolic refs (branches) -> sha they currently point at.
         self._refs: dict[str, str] = {}
+        # One entry per upload commit, in order: {"contains": [paths], "sha": sha}.
+        self.commit_order: list[dict[str, Any]] = []
+        # Every path ever successfully uploaded (test observation seam).
+        self.uploaded_paths: list[str] = []
+        # When True, upload_files raises (simulated Hub outage).
+        self.fail_uploads = False
 
     def __repr__(self) -> str:
         return f"FakeHub(repo_id={self.repo_id!r})"
@@ -83,9 +91,19 @@ class FakeHub:
         return tree[path_in_repo]
 
     def upload_files(self, mapping: dict[str | Path, Path], commit_message: str) -> None:
-        del commit_message  # recorded only for future assertion needs
+        if self.fail_uploads:
+            raise HydrationError(f"upload failed for {self.repo_id}: simulated Hub outage")
+        paths: list[str] = []
         for path_in_repo, local_path in mapping.items():
             self.files[str(path_in_repo)] = Path(local_path).read_bytes()
+            paths.append(str(path_in_repo))
+        self.uploaded_paths.extend(paths)
+        # Each upload is a commit: pin the new tree under a deterministic 40-hex sha.
+        payload = commit_message + "\n" + "\n".join(sorted(paths))
+        sha = hashlib.sha256(payload.encode()).hexdigest()[:40]
+        self._revisions[sha] = dict(self.files)
+        self._head = sha
+        self.commit_order.append({"contains": sorted(paths), "sha": sha})
 
     def _revision_tree(self, revision: str) -> dict[str, bytes]:
         tree = self._revisions.get(revision)

--- a/daydream/archive/hydrate_client.py
+++ b/daydream/archive/hydrate_client.py
@@ -73,8 +73,13 @@ class FakeHub:
     def repo_private(self) -> bool:
         return self.private
 
-    def list_repo_files(self) -> list[str]:
-        return sorted(self.files)
+    def list_repo_files(self, revision: str | None = None) -> list[str]:
+        tree = (
+            self.files
+            if revision is None
+            else self._revision_tree(self._resolve_revision(revision))
+        )
+        return sorted(tree)
 
     def download_file(self, path_in_repo: str, revision: str | None = None) -> bytes:
         tree = (

--- a/daydream/archive/hydrate_client.py
+++ b/daydream/archive/hydrate_client.py
@@ -90,6 +90,19 @@ class FakeHub:
         self.downloaded_log.append(path_in_repo)
         return tree[path_in_repo]
 
+    def mutate_bundle(self, revision: str, session_id: str, content: bytes) -> None:
+        """Re-commit one bundle file at ``revision`` with new content (test setup seam).
+
+        Used to stage an identity collision: same session identity, different
+        bytes. The pinned revision's tree is updated in place, so a client
+        downloading that revision observes the mutation while older pinned
+        revisions remain untouched.
+        """
+        path = f"bundles/{session_id}/manifest.json"
+        self.files[path] = content
+        if revision in self._revisions:
+            self._revisions[revision][path] = content
+
     def upload_files(self, mapping: dict[str | Path, Path], commit_message: str) -> None:
         if self.fail_uploads:
             raise HydrationError(f"upload failed for {self.repo_id}: simulated Hub outage")

--- a/daydream/archive/hydrate_rules.py
+++ b/daydream/archive/hydrate_rules.py
@@ -20,6 +20,9 @@ REASON_CODE_FIXTURE_TMP_ARTIFACT = "fixture_tmp_artifact"
 REASON_CODE_NON_PRODUCTION_BUNDLE = "non_production_bundle"
 REASON_CODE_PIPELINE_STATUS_EVIDENCE_ABSENT = "pipeline_status_evidence_absent"
 REASON_CODE_SECRETS_SCAN_DIRTY = "secrets_scan_dirty"
+REASON_CODE_BUNDLE_UNREADABLE = "bundle_unreadable"
+REASON_CODE_UNTRUSTED_REMOTE_HOST = "untrusted_remote_host"
+REASON_CODE_SANITIZE_FAILED = "sanitize_failed"
 
 # ---------------------------------------------------------------------------
 # Curation-id derivation (Task 3)

--- a/daydream/archive/hydrate_rules.py
+++ b/daydream/archive/hydrate_rules.py
@@ -1,0 +1,17 @@
+"""Version constants and stable reason-code registry for hub hydration (#982).
+
+Expanded by later hydrate tasks; Task 2 lands only the constants the frozen
+curation-manifest-v1 schema (the #983 contract) references.
+"""
+from __future__ import annotations
+
+SANITIZER_VERSION = "1"
+HYDRATION_INDEX_SCHEMA_VERSION = "1"
+ADMISSION_POLICY_VERSION = "1"
+
+# Stable quarantine/exclusion reason codes (fixed registry at v1).
+REASON_CODE_FIXTURE_PYTEST_PATH = "fixture_pytest_path"
+REASON_CODE_FIXTURE_TMP_ARTIFACT = "fixture_tmp_artifact"
+REASON_CODE_NON_PRODUCTION_BUNDLE = "non_production_bundle"
+REASON_CODE_PIPELINE_STATUS_EVIDENCE_ABSENT = "pipeline_status_evidence_absent"
+REASON_CODE_SECRETS_SCAN_DIRTY = "secrets_scan_dirty"

--- a/daydream/archive/hydrate_rules.py
+++ b/daydream/archive/hydrate_rules.py
@@ -23,6 +23,7 @@ REASON_CODE_SECRETS_SCAN_DIRTY = "secrets_scan_dirty"
 REASON_CODE_BUNDLE_UNREADABLE = "bundle_unreadable"
 REASON_CODE_UNTRUSTED_REMOTE_HOST = "untrusted_remote_host"
 REASON_CODE_SANITIZE_FAILED = "sanitize_failed"
+REASON_CODE_IDENTITY_COLLISION = "identity_collision"
 
 # ---------------------------------------------------------------------------
 # Curation-id derivation (Task 3)

--- a/daydream/archive/hydrate_rules.py
+++ b/daydream/archive/hydrate_rules.py
@@ -5,6 +5,11 @@ curation-manifest-v1 schema (the #983 contract) references.
 """
 from __future__ import annotations
 
+import hashlib
+import json
+import re
+from pathlib import Path
+
 SANITIZER_VERSION = "1"
 HYDRATION_INDEX_SCHEMA_VERSION = "1"
 ADMISSION_POLICY_VERSION = "1"
@@ -15,3 +20,88 @@ REASON_CODE_FIXTURE_TMP_ARTIFACT = "fixture_tmp_artifact"
 REASON_CODE_NON_PRODUCTION_BUNDLE = "non_production_bundle"
 REASON_CODE_PIPELINE_STATUS_EVIDENCE_ABSENT = "pipeline_status_evidence_absent"
 REASON_CODE_SECRETS_SCAN_DIRTY = "secrets_scan_dirty"
+
+# ---------------------------------------------------------------------------
+# Curation-id derivation (Task 3)
+# ---------------------------------------------------------------------------
+
+CURATION_ID_RE = re.compile(r"cur-[0-9a-f]{16}")
+
+
+def derive_curation_id(
+    source_commit: str,
+    sanitizer_version: str,
+    index_schema_version: str,
+    admission_policy_version: str,
+) -> str:
+    """Content-addressed curation id: same inputs -> same curated/ prefix.
+
+    sha256 over the canonical tab-joined string with a single trailing
+    newline, hex-truncated to 16 chars, prefixed ``cur-`` (same canonical-
+    string hashing discipline as sanitize._derivative_digest).
+    """
+    canonical = f"cur-v1\t{source_commit}\t{sanitizer_version}\t{index_schema_version}\t{admission_policy_version}\n"
+    return "cur-" + hashlib.sha256(canonical.encode()).hexdigest()[:16]
+
+
+# Frozen exclusion registry at v1. Markers -> stable codes; order never matters
+# because codes are returned as a de-duplicated, sorted list.
+_PYTEST_TMP_MARKERS = ("/tmp/pytest", "pytest-of-", "/tmp/tmp", "PYTEST_CURRENT_TEST")
+_NON_PRODUCTION_MARKERS = ("\"is_fixture\": true", "\"example_only\": true")
+
+EXCLUSION_CODES = (
+    "fixture_pytest_path",
+    "fixture_tmp_artifact",
+    "non_production_bundle",
+)
+
+
+def fixture_exclusion_codes(bundle_dir: Path) -> list[str]:
+    """Detect pytest/tmp-style fixture provenance from manifest content.
+
+    Reads only ``manifest.json`` inside ``bundle_dir``; JSON parse errors
+    propagate (the orchestrator maps them to a ``bundle_unreadable``
+    quarantine code). Returns stable codes from ``EXCLUSION_CODES``.
+    """
+    manifest = json.loads((bundle_dir / "manifest.json").read_text())
+    text = json.dumps(manifest)
+    codes: list[str] = []
+    if any(marker in text for marker in _PYTEST_TMP_MARKERS):
+        codes.append("fixture_pytest_path")
+    if any(marker in text for marker in ("/tmp/tmp", "PYTEST_CURRENT_TEST")):
+        codes.append("fixture_tmp_artifact")
+    if any(marker in text for marker in _NON_PRODUCTION_MARKERS):
+        codes.append("non_production_bundle")
+    return codes
+
+
+def legacy_pipeline_status(
+    pipeline_status: str | None,
+    deep_artifacts: dict[str, object] | None,
+) -> str | tuple[str, str]:
+    """Revalidate a legacy ``pipeline_status`` field; never silently success.
+
+    Non-``unknown`` values pass through unchanged. ``unknown``/missing values
+    are revalidated when the bundle carries deep-artifact evidence; without
+    evidence the bundle is excluded with the stable code
+    ``pipeline_status_evidence_absent`` (spec M9).
+    """
+    if pipeline_status and pipeline_status != "unknown":
+        return pipeline_status
+    if not deep_artifacts:
+        return ("excluded", REASON_CODE_PIPELINE_STATUS_EVIDENCE_ABSENT)
+    from daydream.archive.pipeline import derive_pipeline_status  # lazy: avoid import cycle
+
+    status = deep_artifacts.get("status")
+    if isinstance(status, str) and status and status != "unknown":
+        return status
+    fix_failures = deep_artifacts.get("fix_failures")
+    phase_states = deep_artifacts.get("phase_states")
+    archive_status = deep_artifacts.get("archive_status")
+    if isinstance(fix_failures, dict) or isinstance(phase_states, dict):
+        return derive_pipeline_status(
+            archive_status if isinstance(archive_status, str) else "complete",
+            fix_failures if isinstance(fix_failures, dict) else None,
+            phase_states if isinstance(phase_states, dict) else {},
+        )
+    return ("excluded", REASON_CODE_PIPELINE_STATUS_EVIDENCE_ABSENT)

--- a/daydream/archive/hydrate_rules.py
+++ b/daydream/archive/hydrate_rules.py
@@ -24,6 +24,7 @@ REASON_CODE_BUNDLE_UNREADABLE = "bundle_unreadable"
 REASON_CODE_UNTRUSTED_REMOTE_HOST = "untrusted_remote_host"
 REASON_CODE_SANITIZE_FAILED = "sanitize_failed"
 REASON_CODE_IDENTITY_COLLISION = "identity_collision"
+REASON_CODE_PATH_TRAVERSAL = "path_traversal"
 
 # ---------------------------------------------------------------------------
 # Curation-id derivation (Task 3)

--- a/daydream/benchmark/harbor/runtime-requirements.lock
+++ b/daydream/benchmark/harbor/runtime-requirements.lock
@@ -1,6 +1,6 @@
 # Daydream Harbor runtime requirements (generated; do not edit)
 # daydream_version: 0.28.0
-# source_uv_lock_sha256: 44fbfedbf0e07ded4402c5d4f07a6c17213fc3512ef18a9484cdb707c77f4e10
+# source_uv_lock_sha256: 3957137d32bbe72b82f774acbd3d616bf565774a5b9ec1b64d11672ec0e31c80
 # generation_command: uv export --frozen --no-dev --no-emit-project --format requirements-txt
 # template_version: 4
 

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -22,6 +22,9 @@ top-level ``TARGET`` positional):
       into a JSONL training corpus plus a lineage manifest
     - ``corpus label <session-prefix> --outcome {accepted,contested,rejected,unknown}``
       — record an authoritative human outcome label that overrides automated ones
+    - ``corpus hydrate-hub`` — turn a pinned private-Hub trajectory snapshot into a
+      verified, sanitized, harvestable local staging archive and publish it additively
+      back to the Hub under ``curated/<curation-id>/``
 - ``daydream train --corpus <path> --out <dir>`` — run the four-stage
   training pipeline (stage0 offline gate → stage1 SFT → stage2 RFT →
   stage3 adapter) and write a stage manifest (``--dry-run`` is the GPU-free
@@ -1146,6 +1149,216 @@ def _handle_harvest_command(argv: list[str]) -> int:
     return 0
 
 
+def _build_hydrate_hub_parser() -> argparse.ArgumentParser:
+    """Build the parser for ``daydream corpus hydrate-hub [...]``.
+
+    Drives :func:`daydream.archive.hydrate.run_hydrate_hub`: pin a private-Hub
+    snapshot revision, download it resumably into a staging directory, run the
+    fail-closed ingest gate, and publish the sanitized output additively under
+    ``curated/<curation-id>/`` — reporting success only after the clean-room
+    verification cycle passes.
+    """
+    parser = argparse.ArgumentParser(
+        prog="daydream corpus hydrate-hub",
+        description=(
+            "Hydrate a pinned private-Hub trajectory snapshot into a verified, "
+            "sanitized, harvestable staging archive and publish it additively "
+            "back to the Hub under curated/<curation-id>/ (issue #982)."
+        ),
+    )
+    parser.add_argument(
+        "--source-repo",
+        type=str,
+        required=True,
+        dest="source_repo",
+        metavar="REPO_ID",
+        help="Source private Hub dataset repo (e.g. org/ds) holding the snapshot.",
+    )
+    parser.add_argument(
+        "--source-revision",
+        type=str,
+        required=True,
+        dest="source_revision",
+        metavar="REV",
+        help=(
+            "Pinned source commit: an exact 40-char SHA or unique hex prefix. "
+            "Moving branches/tags require --exploratory."
+        ),
+    )
+    parser.add_argument(
+        "--destination-repo",
+        type=str,
+        required=True,
+        dest="destination_repo",
+        metavar="REPO_ID",
+        help="Destination private Hub repo for the sanitized output (must be private).",
+    )
+    parser.add_argument(
+        "--stage-dir",
+        type=Path,
+        required=True,
+        dest="stage_dir",
+        metavar="PATH",
+        help="Local staging directory for downloads, ingest, and the rebuildable index.",
+    )
+    parser.add_argument(
+        "--exploratory",
+        action="store_true",
+        dest="exploratory",
+        help="Opt in to a moving branch/tag source revision (output is non-canonical).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        dest="dry_run",
+        help="Plan only: pin, download, ingest, and tally — no Hub publication.",
+    )
+    return parser
+
+
+def _run_hydrate_hub(config: Any) -> Any:
+    """Thin module-attribute wrapper around the hydrate orchestrator.
+
+    Lives at module level so tests can monkeypatch ``cli._run_hydrate_hub``
+    (the same seam discipline as harvest's ``run_harvest`` lookup).
+    """
+    from daydream.archive.hydrate import run_hydrate_hub
+
+    return run_hydrate_hub(config)
+
+
+def _handle_hydrate_hub_command(argv: list[str]) -> int:
+    """Handle ``daydream corpus hydrate-hub [...]``.
+
+    Fail-closed, fatal semantics (unlike ``hub.py``'s warn-everything): a
+    missing ``HF_TOKEN`` or a moving-branch revision without ``--exploratory``
+    exits 1 before any Hub access. Success prints the immutable output commit
+    SHA plus a value-free summary (counts and reason-code tallies only). Any
+    ``HydrationError`` is ``redact_text``-processed before display.
+
+    Returns:
+        ``0`` on a verified run (or a completed ``--dry-run`` plan); ``1`` on
+        any validation or hydration failure.
+    """
+    import os
+
+    from daydream.archive import hydrate as _hydrate
+    from daydream.trajectory import redact_text
+    from daydream.ui import create_console
+
+    parser = _build_hydrate_hub_parser()
+    console = create_console()
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        if exc.code == 0:
+            raise
+        print_error(
+            console,
+            "Invalid arguments",
+            "corpus hydrate-hub requires --source-repo, --source-revision, "
+            "--destination-repo, and --stage-dir.",
+        )
+        return 1
+
+    # Moving-branch rejection is checkable locally (no client, no token): a
+    # revision that is neither a full SHA nor a hex prefix is a symbolic ref.
+    revision = args.source_revision.strip().lower()
+    if not args.exploratory and not (
+        _hydrate._FULL_SHA_RE.fullmatch(revision) or _hydrate._HEX_PREFIX_RE.fullmatch(revision)
+    ):
+        print_error(
+            console,
+            "Moving source revision",
+            f"ref {revision!r} is a moving branch/tag, not a pinned commit; pass "
+            "--exploratory to accept it (output is non-canonical), or pin an exact "
+            "40-char commit SHA.",
+        )
+        return 1
+
+    # Token precheck: fail closed before any Hub access; name the env var,
+    # never the token.
+    if not os.environ.get("HF_TOKEN"):
+        print_error(
+            console,
+            "HF_TOKEN is not set",
+            "hydration requires a read token for the private Hub repo. "
+            "Export HF_TOKEN and retry.",
+        )
+        return 1
+
+    stage_dir = args.stage_dir.expanduser()
+    config = _hydrate.HydrateHubConfig(
+        source_repo=args.source_repo,
+        source_revision=revision,
+        destination_repo=args.destination_repo,
+        stage_dir=stage_dir,
+        exploratory=args.exploratory,
+    )
+    if args.dry_run:
+        return _hydrate_hub_dry_run(config, console)
+
+    try:
+        summary = globals()["_run_hydrate_hub"](config)
+    except _hydrate.HydrationError as exc:
+        print_error(console, "Hydration failed", redact_text(str(exc)))
+        return 1
+    if not summary.verified:
+        print_error(
+            console,
+            "Hydration not verified",
+            "the clean-room verification cycle did not pass; no success marker "
+            "was published.",
+        )
+        return 1
+    print_success(
+        console,
+        f"hydration verified: curation {summary.curation_id} published at commit "
+        f"{summary.output_commit_sha}",
+    )
+    print_info(
+        console,
+        f"dry-run admitted {summary.dry_run_admitted} batch(es); "
+        f"verify admitted {summary.verify_admitted} batch(es)",
+    )
+    return 0
+
+
+def _hydrate_hub_dry_run(config: Any, console: Any) -> int:
+    """Plan-only hydrate pass: pin, download, ingest, tally — no publication."""
+    from daydream.archive import hydrate as _hydrate
+    from daydream.trajectory import redact_text
+
+    try:
+        client = _hydrate._make_client(config.destination_repo)
+        source_commit = _hydrate.resolve_source_revision(
+            client, config.source_revision, exploratory=config.exploratory
+        )
+        _hydrate.download_snapshot(client, revision=source_commit, stage_dir=config.stage_dir / "downloads")
+        _hydrate.ingest_bundles(config.stage_dir, revision=source_commit)
+        _hydrate.dedupe_admitted(config.stage_dir, revision=source_commit)
+        ledger = _hydrate.build_import_ledger(
+            config.stage_dir, revision=source_commit, source_commit=source_commit
+        )
+    except _hydrate.HydrationError as exc:
+        print_error(console, "Hydration dry-run failed", redact_text(str(exc)))
+        return 1
+    tallies = ledger.get("tallies", {})
+    rejections = ledger.get("rejections", [])
+    reason_tally: dict[str, int] = {}
+    for rejection in rejections:
+        code = str(rejection.get("reason_code"))
+        reason_tally[code] = reason_tally.get(code, 0) + 1
+    print_info(
+        console,
+        f"dry-run plan for curation {ledger.get('curation_id')}: pinned {source_commit}; "
+        f"admitted {tallies.get('imported', 0)} batch(es); "
+        f"rejected {len(rejections)} batch(es); "
+        f"reason codes: {reason_tally or 'none'}; no publication performed",
+    )
+    return 0
+
+
 def _build_list_reanchored_parser() -> argparse.ArgumentParser:
     """Build the parser for ``daydream improve list-reanchored <target>``.
 
@@ -1400,16 +1613,18 @@ _CORPUS_SUBVERBS: dict[str, Callable[[list[str]], int]] = {
     "harvest": _handle_harvest_command,
     "build": _handle_build_corpus_command,
     "label": _handle_label_command,
+    "hydrate-hub": _handle_hydrate_hub_command,
 }
 
 
 _CORPUS_USAGE = (
-    "usage: daydream corpus {harvest,build,label} ...\n"
+    "usage: daydream corpus {harvest,build,label,hydrate-hub} ...\n"
     "\n"
     "Data-pipeline sub-verbs:\n"
     "  harvest   walk the archive and append one bitemporal annotation per indexed run\n"
     "  build     project the as-of-pinned annotations into a JSONL training corpus\n"
-    "  label     record an authoritative human outcome label that overrides automated ones"
+    "  label     record an authoritative human outcome label that overrides automated ones\n"
+    "  hydrate-hub  hydrate a pinned Hub snapshot into a sanitized, verified staging archive"
 )
 
 _EXT_USAGE = (
@@ -1831,8 +2046,10 @@ def _shutdown_and_exit(console: Console, title: str, message: str) -> None:
     sys.exit(1)
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> None:
     """Run the CLI entry point.
+
+    ``argv`` defaults to ``sys.argv[1:]``; tests may pass an explicit list.
 
     Dispatch is verb-first (see :func:`_first_verb` and :data:`KNOWN_VERBS`):
     the leading token selects a verb, and anything that is not an explicit
@@ -1843,7 +2060,8 @@ def main() -> None:
     Verbs:
         - ``review`` (default) — the review/fix loop (bare ``daydream <target>``)
         - ``summarize`` — print run-info markdown for a trajectory
-        - ``corpus`` — data-pipeline namespace (``harvest`` / ``build`` / ``label``)
+        - ``corpus`` — data-pipeline namespace (``harvest`` / ``build`` / ``label`` /
+          ``hydrate-hub``)
         - ``train`` — four-stage training pipeline (``--dry-run`` for GPU-free CI)
         - ``post-findings`` — validate a findings artifact and post new
           findings to the PR (privileged Phase B poster; unattended)
@@ -1864,7 +2082,7 @@ def main() -> None:
 
     # Verb-first dispatch: non-``review`` verbs are short-circuited here (each
     # owns its parser and exit code); everything else flows into ``_parse_args``.
-    argv = sys.argv[1:]
+    argv = list(argv) if argv is not None else sys.argv[1:]
     # ``bench`` was the legacy benchmark verb, removed in favor of
     # ``daydream benchmark``. Reject it explicitly instead of letting
     # ``_first_verb`` fall through to the review path with ``bench`` as a

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -1263,9 +1263,13 @@ def _handle_hydrate_hub_command(argv: list[str]) -> int:
 
     # Moving-branch rejection is checkable locally (no client, no token): a
     # revision that is neither a full SHA nor a hex prefix is a symbolic ref.
-    revision = args.source_revision.strip().lower()
+    # Case-fold only for the precheck regexes: a symbolic ref is forwarded
+    # case-sensitively so a case-sensitive branch/tag never silently maps to a
+    # differently-cased name (hydrate folds hex only inside its hex branches).
+    revision = args.source_revision.strip()
     if not args.exploratory and not (
-        _hydrate._FULL_SHA_RE.fullmatch(revision) or _hydrate._HEX_PREFIX_RE.fullmatch(revision)
+        _hydrate._FULL_SHA_RE.fullmatch(revision.lower())
+        or _hydrate._HEX_PREFIX_RE.fullmatch(revision.lower())
     ):
         print_error(
             console,
@@ -1330,7 +1334,7 @@ def _hydrate_hub_dry_run(config: Any, console: Any) -> int:
     from daydream.trajectory import redact_text
 
     try:
-        client = _hydrate._make_client(config.destination_repo)
+        client = _hydrate._make_client(config.source_repo)
         source_commit = _hydrate.resolve_source_revision(
             client, config.source_revision, exploratory=config.exploratory
         )

--- a/daydream/training/schema/curation-manifest-v1.json
+++ b/daydream/training/schema/curation-manifest-v1.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Daydream curation manifest (admission ledger) schema v1",
+  "description": "Portable, frozen contract for the hydrated-curation ledger published under curated/<curation-id>/. All path fields are repo-relative; absolute paths and parent traversal are rejected.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "source_hub_commit",
+    "curation_id",
+    "sanitizer_version",
+    "hydration_index_schema_version",
+    "admission_policy_version",
+    "publication_prefix",
+    "batches"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "1"
+    },
+    "source_hub_commit": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "curation_id": {
+      "type": "string",
+      "pattern": "^cur-[0-9a-f]{16}$"
+    },
+    "sanitizer_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "hydration_index_schema_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "admission_policy_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "publication_prefix": {
+      "type": "string",
+      "pattern": "^curated/cur-[0-9a-f]{16}/$"
+    },
+    "batches": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "session_id",
+          "content_digest",
+          "status",
+          "reason_code",
+          "artifact_relpath"
+        ],
+        "properties": {
+          "session_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "content_digest": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          },
+          "status": {
+            "enum": ["admitted", "quarantined", "excluded"]
+          },
+          "reason_code": {
+            "type": ["string", "null"]
+          },
+          "artifact_relpath": {
+            "type": "string",
+            "description": "Relative path only: must not start with '/' and must not contain '..' segments.",
+            "pattern": "^(?!/)(?!.*\\.\\.).+$"
+          },
+          "artifact_digest": {
+            "type": ["string", "null"],
+            "pattern": "^[0-9a-f]{64}$"
+          },
+          "manifest_relpath": {
+            "type": ["string", "null"],
+            "pattern": "^(?!/)(?!.*\\.\\.).+$"
+          }
+        }
+      }
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
 
 [project.optional-dependencies]
 benchmark = ["harbor>=0.22,<0.23"]
+hub = ["huggingface_hub>=0.26"]
 
 [dependency-groups]
 dev = [

--- a/rl/daydream_review_v1/uv.lock
+++ b/rl/daydream_review_v1/uv.lock
@@ -421,6 +421,7 @@ requires-dist = [
     { name = "claude-agent-sdk", specifier = "==0.2.116" },
     { name = "harbor", marker = "extra == 'benchmark'", specifier = ">=0.22,<0.23" },
     { name = "httpx", specifier = ">=0.28" },
+    { name = "huggingface-hub", marker = "extra == 'hub'", specifier = ">=0.26" },
     { name = "jsonschema", specifier = ">=4.0" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pyfiglet", specifier = ">=1.0" },
@@ -433,7 +434,7 @@ requires-dist = [
     { name = "tree-sitter-rust", specifier = "==0.24.2" },
     { name = "tree-sitter-typescript", specifier = "==0.23.2" },
 ]
-provides-extras = ["benchmark"]
+provides-extras = ["benchmark", "hub"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2272,8 +2273,8 @@ name = "uvicorn"
 version = "0.51.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "sys_platform != 'emscripten'" },
-    { name = "h11", marker = "sys_platform != 'emscripten'" },
+    { name = "click" },
+    { name = "h11" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a2/65/b7c6c443ccc58678c91e1e973bbe2a878591538655d6e1d47f24ba1c51f3/uvicorn-0.51.0.tar.gz", hash = "sha256:f6f4b69b657c312f516dd2d268ab9ae6f254b11e4bac504f37b2ab58b24dd0b0", size = 94412, upload-time = "2026-07-08T10:59:05.962Z" }
 wheels = [

--- a/tests/fixtures/training/build_hub_snapshot.py
+++ b/tests/fixtures/training/build_hub_snapshot.py
@@ -1,0 +1,91 @@
+"""Builds the offline fake-Hub snapshot for the hydrate integration suite (M22).
+
+Serializes three session bundles from ``build_archive.FIXTURE_SESSIONS`` (the
+§9 fixture matrix is reused, not re-invented) into a
+:class:`~daydream.archive.hydrate_client.FakeHub` file tree: ``manifest.json`` +
+``trajectory.json`` per session under ``bundles/<session_id>/``, a bronze
+companion file (to assert M10 immutability), an empty remote resume ledger, and
+everything pinned under a deterministic 40-hex ``SNAPSHOT_REVISION``.
+
+``hostile=True`` injects traversal-style relpaths (``../../escape.txt`` and an
+absolute ``/etc/...`` path) so the trust boundary can be exercised end-to-end.
+
+No network, no ``huggingface_hub`` import, no absolute VM-local paths: the
+builder is pure in-memory construction.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+from daydream.archive.hydrate_client import FakeHub
+from daydream.archive.hydrate_rules import (
+    ADMISSION_POLICY_VERSION,
+    HYDRATION_INDEX_SCHEMA_VERSION,
+    SANITIZER_VERSION,
+    derive_curation_id,
+)
+from daydream.archive.manifest import Manifest
+from tests.fixtures.training.build_archive import _MINIMAL_TRAJECTORY, FIXTURE_SESSIONS
+
+REPO_ID = "org/private-ds"
+SNAPSHOT_REVISION = hashlib.sha256(b"fixture-hub-snapshot-v1").hexdigest()[:40]
+
+# Three §9 sessions, aliased to the stable ids the integration scenarios assert on.
+_SNAPSHOT_SESSION_IDS = ("sess-a", "sess-b", "sess-c")
+
+
+def _snapshot_manifest(session_id: str, repo_slug: str, skill: str, outcome_labels: tuple[str, ...]) -> Manifest:
+    """Build a Manifest from §9 session data with staging-safe path fields.
+
+    ``archive_path``/``source_path`` are snapshot-internal placeholders (never
+    pytest/tmp paths, which would trip the fixture-exclusion registry); the
+    orchestrator rewrites both to staging-local values at index time.
+    """
+    return Manifest(
+        session_id=session_id,
+        archived_at="2026-05-17T00:00:00+00:00",
+        status="complete",
+        pipeline_status="succeeded",
+        skill=skill,
+        repo_slug=repo_slug,
+        branch="feat/x",
+        base_branch="main",
+        head_sha="abc123",
+        grounding_rate=0.9,
+        outcome_labels=json.dumps(list(outcome_labels)),
+        archive_path=f"/archive/runs/{session_id}",
+        remote_url=f"https://github.com/{repo_slug}",
+    )
+
+
+def build_snapshot(*, hostile: bool = False) -> FakeHub:
+    """Materialize the pinned three-session snapshot as an in-memory FakeHub."""
+    files: dict[str, bytes] = {}
+    for session_id, session in zip(_SNAPSHOT_SESSION_IDS, FIXTURE_SESSIONS, strict=False):
+        manifest = _snapshot_manifest(
+            session_id, session.repo_slug, session.skill, session.outcome_labels
+        )
+        files[f"bundles/{session_id}/manifest.json"] = json.dumps(
+            manifest.to_dict(), indent=2
+        ).encode()
+        files[f"bundles/{session_id}/trajectory.json"] = json.dumps(
+            _MINIMAL_TRAJECTORY, indent=2
+        ).encode()
+    # Bronze companion content: hydration must never touch it (M10).
+    files["bronze/manifest.json"] = b'{"bronze": true}\n'
+    # Remote resume ledger, seeded empty: the Hub is the canonical resume state.
+    curation_id = derive_curation_id(
+        SNAPSHOT_REVISION, SANITIZER_VERSION, HYDRATION_INDEX_SCHEMA_VERSION,
+        ADMISSION_POLICY_VERSION,
+    )
+    files[f"curated/{curation_id}/resume/ledger.jsonl"] = b""
+
+    if hostile:
+        files["../../escape.txt"] = b"pwned"
+        files["/etc/daydream-escape"] = b"pwned"
+
+    hub = FakeHub(repo_id=REPO_ID, private=True, files=files)
+    hub.commit_revision(SNAPSHOT_REVISION)
+    return hub

--- a/tests/fixtures/training/curation-manifest-v1-fixture.json
+++ b/tests/fixtures/training/curation-manifest-v1-fixture.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "1",
+  "source_hub_commit": "0123456789abcdef0123456789abcdef01234567",
+  "curation_id": "cur-0123456789abcdef",
+  "sanitizer_version": "1",
+  "hydration_index_schema_version": "1",
+  "admission_policy_version": "1",
+  "publication_prefix": "curated/cur-0123456789abcdef/",
+  "batches": [
+    {
+      "session_id": "sess-a",
+      "content_digest": "1111111111111111111111111111111111111111111111111111111111111111",
+      "status": "admitted",
+      "reason_code": null,
+      "artifact_relpath": "runs/sess-a/trajectory.jsonl",
+      "artifact_digest": "2222222222222222222222222222222222222222222222222222222222222222",
+      "manifest_relpath": "runs/sess-a/manifest.json"
+    },
+    {
+      "session_id": "sess-b",
+      "content_digest": "3333333333333333333333333333333333333333333333333333333333333333",
+      "status": "quarantined",
+      "reason_code": "secrets_scan_dirty",
+      "artifact_relpath": "quarantine/sess-b/trajectory.jsonl",
+      "artifact_digest": null,
+      "manifest_relpath": null
+    }
+  ]
+}

--- a/tests/test_archive_hydrate.py
+++ b/tests/test_archive_hydrate.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from daydream.archive import hydrate
+from daydream.archive import hydrate_rules
 from daydream.archive.hydrate_client import FakeHub
 
 SNAPSHOT = {
@@ -28,6 +29,41 @@ def test_fake_hub_roundtrip_and_revision(tmp_path: Path) -> None:
     assert sorted(hub.list_repo_files()) == sorted(SNAPSHOT)
     data = hub.download_file("bundles/sess-a/manifest.json", revision="abc123def4567890")
     assert json.loads(data)["session_id"] == "sess-a"
+
+
+class TestCurationManifestSchema:
+    SCHEMA = Path(hydrate_rules.__file__).parent.parent / "training" / "schema" / "curation-manifest-v1.json"
+    FIXTURE = Path(__file__).parent / "fixtures" / "training" / "curation-manifest-v1-fixture.json"
+
+    def _validate(self, instance: dict) -> None:
+        from jsonschema import Draft202012Validator
+
+        Draft202012Validator(json.loads(self.SCHEMA.read_text())).validate(instance)
+
+    def test_fixture_validates(self) -> None:
+        self._validate(json.loads(self.FIXTURE.read_text()))
+
+    def test_absolute_path_rejected(self, tmp_path: Path) -> None:
+        doc = json.loads(self.FIXTURE.read_text())
+        doc["batches"][0]["artifact_relpath"] = str(tmp_path)  # absolute VM-local path
+        with pytest.raises(Exception):
+            self._validate(doc)
+
+    def test_schema_version_mismatch_flagged(self) -> None:
+        doc = json.loads(self.FIXTURE.read_text())
+        doc["schema_version"] = "999"
+        with pytest.raises(Exception):
+            self._validate(doc)
+
+    def test_required_contract_fields(self) -> None:
+        doc = json.loads(self.FIXTURE.read_text())
+        for field in ("schema_version", "source_hub_commit", "curation_id",
+                      "sanitizer_version", "hydration_index_schema_version",
+                      "admission_policy_version", "batches"):
+            assert field in doc
+        batch = doc["batches"][0]
+        assert {"session_id", "content_digest", "status", "reason_code",
+                "artifact_relpath"} <= set(batch)
 
 
 def test_hf_client_missing_extra_is_fatal_and_redacted(

--- a/tests/test_archive_hydrate.py
+++ b/tests/test_archive_hydrate.py
@@ -18,7 +18,9 @@ SNAPSHOT = {
 
 
 def make_fake_hub(tmp_path: Path) -> FakeHub:
-    return FakeHub(repo_id="org/private-ds", private=True, files=dict(SNAPSHOT))
+    hub = FakeHub(repo_id="org/private-ds", private=True, files=dict(SNAPSHOT))
+    hub.commit_revision("a" * 40)
+    return hub
 
 
 def test_fake_hub_roundtrip_and_revision(tmp_path: Path) -> None:
@@ -386,6 +388,55 @@ class TestIngestAndIndex:
         stage = self._staged(tmp_path)
         hydrate.ingest_bundles(stage, revision="a" * 40)
         assert not list((stage / "runs").rglob(".git"))
+
+
+class TestFinalizeAndVerify:
+    def _config(self, tmp_path: Path) -> hydrate.HydrateHubConfig:
+        return hydrate.HydrateHubConfig(
+            source_repo="org/private-ds", source_revision="a" * 40,
+            destination_repo="org/private-ds", stage_dir=tmp_path / "stage")
+
+    def _staged(self, tmp_path: Path) -> Path:
+        hub = make_fake_hub(tmp_path)
+        stage = tmp_path / "stage"
+        hydrate.download_snapshot(hub, revision="a" * 40, stage_dir=stage / "downloads")
+        hydrate.ingest_bundles(stage, revision="a" * 40)
+        hydrate.dedupe_admitted(stage, revision="a" * 40)
+        hydrate.build_import_ledger(stage, revision="a" * 40, source_commit="a" * 40)
+        return stage
+
+    def test_success_marker_last_and_output_sha_captured(self, tmp_path: Path) -> None:
+        hub = make_fake_hub(tmp_path)
+        stage = self._staged(tmp_path)
+        summary = hydrate.run_hydrate_hub(hydrate.HydrateHubConfig(
+            source_repo="org/private-ds", source_revision="a" * 40,
+            destination_repo="org/private-ds", stage_dir=stage), client=hub)
+        order = hub.commit_order
+        assert order[-1]["contains"] == ["curated/" + summary.curation_id + "/_SUCCESS"]
+        assert summary.output_commit_sha and len(summary.output_commit_sha) == 40
+
+    def test_verify_cycle_reproduces_dry_run_counts(self, tmp_path: Path) -> None:
+        hub = make_fake_hub(tmp_path)
+        self._staged(tmp_path)
+        summary = hydrate.run_hydrate_hub(self._config(tmp_path), client=hub)
+        assert summary.verified is True
+        assert summary.dry_run_admitted == summary.verify_admitted  # M19 count equality
+
+    def test_no_success_on_skipped_upload(self, tmp_path: Path) -> None:
+        hub = make_fake_hub(tmp_path)
+        hub.fail_uploads = True
+        self._staged(tmp_path)
+        with pytest.raises(hydrate.HydrationError):
+            hydrate.run_hydrate_hub(self._config(tmp_path), client=hub)
+        assert "cur-" not in "".join(hub.uploaded_paths) or \
+            not any(p.endswith("_SUCCESS") for p in hub.uploaded_paths)
+
+    def test_no_success_on_public_destination(self, tmp_path: Path) -> None:
+        hub = make_fake_hub(tmp_path)
+        hub.private = False
+        with pytest.raises(hydrate.PublicDestinationError):
+            hydrate.run_hydrate_hub(self._config(tmp_path), client=hub)
+        assert not any(p.endswith("_SUCCESS") for p in hub.uploaded_paths)
 
 
 class TestDedupeAndLedger:

--- a/tests/test_archive_hydrate.py
+++ b/tests/test_archive_hydrate.py
@@ -141,6 +141,16 @@ class TestResolveRevision:
         hub.commit_revision("b" * 40, ref="main")
         assert hydrate.resolve_source_revision(hub, "main", exploratory=True) == "b" * 40
 
+    def test_symbolic_ref_not_case_folded(self) -> None:
+        """Case-sensitive refs are never silently mapped to a differently-cased name."""
+        hub = make_fake_hub(Path("/tmp"))
+        hub.commit_revision("b" * 40, ref="main")
+        with pytest.raises(hydrate.HydrationError, match="unknown revision"):
+            hydrate.resolve_source_revision(hub, "Main", exploratory=True)  # no silent fold to 'main'
+        hub.commit_revision("c" * 40, ref="Main")
+        assert hydrate.resolve_source_revision(hub, "Main", exploratory=True) == "c" * 40
+        assert hydrate.resolve_source_revision(hub, "main", exploratory=True) == "b" * 40
+
     def test_unknown_revision_fails_closed(self) -> None:
         hub = make_fake_hub(Path("/tmp"))
         with pytest.raises(hydrate.HydrationError):
@@ -204,8 +214,8 @@ class TestDownloadSnapshot:
 
     def test_traversal_relpath_rejected(self, tmp_path: Path) -> None:
         hub = make_fake_hub(tmp_path)
+        hub.files["../../escape.txt"] = b"pwned"  # hostile relpath is part of the pinned snapshot
         hub.commit_revision("a" * 40)
-        hub.files["../../escape.txt"] = b"pwned"
         stage = tmp_path / "stage" / "downloads"
         with pytest.raises(hydrate.StageError, match="traversal|escapes"):
             hydrate.download_snapshot(hub, revision="a" * 40, stage_dir=stage)
@@ -213,8 +223,8 @@ class TestDownloadSnapshot:
     def test_traversal_from_manifest_never_writes(self, tmp_path: Path) -> None:
         """A hostile Hub listing pointing outside the staging root writes nothing outside."""
         hub = make_fake_hub(tmp_path)
+        hub.files["bundles/../../outside.txt"] = b"pwned"  # pinned with the snapshot revision
         hub.commit_revision("a" * 40)
-        hub.files["bundles/../../outside.txt"] = b"pwned"
         stage = tmp_path / "stage" / "downloads"
         with pytest.raises(hydrate.StageError):
             hydrate.download_snapshot(hub, revision="a" * 40, stage_dir=stage)
@@ -383,6 +393,51 @@ class TestIngestAndIndex:
         # nothing outside staging was touched
         assert not pathlib.Path("/etc/passwd.git").exists()
 
+    def test_traversal_session_id_quarantined_before_any_write(self, tmp_path: Path) -> None:
+        """A traversal-bearing manifest session id is quarantined pre-write (M4)."""
+        hub = FakeHub(repo_id="org/private-ds", private=True, files={
+            "bundles/sess-evil/manifest.json":
+                b'{"session_id": "../escape", "remote_url": "https://github.com/o/r"}',
+            "bundles/sess-evil/trajectory.json": b"{}",
+        })
+        hub.commit_revision("a" * 40)
+        stage = tmp_path / "stage"
+        hydrate.download_snapshot(hub, revision="a" * 40, stage_dir=stage / "downloads")
+        results = hydrate.ingest_bundles(stage, revision="a" * 40)
+        evil = [r for r in results if r.session_id == "../escape"]
+        assert evil and evil[0].status == "quarantined"
+        assert evil[0].reason_code == hydrate_rules.REASON_CODE_PATH_TRAVERSAL
+        assert not (stage / "runs").exists()          # never admitted
+        assert not (stage / "quarantine").exists()    # sanitize gate never saw it
+        assert not (tmp_path / "escape").exists()     # nothing outside staging
+
+    def test_produced_nested_manifest_indexed_without_crash(self, tmp_path: Path) -> None:
+        """Real manifests nest git.* and carry a nested daydream provenance dict."""
+        from daydream.archive.manifest import Manifest
+        from daydream.archive.provenance import ExecutableProvenance
+
+        manifest = Manifest(
+            session_id="sess-real",
+            remote_url="https://github.com/octo/nested-repo",
+            repo_slug="octo/nested-repo",
+            source_path="/orig/absolute/path",
+            daydream=ExecutableProvenance(version="1.0", install_source="editable"),
+        )
+        hub = FakeHub(repo_id="org/private-ds", private=True, files={
+            "bundles/sess-real/manifest.json": json.dumps(manifest.to_dict()).encode(),
+            "bundles/sess-real/trajectory.json": b"{}",
+        })
+        hub.commit_revision("a" * 40)
+        stage = tmp_path / "stage"
+        hydrate.download_snapshot(hub, revision="a" * 40, stage_dir=stage / "downloads")
+        results = hydrate.ingest_bundles(stage, revision="a" * 40)
+        assert [r.status for r in results] == ["admitted"]
+        hydrate.rebuild_index(stage)  # must not raise: nested daydream dict is dropped
+        from daydream.archive.index import query_runs
+        rows = [r for r in query_runs(stage) if r["session_id"] == "sess-real"]
+        assert len(rows) == 1
+        assert rows[0]["repo_slug"] == "octo/nested-repo"  # nested git.remote_url read
+
     def test_bundles_exclude_git_dirs(self, tmp_path: Path) -> None:
         """Task 0B constraint: no .git ships inside hydrated bundles (harvest priority-1 safety)."""
         stage = self._staged(tmp_path)
@@ -404,6 +459,23 @@ class TestFinalizeAndVerify:
         hydrate.dedupe_admitted(stage, revision="a" * 40)
         hydrate.build_import_ledger(stage, revision="a" * 40, source_commit="a" * 40)
         return stage
+
+    def test_verify_failure_never_publishes_success_marker(self, tmp_path: Path) -> None:
+        """A post-publication verification failure leaves no published _SUCCESS."""
+        class CorruptingHub(FakeHub):
+            def download_file(self, path_in_repo: str, revision: str | None = None) -> bytes:
+                data = super().download_file(path_in_repo, revision)
+                if "/batches/" in path_in_repo and path_in_repo.endswith("trajectory.json"):
+                    return data + b"\ncorrupted"
+                return data
+
+        hub = CorruptingHub(repo_id="org/private-ds", private=True, files=dict(SNAPSHOT))
+        hub.commit_revision("a" * 40)
+        with pytest.raises(hydrate.VerificationError):
+            hydrate.run_hydrate_hub(hydrate.HydrateHubConfig(
+                source_repo="org/private-ds", source_revision="a" * 40,
+                destination_repo="org/private-ds", stage_dir=tmp_path / "stage"), client=hub)
+        assert not any(p.endswith("_SUCCESS") for p in hub.uploaded_paths)
 
     def test_success_marker_last_and_output_sha_captured(self, tmp_path: Path) -> None:
         hub = make_fake_hub(tmp_path)
@@ -447,6 +519,32 @@ class TestDedupeAndLedger:
         hydrate.download_snapshot(hub, revision=revision, stage_dir=stage / "downloads")
         hydrate.ingest_bundles(stage, revision=revision)
         return stage
+
+    def test_collision_durable_across_reruns(self, tmp_path: Path) -> None:
+        """A collision re-quarantines on every later run; the mutated derivative
+        is never re-admitted over the published baseline (M7 durability)."""
+        hub = make_fake_hub(tmp_path)
+        hub.commit_revision("a" * 40)
+        stage = tmp_path / "stage"
+        hydrate.download_snapshot(hub, revision="a" * 40, stage_dir=stage / "downloads")
+        hydrate.ingest_bundles(stage, revision="a" * 40)
+        hydrate.dedupe_admitted(stage, revision="a" * 40)  # run 1: admit baseline
+        baseline_manifest = (stage / "runs" / "sess-a" / "manifest.json").read_bytes()
+        # mutate + re-download + re-ingest (runs 2 and 3 see the same mutated tree)
+        hub.mutate_bundle("a" * 40, "sess-a", b'{"tampered": true}')
+        for _ in range(2):
+            staged = stage / "downloads" / ("a" * 40) / "bundles" / "sess-a" / "manifest.json"
+            staged.unlink()
+            hydrate.download_snapshot(hub, revision="a" * 40, stage_dir=stage / "downloads")
+            hydrate.ingest_bundles(stage, revision="a" * 40)
+            rerun = hydrate.dedupe_admitted(stage, revision="a" * 40)
+            assert rerun.collisions == 1   # every later run re-quarantines
+            assert rerun.admitted == 0     # the mutated derivative is never admitted
+        # the admitted derivative is the restored baseline, byte for byte
+        restored = stage / "runs" / "sess-a" / "manifest.json"
+        assert restored.read_bytes() == baseline_manifest
+        from daydream.archive.index import query_runs
+        assert len(query_runs(stage)) == 1  # one session row, never overwritten
 
     def test_idempotent_rerun_no_duplicates(self, tmp_path: Path) -> None:
         stage = self._staged(tmp_path)

--- a/tests/test_archive_hydrate.py
+++ b/tests/test_archive_hydrate.py
@@ -113,3 +113,48 @@ class TestHydrateRules:
         assert hydrate_rules.legacy_pipeline_status(
             pipeline_status="unknown", deep_artifacts=None) == ("excluded", "pipeline_status_evidence_absent")
         assert hydrate_rules.legacy_pipeline_status(pipeline_status="failed", deep_artifacts=None) == "failed"
+
+
+class TestResolveRevision:
+    def test_exact_sha_passes_through(self) -> None:
+        hub = make_fake_hub(Path("/tmp"))
+        hub.commit_revision("a" * 40)
+        assert hydrate.resolve_source_revision(hub, "a" * 40, exploratory=False) == "a" * 40
+
+    def test_short_prefix_resolves_to_full_sha(self) -> None:
+        hub = make_fake_hub(Path("/tmp"))
+        hub.commit_revision("abcdef1234567890" + "0" * 24)
+        assert hydrate.resolve_source_revision(hub, "abcdef12", exploratory=False) == "abcdef1234567890" + "0" * 24
+
+    def test_moving_branch_rejected_without_optin(self) -> None:
+        hub = make_fake_hub(Path("/tmp"))
+        hub.commit_revision("a" * 40, ref="main")  # branch ref, not immutable
+        with pytest.raises(hydrate.MovingBranchError, match="exploratory"):
+            hydrate.resolve_source_revision(hub, "main", exploratory=False)
+
+    def test_moving_branch_allowed_with_exploratory_flag(self) -> None:
+        hub = make_fake_hub(Path("/tmp"))
+        hub.commit_revision("b" * 40, ref="main")
+        assert hydrate.resolve_source_revision(hub, "main", exploratory=True) == "b" * 40
+
+    def test_unknown_revision_fails_closed(self) -> None:
+        hub = make_fake_hub(Path("/tmp"))
+        with pytest.raises(hydrate.HydrationError):
+            hydrate.resolve_source_revision(hub, "deadbeef" * 5, exploratory=False)
+
+    def test_ambiguous_prefix_fails_closed(self) -> None:
+        hub = make_fake_hub(Path("/tmp"))
+        hub.commit_revision("ab12" + "1" * 36)
+        hub.commit_revision("ab12" + "2" * 36)
+        with pytest.raises(hydrate.HydrationError, match="ambiguous"):
+            hydrate.resolve_source_revision(hub, "ab12", exploratory=False)
+
+    def test_client_error_is_redacted(self) -> None:
+        class LeakyHub(FakeHub):
+            def repo_info(self, revision: str | None = None) -> hydrate.RepoInfo:
+                raise hydrate.HubDownloadError("boom https://user:hf_token_secret@huggingface.co/x")
+
+        hub = LeakyHub(repo_id="org/private-ds")
+        with pytest.raises(hydrate.HydrationError) as excinfo:
+            hydrate.resolve_source_revision(hub, "c" * 40, exploratory=False)
+        assert "hf_token_secret" not in str(excinfo.value)

--- a/tests/test_archive_hydrate.py
+++ b/tests/test_archive_hydrate.py
@@ -1,0 +1,48 @@
+"""Unit/component tests for the #982 hydrate module."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from daydream.archive import hydrate
+from daydream.archive.hydrate_client import FakeHub
+
+SNAPSHOT = {
+    "bundles/sess-a/manifest.json": b'{"session_id": "sess-a"}',
+    "bundles/sess-a/trajectory.json": b"{}",
+}
+
+
+def make_fake_hub(tmp_path: Path) -> FakeHub:
+    return FakeHub(repo_id="org/private-ds", private=True, files=dict(SNAPSHOT))
+
+
+def test_fake_hub_roundtrip_and_revision(tmp_path: Path) -> None:
+    hub = make_fake_hub(tmp_path)
+    hub.commit_revision("abc123def4567890")  # fake pins a "commit sha"
+    info = hub.repo_info(revision="abc123def4567890")
+    assert info.private is True
+    assert info.sha == "abc123def4567890"
+    assert sorted(hub.list_repo_files()) == sorted(SNAPSHOT)
+    data = hub.download_file("bundles/sess-a/manifest.json", revision="abc123def4567890")
+    assert json.loads(data)["session_id"] == "sess-a"
+
+
+def test_hf_client_missing_extra_is_fatal_and_redacted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Missing huggingface_hub is fatal for hydrate (operator command), redacted, never leaks argv."""
+    monkeypatch.setattr(hydrate, "_import_hf_hub", lambda: None)  # simulate ImportError
+    with pytest.raises(hydrate.HubUnavailableError) as excinfo:
+        hydrate._make_client("org/private-ds")
+    msg = str(excinfo.value)
+    assert "huggingface-hub" in msg
+    assert "HF_TOKEN" not in msg  # no token material in the error path
+
+
+def test_hf_client_requires_token_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    with pytest.raises(hydrate.HubUnavailableError, match="HF_TOKEN"):
+        hydrate._make_client("org/private-ds", token_present=False)

--- a/tests/test_archive_hydrate.py
+++ b/tests/test_archive_hydrate.py
@@ -1,6 +1,7 @@
 """Unit/component tests for the #982 hydrate module."""
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 
@@ -158,3 +159,61 @@ class TestResolveRevision:
         with pytest.raises(hydrate.HydrationError) as excinfo:
             hydrate.resolve_source_revision(hub, "c" * 40, exploratory=False)
         assert "hf_token_secret" not in str(excinfo.value)
+
+
+class TestDownloadSnapshot:
+    def test_clean_download_layout_and_digests(self, tmp_path: Path) -> None:
+        hub = make_fake_hub(tmp_path)
+        hub.commit_revision("a" * 40)
+        stage = tmp_path / "stage" / "downloads"
+        hydrate.download_snapshot(hub, revision="a" * 40, stage_dir=stage)
+        manifest = json.loads((stage / ("a" * 40) / "_download_manifest.json").read_text())
+        assert len(manifest["artifacts"]) == len(SNAPSHOT)
+        art = manifest["artifacts"][0]
+        assert art["relpath"].startswith("bundles/")  # paths relative to snapshot root
+        expected = hashlib.sha256(SNAPSHOT[art["relpath"]]).hexdigest()
+        assert art["sha256"] == expected
+        assert (stage / ("a" * 40) / art["relpath"]).read_bytes() == SNAPSHOT[art["relpath"]]
+
+    def test_resume_skips_verified_artifacts(self, tmp_path: Path) -> None:
+        hub = make_fake_hub(tmp_path)
+        hub.commit_revision("a" * 40)
+        stage = tmp_path / "stage" / "downloads"
+        first = hydrate.download_snapshot(hub, revision="a" * 40, stage_dir=stage)
+        assert first.downloaded == len(SNAPSHOT)
+        # interrupt: remove one artifact file, rerun — only it is re-fetched
+        manifest_path = stage / ("a" * 40) / "_download_manifest.json"
+        art = json.loads(manifest_path.read_text())["artifacts"][0]
+        (stage / ("a" * 40) / art["relpath"]).unlink()
+        hub.downloaded_log.clear()
+        second = hydrate.download_snapshot(hub, revision="a" * 40, stage_dir=stage)
+        assert second.downloaded == 1
+        assert second.skipped == len(SNAPSHOT) - 1
+
+    def test_digest_mismatch_rejects_artifact(self, tmp_path: Path) -> None:
+        hub = make_fake_hub(tmp_path)
+        hub.commit_revision("a" * 40)
+        hub.files["bundles/sess-a/manifest.json"] = b'{"session_id": "sess-a", "tampered": true}'
+        stage = tmp_path / "stage" / "downloads"
+        with pytest.raises(hydrate.StageError, match="digest"):
+            hydrate.download_snapshot(hub, revision="a" * 40, stage_dir=stage,
+                                      expect={"bundles/sess-a/manifest.json": "0" * 64})
+
+    def test_traversal_relpath_rejected(self, tmp_path: Path) -> None:
+        hub = make_fake_hub(tmp_path)
+        hub.commit_revision("a" * 40)
+        hub.files["../../escape.txt"] = b"pwned"
+        stage = tmp_path / "stage" / "downloads"
+        with pytest.raises(hydrate.StageError, match="traversal|escapes"):
+            hydrate.download_snapshot(hub, revision="a" * 40, stage_dir=stage)
+
+    def test_traversal_from_manifest_never_writes(self, tmp_path: Path) -> None:
+        """A hostile Hub listing pointing outside the staging root writes nothing outside."""
+        hub = make_fake_hub(tmp_path)
+        hub.commit_revision("a" * 40)
+        hub.files["bundles/../../outside.txt"] = b"pwned"
+        stage = tmp_path / "stage" / "downloads"
+        with pytest.raises(hydrate.StageError):
+            hydrate.download_snapshot(hub, revision="a" * 40, stage_dir=stage)
+        assert not (tmp_path / "outside.txt").exists()
+        assert not (tmp_path / "stage" / "outside.txt").exists()

--- a/tests/test_archive_hydrate.py
+++ b/tests/test_archive_hydrate.py
@@ -220,6 +220,63 @@ class TestDownloadSnapshot:
         assert not (tmp_path / "stage" / "outside.txt").exists()
 
 
+class TestPublish:
+    def _staged(self, tmp_path: Path) -> Path:
+        hub = make_fake_hub(tmp_path)
+        hub.commit_revision("a" * 40)
+        stage = tmp_path / "stage"
+        hydrate.download_snapshot(hub, revision="a" * 40, stage_dir=stage / "downloads")
+        hydrate.ingest_bundles(stage, revision="a" * 40)
+        hydrate.dedupe_admitted(stage, revision="a" * 40)
+        hydrate.build_import_ledger(stage, revision="a" * 40, source_commit="a" * 40)
+        return stage
+
+    def test_public_destination_hard_fails(self, tmp_path: Path) -> None:
+        hub = make_fake_hub(tmp_path)
+        hub.private = False
+        stage = self._staged(tmp_path)
+        cid = hydrate_rules.derive_curation_id(
+            source_commit="a" * 40, sanitizer_version="1", index_schema_version="1",
+            admission_policy_version="1")
+        with pytest.raises(hydrate.PublicDestinationError, match="private"):
+            hydrate.publish_batches(hub, stage, curation_id=cid)
+        assert not any(p.startswith("curated/") for p in hub.files)  # nothing published
+
+    def test_batches_and_ledger_under_additive_prefix(self, tmp_path: Path) -> None:
+        hub = make_fake_hub(tmp_path)
+        stage = self._staged(tmp_path)
+        cid = hydrate_rules.derive_curation_id(
+            source_commit="a" * 40, sanitizer_version="1", index_schema_version="1",
+            admission_policy_version="1")
+        hydrate.publish_batches(hub, stage, curation_id=cid)
+        prefix = f"curated/{cid}/"
+        uploaded = [p for p in hub.files if p.startswith(prefix)]
+        assert any(p.startswith(prefix + "batches/") for p in uploaded)
+        assert any(p == prefix + "resume/ledger.jsonl" for p in uploaded)
+        assert any(p == prefix + "SHA256SUMS" for p in uploaded)
+        # Bronze safety (M10/M13): only curated/… paths are ever written.
+        assert not any(p.startswith("bronze") or p.startswith("runs/") for p in hub.files)
+        ledger = json.loads(hub.files[prefix + "resume/ledger.jsonl"].decode().splitlines()[0])
+        assert ledger["session_id"] == "sess-a"
+        assert ledger["batch_digest"]
+        assert ledger["source_commit"] == "a" * 40
+        # Idempotent re-upload: same content lands at the same content-addressed paths.
+        before = dict(hub.files)
+        hydrate.publish_batches(hub, stage, curation_id=cid)
+        assert hub.files == before
+
+    def test_remote_ledger_checkpoint_enables_resume(self, tmp_path: Path) -> None:
+        hub = make_fake_hub(tmp_path)
+        stage = self._staged(tmp_path)
+        cid = "cur-" + "0" * 16
+        hydrate.publish_batches(hub, stage, curation_id=cid)
+        # a fresh VM with empty disk discovers the remote ledger and skips completed batches
+        fresh = tmp_path / "fresh"
+        state = hydrate.resume_state(hub, curation_id=cid, stage_dir=fresh)
+        assert state.completed_sessions == {"sess-a"}
+        assert state.redownloaded == []  # digests verified remotely, nothing refetched
+
+
 def _staged_with(tmp_path: Path, remote_urls: dict[str, str | None]) -> Path:
     """Stage a tree: ingest + index admitted bundles carrying the given remote URLs."""
     files: dict[str, bytes] = {}

--- a/tests/test_archive_hydrate.py
+++ b/tests/test_archive_hydrate.py
@@ -329,3 +329,78 @@ class TestIngestAndIndex:
         stage = self._staged(tmp_path)
         hydrate.ingest_bundles(stage, revision="a" * 40)
         assert not list((stage / "runs").rglob(".git"))
+
+
+class TestDedupeAndLedger:
+    def _staged(self, tmp_path: Path, revision: str = "a" * 40) -> Path:
+        hub = make_fake_hub(tmp_path)
+        hub.commit_revision(revision)
+        stage = tmp_path / "stage"
+        hydrate.download_snapshot(hub, revision=revision, stage_dir=stage / "downloads")
+        hydrate.ingest_bundles(stage, revision=revision)
+        return stage
+
+    def test_idempotent_rerun_no_duplicates(self, tmp_path: Path) -> None:
+        stage = self._staged(tmp_path)
+        first = hydrate.dedupe_admitted(stage, revision="a" * 40)
+        assert first.admitted == 1 and first.collisions == 0
+        second = hydrate.dedupe_admitted(stage, revision="a" * 40)  # same content re-run
+        assert second.admitted == 1 and second.collisions == 0
+        from daydream.archive.index import query_runs
+        assert len(query_runs(stage)) == 1  # no duplicate rows
+
+    def test_identity_collision_quarantined(self, tmp_path: Path) -> None:
+        hub = make_fake_hub(tmp_path)
+        hub.commit_revision("a" * 40)
+        stage = tmp_path / "stage"
+        hydrate.download_snapshot(hub, revision="a" * 40, stage_dir=stage / "downloads")
+        hydrate.ingest_bundles(stage, revision="a" * 40)
+        hydrate.dedupe_admitted(stage, revision="a" * 40)
+        # same session identity, different content -> quarantine, never overwrite
+        hub.files["bundles/sess-a/trajectory.json"] = b'{"different": true}'
+        hub.commit_revision("a" * 40)  # re-pin the mutated tree at the same revision
+        stage2_dir = stage / "downloads"
+        # re-download only the changed file then re-ingest into the same stage
+        (stage2_dir / ("a" * 40) / "bundles/sess-a/trajectory.json").unlink()
+        hydrate.download_snapshot(hub, revision="a" * 40, stage_dir=stage2_dir)
+        hydrate.ingest_bundles(stage, revision="a" * 40)
+        result = hydrate.dedupe_admitted(stage, revision="a" * 40)
+        assert result.collisions == 1
+        assert (stage / "quarantine" / "sess-a.conflict").exists() or \
+            result.collision_ids == ["sess-a"]
+        from daydream.archive.index import query_runs
+        rows = [r for r in query_runs(stage) if r["session_id"] == "sess-a"]
+        assert len(rows) == 1  # original retained, never overwritten
+
+    def test_fixture_bundle_excluded_with_code(self, tmp_path: Path) -> None:
+        hub = make_fake_hub(tmp_path)
+        hub.files["bundles/sess-fixture/manifest.json"] = (
+            b'{"session_id": "sess-fixture", "source_path": "/tmp/pytest-of-user/test_x"}'
+        )
+        hub.commit_revision("a" * 40)
+        stage = tmp_path / "stage"
+        hydrate.download_snapshot(hub, revision="a" * 40, stage_dir=stage / "downloads")
+        hydrate.ingest_bundles(stage, revision="a" * 40)
+        result = hydrate.dedupe_admitted(stage, revision="a" * 40)
+        assert ("sess-fixture", "fixture_pytest_path") in result.excluded
+        assert not (stage / "runs" / "sess-fixture").exists()  # never indexed/harvest-visible
+
+    def test_ledger_is_value_free(self, tmp_path: Path) -> None:
+        hub = make_fake_hub(tmp_path)
+        hub.files["bundles/sess-bad/manifest.json"] = (
+            b'{"session_id": "sess-bad", "remote_url": "https://user:hunter2@github.com/o/r"}'
+        )
+        hub.commit_revision("a" * 40)
+        stage = tmp_path / "stage"
+        hydrate.download_snapshot(hub, revision="a" * 40, stage_dir=stage / "downloads")
+        hydrate.ingest_bundles(stage, revision="a" * 40)
+        ledger = hydrate.build_import_ledger(stage, revision="a" * 40, source_commit="a" * 40)
+        text = json.dumps(ledger)
+        assert "hunter2" not in text and "user:" not in text  # no matched secret values (M11)
+        assert ledger["pinned_revision"] == "a" * 40
+        assert {"imported", "quarantined", "excluded", "rejections"} <= set(ledger)
+        assert any(e["session_id"] == "sess-bad" for e in ledger["quarantined"])
+        # ledger file persisted under the curated prefix, atomically
+        ledger_path = stage / "curated" / ledger["curation_id"] / "import-ledger.json"
+        assert ledger_path.is_file()
+        assert json.loads(ledger_path.read_text())["pinned_revision"] == "a" * 40

--- a/tests/test_archive_hydrate.py
+++ b/tests/test_archive_hydrate.py
@@ -220,6 +220,54 @@ class TestDownloadSnapshot:
         assert not (tmp_path / "stage" / "outside.txt").exists()
 
 
+def _staged_with(tmp_path: Path, remote_urls: dict[str, str | None]) -> Path:
+    """Stage a tree: ingest + index admitted bundles carrying the given remote URLs."""
+    files: dict[str, bytes] = {}
+    for sid, url in remote_urls.items():
+        manifest: dict[str, str] = {"session_id": sid}
+        if url is not None:
+            manifest["remote_url"] = url
+        files[f"bundles/{sid}/manifest.json"] = json.dumps(manifest).encode()
+        files[f"bundles/{sid}/trajectory.json"] = b"{}"
+    hub = FakeHub(repo_id="org/private-ds", private=True, files=files)
+    hub.commit_revision("a" * 40)
+    stage = tmp_path / "stage"
+    hydrate.download_snapshot(hub, revision="a" * 40, stage_dir=stage / "downloads")
+    hydrate.ingest_bundles(stage, revision="a" * 40)
+    hydrate.rebuild_index(stage)
+    return stage
+
+
+class TestResolutionMap:
+    def test_map_records_slug_and_pinned_sha_no_raw_urls(self, tmp_path: Path) -> None:
+        stage = _staged_with(tmp_path, remote_urls={
+            "sess-a": "https://github.com/octo/repo",
+            "sess-b": None,
+        })
+        cmap = hydrate.build_resolution_map(stage, source_commit="a" * 40)
+        entry = cmap["octo/repo"]
+        assert entry["pinned_sha"].startswith("a" * 8) or entry["pinned_sha"] == "a" * 40
+        assert "raw_url" not in entry and "source_path" not in entry
+        assert "https://github.com/octo/repo" not in json.dumps(cmap)  # raw URL is data, not output
+
+    def test_non_allowlisted_host_reported_not_cloned(self, tmp_path: Path) -> None:
+        stage = _staged_with(tmp_path, remote_urls={"sess-c": "https://gitlab.com/x/y"})
+        cmap = hydrate.build_resolution_map(stage, source_commit="a" * 40)
+        assert cmap["unavailable"] == ["sess-c"]     # reported, no fallback, no clone attempted
+        assert "gitlab.com" not in json.dumps(cmap)  # redacted from published metadata
+
+    def test_no_clone_during_hydration(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        import daydream.git_ops as git_ops
+
+        def boom(*a: object, **k: object) -> None:
+            raise AssertionError("hydration must not clone")
+
+        monkeypatch.setattr(git_ops, "clone_with_token", boom)
+        monkeypatch.setattr(git_ops, "fetch", boom)
+        stage = _staged_with(tmp_path, remote_urls={"sess-a": "https://github.com/octo/repo"})
+        hydrate.build_resolution_map(stage, source_commit="a" * 40)  # must not raise
+
+
 class TestIngestAndIndex:
     def _staged(self, tmp_path: Path, revision: str = "a" * 40) -> Path:
         hub = make_fake_hub(tmp_path)

--- a/tests/test_archive_hydrate.py
+++ b/tests/test_archive_hydrate.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import pathlib
 from pathlib import Path
 
 import pytest
@@ -217,3 +218,66 @@ class TestDownloadSnapshot:
             hydrate.download_snapshot(hub, revision="a" * 40, stage_dir=stage)
         assert not (tmp_path / "outside.txt").exists()
         assert not (tmp_path / "stage" / "outside.txt").exists()
+
+
+class TestIngestAndIndex:
+    def _staged(self, tmp_path: Path, revision: str = "a" * 40) -> Path:
+        hub = make_fake_hub(tmp_path)
+        hub.commit_revision(revision)
+        stage = tmp_path / "stage"
+        hydrate.download_snapshot(hub, revision=revision, stage_dir=stage / "downloads")
+        return stage
+
+    def test_clean_bundle_ingested_and_indexed_staging_local(self, tmp_path: Path) -> None:
+        stage = self._staged(tmp_path)
+        results = hydrate.ingest_bundles(stage, revision="a" * 40)
+        assert [r.status for r in results] == ["admitted"]
+        row_dir = stage / "runs" / "sess-a"
+        assert row_dir.is_dir()
+        # index row carries staging-local paths only
+        from daydream.archive.index import query_runs
+        hydrate.rebuild_index(stage)
+        rows = query_runs(stage)
+        assert len(rows) == 1
+        assert rows[0]["archive_path"].startswith(str(stage))     # inside staging root
+        assert "downloads" not in rows[0]["archive_path"]         # not the raw download path
+        assert rows[0]["source_path"] is None or not Path(rows[0]["source_path"]).is_absolute() or \
+            rows[0]["source_path"].startswith(str(stage))
+
+    def test_dirty_bundle_quarantined_never_visible(self, tmp_path: Path) -> None:
+        hub = make_fake_hub(tmp_path)
+        hub.files["bundles/sess-bad/manifest.json"] = \
+            b'{"session_id": "sess-bad", "remote_url": "https://user:hunter2@github.com/o/r"}'
+        hub.commit_revision("a" * 40)
+        stage = tmp_path / "stage"
+        hydrate.download_snapshot(hub, revision="a" * 40, stage_dir=stage / "downloads")
+        results = hydrate.ingest_bundles(stage, revision="a" * 40)
+        bad = [r for r in results if r.session_id == "sess-bad"]
+        assert bad and bad[0].status == "quarantined"
+        assert bad[0].reason_code == "secrets_scan_dirty"
+        # never visible to the index / harvest
+        hydrate.rebuild_index(stage)
+        from daydream.archive.index import query_runs
+        assert all(row["session_id"] != "sess-bad" for row in query_runs(stage))
+        assert (stage / "quarantine" / "sess-bad").exists()
+
+    def test_embedded_paths_never_dereferenced(self, tmp_path: Path) -> None:
+        hub = make_fake_hub(tmp_path)
+        hub.files["bundles/sess-evil/manifest.json"] = (
+            b'{"session_id": "sess-evil", "archive_path": "/etc", "source_path": "/usr",'
+            b' "remote_url": "file:///etc/passwd"}'
+        )
+        hub.commit_revision("a" * 40)
+        stage = tmp_path / "stage"
+        hydrate.download_snapshot(hub, revision="a" * 40, stage_dir=stage / "downloads")
+        results = hydrate.ingest_bundles(stage, revision="a" * 40)
+        evil = [r for r in results if r.session_id == "sess-evil"]
+        assert evil and evil[0].status == "quarantined"   # non-allowlisted host fails closed
+        # nothing outside staging was touched
+        assert not pathlib.Path("/etc/passwd.git").exists()
+
+    def test_bundles_exclude_git_dirs(self, tmp_path: Path) -> None:
+        """Task 0B constraint: no .git ships inside hydrated bundles (harvest priority-1 safety)."""
+        stage = self._staged(tmp_path)
+        hydrate.ingest_bundles(stage, revision="a" * 40)
+        assert not list((stage / "runs").rglob(".git"))

--- a/tests/test_archive_hydrate.py
+++ b/tests/test_archive_hydrate.py
@@ -6,8 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from daydream.archive import hydrate
-from daydream.archive import hydrate_rules
+from daydream.archive import hydrate, hydrate_rules
 from daydream.archive.hydrate_client import FakeHub
 
 SNAPSHOT = {
@@ -35,7 +34,7 @@ class TestCurationManifestSchema:
     SCHEMA = Path(hydrate_rules.__file__).parent.parent / "training" / "schema" / "curation-manifest-v1.json"
     FIXTURE = Path(__file__).parent / "fixtures" / "training" / "curation-manifest-v1-fixture.json"
 
-    def _validate(self, instance: dict) -> None:
+    def _validate(self, instance: dict[str, object]) -> None:
         from jsonschema import Draft202012Validator
 
         Draft202012Validator(json.loads(self.SCHEMA.read_text())).validate(instance)
@@ -82,3 +81,35 @@ def test_hf_client_requires_token_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("HF_TOKEN", raising=False)
     with pytest.raises(hydrate.HubUnavailableError, match="HF_TOKEN"):
         hydrate._make_client("org/private-ds", token_present=False)
+
+
+class TestHydrateRules:
+    def test_curation_id_deterministic(self) -> None:
+        kwargs = dict(source_commit="a" * 40, sanitizer_version="1.0.0",
+                      index_schema_version="1", admission_policy_version="1")
+        first = hydrate_rules.derive_curation_id(**kwargs)
+        assert first == hydrate_rules.derive_curation_id(**kwargs)
+        assert first == hydrate_rules.derive_curation_id(**kwargs)  # stable across calls
+        assert hydrate_rules.CURATION_ID_RE.fullmatch(first)
+
+    def test_curation_id_inputs_sensitive(self) -> None:
+        base = dict(source_commit="a" * 40, sanitizer_version="1.0.0",
+                    index_schema_version="1", admission_policy_version="1")
+        ids = {hydrate_rules.derive_curation_id(**{**base, k: v})
+               for k, v in [("source_commit", "b" * 40), ("sanitizer_version", "1.0.1"),
+                            ("admission_policy_version", "2")]}
+        assert len(ids) == 3  # every input changes the id
+        assert hydrate_rules.derive_curation_id(**base) not in ids
+
+    def test_fixture_exclusion_reason_codes(self, tmp_path: Path) -> None:
+        (tmp_path / "manifest.json").write_text('{"session_id": "s", "source_path": "/tmp/pytest-of-user/x"}')
+        codes = hydrate_rules.fixture_exclusion_codes(tmp_path)
+        assert "fixture_pytest_path" in codes
+
+    def test_pipeline_status_policy(self) -> None:
+        # evidence present → revalidated value; absent → stable code, never success
+        assert hydrate_rules.legacy_pipeline_status(
+            pipeline_status="unknown", deep_artifacts={"status": "succeeded"}) == "succeeded"
+        assert hydrate_rules.legacy_pipeline_status(
+            pipeline_status="unknown", deep_artifacts=None) == ("excluded", "pipeline_status_evidence_absent")
+        assert hydrate_rules.legacy_pipeline_status(pipeline_status="failed", deep_artifacts=None) == "failed"

--- a/tests/test_archive_hydrate_integration.py
+++ b/tests/test_archive_hydrate_integration.py
@@ -112,6 +112,16 @@ class TestCollision:
         )
         quarantined = {e["session_id"]: e["reason_code"] for e in ledger["quarantined"]}
         assert quarantined.get("sess-a") == hydrate_rules.REASON_CODE_IDENTITY_COLLISION
+        # the published curation manifest lists the collided session exactly once,
+        # as quarantined at the real collision directory (never double-listed)
+        manifest = json.loads(
+            hub.files[f"curated/{rerun.curation_id}/curation-manifest.json"].decode()
+        )
+        sess_rows = [b for b in manifest["batches"] if b["session_id"] == "sess-a"]
+        assert len(sess_rows) == 1
+        assert sess_rows[0]["status"] == "quarantined"
+        assert sess_rows[0]["reason_code"] == hydrate_rules.REASON_CODE_IDENTITY_COLLISION
+        assert sess_rows[0]["artifact_relpath"] == "quarantine/sess-a.conflict"
 
 
 class TestPathTraversal:

--- a/tests/test_archive_hydrate_integration.py
+++ b/tests/test_archive_hydrate_integration.py
@@ -1,0 +1,133 @@
+"""Offline end-to-end hydrate tests over a local fake Hub snapshot (M22).
+
+No network: the snapshot is materialized in-memory by build_hub_snapshot.py and
+served by hydrate_client.FakeHub. Scenarios: clean import, interruption/resume,
+identity collision, path traversal, deterministic re-index — plus bronze
+immutability (M10).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from daydream.archive import hydrate, hydrate_rules
+from daydream.archive.hydrate_client import FakeHub
+from tests.fixtures.training.build_hub_snapshot import SNAPSHOT_REVISION, build_snapshot
+
+REVISION = SNAPSHOT_REVISION  # 40-hex pinned by the fixture builder
+
+# Index fields that legitimately differ between two staging roots (staging-local
+# paths) or across runs (row timestamps) — determinism is asserted on the rest.
+_VOLATILE_ROW_KEYS = frozenset({"archive_path", "source_path", "created_at", "updated_at"})
+
+
+@pytest.fixture()
+def hub() -> FakeHub:
+    return build_snapshot()  # repo org/private-ds, private, bundles for 3 sessions
+
+
+def _config(stage: Path) -> hydrate.HydrateHubConfig:
+    return hydrate.HydrateHubConfig(
+        source_repo="org/private-ds",
+        source_revision=REVISION,
+        destination_repo="org/private-ds",
+        stage_dir=stage,
+    )
+
+
+def _index_rows(stage: Path) -> list[dict[str, object]]:
+    from daydream.archive.index import query_runs
+
+    return [
+        {k: v for k, v in row.items() if k not in _VOLATILE_ROW_KEYS}
+        for row in query_runs(stage)
+    ]
+
+
+class TestCleanImport:
+    def test_hydrate_discovers_all_snapshot_sessions(self, hub: FakeHub, tmp_path: Path) -> None:
+        stage = tmp_path / "stage"
+        summary = hydrate.run_hydrate_hub(_config(stage), client=hub)
+        assert summary.verified
+        # M1: the hydrated staging archive is harvest-discoverable from disk alone.
+        from daydream.archive.index import count_runs
+
+        assert count_runs(stage) == 3
+
+    def test_bronze_never_mutated(self, hub: FakeHub, tmp_path: Path) -> None:
+        before = dict(hub.files)
+        hydrate.run_hydrate_hub(_config(tmp_path / "stage"), client=hub)
+        # M10: files only gain curated/ keys; bronze and every pre-existing key
+        # are byte-identical after the run.
+        for key, content in before.items():
+            if key.startswith("curated/"):
+                continue
+            assert hub.files.get(key) == content, f"pre-existing Hub file {key!r} was mutated"
+        new_keys = set(hub.files) - set(before)
+        assert new_keys and all(k.startswith("curated/") for k in new_keys)
+        assert not any(k.startswith("bronze/") for k in new_keys)
+
+
+class TestInterruptionResume:
+    def test_resume_after_kill_completes_without_duplicates(self, hub: FakeHub, tmp_path: Path) -> None:
+        stage = tmp_path / "stage"
+        # interrupt: download only, then "kill" — no ingest, no ledger, no index.
+        hydrate.download_snapshot(hub, revision=REVISION, stage_dir=stage / "downloads")
+        # fresh VM simulation: empty disk except the remote ledger — resume via
+        # resume_state (Hub ledger is the only canonical resume state, M15).
+        curation_id = hydrate_rules.derive_curation_id(
+            source_commit=REVISION, sanitizer_version=hydrate_rules.SANITIZER_VERSION,
+            index_schema_version=hydrate_rules.HYDRATION_INDEX_SCHEMA_VERSION,
+            admission_policy_version=hydrate_rules.ADMISSION_POLICY_VERSION,
+        )
+        state = hydrate.resume_state(
+            hub, curation_id=curation_id, stage_dir=tmp_path / "fresh"
+        )
+        assert state.completed_sessions is not None
+        summary = hydrate.run_hydrate_hub(_config(stage), client=hub)
+        assert summary.verified
+        from daydream.archive.index import count_runs
+
+        assert count_runs(stage) == 3  # no duplicate sessions after resume
+
+
+class TestCollision:
+    def test_same_identity_different_content_quarantines(self, hub: FakeHub, tmp_path: Path) -> None:
+        stage = tmp_path / "stage"
+        hydrate.run_hydrate_hub(_config(stage), client=hub)
+        hub.mutate_bundle(REVISION, "sess-a", b'{"tampered": true}')  # same identity, new content
+        # simulate the resumed download re-fetching the mutated bundle
+        staged = stage / "downloads" / REVISION / "bundles" / "sess-a" / "manifest.json"
+        staged.unlink()
+        rerun = hydrate.run_hydrate_hub(_config(stage), client=hub)  # collision is reported, not silent
+        from daydream.archive.index import query_runs
+
+        rows = [r for r in query_runs(stage) if r["session_id"] == "sess-a"]
+        assert len(rows) == 1  # original intact
+        # the collision is a recorded rejection with the stable reason code
+        ledger = json.loads(
+            (stage / "curated" / rerun.curation_id / "import-ledger.json").read_text()
+        )
+        quarantined = {e["session_id"]: e["reason_code"] for e in ledger["quarantined"]}
+        assert quarantined.get("sess-a") == hydrate_rules.REASON_CODE_IDENTITY_COLLISION
+
+
+class TestPathTraversal:
+    def test_hostile_snapshot_escapes_nothing(self, tmp_path: Path) -> None:
+        hub = build_snapshot(hostile=True)  # adds ../../ and /etc-style relpaths
+        with pytest.raises(hydrate.HydrationError):
+            hydrate.run_hydrate_hub(_config(tmp_path / "stage"), client=hub)
+        assert not (tmp_path / "escape.txt").exists()
+        assert not (tmp_path / "etc").exists()
+
+
+class TestDeterministicReindex:
+    def test_rerun_yields_identical_index_and_curation_id(self, hub: FakeHub, tmp_path: Path) -> None:
+        s1 = hydrate.run_hydrate_hub(_config(tmp_path / "a"), client=hub)
+        s2 = hydrate.run_hydrate_hub(_config(tmp_path / "b"), client=hub)
+        assert s1.curation_id == s2.curation_id  # M14
+        rows1 = sorted(json.dumps(r, sort_keys=True) for r in _index_rows(tmp_path / "a"))
+        rows2 = sorted(json.dumps(r, sort_keys=True) for r in _index_rows(tmp_path / "b"))
+        assert rows1 == rows2  # deterministic re-index (modulo staging-local paths)

--- a/tests/test_cli_hydrate.py
+++ b/tests/test_cli_hydrate.py
@@ -1,0 +1,57 @@
+"""CLI wiring tests for `daydream corpus hydrate-hub` (#982 M1/M2/M17)."""
+from __future__ import annotations
+
+import pytest
+
+from daydream import cli
+
+
+def test_hydrate_hub_requires_explicit_args(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = cli._handle_hydrate_hub_command([])
+    assert rc == 1
+    assert "--source-repo" in capsys.readouterr().out
+
+
+def test_hydrate_hub_rejects_moving_branch_without_optin(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = cli._handle_hydrate_hub_command(
+        ["--source-repo", "org/ds", "--source-revision", "main",
+         "--destination-repo", "org/ds", "--stage-dir", "/tmp/x"])
+    assert rc == 1
+    assert "exploratory" in capsys.readouterr().out
+
+
+def test_hydrate_hub_missing_token_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    rc = cli._handle_hydrate_hub_command(
+        ["--source-repo", "org/ds", "--source-revision", "a" * 40,
+         "--destination-repo", "org/ds", "--stage-dir", "/tmp/x"])
+    assert rc == 1
+
+
+def test_help_lists_hydrate_hub(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit):
+        cli.main(["corpus", "hydrate-hub", "--help"])
+    assert "hydrate-hub" in capsys.readouterr().out
+
+
+def test_success_path_drives_orchestrator(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    calls: list[object] = []
+
+    class FakeSummary:
+        curation_id = "cur-" + "0" * 16
+        output_commit_sha = "b" * 40
+        verified = True
+        dry_run_admitted = 1
+        verify_admitted = 1
+
+    def fake_run(config):
+        calls.append(config)
+        return FakeSummary()
+
+    monkeypatch.setenv("HF_TOKEN", "t")
+    monkeypatch.setattr(cli, "_run_hydrate_hub", fake_run, raising=False)
+    rc = cli._handle_hydrate_hub_command(
+        ["--source-repo", "org/ds", "--source-revision", "a" * 40,
+         "--destination-repo", "org/ds", "--stage-dir", str(tmp_path)])
+    assert rc == 0
+    assert calls and calls[0].source_revision == "a" * 40

--- a/tests/test_cli_hydrate.py
+++ b/tests/test_cli_hydrate.py
@@ -1,6 +1,9 @@
 """CLI wiring tests for `daydream corpus hydrate-hub` (#982 M1/M2/M17)."""
 from __future__ import annotations
 
+import pathlib
+from typing import Any
+
 import pytest
 
 from daydream import cli
@@ -34,8 +37,10 @@ def test_help_lists_hydrate_hub(capsys: pytest.CaptureFixture[str]) -> None:
     assert "hydrate-hub" in capsys.readouterr().out
 
 
-def test_success_path_drives_orchestrator(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
-    calls: list[object] = []
+def test_success_path_drives_orchestrator(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    calls: list[Any] = []
 
     class FakeSummary:
         curation_id = "cur-" + "0" * 16
@@ -44,7 +49,7 @@ def test_success_path_drives_orchestrator(monkeypatch: pytest.MonkeyPatch, tmp_p
         dry_run_admitted = 1
         verify_admitted = 1
 
-    def fake_run(config):
+    def fake_run(config: Any) -> FakeSummary:
         calls.append(config)
         return FakeSummary()
 

--- a/tests/test_subprocess_lifecycle.py
+++ b/tests/test_subprocess_lifecycle.py
@@ -112,7 +112,7 @@ async def _wait_for_file(path: Path, *, timeout_s: float = 60.0) -> None:
         await asyncio.sleep(0.01)
 
 
-async def _wait_for_group_gone(pgid: int, *, timeout_s: float = 10.0) -> None:
+async def _wait_for_group_gone(pgid: int, *, timeout_s: float = 30.0) -> None:
     """Await *pgid*'s disappearance (a readiness wait, not a fixed sleep).
 
     A group-signal kill reaps the direct child synchronously, but a grandchild
@@ -138,7 +138,7 @@ async def _wait_for_group_gone(pgid: int, *, timeout_s: float = 10.0) -> None:
         await asyncio.sleep(0.01)
 
 
-async def _wait_for_fd_count(base: int, *, timeout_s: float = 10.0) -> None:
+async def _wait_for_fd_count(base: int, *, timeout_s: float = 30.0) -> None:
     """Await the fd count's return to *base* (a readiness wait, not a fixed sleep).
 
     The transport close releases the pipe fds, but the release lands in the

--- a/uv.lock
+++ b/uv.lock
@@ -608,6 +608,9 @@ dependencies = [
 benchmark = [
     { name = "harbor" },
 ]
+hub = [
+    { name = "huggingface-hub" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -628,6 +631,7 @@ requires-dist = [
     { name = "claude-agent-sdk", specifier = "==0.2.116" },
     { name = "harbor", marker = "extra == 'benchmark'", specifier = ">=0.22,<0.23" },
     { name = "httpx", specifier = ">=0.28" },
+    { name = "huggingface-hub", marker = "extra == 'hub'", specifier = ">=0.26" },
     { name = "jsonschema", specifier = ">=4.0" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pyfiglet", specifier = ">=1.0" },
@@ -640,7 +644,7 @@ requires-dist = [
     { name = "tree-sitter-rust", specifier = "==0.24.2" },
     { name = "tree-sitter-typescript", specifier = "==0.23.2" },
 ]
-provides-extras = ["benchmark"]
+provides-extras = ["benchmark", "hub"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
Implements the corpus `hydrate-hub` pipeline (issue #982), including:
- HubClient protocol + lazy HfHubClient + offline FakeHub for tests
- Frozen curation-manifest-v1 schema; curation-id derivation; exclusion registry; pipeline_status policy
- Pinned-revision resolution with moving-branch rejection
- Resumable content-addressed download with traversal rejection
- Staging-local index rebuild behind the #981 ingest gate; deferred-clone repo resolution map
- Content-addressed dedupe, collision quarantine, value-free ledger
- Additive publication with private-destination hard fail; remote resume ledger
- Finalization with _SUCCESS-last ordering and verify-before-success cycle
- CLI `corpus hydrate-hub` wiring; offline M22 integration scenarios
- Round-1 and round-2 daydream review fixes (traversal bounds hardening, manifest labeling, stale _SUCCESS handling, verify-publication traversal guard)

Out-of-scope follow-up: `delete_runs` in daydream/archive/index.py — tracked in #1002.

## Test Plan
- hydrate+archive suite: 266 tests pass
- Full suite: 4902 passed / 28 pre-existing benchmark failures (fail identically at base 2c599cd, unrelated)
- Authorship gate: AUTHORS_OK (all commits Kevin Anderson)

Closes #982