### PR TITLE
Unify CLI backends behind an injectable subprocess and JSONL transport

### DIFF
--- a/daydream/backends/_transport.py
+++ b/daydream/backends/_transport.py
@@ -1,0 +1,201 @@
+"""Injectable subprocess/JSONL transport for the CLI backends (codex, pi, osprey).
+
+One owner for spawn, stdin policy, idle-timeout line reads, stderr handling,
+exit-code surfacing, and shielded teardown, built on the primitives in
+:mod:`daydream.backends._subprocess`. Backends keep all protocol mapping: the
+transport yields raw decoded lines and surfaces only the exit code, so backend
+error messages stay byte-identical to what they were before the transport.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import enum
+from collections.abc import AsyncIterator, Callable
+from typing import TYPE_CHECKING
+
+from daydream.backends._subprocess import (
+    readline_with_idle_timeout,
+    terminate_process,
+)
+
+if TYPE_CHECKING:
+    pass
+
+
+class StdinMode(enum.Enum):
+    """How the child's stdin is wired at spawn."""
+
+    DEVNULL = enum.auto()
+    PIPE = enum.auto()
+
+
+class StderrPolicy(enum.Enum):
+    """Where the child's stderr goes.
+
+    ``MERGE_INTO_STDOUT`` folds stderr into the JSONL stream (codex, pi).
+    ``DRAIN_TASK`` keeps stderr a separate pipe drained by a background task
+    (osprey), whose lines are handed to ``stderr_sink``; the backend awaits
+    :meth:`drain_finished` after ``wait()``/``terminate()`` so the drain task
+    can never outlive the transport.
+    """
+
+    MERGE_INTO_STDOUT = enum.auto()
+    DRAIN_TASK = enum.auto()
+
+
+class TransportExitError(Exception):
+    """The child exited non-zero.
+
+    The transport only surfaces the code and the caller-noted diagnostics —
+    the backend formats its own user-visible message from these.
+    """
+
+    def __init__(self, cli: str, returncode: int, diagnostics: list[str]) -> None:
+        self.cli = cli
+        self.returncode = returncode
+        self.diagnostics = diagnostics
+
+
+class CliTransport:
+    """Spawn a CLI subprocess and stream its stdout as decoded JSONL lines.
+
+    Transport-internal errors propagate as raised: :class:`StreamStalledError`
+    on stream silence, :class:`ValueError` on oversized lines, ``OSError`` from
+    spawn — the caller maps each to its own backend error type. No fallbacks.
+    """
+
+    def __init__(
+        self,
+        cli: str,
+        argv: list[str],
+        *,
+        stdin_mode: StdinMode = StdinMode.DEVNULL,
+        stdin_data: bytes | None = None,
+        stderr_policy: StderrPolicy = StderrPolicy.MERGE_INTO_STDOUT,
+        stderr_sink: Callable[[str], None] | None = None,
+        diagnostics_sink: Callable[[str], None] | None = None,
+        limit: int,
+        env: dict[str, str] | None = None,
+        cwd: str | None = None,
+    ) -> None:
+        if stdin_mode is StdinMode.PIPE and stdin_data is None:
+            raise ValueError("stdin_mode=PIPE requires stdin_data")
+        self._cli = cli
+        self._argv = argv
+        self._stdin_mode = stdin_mode
+        self._stdin_data = stdin_data
+        self._stderr_policy = stderr_policy
+        self._stderr_sink = stderr_sink
+        self._diagnostics: list[str] = []
+        self._diagnostics_sink = diagnostics_sink
+        self._drain_task: asyncio.Task[None] | None = None
+        self.processes: list[asyncio.subprocess.Process] = []
+        self._proc: asyncio.subprocess.Process | None = None
+        self._spawn_kwargs: dict[str, object] = {
+            "limit": limit,
+            "env": env,
+            "cwd": cwd,
+        }
+        self.stdin_closed = False
+
+    async def start(self) -> None:
+        """Spawn the child, write+close stdin when piped, start stderr drain."""
+        stdin = (
+            asyncio.subprocess.PIPE
+            if self._stdin_mode is StdinMode.PIPE
+            else asyncio.subprocess.DEVNULL
+        )
+        stderr = (
+            asyncio.subprocess.STDOUT
+            if self._stderr_policy is StderrPolicy.MERGE_INTO_STDOUT
+            else asyncio.subprocess.PIPE
+        )
+        # Spawn OSError propagates: the caller maps it to its backend error type.
+        proc = await asyncio.create_subprocess_exec(
+            *self._argv,
+            stdin=stdin,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=stderr,
+            start_new_session=True,
+            **self._spawn_kwargs,  # type: ignore[arg-type]
+        )
+        self._proc = proc
+        self.processes.append(proc)
+
+        if self._stdin_mode is StdinMode.PIPE:
+            stdin_writer = proc.stdin
+            if stdin_writer is None:  # pragma: no cover - PIPE guarantees stdin
+                raise OSError("child stdin is not writable despite StdinMode.PIPE")
+            stdin_writer.write(self._stdin_data or b"")
+            stdin_writer.close()
+            self.stdin_closed = True
+
+        if self._stderr_policy is StderrPolicy.DRAIN_TASK and proc.stderr is not None:
+            self._drain_task = asyncio.create_task(self._drain_stderr(proc.stderr))
+
+    async def _drain_stderr(self, stderr: asyncio.StreamReader) -> None:
+        async for raw in stderr:
+            line = raw.decode().strip()
+            if line and self._stderr_sink is not None:
+                self._stderr_sink(line)
+
+    @property
+    def returncode(self) -> int | None:
+        if self._proc is None:
+            return None
+        return self._proc.returncode
+
+    async def lines(
+        self, timeout_for_line: Callable[[], float | None]
+    ) -> AsyncIterator[str]:
+        """Yield decoded, stripped stdout lines under per-line idle windows.
+
+        The callable is invoked per line, so a dual-window policy (response vs
+        tool-active) can switch mid-stream. Silence within the window raises
+        :class:`StreamStalledError` via the shared primitive; an oversized line
+        raises ``ValueError`` unchanged.
+        """
+        if self._proc is None:
+            raise RuntimeError("transport not started; call start() first")
+        stdout = self._proc.stdout
+        if stdout is None:  # pragma: no cover - stdout is always PIPE
+            return
+        while True:
+            raw = await readline_with_idle_timeout(
+                stdout, cli=self._cli, timeout_s=timeout_for_line()
+            )
+            if not raw:
+                return
+            yield raw.decode().strip()
+
+    def note_diagnostic(self, line: str) -> None:
+        """Record *line* as a diagnostic via the caller's sink."""
+        self._diagnostics.append(line)
+        if self._diagnostics_sink is not None:
+            self._diagnostics_sink(line)
+
+    async def wait(self) -> int:
+        """Await the child and return its exit code.
+
+        Raises:
+            TransportExitError: On a non-zero exit; ``.returncode`` and
+                ``.diagnostics`` carry the code and caller-noted lines.
+        """
+        if self._proc is None:
+            raise RuntimeError("transport not started; call start() first")
+        returncode = await self._proc.wait()
+        if returncode != 0:
+            raise TransportExitError(self._cli, returncode, self._diagnostics)
+        return returncode
+
+    async def drain_finished(self) -> None:
+        """Await the stderr drain task (a no-op under MERGE_INTO_STDOUT)."""
+        if self._drain_task is not None:
+            await asyncio.gather(self._drain_task)
+            self._drain_task = None
+
+    async def terminate(self) -> None:
+        """Group-signal, reap, and close pipes; shielded and idempotent."""
+        if self._proc is not None:
+            await terminate_process(self._proc)

--- a/daydream/backends/_transport.py
+++ b/daydream/backends/_transport.py
@@ -74,6 +74,7 @@ class CliTransport:
         stderr_policy: StderrPolicy = StderrPolicy.MERGE_INTO_STDOUT,
         stderr_sink: Callable[[str], None] | None = None,
         diagnostics_sink: Callable[[str], None] | None = None,
+        decode_errors: str = "strict",
         limit: int,
         env: dict[str, str] | None = None,
         cwd: str | None = None,
@@ -88,6 +89,10 @@ class CliTransport:
         self._stderr_sink = stderr_sink
         self._diagnostics: list[str] = []
         self._diagnostics_sink = diagnostics_sink
+        # Backend decode policy: codex/pi were strict pre-transport; osprey
+        # decoded with errors="replace" and must keep doing so (see the
+        # backend's ``decode_errors="replace"`` construction below).
+        self._decode_errors = decode_errors
         self._drain_task: asyncio.Task[None] | None = None
         self.processes: list[asyncio.subprocess.Process] = []
         self._proc: asyncio.subprocess.Process | None = None
@@ -165,7 +170,9 @@ class CliTransport:
         The callable is invoked per line, so a dual-window policy (response vs
         tool-active) can switch mid-stream. Silence within the window raises
         :class:`StreamStalledError` via the shared primitive; an oversized line
-        raises ``ValueError`` unchanged.
+        raises ``ValueError`` unchanged. Lines decode with the configured
+        ``decode_errors`` (strict by default), keeping each backend's
+        historical decode contract.
         """
         if self._proc is None:
             raise RuntimeError("transport not started; call start() first")
@@ -178,7 +185,7 @@ class CliTransport:
             )
             if not raw:
                 return
-            yield raw.decode().strip()
+            yield raw.decode(errors=self._decode_errors).strip()
 
     def note_diagnostic(self, line: str) -> None:
         """Record *line* as a diagnostic via the caller's sink."""
@@ -205,12 +212,14 @@ class CliTransport:
 
         Shielded so a drain awaited in a backend's teardown ``finally`` still
         completes when the caller's scope is already cancelled — the same
