### PR TITLE
chore(dev): add repository-wide EditorConfig defaults (Closes #929)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,34 @@
+# EditorConfig — https://editorconfig.org
+# Contract test: tests/contract/test_editorconfig_contract.py
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml,toml}]
+indent_style = space
+indent_size = 2
+
+# make syntax requires hard tabs in recipes
+[Makefile]
+indent_style = tab
+[*.mk]
+indent_style = tab
+
+# preserve intentional Markdown hard breaks (trailing two spaces)
+[*.md]
+trim_trailing_whitespace = false
+
+# Vendored Harbor code (mechanical-only policy D-03): neutral settings only —
+# no indent style/size, no trailing-whitespace trimming. Editors must never
+# offer to reformat vendored files.
+[daydream/atif/**]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -11,9 +11,13 @@ insert_final_newline = true
 indent_style = space
 indent_size = 4
 
-[*.{yml,yaml,toml}]
+[*.{yml,yaml}]
 indent_style = space
 indent_size = 2
+
+[*.toml]
+indent_style = space
+indent_size = 4
 
 # make syntax requires hard tabs in recipes
 [Makefile]

--- a/.editorconfig
+++ b/.editorconfig
@@ -25,9 +25,12 @@ indent_style = tab
 [*.md]
 trim_trailing_whitespace = false
 
-# Vendored Harbor code (mechanical-only policy D-03): neutral settings only —
-# no indent style/size, no trailing-whitespace trimming. Editors must never
-# offer to reformat vendored files.
+# Vendored Harbor code (mechanical-only policy D-03): the section declares no
+# indent or trailing-whitespace keys, so it imposes no carve-out-specific
+# formatting. EditorConfig merges per key across matching sections and a
+# section can only add or override inherited keys, never unset them, so
+# `[*.py]` 4-space rules still apply to vendored .py files; keep vendored
+# files byte-identical when re-vendoring.
 [daydream/atif/**]
 charset = utf-8
 end_of_line = lf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,7 +208,7 @@ Full contract: `docs/extensions.md`.
 - **`make check`** = root `uv lock --check` + vulture dead-code scan over `daydream tests` and the RL package + ruff/mypy over `daydream tests` + actionlint (Docker) + pytest + standalone RL lockcheck/ruff/mypy/pytest (`cd rl/daydream_review_v1`); `scripts/hooks/pre-push` verifies signatures then delegates to it.
 - Ruff: 120 cols, `E F I W`, py312. `daydream/atif/**` is lint-exempt (vendored, mechanical edits only).
 - Root `.editorconfig` declares editor-side defaults (UTF-8/LF/final newline,
-  4-space Python, 2-space YAML/TOML, Makefile tabs, `*.md` trailing-whitespace
+  4-space Python, 2-space YAML, 4-space TOML, Makefile tabs, `*.md` trailing-whitespace
   preserved); the `daydream/atif/**` carve-out declares no indent/trim keys
   (a section can add or override inherited keys but never unset them, so
   `[*.py]` 4-space rules still apply to vendored `.py` files) — pinned by

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,10 @@ Full contract: `docs/extensions.md`.
 - Deps live in `pyproject.toml`; keep `uv.lock` in sync via `uv lock` or `make check` fails at step one.
 - **`make check`** = root `uv lock --check` + vulture dead-code scan over `daydream tests` and the RL package + ruff/mypy over `daydream tests` + actionlint (Docker) + pytest + standalone RL lockcheck/ruff/mypy/pytest (`cd rl/daydream_review_v1`); `scripts/hooks/pre-push` verifies signatures then delegates to it.
 - Ruff: 120 cols, `E F I W`, py312. `daydream/atif/**` is lint-exempt (vendored, mechanical edits only).
+- Root `.editorconfig` declares editor-side defaults (UTF-8/LF/final newline,
+  4-space Python, 2-space YAML/TOML, Makefile tabs, `*.md` trailing-whitespace
+  preserved); `daydream/atif/**` is a whitespace-neutral carve-out — pinned by
+  `tests/contract/test_editorconfig_contract.py`.
 - **Conventional Commits** (`feat(backends): ...`). Stage explicitly (`git add <path>`), never `git add -A`.
 - Fix bugs at the root. Never bypass the hook, skip tests, or `git push --no-verify`.
 - Own your own bugs in plain language. Never describe your defect as the tool being buggy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,7 +209,9 @@ Full contract: `docs/extensions.md`.
 - Ruff: 120 cols, `E F I W`, py312. `daydream/atif/**` is lint-exempt (vendored, mechanical edits only).
 - Root `.editorconfig` declares editor-side defaults (UTF-8/LF/final newline,
   4-space Python, 2-space YAML/TOML, Makefile tabs, `*.md` trailing-whitespace
-  preserved); `daydream/atif/**` is a whitespace-neutral carve-out — pinned by
+  preserved); the `daydream/atif/**` carve-out declares no indent/trim keys
+  (a section can add or override inherited keys but never unset them, so
+  `[*.py]` 4-space rules still apply to vendored `.py` files) — pinned by
   `tests/contract/test_editorconfig_contract.py`.
 - **Conventional Commits** (`feat(backends): ...`). Stage explicitly (`git add <path>`), never `git add -A`.
 - Fix bugs at the root. Never bypass the hook, skip tests, or `git push --no-verify`.

--- a/README.md
+++ b/README.md
@@ -448,6 +448,10 @@ Python files, and the pre-push gate (the hook verifies commit signatures first,
 then delegates to `make check` — the quality-gate portion of that hook). A running Docker daemon
 is required for `make actionlint` (the workflow YAML checks run the pinned
 container); when no daemon is available that target is skipped with a note and
+
+Editors that support [EditorConfig](https://editorconfig.org) pick up the root
+`.editorconfig` automatically (UTF-8, LF, final newline; 4-space Python, 2-space
+YAML/TOML, tabs in Makefiles, preserved Markdown hard breaks).
 exits 0, so `make check` still succeeds without a daemon (CI always runs
 actionlint).
 

--- a/README.md
+++ b/README.md
@@ -448,12 +448,12 @@ Python files, and the pre-push gate (the hook verifies commit signatures first,
 then delegates to `make check` — the quality-gate portion of that hook). A running Docker daemon
 is required for `make actionlint` (the workflow YAML checks run the pinned
 container); when no daemon is available that target is skipped with a note and
+exits 0, so `make check` still succeeds without a daemon (CI always runs
+actionlint).
 
 Editors that support [EditorConfig](https://editorconfig.org) pick up the root
 `.editorconfig` automatically (UTF-8, LF, final newline; 4-space Python, 2-space
 YAML/TOML, tabs in Makefiles, preserved Markdown hard breaks).
-exits 0, so `make check` still succeeds without a daemon (CI always runs
-actionlint).
 
 See [docs/coverage.md](docs/coverage.md) for the coverage gate and ratchet procedure.
 

--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ actionlint).
 
 Editors that support [EditorConfig](https://editorconfig.org) pick up the root
 `.editorconfig` automatically (UTF-8, LF, final newline; 4-space Python, 2-space
-YAML/TOML, tabs in Makefiles, preserved Markdown hard breaks).
+YAML, 4-space TOML, tabs in Makefiles, preserved Markdown hard breaks).
 
 See [docs/coverage.md](docs/coverage.md) for the coverage gate and ratchet procedure.
 

--- a/tests/contract/test_editorconfig_contract.py
+++ b/tests/contract/test_editorconfig_contract.py
@@ -61,10 +61,16 @@ def test_python_indent() -> None:
     assert section["indent_size"] == "4"
 
 
-def test_yaml_and_toml_indent() -> None:
-    section = _load()["*.{yml,yaml,toml}"]
+def test_yaml_indent() -> None:
+    section = _load()["*.{yml,yaml}"]
     assert section["indent_style"] == "space"
     assert section["indent_size"] == "2"
+
+
+def test_toml_indent() -> None:
+    section = _load()["*.toml"]
+    assert section["indent_style"] == "space"
+    assert section["indent_size"] == "4"
 
 
 def test_makefile_uses_tabs() -> None:

--- a/tests/contract/test_editorconfig_contract.py
+++ b/tests/contract/test_editorconfig_contract.py
@@ -1,0 +1,88 @@
+"""Contract test: the root .editorconfig keeps its load-bearing settings.
+
+Parses `.editorconfig` with stdlib configparser (no editorconfig tooling, no
+network) and asserts the core keys survive: root marker, charset/EOL/final-
+newline defaults, per-type indentation, the Makefile tab rule, the Markdown
+trim rule, and the daydream/atif/** vendored carve-out.
+"""
+
+from __future__ import annotations
+
+import configparser
+import io
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _parse(path: Path) -> configparser.ConfigParser:
+    """Parse an EditorConfig file with stdlib configparser.
+
+    EditorConfig allows `root = true` before any section header; on Python
+    3.14+ configparser raises MissingSectionHeaderError for such keys instead
+    of routing them into DEFAULTSECT. Prepending a synthetic `[DEFAULT]`
+    header restores the historical behavior the assertions rely on, without
+    touching the shipped file.
+    """
+    cp = configparser.ConfigParser()
+    text = "[DEFAULT]\n" + path.read_text(encoding="utf-8")
+    cp.read_file(io.StringIO(text), source=str(path))
+    return cp
+
+
+def _load() -> configparser.ConfigParser:
+    path = _REPO_ROOT / ".editorconfig"
+    assert path.exists(), ".editorconfig missing at repo root"
+    return _parse(path)
+
+
+def test_root_marker_is_true() -> None:
+    _load()  # missing file is a contract failure
+    # `root = true` sits before any section header; with the synthetic
+    # [DEFAULT] header injected by _parse it lands in configparser's
+    # defaults, which every section inherits.
+    defaults = _parse(_REPO_ROOT / ".editorconfig").defaults()
+    assert defaults.get("root", "").strip().lower() == "true", (
+        "first line `root = true` missing (configparser puts it in defaults)"
+    )
+
+
+def test_core_defaults() -> None:
+    cp = _load()
+    star = cp["*"]
+    assert star["charset"] == "utf-8"
+    assert star["end_of_line"] == "lf"
+    assert star["insert_final_newline"] == "true"
+
+
+def test_python_indent() -> None:
+    section = _load()["*.py"]
+    assert section["indent_style"] == "space"
+    assert section["indent_size"] == "4"
+
+
+def test_yaml_and_toml_indent() -> None:
+    cp = _load()
+    for name in ("*.{yml,yaml,toml}",):
+        section = cp[name]
+        assert section["indent_style"] == "space"
+        assert section["indent_size"] == "2"
+
+
+def test_makefile_uses_tabs() -> None:
+    cp = _load()
+    for name in ("Makefile", "*.mk"):
+        assert cp[name]["indent_style"] == "tab", f"{name} must use tabs"
+
+
+def test_markdown_preserves_hard_breaks() -> None:
+    assert _load()["*.md"]["trim_trailing_whitespace"] == "false"
+
+
+def test_atif_carve_out_is_whitespace_neutral() -> None:
+    section = _load()["daydream/atif/**"]
+    for forbidden in ("indent_style", "indent_size", "trim_trailing_whitespace"):
+        assert forbidden not in section, (
+            f"atif carve-out must not impose {forbidden} (vendored D-03 policy)"
+        )
+    assert section["insert_final_newline"] == "true"

--- a/tests/contract/test_editorconfig_contract.py
+++ b/tests/contract/test_editorconfig_contract.py
@@ -62,11 +62,9 @@ def test_python_indent() -> None:
 
 
 def test_yaml_and_toml_indent() -> None:
-    cp = _load()
-    for name in ("*.{yml,yaml,toml}",):
-        section = cp[name]
-        assert section["indent_style"] == "space"
-        assert section["indent_size"] == "2"
+    section = _load()["*.{yml,yaml,toml}"]
+    assert section["indent_style"] == "space"
+    assert section["indent_size"] == "2"
 
 
 def test_makefile_uses_tabs() -> None:


### PR DESCRIPTION
## Summary
Implements issue #929 in daydream (chore(dev): repository-wide EditorConfig defaults).

- Full pipeline: explore -> spec -> plan -> implement -> two sequential daydream deep-precision reviews on fresh VMs
- Review round 2: 1/1 finding resolved (TOML indent_size 4), fix commit 26f0b84
- All commits authored by Kevin Anderson <anderskev@gmail.com>

Closes #929

## Test Plan
- [x] Editorconfig contract test green on branch
- [ ] CI green on this PR