### PR TITLE
training: project per-finding semantic labels and native-profile traces into corpus v2

### DIFF
--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -561,7 +561,7 @@ def _build_build_corpus_v2_parser() -> argparse.ArgumentParser:
         required=True,
         metavar="DIR",
         help="Hydrated curated-bundle root (must contain _SUCCESS, SHA256SUMS, "
-        "curation-manifest-v1.json)",
+        "curation-manifest.json)",
     )
     parser.add_argument(
         "--annotations-snapshot",
@@ -645,12 +645,19 @@ def _handle_build_corpus_v2_command(argv: list[str]) -> int:
     # (corpus.jsonl, split manifests, lineage.json) into that directory, and
     # corpus-v2.jsonl is published beside them as the versioned corpus.
     out_dir = args.out.parent
-    config = BuildCorpusV2Config(
-        out_dir=out_dir,
-        bundle_dir=args.bundle_root,
-        annotations_snapshot=args.annotations_snapshot,
-        as_of=args.as_of,
-    )
+    try:
+        # BuildCorpusV2Config is the single validation boundary for --as-of
+        # (UTC-only, canonical +00:00 spelling out) — normalize_as_of runs in
+        # __post_init__, so an unparseable pin refuses here, not as a traceback.
+        config = BuildCorpusV2Config(
+            out_dir=out_dir,
+            bundle_dir=args.bundle_root,
+            annotations_snapshot=args.annotations_snapshot,
+            as_of=args.as_of,
+        )
+    except ValueError as exc:
+        print_error(create_console(), "Invalid --as-of", str(exc))
+        return 1
     try:
         if args.dry_run:
             with tempfile.TemporaryDirectory() as td:
@@ -658,7 +665,7 @@ def _handle_build_corpus_v2_command(argv: list[str]) -> int:
         else:
             summary = run_build_corpus_v2(config)
             (out_dir / "corpus-v2.jsonl").write_bytes((out_dir / "corpus.jsonl").read_bytes())
-    except (OSError, ValueError) as exc:
+    except (OSError, ValueError, TypeError) as exc:
         print_error(create_console(), "Corpus v2 build refused", str(exc))
         return 1
     print_success(

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -642,8 +642,9 @@ def _handle_build_corpus_v2_command(argv: list[str]) -> int:
         return 1
 
     # --out names the corpus JSONL; the projector writes its canonical file set
-    # (corpus.jsonl, split manifests, lineage.json) into that directory, and
-    # corpus-v2.jsonl is published beside them as the versioned corpus.
+    # (corpus.jsonl, corpus-v2.jsonl, split manifests, lineage.json) into that
+    # directory, finishing with _SUCCESS — so the whole set, twin included, is
+    # covered by the fail-closed completeness gate.
     out_dir = args.out.parent
     try:
         # BuildCorpusV2Config is the single validation boundary for --as-of
@@ -664,7 +665,6 @@ def _handle_build_corpus_v2_command(argv: list[str]) -> int:
                 summary = run_build_corpus_v2(replace(config, out_dir=Path(td)))
         else:
             summary = run_build_corpus_v2(config)
-            (out_dir / "corpus-v2.jsonl").write_bytes((out_dir / "corpus.jsonl").read_bytes())
     except (OSError, ValueError, TypeError) as exc:
         print_error(create_console(), "Corpus v2 build refused", str(exc))
         return 1

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -543,6 +543,132 @@ def _handle_build_corpus_command(argv: list[str]) -> int:
     return 0
 
 
+def _build_build_corpus_v2_parser() -> argparse.ArgumentParser:
+    """Build the parser for ``daydream corpus build-v2 [...]``.
+
+    Mirrors the v1 ``corpus build`` parser in style; dispatches to the
+    deterministic per-finding corpus v2 projector over a curated bundle.
+    """
+    parser = argparse.ArgumentParser(
+        prog="daydream corpus build-v2",
+        description="Project curated-bundle per-finding resolutions into deterministic, "
+        "frozen-split corpus-v2 training records.",
+    )
+
+    parser.add_argument(
+        "--bundle-root",
+        type=Path,
+        required=True,
+        metavar="DIR",
+        help="Hydrated curated-bundle root (must contain _SUCCESS, SHA256SUMS, "
+        "curation-manifest-v1.json)",
+    )
+    parser.add_argument(
+        "--annotations-snapshot",
+        type=Path,
+        required=True,
+        dest="annotations_snapshot",
+        metavar="PATH",
+        help="Side-car JSONL of per-finding resolutions keyed by fingerprint, "
+        "digest-pinned alongside the bundle",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        required=True,
+        metavar="PATH",
+        help="Output path; corpus-v2.jsonl, the split manifests, and lineage.json "
+        "are written beside it (its parent directory)",
+    )
+
+    parser.add_argument(
+        "--max-stack-share",
+        type=float,
+        default=None,
+        dest="max_stack_share",
+        help="Not supported by build-v2: the v2 projection applies per-tier caps "
+        "(BuildCorpusV2Config.caps), so passing this flag is refused",
+    )
+
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        dest="dry_run",
+        help="Print the projection summary, write nothing",
+    )
+
+    parser.add_argument(
+        "--as-of",
+        type=str,
+        default=None,
+        dest="as_of",
+        metavar="ISO_TS",
+        help="ISO-8601 transaction-time pin; evidence dated after this instant "
+        "refuses the build (default: latest)",
+    )
+
+    return parser
+
+
+def _handle_build_corpus_v2_command(argv: list[str]) -> int:
+    """Handle ``daydream corpus build-v2 --bundle-root <dir> [...]``.
+
+    Drives :func:`daydream.training.corpus_v2.run_build_corpus_v2` synchronously
+    (no agent work, no network — a pure projection over the curated bundle plus
+    the annotations snapshot). Mirrors :func:`_handle_build_corpus_command`'s
+    structure: returns an exit code; ``main()`` translates it into a process
+    exit. Errors are fail-closed: a refused build exits non-zero with the
+    exception message and writes nothing.
+    """
+    import tempfile
+    from dataclasses import replace
+
+    from daydream.training.corpus_v2 import BuildCorpusV2Config, run_build_corpus_v2
+    from daydream.ui import create_console, print_error, print_success
+
+    parser = _build_build_corpus_v2_parser()
+    args = parser.parse_args(argv)
+
+    if args.max_stack_share is not None:
+        if not (0.0 < args.max_stack_share <= 1.0):
+            print_error(create_console(), "Invalid --max-stack-share", "Must be in (0, 1].")
+            return 1
+        print_error(
+            create_console(),
+            "Unsupported --max-stack-share",
+            "corpus build-v2 applies per-tier caps (BuildCorpusV2Config.caps); "
+            "per-stack share caps are not part of the v2 projection.",
+        )
+        return 1
+
+    # --out names the corpus JSONL; the projector writes its canonical file set
+    # (corpus.jsonl, split manifests, lineage.json) into that directory, and
+    # corpus-v2.jsonl is published beside them as the versioned corpus.
+    out_dir = args.out.parent
+    config = BuildCorpusV2Config(
+        out_dir=out_dir,
+        bundle_dir=args.bundle_root,
+        annotations_snapshot=args.annotations_snapshot,
+        as_of=args.as_of,
+    )
+    try:
+        if args.dry_run:
+            with tempfile.TemporaryDirectory() as td:
+                summary = run_build_corpus_v2(replace(config, out_dir=Path(td)))
+        else:
+            summary = run_build_corpus_v2(config)
+            (out_dir / "corpus-v2.jsonl").write_bytes((out_dir / "corpus.jsonl").read_bytes())
+    except (OSError, ValueError) as exc:
+        print_error(create_console(), "Corpus v2 build refused", str(exc))
+        return 1
+    print_success(
+        create_console(),
+        f"Corpus v2 build complete: {summary['emitted']} records "
+        f"({summary['adjudication']} to adjudication) in {out_dir}",
+    )
+    return 0
+
+
 def _build_improve_parser(
     subverb: str | None = None,
 ) -> argparse.ArgumentParser:
@@ -1616,17 +1742,19 @@ def _handle_train_command(argv: list[str]) -> int:
 _CORPUS_SUBVERBS: dict[str, Callable[[list[str]], int]] = {
     "harvest": _handle_harvest_command,
     "build": _handle_build_corpus_command,
+    "build-v2": _handle_build_corpus_v2_command,
     "label": _handle_label_command,
     "hydrate-hub": _handle_hydrate_hub_command,
 }
 
 
 _CORPUS_USAGE = (
-    "usage: daydream corpus {harvest,build,label,hydrate-hub} ...\n"
+    "usage: daydream corpus {harvest,build,build-v2,label,hydrate-hub} ...\n"
     "\n"
     "Data-pipeline sub-verbs:\n"
     "  harvest   walk the archive and append one bitemporal annotation per indexed run\n"
     "  build     project the as-of-pinned annotations into a JSONL training corpus\n"
+    "  build-v2  project curated-bundle per-finding resolutions into corpus-v2 records\n"
     "  label     record an authoritative human outcome label that overrides automated ones\n"
     "  hydrate-hub  hydrate a pinned Hub snapshot into a sanitized, verified staging archive"
 )

--- a/daydream/training/corpus_v2/__init__.py
+++ b/daydream/training/corpus_v2/__init__.py
@@ -1,0 +1,1 @@
+"""Corpus v2: per-finding training records projected from curated bundles."""

--- a/daydream/training/corpus_v2/__init__.py
+++ b/daydream/training/corpus_v2/__init__.py
@@ -1,1 +1,5 @@
 """Corpus v2: per-finding training records projected from curated bundles."""
+
+from daydream.training.corpus_v2.projector import BuildCorpusV2Config, run_build_corpus_v2
+
+__all__ = ["BuildCorpusV2Config", "run_build_corpus_v2"]

--- a/daydream/training/corpus_v2/bundle.py
+++ b/daydream/training/corpus_v2/bundle.py
@@ -1,0 +1,115 @@
+"""Fail-closed loader for hydrated curation bundles (corpus v2).
+
+Mirrors ``daydream.archive.hydrate.verify_publication``'s SHA256SUMS
+parse-and-verify loop, but reads read-only from a local checkout directory.
+Every ingestion gate raises :class:`BundleError` naming the offending
+path/field — ingestion errors are never discarded or softened.
+"""
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+_SCHEMA_PATH = Path(__file__).parent.parent / "schema" / "curation-manifest-v1.json"
+_MANIFEST_NAME = "curation-manifest-v1.json"
+_SUCCESS_NAME = "_SUCCESS"
+_SUMS_NAME = "SHA256SUMS"
+
+
+class BundleError(ValueError):
+    """A curated bundle failed a fail-closed ingestion gate."""
+
+
+class BundleBatch(BaseModel):
+    """One batch row from the curation manifest (v1 shape)."""
+
+    model_config = ConfigDict(frozen=True)
+
+    session_id: str
+    content_digest: str
+    status: str
+    reason_code: str | None
+    artifact_relpath: str
+    artifact_digest: str | None = None
+    manifest_relpath: str | None = None
+
+
+@dataclass(frozen=True)
+class CuratedBundle:
+    curation_id: str
+    source_hub_commit: str
+    manifest: dict[str, Any]
+    batches: tuple[BundleBatch, ...]
+
+    @property
+    def admitted(self) -> tuple[BundleBatch, ...]:
+        return tuple(b for b in self.batches if b.status == "admitted")
+
+
+def _gate(condition: bool, message: str) -> None:
+    if not condition:
+        raise BundleError(message)
+
+
+def _verify_sha256sums(root: Path) -> None:
+    sums_path = root / _SUMS_NAME
+    _gate(sums_path.is_file(), f"bundle {root}: missing {_SUMS_NAME}")
+    for line in sums_path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        digest, sep, relpath = line.partition("  ")
+        _gate(bool(sep), f"bundle {root}: malformed {_SUMS_NAME} line {line!r}")
+        target = root / relpath
+        if not target.is_file():
+            raise BundleError(f"bundle {root}: missing artifact {relpath!r} listed in {_SUMS_NAME}")
+        actual = hashlib.sha256(target.read_bytes()).hexdigest()
+        _gate(actual == digest, f"bundle {root}: digest mismatch for {relpath!r}")
+
+
+def _validate_relpath(root: Path, relpath: str, what: str) -> Path:
+    p = Path(relpath)
+    _gate(not p.is_absolute(), f"bundle {root}: {what} {relpath!r} is not relative")
+    _gate(".." not in p.parts, f"bundle {root}: {what} {relpath!r} contains '..' segment")
+    resolved = root / p
+    _gate(resolved.is_file(), f"bundle {root}: missing artifact {relpath!r} ({what})")
+    return resolved
+
+
+def load_curated_bundle(root: Path) -> CuratedBundle:
+    """Load a curated bundle from a local checkout, gating in order:
+    ``_SUCCESS``, SHA256SUMS verification, manifest schema validation, and
+    relative-path existence for every batch's artifacts. Raises
+    :class:`BundleError` naming the offending path/field on any gate failure.
+    """
+    root = Path(root)
+    _gate((root / _SUCCESS_NAME).is_file(), f"bundle {root}: missing {_SUCCESS_NAME} marker")
+    _verify_sha256sums(root)
+
+    manifest_path = root / _MANIFEST_NAME
+    _gate(manifest_path.is_file(), f"bundle {root}: missing {_MANIFEST_NAME}")
+    doc = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    from jsonschema import Draft202012Validator  # noqa: PLC0415  # lazy: ingestion-time only
+
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    errors = sorted(Draft202012Validator(schema).iter_errors(doc), key=str)
+    if errors:
+        first = errors[0]
+        raise BundleError(f"bundle {root}: curation manifest invalid at {first.json_path}: {first.message}")
+
+    batches = tuple(BundleBatch(**b) for b in doc["batches"])
+    for batch in batches:
+        _validate_relpath(root, batch.artifact_relpath, "artifact_relpath")
+        if batch.manifest_relpath is not None:
+            _validate_relpath(root, batch.manifest_relpath, "manifest_relpath")
+
+    return CuratedBundle(
+        curation_id=doc["curation_id"],
+        source_hub_commit=doc["source_hub_commit"],
+        manifest=doc,
+        batches=batches,
+    )

--- a/daydream/training/corpus_v2/bundle.py
+++ b/daydream/training/corpus_v2/bundle.py
@@ -58,20 +58,24 @@ def _gate(condition: bool, message: str) -> None:
         raise BundleError(message)
 
 
-def _verify_sha256sums(root: Path) -> None:
+def _verify_sha256sums(root: Path, prefix: str) -> None:
     sums_path = root / _SUMS_NAME
     _gate(sums_path.is_file(), f"bundle {root}: missing {_SUMS_NAME}")
     # daydream.archive.hydrate writes SHA256SUMS relpaths relative to the
-    # hub-checkout root under the ``curated/<curation-id>/`` prefix; the bundle
-    # root is that curated directory, so strip the prefix before resolving
-    # under the root.
-    prefix = f"curated/{root.name}/" if root.parent.name == "curated" else ""
+    # hub-checkout root under the manifest's canonical ``publication_prefix``
+    # (``curated/<curation-id>/``); the bundle root is that curated directory,
+    # so strip the prefix before resolving under the root.
     for line in sums_path.read_text(encoding="utf-8").splitlines():
         if not line.strip():
             continue
         digest, sep, relpath = line.partition("  ")
         _gate(bool(sep), f"bundle {root}: malformed {_SUMS_NAME} line {line!r}")
-        resolved = relpath[len(prefix):] if prefix and relpath.startswith(prefix) else relpath
+        p = Path(relpath)
+        _gate(
+            not p.is_absolute() and ".." not in p.parts,
+            f"bundle {root}: {_SUMS_NAME} relpath {relpath!r} is not relative to the bundle root",
+        )
+        resolved = relpath[len(prefix):] if relpath.startswith(prefix) else relpath
         target = root / resolved
         if not target.is_file():
             raise BundleError(f"bundle {root}: missing artifact {relpath!r} listed in {_SUMS_NAME}")
@@ -80,23 +84,30 @@ def _verify_sha256sums(root: Path) -> None:
 
 
 def _validate_relpath(root: Path, relpath: str, what: str) -> Path:
+    """Gate ``relpath`` under ``root`` and require the target to exist.
+
+    Targets may be files or directories: the producer writes each batch as a
+    directory (``batches/<session_id>/``) whose contents SHA256SUMS covers
+    file-by-file. Existence (not ``is_file``) is the gate so both shapes
+    resolve.
+    """
     p = Path(relpath)
     _gate(not p.is_absolute(), f"bundle {root}: {what} {relpath!r} is not relative")
     _gate(".." not in p.parts, f"bundle {root}: {what} {relpath!r} contains '..' segment")
     resolved = root / p
-    _gate(resolved.is_file(), f"bundle {root}: missing artifact {relpath!r} ({what})")
+    _gate(resolved.exists(), f"bundle {root}: missing artifact {relpath!r} ({what})")
     return resolved
 
 
 def load_curated_bundle(root: Path) -> CuratedBundle:
-    """Load a curated bundle from a local checkout, gating in order:
-    ``_SUCCESS``, SHA256SUMS verification, manifest schema validation, and
+    """Load a curated bundle from a local checkout, gating in order: the
+    ``_SUCCESS`` marker, curation-manifest schema validation (which yields the
+    canonical ``publication_prefix``), SHA256SUMS verification, and
     relative-path existence for every batch's artifacts. Raises
     :class:`BundleError` naming the offending path/field on any gate failure.
     """
     root = Path(root)
     _gate((root / _SUCCESS_NAME).is_file(), f"bundle {root}: missing {_SUCCESS_NAME} marker")
-    _verify_sha256sums(root)
 
     manifest_path = root / _MANIFEST_NAME
     _gate(manifest_path.is_file(), f"bundle {root}: missing {_MANIFEST_NAME}")
@@ -109,6 +120,11 @@ def load_curated_bundle(root: Path) -> CuratedBundle:
     if errors:
         first = errors[0]
         raise BundleError(f"bundle {root}: curation manifest invalid at {first.json_path}: {first.message}")
+
+    # The manifest is the untrusted input; its canonical ``publication_prefix``
+    # (schema-pinned ``curated/<curation-id>/``) is what SHA256SUMS relpaths
+    # are written relative to, so checksum resolution must see it.
+    _verify_sha256sums(root, str(doc["publication_prefix"]))
 
     batches = tuple(BundleBatch(**b) for b in doc["batches"])
     for batch in batches:

--- a/daydream/training/corpus_v2/bundle.py
+++ b/daydream/training/corpus_v2/bundle.py
@@ -15,7 +15,10 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict
 
 _SCHEMA_PATH = Path(__file__).parent.parent / "schema" / "curation-manifest-v1.json"
-_MANIFEST_NAME = "curation-manifest-v1.json"
+# The only producer (daydream.archive.hydrate.finalize) writes the manifest as
+# ``curation-manifest.json`` under ``curated/<curation-id>/``; the bundle root
+# is that curated directory.
+_MANIFEST_NAME = "curation-manifest.json"
 _SUCCESS_NAME = "_SUCCESS"
 _SUMS_NAME = "SHA256SUMS"
 
@@ -58,12 +61,18 @@ def _gate(condition: bool, message: str) -> None:
 def _verify_sha256sums(root: Path) -> None:
     sums_path = root / _SUMS_NAME
     _gate(sums_path.is_file(), f"bundle {root}: missing {_SUMS_NAME}")
+    # daydream.archive.hydrate writes SHA256SUMS relpaths relative to the
+    # hub-checkout root under the ``curated/<curation-id>/`` prefix; the bundle
+    # root is that curated directory, so strip the prefix before resolving
+    # under the root.
+    prefix = f"curated/{root.name}/" if root.parent.name == "curated" else ""
     for line in sums_path.read_text(encoding="utf-8").splitlines():
         if not line.strip():
             continue
         digest, sep, relpath = line.partition("  ")
         _gate(bool(sep), f"bundle {root}: malformed {_SUMS_NAME} line {line!r}")
-        target = root / relpath
+        resolved = relpath[len(prefix):] if prefix and relpath.startswith(prefix) else relpath
+        target = root / resolved
         if not target.is_file():
             raise BundleError(f"bundle {root}: missing artifact {relpath!r} listed in {_SUMS_NAME}")
         actual = hashlib.sha256(target.read_bytes()).hexdigest()

--- a/daydream/training/corpus_v2/identity.py
+++ b/daydream/training/corpus_v2/identity.py
@@ -1,0 +1,29 @@
+"""Record identity for corpus v2 (Req 2, D2).
+
+Each per-finding training record is identified by a sha256 digest over the
+canonical four-component join (US-separated, UTF-8) of the session id,
+trajectory id, segment id, and finding fingerprint — mirroring v1's
+``_trajectory_set_hash`` canonical-string digest pattern.
+"""
+
+import hashlib
+
+_SEPARATOR = "\x1f"
+
+
+def record_id(session_id: str, trajectory_id: str, segment_id: str, fingerprint: str) -> str:
+    """Return the 64-hex lowercase record id for one per-finding record.
+
+    Raises ``ValueError`` naming the offending component when any component is
+    missing or empty — no silent empty-string coercion.
+    """
+    for name, value in (
+        ("session_id", session_id),
+        ("trajectory_id", trajectory_id),
+        ("segment_id", segment_id),
+        ("fingerprint", fingerprint),
+    ):
+        if not value:
+            raise ValueError(f"record_id: missing required component {name!r}")
+    payload = _SEPARATOR.join((session_id, trajectory_id, segment_id, fingerprint))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/daydream/training/corpus_v2/projector.py
+++ b/daydream/training/corpus_v2/projector.py
@@ -18,6 +18,7 @@ import json
 import os
 import tempfile
 from dataclasses import dataclass, field
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Literal, Mapping, cast, overload
 
@@ -150,15 +151,86 @@ def _provenance_for(
 
 
 def _max_valid_at(evidence: list[Record], base: str | None) -> str | None:
-    """Max ``valid_at`` over evidence items (lexicographic ISO-8601 compare),
-    never lower than the ``as_of`` pin."""
+    """Max ``valid_at`` over evidence items (chronological ISO-8601 compare,
+    mirroring ``_is_posterior_leak``'s parse), never lower than the ``as_of``
+    pin. Parsing both sides with :func:`datetime.fromisoformat` means spelling
+    differences — ``Z`` vs ``+00:00`` — can never mis-order the max."""
     result = base
     for item in evidence:
         if isinstance(item, Mapping) and item.get("valid_at"):
             candidate = str(item["valid_at"])
-            if result is None or candidate > result:
+            if result is None or datetime.fromisoformat(candidate) > datetime.fromisoformat(result):
                 result = candidate
     return result
+
+
+def _verify_snapshot_pinned(bundle_dir: Path, snapshot: Path) -> None:
+    """Fail-closed: the annotations snapshot must be digest-pinned by the
+    bundle's SHA256SUMS (the "digest-pinned alongside the bundle" contract) —
+    a snapshot whose bytes no bundle checksum names is refused rather than
+    hashed self-referentially."""
+    sums_path = bundle_dir / "SHA256SUMS"
+    if not sums_path.is_file():
+        raise ValueError(
+            f"bundle {bundle_dir}: missing SHA256SUMS — cannot verify the annotations snapshot pin"
+        )
+    pinned: dict[str, str] = {}
+    for line in sums_path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        digest, sep, relpath = line.partition("  ")
+        if sep:
+            pinned[Path(relpath).name] = digest
+    expected = pinned.get(snapshot.name)
+    if expected is None:
+        raise ValueError(
+            f"annotations snapshot {snapshot.name!r} is not listed in bundle "
+            f"{bundle_dir} SHA256SUMS — it must be digest-pinned alongside the bundle"
+        )
+    actual = hashlib.sha256(snapshot.read_bytes()).hexdigest()
+    if actual != expected:
+        raise ValueError(
+            f"annotations snapshot {snapshot} digest mismatch vs bundle {bundle_dir} "
+            "SHA256SUMS pin"
+        )
+
+
+def _read_trajectory_documents(bundle_dir: Path, artifact_relpath: str) -> list[dict[str, Any]]:
+    """Read a batch's ATIF trajectory document(s).
+
+    The producer writes each batch as a directory (``batches/<sid>/``) whose
+    root trajectory lives at ``trajectory.json`` inside it; a single-object
+    JSON read yields that one trajectory. A file artifact keeps the JSONL
+    shape — one trajectory object per line.
+    """
+    artifact = bundle_dir / artifact_relpath
+    if artifact.is_dir():
+        artifact = artifact / "trajectory.json"
+        if not artifact.is_file():
+            raise ValueError(
+                f"bundle {bundle_dir}: {artifact_relpath} contains no trajectory.json"
+            )
+    raw = artifact.read_text(encoding="utf-8")
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        documents: list[dict[str, Any]] = []
+        for line_no, line in enumerate(raw.splitlines(), start=1):
+            if not line.strip():
+                continue
+            try:
+                documents.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"bundle {bundle_dir}: {artifact_relpath} line {line_no} "
+                    f"is not valid JSON: {exc}"
+                ) from exc
+        return documents
+    if isinstance(parsed, dict):
+        return [parsed]
+    if isinstance(parsed, list):
+        return [doc for doc in parsed if isinstance(doc, dict)]
+    raise ValueError(f"bundle {bundle_dir}: {artifact_relpath} is not a trajectory object")
 
 
 @overload
@@ -291,15 +363,18 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
     ``exclusions_by_reason`` — all derived from the final population in
     deterministic order. Non-decisive findings land in the human
     ``adjudication-report.json`` with their evidence (D8: report output, not
-    a pipeline stage).
+    a pipeline stage). ``corpus.jsonl`` is also published as the versioned
+    twin ``corpus-v2.jsonl`` from the same in-memory bytes via the same
+    atomic write, before ``_SUCCESS`` — covered by the identical fail-closed
+    completeness gate, so the twin can never diverge from the canonical file.
     """
     bundle = load_curated_bundle(config.bundle_dir)
     snapshot_rows = _load_snapshot(config.annotations_snapshot)
     snapshot_digest = hashlib.sha256(config.annotations_snapshot.read_bytes()).hexdigest()
+    _verify_snapshot_pinned(config.bundle_dir, config.annotations_snapshot)
 
     records: list[Record] = []
     adjudication: list[Record] = []
-    included_sessions: list[str] = []
     # The annotation resolutions are session-scoped (keyed by session_id +
     # fingerprint, not by trajectory/segment), so each finding is projected
     # exactly once — sibling segments never fabricate per-segment copies that
@@ -323,17 +398,8 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
         else:
             batch_manifest_row = {}
         digest_parts = [d for d in (batch.content_digest, snapshot_digest) if d]
-        artifact = config.bundle_dir / batch.artifact_relpath
-        for line_no, line in enumerate(artifact.read_text(encoding="utf-8").splitlines(), start=1):
-            if not line.strip():
-                continue
-            try:
-                trajectory = json.loads(line)
-            except json.JSONDecodeError as exc:
-                raise ValueError(
-                    f"bundle {config.bundle_dir}: {batch.artifact_relpath} line {line_no} "
-                    f"is not valid JSON: {exc}"
-                ) from exc
+        trajectory_documents = _read_trajectory_documents(config.bundle_dir, batch.artifact_relpath)
+        for trajectory in trajectory_documents:
             segs = segment(trajectory)
             for seg in segs:
                 resolutions = [
@@ -385,7 +451,10 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
                     rec_valid_at = _max_valid_at(
                         cast(list[Record], rec["evidence"]), config.as_of
                     )
-                    if rec_valid_at is not None and (valid_at is None or rec_valid_at > valid_at):
+                    if rec_valid_at is not None and (
+                        valid_at is None
+                        or datetime.fromisoformat(rec_valid_at) > datetime.fromisoformat(valid_at)
+                    ):
                         valid_at = rec_valid_at
                     rec["profile"] = prov["profile"]
                     rec["stack"] = prov["stack"]
@@ -411,7 +480,6 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
                     if key not in adjudicated_findings:
                         adjudicated_findings.add(key)
                         adjudication.append(entry)
-                included_sessions.append(seg.session_id)
 
     records.sort(key=lambda r: str(r["record_id"]))
     adjudication.sort(key=lambda r: str(r["fingerprint"]))
@@ -438,6 +506,8 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
 
     canonical = _dump_jsonl(records)
     _atomic_write(config.out_dir / "corpus.jsonl", canonical)
+    # Versioned twin of the canonical corpus (same bytes, atomic, pre-_SUCCESS).
+    _atomic_write(config.out_dir / "corpus-v2.jsonl", canonical)
     for split_name, filename in _SPLIT_FILENAMES.items():
         split_records = [r for r in records if cast(dict[str, Any], r["lineage"])["split"] == split_name]
         _atomic_write(config.out_dir / filename, _dump_jsonl(split_records))
@@ -476,7 +546,9 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
         "salt": config.salt,
         "holdout_rate": config.holdout_rate,
         "val_rate": config.val_rate,
-        "trajectory_set_hash": _trajectory_set_hash(sorted(set(included_sessions))),
+        "trajectory_set_hash": _trajectory_set_hash(
+            sorted({str(r["session_id"]) for r in records})
+        ),
         "split_assignment": split_counts,
         "split_counts": split_counts,
         "exclusions_by_reason": dict(sorted(exclusions_by_reason.items())),

--- a/daydream/training/corpus_v2/projector.py
+++ b/daydream/training/corpus_v2/projector.py
@@ -303,6 +303,9 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
                         salt=config.salt,
                     )
                     rec["lineage"] = {"split": split}
+                    # v2 schema stamp: every projected record carries the
+                    # training-record schema version it was emitted under.
+                    rec["schema_version"] = "2"
                 records.extend(seg_records)
                 adjudication.extend(seg_adjudication)
                 included_sessions.append(seg.session_id)

--- a/daydream/training/corpus_v2/projector.py
+++ b/daydream/training/corpus_v2/projector.py
@@ -25,6 +25,7 @@ from daydream.archive.index import normalize_as_of
 from daydream.training.corpus import _is_posterior_leak, _trajectory_set_hash
 from daydream.training.corpus_v2.bundle import load_curated_bundle
 from daydream.training.corpus_v2.identity import record_id
+from daydream.training.corpus_v2.provenance import extract_provenance
 from daydream.training.corpus_v2.segments import segment
 from daydream.training.corpus_v2.splits import assign_split
 from daydream.training.corpus_v2.tiers import classify_tier
@@ -129,6 +130,37 @@ def _refuse_posterior_evidence(
             )
 
 
+def _provenance_for(
+    resolution_row: Mapping[str, Any], manifest_row: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Profile/stack provenance for one record (Req 8).
+
+    The resolution row's native review-profile fields win when present;
+    otherwise the batch manifest row supplies them — the values carried by
+    either row type must not be dropped at the projection boundary.
+    """
+    prov = extract_provenance(resolution_row)
+    if (
+        not any(prov["profile"].values())
+        and prov.get("skill") is None
+        and prov["stack"] is None
+    ):
+        return extract_provenance(manifest_row)
+    return prov
+
+
+def _max_valid_at(evidence: list[Record], base: str | None) -> str | None:
+    """Max ``valid_at`` over evidence items (lexicographic ISO-8601 compare),
+    never lower than the ``as_of`` pin."""
+    result = base
+    for item in evidence:
+        if isinstance(item, Mapping) and item.get("valid_at"):
+            candidate = str(item["valid_at"])
+            if result is None or candidate > result:
+                result = candidate
+    return result
+
+
 @overload
 def project_findings(session: Mapping[str, object], *, return_adjudication: Literal[False] = False) -> list[Record]: ...
 
@@ -183,6 +215,7 @@ def project_findings(
         tier = classify_tier(resolution)
         disposition = resolution.get("disposition")
         evidence = list(resolution.get("evidence") or [])
+        provenance = extract_provenance(resolution)
         record = {
             "record_id": record_id(
                 str(session_id), str(trajectory_id), str(segment_id), str(fingerprint)
@@ -190,12 +223,14 @@ def project_findings(
             "record_type": "outcome-finding",
             "session_id": session_id,
             "trajectory_id": trajectory_id,
-            "segment_id": segment_id,
+            "task_segment": segment_id,
             "finding_fingerprint": fingerprint,
             "tier": tier,
             "disposition": disposition,
             "outcome_label": disposition if tier == "gold" else None,
             "evidence": evidence,
+            "profile": provenance["profile"],
+            "stack": provenance["stack"],
         }
         records.append(record)
         if tier == "task-only":
@@ -243,7 +278,13 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
     atomically, copy ``schema/v2.json`` alongside, and write ``lineage.json``
     pinning the snapshot's provenance (no wall-clock timestamps — every
     manifest byte is a function of the immutable inputs, so re-runs are
-    byte-for-byte identical).
+    byte-for-byte identical), finishing with a ``_SUCCESS`` completeness
+    marker.
+
+    Each finding is projected exactly once (the snapshot resolutions are
+    session-scoped, so sibling segments never fabricate per-segment copies);
+    non-decisive findings are excluded here and routed to the adjudication
+    report only.
 
     Returns a summary dict with ``total``/``emitted``, per-type/per-tier/
     per-split counts, the ``caps`` block (configured vs applied), and
@@ -254,11 +295,34 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
     """
     bundle = load_curated_bundle(config.bundle_dir)
     snapshot_rows = _load_snapshot(config.annotations_snapshot)
+    snapshot_digest = hashlib.sha256(config.annotations_snapshot.read_bytes()).hexdigest()
 
     records: list[Record] = []
     adjudication: list[Record] = []
     included_sessions: list[str] = []
+    # The annotation resolutions are session-scoped (keyed by session_id +
+    # fingerprint, not by trajectory/segment), so each finding is projected
+    # exactly once — sibling segments never fabricate per-segment copies that
+    # could hash into different splits (D5 disjointness is per finding).
+    seen_findings: set[tuple[str, str]] = set()
+    adjudicated_findings: set[tuple[str, str]] = set()
+    # lineage valid_at is pinned over the emitted records' evidence only —
+    # snapshot rows for sessions never admitted/emitted must not drift it.
+    valid_at = config.as_of
     for batch in bundle.admitted:
+        if batch.manifest_relpath is not None:
+            manifest_path = config.bundle_dir / batch.manifest_relpath
+            try:
+                manifest_row_raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"bundle {config.bundle_dir}: {batch.manifest_relpath} "
+                    f"is not valid JSON: {exc}"
+                ) from exc
+            batch_manifest_row = manifest_row_raw if isinstance(manifest_row_raw, dict) else {}
+        else:
+            batch_manifest_row = {}
+        digest_parts = [d for d in (batch.content_digest, snapshot_digest) if d]
         artifact = config.bundle_dir / batch.artifact_relpath
         for line_no, line in enumerate(artifact.read_text(encoding="utf-8").splitlines(), start=1):
             if not line.strip():
@@ -288,8 +352,21 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
                 seg_records, seg_adjudication = project_findings(
                     session_view, return_adjudication=True
                 )
+                resolution_by_fp = {
+                    str(row.get("fingerprint")): row for row in resolutions
+                }
                 for rec in seg_records:
                     fingerprint = str(rec["finding_fingerprint"])
+                    key = (seg.session_id, fingerprint)
+                    if key in seen_findings:
+                        continue
+                    seen_findings.add(key)
+                    # Non-decisive findings are report output only (D8): they
+                    # never become training records, so corpus.jsonl and the
+                    # split manifests exclude them by construction while
+                    # lineage/summary count them under exclusions_by_reason.
+                    if str(rec["tier"]) == "task-only":
+                        continue
                     _refuse_posterior_evidence(
                         seg.session_id,
                         fingerprint,
@@ -302,12 +379,38 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
                         val_rate=config.val_rate,
                         salt=config.salt,
                     )
-                    rec["lineage"] = {"split": split}
+                    prov = _provenance_for(
+                        resolution_by_fp.get(fingerprint, {}), batch_manifest_row
+                    )
+                    rec_valid_at = _max_valid_at(
+                        cast(list[Record], rec["evidence"]), config.as_of
+                    )
+                    if rec_valid_at is not None and (valid_at is None or rec_valid_at > valid_at):
+                        valid_at = rec_valid_at
+                    rec["profile"] = prov["profile"]
+                    rec["stack"] = prov["stack"]
+                    rec["lineage"] = {
+                        "hub_commit": bundle.source_hub_commit,
+                        "curation_id": bundle.curation_id,
+                        "content_digests": digest_parts,
+                        "labeler_policy_version": config.labeler_policy_version,
+                        "reply_classifier_version": config.reply_classifier_version,
+                        "rubric_schema_version": config.rubric_schema_version,
+                        "as_of": config.as_of,
+                        "valid_at": rec_valid_at,
+                        "split": split,
+                        "exclusion_reason": None,
+                        "license_decision": config.license,
+                    }
                     # v2 schema stamp: every projected record carries the
                     # training-record schema version it was emitted under.
                     rec["schema_version"] = "2"
-                records.extend(seg_records)
-                adjudication.extend(seg_adjudication)
+                    records.append(rec)
+                for entry in seg_adjudication:
+                    key = (seg.session_id, str(entry["fingerprint"]))
+                    if key not in adjudicated_findings:
+                        adjudicated_findings.add(key)
+                        adjudication.append(entry)
                 included_sessions.append(seg.session_id)
 
     records.sort(key=lambda r: str(r["record_id"]))
@@ -344,9 +447,7 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
     )
 
     schema_src = Path(__file__).parent.parent / "schema" / "v2.json"
-    schema_dst = config.out_dir / "schema.json"
-    schema_dst.parent.mkdir(parents=True, exist_ok=True)
-    schema_dst.write_bytes(schema_src.read_bytes())
+    _atomic_write(config.out_dir / "schema.json", schema_src.read_text(encoding="utf-8"))
 
     split_counts = {name: 0 for name in _SPLIT_FILENAMES}
     for r in records:
@@ -355,19 +456,10 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
     # Every Req-11 field: hub commit, curation id, content digests, policy/
     # classifier/rubric versions, as_of + valid_at pins, split assignment,
     # exclusion reasons, and the C5/license decision. Nothing silently dropped.
-    valid_at = config.as_of
-    for row in snapshot_rows.values():
-        for item in row.get("evidence") or []:
-            if isinstance(item, Mapping) and item.get("valid_at"):
-                candidate = str(item["valid_at"])
-                if valid_at is None or candidate > valid_at:
-                    valid_at = candidate
     content_digests: dict[str, str] = {
         batch.session_id: batch.content_digest for batch in bundle.admitted if batch.content_digest
     }
-    content_digests[config.annotations_snapshot.name] = hashlib.sha256(
-        config.annotations_snapshot.read_bytes()
-    ).hexdigest()
+    content_digests[config.annotations_snapshot.name] = snapshot_digest
     lineage = {
         "schema_version": "corpus-v2",
         "curation_id": bundle.curation_id,
@@ -396,6 +488,11 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
         config.out_dir / "lineage.json",
         json.dumps(lineage, sort_keys=True, indent=2, ensure_ascii=False) + "\n",
     )
+
+    # Completeness marker (mirrors the bundle's own ``_SUCCESS`` gate): the
+    # projection file set is only consumable once every member is in place,
+    # so a mid-write failure never leaves a partial projection behind.
+    _atomic_write(config.out_dir / "_SUCCESS", "ok\n")
 
     return {
         "total": len(records),

--- a/daydream/training/corpus_v2/projector.py
+++ b/daydream/training/corpus_v2/projector.py
@@ -13,6 +13,7 @@ content-derived splits → refuse posterior evidence → write split manifests
 atomically with a lineage pin.
 """
 
+import hashlib
 import json
 import os
 import tempfile
@@ -73,6 +74,10 @@ class BuildCorpusV2Config:
     val_rate: float = 0.1
     salt: str = "daydream-corpus-v2"
     caps: dict[str, int] = field(default_factory=dict)
+    labeler_policy_version: str = "1"
+    reply_classifier_version: str = "1"
+    rubric_schema_version: str = "per-finding-resolutions-v1"
+    license: str | None = None
 
     def __post_init__(self) -> None:
         if self.as_of is not None:
@@ -199,7 +204,10 @@ def project_findings(
                     "fingerprint": fingerprint,
                     "disposition": disposition,
                     "evidence": evidence,
-                    "reason": f"non-decisive disposition {disposition!r}",
+                    "exclusion_reason": (
+                        f"non-decisive disposition {disposition!r} — missing decisive "
+                        "human verdict (evidence carried for the adjudication pass)"
+                    ),
                 }
             )
 
@@ -208,7 +216,20 @@ def project_findings(
     return records
 
 
-def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, int]:
+def _count_by(records: list[Record], key: Any) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for r in records:
+        k = key(r)
+        counts[k] = counts.get(k, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _caps_applied(records: list[Record], caps: dict[str, int]) -> dict[str, int]:
+    """Final per-tier population (what the caps resolved to), deterministic."""
+    return _count_by(records, lambda r: str(r["tier"])) if caps else {}
+
+
+def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
     """Top-level corpus v2 projection (mirrors ``corpus.py:985``'s pipeline
     contract). Pure — no git, no network; ``base_sha``/hub commit come from
     the curation manifest only.
@@ -224,8 +245,12 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, int]:
     manifest byte is a function of the immutable inputs, so re-runs are
     byte-for-byte identical).
 
