### PR TITLE
[bug] Make out-of-scope issue filing opt-in and prevent stale reverted-edit issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ The dotfile uses bare top-level keys. It wins on scalar conflicts.
 [tool.daydream]
 model = "claude-opus-5"     # global default across phases
 backend = "claude"          # global default backend
-scope_issue_filing = false  # opt in to filing out-of-scope work as GitHub issues
+scope_issue_filing = false  # default; set true to file out-of-scope work as GitHub issues
 
 [tool.daydream.phases.fix]  # per-phase override
 backend = "codex"

--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ The dotfile uses bare top-level keys. It wins on scalar conflicts.
 [tool.daydream]
 model = "claude-opus-5"     # global default across phases
 backend = "claude"          # global default backend
+scope_issue_filing = false  # opt in to filing out-of-scope work as GitHub issues
 
 [tool.daydream.phases.fix]  # per-phase override
 backend = "codex"
@@ -302,6 +303,10 @@ backend = "codex"
 The resolution order, highest first, is:
 
 **CLI > config file (phase, then global) > built-in per-backend default.**
+
+### Out-of-scope issue filing
+
+`scope_issue_filing` (default `false`) opts a repository into filing out-of-scope findings and reverted out-of-scope edits as GitHub issues. By default daydream makes no GitHub writes for out-of-scope work — findings are excluded from the fix pass and out-of-scope edits are reverted regardless; only the issue filing is gated. Enable it in the target repo's config: `[tool.daydream] scope_issue_filing = true`, or per-run with `daydream --file-scope-issues /path/to/project`.
 
 ### Per-phase settings
 

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -932,6 +932,16 @@ def _build_main_parser(*, full_help: bool = False) -> argparse.ArgumentParser:
         if full_help else argparse.SUPPRESS,
     )
     parser.add_argument(
+        "--file-scope-issues",
+        action="store_true",
+        default=False,
+        dest="file_scope_issues",
+        help="Opt in to filing out-of-scope findings and reverted edits as GitHub "
+             "issues (issue #1056; default off). Also settable via [tool.daydream] "
+             "scope_issue_filing in a config file."
+        if full_help else argparse.SUPPRESS,
+    )
+    parser.add_argument(
         "--copy",
         action="append",
         default=[],
@@ -1163,6 +1173,7 @@ def _parse_args(argv: list[str] | None = None) -> RunConfig:
         flow_name=args.flow_name,
         precision_mode=args.precision,
         approve_on_clean=args.approve_on_clean,
+        scope_issue_filing=args.file_scope_issues,
         extra_copy=list(args.extra_copy),
         non_interactive=args.non_interactive,
         assume=args.assume,

--- a/daydream/config_file.py
+++ b/daydream/config_file.py
@@ -48,6 +48,10 @@ class DaydreamFileConfig:
             ``None`` falls through to the RunConfig field / orchestrator default;
             ``True`` posts ``event: "APPROVE"`` when a deep review has zero
             high/medium findings. Explicit opt-in: never coerced from a non-bool.
+        scope_issue_filing: Opt-in for out-of-scope issue filing (issue #1056).
+            ``None`` falls through to the RunConfig field / orchestrator default;
+            ``True`` re-enables filing GitHub issues for findings and edits
+            outside the reviewed diff. Never coerced from a non-bool.
         review_profile: Repo-committed review-profile path (R9). A lenient path
             read only — the strict profile parse + validation stays in
             ``review_profile.py``. ``None`` (absent or non-str) means the key is
@@ -130,6 +134,7 @@ class DaydreamFileConfig:
     shallow_fanout_threshold: int | None = None
     precision_mode: bool | None = None
     approve_on_clean: bool | None = None
+    scope_issue_filing: bool | None = None
     group_max_wall_s: float | None = None
     group_max_serial_items: int | None = None
     uncovered_sweep: bool | None = None
@@ -378,6 +383,10 @@ def load_file_config(root: Path) -> DaydreamFileConfig:
     # an accidental ``approve_on_clean = 1`` is treated as unset, not enabled.
     raw_approve = merged.get("approve_on_clean")
     approve_on_clean: bool | None = raw_approve if isinstance(raw_approve, bool) else None
+    # scope_issue_filing: bool only, same degrade-to-None rule so an accidental
+    # ``scope_issue_filing = 1`` is treated as unset, not enabled.
+    raw_scope = merged.get("scope_issue_filing")
+    scope_issue_filing: bool | None = raw_scope if isinstance(raw_scope, bool) else None
     # uncovered_sweep: bool only, same degrade-to-None rule as precision_mode so
     # an accidental ``uncovered_sweep = 1`` is treated as unset, not enabled.
     raw_uncovered_sweep = merged.get("uncovered_sweep")
@@ -422,6 +431,7 @@ def load_file_config(root: Path) -> DaydreamFileConfig:
         shallow_fanout_threshold=threshold,
         precision_mode=precision,
         approve_on_clean=approve_on_clean,
+        scope_issue_filing=scope_issue_filing,
         group_max_wall_s=_coerce_float(merged.get("group_max_wall_s")),
         group_max_serial_items=_coerce_int(merged.get("group_max_serial_items")),
         review_profile=_coerce_review_profile_path(merged.get("review_profile")),

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -317,6 +317,22 @@ def _approve_on_clean(config: RunConfig) -> bool:
     return False
 
 
+def _scope_issue_filing(config: RunConfig) -> bool:
+    """Resolve the out-of-scope issue-filing opt-in (issue #1056).
+
+    Precedence mirrors ``_approve_on_clean``: 1) ``RunConfig.scope_issue_filing``
+    (CLI tier), 2) ``DaydreamFileConfig.scope_issue_filing`` (file-config
+    scalar), 3) built-in default ``False`` (no out-of-scope GitHub issues are
+    filed unless a repo explicitly opts in).
+    """
+    if config.scope_issue_filing:
+        return True
+    file_config = config.file_config
+    if file_config is not None and file_config.scope_issue_filing:
+        return True
+    return False
+
+
 def _supervisor_mode(config: RunConfig) -> str:
     """Resolve the file-config-only findings supervisor mode."""
     file_config = config.file_config

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -3430,6 +3430,8 @@ async def _step_fix(ctx: FlowContext) -> Stop | None:
         pre_fix_untracked=pre_fix_untracked,
         changed_files=changed_files,
         finding_files={item["file"] for item in ctx.data["items"] if item.get("file")},
+        # Issue #1056 — reverted-edit filing is opt-in; the revert itself is not.
+        file_scope_issues=_scope_issue_filing(ctx.config),
     )
     if residual_guard_result is None:
         # Fail-close to match the generated-file guard: an unreverted

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -2354,8 +2354,8 @@ async def _step_fix_gate(ctx: FlowContext) -> Stop | None:
         return Stop(0)
 
     # Issue #336 — pre-fix scope partition. Findings on files OUTSIDE the
-    # reviewed diff are filed as GitHub issues (best-effort) and excluded from
-    # auto-fix: the loop must not expand the PR's scope. The reviewed-diff file
+    # reviewed diff are excluded from auto-fix; issue filing is gated by
+    # ``scope_issue_filing`` (#1056). The loop must not expand the PR's scope. The reviewed-diff file
     # set is resolved via _resolve_changed_files (shared with _step_fix) so the
     # gate and the post-fix residual net agree on the allowed set (a divergence
     # left the residual net strictly weaker than the gate on the resume path).
@@ -2365,27 +2365,42 @@ async def _step_fix_gate(ctx: FlowContext) -> Stop | None:
         out_of_scope: list[dict[str, Any]] = []
         for item in items:
             (in_scope if (item.get("file") or "") in changed_files else out_of_scope).append(item)
+        file_scope_issues = _scope_issue_filing(ctx.config)
         for item in out_of_scope:
-            _file_out_of_scope_issue(ctx, item)
+            if file_scope_issues:
+                _file_out_of_scope_issue(ctx, item)
         if out_of_scope:
-            print_warning(
-                console,
-                f"{len(out_of_scope)} finding(s) outside the reviewed diff filed as "
-                "issue(s), not fixed.",
-            )
+            if file_scope_issues:
+                print_warning(
+                    console,
+                    f"{len(out_of_scope)} finding(s) outside the reviewed diff filed as "
+                    "issue(s), not fixed.",
+                )
+            else:
+                print_warning(
+                    console,
+                    f"{len(out_of_scope)} finding(s) outside the reviewed diff excluded "
+                    "from fix (issue filing disabled).",
+                )
         items = in_scope
-        # Issue #336 — every finding routed to issues leaves nothing to
-        # auto-fix, so short-circuit before a no-op fix pass, a full target
+        # Issue #336 — every finding routed out of the fix list leaves nothing
+        # to auto-fix, so short-circuit before a no-op fix pass, a full target
         # test-suite run, and a commit-agent turn. Matches the pre-partition
         # "no actionable items" Stop(0) above. Keying on identity (``is not
         # None``) distinguishes an empty reviewed diff — every file is out of
         # scope, so all findings are filed and the run ends — from ``None``,
         # which skips the partition entirely because scope cannot be judged.
         if not items:
-            print_success(
-                console,
-                "All findings outside the reviewed diff -- filed as issues, nothing to fix.",
-            )
+            if file_scope_issues:
+                print_success(
+                    console,
+                    "All findings outside the reviewed diff -- filed as issues, nothing to fix.",
+                )
+            else:
+                print_success(
+                    console,
+                    "All findings outside the reviewed diff -- nothing to fix (issue filing disabled).",
+                )
             return Stop(0)
 
     # Severity-ordered (high before medium before low), stable within a

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -95,6 +95,7 @@ from daydream.deep.scope_issues import (
     _file_out_of_scope_issue,
     _resolve_changed_files,
     _revert_out_of_scope_edits,
+    _scope_filing_note,
 )
 from daydream.deep.sharding import shard_stacks
 from daydream.eval.analyzer import _agent_label, _records_issues_or_empty, load_trajectories
@@ -2370,37 +2371,27 @@ async def _step_fix_gate(ctx: FlowContext) -> Stop | None:
             if file_scope_issues:
                 _file_out_of_scope_issue(ctx, item)
         if out_of_scope:
-            if file_scope_issues:
-                print_warning(
-                    console,
-                    f"{len(out_of_scope)} finding(s) outside the reviewed diff filed as "
-                    "issue(s), not fixed.",
-                )
-            else:
-                print_warning(
-                    console,
-                    f"{len(out_of_scope)} finding(s) outside the reviewed diff excluded "
-                    "from fix (issue filing disabled).",
-                )
+            print_warning(
+                console,
+                f"{len(out_of_scope)} finding(s) outside the reviewed diff "
+                f"{_scope_filing_note(file_scope_issues)}, not fixed.",
+            )
         items = in_scope
         # Issue #336 — every finding routed out of the fix list leaves nothing
         # to auto-fix, so short-circuit before a no-op fix pass, a full target
         # test-suite run, and a commit-agent turn. Matches the pre-partition
         # "no actionable items" Stop(0) above. Keying on identity (``is not
         # None``) distinguishes an empty reviewed diff — every file is out of
-        # scope, so all findings are filed and the run ends — from ``None``,
-        # which skips the partition entirely because scope cannot be judged.
+        # scope, so every finding is excluded from auto-fix (filed as an issue
+        # only under the ``scope_issue_filing`` opt-in, issue #1056) and the
+        # run ends — from ``None``, which skips the partition entirely because
+        # scope cannot be judged.
         if not items:
-            if file_scope_issues:
-                print_success(
-                    console,
-                    "All findings outside the reviewed diff -- filed as issues, nothing to fix.",
-                )
-            else:
-                print_success(
-                    console,
-                    "All findings outside the reviewed diff -- nothing to fix (issue filing disabled).",
-                )
+            print_success(
+                console,
+                f"All findings outside the reviewed diff -- {_scope_filing_note(file_scope_issues)}, "
+                "nothing to fix.",
+            )
             return Stop(0)
 
     # Severity-ordered (high before medium before low), stable within a

--- a/daydream/deep/scope_issues.py
+++ b/daydream/deep/scope_issues.py
@@ -126,15 +126,26 @@ def _file_out_of_scope_issue(ctx: FlowContext, item: dict[str, Any]) -> None:
 def _scope_edit_fingerprint(path: str, patch: str) -> str:
     """Stable cross-run identity for a reverted out-of-scope edit (issue #1051).
 
-    Keyed on the file path plus the edit's full diff content (the spec's
+    Keyed on the file path plus the edit's changed content lines (the spec's
     "file path plus diff content" option): a re-run that reproduces the same
     residual edit on the same file maps to the same fingerprint and is
-    recognized as already-filed. Distinct from the finding-path fingerprint so
-    the two stores never collide.
+    recognized as already-filed. The raw ``git diff`` evidence embeds volatile
+    hunk offsets (``@@ -x,y +z,w @@``) and context lines, so fingerprinting the
+    raw patch would re-file a duplicate whenever a re-run reproduces the edit
+    at shifted offsets — the duplicate-issue regression #1051 set out to close.
+    Stripping the hunk headers and context lines (keeping only the ``+``/``-``
+    content lines) mirrors how :func:`daydream.pr_review.compute_fingerprint`
+    excludes line numbers so code shifts do not change a finding's identity.
+    Distinct from the finding-path fingerprint so the two stores never collide.
     """
     from daydream.pr_review import compute_fingerprint
 
-    return compute_fingerprint(path, patch, "")
+    changed_lines = [
+        line
+        for line in patch.splitlines()
+        if (line.startswith("+") or line.startswith("-")) and not line.startswith(("+++", "---"))
+    ]
+    return compute_fingerprint(path, "\n".join(changed_lines), "")
 
 
 def _scope_edit_marker(fingerprint: str) -> str:
@@ -172,6 +183,20 @@ def _file_reverted_edit_issue(repo: Path, path: str, patch: str) -> None:
         f"{marker}"
     )
     _file_scope_issue(repo, title=title, body=body, noun="edit", ident=path)