-        shield the cancel-sweep relies on.
+        shield the cancel-sweep relies on. Drain-task exceptions are folded
+        into the gathered result so teardown cannot mask the caller's original
+        backend error.
         """
         if self._drain_task is not None:
             task, self._drain_task = self._drain_task, None
             with anyio.CancelScope(shield=True):
-                await asyncio.gather(task)
+                await asyncio.gather(task, return_exceptions=True)
 
     async def terminate(self) -> None:
         """Group-signal, reap, and close pipes; shielded and idempotent."""

--- a/daydream/backends/_transport.py
+++ b/daydream/backends/_transport.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import asyncio
 import enum
 from collections.abc import AsyncIterator, Callable
-from typing import TYPE_CHECKING
 
 import anyio
 
@@ -21,9 +20,6 @@ from daydream.backends._subprocess import (
     readline_with_idle_timeout,
     terminate_process,
 )
-
-if TYPE_CHECKING:
-    pass
 
 
 class StdinMode(enum.Enum):
@@ -235,5 +231,8 @@ class CliTransport:
             proc for t in transports for proc in t.processes if proc.returncode is None
         ])
         with anyio.CancelScope(shield=True):
-            for t in transports:
+            # Iterate a snapshot: a backend's teardown ``finally`` removes its
+            # transport from this caller-owned list in place while we await, so
+            # a live iteration can raise 'list changed size during iteration'.
+            for t in list(transports):
                 await t.drain_finished()

--- a/daydream/backends/_transport.py
+++ b/daydream/backends/_transport.py
@@ -138,8 +138,20 @@ class CliTransport:
             self._drain_task = asyncio.create_task(self._drain_stderr(proc.stderr))
 
     async def _drain_stderr(self, stderr: asyncio.StreamReader) -> None:
-        async for raw in stderr:
-            line = raw.decode().strip()
+        while True:
+            try:
+                raw = await stderr.readline()
+            except ValueError:
+                # ``StreamReader.readline`` clears an over-limit unterminated
+                # line before raising. Stderr is diagnostic-only, so note the
+                # discard and keep draining instead of failing an otherwise
+                # valid JSONL session during teardown.
+                if self._stderr_sink is not None:
+                    self._stderr_sink("stderr diagnostic line exceeded stream limit and was discarded")
+                continue
+            if not raw:
+                break
+            line = raw.decode(errors="replace").strip()
             if line and self._stderr_sink is not None:
                 self._stderr_sink(line)
 
@@ -193,10 +205,16 @@ class CliTransport:
         return returncode
 
     async def drain_finished(self) -> None:
-        """Await the stderr drain task (a no-op under MERGE_INTO_STDOUT)."""
+        """Await the stderr drain task (a no-op under MERGE_INTO_STDOUT).
+
+        Shielded so a drain awaited in a backend's teardown ``finally`` still
+        completes when the caller's scope is already cancelled — the same
+        shield the cancel-sweep relies on.
+        """
         if self._drain_task is not None:
-            await asyncio.gather(self._drain_task)
-            self._drain_task = None
+            task, self._drain_task = self._drain_task, None
+            with anyio.CancelScope(shield=True):
+                await asyncio.gather(task)
 
     async def terminate(self) -> None:
         """Group-signal, reap, and close pipes; shielded and idempotent."""

--- a/daydream/backends/_transport.py
+++ b/daydream/backends/_transport.py
@@ -14,7 +14,10 @@ import enum
 from collections.abc import AsyncIterator, Callable
 from typing import TYPE_CHECKING
 
+import anyio
+
 from daydream.backends._subprocess import (
+    cancel_processes,
     readline_with_idle_timeout,
     terminate_process,
 )
@@ -199,3 +202,20 @@ class CliTransport:
         """Group-signal, reap, and close pipes; shielded and idempotent."""
         if self._proc is not None:
             await terminate_process(self._proc)
+
+    @classmethod
+    async def cancel_all(cls, transports: list[CliTransport]) -> None:
+        """Cancel every tracked transport, mirroring
+        :func:`daydream.backends._subprocess.cancel_processes`.
+
+        Delegates the per-transport work to :meth:`terminate_process` via
+        :func:`cancel_processes` over the tracked live processes, so the reap is
+        shielded from the caller's cancellation and idempotent on double-call —
+        the same contract the backends' ``cancel()`` delegation relies on.
+        """
+        await cancel_processes([
+            proc for t in transports for proc in t.processes if proc.returncode is None
+        ])
+        with anyio.CancelScope(shield=True):
+            for t in transports:
+                await t.drain_finished()

--- a/daydream/backends/codex.py
+++ b/daydream/backends/codex.py
@@ -441,6 +441,7 @@ class CodexBackend:
                     if len(non_json_lines) >= 20:
                         non_json_lines.pop(0)
                     non_json_lines.append(raw_line)
+                    transport.note_diagnostic(raw_line)
                     _logger.debug("codex: non-JSON line skipped: %r", raw_line[:80])
                     continue
 
@@ -694,6 +695,8 @@ class CodexBackend:
         finally:
             if transport is not None:
                 await transport.terminate()
+                if transport in self._transports:
+                    self._transports.remove(transport)
             if schema_path:
                 Path(schema_path).unlink(missing_ok=True)
             if shared_checkout is not None:

--- a/daydream/backends/codex.py
+++ b/daydream/backends/codex.py
@@ -441,7 +441,6 @@ class CodexBackend:
                     if len(non_json_lines) >= 20:
                         non_json_lines.pop(0)
                     non_json_lines.append(raw_line)
-                    transport.note_diagnostic(raw_line)
                     _logger.debug("codex: non-JSON line skipped: %r", raw_line[:80])
                     continue
 

--- a/daydream/backends/codex.py
+++ b/daydream/backends/codex.py
@@ -32,11 +32,12 @@ from daydream.backends import (
     TurnEndEvent,
     resolve_fanout_concurrency,
 )
-from daydream.backends._subprocess import (
-    cancel_processes,
-    readline_with_idle_timeout,
-    stream_idle_timeout_s,
-    terminate_process,
+from daydream.backends._subprocess import stream_idle_timeout_s
+from daydream.backends._transport import (
+    CliTransport,
+    StderrPolicy,
+    StdinMode,
+    TransportExitError,
 )
 from daydream.pricing import compute_cost_from_totals, load_user_prices, resolve_prices
 
@@ -231,7 +232,7 @@ class CodexBackend:
         self.model = model
         self.reasoning_effort = reasoning_effort
         self.fanout_concurrency = resolve_fanout_concurrency("DAYDREAM_FANOUT_CONCURRENCY", 8)
-        self._processes: list[asyncio.subprocess.Process] = []
+        self._transports: list[CliTransport] = []
         # Disposable read-only checkouts shared across concurrent execute() calls
         # (built once per cwd, refcounted; cleaned up when the last holder exits).
         self._checkout_lock = asyncio.Lock()
@@ -344,7 +345,7 @@ class CodexBackend:
                 unmatched_seq += 1
             return item_id
 
-        proc: asyncio.subprocess.Process | None = None
+        transport: CliTransport | None = None
         execution_cwd = cwd
         shared_checkout: _SharedCheckout | None = None
 
@@ -411,37 +412,26 @@ class CodexBackend:
             # own cwd is never the source path. Path-hiding, not physical.
             child_env = _isolated_child_env(cwd, execution_cwd)
 
-            proc = await asyncio.create_subprocess_exec(
-                *args,
-                stdin=asyncio.subprocess.PIPE,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.STDOUT,
+            if execution_cwd != cwd:
+                # Rebind the prompt so no rendering of the caller's source
+                # path appears in the bytes written to the isolated subprocess.
+                prompt = _rebind_source_paths(prompt, cwd, execution_cwd)
+
+            transport = CliTransport(
+                "codex",
+                args,
+                stdin_mode=StdinMode.PIPE,
+                stdin_data=prompt.encode(),
+                stderr_policy=StderrPolicy.MERGE_INTO_STDOUT,
                 limit=_CODEX_STDOUT_LIMIT_BYTES,
-                start_new_session=True,
                 env=child_env,
                 cwd=str(execution_cwd) if execution_cwd != cwd else None,
             )
-            self._processes.append(proc)
-
-            if proc.stdin:
-                if execution_cwd != cwd:
-                    # Rebind the prompt so no rendering of the caller's source
-                    # path appears in the bytes written to the isolated subprocess.
-                    prompt = _rebind_source_paths(prompt, cwd, execution_cwd)
-                proc.stdin.write(prompt.encode())
-                proc.stdin.close()
+            self._transports.append(transport)
+            await transport.start()
 
             idle_timeout_s = stream_idle_timeout_s()
-            while True:
-                if proc.stdout is None:
-                    break
-                line = await readline_with_idle_timeout(
-                    proc.stdout, cli="codex", timeout_s=idle_timeout_s
-                )
-                if not line:
-                    break
-
-                raw_line = line.decode().strip()
+            async for raw_line in transport.lines(lambda: idle_timeout_s):
                 try:
                     event = json.loads(raw_line)
                 except json.JSONDecodeError:
@@ -685,20 +675,25 @@ class CodexBackend:
                 elif event_type not in ("turn.started",):
                     pass
 
-            await proc.wait()
+            # Reap the child (the transport raises TransportExitError on a
+            # non-zero exit; _check_return_code below formats the backend-
+            # specific message from the code and captured diagnostics).
+            try:
+                await transport.wait()
+            except TransportExitError:
+                pass
 
             # Fail fast on non-zero exit: if codex crashed without emitting a
             # turn.failed event, surface the failure with diagnostic output
             # instead of reporting a successful completion with empty/partial
             # output.
-            self._check_return_code(proc.returncode, non_json_lines)
+            self._check_return_code(transport.returncode, non_json_lines)
             if _pending_result is not None:
                 yield _pending_result
 
         finally:
-            if proc is not None:
-                await terminate_process(proc)
-            self._processes = [active for active in self._processes if active is not proc]
+            if transport is not None:
+                await transport.terminate()
             if schema_path:
                 Path(schema_path).unlink(missing_ok=True)
             if shared_checkout is not None:
@@ -713,7 +708,7 @@ class CodexBackend:
 
         Sends SIGTERM, waits briefly, then SIGKILL if still running.
         """
-        await cancel_processes(self._processes)
+        await CliTransport.cancel_all(self._transports)
 
     @staticmethod
     def _extract_text(item: dict[str, Any]) -> str:

--- a/daydream/backends/osprey.py
+++ b/daydream/backends/osprey.py
@@ -583,6 +583,16 @@ class OspreyBackend:
                     raw_line = await anext(stream)
                 except StopAsyncIteration:
                     break