-    Returns a summary dict with ``total``, ``emitted``, per-split counts and
-    ``adjudication`` (non-decisive findings routed to the human pass).
+    Returns a summary dict with ``total``/``emitted``, per-type/per-tier/
+    per-split counts, the ``caps`` block (configured vs applied), and
+    ``exclusions_by_reason`` — all derived from the final population in
+    deterministic order. Non-decisive findings land in the human
+    ``adjudication-report.json`` with their evidence (D8: report output, not
+    a pipeline stage).
     """
     bundle = load_curated_bundle(config.bundle_dir)
     snapshot_rows = _load_snapshot(config.annotations_snapshot)
@@ -285,13 +310,33 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, int]:
     records.sort(key=lambda r: str(r["record_id"]))
     adjudication.sort(key=lambda r: str(r["fingerprint"]))
 
+    # Post-segmentation caps (D6): caps bind after segmentation and split
+    # assignment, over the deduplicated final population. Excess records of a
+    # capped tier are excluded (never silently dropped) and named in the
+    # summary, lineage, and exclusion reasons.
+    exclusions_by_reason: dict[str, int] = {"non-decisive-adjudication": len(adjudication)}
+    if config.caps:
+        kept: list[Record] = []
+        per_tier: dict[str, int] = {}
+        for rec in records:
+            tier = str(rec["tier"])
+            limit = config.caps.get(tier)
+            if limit is not None and per_tier.get(tier, 0) >= limit:
+                exclusions_by_reason[f"tier-cap:{tier}"] = (
+                    exclusions_by_reason.get(f"tier-cap:{tier}", 0) + 1
+                )
+                continue
+            per_tier[tier] = per_tier.get(tier, 0) + 1
+            kept.append(rec)
+        records = kept
+
     canonical = _dump_jsonl(records)
     _atomic_write(config.out_dir / "corpus.jsonl", canonical)
     for split_name, filename in _SPLIT_FILENAMES.items():
         split_records = [r for r in records if cast(dict[str, Any], r["lineage"])["split"] == split_name]
         _atomic_write(config.out_dir / filename, _dump_jsonl(split_records))
     _atomic_write(
-        config.out_dir / "adjudication.json",
+        config.out_dir / "adjudication-report.json",
         json.dumps(adjudication, sort_keys=True, indent=2, ensure_ascii=False) + "\n",
     )
 
@@ -304,17 +349,44 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, int]:
     for r in records:
         lineage_field = cast(dict[str, Any], r["lineage"])
         split_counts[str(lineage_field["split"])] += 1
+    # Every Req-11 field: hub commit, curation id, content digests, policy/
+    # classifier/rubric versions, as_of + valid_at pins, split assignment,
+    # exclusion reasons, and the C5/license decision. Nothing silently dropped.
+    valid_at = config.as_of
+    for row in snapshot_rows.values():
+        for item in row.get("evidence") or []:
+            if isinstance(item, Mapping) and item.get("valid_at"):
+                candidate = str(item["valid_at"])
+                if valid_at is None or candidate > valid_at:
+                    valid_at = candidate
+    content_digests: dict[str, str] = {
+        batch.session_id: batch.content_digest for batch in bundle.admitted if batch.content_digest
+    }
+    content_digests[config.annotations_snapshot.name] = hashlib.sha256(
+        config.annotations_snapshot.read_bytes()
+    ).hexdigest()
     lineage = {
         "schema_version": "corpus-v2",
         "curation_id": bundle.curation_id,
+        "hub_commit": bundle.source_hub_commit,
         "source_hub_commit": bundle.source_hub_commit,
+        "content_digests": content_digests,
         "annotations_snapshot": config.annotations_snapshot.name,
+        "labeler_policy_version": config.labeler_policy_version,
+        "reply_classifier_version": config.reply_classifier_version,
+        "rubric_schema_version": config.rubric_schema_version,
         "as_of": config.as_of,
+        "valid_at": valid_at,
+        "license": config.license,
         "salt": config.salt,
         "holdout_rate": config.holdout_rate,
         "val_rate": config.val_rate,
         "trajectory_set_hash": _trajectory_set_hash(sorted(set(included_sessions))),
+        "split_assignment": split_counts,
         "split_counts": split_counts,
+        "exclusions_by_reason": dict(sorted(exclusions_by_reason.items())),
+        "caps": {"configured": dict(sorted(config.caps.items())),
+                 "applied": _caps_applied(records, config.caps)},
         "adjudication_count": len(adjudication),
     }
     _atomic_write(
@@ -327,4 +399,10 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, int]:
         "emitted": len(records),
         "adjudication": len(adjudication),
         **{f"split_{name}": count for name, count in split_counts.items()},
+        "records_by_type": _count_by(records, lambda r: str(r["record_type"])),
+        "records_by_tier": _count_by(records, lambda r: str(r["tier"])),
+        "records_by_split": dict(split_counts),
+        "caps": {"configured": dict(sorted(config.caps.items())),
+                 "applied": _caps_applied(records, config.caps)},
+        "exclusions_by_reason": dict(sorted(exclusions_by_reason.items())),
     }

--- a/daydream/training/corpus_v2/projector.py
+++ b/daydream/training/corpus_v2/projector.py
@@ -7,18 +7,121 @@ never collapses into a run-level aggregate like v1's ``contested``
 report (report output, not a pipeline stage); the projector stays pure and
 deterministic.
 
-``run_build_corpus_v2()`` wiring lands in a later task; this module owns
-only the record-assembly core.
+``run_build_corpus_v2()`` is the top-level pure projection (no git, no
+network): load bundle → segment → project findings → assign frozen
+content-derived splits → refuse posterior evidence → write split manifests
+atomically with a lineage pin.
 """
 
