### PR TITLE
chore(deps): drop github-actions Dependabot ecosystem; manual app-token v3.2.0 bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,8 @@
 # Dependabot dependency updates (issue #936).
 #
-# Four bounded ecosystems, each opening at most 5 pull requests at a time:
+# Three bounded ecosystems, each opening at most 5 pull requests at a time:
 #   - uv @ "/"                  — root workspace dependencies (pyproject.toml / uv.lock)
 #   - uv @ "/rl/daydream_review_v1" — the standalone RL package's own dependencies
-#   - github-actions @ "/"      — action version bumps across .github/workflows
 #   - npm @ "/.github/workflows" — the tracking package.json in the workflows folder
 #     (that is where the manifest lives — do not "fix" this directory to "/");
 #     it tracks the single @openai/codex dependency used by CI.
@@ -55,25 +54,12 @@ updates:
     commit-message:
       prefix: chore(deps)
 
-  # GitHub Actions version bumps across .github/workflows.
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: weekly
-      day: monday
-      time: "06:00"
-      timezone: Australia/Brisbane
-    open-pull-requests-limit: 5
-    groups:
-      dependencies:
-        patterns:
-          - "*"
-        update-types:
-          - minor
-          - patch
-    commit-message:
-      prefix: chore(deps)
-
+  # NOTE: the github-actions ecosystem was removed on purpose (PR 1065
+  # follow-up). The repo pins every third-party action to a full commit SHA
+  # registered in tests/test_workflow_templates.py::_PINNED_ACTION_VERSIONS,
+  # which Dependabot cannot update — every actions bump was structurally
+  # unmergeable. Bump actions manually: update the SHA + `# vX.Y.Z` comment in
+  # the workflows AND the map entry, then `make check`.
   # npm tracks the workflows-folder package.json (the @openai/codex pin).
   # The directory is the workflows folder on purpose — see header comment.
   - package-ecosystem: npm

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -79,21 +79,26 @@ triggers and posting identity, not a new output format.
 ## Dependabot dependency updates
 
 `.github/dependabot.yml` keeps dependency updates arriving as small, grouped,
-reviewer-friendly PRs across four managed ecosystems:
+reviewer-friendly PRs across three managed ecosystems:
 
 | Ecosystem | Directory | Notes |
 |---|---|---|
 | `uv` | `/` | Root workspace dependencies (`pyproject.toml` / `uv.lock`) |
 | `uv` | `/rl/daydream_review_v1` | The standalone RL package's own dependencies |
-| `github-actions` | `/` | Action version bumps across `.github/workflows` |
 | `npm` | `/.github/workflows` | Deliberately points at this folder's `package.json`, which tracks the single `@openai/codex` dependency used by CI — do not "fix" the directory to `/` |
 
-**Volume bounds.** All four ecosystems run weekly on Mondays (06:00,
+**Volume bounds.** All three ecosystems run weekly on Mondays (06:00,
 `Australia/Brisbane`) with `open-pull-requests-limit: 5` per ecosystem. The
-three multi-dependency ecosystems (both `uv` blocks and `github-actions`) use
-one minor+patch group each, so at most one grouped PR per uv project and one
-for all action bumps; the npm block is ungrouped since it tracks a single
-dependency. Commit messages carry the `chore(deps)` prefix.
+two multi-dependency `uv` blocks each use one minor+patch group, so at most
+one grouped PR per uv project; the npm block is ungrouped since it tracks a
+single dependency. Commit messages carry the `chore(deps)` prefix.
+
+**Action bumps are manual.** The `github-actions` ecosystem was removed on
+purpose: every third-party action is pinned to a full commit SHA registered in
+`tests/test_workflow_templates.py::_PINNED_ACTION_VERSIONS`, which Dependabot
+cannot update — its action-bump PRs failed CI structurally. Bump actions by
+hand: update the SHA + `# vX.Y.Z` comment in the workflows (live and packaged
+templates) AND the map entry, then run `make check`.
 
 **Validation gate.** Every dependency PR must pass `make check` before merge —
 its lockcheck-first ordering is what catches `uv.lock` / `pyproject.toml`

--- a/.github/workflows/daydream-command.yml
+++ b/.github/workflows/daydream-command.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Mint app token
         id: token
         if: steps.match.outputs.matched == 'true'
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.DAYDREAM_APP_ID }}
           private-key: ${{ secrets.DAYDREAM_APP_PRIVATE_KEY }}