+                except UnicodeDecodeError as exc:
+                    # A non-UTF-8 byte makes the transport's strict stdout
+                    # decode raise here; fall through to the non-JSON diagnosis
+                    # the pre-transport loop produced via errors="replace"
+                    # instead of mislabeling the line as over-limit.
+                    raw = exc.object.decode(errors="replace").strip()
+                    raise OspreyProtocolError(
+                        "Osprey emitted a non-JSON line in JSONL mode: "
+                        f"{_bounded_diagnostics([raw])}"
+                    ) from exc
                 except ValueError as exc:
                     raise OspreyProtocolError(
                         "Osprey stdout JSONL line exceeded the "
@@ -593,6 +603,7 @@ class OspreyBackend:
                 try:
                     event = json.loads(raw_line)
                 except json.JSONDecodeError as exc:
+                    transport.note_diagnostic(raw_line)
                     raise OspreyProtocolError(
                         "Osprey emitted a non-JSON line in JSONL mode: "
                         f"{_bounded_diagnostics([raw_line])}"

--- a/daydream/backends/osprey.py
+++ b/daydream/backends/osprey.py
@@ -8,18 +8,15 @@ existing backend event union.
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 import math
 import os
 import tempfile
-from collections.abc import AsyncGenerator, Iterable
+from collections.abc import AsyncGenerator, Callable, Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
-
-import anyio
 
 from daydream.backends import (
     AgentEvent,
@@ -34,11 +31,12 @@ from daydream.backends import (
     TurnEndEvent,
     resolve_fanout_concurrency,
 )
-from daydream.backends._subprocess import (
-    cancel_processes,
-    readline_with_idle_timeout,
-    stream_idle_timeout_s,
-    terminate_process,
+from daydream.backends._subprocess import stream_idle_timeout_s
+from daydream.backends._transport import (
+    CliTransport,
+    StderrPolicy,
+    StdinMode,
+    TransportExitError,
 )
 from daydream.trajectory import redact_text
 
@@ -188,24 +186,14 @@ def _bounded_diagnostic_line(line: str) -> str:
     return redact_text(line)[:_MAX_DIAGNOSTIC_LINE_CHARS]
 
 
-async def _drain_stderr(stderr: asyncio.StreamReader, diagnostics: list[str]) -> None:
-    """Drain Osprey diagnostics without allowing its stderr pipe to fill."""
-    while True:
-        try:
-            line = await stderr.readline()
-        except ValueError:
-            # ``StreamReader.readline`` clears an over-limit unterminated line
-            # before raising. Stderr is diagnostic-only, so discard that line
-            # and keep draining instead of failing an otherwise valid JSONL
-            # session during teardown.
-            if len(diagnostics) < _MAX_DIAGNOSTIC_LINES:
-                diagnostics.append("stderr diagnostic line exceeded stream limit and was discarded")
-            continue
-        if not line:
-            break
-        raw = line.decode(errors="replace").strip()
-        if raw and len(diagnostics) < _MAX_DIAGNOSTIC_LINES:
-            diagnostics.append(_bounded_diagnostic_line(raw))
+def _stderr_diagnostic_sink(diagnostics: list[str]) -> Callable[[str], None]:
+    """Build the redacting, capped sink the transport's stderr drain feeds."""
+
+    def sink(line: str) -> None:
+        if len(diagnostics) < _MAX_DIAGNOSTIC_LINES:
+            diagnostics.append(_bounded_diagnostic_line(line))
+
+    return sink
 
 
 @dataclass(frozen=True)
@@ -360,7 +348,7 @@ class OspreyBackend:
         self.fanout_concurrency = resolve_fanout_concurrency(
             "DAYDREAM_OSPREY_FANOUT_CONCURRENCY", 4
         )
-        self._processes: list[asyncio.subprocess.Process] = []
+        self._transports: list[CliTransport] = []
 
     def build_command(
         self,
@@ -546,7 +534,6 @@ class OspreyBackend:
         if output_schema is not None:
             schema_path = self._write_temp_schema(output_schema)
 
-        proc: asyncio.subprocess.Process | None = None
         session_id: str | None = None
         session_model: str | None = None
         provider: str | None = None
@@ -557,13 +544,14 @@ class OspreyBackend:
         total_cost: float | None = None
         saw_metric_cost = False
         stderr_lines: list[str] = []
-        stderr_task: asyncio.Task[None] | None = None
         terminal_outcome: str | None = None
         terminal_exit_code: int | None = None
         terminal_structured_output: Any = None
         turn_text_emitted = False
         thinking_parts: list[str] = []
         protocol_state = _OspreyProtocolState()
+
+        transport: CliTransport | None = None
 
         try:
             command = self.build_command(
@@ -577,43 +565,37 @@ class OspreyBackend:
             child_env = os.environ.copy()
             if self.osprey_home is not None:
                 child_env["OSPREY_HOME"] = str(self.osprey_home)
-            proc = await asyncio.create_subprocess_exec(
-                *command,
-                cwd=str(cwd),
-                stdin=asyncio.subprocess.DEVNULL,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
+            transport = CliTransport(
+                "osprey",
+                command,
+                stdin_mode=StdinMode.DEVNULL,
+                stderr_policy=StderrPolicy.DRAIN_TASK,
+                stderr_sink=_stderr_diagnostic_sink(stderr_lines),
                 limit=_OSPREY_STDOUT_LIMIT_BYTES,
                 env=child_env,
-                start_new_session=True,
+                cwd=str(cwd),
             )
-            self._processes.append(proc)
-            if proc.stderr is None:
-                raise OspreyError("Osprey stderr pipe is unavailable", category="PROCESS_START")
-            stderr_task = asyncio.create_task(_drain_stderr(proc.stderr, stderr_lines))
+            self._transports.append(transport)
+            await transport.start()
+            stream = transport.lines(stream_idle_timeout_s)
             while True:
-                if proc.stdout is None:
-                    break
                 try:
-                    line = await readline_with_idle_timeout(
-                        proc.stdout, cli="osprey", timeout_s=stream_idle_timeout_s()
-                    )
+                    raw_line = await anext(stream)
+                except StopAsyncIteration:
+                    break
                 except ValueError as exc:
                     raise OspreyProtocolError(
                         "Osprey stdout JSONL line exceeded the "
                         f"{_OSPREY_STDOUT_LIMIT_BYTES}-byte limit"
                     ) from exc
-                if not line:
-                    break
-                raw = line.decode(errors="replace").strip()
-                if not raw:
+                if not raw_line:
                     continue
                 try:
-                    event = json.loads(raw)
+                    event = json.loads(raw_line)
                 except json.JSONDecodeError as exc:
                     raise OspreyProtocolError(
                         "Osprey emitted a non-JSON line in JSONL mode: "
-                        f"{_bounded_diagnostics([raw])}"
+                        f"{_bounded_diagnostics([raw_line])}"
                     ) from exc
                 if not isinstance(event, dict):
                     raise OspreyProtocolError("Osprey JSONL event must be an object")
@@ -775,13 +757,19 @@ class OspreyBackend:
                 else:
                     raise OspreyProtocolError(f"unknown Osprey JSONL event {event_name!r}")
 
-            await proc.wait()
+            # Reap the child first; the transport raises TransportExitError on
+            # a non-zero exit, and the check below formats the backend-specific
+            # message from the code and captured stderr lines.
+            try:
+                await transport.wait()
+            except TransportExitError:
+                pass
             # A descendant can outlive Osprey while retaining the inherited
             # stderr fd. Reap the process group and close its transports before
             # awaiting EOF so the diagnostic drain cannot hang indefinitely.
-            await terminate_process(proc)
-            await stderr_task
-            returncode = proc.returncode
+            await transport.terminate()
+            await transport.drain_finished()
+            returncode = transport.returncode
             if returncode not in (None, 0):
                 raise OspreyError(
                     f"Osprey CLI exited with return code {returncode}: {_bounded_diagnostics(stderr_lines)}",
@@ -827,17 +815,14 @@ class OspreyBackend:
                 model_name=session_model,
             )
         finally:
-            with anyio.CancelScope(shield=True):
-                if proc is not None:
-                    await terminate_process(proc)
-                if stderr_task is not None:
-                    if not stderr_task.done():
-                        stderr_task.cancel()
-                    await asyncio.gather(stderr_task, return_exceptions=True)
-            self._processes = [active for active in self._processes if active is not proc]
+            if transport is not None:
+                await transport.terminate()
+                await transport.drain_finished()
+                if transport in self._transports:
+                    self._transports.remove(transport)
             if schema_path is not None:
                 Path(schema_path).unlink(missing_ok=True)
 
     async def cancel(self) -> None:
         """Terminate all active Osprey process groups and reap their pipes."""
-        await cancel_processes(self._processes)
+        await CliTransport.cancel_all(self._transports)

--- a/daydream/backends/osprey.py
+++ b/daydream/backends/osprey.py
@@ -571,6 +571,10 @@ class OspreyBackend:
                 stdin_mode=StdinMode.DEVNULL,
                 stderr_policy=StderrPolicy.DRAIN_TASK,
                 stderr_sink=_stderr_diagnostic_sink(stderr_lines),
+                # Replace-decode as the pre-transport osprey read loop did, so
+                # a non-UTF-8 byte inside JSON tool output is repaired and the
+                # session completes instead of hard-failing the phase.
+                decode_errors="replace",
                 limit=_OSPREY_STDOUT_LIMIT_BYTES,
                 env=child_env,
                 cwd=str(cwd),
@@ -583,16 +587,6 @@ class OspreyBackend:
                     raw_line = await anext(stream)
                 except StopAsyncIteration:
                     break
-                except UnicodeDecodeError as exc:
-                    # A non-UTF-8 byte makes the transport's strict stdout
-                    # decode raise here; fall through to the non-JSON diagnosis
-                    # the pre-transport loop produced via errors="replace"
-                    # instead of mislabeling the line as over-limit.
-                    raw = exc.object.decode(errors="replace").strip()
-                    raise OspreyProtocolError(
-                        "Osprey emitted a non-JSON line in JSONL mode: "
-                        f"{_bounded_diagnostics([raw])}"
-                    ) from exc
                 except ValueError as exc:
                     raise OspreyProtocolError(
                         "Osprey stdout JSONL line exceeded the "
@@ -603,7 +597,6 @@ class OspreyBackend:
                 try:
                     event = json.loads(raw_line)
                 except json.JSONDecodeError as exc:
-                    transport.note_diagnostic(raw_line)
                     raise OspreyProtocolError(
                         "Osprey emitted a non-JSON line in JSONL mode: "
                         f"{_bounded_diagnostics([raw_line])}"

--- a/daydream/backends/pi.py
+++ b/daydream/backends/pi.py
@@ -869,6 +869,8 @@ class PiBackend:
         finally:
             if transport is not None:
                 await transport.terminate()
+                if transport in self._transports:
+                    self._transports.remove(transport)
 
     async def cancel(self) -> None:
         """Cancel all running Pi processes.

--- a/daydream/backends/pi.py
+++ b/daydream/backends/pi.py
@@ -24,7 +24,6 @@ URL or writes a models.json override.
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 import math
@@ -51,10 +50,13 @@ from daydream.backends import (
 from daydream.backends._subprocess import (
     DEFAULT_PI_RESPONSE_IDLE_TIMEOUT_S,
     DEFAULT_STREAM_IDLE_TIMEOUT_S,
-    cancel_processes,
-    readline_with_idle_timeout,
     stream_idle_timeout_s,
-    terminate_process,
+)
+from daydream.backends._transport import (
+    CliTransport,
+    StderrPolicy,
+    StdinMode,
+    TransportExitError,
 )
 from daydream.config import DEFAULT_PI_MODEL
 from daydream.json_utils import extract_json
@@ -486,7 +488,7 @@ class PiBackend:
         self.retry_attempts = _pi_retry_attempts()
         self.retry_base_delay_s = _pi_retry_base_delay()
         self.retry_max_delay_s = _pi_retry_max_delay()
-        self._processes: list[asyncio.subprocess.Process] = []
+        self._transports: list[CliTransport] = []
 
     async def execute(
         self,
@@ -651,25 +653,20 @@ class PiBackend:
         saw_finish_reason = False
         saw_turn_start = False
 
-        proc: asyncio.subprocess.Process | None = None
+        transport: CliTransport | None = None
 
         try:
-            proc = await asyncio.create_subprocess_exec(
-                *args,
-                cwd=str(cwd),
-                stdin=asyncio.subprocess.DEVNULL,
-                stdout=asyncio.subprocess.PIPE,
-                # Merge stderr into stdout (matching CodexBackend). stderr=PIPE
-                # here would never be drained — a latent deadlock if pi writes
-                # more than the OS pipe buffer (~64KB) to stderr. The parse loop
-                # below already `continue`s past non-JSON lines, so stray stderr
-                # text mixed into stdout is harmlessly skipped.
-                stderr=asyncio.subprocess.STDOUT,
+            transport = CliTransport(
+                "pi",
+                args,
+                stdin_mode=StdinMode.DEVNULL,
+                stderr_policy=StderrPolicy.MERGE_INTO_STDOUT,
                 limit=_PI_STDOUT_LIMIT_BYTES,
                 env=child_env,
-                start_new_session=True,
+                cwd=str(cwd),
             )
-            self._processes.append(proc)
+            self._transports.append(transport)
+            await transport.start()
 
             response_idle_timeout_s = stream_idle_timeout_s(
                 default=DEFAULT_PI_RESPONSE_IDLE_TIMEOUT_S
@@ -679,22 +676,11 @@ class PiBackend:
             )
             active_tool_calls = 0
             is_first_line = True
-            while True:
-                if proc.stdout is None:
-                    break
-                line = await readline_with_idle_timeout(
-                    proc.stdout,
-                    cli="pi",
-                    timeout_s=(
-                        tool_idle_timeout_s
-                        if active_tool_calls > 0
-                        else response_idle_timeout_s
-                    ),
-                )
-                if not line:
-                    break
-
-                raw_line = line.decode().strip()
+            async for raw_line in transport.lines(
+                lambda: tool_idle_timeout_s
+                if active_tool_calls > 0
+                else response_idle_timeout_s
+            ):
                 if not raw_line:
                     continue
                 try:
@@ -813,13 +799,19 @@ class PiBackend:
                 # tool_execution_update are streaming-only; the full content is
                 # already captured at message_end / tool_execution_end.
 
-            await proc.wait()
+            # Reap the child (the transport raises TransportExitError on a
+            # non-zero exit; the check below formats the backend-specific
+            # message from the code and captured stderr lines).
+            try:
+                await transport.wait()
+            except TransportExitError:
+                pass
 
             # Fail fast on non-zero exit: if pi crashed without emitting a
             # turn_end error event, surface the failure with diagnostic output
             # instead of reporting a successful completion with empty/partial
             # output.
-            returncode = proc.returncode
+            returncode = transport.returncode
             if returncode is not None and returncode != 0:
                 stderr_tail = "\n".join(stderr_lines[-10:])
                 if stderr_lines:
@@ -875,9 +867,8 @@ class PiBackend:
             )
 
         finally:
-            if proc is not None:
-                await terminate_process(proc)
-            self._processes = [active for active in self._processes if active is not proc]
+            if transport is not None:
+                await transport.terminate()
 
     async def cancel(self) -> None:
         """Cancel all running Pi processes.
@@ -885,4 +876,4 @@ class PiBackend:
         Sends SIGTERM, waits briefly, then SIGKILL if still running (mirrors
         ``CodexBackend.cancel``).
         """
-        await cancel_processes(self._processes)
+        await CliTransport.cancel_all(self._transports)

--- a/tests/contract/_loaders.py
+++ b/tests/contract/_loaders.py
@@ -453,7 +453,7 @@ async def pi_loader(
     mock_proc = make_mock_process_pi(lines)
     backend = PiBackend(model="pi-test-model")
     with patch(
-        "daydream.backends.pi.asyncio.create_subprocess_exec",
+        "daydream.backends._transport.asyncio.create_subprocess_exec",
         return_value=mock_proc,
     ):
         async for event in backend.execute(Path("/tmp"), "go", read_only=read_only):

--- a/tests/contract/_loaders.py
+++ b/tests/contract/_loaders.py
@@ -316,7 +316,7 @@ async def codex_loader(
     mock_proc = make_mock_process(lines)
     backend = CodexBackend(model="codex-test-model")
     with patch(
-        "daydream.backends.codex.asyncio.create_subprocess_exec",
+        "daydream.backends._transport.asyncio.create_subprocess_exec",
         return_value=mock_proc,
     ):
         async for event in backend.execute(Path("/tmp"), "go", read_only=read_only):

--- a/tests/contract/test_backend_codex_trajectory.py
+++ b/tests/contract/test_backend_codex_trajectory.py
@@ -59,7 +59,7 @@ async def _drive_codex_through_recorder(
         async with recorder.invocation(phase=DaydreamPhase.REVIEW) as inv:
             mock_proc = make_mock_process_from_fixture(fixture)
             with patch(
-                "daydream.backends.codex.asyncio.create_subprocess_exec",
+                "daydream.backends._transport.asyncio.create_subprocess_exec",
                 return_value=mock_proc,
             ):
                 async for event in backend.execute(tmp_path, "review"):

--- a/tests/harness/codex_replay.py
+++ b/tests/harness/codex_replay.py
@@ -3,7 +3,7 @@
 The returned ``MagicMock`` reproduces the
 exact ``stdout``/``stdin``/``wait``/``returncode``/``terminate``/``kill`` shape
 that ``CodexBackend.execute`` drives via
-``daydream.backends.codex.asyncio.create_subprocess_exec``.
+``daydream.backends._transport.asyncio.create_subprocess_exec``.
 """
 
 from pathlib import Path

--- a/tests/harness/fake_cli_process.py
+++ b/tests/harness/fake_cli_process.py
@@ -60,8 +60,10 @@ class _FakePipeTransport:
 
     def __init__(self, proc: FakeCliProcess) -> None:
         self._proc = proc
+        self.closed = False
 
     def close(self) -> None:
+        self.closed = True
         self._proc._release_pipes()
 
 
@@ -156,7 +158,13 @@ def install_fake_cli_process(
     stdout_reader: asyncio.StreamReader | None = None,
     stderr_reader: asyncio.StreamReader | None = None,
 ) -> FakeCliSpawner:
-    """Patch ``create_subprocess_exec`` as seen by the *cli* backend module.
+    """Patch ``create_subprocess_exec`` at the transport seam.
+
+    ``cli`` names the backend under test; every spawn is asserted to carry
+    that name as its first argv element, so a test whose declared cli no
+    longer matches what the transport actually launches fails loudly here
+    (e.g. after a backend switches transports) instead of silently driving
+    the wrong process shape.
 
     Every launch gets a fresh :class:`FakeCliProcess` with the given shape and
     is recorded on the returned spawner, so tests can assert how many
@@ -168,6 +176,9 @@ def install_fake_cli_process(
     spawner = FakeCliSpawner()
 
     async def fake_exec(*args: Any, **kwargs: Any) -> FakeCliProcess:
+        assert args[0] == cli, (
+            f"spawned CLI argv[0] {args[0]!r} does not match declared cli {cli!r}"
+        )
         proc = FakeCliProcess(
             lines,
             hang=hang,

--- a/tests/harness/fake_cli_process.py
+++ b/tests/harness/fake_cli_process.py
@@ -51,6 +51,20 @@ class _FakeStdin:
         self.closed = True
 
 
+class _FakePipeTransport:
+    """The fd owner ``terminate_process`` closes to release the pipe read ends.
+
+    Closing releases the read ends regardless of EOF — the mechanism that lets
+    a stderr drain finish even when a surviving descendant holds the fd open.
+    """
+
+    def __init__(self, proc: FakeCliProcess) -> None:
+        self._proc = proc
+
+    def close(self) -> None:
+        self._proc._release_pipes()
+
+
 class FakeCliProcess:
     """An ``asyncio.subprocess.Process`` stand-in with modeled exit semantics."""
 
@@ -61,8 +75,23 @@ class FakeCliProcess:
         hang: bool = False,
         exit_code: int = 0,
         ignore_sigterm: bool = False,
+        stderr_lines: list[str] | None = None,
+        stderr_held_open: bool = False,
+        stdout_reader: asyncio.StreamReader | None = None,
+        stderr_reader: asyncio.StreamReader | None = None,
     ) -> None:
-        self.stdout = asyncio.StreamReader()
+        if stdout_reader is not None:
+            self.stdout: asyncio.StreamReader = stdout_reader
+        else:
+            self.stdout = asyncio.StreamReader()
+            for line in lines:
+                self.stdout.feed_data((line + "\n").encode())
+        self.stderr: asyncio.StreamReader | None = stderr_reader
+        if self.stderr is None and (stderr_lines is not None or stderr_held_open):
+            self.stderr = asyncio.StreamReader()
+            for line in stderr_lines or []:
+                self.stderr.feed_data((line + "\n").encode())
+        self._stderr_held_open = stderr_held_open
         self.stdin = _FakeStdin()
         self.returncode: int | None = None
         self.reaped = False
@@ -70,8 +99,7 @@ class FakeCliProcess:
         self.kill_calls = 0
         self._ignore_sigterm = ignore_sigterm
         self._exited = asyncio.Event()
-        for line in lines:
-            self.stdout.feed_data((line + "\n").encode())
+        self._transport = _FakePipeTransport(self)
         if not hang:
             self._exit(exit_code)
 
@@ -79,7 +107,16 @@ class FakeCliProcess:
         if self.returncode is None:
             self.returncode = code
             self.stdout.feed_eof()
+            # A descendant holding the inherited stderr fd keeps its EOF from
+            # arriving; the child's own death alone does not end the drain.
+            if not self._stderr_held_open:
+                self._release_pipes()
             self._exited.set()
+
+    def _release_pipes(self) -> None:
+        """Model the teardown's fd release (real: ``proc._transport.close()``)."""
+        if self.stderr is not None:
+            self.stderr.feed_eof()
 
     def terminate(self) -> None:
         self.terminate_calls += 1
@@ -103,6 +140,7 @@ class FakeCliSpawner:
 
     procs: list[FakeCliProcess] = field(default_factory=list)
     argvs: list[tuple[str, ...]] = field(default_factory=list)
+    kwargs: list[dict[str, Any]] = field(default_factory=list)
 
 
 def install_fake_cli_process(
@@ -113,21 +151,36 @@ def install_fake_cli_process(
     hang: bool = False,
     exit_code: int = 0,
     ignore_sigterm: bool = False,
+    stderr_lines: list[str] | None = None,
+    stderr_held_open: bool = False,
+    stdout_reader: asyncio.StreamReader | None = None,
+    stderr_reader: asyncio.StreamReader | None = None,
 ) -> FakeCliSpawner:
     """Patch ``create_subprocess_exec`` as seen by the *cli* backend module.
 
     Every launch gets a fresh :class:`FakeCliProcess` with the given shape and
     is recorded on the returned spawner, so tests can assert how many
     subprocesses were actually started (e.g. "a stall must not relaunch").
+    The ``stderr_*`` options model osprey's separate stderr pipe: lines fed to
+    the drain, optionally held open past the child's exit (a surviving
+    descendant inheriting the fd) until the teardown releases the fds.
     """
     spawner = FakeCliSpawner()
 
     async def fake_exec(*args: Any, **kwargs: Any) -> FakeCliProcess:
         proc = FakeCliProcess(
-            lines, hang=hang, exit_code=exit_code, ignore_sigterm=ignore_sigterm
+            lines,
+            hang=hang,
+            exit_code=exit_code,
+            ignore_sigterm=ignore_sigterm,
+            stderr_lines=stderr_lines,
+            stderr_held_open=stderr_held_open,
+            stdout_reader=stdout_reader,
+            stderr_reader=stderr_reader,
         )
         spawner.procs.append(proc)
         spawner.argvs.append(tuple(str(a) for a in args))
+        spawner.kwargs.append(kwargs)
         return proc
 
     monkeypatch.setattr(

--- a/tests/harness/fake_cli_process.py
+++ b/tests/harness/fake_cli_process.py
@@ -16,7 +16,9 @@ OS semantics modeled by :class:`FakeCliProcess`:
 - ``wait()`` resolves only once the child has exited, and marks it
   ``reaped`` — the fake equivalent of "gone from the process table".
 
-:func:`install_fake_cli_process` patches ``asyncio.create_subprocess_exec``
+:func:`install_fake_cli_process` patches ``asyncio.create_subprocess_exec`` at
+the transport seam (``daydream.backends._transport``), where the codex/pi
+backends now spawn via :class:`~daydream.backends._transport.CliTransport`,
 as seen by the backend module, so everything of daydream's runs for real —
 argv construction, the readline loop, the idle window, the shielded
 SIGTERM→SIGKILL teardown — only the OS fork is replaced (the same seam
@@ -129,6 +131,6 @@ def install_fake_cli_process(
         return proc
 
     monkeypatch.setattr(
-        f"daydream.backends.{cli}.asyncio.create_subprocess_exec", fake_exec
+        "daydream.backends._transport.asyncio.create_subprocess_exec", fake_exec
     )
     return spawner

--- a/tests/harness/phase_replay.py
+++ b/tests/harness/phase_replay.py
@@ -63,7 +63,7 @@ def _firing_phase() -> DaydreamPhase:
 def codex_subprocess_for_phases(phase_scripts: PhaseScripts) -> AbstractContextManager[Any]:
     """Patch the Codex subprocess boundary to serve per-phase fixtures.
 
-    Patches ``daydream.backends.codex.asyncio.create_subprocess_exec`` with a
+    Patches ``daydream.backends._transport.asyncio.create_subprocess_exec`` with a
     ``side_effect`` factory that, on each subprocess launch, reads the firing
     phase via ``current_phase()`` and returns ``make_mock_process`` over that
     phase's rendered Codex JSONL lines.
@@ -89,6 +89,6 @@ def codex_subprocess_for_phases(phase_scripts: PhaseScripts) -> AbstractContextM
         return make_mock_process(rendered[phase])
 
     return patch(
-        "daydream.backends.codex.asyncio.create_subprocess_exec",
+        "daydream.backends._transport.asyncio.create_subprocess_exec",
         side_effect=factory,
     )

--- a/tests/harness/pi_replay.py
+++ b/tests/harness/pi_replay.py
@@ -3,7 +3,7 @@
 Mirrors :mod:`tests.harness.codex_replay`. The returned ``MagicMock``
 reproduces the exact ``stdout``/``wait``/``returncode``/``terminate``/``kill``
 shape that ``PiBackend.execute`` drives via
-``daydream.backends.pi.asyncio.create_subprocess_exec``.
+``daydream.backends._transport.asyncio.create_subprocess_exec``.
 
 Pi's prompt is a positional argument (not stdin like Codex), so the mock does
 not need a writable stdin handle — but ``PiBackend.execute`` opens the process

--- a/tests/harness/scripts.py
+++ b/tests/harness/scripts.py
@@ -120,7 +120,7 @@ async def drive_codex(
     backend = CodexBackend(model="codex-test-model")
     events: list[AgentEvent] = []
     with patch(
-        "daydream.backends.codex.asyncio.create_subprocess_exec",
+        "daydream.backends._transport.asyncio.create_subprocess_exec",
         return_value=mock_proc,
     ):
         async for event in backend.execute(Path("/tmp"), "go", output_schema=output_schema):

--- a/tests/test_backend_codex.py
+++ b/tests/test_backend_codex.py
@@ -595,6 +595,8 @@ async def test_execute_finally_reaps_process_and_closes_pipes_after_exit() -> No
     assert proc.returncode == 0
     assert proc.reaped, "the finally must reap the child even after clean exit"
     assert proc.stdin.closed, "the finally must close the stdin pipe"
+    assert proc._transport.closed, "the finally must release the pipe fds even after clean exit"
+    assert backend._transports == [], "the finally must drop the transport from the backend list"
 
 
 @pytest.mark.asyncio

--- a/tests/test_backend_codex.py
+++ b/tests/test_backend_codex.py
@@ -37,7 +37,7 @@ FIXTURES_DIR = Path(__file__).parent / "fixtures" / "codex_jsonl"
 async def _run_fixture(backend: Any, prompt: Any, fixture: Any, **kwargs: Any) -> Any:
     """Drive ``execute`` over a canned fixture and collect the event list."""
     mock_proc = make_mock_process_from_fixture(fixture)
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc):
         return [event async for event in backend.execute(Path("/tmp"), prompt, **kwargs)]
 
 
@@ -143,7 +143,7 @@ async def test_turn_failed_raises() -> None:
     backend = CodexBackend(model="fixture-model")
     mock_proc = make_mock_process_from_fixture("turn_failed.jsonl")
 
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc):
         with pytest.raises(CodexError, match="Model returned an error") as exc_info:
             async for _ in backend.execute(Path("/tmp"), "Fail"):
                 pass
@@ -162,7 +162,7 @@ async def test_nonzero_exit_raises_with_captured_output() -> None:
     mock_proc.returncode = 1
 
     events = []
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc):
         with pytest.raises(CodexError, match="return code 1") as exc_info:
             async for event in backend.execute(Path("/tmp"), "Fail"):
                 events.append(event)
@@ -181,7 +181,7 @@ async def test_nonzero_exit_with_no_output_still_informative() -> None:
     mock_proc = make_mock_process([])
     mock_proc.returncode = 1
 
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc):
         with pytest.raises(CodexError, match="return code 1") as exc_info:
             async for _ in backend.execute(Path("/tmp"), "Fail"):
                 pass
@@ -199,7 +199,7 @@ async def test_continuation_token_resumes() -> None:
     mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
     token = ContinuationToken(backend="codex", data={"thread_id": "th_prev"})
 
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
         async for _ in backend.execute(Path("/tmp"), "Continue", continuation=token):
             pass
 
@@ -249,7 +249,7 @@ async def test_codex_read_only_uses_read_only_sandbox(
         captured["args"] = flat
         return mock_proc
 
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", fake_exec):
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", fake_exec):
         async for _ in CodexBackend(model="fixture-model").execute(
             source, f"Audit repository at {source}", read_only=True,
         ):
@@ -296,7 +296,7 @@ async def test_codex_read_only_isolation_failure_is_fail_closed(
 
     monkeypatch.setattr("daydream.backends.codex.git_ops.clone", boom)
     mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc):
         with pytest.raises(CodexError, match="failed to create disposable read-only checkout"):
             async for _ in CodexBackend(model="fixture-model").execute(source, "Audit", read_only=True):
                 pass
@@ -376,7 +376,7 @@ async def test_codex_read_only_resume_is_refused(
     token = ContinuationToken(backend="codex", data={"thread_id": "th_prev"})
     mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
 
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc):
         with pytest.raises(CodexError, match="cannot be resumed"):
             async for _ in backend.execute(source, "Continue", continuation=token, read_only=True):
                 pass
@@ -420,7 +420,7 @@ async def test_codex_read_only_parallel_calls_share_one_clone(
         async for _ in backend.execute(source, f"Audit {source}", read_only=True):
             pass
 
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", fake_exec):
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", fake_exec):
         await asyncio.gather(drive(), drive())
 
     assert len(build_calls) == 1, "the two concurrent calls must share one clone build"
@@ -468,7 +468,7 @@ async def test_codex_read_only_mirrors_symlinks_and_unstaged_deletions(
         captured["doomed_present"] = (isolated / "services/taste/lexer.go").exists()
         return mock_proc
 
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", fake_exec):
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", fake_exec):
         async for _ in CodexBackend(model="fixture-model").execute(source, "Audit", read_only=True):
             pass
 
@@ -486,7 +486,7 @@ async def test_codex_default_uses_full_access_sandbox() -> None:
     backend = CodexBackend(model="fixture-model")
     mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
 
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
         async for _ in backend.execute(Path("/tmp"), "p"):
             pass
 
@@ -511,7 +511,7 @@ async def test_codex_default_full_access_at_worktree_skips_isolation(
     backend = CodexBackend(model="fixture-model")
     mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
 
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
         async for _ in backend.execute(source, "p"):
             pass
 
@@ -527,7 +527,7 @@ async def test_codex_reasoning_effort_appends_config_override() -> None:
     backend = CodexBackend(model="fixture-model", reasoning_effort="high")
     mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
 
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
         async for _ in backend.execute(Path("/tmp"), "p"):
             pass
 
@@ -541,7 +541,7 @@ async def test_codex_no_reasoning_effort_omits_config_override() -> None:
     backend = CodexBackend(model="fixture-model")
     mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
 
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
         async for _ in backend.execute(Path("/tmp"), "p"):
             pass
 
@@ -555,7 +555,7 @@ async def test_spawn_uses_start_new_session() -> None:
     backend = CodexBackend(model="gpt-5.1-codex")
     mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
     with patch(
-        "daydream.backends.codex.asyncio.create_subprocess_exec",
+        "daydream.backends._transport.asyncio.create_subprocess_exec",
         return_value=mock_proc,
     ) as mock_exec:
         events = []
@@ -565,26 +565,36 @@ async def test_spawn_uses_start_new_session() -> None:
 
 
 @pytest.mark.asyncio
-async def test_execute_finally_closes_transport_after_process_exit() -> None:
-    """Even when the CLI already exited, the finally closes the transport.
+async def test_execute_finally_reaps_process_and_closes_pipes_after_exit() -> None:
+    """Even when the CLI already exited, the finally reaps it and closes stdin.
 
     A grandchild holding the pipe write end means the stream never reaches EOF,
-    so the fd is only released by an explicit transport close.
+    so the fds are only released by an explicit teardown.
     """
+    from tests.harness.fake_cli_process import FakeCliProcess, FakeCliSpawner
+
     backend = CodexBackend(model="gpt-5.1-codex")
-    mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
-    mock_proc.returncode = 0  # process already exited
-    mock_proc._transport = MagicMock()
+    captured = FakeCliSpawner()
 
-    with patch(
-        "daydream.backends.codex.asyncio.create_subprocess_exec",
-        return_value=mock_proc,
-    ):
-        events = []
-        async for event in backend.execute(Path("/tmp"), "hello"):
-            events.append(event)
+    async def fake_exec(*args: Any, **kwargs: Any) -> FakeCliProcess:
+        proc = FakeCliProcess(
+            [
+                '{"type":"item.completed","item":{"type":"agent_message","text":"hello"}}',
+                '{"type":"turn.completed","usage":{}}',
+            ],
+            exit_code=0,
+        )
+        captured.procs.append(proc)
+        return proc
 
-    mock_proc._transport.close.assert_called_once()
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", fake_exec):
+        events = [event async for event in backend.execute(Path("/tmp"), "hello")]
+
+    assert events  # the turn ran to completion
+    proc = captured.procs[0]
+    assert proc.returncode == 0
+    assert proc.reaped, "the finally must reap the child even after clean exit"
+    assert proc.stdin.closed, "the finally must close the stdin pipe"
 
 
 @pytest.mark.asyncio
@@ -629,7 +639,7 @@ async def test_codex_stdout_limit_allows_large_jsonl_events() -> None:
         process.kill = MagicMock()
         return process
 
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", fake_exec):
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", fake_exec):
         events = [event async for event in backend.execute(Path("/tmp"), "large event")]
 
     text_events = [e for e in events if isinstance(e, TextEvent)]
@@ -712,7 +722,7 @@ async def test_codex_synthesizes_cost_for_known_model() -> None:
     ]
 
     mock_proc = make_mock_process(lines)
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc):
         events = []
         async for event in backend.execute(Path("/tmp"), "Synth"):
             events.append(event)
@@ -760,7 +770,7 @@ async def test_codex_cost_none_for_unknown_model() -> None:
     ]
 
     mock_proc = make_mock_process(lines)
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc):
         events = []
         async for event in backend.execute(Path("/tmp"), "Unknown"):
             events.append(event)
@@ -848,7 +858,7 @@ async def test_concurrent_execute_calls_do_not_share_stdout_reader() -> None:
     async def consume_second() -> list[object]:
         return [event async for event in backend.execute(Path("/tmp"), "second")]
 
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", fake_exec):
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", fake_exec):
         first_iter = backend.execute(Path("/tmp"), "first")
         first_event = await anext(first_iter)
         assert isinstance(first_event, TextEvent)

--- a/tests/test_backend_codex_metrics.py
+++ b/tests/test_backend_codex_metrics.py
@@ -44,7 +44,7 @@ async def test_metrics_event_emitted_at_turn_completed() -> None:
     """
     backend = CodexBackend(model="gpt-5.3-codex")
     mock_proc = _make_mock_process("turn_completed_with_usage.jsonl")
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc):
         events = []
         async for event in backend.execute(Path("/tmp"), "test"):
             events.append(event)
@@ -77,7 +77,7 @@ async def test_cost_event_still_emitted() -> None:
     """
     backend = CodexBackend(model="fixture-model")
     mock_proc = _make_mock_process("turn_completed_with_usage.jsonl")
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc):
         events = []
         async for event in backend.execute(Path("/tmp"), "test"):
             events.append(event)
@@ -94,7 +94,7 @@ async def test_partial_usage_skips_metrics_event() -> None:
     """usage missing output_tokens => no MetricsEvent emitted (EVNT-02 requires both as int)."""
     backend = CodexBackend(model="fixture-model")
     mock_proc = _make_mock_process("turn_completed_partial_usage.jsonl")
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc):
         events = []
         async for event in backend.execute(Path("/tmp"), "test"):
             events.append(event)

--- a/tests/test_backend_osprey.py
+++ b/tests/test_backend_osprey.py
@@ -184,6 +184,7 @@ async def test_non_utf8_byte_inside_json_event_is_repaired_and_session_completes
         stdout_reader=stdout,
     )
 
+    assert isinstance(events[0], TextEvent)
     assert events[0].text == "x\ufffd"
     assert type(events[-1]) is ResultEvent
 

--- a/tests/test_backend_osprey.py
+++ b/tests/test_backend_osprey.py
@@ -145,11 +145,9 @@ async def test_oversized_stdout_line_is_categorized_as_protocol_error() -> None:
 async def test_non_utf8_stdout_line_is_non_json_protocol_error_not_over_limit() -> None:
     """A non-UTF-8 byte must surface as a non-JSON line, not an over-limit line.
 
-    The transport decodes stdout strictly (byte-identical backend messages
-    were promised pre-refactor), so a 0xff byte raises UnicodeDecodeError — a
-    ValueError — which must be routed to the non-JSON diagnosis (what the old
-    ``errors=\"replace\"`` loop produced), never mislabeled as the
-    10485760-byte-limit error.
+    Osprey decodes stdout with errors="replace" (its historical contract), so
+    a 0xff byte in a line that still fails JSON parsing after repair is
+    diagnosed as non-JSON — never mislabeled as the 10485760-byte-limit error.
     """
     stdout = _over_limit_reader(b'{"event"' + b"\xff" + b"}\n")
     backend = OspreyBackend(osprey_binary="fake")
@@ -161,6 +159,33 @@ async def test_non_utf8_stdout_line_is_non_json_protocol_error_not_over_limit() 
     assert "byte limit" not in str(exc_info.value)
     assert "\ufffd" in str(exc_info.value)
     assert backend._transports == []
+
+
+@pytest.mark.asyncio
+async def test_non_utf8_byte_inside_json_event_is_repaired_and_session_completes() -> None:
+    """A non-UTF-8 byte inside a JSON string is repaired with U+FFFD and the
+    event is processed normally (the historical errors="replace" contract),
+    never hard-failed as a protocol error.
+    """
+    lines, _ = _stream({"event": "text_delta", "content": "x"})
+    payload: list[bytes] = []
+    for event in lines:
+        raw = json.dumps(event).encode()
+        if event.get("event") == "text_delta":
+            raw = raw.replace(b'"x"', b'"x\xff"')
+        payload.append(raw)
+    stdout = asyncio.StreamReader(limit=2_048)
+    stdout.feed_data(b"\n".join(payload) + b"\n")
+    stdout.feed_eof()
+
+    events, _ = await _collect(
+        OspreyBackend(osprey_binary="fake"),
+        [],
+        stdout_reader=stdout,
+    )
+
+    assert events[0].text == "x\ufffd"
+    assert type(events[-1]) is ResultEvent
 
 
 @pytest.mark.asyncio

--- a/tests/test_backend_osprey.py
+++ b/tests/test_backend_osprey.py
@@ -142,6 +142,28 @@ async def test_oversized_stdout_line_is_categorized_as_protocol_error() -> None:
 
 
 @pytest.mark.asyncio
+async def test_non_utf8_stdout_line_is_non_json_protocol_error_not_over_limit() -> None:
+    """A non-UTF-8 byte must surface as a non-JSON line, not an over-limit line.
+
+    The transport decodes stdout strictly (byte-identical backend messages
+    were promised pre-refactor), so a 0xff byte raises UnicodeDecodeError — a
+    ValueError — which must be routed to the non-JSON diagnosis (what the old
+    ``errors=\"replace\"`` loop produced), never mislabeled as the
+    10485760-byte-limit error.
+    """
+    stdout = _over_limit_reader(b'{"event"' + b"\xff" + b"}\n")
+    backend = OspreyBackend(osprey_binary="fake")
+
+    with pytest.raises(OspreyError, match=r"non-JSON line in JSONL mode") as exc_info:
+        await _collect(backend, [], stdout_reader=stdout)
+
+    assert exc_info.value.category == "PROTOCOL"
+    assert "byte limit" not in str(exc_info.value)
+    assert "\ufffd" in str(exc_info.value)
+    assert backend._transports == []
+
+
+@pytest.mark.asyncio
 async def test_oversized_stderr_diagnostic_does_not_fail_successful_run() -> None:
     lines, _ = _stream()
     stderr = _over_limit_reader(b"diagnostic" * 8)

--- a/tests/test_backend_osprey.py
+++ b/tests/test_backend_osprey.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -27,60 +28,10 @@ from daydream.backends.osprey import (
     OspreyProtocolError,
     OspreyTerminalError,
     OspreyUnsupportedOption,
-    _drain_stderr,
+    _stderr_diagnostic_sink,
 )
 from daydream.trajectory import DaydreamPhase, DaydreamRunFlow, TrajectoryRecorder
-
-
-class _FakeStdout:
-    def __init__(self, lines: list[dict[str, object]]) -> None:
-        import json
-
-        self._lines = iter(json.dumps(line).encode() + b"\n" for line in lines)
-
-    async def readline(self) -> bytes:
-        try:
-            return next(self._lines)
-        except StopIteration:
-            return b""
-
-
-class _FakeStderr:
-    def __init__(self, lines: list[str], held_open: asyncio.Event | None = None) -> None:
-        self._lines = iter(line.encode() + b"\n" for line in lines)
-        self._held_open = held_open
-
-    async def readline(self) -> bytes:
-        try:
-            return next(self._lines)
-        except StopIteration:
-            if self._held_open is not None:
-                await self._held_open.wait()
-            return b""
-
-
-class _FakeProcess:
-    def __init__(
-        self,
-        lines: list[dict[str, object]],
-        returncode: int = 0,
-        stderr_lines: list[str] | None = None,
-        stderr_held_open: bool = False,
-        stdout_reader: asyncio.StreamReader | None = None,
-        stderr_reader: asyncio.StreamReader | None = None,
-    ) -> None:
-        self.stdout = stdout_reader or _FakeStdout(lines)
-        self._stderr_eof = asyncio.Event() if stderr_held_open else None
-        self.stderr = stderr_reader or _FakeStderr(stderr_lines or [], self._stderr_eof)
-        self.returncode = returncode
-        self.pid = 137
-
-    async def wait(self) -> int:
-        return self.returncode
-
-    def close_stderr(self) -> None:
-        if self._stderr_eof is not None:
-            self._stderr_eof.set()
+from tests.harness.fake_cli_process import FakeCliProcess, FakeCliSpawner
 
 
 def _stream(
@@ -140,21 +91,24 @@ async def _collect(
     stderr_held_open: bool = False,
     stdout_reader: asyncio.StreamReader | None = None,
     stderr_reader: asyncio.StreamReader | None = None,
-) -> tuple[list[AgentEvent], AsyncMock]:
-    process = _FakeProcess(
-        lines,
-        returncode=returncode,
-        stderr_lines=stderr_lines,
-        stderr_held_open=stderr_held_open,
-        stdout_reader=stdout_reader,
-        stderr_reader=stderr_reader,
-    )
-    exec_mock = AsyncMock(return_value=process)
-    terminate_mock = AsyncMock(side_effect=lambda _process: process.close_stderr())
-    with (
-        patch("daydream.backends.osprey.asyncio.create_subprocess_exec", exec_mock),
-        patch("daydream.backends.osprey.terminate_process", new=terminate_mock),
-    ):
+) -> tuple[list[AgentEvent], FakeCliSpawner]:
+    spawner = FakeCliSpawner()
+
+    async def fake_exec(*args: Any, **kwargs: Any) -> Any:
+        proc = FakeCliProcess(
+            [json.dumps(line) for line in lines],
+            exit_code=returncode,
+            stderr_lines=stderr_lines,
+            stderr_held_open=stderr_held_open,
+            stdout_reader=stdout_reader,
+            stderr_reader=stderr_reader,
+        )
+        spawner.procs.append(proc)
+        spawner.argvs.append(tuple(str(a) for a in args))
+        spawner.kwargs.append(kwargs)
+        return proc
+
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", fake_exec):
         events = [
             event
             async for event in backend.execute(
@@ -168,7 +122,7 @@ async def _collect(
                 persist_session=persist_session,
             )
         ]
-    return events, exec_mock
+    return events, spawner
 
 
 @pytest.mark.asyncio
@@ -184,7 +138,7 @@ async def test_oversized_stdout_line_is_categorized_as_protocol_error() -> None:
         )
 
     assert exc_info.value.category == "PROTOCOL"
-    assert backend._processes == []
+    assert backend._transports == []
 
 
 @pytest.mark.asyncio
@@ -221,11 +175,11 @@ async def test_stderr_diagnostics_are_redacted_and_capped_while_draining() -> No
     diagnostics: list[str] = []
     stderr = asyncio.StreamReader(limit=2_048)
     stderr.feed_data((f"OPENAI_API_KEY={secret} " + "x" * 1_024 + "\n").encode())
-    stderr.feed_eof()
+    sink = _stderr_diagnostic_sink(diagnostics)
+    for _ in range(12):
+        sink("OPENAI_API_KEY=" + secret + " " + "x" * 1_024)
 
-    await _drain_stderr(stderr, diagnostics)
-
-    assert len(diagnostics) == 1
+    assert len(diagnostics) == 10
     assert len(diagnostics[0]) <= 500
     assert secret not in diagnostics[0]
     assert "[REDACTED_ENV_VAR]" in diagnostics[0]
@@ -235,7 +189,7 @@ async def test_stderr_diagnostics_are_redacted_and_capped_while_draining() -> No
 async def test_stderr_is_drained_separately_from_jsonl_stdout() -> None:
     lines, _ = _stream()
 
-    events, exec_mock = await _collect(
+    events, spawner = await _collect(
         OspreyBackend(osprey_binary="fake"),
         lines,
         stderr_lines=[
@@ -245,7 +199,7 @@ async def test_stderr_is_drained_separately_from_jsonl_stdout() -> None:
     )
 
     assert [type(event) for event in events] == [ResultEvent]
-    assert exec_mock.call_args.kwargs["stderr"] is asyncio.subprocess.PIPE
+    assert spawner.kwargs[0]["stderr"] is asyncio.subprocess.PIPE
 
 
 @pytest.mark.asyncio
@@ -603,10 +557,10 @@ def test_command_forwards_verified_policy_resume_fork_and_schema_flags(tmp_path:
 @pytest.mark.asyncio
 async def test_output_schema_is_temp_file_forwarded_and_cleaned(tmp_path: Path) -> None:
     lines, _ = _stream()
-    _, exec_mock = await _collect(
+    _, spawner = await _collect(
         OspreyBackend(osprey_binary="fake"), lines, output_schema={"type": "object"}
     )
-    command = list(exec_mock.call_args.args)
+    command = list(spawner.argvs[0])
     schema_path = Path(command[command.index("--output-schema") + 1])
     assert not schema_path.exists()
 
@@ -802,10 +756,22 @@ async def test_trajectory_preserves_tool_identity(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_cancel_delegates_to_shared_process_lifecycle() -> None:
+async def test_cancel_delegates_to_shared_transport_lifecycle() -> None:
+    """cancel() reaps every tracked transport's process group and pipes."""
+    from daydream.backends._transport import CliTransport
+
     backend = OspreyBackend(osprey_binary="fake")
-    process = MagicMock()
-    backend._processes.append(process)
-    with patch("daydream.backends.osprey.cancel_processes", new=AsyncMock()) as cancel:
-        await backend.cancel()
-    cancel.assert_awaited_once_with([process])
+
+    proc = MagicMock()
+    proc.returncode = None
+    proc.wait = AsyncMock(side_effect=[asyncio.TimeoutError(), 0])
+    proc.terminate = MagicMock()
+    proc.kill = MagicMock()
+    transport = CliTransport("osprey", ["osprey", "agent"], limit=1024)
+    transport.processes.append(proc)
+    backend._transports = [transport]
+
+    await backend.cancel()
+
+    proc.terminate.assert_called_once()
+    proc.kill.assert_called_once()

--- a/tests/test_backend_pi.py
+++ b/tests/test_backend_pi.py
@@ -71,7 +71,7 @@ async def _run_and_capture_args(
     ``(flat_args, mock_exec)`` pair so callers can also assert on kwargs.
     """
     mock_proc = make_mock_process_from_fixture(fixture)
-    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
         async for _ in backend.execute(Path("/tmp"), prompt, **kwargs):
             pass
     return list(mock_exec.call_args.args), mock_exec
@@ -82,7 +82,7 @@ async def test_simple_text_events() -> None:
     backend = PiBackend(model="glm-5.2")
     mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
 
-    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc):
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc):
         events = []
         async for event in backend.execute(Path("/tmp"), "Say hello"):
             events.append(event)
@@ -120,7 +120,7 @@ async def test_thinking_and_tool_use_events() -> None:
     backend = PiBackend(model="glm-5.2")
     mock_proc = make_mock_process_from_fixture("tool_use.jsonl")
 
-    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc):
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc):
         events = []
         async for event in backend.execute(Path("/tmp"), "Read the file"):
             events.append(event)
@@ -153,7 +153,7 @@ async def test_structured_output() -> None:
     mock_proc = make_mock_process_from_fixture("structured_output.jsonl")
     schema = {"type": "object", "properties": {"issues": {"type": "array"}}}
 
-    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
         events = []
         async for event in backend.execute(Path("/tmp"), "Parse", output_schema=schema):
             events.append(event)
@@ -177,7 +177,7 @@ async def test_multi_turn_emits_turn_end_per_turn_and_aggregates_cost() -> None:
     backend = PiBackend(model="glm-5.2")
     mock_proc = make_mock_process_from_fixture("multi_turn.jsonl")
 
-    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc):
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc):
         events = []
         async for event in backend.execute(Path("/tmp"), "Two turns"):
             events.append(event)
@@ -206,7 +206,7 @@ async def test_error_turn_raises_pi_error() -> None:
     backend = PiBackend(model="glm-5.2")
     mock_proc = make_mock_process_from_fixture("error_turn.jsonl")
 
-    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc):
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc):
         with pytest.raises(PiError, match="Model returned an error"):
             async for _ in backend.execute(Path("/tmp"), "Fail"):
                 pass
@@ -258,7 +258,7 @@ async def test_ephemeral_pi_call_uses_no_session() -> None:
 
     mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
     with patch(
-        "daydream.backends.pi.asyncio.create_subprocess_exec",
+        "daydream.backends._transport.asyncio.create_subprocess_exec",
         return_value=mock_proc,
     ):
         result_events = [
@@ -336,7 +336,7 @@ async def test_cwd_passed_to_subprocess() -> None:
     backend = PiBackend(model="glm-5.2")
     mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
 
-    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
         async for _ in backend.execute(Path("/some/repo"), "p"):
             pass
 
@@ -350,7 +350,7 @@ async def test_spawn_uses_start_new_session() -> None:
     backend = PiBackend(model="glm-5.2")
     mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
     with patch(
-        "daydream.backends.pi.asyncio.create_subprocess_exec",
+        "daydream.backends._transport.asyncio.create_subprocess_exec",
         return_value=mock_proc,
     ) as mock_exec:
         events = []
@@ -360,36 +360,37 @@ async def test_spawn_uses_start_new_session() -> None:
 
 
 @pytest.mark.asyncio
-async def test_execute_finally_closes_transport_after_process_exit() -> None:
+async def test_execute_finally_reaps_process_after_exit() -> None:
     """Even when the CLI already exited, the finally reaps the process group.
 
-    The helper runs unconditionally when ``proc`` is not ``None``: its first
-    group signal fires regardless of ``returncode``, so a grandchild that
-    outlived the CLI is still signalled and the pipe fds are still released by
-    the transport close.
+    The transport teardown runs unconditionally: its group signal fires
+    regardless of ``returncode``, so a grandchild that outlived the CLI is
+    still signalled and the pipe fds are still released.
     """
+    from tests.harness.fake_cli_process import FakeCliProcess, FakeCliSpawner
+
     backend = PiBackend(model="glm-5.2")
-    mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
-    mock_proc.returncode = 0  # process already exited
-    mock_proc._transport = MagicMock()
-    terminated: list[asyncio.subprocess.Process] = []
+    captured = FakeCliSpawner()
 
-    from daydream.backends._subprocess import terminate_process as real_terminate
+    async def fake_exec(*args: Any, **kwargs: Any) -> FakeCliProcess:
+        proc = FakeCliProcess(
+            [
+                '{"type":"session","sessionId":"pi_ses_bye"}',
+                '{"type":"agent_start"}',
+                '{"type":"agent_end","messages":[]}',
+            ],
+            exit_code=0,
+        )
+        captured.procs.append(proc)
+        return proc
 
-    async def recording_terminate(proc: asyncio.subprocess.Process, timeout: float | None = None) -> None:
-        terminated.append(proc)
-        await real_terminate(proc, timeout)
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", fake_exec):
+        events = [event async for event in backend.execute(Path("/tmp"), "hello")]
 
-    with (
-        patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc),
-        patch("daydream.backends.pi.terminate_process", side_effect=recording_terminate),
-    ):
-        events = []
-        async for event in backend.execute(Path("/tmp"), "hello"):
-            events.append(event)
-
-    assert terminated == [mock_proc]
-    mock_proc._transport.close.assert_called_once()
+    assert events  # the turn ran to completion
+    proc = captured.procs[0]
+    assert proc.returncode == 0
+    assert proc.reaped, "the finally must reap the child even after clean exit"
 
 
 @pytest.mark.asyncio
@@ -419,7 +420,7 @@ async def test_agent_end_always_finalizes_when_stream_ends_without_it() -> None:
     ]
     mock_proc = make_mock_process(lines)
 
-    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc):
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc):
         events = []
         async for event in backend.execute(Path("/tmp"), "Truncated"):
             events.append(event)
@@ -436,6 +437,8 @@ async def test_agent_end_always_finalizes_when_stream_ends_without_it() -> None:
 @pytest.mark.asyncio
 async def test_cancel_terminates_then_kills() -> None:
     """cancel() sends SIGTERM to all tracked processes, SIGKILL on timeout."""
+    from daydream.backends._transport import CliTransport
+
     backend = PiBackend(model="glm-5.2")
 
     proc = MagicMock()
@@ -443,7 +446,9 @@ async def test_cancel_terminates_then_kills() -> None:
     proc.wait = AsyncMock(side_effect=[asyncio.TimeoutError(), 0])
     proc.terminate = MagicMock()
     proc.kill = MagicMock()
-    backend._processes = [proc]
+    transport = CliTransport("pi", ["pi", "--mode", "json"], limit=1024)
+    transport.processes.append(proc)
+    backend._transports = [transport]
 
     await backend.cancel()
 
@@ -454,7 +459,7 @@ async def test_cancel_terminates_then_kills() -> None:
 @pytest.mark.asyncio
 async def test_cancel_no_op_when_no_processes() -> None:
     backend = PiBackend(model="glm-5.2")
-    backend._processes = []
+    backend._transports = []
     await backend.cancel()  # Must not raise.
 
 
@@ -512,7 +517,7 @@ async def test_stdout_limit_allows_large_jsonl_events() -> None:
         process.kill = MagicMock()
         return process
 
-    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", fake_exec):
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", fake_exec):
         events = [event async for event in backend.execute(Path("/tmp"), "large")]
 
     text_events = [e for e in events if isinstance(e, TextEvent)]
@@ -535,7 +540,7 @@ async def test_missing_usage_skips_metrics_but_keeps_turn_end() -> None:
     ]
     mock_proc = make_mock_process(lines)
 
-    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc):
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc):
         events = []
         async for event in backend.execute(Path("/tmp"), "p"):
             events.append(event)
@@ -561,7 +566,7 @@ async def test_nonzero_exit_raises_with_captured_output() -> None:
     mock_proc = make_mock_process(lines)
     mock_proc.returncode = 1
 
-    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc):
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc):
         with pytest.raises(PiError, match="return code 1") as exc_info:
             async for _ in backend.execute(Path("/tmp"), "p"):
                 pass
@@ -580,7 +585,7 @@ async def test_nonzero_exit_with_no_output_still_informative() -> None:
     mock_proc = make_mock_process([])
     mock_proc.returncode = 1
 
-    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc):
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc):
         with pytest.raises(PiError, match="return code 1") as exc_info:
             async for _ in backend.execute(Path("/tmp"), "p"):
                 pass
@@ -651,7 +656,7 @@ async def test_concurrent_execute_calls_do_not_share_stdout_reader() -> None:
     async def consume_second() -> list[object]:
         return [event async for event in backend.execute(Path("/tmp"), "second")]
 
-    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", fake_exec):
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", fake_exec):
         first_iter = backend.execute(Path("/tmp"), "first")
         first_event = await anext(first_iter)
         assert isinstance(first_event, TextEvent)
@@ -705,7 +710,7 @@ async def test_execute_always_passes_no_skills_never_skill(tmp_path: Path, monke
 
     backend = PiBackend(model="glm-5.2")
     mock_proc = make_mock_process(['{"id": "s1"}'])
-    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
         async for _ in backend.execute(tmp_path, "Review the change."):
             pass
 
@@ -799,7 +804,7 @@ async def test_pi_trajectory_is_valid_atif_v1_7(tmp_path: Path) -> None:
     )
     async with recorder:
         async with recorder.invocation(phase=DaydreamPhase.REVIEW) as inv:
-            with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc):
+            with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc):
                 async for event in backend.execute(tmp_path, "Review"):
                     inv.observe(event)
 
@@ -867,7 +872,7 @@ async def test_default_model_does_not_override_pi_settings(tmp_path: Path, monke
     backend = PiBackend()
     mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
     with patch(
-        "daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc
+        "daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc
     ) as mock_exec:
         async for _ in backend.execute(tmp_path, "Reply"):
             pass
@@ -899,7 +904,7 @@ async def test_explicit_model_overrides_pi_settings(tmp_path: Path, monkeypatch:
     backend = PiBackend(model="custom-model")
     mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
     with patch(
-        "daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc
+        "daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc
     ) as mock_exec:
         async for _ in backend.execute(tmp_path, "Reply"):
             pass
@@ -1034,7 +1039,7 @@ def _capture_pi_subprocess(monkeypatch: pytest.MonkeyPatch, captured: list[list[
         return cast(MagicMock, await real_exec(*args, **kwargs))
 
     monkeypatch.setattr(
-        "daydream.backends.pi.asyncio.create_subprocess_exec", _fake_exec
+        "daydream.backends._transport.asyncio.create_subprocess_exec", _fake_exec
     )
 
 
@@ -1188,7 +1193,7 @@ async def test_stream_eof_without_finish_reason_is_retryable_pi_error() -> None:
             '{"type":"turn_start"}',
         ]
     )
-    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc):
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc):
         with pytest.raises(PiError, match="finish_reason") as raised:
             async for _ in backend.execute(Path("/tmp"), "Truncated"):
                 pass
@@ -1208,7 +1213,7 @@ async def test_stream_eof_after_completed_earlier_turn_is_retryable_pi_error() -
             '{"type":"turn_start"}',
         ]
     )
-    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc):
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc):
         with pytest.raises(PiError, match="finish_reason") as raised:
             async for _ in backend.execute(Path("/tmp"), "Truncated"):
                 pass
@@ -1226,9 +1231,9 @@ async def test_pi_stream_timeout_is_retryable() -> None:
     mock_proc.terminate = MagicMock()
     mock_proc.kill = MagicMock()
     with (
-        patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc),
+        patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc),
         patch(
-            "daydream.backends.pi.readline_with_idle_timeout",
+            "daydream.backends._transport.readline_with_idle_timeout",
             side_effect=StreamStalledError("pi", 1.0),
         ),
     ):
@@ -1344,7 +1349,7 @@ async def test_error_turn_sets_retryable_via_classifier(error_message: Any, expe
     ]
     mock_proc = make_mock_process(lines)
 
-    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc):
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc):
         with pytest.raises(PiError) as exc_info:
             async for _ in backend.execute(Path("/tmp"), "p"):
                 pass
@@ -1371,7 +1376,7 @@ async def test_nonzero_exit_sets_retryable_via_exit_code(
     mock_proc = make_mock_process(output_lines)
     mock_proc.returncode = returncode
 
-    with patch("daydream.backends.pi.asyncio.create_subprocess_exec", return_value=mock_proc):
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc):
         with pytest.raises(PiError) as exc_info:
             async for _ in backend.execute(Path("/tmp"), "p"):
                 pass

--- a/tests/test_backend_pi.py
+++ b/tests/test_backend_pi.py
@@ -391,6 +391,8 @@ async def test_execute_finally_reaps_process_after_exit() -> None:
     proc = captured.procs[0]
     assert proc.returncode == 0
     assert proc.reaped, "the finally must reap the child even after clean exit"
+    assert proc._transport.closed, "the finally must release the pipe fds even after clean exit"
+    assert backend._transports == [], "the finally must drop the transport from the backend list"
 
 
 @pytest.mark.asyncio

--- a/tests/test_codex_real_cli_contract.py
+++ b/tests/test_codex_real_cli_contract.py
@@ -78,7 +78,7 @@ async def test_real_golden_parses_to_expected_events() -> None:
     backend = CodexBackend(model="gpt-5.5")
     mock_proc = make_mock_process_from_fixture(REAL_GOLDEN)
 
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=mock_proc):
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc):
         events: list[Any] = []
         async for event in backend.execute(Path("/tmp"), "Read README.md then hello.py"):
             events.append(event)
@@ -234,7 +234,7 @@ async def test_codex_live_smoke() -> None:
     backend = CodexBackend(model="live-smoke-model")
     from tests.harness.codex_replay import make_mock_process
 
-    with patch("daydream.backends.codex.asyncio.create_subprocess_exec", return_value=make_mock_process(lines)):
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=make_mock_process(lines)):
         events: list[Any] = []
         async for event in backend.execute(sample_repo, prompt):
             events.append(event)

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -7,6 +7,10 @@ import sys
 
 import pytest
 
+from daydream.backends._subprocess import (
+    StreamStalledError,
+    stream_idle_timeout_s,
+)
 from daydream.backends._transport import (
     CliTransport,
     StderrPolicy,
@@ -92,3 +96,104 @@ async def test_transport_stderr_drain_task_feeds_sink() -> None:
     assert await t.wait() == 0
     await t.drain_finished()
     assert diagnostics == ["boom"]
+
+
+_HANGING_CLI = "import time\ntime.sleep(60)\n"
+
+# Mirrors _HOLDER_SCRIPT in tests/test_subprocess_lifecycle.py: the CLI forks a
+# `sleep` grandchild (which inherits the stdout pipe), reports readiness by
+# printing "UP", then hangs. A python CLI is used because bash defers SIGTERM
+# while a child runs, which would stall every test on TERMINATE_GRACE_S.
+_GROUP_HOLDER_CLI = (
+    "import subprocess, sys, time; "
+    "subprocess.Popen(['sleep', '60']); "
+    "print('UP', flush=True); "
+    "time.sleep(1000)"
+)
+
+
+async def _wait_for_group_gone(pgid: int, *, timeout_s: float = 30.0) -> None:
+    """Await *pgid*'s disappearance (mirrors tests/test_subprocess_lifecycle.py).
+
+    A group-signal kill reaps the direct child synchronously, but a grandchild
+    reparented to PID 1 lingers as a zombie until init reaps it — and a zombie
+    still answers ``killpg(pgid, 0)``. Polling until the group is gone makes
+    the assertion deterministic: the observable outcome is "no process remains
+    in the group", not "the group vanished by the next instruction".
+    """
+    import asyncio as _asyncio
+    import os as _os
+
+    loop = _asyncio.get_running_loop()
+    deadline = loop.time() + timeout_s
+    while True:
+        try:
+            _os.killpg(pgid, 0)
+        except ProcessLookupError:
+            return
+        if loop.time() > deadline:
+            raise TimeoutError(f"process group {pgid} still alive after {timeout_s}s")
+        await _asyncio.sleep(0.01)
+
+
+async def test_transport_idle_timeout_fires_on_silent_stream(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A stream that goes silent for the window raises StreamStalledError.
+
+    Feed the transport a real hanging child (never writes), with the env
+    override shrinking the window — the same env contract as production.
+    """
+    monkeypatch.setenv("DAYDREAM_STREAM_IDLE_TIMEOUT_S", "0.2")
+    t = CliTransport(cli="fake", limit=LIMIT, argv=[sys.executable, "-c", _HANGING_CLI])
+    await t.start()
+    with pytest.raises(StreamStalledError) as exc:
+        [line async for line in t.lines(timeout_for_line=lambda: stream_idle_timeout_s())]
+    assert "fake CLI produced no output for 0.2s" in str(exc.value)
+    await t.terminate()  # teardown reaps the hung child
+    assert t.returncode is not None
+
+
+async def test_transport_teardown_is_idempotent_and_group_signalling() -> None:
+    """Double terminate() must not raise, and the grandchild dies with the group."""
+    import os
+
+    t = CliTransport(cli="fake", limit=LIMIT, argv=[sys.executable, "-c", _GROUP_HOLDER_CLI])
+    await t.start()
+    proc = t.processes[0]
+    pgid = os.getpgid(proc.pid)
+    assert pgid == proc.pid  # start_new_session => session leader => pid is the pgid
+    it = t.lines(timeout_for_line=lambda: 5.0).__aiter__()
+    assert await it.__anext__() == "UP"
+    await t.terminate()
+    await t.terminate()  # double-call must not raise
+    assert t.returncode is not None
+    await _wait_for_group_gone(pgid)  # grandchild must be gone too
+
+
+async def test_transport_cancel_all_is_shielded() -> None:
+    """Cancelling the surrounding scope while lines() pends still reaps the group.
+
+    Mirrors the shielded-teardown shape in tests/test_subprocess_lifecycle.py:
+    the cancel fires mid-read, unwinds into the generator's caller, and the
+    ``finally`` teardown (cancel_all) must run to completion despite the still-
+    cancelled scope.
+    """
+    import os
+
+    import anyio
+
+    t = CliTransport(cli="fake", limit=LIMIT, argv=[sys.executable, "-c", _GROUP_HOLDER_CLI])
+    await t.start()
+    pgid = os.getpgid(t.processes[0].pid)
+
+    async def consume() -> None:
+        try:
+            async for _ in t.lines(timeout_for_line=lambda: 5.0):
+                pass
+        finally:
+            await CliTransport.cancel_all([t])
+
+    with anyio.move_on_after(0.2) as scope:
+        await consume()
+    assert scope.cancelled_caught  # cancel fired while lines() was pending
+    assert t.returncode is not None
+    await _wait_for_group_gone(pgid)

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,0 +1,94 @@
+"""Transport contract tests: real subprocess, no mocks on the happy path."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import pytest
+
+from daydream.backends._transport import (
+    CliTransport,
+    StderrPolicy,
+    StdinMode,
+    TransportExitError,
+)
+
+LIMIT = 2**16
+
+
+def emit_lines(*lines: str, exit_code: int = 0, to_stderr: str = "") -> str:
+    body = "".join(f"print({line!r})\n" for line in lines)
+    stderr_part = f"print({to_stderr!r}, file=sys.stderr)" if to_stderr else ""
+    return "import sys\n" + body + stderr_part + f"\nraise SystemExit({exit_code})\n"
+
+
+async def test_transport_streams_jsonl_lines_with_exit_code() -> None:
+    t = CliTransport(cli="fake", limit=LIMIT, argv=[sys.executable, "-c", emit_lines('{"a":1}', '{"b":2}')])
+    await t.start()
+    events = [json.loads(line) async for line in t.lines(timeout_for_line=lambda: 5.0)]
+    assert events == [{"a": 1}, {"b": 2}]
+    assert await t.wait() == 0  # exit code surfaced, transport reaped
+    assert t.returncode == 0
+
+
+async def test_transport_writes_stdin_then_closes() -> None:
+    child = (
+        "import sys\n"
+        'data = sys.stdin.read()\n'
+        'print(json.dumps({"echo": data}))\n'
+        "raise SystemExit(0)\n"
+    ).replace("import sys\n", "import json, sys\n", 1)
+    t = CliTransport(
+        limit=LIMIT,
+        cli="fake",
+        argv=[sys.executable, "-c", child],
+        stdin_mode=StdinMode.PIPE,
+        stdin_data=b"prompt\n",
+    )
+    await t.start()
+    events = [json.loads(line) async for line in t.lines(timeout_for_line=lambda: 5.0)]
+    assert events == [{"echo": "prompt\n"}]
+    assert await t.wait() == 0
+    assert t.stdin_closed is True
+
+
+async def test_transport_nonzero_exit_raises_exit_error_with_diagnostics() -> None:
+    diagnostics: list[str] = []
+    t = CliTransport(
+        limit=LIMIT,
+        cli="fake",
+        argv=[sys.executable, "-c", emit_lines("not json", exit_code=3)],
+        diagnostics_sink=diagnostics.append,
+    )
+    await t.start()
+    seen: list[str] = []
+    async for line in t.lines(timeout_for_line=lambda: 5.0):
+        seen.append(line)
+        if not line.startswith("{"):
+            # Backend-side protocol mapping: non-JSON stdout goes to the sink.
+            t.note_diagnostic(line)
+    assert seen == ["not json"]
+    with pytest.raises(TransportExitError) as excinfo:
+        await t.wait()
+    assert excinfo.value.returncode == 3
+    assert diagnostics == ["not json"]
+    assert excinfo.value.diagnostics == ["not json"]
+    assert t.returncode == 3
+
+
+async def test_transport_stderr_drain_task_feeds_sink() -> None:
+    diagnostics: list[str] = []
+    t = CliTransport(
+        limit=LIMIT,
+        cli="fake",
+        argv=[sys.executable, "-c", emit_lines('{"a":1}', to_stderr="boom")],
+        stderr_policy=StderrPolicy.DRAIN_TASK,
+        stderr_sink=diagnostics.append,
+    )
+    await t.start()
+    events = [json.loads(line) async for line in t.lines(timeout_for_line=lambda: 5.0)]
+    assert events == [{"a": 1}]
+    assert await t.wait() == 0
+    await t.drain_finished()
+    assert diagnostics == ["boom"]


### PR DESCRIPTION
## Summary
- Unifies the CLI backends behind an injectable subprocess runner and a shared JSONL transport layer (daydream/backends/_transport.py)
- Preserves each backend's decode contract (codex, osprey) on top of the common transport
- Regression tests added for the osprey backend path

## Test Plan
- [x] Full suite green on round-2 review VM: 4929 passed, 21 skipped, 0 failed
- [x] Two sequential daydream deep-precision review rounds (8/8 findings fixed, tip b5fa41c)
- [x] Authorship gate AUTHORS_OK

Closes #1017