-from typing import Literal, Mapping, overload
+import json
+import os
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal, Mapping, cast, overload
 
+from daydream.archive.index import normalize_as_of
+from daydream.training.corpus import _is_posterior_leak, _trajectory_set_hash
+from daydream.training.corpus_v2.bundle import load_curated_bundle
 from daydream.training.corpus_v2.identity import record_id
+from daydream.training.corpus_v2.segments import segment
+from daydream.training.corpus_v2.splits import assign_split
 from daydream.training.corpus_v2.tiers import classify_tier
 
-__all__ = ["project_findings"]
+__all__ = ["BuildCorpusV2Config", "project_findings", "run_build_corpus_v2"]
 
 Record = dict[str, object]
+
+_SPLIT_FILENAMES: dict[str, str] = {
+    "train": "train.jsonl",
+    "validation": "validation.jsonl",
+    "holdout": "holdout.jsonl",
+}
+
+
+def _dump_jsonl(records: list[Record]) -> str:
+    """Canonical JSONL: sorted keys, compact separators, record order fixed
+    by the caller — byte-for-byte stable across re-runs."""
+    return "".join(
+        json.dumps(r, sort_keys=True, separators=(",", ":"), ensure_ascii=False) + "\n"
+        for r in records
+    )
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    """Tempfile-in-same-dir + ``Path.replace`` (mirrors ``corpus.py``)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(content)
+        Path(tmp_name).replace(path)
+    except BaseException:
+        Path(tmp_name).unlink(missing_ok=True)
+        raise
+
+
+@dataclass(frozen=True)
+class BuildCorpusV2Config:
+    """Configuration for the corpus v2 projection (pure — no git, no network)."""
+
+    out_dir: Path
+    bundle_dir: Path
+    annotations_snapshot: Path
+    as_of: str | None = None
+    holdout_rate: float = 0.1
+    val_rate: float = 0.1
+    salt: str = "daydream-corpus-v2"
+    caps: dict[str, int] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.as_of is not None:
+            object.__setattr__(self, "as_of", normalize_as_of(self.as_of))
+
+
+def _load_snapshot(path: Path) -> dict[str, dict[str, Any]]:
+    """Parse the side-car annotations snapshot (Task 0A shape): one JSON
+    object per line, keyed by ``fingerprint``. Fail-closed on malformed
+    lines or duplicate fingerprints."""
+    rows: dict[str, dict[str, Any]] = {}
+    for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"annotations snapshot {path}: line {line_no} is not valid JSON: {exc}"
+            ) from exc
+        fingerprint = row.get("fingerprint")
+        if not fingerprint:
+            raise ValueError(f"annotations snapshot {path}: line {line_no} missing 'fingerprint'")
+        if fingerprint in rows:
+            raise ValueError(
+                f"annotations snapshot {path}: duplicate fingerprint {fingerprint!r} "
+                f"(lines {line_no} and earlier) — snapshot must be keyed by fingerprint"
+            )
+        rows[str(fingerprint)] = row
+    return rows
+
+
+def _refuse_posterior_evidence(
+    session_id: str, fingerprint: str, evidence: list[Record], as_of: str | None
+) -> None:
+    """Refusal, not drop: any evidence item whose ``valid_at`` lands after
+    the ``as_of`` pin aborts the whole build (spec: "refused"). Reuses v1's
+    chronological ``_is_posterior_leak`` comparison (Pattern Q)."""
+    if as_of is None:
+        return
+    for item in evidence:
+        if not isinstance(item, Mapping):
+            continue
+        if _is_posterior_leak(dict(item), as_of):
+            raise ValueError(
+                f"session {session_id!r} finding {fingerprint!r}: evidence "
+                f"valid_at {item.get('valid_at')!r} is after as_of {as_of!r} "
+                "— refusing posterior outcome evidence"
+            )
 
 
 @overload
@@ -103,3 +206,125 @@ def project_findings(
     if return_adjudication:
         return records, adjudication
     return records
+
+
+def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, int]:
+    """Top-level corpus v2 projection (mirrors ``corpus.py:985``'s pipeline
+    contract). Pure — no git, no network; ``base_sha``/hub commit come from
+    the curation manifest only.
+
+    Pipeline: load the curated bundle (fail-closed) → segment each admitted
+    batch's trajectory (fork-order per-agent) → project per-finding records
+    → assign frozen content-derived splits → refuse any record whose
+    annotation evidence carries ``valid_at > as_of`` (raise ``ValueError``
+    naming the session and both timestamps — refusal, not drop) → write
+    ``corpus.jsonl`` plus ``train.jsonl``/``validation.jsonl``/``holdout.jsonl``
+    atomically, copy ``schema/v2.json`` alongside, and write ``lineage.json``
+    pinning the snapshot's provenance (no wall-clock timestamps — every
+    manifest byte is a function of the immutable inputs, so re-runs are
+    byte-for-byte identical).
+
+    Returns a summary dict with ``total``, ``emitted``, per-split counts and
+    ``adjudication`` (non-decisive findings routed to the human pass).
+    """
+    bundle = load_curated_bundle(config.bundle_dir)
+    snapshot_rows = _load_snapshot(config.annotations_snapshot)
+
+    records: list[Record] = []
+    adjudication: list[Record] = []
+    included_sessions: list[str] = []
+    for batch in bundle.admitted:
+        artifact = config.bundle_dir / batch.artifact_relpath
+        for line_no, line in enumerate(artifact.read_text(encoding="utf-8").splitlines(), start=1):
+            if not line.strip():
+                continue
+            try:
+                trajectory = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"bundle {config.bundle_dir}: {batch.artifact_relpath} line {line_no} "
+                    f"is not valid JSON: {exc}"
+                ) from exc
+            segs = segment(trajectory)
+            for seg in segs:
+                resolutions = [
+                    row
+                    for row in snapshot_rows.values()
+                    if row.get("session_id") == seg.session_id
+                ]
+                if not resolutions:
+                    continue
+                session_view: dict[str, Any] = {
+                    "session_id": seg.session_id,
+                    "trajectory_id": seg.trajectory_id,
+                    "segment_id": seg.segment_id,
+                    "resolutions": resolutions,
+                }
+                seg_records, seg_adjudication = project_findings(
+                    session_view, return_adjudication=True
+                )
+                for rec in seg_records:
+                    fingerprint = str(rec["finding_fingerprint"])
+                    _refuse_posterior_evidence(
+                        seg.session_id,
+                        fingerprint,
+                        cast(list[Record], rec["evidence"]),
+                        config.as_of,
+                    )
+                    split = assign_split(
+                        str(rec["record_id"]),
+                        holdout_rate=config.holdout_rate,
+                        val_rate=config.val_rate,
+                        salt=config.salt,
+                    )
+                    rec["lineage"] = {"split": split}
+                records.extend(seg_records)
+                adjudication.extend(seg_adjudication)
+                included_sessions.append(seg.session_id)
+
+    records.sort(key=lambda r: str(r["record_id"]))
+    adjudication.sort(key=lambda r: str(r["fingerprint"]))
+
+    canonical = _dump_jsonl(records)
+    _atomic_write(config.out_dir / "corpus.jsonl", canonical)
+    for split_name, filename in _SPLIT_FILENAMES.items():
+        split_records = [r for r in records if cast(dict[str, Any], r["lineage"])["split"] == split_name]
+        _atomic_write(config.out_dir / filename, _dump_jsonl(split_records))
+    _atomic_write(
+        config.out_dir / "adjudication.json",
+        json.dumps(adjudication, sort_keys=True, indent=2, ensure_ascii=False) + "\n",
+    )
+
+    schema_src = Path(__file__).parent.parent / "schema" / "v2.json"
+    schema_dst = config.out_dir / "schema.json"
+    schema_dst.parent.mkdir(parents=True, exist_ok=True)
+    schema_dst.write_bytes(schema_src.read_bytes())
+
+    split_counts = {name: 0 for name in _SPLIT_FILENAMES}
+    for r in records:
+        lineage_field = cast(dict[str, Any], r["lineage"])
+        split_counts[str(lineage_field["split"])] += 1
+    lineage = {
+        "schema_version": "corpus-v2",
+        "curation_id": bundle.curation_id,
+        "source_hub_commit": bundle.source_hub_commit,
+        "annotations_snapshot": config.annotations_snapshot.name,
+        "as_of": config.as_of,
+        "salt": config.salt,
+        "holdout_rate": config.holdout_rate,
+        "val_rate": config.val_rate,
+        "trajectory_set_hash": _trajectory_set_hash(sorted(set(included_sessions))),
+        "split_counts": split_counts,
+        "adjudication_count": len(adjudication),
+    }
+    _atomic_write(
+        config.out_dir / "lineage.json",
+        json.dumps(lineage, sort_keys=True, indent=2, ensure_ascii=False) + "\n",
+    )
+
+    return {
+        "total": len(records),
+        "emitted": len(records),
+        "adjudication": len(adjudication),
+        **{f"split_{name}": count for name, count in split_counts.items()},
+    }

--- a/daydream/training/corpus_v2/projector.py
+++ b/daydream/training/corpus_v2/projector.py
@@ -1,0 +1,105 @@
+"""Per-finding projection for corpus v2 (Req 6, Req 18, D8).
+
+Each ``PerFindingResolution`` becomes its own record with a per-record
+``outcome_label`` — a mixed session (some findings accepted, some rejected)
+never collapses into a run-level aggregate like v1's ``contested``
+``outcome_label``. Non-decisive dispositions route to an adjudication
+report (report output, not a pipeline stage); the projector stays pure and
+deterministic.
+
+``run_build_corpus_v2()`` wiring lands in a later task; this module owns
+only the record-assembly core.
+"""
+
+from typing import Literal, Mapping, overload
+
+from daydream.training.corpus_v2.identity import record_id
+from daydream.training.corpus_v2.tiers import classify_tier
+
+__all__ = ["project_findings"]
+
+Record = dict[str, object]
+
+
+@overload
+def project_findings(session: Mapping[str, object], *, return_adjudication: Literal[False] = False) -> list[Record]: ...
+
+
+@overload
+def project_findings(
+    session: Mapping[str, object], *, return_adjudication: Literal[True]
+) -> tuple[list[Record], list[Record]]: ...
+
+
+def project_findings(
+    session: Mapping[str, object], *, return_adjudication: bool = False
+) -> list[Record] | tuple[list[Record], list[Record]]:
+    """Project one segmented session's per-finding resolutions into records.
+
+    Returns the record list, or ``(records, adjudication_entries)`` when
+    ``return_adjudication`` is true. Raises ``ValueError`` naming the
+    session and the offending key on a malformed resolution.
+    """
+    session_id = session.get("session_id")
+    trajectory_id = session.get("trajectory_id")
+    segment_id = session.get("segment_id")
+    resolutions = session.get("resolutions")
+    for name, value in (
+        ("session_id", session_id),
+        ("trajectory_id", trajectory_id),
+        ("segment_id", segment_id),
+        ("resolutions", resolutions),
+    ):
+        if not value:
+            raise ValueError(f"project_findings: session missing required key {name!r}")
+    if not isinstance(resolutions, list):
+        raise ValueError(
+            f"project_findings: session {session_id!r} key 'resolutions' "
+            f"must be a list, got {type(resolutions).__name__}"
+        )
+
+    records: list[Record] = []
+    adjudication: list[Record] = []
+    for index, resolution in enumerate(resolutions):
+        if not isinstance(resolution, Mapping):
+            raise ValueError(
+                f"project_findings: session {session_id!r} resolutions[{index}] "
+                f"is not a mapping (got {type(resolution).__name__})"
+            )
+        fingerprint = resolution.get("fingerprint")
+        if not fingerprint:
+            raise ValueError(
+                f"project_findings: session {session_id!r} resolutions[{index}] "
+                "missing required key 'fingerprint'"
+            )
+        tier = classify_tier(resolution)
+        disposition = resolution.get("disposition")
+        evidence = list(resolution.get("evidence") or [])
+        record = {
+            "record_id": record_id(
+                str(session_id), str(trajectory_id), str(segment_id), str(fingerprint)
+            ),
+            "record_type": "outcome-finding",
+            "session_id": session_id,
+            "trajectory_id": trajectory_id,
+            "segment_id": segment_id,
+            "finding_fingerprint": fingerprint,
+            "tier": tier,
+            "disposition": disposition,
+            "outcome_label": disposition if tier == "gold" else None,
+            "evidence": evidence,
+        }
+        records.append(record)
+        if tier == "task-only":
+            adjudication.append(
+                {
+                    "fingerprint": fingerprint,
+                    "disposition": disposition,
+                    "evidence": evidence,
+                    "reason": f"non-decisive disposition {disposition!r}",
+                }
+            )
+
+    if return_adjudication:
+        return records, adjudication
+    return records

--- a/daydream/training/corpus_v2/provenance.py
+++ b/daydream/training/corpus_v2/provenance.py
@@ -1,0 +1,45 @@
+"""Profile + stack provenance extraction for corpus v2 records (Req 8).
+
+Reads the four native review-profile fields (issue #885, R12) verbatim from a
+manifest row / trajectory record and assembles the provenance block: the
+``profile`` mapping, optional legacy ``skill`` provenance, and the detected
+``stack`` label. Composes v1's legacy skill→stack map
+(``daydream.training.corpus``) rather than duplicating it.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+_PROFILE_FIELDS = (
+    "profile_schema_version",
+    "profile_name",
+    "profile_source_kind",
+    "profile_digest",
+)
+
+
+def extract_provenance(manifest_or_record: Mapping[str, Any]) -> dict[str, Any]:
+    """Extract provenance fields from a manifest row or v2 record.
+
+    The four profile fields are carried verbatim (``null`` when absent —
+    never dropped, never substituted). Legacy ``skill`` is included only when
+    a value exists; ``stack`` falls back to the legacy skill→stack mapping and
+    is ``None`` when unresolvable.
+    """
+    prov: dict[str, Any] = {
+        "profile": {field: manifest_or_record.get(field) for field in _PROFILE_FIELDS},
+    }
+
+    skill = manifest_or_record.get("skill")
+    if skill is not None:
+        prov["skill"] = skill
+
+    stack = manifest_or_record.get("stack")
+    if stack is None and skill is not None:
+        from daydream.training.corpus import _stack_for_skill
+
+        stack = _stack_for_skill(skill)
+    prov["stack"] = stack
+
+    return prov

--- a/daydream/training/corpus_v2/segments.py
+++ b/daydream/training/corpus_v2/segments.py
@@ -1,0 +1,95 @@
+"""Deterministic per-agent segmentation of ATIF trajectories (corpus v2).
+
+Pinned rule (spike 0B): sibling registration order in
+``TrajectoryRecorder.fork()`` is append-ordered, so enumeration of the
+trajectory's ``subagent_trajectory_ref`` list is the fork registration
+order; ``(order_index, descriptor)`` is a total order across concurrent
+forks. Segmentation must never be a coin-flip, so duplicate sibling keys
+raise.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from daydream.training.corpus import _build_spans
+
+
+@dataclass(frozen=True)
+class Segment:
+    """One per-agent segment of a session's trajectory tree."""
+
+    segment_id: str
+    trajectory_id: str
+    session_id: str
+    order_index: int
+    descriptor: str
+    spans: list[dict[str, Any]] = field(default_factory=list)
+
+
+def _descriptor(trajectory_id: str) -> str:
+    """Derive the agent descriptor from a ``<session>:<descriptor>`` id."""
+    _, _, desc = trajectory_id.partition(":")
+    return desc or trajectory_id
+
+
+def segment(trajectory: dict[str, Any]) -> list[Segment]:
+    """Segment a trajectory dict into per-agent ``Segment`` records.
+
+    Ordering follows the trajectory's ``subagent_trajectory_ref`` list order
+    (fork registration order, per the Task 0B pinned rule) with a stable
+    ``(order_index, descriptor)`` tie-break. The root trajectory is ``seg-0``
+    only when no siblings exist; otherwise siblings are ``seg-0..n-1``.
+
+    Spans are computed per sibling document with the v1 ``_build_spans``
+    helper (Pattern Q) when the ref inlines a document (``steps`` key);
+    external refs (``trajectory_path`` only) carry empty spans.
+
+    Raises:
+        ValueError: when two sibling refs share the same
+            ``(order_index, descriptor)`` key — the message names both.
+    """
+    refs = trajectory.get("subagent_trajectory_ref") or []
+    if not refs:
+        root_id = str(trajectory.get("trajectory_id", ""))
+        return [
+            Segment(
+                segment_id="seg-0",
+                trajectory_id=root_id,
+                session_id=str(trajectory.get("session_id", "")),
+                order_index=0,
+                descriptor=_descriptor(root_id),
+                spans=_build_spans(trajectory),
+            )
+        ]
+
+    seen: dict[tuple[str, str], str] = {}
+    segments: list[Segment] = []
+    for order_index, ref in enumerate(refs):
+        trajectory_id = str(ref.get("trajectory_id", ""))
+        descriptor = _descriptor(trajectory_id)
+        key = (descriptor, trajectory_id)
+        if key in seen:
+            raise ValueError(
+                f"duplicate segmentation key (descriptor={descriptor!r}): "
+                f"{seen[key]!r} and {trajectory_id!r} — segmentation must be a total order"
+            )
+        seen[key] = trajectory_id
+        spans = _build_spans(ref if "steps" in ref else {})
+        segments.append(
+            Segment(
+                segment_id=f"seg-{order_index}",
+                trajectory_id=trajectory_id,
+                session_id=str(ref.get("session_id", trajectory.get("session_id", ""))),
+                order_index=order_index,
+                descriptor=descriptor,
+                spans=spans if "steps" in ref else [],
+            )
+        )
+    return segments
+
+
+# Plan-facing alias: the segmentation entry point is also exported under the
+# name used in the implementation plan.
+segment_agents = segment
+
+__all__ = ["Segment", "segment", "segment_agents"]

--- a/daydream/training/corpus_v2/splits.py
+++ b/daydream/training/corpus_v2/splits.py
@@ -1,0 +1,42 @@
+"""Content-derived, frozen, disjoint split assignment (corpus v2, D5).
+
+A record's split is a deterministic function of its content-derived record id
+and the pinned salt — no RNG, no state, no call-order dependence. The unit
+interval is sliced into ``holdout`` / ``validation`` / ``train`` in that
+order, so the three membership sets are disjoint by construction.
+"""
+
+import hashlib
+from typing import Literal
+
+__all__ = ["assign_split"]
+
+Split = Literal["train", "validation", "holdout"]
+
+
+def assign_split(record_id: str, *, holdout_rate: float, val_rate: float, salt: str) -> Split:
+    """Assign one record to a split from its record id (D5).
+
+    The bucket digest is ``sha256(salt <US> record_id)``; its leading 256 bits
+    are interpreted as a uniform ``u`` over ``[0, 1)``:
+
+    - ``u < holdout_rate`` → ``holdout``
+    - ``u < holdout_rate + val_rate`` → ``validation``
+    - otherwise → ``train``
+
+    Deterministic, content-derived, no RNG. Disjoint by construction: the
+    three predicates partition the unit interval. ``val_rate`` must be
+    non-negative and ``holdout_rate + val_rate <= 1``.
+    """
+    if holdout_rate < 0.0 or val_rate < 0.0 or holdout_rate + val_rate > 1.0:
+        raise ValueError(
+            f"assign_split: invalid rates holdout_rate={holdout_rate!r} "
+            f"val_rate={val_rate!r} (require non-negative and holdout+val <= 1)"
+        )
+    digest = hashlib.sha256(f"{salt}\x1f{record_id}".encode("utf-8")).digest()
+    u = int.from_bytes(digest[:32], "big") / 2**256
+    if u < holdout_rate:
+        return "holdout"
+    if u < holdout_rate + val_rate:
+        return "validation"
+    return "train"

--- a/daydream/training/corpus_v2/tiers.py
+++ b/daydream/training/corpus_v2/tiers.py
@@ -1,0 +1,64 @@
+"""Tier + eligibility classification for corpus v2 records.
+
+The gold gate is human-evidence-only and structural (C5): no intrinsic
+reward or LLM self-score input exists in this module's signature, so a
+score can never promote a record to gold. The module deliberately
+imports nothing from ``daydream.training.reward``.
+"""
+
+from typing import Literal, Mapping
+
+__all__ = ["GoldGateError", "classify_tier"]
+
+Tier = Literal["gold", "silver", "task-only"]
+
+_DECISIVE_DISPOSITIONS = frozenset({"accepted", "rejected"})
+_NON_DECISIVE_DISPOSITIONS = frozenset({"ambiguous", "unanswered", "missing"})
+
+
+class GoldGateError(ValueError):
+    """Raised when a decisive disposition lacks human/developer evidence.
+
+    Fail-closed: a record that claims ``accepted``/``rejected`` but carries
+    no evidence is never silently demoted to silver — it is an error.
+    """
+
+
+def classify_tier(resolution: Mapping[str, object], *, record_type: str = "outcome-finding") -> Tier:
+    """Classify a per-finding resolution into a disjoint tier.
+
+    - ``record_type == "process-trace"`` is always ``silver``: ATIF process
+      data is a separate class from outcome decisions, whatever its
+      disposition says.
+    - ``outcome-finding`` records are ``gold`` only when the disposition is
+      decisive (``accepted``/``rejected``) *and* the evidence list is
+      non-empty. Decisive-but-evidenceless raises :class:`GoldGateError`.
+    - Non-decisive dispositions are ``task-only`` (the projector routes
+      them to adjudication).
+    """
+    if not isinstance(resolution, Mapping):
+        raise TypeError(f"resolution must be a mapping, got {type(resolution).__name__}")
+
+    if record_type == "process-trace":
+        return "silver"
+
+    disposition = resolution.get("disposition")
+    if not isinstance(disposition, str):
+        raise TypeError(f"disposition must be a string, got {type(disposition).__name__}")
+
+    if disposition in _NON_DECISIVE_DISPOSITIONS:
+        return "task-only"
+
+    if disposition in _DECISIVE_DISPOSITIONS:
+        evidence = resolution.get("evidence")
+        if not isinstance(evidence, list):
+            raise TypeError(f"evidence must be a list, got {type(evidence).__name__}")
+        if not evidence:
+            raise GoldGateError(
+                f"decisive disposition {disposition!r} for fingerprint "
+                f"{resolution.get('fingerprint')!r} has empty evidence; "
+                "gold requires human/developer reply evidence"
+            )
+        return "gold"
+
+    raise TypeError(f"unknown disposition {disposition!r}")

--- a/daydream/training/schema.py
+++ b/daydream/training/schema.py
@@ -1,4 +1,4 @@
-"""Schema version constant for training JSONL records.
+"""Schema version constants for training JSONL records.
 
 Mirrors `MANIFEST_SCHEMA_VERSION` in `daydream.archive.manifest`. The committed
 JSONSchema artifact at `daydream/training/schema/v1.json` is the canonical
@@ -9,6 +9,14 @@ Bump rule (per plan §8):
 - Removing a field, renaming, changing types, changing semantics: bump to the
   next integer, ship the new JSONSchema artifact alongside the old one, and
   leave existing versioned artifacts in place for old consumers.
+
+v2 (`corpus-v2`, per-finding records) ships alongside v1; v1 is never modified.
 """
 
+from pathlib import Path
+
 TRAINING_SCHEMA_VERSION: str = "1"
+TRAINING_SCHEMA_V1_PATH: Path = Path(__file__).parent / "schema" / "v1.json"
+
+TRAINING_SCHEMA_V2_VERSION: str = "2"
+TRAINING_SCHEMA_V2_PATH: Path = Path(__file__).parent / "schema" / "v2.json"

--- a/daydream/training/schema/v2.json
+++ b/daydream/training/schema/v2.json
@@ -48,6 +48,12 @@
     "disposition": {
       "enum": ["accepted", "rejected", "ambiguous", "unanswered", "missing", null]
     },
+    "evidence": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
     "profile": {
       "type": "object",
       "additionalProperties": false,
@@ -59,7 +65,7 @@
       ],
       "properties": {
         "profile_schema_version": {
-          "type": ["string", "null"]
+          "type": ["integer", "string", "null"]
         },
         "profile_name": {
           "type": ["string", "null"]
@@ -73,6 +79,9 @@
       }
     },
     "stack": {
+      "type": ["string", "null"]
+    },
+    "outcome_label": {
       "type": ["string", "null"]
     },
     "lineage": {
@@ -121,7 +130,7 @@
           "type": ["string", "null"]
         },
         "split": {
-          "enum": ["train", "val", "holdout", "excluded", null]
+          "enum": ["train", "val", "validation", "holdout", "excluded", null]
         },
         "exclusion_reason": {
           "type": ["string", "null"]

--- a/daydream/training/schema/v2.json
+++ b/daydream/training/schema/v2.json
@@ -28,7 +28,7 @@
       "description": "sha256 hex digest over the canonical (session_id, trajectory_id, segment_id, fingerprint) join."
     },
     "record_type": {
-      "enum": ["outcome-finding", "process-trace", "task-only"]
+      "enum": ["outcome-finding"]
     },
     "tier": {
       "enum": ["gold", "silver", "task-only"]
@@ -46,7 +46,7 @@
       "type": ["string", "null"]
     },
     "disposition": {
-      "enum": ["accepted", "rejected", "ambiguous", "unanswered", "missing", null]
+      "enum": ["accepted", "rejected", "ambiguous", "unanswered", "missing"]
     },
     "evidence": {
       "type": "array",
@@ -130,7 +130,7 @@
           "type": ["string", "null"]
         },
         "split": {
-          "enum": ["train", "val", "validation", "holdout", "excluded", null]
+          "enum": ["train", "validation", "holdout"]
         },
         "exclusion_reason": {
           "type": ["string", "null"]

--- a/daydream/training/schema/v2.json
+++ b/daydream/training/schema/v2.json
@@ -1,0 +1,135 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Daydream training-record (JSONL) schema v2",
+  "description": "Per-finding training record projected from the curated curation bundle. Each accepted/rejected finding is its own stable, tier-classified, fully-provenanced record. Ship alongside the untouched v1 artifact.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "record_id",
+    "record_type",
+    "tier",
+    "session_id",
+    "trajectory_id",
+    "task_segment",
+    "finding_fingerprint",
+    "disposition",
+    "profile",
+    "stack",
+    "lineage"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "2"
+    },
+    "record_id": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "sha256 hex digest over the canonical (session_id, trajectory_id, segment_id, fingerprint) join."
+    },
+    "record_type": {
+      "enum": ["outcome-finding", "process-trace", "task-only"]
+    },
+    "tier": {
+      "enum": ["gold", "silver", "task-only"]
+    },
+    "session_id": {
+      "type": "string"
+    },
+    "trajectory_id": {
+      "type": "string"
+    },
+    "task_segment": {
+      "type": "string"
+    },
+    "finding_fingerprint": {
+      "type": ["string", "null"]
+    },
+    "disposition": {
+      "enum": ["accepted", "rejected", "ambiguous", "unanswered", "missing", null]
+    },
+    "profile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "profile_schema_version",
+        "profile_name",
+        "profile_source_kind",
+        "profile_digest"
+      ],
+      "properties": {
+        "profile_schema_version": {
+          "type": ["string", "null"]
+        },
+        "profile_name": {
+          "type": ["string", "null"]
+        },
+        "profile_source_kind": {
+          "type": ["string", "null"]
+        },
+        "profile_digest": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "stack": {
+      "type": ["string", "null"]
+    },
+    "lineage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "hub_commit",
+        "curation_id",
+        "content_digests",
+        "labeler_policy_version",
+        "reply_classifier_version",
+        "rubric_schema_version",
+        "as_of",
+        "valid_at",
+        "split",
+        "exclusion_reason",
+        "license_decision"
+      ],
+      "properties": {
+        "hub_commit": {
+          "type": ["string", "null"],
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "curation_id": {
+          "type": ["string", "null"]
+        },
+        "content_digests": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "labeler_policy_version": {
+          "type": ["string", "null"]
+        },
+        "reply_classifier_version": {
+          "type": ["string", "null"]
+        },
+        "rubric_schema_version": {
+          "type": ["string", "null"]
+        },
+        "as_of": {
+          "type": ["string", "null"]
+        },
+        "valid_at": {
+          "type": ["string", "null"]
+        },
+        "split": {
+          "enum": ["train", "val", "holdout", "excluded", null]
+        },
+        "exclusion_reason": {
+          "type": ["string", "null"]
+        },
+        "license_decision": {
+          "type": ["string", "null"]
+        }
+      }
+    }
+  }
+}

--- a/daydream/training/stacks.py
+++ b/daydream/training/stacks.py
@@ -8,6 +8,12 @@ touches an excluded or unopted-copyleft repo fails closed.
 
 The lists themselves are owned exclusively by :mod:`daydream.training.exclusion`;
 this module re-implements no parsing.
+
+Corpus v2 adds :func:`load_dataset_v2`, an additive sibling that loads the
+frozen per-split manifests of a ``run_build_corpus_v2`` projection directory
+and refuses any record not stamped ``schema_version == "2"``. The v1 surface
+(``load_dataset``, its ``legacy_policy`` stamping, and its error messages) is
+untouched.
 """
 
 from __future__ import annotations
@@ -16,6 +22,8 @@ import json
 from pathlib import Path
 
 from daydream.training.exclusion import load_copyleft_list, load_exclusion_list
+
+__all__ = ["load_dataset", "load_dataset_v2"]
 
 
 def load_dataset(
@@ -57,6 +65,17 @@ def load_dataset(
             record["legacy_policy"] = not (isinstance(policy_version, str) and policy_version)
             records.append(record)
 
+    _enforce_license_gates(records, path, allow_copyleft)
+    return records
+
+
+def _enforce_license_gates(
+    records: list[dict[str, object]],
+    path: str | Path,
+    allow_copyleft: frozenset[str] | set[str],
+) -> None:
+    """Shared C5/C8 fail-closed gates (see module docstring). The lists are
+    owned by :mod:`daydream.training.exclusion`; this module never parses them."""
     excluded = {slug.casefold() for slug in load_exclusion_list()}
     excluded_offenders = sorted(
         {slug for rec in records if (slug := str(rec.get("repo_slug", "")).casefold()) in excluded}
@@ -84,4 +103,42 @@ def load_dataset(
             f"{', '.join(copyleft_offenders)}. Pass these slugs via allow_copyleft to admit them."
         )
 
+
+def load_dataset_v2(path: str | Path) -> list[dict[str, object]]:
+    """Load a projected corpus v2 directory (the frozen train/validation/
+    holdout JSONL manifests from ``run_build_corpus_v2``), enforcing the same
+    C5 and C8 fail-closed gates as :func:`load_dataset`.
+
+    Args:
+        path: The projection output directory containing ``train.jsonl``,
+            ``validation.jsonl`` and ``holdout.jsonl``.
+
+    Returns:
+        The full list of v2 training-record dicts, in split-file order.
+
+    Raises:
+        ValueError: When any record's ``schema_version`` is not ``"2"`` (the
+            offending record id is named), or a C5/C8 gate fires.
+        json.JSONDecodeError: When a line is not valid JSON — never a silent
+            skip.
+    """
+    projection_dir = Path(path)
+    records: list[dict[str, object]] = []
+    for filename in ("train.jsonl", "validation.jsonl", "holdout.jsonl"):
+        with (projection_dir / filename).open("r", encoding="utf-8") as fh:
+            for line in fh:
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                record = json.loads(stripped)  # malformed line propagates verbatim
+                schema_version = record.get("schema_version")
+                if schema_version != "2":
+                    raise ValueError(
+                        f"corpus v2 record {record.get('record_id')!r} in "
+                        f"{projection_dir / filename}: schema_version {schema_version!r} "
+                        "!= '2' — refusing a record not projected by the v2 schema"
+                    )
+                records.append(record)
+
+    _enforce_license_gates(records, projection_dir, frozenset())
     return records

--- a/daydream/training/stacks.py
+++ b/daydream/training/stacks.py
@@ -11,9 +11,16 @@ this module re-implements no parsing.
 
 Corpus v2 adds :func:`load_dataset_v2`, an additive sibling that loads the
 frozen per-split manifests of a ``run_build_corpus_v2`` projection directory
-and refuses any record not stamped ``schema_version == "2"``. The v1 surface
-(``load_dataset``, its ``legacy_policy`` stamping, and its error messages) is
-untouched.
+and refuses any record not stamped ``schema_version == "2"``. The C5/C8
+license gates are **not** enforced by any v2 code path: v2 projected records
+carry no ``repo_slug`` (no owner/repo field — the projection emits none and
+``schema/v2.json`` declares none), and the curation manifest carries no repo
+identity either, so neither the loader nor the bundle admission gates can
+evaluate the exclusion or copyleft lists. C5/C8 for v2 data is a
+curation-time responsibility: the curation process assembling the admitted
+bundle is where excluded/copyleft repos must be refused, before projection;
+no v2 consumer re-checks them. The v1 surface (``load_dataset``, its
+``legacy_policy`` stamping, and its error messages) is untouched.
 """
 
 from __future__ import annotations
@@ -106,8 +113,21 @@ def _enforce_license_gates(
 
 def load_dataset_v2(path: str | Path) -> list[dict[str, object]]:
     """Load a projected corpus v2 directory (the frozen train/validation/
-    holdout JSONL manifests from ``run_build_corpus_v2``), enforcing the same
-    C5 and C8 fail-closed gates as :func:`load_dataset`.
+    holdout JSONL manifests from ``run_build_corpus_v2``).
+
+    ``holdout.jsonl``. A ``_SUCCESS`` completeness marker (written last by
+    the projector, mirroring the bundle's own gate) is required: a partial
+    projection left by a mid-write failure is refused, never consumed.
+
+    The C5 exclusion and C8 copyleft fail-closed gates are **not** applied by
+    this loader: v2 projected records carry no ``repo_slug`` (the record
+    shape has no owner/repo field — the projection emits none and
+    ``schema/v2.json`` declares none), so they cannot be evaluated against
+    the exclusion or copyleft lists, and no other v2 code path consults
+    those lists either. C5/C8 for v2 data lives at bundle curation time —
+    the curation process assembling the admitted bundle must refuse excluded
+    and unopted-copyleft repos before the projection is built. This loader
+    only verifies the v2 schema stamp on every record.
 
     Args:
         path: The projection output directory containing ``train.jsonl``,
@@ -117,12 +137,18 @@ def load_dataset_v2(path: str | Path) -> list[dict[str, object]]:
         The full list of v2 training-record dicts, in split-file order.
 
     Raises:
-        ValueError: When any record's ``schema_version`` is not ``"2"`` (the
-            offending record id is named), or a C5/C8 gate fires.
+        ValueError: When the projection lacks its ``_SUCCESS`` marker, or
+            when any record's ``schema_version`` is not ``"2"`` (the
+            offending record id is named).
         json.JSONDecodeError: When a line is not valid JSON — never a silent
             skip.
     """
     projection_dir = Path(path)
+    if not (projection_dir / "_SUCCESS").is_file():
+        raise ValueError(
+            f"corpus v2 projection {projection_dir}: missing _SUCCESS marker — "
+            "refusing a partial or incomplete projection"
+        )
     records: list[dict[str, object]] = []
     for filename in ("train.jsonl", "validation.jsonl", "holdout.jsonl"):
         with (projection_dir / filename).open("r", encoding="utf-8") as fh:
@@ -140,5 +166,4 @@ def load_dataset_v2(path: str | Path) -> list[dict[str, object]]:
                     )
                 records.append(record)
 
-    _enforce_license_gates(records, projection_dir, frozenset())
     return records

--- a/tests/test_cli_corpus_namespace.py
+++ b/tests/test_cli_corpus_namespace.py
@@ -69,9 +69,10 @@ def test_corpus_build_and_label_route(monkeypatch: pytest.MonkeyPatch, tmp_path:
 def test_bare_corpus_prints_help_exits_2(capsys: pytest.CaptureFixture[str]) -> None:
     assert _run_main(["corpus"]) == 2
     captured = capsys.readouterr()
-    assert "usage: daydream corpus {harvest,build,label,hydrate-hub}" in captured.out
+    assert "usage: daydream corpus {harvest,build,build-v2,label,hydrate-hub}" in captured.out
     assert "harvest" in captured.out
     assert "build" in captured.out
+    assert "build-v2" in captured.out
     assert "label" in captured.out
 
 

--- a/tests/test_corpus_v2.py
+++ b/tests/test_corpus_v2.py
@@ -69,11 +69,18 @@ def _write_bundle(tmp_path: Path, *, with_success: bool = True, corrupt_digest: 
     return bundle_dir
 
 
+def _cfg(out_dir: Path, bundle_dir: Path, snapshot: Path, **kw: Any) -> Any:
+    from daydream.training.corpus_v2.projector import BuildCorpusV2Config
+
+    return BuildCorpusV2Config(out_dir=out_dir, bundle_dir=bundle_dir, annotations_snapshot=snapshot, **kw)
+
+
 def _write_annotations_snapshot(
     bundle_dir: Path,
     *,
     valid_at: str = "2026-01-01T00:00:00+00:00",
     session_id: str = "sess-a",
+    dispositions: list[str] | None = None,
 ) -> Path:
     """Task 0A side-car shape: a digest-pinned JSONL of per-finding
     resolution records keyed by fingerprint, exported alongside the bundle
@@ -92,28 +99,17 @@ def _write_annotations_snapshot(
         json.dumps(trajectory) + "\n"
     )
     snapshot_path = bundle_dir / "annotations-snapshot.jsonl"
-    rows = [
-        {
-            "session_id": session_id,
-            "fingerprint": "a1" * 32,
-            "disposition": "accepted",
-            "evidence": [{"comment_id": 1, "created_at": "2026-02-01T00:00:00+00:00",
-                          "classifier_label": "accepted", "valid_at": valid_at}],
-        },
-        {
-            "session_id": session_id,
-            "fingerprint": "b2" * 32,
-            "disposition": "rejected",
-            "evidence": [{"comment_id": 2, "created_at": "2026-02-02T00:00:00+00:00",
-                          "classifier_label": "rejected", "valid_at": valid_at}],
-        },
-        {
-            "session_id": session_id,
-            "fingerprint": "c3" * 32,
-            "disposition": "ambiguous",
-            "evidence": [],
-        },
-    ]
+    fps = ["a1" * 32, "b2" * 32, "c3" * 32]
+    rows = []
+    for i, disposition in enumerate(dispositions or ["accepted", "rejected", "ambiguous"]):
+        evidence = (
+            [{"comment_id": i + 1, "created_at": "2026-02-01T00:00:00+00:00",
+              "classifier_label": disposition, "valid_at": valid_at}]
+            if disposition in ("accepted", "rejected")
+            else []
+        )
+        rows.append({"session_id": session_id, "fingerprint": fps[i % len(fps)],
+                     "disposition": disposition, "evidence": evidence})
     snapshot_path.write_text("".join(json.dumps(r, sort_keys=True) + "\n" for r in rows))
     _write_sumsums(bundle_dir)  # the snapshot + trajectory join the digest pin
     return snapshot_path
@@ -357,3 +353,26 @@ def test_run_level_contested_aggregate_never_erases_split() -> None:
                                                      _res("b2" * 32, "rejected")]}))
     assert all(r["outcome_label"] != "contested" for r in records)
     assert sorted(str(r["disposition"]) for r in records) == ["accepted", "rejected"]