--- a/.github/workflows/daydream-post.yml
+++ b/.github/workflows/daydream-post.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Mint posting token
         id: token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.DAYDREAM_APP_ID }}
           private-key: ${{ secrets.DAYDREAM_APP_PRIVATE_KEY }}
@@ -124,7 +124,7 @@ jobs:
     steps:
       - name: Mint posting token
         id: token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.DAYDREAM_APP_ID }}
           private-key: ${{ secrets.DAYDREAM_APP_PRIVATE_KEY }}

--- a/daydream/templates/workflows/daydream-command.yml
+++ b/daydream/templates/workflows/daydream-command.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Mint app token
         id: token
         if: steps.match.outputs.matched == 'true'
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.DAYDREAM_APP_ID }}
           private-key: ${{ secrets.DAYDREAM_APP_PRIVATE_KEY }}

--- a/daydream/templates/workflows/daydream-post.yml
+++ b/daydream/templates/workflows/daydream-post.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Mint posting token
         id: token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.DAYDREAM_APP_ID }}
           private-key: ${{ secrets.DAYDREAM_APP_PRIVATE_KEY }}
@@ -121,7 +121,7 @@ jobs:
     steps:
       - name: Mint posting token
         id: token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.DAYDREAM_APP_ID }}
           private-key: ${{ secrets.DAYDREAM_APP_PRIVATE_KEY }}

--- a/daydream/templates/workflows/single/daydream.yml
+++ b/daydream/templates/workflows/single/daydream.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Mint ack token
         id: token
         if: steps.match.outputs.matched == 'true'
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.DAYDREAM_APP_ID }}
           private-key: ${{ secrets.DAYDREAM_APP_PRIVATE_KEY }}
@@ -262,7 +262,7 @@ jobs:
     steps:
       - name: Mint posting token
         id: token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.DAYDREAM_APP_ID }}
           private-key: ${{ secrets.DAYDREAM_APP_PRIVATE_KEY }}
@@ -320,7 +320,7 @@ jobs:
     steps:
       - name: Mint posting token
         id: token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.DAYDREAM_APP_ID }}
           private-key: ${{ secrets.DAYDREAM_APP_PRIVATE_KEY }}

--- a/tests/test_dependabot_config.py
+++ b/tests/test_dependabot_config.py
@@ -2,9 +2,9 @@
 
 The config's real acceptance happens GitHub-side (Dependency graph registration,
 first grouped PRs). These tests pin the structural invariants a careless edit
