### PR TITLE
docs: document DAYDREAM_GIT_TOKEN harvest clone auth (README + CLAUDE.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,6 +219,7 @@ Full contract: `docs/extensions.md`.
 | `DAYDREAM_BOT_HANDLE` | Actions | Mention handle (no `@`) used by the `@<bot> review` command |
 | `DAYDREAM_EXT_DIR` | Extensions | Path to `daydream_ext` (overrides `import daydream_ext`) |
 | `DAYDREAM_GH_TIMEOUT_SECONDS` / `_RETRIES` | Git ops | `gh` CLI timeout and retry count |
+| `DAYDREAM_GIT_TOKEN` | Harvest | Optional out-of-band auth for sanitized repo clones during `corpus harvest` of private repos (e.g. a GitHub PAT); injected via git config environment variables (`http.extraHeader`), **never embedded in the remote URL** and **never on the command line**. Without it, plain clone via the ambient credential helper |
 | `DAYDREAM_TRAJECTORY_HUB_REPO` | Archive | Optional HuggingFace dataset repo to upload each run's bundle to; one of the two operator sources (the other is the CLI `--trajectory-hub-repo` flag). The target checkout's file config is ignored for this |
 | `PI_PROVIDER` / `PI_THINKING` | Pi | `--provider` / `--thinking`; `PI_THINKING` loses to a per-phase `reasoning_effort` |
 | `PI_API_KEY` | Pi | Copied into the child's provider-native var (e.g. `ZAI_API_KEY`), **never onto argv**; warns and ignores if the provider has no mapped var |

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ The pipeline has three stages:
 2. **Label.** Override the automated outcome for a run. The manual label beats the automated label.
 3. **Build.** Project the annotations into a JSONL training corpus. Add a lineage manifest.
 
-The harvest stage clones the target repository into a local cache before scoring. Setting `DAYDREAM_GIT_TOKEN` (for example, a GitHub PAT with read access) authenticates clones of private repos. The token is injected out-of-band via git config environment variables (`http.extraHeader`). It is never embedded in the remote URL and never on the command line. Without the token, the harvest stage performs a plain clone via the ambient credential helper. A failed clone emits a warning and never blocks the harvest run. The token is only needed for private repos.
+The harvest stage clones the target repository into a local cache before scoring. Setting `DAYDREAM_GIT_TOKEN` (for example, a GitHub PAT with read access) authenticates clones of private repos. The token is injected out-of-band via git config environment variables (`http.extraHeader`). It is never embedded in the remote URL and never on the command line. Without the token, the harvest stage performs a plain clone via the ambient credential helper. A failed clone emits a warning and never blocks the harvest run. The token is only needed for private repos. See docs/runbooks/credential-remediation.md for operational guidance.
 
 The build stage applies a temporal-leakage guard. It prevents future data from leaking into the past. It applies C5, C8, and C9 filters. It stratifies the corpus by stack.
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ The pipeline has three stages:
 2. **Label.** Override the automated outcome for a run. The manual label beats the automated label.
 3. **Build.** Project the annotations into a JSONL training corpus. Add a lineage manifest.
 
-The harvest stage clones the target repository into a local cache before scoring. Setting `DAYDREAM_GIT_TOKEN` (for example, a GitHub PAT with read access) authenticates clones of private repos. The token is injected out-of-band via git config environment variables (`http.extraHeader`). It is never embedded in the remote URL and never on the command line. Without the token, the harvest stage performs a plain clone via the ambient credential helper. A failed clone emits a warning and never blocks the harvest run. The token is only needed for private repos. See docs/runbooks/credential-remediation.md for operational guidance.
+The harvest stage clones the target repository into a local cache before scoring. Setting `DAYDREAM_GIT_TOKEN` (for example, a GitHub PAT with read access) authenticates clones of private repos. The token is injected out-of-band via git config environment variables (`http.extraHeader`). It is never embedded in the remote URL and never on the command line. Without the token, the harvest stage performs a plain clone via the ambient credential helper. A failed clone emits a warning and never blocks the harvest run. The token is only needed for private repos.
 
 The build stage applies a temporal-leakage guard. It prevents future data from leaking into the past. It applies C5, C8, and C9 filters. It stratifies the corpus by stack.
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ The pipeline has three stages:
 2. **Label.** Override the automated outcome for a run. The manual label beats the automated label.
 3. **Build.** Project the annotations into a JSONL training corpus. Add a lineage manifest.
 
+The harvest stage clones the target repository into a local cache before scoring. Setting `DAYDREAM_GIT_TOKEN` (for example, a GitHub PAT with read access) authenticates clones of private repos. The token is injected out-of-band via git config environment variables (`http.extraHeader`). It is never embedded in the remote URL and never on the command line. Without the token, the harvest stage performs a plain clone via the ambient credential helper. A failed clone emits a warning and never blocks the harvest run. The token is only needed for private repos. See docs/runbooks/credential-remediation.md for operational guidance.
+
 The build stage applies a temporal-leakage guard. It prevents future data from leaking into the past. It applies C5, C8, and C9 filters. It stratifies the corpus by stack.
 
 ### Scoring

--- a/tests/test_deadcode_docs.py
+++ b/tests/test_deadcode_docs.py
@@ -12,7 +12,7 @@ def test_readme_documents_git_token() -> None:
     readme = (REPO / "README.md").read_text()
     assert "`DAYDREAM_GIT_TOKEN`" in readme
     assert "never embedded in the remote URL" in readme
-    assert "never" in readme and "command line" in readme
+    assert "never on the command line" in readme
 
 
 def test_claude_md_git_token_row() -> None:

--- a/tests/test_deadcode_docs.py
+++ b/tests/test_deadcode_docs.py
@@ -15,6 +15,16 @@ def test_readme_documents_git_token() -> None:
     assert "never" in readme and "command line" in readme
 
 
+def test_claude_md_git_token_row() -> None:
+    table_row = "| `DAYDREAM_GIT_TOKEN` | Harvest |"
+    assert table_row in CLAUDE_MD
+    idx_token = CLAUDE_MD.index("DAYDREAM_GH_TIMEOUT_SECONDS")
+    idx_new = CLAUDE_MD.index("`DAYDREAM_GIT_TOKEN`")
+    idx_hub = CLAUDE_MD.index("`DAYDREAM_TRAJECTORY_HUB_REPO`")
+    assert idx_token < idx_new < idx_hub
+    assert "http.extraHeader" in CLAUDE_MD
+
+
 def test_check_definition_stays_in_sync_with_makefile() -> None:
     """The commands block must list every dep from Makefile's check: target, in order."""
     check_line = next(

--- a/tests/test_deadcode_docs.py
+++ b/tests/test_deadcode_docs.py
@@ -8,6 +8,13 @@ def test_claude_md_commands_list_deadcode() -> None:
     assert "make deadcode" in CLAUDE_MD
 
 
+def test_readme_documents_git_token() -> None:
+    readme = (REPO / "README.md").read_text()
+    assert "`DAYDREAM_GIT_TOKEN`" in readme
+    assert "never embedded in the remote URL" in readme
+    assert "never" in readme and "command line" in readme
+
+
 def test_check_definition_stays_in_sync_with_makefile() -> None:
     """The commands block must list every dep from Makefile's check: target, in order."""
     check_line = next(


### PR DESCRIPTION
## Summary
- Document DAYDREAM_GIT_TOKEN harvest clone auth in README.md and CLAUDE.md env variable table
- Link credential remediation runbook in harvest docs
- Add tests/test_deadcode_docs.py covering the doc wiring

## Test Plan
- [x] Full suite green (4816 passed, 21 skipped, 0 failed; coverage 86.96%) per round-2 review run

Closes #1025