+
+
+# ---------------------------------------------------------------------------
+# Task 9: summary + full lineage + adjudication report
+# ---------------------------------------------------------------------------
+
+from daydream.training.corpus_v2.projector import run_build_corpus_v2  # noqa: E402
+
+
+def test_build_summary_and_lineage_are_complete(tmp_path: Path) -> None:
+    bundle_dir = _write_bundle(tmp_path)
+    snap = _write_annotations_snapshot(bundle_dir, dispositions=["accepted", "rejected", "ambiguous"])
+    summary = run_build_corpus_v2(_cfg(tmp_path / "out", bundle_dir, snap))
+    assert set(summary) >= {"records_by_type", "records_by_tier", "records_by_split",
+                            "caps", "exclusions_by_reason"}
+    assert summary["records_by_type"]["outcome-finding"] >= 2
+    lineage = json.loads((tmp_path / "out" / "lineage.json").read_text())
+    for key in ("hub_commit", "curation_id", "content_digests", "labeler_policy_version",
+                "reply_classifier_version", "rubric_schema_version", "as_of", "valid_at"):
+        assert key in lineage, key
+    adj_report = tmp_path / "out" / "adjudication-report.json"
+    assert adj_report.is_file()
+    assert "missing" in adj_report.read_text()

--- a/tests/test_corpus_v2.py
+++ b/tests/test_corpus_v2.py
@@ -1,61 +1,106 @@
-"""Tests for corpus-v2: schema artifact, version constants, and projection."""
-
+import hashlib
 import json
 from pathlib import Path
 
