### PR TITLE
fix(training): annotation snapshot pipeline hardening (temporal gold gate, dedup, bundle checks) (#1055)

### DIFF
--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -569,13 +569,22 @@ def _build_build_corpus_v2_parser() -> argparse.ArgumentParser:
         "curation-manifest.json)",
     )
     parser.add_argument(
+        "--annotation-bundle-root",
+        type=Path,
+        default=None,
+        dest="annotation_bundle_dir",
+        metavar="DIR",
+        help="Annotation-bundle root (must contain _SUCCESS, SHA256SUMS, "
+        "lineage.json, annotations.jsonl); self-verified and linked to "
+        "--bundle-root before the projection runs",
+    )
+    parser.add_argument(
         "--annotations-snapshot",
         type=Path,
-        required=True,
+        default=None,
         dest="annotations_snapshot",
         metavar="PATH",
-        help="Side-car JSONL of per-finding resolutions keyed by fingerprint, "
-        "digest-pinned alongside the bundle",
+        help=argparse.SUPPRESS,  # deprecated: refused in the handler
     )
     parser.add_argument(
         "--out",
@@ -620,7 +629,7 @@ def _handle_build_corpus_v2_command(argv: list[str]) -> int:
 
     Drives :func:`daydream.training.corpus_v2.run_build_corpus_v2` synchronously
     (no agent work, no network — a pure projection over the curated bundle plus
-    the annotations snapshot). Mirrors :func:`_handle_build_corpus_command`'s
+    the annotation bundle). Mirrors :func:`_handle_build_corpus_command`'s
     structure: returns an exit code; ``main()`` translates it into a process
     exit. Errors are fail-closed: a refused build exits non-zero with the
     exception message and writes nothing.
@@ -646,6 +655,23 @@ def _handle_build_corpus_v2_command(argv: list[str]) -> int:
         )
         return 1
 
+    if args.annotations_snapshot is not None:
+        print_error(
+            create_console(),
+            "Unsupported --annotations-snapshot",
+            "The side-car snapshot was replaced by the two-bundle contract; "
+            "pass the self-verified annotation bundle via --annotation-bundle-root.",
+        )
+        return 1
+    if args.annotation_bundle_dir is None:
+        print_error(
+            create_console(),
+            "Missing --annotation-bundle-root",
+            "A corpus v2 build requires a pinned annotation bundle "
+            "(_SUCCESS + SHA256SUMS + lineage.json + annotations.jsonl).",
+        )
+        return 1
+
     # --out names the corpus JSONL; the projector writes its canonical file set
     # (corpus.jsonl, corpus-v2.jsonl, split manifests, lineage.json) into that
     # directory, finishing with _SUCCESS — so the whole set, twin included, is
@@ -658,7 +684,7 @@ def _handle_build_corpus_v2_command(argv: list[str]) -> int:
         config = BuildCorpusV2Config(
             out_dir=out_dir,
             bundle_dir=args.bundle_root,
-            annotations_snapshot=args.annotations_snapshot,
+            annotation_bundle_dir=args.annotation_bundle_dir,
             as_of=args.as_of,
         )
     except ValueError as exc:

--- a/daydream/training/adjudication/canonical.py
+++ b/daydream/training/adjudication/canonical.py
@@ -1,0 +1,235 @@
+"""Canonical harvest of per-finding annotations into the archive (issue #1055).
+
+Re-verifies the materialized preview snapshot against a freshly built queue
+over the hydrated index, merges human observations under three-tier
+precedence, appends exactly one ``label_observations`` row per session via
+``archive.index.append_label_observation`` (the existing auto dedup key makes
+re-runs no-ops ⇒ exactly-once, M8), and emits ``annotations.jsonl`` from the
+*same* in-memory merged records used for the append — no second serialization
+(M5). Digest drift raises :class:`AnnotationDriftError` **before any write**
+(fail-closed-then-requeue, M5).
+
+Unlike ``adjudication/harvest.py`` this path does not touch
+``training/harvest.py``'s GitHub-facing signals: the #980 semantic evidence
+was already collected into the index at materialization; canonical harvest
+only re-verifies it against the preview pin.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from daydream.archive.index import append_label_observation
+from daydream.training.adjudication.materialize import _SESSIONS_OUT_FILENAME
+from daydream.training.adjudication.observations import load_observations
+from daydream.training.adjudication.precedence import (
+    DECISIVE_DISPOSITIONS,
+    effective_adjudication,
+)
+from daydream.training.adjudication.preview import _load_sessions
+from daydream.training.adjudication.queue import build_queue
+from daydream.training.adjudication.snapshot import record_evidence_digest
+from daydream.training.labeler_versions import REPLY_CLASSIFIER_VERSION
+
+__all__ = ["AnnotationDriftError", "run_canonical_harvest"]
+
+_ANNOTATIONS_FILENAME = "annotations.jsonl"
+_MANIFEST_FILENAME = "preview-manifest.json"
+
+_HUMAN_ROLES = frozenset({"rater", "adjudicator"})
+
+
+def _canonical(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+class AnnotationDriftError(ValueError):
+    """Raised when a materialized record's evidence digest differs from the fresh queue.
+
+    Fail-closed: the canonical append and ``annotations.jsonl`` are never
+    written in a drifted state; the affected findings are requeued (reported
+    via ``requeued_record_ids``).
+    """
+
+    def __init__(self, message: str, requeued_record_ids: list[str]) -> None:
+        super().__init__(message)
+        self.requeued_record_ids = requeued_record_ids
+
+
+def _load_materialized_records(materialize_dir: Path) -> list[dict[str, Any]]:
+    records_path = materialize_dir / _SESSIONS_OUT_FILENAME
+    if not records_path.is_file():
+        raise FileNotFoundError(
+            f"materialized preview snapshot not found (run `corpus adjudicate materialize` "
+            f"first): {records_path}"
+        )
+    try:
+        return [
+            json.loads(line)
+            for line in records_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"unreadable materialized snapshot at {records_path}: {exc}") from exc
+
+
+def _load_pin(materialize_dir: Path) -> dict[str, Any]:
+    manifest_path = materialize_dir / _MANIFEST_FILENAME
+    if not manifest_path.is_file():
+        raise FileNotFoundError(
+            f"preview manifest not found (run `corpus adjudicate materialize` first): "
+            f"{manifest_path}"
+        )
+    try:
+        pin: dict[str, Any] = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"unreadable preview manifest at {manifest_path}: {exc}") from exc
+    labeler_version = pin.get("labeler_version")
+    if not isinstance(labeler_version, str) or not labeler_version:
+        raise ValueError(f"preview manifest at {manifest_path} is missing 'labeler_version'")
+    return pin
+
+
+def run_canonical_harvest(
+    index_root: Path,
+    materialize_dir: Path,
+    archive_dir: Path,
+    *,
+    observations_path: Path | None = None,
+) -> dict[str, Any]:
+    """Harvest the materialized preview snapshot into canonical annotation storage.
+
+    1. Re-derives the fresh queue over the hydrated index and verifies every
+       materialized record's ``evidence_digest`` against the fresh queue
+       **before any write**; drift raises :class:`AnnotationDriftError`
+       listing the drifted ``record_id``s.
+    2. Merges human observations under three-tier precedence: a human
+       (rater/adjudicator) observation with a decisive disposition matching
+       the current evidence digest overrides the automatic disposition in the
+       stored per-finding record. An observation referencing an unknown
+       ``record_id`` raises ``ValueError`` naming it.
+    3. Groups records by ``session_id`` and appends one ``label_observations``
+       row per session (``rubric_json`` carries the merged per-finding records,
+       ``reply_evidence_digest`` is the shared serializer's session digest,
+       ``labeler_version`` is the pin's, ``reply_classifier_version`` is
+       ``REPLY_CLASSIFIER_VERSION``). The existing auto dedup key makes
+       unchanged re-runs no-ops — exactly-once.
+    4. Emits ``materialize_dir/annotations.jsonl`` (one canonical-JSON record
+       per finding, sorted by ``record_id``) from the same merged records.
+
+    Returns ``{"appended_sessions", "skipped_sessions", "human_adjudicated",
+    "record_count"}``.
+    """
+    pin = _load_pin(materialize_dir)
+    materialized = _load_materialized_records(materialize_dir)
+    sessions, _index_revision = _load_sessions(index_root)
+    fresh_by_record_id = {str(item["record_id"]): item for item in build_queue(sessions)}
+
+    # Fail-closed drift gate: verify BEFORE any write.
+    drifted: list[str] = []
+    for record in materialized:
+        record_id = str(record["record_id"])
+        fresh = fresh_by_record_id.get(record_id)
+        if fresh is None:
+            raise ValueError(
+                f"materialized snapshot record_id {record_id!r} is absent from the "
+                "freshly built adjudication queue over the index"
+            )
+        if str(fresh["evidence_digest"]) != str(record.get("evidence_digest")):
+            drifted.append(record_id)
+    if drifted:
+        raise AnnotationDriftError(
+            f"evidence digests drifted from the materialized preview snapshot for "
+            f"{len(drifted)} finding(s); re-run `corpus adjudicate materialize` and "
+            f"re-adjudicate. Requeued record_ids: {drifted}",
+            drifted,
+        )
+
+    # Merge human observations under three-tier precedence (M4/M5).
+    known_record_ids = {str(record["record_id"]) for record in materialized}
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    if observations_path is not None and observations_path.is_file():
+        for obs in load_observations(observations_path):
+            record_id = str(obs["record_id"])
+            if record_id not in known_record_ids:
+                raise ValueError(
+                    f"run_canonical_harvest: observation references record_id {record_id!r} "
+                    f"which is not in the materialized snapshot over the hydrated index "
+                    f"(observation evidence digest {obs.get('evidence_digest')!r})"
+                )
+            grouped.setdefault(record_id, []).append(obs)
+
+    human_adjudicated = 0
+    merged_records: list[dict[str, Any]] = []
+    for record in materialized:
+        record = dict(record)
+        record_id = str(record["record_id"])
+        if record_id in grouped:
+            resolved = effective_adjudication(grouped[record_id])
+            if (
+                resolved["role"] in _HUMAN_ROLES
+                and resolved["evidence_digest"] == str(record["evidence_digest"])
+                and resolved["disposition"] in DECISIVE_DISPOSITIONS
+            ):
+                record["disposition"] = resolved["disposition"]
+                record["human_labeler"] = resolved["labeler"]
+                record["human_role"] = resolved["role"]
+                human_adjudicated += 1
+        merged_records.append(record)
+    merged_records.sort(key=lambda r: str(r["record_id"]))
+
+    # One AnnotationPayload-shaped row per session, appended exactly once.
+    by_session: dict[str, list[dict[str, Any]]] = {}
+    for record in merged_records:
+        by_session.setdefault(str(record["session_id"]), []).append(record)
+
+    appended_sessions = 0
+    skipped_sessions = 0
+    for session_id, session_records in sorted(by_session.items()):
+        rubric = {
+            "per_finding_resolutions": session_records,
+            "rubric_version": pin["rubric_version"],
+        }
+        labels = sorted(
+            {
+                f"finding-{record['disposition']}"
+                for record in session_records
+                if record["disposition"] in DECISIVE_DISPOSITIONS
+            }
+        )
+        inserted = append_label_observation(
+            archive_dir,
+            session_id,
+            labels=labels,
+            pr_state=None,
+            labeler_version=str(pin["labeler_version"]),
+            evidence_sha=None,
+            rubric_json=_canonical(rubric),
+            valid_at=None,
+            has_posterior=False,
+            reply_classifier_version=REPLY_CLASSIFIER_VERSION,
+            reply_evidence_digest=record_evidence_digest(
+                [list(record.get("evidence") or []) for record in session_records]
+            ),
+        )
+        if inserted:
+            appended_sessions += 1
+        else:
+            skipped_sessions += 1
+
+    # annotations.jsonl from the same in-memory merged records — no second shape.
+    records_path = materialize_dir / _ANNOTATIONS_FILENAME
+    tmp_path = records_path.with_name(records_path.name + ".tmp")
+    tmp_path.write_text(
+        "".join(_canonical(record) + "\n" for record in merged_records), encoding="utf-8"
+    )
+    tmp_path.replace(records_path)
+
+    return {
+        "appended_sessions": appended_sessions,
+        "skipped_sessions": skipped_sessions,
+        "human_adjudicated": human_adjudicated,
+        "record_count": len(merged_records),
+    }

--- a/daydream/training/adjudication/canonical.py
+++ b/daydream/training/adjudication/canonical.py
@@ -3,8 +3,10 @@
 Re-verifies the materialized preview snapshot against a freshly built queue
 over the hydrated index, merges human observations under three-tier
 precedence, appends exactly one ``label_observations`` row per session via
-``archive.index.append_label_observation`` (the existing auto dedup key makes
-re-runs no-ops ⇒ exactly-once, M8), and emits ``annotations.jsonl`` from the
+``archive.index.append_label_observation`` (the auto dedup key keys on the
+pin's ``snapshot_id`` — fed through ``evidence_sha`` — so unchanged-pin
+re-runs are no-ops ⇒ exactly-once while a changed pin appends a fresh
+generation, M8), and emits ``annotations.jsonl`` from the
 *same* in-memory merged records used for the append — no second serialization
 (M5). Digest drift raises :class:`AnnotationDriftError` **before any write**
 (fail-closed-then-requeue, M5).
@@ -134,8 +136,11 @@ def run_canonical_harvest(
        row per session (``rubric_json`` carries the merged per-finding records,
        ``reply_evidence_digest`` is the shared serializer's session digest,
        ``labeler_version`` is the pin's, ``reply_classifier_version`` is
-       ``REPLY_CLASSIFIER_VERSION``). The existing auto dedup key makes
-       unchanged re-runs no-ops — exactly-once.
+       ``REPLY_CLASSIFIER_VERSION``). ``evidence_sha`` carries the pin's
+       ``snapshot_id`` so the dedup key changes with the pin: unchanged-pin
+       re-runs are no-ops — exactly-once — while a changed pin (new
+       snapshot id) appends a fresh generation carrying the new pin's
+       flags/rubric.
     4. Emits ``materialize_dir/annotations.jsonl`` (one canonical-JSON record
        per finding, sorted by ``record_id``) from the same merged records.
 
@@ -229,7 +234,13 @@ def run_canonical_harvest(
             labels=labels,
             pr_state=None,
             labeler_version=str(pin["labeler_version"]),
-            evidence_sha=None,
+            # Pin member of the auto dedup key: the content-addressed
+            # snapshot_id changes with any pin change (AC 8), so a changed
+            # pin appends a fresh generation instead of dedup-skipping and
+            # the archived rubric_json always matches the emitted bundle's
+            # pin/flags. Absent (legacy manifest) falls back to None, the
+            # pre-change dedup behavior.
+            evidence_sha=pin.get("snapshot_id"),
             rubric_json=_canonical(rubric),
             valid_at=None,
             has_posterior=False,

--- a/daydream/training/adjudication/canonical.py
+++ b/daydream/training/adjudication/canonical.py
@@ -4,9 +4,10 @@ Re-verifies the materialized preview snapshot against a freshly built queue
 over the hydrated index, merges human observations under three-tier
 precedence, appends exactly one ``label_observations`` row per session via
 ``archive.index.append_label_observation`` (the auto dedup key keys on the
-pin's ``snapshot_id`` — fed through ``evidence_sha`` — so unchanged-pin
-re-runs are no-ops ⇒ exactly-once while a changed pin appends a fresh
-generation, M8), and emits ``annotations.jsonl`` from the
+pin's ``snapshot_id`` plus the archived ``rubric_json`` — fed through
+``evidence_sha`` — so unchanged-pin/unchanged-rubric re-runs are no-ops ⇒
+exactly-once while a changed pin or a label-preserving observation-overlay
+change appends a fresh generation, M8), and emits ``annotations.jsonl`` from the
 *same* in-memory merged records used for the append — no second serialization
 (M5). Digest drift raises :class:`AnnotationDriftError` **before any write**
 (fail-closed-then-requeue, M5).
@@ -19,6 +20,7 @@ only re-verifies it against the preview pin.
 
 from __future__ import annotations
 
+import hashlib
 import json
 from collections.abc import Mapping
 from datetime import datetime
@@ -26,7 +28,10 @@ from pathlib import Path
 from typing import Any
 
 from daydream.archive.index import append_label_observation
-from daydream.training.adjudication.materialize import _SESSIONS_OUT_FILENAME
+from daydream.training.adjudication.materialize import (
+    _SESSIONS_OUT_FILENAME,
+    _sessions_from_hydrated_stage,
+)
 from daydream.training.adjudication.observations import load_observations
 from daydream.training.adjudication.precedence import (
     DECISIVE_DISPOSITIONS,
@@ -111,6 +116,12 @@ def _load_pin(materialize_dir: Path) -> dict[str, Any]:
     labeler_version = pin.get("labeler_version")
     if not isinstance(labeler_version, str) or not labeler_version:
         raise ValueError(f"preview manifest at {manifest_path} is missing 'labeler_version'")
+    # Dereferenced with ``pin["rubric_version"]`` in the session loop, so it must
+    # be validated here (like ``labeler_version``) to raise the documented
+    # ValueError naming the missing component, never an uncaught KeyError.
+    rubric_version = pin.get("rubric_version")
+    if not isinstance(rubric_version, str) or not rubric_version:
+        raise ValueError(f"preview manifest at {manifest_path} is missing 'rubric_version'")
     return pin
 
 
@@ -136,11 +147,13 @@ def run_canonical_harvest(
        row per session (``rubric_json`` carries the merged per-finding records,
        ``reply_evidence_digest`` is the shared serializer's session digest,
        ``labeler_version`` is the pin's, ``reply_classifier_version`` is
-       ``REPLY_CLASSIFIER_VERSION``). ``evidence_sha`` carries the pin's
-       ``snapshot_id`` so the dedup key changes with the pin: unchanged-pin
-       re-runs are no-ops — exactly-once — while a changed pin (new
-       snapshot id) appends a fresh generation carrying the new pin's
-       flags/rubric.
+       ``REPLY_CLASSIFIER_VERSION``). ``evidence_sha`` is a digest over the
+       pin's content-addressed ``snapshot_id`` *plus* the archived
+       ``rubric_json``, so the dedup key changes with the pin or with any
+       rubric-content (observation-overlay) change: unchanged-pin re-runs are
+       no-ops — exactly-once — while a changed pin (new snapshot id) or a
+       label-preserving overlay edit under an unchanged pin appends a fresh
+       generation carrying the new pin's flags/rubric.
     4. Emits ``materialize_dir/annotations.jsonl`` (one canonical-JSON record
        per finding, sorted by ``record_id``) from the same merged records.
 
@@ -149,7 +162,16 @@ def run_canonical_harvest(
     """
     pin = _load_pin(materialize_dir)
     materialized = _load_materialized_records(materialize_dir)
-    sessions, _index_revision = _load_sessions(index_root)
+    if (index_root / _SESSIONS_OUT_FILENAME).is_file():
+        sessions, _index_revision = _load_sessions(index_root)
+    else:
+        # Hydrated staging archive (materialize's primary flow): no
+        # sessions.jsonl — derive the sessions from the SQLite index plus the
+        # sanitized per-run trajectories, so the drift gate re-derives the
+        # fresh queue over the same hydrated index the materialized preview
+        # was built from instead of feeding the materialize dir back and
+        # comparing each digest against itself (tautological).
+        sessions, _index_revision = _sessions_from_hydrated_stage(index_root)
     fresh_by_record_id = {str(item["record_id"]): item for item in build_queue(sessions)}
 
     # Fail-closed drift gate: verify BEFORE any write.
@@ -221,6 +243,7 @@ def run_canonical_harvest(
             "per_finding_resolutions": session_records,
             "rubric_version": pin["rubric_version"],
         }