+
+
+def _scope_filing_note(file_scope_issues: bool) -> str:
+    """Filing-status note shared by the gate and residual-net messages.
+
+    Issue #1056 — the pre-fix gate (``_step_fix_gate``) and the post-fix
+    residual net (``_revert_out_of_scope_edits``) both branch on the same
+    ``scope_issue_filing`` opt-in to report whether out-of-scope items were
+    filed as GitHub issues or just excluded/reverted. Only the trailing note
+    differs between the two branches at every message site, so the pair is
+    rendered through this single helper instead of per-module if/else ladders
+    that could drift on future edits.
+    """
+    return "filed as issue(s)" if file_scope_issues else "(issue filing disabled)"
 
 
 def _revert_out_of_scope_edits(
@@ -269,12 +294,17 @@ def _revert_out_of_scope_edits(
 
     restoration_failed = False
     for path in residual:
-        # Capture the diff as evidence BEFORE reverting (the revert destroys it).
-        try:
-            patch = git_ops.diff_worktree_against(repo, pre_fix_ref, [path])
-        except GitError as exc:
-            patch = ""
-            print_warning(console, f"Could not diff out-of-scope edit '{path}': {exc}")
+        patch = ""
+        # Capture the diff as evidence BEFORE reverting (the revert destroys
+        # it) — but only when filing is opted in: with filing disabled the
+        # patch has no consumer, so skip the per-residual ``git diff``
+        # subprocess entirely (issue #1056). The revert and fail-close below
+        # never depend on the capture.
+        if file_scope_issues:
+            try:
+                patch = git_ops.diff_worktree_against(repo, pre_fix_ref, [path])
+            except GitError as exc:
+                print_warning(console, f"Could not diff out-of-scope edit '{path}': {exc}")
         # Revert unconditionally — same mechanism as the generated-file guard.
         try:
             git_ops.restore_paths_from_ref(repo, pre_fix_ref, [path])
@@ -290,18 +320,11 @@ def _revert_out_of_scope_edits(
         if file_scope_issues:
             _file_reverted_edit_issue(repo, path, patch)
     if residual:
-        if file_scope_issues:
-            print_warning(
-                console,
-                f"Reverted {len(residual)} post-fix edit(s) outside the reviewed diff and "
-                f"filed issue(s): {residual}.",
-            )
-        else:
-            print_warning(
-                console,
-                f"Reverted {len(residual)} post-fix edit(s) outside the reviewed diff "
-                f"(issue filing disabled): {residual}.",
-            )
+        print_warning(
+            console,
+            f"Reverted {len(residual)} post-fix edit(s) outside the reviewed diff "
+            f"{_scope_filing_note(file_scope_issues)}: {residual}.",
+        )
     return None if restoration_failed else residual
 
 

--- a/daydream/deep/scope_issues.py
+++ b/daydream/deep/scope_issues.py
@@ -2,9 +2,12 @@
 
 The fix loop auto-fixes only findings inside the reviewed diff. Findings on files
 outside the diff, and post-fix edits outside the diff, are routed to tracked
-GitHub issues (best-effort) and excluded from auto-fix. This module owns that
+GitHub issues (best-effort, gated by the ``scope_issue_filing`` opt-in, default
+off — issue #1056) and excluded from auto-fix. This module owns that
 machinery: scope-finding fingerprint -> marker -> cross-run dedup -> filing, plus
-the post-fix residual revert net. Extracted from ``deep/orchestrator.py``.
+the post-fix residual revert net (whose filing path carries the same
+fingerprint -> marker -> dedup -> file chain, issue #1051). Extracted from
+``deep/orchestrator.py``.
 """
 
 from __future__ import annotations
@@ -122,21 +125,71 @@ def _file_out_of_scope_issue(ctx: FlowContext, item: dict[str, Any]) -> None:
     _file_scope_issue(ctx.work.repo, title=title, body=body, noun="finding", ident=file)
 
 
+def _scope_edit_fingerprint(path: str, patch: str) -> str:
+    """Stable cross-run identity for a reverted out-of-scope edit (issue #1051).
+
+    Keyed on the file path plus the edit's diff head (the spec's "file path
+    plus diff content" option): a re-run that reproduces the same residual
+    edit on the same file maps to the same fingerprint and is recognized as
+    already-filed. Distinct from the finding-path fingerprint so the two
+    stores never collide.
+    """
+    from daydream.pr_review import compute_fingerprint
+
+    return compute_fingerprint(path, patch[:2000], "")
+
+
+def _scope_edit_marker(fingerprint: str) -> str:
+    """Hidden HTML comment embedding an edit fingerprint in an issue body.
+
+    Distinct prefix from ``_scope_finding_marker`` so the finding store and
+    the edit store never collide, mirroring the split between
+    ``_scope_finding_marker`` and ``pr_review.finding_marker``.
+    """
+    return f"<!-- daydream-scope-edit: {fingerprint} -->"
+
+
+def _scope_edit_already_filed(repo: Path, marker: str) -> bool:
+    """Best-effort: has an open issue already filed this reverted edit?
+
+    Issue #1051 — the residual net re-derives the same reverted edit on every
+    re-run/resume and would re-file a duplicate issue each time. GitHub is the
+    store: scan open issues for the edit's fingerprint marker and skip filing
+    when present. Best-effort — a failed ``gh issue list`` returns ``False``
+    so the call degrades to filing (never to suppression).
+    """
+    from daydream import git_ops
+
+    try:
+        issues = git_ops.gh_issue_list(repo, search="out-of-scope")
+    except Exception:  # noqa: BLE001 -- best-effort dedup lookup
+        return False
+    return any(marker in (issue.get("body") or "") for issue in issues)
+
+
 def _file_reverted_edit_issue(repo: Path, path: str, patch: str) -> None:
     """Best-effort: file one reverted out-of-scope edit as a tracked GitHub issue.
 
     Issue #336 — the post-fix residual check reverts edits the fix pass made
     outside the reviewed diff. The reverted edit is still *valid* work, so it
     is filed as an issue (with the diff as evidence) instead of being lost.
-    Filing is best-effort: a failed ``gh issue create`` logs a warning and the
-    revert stands regardless.
+    Cross-run dedup (issue #1051): the edit's fingerprint is embedded as a
+    hidden marker in the body, and a re-run/resume skips filing when an open
+    issue already carries it. Filing is best-effort: a failed ``gh issue
+    create`` logs a warning and the revert stands regardless.
     """
+    # Compute the fingerprint marker once and thread it into both the dedup
+    # lookup and the issue body, rather than recomputing it for each.
+    marker = _scope_edit_marker(_scope_edit_fingerprint(path, patch))
+    if _scope_edit_already_filed(repo, marker):
+        return
     title = f"[daydream] out-of-scope edit reverted: {path}"
     body = (
         f"The fix pass edited `{path}`, which is outside the reviewed diff. "
         f"The edit was reverted and is filed here for review.\n\n"
         f"```diff\n{patch}\n```\n\n"
-        "Filed by daydream fix loop: out of scope for PR."
+        "Filed by daydream fix loop: out of scope for PR.\n"
+        f"{marker}"
     )
     _file_scope_issue(repo, title=title, body=body, noun="edit", ident=path)
 
@@ -149,17 +202,24 @@ def _revert_out_of_scope_edits(
     pre_fix_untracked: set[str],
     changed_files: set[str] | None,
     finding_files: set[str],
+    file_scope_issues: bool = False,
 ) -> list[str] | None:
-    """Revert post-fix edits outside the reviewed diff; file an issue per residual.
+    """Revert post-fix edits outside the reviewed diff; conditionally file issues.
 
     Issue #336 (Task 4): after ``phase_fix_parallel`` returns, enumerate the
     files the fix pass actually edited (vs the pre-fix snapshot) and subtract
     the allowed set — the finding files, the reviewed-diff file set, and
     newly-created generated files. Every residual is reverted unconditionally to
     its pre-fix content (``git checkout <ref> -- <file>``, the same mechanism
-    the generated-file guard uses) and filed as a best-effort GitHub issue
-    carrying the edit's diff as evidence, so the commit step can never land an
+    the generated-file guard uses) so the commit step can never land an
     edit outside the reviewed diff.
+
+    Filing is OPT-IN (issue #1056): when *file_scope_issues* is true each
+    reverted residual is additionally filed as a best-effort GitHub issue
+    carrying the edit's diff as evidence (with cross-run dedup, issue #1051);
+    when false (the default) the revert alone happens and a warning notes that
+    issue filing is disabled. The revert and the fail-close never depend on
+    filing.
 
     Only TRACKED edits are considered: a path present at *pre_fix_ref*. Newly
     created untracked files (e.g. the test harness's ``.fixed-*`` sentinels)
@@ -247,13 +307,21 @@ def _revert_out_of_scope_edits(
             # still best-effort reverted before the abort is signalled.
             restoration_failed = True
             continue
-        _file_reverted_edit_issue(repo, path, patch)
+        if file_scope_issues:
+            _file_reverted_edit_issue(repo, path, patch)
     if residual:
-        print_warning(
-            console,
-            f"Reverted {len(residual)} post-fix edit(s) outside the reviewed diff and "
-            f"filed issue(s): {residual}.",
-        )
+        if file_scope_issues:
+            print_warning(
+                console,
+                f"Reverted {len(residual)} post-fix edit(s) outside the reviewed diff and "
+                f"filed issue(s): {residual}.",
+            )
+        else:
+            print_warning(
+                console,
+                f"Reverted {len(residual)} post-fix edit(s) outside the reviewed diff "
+                f"(issue filing disabled): {residual}.",
+            )
     return None if restoration_failed else residual
 
 

--- a/daydream/deep/scope_issues.py
+++ b/daydream/deep/scope_issues.py
@@ -69,26 +69,24 @@ def _scope_finding_marker(fingerprint: str) -> str:
     return f"<!-- daydream-scope-finding: {fingerprint} -->"
 
 
-def _scope_finding_already_filed(repo: Path, marker: str) -> bool:
-    """Best-effort: has an open issue already filed this out-of-scope finding?
+def _scope_already_filed(repo: Path, marker: str) -> bool:
+    """Best-effort: has an open issue already filed this scope marker?
 
-    Issue #336 — out-of-scope findings are never fixed, so a re-run/resume
-    re-derives them and would re-file a duplicate issue every time. GitHub is
-    the store: scan open issues for the finding's fingerprint marker and skip
-    filing when present. Best-effort — a failed ``gh issue list`` returns
-    ``False`` so the call degrades to filing (the prior behavior) rather than
-    silently dropping the finding.
+    Shared by the out-of-scope *finding* router (pre-fix gate, issue #336) and
+    the reverted *edit* filer (post-fix residual net, issue #1051). GitHub is
+    the store: scan open issues for the item's fingerprint marker and skip
+    filing when present, so a re-run/resume re-deriving the same item does not
+    re-file a duplicate issue. Best-effort by construction: ``gh_issue_list``
+    itself returns an empty list on any failure (no auth, offline, cross-org),
+    so a failed lookup degrades to filing (the prior behavior), never to
+    silently dropping the item.
 
-    The marker is computed once by the caller (``_file_out_of_scope_issue``)
-    and threaded in, so the finding's fingerprint is not recomputed for both
-    the dedup lookup and the issue body.
+    The marker is computed once by the caller and threaded in, so the item's
+    fingerprint is not recomputed for both the dedup lookup and the issue body.
     """
     from daydream import git_ops
 
-    try:
-        issues = git_ops.gh_issue_list(repo, search="out-of-scope")
-    except Exception:  # noqa: BLE001 -- best-effort dedup lookup
-        return False
+    issues = git_ops.gh_issue_list(repo, search="out-of-scope")
     return any(marker in (issue.get("body") or "") for issue in issues)
 
 
@@ -111,7 +109,7 @@ def _file_out_of_scope_issue(ctx: FlowContext, item: dict[str, Any]) -> None:
     # Compute the fingerprint marker once and thread it into both the dedup
     # lookup and the issue body, rather than recomputing it for each.
     marker = _scope_finding_marker(_scope_finding_fingerprint(item))
-    if _scope_finding_already_filed(ctx.work.repo, marker):
+    if _scope_already_filed(ctx.work.repo, marker):
         return
     title = f"[daydream] out-of-scope finding: {file}"
     body = (
@@ -128,15 +126,15 @@ def _file_out_of_scope_issue(ctx: FlowContext, item: dict[str, Any]) -> None:
 def _scope_edit_fingerprint(path: str, patch: str) -> str:
     """Stable cross-run identity for a reverted out-of-scope edit (issue #1051).
 
-    Keyed on the file path plus the edit's diff head (the spec's "file path
-    plus diff content" option): a re-run that reproduces the same residual
-    edit on the same file maps to the same fingerprint and is recognized as
-    already-filed. Distinct from the finding-path fingerprint so the two
-    stores never collide.
+    Keyed on the file path plus the edit's full diff content (the spec's
+    "file path plus diff content" option): a re-run that reproduces the same
+    residual edit on the same file maps to the same fingerprint and is
+    recognized as already-filed. Distinct from the finding-path fingerprint so
+    the two stores never collide.
     """
     from daydream.pr_review import compute_fingerprint
 
-    return compute_fingerprint(path, patch[:2000], "")
+    return compute_fingerprint(path, patch, "")
 
 
 def _scope_edit_marker(fingerprint: str) -> str:
@@ -147,24 +145,6 @@ def _scope_edit_marker(fingerprint: str) -> str:
     ``_scope_finding_marker`` and ``pr_review.finding_marker``.
     """
     return f"<!-- daydream-scope-edit: {fingerprint} -->"
-
-
-def _scope_edit_already_filed(repo: Path, marker: str) -> bool:
-    """Best-effort: has an open issue already filed this reverted edit?
-
-    Issue #1051 — the residual net re-derives the same reverted edit on every
-    re-run/resume and would re-file a duplicate issue each time. GitHub is the
-    store: scan open issues for the edit's fingerprint marker and skip filing
-    when present. Best-effort — a failed ``gh issue list`` returns ``False``
-    so the call degrades to filing (never to suppression).
-    """
-    from daydream import git_ops
-
-    try:
-        issues = git_ops.gh_issue_list(repo, search="out-of-scope")
-    except Exception:  # noqa: BLE001 -- best-effort dedup lookup
-        return False
-    return any(marker in (issue.get("body") or "") for issue in issues)
 
 
 def _file_reverted_edit_issue(repo: Path, path: str, patch: str) -> None:
@@ -181,7 +161,7 @@ def _file_reverted_edit_issue(repo: Path, path: str, patch: str) -> None:
     # Compute the fingerprint marker once and thread it into both the dedup
     # lookup and the issue body, rather than recomputing it for each.
     marker = _scope_edit_marker(_scope_edit_fingerprint(path, patch))
-    if _scope_edit_already_filed(repo, marker):
+    if _scope_already_filed(repo, marker):
         return
     title = f"[daydream] out-of-scope edit reverted: {path}"
     body = (

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -177,6 +177,13 @@ class RunConfig:
             ``False`` (precedence CLI > file > default, mirroring
             ``precision_mode``; resolved by ``_approve_on_clean``), so the posted
             event stays COMMENT unless a repo explicitly opts in.
+        scope_issue_filing: Opt-in filing of out-of-scope GitHub issues (issue
+            #1056). When True, out-of-scope findings and reverted post-fix edits
+            are filed as GitHub issues. ``False`` falls through to
+            ``file_config.scope_issue_filing`` then the built-in default
+            ``False`` (precedence CLI > file > default, mirroring
+            ``approve_on_clean``; resolved by ``_scope_issue_filing``), so no
+            out-of-scope issue is filed unless a repo explicitly opts in.
         flow_name: Name of a registered flow to dispatch (``--flow``); built-in
             names route to their dedicated helper, other registered names to the
             generic custom-flow runner.
@@ -300,6 +307,13 @@ class RunConfig:
     # byte-identical behavior; the posted event stays COMMENT unless a repo
     # explicitly opts in.
     approve_on_clean: bool = False
+    # Issue #1056: opt-in filing of out-of-scope GitHub issues. When True, both
+    # filing paths (pre-fix findings and post-fix reverted edits) are enabled.
+    # Default False => byte-identical behavior; no out-of-scope issue is filed
+    # unless a repo explicitly opts in. Precedence: CLI --file-scope-issues >
+    # [tool.daydream] scope_issue_filing > default False (resolved by
+    # _scope_issue_filing).
+    scope_issue_filing: bool = False
     flow_name: str | None = None
     improve_effort: str = "standard"
     improve_focus: str | None = None

--- a/docs/self-hosted-bot-setup.md
+++ b/docs/self-hosted-bot-setup.md
@@ -196,6 +196,10 @@ installed workflows still satisfy the approval-gate contract of the packaged
 versions (contract-intact customizations, such as a different model backend,
 pass with a warning; only drift that breaks the gate is a hard failure).
 
+### Out-of-scope issue filing
+
+By default daydream makes **no** GitHub issue writes for out-of-scope work: findings outside the reviewed diff are excluded from the fix pass, and out-of-scope post-fix edits are reverted — nothing is filed. If the bot runs unattended on repositories you don't own, leave `scope_issue_filing` off (the default) so the bot never opens issues on someone else's tracker. Opting in (`[tool.daydream] scope_issue_filing = true` in the target repo's config, or `daydream --file-scope-issues` per run) re-enables both filing paths — pre-fix out-of-scope findings and reverted post-fix edits — with the reverted-edit path cross-run deduplicated via a hidden fingerprint marker so repeat runs don't file duplicates.
+
 ---
 
 ## Accepted honest limits

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -83,6 +83,20 @@ def test_run_config_flow_name_settable() -> None:
     assert RunConfig(target="/tmp/p", flow_name="ro-audit").flow_name == "ro-audit"
 
 
+def test_file_scope_issues_flag_reaches_runconfig(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(monkeypatch, ["--file-scope-issues", "/tmp/project"])
+    assert cfg.scope_issue_filing is True
+
+
+def test_file_scope_issues_defaults_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg(monkeypatch, ["/tmp/project"])
+    assert cfg.scope_issue_filing is False
+
+
+def test_runconfig_scope_issue_filing_defaults_false() -> None:
+    assert RunConfig(target="/t").scope_issue_filing is False
+
+
 def test_flow_flag_sets_flow_name(monkeypatch: pytest.MonkeyPatch) -> None:
     cfg = _cfg(monkeypatch, ["--flow", "ro-audit", "/tmp/project"])
     assert cfg.flow_name == "ro-audit"

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -176,6 +176,20 @@ def test_approve_on_clean_non_bool_degrades_to_none(tmp_path: Path) -> None:
     assert cfg.approve_on_clean is None
 
 
+def test_scope_issue_filing_true_parses_as_bool(tmp_path: Path) -> None:
+    (tmp_path / ".daydream.toml").write_text("scope_issue_filing = true\n")
+    cfg = load_file_config(tmp_path)
+    assert cfg.scope_issue_filing is True
+
+
+def test_scope_issue_filing_non_bool_degrades_to_none(tmp_path: Path) -> None:
+    # Mirrors approve_on_clean: an accidental ``scope_issue_filing = 1`` is
+    # unset, not enabled — an int must never silently opt a repo into filing.
+    (tmp_path / ".daydream.toml").write_text("scope_issue_filing = 1\n")
+    cfg = load_file_config(tmp_path)
+    assert cfg.scope_issue_filing is None
+
+
 def test_target_trajectory_hub_repo_key_is_ignored(tmp_path: Path) -> None:
     """A target file setting trajectory_hub_repo loads cleanly and contributes
     nothing — the field is removed from the model entirely."""

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -2454,6 +2454,8 @@ async def test_fix_reverts_post_fix_edit_outside_reviewed_diff(
 
     monkeypatch.setattr("daydream.git_ops.gh_issue_create", _record_issue)
 
+    # Issue #1056: filing is opt-in, so this filing-behavior test passes the
+    # opt-in explicitly.
     exit_code = await run(
         make_config(
             target,
@@ -2461,6 +2463,7 @@ async def test_fix_reverts_post_fix_edit_outside_reviewed_diff(
             output_mode="loop",
             non_interactive=False,
             archive=False,
+            scope_issue_filing=True,
         )
     )
     assert exit_code == 0
@@ -2489,7 +2492,10 @@ async def test_fix_reverts_post_fix_edit_outside_reviewed_diff(
 
 
 async def test_fix_reverts_but_files_no_issue_by_default(
-    tmp_path, monkeypatch, make_config, mute_side_effects
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+    mute_side_effects: Mute,
 ) -> None:
     """#1056 default-off: the residual edit is still reverted (safety invariant)
     but no GitHub issue is filed."""
@@ -2505,12 +2511,13 @@ async def test_fix_reverts_but_files_no_issue_by_default(
     stub.fix_edit_line = "\n# daydream fix\n"
     monkeypatch.setattr("daydream.runner.create_backend", lambda name, model=None, **kwargs: stub)
     monkeypatch.setattr("daydream.deep.orchestrator.EXPLORATION_AVAILABLE", False)
-    issues: list[tuple] = []
-    monkeypatch.setattr(
-        "daydream.git_ops.gh_issue_create",
-        lambda repo, *, title, body, **kw: issues.append((title, body))
-        or "https://github.com/owner/repo/issues/9",
-    )
+    issues: list[tuple[str, str]] = []
+
+    def _record_issue(repo: Any, *, title: str, body: str, **kwargs: Any) -> str:
+        issues.append((title, body))
+        return "https://github.com/owner/repo/issues/9"
+
+    monkeypatch.setattr("daydream.git_ops.gh_issue_create", _record_issue)
     exit_code = await run(
         make_config(target, assume="yes", output_mode="loop", non_interactive=False, archive=False)
     )
@@ -2524,7 +2531,10 @@ async def test_fix_reverts_but_files_no_issue_by_default(
 
 
 async def test_fix_reverts_and_files_when_opted_in(
-    tmp_path, monkeypatch, make_config, mute_side_effects
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+    mute_side_effects: Mute,
 ) -> None:
     """#1056 opt-in: the reverted edit is filed exactly as #336 built it."""
     from daydream.runner import run
@@ -2537,12 +2547,13 @@ async def test_fix_reverts_and_files_when_opted_in(
     stub.fix_edit_line = "\n# daydream fix\n"
     monkeypatch.setattr("daydream.runner.create_backend", lambda name, model=None, **kwargs: stub)
     monkeypatch.setattr("daydream.deep.orchestrator.EXPLORATION_AVAILABLE", False)
-    issues: list[tuple] = []
-    monkeypatch.setattr(
-        "daydream.git_ops.gh_issue_create",
-        lambda repo, *, title, body, **kw: issues.append((title, body))
-        or "https://github.com/owner/repo/issues/9",
-    )
+    issues: list[tuple[str, str]] = []
+
+    def _record_issue(repo: Any, *, title: str, body: str, **kwargs: Any) -> str:
+        issues.append((title, body))
+        return "https://github.com/owner/repo/issues/9"
+
+    monkeypatch.setattr("daydream.git_ops.gh_issue_create", _record_issue)
     exit_code = await run(
         make_config(
             target, assume="yes", output_mode="loop", non_interactive=False,
@@ -2554,7 +2565,10 @@ async def test_fix_reverts_and_files_when_opted_in(
 
 
 async def test_reverted_edit_dedups_across_runs(
-    tmp_path, monkeypatch, make_config, mute_side_effects
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+    mute_side_effects: Mute,
 ) -> None:
     """#1051 regression: an opted-in run does not re-file an issue for a
     reverted edit whose fingerprint marker already sits on an open issue."""
@@ -2568,9 +2582,9 @@ async def test_reverted_edit_dedups_across_runs(
     stub.fix_edit_line = "\n# daydream fix\n"
     monkeypatch.setattr("daydream.runner.create_backend", lambda name, model=None, **kwargs: stub)
     monkeypatch.setattr("daydream.deep.orchestrator.EXPLORATION_AVAILABLE", False)
-    created: list[tuple] = []
+    created: list[tuple[str, str]] = []
 
-    def _record_and_list_create(repo, *, title, body, **kw):
+    def _record_and_list_create(repo: Any, *, title: str, body: str, **kw: Any) -> str:
         created.append((title, body))
         return "https://github.com/owner/repo/issues/9"
 
@@ -2585,7 +2599,7 @@ async def test_reverted_edit_dedups_across_runs(
     recorded: list[str] = []
     _real_diff = _git_ops.diff_worktree_against
 
-    def _spy_diff(repo, ref, paths, **kw):
+    def _spy_diff(repo: Any, ref: str, paths: Any, **kw: Any) -> str:
         patch = _real_diff(repo, ref, paths, **kw)
         if list(paths) == ["unrelated.py"]:
             recorded.append(patch)
@@ -2593,7 +2607,7 @@ async def test_reverted_edit_dedups_across_runs(
 
     monkeypatch.setattr("daydream.git_ops.diff_worktree_against", _spy_diff)
 
-    def _list_with_prior_marker(repo, **kw):
+    def _list_with_prior_marker(repo: Any, **kw: Any) -> list[dict[str, Any]]:
         marker = _scope_edit_marker(_scope_edit_fingerprint("unrelated.py", recorded[-1]))
         return [
             {"number": 11, "title": "[daydream] out-of-scope edit reverted: unrelated.py",
@@ -3366,7 +3380,13 @@ async def test_fix_gate_routes_out_of_scope_finding_to_issue(
 
     monkeypatch.setattr("daydream.git_ops.gh_issue_create", _record_issue)
 
-    exit_code = await run(make_config(multi_stack_target, assume="yes", output_mode="loop"))
+    # Issue #1056: filing is opt-in, so this filing-behavior test passes the
+    # opt-in explicitly.
+    exit_code = await run(
+        make_config(
+            multi_stack_target, assume="yes", output_mode="loop", scope_issue_filing=True
+        )
+    )
     assert exit_code == 0
 
     fix_prompts = [
@@ -3408,11 +3428,12 @@ async def test_fix_gate_files_no_issue_by_default(
     ]
     mute_side_effects()
     created: list[tuple[str, str]] = []
-    monkeypatch.setattr(
-        "daydream.git_ops.gh_issue_create",
-        lambda repo, *, title, body, **kw: created.append((title, body))
-        or "https://github.com/owner/repo/issues/9",
-    )
+
+    def _record_issue(repo: Any, *, title: str, body: str, **kwargs: Any) -> str:
+        created.append((title, body))
+        return "https://github.com/owner/repo/issues/9"
+
+    monkeypatch.setattr("daydream.git_ops.gh_issue_create", _record_issue)
     exit_code = await run(make_config(multi_stack_target, assume="yes", output_mode="loop"))
     assert exit_code == 0
     assert created == [], f"no issue may be filed by default, got {created!r}"
@@ -3438,11 +3459,12 @@ async def test_fix_gate_files_issue_when_opted_in(
     ]
     mute_side_effects()
     created: list[tuple[str, str]] = []
-    monkeypatch.setattr(
-        "daydream.git_ops.gh_issue_create",
-        lambda repo, *, title, body, **kw: created.append((title, body))
-        or "https://github.com/owner/repo/issues/9",
-    )
+
+    def _record_issue(repo: Any, *, title: str, body: str, **kwargs: Any) -> str:
+        created.append((title, body))
+        return "https://github.com/owner/repo/issues/9"
+
+    monkeypatch.setattr("daydream.git_ops.gh_issue_create", _record_issue)
     exit_code = await run(
         make_config(
             multi_stack_target, assume="yes", output_mode="loop", scope_issue_filing=True
@@ -3488,7 +3510,13 @@ async def test_fix_gate_keeps_dot_slash_in_scope_finding_in_fix(
 
     monkeypatch.setattr("daydream.git_ops.gh_issue_create", _record_issue)
 
-    exit_code = await run(make_config(multi_stack_target, assume="yes", output_mode="loop"))
+    # Issue #1056: filing is opt-in, so this filing-behavior test passes the
+    # opt-in explicitly.
+    exit_code = await run(
+        make_config(
+            multi_stack_target, assume="yes", output_mode="loop", scope_issue_filing=True
+        )
+    )
     assert exit_code == 0
 
     fix_prompts = [
@@ -3631,7 +3659,13 @@ async def test_fix_gate_short_circuits_when_all_findings_out_of_scope(
 
     monkeypatch.setattr("daydream.git_ops.gh_issue_create", _record_issue)
 
-    exit_code = await run(make_config(multi_stack_target, assume="yes", output_mode="loop"))
+    # Issue #1056: filing is opt-in, so this filing-behavior test passes the
+    # opt-in explicitly.
+    exit_code = await run(
+        make_config(
+            multi_stack_target, assume="yes", output_mode="loop", scope_issue_filing=True
+        )
+    )
     assert exit_code == 0
 
     # Every finding filed as an issue, all on out-of-scope files.

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -2488,6 +2488,132 @@ async def test_fix_reverts_post_fix_edit_outside_reviewed_diff(
     assert "# daydream fix" in (target / "api.py").read_text()
 
 
+async def test_fix_reverts_but_files_no_issue_by_default(
+    tmp_path, monkeypatch, make_config, mute_side_effects
+) -> None:
+    """#1056 default-off: the residual edit is still reverted (safety invariant)
+    but no GitHub issue is filed."""
+    from daydream.runner import run
+
+    target = _build_scope_creep_target(tmp_path, "scope_creep_default_off")
+    pre_fix_unrelated = (target / "unrelated.py").read_text()
+
+    _silence(monkeypatch)
+    _force_interactive(monkeypatch)
+    mute_side_effects(commit=False)
+    stub = _ScopeCreepBackend(target, target / "unrelated.py", "\n# scope creep\n")
+    stub.fix_edit_line = "\n# daydream fix\n"
+    monkeypatch.setattr("daydream.runner.create_backend", lambda name, model=None, **kwargs: stub)
+    monkeypatch.setattr("daydream.deep.orchestrator.EXPLORATION_AVAILABLE", False)
+    issues: list[tuple] = []
+    monkeypatch.setattr(
+        "daydream.git_ops.gh_issue_create",
+        lambda repo, *, title, body, **kw: issues.append((title, body))
+        or "https://github.com/owner/repo/issues/9",
+    )
+    exit_code = await run(
+        make_config(target, assume="yes", output_mode="loop", non_interactive=False, archive=False)
+    )
+    assert exit_code == 0
+    # The safety revert still happened — invariant independent of filing.
+    assert (target / "unrelated.py").read_text() == pre_fix_unrelated
+    committed_paths = _git(target, "show", "--name-only", "--format=", "HEAD").split()
+    assert "unrelated.py" not in committed_paths
+    # Filing did not happen.
+    assert issues == [], f"no issue may be filed by default, got {issues!r}"
+
+
+async def test_fix_reverts_and_files_when_opted_in(
+    tmp_path, monkeypatch, make_config, mute_side_effects
+) -> None:
+    """#1056 opt-in: the reverted edit is filed exactly as #336 built it."""
+    from daydream.runner import run
+
+    target = _build_scope_creep_target(tmp_path, "scope_creep_opt_in")
+    _silence(monkeypatch)
+    _force_interactive(monkeypatch)
+    mute_side_effects(commit=False)
+    stub = _ScopeCreepBackend(target, target / "unrelated.py", "\n# scope creep\n")
+    stub.fix_edit_line = "\n# daydream fix\n"
+    monkeypatch.setattr("daydream.runner.create_backend", lambda name, model=None, **kwargs: stub)
+    monkeypatch.setattr("daydream.deep.orchestrator.EXPLORATION_AVAILABLE", False)
+    issues: list[tuple] = []
+    monkeypatch.setattr(
+        "daydream.git_ops.gh_issue_create",
+        lambda repo, *, title, body, **kw: issues.append((title, body))
+        or "https://github.com/owner/repo/issues/9",
+    )
+    exit_code = await run(
+        make_config(
+            target, assume="yes", output_mode="loop", non_interactive=False,
+            archive=False, scope_issue_filing=True,
+        )
+    )
+    assert exit_code == 0
+    assert len(issues) == 1 and "unrelated.py" in issues[0][1]
+
+
+async def test_reverted_edit_dedups_across_runs(
+    tmp_path, monkeypatch, make_config, mute_side_effects
+) -> None:
+    """#1051 regression: an opted-in run does not re-file an issue for a
+    reverted edit whose fingerprint marker already sits on an open issue."""
+    from daydream.runner import run
+
+    target = _build_scope_creep_target(tmp_path, "scope_creep_dedup")
+    _silence(monkeypatch)
+    _force_interactive(monkeypatch)
+    mute_side_effects(commit=False)
+    stub = _ScopeCreepBackend(target, target / "unrelated.py", "\n# scope creep\n")
+    stub.fix_edit_line = "\n# daydream fix\n"
+    monkeypatch.setattr("daydream.runner.create_backend", lambda name, model=None, **kwargs: stub)
+    monkeypatch.setattr("daydream.deep.orchestrator.EXPLORATION_AVAILABLE", False)
+    created: list[tuple] = []
+
+    def _record_and_list_create(repo, *, title, body, **kw):
+        created.append((title, body))
+        return "https://github.com/owner/repo/issues/9"
+
+    monkeypatch.setattr("daydream.git_ops.gh_issue_create", _record_and_list_create)
+    # The dedup lookup sees a prior issue carrying this revert's marker —
+    # computed the same way the edit filer computes it (path + diff head).
+    # Spy on the evidence diff the filer captures pre-revert: a prior run would
+    # have filed a marker over this exact patch (same path + same edit → same
+    # fingerprint), so the dedup lookup serves an issue body carrying it.
+    from daydream import git_ops as _git_ops
+    from daydream.deep.scope_issues import _scope_edit_fingerprint, _scope_edit_marker
+    recorded: list[str] = []
+    _real_diff = _git_ops.diff_worktree_against
+
+    def _spy_diff(repo, ref, paths, **kw):
+        patch = _real_diff(repo, ref, paths, **kw)
+        if list(paths) == ["unrelated.py"]:
+            recorded.append(patch)
+        return patch
+
+    monkeypatch.setattr("daydream.git_ops.diff_worktree_against", _spy_diff)
+
+    def _list_with_prior_marker(repo, **kw):
+        marker = _scope_edit_marker(_scope_edit_fingerprint("unrelated.py", recorded[-1]))
+        return [
+            {"number": 11, "title": "[daydream] out-of-scope edit reverted: unrelated.py",
+             "body": f"prior run\n{marker}", "url": "u"}
+        ]
+
+    monkeypatch.setattr("daydream.git_ops.gh_issue_list", _list_with_prior_marker)
+    exit_code = await run(
+        make_config(
+            target, assume="yes", output_mode="loop", non_interactive=False,
+            archive=False, scope_issue_filing=True,
+        )
+    )
+    assert exit_code == 0
+    # Revert still happened; the duplicate issue did not.
+    committed_paths = _git(target, "show", "--name-only", "--format=", "HEAD").split()
+    assert "unrelated.py" not in committed_paths
+    assert created == [], f"stale revert must not re-file, got {created!r}"
+
+
 async def test_fix_reverts_post_fix_edit_outside_reviewed_diff_restore_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -3599,7 +3599,11 @@ async def test_fix_gate_dedups_out_of_scope_finding_already_filed(
 
     monkeypatch.setattr("daydream.git_ops.gh_issue_create", _record_create)
 
-    exit_code = await run(make_config(multi_stack_target, assume="yes", output_mode="loop"))
+    exit_code = await run(
+        make_config(
+            multi_stack_target, assume="yes", output_mode="loop", scope_issue_filing=True
+        )
+    )
     assert exit_code == 0
 
     # Deduped: the already-filed finding is NOT re-filed.

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -5481,6 +5481,22 @@ def test_approve_on_clean_resolves_from_file_config() -> None:
     assert _approve_on_clean(unset) is False
 
 
+def test_scope_issue_filing_resolves_precedence() -> None:
+    """#1056 precedence: CLI tier over file config over built-in default False."""
+    from daydream.config_file import DaydreamFileConfig
+    from daydream.deep.orchestrator import _scope_issue_filing
+    from daydream.runner import RunConfig
+
+    cli = RunConfig(target="/t", scope_issue_filing=True)
+    assert _scope_issue_filing(cli) is True
+
+    file_only = RunConfig(target="/t", file_config=DaydreamFileConfig(scope_issue_filing=True))
+    assert _scope_issue_filing(file_only) is True
+
+    unset = RunConfig(target="/t")
+    assert _scope_issue_filing(unset) is False
+
+
 def _prime_merge_resume_records(target: Path, *, python_severity: str | None) -> Path:
     """Write the per-stack records a `--start-at merge` resume needs on disk.
 

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -3264,6 +3264,68 @@ async def test_fix_gate_routes_out_of_scope_finding_to_issue(
     assert "out of scope for PR" in body
 
 
+async def test_fix_gate_files_no_issue_by_default(
+    multi_stack_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+    mute_side_effects: Mute,
+) -> None:
+    """#1056 default-off: out-of-scope findings are excluded and short-circuited
+    but NO GitHub issue is filed."""
+    from daydream.runner import run
+
+    _silence(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    stub.merge_items = [
+        _merge_item(1, "api.py", "high", desc="in-scope finding"),
+        _merge_item(2, "notes.txt", "medium", desc="out-of-scope finding"),
+    ]
+    mute_side_effects()
+    created: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "daydream.git_ops.gh_issue_create",
+        lambda repo, *, title, body, **kw: created.append((title, body))
+        or "https://github.com/owner/repo/issues/9",
+    )
+    exit_code = await run(make_config(multi_stack_target, assume="yes", output_mode="loop"))
+    assert exit_code == 0
+    assert created == [], f"no issue may be filed by default, got {created!r}"
+    # Exclusion still happened: the fix pass never touched notes.txt and the
+    # short-circuit fired before phase_fix.
+    assert not any("notes.txt" in (b or "") for b in _fix_prompts(stub))
+
+
+async def test_fix_gate_files_issue_when_opted_in(
+    multi_stack_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+    mute_side_effects: Mute,
+) -> None:
+    """#1056 opt-in: scope_issue_filing=True restores the #336 filing behavior."""
+    from daydream.runner import run
+
+    _silence(monkeypatch)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    stub.merge_items = [
+        _merge_item(1, "api.py", "high", desc="in-scope finding"),
+        _merge_item(2, "notes.txt", "medium", desc="out-of-scope finding"),
+    ]
+    mute_side_effects()
+    created: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "daydream.git_ops.gh_issue_create",
+        lambda repo, *, title, body, **kw: created.append((title, body))
+        or "https://github.com/owner/repo/issues/9",
+    )
+    exit_code = await run(
+        make_config(
+            multi_stack_target, assume="yes", output_mode="loop", scope_issue_filing=True
+        )
+    )
+    assert exit_code == 0
+    assert len(created) == 1 and "notes.txt" in created[0][1]
+
+
 async def test_fix_gate_keeps_dot_slash_in_scope_finding_in_fix(
     multi_stack_target: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- Gates the deep-fix loop's out-of-scope finding issue filing behind a new `scope_issue_filing` opt-in flag (default off), so daydream no longer auto-files issues for findings outside the reviewed diff.
- Adds dedup on the reverted-edit path so stale/redundant `[daydream] out-of-scope edit reverted` issues (e.g. #1051) are not re-filed when the change is already fixed or no longer actionable.
- Docs for the new flag + tests covering default-off filing coverage across both paths.

Two daydream deep-precision review rounds passed (round 2 fix commit a60c57b).

Closes #1056
Closes #1051