-from jsonschema import Draft202012Validator
+import pytest
 
-from daydream.training.schema import (
-    TRAINING_SCHEMA_V1_PATH,
-    TRAINING_SCHEMA_V2_PATH,
-    TRAINING_SCHEMA_V2_VERSION,
-)
+from daydream.training.corpus_v2.bundle import BundleError, CuratedBundle, load_curated_bundle
 
-
-def _minimal_v2_record() -> dict[str, object]:
-    """Smallest dict passing every required field of schema/v2.json."""
-    return {
-        "schema_version": "2",
-        "record_id": "a" * 64,
-        "record_type": "outcome-finding",
-        "tier": "gold",
-        "session_id": "sess-1",
-        "trajectory_id": "traj-1",
-        "task_segment": "seg-1",
-        "finding_fingerprint": "fp-1",
-        "disposition": "accepted",
-        "profile": {
-            "profile_schema_version": None,
-            "profile_name": None,
-            "profile_source_kind": None,
-            "profile_digest": None,
+_MANIFEST = {
+    "schema_version": "1",
+    "source_hub_commit": "0123456789abcdef0123456789abcdef01234567",
+    "curation_id": "cur-0123456789abcdef",
+    "sanitizer_version": "1",
+    "hydration_index_schema_version": "1",
+    "admission_policy_version": "1",
+    "publication_prefix": "curated/cur-0123456789abcdef/",
+    "batches": [
+        {
+            "session_id": "sess-a",
+            "content_digest": "1111111111111111111111111111111111111111111111111111111111111111",
+            "status": "admitted",
+            "reason_code": None,
+            "artifact_relpath": "batches/sess-a/trajectory.jsonl",
+            "artifact_digest": None,
+            "manifest_relpath": "batches/sess-a/manifest.json",
         },
-        "stack": "python",
-        "lineage": {
-            "hub_commit": None,
-            "curation_id": None,
-            "content_digests": [],
-            "labeler_policy_version": None,
-            "reply_classifier_version": None,
-            "rubric_schema_version": None,
-            "as_of": None,
-            "valid_at": None,
-            "split": "train",
-            "exclusion_reason": None,
-            "license_decision": None,
+        {
+            "session_id": "sess-b",
+            "content_digest": "3333333333333333333333333333333333333333333333333333333333333333",
+            "status": "quarantined",
+            "reason_code": "secrets_scan_dirty",
+            "artifact_relpath": "batches/sess-b/trajectory.jsonl",
+            "artifact_digest": None,
+            "manifest_relpath": None,
         },
-    }
+    ],
+}
 
 
-def test_v2_schema_ships_alongside_v1_and_validates_golden_record() -> None:
-    assert Path(TRAINING_SCHEMA_V2_PATH).exists()
-    assert Path(TRAINING_SCHEMA_V2_PATH) != Path(TRAINING_SCHEMA_V1_PATH)  # v1 untouched
-    schema = json.loads(Path(TRAINING_SCHEMA_V2_PATH).read_text())
-    validator = Draft202012Validator(schema)
-    record = _minimal_v2_record()
-    errors = sorted(validator.iter_errors(record), key=lambda e: e.json_path)
-    assert errors == [], [e.message for e in errors]
+def _write_sumsums(bundle_dir: Path, *, exclude: set[str] = frozenset()) -> None:
+    lines = []
+    for path in sorted(bundle_dir.rglob("*")):
+        if not path.is_file() or path.name == "SHA256SUMS" or path.name == "_SUCCESS":
+            continue
+        rel = path.relative_to(bundle_dir).as_posix()
+        if rel in exclude:
+            continue
+        lines.append(f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {rel}")
+    (bundle_dir / "SHA256SUMS").write_text("\n".join(lines) + "\n")
 
 
-def test_v2_version_constant_is_two() -> None:
-    assert TRAINING_SCHEMA_V2_VERSION == "2"
+def _write_bundle(tmp_path: Path, *, with_success: bool = True, corrupt_digest: bool = False) -> Path:
+    bundle_dir = tmp_path / "curated" / "cur-0123456789abcdef"
+    for rel in ("batches/sess-a/trajectory.jsonl", "batches/sess-a/manifest.json", "batches/sess-b/trajectory.jsonl"):
+        target = bundle_dir / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("{}\n")
+    (bundle_dir / "curation-manifest-v1.json").write_text(json.dumps(_MANIFEST))
+    _write_sumsums(bundle_dir)
+    if with_success:
+        (bundle_dir / "_SUCCESS").write_text("ok\n")
+    if corrupt_digest:
+        (bundle_dir / "batches" / "sess-a" / "trajectory.jsonl").write_bytes(b"tampered\n")
+    return bundle_dir
+
+
+def test_load_bundle_requires_success_marker(tmp_path: Path) -> None:
+    bundle_dir = _write_bundle(tmp_path)
+    (bundle_dir / "_SUCCESS").unlink()
+    with pytest.raises(BundleError, match="_SUCCESS"):
+        load_curated_bundle(bundle_dir)
+
+
+def test_load_bundle_rejects_digest_mismatch(tmp_path: Path) -> None:
+    bundle_dir = _write_bundle(tmp_path, corrupt_digest=True)
+    with pytest.raises(BundleError, match="digest mismatch"):
+        load_curated_bundle(bundle_dir)
+
+
+def test_load_bundle_rejects_incompatible_schema_version(tmp_path: Path) -> None:
+    bundle_dir = _write_bundle(tmp_path)
+    manifest_path = bundle_dir / "curation-manifest-v1.json"
+    doc = json.loads(manifest_path.read_text())
+    doc["schema_version"] = "999"
+    manifest_path.write_text(json.dumps(doc))
+    # SHA256SUMS must be regenerated so the failure is schema, not digest.
+    _write_sumsums(bundle_dir)
+    with pytest.raises(BundleError, match="schema_version"):
+        load_curated_bundle(bundle_dir)
+
+
+def test_load_bundle_uses_relative_paths_only(tmp_path: Path) -> None:
+    bundle_dir = _write_bundle(tmp_path)
+    loaded = load_curated_bundle(bundle_dir)
+    assert isinstance(loaded, CuratedBundle)
+    for batch in loaded.admitted:
+        assert not str(batch.artifact_relpath).startswith("/")
+        assert ".." not in Path(batch.artifact_relpath).parts
+        assert (bundle_dir / batch.artifact_relpath).exists()
+
+
+def test_load_bundle_rejects_missing_batches_file(tmp_path: Path) -> None:
+    bundle_dir = _write_bundle(tmp_path)
+    (bundle_dir / "batches" / "sess-a" / "trajectory.jsonl").unlink()
+    with pytest.raises(BundleError, match="missing artifact"):
+        load_curated_bundle(bundle_dir)

--- a/tests/test_corpus_v2.py
+++ b/tests/test_corpus_v2.py
@@ -256,3 +256,54 @@ def test_legacy_skill_carried_as_provenance_never_required() -> None:
 def test_stack_falls_back_to_none_when_unresolvable() -> None:
     prov = extract_provenance({"skill": "unknown-thing", "stack": None})
     assert prov["stack"] is None
+
+
+# ---------------------------------------------------------------------------
+# Task 7: per-finding projection + adjudication routing
+# ---------------------------------------------------------------------------
+
+from daydream.training.corpus_v2.projector import project_findings  # noqa: E402
+
+
+def _res(fp: str, disposition: str) -> dict[str, object]:
+    return {"fingerprint": fp, "disposition": disposition,
+            "evidence": [{"comment_id": 1, "created_at": "2026-02-01T00:00:00+00:00",
+                          "classifier_label": disposition}] if disposition in ("accepted", "rejected") else []}
+
+
+def test_mixed_session_yields_two_distinct_gold_records() -> None:
+    session = {"session_id": "s1", "trajectory_id": "s1:root", "segment_id": "seg-0",
+               "resolutions": [_res("a1" * 32, "accepted"), _res("b2" * 32, "rejected")]}
+    records = project_findings(session)
+    gold = [r for r in records if r["tier"] == "gold"]
+    assert len(gold) == 2
+    assert {r["finding_fingerprint"] for r in gold} == {"a1" * 32, "b2" * 32}
+    assert {r["record_id"] for r in gold} and len({r["record_id"] for r in gold}) == 2
+    assert {r["disposition"] for r in gold} == {"accepted", "rejected"}
+
+
+def test_reply_existence_never_constitutes_acceptance() -> None:
+    # ambiguous: a reply exists but the classifier did not map accepted/rejected
+    records = list(project_findings({"session_id": "s1", "trajectory_id": "s1:root",
+                                     "segment_id": "seg-0",
+                                     "resolutions": [_res("c3" * 32, "ambiguous")]}))
+    assert all(r["tier"] != "gold" for r in records)
+
+
+def test_non_decisive_findings_route_to_adjudication() -> None:
+    session = {"session_id": "s1", "trajectory_id": "s1:root", "segment_id": "seg-0",
+               "resolutions": [_res("d4" * 32, "ambiguous"), _res("e5" * 32, "missing")]}
+    records, adjudication = project_findings(session, return_adjudication=True)
+    assert {r["finding_fingerprint"] for r in records if r["tier"] == "gold"} == set()
+    assert {a["fingerprint"] for a in adjudication} == {"d4" * 32, "e5" * 32}
+    assert all(a["evidence"] == [] for a in adjudication)  # evidence carried for the human pass
+
+
+def test_run_level_contested_aggregate_never_erases_split() -> None:
+    # v1 collapse: outcome_label="contested". v2 must never produce that shape.
+    records = list(project_findings({"session_id": "s1", "trajectory_id": "s1:root",
+                                     "segment_id": "seg-0",
+                                     "resolutions": [_res("a1" * 32, "accepted"),
+                                                     _res("b2" * 32, "rejected")]}))
+    assert all(r["outcome_label"] != "contested" for r in records)
+    assert sorted(str(r["disposition"]) for r in records) == ["accepted", "rejected"]

--- a/tests/test_corpus_v2.py
+++ b/tests/test_corpus_v2.py
@@ -1,0 +1,61 @@
+"""Tests for corpus-v2: schema artifact, version constants, and projection."""
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+from daydream.training.schema import (
+    TRAINING_SCHEMA_V1_PATH,
+    TRAINING_SCHEMA_V2_PATH,
+    TRAINING_SCHEMA_V2_VERSION,
+)
+
+
+def _minimal_v2_record() -> dict[str, object]:
+    """Smallest dict passing every required field of schema/v2.json."""
+    return {
+        "schema_version": "2",
+        "record_id": "a" * 64,
+        "record_type": "outcome-finding",
+        "tier": "gold",
+        "session_id": "sess-1",
+        "trajectory_id": "traj-1",
+        "task_segment": "seg-1",
+        "finding_fingerprint": "fp-1",
+        "disposition": "accepted",
+        "profile": {
+            "profile_schema_version": None,
+            "profile_name": None,
+            "profile_source_kind": None,
+            "profile_digest": None,
+        },
+        "stack": "python",
+        "lineage": {
+            "hub_commit": None,
+            "curation_id": None,
+            "content_digests": [],
+            "labeler_policy_version": None,
+            "reply_classifier_version": None,
+            "rubric_schema_version": None,
+            "as_of": None,
+            "valid_at": None,
+            "split": "train",
+            "exclusion_reason": None,
+            "license_decision": None,
+        },
+    }
+
+
+def test_v2_schema_ships_alongside_v1_and_validates_golden_record() -> None:
+    assert Path(TRAINING_SCHEMA_V2_PATH).exists()
+    assert Path(TRAINING_SCHEMA_V2_PATH) != Path(TRAINING_SCHEMA_V1_PATH)  # v1 untouched
+    schema = json.loads(Path(TRAINING_SCHEMA_V2_PATH).read_text())
+    validator = Draft202012Validator(schema)
+    record = _minimal_v2_record()
+    errors = sorted(validator.iter_errors(record), key=lambda e: e.json_path)
+    assert errors == [], [e.message for e in errors]
+
+
+def test_v2_version_constant_is_two() -> None:
+    assert TRAINING_SCHEMA_V2_VERSION == "2"

--- a/tests/test_corpus_v2.py
+++ b/tests/test_corpus_v2.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from daydream.training.corpus_v2.bundle import BundleError, CuratedBundle, load_curated_bundle
+from daydream.training.corpus_v2.identity import record_id
 
 _MANIFEST = {
     "schema_version": "1",
@@ -37,7 +38,7 @@ _MANIFEST = {
 }
 
 
-def _write_sumsums(bundle_dir: Path, *, exclude: set[str] = frozenset()) -> None:
+def _write_sumsums(bundle_dir: Path, *, exclude: frozenset[str] = frozenset()) -> None:
     lines = []
     for path in sorted(bundle_dir.rglob("*")):
         if not path.is_file() or path.name == "SHA256SUMS" or path.name == "_SUCCESS":
@@ -104,3 +105,16 @@ def test_load_bundle_rejects_missing_batches_file(tmp_path: Path) -> None:
     (bundle_dir / "batches" / "sess-a" / "trajectory.jsonl").unlink()
     with pytest.raises(BundleError, match="missing artifact"):
         load_curated_bundle(bundle_dir)
+
+def test_record_id_is_stable_and_discriminating() -> None:
+    a = record_id(session_id="s1", trajectory_id="s1:fix-0", segment_id="seg-0", fingerprint="ab" * 32)
+    assert a == record_id(session_id="s1", trajectory_id="s1:fix-0", segment_id="seg-0", fingerprint="ab" * 32)
+    assert record_id(session_id="s2", trajectory_id="s1:fix-0", segment_id="seg-0", fingerprint="ab" * 32) != a
+    assert record_id(session_id="s1", trajectory_id="s1:fix-1", segment_id="seg-0", fingerprint="ab" * 32) != a
+    assert record_id(session_id="s1", trajectory_id="s1:fix-0", segment_id="seg-1", fingerprint="ab" * 32) != a
+    assert record_id(session_id="s1", trajectory_id="s1:fix-0", segment_id="seg-0", fingerprint="cd" * 32) != a
+
+
+def test_record_id_is_deterministic_sha256_of_canonical_join() -> None:
+    expected = hashlib.sha256(b"s1\x1fs1:fix-0\x1fseg-0\x1f" + b"ab" * 32).hexdigest()
+    assert record_id("s1", "s1:fix-0", "seg-0", "ab" * 32) == expected

--- a/tests/test_corpus_v2.py
+++ b/tests/test_corpus_v2.py
@@ -44,13 +44,18 @@ _MANIFEST = {
 
 def _write_sumsums(bundle_dir: Path, *, exclude: frozenset[str] = frozenset()) -> None:
     lines = []
+    # Producer-realistic relpaths: daydream.archive.hydrate.finalize writes
+    # SHA256SUMS lines relative to the hub-checkout root under the
+    # ``curated/<curation-id>/`` prefix; bundle.py strips that prefix because
+    # the bundle root is the curated directory itself.
+    prefix = f"curated/{bundle_dir.name}/" if bundle_dir.parent.name == "curated" else ""
     for path in sorted(bundle_dir.rglob("*")):
         if not path.is_file() or path.name == "SHA256SUMS" or path.name == "_SUCCESS":
             continue
         rel = path.relative_to(bundle_dir).as_posix()
         if rel in exclude:
             continue
-        lines.append(f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {rel}")
+        lines.append(f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {prefix}{rel}")
     (bundle_dir / "SHA256SUMS").write_text("\n".join(lines) + "\n")
 
 
@@ -60,7 +65,7 @@ def _write_bundle(tmp_path: Path, *, with_success: bool = True, corrupt_digest: 
         target = bundle_dir / rel
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text("{}\n")
-    (bundle_dir / "curation-manifest-v1.json").write_text(json.dumps(_MANIFEST))
+    (bundle_dir / "curation-manifest.json").write_text(json.dumps(_MANIFEST))
     _write_sumsums(bundle_dir)
     if with_success:
         (bundle_dir / "_SUCCESS").write_text("ok\n")
@@ -81,18 +86,21 @@ def _write_annotations_snapshot(
     valid_at: str = "2026-01-01T00:00:00+00:00",
     session_id: str = "sess-a",
     dispositions: list[str] | None = None,
+    n_siblings: int = 1,
 ) -> Path:
     """Task 0A side-car shape: a digest-pinned JSONL of per-finding
     resolution records keyed by fingerprint, exported alongside the bundle
     and covered by SHA256SUMS. Also gives the admitted batch a real ATIF
-    trajectory so segmentation has something to segment."""
+    trajectory so segmentation has something to segment (``n_siblings``
+    sibling subagent refs)."""
     trajectory = {
         "session_id": session_id,
         "trajectory_id": f"{session_id}:root",
         "subagent_trajectory_ref": [
-            {"trajectory_id": f"{session_id}:fix-0", "session_id": session_id, "steps": [
+            {"trajectory_id": f"{session_id}:fix-{i}", "session_id": session_id, "steps": [
                 {"step_id": 1, "source": "agent", "message": "fix"},
-            ]},
+            ]}
+            for i in range(n_siblings)
         ],
     }
     (bundle_dir / "batches" / session_id / "trajectory.jsonl").write_text(
@@ -109,7 +117,9 @@ def _write_annotations_snapshot(
             else []
         )
         rows.append({"session_id": session_id, "fingerprint": fps[i % len(fps)],
-                     "disposition": disposition, "evidence": evidence})
+                     "disposition": disposition, "evidence": evidence,
+                     "profile_schema_version": 2, "profile_name": "deep-review",
+                     "profile_source_kind": "builtin", "profile_digest": "d" * 64})
     snapshot_path.write_text("".join(json.dumps(r, sort_keys=True) + "\n" for r in rows))
     _write_sumsums(bundle_dir)  # the snapshot + trajectory join the digest pin
     return snapshot_path
@@ -130,7 +140,7 @@ def test_load_bundle_rejects_digest_mismatch(tmp_path: Path) -> None:
 
 def test_load_bundle_rejects_incompatible_schema_version(tmp_path: Path) -> None:
     bundle_dir = _write_bundle(tmp_path)
-    manifest_path = bundle_dir / "curation-manifest-v1.json"
+    manifest_path = bundle_dir / "curation-manifest.json"
     doc = json.loads(manifest_path.read_text())
     doc["schema_version"] = "999"
     manifest_path.write_text(json.dumps(doc))
@@ -287,7 +297,7 @@ def test_native_profile_run_without_legacy_skill_validates() -> None:
     assert extract_provenance(v2_record)["stack"] == "python"
     # Schema validity is Task 1's validator's job; here we pin that no
     # required-ness is smuggled back in for skill.
-    assert "skill" not in {f for f in v2_record if v2_record[f] is None and f == "skill"} or True
+    assert "skill" in {f for f in v2_record if v2_record[f] is None and f == "skill"}
 
 
 def test_legacy_skill_carried_as_provenance_never_required() -> None:
@@ -378,6 +388,19 @@ def test_build_summary_and_lineage_are_complete(tmp_path: Path) -> None:
     assert "missing" in adj_report.read_text()
 
 
+def test_projected_records_carry_profile_and_stack_provenance(tmp_path: Path) -> None:
+    bundle_dir = _write_bundle(tmp_path)
+    snap = _write_annotations_snapshot(bundle_dir, dispositions=["accepted", "rejected"])
+    run_build_corpus_v2(_cfg(tmp_path / "out", bundle_dir, snap))
+    records = [json.loads(line) for line in
+               (tmp_path / "out" / "corpus.jsonl").read_text().splitlines() if line]
+    assert records
+    for rec in records:
+        assert rec["profile"] == {"profile_schema_version": 2, "profile_name": "deep-review",
+                                   "profile_source_kind": "builtin", "profile_digest": "d" * 64}
+        assert "stack" in rec  # schema-required provenance key, never dropped
+
+
 # ---------------------------------------------------------------------------
 # Task 10: additive v2 loader surface (stacks.py) + v1 untouched gate
 # ---------------------------------------------------------------------------
@@ -405,6 +428,7 @@ def test_v2_loader_loads_projected_manifest_fail_closed(tmp_path: Path) -> None:
 def test_v2_loader_refuses_non_v2_record_naming_record_id(tmp_path: Path) -> None:
     out = tmp_path / "proj"
     out.mkdir()
+    (out / "_SUCCESS").write_text("ok\n")
     bad = {"schema_version": "1", "record_id": "deadbeef", "tier": "gold"}
     (out / "train.jsonl").write_text(json.dumps(bad) + "\n")
     with pytest.raises(ValueError, match="deadbeef"):
@@ -414,9 +438,101 @@ def test_v2_loader_refuses_non_v2_record_naming_record_id(tmp_path: Path) -> Non
 def test_v2_loader_refuses_malformed_line_verbatim(tmp_path: Path) -> None:
     out = tmp_path / "proj"
     out.mkdir()
+    (out / "_SUCCESS").write_text("ok\n")
     (out / "train.jsonl").write_text("{not json\n")
     with pytest.raises(json.JSONDecodeError):
         load_dataset_v2(out)
+
+
+def test_v2_loader_refuses_partial_projection_without_success_marker(tmp_path: Path) -> None:
+    # A mid-write failure leaves a partial file set behind; without the
+    # projector's _SUCCESS completeness marker the loader must refuse it
+    # rather than consume it as a complete row-set.
+    out = tmp_path / "proj"
+    out.mkdir()
+    (out / "train.jsonl").write_text("{}\n")
+    with pytest.raises(ValueError, match="_SUCCESS"):
+        load_dataset_v2(out)
+
+
+def test_emitted_records_validate_against_shipped_v2_schema(tmp_path: Path) -> None:
+    # The projector copies schema/v2.json beside its output, so every emitted
+    # record must validate against that exact artifact (TRAINING_SCHEMA_V2_PATH
+    # is the consumed-by-test canonical contract; nothing may ship a schema the
+    # projector's own output cannot satisfy).
+    from jsonschema import Draft202012Validator
+
+    from daydream.training.schema import TRAINING_SCHEMA_V2_PATH
+
+    bundle_dir = _write_bundle(tmp_path)
+    snap = _write_annotations_snapshot(bundle_dir)
+    out = tmp_path / "proj"
+    summary = run_build_corpus_v2(_cfg(out, bundle_dir, snap))
+    assert summary["emitted"] >= 1
+    validator = Draft202012Validator(json.loads(TRAINING_SCHEMA_V2_PATH.read_text()))
+    records = [
+        json.loads(line)
+        for line in (out / "corpus.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+    assert records
+    errors = sorted(
+        (err.json_path, err.message) for rec in records for err in validator.iter_errors(rec)
+    )
+    assert not errors, errors
+    # every split-manifest record must validate too
+    for name in ("train.jsonl", "validation.jsonl", "holdout.jsonl"):
+        for line in (out / name).read_text().splitlines():
+            if line.strip():
+                errors = list(validator.iter_errors(json.loads(line)))
+                assert not errors, (name, errors)
+
+
+def test_one_record_per_finding_across_segments(tmp_path: Path) -> None:
+    # The snapshot resolutions are session-scoped, so one finding must never
+    # fan out into per-segment copies that could land in different splits.
+    bundle_dir = _write_bundle(tmp_path)
+    snap = _write_annotations_snapshot(
+        bundle_dir, dispositions=["accepted", "rejected"], n_siblings=2
+    )
+    out = tmp_path / "proj"
+    run_build_corpus_v2(_cfg(out, bundle_dir, snap))
+    records = [
+        json.loads(line)
+        for line in (out / "corpus.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+    assert len(records) == 2  # one per (session, fingerprint), not per segment
+    assert len({r["record_id"] for r in records}) == len(records)
+    by_fp: dict[str, list[dict[str, Any]]] = {}
+    for rec in records:
+        by_fp.setdefault(str(rec["finding_fingerprint"]), []).append(rec)
+    assert all(len(v) == 1 for v in by_fp.values())
+
+
+def test_task_only_findings_are_adjudication_only_not_training(tmp_path: Path) -> None:
+    # Non-decisive findings are report output only (D8): excluded from
+    # corpus.jsonl and the split manifests, and counted as excluded in
+    # lineage/summary — the membership and the accounting must agree.
+    bundle_dir = _write_bundle(tmp_path)
+    snap = _write_annotations_snapshot(bundle_dir, dispositions=["accepted", "ambiguous"])
+    out = tmp_path / "proj"
+    summary = run_build_corpus_v2(_cfg(out, bundle_dir, snap))
+    assert summary["records_by_tier"] == {"gold": 1}
+    assert summary["exclusions_by_reason"] == {"non-decisive-adjudication": 1}
+    records = [
+        json.loads(line)
+        for line in (out / "corpus.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+    assert all(r["tier"] != "task-only" for r in records)
+    for name in ("train.jsonl", "validation.jsonl", "holdout.jsonl"):
+        for line in (out / name).read_text().splitlines():
+            if line.strip():
+                assert json.loads(line)["tier"] != "task-only"
+    adjudication = json.loads((out / "adjudication-report.json").read_text())
+    assert [a["fingerprint"] for a in adjudication] == ["b2" * 32]
+    assert (out / "_SUCCESS").is_file()
 
 
 def test_v1_loader_and_v1_artifacts_unaffected(tmp_path: Path) -> None:

--- a/tests/test_corpus_v2.py
+++ b/tests/test_corpus_v2.py
@@ -431,3 +431,43 @@ def test_v1_loader_and_v1_artifacts_unaffected(tmp_path: Path) -> None:
     import daydream.training.corpus  # v1 module importable, unmodified
     v1_src = (Path(daydream.training.corpus.__file__)).read_bytes()
     assert hashlib.sha256(v1_src).hexdigest() == _V1_CORPUS_SHA_AT_PLAN_TIME
+
+
+# ---------------------------------------------------------------------------
+# Task 11: CLI wiring — ``daydream corpus build-v2``
+# ---------------------------------------------------------------------------
+
+
+def _run_cli(argv: list[str]) -> int:
+    """Drive ``cli.main`` (the production entrypoint) with ``argv``."""
+    import sys
+
+    from daydream import cli
+
+    saved = sys.argv
+    sys.argv = ["daydream", *argv]
+    try:
+        cli.main()
+    except SystemExit as exc:  # main() always exits via sys.exit
+        return int(exc.code or 0)
+    finally:
+        sys.argv = saved
+    return 0
+
+
+def test_cli_build_v2_projects_real_bundle(tmp_path: Path) -> None:
+    bundle_dir = _write_bundle(tmp_path)
+    snap = _write_annotations_snapshot(bundle_dir)
+    rc = _run_cli(["corpus", "build-v2", "--bundle-root", str(bundle_dir),
+                   "--annotations-snapshot", str(snap), "--out", str(tmp_path / "out" / "c.jsonl")])
+    assert rc == 0
+    assert (tmp_path / "out" / "corpus-v2.jsonl").is_file()
+    assert (tmp_path / "out" / "lineage.json").is_file()
+
+
+def test_cli_build_v2_refuses_missing_bundle_fail_closed(tmp_path: Path) -> None:
+    rc = _run_cli(["corpus", "build-v2", "--bundle-root", str(tmp_path / "nope"),
+                   "--annotations-snapshot", str(tmp_path / "nope" / "snap.jsonl"),
+                   "--out", str(tmp_path / "out" / "c.jsonl")])
+    assert rc != 0
+    assert not (tmp_path / "out" / "lineage.json").exists()

--- a/tests/test_corpus_v2.py
+++ b/tests/test_corpus_v2.py
@@ -376,3 +376,58 @@ def test_build_summary_and_lineage_are_complete(tmp_path: Path) -> None:
     adj_report = tmp_path / "out" / "adjudication-report.json"
     assert adj_report.is_file()
     assert "missing" in adj_report.read_text()
+
+
+# ---------------------------------------------------------------------------
+# Task 10: additive v2 loader surface (stacks.py) + v1 untouched gate
+# ---------------------------------------------------------------------------
+
+from daydream.training.stacks import load_dataset, load_dataset_v2  # noqa: E402
+
+# sha256 of daydream/training/corpus.py pinned at task-10 start; proves v1
+# module bytes were never touched by the v2 work (Req 16).
+_V1_CORPUS_SHA_AT_PLAN_TIME = (
+    "09a523efbb42aefe52a042df9155a126f3fe4c0ba7b92305ef31b49181223040"
+)
+
+
+def test_v2_loader_loads_projected_manifest_fail_closed(tmp_path: Path) -> None:
+    bundle_dir = _write_bundle(tmp_path)
+    snap = _write_annotations_snapshot(bundle_dir, dispositions=["accepted", "rejected"])
+    summary = run_build_corpus_v2(_cfg(tmp_path / "proj", bundle_dir, snap))
+    assert summary["emitted"] >= 1
+    records = load_dataset_v2(tmp_path / "proj")
+    assert records
+    assert all(r["schema_version"] == "2" for r in records)
+    assert all(r["tier"] in {"gold", "silver", "task-only"} for r in records)
+
+
+def test_v2_loader_refuses_non_v2_record_naming_record_id(tmp_path: Path) -> None:
+    out = tmp_path / "proj"
+    out.mkdir()
+    bad = {"schema_version": "1", "record_id": "deadbeef", "tier": "gold"}
+    (out / "train.jsonl").write_text(json.dumps(bad) + "\n")
+    with pytest.raises(ValueError, match="deadbeef"):
+        load_dataset_v2(out)
+
+
+def test_v2_loader_refuses_malformed_line_verbatim(tmp_path: Path) -> None:
+    out = tmp_path / "proj"
+    out.mkdir()
+    (out / "train.jsonl").write_text("{not json\n")
+    with pytest.raises(json.JSONDecodeError):
+        load_dataset_v2(out)
+
+
+def test_v1_loader_and_v1_artifacts_unaffected(tmp_path: Path) -> None:
+    # v1 loader still loads a v1 record unchanged; v1 schema file untouched
+    v1_record = {"schema_version": "1", "session_id": "s", "repo_slug": "o/r",
+                 "pr_number": 1, "outcome_label": "accepted", "labeler_policy_version": "1"}
+    p = tmp_path / "v1.jsonl"
+    p.write_text(json.dumps(v1_record) + "\n")
+    assert load_dataset(p)[0]["schema_version"] == "1"
+    from daydream.training.schema import TRAINING_SCHEMA_VERSION
+    assert TRAINING_SCHEMA_VERSION == "1"  # never bumped in-place
+    import daydream.training.corpus  # v1 module importable, unmodified
+    v1_src = (Path(daydream.training.corpus.__file__)).read_bytes()
+    assert hashlib.sha256(v1_src).hexdigest() == _V1_CORPUS_SHA_AT_PLAN_TIME

--- a/tests/test_corpus_v2.py
+++ b/tests/test_corpus_v2.py
@@ -1,11 +1,13 @@
 import hashlib
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from daydream.training.corpus_v2.bundle import BundleError, CuratedBundle, load_curated_bundle
 from daydream.training.corpus_v2.identity import record_id
+from daydream.training.corpus_v2.segments import segment, segment_agents
 from daydream.training.corpus_v2.tiers import GoldGateError, classify_tier
 
 _MANIFEST = {
@@ -161,3 +163,54 @@ def test_tiers_are_disjoint_classes() -> None:
     # process-trace tier is silver, never gold; eligibility is a separate field
     tier = classify_tier(_resolution("accepted"), record_type="process-trace")
     assert tier == "silver"  # type/decision split: ATIF process data stays silver
+
+
+def _traj(siblings: list[tuple[str, str]]) -> dict[str, Any]:
+    return {"trajectory_id": "s1:root", "session_id": "s1",
+            "subagent_trajectory_ref": [{"trajectory_id": t, "session_id": "s1",
+                                          "trajectory_path": p} for t, p in siblings]}
+
+
+def test_segment_order_is_fork_registration_then_descriptor() -> None:
+    # Pinned rule from Task 0B: (order_index, descriptor) total order.
+    traj = _traj([("s1:fix-1", "b.jsonl"), ("s1:fix-0", "a.jsonl")])
+    segs = segment(traj)
+    assert [s.segment_id for s in segs] == ["seg-0", "seg-1"]
+    assert [s.trajectory_id for s in segs] == ["s1:fix-1", "s1:fix-0"]
+
+
+def test_segmentation_is_idempotent_across_reprojection() -> None:
+    traj = _traj([("s1:explore-0", "e0.jsonl"), ("s1:review-2", "r2.jsonl")])
+    assert segment(traj) == segment(traj)
+
+
+def test_segment_ids_qualify_session_and_descriptor() -> None:
+    traj = _traj([("s1:fix-0", "a.jsonl")])
+    seg = segment(traj)[0]
+    assert seg.trajectory_id == "s1:fix-0" and seg.session_id == "s1"
+
+
+def test_root_alone_is_seg0() -> None:
+    segs = segment({"trajectory_id": "s1:root", "session_id": "s1"})
+    assert [s.segment_id for s in segs] == ["seg-0"]
+    assert segs[0].trajectory_id == "s1:root"
+
+
+def test_duplicate_sibling_keys_raise() -> None:
+    traj = _traj([("s1:fix-0", "a.jsonl"), ("s1:fix-0", "a.jsonl")])
+    with pytest.raises(ValueError, match="s1:fix-0"):
+        segment(traj)
+
+
+def test_spans_compose_v1_build_spans_per_sibling() -> None:
+    traj = _traj([("s1:fix-0", "a.jsonl")])
+    traj["subagent_trajectory_ref"][0]["steps"] = [
+        {"step_id": 1, "source": "agent", "message": "think"},
+        {"step_id": 2, "source": "agent", "tool_calls": [{"name": "t"}]},
+    ]
+    segs = segment(traj)
+    assert segs[0].spans == [
+        {"step_id": 1, "kind": "REASON", "content_path": "steps[0].message"},
+        {"step_id": 2, "kind": "ACT", "content_path": "steps[1].tool_calls"},
+    ]
+    assert segment_agents is segment

--- a/tests/test_corpus_v2.py
+++ b/tests/test_corpus_v2.py
@@ -7,6 +7,7 @@ import pytest
 
 from daydream.training.corpus_v2.bundle import BundleError, CuratedBundle, load_curated_bundle
 from daydream.training.corpus_v2.identity import record_id
+from daydream.training.corpus_v2.provenance import extract_provenance
 from daydream.training.corpus_v2.segments import segment, segment_agents
 from daydream.training.corpus_v2.tiers import GoldGateError, classify_tier
 
@@ -214,3 +215,44 @@ def test_spans_compose_v1_build_spans_per_sibling() -> None:
         {"step_id": 2, "kind": "ACT", "content_path": "steps[1].tool_calls"},
     ]
     assert segment_agents is segment
+
+
+# ---------------------------------------------------------------------------
+# Task 6: profile + stack provenance
+# ---------------------------------------------------------------------------
+
+
+def test_native_profile_fields_surface_from_manifest() -> None:
+    manifest_row = {
+        "profile_schema_version": 2, "profile_name": "deep-review",
+        "profile_source_kind": "builtin", "profile_digest": "d" * 64,
+        "skill": None,
+    }
+    prov = extract_provenance(manifest_row)
+    assert prov["profile"] == {"profile_schema_version": 2, "profile_name": "deep-review",
+                               "profile_source_kind": "builtin", "profile_digest": "d" * 64}
+    assert "skill" not in prov or prov["skill"] is None  # optional provenance only
+
+
+def test_native_profile_run_without_legacy_skill_validates() -> None:
+    v2_record = {"profile": {"profile_schema_version": 2, "profile_name": "n",
+                             "profile_source_kind": "builtin", "profile_digest": None},
+                 "skill": None, "stack": "python"}
+    assert extract_provenance(v2_record)["stack"] == "python"
+    # Schema validity is Task 1's validator's job; here we pin that no
+    # required-ness is smuggled back in for skill.
+    assert "skill" not in {f for f in v2_record if v2_record[f] is None and f == "skill"} or True
+
+
+def test_legacy_skill_carried_as_provenance_never_required() -> None:
+    prov = extract_provenance({"skill": "beagle-python:review-python", "profile_schema_version": None,
+                               "profile_name": None, "profile_source_kind": None,
+                               "profile_digest": None, "stack": None})
+    assert prov["skill"] == "beagle-python:review-python"
+    assert prov["stack"] == "python"
+    assert all(v is None for v in prov["profile"].values())
+
+
+def test_stack_falls_back_to_none_when_unresolvable() -> None:
+    prov = extract_provenance({"skill": "unknown-thing", "stack": None})
+    assert prov["stack"] is None

--- a/tests/test_corpus_v2.py
+++ b/tests/test_corpus_v2.py
@@ -6,6 +6,7 @@ import pytest
 
 from daydream.training.corpus_v2.bundle import BundleError, CuratedBundle, load_curated_bundle
 from daydream.training.corpus_v2.identity import record_id
+from daydream.training.corpus_v2.tiers import GoldGateError, classify_tier
 
 _MANIFEST = {
     "schema_version": "1",
@@ -118,3 +119,45 @@ def test_record_id_is_stable_and_discriminating() -> None:
 def test_record_id_is_deterministic_sha256_of_canonical_join() -> None:
     expected = hashlib.sha256(b"s1\x1fs1:fix-0\x1fseg-0\x1f" + b"ab" * 32).hexdigest()
     assert record_id("s1", "s1:fix-0", "seg-0", "ab" * 32) == expected
+
+
+def _resolution(
+    disposition: str, *, reward: dict[str, object] | None = None, score: float | None = None
+) -> dict[str, object]:
+    r: dict[str, object] = {
+        "fingerprint": "ab" * 32,
+        "disposition": disposition,
+        "evidence": [{"created_at": "2026-02-01T00:00:00+00:00"}],
+    }
+    if reward is not None:
+        r["intrinsic_reward"] = reward
+    if score is not None:
+        r["llm_self_score"] = score
+    return r
+
+
+def test_decisive_dispositions_are_gold() -> None:
+    assert classify_tier(_resolution("accepted")) == "gold"
+    assert classify_tier(_resolution("rejected")) == "gold"
+
+
+def test_non_decisive_dispositions_never_gold() -> None:
+    for d in ("ambiguous", "unanswered", "missing"):
+        assert classify_tier(_resolution(d)) != "gold"
+        assert classify_tier(_resolution(d)) == "task-only"
+
+
+def test_intrinsic_reward_and_llm_score_cannot_promote_gold() -> None:
+    # C5: a perfect intrinsic score or a confident self-score with a
+    # non-decisive disposition must not classify gold — structurally.
+    assert classify_tier(_resolution("unanswered", reward={"composite": 10.0}, score=0.99)) == "task-only"
+    with pytest.raises(TypeError):
+        classify_tier("accepted")  # type: ignore[arg-type]  # gold input must carry evidence, not a bare label
+    with pytest.raises(GoldGateError):
+        classify_tier({"fingerprint": "ab" * 32, "disposition": "accepted", "evidence": []})
+
+
+def test_tiers_are_disjoint_classes() -> None:
+    # process-trace tier is silver, never gold; eligibility is a separate field
+    tier = classify_tier(_resolution("accepted"), record_type="process-trace")
+    assert tier == "silver"  # type/decision split: ATIF process data stays silver

--- a/tests/test_corpus_v2.py
+++ b/tests/test_corpus_v2.py
@@ -25,7 +25,7 @@ _MANIFEST = {
             "content_digest": "1111111111111111111111111111111111111111111111111111111111111111",
             "status": "admitted",
             "reason_code": None,
-            "artifact_relpath": "batches/sess-a/trajectory.jsonl",
+            "artifact_relpath": "batches/sess-a",
             "artifact_digest": None,
             "manifest_relpath": "batches/sess-a/manifest.json",
         },
@@ -34,7 +34,7 @@ _MANIFEST = {
             "content_digest": "3333333333333333333333333333333333333333333333333333333333333333",
             "status": "quarantined",
             "reason_code": "secrets_scan_dirty",
-            "artifact_relpath": "batches/sess-b/trajectory.jsonl",
+            "artifact_relpath": "batches/sess-b",
             "artifact_digest": None,
             "manifest_relpath": None,
         },
@@ -61,7 +61,10 @@ def _write_sumsums(bundle_dir: Path, *, exclude: frozenset[str] = frozenset()) -
 
 def _write_bundle(tmp_path: Path, *, with_success: bool = True, corrupt_digest: bool = False) -> Path:
     bundle_dir = tmp_path / "curated" / "cur-0123456789abcdef"
-    for rel in ("batches/sess-a/trajectory.jsonl", "batches/sess-a/manifest.json", "batches/sess-b/trajectory.jsonl"):
+    # Producer-realistic batch shape: artifact_relpath names the batch
+    # DIRECTORY (``batches/<session_id>/``) containing the ATIF
+    # ``trajectory.json`` plus the batch ``manifest.json``.
+    for rel in ("batches/sess-a/trajectory.json", "batches/sess-a/manifest.json", "batches/sess-b/trajectory.json"):
         target = bundle_dir / rel
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text("{}\n")
@@ -70,7 +73,7 @@ def _write_bundle(tmp_path: Path, *, with_success: bool = True, corrupt_digest: 
     if with_success:
         (bundle_dir / "_SUCCESS").write_text("ok\n")
     if corrupt_digest:
-        (bundle_dir / "batches" / "sess-a" / "trajectory.jsonl").write_bytes(b"tampered\n")
+        (bundle_dir / "batches" / "sess-a" / "trajectory.json").write_bytes(b"tampered\n")
     return bundle_dir
 
 
@@ -103,7 +106,9 @@ def _write_annotations_snapshot(
             for i in range(n_siblings)
         ],
     }
-    (bundle_dir / "batches" / session_id / "trajectory.jsonl").write_text(
+    # Producer-realistic batch shape: the ATIF trajectory lives at
+    # ``batches/<session_id>/trajectory.json`` (single JSON object).
+    (bundle_dir / "batches" / session_id / "trajectory.json").write_text(
         json.dumps(trajectory) + "\n"
     )
     snapshot_path = bundle_dir / "annotations-snapshot.jsonl"
@@ -162,7 +167,7 @@ def test_load_bundle_uses_relative_paths_only(tmp_path: Path) -> None:
 
 def test_load_bundle_rejects_missing_batches_file(tmp_path: Path) -> None:
     bundle_dir = _write_bundle(tmp_path)
-    (bundle_dir / "batches" / "sess-a" / "trajectory.jsonl").unlink()
+    (bundle_dir / "batches" / "sess-a" / "trajectory.json").unlink()
     with pytest.raises(BundleError, match="missing artifact"):
         load_curated_bundle(bundle_dir)
 
@@ -294,10 +299,15 @@ def test_native_profile_run_without_legacy_skill_validates() -> None:
     v2_record = {"profile": {"profile_schema_version": 2, "profile_name": "n",
                              "profile_source_kind": "builtin", "profile_digest": None},
                  "skill": None, "stack": "python"}
-    assert extract_provenance(v2_record)["stack"] == "python"
+    prov = extract_provenance(v2_record)
+    assert prov["stack"] == "python"
     # Schema validity is Task 1's validator's job; here we pin that no
-    # required-ness is smuggled back in for skill.
-    assert "skill" in {f for f in v2_record if v2_record[f] is None and f == "skill"}
+    # required-ness is smuggled back in for skill: the extractor carries
+    # skill only when a value exists, never for an explicit null (and honors
+    # the record's own stack override).
+    assert "skill" not in prov
+    assert prov["profile"] == {"profile_schema_version": None, "profile_name": None,
+                               "profile_source_kind": None, "profile_digest": None}
 
 
 def test_legacy_skill_carried_as_provenance_never_required() -> None:

--- a/tests/test_corpus_v2.py
+++ b/tests/test_corpus_v2.py
@@ -69,6 +69,56 @@ def _write_bundle(tmp_path: Path, *, with_success: bool = True, corrupt_digest: 
     return bundle_dir
 
 
+def _write_annotations_snapshot(
+    bundle_dir: Path,
+    *,
+    valid_at: str = "2026-01-01T00:00:00+00:00",
+    session_id: str = "sess-a",
+) -> Path:
+    """Task 0A side-car shape: a digest-pinned JSONL of per-finding
+    resolution records keyed by fingerprint, exported alongside the bundle
+    and covered by SHA256SUMS. Also gives the admitted batch a real ATIF
+    trajectory so segmentation has something to segment."""
+    trajectory = {
+        "session_id": session_id,
+        "trajectory_id": f"{session_id}:root",
+        "subagent_trajectory_ref": [
+            {"trajectory_id": f"{session_id}:fix-0", "session_id": session_id, "steps": [
+                {"step_id": 1, "source": "agent", "message": "fix"},
+            ]},
+        ],
+    }
+    (bundle_dir / "batches" / session_id / "trajectory.jsonl").write_text(
+        json.dumps(trajectory) + "\n"
+    )
+    snapshot_path = bundle_dir / "annotations-snapshot.jsonl"
+    rows = [
+        {
+            "session_id": session_id,
+            "fingerprint": "a1" * 32,
+            "disposition": "accepted",
+            "evidence": [{"comment_id": 1, "created_at": "2026-02-01T00:00:00+00:00",
+                          "classifier_label": "accepted", "valid_at": valid_at}],
+        },
+        {
+            "session_id": session_id,
+            "fingerprint": "b2" * 32,
+            "disposition": "rejected",
+            "evidence": [{"comment_id": 2, "created_at": "2026-02-02T00:00:00+00:00",
+                          "classifier_label": "rejected", "valid_at": valid_at}],
+        },
+        {
+            "session_id": session_id,
+            "fingerprint": "c3" * 32,
+            "disposition": "ambiguous",
+            "evidence": [],
+        },
+    ]
+    snapshot_path.write_text("".join(json.dumps(r, sort_keys=True) + "\n" for r in rows))
+    _write_sumsums(bundle_dir)  # the snapshot + trajectory join the digest pin
+    return snapshot_path
+
+
 def test_load_bundle_requires_success_marker(tmp_path: Path) -> None:
     bundle_dir = _write_bundle(tmp_path)
     (bundle_dir / "_SUCCESS").unlink()

--- a/tests/test_corpus_v2_reproducibility.py
+++ b/tests/test_corpus_v2_reproducibility.py
@@ -1,0 +1,94 @@
+"""Frozen deterministic splits + byte-for-byte reproducibility (Req 12, 13, D5).
+
+Mirrors ``tests/test_corpus_reproducibility.py``'s determinism standard and
+``tests/test_corpus_leakage.py``'s as_of boundary standard.
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from daydream.training.corpus_v2.projector import BuildCorpusV2Config, run_build_corpus_v2
+from daydream.training.corpus_v2.splits import assign_split
+from tests.test_corpus_v2 import _write_annotations_snapshot, _write_bundle
+
+
+def _cfg(out_dir: Path, bundle_dir: Path, snapshot: Path, **kw: Any) -> BuildCorpusV2Config:
+    return BuildCorpusV2Config(out_dir=out_dir, bundle_dir=bundle_dir, annotations_snapshot=snapshot, **kw)
+
+
+def _read_split_memberships(out_dir: Path) -> tuple[list[str], list[str], list[str]]:
+    def ids(name: str) -> list[str]:
+        path = out_dir / name
+        if not path.is_file():
+            return []
+        return [json.loads(line)["record_id"] for line in path.read_text().splitlines() if line]
+
+    return ids("train.jsonl"), ids("validation.jsonl"), ids("holdout.jsonl")
+
+
+def test_assign_split_is_deterministic_and_salted() -> None:
+    rid = "ab" * 32
+    assert assign_split(rid, holdout_rate=0.1, val_rate=0.1, salt="s") == assign_split(
+        rid, holdout_rate=0.1, val_rate=0.1, salt="s"
+    )
+    assert assign_split(rid, holdout_rate=0.0, val_rate=0.0, salt="s") == "train"
+    assert assign_split(rid, holdout_rate=1.0, val_rate=0.0, salt="s") == "holdout"
+    # a different salt is allowed to reorder membership — it must merely be stable per salt
+    assert assign_split(rid, holdout_rate=0.5, val_rate=0.0, salt="s1") == assign_split(
+        rid, holdout_rate=0.5, val_rate=0.0, salt="s1"
+    )
+
+
+def test_reprojection_is_byte_for_byte_deterministic(tmp_path: Path) -> None:
+    bundle_dir = _write_bundle(tmp_path)
+    snap = _write_annotations_snapshot(bundle_dir)
+    run_build_corpus_v2(_cfg(tmp_path / "a", bundle_dir, snap))
+    run_build_corpus_v2(_cfg(tmp_path / "b", bundle_dir, snap))
+    assert (tmp_path / "b" / "corpus.jsonl").read_bytes() == (tmp_path / "a" / "corpus.jsonl").read_bytes()
+    assert (tmp_path / "b" / "lineage.json").read_bytes() == (tmp_path / "a" / "lineage.json").read_bytes()
+    for name in ("train.jsonl", "validation.jsonl", "holdout.jsonl"):
+        assert (tmp_path / "b" / name).read_bytes() == (tmp_path / "a" / name).read_bytes()
+
+
+def test_splits_are_disjoint_and_frozen(tmp_path: Path) -> None:
+    bundle_dir = _write_bundle(tmp_path)
+    snap = _write_annotations_snapshot(bundle_dir)
+    out_a = tmp_path / "o"
+    run_build_corpus_v2(_cfg(out_a, bundle_dir, snap))
+    train, val, holdout = _read_split_memberships(out_a)
+    assert not (set(train) & set(val))
+    assert not (set(train) & set(holdout))
+    assert not (set(val) & set(holdout))
+    assert train + val + holdout  # the fixture projected records
+    # frozen: same membership again on re-run into a fresh directory
+    run_build_corpus_v2(_cfg(tmp_path / "b", bundle_dir, snap))
+    train2, _, _ = _read_split_memberships(tmp_path / "b")
+    assert train2 == train
+    # frozen: same membership under re-run in place (overwrite is stable)
+    run_build_corpus_v2(_cfg(out_a, bundle_dir, snap))
+    train3, _, _ = _read_split_memberships(out_a)
+    assert train3 == train
+
+
+def test_split_membership_recorded_in_record_lineage(tmp_path: Path) -> None:
+    bundle_dir = _write_bundle(tmp_path)
+    snap = _write_annotations_snapshot(bundle_dir)
+    out = tmp_path / "o"
+    run_build_corpus_v2(_cfg(out, bundle_dir, snap))
+    for line in (out / "corpus.jsonl").read_text().splitlines():
+        record = json.loads(line)
+        assert record["lineage"]["split"] in {"train", "validation", "holdout"}
+
+
+def test_late_outcome_evidence_is_refused(tmp_path: Path) -> None:
+    bundle_dir = _write_bundle(tmp_path)
+    snap = _write_annotations_snapshot(bundle_dir, valid_at="2030-01-01T00:00:00+00:00")
+    cfg = _cfg(tmp_path / "late", bundle_dir, snap, as_of="2026-06-01T00:00:00+00:00")
+    with pytest.raises(ValueError, match="valid_at"):
+        run_build_corpus_v2(cfg)
+    # refusal, not drop: nothing was written
+    assert not (tmp_path / "late" / "corpus.jsonl").exists()
+    assert not (tmp_path / "late" / "lineage.json").exists()

--- a/tests/test_corpus_v2_reproducibility.py
+++ b/tests/test_corpus_v2_reproducibility.py
@@ -14,19 +14,18 @@ from daydream.training import corpus_v2 as corpus_v2_pkg
 from daydream.training.corpus import BuildCorpusConfig, CorpusFilters, run_build_corpus
 from daydream.training.corpus_v2.projector import BuildCorpusV2Config, run_build_corpus_v2
 from daydream.training.corpus_v2.splits import assign_split
-from tests.test_corpus_v2 import _write_annotations_snapshot, _write_bundle
+from tests.test_corpus_v2 import _cfg, _write_annotations_snapshot, _write_bundle
 from tests.test_training_corpus import _seed_run_with_annotation
-
-
-def _cfg(out_dir: Path, bundle_dir: Path, snapshot: Path, **kw: Any) -> BuildCorpusV2Config:
-    return BuildCorpusV2Config(out_dir=out_dir, bundle_dir=bundle_dir, annotations_snapshot=snapshot, **kw)
 
 
 def _read_split_memberships(out_dir: Path) -> tuple[list[str], list[str], list[str]]:
     def ids(name: str) -> list[str]:
         path = out_dir / name
+        # Fail-closed: a missing split manifest must not read as an empty
+        # membership — vacuous intersection/disjointness checks would mask a
+        # projector regression that skipped a split write.
         if not path.is_file():
-            return []
+            raise FileNotFoundError(f"missing split manifest {path}")
         return [json.loads(line)["record_id"] for line in path.read_text().splitlines() if line]
 
     return ids("train.jsonl"), ids("validation.jsonl"), ids("holdout.jsonl")
@@ -109,6 +108,7 @@ def test_v1_and_v2_projection_paths_are_independent(tmp_path: Path, archive_dir:
         return out_dir / "out" / "corpus.jsonl"
 
     v1_before = _run_v1_build(tmp_path / "v1a" / "corpus.jsonl").read_bytes()
+    assert v1_before  # non-empty checkpoint: a regression that empties v1 must fail here
     _run_v2_build(tmp_path / "v2")
     v1_after = _run_v1_build(tmp_path / "v1b" / "corpus.jsonl").read_bytes()
     assert v1_before == v1_after           # v1 untouched by v2 runs
@@ -128,6 +128,11 @@ def test_late_outcome_evidence_is_refused(tmp_path: Path) -> None:
     cfg = _cfg(tmp_path / "late", bundle_dir, snap, as_of="2026-06-01T00:00:00+00:00")
     with pytest.raises(ValueError, match="valid_at"):
         run_build_corpus_v2(cfg)
-    # refusal, not drop: nothing was written
-    assert not (tmp_path / "late" / "corpus.jsonl").exists()
-    assert not (tmp_path / "late" / "lineage.json").exists()
+    # refusal, not drop: the full fail-closed file set was never written
+    # (every artifact the projector emits, plus the _SUCCESS completeness
+    # marker — a regression that wrote any of them before raising fails)
+    late_dir = tmp_path / "late"
+    for name in ("corpus.jsonl", "corpus-v2.jsonl", "train.jsonl", "validation.jsonl",
+                 "holdout.jsonl", "adjudication-report.json", "schema.json",
+                 "lineage.json", "_SUCCESS"):
+        assert not (late_dir / name).exists(), name

--- a/tests/test_corpus_v2_reproducibility.py
+++ b/tests/test_corpus_v2_reproducibility.py
@@ -10,9 +10,12 @@ from typing import Any
 
 import pytest
 
+from daydream.training import corpus_v2 as corpus_v2_pkg
+from daydream.training.corpus import BuildCorpusConfig, CorpusFilters, run_build_corpus
 from daydream.training.corpus_v2.projector import BuildCorpusV2Config, run_build_corpus_v2
 from daydream.training.corpus_v2.splits import assign_split
 from tests.test_corpus_v2 import _write_annotations_snapshot, _write_bundle
+from tests.test_training_corpus import _seed_run_with_annotation
 
 
 def _cfg(out_dir: Path, bundle_dir: Path, snapshot: Path, **kw: Any) -> BuildCorpusV2Config:
@@ -81,6 +84,42 @@ def test_split_membership_recorded_in_record_lineage(tmp_path: Path) -> None:
     for line in (out / "corpus.jsonl").read_text().splitlines():
         record = json.loads(line)
         assert record["lineage"]["split"] in {"train", "validation", "holdout"}
+
+
+def test_v1_and_v2_projection_paths_are_independent(tmp_path: Path, archive_dir: Any) -> None:
+    """Run BOTH projectors over the same pinned inputs; assert (a) v1 bytes
+    are identical before/after any v2 build, and (b) v2 reprojection is
+    byte-identical — the two paths must agree on inputs and diverge only in
+    their documented, schema-pinned output shape."""
+    _seed_run_with_annotation(archive_dir, "s1", label="accepted",
+                              reward_version="r1", observed_at="2026-03-01T00:00:00+00:00",
+                              valid_at="2026-03-01T00:00:00+00:00")
+    as_of = "2026-04-01T00:00:00+00:00"
+
+    def _run_v1_build(out_path: Path) -> Path:
+        run_build_corpus(BuildCorpusConfig(out_path=out_path, archive_dir=archive_dir,
+                                           filters=CorpusFilters(), as_of=as_of))
+        return out_path
+
+    def _run_v2_build(out_dir: Path) -> Path:
+        bundle_dir = _write_bundle(out_dir)
+        snap = _write_annotations_snapshot(bundle_dir)
+        run_build_corpus_v2(BuildCorpusV2Config(out_dir=out_dir / "out", bundle_dir=bundle_dir,
+                                                annotations_snapshot=snap))
+        return out_dir / "out" / "corpus.jsonl"
+
+    v1_before = _run_v1_build(tmp_path / "v1a" / "corpus.jsonl").read_bytes()
+    _run_v2_build(tmp_path / "v2")
+    v1_after = _run_v1_build(tmp_path / "v1b" / "corpus.jsonl").read_bytes()
+    assert v1_before == v1_after           # v1 untouched by v2 runs
+    v2a = _run_v2_build(tmp_path / "v2a")
+    v2b = _run_v2_build(tmp_path / "v2b")
+    assert v2a.read_bytes() == v2b.read_bytes()   # v2 determinism
+    # the documented, schema-pinned output shape: the v2 build ships schema/v2.json verbatim
+    projector_dir = Path(corpus_v2_pkg.__file__).parent
+    assert (tmp_path / "v2a" / "out" / "schema.json").read_bytes() == (
+        (projector_dir.parent / "schema" / "v2.json").read_bytes()
+    )
 
 
 def test_late_outcome_evidence_is_refused(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Implements corpus v2 schema + deterministic projector for issue #983:

- Versioned corpus-v2 record schema with content-hash record identity (session, source trajectory, task segment, finding fingerprint)
- Fail-closed curated-bundle loader consuming #982's portable curation manifest (_SUCCESS, digest, and schema-compatibility gates; rejects locally invented candidate sets)
- Native review profile identity + detected-stack provenance; legacy `skill` retained only as optional provenance
- Disjoint tier classes (gold/silver/task-only) with human-evidence-only gold gate; mixed PRs emit distinct accepted/rejected finding records instead of one contested run record
- Deterministic fork-order per-agent ATIF segmentation with pinned tie-breaks
- Frozen content-derived splits, byte-for-byte reproducible re-projection
- Output-share caps enforced and reported after segmentation/filtering
- Additive v2 dataset loader and `build-v2` CLI verb; v1 reader/migration path untouched

## Test Plan
- [x] tests/test_corpus_v2.py — schema, tier, identity, bundle-gate coverage
- [x] tests/test_corpus_v2_reproducibility.py — byte-for-byte determinism
- [x] tests/test_cli_corpus_namespace.py — build-v2 CLI wiring
- [x] Two sequential daydream deep-precision review rounds (14 findings each, all resolved)
- [x] verify-branch-authors: AUTHORS_OK

Closes #983