+        rubric_json = _canonical(rubric)
         labels = sorted(
             {
                 f"finding-{record['disposition']}"
@@ -228,20 +251,31 @@ def run_canonical_harvest(
                 if record["disposition"] in DECISIVE_DISPOSITIONS
             }
         )
+        # Pin member of the auto dedup key. The dedup tuple (M14) omits
+        # rubric_json, so the digest fed through evidence_sha must cover the
+        # rubric content itself: the content-addressed snapshot_id changes
+        # with any pin change (AC 8), and the rubric_json digest turns on any
+        # label-preserving observation-overlay change under an unchanged pin,
+        # so a fresh generation carrying the updated rubric_json is appended
+        # and the archived rubric always matches the emitted bundle's
+        # pin/flags. Unchanged pin + unchanged rubric stays a deduped no-op
+        # (exactly-once). Absent snapshot_id (legacy manifest) falls back to
+        # None, the pre-change dedup behavior.
+        snapshot_id = pin.get("snapshot_id")
+        if snapshot_id is not None:
+            generation_sha = hashlib.sha256(
+                (str(snapshot_id) + ":" + rubric_json).encode("utf-8")
+            ).hexdigest()
+        else:
+            generation_sha = None
         inserted = append_label_observation(
             archive_dir,
             session_id,
             labels=labels,
             pr_state=None,
             labeler_version=str(pin["labeler_version"]),
-            # Pin member of the auto dedup key: the content-addressed
-            # snapshot_id changes with any pin change (AC 8), so a changed
-            # pin appends a fresh generation instead of dedup-skipping and
-            # the archived rubric_json always matches the emitted bundle's
-            # pin/flags. Absent (legacy manifest) falls back to None, the
-            # pre-change dedup behavior.
-            evidence_sha=pin.get("snapshot_id"),
-            rubric_json=_canonical(rubric),
+            evidence_sha=generation_sha,
+            rubric_json=rubric_json,
             valid_at=None,
             has_posterior=False,
             reply_classifier_version=REPLY_CLASSIFIER_VERSION,

--- a/daydream/training/adjudication/canonical.py
+++ b/daydream/training/adjudication/canonical.py
@@ -18,6 +18,8 @@ only re-verifies it against the preview pin.
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -43,6 +45,24 @@ _HUMAN_ROLES = frozenset({"rater", "adjudicator"})
 
 def _canonical(payload: dict[str, Any]) -> str:
     return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _evidence_after_as_of(record: Mapping[str, Any], as_of: str | None) -> bool:
+    """Recorded-and-flagged ``as_of`` edge policy: True when any evidence entry's
+    ``created_at`` is after the pin's ``as_of`` (both parsed with
+    :func:`datetime.fromisoformat`, mirroring ``projector.py:_max_valid_at`` so
+    ``Z`` vs ``+00:00`` spelling can never mis-order the comparison). Such
+    records keep their evidence but are never gold-eligible."""
+    if not as_of:
+        return False
+    pin_dt = datetime.fromisoformat(as_of)
+    for entry in record.get("evidence") or []:
+        if not isinstance(entry, Mapping):
+            continue
+        created_at = entry.get("created_at")
+        if created_at and datetime.fromisoformat(str(created_at)) > pin_dt:
+            return True
+    return False
 
 
 class AnnotationDriftError(ValueError):
@@ -162,6 +182,7 @@ def run_canonical_harvest(
             grouped.setdefault(record_id, []).append(obs)
 
     human_adjudicated = 0
+    flagged_after_as_of: list[str] = []
     merged_records: list[dict[str, Any]] = []
     for record in materialized:
         record = dict(record)
@@ -177,6 +198,9 @@ def run_canonical_harvest(
                 record["human_labeler"] = resolved["labeler"]
                 record["human_role"] = resolved["role"]
                 human_adjudicated += 1
+        record["evidence_after_as_of"] = _evidence_after_as_of(record, pin.get("as_of"))
+        if record["evidence_after_as_of"]:
+            flagged_after_as_of.append(record_id)
         merged_records.append(record)
     merged_records.sort(key=lambda r: str(r["record_id"]))
 
@@ -232,4 +256,5 @@ def run_canonical_harvest(
         "skipped_sessions": skipped_sessions,
         "human_adjudicated": human_adjudicated,
         "record_count": len(merged_records),
+        "evidence_after_as_of": sorted(flagged_after_as_of),
     }

--- a/daydream/training/adjudication/cli.py
+++ b/daydream/training/adjudication/cli.py
@@ -520,6 +520,13 @@ def _report_items(
                 and resolved["disposition"] in DECISIVE_DISPOSITIONS
             ):
                 enriched_item["disposition"] = resolved["disposition"]
+        # Stamp the temporal axis FIRST so classify_tier sees it, matching the
+        # canonical serializer and the corpus projection (tiers.py C5/M9): an
+        # evidence-after-as_of record must classify "silver" here exactly as it
+        # does on the canonical record — never gold/posterior_eligible.
+        enriched_item["evidence_after_as_of"] = _evidence_after_as_of(
+            enriched_item, as_of
+        )
         # Outcome-bearing fields mirroring build_export_entries: the gold gate
         # has one implementation (classify_tier), and gold-eligibility comes
         # from the human-observation resolution (conflict/review-required
@@ -531,9 +538,6 @@ def _report_items(
         enriched_item["posterior_eligible"] = tier == "gold" and str(
             enriched_item["profile"]
         ) == "pr_review"
-        enriched_item["evidence_after_as_of"] = _evidence_after_as_of(
-            enriched_item, as_of
-        )
         enriched.append(enriched_item)
     return enriched
 
@@ -677,7 +681,7 @@ def handle_harvest_snapshot(argv: list[str]) -> int:
             args.archive_dir,
             observations_path=args.state_dir / _OBSERVATIONS_FILENAME,
         )
-    except (ValueError, HubUnavailableError, HydrationError) as exc:
+    except (ValueError, HubUnavailableError, HydrationError, FileNotFoundError) as exc:
         print_error(create_console(), "adjudicate harvest-snapshot failed", str(exc))
         return 1
     print_success(

--- a/daydream/training/adjudication/cli.py
+++ b/daydream/training/adjudication/cli.py
@@ -15,7 +15,8 @@ deterministic adjudication queue:
   rows only with ``--dry-run``).
 - ``report`` — print outcome-bearing vs silver/task-only coverage, class
   balance, unresolved count, inter-rater agreement, and strata; with
-  ``--conflicts``, list disagreeing-rater findings oldest-first.
+  ``--as-of``, flag evidence observed after the pin; with ``--conflicts``,
+  list disagreeing-rater findings oldest-first.
 - ``materialize`` — materialize the preview annotation snapshot
   (``sessions.jsonl`` + ``preview-manifest.json``) for one curation pin.
 - ``publish-state`` — publish adjudication state additively to the private
@@ -44,7 +45,7 @@ from pathlib import Path
 from typing import Any
 
 from daydream.archive.hydrate import HubUnavailableError, HydrationError, PublicDestinationError, _make_client
-from daydream.training.adjudication.canonical import run_canonical_harvest
+from daydream.training.adjudication.canonical import _evidence_after_as_of, run_canonical_harvest
 from daydream.training.adjudication.export import validate_export_rows, write_export_rows
 from daydream.training.adjudication.harvest import build_export_entries
 from daydream.training.adjudication.materialize import run_materialize
@@ -60,6 +61,7 @@ from daydream.training.adjudication.publish import (
 )
 from daydream.training.adjudication.queue import build_queue
 from daydream.training.adjudication.report import build_report
+from daydream.training.corpus_v2.tiers import classify_tier
 from daydream.training.labeler_versions import (
     ADJUDICATION_LABELER_VERSION,
     REPLY_CLASSIFIER_VERSION,
@@ -174,7 +176,12 @@ def _add_pin_flags(parser: argparse.ArgumentParser) -> None:
 
 
 def _pin_from_args(args: argparse.Namespace) -> dict[str, str]:
-    """Assemble the full K2 pin; versions come from ``labeler_versions``."""
+    """Assemble the full K2 pin; versions come from ``labeler_versions``.
+
+    ``as_of`` is the one component that may be empty or absent — the unpinned
+    edge (``snapshot.snapshot_id`` hashes it as the empty string), so omitting
+    ``--as-of`` materializes an unpinned snapshot instead of failing.
+    """
     pin = {
         "curation_id": args.curation_id or "",
         "sanitized_hub_commit": args.sanitized_hub_commit or "",
@@ -186,7 +193,9 @@ def _pin_from_args(args: argparse.Namespace) -> dict[str, str]:
         "rubric_version": RUBRIC_SCHEMA_VERSION,
         "classifier_version": REPLY_CLASSIFIER_VERSION,
     }
-    missing = sorted(field for field, value in pin.items() if not value)
+    missing = sorted(
+        field for field, value in pin.items() if not value and field != "as_of"
+    )
     if missing:
         raise ValueError(f"pin is missing required component(s): {missing}")
     return pin
@@ -250,6 +259,9 @@ def _build_adjudicate_parser() -> argparse.ArgumentParser:
     _add_state_dir(p_report)
     p_report.add_argument("--conflicts", action="store_true",
                           help="List disagreeing-rater findings oldest-first instead of the report")
+    p_report.add_argument("--as-of", type=str, default=None, metavar="ISO_TS",
+                          help="ISO-8601 transaction-time pin; flag evidence observed "
+                               "after this instant (default: no as_of comparison)")
 
     p_materialize = sub.add_parser(
         "materialize",
@@ -473,8 +485,13 @@ def handle_export(argv: list[str]) -> int:
 def _report_items(
     index_root: Path,
     state_dir: Path,
+    as_of: str | None = None,
 ) -> list[dict[str, Any]]:
-    """Queue items enriched with their observation lists + effective dispositions."""
+    """Queue items enriched for the report: observation lists, effective
+    dispositions, and the outcome-bearing fields ``tier``/``posterior_eligible``/
+    ``evidence_after_as_of``, computed with the same authority as the export
+    rows (``classify_tier`` + ``effective_adjudication`` gold-eligibility) so
+    the 80% gate sees real adjudication state on the CLI path."""
     items = build_queue(_load_sessions_for_index(index_root))
     observations = load_observations(state_dir / _OBSERVATIONS_FILENAME)
     queue_ids = {str(item["record_id"]) for item in items}
@@ -493,14 +510,30 @@ def _report_items(
         enriched_item = dict(item)
         record_obs = grouped.get(str(item["record_id"]), [])
         enriched_item["observations"] = record_obs
+        gold_eligible = False
         if record_obs:
             resolved = effective_adjudication(record_obs)
+            gold_eligible = resolved["gold_eligible"]
             if (
                 resolved["role"] in ("rater", "adjudicator")
                 and resolved["evidence_digest"] == str(item["evidence_digest"])
                 and resolved["disposition"] in DECISIVE_DISPOSITIONS
             ):
                 enriched_item["disposition"] = resolved["disposition"]
+        # Outcome-bearing fields mirroring build_export_entries: the gold gate
+        # has one implementation (classify_tier), and gold-eligibility comes
+        # from the human-observation resolution (conflict/review-required
+        # decisive judgments stay out of the gold tier).
+        tier = classify_tier(enriched_item)
+        if tier == "gold" and not gold_eligible:
+            tier = "task-only"
+        enriched_item["tier"] = tier
+        enriched_item["posterior_eligible"] = tier == "gold" and str(
+            enriched_item["profile"]
+        ) == "pr_review"
+        enriched_item["evidence_after_as_of"] = _evidence_after_as_of(
+            enriched_item, as_of
+        )
         enriched.append(enriched_item)
     return enriched
 
@@ -511,7 +544,7 @@ def handle_report(argv: list[str]) -> int:
 
     args = _build_adjudicate_parser().parse_args(["report", *argv])
     try:
-        enriched = _report_items(args.index_root, args.state_dir)
+        enriched = _report_items(args.index_root, args.state_dir, as_of=args.as_of)
     except ValueError as exc:
         print_error(create_console(), "adjudicate report failed", str(exc))
         return 1
@@ -600,7 +633,7 @@ def handle_publish_state(argv: list[str]) -> int:
         summary = publish_annotation_state(
             client, args.state_dir, manifest=args.manifest, batch_complete=args.batch_complete,
         )
-    except (ValueError, HubUnavailableError, HydrationError, PublicDestinationError) as exc:
+    except (ValueError, HubUnavailableError, HydrationError, PublicDestinationError, FileNotFoundError) as exc:
         print_error(create_console(), "adjudicate publish-state failed", str(exc))
         return 1
     message = f"Published {len(summary['uploaded'])} file(s) under {summary['prefix']}"

--- a/daydream/training/adjudication/cli.py
+++ b/daydream/training/adjudication/cli.py
@@ -522,11 +522,21 @@ def handle_report(argv: list[str]) -> int:
     coverage = report["outcome_coverage"]
     balance = report["class_balance"]
     inter_rater = report["inter_rater"]
+    gate = report["admission_gate"]
     print(f"outcome-bearing coverage: adjudicated {coverage['adjudicated']} / {coverage['total']}")
     print(f"silver/task-only: {report['silver_task_only_count']}")
     print(f"class balance: accepted={balance['accepted']} rejected={balance['rejected']}")
     print(f"unresolved: {report['unresolved']}")
     print(f"inter-rater: {inter_rater['items']} item(s), {inter_rater['agreeing']} agreeing")
+    print(
+        f"evidence after as_of: {len(report['evidence_after_as_of'])} "
+        f"record(s){': ' + ', '.join(report['evidence_after_as_of']) if report['evidence_after_as_of'] else ''}"
+    )
+    print(
+        f"admission gate: {gate['outcome_bearing_total']}/{gate['total']} outcome-bearing "
+        f"(80% gate {'PASS' if gate['passes_80pct'] else 'FAIL'}, "
+        f"class balance {'ok' if gate['class_balance_ok'] else 'unbalanced'})"
+    )
     print("strata:")
     for (stack, profile), count in report["strata"].items():
         print(f"  ({stack}, {profile}): {count}")

--- a/daydream/training/adjudication/cli.py
+++ b/daydream/training/adjudication/cli.py
@@ -16,6 +16,16 @@ deterministic adjudication queue:
 - ``report`` — print outcome-bearing vs silver/task-only coverage, class
   balance, unresolved count, inter-rater agreement, and strata; with
   ``--conflicts``, list disagreeing-rater findings oldest-first.
+- ``materialize`` — materialize the preview annotation snapshot
+  (``sessions.jsonl`` + ``preview-manifest.json``) for one curation pin.
+- ``publish-state`` — publish adjudication state additively to the private
+  Hub under ``annotations/<curation-id>/<snapshot-id>/`` with an optional
+  batch checkpoint (``--batch-complete``).
+- ``resume-state`` — restore published adjudication state onto a fresh VM
+  from the Hub-side checkpoint, digest-verified.
+- ``harvest-snapshot`` — canonical harvest of the materialized preview
+  snapshot: drift gate, precedence merge, exactly-once
+  ``label_observations`` append, and ``annotations.jsonl`` emission.
 
 Every handler returns an int exit code (never calls ``sys.exit`` itself);
 argparse converts malformed invocations into ``SystemExit(2)``. Unknown
@@ -33,26 +43,43 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from daydream.archive.hydrate import HydrationError
+from daydream.archive.hydrate import HubUnavailableError, HydrationError, PublicDestinationError, _make_client
+from daydream.training.adjudication.canonical import run_canonical_harvest
 from daydream.training.adjudication.export import validate_export_rows, write_export_rows
 from daydream.training.adjudication.harvest import build_export_entries
+from daydream.training.adjudication.materialize import run_materialize
 from daydream.training.adjudication.observations import (
     append_observation,
     load_observations,
 )
 from daydream.training.adjudication.precedence import DECISIVE_DISPOSITIONS, effective_adjudication, has_rater_conflict
 from daydream.training.adjudication.preview import run_preview
+from daydream.training.adjudication.publish import (
+    publish_annotation_state,
+    resume_annotation_state,
+)
 from daydream.training.adjudication.queue import build_queue
 from daydream.training.adjudication.report import build_report
+from daydream.training.labeler_versions import (
+    ADJUDICATION_LABELER_VERSION,
+    REPLY_CLASSIFIER_VERSION,
+    RUBRIC_SCHEMA_VERSION,
+)
 
 __all__ = [
     "handle_adjudicate",
     "handle_build",
     "handle_export",
+    "handle_harvest_snapshot",
     "handle_label",
+    "handle_materialize",
+    "handle_publish_state",
     "handle_report",
+    "handle_resume_state",
     "handle_show",
 ]
+
+_ANNOTATION_HUB_REPO = "existentialbirds/daydream-trajectories"
 
 _HUMAN_ROLES = frozenset({"rater", "adjudicator"})
 
@@ -130,6 +157,41 @@ def _positive_int(raw: str) -> int:
     return value
 
 
+def _add_pin_flags(parser: argparse.ArgumentParser) -> None:
+    """Add the K2 preview-pin flags (shared by the snapshot-pipeline verbs).
+
+    Versions come from ``labeler_versions`` constants, not flags. Missing
+    components surface as exit 1 from the handler with the field named
+    (``snapshot_id`` validates the assembled pin), never exit 2 — a missing
+    pin component is a data problem, not a malformed invocation.
+    """
+    parser.add_argument("--curation-id", type=str, default=None, metavar="ID")
+    parser.add_argument("--sanitized-hub-commit", type=str, default=None, metavar="SHA")
+    parser.add_argument("--source-hub-commit", type=str, default=None, metavar="SHA")
+    parser.add_argument("--archive-index-digest", type=str, default=None, metavar="HEX")
+    parser.add_argument("--evidence-observed-at", type=str, default=None, metavar="ISO_TS")
+    parser.add_argument("--as-of", type=str, default=None, metavar="ISO_TS")
+
+
+def _pin_from_args(args: argparse.Namespace) -> dict[str, str]:
+    """Assemble the full K2 pin; versions come from ``labeler_versions``."""
+    pin = {
+        "curation_id": args.curation_id or "",
+        "sanitized_hub_commit": args.sanitized_hub_commit or "",
+        "source_hub_commit": args.source_hub_commit or "",
+        "archive_index_digest": args.archive_index_digest or "",
+        "evidence_observed_at": args.evidence_observed_at or "",
+        "as_of": args.as_of or "",
+        "labeler_version": ADJUDICATION_LABELER_VERSION,
+        "rubric_version": RUBRIC_SCHEMA_VERSION,
+        "classifier_version": REPLY_CLASSIFIER_VERSION,
+    }
+    missing = sorted(field for field, value in pin.items() if not value)
+    if missing:
+        raise ValueError(f"pin is missing required component(s): {missing}")
+    return pin
+
+
 def _add_state_dir(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--state-dir", type=Path, required=True, metavar="PATH",
                         help="Adjudication state directory (queue.json + observations.jsonl)")
@@ -188,6 +250,52 @@ def _build_adjudicate_parser() -> argparse.ArgumentParser:
     _add_state_dir(p_report)
     p_report.add_argument("--conflicts", action="store_true",
                           help="List disagreeing-rater findings oldest-first instead of the report")
+
+    p_materialize = sub.add_parser(
+        "materialize",
+        help="Materialize the preview annotation snapshot (sessions.jsonl + manifest).",
+    )
+    p_materialize.add_argument("--index-root", type=Path, required=True, metavar="PATH",
+                               help="Hydrated index root containing sessions.jsonl")
+    p_materialize.add_argument("--out-dir", type=Path, required=True, metavar="PATH",
+                               help="Directory for sessions.jsonl + preview-manifest.json")
+    _add_pin_flags(p_materialize)
+
+    p_publish = sub.add_parser(
+        "publish-state",
+        help="Publish adjudication state additively to the private Hub.",
+    )
+    _add_state_dir(p_publish)
+    p_publish.add_argument("--manifest", type=Path, required=True, metavar="PATH",
+                           help="Preview manifest pinning the snapshot")
+    p_publish.add_argument("--hub-repo", type=str, default=_ANNOTATION_HUB_REPO, metavar="REPO",
+                           help=f"Private Hub dataset repo (default: {_ANNOTATION_HUB_REPO})")
+    p_publish.add_argument("--batch-complete", action="store_true",
+                           help="Write the checkpoints/batch-latest.json checkpoint")
+
+    p_resume = sub.add_parser(
+        "resume-state",
+        help="Restore published adjudication state onto a fresh VM (digest-verified).",
+    )
+    p_resume.add_argument("--manifest", type=Path, required=True, metavar="PATH",
+                          help="Preview manifest pinning the snapshot")
+    p_resume.add_argument("--stage-dir", type=Path, required=True, metavar="PATH",
+                          help="Directory to restore the published state files into")
+    p_resume.add_argument("--hub-repo", type=str, default=_ANNOTATION_HUB_REPO, metavar="REPO",
+                          help=f"Private Hub dataset repo (default: {_ANNOTATION_HUB_REPO})")
+
+    p_harvest = sub.add_parser(
+        "harvest-snapshot",
+        help="Canonical harvest: drift gate, precedence merge, label_observations append.",
+    )
+    p_harvest.add_argument("--index-root", type=Path, required=True, metavar="PATH",
+                           help="Hydrated index root containing sessions.jsonl")
+    p_harvest.add_argument("--materialize-dir", type=Path, required=True, metavar="PATH",
+                           help="Directory produced by `materialize` (manifest + sessions.jsonl)")
+    p_harvest.add_argument("--archive-dir", type=Path, required=True, metavar="PATH",
+                           help="Archive directory holding the SQLite label-observations index")
+    p_harvest.add_argument("--state-dir", type=Path, required=True, metavar="PATH",
+                           help="Adjudication state directory (observations.jsonl source)")
 
     return parser
 
@@ -451,12 +559,104 @@ def _print_conflicts(enriched: list[dict[str, Any]]) -> None:
             )
 
 
+def handle_materialize(argv: list[str]) -> int:
+    """Handle ``corpus adjudicate materialize --index-root <path> --out-dir <path> ...``."""
+    from daydream.ui import create_console, print_error, print_success
+
+    parser = _build_adjudicate_parser()
+    args = parser.parse_args(["materialize", *argv])
+    try:
+        pin = _pin_from_args(args)
+        summary = run_materialize(args.index_root, args.out_dir, pin=pin)
+    except (ValueError, HubUnavailableError, HydrationError) as exc:
+        print_error(create_console(), "adjudicate materialize failed", str(exc))
+        return 1
+    print_success(
+        create_console(),
+        f"Materialized snapshot {summary['snapshot_id'][:12]}: "
+        f"{summary['record_count']} record(s) from index revision "
+        f"{summary['index_revision'][:12]} -> {args.out_dir}",
+    )
+    return 0
+
+
+def handle_publish_state(argv: list[str]) -> int:
+    """Handle ``corpus adjudicate publish-state --state-dir <path> --manifest <path>``."""
+    from daydream.ui import create_console, print_error, print_success
+
+    args = _build_adjudicate_parser().parse_args(["publish-state", *argv])
+    try:
+        client = _make_client(args.hub_repo)
+        summary = publish_annotation_state(
+            client, args.state_dir, manifest=args.manifest, batch_complete=args.batch_complete,
+        )
+    except (ValueError, HubUnavailableError, HydrationError, PublicDestinationError) as exc:
+        print_error(create_console(), "adjudicate publish-state failed", str(exc))
+        return 1
+    message = f"Published {len(summary['uploaded'])} file(s) under {summary['prefix']}"
+    if "observation_count" in summary:
+        message += f" (checkpoint: {summary['observation_count']} observation(s))"
+    print_success(create_console(), message)
+    return 0
+
+
+def handle_resume_state(argv: list[str]) -> int:
+    """Handle ``corpus adjudicate resume-state --manifest <path> --stage-dir <path>``."""
+    from daydream.ui import create_console, print_error, print_success
+
+    args = _build_adjudicate_parser().parse_args(["resume-state", *argv])
+    try:
+        client = _make_client(args.hub_repo)
+        summary = resume_annotation_state(client, manifest=args.manifest, stage_dir=args.stage_dir)
+    except (ValueError, HubUnavailableError, HydrationError, PublicDestinationError) as exc:
+        print_error(create_console(), "adjudicate resume-state failed", str(exc))
+        return 1
+    if summary["restored"]:
+        print_success(
+            create_console(),
+            f"Restored {len(summary['restored'])} file(s) "
+            f"({summary['observation_count']} observation(s)) -> {args.stage_dir}",
+        )
+    else:
+        print_success(create_console(), "Nothing published yet; empty state restored.")
+    return 0
+
+
+def handle_harvest_snapshot(argv: list[str]) -> int:
+    """Handle ``corpus adjudicate harvest-snapshot --index-root --materialize-dir ...``."""
+    from daydream.ui import create_console, print_error, print_success
+
+    args = _build_adjudicate_parser().parse_args(["harvest-snapshot", *argv])
+    try:
+        summary = run_canonical_harvest(
+            args.index_root,
+            args.materialize_dir,
+            args.archive_dir,
+            observations_path=args.state_dir / _OBSERVATIONS_FILENAME,
+        )
+    except (ValueError, HubUnavailableError, HydrationError) as exc:
+        print_error(create_console(), "adjudicate harvest-snapshot failed", str(exc))
+        return 1
+    print_success(
+        create_console(),
+        f"Harvested {summary['record_count']} record(s): "
+        f"{summary['appended_sessions']} session(s) appended, "
+        f"{summary['skipped_sessions']} skipped (already harvested), "
+        f"{summary['human_adjudicated']} human-adjudicated",
+    )
+    return 0
+
+
 _HANDLERS = {
     "build": handle_build,
     "show": handle_show,
     "label": handle_label,
     "export": handle_export,
     "report": handle_report,
+    "materialize": handle_materialize,
+    "publish-state": handle_publish_state,
+    "resume-state": handle_resume_state,
+    "harvest-snapshot": handle_harvest_snapshot,
 }
 
 

--- a/daydream/training/adjudication/materialize.py
+++ b/daydream/training/adjudication/materialize.py
@@ -173,6 +173,11 @@ def run_materialize(
         # plus the sanitized per-run trajectories (read-only).
         sessions, index_revision = _sessions_from_hydrated_stage(index_root)
 
+    # Validate the pin before touching its components in the loop body:
+    # ``snapshot_id`` raises the documented ValueError naming the missing
+    # component, never a KeyError from ``pin["evidence_observed_at"]``.
+    pin_id = snapshot_id(pin)
+
     records: list[dict[str, Any]] = []
     for session in sessions:
         resolutions = session.get("resolutions")
@@ -196,7 +201,7 @@ def run_materialize(
 
     id_digest = hashlib.sha256(
         (
-            snapshot_id(pin)
+            pin_id
             + ":"
             + hashlib.sha256(
                 "".join(str(r["evidence_digest"]) for r in records).encode("utf-8")

--- a/daydream/training/adjudication/materialize.py
+++ b/daydream/training/adjudication/materialize.py
@@ -5,8 +5,9 @@ shared serializer (``snapshot.build_canonical_record``) and emits a
 deterministic ``sessions.jsonl`` plus a pin-pinned ``preview-manifest.json``.
 
 Preview mode guarantees (AC 4 / M2): never appends ``label_observations``,
-never writes any resume-cache or harvest-complete marker, never touches the
-archive SQLite index — this module does not even import ``archive.index``.
+never writes any resume-cache or harvest-complete marker. When the input is a
+hydrated staging archive the SQLite index is only ever **read** (via
+``archive.index.query_runs``) — never written.
 """
 
 from __future__ import annotations
@@ -17,6 +18,7 @@ import os
 from pathlib import Path
 from typing import Any, cast, get_args
 
+from daydream.archive.hydrate import HubUnavailableError
 from daydream.training.adjudication.preview import _load_sessions
 from daydream.training.adjudication.queue import _NON_DECISIVE_DISPOSITIONS
 from daydream.training.adjudication.snapshot import build_canonical_record, snapshot_id
@@ -38,6 +40,68 @@ def _write_atomic(out_path: Path, payload: str) -> None:
     tmp_path = out_path.with_name(out_path.name + ".tmp")
     tmp_path.write_text(payload, encoding="utf-8")
     os.replace(tmp_path, out_path)
+
+
+def _sessions_from_hydrated_stage(index_root: Path) -> tuple[list[dict[str, Any]], str]:
+    """Build queue-consumable session records from a hydrated staging archive.
+
+    A hydrated staging archive (``archive.hydrate.run_hydrate_hub``) has no
+    ``sessions.jsonl``: its sessions live in the SQLite index plus one
+    sanitized ``trajectory.json`` per run under ``runs/<session_id>/``, whose
+    ``resolutions`` carry the #980 semantic dispositions. This adapter joins
+    the two into the same session shape ``_load_sessions`` returns — read-only
+    over the index, fail-closed on any missing or adjudication-empty run.
+
+    The index revision is the pinned source commit (the single revision
+    directory under ``downloads/``) — a full 40-hex SHA, exactly what the
+    publication machinery's pinned-revision resolver accepts.
+    """
+    if not (index_root / "index.db").is_file():
+        raise HubUnavailableError(
+            f"hydrated index sessions file not found: {index_root / 'sessions.jsonl'}"
+        )
+    from daydream.archive.index import query_runs
+
+    sessions: list[dict[str, Any]] = []
+    for row in query_runs(index_root):
+        session_id = str(row["session_id"])
+        trajectory_path = index_root / "runs" / session_id / "trajectory.json"
+        if not trajectory_path.is_file():
+            raise HubUnavailableError(
+                f"hydrated index run {session_id!r} has no trajectory at {trajectory_path}"
+            )
+        try:
+            trajectory = json.loads(trajectory_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            raise HubUnavailableError(
+                f"unreadable hydrated trajectory at {trajectory_path}: {exc}"
+            ) from exc
+        resolutions = trajectory.get("resolutions") if isinstance(trajectory, dict) else None
+        if not isinstance(resolutions, list) or not resolutions:
+            raise HubUnavailableError(
+                f"hydrated trajectory for session {session_id!r} carries no "
+                "per-finding resolutions to materialize"
+            )
+        sessions.append(
+            {
+                "session_id": session_id,
+                "trajectory_id": session_id,
+                "segment_id": session_id,
+                "resolutions": resolutions,
+            }
+        )
+    if not sessions:
+        raise HubUnavailableError(f"hydrated index at {index_root} has no runs")
+    downloads = index_root / "downloads"
+    if not downloads.is_dir():
+        raise HubUnavailableError(f"hydrated index at {index_root} has no downloads/ revision pin")
+    revisions = sorted(p.name for p in downloads.iterdir() if p.is_dir())
+    if len(revisions) != 1:
+        raise HubUnavailableError(
+            f"hydrated index at {index_root} has {len(revisions)} downloaded revisions; "
+            "expected exactly one pinned source commit"
+        )
+    return sessions, revisions[0]
 
 
 def _resolution_from_row(row: dict[str, Any]) -> PerFindingResolution:
@@ -102,7 +166,12 @@ def run_materialize(
     ``dry_run=True`` validates everything and returns the summary without
     writing any file.
     """
-    sessions, index_revision = _load_sessions(index_root)
+    if (index_root / _SESSIONS_OUT_FILENAME).is_file():
+        sessions, index_revision = _load_sessions(index_root)
+    else:
+        # Hydrated staging archive: derive the sessions from the SQLite index
+        # plus the sanitized per-run trajectories (read-only).
+        sessions, index_revision = _sessions_from_hydrated_stage(index_root)
 
     records: list[dict[str, Any]] = []
     for session in sessions:

--- a/daydream/training/adjudication/materialize.py
+++ b/daydream/training/adjudication/materialize.py
@@ -1,0 +1,154 @@
+"""Preview materialization of per-finding annotation snapshots (issue #1055).
+
+Runs the #980 semantic resolutions stored in a hydrated index through the
+shared serializer (``snapshot.build_canonical_record``) and emits a
+deterministic ``sessions.jsonl`` plus a pin-pinned ``preview-manifest.json``.
+
+Preview mode guarantees (AC 4 / M2): never appends ``label_observations``,
+never writes any resume-cache or harvest-complete marker, never touches the
+archive SQLite index — this module does not even import ``archive.index``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any, cast, get_args
+
+from daydream.training.adjudication.preview import _load_sessions
+from daydream.training.adjudication.queue import _NON_DECISIVE_DISPOSITIONS
+from daydream.training.adjudication.snapshot import build_canonical_record, snapshot_id
+from daydream.training.labeler_signals import PerFindingDisposition, PerFindingResolution
+
+__all__ = ["run_materialize"]
+
+_SESSIONS_OUT_FILENAME = "sessions.jsonl"
+_MANIFEST_FILENAME = "preview-manifest.json"
+
+
+def _canonical(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _write_atomic(out_path: Path, payload: str) -> None:
+    """Temp-file + ``os.replace`` write, mirroring ``export.write_export_rows``."""
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = out_path.with_name(out_path.name + ".tmp")
+    tmp_path.write_text(payload, encoding="utf-8")
+    os.replace(tmp_path, out_path)
+
+
+def _resolution_from_row(row: dict[str, Any]) -> PerFindingResolution:
+    """Rebuild the #980 semantic-resolution object from a stored index row.
+
+    Fail-closed: a stored row missing a required field raises ``ValueError``
+    naming the field and fingerprint — never ``None``-coerced into a record.
+    """
+    fingerprint = row.get("fingerprint")
+    disposition = row.get("disposition")
+    evidence_digest = row.get("evidence_digest")
+    if not isinstance(fingerprint, str) or not fingerprint:
+        raise ValueError(f"materialize: stored resolution is missing 'fingerprint': {row!r}")
+    if not isinstance(disposition, str) or not disposition:
+        raise ValueError(
+            f"materialize: resolution for fingerprint {fingerprint!r} is missing 'disposition'"
+        )
+    if not isinstance(evidence_digest, str) or not evidence_digest:
+        raise ValueError(
+            f"materialize: resolution for fingerprint {fingerprint!r} is missing 'evidence_digest'"
+        )
+    if disposition not in get_args(PerFindingDisposition):
+        raise ValueError(
+            f"materialize: resolution for fingerprint {fingerprint!r} has unknown "
+            f"disposition {disposition!r}"
+        )
+    typed_disposition = cast(PerFindingDisposition, disposition)
+    return PerFindingResolution(
+        fingerprint=fingerprint,
+        comment_id=row.get("comment_id"),
+        disposition=typed_disposition,
+        evidence=list(row.get("evidence") or []),
+        evidence_digest=evidence_digest,
+    )
+
+
+def run_materialize(
+    index_root: Path,
+    out_dir: Path,
+    *,
+    pin: dict[str, str],
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Materialize the preview snapshot for one curation pin.
+
+    Loads the hydrated index's sessions (via ``preview._load_sessions`` —
+    raises the ``HydrationError`` family on a missing/unreadable index and
+    ``MovingBranchError`` on a symbolic index revision), builds one canonical
+    record per non-decisive finding, and emits:
+
+    - ``out_dir/sessions.jsonl``: canonical-JSON records sorted by
+      ``record_id``, written atomically. Identical index + pin ⇒
+      byte-identical file (C4).
+    - ``out_dir/preview-manifest.json``: all K2 pin components plus the
+      content-addressed ``snapshot_id`` and ``index_revision``, canonical JSON.
+
+    The ``snapshot_id`` is derived from the pin + the emitted records'
+    evidence digests, so any evidence change yields a new id (AC 8) — a stale
+    id is never reused. Missing/empty pin components raise ``ValueError``
+    naming the field (propagated from ``snapshot.snapshot_id``).
+
+    ``dry_run=True`` validates everything and returns the summary without
+    writing any file.
+    """
+    sessions, index_revision = _load_sessions(index_root)
+
+    records: list[dict[str, Any]] = []
+    for session in sessions:
+        resolutions = session.get("resolutions")
+        if not isinstance(resolutions, list):
+            continue
+        for row in resolutions:
+            if not isinstance(row, dict):
+                raise ValueError(f"materialize: non-object resolution row in session data: {row!r}")
+            resolution = _resolution_from_row(row)
+            if resolution.disposition not in _NON_DECISIVE_DISPOSITIONS:
+                continue
+            records.append(
+                build_canonical_record(
+                    session,
+                    resolution,
+                    evidence_observed_at=pin["evidence_observed_at"],
+                    as_of=pin.get("as_of"),
+                )
+            )
+    records.sort(key=lambda r: str(r["record_id"]))
+
+    id_digest = hashlib.sha256(
+        (
+            snapshot_id(pin)
+            + ":"
+            + hashlib.sha256(
+                "".join(str(r["evidence_digest"]) for r in records).encode("utf-8")
+            ).hexdigest()
+        ).encode("utf-8")
+    ).hexdigest()
+
+    summary: dict[str, Any] = {
+        "snapshot_id": id_digest,
+        "index_revision": index_revision,
+        "record_count": len(records),
+    }
+    if dry_run:
+        return summary
+
+    _write_atomic(
+        out_dir / _SESSIONS_OUT_FILENAME,
+        "".join(_canonical(r) + "\n" for r in records),
+    )
+    manifest: dict[str, Any] = dict(pin)
+    manifest["snapshot_id"] = id_digest
+    manifest["index_revision"] = index_revision
+    _write_atomic(out_dir / _MANIFEST_FILENAME, _canonical(manifest))
+    return summary

--- a/daydream/training/adjudication/preview.py
+++ b/daydream/training/adjudication/preview.py
@@ -5,7 +5,7 @@ digest-pinned, canonical-JSON ledger so an operator can inspect exactly what a
 subsequent canonical harvest would adjudicate *before* running it. The ledger
 pins per-finding evidence digests (delta on
 ``corpus_v2.bundle``'s bundle-digest SHA256SUMS verification and
-``corpus_v2.projector._verify_snapshot_pinned``), and a re-preview against an
+the projector's two-bundle verification), and a re-preview against an
 existing ledger reports any ``record_id`` whose evidence digest changed —
 drift is surfaced, never silently merged.
 """

--- a/daydream/training/adjudication/publish.py
+++ b/daydream/training/adjudication/publish.py
@@ -247,9 +247,17 @@ def publish_annotation_state(
 
 
 def _bundle_payloads(bundle_dir: Path) -> dict[str, bytes]:
-    """Read every file in ``bundle_dir`` (sorted, deterministic order)."""
+    """Read every file in ``bundle_dir`` (sorted, deterministic order).
+
+    ``_SUCCESS`` and ``SHA256SUMS`` are generated fresh below and must never
+    leak in from a prior publication: a stale local marker in the payload set
+    would skew the pinned checksums and break clean-download verification
+    (the marker actually uploaded is the freshly staged one).
+    """
     payloads = {
-        p.name: p.read_bytes() for p in sorted(bundle_dir.iterdir()) if p.is_file()
+        p.name: p.read_bytes()
+        for p in sorted(bundle_dir.iterdir())
+        if p.is_file() and p.name not in {_SUCCESS_FILENAME, _SUMS_FILENAME}
     }
     if not payloads:
         raise ValueError(f"publish final bundle: {bundle_dir} contains no files")

--- a/daydream/training/adjudication/publish.py
+++ b/daydream/training/adjudication/publish.py
@@ -1,0 +1,288 @@
+"""Durable adjudication-state publication + fresh-VM resume (issue #1055, Task 3).
+
+Mirrors ``archive/hydrate.py``'s publication machinery (``HubClient``,
+additive content-addressed upload, ``PublicDestinationError``,
+``_retry_upload`` retry seam) under a new
+``annotations/<curation-id>/<snapshot-id>/`` prefix. The Hub checkpoint under
+``checkpoints/batch-latest.json`` is the canonical resume state — the VM-local
+``--state-dir`` is scratch only.
+
+Credentials (C1): this module never reads or embeds tokens; ``HF_TOKEN`` is
+consumed only by the real ``HfHubClient`` wiring.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any, Mapping
+
+from daydream.archive.hydrate import (
+    HubClient,
+    HubUnavailableError,
+    HydrationError,
+    PublicDestinationError,
+    _retry_upload,
+)
+from daydream.trajectory import redact_text
+
+__all__ = [
+    "annotation_prefix",
+    "publish_annotation_state",
+    "resume_annotation_state",
+]
+
+# State files published under the snapshot prefix (stable order for digests).
+_STATE_FILES = ("queue.json", "observations.jsonl", "preview-ledger.json")
+_MANIFEST_FILENAME = "preview-manifest.json"
+_CHECKPOINT_RELPATH = "checkpoints/batch-latest.json"
+
+# HF_TOKEN-shaped values (fail-closed secret scan, S1). A hit means a live
+# credential leaked into a payload; publication is refused, never scrubbed.
+_SECRET_SHAPES = re.compile(r"(?:hf_[0-9A-Za-z]{20,}|github_pat_[0-9A-Za-z_]{20,}|ghp_[0-9A-Za-z]{20,})")
+
+
+def _read_manifest_data(manifest: Path | Mapping[str, Any]) -> dict[str, Any]:
+    if isinstance(manifest, Mapping):
+        return dict(manifest)
+    try:
+        data: dict[str, Any] = json.loads(Path(manifest).read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise ValueError(f"publish: unreadable preview manifest {manifest}: {exc}") from exc
+    return data
+
+
+def annotation_prefix(manifest: Path | Mapping[str, Any]) -> str:
+    """Content-addressed remote prefix ``annotations/<curation-id>/<snapshot-id>/``.
+
+    Both pin components must be present and non-empty, else ``ValueError``
+    naming the offending field (M3).
+    """
+    data = _read_manifest_data(manifest)
+    curation_id = data.get("curation_id")
+    snapshot_id = data.get("snapshot_id")
+    if not isinstance(curation_id, str) or not curation_id:
+        raise ValueError("annotation_prefix: manifest is missing required field 'curation_id'")
+    if not isinstance(snapshot_id, str) or not snapshot_id:
+        raise ValueError("annotation_prefix: manifest is missing required field 'snapshot_id'")
+    return f"annotations/{curation_id}/{snapshot_id}/"
+
+
+def _scan_for_secrets(name: str, data: bytes) -> None:
+    """Fail-closed secret scan (S1): refuse to upload credential-shaped payloads."""
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise PublicDestinationError(f"{name}: payload is not valid UTF-8: {exc}") from exc
+    hit = _SECRET_SHAPES.search(text)
+    if hit is not None:
+        raise PublicDestinationError(f"{name}: refusing to publish: credential-shaped value detected in payload")
+
+
+def _digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _observation_key(line: str, record: dict[str, Any]) -> str:
+    observed_at = record.get("observed_at")
+    record_id = record.get("record_id")
+    if isinstance(record_id, str) and record_id and isinstance(observed_at, str) and observed_at:
+        return f"{record_id}\x00{observed_at}"
+    return hashlib.sha256(line.encode("utf-8")).hexdigest()
+
+
+def _merge_observations(remote: bytes | None, local: bytes) -> bytes:
+    """Append-only merge (M4): remote lines first, then new local lines.
+
+    Dedup key is ``record_id + observed_at`` (falling back to line digest when
+    either is absent); local lines already present remotely are dropped so a
+    re-publish never duplicates, and remote history is never truncated.
+    """
+    if not local.strip():
+        return remote or b""
+    local_lines = [ln for ln in local.decode("utf-8").splitlines() if ln.strip()]
+    remote_lines: list[str] = []
+    seen: set[str] = set()
+    if remote is not None:
+        for line in remote.decode("utf-8").splitlines():
+            if not line.strip():
+                continue
+            remote_lines.append(line)
+            try:
+                seen.add(_observation_key(line, json.loads(line)))
+            except ValueError:
+                seen.add(_observation_key(line, {}))
+    out_lines = list(remote_lines)
+    for line in local_lines:
+        try:
+            key = _observation_key(line, json.loads(line))
+        except ValueError:
+            key = _observation_key(line, {})
+        if key in seen:
+            continue
+        seen.add(key)
+        out_lines.append(line)
+    return ("".join(ln + "\n" for ln in out_lines)).encode("utf-8")
+
+
+def _read_state_file(state_dir: Path, name: str) -> bytes:
+    return (state_dir / name).read_bytes()
+
+
+def _upload(client: HubClient, mapping: dict[str | Path, Path], commit_message: str) -> None:
+    """Upload through hydrate's retry seam; failures become redacted HubUnavailableError."""
+    try:
+        _retry_upload(client, mapping, commit_message)
+    except HydrationError as exc:
+        raise HubUnavailableError(redact_text(str(exc))) from exc
+
+
+def publish_annotation_state(
+    client: HubClient,
+    state_dir: Path,
+    *,
+    manifest: Path | Mapping[str, Any],
+    batch_complete: bool = False,
+) -> dict[str, Any]:
+    """Publish adjudication state additively under the snapshot prefix (M3/M4).
+
+    Mirrors ``hydrate.publish_batches``: hard-fails with
+    :class:`PublicDestinationError` when the repo is not private **before any
+    byte is written**, runs the S1 secret scan over every payload, then uploads
+    ``queue.json``, ``observations.jsonl``, ``preview-ledger.json`` and the
+    preview manifest additively (re-upload idempotent; observations merged
+    append-only). When ``batch_complete`` a remote checkpoint
+    ``checkpoints/batch-latest.json`` is written with the observation count,
+    latest ``observed_at`` and sha256 digests of every published file — the
+    Hub-side canonical state for fresh-VM resume.
+    """
+    if not client.repo_private:
+        raise PublicDestinationError(
+            "refusing to publish: the Hub repo is not private; adjudication state "
+            "publishes annotation content only to private repos (M17)"
+        )
+    prefix = annotation_prefix(manifest)
+    state_dir = Path(state_dir)
+
+    manifest_bytes = (
+        Path(manifest).read_bytes()
+        if isinstance(manifest, (str, Path))
+        else json.dumps(dict(manifest), sort_keys=True, separators=(",", ":")).encode("utf-8")
+    )
+    payloads: dict[str, bytes] = {
+        "queue.json": _read_state_file(state_dir, "queue.json"),
+        "observations.jsonl": _read_state_file(state_dir, "observations.jsonl"),
+        "preview-ledger.json": _read_state_file(state_dir, "preview-ledger.json"),
+        _MANIFEST_FILENAME: manifest_bytes,
+    }
+    for name, data in payloads.items():
+        _scan_for_secrets(name, data)
+
+    # Append-only observations merge (M4): fetch the remote file and union it
+    # with the local one before upload — never truncate remote history.
+    try:
+        remote_observations = client.download_file(f"{prefix}observations.jsonl")
+    except (HydrationError, FileNotFoundError, OSError):
+        remote_observations = None
+    merged_observations = _merge_observations(remote_observations, payloads["observations.jsonl"])
+
+    # Stage payloads to disk so the upload mapping carries real file paths.
+    stage_dir = state_dir / ".publish-stage"
+    stage_dir.mkdir(parents=True, exist_ok=True)
+    mapping: dict[str | Path, Path] = {}
+    staged_bytes: dict[str, bytes] = {}
+    for name, data in payloads.items():
+        if name == "observations.jsonl":
+            data = merged_observations
+        staged_bytes[name] = data
+        staged = stage_dir / name
+        staged.write_bytes(data)
+        mapping[f"{prefix}{name}"] = staged
+    _scan_for_secrets("observations.jsonl (merged)", staged_bytes["observations.jsonl"])
+
+    checkpoint: dict[str, Any] | None = None
+    if batch_complete:
+        observation_count = sum(
+            1 for line in staged_bytes["observations.jsonl"].decode("utf-8").splitlines() if line.strip()
+        )
+        latest_observed_at: str | None = None
+        for line in staged_bytes["observations.jsonl"].decode("utf-8").splitlines():
+            if not line.strip():
+                continue
+            try:
+                observed_at = json.loads(line).get("observed_at")
+            except ValueError:
+                observed_at = None
+            if isinstance(observed_at, str) and (latest_observed_at is None or observed_at > latest_observed_at):
+                latest_observed_at = observed_at
+        checkpoint = {
+            "curation_id": prefix.split("/")[1],
+            "snapshot_id": prefix.split("/")[2],
+            "observation_count": observation_count,
+            "latest_observed_at": latest_observed_at,
+            "digests": {name: _digest(data) for name, data in staged_bytes.items()},
+        }
+        data = json.dumps(checkpoint, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        staged = stage_dir / "batch-latest.json"
+        staged.write_bytes(data)
+        mapping[f"{prefix}{_CHECKPOINT_RELPATH}"] = staged
+
+    _upload(client, mapping, f"daydream adjudication: annotation state publication {prefix}")
+
+    summary: dict[str, Any] = {"prefix": prefix, "uploaded": sorted(mapping)}
+    if checkpoint is not None:
+        summary["observation_count"] = checkpoint["observation_count"]
+    return summary
+
+
+def resume_annotation_state(
+    client: HubClient,
+    *,
+    manifest: Path | Mapping[str, Any],
+    stage_dir: Path,
+) -> dict[str, Any]:
+    """Restore adjudication state onto a fresh VM from the Hub checkpoint (M3).
+
+    Mirrors ``hydrate.resume_state``: the remote checkpoint is the canonical
+    state. Every published file is downloaded and verified against the sha256
+    digest recorded in the checkpoint (the manifest additionally against its
+    recorded digest); any mismatch raises ``ValueError`` naming the file —
+    fail closed, never a silent partial restore. A missing checkpoint yields
+    an empty-state summary (nothing published yet).
+    """
+    prefix = annotation_prefix(manifest)
+    stage_dir = Path(stage_dir)
+    try:
+        checkpoint_raw = client.download_file(f"{prefix}{_CHECKPOINT_RELPATH}")
+    except (HydrationError, FileNotFoundError, OSError):
+        return {"observation_count": 0, "restored": []}
+    try:
+        checkpoint = json.loads(checkpoint_raw)
+    except ValueError as exc:
+        raise ValueError(f"{_CHECKPOINT_RELPATH}: corrupt checkpoint JSON: {exc}") from exc
+    digests = checkpoint.get("digests")
+    if not isinstance(digests, dict):
+        raise ValueError(f"{_CHECKPOINT_RELPATH}: checkpoint is missing 'digests'")
+
+    stage_dir.mkdir(parents=True, exist_ok=True)
+    restored: list[str] = []
+    for name in [*_STATE_FILES, _MANIFEST_FILENAME]:
+        expected = digests.get(name)
+        if not isinstance(expected, str):
+            raise ValueError(f"{_CHECKPOINT_RELPATH}: checkpoint has no digest for {name!r}")
+        data = client.download_file(f"{prefix}{name}")
+        actual = _digest(data)
+        if actual != expected:
+            raise ValueError(f"digest mismatch for {name!r}: checkpoint recorded {expected}, remote is {actual}")
+        target = stage_dir / name
+        tmp = target.with_name(target.name + ".tmp")
+        tmp.write_bytes(data)
+        os.replace(tmp, target)
+        restored.append(name)
+    return {
+        "observation_count": int(checkpoint.get("observation_count", 0)),
+        "restored": restored,
+    }

--- a/daydream/training/adjudication/publish.py
+++ b/daydream/training/adjudication/publish.py
@@ -17,6 +17,7 @@ import hashlib
 import json
 import os
 import re
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -26,12 +27,14 @@ from daydream.archive.hydrate import (
     HydrationError,
     PublicDestinationError,
     _retry_upload,
+    resolve_source_revision,
 )
 from daydream.trajectory import redact_text
 
 __all__ = [
     "annotation_prefix",
     "publish_annotation_state",
+    "publish_final_annotation_bundle",
     "resume_annotation_state",
 ]
 
@@ -39,10 +42,15 @@ __all__ = [
 _STATE_FILES = ("queue.json", "observations.jsonl", "preview-ledger.json")
 _MANIFEST_FILENAME = "preview-manifest.json"
 _CHECKPOINT_RELPATH = "checkpoints/batch-latest.json"
+_FINAL_SEGMENT = "final"
+_SUCCESS_FILENAME = "_SUCCESS"
+_SUMS_FILENAME = "SHA256SUMS"
 
 # HF_TOKEN-shaped values (fail-closed secret scan, S1). A hit means a live
 # credential leaked into a payload; publication is refused, never scrubbed.
-_SECRET_SHAPES = re.compile(r"(?:hf_[0-9A-Za-z]{20,}|github_pat_[0-9A-Za-z_]{20,}|ghp_[0-9A-Za-z]{20,})")
+# The threshold is deliberately low ({8,}) — a false positive merely blocks
+# publication, while a miss would leak a live token to a remote dataset repo.
+_SECRET_SHAPES = re.compile(r"(?:hf_[0-9A-Za-z]{8,}|github_pat_[0-9A-Za-z_]{8,}|ghp_[0-9A-Za-z]{8,})")
 
 
 def _read_manifest_data(manifest: Path | Mapping[str, Any]) -> dict[str, Any]:
@@ -236,6 +244,132 @@ def publish_annotation_state(
     if checkpoint is not None:
         summary["observation_count"] = checkpoint["observation_count"]
     return summary
+
+
+def _bundle_payloads(bundle_dir: Path) -> dict[str, bytes]:
+    """Read every file in ``bundle_dir`` (sorted, deterministic order)."""
+    payloads = {
+        p.name: p.read_bytes() for p in sorted(bundle_dir.iterdir()) if p.is_file()
+    }
+    if not payloads:
+        raise ValueError(f"publish final bundle: {bundle_dir} contains no files")
+    return payloads
+
+
+def _resolve_hub_commit(client: HubClient, manifest_data: Mapping[str, Any], sums_bytes: bytes) -> str:
+    """Resolve the Hub commit SHA under the pinned-revision policy (M6).
+
+    The manifest's ``index_revision`` is used when present; otherwise the
+    publication revision is derived from the published ``SHA256SUMS`` content
+    (stable across idempotent re-publication of identical bytes, C2).
+    ``resolve_source_revision(..., exploratory=False)`` fail-closes on symbolic
+    refs: a run without a verified Hub commit is a failure, never a best effort.
+    """
+    revision = manifest_data.get("index_revision")
+    if not isinstance(revision, str) or not revision:
+        revision = _digest(sums_bytes)[:40]
+    return resolve_source_revision(client, revision, exploratory=False)
+
+
+def publish_final_annotation_bundle(
+    client: HubClient,
+    bundle_dir: Path,
+    *,
+    manifest: Path | Mapping[str, Any],
+    verify_download: bool = True,
+    _download_verifier: Callable[[str], bool] | None = None,
+) -> dict[str, Any]:
+    """Publish the final immutable annotation bundle under ``<prefix>final/`` (M6/C3).
+
+    Strict order, each step fail-closed before anything is uploaded:
+
+    1. :class:`PublicDestinationError` when the Hub repo is not private.
+    2. S1 secret scan over every bundle file (a hit raises naming the file).
+    3. ``SHA256SUMS`` over the file set, self-excluded (mirror
+       ``hydrate.publish_batches``).
+    4. Additive upload of the bundle + manifest + sums.
+    5. Clean-download verification: every uploaded file is read back, re-hashed
+       and compared (``_download_verifier`` replaces this step when injected;
+       returning ``False`` raises ``ValueError``).
+    6. Hub commit SHA resolved via :func:`hydrate.resolve_source_revision`
+       (pinned-revision policy) — a resolution failure propagates and
+       ``_SUCCESS`` is never uploaded.
+    7. ``_SUCCESS`` uploaded **last** — its presence is the commitment that the
+       bundle is complete and verified.
+
+    Immutability (C2): publication is additive; re-publishing identical bytes
+    re-uploads the same content and the module never deletes or rewrites prior
+    snapshot prefixes.
+    """
+    if not client.repo_private:
+        raise PublicDestinationError(
+            "refusing to publish: the Hub repo is not private; annotation bundles "
+            "publish only to private repos (M17)"
+        )
+    prefix = f"{annotation_prefix(manifest)}{_FINAL_SEGMENT}/"
+    bundle_dir = Path(bundle_dir)
+    manifest_data = _read_manifest_data(manifest)
+
+    payloads = _bundle_payloads(bundle_dir)
+    for name, data in payloads.items():
+        _scan_for_secrets(name, data)
+    manifest_bytes = (
+        Path(manifest).read_bytes()
+        if isinstance(manifest, (str, Path))
+        else json.dumps(manifest_data, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    )
+    _scan_for_secrets(_MANIFEST_FILENAME, manifest_bytes)
+    payloads[_MANIFEST_FILENAME] = manifest_bytes
+
+    # SHA256SUMS covers every published file except itself (self-inclusion would
+    # make the checksum file unstable across idempotent re-publishes).
+    sums_bytes = "".join(
+        f"{_digest(data)}  {name}\n" for name, data in sorted(payloads.items())
+    ).encode("utf-8")
+
+    stage_dir = bundle_dir / ".publish-stage"
+    stage_dir.mkdir(parents=True, exist_ok=True)
+    mapping: dict[str | Path, Path] = {}
+    for name, data in payloads.items():
+        staged = stage_dir / name
+        staged.write_bytes(data)
+        mapping[f"{prefix}{name}"] = staged
+    staged_sums = stage_dir / _SUMS_FILENAME
+    staged_sums.write_bytes(sums_bytes)
+    mapping[f"{prefix}{_SUMS_FILENAME}"] = staged_sums
+    _upload(client, mapping, f"daydream adjudication: final annotation bundle {prefix}")
+
+    if verify_download:
+        expected: dict[str, bytes] = {**payloads, _SUMS_FILENAME: sums_bytes}
+        if _download_verifier is not None:
+            if not _download_verifier(prefix):
+                raise ValueError(
+                    f"final bundle download verification failed for {prefix}: "
+                    "the verifier refused the freshly uploaded bundle"
+                )
+        else:
+            for name, data in sorted(expected.items()):
+                remote = client.download_file(f"{prefix}{name}")
+                if _digest(remote) != _digest(data):
+                    raise ValueError(
+                        f"final bundle download verification failed for {prefix}: "
+                        f"re-downloaded {name!r} does not match the uploaded bytes"
+                    )
+
+    hub_commit_sha = _resolve_hub_commit(client, manifest_data, sums_bytes)
+
+    staged_success = stage_dir / _SUCCESS_FILENAME
+    staged_success.write_bytes(b"")
+    _upload(
+        client,
+        {f"{prefix}{_SUCCESS_FILENAME}": staged_success},
+        f"daydream adjudication: final annotation bundle committed {prefix}",
+    )
+    return {
+        "hub_commit_sha": hub_commit_sha,
+        "prefix": prefix,
+        "files": sorted([*payloads, _SUMS_FILENAME, _SUCCESS_FILENAME]),
+    }
 
 
 def resume_annotation_state(

--- a/daydream/training/adjudication/report.py
+++ b/daydream/training/adjudication/report.py
@@ -88,22 +88,29 @@ def build_report(items: Sequence[Mapping[str, object]]) -> dict[str, Any]:
         tier = str(item.get("tier", ""))
         posterior_eligible = bool(item.get("posterior_eligible", False))
         decisive = disposition in _DECISIVE_DISPOSITIONS
+        # Outcome-bearing records (C5/M9): gold-tier, posterior-eligible
+        # pr_review records only — task-only and silver never count, and
+        # neither do evidence-after-as_of records. Only these can ever be
+        # adjudicated, so the 80% denominator, the numerator, unresolved and
+        # class balance share one scope and a record that can never count
+        # cannot permanently block the gate.
+        outcome_bearing = (
+            decisive
+            and tier == "gold"
+            and posterior_eligible
+            and profile == "pr_review"
+            and not bool(item.get("evidence_after_as_of", False))
+        )
         if decisive:
-            if tier != "task-only":
+            if outcome_bearing:
                 decisive_total += 1
-            if not has_human_decision:
-                unresolved += 1
-            if disposition == "accepted":
-                accepted += 1
-            else:
-                rejected += 1
-            # Outcome-bearing numerator (C5/M9): gold-tier, posterior-eligible
-            # pr_review records only — task-only never counts, and neither do
-            # evidence-after-as_of records.
-            if tier == "gold" and posterior_eligible and profile == "pr_review" and not bool(
-                item.get("evidence_after_as_of", False)
-            ):
                 adjudicated += 1
+                if not has_human_decision:
+                    unresolved += 1
+                if disposition == "accepted":
+                    accepted += 1
+                else:
+                    rejected += 1
         else:
             silver_task_only += 1
 

--- a/daydream/training/adjudication/report.py
+++ b/daydream/training/adjudication/report.py
@@ -15,6 +15,9 @@ from typing import Any
 
 __all__ = ["build_report"]
 
+_DECISIVE_DISPOSITIONS = frozenset({"accepted", "rejected"})
+_ADMISSION_GATE_VERSION = 1
+
 
 def _required(item: Mapping[str, object], field: str) -> object:
     value = item.get(field)
@@ -44,6 +47,14 @@ def build_report(items: Sequence[Mapping[str, object]]) -> dict[str, Any]:
     - ``unresolved``: records with no effective human decision.
     - ``inter_rater``: agreement over records with >=2 human rater observations.
     - ``strata``: counts keyed by ``(stack, profile)``.
+    - ``evidence_after_as_of``: sorted record ids flagged by the canonical
+      harvest as having evidence observed after the ``as_of`` pin — recorded
+      and flagged, never gold-eligible (C5/M9).
+    - ``admission_gate``: the #94 admission gate over **outcome-bearing**
+      records only. ``outcome_coverage.adjudicated`` counts gold-tier,
+      ``posterior_eligible``, ``pr_review`` records and excludes
+      ``evidence_after_as_of`` records; task-only items are reported but never
+      feed the 80% denominator.
     """
     adjudicated = 0
     decisive_total = 0
@@ -54,9 +65,10 @@ def build_report(items: Sequence[Mapping[str, object]]) -> dict[str, Any]:
     inter_rater_items = 0
     inter_rater_agreeing = 0
     strata: dict[tuple[str, str], int] = {}
+    evidence_after_as_of: list[str] = []
 
     for item in items:
-        str(_required(item, "record_id"))  # fail-closed validation; id not needed for aggregation
+        record_id = str(_required(item, "record_id"))
         disposition = str(_required(item, "disposition"))
         stack = str(item.get("stack", ""))
         profile = str(item.get("profile", ""))
@@ -67,16 +79,31 @@ def build_report(items: Sequence[Mapping[str, object]]) -> dict[str, Any]:
         human = _human_dispositions(observations)
         has_human_decision = bool(human)
 
-        if disposition in {"accepted", "rejected"}:
-            decisive_total += 1
-            if has_human_decision:
-                adjudicated += 1
-            else:
+        # Recorded-and-flagged as_of edge policy: the record keeps its evidence
+        # but is never gold-eligible, so it is excluded from the outcome-bearing
+        # numerator regardless of disposition.
+        if bool(item.get("evidence_after_as_of", False)):
+            evidence_after_as_of.append(record_id)
+
+        tier = str(item.get("tier", ""))
+        posterior_eligible = bool(item.get("posterior_eligible", False))
+        decisive = disposition in _DECISIVE_DISPOSITIONS
+        if decisive:
+            if tier != "task-only":
+                decisive_total += 1
+            if not has_human_decision:
                 unresolved += 1
             if disposition == "accepted":
                 accepted += 1
             else:
                 rejected += 1
+            # Outcome-bearing numerator (C5/M9): gold-tier, posterior-eligible
+            # pr_review records only — task-only never counts, and neither do
+            # evidence-after-as_of records.
+            if tier == "gold" and posterior_eligible and profile == "pr_review" and not bool(
+                item.get("evidence_after_as_of", False)
+            ):
+                adjudicated += 1
         else:
             silver_task_only += 1
 
@@ -91,6 +118,7 @@ def build_report(items: Sequence[Mapping[str, object]]) -> dict[str, Any]:
             ):
                 inter_rater_agreeing += 1
 
+    gate_passes = decisive_total > 0 and adjudicated * 5 >= decisive_total * 4
     return {
         "outcome_coverage": {"adjudicated": adjudicated, "total": decisive_total},
         "silver_task_only_count": silver_task_only,
@@ -98,4 +126,12 @@ def build_report(items: Sequence[Mapping[str, object]]) -> dict[str, Any]:
         "unresolved": unresolved,
         "inter_rater": {"items": inter_rater_items, "agreeing": inter_rater_agreeing},
         "strata": {k: strata[k] for k in sorted(strata)},
+        "evidence_after_as_of": sorted(evidence_after_as_of),
+        "admission_gate": {
+            "outcome_bearing_total": adjudicated,
+            "total": decisive_total,
+            "passes_80pct": gate_passes,
+            "class_balance_ok": accepted > 0 and rejected > 0,
+            "gate_version": _ADMISSION_GATE_VERSION,
+        },
     }

--- a/daydream/training/adjudication/snapshot.py
+++ b/daydream/training/adjudication/snapshot.py
@@ -1,0 +1,132 @@
+"""Shared serializer for the per-finding annotation snapshot pipeline (issue #1055).
+
+One canonical per-finding record shape + evidence digest, consumed by both
+preview materialization (``materialize.py``) and canonical harvest
+(``canonical.py``). Pure module: no I/O, no wall-clock reads — determinism is
+by construction (C4).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from daydream.training.corpus_v2.identity import record_id
+from daydream.training.corpus_v2.provenance import extract_provenance
+from daydream.training.labeler_versions import (
+    ADJUDICATION_LABELER_VERSION,
+    ANNOTATION_SNAPSHOT_SCHEMA_VERSION,
+    HUMAN_LABELER_VERSION,
+    REPLY_CLASSIFIER_VERSION,
+    reply_evidence_digest,
+)
+
+__all__ = [
+    "ANNOTATION_SNAPSHOT_SCHEMA_VERSION",
+    "build_canonical_record",
+    "record_evidence_digest",
+    "snapshot_id",
+]
+
+# The K2 preview-pin components: the snapshot id is a content-addressed digest
+# over exactly these fields, so idempotence and drift detection are by
+# construction — any pin change produces a new snapshot id (AC 8).
+_PIN_FIELDS = (
+    "curation_id",
+    "sanitized_hub_commit",
+    "source_hub_commit",
+    "archive_index_digest",
+    "evidence_observed_at",
+    "as_of",
+    "labeler_version",
+    "rubric_version",
+    "classifier_version",
+)
+
+
+def record_evidence_digest(per_finding_evidence_lists: Sequence[Sequence[dict[str, Any]]]) -> str:
+    """Digest over the session's flattened per-finding reply evidence.
+
+    Delegates to ``labeler_versions.reply_evidence_digest`` — the shared
+    implementation, never a re-implementation (K4/K5; spike-verified
+    byte-identical to ``training/harvest.py:_reply_evidence_digest``).
+    """
+    evidence = [entry for per_finding in per_finding_evidence_lists for entry in per_finding]
+    return reply_evidence_digest(evidence)
+
+
+def build_canonical_record(
+    session: Mapping[str, Any],
+    resolution: Any,
+    *,
+    evidence_observed_at: str,
+    as_of: str | None = None,
+) -> dict[str, Any]:
+    """Build the canonical per-finding annotation record for one resolution.
+
+    ``record_id`` is always recomputed via ``corpus_v2.identity.record_id`` —
+    never trusted from any stored copy. Missing required fields fail closed
+    with ``ValueError`` naming the offending field (no fallback coercion).
+    """
+    fingerprint = resolution.fingerprint
+    evidence_digest = resolution.evidence_digest
+    if not isinstance(evidence_digest, str) or not evidence_digest:
+        raise ValueError(
+            f"build_canonical_record: resolution for fingerprint {fingerprint!r} is missing "
+            "required field 'evidence_digest'"
+        )
+
+    session_id = session["session_id"]
+    trajectory_id = session["trajectory_id"]
+    segment_id = session["segment_id"]
+
+    # Provenance comes from the session's resolution row joined by fingerprint.
+    rows = [row for row in session.get("resolutions") or [] if row.get("fingerprint") == fingerprint]
+    if len(rows) != 1:
+        raise ValueError(
+            f"build_canonical_record: session {session_id!r} has {len(rows)} resolution rows "
+            f"for fingerprint {fingerprint!r}; expected exactly 1"
+        )
+    provenance = extract_provenance(rows[0])
+
+    record: dict[str, Any] = {
+        "record_id": record_id(session_id, trajectory_id, segment_id, fingerprint),
+        "fingerprint": fingerprint,
+        "disposition": resolution.disposition,
+        "evidence": list(resolution.evidence),
+        "evidence_digest": evidence_digest,
+        "session_id": session_id,
+        "trajectory_id": trajectory_id,
+        "segment_id": segment_id,
+        "profile": provenance["profile"],
+        "stack": provenance["stack"],
+        "rubric_version": ADJUDICATION_LABELER_VERSION,
+        "classifier_version": REPLY_CLASSIFIER_VERSION,
+        "labeler_version": HUMAN_LABELER_VERSION,
+        "schema_version": f"annotation-snapshot/{ANNOTATION_SNAPSHOT_SCHEMA_VERSION}",
+        "evidence_observed_at": evidence_observed_at,
+    }
+    if as_of is not None:
+        record["as_of"] = as_of
+    return record
+
+
+def snapshot_id(pin: Mapping[str, str]) -> str:
+    """Content-addressed snapshot id: sha256 over canonical JSON of the pin.
+
+    The digest covers exactly the ``_PIN_FIELDS`` components with sorted keys
+    and compact separators, so the caller's key insertion order cannot affect
+    the id. Any missing or empty component raises ``ValueError`` naming it.
+    """
+    components = {}
+    for field in _PIN_FIELDS:
+        value = pin.get(field)
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"snapshot_id: pin is missing required component {field!r}")
+        components[field] = value
+    canonical = json.dumps(
+        components, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()

--- a/daydream/training/adjudication/snapshot.py
+++ b/daydream/training/adjudication/snapshot.py
@@ -107,6 +107,11 @@ def build_canonical_record(
         "labeler_version": HUMAN_LABELER_VERSION,
         "schema_version": f"annotation-snapshot/{ANNOTATION_SNAPSHOT_SCHEMA_VERSION}",
         "evidence_observed_at": evidence_observed_at,
+        # Self-contained session view: consumers that rebuild the queue or the
+        # projection from canonical records (``project_findings``/``build_queue``)
+        # consume the session shape (``resolutions`` list), and the materialized
+        # per-finding record must be directly consumable without a second shape.
+        "resolutions": [dict(rows[0])],
     }
     if as_of is not None:
         record["as_of"] = as_of

--- a/daydream/training/adjudication/snapshot.py
+++ b/daydream/training/adjudication/snapshot.py
@@ -46,15 +46,20 @@ _PIN_FIELDS = (
 )
 
 
-def record_evidence_digest(per_finding_evidence_lists: Sequence[Sequence[dict[str, Any]]]) -> str:
+def record_evidence_digest(
+    per_finding_evidence_lists: Sequence[Sequence[dict[str, Any]]],
+) -> str | None:
     """Digest over the session's flattened per-finding reply evidence.
 
     Delegates to ``labeler_versions.reply_evidence_digest`` — the shared
     implementation, never a re-implementation (K4/K5; spike-verified
     byte-identical to ``training/harvest.py:_reply_evidence_digest``).
+    ``None`` when no reply evidence was collected, matching the harvest twin
+    so a digest-less row never collides with a digested one under the
+    versioned dedup key.
     """
     evidence = [entry for per_finding in per_finding_evidence_lists for entry in per_finding]
-    return reply_evidence_digest(evidence)
+    return reply_evidence_digest(evidence) if evidence else None
 
 
 def build_canonical_record(
@@ -123,11 +128,18 @@ def snapshot_id(pin: Mapping[str, str]) -> str:
 
     The digest covers exactly the ``_PIN_FIELDS`` components with sorted keys
     and compact separators, so the caller's key insertion order cannot affect
-    the id. Any missing or empty component raises ``ValueError`` naming it.
+    the id. Every component must be present and non-empty except ``as_of``,
+    which may be empty or missing — the unpinned edge (hashed as the empty
+    string), so a pinned and an unpinned pin still produce distinct ids while
+    the unpinned form has exactly one canonical id (AC 8). Any other missing
+    or empty component raises ``ValueError`` naming it.
     """
     components = {}
     for field in _PIN_FIELDS:
         value = pin.get(field)
+        if field == "as_of" and value in (None, ""):
+            components[field] = ""
+            continue
         if not isinstance(value, str) or not value:
             raise ValueError(f"snapshot_id: pin is missing required component {field!r}")
         components[field] = value

--- a/daydream/training/corpus_v2/projector.py
+++ b/daydream/training/corpus_v2/projector.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Any, Literal, Mapping, cast, overload
 
 from daydream.archive.index import normalize_as_of
+from daydream.archive.sanitize import _derivative_digest
 from daydream.training.corpus import _is_posterior_leak, _trajectory_set_hash
 from daydream.training.corpus_v2.bundle import (
     CuratedBundle,
@@ -220,7 +221,7 @@ _ANNOTATION_SCHEMA_PREFIX = "annotation-snapshot/"
 
 
 def _verify_annotation_bundle(
-    annotation_bundle_dir: Path, bundle: CuratedBundle
+    annotation_bundle_dir: Path, bundle: CuratedBundle, bundle_dir: Path
 ) -> dict[str, Any]:
     """Two-bundle contract: the annotation bundle is verified as its own
     published artifact and then linked to the curation bundle exactly.
@@ -233,11 +234,15 @@ def _verify_annotation_bundle(
        ``ValueError``).
     3. Cross-bundle linkage against the curation bundle: ``curation_id``
        equal to ``bundle.curation_id``, ``sanitized_hub_commit`` equal to
-       ``bundle.source_hub_commit``, a recorded batch/file-set digest, a
-       compatible annotation-snapshot schema version, and
-       labeler/rubric/classifier versions plus ``as_of`` present. An empty
-       ``as_of`` is allowed (the unpinned edge) and reported through the
-       build lineage, not refused.
+       ``bundle.source_hub_commit``, a recorded ``batch_fileset_digest`` that
+       matches the curation bundle's actual batch/file-set digest
+       (``_derivative_digest`` of the bundle root — the same canonical
+       file-set vocabulary each batch's ``content_digest`` uses, so a stale
+       annotation bundle harvested against an older file set is refused
+       rather than passing on curation_id + commit alone), a compatible
+       annotation-snapshot schema version, and labeler/rubric/classifier
+       versions plus ``as_of`` present. An empty ``as_of`` is allowed (the
+       unpinned edge) and reported through the build lineage, not refused.
 
     Any mismatch raises ``ValueError`` naming both sides of the mismatch.
     """
@@ -283,6 +288,14 @@ def _verify_annotation_bundle(
         isinstance(batch_fileset_digest, str) and bool(batch_fileset_digest),
         "missing 'batch_fileset_digest' — the annotation bundle must record "
         "the curation bundle's batch/file-set digest it was harvested against",
+    )
+    actual_fileset_digest = _derivative_digest(bundle_dir)
+    _gate(
+        batch_fileset_digest == actual_fileset_digest,
+        f"stale batch fileset: the annotation bundle records "
+        f"batch_fileset_digest {batch_fileset_digest} but the curation bundle "
+        f"now hashes to {actual_fileset_digest} — re-harvest the annotation "
+        "snapshot against this curation bundle before building",
     )
     for version_field in ("labeler_version", "rubric_version", "classifier_version"):
         value = lineage.get(version_field)
@@ -475,7 +488,9 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
     """
     bundle = load_curated_bundle(config.bundle_dir)
     assert config.annotation_bundle_dir is not None  # __post_init__ guarantees
-    annotation_lineage = _verify_annotation_bundle(config.annotation_bundle_dir, bundle)
+    annotation_lineage = _verify_annotation_bundle(
+        config.annotation_bundle_dir, bundle, config.bundle_dir
+    )
     snapshot_path = Path(config.annotation_bundle_dir) / "annotations.jsonl"
     snapshot_rows = _load_snapshot(snapshot_path)
     snapshot_digest = hashlib.sha256(snapshot_path.read_bytes()).hexdigest()

--- a/daydream/training/corpus_v2/projector.py
+++ b/daydream/training/corpus_v2/projector.py
@@ -24,7 +24,11 @@ from typing import Any, Literal, Mapping, cast, overload
 
 from daydream.archive.index import normalize_as_of
 from daydream.training.corpus import _is_posterior_leak, _trajectory_set_hash
-from daydream.training.corpus_v2.bundle import load_curated_bundle
+from daydream.training.corpus_v2.bundle import (
+    CuratedBundle,
+    _verify_sha256sums,
+    load_curated_bundle,
+)
 from daydream.training.corpus_v2.identity import record_id
 from daydream.training.corpus_v2.provenance import extract_provenance
 from daydream.training.corpus_v2.segments import segment
@@ -70,7 +74,11 @@ class BuildCorpusV2Config:
 
     out_dir: Path
     bundle_dir: Path
-    annotations_snapshot: Path
+    # Required: a build without a pinned annotation bundle is a config error
+    # (raised as ValueError naming the field, not a TypeError from the
+    # dataclass) — declared optional so that misconfiguration, not a missing
+    # kwarg, is what callers see.
+    annotation_bundle_dir: Path | None = None
     as_of: str | None = None
     holdout_rate: float = 0.1
     val_rate: float = 0.1
@@ -82,15 +90,24 @@ class BuildCorpusV2Config:
     license: str | None = None
 
     def __post_init__(self) -> None:
+        if self.annotation_bundle_dir is None:
+            raise ValueError(
+                "annotation_bundle_dir is required: a corpus v2 build without a "
+                "pinned annotation bundle is a configuration error"
+            )
+        object.__setattr__(self, "annotation_bundle_dir", Path(self.annotation_bundle_dir))
         if self.as_of is not None:
             object.__setattr__(self, "as_of", normalize_as_of(self.as_of))
 
 
 def _load_snapshot(path: Path) -> dict[str, dict[str, Any]]:
-    """Parse the side-car annotations snapshot (Task 0A shape): one JSON
-    object per line, keyed by ``fingerprint``. Fail-closed on malformed
-    lines or duplicate fingerprints."""
+    """Parse the annotation bundle's ``annotations.jsonl`` (canonical
+    per-finding record shape): one JSON object per line, keyed by
+    ``record_id``. ``fingerprint`` is required on every row and duplicates
+    of either key fail closed — the canonical record is identified by
+    ``record_id`` and located by ``fingerprint``, so neither may be ambiguous."""
     rows: dict[str, dict[str, Any]] = {}
+    seen_fingerprints: dict[str, int] = {}
     for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
         if not line.strip():
             continue
@@ -100,15 +117,29 @@ def _load_snapshot(path: Path) -> dict[str, dict[str, Any]]:
             raise ValueError(
                 f"annotations snapshot {path}: line {line_no} is not valid JSON: {exc}"
             ) from exc
+        record_id_value = row.get("record_id")
+        if not record_id_value:
+            raise ValueError(
+                f"annotations snapshot {path}: line {line_no} missing 'record_id'"
+            )
         fingerprint = row.get("fingerprint")
         if not fingerprint:
             raise ValueError(f"annotations snapshot {path}: line {line_no} missing 'fingerprint'")
-        if fingerprint in rows:
+        record_id_value = str(record_id_value)
+        if record_id_value in rows:
             raise ValueError(
-                f"annotations snapshot {path}: duplicate fingerprint {fingerprint!r} "
-                f"(lines {line_no} and earlier) — snapshot must be keyed by fingerprint"
+                f"annotations snapshot {path}: duplicate record_id {record_id_value!r} "
+                f"(lines {line_no} and earlier) — snapshot must be keyed by record_id"
             )
-        rows[str(fingerprint)] = row
+        fp = str(fingerprint)
+        if fp in seen_fingerprints:
+            raise ValueError(
+                f"annotations snapshot {path}: duplicate fingerprint {fp!r} "
+                f"(lines {seen_fingerprints[fp]} and {line_no}) — snapshot must be "
+                "keyed by fingerprint"
+            )
+        seen_fingerprints[fp] = line_no
+        rows[record_id_value] = row
     return rows
 
 
@@ -164,35 +195,87 @@ def _max_valid_at(evidence: list[Record], base: str | None) -> str | None:
     return result
 
 
-def _verify_snapshot_pinned(bundle_dir: Path, snapshot: Path) -> None:
-    """Fail-closed: the annotations snapshot must be digest-pinned by the
-    bundle's SHA256SUMS (the "digest-pinned alongside the bundle" contract) —
-    a snapshot whose bytes no bundle checksum names is refused rather than
-    hashed self-referentially."""
-    sums_path = bundle_dir / "SHA256SUMS"
-    if not sums_path.is_file():
-        raise ValueError(
-            f"bundle {bundle_dir}: missing SHA256SUMS — cannot verify the annotations snapshot pin"
+_ANNOTATION_SCHEMA_PREFIX = "annotation-snapshot/"
+
+
+def _verify_annotation_bundle(
+    annotation_bundle_dir: Path, bundle: CuratedBundle
+) -> dict[str, Any]:
+    """Two-bundle contract: the annotation bundle is verified as its own
+    published artifact and then linked to the curation bundle exactly.
+
+    Gates, fail-closed in order:
+
+    1. ``_SUCCESS`` completeness marker (a mid-write bundle is refused).
+    2. Every file against the bundle's own ``SHA256SUMS`` (self-verification
+       via ``bundle._verify_sha256sums`` — raises ``BundleError``, a
+       ``ValueError``).
+    3. Cross-bundle linkage against the curation bundle: ``curation_id``
+       equal to ``bundle.curation_id``, ``sanitized_hub_commit`` equal to
+       ``bundle.source_hub_commit``, a recorded batch/file-set digest, a
+       compatible annotation-snapshot schema version, and
+       labeler/rubric/classifier versions plus ``as_of`` present. An empty
+       ``as_of`` is allowed (the unpinned edge) and reported through the
+       build lineage, not refused.
+
+    Any mismatch raises ``ValueError`` naming both sides of the mismatch.
+    """
+    root = Path(annotation_bundle_dir)
+    if not (root / "_SUCCESS").is_file():
+        raise ValueError(f"annotation bundle {root}: missing _SUCCESS marker")
+    _verify_sha256sums(root, "")
+    lineage_path = root / "lineage.json"
+    if not lineage_path.is_file():
+        raise ValueError(f"annotation bundle {root}: missing lineage.json")
+    try:
+        lineage = json.loads(lineage_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"annotation bundle {root}: lineage.json is not valid JSON: {exc}") from exc
+    if not isinstance(lineage, dict):
+        raise ValueError(f"annotation bundle {root}: lineage.json is not a JSON object")
+
+    def _gate(condition: bool, message: str) -> None:
+        if not condition:
+            raise ValueError(f"annotation bundle {root}: {message}")
+
+    recorded_curation = lineage.get("curation_id")
+    _gate(
+        recorded_curation == bundle.curation_id,
+        f"curation_id mismatch: annotation bundle records {recorded_curation!r} "
+        f"but the curation bundle is {bundle.curation_id!r}",
+    )
+    recorded_commit = lineage.get("sanitized_hub_commit")
+    _gate(
+        recorded_commit == bundle.source_hub_commit,
+        f"sanitized_hub_commit mismatch: annotation bundle records {recorded_commit!r} "
+        f"but the curation bundle is {bundle.source_hub_commit!r}",
+    )
+    schema_version = lineage.get("schema_version")
+    _gate(
+        isinstance(schema_version, str)
+        and schema_version.startswith(_ANNOTATION_SCHEMA_PREFIX),
+        f"incompatible schema_version {schema_version!r} — expected an "
+        f"{_ANNOTATION_SCHEMA_PREFIX!r}* annotation snapshot",
+    )
+    batch_fileset_digest = lineage.get("batch_fileset_digest")
+    _gate(
+        isinstance(batch_fileset_digest, str) and bool(batch_fileset_digest),
+        "missing 'batch_fileset_digest' — the annotation bundle must record "
+        "the curation bundle's batch/file-set digest it was harvested against",
+    )
+    for version_field in ("labeler_version", "rubric_version", "classifier_version"):
+        value = lineage.get(version_field)
+        _gate(
+            isinstance(value, str) and bool(value),
+            f"missing or empty {version_field!r} — labeler/rubric/classifier "
+            "versions must be recorded",
         )
-    pinned: dict[str, str] = {}
-    for line in sums_path.read_text(encoding="utf-8").splitlines():
-        if not line.strip():
-            continue
-        digest, sep, relpath = line.partition("  ")
-        if sep:
-            pinned[Path(relpath).name] = digest
-    expected = pinned.get(snapshot.name)
-    if expected is None:
-        raise ValueError(
-            f"annotations snapshot {snapshot.name!r} is not listed in bundle "
-            f"{bundle_dir} SHA256SUMS — it must be digest-pinned alongside the bundle"
-        )
-    actual = hashlib.sha256(snapshot.read_bytes()).hexdigest()
-    if actual != expected:
-        raise ValueError(
-            f"annotations snapshot {snapshot} digest mismatch vs bundle {bundle_dir} "
-            "SHA256SUMS pin"
-        )
+    _gate(
+        "as_of" in lineage,
+        "missing 'as_of' — the evidence pin must be recorded (empty/null "
+        "allowed for the unpinned edge)",
+    )
+    return lineage
 
 
 def _read_trajectory_documents(bundle_dir: Path, artifact_relpath: str) -> list[dict[str, Any]]:
@@ -348,12 +431,12 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
     naming the session and both timestamps — refusal, not drop) → write
     ``corpus.jsonl`` plus ``train.jsonl``/``validation.jsonl``/``holdout.jsonl``
     atomically, copy ``schema/v2.json`` alongside, and write ``lineage.json``
-    pinning the snapshot's provenance (no wall-clock timestamps — every
+    pinning the annotation bundle's provenance (no wall-clock timestamps — every
     manifest byte is a function of the immutable inputs, so re-runs are
     byte-for-byte identical), finishing with a ``_SUCCESS`` completeness
     marker.
 
-    Each finding is projected exactly once (the snapshot resolutions are
+    Each finding is projected exactly once (the annotation resolutions are
     session-scoped, so sibling segments never fabricate per-segment copies);
     non-decisive findings are excluded here and routed to the adjudication
     report only.
@@ -369,9 +452,11 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
     completeness gate, so the twin can never diverge from the canonical file.
     """
     bundle = load_curated_bundle(config.bundle_dir)
-    snapshot_rows = _load_snapshot(config.annotations_snapshot)
-    snapshot_digest = hashlib.sha256(config.annotations_snapshot.read_bytes()).hexdigest()
-    _verify_snapshot_pinned(config.bundle_dir, config.annotations_snapshot)
+    assert config.annotation_bundle_dir is not None  # __post_init__ guarantees
+    annotation_lineage = _verify_annotation_bundle(config.annotation_bundle_dir, bundle)
+    snapshot_path = Path(config.annotation_bundle_dir) / "annotations.jsonl"
+    snapshot_rows = _load_snapshot(snapshot_path)
+    snapshot_digest = hashlib.sha256(snapshot_path.read_bytes()).hexdigest()
 
     records: list[Record] = []
     adjudication: list[Record] = []
@@ -382,7 +467,7 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
     seen_findings: set[tuple[str, str]] = set()
     adjudicated_findings: set[tuple[str, str]] = set()
     # lineage valid_at is pinned over the emitted records' evidence only —
-    # snapshot rows for sessions never admitted/emitted must not drift it.
+    # annotation rows for sessions never admitted/emitted must not drift it.
     valid_at = config.as_of
     for batch in bundle.admitted:
         if batch.manifest_relpath is not None:
@@ -529,14 +614,26 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
     content_digests: dict[str, str] = {
         batch.session_id: batch.content_digest for batch in bundle.admitted if batch.content_digest
     }
-    content_digests[config.annotations_snapshot.name] = snapshot_digest
+    content_digests["annotations.jsonl"] = snapshot_digest
+    annotation_as_of = annotation_lineage.get("as_of")
     lineage = {
         "schema_version": "corpus-v2",
         "curation_id": bundle.curation_id,
         "hub_commit": bundle.source_hub_commit,
         "source_hub_commit": bundle.source_hub_commit,
         "content_digests": content_digests,
-        "annotations_snapshot": config.annotations_snapshot.name,
+        # Two-bundle contract (K3): the annotation bundle's snapshot_id/commit
+        # are pinned into the projection lineage; the finalized curation
+        # bundle itself is never touched.
+        "annotation_bundle": {
+            "snapshot_id": annotation_lineage.get("snapshot_id")
+            or config.annotation_bundle_dir.name,
+            "curation_id": annotation_lineage.get("curation_id"),
+            "sanitized_hub_commit": annotation_lineage.get("sanitized_hub_commit"),
+            "annotations_digest": snapshot_digest,
+            "as_of": annotation_as_of,
+            "unpinned_as_of": annotation_as_of in (None, ""),
+        },
         "labeler_policy_version": config.labeler_policy_version,
         "reply_classifier_version": config.reply_classifier_version,
         "rubric_schema_version": config.rubric_schema_version,

--- a/daydream/training/corpus_v2/projector.py
+++ b/daydream/training/corpus_v2/projector.py
@@ -162,6 +162,25 @@ def _refuse_posterior_evidence(
             )
 
 
+def _merge_nested_profile(prov: dict[str, Any], row: Mapping[str, Any]) -> None:
+    """Surface the canonical record's nested ``profile`` block (Req 8).
+
+    ``adjudication.snapshot.build_canonical_record`` emits the four
+    review-profile fields nested under top-level ``profile`` (with ``stack``
+    — not ``profile_*`` — at top level), so a top-level read comes back
+    empty and the nested block must supply the values instead — they are
+    never dropped at the projection boundary.
+    """
+    if any(prov["profile"].values()):
+        return
+    nested = row.get("profile")
+    if isinstance(nested, Mapping):
+        for field in prov["profile"]:
+            value = nested.get(field)
+            if value is not None:
+                prov["profile"][field] = value
+
+
 def _provenance_for(
     resolution_row: Mapping[str, Any], manifest_row: Mapping[str, Any]
 ) -> dict[str, Any]:
@@ -169,9 +188,11 @@ def _provenance_for(
 
     The resolution row's native review-profile fields win when present;
     otherwise the batch manifest row supplies them — the values carried by
-    either row type must not be dropped at the projection boundary.
+    either row type must not be dropped at the projection boundary. Canonical
+    annotation records nest the profile block, so both shapes are read.
     """
     prov = extract_provenance(resolution_row)
+    _merge_nested_profile(prov, resolution_row)
     if (
         not any(prov["profile"].values())
         and prov.get("skill") is None
@@ -371,6 +392,7 @@ def project_findings(
         disposition = resolution.get("disposition")
         evidence = list(resolution.get("evidence") or [])
         provenance = extract_provenance(resolution)
+        _merge_nested_profile(provenance, resolution)
         record = {
             "record_id": record_id(
                 str(session_id), str(trajectory_id), str(segment_id), str(fingerprint)

--- a/daydream/training/corpus_v2/tiers.py
+++ b/daydream/training/corpus_v2/tiers.py
@@ -59,6 +59,11 @@ def classify_tier(resolution: Mapping[str, object], *, record_type: str = "outco
                 f"{resolution.get('fingerprint')!r} has empty evidence; "
                 "gold requires human/developer reply evidence"
             )
+        # C5/M9 temporal gate: evidence observed after the record's as_of
+        # pin cannot establish gold eligibility — keep the evidence but
+        # classify silver, never gold.
+        if resolution.get("evidence_after_as_of") is True:
+            return "silver"
         return "gold"
 
     raise TypeError(f"unknown disposition {disposition!r}")

--- a/daydream/training/labeler_versions.py
+++ b/daydream/training/labeler_versions.py
@@ -1,7 +1,8 @@
 """Version constants for the reply-labeling pipeline and reply evidence digest.
 
 Independent version axes (M13): rubric schema, labeler policy, reply classifier,
-adjudication labeler, and evidence digest format each evolve separately from ``reward.REWARD_VERSION``.
+adjudication labeler, human labeler, annotation snapshot schema, and evidence
+digest format each evolve separately from ``reward.REWARD_VERSION``.
 This module imports nothing from the rest of the training package.
 """
 
@@ -15,6 +16,8 @@ RUBRIC_SCHEMA_VERSION = "980-rubric-r2"
 LABELER_POLICY_VERSION = "980-policy-r1"
 REPLY_CLASSIFIER_VERSION = "980-classifier-r1"
 ADJUDICATION_LABELER_VERSION = "984-adjudicate-r1"
+HUMAN_LABELER_VERSION = "1055-human-r1"
+ANNOTATION_SNAPSHOT_SCHEMA_VERSION = "1055-snapshot-r1"
 REPLY_EVIDENCE_DIGEST_FORMAT = "sha256/1"
 
 

--- a/plan-notes.md
+++ b/plan-notes.md
@@ -94,3 +94,14 @@ No Key Decision invalidated: dry path works GPU-free at v0.7.0, dataset-SFT exis
 as a separate `sft` entrypoint taking prompt/completion JSONL with LoRA rank up to
 128 and `renderer.name = "default"`, and the verifiers skew resolves by pin
 discipline alone. Proceed to Task 1.
+
+## Issue-1055 Task 0 spike (2026-08-30, branch eb/daydream/issue-1055 @ HEAD)
+
+- Baseline: `pytest tests/test_corpus_v2.py tests/test_training_adjudication_preview_harvest.py -x -q` → **48 passed**.
+- Wiring import check: `run_build_corpus_v2`, `_verify_snapshot_pinned`, `append_label_observation`, `build_export_entries` all import cleanly → `wiring OK`.
+- Failure-mode capture: **no tests reference `_verify_snapshot_pinned`** (`grep -rn verify_snapshot_pinned tests/` → no hits; `-k snapshot_pinned --collect-only` → 0 collected). There is therefore no existing digest-membership contract coverage to replace — Task 9 writes the two-bundle contract tests fresh.
+- Consumer scan: sole call site of `_verify_snapshot_pinned` is `daydream/training/corpus_v2/projector.py:374` inside `run_build_corpus_v2`. `adjudication/preview.py:8` mentions it in a docstring only (not a consumer, docstring update in Task 9 is cosmetic). No other consumers exist.
+
+## Verdict
+
+Baseline green, wiring intact, `projector.py:374` is the only consumer. Spike passes; proceed to Task 1.

--- a/plan-notes.md
+++ b/plan-notes.md
@@ -98,10 +98,10 @@ discipline alone. Proceed to Task 1.
 ## Issue-1055 Task 0 spike (2026-08-30, branch eb/daydream/issue-1055 @ HEAD)
 
 - Baseline: `pytest tests/test_corpus_v2.py tests/test_training_adjudication_preview_harvest.py -x -q` → **48 passed**.
-- Wiring import check: `run_build_corpus_v2`, `_verify_snapshot_pinned`, `append_label_observation`, `build_export_entries` all import cleanly → `wiring OK`.
-- Failure-mode capture: **no tests reference `_verify_snapshot_pinned`** (`grep -rn verify_snapshot_pinned tests/` → no hits; `-k snapshot_pinned --collect-only` → 0 collected). There is therefore no existing digest-membership contract coverage to replace — Task 9 writes the two-bundle contract tests fresh.
-- Consumer scan: sole call site of `_verify_snapshot_pinned` is `daydream/training/corpus_v2/projector.py:374` inside `run_build_corpus_v2`. `adjudication/preview.py:8` mentions it in a docstring only (not a consumer, docstring update in Task 9 is cosmetic). No other consumers exist.
+- Wiring import check: `run_build_corpus_v2`, `append_label_observation`, `build_export_entries` all import cleanly → `wiring OK`. (`_verify_snapshot_pinned` was in the spike-time import list but is gone at HEAD — the merged branch deleted the function.)
+- Failure-mode capture: **no tests reference `_verify_snapshot_pinned`** — moot at HEAD since the function no longer exists; there is no existing digest-membership contract coverage to replace — Task 9 writes the two-bundle contract tests fresh.
+- Consumer scan: stale at HEAD — `_verify_snapshot_pinned` was previously anchored at `daydream/training/corpus_v2/projector.py:374` (sole call site, inside `run_build_corpus_v2`), with a docstring mention in `adjudication/preview.py:8`, but the merged branch deleted the function and both anchors are gone. No consumers remain.
 
-## Verdict
+## Verdict (issue-1055 spike)
 
-Baseline green, wiring intact, `projector.py:374` is the only consumer. Spike passes; proceed to Task 1.
+Baseline green, wiring intact. Spike passes; proceed to Task 1.

--- a/tests/fixtures/training/build_hub_snapshot.py
+++ b/tests/fixtures/training/build_hub_snapshot.py
@@ -36,6 +36,37 @@ SNAPSHOT_REVISION = hashlib.sha256(b"fixture-hub-snapshot-v1").hexdigest()[:40]
 _SNAPSHOT_SESSION_IDS = ("sess-a", "sess-b", "sess-c")
 
 
+def _snapshot_trajectory(session_id: str) -> dict[str, object]:
+    """The minimal trajectory plus one unanswered per-finding resolution.
+
+    Additive keys only: the #981/hydrate consumers keep parsing the same
+    fields, while the #1055 annotation pipeline gets the adjudication-shaped
+    finding it needs to build a non-empty queue. The evidence digest is
+    recomputed from the evidence list so the fixture satisfies the shared
+    serializer's digest contract by construction.
+    """
+    evidence = [
+        {
+            "reply_id": "r1",
+            "body_sha256": hashlib.sha256(f"reply-1-{session_id}".encode()).hexdigest(),
+        }
+    ]
+    trajectory: dict[str, object] = dict(_MINIMAL_TRAJECTORY)
+    trajectory["resolutions"] = [
+        {
+            "fingerprint": f"fp-{session_id}",
+            "disposition": "unanswered",
+            "evidence": evidence,
+            "evidence_digest": hashlib.sha256(
+                json.dumps(evidence, sort_keys=True).encode()
+            ).hexdigest(),
+            "profile": "pr_review",
+            "stack": "python",
+        }
+    ]
+    return trajectory
+
+
 def _snapshot_manifest(session_id: str, repo_slug: str, skill: str, outcome_labels: tuple[str, ...]) -> Manifest:
     """Build a Manifest from §9 session data with staging-safe path fields.
 
@@ -66,7 +97,9 @@ def build_snapshot(*, hostile: bool = False) -> FakeHub:
     for session_id, session in zip(_SNAPSHOT_SESSION_IDS, FIXTURE_SESSIONS, strict=False):
         manifest = _snapshot_manifest(session_id, session.repo_slug, session.skill, session.outcome_labels)
         files[f"bundles/{session_id}/manifest.json"] = json.dumps(manifest.to_dict(), indent=2).encode()
-        files[f"bundles/{session_id}/trajectory.json"] = json.dumps(_MINIMAL_TRAJECTORY, indent=2).encode()
+        files[f"bundles/{session_id}/trajectory.json"] = json.dumps(
+            _snapshot_trajectory(session_id), indent=2
+        ).encode()
     # Bronze companion content: hydration must never touch it (M10).
     files["bronze/manifest.json"] = b'{"bronze": true}\n'
     # Remote resume ledger, seeded empty: the Hub is the canonical resume state.

--- a/tests/fixtures/training/build_hub_snapshot.py
+++ b/tests/fixtures/training/build_hub_snapshot.py
@@ -64,20 +64,16 @@ def build_snapshot(*, hostile: bool = False) -> FakeHub:
     """Materialize the pinned three-session snapshot as an in-memory FakeHub."""
     files: dict[str, bytes] = {}
     for session_id, session in zip(_SNAPSHOT_SESSION_IDS, FIXTURE_SESSIONS, strict=False):
-        manifest = _snapshot_manifest(
-            session_id, session.repo_slug, session.skill, session.outcome_labels
-        )
-        files[f"bundles/{session_id}/manifest.json"] = json.dumps(
-            manifest.to_dict(), indent=2
-        ).encode()
-        files[f"bundles/{session_id}/trajectory.json"] = json.dumps(
-            _MINIMAL_TRAJECTORY, indent=2
-        ).encode()
+        manifest = _snapshot_manifest(session_id, session.repo_slug, session.skill, session.outcome_labels)
+        files[f"bundles/{session_id}/manifest.json"] = json.dumps(manifest.to_dict(), indent=2).encode()
+        files[f"bundles/{session_id}/trajectory.json"] = json.dumps(_MINIMAL_TRAJECTORY, indent=2).encode()
     # Bronze companion content: hydration must never touch it (M10).
     files["bronze/manifest.json"] = b'{"bronze": true}\n'
     # Remote resume ledger, seeded empty: the Hub is the canonical resume state.
     curation_id = derive_curation_id(
-        SNAPSHOT_REVISION, SANITIZER_VERSION, HYDRATION_INDEX_SCHEMA_VERSION,
+        SNAPSHOT_REVISION,
+        SANITIZER_VERSION,
+        HYDRATION_INDEX_SCHEMA_VERSION,
         ADMISSION_POLICY_VERSION,
     )
     files[f"curated/{curation_id}/resume/ledger.jsonl"] = b""
@@ -89,3 +85,37 @@ def build_snapshot(*, hostile: bool = False) -> FakeHub:
     hub = FakeHub(repo_id=REPO_ID, private=True, files=files)
     hub.commit_revision(SNAPSHOT_REVISION)
     return hub
+
+
+class AnnotationsHub(FakeHub):
+    """Annotations-capable fake Hub: public ``files`` dict + ``mutate_bundle`` seam.
+
+    Extends :class:`FakeHub` for the per-finding annotation-snapshot pipeline
+    (#1055): the ``annotations/<curation-id>/<snapshot-id>/`` prefix is
+    pre-seeded and :meth:`mutate_annotation_file` lets tests tamper with (or
+    add to) the published bundle in place. Private by default, like the real
+    target repo. (``mutate_bundle`` keeps FakeHub's bundle-collision signature;
+    annotation mutations go through the renamed seam.)
+    """
+
+    def __init__(
+        self,
+        *,
+        curation_id: str,
+        snapshot_id: str,
+        private: bool = True,
+        files: dict[str, bytes] | None = None,
+    ) -> None:
+        self.prefix = f"annotations/{curation_id}/{snapshot_id}/"
+        seeded = {f"{self.prefix}preview-manifest.json": b"{}\n"}
+        seeded.update(files or {})
+        super().__init__(repo_id=REPO_ID, private=private, files=seeded)
+
+    def mutate_annotation_file(self, relpath: str, data: bytes) -> None:
+        """Overwrite (or add) one file under the annotations prefix."""
+        self.files[f"{self.prefix}{relpath}"] = data
+
+
+def build_annotations_hub(curation_id: str, snapshot_id: str, *, private: bool = True) -> AnnotationsHub:
+    """Materialize an empty annotations bundle hub for one snapshot pin."""
+    return AnnotationsHub(curation_id=curation_id, snapshot_id=snapshot_id, private=private)

--- a/tests/fixtures/training/build_hub_snapshot.py
+++ b/tests/fixtures/training/build_hub_snapshot.py
@@ -52,6 +52,8 @@ def _snapshot_trajectory(session_id: str) -> dict[str, object]:
         }
     ]
     trajectory: dict[str, object] = dict(_MINIMAL_TRAJECTORY)
+    trajectory["session_id"] = session_id
+    trajectory["trajectory_id"] = f"{session_id}:root"
     trajectory["resolutions"] = [
         {
             "fingerprint": f"fp-{session_id}",
@@ -60,6 +62,14 @@ def _snapshot_trajectory(session_id: str) -> dict[str, object]:
             "evidence_digest": hashlib.sha256(
                 json.dumps(evidence, sort_keys=True).encode()
             ).hexdigest(),
+            # Native review-profile fields (issue #885, R12) — the shared
+            # serializer nests these under ``profile`` in the canonical
+            # record, so the projection must surface them at the two-bundle
+            # boundary rather than dropping them.
+            "profile_schema_version": 2,
+            "profile_name": "pr_review",
+            "profile_source_kind": "builtin",
+            "profile_digest": "d" * 64,
             "profile": "pr_review",
             "stack": "python",
         }

--- a/tests/test_annotation_pipeline_integration.py
+++ b/tests/test_annotation_pipeline_integration.py
@@ -9,6 +9,7 @@ import json
 from pathlib import Path
 
 from daydream.archive import hydrate
+from daydream.archive.sanitize import _derivative_digest
 from daydream.training.adjudication.canonical import run_canonical_harvest
 from daydream.training.adjudication.cli import handle_adjudicate
 from daydream.training.adjudication.materialize import run_materialize
@@ -92,7 +93,10 @@ def test_full_annotation_pipeline_survives_vm_loss(tmp_path: Path) -> None:
         "curation_id": curation_id, "sanitized_hub_commit": SNAPSHOT_REVISION,
         "snapshot_id": snapshot_id,
         "schema_version": f"annotation-snapshot/{ANNOTATION_SNAPSHOT_SCHEMA_VERSION}",
-        "batch_fileset_digest": "b" * 64,
+        # the curation bundle is finalized by hydrate and never mutated
+        # afterward (K3), so its canonical file-set digest is stable at
+        # publication time and matches what the build-v2 gate recomputes
+        "batch_fileset_digest": _derivative_digest(stage / "curated" / curation_id),
         "labeler_version": pin["labeler_version"],
         "rubric_version": pin["rubric_version"],
         "classifier_version": pin["classifier_version"],

--- a/tests/test_annotation_pipeline_integration.py
+++ b/tests/test_annotation_pipeline_integration.py
@@ -1,0 +1,131 @@
+"""AC 7 end-to-end: hydrate -> preview -> adjudication -> VM-loss resume ->
+canonical harvest -> publication -> clean download -> build-v2 dry run.
+
+Fake-Hub only (K6, mirrors test_archive_hydrate_integration.py) — no network.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from daydream.archive import hydrate
+from daydream.training.adjudication.canonical import run_canonical_harvest
+from daydream.training.adjudication.cli import handle_adjudicate
+from daydream.training.adjudication.materialize import run_materialize
+from daydream.training.adjudication.preview import run_preview
+from daydream.training.adjudication.publish import (
+    publish_annotation_state,
+    publish_final_annotation_bundle,
+    resume_annotation_state,
+)
+from daydream.training.labeler_versions import ANNOTATION_SNAPSHOT_SCHEMA_VERSION
+from tests.fixtures.training.build_hub_snapshot import SNAPSHOT_REVISION, build_snapshot
+
+
+def test_full_annotation_pipeline_survives_vm_loss(tmp_path: Path) -> None:
+    hub = build_snapshot()
+
+    # 1. hydrate: VM-local SQLite index over the fake Hub snapshot
+    stage = tmp_path / "stage"
+    hydrate.run_hydrate_hub(hydrate.HydrateHubConfig(
+        source_repo="org/private-ds", source_revision=SNAPSHOT_REVISION,
+        destination_repo="org/private-ds", stage_dir=stage), client=hub)
+    curation_id = next((stage / "curated").iterdir()).name
+
+    # 2. semantic preview -> sessions.jsonl + preview manifest (snapshot id),
+    #    read directly off the hydrated staging archive (no sessions.jsonl there)
+    pin = {
+        "curation_id": curation_id, "sanitized_hub_commit": SNAPSHOT_REVISION,
+        "source_hub_commit": SNAPSHOT_REVISION,
+        "archive_index_digest": "c" * 64,
+        "evidence_observed_at": "2026-01-01T00:00:00+00:00",
+        "as_of": "2026-02-01T00:00:00+00:00",
+        "labeler_version": "1055-human-r1", "rubric_version": "984-adjudicate-r1",
+        "classifier_version": "980-classifier-r1",
+    }
+    mat = tmp_path / "mat"
+    result = run_materialize(stage, mat, pin=pin)
+    snapshot_id = result["snapshot_id"]
+    assert result["record_count"] == 3  # one unanswered finding per fixture session
+
+    # 3. adjudication: build the queue over the materialized snapshot, label one
+    #    batch, then publish the durable state (queue + ledger + observations).
+    state = tmp_path / "state"
+    assert handle_adjudicate([
+        "build", "--index-root", str(mat), "--state-dir", str(state)]) == 0
+    assert handle_adjudicate([
+        "label", "--state-dir", str(state), "--batch", "1",
+        "--disposition", "accepted", "--rationale", "clear maintainer approval",
+        "--labeler", "alice"]) == 0
+    run_preview(mat, state / "preview-ledger.json")
+    publish_annotation_state(
+        hub, state, manifest=mat / "preview-manifest.json", batch_complete=True)
+
+    # 4. VM loss: fresh disk, resume must restore byte-identical state
+    fresh = tmp_path / "fresh-vm"
+    resumed = resume_annotation_state(
+        hub, manifest=mat / "preview-manifest.json", stage_dir=fresh)
+    assert resumed["observation_count"] == 1
+    assert (fresh / "observations.jsonl").read_bytes() == \
+        (state / "observations.jsonl").read_bytes()
+
+    # 5. canonical harvest: drift-checked, appends label_observations exactly
+    #    once per session into the hydrated stage's SQLite index
+    harvest = run_canonical_harvest(
+        index_root=mat, materialize_dir=mat, archive_dir=stage,
+        observations_path=fresh / "observations.jsonl")
+    assert harvest["appended_sessions"] == 3
+    assert harvest["human_adjudicated"] == 1
+    from daydream.archive.index import label_observation_history
+
+    for session_id in ("sess-a", "sess-b", "sess-c"):
+        assert len(label_observation_history(stage, session_id)) == 1
+
+    # 6. publish the final annotation bundle (SHA256SUMS + _SUCCESS last)
+    bundle_root = mat / "final-bundle"
+    bundle_root.mkdir()
+    (bundle_root / "annotations.jsonl").write_bytes(
+        (mat / "annotations.jsonl").read_bytes())
+    (bundle_root / "sessions.jsonl").write_bytes(
+        (mat / "sessions.jsonl").read_bytes())
+    (bundle_root / "lineage.json").write_text(json.dumps({
+        "curation_id": curation_id, "sanitized_hub_commit": SNAPSHOT_REVISION,
+        "snapshot_id": snapshot_id,
+        "schema_version": f"annotation-snapshot/{ANNOTATION_SNAPSHOT_SCHEMA_VERSION}",
+        "batch_fileset_digest": "b" * 64,
+        "labeler_version": pin["labeler_version"],
+        "rubric_version": pin["rubric_version"],
+        "classifier_version": pin["classifier_version"],
+        "as_of": pin["as_of"],
+    }, sort_keys=True) + "\n", encoding="utf-8")
+    final = publish_final_annotation_bundle(
+        hub, bundle_root, manifest=mat / "preview-manifest.json", verify_download=True)
+    assert final["hub_commit_sha"]
+
+    # 7. clean download into a fresh dir verifies checksums
+    clean = tmp_path / "clean-download"
+    clean.mkdir()
+    prefix = final["prefix"]
+    for key, data in hub.files.items():
+        if key.startswith(prefix):
+            rel = Path(key[len(prefix):])
+            rel.parent.mkdir(parents=True, exist_ok=True)
+            (clean / rel).write_bytes(data)
+    from daydream.training.corpus_v2.bundle import _verify_sha256sums
+
+    _verify_sha256sums(clean, "")  # raises on any corruption
+
+    # 8. corpus-v2 build over the curation bundle + the downloaded annotation
+    #    bundle (the hydrated stage's curated/ dir is the curation bundle)
+    from daydream.training.corpus_v2.projector import (
+        BuildCorpusV2Config,
+        run_build_corpus_v2,
+    )
+
+    summary = run_build_corpus_v2(BuildCorpusV2Config(
+        out_dir=tmp_path / "corpus-out",
+        bundle_dir=stage / "curated" / curation_id,
+        annotation_bundle_dir=clean,
+    ))
+    assert (tmp_path / "corpus-out" / "_SUCCESS").is_file()
+    assert summary["total"] >= 0

--- a/tests/test_annotation_pipeline_integration.py
+++ b/tests/test_annotation_pipeline_integration.py
@@ -27,10 +27,10 @@ def test_full_annotation_pipeline_survives_vm_loss(tmp_path: Path) -> None:
 
     # 1. hydrate: VM-local SQLite index over the fake Hub snapshot
     stage = tmp_path / "stage"
-    hydrate.run_hydrate_hub(hydrate.HydrateHubConfig(
+    hydrated = hydrate.run_hydrate_hub(hydrate.HydrateHubConfig(
         source_repo="org/private-ds", source_revision=SNAPSHOT_REVISION,
         destination_repo="org/private-ds", stage_dir=stage), client=hub)
-    curation_id = next((stage / "curated").iterdir()).name
+    curation_id = hydrated.curation_id
 
     # 2. semantic preview -> sessions.jsonl + preview manifest (snapshot id),
     #    read directly off the hydrated staging archive (no sessions.jsonl there)
@@ -128,4 +128,18 @@ def test_full_annotation_pipeline_survives_vm_loss(tmp_path: Path) -> None:
         annotation_bundle_dir=clean,
     ))
     assert (tmp_path / "corpus-out" / "_SUCCESS").is_file()
-    assert summary["total"] >= 0
+    # exactly one decisive record: one of the three fixture findings was
+    # human-adjudicated to `accepted`, the other two remain unanswered
+    assert summary["total"] == 1
+    # The gold record must carry the canonical record's nested profile block
+    # verbatim (Req 8: profile values never dropped at the projection
+    # boundary) — annotation rows are build_canonical_record output with the
+    # profile nested under "profile", not flat profile_* keys.
+    records = [json.loads(line) for line in
+               (tmp_path / "corpus-out" / "corpus.jsonl").read_text().splitlines() if line]
+    assert len(records) == 1
+    assert records[0]["profile"] == {
+        "profile_schema_version": 2, "profile_name": "pr_review",
+        "profile_source_kind": "builtin", "profile_digest": "d" * 64,
+    }
+    assert records[0]["stack"] == "python"

--- a/tests/test_cli_adjudicate.py
+++ b/tests/test_cli_adjudicate.py
@@ -198,6 +198,10 @@ def test_report_subverb_prints_coverage_and_strata(tmp_path: Path, capsys: pytes
     out = capsys.readouterr().out
     assert "outcome-bearing" in out and "silver/task-only" in out
     assert "inter-rater" in out.lower()
+    # The admission gate reads real adjudication state on the CLI path: one
+    # human-accepted gold pr_review item in the seeded queue is outcome-bearing.
+    assert "adjudicated 1 / 1" in out
+    assert "80% gate PASS" in out
 
 
 def test_conflict_review_lists_disagreeing_raters_oldest_first(
@@ -318,7 +322,56 @@ def test_cli_materialize_missing_pin_component_exits_1(tmp_path: Path) -> None:
     ]) == 1
 
 
+def test_cli_materialize_without_as_of_is_unpinned_edge(tmp_path: Path) -> None:
+    """Empty/absent as_of is the supported unpinned edge: materializing without
+    --as-of succeeds, and the manifest + records carry the empty pin (C5/M9)."""
+    out = tmp_path / "out"
+    code = handle_adjudicate([
+        "materialize", "--index-root", str(_cli_index(tmp_path)),
+        "--out-dir", str(out), "--archive-index-digest", "c" * 64,
+        "--curation-id", "cur-1",
+        "--sanitized-hub-commit", "a" * 40,
+        "--source-hub-commit", "b" * 40,
+        "--evidence-observed-at", "2026-01-01T00:00:00+00:00",
+    ])
+    assert code == 0
+    manifest = json.loads((out / "preview-manifest.json").read_text())
+    assert manifest["as_of"] == ""
+    records = [json.loads(line) for line in
+               (out / "sessions.jsonl").read_text().splitlines()]
+    assert records and all(str(r.get("as_of", "missing")) == "" for r in records)
+
+
 def test_cli_materialize_malformed_invocation_exits_2() -> None:
     with pytest.raises(SystemExit) as excinfo:
         handle_adjudicate(["materialize", "--index-root", "/tmp"])  # missing required pin flags
     assert excinfo.value.code == 2
+
+
+def test_cli_publish_state_missing_state_file_exits_1(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing state files fail closed with exit 1, naming the offender (cli.py:31-44)."""
+    from daydream.training.adjudication import cli as adjudication_cli
+
+    class _FakeHub:
+        @property
+        def repo_private(self) -> bool:
+            return True
+
+    monkeypatch.setattr(adjudication_cli, "_make_client", lambda repo_id: _FakeHub())
+    manifest = tmp_path / "preview-manifest.json"
+    manifest.write_text(
+        json.dumps({"curation_id": "cur-1", "snapshot_id": "e" * 64}), encoding="utf-8"
+    )
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()  # queue.json / observations.jsonl / preview-ledger.json absent
+
+    assert handle_adjudicate([
+        "publish-state", "--state-dir", str(state_dir), "--manifest", str(manifest),
+    ]) == 1
+    captured = capsys.readouterr()
+    assert "publish-state failed" in captured.out + captured.err
+    assert "No such file or directory" in captured.out + captured.err  # FileNotFoundError rendered, not a traceback

--- a/tests/test_cli_adjudicate.py
+++ b/tests/test_cli_adjudicate.py
@@ -268,7 +268,7 @@ def _cli_index(tmp_path: Path) -> Path:
     return root
 
 
-def test_cli_materialize_writes_sessions_and_manifest(tmp_path: Path, capsys) -> None:
+def test_cli_materialize_writes_sessions_and_manifest(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     out = tmp_path / "out"
     code = handle_adjudicate([
         "materialize", "--index-root", str(_cli_index(tmp_path)),

--- a/tests/test_cli_adjudicate.py
+++ b/tests/test_cli_adjudicate.py
@@ -230,3 +230,95 @@ def test_adjudicate_build_preserves_observations_and_is_idempotent(tmp_path: Pat
         assert rc == 0
     queue = json.loads((tmp_path / "adj" / "queue.json").read_text())
     assert len(queue) == 2
+
+
+# ---- snapshot pipeline verbs (issue #1055, task 6) ----
+
+from daydream.training.adjudication.cli import handle_adjudicate  # noqa: E402
+from daydream.training.adjudication.materialize import run_materialize  # noqa: E402
+from daydream.training.labeler_versions import (  # noqa: E402
+    ADJUDICATION_LABELER_VERSION,
+    REPLY_CLASSIFIER_VERSION,
+    RUBRIC_SCHEMA_VERSION,
+)
+
+_PIN_ARGS = [
+    "--curation-id", "cur-1",
+    "--sanitized-hub-commit", "a" * 40,
+    "--source-hub-commit", "b" * 40,
+    "--evidence-observed-at", "2026-01-01T00:00:00+00:00",
+    "--as-of", "2026-02-01T00:00:00+00:00",
+]
+
+
+def _cli_index(tmp_path: Path) -> Path:
+    root = tmp_path / "index"
+    root.mkdir(parents=True, exist_ok=True)
+    sessions = [{
+        "session_id": "s1", "trajectory_id": "t", "segment_id": "g",
+        "resolutions": [{
+            "fingerprint": "fp", "disposition": "unanswered",
+            "evidence": [{"reply_id": 1, "body_sha256": "x"}],
+            "evidence_digest": "d" * 32, "profile": "pr_review", "stack": "python",
+        }],
+    }]
+    (root / "sessions.jsonl").write_text(
+        "".join(json.dumps(s, sort_keys=True) + "\n" for s in sessions), encoding="utf-8"
+    )
+    return root
+
+
+def test_cli_materialize_writes_sessions_and_manifest(tmp_path: Path, capsys) -> None:
+    out = tmp_path / "out"
+    code = handle_adjudicate([
+        "materialize", "--index-root", str(_cli_index(tmp_path)),
+        "--out-dir", str(out), "--archive-index-digest", "c" * 64, *_PIN_ARGS,
+    ])
+    assert code == 0
+    assert (out / "sessions.jsonl").is_file()
+    manifest = json.loads((out / "preview-manifest.json").read_text())
+    assert manifest["curation_id"] == "cur-1"
+    printed = capsys.readouterr().out
+    assert "snapshot" in printed and "record" in printed  # S2 operator summary
+
+
+def test_cli_materialize_matches_run_materialize_output(tmp_path: Path) -> None:
+    out_cli = tmp_path / "out-cli"
+    code = handle_adjudicate([
+        "materialize", "--index-root", str(_cli_index(tmp_path)),
+        "--out-dir", str(out_cli), "--archive-index-digest", "c" * 64, *_PIN_ARGS,
+    ])
+    assert code == 0
+    out_direct = tmp_path / "out-direct"
+    run_materialize(_cli_index(tmp_path / "direct"), out_direct, pin={
+        "curation_id": "cur-1", "sanitized_hub_commit": "a" * 40,
+        "source_hub_commit": "b" * 40, "archive_index_digest": "c" * 64,
+        "evidence_observed_at": "2026-01-01T00:00:00+00:00",
+        "as_of": "2026-02-01T00:00:00+00:00",
+        "labeler_version": ADJUDICATION_LABELER_VERSION,
+        "rubric_version": RUBRIC_SCHEMA_VERSION,
+        "classifier_version": REPLY_CLASSIFIER_VERSION,
+    })
+    assert (out_cli / "sessions.jsonl").read_bytes() == (out_direct / "sessions.jsonl").read_bytes()
+    assert (out_cli / "preview-manifest.json").read_bytes() == (out_direct / "preview-manifest.json").read_bytes()
+
+
+def test_cli_materialize_missing_index_exits_1(tmp_path: Path) -> None:
+    assert handle_adjudicate([
+        "materialize", "--index-root", str(tmp_path / "nope"),
+        "--out-dir", str(tmp_path / "out"), "--archive-index-digest", "c" * 64, *_PIN_ARGS,
+    ]) == 1
+
+
+def test_cli_materialize_missing_pin_component_exits_1(tmp_path: Path) -> None:
+    assert handle_adjudicate([
+        "materialize", "--index-root", str(_cli_index(tmp_path)),
+        "--out-dir", str(tmp_path / "out"), "--archive-index-digest", "c" * 64,
+        "--curation-id", "cur-1",  # missing the other pin flags
+    ]) == 1
+
+
+def test_cli_materialize_malformed_invocation_exits_2() -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        handle_adjudicate(["materialize", "--index-root", "/tmp"])  # missing required pin flags
+    assert excinfo.value.code == 2

--- a/tests/test_corpus_v2.py
+++ b/tests/test_corpus_v2.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import pytest
 
+from daydream.archive.sanitize import _derivative_digest
 from daydream.training.corpus_v2.bundle import BundleError, CuratedBundle, load_curated_bundle
 from daydream.training.corpus_v2.identity import record_id
 from daydream.training.corpus_v2.provenance import extract_provenance
@@ -140,12 +141,17 @@ def _write_annotations_snapshot(
         })
     (ann_dir / "annotations.jsonl").write_text(
         "".join(json.dumps(r, sort_keys=True) + "\n" for r in rows))
+    _write_sumsums(bundle_dir)  # the trajectory joins the curation digest pin
     manifest = json.loads((bundle_dir / "curation-manifest.json").read_text())
+    # batch_fileset_digest pins the curation bundle's canonical file-set digest
+    # (_derivative_digest = the same digest vocabulary each batch's
+    # content_digest uses) — computed AFTER the bundle is final so the gate's
+    # equality check against the bundle dir passes.
     (ann_dir / "lineage.json").write_text(json.dumps({
         "curation_id": manifest["curation_id"],
         "sanitized_hub_commit": manifest["source_hub_commit"],
         "schema_version": "annotation-snapshot/1055-snapshot-r1",
-        "batch_fileset_digest": "b" * 64,
+        "batch_fileset_digest": _derivative_digest(bundle_dir),
         "labeler_version": "v1", "rubric_version": "v1",
         "classifier_version": "v1", "as_of": None,
     }, sort_keys=True) + "\n")
@@ -154,7 +160,6 @@ def _write_annotations_snapshot(
         f"{hashlib.sha256((ann_dir / p).read_bytes()).hexdigest()}  {p}\n" for p in rel
     ))
     (ann_dir / "_SUCCESS").write_text("ok\n")
-    _write_sumsums(bundle_dir)  # the trajectory joins the curation digest pin
     return ann_dir / "annotations.jsonl"
 
 
@@ -173,14 +178,15 @@ def existing_bundle_fixture(tmp_path: Path) -> tuple[Path, list[dict[str, Any]],
 
 
 def _write_annotation_bundle(root: Path, rows: list[dict[str, Any]], *, curation_id: str,
-                             sanitized_commit: str, success: bool = True) -> Path:
+                             sanitized_commit: str, batch_fileset_digest: str,
+                             success: bool = True) -> Path:
     root.mkdir(parents=True, exist_ok=True)
     (root / "annotations.jsonl").write_text(
         "".join(json.dumps(r, sort_keys=True) + "\n" for r in rows), encoding="utf-8")
     (root / "lineage.json").write_text(json.dumps({
         "curation_id": curation_id, "sanitized_hub_commit": sanitized_commit,
         "schema_version": "annotation-snapshot/1055-snapshot-r1",
-        "batch_fileset_digest": "b" * 64,
+        "batch_fileset_digest": batch_fileset_digest,
         "labeler_version": "v1", "rubric_version": "v1",
         "classifier_version": "v1", "as_of": None,
     }, sort_keys=True) + "\n", encoding="utf-8")
@@ -719,7 +725,8 @@ def test_build_v2_accepts_separate_annotation_bundle_with_exact_linkage(
     bundle_dir, snapshot_rows, kwargs = existing_bundle_fixture
     ann = _write_annotation_bundle(
         tmp_path / "ann", snapshot_rows,
-        curation_id=kwargs["curation_id"], sanitized_commit=kwargs["hub_commit"])
+        curation_id=kwargs["curation_id"], sanitized_commit=kwargs["hub_commit"],
+        batch_fileset_digest=_derivative_digest(bundle_dir))
     config = BuildCorpusV2Config(out_dir=tmp_path / "out", bundle_dir=bundle_dir,
                                  annotation_bundle_dir=ann)
     summary = run_build_corpus_v2(config)
@@ -730,7 +737,7 @@ def test_build_v2_accepts_separate_annotation_bundle_with_exact_linkage(
 
 
 @pytest.mark.parametrize("mutate", ["missing_success", "wrong_curation", "wrong_commit",
-                                    "corrupt_checksum", "missing_success_after"])
+                                    "wrong_fileset", "corrupt_checksum", "missing_success_after"])
 def test_build_v2_refuses_broken_annotation_bundles(
     tmp_path: Path,
     existing_bundle_fixture: tuple[Path, list[dict[str, Any]], dict[str, str]],
@@ -740,15 +747,20 @@ def test_build_v2_refuses_broken_annotation_bundles(
     ann = _write_annotation_bundle(
         tmp_path / "ann", snapshot_rows,
         curation_id=kwargs["curation_id"], sanitized_commit=kwargs["hub_commit"],
+        batch_fileset_digest=_derivative_digest(bundle_dir),
         success=mutate not in ("missing_success", "missing_success_after"))
     lineage = json.loads((ann / "lineage.json").read_text())
     if mutate == "wrong_curation":
         lineage["curation_id"] = "other"
     elif mutate == "wrong_commit":
         lineage["sanitized_hub_commit"] = "0" * 40
+    elif mutate == "wrong_fileset":
+        # a stale annotation bundle records the older curation file set's
+        # digest — same curation_id + commit, different batch bytes
+        lineage["batch_fileset_digest"] = "f" * 64
     elif mutate == "corrupt_checksum":
         (ann / "annotations.jsonl").write_text("tampered\n", encoding="utf-8")
-    if mutate in ("wrong_curation", "wrong_commit"):
+    if mutate in ("wrong_curation", "wrong_commit", "wrong_fileset"):
         (ann / "lineage.json").write_text(json.dumps(lineage, sort_keys=True) + "\n", encoding="utf-8")
     config = BuildCorpusV2Config(out_dir=tmp_path / "out", bundle_dir=bundle_dir,
                                  annotation_bundle_dir=ann)

--- a/tests/test_corpus_v2.py
+++ b/tests/test_corpus_v2.py
@@ -80,7 +80,8 @@ def _write_bundle(tmp_path: Path, *, with_success: bool = True, corrupt_digest: 
 def _cfg(out_dir: Path, bundle_dir: Path, snapshot: Path, **kw: Any) -> Any:
     from daydream.training.corpus_v2.projector import BuildCorpusV2Config
 
-    return BuildCorpusV2Config(out_dir=out_dir, bundle_dir=bundle_dir, annotations_snapshot=snapshot, **kw)
+    return BuildCorpusV2Config(out_dir=out_dir, bundle_dir=bundle_dir,
+                               annotation_bundle_dir=snapshot.parent, **kw)
 
 
 def _write_annotations_snapshot(
@@ -91,11 +92,11 @@ def _write_annotations_snapshot(
     dispositions: list[str] | None = None,
     n_siblings: int = 1,
 ) -> Path:
-    """Task 0A side-car shape: a digest-pinned JSONL of per-finding
-    resolution records keyed by fingerprint, exported alongside the bundle
-    and covered by SHA256SUMS. Also gives the admitted batch a real ATIF
-    trajectory so segmentation has something to segment (``n_siblings``
-    sibling subagent refs)."""
+    """Two-bundle shape: a self-verified annotation bundle (its own
+    SHA256SUMS + _SUCCESS + lineage.json) whose ``annotations.jsonl``
+    carries per-finding resolution records keyed by ``record_id``. Also
+    gives the admitted batch a real ATIF trajectory so segmentation has
+    something to segment (``n_siblings`` sibling subagent refs)."""
     trajectory = {
         "session_id": session_id,
         "trajectory_id": f"{session_id}:root",
@@ -111,7 +112,10 @@ def _write_annotations_snapshot(
     (bundle_dir / "batches" / session_id / "trajectory.json").write_text(
         json.dumps(trajectory) + "\n"
     )
-    snapshot_path = bundle_dir / "annotations-snapshot.jsonl"
+    from daydream.training.corpus_v2.identity import record_id as _record_id
+
+    ann_dir = bundle_dir.parent / f"{bundle_dir.name}-annotations"
+    ann_dir.mkdir(parents=True, exist_ok=True)
     fps = ["a1" * 32, "b2" * 32, "c3" * 32]
     rows = []
     for i, disposition in enumerate(dispositions or ["accepted", "rejected", "ambiguous"]):
@@ -121,13 +125,67 @@ def _write_annotations_snapshot(
             if disposition in ("accepted", "rejected")
             else []
         )
-        rows.append({"session_id": session_id, "fingerprint": fps[i % len(fps)],
-                     "disposition": disposition, "evidence": evidence,
-                     "profile_schema_version": 2, "profile_name": "deep-review",
-                     "profile_source_kind": "builtin", "profile_digest": "d" * 64})
-    snapshot_path.write_text("".join(json.dumps(r, sort_keys=True) + "\n" for r in rows))
-    _write_sumsums(bundle_dir)  # the snapshot + trajectory join the digest pin
-    return snapshot_path
+        fingerprint = fps[i % len(fps)]
+        rows.append({
+            "record_id": _record_id(session_id, f"{session_id}:root", "seg-0", fingerprint),
+            "session_id": session_id, "fingerprint": fingerprint,
+            "disposition": disposition, "evidence": evidence,
+            "profile_schema_version": 2, "profile_name": "deep-review",
+            "profile_source_kind": "builtin", "profile_digest": "d" * 64,
+        })
+    (ann_dir / "annotations.jsonl").write_text(
+        "".join(json.dumps(r, sort_keys=True) + "\n" for r in rows))
+    manifest = json.loads((bundle_dir / "curation-manifest.json").read_text())
+    (ann_dir / "lineage.json").write_text(json.dumps({
+        "curation_id": manifest["curation_id"],
+        "sanitized_hub_commit": manifest["source_hub_commit"],
+        "schema_version": "annotation-snapshot/1055-snapshot-r1",
+        "batch_fileset_digest": "b" * 64,
+        "labeler_version": "v1", "rubric_version": "v1",
+        "classifier_version": "v1", "as_of": None,
+    }, sort_keys=True) + "\n")
+    rel = sorted(p.relative_to(ann_dir).as_posix() for p in ann_dir.rglob("*") if p.is_file())
+    (ann_dir / "SHA256SUMS").write_text("".join(
+        f"{hashlib.sha256((ann_dir / p).read_bytes()).hexdigest()}  {p}\n" for p in rel
+    ))
+    (ann_dir / "_SUCCESS").write_text("ok\n")
+    _write_sumsums(bundle_dir)  # the trajectory joins the curation digest pin
+    return ann_dir / "annotations.jsonl"
+
+
+@pytest.fixture
+def existing_bundle_fixture(tmp_path: Path) -> tuple[Path, list[dict[str, Any]], dict[str, str]]:
+    """The standard curated-bundle + annotation-bundle pair the two-bundle
+    contract tests build on: bundle dir, the annotation rows (as JSON), and
+    the linkage kwargs (curation id / hub commit)."""
+    bundle_dir = _write_bundle(tmp_path)
+    snap = _write_annotations_snapshot(bundle_dir, dispositions=["accepted", "rejected"])
+    rows = [json.loads(line) for line in snap.read_text().splitlines() if line.strip()]
+    manifest = json.loads((bundle_dir / "curation-manifest.json").read_text())
+    kwargs = {"curation_id": manifest["curation_id"],
+              "hub_commit": manifest["source_hub_commit"]}
+    return bundle_dir, rows, kwargs
+
+
+def _write_annotation_bundle(root: Path, rows: list[dict[str, Any]], *, curation_id: str,
+                             sanitized_commit: str, success: bool = True) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "annotations.jsonl").write_text(
+        "".join(json.dumps(r, sort_keys=True) + "\n" for r in rows), encoding="utf-8")
+    (root / "lineage.json").write_text(json.dumps({
+        "curation_id": curation_id, "sanitized_hub_commit": sanitized_commit,
+        "schema_version": "annotation-snapshot/1055-snapshot-r1",
+        "batch_fileset_digest": "b" * 64,
+        "labeler_version": "v1", "rubric_version": "v1",
+        "classifier_version": "v1", "as_of": None,
+    }, sort_keys=True) + "\n", encoding="utf-8")
+    rel = sorted(p.relative_to(root).as_posix() for p in root.rglob("*") if p.is_file())
+    (root / "SHA256SUMS").write_text("".join(
+        f"{hashlib.sha256((root / p).read_bytes()).hexdigest()}  {p}\n" for p in rel
+    ), encoding="utf-8")
+    if success:
+        (root / "_SUCCESS").write_text("ok\n", encoding="utf-8")
+    return root
 
 
 def test_load_bundle_requires_success_marker(tmp_path: Path) -> None:
@@ -379,7 +437,7 @@ def test_run_level_contested_aggregate_never_erases_split() -> None:
 # Task 9: summary + full lineage + adjudication report
 # ---------------------------------------------------------------------------
 
-from daydream.training.corpus_v2.projector import run_build_corpus_v2  # noqa: E402
+from daydream.training.corpus_v2.projector import BuildCorpusV2Config, run_build_corpus_v2  # noqa: E402
 
 
 def test_build_summary_and_lineage_are_complete(tmp_path: Path) -> None:
@@ -585,7 +643,8 @@ def test_cli_build_v2_projects_real_bundle(tmp_path: Path) -> None:
     bundle_dir = _write_bundle(tmp_path)
     snap = _write_annotations_snapshot(bundle_dir)
     rc = _run_cli(["corpus", "build-v2", "--bundle-root", str(bundle_dir),
-                   "--annotations-snapshot", str(snap), "--out", str(tmp_path / "out" / "c.jsonl")])
+                   "--annotation-bundle-root", str(snap.parent),
+                   "--out", str(tmp_path / "out" / "c.jsonl")])
     assert rc == 0
     assert (tmp_path / "out" / "corpus-v2.jsonl").is_file()
     assert (tmp_path / "out" / "lineage.json").is_file()
@@ -593,7 +652,66 @@ def test_cli_build_v2_projects_real_bundle(tmp_path: Path) -> None:
 
 def test_cli_build_v2_refuses_missing_bundle_fail_closed(tmp_path: Path) -> None:
     rc = _run_cli(["corpus", "build-v2", "--bundle-root", str(tmp_path / "nope"),
-                   "--annotations-snapshot", str(tmp_path / "nope" / "snap.jsonl"),
+                   "--annotation-bundle-root", str(tmp_path / "nope" / "ann"),
                    "--out", str(tmp_path / "out" / "c.jsonl")])
     assert rc != 0
     assert not (tmp_path / "out" / "lineage.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Task 7: two-bundle build-v2 contract (annotation bundle self-verification +
+# cross-bundle linkage replaces the snapshot SHA256SUMS pin)
+# ---------------------------------------------------------------------------
+
+
+def test_build_v2_accepts_separate_annotation_bundle_with_exact_linkage(
+    tmp_path: Path,
+    existing_bundle_fixture: tuple[Path, list[dict[str, Any]], dict[str, str]],
+) -> None:
+    bundle_dir, snapshot_rows, kwargs = existing_bundle_fixture
+    ann = _write_annotation_bundle(
+        tmp_path / "ann", snapshot_rows,
+        curation_id=kwargs["curation_id"], sanitized_commit=kwargs["hub_commit"])
+    config = BuildCorpusV2Config(out_dir=tmp_path / "out", bundle_dir=bundle_dir,
+                                 annotation_bundle_dir=ann)
+    summary = run_build_corpus_v2(config)
+    assert summary["emitted"] > 0
+    # curation bundle untouched (K3: no mutation of the finalized bundle)
+    sums_before = (bundle_dir / "SHA256SUMS").read_bytes()
+    assert (bundle_dir / "SHA256SUMS").read_bytes() == sums_before
+
+
+@pytest.mark.parametrize("mutate", ["missing_success", "wrong_curation", "wrong_commit",
+                                    "corrupt_checksum", "missing_success_after"])
+def test_build_v2_refuses_broken_annotation_bundles(
+    tmp_path: Path,
+    existing_bundle_fixture: tuple[Path, list[dict[str, Any]], dict[str, str]],
+    mutate: str,
+) -> None:
+    bundle_dir, snapshot_rows, kwargs = existing_bundle_fixture
+    ann = _write_annotation_bundle(
+        tmp_path / "ann", snapshot_rows,
+        curation_id=kwargs["curation_id"], sanitized_commit=kwargs["hub_commit"],
+        success=mutate not in ("missing_success", "missing_success_after"))
+    lineage = json.loads((ann / "lineage.json").read_text())
+    if mutate == "wrong_curation":
+        lineage["curation_id"] = "other"
+    elif mutate == "wrong_commit":
+        lineage["sanitized_hub_commit"] = "0" * 40
+    elif mutate == "corrupt_checksum":
+        (ann / "annotations.jsonl").write_text("tampered\n", encoding="utf-8")
+    if mutate in ("wrong_curation", "wrong_commit"):
+        (ann / "lineage.json").write_text(json.dumps(lineage, sort_keys=True) + "\n", encoding="utf-8")
+    config = BuildCorpusV2Config(out_dir=tmp_path / "out", bundle_dir=bundle_dir,
+                                 annotation_bundle_dir=ann)
+    with pytest.raises(ValueError):
+        run_build_corpus_v2(config)
+
+
+def test_build_v2_still_works_without_annotation_bundle_dir_raises(
+    tmp_path: Path,
+    existing_bundle_fixture: tuple[Path, list[dict[str, Any]], dict[str, str]],
+) -> None:
+    bundle_dir, _rows, kwargs = existing_bundle_fixture
+    with pytest.raises(ValueError, match="annotation_bundle_dir"):
+        BuildCorpusV2Config(out_dir=tmp_path / "out", bundle_dir=bundle_dir)

--- a/tests/test_corpus_v2.py
+++ b/tests/test_corpus_v2.py
@@ -130,8 +130,13 @@ def _write_annotations_snapshot(
             "record_id": _record_id(session_id, f"{session_id}:root", "seg-0", fingerprint),
             "session_id": session_id, "fingerprint": fingerprint,
             "disposition": disposition, "evidence": evidence,
-            "profile_schema_version": 2, "profile_name": "deep-review",
-            "profile_source_kind": "builtin", "profile_digest": "d" * 64,
+            # Real canonical-record shape (adjudication/snapshot.py:
+            # build_canonical_record): the four review-profile fields nest
+            # under "profile" with only "stack" at top level — the projector
+            # must surface both at the two-bundle projection boundary.
+            "profile": {"profile_schema_version": 2, "profile_name": "deep-review",
+                        "profile_source_kind": "builtin", "profile_digest": "d" * 64},
+            "stack": "python",
         })
     (ann_dir / "annotations.jsonl").write_text(
         "".join(json.dumps(r, sort_keys=True) + "\n" for r in rows))
@@ -244,13 +249,16 @@ def test_record_id_is_deterministic_sha256_of_canonical_join() -> None:
 
 
 def _resolution(
-    disposition: str, *, reward: dict[str, object] | None = None, score: float | None = None
+    disposition: str, *, reward: dict[str, object] | None = None, score: float | None = None,
+    evidence_after_as_of: bool = False,
 ) -> dict[str, object]:
     r: dict[str, object] = {
         "fingerprint": "ab" * 32,
         "disposition": disposition,
         "evidence": [{"created_at": "2026-02-01T00:00:00+00:00"}],
     }
+    if evidence_after_as_of:
+        r["evidence_after_as_of"] = True
     if reward is not None:
         r["intrinsic_reward"] = reward
     if score is not None:
@@ -277,6 +285,16 @@ def test_intrinsic_reward_and_llm_score_cannot_promote_gold() -> None:
         classify_tier("accepted")  # type: ignore[arg-type]  # gold input must carry evidence, not a bare label
     with pytest.raises(GoldGateError):
         classify_tier({"fingerprint": "ab" * 32, "disposition": "accepted", "evidence": []})
+
+
+def test_evidence_after_as_of_rows_are_never_gold() -> None:
+    # C5/M9 recorded-and-flagged edge: evidence observed after the pin's
+    # as_of keeps its evidence but is never gold-eligible — a decisive
+    # flagged record classifies silver, never gold.
+    assert classify_tier(_resolution("accepted", evidence_after_as_of=True)) == "silver"
+    assert classify_tier(_resolution("rejected", evidence_after_as_of=True)) == "silver"
+    assert classify_tier(_resolution("accepted", evidence_after_as_of=False)) == "gold"
+    assert classify_tier(_resolution("accepted")) == "gold"
 
 
 def test_tiers_are_disjoint_classes() -> None:
@@ -467,6 +485,36 @@ def test_projected_records_carry_profile_and_stack_provenance(tmp_path: Path) ->
         assert rec["profile"] == {"profile_schema_version": 2, "profile_name": "deep-review",
                                    "profile_source_kind": "builtin", "profile_digest": "d" * 64}
         assert "stack" in rec  # schema-required provenance key, never dropped
+
+
+def test_evidence_after_as_of_findings_never_emit_gold(tmp_path: Path) -> None:
+    """The emission boundary honors the canonical harvest's flag: a decisive
+    finding with evidence after the pin's as_of emits silver (outcome_label
+    None), never gold, into corpus.jsonl — the ``evidence_after_as_of``
+    policy is enforced, not just recorded."""
+    bundle_dir = _write_bundle(tmp_path)
+    snap = _write_annotations_snapshot(bundle_dir, dispositions=["accepted"])
+    rows = [json.loads(line) for line in snap.read_text().splitlines() if line.strip()]
+    for row in rows:
+        row["evidence_after_as_of"] = True
+    snap.write_text("".join(json.dumps(r, sort_keys=True) + "\n" for r in rows))
+    # annotations.jsonl changed: regenerate the annotation bundle's checksums
+    # exactly as the fixture does (no SHA256SUMS self-line — it does not exist
+    # when the fixture computes the listing).
+    ann_dir = snap.parent
+    rel = sorted(
+        p.relative_to(ann_dir).as_posix()
+        for p in ann_dir.rglob("*") if p.is_file() and p.name != "SHA256SUMS"
+    )
+    (ann_dir / "SHA256SUMS").write_text("".join(
+        f"{hashlib.sha256((ann_dir / p).read_bytes()).hexdigest()}  {p}\n" for p in rel
+    ))
+    summary = run_build_corpus_v2(_cfg(tmp_path / "out", bundle_dir, snap))
+    assert summary["records_by_tier"] == {"silver": 1}
+    records = [json.loads(line) for line in
+               (tmp_path / "out" / "corpus.jsonl").read_text().splitlines() if line]
+    assert records and records[0]["tier"] == "silver"
+    assert records[0]["outcome_label"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_corpus_v2_reproducibility.py
+++ b/tests/test_corpus_v2_reproducibility.py
@@ -104,7 +104,7 @@ def test_v1_and_v2_projection_paths_are_independent(tmp_path: Path, archive_dir:
         bundle_dir = _write_bundle(out_dir)
         snap = _write_annotations_snapshot(bundle_dir)
         run_build_corpus_v2(BuildCorpusV2Config(out_dir=out_dir / "out", bundle_dir=bundle_dir,
-                                                annotations_snapshot=snap))
+                                                annotation_bundle_dir=snap.parent))
         return out_dir / "out" / "corpus.jsonl"
 
     v1_before = _run_v1_build(tmp_path / "v1a" / "corpus.jsonl").read_bytes()

--- a/tests/test_training_adjudication_canonical.py
+++ b/tests/test_training_adjudication_canonical.py
@@ -29,7 +29,8 @@ def _index(tmp_path: Path, digest: str = "d" * 32) -> Path:
         "session_id": "s1", "trajectory_id": "s1-t", "segment_id": "s1-seg",
         "resolutions": [{
             "fingerprint": "fp-1", "disposition": "unanswered",
-            "evidence": [{"reply_id": 1, "body_sha256": "abc"}],
+            "evidence": [{"reply_id": 1, "body_sha256": "abc",
+                          "created_at": "2026-01-01T00:00:00+00:00"}],
             "evidence_digest": digest, "profile": "pr_review", "stack": "python",
             "comment_id": 7,
         }],
@@ -102,6 +103,87 @@ def test_canonical_harvest_fails_closed_on_drift_before_any_write(tmp_path: Path
     assert excinfo.value.requeued_record_ids  # named for requeue (AC 4/M5)
     assert label_observation_history(archive, "s1") == []  # nothing written
     assert not (tmp_path / "mat" / "annotations.jsonl").exists()
+
+
+def test_canonical_harvest_fails_closed_when_record_absent_from_fresh_queue(
+    tmp_path: Path,
+) -> None:
+    """Sibling fail-closed gate: a materialized record_id absent from the freshly
+    built queue raises ValueError before any write (the absent-from-queue branch,
+    not the digest-drift branch)."""
+    root = _index(tmp_path)
+    archive = tmp_path / "archive"
+    run_materialize(root, tmp_path / "mat", pin=_PIN)
+    # The index is swapped out wholesale: the materialized s1 record no longer
+    # exists in the freshly built queue.
+    sessions = json.loads((root / "sessions.jsonl").read_text().splitlines()[0])
+    sessions["session_id"] = "gone"
+    (root / "sessions.jsonl").write_text(
+        json.dumps(sessions, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    with pytest.raises(ValueError, match="absent from the freshly built"):
+        run_canonical_harvest(
+            index_root=root, materialize_dir=tmp_path / "mat", archive_dir=archive,
+            observations_path=None,
+        )
+    assert not (tmp_path / "mat" / "annotations.jsonl").exists()
+
+
+def test_canonical_harvest_fails_closed_on_missing_materialized_outputs(
+    tmp_path: Path,
+) -> None:
+    """Sibling fail-closed gate: a materialize_dir missing the preview manifest or
+    the materialized sessions.jsonl raises FileNotFoundError before any write."""
+    root = _index(tmp_path)
+    archive = tmp_path / "archive"
+    # No manifest at all: _load_pin refuses.
+    missing_manifest = tmp_path / "missing-manifest"
+    with pytest.raises(FileNotFoundError, match="preview manifest not found"):
+        run_canonical_harvest(
+            index_root=root, materialize_dir=missing_manifest, archive_dir=archive,
+            observations_path=None,
+        )
+    # Manifest present but sessions.jsonl absent: _load_materialized_records refuses.
+    mat = tmp_path / "mat"
+    mat.mkdir()
+    (mat / "preview-manifest.json").write_text(
+        json.dumps(_PIN, sort_keys=True), encoding="utf-8"
+    )
+    with pytest.raises(FileNotFoundError, match="materialized preview snapshot not found"):
+        run_canonical_harvest(
+            index_root=root, materialize_dir=mat, archive_dir=archive,
+            observations_path=None,
+        )
+    assert not (mat / "annotations.jsonl").exists()
+
+
+def test_canonical_harvest_fails_closed_on_unreadable_materialized_outputs(
+    tmp_path: Path,
+) -> None:
+    """Sibling fail-closed gate: an unreadable preview manifest or materialized
+    sessions.jsonl raises ValueError before any write."""
+    root = _index(tmp_path)
+    archive = tmp_path / "archive"
+    bad_manifest = tmp_path / "bad-manifest"
+    bad_manifest.mkdir()
+    (bad_manifest / "preview-manifest.json").write_text("{not json\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="unreadable preview manifest"):
+        run_canonical_harvest(
+            index_root=root, materialize_dir=bad_manifest, archive_dir=archive,
+            observations_path=None,
+        )
+    mat = tmp_path / "mat"
+    mat.mkdir()
+    (mat / "preview-manifest.json").write_text(
+        json.dumps(_PIN, sort_keys=True), encoding="utf-8"
+    )
+    (mat / "sessions.jsonl").write_text("{not json\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="unreadable materialized snapshot"):
+        run_canonical_harvest(
+            index_root=root, materialize_dir=mat, archive_dir=archive,
+            observations_path=None,
+        )
+    assert not (mat / "annotations.jsonl").exists()
 
 
 def test_canonical_harvest_merges_human_observations_by_precedence(tmp_path: Path) -> None:
@@ -216,7 +298,75 @@ def test_canonical_harvest_flags_evidence_after_as_of(tmp_path: Path) -> None:
     records = [json.loads(line) for line in
                (tmp_path / "mat2" / "annotations.jsonl").read_text().splitlines()]
     assert records[0]["evidence_after_as_of"] is True
-    # The first (pre-pin) harvest stays unflagged.
+    # The first (pre-pin) harvest carries a before-pin created_at
+    # (2026-01-01T00:00:00+00:00 < as_of 2026-02-01T00:00:00+00:00) and stays
+    # unflagged — a real timestamp comparison, not the missing-key guard.
     first = [json.loads(line) for line in
              (tmp_path / "mat" / "annotations.jsonl").read_text().splitlines()]
     assert first[0]["evidence_after_as_of"] is False
+
+
+def test_canonical_harvest_changed_pin_appends_new_generation(tmp_path: Path) -> None:
+    """A re-harvest under a changed pin (new as_of/rubric_version ⇒ new
+    snapshot_id) appends a fresh ``label_observations`` generation instead of
+    silently dedup-skipping: the archived ``rubric_json`` must carry the new
+    pin's flags exactly like the rewritten ``annotations.jsonl`` (no bitemporal
+    divergence between the archive row and the emitted bundle)."""
+    root = _index(tmp_path)
+    archive = tmp_path / "archive"
+    _seed_archive(archive)
+    # Evidence observed after pin-a's as_of but before pin-b's: only the
+    # second, re-pinned harvest may flag evidence_after_as_of.
+    sessions = [{
+        "session_id": "s1", "trajectory_id": "s1-t", "segment_id": "s1-seg",
+        "resolutions": [{
+            "fingerprint": "fp-1", "disposition": "unanswered",
+            "evidence": [{"reply_id": 1, "body_sha256": "abc",
+                          "created_at": "2026-02-15T00:00:00+00:00"}],
+            "evidence_digest": "d" * 32, "profile": "pr_review", "stack": "python",
+            "comment_id": 7,
+        }],
+    }]
+    (root / "sessions.jsonl").write_text(
+        "".join(json.dumps(s, sort_keys=True) + "\n" for s in sessions), encoding="utf-8"
+    )
+    pin_a = dict(_PIN, as_of="2026-03-01T00:00:00+00:00")  # evidence before as_of
+    pin_b = dict(_PIN, as_of="2026-02-01T00:00:00+00:00", rubric_version="v2")  # after
+    run_materialize(root, tmp_path / "mat-a", pin=pin_a)
+    out_a = run_canonical_harvest(
+        index_root=root, materialize_dir=tmp_path / "mat-a", archive_dir=archive,
+        observations_path=None,
+    )
+    assert out_a["appended_sessions"] == 1
+    assert out_a["evidence_after_as_of"] == []
+    run_materialize(root, tmp_path / "mat-b", pin=pin_b)
+    out_b = run_canonical_harvest(
+        index_root=root, materialize_dir=tmp_path / "mat-b", archive_dir=archive,
+        observations_path=None,
+    )
+    # Changed pin ⇒ a fresh generation, never a silent dedup skip (the
+    # evidence/labels/digest are all unchanged between the two harvests).
+    assert out_b["appended_sessions"] == 1
+    assert out_b["skipped_sessions"] == 0
+    history = label_observation_history(archive, "s1")
+    assert len(history) == 2
+    latest = history[-1]
+    # The archived row names the exact snapshot it was harvested under.
+    manifest = json.loads((tmp_path / "mat-b" / "preview-manifest.json").read_text())
+    assert latest["evidence_sha"] == manifest["snapshot_id"]
+    rubric = json.loads(latest["rubric_json"])
+    stored = rubric.get("per_finding_outcomes") or rubric.get("per_finding_resolutions")
+    assert rubric["rubric_version"] == "v2"
+    assert stored[0]["evidence_after_as_of"] is True
+    # The archived row and the emitted bundle agree on the new pin's flag.
+    emitted = [json.loads(line) for line in
+               (tmp_path / "mat-b" / "annotations.jsonl").read_text().splitlines()
+               if line.strip()]
+    assert emitted[0]["evidence_after_as_of"] is True
+    # Exactly-once still holds for an unchanged re-run under the same pin.
+    out_c = run_canonical_harvest(
+        index_root=root, materialize_dir=tmp_path / "mat-b", archive_dir=archive,
+        observations_path=None,
+    )
+    assert out_c["appended_sessions"] == 0
+    assert len(label_observation_history(archive, "s1")) == 2

--- a/tests/test_training_adjudication_canonical.py
+++ b/tests/test_training_adjudication_canonical.py
@@ -4,6 +4,7 @@ Drift gate fail-closed pre-write, three-tier precedence merge, and the
 exactly-once ``label_observations`` append (M5/M8).
 """
 
+import hashlib
 import json
 from pathlib import Path
 
@@ -351,9 +352,14 @@ def test_canonical_harvest_changed_pin_appends_new_generation(tmp_path: Path) ->
     history = label_observation_history(archive, "s1")
     assert len(history) == 2
     latest = history[-1]
-    # The archived row names the exact snapshot it was harvested under.
+    # The archived row names the exact generation it was harvested under: a
+    # digest over the content-addressed snapshot_id plus the archived
+    # rubric_json (the dedup tuple omits rubric_json, M14), so the digest
+    # also proves the archive and the emitted bundle agree on the pin/flags.
     manifest = json.loads((tmp_path / "mat-b" / "preview-manifest.json").read_text())
-    assert latest["evidence_sha"] == manifest["snapshot_id"]
+    assert latest["evidence_sha"] == hashlib.sha256(
+        (manifest["snapshot_id"] + ":" + latest["rubric_json"]).encode("utf-8")
+    ).hexdigest()
     rubric = json.loads(latest["rubric_json"])
     stored = rubric.get("per_finding_outcomes") or rubric.get("per_finding_resolutions")
     assert rubric["rubric_version"] == "v2"
@@ -369,4 +375,65 @@ def test_canonical_harvest_changed_pin_appends_new_generation(tmp_path: Path) ->
         observations_path=None,
     )
     assert out_c["appended_sessions"] == 0
+    assert len(label_observation_history(archive, "s1")) == 2
+
+
+def test_canonical_harvest_label_preserving_overlay_change_skips_nothing(
+    tmp_path: Path,
+) -> None:
+    """Unchanged pin + a label-preserving observation-overlay edit (the
+    disposition set stays put) still appends a fresh generation: the dedup
+    tuple omits ``rubric_json``, so the rubric-content digest riding on
+    ``evidence_sha`` is what prevents the archived rubric from going stale
+    while ``annotations.jsonl`` is re-emitted from the new overlay (M14)."""
+    root = _index(tmp_path)
+    archive = tmp_path / "archive"
+    _seed_archive(archive)
+    run_materialize(root, tmp_path / "mat", pin=_PIN)
+    from daydream.training.corpus_v2.identity import record_id
+
+    rid = record_id("s1", "s1-t", "s1-seg", "fp-1")
+    obs = tmp_path / "observations.jsonl"
+    obs.write_text(json.dumps({
+        "record_id": rid, "disposition": "accepted", "evidence_digest": "d" * 32,
+        "evidence": [], "labeler": "alice", "role": "rater", "rationale": "first pass",
+        "valid_at": "2026-01-02T00:00:00+00:00",
+        "observed_at": "2026-01-02T01:00:00+00:00", "rubric_version": "v1",
+    }) + "\n", encoding="utf-8")
+    out1 = run_canonical_harvest(
+        index_root=root, materialize_dir=tmp_path / "mat", archive_dir=archive,
+        observations_path=obs,
+    )
+    assert out1["appended_sessions"] == 1
+    # Same pin, same materialized snapshot, but a different human labeler
+    # re-affirms the same decisive disposition: the archived labels set is
+    # unchanged, so only the rubric-content digest can tell the generations
+    # apart.
+    obs.write_text(json.dumps({
+        "record_id": rid, "disposition": "accepted", "evidence_digest": "d" * 32,
+        "evidence": [], "labeler": "bob", "role": "adjudicator", "rationale": "second pass",
+        "valid_at": "2026-01-02T00:00:00+00:00",
+        "observed_at": "2026-01-02T02:00:00+00:00", "rubric_version": "v1",
+    }) + "\n", encoding="utf-8")
+    out2 = run_canonical_harvest(
+        index_root=root, materialize_dir=tmp_path / "mat", archive_dir=archive,
+        observations_path=obs,
+    )
+    assert out2["appended_sessions"] == 1  # fresh generation, never a silent skip
+    history = label_observation_history(archive, "s1")
+    assert len(history) == 2
+    rubric = json.loads(history[-1]["rubric_json"])
+    stored = rubric.get("per_finding_outcomes") or rubric.get("per_finding_resolutions")
+    assert stored[0]["human_labeler"] == "bob"
+    # The archived rubric matches the emitted bundle's overlay.
+    emitted = [json.loads(line) for line in
+               (tmp_path / "mat" / "annotations.jsonl").read_text().splitlines()
+               if line.strip()]
+    assert emitted[0]["human_labeler"] == "bob"
+    # Unchanged everything (pin + rubric) stays exactly-once.
+    out3 = run_canonical_harvest(
+        index_root=root, materialize_dir=tmp_path / "mat", archive_dir=archive,
+        observations_path=obs,
+    )
+    assert out3["appended_sessions"] == 0
     assert len(label_observation_history(archive, "s1")) == 2

--- a/tests/test_training_adjudication_canonical.py
+++ b/tests/test_training_adjudication_canonical.py
@@ -169,3 +169,54 @@ def test_canonical_harvest_emits_annotations_jsonl_from_merged_records(tmp_path:
     for line in lines:
         assert line == json.dumps(json.loads(line), sort_keys=True,
                                   separators=(",", ":"), ensure_ascii=False)
+
+
+def test_canonical_harvest_flags_evidence_after_as_of(tmp_path: Path) -> None:
+    """Recorded-and-flagged as_of edge policy: evidence observed after the pin's
+    ``as_of`` keeps its evidence but is stamped ``evidence_after_as_of=True``
+    (never gold-eligible downstream); evidence before the pin stays False."""
+    root = _index(tmp_path)
+    archive = tmp_path / "archive"
+    _seed_archive(archive)
+    conn = _get_connection(archive)
+    conn.execute(
+        "INSERT INTO runs (session_id, archived_at, run_flow, archive_path) "
+        "VALUES ('s2', '2026-01-01T00:00:00+00:00', 'deep', 'archive/s2')"
+    )
+    conn.commit()
+    conn.close()
+    run_materialize(root, tmp_path / "mat", pin=_PIN)
+    run_canonical_harvest(
+        index_root=root, materialize_dir=tmp_path / "mat", archive_dir=archive,
+        observations_path=None,
+    )
+    # Second index whose evidence carries a created_at after the pin
+    # (2026-02-01T00:00:00+00:00).
+    sessions = [{
+        "session_id": "s2", "trajectory_id": "s2-t", "segment_id": "s2-seg",
+        "resolutions": [{
+            "fingerprint": "fp-1", "disposition": "unanswered",
+            "evidence": [{"reply_id": 1, "body_sha256": "abc",
+                          "created_at": "2026-03-01T00:00:00+00:00"}],
+            "evidence_digest": "d" * 32, "profile": "pr_review", "stack": "python",
+            "comment_id": 7,
+        }],
+    }]
+    (root / "sessions.jsonl").write_text(
+        "".join(json.dumps(s, sort_keys=True) + "\n" for s in sessions), encoding="utf-8"
+    )
+    run_materialize(root, tmp_path / "mat2", pin=_PIN)
+    out = run_canonical_harvest(
+        index_root=root, materialize_dir=tmp_path / "mat2", archive_dir=archive,
+        observations_path=None,
+    )
+    assert out["evidence_after_as_of"] == [json.loads(
+        (tmp_path / "mat2" / "annotations.jsonl").read_text().splitlines()[0]
+    )["record_id"]]
+    records = [json.loads(line) for line in
+               (tmp_path / "mat2" / "annotations.jsonl").read_text().splitlines()]
+    assert records[0]["evidence_after_as_of"] is True
+    # The first (pre-pin) harvest stays unflagged.
+    first = [json.loads(line) for line in
+             (tmp_path / "mat" / "annotations.jsonl").read_text().splitlines()]
+    assert first[0]["evidence_after_as_of"] is False

--- a/tests/test_training_adjudication_canonical.py
+++ b/tests/test_training_adjudication_canonical.py
@@ -1,0 +1,171 @@
+"""Canonical harvest tests (issue #1055, Task 4).
+
+Drift gate fail-closed pre-write, three-tier precedence merge, and the
+exactly-once ``label_observations`` append (M5/M8).
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from daydream.archive.index import _get_connection, label_observation_history
+from daydream.training.adjudication.canonical import AnnotationDriftError, run_canonical_harvest
+from daydream.training.adjudication.materialize import run_materialize
+
+_PIN = {
+    "curation_id": "cur-1", "sanitized_hub_commit": "a" * 40,
+    "source_hub_commit": "b" * 40, "archive_index_digest": "c" * 64,
+    "evidence_observed_at": "2026-01-01T00:00:00+00:00",
+    "as_of": "2026-02-01T00:00:00+00:00",
+    "labeler_version": "v1", "rubric_version": "v1", "classifier_version": "v1",
+}
+
+
+def _index(tmp_path: Path, digest: str = "d" * 32) -> Path:
+    root = tmp_path / "index"
+    root.mkdir(exist_ok=True)
+    sessions = [{
+        "session_id": "s1", "trajectory_id": "s1-t", "segment_id": "s1-seg",
+        "resolutions": [{
+            "fingerprint": "fp-1", "disposition": "unanswered",
+            "evidence": [{"reply_id": 1, "body_sha256": "abc"}],
+            "evidence_digest": digest, "profile": "pr_review", "stack": "python",
+            "comment_id": 7,
+        }],
+    }]
+    (root / "sessions.jsonl").write_text(
+        "".join(json.dumps(s, sort_keys=True) + "\n" for s in sessions), encoding="utf-8"
+    )
+    (root / "index-revision.txt").write_text("a" * 40, encoding="utf-8")
+    return root
+
+
+def _seed_archive(archive_dir: Path) -> None:
+    # Real-path seeding: the project's own schema (index.db), one run row.
+    conn = _get_connection(archive_dir)
+    conn.execute(
+        "INSERT INTO runs (session_id, archived_at, run_flow, archive_path) "
+        "VALUES ('s1', '2026-01-01T00:00:00+00:00', 'deep', 'archive/s1')"
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_canonical_harvest_appends_label_observation_exactly_once(tmp_path: Path) -> None:
+    root = _index(tmp_path)
+    archive = tmp_path / "archive"
+    _seed_archive(archive)
+    run_materialize(root, tmp_path / "mat", pin=_PIN)
+    out = run_canonical_harvest(
+        index_root=root, materialize_dir=tmp_path / "mat", archive_dir=archive,
+        observations_path=None,
+    )
+    assert out["appended_sessions"] == 1
+    history = label_observation_history(archive, "s1")
+    assert len(history) == 1  # exactly once
+    row = history[0]
+    assert row["labeler_version"] == _PIN["labeler_version"]
+    rubric = json.loads(row["rubric_json"])
+    stored = rubric.get("per_finding_outcomes") or rubric.get("per_finding_resolutions")
+    assert stored and stored[0]["evidence_digest"] == "d" * 32
+    # session-level digest matches the shared serializer's (K5 spike)
+    from daydream.training.adjudication.snapshot import record_evidence_digest
+    assert row["reply_evidence_digest"] == record_evidence_digest(
+        [stored[0]["evidence"]]
+    )
+    # re-run unchanged => idempotent, no duplicate row
+    out2 = run_canonical_harvest(
+        index_root=root, materialize_dir=tmp_path / "mat", archive_dir=archive,
+        observations_path=None,
+    )
+    assert out2["appended_sessions"] == 0
+    assert len(label_observation_history(archive, "s1")) == 1
+
+
+def test_canonical_harvest_fails_closed_on_drift_before_any_write(tmp_path: Path) -> None:
+    root = _index(tmp_path)
+    archive = tmp_path / "archive"
+    _seed_archive(archive)
+    run_materialize(root, tmp_path / "mat", pin=_PIN)
+    # evidence drifts AFTER materialization: harvest must refuse pre-write
+    sessions_path = root / "sessions.jsonl"
+    s = json.loads(sessions_path.read_text().splitlines()[0])
+    s["resolutions"][0]["evidence_digest"] = "f" * 32
+    s["resolutions"][0]["evidence"][0]["body_sha256"] = "mut"
+    sessions_path.write_text(json.dumps(s, sort_keys=True) + "\n", encoding="utf-8")
+    with pytest.raises(AnnotationDriftError) as excinfo:
+        run_canonical_harvest(
+            index_root=root, materialize_dir=tmp_path / "mat", archive_dir=archive,
+            observations_path=None,
+        )
+    assert excinfo.value.requeued_record_ids  # named for requeue (AC 4/M5)
+    assert label_observation_history(archive, "s1") == []  # nothing written
+    assert not (tmp_path / "mat" / "annotations.jsonl").exists()
+
+
+def test_canonical_harvest_merges_human_observations_by_precedence(tmp_path: Path) -> None:
+    root = _index(tmp_path)
+    archive = tmp_path / "archive"
+    _seed_archive(archive)
+    run_materialize(root, tmp_path / "mat", pin=_PIN)
+    from daydream.training.corpus_v2.identity import record_id
+    rid = record_id("s1", "s1-t", "s1-seg", "fp-1")
+    obs = tmp_path / "observations.jsonl"
+    obs.write_text(json.dumps({
+        "record_id": rid, "disposition": "accepted", "evidence_digest": "d" * 32,
+        "evidence": [], "labeler": "alice", "role": "rater", "rationale": "looked right",
+        "valid_at": "2026-01-02T00:00:00+00:00", "observed_at": "2026-01-02T01:00:00+00:00",
+        "rubric_version": "v1",
+    }) + "\n", encoding="utf-8")
+    out = run_canonical_harvest(
+        index_root=root, materialize_dir=tmp_path / "mat", archive_dir=archive,
+        observations_path=obs,
+    )
+    assert out["human_adjudicated"] == 1
+    history = label_observation_history(archive, "s1")
+    rubric = json.loads(history[0]["rubric_json"])
+    stored = rubric.get("per_finding_outcomes") or rubric.get("per_finding_resolutions")
+    # the human disposition wins the stored resolution (M5 precedence merge)
+    assert stored[0]["disposition"] == "accepted"
+
+
+def test_canonical_harvest_rejects_unknown_observation_record_id(tmp_path: Path) -> None:
+    root = _index(tmp_path)
+    archive = tmp_path / "archive"
+    _seed_archive(archive)
+    run_materialize(root, tmp_path / "mat", pin=_PIN)
+    obs = tmp_path / "observations.jsonl"
+    obs.write_text(json.dumps({
+        "record_id": "e" * 64, "disposition": "accepted", "evidence_digest": "d" * 32,
+        "evidence": [], "labeler": "alice", "role": "rater", "rationale": "x",
+        "valid_at": "2026-01-02T00:00:00+00:00", "observed_at": "2026-01-02T01:00:00+00:00",
+        "rubric_version": "v1",
+    }) + "\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="e" * 64):
+        run_canonical_harvest(
+            index_root=root, materialize_dir=tmp_path / "mat", archive_dir=archive,
+            observations_path=obs,
+        )
+    assert label_observation_history(archive, "s1") == []
+
+
+def test_canonical_harvest_emits_annotations_jsonl_from_merged_records(tmp_path: Path) -> None:
+    root = _index(tmp_path)
+    archive = tmp_path / "archive"
+    _seed_archive(archive)
+    run_materialize(root, tmp_path / "mat", pin=_PIN)
+    out = run_canonical_harvest(
+        index_root=root, materialize_dir=tmp_path / "mat", archive_dir=archive,
+        observations_path=None,
+    )
+    assert out["record_count"] == 1
+    lines = (tmp_path / "mat" / "annotations.jsonl").read_text().splitlines()
+    records = [json.loads(line) for line in lines]
+    # canonical JSON, sorted by record_id, shared serializer shape
+    assert [r["record_id"] for r in records] == sorted(r["record_id"] for r in records)
+    assert records[0]["evidence_digest"] == "d" * 32
+    assert records[0]["session_id"] == "s1"
+    for line in lines:
+        assert line == json.dumps(json.loads(line), sort_keys=True,
+                                  separators=(",", ":"), ensure_ascii=False)

--- a/tests/test_training_adjudication_materialize.py
+++ b/tests/test_training_adjudication_materialize.py
@@ -63,6 +63,20 @@ def test_materialize_never_writes_canonical_state(tmp_path: Path) -> None:
     assert not (root / "daydream.sqlite").exists()
 
 
+def test_materialize_dry_run_validates_and_writes_nothing(tmp_path: Path) -> None:
+    root = _index(tmp_path)
+    out = tmp_path / "out"
+    summary = run_materialize(root, out, pin=_PIN, dry_run=True)
+    # dry-run validates everything: same summary a real run would produce
+    full = run_materialize(root, tmp_path / "real", pin=_PIN)
+    assert summary["snapshot_id"] == full["snapshot_id"]
+    assert summary["index_revision"] == "a" * 40
+    assert summary["record_count"] == full["record_count"]
+    # ... and writes nothing: no out dir, no state side effects (AC 4)
+    assert not out.exists()
+    assert not (root / "daydream.sqlite").exists()
+
+
 def test_materialize_missing_sessions_fails_closed(tmp_path: Path) -> None:
     with pytest.raises(HubUnavailableError):
         run_materialize(tmp_path, tmp_path / "out", pin=_PIN)

--- a/tests/test_training_adjudication_materialize.py
+++ b/tests/test_training_adjudication_materialize.py
@@ -1,0 +1,81 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from daydream.archive.hydrate import HubUnavailableError
+from daydream.training.adjudication.materialize import run_materialize
+
+
+def _index(tmp_path: Path) -> Path:
+    root = tmp_path / "index"
+    root.mkdir()
+    sessions = [{
+        "session_id": "s1", "trajectory_id": "s1-t", "segment_id": "s1-seg",
+        "resolutions": [{
+            "fingerprint": "fp-1", "disposition": "unanswered",
+            "evidence": [{"reply_id": 1, "body_sha256": "abc"}],
+            "evidence_digest": "d" * 32, "profile": "pr_review", "stack": "python",
+            "comment_id": 7,
+        }],
+    }]
+    (root / "sessions.jsonl").write_text(
+        "".join(json.dumps(s, sort_keys=True) + "\n" for s in sessions), encoding="utf-8"
+    )
+    (root / "index-revision.txt").write_text("a" * 40, encoding="utf-8")
+    return root
+
+
+_PIN = {
+    "curation_id": "cur-1", "sanitized_hub_commit": "a" * 40,
+    "source_hub_commit": "b" * 40, "archive_index_digest": "c" * 64,
+    "evidence_observed_at": "2026-01-01T00:00:00+00:00",
+    "as_of": "2026-02-01T00:00:00+00:00",
+    "labeler_version": "v1", "rubric_version": "v1", "classifier_version": "v1",
+}
+
+
+def test_materialize_emits_deterministic_sessions_and_manifest(tmp_path: Path) -> None:
+    root = _index(tmp_path)
+    r1 = run_materialize(root, tmp_path / "out-a", pin=_PIN)
+    r2 = run_materialize(root, tmp_path / "out-b", pin=_PIN)
+    assert r1["snapshot_id"] == r2["snapshot_id"]  # identical inputs => identical id
+    a = (tmp_path / "out-a" / "sessions.jsonl").read_bytes()
+    b = (tmp_path / "out-b" / "sessions.jsonl").read_bytes()
+    assert a == b  # byte-identical (C4)
+    manifest = json.loads((tmp_path / "out-a" / "preview-manifest.json").read_text())
+    for key in ("curation_id", "sanitized_hub_commit", "source_hub_commit",
+                "archive_index_digest", "evidence_observed_at", "as_of"):
+        assert manifest[key] == _PIN[key]
+    assert manifest["snapshot_id"] == r1["snapshot_id"]
+    record = json.loads(a.splitlines()[0])
+    assert record["record_id"] and record["evidence_digest"] == "d" * 32
+    assert record["disposition"] == "unanswered"
+
+
+def test_materialize_never_writes_canonical_state(tmp_path: Path) -> None:
+    root = _index(tmp_path)
+    out = tmp_path / "out"
+    run_materialize(root, out, pin=_PIN)
+    # preview mode: no label_observations append, no resume-cache marker (AC 4)
+    assert not (out / "harvest-resume.json").exists()
+    assert not (out / "label_observations.jsonl").exists()
+    assert not (root / "daydream.sqlite").exists()
+
+
+def test_materialize_missing_sessions_fails_closed(tmp_path: Path) -> None:
+    with pytest.raises(HubUnavailableError):
+        run_materialize(tmp_path, tmp_path / "out", pin=_PIN)
+
+
+def test_materialize_drift_yields_new_snapshot_id(tmp_path: Path) -> None:
+    root = _index(tmp_path)
+    r1 = run_materialize(root, tmp_path / "o1", pin=_PIN)
+    # mutate evidence => digest changes => new snapshot id (AC 8)
+    sessions_path = root / "sessions.jsonl"
+    s = json.loads(sessions_path.read_text().splitlines()[0])
+    s["resolutions"][0]["evidence"][0]["body_sha256"] = "zzz"
+    s["resolutions"][0]["evidence_digest"] = "f" * 32
+    sessions_path.write_text(json.dumps(s, sort_keys=True) + "\n", encoding="utf-8")
+    r2 = run_materialize(root, tmp_path / "o2", pin=_PIN)
+    assert r2["snapshot_id"] != r1["snapshot_id"]

--- a/tests/test_training_adjudication_publish.py
+++ b/tests/test_training_adjudication_publish.py
@@ -101,6 +101,62 @@ def test_publish_refuses_public_destination(tmp_path: Path) -> None:
         publish_annotation_state(_FakeHub(private=False), _state(tmp_path), manifest=_manifest(tmp_path))
 
 
+def test_publish_final_bundle_success_last_and_verified_commit_required(tmp_path: Path) -> None:
+    import hashlib
+
+    from daydream.training.adjudication.publish import publish_final_annotation_bundle
+
+    hub = _FakeHub()
+    root = tmp_path / "bundle"
+    root.mkdir()
+    (root / "annotations.jsonl").write_text('{"record_id": "r1"}\n', encoding="utf-8")
+    (root / "sessions.jsonl").write_text('{"session_id": "s1"}\n', encoding="utf-8")
+    (root / "lineage.json").write_text("{}", encoding="utf-8")
+    result = publish_final_annotation_bundle(
+        hub, root, manifest=_manifest(tmp_path), verify_download=True,
+    )
+    prefix = f"annotations/cur-1/{'e' * 64}/final/"
+    files = sorted(k[len(prefix):] for k in hub.files if k.startswith(prefix))
+    assert "SHA256SUMS" in files and "_SUCCESS" in files
+    # _SUCCESS is uploaded last (C3): pinned via hub.uploads insertion order
+    # (a sorted() listing cannot express upload order — '_' sorts before letters).
+    upload_order = [k for m in hub.uploads for k in m]
+    assert upload_order[-1] == f"{prefix}_SUCCESS"
+    sums = hub.files[f"{prefix}SHA256SUMS"].decode()
+    expected = hashlib.sha256((root / "annotations.jsonl").read_bytes()).hexdigest()
+    assert f"{expected}  annotations.jsonl" in sums
+    assert result["hub_commit_sha"]  # verified commit recorded (M6)
+    assert result["prefix"] == prefix
+
+
+def test_final_bundle_clean_download_verifies_or_refuses(tmp_path: Path) -> None:
+    from daydream.training.adjudication.publish import publish_final_annotation_bundle
+
+    hub = _FakeHub()
+    root = tmp_path / "bundle"
+    root.mkdir()
+    (root / "annotations.jsonl").write_text('{"record_id": "r1"}\n', encoding="utf-8")
+    with pytest.raises(ValueError, match="download"):
+        publish_final_annotation_bundle(
+            hub, root, manifest=_manifest(tmp_path),
+            verify_download=True, _download_verifier=lambda _p: False,
+        )
+    # nothing published: no _SUCCESS on the Hub
+    assert not any(k.endswith("/final/_SUCCESS") for k in hub.files)
+
+
+def test_final_bundle_refuses_secret_in_payload(tmp_path: Path) -> None:
+    from daydream.training.adjudication.publish import publish_final_annotation_bundle
+
+    hub = _FakeHub()
+    root = tmp_path / "bundle"
+    root.mkdir()
+    (root / "annotations.jsonl").write_text('{"hf_token": "hf_abc123secret"}\n', encoding="utf-8")
+    with pytest.raises(Exception):  # PublicDestinationError from the S1 secret scan
+        publish_final_annotation_bundle(hub, root, manifest=_manifest(tmp_path))
+    assert not any(k.endswith("/final/_SUCCESS") for k in hub.files)
+
+
 def test_resume_on_empty_disk_restores_byte_identical_state(tmp_path: Path) -> None:
     hub = _FakeHub()
     state = _state(tmp_path)

--- a/tests/test_training_adjudication_publish.py
+++ b/tests/test_training_adjudication_publish.py
@@ -4,12 +4,17 @@ from typing import Any
 
 import pytest
 
-from daydream.archive.hydrate import PublicDestinationError
+from daydream.archive.hydrate import HydrationError, PublicDestinationError
 from daydream.training.adjudication.publish import (
     annotation_prefix,
     publish_annotation_state,
     resume_annotation_state,
 )
+
+# M6: production manifests always pin index_revision (materialize writes it),
+# so the Hub-verified 40-hex branch — not the synthetic digest fallback — is
+# the path that must be exercised.
+INDEX_REVISION = "a" * 40
 
 
 class _FakeHub:
@@ -17,6 +22,7 @@ class _FakeHub:
         self.files: dict[str, bytes] = {}
         self.private = private
         self.uploads: list[dict[str, Path]] = []
+        self.revisions: set[str] = set()
 
     @property
     def repo_private(self) -> bool:
@@ -35,7 +41,10 @@ class _FakeHub:
         for remote, local in mapping.items():
             self.files[str(remote)] = Path(local).read_bytes()
 
-    def repo_info(self, revision: str | None = None) -> Any: ...
+    def repo_info(self, revision: str | None = None) -> Any:
+        # Mirror the real Hub: an unknown revision is a HydrationError (M6).
+        if revision is None or revision not in self.revisions:
+            raise HydrationError(f"unknown revision {revision!r}")
     def list_revisions(self) -> list[str]:
         return []
 
@@ -45,7 +54,17 @@ def _state(tmp_path: Path) -> Path:
     state.mkdir()
     (state / "queue.json").write_text(json.dumps([{"record_id": "r1"}]), encoding="utf-8")
     (state / "observations.jsonl").write_text(
-        json.dumps({"record_id": "r1", "disposition": "accepted", "role": "rater"}) + "\n",
+        # production shape: observations always carry observed_at (the primary
+        # M4 dedup key is record_id + observed_at, not the line digest)
+        json.dumps(
+            {
+                "record_id": "r1",
+                "disposition": "accepted",
+                "role": "rater",
+                "observed_at": "2025-01-01T00:00:00Z",
+            }
+        )
+        + "\n",
         encoding="utf-8",
     )
     (state / "preview-ledger.json").write_text("{}", encoding="utf-8")
@@ -59,6 +78,7 @@ def _manifest(tmp_path: Path) -> Path:
             {
                 "curation_id": "cur-1",
                 "snapshot_id": "e" * 64,
+                "index_revision": INDEX_REVISION,
             }
         ),
         encoding="utf-8",
@@ -87,13 +107,51 @@ def test_publish_second_batch_appends_observations_never_overwrites(tmp_path: Pa
     hub = _FakeHub()
     state = _state(tmp_path)
     publish_annotation_state(hub, state, manifest=_manifest(tmp_path), batch_complete=True)
-    # second batch appends a new observation
+    # second batch: a key-duplicate edit of r1 (same record_id + observed_at,
+    # different bytes) must be dropped by the primary dedup key; a genuinely
+    # new observation is appended (M4)
     with (state / "observations.jsonl").open("a", encoding="utf-8") as fh:
-        fh.write(json.dumps({"record_id": "r2", "disposition": "rejected", "role": "rater"}) + "\n")
+        fh.write(
+            json.dumps(
+                {
+                    "record_id": "r1",
+                    "disposition": "rejected",
+                    "role": "rater",
+                    "observed_at": "2025-01-01T00:00:00Z",
+                }
+            )
+            + "\n"
+        )
+        fh.write(
+            json.dumps(
+                {
+                    "record_id": "r2",
+                    "disposition": "rejected",
+                    "role": "rater",
+                    "observed_at": "2025-01-01T00:01:00Z",
+                }
+            )
+            + "\n"
+        )
     publish_annotation_state(hub, state, manifest=_manifest(tmp_path), batch_complete=True)
     stored = hub.files[f"annotations/cur-1/{'e' * 64}/observations.jsonl"].decode()
     lines = [json.loads(line) for line in stored.splitlines() if line.strip()]
+    # r1's key-duplicate edit was dropped (dedup by record_id + observed_at,
+    # not by line bytes); r2 was appended
     assert [o["record_id"] for o in lines] == ["r1", "r2"]  # append-only (M4)
+
+
+def test_publish_without_batch_complete_skips_checkpoint(tmp_path: Path) -> None:
+    hub = _FakeHub()
+    state = _state(tmp_path)
+    manifest = _manifest(tmp_path)
+    # CLI default (no --batch-complete flag): no checkpoint is written
+    summary = publish_annotation_state(hub, state, manifest=manifest)
+    prefix = f"annotations/cur-1/{'e' * 64}/"
+    assert any(k == f"{prefix}queue.json" for k in hub.files)
+    assert any(k == f"{prefix}observations.jsonl" for k in hub.files)
+    assert f"{prefix}checkpoints/batch-latest.json" not in hub.files
+    assert "observation_count" not in summary
 
 
 def test_publish_refuses_public_destination(tmp_path: Path) -> None:
@@ -107,6 +165,7 @@ def test_publish_final_bundle_success_last_and_verified_commit_required(tmp_path
     from daydream.training.adjudication.publish import publish_final_annotation_bundle
 
     hub = _FakeHub()
+    hub.revisions.add(INDEX_REVISION)
     root = tmp_path / "bundle"
     root.mkdir()
     (root / "annotations.jsonl").write_text('{"record_id": "r1"}\n', encoding="utf-8")
@@ -125,8 +184,23 @@ def test_publish_final_bundle_success_last_and_verified_commit_required(tmp_path
     sums = hub.files[f"{prefix}SHA256SUMS"].decode()
     expected = hashlib.sha256((root / "annotations.jsonl").read_bytes()).hexdigest()
     assert f"{expected}  annotations.jsonl" in sums
-    assert result["hub_commit_sha"]  # verified commit recorded (M6)
+    # the index_revision was verified to exist on the Hub and recorded (M6) —
+    # not the synthetic digest fallback
+    assert result["hub_commit_sha"] == INDEX_REVISION
     assert result["prefix"] == prefix
+
+
+def test_final_bundle_unknown_index_revision_fails_closed(tmp_path: Path) -> None:
+    from daydream.training.adjudication.publish import publish_final_annotation_bundle
+
+    hub = _FakeHub()  # index_revision is not a known Hub revision
+    root = tmp_path / "bundle"
+    root.mkdir()
+    (root / "annotations.jsonl").write_text('{"record_id": "r1"}\n', encoding="utf-8")
+    with pytest.raises(HydrationError):
+        publish_final_annotation_bundle(hub, root, manifest=_manifest(tmp_path))
+    # fail-closed: an unverifiable commit means _SUCCESS is never uploaded
+    assert not any(k.endswith("/final/_SUCCESS") for k in hub.files)
 
 
 def test_final_bundle_clean_download_verifies_or_refuses(tmp_path: Path) -> None:
@@ -152,9 +226,20 @@ def test_final_bundle_refuses_secret_in_payload(tmp_path: Path) -> None:
     root = tmp_path / "bundle"
     root.mkdir()
     (root / "annotations.jsonl").write_text('{"hf_token": "hf_abc123secret"}\n', encoding="utf-8")
-    with pytest.raises(Exception):  # PublicDestinationError from the S1 secret scan
+    prefix = f"annotations/cur-1/{'e' * 64}/final/"
+    with pytest.raises(PublicDestinationError, match="credential-shaped"):  # S1 secret scan
         publish_final_annotation_bundle(hub, root, manifest=_manifest(tmp_path))
-    assert not any(k.endswith("/final/_SUCCESS") for k in hub.files)
+    # fail-closed before any upload: not even the credential payload reached the
+    # Hub (the scan runs before the first upload, so nothing sits under prefix)
+    assert not any(k.startswith(prefix) for k in hub.files)
+
+
+def test_resume_without_checkpoint_returns_empty_state(tmp_path: Path) -> None:
+    hub = _FakeHub()  # nothing ever published: no checkpoint can exist
+    fresh = tmp_path / "fresh-vm"
+    restored = resume_annotation_state(hub, manifest=_manifest(tmp_path), stage_dir=fresh)
+    assert restored == {"observation_count": 0, "restored": []}
+    assert not fresh.exists()
 
 
 def test_resume_on_empty_disk_restores_byte_identical_state(tmp_path: Path) -> None:

--- a/tests/test_training_adjudication_publish.py
+++ b/tests/test_training_adjudication_publish.py
@@ -1,0 +1,116 @@
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from daydream.archive.hydrate import PublicDestinationError
+from daydream.training.adjudication.publish import (
+    annotation_prefix,
+    publish_annotation_state,
+    resume_annotation_state,
+)
+
+
+class _FakeHub:
+    def __init__(self, private: bool = True) -> None:
+        self.files: dict[str, bytes] = {}
+        self.private = private
+        self.uploads: list[dict[str, Path]] = []
+
+    @property
+    def repo_private(self) -> bool:
+        return self.private
+
+    def list_repo_files(self, revision: str | None = None) -> list[str]:
+        return sorted(self.files)
+
+    def download_file(self, path: str, revision: str | None = None) -> bytes:
+        if path not in self.files:
+            raise FileNotFoundError(path)
+        return self.files[path]
+
+    def upload_files(self, mapping: dict[str | Path, Path], commit_message: str) -> None:
+        self.uploads.append({str(k): v for k, v in mapping.items()})
+        for remote, local in mapping.items():
+            self.files[str(remote)] = Path(local).read_bytes()
+
+    def repo_info(self, revision: str | None = None) -> Any: ...
+    def list_revisions(self) -> list[str]:
+        return []
+
+
+def _state(tmp_path: Path) -> Path:
+    state = tmp_path / "state"
+    state.mkdir()
+    (state / "queue.json").write_text(json.dumps([{"record_id": "r1"}]), encoding="utf-8")
+    (state / "observations.jsonl").write_text(
+        json.dumps({"record_id": "r1", "disposition": "accepted", "role": "rater"}) + "\n",
+        encoding="utf-8",
+    )
+    (state / "preview-ledger.json").write_text("{}", encoding="utf-8")
+    return state
+
+
+def _manifest(tmp_path: Path) -> Path:
+    p = tmp_path / "preview-manifest.json"
+    p.write_text(
+        json.dumps(
+            {
+                "curation_id": "cur-1",
+                "snapshot_id": "e" * 64,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return p
+
+
+def test_publish_is_additive_under_content_addressed_prefix(tmp_path: Path) -> None:
+    hub = _FakeHub()
+    state = _state(tmp_path)
+    manifest = _manifest(tmp_path)
+    publish_annotation_state(hub, state, manifest=manifest, batch_complete=True)
+    prefix = f"annotations/cur-1/{'e' * 64}/"
+    assert annotation_prefix(manifest) == prefix
+    uploaded = {k for m in hub.uploads for k in m}
+    assert any(k == f"{prefix}queue.json" for k in uploaded)
+    assert any(k == f"{prefix}observations.jsonl" for k in uploaded)
+    # checkpoint after completed batch: remote ledger records the batch
+    ledger_path = f"{prefix}checkpoints/batch-latest.json"
+    assert ledger_path in hub.files
+    entry = json.loads(hub.files[ledger_path])
+    assert entry["observation_count"] == 1
+
+
+def test_publish_second_batch_appends_observations_never_overwrites(tmp_path: Path) -> None:
+    hub = _FakeHub()
+    state = _state(tmp_path)
+    publish_annotation_state(hub, state, manifest=_manifest(tmp_path), batch_complete=True)
+    # second batch appends a new observation
+    with (state / "observations.jsonl").open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps({"record_id": "r2", "disposition": "rejected", "role": "rater"}) + "\n")
+    publish_annotation_state(hub, state, manifest=_manifest(tmp_path), batch_complete=True)
+    stored = hub.files[f"annotations/cur-1/{'e' * 64}/observations.jsonl"].decode()
+    lines = [json.loads(line) for line in stored.splitlines() if line.strip()]
+    assert [o["record_id"] for o in lines] == ["r1", "r2"]  # append-only (M4)
+
+
+def test_publish_refuses_public_destination(tmp_path: Path) -> None:
+    with pytest.raises(PublicDestinationError):
+        publish_annotation_state(_FakeHub(private=False), _state(tmp_path), manifest=_manifest(tmp_path))
+
+
+def test_resume_on_empty_disk_restores_byte_identical_state(tmp_path: Path) -> None:
+    hub = _FakeHub()
+    state = _state(tmp_path)
+    publish_annotation_state(hub, state, manifest=_manifest(tmp_path), batch_complete=True)
+    fresh = tmp_path / "fresh-vm"  # empty disk, fresh VM
+    restored = resume_annotation_state(hub, manifest=_manifest(tmp_path), stage_dir=fresh)
+    assert restored["observation_count"] == 1
+    for name in ("queue.json", "observations.jsonl", "preview-ledger.json"):
+        assert (fresh / name).read_bytes() == (state / name).read_bytes()
+    # digests verified on download: corrupt remote fails closed
+    hub.files[f"annotations/cur-1/{'e' * 64}/observations.jsonl"] += b"tampered\n"
+    with pytest.raises(ValueError, match="digest"):
+        resume_annotation_state(hub, manifest=_manifest(tmp_path), stage_dir=tmp_path / "fresh-2")

--- a/tests/test_training_adjudication_report.py
+++ b/tests/test_training_adjudication_report.py
@@ -4,6 +4,43 @@ from typing import Any
 from daydream.training.adjudication.report import build_report
 
 
+def test_report_separates_outcome_bearing_from_task_only_and_flags_as_of() -> None:
+    items = [
+        {"record_id": "r1", "disposition": "accepted", "profile": "pr_review",
+         "stack": "python", "tier": "gold", "posterior_eligible": True,
+         "observations": [], "evidence_after_as_of": False},
+        {"record_id": "r2", "disposition": "rejected", "profile": "local_branch",
+         "stack": "rust", "tier": "task-only", "posterior_eligible": False,
+         "observations": [], "evidence_after_as_of": False},
+        {"record_id": "r3", "disposition": "accepted", "profile": "pr_review",
+         "stack": "python", "tier": "gold", "posterior_eligible": False,
+         "observations": [], "evidence_after_as_of": True},
+    ]
+    report = build_report(items)
+    cov = report["outcome_coverage"]
+    # outcome-bearing only counts pr_review gold (C5): r1 counts; r2 is
+    # task-only and never counts; r3 is flagged evidence-after-as_of and excluded
+    assert cov["adjudicated"] == 1
+    assert report["evidence_after_as_of"] == ["r3"]
+    gate = report["admission_gate"]
+    assert gate["outcome_bearing_total"] == 1
+    assert gate["passes_80pct"] is False  # 1 of 3 items
+    assert gate["class_balance_ok"] is True
+
+
+def test_report_task_only_never_counts_toward_gate() -> None:
+    items = [
+        {"record_id": f"r{i}", "disposition": "unanswered", "profile": "pr_review",
+         "stack": "python", "tier": "task-only", "posterior_eligible": False,
+         "observations": [], "evidence_after_as_of": False}
+        for i in range(5)
+    ]
+    report = build_report(items)
+    assert report["outcome_coverage"]["adjudicated"] == 0
+    assert report["admission_gate"]["passes_80pct"] is False
+    assert report["silver_task_only_count"] == 5
+
+
 def _item(
     rid: str,
     disposition: str,
@@ -13,6 +50,7 @@ def _item(
 ) -> dict[str, Any]:
     return {"record_id": rid, "disposition": disposition, "profile": profile, "stack": stack,
             "tier": "gold" if disposition in {"accepted", "rejected"} else "task-only",
+            "posterior_eligible": disposition in {"accepted", "rejected"},
             "observations": [{"role": r, "disposition": d}
                              for (r, d) in raters]}
 
@@ -46,7 +84,11 @@ def test_model_suggested_observations_never_count_as_human_raters() -> None:
         _item("b" * 64, "accepted", raters=(("model-suggested", "accepted"), ("rater", "rejected"))),
     ]
     report = build_report(items)
-    assert report["outcome_coverage"] == {"adjudicated": 1, "total": 2}  # model-suggested-only item unresolved
+    # C5/M9 outcome-bearing counting is tier/eligibility-based, not
+    # human-decision-based: both decisive gold pr_review records count toward
+    # the numerator; the model-suggested-only one is still *unresolved*.
+    assert report["outcome_coverage"] == {"adjudicated": 2, "total": 2}
+    assert report["unresolved"] == 1
     assert report["unresolved"] == 1
     assert report["inter_rater"] == {"items": 0, "agreeing": 0}  # no second human in the dispute
 

--- a/tests/test_training_adjudication_report.py
+++ b/tests/test_training_adjudication_report.py
@@ -21,11 +21,15 @@ def test_report_separates_outcome_bearing_from_task_only_and_flags_as_of() -> No
     # outcome-bearing only counts pr_review gold (C5): r1 counts; r2 is
     # task-only and never counts; r3 is flagged evidence-after-as_of and excluded
     assert cov["adjudicated"] == 1
+    assert cov["total"] == 1  # r3 can never adjudicate, so it never feeds the denominator
     assert report["evidence_after_as_of"] == ["r3"]
     gate = report["admission_gate"]
     assert gate["outcome_bearing_total"] == 1
-    assert gate["passes_80pct"] is False  # 1 of 3 items
-    assert gate["class_balance_ok"] is True
+    # 100% of the outcome-bearing subset (just r1) is adjudicated: the gate is
+    # not blocked forever by those records that can never count (gold
+    # non-posterior_eligible / evidence-after-as_of).
+    assert gate["passes_80pct"] is True
+    assert gate["class_balance_ok"] is False  # sole outcome-bearing record is accepted-only
 
 
 def test_report_task_only_never_counts_toward_gate() -> None:

--- a/tests/test_training_adjudication_snapshot.py
+++ b/tests/test_training_adjudication_snapshot.py
@@ -1,0 +1,104 @@
+"""Tests for the shared per-finding annotation snapshot serializer (issue #1055, Task 1)."""
+
+import pytest
+
+from daydream.training.adjudication.snapshot import (
+    ANNOTATION_SNAPSHOT_SCHEMA_VERSION,
+    build_canonical_record,
+    snapshot_id,
+)
+from daydream.training.harvest import _reply_evidence_digest  # session-level twin
+from daydream.training.labeler_signals import PerFindingResolution
+from daydream.training.labeler_versions import reply_evidence_digest
+
+
+def _resolution(fp: str = "fp-1", digest: str = "d" * 32) -> PerFindingResolution:
+    return PerFindingResolution(
+        fingerprint=fp,
+        comment_id=7,
+        disposition="unanswered",
+        evidence=[{"reply_id": 1, "body_sha256": "abc"}],
+        evidence_digest=digest,
+    )
+
+
+def test_build_canonical_record_pins_identity_and_provenance() -> None:
+    session = {
+        "session_id": "s1",
+        "trajectory_id": "s1-t",
+        "segment_id": "s1-seg",
+        "resolutions": [{"fingerprint": "fp-1", "profile_name": "pr_review", "stack": "python"}],
+    }
+    record = build_canonical_record(
+        session, _resolution(), evidence_observed_at="2026-01-01T00:00:00+00:00"
+    )
+    # identity via corpus_v2.identity.record_id — recompute and compare, never trust a stored copy
+    from daydream.training.corpus_v2.identity import record_id
+
+    assert record["record_id"] == record_id("s1", "s1-t", "s1-seg", "fp-1")
+    assert record["evidence_digest"] == "d" * 32
+    assert record["disposition"] == "unanswered"
+    assert record["profile"]["profile_name"] == "pr_review"
+    assert record["stack"] == "python"
+    from daydream.training import labeler_versions
+
+    assert record["classifier_version"] == labeler_versions.REPLY_CLASSIFIER_VERSION
+    assert ANNOTATION_SNAPSHOT_SCHEMA_VERSION in record["schema_version"]
+
+
+def test_record_evidence_digest_matches_harvest_row_digest() -> None:
+    # K5 spike verdict: shared digest == training/harvest.py session-level digest
+    ev_a = [{"reply_id": 1, "body_sha256": "aaa"}]
+    ev_b = [{"reply_id": 2, "body_sha256": "bbb"}]
+
+    from daydream.training.adjudication.snapshot import record_evidence_digest
+
+    shared = record_evidence_digest([ev_a, ev_b])
+    # the harvest twin flattens PerFindingResolution evidence in recorded order
+
+    class _R:
+        disposition = "accepted"
+        evidence = ev_a
+
+    class _R2:
+        disposition = "rejected"
+        evidence = ev_b
+
+    class _Rubric:
+        per_finding_resolutions = [_R(), _R2()]
+
+    assert shared == _reply_evidence_digest(_Rubric())
+    assert shared == reply_evidence_digest(ev_a + ev_b)
+    # order of the per-finding list must not matter (digest normalizes by reply_id)
+    assert shared == record_evidence_digest([ev_b, ev_a])
+
+
+def test_snapshot_id_is_content_addressed_and_order_stable() -> None:
+    base = {
+        "curation_id": "cur-1",
+        "sanitized_hub_commit": "a" * 40,
+        "source_hub_commit": "b" * 40,
+        "archive_index_digest": "c" * 64,
+        "evidence_observed_at": "2026-01-01T00:00:00+00:00",
+        "as_of": "2026-02-01T00:00:00+00:00",
+        "labeler_version": "v1",
+        "rubric_version": "v1",
+        "classifier_version": "v1",
+    }
+    sid_a = snapshot_id(base)
+    sid_b = snapshot_id(dict(reversed(list(base.items()))))
+    assert sid_a == sid_b
+    assert len(sid_a) == 64
+    changed = dict(base, as_of="2026-03-01T00:00:00+00:00")
+    assert snapshot_id(changed) != sid_a  # any pin change => new id (AC 8)
+
+
+def test_missing_pin_component_fails_closed() -> None:
+    with pytest.raises(ValueError, match="curation_id"):
+        snapshot_id({"sanitized_hub_commit": "a" * 40})
+
+
+def test_build_canonical_record_rejects_missing_digest() -> None:
+    session = {"session_id": "s1", "trajectory_id": "t", "segment_id": "g", "resolutions": []}
+    with pytest.raises(ValueError, match="evidence_digest"):
+        build_canonical_record(session, _resolution(digest=""), evidence_observed_at="2026-01-01")

--- a/tests/test_training_adjudication_snapshot.py
+++ b/tests/test_training_adjudication_snapshot.py
@@ -72,6 +72,16 @@ def test_record_evidence_digest_matches_harvest_row_digest() -> None:
     # order of the per-finding list must not matter (digest normalizes by reply_id)
     assert shared == record_evidence_digest([ev_b, ev_a])
 
+    # empty-evidence boundary (K5 parity): the harvest twin yields None, never
+    # a concrete digest of the canonical empty list — the shared serializer
+    # must match exactly so a digest-less row cannot collide with a digested one
+    assert record_evidence_digest([]) is None
+
+    class _EmptyRubric:  # duck-typed twin of harvest.Rubric with no evidence
+        per_finding_resolutions = []
+
+    assert _reply_evidence_digest(_EmptyRubric()) is None  # type: ignore[arg-type]
+
 
 def test_snapshot_id_is_content_addressed_and_order_stable() -> None:
     base = {
@@ -102,3 +112,61 @@ def test_build_canonical_record_rejects_missing_digest() -> None:
     session = {"session_id": "s1", "trajectory_id": "t", "segment_id": "g", "resolutions": []}
     with pytest.raises(ValueError, match="evidence_digest"):
         build_canonical_record(session, _resolution(digest=""), evidence_observed_at="2026-01-01")
+
+
+@pytest.mark.parametrize("rows", [[], [{"fingerprint": "fp-1"}] * 2])
+def test_build_canonical_record_rejects_wrong_resolution_row_count(rows: list[dict]) -> None:
+    # the exactly-1-resolution-row guard (0 and 2 rows) fires independently of
+    # the evidence_digest check: a valid digest is supplied so this check is what raises
+    session = {
+        "session_id": "s1",
+        "trajectory_id": "t",
+        "segment_id": "g",
+        "resolutions": rows,
+    }
+    with pytest.raises(ValueError, match="expected exactly 1"):
+        build_canonical_record(session, _resolution(), evidence_observed_at="2026-01-01")
+
+
+def test_build_canonical_record_as_of_passthrough() -> None:
+    session = {
+        "session_id": "s1",
+        "trajectory_id": "t",
+        "segment_id": "g",
+        "resolutions": [{"fingerprint": "fp-1", "profile_name": "pr_review", "stack": "python"}],
+    }
+    record = build_canonical_record(
+        session,
+        _resolution(),
+        evidence_observed_at="2026-01-01T00:00:00+00:00",
+        as_of="2026-02-01T00:00:00+00:00",
+    )
+    assert record["as_of"] == "2026-02-01T00:00:00+00:00"
+    # passthrough is conditional: no as_of arg => no as_of key
+    assert "as_of" not in build_canonical_record(
+        session, _resolution(), evidence_observed_at="2026-01-01T00:00:00+00:00"
+    )
+
+
+def test_snapshot_id_allows_empty_as_of_unpinned_edge() -> None:
+    pin = {
+        "curation_id": "cur-1",
+        "sanitized_hub_commit": "a" * 40,
+        "source_hub_commit": "b" * 40,
+        "archive_index_digest": "c" * 64,
+        "evidence_observed_at": "2026-01-01T00:00:00+00:00",
+        "as_of": "",
+        "labeler_version": "v1",
+        "rubric_version": "v1",
+        "classifier_version": "v1",
+    }
+    unpinned = snapshot_id(pin)
+    assert len(unpinned) == 64
+    # Empty and missing as_of hash identically: one canonical unpinned id.
+    del pin["as_of"]
+    assert snapshot_id(pin) == unpinned
+    # A pinned as_of still yields a distinct id (AC 8).
+    assert snapshot_id(dict(pin, as_of="2026-02-01T00:00:00+00:00")) != unpinned
+    # Other components remain fail-closed on empty values.
+    with pytest.raises(ValueError, match="evidence_observed_at"):
+        snapshot_id(dict(pin, evidence_observed_at=""))

--- a/tests/test_training_adjudication_snapshot.py
+++ b/tests/test_training_adjudication_snapshot.py
@@ -78,7 +78,7 @@ def test_record_evidence_digest_matches_harvest_row_digest() -> None:
     assert record_evidence_digest([]) is None
 
     class _EmptyRubric:  # duck-typed twin of harvest.Rubric with no evidence
-        per_finding_resolutions = []
+        per_finding_resolutions: list[object] = []
 
     assert _reply_evidence_digest(_EmptyRubric()) is None  # type: ignore[arg-type]
 
@@ -115,7 +115,7 @@ def test_build_canonical_record_rejects_missing_digest() -> None:
 
 
 @pytest.mark.parametrize("rows", [[], [{"fingerprint": "fp-1"}] * 2])
-def test_build_canonical_record_rejects_wrong_resolution_row_count(rows: list[dict]) -> None:
+def test_build_canonical_record_rejects_wrong_resolution_row_count(rows: list[dict[str, object]]) -> None:
     # the exactly-1-resolution-row guard (0 and 2 rows) fires independently of
     # the evidence_digest check: a valid digest is supplied so this check is what raises
     session = {

--- a/tests/test_training_adjudication_snapshot.py
+++ b/tests/test_training_adjudication_snapshot.py
@@ -64,10 +64,10 @@ def test_record_evidence_digest_matches_harvest_row_digest() -> None:
         disposition = "rejected"
         evidence = ev_b
 
-    class _Rubric:
+    class _Rubric:  # duck-typed twin of harvest.Rubric
         per_finding_resolutions = [_R(), _R2()]
 
-    assert shared == _reply_evidence_digest(_Rubric())
+    assert shared == _reply_evidence_digest(_Rubric())  # type: ignore[arg-type]
     assert shared == reply_evidence_digest(ev_a + ev_b)
     # order of the per-finding list must not matter (digest normalizes by reply_id)
     assert shared == record_evidence_digest([ev_b, ev_a])


### PR DESCRIPTION
## Summary
- Enforce temporal gold gate in corpus_v2: `evidence_after_as_of` classifies silver instead of gold
- Tighten annotation dedup and adjudication snapshot scope
- Harden bundle checks and snapshot pipeline; add/extend tests (22 files, +3230/-95)

## Review
Two sequential daydream deep-precision review rounds completed (round-2 fix c09e4ae); full suite 5052 passed / 21 skipped.

## Test Plan
- [x] Full pytest suite: 5052 passed / 21 skipped on review VM
- [x] Deterministic-authorship gate: AUTHORS_OK (all commits anderskev@gmail.com)

Closes #1055