-could silently break: exactly four ecosystems at the exact directories, weekly
-Monday schedule on one timezone, PR limit 5, grouping on the three
-multi-dependency blocks, and the reviewer-facing docs that make the
+could silently break: exactly three ecosystems at the exact directories, weekly
+Monday schedule on one timezone, PR limit 5, grouping on the two
+multi-dependency uv blocks, and the reviewer-facing docs that make the
 config's volume bounds discoverable.
 """
 
@@ -38,9 +38,12 @@ def test_four_ecosystems_at_exact_directories() -> None:
     assert blocks == {
         ("uv", "/"),
         ("uv", "/rl/daydream_review_v1"),
-        ("github-actions", "/"),
         ("npm", "/.github/workflows"),  # the npm manifest trick — must NOT be "/"
     }
+    # The github-actions ecosystem was deliberately removed (PR 1065 follow-up):
+    # the repo pins every third-party action to a SHA registered in
+    # test_workflow_templates.py::_PINNED_ACTION_VERSIONS, which Dependabot
+    # cannot update, so its bump PRs were structurally unmergeable.
 
 
 def test_weekly_monday_one_timezone_limit_five_everywhere() -> None:
@@ -57,7 +60,7 @@ def test_grouping_on_multi_dependency_blocks_only() -> None:
     # not collapsed by ecosystem alone (the root uv block's grouping would
     # otherwise never be inspected).
     by_block = {(u["package-ecosystem"], u["directory"]): u for u in updates(load_dependabot())}
-    for key in (("uv", "/"), ("uv", "/rl/daydream_review_v1"), ("github-actions", "/")):
+    for key in (("uv", "/"), ("uv", "/rl/daydream_review_v1")):
         group = by_block[key]["groups"]
         assert list(group) == ["dependencies"], f"{key} needs a single group"
         pattern = group["dependencies"]["patterns"]

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -10,7 +10,7 @@ cannot verify and that a careless edit could silently break:
   resolves to a full commit SHA (never a mutable tag/branch/expression).
 - The daydream install stays pinned to the current release tag (cross-file
   drift against ``pyproject.toml``), in every live and shipped workflow.
-- Every App-token action in the live and packaged posting workflows stays pinned to the approved v2.2.2 commit.
+- Every App-token action in the live and packaged posting workflows stays pinned to the approved v3.2.0 commit.
 - The privilege split holds: the job that checks out untrusted PR code never
   holds the App key, and the privileged jobs never check out PR code.
 - The repo's own Codex dogfood workflow persists ``codex login`` before the
@@ -106,7 +106,7 @@ _PINNED_ACTION_VERSIONS = {
     "astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a": "v4.2.0",
     "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02": "v4.6.2",
     "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093": "v4.3.0",
-    "actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349": "v2.2.2",
+    "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1": "v3.2.0",
 }
 
 _USES_LINE_RE = re.compile(r"^\s*uses:\s*(?P<ref>\S+)(?:\s*#\s*(?P<comment>\S+))?$")
@@ -545,10 +545,10 @@ def test_split_setup_preserves_privilege_split(post_path: Path) -> None:
     assert set(_SECRET_REF_RE.findall(post_text)) == {"DAYDREAM_APP_ID", "DAYDREAM_APP_PRIVATE_KEY"}
 
 
-_APP_TOKEN_ACTION = "actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349"
+_APP_TOKEN_ACTION = "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1"
 
 # Every token-minting workflow, shipped or live, pins every App-token action to
-# the approved v2.2.2 commit. Lists the concrete (job, action) pairs so a renamed
+# the approved v3.2.0 commit. Lists the concrete (job, action) pairs so a renamed
 # job, a refloated pin, or a newly added unpinned token action fails loudly rather
 # than being silently absorbed by a wildcard.
 _APP_TOKEN_PIN_CASES = [


### PR DESCRIPTION
Follow-up to #1065.

## Why
The repo pins every third-party action to a full commit SHA registered in `_PINNED_ACTION_VERSIONS` (supply-chain guard). Dependabot rewrites the workflow SHA but cannot update the map, so **every** `github-actions` bump PR failed CI structurally — #1065, plus the checkout/download-artifact bumps.

## Changes
- Remove the `github-actions` block from `.github/dependabot.yml` (with an explanatory comment for future editors)
- Update dependabot invariant tests (`test_dependabot_config.py`) to three ecosystems
- Update `.github/workflows/README.md` ecosystem table + add an 'Action bumps are manual' note
- Manually bump `actions/create-github-app-token` v2.2.2 → v3.2.0 (SHA `bcd2ba49`, verified via GitHub API) across live workflows, packaged templates, the map entry, and `_APP_TOKEN_ACTION`

## Verification
- `pytest tests/test_workflow_templates.py tests/test_dependabot_config.py`: 51 passed
- Full `make check` locally: lint/typecheck/deadcode/actionlint/rl-check/coverage all pass; only local-env failure is `test_benchmark_harbor_package.py` (Docker daemon absent — fails identically on clean main, Docker is present in CI)

Closes the dependabot-churn discussed in #1065.